### PR TITLE
Simplify (T)(a?b:c) to a?(T)b:(T)c

### DIFF
--- a/src/util/simplify_expr_class.h
+++ b/src/util/simplify_expr_class.h
@@ -147,6 +147,7 @@ public:
   // These below all return 'true' if the simplification wasn't applicable.
   // If false is returned, the expression has changed.
   NODISCARD resultt<> simplify_typecast(const typecast_exprt &);
+  bool simplify_typecast_preorder(typecast_exprt &);
   NODISCARD resultt<> simplify_extractbit(const extractbit_exprt &);
   NODISCARD resultt<> simplify_extractbits(const extractbits_exprt &);
   NODISCARD resultt<> simplify_concatenation(const concatenation_exprt &);

--- a/unit/util/simplify_expr.cpp
+++ b/unit/util/simplify_expr.cpp
@@ -524,6 +524,21 @@ TEST_CASE("Simplifying cast expressions", "[core][util]")
     const auto simplified_expr = simplify_expr(expr, ns);
     REQUIRE(simplified_expr == expr);
   }
+
+  SECTION("Simplifying (unsigned)(B ? 4 : 5) > 3")
+  {
+    signedbv_typet sbv{4};
+    unsignedbv_typet ubv{4};
+
+    symbol_exprt b{"B", bool_typet{}};
+    if_exprt if_b{b, from_integer(4, sbv), from_integer(5, sbv)};
+
+    binary_relation_exprt comparison_gt{
+      typecast_exprt{if_b, ubv}, ID_gt, from_integer(3, ubv)};
+    exprt simp = simplify_expr(comparison_gt, ns);
+
+    REQUIRE(simp == true_exprt{});
+  }
 }
 
 TEST_CASE("Simplify bitor", "[core][util]")


### PR DESCRIPTION
The idea of such a rule existed ever since 7285dda, but was possibly too
costly when doing it post-order for one would have to re-process
multiple sub-expressions. A pre-order rule avoids such repeat
processing.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
