### PR TITLE
C front-end: maintain alignment attribute for struct members

### DIFF
--- a/regression/ansi-c/Struct_Padding7/main.c
+++ b/regression/ansi-c/Struct_Padding7/main.c
@@ -1,0 +1,33 @@
+#define CONCAT(a, b) a##b
+#define CONCAT2(a, b) CONCAT(a, b)
+
+#define STATIC_ASSERT(condition)                                               \
+  int CONCAT2(some_array, __LINE__)[(condition) ? 1 : -1]
+
+typedef struct S1
+{
+  int x;
+} S1;
+
+#ifdef __GNUC__
+struct S2
+{
+  struct S1 __attribute__((__aligned__(((1L) << 12)))) s1;
+};
+
+struct foo
+{
+  char a;
+  int x[2] __attribute__((packed));
+};
+#endif
+
+int main()
+{
+#ifdef __GNUC__
+  STATIC_ASSERT(sizeof(struct S1) == sizeof(int));
+  STATIC_ASSERT(sizeof(struct S2) == (1L << 12));
+  STATIC_ASSERT(sizeof(struct foo) == sizeof(char) + 2 * sizeof(int));
+#endif
+  return 0;
+}

--- a/regression/ansi-c/Struct_Padding7/test.desc
+++ b/regression/ansi-c/Struct_Padding7/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+^CONVERSION ERROR$

--- a/src/ansi-c/c_typecheck_type.cpp
+++ b/src/ansi-c/c_typecheck_type.cpp
@@ -761,6 +761,9 @@ void c_typecheck_baset::typecheck_compound_type(struct_union_typet &type)
     original_qualifiers.is_transparent_union;
   remove_qualifiers.write(type);
 
+  bool is_packed = type.get_bool(ID_C_packed);
+  irept alignment = type.find(ID_C_alignment);
+
   if(type.find(ID_tag).is_nil())
   {
     // Anonymous? Must come with body.
@@ -867,6 +870,11 @@ void c_typecheck_baset::typecheck_compound_type(struct_union_typet &type)
   type.swap(tag_type);
 
   original_qualifiers.write(type);
+
+  if(is_packed)
+    type.set(ID_C_packed, true);
+  if(alignment.is_not_nil())
+    type.set(ID_C_alignment, alignment);
 }
 
 void c_typecheck_baset::typecheck_compound_body(


### PR DESCRIPTION
Ensure that struct/union typed members of structs with alignment
attributes keep these annotations during type checking, which were
already correctly preserved for typedef-typed members.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
