### PR TITLE
Avoid spurious libgcc-s1 Debian package dependency

### DIFF
--- a/.github/workflows/pull-request-checks.yaml
+++ b/.github/workflows/pull-request-checks.yaml
@@ -375,6 +375,10 @@ jobs:
         run: | 
           sudo apt-get update
           sudo apt-get install --no-install-recommends -y g++ flex bison cmake ninja-build maven jq libxml2-utils dpkg-dev ccache
+          # remove libgcc-s1, which isn't normally available in Ubuntu 18.04
+          target=$(dpkg-query -W --showformat='${Version}\n' gcc-8-base | head -n 1)
+          # libgcc1 uses an epoch, thus the extra 1:
+          sudo apt-get install -y --allow-downgrades --reinstall gcc g++ libgcc-s1- libstdc++6=$target liblsan0=$target libtsan0=$target libcc1-0=$target libgcc1=1:$target
       - name: Prepare ccache
         uses: actions/cache@v2
         with:

--- a/.github/workflows/release-packages.yaml
+++ b/.github/workflows/release-packages.yaml
@@ -69,7 +69,12 @@ jobs:
         with:
           submodules: recursive
       - name: Fetch dependencies
-        run: sudo apt-get install --no-install-recommends -y g++ flex bison cmake ninja-build maven jq libxml2-utils dpkg-dev ccache
+        run: |
+          sudo apt-get install --no-install-recommends -y g++ flex bison cmake ninja-build maven jq libxml2-utils dpkg-dev ccache
+          # remove libgcc-s1, which isn't normally available in Ubuntu 18.04
+          target=$(dpkg-query -W --showformat='${Version}\n' gcc-8-base | head -n 1)
+          # libgcc1 uses an epoch, thus the extra 1:
+          sudo apt-get install -y --allow-downgrades --reinstall gcc g++ libgcc-s1- libstdc++6=$target liblsan0=$target libtsan0=$target libcc1-0=$target libgcc1=1:$target
       - name: Prepare ccache
         uses: actions/cache@v2
         with:

--- a/cmake/packaging.cmake
+++ b/cmake/packaging.cmake
@@ -27,6 +27,10 @@ set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS YES)
 # In addition, we depend on gcc for preprocessing
 set(CPACK_DEBIAN_PACKAGE_DEPENDS gcc)
 
+# Enable debug output so that we can see the dependencies being generated in the
+# logs
+set(CPACK_DEBIAN_PACKAGE_DEBUG YES)
+
 # For windows we need to set up product and update GUID
 # See: https://docs.microsoft.com/en-us/windows/win32/msi/productcode
 # and  https://docs.microsoft.com/en-us/windows/win32/msi/upgradecode


### PR DESCRIPTION
Marked as Draft (and do-not-merge, do-not-review), includes extra debug output.

Do not add a strict dependency on gcc, which in a GitHub container isn't
necessarily the same version as in a pristine Ubuntu system.

Fixes: #5875

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
