### PR TITLE
Refactor process_goto_program so that all tools use common processing code

### DIFF
--- a/regression/goto-analyzer/approx-array-variable-const-fp/test.desc
+++ b/regression/goto-analyzer/approx-array-variable-const-fp/test.desc
@@ -1,7 +1,7 @@
 CORE
 main.c
 --show-goto-functions --pointer-check
-^Removing function pointers and virtual functions$
+^Removal of function pointers and virtual functions$
 ^\s*IF fp_tbl\[.*i\] == f2 THEN GOTO [0-9]$
 ^\s*IF fp_tbl\[.*i\] == f3 THEN GOTO [0-9]$
 ^\s*IF fp_tbl\[.*i\] == f4 THEN GOTO [0-9]$

--- a/regression/goto-analyzer/approx-const-fp-array-variable-cast-const-fp/test.desc
+++ b/regression/goto-analyzer/approx-const-fp-array-variable-cast-const-fp/test.desc
@@ -1,7 +1,7 @@
 CORE
 main.c
 --show-goto-functions --pointer-check
-^Removing function pointers and virtual functions$
+^Removal of function pointers and virtual functions$
 ^\s*IF fp == f2 THEN GOTO [0-9]$
 ^\s*IF fp == f3 THEN GOTO [0-9]$
 ^\s*IF fp == f4 THEN GOTO [0-9]$

--- a/regression/goto-analyzer/approx-const-fp-array-variable-const-fp-with-null/test.desc
+++ b/regression/goto-analyzer/approx-const-fp-array-variable-const-fp-with-null/test.desc
@@ -1,7 +1,7 @@
 CORE
 main.c
 --show-goto-functions --pointer-check
-^Removing function pointers and virtual functions$
+^Removal of function pointers and virtual functions$
 ^\s*IF fp == f2 THEN GOTO [0-9]$
 ^\s*IF fp == f3 THEN GOTO [0-9]$
 ^\s*IF fp == f4 THEN GOTO [0-9]$

--- a/regression/goto-analyzer/approx-const-fp-array-variable-const-fp/test.desc
+++ b/regression/goto-analyzer/approx-const-fp-array-variable-const-fp/test.desc
@@ -1,7 +1,7 @@
 CORE
 main.c
 --show-goto-functions --pointer-check
-^Removing function pointers and virtual functions$
+^Removal of function pointers and virtual functions$
 ^\s*IF fp == f2 THEN GOTO [0-9]$
 ^\s*IF fp == f3 THEN GOTO [0-9]$
 ^\s*IF fp == f4 THEN GOTO [0-9]$

--- a/regression/goto-analyzer/approx-const-fp-array-variable-const-pointer-const-struct-non-const-fp/test.desc
+++ b/regression/goto-analyzer/approx-const-fp-array-variable-const-pointer-const-struct-non-const-fp/test.desc
@@ -1,7 +1,7 @@
 CORE
 main.c
 --show-goto-functions --pointer-check
-^Removing function pointers and virtual functions$
+^Removal of function pointers and virtual functions$
 ^\s*IF fp == f2 THEN GOTO [0-9]$
 ^\s*IF fp == f3 THEN GOTO [0-9]$
 ^\s*IF fp == f4 THEN GOTO [0-9]$

--- a/regression/goto-analyzer/approx-const-fp-array-variable-const-struct-non-const-fp/test.desc
+++ b/regression/goto-analyzer/approx-const-fp-array-variable-const-struct-non-const-fp/test.desc
@@ -1,7 +1,7 @@
 CORE
 main.c
 --show-goto-functions --pointer-check
-^Removing function pointers and virtual functions$
+^Removal of function pointers and virtual functions$
 ^\s*IF fp == f2 THEN GOTO [0-9]$
 ^\s*IF fp == f3 THEN GOTO [0-9]$
 ^\s*IF fp == f4 THEN GOTO [0-9]$

--- a/regression/goto-analyzer/approx-const-fp-array-variable-invalid-cast-const-fp/test.desc
+++ b/regression/goto-analyzer/approx-const-fp-array-variable-invalid-cast-const-fp/test.desc
@@ -1,7 +1,7 @@
 CORE
 main.c
 --show-goto-functions --pointer-check
-^Removing function pointers and virtual functions$
+^Removal of function pointers and virtual functions$
 ^\s*IF fp == \(.*\)f2 THEN GOTO [0-9]$
 ^\s*IF fp == \(.*\)f3 THEN GOTO [0-9]$
 ^\s*IF fp == \(.*\)f4 THEN GOTO [0-9]$

--- a/regression/goto-analyzer/approx-const-fp-array-variable-struct-const-fp-with-zero/test.desc
+++ b/regression/goto-analyzer/approx-const-fp-array-variable-struct-const-fp-with-zero/test.desc
@@ -1,7 +1,7 @@
 CORE
 main.c
 --show-goto-functions --pointer-check
-^Removing function pointers and virtual functions$
+^Removal of function pointers and virtual functions$
 ^\s*IF fp == f2 THEN GOTO [0-9]$
 ^\s*IF fp == f3 THEN GOTO [0-9]$
 ^\s*IF fp == f4 THEN GOTO [0-9]$

--- a/regression/goto-analyzer/no-match-array-literal-const-fp-null/test.desc
+++ b/regression/goto-analyzer/no-match-array-literal-const-fp-null/test.desc
@@ -1,7 +1,7 @@
 CORE
 main.c
 --show-goto-functions --pointer-check
-^Removing function pointers and virtual functions$
+^Removal of function pointers and virtual functions$
 ^\s*ASSERT FALSE // invalid function pointer$
 ^EXIT=0$
 ^SIGNAL=0$

--- a/regression/goto-analyzer/no-match-const-array-const-pointer-const-fp-const-lost/test.desc
+++ b/regression/goto-analyzer/no-match-const-array-const-pointer-const-fp-const-lost/test.desc
@@ -1,7 +1,7 @@
 CORE
 main.c
 --show-goto-functions --pointer-check
-^Removing function pointers and virtual functions$
+^Removal of function pointers and virtual functions$
 ^\s*IF \*fp == f1 THEN GOTO [0-9]$
 ^\s*IF \*fp == f2 THEN GOTO [0-9]$
 ^\s*IF \*fp == f3 THEN GOTO [0-9]$

--- a/regression/goto-analyzer/no-match-const-fp-array-literal-const-fp-run-time/test.desc
+++ b/regression/goto-analyzer/no-match-const-fp-array-literal-const-fp-run-time/test.desc
@@ -1,7 +1,7 @@
 CORE
 main.c
 --show-goto-functions --pointer-check
-^Removing function pointers and virtual functions$
+^Removal of function pointers and virtual functions$
 ^\s*IF fp == f1 THEN GOTO [0-9]$
 ^\s*IF fp == f2 THEN GOTO [0-9]$
 ^\s*IF fp == f3 THEN GOTO [0-9]$

--- a/regression/goto-analyzer/no-match-const-fp-array-literal-non-const-fp-run-time/test.desc
+++ b/regression/goto-analyzer/no-match-const-fp-array-literal-non-const-fp-run-time/test.desc
@@ -1,7 +1,7 @@
 CORE
 main.c
 --show-goto-functions --pointer-check
-^Removing function pointers and virtual functions$
+^Removal of function pointers and virtual functions$
 ^\s*IF fp == f1 THEN GOTO [0-9]$
 ^\s*IF fp == f2 THEN GOTO [0-9]$
 ^\s*IF fp == f3 THEN GOTO [0-9]$

--- a/regression/goto-analyzer/no-match-const-fp-array-literal-non-const-fp/test.desc
+++ b/regression/goto-analyzer/no-match-const-fp-array-literal-non-const-fp/test.desc
@@ -1,7 +1,7 @@
 CORE
 main.c
 --show-goto-functions --pointer-check
-^Removing function pointers and virtual functions$
+^Removal of function pointers and virtual functions$
 ^\s*IF fp2 == f1 THEN GOTO [0-9]$
 ^\s*IF fp2 == f2 THEN GOTO [0-9]$
 ^\s*IF fp2 == f3 THEN GOTO [0-9]$

--- a/regression/goto-analyzer/no-match-const-fp-array-non-const-fp/test.desc
+++ b/regression/goto-analyzer/no-match-const-fp-array-non-const-fp/test.desc
@@ -1,7 +1,7 @@
 CORE
 main.c
 --show-goto-functions --pointer-check
-^Removing function pointers and virtual functions$
+^Removal of function pointers and virtual functions$
 ^\s*IF fp2 == f1 THEN GOTO [0-9]$
 ^\s*IF fp2 == f2 THEN GOTO [0-9]$
 ^\s*IF fp2 == f3 THEN GOTO [0-9]$

--- a/regression/goto-analyzer/no-match-const-fp-binary-op-const-lost/test.desc
+++ b/regression/goto-analyzer/no-match-const-fp-binary-op-const-lost/test.desc
@@ -1,7 +1,7 @@
 CORE
 main.c
 --show-goto-functions --pointer-check
-^Removing function pointers and virtual functions$
+^Removal of function pointers and virtual functions$
 ^\s*IF fp == f1 THEN GOTO [0-9]$
 ^\s*IF fp == f2 THEN GOTO [0-9]$
 ^\s*IF fp == f3 THEN GOTO [0-9]$

--- a/regression/goto-analyzer/no-match-const-fp-const-array-index-lost/test.desc
+++ b/regression/goto-analyzer/no-match-const-fp-const-array-index-lost/test.desc
@@ -1,7 +1,7 @@
 CORE
 main.c
 --show-goto-functions --pointer-check
-^Removing function pointers and virtual functions$
+^Removal of function pointers and virtual functions$
 ^\s*IF \*fp == f1 THEN GOTO [0-9]$
 ^\s*IF \*fp == f2 THEN GOTO [0-9]$
 ^\s*IF \*fp == f3 THEN GOTO [0-9]$

--- a/regression/goto-analyzer/no-match-const-fp-const-array-lost/test.desc
+++ b/regression/goto-analyzer/no-match-const-fp-const-array-lost/test.desc
@@ -1,7 +1,7 @@
 CORE
 main.c
 --show-goto-functions --pointer-check
