### PR TITLE
C front-end: __builtin_shuffle, __builtin_shufflevector

### DIFF
--- a/regression/cbmc/gcc_vector3/main.c
+++ b/regression/cbmc/gcc_vector3/main.c
@@ -1,0 +1,52 @@
+#include <assert.h>
+
+#ifdef __GNUC__
+typedef int v4si __attribute__((vector_size(16)));
+
+typedef union {
+  v4si v;
+  int members[4];
+} vector_u;
+#endif
+
+int main()
+{
+#if defined(__GNUC__) && !defined(__clang__)
+  // https://gcc.gnu.org/onlinedocs/gcc/Vector-Extensions.html
+  v4si a = {1, 2, 3, 4};
+  v4si b = {5, 6, 7, 8};
+  v4si mask1 = {0, 1, 5, 3};
+  v4si mask2 = {0, 4, 2, 5};
+
+  vector_u res;
+
+  res.v = __builtin_shuffle(a, mask1);
+  assert(res.members[0] == 1);
+  assert(res.members[1] == 2);
+  assert(res.members[2] == 2);
+  assert(res.members[3] == 4);
+
+  res.v = __builtin_shuffle(a, b, mask2);
+  assert(res.members[0] == 1);
+  assert(res.members[1] == 5);
+  assert(res.members[2] == 3);
+  assert(res.members[3] == 6);
+#elif defined(__clang__)
+  v4si a = {1, 2, 3, 4};
+  v4si b = {5, 6, 7, 8};
+
+  vector_u res;
+
+  res.v = __builtin_shufflevector(a, a, 0, 1, -1, 3);
+  assert(res.members[0] == 1);
+  assert(res.members[1] == 2);
+  // res.members[2] is "don't care"
+  assert(res.members[3] == 4);
+
+  res.v = __builtin_shufflevector(a, b, 0, 4, 2, 5);
+  assert(res.members[0] == 1);
+  assert(res.members[1] == 5);
+  assert(res.members[2] == 3);
+  assert(res.members[3] == 6);
+#endif
+}

--- a/regression/cbmc/gcc_vector3/test.desc
+++ b/regression/cbmc/gcc_vector3/test.desc
@@ -1,0 +1,8 @@
+CORE broken-smt-backend
+main.c
+
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring

--- a/scripts/expected_doxygen_warnings.txt
+++ b/scripts/expected_doxygen_warnings.txt
@@ -21,7 +21,7 @@
 warning: Include graph for 'goto_instrument_parse_options.cpp' not generated, too many nodes (97), threshold is 60. Consider increasing DOT_GRAPH_MAX_NODES.
 warning: Included by graph for 'goto_functions.h' not generated, too many nodes (66), threshold is 60. Consider increasing DOT_GRAPH_MAX_NODES.
 warning: Included by graph for 'goto_model.h' not generated, too many nodes (111), threshold is 60. Consider increasing DOT_GRAPH_MAX_NODES.
-warning: Included by graph for 'arith_tools.h' not generated, too many nodes (182), threshold is 60. Consider increasing DOT_GRAPH_MAX_NODES.
+warning: Included by graph for 'arith_tools.h' not generated, too many nodes (183), threshold is 60. Consider increasing DOT_GRAPH_MAX_NODES.
 warning: Included by graph for 'c_types.h' not generated, too many nodes (142), threshold is 60. Consider increasing DOT_GRAPH_MAX_NODES.
 warning: Included by graph for 'config.h' not generated, too many nodes (88), threshold is 60. Consider increasing DOT_GRAPH_MAX_NODES.
 warning: Included by graph for 'exception_utils.h' not generated, too many nodes (61), threshold is 60. Consider increasing DOT_GRAPH_MAX_NODES.

--- a/src/ansi-c/Makefile
+++ b/src/ansi-c/Makefile
@@ -11,6 +11,7 @@ SRC = anonymous_member.cpp \
       ansi_c_typecheck.cpp \
       ansi_c_y.tab.cpp \
       builtin_factory.cpp \
