### PR TITLE
Remove forall_symbol_base_map

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -35,8 +35,7 @@ ForEachMacros: [
   'forall_operands',
   'Forall_operands',
   'forall_expr',
-  'Forall_expr',
-  'forall_symbol_base_map']
+  'Forall_expr']
 IndentCaseLabels: 'false'
 IndentPPDirectives: AfterHash
 IndentWidth: '2'

--- a/src/ansi-c/ansi_c_entry_point.cpp
+++ b/src/ansi-c/ansi_c_entry_point.cpp
@@ -13,6 +13,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/config.h>
 #include <util/message.h>
 #include <util/pointer_expr.h>
+#include <util/range.h>
 #include <util/symbol_table.h>
 
 #include <goto-programs/goto_functions.h>
@@ -119,18 +120,18 @@ bool ansi_c_entry_point(
   {
     std::list<irep_idt> matches;
 
-    forall_symbol_base_map(
-      it, symbol_table.symbol_base_map, config.main.value())
+    for(const auto &symbol_name_entry :
+        equal_range(symbol_table.symbol_base_map, config.main.value()))
     {
       // look it up
-      symbol_tablet::symbolst::const_iterator s_it=
-        symbol_table.symbols.find(it->second);
+      symbol_tablet::symbolst::const_iterator s_it =
+        symbol_table.symbols.find(symbol_name_entry.second);
 
       if(s_it==symbol_table.symbols.end())
         continue;
 
       if(s_it->second.type.id()==ID_code)
-        matches.push_back(it->second);
+        matches.push_back(symbol_name_entry.second);
     }
 
     if(matches.empty())

--- a/src/goto-instrument/interrupt.cpp
+++ b/src/goto-instrument/interrupt.cpp
@@ -13,6 +13,8 @@ Date: September 2011
 
 #include "interrupt.h"
 
+#include <util/range.h>
+
 #include <linking/static_lifetime_init.h>
 
 #ifdef LOCAL_MAY
@@ -152,11 +154,12 @@ get_isr(const symbol_tablet &symbol_table, const irep_idt &interrupt_handler)
 {
   std::list<symbol_exprt> matches;
 
-  forall_symbol_base_map(m_it, symbol_table.symbol_base_map, interrupt_handler)
+  for(const auto &symbol_name_entry :
+      equal_range(symbol_table.symbol_base_map, interrupt_handler))
   {
     // look it up
-    symbol_tablet::symbolst::const_iterator s_it=
-      symbol_table.symbols.find(m_it->second);
+    symbol_tablet::symbolst::const_iterator s_it =
+      symbol_table.symbols.find(symbol_name_entry.second);
 
     if(s_it==symbol_table.symbols.end())
       continue;

--- a/src/jsil/jsil_entry_point.cpp
+++ b/src/jsil/jsil_entry_point.cpp
@@ -14,6 +14,7 @@ Author: Michael Tautschnig, tautschn@amazon.com
 #include <util/arith_tools.h>
 #include <util/config.h>
 #include <util/message.h>
+#include <util/range.h>
 
 #include <goto-programs/goto_functions.h>
 
@@ -60,18 +61,18 @@ bool jsil_entry_point(
   {
     std::list<irep_idt> matches;
 
-    forall_symbol_base_map(
-      it, symbol_table.symbol_base_map, config.main.value())
+    for(const auto &symbol_name_entry :
+        equal_range(symbol_table.symbol_base_map, config.main.value()))
     {
       // look it up
-      symbol_tablet::symbolst::const_iterator s_it=
-        symbol_table.symbols.find(it->second);
+      symbol_tablet::symbolst::const_iterator s_it =
+        symbol_table.symbols.find(symbol_name_entry.second);
 
       if(s_it==symbol_table.symbols.end())
         continue;
 
       if(s_it->second.type.id()==ID_code)
-        matches.push_back(it->second);
+        matches.push_back(symbol_name_entry.second);
     }
 
     if(matches.empty())

--- a/src/util/get_module.cpp
+++ b/src/util/get_module.cpp
@@ -15,6 +15,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <set>
 
 #include "message.h"
+#include "range.h"
 #include "symbol_table.h"
 
 typedef std::list<const symbolt *> symbolptr_listt;
@@ -27,10 +28,11 @@ const symbolt &get_module_by_name(
   symbolptr_listt symbolptr_list;
   messaget message(message_handler);
 
-  forall_symbol_base_map(it, symbol_table.symbol_base_map, module)
+  for(const auto &symbol_name_entry :
+      equal_range(symbol_table.symbol_base_map, module))
   {
-    symbol_tablet::symbolst::const_iterator it2=
-      symbol_table.symbols.find(it->second);
+    symbol_tablet::symbolst::const_iterator it2 =
+      symbol_table.symbols.find(symbol_name_entry.second);
 
     if(it2==symbol_table.symbols.end())
       continue;

--- a/src/util/symbol_table.h
+++ b/src/util/symbol_table.h
@@ -8,12 +8,6 @@
 
 #include "symbol_table_base.h"
 
-#define forall_symbol_base_map(it, expr, base_name) \
-  for(symbol_base_mapt::const_iterator it=(expr).lower_bound(base_name), \
-                                       it_end=(expr).upper_bound(base_name); \
-      it!=it_end; ++it)
-
-
 /// \brief The symbol table
 /// \ingroup gr_symbol_table
 class symbol_tablet : public symbol_table_baset


### PR DESCRIPTION
This was useful in the past, but with C++-11 and the ranget helper we can use a
ranged-for to avoid the iterator altogether.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
