### PR TITLE
dump-c: when removing const-ness, also handle bit fields

### DIFF
--- a/regression/goto-instrument/chain.sh
+++ b/regression/goto-instrument/chain.sh
@@ -38,6 +38,7 @@ elif echo $args | grep -q -- "--dump-c-type-header" ; then
   cat "${name}-mod.gb"
   mv "${name}.gb" "${name}-mod.gb"
 elif echo $args | grep -q -- "--dump-c" ; then
+  cat "${name}-mod.gb"
   mv "${name}-mod.gb" "${name}-mod.c"
 
   if [[ "${is_windows}" == "true" ]]; then

--- a/regression/goto-instrument/dump-decl-const/main.c
+++ b/regression/goto-instrument/dump-decl-const/main.c
@@ -1,0 +1,19 @@
+#include <assert.h>
+
+struct S
+{
+  const int x;
+  const int y : 8;
+  const int *const p;
+};
+
+int foo()
+{
+  return 1;
+}
+
+int main()
+{
+  struct S s1 = {foo(), 1, 0};
+  assert(s1.x == 1);
+}

--- a/regression/goto-instrument/dump-decl-const/test.desc
+++ b/regression/goto-instrument/dump-decl-const/test.desc
@@ -1,0 +1,16 @@
+CORE
+main.c
+--dump-c
+signed int x
+signed int y
+const signed int \*p
+^[[:space:]]*s1 = \(struct S\)\{ .* \};
+^EXIT=0$
+^SIGNAL=0$
+--
+const signed int x
+const signed int y
+const p
+--
+This test demonstrates that the constness of struct members has been removed,
+which is necessary as the initialisation is not performed in the declaration.

--- a/src/goto-instrument/goto_program2code.cpp
+++ b/src/goto-instrument/goto_program2code.cpp
@@ -1591,6 +1591,8 @@ void goto_program2codet::remove_const(typet &type)
         ++it)
       remove_const(it->type());
   }
+  else if(type.id() == ID_c_bit_field)
+    to_c_bit_field_type(type).subtype().remove(ID_C_constant);
 }
 
 static bool has_labels(const codet &code)


### PR DESCRIPTION
We need to remove the const qualifier when the assignment is no longer
performed as part of the declaration. This worked for various types
already, but bit fields had not been considered.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
