### PR TITLE
Generate index expressions for deref(p + offset), where p points to an array in a struct

### DIFF
--- a/regression/cbmc/array-cell-sensitivity15/access.c
+++ b/regression/cbmc/array-cell-sensitivity15/access.c
@@ -1,0 +1,16 @@
+struct st
+{
+  char c;
+  int n[4];
+};
+
+int main()
+{
+  unsigned i;
+  int k;
+  i %= 4;
+  struct st s;
+  int *p = s.n;
+  p[i] = k;
+  return 0;
+}

--- a/regression/cbmc/array-cell-sensitivity15/test.desc
+++ b/regression/cbmc/array-cell-sensitivity15/test.desc
@@ -1,0 +1,11 @@
+CORE paths-lifo-expected-failure
+access.c
+--program-only
+^EXIT=0$
+^SIGNAL=0$
+s!0@1#1\.\.n == \{ s!0@1#1\.\.n\[\[0\]\], s!0@1#1\.\.n\[\[1\]\], s!0@1#1\.\.n\[\[2\]\], s!0@1#1\.\.n\[\[3\]\] } WITH \[\(.*\)i!0@1#2:=k!0@1#1\]
+--
+byte_update
+--
+This tests applying field-sensitivity to a pointer to an array that is part of a struct. See cbmc issue #5397 and PR #5418 for more detail.
+Disabled for paths-lifo mode, which does not support --program-only.

--- a/regression/validate-trace-xml-schema/check.py
+++ b/regression/validate-trace-xml-schema/check.py
@@ -28,6 +28,7 @@ ExcludedTests = list(map(lambda s: os.path.join(test_base_dir, s[0], s[1]), [
     # program-only instead of trace
     ['vla1', 'program-only.desc'],
     ['Quantifiers-simplify', 'simplify_not_forall.desc'],
+    ['array-cell-sensitivity15', 'test.desc'],
     # these test for invalid command line handling
     ['bad_option', 'test_multiple.desc'],
     ['bad_option', 'test.desc'],

--- a/src/pointer-analysis/value_set_dereference.h
+++ b/src/pointer-analysis/value_set_dereference.h
@@ -59,6 +59,12 @@ public:
   /// \param display_points_to_sets: Display size and contents of points to sets
   exprt dereference(const exprt &pointer, bool display_points_to_sets = false);
 
+  /// If `expr` is of the form (c1 ? e1[o1] : c2 ? e2[o2] : c3 ? ...)
+  /// then return `c1 ? e1[o1 + offset] : e2[o2 + offset] : c3 ? ...`
+  /// otherwise return an empty optionalt.
+  optionalt<exprt>
+  try_add_offset_to_indices(const exprt &expr, const exprt &offset);
+
   /// Return value for `build_reference_to`; see that method for documentation.
   class valuet
   {


### PR DESCRIPTION
Currently if offset is unknown, value_set_dereference will resolve p + offset to [(o1, unknown), (o2, unknown), ...], ultimately leading to a byte-update operation that may touch any of o1, o2 etc and specifically knocks them both out of the constant propagator.

With this change if p is known to point to arrays or array-members of structs then we will produce an expression like (c1 ? array1[offset] : c2 ? someobj.array2[offset] : ...)

Field-sensitivity may then kick in and update only the array within someobj, rather than the whole struct (this is unsound, but mirrors our behaviour when an array-in-struct is directly referenced. We may want to make this behaviour optional if the user is intentionally searching for solutions involving out-of-bounds accesses)

Note this is quite similar to value_set_dereferencet::build_reference_to's behaviour when referring to an array (but not an array within a struct), which builds an index expression instead of a byte-extract op. We can't extend that code however as the (constant + nonconstant) form of the pointer being dereferenced is lost by then.

TODOs to get this to usable standard: add tests, check particular if there's any bad interaction between array-type / index-type casts, such as deref'ing an int* whose underlying objects are char arrays.

The interplay of `value_set`, the `value_set_dereferencet` wrapper around it, the `goto_symext::dereference_rec` wrapper around *that*, and `build_reference_to`, `memory_model` and `memory_model_bytes` all attempting to salvage what would otherwise be byte-extract operations has become an unholy mess. Possible suggestion any forthcoming sponsored work on CBMC: document / clean them up?