### PR TITLE
Support c_bool in expr2bits/bits2expr

### DIFF
--- a/regression/cbmc/Bool5/main.c
+++ b/regression/cbmc/Bool5/main.c
@@ -1,0 +1,18 @@
+#include <assert.h>
+#include <string.h>
+
+struct conft
+{
+  _Bool red;
+  int one;
+};
+
+int main()
+{
+  struct conft conf_init = {0, 1};
+  struct conft my_conf;
+  memcpy((char *)&my_conf, (char *)&conf_init, sizeof(struct conft));
+  int num = my_conf.one;
+  assert(num == 1);
+  return 0;
+}

--- a/regression/cbmc/Bool5/test.desc
+++ b/regression/cbmc/Bool5/test.desc
@@ -1,0 +1,9 @@
+CORE
+main.c
+
+Generated 4 VCC\(s\), 0 remaining after simplification
+^VERIFICATION SUCCESSFUL$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring

--- a/src/util/simplify_utils.cpp
+++ b/src/util/simplify_utils.cpp
@@ -191,7 +191,7 @@ optionalt<exprt> bits2expr(
     type.id() == ID_unsignedbv || type.id() == ID_signedbv ||
     type.id() == ID_floatbv || type.id() == ID_fixedbv ||
     type.id() == ID_c_bit_field || type.id() == ID_pointer ||
-    type.id() == ID_bv)
+    type.id() == ID_bv || type.id() == ID_c_bool)
   {
     endianness_mapt map(type, little_endian, ns);
 
@@ -385,7 +385,8 @@ expr2bits(const exprt &expr, bool little_endian, const namespacet &ns)
     if(
       type.id() == ID_unsignedbv || type.id() == ID_signedbv ||
       type.id() == ID_floatbv || type.id() == ID_fixedbv ||
-      type.id() == ID_c_bit_field || type.id() == ID_bv)
+      type.id() == ID_c_bit_field || type.id() == ID_bv ||
+      type.id() == ID_c_bool)
     {
       const auto width = to_bitvector_type(type).get_width();
 


### PR DESCRIPTION
This enables simplification of byte extracts from constants that include
c_bool-typed elements, as demonstrated by the regression test originally
provided in #5542.

Fixes: #5542.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
