### PR TITLE
Fix parallelism configuration for Windows build actions

### DIFF
--- a/.github/workflows/pull-request-checks.yaml
+++ b/.github/workflows/pull-request-checks.yaml
@@ -274,7 +274,7 @@ jobs:
       - name: Build Release
         run: |
           Set-Location build
-          cmake --build . --config Release -- /p:CL_MPcount=2 /p:CLToolExe=clcache
+          cmake --build . --config Release -- /p:UseMultiToolTask=true /p:CLToolExe=clcache
       - name: Print ccache stats
         run: clcache -s
       - name: Create packages

--- a/.github/workflows/release-packages.yaml
+++ b/.github/workflows/release-packages.yaml
@@ -170,7 +170,7 @@ jobs:
       - name: Build Release
         run: |
           Set-Location build
-          cmake --build . --config Release -j2 -- /p:CLToolExe=clcache
+          cmake --build . --config Release -- /p:UseMultiToolTask=true /p:CLToolExe=clcache
       - name: Print ccache stats
         run: clcache -s
       - name: Create packages

--- a/.github/workflows/vs2019/build-cbmc.bat
+++ b/.github/workflows/vs2019/build-cbmc.bat
@@ -19,4 +19,4 @@ echo "Configure CBMC with cmake"
 cmake -S. -Bbuild
 
 echo "Build CBMC with cmake"
-cmake --build build --config Release -- /p:CL_MPcount=2
+cmake --build build --config Release -- /p:UseMultiToolTask=true


### PR DESCRIPTION
It seems that overriding CL_MPCount did not work. Following
https://devblogs.microsoft.com/cppblog/improved-parallelism-in-msbuild/,
UseMultiToolTask appears to reduce the build time from 34 to 28 minutes.

See also https://gitlab.kitware.com/cmake/cmake/-/issues/20564.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- n/a Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [x] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
