### PR TITLE
Collect complexity statistics of solver queries

### DIFF
--- a/regression/CMakeLists.txt
+++ b/regression/CMakeLists.txt
@@ -60,3 +60,5 @@ if(WITH_MEMORY_ANALYZER)
   add_subdirectory(snapshot-harness)
   add_subdirectory(memory-analyzer)
 endif()
+
+add_subdirectory(solver-hardness)

--- a/regression/Makefile
+++ b/regression/Makefile
@@ -30,6 +30,7 @@ DIRS = cbmc \
        goto-cc-file-local \
        linking-goto-binaries \
        symtab2gb \
+       solver-hardness \
        # Empty last line
 
 ifeq ($(OS),Windows_NT)

--- a/regression/solver-hardness/CMakeLists.txt
+++ b/regression/solver-hardness/CMakeLists.txt
@@ -1,0 +1,2 @@
+add_test_pl_tests(
+  "../chain.sh $<TARGET_FILE:cbmc>")

--- a/regression/solver-hardness/Makefile
+++ b/regression/solver-hardness/Makefile
@@ -1,0 +1,23 @@
+default: tests.log
+
+include ../../src/config.inc
+include ../../src/common
+
+CBMC_EXE=../../../src/cbmc/cbmc
+
+test:
+	@../test.pl -e -p -c "../chain.sh $(CBMC_EXE)"
+
+tests.log: ../test.pl
+	@../test.pl -e -p -c "../chain.sh $(CBMC_EXE)"
+
+show:
+	@for dir in *; do \
+		if [ -d "$$dir" ]; then \
+			vim -o "$$dir/*.c" "$$dir/*.out"; \
+		fi; \
+	done;
+
+clean:
+	find -name '*.out' -execdir $(RM) '{}' \;
+	$(RM) tests.log

--- a/regression/solver-hardness/chain.sh
+++ b/regression/solver-hardness/chain.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+cbmc=$1
+
+name=${*:$#}
+args=${*:2:$#-2}
+
+$cbmc ${name} ${args}
+CBMC_RETURN_CODE="$?"
+../parse_json.py "solver_hardness.json"
+exit ${CBMC_RETURN_CODE}

--- a/regression/solver-hardness/parse_json.py
+++ b/regression/solver-hardness/parse_json.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python
+
+import sys
+import json
+
+def main():
+  with open(sys.argv[1], "r") as json_file:
+    data = json.load(json_file)
+  print ("Valid JSON File")
+  print (json.dumps(data))
+
+if __name__ == "__main__":
+  main()

--- a/regression/solver-hardness/solver-hardness-simple/main.c
+++ b/regression/solver-hardness/solver-hardness-simple/main.c
@@ -1,0 +1,9 @@
+#include <assert.h>
+
+int main()
+{
+  int a;
+  int b;
+  assert(a + b < 10);
+  return 0;
+}

--- a/regression/solver-hardness/solver-hardness-simple/test.desc
+++ b/regression/solver-hardness/solver-hardness-simple/test.desc
@@ -1,0 +1,11 @@
+CORE
+main.c
+--write-solver-stats-to "solver_hardness.json"
+^EXIT=10$
+^SIGNAL=0$
+^\[main.assertion.\d+\] line \d+ assertion a \+ b \< 10: FAILURE$
+^VERIFICATION FAILED$
+^Valid JSON File$
+\"SAT_hardness\": \{(\"Clauses\": \d+|\"Variables\": \d+|\"Literals\": \d+), (\"Clauses\": \d+|\"Variables\": \d+|\"Literals\": \d+), (\"Clauses\": \d+|\"Variables\": \d+|\"Literals\": \d+)\}
+--
+^warning: ignoring

--- a/src/cbmc/cbmc_parse_options.cpp
+++ b/src/cbmc/cbmc_parse_options.cpp
@@ -460,6 +460,12 @@ void cbmc_parse_optionst::get_command_line_options(optionst &options)
     }
   }
 
+  if(cmdline.isset("write-solver-stats-to"))
+  {
+    options.set_option(
+      "write-solver-stats-to", cmdline.get_value("write-solver-stats-to"));
+  }
+
   if(cmdline.isset("beautify"))
     options.set_option("beautify", true);
 
@@ -1106,6 +1112,8 @@ void cbmc_parse_optionst::help()
     HELP_FLUSH
     " --verbosity #                verbosity level\n"
     HELP_TIMESTAMP
+    " --write-solver-stats-to json-file\n"
+    "                              collect the solver query complexity\n"
     "\n";
   // clang-format on
 }

--- a/src/cbmc/cbmc_parse_options.h
+++ b/src/cbmc/cbmc_parse_options.h
@@ -46,6 +46,7 @@ class optionst;
   OPT_REACHABILITY_SLICER \
   "(debug-level):(no-propagation)(no-simplify-if)" \
   "(document-subgoals)(outfile):(test-preprocessor)" \
+  "(write-solver-stats-to):"  \
   "D:I:(c89)(c99)(c11)(cpp98)(cpp03)(cpp11)" \
   "(object-bits):" \
   OPT_GOTO_CHECK \

--- a/src/goto-checker/all_properties_verifier_with_trace_storage.h
+++ b/src/goto-checker/all_properties_verifier_with_trace_storage.h
@@ -78,6 +78,7 @@ public:
       output_properties(properties, iterations, ui_message_handler);
     }
     output_overall_result(determine_result(properties), ui_message_handler);
+    incremental_goto_checker.report();
   }
 
   const goto_trace_storaget &get_traces() const

--- a/src/goto-checker/bmc_util.cpp
+++ b/src/goto-checker/bmc_util.cpp
@@ -26,6 +26,7 @@ Author: Daniel Kroening, Peter Schrammel
 #include <linking/static_lifetime_init.h>
 
 #include <solvers/decision_procedure.h>
+#include <solvers/flattening/boolbv.h>
 
 #include <util/make_unique.h>
 #include <util/ui_message.h>
