### PR TITLE
Use simplify_exprtt::resultt in pre-order simplification steps

### DIFF
--- a/src/util/simplify_expr_array.cpp
+++ b/src/util/simplify_expr_array.cpp
@@ -10,6 +10,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "arith_tools.h"
 #include "byte_operators.h"
+#include "expr_util.h"
 #include "pointer_offset_size.h"
 #include "replace_expr.h"
 #include "std_expr.h"
@@ -196,22 +197,44 @@ simplify_exprt::simplify_index(const index_exprt &expr)
       return changed(simplify_byte_extract(result_expr));
     }
   }
-  else if(array.id()==ID_if)
-  {
-    const if_exprt &if_expr=to_if_expr(array);
-    exprt cond=if_expr.cond();
-
-    index_exprt idx_false=to_index_expr(expr);
-    idx_false.array()=if_expr.false_case();
-
-    new_expr.array() = if_expr.true_case();
-
-    exprt result = if_exprt(cond, new_expr, idx_false, expr.type());
-    return changed(simplify_rec(result));
-  }
 
   if(no_change)
     return unchanged(expr);
   else
     return std::move(new_expr);
+}
+
+simplify_exprt::resultt<>
+simplify_exprt::simplify_index_preorder(const index_exprt &expr)
+{
+  // lift up any ID_if on the array
+  if(expr.array().id() == ID_if)
+  {
+    if_exprt if_expr = lift_if(expr, 0);
+    return changed(simplify_if_preorder(if_expr));
+  }
+  else
+  {
+    optionalt<exprt::operandst> new_operands;
+
+    for(std::size_t i = 0; i < expr.operands().size(); ++i)
+    {
+      auto r_it = simplify_rec(expr.operands()[i]); // recursive call
+      if(r_it.has_changed())
+      {
+        if(!new_operands.has_value())
+          new_operands = expr.operands();
+        (*new_operands)[i] = std::move(r_it.expr);
+      }
+    }
+
+    if(new_operands.has_value())
+    {
+      exprt result = expr;
+      std::swap(result.operands(), *new_operands);
+      return result;
+    }
+  }
+
+  return unchanged(expr);
 }

--- a/src/util/simplify_expr_class.h
+++ b/src/util/simplify_expr_class.h
@@ -175,10 +175,16 @@ public:
   NODISCARD resultt<> simplify_with(const with_exprt &);
   NODISCARD resultt<> simplify_update(const update_exprt &);
   NODISCARD resultt<> simplify_index(const index_exprt &);
+  NODISCARD resultt<> simplify_index_preorder(const index_exprt &);
   NODISCARD resultt<> simplify_member(const member_exprt &);
+  NODISCARD resultt<> simplify_member_preorder(const member_exprt &);
   NODISCARD resultt<> simplify_byte_update(const byte_update_exprt &);
   NODISCARD resultt<> simplify_byte_extract(const byte_extract_exprt &);
+  NODISCARD resultt<>
+  simplify_byte_extract_preorder(const byte_extract_exprt &);
   NODISCARD resultt<> simplify_pointer_object(const pointer_object_exprt &);
+  NODISCARD resultt<>
+  simplify_unary_pointer_predicate_preorder(const unary_exprt &);
   NODISCARD resultt<> simplify_object_size(const object_size_exprt &);
   NODISCARD resultt<> simplify_is_dynamic_object(const unary_exprt &);
   NODISCARD resultt<> simplify_is_invalid_pointer(const unary_exprt &);
@@ -186,6 +192,7 @@ public:
   NODISCARD resultt<> simplify_unary_minus(const unary_minus_exprt &);
   NODISCARD resultt<> simplify_unary_plus(const unary_plus_exprt &);
   NODISCARD resultt<> simplify_dereference(const dereference_exprt &);
+  NODISCARD resultt<> simplify_dereference_preorder(const dereference_exprt &);
   NODISCARD resultt<> simplify_address_of(const address_of_exprt &);
   NODISCARD resultt<> simplify_pointer_offset(const pointer_offset_exprt &);
   NODISCARD resultt<> simplify_bswap(const bswap_exprt &);

