### PR TITLE
allow multiple loop invariants

### DIFF
--- a/regression/contracts/invar_check_multiple_loops/main.c
+++ b/regression/contracts/invar_check_multiple_loops/main.c
@@ -7,7 +7,8 @@ int main()
 
   for(r = 0; r < n; ++r)
     // clang-format off
-    __CPROVER_loop_invariant(0 <= r && r <= n && x == y + r)
+    __CPROVER_loop_invariant(0 <= r && r <= n)
+    __CPROVER_loop_invariant(x == y + r)
     __CPROVER_decreases(n - r)
     // clang-format on
     {

--- a/src/ansi-c/c_typecheck_code.cpp
+++ b/src/ansi-c/c_typecheck_code.cpp
@@ -815,10 +815,12 @@ void c_typecheck_baset::typecheck_spec_loop_invariant(codet &code)
 {
   if(code.find(ID_C_spec_loop_invariant).is_not_nil())
   {
-    exprt &invariant = static_cast<exprt &>(code.add(ID_C_spec_loop_invariant));
-
-    typecheck_expr(invariant);
-    implicit_typecast_bool(invariant);
+    for(auto &invariant :
+        (static_cast<exprt &>(code.add(ID_C_spec_loop_invariant)).operands()))
+    {
+      typecheck_expr(invariant);
+      implicit_typecast_bool(invariant);
+    }
   }
 }
 

--- a/src/goto-instrument/code_contracts.cpp
+++ b/src/goto-instrument/code_contracts.cpp
@@ -149,6 +149,11 @@ void code_contractst::check_apply_loop_contracts(
         << messaget::eom;
     }
   }
+  else
+  {
+    // form the conjunction
+    invariant = conjunction(invariant.operands());
+  }
 
   // change
   //   H: loop;


### PR DESCRIPTION
This extends the grammar to allow multiple loop invariants for one loop.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [X] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
