### PR TITLE
Usability/split up pointer primitive checks

### DIFF
--- a/regression/cbmc/pointer-extra-checks/test.desc
+++ b/regression/cbmc/pointer-extra-checks/test.desc
@@ -8,8 +8,8 @@ main.c
 ^\[main.pointer_dereference.3\] .* dereference failure: pointer outside object bounds in \*q: SUCCESS$
 ^\[main.pointer_dereference.4\] .* dereference failure: deallocated dynamic object in \*r: SUCCESS$
 ^\[main.pointer_dereference.5\] .* dereference failure: pointer outside dynamic object bounds in \*r: SUCCESS$
-^\[main.pointer_dereference.6\] .* dereference failure: pointer invalid in \*s: FAILURE$
-^\[main.pointer_dereference.7\] .* dereference failure: pointer NULL in \*s: FAILURE$
+^\[main.pointer_dereference.6\] .* dereference failure: pointer NULL in \*s: FAILURE$
+^\[main.pointer_dereference.7\] .* dereference failure: pointer invalid in \*s: FAILURE$
 ^\[main.pointer_dereference.8\] .* dereference failure: deallocated dynamic object in \*s: FAILURE$
 ^\[main.pointer_dereference.9\] .* dereference failure: dead object in \*s: FAILURE$
 ^\[main.pointer_dereference.10\] .* dereference failure: pointer outside dynamic object bounds in \*s: FAILURE$

--- a/regression/cbmc/pointer-primitive-check-01/test.desc
+++ b/regression/cbmc/pointer-primitive-check-01/test.desc
@@ -1,15 +1,43 @@
-CORE
+CORE broken-smt-backend
 main.c
 --pointer-primitive-check
 ^EXIT=10$
 ^SIGNAL=0$
