### PR TITLE
Concurrency: ensure apply_condition's value is used

### DIFF
--- a/regression/cbmc-concurrency/atomic_section_sc7/main.c
+++ b/regression/cbmc-concurrency/atomic_section_sc7/main.c
@@ -1,0 +1,67 @@
+#include <assert.h>
+
+int start_main = 0;
+int mStartLock = 0;
+int __COUNT__ = 0;
+
+void __VERIFIER_atomic_acquire()
+{
+  __CPROVER_assume(mStartLock == 0);
+  mStartLock = 1;
+}
+
+void __VERIFIER_atomic_release()
+{
+  __CPROVER_assume(mStartLock == 1);
+  mStartLock = 0;
+}
+
+void __VERIFIER_atomic_thr1()
+{
+  if(__COUNT__ == 0)
+  {
+    __COUNT__ = __COUNT__ + 1;
+  }
+  else
+  {
+    assert(0);
+  }
+}
+
+void thr1()
+{
+  __VERIFIER_atomic_acquire();
+  start_main = 1;
+  __VERIFIER_atomic_thr1();
+  __VERIFIER_atomic_release();
+}
+
+void __VERIFIER_atomic_thr2()
+{
+  if(__COUNT__ == 1)
+  {
+    __COUNT__ = __COUNT__ + 1;
+  }
+  else
+  {
+    assert(0);
+  }
+}
+
+void thr2()
+{
+  __CPROVER_assume(start_main != 0);
+  __VERIFIER_atomic_acquire();
+  __VERIFIER_atomic_release();
+  __VERIFIER_atomic_thr2();
+}
+
+int main()
+{
+__CPROVER_ASYNC_1:
+  thr1();
+
+  thr2();
+
+  return 0;
+}

--- a/regression/cbmc-concurrency/atomic_section_sc7/test-guard.desc
+++ b/regression/cbmc-concurrency/atomic_section_sc7/test-guard.desc
@@ -1,0 +1,12 @@
+KNOWNBUG
+main.c
+--program-only
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+__COUNT__#\d+ == (1 \+ __COUNT__#\d+|__COUNT__#\d+ \+ 1)
+--
+__COUNT__ is guaranteed to have been read within the atomic section, there
+should not be a need to produce a conditional assignment, and therefore the
+value of __COUNT__ can be constant propagated.

--- a/regression/cbmc-concurrency/atomic_section_sc7/test.desc
+++ b/regression/cbmc-concurrency/atomic_section_sc7/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+
+^VERIFICATION SUCCESSFUL$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring


### PR DESCRIPTION
goto_statet::apply_condition generates an entry (with fresh L2 index) in
the propagation map with generating an assignment. We did not previously
use the propagation map when handling atomic sections, and thus had a
missing link between values, causing spurious verification failures.

The regression test is based on SV-COMP's
pthread-ext/23_lu-fig2.fixed.c.

There is further room for improvement, as shown in the
KNOWNBUG-regression test. This will be addressed in a separate commit.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
