### PR TITLE
Remove unnecessary cassert include

### DIFF
--- a/jbmc/src/java_bytecode/expr2java.cpp
+++ b/jbmc/src/java_bytecode/expr2java.cpp
@@ -8,7 +8,6 @@ Author: Daniel Kroening, kroening@cs.cmu.edu
 
 #include "expr2java.h"
 
-#include <cassert>
 #include <sstream>
 
 #include <util/namespace.h>

--- a/src/analyses/ai.cpp
+++ b/src/analyses/ai.cpp
@@ -11,7 +11,6 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "ai.h"
 
-#include <cassert>
 #include <memory>
 #include <sstream>
 #include <type_traits>

--- a/src/analyses/cfg_dominators.h
+++ b/src/analyses/cfg_dominators.h
@@ -16,7 +16,6 @@ Author: Georg Weissenbacher, georg@weissenbacher.name
 #include <list>
 #include <map>
 #include <iosfwd>
-#include <cassert>
 
 #include <goto-programs/goto_functions.h>
 #include <goto-programs/goto_program.h>

--- a/src/analyses/dependence_graph.cpp
+++ b/src/analyses/dependence_graph.cpp
@@ -14,8 +14,6 @@ Date: August 2013
 
 #include "dependence_graph.h"
 
-#include <cassert>
-
 #include <util/container_utils.h>
 #include <util/json_irep.h>
 

--- a/src/analyses/flow_insensitive_analysis.cpp
+++ b/src/analyses/flow_insensitive_analysis.cpp
@@ -12,8 +12,6 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "flow_insensitive_analysis.h"
 
-#include <cassert>
-
 #include <util/expr_util.h>
 #include <util/std_code.h>
 #include <util/std_expr.h>

--- a/src/analyses/static_analysis.cpp
+++ b/src/analyses/static_analysis.cpp
@@ -12,7 +12,6 @@ Author: Daniel Kroening, kroening@kroening.com
 #define USE_DEPRECATED_STATIC_ANALYSIS_H
 #include "static_analysis.h"
 
-#include <cassert>
 #include <memory>
 
 #include <util/expr_util.h>

--- a/src/ansi-c/ansi_c_convert_type.cpp
+++ b/src/ansi-c/ansi_c_convert_type.cpp
@@ -11,8 +11,6 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "ansi_c_convert_type.h"
 
-#include <cassert>
-
 #include <util/arith_tools.h>
 #include <util/c_types.h>
 #include <util/config.h>

--- a/src/ansi-c/ansi_c_declaration.cpp
+++ b/src/ansi-c/ansi_c_declaration.cpp
@@ -12,7 +12,6 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "ansi_c_declaration.h"
 
 #include <ostream>
-#include <cassert>
 
 #include <util/config.h>
 #include <util/std_types.h>

--- a/src/ansi-c/ansi_c_declaration.h
+++ b/src/ansi-c/ansi_c_declaration.h
@@ -12,8 +12,6 @@ Author: Daniel Kroening, kroening@kroening.com
 #ifndef CPROVER_ANSI_C_ANSI_C_DECLARATION_H
 #define CPROVER_ANSI_C_ANSI_C_DECLARATION_H
 
-#include <cassert>
-
 #include <util/std_expr.h>
 #include <util/symbol.h>
 

--- a/src/ansi-c/ansi_c_parser.h
+++ b/src/ansi-c/ansi_c_parser.h
@@ -10,7 +10,6 @@ Author: Daniel Kroening, kroening@kroening.com
 #ifndef CPROVER_ANSI_C_ANSI_C_PARSER_H
 #define CPROVER_ANSI_C_ANSI_C_PARSER_H
 
-#include <cassert>
 #include <set>
 
 #include <util/parser.h>

--- a/src/ansi-c/c_typecast.cpp
+++ b/src/ansi-c/c_typecast.cpp
@@ -10,8 +10,6 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <algorithm>
 
-#include <cassert>
-
 #include <util/arith_tools.h>
 #include <util/c_types.h>
 #include <util/config.h>

--- a/src/ansi-c/c_typecheck_expr.cpp
+++ b/src/ansi-c/c_typecheck_expr.cpp
@@ -11,7 +11,6 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "c_typecheck_base.h"
 
-#include <cassert>
 #include <sstream>
 
 #include <util/arith_tools.h>

--- a/src/ansi-c/expr2c.cpp
+++ b/src/ansi-c/expr2c.cpp
@@ -9,7 +9,6 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "expr2c.h"
 
 #include <algorithm>
