### PR TITLE
Install cmake on the cmake job

### DIFF
--- a/buildspec-linux-cmake-gcc.yml
+++ b/buildspec-linux-cmake-gcc.yml
@@ -12,7 +12,7 @@ phases:
     commands:
       - sed -i 's#/archive.ubuntu.com#/us-east-1.ec2.archive.ubuntu.com#g' /etc/apt/sources.list
       - apt-get update -y
-      - apt-get install -y flex bison make git libwww-perl patch ccache libc6-dev-i386 jq
+      - apt-get install -y flex bison make git libwww-perl patch ccache libc6-dev-i386 jq cmake
   build:
     commands:
       - echo Build started on `date`


### PR DESCRIPTION
The cmake code build job has never succeeded. Originally to do with permissions, current failure appears to be because cmake isn't installed. 

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [na] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [na] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [na] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
