### PR TITLE
Concurrency: do not lose L2 entries of procedure-local variables

### DIFF
--- a/regression/cbmc-concurrency/stack2/main.c
+++ b/regression/cbmc-concurrency/stack2/main.c
@@ -1,0 +1,17 @@
+void foo(unsigned x)
+{
+  __CPROVER_assert(x <= 1, "");
+}
+
+int main()
+{
+  unsigned local_to_main;
+  local_to_main %= 2;
+  _Bool nondet1;
+  if(nondet1)
+  {
+  __CPROVER_ASYNC_1:
+    foo(local_to_main);
+    return 0;
+  }
+}

--- a/regression/cbmc-concurrency/stack2/test.desc
+++ b/regression/cbmc-concurrency/stack2/test.desc
@@ -1,0 +1,11 @@
+CORE
+main.c
+
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring
+--
+Procedure-local variables must be copied into a newly created thread, and must
+not be lost when merging goto states.

--- a/src/goto-symex/symex_goto.cpp
+++ b/src/goto-symex/symex_goto.cpp
@@ -784,8 +784,12 @@ static void merge_names(
   // only later be removed from level2.current_names by pop_frame
   // once the thread is executed)
   const irep_idt level_0 = ssa.get_level_0();
-  if(!level_0.empty() && level_0 != std::to_string(dest_state.source.thread_nr))
+  if(
+    !level_0.empty() &&
+    level_0 != std::to_string(dest_state.source.thread_nr) && dest_count != 0)
+  {
     return;
+  }
 
   exprt goto_state_rhs = ssa, dest_state_rhs = ssa;
 


### PR DESCRIPTION
When spawning threads, procedure-local variables are copied into the
newly spawned thread. Merging goto states in the spawning thread must
not result in losing the L2 entries of those copies.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
