### PR TITLE
src/util: Fix compatibility with glibc 2.33 and higher

### DIFF
--- a/src/util/file_util.cpp
+++ b/src/util/file_util.cpp
@@ -54,7 +54,7 @@ std::string get_current_working_directory()
   errno=0;
   char *wd=realpath(".", nullptr);
 
-  if(wd == nullptr || errno != 0)
+  if(wd == nullptr)
     throw system_exceptiont(
       std::string("realpath failed: ") + std::strerror(errno));
 

--- a/src/util/tempdir.cpp
+++ b/src/util/tempdir.cpp
@@ -93,7 +93,7 @@ std::string get_temporary_directory(const std::string &name_template)
   errno = 0;
   char *wd = realpath(td, nullptr);
 
-  if(wd == nullptr || errno != 0)
+  if(wd == nullptr)
     throw system_exceptiont(
       std::string("realpath failed: ") + std::strerror(errno));
 


### PR DESCRIPTION
From `man 3 errno`: The value in errno is significant only when the
return value of the call indicated an error.

Any code using this failed with: `realpath failed: Invalid argument`

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
