### PR TITLE
language_filest is not a messaget

### DIFF
--- a/jbmc/src/java_bytecode/lazy_goto_functions_map.h
+++ b/jbmc/src/java_bytecode/lazy_goto_functions_map.h
@@ -173,7 +173,8 @@ private:
     symbol_table_baset &function_symbol_table) const
   {
     // Fill in symbol table entry body if not already done
-    language_files.convert_lazy_method(name, function_symbol_table);
+    language_files.convert_lazy_method(
+      name, function_symbol_table, message_handler);
 
     underlying_mapt::iterator it = goto_functions.find(name);
     if(it != goto_functions.end())

--- a/jbmc/src/java_bytecode/lazy_goto_model.cpp
+++ b/jbmc/src/java_bytecode/lazy_goto_model.cpp
@@ -57,7 +57,6 @@ lazy_goto_modelt::lazy_goto_modelt(
       driver_program_generate_function_body),
     message_handler(message_handler)
 {
-  language_files.set_message_handler(message_handler);
 }
 
 lazy_goto_modelt::lazy_goto_modelt(lazy_goto_modelt &&other)
@@ -154,7 +153,7 @@ void lazy_goto_modelt::initialize(
 
     msg.status() << "Converting" << messaget::eom;
 
-    if(language_files.typecheck(symbol_table))
+    if(language_files.typecheck(symbol_table, message_handler))
     {
       throw invalid_input_exceptiont("CONVERSION ERROR");
     }

--- a/src/goto-cc/compile.cpp
+++ b/src/goto-cc/compile.cpp
@@ -620,14 +620,14 @@ bool compilet::write_bin_object_file(
 optionalt<symbol_tablet> compilet::parse_source(const std::string &file_name)
 {
   language_filest language_files;
-  language_files.set_message_handler(log.get_message_handler());
 
   if(parse(file_name, language_files))
     return {};
 
   // we just typecheck one file here
   symbol_tablet file_symbol_table;
-  if(language_files.typecheck(file_symbol_table, keep_file_local))
+  if(language_files.typecheck(
+       file_symbol_table, keep_file_local, log.get_message_handler()))
   {
     log.error() << "CONVERSION ERROR" << messaget::eom;
     return {};

--- a/src/goto-programs/initialize_goto_model.cpp
+++ b/src/goto-programs/initialize_goto_model.cpp
@@ -108,7 +108,7 @@ void initialize_from_source_files(
 
     msg.status() << "Converting" << messaget::eom;
 
-    if(language_files.typecheck(symbol_table))
+    if(language_files.typecheck(symbol_table, message_handler))
     {
       throw invalid_input_exceptiont("CONVERSION ERROR");
     }
@@ -200,10 +200,7 @@ goto_modelt initialize_goto_model(
   }
 
   language_filest language_files;
-  language_files.set_message_handler(message_handler);
-
   goto_modelt goto_model;
-
   initialize_from_source_files(
     sources, options, language_files, goto_model.symbol_table, message_handler);
 

--- a/src/langapi/language_file.cpp
+++ b/src/langapi/language_file.cpp
@@ -48,8 +48,10 @@ void language_filest::show_parse(std::ostream &out)
     file.second.language->show_parse(out);
 }
 
-bool language_filest::parse()
+bool language_filest::parse(message_handlert &message_handler)
 {
+  messaget log(message_handler);
+
   for(auto &file : file_map)
   {
     // open file
@@ -58,7 +60,7 @@ bool language_filest::parse()
 
     if(!infile)
     {
-      error() << "Failed to open " << file.first << eom;
+      log.error() << "Failed to open " << file.first << messaget::eom;
       return true;
     }
 
@@ -68,7 +70,7 @@ bool language_filest::parse()
 
     if(language.parse(infile, file.first))
     {
-      error() << "Parsing of " << file.first << " failed" << eom;
+      log.error() << "Parsing of " << file.first << " failed" << messaget::eom;
       return true;
     }
 
@@ -82,7 +84,8 @@ bool language_filest::parse()
 
 bool language_filest::typecheck(
   symbol_table_baset &symbol_table,
-  const bool keep_file_local)
+  const bool keep_file_local,
+  message_handlert &message_handler)
 {
   // typecheck interfaces
 
@@ -153,7 +156,8 @@ bool language_filest::typecheck(
 
   for(auto &module : module_map)
   {
-    if(typecheck_module(symbol_table, module.second, keep_file_local))
+    if(typecheck_module(
+         symbol_table, module.second, keep_file_local, message_handler))
       return true;
   }
 
@@ -203,7 +207,8 @@ bool language_filest::interfaces(symbol_table_baset &symbol_table)
 bool language_filest::typecheck_module(
   symbol_table_baset &symbol_table,
   const std::string &module,
-  const bool keep_file_local)
+  const bool keep_file_local,
+  message_handlert &message_handler)
 {
   // check module map
 
@@ -211,28 +216,34 @@ bool language_filest::typecheck_module(
 
   if(it==module_map.end())
   {
-    error() << "found no file that provides module " << module << eom;
+    messaget log(message_handler);
+    log.error() << "found no file that provides module " << module
+                << messaget::eom;
     return true;
   }
 
-  return typecheck_module(symbol_table, it->second, keep_file_local);
+  return typecheck_module(
+    symbol_table, it->second, keep_file_local, message_handler);
 }
 
 bool language_filest::typecheck_module(
   symbol_table_baset &symbol_table,
   language_modulet &module,
-  const bool keep_file_local)
+  const bool keep_file_local,
+  message_handlert &message_handler)
 {
   // already typechecked?
 
   if(module.type_checked)
     return false;
 
+  messaget log(message_handler);
+
   // already in progress?
 
   if(module.in_progress)
   {
-    error() << "circular dependency in " << module.name << eom;
+    log.error() << "circular dependency in " << module.name << messaget::eom;
     return true;
   }
 
@@ -249,14 +260,15 @@ bool language_filest::typecheck_module(
       it!=dependency_set.end();
       it++)
   {
-    module.in_progress = !typecheck_module(symbol_table, *it, keep_file_local);
+    module.in_progress =
+      !typecheck_module(symbol_table, *it, keep_file_local, message_handler);
     if(module.in_progress == false)
       return true;
   }
 
   // type check it
 
-  status() << "Type-checking " << module.name << eom;
+  log.status() << "Type-checking " << module.name << messaget::eom;
 
   if(module.file->language->can_keep_file_local())
   {

--- a/src/langapi/language_file.h
+++ b/src/langapi/language_file.h
@@ -17,9 +17,9 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <string>
 #include <unordered_set>
 
-#include <util/message.h>
 #include <util/symbol_table_base.h>
 
+class message_handlert;
 class language_filet;
 class languaget;
 
@@ -58,7 +58,7 @@ public:
   ~language_filet();
 };
 
-class language_filest:public messaget
+class language_filest
 {
 private:
   typedef std::map<std::string, language_filet> file_mapt;
@@ -101,15 +101,23 @@ public:
     file_map.clear();
   }
 
-  bool parse();
+  bool parse(message_handlert &message_handler);
 
   void show_parse(std::ostream &out);
 
   bool generate_support_functions(symbol_table_baset &symbol_table);
 
-  bool typecheck(
+  bool
+
+  typecheck(
     symbol_table_baset &symbol_table,
-    const bool keep_file_local = false);
+    const bool keep_file_local,
+    message_handlert &message_handler);
+  bool
+  typecheck(symbol_table_baset &symbol_table, message_handlert &message_handler)
+  {
+    return typecheck(symbol_table, false, message_handler);
+  }
 
   bool final(symbol_table_baset &symbol_table);
 
@@ -120,7 +128,8 @@ public:
   // for this to be legal.
   void convert_lazy_method(
     const irep_idt &id,
-    symbol_table_baset &symbol_table)
+    symbol_table_baset &symbol_table,
+    message_handlert &message_handler)
   {
     PRECONDITION(symbol_table.has_symbol(id));
     lazy_method_mapt::iterator it=lazy_method_map.find(id);
@@ -144,12 +153,14 @@ protected:
   bool typecheck_module(
     symbol_table_baset &symbol_table,
     language_modulet &module,
-    const bool keep_file_local);
+    const bool keep_file_local,
+    message_handlert &message_handler);
 
   bool typecheck_module(
     symbol_table_baset &symbol_table,
     const std::string &module,
-    const bool keep_file_local);
+    const bool keep_file_local,
+    message_handlert &message_handler);
 };
 
 #endif // CPROVER_UTIL_LANGUAGE_FILE_H

--- a/unit/testing-utils/get_goto_model_from_c.cpp
+++ b/unit/testing-utils/get_goto_model_from_c.cpp
@@ -44,7 +44,6 @@ goto_modelt get_goto_model_from_c(std::istream &in)
   }
 
   language_filest language_files;
-  language_files.set_message_handler(null_message_handler);
 
   language_filet &language_file = language_files.add_file("");
 
@@ -66,7 +65,8 @@ goto_modelt get_goto_model_from_c(std::istream &in)
   goto_modelt goto_model;
 
   {
-    const bool error = language_files.typecheck(goto_model.symbol_table);
+    const bool error =
+      language_files.typecheck(goto_model.symbol_table, null_message_handler);
 
     if(error)
       throw invalid_input_exceptiont("typechecking failed");


### PR DESCRIPTION
Pass a message handler as an argument to several of its functions, but do not
construct a messaget object without a configured message handler as that is
deprecated.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
