### PR TITLE
remove unusuable goto_programt::make_return variant

### DIFF
--- a/src/goto-programs/goto_program.h
+++ b/src/goto-programs/goto_program.h
@@ -845,12 +845,6 @@ public:
     }
   }
 
-  static instructiont
-  make_return(const source_locationt &l = source_locationt::nil())
-  {
-    return instructiont(code_returnt(), l, SET_RETURN_VALUE, nil_exprt(), {});
-  }
-
   static instructiont make_return(
     code_returnt c,
     const source_locationt &l = source_locationt::nil())

--- a/unit/goto-instrument/cover_instrument.cpp
+++ b/unit/goto-instrument/cover_instrument.cpp
@@ -17,7 +17,7 @@ TEST_CASE("cover_intrument_end_of_function", "[core]")
     goto_programt::make_function_call(code_function_callt({}, {})));
   goto_program.add(
     goto_programt::make_function_call(code_function_callt({}, {})));
-  goto_program.add(goto_programt::make_return());
+  goto_program.add(goto_programt::make_end_function());
   // Act
   cover_instrument_end_of_function(
     "foo", goto_program, goto_programt::make_assertion);
@@ -37,7 +37,7 @@ TEST_CASE("cover_instrument_end_of_function with custom expression", "[core]")
     goto_programt::make_function_call(code_function_callt({}, {})));
   goto_program.add(
     goto_programt::make_function_call(code_function_callt({}, {})));
-  goto_program.add(goto_programt::make_return());
+  goto_program.add(goto_programt::make_end_function());
   const cover_instrumenter_baset::assertion_factoryt assertion_factory =
     [](const exprt &, const source_locationt &location) {
       return goto_programt::make_assertion(true_exprt{}, location);

--- a/unit/goto-programs/goto_program_validate.cpp
+++ b/unit/goto-programs/goto_program_validate.cpp
@@ -197,7 +197,8 @@ SCENARIO("Validation of a goto program", "[core][goto-programs][validate]")
       auto &function_map = goto_model.goto_functions.function_map;
       auto it = function_map.find("g");
       auto &instructions = it->second.body.instructions;
-      instructions.insert(instructions.begin(), goto_programt::make_return());
+      instructions.insert(
+        instructions.begin(), goto_programt::make_return(code_returnt()));
 
       goto_model_validation_optionst validation_options{
         goto_model_validation_optionst ::set_optionst::all_false};


### PR DESCRIPTION
The instruction generated by this variant violates an invariant, and thus,
this method is not usable.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- n/a Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
