### PR TITLE
Retry with different servers if codesigning fails on `.msi`.

### DIFF
--- a/.github/workflows/release-packages.yaml
+++ b/.github/workflows/release-packages.yaml
@@ -204,7 +204,16 @@ jobs:
       - name: Sign the installer
         id: code_sign
         run: |
-          & signtool.exe sign /f $env:pfxcert /p "${{ secrets.CODESIGNCERTPASSWORD }}" /tr http://ts.ssl.com ${{ steps.create_packages.outputs.msi_installer }}
+          $servers = @('http://ts.ssl.com', 'http://timestamp.digicert.com', 'http://timestamp.sectigo.com')
+          foreach($ts_server in $servers)
+          {
+            & signtool.exe sign /f $env:pfxcert /p "${{ secrets.CODESIGNCERTPASSWORD }}" /tr $ts_server ${{ steps.create_packages.outputs.msi_installer }}
+            if ($LastExitCode -eq "0")
+            {
+              # Stop if code-signing the binary using this server was successful.
+              break
+            }
+          }
       - name: Remove signing certificate
         id: remove_certificate
         run: |


### PR DESCRIPTION
For the Windows package installer build script, we have had
issues in the past where the package build script would fail
completely if the timestamp server was not available.

This now changes it to retry with different timestamp servers
if one of them fails.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
