### PR TITLE
Pointer subtraction was fixed in 3acdb52dd

### DIFF
--- a/regression/cbmc-primitives/r_w_ok_bug/test.desc
+++ b/regression/cbmc-primitives/r_w_ok_bug/test.desc
@@ -1,9 +1,11 @@
-KNOWNBUG
+CORE
 main.c
 --pointer-check --no-simplify --no-propagation
-^EXIT=0$
+^\[main.pointer_dereference.\d+\] line 8 dereference failure: pointer outside dynamic object bounds in \*p1: FAILURE$
+^\[main.pointer_dereference.\d+\] line 8 dereference failure: pointer outside object bounds in \*p1: FAILURE$
+^\*\* 2 of \d+ failed
+^VERIFICATION FAILED$
+^EXIT=10$
 ^SIGNAL=0$
 --
 ^warning: ignoring
---
-Crashes during the flattening, issue #5328


### PR DESCRIPTION
The invariant failure was caused by a bug in handling pointer
subtraction, which was fixed in 3acdb52dd. The test also wrongly assumed
verification would succeed, which is not correct for `*p`, which is out
of bounds.

Fixes: #5328

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
