### PR TITLE
Fix depth_iterator_baset move assignment to return a value.

### DIFF
--- a/src/util/expr_iterator.h
+++ b/src/util/expr_iterator.h
@@ -164,7 +164,10 @@ protected:
   { m_stack=std::move(other.m_stack); }
   depth_iterator_baset &operator=(const depth_iterator_baset&)=default;
   depth_iterator_baset &operator=(depth_iterator_baset &&other)
-  { m_stack=std::move(other.m_stack); }
+  {
+    m_stack = std::move(other.m_stack);
+    return *this;
+  }
 
   const exprt &get_root()
   {


### PR DESCRIPTION
Make the depth_iterator_baset assignment operator return a value.

The type says it should return a value, and VS2019 fails to builds without a return value.