### PR TITLE
Support multiple requires and ensures clauses

### DIFF
--- a/regression/contracts/function-calls-01/main.c
+++ b/regression/contracts/function-calls-01/main.c
@@ -1,5 +1,9 @@
-int f1(int *x1) __CPROVER_requires(*x1 > 1 && *x1 < 10000)
+int f1(int *x1)
+  // clang-format off
+  __CPROVER_requires(*x1 > 1)
+  __CPROVER_requires(*x1 < 10000)
   __CPROVER_ensures(__CPROVER_return_value == *x1 + 1)
+// clang-format on
 {
   return *x1 + 1;
 }

--- a/regression/contracts/function-calls-05/main.c
+++ b/regression/contracts/function-calls-05/main.c
@@ -8,7 +8,8 @@ static int add_operator(const int *a, const int *b)
 
 // clang-format off
 int foo(int *x, int *y)
-  __CPROVER_requires(x != NULL &&  y != NULL)
+  __CPROVER_requires(x != NULL)
+  __CPROVER_requires(y != NULL)
   __CPROVER_ensures(__CPROVER_return_value == 10)
 // clang-format on
 {

--- a/src/ansi-c/ansi_c_convert_type.cpp
+++ b/src/ansi-c/ansi_c_convert_type.cpp
@@ -246,7 +246,7 @@ void ansi_c_convert_typet::read_rec(const typet &type)
   {
     const exprt &as_expr =
       static_cast<const exprt &>(static_cast<const irept &>(type));
-    requires = to_unary_expr(as_expr).op();
+    requires.push_back(to_unary_expr(as_expr).op());
   }
   else if(type.id() == ID_C_spec_assigns)
   {
@@ -258,7 +258,7 @@ void ansi_c_convert_typet::read_rec(const typet &type)
   {
     const exprt &as_expr =
       static_cast<const exprt &>(static_cast<const irept &>(type));
-    ensures = to_unary_expr(as_expr).op();
+    ensures.push_back(to_unary_expr(as_expr).op());
   }
   else
     other.push_back(type);
@@ -306,14 +306,14 @@ void ansi_c_convert_typet::write(typet &type)
     type.swap(other.front());
 
     // the contract expressions are meant for function types only
-    if(requires.is_not_nil())
-      type.add(ID_C_spec_requires) = std::move(requires);
+    if(!requires.empty())
+      to_code_with_contract_type(type).requires() = std::move(requires);
 
     if(assigns.is_not_nil())
-      type.add(ID_C_spec_assigns) = std::move(assigns);
+      to_code_with_contract_type(type).assigns() = std::move(assigns);
 
-    if(ensures.is_not_nil())
-      type.add(ID_C_spec_ensures) = std::move(ensures);
+    if(!ensures.empty())
+      to_code_with_contract_type(type).ensures() = std::move(ensures);
 
     if(constructor || destructor)
     {

--- a/src/ansi-c/ansi_c_convert_type.h
+++ b/src/ansi-c/ansi_c_convert_type.h
@@ -47,7 +47,8 @@ public:
   bool constructor, destructor;
 
   // contracts
-  exprt requires, assigns, ensures;
+  exprt assigns;
+  exprt::operandst requires, ensures;
 
   // storage spec
   c_storage_spect c_storage_spec;
@@ -86,9 +87,9 @@ public:
     msc_based.make_nil();
     gcc_attribute_mode.make_nil();
 
-    requires.make_nil();
     assigns.make_nil();
-    ensures.make_nil();
+    requires.clear();
+    ensures.clear();
 
     packed=aligned=constructor=destructor=false;
 

--- a/src/ansi-c/c_typecheck_base.cpp
+++ b/src/ansi-c/c_typecheck_base.cpp
@@ -724,12 +724,14 @@ void c_typecheck_baset::typecheck_declaration(
         // available
         auto &code_type = to_code_with_contract_type(new_symbol.type);
 
-        if(as_const(code_type).requires().is_not_nil())
+        if(!as_const(code_type).requires().empty())
         {
-          auto &requires = code_type.requires();
-          typecheck_expr(requires);
-          implicit_typecast_bool(requires);
-          disallow_history_variables(requires);
+          for(auto &requires : code_type.requires())
+          {
+            typecheck_expr(requires);
+            implicit_typecast_bool(requires);
+            disallow_history_variables(requires);
+          }
         }
 
         if(as_const(code_type).assigns().is_not_nil())
@@ -738,16 +740,18 @@ void c_typecheck_baset::typecheck_declaration(
             typecheck_expr(op);
         }
 
-        if(as_const(code_type).ensures().is_not_nil())
+        if(!as_const(code_type).ensures().empty())
         {
           const auto &return_type = code_type.return_type();
 
           if(return_type.id() != ID_empty)
             parameter_map[CPROVER_PREFIX "return_value"] = return_type;
 
-          auto &ensures = code_type.ensures();
-          typecheck_expr(ensures);
-          implicit_typecast_bool(ensures);
+          for(auto &ensures : code_type.ensures())
+          {
+            typecheck_expr(ensures);
+            implicit_typecast_bool(ensures);
+          }
 
           if(return_type.id() != ID_empty)
             parameter_map.erase(CPROVER_PREFIX "return_value");

--- a/src/ansi-c/expr2c.cpp
+++ b/src/ansi-c/expr2c.cpp
@@ -550,10 +550,9 @@ std::string expr2ct::convert_rec(
     }
 
     // contract, if any
-    if(to_code_with_contract_type(src).requires().is_not_nil())
+    for(auto &requires : to_code_with_contract_type(src).requires())
     {
-      dest += " [[requires " +
-              convert(to_code_with_contract_type(src).requires()) + "]]";
+      dest += " [[requires " + convert(requires) + "]]";
     }
 
     if(!to_code_with_contract_type(src).assigns().operands().empty())
@@ -562,10 +561,9 @@ std::string expr2ct::convert_rec(
               convert(to_code_with_contract_type(src).assigns()) + "]]";
     }
 
-    if(to_code_with_contract_type(src).ensures().is_not_nil())
+    for(auto &ensures : to_code_with_contract_type(src).ensures())
     {
-      dest += " [[ensures " +
-              convert(to_code_with_contract_type(src).ensures()) + "]]";
+      dest += " [[ensures " + convert(ensures) + "]]";
     }
 
     return dest;

--- a/src/goto-instrument/code_contracts.cpp
+++ b/src/goto-instrument/code_contracts.cpp
@@ -402,13 +402,13 @@ bool code_contractst::apply_function_contract(
   const auto &type = to_code_with_contract_type(function_symbol.type);
 
   // Isolate each component of the contract.
-  exprt assigns = type.assigns();
-  exprt requires = type.requires();
-  exprt ensures = type.ensures();
+  auto assigns = type.assigns();
+  auto requires = conjunction(type.requires());
+  auto ensures = conjunction(type.ensures());
 
-  // Check to see if the function  contract actually constrains its effect on
+  // Check to see if the function contract actually constrains its effect on
   // the program state; if not, return.
-  if(ensures.is_nil() && assigns.is_nil())
+  if(ensures.is_true() && assigns.is_nil())
     return false;
 
   // Create a replace_symbolt object, for replacing expressions in the callee
@@ -984,14 +984,14 @@ void code_contractst::add_contract_check(
   PRECONDITION(!dest.instructions.empty());
 
   const symbolt &function_symbol = ns.lookup(mangled_fun);
-  auto code_type = to_code_with_contract_type(function_symbol.type);
+  const auto &code_type = to_code_with_contract_type(function_symbol.type);
 
-  exprt &assigns = code_type.assigns();
-  exprt &requires = code_type.requires();
-  exprt &ensures = code_type.ensures();
+  exprt assigns = code_type.assigns();
+  exprt requires = conjunction(code_type.requires());
+  exprt ensures = conjunction(code_type.ensures());
 
   INVARIANT(
-    ensures.is_not_nil() || assigns.is_not_nil(),
+    !ensures.is_true() || assigns.is_not_nil(),
     "Code contract enforcement is trivial without an ensures or assigns "
     "clause.");
 

--- a/src/util/c_types.h
+++ b/src/util/c_types.h
@@ -341,8 +341,7 @@ public:
 
   bool has_contract() const
   {
-    return assigns().is_not_nil() || requires().is_not_nil() ||
-           ensures().is_not_nil();
+    return assigns().is_not_nil() || !requires().empty() || !ensures().empty();
   }
 
   const exprt &assigns() const
@@ -358,30 +357,24 @@ public:
     return result;
   }
 
-  const exprt &requires() const
+  const exprt::operandst &requires() const
   {
-    return static_cast<const exprt &>(find(ID_C_spec_requires));
+    return static_cast<const exprt &>(find(ID_C_spec_requires)).operands();
   }
 
-  exprt &requires()
+  exprt::operandst &requires()
   {
-    auto &result = static_cast<exprt &>(add(ID_C_spec_requires));
-    if(result.id().empty()) // not initialized?
-      result.make_nil();
-    return result;
+    return static_cast<exprt &>(add(ID_C_spec_requires)).operands();
   }
 
-  const exprt &ensures() const
+  const exprt::operandst &ensures() const
   {
-    return static_cast<const exprt &>(find(ID_C_spec_ensures));
+    return static_cast<const exprt &>(find(ID_C_spec_ensures)).operands();
   }
 
-  exprt &ensures()
+  exprt::operandst &ensures()
   {
-    auto &result = static_cast<exprt &>(add(ID_C_spec_ensures));
-    if(result.id().empty()) // not initialized?
-      result.make_nil();
-    return result;
+    return static_cast<exprt &>(add(ID_C_spec_ensures)).operands();
   }
 };
 


### PR DESCRIPTION
The C grammar supports multiple ensures and requires clauses.  This commit
adds support for this in the typechecker and in goto-instrument.  The
semantics of multiple clauses is the same as that of the conjunction of the
clauses.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [X] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
