### PR TITLE
SMT2 parser: use lambda for function defintions

### DIFF
--- a/src/solvers/smt2/smt2_parser.h
+++ b/src/solvers/smt2/smt2_parser.h
@@ -49,8 +49,9 @@ public:
 
     kindt kind;
     typet type;
+
+    // this is a lambda when the symbol is a function
     exprt definition;
-    std::vector<irep_idt> parameters;
   };
 
   using id_mapt=std::map<irep_idt, idt>;
@@ -95,7 +96,7 @@ protected:
 
   // add the given identifier to the id_map but
   // complain if that identifier is used already
-  void add_unique_id(const irep_idt &, const exprt &);
+  void add_unique_id(irep_idt, exprt);
 
   struct signature_with_parameter_idst
   {
@@ -132,6 +133,15 @@ protected:
           result.emplace_back(parameters[i], domain[i]);
         return result;
       }
+    }
+
+    // convenience helper for constructing a binding
+    binding_exprt::variablest binding_variables() const
+    {
+      binding_exprt::variablest result;
+      for(auto &pair : ids_and_types())
+        result.emplace_back(pair.first, pair.second);
+      return result;
     }
   };
 

--- a/src/solvers/smt2/smt2_solver.cpp
+++ b/src/solvers/smt2/smt2_solver.cpp
@@ -105,17 +105,12 @@ void smt2_solvert::expand_function_applications(exprt &expr)
         // Does it have a definition? It's otherwise uninterpreted.
         if(!f.definition.is_nil())
         {
-          replace_symbolt replace_symbol;
-
-          for(std::size_t i = 0; i < domain.size(); i++)
-          {
-            replace_symbol.insert(
-              symbol_exprt(f.parameters[i], domain[i]), app.arguments()[i]);
-          }
-
           exprt body = f.definition;
-          replace_symbol(body);
-          expand_function_applications(body);
+
+          if(body.id() == ID_lambda)
+            body = to_lambda_expr(body).application(app.arguments());
+
+          expand_function_applications(body); // rec. call
           expr = body;
         }
       }


### PR DESCRIPTION
This removes special casing for function definitions by using a lambda
expression for the definition instead of a pair of an expression and a
vector of identifiers.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
