### PR TITLE
Adds support for range annotation in assigns clauses

### DIFF
--- a/regression/contracts/assigns_enforce_arrays_01/main.c
+++ b/regression/contracts/assigns_enforce_arrays_01/main.c
@@ -1,4 +1,6 @@
-void f1(int a[], int len) __CPROVER_assigns(a)
+/* clang-format off */
+void f1(int a[], int len) __CPROVER_assigns(a[2 .. 5])
+/* clang-format on */
 {
   int b[10];
   a = b;

--- a/regression/contracts/assigns_enforce_arrays_02/main.c
+++ b/regression/contracts/assigns_enforce_arrays_02/main.c
@@ -8,7 +8,9 @@ int nextIdx() __CPROVER_assigns(idx)
   return idx;
 }
 
-void f1(int a[], int len)
+/* clang-format off */
+void f1(int a[], int len) __CPROVER_assigns(idx, a[2 .. 5])
+/* clang-format on */
 {
   a[nextIdx()] = 5;
 }

--- a/regression/contracts/assigns_enforce_arrays_03/main.c
+++ b/regression/contracts/assigns_enforce_arrays_03/main.c
@@ -1,12 +1,16 @@
-void assign_out_under(int a[], int len) __CPROVER_assigns(a)
+/* clang-format off */
+void f1(int a[], int len) __CPROVER_assigns(a[2 .. 5])
+/* clang-format on */
 {
-  a[1] = 5;
+  int *indr;
+  indr = a + 3;
+  *indr = 5;
 }
 
 int main()
 {
   int arr[10];
-  assign_out_under(arr, 10);
+  f1(arr, 10);
 
   return 0;
 }

--- a/regression/contracts/assigns_enforce_arrays_03/test.desc
+++ b/regression/contracts/assigns_enforce_arrays_03/test.desc
@@ -1,10 +1,10 @@
 CORE
 main.c
 --enforce-all-contracts
-^EXIT=10$
+^EXIT=0$
 ^SIGNAL=0$
-^VERIFICATION FAILED$
+^VERIFICATION SUCCESSFUL$
 --
 --
-Checks whether verification fails when an array is assigned at an index
-below its lower bound.
+Checks whether verification succeeds when an array is assigned indirectly
+through a pointer.

--- a/regression/contracts/assigns_enforce_arrays_04/test.desc
+++ b/regression/contracts/assigns_enforce_arrays_04/test.desc
@@ -6,6 +6,6 @@ main.c
 ^VERIFICATION SUCCESSFUL$
 --
 --
-Checks whether verification succeeds when an array is assigned through
-calls to functions with array assigns clauses which are compatible with
-that of the caller.
+Checks whether verification succeeds when an array is assigned at both upper
+and lower bounds of its assignable array range. Single-value array range
+assignment is checked as well.

--- a/regression/contracts/assigns_enforce_arrays_05/main.c
+++ b/regression/contracts/assigns_enforce_arrays_05/main.c
@@ -1,18 +1,14 @@
-void assigns_ptr(int *x) __CPROVER_assigns(*x)
+/* clang-format off */
+void assign_out_under(int a[], int len) __CPROVER_assigns(a[2 .. 5])
+/* clang-format on */
 {
-  *x = 200;
-}
-
-void assigns_range(int a[], int len) __CPROVER_assigns(a)
-{
-  int *ptr = &(a[7]);
-  assigns_ptr(ptr);
+  a[1] = 5;
 }
 
 int main()
 {
   int arr[10];
-  assigns_range(arr, 10);
+  assign_out_under(arr, 10);
 
   return 0;
 }

--- a/regression/contracts/assigns_enforce_arrays_06/main.c
+++ b/regression/contracts/assigns_enforce_arrays_06/main.c
@@ -1,0 +1,12 @@
+void assign_out_under(int a[], int len) __CPROVER_assigns(a[8])
+{
+  a[7] = 5;
+}
+
+int main()
+{
+  int arr[10];
+  assign_out_under(arr, 10);
+
+  return 0;
+}

