### PR TITLE
Partly revert "Simplify initializer to remove byte_update"

### DIFF
--- a/regression/goto-instrument/dump-union2/main.c
+++ b/regression/goto-instrument/dump-union2/main.c
@@ -1,0 +1,27 @@
+#include <assert.h>
+
+struct S2
+{
+  signed char f0;
+  unsigned short f1;
+};
+
+union U10 {
+  unsigned short f0;
+  struct S2 f3;
+};
+
+union U10 g_2110 = {.f0 = 53747};
+
+union U6 {
+  signed f0 : 3;
+};
+
+union U6 g_1197 = {1L};
+
+int main()
+{
+  assert(g_2110.f0 == 53747);
+
+  return 0;
+}

--- a/regression/goto-instrument/dump-union2/test.desc
+++ b/regression/goto-instrument/dump-union2/test.desc
@@ -1,0 +1,11 @@
+CORE
+main.c
+--dump-c
+VERIFICATION SUCCESSFUL
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--
+This test must verify successfully also for the output generated using dump-c,
+which previously did not correctly represent the union initializer.

--- a/src/ansi-c/c_typecheck_initializer.cpp
+++ b/src/ansi-c/c_typecheck_initializer.cpp
@@ -72,10 +72,7 @@ exprt c_typecheck_baset::do_initializer_rec(
   }
 
   if(value.id()==ID_initializer_list)
-  {
-    return simplify_expr(
-      do_initializer_list(value, type, force_constant), *this);
-  }
+    return do_initializer_list(value, type, force_constant);
 
   if(
     value.id() == ID_array && value.get_bool(ID_C_string_constant) &&

--- a/src/goto-instrument/dump_c.cpp
+++ b/src/goto-instrument/dump_c.cpp
@@ -13,6 +13,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <util/byte_operators.h>
 #include <util/config.h>
+#include <util/expr_initializer.h>
 #include <util/find_symbols.h>
 #include <util/get_base_name.h>
 #include <util/invariant.h>
@@ -1462,6 +1463,24 @@ void dump_ct::cleanup_expr(exprt &expr)
         if(bu.value().type() == comp.type())
         {
           union_exprt union_expr{comp.get_name(), bu.value(), bu.op().type()};
+          expr.swap(union_expr);
+          break;
+        }
+      }
+    }
+    else if(
+      ns.follow(bu.type()).id() == ID_union &&
+      bu.source_location().get_function().empty() &&
+      bu.op() == zero_initializer(bu.op().type(), source_locationt{}, ns)
+                   .value_or(nil_exprt{}))
+    {
+      const union_typet &union_type = to_union_type(ns.follow(bu.type()));
+
+      for(const auto &comp : union_type.components())
+      {
+        if(bu.value().type() == comp.type())
+        {
+          union_exprt union_expr{comp.get_name(), bu.value(), bu.type()};
           expr.swap(union_expr);
           break;
         }


### PR DESCRIPTION
This reverts commit ac31213d57dbfcfba29909de3460254ead632d4a, which can
break dump-c output: the simplified expression may have padding
initialised to non-zero values. This works fine for any analysis, but
breaks dump-c as padding is not included in the output.

Found via tests generated CSmith, a minimised version of which is
included as a regression test.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
