### PR TITLE
Fix and re-enable regression tests that use goto-cl /c

### DIFF
--- a/regression/goto-cc-file-local/CMakeLists.txt
+++ b/regression/goto-cc-file-local/CMakeLists.txt
@@ -4,12 +4,6 @@ else()
     set(is_windows false)
 endif()
 
-
-if(NOT WIN32)
-    add_test_pl_tests(
-        "${CMAKE_CURRENT_SOURCE_DIR}/chain.sh $<TARGET_FILE:goto-cc> $<TARGET_FILE:goto-instrument> $<TARGET_FILE:cbmc> ${is_windows}"
-    )
-else()
-    message(WARNING "Tests are failing under windows for unknown reasons")
-endif()
-
+add_test_pl_tests(
+    "${CMAKE_CURRENT_SOURCE_DIR}/chain.sh $<TARGET_FILE:goto-cc> $<TARGET_FILE:goto-instrument> $<TARGET_FILE:cbmc> ${is_windows}"
+)

--- a/regression/goto-cc-file-local/chain.sh
+++ b/regression/goto-cc-file-local/chain.sh
@@ -63,7 +63,7 @@ if is_in compile-and-link "$ALL_ARGS"; then
           ${wall}                         \
           ${suffix}                       \
           ${SRC}                          \
-          /Fe"${OUT_FILE}"
+          "/Fe${OUT_FILE}"
   
     else
       "${goto_cc}"                        \
@@ -95,8 +95,8 @@ else
           --verbosity 10                  \
           ${wall}                         \
           ${suffix}                       \
-          /c "${base}.c"                  \
-          /Fo"${OUT_FILE}"
+          '/c' "${base}.c"                  \
+          "/Fo${OUT_FILE}"
   
     else
       "${goto_cc}"                        \
@@ -120,7 +120,7 @@ if is_in final-link "$ALL_ARGS"; then
         ${wall}                         \
         ${suffix}                       \
         ./*.gb                          \
-        /Fe"${OUT_FILE}"
+        "/Fe${OUT_FILE}"
 
   else
     "${goto_cc}"                        \

--- a/regression/goto-cl/CMakeLists.txt
+++ b/regression/goto-cl/CMakeLists.txt
@@ -1,3 +1,3 @@
 add_test_pl_tests(
-    "$<TARGET_FILE:goto-cc>" -X goto-link -X winbug
+    "$<TARGET_FILE:goto-cc>" -X goto-link
 )

--- a/regression/goto-cl/Fo/Fo-no-directory.desc
+++ b/regression/goto-cl/Fo/Fo-no-directory.desc
@@ -1,4 +1,4 @@
-CORE winbug
+CORE
 
 --verbosity 10 /c main1.c main2.c /Fodir
 ^EXIT=64$

--- a/regression/test.pl
+++ b/regression/test.pl
@@ -41,7 +41,8 @@ sub run($$$$$) {
   }
 
   print LOG "Running $cmdline\n";
-  system("bash", "-c", "cd '$name' ; $cmdline");
+  # see https://github.com/git-for-windows/msys2-runtime/pull/11/files
+  system("bash", "-c", "cd '$name' ; MSYS_NO_PATHCONV=1 $cmdline");
   my $exit_value = $? >> 8;
   my $signal_num = $? & 127;
   my $dumped_core = $? & 128;


### PR DESCRIPTION
The shell running in Windows GitHub actions performs path expansion of
/c, turning this into C:\. The latter isn't the expected goto-cl command
line argument anymore. Thus quote /c to avoid expansion.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
