### PR TITLE
[RFC] Two new failing tests demonstrating updates outside member bounds

### DIFF
--- a/regression/cbmc/member_bounds1/main.c
+++ b/regression/cbmc/member_bounds1/main.c
@@ -1,0 +1,24 @@
+#include <assert.h>
+
+#pragma pack(push, 1)
+struct S
+{
+  int a[2];
+  int x;
+};
+#pragma pack(pop)
+
+#ifdef _MSC_VER
+#  define _Static_assert(x, m) static_assert(x, m)
+#endif
+
+int main()
+{
+  int A[3];
+  _Static_assert(sizeof(A) == sizeof(struct S), "");
+  struct S *s = A;
+  s->a[2] = 42;
+  assert(*((int *)s + 2) == 42);
+  assert(s->x == 42);
+  assert(A[2] == 42);
+}

--- a/regression/cbmc/member_bounds1/test.desc
+++ b/regression/cbmc/member_bounds1/test.desc
@@ -1,0 +1,11 @@
+KNOWNBUG
+main.c
+--no-simplify
+^VERIFICATION SUCCESSFUL$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--
+This test passes when using the simplifier, but results in "WITH" expressions
+that update elements outside their bounds without the simplifier.

--- a/regression/cbmc/member_bounds1/test.desc
+++ b/regression/cbmc/member_bounds1/test.desc
@@ -1,6 +1,6 @@
-KNOWNBUG
+CORE broken-smt-backend
 main.c
---no-simplify
+--no-simplify --symex-no-member-bounds
 ^VERIFICATION SUCCESSFUL$
 ^EXIT=0$
 ^SIGNAL=0$
@@ -9,3 +9,5 @@ main.c
 --
 This test passes when using the simplifier, but results in "WITH" expressions
 that update elements outside their bounds without the simplifier.
+--symex-no-member-bounds ensures that such expressions are rewritten by
+goto-symex.

--- a/regression/cbmc/member_bounds2/main.c
+++ b/regression/cbmc/member_bounds2/main.c
@@ -1,0 +1,19 @@
+#include <assert.h>
+
+#pragma pack(push, 1)
+struct SU
+{
+  union {
+    int a[2];
+  } u;
+  int x;
+};
+#pragma pack(pop)
+
+int main()
+{
+  struct SU su;
+  su.u.a[2] = 42;
+  assert(*((int *)&su + 2) == 42);
+  assert(su.x == 42);
+}

--- a/regression/cbmc/member_bounds2/test.desc
+++ b/regression/cbmc/member_bounds2/test.desc
@@ -1,0 +1,13 @@
+KNOWNBUG
+main.c
+
+^VERIFICATION SUCCESSFUL$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--
+Field sensitivity makes it (currently) impossible to update bytes outside the
+particular field. One possible way to address this is rewriting subscripted
+array accesses to pointer dereferencing, as the C standard describes. Here, this
+would amount to using *(&su.u.a[0] + 2) instead of su.u.a[2].

--- a/scripts/expected_doxygen_warnings.txt
+++ b/scripts/expected_doxygen_warnings.txt
@@ -1,6 +1,6 @@
 warning: Include graph for 'goto_instrument_parse_options.cpp' not generated, too many nodes (93), threshold is 60. Consider increasing DOT_GRAPH_MAX_NODES.
 warning: Included by graph for 'goto_model.h' not generated, too many nodes (95), threshold is 60. Consider increasing DOT_GRAPH_MAX_NODES.
-warning: Included by graph for 'arith_tools.h' not generated, too many nodes (167), threshold is 60. Consider increasing DOT_GRAPH_MAX_NODES.
+warning: Included by graph for 'arith_tools.h' not generated, too many nodes (168), threshold is 60. Consider increasing DOT_GRAPH_MAX_NODES.
 warning: Included by graph for 'c_types.h' not generated, too many nodes (128), threshold is 60. Consider increasing DOT_GRAPH_MAX_NODES.
 warning: Included by graph for 'config.h' not generated, too many nodes (78), threshold is 60. Consider increasing DOT_GRAPH_MAX_NODES.
 warning: Included by graph for 'invariant.h' not generated, too many nodes (172), threshold is 60. Consider increasing DOT_GRAPH_MAX_NODES.

--- a/src/cbmc/cbmc_parse_options.cpp
+++ b/src/cbmc/cbmc_parse_options.cpp
@@ -345,6 +345,9 @@ void cbmc_parse_optionst::get_command_line_options(optionst &options)
   options.set_option(
     "symex-cache-dereferences", cmdline.isset("symex-cache-dereferences"));
 
+  options.set_option(
+    "symex-no-member-bounds", cmdline.isset("symex-no-member-bounds"));
+
   if(cmdline.isset("incremental-loop"))
   {
     options.set_option(

--- a/src/goto-checker/bmc_util.h
+++ b/src/goto-checker/bmc_util.h
@@ -197,6 +197,7 @@ void run_property_decider(
   "(unwind-max):" \
   "(ignore-properties-before-unwind-min)" \
   "(symex-cache-dereferences)" \
+  "(symex-no-member-bounds)" \
 
 #define HELP_BMC \
   " --paths [strategy]           explore paths one at a time\n" \
@@ -252,6 +253,7 @@ void run_property_decider(
   "                              gets blacklisted\n" \
   " --graphml-witness filename   write the witness in GraphML format to filename\n" /* NOLINT(*) */ \
   " --symex-cache-dereferences   enable caching of repeated dereferences" \
+  " --symex-no-member-bounds     support updates beyond bounds of a compound member" /* NOLINT(*) */ \
 // clang-format on
 
 #endif // CPROVER_GOTO_CHECKER_BMC_UTIL_H

--- a/src/goto-symex/symex_config.h
+++ b/src/goto-symex/symex_config.h
@@ -63,6 +63,10 @@ struct symex_configt final
   ///   Used in goto_symext::dereference_rec
   bool cache_dereferences;
 
+  /// Handle assignments beyond the bounds prescribed by a struct or array
+  /// access path. See tests in regression/cbmc/member_bounds* for examples.
+  bool updates_across_member_bounds;
+
   /// \brief Construct a symex_configt using options specified in an
   /// \ref optionst
   explicit symex_configt(const optionst &options);

--- a/src/goto-symex/symex_main.cpp
+++ b/src/goto-symex/symex_main.cpp
@@ -56,7 +56,9 @@ symex_configt::symex_configt(const optionst &options)
             : DEFAULT_MAX_FIELD_SENSITIVITY_ARRAY_SIZE),
     complexity_limits_active(
       options.get_signed_int_option("symex-complexity-limit") > 0),
-    cache_dereferences{options.get_bool_option("symex-cache-dereferences")}
+    cache_dereferences{options.get_bool_option("symex-cache-dereferences")},
+    updates_across_member_bounds{
+      options.get_bool_option("symex-no-member-bounds")}
 {
 }
 

--- a/src/solvers/lowering/byte_operators.cpp
+++ b/src/solvers/lowering/byte_operators.cpp
@@ -2057,11 +2057,7 @@ static exprt lower_byte_update(
       subtype = to_array_type(src.type()).subtype();
 
     auto element_width = pointer_offset_bits(*subtype, ns);
-    CHECK_RETURN(element_width.has_value());
-    CHECK_RETURN(*element_width > 0);
-    CHECK_RETURN(*element_width % 8 == 0);
-
-    if(*element_width == 8)
+    if(element_width.has_value() && *element_width == 8)
     {
       if(value_as_byte_array.id() != ID_array)
       {


### PR DESCRIPTION
These examples write to a member different from the access path being
used, yet within the object bounds.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
