### PR TITLE
Piped process handler for CBMC/SMT solver IPC

### DIFF
--- a/.github/workflows/pull-request-checks.yaml
+++ b/.github/workflows/pull-request-checks.yaml
@@ -108,6 +108,7 @@ jobs:
         run: |
           make -C unit      test
           make -C jbmc/unit test
+          make TAGS="[z3]" -C unit test
       - name: Run expected failure unit tests
         run: |
           make TAGS="[!shouldfail]" -C unit test
@@ -288,7 +289,9 @@ jobs:
       - name: Print ccache stats
         run: ccache -s
       - name: Run unit tests
-        run: cd unit; ./unit_tests
+        run: |
+          cd unit; ./unit_tests
+          ./unit_tests "[z3]"
       - name: Run JBMC unit tests
         run: cd jbmc/unit; ./unit_tests
       - name: Run regression tests

--- a/doc/API/util/piped_process.md
+++ b/doc/API/util/piped_process.md
@@ -1,0 +1,24 @@
+# `src/util/piped_process.{cpp, h}`
+
+To utilise the `piped_process` API for interprocess communication with any binary:
+
+* You need to initialise it by calling the construct `piped_processt("binary with args")`.
+  * If IPC fails before child process creation, you will get a `system_exceptiont`.
+  * If the `binary command` does not correspond to a binary in the `$PATH` or is
+    not a path to a binary itself, you'll read a string `Launching <xyz> failed with error: <error>`
+    when you attempt to `receive()` output from the child process.
+* The child process is automatically killed with SIGTERM when the destructor for
+  the `piped_processt` object is called.
+  * This will occur automatically when the `piped_processt` goes out of scope if
+    it's locally scoped.
+* Use `send()` to send a string message to the child process' input.
+  * This returns a `send_responset`, an enum that shows whether the
+    sending of the message through the pipe succeeded or failed.
+* Use `receive()` to read a string message from the child process' output.
+  * It's always a good idea to guard a call to `receive` with `can_receive()`,
+    so that receiving is blocked until there's something to receive.
+    * `can_receive` with no arguments will default to infinite wait time for piped
+      process readiness.
+  * Alternatively, you can guard the call to `receive` with `wait_receivable`.
+   `wait_receivable` takes an integer value representing `microseconds` of waiting
+   time between checks for pipe readiness.

--- a/src/util/Makefile
+++ b/src/util/Makefile
@@ -58,6 +58,7 @@ SRC = allocate_objects.cpp \
       options.cpp \
       parse_options.cpp \
       parser.cpp \
+      piped_process.cpp \
       pointer_expr.cpp \
       pointer_offset_size.cpp \
       pointer_offset_sum.cpp \

