### PR TITLE
Add stub implementations for value set classes

### DIFF
--- a/src/analyses/Makefile
+++ b/src/analyses/Makefile
@@ -51,7 +51,11 @@ SRC = ai.cpp \
       variable-sensitivity/value_set_abstract_object.cpp \
       variable-sensitivity/variable_sensitivity_dependence_graph.cpp \
       variable-sensitivity/interval_abstract_value.cpp \
-			variable-sensitivity/interval_array_abstract_object.cpp \
+      variable-sensitivity/interval_array_abstract_object.cpp \
+      variable-sensitivity/value_set_abstract_object.cpp \
+      variable-sensitivity/value_set_abstract_value.cpp \
+      variable-sensitivity/value_set_pointer_abstract_object.cpp \
+      variable-sensitivity/value_set_array_abstract_object.cpp \
       # Empty last line
 
 INCLUDES= -I ..

--- a/src/analyses/variable-sensitivity/value_set_abstract_value.cpp
+++ b/src/analyses/variable-sensitivity/value_set_abstract_value.cpp
@@ -1,0 +1,14 @@
+/*******************************************************************\
+
+ Module: analyses variable-sensitivity variable-sensitivity-value-set
+
+ Author: Diffblue Ltd.
+
+\*******************************************************************/
+
+#include "value_set_abstract_value.h"
+
+value_set_abstract_valuet::value_set_abstract_valuet(const typet &type)
+  : abstract_valuet(type)
+{
+}

--- a/src/analyses/variable-sensitivity/value_set_abstract_value.h
+++ b/src/analyses/variable-sensitivity/value_set_abstract_value.h
@@ -1,0 +1,27 @@
+/*******************************************************************\
+
+ Module: analyses variable-sensitivity variable-sensitivity-value-set
+
+ Author: Diffblue Ltd.
+
+\*******************************************************************/
+
+/// \file
+/// Value sets for primitives
+
+// NOLINTNEXTLINE(whitespace/line_length)
+#ifndef CPROVER_ANALYSES_VARIABLE_SENSITIVITY_VALUE_SET_ABSTRACT_VALUE_H
+// NOLINTNEXTLINE(whitespace/line_length)
+#define CPROVER_ANALYSES_VARIABLE_SENSITIVITY_VALUE_SET_ABSTRACT_VALUE_H
+
+#include "abstract_value.h"
+
+class value_set_abstract_valuet : public abstract_valuet
+{
+public:
+  explicit value_set_abstract_valuet(const typet &type);
+  CLONE
+};
+
+// NOLINTNEXTLINE(whitespace/line_length)
+#endif // CPROVER_ANALYSES_VARIABLE_SENSITIVITY_VALUE_SET_ABSTRACT_VALUE_H

--- a/src/analyses/variable-sensitivity/value_set_array_abstract_object.cpp
+++ b/src/analyses/variable-sensitivity/value_set_array_abstract_object.cpp
@@ -1,0 +1,56 @@
+/*******************************************************************\
+
+ Module: analyses variable-sensitivity variable-sensitivity-value-set
+
+ Author: Diffblue Ltd.
+
+\*******************************************************************/
+
+#include "value_set_array_abstract_object.h"
+
+value_set_array_abstract_objectt::value_set_array_abstract_objectt(
+  const typet &type)
+  : array_abstract_objectt(type)
+{
+}
+
+abstract_object_pointert value_set_array_abstract_objectt::read(
+  const abstract_environmentt &env,
+  const exprt &specifier,
+  const namespacet &ns) const
+{
+  return array_abstract_objectt::read(env, specifier, ns);
+}
+
+abstract_object_pointert value_set_array_abstract_objectt::write(
+  abstract_environmentt &environment,
+  const namespacet &ns,
+  std::stack<exprt> stack,
+  const exprt &specifier,
+  abstract_object_pointert value,
+  bool merging_write) const
+{
+  return array_abstract_objectt::write(
+    environment, ns, stack, specifier, value, merging_write);
+}
+
+abstract_object_pointert value_set_array_abstract_objectt::read_index(
+  const abstract_environmentt &env,
+  const index_exprt &index,
+  const namespacet &ns) const
+{
+  return array_abstract_objectt::read_index(env, index, ns);
+}
+
+sharing_ptrt<array_abstract_objectt>
+value_set_array_abstract_objectt::write_index(
+  abstract_environmentt &environment,
+  const namespacet &ns,
+  std::stack<exprt> stack,
+  const index_exprt &index_expr,
+  abstract_object_pointert value,
+  bool merging_write) const
+{
+  return array_abstract_objectt::write_index(
+    environment, ns, stack, index_expr, value, merging_write);
+}

