### PR TITLE
Build system: make C string converters read files

### DIFF
--- a/src/ansi-c/CMakeLists.txt
+++ b/src/ansi-c/CMakeLists.txt
@@ -6,14 +6,14 @@ add_executable(converter library/converter.cpp)
 file(GLOB ansi_c_library_sources "library/*.c")
 
 add_custom_command(OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/cprover_library.inc"
-    COMMAND cat ${ansi_c_library_sources} | $<TARGET_FILE:converter> > "${CMAKE_CURRENT_BINARY_DIR}/cprover_library.inc"
+    COMMAND $<TARGET_FILE:converter> ${ansi_c_library_sources} > "${CMAKE_CURRENT_BINARY_DIR}/cprover_library.inc"
     DEPENDS converter ${ansi_c_library_sources})
 
 add_executable(file_converter file_converter.cpp)
 
 function(make_inc name)
     add_custom_command(OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/${name}.inc"
-        COMMAND file_converter < "${CMAKE_CURRENT_SOURCE_DIR}/${name}.h" > "${CMAKE_CURRENT_BINARY_DIR}/${name}.inc"
+        COMMAND file_converter "${CMAKE_CURRENT_SOURCE_DIR}/${name}.h" > "${CMAKE_CURRENT_BINARY_DIR}/${name}.inc"
         DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/${name}.h" file_converter
     )
 endfunction(make_inc)

--- a/src/ansi-c/Makefile
+++ b/src/ansi-c/Makefile
@@ -110,10 +110,10 @@ library_check: library/*.c
 	touch $@
 
 cprover_library.inc: library/converter$(EXEEXT) library/*.c
-	cat library/*.c | library/converter$(EXEEXT) > $@
+	library/converter$(EXEEXT) library/*.c > $@
 
 %.inc: %.h file_converter$(EXEEXT)
-	./file_converter$(EXEEXT) < $< > $@
+	./file_converter$(EXEEXT) $< > $@
 
 ansi_c_internal_additions$(OBJEXT): $(BUILTIN_FILES)
 

--- a/src/ansi-c/file_converter.cpp
+++ b/src/ansi-c/file_converter.cpp
@@ -12,34 +12,35 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <iostream>
 #include <string>
 
+static void convert_line(const std::string &line)
+{
+  std::cout << "\"";
+
+  for(std::size_t i = 0; i < line.size(); i++)
+  {
+    const char ch = line[i];
+    if(ch == '\\')
+      std::cout << "\\\\";
+    else if(ch == '"')
+      std::cout << "\\\"";
+    else if(ch == '\r' || ch == '\n')
+    {
+    }
+    else if((ch & 0x80) != 0)
+    {
+      std::cout << "\\x" << std::hex << (unsigned(ch) & 0xff) << std::dec;
+    }
+    else
+      std::cout << ch;
+  }
+
+  std::cout << "\\n\"\n";
+}
+
 int main()
 {
   std::string line;
 
   while(getline(std::cin, line))
-  {
-    std::cout << "\"";
-
-    for(std::size_t i=0; i<line.size(); i++)
-    {
-      const char ch=line[i];
-      if(ch=='\\')
-        std::cout << "\\\\";
-      else if(ch=='"')
-        std::cout << "\\\"";
-      else if(ch=='\r' || ch=='\n')
-      {
-      }
-      else if((ch&0x80)!=0)
-      {
-        std::cout << "\\x"
-                  << std::hex << (unsigned(ch)&0xff)
-                  << std::dec;
-      }
-      else
-        std::cout << ch;
-    }
-
-    std::cout << "\\n\"\n";
-  }
+    convert_line(line);
 }

--- a/src/ansi-c/file_converter.cpp
+++ b/src/ansi-c/file_converter.cpp
@@ -9,6 +9,7 @@ Author: Daniel Kroening, kroening@kroening.com
 /// \file
 /// Convert file contents to C strings
 
+#include <fstream>
 #include <iostream>
 #include <string>
 
@@ -37,10 +38,23 @@ static void convert_line(const std::string &line)
   std::cout << "\\n\"\n";
 }
 
-int main()
+int main(int argc, char *argv[])
 {
   std::string line;
 
-  while(getline(std::cin, line))
-    convert_line(line);
+  for(int i = 1; i < argc; ++i)
+  {
+    std::ifstream input_file(argv[i]);
+
+    if(!input_file)
+    {
+      std::cerr << "Failed to open " << argv[i] << '\n';
+      return 1;
+    }
+
+    while(getline(input_file, line))
+      convert_line(line);
+  }
+
+  return 0;
 }

--- a/src/ansi-c/library/converter.cpp
+++ b/src/ansi-c/library/converter.cpp
@@ -15,51 +15,57 @@ bool has_prefix(const std::string &s, const std::string &prefix)
   return std::string(s, 0, prefix.size())==prefix;
 }
 
+static void convert_line(const std::string &line, bool first)
+{
+  if(has_prefix(line, "/* FUNCTION: "))
+  {
+    if(!first)
+      std::cout << "},\n";
+
+    std::string function = std::string(line, 13, std::string::npos);
+    std::size_t pos = function.find(' ');
+    if(pos != std::string::npos)
+      function = std::string(function, 0, pos);
+
+    std::cout << "{ \"" << function << "\",\n";
+    std::cout << "  \"#line 1 \\\"<builtin-library-" << function
+              << ">\\\"\\n\"\n";
+  }
+  else if(!first)
+  {
+    std::cout << "  \"";
+
+    for(unsigned i = 0; i < line.size(); i++)
+    {
+      const char ch = line[i];
+      if(ch == '\\')
+        std::cout << "\\\\";
+      else if(ch == '"')
+        std::cout << "\\\"";
+      else if(ch == '\r' || ch == '\n')
+      {
+      }
+      else
+        std::cout << ch;
+    }
+
+    std::cout << "\\n\"\n";
+  }
+}
+
 int main()
 {
   std::string line;
-  bool first=true;
+  bool first = true;
 
   std::cout << "{\n";
 
-  while(getline(std::cin, line))
+  if(getline(std::cin, line))
   {
-    if(has_prefix(line, "/* FUNCTION: "))
-    {
-      if(first)
-        first=false;
-      else
-        std::cout << "},\n";
-
-      std::string function=std::string(line, 13, std::string::npos);
-      std::size_t pos=function.find(' ');
-      if(pos!=std::string::npos)
-        function=std::string(function, 0, pos);
-
-      std::cout << "{ \"" << function << "\",\n";
-      std::cout << "  \"#line 1 \\\"<builtin-library-"
-                << function << ">\\\"\\n\"\n";
-    }
-    else if(!first)
-    {
-      std::cout << "  \"";
-
-      for(unsigned i=0; i<line.size(); i++)
-      {
-        const char ch=line[i];
-        if(ch=='\\')
-          std::cout << "\\\\";
-        else if(ch=='"')
-          std::cout << "\\\"";
-        else if(ch=='\r' || ch=='\n')
-        {
-        }
-        else
-          std::cout << ch;
-      }
-
-      std::cout << "\\n\"\n";
-    }
+    convert_line(line, true);
+    first = false;
+    while(getline(std::cin, line))
+      convert_line(line, false);
   }
 
   if(!first)

--- a/src/ansi-c/library/converter.cpp
+++ b/src/ansi-c/library/converter.cpp
@@ -6,7 +6,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 \*******************************************************************/
 
