### PR TITLE
Performance optimisation - Use `unordered_map` in `numbering` instead of `map`

### DIFF
--- a/src/analyses/custom_bitvector_analysis.h
+++ b/src/analyses/custom_bitvector_analysis.h
@@ -163,7 +163,7 @@ public:
 
   unsigned get_bit_nr(const exprt &);
 
-  typedef numbering<irep_idt> bitst;
+  typedef numberingt<irep_idt> bitst;
   bitst bits;
 
 protected:

--- a/src/analyses/escape_analysis.h
+++ b/src/analyses/escape_analysis.h
@@ -120,7 +120,7 @@ protected:
   {
   }
 
-  numbering<irep_idt> bits;
+  numberingt<irep_idt> bits;
 
   void insert_cleanup(
     goto_functionst::goto_functiont &,

--- a/src/analyses/invariant_set.h
+++ b/src/analyses/invariant_set.h
@@ -55,7 +55,7 @@ public:
 protected:
   const namespacet &ns;
 
-  typedef hash_numbering<irep_idt, irep_id_hash> mapt;
+  typedef numbering<irep_idt> mapt;
   mapt map;
 
   struct entryt

--- a/src/analyses/invariant_set.h
+++ b/src/analyses/invariant_set.h
@@ -55,7 +55,7 @@ public:
 protected:
   const namespacet &ns;
 
-  typedef numbering<irep_idt> mapt;
+  typedef numberingt<irep_idt> mapt;
   mapt map;
 
   struct entryt

--- a/src/analyses/local_bitvector_analysis.h
+++ b/src/analyses/local_bitvector_analysis.h
@@ -183,7 +183,7 @@ protected:
 
   typedef std::stack<unsigned> work_queuet;
 
-  numbering<irep_idt> pointers;
+  numberingt<irep_idt> pointers;
 
   // pointers -> flagst
   // This is a vector, so it's fast.

--- a/src/analyses/local_may_alias.h
+++ b/src/analyses/local_may_alias.h
@@ -60,7 +60,7 @@ protected:
 
   typedef std::stack<local_cfgt::node_nrt> work_queuet;
 
-  mutable numbering<exprt> objects;
+  mutable numberingt<exprt, irep_hash> objects;
 
   typedef unsigned_union_find alias_sett;
 

--- a/src/goto-programs/vcd_goto_trace.cpp
+++ b/src/goto-programs/vcd_goto_trace.cpp
@@ -82,7 +82,7 @@ void output_vcd(
 
   // we first collect all variables that are assigned
 
-  numbering<irep_idt> n;
+  numberingt<irep_idt> n;
 
   for(const auto &step : goto_trace.steps)
   {

--- a/src/pointer-analysis/object_numbering.h
+++ b/src/pointer-analysis/object_numbering.h
@@ -25,6 +25,6 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/expr.h>
 #include <util/numbering.h>
 
-typedef hash_numbering<exprt, irep_hash> object_numberingt;
+typedef numberingt<exprt, irep_hash> object_numberingt;
 
 #endif // CPROVER_POINTER_ANALYSIS_OBJECT_NUMBERING_H

--- a/src/pointer-analysis/value_set_fi.cpp
+++ b/src/pointer-analysis/value_set_fi.cpp
@@ -29,7 +29,7 @@ Author: Daniel Kroening, kroening@kroening.com
 const value_set_fit::object_map_dt value_set_fit::object_map_dt::blank{};
 
 object_numberingt value_set_fit::object_numbering;
-hash_numbering<irep_idt, irep_id_hash> value_set_fit::function_numbering;
+numberingt<irep_idt> value_set_fit::function_numbering;
 
 static const char *alloc_adapter_prefix="alloc_adaptor::";
 

--- a/src/pointer-analysis/value_set_fi.h
+++ b/src/pointer-analysis/value_set_fi.h
@@ -39,7 +39,7 @@ public:
   unsigned to_function, from_function;
   unsigned to_target_index, from_target_index;
   static object_numberingt object_numbering;
-  static hash_numbering<irep_idt, irep_id_hash> function_numbering;
+  static numberingt<irep_idt> function_numbering;
 
   void set_from(const irep_idt &function, unsigned inx)
   {

--- a/src/pointer-analysis/value_set_fivr.h
+++ b/src/pointer-analysis/value_set_fivr.h
@@ -36,7 +36,7 @@ public:
   unsigned to_function, from_function;
   unsigned to_target_index, from_target_index;
   static object_numberingt object_numbering;
-  static hash_numbering<irep_idt, irep_id_hash> function_numbering;
+  static numberingt<irep_idt> function_numbering;
 
   void set_from(const irep_idt &function, unsigned inx)
   {

--- a/src/pointer-analysis/value_set_fivrns.h
+++ b/src/pointer-analysis/value_set_fivrns.h
@@ -37,7 +37,7 @@ public:
   unsigned to_function, from_function;
   unsigned to_target_index, from_target_index;
   static object_numberingt object_numbering;
-  static hash_numbering<irep_idt, irep_id_hash> function_numbering;
+  static numberingt<irep_idt> function_numbering;
 
   void set_from(const irep_idt &function, unsigned inx)
   {

--- a/src/solvers/flattening/arrays.h
+++ b/src/solvers/flattening/arrays.h
@@ -68,7 +68,7 @@ protected:
   array_equalitiest array_equalities;
 
   // this is used to find the clusters of arrays being compared
-  union_find<exprt> arrays;
+  union_find<exprt, irep_hash> arrays;
 
   // this tracks the array indicies for each array
   typedef std::set<exprt> index_sett;

--- a/src/solvers/flattening/boolbv.h
+++ b/src/solvers/flattening/boolbv.h
@@ -262,7 +262,7 @@ protected:
   offset_mapt build_offset_map(const struct_typet &src);
 
   // strings
-  numbering<irep_idt> string_numbering;
+  numberingt<irep_idt> string_numbering;
 };
 
 #endif // CPROVER_SOLVERS_FLATTENING_BOOLBV_H

--- a/src/solvers/flattening/pointer_logic.h
+++ b/src/solvers/flattening/pointer_logic.h
@@ -23,7 +23,7 @@ class pointer_logict
 {
 public:
   // this numbers the objects
-  hash_numbering<exprt, irep_hash> objects;
+  numberingt<exprt, irep_hash> objects;
 
   struct pointert
   {

--- a/src/util/irep_hash_container.h
+++ b/src/util/irep_hash_container.h
@@ -69,8 +69,7 @@ protected:
     std::size_t operator()(const packedt &p) const;
   };
 
-  typedef hash_numbering<packedt, vector_hasht> numberingt;
-  numberingt numbering;
+  numberingt<packedt, vector_hasht> numbering;
 
   void pack(const irept &irep, packedt &);
 

--- a/src/util/numbering.h
+++ b/src/util/numbering.h
@@ -9,7 +9,6 @@ Author: Daniel Kroening, kroening@kroening.com
 #ifndef CPROVER_UTIL_NUMBERING_H
 #define CPROVER_UTIL_NUMBERING_H
 
-#include <map>
 #include <unordered_map>
 #include <vector>
 
@@ -108,9 +107,6 @@ public:
     return data_.cend();
   }
 };
-
-template <typename Key>
-using numbering = template_numberingt<std::map<Key, std::size_t>>; // NOLINT
 
 /// \tparam keyt: The type of keys which will be numbered.
 /// \tparam hasht: The type of hashing functor used to hash keys.

--- a/src/util/numbering.h
+++ b/src/util/numbering.h
@@ -112,10 +112,6 @@ public:
 template <typename Key>
 using numbering = template_numberingt<std::map<Key, std::size_t>>; // NOLINT
 
-template <typename Key, typename Hash>
-using hash_numbering = // NOLINT
-  template_numberingt<std::unordered_map<Key, std::size_t, Hash>>;
-
 /// \tparam keyt: The type of keys which will be numbered.
 /// \tparam hasht: The type of hashing functor used to hash keys.
 template <typename keyt, typename hasht = std::hash<keyt>>

--- a/src/util/numbering.h
+++ b/src/util/numbering.h
@@ -15,18 +15,19 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "invariant.h"
 #include "optional.h"
 
-/// \tparam Map: a map from a key type to some numeric type
-template <typename Map>
-class template_numberingt final
+/// \tparam keyt: The type of keys which will be numbered.
+/// \tparam hasht: The type of hashing functor used to hash keys.
+template <typename keyt, typename hasht = std::hash<keyt>>
+class numberingt final
 {
 public:
-  using number_type = typename Map::mapped_type; // NOLINT
-  using key_type = typename Map::key_type;       // NOLINT
+  using number_type = std::size_t; // NOLINT
+  using key_type = keyt;           // NOLINT
 
 private:
   using data_typet = std::vector<key_type>; // NOLINT
   data_typet data_;
-  Map numbers_;
+  std::unordered_map<keyt, number_type, hasht> numbers_;
 
 public:
   using size_type = typename data_typet::size_type;           // NOLINT
@@ -108,10 +109,5 @@ public:
   }
 };
 
-/// \tparam keyt: The type of keys which will be numbered.
-/// \tparam hasht: The type of hashing functor used to hash keys.
-template <typename keyt, typename hasht = std::hash<keyt>>
-using numberingt =
-  template_numberingt<std::unordered_map<keyt, std::size_t, hasht>>;
 
 #endif // CPROVER_UTIL_NUMBERING_H

--- a/src/util/numbering.h
+++ b/src/util/numbering.h
@@ -116,4 +116,10 @@ template <typename Key, typename Hash>
 using hash_numbering = // NOLINT
   template_numberingt<std::unordered_map<Key, std::size_t, Hash>>;
 
+/// \tparam keyt: The type of keys which will be numbered.
+/// \tparam hasht: The type of hashing functor used to hash keys.
+template <typename keyt, typename hasht = std::hash<keyt>>
+using numberingt =
+  template_numberingt<std::unordered_map<keyt, std::size_t, hasht>>;
+
 #endif // CPROVER_UTIL_NUMBERING_H

--- a/src/util/union_find.h
+++ b/src/util/union_find.h
@@ -132,11 +132,13 @@ public:
   size_type get_other(size_type a);
 };
 
-template <typename T>
+/// \tparam T: The type of values stored.
+/// \tparam hasht: The type of hash used for looking up the value numbering.
+template <typename T, typename hasht = std::hash<T>>
 // NOLINTNEXTLINE(readability/identifiers)
 class union_find final
 {
-  using numbering_typet = numbering<T>;
+  using numbering_typet = numberingt<T, hasht>;
   numbering_typet numbers;
 
   // NOLINTNEXTLINE(readability/identifiers)

--- a/src/util/union_find.h
+++ b/src/util/union_find.h
@@ -136,19 +136,19 @@ template <typename T>
 // NOLINTNEXTLINE(readability/identifiers)
 class union_find final
 {
-  typedef numbering<T> numbering_typet;
+  using numbering_typet = numbering<T>;
   numbering_typet numbers;
 
   // NOLINTNEXTLINE(readability/identifiers)
-  typedef typename numbering_typet::number_type number_type;
+  using number_type = typename numbering_typet::number_type;
 
 public:
   // NOLINTNEXTLINE(readability/identifiers)
-  typedef typename numbering_typet::size_type size_type;
+  using size_type = typename numbering_typet::size_type;
   // NOLINTNEXTLINE(readability/identifiers)
-  typedef typename numbering_typet::iterator iterator;
+  using iterator = typename numbering_typet::iterator;
   // NOLINTNEXTLINE(readability/identifiers)
-  typedef typename numbering_typet::const_iterator const_iterator;
+  using const_iterator = typename numbering_typet::const_iterator;
 
   // true == already in same set
   bool make_union(const T &a, const T &b)
@@ -279,7 +279,7 @@ public:
 
 protected:
   unsigned_union_find uuf;
-  typedef numbering_typet subt;
+  using subt = numbering_typet;
 };
 
 #endif // CPROVER_UTIL_UNION_FIND_H

--- a/src/util/union_find.h
+++ b/src/util/union_find.h
@@ -160,8 +160,7 @@ public:
   }
 
   // true == already in same set
-  bool make_union(typename numbering<T>::const_iterator it_a,
-                  typename numbering<T>::const_iterator it_b)
+  bool make_union(const_iterator it_a, const_iterator it_b)
   {
     size_type na=it_a-numbers.begin(), nb=it_b-numbers.begin();
     bool is_union=find_number(na)==find_number(nb);
@@ -183,13 +182,12 @@ public:
   }
 
   // are 'a' and 'b' in the same set?
-  bool same_set(typename numbering<T>::const_iterator it_a,
-                typename numbering<T>::const_iterator it_b) const
+  bool same_set(const_iterator it_a, const_iterator it_b) const
   {
     return uuf.same_set(it_a-numbers.begin(), it_b-numbers.begin());
   }
 
-  const T &find(typename numbering<T>::const_iterator it) const
+  const T &find(const_iterator it) const
   {
     return numbers[find_number(it-numbers.begin())];
   }
@@ -199,7 +197,7 @@ public:
     return numbers[find_number(number(a))];
   }
 
-  size_type find_number(typename numbering<T>::const_iterator it) const
+  size_type find_number(const_iterator it) const
   {
     return find_number(it-numbers.begin());
   }
@@ -228,7 +226,7 @@ public:
       return uuf.is_root(na);
   }
 
