### PR TITLE
C front-end: hide our use of single-bit bool within sizeof

### DIFF
--- a/regression/ansi-c/sizeof4/test.desc
+++ b/regression/ansi-c/sizeof4/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.c
 
 ^EXIT=0$

--- a/src/ansi-c/c_typecheck_expr.cpp
+++ b/src/ansi-c/c_typecheck_expr.cpp
@@ -950,7 +950,14 @@ void c_typecheck_baset::typecheck_expr_sizeof(exprt &expr)
   }
   else
   {
-    type.swap(to_unary_expr(expr).op().type());
+    const exprt &op = to_unary_expr(as_const(expr)).op();
+    // This is one of the few places where it's detectable
+    // that we are using "bool" for boolean operators instead
+    // of "int". We convert for this reason.
+    if(op.type().id() == ID_bool)
+      type = signed_int_type();
+    else
+      type = op.type();
   }
 
   exprt new_expr;


### PR DESCRIPTION
In C, Boolean operations are of type int. Rejecting sizeof expressions
of Boolean operations breaks building the Linux kernel.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