--- a/src/util/piped_process.cpp
+++ b/src/util/piped_process.cpp
@@ -1,0 +1,262 @@
+/// \file piped_process.cpp
+/// Subprocess communication with pipes.
+/// \author Diffblue Ltd.
+
+#ifdef _WIN32
+// Windows includes go here
+#else
+#  include <fcntl.h>  // library for fcntl function
+#  include <poll.h>   // library for poll function
+#  include <signal.h> // library for kill function
+#  include <unistd.h> // library for read/write/sleep/etc. functions
+#endif
+
+#ifdef _WIN32
+// Unimplemented on windows for now...
+#else
+
+#  include <cstring> // library for strerror function (on linux)
+#  include <iostream>
+#  include <vector>
+
+#  include "exception_utils.h"
+#  include "invariant.h"
+#  include "narrow.h"
+#  include "optional.h"
+#  include "piped_process.h"
+#  include "string_utils.h"
+
+#  define BUFSIZE 2048
+
+piped_processt::piped_processt(const std::vector<std::string> commandvec)
+{
+#  ifdef _WIN32
+  UNIMPLEMENTED_FEATURE("Pipe IPC on windows.")
+#  else
+
+  if(pipe(pipe_input) == -1)
+  {
+    throw system_exceptiont("Input pipe creation failed");
+  }
+
+  if(pipe(pipe_output) == -1)
+  {
+    throw system_exceptiont("Output pipe creation failed");
+  }
+
+  // Default state
+  process_state = statet::NOT_CREATED;
+
+  if(fcntl(pipe_output[0], F_SETFL, O_NONBLOCK) < 0)
+  {
+    throw system_exceptiont("Setting pipe non-blocking failed");
+  }
+
+  // Create a new process for the child that will execute the
+  // command and receive information via pipes.
+  child_process_id = fork();
+  if(child_process_id == 0)
+  {
+    // child process here
+
+    // Close pipes that will be used by the parent so we do
+    // not have our own copies and conflicts.
+    close(pipe_input[1]);
+    close(pipe_output[0]);
+
+    // Duplicate pipes so we have the ones we need.
+    dup2(pipe_input[0], STDIN_FILENO);
+    dup2(pipe_output[1], STDOUT_FILENO);
+    dup2(pipe_output[1], STDERR_FILENO);
+
+    // Create a char** for the arguments (all the contents of commandvec
+    // except the first element, i.e. the command itself).
+    char **args =
+      reinterpret_cast<char **>(malloc((commandvec.size()) * sizeof(char *)));
+    // Add all the arguments to the args array of char *.
+    unsigned long i = 0;
+    while(i < commandvec.size())
+    {
+      args[i] = strdup(commandvec[i].c_str());
+      i++;
+    }
+    args[i] = NULL;
+    execvp(commandvec[0].c_str(), args);
+    // The args variable will be handled by the OS if execvp succeeds, but
+    // if execvp fails then we should free it here (just in case the runtime
+    // error below continues execution.)
+    while(i > 0)
+    {
+      i--;
+      free(args[i]);
+    }
+    free(args);
+    // Only reachable if execvp failed
+    // Note that here we send to std::cerr since we are in the child process
+    // here and this is received by the parent process.
+    std::cerr << "Launching " << commandvec[0]
+              << " failed with error: " << std::strerror(errno) << std::endl;
+    abort();
+  }
+  else
+  {
+    // parent process here
+    // Close pipes to be used by the child process
+    close(pipe_input[0]);
+    close(pipe_output[1]);
+
+    // Get stream for sending to the child process
+    command_stream = fdopen(pipe_input[1], "w");
+    process_state = statet::CREATED;
+  }
+#  endif
+}
+
+piped_processt::~piped_processt()
+{
+#  ifdef _WIN32
+  UNIMPLEMENTED_FEATURE("Pipe IPC on windows: piped_processt constructor")
+#  else
+  // Close the parent side of the remaining pipes
+  fclose(command_stream);
+  // Note that the above will call close(pipe_input[1]);
+  close(pipe_output[0]);
+  // Send signal to the child process to terminate
+  kill(child_process_id, SIGTERM);
+#  endif
+}
+
+piped_processt::send_responset piped_processt::send(const std::string &message)
+{
+#  ifdef _WIN32
+  UNIMPLEMENTED_FEATURE("Pipe IPC on windows: send()")
+#  else
+
+  if(process_state != statet::CREATED)
+  {
+    return send_responset::ERROR;
+  }
+
+  // send message to solver process
+  int send_status = fputs(message.c_str(), command_stream);
+  fflush(command_stream);
+
+  if(send_status == EOF)
+  {
+    return send_responset::FAILED;
+  }
+
+  return send_responset::SUCCEEDED;
+#  endif
+}
+
+std::string piped_processt::receive()
+{
+#  ifdef _WIN32
+  UNIMPLEMENTED_FEATURE("Pipe IPC on windows: receive()")
+#  else
+
+  INVARIANT(
+    process_state == statet::CREATED,
+    "Can only receive() from a fully initialised process");
+
+  std::string response = std::string("");
+  int nbytes;
+  char buff[BUFSIZE];
+
+  while(true)
+  {
+    nbytes = read(pipe_output[0], buff, BUFSIZE);
+    INVARIANT(
+      nbytes < BUFSIZE,
+      "More bytes cannot be read at a time, than the size of the buffer");
+    switch(nbytes)
+    {
+    case -1:
+      // Nothing more to read in the pipe
+      return response;
+    case 0:
+      // Pipe is closed.
+      process_state = statet::STOPPED;
+      return response;
+    default:
+      // Read some bytes, append them to the response and continue
+      response.append(buff, nbytes);
+    }
+  }
+
+  UNREACHABLE;
+#  endif
+}
+
+std::string piped_processt::wait_receive()
+{
+  // can_receive(PIPED_PROCESS_INFINITE_TIMEOUT) waits an ubounded time until
+  // there is some data
+  can_receive(PIPED_PROCESS_INFINITE_TIMEOUT);
+  return receive();
+}
+
+piped_processt::statet piped_processt::get_status()
+{
+  return process_state;
+}
+
+bool piped_processt::can_receive(optionalt<std::size_t> wait_time)
+{
+#  ifdef _WIN32
+  UNIMPLEMENTED_FEATURE(
+    "Pipe IPC on windows: can_receive(optionalt<std::size_t> wait_time)")
+#  else
+  // unwrap the optional argument here
+  const int timeout = wait_time ? narrow<int>(*wait_time) : -1;
+  struct pollfd fds // NOLINT
+  {
+    pipe_output[0], POLLIN, 0
+  };
+  nfds_t nfds = POLLIN;
+  const int ready = poll(&fds, nfds, timeout);
+
+  switch(ready)
+  {
+  case -1:
+    // Error case
+    // Further error handling could go here
+    process_state = statet::ERROR;
+    // fallthrough intended
+  case 0:
+    // Timeout case
+    // Do nothing for timeout and error fallthrough, default function behaviour
+    // is to return false.
+    break;
+  default:
+    // Found some events, check for POLLIN
+    if(fds.revents & POLLIN)
+    {
+      // we can read from the pipe here
+      return true;
+    }
+    // Some revent we did not ask for or check for, can't read though.
+  }
+  return false;
+#  endif
+}
+
+bool piped_processt::can_receive()
+{
+  return can_receive(0);
+}
+
+void piped_processt::wait_receivable(int wait_time)
+{
+#  ifdef _WIN32
+  UNIMPLEMENTED_FEATURE("Pipe IPC on windows: wait_stopped(int wait_time)")
+#  else
+  while(process_state == statet::CREATED && !can_receive(0))
+  {
+    usleep(wait_time);
+  }
+#  endif
+}
+
+#endif