-^Removing function pointers and virtual functions$
+^Removal of function pointers and virtual functions$
 ^\s*IF \*fp == f1 THEN GOTO [0-9]$
 ^\s*IF \*fp == f2 THEN GOTO [0-9]$
 ^\s*IF \*fp == f3 THEN GOTO [0-9]$

--- a/regression/goto-analyzer/no-match-const-fp-const-cast/test.desc
+++ b/regression/goto-analyzer/no-match-const-fp-const-cast/test.desc
@@ -1,7 +1,7 @@
 CORE
 main.c
 --show-goto-functions --pointer-check
-^Removing function pointers and virtual functions$
+^Removal of function pointers and virtual functions$
 ^\s*IF fp == f1 THEN GOTO [0-9]$
 ^\s*IF fp == f2 THEN GOTO [0-9]$
 ^\s*IF fp == f3 THEN GOTO [0-9]$

--- a/regression/goto-analyzer/no-match-const-fp-const-fp-null/test.desc
+++ b/regression/goto-analyzer/no-match-const-fp-const-fp-null/test.desc
@@ -1,7 +1,7 @@
 CORE
 main.c
 --show-goto-functions --pointer-check
-^Removing function pointers and virtual functions$
+^Removal of function pointers and virtual functions$
 ^\s*ASSERT FALSE // invalid function pointer$
 ^EXIT=0$
 ^SIGNAL=0$

--- a/regression/goto-analyzer/no-match-const-fp-const-lost/test.desc
+++ b/regression/goto-analyzer/no-match-const-fp-const-lost/test.desc
@@ -1,7 +1,7 @@
 CORE
 main.c
 --show-goto-functions --pointer-check
-^Removing function pointers and virtual functions$
+^Removal of function pointers and virtual functions$
 ^\s*IF fp == f1 THEN GOTO [0-9]$
 ^\s*IF fp == f2 THEN GOTO [0-9]$
 ^\s*IF fp == f3 THEN GOTO [0-9]$

--- a/regression/goto-analyzer/no-match-const-fp-const-pointer-const-struct-const-fp-null/test.desc
+++ b/regression/goto-analyzer/no-match-const-fp-const-pointer-const-struct-const-fp-null/test.desc
@@ -1,7 +1,7 @@
 CORE
 main.c
 --show-goto-functions --pointer-check
-^Removing function pointers and virtual functions$
+^Removal of function pointers and virtual functions$
 ^\s*ASSERT FALSE // invalid function pointer$
 replacing function pointer by 9 possible targets
 ^EXIT=0$

--- a/regression/goto-analyzer/no-match-const-fp-const-pointer-non-const-struct-const-fp/test.desc
+++ b/regression/goto-analyzer/no-match-const-fp-const-pointer-non-const-struct-const-fp/test.desc
@@ -1,7 +1,7 @@
 CORE
 main.c
 --show-goto-functions --pointer-check
-^Removing function pointers and virtual functions$
+^Removal of function pointers and virtual functions$
 ^\s*IF fp == f1 THEN GOTO [0-9]$
 ^\s*IF fp == f2 THEN GOTO [0-9]$
 ^\s*IF fp == f3 THEN GOTO [0-9]$

--- a/regression/goto-analyzer/no-match-const-fp-dereference-const-pointer-null/test.desc
+++ b/regression/goto-analyzer/no-match-const-fp-dereference-const-pointer-null/test.desc
@@ -1,7 +1,7 @@
 CORE
 main.c
 --show-goto-functions --pointer-check
-^Removing function pointers and virtual functions$
+^Removal of function pointers and virtual functions$
 ^\s*ASSERT FALSE // invalid function pointer$
 replacing function pointer by 9 possible targets
 ^EXIT=0$

--- a/regression/goto-analyzer/no-match-const-fp-dereference-non-const-pointer-const-fp/test.desc
+++ b/regression/goto-analyzer/no-match-const-fp-dereference-non-const-pointer-const-fp/test.desc
@@ -1,7 +1,7 @@
 CORE
 main.c
 --show-goto-functions --pointer-check
-^Removing function pointers and virtual functions$
+^Removal of function pointers and virtual functions$
 ^\s*IF final_fp == f1 THEN GOTO [0-9]$
 ^\s*IF final_fp == f2 THEN GOTO [0-9]$
 ^\s*IF final_fp == f3 THEN GOTO [0-9]$

--- a/regression/goto-analyzer/no-match-const-fp-dynamic-array-non-const-fp/test.desc
+++ b/regression/goto-analyzer/no-match-const-fp-dynamic-array-non-const-fp/test.desc
@@ -1,7 +1,7 @@
 CORE
 main.c
 --show-goto-functions --pointer-check
-^Removing function pointers and virtual functions$
+^Removal of function pointers and virtual functions$
 ^\s*IF fp == f1 THEN GOTO [0-9]+$
 ^\s*IF fp == f2 THEN GOTO [0-9]+$
 ^\s*IF fp == f3 THEN GOTO [0-9]+$

--- a/regression/goto-analyzer/no-match-const-fp-dynamic-array-non-const-fp/test.desc
+++ b/regression/goto-analyzer/no-match-const-fp-dynamic-array-non-const-fp/test.desc
@@ -2,15 +2,15 @@ CORE
 main.c
 --show-goto-functions --pointer-check
 ^Removing function pointers and virtual functions$
-^\s*IF fp == f1 THEN GOTO [0-9]$
-^\s*IF fp == f2 THEN GOTO [0-9]$
-^\s*IF fp == f3 THEN GOTO [0-9]$
-^\s*IF fp == f4 THEN GOTO [0-9]$
-^\s*IF fp == f5 THEN GOTO [0-9]$
-^\s*IF fp == f6 THEN GOTO [0-9]$
-^\s*IF fp == f7 THEN GOTO [0-9]$
-^\s*IF fp == f8 THEN GOTO [0-9]$
-^\s*IF fp == f9 THEN GOTO [0-9]$
+^\s*IF fp == f1 THEN GOTO [0-9]+$
+^\s*IF fp == f2 THEN GOTO [0-9]+$
+^\s*IF fp == f3 THEN GOTO [0-9]+$
+^\s*IF fp == f4 THEN GOTO [0-9]+$
+^\s*IF fp == f5 THEN GOTO [0-9]+$
+^\s*IF fp == f6 THEN GOTO [0-9]+$
+^\s*IF fp == f7 THEN GOTO [0-9]+$
+^\s*IF fp == f8 THEN GOTO [0-9]+$
+^\s*IF fp == f9 THEN GOTO [0-9]+$
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/goto-analyzer/no-match-const-fp-non-const-fp-direct-assignment/test.desc
+++ b/regression/goto-analyzer/no-match-const-fp-non-const-fp-direct-assignment/test.desc
@@ -1,7 +1,7 @@
 CORE
 main.c
 --show-goto-functions --pointer-check
-^Removing function pointers and virtual functions$
+^Removal of function pointers and virtual functions$
 ^\s*IF fp2 == f1 THEN GOTO [0-9]$
 ^\s*IF fp2 == f2 THEN GOTO [0-9]$
 ^\s*IF fp2 == f3 THEN GOTO [0-9]$

--- a/regression/goto-analyzer/no-match-const-fp-non-const-pointer-non-const-struct-const-fp/test.desc
+++ b/regression/goto-analyzer/no-match-const-fp-non-const-pointer-non-const-struct-const-fp/test.desc
@@ -1,7 +1,7 @@
 CORE
 main.c
 --show-goto-functions --pointer-check
-^Removing function pointers and virtual functions$
+^Removal of function pointers and virtual functions$
 ^\s*IF fp == f1 THEN GOTO [0-9]$
 ^\s*IF fp == f2 THEN GOTO [0-9]$
 ^\s*IF fp == f3 THEN GOTO [0-9]$

--- a/regression/goto-analyzer/no-match-const-fp-non-const-struct-const-fp/test.desc
+++ b/regression/goto-analyzer/no-match-const-fp-non-const-struct-const-fp/test.desc
@@ -1,7 +1,7 @@
 CORE
 main.c
 --show-goto-functions --pointer-check
-^Removing function pointers and virtual functions$
+^Removal of function pointers and virtual functions$
 ^\s*IF fp == f1 THEN GOTO [0-9]$
 ^\s*IF fp == f2 THEN GOTO [0-9]$
 ^\s*IF fp == f3 THEN GOTO [0-9]$

--- a/regression/goto-analyzer/no-match-const-fp-non-const-struct-non-const-fp/test.desc
+++ b/regression/goto-analyzer/no-match-const-fp-non-const-struct-non-const-fp/test.desc
@@ -1,7 +1,7 @@
 CORE
 main.c
 --show-goto-functions --pointer-check
-^Removing function pointers and virtual functions$
+^Removal of function pointers and virtual functions$
 ^\s*IF fp == f1 THEN GOTO [0-9]$
 ^\s*IF fp == f2 THEN GOTO [0-9]$
 ^\s*IF fp == f3 THEN GOTO [0-9]$

--- a/regression/goto-analyzer/no-match-const-fp-null/test.desc
+++ b/regression/goto-analyzer/no-match-const-fp-null/test.desc
@@ -1,7 +1,7 @@
 CORE
 main.c
 --show-goto-functions --pointer-check
-^Removing function pointers and virtual functions$
+^Removal of function pointers and virtual functions$
 ^\s*ASSERT FALSE // invalid function pointer$
 function func: replacing function pointer by 0 possible targets
 ^EXIT=0$

--- a/regression/goto-analyzer/no-match-const-fp-ternerary-op-const-lost/test.desc
+++ b/regression/goto-analyzer/no-match-const-fp-ternerary-op-const-lost/test.desc
@@ -1,7 +1,7 @@
 CORE
 main.c
 --show-goto-functions --pointer-check
