### PR TITLE
array_comprehension_exprt is now a binding_exprt

### DIFF
--- a/src/util/std_expr.h
+++ b/src/util/std_expr.h
@@ -3009,16 +3009,16 @@ inline cond_exprt &to_cond_expr(exprt &expr)
 /// function, respectively. The range is given by the type of the expression,
 /// which has to be an \ref array_typet (which includes a value for
 /// `array_size`).
-class array_comprehension_exprt : public binary_exprt
+class array_comprehension_exprt : public binding_exprt
 {
 public:
   explicit array_comprehension_exprt(
     symbol_exprt arg,
     exprt body,
     array_typet _type)
-    : binary_exprt(
-        std::move(arg),
+    : binding_exprt(
         ID_array_comprehension,
+        {std::move(arg)},
         std::move(body),
         std::move(_type))
   {
@@ -3036,22 +3036,26 @@ public:
 
   const symbol_exprt &arg() const
   {
-    return static_cast<const symbol_exprt &>(op0());
+    auto &variables = this->variables();
+    PRECONDITION(variables.size() == 1);
+    return variables[0];
   }
 
   symbol_exprt &arg()
   {
-    return static_cast<symbol_exprt &>(op0());
+    auto &variables = this->variables();
+    PRECONDITION(variables.size() == 1);
+    return variables[0];
   }
 
   const exprt &body() const
   {
-    return op1();
+    return where();
   }
 
   exprt &body()
   {
-    return op1();
+    return where();
   }
 };
 


### PR DESCRIPTION
The array comprehension expression introduces a local-scope symbol, and is
therefore a binding.  This commit reflects this in the type hierarchy.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
