### PR TITLE
Make simplify_exprt::get_values file-local

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -55,7 +55,6 @@ ForEachMacros: [
   'Forall_irep',
   'forall_named_irep',
   'Forall_named_irep',
-  'forall_value_list',
   'forall_symbol_base_map',
   'forall_subtypes',
   'Forall_subtypes']

--- a/regression/cbmc/inequality-with-constant-normalisation1/main.c
+++ b/regression/cbmc/inequality-with-constant-normalisation1/main.c
@@ -1,0 +1,20 @@
+#include <assert.h>
+
+#ifdef _MSC_VER
+#  define _Static_assert(x, m) static_assert(x, m)
+#endif
+
+int main()
+{
+  _Bool b1, b2;
+
+  int nc = (b1 ? 1 : 2) == (b2 ? 1 : 2);
+  assert(b1 != b2 || nc != 0);
+
+  // The following are true for all values of b1, b2, and the simplifier should
+  // be able to figure this out.
+  _Static_assert((b1 ? 1 : 1) == (b2 ? 1 : 1), "");
+  _Static_assert(((b1 ? 2 : 3) >= (b2 ? 1 : 2)) != 0, "");
+  _Static_assert(((b1 ? 0 : 1) >= (b2 ? 2 : 3)) == 0, "");
+  _Static_assert(((b1 ? 0 : 1) >= 2) == 0, "");
+}

--- a/regression/cbmc/inequality-with-constant-normalisation1/test.desc
+++ b/regression/cbmc/inequality-with-constant-normalisation1/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring

--- a/src/util/simplify_expr.cpp
+++ b/src/util/simplify_expr.cpp
@@ -1331,31 +1331,6 @@ simplify_exprt::simplify_dereference(const dereference_exprt &expr)
   return unchanged(expr);
 }
 
-bool simplify_exprt::get_values(
-  const exprt &expr,
-  value_listt &value_list)
-{
-  if(expr.is_constant())
-  {
-    mp_integer int_value;
-    if(to_integer(to_constant_expr(expr), int_value))
-      return true;
-
-    value_list.insert(int_value);
-
-    return false;
-  }
-  else if(expr.id()==ID_if)
-  {
-    const auto &if_expr = to_if_expr(expr);
-
-    return get_values(if_expr.true_case(), value_list) ||
-           get_values(if_expr.false_case(), value_list);
-  }
-
-  return true;
-}
-
 simplify_exprt::resultt<>
 simplify_exprt::simplify_lambda(const lambda_exprt &expr)
 {

--- a/src/util/simplify_expr_class.h
+++ b/src/util/simplify_expr_class.h
@@ -66,10 +66,6 @@ class unary_plus_exprt;
 class update_exprt;
 class with_exprt;
 
-#define forall_value_list(it, value_list) \
-  for(simplify_exprt::value_listt::const_iterator it=(value_list).begin(); \
-      it!=(value_list).end(); ++it)
-
 class simplify_exprt
 {
 public:
@@ -220,9 +216,6 @@ public:
   NODISCARD resultt<> simplify_rec(const exprt &);
 
   virtual bool simplify(exprt &expr);
-
-  typedef std::set<mp_integer> value_listt;
-  bool get_values(const exprt &expr, value_listt &value_list);
 
   static bool is_bitvector_type(const typet &type)
   {


### PR DESCRIPTION
This procedure is used in exactly one method, and does not use any class
members. Thus, move it to the file that method resides in. Also remove
the now-unnecessary forall_ macro and replace the previous use by ranged
for.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
