### PR TITLE
goto-cc: Fix compilation with GCC 11

### DIFF
--- a/src/goto-cc/ms_link_cmdline.cpp
+++ b/src/goto-cc/ms_link_cmdline.cpp
@@ -333,7 +333,7 @@ void ms_link_cmdlinet::process_link_option(const std::string &s)
     return;
   }
 
-  for(const std::string &ms_link_option : ms_link_options)
+  for(const std::string ms_link_option : ms_link_options)
   {
     // These are case insensitive.
     if(


### PR DESCRIPTION
The reference type caused following error:
/builddir/build/BUILD/cbmc/src/goto-cc/ms_link_cmdline.cpp:337:26: error: loop variable 'ms_link_option' of type 'const string&' {aka 'const std::__cxx11::basic_string<char>&'} binds to a temporary constructed from type 'const char*' [-Werror=range-loop-construct]
  337 |   for(const std::string &ms_link_option : ms_link_options)
      |                          ^~~~~~~~~~~~~~
/builddir/build/BUILD/cbmc/src/goto-cc/ms_link_cmdline.cpp:337:26: note: use non-reference type 'const string' {aka 'const std::__cxx11::basic_string<char>'} to make the copy explicit or 'const char* const&' to prevent copying

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
