### PR TITLE
Add a copy constructor for goto_program

### DIFF
--- a/src/goto-programs/goto_program.h
+++ b/src/goto-programs/goto_program.h
@@ -72,9 +72,8 @@ std::ostream &operator<<(std::ostream &, goto_program_instruction_typet);
 class goto_programt
 {
 public:
-  /// Copying is deleted as this class contains pointers that cannot be copied
-  goto_programt(const goto_programt &)=delete;
-  goto_programt &operator=(const goto_programt &)=delete;
+  goto_programt(const goto_programt &);
+  goto_programt &operator=(const goto_programt &other);
 
   // Move operations need to be explicitly enabled as they are deleted with the
   // copy operations
@@ -808,7 +807,7 @@ public:
   }
 
   /// Copy a full goto program, preserving targets
-  void copy_from(const goto_programt &src);
+  void copy_from(const goto_programt &other);
 
   /// Does the goto program have an assertion?
   bool has_assertion() const;

--- a/unit/Makefile
+++ b/unit/Makefile
@@ -23,6 +23,7 @@ SRC += analyses/ai/ai.cpp \
        goto-instrument/cover/cover_only.cpp \
        goto-programs/goto_model_function_type_consistency.cpp \
        goto-programs/goto_program_assume.cpp \
+       goto-programs/goto_program_copy_constructor.cpp \
        goto-programs/goto_program_dead.cpp \
        goto-programs/goto_program_declaration.cpp \
        goto-programs/goto_program_function_call.cpp \
@@ -34,8 +35,8 @@ SRC += analyses/ai/ai.cpp \
        goto-programs/is_goto_binary.cpp \
        goto-programs/label_function_pointer_call_sites.cpp \
        goto-programs/osx_fat_reader.cpp \
-       goto-programs/restrict_function_pointers.cpp \
        goto-programs/remove_returns.cpp \
+       goto-programs/restrict_function_pointers.cpp \
        goto-programs/xml_expr.cpp \
        goto-symex/apply_condition.cpp \
        goto-symex/expr_skeleton.cpp \

--- a/unit/goto-programs/goto_program_copy_constructor.cpp
+++ b/unit/goto-programs/goto_program_copy_constructor.cpp
@@ -1,0 +1,104 @@
+/*******************************************************************\
+
+Module: Unit tests for goto_programt copy constructor
+
+Author: Diffblue Ltd.
+
+\*******************************************************************/
+
+#include <goto-programs/goto_program.h>
+#include <testing-utils/get_goto_model_from_c.h>
+#include <testing-utils/use_catch.h>
+#include <util/arith_tools.h>
+#include <util/cmdline.h>
+#include <util/config.h>
+#include <util/std_expr.h>
+
+TEST_CASE(
+  "We can copy an empty goto program",
+  "[core][goto-programs][goto-program-copy]")
+{
+  auto const original_goto_program = goto_programt{};
+  auto const copy = original_goto_program;
+  REQUIRE(copy.empty());
+}
+
+TEST_CASE(
+  "We can copy a non-empty goto program that does not have jumps",
+  "[core][goto-programs][goto-program-copy]")
+{
+  config.set(cmdlinet{});
+  auto const original_goto_model = get_goto_model_from_c(
+    "int main(void) {\n"
+    "  int x = 0;\n"
+    "  int y = x + 1;\n"
+    "  return y;\n"
+    "}\n");
+  auto const &original_goto_program = original_goto_model.get_goto_functions()
+                                        .function_map.find("main")
+                                        ->second.body;
+  goto_programt goto_program_copy = original_goto_program;
+  auto original_it = original_goto_program.instructions.begin();
+  auto copy_it = goto_program_copy.instructions.begin();
+  for(; original_it != original_goto_program.instructions.end() &&
+        copy_it != goto_program_copy.instructions.end();
+      ++original_it, ++copy_it)
+  {
+    // Check that all instructions in both programs have the same type
+    REQUIRE(original_it->type == copy_it->type);
+  }
+  // Check that both goto programs have the same number of instructions
+  REQUIRE(original_it == original_goto_program.instructions.end());
+  REQUIRE(copy_it == goto_program_copy.instructions.end());
+}
+
+TEST_CASE(
+  "We can copy a goto-program with jumps",
+  "[core][goto-programs][goto-program-copy]")
+{
+  config.set(cmdlinet{});
+  auto const original_goto_model = get_goto_model_from_c(
+    "#include <assert.h>\n"
+    "\n"
+    "int main(void) {\n"
+    "  int x = 0;\n"
+    "  int y = 1;\n"
+    "  const int n = 10;\n"
+    "  for(int i = 0; i < n; ++i) {\n"
+    "    int tmp = y;\n"
+    "    y += x;\n"
+    "    x = tmp;\n"
+    "  }\n"
+    "  assert(y == 55);\n"
+    "}\n");
+  auto const &original_goto_program = original_goto_model.get_goto_functions()
+                                        .function_map.find("main")
+                                        ->second.body;
+  goto_programt goto_program_copy = original_goto_program;
+  auto original_it = original_goto_program.instructions.begin();
+  auto copy_it = goto_program_copy.instructions.begin();
+  for(; original_it != original_goto_program.instructions.end() &&
+        copy_it != goto_program_copy.instructions.end();
+      ++original_it, ++copy_it)
+  {
+    // Check that all instructions in both programs have the same type
+    REQUIRE(original_it->type == copy_it->type);
+
+    // check that the targets for all instructions match in original and copy
+    REQUIRE(original_it->targets.size() == copy_it->targets.size());
+    auto original_target_it = original_it->targets.begin();
+    auto copy_target_it = copy_it->targets.begin();
+
+    for(; original_target_it != original_it->targets.end() &&
+          copy_target_it != copy_it->targets.end();
+        ++original_target_it, ++copy_target_it)
+    {
+      REQUIRE((*original_target_it)->type == (*copy_target_it)->type);
+    }
+    REQUIRE(copy_target_it == copy_it->targets.end());
+    REQUIRE(original_target_it == original_it->targets.end());
+  }
+  // Check that both goto programs have the same number of instructions
+  REQUIRE(original_it == original_goto_program.instructions.end());
+  REQUIRE(copy_it == goto_program_copy.instructions.end());
+}


### PR DESCRIPTION
The absence of a copy constructor for `goto_programt` is currently preventing us from copying `goto_model`s. As far as I can the only problem with addying the copy constructor were the internal targets, which _should_ be local to each `goto_programt` and thus can be simply reconstructed from the offset to the start of the program.

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