@@ -149,14 +150,22 @@ void output_graphml(
 
 void convert_symex_target_equation(
   symex_target_equationt &equation,
-  decision_proceduret &decision_procedure,
+  goto_symex_property_decidert &property_decider,
   message_handlert &message_handler)
 {
   messaget msg(message_handler);
   msg.status() << "converting SSA" << messaget::eom;
 
   // convert SSA
-  equation.convert(decision_procedure);
+  if(dynamic_cast<boolbvt *>(&property_decider.get_decision_procedure()))
+  {
+    equation.convert(
+      property_decider.get_decision_procedure(), property_decider.get_prop());
+  }
+  else
+  {
+    equation.convert(property_decider.get_decision_procedure());
+  }
 }
 
 std::unique_ptr<memory_model_baset>
@@ -361,8 +370,7 @@ std::chrono::duration<double> prepare_property_decider(
     << property_decider.get_decision_procedure().decision_procedure_text()
     << messaget::eom;
 
-  convert_symex_target_equation(
-    equation, property_decider.get_decision_procedure(), ui_message_handler);
+  convert_symex_target_equation(equation, property_decider, ui_message_handler);
   property_decider.update_properties_goals_from_symex_target_equation(
     properties);
   property_decider.convert_goals();

--- a/src/goto-checker/bmc_util.cpp
+++ b/src/goto-checker/bmc_util.cpp
@@ -26,7 +26,6 @@ Author: Daniel Kroening, Peter Schrammel
 #include <linking/static_lifetime_init.h>
 
 #include <solvers/decision_procedure.h>
-#include <solvers/flattening/boolbv.h>
 
 #include <util/make_unique.h>
 #include <util/ui_message.h>
@@ -150,22 +149,13 @@ void output_graphml(
 
 void convert_symex_target_equation(
   symex_target_equationt &equation,
-  goto_symex_property_decidert &property_decider,
+  decision_proceduret &decision_procedure,
   message_handlert &message_handler)
 {
   messaget msg(message_handler);
   msg.status() << "converting SSA" << messaget::eom;
 
-  // convert SSA
-  if(dynamic_cast<boolbvt *>(&property_decider.get_decision_procedure()))
-  {
-    equation.convert(
-      property_decider.get_decision_procedure(), property_decider.get_prop());
-  }
-  else
-  {
-    equation.convert(property_decider.get_decision_procedure());
-  }
+  equation.convert(decision_procedure);
 }
 
 std::unique_ptr<memory_model_baset>
@@ -370,7 +360,8 @@ std::chrono::duration<double> prepare_property_decider(
     << property_decider.get_decision_procedure().decision_procedure_text()
     << messaget::eom;
 
-  convert_symex_target_equation(equation, property_decider, ui_message_handler);
+  convert_symex_target_equation(
+    equation, property_decider.get_decision_procedure(), ui_message_handler);
   property_decider.update_properties_goals_from_symex_target_equation(
     properties);
   property_decider.convert_goals();

--- a/src/goto-checker/bmc_util.h
+++ b/src/goto-checker/bmc_util.h
@@ -35,9 +35,9 @@ struct trace_optionst;
 class ui_message_handlert;
 
 void convert_symex_target_equation(
-  symex_target_equationt &,
-  goto_symex_property_decidert &,
-  message_handlert &);
+  symex_target_equationt &equation,
+  decision_proceduret &decision_procedure,
+  message_handlert &message_handler);
 
 /// Returns a function that checks whether an SSA step is an assertion
 /// with \p property_id. Usually used for `build_goto_trace`.

--- a/src/goto-checker/bmc_util.h
+++ b/src/goto-checker/bmc_util.h
@@ -36,7 +36,7 @@ class ui_message_handlert;
 
 void convert_symex_target_equation(
   symex_target_equationt &,
-  decision_proceduret &,
+  goto_symex_property_decidert &,
   message_handlert &);
 
 /// Returns a function that checks whether an SSA step is an assertion

--- a/src/goto-checker/goto_symex_property_decider.cpp
+++ b/src/goto-checker/goto_symex_property_decider.cpp
@@ -110,11 +110,6 @@ goto_symex_property_decidert::get_decision_procedure() const
   return solver->decision_procedure();
 }
 
-propt &goto_symex_property_decidert::get_prop() const
-{
-  return solver->prop();
-}
-
 stack_decision_proceduret &
 goto_symex_property_decidert::get_stack_decision_procedure() const
 {

--- a/src/goto-checker/goto_symex_property_decider.cpp
+++ b/src/goto-checker/goto_symex_property_decider.cpp
@@ -110,6 +110,11 @@ goto_symex_property_decidert::get_decision_procedure() const
   return solver->decision_procedure();
 }
 
+propt &goto_symex_property_decidert::get_prop() const
+{
+  return solver->prop();
+}
+
 stack_decision_proceduret &
 goto_symex_property_decidert::get_stack_decision_procedure() const
 {

--- a/src/goto-checker/goto_symex_property_decider.h
+++ b/src/goto-checker/goto_symex_property_decider.h
@@ -44,6 +44,9 @@ public:
   /// Calls solve() on the solver instance
   decision_proceduret::resultt solve();
 
+  /// Returns the prop
+  propt &get_prop() const;
+
   /// Returns the solver instance
   decision_proceduret &get_decision_procedure() const;
 

--- a/src/goto-checker/goto_symex_property_decider.h
+++ b/src/goto-checker/goto_symex_property_decider.h
@@ -44,9 +44,6 @@ public:
   /// Calls solve() on the solver instance
   decision_proceduret::resultt solve();
 
-  /// Returns the prop
-  propt &get_prop() const;
-
   /// Returns the solver instance
   decision_proceduret &get_decision_procedure() const;
 
@@ -68,7 +65,6 @@ public:
     std::unordered_set<irep_idt> &updated_properties,
     decision_proceduret::resultt dec_result,
     bool set_pass = true) const;
-
 protected:
   const optionst &options;
   ui_message_handlert &ui_message_handler;

--- a/src/goto-checker/incremental_goto_checker.h
+++ b/src/goto-checker/incremental_goto_checker.h
@@ -77,6 +77,12 @@ public:
   /// failing properties any more.
   virtual resultt operator()(propertiest &properties) = 0;
 
+  /// Additional reporting that may result from the underlying solver, no-op by
+  /// default.
+  virtual void report()
+  {
+  }
+
 protected:
   incremental_goto_checkert(const optionst &, ui_message_handlert &);
 

--- a/src/goto-checker/multi_path_symex_checker.cpp
+++ b/src/goto-checker/multi_path_symex_checker.cpp
@@ -25,6 +25,17 @@ multi_path_symex_checkert::multi_path_symex_checkert(
     equation_generated(false),
     property_decider(options, ui_message_handler, equation, ns)
 {
+  if(options.is_set("write-solver-stats-to"))
+  {
+    if(
+      auto hardness_collector =
+        dynamic_cast<hardness_collectort *>(&property_decider.get_prop()))
+    {
+      hardness_collector->enable_hardness_collection();
+      hardness_collector->get_solver_hardness().set_outfile(
+        options.get_option("write-solver-stats-to"));
+    }
+  }
 }
 
 incremental_goto_checkert::resultt multi_path_symex_checkert::
@@ -154,4 +165,20 @@ multi_path_symex_checkert::localize_fault(const irep_idt &property_id) const
     property_decider.get_stack_decision_procedure());
 
   return fault_localizer(property_id);
+}
+
+void multi_path_symex_checkert::report()
+{
+  if(options.is_set("write-solver-stats-to"))
+  {
+    if(
+      auto hardness_collector =
+        dynamic_cast<hardness_collectort *>(&property_decider.get_prop()))
+    {
+      if(hardness_collector->is_hardness_collection_enabled())
+      {
+        hardness_collector->get_solver_hardness().produce_report();
+      }
+    }
+  }
 }

--- a/src/goto-checker/multi_path_symex_checker.cpp
+++ b/src/goto-checker/multi_path_symex_checker.cpp
@@ -13,6 +13,8 @@ Author: Daniel Kroening, Peter Schrammel
 
 #include <chrono>
 
+#include <solvers/hardness_collector.h>
+
 #include "bmc_util.h"
 #include "counterexample_beautification.h"
 #include "goto_symex_fault_localizer.h"
@@ -25,17 +27,6 @@ multi_path_symex_checkert::multi_path_symex_checkert(
     equation_generated(false),
     property_decider(options, ui_message_handler, equation, ns)
 {
-  if(options.is_set("write-solver-stats-to"))
-  {
-    if(
-      auto hardness_collector =
-        dynamic_cast<hardness_collectort *>(&property_decider.get_prop()))
-    {
-      hardness_collector->enable_hardness_collection();
-      hardness_collector->get_solver_hardness().set_outfile(
-        options.get_option("write-solver-stats-to"));
-    }
-  }
 }
 
 incremental_goto_checkert::resultt multi_path_symex_checkert::
@@ -171,14 +162,8 @@ void multi_path_symex_checkert::report()
 {
   if(options.is_set("write-solver-stats-to"))
   {
-    if(
-      auto hardness_collector =
-        dynamic_cast<hardness_collectort *>(&property_decider.get_prop()))
-    {
-      if(hardness_collector->is_hardness_collection_enabled())
-      {
-        hardness_collector->get_solver_hardness().produce_report();
-      }
-    }
+    with_solver_hardness(
+      property_decider.get_decision_procedure(),
+      [](solver_hardnesst &hardness) { hardness.produce_report(); });
   }
 }

--- a/src/goto-checker/multi_path_symex_checker.h
+++ b/src/goto-checker/multi_path_symex_checker.h
@@ -54,6 +54,8 @@ public:
   fault_location_infot
   localize_fault(const irep_idt &property_id) const override;
 
+  void report() override;
+
 protected:
   bool equation_generated;
   goto_symex_property_decidert property_decider;

--- a/src/goto-checker/single_loop_incremental_symex_checker.cpp
+++ b/src/goto-checker/single_loop_incremental_symex_checker.cpp
@@ -89,7 +89,7 @@ operator()(propertiest &properties)
 
         log.status() << "converting SSA" << messaget::eom;
         equation.convert_without_assertions(
-          property_decider.get_decision_procedure());
+          property_decider.get_decision_procedure(), nullptr);
 
         property_decider.update_properties_goals_from_symex_target_equation(
           properties);
@@ -97,7 +97,7 @@ operator()(propertiest &properties)
         // We convert the assertions in a new context.
         property_decider.get_stack_decision_procedure().push();
         equation.convert_assertions(
-          property_decider.get_decision_procedure(), false);
+          property_decider.get_decision_procedure(), nullptr, false);
         property_decider.convert_goals();
 
         current_equation_converted = true;

