### PR TITLE
Add irept::set_size_t to avoid unnecessary casts

### DIFF
--- a/src/util/bitvector_expr.h
+++ b/src/util/bitvector_expr.h
@@ -37,7 +37,7 @@ public:
 
   void set_bits_per_byte(std::size_t bits_per_byte)
   {
-    set(ID_bits_per_byte, narrow_cast<long long>(bits_per_byte));
+    set_size_t(ID_bits_per_byte, bits_per_byte);
   }
 };
 

--- a/src/util/bitvector_types.h
+++ b/src/util/bitvector_types.h
@@ -273,7 +273,7 @@ public:
 
   void set_integer_bits(std::size_t b)
   {
-    set(ID_integer_bits, narrow_cast<long long>(b));
+    set_size_t(ID_integer_bits, b);
   }
 
   static void check(
@@ -335,7 +335,7 @@ public:
 
   void set_f(std::size_t b)
   {
-    set(ID_f, narrow_cast<long long>(b));
+    set_size_t(ID_f, b);
   }
 
   static void check(

--- a/src/util/irep.cpp
+++ b/src/util/irep.cpp
@@ -90,6 +90,15 @@ void irept::set(const irep_namet &name, const long long value)
 #endif
 }
 
+void irept::set_size_t(const irep_namet &name, const std::size_t value)
+{
+#ifdef USE_DSTRING
+  add(name).id(to_dstring(value));
+#else
+  add(name).id(std::to_string(value));
+#endif
+}
+
 void irept::remove(const irep_namet &name)
 {
 #if NAMED_SUB_IS_FORWARD_LIST

--- a/src/util/irep.h
+++ b/src/util/irep.h
@@ -437,6 +437,7 @@ public:
     add(name, std::move(irep));
   }
   void set(const irep_namet &name, const long long value);
+  void set_size_t(const irep_namet &name, const std::size_t value);
 
   void remove(const irep_namet &name);
   void move_to_sub(irept &irep);

--- a/src/util/std_expr.h
+++ b/src/util/std_expr.h
@@ -15,7 +15,6 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "expr_cast.h"
 #include "invariant.h"
-#include "narrow.h"
 #include "std_types.h"
 
 /// An expression without operands
@@ -1539,7 +1538,7 @@ public:
 
   void set_component_number(std::size_t component_number)
   {
-    set(ID_component_number, narrow_cast<long long>(component_number));
+    set_size_t(ID_component_number, component_number);
   }
 };
 

--- a/src/util/std_types.h
+++ b/src/util/std_types.h
@@ -18,7 +18,6 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "invariant.h"
 #include "mp_arith.h"
 #include "validate.h"
-#include <util/narrow.h>
 
 #include <unordered_map>
 
@@ -842,7 +841,7 @@ public:
 
   void set_width(std::size_t width)
   {
-    set(ID_width, narrow_cast<long long>(width));
+    set_size_t(ID_width, width);
   }
 
   static void check(


### PR DESCRIPTION
The integer-typed argument to irept::set is converted to a string, which
works equally well for types other than long long. Naming the new method
just "set" would result in ambiguous overload, thus using set_size_t
(which is also consistent with the existing get_size_t).

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
