### PR TITLE
Fix havocing of arrays when enforcing invariants

### DIFF
--- a/regression/contracts/invar_havoc_dynamic_array/main.c
+++ b/regression/contracts/invar_havoc_dynamic_array/main.c
@@ -1,0 +1,19 @@
+#include <assert.h>
+#include <stdlib.h>
+
+#define SIZE 8
+
+void main()
+{
+  char *data = malloc(SIZE * sizeof(char));
+  data[5] = 0;
+
+  for(unsigned i = 0; i < SIZE; i++)
+    __CPROVER_loop_invariant(i <= SIZE)
+    {
+      data[i] = 1;
+    }
+
+  assert(data[5] == 0);
+  assert(data[5] == 1);
+}

--- a/regression/contracts/invar_havoc_dynamic_array/test.desc
+++ b/regression/contracts/invar_havoc_dynamic_array/test.desc
@@ -1,0 +1,17 @@
+CORE
+main.c
+--enforce-all-contracts
+^EXIT=10$
+^SIGNAL=0$
+^\[main.1\] .* Check loop invariant before entry: SUCCESS$
+^\[main.2\] .* Check that loop invariant is preserved: SUCCESS$
+^\[main.assertion.1\] .* assertion data\[5\] == 0: FAILURE$
+^\[main.assertion.2\] .* assertion data\[5\] == 1: FAILURE$
+^VERIFICATION FAILED$
+--
+--
+Test case related to issue #6020: it checks that arrays are correctly havoced
+when enforcing loop invariant contracts.
+The `data[5] == 0` assertion is expected to fail since `data` is havoced.
+The `data[5] == 1` assertion is also expected to fail since the invariant does
+not reestablish the value for `data[5]`.

--- a/regression/contracts/invar_havoc_dynamic_array/test.desc
+++ b/regression/contracts/invar_havoc_dynamic_array/test.desc
@@ -10,8 +10,8 @@ main.c
 ^VERIFICATION FAILED$
 --
 --
-Test case related to issue #6020: it checks that arrays are correctly havoced
-when enforcing loop invariant contracts.
+Test case related to issue #6020: it checks that dynamically allocated arrays
+are correctly havoced when enforcing loop invariant contracts.
 The `data[5] == 0` assertion is expected to fail since `data` is havoced.
 The `data[5] == 1` assertion is also expected to fail since the invariant does
 not reestablish the value for `data[5]`.

--- a/regression/contracts/invar_havoc_dynamic_array_const_idx/main.c
+++ b/regression/contracts/invar_havoc_dynamic_array_const_idx/main.c
@@ -1,0 +1,20 @@
+#include <assert.h>
+#include <stdlib.h>
+
+#define SIZE 8
+
+void main()
+{
+  char *data = malloc(SIZE * sizeof(char));
+  data[1] = 0;
+  data[4] = 0;
+
+  for(unsigned i = 0; i < SIZE; i++)
+    __CPROVER_loop_invariant(i <= SIZE)
+    {
+      data[1] = i;
+    }
+
+  assert(data[1] == 0 || data[1] == 1);
+  assert(data[4] == 0);
+}

--- a/regression/contracts/invar_havoc_dynamic_array_const_idx/test.desc
+++ b/regression/contracts/invar_havoc_dynamic_array_const_idx/test.desc
@@ -10,8 +10,8 @@ main.c
 ^VERIFICATION FAILED$
 --
 --
-Test case related to issue #6020: it checks that arrays are correctly havoced
-when enforcing loop invariant contracts.
+Test case related to issue #6020: it checks that dynamically allocated arrays
+are correctly havoced when enforcing loop invariant contracts.
 The `data[1] == 0 || data[1] == 1` assertion is expected to fail since `data[1]`
 is havoced and the invariant does not reestablish the value of `data[1]`.
 However, the `data[4] == 0` assertion is expected to pass -- we should not havoc

