### PR TITLE
CBMC additional profiling info: Extend solver hardness to track clauses mapped to an instruction

### DIFF
--- a/regression/solver-hardness/solver-hardness-simple/test.desc
+++ b/regression/solver-hardness/solver-hardness-simple/test.desc
@@ -5,6 +5,7 @@ main.c
 ^SIGNAL=0$
 ^\[main.assertion.\d+\] line \d+ assertion a \+ b \< 10: FAILURE$
 ^VERIFICATION FAILED$
-\"SAT_hardness\":\{(\"Clauses\":\d+|\"Variables\":\d+|\"Literals\":\d+),(\"Clauses\":\d+|\"Variables\":\d+|\"Literals\":\d+),(\"Clauses\":\d+|\"Variables\":\d+|\"Literals\":\d+)\}
+^Valid JSON File$
+\"SAT_hardness\": \{(\"ClauseSet\": \[.*\]|\"Clauses\": \d+|\"Variables\": \d+|\"Literals\": \d+), (\"ClauseSet\": \[.*\]|\"Clauses\": \d+|\"Variables\": \d+|\"Literals\": \d+), (\"ClauseSet\": \[.*\]|\"Clauses\": \d+|\"Variables\": \d+|\"Literals\": \d+), (\"ClauseSet\": \[.*\]|\"Clauses\": \d+|\"Variables\": \d+|\"Literals\": \d+)\}
 --
 ^warning: ignoring

--- a/regression/solver-hardness/solver-hardness-simple/test.desc
+++ b/regression/solver-hardness/solver-hardness-simple/test.desc
@@ -5,7 +5,6 @@ main.c
 ^SIGNAL=0$
 ^\[main.assertion.\d+\] line \d+ assertion a \+ b \< 10: FAILURE$
 ^VERIFICATION FAILED$
-^Valid JSON File$
-\"SAT_hardness\": \{(\"ClauseSet\": \[.*\]|\"Clauses\": \d+|\"Variables\": \d+|\"Literals\": \d+), (\"ClauseSet\": \[.*\]|\"Clauses\": \d+|\"Variables\": \d+|\"Literals\": \d+), (\"ClauseSet\": \[.*\]|\"Clauses\": \d+|\"Variables\": \d+|\"Literals\": \d+), (\"ClauseSet\": \[.*\]|\"Clauses\": \d+|\"Variables\": \d+|\"Literals\": \d+)\}
+\"SAT_hardness\":\{(\"ClauseSet\":\[.*\]|\"Clauses\":\d+|\"Variables\":\d+|\"Literals\":\d+),(\"ClauseSet\":\[.*\]|\"Clauses\":\d+|\"Variables\":\d+|\"Literals\":\d+),(\"ClauseSet\":\[.*\]|\"Clauses\":\d+|\"Variables\":\d+|\"Literals\":\d+),(\"ClauseSet\":\[.*\]|\"Clauses\":\d+|\"Variables\":\d+|\"Literals\":\d+)\}
 --
 ^warning: ignoring

--- a/src/solvers/sat/satcheck_minisat2.cpp
+++ b/src/solvers/sat/satcheck_minisat2.cpp
@@ -140,8 +140,10 @@ void satcheck_minisat2_baset<T>::lcnf(const bvt &bv)
 
     solver->addClause_(c);
 
-    with_solver_hardness(
-      [&bv](solver_hardnesst &hardness) { hardness.register_clause(bv); });
+    size_t solver_clause_num = clause_counter;
+    with_solver_hardness([&bv, &solver_clause_num](solver_hardnesst &hardness) {
+      hardness.register_clause(bv, solver_clause_num);
+    });
     clause_counter++;
   }
   catch(const Minisat::OutOfMemoryException &)

--- a/src/solvers/solver_hardness.cpp
+++ b/src/solvers/solver_hardness.cpp
@@ -108,6 +108,8 @@ void solver_hardnesst::register_clause(
   std::cout << "0\n";
 #endif
 
+  // The clause_counter is incremented after the call to register_clause.
+  // Here we add 1 to solver_clause_num to incorporate this increment.
   current_hardness.clause_set.push_back(solver_clause_num + 1);
   std::sort(
     current_hardness.clause_set.begin(), current_hardness.clause_set.end());

--- a/src/solvers/solver_hardness.cpp
+++ b/src/solvers/solver_hardness.cpp
@@ -26,8 +26,8 @@ operator+=(const solver_hardnesst::sat_hardnesst &other)
   clauses += other.clauses;
   literals += other.literals;
   variables.insert(other.variables.begin(), other.variables.end());
-  clause_set.insert(clause_set.end(),
-    other.clause_set.begin(), other.clause_set.end());
+  clause_set.insert(
+    clause_set.end(), other.clause_set.begin(), other.clause_set.end());
   return *this;
 }
 

