### PR TITLE
Byte-update lowering: handle sub-byte sized bit fields

### DIFF
--- a/regression/cbmc/byte_update13/main.c
+++ b/regression/cbmc/byte_update13/main.c
@@ -1,0 +1,25 @@
+#include <assert.h>
+#include <string.h>
+
+struct blob
+{
+  unsigned dummy;
+  unsigned bit : 1;
+};
+
+int main()
+{
+  struct blob b;
+  struct blob b1 = b;
+
+  // Perform byte-wise updates of the struct, up to its full size. Constant
+  // propagation made impossible, and thus the byte updates need to be handled
+  // by the back-end.
+  if(b.dummy <= sizeof(struct blob))
+    memset(&b, 0, b.dummy);
+
+  // If we updated the complete struct, then the single-bit bit-field needs to
+  // have been set to zero as well. This makes sure that the encoding of byte
+  // update properly handles fields that are smaller than bytes.
+  assert(b1.dummy != sizeof(struct blob) || b.bit == 0);
+}

--- a/regression/cbmc/byte_update13/test.desc
+++ b/regression/cbmc/byte_update13/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring


### PR DESCRIPTION
Extend the value to be updated to the update size immediately to avoid
extractbits operations that attempt to extract bits that do not exist.

Fixes: #5389

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
