### PR TITLE
__atomic_compare_exchange{,_n}: correctly handle not-equal case

### DIFF
--- a/regression/cbmc/atomic_load_store-1/main.c
+++ b/regression/cbmc/atomic_load_store-1/main.c
@@ -15,6 +15,10 @@ int main()
   assert(__atomic_exchange_n(&x, 42, 0) == x_before);
   __atomic_exchange(&x, &v, &x_before, 0);
 
+  int v2 = x == 0;
+  assert(!__atomic_compare_exchange_n(&x, &v2, 42, 0, 0, 0));
+  assert(v2 == x);
+
   assert(__atomic_compare_exchange_n(&x, &v, 42, 0, 0, 0));
   v = 42;
   assert(__atomic_compare_exchange(&x, &v, &v, 0, 0, 0));

--- a/src/ansi-c/c_typecheck_gcc_polymorphic_builtins.cpp
+++ b/src/ansi-c/c_typecheck_gcc_polymorphic_builtins.cpp
@@ -1166,6 +1166,9 @@ static void instantiate_atomic_compare_exchange(
     source_location}};
   success_fence.add_source_location() = source_location;
 
+  code_assignt assign_not_equal{dereference_exprt{parameter_exprs[1]},
+                                deref_ptr};
+  assign_not_equal.add_source_location() = source_location;
   code_expressiont failure_fence{side_effect_expr_function_callt{
     symbol_exprt::typeless("__atomic_thread_fence"),
     {parameter_exprs[5]},
@@ -1173,10 +1176,10 @@ static void instantiate_atomic_compare_exchange(
     source_location}};
   failure_fence.add_source_location() = source_location;
 
-  block.add(
-    code_ifthenelset{result,
-                     code_blockt{{std::move(assign), std::move(success_fence)}},
-                     std::move(failure_fence)});
+  block.add(code_ifthenelset{
+    result,
+    code_blockt{{std::move(assign), std::move(success_fence)}},
+    code_blockt{{std::move(assign_not_equal), std::move(failure_fence)}}});
 
   block.add(code_expressiont{side_effect_expr_function_callt{
     symbol_exprt::typeless(CPROVER_PREFIX "atomic_end"),


### PR DESCRIPTION
GCC's spec of the built-in says: "If they are not equal, the operation
is a read and the current contents of *ptr are written into *expected."
The case of the *ptr and *expected not being equal previously just
returned false, but did not perform any assignment.

Fixes: #5650

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
