### PR TITLE
Use both cores of GitHub runners

### DIFF
--- a/.github/workflows/build-and-test-Xen.yaml
+++ b/.github/workflows/build-and-test-Xen.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: Build CBMC tools
         run: |
           make -C src minisat2-download
-          make -C src cbmc.dir goto-cc.dir goto-diff.dir
+          make -C src cbmc.dir goto-cc.dir goto-diff.dir -j2
 
       - name: Get one-line-scan
         run: git clone -b path-addition https://github.com/awslabs/one-line-scan.git

--- a/.github/workflows/pull-request-checks.yaml
+++ b/.github/workflows/pull-request-checks.yaml
@@ -33,10 +33,10 @@ jobs:
           make TAGS="[!shouldfail]" -C jbmc/unit test
       - name: Run regression tests
         run: |
-          make -C regression test
+          make -C regression test-parallel JOBS=2
           make -C regression/cbmc test-paths-lifo
           env PATH=$PATH:`pwd`/src/solvers make -C regression/cbmc test-cprover-smt2
-          make -C jbmc/regression test
+          make -C jbmc/regression test-parallel JOBS=2
 
   check-ubuntu-20_04-cmake-gcc:
     runs-on: ubuntu-20.04
@@ -57,14 +57,14 @@ jobs:
           cd build
           cmake .. -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=/usr/bin/gcc -DCMAKE_CXX_COMPILER=/usr/bin/g++
       - name: Build with Ninja
-        run: cd build; ninja
+        run: cd build; ninja -j2
       - name: Check if package building works
         run: |
           cd build
           ninja package
           ls *.deb
       - name: Run tests
-        run: cd build; ctest . -V -L CORE
+        run: cd build; ctest . -V -L CORE -j2
 
   check-macos-10_15-make-clang:
     runs-on: macos-10.15
@@ -73,12 +73,12 @@ jobs:
         with:
           submodules: true
       - name: Fetch dependencies
-        run: brew install maven flex bison
+        run: brew install maven flex bison parallel
       - name: Build using Make
         run: |
           make -C src minisat2-download
-          make -C src
-          make -C jbmc/src
+          make -C src -j2
+          make -C jbmc/src -j2
           make -C unit
           make -C jbmc/unit
       - name: Run unit tests
@@ -86,9 +86,9 @@ jobs:
       - name: Run JBMC unit tests
         run: cd jbmc/unit; ./unit_tests
       - name: Run regression tests
-        run: cd regression; make
+        run: make -C regression test-parallel JOBS=2
       - name: Run JBMC regression tests
-        run: cd jbmc/regression; make
+        run: make -C jbmc/regression test-parallel JOBS=2
 
   check-macos-10_15-cmake-clang:
     runs-on: macos-10.15
@@ -104,9 +104,9 @@ jobs:
           cd build
           cmake .. -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=/usr/bin/clang -DCMAKE_CXX_COMPILER=/usr/bin/clang++
       - name: Build with Ninja
-        run: cd build; ninja
+        run: cd build; ninja -j2
       - name: Run CTest
-        run: cd build; ctest -V -L CORE .
+        run: cd build; ctest -V -L CORE . -j2
 
   check-vs-2019-build-and-test:
     runs-on: windows-2019
@@ -196,7 +196,7 @@ jobs:
       - name: Build Release
         run: |
           Set-Location build
-          cmake --build . --config Release
+          cmake --build . --config Release -- /p:CL_MPcount=2
       - name: Create packages
         id: create_packages
         # We need to get the path to cpack because fascinatingly,
@@ -227,9 +227,9 @@ jobs:
       - name: Build using Ninja
         run: |
           cd build
-          ninja
+          ninja -j2
       - name: Run CTest
-        run: cd build; ctest . -V -L CORE -C Release
+        run: cd build; ctest . -V -L CORE -C Release -j2
       - name: Create packages
         id: create_packages
         run: |

--- a/.github/workflows/pull-request-checks.yaml
+++ b/.github/workflows/pull-request-checks.yaml
@@ -15,11 +15,9 @@ jobs:
           # This is needed in addition to -yq to prevent apt-get from asking for
           # user input
           DEBIAN_FRONTEND: noninteractive
-          TESTPL_JOBS: 4
         run: |
-          sudo apt-get install -yq gcc gdb g++ maven jq flex bison libxml2-utils cpanminus
+          sudo apt-get install -yq gcc gdb g++ maven jq flex bison libxml2-utils
           make -C src minisat2-download
-          cpanm Thread::Pool::Simple
       - name: Build with make
         run: |
           make -C src CXX='/usr/bin/g++' -j2
@@ -52,8 +50,7 @@ jobs:
           # user input
           DEBIAN_FRONTEND: noninteractive
         run: |
-          sudo apt-get install -yq cmake ninja-build gcc g++ maven flex bison libxml2-utils cpanminus dpkg-dev
-          cpanm Thread::Pool::Simple
+          sudo apt-get install -yq cmake ninja-build gcc g++ maven flex bison libxml2-utils dpkg-dev
       - name: Configure using CMake
         run: |
           mkdir build
@@ -68,8 +65,6 @@ jobs:
           ls *.deb
       - name: Run tests
         run: cd build; ctest . -V -L CORE
-        env:
-          TESTPL_JOBS: 2
 
   check-macos-10_15-make-clang:
     runs-on: macos-10.15

--- a/.github/workflows/release-packages.yaml
+++ b/.github/workflows/release-packages.yaml
@@ -22,9 +22,9 @@ jobs:
       - name: Build using Ninja
         run: |
           cd build
-          ninja
+          ninja -j2
       - name: Run CTest
-        run: cd build; ctest . -V -L CORE -C Release
+        run: cd build; ctest . -V -L CORE -C Release -j2
       - name: Create packages
         id: create_packages
         run: |
@@ -62,9 +62,9 @@ jobs:
       - name: Build using Ninja
         run: |
           cd build
-          ninja
+          ninja -j2
       - name: Run CTest
-        run: cd build; ctest . -V -L CORE -C Release
+        run: cd build; ctest . -V -L CORE -C Release -j2
       - name: Create packages
         id: create_packages
         run: |
@@ -124,7 +124,7 @@ jobs:
       - name: Build Release
         run: |
           Set-Location build
-          cmake --build . --config Release
+          cmake --build . --config Release -j2
       - name: Create packages
         id: create_packages
         run: |

--- a/.github/workflows/vs2019/build-cbmc.bat
+++ b/.github/workflows/vs2019/build-cbmc.bat
@@ -19,4 +19,4 @@ echo "Configure CBMC with cmake"
 cmake -S. -Bbuild
 
 echo "Build CBMC with cmake"
-cmake --build build --config Release
+cmake --build build --config Release -- /p:CL_MPcount=2


### PR DESCRIPTION
According to
https://docs.github.com/en/free-pro-team@latest/actions/reference/specifications-for-github-hosted-runners#supported-runners-and-hardware-resources,
all GitHub runners feature two CPU cores. Let's use them, as we used to
do in Travis and CodeBuild configurations.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
