### PR TITLE
Tests to check inconsistent assumptions involving __CPROVER_r_ok

### DIFF
--- a/regression/CMakeLists.txt
+++ b/regression/CMakeLists.txt
@@ -56,6 +56,7 @@ add_subdirectory(goto-cc-file-local)
 add_subdirectory(linking-goto-binaries)
 add_subdirectory(symtab2gb)
 add_subdirectory(validate-trace-xml-schema)
+add_subdirectory(cbmc-primitives)
 
 if(WITH_MEMORY_ANALYZER)
   add_subdirectory(snapshot-harness)

--- a/regression/Makefile
+++ b/regression/Makefile
@@ -33,7 +33,8 @@ DIRS = cbmc \
        solver-hardness \
        goto-ld \
        validate-trace-xml-schema \
-			 # Empty last line
+       cbmc-primitives \
+       # Empty last line
 
 ifeq ($(OS),Windows_NT)
     detected_OS := Windows

--- a/regression/cbmc-primitives/CMakeLists.txt
+++ b/regression/cbmc-primitives/CMakeLists.txt
@@ -1,0 +1,3 @@
+add_test_pl_tests(
+    "$<TARGET_FILE:cbmc>"
+)

--- a/regression/cbmc-primitives/Makefile
+++ b/regression/cbmc-primitives/Makefile
@@ -1,0 +1,18 @@
+default: tests.log
+
+test:
+	@../test.pl -e -p -c ../../../src/cbmc/cbmc
+
+tests.log: ../test.pl
+	@../test.pl -e -p -c ../../../src/cbmc/cbmc
+
+show:
+	@for dir in *; do \
+		if [ -d "$$dir" ]; then \
+			vim -o "$$dir/*.c" "$$dir/*.out"; \
+		fi; \
+	done;
+
+clean:
+	find -name '*.out' -execdir $(RM) '{}' \;
+	$(RM) tests.log

--- a/regression/cbmc-primitives/r_w_ok_bug/main.c
+++ b/regression/cbmc-primitives/r_w_ok_bug/main.c
@@ -1,0 +1,9 @@
+#include <assert.h>
+#include <stdlib.h>
+
+void main()
+{
+  char *p1;
+  __CPROVER_assume(__CPROVER_r_ok(p1 - 1, 1));
+  *p1;
+}

--- a/regression/cbmc-primitives/r_w_ok_bug/test.desc
+++ b/regression/cbmc-primitives/r_w_ok_bug/test.desc
@@ -1,0 +1,9 @@
+KNOWNBUG
+main.c
+--pointer-check --no-simplify --no-propagation
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--
+Crashes during the flattening, issue #5328

--- a/regression/cbmc-primitives/r_w_ok_inconsistent_dead/main.c
+++ b/regression/cbmc-primitives/r_w_ok_inconsistent_dead/main.c
@@ -1,0 +1,16 @@
+#include <assert.h>
+#include <stdlib.h>
+
+void main()
+{
+  char *p;
+
+  {
+    char c;
+    p = &c;
+  }
+
+  __CPROVER_assume(__CPROVER_r_ok(p, 1));
+  assert(0); // fails
+  *p;        // succeeds
+}

--- a/regression/cbmc-primitives/r_w_ok_inconsistent_dead/test-no-cp.desc
+++ b/regression/cbmc-primitives/r_w_ok_inconsistent_dead/test-no-cp.desc
@@ -1,0 +1,13 @@
+FUTURE
+main.c
+--pointer-check --no-simplify --no-propagation
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring
+--
+Tests that an inconsistent assumption involving a pointer to an out of scope
+variable and __CPROVER_r_ok() can be detected via assert(0). We use
+--no-simplify and --no-propagation to ensure that the case is not solved by the
+constant propagation and thus tests the constraint encoding.

--- a/regression/cbmc-primitives/r_w_ok_inconsistent_dead/test.desc
+++ b/regression/cbmc-primitives/r_w_ok_inconsistent_dead/test.desc
@@ -1,0 +1,11 @@
+FUTURE
+main.c
+--function test_global_pointer --pointer-check
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring
+--
+Tests that an inconsistent assumption involving a pointer to an out of scope
+variable and __CPROVER_r_ok() can be detected via assert(0).

