### PR TITLE
fix distinct operator

### DIFF
--- a/regression/smt2_solver/distinct/distinct.smt2
+++ b/regression/smt2_solver/distinct/distinct.smt2
@@ -1,0 +1,2 @@
+(assert (distinct (_ bv0 8) (_ bv1 8)))
+(check-sat)

--- a/regression/smt2_solver/distinct/test.desc
+++ b/regression/smt2_solver/distinct/test.desc
@@ -1,0 +1,6 @@
+CORE
+distinct.smt2
+
+^EXIT=0$
+^SIGNAL=0$
+^sat$

--- a/regression/smt2_solver/distinct2/distinct2.smt2
+++ b/regression/smt2_solver/distinct2/distinct2.smt2
@@ -1,0 +1,2 @@
+(assert (distinct (_ bv0 8) (_ bv1 8)(_ bv2 8) (_ bv1 8)))
+(check-sat)

--- a/regression/smt2_solver/distinct2/test.desc
+++ b/regression/smt2_solver/distinct2/test.desc
@@ -1,0 +1,6 @@
+CORE
+distinct2.smt2
+
+^EXIT=0$
+^SIGNAL=0$
+^unsat$

--- a/regression/smt2_solver/distinct3/distinct3.smt2
+++ b/regression/smt2_solver/distinct3/distinct3.smt2
@@ -1,0 +1,2 @@
+(assert (distinct (_ bv0 8)(_ bv0 8)(_ bv2 8) (_ bv2 8)))
+(check-sat)

--- a/regression/smt2_solver/distinct3/test.desc
+++ b/regression/smt2_solver/distinct3/test.desc
@@ -1,0 +1,6 @@
+CORE
+distinct3.smt2
+
+^EXIT=0$
+^SIGNAL=0$
+^unsat$

--- a/src/solvers/smt2/smt2_parser.cpp
+++ b/src/solvers/smt2/smt2_parser.cpp
@@ -950,7 +950,23 @@ void smt2_parsert::setup_expressions()
 
   expressions["distinct"] = [this] {
     // pair-wise different constraint, multi-ary
-    return multi_ary("distinct", operands());
+    auto op = operands();
+    if(op.size() == 2)
+      return binary_predicate(ID_notequal, op);
+    else
+    {
+      std::vector<exprt> pairwise_constraints;
+      for(std::size_t i = 0; i < op.size(); i++)
+      {
+        for(std::size_t j = i; j < op.size(); j++)
+        {
+          if(i != j)
+            pairwise_constraints.push_back(
+              binary_exprt(op[i], ID_notequal, op[j], bool_typet()));
+        }
+      }
+      return multi_ary(ID_and, pairwise_constraints);
+    }
   };
 
   expressions["ite"] = [this] {


### PR DESCRIPTION
<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- [n/a] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [n/a] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [X] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [n/a] My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- [X] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->

Adds support for distinct operator in smt2 parser (which is syntactic sugar for a pairwise "not equal" predicate). Previously operator was parsed but later ignored 
