### PR TITLE
Fix Bison grammar issues preventing us from parsing CoreFoundation

### DIFF
--- a/regression/ansi-c/enum_with_underlying_type/test.c
+++ b/regression/ansi-c/enum_with_underlying_type/test.c
@@ -1,0 +1,19 @@
+typedef unsigned short USHORT;
+
+enum A : USHORT
+{
+  AV
+};
+enum B : unsigned short
+{
+  BV
+};
+enum C : signed long long
+{
+  CV
+};
+
+int main(void)
+{
+  return 0;
+}

--- a/regression/ansi-c/enum_with_underlying_type/test.desc
+++ b/regression/ansi-c/enum_with_underlying_type/test.desc
@@ -1,0 +1,12 @@
+CORE
+test.c
+
+^EXIT=0$
+^SIGNAL=0$
+--
+^PARSING ERROR$
+--
+A previous attempt to allow underlying type specifications didn't allow typedef
+names or multi word types (e.g. unsigned int). We still don't actually fully
+apply the underlying type to the enum, but this at least lets us use parse code
+that uses this feature.

--- a/regression/ansi-c/function_with_postfix_attributes/test.c
+++ b/regression/ansi-c/function_with_postfix_attributes/test.c
@@ -1,0 +1,15 @@
+inline int inline_function_with_postfix_attributes(void)
+  __attribute__((not_a_real_attribute))
+{
+  return 0;
+}
+
+int non_inline_with_postfix_attributes(void)
+  __attribute__((not_a_real_attribute))
+{
+  return 0;
+}
+
+int main(void)
+{
+}

--- a/regression/ansi-c/function_with_postfix_attributes/test.desc
+++ b/regression/ansi-c/function_with_postfix_attributes/test.desc
@@ -1,0 +1,11 @@
+CORE gcc-only
+test.c
+
+^EXIT=0$
+^SIGNAL=0$
+--
+^PARSING ERROR$
+--
+gcc doesn't support postfix attributes but clang does, and Apples CoreFoundation framework makes use of this for availability macros.
+
+Testing both the inline and non-inline variants because these are different cases in our parser.

--- a/src/ansi-c/parser.y
+++ b/src/ansi-c/parser.y
@@ -1837,13 +1837,21 @@ enum_name:
         }
         ;
 
+basic_type_name_list:
+    basic_type_name
+  | basic_type_name_list basic_type_name
+
+enum_underlying_type:
+    basic_type_name_list
+  | typedef_name
+
 enum_underlying_type_opt:
         /* empty */
         {
           init($$);
           parser_stack($$).make_nil();
         }
-        | ':' basic_type_name
+        | ':' enum_underlying_type
         {
           $$=$2;
         }

--- a/src/ansi-c/parser.y
+++ b/src/ansi-c/parser.y
@@ -3003,14 +3003,14 @@ function_head:
           PARSER.add_declarator(parser_stack($$), parser_stack($1));
           create_function_scope($$);
         }
-        | declaration_specifier declarator
+        | declaration_specifier declarator post_declarator_attributes_opt
         {
           init($$, ID_declaration);
           parser_stack($$).type().swap(parser_stack($1));
           PARSER.add_declarator(parser_stack($$), parser_stack($2));
           create_function_scope($$);
         }
-        | type_specifier declarator
+        | type_specifier declarator post_declarator_attributes_opt
         {
           init($$, ID_declaration);
           parser_stack($$).type().swap(parser_stack($1));


### PR DESCRIPTION
<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [X] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->

There are currently two issues preventing us from parsing Apple's CoreFoundation framework: For one, we still don't quite parse underlying enum types correctly, so for example

    enum A : unsigned int { AV };

and 

    enum B : uint32_t { BV };

would previously fail to parse, and we didn't allow gcc-style attributes after a functions parameter list:

    int some_function(int argument) __attribute__((this_previously_wasn't_allowed));

which gcc itself doesn't permit either but is valid in Clang's C dialect, and used this way by Apple across their frameworks for their `API_AVAILABLE` and `API_UNAVAILABLE` macros.

This fixes both of these issues.