### PR TITLE
Add support for void* pointers in goto-harness

### DIFF
--- a/regression/goto-harness/do_not_nondet_globals_by_default/main.c
+++ b/regression/goto-harness/do_not_nondet_globals_by_default/main.c
@@ -1,3 +1,5 @@
+#include <assert.h>
+
 int a_global;
 
 void entry_function(void)

--- a/regression/goto-harness/havoc-global-int-01/main.c
+++ b/regression/goto-harness/havoc-global-int-01/main.c
@@ -1,3 +1,5 @@
+#include <assert.h>
+
 int x = 1;
 
 int main()

--- a/regression/goto-harness/void-star-pointer/main.c
+++ b/regression/goto-harness/void-star-pointer/main.c
@@ -1,0 +1,6 @@
+#include <assert.h>
+
+void test_function(void *input)
+{
+  assert(input == 0);
+}

--- a/regression/goto-harness/void-star-pointer/main.c
+++ b/regression/goto-harness/void-star-pointer/main.c
@@ -12,3 +12,10 @@ void test_void_array(void *input_array[10])
   assert(input_array[0] == 0);
   assert(false);
 }
+
+void test_ptr_array(void **input_array)
+{
+  __CPROVER_assume(input_array != 0);
+  assert(input_array[0] == 0);
+  assert(false);
+}

--- a/regression/goto-harness/void-star-pointer/main.c
+++ b/regression/goto-harness/void-star-pointer/main.c
@@ -1,6 +1,14 @@
 #include <assert.h>
+#include <stdbool.h>
 
 void test_function(void *input)
 {
   assert(input == 0);
+}
+
+void test_void_array(void *input_array[10])
+{
+  __CPROVER_assume(input_array != 0);
+  assert(input_array[0] == 0);
+  assert(false);
 }

--- a/regression/goto-harness/void-star-pointer/test-array-as-array.desc
+++ b/regression/goto-harness/void-star-pointer/test-array-as-array.desc
@@ -2,7 +2,7 @@ CORE
 main.c
 --harness-type call-function --function test_ptr_array --treat-pointer-as-array input_array
 \[test_ptr_array\.assertion\.1\] line \d+ assertion input_array\[0\] == 0: SUCCESS
-\[test_ptr_array\.assertion\.2\] line \d+ assertion false: FAILURE
+\[test_ptr_array\.assertion\.2\] line \d+ assertion .*: FAILURE
 ^VERIFICATION FAILED$
 ^EXIT=10$
 ^SIGNAL=0$

--- a/regression/goto-harness/void-star-pointer/test-array-as-array.desc
+++ b/regression/goto-harness/void-star-pointer/test-array-as-array.desc
@@ -1,0 +1,13 @@
+CORE
+main.c
+--harness-type call-function --function test_ptr_array --treat-pointer-as-array input_array
+\[test_ptr_array\.assertion\.1\] line \d+ assertion input_array\[0\] == 0: SUCCESS
+\[test_ptr_array\.assertion\.2\] line \d+ assertion false: FAILURE
+^VERIFICATION FAILED$
+^EXIT=10$
+^SIGNAL=0$
+--
+--
+Ensure the harness is able to initalize an array of void* pointers where
+the array is non-null, but the elements are null, if the void** is treated as an
+array.

--- a/regression/goto-harness/void-star-pointer/test-array.desc
+++ b/regression/goto-harness/void-star-pointer/test-array.desc
@@ -2,7 +2,7 @@ CORE
 main.c
 --harness-type call-function --function test_void_array
 \[test_void_array\.assertion\.1\] line \d+ assertion input_array\[0\] == 0: SUCCESS
-\[test_void_array\.assertion\.2\] line \d+ assertion false: FAILURE
+\[test_void_array\.assertion\.2\] line \d+ assertion .*: FAILURE
 ^VERIFICATION FAILED$
 ^EXIT=10$
 ^SIGNAL=0$

--- a/regression/goto-harness/void-star-pointer/test-array.desc
+++ b/regression/goto-harness/void-star-pointer/test-array.desc
@@ -1,0 +1,12 @@
+CORE
+main.c
+--harness-type call-function --function test_void_array
+\[test_void_array\.assertion\.1\] line \d+ assertion input_array\[0\] == 0: SUCCESS
+\[test_void_array\.assertion\.2\] line \d+ assertion false: FAILURE
+^VERIFICATION FAILED$
+^EXIT=10$
+^SIGNAL=0$
+--
+--
+Ensure the harness is able to initalize an array of void* pointers where
+the array is non-null, but the elements are null.

