### PR TITLE
Fix Cywin make build

### DIFF
--- a/src/common
+++ b/src/common
@@ -105,10 +105,10 @@ else ifeq ($(BUILD_ENV_),Cygwin)
   CP_CXXFLAGS += -MMD -MP -std=c++11 -U__STRICT_ANSI__
   # Cygwin-g++ has problems with statically linking exception code.
   # If linking fails, remove -static.
-  LINKFLAGS = -static -std=c++11
+  LINKFLAGS = -std=c++11
   LINKLIB = ar rcT $@ $^
-  LINKBIN = $(CXX) $(LINKFLAGS) -o $@ -Wl,--start-group $^ -Wl,--end-group $(LIBS)
-  LINKNATIVE = $(HOSTCXX) -std=c++11 -o $@ $^ -static
+  LINKBIN = $(CXX) $(LINKFLAGS) -o $@ -Wl,--start-group $^ -Wl,--end-group -limagehlp $(LIBS)
+  LINKNATIVE = $(HOSTCXX) -std=c++11 -o $@ $^
 ifeq ($(origin CC),default)
   #CC = gcc
   CC = x86_64-w64-mingw32-gcc

--- a/src/util/invariant.cpp
+++ b/src/util/invariant.cpp
@@ -22,6 +22,7 @@ Author: Martin Brain, martin.brain@diffblue.com
 // clang-format off
 #include <windows.h>
 #include <dbghelp.h>
+#include <imagehlp.h>
 // clang-format on
 #endif
 
@@ -117,9 +118,9 @@ void print_backtrace(
   // for the rationale behind the size of 'symbol'
   const auto max_name_len = 255;
   auto symbol = static_cast<SYMBOL_INFO *>(
-    calloc(sizeof SYMBOL_INFO + (max_name_len - 1) * sizeof(TCHAR), 1));
+    calloc(sizeof(SYMBOL_INFO) + (max_name_len - 1) * sizeof(TCHAR), 1));
   symbol->MaxNameLen = max_name_len;
-  symbol->SizeOfStruct = sizeof SYMBOL_INFO;
+  symbol->SizeOfStruct = sizeof(SYMBOL_INFO);
 
   for(std::size_t i = 0; i < number_of_frames; i++)
   {

--- a/src/util/run.cpp
+++ b/src/util/run.cpp
@@ -448,43 +448,10 @@ int run(
 #endif
 }
 
+#ifndef _WIN32
 /// quote a string for bash and CMD
 static std::string shell_quote(const std::string &src)
 {
-  #ifdef _WIN32
-  // first check if quoting is needed at all
-
-  if(src.find(' ')==std::string::npos &&
-     src.find('"')==std::string::npos &&
-     src.find('&')==std::string::npos &&
-     src.find('|')==std::string::npos &&
-     src.find('(')==std::string::npos &&
-     src.find(')')==std::string::npos &&
-     src.find('<')==std::string::npos &&
-     src.find('>')==std::string::npos &&
-     src.find('^')==std::string::npos)
-  {
-    // seems fine -- return as is
-    return src;
-  }
-
-  std::string result;
-
-  result+='"';
-
-  for(const char ch : src)
-  {
-    if(ch=='"')
-      result+='"'; // quotes are doubled
-    result+=ch;
-  }
-
-  result+='"';
-
-  return result;
-
-  #else
-
   // first check if quoting is needed at all
 
   if(src.find(' ')==std::string::npos &&
@@ -519,8 +486,8 @@ static std::string shell_quote(const std::string &src)
   result+='\'';
 
   return result;
-  #endif
 }
+#endif
 
 int run(
   const std::string &what,


### PR DESCRIPTION
This fixes various details to ensure that make under Cywin can build
cbmc.

This is just some small fixes that appear to stop `cbmc` from being built using `make` and Cygwin.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
