### PR TITLE
abstract_objectt interface

### DIFF
--- a/src/analyses/variable-sensitivity/abstract_object.cpp
+++ b/src/analyses/variable-sensitivity/abstract_object.cpp
@@ -147,9 +147,9 @@ abstract_object_pointert abstract_objectt::read(
 abstract_object_pointert abstract_objectt::write(
   abstract_environmentt &environment,
   const namespacet &ns,
-  const std::stack<exprt> stack,
+  const std::stack<exprt> &stack,
   const exprt &specifier,
-  const abstract_object_pointert value,
+  const abstract_object_pointert &value,
   bool merging_write) const
 {
   return environment.abstract_object_factory(type(), ns, true);

--- a/src/analyses/variable-sensitivity/abstract_object.cpp
+++ b/src/analyses/variable-sensitivity/abstract_object.cpp
@@ -68,7 +68,7 @@ abstract_object_pointert abstract_objectt::abstract_object_merge(
     return this->abstract_object_merge_internal(other);
 
   internal_abstract_object_pointert merged = mutable_clone();
-  merged->make_top();
+  merged->set_top();
   merged->bottom = false;
   return merged->abstract_object_merge_internal(other);
 }

--- a/src/analyses/variable-sensitivity/abstract_object.h
+++ b/src/analyses/variable-sensitivity/abstract_object.h
@@ -121,7 +121,7 @@ public:
   /// Get the real type of the variable this abstract object is representing.
   ///
   /// \return The program type this abstract object represents
-  const typet &type() const;
+  virtual const typet &type() const;
 
   /// Find out if the abstract object is top
   ///

--- a/src/analyses/variable-sensitivity/abstract_object.h
+++ b/src/analyses/variable-sensitivity/abstract_object.h
@@ -213,9 +213,9 @@ public:
   virtual abstract_object_pointert write(
     abstract_environmentt &environment,
     const namespacet &ns,
-    const std::stack<exprt> stack,
+    const std::stack<exprt> &stack,
     const exprt &specifier,
-    const abstract_object_pointert value,
+    const abstract_object_pointert &value,
     bool merging_write) const;
 
   /// Print the value of the abstract object

--- a/src/analyses/variable-sensitivity/abstract_object.h
+++ b/src/analyses/variable-sensitivity/abstract_object.h
@@ -318,7 +318,7 @@ public:
       return shared_from_this();
 
     internal_abstract_object_pointert clone = mutable_clone();
-    clone->make_top();
+    clone->set_top();
     return clone;
   }
 
@@ -328,7 +328,7 @@ public:
       return shared_from_this();
 
     internal_abstract_object_pointert clone = mutable_clone();
-    clone->clear_top();
+    clone->set_not_top();
     return clone;
   }
 
@@ -379,10 +379,10 @@ private:
 
   // Hooks to allow a sub-class to perform its own operations on
   // setting/clearing top
-  virtual void make_top_internal()
+  virtual void set_top_internal()
   {
   }
-  virtual void clear_top_internal()
+  virtual void set_not_top_internal()
   {
   }
 
@@ -473,15 +473,15 @@ protected:
     sharing_mapt<keyt, abstract_object_pointert, false, hash> &out_map);
 
   // The one exception is merge in descendant classes, which needs this
-  void make_top()
+  void set_top()
   {
     top = true;
-    this->make_top_internal();
+    this->set_top_internal();
   }
-  void clear_top()
+  void set_not_top()
   {
     top = false;
-    this->clear_top_internal();
+    this->set_not_top_internal();
   }
 };
 

--- a/src/analyses/variable-sensitivity/abstract_object.h
+++ b/src/analyses/variable-sensitivity/abstract_object.h
@@ -244,11 +244,6 @@ public:
   static void
   dump_map_diff(std::ostream out, const shared_mapt &m1, const shared_mapt &m2);
 
