### PR TITLE
WIP add version bump on release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,33 @@
+name: cprover-release
+on:
+  # Only on pull request so I can see what's happening
+  pull_request:
+    branches: [develop]
+  release:
+    types: [created]
+
+jobs:
+  update-cbmc-version:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set CBMC_VERSION environment variable
+        run: |
+          # This instead of cbmc-5.12.6 this should be GITHUB_REF for releases
+          echo "::set-env name=CBMC_VERSION::$(echo cbmc-5.12.6 | cut -s -d - -f 2)"
+      - name: Update version in config.inc
+        run: sed -i "s/CBMC_VERSION = .*/CBMC_VERSION = $CBMC_VERSION/" src/config.inc
+      - name: Set git identity to github actions bot
+        run: |
+          git config --local user.email "actions@github.com"
+          git config --local user.name "github-actions"
+      - name: Commit version changes
+        run: git commit -a -m "Bump CBMC version to $CBMC_VERSION"
+      - name: DEBUG show config.inc contents
+        run: cat src/config.inc
+      - name: DEBUG show what we _would_ be pushing
+        run: |
+          git show HEAD
+          git status
+          # git push # should do the trick
+


### PR DESCRIPTION
<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

We are using the `CBMC_VERSION` setting in `config.inc` to display a version for `cbmc --version`. Since we’re doing biweekly releases now this field should be updated, ideally automatically, on release. This is an attempt to get that done.

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
