### PR TITLE
Fix bug where reference to temporary string was returned

### DIFF
--- a/jbmc/unit/java-testing-utils/require_goto_statements.h
+++ b/jbmc/unit/java-testing-utils/require_goto_statements.h
@@ -34,19 +34,17 @@ class no_decl_found_exceptiont : public std::exception
 {
 public:
   explicit no_decl_found_exceptiont(const std::string &var_name)
-    : _varname(var_name)
+    : message{"Failed to find declaration for: " + var_name}
   {
   }
 
   virtual const char *what() const throw()
   {
-    std::ostringstream stringStream;
-    stringStream << "Failed to find declaration for: " << _varname;
-    return stringStream.str().c_str();
+    return message.c_str();
   }
 
 private:
-  std::string _varname;
+  std::string message;
 };
 
 pointer_assignment_locationt find_struct_component_assignments(


### PR DESCRIPTION
This is fortunately only in a unit tests and apparently hasn’t caused any
problems so far, but we nevertheless should avoid returning references to
temporaries.

As a bonus the fixed code is simpler.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
