### PR TITLE
Cleanup validation of reference_typet

### DIFF
--- a/src/util/std_types.h
+++ b/src/util/std_types.h
@@ -1556,6 +1556,19 @@ public:
   {
     set(ID_C_reference, true);
   }
+
+  static void check(
+    const typet &type,
+    const validation_modet vm = validation_modet::INVARIANT)
+  {
+    PRECONDITION(type.id() == ID_pointer);
+    const reference_typet &reference_type =
+      static_cast<const reference_typet &>(type);
+    DATA_CHECK(
+      vm, !reference_type.get(ID_width).empty(), "reference must have width");
+    DATA_CHECK(
+      vm, reference_type.get_width() > 0, "reference must have non-zero width");
+  }
 };
 
 /// Check whether a reference to a typet is a \ref reference_typet.
@@ -1565,12 +1578,6 @@ template <>
 inline bool can_cast_type<reference_typet>(const typet &type)
 {
   return can_cast_type<pointer_typet>(type) && type.get_bool(ID_C_reference);
-}
-
-inline void validate_type(const reference_typet &type)
-{
-  DATA_INVARIANT(!type.get(ID_width).empty(), "reference must have width");
-  DATA_INVARIANT(type.get_width() > 0, "reference must have non-zero width");
 }
 
 /// \brief Cast a typet to a \ref reference_typet

--- a/src/util/validate_types.cpp
+++ b/src/util/validate_types.cpp
@@ -46,7 +46,10 @@ void call_on_type(const typet &type, Args &&... args)
   }
   else if(type.id() == ID_pointer)
   {
-    CALL_ON_TYPE(pointer_typet);
+    if(type.get_bool(ID_C_reference))
+      CALL_ON_TYPE(reference_typet);
+    else
+      CALL_ON_TYPE(pointer_typet);
   }
   else if(type.id() == ID_c_bool)
   {


### PR DESCRIPTION
validate_type is not actually used (anymore), instead static member
functions `check` are used.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
