### PR TITLE
Fix loop-to-assume transformation in goto-symex

### DIFF
--- a/regression/cbmc/while2/main.c
+++ b/regression/cbmc/while2/main.c
@@ -1,0 +1,20 @@
+#include "assert.h"
+
+int main()
+{
+  int count = 0;
+  do
+  {
+    count = count + 1;
+  } while(count < 5);
+
+  do
+  {
+  } while(count < 5);
+
+  while(count < 5)
+    ;
+
+  assert(count == 5);
+  assert(count == 17);
+}

--- a/regression/cbmc/while2/requires-transform.c
+++ b/regression/cbmc/while2/requires-transform.c
@@ -1,0 +1,15 @@
+#include "assert.h"
+
+int main()
+{
+  int count;
+
+  do
+  {
+  } while(count < 5);
+
+  while(count < 5)
+    ;
+
+  assert(count >= 5);
+}

--- a/regression/cbmc/while2/requires-transform.desc
+++ b/regression/cbmc/while2/requires-transform.desc
@@ -1,0 +1,11 @@
+CORE
+requires-transform.c
+
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring
+--
+This test will only terminate, if the transformation of loops to assumes by
+goto-symex is applied.

--- a/regression/cbmc/while2/test.desc
+++ b/regression/cbmc/while2/test.desc
@@ -1,0 +1,10 @@
+CORE
+main.c
+
+^EXIT=10$
+^SIGNAL=0$
+^\[main.assertion.1\] line 18 assertion count == 5: SUCCESS$
+^\[main.assertion.2\] line 19 assertion count == 17: FAILURE$
+^VERIFICATION FAILED$
+--
+^warning: ignoring

--- a/src/goto-symex/symex_goto.cpp
+++ b/src/goto-symex/symex_goto.cpp
@@ -252,9 +252,12 @@ void goto_symext::symex_goto(statet &state)
     // is it label: goto label; or while(cond); - popular in SV-COMP
     if(
       symex_config.self_loops_to_assumptions &&
+      // label: goto label; or do {} while(cond);
       (goto_target == state.source.pc ||
+       // while(cond);
        (instruction.incoming_edges.size() == 1 &&
-        *instruction.incoming_edges.begin() == goto_target)))
+        *instruction.incoming_edges.begin() == goto_target &&
+        goto_target->is_goto() && new_guard.is_true())))
     {
       // generate assume(false) or a suitable negation if this
       // instruction is a conditional goto


### PR DESCRIPTION
The previous implementation (from e672e0d4) would not account for
loop heads with side effects.

Fixes: #5450

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
