### PR TITLE
CBMC/JBMC --cover: only store traces with --trace to avoid memory exhaustion

### DIFF
--- a/doc/cprover-manual/test-suite.md
+++ b/doc/cprover-manual/test-suite.md
@@ -128,10 +128,11 @@ and outputs of interest for generating test suites.
 To demonstrate the automatic test suite generation in CBMC, we call the
 following command:
 
-    cbmc pid.c --cover mcdc --unwind 6 --xml-ui
+    cbmc pid.c --cover mcdc --show-test-suite --unwind 6 --xml-ui
 
 We'll describe those command line options one by one. The option `--cover mcdc`
-specifies the code coverage criterion. There
+specifies the code coverage criterion, and --show-test-suite requests that a
+test suite be printed. There
 are four conditional statements in the PID function: in lines 41,
 44, 48, and 49. To satisfy MC/DC, the test suite has to meet
 multiple requirements. For instance, each conditional statement needs to

--- a/regression/cbmc-cover/branch-loop1/test.desc
+++ b/regression/cbmc-cover/branch-loop1/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---xml-ui --cover branch
+--xml-ui --cover branch --show-test-suite
 activate-multi-line-match
 ^EXIT=0$
 ^SIGNAL=0$

--- a/regression/cbmc-cover/pointer-function-parameters-2/test.desc
+++ b/regression/cbmc-cover/pointer-function-parameters-2/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---function fun --cover branch
+--function fun --cover branch --show-test-suite
 ^\*\* 7 of 7 covered \(100.0%\)$
 ^Test suite:$
 a=\(\(signed int \*\*\)NULL\)

--- a/regression/cbmc-cover/pointer-function-parameters/test.desc
+++ b/regression/cbmc-cover/pointer-function-parameters/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---function fun --cover branch
+--function fun --cover branch --show-test-suite
 ^\*\* 5 of 5 covered \(100\.0%\)$
 ^Test suite:$
 ^(tmp(\$\d+)?=[^,]*, a=\(\(signed int \*\)NULL\))|(a=\(\(signed int \*\)NULL\), tmp(\$\d+)?=[^,]*)$

--- a/src/cbmc/cbmc_parse_options.cpp
+++ b/src/cbmc/cbmc_parse_options.cpp
@@ -726,8 +726,11 @@ int cbmc_parse_optionst::doit()
     (void)verifier();
     verifier.report();
 
-    c_test_input_generatort test_generator(ui_message_handler, options);
-    test_generator(verifier.get_traces());
+    if(options.get_bool_option("show-test-suite"))
+    {
+      c_test_input_generatort test_generator(ui_message_handler, options);
+      test_generator(verifier.get_traces());
+    }
 
     return CPROVER_EXIT_SUCCESS;
   }

--- a/src/goto-checker/cover_goals_verifier_with_trace_storage.h
+++ b/src/goto-checker/cover_goals_verifier_with_trace_storage.h
@@ -41,9 +41,14 @@ public:
     while(incremental_goto_checker(properties).progress !=
           incremental_goto_checkert::resultt::progresst::DONE)
     {
-      // we've got a trace; store it and link it to the covered goals
-      message_building_error_trace(log);
-      (void)traces.insert_all(incremental_goto_checker.build_full_trace());
+      if(
+        options.get_bool_option("show-test-suite") ||
+        options.get_bool_option("trace"))
+      {
+        // we've got a trace; store it and link it to the covered goals
+        message_building_error_trace(log);
+        (void)traces.insert_all(incremental_goto_checker.build_full_trace());
+      }
 
       ++iterations;
     }

--- a/src/goto-checker/goto_trace_storage.cpp
+++ b/src/goto-checker/goto_trace_storage.cpp
@@ -27,6 +27,10 @@ const goto_tracet &goto_trace_storaget::insert(goto_tracet &&trace)
     emplace_result.second,
     "cannot associate more than one error trace with property " +
       id2string(last_step.property_id));
+
+  for(auto &step : traces.back().steps)
+    step.merge_ireps(merge_ireps);
+
   return traces.back();
 }
 
@@ -40,6 +44,10 @@ const goto_tracet &goto_trace_storaget::insert_all(goto_tracet &&trace)
   {
     property_id_to_trace_index.emplace(property_id, traces.size() - 1);
   }
+
+  for(auto &step : traces.back().steps)
+    step.merge_ireps(merge_ireps);
+
   return traces.back();
 }
 

--- a/src/goto-checker/goto_trace_storage.cpp
+++ b/src/goto-checker/goto_trace_storage.cpp
@@ -43,7 +43,7 @@ const goto_tracet &goto_trace_storaget::insert_all(goto_tracet &&trace)
   return traces.back();
 }
 
-const std::vector<goto_tracet> &goto_trace_storaget::all() const
+const std::list<goto_tracet> &goto_trace_storaget::all() const
 {
   return traces;
 }
@@ -53,8 +53,9 @@ operator[](const irep_idt &property_id) const
 {
   const auto trace_found = property_id_to_trace_index.find(property_id);
   PRECONDITION(trace_found != property_id_to_trace_index.end());
+  CHECK_RETURN(trace_found->second < traces.size());
 
-  return traces.at(trace_found->second);
+  return *(std::next(traces.begin(), trace_found->second));
 }
 
 const namespacet &goto_trace_storaget::get_namespace() const

