### PR TITLE
Util changes needed for VSD

### DIFF
--- a/src/util/journalling_symbol_table.h
+++ b/src/util/journalling_symbol_table.h
@@ -140,6 +140,9 @@ public:
       base_symbol_table.end(), [this](const irep_idt &id) { on_update(id); });
   }
 
+  using symbol_table_baset::begin;
+  using symbol_table_baset::end;
+
   const changesett &get_inserted() const
   {
     return inserted;

--- a/src/util/symbol_table.h
+++ b/src/util/symbol_table.h
@@ -120,17 +120,8 @@ public:
     return iteratort(internal_symbols.end());
   }
 
-  typedef symbolst::const_iterator const_iteratort;
-
-  virtual const_iteratort begin() const
-  {
-    return internal_symbols.begin();
-  }
-
-  virtual const_iteratort end() const
-  {
-    return internal_symbols.end();
-  }
+  using symbol_table_baset::begin;
+  using symbol_table_baset::end;
 
   /// Check that the symbol table is well-formed
   void validate(const validation_modet vm = validation_modet::INVARIANT) const;

--- a/src/util/symbol_table_base.cpp
+++ b/src/util/symbol_table_base.cpp
@@ -60,6 +60,16 @@ void symbol_table_baset::show(std::ostream &out) const
     out << symbols.at(name);
 }
 
+symbol_table_baset::const_iteratort symbol_table_baset::end() const
+{
+  return symbols.end();
+}
+
+symbol_table_baset::const_iteratort symbol_table_baset::begin() const
+{
+  return symbols.begin();
+}
+
 /// Print the contents of the symbol table.
 /// \param out: The ostream to direct output to
 /// \param symbol_table: The symbol table to print out

--- a/src/util/symbol_table_base.h
+++ b/src/util/symbol_table_base.h
@@ -237,8 +237,8 @@ public:
 
   using const_iteratort = symbolst::const_iterator;
 
-  const_iteratort begin() const;
-  const_iteratort end() const;
+  virtual const_iteratort begin() const;
+  virtual const_iteratort end() const;
 };
 
 std::ostream &

--- a/src/util/symbol_table_base.h
+++ b/src/util/symbol_table_base.h
@@ -234,6 +234,11 @@ public:
 
   virtual iteratort begin() = 0;
   virtual iteratort end() = 0;
+
+  using const_iteratort = symbolst::const_iterator;
+
+  const_iteratort begin() const;
+  const_iteratort end() const;
 };
 
 std::ostream &

--- a/src/util/symbol_table_builder.h
+++ b/src/util/symbol_table_builder.h
@@ -85,6 +85,9 @@ public:
     return base_symbol_table.end();
   }
 
+  using symbol_table_baset::begin;
+  using symbol_table_baset::end;
+
   /// Try to find the next free identity for the passed-in prefix in
   /// this symbol table.
   /// \remark

--- a/unit/util/irep.cpp
+++ b/unit/util/irep.cpp
@@ -22,7 +22,7 @@ SCENARIO("irept_memory", "[core][utils][irept]")
       const std::size_t ref_count_size = 0;
 #endif
 
-#ifndef USE_STRING
+#ifndef USE_STD_STRING
       const std::size_t data_size = sizeof(dstringt);
       REQUIRE(sizeof(dstringt) == sizeof(unsigned));
 #else

--- a/unit/util/symbol_table.cpp
+++ b/unit/util/symbol_table.cpp
@@ -17,14 +17,53 @@ TEST_CASE("Iterating through a symbol table", "[core][utils][symbol_tablet]")
 
   symbol_table.insert(symbol);
 
-  int counter = 0;
-  for(auto &entry : symbol_table)
+  SECTION("Non const iterator")
   {
-    (void)entry; // we are just testing iteration here
-    ++counter;
+    int counter = 0;
+    for(auto &entry : symbol_table)
+    {
+      (void)entry; // we are just testing iteration here
+      ++counter;
+    }
+    REQUIRE(counter == 1);
   }
-
-  REQUIRE(counter == 1);
+  SECTION("Const iterator")
+  {
+    int counter = 0;
+    for(const auto &entry : symbol_table)
+    {
+      (void)entry; // we are just testing iteration here
+      ++counter;
+    }
+    REQUIRE(counter == 1);
+  }
+  SECTION("Polymorphic access")
+  {
+    SECTION("Non-const iterator")
+    {
+      symbol_table_baset &base_st = symbol_table;
+      REQUIRE(std::distance(base_st.begin(), base_st.end()) == 1);
+      int counter = 0;
+      for(auto &entry : base_st)
+      {
+        (void)entry; // we are just testing iteration here
+        ++counter;
+      }
+      REQUIRE(counter == 1);
+    }
+    SECTION("Const iterator")
+    {
+      const symbol_table_baset &base_st = symbol_table;
+      REQUIRE(std::distance(base_st.begin(), base_st.end()) == 1);
+      int counter = 0;
+      for(const auto &entry : base_st)
+      {
+        (void)entry; // we are just testing iteration here
+        ++counter;
+      }
+      REQUIRE(counter == 1);
+    }
+  }
 }
 
 SCENARIO(


### PR DESCRIPTION
Rebased version of #5205, with two additions:

 - tests for the const iterators added to base symbol table
 - stop definitions in symbol_table hiding the implemention in symbol_table_baset (risks these defintions going out of sync) 

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [na] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [na] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
