### PR TITLE
Add an abstract interpreter 'history' that gives (local) per-path analysis and / or loop unwinding

### DIFF
--- a/regression/goto-analyzer/local_control_flow_history_01/main.c
+++ b/regression/goto-analyzer/local_control_flow_history_01/main.c
@@ -1,0 +1,55 @@
+#include <assert.h>
+
+int main(int argc, char **argv)
+{
+  int branch;
+  int x = 0;
+
+  if(branch)
+  {
+    x = 1;
+  }
+  else
+  {
+    x = -1;
+  }
+
+  // Merging a constant domain here will make this unprovable
+  assert(x != 0);
+
+  // Some subtle points here...
+  // The history tracks paths, it is up to the domain to track the
+  // path conditon / consequences of that path.
+  //
+  // We have two paths:
+  //  branch == ?, x ==  1
+  //  branch == 0, x == -1
+  //
+  // As the domain in the first case can't express branch != 0
+  // we will wind up with three paths here, including a spurious
+  // one with branch == 0, x == 1.
+  if(branch)
+  {
+    assert(x == 1);
+  }
+  else
+  {
+    assert(x == -1);
+  }
+
+  // Working around the domain issues...
+  // (This doesn't increase the number of paths)
+  if(x == 1)
+  {
+    x--;
+  }
+  else
+  {
+    x++;
+  }
+
+  // Should be true in all 3 paths
+  assert(x == 0);
+
+  return 0;
+}

--- a/regression/goto-analyzer/local_control_flow_history_01/test.desc
+++ b/regression/goto-analyzer/local_control_flow_history_01/test.desc
@@ -1,0 +1,13 @@
+CORE
+main.c
+--verify --recursive-interprocedural --branching 0 --constants --one-domain-per-history
+^EXIT=0$
+^SIGNAL=0$
+^\[main.assertion.1\] .* assertion x != 0: SUCCESS$
+^\[main.assertion.2\] .* assertion x == 1: SUCCESS$
+^\[main.assertion.3\] .* assertion x == -1: FAILURE \(if reachable\)$
+^\[main.assertion.4\] .* assertion x == 0: SUCCESS$
+--
+^warning: ignoring
+--
+This demonstrates the "lazy merging" that comes from tracking the history of branching

--- a/regression/goto-analyzer/local_control_flow_history_02/main.c
+++ b/regression/goto-analyzer/local_control_flow_history_02/main.c
@@ -1,0 +1,42 @@
+#include <assert.h>
+
+int main(int argc, char **argv)
+{
+  int branching_array[5];
+  int x = 1;
+
+  if(branching_array[0])
+  {
+    ++x;
+  }
+  // Two paths...
+  assert(x > 0);
+
+  if(branching_array[1])
+  {
+    ++x;
+  }
+  // Four paths...
+  assert(x > 0);
+
+  if(branching_array[2])
+  {
+    ++x;
+  }
+  // Eight paths...
+  assert(x > 0);
+
+  if(branching_array[3])
+  {
+    ++x;
+  }
+  // Paths merge so there will be some paths that will set x to \top
+  // and so this will be flagged as unknown
+  assert(x > 0);
+  // In principle it would be possible to merge paths in such a way
+  // that the those with similar domains are merged and this would be
+  // able to be proved.  The local_control_flow_history code doesn't
+  // do this though.
+
+  return 0;
+}

--- a/regression/goto-analyzer/local_control_flow_history_02/test.desc
+++ b/regression/goto-analyzer/local_control_flow_history_02/test.desc
@@ -1,0 +1,13 @@
+CORE
+main.c
+--verify --recursive-interprocedural --branching 12 --constants --one-domain-per-history
+^EXIT=0$
+^SIGNAL=0$
+^\[main.assertion.1\] .* assertion x > 0: SUCCESS$
+^\[main.assertion.2\] .* assertion x > 0: SUCCESS$
+^\[main.assertion.3\] .* assertion x > 0: SUCCESS$
+^\[main.assertion.4\] .* assertion x > 0: UNKNOWN$
+--
+^warning: ignoring
+--
+This demonstrates hitting the path limit and the merging of paths

--- a/regression/goto-analyzer/local_control_flow_history_03/main.c
+++ b/regression/goto-analyzer/local_control_flow_history_03/main.c
@@ -1,0 +1,17 @@
+#include <assert.h>
+
+int main(int argc, char **argv)
+{
+  int total = 0;
+  int n = 50;
+  int i;
+
+  for(i = 0; i < n; ++i)
+  {
+    total += i;
+  }
+
+  assert(total == (n * (n - 1) / 2));
+
+  return 0;
+}