-^Removing function pointers and virtual functions$
+^Removal of function pointers and virtual functions$
 ^\s*IF fp == f1 THEN GOTO [0-9]$
 ^\s*IF fp == f2 THEN GOTO [0-9]$
 ^\s*IF fp == f3 THEN GOTO [0-9]$

--- a/regression/goto-analyzer/no-match-const-pointer-const-struct-const-fp-const-cast/test.desc
+++ b/regression/goto-analyzer/no-match-const-pointer-const-struct-const-fp-const-cast/test.desc
@@ -1,7 +1,7 @@
 CORE
 main.c
 --show-goto-functions --pointer-check
-^Removing function pointers and virtual functions$
+^Removal of function pointers and virtual functions$
 ^\s*IF container_pointer->fp == f1 THEN GOTO [0-9]$
 ^\s*IF container_pointer->fp == f2 THEN GOTO [0-9]$
 ^\s*IF container_pointer->fp == f3 THEN GOTO [0-9]$

--- a/regression/goto-analyzer/no-match-const-pointer-non-const-struct-const-fp/test.desc
+++ b/regression/goto-analyzer/no-match-const-pointer-non-const-struct-const-fp/test.desc
@@ -1,7 +1,7 @@
 CORE
 main.c
 --show-goto-functions --pointer-check
-^Removing function pointers and virtual functions$
+^Removal of function pointers and virtual functions$
 ^\s*IF pts->go == f1 THEN GOTO [0-9]$
 ^\s*IF pts->go == f2 THEN GOTO [0-9]$
 ^\s*IF pts->go == f3 THEN GOTO [0-9]$

--- a/regression/goto-analyzer/no-match-const-struct-non-const-fp-null/test.desc
+++ b/regression/goto-analyzer/no-match-const-struct-non-const-fp-null/test.desc
@@ -1,7 +1,7 @@
 CORE
 main.c
 --show-goto-functions --pointer-check
-^Removing function pointers and virtual functions$
+^Removal of function pointers and virtual functions$
 ^\s*ASSERT FALSE // invalid function pointer$
 ^EXIT=0$
 ^SIGNAL=0$

--- a/regression/goto-analyzer/no-match-dereference-const-pointer-const-array-literal-pointer-const-fp/test.desc
+++ b/regression/goto-analyzer/no-match-dereference-const-pointer-const-array-literal-pointer-const-fp/test.desc
@@ -1,7 +1,7 @@
 CORE
 main.c
 --show-goto-functions --pointer-check
-^Removing function pointers and virtual functions$
+^Removal of function pointers and virtual functions$
 ^\s*IF \*container_ptr->fp_tbl\[.*1\] == f1 THEN GOTO [0-9]$
 ^\s*IF \*container_ptr->fp_tbl\[.*1\] == f2 THEN GOTO [0-9]$
 ^\s*IF \*container_ptr->fp_tbl\[.*1\] == f3 THEN GOTO [0-9]$

--- a/regression/goto-analyzer/no-match-dereference-non-const-struct-const-pointer-const-fp/test.desc
+++ b/regression/goto-analyzer/no-match-dereference-non-const-struct-const-pointer-const-fp/test.desc
@@ -1,7 +1,7 @@
 CORE
 main.c
 --show-goto-functions --pointer-check
-^Removing function pointers and virtual functions$
+^Removal of function pointers and virtual functions$
 ^\s*IF \*container_container\.container == f1 THEN GOTO [0-9]$
 ^\s*IF \*container_container\.container == f2 THEN GOTO [0-9]$
 ^\s*IF \*container_container\.container == f3 THEN GOTO [0-9]$

--- a/regression/goto-analyzer/no-match-dereference-non-const-struct-non-const-pointer-const-fp/test.desc
+++ b/regression/goto-analyzer/no-match-dereference-non-const-struct-non-const-pointer-const-fp/test.desc
@@ -1,7 +1,7 @@
 CORE
 main.c
 --show-goto-functions --pointer-check
-^Removing function pointers and virtual functions$
+^Removal of function pointers and virtual functions$
 ^\s*IF \*container_container\.container == f1 THEN GOTO [0-9]$
 ^\s*IF \*container_container\.container == f2 THEN GOTO [0-9]$
 ^\s*IF \*container_container\.container == f3 THEN GOTO [0-9]$

--- a/regression/goto-analyzer/no-match-non-const-fp-const-fp-direct-assignment/test.desc
+++ b/regression/goto-analyzer/no-match-non-const-fp-const-fp-direct-assignment/test.desc
@@ -1,7 +1,7 @@
 CORE
 main.c
 --show-goto-functions --pointer-check
-^Removing function pointers and virtual functions$
+^Removal of function pointers and virtual functions$
 ^\s*IF fp2 == f1 THEN GOTO [0-9]$
 ^\s*IF fp2 == f2 THEN GOTO [0-9]$
 ^\s*IF fp2 == f3 THEN GOTO [0-9]$

--- a/regression/goto-analyzer/no-match-non-const-fp/test.desc
+++ b/regression/goto-analyzer/no-match-non-const-fp/test.desc
@@ -1,7 +1,7 @@
 CORE
 main.c
 --show-goto-functions --pointer-check
-^Removing function pointers and virtual functions$
+^Removal of function pointers and virtual functions$
 ^\s*IF fp == f1 THEN GOTO [0-9]$
 ^\s*IF fp == f2 THEN GOTO [0-9]$
 ^\s*IF fp == f3 THEN GOTO [0-9]$

--- a/regression/goto-analyzer/no-match-parameter-const-fp/test.desc
+++ b/regression/goto-analyzer/no-match-parameter-const-fp/test.desc
@@ -1,7 +1,7 @@
 CORE
 main.c
 --show-goto-functions --pointer-check
-^Removing function pointers and virtual functions$
+^Removal of function pointers and virtual functions$
 ^\s*IF fp == f1 THEN GOTO [0-9]$
 ^\s*IF fp == f2 THEN GOTO [0-9]$
 ^\s*IF fp == f3 THEN GOTO [0-9]$

--- a/regression/goto-analyzer/no-match-parameter-fp/test.desc
+++ b/regression/goto-analyzer/no-match-parameter-fp/test.desc
@@ -1,7 +1,7 @@
 CORE
 main.c
 --show-goto-functions --pointer-check
-^Removing function pointers and virtual functions$
+^Removal of function pointers and virtual functions$
 ^\s*IF fp == f1 THEN GOTO [0-9]$
 ^\s*IF fp == f2 THEN GOTO [0-9]$
 ^\s*IF fp == f3 THEN GOTO [0-9]$

--- a/regression/goto-analyzer/no-match-pointer-const-struct-array-literal-non-const-fp/test.desc
+++ b/regression/goto-analyzer/no-match-pointer-const-struct-array-literal-non-const-fp/test.desc
@@ -1,7 +1,7 @@
 CORE
 main.c
 --show-goto-functions --pointer-check
-^Removing function pointers and virtual functions$
+^Removal of function pointers and virtual functions$
 ^\s*IF container_ptr->fp_tbl\[.*1\] == f1 THEN GOTO [0-9]$
 ^\s*IF container_ptr->fp_tbl\[.*1\] == f2 THEN GOTO [0-9]$
 ^\s*IF container_ptr->fp_tbl\[.*1\] == f3 THEN GOTO [0-9]$

--- a/regression/goto-analyzer/precise-array-calculation-const-fp/test.desc
+++ b/regression/goto-analyzer/precise-array-calculation-const-fp/test.desc
@@ -1,7 +1,7 @@
 CORE
 main.c
 --show-goto-functions --pointer-check
-^Removing function pointers and virtual functions$
+^Removal of function pointers and virtual functions$
 ^\s*f3\(\);$
 ^EXIT=0$
 ^SIGNAL=0$

--- a/regression/goto-analyzer/precise-array-literal-const-fp/test.desc
+++ b/regression/goto-analyzer/precise-array-literal-const-fp/test.desc
@@ -1,7 +1,7 @@
 CORE
 main.c
 --show-goto-functions --pointer-check
-^Removing function pointers and virtual functions$
+^Removal of function pointers and virtual functions$
 ^\s*f3\(\);$
 ^EXIT=0$
 ^SIGNAL=0$

--- a/regression/goto-analyzer/precise-const-fp-array-const-variable-const-fp/test.desc
+++ b/regression/goto-analyzer/precise-const-fp-array-const-variable-const-fp/test.desc
@@ -1,7 +1,7 @@
 CORE
 main.c
 --show-goto-functions --pointer-check
-^Removing function pointers and virtual functions$
+^Removal of function pointers and virtual functions$
 ^\s*f3\(\);$
 ^EXIT=0$
 ^SIGNAL=0$

--- a/regression/goto-analyzer/precise-const-fp-array-literal-const-fp-run-time/test.desc
+++ b/regression/goto-analyzer/precise-const-fp-array-literal-const-fp-run-time/test.desc
@@ -1,7 +1,7 @@
 CORE
 main.c
 --show-goto-functions --pointer-check
-^Removing function pointers and virtual functions$
+^Removal of function pointers and virtual functions$
 ^\s*f3\(\);$
 ^EXIT=0$
 ^SIGNAL=0$

--- a/regression/goto-analyzer/precise-const-fp-array-literal-const-fp/test.desc
+++ b/regression/goto-analyzer/precise-const-fp-array-literal-const-fp/test.desc
@@ -1,7 +1,7 @@
 CORE
 main.c
 --show-goto-functions --pointer-check
-^Removing function pointers and virtual functions$
+^Removal of function pointers and virtual functions$
 ^\s*f3\(\);$
 ^EXIT=0$
 ^SIGNAL=0$

--- a/regression/goto-analyzer/precise-const-fp-array-literal-const-struct-non-const-fp/test.desc
+++ b/regression/goto-analyzer/precise-const-fp-array-literal-const-struct-non-const-fp/test.desc
@@ -1,7 +1,7 @@
 CORE
 main.c
 --show-goto-functions --pointer-check
-^Removing function pointers and virtual functions$
+^Removal of function pointers and virtual functions$
 ^\s*f3\(\);$
 ^EXIT=0$
 ^SIGNAL=0$

