### PR TITLE
goto_cc_modet isn't a messaget

### DIFF
--- a/src/goto-cc/armcc_mode.cpp
+++ b/src/goto-cc/armcc_mode.cpp
@@ -46,10 +46,11 @@ int armcc_modet::doit()
     has_prefix(base_name, "goto-link");
   #endif
 
-  const auto verbosity = eval_verbosity(
+  const auto verbosity = messaget::eval_verbosity(
     cmdline.get_value("verbosity"), messaget::M_ERROR, message_handler);
 
-  debug() << "ARM mode" << eom;
+  messaget log{message_handler};
+  log.debug() << "ARM mode" << messaget::eom;
 
   // model validation
   compiler.validate_goto_model = cmdline.isset("validate-goto-model");

--- a/src/goto-cc/as_mode.cpp
+++ b/src/goto-cc/as_mode.cpp
@@ -75,6 +75,8 @@ int as_modet::doit()
     return EX_OK;
   }
 
+  messaget log{message_handler};
+
   bool act_as_as86=
     base_name=="as86" ||
     base_name.find("goto-as86")!=std::string::npos;
@@ -83,40 +85,44 @@ int as_modet::doit()
      cmdline.isset("version"))
   {
     if(act_as_as86)
-      status() << "as86 version: 0.16.17 (goto-cc " << CBMC_VERSION << ")"
-               << eom;
+    {
+      log.status() << "as86 version: 0.16.17 (goto-cc " << CBMC_VERSION << ")"
+                   << messaget::eom;
+    }
     else
-      status() << "GNU assembler version 2.20.51.0.7 20100318"
-               << " (goto-cc " << CBMC_VERSION << ")" << eom;
+    {
+      log.status() << "GNU assembler version 2.20.51.0.7 20100318"
+                   << " (goto-cc " << CBMC_VERSION << ")" << messaget::eom;
+    }
 
-    status()
+    log.status()
       << '\n'
       << "Copyright (C) 2006-2014 Daniel Kroening, Christoph Wintersteiger\n"
       << "CBMC version: " << CBMC_VERSION << '\n'
       << "Architecture: " << config.this_architecture() << '\n'
-      << "OS: " << config.this_operating_system() << eom;
+      << "OS: " << config.this_operating_system() << messaget::eom;
 
     return EX_OK; // Exit!
   }
 
   auto default_verbosity = (cmdline.isset("w-") || cmdline.isset("warn")) ?
     messaget::M_WARNING : messaget::M_ERROR;
-  eval_verbosity(
+  messaget::eval_verbosity(
     cmdline.get_value("verbosity"), default_verbosity, message_handler);
 
   if(act_as_as86)
   {
     if(produce_hybrid_binary)
-      debug() << "AS86 mode (hybrid)" << eom;
+      log.debug() << "AS86 mode (hybrid)" << messaget::eom;
     else
-      debug() << "AS86 mode" << eom;
+      log.debug() << "AS86 mode" << messaget::eom;
   }
   else
   {
     if(produce_hybrid_binary)
-      debug() << "AS mode (hybrid)" << eom;
+      log.debug() << "AS mode (hybrid)" << messaget::eom;
     else
-      debug() << "AS mode" << eom;
+      log.debug() << "AS mode" << messaget::eom;
   }
 
   // get configuration
@@ -128,12 +134,12 @@ int as_modet::doit()
   if(cmdline.isset('b')) // as86 only
   {
     compiler.mode=compilet::COMPILE_LINK_EXECUTABLE;
-    debug() << "Compiling and linking an executable" << eom;
+    log.debug() << "Compiling and linking an executable" << messaget::eom;
   }
   else
   {
     compiler.mode=compilet::COMPILE_LINK;
-    debug() << "Compiling and linking a library" << eom;
+    log.debug() << "Compiling and linking a library" << messaget::eom;
   }
 
   config.ansi_c.mode=configt::ansi_ct::flavourt::GCC;
@@ -173,7 +179,7 @@ int as_modet::doit()
     std::ifstream is(infile);
     if(!is.is_open())
     {
-      error() << "Failed to open input source " << infile << eom;
+      log.error() << "Failed to open input source " << infile << messaget::eom;
       return 1;
     }
 
@@ -208,7 +214,7 @@ int as_modet::doit()
         os.open(dest);
         if(!os.is_open())
         {
-          error() << "Failed to tmp output file " << dest << eom;
+          log.error() << "Failed to tmp output file " << dest << messaget::eom;
           return 1;
         }
 
@@ -227,7 +233,10 @@ int as_modet::doit()
       compiler.add_input_file(dest);
     }
     else
-      warning() << "No GOTO-CC section found in " << arg_it->arg << eom;
+    {
+      log.warning() << "No GOTO-CC section found in " << arg_it->arg
+                    << messaget::eom;
+    }
   }
 
   // Revert to as in case there is no source to compile
