### PR TITLE
Expression initialiser: do not generate nil for empty union

### DIFF
--- a/regression/cbmc/Union_Initialization3/main.c
+++ b/regression/cbmc/Union_Initialization3/main.c
@@ -1,0 +1,6 @@
+union {
+} a;
+main()
+{
+  __assert_fail("", 2, __PRETTY_FUNCTION__);
+}

--- a/regression/cbmc/Union_Initialization3/test.desc
+++ b/regression/cbmc/Union_Initialization3/test.desc
@@ -1,0 +1,11 @@
+CORE
+main.c
+
+^EXIT=10$
+^SIGNAL=0$
+^VERIFICATION FAILED$
+--
+^warning: ignoring
+--
+CBMC would previously report "warning: ignoring nil" and eventually fail an
+invariant in src/solvers/flattening/boolbv_width.cpp:199 function: get_entry.

--- a/regression/cbmc/Union_Initialization4/main.c
+++ b/regression/cbmc/Union_Initialization4/main.c
@@ -1,0 +1,16 @@
+union empty {
+};
+
+struct S
+{
+  int x;
+  union empty e;
+  int y;
+};
+
+struct S s = {1};
+
+int main()
+{
+  assert(s.x == 1 && s.y == 0);
+}

--- a/regression/cbmc/Union_Initialization4/test.desc
+++ b/regression/cbmc/Union_Initialization4/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring

--- a/src/ansi-c/c_typecheck_initializer.cpp
+++ b/src/ansi-c/c_typecheck_initializer.cpp
@@ -953,16 +953,21 @@ exprt c_typecheck_baset::do_initializer_list(
      full_type.id()==ID_union ||
      full_type.id()==ID_vector)
   {
-    // start with zero everywhere
-    const auto zero = zero_initializer(type, value.source_location(), *this);
-    if(!zero.has_value())
+    if(
+      full_type.id() != ID_union ||
+      !to_union_type(full_type).components().empty())
     {
-      error().source_location = value.source_location();
-      error() << "cannot zero-initialize '" << to_string(full_type) << "'"
-              << eom;
-      throw 0;
+      // start with zero everywhere
+      const auto zero = zero_initializer(type, value.source_location(), *this);
+      if(!zero.has_value())
+      {
+        error().source_location = value.source_location();
+        error() << "cannot zero-initialize '" << to_string(full_type) << "'"
+                << eom;
+        throw 0;
+      }
+      result = *zero;
     }
-    result = *zero;
   }
   else if(full_type.id()==ID_array)
   {

--- a/src/util/expr_initializer.cpp
+++ b/src/util/expr_initializer.cpp
@@ -192,6 +192,14 @@ optionalt<exprt> expr_initializert<nondet>::expr_initializer_rec(
         code_value.add_source_location()=source_location;
         value.add_to_operands(std::move(code_value));
       }
+      else if(
+        c.type().id() == ID_union_tag &&
+        ns.follow_tag(to_union_tag_type(c.type())).components().empty())
+      {
+        union_exprt empty_union{irep_idt{}, nil_exprt{}, c.type()};
+        empty_union.add_source_location() = source_location;
+        value.add_to_operands(std::move(empty_union));
+      }
       else
       {
         const auto member = expr_initializer_rec(c.type(), source_location);
@@ -235,10 +243,8 @@ optionalt<exprt> expr_initializert<nondet>::expr_initializer_rec(
 
     if(!found)
     {
-      // stupid empty union
-      union_exprt value(irep_idt(), nil_exprt(), type);
-      value.add_source_location() = source_location;
-      return std::move(value);
+      // empty union or no member of known size
+      return {};
     }
     else
     {


### PR DESCRIPTION
Empty unions do not have a meaningful union_exprt as an initialiser, and
thus the expression initialiser should make use of returning an
optionalt{} instead.

This test was generated using C-Reduce based on an example initially
generated by CSmith.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
