### PR TITLE
CBMC additional profiling info: Pointer dereference, points-to set metric

### DIFF
--- a/regression/cbmc/points-to-sets/main.c
+++ b/regression/cbmc/points-to-sets/main.c
@@ -1,9 +1,9 @@
 int main()
 {
-	unsigned int value;
-	int *p = (int *) value;
+  unsigned int value;
+  int *p = (int *)value;
 
-	*p = *p + 1;
-	assert(1);
-	return 0;
+  *p = *p + 1;
+  assert(1);
+  return 0;
 }

--- a/regression/cbmc/points-to-sets/main.c
+++ b/regression/cbmc/points-to-sets/main.c
@@ -1,0 +1,9 @@
+int main()
+{
+	unsigned int value;
+	int *p = (int *) value;
+
+	*p = *p + 1;
+	assert(1);
+	return 0;
+}

--- a/regression/cbmc/points-to-sets/test.desc
+++ b/regression/cbmc/points-to-sets/test.desc
@@ -1,0 +1,10 @@
+CORE
+main.c
+--show-points-to-sets --json-ui
+activate-multi-line-match
+^EXIT=0$
+^SIGNAL=0$
+\{\n\s*"Pointer": "main::1::p!0@1",\n\s*"PointsToSet": \[ "object_descriptor\(integer_address, unknown\)" \],\n\s*"PointsToSetSize": 1,\n\s*"RetainedValuesSet": \[ "object_descriptor\(integer_address, unknown\)" \],\n\s*"RetainedValuesSetSize": 1,\n\s*"Value": "byte_extract_little_endian\(__CPROVER_memory, pointer_offset\(main::1::p!0@1\), signedbv\[32\]\)"\n\s*\},\n\s*\{\n\s*"Pointer": "main::1::p!0@1",\n\s*"PointsToSet": \[ "object_descriptor\(integer_address, unknown\)" \],\n\s*"PointsToSetSize": 1,\n\s*"RetainedValuesSet": \[ "object_descriptor\(integer_address, unknown\)" \],\n\s*"RetainedValuesSetSize": 1,\n\s*"Value": "byte_extract_little_endian\(__CPROVER_memory, pointer_offset\(main::1::p!0@1\), signedbv\[32\]\)"\n\s*\}
+--
+--
+To test output for --show-points-to-sets option that displays the size and contents of points-to sets in json format.

--- a/regression/cbmc/points-to-sets/test.desc
+++ b/regression/cbmc/points-to-sets/test.desc
@@ -1,12 +1,8 @@
 CORE
 main.c
 --show-points-to-sets
-^EXIT=(0|127|134|137)$
+^EXIT=1$
 ^SIGNAL=0$
---- begin invariant violation report ---
-Invariant check failed
-Condition: false
-Reason: Cannot print json data on PLAIN UI
 --
 --
 To test output for --show-points-to-sets option that displays the size and contents of points-to sets in json format.

--- a/regression/cbmc/points-to-sets/test_json.desc
+++ b/regression/cbmc/points-to-sets/test_json.desc
@@ -1,0 +1,11 @@
+CORE
+main.c
+--show-points-to-sets --json-ui
+activate-multi-line-match
+^EXIT=0$
+^SIGNAL=0$
+\{\n\s*"Pointer": "main::1::p!0@1",\n\s*"PointsToSet": \[ "object_descriptor\(integer_address, unknown\)" \],\n\s*"PointsToSetSize": 1,\n\s*"RetainedValuesSet": \[ "object_descriptor\(integer_address, unknown\)" \],\n\s*"RetainedValuesSetSize": 1,\n\s*"Value": "byte_extract_little_endian\(__CPROVER_memory, pointer_offset\(main::1::p!0@1\), signedbv\[32\]\)"\n\s*\},\n\s*\{\n\s*"Pointer": "main::1::p!0@1",\n\s*"PointsToSet": \[ "object_descriptor\(integer_address, unknown\)" \],\n\s*"PointsToSetSize": 1,\n\s*"RetainedValuesSet": \[ "object_descriptor\(integer_address, unknown\)" \],\n\s*"RetainedValuesSetSize": 1,\n\s*"Value": "byte_extract_little_endian\(__CPROVER_memory, pointer_offset\(main::1::p!0@1\), signedbv\[32\]\)"\n\s*\}
+--
+--
+To test output for --show-points-to-sets option that displays the size and contents of points-to sets in json format.
+xml-ui and plain output not supported.

--- a/regression/cbmc/points-to-sets/test_xml.desc
+++ b/regression/cbmc/points-to-sets/test_xml.desc
@@ -1,12 +1,12 @@
 CORE
 main.c
