### PR TITLE
Cover failed assertions

### DIFF
--- a/jbmc/src/jdiff/jdiff_parse_options.cpp
+++ b/jbmc/src/jdiff/jdiff_parse_options.cpp
@@ -367,7 +367,7 @@ void jdiff_parse_optionst::help()
     "\n"
     "Program instrumentation options:\n"
     HELP_GOTO_CHECK
-    " --cover CC                   create test-suite with coverage criterion CC\n" // NOLINT(*)
+    HELP_COVER
     "Java Bytecode frontend options:\n"
     JAVA_BYTECODE_LANGUAGE_OPTIONS_HELP
     "Other options:\n"

--- a/jbmc/src/jdiff/jdiff_parse_options.h
+++ b/jbmc/src/jdiff/jdiff_parse_options.h
@@ -23,6 +23,8 @@ Author: Peter Schrammel
 #include <goto-programs/show_goto_functions.h>
 #include <goto-programs/show_properties.h>
 
+#include <goto-instrument/cover.h>
+
 class goto_modelt;
 
 // clang-format off
@@ -31,7 +33,7 @@ class goto_modelt;
   OPT_SHOW_GOTO_FUNCTIONS \
   OPT_SHOW_PROPERTIES \
   OPT_GOTO_CHECK \
-  "(cover):" \
+  OPT_COVER \
   "(verbosity):(version)" \
   "(no-lazy-methods)" /* should go away */ \
   "(no-refine-strings)" /* should go away */ \

--- a/regression/cbmc/cover-failed-assertions/test-no-failed-assertions.desc
+++ b/regression/cbmc/cover-failed-assertions/test-no-failed-assertions.desc
@@ -1,10 +1,10 @@
 CORE
 test.c
 --cover location --pointer-check --malloc-may-fail --malloc-fail-null
-\[main.coverage.4\] file test.c line \d+ function main block 4 \(lines test.c:main:12,13\): SATISFIED
-\[main.coverage.3\] file test.c line \d+ function main block 3 \(lines test.c:main:10\): FAILED
-\[main.coverage.2\] file test.c line \d+ function main block 2 \(lines test.c:main:4,5,7,9\): SATISFIED
-\[main.coverage.1\] file test.c line \d+ function main block 1 \(lines test.c:main:4\): SATISFIED
+\[main\.coverage\.4\] file test\.c line \d+ function main block 4 \(lines test\.c:main:13,14\): SATISFIED
+\[main\.coverage\.3\] file test\.c line \d+ function main block 3 \(lines test\.c:main:11\): FAILED
+\[main\.coverage\.2\] file test\.c line \d+ function main block 2 \(lines test\.c:main:5,6,8,10\): SATISFIED
+\[main\.coverage\.1\] file test\.c line \d+ function main block 1 \(lines test\.c:main:5\): SATISFIED
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/cbmc/cover-failed-assertions/test-no-failed-assertions.desc
+++ b/regression/cbmc/cover-failed-assertions/test-no-failed-assertions.desc
@@ -1,4 +1,4 @@
-CORE
+CORE paths-lifo-expected-failure
 test.c
 --cover location --pointer-check --malloc-may-fail --malloc-fail-null
 \[main\.coverage\.4\] file test\.c line \d+ function main block 4 \(lines test\.c:main:13,14\): SATISFIED

--- a/regression/cbmc/cover-failed-assertions/test-no-failed-assertions.desc
+++ b/regression/cbmc/cover-failed-assertions/test-no-failed-assertions.desc
@@ -1,0 +1,11 @@
+CORE
+test.c
+--cover location --pointer-check --malloc-may-fail --malloc-fail-null
+\[main.coverage.4\] file test.c line \d+ function main block 4 \(lines test.c:main:12,13\): SATISFIED
+\[main.coverage.3\] file test.c line \d+ function main block 3 \(lines test.c:main:10\): FAILED
+\[main.coverage.2\] file test.c line \d+ function main block 2 \(lines test.c:main:4,5,7,9\): SATISFIED
+\[main.coverage.1\] file test.c line \d+ function main block 1 \(lines test.c:main:4\): SATISFIED
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring

--- a/regression/cbmc/cover-failed-assertions/test-no-failed-assertions.desc
+++ b/regression/cbmc/cover-failed-assertions/test-no-failed-assertions.desc
@@ -1,11 +1,14 @@
 CORE paths-lifo-expected-failure
 test.c
 --cover location --pointer-check --malloc-may-fail --malloc-fail-null
