### PR TITLE
Byte extract with negative offset must not fail invariant

### DIFF
--- a/regression/cbmc/byte_extract1/main.c
+++ b/regression/cbmc/byte_extract1/main.c
@@ -1,0 +1,11 @@
+#include <assert.h>
+#include <string.h>
+
+int main()
+{
+  int x;
+  int *p = (char *)&x - 2;
+  int y;
+  memcpy(&y, p, sizeof(int));
+  assert(0);
+}

--- a/regression/cbmc/byte_extract1/test.desc
+++ b/regression/cbmc/byte_extract1/test.desc
@@ -1,0 +1,11 @@
+CORE
+main.c
+
+^EXIT=10$
+^SIGNAL=0$
+^VERIFICATION FAILED$
+--
+Invariant check failed
+--
+This example previously failed the invariant "mp_integer should be convertible
+to target integral type".

--- a/src/solvers/flattening/boolbv_byte_extract.cpp
+++ b/src/solvers/flattening/boolbv_byte_extract.cpp
@@ -121,7 +121,7 @@ bvt boolbvt::convert_byte_extract(const byte_extract_exprt &expr)
       if(offset + i < 0 || offset + i >= op_bv.size())
         bv[i]=prop.new_variable();
       else
-        bv[i] = op_bv[numeric_cast_v<std::size_t>(offset) + i];
+        bv[i] = op_bv[numeric_cast_v<std::size_t>(offset + i)];
   }
   else
   {


### PR DESCRIPTION
The code has provisions for handling negative offsets in a byte extract,
but then tried to convert only parts of index to an unsigned number: the
overall index is known to be non-negative in this branch, but the offset
alone may still be negative.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
