### PR TITLE
Replace some uses of {f,F}orall_goto_program_instructions by ranged-for

### DIFF
--- a/jbmc/src/java_bytecode/remove_exceptions.cpp
+++ b/jbmc/src/java_bytecode/remove_exceptions.cpp
@@ -190,17 +190,17 @@ symbol_exprt remove_exceptionst::get_inflight_exception_global()
 bool remove_exceptionst::function_or_callees_may_throw(
   const goto_programt &goto_program) const
 {
-  forall_goto_program_instructions(instr_it, goto_program)
+  for(const auto &instruction : goto_program.instructions)
   {
-    if(instr_it->is_throw())
+    if(instruction.is_throw())
     {
       return true;
     }
 
-    if(instr_it->is_function_call())
+    if(instruction.is_function_call())
     {
-      const exprt &function_expr=
-        to_code_function_call(instr_it->code).function();
+      const exprt &function_expr =
+        to_code_function_call(instruction.code).function();
       DATA_INVARIANT(
         function_expr.id()==ID_symbol,
         "identifier expected to be a symbol");

--- a/src/analyses/goto_check.cpp
+++ b/src/analyses/goto_check.cpp
@@ -290,9 +290,9 @@ void goto_checkt::collect_allocations(
     return;
 
   forall_goto_functions(itf, goto_functions)
-    forall_goto_program_instructions(it, itf->second.body)
+  {
+    for(const auto &instruction : itf->second.body.instructions)
     {
-      const goto_programt::instructiont &instruction=*it;
       if(!instruction.is_function_call())
         continue;
 
@@ -313,6 +313,7 @@ void goto_checkt::collect_allocations(
       assert(args[0].type()==args[1].type());
       allocations.push_back({args[0], args[1]});
     }
+  }
 }
 
 void goto_checkt::invalidate(const exprt &lhs)
@@ -2092,28 +2093,33 @@ void goto_checkt::goto_check(
       }
     }
 
-    Forall_goto_program_instructions(i_it, new_code)
+    for(auto &instruction : new_code.instructions)
     {
-      if(i_it->source_location.is_nil())
+      if(instruction.source_location.is_nil())
       {
-        i_it->source_location.id(irep_idt());
+        instruction.source_location.id(irep_idt());
 
         if(!it->source_location.get_file().empty())
-          i_it->source_location.set_file(it->source_location.get_file());
+          instruction.source_location.set_file(it->source_location.get_file());
 
         if(!it->source_location.get_line().empty())
-          i_it->source_location.set_line(it->source_location.get_line());
+          instruction.source_location.set_line(it->source_location.get_line());
 
         if(!it->source_location.get_function().empty())
-          i_it->source_location.set_function(
+          instruction.source_location.set_function(
             it->source_location.get_function());
 
         if(!it->source_location.get_column().empty())
-          i_it->source_location.set_column(it->source_location.get_column());
+        {
+          instruction.source_location.set_column(
+            it->source_location.get_column());
+        }
 
         if(!it->source_location.get_java_bytecode_index().empty())
-          i_it->source_location.set_java_bytecode_index(
+        {
+          instruction.source_location.set_java_bytecode_index(
             it->source_location.get_java_bytecode_index());
+        }
       }
     }
 

--- a/src/analyses/local_bitvector_analysis.cpp
+++ b/src/analyses/local_bitvector_analysis.cpp
@@ -363,9 +363,9 @@ void local_bitvector_analysist::output(
 {
   unsigned l=0;
 
-  forall_goto_program_instructions(i_it, goto_function.body)
+  for(const auto &instruction : goto_function.body.instructions)
   {
-    out << "**** " << i_it->source_location << "\n";
+    out << "**** " << instruction.source_location << "\n";
 
     const auto &loc_info=loc_infos[l];
 
@@ -381,7 +381,7 @@ void local_bitvector_analysist::output(
     }
 
     out << "\n";
-    goto_function.body.output_instruction(ns, irep_idt(), out, *i_it);
+    goto_function.body.output_instruction(ns, irep_idt(), out, instruction);
     out << "\n";
 
     l++;

--- a/src/analyses/local_may_alias.cpp
+++ b/src/analyses/local_may_alias.cpp
@@ -474,9 +474,9 @@ void local_may_aliast::output(
 {
   unsigned l=0;
 
-  forall_goto_program_instructions(i_it, goto_function.body)
+  for(const auto &instruction : goto_function.body.instructions)
   {
-    out << "**** " << i_it->source_location << "\n";
+    out << "**** " << instruction.source_location << "\n";
 
     const loc_infot &loc_info=loc_infos[l];
 
@@ -502,7 +502,7 @@ void local_may_aliast::output(
     }
 
     out << "\n";
-    goto_function.body.output_instruction(ns, irep_idt(), out, *i_it);
+    goto_function.body.output_instruction(ns, irep_idt(), out, instruction);
     out << "\n";
 
     l++;

--- a/src/analyses/local_safe_pointers.cpp
+++ b/src/analyses/local_safe_pointers.cpp
@@ -191,14 +191,14 @@ void local_safe_pointerst::output(
   const goto_programt &goto_program,
   const namespacet &ns)
 {
-  forall_goto_program_instructions(i_it, goto_program)
+  for(const auto &instruction : goto_program.instructions)
   {
-    out << "**** " << i_it->location_number << " "
-        << i_it->source_location << "\n";
+    out << "**** " << instruction.location_number << " "
+        << instruction.source_location << "\n";
 
     out << "Non-null expressions: ";
 
-    auto findit = non_null_expressions.find(i_it->location_number);
+    auto findit = non_null_expressions.find(instruction.location_number);
     if(findit == non_null_expressions.end())
       out << "{}";
     else
@@ -216,7 +216,7 @@ void local_safe_pointerst::output(
     }
 
     out << '\n';
-    goto_program.output_instruction(ns, irep_idt(), out, *i_it);
+    goto_program.output_instruction(ns, irep_idt(), out, instruction);
     out << '\n';
   }
 }
@@ -235,21 +235,21 @@ void local_safe_pointerst::output_safe_dereferences(
   const goto_programt &goto_program,
   const namespacet &ns)
 {
-  forall_goto_program_instructions(i_it, goto_program)
+  for(const auto &instruction : goto_program.instructions)
   {
-    out << "**** " << i_it->location_number << " "
-        << i_it->source_location << "\n";
+    out << "**** " << instruction.location_number << " "
+        << instruction.source_location << "\n";
 
     out << "Safe (known-not-null) dereferences: ";
 
-    auto findit = non_null_expressions.find(i_it->location_number);
+    auto findit = non_null_expressions.find(instruction.location_number);
     if(findit == non_null_expressions.end())
       out << "{}";
     else
     {
       out << "{";
       bool first = true;
-      i_it->apply([&first, &out](const exprt &e) {
+      instruction.apply([&first, &out](const exprt &e) {
         for(auto subexpr_it = e.depth_begin(), subexpr_end = e.depth_end();
             subexpr_it != subexpr_end;
             ++subexpr_it)
@@ -267,7 +267,7 @@ void local_safe_pointerst::output_safe_dereferences(
     }
 
     out << '\n';
-    goto_program.output_instruction(ns, irep_idt(), out, *i_it);
+    goto_program.output_instruction(ns, irep_idt(), out, instruction);
     out << '\n';
   }
 }

--- a/src/analyses/locals.cpp
+++ b/src/analyses/locals.cpp
@@ -17,10 +17,10 @@ Date: March 2013
 
 void localst::build(const goto_functiont &goto_function)
 {
-  forall_goto_program_instructions(it, goto_function.body)
+  for(const auto &instruction : goto_function.body.instructions)
   {
-    if(it->is_decl())
-      locals.insert(it->get_decl().get_identifier());
+    if(instruction.is_decl())
+      locals.insert(instruction.get_decl().get_identifier());
   }
 
   locals.insert(

--- a/src/goto-cc/linker_script_merge.cpp
+++ b/src/goto-cc/linker_script_merge.cpp
@@ -259,9 +259,10 @@ int linker_script_merget::pointerize_linker_defined_symbols(
   for(auto &gf : goto_model.goto_functions.function_map)
   {
     goto_programt &program=gf.second.body;
-    Forall_goto_program_instructions(iit, program)
+    for(auto &instruction : program.instructions)
     {
-      for(exprt *insts : std::list<exprt *>({&(iit->code), &(iit->guard)}))
+      for(exprt *insts :
+          std::list<exprt *>({&(instruction.code), &(instruction.guard)}))
       {
         std::list<symbol_exprt> to_pointerize;
         symbols_to_pointerize(linker_values, *insts, to_pointerize);
@@ -277,7 +278,7 @@ int linker_script_merget::pointerize_linker_defined_symbols(
           log.error() << " Could not pointerize '" << sym.get_identifier()
                       << "' in function " << gf.first << ". Pretty:\n"
                       << sym.pretty() << "\n";
-          log.error().source_location = iit->source_location;
+          log.error().source_location = instruction.source_location;
         }
         log.error() << messaget::eom;
       }

--- a/src/goto-instrument/accelerate/disjunctive_polynomial_acceleration.cpp
+++ b/src/goto-instrument/accelerate/disjunctive_polynomial_acceleration.cpp
@@ -858,11 +858,11 @@ void disjunctive_polynomial_accelerationt::build_fixed()
 
   fixed.copy_from(goto_program);
 
-  Forall_goto_program_instructions(it, fixed)
+  for(auto &instruction : fixed.instructions)
   {
-    if(it->is_assert())
+    if(instruction.is_assert())
     {
-      it->type=ASSUME;
+      instruction.type = ASSUME;
     }
   }
 

--- a/src/goto-instrument/accelerate/sat_path_enumerator.cpp
+++ b/src/goto-instrument/accelerate/sat_path_enumerator.cpp
@@ -216,10 +216,10 @@ void sat_path_enumeratort::build_fixed()
 
   fixed.copy_from(goto_program);
 
-  Forall_goto_program_instructions(it, fixed)
+  for(auto &instruction : fixed.instructions)
   {
-    if(it->is_assert())
-      it->type=ASSUME;
+    if(instruction.is_assert())
+      instruction.type = ASSUME;
   }
 
   // We're only interested in paths that loop back to the loop header.

--- a/src/goto-instrument/call_sequences.cpp
+++ b/src/goto-instrument/call_sequences.cpp
@@ -272,12 +272,12 @@ static void list_calls_and_arguments(
   const namespacet &ns,
   const goto_programt &goto_program)
 {
-  forall_goto_program_instructions(i_it, goto_program)
+  for(const auto &instruction : goto_program.instructions)
   {
-    if(!i_it->is_function_call())
+    if(!instruction.is_function_call())
       continue;
 
-    const code_function_callt &call = to_code_function_call(i_it->code);
+    const code_function_callt &call = to_code_function_call(instruction.code);
 
     const exprt &f=call.function();
 

--- a/src/goto-instrument/count_eloc.cpp
+++ b/src/goto-instrument/count_eloc.cpp
@@ -36,14 +36,17 @@ static void collect_eloc(
 {
   forall_goto_functions(f_it, goto_model.goto_functions)
   {
-    forall_goto_program_instructions(it, f_it->second.body)
+    for(const auto &instruction : f_it->second.body.instructions)
     {
-      filest &files=dest[it->source_location.get_working_directory()];
-      const irep_idt &file=it->source_location.get_file();
+      const auto &source_location = instruction.source_location;
 
-      if(!file.empty() &&
-         !it->source_location.is_built_in())
-        files[file].insert(it->source_location.get_line());
+      filest &files = dest[source_location.get_working_directory()];
+      const irep_idt &file = source_location.get_file();
+
+      if(!file.empty() && !source_location.is_built_in())
+      {
+        files[file].insert(source_location.get_line());
+      }
     }
   }
 }

--- a/src/goto-instrument/cover_filter.cpp
+++ b/src/goto-instrument/cover_filter.cpp
@@ -102,19 +102,19 @@ bool trivial_functions_filtert::operator()(
 {
   (void)function; // unused parameter
   unsigned long count_assignments = 0, count_goto = 0;
-  forall_goto_program_instructions(i_it, goto_function.body)
+  for(const auto &instruction : goto_function.body.instructions)
   {
-    if(i_it->is_goto())
+    if(instruction.is_goto())
     {
       if((++count_goto) >= 2)
         return true;
     }
-    else if(i_it->is_assign())
+    else if(instruction.is_assign())
     {
       if((++count_assignments) >= 5)
         return true;
     }
-    else if(i_it->is_decl())
+    else if(instruction.is_decl())
       return true;
   }
 

--- a/src/goto-instrument/document_properties.cpp
+++ b/src/goto-instrument/document_properties.cpp
@@ -278,18 +278,19 @@ void document_propertiest::doit()
   {
     const goto_programt &goto_program=f_it->second.body;
 
-    forall_goto_program_instructions(i_it, goto_program)
+    for(const auto &instruction : goto_program.instructions)
     {
-      if(i_it->is_assert())
+      if(instruction.is_assert())
       {
+        const auto &source_location = instruction.source_location;
         source_locationt new_source_location;
 
-        new_source_location.set_file(i_it->source_location.get_file());
-        new_source_location.set_line(i_it->source_location.get_line());
-        new_source_location.set_function(i_it->source_location.get_function());
+        new_source_location.set_file(source_location.get_file());
+        new_source_location.set_line(source_location.get_line());
+        new_source_location.set_function(source_location.get_function());
 
-        claim_set[new_source_location].comment_set.
-          insert(i_it->source_location.get_comment());
+        claim_set[new_source_location].comment_set.insert(
+          source_location.get_comment());
       }
     }
   }

--- a/src/goto-instrument/goto_program2code.cpp
+++ b/src/goto-instrument/goto_program2code.cpp
@@ -90,20 +90,26 @@ void goto_program2codet::build_dead_map()
   dead_map.clear();
 
   // record last dead X
-  forall_goto_program_instructions(target, goto_program)
-    if(target->is_dead())
-      dead_map[target->get_dead().get_identifier()] = target->location_number;
+  for(const auto &instruction : goto_program.instructions)
+  {
+    if(instruction.is_dead())
+    {
+      dead_map[instruction.get_dead().get_identifier()] =
+        instruction.location_number;
+    }
+  }
 }
 
 void goto_program2codet::scan_for_varargs()
 {
   va_list_expr.clear();
 
-  forall_goto_program_instructions(target, goto_program)
-    if(target->is_assign())
+  for(const auto &instruction : goto_program.instructions)
+  {
+    if(instruction.is_assign())
     {
-      const exprt &l = target->get_assign().lhs();
-      const exprt &r = target->get_assign().rhs();
+      const exprt &l = instruction.get_assign().lhs();
+      const exprt &r = instruction.get_assign().rhs();
 
       // find va_start
       if(
@@ -120,6 +126,7 @@ void goto_program2codet::scan_for_varargs()
               to_typecast_expr(r).op().id()==ID_address_of)
         va_list_expr.insert(l);
     }
+  }
 
   if(!va_list_expr.empty())
     system_headers.insert("stdarg.h");

--- a/src/goto-instrument/model_argc_argv.cpp
+++ b/src/goto-instrument/model_argc_argv.cpp
@@ -151,8 +151,8 @@ bool model_argc_argv(
     message_handler,
     main_symbol.mode);
 
-  Forall_goto_program_instructions(it, init_instructions)
-    it->source_location.set_file("<built-in-library>");
+  for(auto &instruction : init_instructions.instructions)
+    instruction.source_location.set_file("<built-in-library>");
 
   goto_functionst::function_mapt::iterator start_entry=
     goto_model.goto_functions.function_map.find(

--- a/src/goto-instrument/nondet_static.cpp
+++ b/src/goto-instrument/nondet_static.cpp
@@ -87,24 +87,20 @@ void nondet_static(
 
   goto_programt &init = fct_entry->second.body;
 
-  Forall_goto_program_instructions(i_it, init)
+  for(auto &instruction : init.instructions)
   {
-    const goto_programt::instructiont &instruction=*i_it;
-
     if(instruction.is_assign())
     {
-      const symbol_exprt &sym=to_symbol_expr(
-          to_code_assign(instruction.code).lhs());
+      const symbol_exprt sym =
+        to_symbol_expr(to_code_assign(as_const(instruction.code)).lhs());
 
       if(is_nondet_initializable_static(sym, ns))
       {
-        const goto_programt::instructiont original_instruction = instruction;
-        *i_it = goto_programt::make_assignment(
+        const auto source_location = instruction.source_location;
+        instruction = goto_programt::make_assignment(
           code_assignt(
-            sym,
-            side_effect_expr_nondett(
-              sym.type(), original_instruction.source_location)),
-          original_instruction.source_location);
+            sym, side_effect_expr_nondett(sym.type(), source_location)),
+          source_location);
       }
     }
     else if(instruction.is_function_call())

--- a/src/goto-instrument/undefined_functions.cpp
+++ b/src/goto-instrument/undefined_functions.cpp
@@ -34,10 +34,8 @@ void list_undefined_functions(
 void undefined_function_abort_path(goto_modelt &goto_model)
 {
   Forall_goto_functions(it, goto_model.goto_functions)
-    Forall_goto_program_instructions(iit, it->second.body)
+    for(auto &ins : it->second.body.instructions)
     {
-      goto_programt::instructiont &ins=*iit;
-
       if(!ins.is_function_call())
         continue;
 

--- a/src/goto-instrument/unwind.cpp
+++ b/src/goto-instrument/unwind.cpp
@@ -240,17 +240,17 @@ void goto_unwindt::unwind(
     unwind_log.insert(t_skip, loop_head->location_number);
 
     // redirect gotos into loop body
-    Forall_goto_program_instructions(i_it, goto_program)
+    for(auto &instruction : goto_program.instructions)
     {
-      if(!i_it->is_goto())
+      if(!instruction.is_goto())
         continue;
 
-      goto_programt::const_targett t=i_it->get_target();
+      goto_programt::const_targett t = instruction.get_target();
 
       if(t->location_number>=loop_head->location_number &&
          t->location_number<loop_exit->location_number)
       {
-        i_it->set_target(t_skip);
+        instruction.set_target(t_skip);
       }
     }
 

--- a/src/goto-programs/compute_called_functions.cpp
+++ b/src/goto-programs/compute_called_functions.cpp
@@ -110,13 +110,12 @@ compute_called_functions(const goto_functionst &goto_functions)
 
     compute_address_taken_functions(program, working_queue);
 
-    forall_goto_program_instructions(i_it, program)
+    for(const auto &instruction : program.instructions)
     {
-      if(i_it->is_function_call())
+      if(instruction.is_function_call())
       {
         compute_functions(
-          to_code_function_call(i_it->code).function(),
-          working_queue);
+          to_code_function_call(instruction.code).function(), working_queue);
       }
     }
   }

--- a/src/goto-programs/goto_convert.cpp
+++ b/src/goto-programs/goto_convert.cpp
@@ -56,20 +56,22 @@ static void finish_catch_push_targets(goto_programt &dest)
   }
 
   // in the second pass set the targets
-  Forall_goto_program_instructions(it, dest)
+  for(auto &instruction : dest.instructions)
   {
-    if(it->is_catch() && it->code.get_statement()==ID_push_catch)
+    if(
+      instruction.is_catch() &&
+      instruction.code.get_statement() == ID_push_catch)
     {
       // Populate `targets` with a GOTO instruction target per
       // exception handler if it isn't already populated.
       // (Java handlers, for example, need this finish step; C++
       //  handlers will already be populated by now)
 
-      if(it->targets.empty())
+      if(instruction.targets.empty())
       {
         bool handler_added=true;
-        const code_push_catcht::exception_listt &handler_list=
-          to_code_push_catch(it->code).exception_list();
+        const code_push_catcht::exception_listt &handler_list =
+          to_code_push_catch(instruction.code).exception_list();
 
         for(const auto &handler : handler_list)
         {
@@ -86,7 +88,7 @@ static void finish_catch_push_targets(goto_programt &dest)
           continue;
 
         for(const auto &handler : handler_list)
-          it->targets.push_back(label_targets.at(handler.get_label()));
+          instruction.targets.push_back(label_targets.at(handler.get_label()));
       }
     }
   }

--- a/src/goto-programs/goto_convert_functions.cpp
+++ b/src/goto-programs/goto_convert_functions.cpp
@@ -75,11 +75,13 @@ void goto_convert_functionst::goto_convert(goto_functionst &functions)
 
 bool goto_convert_functionst::hide(const goto_programt &goto_program)
 {
-  forall_goto_program_instructions(i_it, goto_program)
+  for(const auto &instruction : goto_program.instructions)
   {
-    for(const auto &label : i_it->labels)
+    for(const auto &label : instruction.labels)
+    {
       if(label == CPROVER_PREFIX "HIDE")
         return true;
+    }
   }
 
   return false;
@@ -213,10 +215,10 @@ void goto_convert_functionst::convert_function(
     goto_programt::targett a_end =
       f.body.add(goto_programt::make_atomic_end(end_location));
 
-    Forall_goto_program_instructions(i_it, f.body)
+    for(auto &instruction : f.body.instructions)
     {
-      if(i_it->is_goto() && i_it->get_target()->is_end_function())
-        i_it->set_target(a_end);
+      if(instruction.is_goto() && instruction.get_target()->is_end_function())
+        instruction.set_target(a_end);
     }
   }
 

--- a/src/goto-programs/goto_functions.cpp
+++ b/src/goto-programs/goto_functions.cpp
@@ -134,11 +134,11 @@ void goto_functionst::validate(const namespacet &ns, const validation_modet vm)
     // Check that a void function does not contain any RETURN instructions
     if(to_code_type(function_symbol.type).return_type().id() == ID_empty)
     {
-      forall_goto_program_instructions(instruction, goto_function.body)
+      for(const auto &instruction : goto_function.body.instructions)
       {
         DATA_CHECK(
           vm,
-          !instruction->is_return(),
+          !instruction.is_return(),
           "void function should not return a value");
       }
     }

--- a/src/goto-programs/goto_inline_class.cpp
+++ b/src/goto-programs/goto_inline_class.cpp
@@ -296,16 +296,16 @@ void goto_inlinet::insert_function_body(
 
   if(adjust_function)
   {
-    Forall_goto_program_instructions(it, tmp)
+    for(auto &instruction : tmp.instructions)
     {
-      replace_location(it->source_location, target->source_location);
-      replace_location(it->code, target->source_location);
+      replace_location(instruction.source_location, target->source_location);
+      replace_location(instruction.code, target->source_location);
 
-      if(it->has_condition())
+      if(instruction.has_condition())
       {
-        exprt c = it->get_condition();
+        exprt c = instruction.get_condition();
         replace_location(c, target->source_location);
-        it->set_condition(c);
+        instruction.set_condition(c);
       }
     }
   }

--- a/src/goto-programs/goto_program.cpp
+++ b/src/goto-programs/goto_program.cpp
@@ -230,17 +230,17 @@ std::ostream &goto_programt::output_instruction(
 void goto_programt::get_decl_identifiers(
   decl_identifierst &decl_identifiers) const
 {
-  forall_goto_program_instructions(it, (*this))
+  for(const auto &instruction : instructions)
   {
-    if(it->is_decl())
+    if(instruction.is_decl())
     {
       DATA_INVARIANT(
-        it->code.get_statement() == ID_decl,
+        instruction.code.get_statement() == ID_decl,
         "expected statement to be declaration statement");
       DATA_INVARIANT(
-        it->code.operands().size() == 1,
+        instruction.code.operands().size() == 1,
         "declaration statement expects one operand");
-      const symbol_exprt &symbol_expr=to_symbol_expr(it->code.op0());
+      const symbol_exprt &symbol_expr = to_symbol_expr(instruction.code.op0());
       decl_identifiers.insert(symbol_expr.get_identifier());
     }
   }

--- a/src/goto-programs/link_goto_model.cpp
+++ b/src/goto-programs/link_goto_model.cpp
@@ -34,17 +34,15 @@ static void rename_symbols_in_function(
       identifier = entry->second;
   }
 
-  goto_programt &program=function.body;
-
-  Forall_goto_program_instructions(iit, program)
+  for(auto &instruction : function.body.instructions)
   {
-    rename_symbol(iit->code);
+    rename_symbol(instruction.code);
 
-    if(iit->has_condition())
+    if(instruction.has_condition())
     {
-      exprt c = iit->get_condition();
+      exprt c = instruction.get_condition();
       rename_symbol(c);
-      iit->set_condition(c);
+      instruction.set_condition(c);
     }
   }
 }
@@ -147,13 +145,15 @@ static bool link_functions(
   if(!object_type_updates.empty())
   {
     Forall_goto_functions(dest_it, dest_functions)
-      Forall_goto_program_instructions(iit, dest_it->second.body)
+    {
+      for(auto &instruction : dest_it->second.body.instructions)
       {
-        iit->transform([&object_type_updates](exprt expr) {
+        instruction.transform([&object_type_updates](exprt expr) {
           object_type_updates(expr);
           return expr;
         });
       }
+    }
   }
 
   return false;

--- a/src/goto-programs/loop_ids.cpp
+++ b/src/goto-programs/loop_ids.cpp
@@ -32,15 +32,15 @@ void show_loop_ids(
   {
     case ui_message_handlert::uit::PLAIN:
     {
-      forall_goto_program_instructions(it, goto_program)
+      for(const auto &instruction : goto_program.instructions)
       {
-        if(it->is_backwards_goto())
+        if(instruction.is_backwards_goto())
         {
-          std::cout << "Loop " << goto_programt::loop_id(function_id, *it)
-                    << ":"
+          std::cout << "Loop "
+                    << goto_programt::loop_id(function_id, instruction) << ":"
                     << "\n";
 
-          std::cout << "  " << it->source_location << "\n";
+          std::cout << "  " << instruction.source_location << "\n";
           std::cout << "\n";
         }
       }
@@ -48,15 +48,16 @@ void show_loop_ids(
     }
     case ui_message_handlert::uit::XML_UI:
     {
-      forall_goto_program_instructions(it, goto_program)
+      for(const auto &instruction : goto_program.instructions)
       {
-        if(it->is_backwards_goto())
+        if(instruction.is_backwards_goto())
         {
-          std::string id = id2string(goto_programt::loop_id(function_id, *it));
+          std::string id =
+            id2string(goto_programt::loop_id(function_id, instruction));
 
           xmlt xml_loop("loop", {{"name", id}}, {});
           xml_loop.new_element("loop-id").data=id;
-          xml_loop.new_element()=xml(it->source_location);
+          xml_loop.new_element() = xml(instruction.source_location);
           std::cout << xml_loop << "\n";
         }
       }
@@ -75,15 +76,16 @@ void show_loop_ids_json(
 {
   PRECONDITION(ui == ui_message_handlert::uit::JSON_UI); // use function above
 
-  forall_goto_program_instructions(it, goto_program)
+  for(const auto &instruction : goto_program.instructions)
   {
-    if(it->is_backwards_goto())
+    if(instruction.is_backwards_goto())
     {
-      std::string id = id2string(goto_programt::loop_id(function_id, *it));
+      std::string id =
+        id2string(goto_programt::loop_id(function_id, instruction));
 
       loops.push_back(
         json_objectt({{"name", json_stringt(id)},
-                      {"sourceLocation", json(it->source_location)}}));
+                      {"sourceLocation", json(instruction.source_location)}}));
     }
   }
 }

--- a/src/goto-programs/remove_function_pointers.cpp
+++ b/src/goto-programs/remove_function_pointers.cpp
@@ -425,15 +425,17 @@ void remove_function_pointerst::remove_function_pointer(
   new_code.destructive_append(final_skip);
 
   // set locations
-  Forall_goto_program_instructions(it, new_code)
+  for(auto &instruction : new_code.instructions)
   {
-    irep_idt property_class=it->source_location.get_property_class();
-    irep_idt comment=it->source_location.get_comment();
-    it->source_location=target->source_location;
+    source_locationt &source_location = instruction.source_location;
+
+    irep_idt property_class = source_location.get_property_class();
+    irep_idt comment = source_location.get_comment();
+    source_location = target->source_location;
     if(!property_class.empty())
-      it->source_location.set_property_class(property_class);
+      source_location.set_property_class(property_class);
     if(!comment.empty())
-      it->source_location.set_comment(comment);
+      source_location.set_comment(comment);
   }
 
   goto_programt::targett next_target=target;

--- a/src/goto-programs/remove_unused_functions.cpp
+++ b/src/goto-programs/remove_unused_functions.cpp
@@ -71,11 +71,11 @@ void find_used_functions(
 
     if(f_it!=functions.function_map.end())
     {
-      forall_goto_program_instructions(it, f_it->second.body)
+      for(const auto &instruction : f_it->second.body.instructions)
       {
-        if(it->type==FUNCTION_CALL)
+        if(instruction.type == FUNCTION_CALL)
         {
-          const code_function_callt &call = it->get_function_call();
+          const code_function_callt &call = instruction.get_function_call();
 
           const irep_idt &identifier =
             to_symbol_expr(call.function()).get_identifier();

--- a/src/goto-programs/remove_virtual_functions.cpp
+++ b/src/goto-programs/remove_virtual_functions.cpp
@@ -436,15 +436,17 @@ static goto_programt::targett replace_virtual_function_with_dispatch_table(
   new_code.destructive_append(final_skip);
 
   // set locations
-  Forall_goto_program_instructions(it, new_code)
+  for(auto &instruction : new_code.instructions)
   {
-    const irep_idt property_class=it->source_location.get_property_class();
-    const irep_idt comment=it->source_location.get_comment();
-    it->source_location=target->source_location;
+    source_locationt &source_location = instruction.source_location;
+
+    const irep_idt property_class = source_location.get_property_class();
+    const irep_idt comment = source_location.get_comment();
+    source_location = target->source_location;
     if(!property_class.empty())
-      it->source_location.set_property_class(property_class);
+      source_location.set_property_class(property_class);
     if(!comment.empty())
-      it->source_location.set_comment(comment);
+      source_location.set_comment(comment);
   }
 
   goto_program.destructive_insert(next_target, new_code);

--- a/src/goto-programs/rewrite_union.cpp
+++ b/src/goto-programs/rewrite_union.cpp
@@ -101,15 +101,15 @@ void rewrite_union(exprt &expr)
 
 void rewrite_union(goto_functionst::goto_functiont &goto_function)
 {
-  Forall_goto_program_instructions(it, goto_function.body)
+  for(auto &instruction : goto_function.body.instructions)
   {
-    rewrite_union(it->code);
+    rewrite_union(instruction.code);
 
-    if(it->has_condition())
+    if(instruction.has_condition())
     {
-      exprt c = it->get_condition();
+      exprt c = instruction.get_condition();
       rewrite_union(c);
-      it->set_condition(c);
+      instruction.set_condition(c);
     }
   }
 }

--- a/src/goto-programs/slice_global_inits.cpp
+++ b/src/goto-programs/slice_global_inits.cpp
@@ -89,11 +89,11 @@ void slice_global_inits(goto_modelt &goto_model)
     fixed_point_reached = true;
 
     std::vector<bool>::iterator seen_it = seen.begin();
-    forall_goto_program_instructions(i_it, goto_program)
+    for(const auto &instruction : goto_program.instructions)
     {
-      if(!*seen_it && i_it->is_assign())
+      if(!*seen_it && instruction.is_assign())
       {
-        const code_assignt &code_assign = i_it->get_assign();
+        const code_assignt &code_assign = instruction.get_assign();
         const irep_idt id = to_symbol_expr(code_assign.lhs()).get_identifier();
 
         // if we are to keep the left-hand side, then we also need to keep all
@@ -115,11 +115,11 @@ void slice_global_inits(goto_modelt &goto_model)
   }
 
   // now remove unnecessary initializations
-  Forall_goto_program_instructions(i_it, goto_program)
+  for(auto &instruction : goto_program.instructions)
   {
-    if(i_it->is_assign())
+    if(instruction.is_assign())
     {
-      const code_assignt &code_assign = i_it->get_assign();
+      const code_assignt &code_assign = instruction.get_assign();
       const symbol_exprt &symbol_expr=to_symbol_expr(code_assign.lhs());
       const irep_idt id=symbol_expr.get_identifier();
 
@@ -127,7 +127,7 @@ void slice_global_inits(goto_modelt &goto_model)
         !has_prefix(id2string(id), CPROVER_PREFIX) &&
         symbols_to_keep.find(id) == symbols_to_keep.end())
       {
-        i_it->turn_into_skip();
+        instruction.turn_into_skip();
       }
     }
   }

--- a/src/goto-programs/write_goto_binary.cpp
+++ b/src/goto-programs/write_goto_binary.cpp
@@ -92,10 +92,8 @@ bool write_goto_binary(
       write_gb_string(out, id2string(fct.first)); // name
       write_gb_word(out, fct.second.body.instructions.size()); // # instructions
 
-      forall_goto_program_instructions(i_it, fct.second.body)
+      for(const auto &instruction : fct.second.body.instructions)
       {
-        const goto_programt::instructiont &instruction = *i_it;
-
         irepconverter.reference_convert(instruction.code, out);
         irepconverter.reference_convert(instruction.source_location, out);
         write_gb_word(out, (long)instruction.type);


### PR DESCRIPTION
In some (but not all!) cases of {f,F}orall_goto_program_instructions we do not
actually need the iterator.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
