### PR TITLE
Fix MacOS ARM platform configuration

### DIFF
--- a/src/util/config.cpp
+++ b/src/util/config.cpp
@@ -998,6 +998,13 @@ bool configt::set(const cmdlinet &cmdline)
     else
       ansi_c.long_double_width=8*8;
   }
+  else if(os == "macos" && arch == "arm64")
+  {
+    // https://developer.apple.com/documentation/xcode/
+    // writing_arm64_code_for_apple_platforms#//apple_ref/doc/uid/TP40013702-SW1
+    ansi_c.char_is_unsigned = false;
+    ansi_c.long_double_width = 8 * 8;
+  }
 
   // Let's check some of the type widths in case we run
   // the same architecture and OS that we are verifying for.


### PR DESCRIPTION
Apple decided to deviate from aarch64 configurations used by other
Unix-like operating systems as documented at
https://developer.apple.com/documentation/xcode/writing_arm64_code_for_apple_platforms#//apple_ref/doc/uid/TP40013702-SW1.

Fixes: #5627

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
