### PR TITLE
Remove ID_width expression support from solvers

### DIFF
--- a/src/solvers/flattening/boolbv.cpp
+++ b/src/solvers/flattening/boolbv.cpp
@@ -109,25 +109,6 @@ bvt boolbvt::convert_bitvector(const exprt &expr)
     return convert_with(to_with_expr(expr));
   else if(expr.id()==ID_update)
     return convert_update(to_update_expr(expr));
-  else if(expr.id()==ID_width)
-  {
-    std::size_t result_width=boolbv_width(expr.type());
-
-    if(result_width==0)
-      return conversion_failed(expr);
-
-    if(expr.operands().size()!=1)
-      return conversion_failed(expr);
-
-    std::size_t op_width = boolbv_width(to_unary_expr(expr).op().type());
-
-    if(op_width==0)
-      return conversion_failed(expr);
-
-    if(expr.type().id()==ID_unsignedbv ||
-       expr.type().id()==ID_signedbv)
-      return bv_utils.build_constant(op_width/8, result_width);
-  }
   else if(expr.id()==ID_case)
     return convert_case(expr);
   else if(expr.id()==ID_cond)

--- a/src/solvers/smt2/smt2_conv.cpp
+++ b/src/solvers/smt2/smt2_conv.cpp
@@ -1613,17 +1613,6 @@ void smt2_convt::convert_expr(const exprt &expr)
     INVARIANT(
       false, "byte_update ops should be lowered in prepare_for_convert_expr");
   }
-  else if(expr.id()==ID_width)
-  {
-    std::size_t result_width=boolbv_width(expr.type());
-    CHECK_RETURN(result_width != 0);
-
-    std::size_t op_width = boolbv_width(to_unary_expr(expr).op().type());
-    CHECK_RETURN(op_width != 0);
-
-    out << "(_ bv" << op_width/8
-        << " " << result_width << ")";
-  }
   else if(expr.id()==ID_abs)
   {
     const abs_exprt &abs_expr = to_abs_expr(expr);


### PR DESCRIPTION
We do not seem to generate such an expression in the code base, and the
current implementation is rather dubious for it returns the multiple of
8 bits in the propositional encoding.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
