### PR TITLE
Remove forall_rw_range_set_{r,w}_objects

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -30,8 +30,6 @@ DerivePointerAlignment: 'false'
 DisableFormat: 'false'
 ExperimentalAutoDetectBinPacking: 'false'
 ForEachMacros: [
-  'forall_rw_range_set_r_objects',
-  'forall_rw_range_set_w_objects',
   'forall_rw_set_r_entries',
   'forall_rw_set_w_entries',
   'forall_goto_functions',

--- a/src/analyses/dependence_graph.cpp
+++ b/src/analyses/dependence_graph.cpp
@@ -163,7 +163,7 @@ void dep_graph_domaint::data_dependencies(
 
   forall_rw_range_set_r_objects(it, rw_set)
   {
-    const range_domaint &r_ranges=rw_set.get_ranges(it);
+    const range_domaint &r_ranges = rw_set.get_ranges(it->second);
     const rd_range_domaint::ranges_at_loct &w_ranges=
       dep_graph.reaching_definitions()[to].get(it->first);
 

--- a/src/analyses/dependence_graph.cpp
+++ b/src/analyses/dependence_graph.cpp
@@ -161,11 +161,11 @@ void dep_graph_domaint::data_dependencies(
   rw_range_set_value_sett rw_set(ns, value_sets);
   goto_rw(function_to, to, rw_set);
 
-  forall_rw_range_set_r_objects(it, rw_set)
+  for(const auto &read_object_entry : rw_set.get_r_set())
   {
-    const range_domaint &r_ranges = rw_set.get_ranges(it->second);
-    const rd_range_domaint::ranges_at_loct &w_ranges=
-      dep_graph.reaching_definitions()[to].get(it->first);
+    const range_domaint &r_ranges = rw_set.get_ranges(read_object_entry.second);
+    const rd_range_domaint::ranges_at_loct &w_ranges =
+      dep_graph.reaching_definitions()[to].get(read_object_entry.first);
 
     for(const auto &w_range : w_ranges)
     {
@@ -186,7 +186,7 @@ void dep_graph_domaint::data_dependencies(
       }
     }
 
-    dep_graph.reaching_definitions()[to].clear_cache(it->first);
+    dep_graph.reaching_definitions()[to].clear_cache(read_object_entry.first);
   }
 }
 

--- a/src/analyses/goto_rw.cpp
+++ b/src/analyses/goto_rw.cpp
@@ -65,20 +65,20 @@ rw_range_sett::~rw_range_sett()
 void rw_range_sett::output(std::ostream &out) const
 {
   out << "READ:\n";
-  forall_rw_range_set_r_objects(it, *this)
+  for(const auto &read_object_entry : get_r_set())
   {
-    out << "  " << it->first;
-    it->second->output(ns, out);
+    out << "  " << read_object_entry.first;
+    read_object_entry.second->output(ns, out);
     out << '\n';
   }
 
   out << '\n';
 
   out << "WRITE:\n";
-  forall_rw_range_set_w_objects(it, *this)
+  for(const auto &written_object_entry : get_w_set())
   {
-    out << "  " << it->first;
-    it->second->output(ns, out);
+    out << "  " << written_object_entry.first;
+    written_object_entry.second->output(ns, out);
     out << '\n';
   }
 }

--- a/src/analyses/goto_rw.h
+++ b/src/analyses/goto_rw.h
@@ -136,10 +136,11 @@ public:
     return w_range_set;
   }
 
-  const range_domaint &get_ranges(objectst::const_iterator it) const
+  const range_domaint &
+  get_ranges(const std::unique_ptr<range_domain_baset> &ranges) const
   {
-    PRECONDITION(dynamic_cast<range_domaint*>(it->second.get())!=nullptr);
-    return static_cast<const range_domaint &>(*it->second);
+    PRECONDITION(dynamic_cast<range_domaint *>(ranges.get()) != nullptr);
+    return static_cast<const range_domaint &>(*ranges);
   }
 
   enum class get_modet { LHS_W, READ };
@@ -360,11 +361,12 @@ public:
   {
   }
 
-  const guarded_range_domaint &get_ranges(objectst::const_iterator it) const
+  const guarded_range_domaint &
+  get_ranges(const std::unique_ptr<range_domain_baset> &ranges) const
   {
     PRECONDITION(
-      dynamic_cast<guarded_range_domaint*>(it->second.get())!=nullptr);
-    return static_cast<const guarded_range_domaint &>(*it->second);
+      dynamic_cast<guarded_range_domaint *>(ranges.get()) != nullptr);
+    return static_cast<const guarded_range_domaint &>(*ranges);
   }
 
   void get_objects_rec(

--- a/src/analyses/goto_rw.h
+++ b/src/analyses/goto_rw.h
@@ -21,14 +21,6 @@ Date: April 2010
 
 #include <goto-programs/goto_model.h>
 
-#define forall_rw_range_set_r_objects(it, rw_set) \
-  for(rw_range_sett::objectst::const_iterator it=(rw_set).get_r_set().begin(); \
-      it!=(rw_set).get_r_set().end(); ++it)
-
-#define forall_rw_range_set_w_objects(it, rw_set) \
-  for(rw_range_sett::objectst::const_iterator it=(rw_set).get_w_set().begin(); \
-      it!=(rw_set).get_w_set().end(); ++it)
-
 class rw_range_sett;
 class goto_modelt;
 

--- a/src/analyses/reaching_definitions.cpp
+++ b/src/analyses/reaching_definitions.cpp
@@ -148,7 +148,7 @@ void rd_range_domaint::transform(
           continue;
         assert(symbol_ptr!=0);
 
-        const range_domaint &ranges=rw_set.get_ranges(it);
+        const range_domaint &ranges = rw_set.get_ranges(it->second);
 
         if(is_must_alias &&
            (!rd->get_is_threaded()(from) ||
@@ -357,7 +357,7 @@ void rd_range_domaint::transform_assign(
       nullptr_exceptiont,
       "Symbol is in symbol table");
 
-    const range_domaint &ranges=rw_set.get_ranges(it);
+    const range_domaint &ranges = rw_set.get_ranges(it->second);
 
     if(is_must_alias &&
        (!rd.get_is_threaded()(from) ||

--- a/src/analyses/reaching_definitions.cpp
+++ b/src/analyses/reaching_definitions.cpp
@@ -139,16 +139,17 @@ void rd_range_domaint::transform(
       goto_rw(to, rw_set);
       const bool is_must_alias=rw_set.get_w_set().size()==1;
 
-      forall_rw_range_set_w_objects(it, rw_set)
+      for(const auto &written_object_entry : rw_set.get_w_set())
       {
-        const irep_idt &identifier=it->first;
+        const irep_idt &identifier = written_object_entry.first;
         // ignore symex::invalid_object
         const symbolt *symbol_ptr;
         if(ns.lookup(identifier, symbol_ptr))
           continue;
         assert(symbol_ptr!=0);
 
-        const range_domaint &ranges = rw_set.get_ranges(it->second);
+        const range_domaint &ranges =
+          rw_set.get_ranges(written_object_entry.second);
 
         if(is_must_alias &&
            (!rd->get_is_threaded()(from) ||
@@ -345,9 +346,9 @@ void rd_range_domaint::transform_assign(
   goto_rw(function_to, to, rw_set);
   const bool is_must_alias=rw_set.get_w_set().size()==1;
 
-  forall_rw_range_set_w_objects(it, rw_set)
+  for(const auto &written_object_entry : rw_set.get_w_set())
   {
-    const irep_idt &identifier=it->first;
+    const irep_idt &identifier = written_object_entry.first;
     // ignore symex::invalid_object
     const symbolt *symbol_ptr;
     if(ns.lookup(identifier, symbol_ptr))
@@ -357,7 +358,8 @@ void rd_range_domaint::transform_assign(
       nullptr_exceptiont,
       "Symbol is in symbol table");
 
-    const range_domaint &ranges = rw_set.get_ranges(it->second);
+    const range_domaint &ranges =
+      rw_set.get_ranges(written_object_entry.second);
 
     if(is_must_alias &&
        (!rd.get_is_threaded()(from) ||


### PR DESCRIPTION
This was useful in the past, but with C++-11 we can use a ranged-for to avoid the iterator altogether.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
