### PR TITLE
Vsd - merge values

### DIFF
--- a/src/analyses/variable-sensitivity/abstract_object.h
+++ b/src/analyses/variable-sensitivity/abstract_object.h
@@ -456,6 +456,10 @@ protected:
     top = false;
     this->set_not_top_internal();
   }
+  void set_not_bottom()
+  {
+    bottom = false;
+  }
 };
 
 struct abstract_hashert

--- a/src/analyses/variable-sensitivity/abstract_object_set.cpp
+++ b/src/analyses/variable-sensitivity/abstract_object_set.cpp
@@ -37,7 +37,7 @@ void abstract_object_sett::output(
   join_strings(out, output_values.begin(), output_values.end(), ", ");
 }
 
-abstract_object_pointert abstract_object_sett::to_interval()
+constant_interval_exprt abstract_object_sett::to_interval() const
 {
   PRECONDITION(!values.empty());
 
@@ -49,6 +49,5 @@ abstract_object_pointert abstract_object_sett::to_interval()
     lower_expr = constant_interval_exprt::get_min(lower_expr, value_expr);
     upper_expr = constant_interval_exprt::get_max(upper_expr, value_expr);
   }
-  return std::make_shared<interval_abstract_valuet>(
-    constant_interval_exprt(lower_expr, upper_expr));
+  return constant_interval_exprt(lower_expr, upper_expr);
 }

--- a/src/analyses/variable-sensitivity/abstract_object_set.cpp
+++ b/src/analyses/variable-sensitivity/abstract_object_set.cpp
@@ -41,13 +41,20 @@ constant_interval_exprt abstract_object_sett::to_interval() const
 {
   PRECONDITION(!values.empty());
 
-  exprt lower_expr = first()->to_constant();
-  exprt upper_expr = first()->to_constant();
+  const auto &initial =
+    std::dynamic_pointer_cast<const abstract_value_objectt>(first());
+
+  exprt lower_expr = initial->to_interval().get_lower();
+  exprt upper_expr = initial->to_interval().get_upper();
   for(const auto &value : values)
   {
-    const auto &value_expr = value->to_constant();
-    lower_expr = constant_interval_exprt::get_min(lower_expr, value_expr);
-    upper_expr = constant_interval_exprt::get_max(upper_expr, value_expr);
+    const auto &v =
+      std::dynamic_pointer_cast<const abstract_value_objectt>(value);
+    const auto &value_expr = v->to_interval();
+    lower_expr =
+      constant_interval_exprt::get_min(lower_expr, value_expr.get_lower());
+    upper_expr =
+      constant_interval_exprt::get_max(upper_expr, value_expr.get_upper());
   }
   return constant_interval_exprt(lower_expr, upper_expr);
 }

--- a/src/analyses/variable-sensitivity/abstract_object_set.h
+++ b/src/analyses/variable-sensitivity/abstract_object_set.h
@@ -80,10 +80,9 @@ public:
   void
   output(std::ostream &out, const ai_baset &ai, const namespacet &ns) const;
 
-  /// Cast the set of values \p other_values to an interval.
-  /// \param other_values: the value-set to be abstracted into an interval
-  /// \return the interval-abstract-object containing \p other_values
-  abstract_object_pointert to_interval();
+  /// Calculate the set of values as an interval.
+  /// \return the constant_interval_exprt bounding the values
+  constant_interval_exprt to_interval() const;
 
 private:
   value_sett values;

--- a/src/analyses/variable-sensitivity/abstract_value_object.cpp
+++ b/src/analyses/variable-sensitivity/abstract_value_object.cpp
@@ -631,9 +631,15 @@ private:
     auto unwrapped_values = unwrap_and_extract_values(new_values);
 
     if(unwrapped_values.size() > value_set_abstract_objectt::max_value_set_size)
-      return unwrapped_values.to_interval();
+      return make_interval(unwrapped_values);
 
     return make_value_set(unwrapped_values);
+  }
+
+  static abstract_object_pointert
+  make_interval(const abstract_object_sett &values)
+  {
+    return std::make_shared<interval_abstract_valuet>(values.to_interval());
   }
 
   static abstract_object_pointert

--- a/src/analyses/variable-sensitivity/abstract_value_object.h
+++ b/src/analyses/variable-sensitivity/abstract_value_object.h
@@ -291,4 +291,6 @@ protected:
   value_range_implementation() const = 0;
 };
 
+using abstract_value_pointert = sharing_ptrt<const abstract_value_objectt>;
+
 #endif

--- a/src/analyses/variable-sensitivity/abstract_value_object.h
+++ b/src/analyses/variable-sensitivity/abstract_value_object.h
@@ -13,6 +13,7 @@
 #define CPROVER_ANALYSES_VARIABLE_SENSITIVITY_ABSTRACT_VALUE_OBJECT_H
 
 #include <analyses/variable-sensitivity/abstract_object.h>
