### PR TITLE
Fix function pointer restriction bug where jump targets were not preserved

### DIFF
--- a/regression/goto-instrument/restrict-function-pointer-goto-target/test.c
+++ b/regression/goto-instrument/restrict-function-pointer-goto-target/test.c
@@ -1,0 +1,16 @@
+#include <assert.h>
+
+typedef void (*fp_t)();
+
+void f()
+{
+}
+
+int main(void)
+{
+  fp_t fp = f;
+  goto L;
+
+L:
+  fp();
+}

--- a/regression/goto-instrument/restrict-function-pointer-goto-target/test.desc
+++ b/regression/goto-instrument/restrict-function-pointer-goto-target/test.desc
@@ -1,0 +1,13 @@
+KNOWNBUG
+test.c
+--restrict-function-pointer main.function_pointer_call.1/f
+^EXIT=0$
+^SIGNAL=0$
+\[main.assertion.1\] line \d+ dereferenced function pointer at main.function_pointer_call.1 must be f: SUCCESS
+--
+--
+This test checks that a function pointer call that is the target of a goto (in
+the goto program) is correctly handled. Currently there is a bug, as the
+function pointer labelling step which is part of the restrict function pointer
+feature inserts a new instructions before the function pointer calls, but does
+not adjust the goto targets.

--- a/regression/goto-instrument/restrict-function-pointer-goto-target/test.desc
+++ b/regression/goto-instrument/restrict-function-pointer-goto-target/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 test.c
 --restrict-function-pointer main.function_pointer_call.1/f
 ^EXIT=0$
@@ -7,7 +7,7 @@ test.c
 --
 --
 This test checks that a function pointer call that is the target of a goto (in
-the goto program) is correctly handled. Currently there is a bug, as the
+the goto program) is correctly handled. Previously there was a bug, as the
 function pointer labelling step which is part of the restrict function pointer
-feature inserts a new instructions before the function pointer calls, but does
+feature inserted a new instruction before the function pointer call, but did
 not adjust the goto targets.


### PR DESCRIPTION
<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
