### PR TITLE
Allow quantifiers within loop invariants

### DIFF
--- a/regression/contracts/quantifiers-loop-01/main.c
+++ b/regression/contracts/quantifiers-loop-01/main.c
@@ -1,0 +1,29 @@
+#include <assert.h>
+
+#define N 16
+
+void main()
+{
+  int a[N];
+  a[10] = 0;
+
+  for(int i = 0; i < N; ++i)
+    // clang-format off
+    __CPROVER_loop_invariant(
+      (0 <= i) && (i <= N) &&
+      __CPROVER_forall {
+        int k;
+        // constant bounds for explicit unrolling with SAT backend
+        (0 <= k && k <= N) ==> (
+          // the actual symbolic bound for `k`
+          k < i ==> a[k] == 1
+        )
+      }
+    )
+    // clang-format on
+    {
+      a[i] = 1;
+    }
+
+  assert(a[10] == 1);
+}

--- a/regression/contracts/quantifiers-loop-01/test.desc
+++ b/regression/contracts/quantifiers-loop-01/test.desc
@@ -1,0 +1,15 @@
+CORE
+main.c
+--enforce-all-contracts
+^EXIT=0$
+^SIGNAL=0$
+^\[main.1\] line .* Check loop invariant before entry: SUCCESS
+^\[main.2\] line .* Check that loop invariant is preserved: SUCCESS
+^\[main.assertion.1\] line .* assertion a\[10\] == 1: SUCCESS
+^VERIFICATION SUCCESSFUL$
+--
+--
+This test case checks the handling of a `forall` quantifier within a loop invariant.
+
+This test case uses explicit constant bounds on the quantified variable,
+so that it can be unrolled (to conjunctions) with the SAT backend.

--- a/regression/contracts/quantifiers-loop-02/main.c
+++ b/regression/contracts/quantifiers-loop-02/main.c
@@ -1,0 +1,32 @@
+#include <assert.h>
+
+void main()
+{
+  int N, a[64];
+  __CPROVER_assume(0 <= N && N < 64);
+
+  for(int i = 0; i < N; ++i)
+    // clang-format off
+    __CPROVER_loop_invariant(
+      (0 <= i) && (i <= N) &&
+      __CPROVER_forall {
+        int k;
+        (0 <= k && k < i) ==> a[k] == 1
+      }
+    )
+    // clang-format on
+    {
+      a[i] = 1;
+    }
+
+  // clang-format off
+  assert(__CPROVER_forall {
+    int k;
+    (0 <= k && k < N) ==> a[k] == 1
+  });
+  // clang-format on
+
+  int k;
+  __CPROVER_assume(0 <= k && k < N);
+  assert(a[k] == 1);
+}

--- a/regression/contracts/quantifiers-loop-02/test.desc
+++ b/regression/contracts/quantifiers-loop-02/test.desc
@@ -1,0 +1,21 @@
+KNOWNBUG smt-backend broken-cprover-smt-backend
+main.c
+--enforce-all-contracts
+^EXIT=0$
+^SIGNAL=0$
+^\[main.1\] line .* Check loop invariant before entry: SUCCESS
+^\[main.2\] line .* Check that loop invariant is preserved: SUCCESS
+^\[main.assertion.1\] line .* assertion .*: SUCCESS
+^VERIFICATION SUCCESSFUL$
+--
+--
+This test case checks the handling of a universal quantifier, with a symbolic
+upper bound, within a loop invariant.
+
+The test is tagged:
+- `smt-backend`:
+  because the SAT backend does not support (simply ignores) `forall` in negative (e.g. assume) contexts.
+- `broken-cprover-smt-backend`:
+  because the CPROVER SMT2 solver cannot handle (errors out on) `forall` in negative (e.g. assume) contexts.
+
+It has been tagged `KNOWNBUG` for now since `contracts` regression tests are not run with SMT backend yet.

