### PR TITLE
bv_utilst: mark non-modifying members static

### DIFF
--- a/src/solvers/flattening/bv_utils.cpp
+++ b/src/solvers/flattening/bv_utils.cpp
@@ -75,7 +75,7 @@ bvt bv_utilst::extract_lsb(const bvt &a, std::size_t n)
   return result;
 }
 
-bvt bv_utilst::concatenate(const bvt &a, const bvt &b) const
+bvt bv_utilst::concatenate(const bvt &a, const bvt &b)
 {
   bvt result;
 

--- a/src/solvers/flattening/bv_utils.h
+++ b/src/solvers/flattening/bv_utils.h
@@ -30,7 +30,7 @@ public:
 
   enum class representationt { SIGNED, UNSIGNED };
 
-  bvt build_constant(const mp_integer &i, std::size_t width);
+  static bvt build_constant(const mp_integer &i, std::size_t width);
 
   bvt incrementer(const bvt &op, literalt carry_in);
   bvt inc(const bvt &op) { return incrementer(op, const_literal(true)); }
@@ -44,7 +44,7 @@ public:
   literalt overflow_negate(const bvt &op);
 
   // bit-wise negation
-  bvt inverted(const bvt &op);
+  static bvt inverted(const bvt &op);
 
   literalt full_adder(
     const literalt a,
@@ -73,7 +73,7 @@ public:
     SHIFT_LEFT, SHIFT_LRIGHT, SHIFT_ARIGHT, ROTATE_LEFT, ROTATE_RIGHT
   };
 
-  bvt shift(const bvt &op, const shiftt shift, std::size_t distance);
+  static bvt shift(const bvt &op, const shiftt shift, std::size_t distance);
   bvt shift(const bvt &op, const shiftt shift, const bvt &distance);
 
   bvt unsigned_multiplier(const bvt &op0, const bvt &op1);
@@ -172,9 +172,10 @@ public:
   literalt unsigned_less_than(const bvt &bv0, const bvt &bv1);
   literalt signed_less_than(const bvt &bv0, const bvt &bv1);
 
-  bool is_constant(const bvt &bv);
+  static bool is_constant(const bvt &bv);
 
-  bvt extension(const bvt &bv, std::size_t new_size, representationt rep);
+  static bvt
+  extension(const bvt &bv, std::size_t new_size, representationt rep);
 
   bvt sign_extension(const bvt &bv, std::size_t new_size)
   {
@@ -212,10 +213,10 @@ public:
   static bvt extract_lsb(const bvt &a, std::size_t n);
 
   // put a and b together, where a comes first (lower indices)
-  bvt concatenate(const bvt &a, const bvt &b) const;
+  static bvt concatenate(const bvt &a, const bvt &b);
 
   literalt verilog_bv_has_x_or_z(const bvt &);
-  bvt verilog_bv_normal_bits(const bvt &);
+  static bvt verilog_bv_normal_bits(const bvt &);
 
 protected:
   propt &prop;


### PR DESCRIPTION
Some members were marked as const already, but can really be marked as
static; others did not make any use of the (sole) "prop" member, and can
thus be marked static as well.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