--- a/src/analyses/variable-sensitivity/value_set_array_abstract_object.h
+++ b/src/analyses/variable-sensitivity/value_set_array_abstract_object.h
@@ -1,0 +1,54 @@
+/*******************************************************************\
+
+ Module: analyses variable-sensitivity variable-sensitivity-value-set
+
+ Author: Diffblue Ltd.
+
+\*******************************************************************/
+
+/// \file
+/// Arrays with value sets as indices
+
+// NOLINTNEXTLINE(whitespace/line_length)
+#ifndef CPROVER_ANALYSES_VARIABLE_SENSITIVITY_VALUE_SET_ARRAY_ABSTRACT_OBJECT_H
+// NOLINTNEXTLINE(whitespace/line_length)
+#define CPROVER_ANALYSES_VARIABLE_SENSITIVITY_VALUE_SET_ARRAY_ABSTRACT_OBJECT_H
+
+#include "array_abstract_object.h"
+
+class value_set_array_abstract_objectt : public array_abstract_objectt
+{
+public:
+  explicit value_set_array_abstract_objectt(const typet &type);
+
+  abstract_object_pointert read(
+    const abstract_environmentt &env,
+    const exprt &specifier,
+    const namespacet &ns) const override;
+
+  abstract_object_pointert write(
+    abstract_environmentt &environment,
+    const namespacet &ns,
+    std::stack<exprt> stack,
+    const exprt &specifier,
+    abstract_object_pointert value,
+    bool merging_write) const override;
+
+  CLONE
+protected:
+  abstract_object_pointert read_index(
+    const abstract_environmentt &env,
+    const index_exprt &index,
+    const namespacet &ns) const override;
+
+  sharing_ptrt<array_abstract_objectt> write_index(
+    abstract_environmentt &environment,
+    const namespacet &ns,
+    std::stack<exprt> stack,
+    const index_exprt &index_expr,
+    abstract_object_pointert value,
+    bool merging_write) const override;
+};
+
+// NOLINTNEXTLINE(whitespace/line_length)
+#endif // CPROVER_ANALYSES_VARIABLE_SENSITIVITY_VALUE_SET_ARRAY_ABSTRACT_OBJECT_H

--- a/src/analyses/variable-sensitivity/value_set_pointer_abstract_object.cpp
+++ b/src/analyses/variable-sensitivity/value_set_pointer_abstract_object.cpp
@@ -1,0 +1,60 @@
+
+/*******************************************************************\
+
+ Module: analyses variable-sensitivity variable-sensitivity-value-set
+
+ Author: Diffblue Ltd.
+
+\*******************************************************************/
+
+#include "value_set_pointer_abstract_object.h"
+
+abstract_object_pointert
+value_set_pointer_abstract_objectt::merge(abstract_object_pointert other) const
+{
+  return shared_from_this();
+}
+
+abstract_object_pointert value_set_pointer_abstract_objectt::read(
+  const abstract_environmentt &env,
+  const exprt &specifier,
+  const namespacet &ns) const
+{
+  return pointer_abstract_objectt::read(env, specifier, ns);
+}
+
+abstract_object_pointert value_set_pointer_abstract_objectt::write(
+  abstract_environmentt &environment,
+  const namespacet &ns,
+  std::stack<exprt> stack,
+  const exprt &specifier,
+  abstract_object_pointert value,
+  bool merging_write) const
+{
+  return pointer_abstract_objectt::write(
+    environment, ns, stack, specifier, value, merging_write);
+}
+
+value_set_pointer_abstract_objectt::value_set_pointer_abstract_objectt(
+  const typet &type)
+  : pointer_abstract_objectt(type)
+{
+}
+abstract_object_pointert value_set_pointer_abstract_objectt::read_dereference(
+  const abstract_environmentt &env,
+  const namespacet &ns) const
+{
+  return pointer_abstract_objectt::read_dereference(env, ns);
+}
+
+sharing_ptrt<pointer_abstract_objectt>
+value_set_pointer_abstract_objectt::write_dereference(
+  abstract_environmentt &environment,
+  const namespacet &ns,
+  std::stack<exprt> stack,
+  abstract_object_pointert value,
+  bool merging_write) const
+{
+  return pointer_abstract_objectt::write_dereference(
+    environment, ns, stack, value, merging_write);
+}

