### PR TITLE
goto-checker properties: do not ignore ERROR

### DIFF
--- a/src/goto-checker/properties.cpp
+++ b/src/goto-checker/properties.cpp
@@ -226,7 +226,6 @@ property_statust &operator&=(property_statust &a, property_statust const &b)
   switch(a)
   {
   case property_statust::ERROR:
-    a = b;
     return a;
   case property_statust::FAIL:
     a = (b == property_statust::ERROR ? b : a);

--- a/unit/Makefile
+++ b/unit/Makefile
@@ -34,6 +34,7 @@ SRC += analyses/ai/ai.cpp \
        compound_block_locations.cpp \
        get_goto_model_from_c_test.cpp \
        goto-cc/armcc_cmdline.cpp \
+       goto-checker/properties/property_status.cpp \
        goto-checker/report_util/is_property_less_than.cpp \
        goto-instrument/cover_instrument.cpp \
        goto-instrument/cover/cover_only.cpp \

--- a/unit/goto-checker/properties/module_dependencies.txt
+++ b/unit/goto-checker/properties/module_dependencies.txt
@@ -1,0 +1,2 @@
+goto-checker
+testing-utils

--- a/unit/goto-checker/properties/property_status.cpp
+++ b/unit/goto-checker/properties/property_status.cpp
@@ -1,0 +1,178 @@
+// Copyright 2021 Michael Tautschnig
+
+/// \file Tests operations on property_statust
+
+#include <goto-checker/properties.h>
+
+#include <testing-utils/use_catch.h>
+
+TEST_CASE(
+  "Preference order of properties",
+  "[core][goto-checker][property_statust]")
+{
+  const property_statust error{property_statust::ERROR};
+  const property_statust fail{property_statust::FAIL};
+  const property_statust unknown{property_statust::UNKNOWN};
+  const property_statust not_checked{property_statust::NOT_CHECKED};
+  const property_statust not_reachable{property_statust::NOT_REACHABLE};
+  const property_statust pass{property_statust::PASS};
+
+  SECTION("Update a single property status")
+  {
+    property_statust status = property_statust::ERROR;
+    status |= unknown;
+    REQUIRE(status == property_statust::ERROR);
+    status |= error;
+    REQUIRE(status == property_statust::ERROR);
+
+    status = property_statust::FAIL;
+    status |= unknown;
+    REQUIRE(status == property_statust::FAIL);
+    status |= fail;
+    REQUIRE(status == property_statust::FAIL);
+
+    status = property_statust::UNKNOWN;
+    status |= pass;
+    REQUIRE(status == property_statust::PASS);
+    status = property_statust::UNKNOWN;
+    status |= not_reachable;
+    REQUIRE(status == property_statust::NOT_REACHABLE);
+    status = property_statust::UNKNOWN;
+    status |= unknown;
+    REQUIRE(status == property_statust::UNKNOWN);
+    status = property_statust::UNKNOWN;
+    status |= fail;
+    REQUIRE(status == property_statust::FAIL);
+    status = property_statust::UNKNOWN;
+    status |= error;
+    REQUIRE(status == property_statust::ERROR);
+
+    status = property_statust::NOT_CHECKED;
+    status |= pass;
+    REQUIRE(status == property_statust::PASS);
+    status = property_statust::NOT_CHECKED;
+    status |= not_reachable;
+    REQUIRE(status == property_statust::NOT_REACHABLE);
+    status = property_statust::NOT_CHECKED;
+    status |= not_checked;
+    REQUIRE(status == property_statust::NOT_CHECKED);
+    status = property_statust::NOT_CHECKED;
+    status |= unknown;
+    REQUIRE(status == property_statust::UNKNOWN);
+    status = property_statust::NOT_CHECKED;
+    status |= fail;
+    REQUIRE(status == property_statust::FAIL);
+    status = property_statust::NOT_CHECKED;
+    status |= error;
+    REQUIRE(status == property_statust::ERROR);
+
+    status = property_statust::NOT_REACHABLE;
+    status |= not_reachable;
+    REQUIRE(status == property_statust::NOT_REACHABLE);
+    status |= unknown;
+    REQUIRE(status == property_statust::NOT_REACHABLE);
+
+    status = property_statust::PASS;
+    status |= pass;
+    REQUIRE(status == property_statust::PASS);
+    status |= unknown;
+    REQUIRE(status == property_statust::PASS);
+  }
+
+  SECTION("Determine overall status")
+  {
+    property_statust status = property_statust::ERROR;
+    status &= pass;
+    REQUIRE(status == property_statust::ERROR);
+    status &= not_reachable;
+    REQUIRE(status == property_statust::ERROR);
+    status &= not_checked;
+    REQUIRE(status == property_statust::ERROR);
+    status &= unknown;
+    REQUIRE(status == property_statust::ERROR);
+    status &= fail;
+    REQUIRE(status == property_statust::ERROR);
+    status &= error;
+    REQUIRE(status == property_statust::ERROR);
+
+    status = property_statust::FAIL;
+    status &= pass;
+    REQUIRE(status == property_statust::FAIL);
+    status &= not_reachable;
+    REQUIRE(status == property_statust::FAIL);
+    status &= not_checked;
+    REQUIRE(status == property_statust::FAIL);
+    status &= unknown;
+    REQUIRE(status == property_statust::FAIL);
+    status &= fail;
+    REQUIRE(status == property_statust::FAIL);
+    status &= error;
+    REQUIRE(status == property_statust::ERROR);
+
+    status = property_statust::UNKNOWN;
+    status &= pass;
+    REQUIRE(status == property_statust::UNKNOWN);
+    status &= not_reachable;
+    REQUIRE(status == property_statust::UNKNOWN);
+    status &= not_checked;
+    REQUIRE(status == property_statust::UNKNOWN);
+    status &= unknown;
+    REQUIRE(status == property_statust::UNKNOWN);
+    status &= fail;
+    REQUIRE(status == property_statust::FAIL);
+    status = property_statust::UNKNOWN;
+    status &= error;
+    REQUIRE(status == property_statust::ERROR);
+
+    status = property_statust::NOT_CHECKED;
+    status &= pass;
+    REQUIRE(status == property_statust::NOT_CHECKED);
+    status &= not_reachable;
+    REQUIRE(status == property_statust::NOT_CHECKED);
+    status &= not_checked;
+    REQUIRE(status == property_statust::NOT_CHECKED);
+    status &= unknown;
+    REQUIRE(status == property_statust::UNKNOWN);
+    status = property_statust::NOT_CHECKED;
+    status &= fail;
+    REQUIRE(status == property_statust::FAIL);
+    status = property_statust::NOT_CHECKED;
+    status &= error;
+    REQUIRE(status == property_statust::ERROR);
+
+    status = property_statust::NOT_REACHABLE;
+    status &= pass;
+    REQUIRE(status == property_statust::NOT_REACHABLE);
+    status &= not_reachable;
+    REQUIRE(status == property_statust::NOT_REACHABLE);
+    status &= not_checked;
+    REQUIRE(status == property_statust::NOT_CHECKED);
+    status = property_statust::NOT_REACHABLE;
+    status &= unknown;
+    REQUIRE(status == property_statust::UNKNOWN);
+    status = property_statust::NOT_REACHABLE;
+    status &= fail;
+    REQUIRE(status == property_statust::FAIL);
+    status = property_statust::NOT_REACHABLE;
+    status &= error;
+    REQUIRE(status == property_statust::ERROR);
+
+    status = property_statust::PASS;
+    status &= pass;
+    REQUIRE(status == property_statust::PASS);
+    status &= not_reachable;
+    REQUIRE(status == property_statust::NOT_REACHABLE);
+    status = property_statust::PASS;
+    status &= not_checked;
+    REQUIRE(status == property_statust::NOT_CHECKED);
+    status = property_statust::PASS;
+    status &= unknown;
+    REQUIRE(status == property_statust::UNKNOWN);
+    status = property_statust::PASS;
+    status &= fail;
+    REQUIRE(status == property_statust::FAIL);
+    status = property_statust::PASS;
+    status &= error;
+    REQUIRE(status == property_statust::ERROR);
+  }
+}


### PR DESCRIPTION
The assignment of the value of b to overwrite the known-ERROR status of
a resulted in not reporting an overall result of "ERROR" when only some
of the properties had "ERROR" status.

Added a unit test of this code to ensure this keeps working as expected.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
