### PR TITLE
remove deprecated split_string variant

### DIFF
--- a/src/memory-analyzer/memory_analyzer_parse_options.cpp
+++ b/src/memory-analyzer/memory_analyzer_parse_options.cpp
@@ -97,8 +97,7 @@ int memory_analyzer_parse_optionst::doit()
   std::string binary = cmdline.args.front();
 
   const std::string symbol_list(cmdline.get_value("symbols"));
-  std::vector<std::string> result;
-  split_string(symbol_list, ',', result, true, true);
+  std::vector<std::string> result = split_string(symbol_list, ',', true, true);
 
   auto opt = read_goto_binary(binary, ui_message_handler);
 

--- a/src/util/string_utils.cpp
+++ b/src/util/string_utils.cpp
@@ -99,9 +99,8 @@ void split_string(
   // delim can't be a space character if using strip
   PRECONDITION(!std::isspace(delim) || !strip);
 
-  std::vector<std::string> result;
+  std::vector<std::string> result = split_string(s, delim, strip);
 
-  split_string(s, delim, result, strip);
   if(result.size() != 2)
   {
     throw deserialization_exceptiont{"expected string '" + s +

--- a/src/util/string_utils.h
+++ b/src/util/string_utils.h
@@ -20,35 +20,22 @@ std::string strip_string(const std::string &s);
 
 std::string capitalize(const std::string &str);
 
-/// Given a string s, split into a sequence of substrings when separated by
-/// specified delimiter.
-/// \param s: The string to split up
-/// \param delim: The character to use as the delimiter
-/// \param [out] result: The sub strings. Must be empty.
-/// \param strip: If true, strip_string will be used on each element, removing
-///   whitespace from the beginning and end of each element
-/// \param remove_empty: If true, all empty-string elements will be removed.
-///   This is applied after strip so whitespace only elements will be removed if
-///   both are set to true.
-DEPRECATED(SINCE(
-  2019,
-  11,
-  14,
-  "use split_string(s, delim, strip, remove_empty) instead"))
-void split_string(
-  const std::string &s,
-  char delim,
-  std::vector<std::string> &result,
-  bool strip = false,
-  bool remove_empty = false);
-
 void split_string(
   const std::string &s,
   char delim,
   std::string &left,
   std::string &right,
-  bool strip=false);
+  bool strip = false);
 
+/// Given a string s, split into a sequence of substrings when separated by
+/// specified delimiter.
+/// \param s: The string to split up
+/// \param delim: The character to use as the delimiter
+/// \param strip: If true, strip_string will be used on each element, removing
+///   whitespace from the beginning and end of each element
+/// \param remove_empty: If true, all empty-string elements will be removed.
+///   This is applied after strip so whitespace only elements will be removed if
+///   both are set to true.
 std::vector<std::string> split_string(
   const std::string &s,
   char delim,


### PR DESCRIPTION
This function has been deprecated since 14.11.2019, and the replacement is
easy to put in place.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
