### PR TITLE
Treat uninitialized pointers like unknown pointers in address_check()

### DIFF
--- a/regression/cbmc/pointer-check-01/test.c
+++ b/regression/cbmc/pointer-check-01/test.c
@@ -1,0 +1,9 @@
+void main()
+{
+  char *p;
+
+  if(p == 0)
+  {
+    *p;
+  }
+}

--- a/regression/cbmc/pointer-check-01/test.desc
+++ b/regression/cbmc/pointer-check-01/test.desc
@@ -1,0 +1,9 @@
+CORE
+test.c
+--pointer-check
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring
+--
+Check that pointer check for *p fails when its value is constrained to 0

--- a/regression/cbmc/pointer-check-02/test.c
+++ b/regression/cbmc/pointer-check-02/test.c
@@ -1,0 +1,11 @@
+void main()
+{
+  char *p;
+
+  {
+    int i;
+    __CPROVER_assume(p == &i);
+  }
+
+  *p;
+}

--- a/regression/cbmc/pointer-check-02/test.desc
+++ b/regression/cbmc/pointer-check-02/test.desc
@@ -1,0 +1,10 @@
+CORE
+test.c
+--pointer-check
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring
+--
+Check that pointer check for *p fails when its value is constrained to point to
+an out-of-scope local variable

--- a/regression/cbmc/pointer-extra-checks/test.desc
+++ b/regression/cbmc/pointer-extra-checks/test.desc
@@ -8,7 +8,13 @@ main.c
 ^\[main.pointer_dereference.3\] .* dereference failure: pointer outside object bounds in \*q: SUCCESS$
 ^\[main.pointer_dereference.4\] .* dereference failure: deallocated dynamic object in \*r: SUCCESS$
 ^\[main.pointer_dereference.5\] .* dereference failure: pointer outside dynamic object bounds in \*r: SUCCESS$
-^\[main.pointer_dereference.6\] .* dereference failure: pointer uninitialized in \*s: FAILURE$
+^\[main.pointer_dereference.6\] .* dereference failure: pointer invalid in \*s: FAILURE$
+^\[main.pointer_dereference.7\] .* dereference failure: pointer NULL in \*s: FAILURE$
+^\[main.pointer_dereference.8\] .* dereference failure: deallocated dynamic object in \*s: FAILURE$
+^\[main.pointer_dereference.9\] .* dereference failure: dead object in \*s: FAILURE$
+^\[main.pointer_dereference.10\] .* dereference failure: pointer outside dynamic object bounds in \*s: FAILURE$
+^\[main.pointer_dereference.11\] .* dereference failure: pointer outside object bounds in \*s: FAILURE$
+^\[main.pointer_dereference.12\] .* dereference failure: invalid integer address in \*s: FAILURE$
 ^VERIFICATION FAILED$
 --
 ^warning: ignoring
@@ -28,12 +34,6 @@ main.c
 ^\[main.pointer_dereference.[0-9]+\] .* dereference failure: pointer uninitialized in \*r:
 ^\[main.pointer_dereference.[0-9]+\] .* dereference failure: dead object in \*r:
 ^\[main.pointer_dereference.[0-9]+\] .* dereference failure: pointer outside object bounds in \*r:
-^\[main.pointer_dereference.[0-9]+\] .* dereference failure: pointer NULL in \*s:
-^\[main.pointer_dereference.[0-9]+\] .* dereference failure: pointer invalid in \*s:
-^\[main.pointer_dereference.[0-9]+\] .* dereference failure: deallocated dynamic object in \*s:
-^\[main.pointer_dereference.[0-9]+\] .* dereference failure: dead object in \*s:
-^\[main.pointer_dereference.[0-9]+\] .* dereference failure: pointer outside dynamic object bounds in \*s:
-^\[main.pointer_dereference.[0-9]+\] .* dereference failure: pointer outside object bounds in \*s:
 --
 This test ensures that local_bitvector_analysis is correctly labelling obvious
 cases of pointers and that --pointer-check is not generating excess assertions.

--- a/regression/goto-harness/pointer-to-array-function-parameters-with-size/test.desc
+++ b/regression/goto-harness/pointer-to-array-function-parameters-with-size/test.desc
@@ -3,8 +3,8 @@ test.c
 --harness-type call-function --function test --treat-pointer-as-array arr --associated-array-size arr:sz
 ^EXIT=0$
 ^SIGNAL=0$
-\[test.pointer_dereference.1\] line \d+ dereference failure: pointer NULL in arr\[\(signed( long)* int\)i\]: SUCCESS
-\[test.pointer_dereference.2\] line \d+ dereference failure: pointer invalid in arr\[\(signed( long)* int\)i\]: SUCCESS
+\[test.pointer_dereference.1\] line \d+ dereference failure: pointer invalid in arr\[\(signed( long)* int\)i\]: SUCCESS
+\[test.pointer_dereference.2\] line \d+ dereference failure: pointer NULL in arr\[\(signed( long)* int\)i\]: SUCCESS
 \[test.pointer_dereference.3\] line \d+ dereference failure: deallocated dynamic object in arr\[\(signed( long)* int\)i\]: SUCCESS
 \[test.pointer_dereference.4\] line \d+ dereference failure: dead object in arr\[\(signed( long)* int\)i\]: SUCCESS
 \[test.pointer_dereference.5\] line \d+ dereference failure: pointer outside dynamic object bounds in arr\[\(signed( long)* int\)i\]: SUCCESS


### PR DESCRIPTION
Fixes #5332

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