---show-points-to-sets
+--show-points-to-sets --xml-ui
 ^EXIT=(0|127|134|137)$
 ^SIGNAL=0$
 --- begin invariant violation report ---
 Invariant check failed
 Condition: false
-Reason: Cannot print json data on PLAIN UI
+Reason: Cannot print json data on XML UI
 --
 --
 To test output for --show-points-to-sets option that displays the size and contents of points-to sets in json format.

--- a/regression/cbmc/points-to-sets/test_xml.desc
+++ b/regression/cbmc/points-to-sets/test_xml.desc
@@ -1,12 +1,8 @@
 CORE
 main.c
 --show-points-to-sets --xml-ui
-^EXIT=(0|127|134|137)$
+^EXIT=1$
 ^SIGNAL=0$
---- begin invariant violation report ---
-Invariant check failed
-Condition: false
-Reason: Cannot print json data on XML UI
 --
 --
 To test output for --show-points-to-sets option that displays the size and contents of points-to sets in json format.

--- a/src/cbmc/cbmc_parse_options.cpp
+++ b/src/cbmc/cbmc_parse_options.cpp
@@ -522,16 +522,7 @@ void cbmc_parse_optionst::get_command_line_options(optionst &options)
     options.set_option("show-goto-symex-steps", true);
 
   if(cmdline.isset("show-points-to-sets"))
-  {
-    if(!cmdline.isset("json-ui"))
-    {
-      log.error() << "--show-points-to-sets supports only"
-                     " json output. Use --json-ui."
-                  << messaget::eom;
-      exit(CPROVER_EXIT_USAGE_ERROR);
-    }
     options.set_option("show-points-to-sets", true);
-  }
 
   PARSE_OPTIONS_GOTO_TRACE(cmdline, options);
 }

--- a/src/cbmc/cbmc_parse_options.cpp
+++ b/src/cbmc/cbmc_parse_options.cpp
@@ -522,7 +522,16 @@ void cbmc_parse_optionst::get_command_line_options(optionst &options)
     options.set_option("show-goto-symex-steps", true);
 
   if(cmdline.isset("show-points-to-sets"))
+  {
+    if(!cmdline.isset("json-ui"))
+    {
+      log.error() << "--show-points-to-sets supports only"
+                     " json output. Use --json-ui."
+                  << messaget::eom;
+      exit(CPROVER_EXIT_USAGE_ERROR);
+    }
     options.set_option("show-points-to-sets", true);
+  }
 
   PARSE_OPTIONS_GOTO_TRACE(cmdline, options);
 }

--- a/src/cbmc/cbmc_parse_options.cpp
+++ b/src/cbmc/cbmc_parse_options.cpp
@@ -122,6 +122,7 @@ void cbmc_parse_optionst::set_default_options(optionst &options)
   options.set_option("simplify", true);
   options.set_option("simplify-if", true);
   options.set_option("show-goto-symex-steps", false);
+  options.set_option("show-points-to-sets", false);
 
   // Other default
   options.set_option("arrays-uf", "auto");
@@ -519,6 +520,9 @@ void cbmc_parse_optionst::get_command_line_options(optionst &options)
 
   if(cmdline.isset("show-goto-symex-steps"))
     options.set_option("show-goto-symex-steps", true);
+
+  if(cmdline.isset("show-points-to-sets"))
+    options.set_option("show-points-to-sets", true);
 
   PARSE_OPTIONS_GOTO_TRACE(cmdline, options);
 }

--- a/src/cbmc/cbmc_parse_options.cpp
+++ b/src/cbmc/cbmc_parse_options.cpp
@@ -575,6 +575,17 @@ int cbmc_parse_optionst::doit()
     return CPROVER_EXIT_USAGE_ERROR;
   }
 
+  if(cmdline.isset("show-points-to-sets"))
+  {
+    if(!cmdline.isset("json-ui") || cmdline.isset("xml-ui"))
+    {
+      log.error() << "--show-points-to-sets supports only"
+                     " json output. Use --json-ui."
+                  << messaget::eom;
+      return CPROVER_EXIT_USAGE_ERROR;
+    }
+  }
+
   register_languages();
 
   // configure gcc, if required

