### PR TITLE
Simplify bitor/bitxor with ID_bv-typed zero operand

### DIFF
--- a/src/util/simplify_expr_int.cpp
+++ b/src/util/simplify_expr_int.cpp
@@ -715,6 +715,14 @@ simplify_exprt::simplify_bitwise(const multi_ary_exprt &expr)
         it = new_expr.operands().erase(it);
         no_change = false;
       }
+      else if(
+        it->is_constant() && it->type().id() == ID_bv &&
+        to_constant_expr(*it).value_is_zero_string() &&
+        new_expr.operands().size() > 1)
+      {
+        it = new_expr.operands().erase(it);
+        no_change = false;
+      }
       else
         it++;
     }

--- a/unit/util/simplify_expr.cpp
+++ b/unit/util/simplify_expr.cpp
@@ -501,3 +501,18 @@ TEST_CASE("Simplifying cast expressions", "[core][util]")
     REQUIRE(simplified_expr == expr);
   }
 }
+
+TEST_CASE("Simplify bitor", "[core][util]")
+{
+  const symbol_tablet symbol_table;
+  const namespacet ns(symbol_table);
+
+  SECTION("Simplification for raw bitvector")
+  {
+    bv_typet bv{4};
+    constant_exprt zero = from_integer(0, bv);
+    symbol_exprt b{"B", bv};
+
+    REQUIRE(simplify_expr(bitor_exprt{b, zero}, ns) == b);
+  }
+}


### PR DESCRIPTION
exprt::is_zero() (on purpose) does not support ID_bv as this type is not
meant to have a numeric interpretation. As a bit-string, however, it
should be considered in removing a neutral operand from bitor/bitxor.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
