### PR TITLE
Replace some uses of forall_operands by ranged-for

### DIFF
--- a/jbmc/src/java_bytecode/ci_lazy_methods.cpp
+++ b/jbmc/src/java_bytecode/ci_lazy_methods.cpp
@@ -537,8 +537,10 @@ void ci_lazy_methodst::gather_needed_globals(
     }
   }
   else
-    forall_operands(opit, e)
-      gather_needed_globals(*opit, symbol_table, needed);
+  {
+    for(const auto &op : e.operands())
+      gather_needed_globals(op, symbol_table, needed);
+  }
 }
 
 /// Find a virtual callee, if one is defined and the callee type is known to

--- a/jbmc/src/java_bytecode/java_bytecode_convert_method.cpp
+++ b/jbmc/src/java_bytecode/java_bytecode_convert_method.cpp
@@ -978,8 +978,8 @@ static void gather_symbol_live_ranges(
   }
   else
   {
-    forall_operands(it, e)
-      gather_symbol_live_ranges(pc, *it, result);
+    for(const auto &op : e.operands())
+      gather_symbol_live_ranges(pc, op, result);
   }
 }
 

--- a/jbmc/src/java_bytecode/java_bytecode_instrument.cpp
+++ b/jbmc/src/java_bytecode/java_bytecode_instrument.cpp
@@ -451,9 +451,9 @@ optionalt<codet> java_bytecode_instrumentt::instrument_expr(const exprt &expr)
 {
   code_blockt result;
   // First check our operands:
-  forall_operands(it, expr)
+  for(const auto &op : expr.operands())
   {
-    if(optionalt<codet> op_result = instrument_expr(*it))
+    if(optionalt<codet> op_result = instrument_expr(op))
       result.add(std::move(*op_result));
   }
 

--- a/src/analyses/constant_propagator.cpp
+++ b/src/analyses/constant_propagator.cpp
@@ -324,9 +324,9 @@ bool constant_propagator_domaint::two_way_propagate_rec(
     {
       change_this_time = false;
 
-      forall_operands(it, expr)
+      for(const auto &op : expr.operands())
       {
-        change_this_time |= two_way_propagate_rec(*it, ns, cp);
+        change_this_time |= two_way_propagate_rec(op, ns, cp);
         if(change_this_time)
           change = true;
       }

--- a/src/analyses/custom_bitvector_analysis.cpp
+++ b/src/analyses/custom_bitvector_analysis.cpp
@@ -687,9 +687,11 @@ bool custom_bitvector_domaint::has_get_must_or_may(const exprt &src)
   if(src.id() == ID_get_must || src.id() == ID_get_may)
     return true;
 
-  forall_operands(it, src)
-    if(has_get_must_or_may(*it))
+  for(const auto &op : src.operands())
+  {
+    if(has_get_must_or_may(op))
       return true;
+  }
 
   return false;
 }

--- a/src/analyses/dirty.cpp
+++ b/src/analyses/dirty.cpp
@@ -44,8 +44,8 @@ void dirtyt::search_other(const goto_programt::instructiont &instruction)
       statement == ID_array_replace || statement == ID_havoc_object ||
       statement == ID_input || statement == ID_output)
     {
-      forall_operands(it, code)
-        find_dirty(*it);
+      for(const auto &op : code.operands())
+        find_dirty(op);
     }
     // other possible cases according to goto_programt::instructiont::output
     // and goto_symext::symex_other:
@@ -66,8 +66,8 @@ void dirtyt::find_dirty(const exprt &expr)
     return;
   }
 
-  forall_operands(it, expr)
-    find_dirty(*it);
+  for(const auto &op : expr.operands())
+    find_dirty(op);
 }
 
 void dirtyt::find_dirty_address_of(const exprt &expr)

