### PR TITLE
Add justification for GCC polymorphic function naming

### DIFF
--- a/regression/cbmc/atomic_X_fetch-1/main.c
+++ b/regression/cbmc/atomic_X_fetch-1/main.c
@@ -1,6 +1,6 @@
 #include <assert.h>
 
-int main()
+void int_test()
 {
   int *p, v, x, x_before;
   x_before = x;
@@ -9,6 +9,36 @@ int main()
   int result = __atomic_add_fetch(p, v, 0);
   assert(result == x);
   assert(x == x_before + v);
+}
+
+void long_test()
+{
+  long *p, v, x, x_before;
+  x_before = x;
+  p = &x;
+
+  long result = __atomic_add_fetch(p, v, 0);
+  assert(result == x);
+  assert(x == x_before + v);
+}
+
+void mixed_test()
+{
+  int *p, x, x_before;
+  long v;
+  x_before = x;
+  p = &x;
+
+  int result = __atomic_add_fetch(p, v, 0);
+  assert(result == x);
+  assert(x == x_before + (int)v);
+}
+
+int main()
+{
+  int_test();
+  long_test();
+  mixed_test();
 
   return 0;
 }

--- a/src/ansi-c/c_typecheck_expr.cpp
+++ b/src/ansi-c/c_typecheck_expr.cpp
@@ -1893,7 +1893,10 @@ void c_typecheck_baset::typecheck_side_effect_function_call(
         INVARIANT(
           !parameters.empty(),
           "GCC polymorphic built-ins should have at least one parameter");
-        /// XXX why are we only looking at the type of the first parameter?
+
+        // For all atomic/sync polymorphic built-ins (which are the ones handled
+        // by typecheck_gcc_polymorphic_builtin), looking at the first parameter
+        // suffices to distinguish different implementations.
         if(parameters.front().type().id() == ID_pointer)
         {
           identifier_with_type = id2string(identifier) + "_" +


### PR DESCRIPTION
Fixup the previous comment to clarify why the current approach is
adequate. Also expand an existing test to showcase multiple variants of
a polymorphic function being used.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