--- a/regression/contracts/invar_havoc_dynamic_array_const_idx/test.desc
+++ b/regression/contracts/invar_havoc_dynamic_array_const_idx/test.desc
@@ -1,0 +1,18 @@
+CORE
+main.c
+--enforce-all-contracts
+^EXIT=10$
+^SIGNAL=0$
+^\[main.1\] .* Check loop invariant before entry: SUCCESS$
+^\[main.2\] .* Check that loop invariant is preserved: SUCCESS$
+^\[main.assertion.1\] .* assertion data\[1\] == 0 \|\| data\[1\] == 1: FAILURE$
+^\[main.assertion.2\] .* assertion data\[4\] == 0: SUCCESS$
+^VERIFICATION FAILED$
+--
+--
+Test case related to issue #6020: it checks that arrays are correctly havoced
+when enforcing loop invariant contracts.
+The `data[1] == 0 || data[1] == 1` assertion is expected to fail since `data[1]`
+is havoced and the invariant does not reestablish the value of `data[1]`.
+However, the `data[4] == 0` assertion is expected to pass -- we should not havoc
+the entire `data` array, if only a constant index if being modified.

--- a/regression/contracts/invar_havoc_dynamic_multi-dim_array/main.c
+++ b/regression/contracts/invar_havoc_dynamic_multi-dim_array/main.c
@@ -1,0 +1,27 @@
+#include <assert.h>
+#include <stdlib.h>
+
+#define SIZE 8
+
+void main()
+{
+  char ***data = malloc(SIZE * sizeof(char **));
+  for(unsigned i = 0; i < SIZE; i++)
+  {
+    data[i] = malloc(SIZE * sizeof(char *));
+    for(unsigned j = 0; j < SIZE; j++)
+      data[i][j] = malloc(SIZE * sizeof(char));
+  }
+
+  data[1][2][3] = 0;
+  char *old_data123 = &(data[1][2][3]);
+
+  for(unsigned i = 0; i < SIZE; i++)
+    __CPROVER_loop_invariant(i <= SIZE)
+    {
+      data[i][(i + 1) % SIZE][(i + 2) % SIZE] = 1;
+    }
+
+  assert(__CPROVER_same_object(old_data123, &(data[1][2][3])));
+  assert(data[1][2][3] == 0);
+}

--- a/regression/contracts/invar_havoc_dynamic_multi-dim_array/test.desc
+++ b/regression/contracts/invar_havoc_dynamic_multi-dim_array/test.desc
@@ -1,0 +1,21 @@
+KNOWNBUG
+main.c
+--enforce-all-contracts
+^EXIT=10$
+^SIGNAL=0$
+^\[main.1\] .* Check loop invariant before entry: SUCCESS$
+^\[main.2\] .* Check that loop invariant is preserved: SUCCESS$
+^\[main.assertion.1\] .* assertion __CPROVER_same_object(old_data123, &(data\[1\]\[2\]\[3\])): SUCCESS$
+^\[main.assertion.2\] .* assertion data\[1\]\[2\]\[3\] == 0: FAILURE$
+^VERIFICATION FAILED$
+--
+--
+Test case related to issue #6020: it checks that dynamically allocated multi
+dimensional arrays are correctly havoced when enforcing invariant contracts.
+
+The `__CPROVER_same_object(old_data123, &(data[1][2][3]))` assertion is expected
+to pass -- we should not mistakenly havoc the allocations, just their values.
+However, the `data[1][2][3] == 0` assertion is expected to fail since `data`
+is havoced.
+
+Blocked on issue #6021 -- alias analysis is imprecise and returns `unknown`.

