### PR TITLE
Configure bits_per_byte in byte_extract/byte_update expression

### DIFF
--- a/jbmc/unit/java_bytecode/java_trace_validation/java_trace_validation.cpp
+++ b/jbmc/unit/java_bytecode/java_trace_validation/java_trace_validation.cpp
@@ -6,17 +6,18 @@ Author: Diffblue Ltd.
 
 \*******************************************************************/
 
+#include <util/byte_operators.h>
+#include <util/pointer_expr.h>
+#include <util/symbol_table.h>
+
 #include <goto-programs/goto_trace.h>
 
 #include <java_bytecode/java_trace_validation.h>
 #include <java_bytecode/java_types.h>
-
 #include <testing-utils/message.h>
 #include <testing-utils/use_catch.h>
 
-#include <util/byte_operators.h>
-#include <util/pointer_expr.h>
-#include <util/symbol_table.h>
+#include <climits>
 
 TEST_CASE("java trace validation", "[core][java_trace_validation]")
 {
@@ -36,9 +37,9 @@ TEST_CASE("java trace validation", "[core][java_trace_validation]")
   const index_exprt index_plain =
     index_exprt(exprt(ID_nil, array_typet(typet(), nil_exprt())), exprt());
   const byte_extract_exprt byte_little_endian = byte_extract_exprt(
-    ID_byte_extract_little_endian, exprt(), exprt(), typet());
-  const byte_extract_exprt byte_big_endian =
-    byte_extract_exprt(ID_byte_extract_big_endian, exprt(), exprt(), typet());
+    ID_byte_extract_little_endian, exprt(), exprt(), CHAR_BIT, typet());
+  const byte_extract_exprt byte_big_endian = byte_extract_exprt(
+    ID_byte_extract_big_endian, exprt(), exprt(), CHAR_BIT, typet());
   const address_of_exprt valid_address = address_of_exprt(valid_symbol_expr);
   const address_of_exprt invalid_address = address_of_exprt(exprt());
   const struct_exprt struct_plain =

--- a/src/analyses/goto_rw.cpp
+++ b/src/analyses/goto_rw.cpp
@@ -161,7 +161,7 @@ void rw_range_sett::get_objects_byte_extract(
   }
   else
   {
-    *index *= 8;
+    *index *= be.get_bits_per_byte();
     if(*index >= *object_size_bits_opt)
       return;
 

--- a/src/goto-symex/symex_assign.cpp
+++ b/src/goto-symex/symex_assign.cpp
@@ -383,7 +383,8 @@ void symex_assignt::assign_byte_extract(
   else
     UNREACHABLE;
 
-  const byte_update_exprt new_rhs{byte_update_id, lhs.op(), lhs.offset(), rhs};
+  const byte_update_exprt new_rhs{
+    byte_update_id, lhs.op(), lhs.offset(), rhs, lhs.get_bits_per_byte()};
   const expr_skeletont new_skeleton =
     full_lhs.compose(expr_skeletont::remove_op0(lhs));
   assign_rec(lhs.op(), new_skeleton, new_rhs, guard);

--- a/src/solvers/flattening/boolbv_byte_update.cpp
+++ b/src/solvers/flattening/boolbv_byte_update.cpp
@@ -38,7 +38,7 @@ bvt boolbvt::convert_byte_update(const byte_update_exprt &expr)
 
   const bvt &value_bv=convert_bv(value);
   std::size_t update_width=value_bv.size();
-  std::size_t byte_width=8;
+  std::size_t byte_width = expr.get_bits_per_byte();
 
   if(update_width>bv.size())
     update_width=bv.size();
@@ -49,7 +49,7 @@ bvt boolbvt::convert_byte_update(const byte_update_exprt &expr)
   if(index.has_value())
   {
     // yes!
-    const mp_integer offset = *index * 8;
+    const mp_integer offset = *index * byte_width;
 
     if(offset+update_width>mp_integer(bv.size()) || offset<0)
     {

--- a/src/util/byte_operators.cpp
+++ b/src/util/byte_operators.cpp
@@ -47,11 +47,13 @@ static irep_idt byte_update_id()
 byte_extract_exprt
 make_byte_extract(const exprt &_op, const exprt &_offset, const typet &_type)
 {
-  return byte_extract_exprt{byte_extract_id(), _op, _offset, _type};
+  return byte_extract_exprt{
+    byte_extract_id(), _op, _offset, config.ansi_c.char_width, _type};
 }
 
 byte_update_exprt
 make_byte_update(const exprt &_op, const exprt &_offset, const exprt &_value)
 {
-  return byte_update_exprt{byte_update_id(), _op, _offset, _value};
+  return byte_update_exprt{
+    byte_update_id(), _op, _offset, _value, config.ansi_c.char_width};
 }

--- a/src/util/byte_operators.h
+++ b/src/util/byte_operators.h
@@ -32,12 +32,15 @@ public:
     irep_idt _id,
     const exprt &_op,
     const exprt &_offset,
+    std::size_t bits_per_byte,
     const typet &_type)
     : binary_exprt(_op, _id, _offset, _type)
   {
     INVARIANT(
       _id == ID_byte_extract_little_endian || _id == ID_byte_extract_big_endian,
       "byte_extract_exprt: Invalid ID");
+
+    set_bits_per_byte(bits_per_byte);
   }
 
   exprt &op() { return op0(); }
@@ -45,6 +48,16 @@ public:
 
   const exprt &op() const { return op0(); }
   const exprt &offset() const { return op1(); }
+
+  std::size_t get_bits_per_byte() const
+  {
+    return get_size_t(ID_bits_per_byte);
+  }
+
+  void set_bits_per_byte(std::size_t bits_per_byte)
+  {
+    set_size_t(ID_bits_per_byte, bits_per_byte);
+  }
 };
 
 template <>
@@ -81,12 +94,15 @@ public:
     irep_idt _id,
     const exprt &_op,
     const exprt &_offset,
-    const exprt &_value)
+    const exprt &_value,
+    std::size_t bits_per_byte)
     : ternary_exprt(_id, _op, _offset, _value, _op.type())
   {
     INVARIANT(
       _id == ID_byte_update_little_endian || _id == ID_byte_update_big_endian,
       "byte_update_exprt: Invalid ID");
+
+    set_bits_per_byte(bits_per_byte);
   }
 
   void set_op(exprt e)
