### PR TITLE
Install symtab2gb and add it to CPack installers

### DIFF
--- a/src/symtab2gb/CMakeLists.txt
+++ b/src/symtab2gb/CMakeLists.txt
@@ -9,3 +9,5 @@ target_link_libraries(symtab2gb
         util
         goto-programs
         json-symtab-language)
+
+install(TARGETS symtab2gb DESTINATION ${CMAKE_INSTALL_BINDIR})


### PR DESCRIPTION
It was previously omitted from the list of installed targets by accident.

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
