### PR TITLE
_Static_assert failures should be reported in the front-end

### DIFF
--- a/regression/ansi-c/_Static_assert2/global.c
+++ b/regression/ansi-c/_Static_assert2/global.c
@@ -1,0 +1,5 @@
+_Static_assert(1 == 0, "must fail");
+
+int main()
+{
+}

--- a/regression/ansi-c/_Static_assert2/global.desc
+++ b/regression/ansi-c/_Static_assert2/global.desc
@@ -1,0 +1,10 @@
+CORE gcc-only
+global.c
+
+static assertion failed: must fail
+^CONVERSION ERROR$
+^EXIT=(1|64)$
+^SIGNAL=0$
+--
+^warning: ignoring
+Invariant check failed

--- a/regression/ansi-c/_Static_assert2/local.c
+++ b/regression/ansi-c/_Static_assert2/local.c
@@ -1,0 +1,4 @@
+int main()
+{
+  _Static_assert(1 == 0, "must fail");
+}

--- a/regression/ansi-c/_Static_assert2/local.desc
+++ b/regression/ansi-c/_Static_assert2/local.desc
@@ -1,0 +1,10 @@
+CORE gcc-only
+local.c
+
+static assertion failed: must fail
+^CONVERSION ERROR$
+^EXIT=(1|64)$
+^SIGNAL=0$
+--
+^warning: ignoring
+Invariant check failed

--- a/regression/ansi-c/_Static_assert2/not_constant.c
+++ b/regression/ansi-c/_Static_assert2/not_constant.c
@@ -1,0 +1,5 @@
+int main()
+{
+  int x;
+  _Static_assert(x, "must fail");
+}

--- a/regression/ansi-c/_Static_assert2/not_constant.desc
+++ b/regression/ansi-c/_Static_assert2/not_constant.desc
@@ -1,0 +1,10 @@
+CORE gcc-only
+not_constant.c
+
+expected constant expression
+^CONVERSION ERROR$
+^EXIT=(1|64)$
+^SIGNAL=0$
+--
+^warning: ignoring
+Invariant check failed

--- a/regression/cbmc-library/Float_lib1/main.c
+++ b/regression/cbmc-library/Float_lib1/main.c
@@ -43,10 +43,10 @@ int main()
 
   _Static_assert(__builtin_isnormal(DBL_MIN), "__builtin_isnormal is constant");
 
-  _Static_assert(!__builtin_isinf(0), "__builtin_isinf is constant");
+  _Static_assert(!__builtin_isinf(0.0), "__builtin_isinf is constant");
 
   _Static_assert(
-    __builtin_isinf_sign(0) == 0, "__builtin_isinf_sign is constant");
+    __builtin_isinf_sign(0.0) == 0, "__builtin_isinf_sign is constant");
 
 #endif
 