@@ -105,6 +121,16 @@ public:
   const exprt &op() const { return op0(); }
   const exprt &offset() const { return op1(); }
   const exprt &value() const { return op2(); }
+
+  std::size_t get_bits_per_byte() const
+  {
+    return get_size_t(ID_bits_per_byte);
+  }
+
+  void set_bits_per_byte(std::size_t bits_per_byte)
+  {
+    set_size_t(ID_bits_per_byte, bits_per_byte);
+  }
 };
 
 template <>

--- a/src/util/simplify_expr_struct.cpp
+++ b/src/util/simplify_expr_struct.cpp
@@ -152,7 +152,11 @@ simplify_exprt::simplify_member(const member_exprt &expr)
         simplify_plus(plus_exprt(struct_offset, member_offset));
 
       byte_extract_exprt result(
-        op.id(), byte_extract_expr.op(), final_offset, expr.type());
+        op.id(),
+        byte_extract_expr.op(),
+        final_offset,
+        byte_extract_expr.get_bits_per_byte(),
+        expr.type());
 
       return changed(simplify_byte_extract(result)); // recursive call
     }

--- a/unit/solvers/lowering/byte_operators.cpp
+++ b/unit/solvers/lowering/byte_operators.cpp
@@ -55,11 +55,13 @@ TEST_CASE("byte extract and bits", "[core][solvers][lowering][byte_extract]")
     REQUIRE(bit_string2.has_value());
     REQUIRE(*bit_string == *bit_string2);
 
-    const byte_extract_exprt be1{little_endian ? ID_byte_extract_little_endian
-                                               : ID_byte_extract_big_endian,
-                                 sixteen_bits,
-                                 from_integer(0, c_index_type()),
-                                 bit_array_type};
+    const byte_extract_exprt be1{
+      little_endian ? ID_byte_extract_little_endian
+                    : ID_byte_extract_big_endian,
+      sixteen_bits,
+      from_integer(0, c_index_type()),
+      config.ansi_c.char_width,
+      bit_array_type};
     const exprt lower_be1 = lower_byte_extract(be1, ns);
     REQUIRE(lower_be1 == *array_of_bits);
   }
@@ -80,11 +82,13 @@ TEST_CASE("byte extract and bits", "[core][solvers][lowering][byte_extract]")
     REQUIRE(bit_string2.has_value());
     REQUIRE(*bit_string == *bit_string2);
 
-    const byte_extract_exprt be1{little_endian ? ID_byte_extract_little_endian
-                                               : ID_byte_extract_big_endian,
-                                 sixteen_bits,
-                                 from_integer(0, c_index_type()),
-                                 bit_array_type};
+    const byte_extract_exprt be1{
+      little_endian ? ID_byte_extract_little_endian
+                    : ID_byte_extract_big_endian,
+      sixteen_bits,
+      from_integer(0, c_index_type()),
+      config.ansi_c.char_width,
+      bit_array_type};
     const exprt lower_be1 = lower_byte_extract(be1, ns);
     REQUIRE(lower_be1 == *array_of_bits);
   }
@@ -107,7 +111,8 @@ SCENARIO("byte_extract_lowering", "[core][solvers][lowering][byte_extract]")
       ID_byte_extract_little_endian,
       deadbeef,
       from_integer(1, c_index_type()),