--- a/regression/contracts/invar_havoc_dynamic_multi-dim_array_all_const_idx/main.c
+++ b/regression/contracts/invar_havoc_dynamic_multi-dim_array_all_const_idx/main.c
@@ -1,0 +1,27 @@
+#include <assert.h>
+#include <stdlib.h>
+
+#define SIZE 8
+
+void main()
+{
+  char ***data = malloc(SIZE * sizeof(char **));
+  for(unsigned i = 0; i < SIZE; i++)
+  {
+    data[i] = malloc(SIZE * sizeof(char *));
+    for(unsigned j = 0; j < SIZE; j++)
+      data[i][j] = malloc(SIZE * sizeof(char));
+  }
+
+  data[1][2][3] = 0;
+  data[4][5][6] = 0;
+
+  for(unsigned i = 0; i < SIZE; i++)
+    __CPROVER_loop_invariant(i <= SIZE)
+    {
+      data[4][5][6] = 1;
+    }
+
+  assert(data[4][5][6] == 0);
+  assert(data[1][2][3] == 0);
+}

--- a/regression/contracts/invar_havoc_dynamic_multi-dim_array_all_const_idx/test.desc
+++ b/regression/contracts/invar_havoc_dynamic_multi-dim_array_all_const_idx/test.desc
@@ -1,0 +1,21 @@
+KNOWNBUG
+main.c
+--enforce-all-contracts
+^EXIT=10$
+^SIGNAL=0$
+^\[main.1\] .* Check loop invariant before entry: SUCCESS$
+^\[main.2\] .* Check that loop invariant is preserved: SUCCESS$
+^\[main.assertion.1\] .* assertion data\[4\]\[5\]\[6\] == 0: FAILURE$
+^\[main.assertion.2\] .* assertion data\[1\]\[2\]\[3\] == 0: SUCCESS$
+^VERIFICATION FAILED$
+--
+--
+Test case related to issue #6020: it checks that dynamically allocated multi
+dimensional arrays are correctly havoced when enforcing invariant contracts.
+
+The `data[4][5][6] == 0` assertion is expected to fail since `data[4][5][6]`
+is havoced and the invariant does not reestablish its value.
+However, the `data[1][2][3] == 0` assertion is expected to pass -- we should
+not havoc the entire `data` array, if only a constant index if being modified.
+
+Blocked on issue #6021 -- alias analysis is imprecise and returns `unknown`.

--- a/regression/contracts/invar_havoc_dynamic_multi-dim_array_partial_const_idx/main.c
+++ b/regression/contracts/invar_havoc_dynamic_multi-dim_array_partial_const_idx/main.c
@@ -1,0 +1,27 @@
+#include <assert.h>
+#include <stdlib.h>
+
+#define SIZE 8
+
+void main()
+{
+  char ***data = malloc(SIZE * sizeof(char **));
+  for(unsigned i = 0; i < SIZE; i++)
+  {
+    data[i] = malloc(SIZE * sizeof(char *));
+    for(unsigned j = 0; j < SIZE; j++)
+      data[i][j] = malloc(SIZE * sizeof(char));
+  }
+
+  data[1][2][3] = 0;
+  data[4][5][6] = 0;
+
+  for(unsigned i = 0; i < SIZE; i++)
+    __CPROVER_loop_invariant(i <= SIZE)
+    {
+      data[4][i][6] = 1;
+    }
+
+  assert(data[1][2][3] == 0);
+  assert(data[4][5][6] == 0);
+}

--- a/regression/contracts/invar_havoc_dynamic_multi-dim_array_partial_const_idx/test.desc
+++ b/regression/contracts/invar_havoc_dynamic_multi-dim_array_partial_const_idx/test.desc
@@ -1,0 +1,22 @@
+KNOWNBUG
+main.c
+--enforce-all-contracts
+^EXIT=10$
+^SIGNAL=0$
+^\[main.1\] .* Check loop invariant before entry: SUCCESS$
+^\[main.2\] .* Check that loop invariant is preserved: SUCCESS$
+^\[main.assertion.1\] .* assertion data\[1\]\[2\]\[3\] == 0: FAILURE$
+^\[main.assertion.2\] .* assertion data\[4\]\[5\]\[6\] == 0: FAILURE$
+^VERIFICATION FAILED$
+--
+--
+Test case related to issue #6020: it checks that dynamically allocated multi
+dimensional arrays are correctly havoced when enforcing invariant contracts.
+
+Here, both assertions are expected to fail -- the entire `data` array should
+be havoced since we are assigning to a non-constant index.
+We _could_ do a more precise analysis in future where we only havoc
+`data[4][5][6]` but not `data[1][2][3]` since the latter clearly cannot be
+modified in the given loop.
+
+Blocked on issue #6021 -- alias analysis is imprecise and returns `unknown`.

