### PR TITLE
Adds support for function calls within contracts

### DIFF
--- a/src/linking/remove_internal_symbols.cpp
+++ b/src/linking/remove_internal_symbols.cpp
@@ -57,6 +57,30 @@ static void get_symbols(
         if(!ns.lookup(p.get_identifier(), s))
           working_set.push_back(s);
       }
+
+      // check for contract definitions
+      const exprt ensures =
+        static_cast<const exprt &>(code_type.find(ID_C_spec_ensures));
+      const exprt requires =
+        static_cast<const exprt &>(code_type.find(ID_C_spec_requires));
+
+      find_symbols_sett new_symbols;
+      find_type_and_expr_symbols(ensures, new_symbols);
+      find_type_and_expr_symbols(requires, new_symbols);
+
+      for(const auto &s : new_symbols)
+      {
+        // keep functions called in contracts within scope.
+        // should we keep local variables from the contract as well?
+        const symbolt *new_symbol = nullptr;
+        if(!ns.lookup(s, new_symbol))
+        {
+          if(new_symbol->type.id() == ID_code)
+          {
+            working_set.push_back(new_symbol);
+          }
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
Contracts definitions often makes use of elaborate predicates,
which could be written on a separate functions. Therefore,
function contracts should be able to accept functions
as part of their specifications.

Signed-off-by: Felipe R. Monteiro <felisous@amazon.com>

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
