### PR TITLE
C front-end: report struct/union redefinition as an error

### DIFF
--- a/regression/ansi-c/struct8/main.c
+++ b/regression/ansi-c/struct8/main.c
@@ -1,0 +1,2 @@
+struct a;
+union a b;

--- a/regression/ansi-c/struct8/test.desc
+++ b/regression/ansi-c/struct8/test.desc
@@ -1,0 +1,9 @@
+CORE test-c++-front-end
+main.c
+
+^EXIT=(64|1)$
+^SIGNAL=0$
+redefinition of '(struct )?a' as different kind of tag
+^CONVERSION ERROR$
+--
+Invariant check failed

--- a/src/ansi-c/c_typecheck_type.cpp
+++ b/src/ansi-c/c_typecheck_type.cpp
@@ -847,6 +847,13 @@ void c_typecheck_baset::typecheck_compound_type(struct_union_typet &type)
           symbol_table.get_writeable_ref(s_it->first).type.swap(type);
         }
       }
+      else if(s_it->second.type.id() != type.id())
+      {
+        error().source_location = type.source_location();
+        error() << "redefinition of '" << s_it->second.pretty_name << "'"
+                << " as different kind of tag" << eom;
+        throw 0;
+      }
       else if(have_body)
       {
         error().source_location=type.source_location();

--- a/src/cpp/cpp_typecheck_compound_type.cpp
+++ b/src/cpp/cpp_typecheck_compound_type.cpp
@@ -212,6 +212,13 @@ void cpp_typecheckt::typecheck_compound_type(
         throw 0;
       }
     }
+    else if(symbol.type.id() != type.id())
+    {
+      error().source_location = type.source_location();
+      error() << "redefinition of '" << symbol.pretty_name << "'"
+              << " as different kind of tag" << eom;
+      throw 0;
+    }
   }
   else
   {


### PR DESCRIPTION
We previously left this to a failing invariant in namespacet::follow_tag
to be reported. Instead, provide a meaningful error message.

Test generated using C-Reduce starting from an SV-COMP task.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
