### PR TITLE
Linking forward declarations of arrays must not yield type casts

### DIFF
--- a/regression/cbmc/Linking4/test.desc
+++ b/regression/cbmc/Linking4/test.desc
@@ -1,4 +1,4 @@
-CORE broken-smt-backend
+CORE
 link1.c
 link2.c
 ^EXIT=0$

--- a/regression/linking-goto-binaries/array_size/main.c
+++ b/regression/linking-goto-binaries/array_size/main.c
@@ -1,0 +1,9 @@
+#include "supp.h"
+#include <assert.h>
+
+int main()
+{
+  int entry = A[1];
+  assert(entry == 42);
+  return 0;
+}

--- a/regression/linking-goto-binaries/array_size/supp.c
+++ b/regression/linking-goto-binaries/array_size/supp.c
@@ -1,0 +1,3 @@
+#include "supp.h"
+
+int A[2] = {0, 42};

--- a/regression/linking-goto-binaries/array_size/supp.h
+++ b/regression/linking-goto-binaries/array_size/supp.h
@@ -1,0 +1,6 @@
+#ifndef SUPP_H
+#define SUPP_H
+
+extern int A[];
+
+#endif // SUPP_H

--- a/regression/linking-goto-binaries/array_size/test.desc
+++ b/regression/linking-goto-binaries/array_size/test.desc
@@ -1,0 +1,9 @@
+CORE
+main.c
+supp.c
+^EXIT=0$
+^SIGNAL=0$
+\[main.assertion.1\] line [0-9]+ assertion entry == 42: SUCCESS
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring

--- a/regression/linking-goto-binaries/chain.sh
+++ b/regression/linking-goto-binaries/chain.sh
@@ -5,7 +5,6 @@ set -e
 goto_cc=$1
 cbmc=$2
 is_windows=$3
-entry_point='generated_entry_function'
 
 main=${*:$#}
 main=${main%.c}
@@ -13,13 +12,13 @@ args=${*:4:$#-4}
 next=${args%.c}
 
 if [[ "${is_windows}" == "true" ]]; then
-  $goto_cc "${main}.c"
-  $goto_cc "${next}.c"
-  mv "${main}.exe" "${main}.gb"
-  mv "${next}.exe" "${next}.gb"
+  $goto_cc /c "${main}.c" "/Fo${main}.gb"
+  $goto_cc /c "${next}.c" "/Fo${next}.gb"
+  $goto_cc "${main}.gb" "${next}.gb" "/Fefinal.gb"
 else
-  $goto_cc -o "${main}.gb" "${main}.c"
-  $goto_cc -o "${next}.gb" "${next}.c"
+  $goto_cc -c -o "${main}.gb" "${main}.c"
+  $goto_cc -c -o "${next}.gb" "${next}.c"
+  $goto_cc "${main}.gb" "${next}.gb" -o "final.gb"
 fi
 
-$cbmc "${main}.gb" "${next}.gb"
+$cbmc "final.gb"

--- a/src/linking/linking.cpp
+++ b/src/linking/linking.cpp
@@ -36,8 +36,13 @@ bool casting_replace_symbolt::replace_symbol_expr(symbol_exprt &s) const
 
   const exprt &e = it->second;
 
-  typet type = s.type();
-  static_cast<exprt &>(s) = typecast_exprt::conditional_cast(e, type);
+  if(e.type().id() != ID_array)
+  {
+    typet type = s.type();
+    static_cast<exprt &>(s) = typecast_exprt::conditional_cast(e, type);
+  }
+  else
+    static_cast<exprt &>(s) = e;
 
   return false;
 }


### PR DESCRIPTION
Type casts of arrays are not supported. As the previously generated type
casts were solely for cases where a forward declaration without size
specification was present, it's actually safe to omit type casts when
doing object type updates.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
