### PR TITLE
Documentation: consistently use .gb suffix for goto binaries

### DIFF
--- a/doc/architectural/howto.md
+++ b/doc/architectural/howto.md
@@ -76,10 +76,10 @@ If you built using CMake on Unix, you should be able to run the
 Find or write a moderately-interesting C program; we'll call it `main.c`.
 Run the following commands:
 
-    goto-gcc -o main.goto main.c
+    goto-gcc -o main.gb main.c
     cc -o main.exe main.c
 
-Invoke `./main.goto` and `./main.exe` and observe that they run identically.
+Invoke `./main.gb` and `./main.exe` and observe that they run identically.
 The version that was compiled with `goto-gcc` is larger, though:
 
     du -hs *.{goto,exe}
@@ -95,7 +95,7 @@ is (informally) called a *goto-program*.
 `goto-instrument` is a Swiss army knife for viewing goto-programs and
 performing single program analyses on them.  Run the following command:
 
-    goto-instrument --show-goto-functions main.goto
+    goto-instrument --show-goto-functions main.gb
 
 Many of the instructions in the goto-program intermediate representation
 are similar to their C counterparts.  `if` and `goto` statements replace
@@ -105,7 +105,7 @@ Find or write a small C program (2 or 3 functions, each containing a few
 varied statements).  Compile it using `goto-gcc` as above into an object
 file called `main`. You can write the diagram to a file and then view it:
 
-    goto-instrument --dot main.goto | tail -n +2 | dot -Tpng > main.png
+    goto-instrument --dot main.gb | tail -n +2 | dot -Tpng > main.png
     open main.png
 
 (the invocation of `tail` is used to filter out the first line of
@@ -143,7 +143,7 @@ At some point in that function, there will be a long sequence of `if` statements
 **Task:** Add a `--greet` switch to `goto-instrument`, taking an optional
 argument, with the following behaviour:
 
-    $ goto-instrument --greet main.goto
+    $ goto-instrument --greet main.gb
     hello, world!
     $ goto-instrument --greet Leperina main
     hello, Leperina!

--- a/doc/cprover-manual/properties.md
+++ b/doc/cprover-manual/properties.md
@@ -227,14 +227,14 @@ Now, we can compile the program and detect that the error functions are indeed
 called by invoking these commands:
 
 ```
-goto-cc error_example.c -o error_example.goto
+goto-cc error_example.c -o error_example.gb
 # Replace all functions ending with _error
 # (Excluding those starting with __)
 # With ones that have an assert(false) body
-goto-instrument error_example.goto error_example_replaced.goto \
+goto-instrument error_example.gb error_example_replaced.gb \
   --generate-function-body '(?!__).*_error' \
   --generate-function-body-options assert-false
-cbmc error_example_replaced.goto
+cbmc error_example_replaced.gb
 ```
 
 This generates the following output:
@@ -277,7 +277,7 @@ int do_something_with_complex(struct Complex *complex);
 And the command line
 
 ```
-goto-instrument in.goto out.goto
+goto-instrument in.gb out.gb
   --generate-function-body do_something_with_complex
   --generate-function-body-options
     'havoc,params:.*,globals:AGlobalComplex'


### PR DESCRIPTION
Although our implementation does not care about the suffix, we should
avoid surprises. We mostly already used .gb as a suffix in
documentation, and consistently do so in regression tests. This commit
fixes the remaining occurrences of .goto in documentation, replacing all
of them by .gb.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- n/a Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
