### PR TITLE
Set CMake project version based on config.inc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,16 @@
 cmake_minimum_required(VERSION 3.2)
 
-project(CBMC)
+
+# Grab the current CBMC version from config.inc
+file(
+  STRINGS src/config.inc CBMC_VERSION
+  REGEX "CBMC_VERSION = (.*)")
+string(REGEX REPLACE "CBMC_VERSION = (.*)" "\\1" CBMC_VERSION ${CBMC_VERSION})
+
+project(CBMC VERSION ${CBMC_VERSION})
+
+# when config.inc changes we’ll need to reconfigure to check if the version changed
+set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/src/config.inc")
 
 find_program(CCACHE_PROGRAM ccache)
 if(CCACHE_PROGRAM)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,10 @@ cmake_minimum_required(VERSION 3.2)
 
 
 # Grab the current CBMC version from config.inc
+# We do this so we have a matching cbmc version between the Makefile build and
+# the CMake build. This version info is useful for things like generating
+# packages (which usually need to contain version info in their metadata and
+# filenames)
 file(
   STRINGS src/config.inc CBMC_VERSION
   REGEX "CBMC_VERSION = (.*)")


### PR DESCRIPTION
Currently we set the CBMC version in config.inc.

It would be useful to have this information in our CMakeLists.txt as
well (especially for e.g. CPack packaging), and to avoid duplication it
would be better to have it in just one place. It’s somewhat easier to
parse config.inc from CMake than doing it the other way round (and we
already do it in src/util/CMakeLists.txt anyway), we do it here.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
