### PR TITLE
fix file_rename on Windows

### DIFF
--- a/src/util/file_util.cpp
+++ b/src/util/file_util.cpp
@@ -233,23 +233,21 @@ void file_rename(const std::string &old_path, const std::string &new_path)
       MoveFileW(widen(old_path).c_str(), widen(new_path).c_str());
 
     if(MoveFile_result == 0)
-      throw system_exceptiont("MoveFile failed");
+      throw system_exceptiont("MoveFileW failed");
   }
   else
   {
-    // C++17 requires this to be atomic, which is delivered by
-    // ReplaceFile(). MoveFile() or rename() do not guarantee this.
+    // C++17 requires this to be atomic.
+    // MoveFile, MoveFileEx() or rename() do not guarantee this.
     // Any existing file at new_path is to be overwritten.
-    auto ReplaceFile_result = ReplaceFileW(
-      widen(new_path).c_str(), // note the ordering
+    // rename() does not do so on Windows.
+    auto MoveFileEx_result = MoveFileExW(
       widen(old_path).c_str(),
-      nullptr,  // lpBackupFileName
-      0,        // dwReplaceFlags
-      nullptr,  // lpExclude
-      nullptr); // lpReserved
+      widen(new_path).c_str(),
+      MOVEFILE_REPLACE_EXISTING); // flags
 
-    if(ReplaceFile_result == 0)
-      throw system_exceptiont("ReplaceFile failed");
+    if(MoveFileEx_result == 0)
+      throw system_exceptiont("MoveFileExW failed");
   }
 #else
   int rename_result = rename(old_path.c_str(), new_path.c_str());


### PR DESCRIPTION
This is a fixup of 98325ce966bd3.

`ReplaceFile` only works when there is a file to replace.  `MoveFileExW` with
`MOVEFILE_REPLACE_EXISTING` does deliver that.  It's not atomic, but there
does not appear to be a sensible way to deliver that on Windows.  Boost also
uses `MovFileExW`.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
