### PR TITLE
Visual Studio 16.8 has different floating point precision

### DIFF
--- a/jbmc/unit/java_bytecode/expr2java.cpp
+++ b/jbmc/unit/java_bytecode/expr2java.cpp
@@ -99,6 +99,10 @@ TEST_CASE(
 #ifndef _MSC_VER
     REQUIRE(
       floating_point_to_java_string(value) == "0x1p+37f /* 1.37439e+11 */");
+#elif _MSC_VER >= 1928
+    REQUIRE(
+      floating_point_to_java_string(value) ==
+      "0x1.0000000000000p+37f /* 1.37439e+11 */");
 #else
     REQUIRE(
       floating_point_to_java_string(value) ==
@@ -112,6 +116,10 @@ TEST_CASE(
 #ifndef _MSC_VER
     REQUIRE(
       floating_point_to_java_string(value) == "0x1p+37 /* 1.37439e+11 */");
+#elif _MSC_VER >= 1928
+    REQUIRE(
+      floating_point_to_java_string(value) ==
+      "0x1.0000000000000p+37 /* 1.37439e+11 */");
 #else
     REQUIRE(
       floating_point_to_java_string(value) ==


### PR DESCRIPTION
GitHub action runners now feature Visual Studio 16.8.1 (previously:
16.7). According to its STL changelog, this update includes the
following change:

https://github.com/microsoft/STL/pull/1173#pullrequestreview-471077335

Therefore update the unit test to expect 13 trailing zeros.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
