### PR TITLE
Make IPASIR configuration build after solver hardness changes

### DIFF
--- a/.github/workflows/pull-request-checks.yaml
+++ b/.github/workflows/pull-request-checks.yaml
@@ -16,8 +16,7 @@ jobs:
           # user input
           DEBIAN_FRONTEND: noninteractive
         run: |
-          sudo apt-get install --no-install-recommends -yq gcc gdb g++ maven jq flex bison libxml2-utils ccache
-          make -C src minisat2-download
+          sudo apt-get install --no-install-recommends -yq gcc gdb g++ maven jq flex bison libxml2-utils ccache cmake
       - name: Prepare ccache
         uses: actions/cache@v2
         with:
@@ -34,19 +33,24 @@ jobs:
         run: ccache -z --max-size=500M
       - name: Build with make
         run: |
-          make -C src CXX='ccache /usr/bin/g++' -j2
-          make -C unit CXX='ccache /usr/bin/g++' -j2
-          make -C jbmc/src  CXX='ccache /usr/bin/g++' -j2
-          make -C jbmc/unit CXX='ccache /usr/bin/g++' -j2
+          git clone https://github.com/conp-solutions/riss riss.git
+          cmake -Hriss.git -Briss.git/release -DCMAKE_BUILD_TYPE=Release
+          make -C riss.git/release riss-coprocessor-lib-static -j2
+          make -C src -j2 CXX="ccache g++" LIBS="$PWD/riss.git/release/lib/libriss-coprocessor.a -lpthread" IPASIR=$PWD/riss.git/riss
+          make -C jbmc/src -j2 CXX="ccache g++" LIBS="$PWD/riss.git/release/lib/libriss-coprocessor.a -lpthread" IPASIR=$PWD/riss.git/riss
+
+          make -C unit -j2 CXX="ccache g++" LIBS="$PWD/riss.git/release/lib/libriss-coprocessor.a -lpthread" IPASIR=$PWD/riss.git/riss
+
+          make -C jbmc/unit -j2 CXX="ccache g++" LIBS="$PWD/riss.git/release/lib/libriss-coprocessor.a -lpthread" IPASIR=$PWD/riss.git/riss
       - name: Print ccache stats
         run: ccache -s
       - name: Run unit tests
         run: |
-          make -C unit test
-          make -C jbmc/unit test
+          make -C unit test IPASIR=$PWD/riss.git/riss
+          make -C jbmc/unit test IPASIR=$PWD/riss.git/riss
           echo "Running expected failure tests"
-          make TAGS="[!shouldfail]" -C unit test
-          make TAGS="[!shouldfail]" -C jbmc/unit test
+          make TAGS="[!shouldfail]" -C unit test IPASIR=$PWD/riss.git/riss
+          make TAGS="[!shouldfail]" -C jbmc/unit test IPASIR=$PWD/riss.git/riss
       - name: Run regression tests
         run: |
           make -C regression test-parallel JOBS=2

--- a/unit/Makefile
+++ b/unit/Makefile
@@ -225,6 +225,9 @@ EXCLUDED_TESTS=expr_undefined_casts.cpp
 ifneq ($(WITH_MEMORY_ANALYZER),1)
 EXCLUDED_TESTS += gdb_api.cpp
 endif
+ifeq ($(MINISAT2),)
+EXCLUDED_TESTS += satcheck_minisat2.cpp
+endif
 
 N_CATCH_TESTS = $(shell \
                   cat $$(find . -name "*.cpp" \


### PR DESCRIPTION
In #5480 the solver hardness interface was updated, but changes were
only implemented in the Minisat2 interface. Update the IPASIR interface
to match these changes.

To avoid future regressions, make the check-macos-10_15-make-clang
GitHub action use IPASIR with Riss as the back-end solver.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
