### PR TITLE
Add concurrency examples to regression tests

### DIFF
--- a/regression/CMakeLists.txt
+++ b/regression/CMakeLists.txt
@@ -61,6 +61,7 @@ add_subdirectory(linking-goto-binaries)
 add_subdirectory(symtab2gb)
 add_subdirectory(validate-trace-xml-schema)
 add_subdirectory(cbmc-primitives)
+add_subdirectory(cbmc-sequentialization)
 
 if(WITH_MEMORY_ANALYZER)
   add_subdirectory(snapshot-harness)

--- a/regression/cbmc-sequentialization/CMakeLists.txt
+++ b/regression/cbmc-sequentialization/CMakeLists.txt
@@ -1,0 +1,10 @@
+if(NOT WIN32)
+  add_test_pl_tests(
+          "$<TARGET_FILE:cbmc> --validate-goto-model --validate-ssa-equation"
+  )
+else()
+  add_test_pl_tests(
+          "$<TARGET_FILE:cbmc> --validate-goto-model --validate-ssa-equation"
+          -X requires_posix_only_headers
+  )
+endif()

--- a/regression/cbmc-sequentialization/Makefile
+++ b/regression/cbmc-sequentialization/Makefile
@@ -1,0 +1,33 @@
+default: test
+
+include ../../src/config.inc
+include ../../src/common
+
+ifeq ($(BUILD_ENV_),MSVC)
+GCC_ONLY = -X gcc-only
+else
+GCC_ONLY =
+endif
+
+test:
+	@../test.pl -e -p -c "../../../src/cbmc/cbmc --validate-goto-model --validate-ssa-equation" -X smt-backend $(GCC_ONLY)
+
+test-cprover-smt2:
+	@../test.pl -e -p -c "../../../src/cbmc/cbmc --cprover-smt2" -X broken-smt-backend $(GCC_ONLY)
+
+test-paths-lifo:
+	@../test.pl -e -p -c "../../../src/cbmc/cbmc --paths lifo" -X thorough-paths -X smt-backend -X paths-lifo-expected-failure $(GCC_ONLY)
+
+tests.log: ../test.pl test
+
+show:
+	@for dir in *; do \
+		if [ -d "$$dir" ]; then \
+			vim -o "$$dir/*.c" "$$dir/*.out"; \
+		fi; \
+	done;
+
+clean:
+	find -name '*.out' -execdir $(RM) '{}' \;
+	find -name '*.smt2' -execdir $(RM) '{}' \;
+	$(RM) tests.log

