### PR TITLE
Help output: document that stop-on-fail implies trace

### DIFF
--- a/jbmc/src/jbmc/jbmc_parse_options.cpp
+++ b/jbmc/src/jbmc/jbmc_parse_options.cpp
@@ -1070,8 +1070,9 @@ void jbmc_parse_optionst::help()
     HELP_SHOW_PROPERTIES
     " --symex-coverage-report f    generate a Cobertura XML coverage report in f\n" // NOLINT(*)
     " --property id                only check one specific property\n"
-    " --stop-on-fail               stop analysis once a failed property is detected\n" // NOLINT(*)
     " --trace                      give a counterexample trace for failed properties\n" //NOLINT(*)
+    " --stop-on-fail               stop analysis once a failed property is detected\n" // NOLINT(*)
+    "                              (implies --trace)\n"
     HELP_JAVA_TRACE_VALIDATION
     "\n"
     "Program representations:\n"

--- a/src/cbmc/README.md
+++ b/src/cbmc/README.md
@@ -48,7 +48,8 @@ formula using two different possible procedures:
 
 1. When `--stop-on-fail` is passed on the command-line, the formula is solved
    once to find any violated assertion. This is implemented directly in
-   class `bmct`.
+   class `bmct`. If the formula is satisfiable, a counter-example trace is
+   generated.
 2. When `--stop-on-fail` is not passed, BMC is run in "all-properties" mode.
    This categorises the assertions into groups that represent the same property,
    and the solver is run repeatedly to try to satisfy each property at least

--- a/src/cbmc/cbmc_parse_options.cpp
+++ b/src/cbmc/cbmc_parse_options.cpp
@@ -1064,8 +1064,9 @@ void cbmc_parse_optionst::help()
     HELP_SHOW_PROPERTIES
     " --symex-coverage-report f    generate a Cobertura XML coverage report in f\n" // NOLINT(*)
     " --property id                only check one specific property\n"
-    " --stop-on-fail               stop analysis once a failed property is detected\n" // NOLINT(*)
     " --trace                      give a counterexample trace for failed properties\n" //NOLINT(*)
+    " --stop-on-fail               stop analysis once a failed property is detected\n" // NOLINT(*)
+    "                              (implies --trace)\n"
     "\n"
     "C/C++ frontend options:\n"
     " -I path                      set include path (C/C++)\n"


### PR DESCRIPTION
Running CBMC or JBMC with --stop-on-fail will print a counter-example
trace. Previously, the help output suggested that --trace was required
to accomplish this. Clarify in the help output that --trace is implied
by --stop-on-fail.

Fixes: #5654

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [x] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
