### PR TITLE
Fix duplicated code

### DIFF
--- a/src/goto-programs/xml_goto_trace.cpp
+++ b/src/goto-programs/xml_goto_trace.cpp
@@ -70,30 +70,21 @@ void convert(
         xml_assignment.new_element().swap(xml_location);
 
       {
-        auto lhs_object = step.get_lhs_object();
-
         const symbolt *symbol;
 
         if(
           lhs_object.has_value() &&
           !ns.lookup(lhs_object->get_identifier(), symbol))
         {
-          const symbolt *symbol;
+          std::string type_string = from_type(ns, symbol->name, symbol->type);
 
-          if(
-            lhs_object.has_value() &&
-            !ns.lookup(lhs_object->get_identifier(), symbol))
-          {
-            std::string type_string = from_type(ns, symbol->name, symbol->type);
-
-            xml_assignment.set_attribute("mode", id2string(symbol->mode));
-            xml_assignment.set_attribute("identifier", id2string(symbol->name));
-            xml_assignment.set_attribute(
-              "base_name", id2string(symbol->base_name));
-            xml_assignment.set_attribute(
-              "display_name", id2string(symbol->display_name()));
-            xml_assignment.new_element("type").data = type_string;
-          }
+          xml_assignment.set_attribute("mode", id2string(symbol->mode));
+          xml_assignment.set_attribute("identifier", id2string(symbol->name));
+          xml_assignment.set_attribute(
+            "base_name", id2string(symbol->base_name));
+          xml_assignment.set_attribute(
+            "display_name", id2string(symbol->display_name()));
+          xml_assignment.new_element("type").data = type_string;
         }
       }
 

--- a/src/goto-programs/xml_goto_trace.cpp
+++ b/src/goto-programs/xml_goto_trace.cpp
@@ -70,7 +70,7 @@ void convert(
         xml_assignment.new_element().swap(xml_location);
 
       {
-        auto lhs_object=step.get_lhs_object();
+        auto lhs_object = step.get_lhs_object();
 
         const symbolt *symbol;
 
@@ -80,16 +80,19 @@ void convert(
         {
           const symbolt *symbol;
 
-          if(lhs_object.has_value() &&
-             !ns.lookup(lhs_object->get_identifier(), symbol))
+          if(
+            lhs_object.has_value() &&
+            !ns.lookup(lhs_object->get_identifier(), symbol))
           {
-            std::string type_string=from_type(ns, symbol->name, symbol->type);
+            std::string type_string = from_type(ns, symbol->name, symbol->type);
 
             xml_assignment.set_attribute("mode", id2string(symbol->mode));
             xml_assignment.set_attribute("identifier", id2string(symbol->name));
-            xml_assignment.set_attribute("base_name", id2string(symbol->base_name));
-            xml_assignment.set_attribute("display_name", id2string(symbol->display_name()));
-            xml_assignment.new_element("type").data=type_string;
+            xml_assignment.set_attribute(
+              "base_name", id2string(symbol->base_name));
+            xml_assignment.set_attribute(
+              "display_name", id2string(symbol->display_name()));
+            xml_assignment.new_element("type").data = type_string;
           }
         }
       }


### PR DESCRIPTION
Clang tidy highlighted some shadowed variables - looks like a simple case of some copy-pasted code. 

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [na] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [na] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [na] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.