--- a/src/goto-checker/single_loop_incremental_symex_checker.cpp
+++ b/src/goto-checker/single_loop_incremental_symex_checker.cpp
@@ -89,7 +89,7 @@ operator()(propertiest &properties)
 
         log.status() << "converting SSA" << messaget::eom;
         equation.convert_without_assertions(
-          property_decider.get_decision_procedure(), nullptr);
+          property_decider.get_decision_procedure());
 
         property_decider.update_properties_goals_from_symex_target_equation(
           properties);
@@ -97,7 +97,7 @@ operator()(propertiest &properties)
         // We convert the assertions in a new context.
         property_decider.get_stack_decision_procedure().push();
         equation.convert_assertions(
-          property_decider.get_decision_procedure(), nullptr, false);
+          property_decider.get_decision_procedure(), false);
         property_decider.convert_goals();
 
         current_equation_converted = true;

--- a/src/goto-symex/symex_target_equation.h
+++ b/src/goto-symex/symex_target_equation.h
@@ -29,8 +29,11 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "symex_target.h"
 
 class decision_proceduret;
+class propt;
 class namespacet;
 class decision_proceduret;
+class hardness_collectort;
+struct solver_hardnesst;
 
 /// Inheriting the interface of symex_targett this class represents the SSA
 /// form of the input program as a list of \ref SSA_stept. It further extends
@@ -178,6 +181,10 @@ public:
   /// \param decision_procedure: A handle to a decision procedure interface
   void convert(decision_proceduret &decision_procedure);
 
+  /// \copydoc convert(decision_proceduret &)
+  /// \param prop: A handle to a prop interface to query the solver hardness
+  void convert(decision_proceduret &decision_procedure, propt &prop);
+
   /// Interface method to initiate the conversion into a decision procedure
   /// format. The method iterates over the equation, i.e. over the SSA steps and
   /// converts each type of step separately, except assertions.
@@ -185,53 +192,82 @@ public:
   /// e.g. for incremental solving.
   /// \param decision_procedure: A handle to a particular decision procedure
   ///   interface
-  void convert_without_assertions(decision_proceduret &decision_procedure);
+  /// \param solver_hardness: A pointer to solvers statistics collector
+  void convert_without_assertions(
+    decision_proceduret &decision_procedure,
+    solver_hardnesst *solver_hardness = nullptr);
 
   /// Converts assignments: set the equality _lhs==rhs_ to _True_.
   /// \param decision_procedure: A handle to a decision procedure
   ///  interface
-  void convert_assignments(decision_proceduret &decision_procedure);
+  /// \param solver_hardness: A pointer to solvers statistics collector
+  void convert_assignments(
+    decision_proceduret &decision_procedure,
+    solver_hardnesst *solver_hardness = nullptr);
 
   /// Converts declarations: these are effectively ignored by the decision
   /// procedure.
   /// \param decision_procedure: A handle to a decision procedure
   ///  interface
-  void convert_decls(decision_proceduret &decision_procedure);
+  /// \param solver_hardness: A pointer to solvers statistics collector
+  void convert_decls(
+    decision_proceduret &decision_procedure,
+    solver_hardnesst *solver_hardness = nullptr);
 
   /// Converts assumptions: convert the expression the assumption represents.
   /// \param decision_procedure: A handle to a decision procedure interface
-  void convert_assumptions(decision_proceduret &decision_procedure);
+  /// \param solver_hardness: A pointer to solvers statistics collector
+  void convert_assumptions(
+    decision_proceduret &decision_procedure,
+    solver_hardnesst *solver_hardness = nullptr);
 
   /// Converts assertions: build a disjunction of negated assertions.
   /// \param decision_procedure: A handle to a decision procedure interface
   /// \param optimized_for_single_assertions: Use an optimized encoding for
   ///   single assertions (unsound for incremental conversions)
