### PR TITLE
Remove {f,F}orall_irep

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -38,8 +38,6 @@ ForEachMacros: [
   'Forall_operands',
   'forall_expr',
   'Forall_expr',
-  'forall_irep',
-  'Forall_irep',
   'forall_symbol_base_map',
   'forall_subtypes',
   'Forall_subtypes']

--- a/src/ansi-c/c_typecheck_expr.cpp
+++ b/src/ansi-c/c_typecheck_expr.cpp
@@ -433,12 +433,14 @@ void c_typecheck_baset::typecheck_expr_main(exprt &expr)
       expr.add(ID_generic_associations).get_sub();
 
     // first typecheck all types
-    Forall_irep(it, generic_associations)
-      if(it->get(ID_type_arg)!=ID_default)
+    for(auto &irep : generic_associations)
+    {
+      if(irep.get(ID_type_arg) != ID_default)
       {
-        typet &type=static_cast<typet &>(it->add(ID_type_arg));
+        typet &type = static_cast<typet &>(irep.add(ID_type_arg));
         typecheck_type(type);
       }
+    }
 
     // first try non-default match
     exprt default_match=nil_exprt();
@@ -446,13 +448,15 @@ void c_typecheck_baset::typecheck_expr_main(exprt &expr)
 
     const typet &op_type = follow(op.type());
 
-    forall_irep(it, generic_associations)
+    for(const auto &irep : generic_associations)
     {
-      if(it->get(ID_type_arg)==ID_default)
-        default_match=static_cast<const exprt &>(it->find(ID_value));
-      else if(op_type==
-              follow(static_cast<const typet &>(it->find(ID_type_arg))))
-        assoc_match=static_cast<const exprt &>(it->find(ID_value));
+      if(irep.get(ID_type_arg) == ID_default)
+        default_match = static_cast<const exprt &>(irep.find(ID_value));
+      else if(
+        op_type == follow(static_cast<const typet &>(irep.find(ID_type_arg))))
+      {
+        assoc_match = static_cast<const exprt &>(irep.find(ID_value));
+      }
     }
 
     if(assoc_match.is_nil())

