### PR TITLE
[smt2_convt] Fix invalid and NULL pointer handling

### DIFF
--- a/regression/cbmc/memset_null/main.c
+++ b/regression/cbmc/memset_null/main.c
@@ -1,0 +1,9 @@
+#include <stdlib.h>
+#include <string.h>
+
+void main()
+{
+  char *data = nondet() ? NULL : malloc(8);
+  memset(data, 0, 8);
+  memset(data, 0, 8);
+}

--- a/regression/cbmc/memset_null/test.desc
+++ b/regression/cbmc/memset_null/test.desc
@@ -1,0 +1,12 @@
+CORE
+main.c
+
+^\[main.precondition_instance.1\] line .* memset destination region writeable: FAILURE$
+^\[main.precondition_instance.2\] line .* memset destination region writeable: FAILURE$
+^EXIT=10$
+^SIGNAL=0$
+^VERIFICATION FAILED$
+--
+--
+This test case checks that byte operations (e.g. memset) oninvalid and `NULL`
+pointers are correctly encoded in SMT2.

--- a/regression/cbmc/ptr_arithmetic_on_null/main.c
+++ b/regression/cbmc/ptr_arithmetic_on_null/main.c
@@ -1,0 +1,21 @@
+#include <stdlib.h>
+
+void main()
+{
+  assert(NULL != (NULL + 1));
+  assert(NULL != (NULL - 1));
+
+  int offset;
+  __CPROVER_assume(offset != 0);
+  assert(NULL != (NULL + offset));
+
+  assert(NULL - NULL == 0);
+
+  int *ptr;
+  assert(ptr - NULL == 0);
+  ptr = NULL;
+  assert((ptr - 1) + 1 == NULL);
+
+  ptr = nondet() ? NULL : malloc(1);
+  assert((ptr - 1) + 1 == (NULL + 1) - 1);
+}

--- a/regression/cbmc/ptr_arithmetic_on_null/test.desc
+++ b/regression/cbmc/ptr_arithmetic_on_null/test.desc
@@ -1,0 +1,17 @@
+CORE
+main.c
+
+^\[main.assertion.1\] line .* assertion \(void \*\)0 != \(void \*\)0 \+ \(.*\)1: SUCCESS$
+^\[main.assertion.2\] line .* assertion \(void \*\)0 != \(void \*\)0 - \(.*\)1: SUCCESS$
+^\[main.assertion.3\] line .* assertion \(void \*\)0 != \(void \*\)0 \+ \(.*\)offset: SUCCESS$
+^\[main.assertion.4\] line .* assertion \(void \*\)0 - \(void \*\)0 == \(.*\)0: SUCCESS$
+^\[main.assertion.5\] line .* assertion ptr - \(void \*\)0 == \(.*\)0: FAILURE$
+^\[main.assertion.6\] line .* assertion \(ptr - \(.*\)1\) \+ \(.*\)1 == \(\(.* \*\)NULL\): SUCCESS$
+^\[main.assertion.7\] line .* assertion \(ptr - \(.*\)1\) \+ \(.*\)1 == \(\(.* \*\)NULL\): FAILURE$
+^EXIT=10$
+^SIGNAL=0$
+^VERIFICATION FAILED$
+--
+--
+This test case checks that pointer arithmetic on NULL pointers are correctly
+encoded by the SMT2 translation routines.

--- a/src/solvers/smt2/smt2_conv.cpp
+++ b/src/solvers/smt2/smt2_conv.cpp
@@ -4247,6 +4247,11 @@ void smt2_convt::set_to(const exprt &expr, bool value)
   if(expr.id() == ID_equal && value)
   {
     const equal_exprt &equal_expr=to_equal_expr(expr);
+    if(equal_expr.lhs().type().id() == ID_empty)
+    {
+      // ignore equality checking over expressions with empty (void) type
+      return;
+    }
 
     if(equal_expr.lhs().id()==ID_symbol)
     {


### PR DESCRIPTION
Fixes #6022.

Several SMT2 conversion functions used to crash on `NULL` pointers and other kinds of invalid pointers. This change fixes the handling of NULL pointers at several locations.

- [x] Each commit message has a non-empty body, explaining why the change was made.
- NA ~~Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.~~
- NA ~~The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/~~
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- NA ~~My commit message includes data points confirming performance improvements (if claimed).~~
- [x] My PR is restricted to a single feature or bugfix.
- NA ~~White-space or formatting changes outside the feature-related changed lines are in commits of their own.~~