--- a/regression/goto-harness/void-star-pointer/test-as-array.desc
+++ b/regression/goto-harness/void-star-pointer/test-as-array.desc
@@ -1,0 +1,11 @@
+CORE
+main.c
+--harness-type call-function --function test_function --treat-pointer-as-array input
+\[test_function\.assertion\.1\] line \d+ assertion input == 0: SUCCESS
+^VERIFICATION SUCCESSFUL$
+^EXIT=0$
+^SIGNAL=0$
+--
+--
+Ensure the harness is able to initalize a void* ptr to a null value, even when
+the parameter is specified to be treated as an array.

--- a/regression/goto-harness/void-star-pointer/test-as-c-string.desc
+++ b/regression/goto-harness/void-star-pointer/test-as-c-string.desc
@@ -1,0 +1,11 @@
+CORE
+main.c
+--harness-type call-function --function test_function --treat-pointer-as-cstring input
+\[test_function\.assertion\.1\] line \d+ assertion input == 0: SUCCESS
+^VERIFICATION SUCCESSFUL$
+^EXIT=0$
+^SIGNAL=0$
+--
+--
+Ensure the harness is able to initalize a void* ptr to a null value, even when
+the parameter is specified to be treated as a string.

--- a/regression/goto-harness/void-star-pointer/test.desc
+++ b/regression/goto-harness/void-star-pointer/test.desc
@@ -1,0 +1,10 @@
+CORE
+main.c
+--harness-type call-function --function test_function
+\[test_function\.assertion\.1\] line \d+ assertion input == 0: SUCCESS
+^VERIFICATION SUCCESSFUL$
+^EXIT=0$
+^SIGNAL=0$
+--
+--
+Ensure the harness is able to initalize a void* ptr to a null value.

