### PR TITLE
ci_lazy_methodst isn't a messaget

### DIFF
--- a/jbmc/src/java_bytecode/ci_lazy_methods.h
+++ b/jbmc/src/java_bytecode/ci_lazy_methods.h
@@ -94,7 +94,7 @@ typedef std::function<
 typedef std::function<std::vector<irep_idt>(const symbol_tablet &)>
   load_extra_methodst;
 
-class ci_lazy_methodst:public messaget
+class ci_lazy_methodst
 {
 public:
   ci_lazy_methodst(
@@ -105,14 +105,14 @@ public:
     java_class_loadert &java_class_loader,
     const std::vector<irep_idt> &extra_instantiated_classes,
     const select_pointer_typet &pointer_type_selector,
-    message_handlert &message_handler,
     const synthetic_methods_mapt &synthetic_methods);
 
   // not const since messaget
   bool operator()(
     symbol_tablet &symbol_table,
     method_bytecodet &method_bytecode,
-    const method_convertert &method_converter);
+    const method_convertert &method_converter,
+    message_handlert &message_handler);
 
 private:
   void initialize_instantiated_classes(
@@ -154,8 +154,9 @@ private:
   const select_pointer_typet &pointer_type_selector;
   const synthetic_methods_mapt &synthetic_methods;
 
-  std::unordered_set<irep_idt>
-  entry_point_methods(const symbol_tablet &symbol_table);
+  std::unordered_set<irep_idt> entry_point_methods(
+    const symbol_tablet &symbol_table,
+    message_handlert &message_handler);
 
   struct convert_method_resultt
   {
@@ -172,7 +173,8 @@ private:
     std::unordered_set<irep_idt> &methods_to_convert_later,
     std::unordered_set<irep_idt> &instantiated_classes,
     std::unordered_set<class_method_descriptor_exprt, irep_hash>
-      &called_virtual_functions);
+      &called_virtual_functions,
+    message_handlert &message_handler);
 
   bool handle_virtual_methods_with_no_callees(
     std::unordered_set<irep_idt> &methods_to_convert_later,

--- a/jbmc/src/java_bytecode/java_bytecode_language.cpp
+++ b/jbmc/src/java_bytecode/java_bytecode_language.cpp
@@ -1139,10 +1139,10 @@ bool java_bytecode_languaget::do_ci_lazy_method_conversion(
     java_class_loader,
     language_options->java_load_classes,
     get_pointer_type_selector(),
-    get_message_handler(),
     synthetic_methods);
 
-  return method_gather(symbol_table, method_bytecode, method_converter);
+  return method_gather(
+    symbol_table, method_bytecode, method_converter, get_message_handler());
 }
 
 const select_pointer_typet &


### PR DESCRIPTION
Pass a message handler as an argument to the single method that requires
it as there is no is-a relationship between ci_lazy_methodst and
messaget.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
