### PR TITLE
Fix a crash during SMT translation of structs

### DIFF
--- a/regression/cbmc/struct15/main.c
+++ b/regression/cbmc/struct15/main.c
@@ -1,0 +1,14 @@
+#include <assert.h>
+
+struct test
+{
+  unsigned int a;
+  unsigned int b;
+};
+
+int main()
+{
+  struct test t;
+  if(t.a > 10)
+    assert(t.a > 0);
+}

--- a/regression/cbmc/struct15/test.desc
+++ b/regression/cbmc/struct15/test.desc
@@ -1,0 +1,11 @@
+CORE
+main.c
+--trace --z3
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^map::at:
+key not found
+--
+This test checks the encoding of C `struct`s using SMT2 data types.

--- a/src/solvers/smt2/smt2_conv.cpp
+++ b/src/solvers/smt2/smt2_conv.cpp
@@ -4890,8 +4890,10 @@ void smt2_convt::find_symbols_rec(
 
     if(recstack.find(id) == recstack.end())
     {
+      const auto &base_struct = ns.follow_tag(struct_tag);
       recstack.insert(id);
-      find_symbols_rec(ns.follow_tag(struct_tag), recstack);
+      find_symbols_rec(base_struct, recstack);
+      datatype_map[type] = datatype_map[base_struct];
     }
   }
   else if(type.id() == ID_union_tag)

--- a/src/solvers/smt2/smt2_conv.h
+++ b/src/solvers/smt2/smt2_conv.h
@@ -209,8 +209,10 @@ protected:
 
   identifier_mapt identifier_map;
 
-  // for modeling structs as Z3 datatype, enabled when
-  // use_datatype is set
+  // for modeling structs as SMT datatype when use_datatype is set
+  //
+  // it maintains a map of `struct_typet` or `struct_tag_typet`
+  // to datatype names declared in SMT
   typedef std::map<typet, std::string> datatype_mapt;
   datatype_mapt datatype_map;
 


### PR DESCRIPTION
This PR fixes a bug with SMT translation of structs using data types (not bit vectors). CBMC `--smt2 --z3` was crashing on the attached regression test with a `key not found` exception from a `map::at` call.

- [x] Each commit message has a non-empty body, explaining why the change was made.
- NA ~~Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.~~
- NA ~~The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/~~
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- NA ~~My commit message includes data points confirming performance improvements (if claimed).~~
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.