### PR TITLE
strtol must not overflow

### DIFF
--- a/regression/cbmc-library/strtol-02/test.desc
+++ b/regression/cbmc-library/strtol-02/test.desc
@@ -1,8 +1,11 @@
 CORE
 main.c
-
+--signed-overflow-check
 ^EXIT=0$
 ^SIGNAL=0$
 ^VERIFICATION SUCCESSFUL$
 --
 ^warning: ignoring
+--
+Even with --signed-overflow-check enabled, verification should succeed here as
+strtol reports overflow condition with errno set to ERANGE.

--- a/src/ansi-c/library/stdlib.c
+++ b/src/ansi-c/library/stdlib.c
@@ -353,9 +353,15 @@ inline long strtol(const char *nptr, char **endptr, int base)
       break;
 
     in_number=1;
-    long res_before=res;
-    res=res*base+ch-sub;
-    if(res<res_before)
+    _Bool overflow = __CPROVER_overflow_mult(res, (long)base);
+#pragma CPROVER check push
+#pragma CPROVER check disable "signed-overflow"
+    // This is now safe; still do it within the scope of the pragma to avoid an
+    // unnecessary assertion to be generated.
+    if(!overflow)
+      res *= base;
+#pragma CPROVER check pop
+    if(overflow || __CPROVER_overflow_plus(res, (long)(ch - sub)))
     {
       errno=ERANGE;
       if(sign=='-')
@@ -363,6 +369,7 @@ inline long strtol(const char *nptr, char **endptr, int base)
       else
         return LONG_MAX;
     }
+    res += ch - sub;
   }
 
   if(endptr!=0)


### PR DESCRIPTION
The lack of overflow checking in the internal library first showed up in
SV-COMP when running sv-benchmarks/c/busybox-1.22.0/ls-incomplete-2.i
with --unwind 21.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
