### PR TITLE
Make computation of widest union member widely available

### DIFF
--- a/src/util/pointer_offset_size.cpp
+++ b/src/util/pointer_offset_size.cpp
@@ -154,23 +154,16 @@ pointer_offset_bits(const typet &type, const namespacet &ns)
   else if(type.id()==ID_union)
   {
     const union_typet &union_type=to_union_type(type);
-    mp_integer result=0;
 
-    // compute max
+    if(union_type.components().empty())
+      return mp_integer{0};
 
-    for(const auto &c : union_type.components())
-    {
-      const typet &subtype = c.type();
-      auto sub_size = pointer_offset_bits(subtype, ns);
+    const auto widest_member = union_type.find_widest_union_component(ns);
 
-      if(!sub_size.has_value())
-        return {};
-
-      if(*sub_size > result)
-        result = *sub_size;
-    }
-
-    return result;
+    if(widest_member.has_value())
+      return widest_member->second;
+    else
+      return {};
   }
   else if(type.id()==ID_signedbv ||
           type.id()==ID_unsignedbv ||

--- a/src/util/std_types.cpp
+++ b/src/util/std_types.cpp
@@ -294,7 +294,7 @@ union_typet::find_widest_union_component(const namespacet &ns) const
 {
   const union_typet::componentst &comps = components();
 
-  mp_integer max_width = 0;
+  optionalt<mp_integer> max_width;
   typet max_comp_type;
   irep_idt max_comp_name;
 
@@ -302,7 +302,10 @@ union_typet::find_widest_union_component(const namespacet &ns) const
   {
     auto element_width = pointer_offset_bits(comp.type(), ns);
 
-    if(!element_width.has_value() || *element_width <= max_width)
+    if(!element_width.has_value())
+      return {};
+
+    if(max_width.has_value() && *element_width <= *max_width)
       continue;
 
     max_width = *element_width;
@@ -310,9 +313,9 @@ union_typet::find_widest_union_component(const namespacet &ns) const
     max_comp_name = comp.get_name();
   }
 
-  if(max_width == 0)
+  if(!max_width.has_value())
     return {};
   else
     return std::make_pair(
-      struct_union_typet::componentt{max_comp_name, max_comp_type}, max_width);
+      struct_union_typet::componentt{max_comp_name, max_comp_type}, *max_width);
 }

--- a/src/util/std_types.cpp
+++ b/src/util/std_types.cpp
@@ -15,6 +15,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "arith_tools.h"
 #include "bv_arithmetic.h"
 #include "namespace.h"
+#include "pointer_offset_size.h"
 #include "std_expr.h"
 #include "string2int.h"
 
@@ -286,4 +287,32 @@ const constant_exprt &vector_typet::size() const
 constant_exprt &vector_typet::size()
 {
   return static_cast<constant_exprt &>(add(ID_size));
+}
+
+optionalt<std::pair<struct_union_typet::componentt, mp_integer>>
+union_typet::find_widest_union_component(const namespacet &ns) const
+{
+  const union_typet::componentst &comps = components();
+
+  mp_integer max_width = 0;
+  typet max_comp_type;
+  irep_idt max_comp_name;
+
+  for(const auto &comp : comps)
+  {
+    auto element_width = pointer_offset_bits(comp.type(), ns);
+
+    if(!element_width.has_value() || *element_width <= max_width)
+      continue;
+
+    max_width = *element_width;
+    max_comp_type = comp.type();
+    max_comp_name = comp.get_name();
+  }
+
+  if(max_width == 0)
+    return {};
+  else
+    return std::make_pair(
+      struct_union_typet::componentt{max_comp_name, max_comp_type}, max_width);
 }

--- a/src/util/std_types.h
+++ b/src/util/std_types.h
@@ -401,9 +401,8 @@ public:
   {
   }
 
-  /// Determine the member of maximum fixed bit width in a union type. If no
-  /// member, or no member of fixed and non-zero width can be found, return
-  /// nullopt.
+  /// Determine the member of maximum bit width in a union type. If no member,
+  /// or a member of non-fixed width can be found, return nullopt.
   /// \param ns: Namespace to resolve tag types.
   /// \return Pair of a componentt pointing to the maximum fixed bit-width
   ///   member of the union type and the bit width of that member.

--- a/src/util/std_types.h
+++ b/src/util/std_types.h
@@ -400,6 +400,15 @@ public:
     : struct_union_typet(ID_union, std::move(_components))
   {
   }
+
+  /// Determine the member of maximum fixed bit width in a union type. If no
+  /// member, or no member of fixed and non-zero width can be found, return
+  /// nullopt.
+  /// \param ns: Namespace to resolve tag types.
+  /// \return Pair of a componentt pointing to the maximum fixed bit-width
+  ///   member of the union type and the bit width of that member.
+  optionalt<std::pair<struct_union_typet::componentt, mp_integer>>
+  find_widest_union_component(const namespacet &ns) const;
 };
 
 /// Check whether a reference to a typet is a \ref union_typet.


### PR DESCRIPTION
This functionality is of use beyond byte-operator lowering.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
