### PR TITLE
Refactor and optimise size to have approximate bound

### DIFF
--- a/src/goto-symex/complexity_limiter.cpp
+++ b/src/goto-symex/complexity_limiter.cpp
@@ -136,7 +136,7 @@ complexity_limitert::check_complexity(goto_symex_statet &state)
   if(!complexity_limits_active() || !state.reachable)
     return complexity_violationt::NONE;
 
-  std::size_t complexity = state.complexity();
+  std::size_t complexity = state.guard.as_expr().bounded_size(max_complexity);
   if(complexity == 0)
     return complexity_violationt::NONE;
 

--- a/src/goto-symex/complexity_limiter.cpp
+++ b/src/goto-symex/complexity_limiter.cpp
@@ -137,7 +137,7 @@ complexity_limitert::check_complexity(goto_symex_statet &state)
     return complexity_violationt::NONE;
 
   std::size_t complexity = state.guard.as_expr().bounded_size(max_complexity);
-  if(complexity == 0)
+  if(complexity == 1)
     return complexity_violationt::NONE;
 
   auto &current_call_stack = state.call_stack();

--- a/src/goto-symex/goto_state.h
+++ b/src/goto-symex/goto_state.h
@@ -71,15 +71,6 @@ public:
   /// Threads
   unsigned atomic_section_id = 0;
 
-  /// Get the complexity for this state. Used to short-circuit states if they
-  /// have become too computationally complex.
-  inline std::size_t complexity()
-  {
-    // TODO: This isn't too efficent for BDDs, try using a different size
-    // like DAG size.
-    return guard.as_expr().size();
-  }
-
   /// Constructors
   goto_statet() = delete;
   goto_statet &operator=(const goto_statet &other) = delete;

--- a/src/util/expr.cpp
+++ b/src/util/expr.cpp
@@ -24,16 +24,28 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <stack>
 
-std::size_t exprt::size() const
+/// Returns the size of the exprt added to count without searching significantly
+/// beyond the supplied limit.
+std::size_t exprt::bounded_size(std::size_t count, std::size_t limit) const
 {
-  // Initial size of 1 to count self.
-  std::size_t size = 1;
-  for(const auto &op : operands())
+  const auto &ops = operands();
+  count += ops.size();
+  for(const auto &op : ops)
   {
-    size += op.size();
+    if(count >= limit)
+    {
+      return count;
+    }
+    count = op.bounded_size(count, limit);
   }
+  return count;
+}
 
-  return size;
+/// Returns the size of the exprt without significantly searching beyond the
+/// supplied limit.
+std::size_t exprt::bounded_size(std::size_t limit) const
+{
+  return bounded_size(1, limit);
 }
 
 /// Return whether the expression is a constant.

--- a/src/util/expr.h
+++ b/src/util/expr.h
@@ -85,9 +85,9 @@ public:
     return static_cast<const typet &>(find(ID_type));
   }
 
-  /// Amount of nodes this expression tree contains. This is the size of the
-  /// actual tree, ignoring memory/sub-tree sharing.
-  std::size_t size() const;
+  /// Amount of nodes in this expression tree approximately bounded by limit.
+  /// This is the size of the actual tree, ignoring memory/sub-tree sharing.
+  std::size_t bounded_size(std::size_t limit) const;
 
   /// Return true if there is at least one operand.
   bool has_operands() const
@@ -123,6 +123,10 @@ protected:
 
   const exprt &op3() const
   { return operands()[3]; }
+
+  /// Amount of nodes this expression tree contains, with a bound on how far
+  /// to search. Starts with an existing count.
+  std::size_t bounded_size(std::size_t count, std::size_t limit) const;
 
 public:
   void reserve_operands(operandst::size_type n)

--- a/unit/util/expr.cpp
+++ b/unit/util/expr.cpp
@@ -36,3 +36,36 @@ SCENARIO("bitfield-expr-is-zero", "[core][util][expr]")
     }
   }
 }
+
+TEST_CASE("Bounded size is computer correctly", "[core][util][expr]")
+{
+  // Helper types and functions for constructing test expressions.
+  const typet type = signedbv_typet(32);
+  std::function<exprt(size_t)> make_expression;
+  make_expression = [&](size_t size) -> exprt {
+    PRECONDITION(size != 0);
+    if(size <= 1)
+      return from_integer(1, type);
+    if(size == 2)
+      return unary_minus_exprt(from_integer(1, type));
+    return plus_exprt(from_integer(1, type), make_expression(size - 2));
+  };
+  // Actual test cases.
+  REQUIRE(make_expression(1).bounded_size(10) == 1);
+  REQUIRE(make_expression(2).bounded_size(10) == 2);
+  REQUIRE(make_expression(3).bounded_size(10) == 3);
+
+  REQUIRE(make_expression(30).bounded_size(10) < 13);
+  REQUIRE(make_expression(30).bounded_size(10) >= 10);
+}
+
+TEST_CASE("Bounded size versus pathological example", "[core][util][expr]")
+{
+  const typet type = signedbv_typet(32);
+  exprt pathology = plus_exprt(from_integer(1, type), from_integer(1, type));
+  // Create an infinite exprt by self reference!
+  pathology.add_to_operands(pathology);
+  // If bounded size is not checking the bound this will never terminate.
+  REQUIRE(pathology.bounded_size(10) < 13);
+  REQUIRE(pathology.bounded_size(10) >= 10);
+}


### PR DESCRIPTION
This optimises the size function that was only used when
checking for a bound. The new bounded_size takes an
explicit bound argument and reduces the search when
this bound is (approximately) reached.

Also this fixes a bug in the complexity computation where
the complexity (size) can never be zero, instead check
against one.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
