### PR TITLE
Add code sign of Windows installer

### DIFF
--- a/.github/workflows/release-packages.yaml
+++ b/.github/workflows/release-packages.yaml
@@ -112,6 +112,10 @@ jobs:
           choco install winflexbison3
       - uses: microsoft/setup-msbuild@v1.0.1
         name: Setup Visual Studio environment
+      - name: Setup code sign environment
+        run: | 
+          echo "$(Split-Path -Path $(Get-ChildItem -Path ${env:ProgramFiles(x86)} -Recurse -Filter 'signtool.exe' | Where-Object FullName -like '*10.0.19041.0\x64\signtool.exe').FullName)" >> $env:GITHUB_PATH
+          echo "pfxcert=$([string](Get-Location)+'\CodeSignCertificate.pfx')" >> $env:GITHUB_ENV
       - name: Configure with cmake
         run: |
           New-Item -ItemType Directory -Path build
@@ -130,6 +134,23 @@ jobs:
           $msi_name = Get-ChildItem -Filter *.msi -Name
           Write-Output "::set-output name=msi_installer::build/$msi_name"
           Write-Output "::set-output name=msi_name::$msi_name"
+      - name: Decode signing certificate
+        id: decode_certificate
+        run: |
+          $pfx_bytes=[System.Convert]::FromBase64String("${{ secrets.CODESIGNCERTPFX }}")
+          [IO.File]::WriteAllBytes($env:pfxcert, $pfx_bytes)
+      - name: Sign the installer
+        id: code_sign
+        run: |
+          & signtool.exe sign /f $env:pfxcert /p "${{ secrets.CODESIGNCERTPASSWORD }}" /tr http://tsa.starfieldtech.com ${{ steps.create_packages.outputs.msi_installer }}
+      - name: Remove signing certificate
+        id: remove_certificate
+        run: |
+          Remove-Item $env:pfxcert
+      - name: Verify installer signature
+        id: verify_codesign
+        run: |
+          & signtool.exe verify /pa ${{ steps.create_packages.outputs.msi_installer }}
       - name: Get release info
         id: get_release_info
         uses: bruceadams/get-release@v1.2.0


### PR DESCRIPTION
Windows installer will now get automatically signed using Diffblue
code sign certificate so that it will no longer appear as from
unknown publisher when installer is executed.
Windows package release action has 4 tasks added:
1. Decoding Personal Information Exchange file (*.pfx) from Github
Secrets into a file.
2. Signing the Windows Installer package with decoded certificate
using signtool from Windows SDK.
3. Deleting decoded certificate file.
4. Verifying signature.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
