### PR TITLE
make the 'external SAT' solver incremental

### DIFF
--- a/src/solvers/sat/external_sat.h
+++ b/src/solvers/sat/external_sat.h
@@ -14,7 +14,7 @@ public:
 
   bool has_set_assumptions() const override final
   {
-    return false;
+    return true;
   }
 
   bool has_is_in_conflict() const override final
@@ -27,9 +27,16 @@ public:
   bool is_in_conflict(literalt) const override;
   void set_assignment(literalt, bool) override;
 
+  void set_assumptions(const bvt &_assumptions) override
+  {
+    assumptions = _assumptions;
+  }
+
 protected:
-  resultt do_prop_solve() override;
   std::string solver_cmd;
+  bvt assumptions;
+
+  resultt do_prop_solve() override;
   void write_cnf_file(std::string);
   std::string execute_solver(std::string);
   resultt parse_result(std::string);


### PR DESCRIPTION
This adds support for the 'assumption' interface to the external SAT solver.
Note that this is not an implementation of incremental SAT. The formula
is re-solved from scratch with each invocation.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
