### PR TITLE
Use endianness map for both big and little endian

### DIFF
--- a/scripts/expected_doxygen_warnings.txt
+++ b/scripts/expected_doxygen_warnings.txt
@@ -21,9 +21,9 @@
 warning: Include graph for 'goto_instrument_parse_options.cpp' not generated, too many nodes (97), threshold is 60. Consider increasing DOT_GRAPH_MAX_NODES.
 warning: Included by graph for 'goto_functions.h' not generated, too many nodes (66), threshold is 60. Consider increasing DOT_GRAPH_MAX_NODES.
 warning: Included by graph for 'goto_model.h' not generated, too many nodes (111), threshold is 60. Consider increasing DOT_GRAPH_MAX_NODES.
-warning: Included by graph for 'arith_tools.h' not generated, too many nodes (183), threshold is 60. Consider increasing DOT_GRAPH_MAX_NODES.
-warning: Included by graph for 'c_types.h' not generated, too many nodes (143), threshold is 60. Consider increasing DOT_GRAPH_MAX_NODES.
-warning: Included by graph for 'config.h' not generated, too many nodes (78), threshold is 60. Consider increasing DOT_GRAPH_MAX_NODES.
+warning: Included by graph for 'arith_tools.h' not generated, too many nodes (182), threshold is 60. Consider increasing DOT_GRAPH_MAX_NODES.
+warning: Included by graph for 'c_types.h' not generated, too many nodes (144), threshold is 60. Consider increasing DOT_GRAPH_MAX_NODES.
+warning: Included by graph for 'config.h' not generated, too many nodes (77), threshold is 60. Consider increasing DOT_GRAPH_MAX_NODES.
 warning: Included by graph for 'exception_utils.h' not generated, too many nodes (61), threshold is 60. Consider increasing DOT_GRAPH_MAX_NODES.
 warning: Included by graph for 'expr.h' not generated, too many nodes (87), threshold is 60. Consider increasing DOT_GRAPH_MAX_NODES.
 warning: Included by graph for 'expr_util.h' not generated, too many nodes (61), threshold is 60. Consider increasing DOT_GRAPH_MAX_NODES.

--- a/src/solvers/flattening/boolbv.cpp
+++ b/src/solvers/flattening/boolbv.cpp
@@ -15,6 +15,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/arith_tools.h>
 #include <util/bitvector_expr.h>
 #include <util/bitvector_types.h>
+#include <util/config.h>
 #include <util/floatbv_expr.h>
 #include <util/magic.h>
 #include <util/mp_arith.h>
@@ -31,6 +32,13 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <solvers/floatbv/float_utils.h>
 #include <solvers/lowering/expr_lowering.h>
+
+endianness_mapt boolbvt::endianness_map(const typet &type) const
+{
+  const bool little_endian =
+    config.ansi_c.endianness == configt::ansi_ct::endiannesst::IS_LITTLE_ENDIAN;
+  return endianness_map(type, little_endian);
+}
 
 /// Convert expression to vector of literalts, using an internal
 /// cache to speed up conversion if available. Also assert the resultant

--- a/src/solvers/flattening/boolbv.h
+++ b/src/solvers/flattening/boolbv.h
@@ -104,6 +104,8 @@ public:
     return endianness_mapt{type, little_endian, ns};
   }
 
+  virtual endianness_mapt endianness_map(const typet &type) const;
+
 protected:
   boolbv_widtht bv_width;
   bv_utilst bv_utils;

