### PR TITLE
apply_condition: notequal need not have constant operand

### DIFF
--- a/regression/cbmc/apply_condition1/main.c
+++ b/regression/cbmc/apply_condition1/main.c
@@ -1,0 +1,10 @@
+int main()
+{
+  int y;
+  __CPROVER_bool x;
+  if(x == (__CPROVER_bool)y)
+  {
+    __CPROVER_assert(0, "assertion 0");
+  }
+  return 0;
+}

--- a/regression/cbmc/apply_condition1/test.desc
+++ b/regression/cbmc/apply_condition1/test.desc
@@ -1,0 +1,9 @@
+CORE
+main.c
+
+^VERIFICATION FAILED$
+^EXIT=10$
+^SIGNAL=0$
+--
+^Invariant check failed
+^warning: ignoring

--- a/src/goto-symex/goto_state.cpp
+++ b/src/goto-symex/goto_state.cpp
@@ -141,6 +141,9 @@ void goto_statet::apply_condition(
     if(is_ssa_expr(rhs))
       std::swap(lhs, rhs);
 
+    if(!is_ssa_expr(lhs) || !goto_symex_is_constantt()(rhs))
+      return;
+
     if(rhs.is_true())
       apply_condition(equal_exprt{lhs, false_exprt{}}, previous_state, ns);
     else if(rhs.is_false())


### PR DESCRIPTION
Just as is done for equality, the not-equal case needs to test that the
LHS is a symbol and the RHS is a constant before attempting to constant
propagate.

The problem became apparent while trying to enable abort-after-failing-C
assert, but only on Visual Studio builds (owing to the code that the
assert macro expands to in Visual Studio).

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
