### PR TITLE
Refactoring around the goto-cc entry point.

### DIFF
--- a/src/goto-cc/armcc_cmdline.cpp
+++ b/src/goto-cc/armcc_cmdline.cpp
@@ -265,6 +265,20 @@ static const char *options_with_arg[]=
   nullptr
 };
 
+bool prefix_in_list(const char *option, const char **list, std::string &prefix)
+{
+  for(std::size_t i = 0; list[i] != nullptr; i++)
+  {
+    if(strncmp(option, list[i], strlen(list[i])) == 0)
+    {
+      prefix = std::string(list[i]);
+      return true;
+    }
+  }
+
+  return false;
+}
+
 bool armcc_cmdlinet::parse(int argc, const char **argv)
 {
   for(int i=1; i<argc; i++)

--- a/src/goto-cc/armcc_cmdline.cpp
+++ b/src/goto-cc/armcc_cmdline.cpp
@@ -12,9 +12,13 @@ Author: Daniel Kroening
 #include "armcc_cmdline.h"
 
 #include <util/optional.h>
+#include <util/prefix.h>
 
+#include <algorithm>
 #include <cstring>
 #include <iostream>
+#include <string>
+#include <vector>
 
 /// parses the command line options into a cmdlinet
 /// \par parameters: argument count, argument strings
@@ -197,7 +201,8 @@ static const char *options_no_arg[]=
   nullptr
 };
 
-static const char *options_with_prefix[]=
+// clang-format off
+static const std::vector<std::string> options_with_prefix
 {
   "--project=",
   "--workdir=",
@@ -243,11 +248,10 @@ static const char *options_with_prefix[]=
   "--configure_sysroot=",
   "--configure_cpp_headers=",
   "--configure_extra_includes=",
-  "--configure_extra_libraries=",
-  nullptr
+  "--configure_extra_libraries="
 };
 
-static const char *options_with_arg[]=
+static const std::vector<std::string> options_with_arg
 {
   // goto-cc specific
   "--verbosity",
@@ -263,21 +267,20 @@ static const char *options_with_arg[]=
   "-Warmcc,",
   "-o",
   "--cpu",
-  "--apcs",
-  nullptr
+  "--apcs"
 };
+// clang-format on
 
-optionalt<std::string> prefix_in_list(const char *option, const char **list)
+optionalt<std::string>
+prefix_in_list(const std::string &option, const std::vector<std::string> &list)
 {
-  for(std::size_t i = 0; list[i] != nullptr; i++)
-  {
-    if(strncmp(option, list[i], strlen(list[i])) == 0)
-    {
-      return {list[i]};
-    }
-  }
-
-  return {};
+  const auto found =
+    std::find_if(list.cbegin(), list.cend(), [&](const std::string &argument) {
+      return has_prefix(argument, option);
+    });
+  if(found == list.cend())
+    return {};
+  return {*found};
 }
 
 bool armcc_cmdlinet::parse(int argc, const char **argv)

--- a/src/goto-cc/goto_cc_cmdline.cpp
+++ b/src/goto-cc/goto_cc_cmdline.cpp
@@ -13,10 +13,11 @@ Date:   April 2010
 
 #include "goto_cc_cmdline.h"
 
-#include <cstring>
+#include <algorithm>
 #include <cassert>
-#include <iostream>
 #include <cstdio>
+#include <cstring>
+#include <iostream>
 
 #include <util/invariant.h>
 #include <util/prefix.h>
@@ -137,10 +138,8 @@ void goto_cc_cmdlinet::add_infile_arg(const std::string &arg)
 
 bool goto_cc_cmdlinet::have_infile_arg() const
 {
-  for(parsed_argvt::const_iterator it = parsed_argv.begin();
-      it != parsed_argv.end();
-      it++)
-    if(it->is_infile_name)
-      return true;
-  return false;
+  return std::any_of(
+    parsed_argv.cbegin(), parsed_argv.cend(), [](const argt &arg) {
+      return arg.is_infile_name;
+    });
 }

--- a/src/goto-cc/goto_cc_cmdline.cpp
+++ b/src/goto-cc/goto_cc_cmdline.cpp
@@ -47,23 +47,6 @@ bool goto_cc_cmdlinet::in_list(const char *option, const char **list)
   return false;
 }
 
-bool goto_cc_cmdlinet::prefix_in_list(
-  const char *option,
-  const char **list,
-  std::string &prefix)
-{
-  for(std::size_t i=0; list[i]!=nullptr; i++)
-  {
-    if(strncmp(option, list[i], strlen(list[i]))==0)
-    {
-      prefix=std::string(list[i]);
-      return true;
-    }
-  }
-
-  return false;
-}
-
 std::size_t goto_cc_cmdlinet::get_optnr(const std::string &opt_string)
 {
   optionalt<std::size_t> optnr;

--- a/src/goto-cc/goto_cc_cmdline.cpp
+++ b/src/goto-cc/goto_cc_cmdline.cpp
@@ -134,3 +134,13 @@ void goto_cc_cmdlinet::add_infile_arg(const std::string &arg)
     fclose(tmp);
   }
 }
+
+bool goto_cc_cmdlinet::have_infile_arg() const
+{
+  for(parsed_argvt::const_iterator it = parsed_argv.begin();
+      it != parsed_argv.end();
+      it++)
+    if(it->is_infile_name)
+      return true;
+  return false;
+}

