### PR TITLE
OpenBSD can do binary merges with objcopy.

### DIFF
--- a/src/goto-cc/hybrid_binary.cpp
+++ b/src/goto-cc/hybrid_binary.cpp
@@ -32,7 +32,7 @@ int hybrid_binary(
 
   int result;
 
-#if defined(__linux__) || defined(__FreeBSD_kernel__)
+#if defined(__linux__) || defined(__FreeBSD_kernel__) || defined(__OpenBSD__)
   // we can use objcopy for both object files and executables
   (void)building_executable;
 


### PR DESCRIPTION
Added defined(__OpenBSD__) to the platform check for binary merge in goto-cc/hybrid_binary.cpp

- [ X ] Each commit message has a non-empty body, explaining why the change was made.
- [ X ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ X ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ X ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ X ] My commit message includes data points confirming performance improvements (if claimed).
- [ X ] My PR is restricted to a single feature or bugfix.
- [ X ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.