--- a/src/goto-checker/bmc_util.h
+++ b/src/goto-checker/bmc_util.h
@@ -204,7 +204,8 @@ void run_property_decider(
   " --show-symex-strategies      list strategies for use with --paths\n" \
   " --show-goto-symex-steps      show which steps symex travels, includes " \
   "                              diagnostic information\n" \
-  " --show-points-to-sets        show points-to sets for pointer dereference\n" \
+  " --show-points-to-sets        show points-to sets for\n" \
+  "                              pointer dereference\n" \
   " --program-only               only show program expression\n" \
   " --show-byte-ops              show all byte extracts and updates\n" \
   " --show-loops                 show the loops in the program\n" \

--- a/src/goto-checker/bmc_util.h
+++ b/src/goto-checker/bmc_util.h
@@ -205,7 +205,7 @@ void run_property_decider(
   " --show-goto-symex-steps      show which steps symex travels, includes " \
   "                              diagnostic information\n" \
   " --show-points-to-sets        show points-to sets for\n" \
-  "                              pointer dereference\n" \
+  "                              pointer dereference. Requires --json-ui.\n" \
   " --program-only               only show program expression\n" \
   " --show-byte-ops              show all byte extracts and updates\n" \
   " --show-loops                 show the loops in the program\n" \

--- a/src/goto-checker/bmc_util.h
+++ b/src/goto-checker/bmc_util.h
@@ -177,6 +177,7 @@ void run_property_decider(
   "(show-loops)" \
   "(show-vcc)" \
   "(show-goto-symex-steps)" \
+  "(show-points-to-sets)" \
   "(slice-formula)" \
   "(unwinding-assertions)" \
   "(no-unwinding-assertions)" \
@@ -203,6 +204,7 @@ void run_property_decider(
   " --show-symex-strategies      list strategies for use with --paths\n" \
   " --show-goto-symex-steps      show which steps symex travels, includes " \
   "                              diagnostic information\n" \
+  " --show-points-to-sets        show points-to sets for pointer dereference\n" \
   " --program-only               only show program expression\n" \
   " --show-byte-ops              show all byte extracts and updates\n" \
   " --show-loops                 show the loops in the program\n" \

--- a/src/goto-symex/symex_clean_expr.cpp
+++ b/src/goto-symex/symex_clean_expr.cpp
@@ -136,7 +136,7 @@ void goto_symext::process_array_expr(statet &state, exprt &expr)
   value_set_dereferencet dereference(
     ns, state.symbol_table, symex_dereference_state, language_mode, false);
 
-  expr = dereference.dereference(expr);
+  expr = dereference.dereference(expr, symex_config.show_points_to_sets);
   lift_lets(state, expr);
 
   ::process_array_expr(expr, symex_config.simplify_opt, ns);

--- a/src/goto-symex/symex_clean_expr.cpp
+++ b/src/goto-symex/symex_clean_expr.cpp
@@ -134,7 +134,7 @@ void goto_symext::process_array_expr(statet &state, exprt &expr)
   symex_dereference_statet symex_dereference_state(state, ns);
 
   value_set_dereferencet dereference(
-    ns, state.symbol_table, symex_dereference_state, language_mode, false);
+    ns, state.symbol_table, symex_dereference_state, language_mode, false, log);
 
   expr = dereference.dereference(expr, symex_config.show_points_to_sets);
   lift_lets(state, expr);

--- a/src/goto-symex/symex_config.h
+++ b/src/goto-symex/symex_config.h
@@ -46,6 +46,7 @@ struct symex_configt final
   /// \brief Prints out the path that symex is actively taking during execution,
   /// includes diagnostic information about call stack and guard size.
   bool show_symex_steps;
+  bool show_points_to_sets;
 
   /// Maximum sizes for which field sensitivity will be applied to array cells
   std::size_t max_field_sensitivity_array_size;

--- a/src/goto-symex/symex_dereference.cpp
+++ b/src/goto-symex/symex_dereference.cpp
@@ -267,7 +267,7 @@ void goto_symext::dereference_rec(exprt &expr, statet &state, bool write)
       expr_is_not_null);
 
     // std::cout << "**** " << format(tmp1) << '\n';
-    exprt tmp2 = dereference.dereference(tmp1);
+    exprt tmp2 = dereference.dereference(tmp1, symex_config.show_points_to_sets);
     // std::cout << "**** " << format(tmp2) << '\n';
 
     expr.swap(tmp2);

--- a/src/goto-symex/symex_dereference.cpp
+++ b/src/goto-symex/symex_dereference.cpp
@@ -267,7 +267,8 @@ void goto_symext::dereference_rec(exprt &expr, statet &state, bool write)
       expr_is_not_null);
 
     // std::cout << "**** " << format(tmp1) << '\n';
-    exprt tmp2 = dereference.dereference(tmp1, symex_config.show_points_to_sets);
+    exprt tmp2 =
+      dereference.dereference(tmp1, symex_config.show_points_to_sets);
     // std::cout << "**** " << format(tmp2) << '\n';
 
     expr.swap(tmp2);

--- a/src/goto-symex/symex_dereference.cpp
+++ b/src/goto-symex/symex_dereference.cpp
@@ -264,7 +264,8 @@ void goto_symext::dereference_rec(exprt &expr, statet &state, bool write)
       state.symbol_table,
       symex_dereference_state,
       language_mode,
-      expr_is_not_null);
+      expr_is_not_null,
+      log);
 
     // std::cout << "**** " << format(tmp1) << '\n';
     exprt tmp2 =

