### PR TITLE
Change timestamp server for the windows package codesign process.

### DIFF
--- a/.github/workflows/release-packages.yaml
+++ b/.github/workflows/release-packages.yaml
@@ -204,7 +204,7 @@ jobs:
       - name: Sign the installer
         id: code_sign
         run: |
-          & signtool.exe sign /f $env:pfxcert /p "${{ secrets.CODESIGNCERTPASSWORD }}" /tr http://tsa.starfieldtech.com ${{ steps.create_packages.outputs.msi_installer }}
+          & signtool.exe sign /f $env:pfxcert /p "${{ secrets.CODESIGNCERTPASSWORD }}" /tr http://ts.ssl.com ${{ steps.create_packages.outputs.msi_installer }}
       - name: Remove signing certificate
         id: remove_certificate
         run: |


### PR DESCRIPTION
It appears that `tsa.starfieldtech.com` is down for a couple of weeks
now, so we are changing the timestamp server to something that works
for now.

This is a hotfix to allow us to make a new release that works with
windows packages. A more robust solution is going to be developed
soon after this gets merged and unblocks us on the windows packages.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