--- a/src/goto-checker/goto_trace_storage.h
+++ b/src/goto-checker/goto_trace_storage.h
@@ -14,6 +14,8 @@ Author: Daniel Kroening, Peter Schrammel
 
 #include <goto-programs/goto_trace.h>
 
+#include <util/merge_irep.h>
+
 #include <list>
 
 class goto_trace_storaget
@@ -44,6 +46,9 @@ protected:
 
   // maps property ID to index in traces
   std::unordered_map<irep_idt, std::size_t> property_id_to_trace_index;
+
+  /// irep container for shared ireps
+  merge_irept merge_ireps;
 };
 
 #endif // CPROVER_GOTO_CHECKER_GOTO_TRACE_STORAGE_H

--- a/src/goto-checker/goto_trace_storage.h
+++ b/src/goto-checker/goto_trace_storage.h
@@ -14,6 +14,8 @@ Author: Daniel Kroening, Peter Schrammel
 
 #include <goto-programs/goto_trace.h>
 
+#include <list>
+
 class goto_trace_storaget
 {
 public:
@@ -28,7 +30,7 @@ public:
   ///   are mapped to the given trace.
   const goto_tracet &insert_all(goto_tracet &&);
 
-  const std::vector<goto_tracet> &all() const;
+  const std::list<goto_tracet> &all() const;
   const goto_tracet &operator[](const irep_idt &property_id) const;
 
   const namespacet &get_namespace() const;
@@ -38,7 +40,7 @@ protected:
   const namespacet &ns;
 
   /// stores the traces
-  std::vector<goto_tracet> traces;
+  std::list<goto_tracet> traces;
 
   // maps property ID to index in traces
   std::unordered_map<irep_idt, std::size_t> property_id_to_trace_index;

--- a/src/goto-instrument/cover.cpp
+++ b/src/goto-instrument/cover.cpp
@@ -166,6 +166,8 @@ void parse_cover_options(const cmdlinet &cmdline, optionst &options)
     cmdline.isset("cover-traces-must-terminate"));
   options.set_option(
     "cover-failed-assertions", cmdline.isset("cover-failed-assertions"));
+
+  options.set_option("show-test-suite", cmdline.isset("show-test-suite"));
 }
 
 /// Build data structures controlling coverage from command-line options.

--- a/src/goto-instrument/cover.h
+++ b/src/goto-instrument/cover.h
@@ -24,7 +24,8 @@ class optionst;
 
 #define OPT_COVER                                                              \
   "(cover):"                                                                   \
-  "(cover-failed-assertions)"
+  "(cover-failed-assertions)"                                                  \
+  "(show-test-suite)"
 
 #define HELP_COVER                                                             \
   " --cover CC                   create test-suite with coverage criterion "   \
@@ -32,7 +33,9 @@ class optionst;
   " --cover-failed-assertions    do not stop coverage checking at failed "     \
   "assertions\n"                                                               \
   "                              (this is the default for --cover "            \
-  "assertions)\n"
+  "assertions)\n"                                                              \
+  " --show-test-suite            print test suite for coverage criterion "     \
+  "(requires --cover)"
 
 enum class coverage_criteriont
 {

--- a/src/goto-programs/goto_trace.cpp
+++ b/src/goto-programs/goto_trace.cpp
@@ -18,6 +18,7 @@ Author: Daniel Kroening
 #include <util/arith_tools.h>
 #include <util/byte_operators.h>
 #include <util/format_expr.h>
+#include <util/merge_irep.h>
 #include <util/range.h>
 #include <util/string_utils.h>
 #include <util/symbol.h>
@@ -133,6 +134,20 @@ void goto_trace_stept::output(
 
   out << '\n';
 }
+
+void goto_trace_stept::merge_ireps(merge_irept &dest)
+{
+  dest(cond_expr);
+  dest(full_lhs);
+  dest(full_lhs_value);
+
+  for(auto &io_arg : io_args)
+    dest(io_arg);
+
+  for(auto &function_arg : function_arguments)
+    dest(function_arg);
+}
+
 /// Returns the numeric representation of an expression, based on
 /// options. The default is binary without a base-prefix. Setting
 /// options.hex_representation to be true outputs hex format. Setting

--- a/src/goto-programs/goto_trace.h
+++ b/src/goto-programs/goto_trace.h
@@ -24,6 +24,8 @@ Date: July 2005
 
 #include <goto-programs/goto_program.h>
 
+class merge_irept;
+
 /// Step of the trace of a GOTO program
 ///
 /// A step is either:
@@ -162,6 +164,10 @@ public:
     full_lhs_value.make_nil();
     cond_expr.make_nil();
   }
+
+  /// Use \p dest to establish sharing among ireps.
+  /// \param [out] dest: irep storage container.
+  void merge_ireps(merge_irept &dest);
 };
 
 /// Trace of a GOTO program.


### PR DESCRIPTION
Not everyone needs test inputs, especially when programs lack INPUT
instructions anyway. This helped me avoid running out of memory on a
768GB system for a particular verification problem. The same problem can
now be run with just 75GB of memory.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [x] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
