### PR TITLE
Ensure unique GitHub action cache keys

### DIFF
--- a/.github/workflows/pull-request-checks.yaml
+++ b/.github/workflows/pull-request-checks.yaml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: .ccache
-          key: ${{ runner.os }}-20.04-make-${{ github.ref }}-${{ github.sha }}
+          key: ${{ runner.os }}-20.04-make-${{ github.ref }}-${{ github.sha }}-PR
           restore-keys: |
             ${{ runner.os }}-20.04-make-${{ github.ref }}
             ${{ runner.os }}-20.04-make
@@ -71,7 +71,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: .ccache
-          key: ${{ runner.os }}-20.04-Release-${{ github.ref }}-${{ github.sha }}
+          key: ${{ runner.os }}-20.04-Release-${{ github.ref }}-${{ github.sha }}-PR
           restore-keys: |
             ${{ runner.os }}-20.04-Release-${{ github.ref }}
             ${{ runner.os }}-20.04-Release
@@ -110,7 +110,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: .ccache
-          key: ${{ runner.os }}-make-${{ github.ref }}-${{ github.sha }}
+          key: ${{ runner.os }}-make-${{ github.ref }}-${{ github.sha }}-PR
           restore-keys: |
             ${{ runner.os }}-make-${{ github.ref }}
             ${{ runner.os }}-make
@@ -150,7 +150,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: .ccache
-          key: ${{ runner.os }}-Release-${{ github.ref }}-${{ github.sha }}
+          key: ${{ runner.os }}-Release-${{ github.ref }}-${{ github.sha }}-PR
           restore-keys: |
             ${{ runner.os }}-Release-${{ github.ref }}
             ${{ runner.os }}-Release
@@ -191,7 +191,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: .ccache
-          key: ${{ runner.os }}-msbuild-${{ github.ref }}-${{ github.sha }}
+          key: ${{ runner.os }}-msbuild-${{ github.ref }}-${{ github.sha }}-PR
           restore-keys: |
             ${{ runner.os }}-msbuild-${{ github.ref }}
             ${{ runner.os }}-msbuild
@@ -270,7 +270,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: .ccache
-          key: ${{ runner.os }}-msbuild-${{ github.ref }}-${{ github.sha }}
+          key: ${{ runner.os }}-msbuild-${{ github.ref }}-${{ github.sha }}-PKG
           restore-keys: |
             ${{ runner.os }}-msbuild-${{ github.ref }}
             ${{ runner.os }}-msbuild
@@ -310,7 +310,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: .ccache
-          key: ${{ runner.os }}-18.04-Release-${{ github.ref }}-${{ github.sha }}
+          key: ${{ runner.os }}-18.04-Release-${{ github.ref }}-${{ github.sha }}-PR
           restore-keys: |
             ${{ runner.os }}-18.04-Release-${{ github.ref }}
             ${{ runner.os }}-18.04-Release

--- a/.github/workflows/release-packages.yaml
+++ b/.github/workflows/release-packages.yaml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: .ccache
-          key: ${{ runner.os }}-20.04-Release-${{ github.ref }}-${{ github.sha }}
+          key: ${{ runner.os }}-20.04-Release-${{ github.ref }}-${{ github.sha }}-RELEASEPKG
           restore-keys: |
             ${{ runner.os }}-20.04-Release-${{ github.ref }}
             ${{ runner.os }}-20.04-Release
@@ -74,7 +74,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: .ccache
-          key: ${{ runner.os }}-18.04-Release-${{ github.ref }}-${{ github.sha }}
+          key: ${{ runner.os }}-18.04-Release-${{ github.ref }}-${{ github.sha }}-RELEASEPKG
           restore-keys: |
             ${{ runner.os }}-18.04-Release-${{ github.ref }}
             ${{ runner.os }}-18.04-Release
@@ -154,7 +154,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: .ccache
-          key: ${{ runner.os }}-msbuild-${{ github.ref }}-${{ github.sha }}
+          key: ${{ runner.os }}-msbuild-${{ github.ref }}-${{ github.sha }}-RELEASEPKG
           restore-keys: |
             ${{ runner.os }}-msbuild-${{ github.ref }}
             ${{ runner.os }}-msbuild


### PR DESCRIPTION
Concurrently running jobs using the same cache key result in GitHub
actions not caching, reporting "Unable to reserve cache with key
<cache-key>, another job may be creating this cache."

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
