### PR TITLE
5-seconds test is not a reason for broken-smt-backend

### DIFF
--- a/regression/cbmc/Bitfields3/paths.desc
+++ b/regression/cbmc/Bitfields3/paths.desc
@@ -1,4 +1,4 @@
-CORE broken-smt-backend
+CORE
 main.c
 --pointer-check --bounds-check --paths lifo
 ^EXIT=0$
@@ -6,6 +6,3 @@ main.c
 ^VERIFICATION SUCCESSFUL$
 --
 ^warning: ignoring
---
-This test is marked broken-smt-backend for performance reasons only: it passes,
-but takes 5 seconds to do so.


### PR DESCRIPTION
We have several tests that take a lot longer, and test time is vastly
dominated by JBMC's tests anyway.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
