### PR TITLE
Coverage goal filters aren't messaget

### DIFF
--- a/src/goto-instrument/cover.cpp
+++ b/src/goto-instrument/cover.cpp
@@ -184,10 +184,9 @@ cover_configt get_cover_config(
   std::unique_ptr<goal_filterst> &goal_filters = cover_config.goal_filters;
   cover_instrumenterst &instrumenters = cover_config.cover_instrumenters;
 
-  function_filters.add(
-    util_make_unique<internal_functions_filtert>(message_handler));
+  function_filters.add(util_make_unique<internal_functions_filtert>());
 
-  goal_filters->add(util_make_unique<internal_goals_filtert>(message_handler));
+  goal_filters->add(util_make_unique<internal_goals_filtert>());
 
   optionst::value_listt criteria_strings = options.get_list_option("cover");
 
@@ -215,13 +214,11 @@ cover_configt get_cover_config(
   if(!cover_include_pattern.empty())
   {
     function_filters.add(
-      util_make_unique<include_pattern_filtert>(
-        message_handler, cover_include_pattern));
+      util_make_unique<include_pattern_filtert>(cover_include_pattern));
   }
 
   if(options.get_bool_option("no-trivial-tests"))
-    function_filters.add(
-      util_make_unique<trivial_functions_filtert>(message_handler));
+    function_filters.add(util_make_unique<trivial_functions_filtert>());
 
   cover_config.traces_must_terminate =
     options.get_bool_option("cover-traces-must-terminate");
@@ -251,14 +248,14 @@ cover_configt get_cover_config(
   if(cover_only == "function")
   {
     const symbolt &main_symbol = symbol_table.lookup_ref(main_function_id);
-    cover_config.function_filters.add(util_make_unique<single_function_filtert>(
-      message_handler, main_symbol.name));
+    cover_config.function_filters.add(
+      util_make_unique<single_function_filtert>(main_symbol.name));
   }
   else if(cover_only == "file")
   {
     const symbolt &main_symbol = symbol_table.lookup_ref(main_function_id);
-    cover_config.function_filters.add(util_make_unique<file_filtert>(
-      message_handler, main_symbol.location.get_file()));
+    cover_config.function_filters.add(
+      util_make_unique<file_filtert>(main_symbol.location.get_file()));
   }
   else if(!cover_only.empty())
   {

--- a/src/goto-instrument/cover_filter.h
+++ b/src/goto-instrument/cover_filter.h
@@ -16,20 +16,14 @@ Author: Daniel Kroening
 #include <memory>
 
 #include <util/invariant.h>
-#include <util/message.h>
 #include <util/symbol.h>
 
 #include <goto-programs/goto_model.h>
 
 /// Base class for filtering functions
-class function_filter_baset : public messaget
+class function_filter_baset
 {
 public:
-  explicit function_filter_baset(message_handlert &message_handler)
-    : messaget(message_handler)
-  {
-  }
-
   virtual ~function_filter_baset()
   {
   }
@@ -48,14 +42,9 @@ public:
 };
 
 /// Base class for filtering goals
-class goal_filter_baset : public messaget
+class goal_filter_baset
 {
 public:
-  explicit goal_filter_baset(message_handlert &message_handler)
-    : messaget(message_handler)
-  {
-  }
-
   virtual ~goal_filter_baset()
   {
   }
@@ -146,11 +135,6 @@ private:
 class internal_functions_filtert : public function_filter_baset
 {
 public:
-  explicit internal_functions_filtert(message_handlert &message_handler)
-    : function_filter_baset(message_handler)
-  {
-  }
-
   bool operator()(
     const symbolt &identifier,
     const goto_functionst::goto_functiont &goto_function) const override;
@@ -159,10 +143,7 @@ public:
 class file_filtert : public function_filter_baset
 {
 public:
-  explicit file_filtert(
-    message_handlert &message_handler,
-    const irep_idt &file_id)
-    : function_filter_baset(message_handler), file_id(file_id)
+  explicit file_filtert(const irep_idt &file_id) : file_id(file_id)
   {
   }
 
@@ -177,10 +158,8 @@ private:
 class single_function_filtert : public function_filter_baset
 {
 public:
-  explicit single_function_filtert(
-    message_handlert &message_handler,
-    const irep_idt &function_id)
-    : function_filter_baset(message_handler), function_id(function_id)
+  explicit single_function_filtert(const irep_idt &function_id)
+    : function_id(function_id)
   {
   }
 
@@ -196,11 +175,8 @@ private:
 class include_pattern_filtert : public function_filter_baset
 {
 public:
-  explicit include_pattern_filtert(
-    message_handlert &message_handler,
-    const std::string &cover_include_pattern)
-    : function_filter_baset(message_handler),
-      regex_matcher(cover_include_pattern)
+  explicit include_pattern_filtert(const std::string &cover_include_pattern)
+    : regex_matcher(cover_include_pattern)
   {
   }
 
@@ -216,11 +192,6 @@ private:
 class trivial_functions_filtert : public function_filter_baset
 {
 public:
-  explicit trivial_functions_filtert(message_handlert &message_handler)
-    : function_filter_baset(message_handler)
-  {
-  }
-
   bool operator()(
     const symbolt &identifier,
     const goto_functionst::goto_functiont &goto_function) const override;
@@ -230,11 +201,6 @@ public:
 class internal_goals_filtert : public goal_filter_baset
 {
 public:
-  explicit internal_goals_filtert(message_handlert &message_handler)
-    : goal_filter_baset(message_handler)
-  {
-  }
-
   bool operator()(const source_locationt &) const override;
 };
 


### PR DESCRIPTION
The classes didn't use `messaget` anyway.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