--- a/regression/contracts/invar_havoc_static_array/main.c
+++ b/regression/contracts/invar_havoc_static_array/main.c
@@ -1,0 +1,19 @@
+#include <assert.h>
+#include <stdlib.h>
+
+#define SIZE 8
+
+void main()
+{
+  char data[SIZE];
+  data[5] = 0;
+
+  for(unsigned i = 0; i < SIZE; i++)
+    __CPROVER_loop_invariant(i <= SIZE)
+    {
+      data[i] = 1;
+    }
+
+  assert(data[5] == 0);
+  assert(data[5] == 1);
+}

--- a/regression/contracts/invar_havoc_static_array/test.desc
+++ b/regression/contracts/invar_havoc_static_array/test.desc
@@ -1,0 +1,17 @@
+CORE
+main.c
+--enforce-all-contracts
+^EXIT=10$
+^SIGNAL=0$
+^\[main.1\] .* Check loop invariant before entry: SUCCESS$
+^\[main.2\] .* Check that loop invariant is preserved: SUCCESS$
+^\[main.assertion.1\] .* assertion data\[5\] == 0: FAILURE$
+^\[main.assertion.2\] .* assertion data\[5\] == 1: FAILURE$
+^VERIFICATION FAILED$
+--
+--
+Test case related to issue #6020: it checks that arrays are correctly havoced
+when enforcing loop invariant contracts.
+The `data[5] == 0` assertion is expected to fail since `data` is havoced.
+The `data[5] == 1` assertion is also expected to fail since the invariant does
+not reestablish the value for `data[5]`.

--- a/regression/contracts/invar_havoc_static_array_const_idx/main.c
+++ b/regression/contracts/invar_havoc_static_array_const_idx/main.c
@@ -1,0 +1,20 @@
+#include <assert.h>
+#include <stdlib.h>
+
+#define SIZE 8
+
+void main()
+{
+  char data[SIZE];
+  data[1] = 0;
+  data[4] = 0;
+
+  for(unsigned i = 0; i < SIZE; i++)
+    __CPROVER_loop_invariant(i <= SIZE)
+    {
+      data[1] = i;
+    }
+
+  assert(data[1] == 0 || data[1] == 1);
+  assert(data[4] == 0);
+}

--- a/regression/contracts/invar_havoc_static_array_const_idx/test.desc
+++ b/regression/contracts/invar_havoc_static_array_const_idx/test.desc
@@ -1,0 +1,18 @@
+CORE
+main.c
+--enforce-all-contracts
+^EXIT=10$
+^SIGNAL=0$
+^\[main.1\] .* Check loop invariant before entry: SUCCESS$
+^\[main.2\] .* Check that loop invariant is preserved: SUCCESS$
+^\[main.assertion.1\] .* assertion data\[1\] == 0 \|\| data\[1\] == 1: FAILURE$
+^\[main.assertion.2\] .* assertion data\[4\] == 0: SUCCESS$
+^VERIFICATION FAILED$
+--
+--
+Test case related to issue #6020: it checks that arrays are correctly havoced
+when enforcing loop invariant contracts.
+The `data[1] == 0 || data[1] == 1` assertion is expected to fail since `data[1]`
+is havoced and the invariant does not reestablish the value of `data[1]`.
+However, the `data[4] == 0` assertion is expected to pass -- we should not havoc
+the entire `data` array, if only a constant index if being modified.

