### PR TITLE
Fix copy&paste error: check_long_long should check __builtin_ssubll_overflow

### DIFF
--- a/regression/cbmc/gcc_builtin_sub_overflow/main.c
+++ b/regression/cbmc/gcc_builtin_sub_overflow/main.c
@@ -26,10 +26,10 @@ void check_long(void)
 void check_long_long(void)
 {
   long result;
-  assert(!__builtin_ssubl_overflow(1ll, 1ll, &result));
+  assert(!__builtin_ssubll_overflow(1ll, 1ll, &result));
   assert(result == 0ll);
-  assert(__builtin_ssubl_overflow(LLONG_MIN, 1ll, &result));
-  assert(!__builtin_ssubl_overflow(LLONG_MIN / 2ll, LLONG_MAX / 2ll, &result));
+  assert(__builtin_ssubll_overflow(LLONG_MIN, 1ll, &result));
+  assert(!__builtin_ssubll_overflow(LLONG_MIN / 2ll, LLONG_MAX / 2ll, &result));
   assert(result - 1ll == LLONG_MIN);
   assert(0 && "reachability");
 }

--- a/regression/cbmc/gcc_builtin_sub_overflow/test.desc
+++ b/regression/cbmc/gcc_builtin_sub_overflow/test.desc
@@ -13,10 +13,10 @@ main.c
 \[check_long.assertion.4\] line \d+ assertion !__builtin_ssubl_overflow\(.* / 2l, .* / 2l, &result\): SUCCESS
 \[check_long.assertion.5\] line \d+ assertion result - 1l == .*: SUCCESS
 \[check_long.assertion.6\] line \d+ assertion 0 && "reachability": FAILURE
-\[check_long_long.assertion.1\] line \d+ assertion !__builtin_ssubl_overflow\(1ll, 1ll, &result\): SUCCESS
+\[check_long_long.assertion.1\] line \d+ assertion !__builtin_ssubll_overflow\(1ll, 1ll, &result\): SUCCESS
 \[check_long_long.assertion.2\] line \d+ assertion result == 0ll: SUCCESS
-\[check_long_long.assertion.3\] line \d+ assertion __builtin_ssubl_overflow\(.*, 1ll, &result\): SUCCESS
-\[check_long_long.assertion.4\] line \d+ assertion !__builtin_ssubl_overflow\(.* / 2ll, .* / 2ll, &result\): SUCCESS
+\[check_long_long.assertion.3\] line \d+ assertion __builtin_ssubll_overflow\(.*, 1ll, &result\): SUCCESS
+\[check_long_long.assertion.4\] line \d+ assertion !__builtin_ssubll_overflow\(.* / 2ll, .* / 2ll, &result\): SUCCESS
 \[check_long_long.assertion.5\] line \d+ assertion result - 1ll == .*: SUCCESS
 \[check_long_long.assertion.6\] line \d+ assertion 0 && "reachability": FAILURE
 \[check_unsigned.assertion.1\] line \d+ assertion !__builtin_usub_overflow\(1u, 1u, &result\): SUCCESS


### PR DESCRIPTION
The constants are of the right type, but __builtin_ssubl_overflow was
used instead of __builtin_ssubll_overflow (which, however, made no
difference on 64-bit Linux platforms, which most of our tests run on).

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