-
+#include <fstream>
 #include <iostream>
 #include <string>
 
@@ -53,19 +53,28 @@ static void convert_line(const std::string &line, bool first)
   }
 }
 
-int main()
+int main(int argc, char *argv[])
 {
   std::string line;
   bool first = true;
 
   std::cout << "{\n";
 
-  if(getline(std::cin, line))
+  for(int i = 1; i < argc; ++i)
   {
-    convert_line(line, true);
-    first = false;
-    while(getline(std::cin, line))
-      convert_line(line, false);
+    std::ifstream input_file(argv[i]);
+
+    if(!input_file)
+    {
+      std::cerr << "Failed to open " << argv[i] << '\n';
+      return 1;
+    }
+
+    while(getline(input_file, line))
+    {
+      convert_line(line, first);
+      first = false;
+    }
   }
 
   if(!first)
@@ -74,4 +83,6 @@ int main()
   std::cout <<
     "{ 0, 0 }\n"
     "}";
+
+  return 0;
 }

--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -1,7 +1,7 @@
 file(GLOB cpp_library_sources "library/*.c")
 
 add_custom_command(OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/cprover_library.inc"
-        COMMAND cat ${cpp_library_sources} | $<TARGET_FILE:converter> > "${CMAKE_CURRENT_BINARY_DIR}/cprover_library.inc"
+        COMMAND $<TARGET_FILE:converter> ${cpp_library_sources} > "${CMAKE_CURRENT_BINARY_DIR}/cprover_library.inc"
         DEPENDS converter ${cpp_library_sources})
 
 ################################################################################

--- a/src/cpp/Makefile
+++ b/src/cpp/Makefile
@@ -73,7 +73,7 @@ library_check: library/*.c
 	touch $@
 
 cprover_library.inc: ../ansi-c/library/converter$(EXEEXT) library/*.c
-	cat library/*.c | ../ansi-c/library/converter$(EXEEXT) > $@
+	../ansi-c/library/converter$(EXEEXT) library/*.c > $@
 
 generated_files: cprover_library.inc
 


### PR DESCRIPTION
Instead of converting stdin, the converters now open and read the files
they are to convert to C strings. This avoids invoking `cat` in build
steps, which helps portability to non-Unix systems.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
