### PR TITLE
Handling function pointers in contracts instrumentation

### DIFF
--- a/regression/contracts/function-calls-05/main.c
+++ b/regression/contracts/function-calls-05/main.c
@@ -1,0 +1,25 @@
+#include <assert.h>
+#include <stdlib.h>
+
+static int add_operator(const int *a, const int *b)
+{
+  return (*a + *b);
+}
+
+// clang-format off
+int foo(int *x, int *y)
+  __CPROVER_requires(x != NULL &&  y != NULL)
+  __CPROVER_ensures(__CPROVER_return_value == 10)
+// clang-format on
+{
+  int (*sum)(const int *, const int *) = add_operator;
+  return sum(x, y);
+}
+
+int main()
+{
+  int x = 5;
+  int y = 5;
+  assert(foo(&x, &y) == 10);
+  return 0;
+}

--- a/regression/contracts/function-calls-05/test.desc
+++ b/regression/contracts/function-calls-05/test.desc
@@ -1,0 +1,12 @@
+CORE
+main.c
+--enforce-all-contracts
+^EXIT=0$
+^SIGNAL=0$
+\[postcondition.\d+\] file main.c line \d+ Check ensures clause: SUCCESS
+\[foo.\d+\] line \d+ Check that sum is assignable: SUCCESS
+\[main.assertion.\d+\] line \d+ assertion foo\(\&x, \&y\) \=\= 10: SUCCESS
+^VERIFICATION SUCCESSFUL$
+--
+--
+Checks whether function contracts are properly propagated to function pointers.


### PR DESCRIPTION
During instrumentation for enforcing/replacing function contracts,
all calls to function pointers were not handled. We now consider
that a function call might be a dereference and properly handle it
during instrumentation.

Signed-off-by: Felipe R. Monteiro <felisous@amazon.com>

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
