### PR TITLE
C library: Windows defines time to _time64 (or _time32)

### DIFF
--- a/src/ansi-c/library/time.c
+++ b/src/ansi-c/library/time.c
@@ -17,6 +17,48 @@ time_t time(time_t *tloc)
   return res;
 }
 
+/* FUNCTION: _time64 */
+
+#ifdef _WIN32
+
+#  ifndef __CPROVER_TIME_H_INCLUDED
+#    include <time.h>
+#    define __CPROVER_TIME_H_INCLUDED
+#  endif
+
+time_t __VERIFIER_nondet_time_t();
+
+time_t _time64(time_t *tloc)
+{
+  time_t res = __VERIFIER_nondet_time_t();
+  if(tloc)
+    *tloc = res;
+  return res;
+}
+
+#endif
+
+/* FUNCTION: _time32 */
+
+#if defined(_WIN32) && defined(_USE_32BIT_TIME_T)
+
+#  ifndef __CPROVER_TIME_H_INCLUDED
+#    include <time.h>
+#    define __CPROVER_TIME_H_INCLUDED
+#  endif
+
+__time32_t __VERIFIER_nondet_time32_t();
+
+__time32_t _time32(__time32_t *tloc)
+{
+  __time32_t res = __VERIFIER_nondet_time32_t();
+  if(tloc)
+    *tloc = res;
+  return res;
+}
+
+#endif
+
 /* FUNCTION: gmtime */
 
 #ifndef __CPROVER_TIME_H_INCLUDED


### PR DESCRIPTION
Windows uses time as a wrapper to _time64 by default, or _time32 when
_USE_32BIT_TIME_T is defined. See
https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/time-time32-time64?view=msvc-160.

This is a fix-up to c6f1ed5d37, which introduced a broken regression
test for Windows because of the then-undefined _time64 function.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
