### PR TITLE
Specify exactly what the comment at the top of the file should be

### DIFF
--- a/CODING_STANDARD.md
+++ b/CODING_STANDARD.md
@@ -61,12 +61,19 @@ Formatting is enforced using clang-format. For more information about this, see
 # Comments
 - Do not use `/* */`
 - Each source and header file must start with a comment block stating the
-  author. See existing source for an example of the format of this block. This
-  should be followed by a Doxygen `\file` comment:
+  author, followed by a Doxygen comment about the file:
+
   ```c++
+  /*******************************************************************\
+
+  Author: Author Name
+
+  \*******************************************************************/
+
   /// \file
   /// <Some information about this file goes here>
   ```
+
   Note that the `\file` tag must be immediately followed by a newline in order
   for Doxygen to relate the comment to the current file.
 - Each class, member variable and function should be preceded by a Doxygen


### PR DESCRIPTION
It is confusing to reference existing files, as existing files are a little inconsistent (some use a module specifier, more or less at
random). This provides a single source of truth for what should be there.


- [x] Each commit message has a non-empty body, explaining why the change was made.
- [na] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [na] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [na] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [na] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.
