### PR TITLE
ansi_c_entry_point: avoid magic number

### DIFF
--- a/regression/cbmc/argv2/main.i
+++ b/regression/cbmc/argv2/main.i
@@ -1,0 +1,6 @@
+int main(int argc, char *argv[])
+{
+  __CPROVER_assert(
+    sizeof(char *) > sizeof(int) || argc < 0x7FFFFFFF,
+    "argc cannot reach INT_MAX on 32-bit systems");
+}

--- a/regression/cbmc/argv2/test.desc
+++ b/regression/cbmc/argv2/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.i
+--32
+^VERIFICATION SUCCESSFUL$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring

--- a/regression/cbmc/multiple-goto-traces/test.desc
+++ b/regression/cbmc/multiple-goto-traces/test.desc
@@ -5,7 +5,7 @@ activate-multi-line-match
 ^EXIT=10$
 ^SIGNAL=0$
 VERIFICATION FAILED
-Trace for main\.assertion\.1:(\n.*){22}  assertion 4 \!= argc(\n.*){5}Trace for main\.assertion\.3:(\n.*){36}  assertion argc != 4(\n.*){5}Trace for main\.assertion\.4:(\n.*){50}  assertion argc \+ 1 != 5
+Trace for main\.assertion\.1:((\n.*){19}|(\n.*){22})  assertion 4 \!= argc(\n.*){5}Trace for main\.assertion\.3:((\n.*){33}|(\n.*){36})  assertion argc != 4(\n.*){5}Trace for main\.assertion\.4:((\n.*){47}|(\n.*){50})  assertion argc \+ 1 != 5
 \*\* 3 of 4 failed
 --
 ^warning: ignoring

--- a/src/ansi-c/ansi_c_entry_point.cpp
+++ b/src/ansi-c/ansi_c_entry_point.cpp
@@ -313,12 +313,10 @@ bool generate_ansi_c_start_function(
         init_code.add(code_assumet(std::move(ge)));
       }
 
+      if(config.ansi_c.max_argc.has_value())
       {
-        // assume argc is at most MAX/8-1
-        mp_integer upper_bound=
-          power(2, config.ansi_c.int_width-4);
-
-        exprt bound_expr=from_integer(upper_bound, argc_symbol.type);
+        exprt bound_expr =
+          from_integer(*config.ansi_c.max_argc, argc_symbol.type);
 
         binary_relation_exprt le(
           argc_symbol.symbol_expr(), ID_le, std::move(bound_expr));

--- a/src/util/config.h
+++ b/src/util/config.h
@@ -258,6 +258,11 @@ public:
     malloc_failure_modet malloc_failure_mode = malloc_failure_mode_none;
 
     static const std::size_t default_object_bits = 8;
+
+    /// Maximum value of argc, which is operating-systems dependent: Windows
+    /// limits the number of characters accepte by CreateProcess, and Unix
+    /// systems have sysconf(ARG_MAX).
+    optionalt<mp_integer> max_argc;
   } ansi_c;
 
   struct cppt


### PR DESCRIPTION
The code previously hard-coded an upper bound for argc that perhaps was
suitable for 32-bit systems (albeit even questionable for that case).
Replace this calculation by one that refers to configured bit widths.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
