### PR TITLE
CMake builds: set a default build type (Release)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,12 @@
 cmake_minimum_required(VERSION 3.2)
 
+# Build a Release version by default (default build flags for each build type
+# are configured below).
+if (NOT EXISTS ${CMAKE_BINARY_DIR}/CMakeCache.txt)
+    if (NOT CMAKE_BUILD_TYPE)
+        set(CMAKE_BUILD_TYPE "Release" CACHE STRING "" FORCE)
+    endif()
+endif()
 
 # Grab the current CBMC version from config.inc
 # We do this so we have a matching cbmc version between the Makefile build and

--- a/COMPILING.md
+++ b/COMPILING.md
@@ -266,7 +266,8 @@ require manual modification of build files.
    Generally it is not necessary to manually specify individual compiler or
    linker flags, as CMake defines a number of "build modes" including Debug and
    Release modes. To build in a particular mode, add the flag
-   `-DCMAKE_BUILD_TYPE=Debug` (or `Release`) to the initial invocation.
+   `-DCMAKE_BUILD_TYPE=Debug` (or `RelWithDebInfo`) to the initial invocation.
+   The default is to perform an optimized build via the `Release` configuration.
 
    If you *do* need to manually add flags, use `-DCMAKE_CXX_FLAGS=...` and
    `-DCMAKE_EXE_LINKER_FLAGS=...`. This is useful for enabling clang's


### PR DESCRIPTION
In absence of a default build type, CMake would not use any pre-defined
build configuration. As a consequence, any user running CMake without
setting -DCMAKE_BUILD_TYPE would end up with builds without
optimisation, and thus (surprisingly!) poor performance.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
