### PR TITLE
Value set dereference misc refactor

### DIFF
--- a/src/pointer-analysis/value_set_dereference.cpp
+++ b/src/pointer-analysis/value_set_dereference.cpp
@@ -172,23 +172,11 @@ exprt value_set_dereferencet::dereference(
       return build_reference_to(value, compare_against_pointer, ns);
     });
 
-  // can this fail?
-  bool may_fail;
-
-  if(values.empty())
-  {
-    may_fail=true;
-  }
-  else
-  {
-    may_fail=false;
-    for(std::list<valuet>::const_iterator
-        it=values.begin();
-        it!=values.end();
-        it++)
-      if(it->value.is_nil())
-        may_fail=true;
-  }
+  const bool may_fail =
+    values.empty() ||
+    std::any_of(values.begin(), values.end(), [](const valuet &value) {
+      return value.value.is_nil();
+    });
 
   if(may_fail)
   {

--- a/src/pointer-analysis/value_set_dereference.cpp
+++ b/src/pointer-analysis/value_set_dereference.cpp
@@ -222,7 +222,7 @@ exprt value_set_dereferencet::dereference(
 
   // now build big case split, but we only do "good" objects
 
-  exprt value=nil_exprt();
+  exprt result_value = nil_exprt{};
 
   for(std::deque<valuet>::const_iterator it = values.begin();
       it != values.end();
@@ -230,23 +230,24 @@ exprt value_set_dereferencet::dereference(
   {
     if(it->value.is_not_nil())
     {
-      if(value.is_nil()) // first?
-        value=it->value;
+      if(result_value.is_nil()) // first?
+        result_value = it->value;
       else
-        value=if_exprt(it->pointer_guard, it->value, value);
+        result_value = if_exprt(it->pointer_guard, it->value, result_value);
     }
   }
 
   if(compare_against_pointer != pointer)
-    value = let_exprt(to_symbol_expr(compare_against_pointer), pointer, value);
+    result_value =
+      let_exprt(to_symbol_expr(compare_against_pointer), pointer, result_value);
 
   if(display_points_to_sets)
   {
     log.status() << value_set_dereference_stats_to_json(
-      pointer, points_to_set, retained_values, value);
+      pointer, points_to_set, retained_values, result_value);
   }
 
-  return value;
+  return result_value;
 }
 
 /// Check if the two types have matching number of ID_pointer levels, with

--- a/src/pointer-analysis/value_set_dereference.cpp
+++ b/src/pointer-analysis/value_set_dereference.cpp
@@ -141,7 +141,13 @@ exprt value_set_dereferencet::dereference(
     }
   }
 
-  // type of the object
+  return handle_dereference_base_case(pointer, display_points_to_sets);
+}
+
+exprt value_set_dereferencet::handle_dereference_base_case(
+  const exprt &pointer,
+  bool display_points_to_sets)
+{ // type of the object
   const typet &type=pointer.type().subtype();
 
   // collect objects the pointer may point to

--- a/src/pointer-analysis/value_set_dereference.cpp
+++ b/src/pointer-analysis/value_set_dereference.cpp
@@ -224,16 +224,14 @@ exprt value_set_dereferencet::dereference(
 
   exprt result_value = nil_exprt{};
 
-  for(std::deque<valuet>::const_iterator it = values.begin();
-      it != values.end();
-      it++)
+  for(const auto &value : values)
   {
-    if(it->value.is_not_nil())
+    if(value.value.is_not_nil())
     {
       if(result_value.is_nil()) // first?
-        result_value = it->value;
+        result_value = value.value;
       else
-        result_value = if_exprt(it->pointer_guard, it->value, result_value);
+        result_value = if_exprt(value.pointer_guard, value.value, result_value);
     }
   }
 

--- a/src/pointer-analysis/value_set_dereference.h
+++ b/src/pointer-analysis/value_set_dereference.h
@@ -111,6 +111,7 @@ private:
   /// disregard an apparent attempt to dereference NULL
   const bool exclude_null_derefs;
   const messaget &log;
+  valuet get_failure_value(const exprt &pointer, const typet &type);
 };
 
 #endif // CPROVER_POINTER_ANALYSIS_VALUE_SET_DEREFERENCE_H

--- a/src/pointer-analysis/value_set_dereference.h
+++ b/src/pointer-analysis/value_set_dereference.h
@@ -112,6 +112,9 @@ private:
   const bool exclude_null_derefs;
   const messaget &log;
   valuet get_failure_value(const exprt &pointer, const typet &type);
+  exprt handle_dereference_base_case(
+    const exprt &pointer,
+    bool display_points_to_sets);
 };
 
 #endif // CPROVER_POINTER_ANALYSIS_VALUE_SET_DEREFERENCE_H


### PR DESCRIPTION
<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

Various miscellaneous refactorings to value_set_dereference. Goal here is mainly to make the logic easier to follow.

- [X] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
