### PR TITLE
Adds --use-rra for abstracting goto programs using Replication Reducing Abstraction

### DIFF
--- a/regression/rr-abstraction/Makefile
+++ b/regression/rr-abstraction/Makefile
@@ -1,0 +1,38 @@
+default: tests.log
+
+include ../../src/config.inc
+include ../../src/common
+
+bindir="$(pwd)../../../build/bin"
+GOTO_CC="$(bindir)/goto-cc"
+GOTO_INSTRUMENT="$(bindir)/goto-instrument"
+CBMC="$(bindir)/cbmc"
+
+ifeq ($(BUILD_ENV_),MSVC)
+	exe=$(bindir)/goto-cl
+else
+	exe=$(bindir)/goto-cc
+endif
+
+test:
+	@../test.pl -e -p -c '../rr.sh $(exe) $(GOTO_INSTRUMENT) $(CBMC)'
+
+tests.log:
+	@../test.pl -e -p -c '../rr.sh $(exe) $(GOTO_INSTRUMENT) $(CBMC)'
+
+show:
+	@for dir in *; do \
+		if [ -d "$$dir" ]; then \
+			vim -o "$$dir/*.c" "$$dir/*.out"; \
+		fi; \
+	done;
+
+clean:
+	@for dir in *; do \
+		$(RM) tests.log; \
+		if [ -d "$$dir" ]; then \
+			cd "$$dir"; \
+			$(RM) *.out *.gb; \
+			cd ..; \
+		fi \
+	done

