### PR TITLE
Offset computation can handle zero-sized objects

### DIFF
--- a/regression/cbmc/empty_compound_type2/main.c
+++ b/regression/cbmc/empty_compound_type2/main.c
@@ -1,0 +1,15 @@
+struct B
+{
+} b[1];
+struct c
+{
+  void *d;
+} e = {b};
+struct
+{
+  struct c f;
+} * g;
+int main()
+{
+  g->f;
+}

--- a/regression/cbmc/empty_compound_type2/test.desc
+++ b/regression/cbmc/empty_compound_type2/test.desc
@@ -1,0 +1,13 @@
+CORE broken-smt-backend
+main.c
+--pointer-check
+^EXIT=10$
+^SIGNAL=0$
+^VERIFICATION FAILED$
+--
+^warning: ignoring
+Invariant check failed
+--
+Taking the address of an empty struct resulted in an invariant failure in
+address-of flattening. This test was generated using C-Reduce plus some further
+manual simplification.

--- a/regression/cbmc/empty_compound_type3/main.c
+++ b/regression/cbmc/empty_compound_type3/main.c
@@ -1,0 +1,13 @@
+#include <string.h>
+
+struct a
+{
+} b()
+{
+  struct a *c;
+  memcpy(c + 2, c, 1);
+}
+int main()
+{
+  b();
+}

--- a/src/solvers/flattening/boolbv_get.cpp
+++ b/src/solvers/flattening/boolbv_get.cpp
@@ -126,6 +126,10 @@ exprt boolbvt::bv_get_rec(
         dest.operands().swap(op);
         return dest;
       }
+      else
+      {
+        return array_exprt{{}, to_array_type(type)};
+      }
     }
     else if(type.id()==ID_struct_tag)
     {

--- a/src/solvers/flattening/bv_pointers.cpp
+++ b/src/solvers/flattening/bv_pointers.cpp
@@ -138,7 +138,7 @@ bool bv_pointerst::convert_address_of_rec(
 
     // get size
     auto size = pointer_offset_size(array_type.subtype(), ns);
-    CHECK_RETURN(size.has_value() && *size > 0);
+    CHECK_RETURN(size.has_value() && *size >= 0);
 
     offset_arithmetic(bv, *size, index);
     CHECK_RETURN(bv.size()==bits);
@@ -342,7 +342,7 @@ bvt bv_pointerst::convert_pointer_type(const exprt &expr)
         else
         {
           auto size_opt = pointer_offset_size(pointer_sub_type, ns);
-          CHECK_RETURN(size_opt.has_value() && *size_opt > 0);
+          CHECK_RETURN(size_opt.has_value() && *size_opt >= 0);
           size = *size_opt;
         }
       }

--- a/src/util/pointer_offset_size.cpp
+++ b/src/util/pointer_offset_size.cpp
@@ -670,13 +670,8 @@ optionalt<exprt> get_subexpression_at_offset(
 
     // no arrays of non-byte-aligned, zero-, or unknown-sized objects
     if(
-      !elem_size_bits.has_value() || *elem_size_bits == 0 ||
-      *elem_size_bits % 8 != 0)
-    {
-      return {};
-    }
-
-    if(*target_size_bits <= *elem_size_bits)
+      elem_size_bits.has_value() && *elem_size_bits > 0 &&
+      *elem_size_bits % 8 == 0 && *target_size_bits <= *elem_size_bits)
     {
       const mp_integer elem_size_bytes = *elem_size_bits / 8;
       const auto offset_inside_elem = offset_bytes % elem_size_bytes;


### PR DESCRIPTION
Although any access would result in an out-of-bounds access (within the
program being verified), it's perfectly fine to perform offset
computation.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
