### PR TITLE
Fix path to java models library

### DIFF
--- a/jbmc/regression/jbmc-concurrency/CMakeLists.txt
+++ b/jbmc/regression/jbmc-concurrency/CMakeLists.txt
@@ -1,9 +1,3 @@
-if("${CMAKE_SYSTEM_NAME}" STREQUAL "Windows")
-  set(exclude_win_broken_tests -X winbug)
-else()
-  set(exclude_win_broken_tests "")
-endif()
-
 add_test_pl_tests(
-    "$<TARGET_FILE:jbmc> --validate-goto-model --validate-ssa-equation" ${exclude_win_broken_tests}
+    "$<TARGET_FILE:jbmc> --validate-goto-model --validate-ssa-equation"
 )

--- a/jbmc/regression/jbmc-concurrency/synchronized/test.desc
+++ b/jbmc/regression/jbmc-concurrency/synchronized/test.desc
@@ -1,6 +1,6 @@
-CORE winbug
+CORE
 Sync
---java-threading --throw-runtime-exceptions --cp `../../../../scripts/format_classpath.sh . ../../../src/java_bytecode/library/core-models.jar`
+--java-threading --throw-runtime-exceptions --cp `../../../../scripts/format_classpath.sh .  ../../../lib/java-models-library/target/core-models.jar`
 ^EXIT=0$
 ^SIGNAL=0$
 ^VERIFICATION SUCCESSFUL$


### PR DESCRIPTION
The regression test previously failed on Windows, but only because of
the wrong path to the library.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
