### PR TITLE
Refactored parsing rules for function contracts

### DIFF
--- a/src/ansi-c/parser.y
+++ b/src/ansi-c/parser.y
@@ -3230,7 +3230,7 @@ parameter_abstract_declarator:
         | parameter_postfix_abstract_declarator
         ;
 
-cprover_contract:
+cprover_function_contract:
           TOK_CPROVER_ENSURES '(' ACSL_binding_expression ')'
         {
           $$=$1;
@@ -3243,7 +3243,11 @@ cprover_contract:
           set($$, ID_C_spec_requires);
           mto($$, $3);
         }
-        | TOK_CPROVER_ASSIGNS '(' argument_expression_list ')'
+        | cprover_contract_assigns_opt
+        ;
+
+cprover_contract_assigns_opt:
+         TOK_CPROVER_ASSIGNS '(' argument_expression_list ')'
         {
           $$=$1;
           set($$, ID_C_spec_assigns);
@@ -3252,19 +3256,19 @@ cprover_contract:
         }
         ;
 
-cprover_contract_sequence:
-          cprover_contract
-        | cprover_contract_sequence cprover_contract
+cprover_function_contract_sequence:
+          cprover_function_contract
+        | cprover_function_contract_sequence cprover_function_contract
         {
           $$=$1;
           merge($$, $2);
         }
         ;
 
-cprover_contract_sequence_opt:
+cprover_function_contract_sequence_opt:
           /* nothing */
           { init($$); }
-        | cprover_contract_sequence
+        | cprover_function_contract_sequence
         ;
 
 postfixing_abstract_declarator:
@@ -3305,7 +3309,7 @@ postfixing_abstract_declarator:
 parameter_postfixing_abstract_declarator:
           array_abstract_declarator
         | '(' ')'
-          cprover_contract_sequence_opt
+          cprover_function_contract_sequence_opt
         {
           set($1, ID_code);
           stack_type($1).add(ID_parameters);
@@ -3322,7 +3326,7 @@ parameter_postfixing_abstract_declarator:
           parameter_type_list
           ')'
           KnR_parameter_header_opt
-          cprover_contract_sequence_opt
+          cprover_function_contract_sequence_opt
         {
           set($1, ID_code);
           stack_type($1).subtype()=typet(ID_abstract);


### PR DESCRIPTION
The following four changes were made:

1. cprover_contract renamed to cprover_function_contract.
2. cprover_contract_sequence renamed to cprover_function_contract_sequence.
3. cprover_contract_sequence_opt renamed to cprover_function_contract_sequence_opt.
4. Refactored the assigns clause in cprover_function_contract by creating cprover_contract_assigns_opt. 

This was done so we can reuse cprover_contract_assigns_opt for future use in Loop Contracts. 

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [x] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [x] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