+  /// \param solver_hardness: A pointer to solvers statistics collector
   void convert_assertions(
     decision_proceduret &decision_procedure,
+    solver_hardnesst *solver_hardness = nullptr,
     bool optimized_for_single_assertions = true);
 
   /// Converts constraints: set the represented condition to _True_.
   /// \param decision_procedure: A handle to a decision procedure interface
-  void convert_constraints(decision_proceduret &decision_procedure);
+  /// \param solver_hardness: A pointer to solvers statistics collector
+  void convert_constraints(
+    decision_proceduret &decision_procedure,
+    solver_hardnesst *solver_hardness = nullptr);
 
   /// Converts goto instructions: convert the expression representing the
   /// condition of this goto.
   /// \param decision_procedure: A handle to a decision procedure interface
-  void convert_goto_instructions(decision_proceduret &decision_procedure);
+  /// \param solver_hardness: A pointer to solvers statistics collector
+  void convert_goto_instructions(
+    decision_proceduret &decision_procedure,
+    solver_hardnesst *solver_hardness = nullptr);
 
   /// Converts guards: convert the expression the guard represents.
   /// \param decision_procedure: A handle to a decision procedure interface
-  void convert_guards(decision_proceduret &decision_procedure);
+  /// \param solver_hardness: A pointer to solvers statistics collector
+  void convert_guards(
+    decision_proceduret &decision_procedure,
+    solver_hardnesst *solver_hardness = nullptr);
 
   /// Converts function calls: for each argument build an equality between its
   /// symbol and the argument itself.
   /// \param decision_procedure: A handle to a decision procedure interface
-  void convert_function_calls(decision_proceduret &decision_procedure);
+  /// \param solver_hardness: A pointer to solvers statistics collector
+  void convert_function_calls(
+    decision_proceduret &decision_procedure,
+    solver_hardnesst *solver_hardness = nullptr);
 
   /// Converts I/O: for each argument build an equality between its
   /// symbol and the argument itself.
   /// \param decision_procedure: A handle to a decision procedure interface
-  void convert_io(decision_proceduret &decision_procedure);
+  /// \param solver_hardness: A pointer to solvers statistics collector
+  void convert_io(
+    decision_proceduret &decision_procedure,
+    solver_hardnesst *solver_hardness = nullptr);
 
   exprt make_expression() const;
 

--- a/src/goto-symex/symex_target_equation.h
+++ b/src/goto-symex/symex_target_equation.h
@@ -29,7 +29,6 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "symex_target.h"
 
 class decision_proceduret;
-class propt;
 class namespacet;
 class decision_proceduret;
 class hardness_collectort;
@@ -181,10 +180,6 @@ public:
   /// \param decision_procedure: A handle to a decision procedure interface
   void convert(decision_proceduret &decision_procedure);
 
-  /// \copydoc convert(decision_proceduret &)
-  /// \param prop: A handle to a prop interface to query the solver hardness
-  void convert(decision_proceduret &decision_procedure, propt &prop);
-
   /// Interface method to initiate the conversion into a decision procedure
   /// format. The method iterates over the equation, i.e. over the SSA steps and
   /// converts each type of step separately, except assertions.
@@ -192,82 +187,53 @@ public:
   /// e.g. for incremental solving.
   /// \param decision_procedure: A handle to a particular decision procedure
   ///   interface
-  /// \param solver_hardness: A pointer to solvers statistics collector
-  void convert_without_assertions(
-    decision_proceduret &decision_procedure,
-    solver_hardnesst *solver_hardness = nullptr);
+  void convert_without_assertions(decision_proceduret &decision_procedure);
 
   /// Converts assignments: set the equality _lhs==rhs_ to _True_.
   /// \param decision_procedure: A handle to a decision procedure
   ///  interface
-  /// \param solver_hardness: A pointer to solvers statistics collector
-  void convert_assignments(
-    decision_proceduret &decision_procedure,
-    solver_hardnesst *solver_hardness = nullptr);
+  void convert_assignments(decision_proceduret &decision_procedure);
 
   /// Converts declarations: these are effectively ignored by the decision
   /// procedure.
   /// \param decision_procedure: A handle to a decision procedure
   ///  interface
-  /// \param solver_hardness: A pointer to solvers statistics collector
-  void convert_decls(
-    decision_proceduret &decision_procedure,
-    solver_hardnesst *solver_hardness = nullptr);
+  void convert_decls(decision_proceduret &decision_procedure);
 
   /// Converts assumptions: convert the expression the assumption represents.
   /// \param decision_procedure: A handle to a decision procedure interface
-  /// \param solver_hardness: A pointer to solvers statistics collector
-  void convert_assumptions(
-    decision_proceduret &decision_procedure,
-    solver_hardnesst *solver_hardness = nullptr);
+  void convert_assumptions(decision_proceduret &decision_procedure);
 
   /// Converts assertions: build a disjunction of negated assertions.
   /// \param decision_procedure: A handle to a decision procedure interface
   /// \param optimized_for_single_assertions: Use an optimized encoding for
   ///   single assertions (unsound for incremental conversions)
-  /// \param solver_hardness: A pointer to solvers statistics collector
   void convert_assertions(
     decision_proceduret &decision_procedure,
-    solver_hardnesst *solver_hardness = nullptr,
     bool optimized_for_single_assertions = true);
 
   /// Converts constraints: set the represented condition to _True_.
   /// \param decision_procedure: A handle to a decision procedure interface
-  /// \param solver_hardness: A pointer to solvers statistics collector
-  void convert_constraints(
-    decision_proceduret &decision_procedure,
-    solver_hardnesst *solver_hardness = nullptr);
+  void convert_constraints(decision_proceduret &decision_procedure);
 
   /// Converts goto instructions: convert the expression representing the
   /// condition of this goto.
   /// \param decision_procedure: A handle to a decision procedure interface
-  /// \param solver_hardness: A pointer to solvers statistics collector
-  void convert_goto_instructions(
-    decision_proceduret &decision_procedure,
-    solver_hardnesst *solver_hardness = nullptr);
+  void convert_goto_instructions(decision_proceduret &decision_procedure);
 
   /// Converts guards: convert the expression the guard represents.
   /// \param decision_procedure: A handle to a decision procedure interface
-  /// \param solver_hardness: A pointer to solvers statistics collector
-  void convert_guards(
-    decision_proceduret &decision_procedure,
-    solver_hardnesst *solver_hardness = nullptr);
+  void convert_guards(decision_proceduret &decision_procedure);
 
   /// Converts function calls: for each argument build an equality between its
   /// symbol and the argument itself.
   /// \param decision_procedure: A handle to a decision procedure interface
