### PR TITLE
Fix overload resolution in options processing

### DIFF
--- a/regression/CMakeLists.txt
+++ b/regression/CMakeLists.txt
@@ -62,3 +62,6 @@ if(WITH_MEMORY_ANALYZER)
 endif()
 
 add_subdirectory(solver-hardness)
+if(NOT WIN32)
+  add_subdirectory(goto-ld)
+endif()

--- a/regression/Makefile
+++ b/regression/Makefile
@@ -31,6 +31,7 @@ DIRS = cbmc \
        linking-goto-binaries \
        symtab2gb \
        solver-hardness \
+       goto-ld \
        # Empty last line
 
 ifeq ($(OS),Windows_NT)

--- a/regression/goto-gcc/Makefile
+++ b/regression/goto-gcc/Makefile
@@ -18,6 +18,9 @@ tests.log: ../test.pl ../../src/goto-cc/goto-gcc
 ../../src/goto-cc/goto-gcc: ../../src/goto-cc/goto-cc
 	@ln -sf goto-cc ../../src/goto-cc/goto-gcc
 
+../../src/goto-cc/goto-ld: ../../src/goto-cc/goto-cc
+	@ln -sf goto-cc ../../src/goto-cc/goto-ld
+
 test tests.log: archives/libour_archive.a
 archives/libour_archive.a: archives/foo.c ../../src/goto-cc/goto-gcc
 	@cd archives && \

--- a/regression/goto-ld/CMakeLists.txt
+++ b/regression/goto-ld/CMakeLists.txt
@@ -1,0 +1,4 @@
+# TARGET_FILE (as used in other directories) can't be used with goto-gcc as it
+# isn't marked as an executable (target), which CMake requires. Thus construct a
+# path in the same way the symbolic link is created in the goto-cc directory.
+add_test_pl_tests("$<TARGET_FILE_DIR:goto-cc>/goto-ld")

--- a/regression/goto-ld/Makefile
+++ b/regression/goto-ld/Makefile
@@ -1,0 +1,32 @@
+default: tests.log
+
+include ../../src/config.inc
+include ../../src/common
+
+ifeq ($(BUILD_ENV_),MSVC)
+test:
+
+tests.log: ../test.pl
+
+else
+test: ../../src/goto-cc/goto-ld
+	@../test.pl -e -p -c ../../../src/goto-cc/goto-ld
+
+tests.log: ../test.pl ../../src/goto-cc/goto-ld
+	@../test.pl -e -p -c ../../../src/goto-cc/goto-ld
+
+../../src/goto-cc/goto-ld: ../../src/goto-cc/goto-cc
+	@ln -sf goto-cc ../../src/goto-cc/goto-ld
+endif
+
+show:
+	@for dir in *; do \
+	  if [ -d "$$dir" ]; then \
+	    vim -o "$$dir/*.c" "$$dir/*.out"; \
+	  fi; \
+	done;
+
+clean:
+	find -name '*.out' -execdir $(RM) '{}' \;
+	find -name '*.gb' -execdir $(RM) '{}' \;
+	find -name '*.goto-cc-saved' -execdir $(RM) '{}' \;

--- a/regression/goto-ld/options/options.desc
+++ b/regression/goto-ld/options/options.desc
@@ -1,0 +1,9 @@
+CORE
+
+--native-linker=true -o dummy.gb
+^EXIT=0$
+^SIGNAL=0$
+--
+--
+This is just to test that goto-ld exits without an error or a segmentation fault
+when processong command-line options, running the dummy-linker (/bin/)true.

--- a/src/goto-cc/CMakeLists.txt
+++ b/src/goto-cc/CMakeLists.txt
@@ -34,4 +34,9 @@ else()
     COMMAND "${CMAKE_COMMAND}" -E create_symlink
       goto-cc $<TARGET_FILE_DIR:goto-cc>/goto-gcc
     BYPRODUCTS ${CMAKE_BINARY_DIR}/bin/goto-gcc)
+  add_custom_command(TARGET goto-cc
+    POST_BUILD
+    COMMAND "${CMAKE_COMMAND}" -E create_symlink
+      goto-cc $<TARGET_FILE_DIR:goto-cc>/goto-ld
+    BYPRODUCTS ${CMAKE_BINARY_DIR}/bin/goto-ld)
 endif()

--- a/src/goto-cc/goto_cc_cmdline.h
+++ b/src/goto-cc/goto_cc_cmdline.h
@@ -34,6 +34,12 @@ public:
   // never fails, will add if not found
   std::size_t get_optnr(const std::string &option);
 
+  /// Set option \p option to \p value.
+  void set(const std::string &opt, const char *value) override
+  {
+    set(opt, std::string{value});
+  }
+
   void set(const std::string &opt, const std::string &value) override
   {
     std::size_t nr=get_optnr(opt);

--- a/src/util/cmdline.h
+++ b/src/util/cmdline.h
@@ -32,8 +32,14 @@ public:
 
   virtual bool isset(char option) const;
   virtual bool isset(const char *option) const;
+  /// Set option \p option to \p value, or \c true if the value is omitted.
   virtual void set(const std::string &option, bool value = true);
   virtual void set(const std::string &option, const std::string &value);
+  virtual void set(const std::string &option, const char *value)
+  {
+    set(option, std::string{value});
+  }
+
   virtual void clear();
 
   bool has_option(const std::string &option) const


### PR DESCRIPTION
The changes in 688b90a52e resulted in wrong overload resolution as char*
would resolve to bool, with goto-ld (and possibly specific calls of
goto-cc) producing segmentation faults as isset would no longer imply
that a value was present.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
