### PR TITLE
Make min unwind consistent with unwind

### DIFF
--- a/regression/cbmc-incr-oneloop/ignore-before-unwind/include_first_unwind0.desc
+++ b/regression/cbmc-incr-oneloop/ignore-before-unwind/include_first_unwind0.desc
@@ -1,0 +1,12 @@
+CORE
+main.c
+--ignore-properties-before-unwind-min --incremental-loop main.0 --unwind-max 2 --unwind-min 0
+^EXIT=10$
+^SIGNAL=0$
+^\[main.assertion.\d+\] line \d+ property: FAILURE$
+^VERIFICATION FAILED$
+--
+^warning: ignoring
+--
+This test correctly fails because the first iteration of the loop violates the
+property.

--- a/regression/cbmc-incr-oneloop/ignore-before-unwind/include_first_unwind1.desc
+++ b/regression/cbmc-incr-oneloop/ignore-before-unwind/include_first_unwind1.desc
@@ -1,0 +1,12 @@
+CORE
+main.c
+--ignore-properties-before-unwind-min --incremental-loop main.0 --unwind-max 2 --unwind-min 1
+^EXIT=10$
+^SIGNAL=0$
+^\[main.assertion.\d+\] line \d+ property: FAILURE$
+^VERIFICATION FAILED$
+--
+^warning: ignoring
+--
+This test correctly fails because the first iteration of the loop violates the
+property.

--- a/regression/cbmc-incr-oneloop/ignore-before-unwind/skip_first_unwind.desc
+++ b/regression/cbmc-incr-oneloop/ignore-before-unwind/skip_first_unwind.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---ignore-properties-before-unwind-min --incremental-loop main.0 --unwind-max 2 --unwind-min 1
+--ignore-properties-before-unwind-min --incremental-loop main.0 --unwind-max 2 --unwind-min 2
 ^EXIT=0$
 ^SIGNAL=0$
 ^VERIFICATION SUCCESSFUL$

--- a/src/goto-checker/bmc_util.h
+++ b/src/goto-checker/bmc_util.h
@@ -221,6 +221,11 @@ void run_property_decider(
   "                              of loop L\n" \
   "                              (use --show-loops to get the loop IDs)\n" \
   " --unwind-min nr              start incremental-loop after nr unwindings\n" \
+  "                              but before solving that iteration. If for\n" \
+  "                              example it is 1, then the loop will be\n" \
+  "                              unwound once, and immediately checked.\n" \
+  "                              Note: this means for min-unwind 1 or\n"\
+  "                              0 all properties are checked.\n" \
   " --unwind-max nr              stop incremental-loop after nr unwindings\n" \
   " --ignore-properties-before-unwind-min\n" \
   "                              do not check properties before unwind-min\n" \

--- a/src/goto-checker/symex_bmc_incremental_one_loop.cpp
+++ b/src/goto-checker/symex_bmc_incremental_one_loop.cpp
@@ -37,8 +37,12 @@ symex_bmc_incremental_one_loopt::symex_bmc_incremental_one_loopt(
                                    : 0),
     output_ui(output_ui)
 {
+  // the intended behaviour is to stop asserts that are violated before the
+  // unwind
+  // therefore if the min-unwind is 1, then we do one unwind and immediately
+  // start checking for properties
   ignore_assertions =
-    incr_min_unwind >= 1 &&
+    incr_min_unwind > 1 &&
     options.get_bool_option("ignore-properties-before-unwind-min");
 }
 


### PR DESCRIPTION
- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [na] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

Ideally there should be documentation for the incremental feature in the docs, but it doesn't seem to be present. @peterschrammel are you aware of any that can be imported in?
