### PR TITLE
Use single quotes to make regression tests work on Windows

### DIFF
--- a/jbmc/regression/jbmc-strings/CMakeLists.txt
+++ b/jbmc/regression/jbmc-strings/CMakeLists.txt
@@ -1,20 +1,10 @@
-if("${CMAKE_SYSTEM_NAME}" STREQUAL "Windows")
-  set(exclude_win_broken_tests -X winbug)
-else()
-  set(exclude_win_broken_tests "")
-endif()
-
 add_test_pl_tests(
-    "$<TARGET_FILE:jbmc> --validate-goto-model --validate-ssa-equation" ${exclude_win_broken_tests}
+    "$<TARGET_FILE:jbmc> --validate-goto-model --validate-ssa-equation"
 )
 
-if("${CMAKE_SYSTEM_NAME}" STREQUAL "Windows")
-  message(WARNING "skipping broken jbmc-strings/ tests on windows")
-else()
-  add_test_pl_profile(
-    "jbmc-strings-symex-driven-lazy-loading"
-    "$<TARGET_FILE:jbmc> --validate-goto-model --validate-ssa-equation --symex-driven-lazy-loading"
-    "-C;-X;symex-driven-lazy-loading-expected-failure;-s;symex-driven-loading"
-    "CORE"
-    )
-endif()
+add_test_pl_profile(
+  "jbmc-strings-symex-driven-lazy-loading"
+  "$<TARGET_FILE:jbmc> --validate-goto-model --validate-ssa-equation --symex-driven-lazy-loading"
+  "-C;-X;symex-driven-lazy-loading-expected-failure;-s;symex-driven-loading"
+  "CORE"
+  )

--- a/jbmc/regression/jbmc-strings/ConstantEvaluationCompareTo/test_fail1.desc
+++ b/jbmc/regression/jbmc-strings/ConstantEvaluationCompareTo/test_fail1.desc
@@ -1,6 +1,6 @@
-CORE winbug
+CORE
 Main
---function Main.constantCompareToFail1 --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar` --property "java::Main.constantCompareToFail1:()V.assertion.1"
+--function Main.constantCompareToFail1 --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar` --property 'java::Main.constantCompareToFail1:()V.assertion.1'
 ^VERIFICATION FAILED$
 ^EXIT=10$
 ^SIGNAL=0$

--- a/jbmc/regression/jbmc-strings/ConstantEvaluationCompareTo/test_fail1_vcc.desc
+++ b/jbmc/regression/jbmc-strings/ConstantEvaluationCompareTo/test_fail1_vcc.desc
@@ -1,6 +1,6 @@
-CORE winbug
+CORE
 Main
---function Main.constantCompareToFail1 --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar` --property "java::Main.constantCompareToFail1:()V.assertion.1" --show-vcc
+--function Main.constantCompareToFail1 --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar` --property 'java::Main.constantCompareToFail1:()V.assertion.1' --show-vcc
 ^EXIT=0$
 ^SIGNAL=0$
 \{1\} false

--- a/jbmc/regression/jbmc-strings/ConstantEvaluationCompareTo/test_fail2.desc
+++ b/jbmc/regression/jbmc-strings/ConstantEvaluationCompareTo/test_fail2.desc
@@ -1,6 +1,6 @@
-CORE winbug
+CORE
 Main
---function Main.constantCompareToFail2 --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar` --property "java::Main.constantCompareToFail2:()V.assertion.1"
+--function Main.constantCompareToFail2 --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar` --property 'java::Main.constantCompareToFail2:()V.assertion.1'
 ^VERIFICATION FAILED$
 ^EXIT=10$
 ^SIGNAL=0$

--- a/jbmc/regression/jbmc-strings/ConstantEvaluationCompareTo/test_fail2_vcc.desc
+++ b/jbmc/regression/jbmc-strings/ConstantEvaluationCompareTo/test_fail2_vcc.desc
@@ -1,6 +1,6 @@
-CORE winbug
+CORE
 Main
---function Main.constantCompareToFail2 --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar` --property "java::Main.constantCompareToFail2:()V.assertion.1" --show-vcc
+--function Main.constantCompareToFail2 --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar` --property 'java::Main.constantCompareToFail2:()V.assertion.1' --show-vcc
 ^EXIT=0$
 ^SIGNAL=0$
 \{1\} false

--- a/jbmc/regression/jbmc-strings/ConstantEvaluationCompareTo/test_fail3.desc
+++ b/jbmc/regression/jbmc-strings/ConstantEvaluationCompareTo/test_fail3.desc
@@ -1,6 +1,6 @@
-CORE winbug
+CORE
 Main
---function Main.constantCompareToFail3 --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar` --property "java::Main.constantCompareToFail3:()V.assertion.1"
+--function Main.constantCompareToFail3 --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar` --property 'java::Main.constantCompareToFail3:()V.assertion.1'
 ^VERIFICATION FAILED$
 ^EXIT=10$
 ^SIGNAL=0$

--- a/jbmc/regression/jbmc-strings/ConstantEvaluationCompareTo/test_fail3_vcc.desc
+++ b/jbmc/regression/jbmc-strings/ConstantEvaluationCompareTo/test_fail3_vcc.desc
@@ -1,6 +1,6 @@
-CORE winbug
+CORE
 Main
---function Main.constantCompareToFail3 --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar` --property "java::Main.constantCompareToFail3:()V.assertion.1" --show-vcc
+--function Main.constantCompareToFail3 --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar` --property 'java::Main.constantCompareToFail3:()V.assertion.1' --show-vcc
 ^EXIT=0$
 ^SIGNAL=0$
 \{1\} false

--- a/jbmc/regression/jbmc-strings/ConstantEvaluationCompareTo/test_fail4.desc
+++ b/jbmc/regression/jbmc-strings/ConstantEvaluationCompareTo/test_fail4.desc
@@ -1,6 +1,6 @@
-CORE winbug
+CORE
 Main
---function Main.constantCompareToFail4 --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar` --property "java::Main.constantCompareToFail4:()V.assertion.1"
+--function Main.constantCompareToFail4 --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar` --property 'java::Main.constantCompareToFail4:()V.assertion.1'
 ^VERIFICATION FAILED$
 ^EXIT=10$
 ^SIGNAL=0$

--- a/jbmc/regression/jbmc-strings/ConstantEvaluationCompareTo/test_fail4_vcc.desc
+++ b/jbmc/regression/jbmc-strings/ConstantEvaluationCompareTo/test_fail4_vcc.desc
@@ -1,6 +1,6 @@
-CORE winbug
+CORE
 Main
---function Main.constantCompareToFail4 --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar` --property "java::Main.constantCompareToFail4:()V.assertion.1" --show-vcc
+--function Main.constantCompareToFail4 --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar` --property 'java::Main.constantCompareToFail4:()V.assertion.1' --show-vcc
 ^EXIT=0$
 ^SIGNAL=0$
 \{1\} false

--- a/jbmc/regression/jbmc-strings/ConstantEvaluationEndsWith/test_fail.desc
+++ b/jbmc/regression/jbmc-strings/ConstantEvaluationEndsWith/test_fail.desc
@@ -1,6 +1,6 @@
-CORE winbug
+CORE
 Main
---function Main.constantEndsWithFail --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar` --property "java::Main.constantEndsWithFail:()V.assertion.1" 
+--function Main.constantEndsWithFail --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar` --property 'java::Main.constantEndsWithFail:()V.assertion.1' 
 ^VERIFICATION FAILED$
 ^EXIT=10$
 ^SIGNAL=0$

--- a/jbmc/regression/jbmc-strings/ConstantEvaluationEndsWith/test_fail_vcc.desc
+++ b/jbmc/regression/jbmc-strings/ConstantEvaluationEndsWith/test_fail_vcc.desc
@@ -1,6 +1,6 @@
-CORE winbug
+CORE
 Main
---function Main.constantEndsWithFail --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar` --property "java::Main.constantEndsWithFail:()V.assertion.1" --show-vcc
+--function Main.constantEndsWithFail --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar` --property 'java::Main.constantEndsWithFail:()V.assertion.1' --show-vcc
 ^EXIT=0$
 ^SIGNAL=0$
 \{1\} false

--- a/jbmc/regression/jbmc-strings/ConstantEvaluationEndsWith/test_pass.desc
+++ b/jbmc/regression/jbmc-strings/ConstantEvaluationEndsWith/test_pass.desc
@@ -1,6 +1,6 @@
-CORE winbug
+CORE
 Main
---function Main.constantEndsWithPass --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar` --property "java::Main.constantEndsWithPass:()V.assertion.1"
+--function Main.constantEndsWithPass --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar` --property 'java::Main.constantEndsWithPass:()V.assertion.1'
 ^Generated [0-9]+ VCC\(s\), 0 remaining after simplification
 ^VERIFICATION SUCCESSFUL$
 ^EXIT=0$

--- a/jbmc/regression/jbmc-strings/ConstantEvaluationIsEmpty/test_fail.desc
+++ b/jbmc/regression/jbmc-strings/ConstantEvaluationIsEmpty/test_fail.desc
@@ -1,6 +1,6 @@
-CORE winbug
+CORE
 Main
---function Main.constantIsEmptyFail --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar` --property "java::Main.constantIsEmptyFail:()V.assertion.1"
+--function Main.constantIsEmptyFail --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar` --property 'java::Main.constantIsEmptyFail:()V.assertion.1'
 ^VERIFICATION FAILED$
 ^EXIT=10$
 ^SIGNAL=0$

--- a/jbmc/regression/jbmc-strings/ConstantEvaluationIsEmpty/test_fail_vcc.desc
+++ b/jbmc/regression/jbmc-strings/ConstantEvaluationIsEmpty/test_fail_vcc.desc
@@ -1,6 +1,6 @@
-CORE winbug
+CORE
 Main
---function Main.constantIsEmptyFail --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar` --show-vcc --property "java::Main.constantIsEmptyFail:()V.assertion.1" 
+--function Main.constantIsEmptyFail --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar` --show-vcc --property 'java::Main.constantIsEmptyFail:()V.assertion.1' 
 ^EXIT=0$
 ^SIGNAL=0$
 \{1\} false

--- a/jbmc/regression/jbmc-strings/ConstantEvaluationIsEmpty/test_pass.desc
+++ b/jbmc/regression/jbmc-strings/ConstantEvaluationIsEmpty/test_pass.desc
@@ -1,6 +1,6 @@
-CORE winbug
+CORE
 Main
