### PR TITLE
Upgrade setup-msbuild workflow to 1.0.2 to avoid deprecated add-path

### DIFF
--- a/.github/workflows/pull-request-checks.yaml
+++ b/.github/workflows/pull-request-checks.yaml
@@ -132,9 +132,7 @@ jobs:
           Expand-Archive z3.zip
           # We need Get-ChildItem.Name here because the path includes
           # the z3 version number, which we expect to change.
-          $z3_path = "$(Get-Location)\z3\$((Get-ChildItem z3).Name)"
-          $env:PATH += ";$z3_path"
-          Write-Output "::set-env name=PATH::$env:PATH"
+          echo "$(Get-Location)\z3\$((Get-ChildItem z3).Name)" >> $env:GITHUB_PATH
 
       - name: Build cbmc
         run: "${{env.SCRIPT_DIR}}\\build-cbmc.bat"

--- a/.github/workflows/pull-request-checks.yaml
+++ b/.github/workflows/pull-request-checks.yaml
@@ -194,7 +194,7 @@ jobs:
       - name: Fetch dependencies
         run: |
           choco install winflexbison3
-      - uses: microsoft/setup-msbuild@v1.0.1
+      - uses: microsoft/setup-msbuild@v1.0.2
       - name: Configure with cmake
         run: |
           New-Item -ItemType Directory -Path build

--- a/.github/workflows/release-packages.yaml
+++ b/.github/workflows/release-packages.yaml
@@ -110,7 +110,7 @@ jobs:
       - name: Fetch dependencies
         run: |
           choco install winflexbison3
-      - uses: microsoft/setup-msbuild@v1.0.1
+      - uses: microsoft/setup-msbuild@v1.0.2
         name: Setup Visual Studio environment
       - name: Setup code sign environment
         run: | 

--- a/.github/workflows/release-packages.yaml
+++ b/.github/workflows/release-packages.yaml
@@ -91,7 +91,7 @@ jobs:
       - name: Get release tag name
         # The GITHUB_REF we get has refs/tags/ in front of the tag name so we
         # strip that here
-        run: echo "::set-env name=RELEASE_TAG::${GITHUB_REF/refs\/tags\/}"
+        run: echo "RELEASE_TAG=${GITHUB_REF/refs\/tags\/}" >> $GITHUB_ENV
       - name: Create homebrew PR
         run: |
           brew update-reset


### PR DESCRIPTION
The add-path command has now been disabled by GitHub for security
reasons. setup-msbuild fixed the problem on their end in
https://github.com/microsoft/setup-msbuild/pull/25, which hopefully is
part of their 1.0.2 release.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
