### PR TITLE
Remove {f,F}orall_goto_functions

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -30,8 +30,6 @@ DerivePointerAlignment: 'false'
 DisableFormat: 'false'
 ExperimentalAutoDetectBinPacking: 'false'
 ForEachMacros: [
-  'forall_goto_functions',
-  'Forall_goto_functions',
   'forall_goto_program_instructions',
   'Forall_goto_program_instructions',
   'forall_operands',

--- a/jbmc/src/janalyzer/janalyzer_parse_options.cpp
+++ b/jbmc/src/janalyzer/janalyzer_parse_options.cpp
@@ -558,13 +558,13 @@ int janalyzer_parse_optionst::perform_analysis(
   {
     namespacet ns(goto_model.symbol_table);
 
-    forall_goto_functions(it, goto_model.goto_functions)
+    for(const auto &gf_entry : goto_model.goto_functions.function_map)
     {
       std::cout << ">>>>\n";
-      std::cout << ">>>> " << it->first << '\n';
+      std::cout << ">>>> " << gf_entry.first << '\n';
       std::cout << ">>>>\n";
-      local_may_aliast local_may_alias(it->second);
-      local_may_alias.output(std::cout, it->second, ns);
+      local_may_aliast local_may_alias(gf_entry.second);
+      local_may_alias.output(std::cout, gf_entry.second, ns);
       std::cout << '\n';
     }
 

--- a/jbmc/src/java_bytecode/remove_exceptions.cpp
+++ b/jbmc/src/java_bytecode/remove_exceptions.cpp
@@ -619,8 +619,8 @@ void remove_exceptionst::instrument_exceptions(
 
 void remove_exceptionst::operator()(goto_functionst &goto_functions)
 {
-  Forall_goto_functions(it, goto_functions)
-    instrument_exceptions(it->first, it->second.body);
+  for(auto &gf_entry : goto_functions.function_map)
+    instrument_exceptions(gf_entry.first, gf_entry.second.body);
 }
 
 void remove_exceptionst::

--- a/jbmc/src/jdiff/java_syntactic_diff.cpp
+++ b/jbmc/src/jdiff/java_syntactic_diff.cpp
@@ -16,25 +16,25 @@ Author: Peter Schrammel
 
 bool java_syntactic_difft::operator()()
 {
-  forall_goto_functions(it, goto_model1.goto_functions)
+  for(const auto &gf_entry : goto_model1.goto_functions.function_map)
   {
-    if(!it->second.body_available())
+    if(!gf_entry.second.body_available())
       continue;
 
     goto_functionst::function_mapt::const_iterator f_it =
-      goto_model2.goto_functions.function_map.find(it->first);
+      goto_model2.goto_functions.function_map.find(gf_entry.first);
     if(
       f_it == goto_model2.goto_functions.function_map.end() ||
       !f_it->second.body_available())
     {
-      deleted_functions.insert(it->first);
+      deleted_functions.insert(gf_entry.first);
       continue;
     }
 
     // check access qualifiers
-    const symbolt *fun1 = goto_model1.symbol_table.lookup(it->first);
+    const symbolt *fun1 = goto_model1.symbol_table.lookup(gf_entry.first);
     CHECK_RETURN(fun1 != nullptr);
-    const symbolt *fun2 = goto_model2.symbol_table.lookup(it->first);
+    const symbolt *fun2 = goto_model2.symbol_table.lookup(gf_entry.first);
     CHECK_RETURN(fun2 != nullptr);
     const optionalt<irep_idt> class_name = declaring_class(*fun1);
     bool function_access_changed =
@@ -67,29 +67,29 @@ bool java_syntactic_difft::operator()()
     }
     if(function_access_changed || class_access_changed || field_access_changed)
     {
-      modified_functions.insert(it->first);
+      modified_functions.insert(gf_entry.first);
       continue;
     }
 
-    if(!it->second.body.equals(f_it->second.body))
+    if(!gf_entry.second.body.equals(f_it->second.body))
     {
-      modified_functions.insert(it->first);
+      modified_functions.insert(gf_entry.first);
       continue;
     }
   }
-  forall_goto_functions(it, goto_model2.goto_functions)
+  for(const auto &gf_entry : goto_model2.goto_functions.function_map)
   {
-    if(!it->second.body_available())
+    if(!gf_entry.second.body_available())
       continue;
 
     total_functions_count++;
 
     goto_functionst::function_mapt::const_iterator f_it =
-      goto_model1.goto_functions.function_map.find(it->first);
+      goto_model1.goto_functions.function_map.find(gf_entry.first);
     if(
       f_it == goto_model1.goto_functions.function_map.end() ||
       !f_it->second.body_available())
-      new_functions.insert(it->first);
+      new_functions.insert(gf_entry.first);
   }
 
   return !(

--- a/src/analyses/ai.cpp
+++ b/src/analyses/ai.cpp
@@ -24,16 +24,16 @@ void ai_baset::output(
   const goto_functionst &goto_functions,
   std::ostream &out) const
 {
-  forall_goto_functions(f_it, goto_functions)
+  for(const auto &gf_entry : goto_functions.function_map)
   {
-    if(f_it->second.body_available())
+    if(gf_entry.second.body_available())
     {
       out << "////\n";
-      out << "//// Function: " << f_it->first << "\n";
+      out << "//// Function: " << gf_entry.first << "\n";
       out << "////\n";
       out << "\n";
 
-      output(ns, f_it->first, f_it->second.body, out);
+      output(ns, gf_entry.first, gf_entry.second.body, out);
     }
   }
 }
@@ -64,16 +64,16 @@ jsont ai_baset::output_json(
 {
   json_objectt result;
 
-  forall_goto_functions(f_it, goto_functions)
+  for(const auto &gf_entry : goto_functions.function_map)
   {
-    if(f_it->second.body_available())
+    if(gf_entry.second.body_available())
     {
-      result[id2string(f_it->first)] =
-        output_json(ns, f_it->first, f_it->second.body);
+      result[id2string(gf_entry.first)] =
+        output_json(ns, gf_entry.first, gf_entry.second.body);
     }
     else
     {
-      result[id2string(f_it->first)]=json_arrayt();
+      result[id2string(gf_entry.first)] = json_arrayt();
     }
   }
 
@@ -111,17 +111,18 @@ xmlt ai_baset::output_xml(
 {
   xmlt program("program");
 
-  forall_goto_functions(f_it, goto_functions)
+  for(const auto &gf_entry : goto_functions.function_map)
   {
     xmlt function(
       "function",
-      {{"name", id2string(f_it->first)},
-       {"body_available", f_it->second.body_available() ? "true" : "false"}},
+      {{"name", id2string(gf_entry.first)},
+       {"body_available", gf_entry.second.body_available() ? "true" : "false"}},
       {});
 
-    if(f_it->second.body_available())
+    if(gf_entry.second.body_available())
     {
-      function.new_element(output_xml(ns, f_it->first, f_it->second.body));
+      function.new_element(
+        output_xml(ns, gf_entry.first, gf_entry.second.body));
     }
 
     program.new_element(function);
@@ -194,8 +195,8 @@ void ai_baset::initialize(const irep_idt &, const goto_programt &goto_program)
 
 void ai_baset::initialize(const goto_functionst &goto_functions)
 {
-  forall_goto_functions(it, goto_functions)
-    initialize(it->first, it->second);
+  for(const auto &gf_entry : goto_functions.function_map)
+    initialize(gf_entry.first, gf_entry.second);
 }
 
 void ai_baset::finalize()

--- a/src/analyses/ai.h
+++ b/src/analyses/ai.h
@@ -706,20 +706,23 @@ protected:
     typedef std::list<wl_entryt> thread_wlt;
     thread_wlt thread_wl;
 
-    forall_goto_functions(it, goto_functions)
-      forall_goto_program_instructions(t_it, it->second.body)
+    for(const auto &gf_entry : goto_functions.function_map)
+    {
+      forall_goto_program_instructions(t_it, gf_entry.second.body)
       {
         if(is_threaded(t_it))
         {
-          thread_wl.push_back(wl_entryt(it->first, it->second.body, t_it));
+          thread_wl.push_back(
+            wl_entryt(gf_entry.first, gf_entry.second.body, t_it));
 
           goto_programt::const_targett l_end =
-            it->second.body.instructions.end();
+            gf_entry.second.body.instructions.end();
           --l_end;
 
           merge_shared(shared_state, l_end, sh_target, ns);
         }
       }
+    }
 
     // now feed in the shared state into all concurrently executing
     // functions, and iterate until the shared state stabilizes

--- a/src/analyses/call_graph.cpp
+++ b/src/analyses/call_graph.cpp
@@ -39,10 +39,10 @@ call_grapht::call_grapht(
   const goto_functionst &goto_functions, bool collect_callsites):
   collect_callsites(collect_callsites)
 {
-  forall_goto_functions(f_it, goto_functions)
+  for(const auto &gf_entry : goto_functions.function_map)
   {
-    const irep_idt &function_name = f_it->first;
-    const goto_programt &body = f_it->second.body;
+    const irep_idt &function_name = gf_entry.first;
+    const goto_programt &body = gf_entry.second.body;
     nodes.insert(function_name);
     add(function_name, body);
   }

--- a/src/analyses/constant_propagator.cpp
+++ b/src/analyses/constant_propagator.cpp
@@ -741,8 +741,8 @@ void constant_propagator_ait::replace(
   goto_functionst &goto_functions,
   const namespacet &ns)
 {
-  Forall_goto_functions(f_it, goto_functions)
-    replace(f_it->second, ns);
+  for(auto &gf_entry : goto_functions.function_map)
+    replace(gf_entry.second, ns);
 }
 
 

--- a/src/analyses/custom_bitvector_analysis.cpp
+++ b/src/analyses/custom_bitvector_analysis.cpp
@@ -776,19 +776,19 @@ void custom_bitvector_analysist::check(
 {
   unsigned pass=0, fail=0, unknown=0;
 
-  forall_goto_functions(f_it, goto_model.goto_functions)
+  for(const auto &gf_entry : goto_model.goto_functions.function_map)
   {
-    if(!f_it->second.body.has_assertion())
-       continue;
+    if(!gf_entry.second.body.has_assertion())
+      continue;
 
     // TODO this is a hard-coded hack
-    if(f_it->first=="__actual_thread_spawn")
+    if(gf_entry.first == "__actual_thread_spawn")
       continue;
 
     if(!use_xml)
-      out << "******** Function " << f_it->first << '\n';
+      out << "******** Function " << gf_entry.first << '\n';
 
-    forall_goto_program_instructions(i_it, f_it->second.body)
+    forall_goto_program_instructions(i_it, gf_entry.second.body)
     {
       exprt result;
       irep_idt description;
@@ -836,7 +836,7 @@ void custom_bitvector_analysist::check(
           out << ", " << description;
         out << ": ";
         const namespacet ns(goto_model.symbol_table);
-        out << from_expr(ns, f_it->first, result);
+        out << from_expr(ns, gf_entry.first, result);
         out << '\n';
       }
 

--- a/src/analyses/dirty.h
+++ b/src/analyses/dirty.h
@@ -90,8 +90,8 @@ public:
   {
     // dirtyts should not be initialized twice
     PRECONDITION(!initialized);
-    forall_goto_functions(it, goto_functions)
-      build(it->second);
+    for(const auto &gf_entry : goto_functions.function_map)
+      build(gf_entry.second);
     initialized = true;
   }
 

--- a/src/analyses/escape_analysis.cpp
+++ b/src/analyses/escape_analysis.cpp
@@ -463,9 +463,9 @@ void escape_analysist::instrument(
 {
   const namespacet ns(goto_model.symbol_table);
 
-  Forall_goto_functions(f_it, goto_model.goto_functions)
+  for(auto &gf_entry : goto_model.goto_functions.function_map)
   {
-    Forall_goto_program_instructions(i_it, f_it->second.body)
+    Forall_goto_program_instructions(i_it, gf_entry.second.body)
     {
       get_state(i_it);
 
@@ -478,7 +478,12 @@ void escape_analysist::instrument(
         std::set<irep_idt> cleanup_functions;
         operator[](i_it).check_lhs(code_assign.lhs(), cleanup_functions);
         insert_cleanup(
-          f_it->second, i_it, code_assign.lhs(), cleanup_functions, false, ns);
+          gf_entry.second,
+          i_it,
+          code_assign.lhs(),
+          cleanup_functions,
+          false,
+          ns);
       }
       else if(instruction.type == DEAD)
       {
@@ -504,9 +509,14 @@ void escape_analysist::instrument(
         d.check_lhs(code_dead.symbol(), cleanup_functions2);
 
         insert_cleanup(
-          f_it->second, i_it, code_dead.symbol(), cleanup_functions1, true, ns);
+          gf_entry.second,
+          i_it,
+          code_dead.symbol(),
+          cleanup_functions1,
+          true,
+          ns);
         insert_cleanup(
-          f_it->second,
+          gf_entry.second,
           i_it,
           code_dead.symbol(),
           cleanup_functions2,

--- a/src/analyses/flow_insensitive_analysis.cpp
+++ b/src/analyses/flow_insensitive_analysis.cpp
@@ -60,11 +60,12 @@ void flow_insensitive_analysis_baset::output(
   const goto_functionst &goto_functions,
   std::ostream &out)
 {
-  forall_goto_functions(f_it, goto_functions)
+  for(const auto &gf_entry : goto_functions.function_map)
   {
-    out << "////\n" << "//// Function: " << f_it->first << "\n////\n\n";
+    out << "////\n"
+        << "//// Function: " << gf_entry.first << "\n////\n\n";
 
-    output(f_it->first, f_it->second.body, out);
+    output(gf_entry.first, gf_entry.second.body, out);
   }
 }
 
@@ -383,20 +384,14 @@ void flow_insensitive_analysis_baset::fixedpoint(
 {
   // do each function at least once
 
-  forall_goto_functions(it, goto_functions)
-    if(functions_done.find(it->first)==
-       functions_done.end())
+  for(const auto &gf_entry : goto_functions.function_map)
+  {
+    if(functions_done.find(gf_entry.first) == functions_done.end())
     {
-      fixedpoint(it, goto_functions);
+      functions_done.insert(gf_entry.first);
+      fixedpoint(gf_entry.first, gf_entry.second.body, goto_functions);
     }
-}
-
-bool flow_insensitive_analysis_baset::fixedpoint(
-  const goto_functionst::function_mapt::const_iterator it,
-  const goto_functionst &goto_functions)
-{
-  functions_done.insert(it->first);
-  return fixedpoint(it->first, it->second.body, goto_functions);
+  }
 }
 
 void flow_insensitive_analysis_baset::update(const goto_functionst &)

--- a/src/analyses/flow_insensitive_analysis.h
+++ b/src/analyses/flow_insensitive_analysis.h
@@ -172,10 +172,6 @@ protected:
     const goto_programt &goto_program,
     const goto_functionst &goto_functions);
 
-  bool fixedpoint(
-    goto_functionst::function_mapt::const_iterator it,
-    const goto_functionst &goto_functions);
-
   void fixedpoint(
     const goto_functionst &goto_functions);
 

--- a/src/analyses/goto_check.cpp
+++ b/src/analyses/goto_check.cpp
@@ -289,9 +289,9 @@ void goto_checkt::collect_allocations(
   if(!enable_pointer_check && !enable_bounds_check)
     return;
 
-  forall_goto_functions(itf, goto_functions)
+  for(const auto &gf_entry : goto_functions.function_map)
   {
-    for(const auto &instruction : itf->second.body.instructions)
+    for(const auto &instruction : gf_entry.second.body.instructions)
     {
       if(!instruction.is_function_call())
         continue;
@@ -2291,9 +2291,9 @@ void goto_check(
 
   goto_check.collect_allocations(goto_functions);
 
-  Forall_goto_functions(it, goto_functions)
+  for(auto &gf_entry : goto_functions.function_map)
   {
-    goto_check.goto_check(it->first, it->second);
+    goto_check.goto_check(gf_entry.first, gf_entry.second);
   }
 }
 

--- a/src/analyses/interval_analysis.cpp
+++ b/src/analyses/interval_analysis.cpp
@@ -93,6 +93,6 @@ void interval_analysis(goto_modelt &goto_model)
   const namespacet ns(goto_model.symbol_table);
   interval_analysis(goto_model.goto_functions, ns);
 
-  Forall_goto_functions(f_it, goto_model.goto_functions)
-    instrument_intervals(interval_analysis, f_it->second);
+  for(auto &gf_entry : goto_model.goto_functions.function_map)
+    instrument_intervals(interval_analysis, gf_entry.second);
 }

--- a/src/analyses/invariant_propagation.cpp
+++ b/src/analyses/invariant_propagation.cpp
@@ -160,13 +160,13 @@ void invariant_propagationt::add_objects(
   object_listt globals;
   get_globals(globals);
 
-  forall_goto_functions(f_it, goto_functions)
+  for(const auto &gf_entry : goto_functions.function_map)
   {
     // get the locals
     std::set<irep_idt> locals;
-    get_local_identifiers(f_it->second, locals);
+    get_local_identifiers(gf_entry.second, locals);
 
-    const goto_programt &goto_program=f_it->second.body;
+    const goto_programt &goto_program = gf_entry.second.body;
 
     // cache the list for the locals to speed things up
     typedef std::unordered_map<irep_idt, object_listt> object_cachet;
@@ -247,8 +247,8 @@ void invariant_propagationt::initialize(
 
 void invariant_propagationt::simplify(goto_functionst &goto_functions)
 {
-  Forall_goto_functions(it, goto_functions)
-    simplify(it->second.body);
+  for(auto &gf_entry : goto_functions.function_map)
+    simplify(gf_entry.second.body);
 }
 
 void invariant_propagationt::simplify(goto_programt &goto_program)

--- a/src/analyses/is_threaded.cpp
+++ b/src/analyses/is_threaded.cpp
@@ -105,11 +105,13 @@ void is_threadedt::compute(const goto_functionst &goto_functions)
 
   is_threaded_analysis(goto_functions, ns);
 
-  forall_goto_functions(f_it, goto_functions)
-    forall_goto_program_instructions(i_it, f_it->second.body)
+  for(const auto &gf_entry : goto_functions.function_map)
+  {
+    forall_goto_program_instructions(i_it, gf_entry.second.body)
     {
       auto domain_ptr = is_threaded_analysis.abstract_state_before(i_it);
       if(static_cast<const is_threaded_domaint &>(*domain_ptr).is_threaded)
         is_threaded_set.insert(i_it);
     }
+  }
 }

--- a/src/analyses/local_may_alias.h
+++ b/src/analyses/local_may_alias.h
@@ -103,9 +103,11 @@ public:
   {
     goto_functions=&_goto_functions;
 
-    forall_goto_functions(f_it, _goto_functions)
-      forall_goto_program_instructions(i_it, f_it->second.body)
-        target_map[i_it]=f_it->first;
+    for(const auto &gf_entry : _goto_functions.function_map)
+    {
+      forall_goto_program_instructions(i_it, gf_entry.second.body)
+        target_map[i_it] = gf_entry.first;
+    }
   }
 
   local_may_aliast &operator()(const irep_idt &fkt)

--- a/src/analyses/loop_analysis.h
+++ b/src/analyses/loop_analysis.h
@@ -199,12 +199,12 @@ void loop_analysist<T>::output(std::ostream &out) const
 template <class LoopAnalysis>
 void show_loops(const goto_modelt &goto_model, std::ostream &out)
 {
-  forall_goto_functions(it, goto_model.goto_functions)
+  for(const auto &gf_entry : goto_model.goto_functions.function_map)
   {
-    out << "*** " << it->first << '\n';
+    out << "*** " << gf_entry.first << '\n';
 
     LoopAnalysis loop_analysis;
-    loop_analysis(it->second.body);
+    loop_analysis(gf_entry.second.body);
     loop_analysis.output(out);
 
     out << '\n';

--- a/src/analyses/uncaught_exceptions_analysis.cpp
+++ b/src/analyses/uncaught_exceptions_analysis.cpp
@@ -181,10 +181,10 @@ void uncaught_exceptions_analysist::collect_uncaught_exceptions(
   {
     change=false;
     // add all the functions to the worklist
-    forall_goto_functions(current_function, goto_functions)
+    for(const auto &gf_entry : goto_functions.function_map)
     {
       domain.make_top();
-      const goto_programt &goto_program=current_function->second.body;
+      const goto_programt &goto_program = gf_entry.second.body;
 
       if(goto_program.empty())
         continue;
@@ -195,10 +195,10 @@ void uncaught_exceptions_analysist::collect_uncaught_exceptions(
       }
       // did our estimation for the current function improve?
       const std::set<irep_idt> &elements=domain.get_elements();
-      if(exceptions_map[current_function->first].size()<elements.size())
+      if(exceptions_map[gf_entry.first].size() < elements.size())
       {
         change=true;
-        exceptions_map[current_function->first]=elements;
+        exceptions_map[gf_entry.first] = elements;
       }
     }
   }
@@ -211,9 +211,9 @@ void uncaught_exceptions_analysist::output(
 {
   (void)goto_functions; // unused parameter
 #ifdef DEBUG
-  forall_goto_functions(it, goto_functions)
+  for(const auto &gf_entry : goto_functions.function_map)
   {
-    const auto fn=it->first;
+    const auto fn = gf_entry.first;
     const exceptions_mapt::const_iterator found=exceptions_map.find(fn);
     // Functions like __CPROVER_assert and __CPROVER_assume are replaced by
     // explicit GOTO instructions and will not show up in exceptions_map.

--- a/src/goto-analyzer/goto_analyzer_parse_options.cpp
+++ b/src/goto-analyzer/goto_analyzer_parse_options.cpp
@@ -730,13 +730,13 @@ int goto_analyzer_parse_optionst::perform_analysis(const optionst &options)
   {
     namespacet ns(goto_model.symbol_table);
 
-    forall_goto_functions(it, goto_model.goto_functions)
+    for(const auto &gf_entry : goto_model.goto_functions.function_map)
     {
       std::cout << ">>>>\n";
-      std::cout << ">>>> " << it->first << '\n';
+      std::cout << ">>>> " << gf_entry.first << '\n';
       std::cout << ">>>>\n";
-      local_may_aliast local_may_alias(it->second);
-      local_may_alias.output(std::cout, it->second, ns);
+      local_may_aliast local_may_alias(gf_entry.second);
+      local_may_alias.output(std::cout, gf_entry.second, ns);
       std::cout << '\n';
     }
 

--- a/src/goto-analyzer/static_simplifier.cpp
+++ b/src/goto-analyzer/static_simplifier.cpp
@@ -57,11 +57,11 @@ bool static_simplifier(
   messaget m(message_handler);
   m.status() << "Simplifying program" << messaget::eom;
 
-  Forall_goto_functions(f_it, goto_model.goto_functions)
+  for(auto &gf_entry : goto_model.goto_functions.function_map)
   {
-    Forall_goto_program_instructions(i_it, f_it->second.body)
+    Forall_goto_program_instructions(i_it, gf_entry.second.body)
     {
-      m.progress() << "Simplifying " << f_it->first << messaget::eom;
+      m.progress() << "Simplifying " << gf_entry.first << messaget::eom;
 
       if(i_it->is_assert())
       {

--- a/src/goto-analyzer/taint_analysis.cpp
+++ b/src/goto-analyzer/taint_analysis.cpp
@@ -276,11 +276,13 @@ bool taint_analysist::operator()(
 
       end.add(goto_programt::make_end_function());
 
-      forall_goto_functions(f_it, goto_functions)
-        if(f_it->second.body_available() &&
-           f_it->first!=goto_functionst::entry_point())
+      for(const auto &gf_entry : goto_functions.function_map)
+      {
+        if(
+          gf_entry.second.body_available() &&
+          gf_entry.first != goto_functionst::entry_point())
         {
-          const symbolt &symbol = ns.lookup(f_it->first);
+          const symbolt &symbol = ns.lookup(gf_entry.first);
           const code_function_callt call(symbol.symbol_expr());
           goto_programt::targett t =
             calls.add(goto_programt::make_function_call(call));
@@ -289,6 +291,7 @@ bool taint_analysist::operator()(
           gotos.add(goto_programt::make_goto(
             t, side_effect_expr_nondett(bool_typet(), symbol.location)));
         }
+      }
 
       goto_functionst::goto_functiont &entry=
         goto_functions.function_map[goto_functionst::entry_point()];
@@ -313,19 +316,19 @@ bool taint_analysist::operator()(
       return false;
     }
 
-    forall_goto_functions(f_it, goto_functions)
+    for(const auto &gf_entry : goto_functions.function_map)
     {
-      if(!f_it->second.body.has_assertion())
+      if(!gf_entry.second.body.has_assertion())
         continue;
 
-      const symbolt &symbol=ns.lookup(f_it->first);
+      const symbolt &symbol = ns.lookup(gf_entry.first);
 
-      if(f_it->first=="__actual_thread_spawn")
+      if(gf_entry.first == "__actual_thread_spawn")
         continue;
 
       bool first=true;
 
-      forall_goto_program_instructions(i_it, f_it->second.body)
+      forall_goto_program_instructions(i_it, gf_entry.second.body)
       {
         if(!i_it->is_assert())
           continue;

--- a/src/goto-analyzer/unreachable_instructions.cpp
+++ b/src/goto-analyzer/unreachable_instructions.cpp
@@ -161,17 +161,17 @@ void unreachable_instructions(
 
   const namespacet ns(goto_model.symbol_table);
 
-  forall_goto_functions(f_it, goto_model.goto_functions)
+  for(const auto &gf_entry : goto_model.goto_functions.function_map)
   {
-    if(!f_it->second.body_available())
+    if(!gf_entry.second.body_available())
       continue;
 
-    const goto_programt &goto_program=f_it->second.body;
+    const goto_programt &goto_program = gf_entry.second.body;
     dead_mapt dead_map;
 
-    const symbolt &decl=ns.lookup(f_it->first);
+    const symbolt &decl = ns.lookup(gf_entry.first);
 
-    // f_it->first may be a link-time renamed version, use the
+    // gf_entry.first may be a link-time renamed version, use the
     // base_name instead; do not list inlined functions
     if(
       called.find(decl.base_name) != called.end() ||
@@ -185,9 +185,9 @@ void unreachable_instructions(
     if(!dead_map.empty())
     {
       if(!json)
-        output_dead_plain(ns, f_it->first, goto_program, dead_map, os);
+        output_dead_plain(ns, gf_entry.first, goto_program, dead_map, os);
       else
-        add_to_json(ns, f_it->first, goto_program, dead_map, json_result);
+        add_to_json(ns, gf_entry.first, goto_program, dead_map, json_result);
     }
   }
 
@@ -206,12 +206,12 @@ bool static_unreachable_instructions(
 
   const namespacet ns(goto_model.symbol_table);
 
-  forall_goto_functions(f_it, goto_model.goto_functions)
+  for(const auto &gf_entry : goto_model.goto_functions.function_map)
   {
-    if(!f_it->second.body_available())
+    if(!gf_entry.second.body_available())
       continue;
 
-    const goto_programt &goto_program=f_it->second.body;
+    const goto_programt &goto_program = gf_entry.second.body;
     dead_mapt dead_map;
     build_dead_map_from_ai(goto_program, ai, dead_map);
 
@@ -219,16 +219,18 @@ bool static_unreachable_instructions(
     {
       if(options.get_bool_option("json"))
       {
-        add_to_json(ns, f_it->first, f_it->second.body, dead_map, json_result);
+        add_to_json(
+          ns, gf_entry.first, gf_entry.second.body, dead_map, json_result);
       }
       else if(options.get_bool_option("xml"))
       {
-        add_to_xml(f_it->first, f_it->second.body, dead_map, xml_result);
+        add_to_xml(gf_entry.first, gf_entry.second.body, dead_map, xml_result);
       }
       else
       {
         // text or console
-        output_dead_plain(ns, f_it->first, f_it->second.body, dead_map, out);
+        output_dead_plain(
+          ns, gf_entry.first, gf_entry.second.body, dead_map, out);
       }
     }
   }
@@ -292,11 +294,11 @@ static void list_functions(
 
   const namespacet ns(goto_model.symbol_table);
 
-  forall_goto_functions(f_it, goto_model.goto_functions)
+  for(const auto &gf_entry : goto_model.goto_functions.function_map)
   {
-    const symbolt &decl=ns.lookup(f_it->first);
+    const symbolt &decl = ns.lookup(gf_entry.first);
 
-    // f_it->first may be a link-time renamed version, use the
+    // gf_entry.first may be a link-time renamed version, use the
     // base_name instead; do not list inlined functions
     if(
       unreachable == (called.find(decl.base_name) != called.end() ||
@@ -308,9 +310,9 @@ static void list_functions(
     source_locationt first_location=decl.location;
 
     source_locationt last_location;
-    if(f_it->second.body_available())
+    if(gf_entry.second.body_available())
     {
-      const goto_programt &goto_program=f_it->second.body;
+      const goto_programt &goto_program = gf_entry.second.body;
 
       goto_programt::const_targett end_function=
         goto_program.instructions.end();
@@ -404,15 +406,15 @@ std::unordered_set<irep_idt> compute_called_functions_from_ai(
 {
   std::unordered_set<irep_idt> called;
 
-  forall_goto_functions(f_it, goto_model.goto_functions)
+  for(const auto &gf_entry : goto_model.goto_functions.function_map)
   {
-    if(!f_it->second.body_available())
+    if(!gf_entry.second.body_available())
       continue;
 
-    const goto_programt &p = f_it->second.body;
+    const goto_programt &p = gf_entry.second.body;
 
     if(!ai.abstract_state_before(p.instructions.begin())->is_bottom())
-      called.insert(f_it->first);
+      called.insert(gf_entry.first);
   }
 
   return called;

--- a/src/goto-diff/change_impact.cpp
+++ b/src/goto-diff/change_impact.cpp
@@ -99,10 +99,11 @@ void full_slicert::operator()(
   // now replace those instructions that are not needed
   // by skips
 
-  Forall_goto_functions(f_it, goto_functions)
-    if(f_it->second.body_available())
+  for(auto &gf_entry : goto_functions.function_map)
+  {
+    if(gf_entry.second.body_available())
     {
-      Forall_goto_program_instructions(i_it, f_it->second.body)
+      Forall_goto_program_instructions(i_it, gf_entry.second.body)
       {
         const auto &node = cfg.get_node(i_it);
         if(!i_it->is_end_function() && // always retained
@@ -128,6 +129,7 @@ void full_slicert::operator()(
 #endif
       }
     }
+  }
 
   // remove the skips
   remove_skip(goto_functions);
@@ -494,10 +496,18 @@ void change_impactt::operator()()
 
   function_mapt old_funcs, new_funcs;
 
-  forall_goto_functions(it, old_goto_functions)
+  for(auto it = old_goto_functions.function_map.begin();
+      it != old_goto_functions.function_map.end();
+      ++it)
+  {
     old_funcs.insert(std::make_pair(it->first, it));
-  forall_goto_functions(it, new_goto_functions)
+  }
+  for(auto it = new_goto_functions.function_map.begin();
+      it != new_goto_functions.function_map.end();
+      ++it)
+  {
     new_funcs.insert(std::make_pair(it->first, it));
+  }
 
   function_mapt::const_iterator ito=old_funcs.begin();
   for(function_mapt::const_iterator itn=new_funcs.begin();

--- a/src/goto-diff/syntactic_diff.cpp
+++ b/src/goto-diff/syntactic_diff.cpp
@@ -15,24 +15,24 @@ Author: Peter Schrammel
 
 bool syntactic_difft::operator()()
 {
-  forall_goto_functions(it, goto_model1.goto_functions)
+  for(const auto &gf_entry : goto_model1.goto_functions.function_map)
   {
-    if(!it->second.body_available())
+    if(!gf_entry.second.body_available())
       continue;
 
-    goto_functionst::function_mapt::const_iterator f_it=
-      goto_model2.goto_functions.function_map.find(it->first);
+    goto_functionst::function_mapt::const_iterator f_it =
+      goto_model2.goto_functions.function_map.find(gf_entry.first);
     if(f_it==goto_model2.goto_functions.function_map.end() ||
        !f_it->second.body_available())
     {
-      deleted_functions.insert(it->first);
+      deleted_functions.insert(gf_entry.first);
       continue;
     }
 
     // check access qualifiers
-    const symbolt *fun1 = goto_model1.symbol_table.lookup(it->first);
+    const symbolt *fun1 = goto_model1.symbol_table.lookup(gf_entry.first);
     CHECK_RETURN(fun1 != nullptr);
-    const symbolt *fun2 = goto_model2.symbol_table.lookup(it->first);
+    const symbolt *fun2 = goto_model2.symbol_table.lookup(gf_entry.first);
     CHECK_RETURN(fun2 != nullptr);
     const irep_idt &class_name = fun1->type.get(ID_C_class);
     bool function_access_changed =
@@ -65,28 +65,30 @@ bool syntactic_difft::operator()()
     }
     if(function_access_changed || class_access_changed || field_access_changed)
     {
-      modified_functions.insert(it->first);
+      modified_functions.insert(gf_entry.first);
       continue;
     }
 
-    if(!it->second.body.equals(f_it->second.body))
+    if(!gf_entry.second.body.equals(f_it->second.body))
     {
-      modified_functions.insert(it->first);
+      modified_functions.insert(gf_entry.first);
       continue;
     }
   }
-  forall_goto_functions(it, goto_model2.goto_functions)
+  for(const auto &gf_entry : goto_model2.goto_functions.function_map)
   {
-    if(!it->second.body_available())
+    if(!gf_entry.second.body_available())
       continue;
 
     total_functions_count++;
 
-    goto_functionst::function_mapt::const_iterator f_it=
-      goto_model1.goto_functions.function_map.find(it->first);
+    goto_functionst::function_mapt::const_iterator f_it =
+      goto_model1.goto_functions.function_map.find(gf_entry.first);
     if(f_it==goto_model1.goto_functions.function_map.end() ||
        !f_it->second.body_available())
-      new_functions.insert(it->first);
+    {
+      new_functions.insert(gf_entry.first);
+    }
   }
 
   return !(new_functions.empty() &&

--- a/src/goto-diff/unified_diff.cpp
+++ b/src/goto-diff/unified_diff.cpp
@@ -332,10 +332,18 @@ bool unified_difft::operator()()
 
   function_mapt old_funcs, new_funcs;
 
-  forall_goto_functions(it, old_goto_functions)
+  for(auto it = old_goto_functions.function_map.begin();
+      it != old_goto_functions.function_map.end();
+      ++it)
+  {
     old_funcs.insert(std::make_pair(it->first, it));
-  forall_goto_functions(it, new_goto_functions)
+  }
+  for(auto it = new_goto_functions.function_map.begin();
+      it != new_goto_functions.function_map.end();
+      ++it)
+  {
     new_funcs.insert(std::make_pair(it->first, it));
+  }
 
   goto_programt empty;
 

--- a/src/goto-instrument/accelerate/accelerate.cpp
+++ b/src/goto-instrument/accelerate/accelerate.cpp
@@ -642,11 +642,11 @@ void accelerate_functions(
   bool use_z3,
   guard_managert &guard_manager)
 {
-  Forall_goto_functions(it, goto_model.goto_functions)
+  for(auto &gf_entry : goto_model.goto_functions.function_map)
   {
-    std::cout << "Accelerating function " << it->first << '\n';
+    std::cout << "Accelerating function " << gf_entry.first << '\n';
     acceleratet accelerate(
-      it->second.body, goto_model, message_handler, use_z3, guard_manager);
+      gf_entry.second.body, goto_model, message_handler, use_z3, guard_manager);
 
     int num_accelerated=accelerate.accelerate_loops();
 

--- a/src/goto-instrument/aggressive_slicer.cpp
+++ b/src/goto-instrument/aggressive_slicer.cpp
@@ -59,10 +59,10 @@ void aggressive_slicert::find_functions_that_contain_name_snippet()
 {
   for(const auto &name_snippet : name_snippets)
   {
-    forall_goto_functions(f_it, goto_model.goto_functions)
+    for(const auto &gf_entry : goto_model.goto_functions.function_map)
     {
-      if(id2string(f_it->first).find(name_snippet) != std::string::npos)
-        functions_to_keep.insert(f_it->first);
+      if(id2string(gf_entry.first).find(name_snippet) != std::string::npos)
+        functions_to_keep.insert(gf_entry.first);
     }
   }
 }
@@ -110,9 +110,9 @@ void aggressive_slicert::doit()
   for(const auto &func : functions_to_keep)
     message.debug() << func << messaget::eom;
 
-  forall_goto_functions(f_it, goto_model.goto_functions)
+  for(const auto &gf_entry : goto_model.goto_functions.function_map)
   {
-    if(functions_to_keep.find(f_it->first) == functions_to_keep.end())
-      remove_function(goto_model, f_it->first, message_handler);
+    if(functions_to_keep.find(gf_entry.first) == functions_to_keep.end())
+      remove_function(goto_model, gf_entry.first, message_handler);
   }
 }

--- a/src/goto-instrument/branch.cpp
+++ b/src/goto-instrument/branch.cpp
@@ -21,19 +21,19 @@ void branch(
   goto_modelt &goto_model,
   const irep_idt &id)
 {
-  Forall_goto_functions(f_it, goto_model.goto_functions)
+  for(auto &gf_entry : goto_model.goto_functions.function_map)
   {
     // don't instrument our internal functions
-    if(has_prefix(id2string(f_it->first), CPROVER_PREFIX))
+    if(has_prefix(id2string(gf_entry.first), CPROVER_PREFIX))
       continue;
 
     // don't instrument the function to be called,
     // or otherwise this will be recursive
-    if(f_it->first==id)
+    if(gf_entry.first == id)
       continue;
 
     // patch in a call to `id' at the branch points
-    goto_programt &body=f_it->second.body;
+    goto_programt &body = gf_entry.second.body;
 
     Forall_goto_program_instructions(i_it, body)
     {

--- a/src/goto-instrument/call_sequences.cpp
+++ b/src/goto-instrument/call_sequences.cpp
@@ -69,8 +69,8 @@ void show_call_sequences(const goto_modelt &goto_model)
   // do per function
   // show the calls in the body of the specific function
 
-  forall_goto_functions(f_it, goto_model.goto_functions)
-    show_call_sequences(f_it->first, f_it->second.body);
+  for(const auto &gf_entry : goto_model.goto_functions.function_map)
+    show_call_sequences(gf_entry.first, gf_entry.second.body);
 }
 
 class check_call_sequencet
@@ -319,6 +319,6 @@ void list_calls_and_arguments(const goto_modelt &goto_model)
 
   const namespacet ns(goto_model.symbol_table);
 
-  forall_goto_functions(f_it, goto_model.goto_functions)
-    list_calls_and_arguments(ns, f_it->second.body);
+  for(const auto &gf_entry : goto_model.goto_functions.function_map)
+    list_calls_and_arguments(ns, gf_entry.second.body);
 }

--- a/src/goto-instrument/concurrency.cpp
+++ b/src/goto-instrument/concurrency.cpp
@@ -181,15 +181,15 @@ void concurrency_instrumentationt::instrument(
   is_threadedt is_threaded(goto_functions);
 
   // this first collects all shared and thread-local variables
-  forall_goto_functions(f_it, goto_functions)
-    collect(f_it->second.body, is_threaded);
+  for(const auto &gf_entry : goto_functions.function_map)
+    collect(gf_entry.second.body, is_threaded);
 
   // add array symbols
   add_array_symbols();
 
   // now instrument
-  Forall_goto_functions(f_it, goto_functions)
-    instrument(f_it->second.body);
+  for(auto &gf_entry : goto_functions.function_map)
+    instrument(gf_entry.second.body);
 }
 
 void concurrency(

--- a/src/goto-instrument/count_eloc.cpp
+++ b/src/goto-instrument/count_eloc.cpp
@@ -34,9 +34,9 @@ static void collect_eloc(
   const goto_modelt &goto_model,
   working_dirst &dest)
 {
-  forall_goto_functions(f_it, goto_model.goto_functions)
+  for(const auto &gf_entry : goto_model.goto_functions.function_map)
   {
-    for(const auto &instruction : f_it->second.body.instructions)
+    for(const auto &instruction : gf_entry.second.body.instructions)
     {
       const auto &source_location = instruction.source_location;
 
@@ -121,11 +121,14 @@ void print_path_lengths(const goto_modelt &goto_model)
             << " instructions\n";
 
   std::size_t n_loops=0, loop_ins=0;
-  forall_goto_functions(gf_it, goto_model.goto_functions)
-    forall_goto_program_instructions(i_it, gf_it->second.body)
+  for(const auto &gf_entry : goto_model.goto_functions.function_map)
+  {
+    forall_goto_program_instructions(i_it, gf_entry.second.body)
+    {
       // loops or recursion
-      if(i_it->is_backwards_goto() ||
-         i_it==gf_it->second.body.instructions.begin())
+      if(
+        i_it->is_backwards_goto() ||
+        i_it == gf_entry.second.body.instructions.begin())
       {
         const cfgt::entryt &node = cfg.get_node_index(i_it);
         cfgt::patht loop;
@@ -137,6 +140,8 @@ void print_path_lengths(const goto_modelt &goto_model)
           loop_ins+=loop.size()-1;
         }
       }
+    }
+  }
 
   if(n_loops>0)
     std::cout << "Loop information: " << n_loops << " loops, "

--- a/src/goto-instrument/cover.cpp
+++ b/src/goto-instrument/cover.cpp
@@ -386,11 +386,11 @@ bool instrument_cover_goals(
     return true;
   }
 
-  Forall_goto_functions(f_it, goto_functions)
+  for(auto &gf_entry : goto_functions.function_map)
   {
-    const symbolt function_symbol = symbol_table.lookup_ref(f_it->first);
+    const symbolt function_symbol = symbol_table.lookup_ref(gf_entry.first);
     instrument_cover_goals(
-      cover_config, function_symbol, f_it->second, message_handler);
+      cover_config, function_symbol, gf_entry.second, message_handler);
   }
   goto_functions.compute_location_numbers();
 

--- a/src/goto-instrument/document_properties.cpp
+++ b/src/goto-instrument/document_properties.cpp
@@ -274,9 +274,9 @@ void document_propertiest::doit()
   typedef std::map<source_locationt, doc_claimt> claim_sett;
   claim_sett claim_set;
 
-  forall_goto_functions(f_it, goto_functions)
+  for(const auto &gf_entry : goto_functions.function_map)
   {
-    const goto_programt &goto_program=f_it->second.body;
+    const goto_programt &goto_program = gf_entry.second.body;
 
     for(const auto &instruction : goto_program.instructions)
     {

--- a/src/goto-instrument/dot.cpp
+++ b/src/goto-instrument/dot.cpp
@@ -267,9 +267,11 @@ void dott::output(std::ostream &out)
   out << "digraph G {\n";
   out << DOTGRAPHSETTINGS << '\n';
 
-  forall_goto_functions(it, goto_model.goto_functions)
-    if(it->second.body_available())
-      write_dot_subgraph(out, it->first, it->second.body);
+  for(const auto &gf_entry : goto_model.goto_functions.function_map)
+  {
+    if(gf_entry.second.body_available())
+      write_dot_subgraph(out, gf_entry.first, gf_entry.second.body);
+  }
 
   do_dot_function_calls(out);
 

--- a/src/goto-instrument/full_slicer.cpp
+++ b/src/goto-instrument/full_slicer.cpp
@@ -258,10 +258,10 @@ void full_slicert::operator()(
 {
   // build the CFG data structure
   cfg(goto_functions);
-  forall_goto_functions(f_it, goto_functions)
+  for(const auto &gf_entry : goto_functions.function_map)
   {
-    forall_goto_program_instructions(i_it, f_it->second.body)
-      cfg.get_node(i_it).function_id = f_it->first;
+    forall_goto_program_instructions(i_it, gf_entry.second.body)
+      cfg.get_node(i_it).function_id = gf_entry.first;
   }
 
   // fill queue with according to slicing criterion
@@ -305,10 +305,11 @@ void full_slicert::operator()(
   // now replace those instructions that are not needed
   // by skips
 
-  Forall_goto_functions(f_it, goto_functions)
-    if(f_it->second.body_available())
+  for(auto &gf_entry : goto_functions.function_map)
+  {
+    if(gf_entry.second.body_available())
     {
-      Forall_goto_program_instructions(i_it, f_it->second.body)
+      Forall_goto_program_instructions(i_it, gf_entry.second.body)
       {
         const auto &cfg_node = cfg.get_node(i_it);
         if(
@@ -337,6 +338,7 @@ void full_slicert::operator()(
 #endif
       }
     }
+  }
 
   // remove the skips
   remove_skip(goto_functions);

--- a/src/goto-instrument/function.cpp
+++ b/src/goto-instrument/function.cpp
@@ -74,24 +74,24 @@ void function_enter(
   goto_modelt &goto_model,
   const irep_idt &id)
 {
-  Forall_goto_functions(f_it, goto_model.goto_functions)
+  for(auto &gf_entry : goto_model.goto_functions.function_map)
   {
     // don't instrument our internal functions
-    if(has_prefix(id2string(f_it->first), CPROVER_PREFIX))
+    if(has_prefix(id2string(gf_entry.first), CPROVER_PREFIX))
       continue;
 
     // don't instrument the function to be called,
     // or otherwise this will be recursive
-    if(f_it->first==id)
+    if(gf_entry.first == id)
       continue;
 
     // patch in a call to `id' at the entry point
-    goto_programt &body=f_it->second.body;
+    goto_programt &body = gf_entry.second.body;
 
     body.insert_before(
       body.instructions.begin(),
       goto_programt::make_function_call(
-        function_to_call(goto_model.symbol_table, id, f_it->first)));
+        function_to_call(goto_model.symbol_table, id, gf_entry.first)));
   }
 }
 
@@ -99,19 +99,19 @@ void function_exit(
   goto_modelt &goto_model,
   const irep_idt &id)
 {
-  Forall_goto_functions(f_it, goto_model.goto_functions)
+  for(auto &gf_entry : goto_model.goto_functions.function_map)
   {
     // don't instrument our internal functions
-    if(has_prefix(id2string(f_it->first), CPROVER_PREFIX))
+    if(has_prefix(id2string(gf_entry.first), CPROVER_PREFIX))
       continue;
 
     // don't instrument the function to be called,
     // or otherwise this will be recursive
-    if(f_it->first==id)
+    if(gf_entry.first == id)
       continue;
 
     // patch in a call to `id' at the exit points
-    goto_programt &body=f_it->second.body;
+    goto_programt &body = gf_entry.second.body;
 
     // make sure we have END_OF_FUNCTION
     if(body.instructions.empty() ||
@@ -125,7 +125,7 @@ void function_exit(
       if(i_it->is_return())
       {
         goto_programt::instructiont call = goto_programt::make_function_call(
-          function_to_call(goto_model.symbol_table, id, f_it->first));
+          function_to_call(goto_model.symbol_table, id, gf_entry.first));
         body.insert_before_swap(i_it, call);
 
         // move on
@@ -152,7 +152,7 @@ void function_exit(
     if(!has_return)
     {
       goto_programt::instructiont call = goto_programt::make_function_call(
-        function_to_call(goto_model.symbol_table, id, f_it->first));
+        function_to_call(goto_model.symbol_table, id, gf_entry.first));
       body.insert_before_swap(last, call);
     }
   }

--- a/src/goto-instrument/goto_instrument_parse_options.cpp
+++ b/src/goto-instrument/goto_instrument_parse_options.cpp
@@ -247,17 +247,17 @@ int goto_instrument_parse_optionst::doit()
 
       is_threadedt is_threaded(goto_model);
 
-      forall_goto_functions(f_it, goto_model.goto_functions)
+      for(const auto &gf_entry : goto_model.goto_functions.function_map)
       {
         std::cout << "////\n";
-        std::cout << "//// Function: " << f_it->first << '\n';
+        std::cout << "//// Function: " << gf_entry.first << '\n';
         std::cout << "////\n\n";
 
-        const goto_programt &goto_program=f_it->second.body;
+        const goto_programt &goto_program = gf_entry.second.body;
 
         forall_goto_program_instructions(i_it, goto_program)
         {
-          goto_program.output_instruction(ns, f_it->first, std::cout, *i_it);
+          goto_program.output_instruction(ns, gf_entry.first, std::cout, *i_it);
           std::cout << "Is threaded: " << (is_threaded(i_it)?"True":"False")
                     << "\n\n";
         }
@@ -322,13 +322,13 @@ int goto_instrument_parse_optionst::doit()
 
       namespacet ns(goto_model.symbol_table);
 
-      forall_goto_functions(it, goto_model.goto_functions)
+      for(const auto &gf_entry : goto_model.goto_functions.function_map)
       {
-        local_bitvector_analysist local_bitvector_analysis(it->second, ns);
+        local_bitvector_analysist local_bitvector_analysis(gf_entry.second, ns);
         std::cout << ">>>>\n";
-        std::cout << ">>>> " << it->first << '\n';
+        std::cout << ">>>> " << gf_entry.first << '\n';
         std::cout << ">>>>\n";
-        local_bitvector_analysis.output(std::cout, it->second, ns);
+        local_bitvector_analysis.output(std::cout, gf_entry.second, ns);
         std::cout << '\n';
       }
 
@@ -343,19 +343,19 @@ int goto_instrument_parse_optionst::doit()
 
       namespacet ns(goto_model.symbol_table);
 
-      forall_goto_functions(it, goto_model.goto_functions)
+      for(const auto &gf_entry : goto_model.goto_functions.function_map)
       {
         local_safe_pointerst local_safe_pointers;
-        local_safe_pointers(it->second.body);
+        local_safe_pointers(gf_entry.second.body);
         std::cout << ">>>>\n";
-        std::cout << ">>>> " << it->first << '\n';
+        std::cout << ">>>> " << gf_entry.first << '\n';
         std::cout << ">>>>\n";
         if(cmdline.isset("show-local-safe-pointers"))
-          local_safe_pointers.output(std::cout, it->second.body, ns);
+          local_safe_pointers.output(std::cout, gf_entry.second.body, ns);
         else
         {
           local_safe_pointers.output_safe_dereferences(
-            std::cout, it->second.body, ns);
+            std::cout, gf_entry.second.body, ns);
         }
         std::cout << '\n';
       }
@@ -370,14 +370,14 @@ int goto_instrument_parse_optionst::doit()
 
       namespacet ns(goto_model.symbol_table);
 
-      forall_goto_functions(it, goto_model.goto_functions)
+      for(const auto &gf_entry : goto_model.goto_functions.function_map)
       {
         sese_region_analysist sese_region_analysis;
-        sese_region_analysis(it->second.body);
+        sese_region_analysis(gf_entry.second.body);
         std::cout << ">>>>\n";
-        std::cout << ">>>> " << it->first << '\n';
+        std::cout << ">>>> " << gf_entry.first << '\n';
         std::cout << ">>>>\n";
-        sese_region_analysis.output(std::cout, it->second.body, ns);
+        sese_region_analysis.output(std::cout, gf_entry.second.body, ns);
         std::cout << '\n';
       }
 

--- a/src/goto-instrument/havoc_loops.cpp
+++ b/src/goto-instrument/havoc_loops.cpp
@@ -121,6 +121,6 @@ void havoc_loops(goto_modelt &goto_model)
 {
   function_modifiest function_modifies(goto_model.goto_functions);
 
-  Forall_goto_functions(it, goto_model.goto_functions)
-    havoc_loopst(function_modifies, it->second);
+  for(auto &gf_entry : goto_model.goto_functions.function_map)
+    havoc_loopst(function_modifies, gf_entry.second);
 }

--- a/src/goto-instrument/interrupt.cpp
+++ b/src/goto-instrument/interrupt.cpp
@@ -194,20 +194,25 @@ void interrupt(
 
   // now instrument
 
-  Forall_goto_functions(f_it, goto_model.goto_functions)
-    if(f_it->first != INITIALIZE_FUNCTION &&
-       f_it->first!=goto_functionst::entry_point() &&
-       f_it->first!=isr.get_identifier())
+  for(auto &gf_entry : goto_model.goto_functions.function_map)
+  {
+    if(
+      gf_entry.first != INITIALIZE_FUNCTION &&
+      gf_entry.first != goto_functionst::entry_point() &&
+      gf_entry.first != isr.get_identifier())
+    {
       interrupt(
         value_sets,
         goto_model.symbol_table,
-        f_it->first,
+        gf_entry.first,
 #ifdef LOCAL_MAY
-        f_it->second,
+        gf_entry.second,
 #endif
-        f_it->second.body,
+        gf_entry.second.body,
         isr,
         isr_rw_set);
+    }
+  }
 
   goto_model.goto_functions.update();
 }

--- a/src/goto-instrument/k_induction.cpp
+++ b/src/goto-instrument/k_induction.cpp
@@ -164,6 +164,6 @@ void k_induction(
   bool base_case, bool step_case,
   unsigned k)
 {
-  Forall_goto_functions(it, goto_model.goto_functions)
-    k_inductiont(it->first, it->second, base_case, step_case, k);
+  for(auto &gf_entry : goto_model.goto_functions.function_map)
+    k_inductiont(gf_entry.first, gf_entry.second, base_case, step_case, k);
 }

--- a/src/goto-instrument/mmio.cpp
+++ b/src/goto-instrument/mmio.cpp
@@ -162,17 +162,22 @@ void mmio(
 {
   // now instrument
 
-  Forall_goto_functions(f_it, goto_model.goto_functions)
-    if(f_it->first != INITIALIZE_FUNCTION &&
-       f_it->first!=goto_functionst::entry_point())
+  for(auto &gf_entry : goto_model.goto_functions.function_map)
+  {
+    if(
+      gf_entry.first != INITIALIZE_FUNCTION &&
+      gf_entry.first != goto_functionst::entry_point())
+    {
       mmio(
         value_sets,
         goto_model.symbol_table,
-        f_it->first,
+        gf_entry.first,
 #ifdef LOCAL_MAY
-        f_it->second,
+        gf_entry.second,
 #endif
-        f_it->second.body);
+        gf_entry.second.body);
+    }
+  }
 
   goto_model.goto_functions.update();
 }

--- a/src/goto-instrument/race_check.cpp
+++ b/src/goto-instrument/race_check.cpp
@@ -293,15 +293,20 @@ void race_check(
 {
   w_guardst w_guards(goto_model.symbol_table);
 
-  Forall_goto_functions(f_it, goto_model.goto_functions)
-    if(f_it->first!=goto_functionst::entry_point() &&
-       f_it->first != INITIALIZE_FUNCTION)
+  for(auto &gf_entry : goto_model.goto_functions.function_map)
+  {
+    if(
+      gf_entry.first != goto_functionst::entry_point() &&
+      gf_entry.first != INITIALIZE_FUNCTION)
+    {
       race_check(
         value_sets,
         goto_model.symbol_table,
-        f_it->first,
-        L_M_ARG(f_it->second) f_it->second.body,
+        gf_entry.first,
+        L_M_ARG(gf_entry.second) gf_entry.second.body,
         w_guards);
+    }
+  }
 
   // get "main"
   goto_functionst::function_mapt::iterator

--- a/src/goto-instrument/reachability_slicer.cpp
+++ b/src/goto-instrument/reachability_slicer.cpp
@@ -336,10 +336,11 @@ void reachability_slicert::slice(goto_functionst &goto_functions)
   // now replace those instructions that do not reach any assertions
   // by assume(false)
 
-  Forall_goto_functions(f_it, goto_functions)
-    if(f_it->second.body_available())
+  for(auto &gf_entry : goto_functions.function_map)
+  {
+    if(gf_entry.second.body_available())
     {
-      Forall_goto_program_instructions(i_it, f_it->second.body)
+      Forall_goto_program_instructions(i_it, gf_entry.second.body)
       {
         cfgt::nodet &e = cfg.get_node(i_it);
         if(
@@ -352,8 +353,9 @@ void reachability_slicert::slice(goto_functionst &goto_functions)
       }
 
       // replace unreachable code by skip
-      remove_unreachable(f_it->second.body);
+      remove_unreachable(gf_entry.second.body);
     }
+  }
 
   // remove the skips
   remove_skip(goto_functions);

--- a/src/goto-instrument/reachability_slicer_class.h
+++ b/src/goto-instrument/reachability_slicer_class.h
@@ -28,10 +28,10 @@ public:
     bool include_forward_reachability)
   {
     cfg(goto_functions);
-    forall_goto_functions(f_it, goto_functions)
+    for(const auto &gf_entry : goto_functions.function_map)
     {
-      forall_goto_program_instructions(i_it, f_it->second.body)
-        cfg[cfg.entry_map[i_it]].function_id = f_it->first;
+      forall_goto_program_instructions(i_it, gf_entry.second.body)
+        cfg[cfg.entry_map[i_it]].function_id = gf_entry.first;
     }
 
     is_threadedt is_threaded(goto_functions);

--- a/src/goto-instrument/skip_loops.cpp
+++ b/src/goto-instrument/skip_loops.cpp
@@ -104,13 +104,13 @@ bool skip_loops(
   }
 
   loop_mapt::const_iterator it=loop_map.begin();
-  Forall_goto_functions(f_it, goto_model.goto_functions)
+  for(auto &gf_entry : goto_model.goto_functions.function_map)
   {
-    if(it==loop_map.end() || it->first<f_it->first)
+    if(it == loop_map.end() || it->first < gf_entry.first)
       break; // possible error handled below
-    else if(it->first==f_it->first)
+    else if(it->first == gf_entry.first)
     {
-      if(skip_loops(f_it->second.body, it->second, message))
+      if(skip_loops(gf_entry.second.body, it->second, message))
         return true;
       ++it;
     }

--- a/src/goto-instrument/stack_depth.cpp
+++ b/src/goto-instrument/stack_depth.cpp
@@ -83,11 +83,16 @@ void stack_depth(
 
   const exprt depth_expr(from_integer(depth, sym.type()));
 
-  Forall_goto_functions(f_it, goto_model.goto_functions)
-    if(f_it->second.body_available() &&
-        f_it->first != INITIALIZE_FUNCTION &&
-        f_it->first!=goto_functionst::entry_point())
-      stack_depth(f_it->second.body, sym, depth, depth_expr);
+  for(auto &gf_entry : goto_model.goto_functions.function_map)
+  {
+    if(
+      gf_entry.second.body_available() &&
+      gf_entry.first != INITIALIZE_FUNCTION &&
+      gf_entry.first != goto_functionst::entry_point())
+    {
+      stack_depth(gf_entry.second.body, sym, depth, depth_expr);
+    }
+  }
 
   // initialize depth to 0
   goto_functionst::function_mapt::iterator i_it =

--- a/src/goto-instrument/thread_instrumentation.cpp
+++ b/src/goto-instrument/thread_instrumentation.cpp
@@ -57,13 +57,13 @@ void thread_exit_instrumentation(goto_modelt &goto_model)
   // we'll look for START THREAD
   std::set<irep_idt> thread_fkts;
 
-  forall_goto_functions(f_it, goto_model.goto_functions)
+  for(const auto &gf_entry : goto_model.goto_functions.function_map)
   {
-    if(has_start_thread(f_it->second.body))
+    if(has_start_thread(gf_entry.second.body))
     {
       // now look for functions called
 
-      for(const auto &instruction : f_it->second.body.instructions)
+      for(const auto &instruction : gf_entry.second.body.instructions)
         if(instruction.is_function_call())
         {
           const exprt &function=
@@ -132,9 +132,11 @@ void mutex_init_instrumentation(goto_modelt &goto_model)
   if(lock_type.id()!=ID_pointer)
     return;
 
-  Forall_goto_functions(f_it, goto_model.goto_functions)
+  for(auto &gf_entry : goto_model.goto_functions.function_map)
+  {
     mutex_init_instrumentation(
       goto_model.symbol_table,
-      f_it->second.body,
+      gf_entry.second.body,
       to_pointer_type(lock_type).subtype());
+  }
 }

--- a/src/goto-instrument/undefined_functions.cpp
+++ b/src/goto-instrument/undefined_functions.cpp
@@ -25,16 +25,18 @@ void list_undefined_functions(
 {
   const namespacet ns(goto_model.symbol_table);
 
-  forall_goto_functions(it, goto_model.goto_functions)
-    if(!ns.lookup(it->first).is_macro &&
-       !it->second.body_available())
-      os << it->first << '\n';
+  for(const auto &gf_entry : goto_model.goto_functions.function_map)
+  {
+    if(!ns.lookup(gf_entry.first).is_macro && !gf_entry.second.body_available())
+      os << gf_entry.first << '\n';
+  }
 }
 
 void undefined_function_abort_path(goto_modelt &goto_model)
 {
-  Forall_goto_functions(it, goto_model.goto_functions)
-    for(auto &ins : it->second.body.instructions)
+  for(auto &gf_entry : goto_model.goto_functions.function_map)
+  {
+    for(auto &ins : gf_entry.second.body.instructions)
     {
       if(!ins.is_function_call())
         continue;
@@ -60,4 +62,5 @@ void undefined_function_abort_path(goto_modelt &goto_model)
       ins.source_location.set_comment(
         "'" + id2string(function) + "' is undefined");
     }
+  }
 }

--- a/src/goto-instrument/uninitialized.cpp
+++ b/src/goto-instrument/uninitialized.cpp
@@ -198,11 +198,11 @@ void uninitializedt::add_assertions(
 
 void add_uninitialized_locals_assertions(goto_modelt &goto_model)
 {
-  Forall_goto_functions(f_it, goto_model.goto_functions)
+  for(auto &gf_entry : goto_model.goto_functions.function_map)
   {
     uninitializedt uninitialized(goto_model.symbol_table);
 
-    uninitialized.add_assertions(f_it->first, f_it->second.body);
+    uninitialized.add_assertions(gf_entry.first, gf_entry.second.body);
   }
 }
 
@@ -212,16 +212,17 @@ void show_uninitialized(
 {
   const namespacet ns(goto_model.symbol_table);
 
-  forall_goto_functions(f_it, goto_model.goto_functions)
+  for(const auto &gf_entry : goto_model.goto_functions.function_map)
   {
-    if(f_it->second.body_available())
+    if(gf_entry.second.body_available())
     {
       out << "////\n";
-      out << "//// Function: " << f_it->first << '\n';
+      out << "//// Function: " << gf_entry.first << '\n';
       out << "////\n\n";
       uninitialized_analysist uninitialized_analysis;
-      uninitialized_analysis(f_it->first, f_it->second.body, ns);
-      uninitialized_analysis.output(ns, f_it->first, f_it->second.body, out);
+      uninitialized_analysis(gf_entry.first, gf_entry.second.body, ns);
+      uninitialized_analysis.output(
+        ns, gf_entry.first, gf_entry.second.body, out);
     }
   }
 }

--- a/src/goto-instrument/unwind.cpp
+++ b/src/goto-instrument/unwind.cpp
@@ -317,20 +317,20 @@ void goto_unwindt::operator()(
   const unwindsett &unwindset,
   const unwind_strategyt unwind_strategy)
 {
-  Forall_goto_functions(it, goto_functions)
+  for(auto &gf_entry : goto_functions.function_map)
   {
-    goto_functionst::goto_functiont &goto_function=it->second;
+    goto_functionst::goto_functiont &goto_function = gf_entry.second;
 
     if(!goto_function.body_available())
       continue;
 
 #ifdef DEBUG
-    std::cout << "Function: " << it->first << '\n';
+    std::cout << "Function: " << gf_entry.first << '\n';
 #endif
 
     goto_programt &goto_program=goto_function.body;
 
-    unwind(it->first, goto_program, unwindset, unwind_strategy);
+    unwind(gf_entry.first, goto_program, unwindset, unwind_strategy);
   }
 }
 

--- a/src/goto-instrument/wmm/goto2graph.cpp
+++ b/src/goto-instrument/wmm/goto2graph.cpp
@@ -1269,13 +1269,13 @@ bool instrumentert::is_cfg_spurious(const event_grapht::critical_cyclet &cyc)
     goto_programt *current_po=nullptr;
     bool thread_found=false;
 
-    Forall_goto_functions(f_it, goto_functions)
+    for(auto &gf_entry : goto_functions.function_map)
     {
-      for(const auto &instruction : f_it->second.body.instructions)
+      for(const auto &instruction : gf_entry.second.body.instructions)
       {
         if(instruction.source_location == current_location)
         {
-          current_po=&f_it->second.body;
+          current_po = &gf_entry.second.body;
           thread_found=true;
           break;
         }

--- a/src/goto-instrument/wmm/shared_buffers.cpp
+++ b/src/goto-instrument/wmm/shared_buffers.cpp
@@ -1026,18 +1026,18 @@ void shared_bufferst::affected_by_delay(
 {
   namespacet ns(symbol_table);
 
-  Forall_goto_functions(f_it, goto_functions)
+  for(auto &gf_entry : goto_functions.function_map)
   {
 #ifdef LOCAL_MAY
-    local_may_aliast local_may(f_it->second);
+    local_may_aliast local_may(gf_entry.second);
 #endif
 
-    Forall_goto_program_instructions(i_it, f_it->second.body)
+    Forall_goto_program_instructions(i_it, gf_entry.second.body)
     {
       rw_set_loct rw_set(
         ns,
         value_sets,
-        f_it->first,
+        gf_entry.first,
         i_it
 #ifdef LOCAL_MAY
         ,

--- a/src/goto-instrument/wmm/weak_memory.cpp
+++ b/src/goto-instrument/wmm/weak_memory.cpp
@@ -134,15 +134,23 @@ void weak_memory(
   message.status() << "--------" << messaget::eom;
 
   // all access to shared variables is pushed into assignments
-  Forall_goto_functions(f_it, goto_model.goto_functions)
-    if(f_it->first != INITIALIZE_FUNCTION &&
-      f_it->first!=goto_functionst::entry_point())
-      introduce_temporaries(value_sets, goto_model.symbol_table, f_it->first,
-        f_it->second.body,
+  for(auto &gf_entry : goto_model.goto_functions.function_map)
+  {
+    if(
+      gf_entry.first != INITIALIZE_FUNCTION &&
+      gf_entry.first != goto_functionst::entry_point())
+    {
+      introduce_temporaries(
+        value_sets,
+        goto_model.symbol_table,
+        gf_entry.first,
+        gf_entry.second.body,
 #ifdef LOCAL_MAY
-        f_it->second,
+        gf_entry.second,
 #endif
         message);
+    }
+  }
 
   message.status() << "Temp added" << messaget::eom;
 

--- a/src/goto-programs/adjust_float_expressions.cpp
+++ b/src/goto-programs/adjust_float_expressions.cpp
@@ -214,8 +214,8 @@ void adjust_float_expressions(
   goto_functionst &goto_functions,
   const namespacet &ns)
 {
-  Forall_goto_functions(it, goto_functions)
-    adjust_float_expressions(it->second, ns);
+  for(auto &gf_entry : goto_functions.function_map)
+    adjust_float_expressions(gf_entry.second, ns);
 }
 
 void adjust_float_expressions(goto_modelt &goto_model)

--- a/src/goto-programs/cfg.h
+++ b/src/goto-programs/cfg.h
@@ -540,9 +540,11 @@ template<class T, typename P, typename I>
 void cfg_baset<T, P, I>::compute_edges(
   const goto_functionst &goto_functions)
 {
-  forall_goto_functions(it, goto_functions)
-    if(it->second.body_available())
-      compute_edges(goto_functions, it->second.body);
+  for(const auto &gf_entry : goto_functions.function_map)
+  {
+    if(gf_entry.second.body_available())
+      compute_edges(goto_functions, gf_entry.second.body);
+  }
 }
 
 #endif // CPROVER_GOTO_PROGRAMS_CFG_H

--- a/src/goto-programs/compute_called_functions.cpp
+++ b/src/goto-programs/compute_called_functions.cpp
@@ -68,8 +68,8 @@ void compute_address_taken_functions(
   const goto_functionst &goto_functions,
   std::unordered_set<irep_idt> &address_taken)
 {
-  forall_goto_functions(it, goto_functions)
-    compute_address_taken_functions(it->second.body, address_taken);
+  for(const auto &gf_entry : goto_functions.function_map)
+    compute_address_taken_functions(gf_entry.second.body, address_taken);
 }
 
 /// get all functions whose address is taken

--- a/src/goto-programs/goto_functions.h
+++ b/src/goto-programs/goto_functions.h
@@ -114,14 +114,4 @@ public:
   void validate(const namespacet &, validation_modet) const;
 };
 
-#define Forall_goto_functions(it, functions) \
-  for(goto_functionst::function_mapt::iterator \
-      it=(functions).function_map.begin(); \
-      it!=(functions).function_map.end(); it++)
-
-#define forall_goto_functions(it, functions) \
-  for(goto_functionst::function_mapt::const_iterator \
-      it=(functions).function_map.begin(); \
-      it!=(functions).function_map.end(); it++)
-
 #endif // CPROVER_GOTO_PROGRAMS_GOTO_FUNCTIONS_H

--- a/src/goto-programs/goto_inline.cpp
+++ b/src/goto-programs/goto_inline.cpp
@@ -62,14 +62,14 @@ void goto_inline(
   // copying that goto_inlinet would do otherwise
   goto_inlinet::inline_mapt inline_map;
 
-  Forall_goto_functions(f_it, goto_functions)
+  for(auto &gf_entry : goto_functions.function_map)
   {
-    goto_functiont &goto_function=f_it->second;
+    goto_functiont &goto_function = gf_entry.second;
 
     if(!goto_function.body_available())
       continue;
 
-    goto_inlinet::call_listt &call_list=inline_map[f_it->first];
+    goto_inlinet::call_listt &call_list = inline_map[gf_entry.first];
 
     goto_programt &goto_program=goto_function.body;
 
@@ -86,11 +86,11 @@ void goto_inline(
     goto_functionst::entry_point(), entry_function, inline_map, true);
 
   // clean up
-  Forall_goto_functions(f_it, goto_functions)
+  for(auto &gf_entry : goto_functions.function_map)
   {
-    if(f_it->first!=goto_functionst::entry_point())
+    if(gf_entry.first != goto_functionst::entry_point())
     {
-      goto_functiont &goto_function=f_it->second;
+      goto_functiont &goto_function = gf_entry.second;
       goto_function.body.clear();
     }
   }
@@ -145,20 +145,22 @@ void goto_partial_inline(
   // gather all calls
   goto_inlinet::inline_mapt inline_map;
 
-  Forall_goto_functions(f_it, goto_functions)
+  for(auto &gf_entry : goto_functions.function_map)
   {
-    goto_functiont &goto_function=f_it->second;
+    goto_functiont &goto_function = gf_entry.second;
 
     if(!goto_function.body_available())
       continue;
 
-    if(f_it->first==goto_functions.entry_point())
+    if(gf_entry.first == goto_functions.entry_point())
+    {
       // Don't inline any function calls made from the _start function.
       continue;
+    }
 
     goto_programt &goto_program=goto_function.body;
 
-    goto_inlinet::call_listt &call_list=inline_map[f_it->first];
+    goto_inlinet::call_listt &call_list = inline_map[gf_entry.first];
 
     Forall_goto_program_instructions(i_it, goto_program)
     {

--- a/src/goto-programs/goto_inline_class.cpp
+++ b/src/goto-programs/goto_inline_class.cpp
@@ -469,11 +469,11 @@ void goto_inlinet::goto_inline(
 {
   PRECONDITION(check_inline_map(inline_map));
 
-  Forall_goto_functions(f_it, goto_functions)
+  for(auto &gf_entry : goto_functions.function_map)
   {
-    const irep_idt identifier=f_it->first;
+    const irep_idt identifier = gf_entry.first;
     DATA_INVARIANT(!identifier.empty(), "function name must not be empty");
-    goto_functiont &goto_function=f_it->second;
+    goto_functiont &goto_function = gf_entry.second;
 
     if(!goto_function.body_available())
       continue;
@@ -668,9 +668,9 @@ bool goto_inlinet::check_inline_map(
 
 bool goto_inlinet::check_inline_map(const inline_mapt &inline_map) const
 {
-  forall_goto_functions(f_it, goto_functions)
+  for(const auto &gf_entry : goto_functions.function_map)
   {
-    if(!check_inline_map(f_it->first, inline_map))
+    if(!check_inline_map(gf_entry.first, inline_map))
       return false;
   }
 

--- a/src/goto-programs/link_goto_model.cpp
+++ b/src/goto-programs/link_goto_model.cpp
@@ -62,13 +62,13 @@ static bool link_functions(
   namespacet src_ns(src_symbol_table);
 
   // merge functions
-  Forall_goto_functions(src_it, src_functions)
+  for(auto &gf_entry : src_functions.function_map)
   {
     // the function might have been renamed
-    rename_symbolt::expr_mapt::const_iterator e_it=
-      rename_symbol.expr_map.find(src_it->first);
+    rename_symbolt::expr_mapt::const_iterator e_it =
+      rename_symbol.expr_map.find(gf_entry.first);
 
-    irep_idt final_id=src_it->first;
+    irep_idt final_id = gf_entry.first;
 
     if(e_it!=rename_symbol.expr_map.end())
       final_id=e_it->second;
@@ -77,7 +77,7 @@ static bool link_functions(
     goto_functionst::function_mapt::iterator dest_f_it=
       dest_functions.function_map.find(final_id);
 
-    goto_functionst::goto_functiont &src_func = src_it->second;
+    goto_functionst::goto_functiont &src_func = gf_entry.second;
     if(dest_f_it==dest_functions.function_map.end()) // not there yet
     {
       rename_symbols_in_function(src_func, final_id, rename_symbol);
@@ -97,8 +97,9 @@ static bool link_functions(
         in_dest_symbol_table.parameter_identifiers.swap(
           src_func.parameter_identifiers);
       }
-      else if(src_func.body.instructions.empty() ||
-              src_ns.lookup(src_it->first).is_weak)
+      else if(
+        src_func.body.instructions.empty() ||
+        src_ns.lookup(gf_entry.first).is_weak)
       {
         // just keep the old one in dest
       }
@@ -136,17 +137,19 @@ static bool link_functions(
   }
 
   if(!macro_application.expr_map.empty())
-    Forall_goto_functions(dest_it, dest_functions)
+  {
+    for(auto &gf_entry : dest_functions.function_map)
     {
-      irep_idt final_id=dest_it->first;
-      rename_symbols_in_function(dest_it->second, final_id, macro_application);
+      irep_idt final_id = gf_entry.first;
+      rename_symbols_in_function(gf_entry.second, final_id, macro_application);
     }
+  }
 
   if(!object_type_updates.empty())
   {
-    Forall_goto_functions(dest_it, dest_functions)
+    for(auto &gf_entry : dest_functions.function_map)
     {
-      for(auto &instruction : dest_it->second.body.instructions)
+      for(auto &instruction : gf_entry.second.body.instructions)
       {
         instruction.transform([&object_type_updates](exprt expr) {
           object_type_updates(expr);

--- a/src/goto-programs/parameter_assignments.cpp
+++ b/src/goto-programs/parameter_assignments.cpp
@@ -86,8 +86,8 @@ void parameter_assignmentst::do_function_calls(
 
 void parameter_assignmentst::operator()(goto_functionst &goto_functions)
 {
-  Forall_goto_functions(it, goto_functions)
-    do_function_calls(it->second.body);
+  for(auto &gf_entry : goto_functions.function_map)
+    do_function_calls(gf_entry.second.body);
 }
 
 /// removes returns

--- a/src/goto-programs/remove_calls_no_body.cpp
+++ b/src/goto-programs/remove_calls_no_body.cpp
@@ -119,8 +119,8 @@ operator()(goto_programt &goto_program, const goto_functionst &goto_functions)
 /// \param goto_functions: goto functions to operate on
 void remove_calls_no_bodyt::operator()(goto_functionst &goto_functions)
 {
-  Forall_goto_functions(f_it, goto_functions)
+  for(auto &gf_entry : goto_functions.function_map)
   {
-    (*this)(f_it->second.body, goto_functions);
+    (*this)(gf_entry.second.body, goto_functions);
   }
 }

--- a/src/goto-programs/remove_complex.cpp
+++ b/src/goto-programs/remove_complex.cpp
@@ -298,8 +298,8 @@ static void remove_complex(
 /// removes complex data type
 static void remove_complex(goto_functionst &goto_functions)
 {
-  Forall_goto_functions(it, goto_functions)
-    remove_complex(it->second);
+  for(auto &gf_entry : goto_functions.function_map)
+    remove_complex(gf_entry.second);
 }
 
 /// removes complex data type

--- a/src/goto-programs/remove_function_pointers.cpp
+++ b/src/goto-programs/remove_function_pointers.cpp
@@ -123,8 +123,11 @@ remove_function_pointerst::remove_function_pointerst(
   compute_address_taken_functions(goto_functions, address_taken);
 
   // build type map
-  forall_goto_functions(f_it, goto_functions)
-    type_map.emplace(f_it->first, to_code_type(ns.lookup(f_it->first).type));
+  for(const auto &gf_entry : goto_functions.function_map)
+  {
+    type_map.emplace(
+      gf_entry.first, to_code_type(ns.lookup(gf_entry.first).type));
+  }
 }
 
 bool remove_function_pointerst::arg_is_type_compatible(

--- a/src/goto-programs/remove_skip.cpp
+++ b/src/goto-programs/remove_skip.cpp
@@ -193,11 +193,13 @@ void remove_skip(goto_programt &goto_program)
 /// remove unnecessary skip statements
 void remove_skip(goto_functionst &goto_functions)
 {
-  Forall_goto_functions(f_it, goto_functions)
+  for(auto &gf_entry : goto_functions.function_map)
+  {
     remove_skip(
-      f_it->second.body,
-      f_it->second.body.instructions.begin(),
-      f_it->second.body.instructions.end());
+      gf_entry.second.body,
+      gf_entry.second.body.instructions.begin(),
+      gf_entry.second.body.instructions.end());
+  }
 
   // we may remove targets
   goto_functions.update();

--- a/src/goto-programs/remove_unreachable.cpp
+++ b/src/goto-programs/remove_unreachable.cpp
@@ -63,6 +63,6 @@ void remove_unreachable(goto_programt &goto_program)
 /// \return None.
 void remove_unreachable(goto_functionst &goto_functions)
 {
-  Forall_goto_functions(f_it, goto_functions)
-    remove_unreachable(f_it->second.body);
+  for(auto &gf_entry : goto_functions.function_map)
+    remove_unreachable(gf_entry.second.body);
 }

--- a/src/goto-programs/remove_vector.cpp
+++ b/src/goto-programs/remove_vector.cpp
@@ -232,8 +232,8 @@ void remove_vector(goto_functionst::goto_functiont &goto_function)
 /// removes vector data type
 static void remove_vector(goto_functionst &goto_functions)
 {
-  Forall_goto_functions(it, goto_functions)
-    remove_vector(it->second);
+  for(auto &gf_entry : goto_functions.function_map)
+    remove_vector(gf_entry.second);
 }
 
 /// removes vector data type

--- a/src/goto-programs/rewrite_union.cpp
+++ b/src/goto-programs/rewrite_union.cpp
@@ -116,8 +116,8 @@ void rewrite_union(goto_functionst::goto_functiont &goto_function)
 
 void rewrite_union(goto_functionst &goto_functions)
 {
-  Forall_goto_functions(it, goto_functions)
-    rewrite_union(it->second);
+  for(auto &gf_entry : goto_functions.function_map)
+    rewrite_union(gf_entry.second);
 }
 
 void rewrite_union(goto_modelt &goto_model)

--- a/src/goto-programs/set_properties.cpp
+++ b/src/goto-programs/set_properties.cpp
@@ -108,8 +108,8 @@ void set_properties(
 
   property_set.insert(properties.begin(), properties.end());
 
-  Forall_goto_functions(it, goto_functions)
-    set_properties(it->second.body, property_set);
+  for(auto &gf_entry : goto_functions.function_map)
+    set_properties(gf_entry.second.body, property_set);
 
   if(!property_set.empty())
     throw invalid_command_line_argument_exceptiont(

--- a/src/goto-programs/string_abstraction.cpp
+++ b/src/goto-programs/string_abstraction.cpp
@@ -129,11 +129,11 @@ typet string_abstractiont::build_type(whatt what)
 
 void string_abstractiont::operator()(goto_functionst &dest)
 {
-  Forall_goto_functions(it, dest)
+  for(auto &gf_entry : dest.function_map)
   {
-    sym_suffix="#str$"+id2string(it->first);
-    add_str_arguments(it->first, it->second);
-    abstract(it->second.body);
+    sym_suffix = "#str$" + id2string(gf_entry.first);
+    add_str_arguments(gf_entry.first, gf_entry.second);
+    abstract(gf_entry.second.body);
     current_args.clear();
   }
 

--- a/src/goto-programs/write_goto_binary.cpp
+++ b/src/goto-programs/write_goto_binary.cpp
@@ -76,9 +76,11 @@ bool write_goto_binary(
   // now write functions, but only those with body
 
   unsigned cnt=0;
-  forall_goto_functions(it, goto_functions)
-    if(it->second.body_available())
+  for(const auto &gf_entry : goto_functions.function_map)
+  {
+    if(gf_entry.second.body_available())
       cnt++;
+  }
 
   write_gb_word(out, cnt);
 

--- a/src/pointer-analysis/goto_program_dereference.cpp
+++ b/src/pointer-analysis/goto_program_dereference.cpp
@@ -284,8 +284,8 @@ void remove_pointers(
     goto_program_dereference(
       ns, goto_model.symbol_table, options, value_sets);
 
-  Forall_goto_functions(it, goto_model.goto_functions)
-    goto_program_dereference.dereference_program(it->second.body);
+  for(auto &gf_entry : goto_model.goto_functions.function_map)
+    goto_program_dereference.dereference_program(gf_entry.second.body);
 }
 
 /// Remove dereferences in `expr` using `value_sets` to determine to what

--- a/src/pointer-analysis/value_set_analysis_fi.cpp
+++ b/src/pointer-analysis/value_set_analysis_fi.cpp
@@ -125,11 +125,11 @@ void value_set_analysis_fit::add_vars(
   value_set_fit &v=state.value_set;
   v.add_vars(globals);
 
-  forall_goto_functions(f_it, goto_functions)
+  for(const auto &gf_entry : goto_functions.function_map)
   {
     // get the locals
     std::set<irep_idt> locals;
-    get_local_identifiers(f_it->second, locals);
+    get_local_identifiers(gf_entry.second, locals);
 
     for(auto l : locals)
     {

--- a/unit/analyses/ai/ai.cpp
+++ b/unit/analyses/ai/ai.cpp
@@ -250,9 +250,9 @@ SCENARIO(
 
     THEN("No state should be bottom")
     {
-      forall_goto_functions(f_it, goto_model.goto_functions)
+      for(const auto &gf_entry : goto_model.goto_functions.function_map)
       {
-        forall_goto_program_instructions(i_it, f_it->second.body)
+        forall_goto_program_instructions(i_it, gf_entry.second.body)
         {
           REQUIRE_FALSE(example_analysis[i_it].is_bottom());
         }


### PR DESCRIPTION
This was useful in the past, but with C++-11 we can use a ranged-for to
avoid the iterator altogether (in all but the cases in goto-diff, where
we now make the iterator explicit).

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
