### PR TITLE
process_array_expr must not generate arrays of negative size

### DIFF
--- a/regression/cbmc-library/memcpy-07/main.c
+++ b/regression/cbmc-library/memcpy-07/main.c
@@ -1,0 +1,29 @@
+// #include <string.h> intentionally omitted
+
+struct c
+{
+  int d;
+};
+
+struct e
+{
+  struct c *f;
+};
+
+struct g
+{
+  const char *b;
+};
+
+int main()
+{
+  unsigned long nondet;
+
+  struct g *r = (struct g *)nondet;
+  r->b = "";
+
+  struct e *x = (struct e *)nondet;
+  int *d = &x->f->d;
+
+  memcpy(d + 2, 0, 0);
+}

--- a/regression/cbmc-library/memcpy-07/test.desc
+++ b/regression/cbmc-library/memcpy-07/test.desc
@@ -1,0 +1,13 @@
+CORE
+main.c
+
+^EXIT=10$
+^SIGNAL=0$
+^VERIFICATION FAILED$
+--
+^warning: ignoring
+Invariant check failed
+--
+memcpy invocations must not result in generating arrays of negative size, which
+process_array_expr previously generated when trying to access a string literal
+out of bounds.

--- a/src/goto-symex/symex_clean_expr.cpp
+++ b/src/goto-symex/symex_clean_expr.cpp
@@ -113,7 +113,12 @@ process_array_expr(exprt &expr, bool do_simplify, const namespacet &ns)
       exprt subtype_size = typecast_exprt::conditional_cast(
         subtype_size_opt.value(), array_size_type);
       new_offset = div_exprt(new_offset, subtype_size);
-      minus_exprt new_size(prev_array_type.size(), new_offset);
+      minus_exprt subtraction{prev_array_type.size(), new_offset};
+      if_exprt new_size{
+        binary_predicate_exprt{
+          subtraction, ID_ge, from_integer(0, subtraction.type())},
+        subtraction,
+        from_integer(0, subtraction.type())};
       if(do_simplify)
         simplify(new_size, ns);
 

--- a/src/util/simplify_expr.cpp
+++ b/src/util/simplify_expr.cpp
@@ -1886,6 +1886,8 @@ simplify_exprt::simplify_byte_extract(const byte_extract_exprt &expr)
   }
 
   const auto el_size = pointer_offset_bits(expr.type(), ns);
+  if(el_size.has_value() && *el_size < 0)
+    return unchanged(expr);
 
   // byte_extract(byte_extract(root, offset1), offset2) =>
   // byte_extract(root, offset1+offset2)


### PR DESCRIPTION
process_array_expr performed an unconditional subtraction to compute the
array size of a newly formed type. As the regression test showed, this
could result in arrays of negative size being built. (At least)
simplify_byte_extract would fail in such cases, as it tested for the
size being non-zero, assuming that negative values were impossible.

Test is a further simplification of code generated using C-Reduce when
starting from SV-COMP's linux-4.0-rc1---drivers--scsi--pmcraid.ko.cil.i.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
