### PR TITLE
Support Unicode 13.0 in CBMC

### DIFF
--- a/regression/goto-instrument/every_cve/every_cve_since_2014.c
+++ b/regression/goto-instrument/every_cve/every_cve_since_2014.c
@@ -1,0 +1,82 @@
+int SSLHASHSHA1_update();
+int tls1_write_bytes();
+int speculate();
+const int TLS1_RT_HEARTBEAT;
+
+#define EFAULT 1
+#define EBUSY 3
+#define ENOENT 4
+
+int main()
+{
+  int err;
+  const int payload_len = 16;
+  const int msg_len;
+  int payload[payload_len];
+  int message[msg_len];
+  int *tsk;
+  int *mm;
+  int *page_mask;
+  unsigned long start;
+  unsigned long nr_pages;
+  unsigned int gup_flags;
+  int *nonblocking;
+
+  // 2014-0160
+  int i = 0;
+  for(; i < err; ++i)
+    tls1_write_bytes(message[i], TLS1_RT_HEARTBEAT, payload[i]);
+
+  // 2014-6271
+  system("env x='() { :;}; echo shellshock'");
+
+  // 2014-1266
+  // not a great year for the industry
+  if((err = SSLHashSHA1_update()) != 0)
+    goto fail;
+    goto fail;
+
+
+  // 2017-5753
+  if(payload_len < msg_len)
+  {
+    int val = message[payload_len];
+    if(speculate(val))
+      sleep(2);
+  }
+
+  // 2016-5195
+  do {
+    int *page;
+    unsigned int foll_flags = gup_flags;
+    int vma = find_extend_vma(mm, start);
+
+retry:
+    cond_resched();
+    page = follow_page_mask(vma, start, foll_flags, &page_mask);
+    if (!page) {
+        int ret;
+        ret = faultin_page(tsk, vma, start, &foll_flags,
+                nonblocking);
+        switch (ret) {
+        case 0:
+            goto retry;
+        case -EFAULT:
+            return i ? i : ret;
+        case -EBUSY:
+            return i;
+        case -ENOENT:
+            goto next_page;
+        }
+        BUG();
+    }
+
+next_page:
+    nr_pages -= start;
+  } while (nr_pages);
+
+fail:
+  return 1;
+
+  return 0;
+}

