### PR TITLE
remove two deprecated codet-related constructors/methods

### DIFF
--- a/jbmc/src/java_bytecode/java_bytecode_convert_method.cpp
+++ b/jbmc/src/java_bytecode/java_bytecode_convert_method.cpp
@@ -1762,7 +1762,8 @@ java_bytecode_convert_methodt::convert_instructions(const methodt &method)
     // instruction before the actual instruction:
     if(catch_instruction.has_value())
     {
-      c.make_block();
+      if(c.get_statement() != ID_block)
+        c = code_blockt{{c}};
       c.operands().insert(c.operands().begin(), *catch_instruction);
     }
 
@@ -1832,12 +1833,16 @@ java_bytecode_convert_methodt::convert_instructions(const methodt &method)
         }
         else
         {
-          c.make_block();
+          if(c.get_statement() != ID_block)
+            c = code_blockt{{c}};
+
           auto &last_statement=to_code_block(c).find_last_statement();
           if(last_statement.get_statement()==ID_goto)
           {
             // Insert stack twiddling before branch:
-            last_statement.make_block();
+            if(last_statement.get_statement() != ID_block)
+              last_statement = code_blockt{{last_statement}};
+
             last_statement.operands().insert(
               last_statement.operands().begin(),
               more_code.statements().begin(),

--- a/src/cpp/cpp_typecheck_compound_type.cpp
+++ b/src/cpp/cpp_typecheck_compound_type.cpp
@@ -669,15 +669,13 @@ void cpp_typecheckt::typecheck_compound_declarator(
         {
           expr_call.type()=to_code_type(component.type()).return_type();
 
-          func_symb.value =
-            code_returnt(already_typechecked_exprt{std::move(expr_call)})
-              .make_block();
+          func_symb.value = code_blockt{
+            {code_returnt(already_typechecked_exprt{std::move(expr_call)})}};
         }
         else
         {
-          func_symb.value =
-            code_expressiont(already_typechecked_exprt{std::move(expr_call)})
-              .make_block();
+          func_symb.value = code_blockt{{code_expressiont(
+            already_typechecked_exprt{std::move(expr_call)})}};
         }
 
         // add this new function to the list of components
@@ -1241,7 +1239,8 @@ void cpp_typecheckt::move_member_initializers(
       throw 0;
     }
 
-    to_code(value).make_block();
+    if(to_code(value).get_statement() != ID_block)
+      value = code_blockt{{to_code(value)}};
 
     exprt::operandst::iterator o_it=value.operands().begin();
     forall_irep(it, initializers.get_sub())

--- a/src/goto-instrument/goto_program2code.cpp
+++ b/src/goto-instrument/goto_program2code.cpp
@@ -1257,10 +1257,9 @@ goto_programt::const_targett goto_program2codet::convert_start_thread(
       {
         labels_in_use.insert(*it);
 
-        code_labelt l(*it);
-        l.code().swap(b);
+        code_labelt l(*it, std::move(b));
         l.add_source_location()=target->source_location;
-        b.swap(l);
+        b = std::move(l);
       }
 
     assert(b.get_statement()==ID_label);
@@ -1323,10 +1322,9 @@ goto_programt::const_targett goto_program2codet::convert_start_thread(
     {
       labels_in_use.insert(*it);
 
-      code_labelt l(*it);
-      l.code().swap(b);
+      code_labelt l(*it, std::move(b));
       l.add_source_location()=target->source_location;
-      b.swap(l);
+      b = std::move(l);
     }
 
   assert(b.get_statement()==ID_label);

--- a/src/util/std_code.cpp
+++ b/src/util/std_code.cpp
@@ -16,24 +16,6 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "std_expr.h"
 #include "string_constant.h"
 
-/// If this `codet` is a \ref code_blockt (i.e.\ it represents a block of
-/// statements), return the unmodified input. Otherwise (i.e.\ the `codet`
-/// represents a single statement), convert it to a \ref code_blockt with the
-/// original statement as its only operand and return the result.
-code_blockt &codet::make_block()
-{
-  if(get_statement()==ID_block)
-    return static_cast<code_blockt &>(*this);
-
-  exprt tmp;
-  tmp.swap(*this);
-
-  *this = codet(ID_block);
-  add_to_operands(std::move(tmp));
-
-  return static_cast<code_blockt &>(*this);
-}
-
 /// In the case of a `codet` type that represents multiple statements, return
 /// the first of them. Otherwise return the `codet` itself.
 codet &codet::first_statement()

--- a/src/util/std_code.h
+++ b/src/util/std_code.h
@@ -78,9 +78,6 @@ public:
   codet &last_statement();
   const codet &last_statement() const;
 
-  DEPRECATED(SINCE(2019, 2, 6, "use code_blockt(...) instead"))
-  class code_blockt &make_block();
-
   /// Check that the code statement is well-formed (shallow checks only, i.e.,
   /// enclosed statements, subexpressions, etc. are not checked)
   ///
@@ -1377,13 +1374,6 @@ inline code_returnt &to_code_return(codet &code)
 class code_labelt:public codet
 {
 public:
-  DEPRECATED(SINCE(2019, 2, 6, "use code_labelt(label, _code) instead"))
-  explicit code_labelt(const irep_idt &_label):codet(ID_label)
-  {
-    operands().resize(1);
-    set_label(_label);
-  }
-
   code_labelt(const irep_idt &_label, codet _code)
     : codet(ID_label, {std::move(_code)})
   {


### PR DESCRIPTION
Both have been deprecated since 6.2.2019.  Both have easy to apply
replacements.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