--- a/regression/goto-analyzer/local_control_flow_history_03/test.desc
+++ b/regression/goto-analyzer/local_control_flow_history_03/test.desc
@@ -1,0 +1,10 @@
+CORE
+main.c
+--verify --recursive-interprocedural --loop-unwind 0 --constants --one-domain-per-history
+^EXIT=0$
+^SIGNAL=0$
+^\[main.assertion.1\] .* assertion total == \(n \* \(n - 1\) / 2\): SUCCESS$
+--
+^warning: ignoring
+--
+A basic test of loop unwinding.

--- a/regression/goto-analyzer/local_control_flow_history_04/main.c
+++ b/regression/goto-analyzer/local_control_flow_history_04/main.c
@@ -1,0 +1,42 @@
+#include <assert.h>
+
+int main(int argc, char **argv)
+{
+  int total;
+  int n;
+  int i;
+
+  total = 0;
+  n = 8;
+  for(i = 0; i < n; ++i)
+  {
+    total += i;
+  }
+
+  // Unknown due to the limit on unwindings
+  assert(total == (n * (n - 1) / 2));
+
+  // Condense down to one path...
+
+  total = 0;
+  n = 16;
+  for(i = 0; i < n; ++i)
+  {
+    total += i;
+  }
+
+  // Creates a merge path but only one user of it
+  assert(total == (n * (n - 1) / 2));
+
+  total = 0;
+  n = 32;
+  for(i = 0; i < n; ++i)
+  {
+    total += i;
+  }
+
+  // Provable
+  assert(total == (n * (n - 1) / 2));
+
+  return 0;
+}

--- a/regression/goto-analyzer/local_control_flow_history_04/test.desc
+++ b/regression/goto-analyzer/local_control_flow_history_04/test.desc
@@ -1,0 +1,16 @@
+CORE
+main.c
+--verify --recursive-interprocedural --loop-unwind 17 --constants --one-domain-per-history
+^EXIT=0$
+^SIGNAL=0$
+^\[main.assertion.1\] .* assertion total == \(n \* \(n - 1\) / 2\): SUCCESS$
+^\[main.assertion.2\] .* assertion total == \(n \* \(n - 1\) / 2\): SUCCESS$
+^\[main.assertion.3\] .* assertion total == \(n \* \(n - 1\) / 2\): UNKNOWN$
+--
+^warning: ignoring
+--
+A basic test of the loop unwinding limit.
+You might think this has an off-by-one error but to process a loop 16 times
+you have to visit the loop guard 17 times.  Setting the loop limit to 16 will
+cause the last two visits to merge loosing the precision needed to prove the
+conjecture.

--- a/regression/goto-analyzer/local_control_flow_history_05/main.c
+++ b/regression/goto-analyzer/local_control_flow_history_05/main.c
@@ -1,0 +1,23 @@
+#include <assert.h>
+
+int main(int argc, char **argv)
+{
+  int total;
+  int n;
+  int i;
+  int branching[4];
+
+  total = 0;
+  n = 4;
+  for(i = 0; i < n; ++i)
+  {
+    if(branching[i])
+    {
+      total += i;
+    }
+  }
+
+  assert(total <= (n * (n - 1) / 2));
+
+  return 0;
+}

--- a/regression/goto-analyzer/local_control_flow_history_05/test.desc
+++ b/regression/goto-analyzer/local_control_flow_history_05/test.desc
@@ -1,0 +1,11 @@
+CORE
+main.c
+--verify --recursive-interprocedural --loop-unwind-and-branching 32 --constants --one-domain-per-history
+^EXIT=0$
+^SIGNAL=0$
+^\[main.assertion.1\] .* assertion total <= \(n \* \(n - 1\) / 2\): SUCCESS$
+--
+^warning: ignoring
+--
+Test tracking all local control-flow history.
+Note the exponential rise in the number of paths!