--- a/regression/rr-abstraction/abst-funcs.c
+++ b/regression/rr-abstraction/abst-funcs.c
@@ -1,0 +1,714 @@
+#include <assert.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+// Some helper functions.
+
+// nndt_bool, nndt_int, nndt_sizet are available in CBMC.
+
+size_t nndt_size_t()
+{
+  size_t i;
+  return (i);
+}
+
+bool nndt_bool()
+{
+  bool b;
+  return (b);
+}
+
+size_t nndt_under(size_t bound)
+{
+  size_t nd;
+  __CPROVER_assume(nd < bound);
+  return (nd);
+}
+
+size_t nndt_between(size_t l, size_t u)
+{
+  size_t diff = u - l;
+  size_t nd = nndt_under(diff);
+  if(nd == 0)
+    return (l + 1);
+  else
+    return (nd + l);
+}
+
+size_t nndt_above(size_t bound)
+{
+  size_t nd = nndt_size_t();
+  __CPROVER_assume(nd < bound);
+  return (nd);
+}
+
+// For one index: *c*
+// covers c*, +c*
+size_t one_abs(size_t index, size_t a1)
+{
+  if(index < a1)
+    return (0);
+  else if(index == a1)
+    return (1);
+  else
+    return (2);
+}
+
+bool is_precise_1(size_t abs_ind, size_t a1)
+{
+  return (abs_ind == 1);
+}
+
+bool is_abstract_1(size_t abs_ind, size_t a1)
+{
+  return (abs_ind != 1);
+}
+
+size_t concretize_1(size_t abs_ind, size_t a1)
+{
+  assert(abs_ind >= 0);
+  assert(a1 >= 0);
+  if(abs_ind < 1)
+  {
+    if(a1 == 0)
+    {
+      assert(0);
+      return (0);
+    }
+    else
+      return (nndt_under(a1));
+  }
+  else if(abs_ind == 1)
+    return (a1);
+  else
+    return (nndt_above(a1));
+}
+
+// Add a number to an abs_ind
+size_t add_abs_to_conc_1(size_t abs_ind, size_t num, size_t a1)
+{
+  if(num == 1)
+  {
+    if(abs_ind == 0)
+    {
+      if(nndt_bool() > 0)
+        return (abs_ind);
+      else
+        return (abs_ind + 1);
+    }
+    //abs_ind = 1 or 2
+    else
+      return (2);
+  }
+  else
+  {
+    assert(num >= 2);
+    // This might be inefficient model checking wise.
+    // We can always write an explicit abstraction like we did for num = 1.
+    size_t conc = concretize_1(abs_ind, a1);
+    return (one_abs(conc + num, a1));
+  }
+}
+
+size_t sub_conc_from_abs_1(size_t abs_ind, size_t num, size_t a1)
+{
+  if(num == 1)
+  {
+    if(abs_ind == 2)
+    {
+      if(nndt_bool() > 0)
+        return (abs_ind);
+      else
+        return (abs_ind - 1);
+    }
+    // abs_ind = 1 0r 0
+    else
+      return (0);
+  }
+  else
+  {
+    assert(num >= 2);
+    // This might be inefficient model checking wise.
+    // We can always write an explicit abstraction like we did for num = 1.
+    size_t conc = concretize_1(abs_ind, a1);
+    assert(conc >= num);
+    return (one_abs(conc - num, a1));
+  }
+}
+
+// For two indices
+
+// Get the abstraction of an index for shape *c*c*.
+// Cases +c+c*, c+c*, +cc*, c+c*, cc+ can all be
+// handled by the same function as long as we are careful with concretization, increment and other funcs.
+// If model checking time is affected then we can split into finer cases.
+size_t two_abs(size_t index, size_t a1, size_t a2)
+{
+  if(a1 == 0 && a1 + 1 == a2)
+  { // cc*
+    if(index == a1)
+      return 0;
+    else if(index == a2)
+      return 1;
+    else
+      return 2;
+  }
+  else if(!(a1 == 0) && a1 + 1 == a2)
+  { // *cc*
+    if(index < a1)
+      return 0;
+    else if(index == a1)
+      return 1;
+    else if(index == a2)
+      return 2;
+    else
+      return 3;
+  }
+  else if(a1 == 0 && !(a1 + 1 == a2))
+  { // c*c*
+    if(index == a1)
+      return 0;
+    else if(index > a1 && index < a2)
+      return 1;
+    else if(index == a2)
+      return 2;
+    else
+      return 3;
+  }
+  else
+  { // *c*c*, !a1==0 && !a1+1==a2
+    if(index < a1)
+      return 0;
+    else if(index == a1)
+      return 1;
+    else if(index > a1 && index < a2)
+      return 2;
+    else if(index == a2)
+      return 3;
+    else
+      return 4;
+  }
+}
+
+// Get the concretization of an index. We assume all args are >= 0
+// Shape *c*c*
+size_t concretize_2(size_t abs_ind, size_t a1, size_t a2)
+{
+  assert(abs_ind >= 0);
+  assert(a1 >= 0);
+  assert(a2 > a1);
+
+  if(a1 == 0 && a1 + 1 == a2)
+  { // cc*
+    if(abs_ind == 0)
+      return a1;
+    else if(abs_ind == 1)
+      return a2;
+    else if(abs_ind == 2)
+      return nndt_above(a2);
+    else
+    {
+      assert(0 != 0);
+      return 0;
+    }
+  }
+  else if(!(a1 == 0) && a1 + 1 == a2)
+  { // *cc*
+    if(abs_ind == 0)
+      return nndt_under(a1);
+    else if(abs_ind == 1)
+      return a1;
+    else if(abs_ind == 2)
+      return a2;
+    else if(abs_ind == 3)
+      return nndt_above(a2);
+    else
+    {
+      assert(0 != 0);
+      return 0;
+    }
+  }
+  else if(a1 == 0 && !(a1 + 1 == a2))
+  { // c*c*
+    if(abs_ind == 0)
+      return a1;
+    else if(abs_ind == 1)
+      return nndt_between(a1, a2);
+    else if(abs_ind == 2)
+      return a2;
+    else if(abs_ind == 3)
+      return nndt_above(a2);
+    else
+    {
+      assert(0 != 0);
+      return 0;
+    }
+  }
+  else
+  { // *c*c*, !a1==0 && !a1+1==a2
+    if(abs_ind == 0)
+      return nndt_under(a1);
+    else if(abs_ind == 1)
+      return a1;
+    else if(abs_ind == 2)
+      return nndt_between(a1, a2);
+    else if(abs_ind == 3)
+      return a2;
+    else if(abs_ind == 4)
+      return nndt_above(a2);
+    else
+    {
+      assert(0 != 0);
+      return 0;
+    }
+  }
+}
+
+int is_precise_2(size_t abs_ind, size_t a1, size_t a2)
+{
+  if(a1 == 0 && a1 + 1 == a2)
+  { // cc*
+    return abs_ind == 0 || abs_ind == 1;
+  }
+  else if(!(a1 == 0) && a1 + 1 == a2)
+  { // *cc*
+    return abs_ind == 1 || abs_ind == 2;
+  }
+  else if(a1 == 0 && !(a1 + 1 == a2))
+  { // c*c*
+    return abs_ind == 0 || abs_ind == 2;
+  }
+  else
+  { // *c*c*, !a1==0 && !a1+1==a2
+    return abs_ind == 1 || abs_ind == 3;
+  }
+}
+
+int is_abstract_2(size_t abs_ind, size_t a1, size_t a2)
+{
+  int pre = is_precise_2(abs_ind, a1, a2);
+  return (1 - pre);
+}
+
+// Add a number to an abs_ind
+size_t add_abs_to_conc_2(size_t abs_ind, size_t num, size_t a1, size_t a2)
+{
+  // if (num == 0){
+  //     return abs_ind;
+  // }
+  // else if (num == 1){
+  //     if(abs_ind == 0 || abs_ind == 2) {
+  //         if (nndt_bool() > 0) return(abs_ind);
+  //         else return(abs_ind + 1);
+  //     }
+  //     else if (abs_ind == 1) {
+  //         // case *cc*
+  //         if (a2 == a1+1) return(3);
+  //         else return(2);
+  //     }
+  //     //abs_ind = 3 or 4
+  //     else return(4);
+  // }
+  // else {
+  //     assert(num >= 2);
+  //     //This might be inefficient model checking wise.
+  //     //We can always write an explicit abstraction like we did for num = 1.
+  //     int conc = concretize_2(abs_ind, a1, a2);
+  //     return(two_abs(conc+num, a1, a2));
+  // }
+  size_t conc = concretize_2(abs_ind, a1, a2);
+  return two_abs(conc + num, a1, a2);
+}
+
+size_t sub_conc_from_abs_2(size_t abs_ind, size_t num, size_t a1, size_t a2)
+{
+  // if (num == 1){
+  //     if(abs_ind == 4 || abs_ind == 2) {
+  //         if (nndt_bool() > 0) return(abs_ind);
+  //         else return(abs_ind - 1);
+  //     }
+  //     else if (abs_ind == 3) {
+  //         if (a1 == a2) return(1);
+  //         else return(2);
+  //     }
+  //     //abs_ind = 1 0r 0
+  //     else return(0);
+  // }
+  // else {
+  //     assert(num >= 2);
+  //     //This might be extremely inefficient model checking wise.
+  //     //We can always write an explicit abstraction like we did for num = 1.
+  //     int conc = concretize_2(abs_ind, a1, a2);
+  //     return(two_abs(conc-num, a1, a2));
+  // }
+  size_t conc = concretize_2(abs_ind, a1, a2);
+  assert(conc >= num);
+  return two_abs(conc - num, a1, a2);
+}
+
+// helper function
+// translate an index from *c*c*c* to the real one depending on value of a1, a2, a3
+// e.g. when a1=0, a1+1==a2, *c*c*c* becomes cc*c*
+// index 4 in *c*c*c* will be translated into 2 by this function
+size_t raw_to_real_3(size_t raw_index, size_t a1, size_t a2, size_t a3)
+{
+  return raw_index - (raw_index >= 1 && a1 == 0) -
+         (raw_index >= 3 && a1 + 1 == a2) - (raw_index >= 5 && a2 + 1 == a3);
+}
+
+// helper function, the reversed version of raw_to_real
+// *c*c*c*
+// c1: 1-(a1==0)
+// c2: 3-(a1==0)-(a1+1==a2)
+// c3: 5-(a1==0)-(a1+1==a2)-(a2+1==a3)
+size_t real_to_raw_3(size_t real_index, size_t a1, size_t a2, size_t a3)
+{
+  if(real_index < 1 - (a1 == 0))
+    return 0;
+  else if(real_index == 1 - (a1 == 0))
+    return 1;
+  else if(real_index < 3 - (a1 == 0) - (a1 + 1 == a2))
+    return 2;
+  else if(real_index == 3 - (a1 == 0) - (a1 + 1 == a2))
+    return 3;
+  else if(real_index < 5 - (a1 == 0) - (a1 + 1 == a2) - (a2 + 1 == a3))
+    return 4;
+  else if(real_index == 5 - (a1 == 0) - (a1 + 1 == a2) - (a2 + 1 == a3))
+    return 5;
+  else
+    return 6;
+}
+
+// Three indices: *c*c*c*
+// *1: exist if a1>0
+// *2: exist if a1+1!=a2
+// *3: exist if a2+1!=a3
+size_t three_abs(size_t index, size_t a1, size_t a2, size_t a3)
+{
+  size_t raw_index = 0;
+  if(index < a1)
+    raw_index = 0;
+  else if(index == a1)
+    raw_index = 1;
+  else if(index > a1 && index < a2)
+    raw_index = 2;
+  else if(index == a2)
+    raw_index = 3;
+  else if(index > a2 && index < a3)
+    raw_index = 4;
+  else if(index == a3)
+    raw_index = 5;
+  else
+    raw_index = 6;
+  return raw_to_real_3(raw_index, a1, a2, a3);
+}
+
+// Three indices: *c*c*c*
+// Return the concrete index corresponding to abs_ind
+size_t concretize_3(size_t abs_ind, size_t a1, size_t a2, size_t a3)
+{
+  size_t raw_index = real_to_raw_3(abs_ind, a1, a2, a3);
+  if(raw_index == 0)
+    return nndt_under(a1);
+  else if(raw_index == 1)
+    return a1;
+  else if(raw_index == 2)
+    return nndt_between(a1, a2);
+  else if(raw_index == 3)
+    return a2;
+  else if(raw_index == 4)
+    return nndt_between(a2, a3);
+  else if(raw_index == 5)
+    return a3;
+  else
+    return nndt_above(a3);
+}
+
+int is_precise_3(size_t abs_ind, size_t a1, size_t a2, size_t a3)
+{
+  size_t raw_ind = real_to_raw_3(abs_ind, a1, a2, a3);
+  return (raw_ind == 1) || (raw_ind == 3) || (raw_ind == 5);
+}
+
+// Add a number to an abs_ind
+size_t
+add_abs_to_conc_3(size_t abs_ind, size_t num, size_t a1, size_t a2, size_t a3)
+{
+  if(num == 0)
+  {
+    return abs_ind;
+  }
+  else if(num == 1)
+  {
+    if(is_precise_3(abs_ind, a1, a2, a3))
+    {
+      return abs_ind + 1;
+    }
+    else
+    {
+      return (abs_ind > 5 - (a1 == 0) - (a1 + 1 == a2) - (a2 + 1 == a3) ||
+              nndt_bool())
+               ? abs_ind
+               : abs_ind + 1;
+    }
+  }
+  else
+  {
+    size_t conc = concretize_3(abs_ind, a1, a2, a3);
+    return three_abs(conc + num, a1, a2, a3);
+  }
+}
+
+size_t
+sub_conc_from_abs_3(size_t abs_ind, size_t num, size_t a1, size_t a2, size_t a3)
+{
+  if(num == 0)
+  {
+    return abs_ind;
+  }
+  else if(num == 1)
+  {
+    if(is_precise_3(abs_ind, a1, a2, a3))
+    {
+      if(abs_ind != 0)
+        return abs_ind - 1;
+      else
+        assert(0 != 0); // this is to cover the overflow case 0-1
+    }
+    else
+    {
+      return (abs_ind == 0 || nndt_bool()) ? abs_ind : abs_ind - 1;
+    }
+  }
+  else
+  {
+    size_t conc = concretize_3(abs_ind, a1, a2, a3);
+    assert(conc >= num);
+    return three_abs(conc - num, a1, a2, a3);
+  }
+}
+
+size_t multiply_abs_with_conc_3(
+  size_t abs_ind,
+  size_t num,
+  size_t a1,
+  size_t a2,
+  size_t a3)
+{
+  if(num == 0)
+  {
+    return 0;
+  }
+  else if(num == 1)
+  {
+    return abs_ind;
+  }
+  else
+  {
+    size_t conc = concretize_3(abs_ind, a1, a2, a3);
+    return three_abs(abs_ind * num, a1, a2, a3);
+  }
+}
+
+// helper function
+// translate an index from *c*c*c*c* to the real one depending on value of a1, a2, a3, a4
+// e.g. when a1=0, a1+1==a2, *c*c*c*c* becomes cc*c*c*
+// index 4 in *c*c*c*c* will be translated into 2 by this function
+size_t
+raw_to_real_4(size_t raw_index, size_t a1, size_t a2, size_t a3, size_t a4)
+{
+  return raw_index - (raw_index >= 1 && a1 == 0) -
+         (raw_index >= 3 && a1 + 1 == a2) - (raw_index >= 5 && a2 + 1 == a3) -
+         (raw_index >= 7 && a3 + 1 == a4);
+}
+
+// helper function, the reversed version of raw_to_real
+// *c*c*c*c*
+// c1: 1-(a1==0)
+// c2: 3-(a1==0)-(a1+1==a2)
+// c3: 5-(a1==0)-(a1+1==a2)-(a2+1==a3)
+// c4: 7-(a1==0)-(a1+1==a2)-(a2+1==a3)-(a3+1==a4)
+size_t
+real_to_raw_4(size_t real_index, size_t a1, size_t a2, size_t a3, size_t a4)
+{
+  if(real_index < 1 - (a1 == 0))
+    return 0;
+  else if(real_index == 1 - (a1 == 0))
+    return 1;
+  else if(real_index < 3 - (a1 == 0) - (a1 + 1 == a2))
+    return 2;
+  else if(real_index == 3 - (a1 == 0) - (a1 + 1 == a2))
+    return 3;
+  else if(real_index < 5 - (a1 == 0) - (a1 + 1 == a2) - (a2 + 1 == a3))
+    return 4;
+  else if(real_index == 5 - (a1 == 0) - (a1 + 1 == a2) - (a2 + 1 == a3))
+    return 5;
+  else if(
+    real_index <
+    7 - (a1 == 0) - (a1 + 1 == a2) - (a2 + 1 == a3) - (a3 + 1 == a4))
+    return 6;
+  else if(
+    real_index ==
+    7 - (a1 == 0) - (a1 + 1 == a2) - (a2 + 1 == a3) - (a3 + 1 == a4))
+    return 7;
+  else
+    return 8;
+}
+
+// Get the abstraction of an index for shape *c*c*c*c*.
+// If model checking time is affected then we can split into finer cases.
+size_t four_abs(size_t index, size_t a1, size_t a2, size_t a3, size_t a4)
+{
+  size_t raw_index = 0;
+  if(index < a1)
+    raw_index = 0;
+  else if(index == a1)
+    raw_index = 1;
+  else if(index > a1 && index < a2)
+    raw_index = 2;
+  else if(index == a2)
+    raw_index = 3;
+  else if(index > a2 && index < a3)
+    raw_index = 4;
+  else if(index == a3)
+    raw_index = 5;
+  else if(index > a3 && index < a4)
+    raw_index = 6;
+  else if(index == a4)
+    raw_index = 7;
+  else
+    raw_index = 8;
+  return raw_to_real_4(raw_index, a1, a2, a3, a4);
+}
+
+//Get the concretization of an index. We assume all args are >= 0
+//Shape *c*c*c*c*
+size_t concretize_4(size_t abs_ind, size_t a1, size_t a2, size_t a3, size_t a4)
+{
+  assert(a1 < a2);
+  assert(a2 < a3);
+  assert(a3 < a4);
+  size_t raw_index = real_to_raw_4(abs_ind, a1, a2, a3, a4);
+  if(raw_index == 0)
+    return nndt_under(a1);
+  else if(raw_index == 1)
+    return a1;
+  else if(raw_index == 2)
+    return nndt_between(a1, a2);
+  else if(raw_index == 3)
+    return a2;
+  else if(raw_index == 4)
+    return nndt_between(a2, a3);
+  else if(raw_index == 5)
+    return a3;
+  else if(raw_index == 6)
+    return nndt_between(a3, a4);
+  else if(raw_index == 7)
+    return a4;
+  else
+    return nndt_above(a4);
+}
+
+int is_precise_4(size_t abs_ind, size_t a1, size_t a2, size_t a3, size_t a4)
+{
+  size_t raw_ind = real_to_raw_4(abs_ind, a1, a2, a3, a4);
+  return (raw_ind == 1 || raw_ind == 3 || raw_ind == 5 || raw_ind == 7);
+}
+
+int is_abstract_4(size_t abs_ind, size_t a1, size_t a2, size_t a3, size_t a4)
+{
+  return !is_precise_4(abs_ind, a1, a2, a3, a4);
+}
+
+// Add a number to an abs_ind
+size_t add_abs_to_conc_4(
+  size_t abs_ind,
+  size_t num,
+  size_t a1,
+  size_t a2,
+  size_t a3,
+  size_t a4)
+{
+  if(num == 0)
+  {
+    return abs_ind;
+  }
+  else if(num == 1)
+  {
+    if(is_precise_4(abs_ind, a1, a2, a3, a4))
+    {
+      return abs_ind + 1;
+    }
+    else
+    {
+      return (abs_ind > 7 - (a1 == 0) - (a1 + 1 == a2) - (a2 + 1 == a3) -
+                          (a3 + 1 == a4) ||
+              nndt_bool())
+               ? abs_ind
+               : abs_ind + 1;
+    }
+  }
+  else
+  {
+    size_t conc = concretize_4(abs_ind, a1, a2, a3, a4);
+    return four_abs(conc + num, a1, a2, a3, a4);
+  }
+}
+// Substract a number from abs_ind
+size_t sub_conc_from_abs_4(
+  size_t abs_ind,
+  size_t num,
+  size_t a1,
+  size_t a2,
+  size_t a3,
+  size_t a4)
+{
+  if(num == 0)
+  {
+    return abs_ind;
+  }
+  else if(num == 1)
+  {
+    if(is_precise_4(abs_ind, a1, a2, a3, a4))
+    {
+      if(abs_ind != 0)
+        return abs_ind - 1;
+      else
+        assert(0 != 0); // this is to cover the overflow case 0-1
+    }
+    else
+    {
+      return (abs_ind == 0 || nndt_bool()) ? abs_ind : abs_ind - 1;
+    }
+  }
+  else
+  {
+    size_t conc = concretize_4(abs_ind, a1, a2, a3, a4);
+    assert(conc >= num);
+    return four_abs(conc - num, a1, a2, a3, a4);
+  }
+}
+
+size_t multiply_abs_with_conc_4(
+  size_t abs_ind,
+  size_t num,
+  size_t a1,
+  size_t a2,
+  size_t a3,
+  size_t a4)
+{
+  if(num == 0)
+  {
+    return 0;
+  }
+  else if(num == 1)
+  {
+    return abs_ind;
+  }
+  else
+  {
+    size_t conc = concretize_4(abs_ind, a1, a2, a3, a4);
+    return four_abs(abs_ind * num, a1, a2, a3, a4);
+  }
+}

--- a/regression/rr-abstraction/rr.sh
+++ b/regression/rr-abstraction/rr.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# whether verify the program or not
+CHECK=false
+
+# executables
+GOTO_CC=$1
+GOTO_INSTRUMENT=$2
+CBMC=$3
+
+
+CBMC_FLAGS="--unwind 4 
+            --trace
+            --pointer-check"
+            # --nondet-static 
+            # --div-by-zero-check 
+            # --float-overflow-check 
+            # --nan-check 
+            # --pointer-overflow-check 
+            # --undefined-shift-check 
+            # --signed-overflow-check 
+            # --unsigned-overflow-check 
+
+# compile program into goto-programs
+$GOTO_CC -o main.goto main.c
+echo "Goto programs built"
+
+#touch main_abst.goto
+$GOTO_INSTRUMENT --use-rra spec.json main.goto main-abst.goto
+echo "Goto-abst program built"
+# check the program
+if [ $CHECK = true ]; then
+    $CBMC $CBMC_FLAGS main-abst.goto
+fi

