### PR TITLE
jsil_convertt isn't a messaget

### DIFF
--- a/src/jsil/jsil_convert.cpp
+++ b/src/jsil/jsil_convert.cpp
@@ -16,18 +16,14 @@ Author: Michael Tautschnig, tautschn@amazon.com
 
 #include "jsil_parse_tree.h"
 
-class jsil_convertt:public messaget
+class jsil_convertt
 {
 public:
-  jsil_convertt(
-    symbol_tablet &_symbol_table,
-    message_handlert &_message_handler):
-    messaget(_message_handler),
-    symbol_table(_symbol_table)
+  jsil_convertt(symbol_tablet &_symbol_table) : symbol_table(_symbol_table)
   {
   }
 
-  bool operator()(const jsil_parse_treet &parse_tree);
+  bool operator()(const jsil_parse_treet &parse_tree, message_handlert &);
 
 protected:
   symbol_tablet &symbol_table;
@@ -35,7 +31,9 @@ protected:
   bool convert_code(const symbolt &symbol, codet &code);
 };
 
-bool jsil_convertt::operator()(const jsil_parse_treet &parse_tree)
+bool jsil_convertt::operator()(
+  const jsil_parse_treet &parse_tree,
+  message_handlert &message_handler)
 {
   for(jsil_parse_treet::itemst::const_iterator
       it=parse_tree.items.begin();
@@ -58,7 +56,8 @@ bool jsil_convertt::operator()(const jsil_parse_treet &parse_tree)
     }
     if(symbol_table.add(new_symbol))
     {
-      error() << "duplicate symbol " << new_symbol.name << eom;
+      messaget log{message_handler};
+      log.error() << "duplicate symbol " << new_symbol.name << messaget::eom;
       throw 0;
     }
   }
@@ -118,11 +117,11 @@ bool jsil_convert(
   symbol_tablet &symbol_table,
   message_handlert &message_handler)
 {
-  jsil_convertt jsil_convert(symbol_table, message_handler);
+  jsil_convertt jsil_convert{symbol_table};
 
   try
   {
-    return jsil_convert(parse_tree);
+    return jsil_convert(parse_tree, message_handler);
   }
 
   catch(int)
@@ -131,12 +130,14 @@ bool jsil_convert(
 
   catch(const char *e)
   {
-    jsil_convert.error() << e << messaget::eom;
+    messaget log{message_handler};
+    log.error() << e << messaget::eom;
   }
 
   catch(const std::string &e)
   {
-    jsil_convert.error() << e << messaget::eom;
+    messaget log{message_handler};
+    log.error() << e << messaget::eom;
   }
 
   return true;


### PR DESCRIPTION
Pass a message handler as an argument to the single method that requires it as there is no is-a relationship between jsil_convertt and messaget.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
