### PR TITLE
Remove codet::parametert() constructor

### DIFF
--- a/jbmc/src/java_bytecode/lambda_synthesis.cpp
+++ b/jbmc/src/java_bytecode/lambda_synthesis.cpp
@@ -325,12 +325,11 @@ static symbolt constructor_symbol(
       id2string(constructor_name) + "::" + id2string(param_basename));
   }
 
-  java_method_typet::parametert constructor_this_param;
+  java_method_typet::parametert constructor_this_param(
+    java_reference_type(struct_tag_typet(synthetic_class_name)));
   constructor_this_param.set_this();
   constructor_this_param.set_base_name("this");
   constructor_this_param.set_identifier(id2string(constructor_name) + "::this");
-  constructor_this_param.type() =
-    java_reference_type(struct_tag_typet(synthetic_class_name));
 
   constructor_type.parameters().insert(
     constructor_type.parameters().begin(), constructor_this_param);

--- a/jbmc/unit/java_bytecode/java_bytecode_convert_method/convert_method.cpp
+++ b/jbmc/unit/java_bytecode/java_bytecode_convert_method/convert_method.cpp
@@ -929,13 +929,10 @@ TEST_CASE(
   irep_idt method_identifier = "someClass.someMethod";
 
   // The parameters should be already populated, but not have names, ids
-  code_typet::parametert this_param;
+  code_typet::parametert this_param(java_lang_object_type());
   this_param.set_this();
-  this_param.type() = java_lang_object_type();
-  code_typet::parametert ref_to_inner;
-  ref_to_inner.type() = java_lang_object_type();
-  code_typet::parametert other_param;
-  other_param.type() = java_lang_object_type();
+  code_typet::parametert ref_to_inner(java_lang_object_type());
+  code_typet::parametert other_param(java_lang_object_type());
   java_method_typet::parameterst parameters{
     this_param, ref_to_inner, other_param};
   for(const auto &param : parameters)
@@ -985,17 +982,14 @@ TEST_CASE(
   // Arrange
   const irep_idt method_id = "someClass.someMethod";
   // The parameters should be already populated, with names, ids
-  code_typet::parametert this_param;
+  code_typet::parametert this_param(java_lang_object_type());
   this_param.set_this();
-  this_param.type() = java_lang_object_type();
   this_param.set_identifier(id2string(method_id) + "::this");
   this_param.set_base_name("this");
-  code_typet::parametert ref_to_inner;
-  ref_to_inner.type() = java_lang_object_type();
+  code_typet::parametert ref_to_inner(java_lang_object_type());
   ref_to_inner.set_identifier(id2string(method_id) + "::this$0");
   ref_to_inner.set_base_name("this$0");
-  code_typet::parametert other_param;
-  other_param.type() = java_lang_object_type();
+  code_typet::parametert other_param(java_lang_object_type());
   other_param.set_identifier(id2string(method_id) + "::other");
   other_param.set_base_name("other");
   java_method_typet::parameterst parameters{

--- a/src/util/std_types.h
+++ b/src/util/std_types.h
@@ -752,11 +752,6 @@ public:
   class parametert:public exprt
   {
   public:
-    DEPRECATED(SINCE(2018, 9, 21, "use parametert(type) instead"))
-    parametert():exprt(ID_parameter)
-    {
-    }
-
     explicit parametert(const typet &type):exprt(ID_parameter, type)
     {
     }


### PR DESCRIPTION
This constructor has been deprecated since September 2018.  There are two
residual in-tree uses, which are replaced by the (simple) alternative.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- n/a My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
