### PR TITLE
Add pretty printing for exprts in Catch assertions

### DIFF
--- a/unit/testing-utils/catch_pretty_print_expr.h
+++ b/unit/testing-utils/catch_pretty_print_expr.h
@@ -1,0 +1,39 @@
+/*******************************************************************\
+
+Module: Pretty print exprts in Catch assertions
+
+Author: Diffblue Ltd.
+
+\*******************************************************************/
+
+#ifndef CPROVER_TESTING_UTILS_CATCH_PRETTY_PRINT_EXPR_H
+#define CPROVER_TESTING_UTILS_CATCH_PRETTY_PRINT_EXPR_H
+
+// this file is expected to be included from `use_catch.hpp`,
+// this include is only here to make editor syntax highlighting
+// work better
+#include <catch/catch.hpp>
+
+#include <ansi-c/expr2c.h>
+#include <util/expr.h>
+#include <util/namespace.h>
+#include <util/symbol_table.h>
+
+namespace Catch // NOLINT
+{
+template <>
+struct StringMaker<exprt> // NOLINT
+{
+  static std::string convert(const exprt &expr)
+  {
+    // expr2c doesn’t capture everything that’s contained
+    // within an expr, but it’s fairly compact.
+    // expr.pretty() could also work and is more precise,
+    // but leads to very large output multiple lines which
+    // makes it hard to see differences.
+    return expr2c(expr, namespacet{symbol_tablet{}});
+  }
+};
+} // namespace Catch
+
+#endif // CPROVER_TESTING_UTILS_CATCH_PRETTY_PRINT_EXPR_H

--- a/unit/testing-utils/use_catch.h
+++ b/unit/testing-utils/use_catch.h
@@ -39,4 +39,6 @@ Author: Michael Tautschnig
 /// Add to the end of test tags to mark a test that is expected to fail
 #define XFAIL "[.][!shouldfail]"
 
+#include "catch_pretty_print_expr.h"
+
 #endif // CPROVER_TESTING_UTILS_USE_CATCH_H


### PR DESCRIPTION
Without a pretty printer exprt's just show up as ? in
catch assertions, which isn't very helpful.

Other things that could be similarly printed are `typet`s and (especially) `irep_idt`s. These pretty printers are added from the `use_catch` header because I can’t think of a good reason why we’d need to avoid that, and this avoids annoying ? output when you forget to include an optional header (and UB because we have incompatible template instantiations in headers that don’t include the pretty printer, although that’s unlikely to cause actual problems).

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