--- a/regression/cbmc-primitives/r_w_ok_inconsistent_deallocated/main.c
+++ b/regression/cbmc-primitives/r_w_ok_inconsistent_deallocated/main.c
@@ -1,0 +1,12 @@
+#include <assert.h>
+#include <stdlib.h>
+
+void main()
+{
+  char *p = malloc(1);
+  free(p);
+
+  __CPROVER_assume(__CPROVER_r_ok(p, 1));
+  assert(0); // fails
+  *p;        // succeeds
+}

--- a/regression/cbmc-primitives/r_w_ok_inconsistent_deallocated/test-no-cp.desc
+++ b/regression/cbmc-primitives/r_w_ok_inconsistent_deallocated/test-no-cp.desc
@@ -1,0 +1,13 @@
+FUTURE
+main.c
+--pointer-check --no-simplify --no-propagation
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring
+--
+Tests that an inconsistent assumption involving a pointer initialized to an
+integer address not pointing to memory and __CPROVER_r_ok() can be detected via
+assert(0). We use --no-simplify and --no-propagation to ensure that the case is
+not solved by the constant propagation and thus tests the constraint encoding.

--- a/regression/cbmc-primitives/r_w_ok_inconsistent_deallocated/test.desc
+++ b/regression/cbmc-primitives/r_w_ok_inconsistent_deallocated/test.desc
@@ -1,0 +1,12 @@
+FUTURE
+main.c
+--pointer-check
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring
+--
+Tests that an inconsistent assumption involving a pointer initialized to an
+integer address not pointing to memory and __CPROVER_r_ok() can be detected via
+assert(0).

--- a/regression/cbmc-primitives/r_w_ok_inconsistent_integer/main.c
+++ b/regression/cbmc-primitives/r_w_ok_inconsistent_integer/main.c
@@ -1,0 +1,14 @@
+#include <assert.h>
+#include <stdlib.h>
+
+void main()
+{
+  // pointer with object bits = 123 and offset = 123
+  // this is to test with a pointer that does not point to valid memory, but the
+  // value of which is otherwise not special in any way (like for example a null
+  // pointer)
+  char *p = (size_t)123 << (sizeof(char *) * 8 - 8) | 123;
+  __CPROVER_assume(__CPROVER_r_ok(p, 10));
+  assert(0); // fails
+  *p;        // succeeds
+}

--- a/regression/cbmc-primitives/r_w_ok_inconsistent_integer/test-no-cp.desc
+++ b/regression/cbmc-primitives/r_w_ok_inconsistent_integer/test-no-cp.desc
@@ -1,0 +1,13 @@
+FUTURE
+main.c
+--pointer-check --no-simplify --no-propagation
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring
+--
+Tests that an inconsistent assumption involving a pointer initialized to an
+integer address not pointing to memory and __CPROVER_r_ok() can be detected via
+assert(0). We use --no-simplify and --no-propagation to ensure that the case is
+not solved by the constant propagation and thus tests the constraint encoding.

--- a/regression/cbmc-primitives/r_w_ok_inconsistent_integer/test.desc
+++ b/regression/cbmc-primitives/r_w_ok_inconsistent_integer/test.desc
@@ -1,0 +1,12 @@
+FUTURE
+main.c
+--pointer-check
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring
+--
+Tests that an inconsistent assumption involving a pointer initialized to an
+integer address not pointing to memory and __CPROVER_r_ok() can be detected via
+assert(0).

--- a/regression/cbmc-primitives/r_w_ok_inconsistent_invalid/main.c
+++ b/regression/cbmc-primitives/r_w_ok_inconsistent_invalid/main.c
@@ -1,0 +1,12 @@
+#include <assert.h>
+#include <stdlib.h>
+
+void main()
+{
+  // special value of the invalid pointer (object bits = 1 and offset = 0), as
+  // checked for by __CPROVER_is_invalid_pointer()
+  char *p = (size_t)1 << (sizeof(char *) * 8 - 8);
+  __CPROVER_assume(__CPROVER_r_ok(p, 10));
+  assert(0); // fails
+  *p;        // succeeds
+}

