### PR TITLE
Use native path separators to make cmake build under vs2019 work.

### DIFF
--- a/src/ansi-c/CMakeLists.txt
+++ b/src/ansi-c/CMakeLists.txt
@@ -5,9 +5,17 @@ add_executable(converter library/converter.cpp)
 
 file(GLOB ansi_c_library_sources "library/*.c")
 
-add_custom_command(OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/cprover_library.inc"
-    COMMAND cat ${ansi_c_library_sources} | $<TARGET_FILE:converter> > "${CMAKE_CURRENT_BINARY_DIR}/cprover_library.inc"
-    DEPENDS converter ${ansi_c_library_sources})
+# Convert cmake paths to native paths for Windows builds
+file(TO_NATIVE_PATH "${ansi_c_library_sources}"
+     ansi_c_library_sources_paths)
+file(TO_NATIVE_PATH "${CMAKE_CURRENT_BINARY_DIR}/cprover_library.inc"
+     cprover_library_path)
+file(TO_NATIVE_PATH "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/converter"
+     converter_path)
+
+add_custom_command(OUTPUT "${cprover_library_path}"
+    COMMAND cat ${ansi_c_library_sources_paths} | ${converter_path} > ${cprover_library_path}
+    DEPENDS converter ${ansi_c_library_sources_paths})
 
 add_executable(file_converter file_converter.cpp)
 

--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -1,8 +1,16 @@
 file(GLOB cpp_library_sources "library/*.c")
 
-add_custom_command(OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/cprover_library.inc"
-        COMMAND cat ${cpp_library_sources} | $<TARGET_FILE:converter> > "${CMAKE_CURRENT_BINARY_DIR}/cprover_library.inc"
-        DEPENDS converter ${cpp_library_sources})
+# Convert cmake paths to native paths for Windows builds
+file(TO_NATIVE_PATH "${cpp_library_sources}"
+     cpp_library_sources_paths)
+file(TO_NATIVE_PATH "${CMAKE_CURRENT_BINARY_DIR}/cprover_library.inc"
+     cprover_library_path)
+file(TO_NATIVE_PATH "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/converter"
+     converter_path)
+
+add_custom_command(OUTPUT "${cprover_library_path}"
+        COMMAND cat ${cpp_library_sources_paths} | "${converter_path}" > "${cprover_library_path}"
+        DEPENDS converter ${cpp_library_sources_paths})
 
 ################################################################################
 


### PR DESCRIPTION
Make cmake use native path separators in cat commands so that the cmake build will work from the Visual Studio command prompt.

I'd like cbmc to build on windows in the native build environment with minimal dependency on external tools, eg requiring chocolatey and cygwin, etc.  Visual Studio comes with cmake and ninja, and Visual Studio can be installed with git, which will give you access to git bash and all the bash shell tools you might need.

My method is

* Install Visual Studio Community 2019
    * Desktop development with C++
    * Individual components -> Code tools -> Git for windows, Git extension for Visual Studio
* Open x64 Native Tools Command Prompt for VS 2019
* PATH="c:\Program Files\Git\usr\bin";%PATH%
* curl -L https://downloads.sourceforge.net/project/winflexbison/win_flex_bison-latest.zip > bison.zip
* unzip bison.zip
* cmake -S. -Bbuild -GNinja 
* cmake --build build