### PR TITLE
Remove unused simplify_exprt::objects_equal{,_address_of}

### DIFF
--- a/src/util/simplify_expr_class.h
+++ b/src/util/simplify_expr_class.h
@@ -59,7 +59,6 @@ class popcount_exprt;
 class refined_string_exprt;
 class shift_exprt;
 class sign_exprt;
-class tvt;
 class typecast_exprt;
 class unary_exprt;
 class unary_minus_exprt;
@@ -172,10 +171,8 @@ public:
   NODISCARD resultt<> simplify_byte_extract(const byte_extract_exprt &);
   NODISCARD resultt<> simplify_pointer_object(const unary_exprt &);
   NODISCARD resultt<> simplify_object_size(const unary_exprt &);
-  NODISCARD resultt<> simplify_dynamic_size(const unary_exprt &);
   NODISCARD resultt<> simplify_is_dynamic_object(const unary_exprt &);
   NODISCARD resultt<> simplify_is_invalid_pointer(const unary_exprt &);
-  NODISCARD resultt<> simplify_same_object(const unary_exprt &);
   NODISCARD resultt<> simplify_good_pointer(const unary_exprt &);
   NODISCARD resultt<> simplify_object(const exprt &);
   NODISCARD resultt<> simplify_unary_minus(const unary_minus_exprt &);
@@ -205,8 +202,6 @@ public:
   bool simplify_if_disj(exprt &expr, const exprt &cond);
   bool simplify_if_branch(exprt &trueexpr, exprt &falseexpr, const exprt &cond);
   bool simplify_if_cond(exprt &expr);
-  static tvt objects_equal(const exprt &a, const exprt &b);
-  static tvt objects_equal_address_of(const exprt &a, const exprt &b);
   NODISCARD resultt<> simplify_address_of_arg(const exprt &);
   NODISCARD resultt<>
   simplify_inequality_both_constant(const binary_relation_exprt &);

--- a/src/util/simplify_expr_pointer.cpp
+++ b/src/util/simplify_expr_pointer.cpp
@@ -18,7 +18,6 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "prefix.h"
 #include "std_expr.h"
 #include "string_constant.h"
-#include "threeval.h"
 
 static bool is_dereference_integer_object(
   const exprt &expr,
@@ -656,56 +655,6 @@ simplify_exprt::simplify_is_invalid_pointer(const unary_exprt &expr)
     return unchanged(expr);
   else
     return std::move(new_expr);
-}
-
-tvt simplify_exprt::objects_equal(const exprt &a, const exprt &b)
-{
-  if(a==b)
-    return tvt(true);
-
-  if(a.id() == ID_address_of && b.id() == ID_address_of)
-  {
-    return objects_equal_address_of(
-      to_address_of_expr(a).object(), to_address_of_expr(b).object());
-  }
-
-  if(a.id()==ID_constant && b.id()==ID_constant &&
-     a.get(ID_value)==ID_NULL && b.get(ID_value)==ID_NULL)
-    return tvt(true);
-
-  if(a.id()==ID_constant && b.id()==ID_address_of &&
-     a.get(ID_value)==ID_NULL)
-    return tvt(false);
-
-  if(b.id()==ID_constant && a.id()==ID_address_of &&
-     b.get(ID_value)==ID_NULL)
-    return tvt(false);
-
-  return tvt::unknown();
-}
-
-tvt simplify_exprt::objects_equal_address_of(const exprt &a, const exprt &b)
-{
-  if(a==b)
-    return tvt(true);
-
-  if(a.id()==ID_symbol && b.id()==ID_symbol)
-  {
-    if(to_symbol_expr(a).get_identifier() == to_symbol_expr(b).get_identifier())
-      return tvt(true);
-  }
-  else if(a.id()==ID_index && b.id()==ID_index)
-  {
-    return objects_equal_address_of(
-      to_index_expr(a).array(), to_index_expr(b).array());
-  }
-  else if(a.id()==ID_member && b.id()==ID_member)
-  {
-    return objects_equal_address_of(
-      to_member_expr(a).compound(), to_member_expr(b).compound());
-  }
-
-  return tvt::unknown();
 }
 
 simplify_exprt::resultt<>


### PR DESCRIPTION
These methods are not documented and never called from anywhere.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
