### PR TITLE
Minor cleanup of some SMT2 files

### DIFF
--- a/regression/strings/test3/test-bv-to-int-onebyone.smt2
+++ b/regression/strings/test3/test-bv-to-int-onebyone.smt2
@@ -1,5 +1,6 @@
 (set-option :produce-models true)
-(set-logic ALL_SUPPORTED)
+(set-option :incremental true)
+(set-logic ALL)
 
 (declare-fun s () String)
 (declare-fun s2 () String)

--- a/regression/strings/test3/test-bv-to-int.smt2
+++ b/regression/strings/test3/test-bv-to-int.smt2
@@ -1,5 +1,5 @@
 (set-option :produce-models true)
-(set-logic ALL_SUPPORTED)
+(set-logic ALL)
 
 (declare-fun s () String)
 (declare-fun s2 () String)

--- a/regression/strings/test3/test-int.smt2
+++ b/regression/strings/test3/test-int.smt2
@@ -1,5 +1,5 @@
 (set-option :produce-models true)
-(set-logic ALL_SUPPORTED)
+(set-logic ALL)
 
 (declare-fun s () String)
 (declare-fun s2 () String)


### PR DESCRIPTION
This is a minor cleanup PR.

There were 3 SMT2 files that were:
1. being rejected by CVC4 without the `--incremental` cmdline flag
2. leading to errors in Z3 because `ALL_SUPPORTED` logic was not understood

In this PR, I:
1. added `incremental` option in the SMT2 files, which is required for using `push` and `pop` commands in CVC4.
2. replaced `ALL_SUPPORTED` logic (which is CVC4-specific) with `ALL` (which is part of the SMTLIB 2.5+ standard).

The updated SMT2 files have been tested with both solvers and they emit no warnings or errors.

- [x] Each commit message has a non-empty body, explaining why the change was made.
- NA ~~Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.~~
- NA ~~The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/~~
- NA ~~Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).~~
- NA ~~My commit message includes data points confirming performance improvements (if claimed).~~
- [x] My PR is restricted to a single feature or bugfix.
- NA ~~White-space or formatting changes outside the feature-related changed lines are in commits of their own.~~