-  /// \param solver_hardness: A pointer to solvers statistics collector
-  void convert_function_calls(
-    decision_proceduret &decision_procedure,
-    solver_hardnesst *solver_hardness = nullptr);
+  void convert_function_calls(decision_proceduret &decision_procedure);
 
   /// Converts I/O: for each argument build an equality between its
   /// symbol and the argument itself.
   /// \param decision_procedure: A handle to a decision procedure interface
-  /// \param solver_hardness: A pointer to solvers statistics collector
-  void convert_io(
-    decision_proceduret &decision_procedure,
-    solver_hardnesst *solver_hardness = nullptr);
+  void convert_io(decision_proceduret &decision_procedure);
 
   exprt make_expression() const;
 

--- a/src/solvers/Makefile
+++ b/src/solvers/Makefile
@@ -80,6 +80,7 @@ SRC = $(BOOLEFORCE_SRC) \
       $(SQUOLEM2_SRC) \
       $(CADICAL_SRC) \
       decision_procedure.cpp \
+      solver_hardness.cpp \
       flattening/arrays.cpp \
       flattening/boolbv.cpp \
       flattening/boolbv_abs.cpp \

--- a/src/solvers/hardness_collector.h
+++ b/src/solvers/hardness_collector.h
@@ -1,0 +1,36 @@
+/*******************************************************************\
+
+Module: Capability to collect the statistics of the complexity of individual
+        solver queries.
+
+Author: diffblue
+
+\*******************************************************************/
+
+/// \file
+/// Capability to collect the statistics of the complexity of individual solver
+/// queries.
+
+#ifndef CPROVER_SOLVERS_HARDNESS_COLLECTOR_H
+#define CPROVER_SOLVERS_HARDNESS_COLLECTOR_H
+
+#include <solvers/solver_hardness.h>
+
+class exprt;
+
+class hardness_collectort
+{
+public:
+  virtual bool is_hardness_collection_enabled() const
+  {
+    return false;
+  }
+  virtual void enable_hardness_collection()
+  {
+  }
+  virtual solver_hardnesst &get_solver_hardness() = 0;
+
+  virtual ~hardness_collectort() = default;
+};
+
+#endif // CPROVER_SOLVERS_HARDNESS_COLLECTOR_H

--- a/src/solvers/hardness_collector.h
+++ b/src/solvers/hardness_collector.h
@@ -3,7 +3,7 @@
 Module: Capability to collect the statistics of the complexity of individual
         solver queries.
 
-Author: diffblue
+Author: Diffblue Ltd.
 
 \*******************************************************************/
 
@@ -14,6 +14,7 @@ Author: diffblue
 #ifndef CPROVER_SOLVERS_HARDNESS_COLLECTOR_H
 #define CPROVER_SOLVERS_HARDNESS_COLLECTOR_H
 
+#include <functional>
 #include <solvers/solver_hardness.h>
 
 class exprt;
@@ -21,16 +22,24 @@ class exprt;
 class hardness_collectort
 {
 public:
-  virtual bool is_hardness_collection_enabled() const
-  {
-    return false;
-  }
-  virtual void enable_hardness_collection()
-  {
-  }
-  virtual solver_hardnesst &get_solver_hardness() = 0;
-
+  using handlert = std::function<void(solver_hardnesst &)>;
+  virtual void with_solver_hardness(handlert handler) = 0;
+  virtual void enable_hardness_collection() = 0;
   virtual ~hardness_collectort() = default;
 };
 
+template <typename T>
+void with_solver_hardness(
+  T &maybe_hardness_collector,
+  hardness_collectort::handlert handler)
+{
+  // FIXME I am wondering if there is a way to do this that is a bit less
+  // dynamically typed.
+  if(
+    auto hardness_collector =
+      dynamic_cast<hardness_collectort *>(&maybe_hardness_collector))
+  {
+    hardness_collector->with_solver_hardness(handler);
+  }
+}
 #endif // CPROVER_SOLVERS_HARDNESS_COLLECTOR_H

--- a/src/solvers/module_dependencies.txt
+++ b/src/solvers/module_dependencies.txt
@@ -1,3 +1,5 @@
 cplusplus # cudd
 cudd
+goto-programs
 solvers
+util

--- a/src/solvers/prop/prop_conv_solver.cpp
+++ b/src/solvers/prop/prop_conv_solver.cpp
@@ -593,3 +593,16 @@ std::string prop_conv_solvert::decision_procedure_text() const
 {
   return "propositional reduction";
 }
+
+void prop_conv_solvert::with_solver_hardness(
+  hardness_collectort::handlert handler)
+{
+  ::with_solver_hardness(prop, handler);
+}
+void prop_conv_solvert::enable_hardness_collection()
+{
+  if(auto hardness_collector = dynamic_cast<hardness_collectort *>(&prop))
+  {
+    hardness_collector->enable_hardness_collection();
+  }
+}

--- a/src/solvers/prop/prop_conv_solver.h
+++ b/src/solvers/prop/prop_conv_solver.h
@@ -17,8 +17,8 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/std_expr.h>
 
 #include <solvers/conflict_provider.h>
+#include <solvers/hardness_collector.h>
 
-#include "literal.h"
 #include "literal_expr.h"
 #include "prop.h"
 #include "prop_conv.h"
@@ -26,7 +26,8 @@ Author: Daniel Kroening, kroening@kroening.com
 
 class prop_conv_solvert : public conflict_providert,
                           public prop_convt,
-                          public solver_resource_limitst
+                          public solver_resource_limitst,
+                          public hardness_collectort
 {
 public:
   prop_conv_solvert(propt &_prop, message_handlert &message_handler)
@@ -98,6 +99,9 @@ public:
   }
 
   std::size_t get_number_of_solver_calls() const override;
+
+  void with_solver_hardness(handlert handler) override;
+  void enable_hardness_collection() override;
 
 protected:
   virtual void post_process();

--- a/src/solvers/sat/module_dependencies.txt
+++ b/src/solvers/sat/module_dependencies.txt
@@ -2,6 +2,5 @@ core # external - glucose
 simp # external - glucose
 minisat/core # external
 minisat/simp # external
-solvers/prop
-solvers/sat
+solvers
 util

--- a/src/solvers/sat/satcheck_minisat2.cpp
+++ b/src/solvers/sat/satcheck_minisat2.cpp
@@ -140,8 +140,8 @@ void satcheck_minisat2_baset<T>::lcnf(const bvt &bv)
 
     solver->addClause_(c);
 
-    if(solver_hardness.has_value())
-      solver_hardness->register_clause(bv);
+    with_solver_hardness(
+      [&bv](solver_hardnesst &hardness) { hardness.register_clause(bv); });
     clause_counter++;
   }
   catch(const Minisat::OutOfMemoryException &)
@@ -331,12 +331,6 @@ void satcheck_minisat2_baset<T>::set_assumptions(const bvt &bv)
       assumptions.push_back(assumption);
     }
   }