-\[main.pointer_primitives.1\] line \d+ pointer in pointer primitive is neither null nor valid in POINTER_OBJECT.*: FAILURE
-\[main.pointer_primitives.2\] line \d+ pointer in pointer primitive is neither null nor valid in POINTER_OFFSET.*: FAILURE
-\[main.pointer_primitives.3\] line \d+ pointer in pointer primitive is neither null nor valid in POINTER_OBJECT.*: FAILURE
-\[main.pointer_primitives.4\] line \d+ pointer in pointer primitive is neither null nor valid in OBJECT_SIZE.*: FAILURE
-\[main.pointer_primitives.5\] line \d+ pointer in pointer primitive is neither null nor valid in R_OK.*: FAILURE
-\[main.pointer_primitives.6\] line \d+ pointer in pointer primitive is neither null nor valid in W_OK.*: FAILURE
-\*\* 7 of \d+ failed
+\[main.pointer_primitives.1\] line \d+ pointer invalid in POINTER_OBJECT\(\(const void \*\)p1\): FAILURE
+\[main.pointer_primitives.2\] line \d+ deallocated dynamic object in POINTER_OBJECT\(\(const void \*\)p1\): SUCCESS
+\[main.pointer_primitives.3\] line \d+ dead object in POINTER_OBJECT\(\(const void \*\)p1\): SUCCESS
+\[main.pointer_primitives.4\] line \d+ pointer outside dynamic object bounds in POINTER_OBJECT\(\(const void \*\)p1\): FAILURE
+\[main.pointer_primitives.5\] line \d+ pointer outside object bounds in POINTER_OBJECT\(\(const void \*\)p1\): FAILURE
+\[main.pointer_primitives.6\] line \d+ pointer invalid in POINTER_OFFSET\(\(const void \*\)p2\): FAILURE
+\[main.pointer_primitives.7\] line \d+ deallocated dynamic object in POINTER_OFFSET\(\(const void \*\)p2\): SUCCESS
+\[main.pointer_primitives.8\] line \d+ dead object in POINTER_OFFSET\(\(const void \*\)p2\): SUCCESS
+\[main.pointer_primitives.9\] line \d+ pointer outside dynamic object bounds in POINTER_OFFSET\(\(const void \*\)p2\): FAILURE
+\[main.pointer_primitives.10\] line \d+ pointer outside object bounds in POINTER_OFFSET\(\(const void \*\)p2\): FAILURE
+\[main.pointer_primitives.11\] line \d+ pointer invalid in POINTER_OBJECT\(\(const void \*\)p3\): FAILURE
+\[main.pointer_primitives.12\] line \d+ deallocated dynamic object in POINTER_OBJECT\(\(const void \*\)p3\): SUCCESS
+\[main.pointer_primitives.13\] line \d+ dead object in POINTER_OBJECT\(\(const void \*\)p3\): SUCCESS
+\[main.pointer_primitives.14\] line \d+ pointer outside dynamic object bounds in POINTER_OBJECT\(\(const void \*\)p3\): FAILURE
+\[main.pointer_primitives.15\] line \d+ pointer outside object bounds in POINTER_OBJECT\(\(const void \*\)p3\): FAILURE
+\[main.pointer_primitives.16\] line \d+ pointer invalid in OBJECT_SIZE\(\(const void \*\)p4\): FAILURE
+\[main.pointer_primitives.17\] line \d+ deallocated dynamic object in OBJECT_SIZE\(\(const void \*\)p4\): SUCCESS
+\[main.pointer_primitives.18\] line \d+ dead object in OBJECT_SIZE\(\(const void \*\)p4\): SUCCESS
+\[main.pointer_primitives.19\] line \d+ pointer outside dynamic object bounds in OBJECT_SIZE\(\(const void \*\)p4\): FAILURE
+\[main.pointer_primitives.20\] line \d+ pointer outside object bounds in OBJECT_SIZE\(\(const void \*\)p4\): FAILURE
+\[main.pointer_primitives.21\] line \d+ pointer invalid in R_OK\(\(const void \*\)p5, \(__CPROVER_size_t\)1\): FAILURE
+\[main.pointer_primitives.22\] line \d+ deallocated dynamic object in R_OK\(\(const void \*\)p5, \(__CPROVER_size_t\)1\): SUCCESS
+\[main.pointer_primitives.23\] line \d+ dead object in R_OK\(\(const void \*\)p5, \(__CPROVER_size_t\)1\): SUCCESS
+\[main.pointer_primitives.24\] line \d+ pointer outside dynamic object bounds in R_OK\(\(const void \*\)p5, \(__CPROVER_size_t\)1\): FAILURE
+\[main.pointer_primitives.25\] line \d+ pointer outside object bounds in R_OK\(\(const void \*\)p5, \(__CPROVER_size_t\)1\): FAILURE
+\[main.pointer_primitives.26\] line \d+ pointer invalid in W_OK\(\(const void \*\)p6, \(__CPROVER_size_t\)1\): FAILURE
+\[main.pointer_primitives.27\] line \d+ deallocated dynamic object in W_OK\(\(const void \*\)p6, \(__CPROVER_size_t\)1\): SUCCESS
+\[main.pointer_primitives.28\] line \d+ dead object in W_OK\(\(const void \*\)p6, \(__CPROVER_size_t\)1\): SUCCESS
+\[main.pointer_primitives.29\] line \d+ pointer outside dynamic object bounds in W_OK\(\(const void \*\)p6, \(__CPROVER_size_t\)1\): FAILURE
+\[main.pointer_primitives.30\] line \d+ pointer outside object bounds in W_OK\(\(const void \*\)p6, \(__CPROVER_size_t\)1\): FAILURE
+\[main.pointer_primitives.31\] line \d+ pointer invalid in IS_DYNAMIC_OBJECT\(\(const void \*\)p7\): FAILURE
+\[main.pointer_primitives.32\] line \d+ deallocated dynamic object in IS_DYNAMIC_OBJECT\(\(const void \*\)p7\): SUCCESS
+\[main.pointer_primitives.33\] line \d+ dead object in IS_DYNAMIC_OBJECT\(\(const void \*\)p7\): SUCCESS
+\[main.pointer_primitives.34\] line \d+ pointer outside dynamic object bounds in IS_DYNAMIC_OBJECT\(\(const void \*\)p7\): FAILURE
+\[main.pointer_primitives.35\] line \d+ pointer outside object bounds in IS_DYNAMIC_OBJECT\(\(const void \*\)p7\): FAILURE
 --
 ^warning: ignoring
 --

