### PR TITLE
Make it possible to customise the assertions inserted for coverage instrumentation

### DIFF
--- a/src/goto-instrument/cover.cpp
+++ b/src/goto-instrument/cover.cpp
@@ -30,12 +30,17 @@ Date: May 2016
 /// \param mode: mode of the function to instrument (for instance ID_C or
 ///   ID_java)
 /// \param message_handler: a message handler
-void instrument_cover_goals(
+/// \param make_assertion: A function which takes an expression, with a source
+///   location and makes an assertion based on that expression. The expression
+///   asserted is expected to include the expression passed in, but may include
+///   other additional conditions.
+static void instrument_cover_goals(
   const irep_idt &function_id,
   goto_programt &goto_program,
   const cover_instrumenterst &instrumenters,
   const irep_idt &mode,
-  message_handlert &message_handler)
+  message_handlert &message_handler,
+  const cover_instrumenter_baset::assertion_factoryt &make_assertion)
 {
   const std::unique_ptr<cover_blocks_baset> basic_blocks =
     mode == ID_java ? std::unique_ptr<cover_blocks_baset>(
@@ -45,7 +50,7 @@ void instrument_cover_goals(
 
   basic_blocks->report_block_anomalies(
     function_id, goto_program, message_handler);
-  instrumenters(function_id, goto_program, *basic_blocks);
+  instrumenters(function_id, goto_program, *basic_blocks, make_assertion);
 }
 
 /// Create and add an instrumenter based on the given criterion
@@ -309,7 +314,8 @@ static void instrument_cover_goals(
       function.body,
       cover_config.cover_instrumenters,
       function_symbol.mode,
-      message_handler);
+      message_handler,
+      cover_config.make_assertion);
     changed = true;
   }
 
@@ -317,7 +323,8 @@ static void instrument_cover_goals(
     cover_config.traces_must_terminate &&
     function_symbol.name == goto_functionst::entry_point())
   {
-    cover_instrument_end_of_function(function_symbol.name, function.body);
+    cover_instrument_end_of_function(
+      function_symbol.name, function.body, cover_config.make_assertion);
     changed = true;
   }
 

--- a/src/goto-instrument/cover.h
+++ b/src/goto-instrument/cover.h
@@ -44,6 +44,8 @@ struct cover_configt
   std::unique_ptr<goal_filterst> goal_filters =
     util_make_unique<goal_filterst>();
   cover_instrumenterst cover_instrumenters;
+  cover_instrumenter_baset::assertion_factoryt make_assertion =
+    goto_programt::make_assertion;
 };
 
 void instrument_cover_goals(

--- a/src/goto-instrument/cover_instrument.h
+++ b/src/goto-instrument/cover_instrument.h
@@ -40,7 +40,7 @@ public:
   /// \param function_id: name of \p goto_program
   /// \param goto_program: a goto program
   /// \param basic_blocks: detected basic blocks
-  virtual void operator()(
+  void operator()(
     const irep_idt &function_id,
     goto_programt &goto_program,
     const cover_blocks_baset &basic_blocks) const

--- a/src/goto-instrument/cover_instrument.h
+++ b/src/goto-instrument/cover_instrument.h
@@ -36,18 +36,31 @@ public:
   {
   }
 
+  /// The type of function used to make goto_program assertions.
+  using assertion_factoryt = std::function<
+    goto_programt::instructiont(const exprt &, const source_locationt &)>;
+  static_assert(
+    std::is_same<
+      assertion_factoryt,
+      std::function<decltype(goto_programt::make_assertion)>>::value,
+    "`assertion_factoryt` is expected to have the same type as "
+    "`goto_programt::make_assertion`.");
+
   /// Instruments a goto program
   /// \param function_id: name of \p goto_program
   /// \param goto_program: a goto program
   /// \param basic_blocks: detected basic blocks
+  /// \param make_assertion: A function which makes goto program assertions.
+  ///    This parameter may be used to customise the expressions asserted.
   void operator()(
     const irep_idt &function_id,
     goto_programt &goto_program,
-    const cover_blocks_baset &basic_blocks) const
+    const cover_blocks_baset &basic_blocks,
+    const assertion_factoryt &make_assertion) const
   {
     Forall_goto_program_instructions(i_it, goto_program)
     {
-      instrument(function_id, goto_program, i_it, basic_blocks);
+      instrument(function_id, goto_program, i_it, basic_blocks, make_assertion);
     }
   }
 
@@ -63,7 +76,8 @@ protected:
     const irep_idt &function_id,
     goto_programt &,
     goto_programt::targett &,
-    const cover_blocks_baset &) const = 0;
+    const cover_blocks_baset &,
+    const assertion_factoryt &) const = 0;
 
   void initialize_source_location(
     goto_programt::targett t,
@@ -96,13 +110,16 @@ public:
   /// \param function_id: name of \p goto_program
   /// \param goto_program: a goto program
   /// \param basic_blocks: detected basic blocks of the goto program
+  /// \param make_assertion: A function which makes goto program assertions.
+  ///    This parameter may be used to customise the expressions asserted.
   void operator()(
     const irep_idt &function_id,
     goto_programt &goto_program,
-    const cover_blocks_baset &basic_blocks) const
+    const cover_blocks_baset &basic_blocks,
+    const cover_instrumenter_baset::assertion_factoryt &make_assertion) const
   {
     for(const auto &instrumenter : instrumenters)
-      (*instrumenter)(function_id, goto_program, basic_blocks);
+      (*instrumenter)(function_id, goto_program, basic_blocks, make_assertion);
   }
 
 private:
