### PR TITLE
C grammar: introduce attribute_specifier

### DIFF
--- a/src/ansi-c/parser.y
+++ b/src/ansi-c/parser.y
@@ -1008,7 +1008,7 @@ post_declarator_attribute:
           parser_stack($$).set(ID_flavor, ID_gcc);
           parser_stack($$).operands().swap(parser_stack($4).operands());
         }
-        | gcc_attribute_specifier
+        | attribute_specifier
         ;
 
 post_declarator_attributes:
@@ -1114,8 +1114,8 @@ declaration_qualifier_list:
         {
           $$=merge($1, $2);
         }
-        | gcc_attribute_specifier
-        | declaration_qualifier_list gcc_attribute_specifier
+        | attribute_specifier
+        | declaration_qualifier_list attribute_specifier
         {
           $$=merge($1, $2);
         }
@@ -1134,7 +1134,7 @@ type_qualifier_list:
         /* The following is to allow mixing of type attributes with
            type qualifiers, but the list has to start with a
            proper type qualifier. */
-        | type_qualifier_list gcc_attribute_specifier
+        | type_qualifier_list attribute_specifier
         {
           $$=merge($1, $2);
         }
@@ -1180,12 +1180,12 @@ alignas_specifier:
 
 attribute_or_type_qualifier:
           type_qualifier
-        | gcc_attribute_specifier
+        | attribute_specifier
         ;
 
 attribute_or_type_qualifier_or_storage_class:
           type_qualifier
-        | gcc_attribute_specifier
+        | attribute_specifier
         | storage_class
         ;
 
@@ -1671,11 +1671,15 @@ gcc_attribute_list:
         }
         ;          
 
+attribute_specifier:
+          gcc_attribute_specifier
+        | TOK_NORETURN
+        { $$=$1; set($$, ID_noreturn); }
+        ;
+
 gcc_attribute_specifier:
           TOK_GCC_ATTRIBUTE '(' '(' gcc_attribute_list ')' ')'
         { $$=$4; }
-        | TOK_NORETURN
-        { $$=$1; set($$, ID_noreturn); }
         ;
 
 gcc_type_attribute_opt:


### PR DESCRIPTION
This is a preparatory step for introducing C2x-style attribute specifiers.

This also makes it easier to introduce other, custom attributes, say for
code contracts.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- n/a Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
