### PR TITLE
Fix evaluation of decreases clause

### DIFF
--- a/regression/contracts/variant_init_inside_loop/main.c
+++ b/regression/contracts/variant_init_inside_loop/main.c
@@ -1,0 +1,19 @@
+int main()
+{
+  unsigned start, max;
+  unsigned i = start;
+
+  while(i < max)
+    // clang-format off
+    __CPROVER_loop_invariant(
+      (start > max && i == start) ||
+      (start <= i && i <= max)
+    )
+    __CPROVER_decreases(max - i)
+    // clang-format on
+    {
+      i++;
+    }
+
+  return 0;
+}

--- a/regression/contracts/variant_init_inside_loop/test.desc
+++ b/regression/contracts/variant_init_inside_loop/test.desc
@@ -1,0 +1,19 @@
+CORE
+main.c
+--apply-loop-contracts _ --unsigned-overflow-check
+^\[main.1\] .* Check loop invariant before entry: SUCCESS$
+^\[main.2\] .* Check that loop invariant is preserved: SUCCESS$
+^\[main.3\] .* Check decreases clause on loop iteration: SUCCESS$
+^\[main.overflow.1\] .* arithmetic overflow on unsigned - in max - i: SUCCESS$
+^\[main.overflow.3\] .* arithmetic overflow on unsigned - in max - i: SUCCESS$
+^\[main.overflow.2\] .* arithmetic overflow on unsigned \+ in i \+ 1u: SUCCESS$
+^VERIFICATION SUCCESSFUL$
+^EXIT=0$
+^SIGNAL=0$
+--
+--
+This test checks that the decreases clause is evaluated only within the loop iteration,
+not outside of it (before the loop guard).
+The `main.overflow.1` check would fail if the decreases clause `(max - i)` is evaluated
+before the loop guard is satisfied. This would occur when `start > max` and therefore
+`i > max` after assuming the invariant.

--- a/src/goto-instrument/contracts/contracts.h
+++ b/src/goto-instrument/contracts/contracts.h
@@ -123,7 +123,7 @@ public:
   void check_apply_loop_contracts(
     goto_functionst::goto_functiont &goto_function,
     const local_may_aliast &local_may_alias,
-    const goto_programt::targett loop_head,
+    goto_programt::targett loop_head,
     const loopt &loop,
     const irep_idt &mode);
 


### PR DESCRIPTION
`__CPROVER_decreases` clauses on loops were evaluated outside of loop iterations, which was buggy. In this PR, we fix this behavior: decreases clause is evaluated inside the loop block (after the loop guard is satisfied).

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a ~~The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/~~
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a ~~My commit message includes data points confirming performance improvements (if claimed).~~
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.