### PR TITLE
Fixed weakest precondition for code_assertt

### DIFF
--- a/src/goto-programs/wp.cpp
+++ b/src/goto-programs/wp.cpp
@@ -213,6 +213,14 @@ exprt wp_assign(
   return pre;
 }
 
+exprt wp_assert(
+  const code_assertt &code,
+  const exprt &post,
+  const namespacet &)
+{
+  return and_exprt(code.assertion(), post);
+}
+
 exprt wp_assume(
   const code_assumet &code,
   const exprt &post,
@@ -250,7 +258,7 @@ exprt wp(
   else if(statement==ID_decl)
     return wp_decl(to_code_decl(code), post, ns);
   else if(statement==ID_assert)
-    return post;
+    return wp_assert(to_code_assert(code), post, ns);
   else if(statement==ID_expression)
     return post;
   else if(statement==ID_printf)


### PR DESCRIPTION
The existing `wp` function treated an `assert` statement the same way as a `skip` statement. This commit fixes this behavior as per standard Hoare logic rules.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
