### PR TITLE
C front-end: anonymous struct/union members need not be of struct/union type

### DIFF
--- a/regression/ansi-c/anonymous_member1/main.c
+++ b/regression/ansi-c/anonymous_member1/main.c
@@ -1,0 +1,15 @@
+struct S
+{
+  struct
+  {
+    int : 1;
+    int;
+    int named;
+  };
+};
+
+struct S s = {.named = 0};
+
+int main()
+{
+}

--- a/regression/ansi-c/anonymous_member1/test.desc
+++ b/regression/ansi-c/anonymous_member1/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+^CONVERSION ERROR$

--- a/src/ansi-c/anonymous_member.cpp
+++ b/src/ansi-c/anonymous_member.cpp
@@ -88,7 +88,9 @@ bool has_component_rec(
     {
       return true;
     }
-    else if(comp.get_anonymous())
+    else if(
+      comp.get_anonymous() &&
+      (comp.type().id() == ID_struct_tag || comp.type().id() == ID_union_tag))
     {
       if(has_component_rec(comp.type(), component_name, ns))
         return true;


### PR DESCRIPTION
A struct or union can contain anonymous members of any type. Code uses
those to ensure a particular layout. Make sure that recursive member
look-up does not try to recurse into types other structs or unions.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
