### PR TITLE
simplify_inequality_address_of only supports (not)equal

### DIFF
--- a/regression/cbmc/Pointer_comparison3/main.c
+++ b/regression/cbmc/Pointer_comparison3/main.c
@@ -1,0 +1,9 @@
+#include <assert.h>
+#include <stdlib.h>
+
+int main()
+{
+  int *p1 = malloc(sizeof(int));
+
+  assert(p1 < p1 + 1);
+}

--- a/regression/cbmc/Pointer_comparison3/test.desc
+++ b/regression/cbmc/Pointer_comparison3/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+
+^VERIFICATION SUCCESSFUL$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring

--- a/src/util/simplify_expr_int.cpp
+++ b/src/util/simplify_expr_int.cpp
@@ -1242,7 +1242,8 @@ simplify_exprt::simplify_inequality(const binary_relation_exprt &expr)
   // see if we are comparing pointers that are address_of
   if(
     skip_typecast(tmp0).id() == ID_address_of &&
-    skip_typecast(tmp1).id() == ID_address_of)
+    skip_typecast(tmp1).id() == ID_address_of &&
+    (expr.id() == ID_equal || expr.id() == ID_notequal))
   {
     return simplify_inequality_address_of(expr);
   }


### PR DESCRIPTION
Invoking it for arbitrary binary comparisons resulted in an invariant
failure.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
