### PR TITLE
Change name mangler to avoid name collision.

### DIFF
--- a/regression/goto-cc-file-local/combined-compile-and-link/main.c
+++ b/regression/goto-cc-file-local/combined-compile-and-link/main.c
@@ -1,6 +1,6 @@
-int __CPROVER_file_local_foo_c_foo();
+int __CPROVER_file_local_64aa0f01__foo();
 
 int main()
 {
-  return __CPROVER_file_local_foo_c_foo();
+  return __CPROVER_file_local_64aa0f01__foo();
 }

--- a/src/goto-cc/compile.cpp
+++ b/src/goto-cc/compile.cpp
@@ -348,7 +348,7 @@ bool compilet::link()
 
   if(keep_file_local)
   {
-    function_name_manglert<file_name_manglert> mangler(
+    function_name_manglert<djb_manglert> mangler(
       get_message_handler(), goto_model, file_local_mangle_suffix);
     mangler.mangle();
   }


### PR DESCRIPTION
Change the name mangling class from `file_name_manglert` to `djb_manglert` which uses hashing to avoid a name collision
in the namespace that crashes `goto-cc`.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