---function Main.constantIsEmptyPass --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar` --property "java::Main.constantIsEmptyPass:()V.assertion.1"
+--function Main.constantIsEmptyPass --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar` --property 'java::Main.constantIsEmptyPass:()V.assertion.1'
 ^Generated [0-9]+ VCC\(s\), 0 remaining after simplification$
 ^VERIFICATION SUCCESSFUL$
 ^EXIT=0$

--- a/jbmc/regression/jbmc-strings/ConstantEvaluationStringBuilderAppend01/test.desc
+++ b/jbmc/regression/jbmc-strings/ConstantEvaluationStringBuilderAppend01/test.desc
@@ -1,6 +1,6 @@
-CORE winbug
+CORE
 Main
---function Main.test --property "java::Main.test:()V.assertion.1" --property "java::Main.test:()V.assertion.2"
+--function Main.test --property 'java::Main.test:()V.assertion.1' --property 'java::Main.test:()V.assertion.2'
 ^Generated [0-9]+ VCC\(s\), 0 remaining after simplification$
 ^EXIT=0$
 ^SIGNAL=0$

--- a/jbmc/regression/jbmc-strings/ConstantEvaluationStringBuilderAppend02-WithEmptyString/test1.desc
+++ b/jbmc/regression/jbmc-strings/ConstantEvaluationStringBuilderAppend02-WithEmptyString/test1.desc
@@ -1,6 +1,6 @@
-CORE winbug
+CORE
 Main
---function Main.test1 --property "java::Main.test1:()V.assertion.1" --property "java::Main.test1:()V.assertion.2"
+--function Main.test1 --property 'java::Main.test1:()V.assertion.1' --property 'java::Main.test1:()V.assertion.2'
 ^Generated [0-9]+ VCC\(s\), 0 remaining after simplification$
 ^EXIT=0$
 ^SIGNAL=0$

--- a/jbmc/regression/jbmc-strings/ConstantEvaluationStringBuilderAppend02-WithEmptyString/test2.desc
+++ b/jbmc/regression/jbmc-strings/ConstantEvaluationStringBuilderAppend02-WithEmptyString/test2.desc
@@ -1,6 +1,6 @@
-CORE winbug
+CORE
 Main
---function Main.test2 --property "java::Main.test2:()V.assertion.1" --property "java::Main.test2:()V.assertion.2"
+--function Main.test2 --property 'java::Main.test2:()V.assertion.1' --property 'java::Main.test2:()V.assertion.2'
 ^Generated [0-9]+ VCC\(s\), 0 remaining after simplification$
 ^EXIT=0$
 ^SIGNAL=0$

--- a/jbmc/regression/jbmc-strings/ConstantEvaluationStringBuilderAppend02-WithEmptyString/test3.desc
+++ b/jbmc/regression/jbmc-strings/ConstantEvaluationStringBuilderAppend02-WithEmptyString/test3.desc
@@ -1,6 +1,6 @@
-CORE winbug
+CORE
 Main
---function Main.test3 --property "java::Main.test3:()V.assertion.1" --property "java::Main.test3:()V.assertion.2"
+--function Main.test3 --property 'java::Main.test3:()V.assertion.1' --property 'java::Main.test3:()V.assertion.2'
 ^Generated [0-9]+ VCC\(s\), 0 remaining after simplification$
 ^EXIT=0$
 ^SIGNAL=0$

--- a/jbmc/regression/jbmc-strings/ConstantEvaluationStringConcatenation01/test.desc
+++ b/jbmc/regression/jbmc-strings/ConstantEvaluationStringConcatenation01/test.desc
@@ -1,6 +1,6 @@
-CORE winbug
+CORE
 Main
---function Main.test --property "java::Main.test:()V.assertion.1" --property "java::Main.test:()V.assertion.2"
+--function Main.test --property 'java::Main.test:()V.assertion.1' --property 'java::Main.test:()V.assertion.2'
 ^Generated [0-9]+ VCC\(s\), 0 remaining after simplification$
 ^EXIT=0$
 ^SIGNAL=0$

--- a/jbmc/regression/jbmc-strings/ConstantEvaluationStringConcatenation02-WithEmptyString/test1.desc
+++ b/jbmc/regression/jbmc-strings/ConstantEvaluationStringConcatenation02-WithEmptyString/test1.desc
@@ -1,6 +1,6 @@
-CORE winbug
+CORE
 Main
---function Main.test1 --property "java::Main.test1:()V.assertion.1" --property "java::Main.test1:()V.assertion.2"
+--function Main.test1 --property 'java::Main.test1:()V.assertion.1' --property 'java::Main.test1:()V.assertion.2'
 ^Generated [0-9]+ VCC\(s\), 0 remaining after simplification$
 ^EXIT=0$
 ^SIGNAL=0$

--- a/jbmc/regression/jbmc-strings/ConstantEvaluationStringConcatenation02-WithEmptyString/test2.desc
+++ b/jbmc/regression/jbmc-strings/ConstantEvaluationStringConcatenation02-WithEmptyString/test2.desc
@@ -1,6 +1,6 @@
-CORE winbug
+CORE
 Main
---function Main.test2 --property "java::Main.test2:()V.assertion.1" --property "java::Main.test2:()V.assertion.2"
+--function Main.test2 --property 'java::Main.test2:()V.assertion.1' --property 'java::Main.test2:()V.assertion.2'
 ^Generated [0-9]+ VCC\(s\), 0 remaining after simplification$
 ^EXIT=0$
 ^SIGNAL=0$

--- a/jbmc/regression/jbmc-strings/ConstantEvaluationStringConcatenation02-WithEmptyString/test3.desc
+++ b/jbmc/regression/jbmc-strings/ConstantEvaluationStringConcatenation02-WithEmptyString/test3.desc
@@ -1,6 +1,6 @@
-CORE winbug
+CORE
 Main
---function Main.test3 --property "java::Main.test3:()V.assertion.1" --property "java::Main.test3:()V.assertion.2"
+--function Main.test3 --property 'java::Main.test3:()V.assertion.1' --property 'java::Main.test3:()V.assertion.2'
 ^Generated [0-9]+ VCC\(s\), 0 remaining after simplification$
 ^EXIT=0$
 ^SIGNAL=0$

--- a/jbmc/regression/jbmc-strings/ConstantEvaluationStringConcatenation03-NegativeScenarios/test1.desc
+++ b/jbmc/regression/jbmc-strings/ConstantEvaluationStringConcatenation03-NegativeScenarios/test1.desc
@@ -1,6 +1,6 @@
-CORE symex-driven-lazy-loading-expected-failure winbug
+CORE symex-driven-lazy-loading-expected-failure
 Main
---function Main.test1 --property "java::Main.test1:(Ljava/lang/String;)V.assertion.1"
+--function Main.test1 --property 'java::Main.test1:(Ljava/lang/String;)V.assertion.1'
 ^Generated [0-9]+ VCC\(s\), 1 remaining after simplification$
 ^EXIT=10$
 ^SIGNAL=0$

--- a/jbmc/regression/jbmc-strings/ConstantEvaluationStringConcatenation03-NegativeScenarios/test2.desc
+++ b/jbmc/regression/jbmc-strings/ConstantEvaluationStringConcatenation03-NegativeScenarios/test2.desc
@@ -1,6 +1,6 @@
-CORE symex-driven-lazy-loading-expected-failure winbug
+CORE symex-driven-lazy-loading-expected-failure
 Main
---function Main.test2 --property "java::Main.test2:(Ljava/lang/String;)V.assertion.1"
+--function Main.test2 --property 'java::Main.test2:(Ljava/lang/String;)V.assertion.1'
 ^Generated [0-9]+ VCC\(s\), 1 remaining after simplification$
 ^EXIT=10$
 ^SIGNAL=0$

--- a/jbmc/regression/jbmc-strings/ConstantEvaluationStringConcatenation03-NegativeScenarios/test3.desc
+++ b/jbmc/regression/jbmc-strings/ConstantEvaluationStringConcatenation03-NegativeScenarios/test3.desc
@@ -1,6 +1,6 @@
-CORE symex-driven-lazy-loading-expected-failure winbug
+CORE symex-driven-lazy-loading-expected-failure
 Main
---function Main.test3 --property "java::Main.test3:(Ljava/lang/String;)V.assertion.1"
+--function Main.test3 --property 'java::Main.test3:(Ljava/lang/String;)V.assertion.1'
 ^Generated [0-9]+ VCC\(s\), 1 remaining after simplification$
 ^EXIT=10$
 ^SIGNAL=0$

--- a/jbmc/regression/jbmc-strings/ConstantEvaluationStringConcatenation04-StringEqual/test.desc
+++ b/jbmc/regression/jbmc-strings/ConstantEvaluationStringConcatenation04-StringEqual/test.desc
@@ -1,6 +1,6 @@
-CORE winbug
+CORE
 Main
---function Main.test --property "java::Main.test:()V.assertion.1" --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar`
+--function Main.test --property 'java::Main.test:()V.assertion.1' --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar`
 ^Generated [0-9]+ VCC\(s\), 0 remaining after simplification$
 ^EXIT=0$
 ^SIGNAL=0$

--- a/jbmc/regression/jbmc-strings/ConstantEvaluationStringConcatenation06-2byteChar/test.desc
+++ b/jbmc/regression/jbmc-strings/ConstantEvaluationStringConcatenation06-2byteChar/test.desc
@@ -1,6 +1,6 @@
-CORE winbug
+CORE
 Main
---function Main.test --property "java::Main.test:()V.assertion.1" --property "java::Main.test:()V.assertion.2"
+--function Main.test --property 'java::Main.test:()V.assertion.1' --property 'java::Main.test:()V.assertion.2'
 ^Generated [0-9]+ VCC\(s\), 0 remaining after simplification$
 ^EXIT=0$
 ^SIGNAL=0$

--- a/jbmc/regression/jbmc-strings/ConstantEvaluationStringConcatenation07-NonPrintableChar/test.desc
+++ b/jbmc/regression/jbmc-strings/ConstantEvaluationStringConcatenation07-NonPrintableChar/test.desc
@@ -1,6 +1,6 @@
-CORE winbug
+CORE
 Main
---function Main.test --property "java::Main.test:()V.assertion.1" --property "java::Main.test:()V.assertion.2"
+--function Main.test --property 'java::Main.test:()V.assertion.1' --property 'java::Main.test:()V.assertion.2'
 ^Generated [0-9]+ VCC\(s\), 0 remaining after simplification$
 ^EXIT=0$
 ^SIGNAL=0$

