### PR TITLE
export-file-local-symbols: help output and handling of large files

### DIFF
--- a/src/goto-cc/compile.cpp
+++ b/src/goto-cc/compile.cpp
@@ -745,6 +745,9 @@ bool compilet::add_written_cprover_symbols(const symbol_tablet &symbol_table)
     if(!(has_prefix(id2string(name), CPROVER_PREFIX) && new_type.id()==ID_code))
       continue;
 
+    if(has_prefix(id2string(name), FILE_LOCAL_PREFIX))
+      continue;
+
     bool inserted;
     std::map<irep_idt, symbolt>::iterator old;
     std::tie(old, inserted)=written_macros.insert({name, pair.second});


### PR DESCRIPTION
goto-cc --export-file-local-symbols was never documented in --help
output. Its use entails renaming of file-local (function) symbols with a
prefix of __CPROVER_file_local, which had the side effect of those names
being added as defines when building hybrid binaries. For files with
large numbers of static functions, this resulted in a command-line that
exceeds operating-system limits.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
