### PR TITLE
Add generic gcc overflow builtins

### DIFF
--- a/regression/cbmc/gcc_builtin_add_overflow/main.c
+++ b/regression/cbmc/gcc_builtin_add_overflow/main.c
@@ -82,13 +82,31 @@ void check_unsigned_long_long(void)
   unsigned long long const one = 1ull;
   unsigned long long result;
 
-  assert(!__builtin_uaddl_overflow(one, one, &result));
+  assert(!__builtin_uaddll_overflow(one, one, &result));
   assert(result == 2ull);
   assert(!__builtin_uaddll_overflow(ULLONG_MAX / 2, ULLONG_MAX / 2, &result));
   assert(result + 1ull == ULLONG_MAX);
   assert(
     __builtin_uaddll_overflow(ULLONG_MAX / 2 + 2, ULLONG_MAX / 2 + 2, &result));
-  assert(__builtin_uaddl_overflow(one, ULLONG_MAX, &result));
+  assert(__builtin_uaddll_overflow(one, ULLONG_MAX, &result));
+  assert(0 && "reachability");
+}
+
+void check_generic(void)
+{
+  unsigned char small_result;
+  signed long long big_result;
+  assert(!__builtin_add_overflow(17, 25, &small_result));
+  assert(small_result == 42);
+  assert(!__builtin_add_overflow(17, 25, &big_result));
+  assert(big_result == 42ll);
+  assert(__builtin_add_overflow(216, 129, &small_result));
+  assert(!__builtin_add_overflow(216, 129, &big_result));
+  assert(big_result == 345);
+  assert(!__builtin_add_overflow(INT_MAX, INT_MAX, &big_result));
+  assert(big_result == 2ll * INT_MAX);
+  assert(
+    __builtin_add_overflow(LLONG_MAX / 2 + 1, LLONG_MAX / 2 + 1, &big_result));
   assert(0 && "reachability");
 }
 
@@ -100,4 +118,5 @@ int main(void)
   check_unsigned();
   check_unsigned_long();
   check_unsigned_long_long();
+  check_generic();
 }

--- a/regression/cbmc/gcc_builtin_add_overflow/test.desc
+++ b/regression/cbmc/gcc_builtin_add_overflow/test.desc
@@ -39,13 +39,24 @@ main.c
 \[check_unsigned_long.assertion.5\] line \d+ assertion __builtin_uaddl_overflow\(.* / 2 \+ 2, .* / 2 \+ 2, &result\): SUCCESS
 \[check_unsigned_long.assertion.6\] line \d+ assertion __builtin_uaddl_overflow\(one, .*, &result\): SUCCESS
 \[check_unsigned_long.assertion.7\] line \d+ assertion 0 && "reachability": FAILURE
-\[check_unsigned_long_long.assertion.1\] line \d+ assertion !__builtin_uaddl_overflow\(one, one, &result\): SUCCESS
+\[check_unsigned_long_long.assertion.1\] line \d+ assertion !__builtin_uaddll_overflow\(one, one, &result\): SUCCESS
 \[check_unsigned_long_long.assertion.2\] line \d+ assertion result == 2ull: SUCCESS
 \[check_unsigned_long_long.assertion.3\] line \d+ assertion !__builtin_uaddll_overflow\(.* / 2, .* / 2, &result\): SUCCESS
 \[check_unsigned_long_long.assertion.4\] line \d+ assertion result \+ 1ull == .*: SUCCESS
 \[check_unsigned_long_long.assertion.5\] line \d+ assertion __builtin_uaddll_overflow\(.* / 2 \+ 2, .* / 2 \+ 2, &result\): SUCCESS
-\[check_unsigned_long_long.assertion.6\] line \d+ assertion __builtin_uaddl_overflow\(one, .*, &result\): SUCCESS
+\[check_unsigned_long_long.assertion.6\] line \d+ assertion __builtin_uaddll_overflow\(one, .*, &result\): SUCCESS
 \[check_unsigned_long_long.assertion.7\] line \d+ assertion 0 && "reachability": FAILURE
