### PR TITLE
Remove no-op handling of non-existent dynamic_size expression

### DIFF
--- a/src/analyses/invariant_set.cpp
+++ b/src/analyses/invariant_set.cpp
@@ -1014,9 +1014,6 @@ void invariant_sett::modifies(const exprt &lhs)
   else if(lhs.id()=="valid_object")
   {
   }
-  else if(lhs.id()=="dynamic_size")
-  {
-  }
   else if(lhs.id()==ID_byte_extract_little_endian ||
           lhs.id()==ID_byte_extract_big_endian)
   {

--- a/src/pointer-analysis/value_set.cpp
+++ b/src/pointer-analysis/value_set.cpp
@@ -1391,7 +1391,6 @@ void value_sett::assign_rec(
       add_to_sets);
   }
   else if(lhs.id()=="valid_object" ||
-          lhs.id()=="dynamic_size" ||
           lhs.id()=="dynamic_type" ||
           lhs.id()=="is_zero_string" ||
           lhs.id()=="zero_string" ||

--- a/src/pointer-analysis/value_set_fi.cpp
+++ b/src/pointer-analysis/value_set_fi.cpp
@@ -1219,7 +1219,6 @@ void value_set_fit::assign_rec(
       recursion_set);
   }
   else if(lhs.id()=="valid_object" ||
-          lhs.id()=="dynamic_size" ||
           lhs.id()=="dynamic_type")
   {
     // we ignore this here


### PR DESCRIPTION
There is no code that creates an expression with id "dynamic_size" and
the three places handling this id just did nothing.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
