### PR TITLE
Cleanup side effects in declaration initialisers

### DIFF
--- a/regression/cbmc/Sideeffects7/main.c
+++ b/regression/cbmc/Sideeffects7/main.c
@@ -1,0 +1,20 @@
+int foo()
+{
+  __CPROVER_assert(0, "");
+}
+
+int main()
+{
+  struct
+  {
+    int a : 2;
+  } b;
+  int c;
+  short d;
+  // this is to make sure the fix for the below assignment does not introduce a
+  // new bug
+  d |= b.a = c >= 0;
+
+  // we previously weren't able to handle the below
+  short a = (a ^= 0) || foo();
+}

--- a/regression/cbmc/Sideeffects7/test.desc
+++ b/regression/cbmc/Sideeffects7/test.desc
@@ -1,0 +1,10 @@
+CORE
+main.c
+
+^EXIT=10$
+^SIGNAL=0$
+^VERIFICATION FAILED$
+--
+Invariant check failed
+--
+This example previously failed with an unhandled side effect in symex.

--- a/src/goto-programs/goto_convert.cpp
+++ b/src/goto-programs/goto_convert.cpp
@@ -633,10 +633,15 @@ void goto_convertt::convert_decl(
     // Decl must be visible before initializer.
     copy(tmp, DECL, dest);
 
-    code_assignt assign(code.op0(), initializer);
-    assign.add_source_location()=tmp.source_location();
+    clean_expr(initializer, dest, mode);
 
-    convert_assign(assign, dest, mode);
+    if(initializer.is_not_nil())
+    {
+      code_assignt assign(code.op0(), initializer);
+      assign.add_source_location() = tmp.source_location();
+
+      convert_assign(assign, dest, mode);
+    }
   }
 
   // now create a 'dead' instruction -- will be added after the

--- a/src/goto-programs/goto_convert_side_effect.cpp
+++ b/src/goto-programs/goto_convert_side_effect.cpp
@@ -128,8 +128,24 @@ void goto_convertt::remove_assignment(
   // revert assignment in the expression to its LHS
   if(result_is_used)
   {
-    exprt lhs;
-    lhs.swap(to_binary_expr(expr).op0());
+    exprt lhs = to_binary_expr(expr).op0();
+    // assign_* statements can have an lhs operand with a different type than
+    // that of the overall expression, because of integer promotion (which may
+    // have introduced casts to the lhs).
+    if(expr.type() != lhs.type())
+    {
+      // Skip over those type casts, but also
+      // make sure the resulting expression has the same type as before.
+      DATA_INVARIANT(
+        lhs.id() == ID_typecast,
+        id2string(expr.id()) +
+          " expression with different operand type expected to have a "
+          "typecast");
+      DATA_INVARIANT(
+        to_typecast_expr(lhs).op().type() == expr.type(),
+        id2string(expr.id()) + " type mismatch in lhs operand");
+      lhs = to_typecast_expr(lhs).op();
+    }
     expr.swap(lhs);
   }
   else


### PR DESCRIPTION
Declarations with initialisers generate a declaration and an assignment.
The side effect in the rhs of the assignment was never cleaned up,
resulting in a failing invariant during symex for the regression test
included.

The test was built by C-Reduce on a example originating from CSmith.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
