### PR TITLE
Detect use of alloca-allocated object after leaving its scope

### DIFF
--- a/regression/cbmc-library/alloca-02/main.c
+++ b/regression/cbmc-library/alloca-02/main.c
@@ -1,0 +1,19 @@
+#include <stdlib.h>
+
+#ifdef _WIN32
+void *alloca(size_t alloca_size);
+#endif
+
+int *foo()
+{
+  int *foo_ptr = alloca(sizeof(int));
+  return foo_ptr;
+}
+
+int main()
+{
+  int *from_foo = foo();
+  *from_foo = 42; // access to object that has gone out of scope
+
+  return 0;
+}

--- a/regression/cbmc-library/alloca-02/test.desc
+++ b/regression/cbmc-library/alloca-02/test.desc
@@ -1,0 +1,10 @@
+CORE
+main.c
+--pointer-check
+dereference failure: dead object in \*from_foo: FAILURE$
+^\*\* 1 of 6 failed
+^VERIFICATION FAILED$
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring

--- a/src/analyses/goto_check.cpp
+++ b/src/analyses/goto_check.cpp
@@ -2110,6 +2110,28 @@ void goto_checkt::goto_check(
               std::move(lhs), std::move(rhs), i.source_location));
           t->code_nonconst().add_source_location() = i.source_location;
         }
+
+        if(
+          variable.type().id() == ID_pointer &&
+          function_identifier != "alloca" &&
+          (ns.lookup(variable.get_identifier()).base_name ==
+             "return_value___builtin_alloca" ||
+           ns.lookup(variable.get_identifier()).base_name ==
+             "return_value_alloca"))
+        {
+          // mark pointer to alloca result as dead
+          exprt lhs = ns.lookup(CPROVER_PREFIX "dead_object").symbol_expr();
+          exprt alloca_result =
+            typecast_exprt::conditional_cast(variable, lhs.type());
+          if_exprt rhs(
+            side_effect_expr_nondett(bool_typet(), i.source_location),
+            std::move(alloca_result),
+            lhs);
+          goto_programt::targett t =
+            new_code.add(goto_programt::make_assignment(
+              std::move(lhs), std::move(rhs), i.source_location));
+          t->code_nonconst().add_source_location() = i.source_location;
+        }
       }
     }
     else if(i.is_end_function())


### PR DESCRIPTION
alloca-allocated objects need no longer be usable outside their scope.
Detect such use by non-deterministically setting __CPROVER_dead_object
to return_value___builtin_alloca.

This fixes the verification result for SV-COMP's
memsafety-ext3/getNumbers1-1.c.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
