### PR TITLE
Fix max malloc size

### DIFF
--- a/src/ansi-c/ansi_c_internal_additions.cpp
+++ b/src/ansi-c/ansi_c_internal_additions.cpp
@@ -122,7 +122,6 @@ static std::string architecture_string(T value, const char *s)
          std::string(s) + "=" + std::to_string(value) + ";\n";
 }
 
-using max_alloc_sizet = uint64_t;
 /// The maximum allocation size is determined by the number of bits that
 /// are left in the pointer of width \p pointer_width.
 ///
@@ -137,7 +136,7 @@ using max_alloc_sizet = uint64_t;
 /// \param pointer_width: The width of the pointer
 /// \param object_bits : The number of bits used to represent the ID
 /// \return The size in bytes of the maximum allocation supported.
-static max_alloc_sizet
+static mp_integer
 max_malloc_size(std::size_t pointer_width, std::size_t object_bits)
 {
   PRECONDITION(pointer_width >= 1);
@@ -148,9 +147,7 @@ max_malloc_size(std::size_t pointer_width, std::size_t object_bits)
   // but also down to -allocation_size, therefore the size is allowable
   // is number of bits, less the signed bit.
   const auto bits_for_positive_offset = offset_bits - 1;
-  PRECONDITION(
-    bits_for_positive_offset < std::numeric_limits<max_alloc_sizet>::digits);
-  return ((max_alloc_sizet)1) << (max_alloc_sizet)bits_for_positive_offset;
+  return ((mp_integer)1) << (mp_integer)bits_for_positive_offset;
 }
 
 void ansi_c_internal_additions(std::string &code)
@@ -195,7 +192,7 @@ void ansi_c_internal_additions(std::string &code)
     "int " CPROVER_PREFIX "malloc_failure_mode_assert_then_assume="+
     std::to_string(config.ansi_c.malloc_failure_mode_assert_then_assume)+";\n"
     CPROVER_PREFIX "size_t " CPROVER_PREFIX "max_malloc_size="+
