### PR TITLE
Synchronise goto-cc command-line options to re-enable Windows regression tests

### DIFF
--- a/regression/goto-cc-cbmc-shared-options/CMakeLists.txt
+++ b/regression/goto-cc-cbmc-shared-options/CMakeLists.txt
@@ -1,11 +1,9 @@
 if(WIN32)
     set(is_windows true)
-    set(exclude_broken_windows_tests -X winbug)
 else()
     set(is_windows false)
-    set(exclude_broken_windows_tests "")
 endif()
 
 add_test_pl_tests(
-    "${CMAKE_CURRENT_SOURCE_DIR}/chain.sh $<TARGET_FILE:goto-cc> $<TARGET_FILE:cbmc> ${is_windows}" ${exclude_broken_windows_tests}
+    "${CMAKE_CURRENT_SOURCE_DIR}/chain.sh $<TARGET_FILE:goto-cc> $<TARGET_FILE:cbmc> ${is_windows}"
 )

--- a/regression/goto-cc-cbmc-shared-options/object-bits/fewer_bits.desc
+++ b/regression/goto-cc-cbmc-shared-options/object-bits/fewer_bits.desc
@@ -1,4 +1,4 @@
-CORE winbug
+CORE
 test.c
 --function main --object-bits 6
 ^EXIT=10$

--- a/regression/goto-cc-cbmc-shared-options/object-bits/more_bits.desc
+++ b/regression/goto-cc-cbmc-shared-options/object-bits/more_bits.desc
@@ -1,4 +1,4 @@
-CORE winbug
+CORE
 test.c
 --function main --object-bits 10
 ^EXIT=10$

--- a/src/goto-cc/armcc_cmdline.cpp
+++ b/src/goto-cc/armcc_cmdline.cpp
@@ -25,7 +25,7 @@ Author: Daniel Kroening
 /// \return none
 // see
 // http://infocenter.arm.com/help/topic/com.arm.doc.dui0472c/Cchbggjb.html
-
+// clang-format off
 static const char *options_no_arg[]=
 {
   // goto-cc-specific
@@ -44,6 +44,9 @@ static const char *options_no_arg[]=
   "--no-arch",
   "--no-library",
   "--string-abstraction",
+  "--validate-goto-model",
+  "-?",
+  "--export-file-local-symbols",
 
   // armcc
   "--help",
@@ -201,7 +204,6 @@ static const char *options_no_arg[]=
   nullptr
 };
 
-// clang-format off
 static const std::vector<std::string> options_with_prefix
 {
   "--project=",
@@ -256,6 +258,9 @@ static const std::vector<std::string> options_with_arg
   // goto-cc specific
   "--verbosity",
   "--function",
+  "--print-rejected-preprocessed-source",
+  "--mangle-suffix",
+  "--object-bits",
 
   // armcc-specific
   "-D",

--- a/src/goto-cc/bcc_cmdline.cpp
+++ b/src/goto-cc/bcc_cmdline.cpp
@@ -16,6 +16,7 @@ Author: Michael Tautschnig
 
 #include <util/prefix.h>
 
+// clang-format off
 // non-bcc options
 const char *goto_bcc_options_with_argument[]=
 {
@@ -24,6 +25,8 @@ const char *goto_bcc_options_with_argument[]=
   "--native-compiler",
   "--native-linker",
   "--print-rejected-preprocessed-source",
+  "--mangle-suffix",
+  "--object-bits",
   nullptr
 };
 
@@ -66,6 +69,7 @@ const char *bcc_options_with_argument[]=
   "-t",
   nullptr
 };
+// clang-format on
 
 bool bcc_cmdlinet::parse(int argc, const char **argv)
 {

--- a/src/goto-cc/ms_cl_cmdline.cpp
+++ b/src/goto-cc/ms_cl_cmdline.cpp
@@ -48,6 +48,7 @@ const char *non_ms_cl_options[]=
   "--validate-goto-model",
   "--export-file-local-symbols",
   "--mangle-suffix",
+  "--object-bits",
   nullptr
 };
 // clang-format on
@@ -63,7 +64,7 @@ bool ms_cl_cmdlinet::parse(const std::vector<std::string> &arguments)
 
       if(
         arguments[i] == "--verbosity" || arguments[i] == "--function" ||
-        arguments[i] == "--mangle-suffix")
+        arguments[i] == "--mangle-suffix" || arguments[i] == "--object-bits")
       {
         if(i < arguments.size() - 1)
         {

--- a/src/goto-cc/ms_link_cmdline.cpp
+++ b/src/goto-cc/ms_link_cmdline.cpp
@@ -19,14 +19,17 @@ Author: Daniel Kroening
 
 #include <util/unicode.h>
 
+// clang-format off
 /// parses the command line options into a cmdlinet
 /// \par parameters: argument count, argument strings
 /// \return none
 const char *non_ms_link_options[]=
 {
   "--help",
-  "--verbosity"
+  "--verbosity",
+  "--validate-goto-model"
 };
+// clang-format on
 
 bool ms_link_cmdlinet::parse(const std::vector<std::string> &arguments)
 {


### PR DESCRIPTION
object-bits was not supported by all of goto-cc's command-line front-end
variants. While at it, also make other options consistently available.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