--- a/regression/cbmc/pointer-primitive-check-03/test.desc
+++ b/regression/cbmc/pointer-primitive-check-03/test.desc
@@ -3,15 +3,45 @@ main.c
 --pointer-primitive-check
 ^EXIT=10$
 ^SIGNAL=0$
-\[main.pointer_primitives.1\] line \d+ pointer in pointer primitive is neither null nor valid in POINTER_OBJECT.*: FAILURE
-\[main.pointer_primitives.2\] line \d+ pointer in pointer primitive is neither null nor valid in POINTER_OBJECT.*: FAILURE
-\[main.pointer_primitives.3\] line \d+ pointer in pointer primitive is neither null nor valid in POINTER_OBJECT.*: FAILURE
-\[main.pointer_primitives.4\] line \d+ pointer in pointer primitive is neither null nor valid in POINTER_OBJECT.*: FAILURE
-\[main.pointer_primitives.5\] line \d+ pointer in pointer primitive is neither null nor valid in POINTER_OBJECT.*: FAILURE
-\[main.pointer_primitives.6\] line \d+ pointer in pointer primitive is neither null nor valid in POINTER_OBJECT.*: FAILURE
-\[main.pointer_primitives.7\] line \d+ pointer in pointer primitive is neither null nor valid in POINTER_OBJECT.*: FAILURE
-\*\* 7 of \d+ failed
 --
