### PR TITLE
Remove {f,F}orall_named_irep

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -44,8 +44,6 @@ ForEachMacros: [
   'Forall_expr',
   'forall_irep',
   'Forall_irep',
-  'forall_named_irep',
-  'Forall_named_irep',
   'forall_symbol_base_map',
   'forall_subtypes',
   'Forall_subtypes']

--- a/src/cpp/cpp_type2name.cpp
+++ b/src/cpp/cpp_type2name.cpp
@@ -52,33 +52,37 @@ static std::string irep2name(const irept &irep)
   result+='(';
   bool first=true;
 
-  forall_named_irep(it, irep.get_named_sub())
-    if(!irept::is_comment(it->first))
+  for(const auto &named_sub : irep.get_named_sub())
+  {
+    if(!irept::is_comment(named_sub.first))
     {
       if(first)
         first = false;
       else
         result += ',';
 
-      result += do_prefix(name2string(it->first));
+      result += do_prefix(name2string(named_sub.first));
 
       result += '=';
-      result += irep2name(it->second);
+      result += irep2name(named_sub.second);
     }
+  }
 
-  forall_named_irep(it, irep.get_named_sub())
-    if(it->first==ID_C_constant ||
-       it->first==ID_C_volatile ||
-       it->first==ID_C_restricted)
+  for(const auto &named_sub : irep.get_named_sub())
+  {
+    if(
+      named_sub.first == ID_C_constant || named_sub.first == ID_C_volatile ||
+      named_sub.first == ID_C_restricted)
     {
       if(first)
         first=false;
       else
         result+=',';
-      result+=do_prefix(name2string(it->first));
+      result += do_prefix(name2string(named_sub.first));
       result+='=';
-      result += irep2name(it->second);
+      result += irep2name(named_sub.second);
     }
+  }
 
   forall_irep(it, irep.get_sub())
   {

--- a/src/util/irep.cpp
+++ b/src/util/irep.cpp
@@ -438,13 +438,15 @@ std::size_t irept::hash() const
 
   std::size_t number_of_named_ireps = 0;
 
-  forall_named_irep(it, named_sub)
-    if(!is_comment(it->first)) // this variant ignores comments
+  for(const auto &irep_entry : named_sub)
+  {
+    if(!is_comment(irep_entry.first)) // this variant ignores comments
     {
-      result = hash_combine(result, hash_string(it->first));
-      result = hash_combine(result, it->second.hash());
+      result = hash_combine(result, hash_string(irep_entry.first));
+      result = hash_combine(result, irep_entry.second.hash());
       number_of_named_ireps++;
     }
+  }
 
   result = hash_finalize(result, sub.size() + number_of_named_ireps);
 
@@ -467,10 +469,10 @@ std::size_t irept::full_hash() const
   forall_irep(it, sub) result=hash_combine(result, it->full_hash());
 
   // this variant includes all named_sub elements
-  forall_named_irep(it, named_sub)
+  for(const auto &irep_entry : named_sub)
   {
-    result=hash_combine(result, hash_string(it->first));
-    result=hash_combine(result, it->second.full_hash());
+    result = hash_combine(result, hash_string(irep_entry.first));
+    result = hash_combine(result, irep_entry.second.full_hash());
   }
 
   const std::size_t named_sub_size = named_sub.size();
@@ -498,16 +500,16 @@ std::string irept::pretty(unsigned indent, unsigned max_indent) const
     indent+=2;
   }
 
-  forall_named_irep(it, get_named_sub())
+  for(const auto &irep_entry : get_named_sub())
   {
     result+="\n";
     indent_str(result, indent);
 
     result+="* ";
-    result+=id2string(it->first);
+    result += id2string(irep_entry.first);
     result+=": ";
 
-    result+=it->second.pretty(indent+2, max_indent);
+    result += irep_entry.second.pretty(indent + 2, max_indent);
   }
 
   std::size_t count=0;

--- a/src/util/irep.h
+++ b/src/util/irep.h
@@ -72,14 +72,6 @@ inline const std::string &name2string(const irep_namet &n)
   for(irept::subt::iterator it=(irep).begin(); \
       it!=(irep).end(); ++it)
 
-#define forall_named_irep(it, irep) \
-  for(irept::named_subt::const_iterator it=(irep).begin(); \
-      it!=(irep).end(); ++it)
-
-#define Forall_named_irep(it, irep) \
-  for(irept::named_subt::iterator it=(irep).begin(); \
-      it!=(irep).end(); ++it)
-
 #ifdef IREP_DEBUG
 #include <iostream>
 #endif

--- a/src/util/irep_serialization.cpp
+++ b/src/util/irep_serialization.cpp
@@ -31,11 +31,11 @@ void irep_serializationt::write_irep(
     reference_convert(*it, out);
   }
 
-  forall_named_irep(it, irep.get_named_sub())
+  for(const auto &sub_irep_entry : irep.get_named_sub())
   {
     out.put('N');
-    write_string_ref(out, it->first);
-    reference_convert(it->second, out);
+    write_string_ref(out, sub_irep_entry.first);
+    reference_convert(sub_irep_entry.second, out);
   }
 
   out.put(0); // terminator

--- a/src/util/lispirep.cpp
+++ b/src/util/lispirep.cpp
@@ -74,16 +74,16 @@ void irep2lisp(const irept &src, lispexprt &dest)
     dest.push_back(sub);
   }
 
