### PR TITLE
linker_script_merget isn't a messaget

### DIFF
--- a/src/goto-cc/linker_script_merge.h
+++ b/src/goto-cc/linker_script_merge.h
@@ -59,7 +59,7 @@ private:
 };
 
 /// \brief Synthesise definitions of symbols that are defined in linker scripts
-class linker_script_merget:public messaget
+class linker_script_merget
 {
 public:
   /// \brief Add values of linkerscript-defined symbols to the goto-binary
@@ -90,6 +90,7 @@ protected:
   const std::string &elf_binary;
   const std::string &goto_binary;
   const cmdlinet &cmdline;
+  messaget log;
 
   /// \brief The "shapes" of expressions to be replaced by a pointer
   ///


### PR DESCRIPTION
Use a messaget member instead as there is no is-a relationship between
linker_script_merget and messaget.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
