### PR TITLE
Adds get_predecessors() to grapht

### DIFF
--- a/src/util/graph.h
+++ b/src/util/graph.h
@@ -312,6 +312,7 @@ public:
 
   std::list<node_indext> topsort() const;
 
+  std::vector<node_indext> get_predecessors(const node_indext &n) const;
   std::vector<node_indext> get_successors(const node_indext &n) const;
   void output_dot(std::ostream &out) const;
   void for_each_successor(
@@ -932,6 +933,19 @@ void output_dot_generic(
       out << node_to_string(i) << " -> " << node_to_string(n) << '\n';
     });
   });
+}
+
+template <class N>
+std::vector<typename grapht<N>::node_indext>
+grapht<N>::get_predecessors(const node_indext &n) const
+{
+  std::vector<node_indext> result;
+  std::transform(
+    nodes[n].in.begin(),
+    nodes[n].in.end(),
+    std::back_inserter(result),
+    [&](const std::pair<node_indext, edget> &edge) { return edge.first; });
+  return result;
 }
 
 template <class N>

--- a/unit/util/graph.cpp
+++ b/unit/util/graph.cpp
@@ -310,3 +310,25 @@ SCENARIO("graph-connected-subgraphs",
     }
   }
 }
+
+SCENARIO("predecessors-successors-graph", "[core][util][graph]")
+{
+  GIVEN("A graph")
+  {
+    simple_grapht graph;
+    simple_grapht::node_indext indices[2];
+
+    for(int i = 0; i < 2; ++i)
+      indices[i] = graph.add_node();
+
+    graph.add_edge(indices[0], indices[1]);
+
+    THEN("Nodes should have correct successors and predecessors")
+    {
+      REQUIRE(graph.get_predecessors(indices[0]).size() == 0);
+      REQUIRE(graph.get_successors(indices[0]).size() == 1);
+      REQUIRE(graph.get_predecessors(indices[1]).size() == 1);
+      REQUIRE(graph.get_successors(indices[1]).size() == 0);
+    }
+  }
+}


### PR DESCRIPTION
grapht already has get_successors(). This PR adds get_predecessors().


<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
