### PR TITLE
doc/properties: #pragma disable requires version >=5.12

### DIFF
--- a/doc/cprover-manual/properties.md
+++ b/doc/cprover-manual/properties.md
@@ -132,9 +132,10 @@ The goto-instrument program supports these checks:
 As all of these checks apply across the entire input program, we may wish to
 disable them for selected statements in the program. For example, unsigned
 overflows can be expected and acceptable in certain instructions even when
-elsewhere we do not expect them. To selectively disable automatically generated
-properties use `#pragma CPROVER check disable "<name_of_check>"`, which remains
-in effect until a `#pragma CPROVER check pop` (to re-enable all properties
+elsewhere we do not expect them. As of version 5.12, CBMC supports selectively
+disabling automatically generated properties.  To disable property generation,
+use `#pragma CPROVER check disable "<name_of_check>"`, which remains in effect
+until a `#pragma CPROVER check pop` (to re-enable all properties
 disabled before or since the last `#pragma CPROVER check push`) is provided.
 For example, for unsigned overflow checks, use
 ```


### PR DESCRIPTION
Hi,
Just a documentation change: I noticed on the website that the documentation (http://www.cprover.org/cprover-manual/properties/) describes the `#pragma CPROVER check disable` feature, but the one you can download doesn't support that. (It took me a while to realise that's why it wasn't working.) So I just made sure the documentation explicitly stated it's only in the unreleased 5.12.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- [n/a] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [X] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [n/a] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [n/a] My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- [X] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