+#include <util/interval.h>
 
 class abstract_value_tag
 {
@@ -264,6 +265,8 @@ public:
   {
     return value_ranget(value_range_implementation());
   }
+
+  virtual constant_interval_exprt to_interval() const = 0;
 
   /// Interface for transforms
   ///

--- a/src/analyses/variable-sensitivity/constant_abstract_value.cpp
+++ b/src/analyses/variable-sensitivity/constant_abstract_value.cpp
@@ -42,6 +42,11 @@ constant_abstract_valuet::constant_abstract_valuet(const typet &t)
 {
 }
 
+constant_abstract_valuet::constant_abstract_valuet(const exprt &e)
+  : abstract_value_objectt(e.type(), false, false), value(e)
+{
+}
+
 constant_abstract_valuet::constant_abstract_valuet(
   const typet &t,
   bool tp,
@@ -104,38 +109,25 @@ void constant_abstract_valuet::output(
 abstract_object_pointert
 constant_abstract_valuet::merge(abstract_object_pointert other) const
 {
-  constant_abstract_value_pointert cast_other =
-    std::dynamic_pointer_cast<const constant_abstract_valuet>(other);
+  auto cast_other =
+    std::dynamic_pointer_cast<const abstract_value_objectt>(other);
   if(cast_other)
-  {
     return merge_constant_constant(cast_other);
-  }
-  else
-  {
-    // TODO(tkiley): How do we set the result to be toppish? Does it matter?
-    return abstract_objectt::merge(other);
-  }
+
+  return abstract_objectt::merge(other);
 }
 
 abstract_object_pointert constant_abstract_valuet::merge_constant_constant(
-  const constant_abstract_value_pointert &other) const
+  const abstract_value_pointert &other) const
 {
-  if(is_bottom())
-  {
-    return std::make_shared<constant_abstract_valuet>(*other);
-  }
-  else
-  {
-    // Can we actually merge these value
-    if(value == other->value)
-    {
-      return shared_from_this();
-    }
-    else
-    {
-      return abstract_objectt::merge(other);
-    }
-  }
+  auto other_expr = other->to_constant();
+  if(is_bottom() && other_expr.is_constant())
+    return std::make_shared<constant_abstract_valuet>(other_expr);
+
+  if(value == other_expr) // Can we actually merge these value
+    return shared_from_this();
+
+  return abstract_objectt::merge(other);
 }
 
 void constant_abstract_valuet::get_statistics(

--- a/src/analyses/variable-sensitivity/constant_abstract_value.cpp
+++ b/src/analyses/variable-sensitivity/constant_abstract_value.cpp
@@ -91,6 +91,11 @@ exprt constant_abstract_valuet::to_constant() const
   }
 }
 
+constant_interval_exprt constant_abstract_valuet::to_interval() const
+{
+  return constant_interval_exprt(value, value);
+}
+
 void constant_abstract_valuet::output(
   std::ostream &out,
   const ai_baset &ai,

--- a/src/analyses/variable-sensitivity/constant_abstract_value.h
+++ b/src/analyses/variable-sensitivity/constant_abstract_value.h
@@ -36,6 +36,7 @@ public:
   value_range_implementation_ptrt value_range_implementation() const override;
 
   exprt to_constant() const override;
+  constant_interval_exprt to_interval() const override;
 
   void output(
     std::ostream &out,

--- a/src/analyses/variable-sensitivity/constant_abstract_value.h
+++ b/src/analyses/variable-sensitivity/constant_abstract_value.h
@@ -19,12 +19,9 @@
 
 class constant_abstract_valuet : public abstract_value_objectt
 {
-private:
-  typedef sharing_ptrt<constant_abstract_valuet>
-    constant_abstract_value_pointert;
-
 public:
   explicit constant_abstract_valuet(const typet &t);
+  explicit constant_abstract_valuet(const exprt &t);
   constant_abstract_valuet(const typet &t, bool tp, bool bttm);
   constant_abstract_valuet(
     const exprt &e,
@@ -75,7 +72,7 @@ protected:
   abstract_object_pointert merge(abstract_object_pointert other) const override;
 
 private:
-  /// Merges another constant abstract value into this one
+  /// Merges another abstract value into this one
   ///
   /// \param other: the abstract object to merge with
   ///
@@ -83,7 +80,7 @@ private:
   ///         unless the merge is the same as this abstract object, in which
   ///         case it returns this.
   abstract_object_pointert
-  merge_constant_constant(const constant_abstract_value_pointert &other) const;
+  merge_constant_constant(const abstract_value_pointert &other) const;
 
   exprt value;
 };

--- a/src/analyses/variable-sensitivity/interval_abstract_value.cpp
+++ b/src/analyses/variable-sensitivity/interval_abstract_value.cpp
@@ -329,8 +329,8 @@ void interval_abstract_valuet::output(
 abstract_object_pointert
 interval_abstract_valuet::merge(abstract_object_pointert other) const
 {
-  interval_abstract_value_pointert cast_other =
-    std::dynamic_pointer_cast<const interval_abstract_valuet>(other);
+  abstract_value_pointert cast_other =
+    std::dynamic_pointer_cast<const abstract_value_objectt>(other);
   if(cast_other)
   {
     return merge_intervals(cast_other);
@@ -342,31 +342,31 @@ interval_abstract_valuet::merge(abstract_object_pointert other) const
 }
 
 /// Merge another interval abstract object with this one
-/// \param other The interval abstract object to merge with
+/// \param other The abstract value object to merge with
 /// \return This if the other interval is subsumed by this,
 ///          other if this is subsumed by other.
 ///          Otherwise, a new interval abstract object
 ///          with the smallest interval that subsumes both
 ///          this and other
-abstract_object_pointert interval_abstract_valuet::merge_intervals(
-  interval_abstract_value_pointert other) const
+abstract_object_pointert
+interval_abstract_valuet::merge_intervals(abstract_value_pointert &other) const
 {
-  if(is_bottom() || other->interval.contains(interval))
-  {
-    return other;
-  }
-  else if(other->is_bottom() || interval.contains(other->interval))
-  {
+  if(other->is_bottom())
     return shared_from_this();
-  }
-  else
-  {
-    return std::make_shared<interval_abstract_valuet>(constant_interval_exprt(
-      constant_interval_exprt::get_min(
-        interval.get_lower(), other->interval.get_lower()),
-      constant_interval_exprt::get_max(
-        interval.get_upper(), other->interval.get_upper())));
-  }
+
+  auto other_interval = other->to_interval();
+
+  if(is_bottom())
+    return std::make_shared<interval_abstract_valuet>(other_interval);
+
+  if(interval.contains(other_interval))
+    return shared_from_this();
+
+  return std::make_shared<interval_abstract_valuet>(constant_interval_exprt(
+    constant_interval_exprt::get_min(
+      interval.get_lower(), other_interval.get_lower()),
+    constant_interval_exprt::get_max(
+      interval.get_upper(), other_interval.get_upper())));
 }
 
 abstract_object_pointert

--- a/src/analyses/variable-sensitivity/interval_abstract_value.cpp
+++ b/src/analyses/variable-sensitivity/interval_abstract_value.cpp
@@ -282,6 +282,19 @@ exprt interval_abstract_valuet::to_constant() const
 #endif
 }
 
+size_t interval_abstract_valuet::internal_hash() const
+{
+  return std::hash<std::string>{}(interval.pretty());
+}
+
+bool interval_abstract_valuet::internal_equality(
+  const abstract_object_pointert &other) const
+{
+  auto cast_other =
+    std::dynamic_pointer_cast<const interval_abstract_valuet>(other);
+  return cast_other && interval == cast_other->interval;
+}
+
 void interval_abstract_valuet::output(
   std::ostream &out,
   const ai_baset &ai,

--- a/src/analyses/variable-sensitivity/interval_abstract_value.h
+++ b/src/analyses/variable-sensitivity/interval_abstract_value.h
@@ -46,6 +46,9 @@ public:
     return interval;
   }
 
+  size_t internal_hash() const override;
+  bool internal_equality(const abstract_object_pointert &other) const override;
+
   void output(
     std::ostream &out,
     const class ai_baset &ai,

--- a/src/analyses/variable-sensitivity/interval_abstract_value.h
+++ b/src/analyses/variable-sensitivity/interval_abstract_value.h
@@ -41,7 +41,7 @@ public:
   value_range_implementation_ptrt value_range_implementation() const override;
 
   exprt to_constant() const override;
-  const constant_interval_exprt &to_interval() const
+  constant_interval_exprt to_interval() const override
   {
     return interval;
   }
@@ -68,7 +68,7 @@ private:
     sharing_ptrt<interval_abstract_valuet>;
 
   abstract_object_pointert
-  merge_intervals(interval_abstract_value_pointert other) const;
+  merge_intervals(abstract_value_pointert &other) const;
   abstract_object_pointert
   meet_intervals(interval_abstract_value_pointert other) const;
 

--- a/src/analyses/variable-sensitivity/value_set_abstract_object.cpp
+++ b/src/analyses/variable-sensitivity/value_set_abstract_object.cpp
@@ -166,8 +166,15 @@ value_set_abstract_objectt::value_range_implementation() const
 exprt value_set_abstract_objectt::to_constant() const
 {
   verify();
-  return values.size() == 1 ? (*values.begin())->to_constant()
-                            : abstract_objectt::to_constant();
+
+  if(values.size() == 1)
+    return values.first()->to_constant();
+
+  auto interval = to_interval();
+  if(interval.is_single_value_interval())
+    return interval.get_lower();
+
+  return abstract_objectt::to_constant();
 }
 
 constant_interval_exprt value_set_abstract_objectt::to_interval() const

--- a/src/analyses/variable-sensitivity/value_set_abstract_object.cpp
+++ b/src/analyses/variable-sensitivity/value_set_abstract_object.cpp
@@ -9,6 +9,7 @@
 /// \file
 /// Value Set Abstract Object
 
+#include "interval_abstract_value.h"
 #include <analyses/variable-sensitivity/constant_abstract_value.h>
 #include <analyses/variable-sensitivity/context_abstract_object.h>
 #include <analyses/variable-sensitivity/two_value_array_abstract_object.h>
@@ -162,6 +163,18 @@ value_set_abstract_objectt::value_range_implementation() const
   return make_value_set_value_range(values);
 }
 
+exprt value_set_abstract_objectt::to_constant() const
+{
+  verify();
+  return values.size() == 1 ? (*values.begin())->to_constant()
+                            : abstract_objectt::to_constant();
+}
+
+constant_interval_exprt value_set_abstract_objectt::to_interval() const
+{
+  return values.to_interval();
+}
+
 abstract_object_pointert value_set_abstract_objectt::write(
   abstract_environmentt &environment,
   const namespacet &ns,
@@ -199,7 +212,8 @@ abstract_object_pointert value_set_abstract_objectt::resolve_values(
 
   if(unwrapped_values.size() > max_value_set_size)
   {
-    return unwrapped_values.to_interval();
+    return std::make_shared<interval_abstract_valuet>(
+      unwrapped_values.to_interval());
   }
   //if(unwrapped_values.size() == 1)
   //{

--- a/src/analyses/variable-sensitivity/value_set_abstract_object.cpp
+++ b/src/analyses/variable-sensitivity/value_set_abstract_object.cpp
@@ -229,19 +229,19 @@ abstract_object_pointert value_set_abstract_objectt::resolve_values(
 abstract_object_pointert
 value_set_abstract_objectt::merge(abstract_object_pointert other) const
 {
+  auto union_values = !is_bottom() ? values : abstract_object_sett{};
+
   auto other_value_set = std::dynamic_pointer_cast<const value_set_tag>(other);
   if(other_value_set)
   {
-    auto union_values = values;
     union_values.insert(other_value_set->get_values());
     return resolve_values(union_values);
   }
 
   auto other_value =
-    std::dynamic_pointer_cast<const constant_abstract_valuet>(other);
+    std::dynamic_pointer_cast<const abstract_value_objectt>(other);
   if(other_value)
   {
-    auto union_values = values;
     union_values.insert(other_value);
     return resolve_values(union_values);
   }
@@ -268,6 +268,7 @@ void value_set_abstract_objectt::set_values(
     set_not_top();
     values = other_values;
   }
+  set_not_bottom();
   verify();
 }
 

--- a/src/analyses/variable-sensitivity/value_set_abstract_object.h
+++ b/src/analyses/variable-sensitivity/value_set_abstract_object.h
@@ -36,12 +36,8 @@ public:
   value_range_implementation_ptrt value_range_implementation() const override;
 
   /// \copydoc abstract_objectt::to_constant
-  exprt to_constant() const override
-  {
-    verify();
-    return values.size() == 1 ? (*values.begin())->to_constant()
-                              : abstract_objectt::to_constant();
-  }
+  exprt to_constant() const override;
+  constant_interval_exprt to_interval() const override;
 
   /// Getter for the set of stored abstract objects.
   /// \return the values represented by this abstract object

--- a/unit/Makefile
+++ b/unit/Makefile
@@ -20,6 +20,7 @@ SRC += analyses/ai/ai.cpp \
        analyses/variable-sensitivity/full_array_abstract_object/merge.cpp \
        analyses/variable-sensitivity/eval.cpp \
        analyses/variable-sensitivity/eval-member-access.cpp \
+       analyses/variable-sensitivity/interval_abstract_value/merge.cpp \
        analyses/variable-sensitivity/interval_abstract_value/meet.cpp \
        analyses/variable-sensitivity/full_struct_abstract_object/merge.cpp \
        analyses/variable-sensitivity/last_written_location.cpp \

--- a/unit/analyses/variable-sensitivity/constant_abstract_value/merge.cpp
+++ b/unit/analyses/variable-sensitivity/constant_abstract_value/merge.cpp
@@ -48,7 +48,7 @@ SCENARIO(
 
       auto merged = merge(op1, op2);
 
-      THEN("the result 1 is unchanged")
+      THEN("result is unmodified 1")
       {
         EXPECT_UNMODIFIED(merged, val1);
       }
@@ -60,8 +60,9 @@ SCENARIO(
 
       auto merged = merge(op1, op2);
 
-      THEN("result should be TOP")
+      THEN("result is modified TOP")
       {
+        EXPECT_MODIFIED(merged);
         EXPECT_TOP(merged.result);
       }
     }
@@ -72,8 +73,9 @@ SCENARIO(
 
       auto merged = merge(op1, top2);
 
-      THEN("result should be TOP")
+      THEN("result is modified TOP")
       {
+        EXPECT_MODIFIED(merged);
         EXPECT_TOP(merged.result);
       }
     }
@@ -84,7 +86,7 @@ SCENARIO(
 
       auto merged = merge(op1, bottom2);
 
-      THEN("the result 1 is unchanged")
+      THEN("result is unmodified 1")
       {
         EXPECT_UNMODIFIED(merged, val1);
       }
@@ -96,8 +98,9 @@ SCENARIO(
 
       auto merged = merge(top1, op2);
 
-      THEN("result should be TOP")
+      THEN("result is unmodified TOP")
       {
+        EXPECT_UNMODIFIED(merged);
         EXPECT_TOP(merged.result);
       }
     }
@@ -108,8 +111,9 @@ SCENARIO(
 
       auto merged = merge(top1, top2);
 
-      THEN("result should be TOP")
+      THEN("result is unmodified TOP")
       {
+        EXPECT_UNMODIFIED(merged);
         EXPECT_TOP(merged.result);
       }
     }
@@ -120,8 +124,9 @@ SCENARIO(
 
       auto merged = merge(top1, bottom2);
 
-      THEN("result should be TOP")
+      THEN("result is unmodified TOP")
       {
+        EXPECT_UNMODIFIED(merged);
         EXPECT_TOP(merged.result);
       }
     }
@@ -132,7 +137,7 @@ SCENARIO(
 
       auto merged = merge(bottom1, op2);
 
-      THEN("the result is 1")
+      THEN("result is modified 1")
       {
         EXPECT_MODIFIED(merged, val1);
       }
@@ -144,8 +149,9 @@ SCENARIO(
 
       auto merged = merge(bottom1, top2);
 
-      THEN("result should be TOP")
+      THEN("result is modified TOP")
       {
+        EXPECT_MODIFIED(merged);
         EXPECT_TOP(merged.result);
       }
     }
@@ -156,32 +162,13 @@ SCENARIO(
 
       auto merged = merge(bottom1, bottom2);
 
-      THEN("result is BOTTOM")
+      THEN("result is unmodified BOTTOM")
       {
-        CHECK_FALSE(merged.modified);
+        EXPECT_UNMODIFIED(merged);
         EXPECT_BOTTOM(merged.result);
       }
     }
   }
-}
-
-SCENARIO(
-  "merge constant_abstract_value with an abstract object",
-  "[core][analyses][variable-sensitivity][constant_abstract_value][merge]")
-{
-  const typet type = signedbv_typet(32);
-  const exprt val1 = from_integer(1, type);
-  const exprt val2 = from_integer(2, type);
-
-  auto config = vsd_configt::constant_domain();
-  config.context_tracking.data_dependency_context = false;
-  config.context_tracking.last_write_context = false;
-  auto object_factory =
-    variable_sensitivity_object_factoryt::configured_with(config);
-  abstract_environmentt environment{object_factory};
-  environment.make_top();
-  symbol_tablet symbol_table;
-  namespacet ns(symbol_table);
 
   GIVEN("merging a constant and an abstract object")
   {
@@ -192,8 +179,9 @@ SCENARIO(
 
       auto merged = merge(op1, top2);
 
-      THEN("result is TOP")
+      THEN("result is modified TOP")
       {
+        EXPECT_MODIFIED(merged);
         EXPECT_TOP(merged.result);
       }
     }
@@ -204,7 +192,7 @@ SCENARIO(
 
       auto merged = merge(op1, bottom2);
 
-      THEN("the result 1 is unchanged")
+      THEN("result is unmodified 1")
       {
         EXPECT_UNMODIFIED(merged, val1);
       }
@@ -216,8 +204,9 @@ SCENARIO(
 
       auto merged = merge(top1, top2);
 
-      THEN("result is TOP")
+      THEN("result is unmodified TOP")
       {
+        EXPECT_UNMODIFIED(merged);
         EXPECT_TOP(merged.result);
       }
     }
@@ -228,8 +217,9 @@ SCENARIO(
 
       auto merged = merge(top1, bottom2);
 
-      THEN("result is TOP")
+      THEN("result is unmodified TOP")
       {
+        EXPECT_UNMODIFIED(merged);
         EXPECT_TOP(merged.result);
       }
     }
@@ -240,8 +230,9 @@ SCENARIO(
 
       auto merged = merge(bottom1, top2);
 
-      THEN("result is TOP")
+      THEN("result is modified TOP")
       {
+        EXPECT_MODIFIED(merged);
         EXPECT_TOP(merged.result);
       }
     }
@@ -252,115 +243,12 @@ SCENARIO(
 
       auto merged = merge(bottom1, top2);
 
-      THEN("result is TOP")
+      THEN("result is unmodified BOTTOM")
       {
+        EXPECT_UNMODIFIED(merged);
         EXPECT_BOTTOM(merged.result);
       }
     }
   }
 }
 
-SCENARIO(
-  "merging an abstract object with a constant",
-  "[core][analyses][variable-sensitivity][constant_abstract_value][merge]")
-{
-  const typet type = signedbv_typet(32);
-  const exprt val1 = from_integer(1, type);
-  const exprt val2 = from_integer(2, type);
-
-  auto config = vsd_configt::constant_domain();
-  config.context_tracking.data_dependency_context = false;
-  config.context_tracking.last_write_context = false;
-  auto object_factory =
-    variable_sensitivity_object_factoryt::configured_with(config);
-  abstract_environmentt environment{object_factory};
-  environment.make_top();
-  symbol_tablet symbol_table;
-  namespacet ns(symbol_table);
-
-  GIVEN("an abstract object and a constant")
-  {
-    WHEN("merging TOP with 1")
-    {
-      auto top1 = make_top_object();
-      auto op2 = make_constant(val1, environment, ns);
-
-      bool modified;
-      auto result = abstract_objectt::merge(top1, op2, modified);
-
-      THEN("the result is TOP")
-      {
-        EXPECT_UNMODIFIED(result, modified);
-        EXPECT_TOP(result);
-      }
-    }
-    WHEN("merging TOP with TOP constant")
-    {
-      auto top1 = make_top_object();
-      auto top2 = make_top_constant();
-
-      bool modified;
-      auto result = abstract_objectt::merge(top1, top2, modified);
-
-      THEN("the result is TOP")
-      {
-        EXPECT_UNMODIFIED(result, modified);
-        EXPECT_TOP(result);
-      }
-    }
-    WHEN("merging TOP with BOTTOM constant")
-    {
-      auto top1 = make_top_object();
-      auto bottom2 = make_bottom_constant();
-
-      bool modified;
-      auto result = abstract_objectt::merge(top1, bottom2, modified);
-
-      THEN("the result is TOP")
-      {
-        EXPECT_UNMODIFIED(result, modified);
-        EXPECT_TOP(result);
-      }
-    }
-    WHEN("merging BOTTOM with 1")
-    {
-      auto op1 = make_bottom_object();
-      auto op2 = make_constant(val1, environment, ns);
-
-      bool modified;
-      auto result = abstract_objectt::merge(op1, op2, modified);
-
-      THEN("the result is TOP")
-      {
-        EXPECT_TOP(result);
-      }
-    }
-    WHEN("merging BOTTOM with TOP constant")
-    {
-      auto op1 = make_bottom_object();
-      auto top2 = make_top_constant();
-
-      bool modified;
-      auto result = abstract_objectt::merge(op1, top2, modified);
-
-      THEN("the result is TOP")
-      {
-        EXPECT_TOP(result);
-      }
-    }
-    WHEN("merging BOTTOM with BOTTOM constant")
-    {
-      auto bottom1 = make_bottom_object();
-      auto bottom2 = make_bottom_constant();
-
-      bool modified;
-      auto result = abstract_objectt::merge(bottom1, bottom2, modified);
-
-      THEN("The original AO should be returned")
-      {
-        EXPECT_UNMODIFIED(result, modified);
-        EXPECT_BOTTOM(result);
-      }
-    }
-  }
-}

--- a/unit/analyses/variable-sensitivity/constant_abstract_value/merge.cpp
+++ b/unit/analyses/variable-sensitivity/constant_abstract_value/merge.cpp
@@ -250,5 +250,234 @@ SCENARIO(
       }
     }
   }
-}
 
+  GIVEN("merging a constant and an interval")
+  {
+    WHEN("merging 1 with [1, 1]")
+    {
+      auto op1 = make_constant(val1, environment, ns);
+      auto op2 = make_interval(val1, val1, environment, ns);
+
+      auto merged = merge(op1, op2);
+
+      THEN("result is unmodified 1")
+      {
+        EXPECT_UNMODIFIED(merged, val1);
+      }
+    }
+    WHEN("merging 1 with [1, 2]")
+    {
+      auto op1 = make_constant(val1, environment, ns);
+      auto op2 = make_interval(val1, val2, environment, ns);
+
+      auto merged = merge(op1, op2);
+
+      THEN("result is modified TOP")
+      {
+        EXPECT_MODIFIED(merged);
+        EXPECT_TOP(merged.result);
+      }
+    }
+    WHEN("merging 1 with [2, 2]")
+    {
+      auto op1 = make_constant(val1, environment, ns);
+      auto op2 = make_interval(val2, val2, environment, ns);
+
+      auto merged = merge(op1, op2);
+
+      THEN("result is modified TOP")
+      {
+        EXPECT_MODIFIED(merged);
+        EXPECT_TOP(merged.result);
+      }
+    }
+    WHEN("merging BOTTOM with [1, 1]")
+    {
+      auto op1 = make_bottom_constant();
+      auto op2 = make_interval(val1, val1, environment, ns);
+
+      auto merged = merge(op1, op2);
+
+      THEN("result is modified 1")
+      {
+        EXPECT_MODIFIED(merged, val1);
+      }
+    }
+    WHEN("merging BOTTOM with [1, 2]")
+    {
+      auto op1 = make_bottom_constant();
+      auto op2 = make_interval(val1, val2, environment, ns);
+
+      auto merged = merge(op1, op2);
+
+      THEN("result is modified TOP")
+      {
+        EXPECT_MODIFIED(merged);
+        EXPECT_TOP(merged.result);
+      }
+    }
+  }
+
+  GIVEN("merging a constant and a value set")
+  {
+    WHEN("merging 1 with { 1 }")
+    {
+      auto op1 = make_constant(val1, environment, ns);
+      auto op2 = make_value_set(val1, environment, ns);
+
+      auto merged = merge(op1, op2);
+
+      THEN("result is unmodified 1")
+      {
+        EXPECT_UNMODIFIED(merged, val1);
+      }
+    }
+    WHEN("merging 1 with { 2 }")
+    {
+      auto op1 = make_constant(val1, environment, ns);
+      auto op2 = make_value_set(val2, environment, ns);
+
+      auto merged = merge(op1, op2);
+
+      THEN("result is modified TOP")
+      {
+        EXPECT_MODIFIED(merged);
+        EXPECT_TOP(merged.result);
+      }
+    }
+    WHEN("merging 1 with { 1, 2 }")
+    {
+      auto op1 = make_constant(val1, environment, ns);
+      auto op2 = make_value_set({val1, val2}, environment, ns);
+
+      auto merged = merge(op1, op2);
+
+      THEN("result is modified TOP")
+      {
+        EXPECT_MODIFIED(merged);
+        EXPECT_TOP(merged.result);
+      }
+    }
+    WHEN("merging 1 with { [ 1, 1 ] }")
+    {
+      auto op1 = make_constant(val1, environment, ns);
+      auto op2 =
+        make_value_set(constant_interval_exprt(val1, val1), environment, ns);
+
+      auto merged = merge(op1, op2);
+
+      THEN("result is unmodified 1")
+      {
+        EXPECT_UNMODIFIED(merged, val1);
+      }
+    }
+    WHEN("merging 1 with { [ 2, 2 ] }")
+    {
+      auto op1 = make_constant(val1, environment, ns);
+      auto op2 =
+        make_value_set(constant_interval_exprt(val2, val2), environment, ns);
+
+      auto merged = merge(op1, op2);
+
+      THEN("result is modified TOP")
+      {
+        EXPECT_MODIFIED(merged);
+        EXPECT_TOP(merged.result);
+      }
+    }
+    WHEN("merging 1 with { [ 1, 2 ] }")
+    {
+      auto op1 = make_constant(val1, environment, ns);
+      auto op2 =
+        make_value_set(constant_interval_exprt(val1, val2), environment, ns);
+
+      auto merged = merge(op1, op2);
+
+      THEN("result is modified TOP")
+      {
+        EXPECT_MODIFIED(merged);
+        EXPECT_TOP(merged.result);
+      }
+    }
+    WHEN("merging 1 with { 1, [ 1, 2 ] }")
+    {
+      auto op1 = make_constant(val1, environment, ns);
+      auto op2 = make_value_set(
+        {val1, constant_interval_exprt(val1, val2)}, environment, ns);
+
+      auto merged = merge(op1, op2);
+
+      THEN("result is modified TOP")
+      {
+        EXPECT_MODIFIED(merged);
+        EXPECT_TOP(merged.result);
+      }
+    }
+    WHEN("merging BOTTOM with { 1 }")
+    {
+      auto op1 = make_bottom_constant();
+      auto op2 = make_value_set(val1, environment, ns);
+
+      auto merged = merge(op1, op2);
+
+      THEN("result is modified 1")
+      {
+        EXPECT_MODIFIED(merged, val1);
+      }
+    }
+    WHEN("merging BOTTOM with { 1, 2 }")
+    {
+      auto op1 = make_bottom_constant();
+      auto op2 = make_value_set({val1, val2}, environment, ns);
+
+      auto merged = merge(op1, op2);
+
+      THEN("result is modified TOP")
+      {
+        EXPECT_MODIFIED(merged);
+        EXPECT_TOP(merged.result);
+      }
+    }
+    WHEN("merging BOTTOM with { [ 1, 1 ] }")
+    {
+      auto op1 = make_bottom_constant();
+      auto op2 =
+        make_value_set(constant_interval_exprt(val1, val1), environment, ns);
+
+      auto merged = merge(op1, op2);
+
+      THEN("result is modified 1")
+      {
+        EXPECT_MODIFIED(merged, val1);
+      }
+    }
+    WHEN("merging BOTTOM with { [ 1, 2 ] }")
+    {
+      auto op1 = make_bottom_constant();
+      auto op2 =
+        make_value_set(constant_interval_exprt(val1, val2), environment, ns);
+
+      auto merged = merge(op1, op2);
+
+      THEN("result is modified TOP")
+      {
+        EXPECT_MODIFIED(merged);
+        EXPECT_TOP(merged.result);
+      }
+    }
+    WHEN("merging BOTTOM with { 1, [ 1, 2 ] }")
+    {
+      auto op1 = make_bottom_constant();
+      auto op2 = make_value_set(
+        {val1, constant_interval_exprt(val1, val2)}, environment, ns);
+
+      auto merged = merge(op1, op2);
+
+      THEN("result is modified TOP")
+      {
+        EXPECT_MODIFIED(merged);
+        EXPECT_TOP(merged.result);
+      }
+    }
+  }
+}

--- a/unit/analyses/variable-sensitivity/constant_abstract_value/merge.cpp
+++ b/unit/analyses/variable-sensitivity/constant_abstract_value/merge.cpp
@@ -62,8 +62,7 @@ SCENARIO(
 
       THEN("result is modified TOP")
       {
-        EXPECT_MODIFIED(merged);
-        EXPECT_TOP(merged.result);
+        EXPECT_MODIFIED_TOP(merged);
       }
     }
     WHEN("merging 1 with TOP")
@@ -75,8 +74,7 @@ SCENARIO(
 
       THEN("result is modified TOP")
       {
-        EXPECT_MODIFIED(merged);
-        EXPECT_TOP(merged.result);
+        EXPECT_MODIFIED_TOP(merged);
       }
     }
     WHEN("merging 1 with BOTTOM")
@@ -100,8 +98,7 @@ SCENARIO(
 
       THEN("result is unmodified TOP")
       {
-        EXPECT_UNMODIFIED(merged);
-        EXPECT_TOP(merged.result);
+        EXPECT_UNMODIFIED_TOP(merged);
       }
     }
     WHEN("merging TOP with TOP")
@@ -113,8 +110,7 @@ SCENARIO(
 
       THEN("result is unmodified TOP")
       {
-        EXPECT_UNMODIFIED(merged);
-        EXPECT_TOP(merged.result);
+        EXPECT_UNMODIFIED_TOP(merged);
       }
     }
     WHEN("merging TOP with BOTTOM")
@@ -126,8 +122,7 @@ SCENARIO(
 
       THEN("result is unmodified TOP")
       {
-        EXPECT_UNMODIFIED(merged);
-        EXPECT_TOP(merged.result);
+        EXPECT_UNMODIFIED_TOP(merged);
       }
     }
     WHEN("merging BOTTOM with 1")
@@ -151,8 +146,7 @@ SCENARIO(
 
       THEN("result is modified TOP")
       {
-        EXPECT_MODIFIED(merged);
-        EXPECT_TOP(merged.result);
+        EXPECT_MODIFIED_TOP(merged);
       }
     }
     WHEN("merging BOTTOM with BOTTOM")
@@ -164,8 +158,7 @@ SCENARIO(
 
       THEN("result is unmodified BOTTOM")
       {
-        EXPECT_UNMODIFIED(merged);
-        EXPECT_BOTTOM(merged.result);
+        EXPECT_UNMODIFIED_BOTTOM(merged);
       }
     }
   }
@@ -181,8 +174,7 @@ SCENARIO(
 
       THEN("result is modified TOP")
       {
-        EXPECT_MODIFIED(merged);
-        EXPECT_TOP(merged.result);
+        EXPECT_MODIFIED_TOP(merged);
       }
     }
     WHEN("merging 1 with BOTTOM")
@@ -206,8 +198,7 @@ SCENARIO(
 
       THEN("result is unmodified TOP")
       {
-        EXPECT_UNMODIFIED(merged);
-        EXPECT_TOP(merged.result);
+        EXPECT_UNMODIFIED_TOP(merged);
       }
     }
     WHEN("merging TOP constant with BOTTOM")
@@ -219,8 +210,7 @@ SCENARIO(
 
       THEN("result is unmodified TOP")
       {
-        EXPECT_UNMODIFIED(merged);
-        EXPECT_TOP(merged.result);
+        EXPECT_UNMODIFIED_TOP(merged);
       }
     }
     WHEN("merging BOTTOM constant with TOP")
@@ -232,8 +222,7 @@ SCENARIO(
 
       THEN("result is modified TOP")
       {
-        EXPECT_MODIFIED(merged);
-        EXPECT_TOP(merged.result);
+        EXPECT_MODIFIED_TOP(merged);
       }
     }
     WHEN("merging BOTTOM constant with BOTTOM")
@@ -245,8 +234,7 @@ SCENARIO(
 
       THEN("result is unmodified BOTTOM")
       {
-        EXPECT_UNMODIFIED(merged);
-        EXPECT_BOTTOM(merged.result);
+        EXPECT_UNMODIFIED_BOTTOM(merged);
       }
     }
   }
@@ -274,8 +262,7 @@ SCENARIO(
 
       THEN("result is modified TOP")
       {
-        EXPECT_MODIFIED(merged);
-        EXPECT_TOP(merged.result);
+        EXPECT_MODIFIED_TOP(merged);
       }
     }
     WHEN("merging 1 with [2, 2]")
@@ -287,8 +274,7 @@ SCENARIO(
 
       THEN("result is modified TOP")
       {
-        EXPECT_MODIFIED(merged);
-        EXPECT_TOP(merged.result);
+        EXPECT_MODIFIED_TOP(merged);
       }
     }
     WHEN("merging BOTTOM with [1, 1]")
@@ -312,8 +298,7 @@ SCENARIO(
 
       THEN("result is modified TOP")
       {
-        EXPECT_MODIFIED(merged);
-        EXPECT_TOP(merged.result);
+        EXPECT_MODIFIED_TOP(merged);
       }
     }
   }
@@ -341,8 +326,7 @@ SCENARIO(
 
       THEN("result is modified TOP")
       {
-        EXPECT_MODIFIED(merged);
-        EXPECT_TOP(merged.result);
+        EXPECT_MODIFIED_TOP(merged);
       }
     }
     WHEN("merging 1 with { 1, 2 }")
@@ -354,8 +338,7 @@ SCENARIO(
 
       THEN("result is modified TOP")
       {
-        EXPECT_MODIFIED(merged);
-        EXPECT_TOP(merged.result);
+        EXPECT_MODIFIED_TOP(merged);
       }
     }
     WHEN("merging 1 with { [ 1, 1 ] }")
@@ -381,8 +364,7 @@ SCENARIO(
 
       THEN("result is modified TOP")
       {
-        EXPECT_MODIFIED(merged);
-        EXPECT_TOP(merged.result);
+        EXPECT_MODIFIED_TOP(merged);
       }
     }
     WHEN("merging 1 with { [ 1, 2 ] }")
@@ -395,8 +377,7 @@ SCENARIO(
 
       THEN("result is modified TOP")
       {
-        EXPECT_MODIFIED(merged);
-        EXPECT_TOP(merged.result);
+        EXPECT_MODIFIED_TOP(merged);
       }
     }
     WHEN("merging 1 with { 1, [ 1, 2 ] }")
@@ -409,8 +390,7 @@ SCENARIO(
 
       THEN("result is modified TOP")
       {
-        EXPECT_MODIFIED(merged);
-        EXPECT_TOP(merged.result);
+        EXPECT_MODIFIED_TOP(merged);
       }
     }
     WHEN("merging BOTTOM with { 1 }")
@@ -434,8 +414,7 @@ SCENARIO(
 
       THEN("result is modified TOP")
       {
-        EXPECT_MODIFIED(merged);
-        EXPECT_TOP(merged.result);
+        EXPECT_MODIFIED_TOP(merged);
       }
     }
     WHEN("merging BOTTOM with { [ 1, 1 ] }")
@@ -461,8 +440,7 @@ SCENARIO(
 
       THEN("result is modified TOP")
       {
-        EXPECT_MODIFIED(merged);
-        EXPECT_TOP(merged.result);
+        EXPECT_MODIFIED_TOP(merged);
       }
     }
     WHEN("merging BOTTOM with { 1, [ 1, 2 ] }")
@@ -475,8 +453,7 @@ SCENARIO(
 
       THEN("result is modified TOP")
       {
-        EXPECT_MODIFIED(merged);
-        EXPECT_TOP(merged.result);
+        EXPECT_MODIFIED_TOP(merged);
       }
     }
   }

--- a/unit/analyses/variable-sensitivity/constant_abstract_value/merge.cpp
+++ b/unit/analyses/variable-sensitivity/constant_abstract_value/merge.cpp
@@ -354,6 +354,19 @@ SCENARIO(
         EXPECT_UNMODIFIED(merged, val1);
       }
     }
+    WHEN("merging 1 with { 1, [1, 1] }")
+    {
+      auto op1 = make_constant(val1, environment, ns);
+      auto op2 = make_value_set(
+        {val1, constant_interval_exprt(val1, val1)}, environment, ns);
+
+      auto merged = merge(op1, op2);
+
+      THEN("result is unmodified 1")
+      {
+        EXPECT_UNMODIFIED(merged, val1);
+      }
+    }
     WHEN("merging 1 with { [ 2, 2 ] }")
     {
       auto op1 = make_constant(val1, environment, ns);

--- a/unit/analyses/variable-sensitivity/interval_abstract_value/merge.cpp
+++ b/unit/analyses/variable-sensitivity/interval_abstract_value/merge.cpp
@@ -1,0 +1,481 @@
+/*******************************************************************\
+
+ Module: Unit tests for intervalabstract_valuet::merge
+
+ Author: Jez Higgins.
+
+\*******************************************************************/
+
+#include <analyses/variable-sensitivity/variable_sensitivity_object_factory.h>
+#include <analyses/variable-sensitivity/variable_sensitivity_test_helpers.h>
+#include <testing-utils/use_catch.h>
+
+#include <util/bitvector_types.h>
+
+static merge_result<const interval_abstract_valuet>
+merge(abstract_object_pointert op1, abstract_object_pointert op2)
+{
+  bool modified;
+  auto result = abstract_objectt::merge(op1, op2, modified);
+
+  return {modified, as_interval(result)};
+}
+
+SCENARIO(
+  "merge interval_abstract_value",
+  "[core][analyses][variable-sensitivity][interval_abstract_value][merge]")
+{
+  const typet type = signedbv_typet(32);
+  const exprt val1 = from_integer(1, type);
+  const exprt val2 = from_integer(2, type);
+  const exprt val3 = from_integer(3, type);
+  const exprt val4 = from_integer(4, type);
+  const exprt val5 = from_integer(5, type);
+  const exprt val6 = from_integer(6, type);
+
+  auto config = vsd_configt::constant_domain();
+  config.context_tracking.data_dependency_context = false;
+  config.context_tracking.last_write_context = false;
+  auto object_factory =
+    variable_sensitivity_object_factoryt::configured_with(config);
+  abstract_environmentt environment{object_factory};
+  environment.make_top();
+  symbol_tablet symbol_table;
+  namespacet ns(symbol_table);
+
+  GIVEN("merging two intervals")
+  {
+    WHEN("merging [1, 2] with [1, 2]")
+    {
+      auto op1 = make_interval(val1, val2, environment, ns);
+      auto op2 = make_interval(val1, val2, environment, ns);
+
+      auto merged = merge(op1, op2);
+
+      THEN("result is unmodified [1, 2]")
+      {
+        EXPECT_UNMODIFIED(merged, val1, val2);
+      }
+    }
+    WHEN("merging [1, 5] with [2, 3]")
+    {
+      auto op1 = make_interval(val1, val5, environment, ns);
+      auto op2 = make_interval(val2, val3, environment, ns);
+
+      auto merged = merge(op1, op2);
+
+      THEN("result is unmodified [1, 5]")
+      {
+        EXPECT_UNMODIFIED(merged, val1, val5);
+      }
+    }
+    WHEN("merging [2, 3] with [1, 5]")
+    {
+      auto op1 = make_interval(val2, val3, environment, ns);
+      auto op2 = make_interval(val1, val5, environment, ns);
+
+      auto merged = merge(op1, op2);
+
+      THEN("result is modified [1, 5]")
+      {
+        EXPECT_MODIFIED(merged, val1, val5);
+      }
+    }
+    WHEN("merging [1, 2] with [4, 5]")
+    {
+      auto op1 = make_interval(val1, val2, environment, ns);
+      auto op2 = make_interval(val4, val5, environment, ns);
+
+      auto merged = merge(op1, op2);
+
+      THEN("result is modified [1, 5]")
+      {
+        EXPECT_MODIFIED(merged, val1, val5);
+      }
+    }
+    WHEN("merging [4, 5] with [1, 2]")
+    {
+      auto op1 = make_interval(val4, val5, environment, ns);
+      auto op2 = make_interval(val1, val2, environment, ns);
+
+      auto merged = merge(op1, op2);
+
+      THEN("result is modified [1, 5]")
+      {
+        EXPECT_MODIFIED(merged, val1, val5);
+      }
+    }
+    WHEN("merging [2, 4] with [1, 3]")
+    {
+      auto op1 = make_interval(val2, val4, environment, ns);
+      auto op2 = make_interval(val1, val3, environment, ns);
+
+      auto merged = merge(op1, op2);
+
+      THEN("result is modified [1, 4]")
+      {
+        EXPECT_MODIFIED(merged, val1, val4);
+      }
+    }
+    WHEN("merging [1, 3] with [2, 4]")
+    {
+      auto op1 = make_interval(val1, val3, environment, ns);
+      auto op2 = make_interval(val2, val4, environment, ns);
+
+      auto merged = merge(op1, op2);
+
+      THEN("result is modified [1, 4]")
+      {
+        EXPECT_MODIFIED(merged, val1, val4);
+      }
+    }
+    WHEN("merging [1, 2] with TOP")
+    {
+      auto op1 = make_interval(val1, val2, environment, ns);
+      auto top2 = make_top_interval();
+
+      auto merged = merge(op1, top2);
+
+      THEN("result is modified TOP")
+      {
+        EXPECT_MODIFIED_TOP(merged);
+      }
+    }
+    WHEN("merging [1, 2] with BOTTOM")
+    {
+      auto op1 = make_interval(val1, val2, environment, ns);
+      auto bottom2 = make_bottom_interval();
+
+      auto merged = merge(op1, bottom2);
+
+      THEN("result is unmodified [1, 2]")
+      {
+        EXPECT_UNMODIFIED(merged, val1, val2);
+      }
+    }
+    WHEN("merging TOP with [1, 2]")
+    {
+      auto top1 = make_top_interval();
+      auto op2 = make_interval(val1, val2, environment, ns);
+
+      auto merged = merge(top1, op2);
+
+      THEN("result is unmodified TOP")
+      {
+        EXPECT_UNMODIFIED_TOP(merged);
+      }
+    }
+    WHEN("merging TOP with TOP")
+    {
+      auto top1 = make_top_interval();
+      auto top2 = make_top_interval();
+
+      auto merged = merge(top1, top2);
+
+      THEN("result is unmodified TOP")
+      {
+        EXPECT_UNMODIFIED_TOP(merged);
+      }
+    }
+    WHEN("merging TOP with BOTTOM")
+    {
+      auto top1 = make_top_interval();
+      auto bottom2 = make_bottom_interval();
+
+      auto merged = merge(top1, bottom2);
+
+      THEN("result is unmodified TOP")
+      {
+        EXPECT_UNMODIFIED_TOP(merged);
+      }
+    }
+    WHEN("merging BOTTOM with [1, 2]")
+    {
+      auto bottom1 = make_bottom_interval();
+      auto op2 = make_interval(val1, val2, environment, ns);
+
+      auto merged = merge(bottom1, op2);
+
+      THEN("result is modified [1, 2]")
+      {
+        EXPECT_MODIFIED(merged, val1, val2);
+      }
+    }
+    WHEN("merging BOTTOM with TOP")
+    {
+      auto bottom1 = make_bottom_interval();
+      auto top2 = make_top_interval();
+
+      auto merged = merge(bottom1, top2);
+
+      THEN("result is modified TOP")
+      {
+        EXPECT_MODIFIED_TOP(merged);
+      }
+    }
+    WHEN("merging BOTTOM with BOTTOM")
+    {
+      auto bottom1 = make_bottom_interval();
+      auto bottom2 = make_bottom_interval();
+
+      auto merged = merge(bottom1, bottom2);
+
+      THEN("result is unmodified BOTTOM")
+      {
+        EXPECT_UNMODIFIED_BOTTOM(merged);
+      }
+    }
+  }
+
+  GIVEN("merging an interval and an abstract object")
+  {
+    WHEN("merging[1, 2] with TOP")
+    {
+      auto op1 = make_interval(val1, val2, environment, ns);
+      auto top2 = make_top_object();
+
+      auto merged = merge(op1, top2);
+
+      THEN("result is modified TOP")
+      {
+        EXPECT_MODIFIED_TOP(merged);
+      }
+    }
+    WHEN("merging[1, 2] with BOTTOM")
+    {
+      auto op1 = make_interval(val1, val2, environment, ns);
+      auto bottom2 = make_bottom_object();
+
+      auto merged = merge(op1, bottom2);
+
+      THEN("result is unmodified [1, 2]")
+      {
+        EXPECT_UNMODIFIED(merged, val1, val2);
+      }
+    }
+    WHEN("merging TOP interval with TOP")
+    {
+      auto top1 = make_top_interval();
+      auto top2 = make_top_object();
+
+      auto merged = merge(top1, top2);
+
+      THEN("result is unmodified TOP")
+      {
+        EXPECT_UNMODIFIED_TOP(merged);
+      }
+    }
+    WHEN("merging TOP interval with BOTTOM")
+    {
+      auto top1 = make_top_interval();
+      auto bottom2 = make_bottom_object();
+
+      auto merged = merge(top1, bottom2);
+
+      THEN("result is unmodified TOP")
+      {
+        EXPECT_UNMODIFIED_TOP(merged);
+      }
+    }
+    WHEN("merging BOTTOM interval with TOP")
+    {
+      auto bottom1 = make_bottom_interval();
+      auto top2 = make_top_object();
+
+      auto merged = merge(bottom1, top2);
+
+      THEN("result is modified TOP")
+      {
+        EXPECT_MODIFIED_TOP(merged);
+      }
+    }
+    WHEN("merging BOTTOM interval with BOTTOM")
+    {
+      auto bottom1 = make_bottom_interval();
+      auto top2 = make_bottom_object();
+
+      auto merged = merge(bottom1, top2);
+
+      THEN("result is unmodified BOTTOM")
+      {
+        EXPECT_UNMODIFIED_BOTTOM(merged);
+      }
+    }
+  }
+
+  GIVEN("merging an interval and a constant")
+  {
+    WHEN("merging [1, 5] with 1")
+    {
+      auto op1 = make_interval(val1, val5, environment, ns);
+      auto op2 = make_constant(val1, environment, ns);
+
+      auto merged = merge(op1, op2);
+
+      THEN("result is unmodified [1, 5]")
+      {
+        EXPECT_UNMODIFIED(merged, val1, val5);
+      }
+    }
+    WHEN("merging [1, 5] with 3")
+    {
+      auto op1 = make_interval(val1, val5, environment, ns);
+      auto op2 = make_constant(val3, environment, ns);
+
+      auto merged = merge(op1, op2);
+
+      THEN("result is unmodified [1, 5]")
+      {
+        EXPECT_UNMODIFIED(merged, val1, val5);
+      }
+    }
+    WHEN("merging [1, 5] with 5")
+    {
+      auto op1 = make_interval(val1, val5, environment, ns);
+      auto op2 = make_constant(val5, environment, ns);
+
+      auto merged = merge(op1, op2);
+
+      THEN("result is unmodified [1, 5]")
+      {
+        EXPECT_UNMODIFIED(merged, val1, val5);
+      }
+    }
+    WHEN("merging [3, 4] with 6")
+    {
+      auto op1 = make_interval(val3, val4, environment, ns);
+      auto op2 = make_constant(val6, environment, ns);
+
+      auto merged = merge(op1, op2);
+
+      THEN("result is modified [3, 6]")
+      {
+        EXPECT_MODIFIED(merged, val3, val6);
+      }
+    }
+    WHEN("merging [3, 4] with 1")
+    {
+      auto op1 = make_interval(val3, val4, environment, ns);
+      auto op2 = make_constant(val1, environment, ns);
+
+      auto merged = merge(op1, op2);
+
+      THEN("result is modified [1, 4]")
+      {
+        EXPECT_MODIFIED(merged, val1, val4);
+      }
+    }
+    WHEN("merging BOTTOM with 3")
+    {
+      auto op1 = make_bottom_interval();
+      auto op2 = make_constant(val3, environment, ns);
+
+      auto merged = merge(op1, op2);
+
+      THEN("result is modified [3, 3]")
+      {
+        EXPECT_MODIFIED(merged, val3, val3);
+      }
+    }
+  }
+
+  GIVEN("merging an interval and a value_set")
+  {
+    WHEN("merging [1, 5] with { 1, 3, 5 }")
+    {
+      auto op1 = make_interval(val1, val5, environment, ns);
+      auto op2 = make_value_set({val1, val3, val5}, environment, ns);
+
+      auto merged = merge(op1, op2);
+
+      THEN("result is unmodified [1, 5]")
+      {
+        EXPECT_UNMODIFIED(merged, val1, val5);
+      }
+    }
+    WHEN("merging [1, 5] with { 3 }")
+    {
+      auto op1 = make_interval(val1, val5, environment, ns);
+      auto op2 = make_value_set({val3}, environment, ns);
+
+      auto merged = merge(op1, op2);
+
+      THEN("result is unmodified [1, 5]")
+      {
+        EXPECT_UNMODIFIED(merged, val1, val5);
+      }
+    }
+    WHEN("merging [3, 4] with { 6 }")
+    {
+      auto op1 = make_interval(val3, val4, environment, ns);
+      auto op2 = make_value_set({val6}, environment, ns);
+
+      auto merged = merge(op1, op2);
+
+      THEN("result is modified [3, 6]")
+      {
+        EXPECT_MODIFIED(merged, val3, val6);
+      }
+    }
+    WHEN("merging [3, 4] with { 4, 6 }")
+    {
+      auto op1 = make_interval(val3, val4, environment, ns);
+      auto op2 = make_value_set({val4, val6}, environment, ns);
+
+      auto merged = merge(op1, op2);
+
+      THEN("result is modified [3, 6]")
+      {
+        EXPECT_MODIFIED(merged, val3, val6);
+      }
+    }
+    WHEN("merging [3, 4] with { 1 }")
+    {
+      auto op1 = make_interval(val3, val4, environment, ns);
+      auto op2 = make_value_set({val1}, environment, ns);
+
+      auto merged = merge(op1, op2);
+
+      THEN("result is modified [1, 4]")
+      {
+        EXPECT_MODIFIED(merged, val1, val4);
+      }
+    }
+    WHEN("merging [3, 4] with { 1, 3 }")
+    {
+      auto op1 = make_interval(val3, val4, environment, ns);
+      auto op2 = make_value_set({val1, val3}, environment, ns);
+
+      auto merged = merge(op1, op2);
+
+      THEN("result is modified [1, 4]")
+      {
+        EXPECT_MODIFIED(merged, val1, val4);
+      }
+    }
+    WHEN("merging BOTTOM with { 3 }")
+    {
+      auto op1 = make_bottom_interval();
+      auto op2 = make_value_set({val3}, environment, ns);
+
+      auto merged = merge(op1, op2);
+
+      THEN("result is modified [3, 3]")
+      {
+        EXPECT_MODIFIED(merged, val3, val3);
+      }
+    }
+    WHEN("merging BOTTOM with { 1, 3, 6 }")
+    {
+      auto op1 = make_bottom_interval();
+      auto op2 = make_value_set({val1, val3, val6}, environment, ns);
+
+      auto merged = merge(op1, op2);
+
+      THEN("result is modified [1, 6]")
+      {
+        EXPECT_MODIFIED(merged, val1, val6);
+      }
+    }
+  }
+}

--- a/unit/analyses/variable-sensitivity/interval_abstract_value/merge.cpp
+++ b/unit/analyses/variable-sensitivity/interval_abstract_value/merge.cpp
@@ -453,6 +453,32 @@ SCENARIO(
         EXPECT_MODIFIED(merged, val1, val4);
       }
     }
+    WHEN("merging [3, 4] with { [4, 6] }")
+    {
+      auto op1 = make_interval(val3, val4, environment, ns);
+      auto op2 =
+        make_value_set({constant_interval_exprt(val4, val6)}, environment, ns);
+
+      auto merged = merge(op1, op2);
+
+      THEN("result is modified [3, 6]")
+      {
+        EXPECT_MODIFIED(merged, val3, val6);
+      }
+    }
+    WHEN("merging [3, 4] with { 1, [3, 3] }")
+    {
+      auto op1 = make_interval(val3, val4, environment, ns);
+      auto op2 = make_value_set(
+        {val1, constant_interval_exprt(val3, val3)}, environment, ns);
+
+      auto merged = merge(op1, op2);
+
+      THEN("result is modified [1, 4]")
+      {
+        EXPECT_MODIFIED(merged, val1, val4);
+      }
+    }
     WHEN("merging BOTTOM with { 3 }")
     {
       auto op1 = make_bottom_interval();

--- a/unit/analyses/variable-sensitivity/value_expression_evaluation/expression_evaluation.cpp
+++ b/unit/analyses/variable-sensitivity/value_expression_evaluation/expression_evaluation.cpp
@@ -595,9 +595,9 @@ SCENARIO(
       auto op2 = make_value_set({interval12, val1}, environment, ns);
       auto result = add_as_value_set(op1, op2, environment, ns);
 
-      THEN("= { [2,4], [2,3], [2,3], 2 }")
-      { // duplicate interval ok as first pass. Will be eliminated in due course.
-        EXPECT(result, {interval24, interval23, interval23, val2});
+      THEN("= { [2,4], [2,3], 2 }")
+      {
+        EXPECT(result, {interval24, interval23, val2});
       }
     }
   }

--- a/unit/analyses/variable-sensitivity/value_expression_evaluation/expression_evaluation.cpp
+++ b/unit/analyses/variable-sensitivity/value_expression_evaluation/expression_evaluation.cpp
@@ -6,17 +6,17 @@
 
 \*******************************************************************/
 
-#include "analyses/variable-sensitivity/variable_sensitivity_test_helpers.h"
 #include <analyses/variable-sensitivity/variable_sensitivity_object_factory.h>
+#include <analyses/variable-sensitivity/variable_sensitivity_test_helpers.h>
 #include <testing-utils/use_catch.h>
 
 #include <util/arith_tools.h>
 #include <util/bitvector_types.h>
 
 SCENARIO(
-  "constants expression evaluation",
+  "value expression evaluation",
   "[core][analyses][variable-sensitivity][constant_abstract_value][value_set_"
-  "abstract_object][expression_transform]")
+  "abstract_object][interval_abstract_value][expression_transform]")
 {
   const typet type = signedbv_typet(32);
   const exprt val1 = from_integer(1, type);

--- a/unit/analyses/variable-sensitivity/value_expression_evaluation/module_dependencies.txt
+++ b/unit/analyses/variable-sensitivity/value_expression_evaluation/module_dependencies.txt
@@ -1,4 +1,3 @@
 analyses
 testing-utils
 util
-

--- a/unit/analyses/variable-sensitivity/value_set_abstract_object/module_dependencies.txt
+++ b/unit/analyses/variable-sensitivity/value_set_abstract_object/module_dependencies.txt
@@ -1,4 +1,3 @@
 analyses
 testing-utils
 util
-

--- a/unit/analyses/variable-sensitivity/variable_sensitivity_test_helpers.cpp
+++ b/unit/analyses/variable-sensitivity/variable_sensitivity_test_helpers.cpp
@@ -91,6 +91,16 @@ std::shared_ptr<value_set_abstract_objectt> make_top_value_set()
   return std::make_shared<value_set_abstract_objectt>(integer_typet());
 }
 
+abstract_object_pointert make_bottom_object()
+{
+  return std::make_shared<abstract_objectt>(integer_typet(), false, true);
+}
+
+abstract_object_pointert make_top_object()
+{
+  return std::make_shared<abstract_objectt>(integer_typet(), true, false);
+}
+
 std::shared_ptr<const constant_abstract_valuet>
 as_constant(const abstract_object_pointert &aop)
 {
@@ -268,12 +278,58 @@ void EXPECT_UNMODIFIED(
 }
 
 void EXPECT_UNMODIFIED(
+  merge_result<const constant_abstract_valuet> &result,
+  exprt expected_value)
+{
+  EXPECT_UNMODIFIED(result.result, result.modified, expected_value);
+}
+
+void EXPECT_UNMODIFIED(
   std::shared_ptr<const value_set_abstract_objectt> &result,
   bool modified,
   const std::vector<exprt> &expected_values)
 {
   CHECK_FALSE(modified);
   EXPECT(result, expected_values);
+}
+
+void EXPECT_UNMODIFIED(
+  merge_result<const value_set_abstract_objectt> &result,
+  const std::vector<exprt> &expected_values)
+{
+  EXPECT_UNMODIFIED(result.result, result.modified, expected_values);
+}
+
+void EXPECT_MODIFIED(
+  std::shared_ptr<const constant_abstract_valuet> &result,
+  bool modified,
+  exprt expected_value)
+{
+  CHECK(modified);
+  EXPECT(result, expected_value);
+}
+
+void EXPECT_MODIFIED(
+  merge_result<const constant_abstract_valuet> &result,
+  exprt expected_value)
+{
+  EXPECT_MODIFIED(result.result, result.modified, expected_value);
+}
+
+void EXPECT_MODIFIED(
+  std::shared_ptr<const value_set_abstract_objectt> &result,
+  bool modified,
+  const std::vector<exprt> &expected_values)
+{
+  CHECK(modified);
+  EXPECT(result, expected_values);
+}
+
+void EXPECT_MODIFIED(
+  merge_result<const value_set_abstract_objectt> &result,
+  const std::vector<exprt> &expected_values)
+{
+  EXPECT_MODIFIED(result.result, result.modified, expected_values);
 }
 
 void EXPECT_TOP(std::shared_ptr<const abstract_objectt> result)

--- a/unit/analyses/variable-sensitivity/variable_sensitivity_test_helpers.cpp
+++ b/unit/analyses/variable-sensitivity/variable_sensitivity_test_helpers.cpp
@@ -92,6 +92,12 @@ std::shared_ptr<value_set_abstract_objectt> make_value_set(
   return vs;
 }
 
+std::shared_ptr<value_set_abstract_objectt> make_bottom_value_set()
+{
+  return std::make_shared<value_set_abstract_objectt>(
+    integer_typet(), false, true);
+}
+
 std::shared_ptr<value_set_abstract_objectt> make_top_value_set()
 {
   return std::make_shared<value_set_abstract_objectt>(integer_typet());

--- a/unit/analyses/variable-sensitivity/variable_sensitivity_test_helpers.cpp
+++ b/unit/analyses/variable-sensitivity/variable_sensitivity_test_helpers.cpp
@@ -60,6 +60,12 @@ std::shared_ptr<const interval_abstract_valuet> make_top_interval()
     signedbv_typet(32), true, false);
 }
 
+std::shared_ptr<const interval_abstract_valuet> make_bottom_interval()
+{
+  return std::make_shared<interval_abstract_valuet>(
+    signedbv_typet(32), false, true);
+}
+
 std::shared_ptr<value_set_abstract_objectt>
 make_value_set(exprt val, abstract_environmentt &env, namespacet &ns)
 {
@@ -292,6 +298,24 @@ void EXPECT_UNMODIFIED(
 }
 
 void EXPECT_UNMODIFIED(
+  std::shared_ptr<const interval_abstract_valuet> &result,
+  bool modified,
+  exprt lower_value,
+  exprt upper_value)
+{
+  CHECK_FALSE(modified);
+  EXPECT(result, lower_value, upper_value);
+}
+
+void EXPECT_UNMODIFIED(
+  merge_result<const interval_abstract_valuet> &result,
+  exprt lower_value,
+  exprt upper_value)
+{
+  EXPECT_UNMODIFIED(result.result, result.modified, lower_value, upper_value);
+}
+
+void EXPECT_UNMODIFIED(
   std::shared_ptr<const value_set_abstract_objectt> &result,
   bool modified,
   const std::vector<exprt> &expected_values)
@@ -321,6 +345,24 @@ void EXPECT_MODIFIED(
   exprt expected_value)
 {
   EXPECT_MODIFIED(result.result, result.modified, expected_value);
+}
+
+void EXPECT_MODIFIED(
+  std::shared_ptr<const interval_abstract_valuet> &result,
+  bool modified,
+  exprt lower_value,
+  exprt upper_value)
+{
+  CHECK(modified);
+  EXPECT(result, lower_value, upper_value);
+}
+
+void EXPECT_MODIFIED(
+  merge_result<const interval_abstract_valuet> &result,
+  exprt lower_value,
+  exprt upper_value)
+{
+  EXPECT_MODIFIED(result.result, result.modified, lower_value, upper_value);
 }
 
 void EXPECT_MODIFIED(

--- a/unit/analyses/variable-sensitivity/variable_sensitivity_test_helpers.cpp
+++ b/unit/analyses/variable-sensitivity/variable_sensitivity_test_helpers.cpp
@@ -268,6 +268,13 @@ void EXPECT_UNMODIFIED(
   CHECK_FALSE(modified);
 }
 
+void EXPECT_MODIFIED(
+  std::shared_ptr<const abstract_objectt> &result,
+  bool modified)
+{
+  CHECK(modified);
+}
+
 void EXPECT_UNMODIFIED(
   std::shared_ptr<const constant_abstract_valuet> &result,
   bool modified,

--- a/unit/analyses/variable-sensitivity/variable_sensitivity_test_helpers.h
+++ b/unit/analyses/variable-sensitivity/variable_sensitivity_test_helpers.h
@@ -85,6 +85,24 @@ void EXPECT_UNMODIFIED(
   std::shared_ptr<const abstract_objectt> &result,
   bool modified);
 
+template <class abstract_typet>
+void EXPECT_UNMODIFIED(merge_result<const abstract_typet> &result)
+{
+  auto ao = std::dynamic_pointer_cast<const abstract_objectt>(result.result);
+  EXPECT_UNMODIFIED(ao, result.modified);
+}
+
+void EXPECT_MODIFIED(
+  std::shared_ptr<const abstract_objectt> &result,
+  bool modified);
+
+template <class abstract_typet>
+void EXPECT_MODIFIED(merge_result<const abstract_typet> &result)
+{
+  auto ao = std::dynamic_pointer_cast<const abstract_objectt>(result.result);
+  EXPECT_MODIFIED(ao, result.modified);
+}
+
 void EXPECT_UNMODIFIED(
   std::shared_ptr<const constant_abstract_valuet> &result,
   bool modified,

--- a/unit/analyses/variable-sensitivity/variable_sensitivity_test_helpers.h
+++ b/unit/analyses/variable-sensitivity/variable_sensitivity_test_helpers.h
@@ -26,6 +26,7 @@ std::shared_ptr<const interval_abstract_valuet> make_interval(
   abstract_environmentt &env,
   namespacet &ns);
 std::shared_ptr<const interval_abstract_valuet> make_top_interval();
+std::shared_ptr<const interval_abstract_valuet> make_bottom_interval();
 
 std::shared_ptr<value_set_abstract_objectt>
 make_value_set(exprt val, abstract_environmentt &env, namespacet &ns);
@@ -92,6 +93,30 @@ void EXPECT_UNMODIFIED(merge_result<const abstract_typet> &result)
   EXPECT_UNMODIFIED(ao, result.modified);
 }
 
+template <class abstract_typet>
+void EXPECT_UNMODIFIED_TOP(merge_result<const abstract_typet> &result)
+{
+  auto ao = std::dynamic_pointer_cast<const abstract_objectt>(result.result);
+  EXPECT_UNMODIFIED(ao, result.modified);
+  EXPECT_TOP(result.result);
+}
+
+template <class abstract_typet>
+void EXPECT_UNMODIFIED_BOTTOM(merge_result<const abstract_typet> &result)
+{
+  auto ao = std::dynamic_pointer_cast<const abstract_objectt>(result.result);
+  EXPECT_UNMODIFIED(ao, result.modified);
+  EXPECT_BOTTOM(result.result);
+}
+
+template <class abstract_typet>
+void EXPECT_MODIFIED_TOP(merge_result<const abstract_typet> &result)
+{
+  auto ao = std::dynamic_pointer_cast<const abstract_objectt>(result.result);
+  EXPECT_MODIFIED(ao, result.modified);
+  EXPECT_TOP(result.result);
+}
+
 void EXPECT_MODIFIED(
   std::shared_ptr<const abstract_objectt> &result,
   bool modified);
@@ -113,6 +138,17 @@ void EXPECT_UNMODIFIED(
   exprt expected_value);
 
 void EXPECT_UNMODIFIED(
+  std::shared_ptr<const interval_abstract_valuet> &result,
+  bool modified,
+  exprt lower_value,
+  exprt upper_value);
+
+void EXPECT_UNMODIFIED(
+  merge_result<const interval_abstract_valuet> &result,
+  exprt lower_value,
+  exprt upper_value);
+
+void EXPECT_UNMODIFIED(
   std::shared_ptr<const value_set_abstract_objectt> &result,
   bool modified,
   const std::vector<exprt> &expected_values);
@@ -129,6 +165,17 @@ void EXPECT_MODIFIED(
 void EXPECT_MODIFIED(
   merge_result<const constant_abstract_valuet> &result,
   exprt expected_value);
+
+void EXPECT_MODIFIED(
+  std::shared_ptr<const interval_abstract_valuet> &result,
+  bool modified,
+  exprt lower_value,
+  exprt upper_value);
+
+void EXPECT_MODIFIED(
+  merge_result<const interval_abstract_valuet> &result,
+  exprt lower_value,
+  exprt upper_value);
 
 void EXPECT_MODIFIED(
   std::shared_ptr<const value_set_abstract_objectt> &result,

--- a/unit/analyses/variable-sensitivity/variable_sensitivity_test_helpers.h
+++ b/unit/analyses/variable-sensitivity/variable_sensitivity_test_helpers.h
@@ -6,6 +6,9 @@
 
 \*******************************************************************/
 
+#ifndef CPROVER_ANALYSES_VARIABLE_SENSITIVITY_VARIABLE_SENSITIVITY_TEST_HELPERS_H
+#define CPROVER_ANALYSES_VARIABLE_SENSITIVITY_VARIABLE_SENSITIVITY_TEST_HELPERS_H
+
 #include <analyses/variable-sensitivity/constant_abstract_value.h>
 #include <analyses/variable-sensitivity/interval_abstract_value.h>
 #include <analyses/variable-sensitivity/value_set_abstract_object.h>
@@ -36,6 +39,7 @@ std::shared_ptr<value_set_abstract_objectt> make_value_set(
   abstract_environmentt &env,
   namespacet &ns);
 
+std::shared_ptr<value_set_abstract_objectt> make_bottom_value_set();
 std::shared_ptr<value_set_abstract_objectt> make_top_value_set();
 
 abstract_object_pointert make_bottom_object();
@@ -215,3 +219,5 @@ std::shared_ptr<const value_set_abstract_objectt> add_as_value_set(
   const abstract_object_pointert &op3,
   abstract_environmentt &environment,
   namespacet &ns);
+
+#endif

--- a/unit/analyses/variable-sensitivity/variable_sensitivity_test_helpers.h
+++ b/unit/analyses/variable-sensitivity/variable_sensitivity_test_helpers.h
@@ -37,6 +37,9 @@ std::shared_ptr<value_set_abstract_objectt> make_value_set(
 
 std::shared_ptr<value_set_abstract_objectt> make_top_value_set();
 
+abstract_object_pointert make_bottom_object();
+abstract_object_pointert make_top_object();
+
 std::shared_ptr<const constant_abstract_valuet>
 as_constant(const abstract_object_pointert &aop);
 
@@ -71,6 +74,13 @@ void EXPECT_TOP(std::shared_ptr<const value_set_abstract_objectt> &result);
 
 void EXPECT_BOTTOM(std::shared_ptr<const abstract_objectt> result);
 
+template <class value_typet>
+struct merge_result
+{
+  bool modified;
+  std::shared_ptr<const value_typet> result;
+};
+
 void EXPECT_UNMODIFIED(
   std::shared_ptr<const abstract_objectt> &result,
   bool modified);
@@ -81,8 +91,34 @@ void EXPECT_UNMODIFIED(
   exprt expected_value);
 
 void EXPECT_UNMODIFIED(
+  merge_result<const constant_abstract_valuet> &result,
+  exprt expected_value);
+
+void EXPECT_UNMODIFIED(
   std::shared_ptr<const value_set_abstract_objectt> &result,
   bool modified,
+  const std::vector<exprt> &expected_values);
+
+void EXPECT_UNMODIFIED(
+  merge_result<const value_set_abstract_objectt> &result,
+  const std::vector<exprt> &expected_values);
+
+void EXPECT_MODIFIED(
+  std::shared_ptr<const constant_abstract_valuet> &result,
+  bool modified,
+  exprt expected_value);
+
+void EXPECT_MODIFIED(
+  merge_result<const constant_abstract_valuet> &result,
+  exprt expected_value);
+
+void EXPECT_MODIFIED(
+  std::shared_ptr<const value_set_abstract_objectt> &result,
+  bool modified,
+  const std::vector<exprt> &expected_values);
+
+void EXPECT_MODIFIED(
+  merge_result<const value_set_abstract_objectt> &result,
   const std::vector<exprt> &expected_values);
 
 std::shared_ptr<const abstract_objectt> add(


### PR DESCRIPTION
As a precursor to work on widening, I've been filling out the merge implementation for the various value representations. 

The changes are relatively minor, generally simplifying and generalising the merge. Once change of note is the addition of `internal_hash` and `internal_equality` members function to `interval_abstract_valuet`, which means intervals can be inserted into value-sets correctly, without duplication. 

The bulk of this PR is unit tests, covering the various combinations of constants, intervals, and value-sets. 