+\[check_generic.assertion.1\] line \d+ assertion !__builtin_add_overflow\(17, 25, &small_result\): SUCCESS
+\[check_generic.assertion.2\] line \d+ assertion small_result == 42: SUCCESS
+\[check_generic.assertion.3\] line \d+ assertion !__builtin_add_overflow\(17, 25, &big_result\): SUCCESS
+\[check_generic.assertion.4\] line \d+ assertion big_result == 42ll: SUCCESS
+\[check_generic.assertion.5\] line \d+ assertion __builtin_add_overflow\(216, 129, &small_result\): SUCCESS
+\[check_generic.assertion.6\] line \d+ assertion !__builtin_add_overflow\(216, 129, &big_result\): SUCCESS
+\[check_generic.assertion.7\] line \d+ assertion big_result == 345: SUCCESS
+\[check_generic.assertion.8\] line \d+ assertion !__builtin_add_overflow\(.*, .*, &big_result\): SUCCESS
+\[check_generic.assertion.9\] line \d+ assertion big_result == 2ll \* .*: SUCCESS
+\[check_generic.assertion.10\] line \d+ assertion __builtin_add_overflow\(.* / 2 \+ 1, .*/ 2 \+ 1, &big_result\): SUCCESS
+\[check_generic.assertion.11\] line \d+ assertion 0 && "reachability": FAILURE
 VERIFICATION FAILED
 ^EXIT=10$
 ^SIGNAL=0$

--- a/regression/cbmc/gcc_builtin_mul_overflow/main.c
+++ b/regression/cbmc/gcc_builtin_mul_overflow/main.c
@@ -104,6 +104,22 @@ void check_unsigned_long_long(void)
   assert(0 && "reachability");
 }
 
+void check_generic(void)
+{
+  unsigned char small_result;
+  long long big_result;
+
+  assert(__builtin_mul_overflow(100, 100, &small_result));
+  assert(!__builtin_mul_overflow(100, 100, &big_result));
+  assert(big_result == 10000);
+  assert(!__builtin_mul_overflow(10, 10, &small_result));
+  assert(small_result == 100);
+  assert(!__builtin_mul_overflow(INT_MAX, INT_MAX, &big_result));
+  assert(big_result == 4611686014132420609ll);
+  assert(__builtin_mul_overflow(INT_MAX * 2ll, INT_MAX * 2ll, &big_result));
+  assert(0 && "reachability");
+}
+
 int main(void)
 {
   check_int();
@@ -112,5 +128,6 @@ int main(void)
   check_unsigned();
   check_unsigned_long();
   check_unsigned_long_long();
+  check_generic();
   return 0;
 }

--- a/regression/cbmc/gcc_builtin_mul_overflow/test.desc
+++ b/regression/cbmc/gcc_builtin_mul_overflow/test.desc
@@ -37,5 +37,14 @@ main.c
 \[check_unsigned_long_long.assertion.4\] line \d+ assertion result == lt_isqrt_of_unsigned_long_long_max \* lt_isqrt_of_unsigned_long_long_max: SUCCESS
 \[check_unsigned_long_long.assertion.5\] line \d+ assertion __builtin_umulll_overflow\( lt_isqrt_of_unsigned_long_long_max << 1, lt_isqrt_of_unsigned_long_long_max << 1, &result\): SUCCESS
 \[check_unsigned_long_long.assertion.6\] line \d+ assertion 0 && "reachability": FAILURE
