### PR TITLE
Array equal type mismatch

### DIFF
--- a/regression/cbmc/Array_operations1/main.c
+++ b/regression/cbmc/Array_operations1/main.c
@@ -12,6 +12,23 @@ void test_equal()
   __CPROVER_assert(array1[index] == array2[index], "arrays are equal");
 }
 
+void test_unequal()
+{
+  int a1[10];
+  int a2[16];
+
+  __CPROVER_assert(
+    !__CPROVER_array_equal(a1, a2), "different sizes arrays are unequal");
+
+  float a3[10];
+  void *lost_type1 = a1;
+  void *lost_type3 = a3;
+
+  __CPROVER_assert(
+    !__CPROVER_array_equal(lost_type1, lost_type3),
+    "different typed arrays are unequal");
+}
+
 void test_copy()
 {
   char array1[100], array2[100], array3[90];
@@ -54,4 +71,5 @@ int main()
   test_copy();
   test_replace();
   test_set();
+  test_unequal();
 }

--- a/regression/cbmc/Array_operations1/main.c
+++ b/regression/cbmc/Array_operations1/main.c
@@ -19,6 +19,7 @@ void test_unequal()
 
   __CPROVER_assert(
     !__CPROVER_array_equal(a1, a2), "different sizes arrays are unequal");
+  __CPROVER_assert(__CPROVER_array_equal(a1, a2), "expected to fail");
 
   float a3[10];
   void *lost_type1 = a1;
@@ -27,6 +28,15 @@ void test_unequal()
   __CPROVER_assert(
     !__CPROVER_array_equal(lost_type1, lost_type3),
     "different typed arrays are unequal");
+  __CPROVER_assert(
+    __CPROVER_array_equal(lost_type1, lost_type3), "expected to fail");
+
+  int a4[10];
+  int a5[10];
+
+  // Here the arrays both can be equal, and be not equal, so both asserts should fail
+  __CPROVER_assert(!__CPROVER_array_equal(a4, a5), "expected to fail");
+  __CPROVER_assert(__CPROVER_array_equal(a4, a5), "expected to fail");
 }
 
 void test_copy()

--- a/regression/cbmc/Array_operations1/test.desc
+++ b/regression/cbmc/Array_operations1/test.desc
@@ -4,7 +4,9 @@ main.c
 ^EXIT=10$
 ^SIGNAL=0$
 ^\[test_copy\.assertion\.4\] .* expected to fail: FAILURE$
-^\*\* 1 of 8 failed
+^\[test_unequal\.assertion\.1\] .* different sizes arrays are unequal: SUCCESS
+^\[test_unequal\.assertion\.2\] .* different typed arrays are unequal: SUCCESS
+^\*\* 1 of 10 failed
 ^VERIFICATION FAILED$
 --
 ^warning: ignoring

--- a/regression/cbmc/Array_operations1/test.desc
+++ b/regression/cbmc/Array_operations1/test.desc
@@ -5,8 +5,12 @@ main.c
 ^SIGNAL=0$
 ^\[test_copy\.assertion\.4\] .* expected to fail: FAILURE$
 ^\[test_unequal\.assertion\.1\] .* different sizes arrays are unequal: SUCCESS
-^\[test_unequal\.assertion\.2\] .* different typed arrays are unequal: SUCCESS
-^\*\* 1 of 10 failed
+^\[test_unequal\.assertion\.2\] .* expected to fail: FAILURE
+^\[test_unequal\.assertion\.3\] .* different typed arrays are unequal: SUCCESS
+^\[test_unequal\.assertion\.4\] .* expected to fail: FAILURE
+^\[test_unequal\.assertion\.5\] .* expected to fail: FAILURE
+^\[test_unequal\.assertion\.6\] .* expected to fail: FAILURE
+^\*\* 5 of 14 failed
 ^VERIFICATION FAILED$
 --
 ^warning: ignoring

--- a/regression/cbmc/Array_operations1/test.desc
+++ b/regression/cbmc/Array_operations1/test.desc
@@ -8,3 +8,5 @@ main.c
 ^VERIFICATION FAILED$
 --
 ^warning: ignoring
+--
+Verify the properties of various cprover array primitves

--- a/src/goto-symex/symex_other.cpp
+++ b/src/goto-symex/symex_other.cpp
@@ -240,7 +240,7 @@ void goto_symext::symex_other(
 
     // check for size (or type) mismatch
     if(array1.type() != array2.type())
-      assignment.lhs() = false_exprt();
+      assignment.rhs() = false_exprt();
 
     symex_assign(state, assignment);
   }


### PR DESCRIPTION
A typo in the symex evaluation of __CPROVER_array_equal causes CBMC to be unable to assert on whether different sized (or typed) arrays are equal. This fixes it, and adds tests that would have failed.

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [x] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [na] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

