### PR TITLE
goto-symex: nil array size must not have a type added

### DIFF
--- a/src/goto-symex/goto_symex_state.cpp
+++ b/src/goto-symex/goto_symex_state.cpp
@@ -252,6 +252,10 @@ goto_symex_statet::rename(exprt expr, const namespacet &ns)
       as_const(address_of_expr).object().type();
     return renamedt<exprt, level>{std::move(expr)};
   }
+  else if(expr.is_nil())
+  {
+    return renamedt<exprt, level>{std::move(expr)};
+  }
   else
   {
     rename<level>(expr.type(), irep_idt(), ns);

--- a/src/goto-symex/renaming_level.cpp
+++ b/src/goto-symex/renaming_level.cpp
@@ -263,6 +263,10 @@ bool check_renaming(const exprt &expr)
     if(to_ssa_expr(expr).get_original_expr().type() != type)
       return true;
   }
+  else if(expr.id() == ID_nil)
+  {
+    return expr != nil_exprt{};
+  }
   else
   {
     forall_operands(it, expr)

--- a/src/util/std_types.cpp
+++ b/src/util/std_types.cpp
@@ -18,6 +18,19 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "std_expr.h"
 #include "string2int.h"
 
+void array_typet::check(const typet &type, const validation_modet vm)
+{
+  PRECONDITION(type.id() == ID_array);
+  const array_typet &array_type = static_cast<const array_typet &>(type);
+  if(array_type.size().is_nil())
+  {
+    DATA_CHECK(
+      vm,
+      array_type.size() == nil_exprt{},
+      "nil array size must be exactly nil");
+  }
+}
+
 std::size_t fixedbv_typet::get_integer_bits() const
 {
   const irep_idt integer_bits=get(ID_integer_bits);

--- a/src/util/std_types.h
+++ b/src/util/std_types.h
@@ -984,6 +984,10 @@ public:
   {
     return size().is_nil();
   }
+
+  static void check(
+    const typet &type,
+    const validation_modet vm = validation_modet::INVARIANT);
 };
 
 /// Check whether a reference to a typet is a \ref array_typet.

--- a/src/util/validate_types.cpp
+++ b/src/util/validate_types.cpp
@@ -52,6 +52,10 @@ void call_on_type(const typet &type, Args &&... args)
   {
     CALL_ON_TYPE(c_bool_typet);
   }
+  else if(type.id() == ID_array)
+  {
+    CALL_ON_TYPE(array_typet);
+  }
   else
   {
 #ifdef REPORT_UNIMPLEMENTED_TYPE_CHECKS


### PR DESCRIPTION
An expression has a type() member, which the nil irept lacks. Trying to
access (in a non-const context) the type() member would thus create it,
which in turn means that it no longer compares equal to a nil_exprt.  As
SSA renaming did access the type() member in such a way, the type of an
array without specified size would no longer compare equal to the irept
describing the type as generated by the C front-end, which in turn made
simplification fail.

The problem was surfaced by running cbmc --unwind 2 --pointer-check
--bounds-check on
c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--gpu--drm--i915--i915.ko-entry_point.cil.out.i
from SV-COMP.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
