### PR TITLE
Concurrency: treat updates to an unknown field as atomic

### DIFF
--- a/regression/cbmc-concurrency/array1/main.c
+++ b/regression/cbmc-concurrency/array1/main.c
@@ -1,0 +1,19 @@
+int data[2];
+unsigned sync;
+
+void thread()
+{
+  data[sync % 2] = 1;
+  __CPROVER_assert(data[sync % 2] == 1, "1");
+}
+
+int main()
+{
+  unsigned nondet;
+  sync = nondet;
+__CPROVER_ASYNC_1:
+  thread();
+  unsigned sync_value = sync;
+  data[(sync_value + 1) % 2] = 2;
+  __CPROVER_assert(data[(sync_value + 1) % 2] == 2, "2");
+}

--- a/regression/cbmc-concurrency/array1/test.desc
+++ b/regression/cbmc-concurrency/array1/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring


### PR DESCRIPTION
Writing to an object that is composed of multiple fields is generally
treated in a field-sensitive (and thus: single-field) manner, which had
fixed several issues in handling shared arrays or structs. When the
specific field being updated cannot be determined during symbolic
execution (as is the case with non-const indices into arrays), we update
all fields that make up the full object. Such a full-object update must
then be treated as an atomic operation to avoid losing intermittent
writes performed by other threads.

Fixes: #123

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
