### PR TITLE
satcheck minisat2: make all solver hardness processing conditional

### DIFF
--- a/src/solvers/sat/cnf.cpp
+++ b/src/solvers/sat/cnf.cpp
@@ -413,7 +413,7 @@ bvt cnft::eliminate_duplicates(const bvt &bv)
 
 /// filter 'true' from clause, eliminate duplicates, recognise trivially
 /// satisfied clauses
-bool cnft::process_clause(const bvt &bv, bvt &dest)
+bool cnft::process_clause(const bvt &bv, bvt &dest) const
 {
   dest.clear();
 

--- a/src/solvers/sat/cnf.h
+++ b/src/solvers/sat/cnf.h
@@ -55,7 +55,7 @@ protected:
 
   size_t _no_variables;
 
-  bool process_clause(const bvt &bv, bvt &dest);
+  bool process_clause(const bvt &bv, bvt &dest) const;
 
   static bool is_all(const bvt &bv, literalt l)
   {

--- a/src/solvers/sat/satcheck_minisat2.cpp
+++ b/src/solvers/sat/satcheck_minisat2.cpp
@@ -140,22 +140,23 @@ void satcheck_minisat2_baset<T>::lcnf(const bvt &bv)
 
     solver->addClause_(c);
 
-    // To map clauses to lines of program code, track clause indices in the
-    // dimacs cnf output. Dimacs output is generated after processing clauses
-    // to remove duplicates and clauses that are trivially true. Here, a clause
-    // is checked to see if it can be thus eliminated. If not, add the clause
-    // index to list of clauses in solver_hardnesst::register_clause().
-    static size_t cnf_clause_index = 0;
-    bvt cnf;
-    bool clause_removed = process_clause(bv, cnf);
+    with_solver_hardness([this, &bv](solver_hardnesst &hardness) {
+      // To map clauses to lines of program code, track clause indices in the
+      // dimacs cnf output. Dimacs output is generated after processing
+      // clauses to remove duplicates and clauses that are trivially true.
+      // Here, a clause is checked to see if it can be thus eliminated. If
+      // not, add the clause index to list of clauses in
+      // solver_hardnesst::register_clause().
+      static size_t cnf_clause_index = 0;
+      bvt cnf;
+      bool clause_removed = process_clause(bv, cnf);
 
-    if(!clause_removed)
-      cnf_clause_index++;
+      if(!clause_removed)
+        cnf_clause_index++;
 
-    with_solver_hardness(
-      [&bv, &cnf, &clause_removed](solver_hardnesst &hardness) {
-        hardness.register_clause(bv, cnf, cnf_clause_index, !clause_removed);
-      });
+      hardness.register_clause(bv, cnf, cnf_clause_index, !clause_removed);
+    });
+
     clause_counter++;
   }
   catch(const Minisat::OutOfMemoryException &)


### PR DESCRIPTION
There is no need to run process_clause when its output wouldn't even be
used.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
