### PR TITLE
Use curl as default downloader for solvers

### DIFF
--- a/.github/workflows/build-and-test-Xen.yaml
+++ b/.github/workflows/build-and-test-Xen.yaml
@@ -17,7 +17,7 @@ jobs:
           # user input
           DEBIAN_FRONTEND: noninteractive
         run: |
-          sudo apt-get install --no-install-recommends -y coreutils  build-essential gcc git make flex bison software-properties-common libwww-perl python
+          sudo apt-get install --no-install-recommends -y coreutils  build-essential gcc git make flex bison software-properties-common curl python
           sudo apt-get install --no-install-recommends -y bin86 gdb bcc liblzma-dev python-dev gettext iasl uuid-dev libncurses5-dev libncursesw5-dev pkg-config
           sudo apt-get install --no-install-recommends -y libgtk2.0-dev libyajl-dev sudo time ccache
 

--- a/COMPILING.md
+++ b/COMPILING.md
@@ -21,17 +21,17 @@ We assume that you have a Debian/Ubuntu or Red Hat-like distribution.
    The GNU Make needs to be version 3.81 or higher.
    On Debian-like distributions, do as root:
    ```
-   apt-get install g++ gcc flex bison make git libwww-perl patch
+   apt-get install g++ gcc flex bison make git curl patch
    ```
    On Red Hat/Fedora or derivates, do as root:
    ```
-   dnf install gcc gcc-c++ flex bison perl-libwww-perl patch
+   dnf install gcc gcc-c++ flex bison curl patch
    ```
    Note that you need g++ version 5.0 or newer.
 
    On Amazon Linux and similar distributions, do as root:
    ```
-   yum install gcc72-c++ flex bison perl-libwww-perl patch tar
+   yum install gcc72-c++ flex bison curl patch tar
    ```
 
    To compile JBMC, you additionally need the JDK and Maven 3. You also
@@ -153,7 +153,7 @@ Follow these instructions:
 
 1. First install Cygwin, then from the Cygwin setup facility install the
    following packages: `flex, bison, tar, gzip, git, make, wget, patch,
-   libwww-perl`.
+   curl`.
 2. Get the CBMC source via
    ```
    git clone https://github.com/diffblue/cbmc cbmc-git

--- a/buildspec-linux-clang-3.8.yml
+++ b/buildspec-linux-clang-3.8.yml
@@ -10,7 +10,7 @@ phases:
     commands:
       - sed -i 's#/archive.ubuntu.com#/us-east-1.ec2.archive.ubuntu.com#g' /etc/apt/sources.list
       - apt-get update -y
-      - apt-get install -y clang-3.8 flex bison make git libwww-perl patch ccache libc6-dev-i386 jq openjdk-8-jdk maven
+      - apt-get install -y clang-3.8 flex bison make git curl patch ccache libc6-dev-i386 jq openjdk-8-jdk maven
   build:
     commands:
       - echo Build started on `date`

--- a/buildspec-linux-clang.yml
+++ b/buildspec-linux-clang.yml
@@ -14,7 +14,7 @@ phases:
       - wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
       - add-apt-repository 'deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-8 main'
       - apt-get update -y
-      - apt-get install -y clang-8 flex bison make git libwww-perl patch ccache libc6-dev-i386 jq gdb
+      - apt-get install -y clang-8 flex bison make git curl patch ccache libc6-dev-i386 jq gdb
   build:
     commands:
       - echo Build started on `date`

--- a/buildspec-linux-cmake-gcc-cov.yml
+++ b/buildspec-linux-cmake-gcc-cov.yml
@@ -13,7 +13,7 @@ phases:
       - sed -i 's#/archive.ubuntu.com#/us-east-1.ec2.archive.ubuntu.com#g' /etc/apt/sources.list
       - add-apt-repository ppa:ubuntu-toolchain-r/test
       - apt-get update -y
