### PR TITLE
lower_byte_extract: Remove type-inconsistent hack

### DIFF
--- a/src/solvers/lowering/byte_operators.cpp
+++ b/src/solvers/lowering/byte_operators.cpp
@@ -1065,9 +1065,6 @@ exprt lower_byte_extract(const byte_extract_exprt &src, const namespacet &ns)
     if(element_bits.has_value() && *element_bits >= 1 && *element_bits % 8 == 0)
     {
       auto num_elements = numeric_cast<std::size_t>(array_type.size());
-      // XXX: This can't be right -- unpacked is a byte array, whereas array_type may have larger elements
-      if(!num_elements.has_value() && unpacked.op().id() == ID_array)
-        num_elements = unpacked.op().operands().size();
 
       if(num_elements.has_value())
       {


### PR DESCRIPTION
We can nowadays properly handle the case of byte-extracting a
non-constant-sized array out of a fixed-size data structure via
array-comprehension expressions. The byte_update11 regression test used
to take this branch, and continues to succeed after this cleanup.

@smowton This is the follow-up to the comment you added in #5019.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
