### PR TITLE
MSVC supports multiple __declspec specifiers

### DIFF
--- a/regression/ansi-c/VS_extensions1/main.c
+++ b/regression/ansi-c/VS_extensions1/main.c
@@ -20,6 +20,11 @@ __declspec(thread) int thread_local;
 
 struct __declspec(dllimport) some_struct_tag { int x; };
 
+typedef union __declspec(intrin_type) __declspec(align(8)) u {
+  int x;
+  int y;
+} u2;
+
 //__delegate int GetDayOfWeek();
 
 // __event

--- a/src/ansi-c/parser.y
+++ b/src/ansi-c/parser.y
@@ -1440,7 +1440,20 @@ msc_declspec_opt:
         {
           init($$, ID_nil);
         }
-        | msc_declspec
+        | msc_declspec_opt msc_declspec
+        {
+          if(parser_stack($1).is_not_nil())
+          {
+            $$ = $1;
+            exprt::operandst &operands = parser_stack($1).operands();
+            operands.insert(
+              operands.end(),
+              parser_stack($2).operands().begin(),
+              parser_stack($2).operands().end());
+          }
+          else
+            $$ = $2;
+        }
         ;
 
 storage_class:


### PR DESCRIPTION
This isn't obvious from Microsoft's grammar, but does appear in header
files shipped with Visual Studio.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
