### PR TITLE
value sets: do not try to access components of an empty struct/union

### DIFF
--- a/regression/cbmc/empty_compound_type1/main.c
+++ b/regression/cbmc/empty_compound_type1/main.c
@@ -1,0 +1,19 @@
+union a {
+};
+struct
+{
+  union a;
+} b;
+struct c
+{
+  int cli;
+};
+void e(struct c *f)
+{
+  int a = f->cli;
+}
+main()
+{
+  // pass a pointer to an incompatible type
+  e(&b);
+}

--- a/regression/cbmc/empty_compound_type1/test.desc
+++ b/regression/cbmc/empty_compound_type1/test.desc
@@ -1,0 +1,14 @@
+CORE
+main.c
+
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring
+--
+First observed on SV-COMP's
+linux-4.2-rc1.tar.xz-32_7a-drivers--staging--lustre--lustre--mdc--mdc.ko-entry_point.cil.out.i:
+accessing an empty union (or struct) in pointer dereferencing involving
+incompatible pointers resulted in a segmentation fault. This test was generated
+using C-Reduce plus some further manual simplification.

--- a/src/pointer-analysis/value_set.cpp
+++ b/src/pointer-analysis/value_set.cpp
@@ -425,14 +425,17 @@ optionalt<irep_idt> value_sett::get_index_of_symbol(
     const struct_union_typet &struct_union_type =
       to_struct_union_type(followed_type);
 
-    const irep_idt &first_component_name =
-      struct_union_type.components().front().get_name();
+    if(!struct_union_type.components().empty())
+    {
+      const irep_idt &first_component_name =
+        struct_union_type.components().front().get_name();
 
-    index =
-      id2string(identifier) + "." + id2string(first_component_name) + suffix;
-    entry = find_entry(index);
-    if(entry)
-      return std::move(index);
+      index =
+        id2string(identifier) + "." + id2string(first_component_name) + suffix;
+      entry = find_entry(index);
+      if(entry)
+        return std::move(index);
+    }
   }
 
   // not found? try without suffix


### PR DESCRIPTION
This avoids a segmentation fault while running on
c/ldv-linux-4.2-rc1/linux-4.2-rc1.tar.xz-32_7a-drivers--staging--lustre--lustre--mdc--mdc.ko-entry_point.cil.out.i
with options --pointer-check --bounds-check --unwind 2. This benchmark
includes the empty `union __anonunion_u_rpc_386`. While the patch does
address the problem on this benchmark, I failed to come up with a small
regression test.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
