### PR TITLE
VSD - correct widening merge to handle extreme values

### DIFF
--- a/src/analyses/Makefile
+++ b/src/analyses/Makefile
@@ -52,6 +52,7 @@ SRC = ai.cpp \
       variable-sensitivity/variable_sensitivity_dependence_graph.cpp \
       variable-sensitivity/variable_sensitivity_domain.cpp \
       variable-sensitivity/variable_sensitivity_object_factory.cpp \
+      variable-sensitivity/widened_range.cpp \
       variable-sensitivity/write_location_context.cpp \
       variable-sensitivity/write_stack.cpp \
       variable-sensitivity/write_stack_entry.cpp \

--- a/src/analyses/variable-sensitivity/interval_abstract_value.cpp
+++ b/src/analyses/variable-sensitivity/interval_abstract_value.cpp
@@ -354,8 +354,8 @@ abstract_object_pointert widening_merge(
   auto widened = widened_ranget(lhs, rhs);
 
   // new interval ...
-  auto new_interval =
-    constant_interval_exprt(widened.lower_bound, widened.upper_bound);
+  auto new_interval = constant_interval_exprt(
+    widened.widened_lower_bound, widened.widened_upper_bound);
   return interval_abstract_valuet::make_interval(new_interval);
 }
 

--- a/src/analyses/variable-sensitivity/widened_range.cpp
+++ b/src/analyses/variable-sensitivity/widened_range.cpp
@@ -14,10 +14,9 @@ static bool has_underflowed(const exprt &value)
   return constant_interval_exprt::greater_than(
     value, from_integer(0, value.type()));
 }
-static bool has_overflowed(const exprt &value)
+static bool has_overflowed(const exprt &value, const exprt &initial_value)
 {
-  return constant_interval_exprt::less_than(
-    value, from_integer(0, value.type()));
+  return constant_interval_exprt::less_than(value, initial_value);
 }
 
 exprt widened_ranget::widen_lower_bound() const
@@ -44,7 +43,7 @@ exprt widened_ranget::widen_upper_bound() const
 
   if(
     constant_interval_exprt::contains_extreme(new_upper_bound) ||
-    has_overflowed(new_upper_bound))
+    has_overflowed(new_upper_bound, upper_bound))
     return max_exprt(upper_bound.type());
 
   return new_upper_bound;

--- a/src/analyses/variable-sensitivity/widened_range.cpp
+++ b/src/analyses/variable-sensitivity/widened_range.cpp
@@ -20,32 +20,32 @@ static bool has_overflowed(const exprt &value)
     value, from_integer(0, value.type()));
 }
 
-exprt widened_ranget::make_lower_bound() const
+exprt widened_ranget::widen_lower_bound() const
 {
-  if(!lower_extended)
-    return lower_;
+  if(!is_lower_widened)
+    return lower_bound;
 
-  auto new_lower_bound = simplify_expr(minus_exprt(lower_, range_), ns_);
+  auto new_lower_bound = simplify_expr(minus_exprt(lower_bound, range_), ns_);
 
   if(
     constant_interval_exprt::contains_extreme(new_lower_bound) ||
     has_underflowed(new_lower_bound))
-    return min_exprt(lower_.type());
+    return min_exprt(lower_bound.type());
 
   return new_lower_bound;
 }
 
-exprt widened_ranget::make_upper_bound() const
+exprt widened_ranget::widen_upper_bound() const
 {
-  if(!upper_extended)
-    return upper_;
+  if(!is_upper_widened)
+    return upper_bound;
 
-  auto new_upper_bound = simplify_expr(plus_exprt(upper_, range_), ns_);
+  auto new_upper_bound = simplify_expr(plus_exprt(upper_bound, range_), ns_);
 
   if(
     constant_interval_exprt::contains_extreme(new_upper_bound) ||
     has_overflowed(new_upper_bound))
-    return max_exprt(upper_.type());
+    return max_exprt(upper_bound.type());
 
   return new_upper_bound;
 }

