### PR TITLE
C/C++ front-end: do not accept void-typed objects or members

### DIFF
--- a/regression/ansi-c/invalid_use_of_void1/main.c
+++ b/regression/ansi-c/invalid_use_of_void1/main.c
@@ -1,0 +1,21 @@
+struct a
+{
+#ifdef void_member
+  void b;
+#else
+  int b;
+#endif
+};
+struct a *ae;
+void d()
+{
+  ae->b;
+}
+#ifdef void_global
+void x;
+#endif
+int main()
+{
+  void v;
+  d();
+}

--- a/regression/ansi-c/invalid_use_of_void1/test-global.desc
+++ b/regression/ansi-c/invalid_use_of_void1/test-global.desc
@@ -1,0 +1,9 @@
+CORE test-c++-front-end
+main.c
+-Dvoid_global
+^EXIT=(64|1)$
+^SIGNAL=0$
+void-typed symbol not permitted
+^CONVERSION ERROR$
+--
+Invariant check failed

--- a/regression/ansi-c/invalid_use_of_void1/test-non-member.desc
+++ b/regression/ansi-c/invalid_use_of_void1/test-non-member.desc
@@ -1,0 +1,9 @@
+CORE test-c++-front-end
+main.c
+
+^EXIT=(64|1)$
+^SIGNAL=0$
+void-typed symbol not permitted
+^CONVERSION ERROR$
+--
+Invariant check failed

--- a/regression/ansi-c/invalid_use_of_void1/test.desc
+++ b/regression/ansi-c/invalid_use_of_void1/test.desc
@@ -1,0 +1,9 @@
+CORE test-c++-front-end
+main.c
+-Dvoid_member
+^EXIT=(64|1)$
+^SIGNAL=0$
+void-typed member not permitted
+^CONVERSION ERROR$
+--
+Invariant check failed

--- a/src/ansi-c/c_typecheck_base.cpp
+++ b/src/ansi-c/c_typecheck_base.cpp
@@ -103,6 +103,13 @@ void c_typecheck_baset::typecheck_symbol(symbolt &symbol)
     symbol.pretty_name=new_name;
   }
 
+  if(!symbol.is_type && symbol.type.id() == ID_empty)
+  {
+    error().source_location = symbol.location;
+    error() << "void-typed symbol not permitted" << eom;
+    throw 0;
+  }
+
   // see if we have it already
   symbol_tablet::symbolst::const_iterator old_it=
     symbol_table.symbols.find(symbol.name);

--- a/src/ansi-c/c_typecheck_type.cpp
+++ b/src/ansi-c/c_typecheck_type.cpp
@@ -934,6 +934,13 @@ void c_typecheck_baset::typecheck_compound_body(
           throw 0;
         }
 
+        if(new_component.type().id() == ID_empty)
+        {
+          error().source_location = source_location;
+          error() << "void-typed member not permitted" << eom;
+          throw 0;
+        }
+
         components.push_back(new_component);
       }
     }

--- a/src/cpp/cpp_typecheck_code.cpp
+++ b/src/cpp/cpp_typecheck_code.cpp
@@ -448,6 +448,13 @@ void cpp_typecheckt::typecheck_decl(codet &code)
     if(is_typedef)
       continue;
 
+    if(!symbol.is_type && symbol.type.id() == ID_empty)
+    {
+      error().source_location = symbol.location;
+      error() << "void-typed symbol not permitted" << eom;
+      throw 0;
+    }
+
     code_declt decl_statement(cpp_symbol_expr(symbol));
     decl_statement.add_source_location()=symbol.location;
 

--- a/src/cpp/cpp_typecheck_compound_type.cpp
+++ b/src/cpp/cpp_typecheck_compound_type.cpp
@@ -317,6 +317,13 @@ void cpp_typecheckt::typecheck_compound_declarator(
 
   typecheck_type(final_type);
 
+  if(final_type.id() == ID_empty)
+  {
+    error().source_location = declaration.type().source_location();
+    error() << "void-typed member not permitted" << eom;
+    throw 0;
+  }
+
   cpp_namet cpp_name;
   cpp_name.swap(declarator.name());
 

--- a/src/cpp/cpp_typecheck_declaration.cpp
+++ b/src/cpp/cpp_typecheck_declaration.cpp
@@ -148,6 +148,13 @@ void cpp_typecheckt::convert_non_template_declaration(
       declaration_type, declaration.storage_spec(),
       declaration.member_spec(), declarator);
 
+    if(!symbol.is_type && symbol.type.id() == ID_empty)
+    {
+      error().source_location = symbol.location;
+      error() << "void-typed symbol not permitted" << eom;
+      throw 0;
+    }
+
     // any template instance to remember?
     if(declaration.find(ID_C_template).is_not_nil())
     {


### PR DESCRIPTION
We silently accepted these, as many cases would work fine in goto
programs. The included regression test, however, demonstrates where this
would fail an invariant during Boolean flattening (if run with
--pointer-check). GCC refuses void typed variables, and so should we.

Test originates from an SV-COMP task, reduced to this minimal example
using C-Reduce.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a  Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