-  bool is_root(typename numbering<T>::const_iterator it) const
+  bool is_root(const_iterator it) const
   {
     return uuf.is_root(it-numbers.begin());
   }
@@ -251,7 +249,7 @@ public:
     uuf.clear();
   }
 
-  void isolate(typename numbering<T>::const_iterator it)
+  void isolate(const_iterator it)
   {
     uuf.isolate(it-numbers.begin());
   }
@@ -281,7 +279,7 @@ public:
 
 protected:
   unsigned_union_find uuf;
-  typedef numbering<T> subt;
+  typedef numbering_typet subt;
 };
 
 #endif // CPROVER_UTIL_UNION_FIND_H


### PR DESCRIPTION
The commit which specifically gives the performance improvement is titled "Make `union_find` use hashes for numbering". The other commits are related refactoring.

Using `unordered_map` in `numbering` instead of `map`, changes `union_find`, which changes `arrays`, where the performance issue was seen. This change avoids slow lookups into `std::map` caused by long running `irept::operator<` calls. I have an example where cbmc spent approximately 70% of runtime in `irept::operator<` before this change and approximately 1% of runtime in hashing/ordering after this change.

Run time on example exercising arrays code before this PR -
real	2m39.018s
user	2m37.394s
sys	0m1.608s

Run time on example exercising arrays code after this PR -
real	0m30.897s
user	0m29.476s
sys	0m1.404s

