### PR TITLE
Remove deprecated and unused methods

### DIFF
--- a/jbmc/src/java_bytecode/java_utils.cpp
+++ b/jbmc/src/java_bytecode/java_utils.cpp
@@ -23,13 +23,6 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <set>
 #include <unordered_set>
 
-bool java_is_array_type(const typet &type)
-{
-  if(type.id() != ID_struct)
-    return false;
-  return is_java_array_tag(to_struct_type(type).get_tag());
-}
-
 bool is_java_string_type(const struct_typet &struct_type)
 {
   return java_string_library_preprocesst::implements_java_char_sequence(

--- a/jbmc/src/java_bytecode/java_utils.h
+++ b/jbmc/src/java_bytecode/java_utils.h
@@ -21,9 +21,6 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <goto-programs/resolve_inherited_component.h>
 
-DEPRECATED(SINCE(2019, 6, 10, "use is_java_array_type instead"))
-bool java_is_array_type(const typet &type);
-
 /// Returns true iff the argument represents a string type (CharSequence,
 /// StringBuilder, StringBuffer or String).
 /// The check for the length and data components is necessary in the case where

--- a/src/goto-programs/interpreter.cpp
+++ b/src/goto-programs/interpreter.cpp
@@ -428,16 +428,6 @@ void interpretert::execute_decl()
   PRECONDITION(pc->code.get_statement()==ID_decl);
 }
 
-/// retrieves the member at offset
-/// \par parameters: an object and a memory offset
-struct_typet::componentt interpretert::get_component(
-  const irep_idt &object,
-  const mp_integer &offset)
-{
-  const symbolt &symbol = ns.lookup(object);
-  return get_component(symbol.type, offset);
-}
-
 /// Retrieves the member at \p offset of an object of type \p object_type.
 struct_typet::componentt
 interpretert::get_component(const typet &object_type, const mp_integer &offset)

--- a/src/goto-programs/interpreter_class.h
+++ b/src/goto-programs/interpreter_class.h
@@ -196,11 +196,6 @@ protected:
   bool unbounded_size(const typet &);
   mp_integer get_size(const typet &type);
 
-  DEPRECATED("use the object_type version instead")
-  struct_typet::componentt get_component(
-    const irep_idt &object,
-    const mp_integer &offset);
-
   struct_typet::componentt
   get_component(const typet &object_type, const mp_integer &offset);
 

--- a/src/goto-symex/renaming_level.cpp
+++ b/src/goto-symex/renaming_level.cpp
@@ -17,19 +17,6 @@ Author: Romain Brenguier, romain.brenguier@diffblue.com
 
 #include "goto_symex_state.h"
 
-void get_variables(
-  const symex_renaming_levelt &current_names,
-  std::unordered_set<ssa_exprt, irep_hash> &vars)
-{
-  symex_renaming_levelt::viewt view;
-  current_names.get_view(view);
-
-  for(const auto &pair : view)
-  {
-    vars.insert(pair.second.first);
-  }
-}
-
 renamedt<ssa_exprt, L0>
 symex_level0(ssa_exprt ssa_expr, const namespacet &ns, std::size_t thread_nr)
 {

--- a/src/goto-symex/renaming_level.h
+++ b/src/goto-symex/renaming_level.h
@@ -31,12 +31,6 @@ Author: Romain Brenguier, romain.brenguier@diffblue.com
 using symex_renaming_levelt =
   sharing_mapt<irep_idt, std::pair<ssa_exprt, std::size_t>>;
 
-/// Add the \c ssa_exprt of current_names to vars
-DEPRECATED(SINCE(2019, 6, 5, "Unused"))
-void get_variables(
-  const symex_renaming_levelt &current_names,
-  std::unordered_set<ssa_exprt, irep_hash> &vars);
-
 /// Set the level 0 renaming of SSA expressions.
 /// Level 0 corresponds to threads.
 /// The renaming is built for one particular interleaving.

--- a/src/util/ssa_expr.cpp
+++ b/src/util/ssa_expr.cpp
@@ -218,11 +218,6 @@ bool ssa_exprt::can_build_identifier(const exprt &expr)
     return false;
 }
 
-void ssa_exprt::update_identifier()
-{
-  ::update_identifier(*this);
-}
-
 ssa_exprt remove_level_2(ssa_exprt ssa)
 {
   ssa.remove_level_2();

--- a/src/util/ssa_expr.h
+++ b/src/util/ssa_expr.h
@@ -75,9 +75,6 @@ public:
     return get(ID_L2);
   }
 
-  DEPRECATED(SINCE(2019, 05, 29, "Should only be used internally"))
-  void update_identifier();
-
   /// Used to determine whether or not an identifier can be built before trying
   /// and getting an exception
   static bool can_build_identifier(const exprt &src);


### PR DESCRIPTION
These were deprecated in 2019 and had no in-tree users left.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