+\[check_generic.assertion.1\] line \d+ assertion __builtin_mul_overflow\(100, 100, &small_result\): SUCCESS
+\[check_generic.assertion.2\] line \d+ assertion !__builtin_mul_overflow\(100, 100, &big_result\): SUCCESS
+\[check_generic.assertion.3\] line \d+ assertion big_result == 10000: SUCCESS
+\[check_generic.assertion.4\] line \d+ assertion !__builtin_mul_overflow\(10, 10, &small_result\): SUCCESS
+\[check_generic.assertion.5\] line \d+ assertion small_result == 100: SUCCESS
+\[check_generic.assertion.6\] line \d+ assertion !__builtin_mul_overflow\(.*, .*, &big_result\): SUCCESS
+\[check_generic.assertion.7\] line \d+ assertion big_result == 4611686014132420609ll: SUCCESS
+\[check_generic.assertion.8\] line \d+ assertion __builtin_mul_overflow\(.* \* 2ll, .* \* 2ll, &big_result\): SUCCESS
+\[check_generic.assertion.9\] line \d+ assertion 0 && "reachability": FAILURE
 ^EXIT=10$
 ^SIGNAL=0$

--- a/regression/cbmc/gcc_builtin_sub_overflow/main.c
+++ b/regression/cbmc/gcc_builtin_sub_overflow/main.c
@@ -71,6 +71,23 @@ void check_unsigned_long_long(void)
   assert(0 && "reachability");
 }
 
+void check_generic(void)
+{
+  unsigned char small_result;
+  long long big_result;
+
+  assert(__builtin_sub_overflow(5, 10, &small_result));
+  assert(!__builtin_sub_overflow(5, 10, &big_result));
+  assert(big_result == -5ll);
+  assert(!__builtin_sub_overflow(10, 5, &small_result));
+  assert(small_result == 5);
+  assert(!__builtin_sub_overflow(10, 5, &big_result));
+  assert(big_result == 5ll);
+  assert(!__builtin_sub_overflow(INT_MIN, INT_MAX, &big_result));
+  assert(big_result == 2ll * INT_MIN + 1);
+  assert(0 && "reachability");
+}
+
 int main(void)
 {
   check_int();
@@ -79,4 +96,5 @@ int main(void)
   check_unsigned();
   check_unsigned_long();
   check_unsigned_long_long();
+  check_generic();
 }

--- a/regression/cbmc/gcc_builtin_sub_overflow/test.desc
+++ b/regression/cbmc/gcc_builtin_sub_overflow/test.desc
@@ -40,5 +40,15 @@ main.c
 \[check_unsigned_long_long.assertion.5\] line \d+ assertion result == 0ull: SUCCESS
 \[check_unsigned_long_long.assertion.6\] line \d+ assertion __builtin_usubll_overflow\(.* / 2ull, .*, &result\): SUCCESS
 \[check_unsigned_long_long.assertion.7\] line \d+ assertion 0 && "reachability": FAILURE
+\[check_generic.assertion.1\] line 79 assertion __builtin_sub_overflow\(5, 10, &small_result\): SUCCESS
+\[check_generic.assertion.2\] line 80 assertion !__builtin_sub_overflow\(5, 10, &big_result\): SUCCESS
+\[check_generic.assertion.3\] line 81 assertion big_result == -5ll: SUCCESS
+\[check_generic.assertion.4\] line 82 assertion !__builtin_sub_overflow\(10, 5, &small_result\): SUCCESS
+\[check_generic.assertion.5\] line 83 assertion small_result == 5: SUCCESS
+\[check_generic.assertion.6\] line 84 assertion !__builtin_sub_overflow\(10, 5, &big_result\): SUCCESS
+\[check_generic.assertion.7\] line 85 assertion big_result == 5ll: SUCCESS
+\[check_generic.assertion.8\] line 86 assertion !__builtin_sub_overflow\(.*, .*, &big_result\): SUCCESS
+\[check_generic.assertion.9\] line 87 assertion big_result == 2ll \* .* \+ 1: SUCCESS
+\[check_generic.assertion.10\] line 88 assertion 0 && "reachability": FAILURE
 ^EXIT=10$
 ^SIGNAL=0$


### PR DESCRIPTION
GCC has builtin operators `__builtin_add_overflow`, `__builtin_sub_overflow`
and `__builtin_mul_overflow` that perform an arithmetic operation and
check for overflow at the same time. This adds support for these
operators.

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
