### PR TITLE
Make functions with bodies in c_types_util.h inline

### DIFF
--- a/src/util/c_types_util.h
+++ b/src/util/c_types_util.h
@@ -80,7 +80,7 @@ inline bool is_c_enum_type(const typet &type)
 /// \param c_enum the enum type \p member_name is supposed to be part of.
 /// \return constant, that could be assigned as the value of an expression with
 ///   type c_enum.
-constant_exprt convert_member_name_to_enum_value(
+inline constant_exprt convert_member_name_to_enum_value(
   const irep_idt &member_name,
   const c_enum_typet &c_enum)
 {
@@ -100,7 +100,7 @@ constant_exprt convert_member_name_to_enum_value(
 /// Convert id to a Boolean value
 /// \param bool_value: A string that is compared to "true" ignoring case.
 /// \return a constant of type Boolean
-bool id2boolean(const std::string &bool_value)
+inline bool id2boolean(const std::string &bool_value)
 {
   std::string string_value = bool_value;
   std::transform(
@@ -117,7 +117,7 @@ bool id2boolean(const std::string &bool_value)
 /// \param bool_value: A Boolean value.
 /// \param type: The type, the resulting constant is supposed to have.
 /// \return a constant of type \param type with either 0 or 1 as value.
-constant_exprt from_c_boolean_value(bool bool_value, const typet &type)
+inline constant_exprt from_c_boolean_value(bool bool_value, const typet &type)
 {
   return bool_value ? from_integer(mp_integer(1), type)
                     : from_integer(mp_integer(0), type);


### PR DESCRIPTION
Inline indicates linkage. Without inline, if we have two source
files including this header we’ll get linker errors.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