--- a/regression/rr-abstraction/rr_abstraction.sh
+++ b/regression/rr-abstraction/rr_abstraction.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+# whether verify the program or not
+CHECK=true
+
+# executables
+bindir="$(pwd)/../../build/bin"
+GOTO_CC="$bindir/goto-cc"
+GOTO_INSTRUMENT="$bindir/goto-instrument"
+CBMC="$bindir/cbmc"
+
+CBMC_FLAGS="--unwind 4 
+            --trace
+            --pointer-check"
+            # --nondet-static 
+            # --div-by-zero-check 
+            # --float-overflow-check 
+            # --nan-check 
+            # --pointer-overflow-check 
+            # --undefined-shift-check 
+            # --signed-overflow-check 
+            # --unsigned-overflow-check 
+
+ABSTRACTION_TESTS=(
+    "test1" 
+    "test2" 
+    "test3" 
+    "test4" 
+    "test5" 
+    "test6"
+    "test7"
+    "test8"
+    "test9"
+    "test10"
+    "test11"
+)
+
+cwd=$(pwd)
+for test in ${ABSTRACTION_TESTS[@]}; do
+    echo "===== $test ====="
+    cd $test/
+    # compile program into goto-programs
+    $GOTO_CC -o main.goto main.c
+    echo "Goto programs built"
+    cd $cwd
+
+    for spec in "$test"/*.json; do
+        # run goto-instrument to make abstracted goto-programs
+        $GOTO_INSTRUMENT --use-rra $spec \
+            $test/main.goto \
+            $test/main_abst.goto
+        # check the program
+        if [ $CHECK = true ]; then
+            $CBMC $CBMC_FLAGS $test/main_abst.goto
+        fi
+    done
+
+done

--- a/regression/rr-abstraction/test1/main.c
+++ b/regression/rr-abstraction/test1/main.c
@@ -1,0 +1,31 @@
+#include <assert.h>
+#include <stdbool.h>
+#include <stdlib.h>
+
+#define MAX_LEN 100
+
+bool main()
+{
+  char *a1;
+  char *a2;
+  size_t a1_len;
+  size_t a2_len;
+  size_t i = 0;
+  bool res = true;
+
+  __CPROVER_assume(a1_len < MAX_LEN);
+  __CPROVER_assume(a2_len < MAX_LEN);
+  a1 = malloc(a1_len);
+  a2 = malloc(a2_len);
+
+  // This should lead to an out of bounds error.
+  // Also, tests that our abstraction works for while loops.
+  while(i < a1_len)
+  {
+    if(a1[i] != a2[i])
+      res &= false;
+    i++;
+  }
+
+  return res;
+}

--- a/regression/rr-abstraction/test1/spec.json
+++ b/regression/rr-abstraction/test1/spec.json
@@ -1,0 +1,43 @@
+{
+    "entries": [
+    {
+        "entity": "array",
+        "function": "main",
+        "name": "main::1::a1",
+        "shape": {
+            "indices": ["c0", "c1", "l"],
+            "assumptions": ["c0 == 0", "c0 < c1", "c1 < l"],
+            "shape-type": "c*c*l"
+        },
+        "abst-function-file": "../abst-funcs.c",
+        "abst-functions":{
+            "add-abs-conc": "add_abs_to_conc_3",
+            "sub-abs-conc": "sub_conc_from_abs_3",
+            "multiply-abs-conc": "multiply_abs_with_conc_3",
+            "precise-check": "is_precise_3",
+            "abstract-index": "three_abs",
+            "concretize-index": "concretize_3",
+            "multiply-indices": null,
+            "mod-indices": null
+        },
+        "related-entities": [
+            {
+                "entity": "array",
+                "function": "main",
+                "name": "main::1::a2"
+            },
+            {
+                "entity": "length",
+                "function": "main",
+                "name": "main::1::a1_len"
+            },
+            {
+                "entity": "length",
+                "function": "main",
+                "name": "main::1::a2_len"
+            }
+        ]
+
+    }
+]
+}

--- a/regression/rr-abstraction/test1/spec1.json
+++ b/regression/rr-abstraction/test1/spec1.json
@@ -1,0 +1,28 @@
+{
+    "entries": [
+    {
+        "entity": "array",
+        "function": "main",
+        "name": "main::1::a1",
+        "shape": {
+            "indices": ["c0", "c1", "l"],
+            "assumptions": ["c0 == 0", "c0 < c1", "c1 < l"],
+            "shape-type": "c*c*l"
+        },
+        "abst-function-file": "./abst-funcs.c",
+        "abst-functions":{
+            "add-abs-conc": "add_abs_to_conc_3",
+            "sub-abs-conc": "sub_conc_from_abs_3",
+            "multiply-abs-conc": "multiply_abs_with_conc_3",
+            "precise-check": "is_precise_3",
+            "abstract-index": "three_abs",
+            "concretize-index": "concretize_3",
+            "multiply-indices": null,
+            "mod-indices": null
+        },
+        "related-entities": [
+        ]
+
+    }
+]
+}

--- a/regression/rr-abstraction/test1/spec2.json
+++ b/regression/rr-abstraction/test1/spec2.json
@@ -1,0 +1,33 @@
+{
+    "entries": [
+    {
+        "entity": "array",
+        "function": "main",
+        "name": "main::1::a1",
+        "shape": {
+            "indices": ["c0", "c1", "l"],
+            "assumptions": ["c0 == 0", "c0 < c1", "c1 < l"],
+            "shape-type": "c*c*l"
+        },
+        "abst-function-file": "./abst-funcs.c",
+        "abst-functions":{
+            "add-abs-conc": "add_abs_to_conc_3",
+            "sub-abs-conc": "sub_conc_from_abs_3",
+            "multiply-abs-conc": "multiply_abs_with_conc_3",
+            "precise-check": "is_precise_3",
+            "abstract-index": "three_abs",
+            "concretize-index": "concretize_3",
+            "multiply-indices": null,
+            "mod-indices": null
+        },
+        "related-entities": [
+            {
+                "entity": "length",
+                "function": "main",
+                "name": "main::1::a2_len"
+            }
+        ]
+
+    }
+]
+}

--- a/regression/rr-abstraction/test1/test.desc
+++ b/regression/rr-abstraction/test1/test.desc
@@ -1,0 +1,9 @@
+CORE
+main.c
+1
+^EXIT=0$
+^SIGNAL=0$
+^Writing GOTO
+--
+--
+Just adds functions from abst-funcs to module under test.

--- a/regression/rr-abstraction/test10/main.c
+++ b/regression/rr-abstraction/test10/main.c
@@ -1,0 +1,50 @@
+#include <assert.h>
+#include <stdbool.h>
+#include <stdlib.h>
+
+#define MAX_LEN 100
+
+bool search(char *a, size_t a_len, char key)
+{
+  bool res = false;
+  for(size_t i = 0; i < a_len; i++)
+  {
+    if(a[i] == key)
+      res = true;
+  }
+  return res;
+}
+
+bool copy_and_search(char *a1, char *a2, char key)
+{
+  a1 = a2;
+  // a1 will be of length 3 but it won't have abstraction spec.
+  // So searching at index 3,4 will lead to out of bounds.
+  // If a2's spec is transferred to a1 then there will be no out of bounds error.
+  return (search(a1, 5, key));
+}
+
+bool main()
+{
+  const char *a1;
+  const char *a2;
+  const char *a3;
+  size_t a1_len;
+  size_t a2_len;
+  // Some char
+  char key = 'a';
+  // CBMC will choose i non-deterministically
+  size_t i;
+
+  __CPROVER_assume(a1_len < MAX_LEN);
+  __CPROVER_assume(a2_len <= a1_len);
+  __CPROVER_assume(a2_len > 5);
+  __CPROVER_assume(i < a2_len);
+
+  a2 = malloc(a2_len);
+
+  // assignment of the full array.
+  // a2's spec has to be copied over for a1 as well.
+  bool res = copy_and_search(a1, a2, key);
+  return res;
+}

--- a/regression/rr-abstraction/test10/spec.json
+++ b/regression/rr-abstraction/test10/spec.json
@@ -1,0 +1,33 @@
+{
+    "entries": [
+    {
+        "entity": "array",
+        "function": "main",
+        "name": "main::1::a1",
+        "shape": {
+            "indices": ["c0", "c1", "l"],
+            "assumptions": ["c0 == 0", "c0 < c1", "c1 < l"],
+            "shape-type": "c*c*l"
+        },
+        "abst-function-file": "../abst-funcs.c",
+        "abst-functions":{
+            "add-abs-conc": "add_abs_to_conc_3",
+            "sub-abs-conc": "sub_conc_from_abs_3",
+            "multiply-abs-conc": "multiply_abs_with_conc_3",
+            "precise-check": "is_precise_3",
+            "abstract-index": "three_abs",
+            "concretize-index": "concretize_3",
+            "multiply-indices": null,
+            "mod-indices": null
+        },
+        "related-entities": [
+            {
+                "entity": "length",
+                "function": "main",
+                "name": "main::1::a1_len"
+            }
+        ]
+
+    }
+]
+}

--- a/regression/rr-abstraction/test10/test.desc
+++ b/regression/rr-abstraction/test10/test.desc
@@ -1,0 +1,9 @@
+CORE
+main.c
+1
+^EXIT=0$
+^SIGNAL=0$
+^Writing GOTO
+--
+--
+Just adds functions from abst-funcs to module under test.

--- a/regression/rr-abstraction/test11/main.c
+++ b/regression/rr-abstraction/test11/main.c
@@ -1,0 +1,72 @@
+#include <assert.h>
+#include <stdbool.h>
+#include <stdlib.h>
+
+#define MAX_LEN 100
+
+// Compares if two arrays are the same (sort of)
+bool foo(char *a1, size_t a1_len, char *a2, size_t a2_len)
+{
+  bool res = true;
+  if(a1_len == a2_len)
+  {
+    for(size_t i = 0; i < a1_len; i++)
+    {
+      if(a2[i] != a1[i])
+        res &= false;
+    }
+    return res;
+  }
+  else
+  {
+    return false;
+  }
+}
+
+bool search(char *a, size_t a_len, char key)
+{
+  bool res = false;
+  for(size_t i = 0; i < a_len; i++)
+  {
+    if(a[i] == key)
+      res = true;
+  }
+  return res;
+}
+
+void copy(char **a1, char **a2)
+{
+  *a1 = *a2;
+  return;
+}
+
+bool main()
+{
+  char *a1;
+  char *a2;
+  size_t a1_len;
+  size_t a2_len;
+  // Some char
+  char key = 'a';
+  // CBMC will choose i non-deterministically
+  size_t i;
+
+  __CPROVER_assume(a1_len < MAX_LEN);
+  __CPROVER_assume(a2_len <= a1_len);
+  __CPROVER_assume(i < a2_len);
+
+  a2 = malloc(a2_len);
+  // a2_len is identified as abstract in the spec but a1_len is not.
+  // So in the abstracted program a1_len will get the original a2_len, not abst(a2_len)
+  a1_len = a2_len;
+
+  // assignment of the full array.
+  // a2's spec has to be copied over for a1 as well.
+  copy(&a1, &a2);
+
+  // If a2's spec is not transferred to a1, then the search should result in out of bounds access.
+  // If a2's spec is transferred then inside search a1_len
+  // will get abstracted and there will be no out of bounds.
+  bool res = search(a1, a1_len, key);
+  return res;
+}

--- a/regression/rr-abstraction/test11/spec.json
+++ b/regression/rr-abstraction/test11/spec.json
@@ -1,0 +1,33 @@
+{
+    "entries": [
+    {
+        "entity": "array",
+        "function": "main",
+        "name": "main::1::a1",
+        "shape": {
+            "indices": ["c0", "c1", "l"],
+            "assumptions": ["c0 == 0", "c0 < c1", "c1 < l"],
+            "shape-type": "c*c*l"
+        },
+        "abst-function-file": "../abst-funcs.c",
+        "abst-functions":{
+            "add-abs-conc": "add_abs_to_conc_3",
+            "sub-abs-conc": "sub_conc_from_abs_3",
+            "multiply-abs-conc": "multiply_abs_with_conc_3",
+            "precise-check": "is_precise_3",
+            "abstract-index": "three_abs",
+            "concretize-index": "concretize_3",
+            "multiply-indices": null,
+            "mod-indices": null
+        },
+        "related-entities": [
+            {
+                "entity": "length",
+                "function": "main",
+                "name": "main::1::a1_len"
+            }
+        ]
+
+    }
+]
+}

--- a/regression/rr-abstraction/test11/test.desc
+++ b/regression/rr-abstraction/test11/test.desc
@@ -1,0 +1,9 @@
+CORE
+main.c
+1
+^EXIT=0$
+^SIGNAL=0$
+^Writing GOTO
+--
+--
+Just adds functions from abst-funcs to module under test.

--- a/regression/rr-abstraction/test2/main.c
+++ b/regression/rr-abstraction/test2/main.c
@@ -1,0 +1,55 @@
+#include <assert.h>
+#include <stdbool.h>
+#include <stdlib.h>
+
+#define MAX_LEN 100
+
+bool foo(char *a1, size_t a1_len, char *a2, size_t a2_len)
+{
+  bool res = true;
+  if(a1_len == a2_len)
+  {
+    for(size_t i; i < a1_len; i++)
+    {
+      if(a2[i] != a1[i] + 1)
+        res &= false;
+    }
+    return res;
+  }
+  else
+  {
+    return false;
+  }
+}
+
+int bar(char *a1, size_t a1_len, char *a2, size_t a2_len)
+{
+  size_t i;
+  assert(a1_len == a2_len);
+  __CPROVER_assume(i < a1_len);
+  if(a2[i] == a1[i] + 1)
+    return 1;
+  else
+    return 0;
+}
+
+void main()
+{
+  char *a1;
+  char *a2;
+  size_t a1_len;
+  size_t a2_len;
+
+  __CPROVER_assume(a1_len < MAX_LEN);
+  __CPROVER_assume(a2_len < MAX_LEN);
+  a1 = malloc(a1_len);
+  a2 = malloc(a2_len);
+
+  if(foo(a1, a1_len, a2, a2_len))
+  {
+    assert(bar(a1, a1_len, a2, a2_len) > 0);
+  }
+  else
+    assert(true);
+  return;
+}

--- a/regression/rr-abstraction/test2/spec.json
+++ b/regression/rr-abstraction/test2/spec.json
@@ -1,0 +1,43 @@
+{
+    "entries": [
+    {
+        "entity": "array",
+        "function": "main",
+        "name": "main::1::a1",
+        "shape": {
+            "indices": ["c0", "c1", "l"],
+            "assumptions": ["c0 == 0", "c0 < c1", "c1 < l"],
+            "shape-type": "c*c*l"
+        },
+        "abst-function-file": "../abst-funcs.c",
+        "abst-functions":{
+            "add-abs-conc": "add_abs_to_conc_3",
+            "sub-abs-conc": "sub_conc_from_abs_3",
+            "multiply-abs-conc": "multiply_abs_with_conc_3",
+            "precise-check": "is_precise_3",
+            "abstract-index": "three_abs",
+            "concretize-index": "concretize_3",
+            "multiply-indices": null,
+            "mod-indices": null
+        },
+        "related-entities": [
+            {
+                "entity": "array",
+                "function": "main",
+                "name": "main::1::a2"
+            },
+            {
+                "entity": "length",
+                "function": "main",
+                "name": "main::1::a1_len"
+            },
+            {
+                "entity": "length",
+                "function": "main",
+                "name": "main::1::a2_len"
+            }
+        ]
+
+    }
+]
+}

--- a/regression/rr-abstraction/test2/test.desc
+++ b/regression/rr-abstraction/test2/test.desc
@@ -1,0 +1,9 @@
+CORE
+main.c
+1
+^EXIT=0$
+^SIGNAL=0$
+^Writing GOTO
+--
+--
+Just adds functions from abst-funcs to module under test.

--- a/regression/rr-abstraction/test3/main.c
+++ b/regression/rr-abstraction/test3/main.c
@@ -1,0 +1,56 @@
+#include <assert.h>
+#include <stdbool.h>
+#include <stdlib.h>
+
+#define MAX_LEN 100
+
+bool foo(char *a1, size_t a1_len, char *a2, size_t a2_len)
+{
+  bool res = true;
+  if(a1_len == a2_len)
+  {
+    for(size_t i; i < a1_len; i++)
+    {
+      if(a2[i] != a1[i] + 1)
+        res &= false;
+    }
+    return res;
+  }
+  else
+  {
+    return false;
+  }
+}
+
+bool bar(char *a1, size_t a1_len, char *a2, size_t a2_len, size_t i)
+{
+  assert(a1_len == a2_len);
+  __CPROVER_assume(i < a1_len);
+  if(a2[i] == a1[i] + 1)
+    return true;
+  else
+    return false;
+}
+
+void main()
+{
+  const char *a1;
+  const char *a2;
+  size_t a1_len;
+  size_t a2_len;
+  size_t i;
+
+  __CPROVER_assume(a1_len < MAX_LEN);
+  __CPROVER_assume(a2_len < MAX_LEN);
+  __CPROVER_assume(i < a1_len);
+  a1 = malloc(a1_len);
+  a2 = malloc(a2_len);
+
+  if(foo(a1, a1_len, a2, a2_len))
+  {
+    assert(bar(a1, a1_len, a2, a2_len, i));
+  }
+  else
+    assert(true);
+  return;
+}

--- a/regression/rr-abstraction/test3/spec.json
+++ b/regression/rr-abstraction/test3/spec.json
@@ -1,0 +1,43 @@
+{
+    "entries": [
+    {
+        "entity": "array",
+        "function": "main",
+        "name": "main::1::a1",
+        "shape": {
+            "indices": ["c0", "c1", "l"],
+            "assumptions": ["c0 == 0", "c0 < c1", "c1 < l"],
+            "shape-type": "c*c*l"
+        },
+        "abst-function-file": "../abst-funcs.c",
+        "abst-functions":{
+            "add-abs-conc": "add_abs_to_conc_3",
+            "sub-abs-conc": "sub_conc_from_abs_3",
+            "multiply-abs-conc": "multiply_abs_with_conc_3",
+            "precise-check": "is_precise_3",
+            "abstract-index": "three_abs",
+            "concretize-index": "concretize_3",
+            "multiply-indices": null,
+            "mod-indices": null
+        },
+        "related-entities": [
+            {
+                "entity": "array",
+                "function": "main",
+                "name": "main::1::a2"
+            },
+            {
+                "entity": "length",
+                "function": "main",
+                "name": "main::1::a1_len"
+            },
+            {
+                "entity": "length",
+                "function": "main",
+                "name": "main::1::a2_len"
+            }
+        ]
+
+    }
+]
+}

--- a/regression/rr-abstraction/test3/test.desc
+++ b/regression/rr-abstraction/test3/test.desc
@@ -1,0 +1,9 @@
+CORE
+main.c
+1
+^EXIT=0$
+^SIGNAL=0$
+^Writing GOTO
+--
+--
+Just adds functions from abst-funcs to module under test.

--- a/regression/rr-abstraction/test4/main.c
+++ b/regression/rr-abstraction/test4/main.c
@@ -1,0 +1,60 @@
+#include <assert.h>
+#include <stdbool.h>
+#include <stdlib.h>
+
+#define MAX_LEN 100
+
+bool foo(char *a1, size_t a1_len, char *a2, size_t a2_len)
+{
+  bool res = true;
+  if(a1_len == a2_len)
+  {
+    for(size_t i; i < a1_len; i++)
+    {
+      if(a2[i] != a1[i] + 1)
+        res &= false;
+    }
+    return res;
+  }
+  else
+  {
+    return false;
+  }
+}
+
+bool bar(char *a1, size_t a1_len, char *a2, size_t a2_len, size_t i)
+{
+  size_t k = i - 1;
+  assert(a1_len == a2_len);
+  if(k > 0)
+  {
+    if(a2[k] == a1[i] + 1)
+      return true;
+    else
+      return false;
+  }
+  else
+    return true;
+}
+
+void main()
+{
+  const char *a1;
+  const char *a2;
+  size_t a1_len;
+  size_t a2_len;
+  size_t i;
+
+  __CPROVER_assume(a1_len < MAX_LEN);
+  __CPROVER_assume(a2_len < MAX_LEN);
+  a1 = malloc(a1_len);
+  a2 = malloc(a2_len);
+
+  if(foo(a1, a1_len, a2, a2_len))
+  {
+    assert(bar(a1, a1_len, a2, a2_len, i));
+  }
+  else
+    assert(true);
+  return;
+}

--- a/regression/rr-abstraction/test4/spec.json
+++ b/regression/rr-abstraction/test4/spec.json
@@ -1,0 +1,43 @@
+{
+    "entries": [
+    {
+        "entity": "array",
+        "function": "main",
+        "name": "main::1::a1",
+        "shape": {
+            "indices": ["c0", "c1", "l"],
+            "assumptions": ["c0 == 0", "c0 < c1", "c1 < l"],
+            "shape-type": "c*c*l"
+        },
+        "abst-function-file": "../abst-funcs.c",
+        "abst-functions":{
+            "add-abs-conc": "add_abs_to_conc_3",
+            "sub-abs-conc": "sub_conc_from_abs_3",
+            "multiply-abs-conc": "multiply_abs_with_conc_3",
+            "precise-check": "is_precise_3",
+            "abstract-index": "three_abs",
+            "concretize-index": "concretize_3",
+            "multiply-indices": null,
+            "mod-indices": null
+        },
+        "related-entities": [
+            {
+                "entity": "array",
+                "function": "main",
+                "name": "main::1::a2"
+            },
+            {
+                "entity": "length",
+                "function": "main",
+                "name": "main::1::a1_len"
+            },
+            {
+                "entity": "length",
+                "function": "main",
+                "name": "main::1::a2_len"
+            }
+        ]
+
+    }
+]
+}

--- a/regression/rr-abstraction/test4/test.desc
+++ b/regression/rr-abstraction/test4/test.desc
@@ -1,0 +1,9 @@
+CORE
+main.c
+1
+^EXIT=0$
+^SIGNAL=0$
+^Writing GOTO
+--
+--
+Just adds functions from abst-funcs to module under test.

--- a/regression/rr-abstraction/test5/main.c
+++ b/regression/rr-abstraction/test5/main.c
@@ -1,0 +1,47 @@
+#include <assert.h>
+#include <stdbool.h>
+#include <stdlib.h>
+
+#define MAX_LEN 100
+
+// Compares if two arrays are the same (sort of)
+bool foo(char *a1, size_t a1_len, char *a2, size_t a2_len)
+{
+  bool res = true;
+  if(a1_len == a2_len)
+  {
+    for(size_t i = 0; i < a1_len; i++)
+    {
+      if(a2[i] != a1[i])
+        res &= false;
+    }
+    return res;
+  }
+  else
+  {
+    return false;
+  }
+}
+
+void main()
+{
+  const char *a1;
+  const char *a2;
+  size_t a1_len;
+  size_t a2_len;
+  // CBMC will choose i non-deterministically
+  size_t i;
+
+  __CPROVER_assume(a1_len < MAX_LEN);
+  __CPROVER_assume(a2_len <= a1_len);
+  __CPROVER_assume(i < a2_len);
+
+  a1 = malloc(a1_len);
+  a2 = malloc(a2_len);
+
+  if(foo(a1, a1_len, a2, a2_len))
+    assert(a1[i] == a2[i]);
+  else
+    assert(true);
+  return;
+}

--- a/regression/rr-abstraction/test5/spec.json
+++ b/regression/rr-abstraction/test5/spec.json
@@ -1,0 +1,43 @@
+{
+    "entries": [
+    {
+        "entity": "array",
+        "function": "main",
+        "name": "main::1::a1",
+        "shape": {
+            "indices": ["c0", "c1", "l"],
+            "assumptions": ["c0 == 0", "c0 < c1", "c1 < l"],
+            "shape-type": "c*c*l"
+        },
+        "abst-function-file": "../abst-funcs.c",
+        "abst-functions":{
+            "add-abs-conc": "add_abs_to_conc_3",
+            "sub-abs-conc": "sub_conc_from_abs_3",
+            "multiply-abs-conc": "multiply_abs_with_conc_3",
+            "precise-check": "is_precise_3",
+            "abstract-index": "three_abs",
+            "concretize-index": "concretize_3",
+            "multiply-indices": null,
+            "mod-indices": null
+        },
+        "related-entities": [
+            {
+                "entity": "array",
+                "function": "main",
+                "name": "main::1::a2"
+            },
+            {
+                "entity": "length",
+                "function": "main",
+                "name": "main::1::a1_len"
+            },
+            {
+                "entity": "length",
+                "function": "main",
+                "name": "main::1::a2_len"
+            }
+        ]
+
+    }
+]
+}

--- a/regression/rr-abstraction/test5/test.desc
+++ b/regression/rr-abstraction/test5/test.desc
@@ -1,0 +1,9 @@
+CORE
+main.c
+1
+^EXIT=0$
+^SIGNAL=0$
+^Writing GOTO
+--
+--
+Just adds functions from abst-funcs to module under test.

--- a/regression/rr-abstraction/test6/main.c
+++ b/regression/rr-abstraction/test6/main.c
@@ -1,0 +1,52 @@
+#include <assert.h>
+#include <stdbool.h>
+#include <stdlib.h>
+
+#define MAX_LEN 100
+
+// Copies entries from a1 to a2 array.
+int foo(char *a1, size_t a1_len, char *a2, size_t a2_len)
+{
+  bool res = true;
+  if(a1_len == a2_len)
+  {
+    for(size_t i = 0; i < a1_len; i++)
+    {
+      //assign a1 to a2.
+      a2[i] = a1[i] + 1;
+    }
+    return 1;
+  }
+  else
+  {
+    size_t len = (a1_len < a2_len) ? a1_len : a2_len;
+    for(size_t i = 0; i < len; i++)
+    {
+      a2[i] = a1[i];
+    }
+    return 0;
+  }
+}
+
+void main()
+{
+  const char *a1;
+  const char *a2;
+  size_t a1_len;
+  size_t a2_len;
+  // CBMC will choose i non-deterministically
+  size_t i;
+
+  __CPROVER_assume(a1_len < MAX_LEN);
+  __CPROVER_assume(a2_len <= a1_len);
+  __CPROVER_assume(i < a2_len);
+
+  a1 = malloc(a1_len);
+  a2 = malloc(a2_len);
+
+  if(foo(a1, a1_len, a2, a2_len))
+    assert(a1[i] + 1 == a2[i]);
+  else
+    assert(a1[i] == a2[i]);
+  return;
+}

--- a/regression/rr-abstraction/test6/spec.json
+++ b/regression/rr-abstraction/test6/spec.json
@@ -1,0 +1,43 @@
+{
+    "entries": [
+    {
+        "entity": "array",
+        "function": "main",
+        "name": "main::1::a1",
+        "shape": {
+            "indices": ["c0", "c1", "l"],
+            "assumptions": ["c0 == 0", "c0 < c1", "c1 < l"],
+            "shape-type": "c*c*l"
+        },
+        "abst-function-file": "../abst-funcs.c",
+        "abst-functions":{
+            "add-abs-conc": "add_abs_to_conc_3",
+            "sub-abs-conc": "sub_conc_from_abs_3",
+            "multiply-abs-conc": "multiply_abs_with_conc_3",
+            "precise-check": "is_precise_3",
+            "abstract-index": "three_abs",
+            "concretize-index": "concretize_3",
+            "multiply-indices": null,
+            "mod-indices": null
+        },
+        "related-entities": [
+            {
+                "entity": "array",
+                "function": "main",
+                "name": "main::1::a2"
+            },
+            {
+                "entity": "length",
+                "function": "main",
+                "name": "main::1::a1_len"
+            },
+            {
+                "entity": "length",
+                "function": "main",
+                "name": "main::1::a2_len"
+            }
+        ]
+
+    }
+]
+}

--- a/regression/rr-abstraction/test6/test.desc
+++ b/regression/rr-abstraction/test6/test.desc
@@ -1,0 +1,9 @@
+CORE
+main.c
+1
+^EXIT=0$
+^SIGNAL=0$
+^Writing GOTO
+--
+--
+Just adds functions from abst-funcs to module under test.

--- a/regression/rr-abstraction/test7/main.c
+++ b/regression/rr-abstraction/test7/main.c
@@ -1,0 +1,31 @@
+#include <assert.h>
+#include <stdlib.h>
+
+#define MAX_LEN 100
+
+void main()
+{
+  char *a1;
+  char *a2;
+  size_t a1_len;
+  size_t a2_len;
+  size_t i = 0;
+  int sum;
+
+  __CPROVER_assume(a1_len < MAX_LEN);
+  __CPROVER_assume(a2_len < MAX_LEN);
+  a1 = malloc(a1_len);
+  a2 = malloc(a2_len);
+
+  // We are assigning a variable that is not being abstracted --sum.
+  while(i < a1_len)
+  {
+    if(a1[i] == a2[i])
+      sum += a1[i];
+    i++;
+  }
+
+  // This should lead to CBMC finding a counter example
+  assert(sum < 0);
+  return;
+}

--- a/regression/rr-abstraction/test7/readme
+++ b/regression/rr-abstraction/test7/readme
@@ -1,0 +1,11 @@
+Copied from test1.
+Main.c has a simple while loop that compares a1 and a2 but it also has "sum" 
+which is not an abstracted variable that is being assigned inside the loop. This should 
+lead to an error.
+
+With spec2.json it would seem there should be no error as "sum" is 
+also an abstracted entity. But that's not the case: value of sum is dependent on it's
+value from the previous iteration. So it's dependent on the length of the loop, and this
+should also lead to an error.
+
+Spec1.json is not used.

--- a/regression/rr-abstraction/test7/spec.json
+++ b/regression/rr-abstraction/test7/spec.json
@@ -1,0 +1,43 @@
+{
+    "entries": [
+    {
+        "entity": "array",
+        "function": "main",
+        "name": "main::1::a1",
+        "shape": {
+            "indices": ["c0", "c1", "l"],
+            "assumptions": ["c0 == 0", "c0 < c1", "c1 < l"],
+            "shape-type": "c*c*l"
+        },
+        "abst-function-file": "../abst-funcs.c",
+        "abst-functions":{
+            "add-abs-conc": "add_abs_to_conc_3",
+            "sub-abs-conc": "sub_conc_from_abs_3",
+            "multiply-abs-conc": "multiply_abs_with_conc_3",
+            "precise-check": "is_precise_3",
+            "abstract-index": "three_abs",
+            "concretize-index": "concretize_3",
+            "multiply-indices": null,
+            "mod-indices": null
+        },
+        "related-entities": [
+            {
+                "entity": "array",
+                "function": "main",
+                "name": "main::1::a2"
+            },
+            {
+                "entity": "length",
+                "function": "main",
+                "name": "main::1::a1_len"
+            },
+            {
+                "entity": "length",
+                "function": "main",
+                "name": "main::1::a2_len"
+            }
+        ]
+
+    }
+]
+}

--- a/regression/rr-abstraction/test7/spec2.json
+++ b/regression/rr-abstraction/test7/spec2.json
@@ -1,0 +1,48 @@
+{
+    "entries": [
+    {
+        "entity": "array",
+        "function": "main",
+        "name": "main::1::a1",
+        "shape": {
+            "indices": ["c0", "c1", "l"],
+            "assumptions": ["c0 == 0", "c0 < c1", "c1 < l"],
+            "shape-type": "c*c*l"
+        },
+        "abst-function-file": "./abst-funcs.c",
+        "abst-functions":{
+            "add-abs-conc": "add_abs_to_conc_3",
+            "sub-abs-conc": "sub_conc_from_abs_3",
+            "multiply-abs-conc": "multiply_abs_with_conc_3",
+            "precise-check": "is_precise_3",
+            "abstract-index": "three_abs",
+            "concretize-index": "concretize_3",
+            "multiply-indices": null,
+            "mod-indices": null
+        },
+        "related-entities": [
+            {
+                "entity": "array",
+                "function": "main",
+                "name": "main::1::a2"
+            },
+            {
+                "entity": "length",
+                "function": "main",
+                "name": "main::1::a1_len"
+            },
+            {
+                "entity": "length",
+                "function": "main",
+                "name": "main::1::a2_len"
+            },
+            {
+                "entity": "scalar",
+                "function": "main",
+                "name": "main::1::sum"
+            }
+        ]
+
+    }
+]
+}

--- a/regression/rr-abstraction/test7/test.desc
+++ b/regression/rr-abstraction/test7/test.desc
@@ -1,0 +1,9 @@
+CORE
+main.c
+1
+^EXIT=0$
+^SIGNAL=0$
+^Writing GOTO
+--
+--
+Just adds functions from abst-funcs to module under test.

--- a/regression/rr-abstraction/test8/main.c
+++ b/regression/rr-abstraction/test8/main.c
@@ -1,0 +1,30 @@
+#include <assert.h>
+#include <stdlib.h>
+
+#define MAX_LEN 100
+
+void main()
+{
+  char *a1;
+  char *a2;
+  size_t a1_len;
+  size_t a2_len;
+  size_t i = 0;
+  size_t sum;
+
+  __CPROVER_assume(a1_len < MAX_LEN);
+  __CPROVER_assume(a2_len < MAX_LEN);
+  a1 = malloc(a1_len);
+  a2 = malloc(a2_len);
+
+  // We are assigning a variable that is not being abstracted --sum.
+  while(i < a1_len)
+  {
+    if(a1[i] == a2[i])
+      sum = a1[i];
+    i++;
+  }
+  // This assertion is false, should lead to CBMC finding a counter example
+  assert(sum < 0);
+  return;
+}

--- a/regression/rr-abstraction/test8/readme
+++ b/regression/rr-abstraction/test8/readme
@@ -1,0 +1,9 @@
+Copied from test1.
+Main.c has a simple while loop that copies a2 array into a1 but it also has "sum" 
+which is not an abstracted variable that is being assigned inside the array. This should 
+lead to an error.
+
+With spec2.json there should be no error.
+Value of "sum" is not dependent on the loop size.
+
+Spec1.json is not used.

--- a/regression/rr-abstraction/test8/spec.json
+++ b/regression/rr-abstraction/test8/spec.json
@@ -1,0 +1,43 @@
+{
+    "entries": [
+    {
+        "entity": "array",
+        "function": "main",
+        "name": "main::1::a1",
+        "shape": {
+            "indices": ["c0", "c1", "l"],
+            "assumptions": ["c0 == 0", "c0 < c1", "c1 < l"],
+            "shape-type": "c*c*l"
+        },
+        "abst-function-file": "../abst-funcs.c",
+        "abst-functions":{
+            "add-abs-conc": "add_abs_to_conc_3",
+            "sub-abs-conc": "sub_conc_from_abs_3",
+            "multiply-abs-conc": "multiply_abs_with_conc_3",
+            "precise-check": "is_precise_3",
+            "abstract-index": "three_abs",
+            "concretize-index": "concretize_3",
+            "multiply-indices": null,
+            "mod-indices": null
+        },
+        "related-entities": [
+            {
+                "entity": "array",
+                "function": "main",
+                "name": "main::1::a2"
+            },
+            {
+                "entity": "length",
+                "function": "main",
+                "name": "main::1::a1_len"
+            },
+            {
+                "entity": "length",
+                "function": "main",
+                "name": "main::1::a2_len"
+            }
+        ]
+
+    }
+]
+}

--- a/regression/rr-abstraction/test8/spec2.json
+++ b/regression/rr-abstraction/test8/spec2.json
@@ -1,0 +1,48 @@
+{
+    "entries": [
+    {
+        "entity": "array",
+        "function": "main",
+        "name": "main::1::a1",
+        "shape": {
+            "indices": ["c0", "c1", "l"],
+            "assumptions": ["c0 == 0", "c0 < c1", "c1 < l"],
+            "shape-type": "c*c*l"
+        },
+        "abst-function-file": "./abst-funcs.c",
+        "abst-functions":{
+            "add-abs-conc": "add_abs_to_conc_3",
+            "sub-abs-conc": "sub_conc_from_abs_3",
+            "multiply-abs-conc": "multiply_abs_with_conc_3",
+            "precise-check": "is_precise_3",
+            "abstract-index": "three_abs",
+            "concretize-index": "concretize_3",
+            "multiply-indices": null,
+            "mod-indices": null
+        },
+        "related-entities": [
+            {
+                "entity": "array",
+                "function": "main",
+                "name": "main::1::a2"
+            },
+            {
+                "entity": "length",
+                "function": "main",
+                "name": "main::1::a1_len"
+            },
+            {
+                "entity": "length",
+                "function": "main",
+                "name": "main::1::a2_len"
+            },
+            {
+                "entity": "scalar",
+                "function": "main",
+                "name": "main::1::sum"
+            }
+        ]
+
+    }
+]
+}

--- a/regression/rr-abstraction/test8/test.desc
+++ b/regression/rr-abstraction/test8/test.desc
@@ -1,0 +1,9 @@
+CORE
+main.c
+1
+^EXIT=0$
+^SIGNAL=0$
+^Writing GOTO
+--
+--
+Just adds functions from abst-funcs to module under test.

--- a/regression/rr-abstraction/test9/main.c
+++ b/regression/rr-abstraction/test9/main.c
@@ -1,0 +1,45 @@
+#include <assert.h>
+#include <stdbool.h>
+#include <stdlib.h>
+
+#define MAX_LEN 100
+
+bool search(char *a, size_t a_len, char key)
+{
+  bool res = false;
+  for(size_t i = 0; i < a_len; i++)
+  {
+    if(a[i] == key)
+      res = true;
+  }
+  return res;
+}
+
+bool main()
+{
+  const char *a1;
+  const char *a2;
+  const char *a3;
+  size_t a1_len;
+  size_t a2_len;
+  // Some char
+  char key = 'a';
+  // CBMC will choose i non-deterministically
+  size_t i;
+
+  __CPROVER_assume(a1_len < MAX_LEN);
+  __CPROVER_assume(a2_len <= a1_len);
+  __CPROVER_assume(i < a2_len);
+
+  a2 = malloc(a2_len);
+  a1_len = a2_len;
+
+  // assignment of the full array.
+  // a2's spec has to be copied over for a1 as well.
+  a1 = a2;
+
+  if(search(a1, a1_len, key))
+    return true;
+  else
+    return false;
+}

--- a/regression/rr-abstraction/test9/spec.json
+++ b/regression/rr-abstraction/test9/spec.json
@@ -1,0 +1,33 @@
+{
+    "entries": [
+    {
+        "entity": "array",
+        "function": "main",
+        "name": "main::1::a1",
+        "shape": {
+            "indices": ["c0", "c1", "l"],
+            "assumptions": ["c0 == 0", "c0 < c1", "c1 < l"],
+            "shape-type": "c*c*l"
+        },
+        "abst-function-file": "../abst-funcs.c",
+        "abst-functions":{
+            "add-abs-conc": "add_abs_to_conc_3",
+            "sub-abs-conc": "sub_conc_from_abs_3",
+            "multiply-abs-conc": "multiply_abs_with_conc_3",
+            "precise-check": "is_precise_3",
+            "abstract-index": "three_abs",
+            "concretize-index": "concretize_3",
+            "multiply-indices": null,
+            "mod-indices": null
+        },
+        "related-entities": [
+            {
+                "entity": "length",
+                "function": "main",
+                "name": "main::1::a1_len"
+            }
+        ]
+
+    }
+]
+}

--- a/regression/rr-abstraction/test9/test.desc
+++ b/regression/rr-abstraction/test9/test.desc
@@ -1,0 +1,9 @@
+CORE
+main.c
+1
+^EXIT=0$
+^SIGNAL=0$
+^Writing GOTO
+--
+--
+Just adds functions from abst-funcs to module under test.

--- a/src/cbmc/Makefile
+++ b/src/cbmc/Makefile
@@ -23,6 +23,7 @@ OBJ += ../ansi-c/ansi-c$(LIBEXT) \
       ../pointer-analysis/rewrite_index$(OBJEXT) \
       ../pointer-analysis/goto_program_dereference$(OBJEXT) \
       ../goto-instrument/source_lines$(OBJEXT) \
+      ../goto-instrument/abstraction_spect$(OBJEXT) \
       ../goto-instrument/cover$(OBJEXT) \
       ../goto-instrument/cover_basic_blocks$(OBJEXT) \
       ../goto-instrument/cover_filter$(OBJEXT) \

--- a/src/cbmc/cbmc_parse_options.cpp
+++ b/src/cbmc/cbmc_parse_options.cpp
@@ -51,6 +51,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <goto-programs/adjust_float_expressions.h>
 #include <goto-programs/initialize_goto_model.h>
 #include <goto-programs/instrument_preconditions.h>
+#include <goto-programs/link_goto_model.h>
 #include <goto-programs/link_to_library.h>
 #include <goto-programs/loop_ids.h>
 #include <goto-programs/mm_io.h>

--- a/src/cbmc/cbmc_parse_options.h
+++ b/src/cbmc/cbmc_parse_options.h
@@ -83,6 +83,7 @@ class optionst;
   "(round-to-nearest)(round-to-plus-inf)(round-to-minus-inf)(round-to-zero)" \
   OPT_FLUSH \
   "(localize-faults)" \
+  "(use-abstraction):" \
   OPT_GOTO_TRACE \
   OPT_VALIDATE \
   OPT_ANSI_C_LANGUAGE \

--- a/src/goto-instrument/Makefile
+++ b/src/goto-instrument/Makefile
@@ -1,4 +1,5 @@
-SRC = accelerate/accelerate.cpp \
+SRC = abstraction.cpp \
+      accelerate/accelerate.cpp \
       accelerate/acceleration_utils.cpp \
       accelerate/all_paths_enumerator.cpp \
       accelerate/cone_of_influence.cpp \
@@ -12,6 +13,7 @@ SRC = accelerate/accelerate.cpp \
       accelerate/scratch_program.cpp \
       accelerate/trace_automaton.cpp \
       accelerate/util.cpp \
+      abstraction_spect.cpp \
       aggressive_slicer.cpp \
       alignment_checks.cpp \
       branch.cpp \

--- a/src/goto-instrument/goto_instrument_parse_options.h
+++ b/src/goto-instrument/goto_instrument_parse_options.h
@@ -89,6 +89,7 @@ Author: Daniel Kroening, kroening@kroening.com
   "(remove-function-pointers)" \
   "(show-claims)(property):" \
   "(show-symbol-table)(show-points-to)(show-rw-set)" \
+  "(use-rra):" \
   "(cav11)" \
   OPT_TIMESTAMP \
   "(show-natural-loops)(show-lexical-loops)(accelerate)(havoc-loops)" \

--- a/src/goto-instrument/module_dependencies.txt
+++ b/src/goto-instrument/module_dependencies.txt
@@ -5,6 +5,7 @@ assembler
 cpp
 goto-instrument
 goto-programs
+json
 langapi # should go away
 linking
 pointer-analysis

--- a/src/goto-instrument/rr_abstraction.cpp
+++ b/src/goto-instrument/rr_abstraction.cpp
@@ -1,0 +1,45 @@
+/*******************************************************************\
+
+Module: Rr_abstraction
+
+Author: Lefan Zhang, lefanz@amazon.com
+        Murali Talupur talupur@amazon.com
+
+\*******************************************************************/
+
+/// \file
+/// Abstraction
+/// Abstract certain data types to make proofs unbounded
+
+#include <iostream>
+#include <queue>
+
+#include "rr_abstraction.h"
+#include <goto-programs/initialize_goto_model.h>
+#include <goto-programs/link_goto_model.h>
+#include <linking/static_lifetime_init.h>
+#include <util/c_types.h>
+#include <util/expr_util.h>
+#include <util/format_expr.h>
+#include <util/std_expr.h>
+
+void rr_abstractiont::link_abst_functions(
+  goto_modelt &goto_model,
+  const rr_abstraction_spect &abst_spec,
+  ui_message_handlert &msg_handler,
+  const optionst &options)
+{
+  std::vector<std::string> abstfiles =
+    abst_spec.get_abstraction_function_files(); // get abst function file names
+  goto_modelt goto_model_for_abst_fns =
+    initialize_goto_model(abstfiles, msg_handler, options); // read files
+  link_goto_model(
+    goto_model, goto_model_for_abst_fns, msg_handler); // link goto model
+}
+
+void rr_abstractiont::abstract_goto_program(
+  goto_modelt &goto_model,
+  rr_abstraction_spect &abst_spec)
+{
+  return;
+}

