### PR TITLE
SMT cache values and handle z3 errors

### DIFF
--- a/regression/cbmc/Float-div3/test.desc
+++ b/regression/cbmc/Float-div3/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE broken-z3-smt-backend
 main.c
 --floatbv
 ^EXIT=0$

--- a/regression/cbmc/Quantifiers-assertion/test.desc
+++ b/regression/cbmc/Quantifiers-assertion/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE broken-z3-smt-backend
 main.c
 
 ^\*\* Results:$

--- a/regression/cbmc/Quantifiers-assignment/test.desc
+++ b/regression/cbmc/Quantifiers-assignment/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE broken-z3-smt-backend
 main.c
 
 ^\*\* Results:$

--- a/regression/cbmc/Quantifiers-if/test.desc
+++ b/regression/cbmc/Quantifiers-if/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE broken-z3-smt-backend
 main.c
 
 ^\*\* Results:$

--- a/regression/cbmc/Quantifiers-initialisation2/test.desc
+++ b/regression/cbmc/Quantifiers-initialisation2/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE broken-z3-smt-backend
 main.c
 
 ^\*\* Results:$

--- a/regression/cbmc/Quantifiers-not-exists/fixed.desc
+++ b/regression/cbmc/Quantifiers-not-exists/fixed.desc
@@ -1,4 +1,4 @@
-CORE
+CORE broken-z3-smt-backend
 fixed.c
 
 ^\*\* Results:$

--- a/regression/cbmc/Quantifiers-not/test.desc
+++ b/regression/cbmc/Quantifiers-not/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE broken-z3-smt-backend
 main.c
 
 ^\*\* Results:$

--- a/regression/cbmc/Quantifiers-two-dimension-array/test.desc
+++ b/regression/cbmc/Quantifiers-two-dimension-array/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE broken-z3-smt-backend
 main.c
 
 ^\*\* Results:$

--- a/regression/cbmc/enum-trace1/test_json.desc
+++ b/regression/cbmc/enum-trace1/test_json.desc
@@ -1,4 +1,4 @@
-CORE broken-smt-backend
+CORE
 main.c
 --json-ui --function test --trace
 activate-multi-line-match

--- a/regression/cbmc/json-interface1/test.desc
+++ b/regression/cbmc/json-interface1/test.desc
@@ -1,4 +1,4 @@
-CORE broken-smt-backend
+CORE
 --json-interface
 < test.json
 activate-multi-line-match

--- a/regression/cbmc/json1/test.desc
+++ b/regression/cbmc/json1/test.desc
@@ -1,4 +1,4 @@
-CORE broken-smt-backend
+CORE
 main.c
 --json-ui --stop-on-fail
 activate-multi-line-match

--- a/regression/cbmc/union10/union_list2.desc
+++ b/regression/cbmc/union10/union_list2.desc
@@ -1,4 +1,4 @@
-CORE
+CORE broken-z3-smt-backend
 union_list2.c
 
 ^EXIT=0$

--- a/regression/cbmc/union11/union_list.desc
+++ b/regression/cbmc/union11/union_list.desc
@@ -1,4 +1,4 @@
-CORE
+CORE broken-z3-smt-backend
 union_list.c
 
 ^EXIT=0$

--- a/regression/cbmc/z3/Issue5970.c
+++ b/regression/cbmc/z3/Issue5970.c
@@ -1,0 +1,11 @@
+#include <assert.h>
+
+void main()
+{
+  unsigned A, x[64];
+  // clang-format off
+  __CPROVER_assume(0 <= A && A < 64);
+  __CPROVER_assume(__CPROVER_forall { int i ; (0 <= i && i < A) ==> x[i] >= 1 });
+  // clang-format on
+  assert(x[0] > 0);
+}

