### PR TITLE
allow multiple assigns clauses

### DIFF
--- a/regression/contracts/assigns_enforce_03/main.c
+++ b/regression/contracts/assigns_enforce_03/main.c
@@ -8,7 +8,8 @@ void f2(int *x2, int *y2, int *z2) __CPROVER_assigns(*x2, *y2, *z2)
   f3(x2, y2, z2);
 }
 
-void f3(int *x3, int *y3, int *z3) __CPROVER_assigns(*x3, *y3, *z3)
+void f3(int *x3, int *y3, int *z3) __CPROVER_assigns(*x3) __CPROVER_assigns(*y3)
+  __CPROVER_assigns(*z3)
 {
   *x3 = *x3 + 1;
   *y3 = *y3 + 1;

--- a/src/ansi-c/ansi_c_convert_type.cpp
+++ b/src/ansi-c/ansi_c_convert_type.cpp
@@ -252,9 +252,8 @@ void ansi_c_convert_typet::read_rec(const typet &type)
   {
     const exprt &as_expr =
       static_cast<const exprt &>(static_cast<const irept &>(type));
-    assigns = to_unary_expr(as_expr).op();
 
-    for(const exprt &operand : assigns.operands())
+    for(const exprt &operand : to_unary_expr(as_expr).op().operands())
     {
       if(
         operand.id() != ID_symbol && operand.id() != ID_ptrmember &&
@@ -264,6 +263,14 @@ void ansi_c_convert_typet::read_rec(const typet &type)
         error() << "illegal target in assigns clause" << eom;
         throw 0;
       }
+    }
+
+    if(assigns.is_nil())
+      assigns = to_unary_expr(as_expr).op();
+    else
+    {
+      for(auto &assignment : to_unary_expr(as_expr).op().operands())
+        assigns.add_to_operands(std::move(assignment));
     }
   }
   else if(type.id() == ID_C_spec_ensures)


### PR DESCRIPTION
This changes the parser to allow multiple assigns clauses in a contract.
The meaning of multiple clauses is the same as the meaning of one clause
that contains the concatenation of the target lists of the given clauses.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [X] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
