### PR TITLE
Remove exprt::make_bool

### DIFF
--- a/src/util/expr.cpp
+++ b/src/util/expr.cpp
@@ -105,15 +105,6 @@ bool exprt::is_false() const
          get(ID_value)==ID_false;
 }
 
-/// Replace the expression by a Boolean expression representing \p value.
-/// \param value: the Boolean value to give to the expression
-/// \deprecated use constructors instead
-void exprt::make_bool(bool value)
-{
-  *this=exprt(ID_constant, typet(ID_bool));
-  set(ID_value, value?ID_true:ID_false);
-}
-
 /// Return whether the expression represents a Boolean.
 /// \return True if is a Boolean, false otherwise.
 bool exprt::is_boolean() const

--- a/src/util/expr.h
+++ b/src/util/expr.h
@@ -239,9 +239,6 @@ public:
     op.push_back(std::move(e3));
   }
 
-  DEPRECATED(SINCE(2019, 5, 28, "use make_boolean_expr(value) instead"))
-  void make_bool(bool value);
-
   bool is_constant() const;
   bool is_true() const;
   bool is_false() const;
@@ -379,7 +376,6 @@ protected:
 
   // protect these low-level methods
   using exprt::add;
-  using exprt::make_bool;
   using exprt::op0;
   using exprt::op1;
   using exprt::op2;


### PR DESCRIPTION
This method has been deprecated since June 2019, there are no in-tree uses
of this function and there is a simple substitute for external users.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- n/a My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