--- a/regression/cbmc-primitives/r_w_ok_inconsistent_invalid/test-no-cp.desc
+++ b/regression/cbmc-primitives/r_w_ok_inconsistent_invalid/test-no-cp.desc
@@ -1,0 +1,13 @@
+CORE
+main.c
+--pointer-check --no-simplify --no-propagation
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring
+--
+Tests that an inconsistent assumption involving the special invalid pointer
+value and __CPROVER_r_ok() can be detected via assert(0). We use --no-simplify
+and --no-propagation to ensure that the case is not solved by the constant
+propagation and thus tests the constraint encoding.

--- a/regression/cbmc-primitives/r_w_ok_inconsistent_invalid/test.desc
+++ b/regression/cbmc-primitives/r_w_ok_inconsistent_invalid/test.desc
@@ -1,0 +1,11 @@
+CORE
+main.c
+--pointer-check
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring
+--
+Tests that an inconsistent assumption involving the special invalid pointer
+value and __CPROVER_r_ok() can be detected via assert(0).

--- a/regression/cbmc-primitives/r_w_ok_inconsistent_nondet/main.c
+++ b/regression/cbmc-primitives/r_w_ok_inconsistent_nondet/main.c
@@ -1,0 +1,11 @@
+#include <assert.h>
+
+char *nondet();
+
+void main()
+{
+  char *p = nondet();
+  __CPROVER_assume(__CPROVER_r_ok(p, 10));
+  assert(0); // fails
+  *p;        // succeeds
+}

--- a/regression/cbmc-primitives/r_w_ok_inconsistent_nondet/test-no-cp.desc
+++ b/regression/cbmc-primitives/r_w_ok_inconsistent_nondet/test-no-cp.desc
@@ -1,0 +1,13 @@
+FUTURE
+main.c
+--pointer-check --no-simplify --no-propagation
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring
+--
+Tests that an inconsistent assumption involving a nondet pointer and
+__CPROVER_r_ok() can be detected via assert(0). We use --no-simplify and
+--no-propagation to ensure that the case is not solved by the constant
+propagation and thus tests the constraint encoding.

--- a/regression/cbmc-primitives/r_w_ok_inconsistent_nondet/test.desc
+++ b/regression/cbmc-primitives/r_w_ok_inconsistent_nondet/test.desc
@@ -1,0 +1,11 @@
+FUTURE
+main.c
+--pointer-check
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring
+--
+Tests that an inconsistent assumption involving a nondet pointer and
+__CPROVER_r_ok() can be detected via assert(0).

--- a/regression/cbmc-primitives/r_w_ok_null/main.c
+++ b/regression/cbmc-primitives/r_w_ok_null/main.c
@@ -1,0 +1,8 @@
+#include <assert.h>
+#include <stdlib.h>
+
+void main()
+{
+  char *p = NULL;
+  assert(!__CPROVER_r_ok(p, 10));
+}

--- a/regression/cbmc-primitives/r_w_ok_null/test-no-cp.desc
+++ b/regression/cbmc-primitives/r_w_ok_null/test-no-cp.desc
@@ -1,0 +1,12 @@
+CORE
+main.c
+--pointer-check --no-simplify --no-propagation
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring
+--
+Tests that __CPROVER_r_ok() on a null pointers is false. We use --no-simplify
+and --no-propagation to ensure that the case is not solved by the constant
+propagation and thus tests the constraint encoding.

--- a/regression/cbmc-primitives/r_w_ok_null/test.desc
+++ b/regression/cbmc-primitives/r_w_ok_null/test.desc
@@ -1,0 +1,10 @@
+CORE
+main.c
+--pointer-check
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring
+--
+Tests that __CPROVER_r_ok() on a null pointers is false