--- a/src/goto-instrument/rr_abstraction.h
+++ b/src/goto-instrument/rr_abstraction.h
@@ -1,0 +1,54 @@
+/*******************************************************************\
+
+Module: Rr_abstraction
+
+Author: Lefan Zhang, lefanz@amazon.com
+        Murali Talupur talupur@amazon.com
+
+\*******************************************************************/
+
+/// \file
+/// Replication Reducing Abstraction (RRA) for getting unbounded proofs.
+/// Similar to abstractions used in protocol verification, RRA feature
+/// reduces large data structures to small sizes by tracking a few
+/// locations precisely and conservatively over-approximating other
+/// locations. For instance, an array might be abstracted by tracking just
+/// one location precisely. All locations before it are lumped into one
+/// abstract location and similarly, all locations after it. This "shape" can
+/// be viewed as being similar to the regex "*c*".
+/// To use this feature user specifies a json file with arrays/strings
+/// to be abstracted along with the locations to keep precise, relation
+/// between them, helper functions for abstracting the other locations. 
+/// See regression/abstraction folder for some examples.
+/// This resulting program over-approximates the actual program and
+/// since the array/string has a small size the loop unwinding in CBMC
+/// can be small while still giving us an unbounded proof.
+
+#ifndef CPROVER_GOTO_INSTRUMENT_RR_ABSTRACTION_H
+#define CPROVER_GOTO_INSTRUMENT_RR_ABSTRACTION_H
+
+#include <util/expr.h>
+#include <util/json.h>
+
+#include <goto-programs/goto_model.h>
+#include <util/options.h>
+#include <util/ui_message.h>
+
+#include "rr_abstraction_spect.h"
+
+class rr_abstractiont
+{
+public:
+  // link abst functions to goto programs
+  static void link_abst_functions(
+    goto_modelt &goto_model,
+    const rr_abstraction_spect &abst_spec,
+    ui_message_handlert &msg_handler,
+    const optionst &options);
+
+  // abstract goto programs
+  static void
+  abstract_goto_program(goto_modelt &goto_model, rr_abstraction_spect &abst_spec);
+};
+
+#endif // CPROVER_GOTO_INSTRUMENT_ABSTRACTION_H

