### PR TITLE
Replace boolbv_mapt::map_bitt by bvt

### DIFF
--- a/regression/cbmc/Failing_Assert1/dimacs.desc
+++ b/regression/cbmc/Failing_Assert1/dimacs.desc
@@ -1,0 +1,10 @@
+CORE
+main.c
+--dimacs
+^Runtime decision procedure: [0-9]+(\.[0-9]+(e-[0-9]+)?)?s$
+^c main::1::i!0@1#1
+^c main::1::j!0@1#1
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring

--- a/regression/validate-trace-xml-schema/check.py
+++ b/regression/validate-trace-xml-schema/check.py
@@ -43,6 +43,7 @@ ExcludedTests = list(map(lambda s: os.path.join(test_base_dir, s[0], s[1]), [
     ['coverage_report1', 'paths.desc'],
     ['graphml_witness1', 'test.desc'],
     ['switch8', 'program-only.desc'],
+    ['Failing_Assert1', 'dimacs.desc'],
     # this uses json-ui (fails for a different reason actually, but should also
     #   fail because of command line incompatibility)
     ['json1', 'test.desc'],

--- a/scripts/expected_doxygen_warnings.txt
+++ b/scripts/expected_doxygen_warnings.txt
@@ -92,7 +92,7 @@ warning: Included by graph for 'expr_util.h' not generated, too many nodes (61),
 warning: Included by graph for 'invariant.h' not generated, too many nodes (187), threshold is 60. Consider increasing DOT_GRAPH_MAX_NODES.
 warning: Included by graph for 'irep.h' not generated, too many nodes (62), threshold is 60. Consider increasing DOT_GRAPH_MAX_NODES.
 warning: Included by graph for 'message.h' not generated, too many nodes (116), threshold is 60. Consider increasing DOT_GRAPH_MAX_NODES.
-warning: Included by graph for 'namespace.h' not generated, too many nodes (110), threshold is 60. Consider increasing DOT_GRAPH_MAX_NODES.
+warning: Included by graph for 'namespace.h' not generated, too many nodes (109), threshold is 60. Consider increasing DOT_GRAPH_MAX_NODES.
 warning: Included by graph for 'pointer_expr.h' not generated, too many nodes (101), threshold is 60. Consider increasing DOT_GRAPH_MAX_NODES.
 warning: Included by graph for 'prefix.h' not generated, too many nodes (86), threshold is 60. Consider increasing DOT_GRAPH_MAX_NODES.
 warning: Included by graph for 'simplify_expr.h' not generated, too many nodes (77), threshold is 60. Consider increasing DOT_GRAPH_MAX_NODES.

--- a/src/solvers/flattening/boolbv.cpp
+++ b/src/solvers/flattening/boolbv.cpp
@@ -306,7 +306,7 @@ bvt boolbvt::convert_symbol(const exprt &expr)
   const irep_idt &identifier = expr.get(ID_identifier);
   CHECK_RETURN(!identifier.empty());
 
-  map.get_literals(identifier, type, width, bv);
+  map.get_literals(identifier, type, bv);
 
   INVARIANT_WITH_DIAGNOSTICS(
     std::all_of(

--- a/src/solvers/flattening/boolbv.cpp
+++ b/src/solvers/flattening/boolbv.cpp
@@ -300,13 +300,10 @@ bvt boolbvt::convert_symbol(const exprt &expr)
   const typet &type=expr.type();
   std::size_t width=boolbv_width(type);
 
-  bvt bv;
-  bv.resize(width);
-
   const irep_idt &identifier = expr.get(ID_identifier);
   CHECK_RETURN(!identifier.empty());
 
-  map.get_literals(identifier, type, bv);
+  bvt bv = map.get_literals(identifier, type, width);
 
   INVARIANT_WITH_DIAGNOSTICS(
     std::all_of(

--- a/src/solvers/flattening/boolbv.cpp
+++ b/src/solvers/flattening/boolbv.cpp
@@ -306,25 +306,17 @@ bvt boolbvt::convert_symbol(const exprt &expr)
   const irep_idt &identifier = expr.get(ID_identifier);
   CHECK_RETURN(!identifier.empty());
 
-  if(width==0)
-  {
-    // just put in map
-    map.get_map_entry(identifier, type);
-  }
-  else
-  {
-    map.get_literals(identifier, type, width, bv);
+  map.get_literals(identifier, type, width, bv);
 
-    INVARIANT_WITH_DIAGNOSTICS(
-      std::all_of(
-        bv.begin(),
-        bv.end(),
-        [this](const literalt &l) {
-          return l.var_no() < prop.no_variables() || l.is_constant();
-        }),
-      "variable number of non-constant literals should be within bounds",
-      id2string(identifier));
-  }
+  INVARIANT_WITH_DIAGNOSTICS(
+    std::all_of(
+      bv.begin(),
+      bv.end(),
+      [this](const literalt &l) {
+        return l.var_no() < prop.no_variables() || l.is_constant();
+      }),
+    "variable number of non-constant literals should be within bounds",
+    id2string(identifier));
 
   return bv;
 }
@@ -575,8 +567,7 @@ bool boolbvt::is_unbounded_array(const typet &type) const
 void boolbvt::print_assignment(std::ostream &out) const
 {
   arrayst::print_assignment(out);
-  for(const auto &pair : map.mapping)
-    out << pair.first << "=" << pair.second.get_value(prop) << '\n';
+  map.show(out);
 }
 
 boolbvt::offset_mapt boolbvt::build_offset_map(const struct_typet &src)

--- a/src/solvers/flattening/boolbv.h
+++ b/src/solvers/flattening/boolbv.h
@@ -49,7 +49,7 @@ public:
       boolbv_width(_ns),
       bv_utils(_prop),
       functions(*this),
-      map(_prop, boolbv_width)
+      map(_prop)
   {
   }
 

--- a/src/solvers/flattening/boolbv.h
+++ b/src/solvers/flattening/boolbv.h
@@ -230,7 +230,6 @@ protected:
   virtual exprt bv_get_rec(
     const exprt &expr,
     const bvt &bv,
-    const std::vector<bool> &unknown,
     std::size_t offset,
     const typet &type) const;
 

--- a/src/solvers/flattening/boolbv_get.cpp
+++ b/src/solvers/flattening/boolbv_get.cpp
@@ -38,25 +38,16 @@ exprt boolbvt::get(const exprt &expr) const
 
       std::vector<bool> unknown;
       bvt bv;
-      std::size_t width=map_entry.width;
 
-      bv.resize(width);
-      unknown.resize(width);
-
-      for(std::size_t bit_nr=0; bit_nr<width; bit_nr++)
+      if(map_entry.is_set)
       {
-        assert(bit_nr<map_entry.literal_map.size());
-
-        if(map_entry.literal_map[bit_nr].is_set)
-        {
-          unknown[bit_nr]=false;
-          bv[bit_nr]=map_entry.literal_map[bit_nr].l;
-        }
-        else
-        {
-          unknown[bit_nr]=true;
-          bv[bit_nr].clear();
-        }
+        unknown = std::vector<bool>(map_entry.width, false);
+        bv = map_entry.literal_map;
+      }
+      else
+      {
+        unknown = std::vector<bool>(map_entry.width, true);
+        bv = bvt{map_entry.width, literalt{0, false}};
       }
 
       return bv_get_rec(expr, bv, unknown, 0, map_entry.type);

--- a/src/solvers/flattening/boolbv_get.cpp
+++ b/src/solvers/flattening/boolbv_get.cpp
@@ -24,12 +24,11 @@ exprt boolbvt::get(const exprt &expr) const
   {
     const irep_idt &identifier=expr.get(ID_identifier);
 
-    boolbv_mapt::mappingt::const_iterator it=
-      map.mapping.find(identifier);
+    const auto map_entry_opt = map.get_map_entry(identifier);
 
-    if(it!=map.mapping.end())
+    if(map_entry_opt.has_value())
     {
-      const boolbv_mapt::map_entryt &map_entry=it->second;
+      const boolbv_mapt::map_entryt &map_entry = *map_entry_opt;
       // an input expression must either be untyped (this is used for obtaining
       // the value of clock symbols, which do not have a fixed type as the clock
       // type is computed during symbolic execution) or match the type stored in

--- a/src/solvers/flattening/boolbv_get.cpp
+++ b/src/solvers/flattening/boolbv_get.cpp
@@ -35,21 +35,10 @@ exprt boolbvt::get(const exprt &expr) const
       // the mapping
       PRECONDITION(expr.type() == typet() || expr.type() == map_entry.type);
 
-      std::vector<bool> unknown;
-      bvt bv;
+      std::vector<bool> unknown = std::vector<bool>(map_entry.width, false);
 
-      if(map_entry.is_set)
-      {
-        unknown = std::vector<bool>(map_entry.width, false);
-        bv = map_entry.literal_map;
-      }
-      else
-      {
-        unknown = std::vector<bool>(map_entry.width, true);
-        bv = bvt{map_entry.width, literalt{0, false}};
-      }
-
-      return bv_get_rec(expr, bv, unknown, 0, map_entry.type);
+      return bv_get_rec(
+        expr, map_entry.literal_map, unknown, 0, map_entry.type);
     }
   }
 

--- a/src/solvers/flattening/boolbv_get.cpp
+++ b/src/solvers/flattening/boolbv_get.cpp
@@ -35,7 +35,8 @@ exprt boolbvt::get(const exprt &expr) const
       // the mapping
       PRECONDITION(expr.type() == typet() || expr.type() == map_entry.type);
 
-      std::vector<bool> unknown = std::vector<bool>(map_entry.width, false);
+      std::vector<bool> unknown =
+        std::vector<bool>(map_entry.literal_map.size(), false);
 
       return bv_get_rec(
         expr, map_entry.literal_map, unknown, 0, map_entry.type);

--- a/src/solvers/flattening/boolbv_index.cpp
+++ b/src/solvers/flattening/boolbv_index.cpp
@@ -58,8 +58,7 @@ bvt boolbvt::convert_index(const index_exprt &expr)
         {
           std::size_t width = boolbv_width(array_type);
           bvt unused(width);
-          map.get_literals(
-            final_array.get(ID_identifier), array_type, width, unused);
+          map.get_literals(final_array.get(ID_identifier), array_type, unused);
         }
 
         // make sure we have the index in the cache
@@ -79,7 +78,7 @@ bvt boolbvt::convert_index(const index_exprt &expr)
         {
           std::size_t width = boolbv_width(array_type);
           bvt unused(width);
-          map.get_literals(array.get(ID_identifier), array_type, width, unused);
+          map.get_literals(array.get(ID_identifier), array_type, unused);
         }
 
         // make sure we have the index in the cache

--- a/src/solvers/flattening/boolbv_index.cpp
+++ b/src/solvers/flattening/boolbv_index.cpp
@@ -57,8 +57,8 @@ bvt boolbvt::convert_index(const index_exprt &expr)
           final_array.id() == ID_symbol || final_array.id() == ID_nondet_symbol)
         {
           std::size_t width = boolbv_width(array_type);
-          bvt unused(width);
-          map.get_literals(final_array.get(ID_identifier), array_type, unused);
+          (void)map.get_literals(
+            final_array.get(ID_identifier), array_type, width);
         }
 
         // make sure we have the index in the cache
@@ -77,8 +77,7 @@ bvt boolbvt::convert_index(const index_exprt &expr)
         if(array.id() == ID_symbol || array.id() == ID_nondet_symbol)
         {
           std::size_t width = boolbv_width(array_type);
-          bvt unused(width);
-          map.get_literals(array.get(ID_identifier), array_type, unused);
+          (void)map.get_literals(array.get(ID_identifier), array_type, width);
         }
 
         // make sure we have the index in the cache

--- a/src/solvers/flattening/boolbv_index.cpp
+++ b/src/solvers/flattening/boolbv_index.cpp
@@ -56,7 +56,10 @@ bvt boolbvt::convert_index(const index_exprt &expr)
         if(
           final_array.id() == ID_symbol || final_array.id() == ID_nondet_symbol)
         {
-          map.get_map_entry(final_array.get(ID_identifier), array_type);
+          std::size_t width = boolbv_width(array_type);
+          bvt unused(width);
+          map.get_literals(
+            final_array.get(ID_identifier), array_type, width, unused);
         }
 
         // make sure we have the index in the cache
@@ -73,7 +76,11 @@ bvt boolbvt::convert_index(const index_exprt &expr)
 
         // record type if array is a symbol
         if(array.id() == ID_symbol || array.id() == ID_nondet_symbol)
-          map.get_map_entry(array.get(ID_identifier), array_type);
+        {
+          std::size_t width = boolbv_width(array_type);
+          bvt unused(width);
+          map.get_literals(array.get(ID_identifier), array_type, width, unused);
+        }
 
         // make sure we have the index in the cache
         convert_bv(index);

--- a/src/solvers/flattening/boolbv_map.cpp
+++ b/src/solvers/flattening/boolbv_map.cpp
@@ -12,8 +12,6 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <solvers/prop/prop.h>
 
-#include "boolbv_width.h"
-
 #ifdef DEBUG
 #include <iostream>
 #endif
@@ -43,11 +41,8 @@ void boolbv_mapt::show(std::ostream &out) const
 void boolbv_mapt::get_literals(
   const irep_idt &identifier,
   const typet &type,
-  const std::size_t width,
   bvt &literals)
 {
-  PRECONDITION(literals.size() == width);
-
   std::pair<mappingt::iterator, bool> result=
     mapping.insert(std::pair<irep_idt, map_entryt>(
       identifier, map_entryt()));
@@ -57,11 +52,9 @@ void boolbv_mapt::get_literals(
   if(result.second)
   { // actually inserted
     map_entry.type=type;
-    map_entry.width=boolbv_width(type);
-    map_entry.bvtype=get_bvtype(type);
-    map_entry.literal_map.reserve(map_entry.width);
+    map_entry.literal_map.reserve(literals.size());
 
-    for(std::size_t bit = 0; bit < map_entry.width; ++bit)
+    for(std::size_t bit = 0; bit < literals.size(); ++bit)
     {
       map_entry.literal_map.push_back(prop.new_variable());
 
@@ -73,7 +66,7 @@ void boolbv_mapt::get_literals(
   }
 
   INVARIANT(
-    map_entry.literal_map.size() == width,
+    map_entry.literal_map.size() == literals.size(),
     "number of literals in the literal map shall equal the bitvector width");
 
   literals = map_entry.literal_map;
@@ -92,8 +85,6 @@ void boolbv_mapt::set_literals(
   if(result.second)
   { // actually inserted
     map_entry.type = type;
-    map_entry.width = boolbv_width(type);
-    map_entry.bvtype = get_bvtype(type);
 
     for(const auto &literal : literals)
     {
@@ -102,15 +93,10 @@ void boolbv_mapt::set_literals(
         "variable number of non-constant literals shall be within bounds");
     }
 
-    PRECONDITION(literals.size() == map_entry.width);
     map_entry.literal_map = literals;
   }
   else
   {
-    INVARIANT(
-      map_entry.literal_map.size() == map_entry.width,
-      "number of literals in the literal map shall equal the bitvector width");
-
     for(auto it = literals.begin(); it != literals.end(); ++it)
     {
       const literalt &literal = *it;

--- a/src/solvers/flattening/boolbv_map.cpp
+++ b/src/solvers/flattening/boolbv_map.cpp
@@ -20,9 +20,6 @@ Author: Daniel Kroening, kroening@kroening.com
 
 std::string boolbv_mapt::map_entryt::get_value(const propt &prop) const
 {
-  if(!is_set)
-    return std::string(literal_map.size(), '*');
-
   std::string result;
 
   result.reserve(literal_map.size());
@@ -73,8 +70,6 @@ void boolbv_mapt::get_literals(
                 << map_entry.literal_map.back() << '\n';
 #endif
     }
-
-    map_entry.is_set = true;
   }
 
   INVARIANT(
@@ -109,8 +104,6 @@ void boolbv_mapt::set_literals(
 
     PRECONDITION(literals.size() == map_entry.width);
     map_entry.literal_map = literals;
-
-    map_entry.is_set = true;
   }
   else
   {

--- a/src/solvers/flattening/boolbv_map.cpp
+++ b/src/solvers/flattening/boolbv_map.cpp
@@ -38,10 +38,10 @@ void boolbv_mapt::show(std::ostream &out) const
     out << pair.first << "=" << pair.second.get_value(prop) << '\n';
 }
 
-void boolbv_mapt::get_literals(
+const bvt &boolbv_mapt::get_literals(
   const irep_idt &identifier,
   const typet &type,
-  bvt &literals)
+  std::size_t width)
 {
   std::pair<mappingt::iterator, bool> result=
     mapping.insert(std::pair<irep_idt, map_entryt>(
@@ -52,9 +52,9 @@ void boolbv_mapt::get_literals(
   if(result.second)
   { // actually inserted
     map_entry.type=type;
-    map_entry.literal_map.reserve(literals.size());
+    map_entry.literal_map.reserve(width);
 
-    for(std::size_t bit = 0; bit < literals.size(); ++bit)
+    for(std::size_t bit = 0; bit < width; ++bit)
     {
       map_entry.literal_map.push_back(prop.new_variable());
 
@@ -66,10 +66,10 @@ void boolbv_mapt::get_literals(
   }
 
   INVARIANT(
-    map_entry.literal_map.size() == literals.size(),
+    map_entry.literal_map.size() == width,
     "number of literals in the literal map shall equal the bitvector width");
 
-  literals = map_entry.literal_map;
+  return map_entry.literal_map;
 }
 
 void boolbv_mapt::set_literals(

--- a/src/solvers/flattening/boolbv_map.h
+++ b/src/solvers/flattening/boolbv_map.h
@@ -28,15 +28,6 @@ public:
   {
   }
 
-  struct map_bitt
-  {
-    map_bitt():is_set(false) { }
-    bool is_set;
-    literalt l;
-  };
-
-  typedef std::vector<map_bitt> literal_mapt;
-
   class map_entryt
   {
   public:
@@ -47,7 +38,8 @@ public:
     std::size_t width;
     bvtypet bvtype;
     typet type;
-    literal_mapt literal_map;
+    bool is_set = false;
+    bvt literal_map;
 
     std::string get_value(const propt &) const;
   };

--- a/src/solvers/flattening/boolbv_map.h
+++ b/src/solvers/flattening/boolbv_map.h
@@ -14,30 +14,19 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <vector>
 
 #include <util/type.h>
-#include <util/namespace.h>
 
 #include <solvers/prop/prop.h>
-
-#include "boolbv_type.h"
-#include "boolbv_width.h"
 
 class boolbv_mapt
 {
 public:
-  boolbv_mapt(propt &_prop, const boolbv_widtht &_boolbv_width)
-    : prop(_prop), boolbv_width(_boolbv_width)
+  explicit boolbv_mapt(propt &_prop) : prop(_prop)
   {
   }
 
   class map_entryt
   {
   public:
-    map_entryt():width(0), bvtype(bvtypet::IS_UNKNOWN)
-    {
-    }
-
-    std::size_t width;
-    bvtypet bvtype;
     typet type;
     bvt literal_map;
 
@@ -51,7 +40,6 @@ public:
   void get_literals(
     const irep_idt &identifier,
     const typet &type,
-    const std::size_t width,
     bvt &literals);
 
   void set_literals(
@@ -81,7 +69,6 @@ public:
 protected:
   mappingt mapping;
   propt &prop;
-  const boolbv_widtht &boolbv_width;
 };
 
 #endif // CPROVER_SOLVERS_FLATTENING_BOOLBV_MAP_H

--- a/src/solvers/flattening/boolbv_map.h
+++ b/src/solvers/flattening/boolbv_map.h
@@ -37,10 +37,10 @@ public:
 
   void show(std::ostream &out) const;
 
-  void get_literals(
+  const bvt &get_literals(
     const irep_idt &identifier,
     const typet &type,
-    bvt &literals);
+    std::size_t width);
 
   void set_literals(
     const irep_idt &identifier,

--- a/src/solvers/flattening/boolbv_map.h
+++ b/src/solvers/flattening/boolbv_map.h
@@ -10,6 +10,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #ifndef CPROVER_SOLVERS_FLATTENING_BOOLBV_MAP_H
 #define CPROVER_SOLVERS_FLATTENING_BOOLBV_MAP_H
 
+#include <iosfwd>
 #include <vector>
 
 #include <util/type.h>
@@ -45,13 +46,8 @@ public:
   };
 
   typedef std::unordered_map<irep_idt, map_entryt> mappingt;
-  mappingt mapping;
 
-  void show() const;
-
-  map_entryt &get_map_entry(
-    const irep_idt &identifier,
-    const typet &type);
+  void show(std::ostream &out) const;
 
   void get_literals(
     const irep_idt &identifier,
@@ -68,7 +64,23 @@ public:
     const irep_idt &identifier,
     const typet &type);
 
+  optionalt<std::reference_wrapper<const map_entryt>>
+  get_map_entry(const irep_idt &identifier) const
+  {
+    const auto entry = mapping.find(identifier);
+    if(entry == mapping.end())
+      return {};
+
+    return optionalt<std::reference_wrapper<const map_entryt>>(entry->second);
+  }
+
+  const mappingt &get_mapping() const
+  {
+    return mapping;
+  }
+
 protected:
+  mappingt mapping;
   propt &prop;
   const boolbv_widtht &boolbv_width;
 };

--- a/src/solvers/flattening/boolbv_map.h
+++ b/src/solvers/flattening/boolbv_map.h
@@ -39,7 +39,6 @@ public:
     std::size_t width;
     bvtypet bvtype;
     typet type;
-    bool is_set = false;
     bvt literal_map;
 
     std::string get_value(const propt &) const;

--- a/src/solvers/flattening/bv_dimacs.cpp
+++ b/src/solvers/flattening/bv_dimacs.cpp
@@ -60,9 +60,7 @@ bool bv_dimacst::write_dimacs(std::ostream &out)
     {
       out << ' ';
 
-      if(!m.second.is_set)
-        out << '?';
-      else if(lit.is_constant())
+      if(lit.is_constant())
         out << (lit.is_true() ? "TRUE" : "FALSE");
       else
         out << lit.dimacs();

--- a/src/solvers/flattening/bv_dimacs.cpp
+++ b/src/solvers/flattening/bv_dimacs.cpp
@@ -49,7 +49,7 @@ bool bv_dimacst::write_dimacs(std::ostream &out)
   // dump mapping for selected bit-vectors
   for(const auto &m : get_map().mapping)
   {
-    const boolbv_mapt::literal_mapt &literal_map = m.second.literal_map;
+    const auto &literal_map = m.second.literal_map;
 
     if(literal_map.empty())
       continue;
@@ -57,13 +57,16 @@ bool bv_dimacst::write_dimacs(std::ostream &out)
     out << "c " << m.first;
 
     for(const auto &lit : literal_map)
-      if(!lit.is_set)
-        out << " "
-            << "?";
-      else if(lit.l.is_constant())
-        out << " " << (lit.l.is_true() ? "TRUE" : "FALSE");
+    {
+      out << ' ';
+
+      if(!m.second.is_set)
+        out << '?';
+      else if(lit.is_constant())
+        out << (lit.is_true() ? "TRUE" : "FALSE");
       else
-        out << " " << lit.l.dimacs();
+        out << lit.dimacs();
+    }
 
     out << "\n";
   }

--- a/src/solvers/flattening/bv_dimacs.cpp
+++ b/src/solvers/flattening/bv_dimacs.cpp
@@ -47,7 +47,7 @@ bool bv_dimacst::write_dimacs(std::ostream &out)
   }
 
   // dump mapping for selected bit-vectors
-  for(const auto &m : get_map().mapping)
+  for(const auto &m : get_map().get_mapping())
   {
     const auto &literal_map = m.second.literal_map;
 

--- a/src/solvers/flattening/bv_pointers.cpp
+++ b/src/solvers/flattening/bv_pointers.cpp
@@ -231,12 +231,7 @@ bvt bv_pointerst::convert_pointer_type(const exprt &expr)
     const irep_idt &identifier=to_symbol_expr(expr).get_identifier();
     const typet &type=expr.type();
 
-    bvt bv;
-    bv.resize(bits);
-
-    map.get_literals(identifier, type, bv);
-
-    return bv;
+    return map.get_literals(identifier, type, bits);
   }
   else if(expr.id()==ID_nondet_symbol)
   {

--- a/src/solvers/flattening/bv_pointers.cpp
+++ b/src/solvers/flattening/bv_pointers.cpp
@@ -593,12 +593,11 @@ bvt bv_pointerst::convert_bitvector(const exprt &expr)
 exprt bv_pointerst::bv_get_rec(
   const exprt &expr,
   const bvt &bv,
-  const std::vector<bool> &unknown,
   std::size_t offset,
   const typet &type) const
 {
   if(type.id()!=ID_pointer)
-    return SUB::bv_get_rec(expr, bv, unknown, offset, type);
+    return SUB::bv_get_rec(expr, bv, offset, type);
 
   std::string value_addr, value_offset, value;
 
@@ -607,18 +606,14 @@ exprt bv_pointerst::bv_get_rec(
     char ch=0;
     std::size_t bit_nr=i+offset;
 
-    if(unknown[bit_nr])
-      ch='0';
-    else
+    // clang-format off
+    switch(prop.l_get(bv[bit_nr]).get_value())
     {
-      switch(prop.l_get(bv[bit_nr]).get_value())
-      {
-       case tvt::tv_enumt::TV_FALSE: ch='0'; break;
-       case tvt::tv_enumt::TV_TRUE:  ch='1'; break;
-       case tvt::tv_enumt::TV_UNKNOWN: ch='0'; break;
-       default: UNREACHABLE;
-      }
+    case tvt::tv_enumt::TV_FALSE: ch = '0'; break;
+    case tvt::tv_enumt::TV_TRUE: ch = '1'; break;
+    case tvt::tv_enumt::TV_UNKNOWN: ch = '0'; break;
     }
+    // clang-format on
 
     value=ch+value;
 

--- a/src/solvers/flattening/bv_pointers.cpp
+++ b/src/solvers/flattening/bv_pointers.cpp
@@ -234,7 +234,7 @@ bvt bv_pointerst::convert_pointer_type(const exprt &expr)
     bvt bv;
     bv.resize(bits);
 
-    map.get_literals(identifier, type, bits, bv);
+    map.get_literals(identifier, type, bv);
 
     return bv;
   }

--- a/src/solvers/flattening/bv_pointers.h
+++ b/src/solvers/flattening/bv_pointers.h
@@ -46,7 +46,6 @@ protected:
   exprt bv_get_rec(
     const exprt &expr,
     const bvt &bv,
-    const std::vector<bool> &unknown,
     std::size_t offset,
     const typet &type) const override;
 


### PR DESCRIPTION
The Boolean flag is_set does not need to be stored for each individual
bit as all entries will either be false (initial state) or be true. It
is not possible for only some of the bits to be set.

On the benchmark that triggered me looking into this, memory consumption
caused by boolbv_mapt::get_map_entry was 4.50 GB, and is now 2.25 GB
(which is reasonable, because the bool-typed struct member likely
resulted in padding being generated that would effectively double the
memory consumption).

In addition to memory savings, some of the code can now be simplified as
the entire vector can be copied at once.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [x] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