--- a/src/goto-cc/goto_cc_cmdline.h
+++ b/src/goto-cc/goto_cc_cmdline.h
@@ -68,14 +68,7 @@ public:
   typedef std::list<argt> parsed_argvt;
   parsed_argvt parsed_argv;
 
-  bool have_infile_arg() const
-  {
-    for(parsed_argvt::const_iterator
-        it=parsed_argv.begin(); it!=parsed_argv.end(); it++)
-      if(it->is_infile_name)
-        return true;
-    return false;
-  }
+  bool have_infile_arg() const;
 
   std::string stdin_file;
 

--- a/src/goto-cc/goto_cc_cmdline.h
+++ b/src/goto-cc/goto_cc_cmdline.h
@@ -26,11 +26,6 @@ public:
 
   static bool in_list(const char *option, const char **list);
 
-  static bool prefix_in_list(
-    const char *option,
-    const char **list,
-    std::string &prefix);
-
   // never fails, will add if not found
   std::size_t get_optnr(const std::string &option);
 

--- a/src/goto-cc/goto_cc_mode.h
+++ b/src/goto-cc/goto_cc_mode.h
@@ -24,7 +24,7 @@ public:
   virtual int main(int argc, const char **argv);
   virtual int doit()=0;
   virtual void help_mode()=0;
-  virtual void help();
+  void help();
   virtual void usage_error();
 
   goto_cc_modet(

--- a/src/goto-cc/goto_cc_mode.h
+++ b/src/goto-cc/goto_cc_mode.h
@@ -21,7 +21,7 @@ Date: June 2006
 class goto_cc_modet:public messaget
 {
 public:
-  virtual int main(int argc, const char **argv);
+  int main(int argc, const char **argv);
   virtual int doit()=0;
   virtual void help_mode()=0;
   void help();

--- a/unit/CMakeLists.txt
+++ b/unit/CMakeLists.txt
@@ -51,6 +51,7 @@ target_link_libraries(
         testing-utils
         ansi-c
         solvers
+        goto-cc-lib
         goto-checker
         goto-programs
         goto-instrument-lib

--- a/unit/Makefile
+++ b/unit/Makefile
@@ -19,6 +19,7 @@ SRC += analyses/ai/ai.cpp \
        big-int/big-int.cpp \
        compound_block_locations.cpp \
        get_goto_model_from_c_test.cpp \
+       goto-cc/armcc_cmdline.cpp \
        goto-checker/report_util/is_property_less_than.cpp \
        goto-instrument/cover_instrument.cpp \
        goto-instrument/cover/cover_only.cpp \
@@ -162,6 +163,8 @@ testing-utils-clean:
 BMC_DEPS =../src/cbmc/c_test_input_generator$(OBJEXT) \
           ../src/cbmc/cbmc_languages$(OBJEXT) \
           ../src/cbmc/cbmc_parse_options$(OBJEXT) \
+          ../src/goto-cc/armcc_cmdline$(OBJEXT) \
+          ../src/goto-cc/goto_cc_cmdline$(OBJEXT) \
           ../src/goto-instrument/source_lines$(OBJEXT) \
           ../src/goto-instrument/cover$(OBJEXT) \
           ../src/goto-instrument/cover_basic_blocks$(OBJEXT) \

--- a/unit/goto-cc/armcc_cmdline.cpp
+++ b/unit/goto-cc/armcc_cmdline.cpp
@@ -1,0 +1,34 @@
+/// \file
+/// Unit tests of src/goto-cc/armcc_cmdline.cpp
+/// \author Diffblue Ltd.
+
+#include <testing-utils/use_catch.h>
+
+#include <util/optional.h>
+
+#include <string>
+#include <vector>
+
+optionalt<std::string>
+prefix_in_list(const std::string &option, const std::vector<std::string> &list);
+
+static const std::vector<std::string> test_list{"spam", "eggs", "and", "ham"};
+
+TEST_CASE("prefix_in_list exact match", "[core][armcc_cmdline][prefix_in_list]")
+{
+  REQUIRE(*prefix_in_list("spam", test_list) == "spam");
+  REQUIRE(*prefix_in_list("ham", test_list) == "ham");
+}
+
+TEST_CASE(
+  "prefix_in_list match prefix",
+  "[core][armcc_cmdline][prefix_in_list]")
+{
+  REQUIRE(*prefix_in_list("sp", test_list) == "spam");
+  REQUIRE(*prefix_in_list("ha", test_list) == "ham");
+}
+
+TEST_CASE("prefix_in_list unmatched", "[core][armcc_cmdline][prefix_in_list]")
+{
+  REQUIRE_FALSE(prefix_in_list("foobar", test_list));
+}

--- a/unit/goto-cc/module_dependencies.txt
+++ b/unit/goto-cc/module_dependencies.txt
@@ -1,0 +1,3 @@
+goto-cc
+testing-utils
+util


### PR DESCRIPTION
<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

As I was working on https://github.com/diffblue/cbmc/pull/5440, I found the entry point code less than straight forward to follow. I carried out this refactorings locally in order to make it easier for me to understand. I am raising this separate PR containing the refactoring work only as it was not required in order to implement the feature in the original PR, but should still improve maintainability.

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [x] N/A - No user visible behaviour changes. ~The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/~
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [x] N/A - None claimed ~My commit message includes data points confirming performance improvements (if claimed).~
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
