### PR TITLE
Remove {forall,Forall}_symbolptr_list

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -49,8 +49,6 @@ ForEachMacros: [
   'Forall_operands',
   'forall_expr',
   'Forall_expr',
-  'forall_symbolptr_list',
-  'Forall_symbolptr_list',
   'forall_irep',
   'Forall_irep',
   'forall_named_irep',

--- a/src/util/get_module.cpp
+++ b/src/util/get_module.cpp
@@ -19,14 +19,6 @@ Author: Daniel Kroening, kroening@kroening.com
 
 typedef std::list<const symbolt *> symbolptr_listt;
 
-#define forall_symbolptr_list(it, list) \
-  for(symbolptr_listt::const_iterator it=(list).begin(); \
-      it!=(list).end(); ++it)
-
-#define Forall_symbolptr_list(it, list) \
-  for(symbolptr_listt::iterator it=(list).begin(); \
-      it!=(list).end(); ++it)
-
 const symbolt &get_module_by_name(
   const symbol_tablet &symbol_table,
   const std::string &module,
@@ -60,8 +52,8 @@ const symbolt &get_module_by_name(
   {
     message.error() << "module '" << module << "' does not uniquely resolve:\n";
 
-    forall_symbolptr_list(it, symbolptr_list)
-      message.error() << "  " << (*it)->name << '\n';
+    for(const symbolt *symbol_ptr : symbolptr_list)
+      message.error() << "  " << symbol_ptr->name << '\n';
 
     message.error() << messaget::eom;
     throw 0;
@@ -107,8 +99,8 @@ const symbolt &get_module(
     // sorted alphabetically
     std::set<std::string> modules;
 
-    forall_symbolptr_list(it, symbolptr_list)
-      modules.insert(id2string((*it)->pretty_name));
+    for(const symbolt *symbol_ptr : symbolptr_list)
+      modules.insert(id2string(symbol_ptr->pretty_name));
 
     message.error() << "multiple modules found, please select one:\n";
 


### PR DESCRIPTION
This was useful in the past, but with C++-11 we can use a ranged-for to
avoid the iterator altogether. (The Forall variant wasn't even used.)

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