-    std::to_string(max_malloc_size(config.ansi_c.pointer_width, config
+      integer2string(max_malloc_size(config.ansi_c.pointer_width, config
     .bv_encoding.object_bits))+";\n"
 
     // this is ANSI-C

--- a/src/ansi-c/ansi_c_internal_additions.cpp
+++ b/src/ansi-c/ansi_c_internal_additions.cpp
@@ -133,6 +133,7 @@ using max_alloc_sizet = uint64_t;
 static max_alloc_sizet
 max_malloc_size(std::size_t pointer_width, std::size_t object_bits)
 {
+  PRECONDITION(pointer_width >= 1);
   PRECONDITION(object_bits < pointer_width - 1);
   PRECONDITION(object_bits >= 1);
   const auto bits_for_offset = pointer_width - object_bits - 1;

--- a/src/ansi-c/ansi_c_internal_additions.cpp
+++ b/src/ansi-c/ansi_c_internal_additions.cpp
@@ -141,7 +141,7 @@ static max_alloc_sizet
 max_malloc_size(std::size_t pointer_width, std::size_t object_bits)
 {
   PRECONDITION(pointer_width >= 1);
-  PRECONDITION(object_bits < pointer_width - 1);
+  PRECONDITION(object_bits < pointer_width);
   PRECONDITION(object_bits >= 1);
   const auto offset_bits = pointer_width - object_bits;
   // We require the offset to be able to express upto allocation_size - 1,

--- a/unit/Makefile
+++ b/unit/Makefile
@@ -14,6 +14,7 @@ SRC += analyses/ai/ai.cpp \
        analyses/does_remove_const/does_expr_lose_const.cpp \
        analyses/does_remove_const/does_type_preserve_const_correctness.cpp \
        analyses/does_remove_const/is_type_at_least_as_const_as.cpp \
+       ansi-c/max_malloc_size.cpp \
        big-int/big-int.cpp \
        compound_block_locations.cpp \
        get_goto_model_from_c_test.cpp \

--- a/unit/ansi-c/max_malloc_size.cpp
+++ b/unit/ansi-c/max_malloc_size.cpp
@@ -1,0 +1,41 @@
+/*******************************************************************\
+
+Module: Unit test for max_malloc_size
+
+Author: Thomas Kiley
+
+\*******************************************************************/
+
+#include <ansi-c/ansi_c_internal_additions.cpp>
+#include <testing-utils/use_catch.h>
+
+TEST_CASE(
+  "max_malloc_size",
+  "[core][ansi-c][ansi_c_internal_additions][max_malloc_size]")
+{
+  cbmc_invariants_should_throwt throw_invariants;
+
+  SECTION("Too many bits for pointer ID")
+  {
+    REQUIRE_THROWS_AS(max_malloc_size(4, 3), invariant_failedt);
+    REQUIRE_THROWS_AS(max_malloc_size(4, 4), invariant_failedt);
+    REQUIRE_THROWS_AS(max_malloc_size(4, 5), invariant_failedt);
+  }
+
+  SECTION("Not enough bits for pointer ID")
+  {
+    REQUIRE_THROWS_AS(max_malloc_size(4, 0), invariant_failedt);
+  }
+
+  SECTION("Max allocation size overflow")
+  {
+    REQUIRE_THROWS_AS(max_malloc_size(128, 63), invariant_failedt);
+  }
+
+  SECTION("Valid allocation size configurations")
+  {
+    // Here we use 4 bits for the object ID, leaving 3 for the offset
+    REQUIRE(max_malloc_size(8, 4) == 8);
+    REQUIRE(max_malloc_size(128, 64) == 9223372036854775808ull /*2^63*/);
+  }
+}

--- a/unit/ansi-c/max_malloc_size.cpp
+++ b/unit/ansi-c/max_malloc_size.cpp
@@ -27,6 +27,11 @@ TEST_CASE(
     REQUIRE_THROWS_AS(max_malloc_size(4, 0), invariant_failedt);
   }
 
+  SECTION("Not enough bits in the pointer")
+  {
+    REQUIRE_THROWS_AS(max_malloc_size(0, 0), invariant_failedt);
+  }
+
   SECTION("Max allocation size overflow")
   {
     REQUIRE_THROWS_AS(max_malloc_size(128, 63), invariant_failedt);

--- a/unit/ansi-c/max_malloc_size.cpp
+++ b/unit/ansi-c/max_malloc_size.cpp
@@ -33,7 +33,6 @@ TEST_CASE(
 
   SECTION("Max allocation size overflow")
   {
-    REQUIRE_THROWS_AS(max_malloc_size(128, 63), invariant_failedt);
   }
 
   SECTION("Valid allocation size configurations")
@@ -44,5 +43,8 @@ TEST_CASE(
     // Here we use 4 bits for the object ID, leaving 3 for the offset
     REQUIRE(max_malloc_size(8, 4) == 8);
     REQUIRE(max_malloc_size(128, 64) == 9223372036854775808ull /*2^63*/);
+    REQUIRE(
+      max_malloc_size(128, 63) == string2integer("18446744073709551616"
+                                                 /*2^64*/));
   }
 }

--- a/unit/ansi-c/max_malloc_size.cpp
+++ b/unit/ansi-c/max_malloc_size.cpp
@@ -17,7 +17,6 @@ TEST_CASE(
 
   SECTION("Too many bits for pointer ID")
   {
-    REQUIRE_THROWS_AS(max_malloc_size(4, 3), invariant_failedt);
     REQUIRE_THROWS_AS(max_malloc_size(4, 4), invariant_failedt);
     REQUIRE_THROWS_AS(max_malloc_size(4, 5), invariant_failedt);
   }
@@ -39,6 +38,9 @@ TEST_CASE(
 
   SECTION("Valid allocation size configurations")
   {
+    // The one bit offset can be used to store 0, or -1, so we can allocate
+    // a single bit
+    REQUIRE(max_malloc_size(4, 3) == 1);
     // Here we use 4 bits for the object ID, leaving 3 for the offset
     REQUIRE(max_malloc_size(8, 4) == 8);
     REQUIRE(max_malloc_size(128, 64) == 9223372036854775808ull /*2^63*/);

--- a/unit/ansi-c/module_dependencies.txt
+++ b/unit/ansi-c/module_dependencies.txt
@@ -1,0 +1,2 @@
+testing-utils
+ansi-c


### PR DESCRIPTION
Previously, to work out the max allocation size, we we working out how many bits there were for the offset (`pointer_width - object_bits - 1`) and then raising 2 to that power. However, we were doing this with int literals, and so the calculation was done in 32bits.

Therefore, for the default object bits (8) gives you:

1 << (64 - 8 - 1)

Which depends on your compiler / OS might give you [zero](https://ideone.com/H7LRLb), or `8388608` (since overflow on signed integral types is undefined behavior, both are valid). The correct number is `36028797018963968`

This PR changes to use a 64 bit type on all platforms, and invariant if the result is not going to fit. 

Also adds unit tests showing this, and documentation explaining the calculations. 

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [x] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [na] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

