### PR TITLE
Change domain merge(...) to take trace_ptrts rather than locationt.

### DIFF
--- a/src/analyses/ai_domain.h
+++ b/src/analyses/ai_domain.h
@@ -214,9 +214,7 @@ public:
   {
     // For backwards compatability, use the location version
     return static_cast<domainT &>(dest).merge(
-      static_cast<const domainT &>(src),
-      from->current_location(),
-      to->current_location());
+      static_cast<const domainT &>(src), from, to);
   }
 };
 

--- a/src/analyses/constant_propagator.cpp
+++ b/src/analyses/constant_propagator.cpp
@@ -638,8 +638,8 @@ bool constant_propagator_domaint::valuest::meet(
 /// \return Return true if "this" has changed.
 bool constant_propagator_domaint::merge(
   const constant_propagator_domaint &other,
-  locationt,
-  locationt)
+  trace_ptrt,
+  trace_ptrt)
 {
   return values.merge(other.values);
 }

--- a/src/analyses/constant_propagator.h
+++ b/src/analyses/constant_propagator.h
@@ -48,8 +48,8 @@ public:
 
   bool merge(
     const constant_propagator_domaint &other,
-    locationt from,
-    locationt to);
+    trace_ptrt from,
+    trace_ptrt to);
 
   virtual bool ai_simplify(
     exprt &condition,

--- a/src/analyses/custom_bitvector_analysis.cpp
+++ b/src/analyses/custom_bitvector_analysis.cpp
@@ -609,8 +609,8 @@ void custom_bitvector_domaint::output(
 
 bool custom_bitvector_domaint::merge(
   const custom_bitvector_domaint &b,
-  locationt,
-  locationt)
+  trace_ptrt,
+  trace_ptrt)
 {
   bool changed=has_values.is_false();
   has_values=tvt::unknown();

--- a/src/analyses/custom_bitvector_analysis.h
+++ b/src/analyses/custom_bitvector_analysis.h
@@ -71,10 +71,7 @@ public:
     return has_values.is_true();
   }
 
-  bool merge(
-    const custom_bitvector_domaint &b,
-    locationt from,
-    locationt to);
+  bool merge(const custom_bitvector_domaint &b, trace_ptrt from, trace_ptrt to);
 
   typedef unsigned long long bit_vectort;
 

--- a/src/analyses/dependence_graph.cpp
+++ b/src/analyses/dependence_graph.cpp
@@ -21,8 +21,8 @@ Date: August 2013
 
 bool dep_graph_domaint::merge(
   const dep_graph_domaint &src,
-  goto_programt::const_targett,
-  goto_programt::const_targett)
+  trace_ptrt,
+  trace_ptrt)
 {
   // An abstract state at location `to` may be non-bottom even if
   // `merge(..., `to`) has not been called so far. This is due to the special

--- a/src/analyses/dependence_graph.h
+++ b/src/analyses/dependence_graph.h
@@ -73,10 +73,7 @@ public:
   {
   }
 
-  bool merge(
-    const dep_graph_domaint &src,
-    goto_programt::const_targett from,
-    goto_programt::const_targett to);
+  bool merge(const dep_graph_domaint &src, trace_ptrt from, trace_ptrt to);
 
   void transform(
     const irep_idt &function_from,

--- a/src/analyses/escape_analysis.cpp
+++ b/src/analyses/escape_analysis.cpp
@@ -326,10 +326,7 @@ void escape_domaint::output(
   }
 }
 
-bool escape_domaint::merge(
-  const escape_domaint &b,
-  locationt,
-  locationt)
+bool escape_domaint::merge(const escape_domaint &b, trace_ptrt, trace_ptrt)
 {
   bool changed=has_values.is_false();
   has_values=tvt::unknown();

--- a/src/analyses/escape_analysis.h
+++ b/src/analyses/escape_analysis.h
@@ -41,10 +41,7 @@ public:
     const ai_baset &ai,
     const namespacet &ns) const final override;
 
-  bool merge(
-    const escape_domaint &b,
-    locationt from,
-    locationt to);
+  bool merge(const escape_domaint &b, trace_ptrt from, trace_ptrt to);
 
   void make_bottom() final override
   {

--- a/src/analyses/global_may_alias.cpp
+++ b/src/analyses/global_may_alias.cpp
@@ -197,8 +197,8 @@ void global_may_alias_domaint::output(
 
 bool global_may_alias_domaint::merge(
   const global_may_alias_domaint &b,
-  locationt,
-  locationt)
+  trace_ptrt,
+  trace_ptrt)
 {
   bool changed=has_values.is_false();
   has_values=tvt::unknown();

--- a/src/analyses/global_may_alias.h
+++ b/src/analyses/global_may_alias.h
@@ -48,10 +48,7 @@ public:
     const namespacet &ns) const final override;
 
   /// Abstract Interpretation domain merge function.
-  bool merge(
-    const global_may_alias_domaint &b,
-    locationt from,
-    locationt to);
+  bool merge(const global_may_alias_domaint &b, trace_ptrt from, trace_ptrt to);
 
   /// Clear list of aliases, and mark domain as bottom.
   void make_bottom() final override

--- a/src/analyses/interval_domain.h
+++ b/src/analyses/interval_domain.h
@@ -48,10 +48,7 @@ protected:
   bool join(const interval_domaint &b);
 
 public:
-  bool merge(
-    const interval_domaint &b,
-    locationt,
-    locationt)
+  bool merge(const interval_domaint &b, trace_ptrt, trace_ptrt)
   {
     return join(b);
   }

--- a/src/analyses/invariant_set_domain.h
+++ b/src/analyses/invariant_set_domain.h
@@ -33,10 +33,7 @@ public:
 
   // overloading
 
-  bool merge(
-    const invariant_set_domaint &other,
-    locationt,
-    locationt)
+  bool merge(const invariant_set_domaint &other, trace_ptrt, trace_ptrt)
   {
     bool changed=invariant_set.make_union(other.invariant_set) ||
                  has_values.is_false();

--- a/src/analyses/is_threaded.cpp
+++ b/src/analyses/is_threaded.cpp
@@ -28,10 +28,7 @@ public:
     // this is bottom
   }
 
-  bool merge(
-    const is_threaded_domaint &src,
-    locationt,
-    locationt)
+  bool merge(const is_threaded_domaint &src, trace_ptrt, trace_ptrt)
   {
     INVARIANT(src.reachable,
               "Abstract states are only merged at reachable locations");

--- a/src/analyses/reaching_definitions.cpp
+++ b/src/analyses/reaching_definitions.cpp
@@ -675,8 +675,8 @@ bool rd_range_domaint::merge_inner(
 
 bool rd_range_domaint::merge(
   const rd_range_domaint &other,
-  locationt,
-  locationt)
+  trace_ptrt,
+  trace_ptrt)
 {
   bool changed=has_values.is_false();
   has_values=tvt::unknown();

--- a/src/analyses/reaching_definitions.h
+++ b/src/analyses/reaching_definitions.h
@@ -218,10 +218,7 @@ public:
   /// \param from: Not used at all.
   /// \param to: Not used at all.
   /// \return Returns true iff there is something new
-  bool merge(
-    const rd_range_domaint &other,
-    locationt from,
-    locationt to);
+  bool merge(const rd_range_domaint &other, trace_ptrt from, trace_ptrt to);
 
   bool merge_shared(
     const rd_range_domaint &other,

--- a/src/analyses/uninitialized_domain.cpp
+++ b/src/analyses/uninitialized_domain.cpp
@@ -80,8 +80,8 @@ void uninitialized_domaint::output(
 /// \return returns true iff there is something new
 bool uninitialized_domaint::merge(
   const uninitialized_domaint &other,
-  locationt,
-  locationt)
+  trace_ptrt,
+  trace_ptrt)
 {
   auto old_uninitialized=uninitialized.size();
 

--- a/src/analyses/uninitialized_domain.h
+++ b/src/analyses/uninitialized_domain.h
@@ -74,10 +74,8 @@ public:
   }
 
   // returns true iff there is something new
-  bool merge(
-    const uninitialized_domaint &other,
-    locationt from,
-    locationt to);
+  bool
+  merge(const uninitialized_domaint &other, trace_ptrt from, trace_ptrt to);
 
 private:
   tvt has_values;

--- a/src/analyses/variable-sensitivity/variable_sensitivity_dependence_graph.cpp
+++ b/src/analyses/variable-sensitivity/variable_sensitivity_dependence_graph.cpp
@@ -399,8 +399,8 @@ bool variable_sensitivity_dependence_domaint::merge_control_dependencies(
  */
 bool variable_sensitivity_dependence_domaint::merge(
   const variable_sensitivity_domaint &b,
-  locationt from,
-  locationt to)
+  trace_ptrt from,
+  trace_ptrt to)
 {
   bool changed = false;
 

--- a/src/analyses/variable-sensitivity/variable_sensitivity_dependence_graph.h
+++ b/src/analyses/variable-sensitivity/variable_sensitivity_dependence_graph.h
@@ -134,8 +134,8 @@ public:
 
   bool merge(
     const variable_sensitivity_domaint &b,
-    locationt from,
-    locationt to) override;
+    trace_ptrt from,
+    trace_ptrt to) override;
 
   void merge_three_way_function_return(
     const ai_domain_baset &function_call,

--- a/src/analyses/variable-sensitivity/variable_sensitivity_domain.cpp
+++ b/src/analyses/variable-sensitivity/variable_sensitivity_domain.cpp
@@ -197,8 +197,8 @@ void variable_sensitivity_domaint::make_entry()
 
 bool variable_sensitivity_domaint::merge(
   const variable_sensitivity_domaint &b,
-  locationt from,
-  locationt to)
+  trace_ptrt from,
+  trace_ptrt to)
 {
 #ifdef DEBUG
   std::cout << "Merging from/to:\n " << from->location_number << " --> "

--- a/src/analyses/variable-sensitivity/variable_sensitivity_domain.h
+++ b/src/analyses/variable-sensitivity/variable_sensitivity_domain.h
@@ -157,7 +157,7 @@ public:
   ///
   /// \return true if something has changed.
   virtual bool
-  merge(const variable_sensitivity_domaint &b, locationt from, locationt to);
+  merge(const variable_sensitivity_domaint &b, trace_ptrt from, trace_ptrt to);
 
   /// Perform a context aware merge of the changes that have been applied
   /// between function_start and the current state. Anything that has not been

--- a/unit/analyses/ai/ai.cpp
+++ b/unit/analyses/ai/ai.cpp
@@ -70,7 +70,7 @@ public:
     return true;
   }
 
-  bool merge(const instruction_counter_domaint &b, locationt, locationt)
+  bool merge(const instruction_counter_domaint &b, trace_ptrt, trace_ptrt)
   {
     if(b.is_bottom())
       return false;


### PR DESCRIPTION
Passing in trace_ptrts provides more context that locationt, which we
will need in the variable-sensitivity domain to determine if we need to
widen.

While this change touches code across the repository, at the moment
 however, none of the merge functions use this information at all,
so this change is a benign.