--- a/regression/cbmc-sequentialization/posix_semaphores/blocking_queue.c
+++ b/regression/cbmc-sequentialization/posix_semaphores/blocking_queue.c
@@ -1,0 +1,153 @@
+#include <assert.h>
+#include <pthread.h>
+#include <semaphore.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+pthread_t start_worker_thread(void *(*start_routine)(void *))
+{
+  pthread_t worker_thread;
+  const pthread_attr_t *const attributes = NULL;
+  void *const worker_argument = NULL;
+  const int create_status =
+    pthread_create(&worker_thread, attributes, start_routine, worker_argument);
+  assert(create_status == 0);
+  return worker_thread;
+}
+
+void join_thread(const pthread_t thread)
+{
+  const int join_status = pthread_join(thread, NULL);
+  assert(join_status == 0);
+}
+
+sem_t create_semaphore(int initial_value)
+{
+  const int shared_between_processes = false;
+  sem_t semaphore;
+  const int init_error =
+    sem_init(&semaphore, shared_between_processes, initial_value);
+  assert(init_error == false);
+  return semaphore;
+}
+
+void destroy_semaphore(sem_t *const semaphore)
+{
+  int destroy_error = sem_destroy(semaphore);
+  assert(destroy_error == false);
+}
+
+// This blocking queue structure supports waiting for free space before
+// enqueuing and waiting for data before dequeuing, using a pair of semaphores.
+// These functions do not employ a mutex, so a data race may occur if multiple
+// threads attempt to enqueue at the same time or multiple threads attempt to
+// dequeue at the same time. The expected valid use case is with two threads,
+// where one of the two enqueues and the other thread dequeues.
+struct blocking_queuet
+{
+  size_t size;
+  int *elements;
+  size_t begin;
+  size_t end;
+  sem_t free_space;
+  sem_t data_waiting;
+};
+
+struct blocking_queuet initialise_blocking_queue(const size_t size)
+{
+  printf("init queue begin\n");
+  struct blocking_queuet queue;
+  queue.size = size;
+  queue.elements = calloc(size, sizeof(int));
+  queue.begin = 0;
+  queue.end = 0;
+  queue.free_space = create_semaphore(size);
+  queue.data_waiting = create_semaphore(0);
+  printf("init queue end\n");
+  return queue;
+}
+
+void free_blocking_queue(struct blocking_queuet *queue)
+{
+  free(queue->elements);
+  queue->elements = NULL;
+  destroy_semaphore(&queue->free_space);
+  destroy_semaphore(&queue->data_waiting);
+}
+
+void enqueue(struct blocking_queuet *queue, const int data)
+{
+  printf(
+    "enqueue begin:%lu end:%lu data:%d \n", queue->begin, queue->end, data);
+  const int free_wait_error = sem_wait(&queue->free_space);
+  assert(free_wait_error == false);
+  queue->elements[queue->end] = data;
+  if(++queue->end == queue->size)
+  {
+    queue->end = 0;
+  }
+  const int post_error = sem_post(&queue->data_waiting);
+  assert(post_error == false);
+  printf("enqueue done\n");
+}
+
+int dequeue(struct blocking_queuet *queue)
+{
+  printf("dequeue begin:%lu end:%lu\n", queue->begin, queue->end);
+  const int data_wait_error = sem_wait(&queue->data_waiting);
+  assert(data_wait_error == false);
+  int result = queue->elements[queue->begin];
+  if(++queue->begin == queue->size)
+  {
+    queue->begin = 0;
+  }
+  const int free_error = sem_post(&queue->free_space);
+  assert(free_error == false);
+  printf("dequeue done. data:%d \n", result);
+  return result;
+}
+
+struct blocking_queuet input_queue;
+struct blocking_queuet output_queue;
+
+void *worker(void *arguments)
+{
+  int data;
+  while(data = dequeue(&input_queue))
+  {
+    enqueue(&output_queue, data * data);
+  }
+  pthread_exit(NULL);
+}
+
+int main(void)
+{
+  input_queue = initialise_blocking_queue(3);
+  output_queue = initialise_blocking_queue(10);
+  const pthread_t worker_thread1 = start_worker_thread(&worker);
+  printf("worker_started\n");
+  enqueue(&input_queue, 1);
+  enqueue(&input_queue, 2);
+  enqueue(&input_queue, 3);
+  enqueue(&input_queue, 4);
+  enqueue(&input_queue, 5);
+  enqueue(&input_queue, 6);
+  enqueue(&input_queue, 7);
+  enqueue(&input_queue, 8);
+  enqueue(&input_queue, 9);
+  enqueue(&input_queue, 0);
+  join_thread(worker_thread1);
+  free_blocking_queue(&input_queue);
+  assert(dequeue(&output_queue) == 1);
+  assert(dequeue(&output_queue) == 4);
+  assert(dequeue(&output_queue) == 9);
+  assert(dequeue(&output_queue) == 16);
+  assert(dequeue(&output_queue) == 25);
+  assert(dequeue(&output_queue) == 36);
+  assert(dequeue(&output_queue) == 49);
+  assert(dequeue(&output_queue) == 64);
+  assert(dequeue(&output_queue) == 81);
+  free_blocking_queue(&output_queue);
+  return EXIT_SUCCESS;
+}

--- a/regression/cbmc-sequentialization/posix_semaphores/blocking_queue.desc
+++ b/regression/cbmc-sequentialization/posix_semaphores/blocking_queue.desc
@@ -1,0 +1,11 @@
+FUTURE requires_posix_only_headers
+blocking_queue.c
+
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring
+pointer handling for concurrency is unsound
+--
+Test using an example simplistic implementation of a blocking queue.

