### PR TITLE
GCC attribute alias should not trigger warning

### DIFF
--- a/regression/ansi-c/gcc_attributes12/test.desc
+++ b/regression/ansi-c/gcc_attributes12/test.desc
@@ -1,8 +1,9 @@
 CORE gcc-only
 main.c
-
+-Wall
 ^EXIT=0$
 ^SIGNAL=0$
 --
+'extern' symbol 'my_ids_table' should not have an initializer
 ^warning: ignoring
 ^CONVERSION ERROR$

--- a/src/ansi-c/c_typecheck_base.cpp
+++ b/src/ansi-c/c_typecheck_base.cpp
@@ -71,13 +71,14 @@ void c_typecheck_baset::typecheck_symbol(symbolt &symbol)
     new_name=root_name;
     symbol.is_static_lifetime=true;
 
-    if(symbol.value.is_not_nil())
+    if(symbol.value.is_not_nil() && !symbol.is_macro)
     {
       // According to the C standard this should be an error, but at least some
       // versions of Visual Studio insist to use this in their C library, and
       // GCC just warns as well.
       warning().source_location = symbol.value.find_source_location();
-      warning() << "`extern' symbol should not have an initializer" << eom;
+      warning() << "'extern' symbol '" << new_name
+                << "' should not have an initializer" << eom;
     }
   }
   else if(!is_function && symbol.value.id()==ID_code)


### PR DESCRIPTION
We spuriously warned about an extern symbol with value, where it was
only our handling of the "alias" attribute that introduced that value in
the first place. While at it, make that warning more useful.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
