### PR TITLE
concat_dir_file: avoid redundant directory separator

### DIFF
--- a/src/util/file_util.cpp
+++ b/src/util/file_util.cpp
@@ -160,13 +160,28 @@ std::string concat_dir_file(
   const std::string &directory,
   const std::string &file_name)
 {
-  #ifdef _WIN32
-  return (file_name.size() > 1 && file_name[0] != '/' && file_name[1] == ':') ?
-          file_name : directory + "\\" + file_name;
-  #else
-  return (!file_name.empty() && file_name[0]=='/') ?
-          file_name : directory+"/"+file_name;
-  #endif
+#ifdef _WIN32
+  if(
+    file_name.size() > 1 && file_name[0] != '/' && file_name[0] != '\\' &&
+    file_name[1] == ':')
+  {
+    return file_name;
+  }
+  else if(
+    !directory.empty() && (directory.back() == '/' || directory.back() == '\\'))
+  {
+    return directory + file_name;
+  }
+  else
+    return directory + '\\' + file_name;
+#else
+  if(!file_name.empty() && file_name[0] == '/')
+    return file_name;
+  else if(!directory.empty() && directory.back() == '/')
+    return directory + file_name;
+  else
+    return directory + '/' + file_name;
+#endif
 }
 
 bool is_directory(const std::string &path)


### PR DESCRIPTION
When adding `"file.txt"` to `"some/path/"` there is no need to add
another `'/'`.

This is a cosmetical change, for the benefit of user-facing output, since
both Unix-like OSs and Windows tolerate the additional directory separators.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
