### PR TITLE
C front-end: evaluate __builtin_clz over constants

### DIFF
--- a/regression/cbmc-library/__builtin_clz-02/main.c
+++ b/regression/cbmc-library/__builtin_clz-02/main.c
@@ -1,0 +1,12 @@
+#ifdef _MSC_VER
+#  define __builtin_clz(x) __lzcnt(x)
+#  define _Static_assert static_assert
+#endif
+
+int main()
+{
+  _Static_assert(
+    __builtin_clz(0xffU) == 8 * sizeof(unsigned) - 8, "compile-time constant");
+
+  return 0;
+}

--- a/regression/cbmc-library/__builtin_clz-02/test.desc
+++ b/regression/cbmc-library/__builtin_clz-02/test.desc
@@ -1,0 +1,11 @@
+CORE
+main.c
+
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--
+For this example, __builtin_clz is fully evaluated in the front-end. The
+_Static_assert ensures this is the case, as type checking fails when
+_Static_assert does not have a compile-time constant value.

--- a/src/ansi-c/windows_builtin_headers.h
+++ b/src/ansi-c/windows_builtin_headers.h
@@ -1,1 +1,4 @@
 int __assume(int);
+unsigned short __lzcnt16(unsigned short value);
+unsigned int __lzcnt(unsigned int value);
+unsigned __int64 __lzcnt64(unsigned __int64 value);


### PR DESCRIPTION
The Linux kernel uses __builtin_clz(ll) in expressions that are expected
to be compile-time constants. To support this, evaluate such expressions
during type checking.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
