### PR TITLE
SMT-LIB2 parser now models bit-vector division by zero correctly

### DIFF
--- a/regression/smt2_solver/basic-bv1/basic-bv1.smt2
+++ b/regression/smt2_solver/basic-bv1/basic-bv1.smt2
@@ -8,19 +8,24 @@
 (define-fun b03 () Bool (= (bvneg #x07) #xf9)) ; unary minus
 (define-fun b04 () Bool (= (bvmul #x07 #x03) #x15)) ; multiplication
 (define-fun b05 () Bool (= (bvurem #x07 #x03) #x01)) ; unsigned remainder
-(define-fun b06 () Bool (= (bvsrem #x07 #x03) #x01)) ; signed remainder
-(define-fun b07 () Bool (= (bvsmod #x07 #x03) #x01)) ; signed modulo
-(define-fun b08 () Bool (= (bvshl #x07 #x03) #x38)) ; shift left
-(define-fun b09 () Bool (= (bvlshr #xf0 #x03) #x1e)) ; unsigned (logical) shift right
-(define-fun b10 () Bool (= (bvashr #xf0 #x03) #xfe)) ; signed (arithmetical) shift right#x0a
+(define-fun b06 () Bool (= (bvurem #x07 #x00) #x07)) ; unsigned remainder (div. by zero)
+(define-fun b07 () Bool (= (bvudiv #x01 #x00) #xff)) ; unsigned division (div. by zero)
+(define-fun b08 () Bool (= (bvsrem #x07 #x03) #x01)) ; signed remainder
+(define-fun b09 () Bool (= (bvsrem #x07 #x00) #x07)) ; signed remainder (div. by zero)
+(define-fun b10 () Bool (= (bvsmod #x07 #x03) #x01)) ; signed modulo
+(define-fun b11 () Bool (= (bvsmod #x07 #x00) #x07)) ; signed modulo (div. by zero)
+(define-fun b12 () Bool (= (bvsdiv #x01 #x00) #xff)) ; signed division (div. by zero)
+(define-fun b13 () Bool (= (bvshl #x07 #x03) #x38)) ; shift left
+(define-fun b14 () Bool (= (bvlshr #xf0 #x03) #x1e)) ; unsigned (logical) shift right
+(define-fun b15 () Bool (= (bvashr #xf0 #x03) #xfe)) ; signed (arithmetical) shift right#x0a
 
 ; Multi-ary variants, where applicable
-(define-fun b11 () Bool (= (bvadd #x07 #x03 #x01) #x0b)) ; addition
-(define-fun b12 () Bool (= (bvmul #x07 #x03 #x01) #x15)) ; multiplication
+(define-fun b16 () Bool (= (bvadd #x07 #x03 #x01) #x0b)) ; addition
+(define-fun b17 () Bool (= (bvmul #x07 #x03 #x01) #x15)) ; multiplication
 
 ; rotation
-(define-fun b13 () Bool (= ((_ rotate_left 2) #xf7) #xdf)) ; rotation left
-(define-fun b14 () Bool (= ((_ rotate_right 2) #x07) #xc1)) ; rotation right
+(define-fun b18 () Bool (= ((_ rotate_left 2) #xf7) #xdf)) ; rotation left
+(define-fun b19 () Bool (= ((_ rotate_right 2) #x07) #xc1)) ; rotation right
 
 ; Bitwise Operations
 
@@ -67,7 +72,7 @@
 ; all must be true
 
 (assert (not (and
-  b01 b02 b03 b04 b05 b06 b07 b08 b09 b10 b11 b12 b13 b14
+  b01 b02 b03 b04 b05 b06 b07 b08 b09 b10 b11 b12 b13 b14 b15 b16 b17 b18 b19
   d01
   power-test
   p1 p2 p3 p4 p5 p6 p7 p8)))

--- a/src/solvers/smt2/smt2_parser.h
+++ b/src/solvers/smt2/smt2_parser.h
@@ -162,6 +162,8 @@ protected:
   exprt binary_predicate(irep_idt, const exprt::operandst &);
   exprt binary(irep_idt, const exprt::operandst &);
   exprt unary(irep_idt, const exprt::operandst &);
+  exprt bv_division(const exprt::operandst &, bool is_signed);
+  exprt bv_mod(const exprt::operandst &, bool is_signed);
 
   exprt let_expression();
   exprt quantifier_expression(irep_idt);


### PR DESCRIPTION
SMT-LIB2 defines the result of `bvsdiv` and `bvudiv` to be 1...1.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [X] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
