### PR TITLE
allow an empty assigns clause

### DIFF
--- a/regression/contracts/assigns_enforce_15/main.c
+++ b/regression/contracts/assigns_enforce_15/main.c
@@ -20,10 +20,16 @@ int baz() __CPROVER_ensures(__CPROVER_return_value == global)
   return global;
 }
 
+void qux(void) __CPROVER_assigns()
+{
+  global = global + 1;
+}
+
 int main()
 {
   int n;
   n = foo(&n);
   n = baz();
+  qux();
   return 0;
 }

--- a/regression/contracts/assigns_enforce_15/test.desc
+++ b/regression/contracts/assigns_enforce_15/test.desc
@@ -3,8 +3,9 @@ main.c
 --enforce-all-contracts
 ^EXIT=10$
 ^SIGNAL=0$
-^\[bar.1\] line \d+ .*: FAILURE$
-^\[baz.1\] line \d+ .*: FAILURE$
+^\[bar\.1\] line \d+ .*: FAILURE$
+^\[baz\.1\] line \d+ .*: FAILURE$
+^\[qux\.1\] line \d+ .*: FAILURE$
 ^VERIFICATION FAILED$
 --
 --

--- a/src/ansi-c/parser.y
+++ b/src/ansi-c/parser.y
@@ -3250,6 +3250,12 @@ cprover_contract:
           parser_stack($3).id(ID_target_list);
           mto($$, $3);
         }
+        | TOK_CPROVER_ASSIGNS '(' ')'
+        {
+          $$=$1;
+          set($$, ID_C_spec_assigns);
+          parser_stack($$).add_to_operands(exprt(ID_target_list));
+        }
         ;
 
 cprover_contract_sequence:


### PR DESCRIPTION
This adds support for an explicit empty assigns clause, denoting a pure
function.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [X] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