--- a/src/analyses/variable-sensitivity/value_set_pointer_abstract_object.h
+++ b/src/analyses/variable-sensitivity/value_set_pointer_abstract_object.h
@@ -1,0 +1,54 @@
+/*******************************************************************\
+
+ Module: analyses variable-sensitivity variable-sensitivity-value-set
+
+ Author: Diffblue Ltd.
+
+\*******************************************************************/
+
+/// \file
+/// Pointers pointing to a limited-size set of possible targets
+
+// NOLINTNEXTLINE(whitespace/line_length)
+#ifndef CPROVER_ANALYSES_VARIABLE_SENSITIVITY_VALUE_SET_POINTER_ABSTRACT_OBJECT_H
+// NOLINTNEXTLINE(whitespace/line_length)
+#define CPROVER_ANALYSES_VARIABLE_SENSITIVITY_VALUE_SET_POINTER_ABSTRACT_OBJECT_H
+
+#include "pointer_abstract_object.h"
+
+class value_set_pointer_abstract_objectt : public pointer_abstract_objectt
+{
+public:
+  explicit value_set_pointer_abstract_objectt(const typet &type);
+
+  abstract_object_pointert merge(abstract_object_pointert other) const override;
+
+  abstract_object_pointert read(
+    const abstract_environmentt &env,
+    const exprt &specifier,
+    const namespacet &ns) const override;
+
+  abstract_object_pointert write(
+    abstract_environmentt &environment,
+    const namespacet &ns,
+    std::stack<exprt> stack,
+    const exprt &specifier,
+    abstract_object_pointert value,
+    bool merging_write) const override;
+
+  CLONE
+protected:
+  abstract_object_pointert read_dereference(
+    const abstract_environmentt &env,
+    const namespacet &ns) const override;
+
+  sharing_ptrt<pointer_abstract_objectt> write_dereference(
+    abstract_environmentt &environment,
+    const namespacet &ns,
+    std::stack<exprt> stack,
+    abstract_object_pointert value,
+    bool merging_write) const override;
+};
+
+// NOLINTNEXTLINE(whitespace/line_length)
+#endif // CPROVER_ANALYSES_VARIABLE_SENSITIVITY_VALUE_SET_POINTER_ABSTRACT_OBJECT_H

--- a/unit/Makefile
+++ b/unit/Makefile
@@ -21,6 +21,9 @@ SRC += analyses/ai/ai.cpp \
        analyses/variable-sensitivity/full_struct_abstract_object/merge.cpp \
        analyses/variable-sensitivity/interval_abstract_value/meet.cpp \
        analyses/variable-sensitivity/last_written_location.cpp \
+       analyses/variable-sensitivity/value_set/abstract_value.cpp \
+       analyses/variable-sensitivity/value_set/array_abstract_object.cpp \
+       analyses/variable-sensitivity/value_set/pointer_abstract_object.cpp \
        big-int/big-int.cpp \
        compound_block_locations.cpp \
        get_goto_model_from_c_test.cpp \

