### PR TITLE
Satcheck need not implement hardness_collectort

### DIFF
--- a/src/goto-checker/solver_factory.cpp
+++ b/src/goto-checker/solver_factory.cpp
@@ -183,10 +183,22 @@ make_satcheck_prop(message_handlert &message_handler, const optionst &options)
   auto satcheck = util_make_unique<SatcheckT>(message_handler);
   if(options.is_set("write-solver-stats-to"))
   {
-    satcheck->enable_hardness_collection();
-    satcheck->with_solver_hardness([&options](solver_hardnesst &hardness) {
-      hardness.set_outfile(options.get_option("write-solver-stats-to"));
-    });
+    if(
+      auto hardness_collector = dynamic_cast<hardness_collectort *>(&*satcheck))
+    {
+      hardness_collector->enable_hardness_collection();
+      hardness_collector->with_solver_hardness(
+        [&options](solver_hardnesst &hardness) {
+          hardness.set_outfile(options.get_option("write-solver-stats-to"));
+        });
+    }
+    else
+    {
+      messaget log(message_handler);
+      log.warning()
+        << "Configured solver does not support --write-solver-stats-to. "
+        << "Solver stats will not be written." << messaget::eom;
+    }
   }
   return satcheck;
 }


### PR DESCRIPTION
Otherwise compilation fails for SAT solvers that don't implement hardness_collectort yet, e.g. Glucose.

- [X] Each commit message has a non-empty body, explaining why the change was made.
- [n/a] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [n/a] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [n/a] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [n/a] My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- [n/a] White-space or formatting changes outside the feature-related changed lines are in commits of their own.
