### PR TITLE
Refactor/make goto analyzer more modular

### DIFF
--- a/scripts/expected_doxygen_warnings.txt
+++ b/scripts/expected_doxygen_warnings.txt
@@ -20,7 +20,7 @@
 /home/runner/work/cbmc/cbmc/src/util/rename.h:23: warning: documented empty return type of get_new_name
 warning: Include graph for 'goto_instrument_parse_options.cpp' not generated, too many nodes (97), threshold is 60. Consider increasing DOT_GRAPH_MAX_NODES.
 warning: Included by graph for 'goto_functions.h' not generated, too many nodes (66), threshold is 60. Consider increasing DOT_GRAPH_MAX_NODES.
-warning: Included by graph for 'goto_model.h' not generated, too many nodes (110), threshold is 60. Consider increasing DOT_GRAPH_MAX_NODES.
+warning: Included by graph for 'goto_model.h' not generated, too many nodes (111), threshold is 60. Consider increasing DOT_GRAPH_MAX_NODES.
 warning: Included by graph for 'arith_tools.h' not generated, too many nodes (181), threshold is 60. Consider increasing DOT_GRAPH_MAX_NODES.
 warning: Included by graph for 'c_types.h' not generated, too many nodes (141), threshold is 60. Consider increasing DOT_GRAPH_MAX_NODES.
 warning: Included by graph for 'config.h' not generated, too many nodes (87), threshold is 60. Consider increasing DOT_GRAPH_MAX_NODES.
@@ -30,7 +30,7 @@ warning: Included by graph for 'expr_util.h' not generated, too many nodes (61),
 warning: Included by graph for 'invariant.h' not generated, too many nodes (186), threshold is 60. Consider increasing DOT_GRAPH_MAX_NODES.
 warning: Included by graph for 'irep.h' not generated, too many nodes (62), threshold is 60. Consider increasing DOT_GRAPH_MAX_NODES.
 warning: Included by graph for 'message.h' not generated, too many nodes (117), threshold is 60. Consider increasing DOT_GRAPH_MAX_NODES.
-warning: Included by graph for 'namespace.h' not generated, too many nodes (109), threshold is 60. Consider increasing DOT_GRAPH_MAX_NODES.
+warning: Included by graph for 'namespace.h' not generated, too many nodes (110), threshold is 60. Consider increasing DOT_GRAPH_MAX_NODES.
 warning: Included by graph for 'pointer_expr.h' not generated, too many nodes (116), threshold is 60. Consider increasing DOT_GRAPH_MAX_NODES.
 warning: Included by graph for 'prefix.h' not generated, too many nodes (85), threshold is 60. Consider increasing DOT_GRAPH_MAX_NODES.
 warning: Included by graph for 'simplify_expr.h' not generated, too many nodes (79), threshold is 60. Consider increasing DOT_GRAPH_MAX_NODES.

--- a/src/analyses/variable-sensitivity/variable_sensitivity_domain.h
+++ b/src/analyses/variable-sensitivity/variable_sensitivity_domain.h
@@ -72,6 +72,37 @@
 #include <analyses/variable-sensitivity/abstract_environment.h>
 #include <analyses/variable-sensitivity/variable_sensitivity_configuration.h>
 
