### PR TITLE
Remove deprecated methods of value sets

### DIFF
--- a/jbmc/unit/pointer-analysis/custom_value_set_analysis.cpp
+++ b/jbmc/unit/pointer-analysis/custom_value_set_analysis.cpp
@@ -145,17 +145,8 @@ typedef
 #define TEST_FUNCTION_NAME TEST_PREFIX "test:()V"
 #define TEST_LOCAL_PREFIX TEST_FUNCTION_NAME "::"
 
-template<class VST>
-static value_setst::valuest
-get_values(const VST &value_set, const namespacet &ns, const exprt &expr)
-{
-  value_setst::valuest vals;
-  value_set.get_value_set(expr, vals, ns);
-  return vals;
-}
-
-static std::size_t exprs_with_id(
-  const value_setst::valuest &exprs, const irep_idt &id)
+static std::size_t
+exprs_with_id(const std::vector<exprt> &exprs, const irep_idt &id)
 {
   return std::count_if(
     exprs.begin(),
@@ -222,15 +213,15 @@ SCENARIO("test_value_set_analysis",
         TEST_LOCAL_PREFIX "23::ignored", jlo_ref_type);
       THEN("The normal analysis should write to it")
       {
-        auto normal_exprs=
-          get_values(normal_function_end_vs, ns, written_symbol);
+        auto normal_exprs =
+          normal_function_end_vs.get_value_set(written_symbol, ns);
         REQUIRE(exprs_with_id(normal_exprs, ID_dynamic_object)==1);
         REQUIRE(exprs_with_id(normal_exprs, ID_unknown)==0);
       }
       THEN("The custom analysis should ignore the write to it")
       {
-        auto test_exprs=
-          get_values(test_function_end_vs, ns, written_symbol);
+        auto test_exprs =
+          test_function_end_vs.get_value_set(written_symbol, ns);
         REQUIRE(exprs_with_id(test_exprs, ID_dynamic_object)==0);
         REQUIRE(exprs_with_id(test_exprs, ID_unknown)==1);
       }
@@ -242,15 +233,15 @@ SCENARIO("test_value_set_analysis",
         TEST_LOCAL_PREFIX "31::no_write", jlo_ref_type);
       THEN("The normal analysis should write to it")
       {
-        auto normal_exprs=
-          get_values(normal_function_end_vs, ns, written_symbol);
+        auto normal_exprs =
+          normal_function_end_vs.get_value_set(written_symbol, ns);
         REQUIRE(exprs_with_id(normal_exprs, ID_dynamic_object)==1);
         REQUIRE(exprs_with_id(normal_exprs, ID_unknown)==0);
       }
       THEN("The custom analysis should ignore the write to it")
       {
-        auto test_exprs=
-          get_values(test_function_end_vs, ns, written_symbol);
+        auto test_exprs =
+          test_function_end_vs.get_value_set(written_symbol, ns);
         REQUIRE(exprs_with_id(test_exprs, ID_dynamic_object)==0);
         REQUIRE(exprs_with_id(test_exprs, ID_unknown)==1);
       }
@@ -262,15 +253,15 @@ SCENARIO("test_value_set_analysis",
         TEST_LOCAL_PREFIX "55::read", jlo_ref_type);
       THEN("The normal analysis should find a dynamic object")
       {
-        auto normal_exprs=
-          get_values(normal_function_end_vs, ns, written_symbol);
+        auto normal_exprs =
+          normal_function_end_vs.get_value_set(written_symbol, ns);
         REQUIRE(exprs_with_id(normal_exprs, ID_dynamic_object)==1);
         REQUIRE(exprs_with_id(normal_exprs, ID_unknown)==0);
       }
       THEN("The custom analysis should have no information about it")
       {
-        auto test_exprs=
-          get_values(test_function_end_vs, ns, written_symbol);
+        auto test_exprs =
+          test_function_end_vs.get_value_set(written_symbol, ns);
         REQUIRE(test_exprs.size()==0);
       }
     }
@@ -281,16 +272,16 @@ SCENARIO("test_value_set_analysis",
         TEST_PREFIX "maybe_unknown_read", jlo_ref_type);
       THEN("The normal analysis should find a dynamic object")
       {
-        auto normal_exprs=
-          get_values(normal_function_end_vs, ns, written_symbol);
+        auto normal_exprs =
+          normal_function_end_vs.get_value_set(written_symbol, ns);
         REQUIRE(exprs_with_id(normal_exprs, ID_dynamic_object)==1);
         REQUIRE(exprs_with_id(normal_exprs, ID_unknown)==0);
       }
       THEN("The custom analysis should find a dynamic object "
            "*and* an unknown entry")
       {
-        auto test_exprs=
-          get_values(test_function_end_vs, ns, written_symbol);
+        auto test_exprs =
+          test_function_end_vs.get_value_set(written_symbol, ns);
         REQUIRE(test_exprs.size()==2);
         REQUIRE(exprs_with_id(test_exprs, ID_unknown)==1);
         REQUIRE(exprs_with_id(test_exprs, ID_dynamic_object)==1);
@@ -301,16 +292,16 @@ SCENARIO("test_value_set_analysis",
     {
       symbol_exprt read_before_cause_write(
         TEST_PREFIX "first_effect_read", jlo_ref_type);
-        auto normal_exprs_before=
-          get_values(normal_function_end_vs, ns, read_before_cause_write);
-        auto test_exprs_before=
-          get_values(test_function_end_vs, ns, read_before_cause_write);
+      auto normal_exprs_before =
+        normal_function_end_vs.get_value_set(read_before_cause_write, ns);
+      auto test_exprs_before =
+        test_function_end_vs.get_value_set(read_before_cause_write, ns);
       symbol_exprt read_after_cause_write(
         TEST_PREFIX "second_effect_read", jlo_ref_type);
-        auto normal_exprs_after=
-          get_values(normal_function_end_vs, ns, read_after_cause_write);
-        auto test_exprs_after=
-          get_values(test_function_end_vs, ns, read_after_cause_write);
+      auto normal_exprs_after =
+        normal_function_end_vs.get_value_set(read_after_cause_write, ns);
+      auto test_exprs_after =
+        test_function_end_vs.get_value_set(read_after_cause_write, ns);
 
       THEN("Before writing to 'cause' both analyses should think 'effect' "
            "points to some object")

--- a/src/goto-instrument/value_set_fi_fp_removal.cpp
+++ b/src/goto-instrument/value_set_fi_fp_removal.cpp
@@ -214,8 +214,7 @@ void value_set_fi_fp_removal(
                            << messaget::eom;
 
           const auto &pointer = to_dereference_expr(call.function()).pointer();
-          std::list<exprt> addresses;
-          value_sets.get_values(f.first, target, pointer, addresses);
+          auto addresses = value_sets.get_values(f.first, target, pointer);
 
           std::set<symbol_exprt> functions;
 

--- a/src/goto-symex/symex_dereference_state.cpp
+++ b/src/goto-symex/symex_dereference_state.cpp
@@ -13,10 +13,6 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <util/symbol_table.h>
 
-#ifdef DEBUG
-#  include <iostream>
-#endif
-
 /// Get or create a failed symbol for the given pointer-typed expression. These
 /// are used as placeholders when dereferencing expressions that are illegal to
 /// dereference, such as null pointers. The \ref add_failed_symbols pass must
@@ -79,33 +75,6 @@ symex_dereference_statet::get_or_create_failed_symbol(const exprt &expr)
   }
 
   return nullptr;
-}
-
-/// Just forwards a value-set query to `state.value_set`
-void symex_dereference_statet::get_value_set(
-  const exprt &expr,
-  value_setst::valuest &value_set) const
-{
-  state.value_set.get_value_set(expr, value_set, ns);
-
-#ifdef DEBUG
-  std::cout << "symex_dereference_statet state.value_set={\n";
-  state.value_set.output(ns, std::cout, "  - ");
-  std::cout << "}" << std::endl;
-#endif
-
-#if 0
-  std::cout << "E: " << from_expr(goto_symex.ns, irep_idt(), expr) << '\n';
-#endif
-
-#if 0
-  std::cout << "**************************\n";
-  for(value_setst::valuest::const_iterator it=value_set.begin();
-      it!=value_set.end();
-      it++)
-    std::cout << from_expr(goto_symex.ns, irep_idt(), *it) << '\n';
-  std::cout << "**************************\n";
-#endif
 }
 
 /// Just forwards a value-set query to `state.value_set`

--- a/src/goto-symex/symex_dereference_state.h
+++ b/src/goto-symex/symex_dereference_state.h
@@ -34,10 +34,6 @@ protected:
   goto_symext::statet &state;
   const namespacet &ns;
 
-  DEPRECATED(SINCE(2019, 05, 22, "use vector returning version instead"))
-  void get_value_set(const exprt &expr, value_setst::valuest &value_set)
-    const override;
-
   std::vector<exprt> get_value_set(const exprt &expr) const override;
 
   const symbolt *get_or_create_failed_symbol(const exprt &expr) override;

--- a/src/pointer-analysis/dereference_callback.h
+++ b/src/pointer-analysis/dereference_callback.h
@@ -29,10 +29,6 @@ class dereference_callbackt
 public:
   virtual ~dereference_callbackt() = default;
 
-  DEPRECATED(SINCE(2019, 05, 22, "use vector returning version instead"))
-  virtual void
-  get_value_set(const exprt &expr, value_setst::valuest &value_set) const = 0;
-
   virtual std::vector<exprt> get_value_set(const exprt &expr) const = 0;
 
   virtual const symbolt *get_or_create_failed_symbol(const exprt &expr) = 0;

--- a/src/pointer-analysis/goto_program_dereference.cpp
+++ b/src/pointer-analysis/goto_program_dereference.cpp
@@ -126,17 +126,6 @@ void goto_program_dereferencet::dereference_rec(exprt &expr)
 }
 
 /// Gets the value set corresponding to the current target and
-/// expression `expr`.
-/// \param expr: an expression
-/// \param [out] dest: gets the value set
-void goto_program_dereferencet::get_value_set(
-  const exprt &expr,
-  value_setst::valuest &dest) const
-{
-  value_sets.get_values(current_function, current_target, expr, dest);
-}
-
-/// Gets the value set corresponding to the current target and
 /// expression \p expr.
 /// \param expr: an expression
 /// \return the value set

--- a/src/pointer-analysis/goto_program_dereference.h
+++ b/src/pointer-analysis/goto_program_dereference.h
@@ -65,10 +65,6 @@ protected:
 
   const symbolt *get_or_create_failed_symbol(const exprt &expr) override;
 
-  DEPRECATED(SINCE(2019, 05, 22, "use vector returning version instead"))
-  void
-  get_value_set(const exprt &expr, value_setst::valuest &dest) const override;
-
   std::vector<exprt> get_value_set(const exprt &expr) const override;
 
   void dereference_instruction(

--- a/src/pointer-analysis/value_set.cpp
+++ b/src/pointer-analysis/value_set.cpp
@@ -133,14 +133,6 @@ bool value_sett::insert(
   return true;
 }
 
-void value_sett::output(
-  const namespacet &,
-  std::ostream &out,
-  const std::string &indent) const
-{
-  output(out, indent);
-}
-
 void value_sett::output(std::ostream &out, const std::string &indent) const
 {
   values.iterate([&](const irep_idt &, const entryt &e) {
@@ -356,44 +348,12 @@ bool value_sett::eval_pointer_offset(
   return mod;
 }
 
-void value_sett::get_value_set(
-  exprt expr,
-  value_setst::valuest &dest,
-  const namespacet &ns) const
-{
-  object_mapt object_map = get_value_set(std::move(expr), ns, false);
-
-  for(object_map_dt::const_iterator
-      it=object_map.read().begin();
-      it!=object_map.read().end();
-      it++)
-    dest.push_back(to_expr(*it));
-
-  #if 0
-  for(value_setst::valuest::const_iterator it=dest.begin();
-      it!=dest.end(); it++)
-    std::cout << "GET_VALUE_SET: " << format(*it) << '\n';
-  #endif
-}
-
 std::vector<exprt>
 value_sett::get_value_set(exprt expr, const namespacet &ns) const
 {
   const object_mapt object_map = get_value_set(std::move(expr), ns, false);
   return make_range(object_map.read())
     .map([&](const object_map_dt::value_type &pair) { return to_expr(pair); });
-}
-
-void value_sett::get_value_set(
-  exprt expr,
-  object_mapt &dest,
-  const namespacet &ns,
-  bool is_simplified) const
-{
-  if(!is_simplified)
-    simplify(expr, ns);
-
-  get_value_set_rec(expr, dest, "", expr.type(), ns);
 }
 
 value_sett::object_mapt value_sett::get_value_set(

--- a/src/pointer-analysis/value_set.h
+++ b/src/pointer-analysis/value_set.h
@@ -80,11 +80,6 @@ public:
   /// Represents the offset into an object: either a unique integer offset,
   /// or an unknown value, represented by `!offset`.
   typedef optionalt<mp_integer> offsett;
-  DEPRECATED(SINCE(2019, 05, 22, "Unused"))
-  bool offset_is_zero(const offsett &offset) const
-  {
-    return offset && offset->is_zero();
-  }
 
   /// Represents a set of expressions (`exprt` instances) with corresponding
   /// offsets (`offsett` instances). This is the RHS set of a single row of
@@ -235,17 +230,6 @@ public:
     }
   };
 
-  /// Set of expressions; only used for the `get` API, not for internal
-  /// data representation.
-  DEPRECATED(SINCE(2019, 05, 22, "Only used in deprecated function"))
-  typedef std::set<exprt> expr_sett;
-
-  /// Set of dynamic object numbers, equivalent to a set of
-  /// `dynamic_object_exprt`s with corresponding IDs. Used only in internal
-  /// implementation details.
-  DEPRECATED(SINCE(2019, 05, 22, "Unused"))
-  typedef std::set<unsigned int> dynamic_object_id_sett;
-
   /// Map representing the entire value set, mapping from string LHS IDs
   /// to RHS expression sets. Note this data structure is somewhat
   /// denormalized, for example mapping
@@ -261,15 +245,6 @@ public:
   /// `entryt` fields.
   typedef sharing_mapt<irep_idt, entryt> valuest;
 
-  /// Gets values pointed to by \p expr, including following dereference
-  /// operators (i.e. this is not a simple lookup in `valuest`).
-  DEPRECATED(
-    SINCE(2019, 05, 22, "Use get_value_set(exprt, const namespacet &) instead"))
-  void get_value_set(
-    exprt expr,
-    value_setst::valuest &dest,
-    const namespacet &ns) const;
-
   /// Gets values pointed to by `expr`, including following dereference
   /// operators (i.e. this is not a simple lookup in `valuest`).
   /// \param expr: query expression
@@ -277,10 +252,6 @@ public:
   /// \return list of expressions that `expr` may point to. These expressions
   ///   are object_descriptor_exprt or have id ID_invalid or ID_unknown.
   std::vector<exprt> get_value_set(exprt expr, const namespacet &ns) const;
-
-  /// Appears to be unimplemented.
-  DEPRECATED(SINCE(2019, 05, 22, "Unimplemented"))
-  expr_sett &get(const irep_idt &identifier, const std::string &suffix);
 
   void clear()
   {
@@ -317,12 +288,6 @@ public:
   /// \param [out] out: stream to write to
   /// \param indent: string to use for indentation of the output
   void output(std::ostream &out, const std::string &indent = "") const;
-
-  DEPRECATED(SINCE(2019, 06, 11, "Use the version without ns argument"))
-  void output(
-    const namespacet &ns,
-    std::ostream &out,
-    const std::string &indent = "") const;
 
   /// Stores the LHS ID -> RHS expression set map. See `valuest` documentation
   /// for more detail.
@@ -467,16 +432,6 @@ public:
   void erase_symbol(const symbol_exprt &symbol_expr, const namespacet &ns);
 
 protected:
-  /// Reads the set of objects pointed to by \p expr, including making
-  /// recursive lookups for dereference operations etc.
-  DEPRECATED(
-    SINCE(2019, 05, 22, "Use the version returning object_mapt instead"))
-  void get_value_set(
-    exprt expr,
-    object_mapt &dest,
-    const namespacet &ns,
-    bool is_simplified) const;
-
   /// Reads the set of objects pointed to by `expr`, including making
   /// recursive lookups for dereference operations etc.
   /// \param expr: query expression

--- a/src/pointer-analysis/value_set_analysis.h
+++ b/src/pointer-analysis/value_set_analysis.h
@@ -65,17 +65,6 @@ public:
 
 public:
   // interface value_sets
-  DEPRECATED(SINCE(2019, 05, 22, "use list returning version instead"))
-  void get_values(
-    const irep_idt &,
-    locationt l,
-    const exprt &expr,
-    value_setst::valuest &dest) override
-  {
-    (*this)[l].value_set.get_value_set(expr, dest, baset::ns);
-  }
-
-  // interface value_sets
   std::vector<exprt>
   get_values(const irep_idt &, locationt l, const exprt &expr) override
   {

--- a/src/pointer-analysis/value_set_analysis_fi.h
+++ b/src/pointer-analysis/value_set_analysis_fi.h
@@ -58,22 +58,6 @@ protected:
 
 public:
   // interface value_sets
-  DEPRECATED(SINCE(2019, 05, 22, "Use the version returning list instead"))
-  void get_values(
-    const irep_idt &function_id,
-    locationt l,
-    const exprt &expr,
-    std::list<exprt> &dest) override
-  {
-    state.value_set.from_function =
-      state.value_set.function_numbering.number(function_id);
-    state.value_set.to_function =
-      state.value_set.function_numbering.number(function_id);
-    state.value_set.from_target_index = l->location_number;
-    state.value_set.to_target_index = l->location_number;
-    state.value_set.get_value_set(expr, dest, ns);
-  }
-
   std::vector<exprt> get_values(
     const irep_idt &function_id,
     locationt l,

--- a/src/pointer-analysis/value_set_domain.h
+++ b/src/pointer-analysis/value_set_domain.h
@@ -33,9 +33,9 @@ public:
     return value_set.make_union(other.value_set);
   }
 
-  void output(const namespacet &ns, std::ostream &out) const override
+  void output(const namespacet &, std::ostream &out) const override
   {
-    value_set.output(ns, out);
+    value_set.output(out);
   }
 
   void initialize(const namespacet &, locationt l) override

--- a/src/pointer-analysis/value_set_fi.cpp
+++ b/src/pointer-analysis/value_set_fi.cpp
@@ -294,18 +294,6 @@ bool value_set_fit::make_union(object_mapt &dest, const object_mapt &src) const
   return result;
 }
 
-void value_set_fit::get_value_set(
-  const exprt &expr,
-  std::list<exprt> &value_set,
-  const namespacet &ns) const
-{
-  std::vector<exprt> result_as_vector = get_value_set(expr, ns);
-  std::move(
-    result_as_vector.begin(),
-    result_as_vector.end(),
-    std::back_inserter(value_set));
-}
-
 std::vector<exprt>
 value_set_fit::get_value_set(const exprt &expr, const namespacet &ns) const
 {

--- a/src/pointer-analysis/value_set_fi.h
+++ b/src/pointer-analysis/value_set_fi.h
@@ -205,12 +205,6 @@ public:
   typedef std::unordered_set<idt, string_hash> assign_recursion_sett;
   #endif
 
-  DEPRECATED(SINCE(2019, 05, 22, "Use the version returning vector instead"))
-  void get_value_set(
-    const exprt &expr,
-    std::list<exprt> &dest,
-    const namespacet &ns) const;
-
   std::vector<exprt>
   get_value_set(const exprt &expr, const namespacet &ns) const;
 

--- a/src/pointer-analysis/value_sets.h
+++ b/src/pointer-analysis/value_sets.h
@@ -28,14 +28,6 @@ public:
   typedef std::list<exprt> valuest;
 
   // this is not const to allow a lazy evaluation
-  DEPRECATED(SINCE(2019, 05, 22, "use vector returning version instead"))
-  virtual void get_values(
-    const irep_idt &function_id,
-    goto_programt::const_targett l,
-    const exprt &expr,
-    valuest &dest) = 0;
-
-  // this is not const to allow a lazy evaluation
   virtual std::vector<exprt> get_values(
     const irep_idt &function_id,
     goto_programt::const_targett l,


### PR DESCRIPTION
These were deprecated in 2019. The remaining in-tree users now use
non-deprecated variants instead.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