--- a/regression/goto-analyzer/local_control_flow_history_06/main.c
+++ b/regression/goto-analyzer/local_control_flow_history_06/main.c
@@ -1,0 +1,37 @@
+#include <assert.h>
+
+#define CODE_BLOCK                                                             \
+  int i;                                                                       \
+  float flotal = 0;                                                            \
+  for(i = 0; i < n; ++i)                                                       \
+  {                                                                            \
+    flotal += i;                                                               \
+  }                                                                            \
+  assert(flotal == (n * (n - 1) / 2))
+
+void do_the_loop(int n)
+{
+  CODE_BLOCK;
+}
+
+int main(int argc, char **argv)
+{
+  int j;
+
+  // Will give unknown unless the bound is over 25
+  for(j = 0; j < 5; j++)
+  {
+    int n = 5;
+    CODE_BLOCK;
+  }
+
+  // Paths in the loop will merge but that is OK
+  // because the value of n is the important bit
+  for(j = 0; j < 1000; j++)
+  {
+    int n = 10;
+    do_the_loop(n);
+  }
+
+  return 0;
+}

--- a/regression/goto-analyzer/local_control_flow_history_06/test.desc
+++ b/regression/goto-analyzer/local_control_flow_history_06/test.desc
@@ -1,0 +1,11 @@
+CORE
+main.c
+--verify --recursive-interprocedural --loop-unwind-and-branching 12 --constants --one-domain-per-history
+^EXIT=0$
+^SIGNAL=0$
+^\[main.assertion.1\] .* assertion flotal == \(n \* \(n - 1\) / 2\): UNKNOWN$
+^\[do_the_loop.assertion.1\] .* assertion flotal == \(n \* \(n - 1\) / 2\): SUCCESS$
+--
+^warning: ignoring
+--
+Demonstrate the function local behaviour of this history

--- a/src/analyses/Makefile
+++ b/src/analyses/Makefile
@@ -24,6 +24,7 @@ SRC = ai.cpp \
       is_threaded.cpp \
       local_bitvector_analysis.cpp \
       local_cfg.cpp \
+      local_control_flow_history.cpp \
       local_may_alias.cpp \
       local_safe_pointers.cpp \
       locals.cpp \

--- a/src/analyses/ai.h
+++ b/src/analyses/ai.h
@@ -252,7 +252,11 @@ public:
 
     locationt n = std::next(l);
 
-    auto step_return = p->step(n, *(storage->abstract_traces_before(n)));
+    auto step_return = p->step(
+      n,
+      *(storage->abstract_traces_before(n)),
+      ai_history_baset::no_caller_history);
+    // Caller history not needed as this is a local step
 
     return storage->abstract_state_before(step_return.second, *domain_factory);
   }
@@ -469,6 +473,7 @@ protected:
     trace_ptrt p,
     const irep_idt &to_function_id,
     locationt to_l,
+    trace_ptrt caller_history,
     const namespacet &ns,
     working_sett &working_set);
 

--- a/src/analyses/ai_history.cpp
+++ b/src/analyses/ai_history.cpp
@@ -27,3 +27,6 @@ xmlt ai_history_baset::output_xml(void) const
   xml.data = out.str();
   return xml;
 }
+
+const ai_history_baset::trace_ptrt ai_history_baset::no_caller_history =
+  nullptr;

--- a/src/analyses/call_stack_history.h
+++ b/src/analyses/call_stack_history.h
@@ -81,7 +81,10 @@ public:
   {
   }
 
-  step_returnt step(locationt to, const trace_sett &others) const override;
+  step_returnt step(
+    locationt to,
+    const trace_sett &others,
+    trace_ptrt caller_hist) const override;
 
   bool operator<(const ai_history_baset &op) const override;
   bool operator==(const ai_history_baset &op) const override;

