### PR TITLE
Value set dereferencing: do not treat struct prefixes as equal

### DIFF
--- a/jbmc/regression/jbmc/simplify-classid-of-interface/test_no_simplify_vccs.desc
+++ b/jbmc/regression/jbmc/simplify-classid-of-interface/test_no_simplify_vccs.desc
@@ -3,9 +3,13 @@ Test
 --function Test.main --no-simplify --unwind 10 --show-vcc -cp target/classes
 ^EXIT=0$
 ^SIGNAL=0$
-"java::Impl1" = cast\(\{ \{ "java::Impl1" \}, 0 \}, struct (\{ struct \{ string @class_identifier \} @java.lang.Object \}|java::Intf)\)\.@java.lang.Object\.@class_identifier
+"java::Impl1" = byte_extract_little_endian\(\{ \{ "java::Impl1" \}, 0 \}, 0, struct java::Intf\)\.@java.lang.Object\.@class_identifier
 --
 ^warning: ignoring
 --
 This checks that the test generates the VCC testing the class-id that we're
-intending to simplify away in the main test.
+intending to simplify away in the main test. Following the removal of the
+struct-prefix shortcut from value_set_dereferencet::dereference_type_compare
+the encoding of the Intf/Impl1 cast in the VCC is via byte_extract_little_endian
+rather than a struct-to-struct cast (which boolbvt::conversion_failed would
+silently drop with a "warning: ignoring").

--- a/regression/cbmc/struct-prefix-deref1/main.c
+++ b/regression/cbmc/struct-prefix-deref1/main.c
@@ -1,0 +1,28 @@
+// Test that value set dereferencing correctly handles the case where a
+// pointer to a smaller struct is used to access an object of a larger
+// struct type (struct prefix relationship). The removed struct-prefix
+// check in dereference_type_compare would have produced a direct cast
+// (and a "warning: ignoring" from the solver); now it correctly uses
+// byte_extract instead.
+
+#include <assert.h>
+
+struct small
+{
+  int x;
+};
+
+struct big
+{
+  int x;
+  int y;
+};
+
+int main()
+{
+  struct big b = {1, 2};
+  void *v = &b;
+  struct small *p = (struct small *)v;
+  assert(p->x == 1);
+  return 0;
+}

--- a/regression/cbmc/struct-prefix-deref1/vcc.desc
+++ b/regression/cbmc/struct-prefix-deref1/vcc.desc
@@ -1,0 +1,17 @@
+CORE
+main.c
+--no-simplify --show-vcc
+^EXIT=0$
+^SIGNAL=0$
+byte_extract_little_endian\(\{ 1, 2 \}, 0, struct tag-small\)\.x = 1
+--
+^warning: ignoring
+--
+Pin that with the struct-prefix shortcut removed from
+value_set_dereferencet::dereference_type_compare, the assertion VCC
+for `p->x == 1` is encoded via byte_extract_little_endian rather
+than a struct-to-struct typecast (which boolbvt::conversion_failed
+would silently drop with a "warning: ignoring"). --no-simplify keeps
+the SSA shape from being folded away before --show-vcc dumps it. A
+future revert of the fix would restore the typecast encoding and
+this regex would no longer match.

--- a/regression/cbmc/struct2/main.c
+++ b/regression/cbmc/struct2/main.c
@@ -1,0 +1,24 @@
+struct T
+{
+  // intentionally empty to trigger struct-prefix handling in the analysis
+  // (empty structs are a GCC-only feature)
+};
+
+struct S
+{
+  struct T t;
+  int other;
+};
+
+void foo(struct S s2)
+{
+  struct T *p = &s2.t;
+  struct T t2 = *p;
+  __CPROVER_assert(0, "");
+}
+
+int main()
+{
+  struct S s;
+  foo(s);
+}

--- a/regression/cbmc/struct2/test.desc
+++ b/regression/cbmc/struct2/test.desc
@@ -1,0 +1,11 @@
+CORE gcc-only no-new-smt
+main.c
+
+^VERIFICATION FAILED$
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring
+--
+This test must not generate a warning about typecasts (between different struct
+types) being ignored.

--- a/src/cprover/may_alias.cpp
+++ b/src/cprover/may_alias.cpp
@@ -71,7 +71,35 @@ bool is_object_field_element(const exprt &expr)
     return false;
 }
 
