### PR TITLE
Add goto-ld to .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,6 +108,7 @@ src/goto-analyzer/goto-analyzer
 src/goto-analyzer/goto-analyzer.exe
 src/goto-cc/goto-cc
 src/goto-cc/goto-gcc
+src/goto-cc/goto-ld
 src/goto-cc/goto-cc.exe
 src/goto-cc/goto-cl.exe
 src/goto-harness/goto-harness


### PR DESCRIPTION
When building under `make`, the binary `src/goto-cc/goto-ld` is not in the
`.gitignore` file, polluting the `git status` output.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