+\[main.pointer_primitives.1\] line \d+ pointer NULL in POINTER_OBJECT((const void \*)p1): SUCCESS
+\[main.pointer_primitives.2\] line \d+ pointer invalid in POINTER_OBJECT((const void \*)p1): FAILURE
+\[main.pointer_primitives.3\] line \d+ deallocated dynamic object in POINTER_OBJECT((const void \*)p1): SUCCESS
+\[main.pointer_primitives.4\] line \d+ dead object in POINTER_OBJECT((const void \*)p1): SUCCESS
+\[main.pointer_primitives.5\] line \d+ pointer outside dynamic object bounds in POINTER_OBJECT((const void \*)p1): FAILURE
+\[main.pointer_primitives.6\] line \d+ pointer outside object bounds in POINTER_OBJECT((const void \*)p1): FAILURE
+\[main.pointer_primitives.7\] line \d+ pointer NULL in POINTER_OBJECT((const void \*)p2): SUCCESS
+\[main.pointer_primitives.8\] line \d+ pointer invalid in POINTER_OBJECT((const void \*)p2): FAILURE
+\[main.pointer_primitives.9\] line \d+ deallocated dynamic object in POINTER_OBJECT((const void \*)p2): SUCCESS
+\[main.pointer_primitives.10\] line \d+ dead object in POINTER_OBJECT((const void \*)p2): SUCCESS
+\[main.pointer_primitives.11\] line \d+ pointer outside dynamic object bounds in POINTER_OBJECT((const void \*)p2): SUCCESS
+\[main.pointer_primitives.12\] line \d+ pointer outside object bounds in POINTER_OBJECT((const void \*)p2): FAILURE
+\[main.pointer_primitives.13\] line \d+ pointer NULL in POINTER_OBJECT((const void \*)p3): SUCCESS
+\[main.pointer_primitives.14\] line \d+ pointer invalid in POINTER_OBJECT((const void \*)p3): SUCCESS
+\[main.pointer_primitives.15\] line \d+ deallocated dynamic object in POINTER_OBJECT((const void \*)p3): SUCCESS
+\[main.pointer_primitives.16\] line \d+ dead object in POINTER_OBJECT((const void \*)p3): SUCCESS
+\[main.pointer_primitives.17\] line \d+ pointer outside dynamic object bounds in POINTER_OBJECT((const void \*)p3): FAILURE
+\[main.pointer_primitives.18\] line \d+ pointer outside object bounds in POINTER_OBJECT((const void \*)p3): FAILURE
+\[main.pointer_primitives.19\] line \d+ pointer NULL in POINTER_OBJECT((const void \*)p4): SUCCESS
+\[main.pointer_primitives.20\] line \d+ pointer invalid in POINTER_OBJECT((const void \*)p4): SUCCESS
+\[main.pointer_primitives.21\] line \d+ deallocated dynamic object in POINTER_OBJECT((const void \*)p4): SUCCESS
+\[main.pointer_primitives.22\] line \d+ dead object in POINTER_OBJECT((const void \*)p4): SUCCESS
+\[main.pointer_primitives.23\] line \d+ pointer outside dynamic object bounds in POINTER_OBJECT((const void \*)p4): FAILURE
+\[main.pointer_primitives.24\] line \d+ pointer outside object bounds in POINTER_OBJECT((const void \*)p4): SUCCESS
+\[main.pointer_primitives.25\] line \d+ pointer NULL in POINTER_OBJECT((const void \*)p5): SUCCESS
+\[main.pointer_primitives.26\] line \d+ pointer invalid in POINTER_OBJECT((const void \*)p5): SUCCESS
+\[main.pointer_primitives.27\] line \d+ deallocated dynamic object in POINTER_OBJECT((const void \*)p5): SUCCESS
+\[main.pointer_primitives.28\] line \d+ dead object in POINTER_OBJECT((const void \*)p5): SUCCESS
+\[main.pointer_primitives.29\] line \d+ pointer outside dynamic object bounds in POINTER_OBJECT((const void \*)p5): FAILURE
+\[main.pointer_primitives.30\] line \d+ pointer outside object bounds in POINTER_OBJECT((const void \*)p5): SUCCESS
+\[main.pointer_primitives.31\] line \d+ dead object in POINTER_OBJECT((const void \*)p6): FAILURE
+\[main.pointer_primitives.32\] line \d+ pointer outside object bounds in POINTER_OBJECT((const void \*)p6): SUCCESS
+\[main.pointer_primitives.33\] line \d+ pointer NULL in POINTER_OBJECT((const void \*)p7): SUCCESS
+\[main.pointer_primitives.34\] line \d+ pointer invalid in POINTER_OBJECT((const void \*)p7): SUCCESS
+\[main.pointer_primitives.35\] line \d+ deallocated dynamic object in POINTER_OBJECT((const void \*)p7): FAILURE
+\[main.pointer_primitives.36\] line \d+ dead object in POINTER_OBJECT((const void \*)p7): SUCCESS
+\[main.pointer_primitives.37\] line \d+ pointer outside dynamic object bounds in POINTER_OBJECT((const void \*)p7): SUCCESS
+\[main.pointer_primitives.38\] line \d+ pointer outside object bounds in POINTER_OBJECT((const void \*)p7): SUCCESS
 ^warning: ignoring
 --
 Verifies that the pointer primitives check fails for the various forms of

--- a/regression/cbmc/pointer-primitive-check-04/test.desc
+++ b/regression/cbmc/pointer-primitive-check-04/test.desc
@@ -1,10 +1,13 @@
-CORE
+CORE broken-smt-backend
 main.c
 --pointer-primitive-check
 ^EXIT=10$
 ^SIGNAL=0$
