### PR TITLE
C/C++ front-end: void-typed symbols are permitted when extern

### DIFF
--- a/regression/ansi-c/invalid_use_of_void1/main.c
+++ b/regression/ansi-c/invalid_use_of_void1/main.c
@@ -1,3 +1,5 @@
+extern void this_is_ok;
+
 struct a
 {
 #ifdef void_member

--- a/src/ansi-c/c_typecheck_base.cpp
+++ b/src/ansi-c/c_typecheck_base.cpp
@@ -103,7 +103,7 @@ void c_typecheck_baset::typecheck_symbol(symbolt &symbol)
     symbol.pretty_name=new_name;
   }
 
-  if(!symbol.is_type && symbol.type.id() == ID_empty)
+  if(!symbol.is_type && !symbol.is_extern && symbol.type.id() == ID_empty)
   {
     error().source_location = symbol.location;
     error() << "void-typed symbol not permitted" << eom;

--- a/src/cpp/cpp_typecheck_code.cpp
+++ b/src/cpp/cpp_typecheck_code.cpp
@@ -448,7 +448,7 @@ void cpp_typecheckt::typecheck_decl(codet &code)
     if(is_typedef)
       continue;
 
-    if(!symbol.is_type && symbol.type.id() == ID_empty)
+    if(!symbol.is_type && !symbol.is_extern && symbol.type.id() == ID_empty)
     {
       error().source_location = symbol.location;
       error() << "void-typed symbol not permitted" << eom;

--- a/src/cpp/cpp_typecheck_declaration.cpp
+++ b/src/cpp/cpp_typecheck_declaration.cpp
@@ -148,7 +148,7 @@ void cpp_typecheckt::convert_non_template_declaration(
       declaration_type, declaration.storage_spec(),
       declaration.member_spec(), declarator);
 
-    if(!symbol.is_type && symbol.type.id() == ID_empty)
+    if(!symbol.is_type && !symbol.is_extern && symbol.type.id() == ID_empty)
     {
       error().source_location = symbol.location;
       error() << "void-typed symbol not permitted" << eom;


### PR DESCRIPTION
This leaves it to the linker to resolve to some other type, and is
quietly accepted by GCC. Required for building the Linux kernel. The
changes in 9018306f0 were overly strict.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
