### PR TITLE
Fix type mismatch in goto-harness on calling array constructor.

### DIFF
--- a/regression/goto-harness/array-types/example.c
+++ b/regression/goto-harness/array-types/example.c
@@ -1,0 +1,4 @@
+void test(signed int *arr)
+{
+  arr[0l] = 5;
+}

--- a/regression/goto-harness/array-types/test.desc
+++ b/regression/goto-harness/array-types/test.desc
@@ -1,0 +1,11 @@
+CORE
+example.c
+--harness-type call-function --function test --treat-pointer-as-array arr
+VERIFICATION SUCCESSFUL
+^EXIT=0$
+^SIGNAL=0$
+type_constructor_ptr_int\(0, &arr, \(signed int \*\)\(void \*\)0\);
+--
+incompatible pointer types
+--
+Ensure that the function pointer types match

--- a/src/goto-harness/recursive_initialization.cpp
+++ b/src/goto-harness/recursive_initialization.cpp
@@ -209,12 +209,12 @@ void recursive_initializationt::initialize(
       {
         const auto &fun_type_params =
           to_code_type(fun_symbol.type).parameters();
-        const typet &size_var_type = fun_type_params.back().type();
+        const pointer_typet *size_var_type =
+          type_try_dynamic_cast<pointer_typet>(fun_type_params.back().type());
+        INVARIANT(size_var_type, "Size parameter must have pointer type.");
         body.add(code_function_callt{
           fun_symbol.symbol_expr(),
-          {depth,
-           address_of_exprt{lhs},
-           null_pointer_exprt{pointer_type(size_var_type)}}});
+          {depth, address_of_exprt{lhs}, null_pointer_exprt{*size_var_type}}});
       }
       return;
     }


### PR DESCRIPTION
Fix type mismatch in goto-harness on calling array constructor.

- [x] Each commit message has a non-empty body, explaining why the change was made.
- N/A - Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- N/A - The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [X] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- N/A - My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- [X] White-space or formatting changes outside the feature-related changed lines are in commits of their own.