### PR TITLE
Introduce expression classes for r_ok and w_ok

### DIFF
--- a/src/analyses/goto_check.cpp
+++ b/src/analyses/goto_check.cpp
@@ -1261,7 +1261,7 @@ void goto_checkt::pointer_primitive_check(
     return;
 
   const exprt pointer = (expr.id() == ID_r_ok || expr.id() == ID_w_ok)
-                          ? to_binary_expr(expr).lhs()
+                          ? to_r_or_w_ok_expr(expr).pointer()
                           : to_unary_expr(expr).op();
 
   CHECK_RETURN(pointer.type().id() == ID_pointer);
@@ -1822,7 +1822,7 @@ optionalt<exprt> goto_checkt::rw_ok_check(exprt expr)
       expr.operands().size() == 2, "r/w_ok must have two operands");
 
     const auto conditions = get_pointer_dereferenceable_conditions(
-      to_binary_expr(expr).op0(), to_binary_expr(expr).op1());
+      to_r_or_w_ok_expr(expr).pointer(), to_r_or_w_ok_expr(expr).size());
 
     exprt::operandst conjuncts;
 

--- a/src/ansi-c/c_typecheck_expr.cpp
+++ b/src/ansi-c/c_typecheck_expr.cpp
@@ -2550,8 +2550,7 @@ exprt c_typecheck_baset::do_special_functions(
 
     irep_idt id = identifier == CPROVER_PREFIX "r_ok" ? ID_r_ok : ID_w_ok;
 
-    binary_predicate_exprt ok_expr(
-      expr.arguments()[0], id, expr.arguments()[1]);
+    r_or_w_ok_exprt ok_expr(id, expr.arguments()[0], expr.arguments()[1]);
     ok_expr.add_source_location() = source_location;
 
     return std::move(ok_expr);

--- a/src/util/pointer_expr.h
+++ b/src/util/pointer_expr.h
@@ -462,4 +462,69 @@ public:
   }
 };
 
+/// \brief A base class for a predicate that indicates that an
+/// address range is ok to read or write
+class r_or_w_ok_exprt : public binary_predicate_exprt
+{
+public:
+  explicit r_or_w_ok_exprt(irep_idt id, exprt pointer, exprt size)
+    : binary_predicate_exprt(std::move(pointer), id, std::move(size))
+  {
+  }
+
+  const exprt &pointer() const
+  {
+    return op0();
+  }
+
+  const exprt &size() const
+  {
+    return op1();
+  }
+};
+
+inline const r_or_w_ok_exprt &to_r_or_w_ok_expr(const exprt &expr)
+{
+  PRECONDITION(expr.id() == ID_r_ok || expr.id() == ID_w_ok);
+  auto &ret = static_cast<const r_or_w_ok_exprt &>(expr);
+  validate_expr(ret);
+  return ret;
+}
+
+/// \brief A predicate that indicates that an address range is ok to read
+class r_ok_exprt : public r_or_w_ok_exprt
+{
+public:
+  explicit r_ok_exprt(exprt pointer, exprt size)
+    : r_or_w_ok_exprt(ID_r_ok, std::move(pointer), std::move(size))
+  {
+  }
+};
+
+inline const r_ok_exprt &to_r_ok_expr(const exprt &expr)
+{
+  PRECONDITION(expr.id() == ID_r_ok);
+  const r_ok_exprt &ret = static_cast<const r_ok_exprt &>(expr);
+  validate_expr(ret);
+  return ret;
+}
+
+/// \brief A predicate that indicates that an address range is ok to write
+class w_ok_exprt : public r_or_w_ok_exprt
+{
+public:
+  explicit w_ok_exprt(exprt pointer, exprt size)
+    : r_or_w_ok_exprt(ID_w_ok, std::move(pointer), std::move(size))
+  {
+  }
+};
+
+inline const w_ok_exprt &to_w_ok_expr(const exprt &expr)
+{
+  PRECONDITION(expr.id() == ID_w_ok);
+  const w_ok_exprt &ret = static_cast<const w_ok_exprt &>(expr);
+  validate_expr(ret);
+  return ret;
+}
+
 #endif // CPROVER_UTIL_POINTER_EXPR_H


### PR DESCRIPTION
This commit documents two existing expressions.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
