### PR TITLE
[smt2_convt] Use `=>` in place of `implies`

### DIFF
--- a/src/solvers/smt2/smt2_conv.cpp
+++ b/src/solvers/smt2/smt2_conv.cpp
@@ -237,8 +237,8 @@ void smt2_convt::define_object_size(
       continue;
     }
 
-    out << "(assert (implies (= " <<
-      "((_ extract " << h << " " << l << ") ";
+    out << "(assert (=> (= "
+        << "((_ extract " << h << " " << l << ") ";
     convert_expr(ptr);
     out << ") (_ bv" << number << " " << config.bv_encoding.object_bits << "))"
         << "(= " << id << " (_ bv" << *object_size << " " << size_width


### PR DESCRIPTION
Both CVC4 and Z3 reject the `implies` keyword:
- CVC4 rejects it even with `ALL` logic
- Z3 rejects it when `QF_AUFBV` is supplied

The `smt2_conv.cpp` file already uses `=>` in most place, except for one. This PR fixes this occurrence.

- [x] Each commit message has a non-empty body, explaining why the change was made.
- NA ~~Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.~~
- NA ~~The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/~~
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- NA ~~My commit message includes data points confirming performance improvements (if claimed).~~
- [x] My PR is restricted to a single feature or bugfix.
- NA ~~White-space or formatting changes outside the feature-related changed lines are in commits of their own.~~