### PR TITLE
Havoc undefined functions during symbolic execution

### DIFF
--- a/regression/cbmc/havoc_undefined_functions/main.c
+++ b/regression/cbmc/havoc_undefined_functions/main.c
@@ -1,0 +1,9 @@
+void function(int *a);
+
+int main()
+{
+  int a = 0;
+  function(&a);
+  __CPROVER_assert(a == 0, "");
+  return 0;
+}

--- a/regression/cbmc/havoc_undefined_functions/test.desc
+++ b/regression/cbmc/havoc_undefined_functions/test.desc
@@ -1,0 +1,6 @@
+CORE
+main.c
+--havoc-undefined-functions
+^EXIT=10$
+^SIGNAL=0$
+^VERIFICATION FAILED$

--- a/src/cbmc/cbmc_parse_options.cpp
+++ b/src/cbmc/cbmc_parse_options.cpp
@@ -240,6 +240,9 @@ void cbmc_parse_optionst::get_command_line_options(optionst &options)
   if(cmdline.isset("drop-unused-functions"))
     options.set_option("drop-unused-functions", true);
 
+  if(cmdline.isset("havoc-undefined-functions"))
+    options.set_option("havoc-undefined-functions", true);
+
   if(cmdline.isset("string-abstraction"))
     options.set_option("string-abstraction", true);
 
@@ -1082,6 +1085,9 @@ void cbmc_parse_optionst::help()
     HELP_REACHABILITY_SLICER_FB
     " --full-slice                 run full slicer (experimental)\n" // NOLINT(*)
     " --drop-unused-functions      drop functions trivially unreachable from main function\n" // NOLINT(*)
+    " --havoc-undefined-functions\n"
+    "                              for any function that has no body, assign non-deterministic values to\n" // NOLINT(*)
+    "                              any parameters passed as non-const pointers and the return value\n" // NOLINT(*)
     "\n"
     "Semantic transformations:\n"
     // NOLINTNEXTLINE(whitespace/line_length)

--- a/src/cbmc/cbmc_parse_options.h
+++ b/src/cbmc/cbmc_parse_options.h
@@ -67,6 +67,7 @@ class optionst;
   OPT_SHOW_PROPERTIES \
   "(show-symbol-table)(show-parse-tree)" \
   "(drop-unused-functions)" \
+  "(havoc-undefined-functions)" \
   "(property):(stop-on-fail)(trace)" \
   "(error-label):(verbosity):(no-library)" \
   "(nondet-static)" \

--- a/src/goto-checker/symex_bmc.cpp
+++ b/src/goto-checker/symex_bmc.cpp
@@ -33,6 +33,8 @@ symex_bmct::symex_bmct(
       path_storage,
       guard_manager),
     record_coverage(!options.get_option("symex-coverage-report").empty()),
+    havoc_bodyless_functions(
+      options.get_bool_option("havoc-undefined-functions")),
     symex_coverage(ns)
 {
 }
@@ -210,7 +212,13 @@ void symex_bmct::no_body(const irep_idt &identifier)
 {
   if(body_warnings.insert(identifier).second)
   {
-    log.warning() << "**** WARNING: no body for function " << identifier
-                  << log.eom;
+    log.warning() << "**** WARNING: no body for function " << identifier;
+
+    if(havoc_bodyless_functions)
+    {
+      log.warning()
+        << "; assigning non-deterministic values to any pointer arguments";
+    }
+    log.warning() << log.eom;
   }
 }

--- a/src/goto-checker/symex_bmc.h
+++ b/src/goto-checker/symex_bmc.h
@@ -81,6 +81,7 @@ public:
   }
 
   const bool record_coverage;
+  const bool havoc_bodyless_functions;
 
   unwindsett unwindset;
 

--- a/src/goto-symex/symex_config.h
+++ b/src/goto-symex/symex_config.h
@@ -34,6 +34,8 @@ struct symex_configt final
 
   bool partial_loops;
 
+  bool havoc_undefined_functions;
+
   mp_integer debug_level;
 
   /// \brief Should the additional validation checks be run?

--- a/src/goto-symex/symex_main.cpp
+++ b/src/goto-symex/symex_main.cpp
@@ -42,6 +42,8 @@ symex_configt::symex_configt(const optionst &options)
     simplify_opt(options.get_bool_option("simplify")),
     unwinding_assertions(options.get_bool_option("unwinding-assertions")),
     partial_loops(options.get_bool_option("partial-loops")),
+    havoc_undefined_functions(
+      options.get_bool_option("havoc-undefined-functions")),
     debug_level(unsafe_string2int(options.get_option("debug-level"))),
     run_validation_checks(options.get_bool_option("validate-ssa-equation")),
     show_symex_steps(options.get_bool_option("show-goto-symex-steps")),


### PR DESCRIPTION
This havocs any modifiable arguments passed to undefined functions
at symex time. It is enabled by --havoc-undefined-functions

It is possible to achieve a similar result by using goto-instrument generate-function-bodies with the correct command line options but only if the binaries you are using this on are small. goto-instrument generate-function-bodies fails to finish within 1 hour on binaries taken from Xen. Havoc-ing during symex time allows us to run CBMC without generating the function bodies, and CBMC finishes within ten minutes.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- [X] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/

Where am I supposed to document this? None of the symex configuration options seem to be documented in the user guide?

- [X] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [X] My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- [X] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