@@ -285,8 +294,9 @@ int as_modet::as_hybrid_binary(const compilet &compiler)
   if(output_file=="/dev/null")
     return EX_OK;
 
-  debug() << "Running " << native_tool_name
-          << " to generate hybrid binary" << eom;
+  messaget log{message_handler};
+  log.debug() << "Running " << native_tool_name << " to generate hybrid binary"
+              << messaget::eom;
 
   // save the goto-cc output file
   std::string saved = output_file + ".goto-cc-saved";
@@ -296,7 +306,7 @@ int as_modet::as_hybrid_binary(const compilet &compiler)
   }
   catch(const cprover_exception_baset &e)
   {
-    error() << "Rename failed: " << e.what() << eom;
+    log.error() << "Rename failed: " << e.what() << messaget::eom;
     return 1;
   }
 
@@ -309,7 +319,7 @@ int as_modet::as_hybrid_binary(const compilet &compiler)
       saved,
       output_file,
       compiler.mode == compilet::COMPILE_LINK_EXECUTABLE,
-      get_message_handler());
+      message_handler);
   }
 
   return result;

--- a/src/goto-cc/cw_mode.cpp
+++ b/src/goto-cc/cw_mode.cpp
@@ -46,10 +46,11 @@ int cw_modet::doit()
     has_prefix(base_name, "goto-link");
   #endif
 
-  const auto verbosity = eval_verbosity(
+  const auto verbosity = messaget::eval_verbosity(
     cmdline.get_value("verbosity"), messaget::M_ERROR, message_handler);
 
-  debug() << "CodeWarrior mode" << eom;
+  messaget log{message_handler};
+  log.debug() << "CodeWarrior mode" << messaget::eom;
 
   // model validation
   compiler.validate_goto_model = cmdline.isset("validate-goto-model");

--- a/src/goto-cc/goto_cc_mode.cpp
+++ b/src/goto-cc/goto_cc_mode.cpp
@@ -23,6 +23,7 @@ Author: CM Wintersteiger, 2006
 #endif
 
 #include <util/exception_utils.h>
+#include <util/message.h>
 #include <util/parse_options.h>
 #include <util/version.h>
 
@@ -30,10 +31,8 @@ Author: CM Wintersteiger, 2006
 goto_cc_modet::goto_cc_modet(
   goto_cc_cmdlinet &_cmdline,
   const std::string &_base_name,
-  message_handlert &_message_handler):
-  messaget(_message_handler),
-  cmdline(_cmdline),
-  base_name(_base_name)
+  message_handlert &_message_handler)
+  : cmdline(_cmdline), base_name(_base_name), message_handler(_message_handler)
 {
   register_languages();
 }
@@ -88,13 +87,15 @@ int goto_cc_modet::main(int argc, const char **argv)
 
   catch(const char *e)
   {
-    error() << e << eom;
+    messaget log{message_handler};
+    log.error() << e << messaget::eom;
     return EX_SOFTWARE;
   }
 
   catch(const std::string &e)
   {
-    error() << e << eom;
+    messaget log{message_handler};
+    log.error() << e << messaget::eom;
     return EX_SOFTWARE;
   }
 
@@ -105,12 +106,14 @@ int goto_cc_modet::main(int argc, const char **argv)
 
   catch(const std::bad_alloc &)
   {
-    error() << "Out of memory" << eom;
+    messaget log{message_handler};
+    log.error() << "Out of memory" << messaget::eom;
     return EX_SOFTWARE;
   }
   catch(const cprover_exception_baset &e)
   {
-    error() << e.what() << eom;
+    messaget log{message_handler};
+    log.error() << e.what() << messaget::eom;
     return EX_SOFTWARE;
   }
 }

--- a/src/goto-cc/goto_cc_mode.h
+++ b/src/goto-cc/goto_cc_mode.h
@@ -16,9 +16,9 @@ Date: June 2006
 
 #include "goto_cc_cmdline.h"
 
-#include <util/message.h>
+class message_handlert;
 
-class goto_cc_modet:public messaget
+class goto_cc_modet
 {
 public:
   int main(int argc, const char **argv);
@@ -36,6 +36,7 @@ public:
 protected:
   goto_cc_cmdlinet &cmdline;
   const std::string base_name;
+  message_handlert &message_handler;
   void register_languages();
 };
 

--- a/src/goto-cc/ld_mode.cpp
+++ b/src/goto-cc/ld_mode.cpp
@@ -88,7 +88,7 @@ int ld_modet::doit()
   if(cmdline.isset("version") || cmdline.isset("print-sysroot"))
     return run_ld();
 