-#include <cassert>
 #include <sstream>
 
 #include <map>

--- a/src/ansi-c/literals/convert_character_literal.cpp
+++ b/src/ansi-c/literals/convert_character_literal.cpp
@@ -11,8 +11,6 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "convert_character_literal.h"
 
-#include <cassert>
-
 #include <util/arith_tools.h>
 #include <util/c_types.h>
 #include <util/std_expr.h>

--- a/src/ansi-c/literals/convert_float_literal.cpp
+++ b/src/ansi-c/literals/convert_float_literal.cpp
@@ -11,8 +11,6 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "convert_float_literal.h"
 
-#include <cassert>
-
 #include <util/c_types.h>
 #include <util/config.h>
 #include <util/ieee_float.h>

--- a/src/ansi-c/literals/convert_integer_literal.cpp
+++ b/src/ansi-c/literals/convert_integer_literal.cpp
@@ -11,7 +11,6 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "convert_integer_literal.h"
 
-#include <cassert>
 #include <cctype>
 
 #include <util/arith_tools.h>

--- a/src/ansi-c/literals/convert_string_literal.cpp
+++ b/src/ansi-c/literals/convert_string_literal.cpp
@@ -11,8 +11,6 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "convert_string_literal.h"
 
-#include <cassert>
-
 #include <util/arith_tools.h>
 #include <util/c_types.h>
 #include <util/unicode.h>

--- a/src/ansi-c/literals/unescape_string.cpp
+++ b/src/ansi-c/literals/unescape_string.cpp
@@ -11,9 +11,9 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "unescape_string.h"
 
-#include <cassert>
 #include <cctype>
 