--- a/src/util/piped_process.h
+++ b/src/util/piped_process.h
@@ -1,0 +1,99 @@
+/// \file piped_process.h
+/// Subprocess communication with pipes
+/// \author Diffblue Ltd.
+
+#ifndef CPROVER_UTIL_PIPED_PROCESS_H
+#define CPROVER_UTIL_PIPED_PROCESS_H
+
+#ifdef _WIN32
+// TODO: Windows definitions go here
+#else
+
+#  include <vector>
+
+#  include "optional.h"
+
+#  define PIPED_PROCESS_INFINITE_TIMEOUT                                       \
+    optionalt<std::size_t>                                                     \
+    {                                                                          \
+    }
+
+class piped_processt
+{
+public:
+  /// Enumeration to keep track of child process state.
+  enum class statet
+  {
+    NOT_CREATED,
+    CREATED,
+    STOPPED,
+    ERROR
+  };
+
+  /// Enumeration for send response.
+  enum class send_responset
+  {
+    SUCCEEDED,
+    FAILED,
+    ERROR
+  };
+
+  /// Send a string message (command) to the child process.
+  /// \param message The string message to be sent.
+  /// \return
+  send_responset send(const std::string &message);
+  /// Read a string from the child process' output.
+  /// \return a string containing data from the process, empty string if no data
+  std::string receive();
+  /// Wait until a string is available and read a string from the child
+  /// process' output.
+  /// \return a string containing data from the process, empty string if no data
+  std::string wait_receive();
+
+  /// Get child process status.
+  /// \return a statet representing the status of the child process
+  statet get_status();
+
+  /// See if this process can receive data from the other process.
+  /// \param wait_time Amount of time to wait before timing out, with:
+  ///        * positive integer being wait time in milli-seconds,
+  ///        * 0 signifying non-blocking immediate return, and
+  ///        * an empty optional representing infinite wait time.
+  /// \return true is there is data to read from process, false otherwise
+  bool can_receive(optionalt<std::size_t> wait_time);
+
+  /// See if this process can receive data from the other process.
+  /// Note this calls can_receive(0);
+  /// \return true if there is data to read from process, false otherwise.
+  bool can_receive();
+
+  /// Wait for the pipe to be ready, waiting specified time between
+  /// checks. Will return when the pipe is ready or the other process
+  /// is not in a statet::CREATED state (i.e. error has occured).
+  /// \param wait_time Time spent in usleep() (microseconds) between checks
+  //         of can_receive(0)
+  void wait_receivable(int wait_time);
+
+  /// Initiate a new subprocess with pipes supporting communication
+  /// between the parent (this process) and the child.
+  /// \param commandvec The command and arguments to create the process
+  explicit piped_processt(const std::vector<std::string> commandvec);
+
+  ~piped_processt();
+
+protected:
+  // Child process ID.
+  pid_t child_process_id;
+  FILE *command_stream;
+  // The member fields below are so named from the perspective of the
+  // parent -> child process. So `pipe_input` is where we are feeding
+  // commands to the child process, and `pipe_output` is where we read
+  // the results of execution from.
+  int pipe_input[2];
+  int pipe_output[2];
+  statet process_state;
+};
+
+#endif // endif _WIN32
+
+#endif // endifndef CPROVER_UTIL_PIPED_PROCESS_H

