### PR TITLE
goto_analyzer --verify now prints histories in the XML and JSON output

### DIFF
--- a/regression/goto-analyzer/history-output/json.desc
+++ b/regression/goto-analyzer/history-output/json.desc
@@ -1,0 +1,11 @@
+CORE
+main.c
+--verify --recursive-interprocedural --one-domain-per-history --vsd --branching 4 --json -
+^EXIT=0$
+^SIGNAL=0$
+\"falseHistories\": \[ \"local_control_flow_history : location \d+ after \d+ not taken after \d+ taken\" \]
+\"unknownHistories\": \[ \"local_control_flow_history : location \d+ after \d+ taken after \d+ taken\" \]
+--
+^warning: ignoring
+--
+Make sure that the JSON output contains the histories in which the assertion is false and unknown

--- a/regression/goto-analyzer/history-output/main.c
+++ b/regression/goto-analyzer/history-output/main.c
@@ -1,0 +1,28 @@
+#include <assert.h>
+
+int main(int argc, char **argv)
+{
+  int nondet1;
+  int nondet2;
+  int x;
+
+  if(nondet1)
+  {
+    // Taking this path the assertion clearly holds
+    x = 1;
+  }
+  else
+  {
+    if(nondet2)
+    {
+      // Taking this path the assertion clearly fails
+      x = 0;
+    }
+    // Not taking the branch means the assertion is unknown
+    // because x is non-deterministic
+  }
+
+  assert(x);
+
+  return 0;
+}

--- a/regression/goto-analyzer/history-output/xml.desc
+++ b/regression/goto-analyzer/history-output/xml.desc
@@ -1,0 +1,11 @@
+CORE
+main.c
+--verify --recursive-interprocedural --one-domain-per-history --vsd --branching 4 --xml -
+^EXIT=0$
+^SIGNAL=0$
+<history>local_control_flow_history : location \d+ after \d+ taken after \d+ taken<\/history>
+<history>local_control_flow_history : location \d+ after \d+ not taken after \d+ taken<\/history>
+--
+^warning: ignoring
+--
+Make sure that the JSON output contains the histories in which the assertion is false and unknown

