### PR TITLE
Add data structures for setting different smt2 logics in incremental solving

### DIFF
--- a/src/solvers/smt2_incremental/smt_logics.cpp
+++ b/src/solvers/smt2_incremental/smt_logics.cpp
@@ -3,7 +3,7 @@
 #include <solvers/smt2_incremental/smt_logics.h>
 
 // Define the irep_idts for logics.
-#define LOGIC_ID(the_id)                                                       \
+#define LOGIC_ID(the_id, the_name)                                             \
   const irep_idt ID_smt_logic_##the_id{"smt_logic_" #the_id};
 #include <solvers/smt2_incremental/smt_logics.def>
 #undef LOGIC_ID
@@ -21,7 +21,7 @@ bool smt_logict::operator!=(const smt_logict &other) const
 template <typename visitort>
 void accept(const smt_logict &logic, const irep_idt &id, visitort &&visitor)
 {
-#define LOGIC_ID(the_id)                                                       \
+#define LOGIC_ID(the_id, the_name)                                             \
   if(id == ID_smt_logic_##the_id)                                              \
     return visitor.visit(static_cast<const smt_logic_##the_id##t &>(logic));
 // The include below is marked as nolint because including the same file
@@ -41,7 +41,7 @@ void smt_logict::accept(smt_logic_const_downcast_visitort &&visitor) const
   ::accept(*this, id(), std::move(visitor));
 }
 
-#define LOGIC_ID(the_id)                                                       \
+#define LOGIC_ID(the_id, the_name)                                             \
   smt_logic_##the_id##t::smt_logic_##the_id##t()                               \
     : smt_logict{ID_smt_logic_##the_id}                                        \
   {                                                                            \

--- a/src/solvers/smt2_incremental/smt_logics.cpp
+++ b/src/solvers/smt2_incremental/smt_logics.cpp
@@ -41,7 +41,10 @@ void smt_logict::accept(smt_logic_const_downcast_visitort &&visitor) const
   ::accept(*this, id(), std::move(visitor));
 }
 
-smt_logic_quantifier_free_bit_vectorst::smt_logic_quantifier_free_bit_vectorst()
-  : smt_logict{ID_smt_logic_quantifier_free_bit_vectors}
-{
-}
+#define LOGIC_ID(the_id)                                                       \
+  smt_logic_##the_id##t::smt_logic_##the_id##t()                               \
+    : smt_logict{ID_smt_logic_##the_id}                                        \
+  {                                                                            \
+  }
+#include "smt_logics.def"
+#undef LOGIC_ID

--- a/src/solvers/smt2_incremental/smt_logics.def
+++ b/src/solvers/smt2_incremental/smt_logics.def
@@ -6,4 +6,4 @@
 ///  * The constant `irep_idt`s used to identify each of the logic classes.
 ///  * The member functions of the `smt_logic_const_downcast_visitort` class.
 ///  * The type of option checks required to implement `smt_logict::accept`.
-LOGIC_ID(quantifier_free_bit_vectors)
+LOGIC_ID(quantifier_free_bit_vectors, QF_BV)

--- a/src/solvers/smt2_incremental/smt_logics.def
+++ b/src/solvers/smt2_incremental/smt_logics.def
@@ -6,4 +6,9 @@
 ///  * The constant `irep_idt`s used to identify each of the logic classes.
 ///  * The member functions of the `smt_logic_const_downcast_visitort` class.
 ///  * The type of option checks required to implement `smt_logict::accept`.
+LOGIC_ID(quantifier_free_uninterpreted_functions, QF_UF)
 LOGIC_ID(quantifier_free_bit_vectors, QF_BV)
+LOGIC_ID(quantifier_free_uninterpreted_functions_bit_vectors, QF_UFBV)
+LOGIC_ID(quantifier_free_bit_vectors_arrays, QF_ABV)
+LOGIC_ID(quantifier_free_uninterpreted_functions_bit_vectors_arrays, QF_AUFBV)
+LOGIC_ID(all, ALL)

--- a/src/solvers/smt2_incremental/smt_logics.h
+++ b/src/solvers/smt2_incremental/smt_logics.h
@@ -61,11 +61,15 @@ const smt_logict &smt_logict::storert<derivedt>::downcast(const irept &irep)
   return static_cast<const smt_logict &>(irep);
 }
 
-class smt_logic_quantifier_free_bit_vectorst : public smt_logict
-{
-public:
-  smt_logic_quantifier_free_bit_vectorst();
-};
+#define LOGIC_ID(the_id)                                                       \
+  /* NOLINTNEXTLINE(readability/identifiers) cpplint does not match the ## */  \
+  class smt_logic_##the_id##t : public smt_logict                              \
+  {                                                                            \
+  public:                                                                      \
+    smt_logic_##the_id##t();                                                   \
+  };
+#include "smt_logics.def"
+#undef LOGIC_ID
 
 class smt_logic_const_downcast_visitort
 {

--- a/src/solvers/smt2_incremental/smt_logics.h
+++ b/src/solvers/smt2_incremental/smt_logics.h
@@ -61,7 +61,7 @@ const smt_logict &smt_logict::storert<derivedt>::downcast(const irept &irep)
   return static_cast<const smt_logict &>(irep);
 }
 
-#define LOGIC_ID(the_id)                                                       \
+#define LOGIC_ID(the_id, the_name)                                             \
   /* NOLINTNEXTLINE(readability/identifiers) cpplint does not match the ## */  \
   class smt_logic_##the_id##t : public smt_logict                              \
   {                                                                            \
@@ -74,7 +74,8 @@ const smt_logict &smt_logict::storert<derivedt>::downcast(const irept &irep)
 class smt_logic_const_downcast_visitort
 {
 public:
-#define LOGIC_ID(the_id) virtual void visit(const smt_logic_##the_id##t &) = 0;
+#define LOGIC_ID(the_id, the_name)                                             \
+  virtual void visit(const smt_logic_##the_id##t &) = 0;
 #include "smt_logics.def"
 #undef LOGIC_ID
 };

--- a/src/solvers/smt2_incremental/smt_to_smt2_string.cpp
+++ b/src/solvers/smt2_incremental/smt_to_smt2_string.cpp
@@ -265,10 +265,13 @@ public:
   {
   }
 
-  void visit(const smt_logic_quantifier_free_bit_vectorst &) override
-  {
-    os << "QF_BV";
+#define LOGIC_ID(the_id, the_name)                                             \
+  void visit(const smt_logic_##the_id##t &) override                           \
+  {                                                                            \
+    os << #the_name;                                                           \
   }
+#include "smt_logics.def"
+#undef LOGIC_ID
 };
 
 std::ostream &operator<<(std::ostream &os, const smt_logict &logic)

--- a/unit/solvers/smt2_incremental/smt_to_smt2_string.cpp
+++ b/unit/solvers/smt2_incremental/smt_to_smt2_string.cpp
@@ -137,8 +137,19 @@ TEST_CASE(
   "Test smt_set_logic_commandt to string conversion",
   "[core][smt2_incremental]")
 {
-  const smt_logic_quantifier_free_bit_vectorst qf_bv;
+  const auto qf_uf = smt_logic_quantifier_free_uninterpreted_functionst{};
+  CHECK(smt_to_smt2_string(qf_uf) == "QF_UF");
+  const auto qf_bv = smt_logic_quantifier_free_bit_vectorst{};
   CHECK(smt_to_smt2_string(qf_bv) == "QF_BV");
+  const auto qf_ufbv =
+    smt_logic_quantifier_free_uninterpreted_functions_bit_vectorst{};
+  CHECK(smt_to_smt2_string(qf_ufbv) == "QF_UFBV");
+  const auto qf_abv = smt_logic_quantifier_free_bit_vectors_arrayst{};
+  CHECK(smt_to_smt2_string(qf_abv) == "QF_ABV");
+  const auto qf_aufbv =
+    smt_logic_quantifier_free_uninterpreted_functions_bit_vectors_arrayst{};
+  CHECK(smt_to_smt2_string(qf_aufbv) == "QF_AUFBV");
+  CHECK(smt_to_smt2_string(smt_logic_allt{}) == "ALL");
   CHECK(
     smt_to_smt2_string(smt_set_logic_commandt{qf_bv}) == "(set-logic QF_BV)");
 }


### PR DESCRIPTION
This PR adds data structures for setting different smt2 logics in incremental solving. Raised in response to this comment chain on my preceding PR - https://github.com/diffblue/cbmc/pull/6240#discussion_r673713556

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
