### PR TITLE
GitHub actions

### DIFF
--- a/.github/workflows/debian/64bit_regression_tests.patch
+++ b/.github/workflows/debian/64bit_regression_tests.patch
@@ -1,5 +1,14 @@
---- 64bit_regression_tests	2020-06-19 16:40:45.963502746 +0000
-+++ 64bit_regression_tests_patch	2020-06-19 16:42:12.338994730 +0000
+--- /tmp/64bit_regression_tests	2020-07-24 18:34:51.811830486 +0000
++++ 64bit_regression_tests	2020-07-24 18:36:44.827779374 +0000
+@@ -87,7 +87,7 @@
+  <type>union myunion</type>
+ -<full_lhs>byte_extract_little_endian\(u, 0ll?, .*int.*\)</full_lhs>
+ +<full_lhs>byte_extract_little_endian\(u, 0l?l?, .*int.*\)</full_lhs>
+- <full_lhs_value>\d+ll?</full_lhs_value>
++ <full_lhs_value binary="[01]+">\d+ll?</full_lhs_value>
+  <value>\{ \.i=\d+ll? \}</value>
+  <value_expression>
+ --- cbmc-5.12.orig/regression/cbmc/byte_update11/main.c
 @@ -147,14 +147,14 @@
   --harness-type call-function --function test --treat-pointer-as-array arr --associated-array-size arr:sz
   ^EXIT=0$

--- a/.github/workflows/packages.yaml
+++ b/.github/workflows/packages.yaml
@@ -69,7 +69,7 @@ jobs:
           echo CBMC_VERSION = ${{ steps.version.outputs.cbmc_version }}
           echo PKG_VERSION = ${{ steps.version.outputs.pkg_version }}
 
-  Ubuntu16_Stable:
+  Ubuntu16:
     name: Ubuntu 16 cbmc package
     runs-on: ubuntu-16.04
     needs: Tags
@@ -105,43 +105,43 @@ jobs:
           name: ${{ env.ARTIFACT_STABLE_NAME }}
           path: ${{ env.PACKAGE_STABLE_NAME }}
 
-  Ubuntu16_Latest:
-    name: Ubuntu 16 cbmc-latest package
-    runs-on: ubuntu-16.04
-    needs: Tags
-    env:
-      OS: xenial
-      PKG_VERSION: ${{needs.Tags.outputs.pkg_version}}
-      CBMC_VERSION: ${{needs.Tags.outputs.cbmc_version}}
-      TIME: ${{needs.Tags.outputs.time}}
-      SHA: ${{needs.Tags.outputs.sha}}
+#  Ubuntu16_Latest:
+#    name: Ubuntu 16 cbmc-latest package
+#    runs-on: ubuntu-16.04
+#    needs: Tags
+#    env:
+#      OS: xenial
+#      PKG_VERSION: ${{needs.Tags.outputs.pkg_version}}
+#      CBMC_VERSION: ${{needs.Tags.outputs.cbmc_version}}
+#      TIME: ${{needs.Tags.outputs.time}}
+#      SHA: ${{needs.Tags.outputs.sha}}
+#
+#      PACKAGE_LATEST_NAME: cbmc-latest_${{needs.Tags.outputs.pkg_version}}~xenial_amd64.deb
+#      ARTIFACT_LATEST_NAME: Ubuntu16 cbmc-latest ${{needs.Tags.outputs.pkg_version}} xenial ${{needs.Tags.outputs.time}} ${{needs.Tags.outputs.sha}} ${{needs.Tags.outputs.runid}}
+#
+#      SCRIPT_DIR: .github/workflows/debian
+#    steps:
+#
+#      - name: Checkout the repository
+#        uses: actions/checkout@v2
+#
+#      - name: Update the submodules
+#        run: git submodule update --init
+#
+#      - name: Create the package
+#        run: |
+#          cp -r . /tmp/cbmc-${CBMC_VERSION}
+#          cp ${SCRIPT_DIR}/Makefile ${SCRIPT_DIR}/changelog ${SCRIPT_DIR}/surefire ${SCRIPT_DIR}/64bit_regression_tests.patch /tmp
+#          make -C /tmp GITHUB=1 STABLE= CBMC_VERSION=${CBMC_VERSION} PKG_VERSION=${PKG_VERSION}
+#          mv /tmp/*.deb ${PACKAGE_LATEST_NAME}
+#
+#      - name: Upload the package
+#        uses: actions/upload-artifact@v1
+#        with:
+#          name: ${{ env.ARTIFACT_LATEST_NAME }}
+#          path: ${{ env.PACKAGE_LATEST_NAME }}
 
