### PR TITLE
Prevent users from misusing CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,20 @@
 cmake_minimum_required(VERSION 3.2)
 
+# If cmake generates files inside of the cbmc source directory this can lead to important files being overwritten, so we prevent that here
+if("${CMAKE_BINARY_DIR}" STREQUAL "${CMAKE_SOURCE_DIR}")
+  message(FATAL_ERROR
+    "We have detected that you were trying to invoke cmake with its output"
+    " directory being equal to the source directory.  You may have done this by"
+    " accident by invoking cmake from the cbmc top level directory without"
+    " specifying a build directory.  Since this can lead to cmake overwriting"
+    " files in the source tree, this is prohibited.  Please perform an"
+    " out-of-source build by either creating a separate build directory and"
+    " invoking cmake from there, or specifying a build directory with -B.\n"
+    "(see also: COMPILING.md)\n"
+    "Note that running this command will have created CMakeCache.txt"
+    " and a CMakeFiles directory; You should delete both of them.")
+endif()
+
 # Build a Release version by default (default build flags for each build type
 # are configured below).
 if (NOT EXISTS ${CMAKE_BINARY_DIR}/CMakeCache.txt)


### PR DESCRIPTION
When CMake is invoked from the source directory it will overwrite files
in there. In general CMake expects to be used for out-of-source builds.
Previously it was still possible to get this wrong by accident, this
just adds a check to prevent this from happening and tells people what
to do instead.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
