### PR TITLE
github: always test Xen

### DIFF
--- a/.github/workflows/build-and-test-Xen.yml
+++ b/.github/workflows/build-and-test-Xen.yml
@@ -1,0 +1,26 @@
+name: Build and Test Xen
+
+on: [push]
+
+jobs:
+  Linux:
+
+    runs-on: ubuntu-18.04
+
+    steps:
+    - name: Install Packages
+      run: sudo apt-get install coreutils \
+        build-essential gcc git make flex bison \
+        software-properties-common libwww-perl python \
+        bin86 gdb bcc liblzma-dev python-dev gettext iasl \
+        uuid-dev libncurses5-dev libncursesw5-dev pkg-config \
+        libgtk2.0-dev libyajl-dev sudo time
+
+    - uses: actions/checkout@v1
+
+    - name: build CBMC tools
+      run: make -C src minisat2-download
+      run: make -C src cbmc.dir goto-cc.dir goto-diff.dir
+
+    - name: get Xen 4.13
+      run: git clone git://xenbits.xen.org/xen.git xen_4_13 && cd xen_4_13 && git reset --hard RELEASE-4.13.0


### PR DESCRIPTION
We want to make sure Xen related workflows are not broken in the future.
As github workflows offer 6h runtime, this is a good opportunity.
Furthermore, setup and usage is simple.

The current state of the file adds compiling CBMC, as well as getting
Xen. We will add next steps incrementally.

Signed-off-by: Norbert Manthey <nmanthey@amazon.de>

CR: https://code.amazon.com/reviews/CR-28954277

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
