### PR TITLE
Check for validity of pointers in assigns clause

### DIFF
--- a/regression/contracts/assigns_replace_03/test.desc
+++ b/regression/contracts/assigns_replace_03/test.desc
@@ -1,4 +1,4 @@
-CORE
+KNOWNBUG
 main.c
 --replace-all-calls-with-contracts
 ^EXIT=0$
@@ -7,3 +7,7 @@ main.c
 --
 --
 This test checks that a havocked variable can be constrained by a function post-condition.
+
+Known Bug:
+Currently, there is a bug when char variables are being passed to
+__CPROVER_w_ok(). See GitHub issue #6106 for further details.

--- a/regression/contracts/assigns_validity_pointer_01/main.c
+++ b/regression/contracts/assigns_validity_pointer_01/main.c
@@ -1,0 +1,36 @@
+#include <assert.h>
+#include <stddef.h>
+
+int *z;
+
+void bar(int *x, int *y) __CPROVER_assigns(*x, *y) __CPROVER_requires(*x > 0)
+  __CPROVER_ensures(*x == 3 && (y == NULL || *y == 5))
+{
+  *x = 3;
+  if(y != NULL)
+    *y = 5;
+}
+
+void baz() __CPROVER_assigns(*z) __CPROVER_ensures(z == NULL || *z == 7)
+{
+  if(z != NULL)
+    *z = 7;
+}
+
+void foo(int *x) __CPROVER_assigns(*x) __CPROVER_requires(*x > 0)
+  __CPROVER_ensures(*x == 3)
+{
+  bar(x, NULL);
+  z == NULL;
+  baz();
+}
+
+int main()
+{
+  int n;
+  foo(&n);
+
+  assert(n == 3);
+  assert(z == NULL || *z == 7);
+  return 0;
+}