--- a/src/analyses/goto_rw.cpp
+++ b/src/analyses/goto_rw.cpp
@@ -330,8 +330,8 @@ void rw_range_sett::get_objects_array(
 
   if(!subtype_bits.has_value())
   {
-    forall_operands(it, expr)
-      get_objects_rec(mode, *it, range_spect{0}, range_spect::unknown());
+    for(const auto &op : expr.operands())
+      get_objects_rec(mode, op, range_spect{0}, range_spect::unknown());
 
     return;
   }
@@ -346,7 +346,7 @@ void rw_range_sett::get_objects_array(
       ? sub_size * range_spect::to_range_spect(expr.operands().size())
       : full_r_s + size;
 
-  forall_operands(it, expr)
+  for(const auto &op : expr.operands())
   {
     if(full_r_s<=offset+sub_size && full_r_e>offset)
     {
@@ -355,7 +355,7 @@ void rw_range_sett::get_objects_array(
       range_spect cur_r_e=
         full_r_e>offset+sub_size ? sub_size : full_r_e-offset;
 
-      get_objects_rec(mode, *it, cur_r_s, cur_r_e-cur_r_s);
+      get_objects_rec(mode, op, cur_r_s, cur_r_e - cur_r_s);
     }
 
     offset+=sub_size;
@@ -384,9 +384,9 @@ void rw_range_sett::get_objects_struct(
                            ? range_spect::unknown()
                            : full_r_s + size;
 
-  forall_operands(it, expr)
+  for(const auto &op : expr.operands())
   {
-    auto it_bits = pointer_offset_bits(it->type(), ns);
+    auto it_bits = pointer_offset_bits(op.type(), ns);
 
     range_spect sub_size = it_bits.has_value()
                              ? range_spect::to_range_spect(*it_bits)
@@ -394,7 +394,7 @@ void rw_range_sett::get_objects_struct(
 
     if(offset.is_unknown())
     {
-      get_objects_rec(mode, *it, range_spect{0}, sub_size);
+      get_objects_rec(mode, op, range_spect{0}, sub_size);
     }
     else if(sub_size.is_unknown())
     {
@@ -403,7 +403,7 @@ void rw_range_sett::get_objects_struct(
         range_spect cur_r_s =
           full_r_s <= offset ? range_spect{0} : full_r_s - offset;
 
-        get_objects_rec(mode, *it, cur_r_s, range_spect::unknown());
+        get_objects_rec(mode, op, cur_r_s, range_spect::unknown());
       }
 
       offset = range_spect::unknown();
@@ -415,7 +415,7 @@ void rw_range_sett::get_objects_struct(
         range_spect cur_r_s =
           full_r_s <= offset ? range_spect{0} : full_r_s - offset;
 
-        get_objects_rec(mode, *it, cur_r_s, sub_size-cur_r_s);
+        get_objects_rec(mode, op, cur_r_s, sub_size - cur_r_s);
       }
 
       offset+=sub_size;
@@ -427,7 +427,7 @@ void rw_range_sett::get_objects_struct(
       range_spect cur_r_e=
         full_r_e>offset+sub_size ? sub_size : full_r_e-offset;
 
-      get_objects_rec(mode, *it, cur_r_s, cur_r_e-cur_r_s);
+      get_objects_rec(mode, op, cur_r_s, cur_r_e - cur_r_s);
 
       offset+=sub_size;
     }
@@ -619,8 +619,8 @@ void rw_range_sett::get_objects_rec(
     // possibly affects the full object size, even if range_start/size
     // are only a subset of the bytes (e.g., when using the result of
     // arithmetic operations)
-    forall_operands(it, expr)
-      get_objects_rec(mode, *it);
+    for(const auto &op : expr.operands())
+      get_objects_rec(mode, op);
   }
   else if(expr.id() == ID_null_object ||
           expr.id() == ID_string_constant)
@@ -629,8 +629,8 @@ void rw_range_sett::get_objects_rec(
   }
   else if(mode==get_modet::LHS_W)
   {
-    forall_operands(it, expr)
-      get_objects_rec(mode, *it);
+    for(const auto &op : expr.operands())
+      get_objects_rec(mode, op);
   }
   else
     throw "rw_range_sett: assignment to '" + expr.id_string() + "' not handled";

--- a/src/analyses/interval_domain.cpp
+++ b/src/analyses/interval_domain.cpp
@@ -390,14 +390,18 @@ void interval_domaint::assume_rec(
   else if(cond.id()==ID_and)
   {
     if(!negation)
-      forall_operands(it, cond)
-        assume_rec(*it, false);
+    {
+      for(const auto &op : cond.operands())
+        assume_rec(op, false);
+    }
   }
   else if(cond.id()==ID_or)
   {
     if(negation)
-      forall_operands(it, cond)
-        assume_rec(*it, true);
+    {
+      for(const auto &op : cond.operands())
+        assume_rec(op, true);
+    }
   }
 }
 

--- a/src/analyses/invariant_set.cpp
+++ b/src/analyses/invariant_set.cpp
@@ -409,8 +409,8 @@ void invariant_sett::strengthen_rec(const exprt &expr)
   }
   else if(expr.id()==ID_and)
   {
-    forall_operands(it, expr)
-      strengthen_rec(*it);
+    for(const auto &op : expr.operands())
+      strengthen_rec(op);
   }
   else if(expr.id()==ID_le ||
           expr.id()==ID_lt)
@@ -424,10 +424,10 @@ void invariant_sett::strengthen_rec(const exprt &expr)
     {
       const exprt &bitand_op = rel.op1();
 
-      forall_operands(it, bitand_op)
+      for(const auto &op : bitand_op.operands())
       {
         auto tmp(rel);
-        tmp.op1()=*it;
+        tmp.op1() = op;
         strengthen_rec(tmp);
       }
 
@@ -499,10 +499,10 @@ void invariant_sett::strengthen_rec(const exprt &expr)
     {
       const exprt &bitand_op = equal_expr.op1();
 
-      forall_operands(it, bitand_op)
+      for(const auto &op : bitand_op.operands())
       {
         auto tmp(equal_expr);
-        tmp.op1()=*it;
+        tmp.op1() = op;
         tmp.id(ID_le);
         strengthen_rec(tmp);
       }
@@ -602,17 +602,21 @@ tvt invariant_sett::implies_rec(const exprt &expr) const
   }
   else if(expr.id()==ID_and)
   {
-    forall_operands(it, expr)
-      if(implies_rec(*it)!=tvt(true))
+    for(const auto &op : expr.operands())
+    {
+      if(implies_rec(op) != tvt(true))
         return tvt::unknown();
+    }
 
     return tvt(true);
   }
   else if(expr.id()==ID_or)
   {
-    forall_operands(it, expr)
-      if(implies_rec(*it)==tvt(true))
+    for(const auto &op : expr.operands())
+    {
+      if(implies_rec(op) == tvt(true))
         return tvt(true);
+    }
   }
   else if(expr.id()==ID_le ||
           expr.id()==ID_lt ||
@@ -1049,8 +1053,8 @@ void invariant_sett::apply_code(const codet &code)
 
   if(statement==ID_block)
   {
-    forall_operands(it, code)
-      apply_code(to_code(*it));
+    for(const auto &op : code.operands())
+      apply_code(to_code(op));
   }
   else if(statement==ID_assign)
   {

--- a/src/ansi-c/ansi_c_convert_type.cpp
+++ b/src/ansi-c/ansi_c_convert_type.cpp
@@ -202,17 +202,17 @@ void ansi_c_convert_typet::read_rec(const typet &type)
     const exprt &as_expr=
       static_cast<const exprt &>(static_cast<const irept &>(type));
 
-    forall_operands(it, as_expr)
+    for(const auto &op : as_expr.operands())
     {
       // these are symbols
-      const irep_idt &id=it->get(ID_identifier);
+      const irep_idt &id = op.get(ID_identifier);
 
       if(id==ID_thread)
         c_storage_spec.is_thread_local=true;
       else if(id=="align")
       {
         aligned=true;
-        alignment = to_unary_expr(*it).op();
+        alignment = to_unary_expr(op).op();
       }
     }
   }

--- a/src/ansi-c/c_storage_spec.cpp
+++ b/src/ansi-c/c_storage_spec.cpp
@@ -42,9 +42,11 @@ void c_storage_spect::read(const typet &type)
   {
     const exprt &as_expr=
       static_cast<const exprt &>(static_cast<const irept &>(type));
-    forall_operands(it, as_expr)
-      if(it->id()==ID_thread)
+    for(const auto &op : as_expr.operands())
+    {
+      if(op.id() == ID_thread)
         is_thread_local=true;
+    }
   }
   else if(
     type.id() == ID_alias && type.has_subtype() &&

--- a/src/ansi-c/c_typecheck_expr.cpp
+++ b/src/ansi-c/c_typecheck_expr.cpp
@@ -587,15 +587,15 @@ void c_typecheck_baset::typecheck_expr_builtin_offsetof(exprt &expr)
   typet &type=static_cast<typet &>(expr.add(ID_type_arg));
   typecheck_type(type);
 
-  exprt &member=static_cast<exprt &>(expr.add(ID_designator));
+  const exprt &member = static_cast<const exprt &>(expr.add(ID_designator));
 
   exprt result=from_integer(0, size_type());
 
-  forall_operands(m_it, member)
+  for(const auto &op : member.operands())
   {
     type = follow(type);
 
-    if(m_it->id()==ID_member)
+    if(op.id() == ID_member)
     {
       if(type.id()!=ID_union && type.id()!=ID_struct)
       {
@@ -606,7 +606,7 @@ void c_typecheck_baset::typecheck_expr_builtin_offsetof(exprt &expr)
       }
 
       bool found=false;
-      irep_idt component_name=m_it->get(ID_component_name);
+      irep_idt component_name = op.get(ID_component_name);
 
       while(!found)
       {
@@ -692,7 +692,7 @@ void c_typecheck_baset::typecheck_expr_builtin_offsetof(exprt &expr)
         }
       }
     }
-    else if(m_it->id()==ID_index)
+    else if(op.id() == ID_index)
     {
       if(type.id()!=ID_array)
       {
@@ -701,7 +701,7 @@ void c_typecheck_baset::typecheck_expr_builtin_offsetof(exprt &expr)
         throw 0;
       }
 
-      exprt index = to_unary_expr(*m_it).op();
+      exprt index = to_unary_expr(op).op();
 
       // still need to typecheck index
       typecheck_expr(index);

--- a/src/ansi-c/c_typecheck_initializer.cpp
+++ b/src/ansi-c/c_typecheck_initializer.cpp
@@ -775,9 +775,8 @@ designatort c_typecheck_baset::make_designator(
   typet type=src_type;
   designatort designator;
 
-  forall_operands(it, src)
+  for(const auto &d_op : src.operands())
   {
-    const exprt &d_op=*it;
     designatort::entryt entry(type);
     const typet &full_type=follow(entry.type);
 

--- a/src/ansi-c/expr2c.cpp
+++ b/src/ansi-c/expr2c.cpp
@@ -973,8 +973,8 @@ expr2ct::convert_update(const update_exprt &src, unsigned precedence)
 
   const exprt &designator = src.op1();
 
-  forall_operands(it, designator)
-    dest+=convert(*it);
+  for(const auto &op : designator.operands())
+    dest += convert(op);
 
   dest+=", ";
 
@@ -1000,10 +1000,10 @@ std::string expr2ct::convert_cond(
 
   std::string dest="cond {\n";
 
-  forall_operands(it, src)
+  for(const auto &operand : src.operands())
   {
     unsigned p;
-    std::string op=convert_with_precedence(*it, p);
+    std::string op = convert_with_precedence(operand, p);
 
     if(condition)
       dest+="  ";
@@ -1087,7 +1087,7 @@ std::string expr2ct::convert_multi_ary(
   std::string dest;
   bool first=true;
 
-  forall_operands(it, src)
+  for(const auto &operand : src.operands())
   {
     if(first)
       first=false;
@@ -1100,7 +1100,7 @@ std::string expr2ct::convert_multi_ary(
     }
 
     unsigned p;
-    std::string op=convert_with_precedence(*it, p);
+    std::string op = convert_with_precedence(operand, p);
 
     // In pointer arithmetic, x+(y-z) is unfortunately
     // not the same as (x+y)-z, even though + and -
@@ -1109,10 +1109,9 @@ std::string expr2ct::convert_multi_ary(
     // the same as x*(y/z), but * and / have the same
     // precedence.
 
-    bool use_parentheses=
-      precedence>p ||
-      (precedence==p && full_parentheses) ||
-      (precedence==p && src.id()!=it->id());
+    bool use_parentheses = precedence > p ||
+                           (precedence == p && full_parentheses) ||
+                           (precedence == p && src.id() != operand.id());
 
     if(use_parentheses)
       dest+='(';
@@ -2137,7 +2136,7 @@ std::string expr2ct::convert_vector(
   bool newline=false;
   size_t last_size=0;
 
-  forall_operands(it, src)
+  for(const auto &op : src.operands())
   {
     if(first)
       first=false;
@@ -2151,7 +2150,7 @@ std::string expr2ct::convert_vector(
         dest+=' ';
     }
 
-    std::string tmp=convert(*it);
+    std::string tmp = convert(op);
 
     if(last_size+40<dest.size())
     {
@@ -2199,9 +2198,11 @@ std::string expr2ct::convert_array(const exprt &src)
 
   bool all_constant=true;
 
-  forall_operands(it, src)
-    if(!it->is_constant())
+  for(const auto &op : src.operands())
+  {
+    if(!op.is_constant())
       all_constant=false;
+  }
 
   if(
     src.get_bool(ID_C_string_constant) && all_constant &&
@@ -2525,10 +2526,10 @@ std::string expr2ct::convert_overflow(
     dest += convert(to_multi_ary_expr(src).op0().type());
   }
 
-  forall_operands(it, src)
+  for(const auto &op : src.operands())
   {
     unsigned p;
-    std::string arg_str=convert_with_precedence(*it, p);
+    std::string arg_str = convert_with_precedence(op, p);
 
     dest+=", ";
     // TODO: ggf. Klammern je nach p
@@ -2788,8 +2789,8 @@ std::string expr2ct::convert_code_switch(
     }
     else
     {
-      forall_operands(it2, op)
-        dest+=convert_code(to_code(*it2), indent+2);
+      for(const auto &operand : op.operands())
+        dest += convert_code(to_code(operand), indent + 2);
     }
   }
 
@@ -2933,9 +2934,9 @@ std::string expr2ct::convert_code_decl_block(
 {
   std::string dest;
 
-  forall_operands(it, src)
+  for(const auto &op : src.operands())
   {
-    dest+=convert_code(to_code(*it), indent);
+    dest += convert_code(to_code(op), indent);
     dest+="\n";
   }
 

--- a/src/ansi-c/goto_check_c.cpp
+++ b/src/ansi-c/goto_check_c.cpp
@@ -1936,8 +1936,8 @@ void goto_check_ct::check_rec(const exprt &expr, const guardt &guard)
       return;
   }
 
-  forall_operands(it, expr)
-    check_rec(*it, guard);
+  for(const auto &op : expr.operands())
+    check_rec(op, guard);
 
   if(expr.type().id() == ID_c_enum_tag)
     enum_range_check(expr, guard);

--- a/src/ansi-c/parser.y
+++ b/src/ansi-c/parser.y
@@ -2568,10 +2568,10 @@ gcc_local_label_statement:
           statement($$, ID_gcc_local_label);
           
           // put these into the scope
-          forall_operands(it, parser_stack($2))
+          for(const auto &op : as_const(parser_stack($2)).operands())
           {
             // labels have a separate name space
-            irep_idt base_name=it->get(ID_identifier);
+            irep_idt base_name = op.get(ID_identifier);
             irep_idt id="label-"+id2string(base_name);
             ansi_c_parsert::identifiert &i=PARSER.current_scope().name_map[id];
             i.id_class=ansi_c_id_classt::ANSI_C_LOCAL_LABEL;

--- a/src/cpp/cpp_typecheck_code.cpp
+++ b/src/cpp/cpp_typecheck_code.cpp
@@ -262,8 +262,8 @@ void cpp_typecheckt::typecheck_member_initializer(codet &code)
 
     function_call.arguments().push_back(this_expr);
 
-    forall_operands(it, code)
-      function_call.arguments().push_back(*it);
+    for(const auto &op : as_const(code).operands())
+      function_call.arguments().push_back(op);
 
     // done building the expression, check the argument types
     typecheck_function_call_arguments(function_call);

--- a/src/cpp/cpp_typecheck_expr.cpp
+++ b/src/cpp/cpp_typecheck_expr.cpp
@@ -407,9 +407,9 @@ bool cpp_typecheckt::overloadable(const exprt &expr)
 {
   // at least one argument must have class or enumerated type
 
-  forall_operands(it, expr)
+  for(const auto &op : expr.operands())
   {
-    typet t = it->type();
+    typet t = op.type();
 
     if(is_reference(t))
       t = to_reference_type(t).base_type();
@@ -640,8 +640,8 @@ bool cpp_typecheckt::operator_is_overloaded(exprt &expr)
           function_call.arguments().reserve(expr.operands().size());
 
           // now do arguments
-          forall_operands(it, expr)
-            function_call.arguments().push_back(*it);
+          for(const auto &op : as_const(expr).operands())
+            function_call.arguments().push_back(op);
 
           typecheck_side_effect_function_call(function_call);
 

--- a/src/cprover/bv_pointers_wide.cpp
+++ b/src/cprover/bv_pointers_wide.cpp
@@ -405,15 +405,15 @@ bvt bv_pointers_widet::convert_pointer_type(const exprt &expr)
     mp_integer size = 0;
     std::size_t count = 0;
 
-    forall_operands(it, plus_expr)
+    for(const auto &op : plus_expr.operands())
     {
-      if(it->type().id() == ID_pointer)
+      if(op.type().id() == ID_pointer)
       {
         count++;
-        bv = convert_bv(*it);
+        bv = convert_bv(op);
         CHECK_RETURN(bv.size() == bits);
 
-        typet pointer_base_type = to_pointer_type(it->type()).base_type();
+        typet pointer_base_type = to_pointer_type(op.type()).base_type();
 
         if(pointer_base_type.id() == ID_empty)
         {
@@ -437,26 +437,26 @@ bvt bv_pointers_widet::convert_pointer_type(const exprt &expr)
     const std::size_t offset_bits = get_offset_width(type);
     bvt sum = bv_utils.build_constant(0, offset_bits);
 
-    forall_operands(it, plus_expr)
+    for(const auto &op : plus_expr.operands())
     {
-      if(it->type().id() == ID_pointer)
+      if(op.type().id() == ID_pointer)
         continue;
 
-      if(it->type().id() != ID_unsignedbv && it->type().id() != ID_signedbv)
+      if(op.type().id() != ID_unsignedbv && op.type().id() != ID_signedbv)
       {
         return conversion_failed(plus_expr);
       }
 
-      bv_utilst::representationt rep = it->type().id() == ID_signedbv
+      bv_utilst::representationt rep = op.type().id() == ID_signedbv
                                          ? bv_utilst::representationt::SIGNED
                                          : bv_utilst::representationt::UNSIGNED;
 
-      bvt op = convert_bv(*it);
-      CHECK_RETURN(!op.empty());
+      bvt op_bv = convert_bv(op);
+      CHECK_RETURN(!op_bv.empty());
 
-      op = bv_utils.extension(op, offset_bits, rep);
+      op_bv = bv_utils.extension(op_bv, offset_bits, rep);
 
-      sum = bv_utils.add(sum, op);
+      sum = bv_utils.add(sum, op_bv);
     }
 
     return offset_arithmetic(type, bv, size, sum);

--- a/src/goto-instrument/accelerate/acceleration_utils.cpp
+++ b/src/goto-instrument/accelerate/acceleration_utils.cpp
@@ -45,9 +45,9 @@ void acceleration_utilst::gather_rvalues(
   }
   else
   {
-    forall_operands(it, expr)
+    for(const auto &op : expr.operands())
     {
-      gather_rvalues(*it, rvalues);
+      gather_rvalues(op, rvalues);
     }
   }
 }
@@ -1188,9 +1188,9 @@ void acceleration_utilst::gather_array_accesses(
     arrays.insert(to_dereference_expr(e).pointer());
   }
 
-  forall_operands(it, e)
+  for(const auto &op : e.operands())
   {
-    gather_array_accesses(*it, arrays);
+    gather_array_accesses(op, arrays);
   }
 }
 

--- a/src/goto-instrument/accelerate/cone_of_influence.cpp
+++ b/src/goto-instrument/accelerate/cone_of_influence.cpp
@@ -161,9 +161,9 @@ void cone_of_influencet::gather_rvalues(const exprt &expr, expr_sett &rvals)
   }
   else
   {
-    forall_operands(it, expr)
+    for(const auto &op : expr.operands())
     {
-      gather_rvalues(*it, rvals);
+      gather_rvalues(op, rvals);
     }
   }
 }

--- a/src/goto-instrument/accelerate/overflow_instrumenter.cpp
+++ b/src/goto-instrument/accelerate/overflow_instrumenter.cpp
@@ -89,9 +89,9 @@ void overflow_instrumentert::overflow_expr(
   const exprt &expr,
   expr_sett &cases)
 {
-  forall_operands(it, expr)
+  for(const auto &op : expr.operands())
   {
-    overflow_expr(*it, cases);
+    overflow_expr(op, cases);
   }
 
   const typet &type = expr.type();

--- a/src/goto-instrument/goto_program2code.cpp
+++ b/src/goto-instrument/goto_program2code.cpp
@@ -402,13 +402,13 @@ void goto_program2codet::convert_assign_rec(
     const array_typet &type = to_array_type(assign.rhs().type());
 
     unsigned i=0;
-    forall_operands(it, assign.rhs())
+    for(const auto &op : assign.rhs().operands())
     {
       index_exprt index(
         assign.lhs(),
         from_integer(i++, type.index_type()),
         type.element_type());
-      convert_assign_rec(code_assignt(index, *it), dest);
+      convert_assign_rec(code_assignt(index, op), dest);
     }
   }
   else
@@ -1542,12 +1542,14 @@ void goto_program2codet::cleanup_code_block(
     else if(to_code(*it).get_statement()==ID_block)
     {
       bool has_decl=false;
-      forall_operands(it2, *it)
-        if(it2->id()==ID_code && to_code(*it2).get_statement()==ID_decl)
+      for(const auto &op : as_const(*it).operands())
+      {
+        if(op.id() == ID_code && to_code(op).get_statement() == ID_decl)
         {
           has_decl=true;
           break;
         }
+      }
 
       if(!has_decl)
       {
@@ -1617,9 +1619,11 @@ static bool has_labels(const codet &code)
   if(code.get_statement()==ID_label)
     return true;
 
-  forall_operands(it, code)
-    if(it->id()==ID_code && has_labels(to_code(*it)))
+  for(const auto &op : code.operands())
+  {
+    if(op.id() == ID_code && has_labels(to_code(op)))
       return true;
+  }
 
   return false;
 }

--- a/src/goto-instrument/object_id.cpp
+++ b/src/goto-instrument/object_id.cpp
@@ -68,8 +68,10 @@ void get_objects_rec(
   else
   {
     if(mode==get_modet::LHS_R || mode==get_modet::READ)
-      forall_operands(it, expr)
-        get_objects_rec(get_modet::READ, *it, dest, "");
+    {
+      for(const auto &op : expr.operands())
+        get_objects_rec(get_modet::READ, op, dest, "");
+    }
   }
 }
 

--- a/src/goto-instrument/rw_set.cpp
+++ b/src/goto-instrument/rw_set.cpp
@@ -185,8 +185,8 @@ void _rw_set_loct::read_write_rec(
   }
   else
   {
-    forall_operands(it, expr)
-      read_write_rec(*it, r, w, suffix, guard_conjuncts);
+    for(const auto &op : expr.operands())
+      read_write_rec(op, r, w, suffix, guard_conjuncts);
   }
 }
 

--- a/src/goto-programs/adjust_float_expressions.cpp
+++ b/src/goto-programs/adjust_float_expressions.cpp
@@ -75,9 +75,11 @@ static bool have_to_adjust_float_expressions(const exprt &expr)
       return true;
   }
 
-  forall_operands(it, expr)
-    if(have_to_adjust_float_expressions(*it))
+  for(const auto &op : expr.operands())
+  {
+    if(have_to_adjust_float_expressions(op))
       return true;
+  }
 
   return false;
 }

--- a/src/goto-programs/compute_called_functions.cpp
+++ b/src/goto-programs/compute_called_functions.cpp
@@ -21,8 +21,8 @@ void compute_address_taken_functions(
   const exprt &src,
   std::unordered_set<irep_idt> &address_taken)
 {
-  forall_operands(it, src)
-    compute_address_taken_functions(*it, address_taken);
+  for(const auto &op : src.operands())
+    compute_address_taken_functions(op, address_taken);
 
   if(src.id() == ID_address_of)
   {
@@ -44,8 +44,8 @@ void compute_functions(
   const exprt &src,
   std::unordered_set<irep_idt> &address_taken)
 {
-  forall_operands(it, src)
-    compute_functions(*it, address_taken);
+  for(const auto &op : src.operands())
+    compute_functions(op, address_taken);
 
   if(src.type().id()==ID_code &&
      src.id()==ID_symbol)

--- a/src/goto-programs/destructor.cpp
+++ b/src/goto-programs/destructor.cpp
@@ -27,11 +27,11 @@ code_function_callt get_destructor(
   {
     const exprt &methods=static_cast<const exprt&>(type.find(ID_methods));
 
-    forall_operands(it, methods)
+    for(const auto &op : methods.operands())
     {
-      if(it->type().id()==ID_code)
+      if(op.type().id() == ID_code)
       {
-        const code_typet &code_type=to_code_type(it->type());
+        const code_typet &code_type = to_code_type(op.type());
 
         if(code_type.return_type().id()==ID_destructor &&
            code_type.parameters().size()==1)
@@ -42,7 +42,7 @@ code_function_callt get_destructor(
             arg_type.id() == ID_pointer &&
             ns.follow(to_pointer_type(arg_type).base_type()) == type)
           {
-            const symbol_exprt symbol_expr(it->get(ID_name), it->type());
+            const symbol_exprt symbol_expr(op.get(ID_name), op.type());
             return code_function_callt(symbol_expr);
           }
         }

--- a/src/goto-programs/goto_clean_expr.cpp
+++ b/src/goto-programs/goto_clean_expr.cpp
@@ -90,9 +90,11 @@ bool goto_convertt::needs_cleaning(const exprt &expr)
   if(expr.id()==ID_forall || expr.id()==ID_exists)
     return false;
 
-  forall_operands(it, expr)
-    if(needs_cleaning(*it))
+  for(const auto &op : expr.operands())
+  {
+    if(needs_cleaning(op))
       return true;
+  }
 
   return false;
 }

--- a/src/goto-programs/goto_convert.cpp
+++ b/src/goto-programs/goto_convert.cpp
@@ -522,8 +522,8 @@ void goto_convertt::convert(
     copy(code, DEAD, dest);
   else if(statement==ID_decl_block)
   {
-    forall_operands(it, code)
-      convert(to_code(*it), dest, mode);
+    for(const auto &op : code.operands())
+      convert(to_code(op), dest, mode);
   }
   else if(statement==ID_push_catch ||
           statement==ID_pop_catch ||
@@ -1490,8 +1490,8 @@ void goto_convertt::collect_operands(
   else
   {
     // left-to-right is important
-    forall_operands(it, expr)
-      collect_operands(*it, id, dest);
+    for(const auto &op : expr.operands())
+      collect_operands(op, id, dest);
   }
 }
 
@@ -1651,9 +1651,11 @@ void goto_convertt::generate_ifthenelse(
 /// if(guard) goto target;
 static bool has_and_or(const exprt &expr)
 {
-  forall_operands(it, expr)
-    if(has_and_or(*it))
+  for(const auto &op : expr.operands())
+  {
+    if(has_and_or(op))
       return true;
+  }
 
   if(expr.id()==ID_and || expr.id()==ID_or)
     return true;
@@ -1792,16 +1794,18 @@ bool goto_convertt::get_string_constant(
     else if(index_op.id()==ID_array)
     {
       std::string result;
-      forall_operands(it, index_op)
-        if(it->is_constant())
+      for(const auto &op : as_const(index_op).operands())
+      {
+        if(op.is_constant())
         {
-          const auto i = numeric_cast<std::size_t>(*it);
+          const auto i = numeric_cast<std::size_t>(op);
           if(!i.has_value())
             return true;
 
           if(i.value() != 0) // to skip terminating 0
             result += static_cast<char>(i.value());
         }
+      }
 
       return value=result, false;
     }

--- a/src/goto-programs/goto_convert_side_effect.cpp
+++ b/src/goto-programs/goto_convert_side_effect.cpp
@@ -24,9 +24,11 @@ Author: Daniel Kroening, kroening@kroening.com
 
 bool goto_convertt::has_function_call(const exprt &expr)
 {
-  forall_operands(it, expr)
-    if(has_function_call(*it))
+  for(const auto &op : expr.operands())
+  {
+    if(has_function_call(op))
       return true;
+  }
 
   if(expr.id()==ID_side_effect &&
      expr.get(ID_statement)==ID_function_call)

--- a/src/goto-programs/goto_program.cpp
+++ b/src/goto-programs/goto_program.cpp
@@ -467,8 +467,8 @@ void objects_read(
   }
   else
   {
-    forall_operands(it, src)
-      objects_read(*it, dest);
+    for(const auto &op : src.operands())
+      objects_read(op, dest);
   }
 }
 

--- a/src/goto-programs/goto_trace.cpp
+++ b/src/goto-programs/goto_trace.cpp
@@ -257,13 +257,13 @@ std::string trace_numeric_value(
   {
     std::string result;
 
-    forall_operands(it, expr)
+    for(const auto &op : expr.operands())
     {
       if(result.empty())
         result="{ ";
       else
         result+=", ";
-      result+=trace_numeric_value(*it, ns, options);
+      result += trace_numeric_value(op, ns, options);
     }
 
     return result+" }";

--- a/src/goto-programs/graphml_witness.cpp
+++ b/src/goto-programs/graphml_witness.cpp
@@ -105,13 +105,13 @@ std::string graphml_witnesst::convert_assign_rec(
     const array_typet &type = to_array_type(assign.rhs().type());
 
     unsigned i=0;
-    forall_operands(it, assign.rhs())
+    for(const auto &op : assign.rhs().operands())
     {
       index_exprt index(
         assign.lhs(), from_integer(i++, c_index_type()), type.element_type());
       if(!result.empty())
         result+=' ';
-      result+=convert_assign_rec(identifier, code_assignt(index, *it));
+      result += convert_assign_rec(identifier, code_assignt(index, op));
     }
   }
   else if(assign.rhs().id()==ID_struct ||
@@ -277,9 +277,9 @@ static bool contains_symbol_prefix(const exprt &expr, const std::string &prefix)
     return true;
   }
 
-  forall_operands(it, expr)
+  for(const auto &op : expr.operands())
   {
-    if(contains_symbol_prefix(*it, prefix))
+    if(contains_symbol_prefix(op, prefix))
       return true;
   }
   return false;

--- a/src/goto-programs/interpreter_evaluate.cpp
+++ b/src/goto-programs/interpreter_evaluate.cpp
@@ -319,16 +319,16 @@ interpretert::mp_vectort interpretert::evaluate(const exprt &expr)
       dest.reserve(numeric_cast_v<std::size_t>(get_size(expr.type())));
       bool error=false;
 
-      forall_operands(it, expr)
+      for(const auto &op : expr.operands())
       {
-        if(it->type().id()==ID_code)
+        if(op.type().id() == ID_code)
           continue;
 
-        mp_integer sub_size=get_size(it->type());
+        mp_integer sub_size = get_size(op.type());
         if(sub_size==0)
           continue;
 
-        mp_vectort tmp = evaluate(*it);
+        mp_vectort tmp = evaluate(op);
 
         if(tmp.size()==sub_size)
         {
@@ -407,18 +407,18 @@ interpretert::mp_vectort interpretert::evaluate(const exprt &expr)
 
     bool error=false;
 
-    forall_operands(it, expr)
+    for(const auto &op : expr.operands())
     {
-      if(it->type().id()==ID_code)
+      if(op.type().id() == ID_code)
         continue;
 
-      mp_integer sub_size=get_size(it->type());
+      mp_integer sub_size = get_size(op.type());
       if(sub_size==0)
         continue;
 
-      mp_vectort tmp = evaluate(*it);
+      mp_vectort tmp = evaluate(op);
 
-      if(unbounded_size(it->type()) || tmp.size()==sub_size)
+      if(unbounded_size(op.type()) || tmp.size() == sub_size)
       {
         for(std::size_t i=0; i<tmp.size(); i++)
           dest.push_back(tmp[i]);
@@ -467,9 +467,9 @@ interpretert::mp_vectort interpretert::evaluate(const exprt &expr)
       throw id2string(expr.id())+" expects at least two operands";
 
     mp_integer final=0;
-    forall_operands(it, expr)
+    for(const auto &op : expr.operands())
     {
-      mp_vectort tmp = evaluate(*it);
+      mp_vectort tmp = evaluate(op);
       if(tmp.size()==1)
         final=bitwise_or(final, tmp.front());
     }
@@ -481,9 +481,9 @@ interpretert::mp_vectort interpretert::evaluate(const exprt &expr)
       throw id2string(expr.id())+" expects at least two operands";
 
     mp_integer final=-1;
-    forall_operands(it, expr)
+    for(const auto &op : expr.operands())
     {
-      mp_vectort tmp = evaluate(*it);
+      mp_vectort tmp = evaluate(op);
       if(tmp.size()==1)
         final=bitwise_and(final, tmp.front());
     }
@@ -496,9 +496,9 @@ interpretert::mp_vectort interpretert::evaluate(const exprt &expr)
       throw id2string(expr.id())+" expects at least two operands";
 
     mp_integer final=0;
-    forall_operands(it, expr)
+    for(const auto &op : expr.operands())
     {
-      mp_vectort tmp = evaluate(*it);
+      mp_vectort tmp = evaluate(op);
       if(tmp.size()==1)
         final=bitwise_xor(final, tmp.front());
     }
@@ -620,9 +620,9 @@ interpretert::mp_vectort interpretert::evaluate(const exprt &expr)
 
     bool result=false;
 
-    forall_operands(it, expr)
+    for(const auto &op : expr.operands())
     {
-      mp_vectort tmp = evaluate(*it);
+      mp_vectort tmp = evaluate(op);
 
       if(tmp.size()==1 && tmp.front()!=0)
       {
@@ -660,9 +660,9 @@ interpretert::mp_vectort interpretert::evaluate(const exprt &expr)
 
     bool result=true;
 
-    forall_operands(it, expr)
+    for(const auto &op : expr.operands())
     {
-      mp_vectort tmp = evaluate(*it);
+      mp_vectort tmp = evaluate(op);
 
       if(tmp.size()==1 && tmp.front()==0)
       {
@@ -686,9 +686,9 @@ interpretert::mp_vectort interpretert::evaluate(const exprt &expr)
   {
     mp_integer result=0;
 
-    forall_operands(it, expr)
+    for(const auto &op : expr.operands())
     {
-      mp_vectort tmp = evaluate(*it);
+      mp_vectort tmp = evaluate(op);
       if(tmp.size()==1)
         result+=tmp.front();
     }
@@ -716,16 +716,16 @@ interpretert::mp_vectort interpretert::evaluate(const exprt &expr)
     else
       result=1;
 
-    forall_operands(it, expr)
+    for(const auto &op : expr.operands())
     {
-      mp_vectort tmp = evaluate(*it);
+      mp_vectort tmp = evaluate(op);
       if(tmp.size()==1)
       {
         if(expr.type().id()==ID_fixedbv)
         {
           fixedbvt f1, f2;
           f1.spec=fixedbv_spect(to_fixedbv_type(expr.type()));
-          f2.spec=fixedbv_spect(to_fixedbv_type(it->type()));
+          f2.spec = fixedbv_spect(to_fixedbv_type(op.type()));
           f1.set_value(result);
           f2.set_value(tmp.front());
           f1*=f2;
@@ -734,7 +734,7 @@ interpretert::mp_vectort interpretert::evaluate(const exprt &expr)
         else if(expr.type().id()==ID_floatbv)
         {
           ieee_floatt f1(to_floatbv_type(expr.type()));
-          ieee_floatt f2(to_floatbv_type(it->type()));
+          ieee_floatt f2(to_floatbv_type(op.type()));
           f1.unpack(result);
           f2.unpack(tmp.front());
           f1*=f2;
@@ -917,9 +917,9 @@ interpretert::mp_vectort interpretert::evaluate(const exprt &expr)
   else if(expr.id()==ID_array)
   {
     mp_vectort dest;
-    forall_operands(it, expr)
+    for(const auto &op : expr.operands())
     {
-      mp_vectort tmp = evaluate(*it);
+      mp_vectort tmp = evaluate(op);
       dest.insert(dest.end(), tmp.begin(), tmp.end());
     }
     return dest;

--- a/src/goto-programs/json_expr.cpp
+++ b/src/goto-programs/json_expr.cpp
@@ -351,10 +351,11 @@ json_objectt json(const exprt &expr, const namespacet &ns, const irep_idt &mode)
 
     std::size_t index = 0;
 
-    forall_operands(it, expr)
+    for(const auto &op : expr.operands())
     {
-      json_objectt e{{"index", json_numbert(std::to_string(index))},
-                     {"value", json(*it, ns, mode)}};
+      json_objectt e{
+        {"index", json_numbert(std::to_string(index))},
+        {"value", json(op, ns, mode)}};
       elements.push_back(std::move(e));
       index++;
     }

--- a/src/goto-programs/pointer_arithmetic.cpp
+++ b/src/goto-programs/pointer_arithmetic.cpp
@@ -23,12 +23,12 @@ void pointer_arithmetict::read(const exprt &src)
 {
   if(src.id()==ID_plus)
   {
-    forall_operands(it, src)
+    for(const auto &op : src.operands())
     {
-      if(it->type().id()==ID_pointer)
-        read(*it);
+      if(op.type().id() == ID_pointer)
+        read(op);
       else
-        add_to_offset(*it);
+        add_to_offset(op);
     }
   }
   else if(src.id()==ID_minus)

--- a/src/goto-programs/remove_complex.cpp
+++ b/src/goto-programs/remove_complex.cpp
@@ -68,9 +68,11 @@ static bool have_to_remove_complex(const exprt &expr)
   if(have_to_remove_complex(expr.type()))
      return true;
 
-  forall_operands(it, expr)
-    if(have_to_remove_complex(*it))
+  for(const auto &op : expr.operands())
+  {
+    if(have_to_remove_complex(op))
       return true;
+  }
 
   return false;
 }

--- a/src/goto-programs/remove_vector.cpp
+++ b/src/goto-programs/remove_vector.cpp
@@ -53,9 +53,11 @@ static bool have_to_remove_vector(const exprt &expr)
   if(have_to_remove_vector(expr.type()))
     return true;
 
-  forall_operands(it, expr)
-    if(have_to_remove_vector(*it))
+  for(const auto &op : expr.operands())
+  {
+    if(have_to_remove_vector(op))
       return true;
+  }
 
   return false;
 }

--- a/src/goto-programs/rewrite_union.cpp
+++ b/src/goto-programs/rewrite_union.cpp
@@ -32,9 +32,11 @@ static bool have_to_rewrite_union(const exprt &expr)
   else if(expr.id()==ID_union)
     return true;
 
-  forall_operands(it, expr)
-    if(have_to_rewrite_union(*it))
+  for(const auto &op : expr.operands())
+  {
+    if(have_to_rewrite_union(op))
       return true;
+  }
 
   return false;
 }

--- a/src/goto-programs/string_abstraction.cpp
+++ b/src/goto-programs/string_abstraction.cpp
@@ -597,9 +597,11 @@ bool string_abstractiont::has_string_macros(const exprt &expr)
      expr.id()=="buffer_size")
     return true;
 
-  forall_operands(it, expr)
-    if(has_string_macros(*it))
+  for(const auto &op : expr.operands())
+  {
+    if(has_string_macros(op))
       return true;
+  }
 
   return false;
 }

--- a/src/goto-programs/vcd_goto_trace.cpp
+++ b/src/goto-programs/vcd_goto_trace.cpp
@@ -41,8 +41,8 @@ std::string as_vcd_binary(
   {
     std::string result;
 
-    forall_operands(it, expr)
-      result+=as_vcd_binary(*it, ns);
+    for(const auto &op : expr.operands())
+      result += as_vcd_binary(op, ns);
 
     return result;
   }
@@ -50,8 +50,8 @@ std::string as_vcd_binary(
   {
     std::string result;
 
-    forall_operands(it, expr)
-      result+=as_vcd_binary(*it, ns);
+    for(const auto &op : expr.operands())
+      result += as_vcd_binary(op, ns);
 
     return result;
   }

--- a/src/goto-programs/wp.cpp
+++ b/src/goto-programs/wp.cpp
@@ -21,9 +21,11 @@ Author: Daniel Kroening, kroening@kroening.com
 
 bool has_nondet(const exprt &dest)
 {
-  forall_operands(it, dest)
-    if(has_nondet(*it))
+  for(const auto &op : dest.operands())
+  {
+    if(has_nondet(op))
       return true;
+  }
 
   if(dest.id()==ID_side_effect)
   {

--- a/src/goto-programs/xml_expr.cpp
+++ b/src/goto-programs/xml_expr.cpp
@@ -241,11 +241,11 @@ xmlt xml(const exprt &expr, const namespacet &ns)
 
     unsigned index = 0;
 
-    forall_operands(it, expr)
+    for(const auto &op : expr.operands())
     {
       xmlt &e = result.new_element("element");
       e.set_attribute("index", index);
-      e.new_element(xml(*it, ns));
+      e.new_element(xml(op, ns));
       index++;
     }
   }

--- a/src/goto-symex/build_goto_trace.cpp
+++ b/src/goto-symex/build_goto_trace.cpp
@@ -138,8 +138,8 @@ static void set_internal_dynamic_object(
   }
   else
   {
-    forall_operands(it, expr)
-      set_internal_dynamic_object(*it, goto_trace_step, ns);
+    for(const auto &op : expr.operands())
+      set_internal_dynamic_object(op, goto_trace_step, ns);
   }
 }
 

--- a/src/goto-symex/goto_symex_is_constant.h
+++ b/src/goto-symex/goto_symex_is_constant.h
@@ -30,11 +30,11 @@ protected:
       bool found_non_constant = false;
 
       // propagate stuff with sizeof in it
-      forall_operands(it, expr)
+      for(const auto &op : expr.operands())
       {
-        if(it->find(ID_C_c_sizeof_type).is_not_nil())
+        if(op.find(ID_C_c_sizeof_type).is_not_nil())
           return true;
-        else if(!is_constant(*it))
+        else if(!is_constant(op))
           found_non_constant = true;
       }
 
@@ -43,14 +43,17 @@ protected:
     else if(expr.id() == ID_with)
     {
       // this is bad
-      /*
-      forall_operands(it, expr)
-      if(!is_constant(expr.op0()))
-      return false;
+#if 0
+      for(const auto &op : expr.operands())
+      {
+        if(!is_constant(op))
+          return false;
+      }
 
       return true;
-      */
+#else
       return false;
+#endif
     }
 
     return is_constantt::is_constant(expr);

--- a/src/goto-symex/postcondition.cpp
+++ b/src/goto-symex/postcondition.cpp
@@ -173,9 +173,13 @@ bool postconditiont::is_used(
     return false;
   }
   else
-    forall_operands(it, expr)
-      if(is_used(*it, identifier))
+  {
+    for(const auto &op : expr.operands())
+    {
+      if(is_used(op, identifier))
         return true;
+    }
+  }
 
   return false;
 }

--- a/src/goto-symex/renaming_level.cpp
+++ b/src/goto-symex/renaming_level.cpp
@@ -228,9 +228,11 @@ bool check_renaming_l1(const exprt &expr)
   }
   else
   {
-    forall_operands(it, expr)
-      if(check_renaming_l1(*it))
+    for(const auto &op : expr.operands())
+    {
+      if(check_renaming_l1(op))
         return true;
+    }
   }
 
   return false;
@@ -271,9 +273,11 @@ bool check_renaming(const exprt &expr)
   }
   else
   {
-    forall_operands(it, expr)
-      if(check_renaming(*it))
+    for(const auto &op : expr.operands())
+    {
+      if(check_renaming(op))
         return true;
+    }
   }
 
   return false;

--- a/src/goto-symex/symex_builtin_functions.cpp
+++ b/src/goto-symex/symex_builtin_functions.cpp
@@ -35,9 +35,9 @@ inline static optionalt<typet> c_sizeof_type_rec(const exprt &expr)
   }
   else if(expr.id()==ID_mult)
   {
-    forall_operands(it, expr)
+    for(const auto &op : expr.operands())
     {
-      const auto t = c_sizeof_type_rec(*it);
+      const auto t = c_sizeof_type_rec(op);
       if(t.has_value())
         return t;
     }

--- a/src/pointer-analysis/value_set.cpp
+++ b/src/pointer-analysis/value_set.cpp
@@ -713,10 +713,9 @@ void value_sett::get_value_set_rec(
     else
     {
       // we get the points-to for all operands, even integers
-      forall_operands(it, expr)
+      for(const auto &op : expr.operands())
       {
-        get_value_set_rec(
-          *it, pointer_expr_set, "", it->type(), ns);
+        get_value_set_rec(op, pointer_expr_set, "", op.type(), ns);
       }
     }
 
@@ -747,10 +746,9 @@ void value_sett::get_value_set_rec(
     object_mapt pointer_expr_set;
 
     // we get the points-to for all operands, even integers
-    forall_operands(it, expr)
+    for(const auto &op : expr.operands())
     {
-      get_value_set_rec(
-        *it, pointer_expr_set, "", it->type(), ns);
+      get_value_set_rec(op, pointer_expr_set, "", op.type(), ns);
     }
 
     for(object_map_dt::const_iterator
@@ -833,7 +831,7 @@ void value_sett::get_value_set_rec(
 
     // a struct constructor, which may contain addresses
 
-    forall_operands(it, expr)
+    for(const auto &op : expr.operands())
     {
       const std::string &component_name =
         id2string(component_iter->get_name());
@@ -841,7 +839,7 @@ void value_sett::get_value_set_rec(
       {
         std::string remaining_suffix =
           strip_first_field_from_suffix(suffix, component_name);
-        get_value_set_rec(*it, dest, remaining_suffix, original_type, ns);
+        get_value_set_rec(op, dest, remaining_suffix, original_type, ns);
         found_component = true;
       }
       ++component_iter;
@@ -852,8 +850,8 @@ void value_sett::get_value_set_rec(
       // Struct field doesn't appear as expected -- this has probably been
       // cast from an incompatible type. Conservatively assume all fields may
       // be of interest.
-      forall_operands(it, expr)
-        get_value_set_rec(*it, dest, suffix, original_type, ns);
+      for(const auto &op : expr.operands())
+        get_value_set_rec(op, dest, suffix, original_type, ns);
     }
   }
   else if(expr.id() == ID_union)
@@ -922,8 +920,8 @@ void value_sett::get_value_set_rec(
     // Otherwise we're probably reinterpreting some other type -- try persisting
     // with the current suffix for want of a better idea.
 
-    forall_operands(it, expr)
-      get_value_set_rec(*it, dest, new_suffix, original_type, ns);
+    for(const auto &op : expr.operands())
+      get_value_set_rec(op, dest, new_suffix, original_type, ns);
   }
   else if(expr.id()==ID_array_of)
   {
@@ -1394,9 +1392,9 @@ void value_sett::assign(
       else if(rhs.id()==ID_array ||
               rhs.id()==ID_constant)
       {
-        forall_operands(o_it, rhs)
+        for(const auto &op : rhs.operands())
         {
-          assign(lhs_index, *o_it, ns, is_simplified, add_to_sets);
+          assign(lhs_index, op, ns, is_simplified, add_to_sets);
           add_to_sets=true;
         }
       }
@@ -1630,8 +1628,8 @@ void value_sett::apply_code_rec(
 
   if(statement==ID_block)
   {
-    forall_operands(it, code)
-      apply_code_rec(to_code(*it), ns);
+    for(const auto &op : code.operands())
+      apply_code_rec(to_code(op), ns);
   }
   else if(statement==ID_function_call)
   {
@@ -1753,8 +1751,8 @@ void value_sett::guard(
 {
   if(expr.id()==ID_and)
   {
-    forall_operands(it, expr)
-      guard(*it, ns);
+    for(const auto &op : expr.operands())
+      guard(op, ns);
   }
   else if(expr.id()==ID_equal)
   {

--- a/src/pointer-analysis/value_set_fi.cpp
+++ b/src/pointer-analysis/value_set_fi.cpp
@@ -550,14 +550,16 @@ void value_set_fit::get_value_set_rec(
       // find the pointer operand
       const exprt *ptr_operand=nullptr;
 
-      forall_operands(it, expr)
-        if(it->type().id()==ID_pointer)
+      for(const auto &op : expr.operands())
+      {
+        if(op.type().id() == ID_pointer)
         {
           if(ptr_operand==nullptr)
-            ptr_operand=&(*it);
+            ptr_operand = &op;
           else
             throw "more than one pointer operand in pointer arithmetic";
         }
+      }
 
       if(ptr_operand==nullptr)
         throw "pointer type sum expected to have pointer operand";
@@ -657,8 +659,8 @@ void value_set_fit::get_value_set_rec(
           expr.id()==ID_array)
   {
     // an array constructor, possibly containing addresses
-    forall_operands(it, expr)
-      get_value_set_rec(*it, dest, suffix, original_type, ns, recursion_set);
+    for(const auto &op : expr.operands())
+      get_value_set_rec(op, dest, suffix, original_type, ns, recursion_set);
   }
   else if(expr.id()==ID_dynamic_object)
   {
@@ -1085,9 +1087,9 @@ void value_set_fit::assign(
       else if(rhs.id()==ID_array ||
               rhs.id()==ID_constant)
       {
-        forall_operands(o_it, rhs)
+        for(const auto &op : rhs.operands())
         {
-          assign(lhs_index, *o_it, ns);
+          assign(lhs_index, op, ns);
         }
       }
       else if(rhs.id()==ID_with)

--- a/src/solvers/flattening/arrays.cpp
+++ b/src/solvers/flattening/arrays.cpp
@@ -95,7 +95,8 @@ void arrayst::collect_indices(const exprt &expr)
       array_comprehension_args.insert(
         to_array_comprehension_expr(expr).arg().get_identifier());
 
-    forall_operands(op, expr) collect_indices(*op);
+    for(const auto &op : expr.operands())
+      collect_indices(op);
   }
   else
   {

--- a/src/solvers/flattening/boolbv_case.cpp
+++ b/src/solvers/flattening/boolbv_case.cpp
@@ -32,9 +32,9 @@ bvt boolbvt::convert_case(const exprt &expr)
   literalt previous_compare=const_literal(false);
   literalt compare_literal=const_literal(false);
 
-  forall_operands(it, expr)
+  for(const auto &operand : expr.operands())
   {
-    bvt op=convert_bv(*it);
+    bvt op = convert_bv(operand);
 
     switch(what)
     {
@@ -48,7 +48,7 @@ bvt boolbvt::convert_case(const exprt &expr)
         compare_bv.size() == op.size(),
         std::string("size of compare operand does not match:\n") +
           "compare operand: " + std::to_string(compare_bv.size()) +
-          "\noperand: " + std::to_string(op.size()) + '\n' + it->pretty());
+          "\noperand: " + std::to_string(op.size()) + '\n' + operand.pretty());
 
       compare_literal=bv_utils.equal(compare_bv, op);
       compare_literal=prop.land(!previous_compare, compare_literal);
@@ -63,7 +63,7 @@ bvt boolbvt::convert_case(const exprt &expr)
         bv.size() == op.size(),
         std::string("size of value operand does not match:\n") +
           "result size: " + std::to_string(bv.size()) +
-          "\noperand: " + std::to_string(op.size()) + '\n' + it->pretty());
+          "\noperand: " + std::to_string(op.size()) + '\n' + operand.pretty());
 
       {
         literalt value_literal=bv_utils.equal(bv, op);

--- a/src/solvers/flattening/boolbv_cond.cpp
+++ b/src/solvers/flattening/boolbv_cond.cpp
@@ -32,18 +32,18 @@ bvt boolbvt::convert_cond(const cond_exprt &expr)
     // make it free variables
     bv = prop.new_variables(width);
 
-    forall_operands(it, expr)
+    for(const auto &operand : expr.operands())
     {
       if(condition)
       {
-        cond_literal=convert(*it);
+        cond_literal = convert(operand);
         cond_literal=prop.land(!previous_cond, cond_literal);
 
         previous_cond=prop.lor(previous_cond, cond_literal);
       }
       else
       {
-        const bvt &op = convert_bv(*it, bv.size());
+        const bvt &op = convert_bv(operand, bv.size());
 
         literalt value_literal=bv_utils.equal(bv, op);
 

--- a/src/solvers/flattening/boolbv_constraint_select_one.cpp
+++ b/src/solvers/flattening/boolbv_constraint_select_one.cpp
@@ -33,9 +33,9 @@ bvt boolbvt::convert_constraint_select_one(const exprt &expr)
     b.reserve(expr.operands().size());
 
     // add constraints
-    forall_operands(it, expr)
+    for(const auto &op : expr.operands())
     {
-      bvt it_bv=convert_bv(*it);
+      bvt it_bv = convert_bv(op);
 
       if(it_bv.size()!=bv.size())
         throw "constraint_select_one expects matching width";
@@ -48,9 +48,9 @@ bvt boolbvt::convert_constraint_select_one(const exprt &expr)
   else
   {
     std::size_t op_nr=0;
-    forall_operands(it, expr)
+    for(const auto &op : expr.operands())
     {
-      const bvt &op_bv=convert_bv(*it);
+      const bvt &op_bv = convert_bv(op);
 
       if(op_nr==0)
         bv=op_bv;

--- a/src/solvers/flattening/bv_pointers.cpp
+++ b/src/solvers/flattening/bv_pointers.cpp
@@ -438,15 +438,15 @@ bvt bv_pointerst::convert_pointer_type(const exprt &expr)
     mp_integer size=0;
     std::size_t count=0;
 
-    forall_operands(it, plus_expr)
+    for(const auto &op : plus_expr.operands())
     {
-      if(it->type().id()==ID_pointer)
+      if(op.type().id() == ID_pointer)
       {
         count++;
-        bv=convert_bv(*it);
+        bv = convert_bv(op);
         CHECK_RETURN(bv.size()==bits);
 
-        typet pointer_base_type = to_pointer_type(it->type()).base_type();
+        typet pointer_base_type = to_pointer_type(op.type()).base_type();
 
         if(pointer_base_type.id() == ID_empty)
         {
@@ -470,22 +470,23 @@ bvt bv_pointerst::convert_pointer_type(const exprt &expr)
     const std::size_t offset_bits = get_offset_width(type);
     bvt sum = bv_utils.build_constant(0, offset_bits);
 
-    forall_operands(it, plus_expr)
+    for(const auto &operand : plus_expr.operands())
     {
-      if(it->type().id()==ID_pointer)
+      if(operand.type().id() == ID_pointer)
         continue;
 
-      if(it->type().id()!=ID_unsignedbv &&
-         it->type().id()!=ID_signedbv)
+      if(
+        operand.type().id() != ID_unsignedbv &&
+        operand.type().id() != ID_signedbv)
       {
         return conversion_failed(plus_expr);
       }
 
-      bv_utilst::representationt rep=
-        it->type().id()==ID_signedbv?bv_utilst::representationt::SIGNED:
-                                     bv_utilst::representationt::UNSIGNED;
+      bv_utilst::representationt rep = operand.type().id() == ID_signedbv
+                                         ? bv_utilst::representationt::SIGNED
+                                         : bv_utilst::representationt::UNSIGNED;
 
-      bvt op=convert_bv(*it);
+      bvt op = convert_bv(operand);
       CHECK_RETURN(!op.empty());
 
       op = bv_utils.extension(op, offset_bits, rep);

--- a/src/solvers/prop/prop_conv_solver.cpp
+++ b/src/solvers/prop/prop_conv_solver.cpp
@@ -120,9 +120,9 @@ optionalt<bool> prop_conv_solvert::get_bool(const exprt &expr) const
   {
     if(expr.type().id() == ID_bool && expr.operands().size() >= 1)
     {
-      forall_operands(it, expr)
+      for(const auto &op : expr.operands())
       {
-        auto tmp = get_bool(*it);
+        auto tmp = get_bool(op);
         if(!tmp.has_value())
           return {};
 
@@ -240,8 +240,8 @@ literalt prop_conv_solvert::convert_bool(const exprt &expr)
     std::vector<literalt> op_bv;
     op_bv.reserve(op.size());
 
-    forall_operands(it, expr)
-      op_bv.push_back(convert(*it));
+    for(const auto &op : expr.operands())
+      op_bv.push_back(convert(op));
 
     // add constraints
 
@@ -367,8 +367,8 @@ void prop_conv_solvert::add_constraints_to_prop(const exprt &expr, bool value)
 
         if(expr.id() == ID_and)
         {
-          forall_operands(it, expr)
-            add_constraints_to_prop(*it, true);
+          for(const auto &op : expr.operands())
+            add_constraints_to_prop(op, true);
 
           return;
         }
@@ -382,8 +382,8 @@ void prop_conv_solvert::add_constraints_to_prop(const exprt &expr, bool value)
             bvt bv;
             bv.reserve(expr.operands().size());
 
-            forall_operands(it, expr)
-              bv.push_back(convert(*it));
+            for(const auto &op : expr.operands())
+              bv.push_back(convert(op));
 
             prop.lcnf(bv);
             return;
@@ -416,8 +416,8 @@ void prop_conv_solvert::add_constraints_to_prop(const exprt &expr, bool value)
         }
         else if(expr.id() == ID_or) // !(a || b)  ==  (!a && !b)
         {
-          forall_operands(it, expr)
-            add_constraints_to_prop(*it, false);
+          for(const auto &op : expr.operands())
+            add_constraints_to_prop(op, false);
           return;
         }
       }

--- a/src/solvers/qbf/qdimacs_core.cpp
+++ b/src/solvers/qbf/qdimacs_core.cpp
@@ -20,17 +20,17 @@ void qdimacs_coret::simplify_extractbits(exprt &expr) const
     typedef std::map<exprt, std::set<exprt> > used_bits_mapt;
     used_bits_mapt used_bits_map;
 
-    forall_operands(it, expr)
+    for(const auto &op : expr.operands())
     {
-      if(it->id() == ID_extractbit)
+      if(op.id() == ID_extractbit)
       {
-        const auto &extractbit_expr = to_extractbit_expr(*it);
+        const auto &extractbit_expr = to_extractbit_expr(op);
         if(extractbit_expr.op1().is_constant())
           used_bits_map[extractbit_expr.src()].insert(extractbit_expr.index());
       }
-      else if(it->id() == ID_not && to_not_expr(*it).op().id() == ID_extractbit)
+      else if(op.id() == ID_not && to_not_expr(op).op().id() == ID_extractbit)
       {
-        const auto &extractbit_expr = to_extractbit_expr(to_not_expr(*it).op());
+        const auto &extractbit_expr = to_extractbit_expr(to_not_expr(op).op());
         if(extractbit_expr.op1().is_constant())
           used_bits_map[extractbit_expr.src()].insert(extractbit_expr.index());
       }

--- a/src/solvers/smt2/smt2_conv.cpp
+++ b/src/solvers/smt2/smt2_conv.cpp
@@ -1066,10 +1066,10 @@ void smt2_convt::convert_floatbv(const exprt &expr)
       << convert_identifier(
            "float_bv." + expr.id_string() + floatbv_suffix(expr));
 
-  forall_operands(it, expr)
+  for(const auto &op : expr.operands())
   {
     out << ' ';
-    convert_expr(*it);
+    convert_expr(op);
   }
 
   out << ')';
@@ -1173,10 +1173,10 @@ void smt2_convt::convert_expr(const exprt &expr)
     else if(expr.id()==ID_bitnor)
       out << "bvnor";
 
-    forall_operands(it, expr)
+    for(const auto &op : expr.operands())
     {
       out << " ";
-      flatten2bv(*it);
+      flatten2bv(op);
     }
 
     out << ")";
@@ -1348,10 +1348,10 @@ void smt2_convt::convert_expr(const exprt &expr)
       "logical and, or, and xor expressions should have at least two operands");
 
     out << "(" << expr.id();
-    forall_operands(it, expr)
+    for(const auto &op : expr.operands())
     {
       out << " ";
-      convert_expr(*it);
+      convert_expr(op);
     }
     out << ")";
   }
@@ -2348,10 +2348,10 @@ void smt2_convt::convert_expr(const exprt &expr)
       out << "(concat";
 
     // build component-by-component
-    forall_operands(it, vector_expr)
+    for(const auto &op : vector_expr.operands())
     {
       out << " ";
-      convert_expr(*it);
+      convert_expr(op);
     }
 
     out << ")"; // mk-... or concat
@@ -3999,11 +3999,13 @@ void smt2_convt::convert_minus(const minus_exprt &expr)
     for(mp_integer i=0; i!=size; ++i)
     {
       exprt tmp(ID_minus, vector_type.element_type());
-      forall_operands(it, expr)
+      for(const auto &op : expr.operands())
+      {
         tmp.copy_to_operands(index_exprt(
-          *it,
+          op,
           from_integer(size - i - 1, index_type),
           vector_type.element_type()));
+      }
 
       out << " ";
       convert_expr(tmp);
@@ -4162,10 +4164,10 @@ void smt2_convt::convert_mult(const mult_exprt &expr)
   {
     out << "(*";
 
-    forall_operands(it, expr)
+    for(const auto &op : expr.operands())
     {
       out << " ";
-      convert_expr(*it);
+      convert_expr(op);
     }
 
     out << ")";
@@ -4843,15 +4845,15 @@ void smt2_convt::set_to(const exprt &expr, bool value)
 
   if(expr.id()==ID_and && value)
   {
-    forall_operands(it, expr)
-      set_to(*it, true);
+    for(const auto &op : expr.operands())
+      set_to(op, true);
     return;
   }
 
   if(expr.id()==ID_or && !value)
   {
-    forall_operands(it, expr)
-      set_to(*it, false);
+    for(const auto &op : expr.operands())
+      set_to(op, false);
     return;
   }
 
@@ -5058,8 +5060,8 @@ void smt2_convt::find_symbols(const exprt &expr)
   }
 
   // recursive call on operands
-  forall_operands(it, expr)
-    find_symbols(*it);
+  for(const auto &op : expr.operands())
+    find_symbols(op);
 
   if(expr.id()==ID_symbol ||
      expr.id()==ID_nondet_symbol)

--- a/src/solvers/strings/string_refinement.cpp
+++ b/src/solvers/strings/string_refinement.cpp
@@ -1711,8 +1711,8 @@ static void update_index_set(
     }
     else
     {
-      forall_operands(it, cur)
-        to_process.push_back(*it);
+      for(const auto &op : as_const(cur).operands())
+        to_process.push_back(op);
     }
   }
 }

--- a/src/util/expr.cpp
+++ b/src/util/expr.cpp
@@ -169,9 +169,9 @@ const source_locationt &exprt::find_source_location() const
   if(l.is_not_nil())
     return l;
 
-  forall_operands(it, (*this))
+  for(const auto &op : operands())
   {
-    const source_locationt &op_l = it->find_source_location();
+    const source_locationt &op_l = op.find_source_location();
     if(op_l.is_not_nil())
       return op_l;
   }

--- a/src/util/find_macros.cpp
+++ b/src/util/find_macros.cpp
@@ -44,8 +44,8 @@ void find_macros(
     }
     else
     {
-      forall_operands(it, e)
-        stack.push(&(*it));
+      for(const auto &op : e.operands())
+        stack.push(&op);
     }
   }
 }

--- a/src/util/find_symbols.cpp
+++ b/src/util/find_symbols.cpp
@@ -70,9 +70,9 @@ static bool find_symbols(
     }
   }
 
-  forall_operands(it, src)
+  for(const auto &src_op : src.operands())
   {
-    if(!find_symbols(kind, *it, op, bindings))
+    if(!find_symbols(kind, src_op, op, bindings))
       return false;
   }
 

--- a/src/util/interval.cpp
+++ b/src/util/interval.cpp
@@ -1826,16 +1826,16 @@ bool constant_interval_exprt::is_max(const constant_interval_exprt &a)
 
 bool constant_interval_exprt::contains_extreme(const exprt expr)
 {
-  forall_operands(it, expr)
+  for(const auto &op : expr.operands())
   {
-    if(is_extreme(*it))
+    if(is_extreme(op))
     {
       return true;
     }
 
-    if(it->has_operands())
+    if(op.has_operands())
     {
-      return contains_extreme(*it);
+      return contains_extreme(op);
     }
   }
 

--- a/src/util/rename_symbol.cpp
+++ b/src/util/rename_symbol.cpp
@@ -98,9 +98,11 @@ bool rename_symbolt::have_to_rename(const exprt &dest) const
     return expr_map.find(identifier) != expr_map.end();
   }
 
-  forall_operands(it, dest)
-    if(have_to_rename(*it))
+  for(const auto &op : dest.operands())
+  {
+    if(have_to_rename(op))
       return true;
+  }
 
   const irept &c_sizeof_type=dest.find(ID_C_c_sizeof_type);
 

--- a/src/util/replace_symbol.cpp
+++ b/src/util/replace_symbol.cpp
@@ -177,9 +177,11 @@ bool replace_symbolt::have_to_replace(const exprt &dest) const
       return replaces_symbol(identifier);
   }
 
-  forall_operands(it, dest)
-    if(have_to_replace(*it))
+  for(const auto &op : dest.operands())
+  {
+    if(have_to_replace(op))
       return true;
+  }
 
   const irept &c_sizeof_type=dest.find(ID_C_c_sizeof_type);
 

--- a/src/util/simplify_expr_if.cpp
+++ b/src/util/simplify_expr_if.cpp
@@ -105,9 +105,9 @@ bool simplify_exprt::simplify_if_recursive(
 
 bool simplify_exprt::simplify_if_conj(exprt &expr, const exprt &cond)
 {
-  forall_operands(it, cond)
+  for(const auto &op : cond.operands())
   {
-    if(expr == *it)
+    if(expr == op)
     {
       expr = true_exprt();
       return false;
@@ -124,9 +124,9 @@ bool simplify_exprt::simplify_if_conj(exprt &expr, const exprt &cond)
 
 bool simplify_exprt::simplify_if_disj(exprt &expr, const exprt &cond)
 {
-  forall_operands(it, cond)
+  for(const auto &op : cond.operands())
   {
-    if(expr == *it)
+    if(expr == op)
     {
       expr = false_exprt();
       return false;
@@ -251,12 +251,12 @@ bool simplify_exprt::simplify_if_preorder(if_exprt &expr)
     // a ? b : c  --> a ? b[a/true] : c
     if(cond.id() == ID_and)
     {
-      forall_operands(it, cond)
+      for(const auto &op : as_const(cond).operands())
       {
-        if(it->id() == ID_not)
-          local_replace_map.insert(std::make_pair(it->op0(), false_exprt()));
+        if(op.id() == ID_not)
+          local_replace_map.insert(std::make_pair(op.op0(), false_exprt()));
         else
-          local_replace_map.insert(std::make_pair(*it, true_exprt()));
+          local_replace_map.insert(std::make_pair(op, true_exprt()));
       }
     }
     else
@@ -274,12 +274,12 @@ bool simplify_exprt::simplify_if_preorder(if_exprt &expr)
     // a ? b : c  --> a ? b : c[a/false]
     if(cond.id() == ID_or)
     {
-      forall_operands(it, cond)
+      for(const auto &op : as_const(cond).operands())
       {
-        if(it->id() == ID_not)
-          local_replace_map.insert(std::make_pair(it->op0(), true_exprt()));
+        if(op.id() == ID_not)
+          local_replace_map.insert(std::make_pair(op.op0(), true_exprt()));
         else
-          local_replace_map.insert(std::make_pair(*it, false_exprt()));
+          local_replace_map.insert(std::make_pair(op, false_exprt()));
       }
     }
     else

--- a/src/util/simplify_expr_int.cpp
+++ b/src/util/simplify_expr_int.cpp
@@ -463,9 +463,11 @@ simplify_exprt::resultt<> simplify_exprt::simplify_plus(const plus_exprt &expr)
 
     // count the constants
     size_t count=0;
-    forall_operands(it, expr)
-      if(is_number(it->type()) && it->is_constant())
+    for(const auto &op : expr.operands())
+    {
+      if(is_number(op.type()) && op.is_constant())
         count++;
+    }
 
     // merge constants?
     if(count>=2)
@@ -640,14 +642,14 @@ simplify_exprt::simplify_bitwise(const multi_ary_exprt &expr)
   {
     bool all_bool=true;
 
-    forall_operands(it, expr)
+    for(const auto &op : expr.operands())
     {
       if(
-        it->id() == ID_typecast &&
-        to_typecast_expr(*it).op().type().id() == ID_bool)
+        op.id() == ID_typecast &&
+        to_typecast_expr(op).op().type().id() == ID_bool)
       {
       }
-      else if(it->is_zero() || it->is_one())
+      else if(op.is_zero() || op.is_one())
       {
       }
       else
@@ -1152,9 +1154,9 @@ simplify_exprt::simplify_extractbits(const extractbits_exprt &expr)
     // count down
     mp_integer offset = *width;
 
-    forall_operands(it, expr.src())
+    for(const auto &op : expr.src().operands())
     {
-      auto op_width = pointer_offset_bits(it->type(), ns);
+      auto op_width = pointer_offset_bits(op.type(), ns);
 
       if(!op_width.has_value() || *op_width <= 0)
         return unchanged(expr);
@@ -1162,7 +1164,7 @@ simplify_exprt::simplify_extractbits(const extractbits_exprt &expr)
       if(*start < offset && offset <= *end + *op_width)
       {
         extractbits_exprt result = expr;
-        result.src() = *it;
+        result.src() = op;
         result.lower() =
           from_integer(*end - (offset - *op_width), expr.lower().type());
         result.upper() =

--- a/src/util/simplify_expr_pointer.cpp
+++ b/src/util/simplify_expr_pointer.cpp
@@ -484,10 +484,10 @@ simplify_exprt::resultt<> simplify_exprt::simplify_inequality_pointer_object(
   PRECONDITION(expr.type().id() == ID_bool);
 
   exprt::operandst new_inequality_ops;
-  forall_operands(it, expr)
+  for(const auto &operand : expr.operands())
   {
-    PRECONDITION(it->id() == ID_pointer_object);
-    const exprt &op = to_pointer_object_expr(*it).pointer();
+    PRECONDITION(operand.id() == ID_pointer_object);
+    const exprt &op = to_pointer_object_expr(operand).pointer();
 
     if(op.id()==ID_address_of)
     {

--- a/src/util/simplify_utils.cpp
+++ b/src/util/simplify_utils.cpp
@@ -147,28 +147,30 @@ static bool sort_and_join(exprt &expr, bool do_sort)
 
   // check operand types
 
-  forall_operands(it, expr)
-    if(!is_associative_and_commutative_for_type(saj_entry, it->type().id()))
+  for(const auto &op : as_const(expr).operands())
+  {
+    if(!is_associative_and_commutative_for_type(saj_entry, op.type().id()))
       return true;
+  }
 
   // join expressions
 
   exprt::operandst new_ops;
   new_ops.reserve(as_const(expr).operands().size());
 
-  forall_operands(it, expr)
+  for(const auto &op : as_const(expr).operands())
   {
-    if(it->id()==expr.id())
+    if(op.id() == expr.id())
     {
-      new_ops.reserve(new_ops.capacity()+it->operands().size()-1);
+      new_ops.reserve(new_ops.capacity() + op.operands().size() - 1);
 
-      forall_operands(it2, *it)
-        new_ops.push_back(*it2);
+      for(const auto &sub_op : op.operands())
+        new_ops.push_back(sub_op);
 
       no_change = false;
     }
     else
-      new_ops.push_back(*it);
+      new_ops.push_back(op);
   }
 
   // sort it
@@ -469,9 +471,9 @@ expr2bits(const exprt &expr, bool little_endian, const namespacet &ns)
     expr.id() == ID_complex)
   {
     std::string result;
-    forall_operands(it, expr)
+    for(const auto &op : expr.operands())
     {
-      auto tmp = expr2bits(*it, little_endian, ns);
+      auto tmp = expr2bits(op, little_endian, ns);
       if(!tmp.has_value())
         return {}; // failed
       result += tmp.value();


### PR DESCRIPTION
In some (but not all!) cases of forall_operands we do not actually need the
iterator.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
