### PR TITLE
introduce instructiont::assign_lhs() and assign_rhs()

### DIFF
--- a/jbmc/src/java_bytecode/remove_java_new.cpp
+++ b/jbmc/src/java_bytecode/remove_java_new.cpp
@@ -365,14 +365,12 @@ goto_programt::targett remove_java_newt::lower_java_new(
   if(!target->is_assign())
     return target;
 
-  if(as_const(*target).get_assign().rhs().id() == ID_side_effect)
+  if(as_const(*target).assign_rhs().id() == ID_side_effect)
   {
     // we make a copy, as we intend to destroy the assignment
     // inside lower_java_new and lower_java_new_array
-    const auto code_assign = target->get_assign();
-
-    const exprt &lhs = code_assign.lhs();
-    const exprt &rhs = code_assign.rhs();
+    exprt lhs = target->assign_lhs();
+    exprt rhs = target->assign_rhs();
 
     const auto &side_effect_expr = to_side_effect_expr(rhs);
     const auto &statement = side_effect_expr.get_statement();

--- a/src/analyses/constant_propagator.cpp
+++ b/src/analyses/constant_propagator.cpp
@@ -162,9 +162,8 @@ void constant_propagator_domaint::transform(
   }
   else if(from->is_assign())
   {
-    const auto &assignment = from->get_assign();
-    const exprt &lhs=assignment.lhs();
-    const exprt &rhs=assignment.rhs();
+    const exprt &lhs = from->assign_lhs();
+    const exprt &rhs = from->assign_rhs();
     assign_rec(values, lhs, rhs, ns, cp, true);
   }
   else if(from->is_assume())
@@ -768,14 +767,12 @@ void constant_propagator_ait::replace(
     }
     else if(it->is_assign())
     {
-      auto assign = it->get_assign();
-      exprt &rhs = assign.rhs();
+      exprt &rhs = it->assign_rhs_nonconst();
 
       if(!constant_propagator_domaint::partial_evaluate(d.values, rhs, ns))
       {
         if(rhs.id() == ID_constant)
-          rhs.add_source_location() = assign.lhs().source_location();
-        it->set_assign(assign);
+          rhs.add_source_location() = it->assign_lhs().source_location();
       }
     }
     else if(it->is_function_call())

--- a/src/goto-analyzer/static_simplifier.cpp
+++ b/src/goto-analyzer/static_simplifier.cpp
@@ -107,26 +107,21 @@ bool static_simplifier(
       }
       else if(i_it->is_assign())
       {
-        auto assign = i_it->get_assign();
-
         // Simplification needs to be aware of which side of the
         // expression it is handling as:
         // <i=0, j=1>  i=j
         // should simplify to i=1, not to 0=1.
 
-        bool unchanged_lhs =
-          ai.abstract_state_before(i_it)->ai_simplify_lhs(assign.lhs(), ns);
+        bool unchanged_lhs = ai.abstract_state_before(i_it)->ai_simplify_lhs(
+          i_it->assign_lhs_nonconst(), ns);
 
-        bool unchanged_rhs =
-          ai.abstract_state_before(i_it)->ai_simplify(assign.rhs(), ns);
+        bool unchanged_rhs = ai.abstract_state_before(i_it)->ai_simplify(
+          i_it->assign_rhs_nonconst(), ns);
 
         if(unchanged_lhs && unchanged_rhs)
           unmodified.assigns++;
         else
-        {
           simplified.assigns++;
-          i_it->set_assign(assign);
-        }
       }
       else if(i_it->is_function_call())
       {

--- a/src/goto-instrument/accelerate/accelerate.cpp
+++ b/src/goto-instrument/accelerate/accelerate.cpp
@@ -365,7 +365,7 @@ void acceleratet::add_dirty_checks()
     // variables is clean _before_ clearing any dirty flags.
     if(it->is_assign())
     {
-      const exprt &lhs = it->get_assign().lhs();
+      const exprt &lhs = it->assign_lhs();
       expr_mapt::iterator dirty_var=dirty_vars_map.find(lhs);
 
       if(dirty_var!=dirty_vars_map.end())
@@ -385,7 +385,7 @@ void acceleratet::add_dirty_checks()
 
     if(it->is_assign())
     {
-      find_symbols_or_nexts(it->get_assign().rhs(), read);
+      find_symbols_or_nexts(it->assign_rhs(), read);
     }
 
     for(find_symbols_sett::iterator jt=read.begin();

--- a/src/goto-instrument/accelerate/acceleration_utils.cpp
+++ b/src/goto-instrument/accelerate/acceleration_utils.cpp
@@ -905,8 +905,8 @@ bool acceleration_utilst::do_nonrecursive(
   {
     if(it->is_assign())
     {
-      exprt lhs = it->get_assign().lhs();
-      exprt rhs = it->get_assign().rhs();
+      exprt lhs = it->assign_lhs();
+      exprt rhs = it->assign_rhs();
 
       if(lhs.id()==ID_dereference)
       {

--- a/src/goto-instrument/code_contracts.cpp
+++ b/src/goto-instrument/code_contracts.cpp
@@ -534,7 +534,7 @@ void code_contractst::instrument_assign_statement(
     "The first instruction of instrument_assign_statement should always be"
     " an assignment");
 
-  const exprt &lhs = instruction_iterator->get_assign().lhs();
+  const exprt &lhs = instruction_iterator->assign_lhs();
 
   goto_programt alias_assertion;
   alias_assertion.add(goto_programt::make_assertion(
@@ -573,7 +573,7 @@ void code_contractst::instrument_call_statement(
     local_instruction_iterator++;
     if(local_instruction_iterator->is_assign())
     {
-      const exprt &rhs = local_instruction_iterator->get_assign().rhs();
+      const exprt &rhs = local_instruction_iterator->assign_rhs();
       INVARIANT(
         rhs.id() == ID_typecast,
         "malloc is called but the result is not cast. Excluding result from "

--- a/src/goto-instrument/concurrency.cpp
+++ b/src/goto-instrument/concurrency.cpp
@@ -108,8 +108,7 @@ void concurrency_instrumentationt::instrument(
   {
     if(it->is_assign())
     {
-      code_assignt &code = to_code_assign(it->code_nonconst());
-      instrument(code.rhs());
+      instrument(it->assign_rhs_nonconst());
     }
     else if(it->is_assume() || it->is_assert() || it->is_goto())
     {

--- a/src/goto-instrument/count_eloc.cpp
+++ b/src/goto-instrument/count_eloc.cpp
@@ -173,9 +173,8 @@ void print_global_state_size(const goto_modelt &goto_model)
     {
       if(ins.is_assign())
       {
-        const code_assignt &code_assign = ins.get_assign();
         object_descriptor_exprt ode;
-        ode.build(code_assign.lhs(), ns);
+        ode.build(ins.assign_lhs(), ns);
 
         if(ode.root_object().id() == ID_symbol)
         {

--- a/src/goto-instrument/nondet_volatile.cpp
+++ b/src/goto-instrument/nondet_volatile.cpp
@@ -228,15 +228,9 @@ void nondet_volatilet::nondet_volatile(
     if(instruction.is_assign())
     {
       nondet_volatile_rhs(
-        symbol_table,
-        to_code_assign(instruction.code_nonconst()).rhs(),
-        pre,
-        post);
+        symbol_table, instruction.assign_rhs_nonconst(), pre, post);
       nondet_volatile_lhs(
-        symbol_table,
-        to_code_assign(instruction.code_nonconst()).lhs(),
-        pre,
-        post);
+        symbol_table, instruction.assign_lhs_nonconst(), pre, post);
     }
     else if(instruction.is_function_call())
     {

--- a/src/goto-instrument/replace_calls.cpp
+++ b/src/goto-instrument/replace_calls.cpp
@@ -100,8 +100,7 @@ void replace_callst::operator()(
       goto_programt::const_targett next_it = std::next(it);
       if(next_it != goto_program.instructions.end() && next_it->is_assign())
       {
-        const code_assignt &ca = next_it->get_assign();
-        const exprt &rhs = ca.rhs();
+        const exprt &rhs = next_it->assign_rhs();
 
         INVARIANT(
           rhs != return_value_symbol(id, ns),

--- a/src/goto-instrument/rw_set.cpp
+++ b/src/goto-instrument/rw_set.cpp
@@ -47,8 +47,7 @@ void _rw_set_loct::compute()
 {
   if(target->is_assign())
   {
-    const auto &assignment = target->get_assign();
-    assign(assignment.lhs(), assignment.rhs());
+    assign(target->assign_lhs(), target->assign_rhs());
   }
   else if(target->is_goto() ||
           target->is_assume() ||

--- a/src/goto-programs/goto_program.cpp
+++ b/src/goto-programs/goto_program.cpp
@@ -295,12 +295,9 @@ std::list<exprt> expressions_read(
   }
 
   case ASSIGN:
-  {
-    const code_assignt &assignment = instruction.get_assign();
-    dest.push_back(assignment.rhs());
-    parse_lhs_read(assignment.lhs(), dest);
+    dest.push_back(instruction.assign_rhs());
+    parse_lhs_read(instruction.assign_lhs(), dest);
     break;
-  }
 
   case CATCH:
   case THROW:
@@ -339,7 +336,7 @@ std::list<exprt> expressions_written(
     break;
 
   case ASSIGN:
-    dest.push_back(instruction.get_assign().lhs());
+    dest.push_back(instruction.assign_lhs());
     break;
 
   case CATCH:
@@ -931,15 +928,12 @@ void goto_programt::instructiont::transform(
 
   case ASSIGN:
   {
-    auto new_assign_lhs = f(get_assign().lhs());
-    auto new_assign_rhs = f(get_assign().rhs());
-    if(new_assign_lhs.has_value() || new_assign_rhs.has_value())
-    {
-      auto new_assignment = get_assign();
-      new_assignment.lhs() = new_assign_lhs.value_or(new_assignment.lhs());
-      new_assignment.rhs() = new_assign_rhs.value_or(new_assignment.rhs());
-      set_assign(new_assignment);
-    }
+    auto new_assign_lhs = f(assign_lhs());
+    auto new_assign_rhs = f(assign_rhs());
+    if(new_assign_lhs.has_value())
+      assign_lhs_nonconst() = new_assign_lhs.value();
+    if(new_assign_rhs.has_value())
+      assign_rhs_nonconst() = new_assign_rhs.value();
   }
   break;
 
@@ -1031,8 +1025,8 @@ void goto_programt::instructiont::apply(
     break;
 
   case ASSIGN:
-    f(get_assign().lhs());
-    f(get_assign().rhs());
+    f(assign_lhs());
+    f(assign_rhs());
     break;
 
   case DECL:

--- a/src/goto-programs/goto_program.h
+++ b/src/goto-programs/goto_program.h
@@ -194,13 +194,43 @@ public:
     }
 
     /// Get the assignment for ASSIGN
+    DEPRECATED(SINCE(2021, 2, 24, "Use assign_lhs/rhs instead"))
     const code_assignt &get_assign() const
     {
       PRECONDITION(is_assign());
       return to_code_assign(code);
     }
 
+    /// Get the lhs of the assignment for ASSIGN
+    const exprt &assign_lhs() const
+    {
+      PRECONDITION(is_assign());
+      return to_code_assign(code).lhs();
+    }
+
+    /// Get the lhs of the assignment for ASSIGN
+    exprt &assign_lhs_nonconst()
+    {
+      PRECONDITION(is_assign());
+      return to_code_assign(code).lhs();
+    }
+
+    /// Get the rhs of the assignment for ASSIGN
+    const exprt &assign_rhs() const
+    {
+      PRECONDITION(is_assign());
+      return to_code_assign(code).rhs();
+    }
+
+    /// Get the rhs of the assignment for ASSIGN
+    exprt &assign_rhs_nonconst()
+    {
+      PRECONDITION(is_assign());
+      return to_code_assign(code).rhs();
+    }
+
     /// Set the assignment for ASSIGN
+    DEPRECATED(SINCE(2021, 2, 24, "Use assign_lhs/rhs instead"))
     void set_assign(code_assignt c)
     {
       PRECONDITION(is_assign());

--- a/src/goto-programs/graphml_witness.cpp
+++ b/src/goto-programs/graphml_witness.cpp
@@ -231,9 +231,9 @@ static bool filter_out(
   goto_tracet::stepst::const_iterator &it)
 {
   if(
-    it->hidden && (!it->pc->is_assign() ||
-                   it->pc->get_assign().rhs().id() != ID_side_effect ||
-                   it->pc->get_assign().rhs().get(ID_statement) != ID_nondet))
+    it->hidden &&
+    (!it->pc->is_assign() || it->pc->assign_rhs().id() != ID_side_effect ||
+     it->pc->assign_rhs().get(ID_statement) != ID_nondet))
     return true;
 
   if(!it->is_assignment() && !it->is_goto() && !it->is_assert())

--- a/src/goto-programs/mm_io.cpp
+++ b/src/goto-programs/mm_io.cpp
@@ -48,8 +48,9 @@ void mm_io(
 
     if(it->is_assign())
     {
-      auto a = it->get_assign();
-      collect_deref_expr(a.rhs(), deref_expr_r);
+      auto &a_lhs = it->assign_lhs();
+      auto &a_rhs = it->assign_rhs_nonconst();
+      collect_deref_expr(a_rhs, deref_expr_r);
 
       if(mm_io_r.is_not_nil())
       {
@@ -62,8 +63,7 @@ void mm_io(
           irep_idt identifier=to_symbol_expr(mm_io_r).get_identifier();
           auto return_value = return_value_symbol(identifier, ns);
           if_exprt if_expr(integer_address(d.pointer()), return_value, d);
-          if(!replace_expr(d, if_expr, a.rhs()))
-            it->set_assign(a);
+          replace_expr(d, if_expr, a_rhs);
 
           const typet &pt=ct.parameters()[0].type();
           const typet &st=ct.parameters()[1].type();
@@ -81,9 +81,9 @@ void mm_io(
 
       if(mm_io_w.is_not_nil())
       {
-        if(a.lhs().id()==ID_dereference)
+        if(a_lhs.id() == ID_dereference)
         {
-          const dereference_exprt &d=to_dereference_expr(a.lhs());
+          const dereference_exprt &d = to_dereference_expr(a_lhs);
           source_locationt source_location=it->source_location;
           const code_typet &ct=to_code_type(mm_io_w.type());
           const typet &pt=ct.parameters()[0].type();
@@ -95,7 +95,7 @@ void mm_io(
             mm_io_w,
             {typecast_exprt(d.pointer(), pt),
              typecast_exprt(size_opt.value(), st),
-             typecast_exprt(a.rhs(), vt)});
+             typecast_exprt(a_rhs, vt)});
           goto_function.body.insert_before_swap(it);
           *it = goto_programt::make_function_call(fc, source_location);
           it++;

--- a/src/goto-programs/remove_returns.cpp
+++ b/src/goto-programs/remove_returns.cpp
@@ -310,14 +310,15 @@ bool remove_returnst::restore_returns(
   {
     if(instruction.is_assign())
     {
-      const auto &assign = instruction.get_assign();
-
-      if(assign.lhs().id()!=ID_symbol ||
-         to_symbol_expr(assign.lhs()).get_identifier()!=rv_name_id)
+      if(
+        instruction.assign_lhs().id() != ID_symbol ||
+        to_symbol_expr(instruction.assign_lhs()).get_identifier() != rv_name_id)
+      {
         continue;
+      }
 
       // replace "fkt#return_value=x;" by "return x;"
-      const exprt rhs = assign.rhs();
+      const exprt rhs = instruction.assign_rhs();
       instruction = goto_programt::make_return(
         code_returnt(rhs), instruction.source_location);
       did_something = true;
@@ -360,14 +361,12 @@ void remove_returnst::undo_function_calls(
       if(!next->is_assign())
         continue;
 
-      const code_assignt &assign = next->get_assign();
-
       const auto rv_symbol = return_value_symbol(function_id, ns);
-      if(assign.rhs() != rv_symbol)
+      if(next->assign_rhs() != rv_symbol)
         continue;
 
       // restore the previous assignment
-      function_call.lhs()=assign.lhs();
+      function_call.lhs() = next->assign_lhs();
 
       i_it->set_function_call(function_call);
 

--- a/src/goto-programs/restrict_function_pointers.cpp
+++ b/src/goto-programs/restrict_function_pointers.cpp
@@ -414,17 +414,15 @@ function_pointer_restrictionst::get_by_name_restriction(
 
   const goto_programt::const_targett it = std::prev(location);
 
-  const code_assignt &assign = it->get_assign();
-
   INVARIANT(
-    to_symbol_expr(assign.lhs()).get_identifier() ==
+    to_symbol_expr(it->assign_lhs()).get_identifier() ==
       function_pointer_call_site.get_identifier(),
     "called function pointer must have been assigned at the previous location");
 
-  if(!can_cast_expr<symbol_exprt>(assign.rhs()))
+  if(!can_cast_expr<symbol_exprt>(it->assign_rhs()))
     return {};
 
-  const auto &rhs = to_symbol_expr(assign.rhs());
+  const auto &rhs = to_symbol_expr(it->assign_rhs());
 
   const auto restriction = by_name_restrictions.find(rhs.get_identifier());
 

--- a/src/goto-programs/slice_global_inits.cpp
+++ b/src/goto-programs/slice_global_inits.cpp
@@ -93,8 +93,8 @@ void slice_global_inits(goto_modelt &goto_model)
     {
       if(!*seen_it && instruction.is_assign())
       {
-        const code_assignt &code_assign = instruction.get_assign();
-        const irep_idt id = to_symbol_expr(code_assign.lhs()).get_identifier();
+        const irep_idt id =
+          to_symbol_expr(instruction.assign_lhs()).get_identifier();
 
         // if we are to keep the left-hand side, then we also need to keep all
         // symbols occurring in the right-hand side
@@ -103,7 +103,7 @@ void slice_global_inits(goto_modelt &goto_model)
           symbols_to_keep.find(id) != symbols_to_keep.end())
         {
           fixed_point_reached = false;
-          find_symbols(code_assign.rhs(), symbols_to_keep, true, false);
+          find_symbols(instruction.assign_rhs(), symbols_to_keep, true, false);
           *seen_it = true;
         }
       }
@@ -119,8 +119,8 @@ void slice_global_inits(goto_modelt &goto_model)
   {
     if(instruction.is_assign())
     {
-      const code_assignt &code_assign = instruction.get_assign();
-      const symbol_exprt &symbol_expr=to_symbol_expr(code_assign.lhs());
+      const symbol_exprt &symbol_expr =
+        to_symbol_expr(instruction.assign_lhs());
       const irep_idt id=symbol_expr.get_identifier();
 
       if(

--- a/src/goto-programs/string_abstraction.cpp
+++ b/src/goto-programs/string_abstraction.cpp
@@ -517,10 +517,8 @@ goto_programt::targett string_abstractiont::abstract_assign(
   goto_programt::targett target)
 {
   {
-    code_assignt assign = target->get_assign();
-
-    exprt &lhs = assign.lhs();
-    exprt &rhs = assign.rhs();
+    exprt &lhs = target->assign_lhs_nonconst();
+    exprt &rhs = target->assign_rhs_nonconst();
 
     if(has_string_macros(lhs))
     {
@@ -530,11 +528,9 @@ goto_programt::targett string_abstractiont::abstract_assign(
 
     if(has_string_macros(rhs))
       replace_string_macros(rhs, false, target->source_location);
-
-    target->set_assign(assign);
   }
 
-  const typet &type = target->get_assign().lhs().type();
+  const typet &type = target->assign_lhs().type();
 
   if(type.id() == ID_pointer || type.id() == ID_array)
     return abstract_pointer_assign(dest, target);
@@ -1110,11 +1106,9 @@ goto_programt::targett string_abstractiont::abstract_pointer_assign(
   goto_programt &dest,
   const goto_programt::targett target)
 {
-  const code_assignt &assign = target->get_assign();
-
-  const exprt &lhs = assign.lhs();
-  const exprt rhs = assign.rhs();
-  const exprt *rhsp = &(assign.rhs());
+  const exprt &lhs = target->assign_lhs();
+  const exprt rhs = target->assign_rhs();
+  const exprt *rhsp = &(target->assign_rhs());
 
   while(rhsp->id()==ID_typecast)
     rhsp = &(to_typecast_expr(*rhsp).op());
@@ -1152,10 +1146,8 @@ goto_programt::targett string_abstractiont::abstract_char_assign(
   goto_programt &dest,
   goto_programt::targett target)
 {
-  const code_assignt &assign = target->get_assign();
-
-  const exprt &lhs = assign.lhs();
-  const exprt *rhsp = &(assign.rhs());
+  const exprt &lhs = target->assign_lhs();
+  const exprt *rhsp = &(target->assign_rhs());
 
   while(rhsp->id()==ID_typecast)
     rhsp = &(to_typecast_expr(*rhsp).op());

--- a/src/goto-symex/symex_main.cpp
+++ b/src/goto-symex/symex_main.cpp
@@ -667,8 +667,7 @@ void goto_symext::execute_next_instruction(
 
   case ASSIGN:
     if(state.reachable)
-      symex_assign(
-        state, instruction.get_assign().lhs(), instruction.get_assign().rhs());
+      symex_assign(state, instruction.assign_lhs(), instruction.assign_rhs());
 
     symex_transition(state);
     break;

--- a/src/pointer-analysis/goto_program_dereference.cpp
+++ b/src/pointer-analysis/goto_program_dereference.cpp
@@ -208,10 +208,8 @@ void goto_program_dereferencet::dereference_instruction(
 
   if(i.is_assign())
   {
-    auto assignment = i.get_assign();
-    dereference_expr(assignment.lhs(), checks_only);
-    dereference_expr(assignment.rhs(), checks_only);
-    i.set_assign(assignment);
+    dereference_expr(i.assign_lhs_nonconst(), checks_only);
+    dereference_expr(i.assign_rhs_nonconst(), checks_only);
   }
   else if(i.is_function_call())
   {

--- a/unit/goto-programs/label_function_pointer_call_sites.cpp
+++ b/unit/goto-programs/label_function_pointer_call_sites.cpp
@@ -68,10 +68,9 @@ TEST_CASE("Label function pointer call sites", "[core]")
         REQUIRE(fp_symbol == "h.function_pointer_call.2");
 
         auto it_prev = std::prev(it);
-        const auto &assign = it_prev->get_assign();
 
-        const auto &lhs = assign.lhs();
-        const auto &rhs = assign.rhs();
+        const auto &lhs = it_prev->assign_lhs();
+        const auto &rhs = it_prev->assign_rhs();
 
         REQUIRE(
           to_symbol_expr(lhs).get_identifier() == "h.function_pointer_call.2");


### PR DESCRIPTION
This mirrors the change in #5861 by replacing the use of `code_assignt` by
directly returning the lhs and rhs expressions.  The client code is
simplified.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- [X] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
