### PR TITLE
C++ front-end: support GCC type attributes

### DIFF
--- a/regression/cpp/gcc_attributes2/main.cpp
+++ b/regression/cpp/gcc_attributes2/main.cpp
@@ -1,0 +1,9 @@
+#ifdef __GNUC__
+typedef int my_int16_t __attribute__((__mode__(__HI__)));
+static_assert(sizeof(my_int16_t) == 2, "16 bit");
+#endif
+
+int main()
+{
+  return 0;
+}

--- a/regression/cpp/gcc_attributes2/test.desc
+++ b/regression/cpp/gcc_attributes2/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.cpp
+-std=c++11
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+^CONVERSION ERROR$

--- a/src/cpp/cpp_typecheck_type.cpp
+++ b/src/cpp/cpp_typecheck_type.cpp
@@ -272,6 +272,10 @@ void cpp_typecheckt::typecheck_type(typet &type)
   {
     c_typecheck_baset::typecheck_type(type);
   }
+  else if(type.id() == ID_gcc_attribute_mode)
+  {
+    c_typecheck_baset::typecheck_type(type);
+  }
   else
   {
     error().source_location=type.source_location();

--- a/src/cpp/parse.cpp
+++ b/src/cpp/parse.cpp
@@ -2262,7 +2262,7 @@ bool Parser::rAttribute(typet &t)
 
       typet attr(ID_gcc_attribute_mode);
       set_location(attr, tk);
-      attr.set(ID_size, name.get(ID_identifier));
+      attr.set(ID_size, to_cpp_name(name).get_base_name());
       merge_types(attr, t);
       break;
     }
@@ -2880,7 +2880,7 @@ bool Parser::rDeclaratorWithInit(
     bit_field_type.subtype().make_nil();
     set_location(bit_field_type, tk);
 
-    // merge_types(bit_field_type, declarator.type());
+    merge_types(bit_field_type, dw.type());
 
     return true;
   }
@@ -3226,6 +3226,15 @@ bool Parser::rDeclarator(
   }
 
   optCvQualify(d_outer);
+  if(d_outer.is_not_nil() && !d_outer.has_subtypes())
+  {
+    merged_typet merged_type;
+    merged_type.move_to_subtypes(d_outer);
+    typet nil;
+    nil.make_nil();
+    merged_type.move_to_sub(nil);
+    d_outer.swap(merged_type);
+  }
 
 #ifdef DEBUG
   std::cout << std::string(__indent, ' ') << "Parser::rDeclarator2 13\n";


### PR DESCRIPTION
Adding a test that currently fails with:

goto-cc: ../src/cpp/cpp_declarator.cpp:54: typet cpp_declaratort::merge_type(const typet&) const: Assertion `!t.id().empty()' failed.


- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