--- a/regression/goto-analyzer/precise-const-fp-array-variable-const-pointer-const-struct-non-const-fp/test.desc
+++ b/regression/goto-analyzer/precise-const-fp-array-variable-const-pointer-const-struct-non-const-fp/test.desc
@@ -1,7 +1,7 @@
 CORE
 main.c
 --show-goto-functions --pointer-check
-^Removing function pointers and virtual functions$
+^Removal of function pointers and virtual functions$
 ^\s*f2\(\);
 ^EXIT=0$
 ^SIGNAL=0$

--- a/regression/goto-analyzer/precise-const-fp-const-fp/test.desc
+++ b/regression/goto-analyzer/precise-const-fp-const-fp/test.desc
@@ -1,7 +1,7 @@
 CORE
 main.c
 --show-goto-functions --pointer-check
-^Removing function pointers and virtual functions$
+^Removal of function pointers and virtual functions$
 ^\s*f2\(\);$
 ^EXIT=0$
 ^SIGNAL=0$

--- a/regression/goto-analyzer/precise-const-fp-const-struct-const-array-literal-fp/test.desc
+++ b/regression/goto-analyzer/precise-const-fp-const-struct-const-array-literal-fp/test.desc
@@ -1,7 +1,7 @@
 CORE
 main.c
 --show-goto-functions --pointer-check
-^Removing function pointers and virtual functions$
+^Removal of function pointers and virtual functions$
 ^\s*f3\(\);$
 ^EXIT=0$
 ^SIGNAL=0$

--- a/regression/goto-analyzer/precise-const-fp-const-struct-non-const-array-literal-fp/test.desc
+++ b/regression/goto-analyzer/precise-const-fp-const-struct-non-const-array-literal-fp/test.desc
@@ -1,7 +1,7 @@
 CORE
 main.c
 --show-goto-functions --pointer-check
-^Removing function pointers and virtual functions$
+^Removal of function pointers and virtual functions$
 ^\s*f3\(\);$
 ^EXIT=0$
 ^SIGNAL=0$

--- a/regression/goto-analyzer/precise-const-fp-const-struct-non-const-fp/test.desc
+++ b/regression/goto-analyzer/precise-const-fp-const-struct-non-const-fp/test.desc
@@ -1,7 +1,7 @@
 CORE
 main.c
 --show-goto-functions --pointer-check
-^Removing function pointers and virtual functions$
+^Removal of function pointers and virtual functions$
 ^\s*f2\(\);
 ^EXIT=0$
 ^SIGNAL=0$

--- a/regression/goto-analyzer/precise-const-fp-dereference-const-pointer-const-fp/test.desc
+++ b/regression/goto-analyzer/precise-const-fp-dereference-const-pointer-const-fp/test.desc
@@ -1,7 +1,7 @@
 CORE
 main.c
 --show-goto-functions --pointer-check
-^Removing function pointers and virtual functions$
+^Removal of function pointers and virtual functions$
 ^\s*f3\(\);$
 ^EXIT=0$
 ^SIGNAL=0$

--- a/regression/goto-analyzer/precise-const-fp-supurious-const-loss/test.desc
+++ b/regression/goto-analyzer/precise-const-fp-supurious-const-loss/test.desc
@@ -1,7 +1,7 @@
 CORE
 main.c
 --show-goto-functions --pointer-check
-^Removing function pointers and virtual functions$
+^Removal of function pointers and virtual functions$
 ^\s*f2\(\);
 ^EXIT=0$
 ^SIGNAL=0$

--- a/regression/goto-analyzer/precise-const-fp/test.desc
+++ b/regression/goto-analyzer/precise-const-fp/test.desc
@@ -1,7 +1,7 @@
 CORE
 main.c
 --show-goto-functions --pointer-check
-^Removing function pointers and virtual functions$
+^Removal of function pointers and virtual functions$
 ^\s*f2\(\);
 ^EXIT=0$
 ^SIGNAL=0$

--- a/regression/goto-analyzer/precise-const-pointer-const-struct-fp/test.desc
+++ b/regression/goto-analyzer/precise-const-pointer-const-struct-fp/test.desc
@@ -1,7 +1,7 @@
 CORE
 main.c
 --show-goto-functions --pointer-check
-^Removing function pointers and virtual functions$
+^Removal of function pointers and virtual functions$
 ^\s*f2\(\);$
 ^EXIT=0$
 ^SIGNAL=0$

--- a/regression/goto-analyzer/precise-const-struct-non-const-fp/test.desc
+++ b/regression/goto-analyzer/precise-const-struct-non-const-fp/test.desc
@@ -1,7 +1,7 @@
 CORE
 main.c
 --show-goto-functions --pointer-check
-^Removing function pointers and virtual functions$
+^Removal of function pointers and virtual functions$
 ^\s*f2\(\);
 ^EXIT=0$
 ^SIGNAL=0$

--- a/regression/goto-analyzer/precise-derefence-const-pointer-const-fp/test.desc
+++ b/regression/goto-analyzer/precise-derefence-const-pointer-const-fp/test.desc
@@ -1,7 +1,7 @@
 CORE
 main.c
 --show-goto-functions --pointer-check
-^Removing function pointers and virtual functions$
+^Removal of function pointers and virtual functions$
 ^\s*f3\(\);$
 ^EXIT=0$
 ^SIGNAL=0$

--- a/regression/goto-analyzer/precise-derefence/test.desc
+++ b/regression/goto-analyzer/precise-derefence/test.desc
@@ -1,7 +1,7 @@
 CORE
 main.c
 --show-goto-functions --pointer-check
-^Removing function pointers and virtual functions$
+^Removal of function pointers and virtual functions$
 ^\s*f2\(\);
 ^EXIT=0$
 ^SIGNAL=0$

--- a/regression/goto-analyzer/precise-dereference-address-pointer-const-fp/test.desc
+++ b/regression/goto-analyzer/precise-dereference-address-pointer-const-fp/test.desc
@@ -1,7 +1,7 @@
 CORE
 main.c
 --show-goto-functions --pointer-check
-^Removing function pointers and virtual functions$
+^Removal of function pointers and virtual functions$
 ^\s*f3\(\);$
 ^EXIT=0$
 ^SIGNAL=0$

--- a/regression/goto-analyzer/precise-dereference-const-struct-const-pointer-const-fp/test.desc
+++ b/regression/goto-analyzer/precise-dereference-const-struct-const-pointer-const-fp/test.desc
@@ -1,7 +1,7 @@
 CORE
 main.c
 --show-goto-functions --pointer-check
-^Removing function pointers and virtual functions$
+^Removal of function pointers and virtual functions$
 ^\s*f3\(\);$
 ^EXIT=0$
 ^SIGNAL=0$

--- a/regression/goto-analyzer/precise-dereference-const-struct-const-pointer-const-struct-const-fp/test.desc
+++ b/regression/goto-analyzer/precise-dereference-const-struct-const-pointer-const-struct-const-fp/test.desc
@@ -1,7 +1,7 @@
 CORE
 main.c
 --show-goto-functions --pointer-check
-^Removing function pointers and virtual functions$
+^Removal of function pointers and virtual functions$
 ^\s*f3\(\);$
 ^EXIT=0$
 ^SIGNAL=0$

--- a/regression/goto-analyzer/precise-dereference-const-struct-pointer-const-fp/test.desc
+++ b/regression/goto-analyzer/precise-dereference-const-struct-pointer-const-fp/test.desc
@@ -1,7 +1,7 @@
 CORE
 main.c
 --show-goto-functions --pointer-check
-^Removing function pointers and virtual functions$
+^Removal of function pointers and virtual functions$
 ^\s*f3\(\);$
 ^EXIT=0$
 ^SIGNAL=0$

--- a/regression/goto-analyzer/value-set-function-pointers-structs/test.desc
+++ b/regression/goto-analyzer/value-set-function-pointers-structs/test.desc
@@ -5,7 +5,7 @@ main.c
 ^file main.c line 46 function main: replacing function pointer by 2 possible targets$
 ^file main.c line 54 function main: replacing function pointer by 2 possible targets$
 ^main::1::fun1 \(\) -> value-set-begin: ptr ->\(f\), ptr ->\(g\) :value-set-end
-^main::1::s2 \(\) -> \{\.fptr=value-set-begin: ptr ->\(f\), ptr ->\(g\) :value-set-end @ \[23, 25\]} @ \[23, 25\]
+^main::1::s2 \(\) -> \{\.fptr=value-set-begin: ptr ->\(f\), ptr ->\(g\) :value-set-end @ \[30, 32\]} @ \[30, 32\]
 ^main::1::fun2 \(\) -> value-set-begin: ptr ->\(g\) :value-set-end
 ^EXIT=0$
 ^SIGNAL=0$

--- a/scripts/expected_doxygen_warnings.txt
+++ b/scripts/expected_doxygen_warnings.txt
@@ -79,10 +79,9 @@
 /home/runner/work/cbmc/cbmc/src/analyses/variable-sensitivity/variable_sensitivity_object_factory.cpp:188: warning: The following parameter of initialize_abstract_object(const typet type, bool top, bool bottom, const exprt &e, const abstract_environmentt &environment, const namespacet &ns, const vsd_configt &configuration) is not documented:
   parameter 'configuration'
 
-warning: Include graph for 'cbmc_parse_options.cpp' not generated, too many nodes (61), threshold is 60. Consider increasing DOT_GRAPH_MAX_NODES.
 warning: Include graph for 'goto_instrument_parse_options.cpp' not generated, too many nodes (97), threshold is 60. Consider increasing DOT_GRAPH_MAX_NODES.
 warning: Included by graph for 'goto_functions.h' not generated, too many nodes (66), threshold is 60. Consider increasing DOT_GRAPH_MAX_NODES.
