### PR TITLE
Concurrency: do not remove shared or dirty pointers from the value set

### DIFF
--- a/regression/cbmc-concurrency/dirty_local3/main.c
+++ b/regression/cbmc-concurrency/dirty_local3/main.c
@@ -1,0 +1,24 @@
+void worker(int *p)
+{
+  __CPROVER_assert(*p == 1, "reading from dirty object");
+}
+
+void create_thread(int **p)
+{
+#ifdef locals_bug
+  int z = 1;
+__CPROVER_ASYNC_1:
+  worker(&z);
+#else
+__CPROVER_ASYNC_1:
+  worker(*p);
+#endif
+}
+
+int main()
+{
+  int y = 1;
+  int *x[1] = {&y};
+  create_thread(&x[0]);
+  return 0;
+}

--- a/regression/cbmc-concurrency/dirty_local3/test-local.desc
+++ b/regression/cbmc-concurrency/dirty_local3/test-local.desc
@@ -1,0 +1,18 @@
+KNOWNBUG
+main.c
+-Dlocals_bug
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring
+--
+There is a need for further debugging around copying local objects in
+the procedure spawning threads as we generate the following non-sensical
+constraint:
+// 28 file regression/cbmc-concurrency/dirty_local3/main.c line 3 function worker
+(57) CONSTRAINT(z!1@0#2 == z!1@0 || !choice_rf0)
+                ^^^^^^^^^^^^^^^^
+                comparison of L2 and L1 SSA symbols
+// 28 file regression/cbmc-concurrency/dirty_local3/main.c line 3 function worker
+(58) CONSTRAINT(choice_rf0)

--- a/regression/cbmc-concurrency/dirty_local3/test.desc
+++ b/regression/cbmc-concurrency/dirty_local3/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring

--- a/src/goto-symex/symex_dead.cpp
+++ b/src/goto-symex/symex_dead.cpp
@@ -11,13 +11,50 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "goto_symex.h"
 
-#include <util/find_symbols.h>
 #include <util/std_expr.h>
 
 void goto_symext::symex_dead(statet &state)
 {
   const goto_programt::instructiont &instruction=*state.source.pc;
   symex_dead(state, instruction.dead_symbol());
+}
+
+static void remove_l1_object_rec(
+  goto_symext::statet &state,
+  const exprt &l1_expr,
+  const namespacet &ns)
+{
+  if(is_ssa_expr(l1_expr))
+  {
+    const ssa_exprt &l1_ssa = to_ssa_expr(l1_expr);
+    const irep_idt &l1_identifier = l1_ssa.get_identifier();
+
+    // We cannot remove the object from the L1 renaming map, because L1 renaming
+    // information is not local to a path, but removing it from the propagation
+    // map and value-set is safe as 1) it is local to a path and 2) this
+    // instance can no longer appear (unless shared across threads).
+    if(
+      state.threads.size() <= 1 ||
+      state.write_is_shared(l1_ssa, ns) ==
+        goto_symex_statet::write_is_shared_resultt::NOT_SHARED)
+    {
+      state.value_set.values.erase_if_exists(l1_identifier);
+    }
+    state.propagation.erase_if_exists(l1_identifier);
+    // Remove from the local L2 renaming map; this means any reads from the dead
+    // identifier will use generation 0 (e.g. x!N@M#0, where N and M are
+    // positive integers), which is never defined by any write, and will be
+    // dropped by `goto_symext::merge_goto` on merging with branches where the
+    // identifier is still live.
+    state.drop_l1_name(l1_identifier);
+  }
+  else if(l1_expr.id() == ID_array || l1_expr.id() == ID_struct)
+  {
+    for(const auto &op : l1_expr.operands())
+      remove_l1_object_rec(state, op, ns);
+  }
+  else
+    UNREACHABLE;
 }
 
 void goto_symext::symex_dead(statet &state, const symbol_exprt &symbol_expr)
@@ -27,22 +64,5 @@ void goto_symext::symex_dead(statet &state, const symbol_exprt &symbol_expr)
   ssa_exprt ssa = state.rename_ssa<L1>(to_rename, ns).get();
 
   const exprt fields = state.field_sensitivity.get_fields(ns, state, ssa);
-  find_symbols_sett fields_set;
-  find_symbols_or_nexts(fields, fields_set);
-
-  for(const irep_idt &l1_identifier : fields_set)
-  {
-    // We cannot remove the object from the L1 renaming map, because L1 renaming
-    // information is not local to a path, but removing it from the propagation
-    // map and value-set is safe as 1) it is local to a path and 2) this
-    // instance can no longer appear.
-    state.value_set.values.erase_if_exists(l1_identifier);
-    state.propagation.erase_if_exists(l1_identifier);
-    // Remove from the local L2 renaming map; this means any reads from the dead
-    // identifier will use generation 0 (e.g. x!N@M#0, where N and M are
-    // positive integers), which is never defined by any write, and will be
-    // dropped by `goto_symext::merge_goto` on merging with branches where the
-    // identifier is still live.
-    state.drop_l1_name(l1_identifier);
-  }
+  remove_l1_object_rec(state, fields, ns);
 }


### PR DESCRIPTION
Just like we always add (and never replace) shared pointers in
goto_symex_statet::assignment, symex_dead should not remove shared or
dirty pointers.

This fixes a first problem, with further problems remaining as
indicated by the KNOWNBUG regression test.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
