### PR TITLE
bv_pointerst::offset_arithmetic: de-duplicate code

### DIFF
--- a/src/solvers/flattening/bv_pointers.cpp
+++ b/src/solvers/flattening/bv_pointers.cpp
@@ -830,13 +830,8 @@ bvt bv_pointerst::offset_arithmetic(
 {
   const std::size_t offset_bits = bv_pointers_width.get_offset_width(type);
 
-  bvt bv1 = offset_literals(bv, type);
-
-  bvt bv2=bv_utils.build_constant(x, offset_bits);
-
-  bvt tmp=bv_utils.add(bv1, bv2);
-
-  return object_offset_encoding(object_literals(bv, type), tmp);
+  return offset_arithmetic(
+    type, bv, 1, bv_utils.build_constant(x, offset_bits));
 }
 
 bvt bv_pointerst::offset_arithmetic(


### PR DESCRIPTION
Fall back to existing variant of bv_pointerst::offset_arithmetic rather
than duplicating a particular branch of that implementation.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
