### PR TITLE
Assume relation between two symbols

### DIFF
--- a/regression/goto-analyzer/intervals_simple-loops/main.c
+++ b/regression/goto-analyzer/intervals_simple-loops/main.c
@@ -1,0 +1,15 @@
+#include <assert.h>
+const int g_N = 2;
+
+void main(void)
+{
+  for(int i = 0; i < g_N; i++)
+  {
+    assert(0);
+  }
+
+  for(int j = 4; j >= g_N; j--)
+  {
+    assert(0);
+  }
+}

--- a/regression/goto-analyzer/intervals_simple-loops/test.desc
+++ b/regression/goto-analyzer/intervals_simple-loops/test.desc
@@ -1,0 +1,11 @@
+CORE
+main.c
+--intervals
+^EXIT=0$
+^SIGNAL=0$
+\[main\.assertion\.1\] line 8 assertion 0: UNKNOWN
+\[main\.assertion\.2\] line 13 assertion 0: UNKNOWN
+--
+--
+Test comparision between two symbols does not mark the
+result as bottom

--- a/src/analyses/interval_domain.cpp
+++ b/src/analyses/interval_domain.cpp
@@ -329,10 +329,10 @@ void interval_domaint::assume_rec(
     {
       integer_intervalt &lhs_i=int_map[lhs_identifier];
       integer_intervalt &rhs_i=int_map[rhs_identifier];
-      lhs_i.meet(rhs_i);
-      rhs_i=lhs_i;
-      if(rhs_i.is_bottom())
-        make_bottom();
+      if(id == ID_lt && !lhs_i.is_less_than(rhs_i))
+        lhs_i.make_less_than(rhs_i);
+      if(id == ID_le && !lhs_i.is_less_than_eq(rhs_i))
+        lhs_i.make_less_than_eq(rhs_i);
     }
     else if(is_float(lhs.type()) && is_float(rhs.type()))
     {

--- a/src/util/interval_template.h
+++ b/src/util/interval_template.h
@@ -143,6 +143,47 @@ public:
     }
   }
 
+  void make_bottom()
+  {
+    lower_set = upper_set = true;
+    upper = T();
+    lower = upper + 1;
+  }
+
+  void make_less_than_eq(interval_templatet &i)
+  {
+    if(upper_set && i.upper_set)
+      upper = std::min(upper, i.upper);
+    if(lower_set && i.lower_set)
+      i.lower = std::max(lower, i.lower);
+  }
+
+  void make_less_than(interval_templatet &i)
+  {
+    make_less_than_eq(i);
+    if(singleton() && i.singleton() && lower == i.lower)
+    {
+      make_bottom();
+      i.make_bottom();
+    }
+  }
+
+  bool is_less_than_eq(const interval_templatet &i)
+  {
+    if(i.lower_set && upper_set && upper <= i.lower)
+      return true;
+    else
+      return false;
+  }
+
+  bool is_less_than(const interval_templatet &i)
+  {
+    if(i.lower_set && upper_set && upper < i.lower)
+      return true;
+    else
+      return false;
+  }
+
   void approx_union_with(const interval_templatet &i)
   {
     if(i.lower_set && lower_set)


### PR DESCRIPTION
Pulled out of #5361 as appears to be an unrelated bug fix. Not sure what bug it is fixing yet - will try and add a test! 


- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [x] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [na] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
