### PR TITLE
C front-end: support ID_integer-typed expressions in get_c_type

### DIFF
--- a/regression/cbmc/integer-assignments1/integer-typecheck.desc
+++ b/regression/cbmc/integer-assignments1/integer-typecheck.desc
@@ -1,0 +1,14 @@
+CORE
+main.c
+--show-goto-functions
+^[[:space:]]*ASSIGN main::1::b := main::1::b \* cast\(100, ℤ\)$
+^EXIT=0$
+^SIGNAL=0$
+--
+^[[:space:]]*ASSIGN main::1::b := main::1::b \* 100$
+--
+implicit_typecast_arithmetic previously failed to insert a typecast for the
+(mathematical) integer-typed expression. This resulted in a multiplication over
+mixed types, which sometimes (!) resulted in an invariant failure during
+simplification. This was first observed when compiling with GCC 10, cf.
+discussion in #6028.

--- a/regression/validate-trace-xml-schema/check.py
+++ b/regression/validate-trace-xml-schema/check.py
@@ -22,6 +22,7 @@ ExcludedTests = list(map(lambda s: os.path.join(test_base_dir, s[0], s[1]), [
     ['xml-interface1', 'test.desc'],
     ['xml-interface1', 'test_wrong_flag.desc'],
     # these want --show-goto-functions instead of producing a trace
+    ['integer-assignments1', 'integer-typecheck.desc'],
     ['destructors', 'compound_literal.desc'],
     ['destructors', 'enter_lexical_block.desc'],
     ['reachability-slice-interproc2', 'test.desc'],

--- a/src/ansi-c/c_typecast.cpp
+++ b/src/ansi-c/c_typecast.cpp
@@ -382,6 +382,8 @@ c_typecastt::c_typet c_typecastt::get_c_type(
 
     return get_c_type(new_type);
   }
+  else if(type.id() == ID_integer)
+    return INTEGER;
 
   return OTHER;
 }


### PR DESCRIPTION
Mathematical integers were wrongly considered "OTHER," resulting in
missing type casts as demonstrated by the included regression test.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
