### PR TITLE
Deprecate unnecessary dynamic_size pointer predicate

### DIFF
--- a/src/util/pointer_predicates.cpp
+++ b/src/util/pointer_predicates.cpp
@@ -91,34 +91,18 @@ exprt good_pointer_def(
   const auto size_of_expr_opt = size_of_expr(dereference_type, ns);
   CHECK_RETURN(size_of_expr_opt.has_value());
 
-  const or_exprt good_dynamic_tmp1(
-    not_exprt(malloc_object(pointer, ns)),
-    and_exprt(
-      not_exprt(dynamic_object_lower_bound(pointer, nil_exprt())),
-      not_exprt(
-        dynamic_object_upper_bound(pointer, ns, size_of_expr_opt.value()))));
-
-  const and_exprt good_dynamic_tmp2(
-    not_exprt(deallocated(pointer, ns)), good_dynamic_tmp1);
-
   const or_exprt good_dynamic(
-    not_exprt(dynamic_object(pointer)), good_dynamic_tmp2);
+    not_exprt(dynamic_object(pointer)), not_exprt(deallocated(pointer, ns)));
 
   const not_exprt not_null(null_pointer(pointer));
 
   const not_exprt not_invalid{is_invalid_pointer_exprt{pointer}};
 
-  const or_exprt bad_other(
-    object_lower_bound(pointer, nil_exprt()),
-    object_upper_bound(pointer, size_of_expr_opt.value()));
+  const and_exprt good_bounds{
+    not_exprt{object_lower_bound(pointer, nil_exprt())},
+    not_exprt{object_upper_bound(pointer, size_of_expr_opt.value())}};
 
-  const or_exprt good_other(dynamic_object(pointer), not_exprt(bad_other));
-
-  return and_exprt(
-    not_null,
-    not_invalid,
-    good_dynamic,
-    good_other);
+  return and_exprt(not_null, not_invalid, good_dynamic, good_bounds);
 }
 
 exprt null_object(const exprt &pointer)

--- a/src/util/pointer_predicates.h
+++ b/src/util/pointer_predicates.h
@@ -12,6 +12,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #ifndef CPROVER_UTIL_POINTER_PREDICATES_H
 #define CPROVER_UTIL_POINTER_PREDICATES_H
 
+#include "deprecate.h"
 #include "std_expr.h"
 
 #define SYMEX_DYNAMIC_PREFIX "symex_dynamic::"
@@ -19,6 +20,7 @@ Author: Daniel Kroening, kroening@kroening.com
 exprt same_object(const exprt &p1, const exprt &p2);
 exprt deallocated(const exprt &pointer, const namespacet &);
 exprt dead_object(const exprt &pointer, const namespacet &);
+DEPRECATED(SINCE(2021, 5, 6, "Use object_size instead"))
 exprt dynamic_size(const namespacet &);
 exprt pointer_offset(const exprt &pointer);
 exprt pointer_object(const exprt &pointer);
@@ -30,9 +32,11 @@ exprt good_pointer_def(const exprt &pointer, const namespacet &);
 exprt null_object(const exprt &pointer);
 exprt null_pointer(const exprt &pointer);
 exprt integer_address(const exprt &pointer);
+DEPRECATED(SINCE(2021, 5, 6, "Use object_lower_bound instead"))
 exprt dynamic_object_lower_bound(
   const exprt &pointer,
   const exprt &offset);
+DEPRECATED(SINCE(2021, 5, 6, "Use object_upper_bound instead"))
 exprt dynamic_object_upper_bound(
   const exprt &pointer,
   const namespacet &,


### PR DESCRIPTION
As of 11431ea80 all uses of `dynamic_size` can safely be replaced by
`object_size`. The remaining uses in goto_check.cpp will be removed in a
separate commit.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
