### PR TITLE
Do not fail an internal invariant when initialising an empty union

### DIFF
--- a/regression/ansi-c/Union_Initialization2/main.c
+++ b/regression/ansi-c/Union_Initialization2/main.c
@@ -1,0 +1,5 @@
+union a {
+} b()
+{
+  union a c = {0};
+}

--- a/regression/ansi-c/Union_Initialization2/test.desc
+++ b/regression/ansi-c/Union_Initialization2/test.desc
@@ -1,0 +1,11 @@
+CORE
+main.c
+
+union member designator found for empty union
+^SIGNAL=0$
+^EXIT=(1|64)$
+--
+member designator is bounded by components size
+--
+This test previously failed an internal invariant, which is not the correct
+behaviour the problem can be triggered by user input.

--- a/src/ansi-c/c_typecheck_initializer.cpp
+++ b/src/ansi-c/c_typecheck_initializer.cpp
@@ -478,10 +478,21 @@ exprt::operandst::const_iterator c_typecheck_baset::do_designated_initializer(
       const union_typet::componentst &components=
         union_type.components();
 
-      DATA_INVARIANT(index<components.size(),
-                     "member designator is bounded by components size");
+      if(components.empty())
+      {
+        error().source_location = value.source_location();
+        error() << "union member designator found for empty union" << eom;
+        throw 0;
+      }
+      else if(index >= components.size())
+      {
+        error().source_location = value.source_location();
+        error() << "union member designator " << index << " out of bounds ("
+                << components.size() << ")" << eom;
+        throw 0;
+      }
 
-      const union_typet::componentt &component=union_type.components()[index];
+      const union_typet::componentt &component = components[index];
 
       if(dest->id()==ID_union &&
          dest->get(ID_component_name)==component.get_name())


### PR DESCRIPTION
The C front-end should instead report a meaningful error message. The
test is based on an example originally created by CSmith and then
reduced using C-Reduce.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
