### PR TITLE
Clean up CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,7 +2,7 @@
 # approval within two weeks.
 #
 # These owners will be the default owners for everything in the repo.
-*       @kroening @tautschnig @peterschrammel @smowton @chrisr-diffblue
+*       @kroening @tautschnig @peterschrammel @smowton @chrisr-diffblue @hannes-steffenhagen-diffblue
 
 # These files should rarely change
 
@@ -12,8 +12,10 @@
 /src/goto-cc/ @kroening @tautschnig @chrisr-diffblue
 /src/linking/ @kroening @tautschnig @chrisr-diffblue
 /src/memory-models/ @kroening @tautschnig
+/src/goto-checker/ @kroening @tautschnig @peterschrammel
 /src/goto-symex/ @kroening @tautschnig @peterschrammel @smowton @romainbrenguier
 /src/json/ @kroening @tautschnig @peterschrammel
+/src/json-symtab-language/ @martin-cs @smowton
 /src/langapi/ @kroening @tautschnig @peterschrammel
 /src/xmllang/ @kroening @tautschnig @peterschrammel
 /src/nonstd/ @smowton @peterschrammel
@@ -22,30 +24,33 @@
 /src/solvers/miniBDD @tautschnig @kroening
 /src/solvers/prop @martin-cs @kroening @tautschnig @peterschrammel
 /src/solvers/sat @martin-cs @kroening @tautschnig @peterschrammel
-/jbmc/src/miniz/ @smowton @mgudemann @peterschrammel
+/src/symtab2gb/ @martin-cs @smowton
+/jbmc/src/miniz/ @smowton @peterschrammel
 
 
 # These files change frequently and changes are high-risk
 
 /src/cbmc/ @smowton @kroening @tautschnig @peterschrammel
-/src/goto-programs/ @smowton @kroening @tautschnig @peterschrammel @pkesseli
-/src/util/ @smowton @kroening @tautschnig @peterschrammel @pkesseli
+/src/goto-programs/ @smowton @kroening @tautschnig @peterschrammel
+/src/util/ @smowton @kroening @tautschnig @peterschrammel
 /src/solvers/refinement @martin-cs @romainbrenguier @peterschrammel
 /src/solvers/strings @martin-cs @romainbrenguier @peterschrammel
-/jbmc/src/java_bytecode/ @smowton @mgudemann @thk123 @cristina-david @cesaro @pkesseli @NathanJPhillips @peterschrammel
-/src/analyses/ @martin-cs @peterschrammel @chrisr-diffblue @thk123 @smowton @danpoe @owen-jones-diffblue
-/src/pointer-analysis/ @martin-cs @peterschrammel @chrisr-diffblue @smowton @owen-jones-diffblue
+/jbmc/src/java_bytecode/ @smowton @romainbrenguier @peterschrammel
+/src/analyses/ @martin-cs @peterschrammel @chrisr-diffblue @smowton
+/src/pointer-analysis/ @martin-cs @peterschrammel @chrisr-diffblue @smowton
 
 
 # These files change frequently and changes are medium-risk
 
-/src/goto-analyzer/ @martin-cs @chrisr-diffblue @peterschrammel @danpoe @hannes-steffenhagen-diffblue
-/src/goto-harness/ @martin-cs @chrisr-diffblue @peterschrammel @danpoe @hannes-steffenhagen-diffblue
-/src/goto-instrument/ @martin-cs @chrisr-diffblue @peterschrammel @danpoe @hannes-steffenhagen-diffblue @smowton
+/src/goto-analyzer/ @martin-cs @chrisr-diffblue @peterschrammel @hannes-steffenhagen-diffblue
+/src/goto-harness/ @martin-cs @chrisr-diffblue @peterschrammel @hannes-steffenhagen-diffblue
+/src/goto-instrument/ @martin-cs @chrisr-diffblue @peterschrammel @hannes-steffenhagen-diffblue @smowton
 /src/goto-diff/ @tautschnig @peterschrammel
-/jbmc/src/jbmc/ @smowton @mgudemann @cristina-david @cesaro @pkesseli @peterschrammel
-/jbmc/src/janalyzer/ @smowton @mgudemann @cristina-david @cesaro @pkesseli @peterschrammel
-/jbmc/src/jdiff/ @smowton @mgudemann @cristina-david @cesaro @pkesseli @peterschrammel
+/src/jsil/ @kroening @tautschnig
+/src/memory-analyzer/ @tautschnig @hannes-steffenhagen-diffblue
+/jbmc/src/jbmc/ @smowton @peterschrammel @romainbrenguier
+/jbmc/src/janalyzer/ @smowton @peterschrammel @romainbrenguier
+/jbmc/src/jdiff/ @smowton @peterschrammel
 /src/cpp/ @kroening @tautschnig @peterschrammel
 /src/solvers/smt2 @kroening @martin-cs @tautschnig @peterschrammel @allredj @romainbrenguier
 /src/statement-list/ @kroening @tautschnig @peterschrammel @pkesseli
@@ -62,7 +67,7 @@ CMakeLists.txt @hannes-steffenhagen-diffblue
 /jbmc/unit/
 /jbmc/regression/
 
-/scripts/ @diffblue/devops @thk123 @forejtv @peterschrammel
+/scripts/ @diffblue/devops
 /scripts/expected_doxygen_warnings.txt
 
 # CI pipeline is the responsibility of the Open Source maintenance team at Diffblue.


### PR DESCRIPTION
Suggestion for clean-up

The purpose of this is to increase the recall on review requests and reduce noise for those who haven't been actively involved in CBMC for the last couple of months.