--- a/src/goto-analyzer/static_verifier.cpp
+++ b/src/goto-analyzer/static_verifier.cpp
@@ -115,24 +115,7 @@ static void static_verifier_xml(
   {
     xmlt &x = xml_result.new_element("result");
 
-    switch(result.status)
-    {
-    case static_verifier_resultt::TRUE:
-      x.set_attribute("status", "SUCCESS");
-      break;
-
-    case static_verifier_resultt::FALSE:
-      x.set_attribute("status", "FAILURE (if reachable)");
-      break;
-
-    case static_verifier_resultt::BOTTOM:
-      x.set_attribute("status", "SUCCESS (unreachable)");
-      break;
-
-    case static_verifier_resultt::UNKNOWN:
-      x.set_attribute("status", "UNKNOWN");
-    }
-
+    x.set_attribute("status", message(result.status));
     x.set_attribute("file", id2string(result.source_location.get_file()));
     x.set_attribute("line", id2string(result.source_location.get_line()));
     x.set_attribute(
@@ -167,28 +150,7 @@ static void static_verifier_text(
     if(!result.source_location.get_comment().empty())
       out << ", " << result.source_location.get_comment();
 
-    out << ": ";
-
-    switch(result.status)
-    {
-    case static_verifier_resultt::TRUE:
-      out << "Success";
-      break;
-
-    case static_verifier_resultt::FALSE:
-      out << "Failure (if reachable)";
-      break;
-
-    case static_verifier_resultt::BOTTOM:
-      out << "Success (unreachable)";
-      break;
-
-    case static_verifier_resultt::UNKNOWN:
-      out << "Unknown";
-      break;
-    }
-
-    out << '\n';
+    out << ": " << message(result.status) << '\n';
   }
 }
 

--- a/src/goto-analyzer/static_verifier.cpp
+++ b/src/goto-analyzer/static_verifier.cpp
@@ -52,6 +52,122 @@ check_assertion(const ai_domain_baset &domain, exprt e, const namespacet &ns)
   UNREACHABLE;
 }
 
+static static_verifier_resultt check_assertion(
+  const ai_baset &ai,
+  goto_programt::const_targett assert_location,
+  irep_idt function_id,
+  const namespacet &ns)
+{
+  static_verifier_resultt result;
+
+  PRECONDITION(assert_location->is_assert());
+  exprt e(assert_location->get_condition());
+
+  // If there are multiple, distinct histories that reach the same location
+  // we can get better results by checking with each individually rather
+  // than merging all of them and doing one check.
+  const auto trace_set_pointer = ai.abstract_traces_before(
+    assert_location); // Keep a pointer so refcount > 0
+  const auto &trace_set = *trace_set_pointer;
+
+  if(trace_set.size() == 0) // i.e. unreachable
+  {
+    result.status = static_verifier_resultt::BOTTOM;
+  }
+  else if(trace_set.size() == 1)
+  {
+    auto dp = ai.abstract_state_before(assert_location);
+
+    result.status = check_assertion(*dp, e, ns);
+  }
+  else
+  {
+    // Multiple traces, verify against each one
+    std::size_t unreachable_traces = 0;
+    std::size_t true_traces = 0;
+    std::size_t false_traces = 0;
+    std::size_t unknown_traces = 0;
+
+    for(const auto &trace_ptr : trace_set)
+    {
+      auto dp = ai.abstract_state_before(trace_ptr);
+
+      result.status = check_assertion(*dp, e, ns);
+      switch(result.status)
+      {
+      case static_verifier_resultt::BOTTOM:
+        ++unreachable_traces;
+        break;
+      case static_verifier_resultt::TRUE:
+        ++true_traces;
+        break;
+      case static_verifier_resultt::FALSE:
+        ++false_traces;
+        break;
+      case static_verifier_resultt::UNKNOWN:
+        ++unknown_traces;
+        break;
+      default:
+        UNREACHABLE;
+      }
+    }
+
+    // Join the results
+    if(unknown_traces != 0)
+    {
+      // If any trace is unknown, the final result must be unknown
+      result.status = static_verifier_resultt::UNKNOWN;
+    }
+    else
+    {
+      if(false_traces == 0)
+      {
+        // Definitely true; the only question is how
+        if(true_traces == 0)
+        {
+          // Definitely not reachable
+          INVARIANT(
+            unreachable_traces == trace_set.size(),
+            "All traces must not reach the assertion");
+          result.status = static_verifier_resultt::BOTTOM;
+        }
+        else
+        {
+          // At least one trace (may) reach it.
+          // All traces that reach it are safe.
+          result.status = static_verifier_resultt::TRUE;
+        }
+      }
+      else
+      {
+        // At lease one trace (may) reach it and it is false on that trace
+        if(true_traces == 0)
+        {
+          // All traces that (may) reach it are false
+          result.status = static_verifier_resultt::FALSE;
+        }
+        else
+        {
+          // The awkward case, there are traces that (may) reach it and
+          // some are true, some are false.  It is not entirely fair to say
+          // "FAILURE (if reachable)" because it's a bit more complex than
+          // that, "FAILURE (if reachable via a particular trace)" would be
+          // more accurate summary of what we know at this point.
+          // Given that all results of FAILURE from this analysis are
+          // caveated with some reachability questions, the following is not
+          // entirely unreasonable.
+          result.status = static_verifier_resultt::FALSE;
+        }
+      }
+    }
+  }
+
+  result.source_location = assert_location->source_location;
+  result.function_id = function_id;
+
+  return result;
+}
+
 void static_verifier(
   const abstract_goto_modelt &abstract_goto_model,
   const ai_baset &ai,
@@ -286,134 +402,25 @@ bool static_verifier(
       if(!i_it->is_assert())
         continue;
 
-      exprt e(i_it->get_condition());
+      results.push_back(check_assertion(ai, i_it, f.first, ns));
 
-      results.push_back(static_verifier_resultt());
-      auto &result = results.back();
-
-      // If there are multiple, distinct histories that reach the same location
-      // we can get better results by checking with each individually rather
-      // than merging all of them and doing one check.
-      const auto trace_set_pointer =
-        ai.abstract_traces_before(i_it); // Keep a pointer so refcount > 0
-      const auto &trace_set = *trace_set_pointer;
-
-      if(trace_set.size() == 0) // i.e. unreachable
+      switch(results.back().status)
       {
-        result.status = static_verifier_resultt::BOTTOM;
+      case static_verifier_resultt::BOTTOM:
         ++pass;
+        break;
+      case static_verifier_resultt::TRUE:
+        ++pass;
+        break;
+      case static_verifier_resultt::FALSE:
+        ++fail;
+        break;
+      case static_verifier_resultt::UNKNOWN:
+        ++unknown;
+        break;
+      default:
+        UNREACHABLE;
       }
-      else if(trace_set.size() == 1)
-      {
-        auto dp = ai.abstract_state_before(i_it);
-
-        result.status = check_assertion(*dp, e, ns);
-        switch(result.status)
-        {
-        case static_verifier_resultt::BOTTOM:
-          ++pass;
-          break;
-        case static_verifier_resultt::TRUE:
-          ++pass;
-          break;
-        case static_verifier_resultt::FALSE:
-          ++fail;
-          break;
-        case static_verifier_resultt::UNKNOWN:
-          ++unknown;
-          break;
-        default:
-          UNREACHABLE;
-        }
-      }
-      else
-      {
-        // Multiple traces, verify against each one
-        std::size_t unreachable_traces = 0;
-        std::size_t true_traces = 0;
-        std::size_t false_traces = 0;
-        std::size_t unknown_traces = 0;
-
-        for(const auto &trace_ptr : trace_set)
-        {
-          auto dp = ai.abstract_state_before(trace_ptr);
-
-          result.status = check_assertion(*dp, e, ns);
-          switch(result.status)
-          {
-          case static_verifier_resultt::BOTTOM:
-            ++unreachable_traces;
-            break;
-          case static_verifier_resultt::TRUE:
-            ++true_traces;
-            break;
-          case static_verifier_resultt::FALSE:
-            ++false_traces;
-            break;
-          case static_verifier_resultt::UNKNOWN:
-            ++unknown_traces;
-            break;
-          default:
-            UNREACHABLE;
-          }
-        }
-
-        // Join the results
-        if(unknown_traces != 0)
-        {
-          // If any trace is unknown, the final result must be unknown
-          result.status = static_verifier_resultt::UNKNOWN;
-          ++unknown;
-        }
-        else
-        {
-          if(false_traces == 0)
-          {
-            // Definitely true; the only question is how
-            ++pass;
-            if(true_traces == 0)
-            {
-              // Definitely not reachable
-              INVARIANT(
-                unreachable_traces == trace_set.size(),
-                "All traces must not reach the assertion");
-              result.status = static_verifier_resultt::BOTTOM;
-            }
-            else
-            {
-              // At least one trace (may) reach it.
-              // All traces that reach it are safe.
-              result.status = static_verifier_resultt::TRUE;
-            }
-          }
-          else
-          {
-            // At lease one trace (may) reach it and it is false on that trace
-            if(true_traces == 0)
-            {
-              // All traces that (may) reach it are false
-              ++fail;
-              result.status = static_verifier_resultt::FALSE;
-            }
-            else
-            {
-              // The awkward case, there are traces that (may) reach it and
-              // some are true, some are false.  It is not entirely fair to say
-              // "FAILURE (if reachable)" because it's a bit more complex than
-              // that, "FAILURE (if reachable via a particular trace)" would be
-              // more accurate summary of what we know at this point.
-              // Given that all results of FAILURE from this analysis are
-              // caveated with some reachability questions, the following is not
-              // entirely unreasonable.
-              ++fail;
-              result.status = static_verifier_resultt::FALSE;
-            }
-          }
-        }
-      }
-
-      result.source_location = i_it->source_location;
-      result.function_id = f.first;
     }
   }
 

--- a/src/goto-analyzer/static_verifier.cpp
+++ b/src/goto-analyzer/static_verifier.cpp
@@ -13,6 +13,7 @@ Author: Martin Brain, martin.brain@cs.ox.ac.uk
 #include <util/namespace.h>
 #include <util/options.h>
 #include <util/range.h>
+#include <util/xml_irep.h>
 
 #include <goto-programs/goto_model.h>
 
@@ -70,8 +71,16 @@ struct static_verifier_resultt
     xmlt x("result");
 
     x.set_attribute("status", message(this->status));
+
+    // DEPRECATED(SINCE(2020, 12, 2, "Remove and use the structured version"));
+    // Unstructed partial output of source location is not great...
     x.set_attribute("file", id2string(this->source_location.get_file()));
     x.set_attribute("line", id2string(this->source_location.get_line()));
+
+    // ... this is better
+    x.new_element(xml(source_location));
+
+    // ( get_comment is not output as part of xml(source_location) )
     x.set_attribute(
       "description", id2string(this->source_location.get_comment()));
 

--- a/src/goto-analyzer/static_verifier.cpp
+++ b/src/goto-analyzer/static_verifier.cpp
@@ -44,6 +44,8 @@ struct static_verifier_resultt
   statust status;
   source_locationt source_location;
   irep_idt function_id;
+  ai_history_baset::trace_sett unknown_histories;
+  ai_history_baset::trace_sett false_histories;
 };
 
 static statust