--- a/src/goto-instrument/rr_abstraction_spect.cpp
+++ b/src/goto-instrument/rr_abstraction_spect.cpp
@@ -1,0 +1,314 @@
+/*******************************************************************\
+
+Module:
+
+Authors: Murali Talupur talupur@amazon.com
+         Lefan Zhang    lefanz@amazon.com
+
+\*******************************************************************/
+
+#include <iostream>
+
+#include <ansi-c/ansi_c_language.h>
+#include <ansi-c/ansi_c_parser.h>
+#include <ansi-c/ansi_c_typecheck.h>
+#include <json/json_parser.h>
+#include <langapi/language.h>
+#include <langapi/mode.h>
+#include <util/file_util.h>
+#include <util/message.h>
+#include <util/std_expr.h>
+
+#include "rr_abstraction_spect.h"
+
+rr_abstraction_spect::rr_abstraction_spect(
+  std::string filename,
+  message_handlert &message_handler)
+{
+  jsont json;
+  parse_json(filename, message_handler, json);
+  const auto &json_object = to_json_object(json);
+  const auto &json_entries = json_object.find("entries")->second;
+  const auto &json_entries_array = to_json_array(json_entries);
+  for(auto it = json_entries_array.begin(); it != json_entries_array.end();
+      ++it)
+  {
+    const auto &entry_obj = to_json_object(*it);
+    spect spec;
+    size_t spec_index = specs.size();
+    spec.set_spect_index(spec_index);
+
+    // we assume all entries in json file belong to the same function
+    function = entry_obj.find("function")->second.value;
+    // insert the entity
+    spec.insert_entity(
+      entry_obj.find("name")->second.value,
+      entry_obj.find("entity")->second.value);
+    const auto &json_re_array =
+      to_json_array(entry_obj.find("related-entities")->second);
+    for(auto it_r = json_re_array.begin(); it_r != json_re_array.end(); ++it_r)
+    {
+      const auto &related_entity = to_json_object(*it_r);
+      spec.insert_entity(
+        related_entity.find("name")->second.value,
+        related_entity.find("entity")->second.value);
+    }
+
+    // initialize the abst functions
+    spec.set_abst_func_file(
+      get_absolute_path(entry_obj.find("abst-function-file")->second.value));
+    spec.set_addition_func(
+      to_json_object(entry_obj.find("abst-functions")->second)
+        .find("add-abs-conc")
+        ->second.value);
+    spec.set_minus_func(to_json_object(entry_obj.find("abst-functions")->second)
+                          .find("sub-abs-conc")
+                          ->second.value);
+    spec.set_precise_func(
+      to_json_object(entry_obj.find("abst-functions")->second)
+        .find("precise-check")
+        ->second.value);
+    spec.set_abstract_func(
+      to_json_object(entry_obj.find("abst-functions")->second)
+        .find("abstract-index")
+        ->second.value);
+
+    // initialize the shape of this spect
+    const auto &json_shape_obj =
+      to_json_object(entry_obj.find("shape")->second);
+    const auto &json_shape_i_array =
+      to_json_array(json_shape_obj.find("indices")->second);
+    const auto &json_shape_a_array =
+      to_json_array(json_shape_obj.find("assumptions")->second);
+    std::vector<irep_idt> indices;
+    std::vector<std::string> assumptions;
+    for(auto it_i = json_shape_i_array.begin();
+        it_i != json_shape_i_array.end();
+        ++it_i)
+      indices.push_back(to_json_string(*it_i).value);
+    for(auto it_a = json_shape_a_array.begin();
+        it_a != json_shape_a_array.end();
+        ++it_a)
+      assumptions.push_back(to_json_string(*it_a).value);
+    std::string shape_type =
+      to_json_string(json_shape_obj.find("shape-type")->second).value;
+    spec.set_shape(indices, assumptions, shape_type);
+    specs.push_back(spec);
+  }
+}
+
+std::vector<std::string>
+rr_abstraction_spect::get_abstraction_function_files() const
+{
+  std::vector<std::string> files;
+  for(const spect &s : specs)
+  {
+    files.push_back(s.get_abst_func_file());
+  }
+  return files;
+}
+
+rr_abstraction_spect::spect rr_abstraction_spect::spect::update_abst_spec(
+  irep_idt old_function,
+  irep_idt new_function,
+  std::unordered_map<irep_idt, irep_idt> _name_pairs) const
+{
+  // copy the spec into a new one
+  spect new_spec(*this);
+
+  // store the entity names in the original spect
+  std::vector<irep_idt> abst_array_ids;
+  std::vector<irep_idt> abst_index_ids;
+  for(const auto &p : abst_arrays)
+    abst_array_ids.push_back(p.first);
+  for(const auto &p : abst_indices)
+    abst_index_ids.push_back(p.first);
+
+  for(const auto &name : abst_array_ids)
+  {
+    if(
+      std::string(abst_arrays.at(name).entity_name().c_str())
+        .rfind(old_function.c_str(), 0) ==
+      0) // erase the old entity if it's not a global variable
+      new_spec.abst_arrays.erase(name);
+    if(_name_pairs.find(name) != _name_pairs.end())
+    {
+      // This array needs to be updated
+      new_spec.abst_arrays.insert(
+        {_name_pairs[name], entityt(_name_pairs[name])});
+    }
+  }
+  for(const auto &name : abst_index_ids)
+  {
+    if(
+      std::string(abst_indices.at(name).entity_name().c_str())
+        .rfind(old_function.c_str(), 0) ==
+      0) // erase the old entity if it's not a global variable
+      new_spec.abst_indices.erase(name);
+    if(_name_pairs.find(name) != _name_pairs.end())
+    {
+      // This index variable needs to be updated
+      new_spec.abst_indices.insert(
+        {_name_pairs[name], entityt(_name_pairs[name])});
+    }
+  }
+
+  return new_spec;
+}
+
+rr_abstraction_spect rr_abstraction_spect::update_abst_spec(
+  irep_idt old_function,
+  irep_idt new_function,
+  std::unordered_map<irep_idt, irep_idt> _name_pairs) const
+{
+  if(function != old_function)
+  {
+    throw "old rr_abstraction_spect should match the callee";
+  }
+
+  rr_abstraction_spect new_abst_spec;
+  new_abst_spec.function = new_function;
+  for(const auto &spec : specs)
+  {
+    spect new_spec =
+      spec.update_abst_spec(old_function, new_function, _name_pairs);
+    if(!spec.compare_shape_only(new_spec))
+      throw "updated spect's shape should be the same as the original one";
+    new_abst_spec.specs.push_back(new_spec);
+  }
+  if(specs.size() != new_abst_spec.specs.size())
+    throw "updated specs' size should remain the same";
+  return new_abst_spec;
+}
+
+std::string rr_abstraction_spect::get_entities_string() const
+{
+  std::string str = "";
+  for(const auto &spec : specs)
+  {
+    for(const auto &ent : spec.get_abst_arrays())
+      str += "array: " + std::string(ent.second.entity_name().c_str()) + "\n";
+    for(const auto &ent : spec.get_abst_indices())
+      str += "index: " + std::string(ent.second.entity_name().c_str()) + "\n";
+  }
+  return str;
+}
+
+void rr_abstraction_spect::print_entities() const
+{
+  std::cout << get_entities_string();
+}
+
+std::vector<exprt>
+rr_abstraction_spect::spect::get_assumption_exprs(const namespacet &ns) const
+{
+  return shape.get_assumption_exprs(ns, spect_index);
+}
+
+// this is a re-write of ansi_c_languaget::to_expr
+// to add the prefix before the variable name
+bool shape_assumption_to_expr(
+  const std::string &code,
+  const std::string &module,
+  exprt &expr,
+  const namespacet &ns)
+{
+  // change symbol expression "name" to "<prefix>name"
+  class add_prefixt : public expr_visitort
+  {
+  public:
+    add_prefixt(const irep_idt &_prefix, const namespacet &_ns)
+      : prefix(_prefix), ns(_ns)
+    {
+    }
+    void operator()(exprt &expr) override
+    {
+      if(expr.id() == ID_symbol)
+      {
+        const symbol_exprt symb_expr = to_symbol_expr(expr);
+        // get the old name
+        irep_idt name = symb_expr.get_identifier();
+        // get the new name
+        irep_idt new_name =
+          irep_idt(std::string(prefix.c_str()) + std::string(name.c_str()));
+        // replace the expr
+        const symbol_tablet symbol_table = ns.get_symbol_table();
+        INVARIANT(
+          symbol_table.has_symbol(new_name),
+          "The concrete index variable " + std::string(new_name.c_str()) +
+            " is not defined");
+        const symbolt &new_symb = symbol_table.lookup_ref(new_name);
+        expr = new_symb.symbol_expr();
+      }
+    }
+
+  protected:
+    irep_idt prefix;
+    const namespacet &ns; // the ns need to live through the scope of this clss
+  };
+  expr.make_nil();
+
+  // no preprocessing yet...
+  std::istringstream i_preprocessed(
+    "void __my_expression = (void) (\n" + code + "\n);");
+
+  null_message_handlert null_message_handler;
+
+  // parsing
+  ansi_c_parser.clear();
+  ansi_c_parser.set_file(irep_idt());
+  ansi_c_parser.in = &i_preprocessed;
+  ansi_c_parser.set_message_handler(null_message_handler);
+  ansi_c_parser.mode = config.ansi_c.mode;
+  ansi_c_parser.ts_18661_3_Floatn_types = config.ansi_c.ts_18661_3_Floatn_types;
+  ansi_c_scanner_init();
+
+  bool result = ansi_c_parser.parse();
+
+  if(ansi_c_parser.parse_tree.items.empty())
+    result = true;
+  else
+  {
+    expr = ansi_c_parser.parse_tree.items.front().declarator().value();
+
+    // change symbols into symbols with exprs
+    add_prefixt ap(module, ns);
+    expr.visit(ap);
+
+    // typecheck it
+    result = ansi_c_typecheck(expr, null_message_handler, ns);
+  }
+
+  // save some memory
+  ansi_c_parser.clear();
+
+  // now remove that (void) cast
+  if(
+    expr.id() == ID_typecast && expr.type().id() == ID_empty &&
+    expr.operands().size() == 1)
+  {
+    expr = to_typecast_expr(expr).op();
+  }
+
+  return result;
+}
+
+std::vector<exprt> rr_abstraction_spect::spect::abst_shapet::get_assumption_exprs(
+  const namespacet &ns,
+  const size_t &spec_index) const
+{
+  // helper class for parsing assumptions
+  std::string module = get_index_name(irep_idt(""), spec_index).c_str();
+
+  std::vector<exprt> result;
+  for(const auto &assumption : assumptions)
+  {
+    exprt expr;
+    if(shape_assumption_to_expr(assumption, module, expr, ns))
+      throw "cannot parse assumption statements in the json file: " +
+        assumption;
+    result.push_back(expr);
+  }
+
+  return result;
+}