-  eval_verbosity(
+  messaget::eval_verbosity(
     cmdline.get_value("verbosity"), messaget::M_ERROR, gcc_message_handler);
 
   compilet compiler(cmdline, gcc_message_handler, false);
@@ -161,10 +161,11 @@ int ld_modet::run_ld()
   // overwrite argv[0]
   new_argv[0] = native_tool_name;
 
-  debug() << "RUN:";
+  messaget log{gcc_message_handler};
+  log.debug() << "RUN:";
   for(std::size_t i = 0; i < new_argv.size(); i++)
-    debug() << " " << new_argv[i];
-  debug() << eom;
+    log.debug() << " " << new_argv[i];
+  log.debug() << messaget::eom;
 
   return run(new_argv[0], new_argv, cmdline.stdin_file, "", "");
 }
@@ -183,8 +184,9 @@ int ld_modet::ld_hybrid_binary(compilet &compiler)
   else
     output_file = "a.out";
 
-  debug() << "Running " << native_tool_name << " to generate hybrid binary"
-          << eom;
+  messaget log{gcc_message_handler};
+  log.debug() << "Running " << native_tool_name << " to generate hybrid binary"
+              << messaget::eom;
 
   // save the goto-cc output file
   std::string goto_binary = output_file + goto_binary_tmp_suffix;
@@ -195,7 +197,7 @@ int ld_modet::ld_hybrid_binary(compilet &compiler)
   }
   catch(const cprover_exception_baset &e)
   {
-    error() << "Rename failed: " << e.what() << eom;
+    log.error() << "Rename failed: " << e.what() << messaget::eom;
     return 1;
   }
 
@@ -204,7 +206,7 @@ int ld_modet::ld_hybrid_binary(compilet &compiler)
   if(result == 0 && cmdline.isset('T'))
   {
     linker_script_merget ls_merge(
-      compiler, output_file, goto_binary, cmdline, get_message_handler());
+      compiler, output_file, goto_binary, cmdline, message_handler);
     result = ls_merge.add_linker_script_definitions();
   }
 
@@ -217,7 +219,7 @@ int ld_modet::ld_hybrid_binary(compilet &compiler)
       goto_binary,
       output_file,
       compiler.mode == compilet::COMPILE_LINK_EXECUTABLE,
-      get_message_handler());
+      message_handler);
   }
 
   return result;

--- a/src/goto-cc/ms_cl_mode.cpp
+++ b/src/goto-cc/ms_cl_mode.cpp
@@ -57,13 +57,14 @@ int ms_cl_modet::doit()
     has_prefix(base_name, "goto-link");
   #endif
 
-  const auto verbosity = eval_verbosity(
+  const auto verbosity = messaget::eval_verbosity(
     cmdline.get_value("verbosity"), messaget::M_ERROR, message_handler);
 
   ms_cl_versiont ms_cl_version;
   ms_cl_version.get("cl.exe");
 
-  debug() << "Visual Studio mode " << ms_cl_version << eom;
+  messaget log{message_handler};
+  log.debug() << "Visual Studio mode " << ms_cl_version << messaget::eom;
 
   // model validation
   compiler.validate_goto_model = cmdline.isset("validate-goto-model");
@@ -109,7 +110,10 @@ int ms_cl_modet::doit()
       config.cpp.set_cpp11();
     }
     else
-      warning() << "unknown language standard " << std_string << eom;
+    {
+      log.warning() << "unknown language standard " << std_string
+                    << messaget::eom;
+    }
   }
   else
     config.cpp.set_cpp14();
@@ -126,7 +130,7 @@ int ms_cl_modet::doit()
       compiler.output_directory_object = Fo_value;
 
       if(!is_directory(Fo_value))
-        warning() << "not a directory: " << Fo_value << eom;
+        log.warning() << "not a directory: " << Fo_value << messaget::eom;
     }
     else
       compiler.output_file_object = Fo_value;
@@ -137,8 +141,8 @@ int ms_cl_modet::doit()
     cmdline.args.size() > 1 &&
     compiler.output_directory_object.empty())
   {
-    error() << "output directory required for /c with multiple input files"
-            << eom;
+    log.error() << "output directory required for /c with multiple input files"
+                << messaget::eom;
     return EX_USAGE;
   }
 
@@ -152,8 +156,10 @@ int ms_cl_modet::doit()
       cmdline.args.size() >= 1)
     {
       if(!is_directory(compiler.output_file_executable))
-        warning() << "not a directory: "
-                  << compiler.output_file_executable << eom;
+      {
+        log.warning() << "not a directory: " << compiler.output_file_executable
+                      << messaget::eom;
+      }
 
       compiler.output_file_executable+=
         get_base_name(cmdline.args[0], true) + ".exe";

--- a/src/goto-cc/ms_link_mode.cpp
+++ b/src/goto-cc/ms_link_mode.cpp
@@ -30,7 +30,7 @@ int ms_link_modet::doit()
     return 0;
   }
 
-  eval_verbosity(
+  messaget::eval_verbosity(
     cmdline.get_value("verbosity"), messaget::M_ERROR, message_handler);
 
   compilet compiler(cmdline, message_handler, false);


### PR DESCRIPTION
Use local messaget instances instead as there is no is-a relationship
between goto_cc_modet (nor any class deriving from it) and messaget.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
