### PR TITLE
forall_operands should not trigger any non-const operations

### DIFF
--- a/src/util/expr.h
+++ b/src/util/expr.h
@@ -9,17 +9,19 @@ Author: Daniel Kroening, kroening@kroening.com
 #ifndef CPROVER_UTIL_EXPR_H
 #define CPROVER_UTIL_EXPR_H
 
+#include "as_const.h"
 #include "deprecate.h"
 #include "type.h"
 #include "validate_expressions.h"
 #include "validate_types.h"
 #include "validation_mode.h"
 
-#define forall_operands(it, expr) \
-  if((expr).has_operands()) /* NOLINT(readability/braces) */ \
-    for(exprt::operandst::const_iterator it=(expr).operands().begin(), \
-        it##_end=(expr).operands().end(); \
-        it!=it##_end; ++it)
+#define forall_operands(it, expr)                                              \
+  for(exprt::operandst::const_iterator                                         \
+        it = as_const(expr).operands().begin(),                                \
+        it##_end = as_const(expr).operands().end();                            \
+      it != it##_end;                                                          \
+      ++it)
 
 #define Forall_operands(it, expr) \
   if((expr).has_operands()) /* NOLINT(readability/braces) */ \

--- a/src/util/simplify_utils.cpp
+++ b/src/util/simplify_utils.cpp
@@ -7,7 +7,6 @@ Author: Daniel Kroening, kroening@kroening.com
 \*******************************************************************/
 
 #include "simplify_utils.h"
-#include "as_const.h"
 
 #include <algorithm>
 

--- a/src/util/std_expr.h
+++ b/src/util/std_expr.h
@@ -13,7 +13,6 @@ Author: Daniel Kroening, kroening@kroening.com
 /// \file util/std_expr.h
 /// API to expression classes
 
-#include "as_const.h"
 #include "expr_cast.h"
 #include "invariant.h"
 #include "narrow.h"


### PR DESCRIPTION
If .operands() is used in a non-const context, an unnecessary
(temporary) copy of the irep is created. Use as_const to avoid this.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