-bool prefix_of(const typet &a, const typet &b, const namespacet &ns)
+/// Returns true if struct \p a is a prefix of \p b, i.e., if struct \p a has
+/// n components then the component types and names of struct \p a must match
+/// the first n components of \p b.
+/// \param a: Struct type that may be a prefix.
+/// \param b: Struct type to compare with.
+static bool struct_is_prefix_of(const struct_typet &a, const struct_typet &b)
+{
+  const struct_typet::componentst &b_components = b.components();
+  const struct_typet::componentst &a_components = a.components();
+
+  if(b_components.size() < a_components.size())
+    return false;
+
+  struct_typet::componentst::const_iterator b_it = b_components.begin();
+
+  for(const auto &a_c : a_components)
+  {
+    if(b_it->type() != a_c.type() || b_it->get_name() != a_c.get_name())
+    {
+      return false; // they just don't match
+    }
+
+    b_it++;
+  }
+
+  return true; // ok, a is a prefix of b
+}
+
+static bool prefix_of(const typet &a, const typet &b, const namespacet &ns)
 {
   if(a == b)
     return true;
@@ -88,7 +116,8 @@ bool prefix_of(const typet &a, const typet &b, const namespacet &ns)
   const auto &a_struct = to_struct_type(a);
   const auto &b_struct = to_struct_type(b);
 
-  return a_struct.is_prefix_of(b_struct) || b_struct.is_prefix_of(a_struct);
+  return struct_is_prefix_of(a_struct, b_struct) ||
+         struct_is_prefix_of(b_struct, a_struct);
 }
 
 static std::optional<object_address_exprt> find_object(const exprt &expr)

--- a/src/pointer-analysis/value_set_dereference.cpp
+++ b/src/pointer-analysis/value_set_dereference.cpp
@@ -372,22 +372,6 @@ bool value_set_dereferencet::dereference_type_compare(
   if(object_type == dereference_type)
     return true; // ok, they just match
 
-  // check for struct prefixes
-  const typet &ot_base = object_type.id() == ID_struct_tag
-                           ? ns.follow_tag(to_struct_tag_type(object_type))
-                           : object_type;
-  const typet &dt_base = dereference_type.id() == ID_struct_tag
-                           ? ns.follow_tag(to_struct_tag_type(dereference_type))
-                           : dereference_type;
-
-  if(ot_base.id()==ID_struct &&
-     dt_base.id()==ID_struct)
-  {
-    if(to_struct_type(dt_base).is_prefix_of(
-         to_struct_type(ot_base)))
-      return true; // ok, dt is a prefix of ot
-  }
-
   // we are generous about code pointers
   if(dereference_type.id()==ID_code &&
      object_type.id()==ID_code)

--- a/src/util/std_types.cpp
+++ b/src/util/std_types.cpp
@@ -112,35 +112,6 @@ struct_typet::get_base(const irep_idt &id) const
   return {};
 }
 
-/// Returns true if the struct is a prefix of \a other, i.e., if this struct
-/// has n components then the component types and names of this struct must
-/// match the first n components of \a other struct.
-/// \param other: Struct type to compare with.
-bool struct_typet::is_prefix_of(const struct_typet &other) const
-{
-  const componentst &ot_components=other.components();
-  const componentst &tt_components=components();
-
-  if(ot_components.size()<
-     tt_components.size())
-    return false;
-
-  componentst::const_iterator
-    ot_it=ot_components.begin();
-
-  for(const auto &tt_c : tt_components)
-  {
-    if(ot_it->type() != tt_c.type() || ot_it->get_name() != tt_c.get_name())
-    {
-      return false; // they just don't match
-    }
-
-    ot_it++;
-  }
-
-  return true; // ok, *this is a prefix of ot
-}
-
 /// Returns true if the type is a reference.
 bool is_reference(const typet &type)
 {

--- a/src/util/std_types.h
+++ b/src/util/std_types.h
@@ -238,8 +238,6 @@ public:
   {
   }
 
-  bool is_prefix_of(const struct_typet &other) const;
-
   /// A struct may be a class, where members may have access restrictions.
   bool is_class() const
   {


### PR DESCRIPTION
Two distinct struct types cannot be cast between, even when one is a
prefix of the other. Value set dereferencing taking this approach just
resulted in propositional encoding producing a warning about invalid
type casts.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
