### PR TITLE
Fix z3 installation on PR CI jobs

### DIFF
--- a/.github/workflows/pull-request-checks.yaml
+++ b/.github/workflows/pull-request-checks.yaml
@@ -287,7 +287,7 @@ jobs:
           submodules: recursive
       - name: Fetch dependencies
         run: |
-          choco install winflexbison3 strawberryperl
+          choco install winflexbison3 strawberryperl z3
           nuget install clcache -OutputDirectory "c:\tools" -ExcludeVersion -Version 4.1.0
           echo "c:\tools\clcache\clcache-4.1.0" >> $env:GITHUB_PATH
           echo "c:\ProgramData\chocolatey\bin" >> $env:GITHUB_PATH

--- a/.github/workflows/pull-request-checks.yaml
+++ b/.github/workflows/pull-request-checks.yaml
@@ -248,9 +248,12 @@ jobs:
           submodules: recursive
       - name: Fetch dependencies
         run: |
-          choco install winflexbison3 z3
+          choco install winflexbison3
           nuget install clcache -OutputDirectory "c:\tools" -ExcludeVersion -Version 4.1.0
           echo "c:\tools\clcache\clcache-4.1.0" >> $env:GITHUB_PATH
+          Invoke-WebRequest -Uri https://github.com/Z3Prover/z3/releases/download/z3-4.8.10/z3-4.8.10-x64-win.zip -OutFile .\z3.zip
+          Expand-Archive -LiteralPath '.\z3.Zip' -DestinationPath C:\tools
+          echo "c:\tools\z3-4.8.10-x64-win\bin;" >> $env:GITHUB_PATH
       - name: Setup Visual Studio environment
         uses: microsoft/setup-msbuild@v1.0.2
       - name: Prepare ccache
@@ -287,11 +290,14 @@ jobs:
           submodules: recursive
       - name: Fetch dependencies
         run: |
-          choco install winflexbison3 strawberryperl z3
+          choco install winflexbison3 strawberryperl
           nuget install clcache -OutputDirectory "c:\tools" -ExcludeVersion -Version 4.1.0
           echo "c:\tools\clcache\clcache-4.1.0" >> $env:GITHUB_PATH
           echo "c:\ProgramData\chocolatey\bin" >> $env:GITHUB_PATH
           echo "c:\Strawberry\" >> $env:GITHUB_PATH
+          Invoke-WebRequest -Uri https://github.com/Z3Prover/z3/releases/download/z3-4.8.10/z3-4.8.10-x64-win.zip -OutFile .\z3.zip
+          Expand-Archive -LiteralPath '.\z3.Zip' -DestinationPath C:\tools
+          echo "c:\tools\z3-4.8.10-x64-win\bin;" >> $env:GITHUB_PATH
       - name: Setup MSBuild
         uses: microsoft/setup-msbuild@v1.0.2
       - name: Initialise Developer Command Line

--- a/.github/workflows/pull-request-checks.yaml
+++ b/.github/workflows/pull-request-checks.yaml
@@ -434,7 +434,7 @@ jobs:
       - name: Fetch dependencies
         run: | 
           sudo apt-get update
-          sudo apt-get install --no-install-recommends -y g++ flex bison cmake ninja-build maven jq libxml2-utils dpkg-dev ccache
+          sudo apt-get install --no-install-recommends -y g++ flex bison cmake ninja-build maven jq libxml2-utils dpkg-dev ccache z3
           # remove libgcc-s1, which isn't normally available in Ubuntu 18.04
           target=$(dpkg-query -W --showformat='${Version}\n' gcc-8-base | head -n 1)
           # libgcc1 uses an epoch, thus the extra 1:

--- a/.github/workflows/pull-request-checks.yaml
+++ b/.github/workflows/pull-request-checks.yaml
@@ -18,6 +18,8 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install --no-install-recommends -yq gcc gdb g++ maven jq flex bison libxml2-utils ccache cmake z3
+      - name: Confirm z3 solver is available and log the version installed
+        run: z3 --version
       - name: Prepare ccache
         uses: actions/cache@v2
         with:
@@ -78,6 +80,8 @@ jobs:
           sudo apt-get install --no-install-recommends -yq clang-10 clang++-10 gdb maven jq flex bison libxml2-utils cpanminus ccache z3
           make -C src minisat2-download
           cpanm Thread::Pool::Simple
+      - name: Confirm z3 solver is available and log the version installed
+        run: z3 --version
       - name: Prepare ccache
         uses: actions/cache@v2
         with:
@@ -129,6 +133,8 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install --no-install-recommends -yq cmake ninja-build gcc g++ maven flex bison libxml2-utils dpkg-dev ccache doxygen z3
+      - name: Confirm z3 solver is available and log the version installed
+        run: z3 --version
       - name: Prepare ccache
         uses: actions/cache@v2
         with:
@@ -172,6 +178,8 @@ jobs:
           submodules: recursive
       - name: Fetch dependencies
         run: brew install maven flex bison parallel ccache z3
+      - name: Confirm z3 solver is available and log the version installed
+        run: z3 --version
       - name: Prepare ccache
         uses: actions/cache@v2
         with:
@@ -212,6 +220,8 @@ jobs:
           submodules: recursive
       - name: Fetch dependencies
         run: brew install cmake ninja maven flex bison ccache z3
+      - name: Confirm z3 solver is available and log the version installed
+        run: z3 --version
       - name: Prepare ccache
         uses: actions/cache@v2
         with:
@@ -254,6 +264,8 @@ jobs:
           Invoke-WebRequest -Uri https://github.com/Z3Prover/z3/releases/download/z3-4.8.10/z3-4.8.10-x64-win.zip -OutFile .\z3.zip
           Expand-Archive -LiteralPath '.\z3.Zip' -DestinationPath C:\tools
           echo "c:\tools\z3-4.8.10-x64-win\bin;" >> $env:GITHUB_PATH
+      - name: Confirm z3 solver is available and log the version installed
+        run: z3 --version
       - name: Setup Visual Studio environment
         uses: microsoft/setup-msbuild@v1.0.2
       - name: Prepare ccache
@@ -298,6 +310,8 @@ jobs:
           Invoke-WebRequest -Uri https://github.com/Z3Prover/z3/releases/download/z3-4.8.10/z3-4.8.10-x64-win.zip -OutFile .\z3.zip
           Expand-Archive -LiteralPath '.\z3.Zip' -DestinationPath C:\tools
           echo "c:\tools\z3-4.8.10-x64-win\bin;" >> $env:GITHUB_PATH
+      - name: Confirm z3 solver is available and log the version installed
+        run: z3 --version
       - name: Setup MSBuild
         uses: microsoft/setup-msbuild@v1.0.2
       - name: Initialise Developer Command Line
@@ -439,6 +453,8 @@ jobs:
           target=$(dpkg-query -W --showformat='${Version}\n' gcc-8-base | head -n 1)
           # libgcc1 uses an epoch, thus the extra 1:
           sudo apt-get install -y --allow-downgrades --reinstall gcc g++ libgcc-s1- libstdc++6=$target liblsan0=$target libtsan0=$target libcc1-0=$target libgcc1=1:$target
+      - name: Confirm z3 solver is available and log the version installed
+        run: z3 --version
       - name: Prepare ccache
         uses: actions/cache@v2
         with:
@@ -521,6 +537,8 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install --no-install-recommends -y g++ gcc binutils flex bison cmake maven jq libxml2-utils openjdk-11-jdk-headless lcov ccache z3
+      - name: Confirm z3 solver is available and log the version installed
+        run: z3 --version
       - name: Prepare ccache
         uses: actions/cache@v2
         with:

--- a/regression/cbmc/z3/invalid.c
+++ b/regression/cbmc/z3/invalid.c
@@ -1,0 +1,8 @@
+#include <assert.h>
+
+int main()
+{
+  unsigned int non_det;
+  assert(non_det * non_det != 9u);
+  return 0;
+}

--- a/regression/cbmc/z3/invalid.desc
+++ b/regression/cbmc/z3/invalid.desc
@@ -1,0 +1,14 @@
+CORE
+invalid.c
+--trace --smt2 --z3
+^EXIT=10$
+^SIGNAL=0$
+line 6 assertion non_det \* non_det != 9u: FAILURE
+non_det=\d+u
+VERIFICATION FAILED
+--
+line 6 assertion non_det \* non_det != 9u: ERROR
+error running SMT2 solver
+--
+Run cbmc with the --z3 option to confirm that support for the Z3 solver is
+available and working for an invalid program where the assertion may fail.

--- a/regression/cbmc/z3/valid.c
+++ b/regression/cbmc/z3/valid.c
@@ -1,0 +1,8 @@
+#include <assert.h>
+
+int main()
+{
+  unsigned int non_det;
+  assert(non_det * non_det != 12u);
+  return 0;
+}

--- a/regression/cbmc/z3/valid.desc
+++ b/regression/cbmc/z3/valid.desc
@@ -1,0 +1,13 @@
+CORE
+valid.c
+--trace --smt2 --z3
+^EXIT=0$
+^SIGNAL=0$
+line 6 assertion non_det \* non_det != 12u: SUCCESS
+VERIFICATION SUCCESSFUL
+--
+line 6 assertion non_det \* non_det != 12u: ERROR
+error running SMT2 solver
+--
+Run cbmc with the --z3 option to confirm that support for the Z3 solver is
+available and working for a valid program.


### PR DESCRIPTION
Includes updating z3 to 4.8.10 for Windows CI jobs. So that the version, which is currently most recently released is available for use in Windows regression tests. Z3 installation was previously broken, due to the chocolatey package being out of date / broken and due to the installation being missing from various jobs.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
