### PR TITLE
Split unit test into two to avoid GCC warning

### DIFF
--- a/unit/util/string_utils/escape_non_alnum.cpp
+++ b/unit/util/string_utils/escape_non_alnum.cpp
@@ -14,8 +14,10 @@ Author: Diffblue Ltd.
 
 #include <string>
 
+// test split into two halves to avoid a GCC warning ("variable tracking size
+// limit exceeded with -fvar-tracking-assignments, retrying without")
 TEST_CASE(
-  "escape_non_alnum should work with any single byte signed character.",
+  "escape_non_alnum should work with any single byte signed character (part 1)",
   "[core][utils][string_utils][escape_non_alnum]")
 {
   CHECK(escape_non_alnum(std::string{static_cast<signed char>(0x00)}) == "_00");
@@ -147,6 +149,12 @@ TEST_CASE(
   CHECK(escape_non_alnum(std::string{static_cast<signed char>(0x7D)}) == "_7d");
   CHECK(escape_non_alnum(std::string{static_cast<signed char>(0x7E)}) == "_7e");
   CHECK(escape_non_alnum(std::string{static_cast<signed char>(0x7F)}) == "_7f");
+}
+
+TEST_CASE(
+  "escape_non_alnum should work with any single byte signed character (part 2)",
+  "[core][utils][string_utils][escape_non_alnum]")
+{
   CHECK(escape_non_alnum(std::string{static_cast<signed char>(0x80)}) == "_80");
   CHECK(escape_non_alnum(std::string{static_cast<signed char>(0x81)}) == "_81");
   CHECK(escape_non_alnum(std::string{static_cast<signed char>(0x82)}) == "_82");


### PR DESCRIPTION
GCC (version 7.5) issues the following warning: "variable tracking size limit
exceeded with -fvar-tracking-assignments, retrying without" Although harmless,
there is no need to push GCC this far.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
