### PR TITLE
Fully simplify (in)equalities over constants+if

### DIFF
--- a/src/util/simplify_expr_int.cpp
+++ b/src/util/simplify_expr_int.cpp
@@ -1550,10 +1550,10 @@ simplify_exprt::resultt<> simplify_exprt::simplify_inequality_rhs_is_constant(
   if(expr.op0().id()==ID_if && expr.op0().operands().size()==3)
   {
     if_exprt if_expr=lift_if(expr, 0);
-    if_expr.true_case() = simplify_inequality_rhs_is_constant(
-      to_binary_relation_expr(if_expr.true_case()));
-    if_expr.false_case() = simplify_inequality_rhs_is_constant(
-      to_binary_relation_expr(if_expr.false_case()));
+    if_expr.true_case() =
+      simplify_inequality(to_binary_relation_expr(if_expr.true_case()));
+    if_expr.false_case() =
+      simplify_inequality(to_binary_relation_expr(if_expr.false_case()));
     return changed(simplify_if(if_expr));
   }
 

--- a/unit/util/simplify_expr.cpp
+++ b/unit/util/simplify_expr.cpp
@@ -516,3 +516,27 @@ TEST_CASE("Simplify bitor", "[core][util]")
     REQUIRE(simplify_expr(bitor_exprt{b, zero}, ns) == b);
   }
 }
+
+TEST_CASE("Simplify inequality", "[core][util]")
+{
+  symbol_tablet symbol_table;
+  namespacet ns(symbol_table);
+
+  {
+    // This checks that 3 < (B ? 4 : 5) simplifies to true, just like (B ? 4 :
+    // 5) > 3 simplifies to true.
+    signedbv_typet sbv{4};
+    symbol_exprt b{"B", bool_typet{}};
+    if_exprt if_b{b, from_integer(4, sbv), from_integer(5, sbv)};
+
+    binary_relation_exprt comparison_gt{if_b, ID_gt, from_integer(3, sbv)};
+    exprt simp = simplify_expr(comparison_gt, ns);
+
+    REQUIRE(simp == true_exprt{});
+
+    binary_relation_exprt comparison_lt{from_integer(3, sbv), ID_lt, if_b};
+    simp = simplify_expr(comparison_lt, ns);
+
+    REQUIRE(simp == true_exprt{});
+  }
+}


### PR DESCRIPTION
The case of constant-on-lhs together with an if-expression on the
right-hand side previously required multiple simplification passes as
the constant-on-both-sides case was not considered for this case.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
