### PR TITLE
Configure git user before Homebrew PR creation

### DIFF
--- a/.github/workflows/release-packages.yaml
+++ b/.github/workflows/release-packages.yaml
@@ -134,6 +134,10 @@ jobs:
         # The GITHUB_REF we get has refs/tags/ in front of the tag name so we
         # strip that here
         run: echo "RELEASE_TAG=${GITHUB_REF/refs\/tags\/}" >> $GITHUB_ENV
+      - name: Configure git user name and email
+        uses: Homebrew/actions/git-user-config@07da0794847043a11761f14c97cc682577c74d5d
+        with:
+          username: db-ci-cprover
       - name: Create homebrew PR
         run: |
           brew update-reset


### PR DESCRIPTION
When using `brew bump-formula-pr` to update the cbmc Homebrew Formula,
git user credentials are not set, causing commits to be attributed to
"runner". This PR ensures that the name and email are configured prior
to creating version bump PRs for Homebrew.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

---

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

---

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->

Hello, Homebrew maintainer here. I've created this PR to ensure that `git` credentials (name and email) are set before using `brew bump-formula-pr` to update the Homebrew Formula.

In PRs such as https://github.com/Homebrew/homebrew-core/pull/78178, we can see that the PR is created by `db-ci-cprover`, but the commit is attributed to `runner` (based on the GitHub Actions runner login). This causes a small problem – every time we receive a PR to bump `cbmc`, a Homebrew maintainer has to manually trigger CI to run, as `db-ci-cprover` is recognised as a "First Time Contributor". (This is a consequence of a new GitHub security feature to require approval to run CI for new contributors.)

I've used an action authored by the Homebrew organisation and pinned it to a specific commit, to setup the credentials. The action will infer the publicly-available email address for the user (`db-ci-cprover`) using the GitHub API.

If using a third-party action doesn't seem like a good option, I'd be happy to discuss alternatives. Thanks!