--- a/regression/cbmc-primitives/r_w_ok_valid/main.c
+++ b/regression/cbmc-primitives/r_w_ok_valid/main.c
@@ -1,0 +1,19 @@
+#include <assert.h>
+#include <stdlib.h>
+
+char c1;
+
+void main()
+{
+  char c2;
+
+  char *p1 = &c1;
+  assert(__CPROVER_r_ok(p1, 1));
+
+  char *p2 = &c2;
+  assert(__CPROVER_r_ok(p2, 1));
+
+  char *p3 = malloc(1);
+  __CPROVER_assume(p1 != NULL);
+  assert(__CPROVER_r_ok(p3, 1));
+}

--- a/regression/cbmc-primitives/r_w_ok_valid/test-no-cp.desc
+++ b/regression/cbmc-primitives/r_w_ok_valid/test-no-cp.desc
@@ -1,0 +1,13 @@
+CORE
+main.c
+--pointer-check --no-simplify --no-propagation
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring
+--
+Tests that __CPROVER_r_ok() is true for valid pointers to global, local, or
+malloced memory. We use --no-simplify and --no-propagation to ensure that the
+case is not solved by the constant propagation and thus tests the constraint
+encoding.

--- a/regression/cbmc-primitives/r_w_ok_valid/test.desc
+++ b/regression/cbmc-primitives/r_w_ok_valid/test.desc
@@ -1,0 +1,11 @@
+CORE
+main.c
+--pointer-check
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring
+--
+Tests that __CPROVER_r_ok() is true for valid pointers to global, local, or
+malloced memory

--- a/regression/cbmc-primitives/r_w_ok_valid_negated/main.c
+++ b/regression/cbmc-primitives/r_w_ok_valid_negated/main.c
@@ -1,0 +1,34 @@
+#include <assert.h>
+#include <stdlib.h>
+
+char c1;
+
+void main()
+{
+  // We check the conditions for a pointer to global static memory (p1), a
+  // pointer to local memory (p2), and a pointer to dynamic memory (p3).
+  // For each pointer, we check:
+  // (1) whether it is unsafe to access one byte more than was allocated
+  // (2) whether it is unsafe to access one byte before the allocated memory
+  // (3) whether it is unsafe to access one byte after the allocated memory
+
+  char c2;
+
+  char *p1 = &c1;
+
+  assert(!__CPROVER_r_ok(p1, 2));
+  assert(!__CPROVER_r_ok(p1 - 1, 1));
+  assert(!__CPROVER_r_ok(p1 + 1, 1));
+
+  char *p2 = &c2;
+
+  assert(!__CPROVER_r_ok(p2, 2));
+  assert(!__CPROVER_r_ok(p2 - 1, 1));
+  assert(!__CPROVER_r_ok(p2 + 1, 1));
+
+  char *p3 = malloc(1);
+
+  assert(!__CPROVER_r_ok(p3, 2));
+  assert(!__CPROVER_r_ok(p3 - 1, 1));
+  assert(!__CPROVER_r_ok(p3 + 1, 1));
+}

--- a/regression/cbmc-primitives/r_w_ok_valid_negated/test-no-cp.desc
+++ b/regression/cbmc-primitives/r_w_ok_valid_negated/test-no-cp.desc
@@ -1,0 +1,13 @@
+KNOWNBUG
+main.c
+--pointer-check --no-simplify --no-propagation
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring
+--
+Tests that __CPROVER_r_ok() is false for a pointer to a valid memory object,
+though potentially with an offset that is out of bounds. We use --no-simplify
+and --no-propagation to ensure that the case is not solved by the constant
+propagation and thus tests the constraint encoding.

--- a/regression/cbmc-primitives/r_w_ok_valid_negated/test.desc
+++ b/regression/cbmc-primitives/r_w_ok_valid_negated/test.desc
@@ -1,0 +1,11 @@
+CORE
+main.c
+--pointer-check
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring
+--
+Tests that __CPROVER_r_ok() is false for a pointer to a valid memory object,
+though potentially with an offset that is out of bounds.


### PR DESCRIPTION
<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
