### PR TITLE
Remove deprecated side_effect_expr*t constructors

### DIFF
--- a/jbmc/src/java_bytecode/code_with_references.cpp
+++ b/jbmc/src/java_bytecode/code_with_references.cpp
@@ -15,12 +15,12 @@ codet allocate_array(
   const exprt &array_length_expr,
   const source_locationt &loc)
 {
-  const pointer_typet &pointer_type = to_pointer_type(expr.type());
+  pointer_typet pointer_type = to_pointer_type(expr.type());
   const auto &element_type =
     java_array_element_type(to_struct_tag_type(pointer_type.subtype()));
-  side_effect_exprt java_new_array{ID_java_new_array, pointer_type};
-  java_new_array.copy_to_operands(array_length_expr);
-  java_new_array.type().subtype().set(ID_element_type, element_type);
+  pointer_type.subtype().set(ID_element_type, element_type);
+  side_effect_exprt java_new_array{
+    ID_java_new_array, {array_length_expr}, pointer_type, loc};
   return code_assignt{expr, java_new_array, loc};
 }
 

--- a/jbmc/src/java_bytecode/java_entry_point.cpp
+++ b/jbmc/src/java_bytecode/java_entry_point.cpp
@@ -330,8 +330,9 @@ std::pair<code_blockt, std::vector<exprt>> java_build_arguments(
                                     .symbol_expr();
       main_arguments[param_number] = result;
       init_code.add(code_declt{result});
-      init_code.add(
-        code_assignt{result, side_effect_exprt(ID_java_new, p.type())});
+      init_code.add(code_assignt{
+        result,
+        side_effect_exprt{ID_java_new, {}, p.type(), function.location}});
       continue;
     }
 

--- a/src/util/std_code.h
+++ b/src/util/std_code.h
@@ -1865,15 +1865,6 @@ inline const code_expressiont &to_code_expression(const codet &code)
 class side_effect_exprt : public exprt
 {
 public:
-  DEPRECATED(
-    SINCE(2018, 8, 9, "use side_effect_exprt(statement, type, loc) instead"))
-  side_effect_exprt(const irep_idt &statement, const typet &_type)
-    : exprt(ID_side_effect, _type)
-  {
-    set_statement(statement);
-  }
-
-  /// constructor with operands
   side_effect_exprt(
     const irep_idt &statement,
     operandst _operands,
@@ -2116,24 +2107,6 @@ to_side_effect_expr_statement_expression(const exprt &expr)
 class side_effect_expr_function_callt:public side_effect_exprt
 {
 public:
-  DEPRECATED(SINCE(
-    2018,
-    8,
-    9,
-    "use side_effect_expr_function_callt("
-    "function, arguments, type, loc) instead"))
-  side_effect_expr_function_callt(
-    const exprt &_function,
-    const exprt::operandst &_arguments,
-    const typet &_type)
-    : side_effect_exprt(ID_function_call, _type)
-  {
-    operands().resize(2);
-    op1().id(ID_arguments);
-    function() = _function;
-    arguments() = _arguments;
-  }
-
   side_effect_expr_function_callt(
     exprt _function,
     exprt::operandst _arguments,


### PR DESCRIPTION
These were deprecated in 2018 and the remaining in-tree uses are now
fixed/removed.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
