### PR TITLE
Do not use invalid_source_file_exceptiont without source location

### DIFF
--- a/jbmc/src/java_bytecode/java_bytecode_language.cpp
+++ b/jbmc/src/java_bytecode/java_bytecode_language.cpp
@@ -318,7 +318,7 @@ void java_bytecode_languaget::initialize_class_loader()
 
 static void throwMainClassLoadingError(const std::string &main_class)
 {
-  throw invalid_source_file_exceptiont(
+  throw system_exceptiont(
     "Error: Could not find or load main class " + main_class);
 }
 
@@ -392,8 +392,7 @@ bool java_bytecode_languaget::parse(
     std::ifstream jar_file(path);
     if(!jar_file.good())
     {
-      throw invalid_source_file_exceptiont(
-        "Error: Unable to access jarfile " + path);
+      throw system_exceptiont("Error: Unable to access jarfile " + path);
     }
 
     // build an object to potentially limit which classes are loaded

--- a/jbmc/src/java_bytecode/lazy_goto_model.cpp
+++ b/jbmc/src/java_bytecode/lazy_goto_model.cpp
@@ -152,14 +152,14 @@ void lazy_goto_modelt::initialize(
 
     if(dynamic_cast<java_bytecode_languaget &>(language).parse())
     {
-      throw invalid_source_file_exceptiont("PARSING ERROR");
+      throw invalid_input_exceptiont("PARSING ERROR");
     }
 
     msg.status() << "Converting" << messaget::eom;
 
     if(language_files.typecheck(symbol_table))
     {
-      throw invalid_source_file_exceptiont("CONVERSION ERROR");
+      throw invalid_input_exceptiont("CONVERSION ERROR");
     }
   }
   else

--- a/src/crangler/ctokenit.cpp
+++ b/src/crangler/ctokenit.cpp
@@ -46,7 +46,7 @@ ctokenitt match_bracket(ctokenitt t, char open, char close)
   while(true)
   {
     if(!t)
-      throw invalid_source_file_exceptiont("expected " + std::string(1, close));
+      throw invalid_input_exceptiont("expected " + std::string(1, close));
 
     const auto &token = *(t++);
 

--- a/src/crangler/mini_c_parser.cpp
+++ b/src/crangler/mini_c_parser.cpp
@@ -143,7 +143,7 @@ void mini_c_parsert::parse_brackets(char open, char close, tokenst &dest)
   while(true)
   {
     if(eof())
-      throw invalid_source_file_exceptiont("expected " + std::string(1, close));
+      throw invalid_input_exceptiont("expected " + std::string(1, close));
 
     auto &token = consume_token();
     dest.push_back(token);
@@ -297,7 +297,7 @@ mini_c_parsert::tokenst mini_c_parsert::parse_initializer()
     while(true)
     {
       if(eof())
-        throw invalid_source_file_exceptiont("expected an initializer");
+        throw invalid_input_exceptiont("expected an initializer");
       auto &token = consume_token();
       result.push_back(token);
       if(token == ';')
@@ -317,7 +317,7 @@ mini_c_parsert::tokenst mini_c_parsert::parse_initializer()
     while(true)
     {
       if(eof())
-        throw invalid_source_file_exceptiont("eof in function body");
+        throw invalid_input_exceptiont("eof in function body");
       auto &token = consume_token();
       result.push_back(token);
       if(token == '{')

--- a/src/memory-analyzer/analyze_symbol.cpp
+++ b/src/memory-analyzer/analyze_symbol.cpp
@@ -350,7 +350,7 @@ exprt gdb_value_extractort::get_pointer_to_function_value(
   const auto function_symbol = symbol_table.lookup(function_name);
   if(function_symbol == nullptr)
   {
-    throw invalid_source_file_exceptiont{
+    throw invalid_input_exceptiont{
       "input source code does not contain function: " + function_name};
   }
   CHECK_RETURN(function_symbol->type.id() == ID_code);

--- a/src/symtab2gb/symtab2gb_parse_options.cpp
+++ b/src/symtab2gb/symtab2gb_parse_options.cpp
@@ -90,8 +90,8 @@ static void run_symtab2gb(
 
     if(failed(linking(linked_symbol_table, symtab, message_handler)))
     {
-      throw invalid_source_file_exceptiont{"failed to link `" +
-                                           symtab_filename + "'"};
+      throw invalid_input_exceptiont{
+        "failed to link `" + symtab_filename + "'"};
     }
   }
 

--- a/src/util/exception_utils.cpp
+++ b/src/util/exception_utils.cpp
@@ -80,6 +80,11 @@ analysis_exceptiont::analysis_exceptiont(std::string reason)
 {
 }
 
+invalid_input_exceptiont::invalid_input_exceptiont(std::string reason)
+  : cprover_exception_baset(std::move(reason))
+{
+}
+
 invalid_source_file_exceptiont::invalid_source_file_exceptiont(
   std::string reason)
   : cprover_exception_baset(std::move(reason))

--- a/src/util/exception_utils.h
+++ b/src/util/exception_utils.h
@@ -156,6 +156,15 @@ public:
   explicit analysis_exceptiont(std::string reason);
 };
 
+/// Thrown when user-provided input cannot be processed. Use
+/// \ref invalid_source_file_exceptiont when the precise location of erroneous
+/// input is known.
+class invalid_input_exceptiont : public cprover_exception_baset
+{
+public:
+  explicit invalid_input_exceptiont(std::string reason);
+};
+
 /// Thrown when we can't handle something in an input source file.
 /// For example, if we get C source code that is not syntactically valid
 /// or that has type errors.

--- a/unit/testing-utils/get_goto_model_from_c.cpp
+++ b/unit/testing-utils/get_goto_model_from_c.cpp
@@ -58,7 +58,7 @@ goto_modelt get_goto_model_from_c(std::istream &in)
     const bool error = language.parse(in, "");
 
     if(error)
-      throw invalid_source_file_exceptiont("parsing failed");
+      throw invalid_input_exceptiont("parsing failed");
   }
 
   language_file.get_modules();
@@ -69,7 +69,7 @@ goto_modelt get_goto_model_from_c(std::istream &in)
     const bool error = language_files.typecheck(goto_model.symbol_table);
 
     if(error)
-      throw invalid_source_file_exceptiont("typechecking failed");
+      throw invalid_input_exceptiont("typechecking failed");
   }
 
   {
@@ -77,8 +77,7 @@ goto_modelt get_goto_model_from_c(std::istream &in)
       language_files.generate_support_functions(goto_model.symbol_table);
 
     if(error)
-      throw invalid_source_file_exceptiont(
-        "support function generation failed");
+      throw invalid_input_exceptiont("support function generation failed");
   }
 
   goto_convert(


### PR DESCRIPTION
In preparation of tying invalid_source_file_exceptiont to an actual
source location, introduce an exception that is thrown when some invalid
input is encountered, but a precise source location is not known at the
time of throwing the exception.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