--- a/src/goto-symex/symex_main.cpp
+++ b/src/goto-symex/symex_main.cpp
@@ -47,6 +47,7 @@ symex_configt::symex_configt(const optionst &options)
     debug_level(unsafe_string2int(options.get_option("debug-level"))),
     run_validation_checks(options.get_bool_option("validate-ssa-equation")),
     show_symex_steps(options.get_bool_option("show-goto-symex-steps")),
+    show_points_to_sets(options.get_bool_option("show-points-to-sets")),
     max_field_sensitivity_array_size(
       options.is_set("no-array-field-sensitivity")
         ? 0

--- a/src/pointer-analysis/goto_program_dereference.h
+++ b/src/pointer-analysis/goto_program_dereference.h
@@ -36,7 +36,7 @@ public:
     : options(_options),
       ns(_ns),
       value_sets(_value_sets),
-      dereference(_ns, _new_symbol_table, *this, ID_nil, false)
+      dereference(_ns, _new_symbol_table, *this, ID_nil, false, messaget())
   {
   }
 

--- a/src/pointer-analysis/goto_program_dereference.h
+++ b/src/pointer-analysis/goto_program_dereference.h
@@ -28,15 +28,24 @@ public:
   // for the final argument to value_set_dereferencet.
   // This means that language-inappropriate values such as
   // (struct A*)some_integer_value in Java, may be returned.
+  // Note: value_set_dereferencet requires a messaget instance
+  // as on of its arguments to display the points-to set
+  // during symex. Display is not done during goto-program
+  // conversion. To ensure this the display_points_to_sets
+  // parameter in value_set_dereferencet::dereference()
+  // is set to false by default and is not changed by the
+  // goto program conversion modules. Similarly, here we set
+  // _log to be a default messaget instance.
   goto_program_dereferencet(
     const namespacet &_ns,
     symbol_tablet &_new_symbol_table,
     const optionst &_options,
-    value_setst &_value_sets)
+    value_setst &_value_sets,
+    const messaget &_log = messaget())
     : options(_options),
       ns(_ns),
       value_sets(_value_sets),
-      dereference(_ns, _new_symbol_table, *this, ID_nil, false, messaget())
+      dereference(_ns, _new_symbol_table, *this, ID_nil, false, _log)
   {
   }
 

--- a/src/pointer-analysis/value_set_dereference.cpp
+++ b/src/pointer-analysis/value_set_dereference.cpp
@@ -59,7 +59,9 @@ static bool should_use_local_definition_for(const exprt &expr)
   return false;
 }
 
-exprt value_set_dereferencet::dereference(const exprt &pointer, bool display_points_to_sets)
+exprt value_set_dereferencet::dereference(
+  const exprt &pointer,
+  bool display_points_to_sets)
 {
   if(pointer.type().id()!=ID_pointer)
     throw "dereference expected pointer type, but got "+
@@ -70,7 +72,8 @@ exprt value_set_dereferencet::dereference(const exprt &pointer, bool display_poi
   {
     const if_exprt &if_expr=to_if_expr(pointer);
     exprt true_case = dereference(if_expr.true_case(), display_points_to_sets);
-    exprt false_case = dereference(if_expr.false_case(), display_points_to_sets);
+    exprt false_case =
+      dereference(if_expr.false_case(), display_points_to_sets);
     return if_exprt(if_expr.cond(), true_case, false_case);
   }
   else if(pointer.id() == ID_typecast)
@@ -89,8 +92,12 @@ exprt value_set_dereferencet::dereference(const exprt &pointer, bool display_poi
       const auto &if_expr = to_if_expr(*underlying);
       return if_exprt(
         if_expr.cond(),
-        dereference(typecast_exprt(if_expr.true_case(), pointer.type()), display_points_to_sets),
-        dereference(typecast_exprt(if_expr.false_case(), pointer.type()), display_points_to_sets));
+        dereference(
+          typecast_exprt(if_expr.true_case(), pointer.type()),
+          display_points_to_sets),
+        dereference(
+          typecast_exprt(if_expr.false_case(), pointer.type()),
+          display_points_to_sets));
     }
   }
 
