### PR TITLE
Do not use side_effect_expr_nondett in recursive_initialization

### DIFF
--- a/regression/goto-harness/do-not-use-nondet-for-primitives/test.c
+++ b/regression/goto-harness/do-not-use-nondet-for-primitives/test.c
@@ -1,0 +1,6 @@
+#include <assert.h>
+
+void test_function(int test)
+{
+  assert(test != 42);
+}

--- a/regression/goto-harness/do-not-use-nondet-for-primitives/test.desc
+++ b/regression/goto-harness/do-not-use-nondet-for-primitives/test.desc
@@ -1,0 +1,17 @@
+CORE
+test.c
+--function test_function --harness-type call-function
+\[test_function\.assertion\.1\] line \d+ assertion test != 42
+^EXIT=10$
+^SIGNAL=0$
+--
+nondet_signed_int
+--
+If we use side_effect_expr_nondett then dump_c will generation function calls
+to functions with names like nondet_signed_int without declaration.
+This can cause problems around usability.
+
+To fix this, we changed goto-harness to just not use side_effect_expr_nondett
+at all.
+
+This test tests for the absence the use for these things.

--- a/regression/goto-harness/do-not-use-nondet-for-recursion/test.c
+++ b/regression/goto-harness/do-not-use-nondet-for-recursion/test.c
@@ -1,0 +1,11 @@
+struct linked_list
+{
+  struct linked_list *next;
+};
+
+void test(struct linked_list *list)
+{
+  assert(list);
+  assert(list->next);
+  assert(!list->next);
+}

--- a/regression/goto-harness/do-not-use-nondet-for-recursion/test.desc
+++ b/regression/goto-harness/do-not-use-nondet-for-recursion/test.desc
@@ -1,0 +1,14 @@
+CORE
+test.c
+--function test --harness-type call-function
+\[test.assertion.1\] line \d+ assertion list: SUCCESS
+\[test.assertion.2\] line \d+ assertion list->next: FAILURE
+\[test.assertion.3\] line \d+ assertion !\(list->next != \(\(struct linked_list \*\).*\)\): FAILURE
+should_recurse_nondet
+^EXIT=10$
+^SIGNAL=0$
+--
+__CPROVER_nondet_bool
+--
+This is to check that we use the new mechanism to decide whether we should recurse
+non-deterministically (i.e. without using side_effect_expr_nondett).

--- a/regression/goto-harness/do-not-use-nondet-for-selecting-pointers-to-treat-as-equal/test.c
+++ b/regression/goto-harness/do-not-use-nondet-for-selecting-pointers-to-treat-as-equal/test.c
@@ -1,0 +1,8 @@
+void test(int *x, int *y)
+{
+  assert(x);
+  assert(y);
+  assert(x == y);
+  assert(x != y);
+  assert(*x == *y);
+}

--- a/regression/goto-harness/do-not-use-nondet-for-selecting-pointers-to-treat-as-equal/test.desc
+++ b/regression/goto-harness/do-not-use-nondet-for-selecting-pointers-to-treat-as-equal/test.desc
@@ -1,0 +1,18 @@
+CORE
+test.c
+--function test --harness-type call-function --treat-pointers-equal x,y --treat-pointers-equal-maybe
+should_make_equal
+\[test.assertion.1\] line 3 assertion x: SUCCESS
+\[test.assertion.2\] line 4 assertion y: SUCCESS
+\[test.assertion.3\] line 5 assertion x == y: FAILURE
+\[test.assertion.4\] line 6 assertion x != y: FAILURE
+\[test.assertion.5\] line 7 assertion \*x == \*y: FAILURE
+^EXIT=10$
+^SIGNAL=0$
+--
+__CPROVER_nondet_bool
+--
+We are no longer using side_effect_expr_nondett for nondet primitives,
+specifically this is testing that we are using a variable called some variation
+of “should_make_equal” (plus some optional postfix) as the condition variable
+that assigns the same destination to pointers.

--- a/src/goto-harness/recursive_initialization.h
+++ b/src/goto-harness/recursive_initialization.h
@@ -262,11 +262,6 @@ private:
     const exprt &size,
     const optionalt<irep_idt> &lhs_name);
 
-  /// Constructor for strings: as array but the last element is zero.
-  /// \param result: symbol of the result parameter
-  /// \return the body of the constructor
-  code_blockt build_array_string_constructor(const symbol_exprt &result) const;
-
   /// Select the specified struct-member to be non-deterministically
   ///   initialized.
   /// \param lhs: symbol expression of the top structure


### PR DESCRIPTION
If we use side_effect_expr_nondett then dump_c will generation function calls
to functions with names like `nondet_int` without declaration.

This is a problem because it’ll lead the C frontend to complain about
undeclared identifiers and such.

To fix this, we changed goto-harness to just not use side_effect_expr_nondett
at all (better long term fix would be to make sure `dump_c` outputs
declarations too).

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
