### PR TITLE
dump-c: handle further byte_update union initializers

### DIFF
--- a/regression/goto-instrument/dump-union2/main.c
+++ b/regression/goto-instrument/dump-union2/main.c
@@ -19,6 +19,13 @@ union U6 {
 
 union U6 g_1197 = {1L};
 
+union U4 {
+  signed f0 : 6;
+  int f3;
+};
+
+union U4 g_1408 = {-1L};
+
 int main()
 {
   assert(g_2110.f0 == 53747);

--- a/src/goto-instrument/dump_c.cpp
+++ b/src/goto-instrument/dump_c.cpp
@@ -1450,7 +1450,8 @@ void dump_ct::cleanup_expr(exprt &expr)
                                         ID_initializer_list,
                                         std::move(designated_initializer2)};
           expr.swap(initializer_list);
-          break;
+
+          return;
         }
       }
     }
@@ -1467,11 +1468,13 @@ void dump_ct::cleanup_expr(exprt &expr)
         {
           union_exprt union_expr{comp.get_name(), bu.value(), bu.op().type()};
           expr.swap(union_expr);
-          break;
+
+          return;
         }
       }
     }
-    else if(
+
+    if(
       ns.follow(bu.type()).id() == ID_union &&
       bu.source_location().get_function().empty() &&
       bu.op() == zero_initializer(bu.op().type(), source_locationt{}, ns)
@@ -1485,9 +1488,14 @@ void dump_ct::cleanup_expr(exprt &expr)
         {
           union_exprt union_expr{comp.get_name(), bu.value(), bu.type()};
           expr.swap(union_expr);
-          break;
+
+          return;
         }
       }
+
+      // we still haven't found a suitable component, so just ignore types and
+      // build an initializer list without designators
+      expr = unary_exprt{ID_initializer_list, bu.value()};
     }
   }
 }


### PR DESCRIPTION
The changes of a8592a73 made the C front-end introduce byte updates to
ensure compliance with the behaviour of popular compilers when
initialising unions. As byte updates aren't part the C language, dump-c
must make sure such union initialisers using byte updates do not end up
in the (re-)generated output.

db4f25cb was the first step in dump-c in this direction, and 3a24545
introduced further rules. The CSmith test generated with random seed
1612048908, however, demonstrated that dump-c's handling still didn't
cover all cases of byte_update expressions introduced by the C
front-end. This commit now handles those further cases.

The regression test is a minified version of that CSmith test.
<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
