### PR TITLE
Concurrency: ensure function name is correct when starting threads

### DIFF
--- a/src/goto-symex/goto_symex_state.h
+++ b/src/goto-symex/goto_symex_state.h
@@ -181,6 +181,7 @@ public:
   struct threadt
   {
     goto_programt::const_targett pc;
+    irep_idt function_id;
     guardt guard;
     call_stackt call_stack;
     std::map<irep_idt, unsigned> function_frame;

--- a/src/goto-symex/symex_main.cpp
+++ b/src/goto-symex/symex_main.cpp
@@ -292,6 +292,7 @@ switch_to_thread(goto_symex_statet &state, const unsigned int thread_nb)
   // get new PC
   state.source.thread_nr = thread_nb;
   state.source.pc = state.threads[thread_nb].pc;
+  state.source.function_id = state.threads[thread_nb].function_id;
 
   state.guard = state.threads[thread_nb].guard;
   // A thread's initial state is certainly reachable:

--- a/src/goto-symex/symex_start_thread.cpp
+++ b/src/goto-symex/symex_start_thread.cpp
@@ -45,6 +45,7 @@ void goto_symext::symex_start_thread(statet &state)
   // statet::threadt &cur_thread=state.threads[state.source.thread_nr];
   statet::threadt &new_thread=state.threads.back();
   new_thread.pc=thread_target;
+  new_thread.function_id = state.source.function_id;
   new_thread.guard=state.guard;
   new_thread.call_stack.push_back(state.call_stack().top());
   new_thread.call_stack.back().local_objects.clear();


### PR DESCRIPTION
goto-symex did not update the function identifier when switching
threads, resulting in the last function of the previous thread being
used up until the next function call.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