--- a/regression/contracts/assigns_enforce_arrays_06/test.desc
+++ b/regression/contracts/assigns_enforce_arrays_06/test.desc
@@ -1,0 +1,11 @@
+CORE
+main.c
+--enforce-all-contracts
+^EXIT=10$
+^SIGNAL=0$
+^VERIFICATION FAILED$
+--
+--
+Checks whether verification fails when an array is assigned at an index below
+its allowed index and specification contains only a single cell
+instead of a range.

--- a/regression/contracts/assigns_enforce_arrays_07/main.c
+++ b/regression/contracts/assigns_enforce_arrays_07/main.c
@@ -1,0 +1,14 @@
+/* clang-format off */
+void assign_out_over(int a[], int len) __CPROVER_assigns(a[2 .. 5])
+/* clang-format on */
+{
+  a[6] = 5;
+}
+
+int main()
+{
+  int arr[10];
+  assign_out_over(arr, 10);
+
+  return 0;
+}

--- a/regression/contracts/assigns_enforce_arrays_07/test.desc
+++ b/regression/contracts/assigns_enforce_arrays_07/test.desc
@@ -7,4 +7,4 @@ main.c
 --
 --
 Checks whether verification fails when an array is assigned at an index
-below its lower bound.
+above its upper bound.

--- a/regression/contracts/assigns_enforce_arrays_08/main.c
+++ b/regression/contracts/assigns_enforce_arrays_08/main.c
@@ -1,0 +1,12 @@
+void assign_out_under(int a[], int len) __CPROVER_assigns(a[8])
+{
+  a[9] = 5;
+}
+
+int main()
+{
+  int arr[10];
+  assign_out_under(arr, 10);
+
+  return 0;
+}

--- a/regression/contracts/assigns_enforce_arrays_08/test.desc
+++ b/regression/contracts/assigns_enforce_arrays_08/test.desc
@@ -7,4 +7,4 @@ main.c
 --
 --
 Checks whether verification fails when an array is assigned at an index
-below its lower bound.
+above its allowed index.

--- a/regression/contracts/assigns_enforce_arrays_09/main.c
+++ b/regression/contracts/assigns_enforce_arrays_09/main.c
@@ -1,0 +1,14 @@
+/* clang-format off */
+void assigns_in_range(int a[], int last_idx) __CPROVER_assigns(a[2 .. last_idx])
+/* clang-format on */
+{
+  a[last_idx] = 6;
+}
+
+int main()
+{
+  int arr[10];
+  assigns_in_range(arr, 9);
+
+  return 0;
+}

--- a/regression/contracts/assigns_enforce_arrays_09/test.desc
+++ b/regression/contracts/assigns_enforce_arrays_09/test.desc
@@ -1,0 +1,10 @@
+CORE
+main.c
+--enforce-all-contracts
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+--
+Checks whether verification succeeds when an array is assigned at the upper
+bounds of its assignable array range, when the range has a non-constant bound.

--- a/regression/contracts/assigns_enforce_arrays_10/main.c
+++ b/regression/contracts/assigns_enforce_arrays_10/main.c
@@ -1,0 +1,15 @@
+/* clang-format off */
+void assigns_in_range(int a[], int last_idx) __CPROVER_assigns(a[2 .. last_idx])
+/* clang-format on */
+{
+  last_idx++;
+  a[last_idx] = 6;
+}
+
+int main()
+{
+  int arr[10];
+  assigns_in_range(arr, 9);
+
+  return 0;
+}

--- a/regression/contracts/assigns_enforce_arrays_10/test.desc
+++ b/regression/contracts/assigns_enforce_arrays_10/test.desc
@@ -1,0 +1,12 @@
+CORE
+main.c
+--enforce-all-contracts
+^EXIT=10$
+^SIGNAL=0$
+^VERIFICATION FAILED$
+--
+--
+Checks whether verification fails when an array is assigned past the upper
+bound of its assignable array range, using the symbol of the upper bound,
+after it has been incremented. This is intended to show that the bounds
+are determined at the time the function is called.

