### PR TITLE
Add an action to perform automatic releases

### DIFF
--- a/.github/workflows/regular-release.yaml
+++ b/.github/workflows/regular-release.yaml
@@ -1,0 +1,66 @@
+on:
+  schedule:
+#            ┌───────────── minute (0 - 59)
+#            │ ┌───────────── hour (0 - 23)
+#            │ │ ┌───────────── day of the month (1 - 31)
+#            │ │ │ ┌───────────── month (1 - 12 or JAN-DEC)
+#            │ │ │ │ ┌───────────── day of the week (0 - 6 or SUN-SAT)
+#            │ │ │ │ │
+#            │ │ │ │ │
+#            │ │ │ │ │
+    - cron: '0 9 * * THU'
+      # ^ this means 9:00 AM every thursday
+      # I can’t figure out the right syntax
+      # for ‘every other thursday’
+
+jobs:
+  bump_cbmc_version:
+    runs-on: ubuntu-20.04
+    outputs:
+      cbmc_version: ${{ steps.cbmc_version_number.outputs.CBMC_VERSION }}
+      bump_git_sha: ${{ steps.commit_bump.outputs.bump_git_sha }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      - name: Get new CBMC version number
+        id: cbmc_version_number
+        run: |
+          NEW_CBMC_VERSION=$(grep '^CBMC_VERSION =' src/config.inc | cut -d = -f 2 | scripts/increment_version.sh)
+          echo ::set-env name=CBMC_VERSION::$NEW_CBMC_VERSION
+          echo ::set-output name=CBMC_VERSION::$NEW_CBMC_VERSION
+      - name: Update CBMC version
+        run: |
+          sed -i "s/CBMC_VERSION = .*/CBMC_VERSION = $CBMC_VERSION/" src/config.inc
+      - name: Set git identity to github bot
+        run: |
+          git config --local user.name db-ci-cprover
+          git config --local user.email "db-ci-cprover@diffblue.com"
+      - name: Commit changes
+        id: commit_bump
+        run: |
+          git commit -a -m "Bump version to $CBMC_VERSION"
+          echo "::set-output name=bump_git_sha::$(git rev-parse HEAD)"
+      - name: Push changes
+        run: |
+          git push
+  perform-release:
+    needs: bump_cbmc_version
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          # We just added a commit to master, so the default GITHUB_REF doesn’t work anymore
+          ref: master
+      - name: DEBUG show bump version
+        run: echo ${{ needs.bump_cbmc_version.outputs.CBMC_VERSION }}
+      - name: Create release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.DB_CI_CPROVER_ACCESS_TOKEN }}
+        with:
+          tag_name: cbmc-${{ needs.bump_cbmc_version.outputs.CBMC_VERSION }}
+          release_name: cbmc-${{ needs.bump_cbmc_version.outputs.CBMC_VERSION }}
+          draft: false
+          prerelease: false
+          commitish: ${{ needs.bump_cbmc_version.outputs.bump_git_sha }}

--- a/scripts/increment_version.sh
+++ b/scripts/increment_version.sh
@@ -1,0 +1,7 @@
+# By default, just create a new minor version. If we ever need to change
+# major/patch version just do it manually.
+read -r version_line
+major=$(echo $version_line | cut -d . -f 1)
+minor=$(echo $version_line | cut -d . -f 2)
+patch=$(echo $version_line | cut -d . -f 3)
+echo "$major.$(expr $minor + 1).0"


### PR DESCRIPTION
This action automatically does the following every thursday at 9:00 AM:

* Create a commit that increments the last number of CBMC_VERSION
  in src/config.inc
* Perform a release tagged with the new CBMC_VERSION number

This only saves us a tiny bit of work right now, but we’ll add actions to
automatically create and upload binary artifacts for these releases soon.

Depends on https://github.com/diffblue/cbmc/pull/5454 because that sets the `CBMC_VERSION` to what this script expects.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
