### PR TITLE
Port ancillary jobs from Travis to github actions

### DIFF
--- a/.github/workflows/pull-request-check-clang-format.sh
+++ b/.github/workflows/pull-request-check-clang-format.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# Stop on errors
+set -e
+
+# Log information about the run of this check.
+echo "Pull request's base branch is: ${BASE_BRANCH}"
+echo "Pull request's merge branch is: ${MERGE_BRANCH}"
+echo "Pull request's source branch is: ${GITHUB_HEAD_REF}"
+clang-format-7 --version
+
+# The checkout action leaves us in detatched head state. The following line
+# names the checked out commit, for simpler reference later.
+git checkout -b ${MERGE_BRANCH}
+
+# Build list of files to ignore 
+while read file ; do EXCLUDES+="':(top,exclude)$file' " ; done < .clang-format-ignore
+
+# Make sure we can refer to ${BASE_BRANCH} by name
+git checkout ${BASE_BRANCH}
+git checkout ${MERGE_BRANCH}
+
+# Find the commit on which the PR is based.
+MERGE_BASE=$(git merge-base ${BASE_BRANCH} ${MERGE_BRANCH})
+echo "Checking for formatting errors introduced since $MERGE_BASE"
+
+# Do the checking. "eval" is used so that quotes (as inserted into $EXCLUDES
+# above) are not interpreted as parts of file names.
+eval git-clang-format-7 --binary clang-format-7 $MERGE_BASE -- $EXCLUDES
+git diff > formatted.diff
+if [[ -s formatted.diff ]] ; then
+  echo 'Formatting error! The following diff shows the required changes'
+  echo 'Use the raw log to get a version of the diff that preserves spacing'
+  cat formatted.diff
+  exit 1
+fi
+echo 'No formatting errors found'
+exit 0

--- a/.github/workflows/pull-request-check-cpplint.sh
+++ b/.github/workflows/pull-request-check-cpplint.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# Stop on errors
+set -e
+
+# Log information about the run of this check.
+echo "Pull request's base branch is: ${BASE_BRANCH}"
+echo "Pull request's merge branch is: ${MERGE_BRANCH}"
+echo "Pull request's source branch is: ${GITHUB_HEAD_REF}"
+
+# The checkout action leaves us in detatched head state. The following line
+# names the checked out commit, for simpler reference later.
+git checkout -b ${MERGE_BRANCH}
+
+# Make sure we can refer to ${BASE_BRANCH} by name
+git checkout ${BASE_BRANCH}
+git checkout ${MERGE_BRANCH}
+
+# Find the commit on which the PR is based.
+MERGE_BASE=$(git merge-base ${BASE_BRANCH} ${MERGE_BRANCH})
+echo "Checking standards of code touched since $MERGE_BASE"
+
+# Do the checking.
+script_folder='./scripts'
+$script_folder/run_diff.sh CPPLINT $MERGE_BASE

--- a/.github/workflows/pull-request-check-cpplint.sh
+++ b/.github/workflows/pull-request-check-cpplint.sh
@@ -21,5 +21,4 @@ MERGE_BASE=$(git merge-base ${BASE_BRANCH} ${MERGE_BRANCH})
 echo "Checking standards of code touched since $MERGE_BASE"
 
 # Do the checking.
-script_folder='./scripts'
-$script_folder/run_diff.sh CPPLINT $MERGE_BASE
+./scripts/run_diff.sh CPPLINT $MERGE_BASE

--- a/.github/workflows/pull-request-checks.yaml
+++ b/.github/workflows/pull-request-checks.yaml
@@ -144,3 +144,23 @@ jobs:
           BASE_BRANCH: ${{ github.base_ref }}
           MERGE_BRANCH: ${{ github.ref }}
         run: ./.github/workflows/pull-request-check-clang-format.sh
+
+  check-cpplint:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+          fetch-depth: 0
+      - name: Fetch dependencies
+        env:
+          # This is needed in addition to -yq to prevent apt-get from asking for
+          # user input
+          DEBIAN_FRONTEND: noninteractive
+        run: |
+          pip install unidiff
+      - name: Check updated lines of code meet linting standards
+        env:
+          BASE_BRANCH: ${{ github.base_ref }}
+          MERGE_BRANCH: ${{ github.ref }}
+        run: ./.github/workflows/pull-request-check-cpplint.sh

--- a/.github/workflows/pull-request-checks.yaml
+++ b/.github/workflows/pull-request-checks.yaml
@@ -124,3 +124,23 @@ jobs:
 
       - name: Build cbmc
         run: "%SCRIPT_DIR%\\build-cbmc.bat"
+
+  check-clang-format:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+          fetch-depth: 0
+      - name: Fetch dependencies
+        env:
+          # This is needed in addition to -yq to prevent apt-get from asking for
+          # user input
+          DEBIAN_FRONTEND: noninteractive
+        run: |
+          sudo apt-get install -yq clang-format-7
+      - name: Check updated lines of code match clang-format-7 style
+        env:
+          BASE_BRANCH: ${{ github.base_ref }}
+          MERGE_BRANCH: ${{ github.ref }}
+        run: ./.github/workflows/pull-request-check-clang-format.sh

--- a/.github/workflows/pull-request-checks.yaml
+++ b/.github/workflows/pull-request-checks.yaml
@@ -164,3 +164,10 @@ jobs:
           BASE_BRANCH: ${{ github.base_ref }}
           MERGE_BRANCH: ${{ github.ref }}
         run: ./.github/workflows/pull-request-check-cpplint.sh
+
+  check-string-table:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Check for unused irep ids
+        run: ./scripts/string_table_check.sh


### PR DESCRIPTION
These were formerly a Travis CI jobs. Setting them up using Github actions gives us a user interface which integrates into the rest of github better. This is a step towards having all jobs setup in Github actions and removing Travis.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
