### PR TITLE
add missing <algorithm> includes

### DIFF
--- a/src/analyses/variable-sensitivity/abstract_object_set.cpp
+++ b/src/analyses/variable-sensitivity/abstract_object_set.cpp
@@ -7,8 +7,11 @@
 \*******************************************************************/
 
 #include <analyses/variable-sensitivity/abstract_object_set.h>
+
 #include <util/interval.h>
 #include <util/string_utils.h>
+
+#include <algorithm>
 
 static bool by_length(const std::string &lhs, const std::string &rhs)
 {

--- a/src/analyses/variable-sensitivity/abstract_value_object.cpp
+++ b/src/analyses/variable-sensitivity/abstract_value_object.cpp
@@ -21,6 +21,8 @@
 #include <util/make_unique.h>
 #include <util/simplify_expr.h>
 
+#include <algorithm>
+
 class empty_index_ranget : public index_range_implementationt
 {
 public:

--- a/src/analyses/variable-sensitivity/context_abstract_object.cpp
+++ b/src/analyses/variable-sensitivity/context_abstract_object.cpp
@@ -10,6 +10,8 @@
 
 #include "abstract_object_statistics.h"
 
+#include <algorithm>
+
 abstract_object_pointert context_abstract_objectt::get_child() const
 {
   return child_abstract_object;

--- a/src/analyses/variable-sensitivity/value_set_abstract_object.cpp
+++ b/src/analyses/variable-sensitivity/value_set_abstract_object.cpp
@@ -16,6 +16,8 @@
 
 #include <util/make_unique.h>
 
+#include <algorithm>
+
 #include "abstract_environment.h"
 
 static index_range_implementation_ptrt

--- a/src/analyses/variable-sensitivity/value_set_abstract_value.cpp
+++ b/src/analyses/variable-sensitivity/value_set_abstract_value.cpp
@@ -11,6 +11,8 @@
 #include <ansi-c/expr2c.h>
 #include <util/simplify_expr.h>
 
+#include <algorithm>
+
 value_set_abstract_valuet::value_set_abstract_valuet(
   const typet &type,
   bool top,

--- a/src/analyses/variable-sensitivity/variable_sensitivity_domain.cpp
+++ b/src/analyses/variable-sensitivity/variable_sensitivity_domain.cpp
@@ -12,6 +12,8 @@ Date: April 2016
 
 #include <util/cprover_prefix.h>
 
+#include <algorithm>
+
 #ifdef DEBUG
 #  include <iostream>
 #endif

--- a/src/analyses/variable-sensitivity/write_location_context.cpp
+++ b/src/analyses/variable-sensitivity/write_location_context.cpp
@@ -8,6 +8,8 @@
 
 #include "write_location_context.h"
 
+#include <algorithm>
+
 /**
  * Update the location context for an abstract object, potentially
  * propagating the update to any children of this abstract object.

--- a/src/goto-harness/goto_harness_parse_options.cpp
+++ b/src/goto-harness/goto_harness_parse_options.cpp
@@ -8,6 +8,7 @@ Author: Diffblue Ltd.
 
 #include "goto_harness_parse_options.h"
 
+#include <algorithm>
 #include <fstream>
 #include <set>
 #include <string>

--- a/src/goto-instrument/cover_instrument_other.cpp
+++ b/src/goto-instrument/cover_instrument_other.cpp
@@ -15,6 +15,8 @@ Author: Daniel Kroening
 
 #include <langapi/language_util.h>
 
+#include <algorithm>
+
 void cover_path_instrumentert::instrument(
   const irep_idt &,
   goto_programt &,

--- a/src/goto-programs/ensure_one_backedge_per_target.cpp
+++ b/src/goto-programs/ensure_one_backedge_per_target.cpp
@@ -13,6 +13,8 @@ Author: Diffblue Ltd.
 
 #include "goto_model.h"
 
+#include <algorithm>
+
 static bool location_number_less_than(
   const goto_programt::targett &a,
   const goto_programt::targett &b)


### PR DESCRIPTION
The `<algorithm>` include is required for `std::sort`, `std::transform` and
`std::find_if`.  This becomes apparent with g++ when using -D_GLIBCXX_DEBUG.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- n/a Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
