### PR TITLE
Remove deprecated goto_programt::instructiont methods

### DIFF
--- a/src/goto-instrument/value_set_fi_fp_removal.cpp
+++ b/src/goto-instrument/value_set_fi_fp_removal.cpp
@@ -112,9 +112,7 @@ void remove_function_pointer(
 
   // the final target is a skip
   goto_programt final_skip;
-
-  goto_programt::targett t_final = final_skip.add_instruction();
-  t_final->make_skip();
+  goto_programt::targett t_final = final_skip.add(goto_programt::make_skip());
 
   // build the calls and gotos
 
@@ -124,8 +122,8 @@ void remove_function_pointer(
   for(const auto &fun : functions)
   {
     // call function
-    goto_programt::targett t1 = new_code_calls.add_instruction();
-    t1->make_function_call(code);
+    goto_programt::targett t1 =
+      new_code_calls.add(goto_programt::make_function_call(code));
     to_code_function_call(t1->code).function() = fun;
 
     // the signature of the function might not match precisely
@@ -135,21 +133,20 @@ void remove_function_pointer(
       to_code_function_call(t1->code), new_code_calls, goto_model);
 
     // goto final
-    goto_programt::targett t3 = new_code_calls.add_instruction();
-    t3->make_goto(t_final, true_exprt());
+    new_code_calls.add(goto_programt::make_goto(t_final, true_exprt()));
 
     // goto to call
     address_of_exprt address_of(fun, pointer_type(fun.type()));
 
-    goto_programt::targett t4 = new_code_gotos.add_instruction();
-    t4->make_goto(
+    new_code_gotos.add(goto_programt::make_goto(
       t1,
       equal_exprt(
-        pointer, typecast_exprt::conditional_cast(address_of, pointer.type())));
+        pointer,
+        typecast_exprt::conditional_cast(address_of, pointer.type()))));
   }
 
-  goto_programt::targett t = new_code_gotos.add_instruction();
-  t->make_assertion(false_exprt());
+  goto_programt::targett t =
+    new_code_gotos.add(goto_programt::make_assertion(false_exprt()));
   t->source_location.set_property_class("pointer dereference");
   t->source_location.set_comment("invalid function pointer");
 

--- a/src/goto-programs/goto_program.h
+++ b/src/goto-programs/goto_program.h
@@ -353,106 +353,12 @@ public:
       clear(SKIP);
     }
 
