### PR TITLE
Replace some uses of {F,f}orall_expr by ranged-for

### DIFF
--- a/src/analyses/goto_rw.cpp
+++ b/src/analyses/goto_rw.cpp
@@ -745,9 +745,11 @@ static void goto_rw(
   rw_set.get_objects_rec(
     function, target, rw_range_sett::get_modet::READ, function_call.function());
 
-  forall_expr(it, function_call.arguments())
+  for(const auto &argument : function_call.arguments())
+  {
     rw_set.get_objects_rec(
-      function, target, rw_range_sett::get_modet::READ, *it);
+      function, target, rw_range_sett::get_modet::READ, argument);
+  }
 }
 
 void goto_rw(

--- a/src/goto-instrument/dump_c.cpp
+++ b/src/goto-instrument/dump_c.cpp
@@ -1368,24 +1368,26 @@ void dump_ct::cleanup_expr(exprt &expr)
       if(parameters.size()==arguments.size())
       {
         code_typet::parameterst::const_iterator it=parameters.begin();
-        Forall_expr(it2, arguments)
+        for(auto &argument : arguments)
         {
           const typet &type=ns.follow(it->type());
           if(type.id()==ID_union &&
              type.get_bool(ID_C_transparent_union))
           {
-            if(it2->id() == ID_typecast && it2->type() == type)
-              *it2=to_typecast_expr(*it2).op();
+            if(argument.id() == ID_typecast && argument.type() == type)
+              argument = to_typecast_expr(argument).op();
 
             // add a typecast for NULL or 0
-            if(it2->id()==ID_constant &&
-               (it2->is_zero() || to_constant_expr(*it2).get_value()==ID_NULL))
+            if(
+              argument.id() == ID_constant &&
+              (argument.is_zero() ||
+               to_constant_expr(argument).get_value() == ID_NULL))
             {
               const typet &comp_type=
                 to_union_type(type).components().front().type();
 
               if(comp_type.id()==ID_pointer)
-                *it2=typecast_exprt(*it2, comp_type);
+                argument = typecast_exprt(argument, comp_type);
             }
           }
 

--- a/src/goto-instrument/goto_program2code.cpp
+++ b/src/goto-instrument/goto_program2code.cpp
@@ -1435,13 +1435,12 @@ void goto_program2codet::cleanup_code(
 
   if(code.has_operands())
   {
-    exprt::operandst &operands=code.operands();
-    Forall_expr(it, operands)
+    for(auto &op : code.operands())
     {
-      if(it->id()==ID_code)
-        cleanup_code(to_code(*it), code.get_statement());
+      if(op.id() == ID_code)
+        cleanup_code(to_code(op), code.get_statement());
       else
-        cleanup_expr(*it, false);
+        cleanup_expr(op, false);
     }
   }
 
@@ -1498,10 +1497,14 @@ void goto_program2codet::cleanup_function_call(
     if(parameters.size()==arguments.size())
     {
       code_typet::parameterst::const_iterator it=parameters.begin();
-      Forall_expr(it2, arguments)
+      for(auto &argument : arguments)
       {
-        if(it2->type().id() == ID_union || it2->type().id() == ID_union_tag)
-          it2->type()=it->type();
+        if(
+          argument.type().id() == ID_union ||
+          argument.type().id() == ID_union_tag)
+        {
+          argument.type() = it->type();
+        }
         ++it;
       }
     }

--- a/src/goto-instrument/value_set_fi_fp_removal.cpp
+++ b/src/goto-instrument/value_set_fi_fp_removal.cpp
@@ -105,8 +105,8 @@ void remove_function_pointer(
   if(call_type.has_ellipsis() && call_type.parameters().empty())
   {
     call_type.remove_ellipsis();
-    forall_expr(it, code.arguments())
-      call_type.parameters().push_back(code_typet::parametert(it->type()));
+    for(const auto &argument : code.arguments())
+      call_type.parameters().push_back(code_typet::parametert(argument.type()));
   }
 
   const exprt &pointer = to_dereference_expr(function).pointer();

--- a/src/goto-programs/builtin_functions.cpp
+++ b/src/goto-programs/builtin_functions.cpp
@@ -1059,8 +1059,8 @@ void goto_convertt::do_function_call_symbol(
 
     codet fence(ID_fence);
 
-    forall_expr(it, arguments)
-      fence.set(get_string_constant(*it), true);
+    for(const auto &argument : arguments)
+      fence.set(get_string_constant(argument), true);
 
     dest.add(goto_programt::make_other(fence, function.source_location()));
   }

--- a/src/goto-programs/goto_convert_function_call.cpp
+++ b/src/goto-programs/goto_convert_function_call.cpp
@@ -53,8 +53,8 @@ void goto_convertt::do_function_call(
 
   clean_expr(new_function, dest, mode);
 
-  Forall_expr(it, new_arguments)
-    clean_expr(*it, dest, mode);
+  for(auto &new_argument : new_arguments)
+    clean_expr(new_argument, dest, mode);
 
   // split on the function
 

--- a/src/goto-programs/goto_program.cpp
+++ b/src/goto-programs/goto_program.cpp
@@ -292,8 +292,8 @@ std::list<exprt> expressions_read(
   case FUNCTION_CALL:
   {
     const code_function_callt &function_call = instruction.get_function_call();
-    forall_expr(it, function_call.arguments())
-      dest.push_back(*it);
+    for(const auto &argument : function_call.arguments())
+      dest.push_back(argument);
     if(function_call.lhs().is_not_nil())
       parse_lhs_read(function_call.lhs(), dest);
     break;

--- a/src/goto-programs/remove_function_pointers.cpp
+++ b/src/goto-programs/remove_function_pointers.cpp
@@ -279,9 +279,10 @@ void remove_function_pointerst::remove_function_pointer(
      call_type.parameters().empty())
   {
     call_type.remove_ellipsis();
-    forall_expr(it, code.arguments())
-      call_type.parameters().push_back(
-        code_typet::parametert(it->type()));
+    for(const auto &argument : code.arguments())
+    {
+      call_type.parameters().push_back(code_typet::parametert(argument.type()));
+    }
   }
 
   bool found_functions;

--- a/src/goto-symex/symex_function_call.cpp
+++ b/src/goto-symex/symex_function_call.cpp
@@ -200,8 +200,8 @@ void goto_symext::symex_function_call_symbol(
 
   code.function() = clean_expr(std::move(code.function()), state, false);
 
-  Forall_expr(it, code.arguments())
-    *it = clean_expr(std::move(*it), state, false);
+  for(auto &argument : code.arguments())
+    argument = clean_expr(std::move(argument), state, false);
 
   target.location(state.guard.as_expr(), state.source);
 

--- a/src/solvers/flattening/boolbv_array.cpp
+++ b/src/solvers/flattening/boolbv_array.cpp
@@ -32,9 +32,9 @@ bvt boolbvt::convert_array(const exprt &expr)
     bvt bv;
     bv.reserve(width);
 
-    forall_expr(it, operands)
+    for(const auto &op : operands)
     {
-      const bvt &tmp = convert_bv(*it, op_width);
+      const bvt &tmp = convert_bv(op, op_width);
 
       bv.insert(bv.end(), tmp.begin(), tmp.end());
     }

--- a/src/solvers/flattening/boolbv_complex.cpp
+++ b/src/solvers/flattening/boolbv_complex.cpp
@@ -27,9 +27,9 @@ bvt boolbvt::convert_complex(const complex_exprt &expr)
   const exprt::operandst &operands = expr.operands();
   std::size_t op_width = width / operands.size();
 
-  forall_expr(it, operands)
+  for(const auto &op : operands)
   {
-    const bvt &tmp = convert_bv(*it, op_width);
+    const bvt &tmp = convert_bv(op, op_width);
 
     bv.insert(bv.end(), tmp.begin(), tmp.end());
   }

--- a/src/solvers/flattening/boolbv_concatenation.cpp
+++ b/src/solvers/flattening/boolbv_concatenation.cpp
@@ -27,9 +27,9 @@ bvt boolbvt::convert_concatenation(const concatenation_exprt &expr)
   bvt bv;
   bv.resize(width);
 
-  forall_expr(it, operands)
+  for(const auto &operand : operands)
   {
-    const bvt &op=convert_bv(*it);
+    const bvt &op = convert_bv(operand);
 
     INVARIANT(
       op.size() <= offset,

--- a/src/solvers/flattening/boolbv_vector.cpp
+++ b/src/solvers/flattening/boolbv_vector.cpp
@@ -25,9 +25,9 @@ bvt boolbvt::convert_vector(const vector_exprt &expr)
   {
     std::size_t op_width = width / operands.size();
 
-    forall_expr(it, operands)
+    for(const auto &op : operands)
     {
-      const bvt &tmp = convert_bv(*it, op_width);
+      const bvt &tmp = convert_bv(op, op_width);
 
       bv.insert(bv.end(), tmp.begin(), tmp.end());
     }

--- a/src/solvers/prop/prop_conv_solver.cpp
+++ b/src/solvers/prop/prop_conv_solver.cpp
@@ -275,8 +275,8 @@ literalt prop_conv_solvert::convert_bool(const exprt &expr)
 
     bvt bv;
 
-    forall_expr(it, op)
-      bv.push_back(convert(*it));
+    for(const auto &operand : op)
+      bv.push_back(convert(operand));
 
     if(!bv.empty())
     {

--- a/src/util/expr_util.cpp
+++ b/src/util/expr_util.cpp
@@ -73,15 +73,15 @@ with_exprt make_with_expr(const update_exprt &src)
   with_exprt result{exprt{}, exprt{}, exprt{}};
   exprt *dest=&result;
 
-  forall_expr(it, designator)
+  for(const auto &expr : designator)
   {
     with_exprt tmp{exprt{}, exprt{}, exprt{}};
 
-    if(it->id()==ID_index_designator)
+    if(expr.id() == ID_index_designator)
     {
-      tmp.where()=to_index_designator(*it).index();
+      tmp.where() = to_index_designator(expr).index();
     }
-    else if(it->id()==ID_member_designator)
+    else if(expr.id() == ID_member_designator)
     {
       // irep_idt component_name=
       //  to_member_designator(*it).get_component_name();


### PR DESCRIPTION
In some (but not all!) cases of {F,}orall_expr we do not actually need the iterator.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
