### PR TITLE
introduce code_with_contract_typet

### DIFF
--- a/src/ansi-c/c_typecheck_base.cpp
+++ b/src/ansi-c/c_typecheck_base.cpp
@@ -754,15 +754,19 @@ void c_typecheck_baset::typecheck_declaration(
       typecheck_spec_expr(static_cast<codet &>(contract), ID_C_spec_ensures);
       parameter_map.clear();
 
-      irept assigns_to_add = contract.find(ID_C_spec_assigns);
+      exprt assigns_to_add =
+        static_cast<const exprt &>(contract.find(ID_C_spec_assigns));
       if(assigns_to_add.is_not_nil())
-        new_symbol.type.add(ID_C_spec_assigns) = assigns_to_add;
-      irept requires_to_add = contract.find(ID_C_spec_requires);
+        to_code_with_contract_type(new_symbol.type).assigns() = assigns_to_add;
+      exprt requires_to_add =
+        static_cast<const exprt &>(contract.find(ID_C_spec_requires));
       if(requires_to_add.is_not_nil())
-        new_symbol.type.add(ID_C_spec_requires) = requires_to_add;
-      irept ensures_to_add = contract.find(ID_C_spec_ensures);
+        to_code_with_contract_type(new_symbol.type).requires() =
+          requires_to_add;
+      exprt ensures_to_add =
+        static_cast<const exprt &>(contract.find(ID_C_spec_ensures));
       if(ensures_to_add.is_not_nil())
-        new_symbol.type.add(ID_C_spec_ensures) = ensures_to_add;
+        to_code_with_contract_type(new_symbol.type).ensures() = ensures_to_add;
     }
   }
 }

--- a/src/util/c_types.h
+++ b/src/util/c_types.h
@@ -327,6 +327,88 @@ inline c_enum_tag_typet &to_c_enum_tag_type(typet &type)
   return static_cast<c_enum_tag_typet &>(type);
 }
 
+class code_with_contract_typet : public code_typet
+{
+public:
+  /// Constructs a new 'code with contract' type, i.e., a function type
+  /// decorated with a function contract.
+  /// \param _parameters: The vector of function parameters.
+  /// \param _return_type: The return type.
+  code_with_contract_typet(parameterst _parameters, typet _return_type)
+    : code_typet(std::move(_parameters), std::move(_return_type))
+  {
+  }
+
+  bool has_contract() const
+  {
+    return assigns().is_not_nil() || requires().is_not_nil() ||
+           ensures().is_not_nil();
+  }
+
+  const exprt &assigns() const
+  {
+    return static_cast<const exprt &>(find(ID_C_spec_assigns));
+  }
+
+  exprt &assigns()
+  {
+    return static_cast<exprt &>(add(ID_C_spec_assigns));
+  }
+
+  const exprt &requires() const
+  {
+    return static_cast<const exprt &>(find(ID_C_spec_requires));
+  }
+
+  exprt &requires()
+  {
+    return static_cast<exprt &>(add(ID_C_spec_requires));
+  }
+
+  const exprt &ensures() const
+  {
+    return static_cast<const exprt &>(find(ID_C_spec_ensures));
+  }
+
+  exprt &ensures()
+  {
+    return static_cast<exprt &>(add(ID_C_spec_ensures));
+  }
+};
+
+/// Check whether a reference to a typet is a \ref code_typet.
+/// \param type: Source type.
+/// \return True if \p type is a \ref code_typet.
+template <>
+inline bool can_cast_type<code_with_contract_typet>(const typet &type)
+{
+  return type.id() == ID_code;
+}
+
+/// \brief Cast a typet to a \ref code_with_contract_typet
+///
+/// This is an unchecked conversion. \a type must be known to be \ref
+/// code_with_contract_typet. Will fail with a precondition violation if type
+/// doesn't match.
+///
+/// \param type: Source type.
+/// \return Object of type \ref code_with_contract_typet.
+inline const code_with_contract_typet &
+to_code_with_contract_type(const typet &type)
+{
+  PRECONDITION(can_cast_type<code_with_contract_typet>(type));
+  code_with_contract_typet::check(type);
+  return static_cast<const code_with_contract_typet &>(type);
+}
+
+/// \copydoc to_code_type(const typet &)
+inline code_with_contract_typet &to_code_with_contract_type(typet &type)
+{
+  PRECONDITION(can_cast_type<code_with_contract_typet>(type));
+  code_with_contract_typet::check(type);
+  return static_cast<code_with_contract_typet &>(type);
+}
+
 bitvector_typet index_type();
 bitvector_typet enum_constant_type();
 signedbv_typet signed_int_type();


### PR DESCRIPTION
This documents an existing, informal, variant of `code_typet`, which is
decorated with predicates for code contracts.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- [X] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- n/a Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
