### PR TITLE
Enforce purity on missing assigns clause

### DIFF
--- a/regression/contracts/assigns_enforce_05/test.desc
+++ b/regression/contracts/assigns_enforce_05/test.desc
@@ -1,9 +1,11 @@
 CORE
 main.c
 --enforce-all-contracts
-^EXIT=10$
+^EXIT=0$
 ^SIGNAL=0$
-^VERIFICATION FAILED$
+^\[f1.1\] line \d+ .*: SUCCESS$
+^VERIFICATION SUCCESSFUL$
 --
 --
-This test checks that verification fails when a function with an assigns clause calls a function without an assigns clause.
+This test checks that verification succeeds when enforcing a contract
+for functions, without assigns clauses, that don't modify anything.

--- a/regression/contracts/assigns_enforce_15/main.c
+++ b/regression/contracts/assigns_enforce_15/main.c
@@ -1,0 +1,29 @@
+int global = 0;
+
+int foo(int *x) __CPROVER_assigns(*x)
+  __CPROVER_ensures(__CPROVER_return_value == *x + 5)
+{
+  int z = 5;
+  int y = bar(&z);
+  return *x + 5;
+}
+
+int bar(int *a) __CPROVER_ensures(__CPROVER_return_value >= 5)
+{
+  *a = *a + 2;
+  return *a;
+}
+
+int baz() __CPROVER_ensures(__CPROVER_return_value == global)
+{
+  global = global + 1;
+  return global;
+}
+
+int main()
+{
+  int n;
+  n = foo(&n);
+  n = baz();
+  return 0;
+}

--- a/regression/contracts/assigns_enforce_15/test.desc
+++ b/regression/contracts/assigns_enforce_15/test.desc
@@ -1,0 +1,12 @@
+CORE
+main.c
+--enforce-all-contracts
+^EXIT=10$
+^SIGNAL=0$
+^\[bar.1\] line \d+ .*: FAILURE$
+^\[baz.1\] line \d+ .*: FAILURE$
+^VERIFICATION FAILED$
+--
+--
+Checks whether verification fails when enforcing a contract
+for functions, without assigns clauses, that modify an input.

--- a/regression/contracts/function_check_02/main.c
+++ b/regression/contracts/function_check_02/main.c
@@ -4,10 +4,16 @@
 // A known bug (resolved in PR #2278) causes the use of quantifiers
 // in ensures to fail.
 
+// clang-format off
 int initialize(int *arr)
+  __CPROVER_assigns(*arr)
   __CPROVER_ensures(
-    __CPROVER_forall {int i; (0 <= i && i < 10) ==> arr[i] == i}
+    __CPROVER_forall {
+      int i;
+      (0 <= i && i < 10) ==> arr[i] == i
+    }
   )
+// clang-format on
 {
   for(int i = 0; i < 10; i++)
   {

--- a/regression/contracts/quantifiers-exists-ensures-01/main.c
+++ b/regression/contracts/quantifiers-exists-ensures-01/main.c
@@ -1,8 +1,10 @@
 // clang-format off
-int f1(int *arr) __CPROVER_ensures(__CPROVER_exists {
-  int i;
-  (0 <= i && i < 10) ==> arr[i] == i
-})
+int f1(int *arr)
+  __CPROVER_assigns(*arr)
+  __CPROVER_ensures(__CPROVER_exists {
+    int i;
+    (0 <= i && i < 10) ==> arr[i] == i
+  })
 // clang-format on
 {
   for(int i = 0; i < 10; i++)

--- a/regression/contracts/quantifiers-forall-ensures-01/main.c
+++ b/regression/contracts/quantifiers-forall-ensures-01/main.c
@@ -1,8 +1,10 @@
 // clang-format off
-int f1(int *arr) __CPROVER_ensures(__CPROVER_forall {
-  int i;
-  (0 <= i && i < 10) ==> arr[i] == 0
-})
+int f1(int *arr)
+  __CPROVER_assigns(*arr)
+  __CPROVER_ensures(__CPROVER_forall {
+    int i;
+    (0 <= i && i < 10) ==> arr[i] == 0
+  })
 // clang-format on
 {
   for(int i = 0; i < 10; i++)

--- a/regression/contracts/quantifiers-nested-01/main.c
+++ b/regression/contracts/quantifiers-nested-01/main.c
@@ -1,12 +1,14 @@
 // clang-format off
-int f1(int *arr) __CPROVER_ensures(__CPROVER_forall {
-  int i;
-  __CPROVER_forall
-  {
-    int j;
-    (0 <= i && i < 10 && i <= j && j < 10) ==> arr[i] <= arr[j]
-  }
-})
+int f1(int *arr)
+  __CPROVER_assigns(*arr)
+  __CPROVER_ensures(__CPROVER_forall {
+    int i;
+    __CPROVER_forall
+    {
+      int j;
+      (0 <= i && i < 10 && i <= j && j < 10) ==> arr[i] <= arr[j]
+    }
+  })
 // clang-format on
 {
   for(int i = 0; i < 10; i++)

--- a/regression/contracts/quantifiers-nested-03/main.c
+++ b/regression/contracts/quantifiers-nested-03/main.c
@@ -1,4 +1,4 @@
-int f1(int *arr)
+int f1(int *arr) __CPROVER_assigns(*arr)
   __CPROVER_ensures(__CPROVER_return_value == 0 && __CPROVER_exists {
     int i;
     (0 <= i && i < 10) && arr[i] == i


### PR DESCRIPTION
CBMC currently doesn't enforce assigns clauses if there isn't one.
However, whenever enforcing a function contract, the absence of an
assigns clause should be interpreted as an empty write set
(i.e., no inputs will be modified by this function).
CBMC now properly checks for empty assigns clause behavior.

Signed-off-by: Felipe R. Monteiro <felisous@amazon.com>

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
