### PR TITLE
Fix distance check in overflow checking of left shift

### DIFF
--- a/regression/cbmc/Overflow_Leftshift1/main.c
+++ b/regression/cbmc/Overflow_Leftshift1/main.c
@@ -1,3 +1,5 @@
+#include <inttypes.h>
+
 int main()
 {
   unsigned char x;
@@ -22,6 +24,10 @@ int main()
 
   // not an overflow in ANSI-C, but undefined in C99
   s = 1 << (sizeof(int) * 8 - 1);
+
+  // overflow in an expression where operand and distance types are different
+  uint32_t u32;
+  int64_t i64 = ((int64_t)u32) << 32;
 
   return 0;
 }

--- a/regression/cbmc/Overflow_Leftshift1/test-c89.desc
+++ b/regression/cbmc/Overflow_Leftshift1/test-c89.desc
@@ -3,14 +3,15 @@ main.c
 --signed-overflow-check --c89
 ^EXIT=10$
 ^SIGNAL=0$
-^\[.*\] line 6 arithmetic overflow on signed shl in .*: FAILURE$
-^\[.*\] line 9 arithmetic overflow on signed shl in .*: SUCCESS$
-^\[.*\] line 15 arithmetic overflow on signed shl in .*: SUCCESS$
-^\[.*\] line 18 arithmetic overflow on signed shl in .*: FAILURE$
-^\*\* 2 of 5 failed
+^\[.*\] line 8 arithmetic overflow on signed shl in .*: FAILURE$
+^\[.*\] line 11 arithmetic overflow on signed shl in .*: SUCCESS$
+^\[.*\] line 17 arithmetic overflow on signed shl in .*: SUCCESS$
+^\[.*\] line 20 arithmetic overflow on signed shl in .*: FAILURE$
+^\[.*\] line 30 arithmetic overflow on signed shl in .*: SUCCESS$
+^\*\* 2 of 6 failed
 ^VERIFICATION FAILED$
 --
 ^warning: ignoring
-^\[.*\] line 12 arithmetic overflow on signed shl in .*: .*
-^\[.*\] line 21 arithmetic overflow on signed shl in .*: .*
-^\[.*\] line 24 arithmetic overflow on signed shl in .*: .*
+^\[.*\] line 14 arithmetic overflow on signed shl in .*: .*
+^\[.*\] line 23 arithmetic overflow on signed shl in .*: .*
+^\[.*\] line 26 arithmetic overflow on signed shl in .*: .*

--- a/regression/cbmc/Overflow_Leftshift1/test-c99.desc
+++ b/regression/cbmc/Overflow_Leftshift1/test-c99.desc
@@ -3,14 +3,15 @@ main.c
 --signed-overflow-check --c99
 ^EXIT=10$
 ^SIGNAL=0$
-^\[.*\] line 6 arithmetic overflow on signed shl in .*: FAILURE$
-^\[.*\] line 9 arithmetic overflow on signed shl in .*: SUCCESS$
-^\[.*\] line 15 arithmetic overflow on signed shl in .*: SUCCESS$
-^\[.*\] line 18 arithmetic overflow on signed shl in .*: FAILURE$
-^\[.*\] line 24 arithmetic overflow on signed shl in .*: FAILURE$
-^\*\* 3 of 6 failed
+^\[.*\] line 8 arithmetic overflow on signed shl in .*: FAILURE$
+^\[.*\] line 11 arithmetic overflow on signed shl in .*: SUCCESS$
+^\[.*\] line 17 arithmetic overflow on signed shl in .*: SUCCESS$
+^\[.*\] line 20 arithmetic overflow on signed shl in .*: FAILURE$
+^\[.*\] line 26 arithmetic overflow on signed shl in .*: FAILURE$
+^\[.*\] line 30 arithmetic overflow on signed shl in .*: FAILURE$
+^\*\* 4 of 7 failed
 ^VERIFICATION FAILED$
 --
 ^warning: ignoring
-^\[.*\] line 12 arithmetic overflow on signed shl in .*: .*
-^\[.*\] line 21 arithmetic overflow on signed shl in .*: .*
+^\[.*\] line 14 arithmetic overflow on signed shl in .*: .*
+^\[.*\] line 23 arithmetic overflow on signed shl in .*: .*

--- a/src/analyses/goto_check.cpp
+++ b/src/analyses/goto_check.cpp
@@ -777,8 +777,10 @@ void goto_checkt::integer_overflow_check(
       if(distance_type.id() == ID_unsignedbv)
         neg_dist_shift = false_exprt();
       else
-        neg_dist_shift =
-          binary_relation_exprt(op, ID_lt, from_integer(0, distance_type));
+      {
+        neg_dist_shift = binary_relation_exprt(
+          distance, ID_lt, from_integer(0, distance_type));
+      }
 
       // shifting a non-zero value by more than its width is undefined;
       // yet this isn't an overflow


### PR DESCRIPTION
The code wrongly compared the shift operand when checking against
negative shifts.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
