### PR TITLE
Add .github/ responsible members to codeowners.

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -64,3 +64,6 @@ CMakeLists.txt @hannes-steffenhagen-diffblue
 
 /scripts/ @diffblue/devops @thk123 @forejtv @peterschrammel
 /scripts/expected_doxygen_warnings.txt
+
+# CI pipeline is the responsibility of the Open Source maintenance team at Diffblue.
+/.github/ @diffblue/diffblue-opensource


### PR DESCRIPTION
Add the members of the diffblue open-source team, the internal team responsible for maintenance of CBMC to the codeowners file as responsible for the github tooling and CI pipeline.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
