### PR TITLE
Avoid diagnostic code crashing when external front-ends use "C" mode

### DIFF
--- a/src/symtab2gb/CMakeLists.txt
+++ b/src/symtab2gb/CMakeLists.txt
@@ -7,6 +7,7 @@ generic_includes(symtab2gb)
 
 target_link_libraries(symtab2gb
         util
+        ansi-c
         goto-programs
         json-symtab-language)
 

--- a/src/symtab2gb/Makefile
+++ b/src/symtab2gb/Makefile
@@ -4,6 +4,7 @@ SRC = \
   # Empty last line
 
 OBJ += \
+  ../ansi-c/ansi-c$(LIBEXT) \
   ../util/util$(LIBEXT) \
   ../goto-programs/goto-programs$(LIBEXT) \
   ../big-int/big-int$(LIBEXT) \

--- a/src/symtab2gb/module_dependencies.txt
+++ b/src/symtab2gb/module_dependencies.txt
@@ -2,3 +2,4 @@ util
 json-symtab-language
 langapi
 goto-programs
+ansi-c

--- a/src/symtab2gb/symtab2gb_parse_options.cpp
+++ b/src/symtab2gb/symtab2gb_parse_options.cpp
@@ -12,6 +12,8 @@ Author: Diffblue Ltd.
 #include <iostream>
 #include <string>
 
+#include <ansi-c/ansi_c_language.h>
+
 #include <goto-programs/goto_convert_functions.h>
 #include <goto-programs/goto_model.h>
 #include <goto-programs/link_goto_model.h>
@@ -113,6 +115,8 @@ int symtab2gb_parse_optionst::doit()
     gb_filename = cmdline.get_value(SYMTAB2GB_OUT_FILE_OPT);
   }
   register_language(new_json_symtab_language);
+  // Workaround to allow external front-ends to use "C" mode
+  register_language(new_ansi_c_language);
   config.set(cmdline);
   run_symtab2gb(symtab_filenames, gb_filename);
   return CPROVER_EXIT_SUCCESS;


### PR DESCRIPTION
This is a work-around for #6223 until #6219 gets adequately resolved.  I am very open to other solutions because this is a hack.