### PR TITLE
Xml description addition

### DIFF
--- a/doc/assets/xml_spec.xsd
+++ b/doc/assets/xml_spec.xsd
@@ -166,6 +166,7 @@
       <xs:sequence>
         <xs:element ref="goto_trace" minOccurs="0"/>
       </xs:sequence>
+      <xs:attribute name="description" type="xs:string"/>
       <xs:attribute name="property" type="xs:string"/>
       <xs:attribute name="status" type="xs:string"/>
     </xs:complexType>

--- a/regression/cbmc/ACSL/fail-operators.c
+++ b/regression/cbmc/ACSL/fail-operators.c
@@ -1,0 +1,36 @@
+void boolean()
+{
+  __CPROVER_bool a, b;
+  __CPROVER_assert(!(a ≡ b) == (a == b), "≥");
+  __CPROVER_assert(!(a ≢ b) == (a != b), "≢");
+  __CPROVER_assert(!(a ⇒ b) == (!a || b), "⇒");
+  __CPROVER_assert(!(a ⇔ b) == (a == b), "⇔");
+  __CPROVER_assert(!(a ∧ b) == (a && b), "∧");
+  __CPROVER_assert(!(a ∨ b) == (a || b), "∨");
+  __CPROVER_assert(!(a ⊻ b) == (a != b), "⊻");
+  __CPROVER_assert(!(¬ a) == (!a), "¬");
+}
+
+void relations()
+{
+  int a, b;
+  __CPROVER_assert(!(a ≥ b) == (a >= b), "≥");
+  __CPROVER_assert(!(a ≤ b) == (a <= b), "≤");
+  __CPROVER_assert(!(a ≡ b) == (a == b), "≥");
+  __CPROVER_assert(!(a ≢ b) == (a != b), "≢");
+  __CPROVER_assert(!(− a) == (-a), "−");
+}
+
+void quantifiers()
+{
+  __CPROVER_assert(!(∀ int i; 1) == 1, "∀");
+  __CPROVER_assert(!(∃ int i; 1) == 1, "∃");
+  __CPROVER_assert(!(\lambda int i; i + 1)(1) == 2, "lambda");
+}
+
+int main()
+{
+  boolean();
+  relations();
+  quantifiers();
+}

--- a/regression/cbmc/ACSL/fail-operators.desc
+++ b/regression/cbmc/ACSL/fail-operators.desc
@@ -1,0 +1,12 @@
+KNOWNBUG
+fail-operators.c --trace
+
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION FAILURE$
+--
+^VERIFICATION SUCCESSFUL$
+--
+This is to test printing of special operator characters in traces.
+The verification should fail. Note that this is a bug for normal
+and XML output, but not JSON.

--- a/regression/cbmc/xml-interface1/test.desc
+++ b/regression/cbmc/xml-interface1/test.desc
@@ -4,8 +4,8 @@ CORE
 ^EXIT=10$
 ^SIGNAL=0$
 Not unwinding loop foo\.0 iteration 3 file main\.c line 5 function foo thread 0
-<result property="foo\.assertion\.3" status="SUCCESS"/>
-<result property="foo\.assertion\.1" status="FAILURE">
+<result description="assertion 0" property="foo\.assertion\.3" status="SUCCESS"/>
+<result description="assertion 0" property="foo\.assertion\.1" status="FAILURE">
 <goto_trace>
 VERIFICATION FAILED
 --

--- a/regression/validate-trace-xml-schema/check.py
+++ b/regression/validate-trace-xml-schema/check.py
@@ -61,7 +61,10 @@ ExcludedTests = list(map(lambda s: os.path.join(test_base_dir, s[0], s[1]), [
     # the SAT back-end only
     ['integer-assignments1', 'test.desc'],
     # this test is expected to abort, thus producing invalid XML
-    ['String_Abstraction17', 'test.desc']
+    ['String_Abstraction17', 'test.desc'],
+    # these tests use characters that cannot be displayed in XML
+    ['ACSL', 'operators.desc'],
+    ['ACSL', 'quantifier-precedence.desc']
 ]))
 
 # TODO maybe consider looking them up on PATH, but direct paths are

--- a/src/goto-checker/properties.cpp
+++ b/src/goto-checker/properties.cpp
@@ -109,6 +109,7 @@ xmlt xml(const irep_idt &property_id, const property_infot &property_info)
   xmlt xml_result("result");
   xml_result.set_attribute("property", id2string(property_id));
   xml_result.set_attribute("status", as_string(property_info.status));
+  xml_result.set_attribute("description", as_string(property_info.description));
   return xml_result;
 }
 


### PR DESCRIPTION
This unifies the XML output with the JSON output by including the `description` in XML.

Fixes #3798

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