--- a/src/analyses/local_control_flow_history.cpp
+++ b/src/analyses/local_control_flow_history.cpp
@@ -1,0 +1,382 @@
+/*******************************************************************\
+
+Module: Abstract Interpretation
+
+Author: Martin Brain, martin.brain@cs.ox.ac.uk
+
+\*******************************************************************/
+
+/// \file
+/// Track function-local control flow for loop unwinding and path senstivity
+
+#include "local_control_flow_history.h"
+
+template <bool track_forward_jumps, bool track_backward_jumps>
+ai_history_baset::step_returnt
+local_control_flow_historyt<track_forward_jumps, track_backward_jumps>::step(
+  locationt to,
+  const trace_sett &others,
+  trace_ptrt caller_hist) const
+{
+  // First compute what the new history could be,
+  // then find it in others or possibly merge it if the limit is hit
+
+  std::shared_ptr<const local_control_flow_historyt<
+    track_forward_jumps,
+    track_backward_jumps>>
+    next_step = nullptr;
+
+  // Local branching is the key step
+  if(
+    current_loc->is_goto() &&
+    (current_loc->is_backwards_goto() ? track_backward_jumps
+                                      : track_forward_jumps))
+  {
+    bool branch_taken = (current_loc->get_target() == to) &&
+                        !(current_loc->get_target() == std::next(current_loc));
+    // Slight oddity -- we regard branches to the next instruction as not taken
+    // regardless of their guard condition.  This is slightly more general than
+    // is_skip() but without changing the step() interface to have a "taken"
+    // flag we will have to assume taken or not taken and not taken seems safer.
+
+    auto decision = std::make_shared<local_control_flow_decisiont>(
+      current_loc, branch_taken, control_flow_decision_history);
+    next_step = std::make_shared<
+      local_control_flow_historyt<track_forward_jumps, track_backward_jumps>>(
+      to, decision, max_histories_per_location);
+  }
+  else if(
+    current_loc->is_function_call() &&
+    std::next(this->current_loc)->location_number != to->location_number)
+  {
+    // Because the history is local (to avoid massive explosion in work)
+    // the history at function start should be a merge of all callers.
+    // As we dont' need to enforce the number of histories we return directly.
+    if(others.size() == 0)
+    {
+      next_step = std::make_shared<
+        local_control_flow_historyt<track_forward_jumps, track_backward_jumps>>(
+        to, nullptr, max_histories_per_location);
+      return std::make_pair(ai_history_baset::step_statust::NEW, next_step);
+    }
+    else
+    {
+      INVARIANT(
+        others.size() == 1,
+        "Function start should have at most one merged history");
+      INVARIANT(
+        to_local_control_flow_history(*(others.begin()))
+          ->is_path_merge_history(),
+        "The one history must be a merge point");
+
+      return std::make_pair(
+        ai_history_baset::step_statust::MERGED, *(others.begin()));
+    }
+  }
+  else if(current_loc->is_end_function())
+  {
+    // This is slightly complicated as we have to drop the current,
+    // callee history and pick up the caller history.
+    PRECONDITION(caller_hist != ai_history_baset::no_caller_history);
+
+    next_step = std::make_shared<
+      local_control_flow_historyt<track_forward_jumps, track_backward_jumps>>(
+      to,
+      to_local_control_flow_history(caller_hist)->control_flow_decision_history,
+      max_histories_per_location);
+  }
+  else
+  {
+    // No changes to be made to the control_flow_decision_history
+    // Is a local step forward with no branching (or a skipped function call).
+    next_step = std::make_shared<
+      local_control_flow_historyt<track_forward_jumps, track_backward_jumps>>(
+      to, control_flow_decision_history, max_histories_per_location);
+  }
+  INVARIANT(
+    next_step != nullptr, "All branches should create a candidate history");
+
+  // Now check whether this already exists
+  auto it = others.find(next_step);
+  if(it == others.end())
+  {
+    if(has_histories_per_location_limit())
+    {
+      auto number_of_histories = others.size();
+
+      if(number_of_histories < max_histories_per_location - 1)
+      {
+        // Still below limit so we can add one
+        return std::make_pair(ai_history_baset::step_statust::NEW, next_step);
+      }
+      else if(number_of_histories == max_histories_per_location - 1)
+      {
+        // Last space --> we must create the merged history
+        next_step = std::make_shared<local_control_flow_historyt<
+          track_forward_jumps,
+          track_backward_jumps>>(to, nullptr, max_histories_per_location);
+        return std::make_pair(ai_history_baset::step_statust::NEW, next_step);
+      }
+      else if(others.size() == max_histories_per_location)
+      {
+        // Already at limit, need to return the merged history
+
+        // This relies on operator< sorting null after other pointers
+        auto last_history_pointer = std::prev(others.end());
+
+        INVARIANT(
+          to_local_control_flow_history(*last_history_pointer)
+            ->is_path_merge_history(),
+          "The last history must be the merged one");
+
+        return std::make_pair(
+          ai_history_baset::step_statust::MERGED, *last_history_pointer);
+      }
+      else
+      {
+        INVARIANT(
+          others.size() <= max_histories_per_location,
+          "Histories-per-location limit should be enforced");
+      }
+    }
+    else
+    {
+      // No limit so ...
+      return std::make_pair(ai_history_baset::step_statust::NEW, next_step);
+    }
+  }
+  else
+  {
+    // An equivalent history is already available so return that
+    return std::make_pair(ai_history_baset::step_statust::MERGED, *it);
+  }
+  UNREACHABLE;
+}
+
+template <bool track_forward_jumps, bool track_backward_jumps>
+bool local_control_flow_historyt<track_forward_jumps, track_backward_jumps>::
+operator<(const ai_history_baset &op) const
+{
+  auto other = dynamic_cast<
+    const local_control_flow_historyt<track_forward_jumps, track_backward_jumps>
+      &>(op);
+
+  // Primary sort on the current location because it is fast, clusters relevant
+  // things. The side effect is that this can give depth-first search which may
+  // not be that "fair" when limiting the histories per location.
+  if(this->current_loc->location_number < other.current_loc->location_number)
+  {
+    return true;
+  }
+  else if(
+    this->current_loc->location_number > other.current_loc->location_number)
+  {
+    return false;
+  }
+  else
+  {
+    if(
+      this->control_flow_decision_history ==
+      other.control_flow_decision_history)
+    {
+      // They are equal so...
+      return false;
+    }
+    else if(other.control_flow_decision_history == nullptr)
+    {
+      // Special case so that the merged control flow history is last step's
+      // others set also means that non-merged histories are strictly preferred
+      // on the work queue
+      return true;
+    }
+    else if(this->control_flow_decision_history == nullptr)
+    {
+      // Another one, also guarding what we are about to do...
+      return false;
+    }
+    else
+    {
+      return (
+        *(this->control_flow_decision_history) <
+        *(other.control_flow_decision_history));
+    }
+  }
+  UNREACHABLE;
+}
+
+template <bool track_forward_jumps, bool track_backward_jumps>
+bool local_control_flow_historyt<track_forward_jumps, track_backward_jumps>::
+operator==(const ai_history_baset &op) const
+{
+  auto other = dynamic_cast<
+    const local_control_flow_historyt<track_forward_jumps, track_backward_jumps>
+      &>(op);
+
+  // Make the short-cutting clear
+  if(this->current_loc->location_number == other.current_loc->location_number)
+  {
+    if(
+      this->control_flow_decision_history ==
+      other.control_flow_decision_history)
+    {
+      return true;
+    }
+    else if(
+      this->control_flow_decision_history == nullptr ||
+      other.control_flow_decision_history == nullptr)
+    {
+      // Only one is null so clearly can't be equal
+      return false;
+    }
+    else
+    {
+      // Don't have unique construction so in things like step it is possible
+      // to get two distinct local_control_flow_decisiont objects that are equal
+      // in value.
+      return (
+        *(this->control_flow_decision_history) ==
+        *(other.control_flow_decision_history));
+    }
+  }
+  else
+  {
+    return false;
+  }
+  UNREACHABLE;
+}
+
+template <bool track_forward_jumps, bool track_backward_jumps>
+void local_control_flow_historyt<track_forward_jumps, track_backward_jumps>::
+  output(std::ostream &out) const
+{
+  out << "local_control_flow_history : location "
+      << current_loc->location_number;
+  lcfd_ptrt working = control_flow_decision_history;
+  while(working != nullptr)
+  {
+    out << " after " << working->branch_location->location_number;
+    if(working->branch_taken)
+    {
+      out << " taken";
+    }
+    else
+    {
+      out << " not taken";
+    }
+    working = working->previous;
+  }
+  return;
+}
+
+bool local_control_flow_decisiont::
+operator<(const local_control_flow_decisiont &op) const
+{
+  // Lower locations first, generally this means depth first
+  if(
+    this->branch_location->location_number <
+    op.branch_location->location_number)
+  {
+    return true;
+  }
+  else if(
+    this->branch_location->location_number >
+    op.branch_location->location_number)
+  {
+    return false;
+  }
+  else
+  {
+    INVARIANT(
+      this->branch_location->location_number ==
+        op.branch_location->location_number,
+      "Implied by if-then-else");
+
+    if(!this->branch_taken && op.branch_taken)
+    {
+      return true; // Branch not taken takes priority
+    }
+    else if(this->branch_taken && !op.branch_taken)
+    {
+      return false; // The reverse case of above
+    }
+    else
+    {
+      INVARIANT(
+        this->branch_taken == op.branch_taken, "Implied by if-then-else");
+
+      if(this->previous == op.previous)
+      {
+        return false; // They are the same decision chain
+      }
+      else if(this->previous == nullptr)
+      {
+        // This prioritises complete histories over merged ones
+        return false;
+      }
+      else if(op.previous == nullptr)
+      {
+        // Again, the reverse
+        return true;
+      }
+      else
+      {
+        // Neither is null so sort by recursing along the list
+        return *(this->previous) < *(op.previous);
+      }
+    }
+  }
+  UNREACHABLE;
+}
+
+bool local_control_flow_decisiont::
+operator==(const local_control_flow_decisiont &op) const
+{
+  // Compare location numbers because we can't be sure that
+  // both location iterators are from the same function
+  // and so the iterators may not be comparable
+  if(
+    this->branch_location->location_number ==
+    op.branch_location->location_number)
+  {
+    if(this->branch_taken == op.branch_taken)
+    {
+      if(this->previous == op.previous)
+      {
+        return true;
+      }
+      else
+      {
+        if((this->previous != nullptr) && (op.previous != nullptr))
+        {
+          return *(this->previous) == *(op.previous);
+        }
+      }
+    }
+  }
+  return false;
+}
+
+// Instantiate the versions we need
+template ai_history_baset::step_returnt
+local_control_flow_historyt<true, true>::step(
+  locationt to,
+  const trace_sett &others,
+  trace_ptrt caller_hist) const;
+
+template ai_history_baset::step_returnt
+local_control_flow_historyt<true, false>::step(
+  locationt to,
+  const trace_sett &others,
+  trace_ptrt caller_hist) const;
+
+template ai_history_baset::step_returnt
+local_control_flow_historyt<false, true>::step(
+  locationt to,
+  const trace_sett &others,
+  trace_ptrt caller_hist) const;
+
+template ai_history_baset::step_returnt
+local_control_flow_historyt<false, false>::step(
+  locationt to,
+  const trace_sett &others,
+  trace_ptrt caller_hist) const;

