### PR TITLE
goto-harness: create goto binary or C output

### DIFF
--- a/doc/architectural/goto-harness.md
+++ b/doc/architectural/goto-harness.md
@@ -20,7 +20,7 @@ $ goto-cc program.c -o program.gb
 # Run goto-harness to produce harness file
 $ goto-harness --harness-type call-function --harness-function-name generated_harness_test_function --function test_function program.gb harness.c
 # Run the checks targetting the generated harness
-$ cbmc --pointer-check harness.c --function generated_harness_test_function
+$ cbmc --pointer-check harness.c program.c --function generated_harness_test_function
 ```
 
 ## Detailed Usage
@@ -32,11 +32,9 @@ without having any information about the program state.
 * The `memory-snapshot` harness, which loads an existing program state (in form
 of a JSON file) and selectively _havoc-ing_ some variables.
 
-**NOTE**: Due to a [bug](https://github.com/diffblue/cbmc/issues/5351), the
-`memory-snapshot` harness is currently inoperable. We are working to fix this.
-
-It is used similarly to how `goto-instrument` is used by modifying an existing
-GOTO binary, as produced by `goto-cc`.
+The harness generator can either produce the harness (i.e., the function
+environment) as C code, or a full GOTO binary. C code is generated when the
+output file name ends in ".c".
 
 ### The function call harness generator
 
@@ -363,12 +361,6 @@ VERIFICATION SUCCESSFUL
 ```
 
 ## The memory snapshot harness