--- a/jbmc/regression/jbmc-strings/IndexOfConstantEvaluation03-IndexOutOfRange/test.desc
+++ b/jbmc/regression/jbmc-strings/IndexOfConstantEvaluation03-IndexOutOfRange/test.desc
@@ -1,6 +1,6 @@
-CORE symex-driven-lazy-loading-expected-failure winbug
+CORE symex-driven-lazy-loading-expected-failure
 Main
---function Main.constantIndexOf --property "java::Main.constantIndexOf:(Ljava/lang/String;)V.assertion.1"
+--function Main.constantIndexOf --property 'java::Main.constantIndexOf:(Ljava/lang/String;)V.assertion.1'
 ^Generated [0-9]+ VCC\(s\), 0 remaining after simplification$
 ^VERIFICATION SUCCESSFUL$
 ^EXIT=0$

--- a/jbmc/regression/jbmc-strings/IndexOfConstantEvaluation04-NegativeScenarios/test1.desc
+++ b/jbmc/regression/jbmc-strings/IndexOfConstantEvaluation04-NegativeScenarios/test1.desc
@@ -1,6 +1,6 @@
-CORE symex-driven-lazy-loading-expected-failure winbug
+CORE symex-driven-lazy-loading-expected-failure
 Main
---function Main.constantIndexOf --property "java::Main.constantIndexOf:(Ljava/lang/String;CI)V.assertion.1" --show-vcc
+--function Main.constantIndexOf --property 'java::Main.constantIndexOf:(Ljava/lang/String;CI)V.assertion.1' --show-vcc
 ^Generated 1 VCC\(s\), 1 remaining after simplification$
 ^EXIT=0$
 ^SIGNAL=0$

--- a/jbmc/regression/jbmc-strings/IndexOfConstantEvaluation04-NegativeScenarios/test10.desc
+++ b/jbmc/regression/jbmc-strings/IndexOfConstantEvaluation04-NegativeScenarios/test10.desc
@@ -1,6 +1,6 @@
-CORE symex-driven-lazy-loading-expected-failure winbug
+CORE symex-driven-lazy-loading-expected-failure
 Main
---function Main.constantIndexOf --property "java::Main.constantIndexOf:(Ljava/lang/String;CI)V.assertion.10" --show-vcc
+--function Main.constantIndexOf --property 'java::Main.constantIndexOf:(Ljava/lang/String;CI)V.assertion.10' --show-vcc
 ^Generated 1 VCC\(s\), 1 remaining after simplification$
 ^EXIT=0$
 ^SIGNAL=0$

--- a/jbmc/regression/jbmc-strings/IndexOfConstantEvaluation04-NegativeScenarios/test11.desc
+++ b/jbmc/regression/jbmc-strings/IndexOfConstantEvaluation04-NegativeScenarios/test11.desc
@@ -1,6 +1,6 @@
-CORE symex-driven-lazy-loading-expected-failure winbug
+CORE symex-driven-lazy-loading-expected-failure
 Main
---function Main.constantIndexOf --property "java::Main.constantIndexOf:(Ljava/lang/String;CI)V.assertion.11" --show-vcc
+--function Main.constantIndexOf --property 'java::Main.constantIndexOf:(Ljava/lang/String;CI)V.assertion.11' --show-vcc
 ^Generated 1 VCC\(s\), 1 remaining after simplification$
 ^EXIT=0$
 ^SIGNAL=0$

--- a/jbmc/regression/jbmc-strings/IndexOfConstantEvaluation04-NegativeScenarios/test12.desc
+++ b/jbmc/regression/jbmc-strings/IndexOfConstantEvaluation04-NegativeScenarios/test12.desc
@@ -1,6 +1,6 @@
-CORE symex-driven-lazy-loading-expected-failure winbug
+CORE symex-driven-lazy-loading-expected-failure
 Main
---function Main.constantIndexOf --property "java::Main.constantIndexOf:(Ljava/lang/String;CI)V.assertion.12" --show-vcc
+--function Main.constantIndexOf --property 'java::Main.constantIndexOf:(Ljava/lang/String;CI)V.assertion.12' --show-vcc
 ^Generated 1 VCC\(s\), 1 remaining after simplification$
 ^EXIT=0$
 ^SIGNAL=0$

--- a/jbmc/regression/jbmc-strings/IndexOfConstantEvaluation04-NegativeScenarios/test2.desc
+++ b/jbmc/regression/jbmc-strings/IndexOfConstantEvaluation04-NegativeScenarios/test2.desc
@@ -1,6 +1,6 @@
-CORE symex-driven-lazy-loading-expected-failure winbug
+CORE symex-driven-lazy-loading-expected-failure
 Main
---function Main.constantIndexOf --property "java::Main.constantIndexOf:(Ljava/lang/String;CI)V.assertion.2" --show-vcc
+--function Main.constantIndexOf --property 'java::Main.constantIndexOf:(Ljava/lang/String;CI)V.assertion.2' --show-vcc
 ^Generated 1 VCC\(s\), 1 remaining after simplification$
 ^EXIT=0$
 ^SIGNAL=0$

--- a/jbmc/regression/jbmc-strings/IndexOfConstantEvaluation04-NegativeScenarios/test3.desc
+++ b/jbmc/regression/jbmc-strings/IndexOfConstantEvaluation04-NegativeScenarios/test3.desc
@@ -1,6 +1,6 @@
-CORE symex-driven-lazy-loading-expected-failure winbug
+CORE symex-driven-lazy-loading-expected-failure
 Main
---function Main.constantIndexOf --property "java::Main.constantIndexOf:(Ljava/lang/String;CI)V.assertion.3" --show-vcc
+--function Main.constantIndexOf --property 'java::Main.constantIndexOf:(Ljava/lang/String;CI)V.assertion.3' --show-vcc
 ^Generated 1 VCC\(s\), 1 remaining after simplification$
 ^EXIT=0$
 ^SIGNAL=0$

--- a/jbmc/regression/jbmc-strings/IndexOfConstantEvaluation04-NegativeScenarios/test4.desc
+++ b/jbmc/regression/jbmc-strings/IndexOfConstantEvaluation04-NegativeScenarios/test4.desc
@@ -1,6 +1,6 @@
-CORE symex-driven-lazy-loading-expected-failure winbug
+CORE symex-driven-lazy-loading-expected-failure
 Main
---function Main.constantIndexOf --property "java::Main.constantIndexOf:(Ljava/lang/String;CI)V.assertion.4" --show-vcc
+--function Main.constantIndexOf --property 'java::Main.constantIndexOf:(Ljava/lang/String;CI)V.assertion.4' --show-vcc
 ^Generated 1 VCC\(s\), 1 remaining after simplification$
 ^EXIT=0$
 ^SIGNAL=0$

--- a/jbmc/regression/jbmc-strings/IndexOfConstantEvaluation04-NegativeScenarios/test5.desc
+++ b/jbmc/regression/jbmc-strings/IndexOfConstantEvaluation04-NegativeScenarios/test5.desc
@@ -1,6 +1,6 @@
-CORE symex-driven-lazy-loading-expected-failure winbug
+CORE symex-driven-lazy-loading-expected-failure
 Main
---function Main.constantIndexOf --property "java::Main.constantIndexOf:(Ljava/lang/String;CI)V.assertion.5" --show-vcc
+--function Main.constantIndexOf --property 'java::Main.constantIndexOf:(Ljava/lang/String;CI)V.assertion.5' --show-vcc
 ^Generated 1 VCC\(s\), 1 remaining after simplification$
 ^EXIT=0$
 ^SIGNAL=0$

--- a/jbmc/regression/jbmc-strings/IndexOfConstantEvaluation04-NegativeScenarios/test6.desc
+++ b/jbmc/regression/jbmc-strings/IndexOfConstantEvaluation04-NegativeScenarios/test6.desc
@@ -1,6 +1,6 @@
-CORE symex-driven-lazy-loading-expected-failure winbug
+CORE symex-driven-lazy-loading-expected-failure
 Main
---function Main.constantIndexOf --property "java::Main.constantIndexOf:(Ljava/lang/String;CI)V.assertion.6" --show-vcc
+--function Main.constantIndexOf --property 'java::Main.constantIndexOf:(Ljava/lang/String;CI)V.assertion.6' --show-vcc
 ^Generated 1 VCC\(s\), 1 remaining after simplification$
 ^EXIT=0$
 ^SIGNAL=0$

--- a/jbmc/regression/jbmc-strings/IndexOfConstantEvaluation04-NegativeScenarios/test7.desc
+++ b/jbmc/regression/jbmc-strings/IndexOfConstantEvaluation04-NegativeScenarios/test7.desc
@@ -1,6 +1,6 @@
-CORE symex-driven-lazy-loading-expected-failure winbug
+CORE symex-driven-lazy-loading-expected-failure
 Main
---function Main.constantIndexOf --property "java::Main.constantIndexOf:(Ljava/lang/String;CI)V.assertion.7" --show-vcc
+--function Main.constantIndexOf --property 'java::Main.constantIndexOf:(Ljava/lang/String;CI)V.assertion.7' --show-vcc
 ^Generated 1 VCC\(s\), 1 remaining after simplification$
 ^EXIT=0$
 ^SIGNAL=0$

--- a/jbmc/regression/jbmc-strings/IndexOfConstantEvaluation04-NegativeScenarios/test8.desc
+++ b/jbmc/regression/jbmc-strings/IndexOfConstantEvaluation04-NegativeScenarios/test8.desc
@@ -1,6 +1,6 @@
-CORE symex-driven-lazy-loading-expected-failure winbug
+CORE symex-driven-lazy-loading-expected-failure
 Main
---function Main.constantIndexOf --property "java::Main.constantIndexOf:(Ljava/lang/String;CI)V.assertion.8" --show-vcc
+--function Main.constantIndexOf --property 'java::Main.constantIndexOf:(Ljava/lang/String;CI)V.assertion.8' --show-vcc
 ^Generated 1 VCC\(s\), 1 remaining after simplification$
 ^EXIT=0$
 ^SIGNAL=0$

--- a/jbmc/regression/jbmc-strings/IndexOfConstantEvaluation04-NegativeScenarios/test9.desc
+++ b/jbmc/regression/jbmc-strings/IndexOfConstantEvaluation04-NegativeScenarios/test9.desc
@@ -1,6 +1,6 @@
-CORE symex-driven-lazy-loading-expected-failure winbug
+CORE symex-driven-lazy-loading-expected-failure
 Main
