### PR TITLE
Remove deprecated variant of parse_unwindset

### DIFF
--- a/src/goto-instrument/unwindset.cpp
+++ b/src/goto-instrument/unwindset.cpp
@@ -54,19 +54,16 @@ void unwindsett::parse_unwindset_one_loop(std::string val)
   }
 }
 
-void unwindsett::parse_unwindset(const std::string &unwindset)
-{
-  std::vector<std::string> unwindset_elements =
-    split_string(unwindset, ',', true, true);
-
-  for(auto &element : unwindset_elements)
-    parse_unwindset_one_loop(element);
-}
-
 void unwindsett::parse_unwindset(const std::list<std::string> &unwindset)
 {
   for(auto &element : unwindset)
-    parse_unwindset(element);
+  {
+    std::vector<std::string> unwindset_elements =
+      split_string(element, ',', true, true);
+
+    for(auto &element : unwindset_elements)
+      parse_unwindset_one_loop(element);
+  }
 }
 
 optionalt<unsigned>
@@ -104,5 +101,10 @@ void unwindsett::parse_unwindset_file(const std::string &file_name)
 
   std::stringstream buffer;
   buffer << file.rdbuf();
-  parse_unwindset(buffer.str());
+
+  std::vector<std::string> unwindset_elements =
+    split_string(buffer.str(), ',', true, true);
+
+  for(auto &element : unwindset_elements)
+    parse_unwindset_one_loop(element);
 }

--- a/src/goto-instrument/unwindset.h
+++ b/src/goto-instrument/unwindset.h
@@ -16,7 +16,6 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <map>
 #include <string>
 
-#include <util/deprecate.h>
 #include <util/irep.h>
 #include <util/optional.h>
 
@@ -31,10 +30,6 @@ public:
 
   // global limit for all loops
   void parse_unwind(const std::string &unwind);
-
-  // limit for instances of a loop
-  DEPRECATED(SINCE(2019, 11, 15, "use parse_unwindset(list) instead"))
-  void parse_unwindset(const std::string &unwindset);
 
   // limit for instances of a loop
   void parse_unwindset(const std::list<std::string> &unwindset);


### PR DESCRIPTION
The remaining use of the deprecated variant was updated accordingly.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
