### PR TITLE
Fix SMT2 encoding of `array_comprehension_exprt`

### DIFF
--- a/regression/cbmc/byte_update15/test.desc
+++ b/regression/cbmc/byte_update15/test.desc
@@ -1,4 +1,4 @@
-CORE broken-smt-backend
+CORE broken-cprover-smt-backend
 main.c
 
 ^EXIT=0$
@@ -6,3 +6,6 @@ main.c
 ^VERIFICATION SUCCESSFUL$
 --
 ^warning: ignoring
+--
+This test currently does not pass with CPROVER SMT2 backend
+because the solver does not fully support quantified expressions.

--- a/src/solvers/smt2/smt2_conv.h
+++ b/src/solvers/smt2/smt2_conv.h
@@ -62,6 +62,7 @@ public:
   bool use_as_const;
   bool use_datatypes;
   bool use_array_of_bool;
+  bool use_lambda_for_array;
   bool emit_set_logic;
 
   exprt handle(const exprt &expr) override;


### PR DESCRIPTION
The SMT conversion routines were missing a rule for translating `array_comprehension_exprt`.

This PR creates a new translation rule leveraging the `lambda` construct in SMTLIB2.

NOTE: There may be several other `broken-smt-backend` regression tests that may be fixed by this change; I haven't checked (there are too many!).

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] NA ~~Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.~~
- [ ] NA ~~The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/~~
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] NA ~~My commit message includes data points confirming performance improvements (if claimed).~~
- [x] My PR is restricted to a single feature or bugfix.
- [ ] NA ~~White-space or formatting changes outside the feature-related changed lines are in commits of their own.~~