### PR TITLE
Use bitvector types to implement __builtin_{add,sub,mul}_overflow

### DIFF
--- a/regression/cbmc/gcc_builtin_add_overflow/main.c
+++ b/regression/cbmc/gcc_builtin_add_overflow/main.c
@@ -110,6 +110,15 @@ void check_generic(void)
   assert(0 && "reachability");
 }
 
+void check_non_const()
+{
+  int a, b, c, d, r;
+  // this may overflow (negated assertion fails)
+  assert(!__builtin_add_overflow(a, b, &r));
+  // but need not overflow (assertion fails)
+  assert(__builtin_add_overflow(c, d, &c));
+}
+
 int main(void)
 {
   check_int();
@@ -119,4 +128,5 @@ int main(void)
   check_unsigned_long();
   check_unsigned_long_long();
   check_generic();
+  check_non_const();
 }

--- a/regression/cbmc/gcc_builtin_add_overflow/main.c
+++ b/regression/cbmc/gcc_builtin_add_overflow/main.c
@@ -110,6 +110,17 @@ void check_generic(void)
   assert(0 && "reachability");
 }
 
+void check_generic_p(void)
+{
+  unsigned char small_result = 0;
+  signed long long big_result = 0;
+  assert(!__builtin_add_overflow_p(17, 25, small_result));
+  assert(small_result == 0);
+  assert(!__builtin_add_overflow_p(17, 25, big_result));
+  assert(big_result == 0);
+  assert(0 && "reachability");
+}
+
 void check_non_const()
 {
   int a, b, c, d, r;
@@ -128,5 +139,6 @@ int main(void)
   check_unsigned_long();
   check_unsigned_long_long();
   check_generic();
+  check_generic_p();
   check_non_const();
 }

--- a/regression/cbmc/gcc_builtin_add_overflow/test.desc
+++ b/regression/cbmc/gcc_builtin_add_overflow/test.desc
@@ -57,6 +57,11 @@ main.c
 \[check_generic.assertion.9\] line \d+ assertion big_result == 2ll \* .*: SUCCESS
 \[check_generic.assertion.10\] line \d+ assertion __builtin_add_overflow\(.* / 2 \+ 1, .*/ 2 \+ 1, &big_result\): SUCCESS
 \[check_generic.assertion.11\] line \d+ assertion 0 && "reachability": FAILURE
+\[check_generic_p.assertion.1\] line \d+ assertion !__builtin_add_overflow_p\(17, 25, small_result\): SUCCESS
+\[check_generic_p.assertion.2\] line \d+ assertion small_result == 0: SUCCESS
+\[check_generic_p.assertion.3\] line \d+ assertion !__builtin_add_overflow_p\(17, 25, big_result\): SUCCESS
+\[check_generic_p.assertion.4\] line \d+ assertion big_result == 0: SUCCESS
+\[check_generic_p.assertion.5\] line \d+ assertion 0 && "reachability": FAILURE
 \[check_non_const\.assertion\.1\] line \d+ assertion !__builtin_add_overflow\(a, b, &r\): FAILURE
 \[check_non_const\.assertion\.2\] line \d+ assertion __builtin_add_overflow\(c, d, &c\): FAILURE
 VERIFICATION FAILED

--- a/regression/cbmc/gcc_builtin_add_overflow/test.desc
+++ b/regression/cbmc/gcc_builtin_add_overflow/test.desc
@@ -57,6 +57,8 @@ main.c
 \[check_generic.assertion.9\] line \d+ assertion big_result == 2ll \* .*: SUCCESS
 \[check_generic.assertion.10\] line \d+ assertion __builtin_add_overflow\(.* / 2 \+ 1, .*/ 2 \+ 1, &big_result\): SUCCESS
 \[check_generic.assertion.11\] line \d+ assertion 0 && "reachability": FAILURE
+\[check_non_const\.assertion\.1\] line \d+ assertion !__builtin_add_overflow\(a, b, &r\): FAILURE
+\[check_non_const\.assertion\.2\] line \d+ assertion __builtin_add_overflow\(c, d, &c\): FAILURE
 VERIFICATION FAILED
 ^EXIT=10$
 ^SIGNAL=0$

--- a/src/ansi-c/c_expr.h
+++ b/src/ansi-c/c_expr.h
@@ -108,9 +108,9 @@ inline shuffle_vector_exprt &to_shuffle_vector_expr(exprt &expr)
 }
 
 /// \brief A Boolean expression returning true, iff the result of performing
