### PR TITLE
Mark cbmc-cpp/{Templates27,namespace2} as CORE

### DIFF
--- a/regression/cbmc-cpp/Templates27/test.desc
+++ b/regression/cbmc-cpp/Templates27/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE winbug macos-assert-broken
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/namespace2/test.desc
+++ b/regression/cbmc-cpp/namespace2/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE winbug macos-assert-broken
 main.cpp
 
 ^EXIT=0$


### PR DESCRIPTION
Marking them as CORE as they pass ever since cbmc 5.10 (and possibly earlier).

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
