### PR TITLE
CBMC additional profiling info: Track memcmp, memcpy and memset function calls

### DIFF
--- a/regression/cbmc/memop-calls/main.c
+++ b/regression/cbmc/memop-calls/main.c
@@ -1,0 +1,9 @@
+#include<string.h>
+int main()
+{
+	const int a[2] = {0, 0};
+	int b[2];
+
+	memcpy(a, b, 3);
+	return 0;
+}

--- a/regression/cbmc/memop-calls/test.desc
+++ b/regression/cbmc/memop-calls/test.desc
@@ -1,0 +1,11 @@
+CORE
+main.c
+--list-memop-calls
+^EXIT=0$
+^SIGNAL=0$
+^.*main\.c line 7 function main$
+^__builtin___memcpy_chk\(.*\);$
+^Memop Count: 1$
+--
+--
+To test output for --list-memop-calls option that lists all memcpy, memset and memcmp calls.

--- a/regression/cbmc/memop-calls/test_json.desc
+++ b/regression/cbmc/memop-calls/test_json.desc
@@ -1,0 +1,10 @@
+CORE
+main.c
+--list-memop-calls --json-ui
+activate-multi-line-match
+^EXIT=0$
+^SIGNAL=0$
+\{\n\s*"instruction": \{\n\s*"functionCall": "__builtin___memcpy_chk\(.*\);",\n\s*"sourceLocation": \{(\n.*)*\},\n\s*\{\n\s*"memOpCount": 1\n\s*\}
+--
+--
+To test json output for --list-memop-calls option that lists all memcpy, memset and memcmp calls.

--- a/regression/cbmc/memop-calls/test_xml.desc
+++ b/regression/cbmc/memop-calls/test_xml.desc
@@ -1,0 +1,14 @@
+CORE
+main.c
+--list-memop-calls --xml-ui
+^EXIT=0$
+^SIGNAL=0$
+<instruction>
+<function_call>__builtin___memcpy_chk(.*);
+</function_call>
+<location file="main.c" function="main" line="7".*>
+</instruction>
+<memop_count count="1"/>
+--
+--
+To test xml output for --list-memop-calls option that lists all memcpy, memset and memcmp calls.

--- a/src/cbmc/cbmc_parse_options.cpp
+++ b/src/cbmc/cbmc_parse_options.cpp
@@ -824,6 +824,12 @@ int cbmc_parse_optionst::get_goto_program(
     return CPROVER_EXIT_SUCCESS;
   }
 
+  if(cmdline.isset("list-memop-calls"))
+  {
+    show_memop_calls(goto_model.goto_functions, ui_message_handler);
+    return CPROVER_EXIT_SUCCESS;
+  }
+
   log.status() << config.object_bits_info() << messaget::eom;
 
   return -1; // no error, continue

--- a/src/goto-analyzer/goto_analyzer_parse_options.cpp
+++ b/src/goto-analyzer/goto_analyzer_parse_options.cpp
@@ -533,6 +533,12 @@ int goto_analyzer_parse_optionst::doit()
     return CPROVER_EXIT_SUCCESS;
   }
 
+  if(cmdline.isset("list-memop-calls"))
+  {
+    show_memop_calls(goto_model.goto_functions, ui_message_handler);
+    return CPROVER_EXIT_SUCCESS;
+  }
+
   return perform_analysis(options);
 }
 

--- a/src/goto-diff/goto_diff_parse_options.cpp
+++ b/src/goto-diff/goto_diff_parse_options.cpp
@@ -271,6 +271,13 @@ int goto_diff_parse_optionst::doit()
     return CPROVER_EXIT_SUCCESS;
   }
 
+  if(cmdline.isset("list-memop-calls"))
+  {
+    show_memop_calls(goto_model1.goto_functions, ui_message_handler);
+    show_memop_calls(goto_model2.goto_functions, ui_message_handler);
+    return CPROVER_EXIT_SUCCESS;
+  }
+
   if(cmdline.isset("change-impact") ||
      cmdline.isset("forward-impact") ||
      cmdline.isset("backward-impact"))

--- a/src/goto-instrument/goto_instrument_parse_options.cpp
+++ b/src/goto-instrument/goto_instrument_parse_options.cpp
@@ -666,6 +666,12 @@ int goto_instrument_parse_optionst::doit()
       return CPROVER_EXIT_SUCCESS;
     }
 
