### PR TITLE
Upgrade CaDiCaL to 1.4.1

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -152,14 +152,14 @@ glucose-download:
 	@(cd ../glucose-syrup; patch -p1 < ../scripts/glucose-syrup-patch)
 	@rm glucose-syrup.tgz
 
-cadical_release = rel-1.3.0
+cadical_release = rel-1.4.1
 cadical-download:
 	@echo "Downloading CaDiCaL $(cadical_release)"
 	@$(DOWNLOADER) https://github.com/arminbiere/cadical/archive/$(cadical_release).tar.gz
 	@$(TAR) xfz $(cadical_release).tar.gz
 	@rm -Rf ../cadical
 	@mv cadical-$(cadical_release) ../cadical
-	@cd ../cadical && CXX=$(CXX) ./configure -O3 -s -j && make
+	@cd ../cadical && CXX=$(CXX) ./configure -O3 -s && make -j
 	@$(RM) $(cadical_release).tar.gz
 
 doc :

--- a/src/solvers/CMakeLists.txt
+++ b/src/solvers/CMakeLists.txt
@@ -107,14 +107,14 @@ elseif("${sat_impl}" STREQUAL "cadical")
     message(STATUS "Building solvers with cadical")
 
     download_project(PROJ cadical
-        URL https://github.com/arminbiere/cadical/archive/rel-1.3.0.tar.gz
+        URL https://github.com/arminbiere/cadical/archive/rel-1.4.1.tar.gz
         PATCH_COMMAND true
-        COMMAND CXX=${CMAKE_CXX_COMPILER} ./configure -O3 -s -j
-        URL_MD5 5bd15d1e198d2e904a8af8b7873dd341
+        COMMAND CXX=${CMAKE_CXX_COMPILER} ./configure -O3 -s CXXFLAGS=-std=c++14
+        URL_MD5 b44874501a175106424f4bd5de29aa59
     )
 
     message(STATUS "Building CaDiCaL")
-    execute_process(COMMAND make WORKING_DIRECTORY ${cadical_SOURCE_DIR})
+    execute_process(COMMAND make -j WORKING_DIRECTORY ${cadical_SOURCE_DIR})
 
     target_compile_definitions(solvers PUBLIC
         SATCHECK_CADICAL HAVE_CADICAL
@@ -137,10 +137,10 @@ elseif("${sat_impl}" STREQUAL "ipasir-cadical")
     message(STATUS "Building with IPASIR solver linking against: CaDiCaL")
 
     download_project(PROJ cadical
-        URL https://github.com/arminbiere/cadical/archive/rel-1.4.0.tar.gz
+        URL https://github.com/arminbiere/cadical/archive/rel-1.4.1.tar.gz
         PATCH_COMMAND true
         COMMAND ./configure CXX=g++
-        URL_MD5 9bad586a82995a1d95d1197d445a353a
+        URL_MD5 b44874501a175106424f4bd5de29aa59
     )
 
     message(STATUS "Building CaDiCaL")

--- a/src/solvers/CMakeLists.txt
+++ b/src/solvers/CMakeLists.txt
@@ -139,7 +139,7 @@ elseif("${sat_impl}" STREQUAL "ipasir-cadical")
     download_project(PROJ cadical
         URL https://github.com/arminbiere/cadical/archive/rel-1.4.1.tar.gz
         PATCH_COMMAND true
-        COMMAND ./configure CXX=g++
+        COMMAND CXX=${CMAKE_CXX_COMPILER} ./configure -O3 -s CXXFLAGS=-std=c++14
         URL_MD5 b44874501a175106424f4bd5de29aa59
     )
 


### PR DESCRIPTION
Armin Biere has released the version of CaDiCaL competing in the 2021
SAT competition. ~More precisely, there's also a tag sc2021 in the CaDiCaL repository, but the changes do not seem to substantially impact performance when evaluated over SV-COMP.~ Comparing releases 1.3.0 and sc2021 doesn't show any major performance differences, so really this is just to make consistent what the cadical and ipasir-cadical CMake configurations will use.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
