### PR TITLE
dump-c: fix output of _Bool-typed constants

### DIFF
--- a/regression/goto-instrument/dump-bool/main.c
+++ b/regression/goto-instrument/dump-bool/main.c
@@ -1,0 +1,8 @@
+#include <assert.h>
+
+int main()
+{
+  _Bool v;
+  v = 1;
+  assert(v == 1);
+}

--- a/regression/goto-instrument/dump-bool/test.desc
+++ b/regression/goto-instrument/dump-bool/test.desc
@@ -1,0 +1,12 @@
+CORE
+main.c
+--dump-c
+VERIFICATION SUCCESSFUL
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--
+Dump-c previously always generated 0 for _Bool or __CPROVER_bool-typed
+constants. This test ensures that the value "1" (in v = 1) is correctly
+generated, instead of a spurious (v = (__CPROVER_bool)0).

--- a/regression/goto-instrument/dump-union2/main.c
+++ b/regression/goto-instrument/dump-union2/main.c
@@ -12,6 +12,7 @@ union U10 {
 };
 
 union U10 g_2110 = {.f0 = 53747};
+union U10 g_1256 = {-6L};
 
 union U6 {
   signed f0 : 3;

--- a/src/goto-instrument/dump_c.cpp
+++ b/src/goto-instrument/dump_c.cpp
@@ -1469,11 +1469,18 @@ void dump_ct::cleanup_expr(exprt &expr)
       }
     }
 
+    optionalt<exprt> clean_init;
     if(
       ns.follow(bu.type()).id() == ID_union &&
-      bu.source_location().get_function().empty() &&
-      bu.op() == zero_initializer(bu.op().type(), source_locationt{}, ns)
-                   .value_or(nil_exprt{}))
+      bu.source_location().get_function().empty())
+    {
+      clean_init = zero_initializer(bu.op().type(), source_locationt{}, ns)
+                     .value_or(nil_exprt{});
+      if(clean_init->id() != ID_struct || clean_init->has_operands())
+        cleanup_expr(*clean_init);
+    }
+
+    if(clean_init.has_value() && bu.op() == *clean_init)
     {
       const union_typet &union_type = to_union_type(ns.follow(bu.type()));
 

--- a/src/goto-instrument/dump_c_class.h
+++ b/src/goto-instrument/dump_c_class.h
@@ -14,10 +14,6 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <set>
 #include <string>
-#include <memory> // unique_ptr
-
-#include <langapi/language.h>
-#include <langapi/mode.h>
 
 #include <goto-programs/system_library_symbols.h>
 
@@ -116,13 +112,13 @@ public:
     const bool use_all_headers,
     const bool include_harness,
     const namespacet &_ns,
-    language_factoryt factory,
+    const irep_idt &mode,
     const dump_c_configurationt config)
     : goto_functions(_goto_functions),
       copied_symbol_table(_ns.get_symbol_table()),
       ns(copied_symbol_table),
       dump_c_config(config),
-      language(factory()),
+      mode(mode),
       harness(include_harness),
       system_symbols(use_system_headers)
   {
@@ -135,14 +131,14 @@ public:
     const bool use_all_headers,
     const bool include_harness,
     const namespacet &_ns,
-    language_factoryt factory)
+    const irep_idt &mode)
     : dump_ct(
         _goto_functions,
         use_system_headers,
         use_all_headers,
         include_harness,
         _ns,
-        factory,
+        mode,
         dump_c_configurationt::default_configuration)
   {
   }
@@ -156,7 +152,7 @@ protected:
   symbol_tablet copied_symbol_table;
   const namespacet ns;
   const dump_c_configurationt dump_c_config;
-  std::unique_ptr<languaget> language;
+  const irep_idt mode;
   const bool harness;
 
   typedef std::unordered_set<irep_idt> convertedt;

--- a/src/goto-instrument/goto_program2code.cpp
+++ b/src/goto-instrument/goto_program2code.cpp
@@ -1893,13 +1893,19 @@ void goto_program2codet::cleanup_expr(exprt &expr, bool no_typecast)
     }
     else if(expr.type().id()==ID_pointer)
       add_local_types(expr.type());
-    else if(expr.type().id()==ID_bool ||
-            expr.type().id()==ID_c_bool)
+    else if(expr.type().id() == ID_bool)
     {
       expr = typecast_exprt(
         from_integer(
           expr.is_true() ? 1 : 0, signedbv_typet(config.ansi_c.int_width)),
         bool_typet());
+    }
+    else if(expr.type().id() == ID_c_bool)
+    {
+      expr = typecast_exprt(
+        from_integer(
+          expr.is_one() ? 1 : 0, signedbv_typet(config.ansi_c.int_width)),
+        c_bool_type());
     }
 
     const irept &c_sizeof_type=expr.find(ID_C_c_sizeof_type);

--- a/src/goto-instrument/goto_program2code.cpp
+++ b/src/goto-instrument/goto_program2code.cpp
@@ -1893,20 +1893,6 @@ void goto_program2codet::cleanup_expr(exprt &expr, bool no_typecast)
     }
     else if(expr.type().id()==ID_pointer)
       add_local_types(expr.type());
-    else if(expr.type().id() == ID_bool)
-    {
-      expr = typecast_exprt(
-        from_integer(
-          expr.is_true() ? 1 : 0, signedbv_typet(config.ansi_c.int_width)),
-        bool_typet());
-    }
-    else if(expr.type().id() == ID_c_bool)
-    {
-      expr = typecast_exprt(
-        from_integer(
-          expr.is_one() ? 1 : 0, signedbv_typet(config.ansi_c.int_width)),
-        c_bool_type());
-    }
 
     const irept &c_sizeof_type=expr.find(ID_C_c_sizeof_type);
 

--- a/src/util/expr.cpp
+++ b/src/util/expr.cpp
@@ -146,7 +146,9 @@ bool exprt::is_one() const
         CHECK_RETURN(false);
       return rat_value.is_one();
     }
-    else if(type_id==ID_unsignedbv || type_id==ID_signedbv)
+    else if(
+      type_id == ID_unsignedbv || type_id == ID_signedbv ||
+      type_id == ID_c_bool || type_id == ID_c_bit_field)
     {
       const auto width = to_bitvector_type(type()).get_width();
       mp_integer int_value =


### PR DESCRIPTION
Only __CPROVER_bool-typed constants can be used with exprt::is_true.
exprt::is_one's documentation promised that ID_c_bool was supported,
which wasn't actually the case. This commit fixes this and makes use of
is_one to fix the bug in dump-c.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