--- a/regression/cbmc-sequentialization/posix_semaphores/blocking_wait.c
+++ b/regression/cbmc-sequentialization/posix_semaphores/blocking_wait.c
@@ -1,0 +1,64 @@
+#include <assert.h>
+#include <pthread.h>
+#include <semaphore.h>
+#include <stdbool.h>
+#include <stdlib.h>
+
+pthread_t start_worker_thread(void *(*start_routine)(void *))
+{
+  pthread_t worker_thread;
+  const pthread_attr_t *const attributes = NULL;
+  void *const worker_argument = NULL;
+  const int create_status =
+    pthread_create(&worker_thread, attributes, start_routine, worker_argument);
+  assert(create_status == 0);
+  return worker_thread;
+}
+
+void join_thread(const pthread_t thread)
+{
+  const int join_status = pthread_join(thread, NULL);
+  assert(join_status == 0);
+}
+
+sem_t create_semaphore(int initial_value)
+{
+  const int shared_between_processes = false;
+  sem_t semaphore;
+  const int init_error =
+    sem_init(&semaphore, shared_between_processes, initial_value);
+  assert(init_error == false);
+  return semaphore;
+}
+
+void destroy_semaphore(sem_t *const semaphore)
+{
+  int destroy_error = sem_destroy(semaphore);
+  assert(destroy_error == false);
+}
+
+sem_t global_semaphore;
+int global_value;
+
+void *worker(void *arguments)
+{
+  const int wait_error = sem_wait(&global_semaphore);
+  assert(wait_error == false);
+  assert(global_value == 42);
+  pthread_exit(NULL);
+}
+
+int main(void)
+{
+  global_semaphore = create_semaphore(0);
+  global_value = 0;
+
+  const pthread_t worker_thread1 = start_worker_thread(&worker);
+  global_value = 42;
+  const int post_error = sem_post(&global_semaphore);
+  assert(post_error == false);
+  join_thread(worker_thread1);
+
+  destroy_semaphore(&global_semaphore);
+  return EXIT_SUCCESS;
+}

--- a/regression/cbmc-sequentialization/posix_semaphores/blocking_wait.desc
+++ b/regression/cbmc-sequentialization/posix_semaphores/blocking_wait.desc
@@ -1,0 +1,12 @@
+FUTURE requires_posix_only_headers
+blocking_wait.c
+
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring
+pointer handling for concurrency is unsound
+--
+Test that sem_wait will block when the value of a semaphore is 0, until it is
+increased via sem_post.

--- a/regression/cbmc-sequentialization/posix_semaphores/create_destroy.c
+++ b/regression/cbmc-sequentialization/posix_semaphores/create_destroy.c
@@ -1,0 +1,30 @@
+#include <assert.h>
+#include <pthread.h>
+#include <semaphore.h>
+#include <stdbool.h>
+#include <stdlib.h>
+
+sem_t create_semaphore(int initial_value)
+{
+  const int shared_between_processes = false;
+  sem_t semaphore;
+  const int init_error =
+    sem_init(&semaphore, shared_between_processes, initial_value);
+  assert(init_error == false);
+  return semaphore;
+}
+
+void destroy_semaphore(sem_t *const semaphore)
+{
+  int destroy_error = sem_destroy(semaphore);
+  assert(destroy_error == false);
+}
+
+sem_t global_semaphore;
+
+int main(void)
+{
+  global_semaphore = create_semaphore(0);
+  destroy_semaphore(&global_semaphore);
+  return EXIT_SUCCESS;
+}

--- a/regression/cbmc-sequentialization/posix_semaphores/create_destroy.desc
+++ b/regression/cbmc-sequentialization/posix_semaphores/create_destroy.desc
@@ -1,0 +1,11 @@
+CORE requires_posix_only_headers
+create_destroy.c
+
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring
+pointer handling for concurrency is unsound
+--
+Sanity check that cbmc can deal with creation and destruction of semaphores.

