### PR TITLE
Fix double-free bug in stdlib models with --malloc-fail-null

### DIFF
--- a/regression/cbmc/realloc-should-not-free-on-failure-to-allocate/test.c
+++ b/regression/cbmc/realloc-should-not-free-on-failure-to-allocate/test.c
@@ -1,0 +1,17 @@
+#include <stdlib.h>
+
+int main(void)
+{
+  void *ptr = malloc(sizeof(char));
+  if(ptr == NULL)
+    return 0;
+
+  void *ptr1 = realloc(ptr, 2 * sizeof(char));
+  if(ptr1 == NULL)
+  {
+    free(ptr);
+    return 0;
+  }
+
+  free(ptr1);
+}

--- a/regression/cbmc/realloc-should-not-free-on-failure-to-allocate/test.desc
+++ b/regression/cbmc/realloc-should-not-free-on-failure-to-allocate/test.desc
@@ -1,0 +1,11 @@
+CORE
+test.c
+--malloc-may-fail --malloc-fail-null
+^\[main.precondition_instance.\d+] line \d+ double free: SUCCESS$
+^VERIFICATION SUCCESSFUL$
+^EXIT=0$
+^SIGNAL=0$
+--
+--
+This is a test checking for a regression where the --malloc-may-fail flag
+introduced a double-free bug in the stdlib models with realloc.

--- a/src/ansi-c/library/stdlib.c
+++ b/src/ansi-c/library/stdlib.c
@@ -477,8 +477,10 @@ inline void *realloc(void *ptr, __CPROVER_size_t malloc_size)
   void *res;
   res=malloc(malloc_size);
   if(res != (void *)0)
+  {
     __CPROVER_array_copy(res, ptr);
-  free(ptr);
+    free(ptr);
+  }
 
   return res;
 }


### PR DESCRIPTION
If realloc results in a larger memory block the old one needs to be
freed... but this should only happen if the allocation of the new block
succeeds. The old model didn't properly check for that, this is now
fixed.

This should fix https://github.com/diffblue/cbmc/issues/5511

(Linked to wrong issue before)
<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