-      PACKAGE_LATEST_NAME: cbmc-latest_${{needs.Tags.outputs.pkg_version}}~xenial_amd64.deb
-      ARTIFACT_LATEST_NAME: Ubuntu16 cbmc-latest ${{needs.Tags.outputs.pkg_version}} xenial ${{needs.Tags.outputs.time}} ${{needs.Tags.outputs.sha}} ${{needs.Tags.outputs.runid}}
-
-      SCRIPT_DIR: .github/workflows/debian
-    steps:
-
-      - name: Checkout the repository
-        uses: actions/checkout@v2
-
-      - name: Update the submodules
-        run: git submodule update --init
-
-      - name: Create the package
-        run: |
-          cp -r . /tmp/cbmc-${CBMC_VERSION}
-          cp ${SCRIPT_DIR}/Makefile ${SCRIPT_DIR}/changelog ${SCRIPT_DIR}/surefire ${SCRIPT_DIR}/64bit_regression_tests.patch /tmp
-          make -C /tmp GITHUB=1 STABLE= CBMC_VERSION=${CBMC_VERSION} PKG_VERSION=${PKG_VERSION}
-          mv /tmp/*.deb ${PACKAGE_LATEST_NAME}
-
-      - name: Upload the package
-        uses: actions/upload-artifact@v1
-        with:
-          name: ${{ env.ARTIFACT_LATEST_NAME }}
-          path: ${{ env.PACKAGE_LATEST_NAME }}
-
-  Ubuntu18_Stable:
+  Ubuntu18:
     name: Ubuntu 18 cbmc package
     runs-on: ubuntu-18.04
     needs: Tags
@@ -177,41 +177,41 @@ jobs:
           name: ${{ env.ARTIFACT_STABLE_NAME }}
           path: ${{ env.PACKAGE_STABLE_NAME }}
 
-  Ubuntu18_Latest:
-    name: Ubuntu 18 cbmc-latest package
-    runs-on: ubuntu-18.04
-    needs: Tags
-    env:
-      OS: bionic
-      PKG_VERSION: ${{needs.Tags.outputs.pkg_version}}
-      CBMC_VERSION: ${{needs.Tags.outputs.cbmc_version}}
-      TIME: ${{needs.Tags.outputs.time}}
-      SHA: ${{needs.Tags.outputs.sha}}
-
-      PACKAGE_LATEST_NAME: cbmc-latest_${{needs.Tags.outputs.pkg_version}}~bionic_amd64.deb
-      ARTIFACT_LATEST_NAME: Ubuntu18 cbmc-latest ${{needs.Tags.outputs.pkg_version}} bionic ${{needs.Tags.outputs.time}} ${{needs.Tags.outputs.sha}} ${{needs.Tags.outputs.runid}}
-
-      SCRIPT_DIR: .github/workflows/debian
-    steps:
-
-      - name: Checkout the repository
-        uses: actions/checkout@v2
-
-      - name: Update the submodules
-        run: git submodule update --init
-
-      - name: Create the package
-        run: |
-          cp -r . /tmp/cbmc-${CBMC_VERSION}
-          cp ${SCRIPT_DIR}/Makefile ${SCRIPT_DIR}/changelog ${SCRIPT_DIR}/surefire ${SCRIPT_DIR}/64bit_regression_tests.patch /tmp
-          make -C /tmp GITHUB=1 STABLE= CBMC_VERSION=${CBMC_VERSION} PKG_VERSION=${PKG_VERSION}
-          mv /tmp/*.deb ${PACKAGE_LATEST_NAME}
-
-      - name: Upload the package
-        uses: actions/upload-artifact@v1
-        with:
-          name: ${{ env.ARTIFACT_LATEST_NAME }}
-          path: ${{ env.PACKAGE_LATEST_NAME }}
+#  Ubuntu18_Latest:
+#    name: Ubuntu 18 cbmc-latest package
+#    runs-on: ubuntu-18.04
+#    needs: Tags
+#    env:
+#      OS: bionic
+#      PKG_VERSION: ${{needs.Tags.outputs.pkg_version}}
+#      CBMC_VERSION: ${{needs.Tags.outputs.cbmc_version}}
+#      TIME: ${{needs.Tags.outputs.time}}
+#      SHA: ${{needs.Tags.outputs.sha}}
+#
+#      PACKAGE_LATEST_NAME: cbmc-latest_${{needs.Tags.outputs.pkg_version}}~bionic_amd64.deb
+#      ARTIFACT_LATEST_NAME: Ubuntu18 cbmc-latest ${{needs.Tags.outputs.pkg_version}} bionic ${{needs.Tags.outputs.time}} ${{needs.Tags.outputs.sha}} ${{needs.Tags.outputs.runid}}
+#
+#      SCRIPT_DIR: .github/workflows/debian
+#    steps:
+#
+#      - name: Checkout the repository
+#        uses: actions/checkout@v2
+#
+#      - name: Update the submodules
+#        run: git submodule update --init
+#
+#      - name: Create the package
+#        run: |
+#          cp -r . /tmp/cbmc-${CBMC_VERSION}
+#          cp ${SCRIPT_DIR}/Makefile ${SCRIPT_DIR}/changelog ${SCRIPT_DIR}/surefire ${SCRIPT_DIR}/64bit_regression_tests.patch /tmp
+#          make -C /tmp GITHUB=1 STABLE= CBMC_VERSION=${CBMC_VERSION} PKG_VERSION=${PKG_VERSION}
+#          mv /tmp/*.deb ${PACKAGE_LATEST_NAME}
+#
+#      - name: Upload the package
+#        uses: actions/upload-artifact@v1
+#        with:
+#          name: ${{ env.ARTIFACT_LATEST_NAME }}
+#          path: ${{ env.PACKAGE_LATEST_NAME }}
 
   MacOS:
     name: MacOS packages
@@ -242,7 +242,7 @@ jobs:
         run: |
           make -f ${SCRIPT_DIR}/Makefile
           mv cbmc.tar.gz ${PACKAGE_STABLE_NAME}
-          mv cbmc-latest.tar.gz ${PACKAGE_LATEST_NAME}
+#          mv cbmc-latest.tar.gz ${PACKAGE_LATEST_NAME}
 
       - name: Upload the cbmc package
         uses: actions/upload-artifact@v1
@@ -250,11 +250,11 @@ jobs:
           name: ${{env.ARTIFACT_STABLE_NAME}}
           path: ${{env.PACKAGE_STABLE_NAME}}
 
-      - name: Upload the cbmc-latest package
-        uses: actions/upload-artifact@v1
-        with:
-          name: ${{env.ARTIFACT_LATEST_NAME}}
-          path: ${{env.PACKAGE_LATEST_NAME}}
+#      - name: Upload the cbmc-latest package
+#        uses: actions/upload-artifact@v1
+#        with:
+#          name: ${{env.ARTIFACT_LATEST_NAME}}
+#          path: ${{env.PACKAGE_LATEST_NAME}}
 
   VS2019:
     name: Windows VS2019 installers
@@ -298,9 +298,9 @@ jobs:
         run: |
            ${{env.SCRIPT_DIR}}\build-installer.bat cbmc && move cbmc.msi ${{env.PACKAGE_STABLE_NAME}}
 
-      - name: Build the latest installer
-        run: |
-           ${{env.SCRIPT_DIR}}\build-installer.bat cbmc-latest && move cbmc-latest.msi ${{env.PACKAGE_LATEST_NAME}}
+#      - name: Build the latest installer
+#        run: |
+#           ${{env.SCRIPT_DIR}}\build-installer.bat cbmc-latest && move cbmc-latest.msi ${{env.PACKAGE_LATEST_NAME}}
 
       - name: Upload the cbmc installer
         uses: actions/upload-artifact@v1
@@ -308,8 +308,8 @@ jobs:
           name: ${{env.ARTIFACT_STABLE_NAME}}
           path: ${{env.PACKAGE_STABLE_NAME}}
 
-      - name: Upload the cbmc-latest installer
-        uses: actions/upload-artifact@v1
-        with:
-          name: ${{env.ARTIFACT_LATEST_NAME}}
-          path: ${{env.PACKAGE_LATEST_NAME}}
+#      - name: Upload the cbmc-latest installer
+#        uses: actions/upload-artifact@v1
+#        with:
+#          name: ${{env.ARTIFACT_LATEST_NAME}}
+#          path: ${{env.PACKAGE_LATEST_NAME}}

--- a/.github/workflows/packages.yaml
+++ b/.github/workflows/packages.yaml
@@ -15,19 +15,13 @@ jobs:
     #
     name: Generate package tag
     runs-on: ubuntu-latest
-    env:
-      PACKAGE_NAME: cbmc-latest
-      VERSION_SCRIPT: .github/workflows/version.py
     outputs:
       time: ${{ steps.time.outputs.time }}
       sha: ${{ steps.sha.outputs.sha }}
       runid: ${{ steps.runid.outputs.runid }}
       runnum: ${{ steps.runnum.outputs.runnum }}
-      name: ${{ env.PACKAGE_NAME }}
       cbmc_version: ${{ steps.version.outputs.cbmc_version }}
       pkg_version: ${{ steps.version.outputs.pkg_version }}
-      opentag: ${{ steps.opentag.outputs.opentag }}
-      closedtag: ${{ steps.closedtag.outputs.closedtag }}
     steps:
 
       - name: Checkout the repository
@@ -74,16 +68,12 @@ jobs:
     runs-on: ubuntu-16.04
     needs: Tags
     env:
-      OS: xenial
       PKG_VERSION: ${{needs.Tags.outputs.pkg_version}}
       CBMC_VERSION: ${{needs.Tags.outputs.cbmc_version}}
-      TIME: ${{needs.Tags.outputs.time}}
-      SHA: ${{needs.Tags.outputs.sha}}
-
-      PACKAGE_STABLE_NAME: cbmc_${{needs.Tags.outputs.pkg_version}}~xenial_amd64.deb
-      ARTIFACT_STABLE_NAME: Ubuntu16 cbmc ${{needs.Tags.outputs.pkg_version}} xenial ${{needs.Tags.outputs.time}} ${{needs.Tags.outputs.sha}} ${{needs.Tags.outputs.runid}}
-
+      PACKAGE_NAME: cbmc_${{needs.Tags.outputs.pkg_version}}~xenial_amd64.deb
+      ARTIFACT_NAME: Ubuntu16 cbmc ${{needs.Tags.outputs.pkg_version}} xenial ${{needs.Tags.outputs.time}} ${{needs.Tags.outputs.sha}} ${{needs.Tags.outputs.runid}}
       SCRIPT_DIR: .github/workflows/debian
+
     steps:
 
       - name: Checkout the repository
@@ -97,65 +87,25 @@ jobs:
           cp -r . /tmp/cbmc-${CBMC_VERSION}
           cp ${SCRIPT_DIR}/Makefile ${SCRIPT_DIR}/changelog ${SCRIPT_DIR}/surefire ${SCRIPT_DIR}/64bit_regression_tests.patch /tmp
           make -C /tmp GITHUB=1 STABLE=1 CBMC_VERSION=${CBMC_VERSION} PKG_VERSION=${PKG_VERSION}
-          mv /tmp/*.deb ${PACKAGE_STABLE_NAME}
+          mv /tmp/*.deb ${PACKAGE_NAME}
 
       - name: Upload the package
         uses: actions/upload-artifact@v1
         with:
-          name: ${{ env.ARTIFACT_STABLE_NAME }}
-          path: ${{ env.PACKAGE_STABLE_NAME }}
-
-#  Ubuntu16_Latest:
-#    name: Ubuntu 16 cbmc-latest package
-#    runs-on: ubuntu-16.04
-#    needs: Tags
-#    env:
-#      OS: xenial
-#      PKG_VERSION: ${{needs.Tags.outputs.pkg_version}}
-#      CBMC_VERSION: ${{needs.Tags.outputs.cbmc_version}}
-#      TIME: ${{needs.Tags.outputs.time}}
-#      SHA: ${{needs.Tags.outputs.sha}}
-#
-#      PACKAGE_LATEST_NAME: cbmc-latest_${{needs.Tags.outputs.pkg_version}}~xenial_amd64.deb
-#      ARTIFACT_LATEST_NAME: Ubuntu16 cbmc-latest ${{needs.Tags.outputs.pkg_version}} xenial ${{needs.Tags.outputs.time}} ${{needs.Tags.outputs.sha}} ${{needs.Tags.outputs.runid}}
-#
-#      SCRIPT_DIR: .github/workflows/debian
-#    steps:
-#
-#      - name: Checkout the repository
-#        uses: actions/checkout@v2
-#
-#      - name: Update the submodules
-#        run: git submodule update --init
-#
-#      - name: Create the package
-#        run: |
-#          cp -r . /tmp/cbmc-${CBMC_VERSION}
-#          cp ${SCRIPT_DIR}/Makefile ${SCRIPT_DIR}/changelog ${SCRIPT_DIR}/surefire ${SCRIPT_DIR}/64bit_regression_tests.patch /tmp
-#          make -C /tmp GITHUB=1 STABLE= CBMC_VERSION=${CBMC_VERSION} PKG_VERSION=${PKG_VERSION}
-#          mv /tmp/*.deb ${PACKAGE_LATEST_NAME}
-#
-#      - name: Upload the package
-#        uses: actions/upload-artifact@v1
-#        with:
-#          name: ${{ env.ARTIFACT_LATEST_NAME }}
-#          path: ${{ env.PACKAGE_LATEST_NAME }}
+          name: ${{ env.ARTIFACT_NAME }}
+          path: ${{ env.PACKAGE_NAME }}
 
   Ubuntu18:
     name: Ubuntu 18 cbmc package
     runs-on: ubuntu-18.04
     needs: Tags
     env:
-      OS: bionic
       PKG_VERSION: ${{needs.Tags.outputs.pkg_version}}
       CBMC_VERSION: ${{needs.Tags.outputs.cbmc_version}}
-      TIME: ${{needs.Tags.outputs.time}}
-      SHA: ${{needs.Tags.outputs.sha}}
-
-      PACKAGE_STABLE_NAME: cbmc_${{needs.Tags.outputs.pkg_version}}~bionic_amd64.deb
-      ARTIFACT_STABLE_NAME: Ubuntu18 cbmc ${{needs.Tags.outputs.pkg_version}} bionic ${{needs.Tags.outputs.time}} ${{needs.Tags.outputs.sha}} ${{needs.Tags.outputs.runid}}
-
+      PACKAGE_NAME: cbmc_${{needs.Tags.outputs.pkg_version}}~bionic_amd64.deb
+      ARTIFACT_NAME: Ubuntu18 cbmc ${{needs.Tags.outputs.pkg_version}} bionic ${{needs.Tags.outputs.time}} ${{needs.Tags.outputs.sha}} ${{needs.Tags.outputs.runid}}
       SCRIPT_DIR: .github/workflows/debian
+
     steps:
 
       - name: Checkout the repository
@@ -169,67 +119,24 @@ jobs:
           cp -r . /tmp/cbmc-${CBMC_VERSION}
           cp ${SCRIPT_DIR}/Makefile ${SCRIPT_DIR}/changelog ${SCRIPT_DIR}/surefire ${SCRIPT_DIR}/64bit_regression_tests.patch /tmp
           make -C /tmp GITHUB=1 STABLE=1 CBMC_VERSION=${CBMC_VERSION} PKG_VERSION=${PKG_VERSION}
-          mv /tmp/*.deb ${PACKAGE_STABLE_NAME}
+          mv /tmp/*.deb ${PACKAGE_NAME}
 
       - name: Upload the package
         uses: actions/upload-artifact@v1
         with:
-          name: ${{ env.ARTIFACT_STABLE_NAME }}
-          path: ${{ env.PACKAGE_STABLE_NAME }}
-
-#  Ubuntu18_Latest:
-#    name: Ubuntu 18 cbmc-latest package
-#    runs-on: ubuntu-18.04
-#    needs: Tags
-#    env:
-#      OS: bionic
-#      PKG_VERSION: ${{needs.Tags.outputs.pkg_version}}
-#      CBMC_VERSION: ${{needs.Tags.outputs.cbmc_version}}
-#      TIME: ${{needs.Tags.outputs.time}}
-#      SHA: ${{needs.Tags.outputs.sha}}
-#
-#      PACKAGE_LATEST_NAME: cbmc-latest_${{needs.Tags.outputs.pkg_version}}~bionic_amd64.deb
-#      ARTIFACT_LATEST_NAME: Ubuntu18 cbmc-latest ${{needs.Tags.outputs.pkg_version}} bionic ${{needs.Tags.outputs.time}} ${{needs.Tags.outputs.sha}} ${{needs.Tags.outputs.runid}}
-#
-#      SCRIPT_DIR: .github/workflows/debian
-#    steps:
-#
-#      - name: Checkout the repository
-#        uses: actions/checkout@v2
-#
-#      - name: Update the submodules
-#        run: git submodule update --init
-#
-#      - name: Create the package
-#        run: |
-#          cp -r . /tmp/cbmc-${CBMC_VERSION}
-#          cp ${SCRIPT_DIR}/Makefile ${SCRIPT_DIR}/changelog ${SCRIPT_DIR}/surefire ${SCRIPT_DIR}/64bit_regression_tests.patch /tmp
-#          make -C /tmp GITHUB=1 STABLE= CBMC_VERSION=${CBMC_VERSION} PKG_VERSION=${PKG_VERSION}
-#          mv /tmp/*.deb ${PACKAGE_LATEST_NAME}
-#
-#      - name: Upload the package
-#        uses: actions/upload-artifact@v1
-#        with:
-#          name: ${{ env.ARTIFACT_LATEST_NAME }}
-#          path: ${{ env.PACKAGE_LATEST_NAME }}
+          name: ${{ env.ARTIFACT_NAME }}
+          path: ${{ env.PACKAGE_NAME }}
 
   MacOS:
-    name: MacOS packages
+    name: MacOS tarball
     runs-on: macos-10.15
     needs: Tags
     env:
-      OS: catalina
       VERSION: ${{needs.Tags.outputs.pkg_version}}
-      TIME: ${{needs.Tags.outputs.time}}
-      SHA: ${{needs.Tags.outputs.sha}}
-
-      PACKAGE_STABLE_NAME: cbmc_${{needs.Tags.outputs.pkg_version}}~catalina.tar.gz
-      PACKAGE_LATEST_NAME: cbmc-latest_${{needs.Tags.outputs.pkg_version}}~catalina.tar.gz
-
-      ARTIFACT_STABLE_NAME: MacOS cbmc ${{needs.Tags.outputs.pkg_version}} catalina ${{needs.Tags.outputs.time}} ${{needs.Tags.outputs.sha}} ${{needs.Tags.outputs.runid}}
-      ARTIFACT_LATEST_NAME: MacOS cbmc-latest ${{needs.Tags.outputs.pkg_version}} catalina ${{needs.Tags.outputs.time}} ${{needs.Tags.outputs.sha}} ${{needs.Tags.outputs.runid}}
-
+      PACKAGE_NAME: cbmc_${{needs.Tags.outputs.pkg_version}}~catalina.tar.gz
+      ARTIFACT_NAME: MacOS cbmc ${{needs.Tags.outputs.pkg_version}} catalina ${{needs.Tags.outputs.time}} ${{needs.Tags.outputs.sha}} ${{needs.Tags.outputs.runid}}
       SCRIPT_DIR: .github/workflows/macos15
+
     steps:
 
       - name: Checkout the repository
@@ -241,37 +148,22 @@ jobs:
       - name: Build the package
         run: |
           make -f ${SCRIPT_DIR}/Makefile
-          mv cbmc.tar.gz ${PACKAGE_STABLE_NAME}
-#          mv cbmc-latest.tar.gz ${PACKAGE_LATEST_NAME}
+          mv cbmc.tar.gz ${PACKAGE_NAME}
 
-      - name: Upload the cbmc package
+      - name: Upload the package
         uses: actions/upload-artifact@v1
         with:
-          name: ${{env.ARTIFACT_STABLE_NAME}}
-          path: ${{env.PACKAGE_STABLE_NAME}}
-
-#      - name: Upload the cbmc-latest package
-#        uses: actions/upload-artifact@v1
-#        with:
-#          name: ${{env.ARTIFACT_LATEST_NAME}}
-#          path: ${{env.PACKAGE_LATEST_NAME}}
+          name: ${{env.ARTIFACT_NAME}}
+          path: ${{env.PACKAGE_NAME}}
 
   VS2019:
-    name: Windows VS2019 installers
+    name: Windows VS2019 installer
     runs-on: windows-2019
     needs: Tags
     env:
-      OS: vs2019
       VERSION: ${{needs.Tags.outputs.pkg_version}}
-      TIME: ${{needs.Tags.outputs.time}}
-      SHA: ${{needs.Tags.outputs.sha}}
-
-      PACKAGE_STABLE_NAME: cbmc_${{needs.Tags.outputs.pkg_version}}~vs2019.msi
-      PACKAGE_LATEST_NAME: cbmc-latest_${{needs.Tags.outputs.pkg_version}}~vs2019.msi
-
-      ARTIFACT_STABLE_NAME: Windows cbmc ${{needs.Tags.outputs.pkg_version}} vs2019 ${{needs.Tags.outputs.time}} ${{needs.Tags.outputs.sha}} ${{needs.Tags.outputs.runid}}
-      ARTIFACT_LATEST_NAME: Windows cbmc-latest ${{needs.Tags.outputs.pkg_version}} vs2019 ${{needs.Tags.outputs.time}} ${{needs.Tags.outputs.sha}} ${{needs.Tags.outputs.runid}}
-
+      PACKAGE_NAME: cbmc_${{needs.Tags.outputs.pkg_version}}~vs2019.msi
+      ARTIFACT_NAME: Windows cbmc ${{needs.Tags.outputs.pkg_version}} vs2019 ${{needs.Tags.outputs.time}} ${{needs.Tags.outputs.sha}} ${{needs.Tags.outputs.runid}}
       SCRIPT_DIR: .github\workflows\vs2019
 
     defaults:
@@ -294,22 +186,12 @@ jobs:
       - name: Build cbmc
         run: ${{env.SCRIPT_DIR}}\build-cbmc.bat
 
-      - name: Build the stable installer
+      - name: Build the installer
         run: |
-           ${{env.SCRIPT_DIR}}\build-installer.bat cbmc && move cbmc.msi ${{env.PACKAGE_STABLE_NAME}}
+           ${{env.SCRIPT_DIR}}\build-installer.bat cbmc && move cbmc.msi ${{env.PACKAGE_NAME}}
 
-#      - name: Build the latest installer
-#        run: |
-#           ${{env.SCRIPT_DIR}}\build-installer.bat cbmc-latest && move cbmc-latest.msi ${{env.PACKAGE_LATEST_NAME}}
-
-      - name: Upload the cbmc installer
+      - name: Upload the installer
         uses: actions/upload-artifact@v1
         with:
-          name: ${{env.ARTIFACT_STABLE_NAME}}
-          path: ${{env.PACKAGE_STABLE_NAME}}
-
-#      - name: Upload the cbmc-latest installer
-#        uses: actions/upload-artifact@v1
-#        with:
-#          name: ${{env.ARTIFACT_LATEST_NAME}}
-#          path: ${{env.PACKAGE_LATEST_NAME}}
+          name: ${{env.ARTIFACT_NAME}}
+          path: ${{env.PACKAGE_NAME}}


### PR DESCRIPTION
This fixes the GitHub Actions building CBMC packages.
* The Debian patch 64bit_regression_tests.patch failed to apply due to recent changes in regression/cbmc/xml-trace/test.desc
* The workflow was changed to build only the packages that install into the operating system's equivalent of /usr/local/bin (the installation into /usr/local/cbmc-latest/bin turns out to be kind of useless).

By the way, the workflow Build and Test Xen also appears to be broken in develop.