### PR TITLE
Equip bv_pointerst::postponedt with a constructor

### DIFF
--- a/src/solvers/flattening/bv_pointers.cpp
+++ b/src/solvers/flattening/bv_pointers.cpp
@@ -157,10 +157,7 @@ literalt bv_pointerst::convert_rest(const exprt &expr)
       // we postpone
       literalt l=prop.new_variable();
 
-      postponed_list.push_back(postponedt());
-      postponed_list.back().op = convert_bv(operands[0]);
-      postponed_list.back().bv.push_back(l);
-      postponed_list.back().expr = expr;
+      postponed_list.emplace_back(bvt{1, l}, convert_bv(operands[0]), expr);
 
       return l;
     }
@@ -650,15 +647,10 @@ bvt bv_pointerst::convert_bitvector(const exprt &expr)
     // we postpone until we know the objects
     std::size_t width=boolbv_width(expr.type());
 
-    bvt bv = prop.new_variables(width);
+    postponed_list.emplace_back(
+      prop.new_variables(width), convert_bv(to_unary_expr(expr).op()), expr);
 
-    postponed_list.push_back(postponedt());
-
-    postponed_list.back().op = convert_bv(to_unary_expr(expr).op());
-    postponed_list.back().bv=bv;
-    postponed_list.back().expr=expr;
-
-    return bv;
+    return postponed_list.back().bv;
   }
   else if(
     expr.id() == ID_pointer_object &&

--- a/src/solvers/flattening/bv_pointers.h
+++ b/src/solvers/flattening/bv_pointers.h
@@ -98,6 +98,11 @@ protected:
   {
     bvt bv, op;
     exprt expr;
+
+    postponedt(bvt _bv, bvt _op, exprt _expr)
+      : bv(std::move(_bv)), op(std::move(_op)), expr(std::move(_expr))
+    {
+    }
   };
 
   typedef std::list<postponedt> postponed_listt;


### PR DESCRIPTION
This permits constructing list entries in place rather than first
creating a dummy element and then replacing each member.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