@@ -125,7 +142,8 @@ protected:
     const irep_idt &function_id,
     goto_programt &,
     goto_programt::targett &,
-    const cover_blocks_baset &) const override;
+    const cover_blocks_baset &,
+    const assertion_factoryt &) const override;
 };
 
 /// Branch coverage instrumenter
@@ -144,7 +162,8 @@ protected:
     const irep_idt &function_id,
     goto_programt &,
     goto_programt::targett &,
-    const cover_blocks_baset &) const override;
+    const cover_blocks_baset &,
+    const assertion_factoryt &) const override;
 };
 
 /// Condition coverage instrumenter
@@ -163,7 +182,8 @@ protected:
     const irep_idt &function_id,
     goto_programt &,
     goto_programt::targett &,
-    const cover_blocks_baset &) const override;
+    const cover_blocks_baset &,
+    const assertion_factoryt &) const override;
 };
 
 /// Decision coverage instrumenter
@@ -182,7 +202,8 @@ protected:
     const irep_idt &function_id,
     goto_programt &,
     goto_programt::targett &,
-    const cover_blocks_baset &) const override;
+    const cover_blocks_baset &,
+    const assertion_factoryt &) const override;
 };
 
 /// MC/DC coverage instrumenter
@@ -201,7 +222,8 @@ protected:
     const irep_idt &function_id,
     goto_programt &,
     goto_programt::targett &,
-    const cover_blocks_baset &) const override;
+    const cover_blocks_baset &,
+    const assertion_factoryt &) const override;
 };
 
 /// Path coverage instrumenter
@@ -220,7 +242,8 @@ protected:
     const irep_idt &function_id,
     goto_programt &,
     goto_programt::targett &,
-    const cover_blocks_baset &) const override;
+    const cover_blocks_baset &,
+    const assertion_factoryt &) const override;
 };
 
 /// Assertion coverage instrumenter
@@ -239,7 +262,8 @@ protected:
     const irep_idt &function_id,
     goto_programt &,
     goto_programt::targett &,
-    const cover_blocks_baset &) const override;
+    const cover_blocks_baset &,
+    const assertion_factoryt &) const override;
 };
 
 /// __CPROVER_cover coverage instrumenter
@@ -258,11 +282,13 @@ protected:
     const irep_idt &function_id,
     goto_programt &,
     goto_programt::targett &,
-    const cover_blocks_baset &) const override;
+    const cover_blocks_baset &,
+    const assertion_factoryt &) const override;
 };
 
 void cover_instrument_end_of_function(
   const irep_idt &function_id,
-  goto_programt &goto_program);
+  goto_programt &goto_program,
+  const cover_instrumenter_baset::assertion_factoryt &);
 
 #endif // CPROVER_GOTO_INSTRUMENT_COVER_INSTRUMENT_H

--- a/src/goto-instrument/cover_instrument_branch.cpp
+++ b/src/goto-instrument/cover_instrument_branch.cpp
@@ -17,7 +17,8 @@ void cover_branch_instrumentert::instrument(
   const irep_idt &function_id,
   goto_programt &goto_program,
   goto_programt::targett &i_it,
-  const cover_blocks_baset &basic_blocks) const
+  const cover_blocks_baset &basic_blocks,
+  const assertion_factoryt &make_assertion) const
 {
   if(is_non_cover_assertion(i_it))
     i_it->turn_into_skip();
@@ -40,7 +41,7 @@ void cover_branch_instrumentert::instrument(
     source_locationt source_location = i_it->source_location;
 
     goto_programt::targett t = goto_program.insert_before(
-      i_it, goto_programt::make_assertion(false_exprt(), source_location));
+      i_it, make_assertion(false_exprt(), source_location));
     initialize_source_location(t, comment, function_id);
   }
 
