### PR TITLE
Fix/gh issue 5797

### DIFF
--- a/regression/cbmc/aws-byte-buf-regression/main.c
+++ b/regression/cbmc/aws-byte-buf-regression/main.c
@@ -1,0 +1,12 @@
+int main()
+{
+  unsigned size;
+  __CPROVER_assume(size >= sizeof(short));
+  char *buf = __CPROVER_allocate(size, 0);
+
+  short x;
+  __CPROVER_assume(sizeof(short) >= 2);
+
+  buf[0] = ((char *)&x)[0];
+  buf[1] = ((char *)&x)[1];
+}

--- a/regression/cbmc/aws-byte-buf-regression/test.desc
+++ b/regression/cbmc/aws-byte-buf-regression/test.desc
@@ -1,0 +1,12 @@
+CORE
+main.c
+--pointer-check
+VERIFICATION SUCCESSFUL
+^EXIT=0$
+^SIGNAL=0$
+--
+--
+This is testing for a cbmc regression that caused an error in the aws-c-common
+repository in Jan 2021
+
+See https://github.com/diffblue/cbmc/issues/5797

--- a/src/solvers/lowering/byte_operators.cpp
+++ b/src/solvers/lowering/byte_operators.cpp
@@ -913,15 +913,17 @@ static exprt unpack_rec(
       }
     }
 
+    auto const src_as_bitvector = typecast_exprt::conditional_cast(
+      src, bv_typet{numeric_cast_v<std::size_t>(last_bit)});
+    auto const byte_type = bv_typet{8};
     exprt::operandst byte_operands;
     for(; bit_offset < last_bit; bit_offset += 8)
     {
       extractbits_exprt extractbits(
-        typecast_exprt::conditional_cast(
-          src, bv_typet{numeric_cast_v<std::size_t>(last_bit)}),
+        src_as_bitvector,
         from_integer(bit_offset + 7, index_type()),
         from_integer(bit_offset, index_type()),
-        bv_typet{8});
+        byte_type);
 
       // endianness_mapt should be the point of reference for mapping out
       // endianness, but we need to work on elements here instead of

--- a/src/solvers/lowering/byte_operators.cpp
+++ b/src/solvers/lowering/byte_operators.cpp
@@ -897,7 +897,8 @@ static exprt unpack_rec(
     auto bits_opt = pointer_offset_bits(src.type(), ns);
     DATA_INVARIANT(bits_opt.has_value(), "basic type should have a fixed size");
 
-    mp_integer last_bit = *bits_opt;
+    const mp_integer total_bits = *bits_opt;
+    mp_integer last_bit = total_bits;
     mp_integer bit_offset = 0;
 
     if(max_bytes.has_value())
@@ -914,7 +915,7 @@ static exprt unpack_rec(
     }
 
     auto const src_as_bitvector = typecast_exprt::conditional_cast(
-      src, bv_typet{numeric_cast_v<std::size_t>(last_bit)});
+      src, bv_typet{numeric_cast_v<std::size_t>(total_bits)});
     auto const byte_type = bv_typet{8};
     exprt::operandst byte_operands;
     for(; bit_offset < last_bit; bit_offset += 8)

--- a/src/solvers/lowering/byte_operators.cpp
+++ b/src/solvers/lowering/byte_operators.cpp
@@ -897,26 +897,30 @@ static exprt unpack_rec(
     auto bits_opt = pointer_offset_bits(src.type(), ns);
     DATA_INVARIANT(bits_opt.has_value(), "basic type should have a fixed size");
 
-    mp_integer bits = *bits_opt;
-    mp_integer i = 0;
+    mp_integer last_bit = *bits_opt;
+    mp_integer bit_offset = 0;
 
     if(max_bytes.has_value())
     {
       const auto max_bits = *max_bytes * 8;
       if(little_endian)
-        bits = std::min(bits, max_bits);
+      {
+        last_bit = std::min(last_bit, max_bits);
+      }
       else
-        i = std::max(mp_integer{0}, bits - max_bits);
+      {
+        bit_offset = std::max(mp_integer{0}, last_bit - max_bits);
+      }
     }
 
     exprt::operandst byte_operands;
-    for(; i < bits; i += 8)
+    for(; bit_offset < last_bit; bit_offset += 8)
     {
       extractbits_exprt extractbits(
         typecast_exprt::conditional_cast(
-          src, bv_typet{numeric_cast_v<std::size_t>(bits)}),
-        from_integer(i + 7, index_type()),
-        from_integer(i, index_type()),
+          src, bv_typet{numeric_cast_v<std::size_t>(last_bit)}),
+        from_integer(bit_offset + 7, index_type()),
+        from_integer(bit_offset, index_type()),
         bv_typet{8});
 
       // endianness_mapt should be the point of reference for mapping out


### PR DESCRIPTION
This fixes a small logic issue in `unpack_rec`. See https://github.com/diffblue/cbmc/issues/5797 for details.


- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
