### PR TITLE
Simplification of pointer comparison: do not assume numeric types

### DIFF
--- a/regression/cbmc-library/memcpy-06/main.c
+++ b/regression/cbmc-library/memcpy-06/main.c
@@ -1,0 +1,16 @@
+// #include <string.h> is intentionally missing
+
+struct c
+{
+};
+
+int d()
+{
+  struct c e;
+  memcpy(e);
+}
+int main()
+{
+  int (*h)() = d;
+  h();
+}

--- a/regression/cbmc-library/memcpy-06/test.desc
+++ b/regression/cbmc-library/memcpy-06/test.desc
@@ -1,0 +1,10 @@
+CORE
+main.c
+
+function 'memcpy' is not declared
+parameter "memcpy::dst" type mismatch
+^EXIT=6$
+^SIGNAL=0$
+--
+^warning: ignoring
+Invariant check failed

--- a/src/util/simplify_expr_int.cpp
+++ b/src/util/simplify_expr_int.cpp
@@ -1645,14 +1645,19 @@ simplify_exprt::resultt<> simplify_exprt::simplify_inequality_rhs_is_constant(
         }
       }
       else if(
-        expr.op0().id() == ID_typecast &&
-        expr.op0().type().id() == ID_pointer &&
-        (to_typecast_expr(expr.op0()).op().type().id() == ID_pointer ||
-         config.ansi_c.NULL_is_zero))
+        expr.op0().id() == ID_typecast && expr.op0().type().id() == ID_pointer)
       {
+        exprt op = to_typecast_expr(expr.op0()).op();
+        if(
+          op.type().id() != ID_pointer &&
+          (!config.ansi_c.NULL_is_zero || !is_number(op.type()) ||
+           op.type().id() == ID_complex))
+        {
+          return unchanged(expr);
+        }
+
         // (type)ptr == NULL -> ptr == NULL
         // note that 'ptr' may be an integer
-        exprt op = to_typecast_expr(expr.op0()).op();
         auto new_expr = expr;
         new_expr.op0().swap(op);
         if(new_expr.op0().type().id() != ID_pointer)


### PR DESCRIPTION
As we cannot (or chose not to) catch all type inconsistencies in the
language front-end, we may pass expressions to simplification that do
not adhere to typing expectations. The included example is such a case,
where the missing declaration of `memcpy` makes the struct-to-pointer
cast get all the way to the middle end.

Test is based on a sample generated by C-Reduce when starting from an
SV-COMP task.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
