### PR TITLE
C library/time: fix wrong is-null test

### DIFF
--- a/regression/cbmc-library/time-01/main.c
+++ b/regression/cbmc-library/time-01/main.c
@@ -3,7 +3,11 @@
 
 int main()
 {
-  time();
-  assert(0);
+  time_t t1 = time(0);
+
+  time_t t;
+  time_t t2 = time(&t);
+  assert(t2 == t);
+
   return 0;
 }

--- a/regression/cbmc-library/time-01/test.desc
+++ b/regression/cbmc-library/time-01/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.c
 --pointer-check --bounds-check
 ^EXIT=0$

--- a/src/ansi-c/library/time.c
+++ b/src/ansi-c/library/time.c
@@ -12,7 +12,8 @@ time_t __VERIFIER_nondet_time_t();
 time_t time(time_t *tloc)
 {
   time_t res=__VERIFIER_nondet_time_t();
-  if(!tloc) *tloc=res;
+  if(tloc)
+    *tloc = res;
   return res;
 }
 


### PR DESCRIPTION
The assignment should happen if the pointer is non-null, not when it is
null. Also test this library function.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