--- a/regression/cbmc-sequentialization/pthread_cond/checked_signal.c
+++ b/regression/cbmc-sequentialization/pthread_cond/checked_signal.c
@@ -1,0 +1,90 @@
+#include <assert.h>
+#include <pthread.h>
+#include <sched.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+int shared_global;
+pthread_mutex_t signal_mutex;
+pthread_cond_t condition;
+bool signal_sent;
+
+void initialise_condition(void)
+{
+  pthread_mutexattr_t *mutex_attributes = NULL;
+  int pthread_mutex_init_error =
+    pthread_mutex_init(&signal_mutex, mutex_attributes);
+  assert(!pthread_mutex_init_error);
+
+  pthread_condattr_t *condition_attributes = NULL;
+  int condition_init_error =
+    pthread_cond_init(&condition, condition_attributes);
+  assert(!condition_init_error);
+}
+
+// Wait for signal. Note that pthreads requires us to lock and unlock the mutex
+// around the call to `pthread_cond_wait`. Note also that if called
+// pthread_cond_wait function waits then it will leave the mutex unlocked whilst
+// it is waiting.
+void wait(void)
+{
+  const int lock_error = pthread_mutex_lock(&signal_mutex);
+  assert(!lock_error);
+  const int wait_error = pthread_cond_wait(&condition, &signal_mutex);
+  assert(!wait_error);
+  const int unlock_error = pthread_mutex_unlock(&signal_mutex);
+  assert(!unlock_error);
+}
+
+void signal(void)
+{
+  const int lock_error = pthread_mutex_lock(&signal_mutex);
+  assert(!lock_error);
+  int signal_error = pthread_cond_signal(&condition);
+  assert(!signal_error);
+  const int unlock_error = pthread_mutex_unlock(&signal_mutex);
+  assert(!unlock_error);
+}
+
+void *worker(void *arguments)
+{
+  shared_global = 42;
+  signal_sent = true;
+  signal();
+  pthread_exit(NULL);
+}
+
+pthread_t start_worker_thread(void)
+{
+  pthread_t worker_thread;
+  const pthread_attr_t *const attributes = NULL;
+  void *const worker_argument = NULL;
+  const int create_status =
+    pthread_create(&worker_thread, attributes, &worker, worker_argument);
+  assert(create_status == 0);
+  return worker_thread;
+}
+
+void join_thread(const pthread_t thread)
+{
+  const int join_status = pthread_join(thread, NULL);
+  assert(join_status == 0);
+}
+
+int main(void)
+{
+  shared_global = 0;
+  signal_sent = false;
+  const pthread_t worker_thread1 = start_worker_thread();
+  while(!signal_sent)
+  {
+    wait();
+  }
+  assert(shared_global == 42);
+  join_thread(worker_thread1);
+
+  pthread_mutex_destroy(&signal_mutex);
+  pthread_cond_destroy(&condition);
+  return EXIT_SUCCESS;
+}

--- a/regression/cbmc-sequentialization/pthread_cond/checked_signal.desc
+++ b/regression/cbmc-sequentialization/pthread_cond/checked_signal.desc
@@ -1,0 +1,12 @@
+FUTURE requires_posix_only_headers
+test.c
+
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring
+pointer handling for concurrency is unsound
+--
+Test that signals can be used to ensure that the `shared_global` is set before
+the assertion on its value is reached.

--- a/regression/cbmc-sequentialization/pthread_cond/spurious_wakeup.c
+++ b/regression/cbmc-sequentialization/pthread_cond/spurious_wakeup.c
@@ -1,0 +1,84 @@
+#include <assert.h>
+#include <pthread.h>
+#include <sched.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+int shared_global;
+pthread_mutex_t signal_mutex;
+pthread_cond_t condition;
+
+void initialise_condition(void)
+{
+  pthread_mutexattr_t *mutex_attributes = NULL;
+  int pthread_mutex_init_error =
+    pthread_mutex_init(&signal_mutex, mutex_attributes);
+  assert(!pthread_mutex_init_error);
+
+  pthread_condattr_t *condition_attributes = NULL;
+  int condition_init_error =
+    pthread_cond_init(&condition, condition_attributes);
+  assert(!condition_init_error);
+}
+
+// Wait for signal. Note that pthreads requires us to lock and unlock the mutex
+// around the call to `pthread_cond_wait`. Note also that if called
+// pthread_cond_wait function waits then it will leave the mutex unlocked whilst
+// it is waiting.
+void wait(void)
+{
+  const int lock_error = pthread_mutex_lock(&signal_mutex);
+  assert(!lock_error);
+  const int wait_error = pthread_cond_wait(&condition, &signal_mutex);
+  assert(!wait_error);
+  const int unlock_error = pthread_mutex_unlock(&signal_mutex);
+  assert(!unlock_error);
+}
+
+void signal(void)
+{
+  const int lock_error = pthread_mutex_lock(&signal_mutex);
+  assert(!lock_error);
+  int signal_error = pthread_cond_signal(&condition);
+  assert(!signal_error);
+  const int unlock_error = pthread_mutex_unlock(&signal_mutex);
+  assert(!unlock_error);
+}
+
+void *worker(void *arguments)
+{
+  shared_global = 42;
+  signal();
+  pthread_exit(NULL);
+}
+
+pthread_t start_worker_thread(void)
+{
+  pthread_t worker_thread;
+  const pthread_attr_t *const attributes = NULL;
+  void *const worker_argument = NULL;
+  const int create_status =
+    pthread_create(&worker_thread, attributes, &worker, worker_argument);
+  assert(create_status == 0);
+  return worker_thread;
+}
+
+void join_thread(const pthread_t thread)
+{
+  const int join_status = pthread_join(thread, NULL);
+  assert(join_status == 0);
+}
+
+int main(void)
+{
+  shared_global = 0;
+  const pthread_t worker_thread1 = start_worker_thread();
+  wait();
+  assert(shared_global == 42);
+  join_thread(worker_thread1);
+
+  pthread_mutex_destroy(&signal_mutex);
+  pthread_cond_destroy(&condition);
+  return EXIT_SUCCESS;
+}

