### PR TITLE
Fix bool versus bitvec 1 sort mismtach for CVC4

### DIFF
--- a/src/solvers/smt2/smt2_conv.cpp
+++ b/src/solvers/smt2/smt2_conv.cpp
@@ -96,6 +96,7 @@ smt2_convt::smt2_convt(
     break;
 
   case solvert::CVC4:
+    use_array_of_bool = true;
     use_as_const = true;
     break;
 


### PR DESCRIPTION
This fixes a sort mismatch that can occur in CVC4 where an
array of booleans is translated into an array of (_ bitvec 1)
which is then a mismatch when CVC4 expects and can handle an
Array of Bool.

This solves some of the problems in #5977 .

Note that there are NO TESTS for this since we do not support cvc4 in CI.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