-
-***NOTE:*** The memory snapshot harness is temporarily inoperable because of
-a bug that occured when we changed the implementation of `goto-harness` to
-produce C files instead of `goto` binaries. The bug is being tracked
-[here](https://github.com/diffblue/cbmc/issues/5351). We are sorry for the
-inconvenience, and hope to get it back to working properly soon.
 
 The `function-call` harness is used in situations in which we want to analyze a
 function in an arbitrary environment. If we want to analyze a function starting

--- a/regression/goto-harness/chain.sh
+++ b/regression/goto-harness/chain.sh
@@ -8,13 +8,20 @@ cbmc=$3
 is_windows=$4
 entry_point='generated_entry_function'
 
+shift 4
 name=${*:$#}
 name=${name%.c}
-args=${*:5:$#-5}
 
 input_c_file="${name}.c"
 input_goto_binary="${name}.gb"
-harness_c_file="${name}-harness.c"
+if [[ "$1" == "harness.gb" ]]; then
+  harness_file=$1
+  shift
+else
+  harness_file="${name}-harness.c"
+fi
+
+args=${*:1:$#-1}
 
 
 
@@ -25,16 +32,24 @@ else
   $goto_cc -o "$input_goto_binary" "$input_c_file"
 fi
 
-if [ -e "$harness_c_file" ] ; then
-  rm -f "$harness_c_file"
+if [ -e "$harness_file" ] ; then
+  rm -f "$harness_file"
 fi
 
 # `# some comment` is an inline comment - basically, cause bash to execute an empty command
 $cbmc --show-goto-functions "$input_goto_binary"
-$goto_harness "$input_goto_binary" "$harness_c_file" --harness-function-name $entry_point ${args}
-$cbmc --show-goto-functions "$harness_c_file"
-$cbmc --function $entry_point "$input_c_file" "$harness_c_file" \
+$goto_harness "$input_goto_binary" "$harness_file" --harness-function-name $entry_point ${args}
+$cbmc --show-goto-functions "$harness_file"
+if [[ "${harness_file}" == "harness.gb" ]];then
+  $cbmc --function $entry_point "$harness_file" \
+    --pointer-check `# because we want to see out of bounds errors` \
+    --unwind 11 `# with the way we set up arrays symex can't figure out loop bounds automatically` \
+    --unwinding-assertions `# we want to make sure we don't accidentally pass tests because we didn't unwind enough` \
+    # cbmc args end
+else
+$cbmc --function $entry_point "$input_c_file" "$harness_file" \
   --pointer-check `# because we want to see out of bounds errors` \
   --unwind 11 `# with the way we set up arrays symex can't figure out loop bounds automatically` \
   --unwinding-assertions `# we want to make sure we don't accidentally pass tests because we didn't unwind enough` \
   # cbmc args end
+fi

--- a/regression/goto-harness/havoc-global-int-02/test.desc
+++ b/regression/goto-harness/havoc-global-int-02/test.desc
@@ -1,11 +1,9 @@
-KNOWNBUG
+CORE
 main.c
---harness-type initialise-with-memory-snapshot --memory-snapshot ../load-snapshot-json-snapshots/global-int-x-y-snapshot.json --initial-goto-location main:7 --havoc-variables y
+harness.gb --harness-type initialise-with-memory-snapshot --memory-snapshot ../load-snapshot-json-snapshots/global-int-x-y-snapshot.json --initial-goto-location main:7 --havoc-variables y
 ^\[main.assertion.1\] line \d+ assertion y \+ 2 > y: FAILURE$
 ^\[main.assertion.2\] line \d+ assertion 0: FAILURE$
 ^EXIT=10$
 ^SIGNAL=0$
 --
 ^warning: ignoring
---
-More information can be found in github#5351.

--- a/regression/goto-harness/havoc-global-int-03/test.desc
+++ b/regression/goto-harness/havoc-global-int-03/test.desc
@@ -1,6 +1,6 @@
-KNOWNBUG
+CORE
 main.c
---harness-type initialise-with-memory-snapshot --memory-snapshot ../load-snapshot-json-snapshots/global-int-x-1-snapshot.json --initial-source-location main.c:6 --havoc-variables x
+harness.gb --harness-type initialise-with-memory-snapshot --memory-snapshot ../load-snapshot-json-snapshots/global-int-x-1-snapshot.json --initial-source-location main.c:6 --havoc-variables x
 ^EXIT=10$
 ^SIGNAL=0$
 \[main.assertion.1\] line [0-9]+ assertion x == 1: SUCCESS
@@ -8,5 +8,3 @@ main.c
 \[main.assertion.3\] line [0-9]+ assertion x == 3: FAILURE
 --
 ^warning: ignoring
---
-More information can be found in github#5351.

--- a/regression/goto-harness/havoc-global-struct/test.desc
+++ b/regression/goto-harness/havoc-global-struct/test.desc
@@ -1,6 +1,6 @@
-KNOWNBUG
+CORE
 main.c
---harness-type initialise-with-memory-snapshot --memory-snapshot ../load-snapshot-json-snapshots/global-struct-snapshot.json --initial-goto-location main:3 --havoc-variables simple
+harness.gb --harness-type initialise-with-memory-snapshot --memory-snapshot ../load-snapshot-json-snapshots/global-struct-snapshot.json --initial-goto-location main:3 --havoc-variables simple
 ^EXIT=10$
 ^SIGNAL=0$
 ^\[main.assertion.1\] line \d+ assertion simple.j > simple.i: FAILURE$

--- a/regression/goto-harness/load-snapshot-recursive-static-global-int-01/test.desc
+++ b/regression/goto-harness/load-snapshot-recursive-static-global-int-01/test.desc
@@ -1,6 +1,6 @@
-KNOWNBUG
+CORE
 main.c
---harness-type initialise-with-memory-snapshot --memory-snapshot ../load-snapshot-json-snapshots/global-int-x-1-snapshot.json --initial-goto-location main:1
+harness.gb --harness-type initialise-with-memory-snapshot --memory-snapshot ../load-snapshot-json-snapshots/global-int-x-1-snapshot.json --initial-goto-location main:1
 ^EXIT=0$
 ^SIGNAL=0$
 VERIFICATION SUCCESSFUL

--- a/regression/goto-harness/load-snapshot-static-global-array-01/test.desc
+++ b/regression/goto-harness/load-snapshot-static-global-array-01/test.desc
@@ -1,6 +1,6 @@
-KNOWNBUG
+CORE
 main.c
---harness-type initialise-with-memory-snapshot --memory-snapshot snapshot.json --initial-goto-location main:0
+harness.gb --harness-type initialise-with-memory-snapshot --memory-snapshot snapshot.json --initial-goto-location main:0
 ^EXIT=0$
 ^SIGNAL=0$
 VERIFICATION SUCCESSFUL

--- a/regression/goto-harness/load-snapshot-static-global-int-01/test.desc
+++ b/regression/goto-harness/load-snapshot-static-global-int-01/test.desc
@@ -1,10 +1,8 @@
-KNOWNBUG
+CORE
 main.c
---harness-type initialise-with-memory-snapshot --memory-snapshot ../load-snapshot-json-snapshots/global-int-x-1-snapshot.json --initial-goto-location main:0
+harness.gb --harness-type initialise-with-memory-snapshot --memory-snapshot ../load-snapshot-json-snapshots/global-int-x-1-snapshot.json --initial-goto-location main:0
 ^EXIT=0$
 ^SIGNAL=0$
 VERIFICATION SUCCESSFUL
 --
 ^warning: ignoring
---
-More information can be found in github#5351.

--- a/regression/goto-harness/load-snapshot-static-global-int-02/test.desc
+++ b/regression/goto-harness/load-snapshot-static-global-int-02/test.desc
@@ -1,11 +1,9 @@
-KNOWNBUG
+CORE
 main.c
---harness-type initialise-with-memory-snapshot --memory-snapshot ../load-snapshot-json-snapshots/global-int-x-1-snapshot.json --initial-goto-location main:0
+harness.gb --harness-type initialise-with-memory-snapshot --memory-snapshot ../load-snapshot-json-snapshots/global-int-x-1-snapshot.json --initial-goto-location main:0
 ^EXIT=10$
 ^SIGNAL=0$
 \[main.assertion.1\] line [0-9]+ assertion x == 1: SUCCESS
 \[main.assertion.2\] line [0-9]+ assertion y == 1: FAILURE
 --
 ^warning: ignoring
---
-More information can be found in github#5351.

--- a/regression/goto-harness/load-snapshot-static-global-int-03/test.desc
+++ b/regression/goto-harness/load-snapshot-static-global-int-03/test.desc
@@ -1,10 +1,8 @@
-KNOWNBUG
+CORE
 main.c
---harness-type initialise-with-memory-snapshot --memory-snapshot ../load-snapshot-json-snapshots/global-int-x-1-snapshot.json --initial-goto-location main:0
+harness.gb --harness-type initialise-with-memory-snapshot --memory-snapshot ../load-snapshot-json-snapshots/global-int-x-1-snapshot.json --initial-goto-location main:0
 ^EXIT=0$
 ^SIGNAL=0$
 VERIFICATION SUCCESSFUL
 --
 ^warning: ignoring
---
-More information can be found in github#5351.

--- a/regression/goto-harness/load-snapshot-static-global-int-04/test.desc
+++ b/regression/goto-harness/load-snapshot-static-global-int-04/test.desc
@@ -1,10 +1,8 @@
-KNOWNBUG
+CORE
 main.c
---harness-type initialise-with-memory-snapshot --memory-snapshot ../load-snapshot-json-snapshots/global-int-x-1-snapshot.json --initial-goto-location main:1
+harness.gb --harness-type initialise-with-memory-snapshot --memory-snapshot ../load-snapshot-json-snapshots/global-int-x-1-snapshot.json --initial-goto-location main:1
 ^EXIT=0$
 ^SIGNAL=0$
 VERIFICATION SUCCESSFUL
 --
 ^warning: ignoring
---
-More information can be found in github#5351.

--- a/regression/goto-harness/load-snapshot-static-global-pointer-01/test.desc
+++ b/regression/goto-harness/load-snapshot-static-global-pointer-01/test.desc
@@ -1,6 +1,6 @@
-KNOWNBUG
+CORE
 main.c
---harness-type initialise-with-memory-snapshot --memory-snapshot snapshot.json --initial-goto-location main:0
+harness.gb --harness-type initialise-with-memory-snapshot --memory-snapshot snapshot.json --initial-goto-location main:0
 ^EXIT=0$
 ^SIGNAL=0$
 VERIFICATION SUCCESSFUL


### PR DESCRIPTION
It is not always necessary or desirable to produce C output. An ability
to produce goto binaries also avoids possible limitations of C and/or
dump-c (such as goto-harness creating initialisers for structs with bit
fields, which yield functions that take bit fields as parameters, which
isn't possible in C).

While at it, also clean up the help output to fix confusing language
about goto binaries when the output was actually C code.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [x] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
