### PR TITLE
C front-end: require numeric types for assign_bit* operations

### DIFF
--- a/regression/ansi-c/invalid_bitop2/main.c
+++ b/regression/ansi-c/invalid_bitop2/main.c
@@ -1,0 +1,11 @@
+struct
+{
+  int x : 2;
+} a;
+unsigned b;
+_Bool c;
+int main()
+{
+  c |= a.x;
+  b |= a;
+}

--- a/regression/ansi-c/invalid_bitop2/test.desc
+++ b/regression/ansi-c/invalid_bitop2/test.desc
@@ -1,0 +1,9 @@
+CORE test-c++-front-end
+main.c
+
+^EXIT=(64|1)$
+^SIGNAL=0$
+assignment 'assign_bitor' not defined for types 'unsigned int' and 'struct( anon-a)?'
+^CONVERSION ERROR$
+--
+Invariant check failed

--- a/regression/ansi-c/invalid_bitop2/test.desc
+++ b/regression/ansi-c/invalid_bitop2/test.desc
@@ -3,7 +3,7 @@ main.c
 
 ^EXIT=(64|1)$
 ^SIGNAL=0$
-assignment 'assign_bitor' not defined for types 'unsigned int' and 'struct( anon-a)?'
+implicit arithmetic conversion not permitted
 ^CONVERSION ERROR$
 --
 Invariant check failed

--- a/regression/ansi-c/struct9/main.c
+++ b/regression/ansi-c/struct9/main.c
@@ -1,0 +1,28 @@
+enum values
+{
+  A = 1,
+  B = 2
+};
+
+struct S
+{
+  enum values v;
+};
+
+void foo()
+{
+  return;
+}
+
+void *bar()
+{
+  return 0;
+}
+
+int main()
+{
+  _Bool b;
+  struct S s = b ? ((struct S){A}) : ((struct S){B});
+
+  b ? foo() : bar();
+}

--- a/regression/ansi-c/struct9/test.desc
+++ b/regression/ansi-c/struct9/test.desc
@@ -1,0 +1,7 @@
+CORE
+main.c
+
+^EXIT=0$
+^SIGNAL=0$
+--
+^CONVERSION ERROR$

--- a/src/ansi-c/c_typecast.cpp
+++ b/src/ansi-c/c_typecast.cpp
@@ -701,6 +701,11 @@ void c_typecastt::implicit_typecast_arithmetic(
     if(type1==type2)
       return;
   }
+  else if(max_type == OTHER)
+  {
+    errors.push_back("implicit arithmetic conversion not permitted");
+    return;
+  }
 
   implicit_typecast_arithmetic(expr1, max_type);
   implicit_typecast_arithmetic(expr2, max_type);

--- a/src/ansi-c/c_typecast.cpp
+++ b/src/ansi-c/c_typecast.cpp
@@ -704,19 +704,6 @@ void c_typecastt::implicit_typecast_arithmetic(
 
   implicit_typecast_arithmetic(expr1, max_type);
   implicit_typecast_arithmetic(expr2, max_type);
-
-  // arithmetic typecasts only, otherwise this can't be used from
-  // typecheck_expr_trinary
-  #if 0
-  if(max_type==PTR)
-  {
-    if(c_type1==VOIDPTR)
-      do_typecast(expr1, expr2.type());
-
-    if(c_type2==VOIDPTR)
-      do_typecast(expr2, expr1.type());
-  }
-  #endif
 }
 
 void c_typecastt::do_typecast(exprt &expr, const typet &dest_type)

--- a/src/ansi-c/c_typecheck_expr.cpp
+++ b/src/ansi-c/c_typecheck_expr.cpp
@@ -1573,7 +1573,14 @@ void c_typecheck_baset::typecheck_expr_trinary(if_exprt &expr)
   const typet o_type2=operands[2].type();
 
   implicit_typecast_bool(operands[0]);
-  implicit_typecast_arithmetic(operands[1], operands[2]);
+
+  if(o_type1.id() == ID_empty || o_type2.id() == ID_empty)
+  {
+    operands[1] = typecast_exprt::conditional_cast(operands[1], void_type());
+    operands[2] = typecast_exprt::conditional_cast(operands[2], void_type());
+    expr.type() = void_type();
+    return;
+  }
 
   if(operands[1].type().id()==ID_pointer &&
      operands[2].type().id()!=ID_pointer)
