### PR TITLE
Fix static symbols referencing in harness file

### DIFF
--- a/regression/goto-harness-multi-file-project/static_symbols_referencing/first_one.c
+++ b/regression/goto-harness-multi-file-project/static_symbols_referencing/first_one.c
@@ -1,0 +1,25 @@
+#include "first_one.h"
+#include <assert.h>
+
+static int static_function(int a)
+{
+  assert(a == 0);
+  return a;
+}
+
+int non_static_function(int a)
+{
+  return static_function(a);
+}
+
+static int with_matching_signature(int a)
+{
+  assert(0 && "this is not reachable as far as goto-harness is concerned");
+  return 0;
+}
+
+void non_static_with_non_matching_signature(void)
+{
+  // this is just here so `static_with_matching_signature` has a non-file-local use
+  assert(static_with_matching_signature(10) == 10);
+}

--- a/regression/goto-harness-multi-file-project/static_symbols_referencing/first_one.h
+++ b/regression/goto-harness-multi-file-project/static_symbols_referencing/first_one.h
@@ -1,0 +1,1 @@
+int non_static_function(int a);

--- a/regression/goto-harness-multi-file-project/static_symbols_referencing/second_one.c
+++ b/regression/goto-harness-multi-file-project/static_symbols_referencing/second_one.c
@@ -1,0 +1,8 @@
+#include "first_one.h"
+
+int another(int (*fun_ptr)(int), int c)
+{
+  int a = (*fun_ptr)(c);
+
+  return a;
+}

--- a/regression/goto-harness-multi-file-project/static_symbols_referencing/test.desc
+++ b/regression/goto-harness-multi-file-project/static_symbols_referencing/test.desc
@@ -1,0 +1,15 @@
+CORE
+dummy.c
+--function another --harness-type call-function
+^EXIT=10$
+^SIGNAL=0$
+\[static_function\.assertion\.1\] line \d assertion a == 0: FAILURE
+\[non_static_with_non_matching_signature\.assertion\.1] line \d+ assertion static_with_matching_signature\(10\) == 10: SUCCESS
+
+^VERIFICATION FAILED$
+--
+^CONVERSION ERROR$
+--
+For this particular error, we care mostly that goto-harness
+doesn't reference static symbols in other files, which would
+cause analysis through CBMC to fail with a conversion error.

--- a/src/goto-programs/name_mangler.cpp
+++ b/src/goto-programs/name_mangler.cpp
@@ -19,7 +19,7 @@ operator()(const symbolt &src, const std::string &extra_info)
   std::string basename = get_base_name(src.location.get_file().c_str(), false);
 
   std::stringstream ss;
-  ss << CPROVER_PREFIX << "file_local_";
+  ss << FILE_LOCAL_PREFIX;
   ss << std::regex_replace(
           std::regex_replace(basename, forbidden, "_"), multi_under, "_")
      << "_";
@@ -42,7 +42,7 @@ operator()(const symbolt &src, const std::string &extra_info)
   uint32_t eight_nibble_hash = (uint32_t)hash;
 
   std::stringstream ss;
-  ss << CPROVER_PREFIX << "file_local_" << std::setfill('0') << std::setw(8)
-     << std::hex << eight_nibble_hash << "_" << extra_info << "_" << src.name;
+  ss << FILE_LOCAL_PREFIX << std::setfill('0') << std::setw(8) << std::hex
+     << eight_nibble_hash << "_" << extra_info << "_" << src.name;
   return irep_idt(ss.str());
 }

--- a/src/goto-programs/name_mangler.h
+++ b/src/goto-programs/name_mangler.h
@@ -13,6 +13,8 @@
 #include <regex>
 #include <vector>
 
+#define FILE_LOCAL_PREFIX CPROVER_PREFIX "file_local_"
+
 /// \brief Mangles the names in an entire program and its symbol table
 ///
 /// The type parameter to this class should be a functor that has a no-arg


### PR DESCRIPTION
This is fixing an issue we came across when trying to run `goto-harness` against the batch jobs in the https://github.com/awslabs/aws-c-common/tree/master/.cbmc-batch/jobs files, where the tool would generate harnesses that referenced static symbols in different files.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