+#include <util/invariant.h>
 #include <util/unicode.h>
 
 static void append_universal_char(
@@ -50,7 +50,7 @@ std::basic_string<T> unescape_string_templ(const std::string &src)
     {
       // go to next character
       i++;
-      assert(i<src.size()); // backslash can't be last character
+      INVARIANT(i < src.size(), "backslash can't be last character");
 
       ch=(unsigned char)src[i];
       switch(ch)

--- a/src/cpp/cpp_convert_type.cpp
+++ b/src/cpp/cpp_convert_type.cpp
@@ -11,8 +11,6 @@ Author: Daniel Kroening, kroening@cs.cmu.edu
 
 #include "cpp_convert_type.h"
 
-#include <cassert>
-
 #include <util/arith_tools.h>
 #include <util/c_types.h>
 #include <util/config.h>

--- a/src/cpp/cpp_declaration.h
+++ b/src/cpp/cpp_declaration.h
@@ -12,8 +12,6 @@ Author: Daniel Kroening, kroening@cs.cmu.edu
 #ifndef CPROVER_CPP_CPP_DECLARATION_H
 #define CPROVER_CPP_CPP_DECLARATION_H
 
-#include <cassert>
-
 #include "cpp_declarator.h"
 #include "cpp_storage_spec.h"
 #include "cpp_member_spec.h"

--- a/src/cpp/cpp_declarator.cpp
+++ b/src/cpp/cpp_declarator.cpp
@@ -14,7 +14,6 @@ Author: Daniel Kroening, kroening@cs.cmu.edu
 #include <ansi-c/merged_type.h>
 
 #include <ostream>
-#include <cassert>
 
 void cpp_declaratort::output(std::ostream &out) const
 {

--- a/src/cpp/cpp_enum_type.h
+++ b/src/cpp/cpp_enum_type.h
@@ -12,8 +12,6 @@ Author: Daniel Kroening, kroening@cs.cmu.edu
 #ifndef CPROVER_CPP_CPP_ENUM_TYPE_H
 #define CPROVER_CPP_CPP_ENUM_TYPE_H
 
-#include <cassert>
-
 #include <util/type.h>
 
 #include "cpp_name.h"

--- a/src/cpp/cpp_id.h
+++ b/src/cpp/cpp_id.h
@@ -12,7 +12,6 @@ Author: Daniel Kroening, kroening@cs.cmu.edu
 #ifndef CPROVER_CPP_CPP_ID_H
 #define CPROVER_CPP_CPP_ID_H
 
-#include <cassert>
 #include <list>
 #include <map>
 #include <string>

--- a/src/cpp/cpp_item.h
+++ b/src/cpp/cpp_item.h
@@ -12,8 +12,6 @@ Author: Daniel Kroening, kroening@cs.cmu.edu
 #ifndef CPROVER_CPP_CPP_ITEM_H
 #define CPROVER_CPP_CPP_ITEM_H
 
-#include <cassert>
-
 #include "cpp_declaration.h"
 #include "cpp_linkage_spec.h"
 #include "cpp_namespace_spec.h"

--- a/src/cpp/cpp_name.cpp
+++ b/src/cpp/cpp_name.cpp
@@ -11,7 +11,6 @@ Author: Daniel Kroening, kroening@cs.cmu.edu
 
 #include "cpp_name.h"
 
-#include <cassert>
 #include <sstream>
 
 irep_idt cpp_namet::get_base_name() const

--- a/src/cpp/cpp_parser.h
+++ b/src/cpp/cpp_parser.h
@@ -12,8 +12,6 @@ Author: Daniel Kroening, kroening@cs.cmu.edu
 #ifndef CPROVER_CPP_CPP_PARSER_H
 #define CPROVER_CPP_CPP_PARSER_H
 
-#include <cassert>
-
 #include <util/string_hash.h>
 #include <util/parser.h>
 #include <util/expr.h>

--- a/src/cpp/cpp_token_buffer.cpp
+++ b/src/cpp/cpp_token_buffer.cpp
@@ -11,8 +11,6 @@ Author: Daniel Kroening, kroening@cs.cmu.edu
 
 #include "cpp_token_buffer.h"
 
-#include <cassert>
-
 #include <ansi-c/ansi_c_y.tab.h>
 #include <ansi-c/ansi_c_parser.h>
 

--- a/src/cpp/cpp_typecheck_fargs.cpp
+++ b/src/cpp/cpp_typecheck_fargs.cpp
@@ -11,8 +11,6 @@ Author: Daniel Kroening, kroening@cs.cmu.edu
 
 #include "cpp_typecheck_fargs.h"
 
-#include <cassert>
-
 #include <util/std_types.h>
 
 #include <ansi-c/c_qualifiers.h>

--- a/src/cpp/cpp_typecheck_fargs.h
+++ b/src/cpp/cpp_typecheck_fargs.h
@@ -12,8 +12,6 @@ Author: Daniel Kroening, kroening@cs.cmu.edu
 #ifndef CPROVER_CPP_CPP_TYPECHECK_FARGS_H
 #define CPROVER_CPP_CPP_TYPECHECK_FARGS_H
 
-#include <cassert>
-
 #include <util/std_code.h>
 
 class cpp_typecheckt;

--- a/src/cpp/expr2cpp.cpp
+++ b/src/cpp/expr2cpp.cpp
@@ -8,8 +8,6 @@ Author: Daniel Kroening, kroening@cs.cmu.edu
 
 #include "expr2cpp.h"
 
-#include <cassert>
-
 #include <util/std_types.h>
 #include <util/std_expr.h>
 #include <util/symbol.h>

--- a/src/cpp/parse.cpp
+++ b/src/cpp/parse.cpp
@@ -11,7 +11,6 @@ Author: Daniel Kroening, kroening@cs.cmu.edu
 
 #include "cpp_parser.h"
 
-#include <cassert>
 #include <map>
 
 #include <util/c_types.h>

--- a/src/goto-cc/as86_cmdline.cpp
+++ b/src/goto-cc/as86_cmdline.cpp
@@ -11,7 +11,6 @@ Author: Michael Tautschnig
 
 #include "as86_cmdline.h"
 
-#include <cassert>
 #include <iostream>
 
 #include <util/prefix.h>

--- a/src/goto-cc/as_cmdline.cpp
+++ b/src/goto-cc/as_cmdline.cpp
@@ -11,7 +11,6 @@ Author: Michael Tautschnig
 
 #include "as_cmdline.h"
 
-#include <cassert>
 #include <iostream>
 
 #include <util/prefix.h>

--- a/src/goto-cc/bcc_cmdline.cpp
+++ b/src/goto-cc/bcc_cmdline.cpp
@@ -11,7 +11,6 @@ Author: Michael Tautschnig
 
 #include "bcc_cmdline.h"
 
-#include <cassert>
 #include <iostream>
 
 #include <util/prefix.h>

--- a/src/goto-cc/gcc_cmdline.cpp
+++ b/src/goto-cc/gcc_cmdline.cpp
@@ -11,7 +11,6 @@ Author: CM Wintersteiger, 2006
 
 #include "gcc_cmdline.h"
 
-#include <cassert>
 #include <cstring>
 #include <iostream>
 #include <fstream>

--- a/src/goto-cc/goto_cc_cmdline.cpp
+++ b/src/goto-cc/goto_cc_cmdline.cpp
@@ -14,7 +14,6 @@ Date:   April 2010
 #include "goto_cc_cmdline.h"
 
 #include <algorithm>
-#include <cassert>
 #include <cstdio>
 #include <cstring>
 #include <iostream>

--- a/src/goto-cc/ld_cmdline.cpp
+++ b/src/goto-cc/ld_cmdline.cpp
@@ -11,7 +11,6 @@ Author: Daniel Kroening, 2013
 
 #include "ld_cmdline.h"
 
-#include <cassert>
 #include <iostream>
 
 #include <util/prefix.h>

--- a/src/goto-cc/ms_cl_cmdline.cpp
+++ b/src/goto-cc/ms_cl_cmdline.cpp
@@ -11,7 +11,6 @@ Author: Daniel Kroening
 
 #include "ms_cl_cmdline.h"
 
-#include <cassert>
 #include <cstring>
 #include <cstdlib>
 #include <iostream>

--- a/src/goto-cc/ms_link_cmdline.cpp
+++ b/src/goto-cc/ms_link_cmdline.cpp
@@ -11,7 +11,6 @@ Author: Daniel Kroening
 
 #include "ms_link_cmdline.h"
 
-#include <cassert>
 #include <cstdlib>
 #include <cstring>
 #include <fstream>

--- a/src/goto-programs/builtin_functions.cpp
+++ b/src/goto-programs/builtin_functions.cpp
@@ -11,8 +11,6 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "goto_convert_class.h"
 
-#include <cassert>
-
 #include <util/arith_tools.h>
 #include <util/c_types.h>
 #include <util/cprover_prefix.h>

--- a/src/goto-programs/goto_inline.cpp
+++ b/src/goto-programs/goto_inline.cpp
@@ -11,8 +11,6 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "goto_inline.h"
 
-#include <cassert>
-
 #include <util/prefix.h>
 #include <util/cprover_prefix.h>
 #include <util/std_code.h>

--- a/src/goto-programs/remove_function_pointers.cpp
+++ b/src/goto-programs/remove_function_pointers.cpp
@@ -11,8 +11,6 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "remove_function_pointers.h"
 
-#include <cassert>
-
 #include <util/c_types.h>
 #include <util/fresh_symbol.h>
 #include <util/invariant.h>

--- a/src/goto-programs/xml_goto_trace.cpp
+++ b/src/goto-programs/xml_goto_trace.cpp
@@ -13,8 +13,6 @@ Author: Daniel Kroening
 
 #include "xml_goto_trace.h"
 
-#include <cassert>
-
 #include <util/symbol.h>
 #include <util/xml_irep.h>
 

--- a/src/goto-symex/symex_decl.cpp
+++ b/src/goto-symex/symex_decl.cpp
@@ -11,8 +11,6 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "goto_symex.h"
 
-#include <cassert>
-
 #include <util/std_expr.h>
 
 void goto_symext::symex_decl(statet &state)

--- a/src/json/json_parser.h
+++ b/src/json/json_parser.h
@@ -10,7 +10,6 @@ Author: Daniel Kroening, kroening@kroening.com
 #ifndef CPROVER_JSON_JSON_PARSER_H
 #define CPROVER_JSON_JSON_PARSER_H
 
-#include <cassert>
 #include <stack>
 
 #include <util/parser.h>

--- a/src/linking/linking.cpp
+++ b/src/linking/linking.cpp
@@ -11,7 +11,6 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "linking.h"
 
-#include <cassert>
 #include <deque>
 #include <unordered_set>
 

--- a/src/linking/static_lifetime_init.cpp
+++ b/src/linking/static_lifetime_init.cpp
@@ -8,7 +8,6 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "static_lifetime_init.h"
 
-#include <cassert>
 #include <cstdlib>
 
 #include <util/arith_tools.h>

--- a/src/pointer-analysis/value_set.cpp
+++ b/src/pointer-analysis/value_set.cpp
@@ -11,7 +11,6 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "value_set.h"
 
-#include <cassert>
 #include <ostream>
 
 #include <util/arith_tools.h>

--- a/src/pointer-analysis/value_set_fi.cpp
+++ b/src/pointer-analysis/value_set_fi.cpp
@@ -11,7 +11,6 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "value_set_fi.h"
 
-#include <cassert>
 #include <iterator>
 #include <ostream>
 

--- a/src/solvers/bdd/miniBDD/miniBDD.h
+++ b/src/solvers/bdd/miniBDD/miniBDD.h
@@ -21,7 +21,6 @@ Author: Daniel Kroening, kroening@kroening.com
  * \date   Mon Sep 28 00:00:00 BST 2009
 */
 
-#include <cassert>
 #include <list>
 #include <map>
 #include <stack>

--- a/src/solvers/flattening/boolbv_byte_extract.cpp
+++ b/src/solvers/flattening/boolbv_byte_extract.cpp
@@ -8,8 +8,6 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "boolbv.h"
 
-#include <cassert>
-
 #include <util/arith_tools.h>
 #include <util/byte_operators.h>
 #include <util/expr_util.h>

--- a/src/solvers/flattening/boolbv_extractbit.cpp
+++ b/src/solvers/flattening/boolbv_extractbit.cpp
@@ -8,7 +8,6 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "boolbv.h"
 
-#include <cassert>
 #include <algorithm>
 
 #include <util/arith_tools.h>

--- a/src/solvers/flattening/boolbv_get.cpp
+++ b/src/solvers/flattening/boolbv_get.cpp
@@ -8,8 +8,6 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "boolbv.h"
 
-#include <cassert>
-
 #include <util/arith_tools.h>
 #include <util/c_types.h>
 #include <util/simplify_expr.h>

--- a/src/solvers/flattening/boolbv_typecast.cpp
+++ b/src/solvers/flattening/boolbv_typecast.cpp
@@ -8,8 +8,6 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "boolbv.h"
 
-#include <cassert>
-
 #include <util/std_types.h>
 
 #include <solvers/floatbv/float_utils.h>

--- a/src/solvers/flattening/bv_utils.cpp
+++ b/src/solvers/flattening/bv_utils.cpp
@@ -8,8 +8,6 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "bv_utils.h"
 
-#include <cassert>
-
 #include <util/arith_tools.h>
 
 bvt bv_utilst::build_constant(const mp_integer &n, std::size_t width)

--- a/src/util/endianness_map.h
+++ b/src/util/endianness_map.h
@@ -17,7 +17,6 @@ Author: Daniel Kroening, kroening@kroening.com
  * \date   Sun Jul 31 21:54:44 BST 2011
 */
 
-#include <cassert>
 #include <iosfwd>
 #include <vector>
 

--- a/src/util/graph.h
+++ b/src/util/graph.h
@@ -13,7 +13,6 @@ Author: Daniel Kroening, kroening@kroening.com
 #define CPROVER_UTIL_GRAPH_H
 
 #include <algorithm>
-#include <cassert>
 #include <functional>
 #include <iosfwd>
 #include <list>

--- a/src/util/simplify_expr_int.cpp
+++ b/src/util/simplify_expr_int.cpp
@@ -8,8 +8,6 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "simplify_expr_class.h"
 
-#include <cassert>
-
 #include "arith_tools.h"
 #include "byte_operators.h"
 #include "config.h"

--- a/src/util/simplify_expr_pointer.cpp
+++ b/src/util/simplify_expr_pointer.cpp
@@ -8,8 +8,6 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "simplify_expr_class.h"
 
-#include <cassert>
-
 #include "arith_tools.h"
 #include "c_types.h"
 #include "config.h"

--- a/src/util/ssa_expr.cpp
+++ b/src/util/ssa_expr.cpp
@@ -9,7 +9,6 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "ssa_expr.h"
 
 #include <sstream>
-#include <cassert>
 
 #include <util/arith_tools.h>
 

--- a/src/util/string_utils.cpp
+++ b/src/util/string_utils.cpp
@@ -11,7 +11,6 @@ Author: Daniel Poetzl
 #include "invariant.h"
 
 #include <algorithm>
-#include <cassert>
 #include <cctype>
 #include <iomanip>
 

--- a/src/util/union_find.h
+++ b/src/util/union_find.h
@@ -10,7 +10,6 @@ Author: Daniel Kroening, kroening@kroening.com
 #ifndef CPROVER_UTIL_UNION_FIND_H
 #define CPROVER_UTIL_UNION_FIND_H
 
-#include <cassert>
 #include <vector>
 
 #include "invariant.h"

--- a/src/xmllang/graphml.cpp
+++ b/src/xmllang/graphml.cpp
@@ -11,7 +11,6 @@ Author: Michael Tautschnig, mt@eecs.qmul.ac.uk
 
 #include "graphml.h"
 
-#include <cassert>
 #include <set>
 
 #include <util/message.h>


### PR DESCRIPTION
We use invariant.h instead, and with a single exception all #include
statements were unnecessary. The exception: unescape_string.cpp, which
required replacing one use of `assert` by `INVARIANT`.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- n/a Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
