### PR TITLE
on Windows, empty command-line arguments require quotes

### DIFF
--- a/src/util/run.cpp
+++ b/src/util/run.cpp
@@ -165,7 +165,8 @@ static fdt stdio_redirection(int fd, const std::string &file)
 // https://blogs.msdn.microsoft.com/twistylittlepassagesallalike/2011/04/23/everyone-quotes-command-line-arguments-the-wrong-way/
 std::wstring quote_windows_arg(const std::wstring &src)
 {
-  if(src.find_first_of(L" \t\n\v\"") == src.npos)
+  // note that an empty argument requires quotes
+  if(src.find_first_of(L" \t\n\v\"") == src.npos && !src.empty())
     return src;
 
   std::wstring result = L"\"";


### PR DESCRIPTION
Unix-like OSs pass an array of strings to processes as the command line
arguments. Empty arguments do not require special treatment.

By contrast, Windows uses a single string to pass all arguments to the
process.  The process parses the string to construct `argv[]`.  To pass an
empty argument, quotes are required.

Note that this is unrelated to any additional parsing a shell might perform.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