Gprof before (top results up to `has_byte_operator` + `irept::hash()`) -
```
Each sample counts as 0.01 seconds.
  %   cumulative   self              self     total           
 time   seconds   seconds    calls   s/call   s/call  name    
 44.90     21.08    21.08  2025113     0.00     0.00  irept::compare(irept const&) const
 26.84     33.68    12.60 4483321688     0.00     0.00  irept::number_of_non_comments(std::map<dstringt, irept, std::less<dstringt>, std::allocator<std::pair<dstringt const, irept> > > const&)
  6.54     36.75     3.07 52261322     0.00     0.00  Minisat::SimpSolver::addClause_(Minisat::vec<Minisat::Lit>&)
  3.43     38.36     1.61 52261322     0.00     0.00  Minisat::Solver::addClause_(Minisat::vec<Minisat::Lit>&)
  2.26     39.42     1.06    58881     0.00     0.00  has_byte_operator(exprt const&)
  0.06     46.03     0.03  3365106     0.00     0.00  irept::hash() const
```

Gprof after (top results up to `has_byte_operator` + `irept::hash()`) -
```
Each sample counts as 0.01 seconds.
  %   cumulative   self              self     total           
 time   seconds   seconds    calls   s/call   s/call  name    
 27.40      3.11     3.11 52261322     0.00     0.00  Minisat::SimpSolver::addClause_(Minisat::vec<Minisat::Lit>&)
 13.74      4.67     1.56 52261322     0.00     0.00  Minisat::Solver::addClause_(Minisat::vec<Minisat::Lit>&)
  5.73      5.32     0.65 10600597     0.00     0.00  Minisat::SimpSolver::newVar(Minisat::lbool, bool)
  5.29      5.92     0.60    58881     0.00     0.00  has_byte_operator(exprt const&)
  0.18     10.51     0.02  3424407     0.00     0.00  irept::hash() const
```

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [x] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