--- a/src/goto-instrument/rr_abstraction_spect.h
+++ b/src/goto-instrument/rr_abstraction_spect.h
@@ -1,0 +1,482 @@
+/*******************************************************************\
+
+Module:
+
+Authors: Murali Talupur, talupur@amazon.com
+         Lefan Zhang,    lefanz@amazon.com
+
+\*******************************************************************/
+
+#ifndef CPROVER_GOTO_INSTRUMENT_RR_ABSTRACTION_SPECT_H
+#define CPROVER_GOTO_INSTRUMENT_RR_ABSTRACTION_SPECT_H
+
+#include <limits>
+#include <list>
+#include <map>
+#include <string>
+#include <tuple>
+#include <vector>
+
+class rr_abstraction_spect
+{
+public:
+  rr_abstraction_spect()
+  {
+  }
+  // This constructor parses the json abstraction
+  // specification and populates the class.
+  rr_abstraction_spect(std::string, message_handlert &);
+
+  // gathers file names from all the individual specs and returns a list.
+  std::vector<std::string> get_abstraction_function_files() const;
+
+public:
+  struct spect
+  {
+  public:
+    struct abst_shapet
+    {
+      std::vector<irep_idt> indices;
+      std::vector<std::string> assumptions;
+      std::string shape_type; // e.g. "*cc*"
+    public:
+      abst_shapet()
+      {
+      }
+      abst_shapet(
+        std::vector<irep_idt> _indices,
+        std::vector<std::string> _assumptions,
+        std::string _shape_type)
+        : indices(_indices), assumptions(_assumptions), shape_type(_shape_type)
+      {
+      }
+      abst_shapet(const abst_shapet &other)
+        : indices(other.indices),
+          assumptions(other.assumptions),
+          shape_type(other.shape_type)
+      {
+      }
+      void add_index(const irep_idt &_index)
+      {
+        indices.push_back(_index);
+      }
+      void add_assumption(const std::string &_assumption)
+      {
+        assumptions.push_back(_assumption);
+      }
+      void set_shape_type(const std::string &_shape_type)
+      {
+        shape_type = _shape_type;
+      }
+      bool operator==(const abst_shapet &other) const
+      {
+        if(indices.size() != other.indices.size())
+          return false;
+        if(assumptions.size() != other.assumptions.size())
+          return false;
+        for(size_t i = 0; i < indices.size(); i++)
+          if(indices[i] != other.indices[i])
+            return false;
+        for(size_t i = 0; i < assumptions.size(); i++)
+          if(assumptions[i] != other.assumptions[i])
+            return false;
+        return (shape_type == other.shape_type);
+      }
+      static irep_idt
+      get_index_name(const irep_idt &raw_name, const size_t &spec_index)
+      {
+        return irep_idt(
+          "$abst$spec" + std::to_string(spec_index) + "$" +
+          std::string(raw_name.c_str()));
+      }
+      const std::vector<irep_idt> &get_indices() const
+      {
+        return indices;
+      }
+      const irep_idt get_length_index_name() const
+      {
+        INVARIANT(
+          indices.size() > 0,
+          "shape should have at least a length concrete variable");
+        return *(indices.end() - 1);
+      }
+      std::vector<exprt> get_assumption_exprs(
+        const namespacet &ns,
+        const size_t &spec_index) const;
+    };
+
+    struct entityt
+    {
+      // Name of the array/list being abstracted
+      irep_idt
+        // Should be in the id format: function::x::name, the unique identifier
+        name;
+      std::string name_of_abst;
+
+    public:
+      entityt()
+      {
+      }
+      explicit entityt(irep_idt _name) : name(_name)
+      {
+      }
+      entityt(const entityt &_entity)
+        : name(_entity.name), name_of_abst(_entity.name_of_abst)
+      {
+      }
+
+      irep_idt entity_name() const
+      {
+        return name;
+      }
+
+      void set_entity_name(const irep_idt &new_name)
+      {
+        name = new_name;
+      }
+
+      std::string entity_abst() const
+      {
+        return name_of_abst;
+      }
+
+      std::string entity_path()
+      {
+        return ("foo");
+      };
+    };
+
+  protected:
+    // Abstraction func file
+    std::string abst_func_file;
+
+    // Arrays to be abstracted
+    std::unordered_map<irep_idt, entityt> abst_arrays;
+
+    // Index vars to be abstracted
+    std::unordered_map<irep_idt, entityt> abst_indices;
+
+    // Length vars to be abstracted
+    std::unordered_map<irep_idt, entityt> abst_lengths;
+
+    // Shape of the abstraction
+    abst_shapet shape;
+
+    // Abstraction functions follow.
+    // These should be defined in the abst_funcs_file or hard-coded.
+    // In abst_funcs_file function will begin with prefixes such as
+    // is_precise, compare_indices etc plus some shape identifier.
+
+    // Says if an index into the abstracted entity is precisely tracked or not.
+    irep_idt is_precise_func;
+    // Says how the two indices into abstracted entity compare.
+    irep_idt compare_indices_func;
+    // Addition over abstract indices
+    irep_idt addition_func;
+    // Subtraction over abstract indices
+    irep_idt minus_func;
+    // Translate a concrete index to an abst index
+    irep_idt abstract_func;
+
+    // the index of this spect in the rr_abstraction_spect
+    size_t spect_index;
+
+  public:
+    spect()
+    {
+    }
+    spect(const spect &_spec)
+      : abst_func_file(_spec.abst_func_file),
+        abst_arrays(_spec.abst_arrays),
+        abst_indices(_spec.abst_indices),
+        abst_lengths(_spec.abst_lengths),
+        shape(_spec.shape),
+        is_precise_func(_spec.is_precise_func),
+        compare_indices_func(_spec.compare_indices_func),
+        addition_func(_spec.addition_func),
+        minus_func(_spec.minus_func),
+        abstract_func(_spec.abstract_func),
+        spect_index(_spec.spect_index)
+    {
+    }
+
+    // We will have functions for accessing and modifying the above data.
+    // _type: "array", "scalar", "length"
+    void insert_entity(const irep_idt &_name, const std::string &_type)
+    {
+      entityt new_entity(_name);
+      if(_type == "array")
+        abst_arrays.insert({_name, new_entity});
+      else if(_type == "scalar")
+        abst_indices.insert({_name, new_entity});
+      else if(_type == "length")
+      {
+        abst_lengths.insert({_name, new_entity});
+        abst_indices.insert({_name, new_entity});
+      }
+      else
+        throw "unknown entity type: " + _type;
+    }
+
+    const std::unordered_map<irep_idt, entityt> &get_abst_arrays() const
+    {
+      return abst_arrays;
+    }
+
+    const std::unordered_map<irep_idt, entityt> &get_abst_indices() const
+    {
+      return abst_indices;
+    }
+
+    const std::unordered_map<irep_idt, entityt> &get_abst_lengths() const
+    {
+      return abst_lengths;
+    }
+
+    const bool has_entity(const irep_idt &entity_name) const
+    {
+      return (abst_arrays.find(entity_name) != abst_arrays.end()) ||
+             (abst_indices.find(entity_name) != abst_indices.end());
+    }
+
+    const bool has_array_entity(const irep_idt &entity_name) const
+    {
+      return (abst_arrays.find(entity_name) != abst_arrays.end());
+    }
+
+    const bool has_index_entity(const irep_idt &entity_name) const
+    {
+      return (abst_indices.find(entity_name) != abst_indices.end());
+    }
+
+    const irep_idt get_length_index_name() const
+    {
+      return shape.get_length_index_name();
+    }
+
+    // set abst func file path
+    void set_abst_func_file(const std::string &_abst_func_file)
+    {
+      abst_func_file = _abst_func_file;
+    }
+
+    // get abst func file
+    std::string get_abst_func_file() const
+    {
+      return abst_func_file;
+    }
+
+    // set addition func
+    void set_addition_func(const irep_idt &_func_name)
+    {
+      addition_func = _func_name;
+    }
+
+    // get addition func
+    const irep_idt &get_addition_func() const
+    {
+      return addition_func;
+    }
+
+    // set minus func
+    void set_minus_func(const irep_idt &_func_name)
+    {
+      minus_func = _func_name;
+    }
+
+    // get addition func
+    const irep_idt &get_minus_func() const
+    {
+      return minus_func;
+    }
+
+    // set is_precise func
+    void set_precise_func(const irep_idt &_func_name)
+    {
+      is_precise_func = _func_name;
+    }
+
+    // get is_precise func
+    const irep_idt &get_precise_func() const
+    {
+      return is_precise_func;
+    }
+
+    // set abstract_func
+    void set_abstract_func(const irep_idt &_func_name)
+    {
+      abstract_func = _func_name;
+    }
+
+    // get is_precise func
+    const irep_idt &get_abstract_func() const
+    {
+      return abstract_func;
+    }
+
+    // set the shape
+    void set_shape(
+      const std::vector<irep_idt> &indices,
+      const std::vector<std::string> &assumptions,
+      const std::string &shape_type)
+    {
+      std::vector<irep_idt> new_indices(indices);
+      for(auto &index : new_indices)
+        index = abst_shapet::get_index_name(index, spect_index);
+      shape = abst_shapet(new_indices, assumptions, shape_type);
+    }
+
+    std::vector<exprt> get_assumption_exprs(const namespacet &ns) const;
+
+    // compare if two spect have the same abst shape
+    bool compare_shape(const spect &other) const
+    {
+      if(abst_arrays.size() != other.abst_arrays.size())
+        return false;
+      if(abst_indices.size() != other.abst_indices.size())
+        return false;
+      for(const auto &array : abst_arrays)
+        if(other.abst_arrays.find(array.first) == other.abst_arrays.end())
+          return false;
+      for(const auto &index : abst_indices)
+        if(other.abst_indices.find(index.first) == other.abst_indices.end())
+          return false;
+      return shape == other.shape;
+    }
+
+    bool compare_shape_only(const spect &other) const
+    {
+      return shape == other.shape;
+    }
+
+    const std::vector<irep_idt> &get_shape_indices() const
+    {
+      return shape.get_indices();
+    }
+
+    void set_spect_index(const size_t &_index)
+    {
+      spect_index = _index;
+    }
+    // We need to update the abstracted array/list/var names as we cross
+    // the function boundary.
+    // For example, if function Foo has two arrays f1 and f2
+    // that are abstracted.
+    // Function Bar is defined as void Bar(array b1, array b2) and
+    // suppose Foo calls Bar(f1,f2).
+    // Abst_spec in Foo will contain f1, f2. These should be renamed to
+    // b1, b2 to obtain abst_spec for Bar.
+    // The argument for the following function would be Foo, Bar,
+    // {f1: b1, f2: b2}
+    // Return a new spect reflecting the changes
+    spect update_abst_spec(
+      irep_idt old_function,
+      irep_idt new_function,
+      std::unordered_map<irep_idt, irep_idt> _name_pairs) const;
+  };
+
+  // gather specs
+  std::vector<spect> &get_specs()
+  {
+    return specs;
+  }
+
+  // gather specs constant version
+  const std::vector<spect> &get_specs() const
+  {
+    return specs;
+  }
+
+  // get function name
+  const irep_idt &get_func_name() const
+  {
+    return function;
+  }
+
+  // update all specs when crossing the function call boundary
+  rr_abstraction_spect update_abst_spec(
+    irep_idt old_function,
+    irep_idt new_function,
+    std::unordered_map<irep_idt, irep_idt> _name_pairs) const;
+
+  // check if a variable is abstracted
+  bool has_entity(const irep_idt &entity_name) const
+  {
+    for(const spect &spec : specs)
+    {
+      if(spec.has_entity(entity_name))
+        return true;
+    }
+    return false;
+  }
+
+  bool has_array_entity(const irep_idt &entity_name) const
+  {
+    for(const spect &spec : specs)
+    {
+      if(spec.has_array_entity(entity_name))
+        return true;
+    }
+    return false;
+  }
+
+  // check if a variable is an index to be abstracted
+  bool has_index_entity(const irep_idt &entity_name) const
+  {
+    for(const spect &spec : specs)
+    {
+      if(spec.has_index_entity(entity_name))
+        return true;
+    }
+    return false;
+  }
+
+  // return the spect that has the entity,
+  // should always run has_index_entity before running this function
+  const spect &get_spec_for_index_entity(const irep_idt &entity_name) const
+  {
+    for(const spect &spec : specs)
+    {
+      if(spec.has_index_entity(entity_name))
+        return spec;
+    }
+    throw "entity " + std::string(entity_name.c_str()) + " not found";
+  }
+
+  // return the spect that has the entity,
+  // should always run has_array_entity before running this function
+  const spect &get_spec_for_array_entity(const irep_idt &entity_name) const
+  {
+    for(const spect &spec : specs)
+    {
+      if(spec.has_array_entity(entity_name))
+        return spec;
+    }
+    throw "entity " + std::string(entity_name.c_str()) + " not found";
+  }
+
+  // compare if two spect have the same structure
+  bool compare_shape(const rr_abstraction_spect &other) const
+  {
+    // In the update_abst_spec function, the result and the
+    // original one should have the same spects in terms
+    // of both order and shape
+    if(specs.size() != other.specs.size())
+      return false;
+    for(size_t i = 0; i < specs.size(); i++)
+      if(!specs[i].compare_shape(other.specs[i]))
+        return false;
+    return true;
+  }
+
+  // get a string containing all entity names
+  std::string get_entities_string() const;
+  // print all entities
+  void print_entities() const;
+
+protected:
+  std::vector<spect> specs;
+  irep_idt function; // function name, no need to have path
+};
+
+#endif // CPROVER_GOTO_INSTRUMENT_ABSTSPEC_H

--- a/src/util/file_util.h
+++ b/src/util/file_util.h
@@ -20,6 +20,9 @@ void delete_directory(const std::string &path);
 std::string get_current_working_directory();
 void set_current_path(const std::string &path);
 
+// C++17 will allow us to use std::filesystem::absolute
+std::string get_absolute_path(const std::string &rel_path);
+
 // C++17 will allow us to use std::filesystem::path(dir).append(file)
 std::string concat_dir_file(const std::string &directory,
                             const std::string &file_name);


### PR DESCRIPTION
This can be used to unbounded proofs using CBMC. User has to specify the data structures to be abstracted
in a json file along with use-rra flag.

Current commit introduces infrastructure for parsing the spec files, the option with a minimal flow,
and a set of regression tests.

Joint work with Lefan Zhang (lefanz@amazon.com).

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x ] Each commit message has a non-empty body, explaining why the change was made.
- [ x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ x] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ x] My commit message includes data points confirming performance improvements (if claimed).
- [ x] My PR is restricted to a single feature or bugfix.
- [ x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
