### PR TITLE
Pointer types must not be used with bit-level operators

### DIFF
--- a/regression/ansi-c/invalid_bitop1/main.c
+++ b/regression/ansi-c/invalid_bitop1/main.c
@@ -1,0 +1,8 @@
+int main()
+{
+  int *p;
+  // bitand and shift are correctly rejected by the C front-end
+  // p = p & 0;
+  // p = p << sizeof(int *) * 8;
+  p <<= sizeof(int *) * 8;
+}

--- a/regression/ansi-c/invalid_bitop1/test.desc
+++ b/regression/ansi-c/invalid_bitop1/test.desc
@@ -1,0 +1,11 @@
+CORE test-c++-front-end
+main.c
+
+^EXIT=(64|1)$
+^SIGNAL=0$
+assignment 'assign_shl' not defined for types 'signed int \*' and 'unsigned (long (long )?)?int'
+^CONVERSION ERROR$
+--
+EXIT=0
+--
+This test must not pass as shifts involving pointers should not be permitted.

--- a/src/ansi-c/c_typecheck_expr.cpp
+++ b/src/ansi-c/c_typecheck_expr.cpp
@@ -3605,7 +3605,7 @@ void c_typecheck_baset::typecheck_side_effect_assignment(
     implicit_typecast_arithmetic(op0);
     implicit_typecast_arithmetic(op1);
 
-    if(is_number(op1.type()))
+    if(is_number(op0.type()) && is_number(op1.type()))
     {
       if(statement==ID_assign_shl)
       {

--- a/src/solvers/flattening/bv_pointers.cpp
+++ b/src/solvers/flattening/bv_pointers.cpp
@@ -433,21 +433,6 @@ bvt bv_pointerst::convert_pointer_type(const exprt &expr)
 
     return bv;
   }
-  else if(expr.id()==ID_lshr ||
-          expr.id()==ID_shl)
-  {
-    return SUB::convert_shift(to_shift_expr(expr));
-  }
-  else if(expr.id()==ID_bitand ||
-          expr.id()==ID_bitor ||
-          expr.id()==ID_bitnot)
-  {
-    return convert_bitwise(expr);
-  }
-  else if(expr.id()==ID_concatenation)
-  {
-    return SUB::convert_concatenation(to_concatenation_expr(expr));
-  }
   else if(expr.id()==ID_byte_extract_little_endian ||
           expr.id()==ID_byte_extract_big_endian)
   {


### PR DESCRIPTION
Any such use requires a type cast.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
