### PR TITLE
Makefile builds: memory-analyzer requires linking.dir

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -87,7 +87,8 @@ goto-diff.dir: languages goto-programs.dir pointer-analysis.dir \
 
 goto-cc.dir: languages goto-programs.dir linking.dir
 
-memory-analyzer.dir: util.dir goto-programs.dir ansi-c.dir
+memory-analyzer.dir: util.dir goto-programs.dir langapi.dir linking.dir \
+	                   ansi-c.dir
 
 symtab2gb.dir: util.dir goto-programs.dir langapi.dir linking.dir \
                json.dir json-symtab-language.dir


### PR DESCRIPTION
With the undeclared build dependency, parallel builds would sometimes
fail, depending on the exact time the subdirectories completed their
build steps. Avoid this problem by properly declaring the dependency.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
