### PR TITLE
Pretty print `havoc_object` instructions

### DIFF
--- a/regression/goto-instrument/show-goto-functions1/main.c
+++ b/regression/goto-instrument/show-goto-functions1/main.c
@@ -1,0 +1,5 @@
+int main()
+{
+  int a[64];
+  __CPROVER_havoc_object(a);
+}

--- a/regression/goto-instrument/show-goto-functions1/test.desc
+++ b/regression/goto-instrument/show-goto-functions1/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+--show-goto-functions
+HAVOC_OBJECT \(void \*\)a
+^SIGNAL=0$
+^EXIT=0$
+--
+irep\("\(.* \(\\"havoc_object\\"\)\)"\)

--- a/src/goto-programs/goto_program.cpp
+++ b/src/goto-programs/goto_program.cpp
@@ -100,8 +100,20 @@ std::ostream &goto_programt::output_instruction(
     out << '\n';
     break;
 
-  case RETURN:
   case OTHER:
+    if(instruction.get_other().id() == ID_code)
+    {
+      const auto &code = to_code(instruction.get_other());
+      if(code.get_statement() == ID_havoc_object)
+      {
+        out << "HAVOC_OBJECT " << from_expr(ns, identifier, code.op0()) << '\n';
+        break;
+      }
+      // fallthrough
+    }
+    // fallthrough
+
+  case RETURN:
   case DECL:
   case DEAD:
   case FUNCTION_CALL:


### PR DESCRIPTION
Resolves #6125.

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a ~~The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/~~
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a ~~My commit message includes data points confirming performance improvements (if claimed).~~
- [x] My PR is restricted to a single feature or bugfix.
- n/a ~~White-space or formatting changes outside the feature-related changed lines are in commits of their own.~~