--- a/regression/contracts/assigns_enforce_arrays_11/main.c
+++ b/regression/contracts/assigns_enforce_arrays_11/main.c
@@ -1,0 +1,25 @@
+void assigns_single(int a[], int len) __CPROVER_assigns(a[7])
+{
+}
+
+/* clang-format off */
+void assigns_range(int a[], int len) __CPROVER_assigns(a[2 .. 5])
+/* clang-format on */
+{
+}
+
+/* clang-format off */
+void assigns_big_range(int a[], int len) __CPROVER_assigns(a[2 .. 7])
+/* clang-format on */
+{
+  assigns_single(a, len);
+  assigns_range(a, len);
+}
+
+int main()
+{
+  int arr[10];
+  assigns_big_range(arr, 10);
+
+  return 0;
+}

--- a/regression/contracts/assigns_enforce_arrays_11/test.desc
+++ b/regression/contracts/assigns_enforce_arrays_11/test.desc
@@ -1,0 +1,11 @@
+CORE
+main.c
+--enforce-all-contracts
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+--
+Checks whether verification succeeds when an array is assigned through
+calls to functions with array assigns clauses which are compatible with
+that of the caller.

--- a/regression/contracts/assigns_enforce_arrays_12/main.c
+++ b/regression/contracts/assigns_enforce_arrays_12/main.c
@@ -1,0 +1,20 @@
+/* clang-format off */
+void assign_25(int a[], int len) __CPROVER_assigns(a[2 .. 5])
+/* clang-format on */
+{
+}
+
+/* clang-format off */
+void assign_37(int a[], int len) __CPROVER_assigns(a[3 .. 7])
+/* clang-format on */
+{
+  assign_25(a, len);
+}
+
+int main()
+{
+  int arr[10];
+  assign_37(arr, 10);
+
+  return 0;
+}

--- a/regression/contracts/assigns_enforce_arrays_12/test.desc
+++ b/regression/contracts/assigns_enforce_arrays_12/test.desc
@@ -1,0 +1,10 @@
+CORE
+main.c
+--enforce-all-contracts
+^EXIT=10$
+^SIGNAL=0$
+^VERIFICATION FAILED$
+--
+--
+Checks whether verification fails when a function with an array assigns target
+calls a function which may assign below the allowable range.

--- a/regression/contracts/assigns_enforce_arrays_13/main.c
+++ b/regression/contracts/assigns_enforce_arrays_13/main.c
@@ -1,0 +1,20 @@
+void assigns_ptr(int *x) __CPROVER_assigns(*x)
+{
+  *x = 200;
+}
+
+/* clang-format off */
+void assigns_range(int a[], int len) __CPROVER_assigns(a[2 .. 5])
+/* clang-format on */
+{
+  int *ptr = &(a[3]);
+  assigns_ptr(ptr);
+}
+
+int main()
+{
+  int arr[10];
+  assigns_range(arr, 10);
+
+  return 0;
+}

--- a/regression/contracts/assigns_enforce_arrays_13/test.desc
+++ b/regression/contracts/assigns_enforce_arrays_13/test.desc
@@ -1,0 +1,10 @@
+CORE
+main.c
+--enforce-all-contracts
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+--
+Checks whether verification succeeds when an array is assigned via a
+function call which assigns a pointer to one of its elements.

--- a/regression/contracts/assigns_enforce_arrays_14/main.c
+++ b/regression/contracts/assigns_enforce_arrays_14/main.c
@@ -1,0 +1,20 @@
+void assigns_ptr(int *x) __CPROVER_assigns(*x)
+{
+  *x = 200;
+}
+
+/* clang-format off */
+void assigns_range(int a[], int len) __CPROVER_assigns(a[2 .. 5])
+/* clang-format on */
+{
+  int *ptr = &(a[7]);
+  assigns_ptr(ptr);
+}
+
+int main()
+{
+  int arr[10];
+  assigns_range(arr, 10);
+
+  return 0;
+}

--- a/regression/contracts/assigns_enforce_arrays_14/test.desc
+++ b/regression/contracts/assigns_enforce_arrays_14/test.desc
@@ -1,0 +1,11 @@
+CORE
+main.c
+--enforce-all-contracts
+^EXIT=10$
+^SIGNAL=0$
+^VERIFICATION FAILED$
+--
+--
+Checks whether verification fails when an array is assigned via a
+function call which assigns a pointer to an element out of the
+allowable range.