---function Main.constantIndexOf --property "java::Main.constantIndexOf:(Ljava/lang/String;CI)V.assertion.9" --show-vcc
+--function Main.constantIndexOf --property 'java::Main.constantIndexOf:(Ljava/lang/String;CI)V.assertion.9' --show-vcc
 ^Generated 1 VCC\(s\), 1 remaining after simplification$
 ^EXIT=0$
 ^SIGNAL=0$

--- a/jbmc/regression/jbmc-strings/IndexOfConstantEvaluation06-AssertionFailure/test.desc
+++ b/jbmc/regression/jbmc-strings/IndexOfConstantEvaluation06-AssertionFailure/test.desc
@@ -1,6 +1,6 @@
-CORE symex-driven-lazy-loading-expected-failure winbug
+CORE symex-driven-lazy-loading-expected-failure
 Main
---function Main.constantIndexOf --property "java::Main.constantIndexOf:()V.assertion.1"
+--function Main.constantIndexOf --property 'java::Main.constantIndexOf:()V.assertion.1'
 ^Generated [0-9]+ VCC\(s\), 1 remaining after simplification$
 ^VERIFICATION FAILED$
 ^EXIT=10$

--- a/jbmc/regression/jbmc-strings/RegionMatches/test1.desc
+++ b/jbmc/regression/jbmc-strings/RegionMatches/test1.desc
@@ -1,6 +1,6 @@
 FUTURE
 RegionMatches
---max-nondet-string-length 1000 --function RegionMatches.constant --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar` --property "java::RegionMatches.constant:(I)V.assertion.1"
+--max-nondet-string-length 1000 --function RegionMatches.constant --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar` --property 'java::RegionMatches.constant:(I)V.assertion.1'
 ^EXIT=0$
 ^SIGNAL=0$
 ^VERIFICATION SUCCESSFUL$

--- a/jbmc/regression/jbmc-strings/RegionMatches/test2.desc
+++ b/jbmc/regression/jbmc-strings/RegionMatches/test2.desc
@@ -1,6 +1,6 @@
 FUTURE
 RegionMatches
---max-nondet-string-length 1000 --function RegionMatches.constant --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar` --property "java::RegionMatches.constant:(I)V.assertion.2"
+--max-nondet-string-length 1000 --function RegionMatches.constant --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar` --property 'java::RegionMatches.constant:(I)V.assertion.2'
 ^EXIT=10$
 ^SIGNAL=0$
 ^VERIFICATION FAILED$

--- a/jbmc/regression/jbmc-strings/RegionMatches/test3.desc
+++ b/jbmc/regression/jbmc-strings/RegionMatches/test3.desc
@@ -1,6 +1,6 @@
 FUTURE
 RegionMatches
---max-nondet-string-length 1000 --function RegionMatches.constant --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar` --property "java::RegionMatches.constant:(I)V.assertion.3"
+--max-nondet-string-length 1000 --function RegionMatches.constant --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar` --property 'java::RegionMatches.constant:(I)V.assertion.3'
 ^EXIT=0$
 ^SIGNAL=0$
 ^VERIFICATION SUCCESSFUL$

--- a/jbmc/regression/jbmc-strings/RegionMatches/test4.desc
+++ b/jbmc/regression/jbmc-strings/RegionMatches/test4.desc
@@ -1,6 +1,6 @@
 FUTURE
 RegionMatches
---max-nondet-string-length 1000 --function RegionMatches.constant --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar` --property "java::RegionMatches.constant:(I)V.assertion.4"
+--max-nondet-string-length 1000 --function RegionMatches.constant --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar` --property 'java::RegionMatches.constant:(I)V.assertion.4'
 ^EXIT=10$
 ^SIGNAL=0$
 ^VERIFICATION FAILED$

--- a/jbmc/regression/jbmc-strings/StringBuilderAppend03/test1.desc
+++ b/jbmc/regression/jbmc-strings/StringBuilderAppend03/test1.desc
@@ -1,6 +1,6 @@
-CORE winbug
+CORE
 test
---function test.nondet --max-nondet-string-length 1000 --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar` --property "java::test.nondet:(Ljava/lang/String;)V.assertion.1"
+--function test.nondet --max-nondet-string-length 1000 --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar` --property 'java::test.nondet:(Ljava/lang/String;)V.assertion.1'
 ^EXIT=10$
 ^SIGNAL=0$
 \[.*assertion\.1\] .* line 9 .* FAILURE

--- a/jbmc/regression/jbmc-strings/StringBuilderAppend03/test2.desc
+++ b/jbmc/regression/jbmc-strings/StringBuilderAppend03/test2.desc
@@ -1,6 +1,6 @@
-CORE winbug
+CORE
 test
---function test.nondet --max-nondet-string-length 1000 --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar` --property "java::test.nondet:(Ljava/lang/String;)V.assertion.2"
+--function test.nondet --max-nondet-string-length 1000 --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar` --property 'java::test.nondet:(Ljava/lang/String;)V.assertion.2'
 ^EXIT=10$
 ^SIGNAL=0$
 \[.*assertion\.2\] .* line 11.* FAILURE

--- a/jbmc/regression/jbmc-strings/StringBuilderAppend03/test3.desc
+++ b/jbmc/regression/jbmc-strings/StringBuilderAppend03/test3.desc
@@ -1,6 +1,6 @@
-CORE symex-driven-lazy-loading-expected-failure winbug
+CORE symex-driven-lazy-loading-expected-failure
 test
---function test.nondet --max-nondet-string-length 1000 --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar` --property "java::test.nondet:(Ljava/lang/String;)V.assertion.3"
+--function test.nondet --max-nondet-string-length 1000 --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar` --property 'java::test.nondet:(Ljava/lang/String;)V.assertion.3'
 ^EXIT=0$
 ^SIGNAL=0$
 \[.*assertion\.3\] .* line 13.* SUCCESS

--- a/jbmc/regression/jbmc-strings/StringBuilderSubstringConstantEvaluation2/test1.desc
+++ b/jbmc/regression/jbmc-strings/StringBuilderSubstringConstantEvaluation2/test1.desc
@@ -1,6 +1,6 @@
-CORE symex-driven-lazy-loading-expected-failure winbug
+CORE symex-driven-lazy-loading-expected-failure
 Main
---function Main.test1 --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar` --property "java::Main.test1:(Ljava/lang/StringBuilder;)V.assertion.1"
+--function Main.test1 --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar` --property 'java::Main.test1:(Ljava/lang/StringBuilder;)V.assertion.1'
 ^Generated 1 VCC\(s\), 1 remaining after simplification$
 ^EXIT=10$
 ^SIGNAL=0$

--- a/jbmc/regression/jbmc-strings/StringBuilderSubstringConstantEvaluation2/test2.desc
+++ b/jbmc/regression/jbmc-strings/StringBuilderSubstringConstantEvaluation2/test2.desc
@@ -1,6 +1,6 @@
-CORE symex-driven-lazy-loading-expected-failure winbug
+CORE symex-driven-lazy-loading-expected-failure
 Main
---function Main.test2 --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar` --property "java::Main.test2:(I)V.assertion.1"
+--function Main.test2 --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar` --property 'java::Main.test2:(I)V.assertion.1'
 ^Generated 1 VCC\(s\), 1 remaining after simplification$
 ^EXIT=10$
 ^SIGNAL=0$

--- a/jbmc/regression/jbmc-strings/StringBuilderSubstringConstantEvaluation2/test3.desc
+++ b/jbmc/regression/jbmc-strings/StringBuilderSubstringConstantEvaluation2/test3.desc
@@ -1,6 +1,6 @@
-CORE symex-driven-lazy-loading-expected-failure winbug
+CORE symex-driven-lazy-loading-expected-failure
 Main
---function Main.test3 --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar` --property "java::Main.test3:(Ljava/lang/StringBuilder;I)V.assertion.1"
+--function Main.test3 --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar` --property 'java::Main.test3:(Ljava/lang/StringBuilder;I)V.assertion.1'
 ^Generated 1 VCC\(s\), 1 remaining after simplification$
 ^EXIT=10$
 ^SIGNAL=0$

--- a/jbmc/regression/jbmc-strings/StringCompareTo/testFail1.desc
+++ b/jbmc/regression/jbmc-strings/StringCompareTo/testFail1.desc
@@ -1,6 +1,6 @@
-CORE symex-driven-lazy-loading-expected-failure winbug
+CORE symex-driven-lazy-loading-expected-failure
 Main
---function Main.nondetFail --max-nondet-string-length 1000 --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar` --property "java::Main.nondetFail:(ZLjava/lang/String;Ljava/lang/String;)V.assertion.1" 
+--function Main.nondetFail --max-nondet-string-length 1000 --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar` --property 'java::Main.nondetFail:(ZLjava/lang/String;Ljava/lang/String;)V.assertion.1' 
 ^EXIT=10$
 ^SIGNAL=0$
 ^VERIFICATION FAILED$

--- a/jbmc/regression/jbmc-strings/StringCompareTo/testFail2.desc
+++ b/jbmc/regression/jbmc-strings/StringCompareTo/testFail2.desc
@@ -1,6 +1,6 @@
-CORE symex-driven-lazy-loading-expected-failure winbug
+CORE symex-driven-lazy-loading-expected-failure
 Main
---function Main.nondetFail --max-nondet-string-length 1000 --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar` --property "java::Main.nondetFail:(ZLjava/lang/String;Ljava/lang/String;)V.assertion.2" 
+--function Main.nondetFail --max-nondet-string-length 1000 --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar` --property 'java::Main.nondetFail:(ZLjava/lang/String;Ljava/lang/String;)V.assertion.2' 
 ^EXIT=10$
 ^SIGNAL=0$
 ^VERIFICATION FAILED$

--- a/jbmc/regression/jbmc-strings/StringCompareTo/testFail3.desc
+++ b/jbmc/regression/jbmc-strings/StringCompareTo/testFail3.desc
@@ -1,6 +1,6 @@
-CORE symex-driven-lazy-loading-expected-failure winbug
+CORE symex-driven-lazy-loading-expected-failure
 Main
---function Main.nondetFail --max-nondet-string-length 1000 --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar` --property "java::Main.nondetFail:(ZLjava/lang/String;Ljava/lang/String;)V.assertion.3" 
+--function Main.nondetFail --max-nondet-string-length 1000 --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar` --property 'java::Main.nondetFail:(ZLjava/lang/String;Ljava/lang/String;)V.assertion.3' 
 ^EXIT=10$
 ^SIGNAL=0$
 ^VERIFICATION FAILED$

