### PR TITLE
Add cmake install target

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -338,6 +338,37 @@ jobs:
         - WITH_MEMORY_ANALYZER=1
       script: echo "This is coverity build. No need for tests."
 
+    # cmake install test
+    - stage: Test different OS/CXX/Flags
+      os: linux
+      dist: trusty
+      sudo: false
+      compiler: gcc
+      cache: ccache
+      env:
+        - NAME="cmake install test"
+        - BINARIES="cbmc goto-cc goto-gcc goto-ld goto-instrument goto-analyzer goto-diff goto-harness jbmc janalyzer jdiff"
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-5
+            - maven
+      install:
+        - ccache -z
+        - ccache --max-size=1G
+        - cmake --version
+        - cmake -S . -Bbuild '-DCMAKE_CXX_COMPILER=/usr/bin/g++-5' '-DCMAKE_INSTALL_PREFIX=install'
+        - cmake --build build -- -j4
+        - pushd build; make install; popd
+      script: |
+        for b in $BINARIES; do
+          ( echo === $b === &&
+            install/bin/$b --version &&
+            man -M install/share/man $b | head ) || exit 1 ;
+        done
+
 install:
   - ccache -z
   - ccache --max-size=1G

--- a/jbmc/src/janalyzer/CMakeLists.txt
+++ b/jbmc/src/janalyzer/CMakeLists.txt
@@ -24,3 +24,12 @@ target_link_libraries(janalyzer-lib
 # Executable
 add_executable(janalyzer janalyzer_main.cpp)
 target_link_libraries(janalyzer janalyzer-lib)
+install(TARGETS janalyzer DESTINATION ${CMAKE_INSTALL_BINDIR})
+
+# Symlink man page to cbmc man page until a real man page is written
+install(CODE "execute_process( \
+  COMMAND ${CMAKE_COMMAND} -E create_symlink \
+  cbmc.1 \
+  ${CMAKE_INSTALL_FULL_MANDIR}/man1/janalyzer.1 \
+  )"
+)

--- a/jbmc/src/jbmc/CMakeLists.txt
+++ b/jbmc/src/jbmc/CMakeLists.txt
@@ -30,3 +30,12 @@ target_link_libraries(jbmc-lib
 # Executable
 add_executable(jbmc jbmc_main.cpp)
 target_link_libraries(jbmc jbmc-lib)
+install(TARGETS jbmc DESTINATION ${CMAKE_INSTALL_BINDIR})
+
+# Symlink man page to cbmc man page until a real man page is written
+install(CODE "execute_process( \
+  COMMAND ${CMAKE_COMMAND} -E create_symlink \
+  cbmc.1 \
+  ${CMAKE_INSTALL_FULL_MANDIR}/man1/jbmc.1 \
+  )"
+)

--- a/jbmc/src/jdiff/CMakeLists.txt
+++ b/jbmc/src/jdiff/CMakeLists.txt
@@ -25,3 +25,12 @@ target_link_libraries(jdiff-lib
 # Executable
 add_executable(jdiff jdiff_main.cpp)
 target_link_libraries(jdiff jdiff-lib)
+install(TARGETS jdiff DESTINATION ${CMAKE_INSTALL_BINDIR})
+
+# Symlink man page to cbmc man page until a real man page is written
+install(CODE "execute_process( \
+  COMMAND ${CMAKE_COMMAND} -E create_symlink \
+  cbmc.1 \
+  ${CMAKE_INSTALL_FULL_MANDIR}/man1/jdiff.1 \
+  )"
+)

--- a/src/cbmc/CMakeLists.txt
+++ b/src/cbmc/CMakeLists.txt
@@ -34,3 +34,10 @@ add_if_library(cbmc-lib jsil)
 # Executable
 add_executable(cbmc cbmc_main.cpp)
 target_link_libraries(cbmc cbmc-lib)
+install(TARGETS cbmc DESTINATION ${CMAKE_INSTALL_BINDIR})
+
+# Man page
+if(NOT WIN32)
+  install(FILES ${CMAKE_SOURCE_DIR}/doc/man/cbmc.1
+          DESTINATION ${CMAKE_INSTALL_MANDIR}/man1)
+endif()

--- a/src/goto-analyzer/CMakeLists.txt
+++ b/src/goto-analyzer/CMakeLists.txt
@@ -27,3 +27,12 @@ add_if_library(goto-analyzer-lib jsil)
 # Executable
 add_executable(goto-analyzer goto_analyzer_main.cpp)
 target_link_libraries(goto-analyzer goto-analyzer-lib)
+install(TARGETS goto-analyzer DESTINATION ${CMAKE_INSTALL_BINDIR})
+
+# Symlink man page to cbmc man page until a real man page is written
+install(CODE "execute_process( \
+  COMMAND ${CMAKE_COMMAND} -E create_symlink \
+  cbmc.1 \
+  ${CMAKE_INSTALL_FULL_MANDIR}/man1/goto-analyzer.1 \
+  )"
+)

--- a/src/goto-cc/CMakeLists.txt
+++ b/src/goto-cc/CMakeLists.txt
@@ -28,6 +28,7 @@ target_link_libraries(goto-cc goto-cc-lib)
 
 if(WIN32)
   set_target_properties(goto-cc PROPERTIES OUTPUT_NAME goto-cl)
+  install(TARGETS goto-cl DESTINATION ${CMAKE_INSTALL_BINDIR})
 else()
   add_custom_command(TARGET goto-cc
     POST_BUILD
@@ -39,4 +40,36 @@ else()
     COMMAND "${CMAKE_COMMAND}" -E create_symlink
       goto-cc $<TARGET_FILE_DIR:goto-cc>/goto-ld
     BYPRODUCTS ${CMAKE_BINARY_DIR}/bin/goto-ld)
+  install(TARGETS goto-cc DESTINATION ${CMAKE_INSTALL_BINDIR})
+  install(CODE "execute_process( \
+    COMMAND ${CMAKE_COMMAND} -E create_symlink \
+    goto-cc \
+    ${CMAKE_INSTALL_FULL_BINDIR}/goto-gcc \
+    )"
+  )
+  install(CODE "execute_process( \
+    COMMAND ${CMAKE_COMMAND} -E create_symlink \
+    goto-cc \
+    ${CMAKE_INSTALL_FULL_BINDIR}/goto-ld \
+    )"
+  )
+  # Symlink man page to cbmc man page until a real man page is written
+  install(CODE "execute_process( \
+    COMMAND ${CMAKE_COMMAND} -E create_symlink \
+    cbmc.1 \
+    ${CMAKE_INSTALL_FULL_MANDIR}/man1/goto-cc.1 \
+    )"
+  )
+  install(CODE "execute_process( \
+    COMMAND ${CMAKE_COMMAND} -E create_symlink \
+    cbmc.1 \
+    ${CMAKE_INSTALL_FULL_MANDIR}/man1/goto-gcc.1 \
+    )"
+  )
+  install(CODE "execute_process( \
+    COMMAND ${CMAKE_COMMAND} -E create_symlink \
+    cbmc.1 \
+    ${CMAKE_INSTALL_FULL_MANDIR}/man1/goto-ld.1 \
+    )"
+  )
 endif()

--- a/src/goto-diff/CMakeLists.txt
+++ b/src/goto-diff/CMakeLists.txt
@@ -28,3 +28,12 @@ add_if_library(goto-diff-lib jsil)
 # Executable
 add_executable(goto-diff goto_diff_main.cpp)
 target_link_libraries(goto-diff goto-diff-lib)
+install(TARGETS goto-diff DESTINATION ${CMAKE_INSTALL_BINDIR})
+
+# Symlink man page to cbmc man page until a real man page is written
+install(CODE "execute_process( \
+  COMMAND ${CMAKE_COMMAND} -E create_symlink \
+  cbmc.1 \
+  ${CMAKE_INSTALL_FULL_MANDIR}/man1/goto-diff.1 \
+  )"
+)

--- a/src/goto-harness/CMakeLists.txt
+++ b/src/goto-harness/CMakeLists.txt
@@ -8,3 +8,12 @@ target_link_libraries(goto-harness
   json
   json-symtab-language
 )
+install(TARGETS goto-harness DESTINATION ${CMAKE_INSTALL_BINDIR})
+
+# Symlink man page to cbmc man page until a real man page is written
+install(CODE "execute_process( \
+  COMMAND ${CMAKE_COMMAND} -E create_symlink \
+  cbmc.1 \
+  ${CMAKE_INSTALL_FULL_MANDIR}/man1/goto-harness.1 \
+  )"
+)

--- a/src/goto-instrument/CMakeLists.txt
+++ b/src/goto-instrument/CMakeLists.txt
@@ -29,3 +29,12 @@ add_if_library(goto-instrument-lib glpk)
 # Executable
 add_executable(goto-instrument goto_instrument_main.cpp)
 target_link_libraries(goto-instrument goto-instrument-lib)
+install(TARGETS goto-instrument DESTINATION ${CMAKE_INSTALL_BINDIR})
+
+# Symlink man page to cbmc man page until a real man page is written
+install(CODE "execute_process( \
+  COMMAND ${CMAKE_COMMAND} -E create_symlink \
+  cbmc.1 \
+  ${CMAKE_INSTALL_FULL_MANDIR}/man1/goto-instrument.1 \
+  )"
+)


### PR DESCRIPTION
Add an install target to the cmake build.

Aside from being generally useful, an install target for the purpose of simplifying maintenance was explicitly requested on the pull request to add CBMC to Homebrew (the MacOS package manager). https://github.com/Homebrew/homebrew-core/pull/53282

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ x] My PR is restricted to a single feature or bugfix.
- [ x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
