### PR TITLE
java_class_loader(_base)t isn't a messaget

### DIFF
--- a/jbmc/src/java_bytecode/java_class_loader.h
+++ b/jbmc/src/java_bytecode/java_class_loader.h
@@ -41,15 +41,17 @@ public:
   {
   }
 
-  parse_tree_with_overlayst &operator()(const irep_idt &class_name);
+  parse_tree_with_overlayst &
+  operator()(const irep_idt &class_name, message_handlert &);
 
   /// Checks whether \p class_name is parseable from the classpath,
   /// ignoring class loading limits.
-  bool can_load_class(const irep_idt &class_name);
+  bool can_load_class(const irep_idt &class_name, message_handlert &);
 
   parse_tree_with_overlayst &get_parse_tree(
     java_class_loader_limitt &class_loader_limit,
-    const irep_idt &class_name);
+    const irep_idt &class_name,
+    message_handlert &);
 
   /// Set the argument of the class loader limit \ref java_class_loader_limitt
   /// \param cp_include_files: argument string for java_class_loader_limit
@@ -74,7 +76,8 @@ public:
       java_load_classes.push_back(id);
   }
 
-  std::vector<irep_idt> load_entire_jar(const std::string &jar_path);
+  std::vector<irep_idt>
+  load_entire_jar(const std::string &jar_path, message_handlert &);
 
   /// Map from class names to the bytecode parse trees
   fixed_keys_map_wrappert<parse_tree_with_overridest_mapt>
@@ -103,7 +106,8 @@ private:
   /// Map from class names to the bytecode parse trees
   parse_tree_with_overridest_mapt class_map;
 
-  optionalt<std::vector<irep_idt>> read_jar_file(const std::string &jar_path);
+  optionalt<std::vector<irep_idt>>
+  read_jar_file(const std::string &jar_path, message_handlert &);
 };
 
 #endif // CPROVER_JAVA_BYTECODE_JAVA_CLASS_LOADER_H

--- a/jbmc/src/java_bytecode/java_class_loader_base.h
+++ b/jbmc/src/java_bytecode/java_class_loader_base.h
@@ -9,13 +9,13 @@ Author: Daniel Kroening, kroening@kroening.com
 #ifndef CPROVER_JAVA_BYTECODE_JAVA_CLASS_LOADER_BASE_H
 #define CPROVER_JAVA_BYTECODE_JAVA_CLASS_LOADER_BASE_H
 
-#include <util/message.h>
-
 #include "jar_pool.h"
 #include "java_bytecode_parse_tree.h"
 
+class message_handlert;
+
 /// Base class for maintaining classpath.
-class java_class_loader_baset : public messaget
+class java_class_loader_baset
 {
 public:
   /// Clear all classpath entries
@@ -28,7 +28,7 @@ public:
   /// argument may be
   /// 1) The name of a directory, used for searching for .class files
   /// 2) The name of a JAR file
-  void add_classpath_entry(const std::string &);
+  void add_classpath_entry(const std::string &, message_handlert &);
 
   static std::string file_to_class_name(const std::string &);
   static std::string class_name_to_os_file(const irep_idt &);
@@ -55,16 +55,22 @@ protected:
   std::list<classpath_entryt> classpath_entries;
 
   /// attempt to load a class from a classpath_entry
-  optionalt<java_bytecode_parse_treet>
-  load_class(const irep_idt &class_name, const classpath_entryt &);
+  optionalt<java_bytecode_parse_treet> load_class(
+    const irep_idt &class_name,
+    const classpath_entryt &,
+    message_handlert &);
 
   /// attempt to load a class from a given jar file
-  optionalt<java_bytecode_parse_treet>
-  get_class_from_jar(const irep_idt &class_name, const std::string &jar_file);
+  optionalt<java_bytecode_parse_treet> get_class_from_jar(
+    const irep_idt &class_name,
+    const std::string &jar_file,
+    message_handlert &);
 
   /// attempt to load a class from a given directory
-  optionalt<java_bytecode_parse_treet>
-  get_class_from_directory(const irep_idt &class_name, const std::string &path);
+  optionalt<java_bytecode_parse_treet> get_class_from_directory(
+    const irep_idt &class_name,
+    const std::string &path,
+    message_handlert &);
 };
 
 #endif // CPROVER_JAVA_BYTECODE_JAVA_CLASS_LOADER_BASE_H

--- a/jbmc/src/java_bytecode/java_class_loader_limit.cpp
+++ b/jbmc/src/java_bytecode/java_class_loader_limit.cpp
@@ -57,8 +57,8 @@ void java_class_loader_limitt::setup_class_load_limit(
   if(use_regex_match)
   {
     regex_matcher=std::regex(java_cp_include_files);
-    debug() << "Limit loading to classes matching '" << java_cp_include_files
-            << "'" << eom;
+    log.debug() << "Limit loading to classes matching '"
+                << java_cp_include_files << "'" << messaget::eom;
   }
   else
   {
@@ -66,7 +66,7 @@ void java_class_loader_limitt::setup_class_load_limit(
     jsont json_cp_config;
     if(parse_json(
          java_cp_include_files.substr(1),
-         get_message_handler(),
+         log.get_message_handler(),
          json_cp_config))
       throw "cannot read JSON input configuration for JAR loading";
     if(!json_cp_config.is_object())
@@ -93,7 +93,8 @@ bool java_class_loader_limitt::load_class_file(const std::string &file_name)
     std::smatch string_matches;
     if(std::regex_match(file_name, string_matches, regex_matcher))
       return true;
-    debug() << file_name + " discarded since not matching loader regexp" << eom;
+    log.debug() << file_name + " discarded since not matching loader regexp"
+                << messaget::eom;
     return false;
   }
   else

--- a/jbmc/src/java_bytecode/java_class_loader_limit.h
+++ b/jbmc/src/java_bytecode/java_class_loader_limit.h
@@ -15,12 +15,13 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <set>
 #include <regex>
 
-#include <util/irep.h>
 #include <util/message.h>
 
 /// Class representing a filter for class file loading.
-class java_class_loader_limitt:public messaget
+class java_class_loader_limitt
 {
+  messaget log;
+
   /// Whether to use regex_matcher instead of set_matcher
   bool use_regex_match;
   std::regex regex_matcher;
@@ -32,7 +33,7 @@ public:
   explicit java_class_loader_limitt(
     message_handlert &message_handler,
     const std::string &java_cp_include_files)
-    : messaget(message_handler)
+    : log(message_handler)
   {
     setup_class_load_limit(java_cp_include_files);
   }


### PR DESCRIPTION
Pass a message handler as an argument to several of their functions, but
do not construct a messaget object without a configured message handler
as that is deprecated.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