--- a/jbmc/regression/jbmc-strings/StringCompareTo/testFail4.desc
+++ b/jbmc/regression/jbmc-strings/StringCompareTo/testFail4.desc
@@ -1,6 +1,6 @@
-CORE symex-driven-lazy-loading-expected-failure winbug
+CORE symex-driven-lazy-loading-expected-failure
 Main
---function Main.nondetFail --max-nondet-string-length 1000 --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar` --property "java::Main.nondetFail:(ZLjava/lang/String;Ljava/lang/String;)V.assertion.4" 
+--function Main.nondetFail --max-nondet-string-length 1000 --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar` --property 'java::Main.nondetFail:(ZLjava/lang/String;Ljava/lang/String;)V.assertion.4' 
 ^EXIT=10$
 ^SIGNAL=0$
 ^VERIFICATION FAILED$

--- a/jbmc/regression/jbmc-strings/StringCompareTo/testFail5.desc
+++ b/jbmc/regression/jbmc-strings/StringCompareTo/testFail5.desc
@@ -1,6 +1,6 @@
-CORE symex-driven-lazy-loading-expected-failure winbug
+CORE symex-driven-lazy-loading-expected-failure
 Main
---function Main.nondetFail --max-nondet-string-length 1000 --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar` --property "java::Main.nondetFail:(ZLjava/lang/String;Ljava/lang/String;)V.assertion.5" 
+--function Main.nondetFail --max-nondet-string-length 1000 --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar` --property 'java::Main.nondetFail:(ZLjava/lang/String;Ljava/lang/String;)V.assertion.5' 
 ^EXIT=10$
 ^SIGNAL=0$
 ^VERIFICATION FAILED$

--- a/jbmc/regression/jbmc-strings/StringCompareTo/testFail6.desc
+++ b/jbmc/regression/jbmc-strings/StringCompareTo/testFail6.desc
@@ -1,6 +1,6 @@
-CORE symex-driven-lazy-loading-expected-failure winbug
+CORE symex-driven-lazy-loading-expected-failure
 Main
---function Main.nondetFail --max-nondet-string-length 1000 --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar` --property "java::Main.nondetFail:(ZLjava/lang/String;Ljava/lang/String;)V.assertion.6" 
+--function Main.nondetFail --max-nondet-string-length 1000 --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar` --property 'java::Main.nondetFail:(ZLjava/lang/String;Ljava/lang/String;)V.assertion.6' 
 ^EXIT=10$
 ^SIGNAL=0$
 ^VERIFICATION FAILED$

--- a/jbmc/regression/jbmc-strings/StringCompareTo/testPass1.desc
+++ b/jbmc/regression/jbmc-strings/StringCompareTo/testPass1.desc
@@ -1,6 +1,6 @@
-CORE symex-driven-lazy-loading-expected-failure winbug
+CORE symex-driven-lazy-loading-expected-failure
 Main
---function Main.nondetPass --max-nondet-string-length 1000 --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar` --property "java::Main.nondetPass:(Ljava/lang/String;Ljava/lang/String;)V.assertion.1" 
+--function Main.nondetPass --max-nondet-string-length 1000 --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar` --property 'java::Main.nondetPass:(Ljava/lang/String;Ljava/lang/String;)V.assertion.1' 
 ^EXIT=0$
 ^SIGNAL=0$
 ^VERIFICATION SUCCESSFUL$

--- a/jbmc/regression/jbmc-strings/StringCompareTo/testPass2.desc
+++ b/jbmc/regression/jbmc-strings/StringCompareTo/testPass2.desc
@@ -1,6 +1,6 @@
-CORE symex-driven-lazy-loading-expected-failure winbug
+CORE symex-driven-lazy-loading-expected-failure
 Main
---function Main.nondetPass --max-nondet-string-length 1000 --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar` --property "java::Main.nondetPass:(Ljava/lang/String;Ljava/lang/String;)V.assertion.2" 
+--function Main.nondetPass --max-nondet-string-length 1000 --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar` --property 'java::Main.nondetPass:(Ljava/lang/String;Ljava/lang/String;)V.assertion.2' 
 ^EXIT=0$
 ^SIGNAL=0$
 ^VERIFICATION SUCCESSFUL$

--- a/jbmc/regression/jbmc-strings/StringCompareTo/testPass3.desc
+++ b/jbmc/regression/jbmc-strings/StringCompareTo/testPass3.desc
@@ -1,6 +1,6 @@
-CORE symex-driven-lazy-loading-expected-failure winbug
+CORE symex-driven-lazy-loading-expected-failure
 Main
---function Main.nondetPass --max-nondet-string-length 1000 --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar` --property "java::Main.nondetPass:(Ljava/lang/String;Ljava/lang/String;)V.assertion.3" 
+--function Main.nondetPass --max-nondet-string-length 1000 --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar` --property 'java::Main.nondetPass:(Ljava/lang/String;Ljava/lang/String;)V.assertion.3' 
 ^EXIT=0$
 ^SIGNAL=0$
 ^VERIFICATION SUCCESSFUL$

--- a/jbmc/regression/jbmc-strings/StringCompareTo/testPass4.desc
+++ b/jbmc/regression/jbmc-strings/StringCompareTo/testPass4.desc
@@ -1,6 +1,6 @@
-CORE symex-driven-lazy-loading-expected-failure winbug
+CORE symex-driven-lazy-loading-expected-failure
 Main
---function Main.nondetPass --max-nondet-string-length 1000 --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar` --property "java::Main.nondetPass:(Ljava/lang/String;Ljava/lang/String;)V.assertion.4" 
+--function Main.nondetPass --max-nondet-string-length 1000 --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar` --property 'java::Main.nondetPass:(Ljava/lang/String;Ljava/lang/String;)V.assertion.4' 
 ^EXIT=0$
 ^SIGNAL=0$
 ^VERIFICATION SUCCESSFUL$

--- a/jbmc/regression/jbmc-strings/StringCompareTo/testPass5.desc
+++ b/jbmc/regression/jbmc-strings/StringCompareTo/testPass5.desc
@@ -1,6 +1,6 @@
-CORE symex-driven-lazy-loading-expected-failure winbug
+CORE symex-driven-lazy-loading-expected-failure
 Main
---function Main.nondetPass --max-nondet-string-length 1000 --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar` --property "java::Main.nondetPass:(Ljava/lang/String;Ljava/lang/String;)V.assertion.5" 
+--function Main.nondetPass --max-nondet-string-length 1000 --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar` --property 'java::Main.nondetPass:(Ljava/lang/String;Ljava/lang/String;)V.assertion.5' 
 ^EXIT=0$
 ^SIGNAL=0$
 ^VERIFICATION SUCCESSFUL$

--- a/jbmc/regression/jbmc-strings/StringCompareTo/testPass6.desc
+++ b/jbmc/regression/jbmc-strings/StringCompareTo/testPass6.desc
@@ -1,6 +1,6 @@
-CORE symex-driven-lazy-loading-expected-failure winbug
+CORE symex-driven-lazy-loading-expected-failure
 Main
---function Main.nondetPass --max-nondet-string-length 1000 --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar` --property "java::Main.nondetPass:(Ljava/lang/String;Ljava/lang/String;)V.assertion.6" 
+--function Main.nondetPass --max-nondet-string-length 1000 --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar` --property 'java::Main.nondetPass:(Ljava/lang/String;Ljava/lang/String;)V.assertion.6' 
 ^EXIT=0$
 ^SIGNAL=0$
 ^VERIFICATION SUCCESSFUL$

--- a/jbmc/regression/jbmc-strings/StringFormatBool/test-bool-length-true-fail.desc
+++ b/jbmc/regression/jbmc-strings/StringFormatBool/test-bool-length-true-fail.desc
@@ -1,6 +1,6 @@
-CORE winbug
+CORE
 Test
---function Test.testBoolLengthTrue --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar` --property "java::Test.testBoolLengthTrue:()Ljava/lang/String;.assertion.1"
+--function Test.testBoolLengthTrue --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar` --property 'java::Test.testBoolLengthTrue:()Ljava/lang/String;.assertion.1'
 ^EXIT=10$
 ^SIGNAL=0$
 line 27 assertion at file Test.java .*: FAILURE

--- a/jbmc/regression/jbmc-strings/StringFormatBool/test-bool-length-true-pass.desc
+++ b/jbmc/regression/jbmc-strings/StringFormatBool/test-bool-length-true-pass.desc
@@ -1,6 +1,6 @@
 KNOWNBUG
 Test
---function Test.testBoolLengthTrue --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar` --property "java::Test.testBoolLengthTrue:()Ljava/lang/String;.assertion.2"
+--function Test.testBoolLengthTrue --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar` --property 'java::Test.testBoolLengthTrue:()Ljava/lang/String;.assertion.2'
 ^EXIT=0$
 ^SIGNAL=0$
 line 29 assertion at file Test.java .*: SUCCESS

--- a/jbmc/regression/jbmc-strings/StringFormatBool/test-bool-length1.desc
+++ b/jbmc/regression/jbmc-strings/StringFormatBool/test-bool-length1.desc
@@ -1,6 +1,6 @@
-CORE winbug
+CORE
 Test
---function Test.testBoolLength --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar` --property "java::Test.testBoolLength:(Z)Ljava/lang/String;.assertion.1"
+--function Test.testBoolLength --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar` --property 'java::Test.testBoolLength:(Z)Ljava/lang/String;.assertion.1'
 ^EXIT=10$
 ^SIGNAL=0$
 line 16 assertion at file Test.java .*: FAILURE

--- a/jbmc/regression/jbmc-strings/StringFormatBool/test-bool-length2.desc
+++ b/jbmc/regression/jbmc-strings/StringFormatBool/test-bool-length2.desc
@@ -1,6 +1,6 @@
-CORE winbug
+CORE
 Test
---function Test.testBoolLength --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar` --property "java::Test.testBoolLength:(Z)Ljava/lang/String;.assertion.2"
+--function Test.testBoolLength --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar` --property 'java::Test.testBoolLength:(Z)Ljava/lang/String;.assertion.2'
 ^EXIT=10$
 ^SIGNAL=0$
 line 18 assertion at file Test.java .*: FAILURE

--- a/jbmc/regression/jbmc-strings/StringFormatBool/test-bool-length3.desc
+++ b/jbmc/regression/jbmc-strings/StringFormatBool/test-bool-length3.desc
@@ -1,6 +1,6 @@
-CORE symex-driven-lazy-loading-expected-failure winbug
+CORE symex-driven-lazy-loading-expected-failure
 Test
