### PR TITLE
Enable reading NULL_is_zero from symbol table

### DIFF
--- a/regression/goto-instrument/show-symbol-table-json/test.desc
+++ b/regression/goto-instrument/show-symbol-table-json/test.desc
@@ -4,6 +4,7 @@ test.c
 "symbolTable": \{
 "main": \{
 "main::1::x": \{
+"__CPROVER_architecture_NULL_is_zero": \{
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/src/util/config.cpp
+++ b/src/util/config.cpp
@@ -1259,8 +1259,7 @@ void configt::set_from_symbol_table(
   else
     ansi_c.os=ansi_ct::string_to_os(id2string(string_from_ns(ns, "os")));
 
-  // NULL_is_zero=from_ns("NULL_is_zero");
-  ansi_c.NULL_is_zero=true;
+  ansi_c.NULL_is_zero = unsigned_from_ns(ns, "NULL_is_zero") != 0;
 
   // mode, preprocessor (and all preprocessor command line options),
   // lib, string_abstraction not stored in namespace


### PR DESCRIPTION
This was left commented out ever since introducing it in 5952f6aeb7c,
which is reasonable for it required bumping the goto-program version. We
have incremented the version since 2014, and thus it is safe to enable
this now.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
