### PR TITLE
Add side_effect_expr_overflowt

### DIFF
--- a/src/ansi-c/c_expr.h
+++ b/src/ansi-c/c_expr.h
@@ -107,4 +107,97 @@ inline shuffle_vector_exprt &to_shuffle_vector_expr(exprt &expr)
   return ret;
 }
 
+/// \brief A Boolean expression returning true, iff the result of performing
+/// operation \c kind on operands \c lhs and \c rhs in infinite-precision
+/// arithmetic cannot be represented in the type of the object that \c result
+/// points to.
+/// If \c result is a pointer, the result of the operation is stored in the
+/// object pointed to by \c result.
+class side_effect_expr_overflowt : public side_effect_exprt
+{
+public:
+  side_effect_expr_overflowt(
+    const irep_idt &kind,
+    exprt _lhs,
+    exprt _rhs,
+    exprt _result,
+    const source_locationt &loc)
+    : side_effect_exprt(
+        "overflow-" + id2string(kind),
+        {std::move(_lhs), std::move(_rhs), std::move(_result)},
+        bool_typet{},
+        loc)
+  {
+  }
+
+  exprt &lhs()
+  {
+    return op0();
+  }
+
+  const exprt &lhs() const
+  {
+    return op0();
+  }
+
+  exprt &rhs()
+  {
+    return op1();
+  }
+
+  const exprt &rhs() const
+  {
+    return op1();
+  }
+
+  exprt &result()
+  {
+    return op2();
+  }
+
+  const exprt &result() const
+  {
+    return op2();
+  }
+};
+
+template <>
+inline bool can_cast_expr<side_effect_expr_overflowt>(const exprt &base)
+{
+  if(base.id() != ID_side_effect)
+    return false;
+
+  const irep_idt &statement = to_side_effect_expr(base).get_statement();
+  return statement == ID_overflow_plus || statement == ID_overflow_mult ||
+         statement == ID_overflow_minus;
+}
+
+/// \brief Cast an exprt to a \ref side_effect_expr_overflowt
+///
+/// \a expr must be known to be \ref side_effect_expr_overflowt.
+///
+/// \param expr: Source expression
+/// \return Object of type \ref side_effect_expr_overflowt
+inline const side_effect_expr_overflowt &
+to_side_effect_expr_overflow(const exprt &expr)
+{
+  const auto &side_effect_expr = to_side_effect_expr(expr);
+  PRECONDITION(
+    side_effect_expr.get_statement() == ID_overflow_plus ||
+    side_effect_expr.get_statement() == ID_overflow_mult ||
+    side_effect_expr.get_statement() == ID_overflow_minus);
+  return static_cast<const side_effect_expr_overflowt &>(side_effect_expr);
+}
+
+/// \copydoc to_side_effect_expr_overflow(const exprt &)
+inline side_effect_expr_overflowt &to_side_effect_expr_overflow(exprt &expr)
+{
+  auto &side_effect_expr = to_side_effect_expr(expr);
+  PRECONDITION(
+    side_effect_expr.get_statement() == ID_overflow_plus ||
+    side_effect_expr.get_statement() == ID_overflow_mult ||
+    side_effect_expr.get_statement() == ID_overflow_minus);
+  return static_cast<side_effect_expr_overflowt &>(side_effect_expr);
+}
+
 #endif // CPROVER_ANSI_C_C_EXPR_H

--- a/src/goto-programs/goto_convert_class.h
+++ b/src/goto-programs/goto_convert_class.h
@@ -25,6 +25,8 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "goto_program.h"
 #include "destructor_tree.h"
 
+class side_effect_expr_overflowt;
+
 class goto_convertt:public messaget
 {
 public:
@@ -149,6 +151,11 @@ protected:
   void remove_gcc_conditional_expression(
     exprt &expr,
     goto_programt &dest,
+    const irep_idt &mode);
+  void remove_overflow(
+    side_effect_expr_overflowt &expr,
+    goto_programt &dest,
+    bool result_is_used,
     const irep_idt &mode);
 
   virtual void do_cpp_new(


### PR DESCRIPTION
Introduce a new expression to handle GCC's __builtin_X_overflow in the
middle-end (during goto conversion) instead of directly encoding the
semantics during type checking.

This commit is a refactoring only, it does not yet fix the bugs that #5544 intends to fix. #5544 will now be rebased on top of this commit.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
