### PR TITLE
Fix AWS windows cmake CI

### DIFF
--- a/buildspec-windows-cmake.yml
+++ b/buildspec-windows-cmake.yml
@@ -9,7 +9,9 @@ phases:
   install:
     commands:
       - choco install -y --no-progress cmake --installargs 'ADD_CMAKE_TO_PATH=System'
-      - choco install -y --no-progress winflexbison3 ninja
+      - choco install cyg-get -y --no-progress
+      - cyg-get bison flex
+      - choco install -y --no-progress ninja
       - nuget install clcache -OutputDirectory "c:\tools" -ExcludeVersion -Version 4.1.0
 
   build:


### PR DESCRIPTION
Install bison and flex on the windows cmake build from cyg-get. Because the chocolatey package for flex and bison is currently broken, due to a dead link.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