--- a/src/solvers/solver_hardness.cpp
+++ b/src/solvers/solver_hardness.cpp
@@ -111,8 +111,6 @@ void solver_hardnesst::register_clause(
   // The clause_counter is incremented after the call to register_clause.
   // Here we add 1 to solver_clause_num to incorporate this increment.
   current_hardness.clause_set.push_back(solver_clause_num + 1);
-  std::sort(
-    current_hardness.clause_set.begin(), current_hardness.clause_set.end());
 }
 
 void solver_hardnesst::set_outfile(const std::string &file_name)

--- a/src/solvers/solver_hardness.cpp
+++ b/src/solvers/solver_hardness.cpp
@@ -91,7 +91,9 @@ void solver_hardnesst::register_assertion_ssas(
 
 void solver_hardnesst::register_clause(
   const bvt &bv,
-  const size_t solver_clause_num)
+  const bvt &cnf,
+  const size_t cnf_clause_index,
+  bool register_cnf)
 {
   current_hardness.clauses++;
   current_hardness.literals += bv.size();
@@ -101,16 +103,16 @@ void solver_hardnesst::register_clause(
     current_hardness.variables.insert(literal.var_no());
   }
 
+  if(register_cnf)
+  {
 #ifdef DEBUG
-  std::cout << solver_clause_num << ": ";
-  for(const auto &literal : bv)
-    std::cout << literal.dimacs() << " ";
-  std::cout << "0\n";
+    std::cout << cnf_clause_index << ": ";
+    for(const auto &literal : cnf)
+      std::cout << literal.dimacs() << " ";
+    std::cout << "0\n";
 #endif
-
-  // The clause_counter is incremented after the call to register_clause.
-  // Here we add 1 to solver_clause_num to incorporate this increment.
-  current_hardness.clause_set.push_back(solver_clause_num + 1);
+    current_hardness.clause_set.push_back(cnf_clause_index);
+  }
 }
 
 void solver_hardnesst::set_outfile(const std::string &file_name)

--- a/src/solvers/solver_hardness.cpp
+++ b/src/solvers/solver_hardness.cpp
@@ -89,24 +89,28 @@ void solver_hardnesst::register_assertion_ssas(
   current_hardness = {};
 }
 
-void solver_hardnesst::register_clause(const bvt &bv)
+void solver_hardnesst::register_clause(
+  const bvt &bv,
+  const size_t solver_clause_num)
 {
   current_hardness.clauses++;
   current_hardness.literals += bv.size();
-  std::vector<int> clause;
 
   for(const auto &literal : bv)
   {
     current_hardness.variables.insert(literal.var_no());
-
-    int signed_literal = literal.var_no();
-    if(literal.sign())
-      signed_literal = -signed_literal;
-    clause.push_back(signed_literal);
   }
-  clause.push_back(0);
-  std::sort(clause.begin(), clause.end());
-  current_hardness.clause_set.push_back(clause);
+
+#ifdef DEBUG
+  std::cout << solver_clause_num << ": ";
+  for(const auto &literal : bv)
+    std::cout << literal.dimacs() << " ";
+  std::cout << "0\n";
+#endif
+
+  current_hardness.clause_set.push_back(solver_clause_num + 1);
+  std::sort(
+    current_hardness.clause_set.begin(), current_hardness.clause_set.end());
 }
 
 void solver_hardnesst::set_outfile(const std::string &file_name)
@@ -166,10 +170,8 @@ void solver_hardnesst::produce_report()
       json_arrayt sat_hardness_clause_set_json;
       for(auto const &clause : hardness.clause_set)
       {
-        json_arrayt clause_json;
-        for(auto const &lit : clause)
-          clause_json.push_back(json_numbert{std::to_string(lit)});
-        sat_hardness_clause_set_json.push_back(clause_json);
+        sat_hardness_clause_set_json.push_back(
+          json_numbert{std::to_string(clause)});
       }
       sat_hardness_json["ClauseSet"] = sat_hardness_clause_set_json;
 
