### PR TITLE
Mark unnecessarily-public members of compilet protected

### DIFF
--- a/src/goto-cc/compile.h
+++ b/src/goto-cc/compile.h
@@ -27,13 +27,10 @@ class compilet : public messaget
 {
 public:
   // compilation results
-  namespacet ns;
   goto_modelt goto_model;
 
   // configuration
   bool echo_file_name;
-  std::string working_directory;
-  std::string override_language;
   bool validate_goto_model = false;
 
   enum { PREPROCESS_ONLY, // gcc -E
@@ -48,8 +45,6 @@ public:
   std::list<std::string> source_files;
   std::list<std::string> object_files;
   std::list<std::string> libraries;
-  std::list<std::string> tmp_dirs;
-  std::list<irep_idt> seen_modes;
 
   std::string object_file_extension;
   std::string output_file_executable;
@@ -93,6 +88,14 @@ public:
   }
 
 protected:
+  namespacet ns;
+
+  std::string working_directory;
+  std::string override_language;
+
+  std::list<std::string> tmp_dirs;
+  std::list<irep_idt> seen_modes;
+
   cmdlinet &cmdline;
   bool warning_is_fatal;
 


### PR DESCRIPTION
compilet has several public members, which should eventually have
setters/getters instead. To make clearer which those are, first mark
those that aren't needed outside the class protected.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