--- a/src/analyses/variable-sensitivity/widened_range.cpp
+++ b/src/analyses/variable-sensitivity/widened_range.cpp
@@ -1,0 +1,51 @@
+/*******************************************************************\
+
+ Module: helper for extending intervals during widening merges
+
+ Author: Jez Higgins
+
+\*******************************************************************/
+
+#include "widened_range.h"
+#include <util/simplify_expr.h>
+
+static bool has_underflowed(const exprt &value)
+{
+  return constant_interval_exprt::greater_than(
+    value, from_integer(0, value.type()));
+}
+static bool has_overflowed(const exprt &value)
+{
+  return constant_interval_exprt::less_than(
+    value, from_integer(0, value.type()));
+}
+
+exprt widened_ranget::make_lower_bound() const
+{
+  if(!lower_extended)
+    return lower_;
+
+  auto new_lower_bound = simplify_expr(minus_exprt(lower_, range_), ns_);
+
+  if(
+    constant_interval_exprt::contains_extreme(new_lower_bound) ||
+    has_underflowed(new_lower_bound))
+    return min_exprt(lower_.type());
+
+  return new_lower_bound;
+}
+
+exprt widened_ranget::make_upper_bound() const
+{
+  if(!upper_extended)
+    return upper_;
+
+  auto new_upper_bound = simplify_expr(plus_exprt(upper_, range_), ns_);
+
+  if(
+    constant_interval_exprt::contains_extreme(new_upper_bound) ||
+    has_overflowed(new_upper_bound))
+    return max_exprt(upper_.type());
+
+  return new_upper_bound;
+}

--- a/src/analyses/variable-sensitivity/widened_range.h
+++ b/src/analyses/variable-sensitivity/widened_range.h
@@ -1,0 +1,57 @@
+/*******************************************************************\
+
+ Module: helper for extending intervals during widening merges
+
+ Author: Jez Higgins
+
+\*******************************************************************/
+
+#ifndef CPROVER_ANALYSES_VARIABLE_SENSITIVITY_WIDENED_RANGE_H
+#define CPROVER_ANALYSES_VARIABLE_SENSITIVITY_WIDENED_RANGE_H
+
+#include <util/arith_tools.h>
+#include <util/interval.h>
+#include <util/namespace.h>
+#include <util/symbol_table.h>
+
+class widened_ranget
+{
+public:
+  widened_ranget(
+    const constant_interval_exprt &lhs,
+    const constant_interval_exprt &rhs)
+    : lower_extended(
+        constant_interval_exprt::less_than(rhs.get_lower(), lhs.get_lower())),
+      upper_extended(
+        constant_interval_exprt::less_than(lhs.get_upper(), rhs.get_upper())),
+      ns_(symbol_tablet{}),
+      lower_(
+        constant_interval_exprt::get_min(lhs.get_lower(), rhs.get_lower())),
+      upper_(
+        constant_interval_exprt::get_max(lhs.get_upper(), rhs.get_upper())),
+      range_(
+        plus_exprt(minus_exprt(upper_, lower_), from_integer(1, lhs.type()))),
+      lower_bound(make_lower_bound()),
+      upper_bound(make_upper_bound())
+  {
+  }
+
+  const bool lower_extended;
+  const bool upper_extended;
+
+private:
+  namespacet ns_;
+  exprt lower_;
+  exprt upper_;
+  exprt range_;
+
+public:
+  const exprt lower_bound;
+  const exprt upper_bound;
+
+private:
+  exprt make_lower_bound() const;
+  exprt make_upper_bound() const;
+};
+
+#endif // CPROVER_ANALYSES_VARIABLE_SENSITIVITY_WIDENED_RANGE_H

--- a/src/analyses/variable-sensitivity/widened_range.h
+++ b/src/analyses/variable-sensitivity/widened_range.h
@@ -20,38 +20,39 @@ public:
   widened_ranget(
     const constant_interval_exprt &lhs,
     const constant_interval_exprt &rhs)
