### PR TITLE
Register the json_symtab languauge in symtab2gb

### DIFF
--- a/src/symtab2gb/module_dependencies.txt
+++ b/src/symtab2gb/module_dependencies.txt
@@ -1,3 +1,4 @@
 util
 json-symtab-language
+langapi
 goto-programs

--- a/src/symtab2gb/symtab2gb_parse_options.cpp
+++ b/src/symtab2gb/symtab2gb_parse_options.cpp
@@ -17,6 +17,7 @@ Author: Diffblue Ltd.
 #include <goto-programs/link_goto_model.h>
 #include <goto-programs/write_goto_binary.h>
 #include <json-symtab-language/json_symtab_language.h>
+#include <langapi/mode.h>
 
 #include <util/config.h>
 #include <util/exception_utils.h>
@@ -111,6 +112,7 @@ int symtab2gb_parse_optionst::doit()
   {
     gb_filename = cmdline.get_value(SYMTAB2GB_OUT_FILE_OPT);
   }
+  register_language(new_json_symtab_language);
   config.set(cmdline);
   run_symtab2gb(symtab_filenames, gb_filename);
   return CPROVER_EXIT_SUCCESS;


### PR DESCRIPTION
To quote langapi/mode.cpp:

"Note: registering a language is required for using the functions
in language_util.h"

symtab2gb previously failed to do this and so fails in invariant
under some obscure and unclear circumstances.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
