### PR TITLE
Memcpy for pointers involving structs was fixed via field sensitivity

### DIFF
--- a/regression/cbmc-library/memcpy-01/test.desc
+++ b/regression/cbmc-library/memcpy-01/test.desc
@@ -1,11 +1,11 @@
-KNOWNBUG
+CORE
 main.c
 --bounds-check --pointer-check
 ^EXIT=0$
 ^SIGNAL=0$
 ^VERIFICATION SUCCESSFUL$
-^\[main\.assertion\.5\] assertion q\.s->x == 42: SUCCESS$
-^\[main\.assertion\.6\] assertion q\.s->y == 43: SUCCESS$
+^\[main\.assertion\.5\] line 46 assertion q\.s->x == 42: SUCCESS$
+^\[main\.assertion\.6\] line 47 assertion q\.s->y == 43: SUCCESS$
 --
 ^warning: ignoring
 --


### PR DESCRIPTION
This test passes as of ca9fcb793, except for the missing "line NN" part
that wasn't included in the pattern to be matched.

Fixes: #2925

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