--- a/regression/contracts/assigns_enforce_multi_file_03/header.h
+++ b/regression/contracts/assigns_enforce_multi_file_03/header.h
@@ -1,3 +1,9 @@
+void assigns_single(int a[], int len);
+
+void assigns_upper_bound(int a[], int len);
+
+void assigns_lower_bound(int a[], int len);
+
 void assigns_single(int a[], int len) __CPROVER_assigns(a[8])
 {
   a[8] = 20;
@@ -12,17 +18,7 @@ void assigns_upper_bound(int a[], int len) __CPROVER_assigns(a[2 .. 5])
 
 /* clang-format off */
 void assigns_lower_bound(int a[], int len) __CPROVER_assigns(a[2 .. 5])
-/* clang-format oon */
+/* clang-format on */
 {
   a[2] = 10;
-}
-
-int main()
-{
-  int arr[10];
-  assigns_upper_bound(arr, 10);
-  assigns_lower_bound(arr, 10);
-  assigns_single(arr, 10);
-
-  return 0;
 }

--- a/regression/contracts/assigns_enforce_multi_file_03/main.c
+++ b/regression/contracts/assigns_enforce_multi_file_03/main.c
@@ -1,0 +1,11 @@
+#include "header.h"
+
+int main()
+{
+  int arr[10];
+  assigns_upper_bound(arr, 10);
+  assigns_lower_bound(arr, 10);
+  assigns_single(arr, 10);
+
+  return 0;
+}

--- a/regression/contracts/assigns_enforce_multi_file_03/test.desc
+++ b/regression/contracts/assigns_enforce_multi_file_03/test.desc
@@ -1,0 +1,10 @@
+CORE
+main.c
+--enforce-all-contracts
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+--
+This test replicates the behavior of assigns_enforce_arrays_04, but separates
+the function headers and contracts into a separate file header.h.

--- a/regression/contracts/assigns_replace_06/main.c
+++ b/regression/contracts/assigns_replace_06/main.c
@@ -1,10 +1,12 @@
 #include <assert.h>
 
-void foo(char c[]) __CPROVER_assigns(c)
+/* clang-format off */
+void foo(char c[]) __CPROVER_assigns(c[2 .. 4])
+/* clang-format on */
 {
 }
 
-void bar(char d[]) __CPROVER_assigns(d)
+void bar(char d[]) __CPROVER_assigns(d[7])
 {
 }
 

--- a/regression/contracts/assigns_replace_07/test.desc
+++ b/regression/contracts/assigns_replace_07/test.desc
@@ -6,5 +6,5 @@ main.c
 ^VERIFICATION FAILED$
 --
 --
-Checks whether the value inside a single-index array assigns target is
-havocked when calling the associated function.
+Checks whether the values inside an array range specified by the assigns
+target are havocked when calling the associated function.

--- a/regression/contracts/assigns_replace_08/main.c
+++ b/regression/contracts/assigns_replace_08/main.c
@@ -1,8 +1,6 @@
 #include <assert.h>
 
-/* clang-format off */
-void foo(char c[]) __CPROVER_assigns(c[2 .. 4])
-/* clang-format on */
+void bar(char d[]) __CPROVER_assigns(d[7])
 {
 }
 
@@ -19,8 +17,8 @@ int main()
   b[7] = 'h';
   b[8] = 'i';
   b[9] = 'j';
-  foo(b);
-  assert(b[2] == 'c' || b[3] == 'd' || b[4] == 'e');
+  bar(b);
+  assert(b[7] == 'h');
 
   return 0;
 }

--- a/regression/contracts/assigns_replace_08/test.desc
+++ b/regression/contracts/assigns_replace_08/test.desc
@@ -1,0 +1,10 @@
+CORE
+main.c
+--replace-all-calls-with-contracts
+^EXIT=10$
+^SIGNAL=0$
+^VERIFICATION FAILED$
+--
+--
+Checks whether the value inside a single-index array assigns target is
+havocked when calling the associated function.