--- a/regression/contracts/invar_havoc_static_multi-dim_array/main.c
+++ b/regression/contracts/invar_havoc_static_multi-dim_array/main.c
@@ -1,0 +1,21 @@
+#include <assert.h>
+#include <stdlib.h>
+
+#define SIZE 8
+
+void main()
+{
+  char data[SIZE][SIZE][SIZE];
+
+  data[1][2][3] = 0;
+  char *old_data123 = &(data[1][2][3]);
+
+  for(unsigned i = 0; i < SIZE; i++)
+    __CPROVER_loop_invariant(i <= SIZE)
+    {
+      data[i][(i + 1) % SIZE][(i + 2) % SIZE] = 1;
+    }
+
+  assert(__CPROVER_same_object(old_data123, &(data[1][2][3])));
+  assert(data[1][2][3] == 0);
+}

--- a/regression/contracts/invar_havoc_static_multi-dim_array/test.desc
+++ b/regression/contracts/invar_havoc_static_multi-dim_array/test.desc
@@ -1,0 +1,19 @@
+CORE
+main.c
+--enforce-all-contracts
+^EXIT=10$
+^SIGNAL=0$
+^\[main.1\] .* Check loop invariant before entry: SUCCESS$
+^\[main.2\] .* Check that loop invariant is preserved: SUCCESS$
+^\[main.assertion.1\] .* assertion __CPROVER_same_object\(old_data123, &\(data\[1\]\[2\]\[3\]\)\): SUCCESS$
+^\[main.assertion.2\] .* assertion data\[1\]\[2\]\[3\] == 0: FAILURE$
+^VERIFICATION FAILED$
+--
+--
+Test case related to issue #6020: it checks that multi dimensional arrays
+are correctly havoced when enforcing invariant contracts.
+
+The `__CPROVER_same_object(old_data123, &(data[1][2][3]))` assertion is expected
+to pass -- we should not mistakenly havoc the allocations, just their values.
+However, the `data[1][2][3] == 0` assertion is expected to fail since `data`
+is havoced.

--- a/regression/contracts/invar_havoc_static_multi-dim_array_all_const_idx/main.c
+++ b/regression/contracts/invar_havoc_static_multi-dim_array_all_const_idx/main.c
@@ -1,0 +1,21 @@
+#include <assert.h>
+#include <stdlib.h>
+
+#define SIZE 8
+
+void main()
+{
+  char data[SIZE][SIZE][SIZE];
+
+  data[1][2][3] = 0;
+  data[4][5][6] = 0;
+
+  for(unsigned i = 0; i < SIZE; i++)
+    __CPROVER_loop_invariant(i <= SIZE)
+    {
+      data[4][5][6] = 1;
+    }
+
+  assert(data[4][5][6] == 0);
+  assert(data[1][2][3] == 0);
+}

--- a/regression/contracts/invar_havoc_static_multi-dim_array_all_const_idx/test.desc
+++ b/regression/contracts/invar_havoc_static_multi-dim_array_all_const_idx/test.desc
@@ -1,0 +1,19 @@
+CORE
+main.c
+--enforce-all-contracts
+^EXIT=10$
+^SIGNAL=0$
+^\[main.1\] .* Check loop invariant before entry: SUCCESS$
+^\[main.2\] .* Check that loop invariant is preserved: SUCCESS$
+^\[main.assertion.1\] .* assertion data\[4\]\[5\]\[6\] == 0: FAILURE$
+^\[main.assertion.2\] .* assertion data\[1\]\[2\]\[3\] == 0: SUCCESS$
+^VERIFICATION FAILED$
+--
+--
+Test case related to issue #6020: it checks that multi dimensional arrays
+are correctly havoced when enforcing invariant contracts.
+
+The `data[4][5][6] == 0` assertion is expected to fail since `data[4][5][6]`
+is havoced and the invariant does not reestablish its value.
+However, the `data[1][2][3] == 0` assertion is expected to pass -- we should
+not havoc the entire `data` array, if only a constant index if being modified.