--- a/src/ansi-c/c_typecheck_base.cpp
+++ b/src/ansi-c/c_typecheck_base.cpp
@@ -627,9 +627,10 @@ void c_typecheck_baset::typecheck_declaration(
 {
   if(declaration.get_is_static_assert())
   {
-    auto &static_assert_expr = to_binary_expr(declaration);
-    typecheck_expr(static_assert_expr.op0());
-    typecheck_expr(static_assert_expr.op1());
+    codet code(ID_static_assert);
+    code.add_source_location() = declaration.source_location();
+    code.operands().swap(declaration.operands());
+    typecheck_code(code);
   }
   else
   {

--- a/src/ansi-c/c_typecheck_expr.cpp
+++ b/src/ansi-c/c_typecheck_expr.cpp
@@ -2457,6 +2457,15 @@ exprt c_typecheck_baset::do_special_functions(
 
     typecheck_function_call_arguments(expr);
 
+    const exprt &fp_value = expr.arguments().front();
+
+    if(fp_value.type().id() != ID_floatbv)
+    {
+      error().source_location = fp_value.source_location();
+      error() << "non-floating-point argument for " << identifier << eom;
+      throw 0;
+    }
+
     isinf_exprt isinf_expr(expr.arguments().front());
     isinf_expr.add_source_location()=source_location;
 
@@ -2476,6 +2485,13 @@ exprt c_typecheck_baset::do_special_functions(
     // returns 1 for +inf and -1 for -inf, and 0 otherwise
 
     const exprt &fp_value = expr.arguments().front();
+
+    if(fp_value.type().id() != ID_floatbv)
+    {
+      error().source_location = fp_value.source_location();
+      error() << "non-floating-point argument for " << identifier << eom;
+      throw 0;
+    }
 
     isinf_exprt isinf_expr(fp_value);
     isinf_expr.add_source_location() = source_location;

--- a/src/ansi-c/c_typecheck_type.cpp
+++ b/src/ansi-c/c_typecheck_type.cpp
@@ -1029,6 +1029,13 @@ void c_typecheck_baset::typecheck_compound_body(
   {
     if(it->id()==ID_static_assert)
     {
+      if(config.ansi_c.mode == configt::ansi_ct::flavourt::VISUAL_STUDIO)
+      {
+        error().source_location = it->source_location();
+        error() << "static_assert not supported in compound body" << eom;
+        throw 0;
+      }
+
       exprt &assertion = to_binary_expr(*it).op0();
       typecheck_expr(assertion);
       typecheck_expr(to_binary_expr(*it).op1());

--- a/src/ansi-c/scanner.l
+++ b/src/ansi-c/scanner.l
@@ -852,7 +852,15 @@ or_eq               { return cpp98_keyword(TOK_ORASSIGN); }
 private             { return cpp98_keyword(TOK_PRIVATE); }
 protected           { return cpp98_keyword(TOK_PROTECTED); }
 public              { return cpp98_keyword(TOK_PUBLIC); }
-static_assert       { return cpp11_keyword(TOK_STATIC_ASSERT); } // C++11
+static_assert       { // C++11, but Visual Studio supports it in all modes (and
+                      // doesn't support _Static_assert)
+                      if(PARSER.mode == configt::ansi_ct::flavourt::VISUAL_STUDIO)
+                      {
+                        loc(); return TOK_STATIC_ASSERT;
+                      }
+                      else
+                        return cpp11_keyword(TOK_STATIC_ASSERT);
+                    }
 template            { return cpp98_keyword(TOK_TEMPLATE); }
 this                { return cpp98_keyword(TOK_THIS); }
 thread_local        { return cpp11_keyword(TOK_THREAD_LOCAL); } // C++11

--- a/src/cpp/cpp_typecheck_static_assert.cpp
+++ b/src/cpp/cpp_typecheck_static_assert.cpp
@@ -19,15 +19,10 @@ void cpp_typecheckt::convert(cpp_static_assertt &cpp_static_assert)
   typecheck_expr(cpp_static_assert.op0());
   typecheck_expr(cpp_static_assert.op1());
 
-  cpp_static_assert.op0() =
-    typecast_exprt::conditional_cast(cpp_static_assert.op0(), bool_typet());
+  implicit_typecast_bool(cpp_static_assert.op0());
   make_constant(cpp_static_assert.op0());
 
-  if(cpp_static_assert.op0().is_true())
-  {
-    // ok
-  }
-  else if(cpp_static_assert.op0().is_false())
+  if(cpp_static_assert.op0().is_false())
   {
     // failed
     error().source_location=cpp_static_assert.source_location();
@@ -36,13 +31,6 @@ void cpp_typecheckt::convert(cpp_static_assertt &cpp_static_assert)
       error() << ": "
               << to_string_constant(cpp_static_assert.op1()).get_value();
     error() << eom;
-    throw 0;
-  }
-  else
-  {
-    // not true or false
-    error().source_location=cpp_static_assert.source_location();
-    error() << "static assertion is not constant" << eom;
     throw 0;
   }
 }

--- a/src/util/simplify_expr_floatbv.cpp
+++ b/src/util/simplify_expr_floatbv.cpp
@@ -20,6 +20,8 @@ Author: Daniel Kroening, kroening@kroening.com
 simplify_exprt::resultt<>
 simplify_exprt::simplify_isinf(const unary_exprt &expr)
 {
+  PRECONDITION(expr.op().type().id() == ID_floatbv);
+
   if(expr.op().is_constant())
   {
     ieee_floatt value(to_constant_expr(expr.op()));
@@ -32,6 +34,8 @@ simplify_exprt::simplify_isinf(const unary_exprt &expr)
 simplify_exprt::resultt<>
 simplify_exprt::simplify_isnan(const unary_exprt &expr)
 {
+  PRECONDITION(expr.op().type().id() == ID_floatbv);
+
   if(expr.op().is_constant())
   {
     ieee_floatt value(to_constant_expr(expr.op()));
@@ -44,6 +48,8 @@ simplify_exprt::simplify_isnan(const unary_exprt &expr)
 simplify_exprt::resultt<>
 simplify_exprt::simplify_isnormal(const unary_exprt &expr)
 {
+  PRECONDITION(expr.op().type().id() == ID_floatbv);
+
   if(expr.op().is_constant())
   {
     ieee_floatt value(to_constant_expr(expr.op()));

--- a/src/util/simplify_expr_floatbv.cpp
+++ b/src/util/simplify_expr_floatbv.cpp
@@ -20,9 +20,6 @@ Author: Daniel Kroening, kroening@kroening.com
 simplify_exprt::resultt<>
 simplify_exprt::simplify_isinf(const unary_exprt &expr)
 {
-  if(expr.op().type().id() != ID_floatbv)
-    return unchanged(expr);
-
   if(expr.op().is_constant())
   {
     ieee_floatt value(to_constant_expr(expr.op()));


### PR DESCRIPTION
We left it to a failing invariant in goto-program conversion to detect a
failing (local) _Static_assert. Global _Static_assert statements were
not verified at all.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
