### PR TITLE
Symex max depth default max

### DIFF
--- a/jbmc/src/jbmc/jbmc_parse_options.cpp
+++ b/jbmc/src/jbmc/jbmc_parse_options.cpp
@@ -113,6 +113,7 @@ void jbmc_parse_optionst::set_default_options(optionst &options)
 
   // Other default
   options.set_option("arrays-uf", "auto");
+  options.set_option("depth", UINT32_MAX);
 }
 
 void jbmc_parse_optionst::get_command_line_options(optionst &options)

--- a/src/cbmc/cbmc_parse_options.cpp
+++ b/src/cbmc/cbmc_parse_options.cpp
@@ -117,6 +117,7 @@ void cbmc_parse_optionst::set_default_options(optionst &options)
 
   // Other default
   options.set_option("arrays-uf", "auto");
+  options.set_option("depth", UINT32_MAX);
 }
 
 void cbmc_parse_optionst::get_command_line_options(optionst &options)

--- a/src/goto-symex/symex_main.cpp
+++ b/src/goto-symex/symex_main.cpp
@@ -612,7 +612,7 @@ void goto_symext::execute_next_instruction(
     merge_gotos(state);
 
   // depth exceeded?
-  if(symex_config.max_depth != 0 && state.depth > symex_config.max_depth)
+  if(state.depth > symex_config.max_depth)
   {
     // Rule out this path:
     symex_assume_l2(state, false_exprt());


### PR DESCRIPTION
This PR implements the recommended fix in [#2295](https://github.com/diffblue/cbmc/issues/2295).

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