--- a/src/solvers/flattening/boolbv_byte_update.cpp
+++ b/src/solvers/flattening/boolbv_byte_update.cpp
@@ -58,31 +58,23 @@ bvt boolbvt::convert_byte_update(const byte_update_exprt &expr)
     }
     else
     {
-      if(little_endian)
+      endianness_mapt map_op = endianness_map(op.type(), little_endian);
+      endianness_mapt map_value = endianness_map(value.type(), little_endian);
+
+      const std::size_t offset_i = numeric_cast_v<std::size_t>(offset);
+
+      for(std::size_t i = 0; i < update_width; i++)
       {
-        for(std::size_t i=0; i<update_width; i++)
-          bv[numeric_cast_v<std::size_t>(offset + i)] = value_bv[i];
-      }
-      else
-      {
-        endianness_mapt map_op = endianness_map(op.type(), false);
-        endianness_mapt map_value = endianness_map(value.type(), false);
+        size_t index_op = map_op.map_bit(offset_i + i);
+        size_t index_value = map_value.map_bit(i);
 
-        const std::size_t offset_i = numeric_cast_v<std::size_t>(offset);
+        INVARIANT(
+          index_op < bv.size(), "bit vector index shall be within bounds");
+        INVARIANT(
+          index_value < value_bv.size(),
+          "bit vector index shall be within bounds");
 
-        for(std::size_t i=0; i<update_width; i++)
-        {
-          size_t index_op=map_op.map_bit(offset_i+i);
-          size_t index_value=map_value.map_bit(i);
-
-          INVARIANT(
-            index_op < bv.size(), "bit vector index shall be within bounds");
-          INVARIANT(
-            index_value < value_bv.size(),
-            "bit vector index shall be within bounds");
-
-          bv[index_op]=value_bv[index_value];
-        }
+        bv[index_op] = value_bv[index_value];
       }
     }
 

--- a/src/solvers/flattening/boolbv_member.cpp
+++ b/src/solvers/flattening/boolbv_member.cpp
@@ -8,16 +8,20 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "boolbv.h"
 
-bvt boolbvt::convert_member(const member_exprt &expr)
+#include <util/c_types.h>
+
+static bvt convert_member_struct(
+  const member_exprt &expr,
+  const bvt &struct_bv,
+  const std::function<std::size_t(const typet &)> boolbv_width,
+  const namespacet &ns)
 {
   const exprt &struct_op=expr.struct_op();
   const typet &struct_op_type=ns.follow(struct_op.type());
 
-  const bvt &struct_bv=convert_bv(struct_op);
-
   const irep_idt &component_name = expr.get_component_name();
-  const struct_union_typet::componentst &components =
-    to_struct_union_type(struct_op_type).components();
+  const struct_typet::componentst &components =
+    to_struct_type(struct_op_type).components();
 
   std::size_t offset = 0;
 
@@ -42,8 +46,7 @@ bvt boolbvt::convert_member(const member_exprt &expr)
         struct_bv.begin() + offset, struct_bv.begin() + offset + sub_width);
     }
 
-    if(struct_op_type.id() != ID_union)
-      offset += sub_width;
+    offset += sub_width;
   }
 
   INVARIANT_WITH_DIAGNOSTICS(
@@ -51,4 +54,53 @@ bvt boolbvt::convert_member(const member_exprt &expr)
     "struct type shall contain component accessed by member expression",
     expr.find_source_location(),
     id2string(component_name));
+}
+
+static bvt convert_member_union(
+  const member_exprt &expr,
+  const bvt &union_bv,
+  const boolbvt &boolbv,
+  const namespacet &ns)
+{
+  const exprt &union_op = expr.compound();
+  const union_typet &union_op_type =
+    ns.follow_tag(to_union_tag_type(union_op.type()));
+
+  const irep_idt &component_name = expr.get_component_name();
+  const union_typet::componentt &component =
+    union_op_type.get_component(component_name);
+  DATA_INVARIANT_WITH_DIAGNOSTICS(
+    component.is_not_nil(),
+    "union type shall contain component accessed by member expression",
+    expr.find_source_location(),
+    id2string(component_name));
+
+  const typet &subtype = component.type();
+  const std::size_t sub_width = boolbv.boolbv_width(subtype);
+
+  endianness_mapt map_u = boolbv.endianness_map(union_op_type);
+  endianness_mapt map_component = boolbv.endianness_map(subtype);
+
+  bvt result(sub_width, literalt{});
+  for(std::size_t i = 0; i < sub_width; ++i)
+    result[map_u.map_bit(i)] = union_bv[map_component.map_bit(i)];
+
+  return result;
+}
+
+bvt boolbvt::convert_member(const member_exprt &expr)
+{
+  const bvt &compound_bv = convert_bv(expr.compound());
+
+  if(expr.compound().type().id() == ID_struct_tag)
+    return convert_member_struct(
+      expr,
+      compound_bv,
+      [this](const typet &t) { return boolbv_width(t); },
+      ns);
+  else
+  {
+    PRECONDITION(expr.compound().type().id() == ID_union_tag);
+    return convert_member_union(expr, compound_bv, *this, ns);
+  }
 }

