### PR TITLE
Correct make install reference to nonexistent goto-cl->goto-cc target

### DIFF
--- a/src/goto-cc/CMakeLists.txt
+++ b/src/goto-cc/CMakeLists.txt
@@ -28,7 +28,7 @@ target_link_libraries(goto-cc goto-cc-lib)
 
 if(WIN32)
   set_target_properties(goto-cc PROPERTIES OUTPUT_NAME goto-cl)
-  install(TARGETS goto-cl DESTINATION ${CMAKE_INSTALL_BINDIR})
+  install(TARGETS goto-cc DESTINATION ${CMAKE_INSTALL_BINDIR})
 else()
   add_custom_command(TARGET goto-cc
     POST_BUILD


### PR DESCRIPTION
<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

This pull request corrects a windows cmake install command.  The src/goto-cc/CMakeLists.txt defines the goto-cc target with the output name goto-cl.  The install command there refers to the target as goto-cl.  This patch corrects the install command to refer to the target as goto-cc.


- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
