### PR TITLE
[HOTFIX] Rename version tag during release.

### DIFF
--- a/.github/workflows/regular-release.yaml
+++ b/.github/workflows/regular-release.yaml
@@ -33,12 +33,12 @@ jobs:
         uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.DB_CI_CPROVER_ACCESS_TOKEN }}
-          CBMC_TAG: ${{ needs.get-version-information.outputs.version }}
+          CBMC_VERSION: ${{ needs.get-version-information.outputs.version }}
         with:
-          tag_name: ${{ env.CBMC_TAG }}
-          release_name: ${{ env.CBMC_TAG }}
+          tag_name: cbmc-${{ env.CBMC_VERSION }}
+          release_name: cbmc-${{ env.CBMC_VERSION }}
           body: |
-            This is CBMC version ${{ env.CBMC_TAG }}.
+            This is CBMC version ${{ env.CBMC_VERSION }}.
 
             ## MacOS
 
@@ -60,19 +60,19 @@ jobs:
 
             ```sh
             # Ubuntu 18:
-            $ dpkg -i ubuntu-18.04-cbmc-${{ env.CBMC_TAG }}-Linux.deb
+            $ dpkg -i ubuntu-18.04-cbmc-${{ env.CBMC_VERSION }}-Linux.deb
             # Ubuntu 20:
-            $ dpkg -i ubuntu-20.04-cbmc-${{ env.CBMC_TAG }}-Linux.deb
+            $ dpkg -i ubuntu-20.04-cbmc-${{ env.CBMC_VERSION }}-Linux.deb
             ```
 
             ## Windows
 
-            On Windows, install CBMC by downloading the `cbmc-${{ env.CBMC_TAG }}-win64.msi` installer below, double-clicking on the installer to run it, and adding the folder `C:\Program Files\cbmc\bin` in your `PATH` environment variable.
+            On Windows, install CBMC by downloading the `cbmc-${{ env.CBMC_VERSION }}-win64.msi` installer below, double-clicking on the installer to run it, and adding the folder `C:\Program Files\cbmc\bin` in your `PATH` environment variable.
 
             For installation from the windows command prompt, run:
 
             ```sh
-            msiexec /i cbmc-${{ env.CBMC_TAG }}-win64.msi
+            msiexec /i cbmc-${{ env.CBMC_VERSION }}-win64.msi
             PATH="C:\Program Files\cbmc\bin";%PATH%
             ```
 
@@ -87,7 +87,7 @@ jobs:
             set up correctly, and then issue:
 
             ```sh
-            $ docker run -it diffblue/cbmc:${{ env.CBMC-TAG }}
+            $ docker run -it diffblue/cbmc:${{ env.CBMC_VERSION }}
             #
             ```
 


### PR DESCRIPTION
Because of a recent refactoring during to our
regular release process script, we misnamed
the release tag, causing a number of automated
systems that were dependent on a specific form
of a release tag (e.g `cbmc-<version>`) to fall
over.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