@@ -208,10 +210,8 @@ void solver_hardnesst::produce_report()
     json_arrayt assertion_sat_hardness_clause_set_json;
     for(auto const &clause : assertion_stats.sat_hardness.clause_set)
     {
-      json_arrayt clause_json;
-      for(auto const &lit : clause)
-        clause_json.push_back(json_numbert{std::to_string(lit)});
-      assertion_sat_hardness_clause_set_json.push_back(clause_json);
+      assertion_sat_hardness_clause_set_json.push_back(
+        json_numbert{std::to_string(clause)});
     }
     assertion_hardness_json["ClauseSet"] =
       assertion_sat_hardness_clause_set_json;

--- a/src/solvers/solver_hardness.h
+++ b/src/solvers/solver_hardness.h
@@ -108,7 +108,11 @@ struct solver_hardnesst
   /// \param bv: the clause (vector of literals)
   /// \param solver_clause_num: clause counter value passed from
   /// `satcheck_minisat2::lcnf`
-  void register_clause(const bvt &bv, const size_t solver_clause_num);
+  void register_clause(
+    const bvt &bv,
+    const bvt &cnf,
+    const size_t cnf_clause_index,
+    bool register_cnf);
 
   void set_outfile(const std::string &file_name);
 

--- a/src/solvers/solver_hardness.h
+++ b/src/solvers/solver_hardness.h
@@ -50,7 +50,7 @@ struct solver_hardnesst
     size_t clauses = 0;
     size_t literals = 0;
     std::unordered_set<size_t> variables = {};
-    std::vector<std::vector<int>> clause_set = {};
+    std::vector<int> clause_set = {};
 
     sat_hardnesst &operator+=(const sat_hardnesst &other);
   };
@@ -106,7 +106,9 @@ struct solver_hardnesst
   /// Called e.g. from the `satcheck_minisat2::lcnf`, this function adds the
   ///   complexity statistics from the last SAT query to the `current_ssa_key`.
   /// \param bv: the clause (vector of literals)
-  void register_clause(const bvt &bv);
+  /// \param solver_clause_num: clause counter value passed from
+  /// `satcheck_minisat2::lcnf`
+  void register_clause(const bvt &bv, const size_t solver_clause_num);
 
   void set_outfile(const std::string &file_name);
 

--- a/src/solvers/solver_hardness.h
+++ b/src/solvers/solver_hardness.h
@@ -50,7 +50,7 @@ struct solver_hardnesst
     size_t clauses = 0;
     size_t literals = 0;
     std::unordered_set<size_t> variables = {};
-    std::vector<int> clause_set = {};
+    std::vector<size_t> clause_set = {};
 
     sat_hardnesst &operator+=(const sat_hardnesst &other);
   };

--- a/src/solvers/solver_hardness.h
+++ b/src/solvers/solver_hardness.h
@@ -50,6 +50,7 @@ struct solver_hardnesst
     size_t clauses = 0;
     size_t literals = 0;
     std::unordered_set<size_t> variables = {};
+    std::vector<std::vector<int>> clause_set = {};
 
     sat_hardnesst &operator+=(const sat_hardnesst &other);
   };

--- a/src/solvers/solver_hardness.h
+++ b/src/solvers/solver_hardness.h
@@ -106,8 +106,10 @@ struct solver_hardnesst
   /// Called e.g. from the `satcheck_minisat2::lcnf`, this function adds the
   ///   complexity statistics from the last SAT query to the `current_ssa_key`.
   /// \param bv: the clause (vector of literals)
-  /// \param solver_clause_num: clause counter value passed from
-  /// `satcheck_minisat2::lcnf`
+  /// \param cnf: processed clause
+  /// \param cnf_clause_index: index of clause in dimacs output
+  /// \param register_cnf: negation of boolean variable tracking if the clause
+  /// can be eliminated
   void register_clause(
     const bvt &bv,
     const bvt &cnf,


### PR DESCRIPTION
<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->
Currently solver hardness tracks number of clauses. This is an extension of solver hardness to track the clauses themselves. Provides a mapping between clauses and instructions.

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [x] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
