### PR TITLE
Fix nuget version to 5.8.x

### DIFF
--- a/.github/workflows/pull-request-checks.yaml
+++ b/.github/workflows/pull-request-checks.yaml
@@ -258,7 +258,7 @@ jobs:
           submodules: recursive
       - uses: nuget/setup-nuget@v1
         with:
-          nuget-version: 'latest'
+          nuget-version: '5.8.x'
       - name: Fetch dependencies
         run: |
           choco install winflexbison3
@@ -305,7 +305,7 @@ jobs:
           submodules: recursive
       - uses: nuget/setup-nuget@v1
         with:
-          nuget-version: 'latest'
+          nuget-version: '5.8.x'
       - name: Fetch dependencies
         run: |
           choco install winflexbison3 strawberryperl
@@ -408,7 +408,7 @@ jobs:
           submodules: recursive
       - uses: nuget/setup-nuget@v1
         with:
-          nuget-version: 'latest'
+          nuget-version: '5.8.x'
       - name: Fetch dependencies
         run: |
           choco install winflexbison3

--- a/.github/workflows/release-packages.yaml
+++ b/.github/workflows/release-packages.yaml
@@ -150,7 +150,7 @@ jobs:
           submodules: recursive
       - uses: nuget/setup-nuget@v1
         with:
-          nuget-version: 'latest'
+          nuget-version: '5.8.x'
       - name: Fetch dependencies
         run: |
           choco install winflexbison3


### PR DESCRIPTION
Previously, we had an issue where the latest default version of
nuget in github actions was broken and couldn't install dependencies.
This was fixed (temporarily) by #6054 when the latest version
installed by setup-nuget was 5.8.1. This has now changed to also
install the bugged version (5.9.x) by default, giving us problems.

These are now solved by temporarily fixing the version of nuget
to a known working version (according to multiple reports online,
and evidence of our own CI logs).

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
