### PR TITLE
Fix Dockerfile for Xen integration test

### DIFF
--- a/integration/xen/Dockerfile
+++ b/integration/xen/Dockerfile
@@ -8,6 +8,7 @@ RUN apt-get update && apt-get --no-install-recommends -y install \
         libgtk2.0-dev libyajl-dev sudo time
 
 ADD integration/xen/docker_compile_xen.sh docker_compile_xen.sh
+ADD .git /tmp/cbmc/.git
 ADD src /tmp/cbmc/src
 ADD scripts /tmp/cbmc/scripts
 RUN ./docker_compile_xen.sh


### PR DESCRIPTION
This fixes the xen integration test. In  b96c7ba85781e7ca732aeb05eb940b7bb05ee2a1, the code for versioning was moved from version.h into the Makefile in src/util, and it uses the .git file in the CBMC top directory. This means that the dockerfile now needs access to that .git file.

There are no tests added in this PR because this PR fixes a broken test and makes no changes to CBMC itself.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- [n/a] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [n/a ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [n/a] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [n/a ] My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- [n/a] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
