### PR TITLE
Binary comparison <, <=, >, >= over pointers requires same-object

### DIFF
--- a/regression/cbmc/Pointer29/main.c
+++ b/regression/cbmc/Pointer29/main.c
@@ -3,6 +3,14 @@
 int main()
 {
   unsigned int *s_pdt = (unsigned int *)(0xdeadbeef);
-  assert(s_pdt > 1);
+  // this is well defined
+  assert((unsigned long long)s_pdt > 1);
+  // this is undefined as it could both be a comparison over integers as well as
+  // over pointers; the latter may mean comparing pointers to different objects,
+  // so guard against that
+  assert(
+    __CPROVER_POINTER_OBJECT(s_pdt) !=
+      __CPROVER_POINTER_OBJECT((unsigned int *)1) ||
+    s_pdt > 1);
   return 0;
 }

--- a/regression/cbmc/Pointer_comparison3/main.c
+++ b/regression/cbmc/Pointer_comparison3/main.c
@@ -1,9 +1,29 @@
 #include <assert.h>
 #include <stdlib.h>
 
+char *nondet_pointer();
+
 int main()
 {
   int *p1 = malloc(sizeof(int));
 
   assert(p1 < p1 + 1);
+
+  int *p2 = malloc(sizeof(int));
+
+  assert(p1 != p2);
+
+  _Bool nondet;
+  // In the current implementation, CBMC always produces "false" for a
+  // comparison over different objects. This could change at any time, which
+  // would require updating this test.
+  if(nondet)
+    __CPROVER_assert(p1 < p2, "always false for different objects");
+  else
+    __CPROVER_assert(p1 > p2, "always false for different objects");
+
+  char *p = nondet_pointer();
+
+  __CPROVER_assume(p < p1 + 1);
+  assert(__CPROVER_POINTER_OBJECT(p) == __CPROVER_POINTER_OBJECT(p1));
 }

--- a/regression/cbmc/Pointer_comparison3/test.desc
+++ b/regression/cbmc/Pointer_comparison3/test.desc
@@ -1,8 +1,11 @@
 CORE
 main.c
 
-^VERIFICATION SUCCESSFUL$
-^EXIT=0$
+^\[main.assertion.3\] line 21 always false for different objects: FAILURE$
+^\[main.assertion.4\] line 23 always false for different objects: FAILURE$
+^\*\* 2 of 7 failed
+^VERIFICATION FAILED$
+^EXIT=10$
 ^SIGNAL=0$
 --
 ^warning: ignoring

--- a/src/util/simplify_expr_int.cpp
+++ b/src/util/simplify_expr_int.cpp
@@ -1473,6 +1473,14 @@ simplify_exprt::resultt<> simplify_exprt::simplify_inequality_no_constant(
   if(expr.op0().type().id() == ID_floatbv)
     return unchanged(expr);
 
+  // simplifications below require same-object, which we don't check for
+  if(
+    expr.op0().type().id() == ID_pointer && expr.id() != ID_equal &&
+    expr.id() != ID_notequal)
+  {
+    return unchanged(expr);
+  }
+
   // eliminate strict inequalities
   if(expr.id()==ID_notequal)
   {


### PR DESCRIPTION
We used to compare them just like integers, even though our
object:offset encoding restricted the space of possible results.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
