### PR TITLE
Initialise union of static lifetime with zeros

### DIFF
--- a/regression/cbmc/Union_Initialization5/main.c
+++ b/regression/cbmc/Union_Initialization5/main.c
@@ -1,5 +1,10 @@
 #include <assert.h>
 
+union U_ok {
+  int x;
+  int y;
+} u_ok = {.x = 1, .y = 2};
+
 #ifndef _MSC_VER
 union U {
   int x;
@@ -8,11 +13,13 @@ union U {
 
 int main()
 {
+  assert(u_ok.y == 2);
   // the excess initializer (2) is ignored
   assert(u.x == 1);
 }
 #else
 int main()
 {
+  assert(u_ok.y == 2);
 }
 #endif

--- a/regression/cbmc/union1/test.desc
+++ b/regression/cbmc/union1/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.c
 
 ^EXIT=0$

--- a/regression/goto-instrument/dump-union/main.c
+++ b/regression/goto-instrument/dump-union/main.c
@@ -1,0 +1,8 @@
+union U {
+  int *p;
+  unsigned long long p_int;
+} u = {.p_int = 42};
+
+int main()
+{
+}

--- a/regression/goto-instrument/dump-union/main.c
+++ b/regression/goto-instrument/dump-union/main.c
@@ -1,3 +1,5 @@
+#include <assert.h>
+
 union U {
   int *p;
   unsigned long long p_int;
@@ -5,4 +7,5 @@ union U {
 
 int main()
 {
+  assert(u.p_int == 42);
 }

--- a/regression/goto-instrument/dump-union/test.desc
+++ b/regression/goto-instrument/dump-union/test.desc
@@ -2,6 +2,7 @@ CORE
 main.c
 --dump-c
 =(\(signed int \*\))?42
+VERIFICATION SUCCESSFUL
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/goto-instrument/dump-union/test.desc
+++ b/regression/goto-instrument/dump-union/test.desc
@@ -1,0 +1,12 @@
+CORE
+main.c
+--dump-c
+=(\(signed int \*\))?42
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+irep
+--
+This test must pass compiling the output generated using dump-c, which implies
+that no irep strings can occur.

--- a/src/ansi-c/c_typecheck_initializer.cpp
+++ b/src/ansi-c/c_typecheck_initializer.cpp
@@ -72,7 +72,10 @@ exprt c_typecheck_baset::do_initializer_rec(
   }
 
   if(value.id()==ID_initializer_list)
-    return do_initializer_list(value, type, force_constant);
+  {
+    return simplify_expr(
+      do_initializer_list(value, type, force_constant), *this);
+  }
 
   if(
     value.id() == ID_array && value.get_bool(ID_C_string_constant) &&

--- a/src/ansi-c/c_typecheck_initializer.cpp
+++ b/src/ansi-c/c_typecheck_initializer.cpp
@@ -12,6 +12,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "c_typecheck_base.h"
 
 #include <util/arith_tools.h>
+#include <util/byte_operators.h>
 #include <util/c_types.h>
 #include <util/config.h>
 #include <util/cprover_prefix.h>
@@ -520,13 +521,15 @@ exprt::operandst::const_iterator c_typecheck_baset::do_designated_initializer(
       {
         // Already right union component. We can initialize multiple submembers,
         // so do not overwrite this.
+        dest = &(to_union_expr(*dest).op());
       }
       else
       {
         // The first component is not the maximum member, which the (default)
         // zero initializer prepared. Replace this by a component-specific
         // initializer; other bytes have an unspecified value (C Standard
-        // 6.2.6.1(7)).
+        // 6.2.6.1(7)). In practice, objects of static lifetime are fully zero
+        // initialized.
         const auto zero =
           zero_initializer(component.type(), value.source_location(), *this);
         if(!zero.has_value())
@@ -536,12 +539,23 @@ exprt::operandst::const_iterator c_typecheck_baset::do_designated_initializer(
                   << to_string(component.type()) << "'" << eom;
           throw 0;
         }
-        union_exprt union_expr(component.get_name(), *zero, type);
-        union_expr.add_source_location()=value.source_location();
-        *dest=union_expr;
-      }
 
-      dest = &(to_union_expr(*dest).op());
+        if(current_symbol.is_static_lifetime)
+        {
+          byte_update_exprt byte_update{
+            byte_update_id(), *dest, from_integer(0, index_type()), *zero};
+          byte_update.add_source_location() = value.source_location();
+          *dest = std::move(byte_update);
+          dest = &(to_byte_update_expr(*dest).op2());
+        }
+        else
+        {
+          union_exprt union_expr(component.get_name(), *zero, type);
+          union_expr.add_source_location() = value.source_location();
+          *dest = std::move(union_expr);
+          dest = &(to_union_expr(*dest).op());
+        }
+      }
     }
     else
       UNREACHABLE;

--- a/src/ansi-c/expr2c.cpp
+++ b/src/ansi-c/expr2c.cpp
@@ -1911,12 +1911,8 @@ std::string expr2ct::convert_constant(
       if(type.subtype().id()!=ID_empty)
         dest="(("+convert(type)+")"+dest+")";
     }
-    else
+    else if(src.operands().size() == 1)
     {
-      // we prefer the annotation
-      if(src.operands().size()!=1)
-        return convert_norep(src, precedence);
-
       const auto &annotation = to_unary_expr(src).op();
 
       if(annotation.id() == ID_constant)
@@ -1932,6 +1928,12 @@ std::string expr2ct::convert_constant(
       }
       else
         return convert_with_precedence(annotation, precedence);
+    }
+    else
+    {
+      const auto width = to_pointer_type(type).get_width();
+      mp_integer int_value = bvrep2integer(value, width, false);
+      return "(" + convert(type) + ")" + integer2string(int_value);
     }
   }
   else if(type.id()==ID_string)

--- a/src/ansi-c/expr2c.cpp
+++ b/src/ansi-c/expr2c.cpp
@@ -2280,10 +2280,36 @@ std::string expr2ct::convert_designated_initializer(const exprt &src)
     return convert_norep(src, precedence);
   }
 
-  std::string dest=".";
-  // TODO it->find(ID_member)
+  const exprt &value = to_unary_expr(src).op();
+
+  const exprt &designator = static_cast<const exprt &>(src.find(ID_designator));
+  if(designator.operands().size() != 1)
+  {
+    unsigned precedence;
+    return convert_norep(src, precedence);
+  }
+
+  const exprt &designator_id = to_unary_expr(designator).op();
+
+  std::string dest;
+
+  if(designator_id.id() == ID_member)
+  {
+    dest = "." + id2string(designator_id.get(ID_component_name));
+  }
+  else if(
+    designator_id.id() == ID_index && designator_id.operands().size() == 1)
+  {
+    dest = "[" + convert(to_unary_expr(designator_id).op()) + "]";
+  }
+  else
+  {
+    unsigned precedence;
+    return convert_norep(src, precedence);
+  }
+
   dest+='=';
-  dest += convert(to_unary_expr(src).op());
+  dest += convert(value);
 
   return dest;
 }

--- a/src/ansi-c/parser.y
+++ b/src/ansi-c/parser.y
@@ -439,12 +439,11 @@ offsetof:
 offsetof_member_designator:
           member_name
         {
-          init($$, ID_designated_initializer);
-          parser_stack($$).operands().resize(1);
-          auto &op = to_unary_expr(parser_stack($$)).op();
-          op.id(ID_member);
+          init($$);
+          exprt op{ID_member};
           op.add_source_location()=parser_stack($1).source_location();
           op.set(ID_component_name, parser_stack($1).get(ID_C_base_name));
+          parser_stack($$).add_to_operands(std::move(op));
         }
         | offsetof_member_designator '.' member_name
         {

--- a/src/solvers/flattening/bv_pointers.cpp
+++ b/src/solvers/flattening/bv_pointers.cpp
@@ -308,7 +308,7 @@ bvt bv_pointerst::convert_pointer_type(const exprt &expr)
       encode(pointer_logic.get_null_object(), bv);
     else
     {
-      mp_integer i=string2integer(id2string(value), 2);
+      mp_integer i = bvrep2integer(value, bits, false);
       bv=bv_utils.build_constant(i, bits);
     }
 

--- a/src/util/simplify_utils.cpp
+++ b/src/util/simplify_utils.cpp
@@ -185,8 +185,15 @@ optionalt<exprt> bits2expr(
   // bits start at lowest memory address
   auto type_bits = pointer_offset_bits(type, ns);
 
-  if(!type_bits.has_value() || *type_bits != bits.size())
+  if(
+    !type_bits.has_value() ||
+    (type.id() != ID_union && type.id() != ID_union_tag &&
+     *type_bits != bits.size()) ||
+    ((type.id() == ID_union || type.id() == ID_union_tag) &&
+     *type_bits < bits.size()))
+  {
     return {};
+  }
 
   if(
     type.id() == ID_unsignedbv || type.id() == ID_signedbv ||

--- a/src/util/simplify_utils.cpp
+++ b/src/util/simplify_utils.cpp
@@ -201,6 +201,13 @@ optionalt<exprt> bits2expr(
     type.id() == ID_c_bit_field || type.id() == ID_pointer ||
     type.id() == ID_bv || type.id() == ID_c_bool)
   {
+    if(
+      type.id() == ID_pointer && config.ansi_c.NULL_is_zero &&
+      bits.find('1') == std::string::npos)
+    {
+      return null_pointer_exprt(to_pointer_type(type));
+    }
+
     endianness_mapt map(type, little_endian, ns);
 
     std::string tmp = bits;
@@ -410,7 +417,7 @@ expr2bits(const exprt &expr, bool little_endian, const namespacet &ns)
     else if(type.id() == ID_pointer)
     {
       if(value == ID_NULL && config.ansi_c.NULL_is_zero)
-        return std::string('0', to_bitvector_type(type).get_width());
+        return std::string(to_bitvector_type(type).get_width(), '0');
       else
         return {};
     }


### PR DESCRIPTION
The C standard does not specify the value of bytes that do not belong to
the object representation of a member referred to in an initializer
list, but compilers seem to ensure those bytes are zero (possibly by
using the .bss section).

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
