### PR TITLE
Fix missing includes of deprecate.h

### DIFF
--- a/src/analyses/ai.h
+++ b/src/analyses/ai.h
@@ -49,10 +49,11 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <map>
 #include <memory>
 
-#include <util/json.h>
-#include <util/xml.h>
+#include <util/deprecate.h>
 #include <util/expr.h>
+#include <util/json.h>
 #include <util/make_unique.h>
+#include <util/xml.h>
 
 #include <goto-programs/goto_model.h>
 

--- a/src/analyses/ai_domain.h
+++ b/src/analyses/ai_domain.h
@@ -40,6 +40,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #ifndef CPROVER_ANALYSES_AI_DOMAIN_H
 #define CPROVER_ANALYSES_AI_DOMAIN_H
 
+#include <util/deprecate.h>
 #include <util/expr.h>
 #include <util/json.h>
 #include <util/make_unique.h>

--- a/src/analyses/ai_storage.h
+++ b/src/analyses/ai_storage.h
@@ -23,6 +23,8 @@ Author: Martin Brain, martin.brain@cs.ox.ac.uk
 #ifndef CPROVER_ANALYSES_AI_STORAGE_H
 #define CPROVER_ANALYSES_AI_STORAGE_H
 
+#include <util/deprecate.h>
+
 #include <goto-programs/goto_program.h>
 
 #include "ai_domain.h"


### PR DESCRIPTION
These files relied on goto_function.h to provide the include, which it
won't do in future.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