-\[main.pointer_primitives.1\] line \d+ pointer in pointer primitive is neither null nor valid in R_OK.*: FAILURE
-\*\* 1 of \d+ failed
+\[main.pointer_primitives.1\] line \d+ pointer invalid in R_OK\(\(const void \*\)p, \(__CPROVER_size_t\)1\): FAILURE
+\[main.pointer_primitives.2\] line \d+ deallocated dynamic object in R_OK\(\(const void \*\)p, \(__CPROVER_size_t\)1\): SUCCESS
+\[main.pointer_primitives.3\] line \d+ dead object in R_OK\(\(const void \*\)p, \(__CPROVER_size_t\)1\): SUCCESS
+\[main.pointer_primitives.4\] line \d+ pointer outside dynamic object bounds in R_OK\(\(const void \*\)p, \(__CPROVER_size_t\)1\): FAILURE
+\[main.pointer_primitives.5\] line \d+ pointer outside object bounds in R_OK\(\(const void \*\)p, \(__CPROVER_size_t\)1\): FAILURE
 --
 ^warning: ignoring
 --

--- a/regression/goto-harness/pointer-to-array-function-parameters-with-size/test.desc
+++ b/regression/goto-harness/pointer-to-array-function-parameters-with-size/test.desc
@@ -3,8 +3,8 @@ test.c
 --harness-type call-function --function test --treat-pointer-as-array arr --associated-array-size arr:sz
 ^EXIT=0$
 ^SIGNAL=0$
-\[test.pointer_dereference.1\] line \d+ dereference failure: pointer invalid in arr\[\(signed( long)* int\)i\]: SUCCESS
-\[test.pointer_dereference.2\] line \d+ dereference failure: pointer NULL in arr\[\(signed( long)* int\)i\]: SUCCESS
+\[test.pointer_dereference.1\] line \d+ dereference failure: pointer NULL in arr\[\(signed( long)* int\)i\]: SUCCESS
+\[test.pointer_dereference.2\] line \d+ dereference failure: pointer invalid in arr\[\(signed( long)* int\)i\]: SUCCESS
 \[test.pointer_dereference.3\] line \d+ dereference failure: deallocated dynamic object in arr\[\(signed( long)* int\)i\]: SUCCESS
 \[test.pointer_dereference.4\] line \d+ dereference failure: dead object in arr\[\(signed( long)* int\)i\]: SUCCESS
 \[test.pointer_dereference.5\] line \d+ dereference failure: pointer outside dynamic object bounds in arr\[\(signed( long)* int\)i\]: SUCCESS

--- a/src/analyses/goto_check.cpp
+++ b/src/analyses/goto_check.cpp
@@ -1236,22 +1236,18 @@ void goto_checkt::pointer_primitive_check(
                        ? from_integer(1, size_type())
                        : size_of_expr_opt.value();
 
-  const conditionst &conditions = get_pointer_dereferenceable_conditions(pointer, size);
-
-  exprt::operandst conjuncts;
-
+  const conditionst &conditions =
+    get_pointer_points_to_valid_memory_conditions(pointer, size);
   for(const auto &c : conditions)
-    conjuncts.push_back(c.assertion);
-
-  const or_exprt or_expr(null_object(pointer), conjunction(conjuncts));
-
-  add_guarded_property(
-    or_expr,
-    "pointer in pointer primitive is neither null nor valid",
-    "pointer primitives",
-    expr.source_location(),
-    expr,
-    guard);
+  {
+    add_guarded_property(
+      or_exprt{null_object(pointer), c.assertion},
+      c.description,
+      "pointer primitives",
+      expr.source_location(),
+      expr,
+      guard);
+  }
 }
 
 bool goto_checkt::is_pointer_primitive(const exprt &expr)

--- a/src/analyses/goto_check.cpp
+++ b/src/analyses/goto_check.cpp
@@ -1298,12 +1298,6 @@ goto_checkt::address_check(const exprt &address, const exprt &size)
 
     const bool unknown = flags.is_unknown() || flags.is_uninitialized();
 
-    if(unknown)
-    {
-      conditions.push_back(conditiont{
-        not_exprt{is_invalid_pointer_exprt{address}}, "pointer invalid"});
-    }
-
     if(unknown || flags.is_null())
     {
       conditions.push_back(conditiont(
@@ -1311,6 +1305,12 @@ goto_checkt::address_check(const exprt &address, const exprt &size)
           in_bounds_of_some_explicit_allocation,
           not_exprt(null_pointer(address))),
         "pointer NULL"));
