### PR TITLE
Do not rely on Clang's results to verify our GCC version handling

### DIFF
--- a/regression/ansi-c/gcc_version1/gcc-4.c
+++ b/regression/ansi-c/gcc_version1/gcc-4.c
@@ -1,4 +1,5 @@
-// None of these types should be defined when emulating gcc-4:
+// None of these types should be defined when emulating gcc-4, which clang on
+// macOS also emulates:
 
 typedef float _Float32;
 typedef double _Float32x;

--- a/regression/ansi-c/gcc_version1/gcc-5.c
+++ b/regression/ansi-c/gcc_version1/gcc-5.c
@@ -1,4 +1,6 @@
 // These types should *not* be provided when emulating gcc-5:
+
+#ifndef __clang__
 typedef float _Float32;
 typedef double _Float32x;
 typedef double _Float64;
@@ -8,3 +10,4 @@ typedef long double _Float128x;
 
 // But this type should:
 __float128 f128;
+#endif

--- a/regression/ansi-c/gcc_version1/gcc-7.c
+++ b/regression/ansi-c/gcc_version1/gcc-7.c
@@ -1,4 +1,6 @@
 // All these types should be provided when emulating gcc-7:
+
+#ifndef __clang__
 _Float32 f32;
 _Float32x f32x;
 _Float64 f64;
@@ -7,3 +9,4 @@ _Float128 f128;
 _Float128x f128x;
 
 __float128 gcc_f128;
+#endif


### PR DESCRIPTION
We use __float128 to distinguish GCC versions, which is not a
distinguishing factor for Clang. (It's supported on several Clang
versions on x86, but not on Apple's M1/ARM.) This commit effectively
disables the gcc_version1 test on macOS (where "gcc" really is Clang).

Fixes: #5828

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
