### PR TITLE
Fix unpack_array_vector to produce an array of bytes

### DIFF
--- a/regression/cbmc-library/memcpy-08/main.c
+++ b/regression/cbmc-library/memcpy-08/main.c
@@ -1,0 +1,22 @@
+#include <stdlib.h>
+#include <string.h>
+
+int __VERIFIER_nondet_int();
+
+void main()
+{
+  size_t size;
+  __CPROVER_assume(size >= 2);
+  // limit the size to ensure size * sizeof(int) wouldn't overflow, and we don't
+  // reach the maximum object size
+  __CPROVER_assume(size <= 1000);
+
+  int *dest_buffer = malloc(size * sizeof(int));
+  int *src_buffer = malloc(size * sizeof(int));
+  src_buffer[0] = 42;
+  src_buffer[1] = __VERIFIER_nondet_int();
+
+  memcpy(dest_buffer, src_buffer, size * sizeof(int));
+  __CPROVER_assert(dest_buffer[0] == 42, "should pass");
+  __CPROVER_assert(dest_buffer[1] == 42, "should fail");
+}

--- a/regression/cbmc-library/memcpy-08/test.desc
+++ b/regression/cbmc-library/memcpy-08/test.desc
@@ -1,0 +1,11 @@
+CORE
+main.c
+
+^\[main.assertion.1\] line 20 should pass: SUCCESS$
+^\[main.assertion.2\] line 21 should fail: FAILURE$
+^\*\* 1 of \d+ failed
+^VERIFICATION FAILED$
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring

--- a/src/solvers/lowering/byte_operators.cpp
+++ b/src/solvers/lowering/byte_operators.cpp
@@ -476,23 +476,21 @@ static exprt unpack_array_vector(
     }
 
     optionalt<exprt> array_vector_size;
-    optionalt<typet> subtype;
     if(src.type().id() == ID_vector)
     {
       array_vector_size = to_vector_type(src.type()).size();
-      subtype = to_vector_type(src.type()).subtype();
     }
     else
     {
       array_vector_size = to_array_type(src.type()).size();
-      subtype = to_array_type(src.type()).subtype();
     }
+
 
     return array_comprehension_exprt{
       std::move(array_comprehension_index),
       std::move(body),
       array_typet{
-        *subtype,
+        bv_typet{8},
         mult_exprt{*array_vector_size,
                    from_integer(el_bytes, array_vector_size->type())}}};
   }
@@ -1034,6 +1032,9 @@ exprt lower_byte_extract(const byte_extract_exprt &src, const namespacet &ns)
   byte_extract_exprt unpacked(src);
   unpacked.op() = unpack_rec(
     src.op(), little_endian, lower_bound_int_opt, upper_bound_int_opt, ns);
+  CHECK_RETURN(
+    to_bitvector_type(to_type_with_subtype(unpacked.op().type()).subtype())
+      .get_width() == 8);
 
   if(src.type().id()==ID_array)
   {

--- a/src/solvers/lowering/byte_operators.cpp
+++ b/src/solvers/lowering/byte_operators.cpp
@@ -475,24 +475,17 @@ static exprt unpack_array_vector(
         body};
     }
 
-    optionalt<exprt> array_vector_size;
-    if(src.type().id() == ID_vector)
-    {
-      array_vector_size = to_vector_type(src.type()).size();
-    }
-    else
-    {
-      array_vector_size = to_array_type(src.type()).size();
-    }
-
+    const exprt array_vector_size = src.type().id() == ID_vector
+                                      ? to_vector_type(src.type()).size()
+                                      : to_array_type(src.type()).size();
 
     return array_comprehension_exprt{
       std::move(array_comprehension_index),
       std::move(body),
       array_typet{
         bv_typet{8},
-        mult_exprt{*array_vector_size,
-                   from_integer(el_bytes, array_vector_size->type())}}};
+        mult_exprt{array_vector_size,
+                   from_integer(el_bytes, array_vector_size.type())}}};
   }
 
   exprt::operandst byte_operands;


### PR DESCRIPTION
We wrongly created a return type (though not the underlying expression,
which was correct!) as an array of elements of the original subtype,
even though the sole purpose of unpack_array_vector is to turn the
original subtype into a sequence of bytes.

We seemingly neither had a test covering this code nor did we have
additional result verification in place. Both are now rectified: a new
regression test is added, and an invariant is checked right after
returning from unpack_rec (which may invoke unpack_array_vector).

Fixes: #5718

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