--- a/src/util/simplify_expr_class.h
+++ b/src/util/simplify_expr_class.h
@@ -149,7 +149,7 @@ public:
   // These below all return 'true' if the simplification wasn't applicable.
   // If false is returned, the expression has changed.
   NODISCARD resultt<> simplify_typecast(const typecast_exprt &);
-  bool simplify_typecast_preorder(typecast_exprt &);
+  NODISCARD resultt<> simplify_typecast_preorder(const typecast_exprt &);
   NODISCARD resultt<> simplify_extractbit(const extractbit_exprt &);
   NODISCARD resultt<> simplify_extractbits(const extractbits_exprt &);
   NODISCARD resultt<> simplify_concatenation(const concatenation_exprt &);
@@ -163,7 +163,7 @@ public:
   NODISCARD resultt<> simplify_shifts(const shift_exprt &);
   NODISCARD resultt<> simplify_power(const binary_exprt &);
   NODISCARD resultt<> simplify_bitwise(const multi_ary_exprt &);
-  bool simplify_if_preorder(if_exprt &expr);
+  NODISCARD resultt<> simplify_if_preorder(const if_exprt &expr);
   NODISCARD resultt<> simplify_if(const if_exprt &);
   NODISCARD resultt<> simplify_bitnot(const bitnot_exprt &);
   NODISCARD resultt<> simplify_not(const not_exprt &);
@@ -259,8 +259,8 @@ public:
   simplify_inequality_pointer_object(const binary_relation_exprt &);
 
   // main recursion
-  NODISCARD resultt<> simplify_node(exprt);
-  bool simplify_node_preorder(exprt &expr);
+  NODISCARD resultt<> simplify_node(const exprt &);
+  NODISCARD resultt<> simplify_node_preorder(const exprt &);
   NODISCARD resultt<> simplify_rec(const exprt &);
 
   virtual bool simplify(exprt &expr);

--- a/src/util/simplify_expr_if.cpp
+++ b/src/util/simplify_expr_if.cpp
@@ -211,47 +211,66 @@ bool simplify_exprt::simplify_if_cond(exprt &expr)
   return no_change;
 }
 
-bool simplify_exprt::simplify_if_preorder(if_exprt &expr)
+static simplify_exprt::resultt<> build_if_expr(
+  const if_exprt &expr,
+  simplify_exprt::resultt<> cond,
+  simplify_exprt::resultt<> truevalue,
+  simplify_exprt::resultt<> falsevalue)
 {
-  exprt &cond = expr.cond();
-  exprt &truevalue = expr.true_case();
-  exprt &falsevalue = expr.false_case();
+  if(
+    !cond.has_changed() && !truevalue.has_changed() &&
+    !falsevalue.has_changed())
+  {
+    return simplify_exprt::resultt<>(
+      simplify_exprt::resultt<>::UNCHANGED, expr);
+  }
+  else
+  {
+    if_exprt result = expr;
+    if(cond.has_changed())
+      result.cond() = std::move(cond.expr);
+    if(truevalue.has_changed())
+      result.true_case() = std::move(truevalue.expr);
+    if(falsevalue.has_changed())
+      result.false_case() = std::move(falsevalue.expr);
+    return result;
+  }
+}
 
