### PR TITLE
Implement basic operations for VSD Value Sets

### DIFF
--- a/src/analyses/variable-sensitivity/module_dependencies.txt
+++ b/src/analyses/variable-sensitivity/module_dependencies.txt
@@ -1,4 +1,5 @@
 analyses
+ansi-c
 goto-programs
 langapi # should go away
 util

--- a/src/analyses/variable-sensitivity/value_set_abstract_value.cpp
+++ b/src/analyses/variable-sensitivity/value_set_abstract_value.cpp
@@ -9,6 +9,70 @@
 #include "value_set_abstract_value.h"
 
 value_set_abstract_valuet::value_set_abstract_valuet(const typet &type)
-  : abstract_valuet{type}
+  : abstract_valuet{type}, values{}
+{
+}
+
+const value_set_abstract_valuet::valuest &
+value_set_abstract_valuet::get_values() const
+{
+  PRECONDITION(!is_top());
+  PRECONDITION(!is_bottom());
+  return values;
+}
+
+abstract_object_pointert
+value_set_abstract_valuet::merge(abstract_object_pointert other) const
+{
+  if(is_top())
+  {
+    return shared_from_this();
+  }
+
+  if(other->is_top())
+  {
+    return other;
+  }
+
+  if(is_bottom())
+  {
+    return other;
+  }
+
+  if(other->is_bottom())
+  {
+    return shared_from_this();
+  }
+
+  if(
+    auto other_value_set =
+      dynamic_cast<const value_set_abstract_valuet *>(other.get()))
+  {
+    valuest merged_values{values};
+    auto const &other_values = other_value_set->get_values();
+    merged_values.insert(other_values.begin(), other_values.end());
+    return std::make_shared<value_set_abstract_valuet>(
+      type(), std::move(merged_values));
+  }
+  return abstract_objectt::merge(other);
+}
+
+value_set_abstract_valuet::value_set_abstract_valuet(
+  const typet &type,
+  valuest values)
+  : abstract_valuet{type, values.size() > max_value_set_size, values.empty()},
+    values{std::move(values)}
+{
+  if(values.size() > max_value_set_size)
+  {
+    this->values.clear();
+  }
+}
+
+value_set_abstract_valuet::value_set_abstract_valuet(
+  exprt expr,
+  const abstract_environmentt &environment,
+  const namespacet &ns)
+  : value_set_abstract_valuet{expr.type(), valuest{expr}}
 {
 }

--- a/src/analyses/variable-sensitivity/value_set_abstract_value.cpp
+++ b/src/analyses/variable-sensitivity/value_set_abstract_value.cpp
@@ -10,8 +10,11 @@
 
 #include <ansi-c/expr2c.h>
 
-value_set_abstract_valuet::value_set_abstract_valuet(const typet &type)
-  : abstract_valuet{type}, values{}
+value_set_abstract_valuet::value_set_abstract_valuet(
+  const typet &type,
+  bool top,
+  bool bottom)
+  : abstract_valuet{type, top, bottom}, values{}
 {
 }
 
