### PR TITLE
Build cbmc with cadical using make and IPASIR

### DIFF
--- a/COMPILING.md
+++ b/COMPILING.md
@@ -380,6 +380,47 @@ For the packaged builds of CBMC on our release page we currently build CBMC
 with the MiniSat2 SAT solver statically linked at compile time. However it is
 also possible to build CBMC using alternative SAT solvers.
 
+### Compiling with CaDiCaL
+
+The [CaDiCaL](https://github.com/arminbiere/cadical) solver supports the
+[IPASIR](https://github.com/biotomas/ipasir) C interface to incremental SAT
+solvers, which is also supported by CBMC. So the process for producing a CBMC
+with CaDiCaL build is to build CaDiCaL as a static library then compile CBMC
+with the IPASIR build options and link to the CaDiCaL static library.
+
+Note that at the time of writing this has been tested to work with the CaDiCaL
+1.4.0 on Ubuntu 18.04 & 20.04.
+
+1. Download CaDiCaL:
+   ```
+   git clone --branch rel-1.4.0 https://github.com/arminbiere/cadical.git
+   ```
+   This will clone the CaDiCaL repository into a `cadical` subdirectory and
+   checkout release 1.4.0, which has been checked for compatibility with CBMC at
+   the time these instructions were written.
+
+2. Build CaDiCaL:
+   ```
+   cd cadical
+   ./configure
+   make cadical
+   cd ..
+   ```
+   This will create a build directory called `build` inside the clone of the
+   CaDiCaL repository. The `cadical` make target is specified in this example in
+   order to avoid building targets which are not required by CBMC. The built
+   static library will be placed in `cadical/build/libcadical.a`.
+
+3. Build CBMC:
+   ```
+   make -C src LIBS="$PWD/cadical/build/libcadical.a" IPASIR=$PWD/cadical/src
+   ```
+   This links the CaDiCaL library as part of the build. Passing the IPASIR
+   parameter tells the build system to build for the IPASIR interface. The
+   argument for the IPASIR parameter gives the build system the location for
+   the IPASIR headers, which is needed for the cbmc includes of `ipasir.h`. The
+   compiled binary will be placed in `cbmc/src/cbmc/cbmc`.
+
 ### Compiling with Riss
 
 The [Riss](https://github.com/conp-solutions/riss) solver supports the

--- a/COMPILING.md
+++ b/COMPILING.md
@@ -389,7 +389,7 @@ with CaDiCaL build is to build CaDiCaL as a static library then compile CBMC
 with the IPASIR build options and link to the CaDiCaL static library.
 
 Note that at the time of writing this has been tested to work with the CaDiCaL
-1.4.0 on Ubuntu 18.04 & 20.04.
+1.4.0 on Ubuntu 18.04 & 20.04 and MacOS.
 
 1. Download CaDiCaL:
    ```

--- a/COMPILING.md
+++ b/COMPILING.md
@@ -380,7 +380,44 @@ For the packaged builds of CBMC on our release page we currently build CBMC
 with the MiniSat2 SAT solver statically linked at compile time. However it is
 also possible to build CBMC using alternative SAT solvers.
 
-### Compiling with CaDiCaL
+### Compiling with CBMC Wrapper
+
+The following solvers are supported by CBMC using custom interfaces and can
+by downloaded and compiled by the build process: MiniSAT2, CaDiCaL, and Glucose.
+
+For `make` alternatives to the default (i.e. not MiniSAT) can be built with the
+following commands for CaDiCaL:
+```
+make -C src cadical-download
+make -C src CADICAL=../../cadical
+```
+and for glucose
+```
+make -C src glucose-download
+make -C src GLUCOSE=../../glucose-syrup
+```
+
+For `cmake` the alternatives can be built with the following arguments to `cmake`
+for CaDiCaL `-Dsat_impl=cadical` and for glucose `-Dsat_impl=glucose`.
+
+
+### Compiling with IPASIR Interface
+
+The below compiling instructions allow linking of an arbitrary IPASIR
+compatible SAT solver when compiling CBMC.
+
+The general command using `make` is to compile with
+```
+make -C src LIBS="$PWD/SATOBJ SATLINKFLAGS" IPASIR=$PWD/SATPATH
+```
+Where `SATOBJ` is the pre-compiled IPASIR compatible SAT binary,
+`SATLINKFLAGS` are any flags required by the SAT object file, and
+`SATPATH` is the path to the SAT interface.
+
+The rest of this section provides detailed instructions for some example
+SAT solvers.
+
+#### Compiling with CaDiCaL
 
 The [CaDiCaL](https://github.com/arminbiere/cadical) solver supports the
 [IPASIR](https://github.com/biotomas/ipasir) C interface to incremental SAT
@@ -421,7 +458,7 @@ Note that at the time of writing this has been tested to work with the CaDiCaL
    the IPASIR headers, which is needed for the cbmc includes of `ipasir.h`. The
    compiled binary will be placed in `cbmc/src/cbmc/cbmc`.
 
-### Compiling with Riss
+#### Compiling with Riss
 
 The [Riss](https://github.com/conp-solutions/riss) solver supports the
 [IPASIR](https://github.com/biotomas/ipasir) C interface to incremental SAT

--- a/COMPILING.md
+++ b/COMPILING.md
@@ -380,7 +380,7 @@ For the packaged builds of CBMC on our release page we currently build CBMC
 with the MiniSat2 SAT solver statically linked at compile time. However it is
 also possible to build CBMC using alternative SAT solvers.
 
-### Compiling with CBMC Wrapper
+### Compiling CBMC Using Solver Native Interfaces
 
 The following solvers are supported by CBMC using custom interfaces and can
 by downloaded and compiled by the build process: MiniSAT2, CaDiCaL, and Glucose.
@@ -417,7 +417,11 @@ Where `SATOBJ` is the pre-compiled IPASIR compatible SAT binary,
 The rest of this section provides detailed instructions for some example
 SAT solvers.
 
-#### Compiling with CaDiCaL
+#### Compiling with CaDiCaL via IPASIR
+
+Note that CaDiCaL can also be built using CBMC's CaDiCaL native interface
+as described above. This section is to use CaDiCaL with the IPASIR
+interface in CBMC.
 
 The [CaDiCaL](https://github.com/arminbiere/cadical) solver supports the
 [IPASIR](https://github.com/biotomas/ipasir) C interface to incremental SAT
@@ -458,7 +462,7 @@ Note that at the time of writing this has been tested to work with the CaDiCaL
    the IPASIR headers, which is needed for the cbmc includes of `ipasir.h`. The
    compiled binary will be placed in `cbmc/src/cbmc/cbmc`.
 
-#### Compiling with Riss
+#### Compiling with Riss via IPASIR
 
 The [Riss](https://github.com/conp-solutions/riss) solver supports the
 [IPASIR](https://github.com/biotomas/ipasir) C interface to incremental SAT


### PR DESCRIPTION
This adds documentation for CaDiCaL with IPASIR linking to `cbmc`. This is tested for Ubuntu and MacOS.

Note that while CaDiCaL can be compiled for Windows (Cygwin), there are problems with building `cbmc` that need to be fixed, and also problems with Cygwin handling of some libraries. For this reason Windows build support is not included in this PR, although this may come later (or via `cmake`).

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
