### PR TITLE
Bug fix using `format` function on `code_declt` containing initialization

### DIFF
--- a/src/goto-instrument/dump_c.cpp
+++ b/src/goto-instrument/dump_c.cpp
@@ -650,19 +650,18 @@ void dump_ct::cleanup_decl(
   std::list<irep_idt> &local_static,
   std::list<irep_idt> &local_type_decls)
 {
-  exprt value=nil_exprt();
+  const optionalt<exprt> value = decl.initial_value();
 
-  if(decl.operands().size()==2)
+  if(value)
   {
-    value=decl.op1();
     decl.operands().resize(1);
   }
 
   goto_programt tmp;
   tmp.add(goto_programt::make_decl(decl.symbol()));
 
-  if(value.is_not_nil())
-    tmp.add(goto_programt::make_assignment(decl.symbol(), value));
+  if(value)
+    tmp.add(goto_programt::make_assignment(decl.symbol(), *value));
 
   tmp.add(goto_programt::make_end_function());
 

--- a/src/goto-instrument/dump_c.cpp
+++ b/src/goto-instrument/dump_c.cpp
@@ -650,18 +650,14 @@ void dump_ct::cleanup_decl(
   std::list<irep_idt> &local_static,
   std::list<irep_idt> &local_type_decls)
 {
-  const optionalt<exprt> value = decl.initial_value();
-
-  if(value)
-  {
-    decl.set_initial_value({});
-  }
-
   goto_programt tmp;
   tmp.add(goto_programt::make_decl(decl.symbol()));
 
-  if(value)
-    tmp.add(goto_programt::make_assignment(decl.symbol(), *value));
+  if(optionalt<exprt> value = decl.initial_value())
+  {
+    decl.set_initial_value({});
+    tmp.add(goto_programt::make_assignment(decl.symbol(), std::move(*value)));
+  }
 
   tmp.add(goto_programt::make_end_function());
 

--- a/src/goto-instrument/dump_c.cpp
+++ b/src/goto-instrument/dump_c.cpp
@@ -654,7 +654,7 @@ void dump_ct::cleanup_decl(
 
   if(value)
   {
-    decl.operands().resize(1);
+    decl.set_initial_value({});
   }
 
   goto_programt tmp;

--- a/src/goto-instrument/goto_program2code.cpp
+++ b/src/goto-instrument/goto_program2code.cpp
@@ -477,7 +477,7 @@ goto_programt::const_targett goto_program2codet::convert_decl(
     {
       if(next->is_assign())
       {
-        d.copy_to_operands(next->get_assign().rhs());
+        d.set_initial_value({next->get_assign().rhs()});
       }
       else
       {

--- a/src/goto-programs/goto_program.h
+++ b/src/goto-programs/goto_program.h
@@ -199,13 +199,21 @@ public:
     const code_declt &get_decl() const
     {
       PRECONDITION(is_decl());
-      return to_code_decl(code);
+      const auto &decl = expr_checked_cast<code_declt>(code);
+      INVARIANT(
+        !decl.initial_value(),
+        "code_declt in goto program may not contain initialization.");
+      return decl;
     }
 
     /// Set the declaration for DECL
     void set_decl(code_declt c)
     {
       PRECONDITION(is_decl());
+      INVARIANT(
+        !c.initial_value(),
+        "Initialization must be separated from code_declt before adding to "
+        "goto_instructiont.");
       code = std::move(c);
     }
 

--- a/src/goto-programs/wp.cpp
+++ b/src/goto-programs/wp.cpp
@@ -226,6 +226,7 @@ exprt wp_decl(
   const exprt &post,
   const namespacet &ns)
 {
+  PRECONDITION(!code.initial_value());
   // Model decl(var) as var = nondet()
   const exprt &var = code.symbol();
   side_effect_expr_nondett nondet(var.type(), source_locationt());

--- a/src/util/format_expr.cpp
+++ b/src/util/format_expr.cpp
@@ -354,13 +354,13 @@ std::ostream &format_rec(std::ostream &os, const exprt &expr)
     {
       return os << "dead " << format(to_code_dead(code).symbol()) << ";";
     }
-    else if(statement == ID_decl)
+    else if(const auto decl = expr_try_dynamic_cast<code_declt>(code))
     {
-      const auto &declaration_symb = to_code_decl(code).symbol();
+      const auto &declaration_symb = decl->symbol();
       os << "decl " << format(declaration_symb.type()) << " "
          << format(declaration_symb);
-      if(code.operands().size() > 1)
-        os << " = " << format(code.op1());
+      if(const optionalt<exprt> initial_value = decl->initial_value())
+        os << " = " << format(*initial_value);
       return os << ";";
     }
     else if(statement == ID_function_call)

--- a/src/util/format_expr.cpp
+++ b/src/util/format_expr.cpp
@@ -357,8 +357,11 @@ std::ostream &format_rec(std::ostream &os, const exprt &expr)
     else if(statement == ID_decl)
     {
       const auto &declaration_symb = to_code_decl(code).symbol();
-      return os << "decl " << format(declaration_symb.type()) << " "
-                << format(declaration_symb) << ";";
+      os << "decl " << format(declaration_symb.type()) << " "
+         << format(declaration_symb);
+      if(code.operands().size() > 1)
+        os << " = " << format(code.op1());
+      return os << ";";
     }
     else if(statement == ID_function_call)
     {

--- a/src/util/std_code.h
+++ b/src/util/std_code.h
@@ -422,6 +422,8 @@ public:
 
   /// Returns the initial value to which the declared variable is initialized,
   /// or empty in the case where no initialisation is included.
+  /// \note: Initial values may be present in the front end but they must be
+  ///   separated into a separate assignment when used in a `goto_instructiont`.
   optionalt<exprt> initial_value() const
   {
     if(operands().size() < 2)
@@ -431,6 +433,8 @@ public:
 
   /// Sets the value to which this declaration initializes the declared
   /// variable. Empty optional maybe passed to remove existing initialisation.
+  /// \note: Initial values may be present in the front end but they must be
+  ///   separated into a separate assignment when used in a `goto_instructiont`.
   void set_initial_value(optionalt<exprt> initial_value)
   {
     if(!initial_value)

--- a/src/util/std_code.h
+++ b/src/util/std_code.h
@@ -429,6 +429,25 @@ public:
     return {op1()};
   }
 
+  /// Sets the value to which this declaration initializes the declared
+  /// variable. Empty optional maybe passed to remove existing initialisation.
+  void set_initial_value(optionalt<exprt> initial_value)
+  {
+    if(!initial_value)
+    {
+      operands().resize(1);
+    }
+    else if(operands().size() < 2)
+    {
+      PRECONDITION(operands().size() == 1);
+      add_to_operands(std::move(*initial_value));
+    }
+    else
+    {
+      op1() = std::move(*initial_value);
+    }
+  }
+
   static void check(
     const codet &code,
     const validation_modet vm = validation_modet::INVARIANT)

--- a/src/util/std_code.h
+++ b/src/util/std_code.h
@@ -420,6 +420,15 @@ public:
     return symbol().get_identifier();
   }
 
+  /// Returns the initial value to which the declared variable is initialized,
+  /// or empty in the case where no initialisation is included.
+  optionalt<exprt> initial_value() const
+  {
+    if(operands().size() < 2)
+      return {};
+    return {op1()};
+  }
+
   static void check(
     const codet &code,
     const validation_modet vm = validation_modet::INVARIANT)

--- a/unit/Makefile
+++ b/unit/Makefile
@@ -90,6 +90,7 @@ SRC += analyses/ai/ai.cpp \
        util/expr.cpp \
        util/expr_iterator.cpp \
        util/file_util.cpp \
+       util/format.cpp \
        util/format_number_range.cpp \
        util/get_base_name.cpp \
        util/graph.cpp \

--- a/unit/util/format.cpp
+++ b/unit/util/format.cpp
@@ -1,0 +1,22 @@
+/*******************************************************************\
+
+ Module: Unit tests for `format` function.
+
+ Author: DiffBlue Limited.
+
+\*******************************************************************/
+
+#include <util/format.h>
+#include <util/format_expr.h>
+#include <util/std_code.h>
+
+#include <testing-utils/use_catch.h>
+
+TEST_CASE("Format a declaration statement.", "[core][util][format]")
+{
+  const signedbv_typet int_type{32};
+  code_declt declaration{symbol_exprt{"foo", int_type}};
+  REQUIRE(format_to_string(declaration) == "decl signedbv[32] foo;");
+  declaration.add_to_operands(int_type.zero_expr());
+  REQUIRE(format_to_string(declaration) == "decl signedbv[32] foo = 0;");
+}

--- a/unit/util/format.cpp
+++ b/unit/util/format.cpp
@@ -17,6 +17,6 @@ TEST_CASE("Format a declaration statement.", "[core][util][format]")
   const signedbv_typet int_type{32};
   code_declt declaration{symbol_exprt{"foo", int_type}};
   REQUIRE(format_to_string(declaration) == "decl signedbv[32] foo;");
-  declaration.add_to_operands(int_type.zero_expr());
+  declaration.set_initial_value({int_type.zero_expr()});
   REQUIRE(format_to_string(declaration) == "decl signedbv[32] foo = 0;");
 }


### PR DESCRIPTION
Bug fix using `format` function on `code_declt` containing initialization. Functionality was previously unimplemented, which resulted in part of the statement being missing from the formatted output.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [x] N/A ~~The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/~~
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [x] N/A ~~My commit message includes data points confirming performance improvements (if claimed).~~
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