-  forall_named_irep(it, src.get_named_sub())
+  for(const auto &irep_entry : src.get_named_sub())
   {
     lispexprt name;
     name.type=lispexprt::String;
-    name.value=name2string(it->first);
+    name.value = name2string(irep_entry.first);
     dest.push_back(name);
 
     lispexprt sub;
 
-    irep2lisp(it->second, sub);
+    irep2lisp(irep_entry.second, sub);
     dest.push_back(sub);
   }
 

--- a/src/util/merge_irep.cpp
+++ b/src/util/merge_irep.cpp
@@ -20,12 +20,11 @@ std::size_t to_be_merged_irept::hash() const
   forall_irep(it, sub)
     result=hash_combine(result, static_cast<const merged_irept &>(*it).hash());
 
-  forall_named_irep(it, named_sub)
+  for(const auto &irep_entry : named_sub)
   {
-    result=hash_combine(result, hash_string(it->first));
-    result=
-      hash_combine(
-        result, static_cast<const merged_irept &>(it->second).hash());
+    result = hash_combine(result, hash_string(irep_entry.first));
+    result = hash_combine(
+      result, static_cast<const merged_irept &>(irep_entry.second).hash());
   }
 
   const std::size_t named_sub_size = named_sub.size();
@@ -108,14 +107,15 @@ const merged_irept &merged_irepst::merged(const irept &irep)
 #if NAMED_SUB_IS_FORWARD_LIST
   irept::named_subt::iterator before = dest_named_sub.before_begin();
 #endif
-  forall_named_irep(it, src_named_sub)
+  for(const auto &irep_entry : src_named_sub)
   {
 #if NAMED_SUB_IS_FORWARD_LIST
     dest_named_sub.emplace_after(
-      before, it->first, merged(it->second)); // recursive call
+      before, irep_entry.first, merged(irep_entry.second)); // recursive call
     ++before;
 #else
-    dest_named_sub[it->first]=merged(it->second); // recursive call
+    dest_named_sub[irep_entry.first] =
+      merged(irep_entry.second); // recursive call
 #endif
   }
 
@@ -164,12 +164,12 @@ const irept &merge_irept::merged(const irept &irep)
   irept::named_subt *dest_named_sub_ptr = nullptr;
 
   std::ptrdiff_t advance_by = 0;
-  forall_named_irep(it, src_named_sub)
+  for(const auto &irep_entry : src_named_sub)
   {
-    if(!irept::is_comment(it->first))
+    if(!irept::is_comment(irep_entry.first))
     {
-      const irept &op = merged(it->second); // recursive call
-      if(&op.read() != &(it->second.read()))
+      const irept &op = merged(irep_entry.second); // recursive call
+      if(&op.read() != &(irep_entry.second.read()))
       {
         if(!dest_named_sub_ptr)
           dest_named_sub_ptr =
@@ -212,14 +212,15 @@ const irept &merge_full_irept::merged(const irept &irep)
 #if NAMED_SUB_IS_FORWARD_LIST
   irept::named_subt::iterator before = dest_named_sub.before_begin();
 #endif
-  forall_named_irep(it, src_named_sub)
+  for(const auto &irep_entry : src_named_sub)
   {
 #if NAMED_SUB_IS_FORWARD_LIST
     dest_named_sub.emplace_after(
-      before, it->first, merged(it->second)); // recursive call
+      before, irep_entry.first, merged(irep_entry.second)); // recursive call
     ++before;
 #else
-    dest_named_sub[it->first]=merged(it->second); // recursive call
+    dest_named_sub[irep_entry.first] =
+      merged(irep_entry.second); // recursive call
 #endif
   }
 

--- a/src/util/source_location.cpp
+++ b/src/util/source_location.cpp
@@ -72,10 +72,10 @@ std::string source_locationt::as_string(bool print_cwd) const
 
 void source_locationt::merge(const source_locationt &from)
 {
-  forall_named_irep(it, from.get_named_sub())
+  for(const auto &irep_entry : from.get_named_sub())
   {
-    if(get(it->first).empty())
-      set(it->first, it->second);
+    if(get(irep_entry.first).empty())
+      set(irep_entry.first, irep_entry.second);
   }
 }
 

--- a/src/util/xml_irep.cpp
+++ b/src/util/xml_irep.cpp
@@ -29,21 +29,25 @@ void convert(
     convert(*it, x_sub);
   }
 
-  forall_named_irep(it, irep.get_named_sub())
-    if(!irept::is_comment(it->first))
+  for(const auto &irep_entry : irep.get_named_sub())
+  {
+    if(!irept::is_comment(irep_entry.first))
     {
       xmlt &x_nsub = xml.new_element("named_sub");
-      x_nsub.set_attribute("name", name2string(it->first));
-      convert(it->second, x_nsub);
+      x_nsub.set_attribute("name", name2string(irep_entry.first));
+      convert(irep_entry.second, x_nsub);
     }
+  }
 
-  forall_named_irep(it, irep.get_named_sub())
-    if(!irept::is_comment(it->first))
+  for(const auto &irep_entry : irep.get_named_sub())
+  {
+    if(!irept::is_comment(irep_entry.first))
     {
       xmlt &x_com = xml.new_element("comment");
-      x_com.set_attribute("name", name2string(it->first));
-      convert(it->second, x_com);
+      x_com.set_attribute("name", name2string(irep_entry.first));
+      convert(irep_entry.second, x_com);
     }
+  }
 }
 
 void convert(


### PR DESCRIPTION
This was useful in the past, but with C++-11 we can use a ranged-for to
avoid the iterator altogether.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
