### PR TITLE
Array initializers can also be compound literals

### DIFF
--- a/regression/cbmc/compound_literal1/main.c
+++ b/regression/cbmc/compound_literal1/main.c
@@ -6,6 +6,8 @@ union U { float f; int i; };
 // global scope, static lifetime
 int *global_scope_literal=&(int){ 43 };
 
+int array[3] = (int[3]){1, 2, 3};
+
 int main()
 {
   assert(*global_scope_literal==43);

--- a/src/ansi-c/c_typecheck_initializer.cpp
+++ b/src/ansi-c/c_typecheck_initializer.cpp
@@ -38,7 +38,9 @@ void c_typecheck_baset::do_initializer(
                    "any array must have a size");
 
     // we don't allow initialisation with symbols of array type
-    if(result.id() != ID_array && result.id() != ID_array_of)
+    if(
+      result.id() != ID_array && result.id() != ID_array_of &&
+      result.id() != ID_compound_literal)
     {
       error().source_location = result.source_location();
       error() << "invalid array initializer " << to_string(result)


### PR DESCRIPTION
We previously failed this test, stating that { 1, 2, 3 } was an invalid
array initializer.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