--- a/regression/cbmc/z3/Issue5970.desc
+++ b/regression/cbmc/z3/Issue5970.desc
@@ -1,0 +1,12 @@
+CORE smt-backend broken-cprover-smt-backend
+Issue5970.c
+--z3
+^EXIT=10$
+^SIGNAL=0$
+^\[main\.assertion\.1\] line [0-9]+ assertion x\[0\] > 0: FAILURE$
+--
+invalid get-value term, term must be ground and must not contain quantifiers
+^\[main\.assertion\.1\] line [0-9]+ assertion x\[0\] > 0: ERROR$
+--
+This tests that attempts to "(get-value |XXX|)" from z3 sat results
+are handled and do not cause an error message or ERROR result.

--- a/regression/cbmc/z3/trace-char.c
+++ b/regression/cbmc/z3/trace-char.c
@@ -1,0 +1,5 @@
+void main(int argc, char **argv)
+{
+  char arr[] = {'0', '1', '2', '3', '4', '5', '6', '7'};
+  assert(arr[0] == '2');
+}

--- a/regression/cbmc/z3/trace-char.desc
+++ b/regression/cbmc/z3/trace-char.desc
@@ -1,0 +1,13 @@
+CORE smt-backend broken-cprover-smt-backend
+trace-char.c
+--trace --smt2 --z3
+^EXIT=10$
+^SIGNAL=0$
+arr=\{ arr
+arr=\{ '0', '1', '2', '3', '4', '5', '6', '7' \}
+--
+arr=(assignment removed)
+error running SMT2 solver
+--
+Run cbmc with the --z3 and --trace options with arrays to confirm that
+char arrays are displayed in traces.

--- a/regression/cbmc/z3/trace.c
+++ b/regression/cbmc/z3/trace.c
@@ -1,0 +1,5 @@
+void main(int argc, char **argv)
+{
+  int arr[] = {0, 1, 2, 3, 4, 5, 6, 17};
+  assert(arr[0] == 2);
+}

--- a/regression/cbmc/z3/trace.desc
+++ b/regression/cbmc/z3/trace.desc
@@ -1,0 +1,13 @@
+CORE smt-backend broken-cprover-smt-backend
+trace.c
+--trace --smt2 --z3
+^EXIT=10$
+^SIGNAL=0$
+arr=\{ arr
+arr=\{ 0, 1, 2, 3, 4, 5, 6, 17 \}
+--
+arr=(assignment removed)
+error running SMT2 solver
+--
+Run cbmc with the --z3 and --trace options with arrays to confirm that
+int arrays are displayed in traces.

--- a/src/solvers/smt2/smt2_conv.cpp
+++ b/src/solvers/smt2/smt2_conv.cpp
@@ -319,6 +319,15 @@ exprt smt2_convt::get(const exprt &expr) const
   }
   else if(expr.is_constant())
     return expr;
+  else if(const auto &array = expr_try_dynamic_cast<array_exprt>(expr))
+  {
+    exprt array_copy = *array;
+    for(auto &element : array_copy.operands())
+    {
+      element = get(element);
+    }
+    return array_copy;
+  }
 
   return nil_exprt();
 }

--- a/src/solvers/smt2/smt2_conv.cpp
+++ b/src/solvers/smt2/smt2_conv.cpp
@@ -4415,6 +4415,7 @@ void smt2_convt::set_to(const exprt &expr, bool value)
     // This is a converted expression, we can just assert the literal name
     // since the expression is already defined
     out << found_literal->second;
