### PR TITLE
Use 3 cores on GitHub macOS runners

### DIFF
--- a/.github/workflows/pull-request-checks.yaml
+++ b/.github/workflows/pull-request-checks.yaml
@@ -189,8 +189,8 @@ jobs:
       - name: Build using Make
         run: |
           make -C src minisat2-download
-          make -C src -j2 CXX="ccache clang++"
-          make -C jbmc/src -j2 CXX="ccache clang++"
+          make -C src -j3 CXX="ccache clang++"
+          make -C jbmc/src -j3 CXX="ccache clang++"
           make -C unit "CXX=ccache clang++"
           make -C jbmc/unit "CXX=ccache clang++"
       - name: Print ccache stats
@@ -200,9 +200,9 @@ jobs:
       - name: Run JBMC unit tests
         run: cd jbmc/unit; ./unit_tests
       - name: Run regression tests
-        run: make -C regression test-parallel JOBS=2
+        run: make -C regression test-parallel JOBS=3
       - name: Run JBMC regression tests
-        run: make -C jbmc/regression test-parallel JOBS=2
+        run: make -C jbmc/regression test-parallel JOBS=3
 
   check-macos-10_15-cmake-clang:
     runs-on: macos-10.15
@@ -232,11 +232,11 @@ jobs:
           cd build
           cmake .. -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=/usr/bin/clang -DCMAKE_CXX_COMPILER=/usr/bin/clang++ -Dsat_impl=glucose
       - name: Build with Ninja
-        run: cd build; ninja -j2
+        run: cd build; ninja -j3
       - name: Print ccache stats
         run: ccache -s
       - name: Run CTest
-        run: cd build; ctest -V -L CORE . -j2
+        run: cd build; ctest -V -L CORE . -j3
 
   check-vs-2019-build-and-test:
     runs-on: windows-2019


### PR DESCRIPTION
According to
https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners,
macOS virtual machines have 3 cores available.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [x] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
