### PR TITLE
Remove {f,F}orall_subtypes

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -38,9 +38,7 @@ ForEachMacros: [
   'Forall_operands',
   'forall_expr',
   'Forall_expr',
-  'forall_symbol_base_map',
-  'forall_subtypes',
-  'Forall_subtypes']
+  'forall_symbol_base_map']
 IndentCaseLabels: 'false'
 IndentPPDirectives: AfterHash
 IndentWidth: '2'

--- a/src/ansi-c/ansi_c_convert_type.cpp
+++ b/src/ansi-c/ansi_c_convert_type.cpp
@@ -32,8 +32,8 @@ void ansi_c_convert_typet::read_rec(const typet &type)
 {
   if(type.id()==ID_merged_type)
   {
-    forall_subtypes(it, type)
-      read_rec(*it);
+    for(const typet &subtype : to_type_with_subtypes(type).subtypes())
+      read_rec(subtype);
   }
   else if(type.id()==ID_signed)
     signed_cnt++;

--- a/src/ansi-c/ansi_c_parser.cpp
+++ b/src/ansi-c/ansi_c_parser.cpp
@@ -164,9 +164,11 @@ ansi_c_id_classt ansi_c_parsert::get_class(const typet &type)
     return ansi_c_id_classt::ANSI_C_TAG;
   else if(type.id()==ID_merged_type)
   {
-    forall_subtypes(it, type)
-      if(get_class(*it)==ansi_c_id_classt::ANSI_C_TYPEDEF)
+    for(const typet &subtype : to_type_with_subtypes(type).subtypes())
+    {
+      if(get_class(subtype) == ansi_c_id_classt::ANSI_C_TYPEDEF)
         return ansi_c_id_classt::ANSI_C_TYPEDEF;
+    }
   }
   else if(type.has_subtype())
     return get_class(type.subtype());

--- a/src/ansi-c/c_storage_spec.cpp
+++ b/src/ansi-c/c_storage_spec.cpp
@@ -16,8 +16,8 @@ void c_storage_spect::read(const typet &type)
   if(type.id()==ID_merged_type ||
      type.id()==ID_code)
   {
-    forall_subtypes(it, type)
-      read(*it);
+    for(const typet &subtype : to_type_with_subtypes(type).subtypes())
+      read(subtype);
   }
   else if(type.id()==ID_static)
     is_static=true;

--- a/src/ansi-c/type2name.cpp
+++ b/src/ansi-c/type2name.cpp
@@ -258,9 +258,9 @@ static std::string type2name(
   if(type.has_subtypes())
   {
     result+='$';
-    forall_subtypes(it, type)
+    for(const typet &subtype : to_type_with_subtypes(type).subtypes())
     {
-      result+=type2name(*it, ns, symbol_number);
+      result += type2name(subtype, ns, symbol_number);
       result+='|';
     }
     result[result.size()-1]='$';

--- a/src/cpp/cpp_declaration.cpp
+++ b/src/cpp/cpp_declaration.cpp
@@ -57,7 +57,7 @@ void cpp_declarationt::name_anon_struct_union(typet &dest)
   }
   else if(dest.id()==ID_merged_type)
   {
-    Forall_subtypes(it, dest)
-      name_anon_struct_union(*it);
+    for(typet &subtype : to_type_with_subtypes(dest).subtypes())
+      name_anon_struct_union(subtype);
   }
 }

--- a/src/cpp/cpp_storage_spec.cpp
+++ b/src/cpp/cpp_storage_spec.cpp
@@ -12,8 +12,8 @@ void cpp_storage_spect::read(const typet &type)
 {
   if(type.id() == ID_merged_type || type.id() == ID_function_type)
   {
-    forall_subtypes(it, type)
-      read(*it);
+    for(const typet &subtype : to_type_with_subtypes(type).subtypes())
+      read(subtype);
   }
   else if(type.id() == ID_static)
     set_static();

--- a/src/cpp/cpp_typecheck_compound_type.cpp
+++ b/src/cpp/cpp_typecheck_compound_type.cpp
@@ -35,9 +35,11 @@ bool cpp_typecheckt::has_const(const typet &type)
     return true;
   else if(type.id()==ID_merged_type)
   {
-    forall_subtypes(it, type)
-      if(has_const(*it))
+    for(const typet &subtype : to_type_with_subtypes(type).subtypes())
+    {
+      if(has_const(subtype))
         return true;
+    }
 
     return false;
   }
@@ -51,9 +53,11 @@ bool cpp_typecheckt::has_volatile(const typet &type)
     return true;
   else if(type.id()==ID_merged_type)
   {
-    forall_subtypes(it, type)
-      if(has_volatile(*it))
+    for(const typet &subtype : to_type_with_subtypes(type).subtypes())
+    {
+      if(has_volatile(subtype))
         return true;
+    }
 
     return false;
   }
@@ -69,9 +73,11 @@ bool cpp_typecheckt::has_auto(const typet &type)
     type.id() == ID_merged_type || type.id() == ID_frontend_pointer ||
     type.id() == ID_pointer)
   {
-    forall_subtypes(it, type)
-      if(has_auto(*it))
+    for(const typet &subtype : to_type_with_subtypes(type).subtypes())
+    {
+      if(has_auto(subtype))
         return true;
+    }
 
     return false;
   }

--- a/src/cpp/template_map.cpp
+++ b/src/cpp/template_map.cpp
@@ -62,8 +62,8 @@ void template_mapt::apply(typet &type) const
   }
   else if(type.id()==ID_merged_type)
   {
-    Forall_subtypes(it, type)
-      apply(*it);
+    for(typet &subtype : to_type_with_subtypes(type).subtypes())
+      apply(subtype);
   }
 }
 

