### PR TITLE
Set the correct C++ standard version so that regression test pass rel…

### DIFF
--- a/regression/cpp/Method_qualifier1/test.desc
+++ b/regression/cpp/Method_qualifier1/test.desc
@@ -1,6 +1,6 @@
 CORE winbug macos-assert-broken
 main.cpp
-
+-std=c++14
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/cpp/virtual1/test.desc
+++ b/regression/cpp/virtual1/test.desc
@@ -1,6 +1,6 @@
 CORE macos-assert-broken
 main.cpp
-
+-std=c++14
 ^EXIT=0$
 ^SIGNAL=0$
 --


### PR DESCRIPTION
…iably

This should address issue:

https://github.com/diffblue/cbmc/issues/6090

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
