### PR TITLE
Overload field_sensitivityt::apply for ssa_exprt

### DIFF
--- a/src/goto-symex/field_sensitivity.cpp
+++ b/src/goto-symex/field_sensitivity.cpp
@@ -21,6 +21,18 @@ Author: Michael Tautschnig
 exprt field_sensitivityt::apply(
   const namespacet &ns,
   goto_symex_statet &state,
+  ssa_exprt ssa_expr,
+  bool write) const
+{
+  if(!run_apply || write)
+    return std::move(ssa_expr);
+  else
+    return get_fields(ns, state, ssa_expr);
+}
+
+exprt field_sensitivityt::apply(
+  const namespacet &ns,
+  goto_symex_statet &state,
   exprt expr,
   bool write) const
 {
@@ -33,9 +45,9 @@ exprt field_sensitivityt::apply(
       *it = apply(ns, state, std::move(*it), write);
   }
 
-  if(is_ssa_expr(expr) && !write)
+  if(!write && is_ssa_expr(expr))
   {
-    return get_fields(ns, state, to_ssa_expr(expr));
+    return apply(ns, state, to_ssa_expr(expr), write);
   }
   else if(
     !write && expr.id() == ID_member &&

--- a/src/goto-symex/field_sensitivity.h
+++ b/src/goto-symex/field_sensitivity.h
@@ -119,6 +119,12 @@ public:
   exprt
   apply(const namespacet &ns, goto_symex_statet &state, exprt expr, bool write)
     const;
+  /// \copydoc apply(const namespacet&,goto_symex_statet&,exprt,bool) const
+  exprt apply(
+    const namespacet &ns,
+    goto_symex_statet &state,
+    ssa_exprt expr,
+    bool write) const;
 
   /// Compute an expression representing the individual components of a
   /// field-sensitive SSA representation of \p ssa_expr.


### PR DESCRIPTION
For two of the eight call sites of field_sensitivityt::apply we know at
compile time that an ssa_exprt is being passed in. We can thus avoid
redundant is-it-an-SSA-expression tests for those cases, and also know
that we do not need to look at any operands.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