@@ -98,6 +100,14 @@ static static_verifier_resultt check_assertion(
     auto dp = ai.abstract_state_before(assert_location);
 
     result.status = check_assertion(*dp, e, ns);
+    if(result.status == statust::FALSE)
+    {
+      result.false_histories = trace_set;
+    }
+    else if(result.status == statust::UNKNOWN)
+    {
+      result.unknown_histories = trace_set;
+    }
   }
   else
   {
@@ -122,9 +132,11 @@ static static_verifier_resultt check_assertion(
         break;
       case statust::FALSE:
         ++false_traces;
+        result.false_histories.insert(trace_ptr);
         break;
       case statust::UNKNOWN:
         ++unknown_traces;
+        result.unknown_histories.insert(trace_ptr);
         break;
       default:
         UNREACHABLE;

--- a/src/goto-analyzer/static_verifier.cpp
+++ b/src/goto-analyzer/static_verifier.cpp
@@ -180,33 +180,31 @@ void static_verifier(
   {
     auto &property_status = property.second.status;
     const goto_programt::const_targett &property_location = property.second.pc;
-    exprt condition = property_location->get_condition();
-    const std::shared_ptr<const ai_baset::statet> predecessor_state_copy =
-      ai.abstract_state_before(property_location);
-    // simplify the condition given the domain information we have
-    // about the state right before the assertion is evaluated
-    predecessor_state_copy->ai_simplify(condition, ns);
-    // if the condition simplifies to true the assertion always succeeds
-    if(condition.is_true())
+
+    auto result = check_assertion(ai, property_location, "unused", ns);
+
+    switch(result.status)
     {
+    case static_verifier_resultt::TRUE:
+      // if the condition simplifies to true the assertion always succeeds
       property_status = property_statust::PASS;
-    }
-    // if the condition simplifies to false the assertion always fails
-    else if(condition.is_false())
-    {
+      break;
+    case static_verifier_resultt::FALSE:
+      // if the condition simplifies to false the assertion always fails
       property_status = property_statust::FAIL;
-    }
-    // if the domain state is bottom then the assertion is definitely
-    // unreachable
-    else if(predecessor_state_copy->is_bottom())
-    {
+      break;
+    case static_verifier_resultt::BOTTOM:
+      // if the domain state is bottom then the assertion is definitely
+      // unreachable
       property_status = property_statust::NOT_REACHABLE;
-    }
-    // if the condition isn't definitely true, false or unreachable
-    // we don't know whether or not it may fail
-    else
-    {
+      break;
+    case static_verifier_resultt::UNKNOWN:
+      // if the condition isn't definitely true, false or unreachable
+      // we don't know whether or not it may fail
       property_status = property_statust::UNKNOWN;
+      break;
+    default:
+      UNREACHABLE;
     }
   }
 }

--- a/src/goto-analyzer/static_verifier.cpp
+++ b/src/goto-analyzer/static_verifier.cpp
@@ -27,6 +27,31 @@ struct static_verifier_resultt
   irep_idt function_id;
 };
 
+static static_verifier_resultt::statust
+check_assertion(const ai_domain_baset &domain, exprt e, const namespacet &ns)
+{
+  if(domain.is_bottom())
+  {
+    return static_verifier_resultt::BOTTOM;
+  }
+
+  domain.ai_simplify(e, ns);
+  if(e.is_true())
+  {
+    return static_verifier_resultt::TRUE;
+  }
+  else if(e.is_false())
+  {
+    return static_verifier_resultt::FALSE;
+  }
+  else
+  {
+    return static_verifier_resultt::UNKNOWN;
+  }
+
+  UNREACHABLE;
+}
+
 void static_verifier(
   const abstract_goto_modelt &abstract_goto_model,
   const ai_baset &ai,
@@ -222,31 +247,6 @@ static void static_verifier_console(
 
   if(!results.empty())
     m.result() << '\n';
-}
-
-static static_verifier_resultt::statust
-check_assertion(const ai_domain_baset &domain, exprt e, const namespacet &ns)
-{
-  if(domain.is_bottom())
-  {
-    return static_verifier_resultt::BOTTOM;
-  }
-
-  domain.ai_simplify(e, ns);
-  if(e.is_true())
-  {
-    return static_verifier_resultt::TRUE;
-  }
-  else if(e.is_false())
-  {
-    return static_verifier_resultt::FALSE;
-  }
-  else
-  {
-    return static_verifier_resultt::UNKNOWN;
-  }
-
-  UNREACHABLE;
 }
 
 /// Runs the analyzer and then prints out the domain


### PR DESCRIPTION
This patch adds to the `--json` and `--xml` output to give the `ai_historyt`s that show that an assertion is either false or unknown.

To do this I had to refactor the output handling a bit.  I think it is now simpler.  In the process I have improved the `properties` output in the case where a history other than `ahistoricalt` is used.

I haven't add the traces to the text output because it wasn't obvious to how to do it without breaking the format (maybe there is something to be said for JSON and even XML!).  I'm working on a new task that will do a lot more with outputting the histories for failed verifications so that might be the right way of handling it.