### PR TITLE
Make IPASIR support compile

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -163,4 +163,4 @@ cadical-download:
 doc :
 	doxygen
 
-.PHONY: ipasir-build minisat2-download glucose-download
+.PHONY: minisat2-download cudd-download glucose-download cadical-download

--- a/src/memory-analyzer/Makefile
+++ b/src/memory-analyzer/Makefile
@@ -7,7 +7,7 @@ SRC = \
 
 INCLUDES= -I ..
 
-LIBS = \
+OBJ += \
   ../ansi-c/ansi-c$(LIBEXT) \
   ../goto-programs/goto-programs$(LIBEXT) \
   ../linking/linking$(LIBEXT) \
@@ -15,6 +15,7 @@ LIBS = \
   ../big-int/big-int$(LIBEXT) \
   ../langapi/langapi$(LIBEXT)
 
+LIBS =
 
 CLEANFILES = memory-analyzer$(EXEEXT)
 

--- a/src/solvers/sat/satcheck_ipasir.cpp
+++ b/src/solvers/sat/satcheck_ipasir.cpp
@@ -90,6 +90,9 @@ void satcheck_ipasirt::lcnf(const bvt &bv)
   }
   ipasir_add(solver, 0); // terminate clause
 
+  with_solver_hardness(
+    [&bv](solver_hardnesst &hardness) { hardness.register_clause(bv); });
+
   clause_counter++;
 }
 
@@ -158,8 +161,8 @@ void satcheck_ipasirt::set_assignment(literalt a, bool value)
   INVARIANT(false, "method not supported");
 }
 
-satcheck_ipasirt::satcheck_ipasirt()
-: solver(nullptr)
+satcheck_ipasirt::satcheck_ipasirt(message_handlert &message_handler)
+  : cnf_solvert(message_handler), solver(nullptr)
 {
   INVARIANT(!solver, "there cannot be a solver already");
   solver=ipasir_init();

--- a/src/solvers/sat/satcheck_ipasir.h
+++ b/src/solvers/sat/satcheck_ipasir.h
@@ -14,11 +14,13 @@ instructions.
 
 #include "cnf.h"
 
+#include <solvers/hardness_collector.h>
+
 /// Interface for generic SAT solver interface IPASIR
-class satcheck_ipasirt:public cnf_solvert
+class satcheck_ipasirt : public cnf_solvert, public hardness_collectort
 {
 public:
-  satcheck_ipasirt();
+  satcheck_ipasirt(message_handlert &message_handler);
   virtual ~satcheck_ipasirt() override;
 
   /// This method returns the description produced by the linked SAT solver
@@ -44,12 +46,28 @@ public:
     return true;
   }
 
+  void
+  with_solver_hardness(std::function<void(solver_hardnesst &)> handler) override
+  {
+    if(solver_hardness.has_value())
+    {
+      handler(solver_hardness.value());
+    }
+  }
+
+  void enable_hardness_collection() override
+  {
+    solver_hardness = solver_hardnesst{};
+  }
+
 protected:
   resultt do_prop_solve() override;
 
   void *solver;
 
   bvt assumptions;
+
+  optionalt<solver_hardnesst> solver_hardness;
 };
 
 #endif // CPROVER_SOLVERS_SAT_SATCHECK_IPASIR_H


### PR DESCRIPTION
Hardness support was added to minisat2 only, and 89641a2 failed to
update the IPASIR interface.

Also cleanup the list of phony targets in the top-level Makefile, and
ensure that linking of the memory analyzer succeeds even in presence of
LIBS set on the make command line.

Fixes: #5345

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
