### PR TITLE
java_bytecode_instrumentt isn't a messaget

### DIFF
--- a/jbmc/src/java_bytecode/java_bytecode_instrument.cpp
+++ b/jbmc/src/java_bytecode/java_bytecode_instrument.cpp
@@ -22,15 +22,14 @@ Date:   June 2017
 #include "java_expr.h"
 #include "java_utils.h"
 
-class java_bytecode_instrumentt:public messaget
+class java_bytecode_instrumentt
 {
 public:
   java_bytecode_instrumentt(
     symbol_table_baset &_symbol_table,
     const bool _throw_runtime_exceptions,
     message_handlert &_message_handler)
-    : messaget(_message_handler),
-      symbol_table(_symbol_table),
+    : symbol_table(_symbol_table),
       throw_runtime_exceptions(_throw_runtime_exceptions),
       message_handler(_message_handler)
   {
@@ -104,7 +103,7 @@ code_ifthenelset java_bytecode_instrumentt::throw_exception(
     generate_class_stub(
       exc_name,
       symbol_table,
-      get_message_handler(),
+      message_handler,
       struct_union_typet::componentst{});
   }
 


### PR DESCRIPTION
The class had an unused message_handler member, which is actually all
that's needed.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
