### PR TITLE
remove_const_function_pointerst isn't a messaget

### DIFF
--- a/src/goto-programs/remove_const_function_pointers.cpp
+++ b/src/goto-programs/remove_const_function_pointers.cpp
@@ -19,12 +19,12 @@ Author: Thomas Kiley, thomas.kiley@diffblue.com
 
 #include "goto_functions.h"
 
-#define LOG(message, irep) \
-  do { \
-    debug().source_location = irep.source_location(); \
-    debug() << message << ": " << format(irep) << eom; \
-  } \
-  while(0)
+#define LOG(message, irep)                                                     \
+  do                                                                           \
+  {                                                                            \
+    log.debug().source_location = irep.source_location();                      \
+    log.debug() << message << ": " << format(irep) << messaget::eom;           \
+  } while(0)
 
 /// To take a function call on a function pointer, and if possible resolve it to
 /// a small collection of possible values.
@@ -34,10 +34,8 @@ Author: Thomas Kiley, thomas.kiley@diffblue.com
 remove_const_function_pointerst::remove_const_function_pointerst(
   message_handlert &message_handler,
   const namespacet &ns,
-  const symbol_tablet &symbol_table):
-    messaget(message_handler),
-    ns(ns),
-    symbol_table(symbol_table)
+  const symbol_tablet &symbol_table)
+  : log(message_handler), ns(ns), symbol_table(symbol_table)
 {}
 
 /// To take a function call on a function pointer, and if possible resolve it to

--- a/src/goto-programs/remove_const_function_pointers.h
+++ b/src/goto-programs/remove_const_function_pointers.h
@@ -29,7 +29,7 @@ class symbol_exprt;
 class symbol_tablet;
 class typecast_exprt;
 
-class remove_const_function_pointerst:public messaget
+class remove_const_function_pointerst
 {
 public:
   typedef std::unordered_set<symbol_exprt, irep_hash> functionst;
@@ -101,6 +101,7 @@ private:
   exprt get_component_value(
     const struct_exprt &struct_expr, const member_exprt &member_expr);
 
+  messaget log;
   const namespacet &ns;
   const symbol_tablet &symbol_table;
 };


### PR DESCRIPTION
Use a messaget member instead as there is no is-a relationship between
remove_const_function_pointerst and messaget.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
