### PR TITLE
C front-end: support inline (and its variants) after asm

### DIFF
--- a/regression/ansi-c/asm2/main.c
+++ b/regression/ansi-c/asm2/main.c
@@ -3,10 +3,11 @@
 int main()
 {
   int x, y;
-  #ifdef __GNUC__
+#ifdef __GNUC__
   asm goto ("jc %l[error];"
       : : "r"(x), "r"(&y) : "memory" : error);
-  #endif
+  asm __inline volatile("jc %l[error];" : : "r"(x), "r"(&y) : "memory" : error);
+#endif
 error:
   return 0;
 }

--- a/src/ansi-c/parser.y
+++ b/src/ansi-c/parser.y
@@ -2675,10 +2675,9 @@ cprover_exception_statement:
 
 volatile_or_goto_opt:
           /* nothing */
-        | TOK_VOLATILE
-        | TOK_GOTO
-        | TOK_GOTO TOK_VOLATILE
-        | TOK_VOLATILE TOK_GOTO
+        | volatile_or_goto_opt TOK_VOLATILE
+        | volatile_or_goto_opt TOK_GOTO
+        | volatile_or_goto_opt TOK_INLINE
         ;
 
 /* asm ( assembler template

--- a/src/ansi-c/scanner.l
+++ b/src/ansi-c/scanner.l
@@ -1639,6 +1639,9 @@ __decltype          { if(PARSER.cpp98 &&
 "__volatile"    { yyless(0); BEGIN(GRAMMAR); loc(); return TOK_GCC_ASM_PAREN; }
 "__volatile__"  { yyless(0); BEGIN(GRAMMAR); loc(); return TOK_GCC_ASM_PAREN; }
 "goto"          { yyless(0); BEGIN(GRAMMAR); loc(); return TOK_GCC_ASM_PAREN; }
+"inline"        { yyless(0); BEGIN(GRAMMAR); loc(); return TOK_GCC_ASM_PAREN; }
+"__inline"      { yyless(0); BEGIN(GRAMMAR); loc(); return TOK_GCC_ASM_PAREN; }
+"__inline__"    { yyless(0); BEGIN(GRAMMAR); loc(); return TOK_GCC_ASM_PAREN; }
 .               { yyless(0); BEGIN(GRAMMAR); loc(); PARSER.asm_block_following=true; return TOK_GCC_ASM; }
 }
 


### PR DESCRIPTION
GCC supports volatile, inline, goto as asm-qualifiers:
https://gcc.gnu.org/onlinedocs/gcc/Extended-Asm.html.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
