### PR TITLE
Include width in format() output of raw bitvector type

### DIFF
--- a/src/util/format_type.cpp
+++ b/src/util/format_type.cpp
@@ -83,6 +83,8 @@ std::ostream &format_rec(std::ostream &os, const typet &type)
     return os << "signedbv[" << to_signedbv_type(type).get_width() << ']';
   else if(id == ID_unsignedbv)
     return os << "unsignedbv[" << to_unsignedbv_type(type).get_width() << ']';
+  else if(id == ID_bv)
+    return os << "bv[" << to_bitvector_type(type).get_width() << ']';
   else if(id == ID_floatbv)
     return os << "floatbv[" << to_floatbv_type(type).get_width() << ']';
   else if(id == ID_c_bool)


### PR DESCRIPTION
ID_bv is also a bitvector type, and should thus be printed with a width,
just like signed/unsigned bv.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
