### PR TITLE
Remove deprecated variants of find_symbols

### DIFF
--- a/src/util/find_symbols.cpp
+++ b/src/util/find_symbols.cpp
@@ -63,16 +63,6 @@ bool has_symbol(
 
 void find_symbols(
   const exprt &src,
-  std::set<exprt> &dest)
-{
-  src.visit_pre([&dest](const exprt &e) {
-    if(e.id() == ID_symbol || e.id() == ID_next_symbol)
-      dest.insert(e);
-  });
-}
-
-void find_symbols(
-  const exprt &src,
   std::set<symbol_exprt> &dest)
 {
   src.visit_pre([&dest](const exprt &e) {

--- a/src/util/find_symbols.h
+++ b/src/util/find_symbols.h
@@ -14,7 +14,6 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <set>
 #include <unordered_set>
 
-#include "deprecate.h"
 #include "irep.h"
 
 class exprt;
@@ -48,12 +47,6 @@ void find_symbols(
   find_symbols_sett &dest,
   bool current,
   bool next);
-
-/// Find sub expressions with id ID_symbol or ID_next_symbol
-DEPRECATED(SINCE(2019, 06, 17, "Unused"))
-void find_symbols(
-  const exprt &src,
-  std::set<exprt> &dest);
 
 /// Find sub expressions with id ID_symbol
 void find_symbols(


### PR DESCRIPTION
It was deprecated in 2019 and had no in-tree users left.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- n/a Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
