### PR TITLE
bv_pointerst: use convert instead of convert_bv for Boolean expression

### DIFF
--- a/src/solvers/flattening/bv_pointers.cpp
+++ b/src/solvers/flattening/bv_pointers.cpp
@@ -546,8 +546,7 @@ bvt bv_pointerst::convert_bitvector(const exprt &expr)
     // do the same-object-test via an expression as this may permit re-using
     // already cached encodings of the equality test
     const exprt same_object = ::same_object(minus_expr.lhs(), minus_expr.rhs());
-    const bvt &same_object_bv = convert_bv(same_object);
-    CHECK_RETURN(same_object_bv.size() == 1);
+    const literalt same_object_lit = convert(same_object);
 
     // compute the object size (again, possibly using cached results)
     const exprt object_size = ::object_size(minus_expr.lhs());
@@ -556,7 +555,7 @@ bvt bv_pointerst::convert_bitvector(const exprt &expr)
 
     bvt bv = prop.new_variables(width);
 
-    if(!same_object_bv[0].is_false())
+    if(!same_object_lit.is_false())
     {
       const pointer_typet &lhs_pt = to_pointer_type(minus_expr.lhs().type());
       const bvt &lhs = convert_bv(minus_expr.lhs());
@@ -604,7 +603,7 @@ bvt bv_pointerst::convert_bitvector(const exprt &expr)
       }
 
       prop.l_set_to_true(prop.limplies(
-        prop.land(same_object_bv[0], prop.land(lhs_in_bounds, rhs_in_bounds)),
+        prop.land(same_object_lit, prop.land(lhs_in_bounds, rhs_in_bounds)),
         bv_utils.equal(difference, bv)));
     }
 


### PR DESCRIPTION
Although not directly using a cache, convert is the right method to
encode Boolean expressions. convert_bv is to be used with vectors of
literals are required. convert will transitively call (the caching)
convert_bv to encode operands of an expression.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
