### PR TITLE
show flow-insensitive value set

### DIFF
--- a/src/goto-instrument/goto_instrument_parse_options.cpp
+++ b/src/goto-instrument/goto_instrument_parse_options.cpp
@@ -54,6 +54,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <pointer-analysis/goto_program_dereference.h>
 #include <pointer-analysis/show_value_sets.h>
 #include <pointer-analysis/value_set_analysis.h>
+#include <pointer-analysis/value_set_analysis_fi.h>
 
 #include <analyses/call_graph.h>
 #include <analyses/constant_propagator.h>
@@ -290,6 +291,17 @@ int goto_instrument_parse_optionst::doit()
       value_set_analysis(goto_model.goto_functions);
       show_value_sets(
         ui_message_handler.get_ui(), goto_model, value_set_analysis);
+      return CPROVER_EXIT_SUCCESS;
+    }
+
+    if(cmdline.isset("show-value-set-fi"))
+    {
+      namespacet ns(goto_model.symbol_table);
+      value_set_analysis_fit value_set(
+        ns, value_set_analysis_fit::track_optionst::TRACK_FUNCTION_POINTERS);
+
+      value_set(goto_model.goto_functions);
+      value_set.output(goto_model.goto_functions, std::cout);
       return CPROVER_EXIT_SUCCESS;
     }
 

--- a/src/goto-instrument/goto_instrument_parse_options.h
+++ b/src/goto-instrument/goto_instrument_parse_options.h
@@ -74,6 +74,7 @@ Author: Daniel Kroening, kroening@kroening.com
   OPT_SHOW_PROPERTIES \
   "(drop-unused-functions)" \
   "(show-value-sets)" \
+  "(show-value-set-fi)" \
   "(show-global-may-alias)" \
   "(show-local-bitvector-analysis)(show-custom-bitvector-analysis)" \
   "(show-escape-analysis)(escape-analysis)" \


### PR DESCRIPTION
Adds command line argument to goto-instrument to show the flow insensitive value set. Previously only possible to show the flow sensitive value set. Does not add this command line argument to help file, to be consistent with the original flow sensitive value set

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- [X] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/

None of the existing similar goto-instrument options are documented, or in the help file so I assume these are not meant to be publicly advertised features

- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).

I haven't added new features, just the ability to print the result

- [X] My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- [X] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
