### PR TITLE
Supports nested quantifiers in function contracts

### DIFF
--- a/regression/contracts/quantifiers-nested-01/main.c
+++ b/regression/contracts/quantifiers-nested-01/main.c
@@ -1,0 +1,24 @@
+// clang-format off
+int f1(int *arr) __CPROVER_ensures(__CPROVER_forall {
+  int i;
+  __CPROVER_forall
+  {
+    int j;
+    (0 <= i && i < 10 && i <= j && j < 10) ==> arr[i] <= arr[j]
+  }
+})
+// clang-format on
+{
+  for(int i = 0; i < 10; i++)
+  {
+    arr[i] = i;
+  }
+
+  return 0;
+}
+
+int main()
+{
+  int arr[10];
+  f1(arr);
+}

--- a/regression/contracts/quantifiers-nested-01/test.desc
+++ b/regression/contracts/quantifiers-nested-01/test.desc
@@ -1,0 +1,11 @@
+CORE
+main.c
+--enforce-all-contracts
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+--
+Verification:
+This test case checks the handling of a forall expression
+nested within another forall expression.

--- a/regression/contracts/quantifiers-nested-02/main.c
+++ b/regression/contracts/quantifiers-nested-02/main.c
@@ -1,0 +1,19 @@
+// clang-format off
+int f1(int *arr) __CPROVER_requires(__CPROVER_forall {
+  int i;
+  0 <= i && i < 9 ==> __CPROVER_forall
+  {
+    int j;
+    (i <= j && j < 10) ==> arr[i] <= arr[j]
+  }
+}) __CPROVER_ensures(__CPROVER_return_value == 0)
+// clang-format on
+{
+  return 0;
+}
+
+int main()
+{
+  int arr[10] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+  f1(arr);
+}

--- a/regression/contracts/quantifiers-nested-02/test.desc
+++ b/regression/contracts/quantifiers-nested-02/test.desc
@@ -1,0 +1,11 @@
+CORE
+main.c
+--replace-all-calls-with-contracts
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+--
+Verification:
+This test case checks the handling of a forall expression
+nested within an implication.

--- a/regression/contracts/quantifiers-nested-03/main.c
+++ b/regression/contracts/quantifiers-nested-03/main.c
@@ -1,0 +1,19 @@
+int f1(int *arr)
+  __CPROVER_ensures(__CPROVER_return_value == 0 && __CPROVER_exists {
+    int i;
+    (0 <= i && i < 10) && arr[i] == i
+  })
+{
+  for(int i = 0; i < 10; i++)
+  {
+    arr[i] = i;
+  }
+
+  return 0;
+}
+
+int main()
+{
+  int arr[10];
+  f1(arr);
+}

--- a/regression/contracts/quantifiers-nested-03/test.desc
+++ b/regression/contracts/quantifiers-nested-03/test.desc
@@ -1,0 +1,11 @@
+CORE
+main.c
+--enforce-all-contracts
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+--
+Verification:
+This test case checks the handling of an exists expression
+nested within a conjunction.

--- a/regression/contracts/quantifiers-nested-04/main.c
+++ b/regression/contracts/quantifiers-nested-04/main.c
@@ -1,0 +1,21 @@
+// clang-format off
+int f1(int *arr) __CPROVER_requires(
+  __CPROVER_forall {
+    int i;
+    (0 <= i && i < 10) ==> arr[i] == 0
+  } ||
+  arr[9] == -1 ||
+  __CPROVER_exists {
+    int i;
+    (0 <= i && i < 10) && arr[i] == i
+  }) __CPROVER_ensures(__CPROVER_return_value == 0)
+// clang-format on
+{
+  return 0;
+}
+
+int main()
+{
+  int arr[10] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+  f1(arr);
+}

--- a/regression/contracts/quantifiers-nested-04/test.desc
+++ b/regression/contracts/quantifiers-nested-04/test.desc
@@ -1,0 +1,11 @@
+CORE
+main.c
+--replace-all-calls-with-contracts
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+--
+Verification:
+This test case checks the handling of both a forall expression
+and an exists expression nested within a disjunction.

--- a/regression/contracts/quantifiers-nested-05/main.c
+++ b/regression/contracts/quantifiers-nested-05/main.c
@@ -1,0 +1,15 @@
+// clang-format off
+int f1(int *arr) __CPROVER_requires(!__CPROVER_forall {
+    int i;
+    (0 <= i && i < 10) ==> arr[i] == 0
+  }) __CPROVER_ensures(__CPROVER_return_value == 0)
+// clang-format on
+{
+  return 0;
+}
+
+int main()
+{
+  int arr[10] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+  f1(arr);
+}

--- a/regression/contracts/quantifiers-nested-05/test.desc
+++ b/regression/contracts/quantifiers-nested-05/test.desc
@@ -1,0 +1,11 @@
+CORE
+main.c
+--replace-all-calls-with-contracts
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+--
+Verification:
+This test case checks the handling of a forall expression
+nested within a negation.

--- a/regression/contracts/quantifiers-nested-06/main.c
+++ b/regression/contracts/quantifiers-nested-06/main.c
@@ -1,0 +1,27 @@
+// clang-format off
+int f1(int *arr) __CPROVER_requires(
+  (__CPROVER_forall {
+    int i;
+    (0 <= i && i < 10) ==> arr[i] == 0
+  } ? __CPROVER_exists {
+    int i;
+    (0 <= i && i < 10) ==> arr[i] == 0
+  } : 1 == 0) &&
+  (__CPROVER_forall {
+    int i;
+    (0 <= i && i < 10) ==> arr[i] == i
+  } ? 1 == 0 :
+    __CPROVER_forall {
+      int i;
+      (0 <= i && i < 10) ==> arr[i] == 0
+  })) __CPROVER_ensures(__CPROVER_return_value == 0)
+// clang-format on
+{
+  return 0;
+}
+
+int main()
+{
+  int arr[10] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+  f1(arr);
+}

--- a/regression/contracts/quantifiers-nested-06/test.desc
+++ b/regression/contracts/quantifiers-nested-06/test.desc
@@ -1,0 +1,11 @@
+CORE
+main.c
+--replace-all-calls-with-contracts
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+--
+Verification:
+This test case checks the handling of forall and exists expressions
+nested within ternary ITE expressions (condition ? true : false).

--- a/src/goto-instrument/code_contracts.h
+++ b/src/goto-instrument/code_contracts.h
@@ -167,8 +167,10 @@ protected:
   void
   add_contract_check(const irep_idt &, const irep_idt &, goto_programt &dest);
 
-  /// If the expression is a quantified expression, this function adds
-  /// the quantified variable to the symbol table and to the expression map
+  /// This function recursively searches the expression to find nested or
+  /// non-nested quantified expressions. When a quantified expression is found,
+  /// the quantified variable is added to the symbol table
+  /// and to the expression map.
   void add_quantified_variable(
     exprt expression,
     replace_symbolt &replace,


### PR DESCRIPTION
This PR adds support for nested quantified expressions in function contracts. It is a direct extension to #5959 
<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [x] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [x] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
