### PR TITLE
Refactor value set dereference debug output

### DIFF
--- a/src/pointer-analysis/value_set_dereference.cpp
+++ b/src/pointer-analysis/value_set_dereference.cpp
@@ -142,21 +142,9 @@ exprt value_set_dereferencet::dereference(
   // type of the object
   const typet &type=pointer.type().subtype();
 
-#ifdef DEBUG
-  std::cout << "value_set_dereferencet::dereference pointer=" << format(pointer)
-            << '\n';
-#endif
-
   // collect objects the pointer may point to
   const std::vector<exprt> points_to_set =
     dereference_callback.get_value_set(pointer);
-
-#ifdef DEBUG
-  std::cout << "value_set_dereferencet::dereference points_to_set={";
-  for(auto p : points_to_set)
-    std::cout << format(p) << "; ";
-  std::cout << "}\n" << std::flush;
-#endif
 
   // get the values of these
   const std::vector<exprt> retained_values =
@@ -178,13 +166,6 @@ exprt value_set_dereferencet::dereference(
 
     compare_against_pointer = fresh_binder.symbol_expr();
   }
-
-#ifdef DEBUG
-  std::cout << "value_set_dereferencet::dereference retained_values={";
-  for(const auto &value : retained_values)
-    std::cout << format(value) << "; ";
-  std::cout << "}\n" << std::flush;
-#endif
 
   std::list<valuet> values =
     make_range(retained_values).map([&](const exprt &value) {
@@ -268,17 +249,12 @@ exprt value_set_dereferencet::dereference(
   if(compare_against_pointer != pointer)
     value = let_exprt(to_symbol_expr(compare_against_pointer), pointer, value);
 
-#ifdef DEBUG
-  std::cout << "value_set_derefencet::dereference value=" << format(value)
-            << '\n'
-            << std::flush;
-#endif
-
   if(display_points_to_sets)
   {
     log.status() << value_set_dereference_stats_to_json(
       pointer, points_to_set, retained_values, value);
   }
+
   return value;
 }
 

--- a/src/util/format.h
+++ b/src/util/format.h
@@ -10,6 +10,8 @@ Author: Daniel Kroening, kroening@kroening.com
 #define CPROVER_UTIL_FORMAT_H
 
 #include <iosfwd>
+#include <sstream>
+#include <string>
 
 //! The below enables convenient syntax for feeding
 //! objects into streams, via stream << format(o)
@@ -35,6 +37,14 @@ template <typename T>
 static inline format_containert<T> format(const T &o)
 {
   return format_containert<T>(o);
+}
+
+template <typename T>
+std::string format_to_string(const T &o)
+{
+  std::ostringstream oss;
+  oss << format(o);
+  return oss.str();
 }
 
 #endif // CPROVER_UTIL_FORMAT_H


### PR DESCRIPTION
<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

This moves the output functionality for `--show-points-to-sets` out of the main logic for `value_set_dereference` and removes the `#ifdef DEBUG` output which is essentially the same information as that flag gives. This makes it somewhat easier to follow along with the logic of the function.

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