-warning: Included by graph for 'goto_model.h' not generated, too many nodes (109), threshold is 60. Consider increasing DOT_GRAPH_MAX_NODES.
+warning: Included by graph for 'goto_model.h' not generated, too many nodes (110), threshold is 60. Consider increasing DOT_GRAPH_MAX_NODES.
 warning: Included by graph for 'arith_tools.h' not generated, too many nodes (181), threshold is 60. Consider increasing DOT_GRAPH_MAX_NODES.
 warning: Included by graph for 'c_types.h' not generated, too many nodes (110), threshold is 60. Consider increasing DOT_GRAPH_MAX_NODES.
 warning: Included by graph for 'config.h' not generated, too many nodes (85), threshold is 60. Consider increasing DOT_GRAPH_MAX_NODES.
@@ -91,7 +90,7 @@ warning: Included by graph for 'expr.h' not generated, too many nodes (87), thre
 warning: Included by graph for 'expr_util.h' not generated, too many nodes (61), threshold is 60. Consider increasing DOT_GRAPH_MAX_NODES.
 warning: Included by graph for 'invariant.h' not generated, too many nodes (187), threshold is 60. Consider increasing DOT_GRAPH_MAX_NODES.
 warning: Included by graph for 'irep.h' not generated, too many nodes (62), threshold is 60. Consider increasing DOT_GRAPH_MAX_NODES.
-warning: Included by graph for 'message.h' not generated, too many nodes (116), threshold is 60. Consider increasing DOT_GRAPH_MAX_NODES.
+warning: Included by graph for 'message.h' not generated, too many nodes (117), threshold is 60. Consider increasing DOT_GRAPH_MAX_NODES.
 warning: Included by graph for 'namespace.h' not generated, too many nodes (109), threshold is 60. Consider increasing DOT_GRAPH_MAX_NODES.
 warning: Included by graph for 'pointer_expr.h' not generated, too many nodes (101), threshold is 60. Consider increasing DOT_GRAPH_MAX_NODES.
 warning: Included by graph for 'prefix.h' not generated, too many nodes (86), threshold is 60. Consider increasing DOT_GRAPH_MAX_NODES.