+#define OPT_VSD                                                                \
+  "(vsd-values):"                                                              \
+  "(vsd-structs):"                                                             \
+  "(vsd-arrays):"                                                              \
+  "(vsd-pointers):"                                                            \
+  "(vsd-unions):"                                                              \
+  "(vsd-flow-insensitive)"                                                     \
+  "(vsd-data-dependencies)"
+
+// clang-format off
+#define HELP_VSD \
+    " --vsd-values                 value tracking - constants|intervals|set-of-constants\n" /* NOLINT(whitespace/line_length) */ \
+    " --vsd-structs                struct field sensitive analysis - top-bottom|every-field\n" /* NOLINT(whitespace/line_length) */ \
+    " --vsd-arrays                 array entry sensitive analysis - top-bottom|every-element\n" /* NOLINT(whitespace/line_length) */ \
+    " --vsd-pointers               pointer sensitive analysis - top-bottom|constants|value-set\n" /* NOLINT(whitespace/line_length) */ \
+    " --vsd-unions                 union sensitive analysis - top-bottom\n" \
+    " --vsd-flow-insensitive       disables flow sensitivity\n" \
+    " --vsd-data-dependencies      track data dependencies\n" \
+
+// cland-format on
+
+#define PARSE_OPTIONS_VSD(cmdline, options) \
+  options.set_option("values", cmdline.get_value("vsd-values")); \
+  options.set_option("pointers", cmdline.get_value("vsd-pointers")); \
+  options.set_option("arrays", cmdline.get_value("vsd-arrays")); \
+  options.set_option("structs", cmdline.get_value("vsd-structs")); \
+  options.set_option("unions", cmdline.get_value("vsd-unions")); \
+  options.set_option("flow-insensitive", cmdline.isset("vsd-flow-insensitive")); /* NOLINT(whitespace/line_length) */ \
+  options.set_option("data-dependencies", cmdline.isset("vsd-data-dependencies")); /* NOLINT(whitespace/line_length) */ \
+  (void)0
+
 class variable_sensitivity_domaint : public ai_domain_baset
 {
 public:

--- a/src/goto-analyzer/Makefile
+++ b/src/goto-analyzer/Makefile
@@ -7,6 +7,7 @@ SRC = goto_analyzer_main.cpp \
       static_show_domain.cpp \
       static_simplifier.cpp \
       static_verifier.cpp \
+      build_analyzer.cpp \
       # Empty last line
 
 OBJ += ../ansi-c/ansi-c$(LIBEXT) \

--- a/src/goto-analyzer/build_analyzer.cpp
+++ b/src/goto-analyzer/build_analyzer.cpp
@@ -1,0 +1,169 @@
+/*******************************************************************\
+
+Module: Goto-Analyzer Command Line Option Processing
+
+Author: Martin Brain, martin.brain@cs.ox.ac.uk
+
+\*******************************************************************/
+
+#include "build_analyzer.h"
+
+#include <analyses/ai.h>
+#include <analyses/call_stack_history.h>
+#include <analyses/constant_propagator.h>
+#include <analyses/dependence_graph.h>
+#include <analyses/goto_check.h>
+#include <analyses/interval_domain.h>
+#include <analyses/is_threaded.h>
+#include <analyses/local_control_flow_history.h>
+#include <analyses/local_may_alias.h>
+#include <analyses/variable-sensitivity/three_way_merge_abstract_interpreter.h>
+#include <analyses/variable-sensitivity/variable_sensitivity_configuration.h>
+#include <analyses/variable-sensitivity/variable_sensitivity_dependence_graph.h>
+#include <analyses/variable-sensitivity/variable_sensitivity_domain.h>
+#include <analyses/variable-sensitivity/variable_sensitivity_object_factory.h>
+
+#include <goto-programs/goto_model.h>
+
+#include <util/namespace.h>
+#include <util/options.h>
+
+/// Ideally this should be a pure function of options.
+/// However at the moment some domains require the goto_model or parts of it
+std::unique_ptr<ai_baset> build_analyzer(
+  const optionst &options,
+  const goto_modelt &goto_model,
+  const namespacet &ns)
+{
+  auto vsd_config = vsd_configt::from_options(options);
+  auto vs_object_factory =
+    variable_sensitivity_object_factoryt::configured_with(vsd_config);
+
+  // These support all of the option categories
+  if(
+    options.get_bool_option("recursive-interprocedural") ||
+    options.get_bool_option("three-way-merge"))
+  {
+    // Build the history factory
+    std::unique_ptr<ai_history_factory_baset> hf = nullptr;
+    if(options.get_bool_option("ahistorical"))
+    {
+      hf = util_make_unique<
+        ai_history_factory_default_constructort<ahistoricalt>>();
+    }
+    else if(options.get_bool_option("call-stack"))
+    {
+      hf = util_make_unique<call_stack_history_factoryt>(
+        options.get_unsigned_int_option("call-stack-recursion-limit"));
+    }
+    else if(options.get_bool_option("local-control-flow-history"))
+    {
+      hf = util_make_unique<local_control_flow_history_factoryt>(
+        options.get_bool_option("local-control-flow-history-forward"),
+        options.get_bool_option("local-control-flow-history-backward"),
+        options.get_unsigned_int_option("local-control-flow-history-limit"));
+    }
+
+    // Build the domain factory
+    std::unique_ptr<ai_domain_factory_baset> df = nullptr;
+    if(options.get_bool_option("constants"))
+    {
+      df = util_make_unique<
+        ai_domain_factory_default_constructort<constant_propagator_domaint>>();
+    }
+    else if(options.get_bool_option("intervals"))
+    {
+      df = util_make_unique<
+        ai_domain_factory_default_constructort<interval_domaint>>();
+    }
+    else if(options.get_bool_option("vsd"))
+    {
+      df = util_make_unique<variable_sensitivity_domain_factoryt>(
+        vs_object_factory, vsd_config);
+    }
+    // non-null is not fully supported, despite the historical options
+    // dependency-graph is quite heavily tied to the legacy-ait infrastructure
+    // dependency-graph-vs is very similar to dependency-graph
+
+    // Build the storage object
+    std::unique_ptr<ai_storage_baset> st = nullptr;
+    if(options.get_bool_option("one-domain-per-history"))
+    {
+      st = util_make_unique<history_sensitive_storaget>();
+    }
+    else if(options.get_bool_option("one-domain-per-location"))
+    {
+      st = util_make_unique<location_sensitive_storaget>();
+    }
+
+    // Only try to build the abstract interpreter if all the parts have been
+    // correctly specified and configured
+    if(hf != nullptr && df != nullptr && st != nullptr)
+    {
+      if(options.get_bool_option("recursive-interprocedural"))
+      {
+        return util_make_unique<ai_recursive_interproceduralt>(
+          std::move(hf), std::move(df), std::move(st));
+      }
+      else if(options.get_bool_option("three-way-merge"))
+      {
+        // Only works with VSD
+        if(options.get_bool_option("vsd"))
+        {
+          return util_make_unique<ai_three_way_merget>(
+            std::move(hf), std::move(df), std::move(st));
+        }
+      }
+    }
+  }
+  else if(options.get_bool_option("legacy-ait"))
+  {
+    if(options.get_bool_option("constants"))
+    {
+      // constant_propagator_ait derives from ait<constant_propagator_domaint>
+      return util_make_unique<constant_propagator_ait>(
+        goto_model.goto_functions);
+    }
+    else if(options.get_bool_option("dependence-graph"))
+    {
+      return util_make_unique<dependence_grapht>(ns);
+    }
+    else if(options.get_bool_option("dependence-graph-vs"))
+    {
+      return util_make_unique<variable_sensitivity_dependence_grapht>(
+        goto_model.goto_functions, ns, vs_object_factory, vsd_config);
+    }
+    else if(options.get_bool_option("vsd"))
+    {
+      auto df = util_make_unique<variable_sensitivity_domain_factoryt>(
+        vs_object_factory, vsd_config);
+      return util_make_unique<ait<variable_sensitivity_domaint>>(std::move(df));
+    }
+    else if(options.get_bool_option("intervals"))
+    {
+      return util_make_unique<ait<interval_domaint>>();
+    }
+#if 0
+    // Not actually implemented, despite the option...
+    else if(options.get_bool_option("non-null"))
+    {
+      return util_make_unique<ait<non_null_domaint> >();
+    }
+#endif
+  }
+  else if(options.get_bool_option("legacy-concurrent"))
+  {
+#if 0
+    // Very few domains can work with this interpreter
+    // as it requires that changes to the domain are
+    // 'non-revertable' and it has merge shared
+    if(options.get_bool_option("dependence-graph"))
+    {
+      return util_make_unique<dependence_grapht>(ns);
+    }
+#endif
+  }
+
+  // Construction failed due to configuration errors
+  return nullptr;
+}

--- a/src/goto-analyzer/build_analyzer.h
+++ b/src/goto-analyzer/build_analyzer.h
@@ -1,0 +1,34 @@
+/*******************************************************************\
+
+Module: Goto-Analyzer Command Line Option Processing
+
+Author: Martin Brain, martin.brain@cs.ox.ac.uk
+
+\*******************************************************************/
+
+#ifndef CPROVER_GOTO_ANALYZER_BUILD_ANALYZER_H
+#define CPROVER_GOTO_ANALYZER_BUILD_ANALYZER_H
+
+#include <memory>
+
+class ai_baset;
+class goto_modelt;
+class namespacet;
+class optionst;
+
+/// Build an abstract interpreter configured by the options.
+/// This may require options for:
+///  * which interpreter to use
+///  * which history to use
+///  * which storage to use
+///  * which domain to use
+///  * how that domain is configured
+/// Not every combination of options is supported.
+/// Unsupported options will give null.
+/// Domains also may throw a invalid_command_line_argument_exceptiont
+std::unique_ptr<ai_baset> build_analyzer(
+  const optionst &options,
+  const goto_modelt &goto_model,
+  const namespacet &ns);
+
+#endif // CPROVER_GOTO_ANALYZER_GOTO_ANALYZER_PARSE_OPTIONS_H

--- a/src/goto-analyzer/goto_analyzer_parse_options.cpp
+++ b/src/goto-analyzer/goto_analyzer_parse_options.cpp
@@ -39,19 +39,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <goto-programs/show_symbol_table.h>
 #include <goto-programs/validate_goto_model.h>
 
-#include <analyses/call_stack_history.h>
-#include <analyses/constant_propagator.h>
-#include <analyses/dependence_graph.h>
-#include <analyses/goto_check.h>
-#include <analyses/interval_domain.h>
-#include <analyses/is_threaded.h>
-#include <analyses/local_control_flow_history.h>
 #include <analyses/local_may_alias.h>
-#include <analyses/variable-sensitivity/three_way_merge_abstract_interpreter.h>
-#include <analyses/variable-sensitivity/variable_sensitivity_configuration.h>
-#include <analyses/variable-sensitivity/variable_sensitivity_dependence_graph.h>
-#include <analyses/variable-sensitivity/variable_sensitivity_domain.h>
-#include <analyses/variable-sensitivity/variable_sensitivity_object_factory.h>
 
 #include <langapi/mode.h>
 #include <langapi/language.h>
@@ -63,6 +51,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/unicode.h>
 #include <util/version.h>
 
+#include "build_analyzer.h"
 #include "show_on_source.h"
 #include "static_show_domain.h"
 #include "static_simplifier.h"
@@ -391,145 +380,6 @@ void goto_analyzer_parse_optionst::get_command_line_options(optionst &options)
   }
 }
 