---function Test.testBoolLength --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar` --property "java::Test.testBoolLength:(Z)Ljava/lang/String;.assertion.3"
+--function Test.testBoolLength --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar` --property 'java::Test.testBoolLength:(Z)Ljava/lang/String;.assertion.3'
 ^EXIT=0$
 ^SIGNAL=0$
 line 20 assertion at file Test.java .*: SUCCESS

--- a/jbmc/regression/jbmc-strings/StringFormatBool/test-bool1.desc
+++ b/jbmc/regression/jbmc-strings/StringFormatBool/test-bool1.desc
@@ -1,6 +1,6 @@
-CORE winbug
+CORE
 Test
---function Test.testBool --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar` --property "java::Test.testBool:(Z)Ljava/lang/String;.assertion.1"
+--function Test.testBool --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar` --property 'java::Test.testBool:(Z)Ljava/lang/String;.assertion.1'
 ^EXIT=10$
 ^SIGNAL=0$
 line 5 assertion at file Test.java .*: FAILURE

--- a/jbmc/regression/jbmc-strings/StringFormatBool/test-bool2.desc
+++ b/jbmc/regression/jbmc-strings/StringFormatBool/test-bool2.desc
@@ -1,6 +1,6 @@
-CORE winbug
+CORE
 Test
---function Test.testBool --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar` --property "java::Test.testBool:(Z)Ljava/lang/String;.assertion.2"
+--function Test.testBool --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar` --property 'java::Test.testBool:(Z)Ljava/lang/String;.assertion.2'
 ^EXIT=10$
 ^SIGNAL=0$
 line 7 assertion at file Test.java .*: FAILURE

--- a/jbmc/regression/jbmc-strings/StringFormatBool/test-bool3.desc
+++ b/jbmc/regression/jbmc-strings/StringFormatBool/test-bool3.desc
@@ -1,6 +1,6 @@
-CORE symex-driven-lazy-loading-expected-failure winbug
+CORE symex-driven-lazy-loading-expected-failure
 Test
---function Test.testBool --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar` --property "java::Test.testBool:(Z)Ljava/lang/String;.assertion.3"
+--function Test.testBool --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar` --property 'java::Test.testBool:(Z)Ljava/lang/String;.assertion.3'
 ^EXIT=0$
 ^SIGNAL=0$
 line 9 assertion at file Test.java .*: SUCCESS

--- a/jbmc/regression/jbmc-strings/StringFormatHex/test-hex-length-const-fail.desc
+++ b/jbmc/regression/jbmc-strings/StringFormatHex/test-hex-length-const-fail.desc
@@ -1,6 +1,6 @@
-CORE winbug
+CORE
 Test
---function Test.testHexLengthConstFAIL --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar` --property "java::Test.testHexLengthConstFAIL:()V.assertion.1"
+--function Test.testHexLengthConstFAIL --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar` --property 'java::Test.testHexLengthConstFAIL:()V.assertion.1'
 ^EXIT=10$
 ^SIGNAL=0$
 line 20 assertion at file Test.java .*: FAILURE

--- a/jbmc/regression/jbmc-strings/StringFormatHex/test-hex-length-const-pass.desc
+++ b/jbmc/regression/jbmc-strings/StringFormatHex/test-hex-length-const-pass.desc
@@ -1,6 +1,6 @@
-CORE winbug
+CORE
 Test
---function Test.testHexLengthConstPASS --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar` --property "java::Test.testHexLengthConstPASS:()V.assertion.1"
+--function Test.testHexLengthConstPASS --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar` --property 'java::Test.testHexLengthConstPASS:()V.assertion.1'
 ^EXIT=0$
 ^SIGNAL=0$
 line 15 assertion at file Test.java .*: SUCCESS

--- a/jbmc/regression/jbmc-strings/StringFormatHex/test-hex1.desc
+++ b/jbmc/regression/jbmc-strings/StringFormatHex/test-hex1.desc
@@ -1,6 +1,6 @@
-CORE winbug
+CORE
 Test
---function Test.testHex --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar` --property "java::Test.testHex:(I)Ljava/lang/String;.assertion.1"
+--function Test.testHex --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar` --property 'java::Test.testHex:(I)Ljava/lang/String;.assertion.1'
 ^EXIT=10$
 ^SIGNAL=0$
 line 5 assertion at file Test.java .*: FAILURE

--- a/jbmc/regression/jbmc-strings/StringFormatHex/test-hex2.desc
+++ b/jbmc/regression/jbmc-strings/StringFormatHex/test-hex2.desc
@@ -1,6 +1,6 @@
-CORE winbug
+CORE
 Test
---function Test.testHex --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar` --property "java::Test.testHex:(I)Ljava/lang/String;.assertion.2"
+--function Test.testHex --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar` --property 'java::Test.testHex:(I)Ljava/lang/String;.assertion.2'
 ^EXIT=10$
 ^SIGNAL=0$
 line 7 assertion at file Test.java .*: FAILURE

--- a/jbmc/regression/jbmc-strings/StringFormatHex/test-hex3.desc
+++ b/jbmc/regression/jbmc-strings/StringFormatHex/test-hex3.desc
@@ -1,6 +1,6 @@
-CORE symex-driven-lazy-loading-expected-failure winbug
+CORE symex-driven-lazy-loading-expected-failure
 Test
---function Test.testHex --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar` --property "java::Test.testHex:(I)Ljava/lang/String;.assertion.3"
+--function Test.testHex --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar` --property 'java::Test.testHex:(I)Ljava/lang/String;.assertion.3'
 ^EXIT=0$
 ^SIGNAL=0$
 line 9 assertion at file Test.java .*: SUCCESS

--- a/jbmc/regression/jbmc-strings/StringFormatInt/test-int-length-const-fail.desc
+++ b/jbmc/regression/jbmc-strings/StringFormatInt/test-int-length-const-fail.desc
@@ -1,6 +1,6 @@
-CORE winbug
+CORE
 Test
---function Test.testIntLengthConstFAIL --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar` --property "java::Test.testIntLengthConstFAIL:()V.assertion.1"
+--function Test.testIntLengthConstFAIL --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar` --property 'java::Test.testIntLengthConstFAIL:()V.assertion.1'
 ^EXIT=10$
 ^SIGNAL=0$
 line 25 assertion at file Test.java .*: FAILURE

--- a/jbmc/regression/jbmc-strings/StringFormatInt/test-int-length-const-pass.desc
+++ b/jbmc/regression/jbmc-strings/StringFormatInt/test-int-length-const-pass.desc
@@ -1,6 +1,6 @@
-CORE winbug
+CORE
 Test
---function Test.testIntLengthConstPASS --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar` --property "java::Test.testIntLengthConstPASS:()V.assertion.1"
+--function Test.testIntLengthConstPASS --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar` --property 'java::Test.testIntLengthConstPASS:()V.assertion.1'
 ^EXIT=0$
 ^SIGNAL=0$
 line 20 assertion at file Test.java .*: SUCCESS

--- a/jbmc/regression/jbmc-strings/StringFormatInt/test-int-length.desc
+++ b/jbmc/regression/jbmc-strings/StringFormatInt/test-int-length.desc
@@ -1,6 +1,6 @@
-CORE winbug
+CORE
 Test
---function Test.testIntLength --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar` --property "java::Test.testIntLength:(I)V.assertion.1"
+--function Test.testIntLength --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar` --property 'java::Test.testIntLength:(I)V.assertion.1'
  
 ^EXIT=10$
 ^SIGNAL=0$

--- a/jbmc/regression/jbmc-strings/StringFormatInt/test-int1.desc
+++ b/jbmc/regression/jbmc-strings/StringFormatInt/test-int1.desc
@@ -1,6 +1,6 @@
-CORE winbug
+CORE
 Test
---function Test.testInt --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar` --property "java::Test.testInt:(I)Ljava/lang/String;.assertion.1"
+--function Test.testInt --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar` --property 'java::Test.testInt:(I)Ljava/lang/String;.assertion.1'
 ^EXIT=10$
 ^SIGNAL=0$
 line 5 assertion at file Test.java .*: FAILURE

--- a/jbmc/regression/jbmc-strings/StringFormatInt/test-int2.desc
+++ b/jbmc/regression/jbmc-strings/StringFormatInt/test-int2.desc
@@ -1,6 +1,6 @@
-CORE symex-driven-lazy-loading-expected-failure winbug
+CORE symex-driven-lazy-loading-expected-failure
 Test
---function Test.testInt --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar` --property "java::Test.testInt:(I)Ljava/lang/String;.assertion.2"
+--function Test.testInt --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar` --property 'java::Test.testInt:(I)Ljava/lang/String;.assertion.2'
 ^EXIT=0$
 ^SIGNAL=0$
 line 7 assertion at file Test.java .*: SUCCESS

--- a/jbmc/regression/jbmc-strings/StringFormatInt/test-int3.desc
+++ b/jbmc/regression/jbmc-strings/StringFormatInt/test-int3.desc
@@ -1,6 +1,6 @@
-CORE winbug
+CORE
 Test
---function Test.testInt --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar` --property "java::Test.testInt:(I)Ljava/lang/String;.assertion.3"
+--function Test.testInt --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar` --property 'java::Test.testInt:(I)Ljava/lang/String;.assertion.3'
 ^EXIT=10$
 ^SIGNAL=0$
 line 9 assertion at file Test.java .*: FAILURE

--- a/jbmc/regression/jbmc-strings/StringFormatSpecial/test-newline-fail.desc
+++ b/jbmc/regression/jbmc-strings/StringFormatSpecial/test-newline-fail.desc
@@ -1,6 +1,6 @@
-CORE winbug
+CORE
 Test
---function Test.newline --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar` --property "java::Test.newline:()Ljava/lang/String;.assertion.1"
+--function Test.newline --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar` --property 'java::Test.newline:()Ljava/lang/String;.assertion.1'
 ^EXIT=10$
 ^SIGNAL=0$
 line 23 assertion at file Test.java .*: FAILURE

--- a/jbmc/regression/jbmc-strings/StringFormatSpecial/test-newline-length-fail.desc
+++ b/jbmc/regression/jbmc-strings/StringFormatSpecial/test-newline-length-fail.desc
@@ -1,6 +1,6 @@
-CORE winbug
+CORE
 Test
---function Test.newlineLength --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar` --property "java::Test.newlineLength:()Ljava/lang/String;.assertion.1"
+--function Test.newlineLength --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar` --property 'java::Test.newlineLength:()Ljava/lang/String;.assertion.1'
 ^EXIT=10$
 ^SIGNAL=0$
 line 32 assertion at file Test.java .*: FAILURE

