### PR TITLE
Fix PATH separator and CMake syntax to make cbmc-cprover-smt2 tests work on Windows

### DIFF
--- a/regression/cbmc/CMakeLists.txt
+++ b/regression/cbmc/CMakeLists.txt
@@ -1,41 +1,40 @@
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
   set(gcc_only -X gcc-only)
+  set(gcc_only_string "-X;gcc-only;")
 else()
   set(gcc_only "")
-endif()
-
-if("${CMAKE_SYSTEM_NAME}" STREQUAL "Windows")
-  set(exclude_win_broken_tests -X winbug)
-else()
-  set(exclude_win_broken_tests "")
+  set(gcc_only_string "")
 endif()
 
 add_test_pl_tests(
-    "$<TARGET_FILE:cbmc> --validate-goto-model --validate-ssa-equation" -X smt-backend ${gcc_only} ${exclude_win_broken_tests}
+    "$<TARGET_FILE:cbmc> --validate-goto-model --validate-ssa-equation" -X smt-backend ${gcc_only}
 )
 
 add_test_pl_profile(
     "cbmc-paths-lifo"
     "$<TARGET_FILE:cbmc> --paths lifo"
-    "-C;-X;thorough-paths;-X;smt-backend;-X;paths-lifo-expected-failure;-s;paths-lifo"
+    "-C;-X;thorough-paths;-X;smt-backend;-X;paths-lifo-expected-failure;${gcc_only_string}-s;paths-lifo"
     "CORE"
-    ${gcc_only}
 )
 
-if("${CMAKE_SYSTEM_NAME}" STREQUAL "Windows")
-  message(WARNING "Tests are failing on windows under this config, for reasons unknown. Investigation is pending.")
-else()
-  add_test_pl_profile(
+add_test_pl_profile(
     "cbmc-cprover-smt2"
     "$<TARGET_FILE:cbmc> --cprover-smt2"
-    "-C;-X;broken-smt-backend;-s;cprover-smt2"
+    "-C;-X;broken-smt-backend;${gcc_only_string}-s;cprover-smt2"
     "CORE"
-    ${gcc_only}
-    )
+)
 
+if(NOT "${CMAKE_SYSTEM_NAME}" STREQUAL "Windows")
   set_property(
     TEST "cbmc-cprover-smt2-CORE"
     PROPERTY ENVIRONMENT
-      "PATH=$ENV{PATH}:${CMAKE_BINARY_DIR}/bin"
+      "PATH=$ENV{PATH}:$<TARGET_FILE_DIR:smt2_solver>"
+  )
+else()
+  string(REPLACE ";" "\\;" path_value "$ENV{PATH}")
+  set_property(
+    TEST "cbmc-cprover-smt2-CORE"
+    PROPERTY ENVIRONMENT
+      "PATH=${path_value}\;$<TARGET_FILE_DIR:smt2_solver>"
   )
 endif()

--- a/regression/cbmc/address_space_size_limit1/test.desc
+++ b/regression/cbmc/address_space_size_limit1/test.desc
@@ -1,4 +1,4 @@
-CORE thorough-paths broken-smt-backend winbug
+CORE thorough-paths broken-smt-backend
 test.c
 --no-simplify --unwind 300 --object-bits 8
 too many addressed objects


### PR DESCRIPTION
Windows separates PATH components by semicolons. add_test_pl_profile does not take more than 4 arguments.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