-  bool no_change = true;
+simplify_exprt::resultt<>
+simplify_exprt::simplify_if_preorder(const if_exprt &expr)
+{
+  const exprt &cond = expr.cond();
+  const exprt &truevalue = expr.true_case();
+  const exprt &falsevalue = expr.false_case();
 
   // we first want to look at the condition
   auto r_cond = simplify_rec(cond);
-  if(r_cond.has_changed())
-  {
-    cond = r_cond.expr;
-    no_change = false;
-  }
 
   // 1 ? a : b -> a  and  0 ? a : b -> b
-  if(cond.is_constant())
+  if(r_cond.expr.is_constant())
   {
-    exprt tmp = cond.is_true() ? truevalue : falsevalue;
-    tmp = simplify_rec(tmp);
-    expr.swap(tmp);
-    return false;
+    return changed(
+      simplify_rec(r_cond.expr.is_true() ? truevalue : falsevalue));
   }
 
   if(do_simplify_if)
   {
-    if(cond.id() == ID_not)
+    bool swap_branches = false;
+
+    if(r_cond.expr.id() == ID_not)
     {
-      cond = to_not_expr(cond).op();
-      truevalue.swap(falsevalue);
-      no_change = false;
+      r_cond = changed(to_not_expr(r_cond.expr).op());
+      swap_branches = true;
     }
 
 #ifdef USE_LOCAL_REPLACE_MAP
     replace_mapt map_before(local_replace_map);
 
     // a ? b : c  --> a ? b[a/true] : c
-    if(cond.id() == ID_and)
+    if(r_cond.expr.id() == ID_and)
     {
-      for(const auto &op : as_const(cond).operands())
+      for(const auto &op : r_cond.expr.operands())
       {
         if(op.id() == ID_not)
           local_replace_map.insert(std::make_pair(op.op0(), false_exprt()));
@@ -260,21 +279,16 @@ bool simplify_exprt::simplify_if_preorder(if_exprt &expr)
       }
     }
     else
-      local_replace_map.insert(std::make_pair(cond, true_exprt()));
+      local_replace_map.insert(std::make_pair(r_cond.expr, true_exprt()));
 
-    auto r_truevalue = simplify_rec(truevalue);
-    if(r_truevalue.has_changed())
-    {
-      truevalue = r_truevalue.expr;
-      no_change = false;
-    }
+    auto r_truevalue = simplify_rec(swap_branches ? falsevalue : truevalue);
 
     local_replace_map = map_before;
 
     // a ? b : c  --> a ? b : c[a/false]
-    if(cond.id() == ID_or)
+    if(r_cond.expr.id() == ID_or)
     {
-      for(const auto &op : as_const(cond).operands())
+      for(const auto &op : r_cond.expr.operands())
       {
         if(op.id() == ID_not)
           local_replace_map.insert(std::make_pair(op.op0(), true_exprt()));
@@ -283,48 +297,40 @@ bool simplify_exprt::simplify_if_preorder(if_exprt &expr)
       }
     }
     else
-      local_replace_map.insert(std::make_pair(cond, false_exprt()));
+      local_replace_map.insert(std::make_pair(r_cond.expr, false_exprt()));
 
-    auto r_falsevalue = simplify_rec(falsevalue);
-    if(r_falsevalue.has_changed())
-    {
-      falsevalue = r_falsevalue.expr;
-      no_change = false;
-    }
+    auto r_falsevalue = simplify_rec(swap_branches ? truevalue : falsevalue);
 
     local_replace_map.swap(map_before);
-#else
-    auto r_truevalue = simplify_rec(truevalue);
-    if(r_truevalue.has_changed())
+
+    if(swap_branches)
     {
-      truevalue = r_truevalue.expr;
-      no_change = false;
+      // tell build_if_expr to replace truevalue and falsevalue
+      r_truevalue.expr_changed = CHANGED;
+      r_falsevalue.expr_changed = CHANGED;
     }
-    auto r_falsevalue = simplify_rec(falsevalue);
-    if(r_falsevalue.has_changed())
+    return build_if_expr(expr, r_cond, r_truevalue, r_falsevalue);
+#else
+    if(!swap_branches)
     {
-      falsevalue = r_falsevalue.expr;
-      no_change = false;
+      return build_if_expr(
+        expr, r_cond, simplify_rec(truevalue), simplify_rec(falsevalue));
+    }
+    else
+    {
+      return build_if_expr(
+        expr,
+        r_cond,
+        changed(simplify_rec(falsevalue)),
+        changed(simplify_rec(truevalue)));
     }
 #endif
   }
   else
   {
-    auto r_truevalue = simplify_rec(truevalue);
-    if(r_truevalue.has_changed())
-    {
-      truevalue = r_truevalue.expr;
-      no_change = false;
-    }
-    auto r_falsevalue = simplify_rec(falsevalue);
-    if(r_falsevalue.has_changed())
-    {
-      falsevalue = r_falsevalue.expr;
-      no_change = false;
-    }
+    return build_if_expr(
+      expr, r_cond, simplify_rec(truevalue), simplify_rec(falsevalue));
   }
-
-  return no_change;
 }
 
 simplify_exprt::resultt<> simplify_exprt::simplify_if(const if_exprt &expr)


### PR DESCRIPTION
The use of resultt increases type safety as the expression to be
simplified is no longer modified in place. All post-order simplification
steps already use resultt, but pre-order steps had been left to be
done.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