-/// For the task, build the appropriate kind of analyzer
-/// Ideally this should be a pure function of options.
-/// However at the moment some domains require the goto_model or parts of it
-ai_baset *goto_analyzer_parse_optionst::build_analyzer(
-  const optionst &options,
-  const namespacet &ns)
-{
-  auto vsd_config = vsd_configt::from_options(options);
-  auto vs_object_factory =
-    variable_sensitivity_object_factoryt::configured_with(vsd_config);
-
-  // These support all of the option categories
-  if(
-    options.get_bool_option("recursive-interprocedural") ||
-    options.get_bool_option("three-way-merge"))
-  {
-    // Build the history factory
-    std::unique_ptr<ai_history_factory_baset> hf = nullptr;
-    if(options.get_bool_option("ahistorical"))
-    {
-      hf = util_make_unique<
-        ai_history_factory_default_constructort<ahistoricalt>>();
-    }
-    else if(options.get_bool_option("call-stack"))
-    {
-      hf = util_make_unique<call_stack_history_factoryt>(
-        options.get_unsigned_int_option("call-stack-recursion-limit"));
-    }
-    else if(options.get_bool_option("local-control-flow-history"))
-    {
-      hf = util_make_unique<local_control_flow_history_factoryt>(
-        options.get_bool_option("local-control-flow-history-forward"),
-        options.get_bool_option("local-control-flow-history-backward"),
-        options.get_unsigned_int_option("local-control-flow-history-limit"));
-    }
-
-    // Build the domain factory
-    std::unique_ptr<ai_domain_factory_baset> df = nullptr;
-    if(options.get_bool_option("constants"))
-    {
-      df = util_make_unique<
-        ai_domain_factory_default_constructort<constant_propagator_domaint>>();
-    }
-    else if(options.get_bool_option("intervals"))
-    {
-      df = util_make_unique<
-        ai_domain_factory_default_constructort<interval_domaint>>();
-    }
-    else if(options.get_bool_option("vsd"))
-    {
-      df = util_make_unique<variable_sensitivity_domain_factoryt>(
-        vs_object_factory, vsd_config);
-    }
-    // non-null is not fully supported, despite the historical options
-    // dependency-graph is quite heavily tied to the legacy-ait infrastructure
-    // dependency-graph-vs is very similar to dependency-graph
-
-    // Build the storage object
-    std::unique_ptr<ai_storage_baset> st = nullptr;
-    if(options.get_bool_option("one-domain-per-history"))
-    {
-      st = util_make_unique<history_sensitive_storaget>();
-    }
-    else if(options.get_bool_option("one-domain-per-location"))
-    {
-      st = util_make_unique<location_sensitive_storaget>();
-    }
-
-    // Only try to build the abstract interpreter if all the parts have been
-    // correctly specified and configured
-    if(hf != nullptr && df != nullptr && st != nullptr)
-    {
-      if(options.get_bool_option("recursive-interprocedural"))
-      {
-        return new ai_recursive_interproceduralt(
-          std::move(hf), std::move(df), std::move(st));
-      }
-      else if(options.get_bool_option("three-way-merge"))
-      {
-        // Only works with VSD
-        if(options.get_bool_option("vsd"))
-        {
-          return new ai_three_way_merget(
-            std::move(hf), std::move(df), std::move(st));
-        }
-      }
-    }
-  }
-  else if(options.get_bool_option("legacy-ait"))
-  {
-    if(options.get_bool_option("constants"))
-    {
-      // constant_propagator_ait derives from ait<constant_propagator_domaint>
-      return new constant_propagator_ait(goto_model.goto_functions);
-    }
-    else if(options.get_bool_option("dependence-graph"))
-    {
-      return new dependence_grapht(ns);
-    }
-    else if(options.get_bool_option("dependence-graph-vs"))
-    {
-      return new variable_sensitivity_dependence_grapht(
-        goto_model.goto_functions, ns, vs_object_factory, vsd_config);
-    }
-    else if(options.get_bool_option("vsd"))
-    {
-      auto df = util_make_unique<variable_sensitivity_domain_factoryt>(
-        vs_object_factory, vsd_config);
-      return new ait<variable_sensitivity_domaint>(std::move(df));
-    }
-    else if(options.get_bool_option("intervals"))
-    {
-      return new ait<interval_domaint>();
-    }
-#if 0
-    // Not actually implemented, despite the option...
-    else if(options.get_bool_option("non-null"))
-    {
-      return new ait<non_null_domaint>();
-    }
-#endif
-  }
-  else if(options.get_bool_option("legacy-concurrent"))
-  {
-#if 0
-    // Very few domains can work with this interpreter
-    // as it requires that changes to the domain are
-    // 'non-revertable' and it has merge shared
-    if(options.get_bool_option("dependence-graph"))
-    {
-      return new dependence_grapht(ns);
-    }
-#endif
-  }
-
-  // Construction failed due to configuration errors
-  return nullptr;
-}
-
 /// invoke main modules
 int goto_analyzer_parse_optionst::doit()
 {
@@ -742,7 +592,7 @@ int goto_analyzer_parse_optionst::perform_analysis(const optionst &options)
 
     try
     {
-      analyzer.reset(build_analyzer(options, ns));
+      analyzer = build_analyzer(options, goto_model, ns);
     }
     catch(const invalid_command_line_argument_exceptiont &e)
     {

--- a/src/goto-analyzer/goto_analyzer_parse_options.cpp
+++ b/src/goto-analyzer/goto_analyzer_parse_options.cpp
@@ -70,8 +70,6 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "taint_analysis.h"
 #include "unreachable_instructions.h"
 
-void vsd_options(optionst &options, const cmdlinet &cmdline);
-
 goto_analyzer_parse_optionst::goto_analyzer_parse_optionst(
   int argc,
   const char **argv)
@@ -329,17 +327,17 @@ void goto_analyzer_parse_optionst::get_command_line_options(optionst &options)
     else if(cmdline.isset("vsd") || cmdline.isset("variable-sensitivity"))
     {
       options.set_option("vsd", true);
-      options.set_option(
-        "data-dependencies", cmdline.isset("vsd-data-dependencies"));
+      options.set_option("domain set", true);
 
-      vsd_options(options, cmdline);
+      PARSE_OPTIONS_VSD(cmdline, options);
     }
     else if(cmdline.isset("dependence-graph-vs"))
     {
       options.set_option("dependence-graph-vs", true);
-      options.set_option("data-dependencies", true);
+      options.set_option("domain set", true);
 
-      vsd_options(options, cmdline);
+      PARSE_OPTIONS_VSD(cmdline, options);
+      options.set_option("data-dependencies", true); // Always set
     }
 
     // Reachability questions, when given with a domain swap from specific
@@ -917,13 +915,7 @@ void goto_analyzer_parse_optionst::help()
     " --dependence-graph-vs        dependencies between instructions using VSD\n" // NOLINT(*)
     "\n"
     "Variable sensitivity domain (VSD) options:\n"
-    " --vsd-values                 value tracking - constants|intervals|set-of-constants\n"
-    " --vsd-structs                struct field sensitive analysis - top-bottom|every-field\n"
-    " --vsd-arrays                 array entry sensitive analysis - top-bottom|every-element\n"
-    " --vsd-pointers               pointer sensitive analysis - top-bottom|constants|value-set\n"
-    " --vsd-unions                 union sensitive analysis - top-bottom\n"
-    " --vsd-flow-insensitive       disables flow sensitivity\n"
-    " --vsd-data-dependencies      track data dependencies\n"
+    HELP_VSD
     "\n"
     "Storage options:\n"
     // NOLINTNEXTLINE(whitespace/line_length)
@@ -965,17 +957,4 @@ void goto_analyzer_parse_optionst::help()
     HELP_TIMESTAMP
     "\n";
   // clang-format on
-}
-
-void vsd_options(optionst &options, const cmdlinet &cmdline)
-{
-  options.set_option("domain set", true);
-
-  // Configuration of VSD
-  options.set_option("values", cmdline.get_value("vsd-values"));
-  options.set_option("pointers", cmdline.get_value("vsd-pointers"));
-  options.set_option("arrays", cmdline.get_value("vsd-arrays"));
-  options.set_option("structs", cmdline.get_value("vsd-structs"));
-  options.set_option("unions", cmdline.get_value("vsd-unions"));
-  options.set_option("flow-insensitive", cmdline.isset("vsd-flow-insensitive"));
 }

--- a/src/goto-analyzer/goto_analyzer_parse_options.h
+++ b/src/goto-analyzer/goto_analyzer_parse_options.h
@@ -103,6 +103,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <analyses/ai.h>
 #include <analyses/goto_check.h>
+#include <analyses/variable-sensitivity/variable_sensitivity_domain.h>
 
 class goto_functionst;
 class optionst;
@@ -134,15 +135,6 @@ class optionst;
   "(dependence-graph)" \
   "(vsd)(variable-sensitivity)" \
   "(dependence-graph-vs)" \
-
-#define GOTO_ANALYSER_OPTIONS_VSD \
-  "(vsd-values):" \
-  "(vsd-structs):" \
-  "(vsd-arrays):" \
-  "(vsd-pointers):" \
-  "(vsd-unions):" \
-  "(vsd-flow-insensitive)" \
-  "(vsd-data-dependencies)"
 
 #define GOTO_ANALYSER_OPTIONS_STORAGE \
   "(one-domain-per-history)" \
@@ -177,7 +169,7 @@ class optionst;
   "(location-sensitive)(concurrent)" \
   GOTO_ANALYSER_OPTIONS_HISTORY \
   GOTO_ANALYSER_OPTIONS_DOMAIN \
-  GOTO_ANALYSER_OPTIONS_VSD \
+  OPT_VSD \
   GOTO_ANALYSER_OPTIONS_STORAGE  \
   GOTO_ANALYSER_OPTIONS_OUTPUT \
   GOTO_ANALYSER_OPTIONS_SPECIFIC_ANALYSES \

--- a/src/goto-analyzer/goto_analyzer_parse_options.h
+++ b/src/goto-analyzer/goto_analyzer_parse_options.h
@@ -193,8 +193,6 @@ protected:
   virtual bool process_goto_program(const optionst &options);
 
   virtual int perform_analysis(const optionst &options);
-
-  ai_baset *build_analyzer(const optionst &, const namespacet &ns);
 };
 
 #endif // CPROVER_GOTO_ANALYZER_GOTO_ANALYZER_PARSE_OPTIONS_H

