### PR TITLE
Remove forall_rw_set_{r,w}_entries

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -30,8 +30,6 @@ DerivePointerAlignment: 'false'
 DisableFormat: 'false'
 ExperimentalAutoDetectBinPacking: 'false'
 ForEachMacros: [
-  'forall_rw_set_r_entries',
-  'forall_rw_set_w_entries',
   'forall_goto_functions',
   'Forall_goto_functions',
   'forall_goto_program_instructions',

--- a/src/goto-instrument/interrupt.cpp
+++ b/src/goto-instrument/interrupt.cpp
@@ -24,9 +24,9 @@ static bool potential_race_on_read(
   const rw_set_baset &isr_rw_set)
 {
   // R/W race?
-  forall_rw_set_r_entries(e_it, code_rw_set)
+  for(const auto &r_entry : code_rw_set.r_entries)
   {
-    if(isr_rw_set.has_w_entry(e_it->first))
+    if(isr_rw_set.has_w_entry(r_entry.first))
       return true;
   }
 
@@ -38,12 +38,12 @@ static bool potential_race_on_write(
   const rw_set_baset &isr_rw_set)
 {
   // W/R or W/W?
-  forall_rw_set_w_entries(e_it, code_rw_set)
+  for(const auto &w_entry : code_rw_set.w_entries)
   {
-    if(isr_rw_set.has_r_entry(e_it->first))
+    if(isr_rw_set.has_r_entry(w_entry.first))
       return true;
 
-    if(isr_rw_set.has_w_entry(e_it->first))
+    if(isr_rw_set.has_w_entry(w_entry.first))
       return true;
   }
 

--- a/src/goto-instrument/race_check.cpp
+++ b/src/goto-instrument/race_check.cpp
@@ -193,16 +193,16 @@ static void race_check(
       i_it++;
 
       // now add assignments for what is written -- set
-      forall_rw_set_w_entries(e_it, rw_set)
+      for(const auto &w_entry : rw_set.w_entries)
       {
-        if(!is_shared(ns, e_it->second.symbol_expr))
+        if(!is_shared(ns, w_entry.second.symbol_expr))
           continue;
 
         goto_programt::targett t = goto_program.insert_before(
           i_it,
           goto_programt::make_assignment(
-            w_guards.get_w_guard_expr(e_it->second),
-            e_it->second.guard,
+            w_guards.get_w_guard_expr(w_entry.second),
+            w_entry.second.guard,
             original_instruction.source_location));
         i_it=++t;
       }
@@ -215,46 +215,46 @@ static void race_check(
       }
 
       // now add assignments for what is written -- reset
-      forall_rw_set_w_entries(e_it, rw_set)
+      for(const auto &w_entry : rw_set.w_entries)
       {
-        if(!is_shared(ns, e_it->second.symbol_expr))
+        if(!is_shared(ns, w_entry.second.symbol_expr))
           continue;
 
         goto_programt::targett t = goto_program.insert_before(
           i_it,
           goto_programt::make_assignment(
-            w_guards.get_w_guard_expr(e_it->second),
+            w_guards.get_w_guard_expr(w_entry.second),
             false_exprt(),
             original_instruction.source_location));
         i_it = std::next(t);
       }
 
       // now add assertions for what is read and written
-      forall_rw_set_r_entries(e_it, rw_set)
+      for(const auto &r_entry : rw_set.r_entries)
       {
-        if(!is_shared(ns, e_it->second.symbol_expr))
+        if(!is_shared(ns, r_entry.second.symbol_expr))
           continue;
 
         goto_programt::targett t = goto_program.insert_before(
           i_it,
           goto_programt::make_assertion(
-            w_guards.get_assertion(e_it->second),
+            w_guards.get_assertion(r_entry.second),
             original_instruction.source_location));
-        t->source_location.set_comment(comment(e_it->second, false));
+        t->source_location.set_comment(comment(r_entry.second, false));
         i_it=++t;
       }
 
-      forall_rw_set_w_entries(e_it, rw_set)
+      for(const auto &w_entry : rw_set.w_entries)
       {
-        if(!is_shared(ns, e_it->second.symbol_expr))
+        if(!is_shared(ns, w_entry.second.symbol_expr))
           continue;
 
         goto_programt::targett t = goto_program.insert_before(
           i_it,
           goto_programt::make_assertion(
-            w_guards.get_assertion(e_it->second),
+            w_guards.get_assertion(w_entry.second),
             original_instruction.source_location));
-        t->source_location.set_comment(comment(e_it->second, true));
+        t->source_location.set_comment(comment(w_entry.second, true));
         i_it=++t;
       }
 

--- a/src/goto-instrument/rw_set.h
+++ b/src/goto-instrument/rw_set.h
@@ -107,14 +107,6 @@ inline std::ostream &operator<<(
   return out;
 }
 
-#define forall_rw_set_r_entries(it, rw_set) \
-  for(rw_set_baset::entriest::const_iterator it=(rw_set).r_entries.begin(); \
-      it!=(rw_set).r_entries.end(); it++)
-
-#define forall_rw_set_w_entries(it, rw_set) \
-  for(rw_set_baset::entriest::const_iterator it=(rw_set).w_entries.begin(); \
-      it!=(rw_set).w_entries.end(); it++)
-
 // a producer of read/write sets
 
 class _rw_set_loct:public rw_set_baset


### PR DESCRIPTION
This was useful in the past, but with C++-11 we can use a ranged-for to
avoid the iterator altogether.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