--- a/src/ansi-c/parser_static.inc
+++ b/src/ansi-c/parser_static.inc
@@ -410,10 +410,10 @@ static void adjust_KnR_parameters(
 
       // we just do a linear search over the parameters
       // this could be improved with a hash map
-      Forall_irep(a_it, parameters.get_sub())
+      for(auto &parameter : parameters.get_sub())
       {
         ansi_c_declarationt &p_decl=
-          to_ansi_c_declaration(static_cast<exprt &>(*a_it));
+          to_ansi_c_declaration(static_cast<exprt &>(parameter));
 
         if(p_decl.declarator().get_base_name()==base_name)
         {

--- a/src/cpp/cpp_convert_type.cpp
+++ b/src/cpp/cpp_convert_type.cpp
@@ -129,9 +129,9 @@ void cpp_convert_typet::read_template(const typet &type)
 
   irept &arguments=t.add(ID_arguments);
 
-  Forall_irep(it, arguments.get_sub())
+  for(auto &argument : arguments.get_sub())
   {
-    exprt &decl=static_cast<exprt &>(*it);
+    exprt &decl = static_cast<exprt &>(argument);
 
     // may be type or expression
     bool is_type=decl.get_bool(ID_is_type);

--- a/src/cpp/cpp_declarator_converter.cpp
+++ b/src/cpp/cpp_declarator_converter.cpp
@@ -572,9 +572,9 @@ irep_idt cpp_declarator_convertert::get_pretty_name()
 
     std::string result=scope->prefix+id2string(base_name)+"(";
 
-    forall_irep(it, parameters)
+    for(auto it = parameters.begin(); it != parameters.end(); ++it)
     {
-      const typet &parameter_type=((exprt &)*it).type();
+      const typet &parameter_type = ((exprt &)*it).type();
 
       if(it!=parameters.begin())
         result+=", ";

--- a/src/cpp/cpp_enum_type.cpp
+++ b/src/cpp/cpp_enum_type.cpp
@@ -26,10 +26,10 @@ irep_idt cpp_enum_typet::generate_anon_tag() const
 
   std::string result="#anonE";
 
-  forall_irep(it, b)
+  for(const auto &value : b)
   {
     result+='#';
-    result+=id2string(it->get(ID_name));
+    result += id2string(value.get(ID_name));
   }
 
   return result;

--- a/src/cpp/cpp_name.cpp
+++ b/src/cpp/cpp_name.cpp
@@ -44,14 +44,14 @@ void cpp_namet::convert(
   std::string &identifier,
   std::string &base_name) const
 {
-  forall_irep(it, get_sub())
+  for(const auto &irep : get_sub())
   {
-    const irep_idt id=it->id();
+    const irep_idt id = irep.id();
 
     std::string name_component;
 
     if(id==ID_name)
-      name_component=it->get_string(ID_identifier);
+      name_component = irep.get_string(ID_identifier);
     else if(id==ID_template_args)
     {
       std::stringstream ss;
@@ -60,7 +60,7 @@ void cpp_namet::convert(
       throw ss.str();
     }
     else
-      name_component=it->id_string();
+      name_component = irep.id_string();
 
     identifier+=name_component;
 
@@ -76,14 +76,14 @@ std::string cpp_namet::to_string() const
 {
   std::string str;
 
-  forall_irep(it, get_sub())
+  for(const auto &irep : get_sub())
   {
-    if(it->id()=="::")
-      str += it->id_string();
-    else if(it->id()==ID_template_args)
+    if(irep.id() == "::")
+      str += irep.id_string();
+    else if(irep.id() == ID_template_args)
       str += "<...>";
     else
-      str+=it->get_string(ID_identifier);
+      str += irep.get_string(ID_identifier);
   }
 
   return str;

--- a/src/cpp/cpp_name.h
+++ b/src/cpp/cpp_name.h
@@ -108,9 +108,11 @@ public:
 
   bool is_qualified() const
   {
-    forall_irep(it, get_sub())
-      if(it->id()=="::")
+    for(const auto &irep : get_sub())
+    {
+      if(irep.id() == "::")
         return true;
+    }
     return false;
   }
 
@@ -121,9 +123,11 @@ public:
 
   bool has_template_args() const
   {
-    forall_irep(it, get_sub())
-      if(it->id()==ID_template_args)
+    for(const auto &irep : get_sub())
+    {
+      if(irep.id() == ID_template_args)
         return true;
+    }
 
     return false;
   }

--- a/src/cpp/cpp_type2name.cpp
+++ b/src/cpp/cpp_type2name.cpp
@@ -84,13 +84,13 @@ static std::string irep2name(const irept &irep)
     }
   }
 
-  forall_irep(it, irep.get_sub())
+  for(const auto &sub : irep.get_sub())
   {
     if(first)
       first=false;
     else
       result+=',';
-    result += irep2name(*it);
+    result += irep2name(sub);
   }
 
   result+=')';

--- a/src/cpp/cpp_typecheck_bases.cpp
+++ b/src/cpp/cpp_typecheck_bases.cpp
@@ -22,10 +22,9 @@ void cpp_typecheckt::typecheck_compound_bases(struct_typet &type)
 
   irept::subt &bases_irep=type.add(ID_bases).get_sub();
 
-  Forall_irep(base_it, bases_irep)
+  for(auto &base : bases_irep)
   {
-    const cpp_namet &name=
-      to_cpp_name(base_it->find(ID_name));
+    const cpp_namet &name = to_cpp_name(base.find(ID_name));
 
     exprt base_symbol_expr=
       resolve(
@@ -68,8 +67,8 @@ void cpp_typecheckt::typecheck_compound_bases(struct_typet &type)
       throw 0;
     }
 
-    bool virtual_base = base_it->get_bool(ID_virtual);
-    irep_idt class_access = base_it->get(ID_protection);
+    bool virtual_base = base.get_bool(ID_virtual);
+    irep_idt class_access = base.get(ID_protection);
 
     if(class_access.empty())
       class_access = default_class_access;
@@ -80,7 +79,7 @@ void cpp_typecheckt::typecheck_compound_bases(struct_typet &type)
     if(virtual_base)
       base_symbol_expr.set(ID_virtual, true);
 
-    base_it->swap(base_symbol_expr);
+    base.swap(base_symbol_expr);
 
     // Add base scopes as parents to the current scope
     cpp_scopes.current_scope().add_secondary_scope(

--- a/src/cpp/cpp_typecheck_compound_type.cpp
+++ b/src/cpp/cpp_typecheck_compound_type.cpp
@@ -1257,9 +1257,10 @@ void cpp_typecheckt::move_member_initializers(
       value = code_blockt{{to_code(value)}};
 
     exprt::operandst::iterator o_it=value.operands().begin();
-    forall_irep(it, initializers.get_sub())
+    for(const auto &initializer : initializers.get_sub())
     {
-      o_it=value.operands().insert(o_it, static_cast<const exprt &>(*it));
+      o_it =
+        value.operands().insert(o_it, static_cast<const exprt &>(initializer));
       o_it++;
     }
   }
@@ -1620,10 +1621,8 @@ bool cpp_typecheckt::check_component_access(
   // check friendship
   const irept::subt &friends = struct_union_type.find(ID_C_friends).get_sub();
 
-  forall_irep(f_it, friends)
+  for(const auto &friend_symb : friends)
   {
-    const irept &friend_symb=*f_it;
-
     const cpp_scopet &friend_scope =
       cpp_scopes.get_scope(friend_symb.get(ID_identifier));
 

--- a/src/cpp/cpp_typecheck_constructor.cpp
+++ b/src/cpp/cpp_typecheck_constructor.cpp
@@ -423,9 +423,8 @@ void cpp_typecheckt::check_member_initializers(
 {
   assert(initializers.id()==ID_member_initializers);
 
-  forall_irep(init_it, initializers.get_sub())
+  for(const auto &initializer : initializers.get_sub())
   {
-    const irept &initializer=*init_it;
     assert(initializer.is_not_nil());
 
     const cpp_namet &member_name=
@@ -601,10 +600,8 @@ void cpp_typecheckt::full_member_initialization(
       // explicitly calls the parent constructor.
       bool found=false;
 
-      forall_irep(m_it, initializers.get_sub())
+      for(irept initializer : initializers.get_sub())
       {
-        irept initializer=*m_it;
-
         const cpp_namet &member_name=
           to_cpp_name(initializer.find(ID_member));
 
@@ -715,10 +712,8 @@ void cpp_typecheckt::full_member_initialization(
     // Check if the initialization list of the constructor
     // explicitly initializes the data member
     bool found=false;
-    Forall_irep(m_it, initializers.get_sub())
+    for(auto &initializer : initializers.get_sub())
     {
-      irept &initializer=*m_it;
-
       if(initializer.get(ID_member)!=ID_cpp_name)
         continue;
       cpp_namet &member_name=(cpp_namet&) initializer.add(ID_member);

--- a/src/cpp/cpp_typecheck_enum_type.cpp
+++ b/src/cpp/cpp_typecheck_enum_type.cpp
@@ -30,13 +30,13 @@ void cpp_typecheckt::typecheck_enum_body(symbolt &enum_symbol)
 
   mp_integer i=0;
 
-  Forall_irep(it, components)
+  for(auto &component : components)
   {
-    const irep_idt &name=it->get(ID_name);
+    const irep_idt &name = component.get(ID_name);
 
-    if(it->find(ID_value).is_not_nil())
+    if(component.find(ID_value).is_not_nil())
     {
-      exprt &value=static_cast<exprt &>(it->add(ID_value));
+      exprt &value = static_cast<exprt &>(component.add(ID_value));
       typecheck_expr(value);
       implicit_typecast(value, c_enum_type.subtype());
       make_constant(value);
@@ -56,8 +56,8 @@ void cpp_typecheckt::typecheck_enum_body(symbolt &enum_symbol)
     symbol.name=id2string(enum_symbol.name)+"::"+id2string(name);
     symbol.base_name=name;
     symbol.value=value_expr;
-    symbol.location=
-      static_cast<const source_locationt &>(it->find(ID_C_source_location));
+    symbol.location = static_cast<const source_locationt &>(
+      component.find(ID_C_source_location));
     symbol.mode = enum_symbol.mode;
     symbol.module=module;
     symbol.type=enum_tag_type;

--- a/src/cpp/expr2cpp.cpp
+++ b/src/cpp/expr2cpp.cpp
@@ -232,7 +232,7 @@ std::string expr2cppt::convert_rec(
 
     const irept::subt &arguments=src.find(ID_arguments).get_sub();
 
-    forall_irep(it, arguments)
+    for(auto it = arguments.begin(); it != arguments.end(); ++it)
     {
       if(it!=arguments.begin())
         dest+=", ";

--- a/src/cpp/parse.cpp
+++ b/src/cpp/parse.cpp
@@ -1756,12 +1756,14 @@ bool Parser::rOtherDeclaration(
     assert(!type_name.get_sub().empty());
 
     bool is_destructor=false;
-    forall_irep(it, type_name.get_sub())
-      if(it->id()=="~")
+    for(const auto &irep : type_name.get_sub())
+    {
+      if(irep.id() == "~")
       {
         is_destructor=true;
         break;
       }
+    }
 
     cpp_declaratort constructor_declarator;
     typet trailing_return_type;

--- a/src/cpp/template_map.cpp
+++ b/src/cpp/template_map.cpp
@@ -54,10 +54,10 @@ void template_mapt::apply(typet &type) const
 
     irept::subt &parameters=type.add(ID_parameters).get_sub();
 
-    Forall_irep(it, parameters)
+    for(auto &parameter : parameters)
     {
-      if(it->id()==ID_parameter)
-        apply(static_cast<typet &>(it->add(ID_type)));
+      if(parameter.id() == ID_parameter)
+        apply(static_cast<typet &>(parameter.add(ID_type)));
     }
   }
   else if(type.id()==ID_merged_type)

--- a/src/goto-instrument/dump_c.cpp
+++ b/src/goto-instrument/dump_c.cpp
@@ -436,15 +436,16 @@ void dump_ct::convert_compound(
 
   const irept &bases = type.find(ID_bases);
   std::stringstream base_decls;
-  forall_irep(parent_it, bases.get_sub())
+  for(const auto &parent : bases.get_sub())
   {
     UNREACHABLE;
-    /*
-    assert(parent_it->id() == ID_base);
-    assert(parent_it->get(ID_type) == ID_struct_tag);
+    (void)parent;
+#if 0
+    assert(parent.id() == ID_base);
+    assert(parent.get(ID_type) == ID_struct_tag);
 
     const irep_idt &base_id=
-      parent_it->find(ID_type).get(ID_identifier);
+      parent.find(ID_type).get(ID_identifier);
     const irep_idt &renamed_base_id=global_renaming[base_id];
     const symbolt &parsymb=ns.lookup(renamed_base_id);
 
@@ -452,10 +453,10 @@ void dump_ct::convert_compound(
 
     base_decls << id2string(renamed_base_id) +
       (parent_it+1==bases.get_sub().end()?"":", ");
-      */
+#endif
   }
 
-  /*
+#if 0
   // for the constructor
   string constructor_args;
   string constructor_body;
@@ -471,7 +472,7 @@ void dump_ct::convert_compound(
   constructor_args += "const " + type_to_string(compo.type()) + "& " + component_name;
 
   constructor_body += indent + indent + "this->"+component_name + " = " + component_name + ";\n";
-  */
+#endif
 
   std::stringstream struct_body;
 

--- a/src/util/irep.cpp
+++ b/src/util/irep.cpp
@@ -434,7 +434,8 @@ std::size_t irept::hash() const
 
   std::size_t result=hash_string(id());
 
-  forall_irep(it, sub) result=hash_combine(result, it->hash());
+  for(const auto &irep : sub)
+    result = hash_combine(result, irep.hash());
 
   std::size_t number_of_named_ireps = 0;
 
@@ -466,7 +467,8 @@ std::size_t irept::full_hash() const
 
   std::size_t result=hash_string(id());
 
-  forall_irep(it, sub) result=hash_combine(result, it->full_hash());
+  for(const auto &irep : sub)
+    result = hash_combine(result, irep.full_hash());
 
   // this variant includes all named_sub elements
   for(const auto &irep_entry : named_sub)
@@ -514,7 +516,7 @@ std::string irept::pretty(unsigned indent, unsigned max_indent) const
 
   std::size_t count=0;
 
-  forall_irep(it, get_sub())
+  for(const auto &irep : get_sub())
   {
     result+="\n";
     indent_str(result, indent);
@@ -522,7 +524,7 @@ std::string irept::pretty(unsigned indent, unsigned max_indent) const
     result+=std::to_string(count++);
     result+=": ";
 
-    result+=it->pretty(indent+2, max_indent);
+    result += irep.pretty(indent + 2, max_indent);
   }
 
   return result;

--- a/src/util/irep.h
+++ b/src/util/irep.h
@@ -64,14 +64,6 @@ inline const std::string &name2string(const irep_namet &n)
   #endif
 }
 
-#define forall_irep(it, irep) \
-  for(irept::subt::const_iterator it=(irep).begin(); \
-      it!=(irep).end(); ++it)
-
-#define Forall_irep(it, irep) \
-  for(irept::subt::iterator it=(irep).begin(); \
-      it!=(irep).end(); ++it)
-
 #ifdef IREP_DEBUG
 #include <iostream>
 #endif

--- a/src/util/irep_hash_container.cpp
+++ b/src/util/irep_hash_container.cpp
@@ -66,8 +66,8 @@ void irep_hash_container_baset::pack(
     packed.push_back(irep_id_hash()(irep.id()));
 
     packed.push_back(sub.size());
-    forall_irep(it, sub)
-      packed.push_back(number(*it));
+    for(const auto &sub_irep : sub)
+      packed.push_back(number(sub_irep));
 
     packed.push_back(named_sub_size);
     for(const auto &sub_irep : named_sub)
@@ -88,8 +88,8 @@ void irep_hash_container_baset::pack(
     packed.push_back(irep_id_hash()(irep.id()));
 
     packed.push_back(sub.size());
-    forall_irep(it, sub)
-      packed.push_back(number(*it));
+    for(const auto &sub_irep : sub)
+      packed.push_back(number(sub_irep));
 
     packed.push_back(non_comment_count);
     for(const auto &sub_irep : named_sub)

--- a/src/util/irep_serialization.cpp
+++ b/src/util/irep_serialization.cpp
@@ -25,10 +25,10 @@ void irep_serializationt::write_irep(
 {
   write_string_ref(out, irep.id());
 
-  forall_irep(it, irep.get_sub())
+  for(const auto &sub_irep : irep.get_sub())
   {
     out.put('S');
-    reference_convert(*it, out);
+    reference_convert(sub_irep, out);
   }
 
   for(const auto &sub_irep_entry : irep.get_named_sub())

--- a/src/util/lispirep.cpp
+++ b/src/util/lispirep.cpp
@@ -61,7 +61,7 @@ void irep2lisp(const irept &src, lispexprt &dest)
 
   // reserve objects for extra performance
 
-  forall_irep(it, src.get_sub())
+  for(const auto &irep : src.get_sub())
   {
     lispexprt name;
     name.type=lispexprt::String;
@@ -70,7 +70,7 @@ void irep2lisp(const irept &src, lispexprt &dest)
 
     lispexprt sub;
 
-    irep2lisp(*it, sub);
+    irep2lisp(irep, sub);
     dest.push_back(sub);
   }
 

--- a/src/util/merge_irep.cpp
+++ b/src/util/merge_irep.cpp
@@ -17,8 +17,11 @@ std::size_t to_be_merged_irept::hash() const
   const irept::subt &sub=get_sub();
   const irept::named_subt &named_sub=get_named_sub();
 
-  forall_irep(it, sub)
-    result=hash_combine(result, static_cast<const merged_irept &>(*it).hash());
+  for(const auto &irep : sub)
+  {
+    result =
+      hash_combine(result, static_cast<const merged_irept &>(irep).hash());
+  }
 
   for(const auto &irep_entry : named_sub)
   {
@@ -98,8 +101,8 @@ const merged_irept &merged_irepst::merged(const irept &irep)
   irept::subt &dest_sub=new_irep.get_sub();
   dest_sub.reserve(src_sub.size());
 
-  forall_irep(it, src_sub)
-    dest_sub.push_back(merged(*it)); // recursive call
+  for(const auto &sub_irep : src_sub)
+    dest_sub.push_back(merged(sub_irep)); // recursive call
 
   const irept::named_subt &src_named_sub=irep.get_named_sub();
   irept::named_subt &dest_named_sub=new_irep.get_named_sub();
@@ -148,10 +151,10 @@ const irept &merge_irept::merged(const irept &irep)
   irept::subt *dest_sub_ptr = nullptr;
 
   std::size_t index = 0;
-  forall_irep(it, src_sub)
+  for(const auto &sub_irep : src_sub)
   {
-    const irept &op = merged(*it); // recursive call
-    if(&op.read() != &(it->read()))
+    const irept &op = merged(sub_irep); // recursive call
+    if(&op.read() != &(sub_irep.read()))
     {
       if(!dest_sub_ptr)
         dest_sub_ptr = &(const_cast<irept &>(*entry.first)).get_sub();
@@ -203,8 +206,8 @@ const irept &merge_full_irept::merged(const irept &irep)
   irept::subt &dest_sub=new_irep.get_sub();
   dest_sub.reserve(src_sub.size());
 
-  forall_irep(it, src_sub)
-    dest_sub.push_back(merged(*it)); // recursive call
+  for(const auto &sub_irep : src_sub)
+    dest_sub.push_back(merged(sub_irep)); // recursive call
 
   const irept::named_subt &src_named_sub=irep.get_named_sub();
   irept::named_subt &dest_named_sub=new_irep.get_named_sub();

--- a/src/util/xml_irep.cpp
+++ b/src/util/xml_irep.cpp
@@ -23,10 +23,10 @@ void convert(
   if(irep.id()!=ID_nil)
     xml.new_element("id").data=irep.id_string();
 
-  forall_irep(it, irep.get_sub())
+  for(const auto &sub_irep : irep.get_sub())
   {
     xmlt &x_sub=xml.new_element("sub");
-    convert(*it, x_sub);
+    convert(sub_irep, x_sub);
   }
 
   for(const auto &irep_entry : irep.get_named_sub())


### PR DESCRIPTION
This was useful in the past, but with C++-11 we can use a ranged-for to
avoid the iterator altogether.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
