### PR TITLE
Add a release action to github actions for pushing an image dockerhub

### DIFF
--- a/.github/workflows/release-packages.yaml
+++ b/.github/workflows/release-packages.yaml
@@ -206,3 +206,22 @@ jobs:
           asset_path: ${{ steps.create_packages.outputs.msi_installer }}
           asset_name: ${{ steps.create_packages.outputs.msi_name }}
           asset_content_type: application/x-msi
+
+  push-docker-image-dockerhub:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout CBMC source
+        uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      - name: Get release info
+        id: get_release_info
+        uses: bruceadams/get-release@v1.2.0
+      - name: Set Image Tag
+        run: echo "IMAGE_TAG=diffblue/cbmc:${{ steps.get_release_info.outputs.tag_name }}" >> $GITHUB_ENV
+      - name: Build docker image
+        run: docker build -t $IMAGE_TAG .
+      - name: Push docker image to DockerHub
+        run: |
+          docker login --username=dbcicprover --password=${{ secrets.DOCKERHUB_ACCESS_DB_CI_CPROVER }}
+          docker image push $IMAGE_TAG


### PR DESCRIPTION
This is a PR that adds a release action to our releases to build and push an image to the dockerhub registry.

This is experimental, as it's impossible to test this change in a private repository, as it depends on a number
of things (permissions to edit and make releases and push to dockerhub registries using a specific access token)
that are only available in this repository. 

As such, we will need this to get merged as in, and submit further improvements/fixes to it in a series of
later PRs, as we attempt to debug it making some experimental releases in CBMC to see this new release
action exercised.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
