### PR TITLE
compilet isn't a messaget

### DIFF
--- a/src/goto-cc/compile.h
+++ b/src/goto-cc/compile.h
@@ -23,7 +23,7 @@ Date: June 2006
 class language_filest;
 class languaget;
 
-class compilet : public messaget
+class compilet
 {
 public:
   // configuration
@@ -102,6 +102,7 @@ protected:
   std::list<std::string> tmp_dirs;
   std::list<irep_idt> seen_modes;
 
+  messaget log;
   cmdlinet &cmdline;
   bool warning_is_fatal;
 
@@ -118,7 +119,10 @@ protected:
     const goto_modelt &src_goto_model)
   {
     if(write_bin_object_file(
-         file_name, src_goto_model, validate_goto_model, get_message_handler()))
+         file_name,
+         src_goto_model,
+         validate_goto_model,
+         log.get_message_handler()))
     {
       return true;
     }


### PR DESCRIPTION
Use a messaget member instead as there is no is-a relationship between
compilet and messaget.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
