### PR TITLE
SMT2 parser: add 'as const'

### DIFF
--- a/regression/smt2_solver/arrays/as_const1.desc
+++ b/regression/smt2_solver/arrays/as_const1.desc
@@ -1,0 +1,7 @@
+CORE
+as_const1.smt2
+
+^EXIT=0$
+^SIGNAL=0$
+^unsat$
+--

--- a/regression/smt2_solver/arrays/as_const1.smt2
+++ b/regression/smt2_solver/arrays/as_const1.smt2
@@ -1,0 +1,8 @@
+; an array consisting of all #x10
+(declare-const array (Array (_ BitVec 16) (_ BitVec 8)))
+(assert (= array ((as const (Array (_ BitVec 16) (_ BitVec 8))) #x10)))
+
+(declare-const index (_ BitVec 16))
+(assert (not (= #x10 (select array index))))
+
+(check-sat)

--- a/regression/smt2_solver/arrays/as_const2.desc
+++ b/regression/smt2_solver/arrays/as_const2.desc
@@ -1,0 +1,8 @@
+CORE
+as_const2.smt2
+
+^EXIT=0$
+^SIGNAL=0$
+^sat$
+^\(\(sample \(_ bv16 8\)\)\)$
+--

--- a/regression/smt2_solver/arrays/as_const2.smt2
+++ b/regression/smt2_solver/arrays/as_const2.smt2
@@ -1,0 +1,9 @@
+; an array consisting of all #x10
+(declare-const array (Array (_ BitVec 16) (_ BitVec 8)))
+(assert (= array ((as const (Array (_ BitVec 16) (_ BitVec 8))) #x10)))
+
+(declare-const sample (_ BitVec 8))
+(assert (= sample (select array #x0000)))
+
+(check-sat)
+(get-value (sample))


### PR DESCRIPTION
This is an extension understood by Z3 and CVC4, which is the equivalent of
array_of_exprt.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [X] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
