### PR TITLE
Assignment side effects may require additional temporaries

### DIFF
--- a/regression/cbmc/Sideeffects8/main.c
+++ b/regression/cbmc/Sideeffects8/main.c
@@ -1,0 +1,18 @@
+#include <assert.h>
+#include <stdlib.h>
+
+struct A
+{
+  struct A *p;
+};
+
+int main(void)
+{
+  struct A x = {&x};
+  struct A *r = x.p->p = NULL;
+  assert(r == NULL);
+
+  struct A arr[2] = {arr, 0};
+  r = arr[0].p->p += 1;
+  assert(r == &arr[1]);
+}

--- a/regression/cbmc/Sideeffects8/test.desc
+++ b/regression/cbmc/Sideeffects8/test.desc
@@ -1,0 +1,12 @@
+CORE
+main.c
+--pointer-check
+^VERIFICATION SUCCESSFUL$
+^EXIT=0$
+^SIGNAL=0$
+--
+Invariant check failed
+^warning: ignoring
+--
+Assignments can affect dereferences occuring with the LHS, and thus may require
+introducing temporaries.

--- a/src/goto-programs/goto_clean_expr.cpp
+++ b/src/goto-programs/goto_clean_expr.cpp
@@ -409,7 +409,8 @@ void goto_convertt::clean_expr(
 
   if(expr.id()==ID_side_effect)
   {
-    remove_side_effect(to_side_effect_expr(expr), dest, mode, result_is_used);
+    remove_side_effect(
+      to_side_effect_expr(expr), dest, mode, result_is_used, false);
   }
   else if(expr.id()==ID_compound_literal)
   {
@@ -482,7 +483,7 @@ void goto_convertt::clean_expr_address_of(
   }
   else if(expr.id() == ID_side_effect)
   {
-    remove_side_effect(to_side_effect_expr(expr), dest, mode, true);
+    remove_side_effect(to_side_effect_expr(expr), dest, mode, true, true);
   }
   else
     Forall_operands(it, expr)

--- a/src/goto-programs/goto_convert_class.h
+++ b/src/goto-programs/goto_convert_class.h
@@ -102,11 +102,13 @@ protected:
     side_effect_exprt &expr,
     goto_programt &dest,
     const irep_idt &mode,
-    bool result_is_used);
+    bool result_is_used,
+    bool address_taken);
   void remove_assignment(
     side_effect_exprt &expr,
     goto_programt &dest,
     bool result_is_used,
+    bool address_taken,
     const irep_idt &mode);
   void remove_pre(
     side_effect_exprt &expr,


### PR DESCRIPTION
An assignment may invalidate pointers used in the left-hand side. In
case the result of the assignment is used, we therefore cannot re-use
the left-hand side to represent the result. Instead, introduce
temporaries as needed to store the right-hand side value, and use the
temporary to represent the result.

Fixes: #5857

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