-    DEPRECATED(SINCE(2019, 2, 13, "use goto_programt::make_return() instead"))
-    void make_return() { clear(RETURN); }
-
-    DEPRECATED(SINCE(2019, 2, 13, "use goto_programt::make_skip() instead"))
-    void make_skip() { clear(SKIP); }
-
-    DEPRECATED(SINCE(2019, 2, 13, "use goto_programt::make_location() instead"))
-    void make_location(const source_locationt &l)
-    { clear(LOCATION); source_location=l; }
-
-    DEPRECATED(SINCE(2019, 2, 13, "use goto_programt::make_throw() instead"))
-    void make_throw() { clear(THROW); }
-
-    DEPRECATED(SINCE(2019, 2, 13, "use goto_programt::make_catch() instead"))
-    void make_catch() { clear(CATCH); }
-
-    DEPRECATED(
-      SINCE(2019, 2, 13, "use goto_programt::make_assertion() instead"))
-    void make_assertion(const exprt &g) { clear(ASSERT); guard=g; }
-
-    DEPRECATED(
-      SINCE(2019, 2, 13, "use goto_programt::make_assumption() instead"))
-    void make_assumption(const exprt &g) { clear(ASSUME); guard=g; }
-
-    DEPRECATED(
-      SINCE(2019, 2, 13, "use goto_programt::make_assignment() instead"))
-    void make_assignment() { clear(ASSIGN); }
-
-    DEPRECATED(SINCE(2019, 2, 13, "use goto_programt::make_other() instead"))
-    void make_other(const codet &_code) { clear(OTHER); code=_code; }
-
-    DEPRECATED(SINCE(2019, 2, 13, "use goto_programt::make_decl() instead"))
-    void make_decl() { clear(DECL); }
-
-    DEPRECATED(SINCE(2019, 2, 13, "use goto_programt::make_dead() instead"))
-    void make_dead() { clear(DEAD); }
-
-    DEPRECATED(
-      SINCE(2019, 2, 13, "use goto_programt::make_atomic_begin() instead"))
-    void make_atomic_begin() { clear(ATOMIC_BEGIN); }
-
-    DEPRECATED(
-      SINCE(2019, 2, 13, "use goto_programt::make_atomic_end() instead"))
-    void make_atomic_end() { clear(ATOMIC_END); }
-
-    DEPRECATED(
-      SINCE(2019, 2, 13, "use goto_programt::make_end_function() instead"))
-    void make_end_function() { clear(END_FUNCTION); }
-
-    DEPRECATED(
-      SINCE(2019, 2, 13, "use goto_programt::make_incomplete_goto() instead"))
-    void make_incomplete_goto(const code_gotot &_code)
-    {
-      clear(INCOMPLETE_GOTO);
-      code = _code;
-    }
-
-    DEPRECATED(SINCE(2019, 2, 13, "use goto_programt::make_goto() instead"))
-    void make_goto(targett _target)
-    {
-      clear(GOTO);
-      targets.push_back(_target);
-    }
-
-    DEPRECATED(SINCE(2019, 2, 13, "use goto_programt::make_goto() instead"))
-    void make_goto(targett _target, const exprt &g)
-    {
-      make_goto(_target);
-      guard=g;
-    }
-
     void complete_goto(targett _target)
     {
       PRECONDITION(type == INCOMPLETE_GOTO);
       code.make_nil();
       targets.push_back(_target);
       type = GOTO;
-    }
-
-    DEPRECATED(
-      SINCE(2019, 2, 13, "use goto_programt::make_assignment() instead"))
-    void make_assignment(const code_assignt &_code)
-    {
-      clear(ASSIGN);
-      code=_code;
-    }
-
-    DEPRECATED(SINCE(2019, 2, 13, "use goto_programt::make_decl() instead"))
-    void make_decl(const code_declt &_code)
-    {
-      clear(DECL);
-      code=_code;
-    }
-
-    DEPRECATED(
-      SINCE(2019, 2, 13, "use goto_programt::make_function_call() instead"))
-    void make_function_call(const code_function_callt &_code)
-    {
-      clear(FUNCTION_CALL);
-      code=_code;
     }
 
     bool is_goto         () const { return type==GOTO;          }

--- a/unit/goto-programs/goto_program_table_consistency.cpp
+++ b/unit/goto-programs/goto_program_table_consistency.cpp
@@ -32,14 +32,11 @@ SCENARIO(
     binary_relation_exprt x_le_10(varx, ID_le, val10);
 
     goto_functiont goto_function;
-    auto &instructions = goto_function.body.instructions;
-    instructions.emplace_back(goto_programt::make_assertion(x_le_10));
+    goto_function.body.add(goto_programt::make_assertion(x_le_10));
 
     // required as goto_function.validate checks (if a function has a body) that
     // the last instruction of a function body marks the function's end.
-    goto_programt::instructiont end_function_instruction;
-    end_function_instruction.make_end_function();
-    instructions.push_back(end_function_instruction);
+    goto_function.body.add(goto_programt::make_end_function());
 
     symbol_table.insert(function_symbol);
     WHEN("Symbol table has the right symbol")

--- a/unit/goto-programs/goto_program_validate.cpp
+++ b/unit/goto-programs/goto_program_validate.cpp
@@ -193,13 +193,10 @@ SCENARIO("Validation of a goto program", "[core][goto-programs][validate]")
     {
       goto_convert(goto_model, null_message_handler);
 
-      goto_programt::instructiont instruction;
-      instruction.make_return();
-
       auto &function_map = goto_model.goto_functions.function_map;
       auto it = function_map.find("g");
       auto &instructions = it->second.body.instructions;
-      instructions.insert(instructions.begin(), instruction);
+      instructions.insert(instructions.begin(), goto_programt::make_return());
 
       goto_model_validation_optionst validation_options{
         goto_model_validation_optionst ::set_optionst::all_false};


### PR DESCRIPTION
These were deprecated in 2019. All remaining in-tree uses are updated
according to the instructions provided with the deprecated methods.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
