### PR TITLE
Add regression test for object accessed through integer pointer

### DIFF
--- a/regression/cbmc/integer-pointer/main.c
+++ b/regression/cbmc/integer-pointer/main.c
@@ -1,0 +1,17 @@
+#include <assert.h>
+#include <stdlib.h>
+
+void main()
+{
+  char *p = malloc(1);
+  __CPROVER_assume(__CPROVER_POINTER_OBJECT(p) == 2);
+  assert(0); // fails as expected
+
+  // same value as the malloc'd pointer above
+  char *q = (char *)((size_t)2 << sizeof(char *) * 8 - 8);
+
+  *p = 1;
+  *q = 2;
+
+  assert(*p == 1); // currently succeeds
+}

--- a/regression/cbmc/integer-pointer/test.desc
+++ b/regression/cbmc/integer-pointer/test.desc
@@ -1,0 +1,13 @@
+KNOWNBUG
+main.c
+--pointer-check --no-simplify --no-propagation
+^EXIT=10$
+^SIGNAL=0$
+\[main.assertion.1\] .*: FAILURE
+\[main.assertion.2\] .*: FAILURE
+--
+^warning: ignoring
+--
+The assertion should fail as q has the same value as p. However since q was
+initialized via an integer literal it points into __CPROVER_memory, and not to
+the malloced memory. Issue #5327.


### PR DESCRIPTION
This is probably a known issue.

@kroening @tautschnig @peterschrammel Do we have a test for that already?

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