--- a/unit/Makefile
+++ b/unit/Makefile
@@ -127,6 +127,7 @@ SRC += analyses/ai/ai.cpp \
        util/optional.cpp \
        util/optional_utils.cpp \
        util/parse_options.cpp \
+       util/piped_process.cpp \
        util/pointer_offset_size.cpp \
        util/prefix_filter.cpp \
        util/range.cpp \

--- a/unit/util/piped_process.cpp
+++ b/unit/util/piped_process.cpp
@@ -1,0 +1,270 @@
+/// \file
+/// \author Diffblue Ltd.
+/// Unit tests for checking the piped process communication mechanism.
+
+#ifdef _WIN32
+// No unit tests yet!
+#else
+
+#  include <testing-utils/use_catch.h>
+#  include <util/optional.h>
+#  include <util/piped_process.h>
+#  include <util/string_utils.h>
+
+TEST_CASE(
+  "Creating a sub process and reading its output.",
+  "[core][util][piped_process]")
+{
+  const std::string to_be_echoed = "The Jabberwocky";
+  // Need to give path to avoid shell built-in invocation
+  std::vector<std::string> commands;
+  commands.push_back("/bin/echo");
+  commands.push_back(to_be_echoed);
+  piped_processt process = piped_processt(commands);
+
+  // This is an indirect way to detect when the pipe has something. This
+  // could (in theory) also return when there is an error, but this unit
+  // test is not doing error handling.
+  process.can_receive(PIPED_PROCESS_INFINITE_TIMEOUT);
+  std::string response = strip_string(process.receive());
+
+  REQUIRE(response == to_be_echoed);
+}
+
+TEST_CASE(
+  "Creating a sub process with a binary that doesn't exist.",
+  "[core][util][piped_process]")
+{
+  const std::string expected_error("Launching abcde failed");
+  std::vector<std::string> commands;
+  commands.push_back("abcde");
+  piped_processt process = piped_processt(commands);
+
+  // This is an indirect way to detect when the pipe has something. This
+  // could (in theory) also return when there is an error, but this unit
+  // test is not doing error handling.
+  process.can_receive(PIPED_PROCESS_INFINITE_TIMEOUT);
+  std::string response = process.receive();
+  // This tracks how many times we tried, if for some reason we are stuck
+  // give up eventually for this test.
+  int too_many_tries = 0;
+  // The expected length of the output string is 6 characters, keep
+  // trying up to the retry limit of 5 or the string is long enough
+  while(too_many_tries < 5 && response.length() < 64)
+  {
+    // Wait a short amount of time to try and receive
+    process.can_receive(10);
+    response += process.receive();
+    too_many_tries++;
+  }
+
+  REQUIRE(response.find(expected_error) < response.length() - 5);
+}
+
+TEST_CASE(
+  "Creating a sub process of z3 and read a response from an echo command.",
+  "[core][util][piped_process][.z3]")
+{
+  std::vector<std::string> commands;
+  commands.push_back("z3");
+  commands.push_back("-in");
+  piped_processt process = piped_processt(commands);
+
+  REQUIRE(
+    process.send("(echo \"hi\")\n") ==
+    piped_processt::send_responset::SUCCEEDED);
+
+  process.can_receive(PIPED_PROCESS_INFINITE_TIMEOUT);
+  std::string response = strip_string(process.receive());
+  REQUIRE(response == "hi");
+
+  REQUIRE(
+    process.send("(exit)\n") == piped_processt::send_responset::SUCCEEDED);
+}
+
+TEST_CASE(
+  "Creating a sub process and interacting with it.",
+  "[core][util][piped_process][.z3]")
+{
+  std::vector<std::string> commands;
+  commands.push_back("z3");
+  commands.push_back("-in");
+  const std::string termination_statement = "(exit)\n";
+  piped_processt process = piped_processt(commands);
+
+  REQUIRE(
+    process.send("(echo \"hi\")\n") ==
+    piped_processt::send_responset::SUCCEEDED);
+
+  process.can_receive(PIPED_PROCESS_INFINITE_TIMEOUT);
+  std::string response = strip_string(process.receive());
+  REQUIRE(response == "hi");
+
+  std::string statement = std::string("(echo \"Second string\")\n");
+  REQUIRE(process.send(statement) == piped_processt::send_responset::SUCCEEDED);
+
+  process.can_receive(PIPED_PROCESS_INFINITE_TIMEOUT);
+  response = strip_string(process.receive());
+  REQUIRE(response == "Second string");
+
+  REQUIRE(
+    process.send(termination_statement) ==
+    piped_processt::send_responset::SUCCEEDED);
+}
+
+TEST_CASE(
+  "Use a created piped process instance of z3 to solve a simple SMT problem",
+  "[core][util][piped_process][.z3]")
+{
+  std::vector<std::string> commands;
+  commands.push_back("z3");
+  commands.push_back("-in");
+  commands.push_back("-smt2");
+  piped_processt process = piped_processt(commands);
+
+  std::string message =
+    "(set-logic QF_LIA) (declare-const x Int) (declare-const y Int) (assert (> "
+    "(+ (mod x 4) (* 3 (div y 2))) (- x y)))  (check-sat)\n";
+  REQUIRE(process.send(message) == piped_processt::send_responset::SUCCEEDED);
+
+  process.can_receive(PIPED_PROCESS_INFINITE_TIMEOUT);
+  std::string response = strip_string(process.receive());
+  REQUIRE(response == "sat");
+
+  REQUIRE(
+    process.send("(exit)\n") == piped_processt::send_responset::SUCCEEDED);
+}
+
+TEST_CASE(
+  "Use a created piped process instance of z3 to solve a simple SMT problem "
+  "with wait_receive",
+  "[core][util][piped_process][.z3]")
+{
+  std::vector<std::string> commands;
+  commands.push_back("z3");
+  commands.push_back("-in");
+  commands.push_back("-smt2");
+  piped_processt process = piped_processt(commands);
+
+  std::string statement =
+    "(set-logic QF_LIA) (declare-const x Int) (declare-const y Int) (assert (> "
+    "(+ (mod x 4) (* 3 (div y 2))) (- x y)))  (check-sat)\n";
+
+  REQUIRE(process.send(statement) == piped_processt::send_responset::SUCCEEDED);
+
+  std::string response = strip_string(process.wait_receive());
+  REQUIRE(response == "sat");
+
+  REQUIRE(
+    process.send("(exit)\n") == piped_processt::send_responset::SUCCEEDED);
+}
+
+TEST_CASE(
+  "Use a created piped process instance of z3 to test wait_receivable",
+  "[core][util][piped_process]")
+{
+  std::vector<std::string> commands;
+  commands.push_back("z3");
+  commands.push_back("-in");
+  piped_processt process = piped_processt(commands);
+
+  REQUIRE(
+    process.send("(echo \"hi\")\n") ==
+    piped_processt::send_responset::SUCCEEDED);
+
+  process.wait_receivable(100);
+  std::string response = strip_string(process.receive());
+  REQUIRE(response == "hi");
+
+  std::string statement = std::string("(echo \"Second string\")\n");
+  REQUIRE(process.send(statement) == piped_processt::send_responset::SUCCEEDED);
+
+  process.wait_receivable(100);
+  response = strip_string(process.receive());
+  REQUIRE(response == "Second string");
+
+  REQUIRE(
+    process.send("(exit)\n") == piped_processt::send_responset::SUCCEEDED);
+}
+
+TEST_CASE(
+  "Use piped process instance of z3 to solve a simple SMT problem and get the "
+  "model, with wait_receivable/can_receive",
+  "[core][util][piped_process][.z3]")
+{
+  std::vector<std::string> commands;
+  commands.push_back("z3");
+  commands.push_back("-in");
+  commands.push_back("-smt2");
+  piped_processt process = piped_processt(commands);
+
+  std::string statement =
+    "(set-logic QF_LIA) (declare-const x Int) (declare-const y Int) (assert (> "
+    "(+ (mod x 4) (* 3 (div y 2))) (- x y)))  (check-sat)\n";
+  REQUIRE(process.send(statement) == piped_processt::send_responset::SUCCEEDED);
+
+  process.can_receive(PIPED_PROCESS_INFINITE_TIMEOUT);
+  std::string response = strip_string(process.receive());
+  REQUIRE(response == "sat");
+
+  REQUIRE(
+    process.send("(get-model)\n") == piped_processt::send_responset::SUCCEEDED);
+
+  process.can_receive(PIPED_PROCESS_INFINITE_TIMEOUT);
+  // If we receive here we can get less than the full (expected) output.
+  // The normal expectation is that the caller will handle parsing and
+  // checking of the received data (i.e. it is not the responsibility
+  // of the piped_process to know how big the response should be).
+  // Therefore, we need to rebuild the string here.
+  response = process.receive();
+  // This tracks how many times we tried, if for some reason we are stuck
+  // give up eventually for this test.
+  int too_many_tries = 0;
+  // The expected length of the output string is 74 characters, keep
+  // trying up to the retry limit of 5 or the string is long enough
+  while(too_many_tries < 5 && response.length() < 74)
+  {
+    // Wait a short amount of time to try and receive
+    process.can_receive(10);
+    response += process.receive();
+    too_many_tries++;
+  }
+  // It would be nice to check then whole model, but this is non-deterministic
+  // and so causes problems.
+  // Note that the above loop would need to read 74 characters to safely check
+  // the model commented out here.
+  // const std::string expected_response = std::string(
+  //   "(model \n  (define-fun y () Int\n    0)\n  "
+  //   "(define-fun x () Int\n    (- 4))\n)\n");
+  // REQUIRE(response == expected_response);
+  REQUIRE(response.find("(define-fun") != std::string::npos);
+
+  REQUIRE(
+    process.send("(exit)\n") == piped_processt::send_responset::SUCCEEDED);
+}
+
+TEST_CASE(
+  "Use a created piped process instance of z3 to solve a simple SMT problem "
+  "and get the model, using infinite wait can_receive(...)",
+  "[core][util][piped_process][.z3]")
+{
+  std::vector<std::string> commands;
+  commands.push_back("z3");
+  commands.push_back("-in");
+  commands.push_back("-smt2");
+  piped_processt process = piped_processt(commands);
+
+  std::string statement =
+    "(set-logic QF_LIA) (declare-const x Int) (declare-const y Int) (assert (> "
+    "(+ (mod x 4) (* 3 (div y 2))) (- x y)))  (check-sat)\n";
+  REQUIRE(process.send(statement) == piped_processt::send_responset::SUCCEEDED);
+
+  process.can_receive(PIPED_PROCESS_INFINITE_TIMEOUT);
+  std::string response = strip_string(process.receive());
+  REQUIRE(response == "sat");
+
+  REQUIRE(
+    process.send("(exit)\n") == piped_processt::send_responset::SUCCEEDED);
+}
+
+#endif


### PR DESCRIPTION
This PR is related to #6134 .

This is adding a piped process handler class, with the bulk of it extracted/re-arranged
from `src/memory-analyzer/gdb_api.cpp`.

The idea is that we want to abstract away that interface (since it is code that has been
validated once, and it's known to be working - or have been in the past) and use it to
allow IPC with SMT solvers in the new incremental SMT backend (described in #6134).
Additionally, the `gdb_api.cpp` is going to be adapted at a later time to use this interface.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
