### PR TITLE
goto_inlinet isn't a messaget

### DIFF
--- a/src/goto-programs/goto_inline_class.cpp
+++ b/src/goto-programs/goto_inline_class.cpp
@@ -64,10 +64,10 @@ void goto_inlinet::parameter_assignments(
     // if you run out of actual arguments there was a mismatch
     if(it1==arguments.end())
     {
-      warning().source_location=source_location;
-      warning() << "call to '" << function_name << "': "
-                << "not enough arguments, "
-                << "inserting non-deterministic value" << eom;
+      log.warning().source_location = source_location;
+      log.warning() << "call to '" << function_name << "': "
+                    << "not enough arguments, "
+                    << "inserting non-deterministic value" << messaget::eom;
 
       actual = side_effect_expr_nondett(parameter_type, source_location);
     }
@@ -171,9 +171,9 @@ void goto_inlinet::replace_return(
       {
         if(!code_return.has_return_value())
         {
-          warning().source_location=it->code.find_source_location();
-          warning() << "return expects one operand!\n"
-                    << it->code.pretty() << eom;
+          log.warning().source_location = it->code.find_source_location();
+          log.warning() << "return expects one operand!\n"
+                        << it->code.pretty() << messaget::eom;
           continue;
         }
 
@@ -355,9 +355,9 @@ void goto_inlinet::expand_function_call(
   {
     // it's recursive.
     // Uh. Buh. Give up.
-    warning().source_location=function.find_source_location();
-    warning() << "recursion is ignored on call to '" << identifier << "'"
-              << eom;
+    log.warning().source_location = function.find_source_location();
+    log.warning() << "recursion is ignored on call to '" << identifier << "'"
+                  << messaget::eom;
 
     if(force_full)
       target->turn_into_skip();
@@ -370,8 +370,9 @@ void goto_inlinet::expand_function_call(
 
   if(f_it==goto_functions.function_map.end())
   {
-    warning().source_location=function.find_source_location();
-    warning() << "missing function '" << identifier << "' is ignored" << eom;
+    log.warning().source_location = function.find_source_location();
+    log.warning() << "missing function '" << identifier << "' is ignored"
+                  << messaget::eom;
 
     if(force_full)
       target->turn_into_skip();
@@ -401,15 +402,17 @@ void goto_inlinet::expand_function_call(
         function,
         arguments);
 
-      progress() << "Inserting " << identifier << " into caller" << eom;
-      progress() << "Number of instructions: "
-                 << cached.body.instructions.size() << eom;
+      log.progress() << "Inserting " << identifier << " into caller"
+                     << messaget::eom;
+      log.progress() << "Number of instructions: "
+                     << cached.body.instructions.size() << messaget::eom;
 
       if(!caching)
       {
-        progress() << "Removing " << identifier << " from cache" << eom;
-        progress() << "Number of instructions: "
-                   << cached.body.instructions.size() << eom;
+        log.progress() << "Removing " << identifier << " from cache"
+                       << messaget::eom;
+        log.progress() << "Number of instructions: "
+                       << cached.body.instructions.size() << messaget::eom;
 
         inline_log.cleanup(cached.body);
         cache.erase(identifier);
@@ -438,8 +441,9 @@ void goto_inlinet::expand_function_call(
   {
     if(no_body_set.insert(identifier).second) // newly inserted
     {
-      warning().source_location = function.find_source_location();
-      warning() << "no body for function '" << identifier << "'" << eom;
+      log.warning().source_location = function.find_source_location();
+      log.warning() << "no body for function '" << identifier << "'"
+                    << messaget::eom;
     }
   }
 }
@@ -567,9 +571,9 @@ const goto_inlinet::goto_functiont &goto_inlinet::goto_inline_transitive(
   DATA_INVARIANT(
     cached.body.empty(), "body of new function in cache must be empty");
 
-  progress() << "Creating copy of " << identifier << eom;
-  progress() << "Number of instructions: "
-             << goto_function.body.instructions.size() << eom;
+  log.progress() << "Creating copy of " << identifier << messaget::eom;
+  log.progress() << "Number of instructions: "
+                 << goto_function.body.instructions.size() << messaget::eom;
 
   cached.copy_from(goto_function); // location numbers not changed
   inline_log.copy_from(goto_function.body, cached.body);

--- a/src/goto-programs/goto_inline_class.h
+++ b/src/goto-programs/goto_inline_class.h
@@ -17,7 +17,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "goto_functions.h"
 
-class goto_inlinet:public messaget
+class goto_inlinet
 {
 public:
   goto_inlinet(
@@ -25,12 +25,12 @@ public:
     const namespacet &ns,
     message_handlert &message_handler,
     bool adjust_function,
-    bool caching=true):
-    messaget(message_handler),
-    goto_functions(goto_functions),
-    ns(ns),
-    adjust_function(adjust_function),
-    caching(caching)
+    bool caching = true)
+    : log(message_handler),
+      goto_functions(goto_functions),
+      ns(ns),
+      adjust_function(adjust_function),
+      caching(caching)
   {
   }
 
@@ -122,6 +122,7 @@ public:
   };
 
 protected:
+  messaget log;
   goto_functionst &goto_functions;
   const namespacet &ns;
 


### PR DESCRIPTION
Use a messaget member instead as there is no is-a relationship between
goto_inlinet and messaget.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
