### PR TITLE
Follow-up to 090790a467: attribute __used__ requires unique names

### DIFF
--- a/regression/ansi-c/gcc_attribute_used1/main.c
+++ b/regression/ansi-c/gcc_attribute_used1/main.c
@@ -1,0 +1,6 @@
+static int foo __attribute__((used)) = 42;
+
+int main()
+{
+  return 0;
+}

--- a/regression/ansi-c/gcc_attribute_used1/other.c
+++ b/regression/ansi-c/gcc_attribute_used1/other.c
@@ -1,0 +1,15 @@
+struct bar
+{
+  char *ptr;
+};
+
+static struct bar foo __attribute__((used))
+__attribute__((__section__(".ref.data")));
+
+static struct bar foo __attribute__((used))
+__attribute__((__section__(".ref.data"))) = {0};
+
+void use_foo()
+{
+  __CPROVER_assert(foo.ptr == 0, "null");
+}

--- a/regression/ansi-c/gcc_attribute_used1/test.desc
+++ b/regression/ansi-c/gcc_attribute_used1/test.desc
@@ -1,9 +1,8 @@
-CORE
+CORE gcc-only
 main.c
-
+other.c
 ^EXIT=0$
 ^SIGNAL=0$
-^[[:space:]]*ASSIGN .*foo := 42$
 --
 ^warning: ignoring
 ^CONVERSION ERROR$

--- a/src/ansi-c/ansi_c_declaration.cpp
+++ b/src/ansi-c/ansi_c_declaration.cpp
@@ -173,10 +173,6 @@ void ansi_c_declarationt::to_symbol(
         else  if(get_is_extern()) // traditional GCC
           symbol.is_file_local=true;
       }
-
-      // GCC __attribute__((__used__)) - do not treat those as file-local
-      if(get_is_used())
-        symbol.is_file_local = false;
     }
   }
   else // non-function
@@ -190,10 +186,8 @@ void ansi_c_declarationt::to_symbol(
       (!symbol.is_static_lifetime && !get_is_extern()) ||
       get_is_thread_local();
 
-    symbol.is_file_local=
-      symbol.is_macro ||
-      (!get_is_global() && !get_is_extern()) ||
-      (get_is_global() && get_is_static() && !get_is_used()) ||
-      symbol.is_parameter;
+    symbol.is_file_local =
+      symbol.is_macro || (!get_is_global() && !get_is_extern()) ||
+      (get_is_global() && get_is_static()) || symbol.is_parameter;
   }
 }

--- a/src/ansi-c/ansi_c_declaration.h
+++ b/src/ansi-c/ansi_c_declaration.h
@@ -195,16 +195,6 @@ public:
     set(ID_is_weak, is_weak);
   }
 
-  bool get_is_used() const
-  {
-    return get_bool(ID_is_used);
-  }
-
-  void set_is_used(bool is_used)
-  {
-    set(ID_is_used, is_used);
-  }
-
   void to_symbol(
     const ansi_c_declaratort &,
     symbolt &symbol) const;

--- a/src/ansi-c/c_typecheck_base.cpp
+++ b/src/ansi-c/c_typecheck_base.cpp
@@ -19,6 +19,8 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/std_types.h>
 #include <util/symbol_table_base.h>
 
+#include <goto-programs/name_mangler.h>
+
 #include "ansi_c_declaration.h"
 #include "c_storage_spec.h"
 #include "expr2c.h"
@@ -758,7 +760,6 @@ void c_typecheck_baset::typecheck_declaration(
       declaration.set_is_register(full_spec.is_register);
       declaration.set_is_typedef(full_spec.is_typedef);
       declaration.set_is_weak(full_spec.is_weak);
-      declaration.set_is_used(full_spec.is_used);
 
       symbolt symbol;
       declaration.to_symbol(declarator, symbol);
@@ -786,6 +787,20 @@ void c_typecheck_baset::typecheck_declaration(
         else
           symbol.value = symbol_exprt::typeless(renaming_entry->second);
         symbol.is_macro=true;
+      }
+
+      if(full_spec.is_used && symbol.is_file_local)
+      {
+        // GCC __attribute__((__used__)) - do not treat those as file-local, but
+        // make sure the name is unique
+        symbol.is_file_local = false;
+
+        symbolt symbol_for_renaming = symbol;
+        if(!full_spec.asm_label.empty())
+          symbol_for_renaming.name = full_spec.asm_label;
+        full_spec.asm_label = djb_manglert{}(
+          symbol_for_renaming,
+          id2string(symbol_for_renaming.location.get_file()));
       }
 
       if(full_spec.section.empty())


### PR DESCRIPTION
With 090790a467 we made sure that symbols marked with
__attribute__((__used__)) are not discarded. Linking multiple files that
use symbols marked as such still must not result in conflicting
declarations on such symbols, thus use the DJB name mangler to generate
unique names.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
