### PR TITLE
GraphML fixes to ensure SV-COMP compatibility

### DIFF
--- a/src/xmllang/graphml.cpp
+++ b/src/xmllang/graphml.cpp
@@ -305,7 +305,7 @@ bool write_graphml(const graphmlt &src, std::ostream &os)
     key.new_element("default").data="false";
   }
 
-  // <key attr.name="cyclehead" attr.type="boolean" for="edge"
+  // <key attr.name="cyclehead" attr.type="boolean" for="node"
   //      id="cyclehead">
   //   <default>false</default>
   // </key>
@@ -313,7 +313,7 @@ bool write_graphml(const graphmlt &src, std::ostream &os)
     xmlt &key = graphml.new_element("key");
     key.set_attribute("attr.name", "cyclehead");
     key.set_attribute("attr.type", "boolean");
-    key.set_attribute("for", "edge");
+    key.set_attribute("for", "node");
     key.set_attribute("id", "cyclehead");
 
     key.new_element("default").data = "false";

--- a/src/xmllang/graphml.cpp
+++ b/src/xmllang/graphml.cpp
@@ -402,6 +402,16 @@ bool write_graphml(const graphmlt &src, std::ostream &os)
     key.set_attribute("id", "producer");
   }
 
+  // <key attr.name="creationtime" attr.type="string" for="graph"
+  //      id="creationtime"/>
+  {
+    xmlt &key = graphml.new_element("key");
+    key.set_attribute("attr.name", "creationtime");
+    key.set_attribute("attr.type", "string");
+    key.set_attribute("for", "graph");
+    key.set_attribute("id", "creationtime");
+  }
+
   // <key attr.name="startline" attr.type="int" for="edge" id="startline"/>
   {
     xmlt &key=graphml.new_element("key");


### PR DESCRIPTION
The witness linter exposed two bugs in our GraphML output. (See the individual commit messages.)

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
