### PR TITLE
Refactoring of the parsing of the `--object-bits` command line argument

### DIFF
--- a/regression/cbmc/object-bits-parsing/non_numeric.desc
+++ b/regression/cbmc/object-bits-parsing/non_numeric.desc
@@ -1,6 +1,7 @@
 CORE
 test.c
 --object-bits foobar
+Value of "foobar" given for object-bits is not a valid unsigned integer.
 object-bits must be positive and less than the pointer width
 ^EXIT=1$
 ^SIGNAL=0$

--- a/regression/cbmc/object-bits-parsing/non_numeric.desc
+++ b/regression/cbmc/object-bits-parsing/non_numeric.desc
@@ -1,0 +1,9 @@
+CORE
+test.c
+--object-bits foobar
+object-bits must be positive and less than the pointer width
+^EXIT=1$
+^SIGNAL=0$
+--
+--
+Test parsing of an invalid non numeric object-bits setting.

--- a/regression/cbmc/object-bits-parsing/test.c
+++ b/regression/cbmc/object-bits-parsing/test.c
@@ -1,0 +1,8 @@
+
+#include <assert.h>
+#include <stdlib.h>
+
+int main(int argc, char **argv)
+{
+  void *p = malloc(1);
+}

--- a/regression/cbmc/object-bits-parsing/too_large.desc
+++ b/regression/cbmc/object-bits-parsing/too_large.desc
@@ -1,0 +1,9 @@
+CORE
+test.c
+--object-bits 65
+object-bits must be positive and less than the pointer width
+^EXIT=1$
+^SIGNAL=0$
+--
+--
+Test parsing of a too large object-bits setting.

--- a/regression/cbmc/object-bits-parsing/too_large.desc
+++ b/regression/cbmc/object-bits-parsing/too_large.desc
@@ -1,6 +1,7 @@
 CORE
 test.c
 --object-bits 65
+Value of "65" given for object-bits is out of range.
 object-bits must be positive and less than the pointer width
 ^EXIT=1$
 ^SIGNAL=0$

--- a/regression/cbmc/object-bits-parsing/valid.desc
+++ b/regression/cbmc/object-bits-parsing/valid.desc
@@ -1,0 +1,8 @@
+CORE
+test.c
+--object-bits 8
+^EXIT=0$
+^SIGNAL=0$
+--
+--
+Test parsing of a valid object-bits setting.

--- a/regression/cbmc/object-bits-parsing/zero.desc
+++ b/regression/cbmc/object-bits-parsing/zero.desc
@@ -1,0 +1,9 @@
+CORE
+test.c
+--object-bits 0
+object-bits must be positive and less than the pointer width
+^EXIT=1$
+^SIGNAL=0$
+--
+--
+Test parsing of a too small object-bits setting.

--- a/regression/cbmc/object-bits-parsing/zero.desc
+++ b/regression/cbmc/object-bits-parsing/zero.desc
@@ -1,6 +1,7 @@
 CORE
 test.c
 --object-bits 0
+Value of "0" given for object-bits is out of range.
 object-bits must be positive and less than the pointer width
 ^EXIT=1$
 ^SIGNAL=0$

--- a/src/util/config.cpp
+++ b/src/util/config.cpp
@@ -786,7 +786,7 @@ configt::bv_encodingt parse_object_bits_encoding(
   const auto object_bits = string2optional<unsigned int>(argument);
   if(!object_bits)
     throw_for_reason("not a valid unsigned integer");
-  if(*object_bits <= 0 || *object_bits >= pointer_width)
+  if(*object_bits == 0 || *object_bits >= pointer_width)
     throw_for_reason("out of range");
 
   configt::bv_encodingt bv_encoding;

--- a/src/util/config.cpp
+++ b/src/util/config.cpp
@@ -776,14 +776,18 @@ configt::bv_encodingt parse_object_bits_encoding(
   const std::string &argument,
   const std::size_t pointer_width)
 {
-  const auto object_bits = string2optional<unsigned int>(argument);
-  if(!object_bits || *object_bits <= 0 || *object_bits >= pointer_width)
-  {
+  const auto throw_for_reason = [&](const std::string &reason) {
     throw invalid_command_line_argument_exceptiont(
-      "object-bits must be positive and less than the pointer width (" +
+      "Value of \"" + argument + "\" given for object-bits is " + reason +
+        ". object-bits must be positive and less than the pointer width (" +
         std::to_string(pointer_width) + ") ",
       "--object_bits");
-  }
+  };
+  const auto object_bits = string2optional<unsigned int>(argument);
+  if(!object_bits)
+    throw_for_reason("not a valid unsigned integer");
+  if(*object_bits <= 0 || *object_bits >= pointer_width)
+    throw_for_reason("out of range");
 
   configt::bv_encodingt bv_encoding;
   bv_encoding.object_bits = *object_bits;

--- a/src/util/config.cpp
+++ b/src/util/config.cpp
@@ -771,10 +771,6 @@ bool configt::set(const cmdlinet &cmdline)
 
   cpp.cpp_standard=cppt::default_cpp_standard();
 
-  bv_encoding.object_bits=bv_encoding.default_object_bits;
-  // This will allow us to override by language defaults later.
-  bv_encoding.is_object_bits_default=true;
-
   ansi_c.single_precision_constant=false;
   ansi_c.for_has_scope=true; // C99 or later
   ansi_c.ts_18661_3_Floatn_types=false;

--- a/src/util/config.cpp
+++ b/src/util/config.cpp
@@ -765,6 +765,32 @@ void configt::set_arch(const irep_idt &arch)
   }
 }
 
