### PR TITLE
bv_pointerst: sum over pointer offsets is restricted to offset bits

### DIFF
--- a/src/solvers/flattening/bv_pointers.cpp
+++ b/src/solvers/flattening/bv_pointers.cpp
@@ -444,7 +444,8 @@ bvt bv_pointerst::convert_pointer_type(const exprt &expr)
       count == 1,
       "there should be exactly one pointer-type operand in a pointer-type sum");
 
-    bvt sum=bv_utils.build_constant(0, bits);
+    const std::size_t offset_bits = bv_pointers_width.get_offset_width(type);
+    bvt sum = bv_utils.build_constant(0, offset_bits);
 
     forall_operands(it, plus_expr)
     {
@@ -466,12 +467,7 @@ bvt bv_pointerst::convert_pointer_type(const exprt &expr)
       bvt op=convert_bv(*it);
       CHECK_RETURN(!op.empty());
 
-      // we cut any extra bits off
-
-      if(op.size()>bits)
-        op.resize(bits);
-      else if(op.size()<bits)
-        op=bv_utils.extension(op, bits, rep);
+      op = bv_utils.extension(op, offset_bits, rep);
 
       sum=bv_utils.add(sum, op);
     }


### PR DESCRIPTION
Offset arithmetic must not affect the object part of the encoding.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
