### PR TITLE
SMT Switch API

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,7 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS true)
 set(CMAKE_OSX_DEPLOYMENT_TARGET 10.9)
 
 include(GNUInstallDirs)
+include("${CMAKE_CURRENT_SOURCE_DIR}/cmake/DownloadProject.cmake")
 
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
@@ -30,7 +31,7 @@ elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
     # This would be the place to enable warnings for Windows builds, although
     # config.inc doesn't seem to do that currently
 
-    # Include Git Bash Environment (rqeuired for download_project (patch))
+    # Include Git Bash Environment (required for download_project (patch))
     find_package(Git)
     if(GIT_FOUND)
         get_filename_component(git_root ${GIT_EXECUTABLE} DIRECTORY)
@@ -50,8 +51,17 @@ if(${enable_cbmc_tests})
     enable_testing()
 endif()
 
+option(use_smt_switch "use generic smt interface")
+if (use_smt_switch)
+    download_project(
+            PROJ smt-switch
+            URL https://github.com/makaimann/smt-switch/archive/hwmcc19.tar.gz
+            URL_MD5 c3c40be8b1294017cd129b9a3d99ff30
+    )
+    add_subdirectory(${smt-switch_SOURCE_DIR})
+endif ()
+
 if(DEFINED CMAKE_USE_CUDD)
-    include("${CMAKE_CURRENT_SOURCE_DIR}/cmake/DownloadProject.cmake")
     message(STATUS "Downloading Cudd-3.0.0")
     download_project(PROJ cudd
             URL https://sourceforge.net/projects/cudd-mirror/files/cudd-3.0.0.tar.gz/download

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,7 +59,24 @@ if (use_smt_switch)
             URL_MD5 c3c40be8b1294017cd129b9a3d99ff30
     )
     add_subdirectory(${smt-switch_SOURCE_DIR})
+    target_compile_features(smt-switch PRIVATE cxx_std_17)
     add_compile_options(-DHAVE_SMT_SWITCH)
+
+    if (BUILD_CVC4)
+        add_custom_target(obtain-switch-cvc4
+                COMMAND ./contrib/setup-cvc4.sh -y WORKING_DIRECTORY ${smt-switch_SOURCE_DIR})
+
+        add_dependencies(smt-switch-cvc4 obtain-switch-cvc4)
+    else()
+        message(WARNING "No smt-switch backend selected, add -DBUILD_CVC4=ON to enable CVC4 backend")
+    endif ()
+
+    if (BUILD_BTOR)
+        message(SEND_ERROR "Using the boolector smt-switch backend is not supported")
+    endif ()
+    if (BUILD_MSAT)
+        message(SEND_ERROR "Using the MSat smt-switch backend is not supported")
+    endif ()
 endif ()
 
 if(DEFINED CMAKE_USE_CUDD)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,6 @@ if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" OR
     set(CMAKE_CXX_FLAGS_RELEASE "-O2")
     set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O2 -g")
     #   Enable lots of warnings
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wpedantic -Werror -Wno-deprecated-declarations -Wswitch-enum")
 elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
     # This would be the place to enable warnings for Windows builds, although
     # config.inc doesn't seem to do that currently
@@ -135,6 +134,12 @@ function(cprover_default_properties)
     set(CBMC_CXX_STANDARD_REQUIRED true)
     set(CBMC_XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY
             "Developer ID Application: Daniel Kroening")
+
+    foreach (target IN LISTS ARGN)
+        message(${target})
+        target_compile_options(${target} PRIVATE -Wall -Wpedantic -Werror -Wno-deprecated-declarations -Wswitch-enum)
+    endforeach ()
+
 
     set_target_properties(
       ${ARGN}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,6 +59,7 @@ if (use_smt_switch)
             URL_MD5 c3c40be8b1294017cd129b9a3d99ff30
     )
     add_subdirectory(${smt-switch_SOURCE_DIR})
+    add_compile_options(-DHAVE_SMT_SWITCH)
 endif ()
 
 if(DEFINED CMAKE_USE_CUDD)