@@ -1629,6 +1636,13 @@ void c_typecheck_baset::typecheck_expr_trinary(if_exprt &expr)
   {
     expr.type()=void_type();
     return;
+  }
+
+  if(
+    operands[1].type() != operands[2].type() ||
+    operands[1].type().id() == ID_array)
+  {
+    implicit_typecast_arithmetic(operands[1], operands[2]);
   }
 
   if(operands[1].type() == operands[2].type())

--- a/src/ansi-c/c_typecheck_expr.cpp
+++ b/src/ansi-c/c_typecheck_expr.cpp
@@ -3683,12 +3683,13 @@ void c_typecheck_baset::typecheck_side_effect_assignment(
        o_type0.id()==ID_c_bool)
     {
       implicit_typecast_arithmetic(op0, op1);
-      if(op1.type().id()==ID_bool ||
-         op1.type().id()==ID_c_bool ||
-         op1.type().id()==ID_c_enum_tag ||
-         op1.type().id()==ID_unsignedbv ||
-         op1.type().id()==ID_signedbv)
+      if(
+        op1.type().id() == ID_bool || op1.type().id() == ID_c_bool ||
+        op1.type().id() == ID_c_enum_tag || op1.type().id() == ID_unsignedbv ||
+        op1.type().id() == ID_signedbv || op1.type().id() == ID_c_bit_field)
+      {
         return;
+      }
     }
     else if(o_type0.id()==ID_c_enum_tag ||
             o_type0.id()==ID_unsignedbv ||
@@ -3696,7 +3697,12 @@ void c_typecheck_baset::typecheck_side_effect_assignment(
             o_type0.id()==ID_c_bit_field)
     {
       implicit_typecast_arithmetic(op0, op1);
-      return;
+      if(
+        op1.type().id() == ID_c_enum_tag || op1.type().id() == ID_unsignedbv ||
+        op1.type().id() == ID_signedbv || op1.type().id() == ID_c_bit_field)
+      {
+        return;
+      }
     }
     else if(o_type0.id()==ID_vector &&
             o_type1.id()==ID_vector)

--- a/src/ansi-c/c_typecheck_typecast.cpp
+++ b/src/ansi-c/c_typecheck_typecast.cpp
@@ -45,10 +45,43 @@ void c_typecheck_baset::implicit_typecast_arithmetic(
 {
   c_typecastt c_typecast(*this);
   c_typecast.implicit_typecast_arithmetic(expr1, expr2);
+
+  for(const auto &tc_error : c_typecast.errors)
+  {
+    error().source_location = expr1.find_source_location();
+    error() << "in expression '" << to_string(expr1) << "':\n"
+            << "conversion from '" << to_string(expr1.type()) << "' to '"
+            << to_string(expr2.type()) << "': " << tc_error << eom;
+  }
+
+  if(!c_typecast.errors.empty())
+    throw 0; // give up
+
+  for(const auto &tc_warning : c_typecast.warnings)
+  {
+    warning().source_location = expr1.find_source_location();
+    warning() << "conversion from '" << to_string(expr1.type()) << "' to '"
+              << to_string(expr2.type()) << "': " << tc_warning << eom;
+  }
 }
 
 void c_typecheck_baset::implicit_typecast_arithmetic(exprt &expr)
 {
   c_typecastt c_typecast(*this);
   c_typecast.implicit_typecast_arithmetic(expr);
+
+  for(const auto &tc_error : c_typecast.errors)
+  {
+    error().source_location = expr.find_source_location();
+    error() << tc_error << eom;
+  }
+
+  if(!c_typecast.errors.empty())
+    throw 0; // give up
+
+  for(const auto &tc_warning : c_typecast.warnings)
+  {
+    warning().source_location = expr.find_source_location();
+    warning() << tc_warning << eom;
+  }
 }


### PR DESCRIPTION
We already had those checks for bit* operations (without the
assignment), but left the assign_bit* operations to invariants failing
at a much later stage.

Found using C-Reduce on a CSmith-generated test.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