--- a/regression/contracts/quantifiers-loop-03/main.c
+++ b/regression/contracts/quantifiers-loop-03/main.c
@@ -1,0 +1,42 @@
+#include <assert.h>
+#include <stdlib.h>
+
+#define MAX_SIZE 64
+
+void main()
+{
+  unsigned N;
+  __CPROVER_assume(N <= MAX_SIZE);
+
+  int *a = malloc(N * sizeof(int));
+
+  for(int i = 0; i < N; ++i)
+    // clang-format off
+    __CPROVER_loop_invariant(
+      (0 <= i) && (i <= N) &&
+      (i != 0 ==> __CPROVER_exists {
+        int k;
+        // constant bounds for explicit unrolling with SAT backend
+        (0 <= k && k <= MAX_SIZE) && (
+          // the actual symbolic bound for `k`
+          k < i && a[k] == 1
+        )
+      })
+    )
+    // clang-format on
+    {
+      a[i] = 1;
+    }
+
+  // clang-format off
+  assert(
+    N != 0 ==> __CPROVER_exists {
+    int k;
+    // constant bounds for explicit unrolling with SAT backend
+    (0 <= k && k <= MAX_SIZE) && (
+      // the actual symbolic bound for `k`
+      k < N && a[k] == 1
+    )
+  });
+  // clang-format on
+}

--- a/regression/contracts/quantifiers-loop-03/test.desc
+++ b/regression/contracts/quantifiers-loop-03/test.desc
@@ -1,0 +1,16 @@
+CORE
+main.c
+--enforce-all-contracts
+^EXIT=0$
+^SIGNAL=0$
+^\[main.1\] line .* Check loop invariant before entry: SUCCESS
+^\[main.2\] line .* Check that loop invariant is preserved: SUCCESS
+^\[main.assertion.1\] line .* assertion .*: SUCCESS
+^VERIFICATION SUCCESSFUL$
+--
+--
+This test case checks the handling of an existential quantifier, with a symbolic
+upper bound, within a loop invariant.
+
+This test case uses explicit constant bounds on the quantified variable,
+so that it can be unrolled (to conjunctions) with the SAT backend.

--- a/src/goto-instrument/code_contracts.h
+++ b/src/goto-instrument/code_contracts.h
@@ -185,9 +185,9 @@ protected:
   /// the quantified variable is added to the symbol table
   /// and to the expression map.
   void add_quantified_variable(
-    exprt expression,
+    const exprt &expression,
     replace_symbolt &replace,
-    irep_idt mode);
+    const irep_idt &mode);
 
   /// This function recursively identifies the "old" expressions within expr
   /// and replaces them with correspoding history variables.

--- a/src/util/c_types.h
+++ b/src/util/c_types.h
@@ -352,7 +352,10 @@ public:
 
   exprt &assigns()
   {
-    return static_cast<exprt &>(add(ID_C_spec_assigns));
+    auto &result = static_cast<exprt &>(add(ID_C_spec_assigns));
+    if(result.id().empty()) // not initialized?
+      result.make_nil();
+    return result;
   }
 
   const exprt &requires() const
@@ -362,7 +365,10 @@ public:
 
   exprt &requires()
   {
-    return static_cast<exprt &>(add(ID_C_spec_requires));
+    auto &result = static_cast<exprt &>(add(ID_C_spec_requires));
+    if(result.id().empty()) // not initialized?
+      result.make_nil();
+    return result;
   }
 
   const exprt &ensures() const
@@ -372,7 +378,10 @@ public:
 
   exprt &ensures()
   {
-    return static_cast<exprt &>(add(ID_C_spec_ensures));
+    auto &result = static_cast<exprt &>(add(ID_C_spec_ensures));
+    if(result.id().empty()) // not initialized?
+      result.make_nil();
+    return result;
   }
 };
 


### PR DESCRIPTION
This PR adds support for quantified expressions in loop contracts. ~~This PR depends on #5942.~~

We have included 3 regression tests in this PR. However, two of them are marked as `KNOWNBUG` due to a current limitation of quantifiers that does not allow symbolic ranges for the quantified variable when using the SAT back-end.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [x] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [x] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
