### PR TITLE
Return value removal: handle missing declarations more gracefully

### DIFF
--- a/regression/cbmc/return7/main.c
+++ b/regression/cbmc/return7/main.c
@@ -1,0 +1,18 @@
+void a()
+{
+  // Uses the implicit signature of undefined functions: int c(void)
+  int b;
+  b = c();
+  __CPROVER_assert(b == 0, "expected to fail");
+}
+void c(void)
+{
+  // Actually... don't return anything
+  // So the results will be non-deterministic
+}
+
+int main(int argc, char **argv)
+{
+  a();
+  return 0;
+}

--- a/regression/cbmc/return7/test.desc
+++ b/regression/cbmc/return7/test.desc
@@ -1,0 +1,9 @@
+CORE
+main.c
+
+^VERIFICATION FAILED$
+^EXIT=10$
+^SIGNAL=0$
+--
+Reason: Check return value
+^warning: ignoring

--- a/src/goto-programs/builtin_functions.cpp
+++ b/src/goto-programs/builtin_functions.cpp
@@ -762,6 +762,16 @@ void goto_convertt::do_function_call_symbol(
     code_function_callt function_call(lhs, function, arguments);
     function_call.add_source_location() = function.source_location();
 
+    // remove void-typed assignments, which may have been created when the
+    // front-end was unable to detect them in type checking for a lack of
+    // available declarations
+    if(
+      lhs.is_not_nil() &&
+      to_code_type(symbol->type).return_type().id() == ID_empty)
+    {
+      function_call.lhs().make_nil();
+    }
+
     copy(function_call, FUNCTION_CALL, dest);
 
     return;
@@ -1434,6 +1444,16 @@ void goto_convertt::do_function_call_symbol(
     // insert function call
     code_function_callt function_call(lhs, function, arguments);
     function_call.add_source_location()=function.source_location();
+
+    // remove void-typed assignments, which may have been created when the
+    // front-end was unable to detect them in type checking for a lack of
+    // available declarations
+    if(
+      lhs.is_not_nil() &&
+      to_code_type(symbol->type).return_type().id() == ID_empty)
+    {
+      function_call.lhs().make_nil();
+    }
 
     copy(function_call, FUNCTION_CALL, dest);
   }

--- a/src/goto-programs/remove_returns.cpp
+++ b/src/goto-programs/remove_returns.cpp
@@ -175,10 +175,10 @@ bool remove_returnst::do_function_calls(
         optionalt<symbol_exprt> return_value;
 
         if(!is_stub)
-        {
           return_value = get_or_create_return_value_symbol(function_id);
-          CHECK_RETURN(return_value.has_value());
 
+        if(return_value.has_value())
+        {
           // The return type in the definition of the function may differ
           // from the return type in the declaration.  We therefore do a
           // cast.
@@ -199,7 +199,7 @@ bool remove_returnst::do_function_calls(
         // fry the previous assignment
         i_it->call_lhs().make_nil();
 
-        if(!is_stub)
+        if(return_value.has_value())
         {
           goto_program.insert_after(
             t_a,


### PR DESCRIPTION
If a function is used before it is defined, a signature of int f(void)
is assumed. Then trying to use the (possibly non-existent) return value
fails during return-statement removal. In such cases, just assume a
non-deterministic value is being returned.

Found by running C-Reduce on a CSmith-generated example.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