-/// operation \c kind on operands \c lhs and \c rhs in infinite-precision
-/// arithmetic cannot be represented in the type of the object that \c result
-/// points to.
+/// operation \c kind on operands \c a and \c b in infinite-precision arithmetic
+/// cannot be represented in the type of the object that \c result points to (or
+/// the type of \c result, if it is not a pointer).
 /// If \c result is a pointer, the result of the operation is stored in the
 /// object pointed to by \c result.
 class side_effect_expr_overflowt : public side_effect_exprt

--- a/src/ansi-c/c_typecheck_expr.cpp
+++ b/src/ansi-c/c_typecheck_expr.cpp
@@ -29,6 +29,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/range.h>
 #include <util/simplify_expr.h>
 #include <util/string_constant.h>
+#include <util/suffix.h>
 
 #include <goto-programs/adjust_float_expressions.h>
 
@@ -3012,7 +3013,10 @@ exprt c_typecheck_baset::do_special_functions(
   else if(
     identifier == "__builtin_add_overflow" ||
     identifier == "__builtin_sub_overflow" ||
-    identifier == "__builtin_mul_overflow")
+    identifier == "__builtin_mul_overflow" ||
+    identifier == "__builtin_add_overflow_p" ||
+    identifier == "__builtin_sub_overflow_p" ||
+    identifier == "__builtin_mul_overflow_p")
   {
     // check function signature
     if(expr.arguments().size() != 3)
@@ -3028,47 +3032,52 @@ exprt c_typecheck_baset::do_special_functions(
 
     auto lhs = expr.arguments()[0];
     auto rhs = expr.arguments()[1];
-    auto result_ptr = expr.arguments()[2];
+    auto result = expr.arguments()[2];
+
+    const bool is__p_variant = has_suffix(id2string(identifier), "_p");
 
     {
       auto const raise_wrong_argument_error =
-        [this,
-         identifier](const exprt &wrong_argument, std::size_t argument_number) {
+        [this, identifier](
+          const exprt &wrong_argument, std::size_t argument_number, bool _p) {
           std::ostringstream error_message;
           error_message << wrong_argument.source_location().as_string() << ": "
                         << identifier << " has signature " << identifier
-                        << "(integral, integral, integral*), "
+                        << "(integral, integral, integral" << (_p ? "" : "*")
+                        << "), "
                         << "but argument " << argument_number << " ("
                         << expr2c(wrong_argument, *this) << ") has type `"
                         << type2c(wrong_argument.type(), *this) << '`';
           throw invalid_source_file_exceptiont{error_message.str()};
         };
-      for(auto const arg_index : {0, 1})
+      for(int arg_index = 0; arg_index <= (!is__p_variant ? 1 : 2); ++arg_index)
       {
         auto const &argument = expr.arguments()[arg_index];
 
         if(!is_signed_or_unsigned_bitvector(argument.type()))
         {
-          raise_wrong_argument_error(argument, arg_index + 1);
+          raise_wrong_argument_error(argument, arg_index + 1, is__p_variant);
         }
       }
       if(
-        result_ptr.type().id() != ID_pointer ||
-        !is_signed_or_unsigned_bitvector(result_ptr.type().subtype()))
+        !is__p_variant &&
+        (result.type().id() != ID_pointer ||
+         !is_signed_or_unsigned_bitvector(result.type().subtype())))
       {
-        raise_wrong_argument_error(result_ptr, 3);
+        raise_wrong_argument_error(result, 3, is__p_variant);
       }
     }
 
     irep_idt kind =
-      (identifier == "__builtin_add_overflow")
+      has_prefix(id2string(identifier), "__builtin_add_overflow")
         ? ID_plus
-        : (identifier == "__builtin_sub_overflow") ? ID_minus : ID_mult;
+        : has_prefix(id2string(identifier), "__builtin_sub_overflow") ? ID_minus
+                                                                      : ID_mult;
 
     return side_effect_expr_overflowt{kind,
                                       std::move(lhs),
                                       std::move(rhs),
-                                      std::move(result_ptr),
+                                      std::move(result),
                                       expr.source_location()};
   }
   else


### PR DESCRIPTION
The use of mathematical integers is not supported by the SAT back-end.
Although GCC's specification describes the operations over mathematical
integers, the same precision can be achieved by using bitvector types of
sufficient width.

The implementation now also introduces a fresh symbol to store the
result of the full-precision operation. This ensures that the arguments
to __builtin_{add,sub,mul}_overflow are evaluated exactly once.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
