### PR TITLE
Update subclasses of ai_domain_baset to deprecate function

### DIFF
--- a/src/analyses/ai_domain.h
+++ b/src/analyses/ai_domain.h
@@ -103,24 +103,6 @@ public:
     const irep_idt &function_to,
     trace_ptrt to,
     ai_baset &ai,
-    const namespacet &ns)
-  {
-    return transform(
-      function_from,
-      from->current_location(),
-      function_to,
-      to->current_location(),
-      ai,
-      ns);
-  }
-
-  DEPRECATED(SINCE(2019, 08, 01, "use the history signature instead"))
-  virtual void transform(
-    const irep_idt &function_from,
-    locationt from,
-    const irep_idt &function_to,
-    locationt to,
-    ai_baset &ai,
     const namespacet &ns) = 0;
 
   virtual void

--- a/src/analyses/constant_propagator.cpp
+++ b/src/analyses/constant_propagator.cpp
@@ -122,12 +122,15 @@ void constant_propagator_domaint::assign_rec(
 
 void constant_propagator_domaint::transform(
   const irep_idt &function_from,
-  locationt from,
+  trace_ptrt trace_from,
   const irep_idt &function_to,
-  locationt to,
+  trace_ptrt trace_to,
   ai_baset &ai,
   const namespacet &ns)
 {
+  locationt from{trace_from->current_location()};
+  locationt to{trace_to->current_location()};
+
 #ifdef DEBUG
   std::cout << "Transform from/to:\n";
   std::cout << from->location_number << " --> "

--- a/src/analyses/constant_propagator.h
+++ b/src/analyses/constant_propagator.h
@@ -35,9 +35,9 @@ class constant_propagator_domaint:public ai_domain_baset
 public:
   virtual void transform(
     const irep_idt &function_from,
-    locationt from,
+    trace_ptrt trace_from,
     const irep_idt &function_to,
-    locationt to,
+    trace_ptrt trace_to,
     ai_baset &ai_base,
     const namespacet &ns) final override;
 

--- a/src/analyses/custom_bitvector_analysis.cpp
+++ b/src/analyses/custom_bitvector_analysis.cpp
@@ -267,12 +267,15 @@ void custom_bitvector_domaint::assign_struct_rec(
 
 void custom_bitvector_domaint::transform(
   const irep_idt &function_from,
-  locationt from,
+  trace_ptrt trace_from,
   const irep_idt &function_to,
-  locationt to,
+  trace_ptrt trace_to,
   ai_baset &ai,
   const namespacet &ns)
 {
+  locationt from{trace_from->current_location()};
+  locationt to{trace_to->current_location()};
+
   // upcast of ai
   custom_bitvector_analysist &cba=
     static_cast<custom_bitvector_analysist &>(ai);

--- a/src/analyses/custom_bitvector_analysis.h
+++ b/src/analyses/custom_bitvector_analysis.h
@@ -25,9 +25,9 @@ class custom_bitvector_domaint:public ai_domain_baset
 public:
   void transform(
     const irep_idt &function_from,
-    locationt from,
+    trace_ptrt trace_from,
     const irep_idt &function_to,
-    locationt to,
+    trace_ptrt trace_to,
     ai_baset &ai,
     const namespacet &ns) final override;
 

--- a/src/analyses/dependence_graph.cpp
+++ b/src/analyses/dependence_graph.cpp
@@ -194,12 +194,15 @@ void dep_graph_domaint::data_dependencies(
 
 void dep_graph_domaint::transform(
   const irep_idt &function_from,
-  goto_programt::const_targett from,
+  trace_ptrt trace_from,
   const irep_idt &function_to,
-  goto_programt::const_targett to,
+  trace_ptrt trace_to,
   ai_baset &ai,
   const namespacet &ns)
 {
+  locationt from{trace_from->current_location()};
+  locationt to{trace_to->current_location()};
+
   dependence_grapht *dep_graph=dynamic_cast<dependence_grapht*>(&ai);
   assert(dep_graph!=nullptr);
 

--- a/src/analyses/dependence_graph.h
+++ b/src/analyses/dependence_graph.h
@@ -80,9 +80,9 @@ public:
 
   void transform(
     const irep_idt &function_from,
-    goto_programt::const_targett from,
+    trace_ptrt trace_from,
     const irep_idt &function_to,
-    goto_programt::const_targett to,
+    trace_ptrt trace_to,
     ai_baset &ai,
     const namespacet &ns) final override;
 

--- a/src/analyses/escape_analysis.cpp
+++ b/src/analyses/escape_analysis.cpp
@@ -166,13 +166,15 @@ void escape_domaint::get_rhs_aliases_address_of(
 }
 
 void escape_domaint::transform(
-  const irep_idt &,
-  locationt from,
-  const irep_idt &,
-  locationt,
-  ai_baset &,
-  const namespacet &)
+  const irep_idt &function_from,
+  trace_ptrt trace_from,
+  const irep_idt &function_to,
+  trace_ptrt trace_to,
+  ai_baset &ai,
+  const namespacet &ns)
 {
+  locationt from{trace_from->current_location()};
+
   if(has_values.is_false())
     return;
 

--- a/src/analyses/escape_analysis.h
+++ b/src/analyses/escape_analysis.h
@@ -30,9 +30,9 @@ public:
 
   void transform(
     const irep_idt &function_from,
-    locationt from,
+    trace_ptrt trace_from,
     const irep_idt &function_to,
-    locationt to,
+    trace_ptrt trace_to,
     ai_baset &ai,
     const namespacet &ns) final override;
 

--- a/src/analyses/global_may_alias.cpp
+++ b/src/analyses/global_may_alias.cpp
@@ -91,13 +91,15 @@ void global_may_alias_domaint::get_rhs_aliases_address_of(
 }
 
 void global_may_alias_domaint::transform(
-  const irep_idt &,
-  locationt from,
-  const irep_idt &,
-  locationt,
-  ai_baset &,
-  const namespacet &)
+  const irep_idt &function_from,
+  trace_ptrt trace_from,
+  const irep_idt &function_to,
+  trace_ptrt trace_to,
+  ai_baset &ai,
+  const namespacet &ns)
 {
+  locationt from{trace_from->current_location()};
+
   if(has_values.is_false())
     return;
 

--- a/src/analyses/global_may_alias.h
+++ b/src/analyses/global_may_alias.h
@@ -31,9 +31,9 @@ public:
   /// Abstract Interpretation domain transform function.
   void transform(
     const irep_idt &function_from,
-    locationt from,
+    trace_ptrt trace_from,
     const irep_idt &function_to,
-    locationt to,
+    trace_ptrt trace_to,
     ai_baset &ai,
     const namespacet &ns) final override;
 

--- a/src/analyses/interval_domain.cpp
+++ b/src/analyses/interval_domain.cpp
@@ -57,13 +57,16 @@ void interval_domaint::output(
 }
 
 void interval_domaint::transform(
-  const irep_idt &,
-  locationt from,
-  const irep_idt &,
-  locationt to,
-  ai_baset &,
+  const irep_idt &function_from,
+  trace_ptrt trace_from,
+  const irep_idt &function_to,
+  trace_ptrt trace_to,
+  ai_baset &ai,
   const namespacet &ns)
 {
+  locationt from{trace_from->current_location()};
+  locationt to{trace_to->current_location()};
+
   const goto_programt::instructiont &instruction=*from;
   switch(instruction.type)
   {

--- a/src/analyses/interval_domain.h
+++ b/src/analyses/interval_domain.h
@@ -33,9 +33,9 @@ public:
 
   void transform(
     const irep_idt &function_from,
-    locationt from,
+    trace_ptrt trace_from,
     const irep_idt &function_to,
-    locationt to,
+    trace_ptrt trace_to,
     ai_baset &ai,
     const namespacet &ns) final override;
 

--- a/src/analyses/invariant_set_domain.cpp
+++ b/src/analyses/invariant_set_domain.cpp
@@ -15,13 +15,16 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/simplify_expr.h>
 
 void invariant_set_domaint::transform(
-  const irep_idt &,
-  locationt from_l,
-  const irep_idt &,
-  locationt to_l,
-  ai_baset &,
+  const irep_idt &function_from,
+  trace_ptrt trace_from,
+  const irep_idt &function_to,
+  trace_ptrt trace_to,
+  ai_baset &ai,
   const namespacet &ns)
 {
+  locationt from_l(trace_from->current_location());
+  locationt to_l(trace_to->current_location());
+
   switch(from_l->type)
   {
   case GOTO:

--- a/src/analyses/invariant_set_domain.h
+++ b/src/analyses/invariant_set_domain.h
@@ -58,9 +58,9 @@ public:
 
   virtual void transform(
     const irep_idt &function_from,
-    locationt from_l,
+    trace_ptrt trace_from,
     const irep_idt &function_to,
-    locationt to_l,
+    trace_ptrt trace_to,
     ai_baset &ai,
     const namespacet &ns) final override;
 

--- a/src/analyses/is_threaded.cpp
+++ b/src/analyses/is_threaded.cpp
@@ -48,12 +48,14 @@ public:
 
   void transform(
     const irep_idt &,
-    locationt from,
+    trace_ptrt trace_from,
     const irep_idt &,
-    locationt,
+    trace_ptrt,
     ai_baset &,
-    const namespacet &) final override
+    const namespacet &) override
   {
+    locationt from{trace_from->current_location()};
+
     INVARIANT(reachable,
               "Transformers are only applied at reachable locations");
 

--- a/src/analyses/reaching_definitions.cpp
+++ b/src/analyses/reaching_definitions.cpp
@@ -90,12 +90,15 @@ void rd_range_domaint::populate_cache(const irep_idt &identifier) const
 
 void rd_range_domaint::transform(
   const irep_idt &function_from,
-  locationt from,
+  trace_ptrt trace_from,
   const irep_idt &function_to,
-  locationt to,
+  trace_ptrt trace_to,
   ai_baset &ai,
   const namespacet &ns)
 {
+  locationt from{trace_from->current_location()};
+  locationt to{trace_to->current_location()};
+
   reaching_definitions_analysist *rd=
     dynamic_cast<reaching_definitions_analysist*>(&ai);
   INVARIANT_STRUCTURED(

--- a/src/analyses/reaching_definitions.h
+++ b/src/analyses/reaching_definitions.h
@@ -149,17 +149,17 @@ public:
   /// `transform_*` method for the recognised instruction.
   /// \param function_from: Just passed to `transform_function_call` and
   ///   `transform_end_function` callees.
-  /// \param from: Reference to a GOTO instruction according to which `*this`
-  ///   instance should be transformed.
+  /// \param trace_from: The ai_history giving the GOTO instruction which
+  ///    `*this` instance should be transformed.
   /// \param function_to: Just passed to `transform_function_call` callee.
-  /// \param to: Just passed to `transform_end_function` callee.
+  /// \param trace_to: Just passed to `transform_end_function` callee.
   /// \param ai: A reference to 'reaching_definitions_analysist' instance.
   /// \param ns: Just passed to callees.
   void transform(
     const irep_idt &function_from,
-    locationt from,
+    trace_ptrt trace_from,
     const irep_idt &function_to,
-    locationt to,
+    trace_ptrt trace_to,
     ai_baset &ai,
     const namespacet &ns) final override;
 

--- a/src/analyses/uninitialized_domain.cpp
+++ b/src/analyses/uninitialized_domain.cpp
@@ -20,12 +20,14 @@ Date: January 2010
 
 void uninitialized_domaint::transform(
   const irep_idt &,
-  locationt from,
+  trace_ptrt trace_from,
   const irep_idt &,
-  locationt,
+  trace_ptrt,
   ai_baset &,
   const namespacet &ns)
 {
+  locationt from{trace_from->current_location()};
+
   if(has_values.is_false())
     return;
 

--- a/src/analyses/uninitialized_domain.h
+++ b/src/analyses/uninitialized_domain.h
@@ -31,9 +31,9 @@ public:
 
   void transform(
     const irep_idt &function_from,
-    locationt from,
+    trace_ptrt trace_from,
     const irep_idt &function_to,
-    locationt to,
+    trace_ptrt trace_to,
     ai_baset &ai,
     const namespacet &ns) final override;
 

--- a/src/analyses/variable-sensitivity/three_way_merge_abstract_interpreter.cpp
+++ b/src/analyses/variable-sensitivity/three_way_merge_abstract_interpreter.cpp
@@ -125,9 +125,9 @@ bool ai_three_way_merget::visit_edge_function_call(
     // but in VSD it does, so this cannot be omitted.
     s_working.transform(
       callee_function_id,
-      l_callee_end,
+      p_callee_end,
       calling_function_id,
-      l_return_site,
+      p_return_site,
       *this,
       ns);
 

--- a/src/analyses/variable-sensitivity/variable_sensitivity_dependence_graph.cpp
+++ b/src/analyses/variable-sensitivity/variable_sensitivity_dependence_graph.cpp
@@ -65,14 +65,17 @@ void variable_sensitivity_dependence_domaint::eval_data_deps(
  */
 void variable_sensitivity_dependence_domaint::transform(
   const irep_idt &function_from,
-  locationt from,
+  trace_ptrt trace_from,
   const irep_idt &function_to,
-  locationt to,
+  trace_ptrt trace_to,
   ai_baset &ai,
   const namespacet &ns)
 {
+  locationt from{trace_from->current_location()};
+  locationt to{trace_to->current_location()};
+
   variable_sensitivity_domaint::transform(
-    function_from, from, function_to, to, ai, ns);
+    function_from, trace_from, function_to, trace_to, ai, ns);
 
   variable_sensitivity_dependence_grapht *dep_graph =
     dynamic_cast<variable_sensitivity_dependence_grapht *>(&ai);

--- a/src/analyses/variable-sensitivity/variable_sensitivity_dependence_graph.h
+++ b/src/analyses/variable-sensitivity/variable_sensitivity_dependence_graph.h
@@ -81,9 +81,9 @@ public:
 
   void transform(
     const irep_idt &function_from,
-    locationt from,
+    trace_ptrt trace_from,
     const irep_idt &function_to,
-    locationt to,
+    trace_ptrt trace_to,
     ai_baset &ai,
     const namespacet &ns) override;
 

--- a/src/analyses/variable-sensitivity/variable_sensitivity_domain.cpp
+++ b/src/analyses/variable-sensitivity/variable_sensitivity_domain.cpp
@@ -23,12 +23,15 @@ Date: April 2016
 
 void variable_sensitivity_domaint::transform(
   const irep_idt &function_from,
-  locationt from,
+  trace_ptrt trace_from,
   const irep_idt &function_to,
-  locationt to,
+  trace_ptrt trace_to,
   ai_baset &ai,
   const namespacet &ns)
 {
+  locationt from{trace_from->current_location()};
+  locationt to{trace_to->current_location()};
+
 #ifdef DEBUG
   std::cout << "Transform from/to:\n";
   std::cout << from->location_number << " --> " << to->location_number << '\n';

--- a/src/analyses/variable-sensitivity/variable_sensitivity_domain.h
+++ b/src/analyses/variable-sensitivity/variable_sensitivity_domain.h
@@ -84,9 +84,9 @@ public:
   /// \param ns: the namespace
   void transform(
     const irep_idt &function_from,
-    locationt from,
+    trace_ptrt trace_from,
     const irep_idt &function_to,
-    locationt to,
+    trace_ptrt trace_to,
     ai_baset &ai,
     const namespacet &ns) override;
 

--- a/unit/analyses/ai/ai.cpp
+++ b/unit/analyses/ai/ai.cpp
@@ -38,9 +38,9 @@ public:
 
   void transform(
     const irep_idt &,
-    locationt,
+    trace_ptrt,
     const irep_idt &,
-    locationt,
+    trace_ptrt,
     ai_baset &,
     const namespacet &) override
   {

--- a/unit/analyses/ai/ai_simplify_lhs.cpp
+++ b/unit/analyses/ai/ai_simplify_lhs.cpp
@@ -28,9 +28,9 @@ class constant_simplification_mockt:public ai_domain_baset
 public:
   void transform(
     const irep_idt &,
-    locationt,
+    trace_ptrt,
     const irep_idt &,
-    locationt,
+    trace_ptrt,
     ai_baset &,
     const namespacet &) override
   {}


### PR DESCRIPTION
transform's signature changed during the addition of
ai_historyt.  This is removing the old signature in favour
of the newer, more flexible one.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
