### PR TITLE
GitHub actions: Do not unnecessarily install recommended packages

### DIFF
--- a/.github/workflows/build-and-test-Xen.yaml
+++ b/.github/workflows/build-and-test-Xen.yaml
@@ -17,9 +17,9 @@ jobs:
           # user input
           DEBIAN_FRONTEND: noninteractive
         run: |
-          sudo apt-get install -y coreutils  build-essential gcc git make flex bison software-properties-common libwww-perl python
-          sudo apt-get install -y bin86 gdb bcc liblzma-dev python-dev gettext iasl uuid-dev libncurses5-dev libncursesw5-dev pkg-config
-          sudo apt-get install -y libgtk2.0-dev libyajl-dev sudo time
+          sudo apt-get install --no-install-recommends -y coreutils  build-essential gcc git make flex bison software-properties-common libwww-perl python
+          sudo apt-get install --no-install-recommends -y bin86 gdb bcc liblzma-dev python-dev gettext iasl uuid-dev libncurses5-dev libncursesw5-dev pkg-config
+          sudo apt-get install --no-install-recommends -y libgtk2.0-dev libyajl-dev sudo time
 
       - name: Build CBMC tools
         run: |

--- a/.github/workflows/doxygen-check.yaml
+++ b/.github/workflows/doxygen-check.yaml
@@ -14,6 +14,6 @@ jobs:
         # user input
         DEBIAN_FRONTEND: noninteractive
       run: |
-        sudo apt-get install -yq doxygen graphviz
+        sudo apt-get install --no-install-recommends -yq doxygen graphviz
     - name: Run Doxygen
       run: ./scripts/run_doxygen.sh

--- a/.github/workflows/pull-request-checks.yaml
+++ b/.github/workflows/pull-request-checks.yaml
@@ -16,7 +16,7 @@ jobs:
           # user input
           DEBIAN_FRONTEND: noninteractive
         run: |
-          sudo apt-get install -yq gcc gdb g++ maven jq flex bison libxml2-utils ccache
+          sudo apt-get install --no-install-recommends -yq gcc gdb g++ maven jq flex bison libxml2-utils ccache
           make -C src minisat2-download
       - name: Prepare ccache
         uses: actions/cache@v2
@@ -66,7 +66,7 @@ jobs:
           # user input
           DEBIAN_FRONTEND: noninteractive
         run: |
-          sudo apt-get install -yq cmake ninja-build gcc g++ maven flex bison libxml2-utils dpkg-dev ccache
+          sudo apt-get install --no-install-recommends -yq cmake ninja-build gcc g++ maven flex bison libxml2-utils dpkg-dev ccache
       - name: Prepare ccache
         uses: actions/cache@v2
         with:
@@ -224,7 +224,7 @@ jobs:
           # user input
           DEBIAN_FRONTEND: noninteractive
         run: |
-          sudo apt-get install -yq clang-format-7
+          sudo apt-get install --no-install-recommends -yq clang-format-7
       - name: Check updated lines of code match clang-format-7 style
         env:
           BASE_BRANCH: ${{ github.base_ref }}
@@ -305,7 +305,7 @@ jobs:
         with:
           submodules: recursive
       - name: Fetch dependencies
-        run: sudo apt install g++ flex bison cmake ninja-build maven jq libxml2-utils dpkg-dev ccache
+        run: sudo apt-get install --no-install-recommends -y g++ flex bison cmake ninja-build maven jq libxml2-utils dpkg-dev ccache
       - name: Prepare ccache
         uses: actions/cache@v2
         with:

--- a/.github/workflows/release-packages.yaml
+++ b/.github/workflows/release-packages.yaml
@@ -13,7 +13,7 @@ jobs:
         with:
           submodules: recursive
       - name: Fetch dependencies
-        run: sudo apt install g++ flex bison cmake ninja-build maven jq libxml2-utils dpkg-dev ccache
+        run: sudo apt-get install --no-install-recommends -y g++ flex bison cmake ninja-build maven jq libxml2-utils dpkg-dev ccache
       - name: Prepare ccache
         uses: actions/cache@v2
         with:
@@ -69,7 +69,7 @@ jobs:
         with:
           submodules: recursive
       - name: Fetch dependencies
-        run: sudo apt install g++ flex bison cmake ninja-build maven jq libxml2-utils dpkg-dev ccache
+        run: sudo apt-get install --no-install-recommends -y g++ flex bison cmake ninja-build maven jq libxml2-utils dpkg-dev ccache
       - name: Prepare ccache
         uses: actions/cache@v2
         with:


### PR DESCRIPTION
There is no need to install further packages beyond the ones explicitly
requested (or their dependencies) for our build steps. This fixes the
current build failure of Xen-build GitHub action, but also reduces the
time GitHub actions will take by a few seconds.

See https://github.com/diffblue/cbmc/pull/5677/checks?check_run_id=1583935711 for an example of the current build failures.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