-  abstract_object_pointert clone() const
-  {
-    return abstract_object_pointert(mutable_clone());
-  }
-
   /**
    * Determine whether 'this' abstract_object has been modified in comparison
    * to a previous 'before' state.

--- a/src/analyses/variable-sensitivity/array_abstract_object.cpp
+++ b/src/analyses/variable-sensitivity/array_abstract_object.cpp
@@ -46,9 +46,9 @@ abstract_object_pointert array_abstract_objectt::read(
 abstract_object_pointert array_abstract_objectt::write(
   abstract_environmentt &environment,
   const namespacet &ns,
-  const std::stack<exprt> stack,
+  const std::stack<exprt> &stack,
   const exprt &specifier,
-  const abstract_object_pointert value,
+  const abstract_object_pointert &value,
   bool merging_write) const
 {
   return this->write_index(
@@ -71,9 +71,9 @@ abstract_object_pointert array_abstract_objectt::read_index(
 abstract_object_pointert array_abstract_objectt::write_index(
   abstract_environmentt &environment,
   const namespacet &ns,
-  const std::stack<exprt> stack,
+  const std::stack<exprt> &stack,
   const index_exprt &index_expr,
-  const abstract_object_pointert value,
+  const abstract_object_pointert &value,
   bool merging_write) const
 {
   // TODO(tkiley): Should this in fact havoc since we can't verify

--- a/src/analyses/variable-sensitivity/array_abstract_object.cpp
+++ b/src/analyses/variable-sensitivity/array_abstract_object.cpp
@@ -82,12 +82,11 @@ abstract_object_pointert array_abstract_objectt::write_index(
   // havoc and the default should derive from this.
   if(is_top() || is_bottom())
   {
-    return std::dynamic_pointer_cast<const array_abstract_objectt>(clone());
+    return shared_from_this();
   }
   else
   {
-    return sharing_ptrt<array_abstract_objectt>(
-      new array_abstract_objectt(type(), true, false));
+    return std::make_shared<array_abstract_objectt>(type(), true, false);
   }
 }
 

--- a/src/analyses/variable-sensitivity/array_abstract_object.cpp
+++ b/src/analyses/variable-sensitivity/array_abstract_object.cpp
@@ -68,7 +68,7 @@ abstract_object_pointert array_abstract_objectt::read_index(
   return env.abstract_object_factory(subtype, ns, !is_bottom(), is_bottom());
 }
 
-sharing_ptrt<array_abstract_objectt> array_abstract_objectt::write_index(
+abstract_object_pointert array_abstract_objectt::write_index(
   abstract_environmentt &environment,
   const namespacet &ns,
   const std::stack<exprt> stack,

--- a/src/analyses/variable-sensitivity/array_abstract_object.h
+++ b/src/analyses/variable-sensitivity/array_abstract_object.h
@@ -117,10 +117,10 @@ protected:
   /// \param value: the value we are trying to assign to that value in the array
   /// \param merging_write: ?
   ///
-  /// \return The array_abstract_objectt representing the result of writing
+  /// \return The abstract_object_pointert representing the result of writing
   ///          to a specific component. In this case this will always be top
   ///          as we are not tracking the value in the array.
-  virtual sharing_ptrt<array_abstract_objectt> write_index(
+  virtual abstract_object_pointert write_index(
     abstract_environmentt &environment,
     const namespacet &ns,
     const std::stack<exprt> stack,

--- a/src/analyses/variable-sensitivity/array_abstract_object.h
+++ b/src/analyses/variable-sensitivity/array_abstract_object.h
@@ -78,9 +78,9 @@ public:
   abstract_object_pointert write(
     abstract_environmentt &environment,
     const namespacet &ns,
-    const std::stack<exprt> stack,
+    const std::stack<exprt> &stack,
     const exprt &specifier,
-    const abstract_object_pointert value,
+    const abstract_object_pointert &value,
     bool merging_write) const override;
 
   void get_statistics(
@@ -123,9 +123,9 @@ protected:
   virtual abstract_object_pointert write_index(
     abstract_environmentt &environment,
     const namespacet &ns,
-    const std::stack<exprt> stack,
+    const std::stack<exprt> &stack,
     const index_exprt &index_expr,
-    const abstract_object_pointert value,
+    const abstract_object_pointert &value,
     bool merging_write) const;
 };
 

--- a/src/analyses/variable-sensitivity/constant_array_abstract_object.cpp
+++ b/src/analyses/variable-sensitivity/constant_array_abstract_object.cpp
@@ -189,13 +189,12 @@ abstract_object_pointert constant_array_abstract_objectt::read_index(
   }
 }
 
-abstract_object_pointert
-constant_array_abstract_objectt::write_index(
+abstract_object_pointert constant_array_abstract_objectt::write_index(
   abstract_environmentt &environment,
   const namespacet &ns,
-  const std::stack<exprt> stack,
+  const std::stack<exprt> &stack,
   const index_exprt &index_expr,
-  const abstract_object_pointert value,
+  const abstract_object_pointert &value,
   bool merging_write) const
 {
   if(is_bottom())

--- a/src/analyses/variable-sensitivity/constant_array_abstract_object.cpp
+++ b/src/analyses/variable-sensitivity/constant_array_abstract_object.cpp
@@ -43,7 +43,7 @@ constant_array_abstract_objectt::constant_array_abstract_objectt(
       map.insert(mp_integer(index), environment.eval(entry, ns));
       ++index;
     }
-    clear_top();
+    set_not_top();
   }
   DATA_INVARIANT(verify(), "Structural invariants maintained");
 }
@@ -56,7 +56,7 @@ bool constant_array_abstract_objectt::verify() const
          (is_top() || is_bottom()) == map.empty();
 }
 
-void constant_array_abstract_objectt::make_top_internal()
+void constant_array_abstract_objectt::set_top_internal()
 {
   // A structural invariant of constant_array_abstract_objectt is that
   // (is_top() || is_bottom()) => map.empty()
@@ -231,7 +231,7 @@ constant_array_abstract_objectt::write_index(
             old_value.value(), value, stack, ns, merging_write));
       }
 
-      result->clear_top();
+      result->set_not_top();
       DATA_INVARIANT(result->verify(), "Structural invariants maintained");
       return result;
     }
@@ -248,7 +248,7 @@ constant_array_abstract_objectt::write_index(
           starting_value.first,
           environment.write(starting_value.second, value, stack, ns, true));
 
-        result->clear_top();
+        result->set_not_top();
       }
 
       DATA_INVARIANT(result->verify(), "Structural invariants maintained");
@@ -303,7 +303,7 @@ constant_array_abstract_objectt::write_index(
         {
           result->map.insert(index_value, value);
         }
-        result->clear_top();
+        result->set_not_top();
         DATA_INVARIANT(result->verify(), "Structural invariants maintained");
         return result;
       }

--- a/src/analyses/variable-sensitivity/constant_array_abstract_object.cpp
+++ b/src/analyses/variable-sensitivity/constant_array_abstract_object.cpp
@@ -189,7 +189,7 @@ abstract_object_pointert constant_array_abstract_objectt::read_index(
   }
 }
 
-sharing_ptrt<array_abstract_objectt>
+abstract_object_pointert
 constant_array_abstract_objectt::write_index(
   abstract_environmentt &environment,
   const namespacet &ns,

--- a/src/analyses/variable-sensitivity/constant_array_abstract_object.h
+++ b/src/analyses/variable-sensitivity/constant_array_abstract_object.h
@@ -110,9 +110,9 @@ protected:
   /// \param value: the value we are trying to assign to that value in the array
   /// \param merging_write: Should this and all future writes be merged with the
   ///                       current value
-  /// \return The array_abstract_objectt representing the result of writing
+  /// \return The abstract_object_pointert representing the result of writing
   ///         to a specific index.
-  sharing_ptrt<array_abstract_objectt> write_index(
+  abstract_object_pointert write_index(
     abstract_environmentt &environment,
     const namespacet &ns,
     const std::stack<exprt> stack,

--- a/src/analyses/variable-sensitivity/constant_array_abstract_object.h
+++ b/src/analyses/variable-sensitivity/constant_array_abstract_object.h
@@ -138,7 +138,7 @@ protected:
 
   /// \brief Perform any additional structural modifications when setting this
   /// object to TOP
-  void make_top_internal() override;
+  void set_top_internal() override;
 
   /// Evaluates the index and tries to convert it to a constant integer
   ///

--- a/src/analyses/variable-sensitivity/constant_array_abstract_object.h
+++ b/src/analyses/variable-sensitivity/constant_array_abstract_object.h
@@ -115,9 +115,9 @@ protected:
   abstract_object_pointert write_index(
     abstract_environmentt &environment,
     const namespacet &ns,
-    const std::stack<exprt> stack,
+    const std::stack<exprt> &stack,
     const index_exprt &index_expr,
-    const abstract_object_pointert value,
+    const abstract_object_pointert &value,
     bool merging_write) const override;
 
   /// Tries to do an array/array merge if merging with a constant array

--- a/src/analyses/variable-sensitivity/constant_pointer_abstract_object.cpp
+++ b/src/analyses/variable-sensitivity/constant_pointer_abstract_object.cpp
@@ -46,11 +46,11 @@ constant_pointer_abstract_objectt::constant_pointer_abstract_objectt(
   PRECONDITION(expr.type().id() == ID_pointer);
   if(value_stack.is_top_value())
   {
-    make_top();
+    set_top();
   }
   else
   {
-    clear_top();
+    set_not_top();
   }
 }
 

--- a/src/analyses/variable-sensitivity/constant_pointer_abstract_object.cpp
+++ b/src/analyses/variable-sensitivity/constant_pointer_abstract_object.cpp
@@ -169,12 +169,11 @@ abstract_object_pointert constant_pointer_abstract_objectt::read_dereference(
   }
 }
 
-abstract_object_pointert
-constant_pointer_abstract_objectt::write_dereference(
+abstract_object_pointert constant_pointer_abstract_objectt::write_dereference(
   abstract_environmentt &environment,
   const namespacet &ns,
-  const std::stack<exprt> stack,
-  const abstract_object_pointert new_value,
+  const std::stack<exprt> &stack,
+  const abstract_object_pointert &new_value,
   bool merging_write) const
 {
   if(is_top() || is_bottom() || value_stack.is_top_value())

--- a/src/analyses/variable-sensitivity/constant_pointer_abstract_object.cpp
+++ b/src/analyses/variable-sensitivity/constant_pointer_abstract_object.cpp
@@ -169,7 +169,7 @@ abstract_object_pointert constant_pointer_abstract_objectt::read_dereference(
   }
 }
 
-sharing_ptrt<pointer_abstract_objectt>
+abstract_object_pointert
 constant_pointer_abstract_objectt::write_dereference(
   abstract_environmentt &environment,
   const namespacet &ns,

--- a/src/analyses/variable-sensitivity/constant_pointer_abstract_object.h
+++ b/src/analyses/variable-sensitivity/constant_pointer_abstract_object.h
@@ -102,8 +102,8 @@ public:
   abstract_object_pointert write_dereference(
     abstract_environmentt &environment,
     const namespacet &ns,
-    const std::stack<exprt> stack,
-    const abstract_object_pointert value,
+    const std::stack<exprt> &stack,
+    const abstract_object_pointert &value,
     bool merging_write) const override;
 
   void get_statistics(

--- a/src/analyses/variable-sensitivity/constant_pointer_abstract_object.h
+++ b/src/analyses/variable-sensitivity/constant_pointer_abstract_object.h
@@ -99,7 +99,7 @@ public:
   ///
   /// \return A modified abstract object representing this pointer after it
   ///         has been written to.
-  sharing_ptrt<pointer_abstract_objectt> write_dereference(
+  abstract_object_pointert write_dereference(
     abstract_environmentt &environment,
     const namespacet &ns,
     const std::stack<exprt> stack,

--- a/src/analyses/variable-sensitivity/context_abstract_object.cpp
+++ b/src/analyses/variable-sensitivity/context_abstract_object.cpp
@@ -18,13 +18,13 @@ void context_abstract_objectt::set_child(const abstract_object_pointert &child)
   child_abstract_object = child;
 }
 
-void context_abstract_objectt::make_top_internal()
+void context_abstract_objectt::set_top_internal()
 {
   if(!child_abstract_object->is_top())
     set_child(child_abstract_object->make_top());
 }
 
-void context_abstract_objectt::clear_top_internal()
+void context_abstract_objectt::set_not_top_internal()
 {
   if(child_abstract_object->is_top())
     set_child(child_abstract_object->clear_top());

--- a/src/analyses/variable-sensitivity/context_abstract_object.cpp
+++ b/src/analyses/variable-sensitivity/context_abstract_object.cpp
@@ -71,9 +71,9 @@ abstract_object_pointert context_abstract_objectt::read(
 abstract_object_pointert context_abstract_objectt::write(
   abstract_environmentt &environment,
   const namespacet &ns,
-  const std::stack<exprt> stack,
+  const std::stack<exprt> &stack,
   const exprt &specifier,
-  const abstract_object_pointert value,
+  const abstract_object_pointert &value,
   bool merging_write) const
 {
   abstract_object_pointert updated_child = child_abstract_object->write(

--- a/src/analyses/variable-sensitivity/context_abstract_object.h
+++ b/src/analyses/variable-sensitivity/context_abstract_object.h
@@ -55,7 +55,7 @@ public:
   {
   }
 
-  virtual const typet &type() const
+  const typet &type() const override
   {
     return child_abstract_object->type();
   }

--- a/src/analyses/variable-sensitivity/context_abstract_object.h
+++ b/src/analyses/variable-sensitivity/context_abstract_object.h
@@ -115,9 +115,9 @@ protected:
   abstract_object_pointert write(
     abstract_environmentt &environment,
     const namespacet &ns,
-    const std::stack<exprt> stack,
+    const std::stack<exprt> &stack,
     const exprt &specifier,
-    const abstract_object_pointert value,
+    const abstract_object_pointert &value,
     bool merging_write) const override;
 
   bool has_been_modified(const abstract_object_pointert before) const override;

--- a/src/analyses/variable-sensitivity/context_abstract_object.h
+++ b/src/analyses/variable-sensitivity/context_abstract_object.h
@@ -104,8 +104,8 @@ protected:
 
   // These are internal hooks that allow sub-classes to perform additional
   // actions when an abstract_object is set/unset to TOP
-  void make_top_internal() override;
-  void clear_top_internal() override;
+  void set_top_internal() override;
+  void set_not_top_internal() override;
 
   abstract_object_pointert read(
     const abstract_environmentt &env,

--- a/src/analyses/variable-sensitivity/data_dependency_context.cpp
+++ b/src/analyses/variable-sensitivity/data_dependency_context.cpp
@@ -186,9 +186,9 @@ data_dependency_contextt::set_data_deps(const dependencest &dependencies) const
 abstract_object_pointert data_dependency_contextt::write(
   abstract_environmentt &environment,
   const namespacet &ns,
-  const std::stack<exprt> stack,
+  const std::stack<exprt> &stack,
   const exprt &specifier,
-  const abstract_object_pointert value,
+  const abstract_object_pointert &value,
   bool merging_write) const
 {
   const auto updated_parent =

--- a/src/analyses/variable-sensitivity/data_dependency_context.h
+++ b/src/analyses/variable-sensitivity/data_dependency_context.h
@@ -50,9 +50,9 @@ public:
   abstract_object_pointert write(
     abstract_environmentt &environment,
     const namespacet &ns,
-    const std::stack<exprt> stack,
+    const std::stack<exprt> &stack,
     const exprt &specifier,
-    const abstract_object_pointert value,
+    const abstract_object_pointert &value,
     bool merging_write) const override;
 
   abstract_object_pointert update_location_context(

--- a/src/analyses/variable-sensitivity/full_struct_abstract_object.cpp
+++ b/src/analyses/variable-sensitivity/full_struct_abstract_object.cpp
@@ -104,13 +104,12 @@ abstract_object_pointert full_struct_abstract_objectt::read_component(
   }
 }
 
-abstract_object_pointert
-full_struct_abstract_objectt::write_component(
+abstract_object_pointert full_struct_abstract_objectt::write_component(
   abstract_environmentt &environment,
   const namespacet &ns,
   const std::stack<exprt> &stack,
   const member_exprt &member_expr,
-  const abstract_object_pointert value,
+  const abstract_object_pointert &value,
   bool merging_write) const
 {
 #ifdef DEBUG
@@ -120,7 +119,7 @@ full_struct_abstract_objectt::write_component(
   if(is_bottom())
   {
     return std::make_shared<full_struct_abstract_objectt>(
-        member_expr.compound().type(), false, true);
+      member_expr.compound().type(), false, true);
   }
 
   const auto &result =

--- a/src/analyses/variable-sensitivity/full_struct_abstract_object.cpp
+++ b/src/analyses/variable-sensitivity/full_struct_abstract_object.cpp
@@ -66,7 +66,7 @@ full_struct_abstract_objectt::full_struct_abstract_objectt(
 
   if(did_initialize_values)
   {
-    clear_top();
+    set_not_top();
   }
 
   DATA_INVARIANT(verify(), "Structural invariants maintained");
@@ -145,7 +145,7 @@ full_struct_abstract_objectt::write_component(
         environment.write(old_value.value(), value, stack, ns, merging_write));
     }
 
-    result->clear_top();
+    result->set_not_top();
     DATA_INVARIANT(result->verify(), "Structural invariants maintained");
     return result;
   }
@@ -189,7 +189,7 @@ full_struct_abstract_objectt::write_component(
       {
         result->map.insert(c, value);
       }
-      result->clear_top();
+      result->set_not_top();
       INVARIANT(!result->is_bottom(), "top != bottom");
     }
 

--- a/src/analyses/variable-sensitivity/full_struct_abstract_object.cpp
+++ b/src/analyses/variable-sensitivity/full_struct_abstract_object.cpp
@@ -104,7 +104,7 @@ abstract_object_pointert full_struct_abstract_objectt::read_component(
   }
 }
 
-sharing_ptrt<struct_abstract_objectt>
+abstract_object_pointert
 full_struct_abstract_objectt::write_component(
   abstract_environmentt &environment,
   const namespacet &ns,
@@ -119,9 +119,8 @@ full_struct_abstract_objectt::write_component(
 
   if(is_bottom())
   {
-    return sharing_ptrt<full_struct_abstract_objectt>(
-      new full_struct_abstract_objectt(
-        member_expr.compound().type(), false, true));
+    return std::make_shared<full_struct_abstract_objectt>(
+        member_expr.compound().type(), false, true);
   }
 
   const auto &result =

--- a/src/analyses/variable-sensitivity/full_struct_abstract_object.h
+++ b/src/analyses/variable-sensitivity/full_struct_abstract_object.h
@@ -142,7 +142,7 @@ protected:
     const namespacet &ns,
     const std::stack<exprt> &stack,
     const member_exprt &member_expr,
-    const abstract_object_pointert value,
+    const abstract_object_pointert &value,
     bool merging_write) const override;
 
   /// Function: full_struct_abstract_objectt::verify

--- a/src/analyses/variable-sensitivity/full_struct_abstract_object.h
+++ b/src/analyses/variable-sensitivity/full_struct_abstract_object.h
@@ -137,7 +137,7 @@ protected:
   ///         writing to a specific component. In this case this will
   ///         always be top as we are not tracking the value of this
   ///          struct.
-  sharing_ptrt<struct_abstract_objectt> write_component(
+  abstract_object_pointert write_component(
     abstract_environmentt &environment,
     const namespacet &ns,
     const std::stack<exprt> &stack,

--- a/src/analyses/variable-sensitivity/interval_array_abstract_object.cpp
+++ b/src/analyses/variable-sensitivity/interval_array_abstract_object.cpp
@@ -47,7 +47,7 @@ static constant_interval_exprt eval_and_get_as_interval(
   return evaluated_index_interval->get_interval();
 }
 
-sharing_ptrt<array_abstract_objectt>
+abstract_object_pointert
 interval_array_abstract_objectt::write_index(
   abstract_environmentt &environment,
   const namespacet &ns,

--- a/src/analyses/variable-sensitivity/interval_array_abstract_object.cpp
+++ b/src/analyses/variable-sensitivity/interval_array_abstract_object.cpp
@@ -47,13 +47,12 @@ static constant_interval_exprt eval_and_get_as_interval(
   return evaluated_index_interval->get_interval();
 }
 
-abstract_object_pointert
-interval_array_abstract_objectt::write_index(
+abstract_object_pointert interval_array_abstract_objectt::write_index(
   abstract_environmentt &environment,
   const namespacet &ns,
-  const std::stack<exprt> stack,
+  const std::stack<exprt> &stack,
   const index_exprt &index_expr,
-  const abstract_object_pointert value,
+  const abstract_object_pointert &value,
   bool merging_write) const
 {
   auto index_interval =

--- a/src/analyses/variable-sensitivity/interval_array_abstract_object.h
+++ b/src/analyses/variable-sensitivity/interval_array_abstract_object.h
@@ -32,7 +32,7 @@ protected:
     const index_exprt &index,
     const namespacet &ns) const override;
 
-  sharing_ptrt<array_abstract_objectt> write_index(
+  abstract_object_pointert write_index(
     abstract_environmentt &environment,
     const namespacet &ns,
     const std::stack<exprt> stack,

--- a/src/analyses/variable-sensitivity/interval_array_abstract_object.h
+++ b/src/analyses/variable-sensitivity/interval_array_abstract_object.h
@@ -35,9 +35,9 @@ protected:
   abstract_object_pointert write_index(
     abstract_environmentt &environment,
     const namespacet &ns,
-    const std::stack<exprt> stack,
+    const std::stack<exprt> &stack,
     const index_exprt &index_expr,
-    const abstract_object_pointert value,
+    const abstract_object_pointert &value,
     bool merging_write) const override;
 
   bool eval_index(

--- a/src/analyses/variable-sensitivity/pointer_abstract_object.cpp
+++ b/src/analyses/variable-sensitivity/pointer_abstract_object.cpp
@@ -47,9 +47,9 @@ abstract_object_pointert pointer_abstract_objectt::read(
 abstract_object_pointert pointer_abstract_objectt::write(
   abstract_environmentt &environment,
   const namespacet &ns,
-  const std::stack<exprt> stack,
+  const std::stack<exprt> &stack,
   const exprt &specifier,
-  const abstract_object_pointert value,
+  const abstract_object_pointert &value,
   bool merging_write) const
 {
   return write_dereference(environment, ns, stack, value, merging_write);
@@ -67,12 +67,11 @@ abstract_object_pointert pointer_abstract_objectt::read_dereference(
 
 #include <iostream>
 
-abstract_object_pointert
-pointer_abstract_objectt::write_dereference(
+abstract_object_pointert pointer_abstract_objectt::write_dereference(
   abstract_environmentt &environment,
   const namespacet &ns,
-  const std::stack<exprt> stack,
-  const abstract_object_pointert value,
+  const std::stack<exprt> &stack,
+  const abstract_object_pointert &value,
   bool merging_write) const
 {
   if(is_top() || is_bottom())

--- a/src/analyses/variable-sensitivity/pointer_abstract_object.cpp
+++ b/src/analyses/variable-sensitivity/pointer_abstract_object.cpp
@@ -65,7 +65,9 @@ abstract_object_pointert pointer_abstract_objectt::read_dereference(
   return env.abstract_object_factory(pointed_to_type, ns, true, false);
 }
 
-sharing_ptrt<pointer_abstract_objectt>
+#include <iostream>
+
+abstract_object_pointert
 pointer_abstract_objectt::write_dereference(
   abstract_environmentt &environment,
   const namespacet &ns,
@@ -76,12 +78,11 @@ pointer_abstract_objectt::write_dereference(
   if(is_top() || is_bottom())
   {
     environment.havoc("Writing to a 2value pointer");
-    return std::dynamic_pointer_cast<const pointer_abstract_objectt>(clone());
+    return shared_from_this();
   }
   else
   {
-    return sharing_ptrt<pointer_abstract_objectt>(
-      new pointer_abstract_objectt(type(), true, false));
+    return std::make_shared<pointer_abstract_objectt>(type(), true, false);
   }
 }
 

--- a/src/analyses/variable-sensitivity/pointer_abstract_object.h
+++ b/src/analyses/variable-sensitivity/pointer_abstract_object.h
@@ -120,7 +120,7 @@ protected:
   ///
   /// \return A modified abstract object representing this pointer after it
   ///         has been written to.
-  virtual sharing_ptrt<pointer_abstract_objectt> write_dereference(
+  virtual abstract_object_pointert write_dereference(
     abstract_environmentt &environment,
     const namespacet &ns,
     const std::stack<exprt> stack,

--- a/src/analyses/variable-sensitivity/pointer_abstract_object.h
+++ b/src/analyses/variable-sensitivity/pointer_abstract_object.h
@@ -79,9 +79,9 @@ public:
   abstract_object_pointert write(
     abstract_environmentt &environment,
     const namespacet &ns,
-    const std::stack<exprt> stack,
+    const std::stack<exprt> &stack,
     const exprt &specifier,
-    const abstract_object_pointert value,
+    const abstract_object_pointert &value,
     bool merging_write) const override;
 
   void get_statistics(
@@ -123,8 +123,8 @@ protected:
   virtual abstract_object_pointert write_dereference(
     abstract_environmentt &environment,
     const namespacet &ns,
-    const std::stack<exprt> stack,
-    const abstract_object_pointert value,
+    const std::stack<exprt> &stack,
+    const abstract_object_pointert &value,
     bool merging_write) const;
 };
 

--- a/src/analyses/variable-sensitivity/struct_abstract_object.cpp
+++ b/src/analyses/variable-sensitivity/struct_abstract_object.cpp
@@ -48,9 +48,9 @@ abstract_object_pointert struct_abstract_objectt::read(
 abstract_object_pointert struct_abstract_objectt::write(
   abstract_environmentt &environment,
   const namespacet &ns,
-  const std::stack<exprt> stack,
+  const std::stack<exprt> &stack,
   const exprt &specifier,
-  const abstract_object_pointert value,
+  const abstract_object_pointert &value,
   bool merging_write) const
 {
   return this->write_component(
@@ -73,7 +73,7 @@ abstract_object_pointert struct_abstract_objectt::write_component(
   const namespacet &ns,
   const std::stack<exprt> &stack,
   const member_exprt &member_expr,
-  const abstract_object_pointert value,
+  const abstract_object_pointert &value,
   bool merging_write) const
 {
   if(is_top() || is_bottom())

--- a/src/analyses/variable-sensitivity/struct_abstract_object.cpp
+++ b/src/analyses/variable-sensitivity/struct_abstract_object.cpp
@@ -68,7 +68,7 @@ abstract_object_pointert struct_abstract_objectt::read_component(
     member_expr.type(), ns, !is_bottom(), is_bottom());
 }
 
-sharing_ptrt<struct_abstract_objectt> struct_abstract_objectt::write_component(
+abstract_object_pointert struct_abstract_objectt::write_component(
   abstract_environmentt &environment,
   const namespacet &ns,
   const std::stack<exprt> &stack,
@@ -78,12 +78,11 @@ sharing_ptrt<struct_abstract_objectt> struct_abstract_objectt::write_component(
 {
   if(is_top() || is_bottom())
   {
-    return std::dynamic_pointer_cast<const struct_abstract_objectt>(clone());
+    return shared_from_this();
   }
   else
   {
-    return sharing_ptrt<struct_abstract_objectt>(
-      new struct_abstract_objectt(type(), true, false));
+    return std::make_shared<struct_abstract_objectt>(type(), true, false);
   }
 }
 

--- a/src/analyses/variable-sensitivity/struct_abstract_object.h
+++ b/src/analyses/variable-sensitivity/struct_abstract_object.h
@@ -125,7 +125,7 @@ protected:
   /// \return The struct_abstract_objectt representing the result of writing
   ///         to a specific component. In this case this will always be top
   ///         as we are not tracking the value of this struct.
-  virtual sharing_ptrt<struct_abstract_objectt> write_component(
+  virtual abstract_object_pointert write_component(
     abstract_environmentt &environment,
     const namespacet &ns,
     const std::stack<exprt> &stack,

--- a/src/analyses/variable-sensitivity/struct_abstract_object.h
+++ b/src/analyses/variable-sensitivity/struct_abstract_object.h
@@ -78,9 +78,9 @@ public:
   abstract_object_pointert write(
     abstract_environmentt &environment,
     const namespacet &ns,
-    const std::stack<exprt> stack,
+    const std::stack<exprt> &stack,
     const exprt &specifier,
-    const abstract_object_pointert value,
+    const abstract_object_pointert &value,
     bool merging_write) const override;
 
   void get_statistics(
@@ -130,7 +130,7 @@ protected:
     const namespacet &ns,
     const std::stack<exprt> &stack,
     const member_exprt &member_expr,
-    const abstract_object_pointert value,
+    const abstract_object_pointert &value,
     bool merging_write) const;
 };
 

--- a/src/analyses/variable-sensitivity/union_abstract_object.cpp
+++ b/src/analyses/variable-sensitivity/union_abstract_object.cpp
@@ -47,9 +47,9 @@ abstract_object_pointert union_abstract_objectt::read(
 abstract_object_pointert union_abstract_objectt::write(
   abstract_environmentt &environment,
   const namespacet &ns,
-  const std::stack<exprt> stack,
+  const std::stack<exprt> &stack,
   const exprt &specifier,
-  const abstract_object_pointert value,
+  const abstract_object_pointert &value,
   bool merging_write) const
 {
   return write_component(
@@ -70,7 +70,7 @@ abstract_object_pointert union_abstract_objectt::write_component(
   const namespacet &ns,
   const std::stack<exprt> &stack,
   const member_exprt &member_expr,
-  const abstract_object_pointert value,
+  const abstract_object_pointert &value,
   bool merging_write) const
 {
   if(is_top() || is_bottom())

--- a/src/analyses/variable-sensitivity/union_abstract_object.cpp
+++ b/src/analyses/variable-sensitivity/union_abstract_object.cpp
@@ -65,7 +65,7 @@ abstract_object_pointert union_abstract_objectt::read_component(
     member_expr.type(), ns, !is_bottom(), is_bottom());
 }
 
-sharing_ptrt<union_abstract_objectt> union_abstract_objectt::write_component(
+abstract_object_pointert union_abstract_objectt::write_component(
   abstract_environmentt &environment,
   const namespacet &ns,
   const std::stack<exprt> &stack,
@@ -75,11 +75,10 @@ sharing_ptrt<union_abstract_objectt> union_abstract_objectt::write_component(
 {
   if(is_top() || is_bottom())
   {
-    return std::dynamic_pointer_cast<const union_abstract_objectt>(clone());
+    return shared_from_this();
   }
   else
   {
-    return sharing_ptrt<union_abstract_objectt>(
-      new union_abstract_objectt(type(), true, false));
+    return std::make_shared<union_abstract_objectt>(type(), true, false);
   }
 }

--- a/src/analyses/variable-sensitivity/union_abstract_object.h
+++ b/src/analyses/variable-sensitivity/union_abstract_object.h
@@ -78,9 +78,9 @@ public:
   abstract_object_pointert write(
     abstract_environmentt &environment,
     const namespacet &ns,
-    const std::stack<exprt> stack,
+    const std::stack<exprt> &stack,
     const exprt &specifier,
-    const abstract_object_pointert value,
+    const abstract_object_pointert &value,
     bool merging_write) const override;
 
 protected:
@@ -123,7 +123,7 @@ protected:
     const namespacet &ns,
     const std::stack<exprt> &stack,
     const member_exprt &member_expr,
-    const abstract_object_pointert value,
+    const abstract_object_pointert &value,
     bool merging_write) const;
 };
 #endif // CPROVER_ANALYSES_VARIABLE_SENSITIVITY_UNION_ABSTRACT_OBJECT_H

--- a/src/analyses/variable-sensitivity/union_abstract_object.h
+++ b/src/analyses/variable-sensitivity/union_abstract_object.h
@@ -118,7 +118,7 @@ protected:
   /// \return The union_abstract_objectt representing the result of writing
   ///         to a specific component. In this case this will always be top
   ///         as we are not tracking the value of this union.
-  virtual sharing_ptrt<union_abstract_objectt> write_component(
+  virtual abstract_object_pointert write_component(
     abstract_environmentt &environment,
     const namespacet &ns,
     const std::stack<exprt> &stack,

--- a/src/analyses/variable-sensitivity/value_set_abstract_object.cpp
+++ b/src/analyses/variable-sensitivity/value_set_abstract_object.cpp
@@ -174,7 +174,7 @@ abstract_object_pointert value_set_abstract_objectt::resolve_new_values(
     unwrapped_values.size() > max_value_set_size ||
     new_type == abstract_typet::UNSUPPORTED)
   {
-    result->make_top();
+    result->set_top();
   }
   else
   {

--- a/src/analyses/variable-sensitivity/value_set_abstract_object.cpp
+++ b/src/analyses/variable-sensitivity/value_set_abstract_object.cpp
@@ -126,9 +126,9 @@ abstract_object_pointert value_set_abstract_objectt::read(
 abstract_object_pointert value_set_abstract_objectt::write(
   abstract_environmentt &environment,
   const namespacet &ns,
-  const std::stack<exprt> stack,
+  const std::stack<exprt> &stack,
   const exprt &specifier,
-  const abstract_object_pointert value,
+  const abstract_object_pointert &value,
   bool merging_write) const
 {
   abstract_object_sett new_values;

--- a/src/analyses/variable-sensitivity/value_set_abstract_object.h
+++ b/src/analyses/variable-sensitivity/value_set_abstract_object.h
@@ -103,9 +103,9 @@ public:
   abstract_object_pointert write(
     abstract_environmentt &environment,
     const namespacet &ns,
-    const std::stack<exprt> stack,
+    const std::stack<exprt> &stack,
     const exprt &specifier,
-    const abstract_object_pointert value,
+    const abstract_object_pointert &value,
     bool merging_write) const override;
 
   /// Enforce casting to interval.

--- a/src/analyses/variable-sensitivity/value_set_array_abstract_object.cpp
+++ b/src/analyses/variable-sensitivity/value_set_array_abstract_object.cpp
@@ -25,9 +25,9 @@ abstract_object_pointert value_set_array_abstract_objectt::read(
 abstract_object_pointert value_set_array_abstract_objectt::write(
   abstract_environmentt &environment,
   const namespacet &ns,
-  std::stack<exprt> stack,
+  const std::stack<exprt> &stack,
   const exprt &specifier,
-  abstract_object_pointert value,
+  const abstract_object_pointert &value,
   bool merging_write) const
 {
   return array_abstract_objectt::write(
@@ -42,13 +42,12 @@ abstract_object_pointert value_set_array_abstract_objectt::read_index(
   return array_abstract_objectt::read_index(env, index, ns);
 }
 
-abstract_object_pointert
-value_set_array_abstract_objectt::write_index(
+abstract_object_pointert value_set_array_abstract_objectt::write_index(
   abstract_environmentt &environment,
   const namespacet &ns,
-  std::stack<exprt> stack,
+  const std::stack<exprt> &stack,
   const index_exprt &index_expr,
-  abstract_object_pointert value,
+  const abstract_object_pointert &value,
   bool merging_write) const
 {
   return array_abstract_objectt::write_index(

--- a/src/analyses/variable-sensitivity/value_set_array_abstract_object.cpp
+++ b/src/analyses/variable-sensitivity/value_set_array_abstract_object.cpp
@@ -42,7 +42,7 @@ abstract_object_pointert value_set_array_abstract_objectt::read_index(
   return array_abstract_objectt::read_index(env, index, ns);
 }
 
-sharing_ptrt<array_abstract_objectt>
+abstract_object_pointert
 value_set_array_abstract_objectt::write_index(
   abstract_environmentt &environment,
   const namespacet &ns,

--- a/src/analyses/variable-sensitivity/value_set_array_abstract_object.h
+++ b/src/analyses/variable-sensitivity/value_set_array_abstract_object.h
@@ -41,7 +41,7 @@ protected:
     const index_exprt &index,
     const namespacet &ns) const override;
 
-  sharing_ptrt<array_abstract_objectt> write_index(
+  abstract_object_pointert write_index(
     abstract_environmentt &environment,
     const namespacet &ns,
     std::stack<exprt> stack,

--- a/src/analyses/variable-sensitivity/value_set_array_abstract_object.h
+++ b/src/analyses/variable-sensitivity/value_set_array_abstract_object.h
@@ -29,9 +29,9 @@ public:
   abstract_object_pointert write(
     abstract_environmentt &environment,
     const namespacet &ns,
-    std::stack<exprt> stack,
+    const std::stack<exprt> &stack,
     const exprt &specifier,
-    abstract_object_pointert value,
+    const abstract_object_pointert &value,
     bool merging_write) const override;
 
   CLONE
@@ -44,9 +44,9 @@ protected:
   abstract_object_pointert write_index(
     abstract_environmentt &environment,
     const namespacet &ns,
-    std::stack<exprt> stack,
+    const std::stack<exprt> &stack,
     const index_exprt &index_expr,
-    abstract_object_pointert value,
+    const abstract_object_pointert &value,
     bool merging_write) const override;
 };
 

--- a/src/analyses/variable-sensitivity/value_set_pointer_abstract_object.cpp
+++ b/src/analyses/variable-sensitivity/value_set_pointer_abstract_object.cpp
@@ -47,7 +47,7 @@ abstract_object_pointert value_set_pointer_abstract_objectt::read_dereference(
   return pointer_abstract_objectt::read_dereference(env, ns);
 }
 
-sharing_ptrt<pointer_abstract_objectt>
+abstract_object_pointert
 value_set_pointer_abstract_objectt::write_dereference(
   abstract_environmentt &environment,
   const namespacet &ns,

--- a/src/analyses/variable-sensitivity/value_set_pointer_abstract_object.cpp
+++ b/src/analyses/variable-sensitivity/value_set_pointer_abstract_object.cpp
@@ -26,9 +26,9 @@ abstract_object_pointert value_set_pointer_abstract_objectt::read(
 abstract_object_pointert value_set_pointer_abstract_objectt::write(
   abstract_environmentt &environment,
   const namespacet &ns,
-  std::stack<exprt> stack,
+  const std::stack<exprt> &stack,
   const exprt &specifier,
-  abstract_object_pointert value,
+  const abstract_object_pointert &value,
   bool merging_write) const
 {
   return pointer_abstract_objectt::write(
@@ -47,12 +47,11 @@ abstract_object_pointert value_set_pointer_abstract_objectt::read_dereference(
   return pointer_abstract_objectt::read_dereference(env, ns);
 }
 
-abstract_object_pointert
-value_set_pointer_abstract_objectt::write_dereference(
+abstract_object_pointert value_set_pointer_abstract_objectt::write_dereference(
   abstract_environmentt &environment,
   const namespacet &ns,
-  std::stack<exprt> stack,
-  abstract_object_pointert value,
+  const std::stack<exprt> &stack,
+  const abstract_object_pointert &value,
   bool merging_write) const
 {
   return pointer_abstract_objectt::write_dereference(

--- a/src/analyses/variable-sensitivity/value_set_pointer_abstract_object.h
+++ b/src/analyses/variable-sensitivity/value_set_pointer_abstract_object.h
@@ -42,7 +42,7 @@ protected:
     const abstract_environmentt &env,
     const namespacet &ns) const override;
 
-  sharing_ptrt<pointer_abstract_objectt> write_dereference(
+  abstract_object_pointert write_dereference(
     abstract_environmentt &environment,
     const namespacet &ns,
     std::stack<exprt> stack,

--- a/src/analyses/variable-sensitivity/value_set_pointer_abstract_object.h
+++ b/src/analyses/variable-sensitivity/value_set_pointer_abstract_object.h
@@ -31,9 +31,9 @@ public:
   abstract_object_pointert write(
     abstract_environmentt &environment,
     const namespacet &ns,
-    std::stack<exprt> stack,
+    const std::stack<exprt> &stack,
     const exprt &specifier,
-    abstract_object_pointert value,
+    const abstract_object_pointert &value,
     bool merging_write) const override;
 
   CLONE
@@ -45,8 +45,8 @@ protected:
   abstract_object_pointert write_dereference(
     abstract_environmentt &environment,
     const namespacet &ns,
-    std::stack<exprt> stack,
-    abstract_object_pointert value,
+    const std::stack<exprt> &stack,
+    const abstract_object_pointert &value,
     bool merging_write) const override;
 };
 

--- a/src/analyses/variable-sensitivity/write_location_context.cpp
+++ b/src/analyses/variable-sensitivity/write_location_context.cpp
@@ -69,9 +69,9 @@ write_location_contextt::get_last_written_locations() const
 abstract_object_pointert write_location_contextt::write(
   abstract_environmentt &environment,
   const namespacet &ns,
-  const std::stack<exprt> stack,
+  const std::stack<exprt> &stack,
   const exprt &specifier,
-  const abstract_object_pointert value,
+  const abstract_object_pointert &value,
   bool merging_write) const
 {
   abstract_object_pointert updated_child = child_abstract_object->write(

--- a/src/analyses/variable-sensitivity/write_location_context.h
+++ b/src/analyses/variable-sensitivity/write_location_context.h
@@ -107,9 +107,9 @@ protected:
   abstract_object_pointert write(
     abstract_environmentt &environment,
     const namespacet &ns,
-    const std::stack<exprt> stack,
+    const std::stack<exprt> &stack,
     const exprt &specifier,
-    const abstract_object_pointert value,
+    const abstract_object_pointert &value,
     bool merging_write) const override;
 
   static void output_last_written_locations(


### PR DESCRIPTION
Tightens up the abstract_objectt interface 

* removes public `abstract_objectt::clone` member function. It's unnecessary as abstract_objectts are immutable after construction
* made `abstract_objectt::type()` member function virtual. `context_abstract_object` wanted to override it, but because it wasn't virtual was just hiding it.
* pass all immutable parameters to `abstract_objectt::write` as const-refs. There were a couple of parameters passed by const value. Corrected implementation member functions in derived classes to match. 

There are no functional changes in this PR. 