### PR TITLE
Fix CPP models when using CMake Build

### DIFF
--- a/regression/cbmc-cpp/cpp-new/main.cpp
+++ b/regression/cbmc-cpp/cpp-new/main.cpp
@@ -1,0 +1,9 @@
+#include <cassert>
+
+int main()
+{
+  int *some_data = new int(10);
+  assert(some_data);
+  assert(*some_data == 10);
+  return 0;
+}

--- a/regression/cbmc-cpp/cpp-new/test.desc
+++ b/regression/cbmc-cpp/cpp-new/test.desc
@@ -1,0 +1,10 @@
+CORE
+main.cpp
+--pointer-check
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring
+--
+Ensure that the new operator is implemented.

--- a/regression/cbmc-library/string-abstraction/test-c-with-string-abstraction.desc
+++ b/regression/cbmc-library/string-abstraction/test-c-with-string-abstraction.desc
@@ -1,0 +1,10 @@
+CORE
+test.c
+--string-abstraction --show-goto-functions
+strlen#return_value = \(.*\)s#strarg->length - POINTER_OFFSET\(s\);
+^EXIT=0$
+^SIGNAL=0$
+--
+--
+Ensure that the --string-abstraction flag enables the string abstraction
+version of string functions

--- a/regression/cbmc-library/string-abstraction/test-c-without-string-abstraction.desc
+++ b/regression/cbmc-library/string-abstraction/test-c-without-string-abstraction.desc
@@ -1,0 +1,10 @@
+CORE
+test.c
+--show-goto-functions
+IF !\(\(signed int\)s\[\(.*\)len\] != 0\) THEN GOTO 2
+^EXIT=0$
+^SIGNAL=0$
+--
+--
+Ensure that if the string abstraction flag is not provided, the regular model for
+string functions is used (in this case searching for the terminator).

--- a/regression/cbmc-library/string-abstraction/test.c
+++ b/regression/cbmc-library/string-abstraction/test.c
@@ -1,0 +1,9 @@
+#include <assert.h>
+#include <stdlib.h>
+
+int main()
+{
+  char *x = malloc(sizeof(char) * 10);
+  x[8] = '\0';
+  assert(strlen(x) == 8);
+}

--- a/src/ansi-c/cprover_library.cpp
+++ b/src/ansi-c/cprover_library.cpp
@@ -45,7 +45,9 @@ std::string get_cprover_library_text(
   const struct cprover_library_entryt cprover_library[],
   const std::string &prologue)
 {
-  std::ostringstream library_text(prologue);
+  // the default mode is ios_base::out which means subsequent write to the
+  // stream will overwrite the original content
+  std::ostringstream library_text(prologue, std::ios_base::ate);
 
   std::size_t count=0;
 

--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -1,14 +1,8 @@
 file(GLOB cpp_library_sources "library/*.c")
 
-add_custom_command(OUTPUT converter_input.txt
-    COMMAND cat ${cpp_library_sources} > converter_input.txt
-    DEPENDS ${cpp_library_sources}
-)
-
 add_custom_command(OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/cprover_library.inc"
-    COMMAND ../ansi-c/converter < "converter_input.txt" > "${CMAKE_CURRENT_BINARY_DIR}/cprover_library.inc"
-    DEPENDS "converter_input.txt" ../ansi-c/converter
-)
+        COMMAND cat ${cpp_library_sources} | $<TARGET_FILE:converter> > "${CMAKE_CURRENT_BINARY_DIR}/cprover_library.inc"
+        DEPENDS converter ${cpp_library_sources})
 
 ################################################################################
 
@@ -32,6 +26,12 @@ endif()
 
 file(GLOB_RECURSE sources "*.cpp" "*.h")
 add_library(cpp ${sources})
+
+set_source_files_properties(
+        ${sources}
+        PROPERTIES
+        OBJECT_DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/cprover_library.inc"
+)
 
 generic_includes(cpp)
 


### PR DESCRIPTION
In trying to track down why the defines don't work in the library, I discovered that the cpp models (that includes definitions for new) do not work on CMake builds. I'm working on a fix, but just to confirm my suspicion I've added a test that I believe will pass on non-cmake builds but will fail on cmake builds. 



- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [na] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [na] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