--- a/src/analyses/local_control_flow_history.h
+++ b/src/analyses/local_control_flow_history.h
@@ -1,0 +1,203 @@
+/*******************************************************************\
+
+Module: Abstract Interpretation
+
+Author: Martin Brain, martin.brain@cs.ox.ac.uk
+
+\*******************************************************************/
+
+/// \file
+/// Track function-local control flow for loop unwinding and path senstivity
+
+#ifndef CPROVER_ANALYSES_LOCAL_CONTROL_FLOW_HISTORY_H
+#define CPROVER_ANALYSES_LOCAL_CONTROL_FLOW_HISTORY_H
+
+#include "ai_history.h"
+
+/// Records all local control-flow decisions up to a limit of number of
+/// histories per location.  This gives a linear scaling between history limits
+/// and space and time used.  Note this does no interprocedural context so all
+/// calls will be merged to a single start point.
+
+/// The history is stored as a (shared) list of decisions, effectively a tree
+class local_control_flow_decisiont
+{
+public:
+  typedef ai_history_baset::locationt locationt;
+  locationt branch_location;
+  bool branch_taken;
+  typedef std::shared_ptr<const local_control_flow_decisiont> lcfd_ptrt;
+  lcfd_ptrt previous; // null at the start of the function
+
+  local_control_flow_decisiont(locationt loc, bool taken, lcfd_ptrt ptr)
+    : branch_location(loc), branch_taken(taken), previous(ptr)
+  {
+  }
+
+  bool operator<(const local_control_flow_decisiont &op) const;
+  bool operator==(const local_control_flow_decisiont &op) const;
+};
+
+/// Whether we track forwards and / or backwards jumps is compile-time fixed
+/// as it does not need to be variable and because there may be a *lot* of
+/// history objects created
+template <bool track_forward_jumps, bool track_backward_jumps>
+class local_control_flow_historyt : public ai_history_baset
+{
+protected:
+  typedef local_control_flow_decisiont::lcfd_ptrt lcfd_ptrt;
+
+  locationt current_loc;
+  lcfd_ptrt control_flow_decision_history;
+  size_t max_histories_per_location;
+
+  // A repeating idiom -- can cast from interface type to this type
+  // caller's responsibility to ensure correct types
+  std::shared_ptr<const local_control_flow_historyt<
+    track_forward_jumps,
+    track_backward_jumps>>
+  to_local_control_flow_history(trace_ptrt in) const
+  {
+    PRECONDITION(in != nullptr);
+    auto tmp = std::dynamic_pointer_cast<const local_control_flow_historyt<
+      track_forward_jumps,
+      track_backward_jumps>>(in);
+    PRECONDITION(tmp != nullptr);
+    return tmp;
+  }
+
+public:
+  // nullptr denotes this is the "merge all other CFG paths" node
+  bool is_path_merge_history(void) const
+  {
+    return control_flow_decision_history == nullptr;
+  }
+
+  // Set to 0 to disable but be aware that this may well diverge
+  // and not terminate
+  bool has_histories_per_location_limit(void) const
+  {
+    return max_histories_per_location != 0;
+  }
+
+  explicit local_control_flow_historyt(locationt loc)
+    : ai_history_baset(loc),
+      current_loc(loc),
+      control_flow_decision_history(
+        std::make_shared<local_control_flow_decisiont>(loc, true, nullptr)),
+      max_histories_per_location(0)
+  {
+  }
+
+  local_control_flow_historyt(locationt loc, lcfd_ptrt hist, size_t max_hist)
+    : ai_history_baset(loc),
+      current_loc(loc),
+      control_flow_decision_history(hist),
+      max_histories_per_location(max_hist)
+  {
+  }
+
+  local_control_flow_historyt(locationt loc, size_t max_hist)
+    : ai_history_baset(loc),
+      current_loc(loc),
+      control_flow_decision_history(
+        std::make_shared<local_control_flow_decisiont>(loc, true, nullptr)),
+      max_histories_per_location(max_hist)
+  {
+  }
+
+  local_control_flow_historyt(
+    const local_control_flow_historyt<track_forward_jumps, track_backward_jumps>
+      &old)
+    : ai_history_baset(old.current_loc),
+      current_loc(old.current_loc),
+      control_flow_decision_history(old.control_flow_decision_history),
+      max_histories_per_location(old.max_histories_per_location)
+  {
+  }
+
+  step_returnt step(
+    locationt to,
+    const trace_sett &others,
+    trace_ptrt caller_hist) const override;
+
+  bool operator<(const ai_history_baset &op) const override;
+  bool operator==(const ai_history_baset &op) const override;
+
+  const locationt &current_location(void) const override
+  {
+    return current_loc;
+  }
+
+  // If there is no history, then it is because we have merged
+  // If we are merging control flow histories then we should probably
+  // also widen on domain merge so that analysis converges faster.
+  bool should_widen(const ai_history_baset &other) const override
+  {
+    return is_path_merge_history();
+  }
+
+  void output(std::ostream &out) const override;
+};
+
+// Sets the kind of jumps to track and the max number of histories per location
+class local_control_flow_history_factoryt : public ai_history_factory_baset
+{
+protected:
+  bool track_forward_jumps;
+  bool track_backward_jumps;
+  size_t max_histories_per_location;
+
+public:
+  local_control_flow_history_factoryt(
+    bool track_f,
+    bool track_b,
+    size_t max_hist)
+    : track_forward_jumps(track_f),
+      track_backward_jumps(track_b),
+      max_histories_per_location(max_hist)
+  {
+  }
+
+  ai_history_baset::trace_ptrt epoch(ai_history_baset::locationt l) override
+  {
+    if(track_forward_jumps)
+    {
+      if(track_backward_jumps)
+      {
+        // All local control flow branches
+        return std::make_shared<local_control_flow_historyt<true, true>>(
+          l, max_histories_per_location);
+      }
+      else
+      {
+        // "Path sensitive" but merge loops eagerly
+        return std::make_shared<local_control_flow_historyt<true, false>>(
+          l, max_histories_per_location);
+      }
+    }
+    else
+    {
+      if(track_backward_jumps)
+      {
+        // Loop unwinding but merge branches eagerly
+        return std::make_shared<local_control_flow_historyt<false, true>>(
+          l, max_histories_per_location);
+      }
+      else
+      {
+        // Ignore all branches.  Same effect as ahistorical but at more cost???
+        return std::make_shared<local_control_flow_historyt<false, false>>(
+          l, max_histories_per_location);
+      }
+    }
+    UNREACHABLE;
+  }
+
+  virtual ~local_control_flow_history_factoryt()
+  {
+    // Pointer is reference counted.
+  }
+};
+
+#endif // CPROVER_ANALYSES_LOCAL_CONTROL_FLOW_HISTORY_H

