### PR TITLE
Make guard_exprt::operator-= work with individual conditions

### DIFF
--- a/regression/cbmc-concurrency/atomic_section_sc7/test-guard.desc
+++ b/regression/cbmc-concurrency/atomic_section_sc7/test-guard.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.c
 --program-only
 ^EXIT=0$

--- a/src/analyses/guard_expr.cpp
+++ b/src/analyses/guard_expr.cpp
@@ -65,8 +65,42 @@ void guard_exprt::add(const exprt &expr)
 
 guard_exprt &operator-=(guard_exprt &g1, const guard_exprt &g2)
 {
-  if(g1.expr.id() != ID_and || g2.expr.id() != ID_and)
+  if(g1.expr.id() != ID_and)
+  {
+    if(g2.expr.id() != ID_and)
+    {
+      if(g1.expr == g2.expr)
+        g1.expr = true_exprt{};
+    }
+    else
+    {
+      for(const auto &op : g2.expr.operands())
+      {
+        if(g1.expr == op)
+        {
+          g1.expr = true_exprt{};
+          break;
+        }
+      }
+    }
+
     return g1;
+  }
+
+  if(g2.expr.id() != ID_and)
+  {
+    exprt::operandst &op1 = g1.expr.operands();
+    for(exprt::operandst::iterator it = op1.begin(); it != op1.end(); ++it)
+    {
+      if(g1.expr == g2.expr)
+      {
+        op1.erase(it);
+        break;
+      }
+    }
+
+    return g1;
+  }
 
   sort_and_join(g1.expr);
   exprt g2_sorted = g2.as_expr();


### PR DESCRIPTION
Before, operator-= would only apply when both of the operands were
conjunctions. Yet it is perfectly safe use when one or both operands
aren't conjunctions.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