-      signedbv_typet(8));
+      config.ansi_c.char_width,
+      signedbv_typet(config.ansi_c.char_width));
 
     THEN("byte_extract lowering yields the expected value")
     {
@@ -136,6 +141,7 @@ SCENARIO("byte_extract_lowering", "[core][solvers][lowering][byte_extract]")
       ID_byte_extract_little_endian,
       deadbeef,
       from_integer(1, c_index_type()),
+      config.ansi_c.char_width,
       struct_typet(
         {{"unbounded_array",
           array_typet(
@@ -164,6 +170,7 @@ SCENARIO("byte_extract_lowering", "[core][solvers][lowering][byte_extract]")
       ID_byte_extract_little_endian,
       deadbeef,
       from_integer(1, c_index_type()),
+      config.ansi_c.char_width,
       union_typet(
         {{"unbounded_array",
           array_typet(
@@ -192,6 +199,7 @@ SCENARIO("byte_extract_lowering", "[core][solvers][lowering][byte_extract]")
       ID_byte_extract_little_endian,
       deadbeef,
       from_integer(1, c_index_type()),
+      config.ansi_c.char_width,
       union_typet{});
 
     THEN("byte_extract lowering does not raise an exception")
@@ -217,6 +225,7 @@ SCENARIO("byte_extract_lowering", "[core][solvers][lowering][byte_extract]")
       ID_byte_extract_little_endian,
       s,
       from_integer(1, c_index_type()),
+      config.ansi_c.char_width,
       unsignedbv_typet(16));
 
     THEN("byte_extract lowering yields the expected value")
@@ -332,7 +341,11 @@ SCENARIO("byte_extract_lowering", "[core][solvers][lowering][byte_extract]")
             REQUIRE(r.has_value());
 
             const byte_extract_exprt be(
-              endianness, *s, from_integer(2, c_index_type()), t2);
+              endianness,
+              *s,
+              from_integer(2, c_index_type()),
+              config.ansi_c.char_width,
+              t2);
 
             const exprt lower_be = lower_byte_extract(be, ns);
             const exprt lower_be_s = simplify_expr(lower_be, ns);
@@ -366,7 +379,8 @@ SCENARIO("byte_update_lowering", "[core][solvers][lowering][byte_update]")
       ID_byte_update_little_endian,
       deadbeef,
       from_integer(1, c_index_type()),
-      from_integer(0x42, unsignedbv_typet(8)));
+      from_integer(0x42, unsignedbv_typet(8)),
+      config.ansi_c.char_width);
 
     THEN("byte_update lowering yields the expected value")
     {
@@ -486,7 +500,11 @@ SCENARIO("byte_update_lowering", "[core][solvers][lowering][byte_update]")
             REQUIRE(r.has_value());
 
             const byte_update_exprt bu(
-              endianness, *s, from_integer(2, c_index_type()), *u);
+              endianness,
+              *s,
+              from_integer(2, c_index_type()),
+              *u,
+              config.ansi_c.char_width);
 
             const exprt lower_bu = lower_byte_operators(bu, ns);
             const exprt lower_bu_s = simplify_expr(lower_bu, ns);

--- a/unit/util/expr_cast/expr_cast.cpp
+++ b/unit/util/expr_cast/expr_cast.cpp
@@ -147,6 +147,7 @@ SCENARIO("expr_dynamic_cast",
       ID_byte_extract_little_endian,
       symbol_exprt(typet()),
       constant_exprt("0", typet()),
+      1, // arbitrary integer
       typet());
     THEN("try_expr_dynamic_cast<byte_extract_expr> returns non-empty")
     {
@@ -159,6 +160,7 @@ SCENARIO("expr_dynamic_cast",
       ID_byte_extract_big_endian,
       symbol_exprt(typet()),
       constant_exprt("0", typet()),
+      1, // arbitrary integer
       typet());
     THEN("try_expr_dynamic_cast<byte_extract_expr> returns non-empty")
     {
@@ -183,6 +185,7 @@ SCENARIO("can_cast_expr", "[core][utils][expr_cast][can_cast_expr]")
       ID_byte_extract_little_endian,
       symbol_exprt(typet()),
       constant_exprt("0", typet()),
+      1, // arbitrary integer
       typet());
     THEN("can_expr_expr<byte_extract_expr> returns true")
     {
@@ -195,6 +198,7 @@ SCENARIO("can_cast_expr", "[core][utils][expr_cast][can_cast_expr]")
       ID_byte_extract_big_endian,
       symbol_exprt(typet()),
       constant_exprt("0", typet()),
+      1, // arbitrary integer
       typet());
     THEN("can_expr_expr<byte_extract_expr> returns true")
     {


### PR DESCRIPTION
Semantically evaluating a byte_extract/byte_update expression requires
knowledge of the number of bits that a byte is composed of. This,
however, is a configuration parameter known to the front-end that
created the expression in the first place. The back-end should not need
to consult configuration information to evaluate the expression.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