-    : lower_extended(
+    : is_lower_widened(
         constant_interval_exprt::less_than(rhs.get_lower(), lhs.get_lower())),
-      upper_extended(
+      is_upper_widened(
         constant_interval_exprt::less_than(lhs.get_upper(), rhs.get_upper())),
-      ns_(symbol_tablet{}),
-      lower_(
+      lower_bound(
         constant_interval_exprt::get_min(lhs.get_lower(), rhs.get_lower())),
-      upper_(
+      upper_bound(
         constant_interval_exprt::get_max(lhs.get_upper(), rhs.get_upper())),
-      range_(
-        plus_exprt(minus_exprt(upper_, lower_), from_integer(1, lhs.type()))),
-      lower_bound(make_lower_bound()),
-      upper_bound(make_upper_bound())
+      ns_(symbol_tablet{}),
+      range_(plus_exprt(
+        minus_exprt(upper_bound, lower_bound),
+        from_integer(1, lhs.type()))),
+      widened_lower_bound(widen_lower_bound()),
+      widened_upper_bound(widen_upper_bound())
   {
   }
 
-  const bool lower_extended;
-  const bool upper_extended;
-
-private:
-  namespacet ns_;
-  exprt lower_;
-  exprt upper_;
-  exprt range_;
-
-public:
+  const bool is_lower_widened;
+  const bool is_upper_widened;
   const exprt lower_bound;
   const exprt upper_bound;
 
 private:
-  exprt make_lower_bound() const;
-  exprt make_upper_bound() const;
+  namespacet ns_;
+  exprt range_;
+
+public:
+  const exprt widened_lower_bound;
+  const exprt widened_upper_bound;
+
+private:
+  exprt widen_lower_bound() const;
+  exprt widen_upper_bound() const;
 };
 
 #endif // CPROVER_ANALYSES_VARIABLE_SENSITIVITY_WIDENED_RANGE_H

--- a/unit/analyses/variable-sensitivity/interval_abstract_value/widening_merge.cpp
+++ b/unit/analyses/variable-sensitivity/interval_abstract_value/widening_merge.cpp
@@ -13,8 +13,9 @@
 #include <util/arith_tools.h>
 #include <util/bitvector_types.h>
 
-static merge_result<const interval_abstract_valuet>
-widening_merge(const abstract_object_pointert &op1, const abstract_object_pointert &op2)
+static merge_result<const interval_abstract_valuet> widening_merge(
+  const abstract_object_pointert &op1,
+  const abstract_object_pointert &op2)
 {
   auto result = abstract_objectt::merge(op1, op2, widen_modet::could_widen);
 
@@ -319,7 +320,7 @@ SCENARIO(
     }
     WHEN("merging [0, 1] with [1, very_large]")
     {
-      auto veryLarge = from_integer(2<<29, type);
+      auto veryLarge = from_integer(2 << 29, type);
       auto op1 = make_interval(val0, val1, environment, ns);
       auto op2 = make_interval(val1, veryLarge, environment, ns);
 
@@ -328,6 +329,114 @@ SCENARIO(
       THEN("result is [0, MAX]")
       {
         EXPECT_MODIFIED(merged, val0, valMax);
+      }
+    }
+
+    WHEN("merging [1, 10] with [MIN, 1]")
+    {
+      auto op1 = make_interval(val1, val10, environment, ns);
+      auto op2 = make_interval(valMin, val1, environment, ns);
+
+      auto merged = widening_merge(op1, op2);
+
+      THEN("result is [MIN, 10]")
+      {
+        EXPECT_MODIFIED(merged, valMin, val10);
+      }
+    }
+    WHEN("merging [0, 1] with [-very_large, 1]")
+    {
+      auto veryLargeMinus = from_integer(-(2 << 29), type);
+      auto op1 = make_interval(val0, val1, environment, ns);
+      auto op2 = make_interval(veryLargeMinus, val1, environment, ns);
+
+      auto merged = widening_merge(op1, op2);
+
+      THEN("result is [MIN, 1]")
+      {
+        EXPECT_MODIFIED(merged, valMin, val1);
+      }
+    }
+
+    WHEN("merging [1, MAX] with [MIN, 1]")
+    {
+      auto op1 = make_interval(val1, valMax, environment, ns);
+      auto op2 = make_interval(valMin, val1, environment, ns);
+
+      auto merged = widening_merge(op1, op2);
+
+      THEN("result is TOP - ie [MIN, MAX]")
+      {
+        EXPECT_MODIFIED_TOP(merged);
+      }
+    }
+    WHEN("merging [MIN, 1] with [1, MAX]")
+    {
+      auto op1 = make_interval(valMin, val1, environment, ns);
+      auto op2 = make_interval(val1, valMax, environment, ns);
+
+      auto merged = widening_merge(op1, op2);
+
+      THEN("result is TOP - ie [MIN, MAX]")
+      {
+        EXPECT_MODIFIED_TOP(merged);
+      }
+    }
+    WHEN("merging [0, very_large] with [-very_large, 0]")
+    {
+      auto veryLarge = from_integer(2 << 29, type);
+      auto veryLargeMinus = from_integer(-(2 << 29), type);
+      auto op1 = make_interval(val0, veryLarge, environment, ns);
+      auto op2 = make_interval(veryLargeMinus, val0, environment, ns);
+
+      auto merged = widening_merge(op1, op2);
+
+      THEN("result is [MIN, very_large]")
+      {
+        EXPECT_MODIFIED(merged, valMin, veryLarge);
+      }
+    }
+    WHEN("merging [-very_large, 0] with [0, very_large]")
+    {
+      auto veryLarge = from_integer(2 << 29, type);
+      auto veryLargeMinus = from_integer(-(2 << 29), type);
+      auto op1 = make_interval(veryLargeMinus, val0, environment, ns);
+      auto op2 = make_interval(val0, veryLarge, environment, ns);
+
+      auto merged = widening_merge(op1, op2);
+
+      THEN("result is [-very_large, MAX]")
+      {
+        EXPECT_MODIFIED(merged, veryLargeMinus, valMax);
+      }
+    }
+
+    WHEN("merging [-very_large, very_large] with [0, 1]")
+    {
+      auto veryLarge = from_integer(2 << 29, type);
+      auto veryLargeMinus = from_integer(-(2 << 29), type);
+      auto op1 = make_interval(veryLargeMinus, veryLarge, environment, ns);
+      auto op2 = make_interval(val0, val1, environment, ns);
+
+      auto merged = widening_merge(op1, op2);
+
+      THEN("result is [-very_large, very_large]")
+      {
+        EXPECT_UNMODIFIED(merged, veryLargeMinus, veryLarge);
+      }
+    }
+    WHEN("merging [0, 1] with [-very_large, very_large]")
+    {
+      auto veryLarge = from_integer(2 << 29, type);
+      auto veryLargeMinus = from_integer(-(2 << 29), type);
+      auto op1 = make_interval(val0, val1, environment, ns);
+      auto op2 = make_interval(veryLargeMinus, veryLarge, environment, ns);
+
+      auto merged = widening_merge(op1, op2);
+
+      THEN("result is TOP, ie [MIN, MAX]")
+      {
+        EXPECT_MODIFIED_TOP(merged);
       }
     }
   }

--- a/unit/analyses/variable-sensitivity/interval_abstract_value/widening_merge.cpp
+++ b/unit/analyses/variable-sensitivity/interval_abstract_value/widening_merge.cpp
@@ -332,6 +332,43 @@ SCENARIO(
         EXPECT_MODIFIED(merged, val0, valMax);
       }
     }
+    WHEN("merging [0, 1] with [1, unsigned_very_large]")
+    {
+      auto utype = unsignedbv_typet(32);
+      auto uval0 = from_integer(0, utype);
+      auto uval1 = from_integer(1, utype);
+      auto uVeryLarge = from_integer(2 << 30, utype);
+
+      auto op1 = make_interval(uval0, uval1, environment, ns);
+      auto op2 = make_interval(uval1, uVeryLarge, environment, ns);
+
+      auto merged = widening_merge(op1, op2);
+
+      THEN("result is [0, MAX]")
+      {
+        auto uvalMax = max_exprt(utype);
+        EXPECT_MODIFIED(merged, uval0, uvalMax);
+      }
+    }
+    WHEN("merging unsigned [7, 9] with [3, 6]")
+    {
+      auto utype = unsignedbv_typet(32);
+      auto uval0 = from_integer(0, utype);
+      auto uval3 = from_integer(3, utype);
+      auto uval6 = from_integer(6, utype);
+      auto uval7 = from_integer(7, utype);
+      auto uval9 = from_integer(9, utype);
+
+      auto op1 = make_interval(uval7, uval9, environment, ns);
+      auto op2 = make_interval(uval3, uval6, environment, ns);
+
+      auto merged = widening_merge(op1, op2);
+
+      THEN("result is [0, 9]")
+      {
+        EXPECT_MODIFIED(merged, uval0, uval9);
+      }
+    }
 
     WHEN("merging [1, 10] with [MIN, 1]")
     {

--- a/unit/analyses/variable-sensitivity/interval_abstract_value/widening_merge.cpp
+++ b/unit/analyses/variable-sensitivity/interval_abstract_value/widening_merge.cpp
@@ -14,7 +14,7 @@
 #include <util/bitvector_types.h>
 
 static merge_result<const interval_abstract_valuet>
-widening_merge(abstract_object_pointert op1, abstract_object_pointert op2)
+widening_merge(const abstract_object_pointert &op1, const abstract_object_pointert &op2)
 {
   auto result = abstract_objectt::merge(op1, op2, widen_modet::could_widen);
 
@@ -41,6 +41,8 @@ SCENARIO(
   const exprt val5minus = from_integer(-5, type);
   const exprt val8minus = from_integer(-8, type);
   const exprt val10minus = from_integer(-10, type);
+  auto valMax = max_exprt(type);
+  auto valMin = min_exprt(type);
 
   auto config = vsd_configt::constant_domain();
   config.context_tracking.data_dependency_context = false;
@@ -300,6 +302,32 @@ SCENARIO(
       THEN("result is widen both bounds - [-10, 4]")
       {
         EXPECT_MODIFIED(merged, val10minus, val4);
+      }
+    }
+
+    WHEN("merging [1, 10] with [1, MAX]")
+    {
+      auto op1 = make_interval(val1, val10, environment, ns);
+      auto op2 = make_interval(val1, valMax, environment, ns);
+
+      auto merged = widening_merge(op1, op2);
+
+      THEN("result is [1, MAX]")
+      {
+        EXPECT_MODIFIED(merged, val1, valMax);
+      }
+    }
+    WHEN("merging [0, 1] with [1, very_large]")
+    {
+      auto veryLarge = from_integer(2<<29, type);
+      auto op1 = make_interval(val0, val1, environment, ns);
+      auto op2 = make_interval(val1, veryLarge, environment, ns);
+
+      auto merged = widening_merge(op1, op2);
+
+      THEN("result is [0, MAX]")
+      {
+        EXPECT_MODIFIED(merged, val0, valMax);
       }
     }
   }

--- a/unit/analyses/variable-sensitivity/interval_abstract_value/widening_merge.cpp
+++ b/unit/analyses/variable-sensitivity/interval_abstract_value/widening_merge.cpp
@@ -44,6 +44,8 @@ SCENARIO(
   const exprt val10minus = from_integer(-10, type);
   auto valMax = max_exprt(type);
   auto valMin = min_exprt(type);
+  auto veryLarge = from_integer(2 << 29, type);
+  auto veryLargeMinus = from_integer(-(2 << 29), type);
 
   auto config = vsd_configt::constant_domain();
   config.context_tracking.data_dependency_context = false;
@@ -320,7 +322,6 @@ SCENARIO(
     }
     WHEN("merging [0, 1] with [1, very_large]")
     {
-      auto veryLarge = from_integer(2 << 29, type);
       auto op1 = make_interval(val0, val1, environment, ns);
       auto op2 = make_interval(val1, veryLarge, environment, ns);
 
@@ -346,7 +347,6 @@ SCENARIO(
     }
     WHEN("merging [0, 1] with [-very_large, 1]")
     {
-      auto veryLargeMinus = from_integer(-(2 << 29), type);
       auto op1 = make_interval(val0, val1, environment, ns);
       auto op2 = make_interval(veryLargeMinus, val1, environment, ns);
 
@@ -384,8 +384,6 @@ SCENARIO(
     }
     WHEN("merging [0, very_large] with [-very_large, 0]")
     {
-      auto veryLarge = from_integer(2 << 29, type);
-      auto veryLargeMinus = from_integer(-(2 << 29), type);
       auto op1 = make_interval(val0, veryLarge, environment, ns);
       auto op2 = make_interval(veryLargeMinus, val0, environment, ns);
 
@@ -398,8 +396,6 @@ SCENARIO(
     }
     WHEN("merging [-very_large, 0] with [0, very_large]")
     {
-      auto veryLarge = from_integer(2 << 29, type);
-      auto veryLargeMinus = from_integer(-(2 << 29), type);
       auto op1 = make_interval(veryLargeMinus, val0, environment, ns);
       auto op2 = make_interval(val0, veryLarge, environment, ns);
 
@@ -413,8 +409,6 @@ SCENARIO(
 
     WHEN("merging [-very_large, very_large] with [0, 1]")
     {
-      auto veryLarge = from_integer(2 << 29, type);
-      auto veryLargeMinus = from_integer(-(2 << 29), type);
       auto op1 = make_interval(veryLargeMinus, veryLarge, environment, ns);
       auto op2 = make_interval(val0, val1, environment, ns);
 
@@ -427,8 +421,6 @@ SCENARIO(
     }
     WHEN("merging [0, 1] with [-very_large, very_large]")
     {
-      auto veryLarge = from_integer(2 << 29, type);
-      auto veryLargeMinus = from_integer(-(2 << 29), type);
       auto op1 = make_interval(val0, val1, environment, ns);
       auto op2 = make_interval(veryLargeMinus, veryLarge, environment, ns);
 


### PR DESCRIPTION
During a widening merge, it is possible for the upper or lower bound to be extended to integer limits - `max_exprt(type)` or `min_exprt(type)`. This was not handled gracefully and could have resulted in an (inappropriate) invariant violation constructing new intervals. Extreme values, along with overflow and underflow calculating new bounds, are now handled appropriately. 