-}
-
-template <typename T>
-void satcheck_minisat2_baset<T>::enable_hardness_collection()
-{
-  solver_hardness = solver_hardnesst{};
 }
 
 satcheck_minisat_no_simplifiert::satcheck_minisat_no_simplifiert(

--- a/src/solvers/sat/satcheck_minisat2.cpp
+++ b/src/solvers/sat/satcheck_minisat2.cpp
@@ -140,6 +140,8 @@ void satcheck_minisat2_baset<T>::lcnf(const bvt &bv)
 
     solver->addClause_(c);
 
+    if(solver_hardness.has_value())
+      solver_hardness->register_clause(bv);
     clause_counter++;
   }
   catch(const Minisat::OutOfMemoryException &)
@@ -329,6 +331,12 @@ void satcheck_minisat2_baset<T>::set_assumptions(const bvt &bv)
       assumptions.push_back(assumption);
     }
   }
+}
+
+template <typename T>
+void satcheck_minisat2_baset<T>::enable_hardness_collection()
+{
+  solver_hardness = solver_hardnesst{};
 }
 
 satcheck_minisat_no_simplifiert::satcheck_minisat_no_simplifiert(

--- a/src/solvers/sat/satcheck_minisat2.h
+++ b/src/solvers/sat/satcheck_minisat2.h
@@ -12,6 +12,8 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "cnf.h"
 
+#include <solvers/hardness_collector.h>
+
 // Select one: basic solver or with simplification.
 // Note that the solver with simplifier isn't really robust
 // when used incrementally, as variables may disappear
@@ -23,8 +25,8 @@ class Solver; // NOLINT(readability/identifiers)
 class SimpSolver; // NOLINT(readability/identifiers)
 }
 
-template<typename T>
-class satcheck_minisat2_baset:public cnf_solvert
+template <typename T>
+class satcheck_minisat2_baset : public cnf_solvert, public hardness_collectort
 {
 public:
   satcheck_minisat2_baset(T *, message_handlert &message_handler);
@@ -62,6 +64,17 @@ public:
     time_limit_seconds=lim;
   }
 
+  bool is_hardness_collection_enabled() const override
+  {
+    return solver_hardness.has_value();
+  }
+  void enable_hardness_collection() override;
+  solver_hardnesst &get_solver_hardness() override
+  {
+    PRECONDITION(solver_hardness.has_value());
+    return *solver_hardness;
+  }
+
 protected:
   resultt do_prop_solve() override;
 
@@ -70,6 +83,8 @@ protected:
 
   void add_variables();
   bvt assumptions;
+
+  optionalt<solver_hardnesst> solver_hardness;
 };
 
 class satcheck_minisat_no_simplifiert:

--- a/src/solvers/sat/satcheck_minisat2.h
+++ b/src/solvers/sat/satcheck_minisat2.h
@@ -64,15 +64,18 @@ public:
     time_limit_seconds=lim;
   }
 
-  bool is_hardness_collection_enabled() const override
+  void
+  with_solver_hardness(std::function<void(solver_hardnesst &)> handler) override
   {
-    return solver_hardness.has_value();
+    if(solver_hardness.has_value())
+    {
+      handler(solver_hardness.value());
+    }
   }
-  void enable_hardness_collection() override;
-  solver_hardnesst &get_solver_hardness() override
+
+  void enable_hardness_collection() override
   {
-    PRECONDITION(solver_hardness.has_value());
-    return *solver_hardness;
+    solver_hardness = solver_hardnesst{};
   }
 
 protected:

--- a/src/solvers/solver_hardness.cpp
+++ b/src/solvers/solver_hardness.cpp
@@ -1,0 +1,315 @@
+/*******************************************************************\
+
+Module: measure and track the complexity of solver queries
+
+Author: Diffblue Ltd.
+
+\*******************************************************************/
+
+#include "solver_hardness.h"
+
+#include <algorithm>
+#include <iomanip>
+#include <iostream>
+
+#include <cstdint>
+
+#include <util/format_expr.h>
+#include <util/format_type.h>
+#include <util/json_irep.h>
+#include <util/json_stream.h>
+#include <util/string2int.h>
+
+void solver_hardnesst::register_ssa_size(std::size_t size)
+{
+  // do not shrink
+  if(size <= hardness_stats.size())
+    return;
+
+  hardness_stats.resize(size);
+}
+
+void solver_hardnesst::register_ssa(
+  std::size_t ssa_index,
+  const exprt ssa_expression,
+  goto_programt::const_targett pc)
+{
+  PRECONDITION(ssa_index < hardness_stats.size());
+
+  current_stats.ssa_expression = expr2string(ssa_expression);
+  current_stats.pc = pc;
+  hardness_stats[ssa_index].insert(current_stats);
+  if(hardness_stats[ssa_index].size() > max_ssa_set_size)
+    max_ssa_set_size = hardness_stats[ssa_index].size();
+  current_stats.clear();
+}
+
+void solver_hardnesst::register_assertion_ssas(
+  const exprt ssa_expression,
+  const std::vector<goto_programt::const_targett> &pcs)
+{
+  if(assertion_stats.empty())
+    return;
+
+  assertion_stats.sat_hardness = current_stats.sat_hardness;
+  assertion_stats.ssa_expression = expr2string(ssa_expression);
+  assertion_stats.pcs = pcs;
+  current_stats.clear();
+}
+
+void solver_hardnesst::register_clause(const bvt &bv)
+{
+  auto &current_hardness = current_stats.sat_hardness;
+  current_hardness.clauses++;
+  current_hardness.literals += bv.size();
+  for(const auto &literal : bv)
+  {
+    current_hardness.variables.insert(literal.var_no());
+  }
+}
+
+void solver_hardnesst::produce_report()
+{
+  PRECONDITION(!outfile.empty());
+
+  // The SSA steps and indexed internally (by the position in the SSA equation)
+  // but if the `--paths` option is used, there are multiple equations, some
+  // sharing SSA steps. We only store the unique ones in a set but now we want
+  // to identify them by a single number. So we shift the SSA index to make room
+  // for the set index.
+  std::size_t ssa_set_bit_offset = 0;
+  const std::size_t one = 1;
+  while((one << ssa_set_bit_offset) < max_ssa_set_size)
+    ++ssa_set_bit_offset;
+
+  std::ofstream out{outfile};
+  json_stream_arrayt json_stream_array{out};
+
+  for(std::size_t i = 0; i < hardness_stats.size(); i++)
+  {
+    const auto &ssa_set = hardness_stats[i];
+    if(ssa_set.empty())
+      continue;
+
+    std::size_t j = 0;
+    for(const auto &stat : ssa_set)
+    {
+      auto hardness_stats_json = json_objectt{};
+      hardness_stats_json["SSA_expr"] = json_stringt{stat.ssa_expression};
+      hardness_stats_json["GOTO"] =
+        json_stringt{goto_instruction2string(stat.pc)};
+
+      // It might be desirable to collect all SAT hardness statistics pertaining
+      // to a particular GOTO instruction, since there may be a number of SSA
+      // steps per GOTO instruction. The following JSON contains a unique
+      // identifier for each one.
+      hardness_stats_json["GOTO_ID"] =
+        json_numbert{std::to_string((i << ssa_set_bit_offset) + j)};
+      hardness_stats_json["Source"] = json(stat.pc->source_location);
+
+      auto sat_hardness_json = json_objectt{};
+      sat_hardness_json["Clauses"] =
+        json_numbert{std::to_string(stat.sat_hardness.clauses)};
+      sat_hardness_json["Literals"] =
+        json_numbert{std::to_string(stat.sat_hardness.literals)};
+      sat_hardness_json["Variables"] =
+        json_numbert{std::to_string(stat.sat_hardness.variables.size())};
+
+      hardness_stats_json["SAT_hardness"] = sat_hardness_json;
+
+      json_stream_array.push_back(hardness_stats_json);
+      ++j;
+    }
+  }
+
+  if(!assertion_stats.empty())
+  {
+    auto assertion_stats_json = json_objectt{};
+    assertion_stats_json["SSA_expr"] =
+      json_stringt{assertion_stats.ssa_expression};
+
+    auto assertion_stats_pcs_json = json_arrayt{};
+    for(const auto pc : assertion_stats.pcs)
+    {
+      auto assertion_stats_pc_json = json_objectt{};
+      assertion_stats_pc_json["GOTO"] =
+        json_stringt{goto_instruction2string(pc)};
+      assertion_stats_pc_json["Source"] = json(pc->source_location);
+      assertion_stats_pcs_json.push_back(assertion_stats_pc_json);
+    }
+    assertion_stats_json["Sources"] = assertion_stats_pcs_json;
+
+    auto assertion_hardness_json = json_objectt{};
+    assertion_hardness_json["Clauses"] =
+      json_numbert{std::to_string(assertion_stats.sat_hardness.clauses)};
+    assertion_hardness_json["Literals"] =
+      json_numbert{std::to_string(assertion_stats.sat_hardness.literals)};
+    assertion_hardness_json["Variables"] = json_numbert{
+      std::to_string(assertion_stats.sat_hardness.variables.size())};
+
+    assertion_stats_json["SAT_hardness"] = assertion_hardness_json;
+
+    json_stream_array.push_back(assertion_stats_json);
+  }
+}
+
+std::string
+solver_hardnesst::goto_instruction2string(goto_programt::const_targett pc)
+{
+  std::stringstream out;
+  auto instruction = *pc;
+
+  if(!instruction.labels.empty())
+  {
+    out << "        // Labels:";
+    for(const auto &label : instruction.labels)
+      out << " " << label;
+  }
+
+  if(instruction.is_target())
+    out << std::setw(6) << instruction.target_number << ": ";
+
+  switch(instruction.type)
+  {
+  case NO_INSTRUCTION_TYPE:
+    out << "NO INSTRUCTION TYPE SET";
+    break;
+
+  case GOTO:
+  case INCOMPLETE_GOTO:
+    if(!instruction.get_condition().is_true())
+    {
+      out << "IF " << format(instruction.get_condition()) << " THEN ";
+    }
+
+    out << "GOTO ";
+
+    if(instruction.is_incomplete_goto())
+    {
+      out << "(incomplete)";
+    }
+    else
+    {
+      for(auto gt_it = instruction.targets.begin();
+          gt_it != instruction.targets.end();
+          gt_it++)
+      {
+        if(gt_it != instruction.targets.begin())
+          out << ", ";
+        out << (*gt_it)->target_number;
+      }
+    }
+    break;
+
+  case RETURN:
+  case OTHER:
+  case DECL:
+  case DEAD:
+  case FUNCTION_CALL:
+  case ASSIGN:
+    out << format(instruction.code);
+    break;
+
+  case ASSUME:
+  case ASSERT:
+    if(instruction.is_assume())
+      out << "ASSUME ";
+    else
+      out << "ASSERT ";
+
+    out << format(instruction.get_condition());
+    break;
+
+  case SKIP:
+    out << "SKIP";
+    break;
+
+  case END_FUNCTION:
+    out << "END_FUNCTION";
+    break;
+
+  case LOCATION:
+    out << "LOCATION";
+    break;
+
+  case THROW:
+    out << "THROW";
+
+    {
+      const irept::subt &exception_list =
+        instruction.code.find(ID_exception_list).get_sub();
+
+      for(const auto &ex : exception_list)
+        out << " " << ex.id();
+    }
+
+    if(instruction.code.operands().size() == 1)
+      out << ": " << format(instruction.code.op0());
+
+    break;
+
+  case CATCH:
+  {
+    if(instruction.code.get_statement() == ID_exception_landingpad)
+    {
+      const auto &landingpad = to_code_landingpad(instruction.code);
+      out << "EXCEPTION LANDING PAD (" << format(landingpad.catch_expr().type())
+          << ' ' << format(landingpad.catch_expr()) << ")";
+    }
+    else if(instruction.code.get_statement() == ID_push_catch)
+    {
+      out << "CATCH-PUSH ";
+
+      unsigned i = 0;
+      const irept::subt &exception_list =
+        instruction.code.find(ID_exception_list).get_sub();
+      DATA_INVARIANT(
+        instruction.targets.size() == exception_list.size(),
+        "unexpected discrepancy between sizes of instruction"
+        "targets and exception list");
+      for(auto gt_it = instruction.targets.begin();
+          gt_it != instruction.targets.end();
+          gt_it++, i++)
+      {
+        if(gt_it != instruction.targets.begin())
+          out << ", ";
+        out << exception_list[i].id() << "->" << (*gt_it)->target_number;
+      }
+    }
+    else if(instruction.code.get_statement() == ID_pop_catch)
+    {
+      out << "CATCH-POP";
+    }
+    else
+    {
+      UNREACHABLE;
+    }
+    break;
+  }
+
+  case ATOMIC_BEGIN:
+    out << "ATOMIC_BEGIN";
+    break;
+
+  case ATOMIC_END:
+    out << "ATOMIC_END";
+    break;
+
+  case START_THREAD:
+    out << "START THREAD " << instruction.get_target()->target_number;
+    break;
+
+  case END_THREAD:
+    out << "END THREAD";
+    break;
+  }
+
+  return out.str();
+}
+
+std::string solver_hardnesst::expr2string(const exprt expr)
+{
+  std::stringstream ss;
+  ss << format(expr);
+  return ss.str();
+}