--- a/jbmc/regression/jbmc-strings/StringFormatSpecial/test-newline-length-pass.desc
+++ b/jbmc/regression/jbmc-strings/StringFormatSpecial/test-newline-length-pass.desc
@@ -1,6 +1,6 @@
-CORE symex-driven-lazy-loading-expected-failure winbug
+CORE symex-driven-lazy-loading-expected-failure
 Test
---function Test.newlineLength --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar` --property "java::Test.newlineLength:()Ljava/lang/String;.assertion.2"
+--function Test.newlineLength --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar` --property 'java::Test.newlineLength:()Ljava/lang/String;.assertion.2'
 ^EXIT=0$
 ^SIGNAL=0$
 line 34 assertion at file Test.java .*: SUCCESS

--- a/jbmc/regression/jbmc-strings/StringFormatSpecial/test-newline-pass.desc
+++ b/jbmc/regression/jbmc-strings/StringFormatSpecial/test-newline-pass.desc
@@ -1,6 +1,6 @@
-CORE symex-driven-lazy-loading-expected-failure winbug
+CORE symex-driven-lazy-loading-expected-failure
 Test
---function Test.newline --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar` --property "java::Test.newline:()Ljava/lang/String;.assertion.2"
+--function Test.newline --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar` --property 'java::Test.newline:()Ljava/lang/String;.assertion.2'
 ^EXIT=0$
 ^SIGNAL=0$
 line 25 assertion at file Test.java .*: SUCCESS

--- a/jbmc/regression/jbmc-strings/StringFormatSpecial/test-percent-fail.desc
+++ b/jbmc/regression/jbmc-strings/StringFormatSpecial/test-percent-fail.desc
@@ -1,6 +1,6 @@
-CORE winbug
+CORE
 Test
---function Test.percent --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar` --property "java::Test.percent:()Ljava/lang/String;.assertion.1"
+--function Test.percent --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar` --property 'java::Test.percent:()Ljava/lang/String;.assertion.1'
 ^EXIT=10$
 ^SIGNAL=0$
 line 5 assertion at file Test.java .*: FAILURE

--- a/jbmc/regression/jbmc-strings/StringFormatSpecial/test-percent-length-fail.desc
+++ b/jbmc/regression/jbmc-strings/StringFormatSpecial/test-percent-length-fail.desc
@@ -1,6 +1,6 @@
-CORE winbug
+CORE
 Test
---function Test.percentLength --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar` --property "java::Test.percentLength:()Ljava/lang/String;.assertion.1"
+--function Test.percentLength --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar` --property 'java::Test.percentLength:()Ljava/lang/String;.assertion.1'
 ^EXIT=10$
 ^SIGNAL=0$
 line 14 assertion at file Test.java .*: FAILURE

--- a/jbmc/regression/jbmc-strings/StringFormatSpecial/test-percent-length-pass.desc
+++ b/jbmc/regression/jbmc-strings/StringFormatSpecial/test-percent-length-pass.desc
@@ -1,6 +1,6 @@
-CORE symex-driven-lazy-loading-expected-failure winbug
+CORE symex-driven-lazy-loading-expected-failure
 Test
---function Test.percentLength --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar` --property "java::Test.percentLength:()Ljava/lang/String;.assertion.2"
+--function Test.percentLength --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar` --property 'java::Test.percentLength:()Ljava/lang/String;.assertion.2'
 ^EXIT=0$
 ^SIGNAL=0$
 line 16 assertion at file Test.java .*: SUCCESS

--- a/jbmc/regression/jbmc-strings/StringFormatSpecial/test-percent-pass.desc
+++ b/jbmc/regression/jbmc-strings/StringFormatSpecial/test-percent-pass.desc
@@ -1,6 +1,6 @@
-CORE symex-driven-lazy-loading-expected-failure winbug
+CORE symex-driven-lazy-loading-expected-failure
 Test
---function Test.percent --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar` --property "java::Test.percent:()Ljava/lang/String;.assertion.2"
+--function Test.percent --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar` --property 'java::Test.percent:()Ljava/lang/String;.assertion.2'
 ^EXIT=0$
 ^SIGNAL=0$
 line 7 assertion at file Test.java .*: SUCCESS

--- a/jbmc/regression/jbmc-strings/StringFormatString/test-string2.desc
+++ b/jbmc/regression/jbmc-strings/StringFormatString/test-string2.desc
@@ -1,6 +1,6 @@
-CORE winbug
+CORE
 Test
---function Test.string2 --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar` --max-nondet-string-length 20 --property "java::Test.string2:(Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;.assertion.1"
+--function Test.string2 --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar` --max-nondet-string-length 20 --property 'java::Test.string2:(Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;.assertion.1'
 ^EXIT=0$
 ^SIGNAL=0$
 line 37 assertion at file Test.java .*: SUCCESS

--- a/jbmc/regression/jbmc-strings/StringFormatString/test-string3.desc
+++ b/jbmc/regression/jbmc-strings/StringFormatString/test-string3.desc
@@ -1,6 +1,6 @@
-CORE winbug
+CORE
 Test
---function Test.string3 --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar` --max-nondet-string-length 5 --property "java::Test.string3:(Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;.assertion.1"
+--function Test.string3 --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar` --max-nondet-string-length 5 --property 'java::Test.string3:(Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;.assertion.1'
 ^EXIT=0$
 ^SIGNAL=0$
 line 45 assertion at file Test.java .*: SUCCESS

--- a/jbmc/regression/jbmc-strings/StringSubstringConstantEvaluation2/test1.desc
+++ b/jbmc/regression/jbmc-strings/StringSubstringConstantEvaluation2/test1.desc
@@ -1,6 +1,6 @@
-CORE symex-driven-lazy-loading-expected-failure winbug
+CORE symex-driven-lazy-loading-expected-failure
 Main
---function Main.test1 --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar` --property "java::Main.test1:(Ljava/lang/String;)V.assertion.1"
+--function Main.test1 --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar` --property 'java::Main.test1:(Ljava/lang/String;)V.assertion.1'
 ^Generated 1 VCC\(s\), 1 remaining after simplification$
 ^EXIT=10$
 ^SIGNAL=0$

--- a/jbmc/regression/jbmc-strings/StringSubstringConstantEvaluation2/test2.desc
+++ b/jbmc/regression/jbmc-strings/StringSubstringConstantEvaluation2/test2.desc
@@ -1,6 +1,6 @@
-CORE symex-driven-lazy-loading-expected-failure winbug
+CORE symex-driven-lazy-loading-expected-failure
 Main
---function Main.test2 --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar` --property "java::Main.test2:(I)V.assertion.1"
+--function Main.test2 --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar` --property 'java::Main.test2:(I)V.assertion.1'
 ^Generated 1 VCC\(s\), 1 remaining after simplification$
 ^EXIT=10$
 ^SIGNAL=0$

--- a/jbmc/regression/jbmc-strings/StringSubstringConstantEvaluation2/test3.desc
+++ b/jbmc/regression/jbmc-strings/StringSubstringConstantEvaluation2/test3.desc
@@ -1,6 +1,6 @@
-CORE symex-driven-lazy-loading-expected-failure winbug
+CORE symex-driven-lazy-loading-expected-failure
 Main
---function Main.test3 --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar` --property "java::Main.test3:(Ljava/lang/String;I)V.assertion.1"
+--function Main.test3 --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar` --property 'java::Main.test3:(Ljava/lang/String;I)V.assertion.1'
 ^Generated 1 VCC\(s\), 1 remaining after simplification$
 ^EXIT=10$
 ^SIGNAL=0$

--- a/jbmc/regression/jbmc-strings/string-input-value/test1.desc
+++ b/jbmc/regression/jbmc-strings/string-input-value/test1.desc
@@ -1,6 +1,6 @@
-CORE winbug
+CORE
 Test
---string-input-value fo --string-input-value barr --function Test.checkStringInputValue --string-input-value "" --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar`
+--string-input-value fo --string-input-value barr --function Test.checkStringInputValue --string-input-value '' --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar`
 ^EXIT=10$
 ^SIGNAL=0$
 assertion.1.*FAILURE

--- a/jbmc/regression/jbmc/CMakeLists.txt
+++ b/jbmc/regression/jbmc/CMakeLists.txt
@@ -1,11 +1,5 @@
-if("${CMAKE_SYSTEM_NAME}" STREQUAL "Windows")
-  set(exclude_win_broken_tests -X winbug)
-else()
-  set(exclude_win_broken_tests "")
-endif()
-
 add_test_pl_tests(
-    "$<TARGET_FILE:jbmc> --validate-goto-model --validate-ssa-equation --validate-trace" ${exclude_win_broken_tests}
+    "$<TARGET_FILE:jbmc> --validate-goto-model --validate-ssa-equation --validate-trace"
 )
 
 if(DEFINED BDD_GUARDS)
@@ -14,7 +8,6 @@ if(DEFINED BDD_GUARDS)
             "$<TARGET_FILE:jbmc> --validate-goto-model --validate-ssa-equation --validate-trace --symex-driven-lazy-loading"
             "-C;-X;symex-driven-lazy-loading-expected-failure;-s;symex-driven-loading"
             "CORE"
-            ${exclude_win_broken_tests}
     )
 else()
     add_test_pl_profile(
@@ -22,6 +15,5 @@ else()
             "$<TARGET_FILE:jbmc> --validate-goto-model --validate-ssa-equation --validate-trace --symex-driven-lazy-loading"
             "-C;-X;symex-driven-lazy-loading-expected-failure;-X;bdd-expected-timeout;-s;symex-driven-loading"
             "CORE"
-            ${exclude_win_broken_tests}
     )
 endif()

--- a/jbmc/regression/jbmc/array-cell-sensitivity-static-fields/test-char-array-ref-static-values.desc
+++ b/jbmc/regression/jbmc/array-cell-sensitivity-static-fields/test-char-array-ref-static-values.desc
@@ -1,6 +1,6 @@
-CORE symex-driven-lazy-loading-expected-failure winbug
+CORE symex-driven-lazy-loading-expected-failure
 Test
---function Test.charArrayRef --property "java::Test.charArrayRef:()[C.assertion.2" --static-values static-values.json
+--function Test.charArrayRef --property 'java::Test.charArrayRef:()[C.assertion.2' --static-values static-values.json
 Generated 0 VCC[(]s[)], 0 remaining after simplification
 assertion at file Test.java line 31 .*: SUCCESS
 ^EXIT=0$

