### PR TITLE
C front-end: fix initialisation of large arrays

### DIFF
--- a/regression/ansi-c/array_initialization6/main.c
+++ b/regression/ansi-c/array_initialization6/main.c
@@ -1,0 +1,7 @@
+// an array that is larger than MAX_FLATTENED_ARRAY_SIZE
+static const unsigned char data[256 * 4] = {0x0, 0x0};
+
+int main()
+{
+  return data[0];
+}

--- a/regression/ansi-c/array_initialization6/test.desc
+++ b/regression/ansi-c/array_initialization6/test.desc
@@ -1,0 +1,7 @@
+CORE
+main.c
+
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring


### PR DESCRIPTION
In 375e9a8c the construction of zero initialisers was switched to
array_of expressions for arrays with more than 1000 elements. This is
beneficial to avoid running out of memory, but didn't take into account
arrays with designated initialisers, which this patch fixes.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
