### PR TITLE
Add TODO in invariant_set seeking to understand magic number

### DIFF
--- a/src/analyses/invariant_set.cpp
+++ b/src/analyses/invariant_set.cpp
@@ -364,6 +364,8 @@ void invariant_sett::add_type_bounds(const exprt &expr, const typet &type)
   {
     std::size_t op_width=to_unsignedbv_type(type).get_width();
 
+    // TODO - 8 appears to be a magic number here -- or perhaps this should say
+    // ">=" instead, and is meant to restrict types larger than a single byte?
     if(op_width<=8)
     {
       unsigned a;


### PR DESCRIPTION
When trying to eliminate hard-coded uses of "8" in the code base I came
across this piece of code, which I don't actually understand the purpose
of. Should someone decipher invariant_set.cpp at some later date:
perhaps they can clean this up.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- n/a Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
