### PR TITLE
Remove conversion_failed(exprt, bvt)

### DIFF
--- a/src/solvers/flattening/boolbv.h
+++ b/src/solvers/flattening/boolbv.h
@@ -124,11 +124,6 @@ protected:
   // NOLINTNEXTLINE(readability/identifiers)
   typedef arrayst SUB;
 
-  void conversion_failed(const exprt &expr, bvt &bv)
-  {
-    bv=conversion_failed(expr);
-  }
-
   bvt conversion_failed(const exprt &expr);
 
   typedef std::unordered_map<const exprt, bvt, irep_hash> bv_cachet;

--- a/src/solvers/flattening/bv_pointers.cpp
+++ b/src/solvers/flattening/bv_pointers.cpp
@@ -382,12 +382,7 @@ bvt bv_pointerst::convert_pointer_type(const exprt &expr)
 
     auto bv_opt = convert_address_of_rec(address_of_expr.op());
     if(!bv_opt.has_value())
-    {
-      bvt bv;
-      bv.resize(bits);
-      conversion_failed(address_of_expr, bv);
-      return bv;
-    }
+      return conversion_failed(address_of_expr);
 
     CHECK_RETURN(bv_opt->size() == bits);
     return *bv_opt;
@@ -454,9 +449,7 @@ bvt bv_pointerst::convert_pointer_type(const exprt &expr)
       if(it->type().id()!=ID_unsignedbv &&
          it->type().id()!=ID_signedbv)
       {
-        bvt failed_bv;
-        conversion_failed(plus_expr, failed_bv);
-        return failed_bv;
+        return conversion_failed(plus_expr);
       }
 
       bv_utilst::representationt rep=
@@ -492,9 +485,7 @@ bvt bv_pointerst::convert_pointer_type(const exprt &expr)
       minus_expr.rhs().type().id() != ID_unsignedbv &&
       minus_expr.rhs().type().id() != ID_signedbv)
     {
-      bvt bv;
-      conversion_failed(minus_expr, bv);
-      return bv;
+      return conversion_failed(minus_expr);
     }
 
     const unary_minus_exprt neg_op1(minus_expr.rhs());


### PR DESCRIPTION
This just invited the anti-pattern of uselessly building a bvt of a
certain size when it got completely replaced by the function call
anyway.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
