### PR TITLE
Handle bool expressions in implicit_typecast_arithmetic

### DIFF
--- a/regression/ansi-c/int128_and_bool1/main.c
+++ b/regression/ansi-c/int128_and_bool1/main.c
@@ -1,0 +1,6 @@
+int main(int argc, char *argv[])
+{
+  unsigned __int128 z;
+  z = (unsigned __int128)argc;
+  z += (argc < 1);
+}

--- a/regression/ansi-c/int128_and_bool1/test.desc
+++ b/regression/ansi-c/int128_and_bool1/test.desc
@@ -1,0 +1,7 @@
+CORE gcc-only
+main.c
+
+^EXIT=0$
+^SIGNAL=0$
+--
+^CONVERSION ERROR$

--- a/regression/cbmc/enum9/main.c
+++ b/regression/cbmc/enum9/main.c
@@ -1,0 +1,25 @@
+#include <limits.h>
+
+enum E
+{
+  V1 = 1,
+  V2 = 2
+};
+
+struct B
+{
+  unsigned b : 2;
+};
+
+int main()
+{
+  unsigned __int128 int x;
+  __CPROVER_assume(x < (~(unsigned __int128)0) - 4);
+
+  enum E e;
+  __CPROVER_assume(__CPROVER_enum_is_in_range(e));
+  __CPROVER_assert(x + e > x, "long long plus enum");
+
+  struct B b;
+  __CPROVER_assert(x + b.b >= x, "long long plus bitfield");
+}

--- a/regression/cbmc/enum9/test.desc
+++ b/regression/cbmc/enum9/test.desc
@@ -1,0 +1,9 @@
+CORE gcc-only
+main.c
+
+^VERIFICATION SUCCESSFUL$
+^EXIT=0$
+^SIGNAL=0$
+--
+^CONVERSION ERROR$
+^warning: ignoring

--- a/src/ansi-c/c_typecast.cpp
+++ b/src/ansi-c/c_typecast.cpp
@@ -650,24 +650,8 @@ void c_typecastt::implicit_typecast_arithmetic(
 
   if(max_type==LARGE_SIGNED_INT || max_type==LARGE_UNSIGNED_INT)
   {
-    // get the biggest width of both
-    std::size_t width1 = to_bitvector_type(type1).get_width();
-    std::size_t width2 = to_bitvector_type(type2).get_width();
-
     // produce type
-    typet result_type;
-
-    if(width1==width2)
-    {
-      if(max_type==LARGE_SIGNED_INT)
-        result_type=signedbv_typet(width1);
-      else
-        result_type=unsignedbv_typet(width1);
-    }
-    else if(width1>width2)
-      result_type=type1;
-    else // width1<width2
-      result_type=type2;
+    typet result_type = (max_type == c_type1) ? type1 : type2;
 
     do_typecast(expr1, result_type);
     do_typecast(expr2, result_type);


### PR DESCRIPTION
We use Booleans instead of int as type of binary predicates. This must
not preclude mixing binary predicates with bitvector-typed expressions.

Fixes: #5103

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
