### PR TITLE
add support for parsing SMT-LIB2 to_fp

### DIFF
--- a/regression/smt2_solver/fp/basic-fp1.desc
+++ b/regression/smt2_solver/fp/basic-fp1.desc
@@ -1,0 +1,7 @@
+CORE
+basic-fp1.smt2
+
+^EXIT=0$
+^SIGNAL=0$
+^unsat$
+--

--- a/regression/smt2_solver/fp/basic-fp1.smt2
+++ b/regression/smt2_solver/fp/basic-fp1.smt2
@@ -1,0 +1,9 @@
+(set-logic FP)
+
+(define-fun Areal () (_ FloatingPoint 11 53) ((_ to_fp 11 53) roundNearestTiesToEven 1.185043))
+(define-fun Ahexa () (_ FloatingPoint 11 53) (fp #b0 #b01111111111 #x2f5efa615a8df))
+
+; should be the same
+(assert (not (= Areal Ahexa)))
+
+(check-sat)

--- a/src/solvers/smt2/smt2_parser.cpp
+++ b/src/solvers/smt2/smt2_parser.cpp
@@ -684,6 +684,60 @@ exprt smt2_parsert::function_application()
           else
             return nil_exprt();
         }
+        else if(id == "to_fp")
+        {
+          if(next_token() != smt2_tokenizert::NUMERAL)
+            throw error("expected number after to_fp");
+
+          auto width_e = std::stoll(smt2_tokenizer.get_buffer());
+
+          if(next_token() != smt2_tokenizert::NUMERAL)
+            throw error("expected second number after to_fp");
+
+          auto width_f = std::stoll(smt2_tokenizer.get_buffer());
+
+          if(next_token() != smt2_tokenizert::CLOSE)
+            throw error("expected ')' after to_fp");
+
+          auto rounding_mode = expression();
+
+          if(next_token() != smt2_tokenizert::NUMERAL)
+            throw error("expected number after to_fp");
+
+          auto real_number = smt2_tokenizer.get_buffer();
+
+          if(next_token() != smt2_tokenizert::CLOSE)
+            throw error("expected ')' at the end of to_fp");
+
+          mp_integer significand, exponent;
+
+          auto dot_pos = real_number.find('.');
+          if(dot_pos == std::string::npos)
+          {
+            exponent = 0;
+            significand = string2integer(real_number);
+          }
+          else
+          {
+            // remove the '.', if any
+            std::string significand_str;
+            significand_str.reserve(real_number.size());
+            for(auto ch : real_number)
+              if(ch != '.')
+                significand_str += ch;
+
+            exponent = mp_integer(dot_pos) - mp_integer(real_number.size()) + 1;
+            significand = string2integer(significand_str);
+          }
+
+          // width_f *includes* the hidden bit
+          ieee_float_spect spec(width_f - 1, width_e);
+          ieee_floatt a(spec);
+          a.rounding_mode = static_cast<ieee_floatt::rounding_modet>(
+            numeric_cast_v<int>(to_constant_expr(rounding_mode)));
+          a.from_base10(significand, exponent);
+          return a.to_expr();
+        }
         else
         {
           throw error() << "unknown indexed identifier '"


### PR DESCRIPTION
This adds support for parsing SMT-LIB2 `to_fp` expressions that use a numeral.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [X] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