--- a/src/solvers/flattening/boolbv_union.cpp
+++ b/src/solvers/flattening/boolbv_union.cpp
@@ -8,9 +8,6 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "boolbv.h"
 
-#include <util/arith_tools.h>
-#include <util/config.h>
-
 bvt boolbvt::convert_union(const union_exprt &expr)
 {
   std::size_t width=boolbv_width(expr.type());
@@ -28,31 +25,15 @@ bvt boolbvt::convert_union(const union_exprt &expr)
   bvt bv;
   bv.resize(width);
 
-  if(config.ansi_c.endianness==configt::ansi_ct::endiannesst::IS_LITTLE_ENDIAN)
-  {
-    for(std::size_t i=0; i<op_bv.size(); i++)
-      bv[i]=op_bv[i];
+  endianness_mapt map_u = endianness_map(expr.type());
+  endianness_mapt map_op = endianness_map(expr.op().type());
 
-    // pad with nondets
-    for(std::size_t i=op_bv.size(); i<bv.size(); i++)
-      bv[i]=prop.new_variable();
-  }
-  else
-  {
-    INVARIANT(
-      config.ansi_c.endianness == configt::ansi_ct::endiannesst::IS_BIG_ENDIAN,
-      "endianness should be set to either little endian or big endian");
+  for(std::size_t i = 0; i < op_bv.size(); i++)
+    bv[map_u.map_bit(i)] = op_bv[map_op.map_bit(i)];
 
-    endianness_mapt map_u = endianness_map(expr.type(), false);
-    endianness_mapt map_op = endianness_map(expr.op().type(), false);
-
-    for(std::size_t i=0; i<op_bv.size(); i++)
-      bv[map_u.map_bit(i)]=op_bv[map_op.map_bit(i)];
-
-    // pad with nondets
-    for(std::size_t i=op_bv.size(); i<bv.size(); i++)
-      bv[map_u.map_bit(i)]=prop.new_variable();
-  }
+  // pad with nondets
+  for(std::size_t i = op_bv.size(); i < bv.size(); i++)
+    bv[map_u.map_bit(i)] = prop.new_variable();
 
   return bv;
 }

--- a/src/solvers/flattening/boolbv_with.cpp
+++ b/src/solvers/flattening/boolbv_with.cpp
@@ -10,7 +10,6 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <util/arith_tools.h>
 #include <util/c_types.h>
-#include <util/config.h>
 #include <util/std_expr.h>
 #include <util/std_types.h>
 
@@ -237,20 +236,9 @@ void boolbvt::convert_with_union(
     "convert_with_union: unexpected operand op2 width",
     irep_pretty_diagnosticst{type});
 
-  if(config.ansi_c.endianness==configt::ansi_ct::endiannesst::IS_LITTLE_ENDIAN)
-  {
-    for(std::size_t i=0; i<op2_bv.size(); i++)
-      next_bv[i]=op2_bv[i];
-  }
-  else
-  {
-    assert(
-      config.ansi_c.endianness==configt::ansi_ct::endiannesst::IS_BIG_ENDIAN);
+  endianness_mapt map_u = endianness_map(type);
+  endianness_mapt map_op2 = endianness_map(op2.type());
 
-    endianness_mapt map_u = endianness_map(type, false);
-    endianness_mapt map_op2 = endianness_map(op2.type(), false);
-
-    for(std::size_t i=0; i<op2_bv.size(); i++)
-      next_bv[map_u.map_bit(i)]=op2_bv[map_op2.map_bit(i)];
-  }
+  for(std::size_t i = 0; i < op2_bv.size(); i++)
+    next_bv[map_u.map_bit(i)] = op2_bv[map_op2.map_bit(i)];
 }


### PR DESCRIPTION
Avoid special-casing little endianness, and use endianness map for union
member access.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