+    }
+
+    if(unknown)
+    {
+      conditions.push_back(conditiont{
+        not_exprt{is_invalid_pointer_exprt{address}}, "pointer invalid"});
     }
 
     if(unknown || flags.is_dynamic_heap())

--- a/src/analyses/goto_check.cpp
+++ b/src/analyses/goto_check.cpp
@@ -202,7 +202,18 @@ protected:
   /// \return true if the given expression is a pointer primitive
   bool is_pointer_primitive(const exprt &expr);
 
-  conditionst address_check(const exprt &address, const exprt &size);
+  optionalt<goto_checkt::conditiont>
+  get_pointer_is_null_condition(const exprt &address, const exprt &size);
+  conditionst get_pointer_points_to_valid_memory_conditions(
+    const exprt &address,
+    const exprt &size);
+  exprt is_in_bounds_of_some_explicit_allocation(
+    const exprt &pointer,
+    const exprt &size);
+
+  conditionst get_pointer_dereferenceable_conditions(
+    const exprt &address,
+    const exprt &size);
   void integer_overflow_check(const exprt &, const guardt &);
   void conversion_check(const exprt &, const guardt &);
   void float_overflow_check(const exprt &, const guardt &);
@@ -1181,7 +1192,7 @@ void goto_checkt::pointer_validity_check(
     size = size_of_expr_opt.value();
   }
 