--- a/regression/cbmc-sequentialization/pthread_cond/spurious_wakeup.desc
+++ b/regression/cbmc-sequentialization/pthread_cond/spurious_wakeup.desc
@@ -1,0 +1,12 @@
+FUTURE requires_posix_only_headers
+spurious_wakeup.c
+
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION FAILED$
+--
+^warning: ignoring
+pointer handling for concurrency is unsound
+--
+Test that spurious wake ups in code employing signals can violate conditions
+which we would other wise expect to hold.

--- a/regression/cbmc-sequentialization/pthread_join/main.c
+++ b/regression/cbmc-sequentialization/pthread_join/main.c
@@ -1,0 +1,28 @@
+#include <assert.h>
+#include <pthread.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+void *worker(void *arguments)
+{
+  int *return_value = malloc(sizeof(int));
+  *return_value = 42;
+  pthread_exit(return_value);
+}
+
+int main(void)
+{
+  pthread_t thread;
+  const pthread_attr_t *const attributes = NULL;
+  void *const worker_argument = NULL;
+  int create_status =
+    pthread_create(&thread, attributes, &worker, worker_argument);
+  assert(create_status == 0);
+  int *worker_return;
+  int join_status = pthread_join(thread, (void **)&worker_return);
+  assert(join_status == 0);
+  printf("Thread return value is %d.\n", *worker_return);
+  assert(*worker_return == 42);
+  free(worker_return);
+  return EXIT_SUCCESS;
+}

--- a/regression/cbmc-sequentialization/pthread_join/test.desc
+++ b/regression/cbmc-sequentialization/pthread_join/test.desc
@@ -1,0 +1,12 @@
+FUTURE requires_posix_only_headers
+main.c
+
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring
+pointer handling for concurrency is unsound
+--
+Test that the assertion that the worker thread return value acquired by
+pthread_join is the expected hardcoded value cannot be violated.

--- a/regression/cbmc-sequentialization/pthread_mutex/no_mutex.c
+++ b/regression/cbmc-sequentialization/pthread_mutex/no_mutex.c
@@ -1,0 +1,52 @@
+#include <assert.h>
+#include <pthread.h>
+#include <sched.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+int shared_count = 0;
+
+void *worker(void *arguments)
+{
+  for(int i = 0; i < 100; ++i)
+  {
+    int shared_count_copy = shared_count;
+    // The following call to yield is here in order to increase the chance of
+    // thread swaps during concrete execution in order to show unsoundness.
+    sched_yield();
+    ++shared_count_copy;
+    shared_count = shared_count_copy;
+  }
+  pthread_exit(NULL);
+}
+
+pthread_t start_worker_thread(void)
+{
+  pthread_t worker_thread;
+  const pthread_attr_t *const attributes = NULL;
+  void *const worker_argument = NULL;
+  const int create_status =
+    pthread_create(&worker_thread, attributes, &worker, worker_argument);
+  assert(create_status == 0);
+  return worker_thread;
+}
+
+void join_thread(const pthread_t thread)
+{
+  const int join_status = pthread_join(thread, NULL);
+  assert(join_status == 0);
+}
+
+int main(void)
+{
+  const pthread_t worker_thread1 = start_worker_thread();
+  const pthread_t worker_thread2 = start_worker_thread();
+  join_thread(worker_thread1);
+  join_thread(worker_thread2);
+
+  // Check if the shared count has been incremented 200 times.
+  printf("The shared count is %d.\n", shared_count);
+  assert(shared_count == 200);
+  return EXIT_SUCCESS;
+}

--- a/regression/cbmc-sequentialization/pthread_mutex/no_mutex.desc
+++ b/regression/cbmc-sequentialization/pthread_mutex/no_mutex.desc
@@ -1,0 +1,13 @@
+FUTURE requires_posix_only_headers
+no_mutex.c
+
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION FAILED$
+--
+^warning: ignoring
+pointer handling for concurrency is unsound
+--
+Test that cbmc can detect the unsafe shared global access. This is demonstrated
+by the violation of the final assertion that the final value of the shared count
+is 200.