--- a/unit/analyses/variable-sensitivity/value_set/abstract_value.cpp
+++ b/unit/analyses/variable-sensitivity/value_set/abstract_value.cpp
@@ -1,0 +1,19 @@
+/*******************************************************************\
+
+Module: Unit tests for value set abstract values
+
+Author: Diffblue Ltd.
+
+\*******************************************************************/
+
+#include "value_set_test_common.h"
+#include <analyses/variable-sensitivity/value_set_abstract_value.h>
+
+TEST_CASE(
+  "A value set abstract object created from type is top",
+  VALUE_SET_TEST_TAGS)
+{
+  value_set_abstract_valuet abstract_value(signedbv_typet{32});
+  REQUIRE(abstract_value.is_top());
+  REQUIRE(!abstract_value.is_bottom());
+}

--- a/unit/analyses/variable-sensitivity/value_set/array_abstract_object.cpp
+++ b/unit/analyses/variable-sensitivity/value_set/array_abstract_object.cpp
@@ -1,0 +1,21 @@
+/*******************************************************************\
+
+Module: Unit tests for value set array abstract values
+
+Author: Diffblue Ltd.
+
+\*******************************************************************/
+
+#include "value_set_test_common.h"
+#include <analyses/variable-sensitivity/value_set_array_abstract_object.h>
+#include <util/arith_tools.h>
+
+TEST_CASE(
+  "A value set array abstract object created from type is top",
+  VALUE_SET_TEST_TAGS)
+{
+  value_set_array_abstract_objectt abstract_object{
+    array_typet{signedbv_typet{32}, from_integer(1, unsignedbv_typet{32})}};
+  REQUIRE(abstract_object.is_top());
+  REQUIRE(!abstract_object.is_bottom());
+}

--- a/unit/analyses/variable-sensitivity/value_set/module_dependencies.txt
+++ b/unit/analyses/variable-sensitivity/value_set/module_dependencies.txt
@@ -1,0 +1,3 @@
+analyses
+testing-utils
+util

--- a/unit/analyses/variable-sensitivity/value_set/pointer_abstract_object.cpp
+++ b/unit/analyses/variable-sensitivity/value_set/pointer_abstract_object.cpp
@@ -1,0 +1,20 @@
+/*******************************************************************\
+
+Module: Unit tests for value set pointer abstract objects
+
+Author: Diffblue Ltd.
+
+\*******************************************************************/
+
+#include "value_set_test_common.h"
+#include <analyses/variable-sensitivity/value_set_pointer_abstract_object.h>
+
+TEST_CASE(
+  "A value set pointer abstract object created from type is top",
+  VALUE_SET_TEST_TAGS)
+{
+  value_set_pointer_abstract_objectt abstract_object(
+    pointer_typet(signedbv_typet{32}, 32));
+  REQUIRE(abstract_object.is_top());
+  REQUIRE(!abstract_object.is_bottom());
+}

--- a/unit/analyses/variable-sensitivity/value_set/value_set_test_common.h
+++ b/unit/analyses/variable-sensitivity/value_set/value_set_test_common.h
@@ -1,0 +1,18 @@
+/*******************************************************************\
+
+Module: Unit tests for value set pointer abstract objects
+
+Author: Diffblue Ltd.
+
+\*******************************************************************/
+
+// NOLINTNEXTLINE(whitespace/line_length)
+#ifndef CPROVER_ANALYSES_VARIABLE_SENSITIVITY_VALUE_SET_VALUE_SET_TEST_COMMON_H
+// NOLINTNEXTLINE(whitespace/line_length)
+#define CPROVER_ANALYSES_VARIABLE_SENSITIVITY_VALUE_SET_VALUE_SET_TEST_COMMON_H
+
+#include <testing-utils/use_catch.h>
+#define VALUE_SET_TEST_TAGS "[core][analyses][variable-sensitivity][value-set]"
+
+// NOLINTNEXTLINE(whitespace/line_length)
+#endif // CPROVER_ANALYSES_VARIABLE_SENSITIVITY_VALUE_SET_VALUE_SET_TEST_COMMON_H


### PR DESCRIPTION
<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

This is just add some stub implementation for the value set classes we'll be moving the existing value set functionality to (and fix it along the way).

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