@@ -77,6 +80,18 @@ value_set_abstract_valuet::value_set_abstract_valuet(
   const namespacet &ns)
   : value_set_abstract_valuet{expr.type(), valuest{expr}}
 {
+}
+
+exprt value_set_abstract_valuet::to_constant() const
+{
+  if(!is_top() && !is_bottom() && values.size() == 1)
+  {
+    return *values.begin();
+  }
+  else
+  {
+    return nil_exprt{};
+  }
 }
 
 void value_set_abstract_valuet::output(

--- a/src/analyses/variable-sensitivity/value_set_abstract_value.cpp
+++ b/src/analyses/variable-sensitivity/value_set_abstract_value.cpp
@@ -9,6 +9,6 @@
 #include "value_set_abstract_value.h"
 
 value_set_abstract_valuet::value_set_abstract_valuet(const typet &type)
-  : abstract_valuet(type)
+  : abstract_valuet{type}
 {
 }

--- a/src/analyses/variable-sensitivity/value_set_abstract_value.cpp
+++ b/src/analyses/variable-sensitivity/value_set_abstract_value.cpp
@@ -8,6 +8,8 @@
 
 #include "value_set_abstract_value.h"
 
+#include <ansi-c/expr2c.h>
+
 value_set_abstract_valuet::value_set_abstract_valuet(const typet &type)
   : abstract_valuet{type}, values{}
 {
@@ -75,4 +77,36 @@ value_set_abstract_valuet::value_set_abstract_valuet(
   const namespacet &ns)
   : value_set_abstract_valuet{expr.type(), valuest{expr}}
 {
+}
+
+void value_set_abstract_valuet::output(
+  std::ostream &out,
+  const class ai_baset &,
+  const namespacet &ns) const
+{
+  if(is_bottom())
+  {
+    out << "BOTTOM";
+    return;
+  }
+  else if(is_top())
+  {
+    out << "TOP";
+    return;
+  }
+
+  std::vector<std::string> vals;
+  for(const auto &elem : values)
+  {
+    vals.push_back(expr2c(elem, ns));
+  }
+
+  std::sort(vals.begin(), vals.end());
+
+  out << "{ ";
+  for(const auto &val : vals)
+  {
+    out << val << " ";
+  }
+  out << "}";
 }

--- a/src/analyses/variable-sensitivity/value_set_abstract_value.h
+++ b/src/analyses/variable-sensitivity/value_set_abstract_value.h
@@ -16,11 +16,37 @@
 
 #include "abstract_value.h"
 
+#include <unordered_set>
+
 class value_set_abstract_valuet : public abstract_valuet
 {
 public:
+  using valuest = std::unordered_set<exprt, irep_hash>;
+
   explicit value_set_abstract_valuet(const typet &type);
+  value_set_abstract_valuet(
+    exprt expr,
+    const abstract_environmentt &environment,
+    const namespacet &ns);
+  value_set_abstract_valuet(const typet &type, valuest values);
+
+  /// Get the possible values for this abstract object.
+  /// Only meaningful when this is neither TOP nor BOTTOM.
+  const valuest &get_values() const;
+
   CLONE
+
+  /// TODO arbitrary limit, make configurable
+  static constexpr std::size_t max_value_set_size = 10;
+
+protected:
+  abstract_object_pointert merge(abstract_object_pointert other) const override;
+
+private:
+  /// If BOTTOM then empty.
+  /// If neither BOTTOM or TOP then the exact set of values.
+  /// If TOP this field doesn't mean anything and shouldn't be looked at.
+  valuest values;
 };
 
 // NOLINTNEXTLINE(whitespace/line_length)

--- a/src/analyses/variable-sensitivity/value_set_abstract_value.h
+++ b/src/analyses/variable-sensitivity/value_set_abstract_value.h
@@ -23,7 +23,10 @@ class value_set_abstract_valuet : public abstract_valuet
 public:
   using valuest = std::unordered_set<exprt, irep_hash>;
 
-  explicit value_set_abstract_valuet(const typet &type);
+  explicit value_set_abstract_valuet(
+    const typet &type,
+    bool top = true,
+    bool bottom = false);
   value_set_abstract_valuet(
     exprt expr,
     const abstract_environmentt &environment,
@@ -38,6 +41,8 @@ public:
 
   /// TODO arbitrary limit, make configurable
   static constexpr std::size_t max_value_set_size = 10;
+
+  exprt to_constant() const override;
 
   void output(std::ostream &out, const class ai_baset &ai, const namespacet &ns)
     const override;

--- a/src/analyses/variable-sensitivity/value_set_abstract_value.h
+++ b/src/analyses/variable-sensitivity/value_set_abstract_value.h
@@ -39,6 +39,9 @@ public:
   /// TODO arbitrary limit, make configurable
   static constexpr std::size_t max_value_set_size = 10;
 
+  void output(std::ostream &out, const class ai_baset &ai, const namespacet &ns)
+    const override;
+
 protected:
   abstract_object_pointert merge(abstract_object_pointert other) const override;
 

--- a/unit/analyses/variable-sensitivity/value_set/abstract_value.cpp
+++ b/unit/analyses/variable-sensitivity/value_set/abstract_value.cpp
@@ -7,7 +7,9 @@ Author: Diffblue Ltd.
 \*******************************************************************/
 
 #include "value_set_test_common.h"
+#include <analyses/ai.h>
 #include <analyses/variable-sensitivity/value_set_abstract_value.h>
+#include <analyses/variable-sensitivity/variable_sensitivity_domain.h>
 #include <ansi-c/expr2c.h>
 
 #include <sstream>
@@ -241,4 +243,71 @@ TEST_CASE(
 
   REQUIRE(merged_abstract_object->is_top());
   REQUIRE(!merged_abstract_object->is_bottom());
+}
+
+TEST_CASE(
+  "Make sure the output method works correctly with a value set with 0 "
+  "elements",
+  VALUE_SET_TEST_TAGS)
+{
+  auto const type = signedbv_typet{32};
+  auto const value_set = value_set_abstract_valuet{type, {}};
+
+  std::stringstream ss;
+  value_set.output(
+    ss, ait<variable_sensitivity_domaint>{}, namespacet{symbol_tablet{}});
+  REQUIRE(ss.str() == "BOTTOM");
+}
+
+TEST_CASE(
+  "Make sure the output method works correctly with a value set with 1 element",
+  VALUE_SET_TEST_TAGS)
+{
+  auto const type = signedbv_typet{32};
+  auto const value = from_integer(10, type);
+  auto const value_set = value_set_abstract_valuet{type, {value}};
+
+  std::stringstream ss;
+  value_set.output(
+    ss, ait<variable_sensitivity_domaint>{}, namespacet{symbol_tablet{}});
+  REQUIRE(ss.str() == "{ 10 }");
+}
+
+TEST_CASE(
+  "Make sure the output method works correctly with a value set with 3 "
+  "elements",
+  VALUE_SET_TEST_TAGS)
+{
+  auto const type = signedbv_typet{32};
+  auto const value1 = from_integer(10, type);
+  auto const value2 = from_integer(12, type);
+  auto const value3 = from_integer(14, type);
+  auto const value_set =
+    value_set_abstract_valuet{type, {value1, value2, value3}};
+
+  std::stringstream ss;
+  value_set.output(
+    ss, ait<variable_sensitivity_domaint>{}, namespacet{symbol_tablet{}});
+  REQUIRE(ss.str() == "{ 10 12 14 }");
+}
+
+TEST_CASE(
+  "Make sure that the output method works with a TOP value set",
+  VALUE_SET_TEST_TAGS)
+{
+  // Build and ensure value set is TOP
+  auto const type = signedbv_typet{32};
+  auto values = value_set_abstract_valuet::valuest{};
+  for(std::size_t i = 0; i <= value_set_abstract_valuet::max_value_set_size;
+      ++i)
+  {
+    values.insert(from_integer(i, type));
+  }
+  auto const value_set = value_set_abstract_valuet{type, values};
+  REQUIRE(value_set.is_top());
+
+  std::stringstream ss;
+  value_set.output(
+    ss, ait<variable_sensitivity_domaint>{}, namespacet{symbol_tablet{}});
+  REQUIRE(ss.str() == "TOP");
 }

--- a/unit/analyses/variable-sensitivity/value_set/abstract_value.cpp
+++ b/unit/analyses/variable-sensitivity/value_set/abstract_value.cpp
@@ -8,6 +8,60 @@ Author: Diffblue Ltd.
 
 #include "value_set_test_common.h"
 #include <analyses/variable-sensitivity/value_set_abstract_value.h>
+#include <ansi-c/expr2c.h>
+
+#include <sstream>
+#include <string>
+#include <util/arith_tools.h>
+#include <vector>
+
+namespace
+{
+// NOLINTNEXTLINE(readability/identifiers)
+class ContainsAllOf
+  : public Catch::MatcherBase<value_set_abstract_valuet::valuest>
+{
+private:
+  std::vector<exprt> should_contain_values;
+
+public:
+  template <typename... Args>
+  explicit ContainsAllOf(Args &&... should_contain_values)
+    : should_contain_values{std::forward<Args>(should_contain_values)...}
+  {
+  }
+
+  bool match(const value_set_abstract_valuet::valuest &values) const override
+  {
+    for(auto const &value : should_contain_values)
+    {
+      if(values.count(value) == 0)
+      {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  std::string describe() const override
+  {
+    std::ostringstream oss{};
+    auto const ns = namespacet{symbol_tablet{}};
+    oss << "contains all of { ";
+    bool first = true;
+    for(auto const &value : should_contain_values)
+    {
+      if(!first)
+      {
+        oss << ", ";
+      }
+      oss << expr2c(value, ns);
+    }
+    oss << " }";
+    return oss.str();
+  }
+};
+} // namespace
 
 TEST_CASE(
   "A value set abstract object created from type is top",
@@ -16,4 +70,175 @@ TEST_CASE(
   value_set_abstract_valuet abstract_value(signedbv_typet{32});
   REQUIRE(abstract_value.is_top());
   REQUIRE(!abstract_value.is_bottom());
+}
+
+TEST_CASE(
+  "A value set created from a single value represents that value",
+  VALUE_SET_TEST_TAGS)
+{
+  auto const type = signedbv_typet{32};
+  auto const value = from_integer(10, type);
+  auto const value_set = value_set_abstract_valuet{type, {value}};
+
+  REQUIRE(!value_set.is_top());
+  REQUIRE(!value_set.is_bottom());
+  REQUIRE(value_set.get_values().size() == 1);
+  REQUIRE_THAT(value_set.get_values(), ContainsAllOf{value});
+}
+
+TEST_CASE(
+  "A value set created from multiple values represents all of them",
+  VALUE_SET_TEST_TAGS)
+{
+  auto const type = signedbv_typet{32};
+  auto const value1 = from_integer(10, type);
+  auto const value2 = from_integer(36, type);
+  auto const value3 = from_integer(42, type);
+  auto const value_set =
+    value_set_abstract_valuet{type, {value1, value2, value3}};
+
+  REQUIRE(!value_set.is_top());
+  REQUIRE(!value_set.is_bottom());
+  REQUIRE(value_set.get_values().size() == 3);
+  REQUIRE_THAT(value_set.get_values(), ContainsAllOf(value1, value2, value3));
+}
+
+TEST_CASE(
+  "A value set created from an empty set is bottom",
+  VALUE_SET_TEST_TAGS)
+{
+  auto const type = signedbv_typet{32};
+  auto const value_set = value_set_abstract_valuet{type, {}};
+  REQUIRE(!value_set.is_top());
+  REQUIRE(value_set.is_bottom());
+}
+
+TEST_CASE(
+  "A value set created with too many elements is TOP",
+  VALUE_SET_TEST_TAGS)
+{
+  auto const type = signedbv_typet{32};
+  auto values = value_set_abstract_valuet::valuest{};
+  for(std::size_t i = 0; i <= value_set_abstract_valuet::max_value_set_size;
+      ++i)
+  {
+    values.insert(from_integer(i, type));
+  }
+  auto const value_set = value_set_abstract_valuet{type, values};
+
+  REQUIRE(value_set.is_top());
+  REQUIRE(!value_set.is_bottom());
+}
+
+TEST_CASE(
+  "A value set created by merging two single value-value sets contains both "
+  "values",
+  VALUE_SET_TEST_TAGS)
+{
+  auto const type = signedbv_typet{32};
+  auto const value1 = from_integer(10, type);
+  auto const value2 = from_integer(42, type);
+  using valuest = value_set_abstract_valuet::valuest;
+  auto const value_set1 =
+    std::make_shared<value_set_abstract_valuet>(type, valuest{value1});
+  auto const value_set2 =
+    std::make_shared<value_set_abstract_valuet>(type, valuest{value2});
+
+  bool out_modifications;
+  auto const merged_abstract_object =
+    abstract_objectt::merge(value_set1, value_set2, out_modifications);
+  auto const merged_value_set =
+    std::dynamic_pointer_cast<const value_set_abstract_valuet>(
+      merged_abstract_object);
+
+  REQUIRE(merged_value_set != nullptr);
+  REQUIRE(!merged_value_set->is_top());
+  REQUIRE(!merged_value_set->is_bottom());
+  REQUIRE(merged_value_set->get_values().size() == 2);
+  REQUIRE_THAT(merged_value_set->get_values(), ContainsAllOf(value1, value2));
+}
+
+TEST_CASE(
+  "A value set created by merging two multi-value value sets contains all "
+  "values from both of them",
+  VALUE_SET_TEST_TAGS)
+{
+  auto const type = signedbv_typet{32};
+  auto const value1 = from_integer(10, type);
+  auto const value2 = from_integer(20, type);
+  auto const value3 = from_integer(30, type);
+  using valuest = value_set_abstract_valuet::valuest;
+  auto const value_set1 =
+    std::make_shared<value_set_abstract_valuet>(type, valuest{value1, value2});
+  auto const value_set2 =
+    std::make_shared<value_set_abstract_valuet>(type, valuest{value2, value3});
+
+  bool out_modifications;
+  auto const merged_abstracted_object =
+    abstract_objectt::merge(value_set1, value_set2, out_modifications);
+  auto const merged_value_set =
+    std::dynamic_pointer_cast<const value_set_abstract_valuet>(
+      merged_abstracted_object);
+
+  REQUIRE(merged_value_set != nullptr);
+  REQUIRE(!merged_value_set->is_top());
+  REQUIRE(!merged_value_set->is_bottom());
+  REQUIRE(merged_value_set->get_values().size() == 3);
+  REQUIRE_THAT(
+    merged_value_set->get_values(), ContainsAllOf(value1, value2, value3));
+}
+
+TEST_CASE(
+  "The result of merging two value sets is TOP if both are non-top value sets "
+  "and the resulting set would have too many elements",
+  VALUE_SET_TEST_TAGS)
+{
+  auto const type = signedbv_typet{32};
+  using valuest = value_set_abstract_valuet::valuest;
+  auto values = valuest{};
+  for(std::size_t i = 0; i < value_set_abstract_valuet::max_value_set_size; ++i)
+  {
+    values.insert(from_integer(i, type));
+  }
+
+  auto const straw_that_broke_the_camels_back =
+    from_integer(value_set_abstract_valuet::max_value_set_size, type);
+
+  auto const value_set1 =
+    std::make_shared<value_set_abstract_valuet>(type, values);
+  REQUIRE(!value_set1->is_top());
+
+  auto const value_set2 = std::make_shared<value_set_abstract_valuet>(
+    type, valuest{straw_that_broke_the_camels_back});
+  REQUIRE(!value_set2->is_top());
+
+  bool out_modifications;
+  auto const merged_abstract_object =
+    abstract_objectt::merge(value_set1, value_set2, out_modifications);
+  auto const merged_value_set =
+    std::dynamic_pointer_cast<const value_set_abstract_valuet>(
+      merged_abstract_object);
+
+  REQUIRE(merged_value_set != nullptr);
+  REQUIRE(merged_value_set->is_top());
+  REQUIRE(!merged_value_set->is_bottom());
+}
+
+TEST_CASE(
+  "The result of merging two value sets is top if one of them is TOP",
+  VALUE_SET_TEST_TAGS)
+{
+  auto const type = signedbv_typet{32};
+  auto const value = from_integer(10, type);
+  using valuest = value_set_abstract_valuet::valuest;
+  auto const value_set1 =
+    std::make_shared<value_set_abstract_valuet>(type, valuest{value});
+  auto const value_set2 = std::make_shared<value_set_abstract_valuet>(type);
+
+  bool out_modifications;
+  auto const merged_abstract_object =
+    abstract_objectt::merge(value_set1, value_set2, out_modifications);
+
+  REQUIRE(merged_abstract_object->is_top());
+  REQUIRE(!merged_abstract_object->is_bottom());
 }

--- a/unit/analyses/variable-sensitivity/value_set/abstract_value.cpp
+++ b/unit/analyses/variable-sensitivity/value_set/abstract_value.cpp
@@ -110,7 +110,8 @@ TEST_CASE(
   VALUE_SET_TEST_TAGS)
 {
   auto const type = signedbv_typet{32};
-  auto const value_set = value_set_abstract_valuet{type, {}};
+  auto const value_set =
+    value_set_abstract_valuet{type, value_set_abstract_valuet::valuest{}};
   REQUIRE(!value_set.is_top());
   REQUIRE(value_set.is_bottom());
 }
@@ -251,7 +252,8 @@ TEST_CASE(
   VALUE_SET_TEST_TAGS)
 {
   auto const type = signedbv_typet{32};
-  auto const value_set = value_set_abstract_valuet{type, {}};
+  auto const value_set =
+    value_set_abstract_valuet{type, value_set_abstract_valuet::valuest{}};
 
   std::stringstream ss;
   value_set.output(
@@ -310,4 +312,50 @@ TEST_CASE(
   value_set.output(
     ss, ait<variable_sensitivity_domaint>{}, namespacet{symbol_tablet{}});
   REQUIRE(ss.str() == "TOP");
+}
+
+TEST_CASE(
+  "Value set abstract value that is TOP can not be turned into a constant",
+  VALUE_SET_TEST_TAGS)
+{
+  auto const type = signedbv_typet{32};
+  auto const value_set = value_set_abstract_valuet{type};
+
+  REQUIRE(value_set.to_constant() == nil_exprt{});
+}
+
+TEST_CASE(
+  "Value set abstract value that is bottom can not be turned into a constant",
+  VALUE_SET_TEST_TAGS)
+{
+  auto const type = signedbv_typet{32};
+  auto const value_set =
+    value_set_abstract_valuet{type, value_set_abstract_valuet::valuest{}};
+
+  REQUIRE(value_set.to_constant() == nil_exprt{});
+}
+
+TEST_CASE(
+  "Value set with multiple possible values can not be turned into a constant",
+  VALUE_SET_TEST_TAGS)
+{
+  auto const type = signedbv_typet{32};
+  auto values = value_set_abstract_valuet::valuest{};
+  values.insert(from_integer(0, type));
+  values.insert(from_integer(1, type));
+  auto const value_set = value_set_abstract_valuet{type, values};
+
+  REQUIRE(value_set.to_constant() == nil_exprt{});
+}
+
+TEST_CASE(
+  "Value set with exactly one possible value can be turned into a constant",
+  VALUE_SET_TEST_TAGS)
+{
+  auto const type = signedbv_typet{32};
+  auto const value = from_integer(0, type);
+  auto const value_set =
+    value_set_abstract_valuet{type, value_set_abstract_valuet::valuest{value}};
+
+  REQUIRE(value_set.to_constant() == value);
 }

--- a/unit/analyses/variable-sensitivity/value_set/module_dependencies.txt
+++ b/unit/analyses/variable-sensitivity/value_set/module_dependencies.txt
@@ -1,3 +1,4 @@
 analyses
+ansi-c
 testing-utils
 util


### PR DESCRIPTION
This implements some of the basic functions for abstract values, such as creation, merge, and converting single-value sets to a constant (which is needed for simplification later on).

Nothing is hooked up to goto-analyser yet, but the functionality is unit tested.

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.