-\[main\.coverage\.4\] file test\.c line \d+ function main block 4 \(lines test\.c:main:13,14\): SATISFIED
-\[main\.coverage\.3\] file test\.c line \d+ function main block 3 \(lines test\.c:main:11\): FAILED
-\[main\.coverage\.2\] file test\.c line \d+ function main block 2 \(lines test\.c:main:5,6,8,10\): SATISFIED
+\[main\.coverage\.4\] file test\.c line \d+ function main block 4 \(lines test\.c:main:17,18\): SATISFIED
+\[main\.coverage\.3\] file test\.c line \d+ function main block 3 \(lines test\.c:main:15\): FAILED
+\[main\.coverage\.2\] file test\.c line \d+ function main block 2 \(lines test\.c:main:5,6,12,14\): SATISFIED
 \[main\.coverage\.1\] file test\.c line \d+ function main block 1 \(lines test\.c:main:5\): SATISFIED
 ^EXIT=0$
 ^SIGNAL=0$
 --
 ^warning: ignoring
+--
+This is checking that without the --cover-failed-assertions flag we still get the same result as we did before adding
+it in this example.

--- a/regression/cbmc/cover-failed-assertions/test.c
+++ b/regression/cbmc/cover-failed-assertions/test.c
@@ -5,6 +5,10 @@ int main()
   int *ptr = malloc(sizeof(*ptr));
   int a;
 
+  // pointer check would detect the dereference of a null pointer here
+  // default --cover lines behaviour is to treat non-cover assertions as
+  // assumptions instead, so in the ptr == NULL case we don't get past this line
+  // leading to failed coverage for the body of the if statement down below
   a = *ptr;
 
   if(ptr == NULL)

--- a/regression/cbmc/cover-failed-assertions/test.c
+++ b/regression/cbmc/cover-failed-assertions/test.c
@@ -1,0 +1,14 @@
+#include <stdlib.h>
+
+int main()
+{
+  int *ptr = malloc(sizeof(*ptr));
+  int a;
+
+  a = *ptr;
+
+  if(ptr == NULL)
+    a = 1;
+
+  return 0;
+}

--- a/regression/cbmc/cover-failed-assertions/test.desc
+++ b/regression/cbmc/cover-failed-assertions/test.desc
@@ -1,10 +1,10 @@
 CORE
 test.c
 --cover location --cover-failed-assertions --pointer-check --malloc-may-fail --malloc-fail-null
-\[main.coverage.4\] file test.c line \d+ function main block 4 \(lines test.c:main:12,13\): SATISFIED
-\[main.coverage.3\] file test.c line \d+ function main block 3 \(lines test.c:main:10\): SATISFIED
-\[main.coverage.2\] file test.c line \d+ function main block 2 \(lines test.c:main:4,5,7,9\): SATISFIED
-\[main.coverage.1\] file test.c line \d+ function main block 1 \(lines test.c:main:4\): SATISFIED
+\[main.coverage\.4\] file test\.c line \d+ function main block 4 \(lines test\.c:main:13,14\): SATISFIED
+\[main.coverage\.3\] file test\.c line \d+ function main block 3 \(lines test\.c:main:11\): SATISFIED
+\[main.coverage\.2\] file test\.c line \d+ function main block 2 \(lines test\.c:main:5,6,8,10\): SATISFIED
+\[main.coverage\.1\] file test\.c line \d+ function main block 1 \(lines test\.c:main:5\): SATISFIED
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/cbmc/cover-failed-assertions/test.desc
+++ b/regression/cbmc/cover-failed-assertions/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE paths-lifo-expected-failure
 test.c
 --cover location --cover-failed-assertions --pointer-check --malloc-may-fail --malloc-fail-null
 \[main.coverage\.4\] file test\.c line \d+ function main block 4 \(lines test\.c:main:13,14\): SATISFIED

--- a/regression/cbmc/cover-failed-assertions/test.desc
+++ b/regression/cbmc/cover-failed-assertions/test.desc
@@ -1,11 +1,13 @@
 CORE paths-lifo-expected-failure
 test.c
 --cover location --cover-failed-assertions --pointer-check --malloc-may-fail --malloc-fail-null
-\[main.coverage\.4\] file test\.c line \d+ function main block 4 \(lines test\.c:main:13,14\): SATISFIED
-\[main.coverage\.3\] file test\.c line \d+ function main block 3 \(lines test\.c:main:11\): SATISFIED
-\[main.coverage\.2\] file test\.c line \d+ function main block 2 \(lines test\.c:main:5,6,8,10\): SATISFIED
+\[main.coverage\.4\] file test\.c line \d+ function main block 4 \(lines test\.c:main:17,18\): SATISFIED
+\[main.coverage\.3\] file test\.c line \d+ function main block 3 \(lines test\.c:main:15\): SATISFIED
+\[main.coverage\.2\] file test\.c line \d+ function main block 2 \(lines test\.c:main:5,6,12,14\): SATISFIED
 \[main.coverage\.1\] file test\.c line \d+ function main block 1 \(lines test\.c:main:5\): SATISFIED
 ^EXIT=0$
 ^SIGNAL=0$
 --
 ^warning: ignoring
