### PR TITLE
Add human readable error message for invalid main signatures

### DIFF
--- a/regression/cbmc/human-readable-error-on-wrong-main-signature/main.c
+++ b/regression/cbmc/human-readable-error-on-wrong-main-signature/main.c
@@ -1,0 +1,12 @@
+#include <assert.h>
+#include <stddef.h>
+
+struct foo
+{
+  int x;
+  int y;
+};
+
+int main(struct foo *p)
+{
+}

--- a/regression/cbmc/human-readable-error-on-wrong-main-signature/test.desc
+++ b/regression/cbmc/human-readable-error-on-wrong-main-signature/test.desc
@@ -1,0 +1,11 @@
+CORE
+main.c
+
+'main' with signature .* found
+^EXIT=6$
+^SIGNAL=0$
+--
+Invariant check failed
+--
+This is just to check that CBMC doesn’t crash when we see a ‘main’ function
+with an unexpected signature, see https://github.com/diffblue/cbmc/issues/5415

--- a/src/ansi-c/ansi_c_entry_point.cpp
+++ b/src/ansi-c/ansi_c_entry_point.cpp
@@ -18,6 +18,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <linking/static_lifetime_init.h>
 
 #include "c_nondet_symbol_factory.h"
+#include "expr2c.h"
 
 exprt::operandst build_function_environment(
   const code_typet::parameterst &parameters,
@@ -473,7 +474,19 @@ bool generate_ansi_c_start_function(
       }
     }
     else
-      UNREACHABLE;
+    {
+      const namespacet ns{symbol_table};
+      const std::string main_signature = type2c(symbol.type, ns);
+      throw invalid_source_file_exceptiont{
+        "'main' with signature '" + main_signature +
+        "' found,"
+        " but expecting one of:\n"
+        "   int main(void)\n"
+        "   int main(int argc, char *argv[])\n"
+        "   int main(int argc, char *argv[], char *envp[])\n"
+        "If this is a non-standard main entry point please provide a custom\n"
+        "entry function and point to it via cbmc --function instead"};
+    }
   }
   else
   {


### PR DESCRIPTION
Currently we have special handling if the entry point for analysis is called
`main`, in particular we assume it is one of the following:

    int main(void)
    int main(int argc, char *argv[])
    int main(int argc, char *argv[], char *envp[])

If it is not so far we have been failing with an UNREACHABLE invariant failure.
Since it is completely possible to have a main signature like that, we should
fail with a proper human readable error message that tells people what is wrong
and maybe how they can work around it.

For now, addresses https://github.com/diffblue/cbmc/issues/5415. As I say in that ticket maybe we want to handle non-standard `main` signatures in a more graceful way, but until we decide on that having a better error message should take away some of the pain.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
