### PR TITLE
Additional and updated union regression tests involving pointers

### DIFF
--- a/regression/cbmc/union10/union_list2.desc
+++ b/regression/cbmc/union10/union_list2.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 union_list2.c
 
 ^EXIT=0$

--- a/regression/cbmc/union14/main.c
+++ b/regression/cbmc/union14/main.c
@@ -1,0 +1,47 @@
+struct fatptr
+{
+  int *data;
+  unsigned long int len;
+};
+
+struct slice
+{
+  int *data;
+  unsigned long int len;
+};
+
+union repr {
+  struct slice rust;
+  struct fatptr raw;
+};
+
+struct slice cast(int *data, unsigned long int len)
+{
+  struct fatptr x;
+  union repr z;
+  x.data = data;
+  x.len = len;
+  z.raw = x;
+  return z.rust;
+}
+
+struct fatptr cast2(int *data, unsigned long int len)
+{
+  struct slice w;
+  union repr z;
+  w.data = data;
+  w.len = len;
+  z.rust = w;
+  return z.raw;
+}
+
+int main()
+{
+  int x = 256;
+
+  struct slice z = cast(&x, 1);
+  struct fatptr z2 = cast2(&x, 1);
+
+  __CPROVER_assert(*z.data == 256, "test 1");
+  __CPROVER_assert(*z2.data == 256, "test 2");
+}

--- a/regression/cbmc/union14/test.desc
+++ b/regression/cbmc/union14/test.desc
@@ -1,0 +1,12 @@
+KNOWNBUG
+main.c
+
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring
+--
+Value sets do not properly track pointers through byte-extract operations. Thus
+derferencing yields __CPROVER_memory, which results in a spurious verification
+failure.


### PR DESCRIPTION
union10/union_list2 passes as of 73fadb3c9a, but crafting other tests
that involve pointers and unions (and spuriously fail) is possible as
the new test union14 demonstrates.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