--- a/regression/cbmc-sequentialization/pthread_mutex/with_mutex.c
+++ b/regression/cbmc-sequentialization/pthread_mutex/with_mutex.c
@@ -1,0 +1,63 @@
+#include <assert.h>
+#include <pthread.h>
+#include <sched.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+int shared_count = 0;
+pthread_mutex_t mutex;
+
+void *worker(void *arguments)
+{
+  for(int i = 0; i < 100; ++i)
+  {
+    const int lock_error = pthread_mutex_lock(&mutex);
+    assert(!lock_error);
+    int shared_count_copy = shared_count;
+    // The following call to yield is here in order to increase the chance of
+    // thread swaps during concrete execution in order to show unsoundness.
+    sched_yield();
+    ++shared_count_copy;
+    shared_count = shared_count_copy;
+    const int unlock_error = pthread_mutex_unlock(&mutex);
+    assert(!unlock_error);
+  }
+  pthread_exit(NULL);
+}
+
+pthread_t start_worker_thread(void)
+{
+  pthread_t worker_thread;
+  const pthread_attr_t *const attributes = NULL;
+  void *const worker_argument = NULL;
+  const int create_status =
+    pthread_create(&worker_thread, attributes, &worker, worker_argument);
+  assert(create_status == 0);
+  return worker_thread;
+}
+
+void join_thread(const pthread_t thread)
+{
+  const int join_status = pthread_join(thread, NULL);
+  assert(join_status == 0);
+}
+
+int main(void)
+{
+  pthread_mutexattr_t *mutex_attributes = NULL;
+  int pthread_mutex_init_error = pthread_mutex_init(&mutex, mutex_attributes);
+  assert(!pthread_mutex_init_error);
+
+  const pthread_t worker_thread1 = start_worker_thread();
+  const pthread_t worker_thread2 = start_worker_thread();
+  join_thread(worker_thread1);
+  join_thread(worker_thread2);
+
+  // Check if the shared count has been incremented 200 times.
+  printf("The shared count is %d.\n", shared_count);
+  assert(shared_count == 200);
+
+  pthread_mutex_destroy(&mutex);
+  return EXIT_SUCCESS;
+}

--- a/regression/cbmc-sequentialization/pthread_mutex/with_mutex.desc
+++ b/regression/cbmc-sequentialization/pthread_mutex/with_mutex.desc
@@ -1,0 +1,12 @@
+FUTURE requires_posix_only_headers
+with_mutex.c
+
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring
+pointer handling for concurrency is unsound
+--
+Test that adding an appropriate mutex to the `no_mutex.c` example leads to cbmc
+considering the program to be sound.

--- a/regression/cbmc-sequentialization/pthread_self_equal/main.c
+++ b/regression/cbmc-sequentialization/pthread_self_equal/main.c
@@ -1,0 +1,34 @@
+#include <assert.h>
+#include <pthread.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+pthread_t worker_self_thread;
+
+void *worker(void *arguments)
+{
+  // Check pthread_self() returns a consistent value.
+  const pthread_t self1 = pthread_self();
+  const pthread_t self2 = pthread_self();
+  assert(pthread_equal(self1, self2));
+
+  worker_self_thread = self1;
+  pthread_exit(NULL);
+}
+
+int main(void)
+{
+  pthread_t worker_thread;
+  const pthread_attr_t *const attributes = NULL;
+  void *const worker_argument = NULL;
+  const int create_status =
+    pthread_create(&worker_thread, attributes, &worker, worker_argument);
+  assert(create_status == 0);
+  const int join_status = pthread_join(worker_thread, NULL);
+  assert(join_status == 0);
+
+  // Check main thread self is different from worker thread self.
+  const pthread_t main_thread = pthread_self();
+  assert(!pthread_equal(main_thread, worker_self_thread));
+  return EXIT_SUCCESS;
+}

--- a/regression/cbmc-sequentialization/pthread_self_equal/test.desc
+++ b/regression/cbmc-sequentialization/pthread_self_equal/test.desc
@@ -1,0 +1,11 @@
+FUTURE requires_posix_only_headers
+main.c
+
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring
+pointer handling for concurrency is unsound
+--
+Test sanity of values returned by pthread_self and pthread_equal.

--- a/regression/cbmc-sequentialization/rw_lock/race_test.c
+++ b/regression/cbmc-sequentialization/rw_lock/race_test.c
@@ -1,0 +1,2 @@
+#define NO_LOCKS
+#include "with_lock.c"

