### PR TITLE
Post-dominators: support multiple exit points

### DIFF
--- a/regression/goto-instrument/slice25/main.c
+++ b/regression/goto-instrument/slice25/main.c
@@ -1,0 +1,13 @@
+int main()
+{
+#ifdef __GNUC__
+  int x = 1;
+  if(x == 0)
+  {
+    __CPROVER_assert(0, "");
+    // __builtin_types_compatible_p yields a proper "bool" typed constant
+    __CPROVER_assume(__builtin_types_compatible_p(double, float));
+  }
+#endif
+  return 0;
+}

--- a/regression/goto-instrument/slice25/test.desc
+++ b/regression/goto-instrument/slice25/test.desc
@@ -1,0 +1,6 @@
+CORE
+main.c
+--full-slice
+^VERIFICATION SUCCESSFUL$
+^EXIT=0$
+^SIGNAL=0$

--- a/src/analyses/cfg_dominators.h
+++ b/src/analyses/cfg_dominators.h
@@ -163,6 +163,27 @@ void cfg_dominators_templatet<P, T, post_dom>::fixedpoint(P &program)
       ++s_it)
     worklist.push_back(cfg[s_it->first].PC);
 
+  // A program may have multiple "exit" nodes when self loops or assume(false)
+  // instructions are present.
+  if(post_dom)
+  {
+    for(auto &cfg_entry : cfg.entry_map)
+    {
+      if(cfg[cfg_entry.second].PC == entry_node)
+        continue;
+
+      typename cfgt::nodet &n_it = cfg[cfg_entry.second];
+      if(
+        n_it.out.empty() ||
+        (n_it.out.size() == 1 && n_it.out.begin()->first == cfg_entry.second))
+      {
+        n_it.dominators.insert(cfg[cfg_entry.second].PC);
+        for(const auto &predecessor : n_it.in)
+          worklist.push_back(cfg[predecessor.first].PC);
+      }
+    }
+  }
+
   while(!worklist.empty())
   {
     // get node from worklist


### PR DESCRIPTION
Programs with assume(false) or (unconditional) self loops include
instructions from which the regular program exit cannot be reached.
Nevertheless, such instructions still need to be included in
post-dominator computation.

Not doing so would result in missing control dependencies when building
the dependence graph, and thus in wrong slicing results (which the
included regression test previously showed).

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
