### PR TITLE
Remove multiple function assertion

### DIFF
--- a/src/goto-programs/name_mangler.h
+++ b/src/goto-programs/name_mangler.h
@@ -121,10 +121,9 @@ public:
 
       auto inserted = model.goto_functions.function_map.emplace(
         pair.second, std::move(found->second));
-      INVARIANT(
-        inserted.second,
-        "The mangled name '" + std::string(pair.second.c_str()) +
-          "' should not already exist in the codebase");
+      if(!inserted.second)
+        log.debug() << "Found a mangled name that already exists: "
+                    << std::string(pair.second.c_str()) << log.eom;
 
       model.goto_functions.function_map.erase(found);
     }


### PR DESCRIPTION
This commit removes an assertion that triggers when multiple functions
get mangled to the same name when using the --export-file-local-symbols
flag to goto-cc.

This assertion was previously valid when compiling files one at a time, but
commit fcd1083 introduced the possibility of compiling and linking several
files at once. This is a problem when two source files both include an
implementation file, like [1], because the implementation may contain static
functions that get mangled twice.

This commit replaces the assertion with a debug message in case users would
like to check how often this happens.

This commit fixes #5380.

[1] https://github.com/awslabs/aws-c-common/blob/master/include/aws/common/atomics_gnu.inl

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
