### PR TITLE
Dirty locals copied across threads require program-order constraints

### DIFF
--- a/regression/cbmc-concurrency/dirty_local3/test-local.desc
+++ b/regression/cbmc-concurrency/dirty_local3/test-local.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.c
 -Dlocals_bug
 ^EXIT=0$
@@ -7,12 +7,6 @@ main.c
 --
 ^warning: ignoring
 --
-There is a need for further debugging around copying local objects in
-the procedure spawning threads as we generate the following non-sensical
-constraint:
-// 28 file regression/cbmc-concurrency/dirty_local3/main.c line 3 function worker
-(57) CONSTRAINT(z!1@0#2 == z!1@0 || !choice_rf0)
-                ^^^^^^^^^^^^^^^^
-                comparison of L2 and L1 SSA symbols
-// 28 file regression/cbmc-concurrency/dirty_local3/main.c line 3 function worker
-(58) CONSTRAINT(choice_rf0)
+We previously missed SHARED_WRITE events in program order in a newly-spawned
+thread for dirty locals, resulting in spurious failures as reading from initial
+values seemed possible.

--- a/src/goto-symex/symex_start_thread.cpp
+++ b/src/goto-symex/symex_start_thread.cpp
@@ -40,7 +40,7 @@ void goto_symext::symex_start_thread(statet &state)
     instruction.get_target();
 
   // put into thread vector
-  std::size_t t=state.threads.size();
+  const std::size_t new_thread_nr = state.threads.size();
   state.threads.push_back(statet::threadt(guard_manager));
   // statet::threadt &cur_thread=state.threads[state.source.thread_nr];
   statet::threadt &new_thread=state.threads.back();
@@ -52,6 +52,8 @@ void goto_symext::symex_start_thread(statet &state)
   #if 0
   new_thread.abstract_events=&(target.new_thread(cur_thread.abstract_events));
   #endif
+
+  const std::size_t current_thread_nr = state.source.thread_nr;
 
   // create a copy of the local variables for the new thread
   framet &frame = state.call_stack().top();
@@ -71,7 +73,8 @@ void goto_symext::symex_start_thread(statet &state)
     ssa_exprt lhs(pair.second.first.get_original_expr());
 
     // get L0 name for current thread
-    const renamedt<ssa_exprt, L0> l0_lhs = symex_level0(std::move(lhs), ns, t);
+    const renamedt<ssa_exprt, L0> l0_lhs =
+      symex_level0(std::move(lhs), ns, new_thread_nr);
     const irep_idt &l0_name = l0_lhs.get().get_identifier();
     std::size_t l1_index = path_storage.get_unique_l1_index(l0_name, 0);
     CHECK_RETURN(l1_index == 0);
@@ -92,7 +95,20 @@ void goto_symext::symex_start_thread(statet &state)
     symex_assignt{
       state, symex_targett::assignment_typet::HIDDEN, ns, symex_config, target}
       .assign_symbol(lhs_l1, expr_skeletont{}, rhs, lhs_conditions);
+    const exprt l2_lhs = state.rename(lhs_l1, ns).get();
     state.record_events.pop();
+
+    // record a shared write in the new thread
+    if(
+      state.write_is_shared(lhs_l1, ns) ==
+        goto_symex_statet::write_is_shared_resultt::SHARED &&
+      is_ssa_expr(l2_lhs))
+    {
+      state.source.thread_nr = new_thread_nr;
+      target.shared_write(
+        state.guard.as_expr(), to_ssa_expr(l2_lhs), 0, state.source);
+      state.source.thread_nr = current_thread_nr;
+    }
   }
 
   // initialize all variables marked thread-local
@@ -111,7 +127,7 @@ void goto_symext::symex_start_thread(statet &state)
     ssa_exprt lhs(symbol.symbol_expr());
 
     // get L0 name for current thread
-    lhs.set_level_0(t);
+    lhs.set_level_0(new_thread_nr);
 
     exprt rhs=symbol.value;
     if(rhs.is_nil())


### PR DESCRIPTION
We previously lacked SHARED_WRITE events in program order in a newly-spawned
thread for dirty locals being copied from the spawning thread. This resulted in
spurious failures as reading from initial values seemed possible, when the
from-read constraint should have prevented such reads.

Also, replace the variable "t" by the more descriptive "new_thread_nr."

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
