### PR TITLE
Avoid short-lived heap-allocated objects

### DIFF
--- a/src/goto-symex/field_sensitivity.cpp
+++ b/src/goto-symex/field_sensitivity.cpp
@@ -170,11 +170,10 @@ exprt field_sensitivityt::get_fields(
 
     for(const auto &comp : components)
     {
-      const member_exprt member(struct_op, comp.get_name(), comp.type());
       ssa_exprt tmp = ssa_expr;
       bool was_l2 = !tmp.get_level_2().empty();
       tmp.remove_level_2();
-      tmp.set_expression(member);
+      tmp.set_expression(member_exprt{struct_op, comp.get_name(), comp.type()});
       if(was_l2)
       {
         fields.push_back(state.rename(get_fields(ns, state, tmp), ns).get());

--- a/src/solvers/flattening/boolbv.cpp
+++ b/src/solvers/flattening/boolbv.cpp
@@ -100,12 +100,7 @@ bvt boolbvt::conversion_failed(const exprt &expr)
 bvt boolbvt::convert_bitvector(const exprt &expr)
 {
   if(expr.type().id()==ID_bool)
-  {
-    bvt bv;
-    bv.resize(1);
-    bv[0]=convert(expr);
-    return bv;
-  }
+    return {convert(expr)};
 
   if(expr.id()==ID_index)
     return convert_index(to_index_expr(expr));

--- a/src/solvers/sat/cnf.cpp
+++ b/src/solvers/sat/cnf.cpp
@@ -412,14 +412,10 @@ bvt cnft::new_variables(std::size_t width)
 /// \return set of literals, duplicates removed
 bvt cnft::eliminate_duplicates(const bvt &bv)
 {
-  std::set<literalt> s;
-
-  bvt dest;
-  dest.reserve(bv.size());
-
-  for(const auto &l : bv)
-    if(s.insert(l).second)
-      dest.push_back(l);
+  bvt dest = bv;
+  std::sort(dest.begin(), dest.end());
+  auto last = std::unique(dest.begin(), dest.end());
+  dest.erase(last, dest.end());
 
   return dest;
 }

--- a/src/util/pointer_expr.cpp
+++ b/src/util/pointer_expr.cpp
@@ -122,9 +122,9 @@ address_of_exprt::address_of_exprt(const exprt &_op)
 {
 }
 
-const exprt &object_descriptor_exprt::root_object() const
+const exprt &object_descriptor_exprt::root_object(const exprt &expr)
 {
-  const exprt *p = &object();
+  const exprt *p = &expr;
 
   while(true)
   {

--- a/src/util/pointer_expr.h
+++ b/src/util/pointer_expr.h
@@ -180,7 +180,11 @@ public:
     return op0();
   }
 
-  const exprt &root_object() const;
+  static const exprt &root_object(const exprt &expr);
+  const exprt &root_object() const
+  {
+    return root_object(object());
+  }
 
   exprt &offset()
   {

--- a/src/util/sharing_node.h
+++ b/src/util/sharing_node.h
@@ -346,8 +346,13 @@ public:
     const to_mapt &m = get_to_map();
     typename to_mapt::const_iterator it = m.find(n);
 
+#if SN_SMALL_MAP == 1
+    if(it != m.end())
+      return &it.get_value();
+#else
     if(it != m.end())
       return &it->second;
+#endif
 
     return nullptr;
   }

--- a/src/util/small_map.h
+++ b/src/util/small_map.h
@@ -265,6 +265,15 @@ public:
       return std::make_shared<valuet>(idx, *(m.p + ii));
     }
 
+    /// Non-standard direct access to the underlying value instead of creating a
+    /// \c valuet object. Avoids creating a very short-lived \c valuet object
+    /// when only the value is needed.
+    /// \return Reference to value stored in the map.
+    const T &get_value() const
+    {
+      return *(m.p + ii);
+    }
+
     const_iterator operator++()
     {
       idx++;

--- a/src/util/ssa_expr.cpp
+++ b/src/util/ssa_expr.cpp
@@ -134,10 +134,10 @@ static void update_identifier(ssa_exprt &ssa)
   ssa.set(ID_L1_object_identifier, idpair.second);
 }
 
-void ssa_exprt::set_expression(const exprt &expr)
+void ssa_exprt::set_expression(exprt expr)
 {
-  type() = expr.type();
-  add(ID_expression, expr);
+  type() = as_const(expr).type();
+  add(ID_expression, std::move(expr));
   ::update_identifier(*this);
 }
 
@@ -148,8 +148,8 @@ irep_idt ssa_exprt::get_object_name() const
   if(original_expr.id() == ID_symbol)
     return to_symbol_expr(original_expr).get_identifier();
 
-  object_descriptor_exprt ode(original_expr);
-  return to_symbol_expr(ode.root_object()).get_identifier();
+  return to_symbol_expr(object_descriptor_exprt::root_object(original_expr))
+    .get_identifier();
 }
 
 const ssa_exprt ssa_exprt::get_l1_object() const

--- a/src/util/ssa_expr.h
+++ b/src/util/ssa_expr.h
@@ -38,7 +38,7 @@ public:
   /// Replace the underlying, original expression by \p expr while maintaining
   /// SSA indices.
   /// \param expr: expression to store
-  void set_expression(const exprt &expr);
+  void set_expression(exprt expr);
 
   irep_idt get_object_name() const;
 


### PR DESCRIPTION
valgrind --tool=dhat reports these as heap allocations that only have a
lifetime of a few hundred instructions, or even less than 100.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [x] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
