### PR TITLE
Fix bug in constant propagator

### DIFF
--- a/regression/goto-instrument/constant_propagator_unreachable/test.c
+++ b/regression/goto-instrument/constant_propagator_unreachable/test.c
@@ -1,0 +1,12 @@
+#include <assert.h>
+
+void unreachable(void)
+{
+  int x = 0;
+  assert(x != 0);
+}
+
+int main(void)
+{
+  return 0;
+}

--- a/regression/goto-instrument/constant_propagator_unreachable/test.desc
+++ b/regression/goto-instrument/constant_propagator_unreachable/test.desc
@@ -1,0 +1,11 @@
+CORE
+test.c
+--constant-propagator
+^EXIT=0$
+^SIGNAL=0$
+VERIFICATION SUCCESSFUL
+--
+failed to find state
+--
+This is testing for a previous regression that caused constant propagation to
+fail in unreachable code

--- a/src/analyses/constant_propagator.cpp
+++ b/src/analyses/constant_propagator.cpp
@@ -751,8 +751,10 @@ void constant_propagator_ait::replace(
 {
   Forall_goto_program_instructions(it, goto_function.body)
   {
-    // Works because this is a location (but not history) sensitive domain
-    const constant_propagator_domaint &d = (*this)[it];
+    auto const current_domain_ptr =
+      std::dynamic_pointer_cast<const constant_propagator_domaint>(
+        this->abstract_state_before(it));
+    const constant_propagator_domaint &d = *current_domain_ptr;
 
     if(d.is_bottom())
       continue;


### PR DESCRIPTION
Before it was using the index operator. However, since there is no
initialisation, this caused an error if there was unreachable code in
the goto model. This can be fixed by simply using abstract_state_before
which will always return a valid domain state (bottom for unreachable
code) instead.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