+/// \brief Parses the `object_bits` argument from the command line arguments.
+/// \param argument The command line argument to parse the `object_bits` from.
+/// \param pointer_width The width of a pointer in bits. This is used to check
+///   the value of object_bits is within the valid range.
+/// \return A `bv_encodingt` on successful parsing. In the case where an invalid
+///    argument is specified, an `invalid_command_line_argument_exceptiont` will
+///    be thrown.
+configt::bv_encodingt parse_object_bits_encoding(
+  const std::string &argument,
+  const std::size_t pointer_width)
+{
+  const unsigned int object_bits = unsafe_string2unsigned(argument);
+  if(object_bits <= 0 || object_bits >= pointer_width)
+  {
+    throw invalid_command_line_argument_exceptiont(
+      "object-bits must be positive and less than the pointer width (" +
+        std::to_string(pointer_width) + ") ",
+      "--object_bits");
+  }
+
+  configt::bv_encodingt bv_encoding;
+  bv_encoding.object_bits = object_bits;
+  bv_encoding.is_object_bits_default = false;
+  return bv_encoding;
+}
+
 bool configt::set(const cmdlinet &cmdline)
 {
   // defaults -- we match the architecture we have ourselves
@@ -1074,19 +1100,8 @@ bool configt::set(const cmdlinet &cmdline)
 
   if(cmdline.isset("object-bits"))
   {
-    bv_encoding.object_bits=
-      unsafe_string2unsigned(cmdline.get_value("object-bits"));
-
-    if(!(0<bv_encoding.object_bits &&
-         bv_encoding.object_bits<ansi_c.pointer_width))
-    {
-      throw invalid_command_line_argument_exceptiont(
-        "object-bits must be positive and less than the pointer width (" +
-          std::to_string(ansi_c.pointer_width) + ") ",
-        "--object_bits");
-    }
-
-    bv_encoding.is_object_bits_default = false;
+    bv_encoding = parse_object_bits_encoding(
+      cmdline.get_value("object-bits"), ansi_c.pointer_width);
   }
 
   if(cmdline.isset("malloc-fail-assert") && cmdline.isset("malloc-fail-null"))

--- a/src/util/config.cpp
+++ b/src/util/config.cpp
@@ -776,8 +776,8 @@ configt::bv_encodingt parse_object_bits_encoding(
   const std::string &argument,
   const std::size_t pointer_width)
 {
-  const unsigned int object_bits = unsafe_string2unsigned(argument);
-  if(object_bits <= 0 || object_bits >= pointer_width)
+  const auto object_bits = string2optional<unsigned int>(argument);
+  if(!object_bits || *object_bits <= 0 || *object_bits >= pointer_width)
   {
     throw invalid_command_line_argument_exceptiont(
       "object-bits must be positive and less than the pointer width (" +
@@ -786,7 +786,7 @@ configt::bv_encodingt parse_object_bits_encoding(
   }
 
   configt::bv_encodingt bv_encoding;
-  bv_encoding.object_bits = object_bits;
+  bv_encoding.object_bits = *object_bits;
   bv_encoding.is_object_bits_default = false;
   return bv_encoding;
 }

--- a/src/util/config.h
+++ b/src/util/config.h
@@ -173,10 +173,8 @@ public:
   struct bv_encodingt
   {
     // number of bits to encode heap object addresses
-    std::size_t object_bits;
-    bool is_object_bits_default;
-
-    static const std::size_t default_object_bits=8;
+    std::size_t object_bits = 8;
+    bool is_object_bits_default = true;
   } bv_encoding;
 
   // this is the function to start executing

--- a/src/util/string2int.h
+++ b/src/util/string2int.h
@@ -107,7 +107,7 @@ auto wrap_string_conversion(do_conversiont do_conversion)
 ///   (unsigned) long long
 /// does not accept negative inputs when the result type is unsigned
 template <typename T>
-optionalt<T> string2optional(const std::string &str, int base)
+optionalt<T> string2optional(const std::string &str, int base = 10)
 {
   return wrap_string_conversion([&]() {
     return narrow_or_throw_out_of_range<T>(string2optional_base<T>(str, base));


### PR DESCRIPTION
<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

As I was working on #5440, I found the entry point code less than straight forward to follow. I carried out this refactorings locally in order to make it easier for me to understand. I am raising this separate PR containing the refactoring work only as it was not required in order to implement the feature in the original PR, but should still improve maintainability.

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [x] N/A - No user visible changes ~The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/~
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [x] N/A - non claimed - ~My commit message includes data points confirming performance improvements (if claimed).~
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
