### PR TITLE
Move exprt::bounded_size to complexity_limitert

### DIFF
--- a/src/goto-symex/complexity_limiter.h
+++ b/src/goto-symex/complexity_limiter.h
@@ -69,6 +69,12 @@ public:
     complexity_violationt complexity_violation,
     goto_symex_statet &current_state);
 
+  /// Amount of nodes in \p expr approximately bounded by limit.
+  /// This is the size of the actual tree, ignoring memory/sub-tree sharing.
+  /// Expressions that make substantial use of sharing may result in excessive
+  /// run time.
+  static std::size_t bounded_expr_size(const exprt &expr, std::size_t limit);
+
 protected:
   mutable messaget log;
 

--- a/src/util/expr.cpp
+++ b/src/util/expr.cpp
@@ -24,30 +24,6 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <stack>
 
-/// Returns the size of the exprt added to count without searching significantly
-/// beyond the supplied limit.
-std::size_t exprt::bounded_size(std::size_t count, std::size_t limit) const
-{
-  const auto &ops = operands();
-  count += ops.size();
-  for(const auto &op : ops)
-  {
-    if(count >= limit)
-    {
-      return count;
-    }
-    count = op.bounded_size(count, limit);
-  }
-  return count;
-}
-
-/// Returns the size of the exprt without significantly searching beyond the
-/// supplied limit.
-std::size_t exprt::bounded_size(std::size_t limit) const
-{
-  return bounded_size(1, limit);
-}
-
 /// Return whether the expression is a constant.
 /// \return True if is a constant, false otherwise
 bool exprt::is_constant() const

--- a/src/util/expr.h
+++ b/src/util/expr.h
@@ -85,10 +85,6 @@ public:
     return static_cast<const typet &>(find(ID_type));
   }
 
-  /// Amount of nodes in this expression tree approximately bounded by limit.
-  /// This is the size of the actual tree, ignoring memory/sub-tree sharing.
-  std::size_t bounded_size(std::size_t limit) const;
-
   /// Return true if there is at least one operand.
   bool has_operands() const
   { return !operands().empty(); }
@@ -123,10 +119,6 @@ protected:
 
   const exprt &op3() const
   { return operands()[3]; }
-
-  /// Amount of nodes this expression tree contains, with a bound on how far
-  /// to search. Starts with an existing count.
-  std::size_t bounded_size(std::size_t count, std::size_t limit) const;
 
 public:
   void reserve_operands(operandst::size_type n)

--- a/unit/Makefile
+++ b/unit/Makefile
@@ -54,6 +54,7 @@ SRC += analyses/ai/ai.cpp \
        goto-programs/remove_returns.cpp \
        goto-programs/xml_expr.cpp \
        goto-symex/apply_condition.cpp \
+       goto-symex/complexity_limiter.cpp \
        goto-symex/expr_skeleton.cpp \
        goto-symex/goto_symex_state.cpp \
        goto-symex/ssa_equation.cpp \

--- a/unit/goto-symex/complexity_limiter.cpp
+++ b/unit/goto-symex/complexity_limiter.cpp
@@ -1,0 +1,52 @@
+/*******************************************************************\
+
+Module: Unit test for goto-symex/complexity_limiter
+
+Author: Diffblue Ltd
+
+\*******************************************************************/
+
+#include <testing-utils/use_catch.h>
+
+#include <util/arith_tools.h>
+
+#include <goto-symex/complexity_limiter.h>
+
+TEST_CASE(
+  "Bounded expression size is computed correctly",
+  "[core][goto-symex][complexity_limiter]")
+{
+  // Helper types and functions for constructing test expressions.
+  const typet type = signedbv_typet(32);
+  std::function<exprt(size_t)> make_expression;
+  make_expression = [&](size_t size) -> exprt {
+    PRECONDITION(size != 0);
+    if(size <= 1)
+      return from_integer(1, type);
+    if(size == 2)
+      return unary_minus_exprt(from_integer(1, type));
+    return plus_exprt(from_integer(1, type), make_expression(size - 2));
+  };
+  // Actual test cases.
+  REQUIRE(complexity_limitert::bounded_expr_size(make_expression(1), 10) == 1);
+  REQUIRE(complexity_limitert::bounded_expr_size(make_expression(2), 10) == 2);
+  REQUIRE(complexity_limitert::bounded_expr_size(make_expression(3), 10) == 3);
+
+  REQUIRE(complexity_limitert::bounded_expr_size(make_expression(30), 10) < 13);
+  REQUIRE(
+    complexity_limitert::bounded_expr_size(make_expression(30), 10) >= 10);
+}
+
+TEST_CASE(
+  "Bounded expression size versus pathological example",
+  "[core][goto-symex][complexity_limiter]")
+{
+  const typet type = signedbv_typet(32);
+  exprt pathology = plus_exprt(from_integer(1, type), from_integer(1, type));
+  // Create an infinite exprt by self reference!
+  pathology.add_to_operands(pathology);
+  // If bounded expression size is not checking the bound this will never
+  // terminate.
+  REQUIRE(complexity_limitert::bounded_expr_size(pathology, 10) < 13);
+  REQUIRE(complexity_limitert::bounded_expr_size(pathology, 10) >= 10);
+}

--- a/unit/util/expr.cpp
+++ b/unit/util/expr.cpp
@@ -36,36 +36,3 @@ SCENARIO("bitfield-expr-is-zero", "[core][util][expr]")
     }
   }
 }
-
-TEST_CASE("Bounded size is computer correctly", "[core][util][expr]")
-{
-  // Helper types and functions for constructing test expressions.
-  const typet type = signedbv_typet(32);
-  std::function<exprt(size_t)> make_expression;
-  make_expression = [&](size_t size) -> exprt {
-    PRECONDITION(size != 0);
-    if(size <= 1)
-      return from_integer(1, type);
-    if(size == 2)
-      return unary_minus_exprt(from_integer(1, type));
-    return plus_exprt(from_integer(1, type), make_expression(size - 2));
-  };
-  // Actual test cases.
-  REQUIRE(make_expression(1).bounded_size(10) == 1);
-  REQUIRE(make_expression(2).bounded_size(10) == 2);
-  REQUIRE(make_expression(3).bounded_size(10) == 3);
-
-  REQUIRE(make_expression(30).bounded_size(10) < 13);
-  REQUIRE(make_expression(30).bounded_size(10) >= 10);
-}
-
-TEST_CASE("Bounded size versus pathological example", "[core][util][expr]")
-{
-  const typet type = signedbv_typet(32);
-  exprt pathology = plus_exprt(from_integer(1, type), from_integer(1, type));
-  // Create an infinite exprt by self reference!
-  pathology.add_to_operands(pathology);
-  // If bounded size is not checking the bound this will never terminate.
-  REQUIRE(pathology.bounded_size(10) < 13);
-  REQUIRE(pathology.bounded_size(10) >= 10);
-}


### PR DESCRIPTION
complexity_limitert is really the only user of this method, and may be
fine with its implementation details (cf. discussion in #5914). For
other potential users such assumptions might not be safe.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