--- a/regression/contracts/invar_havoc_static_multi-dim_array_partial_const_idx/main.c
+++ b/regression/contracts/invar_havoc_static_multi-dim_array_partial_const_idx/main.c
@@ -1,0 +1,21 @@
+#include <assert.h>
+#include <stdlib.h>
+
+#define SIZE 8
+
+void main()
+{
+  char data[SIZE][SIZE][SIZE];
+
+  data[1][2][3] = 0;
+  data[4][5][6] = 0;
+
+  for(unsigned i = 0; i < SIZE; i++)
+    __CPROVER_loop_invariant(i <= SIZE)
+    {
+      data[4][i][6] = 1;
+    }
+
+  assert(data[1][2][3] == 0);
+  assert(data[4][5][6] == 0);
+}

--- a/regression/contracts/invar_havoc_static_multi-dim_array_partial_const_idx/test.desc
+++ b/regression/contracts/invar_havoc_static_multi-dim_array_partial_const_idx/test.desc
@@ -1,0 +1,20 @@
+CORE
+main.c
+--enforce-all-contracts
+^EXIT=10$
+^SIGNAL=0$
+^\[main.1\] .* Check loop invariant before entry: SUCCESS$
+^\[main.2\] .* Check that loop invariant is preserved: SUCCESS$
+^\[main.assertion.1\] .* assertion data\[1\]\[2\]\[3\] == 0: FAILURE$
+^\[main.assertion.2\] .* assertion data\[4\]\[5\]\[6\] == 0: FAILURE$
+^VERIFICATION FAILED$
+--
+--
+Test case related to issue #6020: it checks that multi dimensional arrays
+are correctly havoced when enforcing invariant contracts.
+
+Here, both assertions are expected to fail -- the entire `data` array should
+be havoced since we are assigning to a non-constant index.
+We _could_ do a more precise analysis in future where we only havoc
+`data[4][5][6]` but not `data[1][2][3]` since the latter clearly cannot be
+modified in the given loop.

--- a/scripts/expected_doxygen_warnings.txt
+++ b/scripts/expected_doxygen_warnings.txt
@@ -26,7 +26,7 @@ warning: Included by graph for 'c_types.h' not generated, too many nodes (144), 
 warning: Included by graph for 'config.h' not generated, too many nodes (77), threshold is 60. Consider increasing DOT_GRAPH_MAX_NODES.
 warning: Included by graph for 'exception_utils.h' not generated, too many nodes (61), threshold is 60. Consider increasing DOT_GRAPH_MAX_NODES.
 warning: Included by graph for 'expr.h' not generated, too many nodes (87), threshold is 60. Consider increasing DOT_GRAPH_MAX_NODES.
-warning: Included by graph for 'expr_util.h' not generated, too many nodes (61), threshold is 60. Consider increasing DOT_GRAPH_MAX_NODES.
+warning: Included by graph for 'expr_util.h' not generated, too many nodes (62), threshold is 60. Consider increasing DOT_GRAPH_MAX_NODES.
 warning: Included by graph for 'invariant.h' not generated, too many nodes (186), threshold is 60. Consider increasing DOT_GRAPH_MAX_NODES.
 warning: Included by graph for 'irep.h' not generated, too many nodes (62), threshold is 60. Consider increasing DOT_GRAPH_MAX_NODES.
 warning: Included by graph for 'message.h' not generated, too many nodes (118), threshold is 60. Consider increasing DOT_GRAPH_MAX_NODES.

--- a/src/goto-instrument/loop_utils.cpp
+++ b/src/goto-instrument/loop_utils.cpp
@@ -11,11 +11,34 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "loop_utils.h"
 
+#include <util/expr_util.h>
 #include <util/pointer_expr.h>
 #include <util/std_expr.h>
 
+#include <goto-programs/pointer_arithmetic.h>
+
 #include <analyses/natural_loops.h>
 #include <analyses/local_may_alias.h>