--- a/src/solvers/solver_hardness.h
+++ b/src/solvers/solver_hardness.h
@@ -1,0 +1,201 @@
+/*******************************************************************\
+
+Module: measure and track the complexity of solver queries
+
+Author: Diffblue Ltd.
+
+\*******************************************************************/
+
+#ifndef CPROVER_SOLVERS_SOLVER_HARDNESS_H
+#define CPROVER_SOLVERS_SOLVER_HARDNESS_H
+
+#include <solvers/prop/literal.h>
+
+#include <fstream>
+#include <sstream>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include <iostream>
+
+#include <goto-programs/goto_program.h>
+
+#include <util/optional.h>
+
+/// A structure that facilitates collecting the complexity statistics from a
+/// decision procedure. The idea is to associate some solver complexity metric
+/// with each line-of-code, GOTO instruction, and SSA step. The motivation is to
+/// be able to track the impact of (1) which C instruction to use on the code
+/// level, (2) which GOTO instruction to generate when parsing the source or
+/// running internal optimisations, (3) which SSA step to produce for each GOTO
+/// instruction, etc.
+///
+/// In terms of a SAT solver the complexity metric can be number of
+/// clauses/literals/variables.
+///
+/// The object of this type should be visible from the \ref
+/// symex_target_equationt (so that we can register which SSA/GOTO/program
+/// counter was passed to the solver) and from some decision procedure (e.g. a
+/// derived class of \ref cnft for SAT solving). For this purpose the object
+/// lives in the \ref solver_factoryt::solvert and pointers are passed to both
+/// \ref decision_proceduret and \ref propt.
+struct solver_hardnesst
+{
+  // From SAT solver we collect the number of clauses, the number of literals
+  // and the number of distinct variables that were used in all clauses.
+  struct sat_hardnesst
+  {
+    size_t clauses;
+    size_t literals;
+    std::unordered_set<size_t> variables;
+
+    sat_hardnesst() : clauses(0), literals(0)
+    {
+    }
+
+    bool empty() const
+    {
+      return clauses == 0;
+    }
+
+    void clear()
+    {
+      clauses = 0;
+      literals = 0;
+      variables.clear();
+    }
+  };
+
+  // Associate an SSA step expression (the one passed to the solver: the guard
+  // for GOTO; equality for ASSIGN, etc.) with the SAT hardness of the resulting
+  // query. The GOTO and source level instructions are stored as \ref
+  // goto_programt::const_targett.
+  struct hardness_statst
+  {
+    sat_hardnesst sat_hardness;
+    std::string ssa_expression;
+    goto_programt::const_targett pc;
+
+    hardness_statst() : sat_hardness{}, ssa_expression{""}
+    {
+    }
+
+    bool empty() const
+    {
+      return ssa_expression.empty();
+    }
+    void clear()
+    {
+      sat_hardness.clear();
+      ssa_expression = "";
+    }
+
+    bool operator==(const hardness_statst &other) const
+    {
+      if(ssa_expression != other.ssa_expression)
+        return false;
+      return pc->source_location.as_string() ==
+             other.pc->source_location.as_string();
+    }
+  };
+
+  struct hardness_stats_hashert
+  {
+    std::size_t operator()(const hardness_statst &hashed_stats) const
+    {
+      return std::hash<std::string>{}(
+        hashed_stats.ssa_expression +
+        hashed_stats.pc->source_location.as_string());
+    }
+  };
+
+  // As above but for the special case of multiple assertions, which are
+  // presented to the solver as a single disjunction. Hence we have one SSA
+  // expression (the whole disjunction) and multiple program counters.
+  struct assertion_statst
+  {
+    sat_hardnesst sat_hardness;
+    std::string ssa_expression;
+    std::vector<goto_programt::const_targett> pcs;
+
+    assertion_statst() : sat_hardness{}, ssa_expression{""}
+    {
+    }
+
+    bool empty() const
+    {
+      return pcs.empty();
+    }
+  };
+
+  /// Called from the `symtex_target_equationt::convert_*`, this function
+  ///   associates an SSA step to all the solver queries collected since the
+  ///   last call.
+  /// \param ssa_index: position (of this step) in the SSA equation
+  /// \param ssa_expression: string representing the SSA step expression
+  /// \param pc: the GOTO instruction iterator for this SSA step
+  void register_ssa(
+    std::size_t ssa_index,
+    const exprt ssa_expression,
+    goto_programt::const_targett pc);
+
+  /// Called from the `symtex_target_equationt::convert_assertions`, this
+  ///   function associates the disjunction of assertions to all the solver
+  ///   queries collected since the last call.
+  /// \param ssa_expression: string representing the disjuction of SSA
+  ///   assertions
+  /// \param pcs: all GOTO instruction iterators that contributed in the
+  ///   disjunction
+  void register_assertion_ssas(
+    const exprt ssa_expression,
+    const std::vector<goto_programt::const_targett> &pcs);
+
+  /// Called e.g. from the `satcheck_minisat2::lcnf`, this function adds the
+  ///   complexity statistics from the last SAT query to the `current_stats`.
+  /// \param bv: the clause (vector of literals)
+  void register_clause(const bvt &bv);
+
+  /// Print the statistics to a JSON file (specified via command-line option).
+  void produce_report();
+
+  void set_outfile(const std::string &file_name)
+  {
+    outfile = file_name;
+  }
+
+  void register_ssa_size(std::size_t size);
+
+  bool were_assertion_steps_registered() const
+  {
+    return !assertion_stats.empty();
+  }
+
+  solver_hardnesst() : outfile{""}, max_ssa_set_size(0)
+  {
+  }
+
+  solver_hardnesst(const solver_hardnesst &other)
+  {
+    // we only allow copying the statistics before initialization
+    PRECONDITION(other.hardness_stats.empty());
+    outfile = "";
+    max_ssa_set_size = 0;
+  }
+
+  // A minor modification of \ref goto_programt::output_instruction
+  static std::string goto_instruction2string(goto_programt::const_targett pc);
+
+  static std::string expr2string(const exprt expr);
+
+private:
+  std::string outfile;
+  std::vector<std::unordered_set<hardness_statst, hardness_stats_hashert>>
+    hardness_stats;
+  hardness_statst current_stats;
+  assertion_statst assertion_stats;
+  std::size_t max_ssa_set_size;
+};
+
+#endif // CPROVER_SOLVERS_SOLVER_HARDNESS_H


### PR DESCRIPTION

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

Introduces a functionality to track and collect the complexity of individual
solver queries. For SAT solvers we collect the number of clauses, literals, and
variables. The functionality matches solver queries to the SSA steps that
produced them. After running the solver, we produce a JSON report that matches
program line to GOTO instruction to SSA step to solver hardness.

At present the collection is command-line optional and only works with the
default SAT solver (minisat2). Extension to other SAT and SMT solvers should be
possible.

Supercedes https://github.com/diffblue/cbmc/pull/5159

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