@@ -55,11 +56,11 @@ void cover_branch_instrumentert::instrument(
     source_locationt source_location = i_it->source_location;
 
     goto_program.insert_before_swap(i_it);
-    *i_it = goto_programt::make_assertion(not_exprt(guard), source_location);
+    *i_it = make_assertion(not_exprt(guard), source_location);
     initialize_source_location(i_it, true_comment, function_id);
 
     goto_program.insert_before_swap(i_it);
-    *i_it = goto_programt::make_assertion(guard, source_location);
+    *i_it = make_assertion(guard, source_location);
     initialize_source_location(i_it, false_comment, function_id);
 
     std::advance(i_it, 2);

--- a/src/goto-instrument/cover_instrument_condition.cpp
+++ b/src/goto-instrument/cover_instrument_condition.cpp
@@ -20,7 +20,8 @@ void cover_condition_instrumentert::instrument(
   const irep_idt &function_id,
   goto_programt &goto_program,
   goto_programt::targett &i_it,
-  const cover_blocks_baset &) const
+  const cover_blocks_baset &,
+  const assertion_factoryt &make_assertion) const
 {
   if(is_non_cover_assertion(i_it))
     i_it->turn_into_skip();
@@ -38,12 +39,12 @@ void cover_condition_instrumentert::instrument(
 
       const std::string comment_t = "condition '" + c_string + "' true";
       goto_program.insert_before_swap(i_it);
-      *i_it = goto_programt::make_assertion(c, source_location);
+      *i_it = make_assertion(c, source_location);
       initialize_source_location(i_it, comment_t, function_id);
 
       const std::string comment_f = "condition '" + c_string + "' false";
       goto_program.insert_before_swap(i_it);
-      *i_it = goto_programt::make_assertion(not_exprt(c), source_location);
+      *i_it = make_assertion(not_exprt(c), source_location);
       initialize_source_location(i_it, comment_f, function_id);
     }
 

--- a/src/goto-instrument/cover_instrument_decision.cpp
+++ b/src/goto-instrument/cover_instrument_decision.cpp
@@ -19,7 +19,8 @@ void cover_decision_instrumentert::instrument(
   const irep_idt &function_id,
   goto_programt &goto_program,
   goto_programt::targett &i_it,
-  const cover_blocks_baset &) const
+  const cover_blocks_baset &,
+  const assertion_factoryt &make_assertion) const
 {
   if(is_non_cover_assertion(i_it))
     i_it->turn_into_skip();
@@ -37,12 +38,12 @@ void cover_decision_instrumentert::instrument(
 
       const std::string comment_t = "decision '" + d_string + "' true";
       goto_program.insert_before_swap(i_it);
-      *i_it = goto_programt::make_assertion(d, source_location);
+      *i_it = make_assertion(d, source_location);
       initialize_source_location(i_it, comment_t, function_id);
 
       const std::string comment_f = "decision '" + d_string + "' false";
       goto_program.insert_before_swap(i_it);
-      *i_it = goto_programt::make_assertion(not_exprt(d), source_location);
+      *i_it = make_assertion(not_exprt(d), source_location);
       initialize_source_location(i_it, comment_f, function_id);
     }
 

--- a/src/goto-instrument/cover_instrument_location.cpp
+++ b/src/goto-instrument/cover_instrument_location.cpp
@@ -18,7 +18,8 @@ void cover_location_instrumentert::instrument(
   const irep_idt &function_id,
   goto_programt &goto_program,
   goto_programt::targett &i_it,
-  const cover_blocks_baset &basic_blocks) const
+  const cover_blocks_baset &basic_blocks,
+  const assertion_factoryt &make_assertion) const
 {
   if(is_non_cover_assertion(i_it))
     i_it->turn_into_skip();
@@ -40,7 +41,7 @@ void cover_location_instrumentert::instrument(
       const std::string comment =
         "block " + b + " (lines " + source_lines + ")";
       goto_program.insert_before_swap(i_it);
-      *i_it = goto_programt::make_assertion(false_exprt(), source_location);
+      *i_it = make_assertion(false_exprt(), source_location);
       initialize_source_location(i_it, comment, function_id);
       i_it++;
     }

--- a/src/goto-instrument/cover_instrument_mcdc.cpp
+++ b/src/goto-instrument/cover_instrument_mcdc.cpp
@@ -623,7 +623,8 @@ void cover_mcdc_instrumentert::instrument(
   const irep_idt &function_id,
   goto_programt &goto_program,
   goto_programt::targett &i_it,
-  const cover_blocks_baset &) const
+  const cover_blocks_baset &,
+  const assertion_factoryt &make_assertion) const
 {
   if(is_non_cover_assertion(i_it))
     i_it->turn_into_skip();
@@ -661,7 +662,7 @@ void cover_mcdc_instrumentert::instrument(
 
       std::string comment_t = description + " '" + p_string + "' true";
       goto_program.insert_before_swap(i_it);
-      *i_it = goto_programt::make_assertion(not_exprt(p), source_location);
+      *i_it = make_assertion(not_exprt(p), source_location);
       i_it->source_location.set_comment(comment_t);
       i_it->source_location.set(ID_coverage_criterion, coverage_criterion);
       i_it->source_location.set_property_class(property_class);
@@ -669,7 +670,7 @@ void cover_mcdc_instrumentert::instrument(
 
       std::string comment_f = description + " '" + p_string + "' false";
       goto_program.insert_before_swap(i_it);
-      *i_it = goto_programt::make_assertion(p, source_location);
+      *i_it = make_assertion(p, source_location);
       i_it->source_location.set_comment(comment_f);
       i_it->source_location.set(ID_coverage_criterion, coverage_criterion);
       i_it->source_location.set_property_class(property_class);
@@ -694,7 +695,7 @@ void cover_mcdc_instrumentert::instrument(
         "MC/DC independence condition '" + p_string + "'";
 
       goto_program.insert_before_swap(i_it);
-      *i_it = goto_programt::make_assertion(not_exprt(p), source_location);
+      *i_it = make_assertion(not_exprt(p), source_location);
       i_it->source_location.set_comment(description);
       i_it->source_location.set(ID_coverage_criterion, coverage_criterion);
       i_it->source_location.set_property_class(property_class);

--- a/unit/goto-instrument/cover_instrument.cpp
+++ b/unit/goto-instrument/cover_instrument.cpp
@@ -19,10 +19,35 @@ TEST_CASE("cover_intrument_end_of_function", "[core]")
     goto_programt::make_function_call(code_function_callt({}, {})));
   goto_program.add(goto_programt::make_return());
   // Act
-  cover_instrument_end_of_function("foo", goto_program);
+  cover_instrument_end_of_function(
+    "foo", goto_program, goto_programt::make_assertion);
   // Assert
   REQUIRE(goto_program.instructions.size() == 4);
   const auto newly_inserted = std::next(goto_program.instructions.begin(), 2);
   REQUIRE(newly_inserted->is_assert());
+  REQUIRE(newly_inserted->get_condition() == false_exprt{});
+  REQUIRE(newly_inserted->source_location.get_function() == "foo");
+}
+
+TEST_CASE("cover_instrument_end_of_function with custom expression", "[core]")
+{
+  // Arrange
+  goto_programt goto_program{};
+  goto_program.add(
+    goto_programt::make_function_call(code_function_callt({}, {})));
+  goto_program.add(
+    goto_programt::make_function_call(code_function_callt({}, {})));
+  goto_program.add(goto_programt::make_return());
+  const cover_instrumenter_baset::assertion_factoryt assertion_factory =
+    [](const exprt &, const source_locationt &location) {
+      return goto_programt::make_assertion(true_exprt{}, location);
+    };
+  // Act
+  cover_instrument_end_of_function("foo", goto_program, assertion_factory);
+  // Assert
+  REQUIRE(goto_program.instructions.size() == 4);
+  const auto newly_inserted = std::next(goto_program.instructions.begin(), 2);
+  REQUIRE(newly_inserted->is_assert());
+  REQUIRE(newly_inserted->get_condition() == true_exprt{});
   REQUIRE(newly_inserted->source_location.get_function() == "foo");
 }


### PR DESCRIPTION
This PR makes it possible to customise the assertions inserted for coverage instrumentation. We have a requirement in a downstream repository to be able to consider coverage goals only to be met when additional criteria are satisfied. The additional configure-ability this PR adds to CBMC allows us to achieve this.

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] ~~The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/~~ No user visible changes.
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] ~~My commit message includes data points confirming performance improvements (if claimed).~~ Non claimed.
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
