### PR TITLE
Parser support for assigns contracts on loops

### DIFF
--- a/regression/contracts/invar_assigns_alias_analysis/main.c
+++ b/regression/contracts/invar_assigns_alias_analysis/main.c
@@ -1,0 +1,27 @@
+#include <assert.h>
+#include <stdlib.h>
+
+#define SIZE 8
+
+struct blob
+{
+  char *data;
+};
+
+void main()
+{
+  struct blob *b = malloc(sizeof(struct blob));
+  b->data = malloc(SIZE);
+
+  b->data[5] = 0;
+  for(unsigned i = 0; i < SIZE; i++)
+    // clang-format off
+    __CPROVER_assigns(b->data)
+    __CPROVER_loop_invariant(i <= SIZE)
+    // clang-format on
+    {
+      b->data[i] = 1;
+    }
+
+  assert(b->data[5] == 0);
+}

--- a/regression/contracts/invar_assigns_alias_analysis/test.desc
+++ b/regression/contracts/invar_assigns_alias_analysis/test.desc
@@ -1,0 +1,14 @@
+KNOWNBUG
+main.c
+--apply-loop-contracts
+^EXIT=0$
+^SIGNAL=0$
+^\[main.1\] .* Check loop invariant before entry: SUCCESS$
+^\[main.2\] .* Check that loop invariant is preserved: SUCCESS$
+^\[main.assertion.1\] .* assertion b->data[5] == 0: FAILURE$
+^VERIFICATION FAILED$
+--
+--
+This test shows the need for assigns clauses. Currently we only
+parse the assigns clause for loops, but there is no implementation
+to actually enforce them. In the future, we will add this feature.

--- a/regression/contracts/invar_assigns_empty/main.c
+++ b/regression/contracts/invar_assigns_empty/main.c
@@ -1,0 +1,15 @@
+#include <assert.h>
+
+int main()
+{
+  int r;
+  __CPROVER_assume(r >= 0);
+  while(r > 0)
+    __CPROVER_assigns() __CPROVER_loop_invariant(r >= 0)
+    {
+      r--;
+    }
+  assert(r == 0);
+
+  return 0;
+}

--- a/regression/contracts/invar_assigns_empty/test.desc
+++ b/regression/contracts/invar_assigns_empty/test.desc
@@ -1,0 +1,13 @@
+CORE
+main.c
+--apply-loop-contracts
+^EXIT=0$
+^SIGNAL=0$
+^\[main.1\] .* Check loop invariant before entry: SUCCESS$
+^\[main.2\] .* Check that loop invariant is preserved: SUCCESS$
+^\[main.assertion.1\] .* assertion r == 0: SUCCESS$
+^VERIFICATION SUCCESSFUL$
+--
+--
+This test checks that empty assigns clause is supported 
+in loop contracts.

--- a/regression/contracts/invar_assigns_opt/main.c
+++ b/regression/contracts/invar_assigns_opt/main.c
@@ -1,0 +1,26 @@
+#include <assert.h>
+
+int main()
+{
+  int r1, s1 = 1;
+  __CPROVER_assume(r1 >= 0);
+  while(r1 > 0)
+    __CPROVER_loop_invariant(r1 >= 0 && s1 == 1) __CPROVER_decreases(r1)
+    {
+      s1 = 1;
+      r1--;
+    }
+  assert(r1 == 0);
+
+  int r2, s2 = 1;
+  __CPROVER_assume(r2 >= 0);
+  while(r2 > 0)
+    __CPROVER_assigns(r2, s2) __CPROVER_loop_invariant(r2 >= 0 && s2 == 1)
+      __CPROVER_decreases(r2)
+    {
+      s2 = 1;
+      r2--;
+    }
+  assert(r2 == 0);
+  return 0;
+}

--- a/regression/contracts/invar_assigns_opt/test.desc
+++ b/regression/contracts/invar_assigns_opt/test.desc
@@ -1,0 +1,20 @@
+CORE
+main.c
+--apply-loop-contracts
+^EXIT=0$
+^SIGNAL=0$
+^\[main.1\] .* Check loop invariant before entry: SUCCESS$
+^\[main.2\] .* Check that loop invariant is preserved: SUCCESS$
+^\[main.3\] .* Check decreases clause on loop iteration: SUCCESS$
+^\[main.assertion.1\] .* assertion r1 == 0: SUCCESS$
+^\[main.4\] .* Check loop invariant before entry: SUCCESS$
+^\[main.5\] .* Check that loop invariant is preserved: SUCCESS$
+^\[main.6\] .* Check decreases clause on loop iteration: SUCCESS$
+^\[main.assertion.2\] .* assertion r2 == 0: SUCCESS$
+^VERIFICATION SUCCESSFUL$
+--
+--
+This test checks that adding assigns clause is optional
+and that if a proof does not require it, then adding an
+appropriate assigns clause does not lead to any 
+unexpected behavior. 


### PR DESCRIPTION
1. Created cprover_loop_contract that has cprover_contract_assigns_opt and loop_invariant_opt.

This adds support for parsing assigns clauses for loops.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [x] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
