### PR TITLE
Remove forall_nodes

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -42,7 +42,6 @@ ForEachMacros: [
   'Forall_objects',
   'forall_valid_objects',
   'Forall_valid_objects',
-  'forall_nodes',
   'forall_literals',
   'Forall_literals',
   'forall_operands',

--- a/src/solvers/bdd/miniBDD/miniBDD.cpp
+++ b/src/solvers/bdd/miniBDD/miniBDD.cpp
@@ -17,9 +17,6 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <iostream>
 
-#define forall_nodes(it)                                                       \
-  for(nodest::const_iterator it = nodes.begin(); it != nodes.end(); it++)
-
 void mini_bdd_nodet::remove_reference()
 {
   PRECONDITION_WITH_DIAGNOSTICS(
@@ -65,9 +62,11 @@ void mini_bdd_mgrt::DumpDot(std::ostream &out, bool suppress_zero) const
            "{ node [shape=plaintext,fontname=\"Times Italic\",fontsize=24] \" "
         << var_table[v].label << " \" }; ";
 
-    forall_nodes(u)
-      if(u->var == (v + 1) && u->reference_counter != 0)
-        out << '"' << u->node_number << "\"; ";
+    for(const auto &u : nodes)
+    {
+      if(u.var == (v + 1) && u.reference_counter != 0)
+        out << '"' << u.node_number << "\"; ";
+    }
 
     out << "}\n";
   }
@@ -83,22 +82,21 @@ void mini_bdd_mgrt::DumpDot(std::ostream &out, bool suppress_zero) const
 
   out << '\n';
 
-  forall_nodes(u)
+  for(const auto &u : nodes)
   {
-    if(u->reference_counter == 0)
+    if(u.reference_counter == 0)
       continue;
-    if(u->node_number <= 1)
+    if(u.node_number <= 1)
       continue;
 
-    if(!suppress_zero || u->high.node_number() != 0)
-      out << '"' << u->node_number << '"' << " -> " << '"'
-          << u->high.node_number() << '"'
+    if(!suppress_zero || u.high.node_number() != 0)
+      out << '"' << u.node_number << '"' << " -> " << '"'
+          << u.high.node_number() << '"'
           << " [style=solid,arrowsize=\".75\"];\n";
 
-    if(!suppress_zero || u->low.node_number() != 0)
-      out << '"' << u->node_number << '"' << " -> " << '"'
-          << u->low.node_number() << '"'
-          << " [style=dashed,arrowsize=\".75\"];\n";
+    if(!suppress_zero || u.low.node_number() != 0)
+      out << '"' << u.node_number << '"' << " -> " << '"' << u.low.node_number()
+          << '"' << " [style=dashed,arrowsize=\".75\"];\n";
 
     out << '\n';
   }
@@ -128,9 +126,9 @@ void mini_bdd_mgrt::DumpTikZ(
 
     unsigned previous = 0;
 
-    forall_nodes(u)
+    for(const auto &u : nodes)
     {
-      if(u->var == (v + 1) && u->reference_counter != 0)
+      if(u.var == (v + 1) && u.reference_counter != 0)
       {
         out << "  \\node[xshift=0cm, BDDnode, ";
 
@@ -139,11 +137,11 @@ void mini_bdd_mgrt::DumpTikZ(
         else
           out << "right of=n" << previous;
 
-        out << "] (n" << u->node_number << ") {";
+        out << "] (n" << u.node_number << ") {";
         if(node_numbers)
-          out << "\\small $" << u->node_number << "$";
+          out << "\\small $" << u.node_number << "$";
         out << "};\n";
-        previous = u->node_number;
+        previous = u.node_number;
       }
     }
 
@@ -164,17 +162,17 @@ void mini_bdd_mgrt::DumpTikZ(
   out << "  % edges\n";
   out << '\n';
 
-  forall_nodes(u)
+  for(const auto &u : nodes)
   {
-    if(u->reference_counter != 0 && u->node_number >= 2)
+    if(u.reference_counter != 0 && u.node_number >= 2)
     {
-      if(!suppress_zero || u->low.node_number() != 0)
-        out << "  \\draw[->,dashed] (n" << u->node_number << ") -> (n"
-            << u->low.node_number() << ");\n";
+      if(!suppress_zero || u.low.node_number() != 0)
+        out << "  \\draw[->,dashed] (n" << u.node_number << ") -> (n"
+            << u.low.node_number() << ");\n";
 
-      if(!suppress_zero || u->high.node_number() != 0)
-        out << "  \\draw[->] (n" << u->node_number << ") -> (n"
-            << u->high.node_number() << ");\n";
+      if(!suppress_zero || u.high.node_number() != 0)
+        out << "  \\draw[->] (n" << u.node_number << ") -> (n"
+            << u.high.node_number() << ");\n";
     }
   }
 
@@ -490,23 +488,22 @@ void mini_bdd_mgrt::DumpTable(std::ostream &out) const
   out << "\\# & \\mathit{var} & \\mathit{low} &"
          " \\mathit{high} \\\\\\hline\n";
 
-  forall_nodes(it)
+  for(const auto &n : nodes)
   {
-    out << it->node_number << " & ";
+    out << n.node_number << " & ";
 
-    if(it->node_number == 0 || it->node_number == 1)
-      out << it->var << " & & \\\\";
-    else if(it->reference_counter == 0)
+    if(n.node_number == 0 || n.node_number == 1)
+      out << n.var << " & & \\\\";
+    else if(n.reference_counter == 0)
       out << "- & - & - \\\\";
     else
-      out << it->var << "\\," << var_table[it->var - 1].label << " & "
-          << it->low.node_number() << " & " << it->high.node_number()
-          << " \\\\";
+      out << n.var << "\\," << var_table[n.var - 1].label << " & "
+          << n.low.node_number() << " & " << n.high.node_number() << " \\\\";
 
-    if(it->node_number == 1)
+    if(n.node_number == 1)
       out << "\\hline";
 
-    out << " % " << it->reference_counter << '\n';
+    out << " % " << n.reference_counter << '\n';
   }
 }
 


### PR DESCRIPTION
This was useful in the past, but with C++-11 we can use a ranged-for to
avoid the iterator altogether.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
