### PR TITLE
C library: model rand, rand_r so as not to return negative numbers

### DIFF
--- a/regression/cbmc-library/rand-01/main.c
+++ b/regression/cbmc-library/rand-01/main.c
@@ -1,0 +1,9 @@
+#include <assert.h>
+#include <stdlib.h>
+
+int main()
+{
+  int r = rand();
+  assert(r >= 0);
+  return 0;
+}

--- a/regression/cbmc-library/rand-01/test.desc
+++ b/regression/cbmc-library/rand-01/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+--pointer-check --bounds-check
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring

--- a/regression/cbmc-library/rand_r-01/main.c
+++ b/regression/cbmc-library/rand_r-01/main.c
@@ -1,0 +1,10 @@
+#include <assert.h>
+#include <stdlib.h>
+
+int main()
+{
+  unsigned int seed;
+  int r = rand_r(&seed);
+  assert(r >= 0);
+  return 0;
+}

--- a/regression/cbmc-library/rand_r-01/test.desc
+++ b/regression/cbmc-library/rand_r-01/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+--pointer-check --bounds-check
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring

--- a/src/ansi-c/library/stdlib.c
+++ b/src/ansi-c/library/stdlib.c
@@ -564,3 +564,30 @@ long random(void)
   __CPROVER_assume(result>=0 && result<=2147483647);
   return result;
 }
+
+/* FUNCTION: rand */
+
+int __VERIFIER_nondet_int();
+
+int rand(void)
+{
+__CPROVER_HIDE:;
+  // We return a non-deterministic value instead of a random one.
+  int result = __VERIFIER_nondet_int();
+  __CPROVER_assume(result >= 0);
+  return result;
+}
+
+/* FUNCTION: rand_r */
+
+int __VERIFIER_nondet_int();
+
+int rand_r(unsigned int *seed)
+{
+__CPROVER_HIDE:;
+  // We return a non-deterministic value instead of a random one.
+  (void)*seed;
+  int result = __VERIFIER_nondet_int();
+  __CPROVER_assume(result >= 0);
+  return result;
+}


### PR DESCRIPTION
The modelling remains over-approximating as we return a
non-deterministic value rather than some sequence of random numbers.
Still, we should not be returning a negative number.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
