### PR TITLE
boolbv_index: preserve endianness when generating byte extract

### DIFF
--- a/regression/cbmc/member_bounds3/main.c
+++ b/regression/cbmc/member_bounds3/main.c
@@ -1,0 +1,22 @@
+#include <assert.h>
+
+#pragma pack(push, 1)
+struct S
+{
+  int a[2];
+  int x;
+};
+#pragma pack(pop)
+
+#ifdef _MSC_VER
+#  define _Static_assert(x, m) static_assert(x, m)
+#endif
+
+int main()
+{
+  int A[3];
+  _Static_assert(sizeof(A) == sizeof(struct S), "");
+  struct S *s = A;
+  A[2] = 42;
+  assert(s->a[2] == 42);
+}

--- a/regression/cbmc/member_bounds3/test.desc
+++ b/regression/cbmc/member_bounds3/test.desc
@@ -1,0 +1,8 @@
+CORE broken-smt-backend
+main.c
+--no-simplify
+^VERIFICATION SUCCESSFUL$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring

--- a/regression/cbmc/member_bounds4/main.c
+++ b/regression/cbmc/member_bounds4/main.c
@@ -1,0 +1,19 @@
+#include <assert.h>
+#include <inttypes.h>
+
+union U {
+  uint8_t a[4];
+};
+
+int main()
+{
+  uint32_t x[2] = {0xDEADBEEF, 0xDEADBEEF};
+  union U *u = x;
+  uint8_t c4 = u->a[4];
+
+  unsigned word = 1;
+  if(*(char *)&word == 1)
+    assert(c4 == 0xEF); // little endian
+  else
+    assert(c4 == 0xDE); // big endian
+}

--- a/regression/cbmc/member_bounds4/test.desc
+++ b/regression/cbmc/member_bounds4/test.desc
@@ -1,0 +1,8 @@
+CORE broken-smt-backend
+main.c
+--no-simplify
+^VERIFICATION SUCCESSFUL$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring


### PR DESCRIPTION
byte_extract(...)[index] translated to byte_extract expressions with
config-specified endianness rather than preserving the endianness of the
original byte_extract expression. This, however, is a hardly exercised
code path as the simplifier already did a similar transformation that
did preserve endianness.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
