### PR TITLE
C front-end: initializer lists do not initialise anonymous members

### DIFF
--- a/regression/ansi-c/Empty_Declaration1/main.c
+++ b/regression/ansi-c/Empty_Declaration1/main.c
@@ -1,10 +1,12 @@
 int blah(void);
 ; // empty!
 
+#ifndef _MSC_VER
 struct some
 {
   ; // empty
 };
+#endif
 
 int main() {
 }

--- a/regression/ansi-c/Union_Initialization2/test.desc
+++ b/regression/ansi-c/Union_Initialization2/test.desc
@@ -1,7 +1,7 @@
 CORE
 main.c
 
-union member designator found for empty union
+(union member designator found for empty union|C requires that a struct or union has at least one member)
 ^SIGNAL=0$
 ^EXIT=(1|64)$
 --

--- a/regression/ansi-c/_Generic1/main.c
+++ b/regression/ansi-c/_Generic1/main.c
@@ -13,6 +13,7 @@
                 struct some: 5 \
              )
 
+#ifdef __GNUC__
 struct some
 {
 } s;
@@ -22,7 +23,6 @@ char ch;
 long double ld;
 short sh;
 
-#ifdef __GNUC__
 STATIC_ASSERT(G(i)==3);
 STATIC_ASSERT(G(sh)==10);
 STATIC_ASSERT(G(ld)==1);

--- a/regression/ansi-c/anonymous_member1/main.c
+++ b/regression/ansi-c/anonymous_member1/main.c
@@ -1,14 +1,38 @@
+#ifdef _MSC_VER
+// No _Static_assert in Visual Studio
+#  define _Static_assert(condition, message) static_assert(condition, message)
+#endif
+
 struct S
 {
   struct
   {
     int : 1;
+#ifndef _MSC_VER
     int;
+#endif
     int named;
   };
 };
 
+_Static_assert(sizeof(struct S) == sizeof(int) * 2, "ignore int;");
+
 struct S s = {.named = 0};
