### PR TITLE
Fix SMT2 encoding of `array_of_exprt`

### DIFF
--- a/src/solvers/smt2/smt2_conv.h
+++ b/src/solvers/smt2/smt2_conv.h
@@ -59,6 +59,7 @@ public:
   ~smt2_convt() override = default;
 
   bool use_FPA_theory;
+  bool use_as_const;
   bool use_datatypes;
   bool use_array_of_bool;
   bool emit_set_logic;


### PR DESCRIPTION
The SMT conversion routines were broken for `array_comprehension_exprt`. They used quantifiers to initialize constant arrays, but that encoding didn't seem to work with existing SMT solvers.

This PR fixes the translation rule by using the `as const` construct in SMTLIB2.

NOTE: I am not sure which regression test is directly affected by this, I just noticed this issue while fixing another bug [#5973]. I'd be happy to add a new regression test, but there must be some `broken-smt-backend` regression test blocked on this one.

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] NA ~~Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.~~
- [ ] NA ~~The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/~~
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] NA ~~My commit message includes data points confirming performance improvements (if claimed).~~
- [x] My PR is restricted to a single feature or bugfix.
- [ ] NA ~~White-space or formatting changes outside the feature-related changed lines are in commits of their own.~~