### PR TITLE
Remove unnecessary deprecate.h includes

### DIFF
--- a/src/goto-programs/link_to_library.h
+++ b/src/goto-programs/link_to_library.h
@@ -15,7 +15,6 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <functional>
 #include <set>
 
-#include <util/deprecate.h>
 #include <util/irep.h>
 
 class goto_modelt;

--- a/src/goto-programs/read_goto_binary.h
+++ b/src/goto-programs/read_goto_binary.h
@@ -14,7 +14,6 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <string>
 
-#include <util/deprecate.h>
 #include <util/optional.h>
 
 class goto_functionst;

--- a/src/util/string_utils.h
+++ b/src/util/string_utils.h
@@ -10,8 +10,6 @@ Author: Daniel Poetzl
 #ifndef CPROVER_UTIL_STRING_UTILS_H
 #define CPROVER_UTIL_STRING_UTILS_H
 
-#include "deprecate.h"
-
 #include <iosfwd>
 #include <string>
 #include <vector>

--- a/src/util/type.h
+++ b/src/util/type.h
@@ -15,7 +15,6 @@ Author: Daniel Kroening, kroening@kroening.com
 
 class namespacet;
 
-#include "deprecate.h"
 #include "source_location.h"
 #include "validate_types.h"
 #include "validation_mode.h"


### PR DESCRIPTION
The procedures or methods marked `DEPRECATED` have been removed already,
but the #include was unnecessarily left in place.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