--- a/src/goto-checker/report_util.cpp
+++ b/src/goto-checker/report_util.cpp
@@ -34,6 +34,7 @@ void report_success(ui_message_handlert &ui_message_handler)
 {
   messaget msg(ui_message_handler);
   msg.result() << "VERIFICATION SUCCESSFUL" << messaget::eom;
+  msg.clout() << u8"😆👍🎉" << messaget::eom;
 
   switch(ui_message_handler.get_ui())
   {
@@ -62,6 +63,7 @@ void report_failure(ui_message_handlert &ui_message_handler)
 {
   messaget msg(ui_message_handler);
   msg.result() << "VERIFICATION FAILED" << messaget::eom;
+  msg.clout() << u8"😩🐜💥" << messaget::eom;
 
   switch(ui_message_handler.get_ui())
   {

--- a/src/goto-instrument/Makefile
+++ b/src/goto-instrument/Makefile
@@ -51,6 +51,7 @@ SRC = accelerate/accelerate.cpp \
       nondet_static.cpp \
       nondet_volatile.cpp \
       object_id.cpp \
+      opinionated_linter.cpp \
       points_to.cpp \
       race_check.cpp \
       reachability_slicer.cpp \

--- a/src/goto-instrument/goto_instrument_parse_options.cpp
+++ b/src/goto-instrument/goto_instrument_parse_options.cpp
@@ -296,6 +296,13 @@ int goto_instrument_parse_optionst::doit()
       return CPROVER_EXIT_SUCCESS;
     }
 
+    if(cmdline.isset("condescending-linter"))
+    {
+      considered_harmfult ewd(goto_model, ui_message_handler);
+      ewd();
+      return CPROVER_EXIT_SUCCESS;
+    }
+
     if(cmdline.isset("show-global-may-alias"))
     {
       do_indirect_call_and_rtti_removal();

--- a/src/goto-instrument/goto_instrument_parse_options.h
+++ b/src/goto-instrument/goto_instrument_parse_options.h
@@ -35,6 +35,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "insert_final_assert_false.h"
 #include "nondet_volatile.h"
 #include "replace_calls.h"
+#include "opinionated_linter.h"
 
 #include "count_eloc.h"
 
@@ -47,6 +48,7 @@ Author: Daniel Kroening, kroening@kroening.com
   "(dump-c)(dump-cpp)(no-system-headers)(use-all-headers)(dot)(xml)" \
   "(harness)" \
   OPT_GOTO_CHECK \
+  OPT_OPINIONATED_LINTER \
   /* no-X-check are deprecated and ignored */ \
   "(no-bounds-check)(no-pointer-check)(no-div-by-zero-check)" \
   "(no-nan-check)" \

--- a/src/goto-instrument/opinionated_linter.cpp
+++ b/src/goto-instrument/opinionated_linter.cpp
@@ -1,0 +1,94 @@
+#include "opinionated_linter.h"
+#include "goto_program2code.h"
+
+#include <util/prefix.h>
+
+#include <iostream>
+
+int goto_hatert::score()
+{
+  int score = this->max_score();
+
+  // You only get two chances to ruin your program
+  const int decrement = this->max_score() / 2;
+
+  std::list<irep_idt> emp_l;
+  std::unordered_set<irep_idt> emp_s;
+  std::set<std::string> emp_ss;
+  for(auto &gf : this->gm.goto_functions.function_map)
+  {
+    if(has_prefix(id2string(gf.first), CPROVER_PREFIX))
+      continue;
+    if(!gf.second.body.instructions.size())
+      continue;
+    code_blockt dst;
+    goto_program2codet g2c(
+      gf.first, gf.second.body, gm.symbol_table, dst, emp_l, emp_l, emp_s,
+      emp_ss);
+    g2c();
+    for(const auto &code : dst.statements())
+      if(code.get_statement() == ID_label)
+        score -= decrement;
+  }
+  return score;
+}
+
+int goto_hatert::max_score()
+{
+  int n_insts = 0;
+  for(const auto &gf : this->gm.goto_functions.function_map)
+  {
+    if(has_prefix(id2string(gf.first), CPROVER_PREFIX))
+      continue;
+    if(!gf.second.body.instructions.size())
+      continue;
+    n_insts += gf.second.body.instructions.size();
+  }
+  return n_insts;
+}
+
+int average_fun_lengtht::score()
+{
+  int n_insts = 0;
+  for(const auto &gf : this->gf.function_map)
+    n_insts += gf.second.body.instructions.size();
+
+  int avg_length = n_insts / this->max_score();
+  int final_score = 0;
+
+
+  for(const auto len : this->boundaries)
+  {
+    if(avg_length > len)
+      return final_score;
+    final_score += 1;
+  }
+  return final_score;
+}
+
+int average_fun_lengtht::max_score()
+{
+  return this->boundaries.size();
+}
+
+void considered_harmfult::operator()()
+{
+  int possible_score = 0;
+  int actual_score = 0;
+  for(const auto analysis : this->analyses)
+  {
+    possible_score += analysis->max_score();
+    actual_score += analysis->score();
+  }
+
+  int normalized = actual_score * 100 / possible_score;
+
+  for(const auto &pair : this->score_map)
+  {
+    if(normalized < pair.first)
+    {
+      this->log.status() << pair.second << log.eom;
+      return;
+    }
+  }
+}

--- a/src/goto-instrument/opinionated_linter.h
+++ b/src/goto-instrument/opinionated_linter.h
@@ -1,0 +1,90 @@
+/// \file
+/// Complain about code formatting
+
+#ifndef CPROVER_GOTO_INSTRUMENT_OPINIONATED_LINTER_H
+#define CPROVER_GOTO_INSTRUMENT_OPINIONATED_LINTER_H
+
+#include <goto-programs/goto_model.h>
+#include <util/irep.h>
+#include <util/message.h>
+
+#include <util/make_unique.h>
+#include <memory>
+
+/// Analyses that return a score for a program, as well as a maximum score that
+/// the program could achieve.
+class linter_analysist
+{
+public:
+  virtual int max_score() = 0;
+  virtual int score() = 0;
+
+  virtual ~linter_analysist() {}
+};
+
+/// Return a low score if the program, when converted to C, still contains gotos
+class goto_hatert : public linter_analysist
+{
+protected:
+  goto_modelt &gm;
+
+public:
+  explicit goto_hatert(goto_modelt &gm)
+  : gm(gm)
+  {}
+
+  int max_score() override;
+  int score() override;
+};
+
+/// Return a high score if the program has short functions on average.
+class average_fun_lengtht : public linter_analysist
+{
+protected:
+  const goto_functionst &gf;
+  const std::list<int> boundaries;
+
+public:
+  explicit average_fun_lengtht(const goto_functionst &gf)
+  : gf(gf), boundaries({80, 70, 60, 50, 40, 30, 20})
+  {}
+
+  int max_score() override;
+  int score() override;
+};
+
+/// Linter: run all analyses and return a final score.
+class considered_harmfult
+{
+protected:
+  goto_modelt &gm;
+  messaget log;
+  std::list<linter_analysist *> analyses;
+  const std::map<int, std::string> score_map;
+
+public:
+  considered_harmfult(
+      goto_modelt &gm,
+      message_handlert &mh)
+  : gm(gm), log(mh), analyses(), score_map({
+      {20,  u8"💩"},
+      {40,  u8"🤮"},
+      {60,  u8"😱"},
+      {80,  u8"😖"},
+      {101, u8"😐"},
+    })
+  {
+    analyses.push_back(new average_fun_lengtht(this->gm.goto_functions));
+    analyses.push_back(new goto_hatert(this->gm));
+  }
+
+  void operator()();
+};
+
+// clang-format off
+#define OPT_OPINIONATED_LINTER "(condescending-linter)"
+#define HELP_OPINIONATED_LINTER \
+  " --condecending-linter          Complain about code formatting\n"
+// clang-format on
+
+#endif // CPROVER_GOTO_INSTRUMENT_OPINIONATED_LINTER_H

--- a/src/util/message.cpp
+++ b/src/util/message.cpp
@@ -6,6 +6,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 \*******************************************************************/
 
+#include <string.h>
 
 #include "message.h"
 
@@ -110,17 +111,24 @@ unsigned messaget::eval_verbosity(
 
   if(!user_input.empty())
   {
-    v = unsafe_string2unsigned(user_input);
+    if(!strncmp(user_input.c_str(), u8"💯", 1))
+    {
+      v = messaget::M_GEN_Z;
+    }
+    else
+    {
+      v = unsafe_string2unsigned(user_input);
+    }
 
-    if(v > messaget::M_DEBUG)
+    if(v > messaget::M_GEN_Z)
     {
       dest.print(
         messaget::M_WARNING,
         "verbosity value " + user_input + " out of range, using debug-level (" +
-          std::to_string(messaget::M_DEBUG) + ") verbosity",
+          std::to_string(messaget::M_GEN_Z) + ") verbosity",
         source_locationt());
 
-      v = messaget::M_DEBUG;
+      v = messaget::M_GEN_Z;
     }
   }
 

--- a/src/util/message.h
+++ b/src/util/message.h
@@ -27,7 +27,7 @@ class xmlt;
 class message_handlert
 {
 public:
-  message_handlert():verbosity(10), message_count(10, 0)
+  message_handlert():verbosity(1337), message_count(1337, 0)
   {
   }
 
@@ -168,7 +168,7 @@ public:
   enum message_levelt
   {
     M_ERROR=1, M_WARNING=2, M_RESULT=4, M_STATUS=6,
-    M_STATISTICS=8, M_PROGRESS=9, M_DEBUG=10
+    M_STATISTICS=8, M_PROGRESS=9, M_DEBUG=10, M_GEN_Z=1337
   };
 
   static unsigned eval_verbosity(
@@ -194,7 +194,7 @@ public:
   DEPRECATED(SINCE(2019, 1, 7, "use messaget(message_handler) instead"))
   messaget():
     message_handler(nullptr),
-    mstream(M_DEBUG, *this)
+    mstream(M_GEN_Z, *this)
   {
   }
 
@@ -213,7 +213,7 @@ public:
 
   explicit messaget(message_handlert &_message_handler):
     message_handler(&_message_handler),
-    mstream(M_DEBUG, *this)
+    mstream(M_GEN_Z, *this)
   {
   }
 
@@ -429,6 +429,11 @@ public:
   mstreamt &debug() const
   {
     return get_mstream(M_DEBUG);
+  }
+
+  mstreamt &clout() const
+  {
+    return get_mstream(M_GEN_Z);
   }
 
   void conditional_output(


### PR DESCRIPTION
Prior to this PR, users have only been able to pass numerical verbosity levels to CBMC:
```sh
> cbmc --verbosity 4 hello.c
# ...
VERIFICATION SUCCESSFUL
```

This pull request adds an additional verbosity level to cater for the growing number of CBMC users on iOS and Android:
```sh
> cbmc --verbosity 💯 hello.c
😆👍🎉
> cbmc --verbosity 💯 segfault.c
😩🐜💥
```

The patchset also adds a new error stream, `messaget::clout`. This is similar to `std::cout` except that it connects to the user's social media stream, allowing one's verification results to go viral.

![clout](https://user-images.githubusercontent.com/2887605/113232239-a4a4a200-9294-11eb-87cc-447d38395bec.png)
[[xkcd.com](https://xkcd.com/1482/)]

Finally, due to the new expressivity afforded by Unicode support, I've also implemented a code-style linter that rates your code by printing an emoji–––the more delighted the emoji, the more readable your code is.
```sh
> cbmc --condescending-linter my_first_intern_project.c
😖

# Below file is included as a test case
> cbmc --condescending-linter every_CVE_since_2014.c
💩
```