### PR TITLE
Add details about opening the Cygwin shell

### DIFF
--- a/COMPILING.md
+++ b/COMPILING.md
@@ -170,6 +170,16 @@ Follow these instructions:
       ```
       bash.exe -login
       ```
+      Please note that this might open a different shell instead, especially if
+      you have installed other Linux subsystems previously. To verify that you
+      are in the correct shell, make sure that the Windows file system can be
+      accessed via the folder`/cygdrive`. If the command above does not open
+      the Cygwin shell, you can also access it by using its absolute path,
+      `C:\cygwin64\bin\bash.exe` by default. In the Developer Command Prompt, 
+      simply type
+      ```
+      C:\cygwin64\bin\bash.exe -login
+      ```
    2. To compile with MinGW, use Cygwin setup to install a mingw g++ compiler
       package, i.e. one of `mingw{32,64}-{x86_64,i686}-gcc-g++`. You may also
       have to adjust the section in `src/common` that defines `CC` and `CXX`


### PR DESCRIPTION
When compiling on Windows with Cygwin and if the user installed a Linux subsystem, there is a chance that its shell is started instead of the regular Cygwin shell when typing `bash.exe -login` in the Visual Studio Command Prompt. This PR addresses this issue and provides a small workaround.

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [x] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [x] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.