--- a/src/analyses/goto_check.h
+++ b/src/analyses/goto_check.h
@@ -40,7 +40,10 @@ void goto_check(
   "(pointer-overflow-check)(conversion-check)(undefined-shift-check)"          \
   "(float-overflow-check)(nan-check)(no-built-in-assertions)"                  \
   "(pointer-primitive-check)"                                                  \
-  "(retain-trivial-checks)"
+  "(retain-trivial-checks)"                                                    \
+  "(error-label):"                                                             \
+  "(no-assertions)(no-assumptions)"                                            \
+  "(assert-to-assume)"
 
 // clang-format off
 #define HELP_GOTO_CHECK \
@@ -59,6 +62,11 @@ void goto_check(
   " --pointer-primitive-check    checks that all pointers in pointer primitives are valid or null\n" /* NOLINT(whitespace/line_length) */ \
   " --no-built-in-assertions     ignore assertions in built-in library\n" \
   " --retain-trivial-checks      include checks that are trivially true\n" \
+  " --error-label label          check that label is unreachable\n" \
+  " --no-built-in-assertions     ignore assertions in built-in library\n" \
+  " --no-assertions              ignore user assertions\n" \
+  " --no-assumptions             ignore user assumptions\n" \
+  " --assert-to-assume           convert user assertions to assumptions\n" \
 
 #define PARSE_OPTIONS_GOTO_CHECK(cmdline, options) \
   options.set_option("bounds-check", cmdline.isset("bounds-check")); \
@@ -77,6 +85,12 @@ void goto_check(
   options.set_option("pointer-primitive-check", cmdline.isset("pointer-primitive-check")); /* NOLINT(whitespace/line_length) */ \
   options.set_option("retain-trivial-checks", \
                      cmdline.isset("retain-trivial-checks")); \
+  options.set_option("assertions", !cmdline.isset("no-assertions")); /* NOLINT(whitespace/line_length) */ \
+  options.set_option("assumptions", !cmdline.isset("no-assumptions")); /* NOLINT(whitespace/line_length) */ \
+  options.set_option("assert-to-assume", cmdline.isset("assert-to-assume")); /* NOLINT(whitespace/line_length) */ \
+  options.set_option("retain-trivial", cmdline.isset("retain-trivial")); /* NOLINT(whitespace/line_length) */ \
+  if(cmdline.isset("error-label")) \
+    options.set_option("error-label", cmdline.get_values("error-label")); \
   (void)0
 // clang-format on
 

--- a/src/cbmc/cbmc_parse_options.cpp
+++ b/src/cbmc/cbmc_parse_options.cpp
@@ -957,6 +957,12 @@ bool cbmc_parse_optionst::process_goto_program(
   // checks don't know about adjusted float expressions
   adjust_float_expressions(goto_model);
 
+  if(options.get_bool_option("string-abstraction"))
+  {
+    log.status() << "String Abstraction" << messaget::eom;
+    string_abstraction(goto_model, log.get_message_handler());
+  }
+
   // ignore default/user-specified initialization
   // of variables with static lifetime
   if(options.get_bool_option("nondet-static"))
@@ -965,12 +971,6 @@ bool cbmc_parse_optionst::process_goto_program(
                     "of static/global variables"
                  << messaget::eom;
     nondet_static(goto_model);
-  }
-
-  if(options.get_bool_option("string-abstraction"))
-  {
-    log.status() << "String Abstraction" << messaget::eom;
-    string_abstraction(goto_model, log.get_message_handler());
   }
 
   // add failed symbols

--- a/src/cbmc/cbmc_parse_options.cpp
+++ b/src/cbmc/cbmc_parse_options.cpp
@@ -50,6 +50,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <goto-programs/add_malloc_may_fail_variable_initializations.h>
 #include <goto-programs/adjust_float_expressions.h>
+#include <goto-programs/goto_inline.h>
 #include <goto-programs/initialize_goto_model.h>
 #include <goto-programs/instrument_preconditions.h>
 #include <goto-programs/link_to_library.h>
@@ -945,6 +946,13 @@ bool cbmc_parse_optionst::process_goto_program(
 
   // instrument library preconditions
   instrument_preconditions(goto_model);
+
+  // do partial inlining
+  if(options.get_bool_option("partial-inline"))
+  {
+    log.status() << "Partial Inlining" << messaget::eom;
+    goto_partial_inline(goto_model, log.get_message_handler());
+  }
 
   // remove returns, gcc vectors, complex
   remove_returns(goto_model);

--- a/src/cbmc/cbmc_parse_options.cpp
+++ b/src/cbmc/cbmc_parse_options.cpp
@@ -531,6 +531,9 @@ void cbmc_parse_optionst::get_command_line_options(optionst &options)
     options.set_option("show-points-to-sets", true);
 
   PARSE_OPTIONS_GOTO_TRACE(cmdline, options);
+
+  // Options for process_goto_program
+  options.set_option("rewrite-union", true);
 }
 
 /// invoke main modules
@@ -958,7 +961,8 @@ bool cbmc_parse_optionst::process_goto_program(
   remove_returns(goto_model);
   remove_vector(goto_model);
   remove_complex(goto_model);
-  rewrite_union(goto_model);
+  if(options.get_bool_option("rewrite-union"))
+    rewrite_union(goto_model);
 
   // add generic checks
   log.status() << "Generic Property Instrumentation" << messaget::eom;

--- a/src/cbmc/cbmc_parse_options.cpp
+++ b/src/cbmc/cbmc_parse_options.cpp
@@ -963,6 +963,12 @@ bool cbmc_parse_optionst::process_goto_program(
     string_abstraction(goto_model, log.get_message_handler());
   }
 
+  // recalculate numbers, etc.
+  goto_model.goto_functions.update();
+
+  // add loop ids
+  goto_model.goto_functions.compute_loop_numbers();
+
   // ignore default/user-specified initialization
   // of variables with static lifetime
   if(options.get_bool_option("nondet-static"))
@@ -976,12 +982,6 @@ bool cbmc_parse_optionst::process_goto_program(
   // add failed symbols
   // needs to be done before pointer analysis
   add_failed_symbols(goto_model.symbol_table);
-
-  // recalculate numbers, etc.
-  goto_model.goto_functions.update();
-
-  // add loop ids
-  goto_model.goto_functions.compute_loop_numbers();
 
   if(options.get_bool_option("drop-unused-functions"))
   {

--- a/src/cbmc/cbmc_parse_options.cpp
+++ b/src/cbmc/cbmc_parse_options.cpp
@@ -114,8 +114,6 @@ cbmc_parse_optionst::cbmc_parse_optionst(int argc, const char **argv)
 void cbmc_parse_optionst::set_default_options(optionst &options)
 {
   // Default true
-  options.set_option("assertions", true);
-  options.set_option("assumptions", true);
   options.set_option("built-in-assertions", true);
   options.set_option("pretty-names", true);
   options.set_option("propagation", true);
@@ -312,18 +310,6 @@ void cbmc_parse_optionst::get_command_line_options(optionst &options)
 
   // all checks supported by goto_check
   PARSE_OPTIONS_GOTO_CHECK(cmdline, options);
-
-  // check assertions
-  if(cmdline.isset("no-assertions"))
-    options.set_option("assertions", false);
-
-  // use assumptions
-  if(cmdline.isset("no-assumptions"))
-    options.set_option("assumptions", false);
-
-  // magic error label
-  if(cmdline.isset("error-label"))
-    options.set_option("error-label", cmdline.get_values("error-label"));
 
   // generate unwinding assertions
   if(cmdline.isset("unwinding-assertions"))
@@ -1135,9 +1121,6 @@ void cbmc_parse_optionst::help()
     "\n"
     "Program instrumentation options:\n"
     HELP_GOTO_CHECK
-    " --no-assertions              ignore user assertions\n"
-    " --no-assumptions             ignore user assumptions\n"
-    " --error-label label          check that label is unreachable\n"
     HELP_COVER
     " --mm MM                      memory consistency model for concurrent programs\n" // NOLINT(*)
     // NOLINTNEXTLINE(whitespace/line_length)

--- a/src/cbmc/cbmc_parse_options.cpp
+++ b/src/cbmc/cbmc_parse_options.cpp
@@ -55,6 +55,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <goto-programs/link_to_library.h>
 #include <goto-programs/loop_ids.h>
 #include <goto-programs/mm_io.h>
+#include <goto-programs/process_goto_program.h>
 #include <goto-programs/read_goto_binary.h>
 #include <goto-programs/remove_complex.h>
 #include <goto-programs/remove_function_pointers.h>
@@ -912,6 +913,9 @@ bool cbmc_parse_optionst::process_goto_program(
   const optionst &options,
   messaget &log)
 {
+  // Common removal of types and complex constructs
+  ::process_goto_program(goto_model, options, log);
+
   // Remove inline assembler; this needs to happen before
   // adding the library.
   remove_asm(goto_model);

--- a/src/cbmc/cbmc_parse_options.h
+++ b/src/cbmc/cbmc_parse_options.h
@@ -53,7 +53,6 @@ class optionst;
   "D:I:(c89)(c99)(c11)(cpp98)(cpp03)(cpp11)" \
   "(object-bits):" \
   OPT_GOTO_CHECK \
-  "(no-assertions)(no-assumptions)" \
   "(malloc-fail-assert)(malloc-fail-null)" \
   "(malloc-may-fail)" \
   OPT_XML_INTERFACE \
@@ -73,7 +72,7 @@ class optionst;
   "(drop-unused-functions)" \
   "(havoc-undefined-functions)" \
   "(property):(stop-on-fail)(trace)" \
-  "(error-label):(verbosity):(no-library)" \
+  "(verbosity):(no-library)" \
   "(nondet-static)" \
   "(version)" \
   OPT_COVER \

--- a/src/goto-analyzer/goto_analyzer_parse_options.cpp
+++ b/src/goto-analyzer/goto_analyzer_parse_options.cpp
@@ -913,6 +913,12 @@ bool goto_analyzer_parse_optionst::process_goto_program(
     // checks don't know about adjusted float expressions
     adjust_float_expressions(goto_model);
 
+    if(options.get_bool_option("string-abstraction"))
+    {
+      log.status() << "String Abstraction" << messaget::eom;
+      string_abstraction(goto_model, log.get_message_handler());
+    }
+
     // recalculate numbers, etc.
     goto_model.goto_functions.update();
 

--- a/src/goto-analyzer/goto_analyzer_parse_options.cpp
+++ b/src/goto-analyzer/goto_analyzer_parse_options.cpp
@@ -147,6 +147,9 @@ void goto_analyzer_parse_optionst::get_command_line_options(optionst &options)
     options.set_option("error-label", cmdline.get_values("error-label"));
 #endif
 
+  // all checks supported by goto_check
+  PARSE_OPTIONS_GOTO_CHECK(cmdline, options);
+
   // The user should either select:
   //  1. a specific analysis, or
   //  2. a tuple of task / analyser options / outputs
@@ -894,7 +897,7 @@ bool goto_analyzer_parse_optionst::process_goto_program(
     log.status() << "Removing function pointers and virtual functions"
                  << messaget::eom;
     remove_function_pointers(
-      ui_message_handler, goto_model, cmdline.isset("pointer-check"));
+      ui_message_handler, goto_model, options.get_bool_option("pointer-check"));
 
     // instrument library preconditions
     instrument_preconditions(goto_model);

--- a/src/goto-analyzer/goto_analyzer_parse_options.cpp
+++ b/src/goto-analyzer/goto_analyzer_parse_options.cpp
@@ -882,7 +882,7 @@ bool goto_analyzer_parse_optionst::process_goto_program(
       string_instrumentation(goto_model);
 
     // remove function pointers
-    log.status() << "Removing function pointers and virtual functions"
+    log.status() << "Removal of function pointers and virtual functions"
                  << messaget::eom;
     remove_function_pointers(
       ui_message_handler, goto_model, options.get_bool_option("pointer-check"));

--- a/src/goto-analyzer/goto_analyzer_parse_options.cpp
+++ b/src/goto-analyzer/goto_analyzer_parse_options.cpp
@@ -872,11 +872,11 @@ bool goto_analyzer_parse_optionst::process_goto_program(
   ::process_goto_program(goto_model, options, log);
 
   {
-    #if 0
     // Remove inline assembler; this needs to happen before
     // adding the library.
     remove_asm(goto_model);
 
+#if 0
     // add the library
     log.status() << "Adding CPROVER library (" << config.ansi_c.arch << ")" << messaget::eom;
     link_to_library(

--- a/src/goto-analyzer/goto_analyzer_parse_options.cpp
+++ b/src/goto-analyzer/goto_analyzer_parse_options.cpp
@@ -131,24 +131,6 @@ void goto_analyzer_parse_optionst::get_command_line_options(optionst &options)
     config.cpp.set_cpp11();
 #endif
 
-#if 0
-  // check assertions
-  if(cmdline.isset("no-assertions"))
-    options.set_option("assertions", false);
-  else
-    options.set_option("assertions", true);
-
-  // use assumptions
-  if(cmdline.isset("no-assumptions"))
-    options.set_option("assumptions", false);
-  else
-    options.set_option("assumptions", true);
-
-  // magic error label
-  if(cmdline.isset("error-label"))
-    options.set_option("error-label", cmdline.get_values("error-label"));
-#endif
-
   // all checks supported by goto_check
   PARSE_OPTIONS_GOTO_CHECK(cmdline, options);
 

--- a/src/goto-analyzer/goto_analyzer_parse_options.cpp
+++ b/src/goto-analyzer/goto_analyzer_parse_options.cpp
@@ -33,6 +33,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <goto-programs/initialize_goto_model.h>
 #include <goto-programs/instrument_preconditions.h>
 #include <goto-programs/link_to_library.h>
+#include <goto-programs/mm_io.h>
 #include <goto-programs/process_goto_program.h>
 #include <goto-programs/read_goto_binary.h>
 #include <goto-programs/remove_complex.h>
@@ -898,6 +899,8 @@ bool goto_analyzer_parse_optionst::process_goto_program(
                  << messaget::eom;
     remove_function_pointers(
       ui_message_handler, goto_model, options.get_bool_option("pointer-check"));
+
+    mm_io(goto_model);
 
     // instrument library preconditions
     instrument_preconditions(goto_model);

--- a/src/goto-analyzer/goto_analyzer_parse_options.cpp
+++ b/src/goto-analyzer/goto_analyzer_parse_options.cpp
@@ -43,6 +43,8 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <goto-programs/set_properties.h>
 #include <goto-programs/show_properties.h>
 #include <goto-programs/show_symbol_table.h>
+#include <goto-programs/string_abstraction.h>
+#include <goto-programs/string_instrumentation.h>
 #include <goto-programs/validate_goto_model.h>
 
 #include <analyses/call_stack_history.h>
@@ -884,6 +886,9 @@ bool goto_analyzer_parse_optionst::process_goto_program(
     link_to_library(goto_model, ui_message_handler, cprover_c_library_factory);
 
     add_malloc_may_fail_variable_initializations(goto_model);
+
+    if(options.get_bool_option("string-abstraction"))
+      string_instrumentation(goto_model);
 
     // remove function pointers
     log.status() << "Removing function pointers and virtual functions"

--- a/src/goto-analyzer/goto_analyzer_parse_options.cpp
+++ b/src/goto-analyzer/goto_analyzer_parse_options.cpp
@@ -41,6 +41,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <goto-programs/remove_returns.h>
 #include <goto-programs/remove_vector.h>
 #include <goto-programs/remove_virtual_functions.h>
+#include <goto-programs/rewrite_union.h>
 #include <goto-programs/set_properties.h>
 #include <goto-programs/show_properties.h>
 #include <goto-programs/show_symbol_table.h>
@@ -610,6 +611,7 @@ int goto_analyzer_parse_optionst::doit()
 
   // Perserve backwards compatability in processing
   options.set_option("partial-inline", true);
+  options.set_option("rewrite-union", false);
 
   if(process_goto_program(options))
     return CPROVER_EXIT_INTERNAL_ERROR;
@@ -919,6 +921,8 @@ bool goto_analyzer_parse_optionst::process_goto_program(
     remove_returns(goto_model);
     remove_vector(goto_model);
     remove_complex(goto_model);
+    if(options.get_bool_option("rewrite-union"))
+      rewrite_union(goto_model);
 
 #if 0
     // add generic checks

--- a/src/goto-analyzer/goto_analyzer_parse_options.cpp
+++ b/src/goto-analyzer/goto_analyzer_parse_options.cpp
@@ -31,6 +31,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <goto-programs/goto_convert_functions.h>
 #include <goto-programs/goto_inline.h>
 #include <goto-programs/initialize_goto_model.h>
+#include <goto-programs/instrument_preconditions.h>
 #include <goto-programs/link_to_library.h>
 #include <goto-programs/process_goto_program.h>
 #include <goto-programs/read_goto_binary.h>
@@ -876,24 +877,22 @@ bool goto_analyzer_parse_optionst::process_goto_program(
     // adding the library.
     remove_asm(goto_model);
 
-#if 0
     // add the library
     log.status() << "Adding CPROVER library (" << config.ansi_c.arch << ")" << messaget::eom;
     link_to_library(
       goto_model, ui_message_handler, cprover_cpp_library_factory);
     link_to_library(goto_model, ui_message_handler, cprover_c_library_factory);
 
-    // these are commented out as well because without the library
-    // this initialization code doesn’t make any sense
     add_malloc_may_fail_variable_initializations(goto_model);
-
-#endif
 
     // remove function pointers
     log.status() << "Removing function pointers and virtual functions"
                  << messaget::eom;
     remove_function_pointers(
       ui_message_handler, goto_model, cmdline.isset("pointer-check"));
+
+    // instrument library preconditions
+    instrument_preconditions(goto_model);
 
     // do partial inlining
     log.status() << "Partial Inlining" << messaget::eom;

--- a/src/goto-analyzer/goto_analyzer_parse_options.cpp
+++ b/src/goto-analyzer/goto_analyzer_parse_options.cpp
@@ -32,6 +32,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <goto-programs/goto_inline.h>
 #include <goto-programs/initialize_goto_model.h>
 #include <goto-programs/link_to_library.h>
+#include <goto-programs/process_goto_program.h>
 #include <goto-programs/read_goto_binary.h>
 #include <goto-programs/remove_complex.h>
 #include <goto-programs/remove_function_pointers.h>
@@ -867,6 +868,9 @@ int goto_analyzer_parse_optionst::perform_analysis(const optionst &options)
 bool goto_analyzer_parse_optionst::process_goto_program(
   const optionst &options)
 {
+  // Common removal of types and complex constructs
+  ::process_goto_program(goto_model, options, log);
+
   {
     #if 0
     // Remove inline assembler; this needs to happen before

--- a/src/goto-analyzer/goto_analyzer_parse_options.cpp
+++ b/src/goto-analyzer/goto_analyzer_parse_options.cpp
@@ -906,13 +906,9 @@ bool goto_analyzer_parse_optionst::process_goto_program(
     if(options.get_bool_option("rewrite-union"))
       rewrite_union(goto_model);
 
-#if 0
     // add generic checks
     log.status() << "Generic Property Instrumentation" << messaget::eom;
     goto_check(options, goto_model);
-#else
-    (void)options; // unused parameter
-#endif
 
     // recalculate numbers, etc.
     goto_model.goto_functions.update();

--- a/src/goto-analyzer/goto_analyzer_parse_options.cpp
+++ b/src/goto-analyzer/goto_analyzer_parse_options.cpp
@@ -608,6 +608,9 @@ int goto_analyzer_parse_optionst::doit()
 
   goto_model = initialize_goto_model(cmdline.args, ui_message_handler, options);
 
+  // Perserve backwards compatability in processing
+  options.set_option("partial-inline", true);
+
   if(process_goto_program(options))
     return CPROVER_EXIT_INTERNAL_ERROR;
 
@@ -906,8 +909,11 @@ bool goto_analyzer_parse_optionst::process_goto_program(
     instrument_preconditions(goto_model);
 
     // do partial inlining
-    log.status() << "Partial Inlining" << messaget::eom;
-    goto_partial_inline(goto_model, ui_message_handler);
+    if(options.get_bool_option("partial-inline"))
+    {
+      log.status() << "Partial Inlining" << messaget::eom;
+      goto_partial_inline(goto_model, ui_message_handler);
+    }
 
     // remove returns, gcc vectors, complex
     remove_returns(goto_model);

--- a/src/goto-analyzer/goto_analyzer_parse_options.cpp
+++ b/src/goto-analyzer/goto_analyzer_parse_options.cpp
@@ -581,7 +581,7 @@ int goto_analyzer_parse_optionst::doit()
 
   goto_model = initialize_goto_model(cmdline.args, ui_message_handler, options);
 
-  // Perserve backwards compatability in processing
+  // Preserve backwards compatibility in processing
   options.set_option("partial-inline", true);
   options.set_option("rewrite-union", false);
 

--- a/src/goto-analyzer/goto_analyzer_parse_options.cpp
+++ b/src/goto-analyzer/goto_analyzer_parse_options.cpp
@@ -910,6 +910,9 @@ bool goto_analyzer_parse_optionst::process_goto_program(
     log.status() << "Generic Property Instrumentation" << messaget::eom;
     goto_check(options, goto_model);
 
+    // checks don't know about adjusted float expressions
+    adjust_float_expressions(goto_model);
+
     // recalculate numbers, etc.
     goto_model.goto_functions.update();
 

--- a/src/goto-diff/goto_diff_parse_options.cpp
+++ b/src/goto-diff/goto_diff_parse_options.cpp
@@ -24,6 +24,7 @@ Author: Peter Schrammel
 
 #include <langapi/language.h>
 
+#include <goto-programs/add_malloc_may_fail_variable_initializations.h>
 #include <goto-programs/adjust_float_expressions.h>
 #include <goto-programs/goto_convert_functions.h>
 #include <goto-programs/goto_inline.h>
@@ -329,6 +330,8 @@ bool goto_diff_parse_optionst::process_goto_program(
     link_to_library(
       goto_model, ui_message_handler, cprover_cpp_library_factory);
     link_to_library(goto_model, ui_message_handler, cprover_c_library_factory);
+
+    add_malloc_may_fail_variable_initializations(goto_model);
 
     // remove function pointers
     log.status() << "Removal of function pointers and virtual functions"

--- a/src/goto-diff/goto_diff_parse_options.cpp
+++ b/src/goto-diff/goto_diff_parse_options.cpp
@@ -310,6 +310,12 @@ bool goto_diff_parse_optionst::process_goto_program(
     // checks don't know about adjusted float expressions
     adjust_float_expressions(goto_model);
 
+    if(options.get_bool_option("string-abstraction"))
+    {
+      log.status() << "String Abstraction" << messaget::eom;
+      string_abstraction(goto_model, log.get_message_handler());
+    }
+
     // recalculate numbers, etc.
     goto_model.goto_functions.update();
 

--- a/src/goto-diff/goto_diff_parse_options.cpp
+++ b/src/goto-diff/goto_diff_parse_options.cpp
@@ -169,6 +169,9 @@ void goto_diff_parse_optionst::get_command_line_options(optionst &options)
   }
 
   options.set_option("show-properties", cmdline.isset("show-properties"));
+
+  // Options for process_goto_program
+  options.set_option("rewrite-union", true);
 }
 
 /// invoke main modules
@@ -313,7 +316,8 @@ bool goto_diff_parse_optionst::process_goto_program(
     remove_returns(goto_model);
     remove_vector(goto_model);
     remove_complex(goto_model);
-    rewrite_union(goto_model);
+    if(options.get_bool_option("rewrite-union"))
+      rewrite_union(goto_model);
 
     // add generic checks
     log.status() << "Generic Property Instrumentation" << messaget::eom;

--- a/src/goto-diff/goto_diff_parse_options.cpp
+++ b/src/goto-diff/goto_diff_parse_options.cpp
@@ -133,22 +133,6 @@ void goto_diff_parse_optionst::get_command_line_options(optionst &options)
   // all checks supported by goto_check
   PARSE_OPTIONS_GOTO_CHECK(cmdline, options);
 
-  // check assertions
-  if(cmdline.isset("no-assertions"))
-    options.set_option("assertions", false);
-  else
-    options.set_option("assertions", true);
-
-  // use assumptions
-  if(cmdline.isset("no-assumptions"))
-    options.set_option("assumptions", false);
-  else
-    options.set_option("assumptions", true);
-
-  // magic error label
-  if(cmdline.isset("error-label"))
-    options.set_option("error-label", cmdline.get_values("error-label"));
-
   // generate unwinding assertions
   if(cmdline.isset("cover"))
     options.set_option("unwinding-assertions", false);

--- a/src/goto-diff/goto_diff_parse_options.cpp
+++ b/src/goto-diff/goto_diff_parse_options.cpp
@@ -32,6 +32,7 @@ Author: Peter Schrammel
 #include <goto-programs/link_to_library.h>
 #include <goto-programs/loop_ids.h>
 #include <goto-programs/mm_io.h>
+#include <goto-programs/process_goto_program.h>
 #include <goto-programs/read_goto_binary.h>
 #include <goto-programs/remove_complex.h>
 #include <goto-programs/remove_function_pointers.h>
@@ -314,6 +315,9 @@ bool goto_diff_parse_optionst::process_goto_program(
   const optionst &options,
   goto_modelt &goto_model)
 {
+  // Common removal of types and complex constructs
+  ::process_goto_program(goto_model, options, log);
+
   {
     // Remove inline assembler; this needs to happen before
     // adding the library.

--- a/src/goto-diff/goto_diff_parse_options.cpp
+++ b/src/goto-diff/goto_diff_parse_options.cpp
@@ -340,7 +340,7 @@ bool goto_diff_parse_optionst::process_goto_program(
     log.status() << "Removal of function pointers and virtual functions"
                  << messaget::eom;
     remove_function_pointers(
-      ui_message_handler, goto_model, cmdline.isset("pointer-check"));
+      ui_message_handler, goto_model, options.get_bool_option("pointer-check"));
 
     mm_io(goto_model);
 

--- a/src/goto-diff/goto_diff_parse_options.cpp
+++ b/src/goto-diff/goto_diff_parse_options.cpp
@@ -333,6 +333,9 @@ bool goto_diff_parse_optionst::process_goto_program(
 
     add_malloc_may_fail_variable_initializations(goto_model);
 
+    if(options.get_bool_option("string-abstraction"))
+      string_instrumentation(goto_model);
+
     // remove function pointers
     log.status() << "Removal of function pointers and virtual functions"
                  << messaget::eom;

--- a/src/goto-diff/goto_diff_parse_options.cpp
+++ b/src/goto-diff/goto_diff_parse_options.cpp
@@ -130,53 +130,8 @@ void goto_diff_parse_optionst::get_command_line_options(optionst &options)
   else
     options.set_option("propagation", true);
 
-  // check array bounds
-  if(cmdline.isset("bounds-check"))
-    options.set_option("bounds-check", true);
-  else
-    options.set_option("bounds-check", false);
-
-  // check division by zero
-  if(cmdline.isset("div-by-zero-check"))
-    options.set_option("div-by-zero-check", true);
-  else
-    options.set_option("div-by-zero-check", false);
-
-  // check overflow/underflow
-  if(cmdline.isset("signed-overflow-check"))
-    options.set_option("signed-overflow-check", true);
-  else
-    options.set_option("signed-overflow-check", false);
-
-  // check overflow/underflow
-  if(cmdline.isset("unsigned-overflow-check"))
-    options.set_option("unsigned-overflow-check", true);
-  else
-    options.set_option("unsigned-overflow-check", false);
-
-  // check overflow/underflow
-  if(cmdline.isset("float-overflow-check"))
-    options.set_option("float-overflow-check", true);
-  else
-    options.set_option("float-overflow-check", false);
-
-  // check for NaN (not a number)
-  if(cmdline.isset("nan-check"))
-    options.set_option("nan-check", true);
-  else
-    options.set_option("nan-check", false);
-
-  // check pointers
-  if(cmdline.isset("pointer-check"))
-    options.set_option("pointer-check", true);
-  else
-    options.set_option("pointer-check", false);
-
-  // check for memory leaks
-  if(cmdline.isset("memory-leak-check"))
-    options.set_option("memory-leak-check", true);
-  else
-    options.set_option("memory-leak-check", false);
+  // all checks supported by goto_check
+  PARSE_OPTIONS_GOTO_CHECK(cmdline, options);
 
   // check assertions
   if(cmdline.isset("no-assertions"))

--- a/src/goto-diff/goto_diff_parse_options.cpp
+++ b/src/goto-diff/goto_diff_parse_options.cpp
@@ -302,6 +302,13 @@ bool goto_diff_parse_optionst::process_goto_program(
     // instrument library preconditions
     instrument_preconditions(goto_model);
 
+    // do partial inlining
+    if(options.get_bool_option("partial-inline"))
+    {
+      log.status() << "Partial Inlining" << messaget::eom;
+      goto_partial_inline(goto_model, ui_message_handler);
+    }
+
     // remove returns, gcc vectors, complex
     remove_returns(goto_model);
     remove_vector(goto_model);

--- a/src/goto-instrument/goto_instrument_parse_options.cpp
+++ b/src/goto-instrument/goto_instrument_parse_options.cpp
@@ -1010,30 +1010,8 @@ void goto_instrument_parse_optionst::instrument_goto_program()
   else
     options.set_option("simplify", true);
 
-  // use assumptions instead of assertions?
-  if(cmdline.isset("assert-to-assume"))
-    options.set_option("assert-to-assume", true);
-  else
-    options.set_option("assert-to-assume", false);
-
   // all checks supported by goto_check
   PARSE_OPTIONS_GOTO_CHECK(cmdline, options);
-
-  // check assertions
-  if(cmdline.isset("no-assertions"))
-    options.set_option("assertions", false);
-  else
-    options.set_option("assertions", true);
-
-  // use assumptions
-  if(cmdline.isset("no-assumptions"))
-    options.set_option("assumptions", false);
-  else
-    options.set_option("assumptions", true);
-
-  // magic error label
-  if(cmdline.isset("error-label"))
-    options.set_option("error-label", cmdline.get_value("error-label"));
 
   // unwind loops
   if(cmdline.isset("unwind"))
@@ -1806,7 +1784,6 @@ void goto_instrument_parse_optionst::help()
     " --no-assertions              ignore user assertions\n"
     HELP_GOTO_CHECK
     " --uninitialized-check        add checks for uninitialized locals (experimental)\n" // NOLINT(*)
-    " --error-label label          check that label is unreachable\n"
     " --stack-depth n              add check that call stack size of non-inlined functions never exceeds n\n" // NOLINT(*)
     " --race-check                 add floating-point data race checks\n"
     "\n"

--- a/src/goto-instrument/goto_instrument_parse_options.h
+++ b/src/goto-instrument/goto_instrument_parse_options.h
@@ -52,8 +52,7 @@ Author: Daniel Kroening, kroening@kroening.com
   "(no-nan-check)" \
   "(remove-pointers)" \
   "(no-simplify)" \
-  "(assert-to-assume)" \
-  "(no-assertions)(no-assumptions)(uninitialized-check)" \
+  "(uninitialized-check)" \
   "(race-check)(scc)(one-event-per-cycle)" \
   "(minimum-interference)" \
   "(mm):(my-events)" \
@@ -92,7 +91,7 @@ Author: Daniel Kroening, kroening@kroening.com
   "(cav11)" \
   OPT_TIMESTAMP \
   "(show-natural-loops)(show-lexical-loops)(accelerate)(havoc-loops)" \
-  "(error-label):(string-abstraction)" \
+  "(string-abstraction)" \
   "(verbosity):(version)(xml-ui)(json-ui)(show-loops)" \
   "(accelerate)(constant-propagator)" \
   "(k-induction):(step-case)(base-case)" \

--- a/src/goto-programs/Makefile
+++ b/src/goto-programs/Makefile
@@ -39,6 +39,7 @@ SRC = add_malloc_may_fail_variable_initializations.cpp \
       parameter_assignments.cpp \
       pointer_arithmetic.cpp \
       printf_formatter.cpp \
+      process_goto_program.cpp \
       read_bin_goto_object.cpp \
       read_goto_binary.cpp \
       rebuild_goto_start_function.cpp \

--- a/src/goto-programs/process_goto_program.cpp
+++ b/src/goto-programs/process_goto_program.cpp
@@ -1,0 +1,25 @@
+/*******************************************************************\
+
+Module: Process a Goto Program
+
+Author: Martin Brain, martin.brain@cs.ox.ac.uk
+
+\*******************************************************************/
+
+/// \file
+/// Get a Goto Program
+
+#include "process_goto_program.h"
+
+#include <goto-programs/goto_model.h>
+
+#include <util/message.h>
+#include <util/options.h>
+
+bool process_goto_program(
+  goto_modelt &goto_model,
+  const optionst &options,
+  messaget &log)
+{
+  return false;
+}

--- a/src/goto-programs/process_goto_program.cpp
+++ b/src/goto-programs/process_goto_program.cpp
@@ -11,7 +11,20 @@ Author: Martin Brain, martin.brain@cs.ox.ac.uk
 
 #include "process_goto_program.h"
 
+#include <analyses/goto_check.h>
+
+#include <goto-programs/adjust_float_expressions.h>
+#include <goto-programs/goto_inline.h>
 #include <goto-programs/goto_model.h>
+#include <goto-programs/instrument_preconditions.h>
+#include <goto-programs/mm_io.h>
+#include <goto-programs/remove_complex.h>
+#include <goto-programs/remove_function_pointers.h>
+#include <goto-programs/remove_returns.h>
+#include <goto-programs/remove_vector.h>
+#include <goto-programs/rewrite_union.h>
+#include <goto-programs/string_abstraction.h>
+#include <goto-programs/string_instrumentation.h>
 
 #include <util/message.h>
 #include <util/options.h>
@@ -21,5 +34,54 @@ bool process_goto_program(
   const optionst &options,
   messaget &log)
 {
+  if(options.get_bool_option("string-abstraction"))
+    string_instrumentation(goto_model);
+
+  // remove function pointers
+  log.status() << "Removal of function pointers and virtual functions"
+               << messaget::eom;
+  remove_function_pointers(
+    log.get_message_handler(),
+    goto_model,
+    options.get_bool_option("pointer-check"));
+
+  mm_io(goto_model);
+
+  // instrument library preconditions
+  instrument_preconditions(goto_model);
+
+  // do partial inlining
+  if(options.get_bool_option("partial-inline"))
+  {
+    log.status() << "Partial Inlining" << messaget::eom;
+    goto_partial_inline(goto_model, log.get_message_handler());
+  }
+
+  // remove returns, gcc vectors, complex
+  remove_returns(goto_model);
+  remove_vector(goto_model);
+  remove_complex(goto_model);
+  if(options.get_bool_option("rewrite-union"))
+    rewrite_union(goto_model);
+
+  // add generic checks
+  log.status() << "Generic Property Instrumentation" << messaget::eom;
+  goto_check(options, goto_model);
+
+  // checks don't know about adjusted float expressions
+  adjust_float_expressions(goto_model);
+
+  if(options.get_bool_option("string-abstraction"))
+  {
+    log.status() << "String Abstraction" << messaget::eom;
+    string_abstraction(goto_model, log.get_message_handler());
+  }
+
+  // recalculate numbers, etc.
+  goto_model.goto_functions.update();
+
+  // add loop ids
+  goto_model.goto_functions.compute_loop_numbers();
+
   return false;
 }

--- a/src/goto-programs/process_goto_program.h
+++ b/src/goto-programs/process_goto_program.h
@@ -1,0 +1,27 @@
+/*******************************************************************\
+
+Module: Process a Goto Program
+
+Author: Martin Brain, martin.brain@cs.ox.ac.uk
+
+\*******************************************************************/
+
+#ifndef CPROVER_GOTO_PROGRAMS_PROCESS_GOTO_PROGRAM_H
+#define CPROVER_GOTO_PROGRAMS_PROCESS_GOTO_PROGRAM_H
+
+class goto_modelt;
+class optionst;
+class messaget;
+
+/// Common processing and simplification of goto_programts.
+/// This includes removing a number of more complex types
+/// (vectors, complex, etc.) and constructs
+/// (returns, function pointers, etc.).
+/// This is can be used after initialize_goto_model but before
+/// analysis.  It is not mandatory but is used by most tools.
+bool process_goto_program(
+  goto_modelt &goto_model,
+  const optionst &options,
+  messaget &log);
+
+#endif // CPROVER_GOTO_PROGRAMS_PROCESS_GOTO_PROGRAM_H

--- a/unit/path_strategies.cpp
+++ b/unit/path_strategies.cpp
@@ -384,6 +384,8 @@ void _check_with_strategy(
 
   optionst options;
   cbmc_parse_optionst::set_default_options(options);
+  options.set_option("assertions", true);
+  options.set_option("assumptions", true);
   options.set_option("paths", true);
   options.set_option("exploration-strategy", strategy);
   REQUIRE(is_valid_path_strategy(strategy));


### PR DESCRIPTION
`*_parse_optionst::process_goto_program` appears in `cbmc`, `goto-analyze` and `goto-diff` (and maybe the Java tools, @peterschrammel @hannes-steffenhagen-diffblue who is handling these at the moment?) with slight variations, bugs, inconsistencies and omissions.  This PR carefully makes them the same (so that we can `git-bisect` to find any issues this might introduce) and then pulls the common code out into a helper function.  This is another step towards a common format for goto-programs and stronger invariants.

This does not break tested functionality but it will have an impact on untested functionality.  Mostly, as far as I can see, it goes from 'silently doing the wrong thing' to 'maybe works, maybe breaks in an obvious way'.  i consider this a net win.