### PR TITLE
Remove {f,F}orall_objects

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -38,8 +38,6 @@ ForEachMacros: [
   'Forall_goto_functions',
   'forall_goto_program_instructions',
   'Forall_goto_program_instructions',
-  'forall_objects',
-  'Forall_objects',
   'forall_valid_objects',
   'Forall_valid_objects',
   'forall_nodes',


### PR DESCRIPTION
This was useful in the past, but with C++-11 we can use a ranged-for to
avoid the iterator altogether.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
