### PR TITLE
gen_nondet_array_init: arrays may have size 0

### DIFF
--- a/src/ansi-c/c_nondet_symbol_factory.cpp
+++ b/src/ansi-c/c_nondet_symbol_factory.cpp
@@ -172,9 +172,9 @@ void symbol_factoryt::gen_nondet_array_init(
   auto const &array_type = to_array_type(expr.type());
   const auto &size = array_type.size();
   PRECONDITION(size.id() == ID_constant);
-  auto const array_size = numeric_cast_v<size_t>(to_constant_expr(size));
+  auto const array_size = numeric_cast_v<mp_integer>(to_constant_expr(size));
   DATA_INVARIANT(array_size >= 0, "Arrays must have non-negative size");
-  for(size_t index = 0; index < array_size; ++index)
+  for(mp_integer index = 0; index < array_size; ++index)
   {
     gen_nondet_init(
       assignments,

--- a/src/ansi-c/c_nondet_symbol_factory.cpp
+++ b/src/ansi-c/c_nondet_symbol_factory.cpp
@@ -173,7 +173,7 @@ void symbol_factoryt::gen_nondet_array_init(
   const auto &size = array_type.size();
   PRECONDITION(size.id() == ID_constant);
   auto const array_size = numeric_cast_v<size_t>(to_constant_expr(size));
-  DATA_INVARIANT(array_size > 0, "Arrays should have positive size");
+  DATA_INVARIANT(array_size >= 0, "Arrays must have non-negative size");
   for(size_t index = 0; index < array_size; ++index)
   {
     gen_nondet_init(


### PR DESCRIPTION
The various C standards clearly allow arrays of size 0.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
