### PR TITLE
C library/str(n)cat: do not write spurious 0 byte

### DIFF
--- a/regression/cbmc-library/strcat-01/main.c
+++ b/regression/cbmc-library/strcat-01/main.c
@@ -10,19 +10,5 @@ int main()
   assert(A1[3] == 'd');
   assert(strlen(A1) == 4);
 
-  char A2[5] = {'a', 'b', '\0'};
-  char B2[3] = {'c', 'd', '\0'};
-
-  strncat(A2, B2, 2);
-  assert(A2[3] == 'd');
-  assert(strlen(A2) == 4);
-
-  char A3[5] = {'a', 'b', '\0'};
-  char B3[3] = {'c', 'd', '\0'};
-
-  strncat(A3, B3, 1);
-  assert(A3[3] == '\0');
-  assert(strlen(A3) == 4); // expected to fail
-
   return 0;
 }

--- a/regression/cbmc-library/strcat-01/test.desc
+++ b/regression/cbmc-library/strcat-01/test.desc
@@ -1,10 +1,8 @@
 CORE
 main.c
---unwind 10
-^EXIT=10$
+--unwind 10 --pointer-check --bounds-check
+^VERIFICATION SUCCESSFUL$
+^EXIT=0$
 ^SIGNAL=0$
-^VERIFICATION FAILED$
-\[main.assertion.6\] .* assertion strlen\(A3\) == 4: FAILURE
-\*\* 1 of 9 failed
 --
 ^warning: ignoring

--- a/regression/cbmc-library/strncat-01/main.c
+++ b/regression/cbmc-library/strncat-01/main.c
@@ -3,7 +3,19 @@
 
 int main()
 {
-  strncat();
-  assert(0);
+  char A2[5] = {'a', 'b', '\0'};
+  char B2[3] = {'c', 'd', '\0'};
+
+  strncat(A2, B2, 2);
+  assert(A2[3] == 'd');
+  assert(strlen(A2) == 4);
+
+  char A3[5] = {'a', 'b', '\0'};
+  char B3[3] = {'c', 'd', '\0'};
+
+  strncat(A3, B3, 1);
+  assert(A3[3] == '\0');
+  assert(strlen(A3) == 4); // expected to fail
+
   return 0;
 }

--- a/regression/cbmc-library/strncat-01/test.desc
+++ b/regression/cbmc-library/strncat-01/test.desc
@@ -1,8 +1,10 @@
-KNOWNBUG
+CORE
 main.c
---pointer-check --bounds-check
-^EXIT=0$
+--unwind 10 --pointer-check --bounds-check
+^EXIT=10$
 ^SIGNAL=0$
-^VERIFICATION SUCCESSFUL$
+^VERIFICATION FAILED$
+\[main.assertion.4\] .* assertion strlen\(A3\) == 4: FAILURE
+\*\* 1 of \d+ failed
 --
 ^warning: ignoring

--- a/src/ansi-c/library/string.c
+++ b/src/ansi-c/library/string.c
@@ -72,7 +72,6 @@ __CPROVER_HIDE:;
     ch = src[j];
     dst[i] = ch;
   }
-  dst[i] = '\0';
 #endif
   return dst;
 }
@@ -122,7 +121,8 @@ __CPROVER_HIDE:;
     ch = src[j];
     dst[i] = ch;
   }
-  dst[i] = '\0';
+  if(ch != (char)0)
+    dst[i] = '\0';
 #endif
   return dst;
 }
@@ -288,7 +288,6 @@ __CPROVER_HIDE:;
     ch = src[j];
     dst[i] = ch;
   }
-  dst[i] = '\0';
 #endif
   return dst;
 }
@@ -342,7 +341,8 @@ __CPROVER_HIDE:;
     ch = src[j];
     dst[i] = ch;
   }
-  dst[i] = '\0';
+  if(ch != (char)0)
+    dst[i] = '\0';
 #endif
   return dst;
 }


### PR DESCRIPTION
In strcat, the construction of the loop already ensures that the 0 byte
is written. In strncat, the 0 byte should only be written when the loop
terminated early.

Also, clean up regression tests of str(n)cat.

Fixes: #3200

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
