### PR TITLE
Unify make and cmake behaviours

### DIFF
--- a/regression/Makefile
+++ b/regression/Makefile
@@ -85,7 +85,7 @@ test:
 .PHONY: $(DIRS)
 $(DIRS):
 	@echo "Running $@..." ;
-	$(MAKE) -C "$@" test || exit 1;
+	$(MAKE) -C "$@" || exit 1;
 
 # Run all test directories using GNU Parallel
 .PHONY: test-parallel

--- a/regression/Makefile
+++ b/regression/Makefile
@@ -78,14 +78,14 @@ endif
 .PHONY: test
 test:
 	@for dir in $(DIRS); do \
-		$(MAKE) "$$dir" || exit 1; \
+		$(MAKE) "$$dir" test || exit 1; \
 	done;
 
 # Pattern to execute a single test suite directory
 .PHONY: $(DIRS)
 $(DIRS):
 	@echo "Running $@..." ;
-	$(MAKE) -C "$@" || exit 1;
+	$(MAKE) -C "$@" test || exit 1;
 
 # Run all test directories using GNU Parallel
 .PHONY: test-parallel

--- a/regression/cbmc/Makefile
+++ b/regression/cbmc/Makefile
@@ -1,5 +1,3 @@
-THIS_FILE := $(lastword $(MAKEFILE_LIST))
-
 default: test
 
 include ../../src/config.inc
@@ -11,10 +9,8 @@ else
 GCC_ONLY =
 endif
 
-test:
+test: test-cprover-smt2 test-paths-lifo
 	@../test.pl -e -p -c "../../../src/cbmc/cbmc --validate-goto-model --validate-ssa-equation" -X smt-backend $(GCC_ONLY)
-	@$(MAKE) -f $(THIS_FILE) test-paths-lifo
-	@$(MAKE) -f $(THIS_FILE) test-cprover-smt2
 
 test-cprover-smt2:
 	@../test.pl -e -p -c "../../../src/cbmc/cbmc --cprover-smt2" \

--- a/regression/cbmc/Makefile
+++ b/regression/cbmc/Makefile
@@ -1,3 +1,5 @@
+THIS_FILE := $(lastword $(MAKEFILE_LIST))
+
 default: test
 
 include ../../src/config.inc
@@ -11,6 +13,8 @@ endif
 
 test:
 	@../test.pl -e -p -c "../../../src/cbmc/cbmc --validate-goto-model --validate-ssa-equation" -X smt-backend $(GCC_ONLY)
+	@$(MAKE) -f $(THIS_FILE) test-paths-lifo
+	@$(MAKE) -f $(THIS_FILE) test-cprover-smt2
 
 test-cprover-smt2:
 	@../test.pl -e -p -c "../../../src/cbmc/cbmc --cprover-smt2" \


### PR DESCRIPTION
This fixes the inconsistencies between cmake and make
behaviours.

Fixes #5986 

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