-      - apt-get install -y flex bison make git libwww-perl patch ccache libc6-dev-i386 jq lcov cmake curl gdb
+      - apt-get install -y flex bison make git curl patch ccache libc6-dev-i386 jq lcov cmake curl gdb
   build:
     commands:
       - echo Build started on `date`

--- a/buildspec-linux-cmake-gcc.yml
+++ b/buildspec-linux-cmake-gcc.yml
@@ -12,7 +12,7 @@ phases:
     commands:
       - sed -i 's#/archive.ubuntu.com#/us-east-1.ec2.archive.ubuntu.com#g' /etc/apt/sources.list
       - apt-get update -y
-      - apt-get install -y flex bison make git libwww-perl patch ccache libc6-dev-i386 jq cmake
+      - apt-get install -y flex bison make git curl patch ccache libc6-dev-i386 jq cmake
   build:
     commands:
       - echo Build started on `date`

--- a/buildspec-linux-make-gcc-cov.yml
+++ b/buildspec-linux-make-gcc-cov.yml
@@ -12,7 +12,7 @@ phases:
     commands:
       - sed -i 's#/archive.ubuntu.com#/us-east-1.ec2.archive.ubuntu.com#g' /etc/apt/sources.list
       - apt-get update -y
-      - apt-get install -y flex bison make git libwww-perl patch ccache libc6-dev-i386 jq gdb lcov curl
+      - apt-get install -y flex bison make git curl patch ccache libc6-dev-i386 jq gdb lcov curl
   build:
     commands:
       - echo Build started on `date`

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -13,7 +13,7 @@ phases:
     commands:
       - sed -i 's#/archive.ubuntu.com#/us-east-1.ec2.archive.ubuntu.com#g' /etc/apt/sources.list
       - apt-get update -y
-      - apt-get install -y flex bison make git libwww-perl patch ccache libc6-dev-i386 jq gdb libxml2-utils
+      - apt-get install -y flex bison make git curl patch ccache libc6-dev-i386 jq gdb libxml2-utils
   build:
     commands:
       - echo Build started on `date`

--- a/integration/xen/Dockerfile
+++ b/integration/xen/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:16.04
 
 RUN apt-get update && apt-get --no-install-recommends -y install \
         build-essential gcc git make flex bison \
-        software-properties-common libwww-perl python \
+        software-properties-common curl python \
         bin86 gdb bcc liblzma-dev python-dev gettext iasl \
         uuid-dev libncurses5-dev libncursesw5-dev pkg-config \
         libgtk2.0-dev libyajl-dev sudo time

--- a/src/Makefile
+++ b/src/Makefile
@@ -115,7 +115,7 @@ $(patsubst %, %_clean, $(DIRS)):
 
 # minisat2 and glucose download, for your convenience
 
-DOWNLOADER = lwp-download
+DOWNLOADER = curl -L --remote-name
 TAR = tar
 
 minisat2-download:
@@ -155,11 +155,13 @@ glucose-download:
 cadical_release = rel-06w
 cadical-download:
 	@echo "Downloading CaDiCaL $(cadical_release)"
-	@curl -L https://github.com/arminbiere/cadical/archive/$(cadical_release).tar.gz | tar xz
+	@$(DOWNLOADER) https://github.com/arminbiere/cadical/archive/$(cadical_release).tar.gz
+	@$(TAR) xfz $(cadical_release).tar.gz
 	@rm -Rf ../cadical
 	@mv cadical-$(cadical_release) ../cadical
 	@(cd ../cadical; patch -p1 < ../scripts/cadical-patch)
 	@cd ../cadical && CXX=$(CXX) CXXFLAGS=-O3 ./configure --debug && make
+	@$(RM) $(cadical_release).tar.gz
 
 doc :
 	doxygen


### PR DESCRIPTION
Switching from lwp-download to curl to solve problems with SSL
certificates on OS X (cf. #5169). These days, curl is available by
default on most systems anyway, and should thus be easy to use for
everyone. If need be, running `make DOWNLOADER=lwp-download` would yield
the previous behaviour.

Fixes: #5169

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [x] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