+      c_expr.cpp \
       c_misc.cpp \
       c_nondet_symbol_factory.cpp \
       c_object_factory_parameters.cpp \

--- a/src/ansi-c/c_expr.cpp
+++ b/src/ansi-c/c_expr.cpp
@@ -1,0 +1,64 @@
+/*******************************************************************\
+
+Module: API to expression classes that are internal to the C frontend
+
+Author: Daniel Kroening, kroening@kroening.com
+
+\*******************************************************************/
+
+#include "c_expr.h"
+
+#include <util/arith_tools.h>
+
+shuffle_vector_exprt::shuffle_vector_exprt(
+  exprt vector1,
+  optionalt<exprt> vector2,
+  exprt::operandst indices)
+  : multi_ary_exprt(
+      ID_shuffle_vector,
+      {std::move(vector1), nil_exprt{}, exprt{}},
+      typet{})
+{
+  if(vector2.has_value())
+    op1() = std::move(*vector2);
+
+  const vector_typet &vt = to_vector_type(op0().type());
+  type() =
+    vector_typet{vt.subtype(), from_integer(indices.size(), vt.size().type())};
+
+  op2().operands().swap(indices);
+}
+
+vector_exprt shuffle_vector_exprt::lower() const
+{
+  PRECONDITION(
+    !has_two_input_vectors() || vector1().type() == vector2().type());
+
+  if(indices().empty())
+    return vector_exprt{exprt::operandst{}, type()};
+
+  auto input_size =
+    numeric_cast<mp_integer>(to_vector_type(vector1().type()).size());
+  CHECK_RETURN(input_size.has_value());
+
+  exprt::operandst operands;
+  operands.reserve(indices().size());
+
+  for(const exprt &index : indices())
+  {
+    if(has_two_input_vectors())
+    {
+      operands.push_back(if_exprt{
+        binary_predicate_exprt{
+          index, ID_lt, from_integer(*input_size, index.type())},
+        index_exprt{vector1(), index},
+        index_exprt{
+          vector2(),
+          minus_exprt{index, from_integer(*input_size, index.type())}}});
+    }
+    else
+      operands.push_back(index_exprt{vector1(), index});
+  }
+
+  return vector_exprt{std::move(operands), type()};
+}

--- a/src/ansi-c/c_expr.h
+++ b/src/ansi-c/c_expr.h
@@ -14,4 +14,97 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <util/std_code.h>
 
+/// \brief Shuffle elements of one or two vectors, modelled after Clang's
+/// __builtin_shufflevector.
+class shuffle_vector_exprt : public multi_ary_exprt
+{
+public:
+  shuffle_vector_exprt(
+    exprt vector1,
+    optionalt<exprt> vector2,
+    exprt::operandst indices);
+
+  const vector_typet &type() const
+  {
+    return static_cast<const vector_typet &>(multi_ary_exprt::type());
+  }
+
+  vector_typet &type()
+  {
+    return static_cast<vector_typet &>(multi_ary_exprt::type());
+  }
+
+  const exprt &vector1() const
+  {
+    return op0();
+  }
+
+  exprt &vector1()
+  {
+    return op0();
+  }
+
+  const exprt &vector2() const
+  {
+    return op1();
+  }
+
+  exprt &vector2()
+  {
+    return op1();
+  }
+
+  bool has_two_input_vectors() const
+  {
+    return vector2().is_not_nil();
+  }
+
+  const exprt::operandst &indices() const
+  {
+    return op2().operands();
+  }
+
+  exprt::operandst &indices()
+  {
+    return op2().operands();
+  }
+
+  vector_exprt lower() const;
+};
+
+template <>
+inline bool can_cast_expr<shuffle_vector_exprt>(const exprt &base)
+{
+  return base.id() == ID_shuffle_vector;
+}
+
+inline void validate_expr(const shuffle_vector_exprt &value)
+{
+  validate_operands(value, 3, "shuffle_vector must have three operands");
+}
+
+/// \brief Cast an exprt to a \ref shuffle_vector_exprt
+///
+/// \a expr must be known to be \ref shuffle_vector_exprt.
+///
+/// \param expr: Source expression
+/// \return Object of type \ref shuffle_vector_exprt
+inline const shuffle_vector_exprt &to_shuffle_vector_expr(const exprt &expr)
+{
+  PRECONDITION(expr.id() == ID_shuffle_vector);
+  const shuffle_vector_exprt &ret =
+    static_cast<const shuffle_vector_exprt &>(expr);
+  validate_expr(ret);
+  return ret;
+}
+
+/// \copydoc to_shuffle_vector_expr(const exprt &)
+inline shuffle_vector_exprt &to_shuffle_vector_expr(exprt &expr)
+{
+  PRECONDITION(expr.id() == ID_shuffle_vector);
+  shuffle_vector_exprt &ret = static_cast<shuffle_vector_exprt &>(expr);
+  validate_expr(ret);
+  return ret;
+}
+
 #endif // CPROVER_ANSI_C_C_EXPR_H

