### PR TITLE
Refine recursive calls within the simplifier

### DIFF
--- a/src/util/simplify_expr_array.cpp
+++ b/src/util/simplify_expr_array.cpp
@@ -183,15 +183,16 @@ simplify_exprt::simplify_index(const index_exprt &expr)
         return unchanged(expr);
 
       // add offset to index
-      mult_exprt offset(
-        from_integer(*sub_size, byte_extract_expr.offset().type()), index);
+      exprt offset = simplify_mult(mult_exprt{
+        from_integer(*sub_size, byte_extract_expr.offset().type()), index});
       exprt final_offset =
-        simplify_node(plus_exprt(byte_extract_expr.offset(), offset));
+        simplify_plus(plus_exprt(byte_extract_expr.offset(), offset));
 
-      exprt result_expr(array.id(), expr.type());
-      result_expr.add_to_operands(byte_extract_expr.op(), final_offset);
+      auto result_expr = byte_extract_expr;
+      result_expr.type() = expr.type();
+      result_expr.offset() = final_offset;
 
-      return changed(simplify_rec(result_expr));
+      return changed(simplify_byte_extract(result_expr));
     }
   }
   else if(array.id()==ID_if)

--- a/src/util/simplify_expr_boolean.cpp
+++ b/src/util/simplify_expr_boolean.cpp
@@ -38,7 +38,7 @@ simplify_exprt::resultt<> simplify_exprt::simplify_boolean(const exprt &expr)
     binary_exprt new_expr = implies_expr;
     new_expr.id(ID_or);
     new_expr.op0() = simplify_not(not_exprt(new_expr.op0()));
-    return changed(simplify_node(new_expr));
+    return changed(simplify_boolean(new_expr));
   }
   else if(expr.id()==ID_xor)
   {
@@ -204,18 +204,14 @@ simplify_exprt::resultt<> simplify_exprt::simplify_not(const not_exprt &expr)
   else if(op.id()==ID_exists) // !(exists: a) <-> forall: not a
   {
     auto const &op_as_exists = to_exists_expr(op);
-    forall_exprt rewritten_op(
-      op_as_exists.symbol(), not_exprt(op_as_exists.where()));
-    rewritten_op.where() = simplify_node(rewritten_op.where());
-    return std::move(rewritten_op);
+    return forall_exprt{op_as_exists.symbol(),
+                        simplify_not(not_exprt(op_as_exists.where()))};
   }
   else if(op.id() == ID_forall) // !(forall: a) <-> exists: not a
   {
     auto const &op_as_forall = to_forall_expr(op);
-    exists_exprt rewritten_op(
-      op_as_forall.symbol(), not_exprt(op_as_forall.where()));
-    rewritten_op.where() = simplify_node(rewritten_op.where());
-    return std::move(rewritten_op);
+    return exists_exprt{op_as_forall.symbol(),
+                        simplify_not(not_exprt(op_as_forall.where()))};
   }
 
   return unchanged(expr);

--- a/src/util/simplify_expr_if.cpp
+++ b/src/util/simplify_expr_if.cpp
@@ -357,24 +357,24 @@ simplify_exprt::resultt<> simplify_exprt::simplify_if(const if_exprt &expr)
       else if(falsevalue.is_false())
       {
         // a?b:0 <-> a AND b
-        return changed(simplify_node(and_exprt(cond, truevalue)));
+        return changed(simplify_boolean(and_exprt(cond, truevalue)));
       }
       else if(falsevalue.is_true())
       {
         // a?b:1 <-> !a OR b
         return changed(
-          simplify_node(or_exprt(simplify_not(not_exprt(cond)), truevalue)));
+          simplify_boolean(or_exprt(simplify_not(not_exprt(cond)), truevalue)));
       }
       else if(truevalue.is_true())
       {
         // a?1:b <-> a||(!a && b) <-> a OR b
-        return changed(simplify_node(or_exprt(cond, falsevalue)));
+        return changed(simplify_boolean(or_exprt(cond, falsevalue)));
       }
       else if(truevalue.is_false())
       {
         // a?0:b <-> !a && b
-        return changed(
-          simplify_node(and_exprt(simplify_not(not_exprt(cond)), falsevalue)));
+        return changed(simplify_boolean(
+          and_exprt(simplify_not(not_exprt(cond)), falsevalue)));
       }
     }
   }

--- a/src/util/simplify_expr_int.cpp
+++ b/src/util/simplify_expr_int.cpp
@@ -570,7 +570,7 @@ simplify_exprt::simplify_minus(const minus_exprt &expr)
     // rewrite "a-b" to "a+(-b)"
     unary_minus_exprt rhs_negated(operands[1]);
     plus_exprt plus_expr(operands[0], simplify_unary_minus(rhs_negated));
-    return changed(simplify_node(plus_expr));
+    return changed(simplify_plus(plus_expr));
   }
   else if(
     minus_expr.type().id() == ID_pointer &&
@@ -646,10 +646,9 @@ simplify_exprt::simplify_bitwise(const multi_ary_exprt &expr)
       }
 
       new_expr.type()=bool_typet();
-      new_expr = simplify_node(new_expr);
+      new_expr = simplify_boolean(new_expr);
 
-      new_expr = typecast_exprt(new_expr, expr.type());
-      return changed(simplify_node(new_expr));
+      return changed(simplify_typecast(typecast_exprt(new_expr, expr.type())));
     }
   }
 


### PR DESCRIPTION
1) When we know the id of an expression, use the corresponding simplify_*
method rather than the generic simplify_node.
2) Avoid simplify_rec when all operands have been simplified already.
3) Don't call simplify_rec (or simplify_node) when there is nothing to
simplify.

Fixes: #4988

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
