### PR TITLE
[CI] Cleanup dockerhub release action.

### DIFF
--- a/.github/workflows/regular-release.yaml
+++ b/.github/workflows/regular-release.yaml
@@ -8,15 +8,20 @@ name: Create Release
 jobs:
   get-version-information:
     name: Get Version Information
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     outputs:
-      version: ${{ steps.split.outputs._2 }}
+      version: ${{ steps.split-version.outputs._1 }}
     steps:
       - uses: jungwinter/split@v1
         id: split
         with:
           msg: ${{ github.ref }}
           seperator: '/'
+      - uses: jungwinter/split@v1
+        id: split-version
+        with:
+          msg: ${{ steps.split.outputs._2 }}
+          seperator: '-'
   perform-release:
     name: Perform Release
     runs-on: ubuntu-20.04
@@ -55,24 +60,39 @@ jobs:
 
             ```sh
             # Ubuntu 18:
-            $ dpkg -i ubuntu-18.04-${{ env.CBMC_TAG }}-Linux.deb
+            $ dpkg -i ubuntu-18.04-cbmc-${{ env.CBMC_TAG }}-Linux.deb
             # Ubuntu 20:
-            $ dpkg -i ubuntu-20.04-${{ env.CBMC_TAG }}-Linux.deb
+            $ dpkg -i ubuntu-20.04-cbmc-${{ env.CBMC_TAG }}-Linux.deb
             ```
 
             ## Windows
 
-            On Windows, install CBMC by downloading the `${{ env.CBMC_TAG }}-win64.msi` installer below, double-clicking on the installer to run it, and adding the folder `C:\Program Files\cbmc\bin` in your `PATH` environment variable.
+            On Windows, install CBMC by downloading the `cbmc-${{ env.CBMC_TAG }}-win64.msi` installer below, double-clicking on the installer to run it, and adding the folder `C:\Program Files\cbmc\bin` in your `PATH` environment variable.
 
             For installation from the windows command prompt, run:
 
             ```sh
-            msiexec /i ${{ env.CBMC_TAG }}-win64.msi
+            msiexec /i cbmc-${{ env.CBMC_TAG }}-win64.msi
             PATH="C:\Program Files\cbmc\bin";%PATH%
             ```
 
             Note that we depend on the Visual C++ redistributables. You likely already have these, if not please download and run vcredist.x64.exe from Microsoft to install them prior to running cbmc, or make sure you have Visual Studio 2019 installed.
 
             You can download either [Visual Studio 2019 Community Edition](https://visualstudio.microsoft.com/vs/community/) or the [Visual C++ Redistributables](https://support.microsoft.com/en-gb/help/2977003/the-latest-supported-visual-c-downloads) from Microsoft for free.
+
+            ## Docker
+
+            To run the CProver suite of tools under a Docker container, make sure that
+            [Docker](https://www.docker.com/) is already installed in your system and
+            set up correctly, and then issue:
+
+            ```sh
+            $ docker run -it diffblue/cbmc:${{ env.CBMC-TAG }}
+            #
+            ```
+
+            That will initialise an execution of the container based on the image pushed
+            as part of this release. The CProver tools are present in the `$PATH` of the
+            container.
           draft: false
           prerelease: false

--- a/.github/workflows/release-packages.yaml
+++ b/.github/workflows/release-packages.yaml
@@ -118,7 +118,6 @@ jobs:
 
 
   homebrew-pr:
-    if: ${{ false }}  # disable for now
     runs-on: macos-10.15
     steps:
       - name: Get release tag name

--- a/.github/workflows/release-packages.yaml
+++ b/.github/workflows/release-packages.yaml
@@ -226,3 +226,6 @@ jobs:
         run: |
           echo ${{ secrets.DOCKERHUB_ACCESS_DB_CI_CPROVER }} | docker login --username=dbcicprover --password-stdin
           docker image push "$IMAGE_TAG"
+          # For security reasons remove stored login credentials from
+          # configuration file they are stored at by docker login.
+          docker logout


### PR DESCRIPTION
This is the last cleanup of the dockerhub image push action, and finalises this line of work by doing the following:

* Revert the commit that temporarily disabled the homebrew PR push per release (was necessary so we didn't spam homebrew with low quality releases while testing).
* Adds a `docker logout` instruction to the action for better security of the credentials.
* Adds documentation to the release page on how to run cbmc in a docker container.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