--- a/src/ansi-c/c_typecheck_base.h
+++ b/src/ansi-c/c_typecheck_base.h
@@ -163,6 +163,7 @@ protected:
   virtual void typecheck_expr_operands(exprt &expr);
   virtual void typecheck_expr_comma(exprt &expr);
   virtual void typecheck_expr_constant(exprt &expr);
+  virtual void typecheck_expr_range(exprt &expr);
   virtual void typecheck_expr_side_effect(side_effect_exprt &expr);
   virtual void typecheck_expr_unary_arithmetic(exprt &expr);
   virtual void typecheck_expr_unary_boolean(exprt &expr);

--- a/src/ansi-c/c_typecheck_expr.cpp
+++ b/src/ansi-c/c_typecheck_expr.cpp
@@ -491,12 +491,26 @@ void c_typecheck_baset::typecheck_expr_main(exprt &expr)
   {
     // already type checked
   }
+  else if(expr.id() == ID_range)
+  {
+    typecheck_expr_range(expr);
+  }
   else
   {
     error().source_location = expr.source_location();
     error() << "unexpected expression: " << expr.pretty() << eom;
     throw 0;
   }
+}
+
+void c_typecheck_baset::typecheck_expr_range(exprt &expr)
+{
+  // Already type checked
+  exprt &lower = to_range_exprt(expr).lower();
+  exprt &upper = to_range_exprt(expr).upper();
+
+  implicit_typecast_arithmetic(lower);
+  implicit_typecast_arithmetic(upper);
 }
 
 void c_typecheck_baset::typecheck_expr_comma(exprt &expr)

--- a/src/ansi-c/scanner.l
+++ b/src/ansi-c/scanner.l
@@ -1517,6 +1517,7 @@ __decltype          { if(PARSER.cpp98 &&
 "&&"            { loc(); return TOK_ANDAND; }
 "||"            { loc(); return TOK_OROR; }
 "..."           { loc(); return TOK_ELLIPSIS; }
+".."            { loc(); return TOK_RANGE; }
 
 "*="            { loc(); return TOK_MULTASSIGN; }
 "/="            { loc(); return TOK_DIVASSIGN; }

--- a/src/util/std_expr.h
+++ b/src/util/std_expr.h
@@ -824,6 +824,67 @@ inline multi_ary_exprt &to_multi_ary_expr(exprt &expr)
   return static_cast<multi_ary_exprt &>(expr);
 }
 
+/// \brief A base class for int-range expressions
+class range_exprt : public expr_protectedt
+{
+public:
+  range_exprt(exprt &lower, exprt &upper, typet _type)
+    : expr_protectedt(
+        ID_range,
+        std::move(_type),
+        {std::move(lower), std::move(upper)})
+  {
+  }
+
+  exprt &lower()
+  {
+    return op0();
+  }
+
+  const exprt &lower() const
+  {
+    return op0();
+  }
+
+  exprt &upper()
+  {
+    return op1();
+  }
+
+  const exprt &upper() const
+  {
+    return op1();
+  }
+
+  const exprt &op2() const = delete;
+  exprt &op2() = delete;
+  const exprt &op3() const = delete;
+  exprt &op3() = delete;
+};
+
+/// \brief Cast an exprt to a \ref range_exprt
+///
+/// \a expr must be known to be \ref range_exprt.
+///
+/// \param expr: Source expression
+/// \return Object of type \ref range_exprt
+inline const range_exprt &to_range_exprt(const exprt &expr)
+{
+  PRECONDITION(expr.id() == ID_range);
+  return static_cast<const range_exprt &>(expr);
+}
+
+/// \brief Cast an exprt to a \ref range_exprt
+///
+/// \a expr must be known to be \ref range_exprt.
+///
+/// \param expr: Source expression
+/// \return Object of type \ref range_exprt
+inline range_exprt &to_range_exprt(exprt &expr)
+{
+  PRECONDITION(expr.id() == ID_range);
+  return static_cast<range_exprt &>(expr);
+}
 
 /// \brief The plus expression
 /// Associativity is not specified.


### PR DESCRIPTION
We proposed an initial support for array ranges based on the ACSL language at #5538. As discussed at #5966, this might not be the correct approach to handle arrays in assigns clause. I'll keep this PR open until we agree on a proper design for assigns clauses moving forward.

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [x] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