--- a/regression/contracts/assigns_validity_pointer_01/test.desc
+++ b/regression/contracts/assigns_validity_pointer_01/test.desc
@@ -1,0 +1,29 @@
+CORE
+main.c
+--enforce-contract foo --replace-call-with-contract bar --replace-call-with-contract baz
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+SUCCESS
+// bar
+ASSERT \*x > 0
+IF !\(\*x == 3\) THEN GOTO \d
+IF !\(\(signed int \*\)\(void \*\)0 == \(\(signed int \*\)NULL\)\) THEN GOTO \d
+tmp_if_expr = \*\(\(signed int \*\)\(void \*\)0\) == 5 \? TRUE \: FALSE;
+tmp_if_expr\$\d = tmp_if_expr \? TRUE : FALSE;
+ASSUME tmp_if_expr\$\d
+// baz
+IF !\(z == \(\(signed int \*\)NULL\)\) THEN GOTO \d
+tmp_if_expr\$\d = \*z == 7 \? TRUE : FALSE;
+ASSUME tmp_if_expr\$\d
+// foo
+ASSUME \*tmp_cc\$\d > 0
+ASSERT \*tmp_cc\$\d == 3
+--
+\[3\] file main\.c line 6 assertion: FAILURE
+--
+Verification:
+This test checks support for a NULL pointer that is assigned to by
+a function (bar and baz). Both functions bar and baz are being replaced by
+their function contracts, while the calling function foo is being checked
+(by enforcing it's function contracts).

--- a/regression/contracts/assigns_validity_pointer_02/main.c
+++ b/regression/contracts/assigns_validity_pointer_02/main.c
@@ -1,0 +1,36 @@
+#include <assert.h>
+#include <stddef.h>
+
+int *z;
+
+void bar(int *x, int *y) __CPROVER_assigns(*x, *y) __CPROVER_requires(*x > 0)
+  __CPROVER_ensures(*x == 3 && (y == NULL || *y == 5))
+{
+  *x = 3;
+  if(y != NULL)
+    *y = 5;
+}
+
+void baz() __CPROVER_assigns(*z) __CPROVER_ensures(z == NULL || *z == 7)
+{
+  if(z != NULL)
+    *z = 7;
+}
+
+void foo(int *x) __CPROVER_assigns(*x) __CPROVER_requires(*x > 0)
+  __CPROVER_ensures(*x == 3)
+{
+  bar(x, NULL);
+  *x = 3;
+  z == NULL;
+  baz();
+}
+
+int main()
+{
+  int n;
+  foo(&n);
+
+  assert(n == 3);
+  return 0;
+}

--- a/regression/contracts/assigns_validity_pointer_02/test.desc
+++ b/regression/contracts/assigns_validity_pointer_02/test.desc
@@ -1,0 +1,19 @@
+CORE
+main.c
+--enforce-contract foo
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+//^([foo\.1] line 15 assertion: FAILURE)
+// foo
+ASSUME \*tmp_cc\$\d > 0
+ASSERT \*tmp_cc\$\d == 3
+--
+\[foo\.1\] line 24 assertion: FAILURE
+\[foo\.3\] line 27 assertion: FAILURE
+--
+Verification:
+This test checks support for a NULL pointer that is assigned to by
+a function (bar and baz). The calling function foo is being checked
+(by enforcing it's function contracts). As for bar and baz, their
+function contracts are ot being considered for this test.

--- a/regression/contracts/assigns_validity_pointer_03/main.c
+++ b/regression/contracts/assigns_validity_pointer_03/main.c
@@ -1,0 +1,33 @@
+#include <assert.h>
+#include <stddef.h>
+
+int *z;
+
+void bar(int *x, int *y) __CPROVER_assigns(*x, *y) __CPROVER_requires(*x > 0)
+  __CPROVER_ensures(*x == 3 && *y == 5)
+{
+}
+
+void baz() __CPROVER_assigns(*z) __CPROVER_ensures(*z == 7)
+{
+}
+
+void foo(int *x) __CPROVER_assigns(*x) __CPROVER_requires(*x > 0)
+  __CPROVER_ensures(*x == 3)
+{
+  int *y;
+  bar(x, y);
+  assert(*y == 5);
+
+  baz();
+  assert(*z == 7);
+}
+
+int main()
+{
+  int n;
+  foo(&n);
+
+  assert(n == 3);
+  return 0;
+}

--- a/regression/contracts/assigns_validity_pointer_03/test.desc
+++ b/regression/contracts/assigns_validity_pointer_03/test.desc
@@ -1,0 +1,28 @@
+KNOWNBUG
+main.c
+--enforce-contract foo --replace-call-with-contract bar --replace-call-with-contract baz
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+// bar
+ASSERT \*x > 0
+IF !\(\*x == 3\) THEN GOTO \d
+tmp_if_expr = \*y == 5 \? TRUE \: FALSE;
+ASSUME tmp_if_expr
+// baz
+ASSUME \*z == 7
+// foo
+ASSUME \*tmp_cc\$\d > 0
+ASSERT \*tmp_cc\$\d == 3
+--
+--
+Verification:
+This test checks support for an uninitialized pointer that is assigned to by
+a function (bar and baz). Both functions bar and baz are being replaced by
+their function contracts, while the calling function foo is being checked
+(by enforcing it's function contracts).
+
+Known Bug:
+Currently, there is a known issue with __CPROVER_w_ok(ptr, 0) such that it
+returns true if ptr is uninitialized. This is not the expected behavior,
+therefore, the outcome of this test case is currently incorrect.

--- a/regression/contracts/assigns_validity_pointer_04/main.c
+++ b/regression/contracts/assigns_validity_pointer_04/main.c
@@ -1,0 +1,34 @@
+#include <assert.h>
+#include <stddef.h>
+
+int *z;
+
+void bar(int *x, int *y) __CPROVER_assigns(*x, *y) __CPROVER_requires(*x > 0)
+  __CPROVER_ensures(*x == 3 && *y == 5)
+{
+}
+
+void baz() __CPROVER_assigns(*z) __CPROVER_ensures(*z == 7)
+{
+}
+
+void foo(int *x) __CPROVER_assigns(*x) __CPROVER_requires(*x > 0)
+  __CPROVER_ensures(*x == 3)
+{
+  int *y = malloc(sizeof(int));
+  bar(x, y);
+  assert(*y == 5);
+
+  z = malloc(sizeof(int));
+  baz();
+  assert(*z == 7);
+}
+
+int main()
+{
+  int n;
+  foo(&n);
+
+  assert(n == 3);
+  return 0;
+}

--- a/regression/contracts/assigns_validity_pointer_04/test.desc
+++ b/regression/contracts/assigns_validity_pointer_04/test.desc
@@ -1,0 +1,23 @@
+CORE
+main.c
+--enforce-contract foo --replace-call-with-contract bar --replace-call-with-contract baz
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+// bar
+ASSERT \*x > 0
+IF !\(\*x == 3\) THEN GOTO \d
+tmp_if_expr = \*y == 5 \? TRUE \: FALSE;
+ASSUME tmp_if_expr
+// baz
+ASSUME \*z == 7
+// foo
+ASSUME \*tmp_cc\$\d > 0
+ASSERT \*tmp_cc\$\d == 3
+--
+--
+Verification:
+This test checks support for a malloced pointer that is assigned to by
+a function (bar and baz). Both functions bar and baz are being replaced by
+their function contracts, while the calling function foo is being checked
+(by enforcing it's function contracts).


### PR DESCRIPTION
Consider the following example:

```
void bar(int *x, int *y) __CPROVER_assigns(*x, *y)
{
  *x = 3;
  if(y != NULL)
    *y = 5;
}

void foo(int *x) __CPROVER_assigns(*x)
{
  bar(x, NULL);
  *x = 3;
}
```

The potential problem in this case is that `foo` calls `bar` by passing a null pointer. Of course, considering the contents of `bar`, this will not be problematic. However, the assigns clause for `bar` is not aware of what is inside `bar`, so the assigns clause previously could not handle the null pointer.

This PR adds support for such cases, by checking for passed null pointers at the goto program level.

**Note:** currently, this PR only supports pointers, which is required for function contracts for the [coreJSON](https://github.com/FreeRTOS/coreJSON) project.


<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [x] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [x] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
