### PR TITLE
Use simplification for more reliable pointer comparison

### DIFF
--- a/regression/cbmc/Pointer_comparison2/main.c
+++ b/regression/cbmc/Pointer_comparison2/main.c
@@ -1,0 +1,18 @@
+#include <assert.h>
+#include <stdlib.h>
+
+int *get_ptr_minus_one(int *ptr)
+{
+  if(ptr)
+    return ptr - 1;
+  return 0;
+}
+
+int main()
+{
+  int *begin = malloc(4 * 4);
+  int *end = begin + 1;
+
+  if(begin != get_ptr_minus_one(end))
+    assert(0);
+}

--- a/regression/cbmc/Pointer_comparison2/test.desc
+++ b/regression/cbmc/Pointer_comparison2/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+
+^VERIFICATION SUCCESSFUL$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring

--- a/src/util/simplify_expr_int.cpp
+++ b/src/util/simplify_expr_int.cpp
@@ -1243,13 +1243,8 @@ simplify_exprt::simplify_inequality(const binary_relation_exprt &expr)
 
   // see if we are comparing pointers that are address_of
   if(
-    (tmp0.id() == ID_address_of ||
-     (tmp0.id() == ID_typecast &&
-      to_typecast_expr(tmp0).op().id() == ID_address_of)) &&
-    (tmp1.id() == ID_address_of ||
-     (tmp1.id() == ID_typecast &&
-      to_typecast_expr(tmp1).op().id() == ID_address_of)) &&
-    (expr.id() == ID_equal || expr.id() == ID_notequal))
+    skip_typecast(tmp0).id() == ID_address_of &&
+    skip_typecast(tmp1).id() == ID_address_of)
   {
     return simplify_inequality_address_of(expr);
   }

--- a/src/util/simplify_expr_pointer.cpp
+++ b/src/util/simplify_expr_pointer.cpp
@@ -426,12 +426,8 @@ simplify_exprt::resultt<> simplify_exprt::simplify_inequality_address_of(
 
   PRECONDITION(expr.id() == ID_equal || expr.id() == ID_notequal);
 
-  exprt tmp0=expr.op0();
-
   // skip over the typecast
-  if(tmp0.id()==ID_typecast)
-    tmp0 = to_typecast_expr(tmp0).op();
-
+  exprt tmp0 = skip_typecast(expr.op0());
   PRECONDITION(tmp0.id() == ID_address_of);
 
   auto &tmp0_address_of = to_address_of_expr(tmp0);
@@ -444,12 +440,8 @@ simplify_exprt::resultt<> simplify_exprt::simplify_inequality_address_of(
       address_of_exprt(to_index_expr(tmp0_address_of.object()).array());
   }
 
-  exprt tmp1=expr.op1();
-
   // skip over the typecast
-  if(tmp1.id()==ID_typecast)
-    tmp1 = to_typecast_expr(tmp1).op();
-
+  exprt tmp1 = skip_typecast(expr.op1());
   PRECONDITION(tmp1.id() == ID_address_of);
 
   auto &tmp1_address_of = to_address_of_expr(tmp1);


### PR DESCRIPTION
As demonstrated in #5921, try_evaluate_pointer_comparisons must not
assume that all pointers being compared to have a canonical
representation. Use simplification to handle more cases instead of
relying on syntactic equality of expressions.

Co-authored-by: Breno Rodrigues Guimarães <brenorg@gmail.com>

Fixes: #5921

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
