### PR TITLE
Switch the OSX universal binary build to X86 + ARM64

### DIFF
--- a/src/common
+++ b/src/common
@@ -47,9 +47,9 @@ endif
 ifeq ($(filter-out OSX OSX_Universal,$(BUILD_ENV_)),)
   ifeq ($(BUILD_ENV_),OSX_Universal)
     # MacOS Fat Binaries
-    CP_CXXFLAGS += -force_cpusubtype_ALL -arch i386 -arch x86_64
-    CP_CFLAGS += -force_cpusubtype_ALL -arch i386 -arch x86_64
-    LINKFLAGS += -force_cpusubtype_ALL -arch i386 -arch x86_64
+    CP_CXXFLAGS += -force_cpusubtype_ALL -arch arm64 -arch x86_64
+    CP_CFLAGS += -force_cpusubtype_ALL -arch arm64 -arch x86_64
+    LINKFLAGS += -force_cpusubtype_ALL -arch arm64 -arch x86_64
   endif
   LINKLIB = /usr/bin/libtool -static -o $@ $^
   LINKBIN = $(CXX) $(LINKFLAGS) -o $@ $^ $(LIBS)


### PR DESCRIPTION
This adds support for ARM64 and removes the support for i386.  Support for
i386 has been removed from XCode, and the building with this target fails
owing to missing libraries for this architecture.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- n/a Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
