### PR TITLE
Fix cmake build from VS2019 command prompt

### DIFF
--- a/src/ansi-c/CMakeLists.txt
+++ b/src/ansi-c/CMakeLists.txt
@@ -5,9 +5,17 @@ add_executable(converter library/converter.cpp)
 
 file(GLOB ansi_c_library_sources "library/*.c")
 
-add_custom_command(OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/cprover_library.inc"
-    COMMAND cat ${ansi_c_library_sources} | $<TARGET_FILE:converter> > "${CMAKE_CURRENT_BINARY_DIR}/cprover_library.inc"
-    DEPENDS converter ${ansi_c_library_sources})
+# Convert cmake paths to native paths for Windows builds
+file(TO_NATIVE_PATH "${ansi_c_library_sources}"
+     ansi_c_library_sources_paths)
+file(TO_NATIVE_PATH "${CMAKE_CURRENT_BINARY_DIR}/cprover_library.inc"
+     cprover_library_path)
+file(TO_NATIVE_PATH "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/converter"
+     converter_path)
+
+add_custom_command(OUTPUT "${cprover_library_path}"
+    COMMAND cat ${ansi_c_library_sources_paths} | ${converter_path} > ${cprover_library_path}
+    DEPENDS converter ${ansi_c_library_sources_paths})
 
 add_executable(file_converter file_converter.cpp)
 

--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -1,8 +1,16 @@
 file(GLOB cpp_library_sources "library/*.c")
 
-add_custom_command(OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/cprover_library.inc"
-        COMMAND cat ${cpp_library_sources} | $<TARGET_FILE:converter> > "${CMAKE_CURRENT_BINARY_DIR}/cprover_library.inc"
-        DEPENDS converter ${cpp_library_sources})
+# Convert cmake paths to native paths for Windows builds
+file(TO_NATIVE_PATH "${cpp_library_sources}"
+     cpp_library_sources_paths)
+file(TO_NATIVE_PATH "${CMAKE_CURRENT_BINARY_DIR}/cprover_library.inc"
+     cprover_library_path)
+file(TO_NATIVE_PATH "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/converter"
+     converter_path)
+
+add_custom_command(OUTPUT "${cprover_library_path}"
+        COMMAND cat ${cpp_library_sources_paths} | "${converter_path}" > "${cprover_library_path}"
+        DEPENDS converter ${cpp_library_sources_paths})
 
 ################################################################################
 

--- a/src/util/expr_iterator.h
+++ b/src/util/expr_iterator.h
@@ -164,7 +164,11 @@ protected:
   { m_stack=std::move(other.m_stack); }
   depth_iterator_baset &operator=(const depth_iterator_baset&)=default;
   depth_iterator_baset &operator=(depth_iterator_baset &&other)
-  { m_stack=std::move(other.m_stack); }
+  {
+    m_stack=std::move(other.m_stack);
+    // VS 2019 cl wants this function definition to return a value
+    return *this;
+  }
 
   const exprt &get_root()
   {

--- a/src/util/expr_iterator.h
+++ b/src/util/expr_iterator.h
@@ -165,8 +165,7 @@ protected:
   depth_iterator_baset &operator=(const depth_iterator_baset&)=default;
   depth_iterator_baset &operator=(depth_iterator_baset &&other)
   {
-    m_stack=std::move(other.m_stack);
-    // VS 2019 cl wants this function definition to return a value
+    m_stack = std::move(other.m_stack);
     return *this;
   }
 


### PR DESCRIPTION
I made these changes to get cbmc to build on Windows from the VS2019 command prompt with the cmake, git, and ninja installed there.

My method was
* Install Visual Studio Community 2019
    * Desktop development with C++
    * Individual components -> Code tools -> Git for windows, Git extension for Visual Studio
* Open x64 Native Tools Command Prompt for VS 2019
* PATH="c:\Program Files\Git\usr\bin";%PATH%
* curl -L https://downloads.sourceforge.net/project/winflexbison/win_flex_bison-latest.zip > bison.zip
* unzip bison.zip
* cmake -S. -Bbuild -GNinja -DWITH_JBMC=NO
* cmake --build build