+--
+This is checking that the if statement body can actually be covered with the new flag

--- a/regression/cbmc/cover-failed-assertions/test.desc
+++ b/regression/cbmc/cover-failed-assertions/test.desc
@@ -1,0 +1,11 @@
+CORE
+test.c
+--cover location --cover-failed-assertions --pointer-check --malloc-may-fail --malloc-fail-null
+\[main.coverage.4\] file test.c line \d+ function main block 4 \(lines test.c:main:12,13\): SATISFIED
+\[main.coverage.3\] file test.c line \d+ function main block 3 \(lines test.c:main:10\): SATISFIED
+\[main.coverage.2\] file test.c line \d+ function main block 2 \(lines test.c:main:4,5,7,9\): SATISFIED
+\[main.coverage.1\] file test.c line \d+ function main block 1 \(lines test.c:main:4\): SATISFIED
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring

--- a/regression/validate-trace-xml-schema/check.py
+++ b/regression/validate-trace-xml-schema/check.py
@@ -34,6 +34,9 @@ ExcludedTests = list(map(lambda s: os.path.join(test_base_dir, s[0], s[1]), [
     ['unknown-argument-suggestion', 'test.desc'],
     # this one produces XML intermingled with main XML output when used with --xml-ui
     ['graphml_witness2', 'test.desc'],
+    # these are producing coverage goals which aren't including in the schema
+    ['cover-failed-assertions', 'test.desc'],
+    ['cover-failed-assertions', 'test-no-failed-assertions.desc'],
     # produces intermingled XML on the command line
     ['coverage_report1', 'test.desc'],
     ['coverage_report1', 'paths.desc'],

--- a/regression/validate-trace-xml-schema/check.py
+++ b/regression/validate-trace-xml-schema/check.py
@@ -34,7 +34,7 @@ ExcludedTests = list(map(lambda s: os.path.join(test_base_dir, s[0], s[1]), [
     ['unknown-argument-suggestion', 'test.desc'],
     # this one produces XML intermingled with main XML output when used with --xml-ui
     ['graphml_witness2', 'test.desc'],
-    # these are producing coverage goals which aren't including in the schema
+    # these are producing coverage goals which aren't included in the schema
     ['cover-failed-assertions', 'test.desc'],
     ['cover-failed-assertions', 'test-no-failed-assertions.desc'],
     # produces intermingled XML on the command line

--- a/src/cbmc/README.md
+++ b/src/cbmc/README.md
@@ -76,13 +76,15 @@ by other mechanism may categorise their properties differently.
 
 ### Coverage mode
 
-There is one further BMC mode that differs more fundamentally: when `--cover` is
-passed, assertions in the program text are converted into assumptions (these
+There is one further BMC mode that differs more fundamentally: when `--cover`
+is passed, assertions in the program text are converted into assumptions (these
 must hold for control flow to proceed past them, but are not goals for the
-equation solver), while new `assert(false)` statements are added throughout the
-source program representing coverage goals. The equation solving process then
-proceeds the same as in all-properties mode. Coverage solving is implemented by
-`bmc_covert`, but is structurally practically identical to
+equation solver; In cases where this behaviour is undesirable you can pass the
+`--cover-failed-assertions` which makes coverage checking continue even for
+paths where assertions fail), while new `assert(false)` statements are added
+throughout the source program representing coverage goals. The equation solving
+process then proceeds the same as in all-properties mode. Coverage solving is
+implemented by `bmc_covert`, but is structurally practically identical to
 `bmc_all_propertiest`-- only the reporting differs (goals are called "covered"
 rather than "failed").
 

--- a/src/cbmc/cbmc_parse_options.cpp
+++ b/src/cbmc/cbmc_parse_options.cpp
@@ -1118,7 +1118,7 @@ void cbmc_parse_optionst::help()
     " --no-assertions              ignore user assertions\n"
     " --no-assumptions             ignore user assumptions\n"
     " --error-label label          check that label is unreachable\n"
-    " --cover CC                   create test-suite with coverage criterion CC\n" // NOLINT(*)
+    HELP_COVER
     " --mm MM                      memory consistency model for concurrent programs\n" // NOLINT(*)
     // NOLINTNEXTLINE(whitespace/line_length)
     " --malloc-fail-assert         set malloc failure mode to assert-then-assume\n"

--- a/src/cbmc/cbmc_parse_options.h
+++ b/src/cbmc/cbmc_parse_options.h
@@ -75,7 +75,7 @@ class optionst;
   "(property):(stop-on-fail)(trace)" \
   "(error-label):(verbosity):(no-library)" \
   "(nondet-static)" \
-  "(version)"        \
+  "(version)" \
   OPT_COVER \
   "(symex-coverage-report):" \
   "(mm):" \

--- a/src/cbmc/cbmc_parse_options.h
+++ b/src/cbmc/cbmc_parse_options.h
@@ -34,6 +34,8 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <json/json_interface.h>
 #include <xmllang/xml_interface.h>
 
+#include <goto-instrument/cover.h>
+
 class goto_functionst;
 class optionst;
 
@@ -73,8 +75,9 @@ class optionst;
   "(property):(stop-on-fail)(trace)" \
   "(error-label):(verbosity):(no-library)" \
   "(nondet-static)" \
-  "(version)" \
-  "(cover):(symex-coverage-report):" \
+  "(version)"        \
+  OPT_COVER \
+  "(symex-coverage-report):" \
   "(mm):" \
   OPT_TIMESTAMP \
   "(i386-linux)(i386-macos)(i386-win32)(win32)(winx64)(gcc)" \

--- a/src/goto-diff/goto_diff_parse_options.cpp
+++ b/src/goto-diff/goto_diff_parse_options.cpp
@@ -411,7 +411,7 @@ void goto_diff_parse_optionst::help()
     "\n"
     "Program instrumentation options:\n"
     HELP_GOTO_CHECK
-    " --cover CC                   create test-suite with coverage criterion CC\n" // NOLINT(*)
+    HELP_COVER
     "Other options:\n"
     " --version                    show version and exit\n"
     " --json-ui                    use JSON-formatted output\n"

--- a/src/goto-diff/goto_diff_parse_options.h
+++ b/src/goto-diff/goto_diff_parse_options.h
@@ -22,6 +22,8 @@ Author: Peter Schrammel
 #include <goto-programs/show_goto_functions.h>
 #include <goto-programs/show_properties.h>
 
+#include <goto-instrument/cover.h>
+
 class goto_modelt;
 class optionst;
 
@@ -31,7 +33,7 @@ class optionst;
   OPT_SHOW_GOTO_FUNCTIONS \
   OPT_SHOW_PROPERTIES \
   OPT_GOTO_CHECK \
-  "(cover):" \
+  OPT_COVER \
   "(verbosity):(version)" \
   OPT_FLUSH \
   OPT_TIMESTAMP \

--- a/src/goto-instrument/cover.h
+++ b/src/goto-instrument/cover.h
@@ -22,9 +22,17 @@ class message_handlert;
 class cmdlinet;
 class optionst;
 
-#define OPT_COVER "(cover):"
-#define HELP_COVER \
-  " --cover CC                   create test-suite with coverage criterion CC\n"
+#define OPT_COVER                                                              \
+  "(cover):"                                                                   \
+  "(cover-failed-assertions)"
+
+#define HELP_COVER                                                             \
+  " --cover CC                   create test-suite with coverage criterion "   \
+  "CC\n"                                                                       \
+  " --cover-failed-assertions    do not stop coverage checking at failed "     \
+  "assertions\n"                                                               \
+  "                              (this is the default for --cover "            \
+  "assertions)\n"
 
 enum class coverage_criteriont
 {
@@ -41,6 +49,7 @@ enum class coverage_criteriont
 struct cover_configt
 {
   bool keep_assertions;
+  bool cover_failed_assertions;
   bool traces_must_terminate;
   irep_idt mode;
   function_filterst function_filters;

--- a/src/goto-instrument/cover.h
+++ b/src/goto-instrument/cover.h
@@ -22,6 +22,10 @@ class message_handlert;
 class cmdlinet;
 class optionst;
 
+#define OPT_COVER "(cover):"
+#define HELP_COVER \
+  " --cover CC                   create test-suite with coverage criterion CC\n"
+
 enum class coverage_criteriont
 {
   LOCATION,


### PR DESCRIPTION
<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

This adds an option `--cover-failed-assertions` that prevents the
default behaviour of coverage stopping at failed assertions by turning
assertions into skips rather than assumes (which is the default
behaviour for coverage criteria other than `assertion`, which behaves
the same with or without the flag).


This is one way to address https://github.com/diffblue/cbmc/issues/5543

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
