### PR TITLE
Remove deprecated byte_update_exprt non-const methods

### DIFF
--- a/src/util/byte_operators.h
+++ b/src/util/byte_operators.h
@@ -92,13 +92,6 @@ public:
       "byte_update_exprt: Invalid ID");
   }
 
-  DEPRECATED(SINCE(2019, 5, 21, "use set_op or as_const instead"))
-  exprt &op() { return op0(); }
-  DEPRECATED(SINCE(2019, 5, 21, "use set_offset or as_const instead"))
-  exprt &offset() { return op1(); }
-  DEPRECATED(SINCE(2019, 5, 21, "use set_value or as_const instead"))
-  exprt &value() { return op2(); }
-
   void set_op(exprt e)
   {
     op0() = std::move(e);


### PR DESCRIPTION
They were deprecated in 2019 in favour of their set_* counterparts, and
had no in-tree users left.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
