### PR TITLE
Remove line breaks from the body of the text on the release page.

### DIFF
--- a/.github/workflows/regular-release.yaml
+++ b/.github/workflows/regular-release.yaml
@@ -38,6 +38,7 @@ jobs:
             ## MacOS
 
             On MacOS, install CBMC using [Homebrew](https://brew.sh/) with
+
             ```sh
             brew install cbmc
             ```
@@ -50,8 +51,7 @@ jobs:
 
             ## Ubuntu
 
-            On Ubuntu, install CBMC by downloading the *.deb package below for your version of Ubuntu
-            and install with one of
+            On Ubuntu, install CBMC by downloading the *.deb package below for your version of Ubuntu and install with one of
 
             ```sh
             # Ubuntu 18:
@@ -62,9 +62,7 @@ jobs:
 
             ## Windows
 
-            On Windows, install CBMC by downloading the `${{ env.CBMC_TAG }}-win64.msi` installer
-            below, double-clicking on the installer to run it, and adding the folder
-            `C:\Program Files\cbmc\bin` in your `PATH` environment variable.
+            On Windows, install CBMC by downloading the `${{ env.CBMC_TAG }}-win64.msi` installer below, double-clicking on the installer to run it, and adding the folder `C:\Program Files\cbmc\bin` in your `PATH` environment variable.
 
             For installation from the windows command prompt, run:
 
@@ -73,11 +71,8 @@ jobs:
             PATH="c:\program files\cbmc\bin";%PATH%
             ```
 
-            Note that we depend on the Visual C++ redistributables. You likely already have these,
-            if not please download and run vcredist.x64.exe from Microsoft to install them prior
-            to running cbmc, or make sure you have Visual Studio 2019 installed.
+            Note that we depend on the Visual C++ redistributables. You likely already have these, if not please download and run vcredist.x64.exe from Microsoft to install them prior to running cbmc, or make sure you have Visual Studio 2019 installed.
 
-            You can download either [Visual Studio 2019 Community Edition](https://visualstudio.microsoft.com/vs/community/)
-            or the [Visual C++ Redistributables](https://support.microsoft.com/en-gb/help/2977003/the-latest-supported-visual-c-downloads) from Microsoft for free.
+            You can download either [Visual Studio 2019 Community Edition](https://visualstudio.microsoft.com/vs/community/) or the [Visual C++ Redistributables](https://support.microsoft.com/en-gb/help/2977003/the-latest-supported-visual-c-downloads) from Microsoft for free.
           draft: false
           prerelease: false

--- a/.github/workflows/regular-release.yaml
+++ b/.github/workflows/regular-release.yaml
@@ -68,7 +68,7 @@ jobs:
 
             ```sh
             msiexec /i ${{ env.CBMC_TAG }}-win64.msi
-            PATH="c:\program files\cbmc\bin";%PATH%
+            PATH="C:\Program Files\cbmc\bin";%PATH%
             ```
 
             Note that we depend on the Visual C++ redistributables. You likely already have these, if not please download and run vcredist.x64.exe from Microsoft to install them prior to running cbmc, or make sure you have Visual Studio 2019 installed.


### PR DESCRIPTION
The yaml file regular-release.yaml generating the release page include
the body of text for the release page.  The definition of the body
include line breaks to make the text fit within 80 characters in the
yaml file, but the line breaks in the yaml file are treated as line
breaks in the resulting markdown file, and the text does not flow well
in a web browser.

This page just removes the line breaks within a paragraph of text.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
