### PR TITLE
goto-symex: avoid redundant operations in pop_frame

### DIFF
--- a/src/goto-symex/symex_function_call.cpp
+++ b/src/goto-symex/symex_function_call.cpp
@@ -387,30 +387,17 @@ static void pop_frame(
       state.guard = frame.guard_at_function_start;
     }
 
-    symex_renaming_levelt::viewt view;
-    state.get_level2().current_names.get_view(view);
-
-    std::vector<irep_idt> keys_to_erase;
-
-    for(const auto &pair : view)
+    for(const irep_idt &l1_o_id : frame.local_objects)
     {
-      const irep_idt l1_o_id = pair.second.first.get_l1_object_identifier();
+      const auto l2_entry_opt = state.get_level2().current_names.find(l1_o_id);
 
-      // could use iteration over local_objects as l1_o_id is prefix
       if(
-        frame.local_objects.find(l1_o_id) == frame.local_objects.end() ||
-        (state.threads.size() > 1 &&
-         path_storage.dirty(pair.second.first.get_object_name())))
+        l2_entry_opt.has_value() &&
+        (state.threads.size() == 1 ||
+         !path_storage.dirty(l2_entry_opt->get().first.get_object_name())))
       {
-        continue;
+        state.drop_existing_l1_name(l1_o_id);
       }
-
-      keys_to_erase.push_back(pair.first);
-    }
-
-    for(const irep_idt &key : keys_to_erase)
-    {
-      state.drop_existing_l1_name(key);
     }
   }
 

--- a/src/goto-symex/symex_function_call.cpp
+++ b/src/goto-symex/symex_function_call.cpp
@@ -360,44 +360,42 @@ static void pop_frame(
 {
   PRECONDITION(!state.call_stack().empty());
 
+  const framet &frame = state.call_stack().top();
+
+  // restore program counter
+  symex_transition(state, frame.calling_location.pc, false);
+  state.source.function_id = frame.calling_location.function_id;
+
+  // restore L1 renaming
+  state.level1.restore_from(frame.old_level1);
+
+  // If the program is multi-threaded then the state guard is used to
+  // accumulate assumptions (in symex_assume_l2) and must be left alone.
+  // If however it is single-threaded then we should restore the guard, as the
+  // guard coming out of the function may be more complex (e.g. if the callee
+  // was { if(x) while(true) { } } then the guard may still be `!x`),
+  // but at this point all control-flow paths have either converged or been
+  // proven unviable, so we can stop specifying the callee's constraints when
+  // we generate an assumption or VCC.
+
+  // If we're doing path exploration then we do tail-duplication, and we
+  // actually *are* in a more-restricted context than we were when the
+  // function began.
+  if(state.threads.size() == 1 && !doing_path_exploration)
   {
-    const framet &frame = state.call_stack().top();
+    state.guard = frame.guard_at_function_start;
+  }
 
-    // restore program counter
-    symex_transition(state, frame.calling_location.pc, false);
-    state.source.function_id = frame.calling_location.function_id;
+  for(const irep_idt &l1_o_id : frame.local_objects)
+  {
+    const auto l2_entry_opt = state.get_level2().current_names.find(l1_o_id);
 
-    // restore L1 renaming
-    state.level1.restore_from(frame.old_level1);
-
-    // If the program is multi-threaded then the state guard is used to
-    // accumulate assumptions (in symex_assume_l2) and must be left alone.
-    // If however it is single-threaded then we should restore the guard, as the
-    // guard coming out of the function may be more complex (e.g. if the callee
-    // was { if(x) while(true) { } } then the guard may still be `!x`),
-    // but at this point all control-flow paths have either converged or been
-    // proven unviable, so we can stop specifying the callee's constraints when
-    // we generate an assumption or VCC.
-
-    // If we're doing path exploration then we do tail-duplication, and we
-    // actually *are* in a more-restricted context than we were when the
-    // function began.
-    if(state.threads.size() == 1 && !doing_path_exploration)
+    if(
+      l2_entry_opt.has_value() &&
+      (state.threads.size() == 1 ||
+       !path_storage.dirty(l2_entry_opt->get().first.get_object_name())))
     {
-      state.guard = frame.guard_at_function_start;
-    }
-
-    for(const irep_idt &l1_o_id : frame.local_objects)
-    {
-      const auto l2_entry_opt = state.get_level2().current_names.find(l1_o_id);
-
-      if(
-        l2_entry_opt.has_value() &&
-        (state.threads.size() == 1 ||
-         !path_storage.dirty(l2_entry_opt->get().first.get_object_name())))
-      {
-        state.drop_existing_l1_name(l1_o_id);
-      }
+      state.drop_existing_l1_name(l1_o_id);
     }
   }
 


### PR DESCRIPTION
There is no need to reconstruct the L1 object identifier when it is
already available as the key of a data structure being iterated over.
Also, perform the linear iteration over the smaller of the two
containers that we are computing the intersection of.

On a set of CSmith-generated tests (which 1) hardly require any use of a
SAT solver, and thus runtime is dominated by symex, and 2) contain a lot
of function calls), `perf` reported that 34% of CPU cycles were spent on
ssa_exprt::get_l1_object_identifier and its children. As stated above,
the call to this function in pop_frame is completely unnecessary. With
the changes applied, ssa_exprt::get_l1_object_identifier is below the 1%
mark.

For a different set of benchmarks: on
DeviceDriversLinux64Large-ReachSafety benchmarks, 9.59% of time were
spent on get_l1_object_identifier.

Please review commit-by-commit as the second commit is whitespace-only.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [x] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
