### PR TITLE
symex: use lhs/rhs instead of code_assignt

### DIFF
--- a/src/goto-symex/auto_objects.cpp
+++ b/src/goto-symex/auto_objects.cpp
@@ -69,8 +69,7 @@ void goto_symext::initialize_auto_object(const exprt &expr, statet &state)
         null_pointer_exprt(pointer_type),
         address_of_expr);
 
-      code_assignt assignment(expr, rhs);
-      symex_assign(state, assignment);
+      symex_assign(state, expr, rhs);
     }
   }
 }

--- a/src/goto-symex/goto_symex.cpp
+++ b/src/goto-symex/goto_symex.cpp
@@ -36,10 +36,13 @@ void goto_symext::do_simplify(exprt &expr)
     simplify(expr, ns);
 }
 
-void goto_symext::symex_assign(statet &state, const code_assignt &code)
+void goto_symext::symex_assign(
+  statet &state,
+  const exprt &o_lhs,
+  const exprt &o_rhs)
 {
-  exprt lhs = clean_expr(code.lhs(), state, true);
-  exprt rhs = clean_expr(code.rhs(), state, false);
+  exprt lhs = clean_expr(o_lhs, state, true);
+  exprt rhs = clean_expr(o_rhs, state, false);
 
   DATA_INVARIANT(
     lhs.type() == rhs.type(), "assignments must be type consistent");

--- a/src/goto-symex/goto_symex.h
+++ b/src/goto-symex/goto_symex.h
@@ -508,8 +508,9 @@ protected:
   /// Symbolically execute an ASSIGN instruction or simulate such an execution
   /// for a synthetic assignment
   /// \param state: Symbolic execution state for current instruction
-  /// \param code: The assignment to execute
-  void symex_assign(statet &state, const code_assignt &code);
+  /// \param lhs: The lhs of the assignment to execute
+  /// \param rhs: The rhs of the assignment to execute
+  void symex_assign(statet &state, const exprt &lhs, const exprt &rhs);
 
   /// Attempt to constant propagate side effects of the assignment (if any)
   ///

--- a/src/goto-symex/symex_function_call.cpp
+++ b/src/goto-symex/symex_function_call.cpp
@@ -165,7 +165,7 @@ void goto_symext::parameter_assignments(
 
       state.call_stack().top().parameter_names.push_back(va_arg.name);
 
-      symex_assign(state, code_assignt{va_arg.symbol_expr(), *it1});
+      symex_assign(state, va_arg.symbol_expr(), *it1);
     }
   }
   else if(it1!=arguments.end())
@@ -287,8 +287,7 @@ void goto_symext::symex_function_call_code(
     {
       const auto rhs =
         side_effect_expr_nondett(call.lhs().type(), call.source_location());
-      code_assignt code(call.lhs(), rhs);
-      symex_assign(state, code);
+      symex_assign(state, call.lhs(), rhs);
     }
 
     if(symex_config.havoc_undefined_functions)

--- a/src/goto-symex/symex_main.cpp
+++ b/src/goto-symex/symex_main.cpp
@@ -667,7 +667,8 @@ void goto_symext::execute_next_instruction(
 
   case ASSIGN:
     if(state.reachable)
-      symex_assign(state, instruction.get_assign());
+      symex_assign(
+        state, instruction.get_assign().lhs(), instruction.get_assign().rhs());
 
     symex_transition(state);
     break;

--- a/src/goto-symex/symex_other.cpp
+++ b/src/goto-symex/symex_other.cpp
@@ -31,12 +31,10 @@ void goto_symext::havoc_rec(
       lhs=if_exprt(
         guard.as_expr(), dest, exprt(ID_null_object, dest.type()));
 
-    code_assignt assignment;
-    assignment.lhs()=lhs;
-    assignment.rhs() =
+    auto rhs =
       side_effect_expr_nondett(dest.type(), state.source.pc->source_location);
 
-    symex_assign(state, assignment);
+    symex_assign(state, lhs, rhs);
   }
   else if(dest.id()==ID_byte_extract_little_endian ||
           dest.id()==ID_byte_extract_big_endian)
@@ -167,8 +165,7 @@ void goto_symext::symex_other(
       }
     }
 
-    code_assignt assignment(dest_array, src_array);
-    symex_assign(state, assignment);
+    symex_assign(state, dest_array, src_array);
   }
   else if(statement==ID_array_set)
   {
@@ -211,8 +208,7 @@ void goto_symext::symex_other(
     if(array_type.subtype() != value.type())
       value = typecast_exprt(value, array_type.subtype());
 
-    code_assignt assignment(array_expr, array_of_exprt(value, array_type));
-    symex_assign(state, assignment);
+    symex_assign(state, array_expr, array_of_exprt(value, array_type));
   }
   else if(statement==ID_array_equal)
   {
@@ -236,13 +232,13 @@ void goto_symext::symex_other(
     process_array_expr(state, array1);
     process_array_expr(state, array2);
 
-    code_assignt assignment(code.op2(), equal_exprt(array1, array2));
+    exprt rhs = equal_exprt(array1, array2);
 
     // check for size (or type) mismatch
     if(array1.type() != array2.type())
-      assignment.rhs() = false_exprt();
+      rhs = false_exprt();
 
-    symex_assign(state, assignment);
+    symex_assign(state, code.op2(), rhs);
   }
   else if(statement==ID_user_specified_predicate ||
           statement==ID_user_specified_parameter_predicates ||


### PR DESCRIPTION
This replaces the use of `code_assignt` by an explicit lhs/rhs pair in goto
symex.  This avoids constructing the `code_assignt` in a number of places.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