@@ -116,7 +123,8 @@ exprt value_set_dereferencet::dereference(const exprt &pointer, bool display_poi
 
   if(display_points_to_sets)
   {
-    json_result["PointsToSetSize"] = json_numbert(std::to_string(points_to_set.size()));
+    json_result["PointsToSetSize"] =
+      json_numbert(std::to_string(points_to_set.size()));
 
     json_arrayt points_to_set_json;
     for(auto p : points_to_set)
@@ -159,7 +167,8 @@ exprt value_set_dereferencet::dereference(const exprt &pointer, bool display_poi
 
   if(display_points_to_sets)
   {
-    json_result["RetainedValuesSetSize"] = json_numbert(std::to_string(points_to_set.size()));
+    json_result["RetainedValuesSetSize"] =
+      json_numbert(std::to_string(points_to_set.size()));
 
     json_arrayt retained_values_set_json;
     for(auto &value : retained_values)

--- a/src/pointer-analysis/value_set_dereference.cpp
+++ b/src/pointer-analysis/value_set_dereference.cpp
@@ -276,7 +276,7 @@ exprt value_set_dereferencet::dereference(
     ss << format(value);
     json_result["Value"] = json_stringt(ss.str());
 
-    std::cout << ",\n" << json_result;
+    log.status() << json_result;
   }
 
 #ifdef DEBUG

--- a/src/pointer-analysis/value_set_dereference.cpp
+++ b/src/pointer-analysis/value_set_dereference.cpp
@@ -11,9 +11,9 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "value_set_dereference.h"
 
+#ifdef DEBUG
 #include <iostream>
-#include <util/format_expr.h>
-#include <util/json_irep.h>
+#endif
 
 #include <util/arith_tools.h>
 #include <util/array_name.h>
@@ -23,8 +23,10 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/cprover_prefix.h>
 #include <util/expr_iterator.h>
 #include <util/expr_util.h>
+#include <util/format_expr.h>
 #include <util/format_type.h>
 #include <util/fresh_symbol.h>
+#include <util/json_irep.h>
 #include <util/options.h>
 #include <util/pointer_offset_size.h>
 #include <util/pointer_predicates.h>

--- a/src/pointer-analysis/value_set_dereference.h
+++ b/src/pointer-analysis/value_set_dereference.h
@@ -14,6 +14,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <unordered_set>
 
+#include <util/message.h>
 #include <util/std_expr.h>
 
 #include "dereference_callback.h"
@@ -34,17 +35,20 @@ public:
   ///   dereference failure
   /// \param _exclude_null_derefs: Ignore value-set entries that indicate a
   //    given dereference may follow a null pointer
+  /// \param _log: Messaget object for displaying points-to set
   value_set_dereferencet(
     const namespacet &_ns,
     symbol_tablet &_new_symbol_table,
     dereference_callbackt &_dereference_callback,
     const irep_idt _language_mode,
-    bool _exclude_null_derefs):
-    ns(_ns),
-    new_symbol_table(_new_symbol_table),
-    dereference_callback(_dereference_callback),
-    language_mode(_language_mode),
-    exclude_null_derefs(_exclude_null_derefs)
+    bool _exclude_null_derefs,
+    const messaget &_log)
+    : ns(_ns),
+      new_symbol_table(_new_symbol_table),
+      dereference_callback(_dereference_callback),
+      language_mode(_language_mode),
+      exclude_null_derefs(_exclude_null_derefs),
+      log(_log)
   { }
 
   virtual ~value_set_dereferencet() { }
@@ -106,6 +110,7 @@ private:
   /// Flag indicating whether `value_set_dereferencet::dereference` should
   /// disregard an apparent attempt to dereference NULL
   const bool exclude_null_derefs;
+  const messaget &log;
 };
 
 #endif // CPROVER_POINTER_ANALYSIS_VALUE_SET_DEREFERENCE_H

--- a/src/pointer-analysis/value_set_dereference.h
+++ b/src/pointer-analysis/value_set_dereference.h
@@ -52,7 +52,8 @@ public:
   /// Dereference the given pointer-expression. Any errors are
   /// reported to the callback method given in the constructor.
   /// \param pointer: A pointer-typed expression, to be dereferenced.
-  exprt dereference(const exprt &pointer);
+  /// \param display_points_to_sets: Display size and contents of points to sets
+  exprt dereference(const exprt &pointer, bool display_points_to_sets = false);
 
   /// Return value for `build_reference_to`; see that method for documentation.
   class valuet


### PR DESCRIPTION
<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->
Parse option to track size and contents of points-to sets during pointer dereferencing.
- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [x] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