-  auto conditions = address_check(pointer, size);
+  auto conditions = get_pointer_dereferenceable_conditions(pointer, size);
 
   for(const auto &c : conditions)
   {
@@ -1225,7 +1236,7 @@ void goto_checkt::pointer_primitive_check(
                        ? from_integer(1, size_type())
                        : size_of_expr_opt.value();
 
-  const conditionst &conditions = address_check(pointer, size);
+  const conditionst &conditions = get_pointer_dereferenceable_conditions(pointer, size);
 
   exprt::operandst conjuncts;
 
@@ -1253,123 +1264,17 @@ bool goto_checkt::is_pointer_primitive(const exprt &expr)
          expr.id() == ID_w_ok || expr.id() == ID_is_dynamic_object;
 }
 
-goto_checkt::conditionst
-goto_checkt::address_check(const exprt &address, const exprt &size)
+goto_checkt::conditionst goto_checkt::get_pointer_dereferenceable_conditions(
+  const exprt &address,
+  const exprt &size)
 {
-  PRECONDITION(local_bitvector_analysis);
-  PRECONDITION(address.type().id() == ID_pointer);
-  const auto &pointer_type = to_pointer_type(address.type());
-
-  local_bitvector_analysist::flagst flags =
-    local_bitvector_analysis->get(current_target, address);
-
-  // For Java, we only need to check for null
-  if(mode == ID_java)
+  auto conditions =
+    get_pointer_points_to_valid_memory_conditions(address, size);
+  if(auto maybe_null_condition = get_pointer_is_null_condition(address, size))
   {
-    if(flags.is_unknown() || flags.is_null())
-    {
-      notequal_exprt not_eq_null(address, null_pointer_exprt(pointer_type));
-
-      return {conditiont(not_eq_null, "reference is null")};
-    }
-    else
-      return {};
+    conditions.push_front(*maybe_null_condition);
   }
-  else
-  {
-    conditionst conditions;
-    exprt::operandst alloc_disjuncts;
-
-    for(const auto &a : allocations)
-    {
-      typecast_exprt int_ptr(address, a.first.type());
-
-      binary_relation_exprt lb_check(a.first, ID_le, int_ptr);
-
-      plus_exprt ub{int_ptr, size};
-
-      binary_relation_exprt ub_check(ub, ID_le, plus_exprt(a.first, a.second));
-
-      alloc_disjuncts.push_back(and_exprt(lb_check, ub_check));
-    }
-
-    const exprt in_bounds_of_some_explicit_allocation =
-      disjunction(alloc_disjuncts);
-
-    const bool unknown = flags.is_unknown() || flags.is_uninitialized();
-
-    if(unknown || flags.is_null())
-    {
-      conditions.push_back(conditiont(
-        or_exprt(
-          in_bounds_of_some_explicit_allocation,
-          not_exprt(null_pointer(address))),
-        "pointer NULL"));
-    }
-
-    if(unknown)
-    {
-      conditions.push_back(conditiont{
-        not_exprt{is_invalid_pointer_exprt{address}}, "pointer invalid"});
-    }
-
-    if(unknown || flags.is_dynamic_heap())
-    {
-      conditions.push_back(conditiont(
-        or_exprt(
-          in_bounds_of_some_explicit_allocation,
-          not_exprt(deallocated(address, ns))),
-        "deallocated dynamic object"));
-    }
-
-    if(unknown || flags.is_dynamic_local())
-    {
-      conditions.push_back(conditiont(
-        or_exprt(
-          in_bounds_of_some_explicit_allocation,
-          not_exprt(dead_object(address, ns))),
-        "dead object"));
-    }
-
-    if(unknown || flags.is_dynamic_heap())
-    {
-      const or_exprt object_bounds_violation(
-        object_lower_bound(address, nil_exprt()),
-        object_upper_bound(address, size));
-
-      conditions.push_back(conditiont(
-        or_exprt(
-          in_bounds_of_some_explicit_allocation,
-          implies_exprt(
-            dynamic_object(address), not_exprt(object_bounds_violation))),
-        "pointer outside dynamic object bounds"));
-    }
-
-    if(unknown || flags.is_dynamic_local() || flags.is_static_lifetime())
-    {
-      const or_exprt object_bounds_violation(
-        object_lower_bound(address, nil_exprt()),
-        object_upper_bound(address, size));
-
-      conditions.push_back(conditiont(
-        or_exprt(
-          in_bounds_of_some_explicit_allocation,
-          implies_exprt(
-            not_exprt(dynamic_object(address)),
-            not_exprt(object_bounds_violation))),
-        "pointer outside object bounds"));
-    }
-
-    if(unknown || flags.is_integer_address())
-    {
-      conditions.push_back(conditiont(
-        implies_exprt(
-          integer_address(address), in_bounds_of_some_explicit_allocation),
-        "invalid integer address"));
-    }
-
-    return conditions;
-  }
+  return conditions;
 }
 
 std::string goto_checkt::array_name(const exprt &expr)
@@ -1855,8 +1760,8 @@ optionalt<exprt> goto_checkt::rw_ok_check(exprt expr)
     DATA_INVARIANT(
       expr.operands().size() == 2, "r/w_ok must have two operands");
 
-    const auto conditions =
-      address_check(to_binary_expr(expr).op0(), to_binary_expr(expr).op1());
+    const auto conditions = get_pointer_dereferenceable_conditions(
+      to_binary_expr(expr).op0(), to_binary_expr(expr).op1());
 
     exprt::operandst conjuncts;
 
@@ -2226,6 +2131,140 @@ void goto_checkt::goto_check(
 
   if(did_something)
     remove_skip(goto_program);
+}
+
+goto_checkt::conditionst
+goto_checkt::get_pointer_points_to_valid_memory_conditions(
+  const exprt &address,
+  const exprt &size)
+{
+  PRECONDITION(local_bitvector_analysis);
+  PRECONDITION(address.type().id() == ID_pointer);
+  local_bitvector_analysist::flagst flags =
+    local_bitvector_analysis->get(current_target, address);
+
+  conditionst conditions;
+
+  if(mode == ID_java)
+  {
+    // The following conditions don’t apply to Java
+    return conditions;
+  }
+
+  const exprt in_bounds_of_some_explicit_allocation =
+    is_in_bounds_of_some_explicit_allocation(address, size);
+
+  const bool unknown = flags.is_unknown() || flags.is_uninitialized();
+
+  if(unknown)
+  {
+    conditions.push_back(conditiont{
+      not_exprt{is_invalid_pointer_exprt{address}}, "pointer invalid"});
+  }
+
+  if(unknown || flags.is_dynamic_heap())
+  {
+    conditions.push_back(conditiont(
+      or_exprt(
+        in_bounds_of_some_explicit_allocation,
+        not_exprt(deallocated(address, ns))),
+      "deallocated dynamic object"));
+  }
+
+  if(unknown || flags.is_dynamic_local())
+  {
+    conditions.push_back(conditiont(
+      or_exprt(
+        in_bounds_of_some_explicit_allocation,
+        not_exprt(dead_object(address, ns))),
+      "dead object"));
+  }
+
+  if(unknown || flags.is_dynamic_heap())
+  {
+    const or_exprt object_bounds_violation(
+      object_lower_bound(address, nil_exprt()),
+      object_upper_bound(address, size));
+
+    conditions.push_back(conditiont(
+      or_exprt(
+        in_bounds_of_some_explicit_allocation,
+        implies_exprt(
+          dynamic_object(address), not_exprt(object_bounds_violation))),
+      "pointer outside dynamic object bounds"));
+  }
+
+  if(unknown || flags.is_dynamic_local() || flags.is_static_lifetime())
+  {
+    const or_exprt object_bounds_violation(
+      object_lower_bound(address, nil_exprt()),
+      object_upper_bound(address, size));
+
+    conditions.push_back(conditiont(
+      or_exprt(
+        in_bounds_of_some_explicit_allocation,
+        implies_exprt(
+          not_exprt(dynamic_object(address)),
+          not_exprt(object_bounds_violation))),
+      "pointer outside object bounds"));
+  }
+
+  if(unknown || flags.is_integer_address())
+  {
+    conditions.push_back(conditiont(
+      implies_exprt(
+        integer_address(address), in_bounds_of_some_explicit_allocation),
+      "invalid integer address"));
+  }
+
+  return conditions;
+}
+
+optionalt<goto_checkt::conditiont> goto_checkt::get_pointer_is_null_condition(
+  const exprt &address,
+  const exprt &size)
+{
+  PRECONDITION(local_bitvector_analysis);
+  PRECONDITION(address.type().id() == ID_pointer);
+  const auto &pointer_type = to_pointer_type(address.type());
+  local_bitvector_analysist::flagst flags =
+    local_bitvector_analysis->get(current_target, address);
+  if(mode == ID_java)
+  {
+    if(flags.is_unknown() || flags.is_null())
+    {
+      notequal_exprt not_eq_null(address, null_pointer_exprt{pointer_type});
+      return {conditiont{not_eq_null, "reference is null"}};
+    }
+  }
+  else if(flags.is_unknown() || flags.is_uninitialized() || flags.is_null())
+  {
+    return {conditiont{
+      or_exprt{is_in_bounds_of_some_explicit_allocation(address, size),
+               not_exprt(null_pointer(address))},
+      "pointer NULL"}};
+  }
+  return {};
+}
+
+exprt goto_checkt::is_in_bounds_of_some_explicit_allocation(
+  const exprt &pointer,
+  const exprt &size)
+{
+  exprt::operandst alloc_disjuncts;
+  for(const auto &a : allocations)
+  {
+    typecast_exprt int_ptr(pointer, a.first.type());
+
+    binary_relation_exprt lb_check(a.first, ID_le, int_ptr);
+
+    plus_exprt ub{int_ptr, size};
+
+    binary_relation_exprt ub_check(ub, ID_le, plus_exprt(a.first, a.second));
+
+    alloc_disjuncts.push_back(and_exprt(lb_check, ub_check));
+  }
+  return disjunction(alloc_disjuncts);
 }
 
 void goto_check(


### PR DESCRIPTION
The pointer-primitive-checks require an address check. Previous we’ve just done these all in in one go, but this makes it hard to see _which_ of our address checks failed.

See https://github.com/diffblue/cbmc/issues/5531
- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.