### PR TITLE
[CI] Get version information from $GITHUB_REF.

### DIFF
--- a/.github/workflows/release-packages.yaml
+++ b/.github/workflows/release-packages.yaml
@@ -210,20 +210,16 @@ jobs:
 
   push-docker-image-dockerhub:
     runs-on: ubuntu-20.04
-    env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout CBMC source
         uses: actions/checkout@v2
         with:
           submodules: recursive
-      - name: Get release info
-        id: get_release_info
-        uses: bruceadams/get-release@v1.2.0
       - name: Set Image Tag
         run: |
-          echo ${{  steps.get_release_info.outputs.tag_name }}
-          VERSION = ${{ steps.get_release_info.outputs.tag_name }}
+          echo ${{ github.ref }}
+          echo $GITHUB_REF
+          echo $GITHUB_REF | cut -d "/" -f 3 >> $VERSION
           arrVERSION=(${VERSION//-/ })
           echo "IMAGE_TAG=diffblue/cbmc:${arrVERSION[1]}" >> $GITHUB_ENV
       - name: Build docker image


### PR DESCRIPTION
This deactivates the usage of the bruce_adams/get-release-info
action which was problematic for our usage, in favour of getting
release info from github environment variables.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
