### PR TITLE
Print meaningful error message when trying to use undeclared uninterpreted functions

### DIFF
--- a/regression/ansi-c/undeclared_function/undeclared_uninterpreted.desc
+++ b/regression/ansi-c/undeclared_function/undeclared_uninterpreted.desc
@@ -1,0 +1,11 @@
+CORE
+uninterpreted.c
+
+missing type information required to construct call to uninterpreted function
+^EXIT=70$
+^SIGNAL=0$
+--
+^warning: ignoring
+^Invariant check failed$
+--
+Test to confirm that an actionable error message is provided.

--- a/regression/ansi-c/undeclared_function/uninterpreted.c
+++ b/regression/ansi-c/undeclared_function/uninterpreted.c
@@ -1,0 +1,10 @@
+#include <assert.h>
+
+int main()
+{
+  int x;
+  assert(__CPROVER_uninterpreted_fn(x) == __CPROVER_uninterpreted_fn(x));
+  return 0;
+}
+
+int __CPROVER_uninterpreted_fn(int x);

--- a/src/goto-programs/builtin_functions.cpp
+++ b/src/goto-programs/builtin_functions.cpp
@@ -892,6 +892,15 @@ void goto_convertt::do_function_call_symbol(
     if(lhs.is_nil())
       return;
 
+    if(function.type().get_bool(ID_C_incomplete))
+    {
+      error().source_location = function.find_source_location();
+      error() << "'" << identifier << "' is not declared, "
+              << "missing type information required to construct call to "
+              << "uninterpreted function" << eom;
+      throw 0;
+    }
+
     const code_typet &function_call_type = to_code_type(function.type());
     mathematical_function_typet::domaint domain;
     for(const auto &parameter : function_call_type.parameters())


### PR DESCRIPTION
With 32715b46c258a2, the use of undeclared uninterpreted functions
resulted in an invariant failure. The commit introduced additional
sanity checking, but such failing such checks should still yield an
error message that is actionable by an end user.

Fixes: #5641

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
