### PR TITLE
Correctly handle SMT solver errors in loop acceleration code

### DIFF
--- a/src/goto-instrument/accelerate/scratch_program.cpp
+++ b/src/goto-instrument/accelerate/scratch_program.cpp
@@ -71,7 +71,21 @@ bool scratch_programt::check_sat(bool do_slice, guard_managert &guard_manager)
   std::cout << "Finished symex, invoking decision procedure.\n";
 #endif
 
-  return ((*checker)() == decision_proceduret::resultt::D_SATISFIABLE);
+  switch((*checker)())
+  {
+  case decision_proceduret::resultt::D_ERROR:
+    throw "error running the SMT solver";
+
+  case decision_proceduret::resultt::D_SATISFIABLE:
+    return true;
+
+  case decision_proceduret::resultt::D_UNSATISFIABLE:
+    return false;
+
+    UNREACHABLE;
+  }
+
+  UNREACHABLE;
 }
 
 exprt scratch_programt::eval(const exprt &e)


### PR DESCRIPTION
Related to #5944 and #5947.

This PR correctly handles SMT solver failures in loop acceleration routines. Earlier these errors were silently ignored, and were being treated as UNSAT.

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] NA ~~The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/~~
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] NA ~~My commit message includes data points confirming performance improvements (if claimed).~~
- [x] My PR is restricted to a single feature or bugfix.
- [ ] NA ~~White-space or formatting changes outside the feature-related changed lines are in commits of their own.~~