### PR TITLE
bv_pointerst: make all members return (optional) bvt

### DIFF
--- a/src/solvers/flattening/bv_pointers.h
+++ b/src/solvers/flattening/bv_pointers.h
@@ -10,6 +10,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #ifndef CPROVER_SOLVERS_FLATTENING_BV_POINTERS_H
 #define CPROVER_SOLVERS_FLATTENING_BV_POINTERS_H
 
+#include <util/nodiscard.h>
 
 #include "boolbv.h"
 #include "pointer_logic.h"
@@ -54,11 +55,13 @@ protected:
   // NOLINTNEXTLINE(readability/identifiers)
   typedef boolbvt SUB;
 
-  void encode(std::size_t object, const pointer_typet &type, bvt &bv) const;
+  NODISCARD
+  bvt encode(std::size_t object, const pointer_typet &type) const;
 
   virtual bvt convert_pointer_type(const exprt &expr);
 
-  virtual void add_addr(const exprt &expr, bvt &bv);
+  NODISCARD
+  virtual bvt add_addr(const exprt &expr);
 
   // overloading
   literalt convert_rest(const exprt &expr) override;
@@ -70,20 +73,24 @@ protected:
     std::size_t offset,
     const typet &type) const override;
 
-  bool convert_address_of_rec(
-    const exprt &expr,
-    bvt &bv);
+  NODISCARD
+  optionalt<bvt> convert_address_of_rec(const exprt &expr);
 
-  void
-  offset_arithmetic(const pointer_typet &type, bvt &bv, const mp_integer &x);
-  void offset_arithmetic(
+  NODISCARD
+  bvt offset_arithmetic(
     const pointer_typet &type,
-    bvt &bv,
+    const bvt &bv,
+    const mp_integer &x);
+  NODISCARD
+  bvt offset_arithmetic(
+    const pointer_typet &type,
+    const bvt &bv,
     const mp_integer &factor,
     const exprt &index);
-  void offset_arithmetic(
+  NODISCARD
+  bvt offset_arithmetic(
     const pointer_typet &type,
-    bvt &bv,
+    const bvt &bv,
     const mp_integer &factor,
     const bvt &index_bv);
 


### PR DESCRIPTION
Instead of having in-out non-const bvt references, return bvt by value
and rely on copy elision for performance. This simplifies the code in
that it avoids creating (and sometimes unnecessarily resizing) objects
that are then to be populated by a function.

For convert_address_of_rec use optionalt<bvt> to remove the true/false
error reporting.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
