### PR TITLE
Regression tests demonstrating spurious pointer overflow check failure

### DIFF
--- a/regression/cbmc/pointer-overflow2/main.c
+++ b/regression/cbmc/pointer-overflow2/main.c
@@ -1,0 +1,10 @@
+#include <stdlib.h>
+
+void main()
+{
+  char *p = (char *)10;
+  p -= 1;
+  p += 1;
+  p += -1; // spurious pointer overflow report
+  p -= -1; // spurious pointer overflow report
+}

--- a/regression/cbmc/pointer-overflow2/test.desc
+++ b/regression/cbmc/pointer-overflow2/test.desc
@@ -1,0 +1,11 @@
+KNOWNBUG
+main.c
+--pointer-overflow-check
+^EXIT=0$
+^SIGNAL=0$
+\[main.overflow.1\] line \d+ pointer arithmetic overflow on - in p - \(signed long int\)1: SUCCESS
+\[main.overflow.2\] line \d+ pointer arithmetic overflow on \+ in p \+ \(signed long int\)1: SUCCESS
+\[main.overflow.3\] line \d+ pointer arithmetic overflow on \+ in p \+ \(signed long int\)-1: SUCCESS
+\[main.overflow.4\] line \d+ pointer arithmetic overflow on - in p - \(signed long int\)-1: SUCCESS
+--
+^warning: ignoring


### PR DESCRIPTION
See #5284

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