+    set_values[found_literal->second] = value;
   }
   else
   {

--- a/src/solvers/smt2/smt2_conv.h
+++ b/src/solvers/smt2/smt2_conv.h
@@ -250,6 +250,10 @@ protected:
 
   typedef std::map<exprt, irep_idt> defined_expressionst;
   defined_expressionst defined_expressions;
+  /// The values which boolean identifiers have been `smt2_convt::set_to` or
+  /// in other words those which are asserted as true / false in the output
+  /// smt2 formula.
+  std::unordered_map<irep_idt, bool> set_values;
 
   defined_expressionst object_sizes;
 

--- a/src/solvers/smt2/smt2_conv.h
+++ b/src/solvers/smt2/smt2_conv.h
@@ -159,8 +159,23 @@ protected:
   constant_exprt parse_literal(const irept &, const typet &type);
   struct_exprt parse_struct(const irept &s, const struct_typet &type);
   exprt parse_union(const irept &s, const union_typet &type);
+  /// This function is for parsing array output from SMT solvers
+  /// when "(get-value |???|)" returns an array object.
+  /// \param s: is the irept parsed from the SMT output
+  /// \param type: is the expected type
+  /// \returns an exprt that represents the array
   exprt parse_array(const irept &s, const array_typet &type);
   exprt parse_rec(const irept &s, const typet &type);
+  /// This function walks the SMT output and populates a
+  /// map with index/value pairs for the array
+  /// \param operands_map: is a map of the operands to the array
+  ///    being constructed indexed by their index.
+  /// \param src: is the irept source for the SMT output
+  /// \param type: is the type of the array
+  void walk_array_tree(
+    std::unordered_map<int64_t, exprt> *operands_map,
+    const irept &src,
+    const array_typet &type);
 
   // we use this to build a bit-vector encoding of the FPA theory
   void convert_floatbv(const exprt &expr);

--- a/src/solvers/smt2/smt2_dec.cpp
+++ b/src/solvers/smt2/smt2_dec.cpp
@@ -175,16 +175,35 @@ decision_proceduret::resultt smt2_dect::read_result(std::istream &in)
     {
       // We ignore errors after UNSAT because get-value after check-sat
       // returns unsat will give an error.
-      if(res!=resultt::D_UNSATISFIABLE)
+      if(res != resultt::D_UNSATISFIABLE)
       {
-        messaget log{message_handler};
-        log.error() << "SMT2 solver returned error message:\n"
-                    << "\t\"" << parsed.get_sub()[1].id() << "\""
-                    << messaget::eom;
-        return decision_proceduret::resultt::D_ERROR;
+        const auto &message = id2string(parsed.get_sub()[1].id());
+        // Special case error handling
+        if(
+          solver == solvert::Z3 &&
+          message.find("must not contain quantifiers") != std::string::npos)
+        {
+          // We tried to "(get-value |XXXX|)" where |XXXX| is determined to
+          // include a quantified expression
+          // Nothing to do, this should be caught and value assigned by the
+          // set_to defaults later.
+        }
+        // Unhandled error, log the error and report it back up to caller
+        else
+        {
+          messaget log{message_handler};
+          log.error() << "SMT2 solver returned error message:\n"
+                      << "\t\"" << message << "\"" << messaget::eom;
+          return decision_proceduret::resultt::D_ERROR;
+        }
       }
     }
   }
+
+  // If the result is not satisfiable don't bother updating the assignments and
+  // values (since we didn't get any), just return.
+  if(res != resultt::D_SATISFIABLE)
+    return res;
 
   for(auto &assignment : identifier_map)
   {


### PR DESCRIPTION
This PR contains a fix for problems due to `cbmc` being able to send expressions with quantifiers to `z3`. This creates a problem where a `sat` result can be followed by an attempt to `(get-value |XXX|)` for various identifiers `XXX`. However, when `z3` has a quantifier in one of these identifiers this raises an error.

This PR addresses this problem by doing three things:

1. When we pass the solver input of the form `(assert |XXX|)` via the `set_to` function that is in turn referring to something in `defined_expressions`, then we also store what value we set this identifier to in `set_values`. (This covers various expressions, but most importantly here quantifier questions which `z3` will fail to handle with `(get-value |XXX|)`.)
2. When we parse output from the SMT solver if we hit an error relating to quantifiers after `z3` has determined the result is `sat`, then we ignore this error. This would lead to us missing results from the `(get-value ...)` expressions except for
3. When parsing results, if we already know the correct response for `sat` because we stored it in the `set_values` in 1 (above), then use this instead of parsing and checking the result from the solver. This also solves the problem with `z3` not being able to return the result and it being skipped in 2 (above).

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
