### PR TITLE
Handle MSVC's __noop in type checker

### DIFF
--- a/regression/ansi-c/noop1/main.c
+++ b/regression/ansi-c/noop1/main.c
@@ -1,0 +1,15 @@
+// this is permitted - __noop yields a compile-time constant 0
+int array[__noop() + 1];
+
+struct S
+{
+  int x;
+};
+
+int main(int argc, char *argv)
+{
+  struct S s;
+  // the arguments to __noop are type checked, and thus the following is not
+  // permitted
+  __noop((char *)s);
+}

--- a/regression/ansi-c/noop1/test.desc
+++ b/regression/ansi-c/noop1/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+--i386-win32
+type cast from 'struct S' not permitted
+^EXIT=(1|64)$
+^SIGNAL=0$
+--
+^warning: ignoring

--- a/regression/cbmc-library/__noop-01/main.c
+++ b/regression/cbmc-library/__noop-01/main.c
@@ -1,9 +1,0 @@
-#include <assert.h>
-#include <noop.h>
-
-int main()
-{
-  __noop();
-  assert(0);
-  return 0;
-}

--- a/regression/cbmc/noop1/main.c
+++ b/regression/cbmc/noop1/main.c
@@ -1,9 +1,7 @@
-#include <assert.h>
-
 int some_function()
 {
   // this will not be executed
-  assert(0);
+  __CPROVER_assert(0, "not executed");
 }
 
 int main()

--- a/regression/cbmc/noop1/test.desc
+++ b/regression/cbmc/noop1/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
-
+-winx64
 ^EXIT=0$
 ^SIGNAL=0$
 ^VERIFICATION SUCCESSFUL$

--- a/regression/cbmc/noop2/main.c
+++ b/regression/cbmc/noop2/main.c
@@ -1,0 +1,6 @@
+int main(int argc, char *argv)
+{
+  int x = 0;
+  __noop(++x);
+  __CPROVER_assert(x == 0, "__noop ignores side effects");
+}

--- a/regression/cbmc/noop2/test.desc
+++ b/regression/cbmc/noop2/test.desc
@@ -1,6 +1,6 @@
-KNOWNBUG
+CORE
 main.c
---pointer-check --bounds-check
+-win32
 ^EXIT=0$
 ^SIGNAL=0$
 ^VERIFICATION SUCCESSFUL$

--- a/src/ansi-c/ansi_c_internal_additions.cpp
+++ b/src/ansi-c/ansi_c_internal_additions.cpp
@@ -295,8 +295,7 @@ void ansi_c_internal_additions(std::string &code)
 
   // this is Visual C/C++ only
   if(config.ansi_c.os==configt::ansi_ct::ost::OS_WIN)
-    code+="int __noop();\n"
-          "int __assume(int);\n";
+    code += "int __assume(int);\n";
 
   // ARM stuff
   if(config.ansi_c.mode==configt::ansi_ct::flavourt::ARM)

--- a/src/ansi-c/c_typecheck_expr.cpp
+++ b/src/ansi-c/c_typecheck_expr.cpp
@@ -1885,6 +1885,20 @@ void c_typecheck_baset::typecheck_side_effect_function_call(
         // yes, it's a builtin
       }
       else if(
+        identifier == "__noop" &&
+        config.ansi_c.mode == configt::ansi_ct::flavourt::VISUAL_STUDIO)
+      {
+        // https://docs.microsoft.com/en-us/cpp/intrinsics/noop
+        // typecheck and discard, just generating 0 instead
+        for(auto &op : expr.arguments())
+          typecheck_expr(op);
+
+        exprt result = from_integer(0, signed_int_type());
+        expr.swap(result);
+
+        return;
+      }
+      else if(
         auto gcc_polymorphic = typecheck_gcc_polymorphic_builtin(
           identifier, expr.arguments(), f_op.source_location()))
       {

--- a/src/ansi-c/library/noop.c
+++ b/src/ansi-c/library/noop.c
@@ -1,7 +1,0 @@
-/* FUNCTION: __noop */
-
-int __noop()
-{
-  // does nothing
-  return 0;
-}

--- a/src/ansi-c/library_check.sh
+++ b/src/ansi-c/library_check.sh
@@ -10,7 +10,6 @@ for f in "$@"; do
     perl -p -i -e 's/(_mm_.fence)/s$1/' __libcheck.c
     perl -p -i -e 's/(__sync_)/s$1/' __libcheck.c
     perl -p -i -e 's/(__atomic_)/s$1/' __libcheck.c
-    perl -p -i -e 's/(__noop)/s$1/' __libcheck.c
     "$CC" -std=gnu99 -E -include library/cprover.h -D__CPROVER_bool=_Bool -D__CPROVER_thread_local=__thread -DLIBRARY_CHECK -o __libcheck.i __libcheck.c
     "$CC" -S -Wall -Werror -pedantic -Wextra -std=gnu99 __libcheck.i \
       -o __libcheck.s -Wno-unused-label -Wno-unknown-pragmas

--- a/src/ansi-c/windows_builtin_headers.h
+++ b/src/ansi-c/windows_builtin_headers.h
@@ -1,2 +1,1 @@
-int __noop();
 int __assume(int);

--- a/src/goto-programs/goto_clean_expr.cpp
+++ b/src/goto-programs/goto_clean_expr.cpp
@@ -387,18 +387,6 @@ void goto_convertt::clean_expr(
         return;
       }
     }
-    else if(statement==ID_function_call)
-    {
-      if(to_side_effect_expr_function_call(expr).function().id()==ID_symbol &&
-         to_symbol_expr(
-           to_side_effect_expr_function_call(expr).
-           function()).get_identifier()=="__noop")
-      {
-        // __noop needs special treatment, as arguments are not
-        // evaluated
-        to_side_effect_expr_function_call(expr).arguments().clear();
-      }
-    }
   }
   else if(expr.id()==ID_forall || expr.id()==ID_exists)
   {

--- a/src/goto-programs/goto_convert_function_call.cpp
+++ b/src/goto-programs/goto_convert_function_call.cpp
@@ -53,13 +53,6 @@ void goto_convertt::do_function_call(
 
   clean_expr(new_function, dest, mode);
 
-  // the arguments of __noop do not get evaluated
-  if(new_function.id()==ID_symbol &&
-     to_symbol_expr(new_function).get_identifier()=="__noop")
-  {
-    new_arguments.clear();
-  }
-
   Forall_expr(it, new_arguments)
     clean_expr(*it, dest, mode);
 


### PR DESCRIPTION
The documentation states that it does not generate any code other than
`0`. Hence, don't maintain a library function, but instead discard the
expression in the type checker.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
