### PR TITLE
Simplify byte-extract from struct or union expressions

### DIFF
--- a/regression/cbmc/simplify-union/main.c
+++ b/regression/cbmc/simplify-union/main.c
@@ -1,0 +1,49 @@
+#include <assert.h>
+#include <stdlib.h>
+
+struct O
+{
+  char *ptr;
+  unsigned len;
+};
+
+struct E
+{
+  int e;
+};
+
+union U {
+  struct O ok;
+  struct E err;
+};
+
+struct S
+{
+  union U u;
+  _Bool success;
+};
+
+void alloc(struct S *s, unsigned size)
+{
+  char *p = malloc(sizeof(char) * size);
+  if(p != 0)
+  {
+    s->u.ok = (struct O){p, size};
+    s->success = 1;
+  }
+  else
+  {
+    s->success = 0;
+  }
+}
+
+int main()
+{
+  struct S s;
+  alloc(&s, 2);
+  if(s.success)
+  {
+    assert(s.u.ok.len == 2);
+    s.u.ok.ptr = "a";
+  }
+}

--- a/regression/cbmc/simplify-union/test.desc
+++ b/regression/cbmc/simplify-union/test.desc
@@ -1,0 +1,11 @@
+CORE
+main.c
+
+^Generated 1 VCC\(s\), 0 remaining after simplification$
+^VERIFICATION SUCCESSFUL$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--
+The len member should constant propagate with the help of simplification.

--- a/scripts/expected_doxygen_warnings.txt
+++ b/scripts/expected_doxygen_warnings.txt
@@ -7,7 +7,7 @@ warning: Included by graph for 'invariant.h' not generated, too many nodes (172)
 warning: Included by graph for 'irep.h' not generated, too many nodes (80), threshold is 60. Consider increasing DOT_GRAPH_MAX_NODES.
 warning: Included by graph for 'message.h' not generated, too many nodes (97), threshold is 60. Consider increasing DOT_GRAPH_MAX_NODES.
 warning: Included by graph for 'namespace.h' not generated, too many nodes (88), threshold is 60. Consider increasing DOT_GRAPH_MAX_NODES.
-warning: Included by graph for 'pointer_expr.h' not generated, too many nodes (121), threshold is 60. Consider increasing DOT_GRAPH_MAX_NODES.
+warning: Included by graph for 'pointer_expr.h' not generated, too many nodes (122), threshold is 60. Consider increasing DOT_GRAPH_MAX_NODES.
 warning: Included by graph for 'prefix.h' not generated, too many nodes (62), threshold is 60. Consider increasing DOT_GRAPH_MAX_NODES.
 warning: Included by graph for 'simplify_expr.h' not generated, too many nodes (67), threshold is 60. Consider increasing DOT_GRAPH_MAX_NODES.
 warning: Included by graph for 'std_code.h' not generated, too many nodes (71), threshold is 60. Consider increasing DOT_GRAPH_MAX_NODES.

--- a/src/pointer-analysis/value_set.cpp
+++ b/src/pointer-analysis/value_set.cpp
@@ -784,6 +784,11 @@ void value_sett::get_value_set_rec(
         get_value_set_rec(*it, dest, suffix, original_type, ns);
     }
   }
+  else if(expr.id() == ID_union)
+  {
+    get_value_set_rec(
+      to_union_expr(expr).op(), dest, suffix, original_type, ns);
+  }
   else if(expr.id()==ID_with)
   {
     const with_exprt &with_expr = to_with_expr(expr);


### PR DESCRIPTION
With rewrite_union introducing rewriting union accesses to byte-extract
operations, simplifying such expressions must cover as many cases as
possible. Constants were mostly already being rewritten via expr2bits,
but that wouldn't be able to handle expressions involving pointers (even
when they are effectively constants when using address-of operations).
The additional simplification rules mimic what lower_byte_extract
already did at a later stage, but such late rewrites would not benefit
constant propagation done by goto-symex.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
