### PR TITLE
Tests demonstrating pointer-encoding unsoundness

### DIFF
--- a/regression/cbmc/Pointer_Arithmetic18/main.c
+++ b/regression/cbmc/Pointer_Arithmetic18/main.c
@@ -1,0 +1,11 @@
+#define MB 0x00100000
+#define BASE (15 * MB)
+#define OFFSET (1 * MB)
+
+main()
+{
+  char *base = BASE;
+  int offset = OFFSET;
+  __CPROVER_assert(
+    &((char *)base)[offset] >= BASE + OFFSET, "no wrap-around expected");
+}

--- a/regression/cbmc/Pointer_Arithmetic18/test.desc
+++ b/regression/cbmc/Pointer_Arithmetic18/test.desc
@@ -1,0 +1,8 @@
+KNOWNBUG
+main.c
+--32
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring

--- a/regression/cbmc/Pointer_comparison1/main.c
+++ b/regression/cbmc/Pointer_comparison1/main.c
@@ -1,0 +1,22 @@
+#include <stdlib.h>
+
+int main()
+{
+  if(sizeof(void *) != 8)
+    return 0;
+
+  char *p = malloc(1);
+  if(p == 0)
+    return 0;
+
+  if(
+    (unsigned long)p >
+    42) // unsoundly evaluates to true due to pointer encoding
+  {
+    return 0;
+  }
+
+  __CPROVER_assert(0, "");
+
+  return 0;
+}

--- a/regression/cbmc/Pointer_comparison1/test.desc
+++ b/regression/cbmc/Pointer_comparison1/test.desc
@@ -1,0 +1,8 @@
+KNOWNBUG
+main.c
+
+^EXIT=10$
+^SIGNAL=0$
+^VERIFICATION FAILED$
+--
+^warning: ignoring


### PR DESCRIPTION
The tests exercise the way the back-end encodes pointers. Upcoming
encoding changes will ensure that these can soundly be handled.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
