### PR TITLE
C front-end: clean-up strings being thrown as exceptions

### DIFF
--- a/src/ansi-c/literals/convert_character_literal.cpp
+++ b/src/ansi-c/literals/convert_character_literal.cpp
@@ -32,13 +32,13 @@ exprt convert_character_literal(
 
     std::basic_string<unsigned int> value=
       unescape_wide_string(std::string(src, 2, src.size()-3));
+    // the parser rejects empty character constants
+    CHECK_RETURN(!value.empty());
 
     // L is wchar_t, u is char16_t, U is char32_t
     typet type=wchar_t_type();
 
-    if(value.empty())
-      throw "empty wide character literal";
-    else if(value.size()==1)
+    if(value.size() == 1)
     {
       result=from_integer(value[0], type);
     }
@@ -69,10 +69,10 @@ exprt convert_character_literal(
 
     std::string value=
       unescape_string(std::string(src, 1, src.size()-2));
+    // the parser rejects empty character constants
+    CHECK_RETURN(!value.empty());
 
-    if(value.empty())
-      throw "empty character literal";
-    else if(value.size()==1)
+    if(value.size() == 1)
     {
       typet type=force_integer_type?signed_int_type():char_type();
       result=from_integer(value[0], type);

--- a/src/ansi-c/literals/convert_string_literal.cpp
+++ b/src/ansi-c/literals/convert_string_literal.cpp
@@ -91,17 +91,14 @@ exprt convert_string_literal(const std::string &src)
 
     // find start of sequence
     std::size_t j=src.find('"', i);
-    if(j==std::string::npos)
-      throw "invalid string constant '" + src + "'";
+    CHECK_RETURN(j != std::string::npos);
 
     // find end of sequence, considering escaping
     for(++j; j<src.size() && src[j]!='"'; ++j)
       if(src[j]=='\\') // skip next character
         ++j;
 
-    assert(j<=src.size());
-    if(j==src.size())
-      throw "non-terminated string constant '" + src + "'";
+    INVARIANT(j < src.size(), "non-terminated string constant '" + src + "'");
 
     std::string tmp_src=std::string(src, i, j-i+1);
     std::basic_string<unsigned int> tmp_value=


### PR DESCRIPTION
The remaining instances were all invariants and should not actually be
thrown as (user-facing) exceptions at all.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
