### PR TITLE
fixup! Assignment side effects may require additional temporaries

### DIFF
--- a/regression/cbmc/Sideeffects8/main.c
+++ b/regression/cbmc/Sideeffects8/main.c
@@ -6,13 +6,30 @@ struct A
   struct A *p;
 };
 
+struct A *return_null()
+{
+  return NULL;
+}
+
 int main(void)
 {
   struct A x = {&x};
   struct A *r = x.p->p = NULL;
   assert(r == NULL);
 
+  struct A x2 = {&x2};
+  r = x2.p->p = return_null();
+  assert(r == NULL);
+
   struct A arr[2] = {arr, 0};
   r = arr[0].p->p += 1;
   assert(r == &arr[1]);
+
+  struct A arr2[2] = {arr2, 0};
+  r = ++(arr2[0].p->p);
+  assert(r == &arr2[1]);
+
+  struct A arr3[2] = {arr3, 0};
+  r = (arr3[0].p->p)++;
+  assert(r == &arr3[0]);
 }

--- a/src/goto-programs/goto_clean_expr.cpp
+++ b/src/goto-programs/goto_clean_expr.cpp
@@ -374,6 +374,16 @@ void goto_convertt::clean_expr(
         clean_expr(side_effect_assign.lhs(), dest, mode);
         exprt lhs = side_effect_assign.lhs();
 
+        const bool must_use_rhs = needs_cleaning(lhs);
+        if(must_use_rhs)
+        {
+          remove_function_call(
+            to_side_effect_expr_function_call(side_effect_assign.rhs()),
+            dest,
+            mode,
+            true);
+        }
+
         // turn into code
         code_assignt assignment;
         assignment.lhs()=lhs;
@@ -382,7 +392,7 @@ void goto_convertt::clean_expr(
         convert_assign(assignment, dest, mode);
 
         if(result_is_used)
-          expr.swap(lhs);
+          expr = must_use_rhs ? side_effect_assign.rhs() : lhs;
         else
           expr.make_nil();
         return;

--- a/src/goto-programs/goto_convert_class.h
+++ b/src/goto-programs/goto_convert_class.h
@@ -114,6 +114,7 @@ protected:
     side_effect_exprt &expr,
     goto_programt &dest,
     bool result_is_used,
+    bool address_taken,
     const irep_idt &mode);
   void remove_post(
     side_effect_exprt &expr,


### PR DESCRIPTION
The fixes in #5858 addressed the problem of assignments having side
effects, but did not consider function calls or pre-increment/decrement,
which eventually also yield assignments, and thus may have similar side
effects.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
