### PR TITLE
First set of fixes to Dockerhub push action.

### DIFF
--- a/.github/workflows/release-packages.yaml
+++ b/.github/workflows/release-packages.yaml
@@ -118,6 +118,7 @@ jobs:
 
 
   homebrew-pr:
+    if: ${{ false }}  # disable for now
     runs-on: macos-10.15
     steps:
       - name: Get release tag name

--- a/.github/workflows/release-packages.yaml
+++ b/.github/workflows/release-packages.yaml
@@ -210,6 +210,8 @@ jobs:
 
   push-docker-image-dockerhub:
     runs-on: ubuntu-20.04
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout CBMC source
         uses: actions/checkout@v2


### PR DESCRIPTION
This PR contains two small fixes to the Dockerhub image push action we wrote:

1. Deactivates the Homebrew PR action temporarily, so that we don't spam it
    everytime we make a new experimental release.
2. Adds a missing `GITHUB_TOKEN` within the scope of the Dockerhub image
    push action so it can have access to metadata required (release version) to
    name the docker image appropriately.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
