### PR TITLE
Fix doxygen in cmake

### DIFF
--- a/.github/workflows/pull-request-checks.yaml
+++ b/.github/workflows/pull-request-checks.yaml
@@ -66,7 +66,7 @@ jobs:
           # user input
           DEBIAN_FRONTEND: noninteractive
         run: |
-          sudo apt-get install --no-install-recommends -yq cmake ninja-build gcc g++ maven flex bison libxml2-utils dpkg-dev ccache
+          sudo apt-get install --no-install-recommends -yq cmake ninja-build gcc g++ maven flex bison libxml2-utils dpkg-dev ccache doxygen
       - name: Prepare ccache
         uses: actions/cache@v2
         with:
@@ -84,6 +84,10 @@ jobs:
           mkdir build
           cd build
           cmake .. -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=/usr/bin/gcc -DCMAKE_CXX_COMPILER=/usr/bin/g++
+      - name: Check that doc task works
+        run: |
+          cd build
+          ninja doc
       - name: Zero ccache stats and limit in size
         run: ccache -z --max-size=500M
       - name: Build with Ninja

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,10 +5,26 @@ find_package(FLEX REQUIRED)
 
 find_package(Doxygen)
 if(DOXYGEN_FOUND)
-    add_custom_target(doc
-        "${DOXYGEN_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/doxygen.cfg"
-        WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
-    )
+  set(ROOT_BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/..")
+  set(ROOT_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/..")
+  set(ORIGINAL_DOXYFILE "${CMAKE_CURRENT_SOURCE_DIR}/doxyfile")
+  set(CONFIGURED_DOXYFILE "${ROOT_BINARY_DIR}/doxyfile")
+  set(DOC_INPUT_DIRECTORY "${ROOT_SOURCE_DIR}/doc")
+  set(DOC_OUTPUT_DIRECTORY "${ROOT_BINARY_DIR}/doc")
+
+  configure_file("${CMAKE_CURRENT_SOURCE_DIR}/doxyfile.override.in" "${CONFIGURED_DOXYFILE}")
+  add_custom_target(doc
+      COMMAND "${CMAKE_COMMAND}" -E remove_directory "${DOC_OUTPUT_DIRECTORY}"
+      COMMAND "${CMAKE_COMMAND}" -E copy_directory "${DOC_INPUT_DIRECTORY}" "${DOC_OUTPUT_DIRECTORY}"
+      COMMAND "${DOXYGEN_EXECUTABLE}" "${CONFIGURED_DOXYFILE}"
+      WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}")
+
+  unset(DOC_OUTPUT_DIRECTORY)
+  unset(DOC_INPUT_DIRECTORY)
+  unset(CONFIGURED_DOXYFILE)
+  unset(ORIGINAL_DOXYFILE)
+  unset(ROOT_SOURCE_DIR)
+  unset(ROOT_BINARY_DIR)
 endif(DOXYGEN_FOUND)
 
 #   Add a bison target named 'parser'.

--- a/src/doxyfile.override.in
+++ b/src/doxyfile.override.in
@@ -1,0 +1,12 @@
+# Overrides for cmake out of source builds specifically, we
+# want to avoid copying files into the main doc directory,
+# instead we should be generating the doxygen docs in our
+# cmake output directory
+
+# Note: This file is intended to be used with cmake
+# configure_file; variables like @this@ are replaced by
+# cmake variables.
+
+@INCLUDE = @ORIGINAL_DOXYFILE@
+
+OUTPUT_DIRECTORY = @DOC_OUTPUT_DIRECTORY@


### PR DESCRIPTION
This has been broken for 3 years, ever since doxygen.cfg was renamed to
doxyfile. This lets us build documentation in from cmake with the 'doc'
target. One difference to the previous version (i.e. the one that was
broken before) is that this creates the documentation in the cmake
binary directory now instead of the source directory. Reasoning for this
is that cmake targets should not change files in the source directory
ideally.

---

Not addressed here: I think this is probably the wrong place to do doxygen stuff anyway, we're referring to files outside this directory which is somewhat unfortunate.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
