### PR TITLE
Fix pointer subtraction semantics

### DIFF
--- a/regression/cbmc-library/posix_memalign-02/test.desc
+++ b/regression/cbmc-library/posix_memalign-02/test.desc
@@ -6,6 +6,5 @@ main.c
 ^VERIFICATION FAILED$
 \[main.precondition_instance.1\] .* memcpy src/dst overlap: FAILURE
 \[main.precondition_instance.3\] .* memcpy destination region writeable: FAILURE
-\*\* 2 of 14 failed
 --
 ^warning: ignoring

--- a/regression/cbmc/Pointer_difference2/main.c
+++ b/regression/cbmc/Pointer_difference2/main.c
@@ -1,9 +1,31 @@
 int main()
 {
-  int array[2];
+  int array[4];
   int other_array[2];
 
+  __CPROVER_assert(&array[0] - &array[2] == -2, "correct");
+
   int diff = array - other_array;
+  _Bool nondet;
+  if(nondet)
+    __CPROVER_assert(diff != 42, "undefined behavior");
+  else
+    __CPROVER_assert(diff == 42, "undefined behavior");
+
+  __CPROVER_assert(
+    ((char *)(&array[3])) - ((char *)(&array[1])) == 2 * sizeof(int),
+    "casting works");
+
+  int *p = &array[3];
+  ++p;
+  __CPROVER_assert(p - &array[0] == 4, "end plus one works");
+  __CPROVER_assert(p - &array[0] != 3, "end plus one works");
+  ++p;
+  _Bool nondet_branch;
+  if(nondet_branch)
+    __CPROVER_assert(p - &array[0] == 5, "end plus 2 is nondet");
+  else
+    __CPROVER_assert(p - &array[0] != 5, "end plus 2 is nondet");
 
   return 0;
 }

--- a/regression/cbmc/Pointer_difference2/main.c
+++ b/regression/cbmc/Pointer_difference2/main.c
@@ -1,0 +1,9 @@
+int main()
+{
+  int array[2];
+  int other_array[2];
+
+  int diff = array - other_array;
+
+  return 0;
+}

--- a/regression/cbmc/Pointer_difference2/test.desc
+++ b/regression/cbmc/Pointer_difference2/test.desc
@@ -1,7 +1,15 @@
-CORE
+CORE broken-smt-backend
 main.c
 --pointer-check
-^\[main.pointer.1\] line 6 same object violation in array - other_array: FAILURE$
+^\[main.assertion.1\] line 6 correct: SUCCESS
+^\[main.pointer.1\] line 8 same object violation in array - other_array: FAILURE$
+^\[main.assertion.2\] line 11 undefined behavior: FAILURE$
+^\[main.assertion.3\] line 13 undefined behavior: FAILURE$
+^\[main.assertion.7\] line 26 end plus 2 is nondet: FAILURE$
+^\[main.pointer_arithmetic.\d+\] line 26 pointer relation: pointer outside object bounds in p: FAILURE$
+^\[main.assertion.8\] line 28 end plus 2 is nondet: FAILURE$
+^\[main.pointer_arithmetic.\d+\] line 28 pointer relation: pointer outside object bounds in p: FAILURE$
+^\*\* 7 of \d+ failed
 ^VERIFICATION FAILED$
 ^EXIT=10$
 ^SIGNAL=0$

--- a/regression/cbmc/Pointer_difference2/test.desc
+++ b/regression/cbmc/Pointer_difference2/test.desc
@@ -1,0 +1,10 @@
+CORE
+main.c
+--pointer-check
+^\[main.pointer.1\] line 6 same object violation in array - other_array: FAILURE$
+^VERIFICATION FAILED$
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring
+^CONVERSION ERROR$

--- a/regression/cbmc/void_pointer3/main.c
+++ b/regression/cbmc/void_pointer3/main.c
@@ -2,14 +2,14 @@
 
 int main()
 {
-  // make sure they are NULL objects
-  void *p=0, *q=0;
+  int array[1 << (sizeof(unsigned char) * 8)];
+
+  void *p = array, *q = array;
   // with the object:offset encoding we need to make sure the address arithmetic
   // below will only touch the offset part
   __CPROVER_assume(sizeof(unsigned char)<sizeof(void*));
   unsigned char o1, o2;
-  // there is ample undefined behaviour here, but the goal of this test solely
-  // is exercising CBMC's pointer subtraction encoding
+
   p+=o1;
   q+=o2;
 

--- a/src/analyses/goto_check.cpp
+++ b/src/analyses/goto_check.cpp
@@ -1128,18 +1128,15 @@ void goto_checkt::pointer_rel_check(
   {
     // add same-object subgoal
 
-    if(enable_pointer_check)
-    {
-      exprt same_object=::same_object(expr.op0(), expr.op1());
+    exprt same_object = ::same_object(expr.op0(), expr.op1());
 
-      add_guarded_property(
-        same_object,
-        "same object violation",
-        "pointer",
-        expr.find_source_location(),
-        expr,
-        guard);
-    }
+    add_guarded_property(
+      same_object,
+      "same object violation",
+      "pointer",
+      expr.find_source_location(),
+      expr,
+      guard);
   }
 }
 

--- a/src/analyses/goto_check.cpp
+++ b/src/analyses/goto_check.cpp
@@ -178,7 +178,7 @@ protected:
   void mod_overflow_check(const mod_exprt &, const guardt &);
   void enum_range_check(const exprt &, const guardt &);
   void undefined_shift_check(const shift_exprt &, const guardt &);
-  void pointer_rel_check(const binary_relation_exprt &, const guardt &);
+  void pointer_rel_check(const binary_exprt &, const guardt &);
   void pointer_overflow_check(const exprt &, const guardt &);
 
   /// Generates VCCs for the validity of the given dereferencing operation.
@@ -1117,7 +1117,7 @@ void goto_checkt::nan_check(
 }
 
 void goto_checkt::pointer_rel_check(
-  const binary_relation_exprt &expr,
+  const binary_exprt &expr,
   const guardt &guard)
 {
   if(!enable_pointer_check)
@@ -1137,6 +1137,25 @@ void goto_checkt::pointer_rel_check(
       expr.find_source_location(),
       expr,
       guard);
+
+    for(const auto &pointer : expr.operands())
+    {
+      // just this particular byte must be within object bounds or one past the
+      // end
+      const auto size = from_integer(0, size_type());
+      auto conditions = get_pointer_dereferenceable_conditions(pointer, size);
+
+      for(const auto &c : conditions)
+      {
+        add_guarded_property(
+          c.assertion,
+          "pointer relation: " + c.description,
+          "pointer arithmetic",
+          expr.find_source_location(),
+          pointer,
+          guard);
+      }
+    }
   }
 }
 
@@ -1647,6 +1666,14 @@ void goto_checkt::check_rec_arithmetic_op(const exprt &expr, guardt &guard)
   if(expr.type().id() == ID_signedbv || expr.type().id() == ID_unsignedbv)
   {
     integer_overflow_check(expr, guard);
+
+    if(
+      expr.operands().size() == 2 && expr.id() == ID_minus &&
+      expr.operands()[0].type().id() == ID_pointer &&
+      expr.operands()[1].type().id() == ID_pointer)
+    {
+      pointer_rel_check(to_binary_expr(expr), guard);
+    }
   }
   else if(expr.type().id() == ID_floatbv)
   {


### PR DESCRIPTION
(Please review commit-by-commit.)

Subtracting pointers over the same object is subtraction of the offset
(divided by the element size). Subtracting pointers over different
objects should yield a non-deterministic result.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
