### PR TITLE
Remove unnecessary copy and loss of state information

### DIFF
--- a/src/goto-symex/goto_state.h
+++ b/src/goto-symex/goto_state.h
@@ -20,6 +20,10 @@ Author: Romain Brenguier, romain.brenguier@diffblue.com
 
 #include "renaming_level.h"
 
+// Forward declaration required since subclass is used explicitly
+// by the parent class.
+class goto_symex_statet;
+
 /// Container for data that varies per program point, e.g. the constant
 /// propagator state, when state needs to branch. This is copied out of
 /// goto_symex_statet at a control-flow fork and then back into it at a
@@ -82,8 +86,6 @@ public:
   goto_statet &operator=(goto_statet &&other) = default;
   goto_statet(const goto_statet &other) = default;
   goto_statet(goto_statet &&other) = default;
-
-  explicit goto_statet(const class goto_symex_statet &s);
 
   explicit goto_statet(guard_managert &guard_manager)
     : guard(true_exprt(), guard_manager), reachable(true)

--- a/src/goto-symex/goto_symex_state.h
+++ b/src/goto-symex/goto_symex_state.h
@@ -272,15 +272,4 @@ private:
   goto_symex_statet(const goto_symex_statet &other) = default;
 };
 
-inline goto_statet::goto_statet(const class goto_symex_statet &s)
-  : depth(s.depth),
-    level2(s.level2),
-    value_set(s.value_set),
-    guard(s.guard),
-    reachable(s.reachable),
-    propagation(s.propagation),
-    atomic_section_id(s.atomic_section_id)
-{
-}
-
 #endif // CPROVER_GOTO_SYMEX_GOTO_SYMEX_STATE_H


### PR DESCRIPTION
This removes a constructor that was not necessary
because it implemented the default behaviour of
the copy constructor (and thus created two places
to edit if changes were made to the class).

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
