### PR TITLE
Updates parser for assigns clause to match code_contract.* support

### DIFF
--- a/regression/contracts/assigns_replace_07/main.c
+++ b/regression/contracts/assigns_replace_07/main.c
@@ -1,6 +1,6 @@
 #include <assert.h>
 
-void bar(char d[]) __CPROVER_assigns(d[7])
+void bar(char d[]) __CPROVER_assigns(*d)
 {
 }
 
@@ -18,7 +18,7 @@ int main()
   b[8] = 'i';
   b[9] = 'j';
   bar(b);
-  assert(b[7] == 'h');
+  assert(b[0] == 'a');
 
   return 0;
 }

--- a/regression/contracts/assigns_replace_07/test.desc
+++ b/regression/contracts/assigns_replace_07/test.desc
@@ -6,5 +6,5 @@ main.c
 ^VERIFICATION FAILED$
 --
 --
-Checks whether the value inside a single-index array assigns target is
+Checks whether the value inside an array assigns target is
 havocked when calling the associated function.

--- a/src/ansi-c/parser.y
+++ b/src/ansi-c/parser.y
@@ -3243,13 +3243,66 @@ cprover_contract:
           set($$, ID_C_spec_requires);
           mto($$, $3);
         }
-        | TOK_CPROVER_ASSIGNS '(' argument_expression_list ')'
+        | TOK_CPROVER_ASSIGNS '(' target_list ')'
         {
           $$=$1;
           set($$, ID_C_spec_assigns);
           parser_stack($3).id(ID_target_list);
           mto($$, $3);
         }
+        ;
+
+target_list:
+          target
+        {
+          init($$, ID_target_list);
+          mto($$, $1);
+        }
+        | target_list ',' target
+        {
+          $$=$1;
+          mto($$, $3);
+        }
+        ;
+
+target:
+          deref_target
+        | member_target
+        | primary_target
+        ;
+
+deref_target:
+          '*' target
+        {
+          $$=$1;
+          set($$, ID_dereference);
+          mto($$, $2);
+        }
+        ;
+
+member_target:
+          primary_target '.' member_name
+        | member_target '.' member_name
+        {
+          $$=$2;
+          set($$, ID_member);
+          mto($$, $1);
+          parser_stack($$).set(ID_component_name, parser_stack($3).get(ID_C_base_name));
+        }
+        | primary_target TOK_ARROW member_name
+        | member_target TOK_ARROW member_name
+        {
+          $$=$2;
+          set($$, ID_ptrmember);
+          mto($$, $1);
+          parser_stack($$).set(ID_component_name, parser_stack($3).get(ID_C_base_name));
+        }
+        ;
+
+primary_target:
+          identifier
+        | '(' target ')'
+        { $$ = $2; }
         ;
 
 cprover_contract_sequence:


### PR DESCRIPTION
Currently, the parser treats the content in an assigns clause as an
`argument_expression_list`, which doesn't correspond to the
implementation inside the `code_contracts.*`.
This could lead to errors when parsing these expressions.

Signed-off-by: Felipe R. Monteiro <felisous@amazon.com>

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
