### PR TITLE
Smt unknown handling

### DIFF
--- a/regression/cbmc/z3/Issue5977.c
+++ b/regression/cbmc/z3/Issue5977.c
@@ -1,0 +1,11 @@
+#include <assert.h>
+
+void main()
+{
+  int i;
+  __CPROVER_assume(i % 2 == 0);
+  assert(__CPROVER_exists {
+    int j;
+    i == j + j
+  });
+}

--- a/regression/cbmc/z3/Issue5977.desc
+++ b/regression/cbmc/z3/Issue5977.desc
@@ -1,0 +1,9 @@
+CORE smt-backend broken-cprover-smt-backend
+Issue5977.c
+--z3
+^EXIT=(6|10)$
+^SIGNAL=0$
+^SMT2 solver returned "unknown"$
+--
+--
+This tests that an "unknown" result from the SMT solver is reported.

--- a/src/solvers/smt2/smt2_dec.cpp
+++ b/src/solvers/smt2/smt2_dec.cpp
@@ -154,6 +154,12 @@ decision_proceduret::resultt smt2_dect::read_result(std::istream &in)
       res=resultt::D_SATISFIABLE;
     else if(parsed.id()=="unsat")
       res=resultt::D_UNSATISFIABLE;
+    else if(parsed.id() == "unknown")
+    {
+      messaget log{message_handler};
+      log.error() << "SMT2 solver returned \"unknown\"" << messaget::eom;
+      return decision_proceduret::resultt::D_ERROR;
+    }
     else if(
       parsed.id().empty() && parsed.get_sub().size() == 1 &&
       parsed.get_sub().front().get_sub().size() == 2)


### PR DESCRIPTION
It is possible for an SMT solver to return `unknown` as the result of satisfiability in `cbmc` at the moment. This PR changes the output to the user to make it clear that this is where the `ERROR` result comes from and also includes a regression test for this behaviour using `z3`.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