--- a/src/goto-analyzer/goto_analyzer_parse_options.cpp
+++ b/src/goto-analyzer/goto_analyzer_parse_options.cpp
@@ -48,6 +48,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <analyses/goto_check.h>
 #include <analyses/interval_domain.h>
 #include <analyses/is_threaded.h>
+#include <analyses/local_control_flow_history.h>
 #include <analyses/local_may_alias.h>
 
 #include <langapi/mode.h>
@@ -295,6 +296,34 @@ void goto_analyzer_parse_optionst::get_command_line_options(optionst &options)
         "call-stack-recursion-limit", cmdline.get_value("call-stack"));
       options.set_option("history set", true);
     }
+    else if(cmdline.isset("loop-unwind"))
+    {
+      options.set_option("local-control-flow-history", true);
+      options.set_option("local-control-flow-history-forward", false);
+      options.set_option("local-control-flow-history-backward", true);
+      options.set_option(
+        "local-control-flow-history-limit", cmdline.get_value("loop-unwind"));
+      options.set_option("history set", true);
+    }
+    else if(cmdline.isset("branching"))
+    {
+      options.set_option("local-control-flow-history", true);
+      options.set_option("local-control-flow-history-forward", true);
+      options.set_option("local-control-flow-history-backward", false);
+      options.set_option(
+        "local-control-flow-history-limit", cmdline.get_value("branching"));
+      options.set_option("history set", true);
+    }
+    else if(cmdline.isset("loop-unwind-and-branching"))
+    {
+      options.set_option("local-control-flow-history", true);
+      options.set_option("local-control-flow-history-forward", true);
+      options.set_option("local-control-flow-history-backward", true);
+      options.set_option(
+        "local-control-flow-history-limit",
+        cmdline.get_value("loop-unwind-and-branching"));
+      options.set_option("history set", true);
+    }
 
     if(!options.get_bool_option("history set"))
     {
@@ -399,6 +428,13 @@ ai_baset *goto_analyzer_parse_optionst::build_analyzer(
     {
       hf = util_make_unique<call_stack_history_factoryt>(
         options.get_unsigned_int_option("call-stack-recursion-limit"));
+    }
+    else if(options.get_bool_option("local-control-flow-history"))
+    {
+      hf = util_make_unique<local_control_flow_history_factoryt>(
+        options.get_bool_option("local-control-flow-history-forward"),
+        options.get_bool_option("local-control-flow-history-backward"),
+        options.get_unsigned_int_option("local-control-flow-history-limit"));
     }
 
     // Build the domain factory
@@ -855,6 +891,18 @@ void goto_analyzer_parse_optionst::help()
     " --call-stack n               track the calling location stack for each function\n"
     // NOLINTNEXTLINE(whitespace/line_length)
     "                              limiting to at most n recursive loops, 0 to disable\n"
+    // NOLINTNEXTLINE(whitespace/line_length)
+    " --loop-unwind n              track the number of loop iterations within a function\n"
+    // NOLINTNEXTLINE(whitespace/line_length)
+    "                              limited to n histories per location, 0 is unlimited\n"
+    // NOLINTNEXTLINE(whitespace/line_length)
+    " --branching n                track the forwards jumps (if, switch, etc.) within a function\n"
+    // NOLINTNEXTLINE(whitespace/line_length)
+    "                              limited to n histories per location, 0 is unlimited\n"
+    // NOLINTNEXTLINE(whitespace/line_length)
+    " --loop-unwind-and-branching n track all local control flow\n"
+    // NOLINTNEXTLINE(whitespace/line_length)
+    "                              limited to n histories per location, 0 is unlimited\n"
     "\n"
     "Domain options:\n"
     " --constants                  a constant for each variable if possible\n"

--- a/src/goto-analyzer/goto_analyzer_parse_options.h
+++ b/src/goto-analyzer/goto_analyzer_parse_options.h
@@ -120,7 +120,10 @@ class optionst;
 
 #define GOTO_ANALYSER_OPTIONS_HISTORY \
   "(ahistorical)" \
-  "(call-stack):"
+  "(call-stack):" \
+  "(loop-unwind):" \
+  "(branching):" \
+  "(loop-unwind-and-branching):"
 
 #define GOTO_ANALYSER_OPTIONS_DOMAIN \
   "(intervals)" \


### PR DESCRIPTION
In the past users have had to modify the program before analysis to get this kind of precision.  Doing so is expensive in terms of memory for both the program and the analysis.  This gives a more efficient route.  The is an equivalent of an unwinding limit that controls the number of histories that can be generated for each location.  This is a better measure as it should scale memory linearly and time linearly(ish) while loop unwinding can have seriously non-linear effects when there are nested loops.

This is the enabling technology for a "loop unwinding" analysis that can automatically over-approximate loop bounds.  It is also probably the last "core" change to the AI infrastructure before VSD can be merged in full.
<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