--- a/src/ansi-c/c_typecheck_base.h
+++ b/src/ansi-c/c_typecheck_base.h
@@ -203,6 +203,8 @@ protected:
   virtual code_blockt instantiate_gcc_polymorphic_builtin(
     const irep_idt &identifier,
     const symbol_exprt &function_symbol);
+  virtual exprt
+  typecheck_shuffle_vector(const side_effect_expr_function_callt &expr);
 
   virtual void make_index_type(exprt &expr);
   virtual void make_constant(exprt &expr);

--- a/src/ansi-c/c_typecheck_expr.cpp
+++ b/src/ansi-c/c_typecheck_expr.cpp
@@ -1928,6 +1928,24 @@ void c_typecheck_baset::typecheck_side_effect_function_call(
         return;
       }
       else if(
+        identifier == "__builtin_shuffle" &&
+        config.ansi_c.mode == configt::ansi_ct::flavourt::GCC)
+      {
+        exprt result = typecheck_shuffle_vector(expr);
+        expr.swap(result);
+
+        return;
+      }
+      else if(
+        identifier == "__builtin_shufflevector" &&
+        config.ansi_c.mode == configt::ansi_ct::flavourt::CLANG)
+      {
+        exprt result = typecheck_shuffle_vector(expr);
+        expr.swap(result);
+
+        return;
+      }
+      else if(
         auto gcc_polymorphic = typecheck_gcc_polymorphic_builtin(
           identifier, expr.arguments(), f_op.source_location()))
       {

--- a/src/ansi-c/clang_builtin_headers.h
+++ b/src/ansi-c/clang_builtin_headers.h
@@ -1,5 +1,3 @@
-__gcc_v4sf __builtin_shufflevector(__gcc_v4sf, __gcc_v4sf, ...);
-
 __gcc_v2di __builtin_ia32_undef128(void);
 __gcc_v4di __builtin_ia32_undef256(void);
 __gcc_v8di __builtin_ia32_undef512(void);

--- a/src/util/irep_ids.def
+++ b/src/util/irep_ids.def
@@ -849,6 +849,7 @@ IREP_ID_TWO(vector_ge, vector->=)
 IREP_ID_TWO(vector_le, vector-<=)
 IREP_ID_TWO(vector_gt, vector->)
 IREP_ID_TWO(vector_lt, vector-<)
+IREP_ID_ONE(shuffle_vector)
 
 // Projects depending on this code base that wish to extend the list of
 // available ids should provide a file local_irep_ids.def in their source tree


### PR DESCRIPTION
These are polymorphic built-ins supported by GCC and Clang,
respectively. Introduce a new shuffle_vector expression to handle these,
with type checking addressing the differences between the GCC/Clang
APIs.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