--- a/src/goto-harness/recursive_initialization.cpp
+++ b/src/goto-harness/recursive_initialization.cpp
@@ -793,6 +793,15 @@ code_blockt recursive_initializationt::build_dynamic_array_constructor(
   PRECONDITION(pointer_type.id() == ID_pointer);
   const typet &element_type = pointer_type.subtype();
 
+  null_pointer_exprt nullptr_expr{::pointer_type(element_type)};
+  const code_assignt assign_null{dereference_exprt{result}, nullptr_expr};
+
+  // always initalize void* pointers as NULL
+  if(element_type.id() == ID_empty)
+  {
+    return code_blockt{{assign_null, code_returnt{}}};
+  }
+
   // builds:
   // void type_constructor_ptr_T(int depth, T** result, int* size)
   // {

--- a/src/goto-harness/recursive_initialization.cpp
+++ b/src/goto-harness/recursive_initialization.cpp
@@ -639,7 +639,8 @@ code_blockt recursive_initializationt::build_pointer_constructor(
   // {
   //   if(has_seen && depth >= max_depth)
   //     *result=NULL;
-  //   else if(depth < min_null_tree_depth || nondet()) {
+  //     return
+  //   if(nondet()) {
   //     size_t has_seen_prev;
   //     has_seen_prev = T_has_seen;
   //     T_has_seen = 1;

--- a/src/goto-harness/recursive_initialization.cpp
+++ b/src/goto-harness/recursive_initialization.cpp
@@ -623,6 +623,17 @@ code_blockt recursive_initializationt::build_pointer_constructor(
 
   code_blockt body{};
 
+  // always initalize void* pointers as NULL
+  if(type.subtype().id() == ID_empty)
+  {
+    null_pointer_exprt nullptr_expr{pointer_type(type.subtype())};
+    code_blockt null_and_return{};
+    code_assignt assign_null{dereference_exprt{result}, nullptr_expr};
+    null_and_return.add(assign_null);
+    null_and_return.add(code_returnt{});
+    return null_and_return;
+  }
+
   // build:
   // void type_constructor_ptr_T(int depth, T** result)
   // {

--- a/src/goto-harness/recursive_initialization.cpp
+++ b/src/goto-harness/recursive_initialization.cpp
@@ -230,6 +230,15 @@ void recursive_initializationt::initialize(
                                {depth, address_of_exprt{lhs}}});
 }
 
+code_blockt build_null_pointer(const symbol_exprt &result_symbol)
+{
+  const typet &type_to_construct = result_symbol.type().subtype();
+  const null_pointer_exprt nullptr_expr{to_pointer_type(type_to_construct)};
+  const code_assignt assign_null{dereference_exprt{result_symbol},
+                                 nullptr_expr};
+  return code_blockt{{assign_null, code_returnt{}}};
+}
+
 code_blockt recursive_initializationt::build_constructor_body(
   const exprt &depth_symbol,
   const symbol_exprt &result_symbol,
@@ -248,6 +257,11 @@ code_blockt recursive_initializationt::build_constructor_body(
     if(type.subtype().id() == ID_code)
     {
       return build_function_pointer_constructor(result_symbol, is_nullable);
+    }
+    if(type.subtype().id() == ID_empty)
+    {
+      // always initalize void* pointers as NULL
+      return build_null_pointer(result_symbol);
     }
     if(lhs_name.has_value())
     {
@@ -620,15 +634,7 @@ code_blockt recursive_initializationt::build_pointer_constructor(
   PRECONDITION(result.type().id() == ID_pointer);
   const typet &type = result.type().subtype();
   PRECONDITION(type.id() == ID_pointer);
-
-  null_pointer_exprt nullptr_expr{pointer_type(type.subtype())};
-  const code_assignt assign_null{dereference_exprt{result}, nullptr_expr};
-
-  // always initalize void* pointers as NULL
-  if(type.subtype().id() == ID_empty)
-  {
-    return code_blockt{{assign_null, code_returnt{}}};
-  }
+  PRECONDITION(type.subtype().id() != ID_empty);
 
   code_blockt body{};
   // build:
@@ -663,6 +669,8 @@ code_blockt recursive_initializationt::build_pointer_constructor(
     should_not_recurse.push_back(has_seen_expr);
   }
 
+  null_pointer_exprt nullptr_expr{pointer_type(type.subtype())};
+  const code_assignt assign_null{dereference_exprt{result}, nullptr_expr};
   code_blockt null_and_return{{assign_null, code_returnt{}}};
   body.add(code_ifthenelset{conjunction(should_not_recurse), null_and_return});
 
@@ -792,15 +800,7 @@ code_blockt recursive_initializationt::build_dynamic_array_constructor(
   const typet &pointer_type = result.type().subtype();
   PRECONDITION(pointer_type.id() == ID_pointer);
   const typet &element_type = pointer_type.subtype();
-
-  null_pointer_exprt nullptr_expr{::pointer_type(element_type)};
-  const code_assignt assign_null{dereference_exprt{result}, nullptr_expr};
-
-  // always initalize void* pointers as NULL
-  if(element_type.id() == ID_empty)
-  {
-    return code_blockt{{assign_null, code_returnt{}}};
-  }
+  PRECONDITION(element_type.id() != ID_empty);
 
   // builds:
   // void type_constructor_ptr_T(int depth, T** result, int* size)

--- a/src/goto-harness/recursive_initialization.cpp
+++ b/src/goto-harness/recursive_initialization.cpp
@@ -621,19 +621,16 @@ code_blockt recursive_initializationt::build_pointer_constructor(
   const typet &type = result.type().subtype();
   PRECONDITION(type.id() == ID_pointer);
 
-  code_blockt body{};
+  null_pointer_exprt nullptr_expr{pointer_type(type.subtype())};
+  const code_assignt assign_null{dereference_exprt{result}, nullptr_expr};
 
   // always initalize void* pointers as NULL
   if(type.subtype().id() == ID_empty)
   {
-    null_pointer_exprt nullptr_expr{pointer_type(type.subtype())};
-    code_blockt null_and_return{};
-    code_assignt assign_null{dereference_exprt{result}, nullptr_expr};
-    null_and_return.add(assign_null);
-    null_and_return.add(code_returnt{});
-    return null_and_return;
+    return code_blockt{{assign_null, code_returnt{}}};
   }
 
+  code_blockt body{};
   // build:
   // void type_constructor_ptr_T(int depth, T** result)
   // {
@@ -666,11 +663,7 @@ code_blockt recursive_initializationt::build_pointer_constructor(
     should_not_recurse.push_back(has_seen_expr);
   }
 
-  null_pointer_exprt nullptr_expr{pointer_type(type.subtype())};
-  code_blockt null_and_return{};
-  code_assignt assign_null{dereference_exprt{result}, nullptr_expr};
-  null_and_return.add(assign_null);
-  null_and_return.add(code_returnt{});
+  code_blockt null_and_return{{assign_null, code_returnt{}}};
   body.add(code_ifthenelset{conjunction(should_not_recurse), null_and_return});
 
   exprt::operandst should_recurse_ops{


### PR DESCRIPTION
- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [x] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [na] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