--- a/jbmc/regression/jbmc/array-cell-sensitivity-static-fields/test-char-array-ref.desc
+++ b/jbmc/regression/jbmc/array-cell-sensitivity-static-fields/test-char-array-ref.desc
@@ -1,6 +1,6 @@
-CORE symex-driven-lazy-loading-expected-failure winbug
+CORE symex-driven-lazy-loading-expected-failure
 Test
---function Test.charArrayRef --property "java::Test.charArrayRef:()[C.assertion.1"
+--function Test.charArrayRef --property 'java::Test.charArrayRef:()[C.assertion.1'
 Generated 0 VCC[(]s[)], 0 remaining after simplification
 assertion at file Test.java line 29 .*: SUCCESS
 ^EXIT=0$

--- a/jbmc/regression/jbmc/array-cell-sensitivity-static-fields/test-char-array-static-values.desc
+++ b/jbmc/regression/jbmc/array-cell-sensitivity-static-fields/test-char-array-static-values.desc
@@ -1,6 +1,6 @@
-CORE symex-driven-lazy-loading-expected-failure winbug
+CORE symex-driven-lazy-loading-expected-failure
 Test
---function Test.charArray --property "java::Test.charArray:()[C.assertion.2" --static-values static-values.json
+--function Test.charArray --property 'java::Test.charArray:()[C.assertion.2' --static-values static-values.json
 Generated 0 VCC[(]s[)], 0 remaining after simplification
 assertion at file Test.java line 21 .*: SUCCESS
 ^EXIT=0$

--- a/jbmc/regression/jbmc/array-cell-sensitivity-static-fields/test-char-array1.desc
+++ b/jbmc/regression/jbmc/array-cell-sensitivity-static-fields/test-char-array1.desc
@@ -1,6 +1,6 @@
-CORE symex-driven-lazy-loading-expected-failure winbug
+CORE symex-driven-lazy-loading-expected-failure
 Test
---function Test.charArray --property "java::Test.charArray:()[C.assertion.1"
+--function Test.charArray --property 'java::Test.charArray:()[C.assertion.1'
 Generated 0 VCC[(]s[)], 0 remaining after simplification
 assertion at file Test.java line 20 .*: SUCCESS
 ^EXIT=0$

--- a/jbmc/regression/jbmc/assume-inputs-interval/arg_assume_singleton.desc
+++ b/jbmc/regression/jbmc/assume-inputs-interval/arg_assume_singleton.desc
@@ -1,6 +1,6 @@
-CORE symex-driven-lazy-loading-expected-failure winbug
+CORE symex-driven-lazy-loading-expected-failure
 My
---function My.intervalUnion --java-assume-inputs-interval [3:3] --property "java::My.intervalUnion:(I)V.assertion.1" --property "java::My.intervalUnion:(I)V.assertion.2" --property "java::My.intervalUnion:(I)V.assertion.3" --property "java::My.intervalUnion:(I)V.assertion.4" --property "java::My.intervalUnion:(I)V.assertion.6"
+--function My.intervalUnion --java-assume-inputs-interval [3:3] --property 'java::My.intervalUnion:(I)V.assertion.1' --property 'java::My.intervalUnion:(I)V.assertion.2' --property 'java::My.intervalUnion:(I)V.assertion.3' --property 'java::My.intervalUnion:(I)V.assertion.4' --property 'java::My.intervalUnion:(I)V.assertion.6'
 ^EXIT=0$
 ^SIGNAL=0$
 ^VERIFICATION SUCCESSFUL$

--- a/jbmc/regression/jbmc/core-models-required/test.desc
+++ b/jbmc/regression/jbmc/core-models-required/test.desc
@@ -1,6 +1,6 @@
 KNOWNBUG
 HelloWorld
---function "HelloWorld.helloWorld:()Ljava/lang/String;" --context-include wrongpkg
+--function 'HelloWorld.helloWorld:()Ljava/lang/String;' --context-include wrongpkg
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/jbmc/regression/jbmc/enum/test_enum_switch.desc
+++ b/jbmc/regression/jbmc/enum/test_enum_switch.desc
@@ -1,6 +1,6 @@
-CORE symex-driven-lazy-loading-expected-failure winbug
+CORE symex-driven-lazy-loading-expected-failure
 Foo
---trace --depth 1024 --java-max-vla-length 16 --max-nondet-string-length 20 --string-printable --unwind 10 --function "Foo.foo" --java-unwind-enum-static
+--trace --depth 1024 --java-max-vla-length 16 --max-nondet-string-length 20 --string-printable --unwind 10 --function 'Foo.foo' --java-unwind-enum-static
 assertion at file Foo.java line 6 .*: FAILURE
 assertion at file Foo.java line 9 .*: FAILURE
 assertion at file Foo.java line 12 .*: FAILURE

--- a/jbmc/regression/jbmc/enum/test_enum_values_clone.desc
+++ b/jbmc/regression/jbmc/enum/test_enum_values_clone.desc
@@ -1,6 +1,6 @@
 CORE symex-driven-lazy-loading-expected-failure
 EnumIter
---java-max-vla-length 16 --max-nondet-string-length 20 --string-printable --unwind 2 --function "EnumIter.f" --java-unwind-enum-static --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar`
+--java-max-vla-length 16 --max-nondet-string-length 20 --string-printable --unwind 2 --function 'EnumIter.f' --java-unwind-enum-static --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar`
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/jbmc/regression/jbmc/enum/test_enum_values_clone_name.desc
+++ b/jbmc/regression/jbmc/enum/test_enum_values_clone_name.desc
@@ -1,6 +1,6 @@
 CORE symex-driven-lazy-loading-expected-failure
 EnumIter
---java-max-vla-length 16 --max-nondet-string-length 20 --string-printable --unwind 2 --function "EnumIter.name" --java-unwind-enum-static --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar`
+--java-max-vla-length 16 --max-nondet-string-length 20 --string-printable --unwind 2 --function 'EnumIter.name' --java-unwind-enum-static --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar`
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/jbmc/regression/jbmc/nondet-array-size/test.desc
+++ b/jbmc/regression/jbmc/nondet-array-size/test.desc
@@ -1,6 +1,6 @@
-CORE winbug
+CORE
 TestClass
---function "TestClass.minimalJbmc" --unwind 5 --max-nondet-string-length 10 --java-unwind-enum-static --trace --json-ui
+--function 'TestClass.minimalJbmc' --unwind 5 --max-nondet-string-length 10 --java-unwind-enum-static --trace --json-ui
 ^EXIT=10$
 ^SIGNAL=0$
 VERIFICATION FAILED

--- a/jbmc/regression/jbmc/nondet-static/test.desc
+++ b/jbmc/regression/jbmc/nondet-static/test.desc
@@ -1,6 +1,6 @@
-CORE symex-driven-lazy-loading-expected-failure winbug
+CORE symex-driven-lazy-loading-expected-failure
 My
---function "My.<init>" --nondet-static --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar`
+--function 'My.<init>' --nondet-static --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar`
 ^EXIT=10$
 ^SIGNAL=0$
 file My\.java line 104 function java::My\.\<init\>:\(I\)V.*FAILURE$

--- a/jbmc/regression/jbmc/parameter-annotation-not-null/test_kotlin.desc
+++ b/jbmc/regression/jbmc/parameter-annotation-not-null/test_kotlin.desc
@@ -1,6 +1,6 @@
-CORE winbug
+CORE
 MainKotlin
---function "MainKotlin.<init>" --show-properties
+--function 'MainKotlin.<init>' --show-properties
 ^EXIT=0$
 ^SIGNAL=0$
 Property java::MainKotlin.<init>:\(Ljava/lang/String;Ljava/lang/String;\)V.not-null-annotation-check.1:

--- a/regression/goto-instrument/CMakeLists.txt
+++ b/regression/goto-instrument/CMakeLists.txt
@@ -4,12 +4,6 @@ else()
     set(is_windows false)
 endif()
 
-if("${CMAKE_SYSTEM_NAME}" STREQUAL "Windows")
-  set(exclude_win_broken_tests -X winbug)
-else()
-  set(exclude_win_broken_tests "")
-endif()
-
 add_test_pl_tests(
-    "${CMAKE_CURRENT_SOURCE_DIR}/chain.sh $<TARGET_FILE:goto-cc> $<TARGET_FILE:goto-instrument> $<TARGET_FILE:cbmc> ${is_windows}" ${exclude_win_broken_tests}
+    "${CMAKE_CURRENT_SOURCE_DIR}/chain.sh $<TARGET_FILE:goto-cc> $<TARGET_FILE:goto-instrument> $<TARGET_FILE:cbmc> ${is_windows}"
 )

--- a/regression/goto-instrument/restrict-function-pointer-to-complex-expression/test.desc
+++ b/regression/goto-instrument/restrict-function-pointer-to-complex-expression/test.desc
@@ -1,6 +1,6 @@
-CORE winbug
+CORE
 test.c
---restrict-function-pointer "use_fg.function_pointer_call.1/f,g"
+--restrict-function-pointer 'use_fg.function_pointer_call.1/f,g'
 \[use_fg.assertion.2\] line \d+ assertion \(choice \? fptr : gptr\)\(10\) == 10 \+ choice: SUCCESS
 \[use_fg.assertion.1\] line \d+ dereferenced function pointer at use_fg.function_pointer_call.1 must be one of \[(f|g), (f|g)\]: SUCCESS
 ^EXIT=0$

--- a/regression/solver-hardness/CMakeLists.txt
+++ b/regression/solver-hardness/CMakeLists.txt
@@ -1,7 +1,2 @@
-if(NOT "${CMAKE_SYSTEM_NAME}" STREQUAL "Windows")
-  add_test_pl_tests(
-    "../chain.sh $<TARGET_FILE:cbmc>")
-else()
-  message(WARNING "solver-hardness/ tests are failing on windows for unknown reasons. An investigation is pending.")
-endif()
-
+add_test_pl_tests(
+  "../chain.sh $<TARGET_FILE:cbmc>")

--- a/regression/solver-hardness/solver-hardness-simple/test.desc
+++ b/regression/solver-hardness/solver-hardness-simple/test.desc
@@ -1,6 +1,6 @@
-CORE winbug
+CORE
 main.c
---write-solver-stats-to "solver_hardness.json"
+--write-solver-stats-to 'solver_hardness.json'
 ^EXIT=10$
 ^SIGNAL=0$
 ^\[main.assertion.\d+\] line \d+ assertion a \+ b \< 10: FAILURE$


### PR DESCRIPTION
test.pl cannot cope with double quotes on some Windows-based platforms
(including GitHub's Windows environment).

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
