### PR TITLE
Xen-build GitHub action: use ccache and Ubuntu 20.04

### DIFF
--- a/.github/workflows/build-and-test-Xen.yaml
+++ b/.github/workflows/build-and-test-Xen.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   CompileXen:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
         with:
@@ -19,12 +19,28 @@ jobs:
         run: |
           sudo apt-get install --no-install-recommends -y coreutils  build-essential gcc git make flex bison software-properties-common libwww-perl python
           sudo apt-get install --no-install-recommends -y bin86 gdb bcc liblzma-dev python-dev gettext iasl uuid-dev libncurses5-dev libncursesw5-dev pkg-config
-          sudo apt-get install --no-install-recommends -y libgtk2.0-dev libyajl-dev sudo time
+          sudo apt-get install --no-install-recommends -y libgtk2.0-dev libyajl-dev sudo time ccache
 
+      - name: Prepare ccache
+        uses: actions/cache@v2
+        with:
+          path: .ccache
+          key: ${{ runner.os }}-20.04-make-${{ github.ref }}-${{ github.sha }}-XEN
+          restore-keys: |
+            ${{ runner.os }}-20.04-make-${{ github.ref }}
+            ${{ runner.os }}-20.04-make
+      - name: ccache environment
+        run: |
+          echo "CCACHE_BASEDIR=$PWD" >> $GITHUB_ENV
+          echo "CCACHE_DIR=$PWD/.ccache" >> $GITHUB_ENV
+      - name: Zero ccache stats and limit in size
+        run: ccache -z --max-size=500M
       - name: Build CBMC tools
         run: |
           make -C src minisat2-download
-          make -C src cbmc.dir goto-cc.dir goto-diff.dir -j2
+          make -C src CXX='ccache /usr/bin/g++' cbmc.dir goto-cc.dir goto-diff.dir -j2
+      - name: Print ccache stats
+        run: ccache -s
 
       - name: Get one-line-scan
         run: git clone -b path-addition https://github.com/awslabs/one-line-scan.git


### PR DESCRIPTION
The CBMC build in this action takes more than 10 minutes (building just
some selected directories), when the full build using ccache takes less
than 1 minute. Use ccache to achieve the same speed-up. As we only have
a make-build cache for 20.04, upgrade the environment to this Ubuntu
version.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [x] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