+    if(cmdline.isset("list-memop-calls"))
+    {
+      show_memop_calls(goto_model.goto_functions, ui_message_handler);
+      return CPROVER_EXIT_SUCCESS;
+    }
+
     if(cmdline.isset("list-undefined-functions"))
     {
       list_undefined_functions(goto_model, std::cout);

--- a/src/goto-programs/goto_function.cpp
+++ b/src/goto-programs/goto_function.cpp
@@ -77,28 +77,29 @@ void goto_functiont::validate(const namespacet &ns, const validation_modet vm)
 
 bool is_mem_op(const irept &irep)
 {
-  return (irep.id() == "memcmp" || irep.id() == "memcpy" ||
-    irep.id() == "memset" || irep.id() == "__builtin___memcpy_chk" ||
+  return (
+    irep.id() == "memcmp" || irep.id() == "memcpy" || irep.id() == "memset" ||
+    irep.id() == "__builtin___memcpy_chk" ||
     irep.id() == "__builtin___memset_chk");
 }
 
-json_objectt show_goto_instruction_json(
-  const goto_programt::instructiont &instruction)
+json_objectt
+show_goto_instruction_json(const goto_programt::instructiont &instruction)
 {
   std::stringstream ss;
   ss << format(instruction.get_function_call());
   const std::string &func_call = ss.str();
 
   json_objectt json_instr{
-    {"instruction", json_objectt{
-      {"functionCall", json_stringt(func_call)},
-      {"sourceLocation", json(instruction.code.source_location())}}}};
+    {"instruction",
+     json_objectt{
+       {"functionCall", json_stringt(func_call)},
+       {"sourceLocation", json(instruction.code.source_location())}}}};
 
   return json_instr;
 }
 
-xmlt show_goto_instruction_xml(
-  const goto_programt::instructiont &instruction)
+xmlt show_goto_instruction_xml(const goto_programt::instructiont &instruction)
 {
   xmlt xml_instr{"instruction"};
 
@@ -108,8 +109,7 @@ xmlt show_goto_instruction_xml(
 
   xmlt &xml_function_call = xml_instr.new_element("function_call");
   xml_function_call.data = func_call;
-  xml_instr.new_element(
-    xml(instruction.code.source_location()));
+  xml_instr.new_element(xml(instruction.code.source_location()));
 
   return xml_instr;
 }
@@ -123,30 +123,29 @@ void show_goto_instruction(
 
   switch(ui)
   {
-    case ui_message_handlert::uit::XML_UI:
-    {
-      msg.status() << show_goto_instruction_xml(instruction);
-    }
-    break;
-    case ui_message_handlert::uit::JSON_UI:
-    {
-      msg.status() << show_goto_instruction_json(instruction);
-    }
-    break;
-    case ui_message_handlert::uit::PLAIN:
-    {
-      msg.status() << messaget::faint << "\n"
-        << instruction.code.source_location().as_string()
-        << messaget::reset << messaget::eom;
-      msg.status() << format(instruction.get_function_call()) << messaget::eom;
-    }
-    break;
+  case ui_message_handlert::uit::XML_UI:
+  {
+    msg.status() << show_goto_instruction_xml(instruction);
   }
-
+  break;
+  case ui_message_handlert::uit::JSON_UI:
+  {
+    msg.status() << show_goto_instruction_json(instruction);
+  }
+  break;
+  case ui_message_handlert::uit::PLAIN:
+  {
+    msg.status() << messaget::faint << "\n"
+                 << instruction.code.source_location().as_string()
+                 << messaget::reset << messaget::eom;
+    msg.status() << format(instruction.get_function_call()) << messaget::eom;
+  }
+  break;
+  }
 }
 
-size_t goto_functiont::get_memop_calls(
-  ui_message_handlert &ui_message_handler) const
+size_t
+goto_functiont::get_memop_calls(ui_message_handlert &ui_message_handler) const
 {
   size_t memop_count = 0;
   for(const auto &instruction : body.instructions)

--- a/src/goto-programs/goto_function.cpp
+++ b/src/goto-programs/goto_function.cpp
@@ -13,6 +13,10 @@ Date: May 2018
 
 #include "goto_function.h"
 
+#include <util/format_expr.h>
+#include <util/json_irep.h>
+#include <util/xml_irep.h>
+
 /// Return in \p dest the identifiers of the local variables declared in the \p
 /// goto_function and the identifiers of the paramters of the \p goto_function.
 void get_local_identifiers(
@@ -69,4 +73,94 @@ void goto_functiont::validate(const namespacet &ns, const validation_modet vm)
   }
 
   validate_full_type(type, ns, vm);
+}
+
+bool is_mem_op(const irept &irep)
+{
+  return (irep.id() == "memcmp" || irep.id() == "memcpy" ||
+    irep.id() == "memset" || irep.id() == "__builtin___memcpy_chk" ||
+    irep.id() == "__builtin___memset_chk");
+}
+
+json_objectt show_goto_instruction_json(
+  const goto_programt::instructiont &instruction)
+{
+  std::stringstream ss;
+  ss << format(instruction.get_function_call());
+  const std::string &func_call = ss.str();
+
+  json_objectt json_instr{
+    {"instruction", json_objectt{
+      {"functionCall", json_stringt(func_call)},
+      {"sourceLocation", json(instruction.code.source_location())}}}};
+
+  return json_instr;
+}
+
+xmlt show_goto_instruction_xml(
+  const goto_programt::instructiont &instruction)
+{
+  xmlt xml_instr{"instruction"};
+
+  std::stringstream ss;
+  ss << format(instruction.get_function_call());
+  const std::string &func_call = ss.str();
+
+  xmlt &xml_function_call = xml_instr.new_element("function_call");
+  xml_function_call.data = func_call;
+  xml_instr.new_element(
+    xml(instruction.code.source_location()));
+
+  return xml_instr;
+}
+
+void show_goto_instruction(
+  const goto_programt::instructiont &instruction,
+  ui_message_handlert &ui_message_handler)
+{
+  ui_message_handlert::uit ui = ui_message_handler.get_ui();
+  messaget msg(ui_message_handler);
+
+  switch(ui)
+  {
+    case ui_message_handlert::uit::XML_UI:
+    {
+      msg.status() << show_goto_instruction_xml(instruction);
+    }
+    break;
+    case ui_message_handlert::uit::JSON_UI:
+    {
+      msg.status() << show_goto_instruction_json(instruction);
+    }
+    break;
+    case ui_message_handlert::uit::PLAIN:
+    {
+      msg.status() << messaget::faint << "\n"
+        << instruction.code.source_location().as_string()
+        << messaget::reset << messaget::eom;
+      msg.status() << format(instruction.get_function_call()) << messaget::eom;
+    }
+    break;
+  }
+
+}
+
+size_t goto_functiont::get_memop_calls(
+  ui_message_handlert &ui_message_handler) const
+{
+  size_t memop_count = 0;
+  for(const auto &instruction : body.instructions)
+  {
+    if(instruction.type == FUNCTION_CALL)
+    {
+      auto called_function = instruction.get_function_call().function();
+
+      if(is_mem_op(called_function.find(ID_identifier)))
+      {
+        memop_count++;
+        show_goto_instruction(instruction, ui_message_handler);
+      }
+    }
+  }
+  return memop_count;
 }

--- a/src/goto-programs/goto_function.h
+++ b/src/goto-programs/goto_function.h
@@ -19,6 +19,7 @@ Date: May 2018
 #include <util/deprecate.h>
 #include <util/find_symbols.h>
 #include <util/std_types.h>
+#include <util/ui_message.h>
 
 #include "goto_program.h"
 
@@ -40,6 +41,8 @@ public:
   /// Note: This is now the preferred way of getting the identifiers of the
   /// parameters. The identifiers in the type will go away.
   parameter_identifierst parameter_identifiers;
+
+  size_t get_memop_calls(ui_message_handlert &ui_message_handler) const;
 
   bool body_available() const
   {

--- a/src/goto-programs/show_goto_functions.cpp
+++ b/src/goto-programs/show_goto_functions.cpp
@@ -92,8 +92,7 @@ void show_goto_functions(
 
 void show_memop_calls(
   const goto_functionst &goto_functions,
-  ui_message_handlert &ui_message_handler
-  )
+  ui_message_handlert &ui_message_handler)
 {
   messaget msg(ui_message_handler);
 
@@ -106,23 +105,23 @@ void show_memop_calls(
   ui_message_handlert::uit ui = ui_message_handler.get_ui();
   switch(ui)
   {
-    case ui_message_handlert::uit::XML_UI:
-    {
-      xmlt xml_memop_count{"memop_count"};
-      xml_memop_count.set_attribute("count", memop_count);
+  case ui_message_handlert::uit::XML_UI:
+  {
+    xmlt xml_memop_count{"memop_count"};
+    xml_memop_count.set_attribute("count", memop_count);
 
-      msg.status() << xml_memop_count;
-    }
-    break;
-    case ui_message_handlert::uit::JSON_UI:
-    {
-      json_objectt json_memop_count{
-        {"memOpCount", json_numbert(std::to_string(memop_count))}
-      };
-      msg.status() << json_memop_count;
-    }
-    break;
-    case ui_message_handlert::uit::PLAIN:
-      msg.status() << "\nMemop Count: " << memop_count << messaget::eom;;
+    msg.status() << xml_memop_count;
+  }
+  break;
+  case ui_message_handlert::uit::JSON_UI:
+  {
+    json_objectt json_memop_count{
+      {"memOpCount", json_numbert(std::to_string(memop_count))}};
+    msg.status() << json_memop_count;
+  }
+  break;
+  case ui_message_handlert::uit::PLAIN:
+    msg.status() << "\nMemop Count: " << memop_count << messaget::eom;
+  break;
   }
 }

--- a/src/goto-programs/show_goto_functions.cpp
+++ b/src/goto-programs/show_goto_functions.cpp
@@ -89,3 +89,40 @@ void show_goto_functions(
   show_goto_functions(
     ns, ui_message_handler, goto_model.goto_functions, list_only);
 }
+
+void show_memop_calls(
+  const goto_functionst &goto_functions,
+  ui_message_handlert &ui_message_handler
+  )
+{
+  messaget msg(ui_message_handler);
+
+  const auto sorted = goto_functions.sorted();
+  static size_t memop_count = 0;
+
+  for(const auto &fun : sorted)
+    memop_count += fun->second.get_memop_calls(ui_message_handler);
+
+  ui_message_handlert::uit ui = ui_message_handler.get_ui();
+  switch(ui)
+  {
+    case ui_message_handlert::uit::XML_UI:
+    {
+      xmlt xml_memop_count{"memop_count"};
+      xml_memop_count.set_attribute("count", memop_count);
+
+      msg.status() << xml_memop_count;
+    }
+    break;
+    case ui_message_handlert::uit::JSON_UI:
+    {
+      json_objectt json_memop_count{
+        {"memOpCount", json_numbert(std::to_string(memop_count))}
+      };
+      msg.status() << json_memop_count;
+    }
+    break;
+    case ui_message_handlert::uit::PLAIN:
+      msg.status() << "\nMemop Count: " << memop_count << messaget::eom;;
+  }
+}

--- a/src/goto-programs/show_goto_functions.h
+++ b/src/goto-programs/show_goto_functions.h
@@ -21,11 +21,13 @@ class goto_functionst;
 // clang-format off
 #define OPT_SHOW_GOTO_FUNCTIONS \
   "(show-goto-functions)" \
-  "(list-goto-functions)"
+  "(list-goto-functions)" \
+  "(list-memop-calls)"
 
 #define HELP_SHOW_GOTO_FUNCTIONS \
   " --show-goto-functions        show loaded goto program\n" \
-  " --list-goto-functions        list loaded goto functions\n"
+  " --list-goto-functions        list loaded goto functions\n" \
+  " --list-memop-calls           list all calls to memop\n"
 // clang-format on
 
 void show_goto_functions(
@@ -38,5 +40,9 @@ void show_goto_functions(
   const goto_modelt &,
   ui_message_handlert &ui_message_handler,
   bool list_only);
+
+void show_memop_calls(
+  const goto_functionst &goto_functions,
+  ui_message_handlert &ui_message_handler);
 
 #endif // CPROVER_GOTO_PROGRAMS_SHOW_GOTO_FUNCTIONS_H


### PR DESCRIPTION
<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->
Memset, memcmp and memcpy functions often increase proof runtime and need to be replaced by stubs. Here we track these calls for ease of identification and subsequent replacement by stubs.

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [x] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
