### PR TITLE
[smt_convt] Fix usage of `use_array_of_bool`

### DIFF
--- a/regression/cbmc/array_of_bool_as_bitvec/main.c
+++ b/regression/cbmc/array_of_bool_as_bitvec/main.c
@@ -1,0 +1,19 @@
+#include <assert.h>
+#include <stdbool.h>
+#include <stdlib.h>
+
+__CPROVER_bool w[8];
+
+void main()
+{
+  _Bool x[8] = {false};
+  __CPROVER_bool y[8] = {false};
+  bool *z = calloc(8, sizeof(bool));
+
+  unsigned idx;
+  __CPROVER_assume(0 <= idx && idx < 8);
+
+  assert(w[idx] == x[idx]);
+  assert(x[idx] == y[idx]);
+  assert(y[idx] == z[idx]);
+}

--- a/regression/cbmc/array_of_bool_as_bitvec/test-smt2-outfile.desc
+++ b/regression/cbmc/array_of_bool_as_bitvec/test-smt2-outfile.desc
@@ -1,0 +1,31 @@
+CORE broken-smt-backend
+main.c
+--smt2 --outfile -
+\(= \(select array_of\.2 i\) \(ite false #b1 #b0\)\)
+\(= \(select array\.3 \(\(_ zero_extend 32\) \|main::1::idx!0@1#1\|\)\) #b1\)
+\(= \(select array\.3 \(_ bv\d+ 64\)\) \(ite false #b1 #b0\)\)
+^EXIT=0$
+^SIGNAL=0$
+--
+\(= \(select array_of\.2 i\) false\)
+\(= \(select array\.3 \(\(_ zero_extend 32\) \|main::1::idx!0@1#1\|\)\) #b1 #b0\)
+\(= \(select array\.3 \(_ bv\d+ 64\)\) false\)
+--
+This test checks for correctness of BitVec-array encoding of Boolean arrays.
+
+Ideally, we shouldn't have to check the SMT output, but should run with backend
+SMT solvers. However, we currently cannot because of #5977 (also see #6005).
+
+For now, we tag this test as `broken-smt-backend` to avoid running main.c
+with `--z3` or `--cprover-smt2`, both of which encode Boolean arrays directly.
+Instead, we generate a generic SMT encoding with `--smt2` and check the output.
+
+Explanation of regexes:
+line 4,10: array.2 elements should be BitVec not Bool
+line 5,11: equality operator (=) should have 2 arguments not 3
+line 6,12: array.3 elements should be BitVec not Bool
+
+Once #5977 and #6005 are resolved, we should:
+- remove `broken-smt-backend` tag
+- run with `--smt2 --cprover-smt2` and `--smt2 --z3`
+- check for successful verification

--- a/regression/validate-trace-xml-schema/check.py
+++ b/regression/validate-trace-xml-schema/check.py
@@ -12,6 +12,8 @@ test_base_dir = os.path.abspath(os.path.join(this_script_dir, '..', 'cbmc'))
 
 # some tests in the cbmc suite don't work for the trace checks for one reason or another
 ExcludedTests = list(map(lambda s: os.path.join(test_base_dir, s[0], s[1]), [
+    # these tests dump the raw SMT2 output (using --outfile)
+    ['array_of_bool_as_bitvec', 'test-smt2-outfile.desc'],
     # these tests expect input from stdin
     ['json-interface1', 'test_wrong_option.desc'],
     ['json-interface1', 'test.desc'],


### PR DESCRIPTION
Several SMT translation routines were not respecting `use_array_of_bool`, or led to a buggy SMT translation when they used it.

This change ensures consistent usage of this option across all array-related translation routines.

- [x] Each commit message has a non-empty body, explaining why the change was made.
- NA ~~Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.~~
- NA ~~The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/~~
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- NA ~~My commit message includes data points confirming performance improvements (if claimed).~~
- [x] My PR is restricted to a single feature or bugfix.
- NA ~~White-space or formatting changes outside the feature-related changed lines are in commits of their own.~~