### PR TITLE
Variable sensitivity object factory rework

### DIFF
--- a/src/analyses/variable-sensitivity/abstract_enviroment.cpp
+++ b/src/analyses/variable-sensitivity/abstract_enviroment.cpp
@@ -337,7 +337,7 @@ abstract_object_pointert abstract_environmentt::abstract_object_factory(
   const abstract_environmentt &environment,
   const namespacet &ns) const
 {
-  return variable_sensitivity_object_factoryt::instance().get_abstract_object(
+  return object_factory->get_abstract_object(
     type, top, bottom, e, environment, ns);
 }
 
@@ -526,8 +526,4 @@ abstract_environmentt::gather_statistics(const namespacet &ns) const
     }
   }
   return statistics;
-}
-
-abstract_environmentt::abstract_environmentt() : bottom(true)
-{
 }

--- a/src/analyses/variable-sensitivity/abstract_enviroment.h
+++ b/src/analyses/variable-sensitivity/abstract_enviroment.h
@@ -28,11 +28,23 @@
 #include <util/sharing_map.h>
 #include <util/std_expr.h>
 
+class variable_sensitivity_object_factoryt;
+using variable_sensitivity_object_factory_ptrt =
+std::shared_ptr<variable_sensitivity_object_factoryt>;
+
 class abstract_environmentt
 {
 public:
   using map_keyt = irep_idt;
-  abstract_environmentt();
+
+  abstract_environmentt() = delete;
+
+  abstract_environmentt(
+    variable_sensitivity_object_factory_ptrt _object_factory)
+  : bottom(true),
+    object_factory(_object_factory) {
+  }
+
   /// These three are really the heart of the method
 
   /// Evaluate the value of an expression relative to the current domain
@@ -248,6 +260,8 @@ private:
     const exprt &e,
     const abstract_environmentt &environment,
     const namespacet &ns) const;
+
+  variable_sensitivity_object_factory_ptrt object_factory;
 };
 
 #endif // CPROVER_ANALYSES_VARIABLE_SENSITIVITY_ABSTRACT_ENVIROMENT_H

--- a/src/analyses/variable-sensitivity/abstract_enviroment.h
+++ b/src/analyses/variable-sensitivity/abstract_enviroment.h
@@ -30,7 +30,7 @@
 
 class variable_sensitivity_object_factoryt;
 using variable_sensitivity_object_factory_ptrt =
-std::shared_ptr<variable_sensitivity_object_factoryt>;
+  std::shared_ptr<variable_sensitivity_object_factoryt>;
 
 class abstract_environmentt
 {
@@ -41,8 +41,8 @@ public:
 
   abstract_environmentt(
     variable_sensitivity_object_factory_ptrt _object_factory)
-  : bottom(true),
-    object_factory(_object_factory) {
+    : bottom(true), object_factory(_object_factory)
+  {
   }
 
   /// These three are really the heart of the method

--- a/src/analyses/variable-sensitivity/variable_sensitivity_dependence_graph.cpp
+++ b/src/analyses/variable-sensitivity/variable_sensitivity_dependence_graph.cpp
@@ -612,8 +612,7 @@ public:
   explicit variable_sensitivity_dependence_domain_factoryt(
     variable_sensitivity_dependence_grapht &_dg,
     variable_sensitivity_object_factory_ptrt _object_factory)
-    : dg(_dg),
-      object_factory(_object_factory)
+    : dg(_dg), object_factory(_object_factory)
   {
   }
 
@@ -621,7 +620,8 @@ public:
   {
     auto node_id = dg.add_node();
     dg.nodes[node_id].PC = l;
-    auto p = util_make_unique<variable_sensitivity_dependence_domaint>(node_id, object_factory);
+    auto p = util_make_unique<variable_sensitivity_dependence_domaint>(
+      node_id, object_factory);
     CHECK_RETURN(p->is_bottom());
 
     return std::unique_ptr<statet>(p.release());
@@ -638,7 +638,9 @@ variable_sensitivity_dependence_grapht::variable_sensitivity_dependence_grapht(
   variable_sensitivity_object_factory_ptrt _object_factory)
   : ai_three_way_merget(
       util_make_unique<ai_history_factory_default_constructort<ahistoricalt>>(),
-      util_make_unique<variable_sensitivity_dependence_domain_factoryt>(*this, _object_factory),
+      util_make_unique<variable_sensitivity_dependence_domain_factoryt>(
+        *this,
+        _object_factory),
       util_make_unique<location_sensitive_storaget>()),
     goto_functions(goto_functions),
     ns(_ns)

--- a/src/analyses/variable-sensitivity/variable_sensitivity_dependence_graph.cpp
+++ b/src/analyses/variable-sensitivity/variable_sensitivity_dependence_graph.cpp
@@ -610,8 +610,10 @@ class variable_sensitivity_dependence_domain_factoryt
 {
 public:
   explicit variable_sensitivity_dependence_domain_factoryt(
-    variable_sensitivity_dependence_grapht &_dg)
-    : dg(_dg)
+    variable_sensitivity_dependence_grapht &_dg,
+    variable_sensitivity_object_factory_ptrt _object_factory)
+    : dg(_dg),
+      object_factory(_object_factory)
   {
   }
 
@@ -619,7 +621,7 @@ public:
   {
     auto node_id = dg.add_node();
     dg.nodes[node_id].PC = l;
-    auto p = util_make_unique<variable_sensitivity_dependence_domaint>(node_id);
+    auto p = util_make_unique<variable_sensitivity_dependence_domaint>(node_id, object_factory);
     CHECK_RETURN(p->is_bottom());
 
     return std::unique_ptr<statet>(p.release());
@@ -627,14 +629,16 @@ public:
 
 private:
   variable_sensitivity_dependence_grapht &dg;
+  variable_sensitivity_object_factory_ptrt object_factory;
 };
 
 variable_sensitivity_dependence_grapht::variable_sensitivity_dependence_grapht(
   const goto_functionst &goto_functions,
-  const namespacet &_ns)
+  const namespacet &_ns,
+  variable_sensitivity_object_factory_ptrt _object_factory)
   : ai_three_way_merget(
       util_make_unique<ai_history_factory_default_constructort<ahistoricalt>>(),
-      util_make_unique<variable_sensitivity_dependence_domain_factoryt>(*this),
+      util_make_unique<variable_sensitivity_dependence_domain_factoryt>(*this, _object_factory),
       util_make_unique<location_sensitive_storaget>()),
     goto_functions(goto_functions),
     ns(_ns)

--- a/src/analyses/variable-sensitivity/variable_sensitivity_dependence_graph.h
+++ b/src/analyses/variable-sensitivity/variable_sensitivity_dependence_graph.h
@@ -76,8 +76,8 @@ public:
 
   explicit variable_sensitivity_dependence_domaint(
     node_indext id,
-    variable_sensitivity_object_factory_ptrt object_factory
-  ) : variable_sensitivity_domaint(object_factory),
+    variable_sensitivity_object_factory_ptrt object_factory)
+    : variable_sensitivity_domaint(object_factory),
       node_id(id),
       has_values(false),
       has_changed(false)

--- a/src/analyses/variable-sensitivity/variable_sensitivity_dependence_graph.h
+++ b/src/analyses/variable-sensitivity/variable_sensitivity_dependence_graph.h
@@ -74,8 +74,13 @@ class variable_sensitivity_dependence_domaint
 public:
   typedef grapht<vs_dep_nodet>::node_indext node_indext;
 
-  explicit variable_sensitivity_dependence_domaint(node_indext id)
-    : node_id(id), has_values(false), has_changed(false)
+  explicit variable_sensitivity_dependence_domaint(
+    node_indext id,
+    variable_sensitivity_object_factory_ptrt object_factory
+  ) : variable_sensitivity_domaint(object_factory),
+      node_id(id),
+      has_values(false),
+      has_changed(false)
   {
   }
 
@@ -237,7 +242,8 @@ public:
 
   explicit variable_sensitivity_dependence_grapht(
     const goto_functionst &goto_functions,
-    const namespacet &_ns);
+    const namespacet &_ns,
+    variable_sensitivity_object_factory_ptrt object_factory);
 
   void
   initialize(const irep_idt &function_id, const goto_programt &goto_program)

