### PR TITLE
Add CMake support for building and linking against CaDiCaL using the IPASIR interface

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,7 +81,7 @@ set(enable_cbmc_tests on CACHE BOOL "Whether CBMC tests should be enabled")
 
 set(sat_impl "minisat2" CACHE STRING
     "This setting controls the SAT library which is used. Valid values are
-    'minisat2', 'glucose', or 'cadical'"
+    'minisat2', 'glucose', 'cadical' or 'ipasir-cadical'"
 )
 
 if(${enable_cbmc_tests})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,7 +81,7 @@ set(enable_cbmc_tests on CACHE BOOL "Whether CBMC tests should be enabled")
 
 set(sat_impl "minisat2" CACHE STRING
     "This setting controls the SAT library which is used. Valid values are
-    'minisat2', 'glucose', 'cadical' or 'ipasir-cadical'"
+    'minisat2', 'glucose', 'cadical', 'ipasir-cadical' or 'ipasir-custom'"
 )
 
 if(${enable_cbmc_tests})

--- a/COMPILING.md
+++ b/COMPILING.md
@@ -467,9 +467,21 @@ Note that at the time of writing this has been tested to work with the CaDiCaL
 It's also possible to build CBMC using CaDiCaL through IPASIR via `cmake`,
 controlled with the flag `-Dsat_impl=ipasir-cadical`, like so:
 
-```
+```sh
 $ cmake -Bbuild_ipasir -S. -Dsat_impl=ipasir-cadical
 ```
+
+An advanced user may also take a more adventurous route, trying to link
+CBMC against any solver supporthing the IPASIR interface. To do that,
+an invocation like this is needed:
+
+```sh
+$ cmake -Bbuild_ipasir -S . -Dsat_impl=ipasir-custom -DIPASIR=<source_location> -DIPASIR_LIB=<lib_location>
+```
+
+with `<source_location>` being the absolute path to the folder containing
+the solver implementation and `<lib_location>` being the absolute path that
+contains a precompiled static library of the solver (`.a` file).
 
 #### Compiling with Riss via IPASIR
 

--- a/COMPILING.md
+++ b/COMPILING.md
@@ -462,6 +462,15 @@ Note that at the time of writing this has been tested to work with the CaDiCaL
    the IPASIR headers, which is needed for the cbmc includes of `ipasir.h`. The
    compiled binary will be placed in `cbmc/src/cbmc/cbmc`.
 
+---
+
+It's also possible to build CBMC using CaDiCaL through IPASIR via `cmake`,
+controlled with the flag `-Dsat_impl=ipasir-cadical`, like so:
+
+```
+$ cmake -Bbuild_ipasir -S. -Dsat_impl=ipasir-cadical
+```
+
 #### Compiling with Riss via IPASIR
 
 The [Riss](https://github.com/conp-solutions/riss) solver supports the

--- a/src/solvers/CMakeLists.txt
+++ b/src/solvers/CMakeLists.txt
@@ -160,6 +160,38 @@ elseif("${sat_impl}" STREQUAL "ipasir-cadical")
         ${cadical_SOURCE_DIR}/src
     )
     target_link_libraries(solvers cadical_ipasir)
+elseif("${sat_impl}" STREQUAL "ipasir-custom")
+    message(STATUS "Building with IPASIR solver linking: custom solver provided")
+
+    if (NOT DEFINED IPASIR)
+        message(FATAL_ERROR
+          "IPASIR solver source code not provided. Please use -DIPASIR=<location> "
+          "with <location> being the path to the IPASIR solver source code."
+        )
+    endif()
+
+    if (NOT DEFINED IPASIR_LIB)
+        message(FATAL_ERROR
+            "IPASIR solver library not provided. Please use -DIPASIR_LIB=<location> "
+            "with <location> being the path to the IPASIR solver precompiled static "
+            "library."
+        )
+    endif()
+
+    target_compile_definitions(solvers PUBLIC
+        SATCHECK_IPASIR HAVE_IPASIR IPASIR=${IPASIR}
+    )
+
+    add_library(ipasir_custom STATIC IMPORTED)
+    set_property(TARGET ipasir_custom
+        PROPERTY IMPORTED_LOCATION ${IPASIR_LIB}
+    )
+
+    target_include_directories(solvers
+        PUBLIC
+        ${IPASIR}
+    )
+    target_link_libraries(solvers ipasir_custom pthread)
 endif()
 
 if(CMAKE_USE_CUDD)

--- a/src/solvers/CMakeLists.txt
+++ b/src/solvers/CMakeLists.txt
@@ -38,6 +38,10 @@ set(booleforce_source
 set(minibdd_source
     ${CMAKE_CURRENT_SOURCE_DIR}/bdd/miniBDD/example.cpp
 )
+set(ipasir_source
+    ${CMAKE_CURRENT_SOURCE_DIR}/sat/satcheck_ipasir.cpp
+)
+
 
 file(GLOB_RECURSE sources "*.cpp" "*.h")
 list(REMOVE_ITEM sources
@@ -51,6 +55,7 @@ list(REMOVE_ITEM sources
     ${lingeling_source}
     ${booleforce_source}
     ${minibdd_source}
+    # ${ipasir_source}
 )
 
 add_library(solvers ${sources})
@@ -128,6 +133,33 @@ elseif("${sat_impl}" STREQUAL "cadical")
     )
 
     target_link_libraries(solvers cadical)
+elseif("${sat_impl}" STREQUAL "ipasir-cadical")
+    message(STATUS "Building with IPASIR solver linking against: CaDiCaL")
+
+    download_project(PROJ cadical
+        URL https://github.com/arminbiere/cadical/archive/rel-1.4.0.tar.gz
+        PATCH_COMMAND true
+        COMMAND ./configure CXX=g++
+        URL_MD5 9bad586a82995a1d95d1197d445a353a
+    )
+
+    message(STATUS "Building CaDiCaL")
+    execute_process(COMMAND make WORKING_DIRECTORY ${cadical_SOURCE_DIR})
+
+    target_compile_definitions(solvers PUBLIC
+        SATCHECK_IPASIR HAVE_IPASIR IPASIR=${cadical_SOURCE_DIR}/src
+    )
+
+    add_library(cadical_ipasir STATIC IMPORTED)
+    set_property(TARGET cadical_ipasir
+        PROPERTY IMPORTED_LOCATION ${cadical_SOURCE_DIR}/build/libcadical.a
+    )
+
+    target_include_directories(solvers
+        PUBLIC
+        ${cadical_SOURCE_DIR}/src
+    )
+    target_link_libraries(solvers cadical_ipasir)
 endif()
 
 if(CMAKE_USE_CUDD)


### PR DESCRIPTION
Expand the CMake build to be able to link against IPASIR supporting solvers. Two
new solver configurations have been added:

* CaDiCaL, which should be easy to compile against (`-Dsat_impl=ipasir_cadical` will handle downloading, building and linking against the solver), and
* Any arbitrary solver supporting the IPASIR interface (for the more ~adventurous~ demanding users, who may want to link against a different variety of solvers). This is more involved as an option (requires a number of different flags to be passed to CMake).

This expands our configuration options significantly. Previously, we could do one of two things:
  
  * Build with `cmake` using the internal CaDiCaL interface (`satcheck_cadical`), or
  * Build with `make` using the IPASIR interface.

This now allows us to build using both of the build systems, and link with a number of different solvers, for both testing and production use.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [x] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