--- a/regression/cbmc-sequentialization/rw_lock/race_test.c
+++ b/regression/cbmc-sequentialization/rw_lock/race_test.c
@@ -1,2 +1,102 @@
-#define NO_LOCKS
-#include "with_lock.c"
+#include <assert.h>
+#include <pthread.h>
+#include <sched.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+struct sharedt
+{
+  int a;
+  int b;
+  int c;
+};
+
+void set_state1(struct sharedt *shared)
+{
+  shared->a = 1;
+  shared->b = 2;
+  // The following call to yield is here in order to increase the chance of
+  // thread swaps during concrete execution in order to show unsoundness.
+  sched_yield();
+  shared->c = 3;
+}
+
+void set_state2(struct sharedt *shared)
+{
+  shared->a = 4;
+  shared->b = 5;
+  // The following call to yield is here in order to increase the chance of
+  // thread swaps during concrete execution in order to show unsoundness.
+  sched_yield();
+  shared->c = 6;
+}
+
+void *writer1(void *arguments)
+{
+  struct sharedt *shared = (struct sharedt *)arguments;
+  for(int i = 0; i < 1000; ++i)
+  {
+    set_state1(shared);
+  }
+  pthread_exit(NULL);
+}
+
+void *writer2(void *arguments)
+{
+  struct sharedt *shared = (struct sharedt *)arguments;
+  for(int i = 0; i < 1000; ++i)
+  {
+    set_state2(shared);
+  }
+  pthread_exit(NULL);
+}
+
+void *checker(void *arguments)
+{
+  struct sharedt *shared = (struct sharedt *)arguments;
+  for(int i = 0; i < 1000; ++i)
+  {
+    const bool is_state1 = shared->a == 1 && shared->b == 2 && shared->c == 3;
+    // The following call to yield is here in order to increase the chance of
+    // thread swaps during concrete execution in order to show unsoundness.
+    sched_yield();
+    const bool is_state2 = shared->a == 4 && shared->b == 5 && shared->c == 6;
+    assert(is_state1 != is_state2);
+    printf(is_state1 ? "State1\n" : "State2\n");
+  }
+  pthread_exit(NULL);
+}
+
+int main(void)
+{
+  struct sharedt shared;
+  set_state1(&shared);
+
+  const pthread_attr_t *const attributes = NULL;
+  void *const thread_argument = &shared;
+  pthread_t thread_writer1;
+  assert(
+    !pthread_create(&thread_writer1, attributes, &writer1, thread_argument));
+  pthread_t thread_writer2;
+  assert(
+    !pthread_create(&thread_writer2, attributes, &writer2, thread_argument));
+
+  pthread_t thread_checker1;
+  pthread_t thread_checker2;
+  pthread_t thread_checker3;
+  assert(
+    !pthread_create(&thread_checker1, attributes, &checker, thread_argument));
+  assert(
+    !pthread_create(&thread_checker2, attributes, &checker, thread_argument));
+  assert(
+    !pthread_create(&thread_checker3, attributes, &checker, thread_argument));
+
+  assert(!pthread_join(thread_writer1, NULL));
+  assert(!pthread_join(thread_writer2, NULL));
+  assert(!pthread_join(thread_checker1, NULL));
+  assert(!pthread_join(thread_checker2, NULL));
+  assert(!pthread_join(thread_checker3, NULL));
+
+  return EXIT_SUCCESS;
+}

--- a/regression/cbmc-sequentialization/rw_lock/race_test.desc
+++ b/regression/cbmc-sequentialization/rw_lock/race_test.desc
@@ -1,0 +1,12 @@
+FUTURE requires_posix_only_headers
+with_lock.c
+--unwind 10
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION FAILED$
+--
+^warning: ignoring
+pointer handling for concurrency is unsound
+--
+Test that concurrent reading and and writing to a shared structure allows its
+state to become inconsistent.

