### PR TITLE
goto_symext::apply_goto_condition must honour --no-propagation

### DIFF
--- a/regression/cbmc/no-propagation/main.c
+++ b/regression/cbmc/no-propagation/main.c
@@ -1,0 +1,6 @@
+int main()
+{
+  int x;
+  if(x == 1)
+    __CPROVER_assert(x == 1, "");
+}

--- a/regression/cbmc/no-propagation/test.desc
+++ b/regression/cbmc/no-propagation/test.desc
@@ -1,0 +1,9 @@
+CORE
+main.c
+--no-propagation
+Generated 1 VCC\(s\), 1 remaining after simplification
+^VERIFICATION SUCCESSFUL$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring

--- a/src/goto-symex/symex_goto.cpp
+++ b/src/goto-symex/symex_goto.cpp
@@ -53,6 +53,9 @@ void goto_symext::apply_goto_condition(
     &jump_not_taken_state.value_set,
     ns);
 
+  if(!symex_config.constant_propagation)
+    return;
+
   jump_taken_state.apply_condition(new_guard, current_state, ns);
 
   // Could use not_exprt + simplify, but let's avoid paying that cost on quite


### PR DESCRIPTION
goto_symext::apply_goto_condition unconditionally wrote to the
propagation map (via goto_statet::apply_condition). Although
--no-propagation might not be really useful in practice, but is used for
testing (including some of our existing regression tests) or debugging.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