+
+class loop_utils_is_constantt : public is_constantt
+{
+public:
+  explicit loop_utils_is_constantt(const modifiest &mod) : modifies(mod)
+  {
+  }
+  bool is_constant(const exprt &expr) const override
+  {
+    // Besides the "usual" constants (checked in is_constantt::is_constant),
+    // we also treat unmodified symbols as constants
+    if(expr.id() == ID_symbol && modifies.find(expr) == modifies.end())
+      return true;
+
+    return is_constantt::is_constant(expr);
+  }
+
+protected:
+  const modifiest &modifies;
+};
 
 goto_programt::targett get_loop_exit(const loopt &loop)
 {
@@ -35,23 +58,49 @@ goto_programt::targett get_loop_exit(const loopt &loop)
   return ++last;
 }
 
+void build_havoc_code_for_scalar(
+  const goto_programt::targett loop_head,
+  const exprt &lhs,
+  goto_programt &dest)
+{
+  side_effect_expr_nondett rhs(lhs.type(), loop_head->source_location);
+
+  goto_programt::targett t = dest.add(goto_programt::make_assignment(
+    lhs, std::move(rhs), loop_head->source_location));
+  t->code_nonconst().add_source_location() = loop_head->source_location;
+}
+
+void build_havoc_code_for_object(
+  const goto_programt::targett loop_head,
+  const exprt &lhs,
+  goto_programt &dest)
+{
+  codet havoc(ID_havoc_object);
+  havoc.add_source_location() = loop_head->source_location;
+  havoc.add_to_operands(lhs);
+
+  dest.add(goto_programt::make_other(havoc, loop_head->source_location));
+}
+
 void build_havoc_code(
   const goto_programt::targett loop_head,
   const modifiest &modifies,
   goto_programt &dest)
 {
-  for(modifiest::const_iterator
-      m_it=modifies.begin();
-      m_it!=modifies.end();
-      m_it++)
+  loop_utils_is_constantt is_constant(modifies);
+  for(const auto &lhs : modifies)
   {
-    exprt lhs=*m_it;
-    side_effect_expr_nondett rhs(lhs.type(), loop_head->source_location);
+    if(lhs.id() == ID_index || lhs.id() == ID_dereference)
+    {
+      address_of_exprt address_of_lhs(lhs);
+      if(!is_constant(address_of_lhs))
+      {
+        build_havoc_code_for_object(loop_head, address_of_lhs, dest);
+        continue;
+      }
+    }
 
-    goto_programt::targett t = dest.add(goto_programt::make_assignment(
-      code_assignt(std::move(lhs), std::move(rhs)),
-      loop_head->source_location));
-    t->code_nonconst().add_source_location() = loop_head->source_location;
+    build_havoc_code_for_scalar(loop_head, lhs, dest);
   }
 }
 
@@ -61,16 +110,18 @@ void get_modifies_lhs(
   const exprt &lhs,
   modifiest &modifies)
 {
-  if(lhs.id() == ID_symbol || lhs.id() == ID_member)
+  if(lhs.id() == ID_symbol || lhs.id() == ID_member || lhs.id() == ID_index)
     modifies.insert(lhs);
   else if(lhs.id()==ID_dereference)
   {
-    const auto &pointer = to_dereference_expr(lhs).pointer();
-    for(const auto &mod : local_may_alias.get(t, pointer))
-      modifies.insert(dereference_exprt{mod});
-  }
-  else if(lhs.id()==ID_index)
-  {
+    const pointer_arithmetict ptr(to_dereference_expr(lhs).pointer());
+    for(const auto &mod : local_may_alias.get(t, ptr.pointer))
+    {
+      if(ptr.offset.is_nil())
+        modifies.insert(dereference_exprt{mod});
+      else
+        modifies.insert(dereference_exprt{plus_exprt{mod, ptr.offset}});
+    }
   }
   else if(lhs.id()==ID_if)
   {


### PR DESCRIPTION
Fixes #6020.

As reported in #6020, only the first element of an array was being havoced earlier. In this change, we fix this behavior using `havoc_object`.

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- NA ~~The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/~~
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- NA ~~My commit message includes data points confirming performance improvements (if claimed).~~
- [x] My PR is restricted to a single feature or bugfix.
- NA ~~White-space or formatting changes outside the feature-related changed lines are in commits of their own.~~