+
+struct S1
+{
+  struct S2
+  {
+    int : 1;
+    int named;
+  };
+};
+
+#ifdef _MSC_VER
+_Static_assert(sizeof(struct S1) == sizeof(int) * 2, "");
+#else
+_Static_assert(sizeof(struct S1) == 0, "");
+#endif
 
 int main()
 {

--- a/regression/ansi-c/anonymous_member2/main.c
+++ b/regression/ansi-c/anonymous_member2/main.c
@@ -1,0 +1,29 @@
+#define static_assert(x)                                                       \
+  struct                                                                       \
+  {                                                                            \
+    char some[(x) ? 1 : -1];                                                   \
+  }
+
+struct a
+{
+};
+struct c
+{
+  struct a;
+  void *d;
+} e =
+  {
+#ifdef not_permitted
+    {},
+#endif
+    0},
+  e2;
+struct
+{
+  struct c f;
+} * g;
+int main()
+{
+  g->f;
+  static_assert(sizeof(e) == sizeof(void *));
+}

--- a/regression/ansi-c/anonymous_member2/not_permitted.desc
+++ b/regression/ansi-c/anonymous_member2/not_permitted.desc
@@ -1,0 +1,9 @@
+CORE gcc-only
+main.c
+-Dnot_permitted
+cannot initialize 'void \*' with an initializer list
+^CONVERSION ERROR$
+^EXIT=(1|64)$
+^SIGNAL=0$
+--
+^warning: ignoring

--- a/regression/ansi-c/anonymous_member2/test.desc
+++ b/regression/ansi-c/anonymous_member2/test.desc
@@ -1,8 +1,8 @@
 CORE gcc-only
 main.c
---json-ui
-VERIFICATION FAILED
-^EXIT=10$
+
+^EXIT=0$
 ^SIGNAL=0$
 --
 ^warning: ignoring
+^CONVERSION ERROR$

--- a/regression/ansi-c/anonymous_member3/main.c
+++ b/regression/ansi-c/anonymous_member3/main.c
@@ -1,0 +1,21 @@
+typedef void(keyhandler_fn_t)(void);
+typedef void(irq_keyhandler_fn_t)(int);
+
+void foo()
+{
+}
+
+struct keyhandler
+{
+  union
+  {
+    keyhandler_fn_t *fn;
+    irq_keyhandler_fn_t *irq_fn;
+  };
+  const char *desc;
+  _Bool x, y;
+} key_table[3] = {[0] = {{(keyhandler_fn_t *)(foo)}, "text", 1, 0}};
+
+int main()
+{
+}

--- a/regression/ansi-c/anonymous_member3/test.desc
+++ b/regression/ansi-c/anonymous_member3/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---i386-win32
+
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/ansi-c/sizeof3/main.c
+++ b/regression/ansi-c/sizeof3/main.c
@@ -4,6 +4,7 @@
 #define STATIC_ASSERT(condition)                                               \
   int CONCAT2(some_array, __LINE__)[(condition) ? 1 : -1]
 
+#ifndef _MSC_VER
 struct empty_struct { };
 union empty_union { };
 
@@ -16,6 +17,7 @@ struct combination {
 STATIC_ASSERT(sizeof(struct empty_struct)==0);
 STATIC_ASSERT(sizeof(union empty_union)==0);
 STATIC_ASSERT(sizeof(struct combination)==sizeof(int));
+#endif
 
 int main()
 {

--- a/regression/cbmc-concurrency/invalid_object1/main.c
+++ b/regression/cbmc-concurrency/invalid_object1/main.c
@@ -134,6 +134,7 @@ struct OpenEthState
 
 struct device
 {
+  int dummy;
 };
 
 struct napi_struct

--- a/regression/cbmc-library/CMakeLists.txt
+++ b/regression/cbmc-library/CMakeLists.txt
@@ -6,7 +6,7 @@ else()
 add_test_pl_profile(
     "cbmc-library"
     "$<TARGET_FILE:cbmc>"
-    "-C;-X;unix"
+    "-C;-X;unix;-X;gcc-only"
     "CORE"
 )
 endif()

--- a/regression/cbmc-library/Makefile
+++ b/regression/cbmc-library/Makefile
@@ -5,13 +5,14 @@ include ../../src/common
 
 ifeq ($(BUILD_ENV_),MSVC)
 	unix_only = -X unix
+	gcc_only = -X gcc-only
 endif
 
 test:
-	@../test.pl -e -p -c ../../../src/cbmc/cbmc $(unix_only)
+	@../test.pl -e -p -c ../../../src/cbmc/cbmc $(unix_only) $(gcc_only)
 
 tests.log: ../test.pl
-	@../test.pl -e -p -c ../../../src/cbmc/cbmc $(unix_only)
+	@../test.pl -e -p -c ../../../src/cbmc/cbmc $(unix_only) $(gcc_only)
 
 clean:
 	find . -name '*.out' -execdir $(RM) '{}' \;

--- a/regression/cbmc-library/memcpy-06/test.desc
+++ b/regression/cbmc-library/memcpy-06/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE gcc-only
 main.c
 
 function 'memcpy' is not declared
@@ -8,3 +8,6 @@ parameter "memcpy::dst" type mismatch
 --
 ^warning: ignoring
 Invariant check failed
+--
+This test requires support for empty structs, which aren't supported by Visual
+Studio.

--- a/regression/cbmc-library/memcpy-09/test.desc
+++ b/regression/cbmc-library/memcpy-09/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE gcc-only
 main.c
 
 ^VERIFICATION SUCCESSFUL$

--- a/regression/cbmc/Anonymous_Struct2/main.c
+++ b/regression/cbmc/Anonymous_Struct2/main.c
@@ -1,6 +1,9 @@
 // The member without name is a Visual Studio feature
 // https://msdn.microsoft.com/en-us/library/z2cx9y4f.aspx
 
+#ifdef _MSC_VER
+#  include <assert.h>
+
 struct X
 {
   struct
@@ -47,3 +50,8 @@ int main()
   assert(s2.y==1);
   assert(s2.z==1);
 }
+#else
+int main()
+{
+}
+#endif

--- a/regression/cbmc/Anonymous_Struct3/main.c
+++ b/regression/cbmc/Anonymous_Struct3/main.c
@@ -1,5 +1,3 @@
-#include <assert.h>
-
 // The member without name is a Visual Studio feature
 // https://msdn.microsoft.com/en-us/library/z2cx9y4f.aspx
 typedef union my_U {
@@ -19,7 +17,7 @@ int main()
   x.f1 = 1;
 
   if(*(char *)&word==1)
-    assert(x.raw==2); // little endian
+    __CPROVER_assert(x.raw == 2, "little endian");
   else
-    assert(x.raw==64); // big endian
+    __CPROVER_assert(x.raw == 64, "big endian");
 }

--- a/regression/cbmc/Anonymous_Struct3/test.desc
+++ b/regression/cbmc/Anonymous_Struct3/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
-
+-win32
 ^EXIT=0$
 ^SIGNAL=0$
 ^VERIFICATION SUCCESSFUL$

--- a/regression/cbmc/Empty_struct1/test.desc
+++ b/regression/cbmc/Empty_struct1/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE gcc-only
 main.c
 
 ^EXIT=0$

--- a/regression/cbmc/Empty_struct2/test.desc
+++ b/regression/cbmc/Empty_struct2/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE gcc-only
 main.c
 
 ^EXIT=0$

--- a/regression/cbmc/Malloc10/main.c
+++ b/regression/cbmc/Malloc10/main.c
@@ -1,3 +1,4 @@
+#include <assert.h>
 #include <stdlib.h>
 
 void __blast_assert()
@@ -7,6 +8,7 @@ void __blast_assert()
 
 struct list_head
 {
+  int dummy;
 };
 
 struct list_head *elem = (struct list_head *)((void *)0);

--- a/regression/cbmc/Union_Initialization2/test.desc
+++ b/regression/cbmc/Union_Initialization2/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE gcc-only
 main.c
 
 ^EXIT=10$

--- a/regression/cbmc/atomic_section_seq1/main.c
+++ b/regression/cbmc/atomic_section_seq1/main.c
@@ -200,6 +200,7 @@ struct OpenEthState$link4
 
 struct device
 {
+  int dummy;
 };
 
 struct napi_struct

--- a/regression/cbmc/atomic_section_seq1/test.desc
+++ b/regression/cbmc/atomic_section_seq1/test.desc
@@ -1,4 +1,4 @@
-CORE broken-smt-backend
+CORE
 main.c
 
 ^EXIT=10$
@@ -6,6 +6,3 @@ main.c
 ^VERIFICATION FAILED$
 --
 ^warning: ignoring
---
-This test involves empty structs, which the SMT2 back-end does not currently
-support.

--- a/regression/cbmc/empty_compound_type1/test.desc
+++ b/regression/cbmc/empty_compound_type1/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE gcc-only
 main.c
 
 ^EXIT=0$

--- a/regression/cbmc/empty_compound_type2/test.desc
+++ b/regression/cbmc/empty_compound_type2/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE gcc-only
 main.c
 --pointer-check
 ^EXIT=10$

--- a/regression/cbmc/empty_compound_type3/test.desc
+++ b/regression/cbmc/empty_compound_type3/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE gcc-only
 main.c
 
 ^EXIT=10$

--- a/regression/cbmc/empty_compound_type4/test.desc
+++ b/regression/cbmc/empty_compound_type4/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE gcc-only
 main.c
 --trace
 ^VERIFICATION FAILED$

--- a/regression/cbmc/struct1/test.desc
+++ b/regression/cbmc/struct1/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE gcc-only
 main.c
 
 ^EXIT=0$

--- a/regression/cbmc/union/union_member.c
+++ b/regression/cbmc/union/union_member.c
@@ -2,7 +2,7 @@
 
 struct s
 {
-  union U
+  union
   {
     char b[2];
   };

--- a/regression/goto-cc-goto-analyzer/instrument_preconditions_locations/s2n_hash_inlined.c
+++ b/regression/goto-cc-goto-analyzer/instrument_preconditions_locations/s2n_hash_inlined.c
@@ -17,6 +17,7 @@ struct s2n_evp_digest
   const void *ctx;
 };
 union s2n_hash_low_level_digest {
+  void *dummy; // for MSVC compatibility
 };
 struct s2n_hash_evp_digest
 {

--- a/src/ansi-c/c_typecheck_initializer.cpp
+++ b/src/ansi-c/c_typecheck_initializer.cpp
@@ -276,7 +276,9 @@ void c_typecheck_baset::designator_enter(
       DATA_INVARIANT(
         c.type().id() != ID_code, "struct member must not be of code type");
 
-      if(!c.get_is_padding())
+      if(
+        !c.get_is_padding() &&
+        (c.type().id() != ID_c_bit_field || !c.get_anonymous()))
       {
         entry.subtype = c.type();
         break;
@@ -738,13 +740,12 @@ void c_typecheck_baset::increment_designator(designatort &designator)
         struct_type.components();
       assert(components.size()==entry.size);
 
-      // we skip over any padding or code
-      // we also skip over anonymous members
+      // we skip over any padding
+      // we also skip over anonymous members that are bit fields
       while(entry.index < entry.size &&
             (components[entry.index].get_is_padding() ||
              (components[entry.index].get_anonymous() &&
-              components[entry.index].type().id() != ID_struct_tag &&
-              components[entry.index].type().id() != ID_union_tag)))
+              components[entry.index].type().id() == ID_c_bit_field)))
       {
         entry.index++;
       }
@@ -843,8 +844,9 @@ designatort c_typecheck_baset::make_designator(
       }
       else
       {
-        // We will search for anonymous members,
-        // in a loop. This isn't supported by gcc, but icc does allow it.
+        // We will search for anonymous members, in a loop. This isn't supported
+        // by GCC (unless the anonymous member is within an unnamed union or
+        // struct), but Visual Studio does allow it.
 
         bool found=false, repeat;
         typet tmp_type=entry.type;
@@ -870,6 +872,9 @@ designatort c_typecheck_baset::make_designator(
               c.get_anonymous() &&
               (c.type().id() == ID_struct_tag ||
                c.type().id() == ID_union_tag) &&
+              (config.ansi_c.mode ==
+                 configt::ansi_ct::flavourt::VISUAL_STUDIO ||
+               follow(c.type()).find(ID_tag).is_nil()) &&
               has_component_rec(c.type(), component_name, *this))
             {
               entry.index=number;

--- a/src/goto-instrument/dump_c.cpp
+++ b/src/goto-instrument/dump_c.cpp
@@ -326,10 +326,13 @@ void dump_ct::operator()(std::ostream &os)
 
     if(
       symbol.is_type &&
-      (symbol.type.id() == ID_struct || symbol.type.id() == ID_union))
+      (symbol.type.id() == ID_struct || symbol.type.id() == ID_union) &&
+      !to_struct_union_type(symbol.type).is_incomplete())
+    {
       convert_compound_declaration(
           symbol,
           compound_body_stream);
+    }
   }
 
   // Dump the code to the target stream;


### PR DESCRIPTION
We already took care of this in another place in
c_typecheck_initializer, but did not handle initializer lists correctly.

The test is based on a case found by C-Reduce when starting from an
SV-COMP task.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
