### PR TITLE
Avoids arithmetic overflow on signed to unsigned type conversion

### DIFF
--- a/src/ansi-c/library/string.c
+++ b/src/ansi-c/library/string.c
@@ -374,8 +374,11 @@ inline int strcmp(const char *s1, const char *s2)
   unsigned char ch1, ch2;
   do
   {
+#  pragma CPROVER check push
+#  pragma CPROVER check disable "conversion"
     ch1=s1[i];
     ch2=s2[i];
+#  pragma CPROVER check pop
 
     if(ch1==ch2)
     {
@@ -389,7 +392,7 @@ inline int strcmp(const char *s1, const char *s2)
   }
   while(ch1!=0 && ch2!=0);
   return 0;
-  #endif
+#endif
 }
 
 /* FUNCTION: strcasecmp */
@@ -420,8 +423,11 @@ inline int strcasecmp(const char *s1, const char *s2)
   unsigned char ch1, ch2;
   do
   {
+#  pragma CPROVER check push
+#  pragma CPROVER check disable "conversion"
     ch1=s1[i];
     ch2=s2[i];
+#  pragma CPROVER check pop
 
     if(ch1>='A' && ch1<='Z') ch1+=('a'-'A');
     if(ch2>='A' && ch2<='Z') ch2+=('a'-'A');
@@ -438,7 +444,7 @@ inline int strcasecmp(const char *s1, const char *s2)
   }
   while(ch1!=0 && ch2!=0);
   return 0;
-  #endif
+#endif
 }
 
 /* FUNCTION: strncmp */
@@ -467,8 +473,11 @@ inline int strncmp(const char *s1, const char *s2, size_t n)
     return 0;
   do
   {
+#  pragma CPROVER check push
+#  pragma CPROVER check disable "conversion"
     ch1=s1[i];
     ch2=s2[i];
+#  pragma CPROVER check pop
 
     if(ch1==ch2)
     {
@@ -482,7 +491,7 @@ inline int strncmp(const char *s1, const char *s2, size_t n)
   }
   while(ch1!=0 && ch2!=0 && i<n);
   return 0;
-  #endif
+#endif
 }
 
 /* FUNCTION: strncasecmp */
@@ -511,8 +520,11 @@ inline int strncasecmp(const char *s1, const char *s2, size_t n)
     return 0;
   do
   {
+#  pragma CPROVER check push
+#  pragma CPROVER check disable "conversion"
     ch1=s1[i];
     ch2=s2[i];
+#  pragma CPROVER check pop
 
     if(ch1>='A' && ch1<='Z') ch1+=('a'-'A');
     if(ch2>='A' && ch2<='Z') ch2+=('a'-'A');
@@ -529,7 +541,7 @@ inline int strncasecmp(const char *s1, const char *s2, size_t n)
   }
   while(ch1!=0 && ch2!=0 && i<n);
   return 0;
-  #endif
+#endif
 }
 
 /* FUNCTION: strlen */


### PR DESCRIPTION
Running CBMC on the following example from `regression/cbmc-library/String6` using the `conversion-check` flag reported an arithmetic overflow:
```
cbmc main.c --pointer-check --bounds-check --conversion-check
```

```
#include <assert.h>
#include <stdlib.h>
#include <string.h>

int main()
{
  char str[500] = "Hello";

  assert(strcmp(str, "Hello") == 0);
  assert(strncmp(str, "Hello", 5) == 0);

#ifndef _MSC_VER
  assert(strcasecmp(str, "HELLO") == 0);
  assert(strncasecmp(str, "HELLO", 5) == 0);
#endif

  assert(strcmp(str, "\xff") < 0);
  assert(strncmp("ASDxx", "ASDyy", 3) == 0);

  assert(strlen(str) == 5);
  char *str_cpy = strdup(str);
  assert(strcmp(str, str_cpy) == 0);
  free(str_cpy);

  return 0;
}
```

```
Violated property:
  file <builtin-library-strncmp> function strncmp line 26 thread 0
  arithmetic overflow on signed to unsigned type conversion in (unsigned char)s1[(signed long int)i]
  s1[(signed long int)i] >= 0
```

Adding pragmas to avoid spurious reports and to keep in sync with the [standard](https://pubs.opengroup.org/onlinepubs/7908799/xsh/strncmp.html),i.e., _"the sign of a non-zero return value is determined by the sign of the difference between the values of the first pair of bytes (**both interpreted as type unsigned char**) that differ in the strings being compared."_

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [x] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [x] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