--- a/src/analyses/variable-sensitivity/variable_sensitivity_domain.h
+++ b/src/analyses/variable-sensitivity/variable_sensitivity_domain.h
@@ -218,14 +218,11 @@ public:
 #endif
 };
 
-template <>
-class ai_domain_factory_default_constructort<variable_sensitivity_domaint>
+class variable_sensitivity_domain_factoryt
   : public ai_domain_factoryt<variable_sensitivity_domaint>
 {
 public:
-  ai_domain_factory_default_constructort() = delete;
-
-  explicit ai_domain_factory_default_constructort(
+  explicit variable_sensitivity_domain_factoryt(
     variable_sensitivity_object_factory_ptrt _object_factory)
     : object_factory(_object_factory)
   {
@@ -241,9 +238,6 @@ public:
 private:
   variable_sensitivity_object_factory_ptrt object_factory;
 };
-
-using variable_sensitivity_domain_factoryt =
-  ai_domain_factory_default_constructort<variable_sensitivity_domaint>;
 
 #ifdef ENABLE_STATS
 template <>

--- a/src/analyses/variable-sensitivity/variable_sensitivity_domain.h
+++ b/src/analyses/variable-sensitivity/variable_sensitivity_domain.h
@@ -76,7 +76,8 @@ class variable_sensitivity_domaint : public ai_domain_baset
 public:
   explicit variable_sensitivity_domaint(
     variable_sensitivity_object_factory_ptrt _object_factory)
-  : abstract_state(_object_factory) {
+    : abstract_state(_object_factory)
+  {
   }
 
   /// Compute the abstract transformer for a single instruction
@@ -217,7 +218,7 @@ public:
 #endif
 };
 
-template<>
+template <>
 class ai_domain_factory_default_constructort<variable_sensitivity_domaint>
   : public ai_domain_factoryt<variable_sensitivity_domaint>
 {
@@ -226,7 +227,8 @@ public:
 
   explicit ai_domain_factory_default_constructort(
     variable_sensitivity_object_factory_ptrt _object_factory)
-  : object_factory(_object_factory) {
+    : object_factory(_object_factory)
+  {
   }
 
   std::unique_ptr<statet> make(locationt l) const override

--- a/src/analyses/variable-sensitivity/variable_sensitivity_domain.h
+++ b/src/analyses/variable-sensitivity/variable_sensitivity_domain.h
@@ -71,15 +71,12 @@
 #include <analyses/ai.h>
 #include <analyses/variable-sensitivity/abstract_enviroment.h>
 
-class variable_sensitivity_object_factoryt;
-using variable_sensitivity_object_factory_ptrt =
-std::shared_ptr<variable_sensitivity_object_factoryt>;
-
 class variable_sensitivity_domaint : public ai_domain_baset
 {
 public:
   explicit variable_sensitivity_domaint(
-    variable_sensitivity_object_factory_ptrt _object_factory) {
+    variable_sensitivity_object_factory_ptrt _object_factory)
+  : abstract_state(_object_factory) {
   }
 
   /// Compute the abstract transformer for a single instruction

--- a/src/analyses/variable-sensitivity/variable_sensitivity_domain.h
+++ b/src/analyses/variable-sensitivity/variable_sensitivity_domain.h
@@ -71,9 +71,19 @@
 #include <analyses/ai.h>
 #include <analyses/variable-sensitivity/abstract_enviroment.h>
 
+class variable_sensitivity_object_factoryt;
+using variable_sensitivity_object_factory_ptrt =
+std::shared_ptr<variable_sensitivity_object_factoryt>;
+
 class variable_sensitivity_domaint : public ai_domain_baset
 {
 public:
+  variable_sensitivity_domaint() { }
+
+  explicit variable_sensitivity_domaint(
+    variable_sensitivity_object_factory_ptrt _object_factory) {
+  }
+
   /// Compute the abstract transformer for a single instruction
   ///
   /// \param function_from: the name of the function containing from
@@ -212,21 +222,24 @@ public:
 #endif
 };
 
-class variable_sensitivity_object_factoryt;
-using variable_sensitivity_object_factory_ptrt =
-  std::shared_ptr<variable_sensitivity_object_factoryt>;
-
 class variable_sensitivity_domain_factoryt
   : public ai_domain_factory_default_constructort<variable_sensitivity_domaint>
 {
 public:
   explicit variable_sensitivity_domain_factoryt(
-    variable_sensitivity_object_factory_ptrt object_factory
-  ) : vs_object_factory(object_factory) {
+    variable_sensitivity_object_factory_ptrt _object_factory)
+  : object_factory(_object_factory) {
+  }
+
+  std::unique_ptr<statet> make(locationt l) const override
+  {
+    auto d = util_make_unique<variable_sensitivity_domaint>(object_factory);
+    CHECK_RETURN(d->is_bottom());
+    return std::unique_ptr<statet>(d.release());
   }
 
 private:
-  variable_sensitivity_object_factory_ptrt vs_object_factory;
+  variable_sensitivity_object_factory_ptrt object_factory;
 };
 
 #ifdef ENABLE_STATS

--- a/src/analyses/variable-sensitivity/variable_sensitivity_domain.h
+++ b/src/analyses/variable-sensitivity/variable_sensitivity_domain.h
@@ -212,6 +212,11 @@ public:
 #endif
 };
 
+class variable_sensitivity_domain_factoryt
+  : public ai_domain_factory_default_constructort<variable_sensitivity_domaint>
+{
+};
+
 #ifdef ENABLE_STATS
 template <>
 struct get_domain_statisticst<variable_sensitivity_domaint>

--- a/src/analyses/variable-sensitivity/variable_sensitivity_domain.h
+++ b/src/analyses/variable-sensitivity/variable_sensitivity_domain.h
@@ -212,9 +212,21 @@ public:
 #endif
 };
 
+class variable_sensitivity_object_factoryt;
+using variable_sensitivity_object_factory_ptrt =
+  std::shared_ptr<variable_sensitivity_object_factoryt>;
+
 class variable_sensitivity_domain_factoryt
   : public ai_domain_factory_default_constructort<variable_sensitivity_domaint>
 {
+public:
+  explicit variable_sensitivity_domain_factoryt(
+    variable_sensitivity_object_factory_ptrt object_factory
+  ) : vs_object_factory(object_factory) {
+  }
+
+private:
+  variable_sensitivity_object_factory_ptrt vs_object_factory;
 };
 
 #ifdef ENABLE_STATS

--- a/src/analyses/variable-sensitivity/variable_sensitivity_domain.h
+++ b/src/analyses/variable-sensitivity/variable_sensitivity_domain.h
@@ -78,8 +78,6 @@ std::shared_ptr<variable_sensitivity_object_factoryt>;
 class variable_sensitivity_domaint : public ai_domain_baset
 {
 public:
-  variable_sensitivity_domaint() { }
-
   explicit variable_sensitivity_domaint(
     variable_sensitivity_object_factory_ptrt _object_factory) {
   }
@@ -222,11 +220,14 @@ public:
 #endif
 };
 
-class variable_sensitivity_domain_factoryt
-  : public ai_domain_factory_default_constructort<variable_sensitivity_domaint>
+template<>
+class ai_domain_factory_default_constructort<variable_sensitivity_domaint>
+  : public ai_domain_factoryt<variable_sensitivity_domaint>
 {
 public:
-  explicit variable_sensitivity_domain_factoryt(
+  ai_domain_factory_default_constructort() = delete;
+
+  explicit ai_domain_factory_default_constructort(
     variable_sensitivity_object_factory_ptrt _object_factory)
   : object_factory(_object_factory) {
   }
@@ -241,6 +242,9 @@ public:
 private:
   variable_sensitivity_object_factory_ptrt object_factory;
 };
+
+using variable_sensitivity_domain_factoryt =
+  ai_domain_factory_default_constructort<variable_sensitivity_domaint>;
 
 #ifdef ENABLE_STATS
 template <>

--- a/src/analyses/variable-sensitivity/variable_sensitivity_object_factory.cpp
+++ b/src/analyses/variable-sensitivity/variable_sensitivity_object_factory.cpp
@@ -10,9 +10,6 @@
 #include "util/namespace.h"
 #include "value_set_abstract_value.h"
 
-variable_sensitivity_object_factoryt
-  variable_sensitivity_object_factoryt::s_instance;
-
 variable_sensitivity_object_factoryt::ABSTRACT_OBJECT_TYPET
 variable_sensitivity_object_factoryt::get_abstract_object_type(const typet type)
 {
@@ -142,11 +139,4 @@ variable_sensitivity_object_factoryt::get_abstract_object(
     return initialize_abstract_object<abstract_objectt>(
       followed_type, top, bottom, e, environment, ns);
   }
-}
-
-void variable_sensitivity_object_factoryt::set_options(
-  const vsd_configt &options)
-{
-  this->configuration = options;
-  initialized = true;
 }

--- a/src/analyses/variable-sensitivity/variable_sensitivity_object_factory.h
+++ b/src/analyses/variable-sensitivity/variable_sensitivity_object_factory.h
@@ -122,10 +122,14 @@ struct vsd_configt
   }
 };
 
+class variable_sensitivity_object_factoryt;
+using variable_sensitivity_object_factory_ptrt =
+std::shared_ptr<variable_sensitivity_object_factoryt>;
+
 class variable_sensitivity_object_factoryt
 {
 public:
-  static std::shared_ptr<variable_sensitivity_object_factoryt> configured_with(
+  static variable_sensitivity_object_factory_ptrt configured_with(
     const vsd_configt &options) {
     return std::make_shared<variable_sensitivity_object_factoryt>(options);
   }

--- a/src/analyses/variable-sensitivity/variable_sensitivity_object_factory.h
+++ b/src/analyses/variable-sensitivity/variable_sensitivity_object_factory.h
@@ -124,19 +124,20 @@ struct vsd_configt
 
 class variable_sensitivity_object_factoryt;
 using variable_sensitivity_object_factory_ptrt =
-std::shared_ptr<variable_sensitivity_object_factoryt>;
+  std::shared_ptr<variable_sensitivity_object_factoryt>;
 
 class variable_sensitivity_object_factoryt
 {
 public:
-  static variable_sensitivity_object_factory_ptrt configured_with(
-    const vsd_configt &options) {
+  static variable_sensitivity_object_factory_ptrt
+  configured_with(const vsd_configt &options)
+  {
     return std::make_shared<variable_sensitivity_object_factoryt>(options);
   }
 
   explicit variable_sensitivity_object_factoryt(const vsd_configt &options)
-    : configuration(options),
-      initialized(true) {
+    : configuration(options), initialized(true)
+  {
   }
 
   /// Get the appropriate abstract object for the variable under

--- a/src/analyses/variable-sensitivity/variable_sensitivity_object_factory.h
+++ b/src/analyses/variable-sensitivity/variable_sensitivity_object_factory.h
@@ -125,14 +125,14 @@ struct vsd_configt
 class variable_sensitivity_object_factoryt
 {
 public:
+  static std::shared_ptr<variable_sensitivity_object_factoryt> configured_with(
+    const vsd_configt &options) {
+    return std::make_shared<variable_sensitivity_object_factoryt>(options);
+  }
+
   explicit variable_sensitivity_object_factoryt(const vsd_configt &options)
     : configuration(options),
       initialized(true) {
-  }
-
-  static variable_sensitivity_object_factoryt &instance()
-  {
-    return s_instance;
   }
 
   /// Get the appropriate abstract object for the variable under
@@ -157,17 +157,11 @@ public:
     const abstract_environmentt &environment,
     const namespacet &ns);
 
-  /// Called once to record the appropriate variables from the command line
-  /// options so that they can be accessed easily when they are needed.
-  ///
-  /// \param options: the command line options
-  void set_options(const vsd_configt &options);
-
 private:
   variable_sensitivity_object_factoryt() : initialized(false)
   {
   }
-  static variable_sensitivity_object_factoryt s_instance;
+
   enum ABSTRACT_OBJECT_TYPET
   {
     TWO_VALUE,

--- a/src/analyses/variable-sensitivity/variable_sensitivity_object_factory.h
+++ b/src/analyses/variable-sensitivity/variable_sensitivity_object_factory.h
@@ -125,6 +125,11 @@ struct vsd_configt
 class variable_sensitivity_object_factoryt
 {
 public:
+  explicit variable_sensitivity_object_factoryt(const vsd_configt &options)
+    : configuration(options),
+      initialized(true) {
+  }
+
   static variable_sensitivity_object_factoryt &instance()
   {
     return s_instance;

--- a/src/goto-analyzer/goto_analyzer_parse_options.cpp
+++ b/src/goto-analyzer/goto_analyzer_parse_options.cpp
@@ -447,7 +447,8 @@ ai_baset *goto_analyzer_parse_optionst::build_analyzer(
   const namespacet &ns)
 {
   auto vsd_config = vsd_configt::from_options(options);
-  auto vs_object_factory = variable_sensitivity_object_factoryt::configured_with(vsd_config);
+  auto vs_object_factory =
+    variable_sensitivity_object_factoryt::configured_with(vsd_config);
 
   // These support all of the option categories
   if(
@@ -488,8 +489,8 @@ ai_baset *goto_analyzer_parse_optionst::build_analyzer(
     }
     else if(options.get_bool_option("vsd"))
     {
-      df = util_make_unique<
-        variable_sensitivity_domain_factoryt>(vs_object_factory);
+      df = util_make_unique<variable_sensitivity_domain_factoryt>(
+        vs_object_factory);
     }
     // non-null is not fully supported, despite the historical options
     // dependency-graph is quite heavily tied to the legacy-ait infrastructure
@@ -544,7 +545,8 @@ ai_baset *goto_analyzer_parse_optionst::build_analyzer(
     }
     else if(options.get_bool_option("vsd"))
     {
-      auto df = util_make_unique<variable_sensitivity_domain_factoryt>(vs_object_factory);
+      auto df = util_make_unique<variable_sensitivity_domain_factoryt>(
+        vs_object_factory);
       return new ait<variable_sensitivity_domaint>(std::move(df));
     }
     else if(options.get_bool_option("intervals"))

--- a/src/goto-analyzer/goto_analyzer_parse_options.cpp
+++ b/src/goto-analyzer/goto_analyzer_parse_options.cpp
@@ -771,16 +771,16 @@ int goto_analyzer_parse_optionst::perform_analysis(const optionst &options)
   if(options.get_bool_option("general-analysis"))
   {
     // TODO : replace with the domain factory infrastructure
-    try
-    {
-      variable_sensitivity_object_factoryt::instance().set_options(
-        vsd_configt::from_options(options));
-    }
-    catch(const invalid_command_line_argument_exceptiont &e)
-    {
-      log.error() << e.what() << messaget::eom;
-      return CPROVER_EXIT_USAGE_ERROR;
-    }
+    //try
+    //{
+    //  variable_sensitivity_object_factoryt::instance().set_options(
+    //    vsd_configt::from_options(options));
+    //}
+    //catch(const invalid_command_line_argument_exceptiont &e)
+    //{
+    //  log.error() << e.what() << messaget::eom;
+    //  return CPROVER_EXIT_USAGE_ERROR;
+    //}
 
     // Output file factory
     const std::string outfile=options.get_option("outfile");

--- a/src/goto-analyzer/goto_analyzer_parse_options.cpp
+++ b/src/goto-analyzer/goto_analyzer_parse_options.cpp
@@ -540,8 +540,12 @@ ai_baset *goto_analyzer_parse_optionst::build_analyzer(
     }
     else if(options.get_bool_option("dependence-graph-vs"))
     {
+      auto vsd_config = vsd_configt::from_options(options);
+      auto vs_object_factory =
+        std::make_shared<variable_sensitivity_object_factoryt>(vsd_config);
+
       return new variable_sensitivity_dependence_grapht(
-        goto_model.goto_functions, ns);
+        goto_model.goto_functions, ns, vs_object_factory);
     }
     else if(options.get_bool_option("vsd"))
     {

--- a/src/goto-analyzer/goto_analyzer_parse_options.cpp
+++ b/src/goto-analyzer/goto_analyzer_parse_options.cpp
@@ -485,8 +485,12 @@ ai_baset *goto_analyzer_parse_optionst::build_analyzer(
     }
     else if(options.get_bool_option("vsd"))
     {
+      auto vsd_config = vsd_configt::from_options(options);
+      auto vs_object_factory =
+        std::make_shared<variable_sensitivity_object_factoryt>(vsd_config);
+
       df = util_make_unique<
-        variable_sensitivity_domain_factoryt>();
+        variable_sensitivity_domain_factoryt>(vs_object_factory);
     }
     // non-null is not fully supported, despite the historical options
     // dependency-graph is quite heavily tied to the legacy-ait infrastructure
@@ -541,7 +545,11 @@ ai_baset *goto_analyzer_parse_optionst::build_analyzer(
     }
     else if(options.get_bool_option("vsd"))
     {
-      auto df = util_make_unique<variable_sensitivity_domain_factoryt>();
+      auto vsd_config = vsd_configt::from_options(options);
+      auto vs_object_factory =
+        std::make_shared<variable_sensitivity_object_factoryt>(vsd_config);
+
+      auto df = util_make_unique<variable_sensitivity_domain_factoryt>(vs_object_factory);
       return new ait<variable_sensitivity_domaint>(std::move(df));
     }
     else if(options.get_bool_option("intervals"))

--- a/src/goto-analyzer/goto_analyzer_parse_options.cpp
+++ b/src/goto-analyzer/goto_analyzer_parse_options.cpp
@@ -486,7 +486,7 @@ ai_baset *goto_analyzer_parse_optionst::build_analyzer(
     else if(options.get_bool_option("vsd"))
     {
       df = util_make_unique<
-        ai_domain_factory_default_constructort<variable_sensitivity_domaint>>();
+        variable_sensitivity_domain_factoryt>();
     }
     // non-null is not fully supported, despite the historical options
     // dependency-graph is quite heavily tied to the legacy-ait infrastructure
@@ -541,7 +541,8 @@ ai_baset *goto_analyzer_parse_optionst::build_analyzer(
     }
     else if(options.get_bool_option("vsd"))
     {
-      return new ait<variable_sensitivity_domaint>();
+      auto df = util_make_unique<variable_sensitivity_domain_factoryt>();
+      return new ait<variable_sensitivity_domaint>(std::move(df));
     }
     else if(options.get_bool_option("intervals"))
     {
@@ -628,7 +629,6 @@ int goto_analyzer_parse_optionst::doit()
 
   return perform_analysis(options);
 }
-
 
 /// Depending on the command line mode, run one of the analysis tasks
 int goto_analyzer_parse_optionst::perform_analysis(const optionst &options)
@@ -861,7 +861,6 @@ int goto_analyzer_parse_optionst::perform_analysis(const optionst &options)
     return result ?
       CPROVER_EXIT_VERIFICATION_UNSAFE : CPROVER_EXIT_VERIFICATION_SAFE;
   }
-
 
   // Final defensive error case
   log.error() << "no analysis option given -- consider reading --help"

--- a/unit/analyses/variable-sensitivity/constant_abstract_value/merge.cpp
+++ b/unit/analyses/variable-sensitivity/constant_abstract_value/merge.cpp
@@ -30,7 +30,7 @@ SCENARIO(
 
     auto object_factory = variable_sensitivity_object_factoryt::configured_with(
       vsd_configt::constant_domain());
-    abstract_environmentt enviroment { object_factory };
+    abstract_environmentt enviroment{object_factory};
     enviroment.make_top();
     symbol_tablet symbol_table;
     namespacet ns(symbol_table);

--- a/unit/analyses/variable-sensitivity/constant_abstract_value/merge.cpp
+++ b/unit/analyses/variable-sensitivity/constant_abstract_value/merge.cpp
@@ -9,6 +9,7 @@
 #include <analyses/variable-sensitivity/abstract_enviroment.h>
 #include <analyses/variable-sensitivity/abstract_object.h>
 #include <analyses/variable-sensitivity/constant_abstract_value.h>
+#include <analyses/variable-sensitivity/variable_sensitivity_object_factory.h>
 #include <testing-utils/use_catch.h>
 #include <typeinfo>
 #include <util/arith_tools.h>
@@ -27,7 +28,9 @@ SCENARIO(
     const exprt val1 = from_integer(1, integer_typet());
     const exprt val2 = from_integer(2, integer_typet());
 
-    abstract_environmentt enviroment;
+    auto object_factory = variable_sensitivity_object_factoryt::configured_with(
+      vsd_configt::constant_domain());
+    abstract_environmentt enviroment { object_factory };
     enviroment.make_top();
     symbol_tablet symbol_table;
     namespacet ns(symbol_table);

--- a/unit/analyses/variable-sensitivity/constant_array_abstract_object/merge.cpp
+++ b/unit/analyses/variable-sensitivity/constant_array_abstract_object/merge.cpp
@@ -101,13 +101,12 @@ SCENARIO(
     const index_exprt i2 =
       index_exprt(nil_exprt(), from_integer(2, integer_typet()));
 
-    abstract_environmentt enviroment;
+    auto object_factory = variable_sensitivity_object_factoryt::configured_with(
+      vsd_configt::constant_domain());
+    abstract_environmentt enviroment(object_factory);
     enviroment.make_top();
     symbol_tablet symbol_table;
     namespacet ns(symbol_table);
-
-    variable_sensitivity_object_factoryt::instance().set_options(
-      vsd_configt::constant_domain());
 
     array_utilt util(enviroment, ns);
 

--- a/unit/analyses/variable-sensitivity/eval.cpp
+++ b/unit/analyses/variable-sensitivity/eval.cpp
@@ -21,9 +21,9 @@ SCENARIO(
 {
   GIVEN("An environment with intervals domain")
   {
-    variable_sensitivity_object_factoryt::instance().set_options(
+    auto object_factory = variable_sensitivity_object_factoryt::configured_with(
       vsd_configt::intervals());
-    abstract_environmentt environment;
+    abstract_environmentt environment(object_factory);
     environment.make_top(); // Domains are bottom on construction
 
     symbol_tablet symbol_table;
@@ -68,7 +68,7 @@ SCENARIO(
         // b1 = 0
         environment.assign(
           b1.symbol_expr(),
-          variable_sensitivity_object_factoryt::instance().get_abstract_object(
+          object_factory->get_abstract_object(
             number_type,
             false,
             false,

--- a/unit/analyses/variable-sensitivity/full_struct_abstract_object/merge.cpp
+++ b/unit/analyses/variable-sensitivity/full_struct_abstract_object/merge.cpp
@@ -128,13 +128,12 @@ SCENARIO(
     const member_exprt b(nil_exprt(), "b", integer_typet());
     const member_exprt c(nil_exprt(), "c", integer_typet());
 
-    abstract_environmentt enviroment;
+    auto object_factory = variable_sensitivity_object_factoryt::configured_with(
+      vsd_configt::constant_domain());
+    abstract_environmentt enviroment(object_factory);
     enviroment.make_top();
     symbol_tablet symbol_table;
     namespacet ns(symbol_table);
-
-    variable_sensitivity_object_factoryt::instance().set_options(
-      vsd_configt::constant_domain());
 
     struct_utilt util(enviroment, ns);
 

--- a/unit/analyses/variable-sensitivity/interval_abstract_value/meet.cpp
+++ b/unit/analyses/variable-sensitivity/interval_abstract_value/meet.cpp
@@ -46,7 +46,7 @@ SCENARIO(
     auto object_factory = variable_sensitivity_object_factoryt::configured_with(
       vsd_configt::intervals());
 
-    abstract_environmentt enviroment { object_factory };
+    abstract_environmentt enviroment{object_factory};
     enviroment.make_top();
     symbol_tablet symbol_table;
     namespacet ns(symbol_table);

--- a/unit/analyses/variable-sensitivity/interval_abstract_value/meet.cpp
+++ b/unit/analyses/variable-sensitivity/interval_abstract_value/meet.cpp
@@ -11,6 +11,7 @@
 #include <analyses/variable-sensitivity/abstract_enviroment.h>
 #include <analyses/variable-sensitivity/abstract_object.h>
 #include <analyses/variable-sensitivity/interval_abstract_value.h>
+#include <analyses/variable-sensitivity/variable_sensitivity_object_factory.h>
 
 SCENARIO(
   "meet_interval_abstract_value",
@@ -42,7 +43,10 @@ SCENARIO(
     const auto x_ge_max = binary_relation_exprt(varx, ID_ge, max_value);
     const auto x_gt_max = binary_relation_exprt(varx, ID_gt, max_value);
 
-    abstract_environmentt enviroment;
+    auto object_factory = variable_sensitivity_object_factoryt::configured_with(
+      vsd_configt::intervals());
+
+    abstract_environmentt enviroment { object_factory };
     enviroment.make_top();
     symbol_tablet symbol_table;
     namespacet ns(symbol_table);

--- a/unit/analyses/variable-sensitivity/last_written_location.cpp
+++ b/unit/analyses/variable-sensitivity/last_written_location.cpp
@@ -34,6 +34,9 @@ SCENARIO(
   "symbols",
   "[core][analyses][variable-sensitivity][last-written-location]")
 {
+  auto object_factory = variable_sensitivity_object_factoryt::configured_with(
+    vsd_configt::constant_domain());
+
   GIVEN("Two identifiers that contain integer values")
   {
     const irep_idt identifier = "hello";
@@ -54,12 +57,9 @@ SCENARIO(
     symbol_table.add(second_sym);
     namespacet ns(symbol_table);
 
-    variable_sensitivity_object_factoryt::instance().set_options(
-      vsd_configt::constant_domain());
-
     WHEN("The identifiers get inserted into two environments")
     {
-      abstract_environmentt env;
+      abstract_environmentt env(object_factory);
 
       auto first_eval_rhs = env.eval(rhs_val, ns);
       auto first_eval_res = env.eval(first_val, ns);
@@ -71,7 +71,7 @@ SCENARIO(
       env.assign(first_val, first_eval_rhs, ns);
       env.assign(second_val, second_eval_rhs, ns);
 
-      abstract_environmentt second_env;
+      abstract_environmentt second_env(object_factory);
       second_env.assign(first_val, first_eval_rhs, ns);
       second_env.assign(second_val, second_eval_rhs, ns);
 
@@ -107,7 +107,7 @@ SCENARIO(
       "The identifiers get inserted into two environments, but one of "
       "them has a different value in one of the environments")
     {
-      abstract_environmentt env;
+      abstract_environmentt env(object_factory);
 
       auto first_eval_rhs = env.eval(rhs_val, ns);
       auto first_eval_res = env.eval(first_val, ns);
@@ -121,7 +121,7 @@ SCENARIO(
 
       auto rhs_val_3 = from_integer(20, integer_typet());
 
-      abstract_environmentt second_env;
+      abstract_environmentt second_env(object_factory);
       auto new_rhs_val = second_env.eval(rhs_val_3, ns);
       second_env.assign(first_val, first_eval_rhs, ns);
       second_env.assign(second_val, new_rhs_val, ns);

--- a/unit/analyses/variable-sensitivity/value_set/abstract_value.cpp
+++ b/unit/analyses/variable-sensitivity/value_set/abstract_value.cpp
@@ -67,6 +67,16 @@ public:
 };
 } // namespace
 
+std::unique_ptr<variable_sensitivity_domain_factoryt> domain_factory()
+{
+  auto vs_object_factory =
+    std::make_shared<variable_sensitivity_object_factoryt>(vsd_configt {});
+
+  return
+    util_make_unique<variable_sensitivity_domain_factoryt>(vs_object_factory);
+}
+
+
 TEST_CASE(
   "A value set abstract object created from type is top",
   VALUE_SET_TEST_TAGS)
@@ -257,9 +267,11 @@ TEST_CASE(
   auto const value_set =
     value_set_abstract_valuet{type, value_set_abstract_valuet::valuest{}};
 
+  const ait<variable_sensitivity_domaint> ai { domain_factory() };
+
   std::stringstream ss;
   value_set.output(
-    ss, ait<variable_sensitivity_domaint>{}, namespacet{symbol_tablet{}});
+    ss, ai, namespacet{symbol_tablet{}});
   REQUIRE(ss.str() == "BOTTOM");
 }
 
@@ -271,9 +283,11 @@ TEST_CASE(
   auto const value = from_integer(10, type);
   auto const value_set = value_set_abstract_valuet{type, {value}};
 
+  const ait<variable_sensitivity_domaint> ai { domain_factory() };
+
   std::stringstream ss;
   value_set.output(
-    ss, ait<variable_sensitivity_domaint>{}, namespacet{symbol_tablet{}});
+    ss, ai, namespacet{symbol_tablet{}});
   REQUIRE(ss.str() == "{ 10 }");
 }
 
@@ -289,9 +303,11 @@ TEST_CASE(
   auto const value_set =
     value_set_abstract_valuet{type, {value1, value2, value3}};
 
+  const ait<variable_sensitivity_domaint> ai { domain_factory() };
+
   std::stringstream ss;
   value_set.output(
-    ss, ait<variable_sensitivity_domaint>{}, namespacet{symbol_tablet{}});
+    ss, ai, namespacet{symbol_tablet{}});
   REQUIRE(ss.str() == "{ 10 12 14 }");
 }
 
@@ -310,9 +326,11 @@ TEST_CASE(
   auto const value_set = value_set_abstract_valuet{type, values};
   REQUIRE(value_set.is_top());
 
+  const ait<variable_sensitivity_domaint> ai { domain_factory() };
+
   std::stringstream ss;
   value_set.output(
-    ss, ait<variable_sensitivity_domaint>{}, namespacet{symbol_tablet{}});
+    ss, ai, namespacet{symbol_tablet{}});
   REQUIRE(ss.str() == "TOP");
 }
 
@@ -368,8 +386,8 @@ static abstract_environmentt get_value_set_abstract_environment()
   config.advanced_sensitivities.new_value_set = true;
   config.context_tracking.data_dependency_context = false;
   config.context_tracking.last_write_context = false;
-  variable_sensitivity_object_factoryt::instance().set_options(config);
-  auto environment = abstract_environmentt{};
+  auto object_factory = variable_sensitivity_object_factoryt::configured_with(config);
+  auto environment = abstract_environmentt { object_factory };
   environment.make_top();
   return environment;
 }

--- a/unit/analyses/variable-sensitivity/value_set/abstract_value.cpp
+++ b/unit/analyses/variable-sensitivity/value_set/abstract_value.cpp
@@ -70,12 +70,11 @@ public:
 std::unique_ptr<variable_sensitivity_domain_factoryt> domain_factory()
 {
   auto vs_object_factory =
-    std::make_shared<variable_sensitivity_object_factoryt>(vsd_configt {});
+    std::make_shared<variable_sensitivity_object_factoryt>(vsd_configt{});
 
-  return
-    util_make_unique<variable_sensitivity_domain_factoryt>(vs_object_factory);
+  return util_make_unique<variable_sensitivity_domain_factoryt>(
+    vs_object_factory);
 }
-
 
 TEST_CASE(
   "A value set abstract object created from type is top",
@@ -267,11 +266,10 @@ TEST_CASE(
   auto const value_set =
     value_set_abstract_valuet{type, value_set_abstract_valuet::valuest{}};
 
-  const ait<variable_sensitivity_domaint> ai { domain_factory() };
+  const ait<variable_sensitivity_domaint> ai{domain_factory()};
 
   std::stringstream ss;
-  value_set.output(
-    ss, ai, namespacet{symbol_tablet{}});
+  value_set.output(ss, ai, namespacet{symbol_tablet{}});
   REQUIRE(ss.str() == "BOTTOM");
 }
 
@@ -283,11 +281,10 @@ TEST_CASE(
   auto const value = from_integer(10, type);
   auto const value_set = value_set_abstract_valuet{type, {value}};
 
-  const ait<variable_sensitivity_domaint> ai { domain_factory() };
+  const ait<variable_sensitivity_domaint> ai{domain_factory()};
 
   std::stringstream ss;
-  value_set.output(
-    ss, ai, namespacet{symbol_tablet{}});
+  value_set.output(ss, ai, namespacet{symbol_tablet{}});
   REQUIRE(ss.str() == "{ 10 }");
 }
 
@@ -303,11 +300,10 @@ TEST_CASE(
   auto const value_set =
     value_set_abstract_valuet{type, {value1, value2, value3}};
 
-  const ait<variable_sensitivity_domaint> ai { domain_factory() };
+  const ait<variable_sensitivity_domaint> ai{domain_factory()};
 
   std::stringstream ss;
-  value_set.output(
-    ss, ai, namespacet{symbol_tablet{}});
+  value_set.output(ss, ai, namespacet{symbol_tablet{}});
   REQUIRE(ss.str() == "{ 10 12 14 }");
 }
 
@@ -326,11 +322,10 @@ TEST_CASE(
   auto const value_set = value_set_abstract_valuet{type, values};
   REQUIRE(value_set.is_top());
 
-  const ait<variable_sensitivity_domaint> ai { domain_factory() };
+  const ait<variable_sensitivity_domaint> ai{domain_factory()};
 
   std::stringstream ss;
-  value_set.output(
-    ss, ai, namespacet{symbol_tablet{}});
+  value_set.output(ss, ai, namespacet{symbol_tablet{}});
   REQUIRE(ss.str() == "TOP");
 }
 
@@ -386,8 +381,9 @@ static abstract_environmentt get_value_set_abstract_environment()
   config.advanced_sensitivities.new_value_set = true;
   config.context_tracking.data_dependency_context = false;
   config.context_tracking.last_write_context = false;
-  auto object_factory = variable_sensitivity_object_factoryt::configured_with(config);
-  auto environment = abstract_environmentt { object_factory };
+  auto object_factory =
+    variable_sensitivity_object_factoryt::configured_with(config);
+  auto environment = abstract_environmentt{object_factory};
   environment.make_top();
   return environment;
 }


### PR DESCRIPTION
This PR removes the variable_sensitivity_object_factoryt static instance. 

Now, a configured variable_sensitivity_object_factoryt instance is passed into the variable_sensitivity_domain_factoryt, which in turn passes down into the variable_sensitivity_domaint objects it creates. Those pass the object factory to their abstract_environments and, finally, they use the factory to
build the objects they need.

The variable_sensitivity_object_factoryt are created and passed as shared pointers.
