### PR TITLE
string_abstractiont isn't a messaget

### DIFF
--- a/src/goto-programs/string_abstraction.cpp
+++ b/src/goto-programs/string_abstraction.cpp
@@ -17,6 +17,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/c_types.h>
 #include <util/exception_utils.h>
 #include <util/expr_util.h>
+#include <util/message.h>
 #include <util/pointer_predicates.h>
 #include <util/string_constant.h>
 
@@ -44,8 +45,9 @@ bool string_abstractiont::build_wrap(
     !(dest.type().id() == ID_array && a_t.id() == ID_pointer &&
       dest.type().subtype() == a_t.subtype()))
   {
-    warning() << "warning: inconsistent abstract type for "
-              << object.pretty() << eom;
+    messaget log{message_handler};
+    log.warning() << "warning: inconsistent abstract type for "
+                  << object.pretty() << messaget::eom;
     return true;
   }
 
@@ -92,13 +94,13 @@ void string_abstraction(
 
 string_abstractiont::string_abstractiont(
   symbol_tablet &_symbol_table,
-  message_handlert &_message_handler):
-  messaget(_message_handler),
-  arg_suffix("#strarg"),
-  sym_suffix("#str$fcn"),
-  symbol_table(_symbol_table),
-  ns(_symbol_table),
-  temporary_counter(0)
+  message_handlert &_message_handler)
+  : arg_suffix("#strarg"),
+    sym_suffix("#str$fcn"),
+    symbol_table(_symbol_table),
+    ns(_symbol_table),
+    temporary_counter(0),
+    message_handler(_message_handler)
 {
   struct_typet s({{"is_zero", build_type(whatt::IS_ZERO)},
                   {"length", build_type(whatt::LENGTH)},

--- a/src/goto-programs/string_abstraction.h
+++ b/src/goto-programs/string_abstraction.h
@@ -13,18 +13,19 @@ Author: Daniel Kroening, kroening@kroening.com
 #define CPROVER_GOTO_PROGRAMS_STRING_ABSTRACTION_H
 
 #include <util/symbol_table.h>
-#include <util/message.h>
 #include <util/config.h>
 #include <util/std_expr.h>
 
 #include "goto_model.h"
+
+class message_handlert;
 
 /// Replace all uses of `char *` by a struct that carries that string, and also
 /// the underlying allocation and the C string length.
 /// This will become useful (with some modifications) for supporting strings in
 /// the C frontend, as the string solver expects a struct that bundles the
 /// string length and the underlying character array.
-class string_abstractiont:public messaget
+class string_abstractiont
 {
 public:
   string_abstractiont(
@@ -40,6 +41,7 @@ protected:
   symbol_tablet &symbol_table;
   namespacet ns;
   unsigned temporary_counter;
+  message_handlert &message_handler;
 
   typedef ::std::map< typet, typet > abstraction_types_mapt;
   abstraction_types_mapt abstraction_types_map;


### PR DESCRIPTION
Use a local messaget instance instead as there is no is-a relationship
between string_abstractiont and messaget.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