--- a/regression/cbmc-sequentialization/rw_lock/with_lock.c
+++ b/regression/cbmc-sequentialization/rw_lock/with_lock.c
@@ -1,0 +1,138 @@
+#include <assert.h>
+#include <pthread.h>
+#include <sched.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+struct sharedt
+{
+#ifndef NO_LOCKS
+  pthread_rwlock_t lock;
+#endif
+  int a;
+  int b;
+  int c;
+};
+
+void set_state1(struct sharedt *shared)
+{
+  shared->a = 1;
+  shared->b = 2;
+  // The following call to yield is here in order to increase the chance of
+  // thread swaps during concrete execution in order to show unsoundness.
+  sched_yield();
+  shared->c = 3;
+}
+
+void set_state2(struct sharedt *shared)
+{
+  shared->a = 4;
+  shared->b = 5;
+  // The following call to yield is here in order to increase the chance of
+  // thread swaps during concrete execution in order to show unsoundness.
+  sched_yield();
+  shared->c = 6;
+}
+
+void *writer1(void *arguments)
+{
+  struct sharedt *shared = (struct sharedt *)arguments;
+  for(int i = 0; i < 1000; ++i)
+  {
+#ifndef NO_LOCKS
+    const int lock_error = pthread_rwlock_wrlock(&(shared->lock));
+    assert(!lock_error);
+#endif
+    set_state1(shared);
+#ifndef NO_LOCKS
+    const int unlock_error = pthread_rwlock_unlock(&(shared->lock));
+    assert(!unlock_error);
+#endif
+  }
+  pthread_exit(NULL);
+}
+
+void *writer2(void *arguments)
+{
+  struct sharedt *shared = (struct sharedt *)arguments;
+  for(int i = 0; i < 1000; ++i)
+  {
+#ifndef NO_LOCKS
+    const int lock_error = pthread_rwlock_wrlock(&(shared->lock));
+    assert(!lock_error);
+#endif
+    set_state2(shared);
+#ifndef NO_LOCKS
+    const int unlock_error = pthread_rwlock_unlock(&(shared->lock));
+    assert(!unlock_error);
+#endif
+  }
+  pthread_exit(NULL);
+}
+
+void *checker(void *arguments)
+{
+  struct sharedt *shared = (struct sharedt *)arguments;
+  for(int i = 0; i < 1000; ++i)
+  {
+#ifndef NO_LOCKS
+    const int lock_error = pthread_rwlock_rdlock(&(shared->lock));
+    assert(!lock_error);
+#endif
+    const bool is_state1 = shared->a == 1 && shared->b == 2 && shared->c == 3;
+    // The following call to yield is here in order to increase the chance of
+    // thread swaps during concrete execution in order to show unsoundness.
+    sched_yield();
+    const bool is_state2 = shared->a == 4 && shared->b == 5 && shared->c == 6;
+    assert(is_state1 != is_state2);
+#ifndef NO_LOCKS
+    const int unlock_error = pthread_rwlock_unlock(&(shared->lock));
+    assert(!unlock_error);
+#endif
+    printf(is_state1 ? "State1\n" : "State2\n");
+  }
+  pthread_exit(NULL);
+}
+
+int main(void)
+{
+  struct sharedt shared;
+  set_state1(&shared);
+#ifndef NO_LOCKS
+  const pthread_rwlockattr_t *init_attributes = NULL;
+  const int init_error = pthread_rwlock_init(&(shared.lock), init_attributes);
+  assert(!init_error);
+#endif
+
+  const pthread_attr_t *const attributes = NULL;
+  void *const thread_argument = &shared;
+  pthread_t thread_writer1;
+  assert(
+    !pthread_create(&thread_writer1, attributes, &writer1, thread_argument));
+  pthread_t thread_writer2;
+  assert(
+    !pthread_create(&thread_writer2, attributes, &writer2, thread_argument));
+
+  pthread_t thread_checker1;
+  pthread_t thread_checker2;
+  pthread_t thread_checker3;
+  assert(
+    !pthread_create(&thread_checker1, attributes, &checker, thread_argument));
+  assert(
+    !pthread_create(&thread_checker2, attributes, &checker, thread_argument));
+  assert(
+    !pthread_create(&thread_checker3, attributes, &checker, thread_argument));
+
+  assert(!pthread_join(thread_writer1, NULL));
+  assert(!pthread_join(thread_writer2, NULL));
+  assert(!pthread_join(thread_checker1, NULL));
+  assert(!pthread_join(thread_checker2, NULL));
+  assert(!pthread_join(thread_checker3, NULL));
+
+#ifndef NO_LOCKS
+  const int destroy_error = pthread_rwlock_destroy(&(shared.lock));
+  assert(!destroy_error);
+#endif
+  return EXIT_SUCCESS;
+}

--- a/regression/cbmc-sequentialization/rw_lock/with_lock.desc
+++ b/regression/cbmc-sequentialization/rw_lock/with_lock.desc
@@ -1,0 +1,12 @@
+FUTURE requires_posix_only_headers
+with_lock.c
+--unwind 10
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring
+pointer handling for concurrency is unsound
+--
+Test that an appropriate read write lock keeps the state of a shared structure
+consistent.


### PR DESCRIPTION
This PR adds concurrency examples to the regression tests in preparation for the planned sequentialization work.
<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
