### PR TITLE
Remove deprecated exprt::move_to_operands

### DIFF
--- a/src/util/expr.cpp
+++ b/src/util/expr.cpp
@@ -35,51 +35,6 @@ std::size_t exprt::size() const
   return size;
 }
 
-/// Move the given argument to the end of `exprt`'s operands.
-/// The argument is destroyed and mutated to a reference to a nil `irept`.
-/// \param expr: `exprt` to append to the operands
-void exprt::move_to_operands(exprt &expr)
-{
-  operandst &op=operands();
-  op.push_back(static_cast<const exprt &>(get_nil_irep()));
-  op.back().swap(expr);
-}
-
-/// Move the given arguments to the end of `exprt`'s operands.
-/// The arguments are destroyed and mutated to a reference to a nil `irept`.
-/// \param e1: first `exprt` to append to the operands
-/// \param e2: second `exprt` to append to the operands
-void exprt::move_to_operands(exprt &e1, exprt &e2)
-{
-  operandst &op=operands();
-  #ifndef USE_LIST
-  op.reserve(op.size()+2);
-  #endif
-  op.push_back(static_cast<const exprt &>(get_nil_irep()));
-  op.back().swap(e1);
-  op.push_back(static_cast<const exprt &>(get_nil_irep()));
-  op.back().swap(e2);
-}
-
-/// Move the given arguments to the end of `exprt`'s operands.
-/// The arguments are destroyed and mutated to a reference to a nil `irept`.
-/// \param e1: first `exprt` to append to the operands
-/// \param e2: second `exprt` to append to the operands
-/// \param e3: third `exprt` to append to the operands
-void exprt::move_to_operands(exprt &e1, exprt &e2, exprt &e3)
-{
-  operandst &op=operands();
-  #ifndef USE_LIST
-  op.reserve(op.size()+3);
-  #endif
-  op.push_back(static_cast<const exprt &>(get_nil_irep()));
-  op.back().swap(e1);
-  op.push_back(static_cast<const exprt &>(get_nil_irep()));
-  op.back().swap(e2);
-  op.push_back(static_cast<const exprt &>(get_nil_irep()));
-  op.back().swap(e3);
-}
-
 /// Return whether the expression is a constant.
 /// \return True if is a constant, false otherwise
 bool exprt::is_constant() const

--- a/src/util/expr.h
+++ b/src/util/expr.h
@@ -10,7 +10,6 @@ Author: Daniel Kroening, kroening@kroening.com
 #define CPROVER_UTIL_EXPR_H
 
 #include "as_const.h"
-#include "deprecate.h"
 #include "type.h"
 #include "validate_expressions.h"
 #include "validate_types.h"
@@ -128,24 +127,6 @@ protected:
 public:
   void reserve_operands(operandst::size_type n)
   { operands().reserve(n) ; }
-
-  DEPRECATED(SINCE(2018, 10, 1, "use add_to_operands(std::move(expr)) instead"))
-  void move_to_operands(exprt &expr);
-
-  DEPRECATED(SINCE(
-    2018,
-    10,
-    1,
-    "use add_to_operands(std::move(e1), std::move(e2)) instead"))
-  void move_to_operands(exprt &e1, exprt &e2);
-
-  DEPRECATED(SINCE(
-    2018,
-    10,
-    1,
-    "use add_to_operands(std::move(e1), std::move(e2), std::move(e3))"
-    "instead"))
-  void move_to_operands(exprt &e1, exprt &e2, exprt &e3);
 
   /// Copy the given argument to the end of `exprt`'s operands.
   /// \param expr: `exprt` to append to the operands


### PR DESCRIPTION
All methods were deprecated in 2018. There are no in-tree users left.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
