### PR TITLE
Fix union initialization

### DIFF
--- a/regression/ansi-c/Union_Initialization3/main.c
+++ b/regression/ansi-c/Union_Initialization3/main.c
@@ -1,0 +1,23 @@
+union {
+  int a;
+  struct
+  {
+    unsigned b : 4;
+    unsigned c : 4;
+  };
+} u1 = {.b = 5, .c = 1};
+
+#ifndef _MSC_VER
+union {
+  int;
+  struct
+  {
+    unsigned b : 4;
+    unsigned c : 4;
+  };
+} u2 = {.b = 5, .c = 1};
+#endif
+
+int main()
+{
+}

--- a/regression/ansi-c/Union_Initialization3/test.desc
+++ b/regression/ansi-c/Union_Initialization3/test.desc
@@ -1,0 +1,12 @@
+CORE
+main.c
+
+^EXIT=0$
+^SIGNAL=0$
+--
+Invariant check failed
+--
+This test previously failed an internal invariant:
+File: ../src/ansi-c/c_typecheck_initializer.cpp:517 function: do_designated_initializer
+Condition: dest->id() == ID_union
+Reason: union should be zero initialized


### PR DESCRIPTION
The attached test shows that we could reach recursive initialisation of
unions with a byte_update instead of a union expression. The test was
constructed using creduce, starting from code included in the Linux
kernel.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
