### PR TITLE
Loop counter resetting must not result in unlimited unwinding

### DIFF
--- a/regression/cbmc/unwind_counters4/main.c
+++ b/regression/cbmc/unwind_counters4/main.c
@@ -1,0 +1,24 @@
+int main()
+{
+  int x;
+  int y;
+
+  do
+  {
+    y = 10;
+    goto label;
+    x = 1; // dead code, makes sure the above goto is not removed
+  label:
+    _Bool nondet;
+    if(nondet)
+      __CPROVER_assert(y != 10, "violated via first loop");
+    else
+      __CPROVER_assert(y != 20, "violated via second loop");
+
+    if(x % 2)
+      break; // this statement must not cause the loop counter to be reset
+  } while(1);
+
+  y = 20;
+  goto label;
+}

--- a/regression/cbmc/unwind_counters4/test.desc
+++ b/regression/cbmc/unwind_counters4/test.desc
@@ -1,0 +1,11 @@
+CORE
+main.c
+--unwind 2
+^EXIT=10$
+^SIGNAL=0$
+^VERIFICATION FAILED$
+^\** 2 of 2 failed
+--
+--
+Loop unwinding must terminate despite the existence of multiple loop entry
+points.

--- a/src/goto-symex/symex_main.cpp
+++ b/src/goto-symex/symex_main.cpp
@@ -97,7 +97,7 @@ void symex_transition(
     for(const auto &i_e : instruction.incoming_edges)
     {
       if(
-        i_e->is_goto() && i_e->is_backwards_goto() &&
+        i_e->is_backwards_goto() && i_e->get_target() == to &&
         (!is_backwards_goto ||
          state.source.pc->location_number > i_e->location_number))
       {


### PR DESCRIPTION
Loops with multiple entry points previously resulted in unlimited
unwinding as loop counters were wrongly being reset via edges leaving
one of the loops (and entering the other).

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
