### PR TITLE
Fix type checking of vector expressions

### DIFF
--- a/regression/cbmc/gcc_vector1/main.c
+++ b/regression/cbmc/gcc_vector1/main.c
@@ -47,6 +47,13 @@ int main()
   assert(z.members[2]==~x.members[2]);
   assert(z.members[3]==~x.members[3]);
 
+  z = x;
+  z.v <<= (v4si){1, 2, 3, 4};
+  assert(z.members[0] == (x.members[0] << 1));
+  assert(z.members[1] == (x.members[1] << 2));
+  assert(z.members[2] == (x.members[2] << 3));
+  assert(z.members[3] == (x.members[3] << 4));
+
   // vector operator scalar
   z=x;
   z.v=z.v+1;
@@ -54,6 +61,41 @@ int main()
   assert(z.members[1]==x.members[1]+1);
   assert(z.members[2]==x.members[2]+1);
   assert(z.members[3]==x.members[3]+1);
+
+  z = x;
+  z.v += 1;
+  assert(z.members[0] == x.members[0] + 1);
+  assert(z.members[1] == x.members[1] + 1);
+  assert(z.members[2] == x.members[2] + 1);
+  assert(z.members[3] == x.members[3] + 1);
+
+  z = x;
+  z.v = z.v & 1;
+  assert(z.members[0] == (x.members[0] & 1));
+  assert(z.members[1] == (x.members[1] & 1));
+  assert(z.members[2] == (x.members[2] & 1));
+  assert(z.members[3] == (x.members[3] & 1));
+
+  z = x;
+  z.v &= 1;
+  assert(z.members[0] == (x.members[0] & 1));
+  assert(z.members[1] == (x.members[1] & 1));
+  assert(z.members[2] == (x.members[2] & 1));
+  assert(z.members[3] == (x.members[3] & 1));
+
+  z = x;
+  z.v = z.v << 2;
+  assert(z.members[0] == (x.members[0] << 2));
+  assert(z.members[1] == (x.members[1] << 2));
+  assert(z.members[2] == (x.members[2] << 2));
+  assert(z.members[3] == (x.members[3] << 2));
+
+  z = x;
+  z.v <<= 2;
+  assert(z.members[0] == (x.members[0] << 2));
+  assert(z.members[1] == (x.members[1] << 2));
+  assert(z.members[2] == (x.members[2] << 2));
+  assert(z.members[3] == (x.members[3] << 2));
 
   // unary operators on vectors
   z=x;

--- a/src/goto-programs/remove_vector.cpp
+++ b/src/goto-programs/remove_vector.cpp
@@ -25,11 +25,14 @@ static bool have_to_remove_vector(const exprt &expr)
 {
   if(expr.type().id()==ID_vector)
   {
-    if(expr.id()==ID_plus || expr.id()==ID_minus ||
-       expr.id()==ID_mult || expr.id()==ID_div ||
-       expr.id()==ID_mod  || expr.id()==ID_bitxor ||
-       expr.id()==ID_bitand || expr.id()==ID_bitor)
+    if(
+      expr.id() == ID_plus || expr.id() == ID_minus || expr.id() == ID_mult ||
+      expr.id() == ID_div || expr.id() == ID_mod || expr.id() == ID_bitxor ||
+      expr.id() == ID_bitand || expr.id() == ID_bitor || expr.id() == ID_shl ||
+      expr.id() == ID_lshr || expr.id() == ID_ashr)
+    {
       return true;
+    }
     else if(expr.id()==ID_unary_minus || expr.id()==ID_bitnot)
       return true;
     else if(expr.id()==ID_vector)
@@ -77,10 +80,11 @@ static void remove_vector(exprt &expr)
 
   if(expr.type().id()==ID_vector)
   {
-    if(expr.id()==ID_plus || expr.id()==ID_minus ||
-       expr.id()==ID_mult || expr.id()==ID_div ||
-       expr.id()==ID_mod  || expr.id()==ID_bitxor ||
-       expr.id()==ID_bitand || expr.id()==ID_bitor)
+    if(
+      expr.id() == ID_plus || expr.id() == ID_minus || expr.id() == ID_mult ||
+      expr.id() == ID_div || expr.id() == ID_mod || expr.id() == ID_bitxor ||
+      expr.id() == ID_bitand || expr.id() == ID_bitor || expr.id() == ID_shl ||
+      expr.id() == ID_lshr || expr.id() == ID_ashr)
     {
       // FIXME plus, mult, bitxor, bitand and bitor are defined as n-ary
       //      operations rather than binary. This code assumes that they


### PR DESCRIPTION
Type checking was correctly done only for some assign_* expressions,
mostly lacking support for the case of vectors + scalars.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
