### PR TITLE
Value sets: fix byte extracts from structs

### DIFF
--- a/regression/cbmc/Pointer_byte_extract8/main.c
+++ b/regression/cbmc/Pointer_byte_extract8/main.c
@@ -1,0 +1,58 @@
+#include <assert.h>
+#include <stdlib.h>
+
+#ifdef _MSC_VER
+#  define _Static_assert(x, m) static_assert(x, m)
+#endif
+
+struct list;
+
+typedef struct list list_nodet;
+
+list_nodet fill_node(signed int depth_tag_list);
+
+struct list
+{
+  int datum;
+  struct list *next;
+};
+
+int max_depth = 2;
+
+list_nodet *build_node(int depth)
+{
+  if(max_depth < depth)
+    return ((list_nodet *)NULL);
+  else
+  {
+    _Static_assert(sizeof(list_nodet) == 16, "");
+    list_nodet *result = malloc(16);
+
+    if(result)
+    {
+      *result = fill_node(depth + 1);
+    }
+    return result;
+  }
+}
+
+list_nodet fill_node(int depth)
+{
+  list_nodet result;
+  result.datum = depth;
+  result.next = build_node(depth);
+  return result;
+}
+
+int main()
+{
+  list_nodet *node = build_node(0);
+  int i = 0;
+  list_nodet *list_walker = node;
+  for(; list_walker; list_walker = list_walker->next)
+  {
+    i = i + 1;
+  }
+  assert(i == 3);
+  return 0;
+}

--- a/regression/cbmc/Pointer_byte_extract8/test.desc
+++ b/regression/cbmc/Pointer_byte_extract8/test.desc
@@ -1,0 +1,9 @@
+CORE
+main.c
+--64 --unwind 4 --unwinding-assertions
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring
+^CONVERSION ERROR$


### PR DESCRIPTION
Pointers may be contained in any member that's included in the byte
range being extracted, not just the one right at the offset that the
byte extract starts from.

Co-Authored-By: Petr Bauch <petr.bauch@gmail.com>

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
