### PR TITLE
SMT parser: function sorts -> and lambda terms

### DIFF
--- a/regression/smt2_solver/function-applications/lambda1.desc
+++ b/regression/smt2_solver/function-applications/lambda1.desc
@@ -1,0 +1,7 @@
+CORE
+lambda1.smt2
+
+^EXIT=0$
+^SIGNAL=0$
+^unsat$
+--

--- a/regression/smt2_solver/function-applications/lambda1.smt2
+++ b/regression/smt2_solver/function-applications/lambda1.smt2
@@ -1,0 +1,14 @@
+(set-logic QF_BV)
+
+(define-const min (-> (_ BitVec 8) (_ BitVec 8) (_ BitVec 8))
+  (lambda ((a (_ BitVec 8)) (b (_ BitVec 8))) 
+    (ite (bvule a b) a b)))
+
+(define-fun p1 () Bool (= (min #x01 #x02) #x01))
+(define-fun p2 () Bool (= (min #xff #xfe) #xfe))
+
+; all must be true
+
+(assert (not (and p1 p2)))
+
+(check-sat)

--- a/src/solvers/smt2/smt2_parser.cpp
+++ b/src/solvers/smt2/smt2_parser.cpp
@@ -275,6 +275,12 @@ std::pair<binding_exprt::variablest, exprt> smt2_parsert::binding(irep_idt id)
   return {std::move(bindings), std::move(expr)};
 }
 
+exprt smt2_parsert::lambda_expression()
+{
+  auto binding = this->binding(ID_lambda);
+  return lambda_exprt(binding.first, binding.second);
+}
+
 exprt smt2_parsert::quantifier_expression(irep_idt id)
 {
   auto binding = this->binding(id);
@@ -972,6 +978,7 @@ void smt2_parsert::setup_expressions()
     return from_integer(ieee_floatt::ROUND_TO_ZERO, unsignedbv_typet(32));
   };
 
+  expressions["lambda"] = [this] { return lambda_expression(); };
   expressions["let"] = [this] { return let_expression(); };
   expressions["exists"] = [this] { return quantifier_expression(ID_exists); };
   expressions["forall"] = [this] { return quantifier_expression(ID_forall); };

--- a/src/solvers/smt2/smt2_parser.h
+++ b/src/solvers/smt2/smt2_parser.h
@@ -164,6 +164,7 @@ protected:
   exprt unary(irep_idt, const exprt::operandst &);
 
   std::pair<binding_exprt::variablest, exprt> binding(irep_idt);
+  exprt lambda_expression();
   exprt let_expression();
   exprt quantifier_expression(irep_idt);
   exprt function_application(

--- a/src/solvers/smt2/smt2_parser.h
+++ b/src/solvers/smt2/smt2_parser.h
@@ -177,6 +177,7 @@ protected:
 
   // sorts
   typet sort();
+  typet function_sort();
   std::unordered_map<std::string, std::function<typet()>> sorts;
   void setup_sorts();
 

--- a/src/solvers/smt2/smt2_parser.h
+++ b/src/solvers/smt2/smt2_parser.h
@@ -163,6 +163,7 @@ protected:
   exprt binary(irep_idt, const exprt::operandst &);
   exprt unary(irep_idt, const exprt::operandst &);
 
+  std::pair<binding_exprt::variablest, exprt> binding(irep_idt);
   exprt let_expression();
   exprt quantifier_expression(irep_idt);
   exprt function_application(


### PR DESCRIPTION
This adds support for parsing the candidate SMT-LIB 3 function sorts and lambda terms.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [X] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