--- a/src/goto-instrument/dump_c.cpp
+++ b/src/goto-instrument/dump_c.cpp
@@ -1475,8 +1475,8 @@ void dump_ct::cleanup_expr(exprt &expr)
 
 void dump_ct::cleanup_type(typet &type)
 {
-  Forall_subtypes(it, type)
-    cleanup_type(*it);
+  for(typet &subtype : to_type_with_subtypes(type).subtypes())
+    cleanup_type(subtype);
 
   if(type.id()==ID_code)
   {

--- a/src/util/find_symbols.cpp
+++ b/src/util/find_symbols.cpp
@@ -124,8 +124,8 @@ void find_symbols(kindt kind, const typet &src, find_symbols_sett &dest)
     if(src.has_subtype())
       find_symbols(kind, to_type_with_subtype(src).subtype(), dest);
 
-    forall_subtypes(it, src)
-      find_symbols(kind, *it, dest);
+    for(const typet &subtype : to_type_with_subtypes(src).subtypes())
+      find_symbols(kind, subtype, dest);
 
     const irep_idt &typedef_name=src.get(ID_C_typedef);
     if(!typedef_name.empty())

--- a/src/util/rename_symbol.cpp
+++ b/src/util/rename_symbol.cpp
@@ -129,9 +129,11 @@ bool rename_symbolt::rename(typet &dest) const
     if(!rename(dest.subtype()))
       result=false;
 
-  Forall_subtypes(it, dest)
-    if(!rename(*it))
+  for(typet &subtype : to_type_with_subtypes(dest).subtypes())
+  {
+    if(!rename(subtype))
       result=false;
+  }
 
   if(dest.id()==ID_struct ||
      dest.id()==ID_union)
@@ -193,9 +195,11 @@ bool rename_symbolt::have_to_rename(const typet &dest) const
     if(have_to_rename(dest.subtype()))
       return true;
 
-  forall_subtypes(it, dest)
-    if(have_to_rename(*it))
+  for(const typet &subtype : to_type_with_subtypes(dest).subtypes())
+  {
+    if(have_to_rename(subtype))
       return true;
+  }
 
   if(dest.id()==ID_struct ||
      dest.id()==ID_union)

--- a/src/util/replace_symbol.cpp
+++ b/src/util/replace_symbol.cpp
@@ -170,9 +170,11 @@ bool replace_symbolt::replace(typet &dest) const
     if(!replace(dest.subtype()))
       result=false;
 
-  Forall_subtypes(it, dest)
-    if(!replace(*it))
+  for(typet &subtype : to_type_with_subtypes(dest).subtypes())
+  {
+    if(!replace(subtype))
       result=false;
+  }
 
   if(dest.id()==ID_struct ||
      dest.id()==ID_union)
@@ -212,9 +214,11 @@ bool replace_symbolt::have_to_replace(const typet &dest) const
     if(have_to_replace(dest.subtype()))
       return true;
 
-  forall_subtypes(it, dest)
-    if(have_to_replace(*it))
+  for(const typet &subtype : to_type_with_subtypes(dest).subtypes())
+  {
+    if(have_to_replace(subtype))
       return true;
+  }
 
   if(dest.id()==ID_struct ||
      dest.id()==ID_union)

--- a/src/util/type.h
+++ b/src/util/type.h
@@ -149,14 +149,6 @@ public:
     : typet(std::move(_id), std::move(_subtype))
   {
   }
-
-  #if 0
-  const typet &subtype() const
-  { return (typet &)find(ID_subtype); }
-
-  typet &subtype()
-  { return (typet &)add(ID_subtype); }
-  #endif
 };
 
 inline const type_with_subtypet &to_type_with_subtype(const typet &type)
@@ -212,17 +204,6 @@ inline type_with_subtypest &to_type_with_subtypes(typet &type)
 {
   return static_cast<type_with_subtypest &>(type);
 }
-
-#define forall_subtypes(it, type) \
-  if((type).has_subtypes()) /* NOLINT(readability/braces) */ \
-    for(type_with_subtypest::subtypest::const_iterator it=to_type_with_subtypes(type).subtypes().begin(), \
-        it##_end=to_type_with_subtypes(type).subtypes().end(); \
-        it!=it##_end; ++it)
-
-#define Forall_subtypes(it, type) \
-  if((type).has_subtypes()) /* NOLINT(readability/braces) */ \
-    for(type_with_subtypest::subtypest::iterator it=to_type_with_subtypes(type).subtypes().begin(); \
-        it!=to_type_with_subtypes(type).subtypes().end(); ++it)
 
 /// Remove const qualifier from type (if any).
 /// Returns type as is if there is no const qualifier.


### PR DESCRIPTION
This was useful in the past, but with C++-11 we can use a ranged-for to
avoid the iterator altogether.

As subtypes are no longer stored in a named sub (removing the
corresponding #if-0-disabled code), the ranged-for can be used directly
without testing for the existence of subtypes beforehand, as the forall
macro did.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
