### PR TITLE
Simplify overflow-* expressions

### DIFF
--- a/regression/ansi-c/simplify-overflow/main.c
+++ b/regression/ansi-c/simplify-overflow/main.c
@@ -1,0 +1,14 @@
+#ifdef _MSC_VER
+#  define _Static_assert static_assert
+#endif
+
+int main()
+{
+  _Static_assert(!__CPROVER_overflow_plus(1, 2), "");
+  _Static_assert(__CPROVER_overflow_minus(1U, 2U), "");
+  _Static_assert(__CPROVER_overflow_minus(0U, 2U), "");
+  _Static_assert(!__CPROVER_overflow_mult(1U, 2U), "");
+  _Static_assert(!__CPROVER_overflow_shl(1, 2), "");
+  _Static_assert(!__CPROVER_overflow_unary_minus(1), "");
+  _Static_assert(__CPROVER_overflow_unary_minus(1U), "");
+}

--- a/regression/ansi-c/simplify-overflow/test.desc
+++ b/regression/ansi-c/simplify-overflow/test.desc
@@ -1,0 +1,7 @@
+CORE
+main.c
+
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring

--- a/src/util/simplify_expr_class.h
+++ b/src/util/simplify_expr_class.h
@@ -185,6 +185,16 @@ public:
   NODISCARD resultt<> simplify_popcount(const popcount_exprt &);
   NODISCARD resultt<> simplify_complex(const unary_exprt &);
 
+  /// Try to simplify overflow-+, overflow-*, overflow--, overflow-shl.
+  /// Simplification will be possible when the operands are constants or the
+  /// types of the operands have infinite domains.
+  NODISCARD resultt<> simplify_overflow_binary(const binary_exprt &);
+
+  /// Try to simplify overflow-unary-.
+  /// Simplification will be possible when the operand is constants or the
+  /// type of the operand has an infinite domain.
+  NODISCARD resultt<> simplify_overflow_unary(const unary_exprt &);
+
   /// Attempt to simplify mathematical function applications if we have
   /// enough information to do so. Currently focused on constant comparisons.
   NODISCARD resultt<>


### PR DESCRIPTION
We can simplify these over constants and for some trivial cases when
mathematical types are used.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