--- a/src/goto-analyzer/static_verifier.cpp
+++ b/src/goto-analyzer/static_verifier.cpp
@@ -243,7 +243,7 @@ void static_verifier(
     auto &property_status = property.second.status;
     const goto_programt::const_targett &property_location = property.second.pc;
 
-    static_verifier_resultt result(ai, property_location, "unused", ns);
+    const static_verifier_resultt result(ai, property_location, "unused", ns);
 
     switch(result.status)
     {

--- a/src/goto-analyzer/static_verifier.cpp
+++ b/src/goto-analyzer/static_verifier.cpp
@@ -61,7 +61,7 @@ xmlt static_verifier_resultt::output_xml(void) const
   x.set_attribute("status", as_string(this->status));
 
   // DEPRECATED(SINCE(2020, 12, 2, "Remove and use the structured version"));
-  // Unstructed partial output of source location is not great...
+  // Unstructured partial output of source location is not great...
   x.set_attribute("file", id2string(this->source_location.get_file()));
   x.set_attribute("line", id2string(this->source_location.get_line()));
 

--- a/src/goto-analyzer/static_verifier.cpp
+++ b/src/goto-analyzer/static_verifier.cpp
@@ -20,7 +20,7 @@ Author: Martin Brain, martin.brain@cs.ox.ac.uk
 #include <analyses/ai.h>
 
 /// Makes a status message string from a status.
-static const char *message(const ai_verifier_statust &status)
+std::string as_string(const ai_verifier_statust &status)
 {
   switch(status)
   {
@@ -55,7 +55,7 @@ struct static_verifier_resultt
       false_json.push_back(trace_ptr->output_json());
 
     return json_objectt{
-      {"status", json_stringt{message(this->status)}},
+      {"status", json_stringt{as_string(this->status)}},
       {"sourceLocation", json(this->source_location)},
       {"unknownHistories", unknown_json},
       {"falseHistories", false_json},
@@ -66,7 +66,7 @@ struct static_verifier_resultt
   {
     xmlt x("result");
 
-    x.set_attribute("status", message(this->status));
+    x.set_attribute("status", as_string(this->status));
 
     // DEPRECATED(SINCE(2020, 12, 2, "Remove and use the structured version"));
     // Unstructed partial output of source location is not great...
@@ -336,7 +336,7 @@ static void static_verifier_text(
     if(!result.source_location.get_comment().empty())
       out << ", " << result.source_location.get_comment();
 
-    out << ": " << message(result.status) << '\n';
+    out << ": " << as_string(result.status) << '\n';
   }
 }
 

--- a/src/goto-analyzer/static_verifier.h
+++ b/src/goto-analyzer/static_verifier.h
@@ -36,4 +36,12 @@ void static_verifier(
   const ai_baset &ai,
   propertiest &properties);
 
+enum class ai_verifier_statust
+{
+  TRUE,
+  FALSE,
+  BOTTOM,
+  UNKNOWN
+};
+
 #endif // CPROVER_GOTO_ANALYZER_STATIC_VERIFIER_H

--- a/src/goto-analyzer/static_verifier.h
+++ b/src/goto-analyzer/static_verifier.h
@@ -44,4 +44,7 @@ enum class ai_verifier_statust
   UNKNOWN
 };
 
+std::string as_string(const ai_verifier_statust &);
+
+
 #endif // CPROVER_GOTO_ANALYZER_STATIC_VERIFIER_H

--- a/src/goto-analyzer/static_verifier.h
+++ b/src/goto-analyzer/static_verifier.h
@@ -58,6 +58,12 @@ public:
   ai_history_baset::trace_sett unknown_histories;
   ai_history_baset::trace_sett false_histories;
 
+  static_verifier_resultt(
+    const ai_baset &ai,
+    goto_programt::const_targett assert_location,
+    irep_idt func_id,
+    const namespacet &ns);
+
   jsont output_json(void) const;
   xmlt output_xml(void) const;
 };

--- a/src/goto-analyzer/static_verifier.h
+++ b/src/goto-analyzer/static_verifier.h
@@ -41,8 +41,8 @@ void static_verifier(
 enum class ai_verifier_statust
 {
   TRUE,
-  FALSE,
-  BOTTOM,
+  FALSE_IF_REACHABLE,
+  NOT_REACHABLE,
   UNKNOWN
 };
 

--- a/src/goto-analyzer/static_verifier.h
+++ b/src/goto-analyzer/static_verifier.h
@@ -38,17 +38,30 @@ void static_verifier(
   const ai_baset &ai,
   propertiest &properties);
 
+/// An ai_baset contains zero or more histories that reach a location.
+/// In a given history, a Boolean expression can be true, false or unknown.
+/// If we only care about "does there exist a history that make the condition
+/// true/false/unknown" then that means there are 8 possible statuses.
+/// In practice not all of them are usefully distinguishable, so we only
+/// consider 4 of them.
+/// Also note that because abstract interpretation is an over-approximate
+/// analysis, the existence of a history does not necessarily mean that there
+/// is an actual executation trace that makes the condition true/false.
 enum class ai_verifier_statust
 {
-  TRUE,
-  FALSE_IF_REACHABLE,
-  NOT_REACHABLE,
-  UNKNOWN
+  TRUE,               // true : 1+, unknown :  0, false :  0
+  FALSE_IF_REACHABLE, // true : 0+, unknown :  0, false : 1+
+  NOT_REACHABLE,      // true :  0, unknown :  0, false :  0
+  UNKNOWN             // true : 0+, unknown : 1+, false : 0+
 };
 
 std::string as_string(const ai_verifier_statust &);
 
 /// The result of verifying a single assertion
+/// As well as the status of the assertion (see above), it also contains the
+/// location (source_location and function_id) and the set of histories
+/// in which the assertion is unknown or false, so that more detailed
+/// post-processing or error output can be done.
 class static_verifier_resultt
 {
 public:

--- a/src/goto-analyzer/static_verifier.h
+++ b/src/goto-analyzer/static_verifier.h
@@ -9,7 +9,9 @@ Author: Martin Brain, martin.brain@cs.ox.ac.uk
 #ifndef CPROVER_GOTO_ANALYZER_STATIC_VERIFIER_H
 #define CPROVER_GOTO_ANALYZER_STATIC_VERIFIER_H
 
+#include <analyses/ai.h>
 #include <goto-checker/properties.h>
+
 #include <iosfwd>
 
 class abstract_goto_modelt;
@@ -46,5 +48,18 @@ enum class ai_verifier_statust
 
 std::string as_string(const ai_verifier_statust &);
 
+/// The result of verifying a single assertion
+class static_verifier_resultt
+{
+public:
+  ai_verifier_statust status;
+  source_locationt source_location;
+  irep_idt function_id;
+  ai_history_baset::trace_sett unknown_histories;
+  ai_history_baset::trace_sett false_histories;
+
+  jsont output_json(void) const;
+  xmlt output_xml(void) const;
+};
 
 #endif // CPROVER_GOTO_ANALYZER_STATIC_VERIFIER_H


### PR DESCRIPTION
This should be completely functionality neutral.  It is intended to make it easier for other applications to make use of the abstract interpreter in the same way that goto-analyzer does and save duplicating the construction and verification code.  I strongly suggest reviewing commit by commit.