--- a/COMPILING.md
+++ b/COMPILING.md
@@ -339,3 +339,21 @@ compilation flag:
     cmake -S . -Bbuild -DCMAKE_CXX_FLAGS="-DBDD_GUARDS"
     ```
     and then `cmake --build build`
+
+## Use SMT-Switch interface
+
+CBMC can be compiled with the [smt-switch](https://github.com/makaimann/smt-switch) library. Currently this is unused - but will be used to use different SMT back-ends when solving.
+
+This requires CMake and C++17 support.
+
+To enable compiling, specify the following CMake flags:
+
+```
+-Duse_smt_switch=ON -DBUILD_CVC4=ON
+```
+
+Currently on the CVC4 back-end can be configured this way.
+
+_Note: on first run after cleaning build directory, this will take a while_.
+
+See [SMT Switch documentation](doc/smt-switch.md) for more details on how this can be used in code.

--- a/COMPILING.md
+++ b/COMPILING.md
@@ -344,7 +344,11 @@ compilation flag:
 
 CBMC can be compiled with the [smt-switch](https://github.com/makaimann/smt-switch) library. Currently this is unused - but will be used to use different SMT back-ends when solving.
 
-This requires CMake and C++17 support.
+This requires CMake and C++17 support. It also requires the dependencies required for the chosen solver:
+
+ - [CVC4 dependencies](https://github.com/CVC4/CVC4/blob/master/INSTALL.md#build-dependencies)
+ - [Boolector](https://github.com/Boolector/boolector#prerequisites)
+ - _MathSAT does not require any additional dependencies._
 
 To enable compiling, specify the following CMake flags:
 

--- a/buildspec-linux-cmake-smt-switch.yml
+++ b/buildspec-linux-cmake-smt-switch.yml
@@ -1,0 +1,32 @@
+version: 0.2
+
+env:
+  variables:
+    # CodeBuild console doesn't display color codes correctly
+    TESTPL_COLOR_OUTPUT: 0
+
+phases:
+  install:
+    runtime-versions:
+      java: openjdk8
+    commands:
+      - sed -i 's#/archive.ubuntu.com#/us-east-1.ec2.archive.ubuntu.com#g' /etc/apt/sources.list
+      - apt-get update -y
+      - apt-get install -y flex bison make git libwww-perl patch ccache libc6-dev-i386 jq cmake clang-7 libgmp3-dev
+  build:
+    commands:
+      - echo Build started on `date`
+      - cmake -S . -Bbuild '-Duse_smt_switch=ON' '-DBUILD_CVC4=ON' '-DCMAKE_BUILD_TYPE=Release' '-DCMAKE_CXX_COMPILER=/usr/bin/clang++-7' '-DCMAKE_CXX_FLAGS=-Qunused-arguments -std=c++17'
+      - git submodule update --init --recursive
+      - cmake --build build -- -j2
+  post_build:
+    commands:
+      # we only run unit tests for now - as these are the only users of SMT Switch
+      - cd build; ctest -V -R unit CORE -j2
+      - cd build; ctest -V -R unit-xfail -j2
+      - echo Build completed on `date`
+cache:
+  paths:
+    - '/var/cache/apt/**/*'
+    - '/var/lib/apt/lists/**/*'
+    - '/root/.ccache/**/*'

--- a/doc/smt-switch.md
+++ b/doc/smt-switch.md
@@ -1,0 +1,26 @@
+\ingroup module_hidden
+\page smt_switch SMT Switch
+
+\section compiling_smt_switch Compiling SMT Switch
+
+See [COMPILING.md](https://github.com/diffblue/cbmc/blob/develop/COMPILING.md#Use-SMT-Switch-interface) for details on how to compile the SMT Switch library.
+
+\section using_smt_switch Using the SMT Switch Library.
+
+Having compiled CBMC with appropriate flags, you can add the following `target_lik_libraries` to a `CMakeLists.txt`:
+
+```
+if (use_smt_switch)
+    target_link_libraries(
+            <target>
+            smt-switch
+            smt-switch-cvc4
+    )
+endif ()
+```
+
+Which will allow you to use the SMT switch API.
+
+There is a compile flag `HAVE_SMT_SWITCH` which can be used to enable code that requires SMT Switch.
+
+See [unit/solvers/smt_switch.cpp](../../unit/solvers/smt_switch.cpp) for an example test that uses the SMT switch API.

--- a/jbmc/CMakeLists.txt
+++ b/jbmc/CMakeLists.txt
@@ -10,7 +10,6 @@ add_custom_target(java-models-library ALL
 
 cprover_default_properties(
     java_bytecode
-    java-models-library
     jbmc
     jbmc-lib
     janalyzer

--- a/unit/CMakeLists.txt
+++ b/unit/CMakeLists.txt
@@ -60,6 +60,14 @@ target_link_libraries(
         statement-list
 )
 
+if (use_smt_switch)
+    target_link_libraries(
+            unit
+            smt-switch
+            smt-switch-cvc4
+    )
+endif ()
+
 add_test(
     NAME unit
     COMMAND $<TARGET_FILE:unit>

--- a/unit/Makefile
+++ b/unit/Makefile
@@ -66,6 +66,7 @@ SRC += analyses/ai/ai.cpp \
        solvers/strings/string_refinement/string_refinement.cpp \
        solvers/strings/string_refinement/substitute_array_list.cpp \
        solvers/strings/string_refinement/union_find_replace.cpp \
+       solvers/smt_switch.cpp \
        util/allocate_objects.cpp \
        util/cmdline.cpp \
        util/dense_integer_map.cpp \

--- a/unit/solvers/smt_switch.cpp
+++ b/unit/solvers/smt_switch.cpp
@@ -1,0 +1,43 @@
+/*******************************************************************\
+
+Module: Unit tests for checking the integration of SMT switch
+
+Author: Diffblue Ltd.
+
+\*******************************************************************/
+
+#include <testing-utils/use_catch.h>
+
+// only enable the tests if compiling with SMT switch
+#ifdef HAVE_SMT_SWITCH
+#  include <cvc4_factory.h>
+#  include <smt.h>
+#endif
+
+#include <vector>
+
+TEST_CASE("Trivial SMT switch using CVC4", "[core][solvers][smt-switch]")
+{
+#ifdef HAVE_SMT_SWITCH
+  smt::SmtSolver s = smt::CVC4SolverFactory::create();
+  s->set_opt("produce-models", "true");
+  smt::Sort bvsort32 = s->make_sort(smt::BV, 32);
+  smt::Sort array32_32 = s->make_sort(smt::ARRAY, bvsort32, bvsort32);
+  smt::Term x = s->make_term("x", bvsort32);
+  smt::Term y = s->make_term("y", bvsort32);
+  smt::Term arr = s->make_term("arr", array32_32);
+
+  s->assert_formula(s->make_term(
+    smt::Not,
+    s->make_term(
+      smt::Implies,
+      s->make_term(smt::Equal, x, y),
+      s->make_term(
+        smt::Equal,
+        s->make_term(smt::Select, arr, x),
+        s->make_term(smt::Select, arr, y)))));
+  REQUIRE_FALSE(s->check_sat().is_sat());
+#else
+  INFO("SMT switch test disabled");
+#endif
+}

--- a/unit/solvers/smt_switch.cpp
+++ b/unit/solvers/smt_switch.cpp
@@ -12,11 +12,17 @@ Author: Diffblue Ltd.
 #ifdef HAVE_SMT_SWITCH
 #  include <cvc4_factory.h>
 #  include <smt.h>
+#  define SMT_SWITCH_TEST_LABEL
+#else
+// if smt-switch is not enabled, make the test XFAIL
+#  define SMT_SWITCH_TEST_LABEL XFAIL
 #endif
 
 #include <vector>
 
-TEST_CASE("Trivial SMT switch using CVC4", "[core][solvers][smt-switch]")
+TEST_CASE(
+  "Trivial SMT switch using CVC4",
+  "[core][solvers][smt-switch]" SMT_SWITCH_TEST_LABEL)
 {
 #ifdef HAVE_SMT_SWITCH
   smt::SmtSolver s = smt::CVC4SolverFactory::create();
@@ -38,6 +44,7 @@ TEST_CASE("Trivial SMT switch using CVC4", "[core][solvers][smt-switch]")
         s->make_term(smt::Select, arr, y)))));
   REQUIRE_FALSE(s->check_sat().is_sat());
 #else
-  INFO("SMT switch test disabled");
+  INFO("SMT switch not enabled");
+  REQUIRE(false);
 #endif
 }


### PR DESCRIPTION
Adds the [smt-switch](https://github.com/makaimann/smt-switch) dependency if you build with `cmake and -DSMT_SWITCH=ON -DSMT_CVC4=ON`. Currently not used, outside of a unit test to prove compiling correctly. 

There are still a few things I need to do
 - [x] ~Need to add to `make` build as well I suppose.~
 - [x] Update documentation for how to enable the build
 - [x] Enable the codebuild job

But at least the CMake changes can be reviewed 

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [x] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [na] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
