### PR TITLE
Fix quantifiers for arrays only works with Z3 and CVC4

### DIFF
--- a/regression/cbmc/Malloc22/test.desc
+++ b/regression/cbmc/Malloc22/test.desc
@@ -1,7 +1,10 @@
-CORE
+KNOWNBUG
 main.c
 --unwind 2 --smt2 --outfile main.smt2
 ^EXIT=0$
 ^SIGNAL=0$
 --
 ^Invalid expression: failed to get width of byte_update
+--
+20220523: Marked as KNOWNBUG due to encoding into some solvers not being
+done correctly. This works for z3 and cvc4, but not other solvers.

--- a/regression/cbmc/array_of_bool_as_bitvec/test-smt2-outfile.desc
+++ b/regression/cbmc/array_of_bool_as_bitvec/test-smt2-outfile.desc
@@ -1,4 +1,4 @@
-CORE broken-smt-backend
+KNOWNBUG broken-smt-backend
 main.c
 --smt2 --outfile -
 \(= \(select array_of\.2 i\) \(ite false #b1 #b0\)\)
@@ -11,6 +11,10 @@ main.c
 \(= \(select array\.3 \(\(_ zero_extend 32\) \|main::1::idx!0@1#1\|\)\) #b1 #b0\)
 \(= \(select array\.3 \(_ bv\d+ 64\)\) false\)
 --
+20220523: Marked as KNOWNBUG due to encoding into some solvers not being
+done correctly. This works for z3 and cvc4, but not other solvers. Old
+comments below.
+
 This test checks for correctness of BitVec-array encoding of Boolean arrays.
 
 Ideally, we shouldn't have to check the SMT output, but should run with backend

--- a/src/solvers/smt2/smt2_conv.cpp
+++ b/src/solvers/smt2/smt2_conv.cpp
@@ -4742,11 +4742,15 @@ void smt2_convt::find_symbols(const exprt &expr)
           }
           out << ")))\n";
         }
-        // else
-        // {
-        //   // This is where an alternate for other solvers that does not use
-        //   // quantifiers should go.
-        // }
+        else
+        {
+          // This is where an alternate for other solvers that does not use
+          // quantifiers should go.
+          INVARIANT(
+            false,
+            "Cannot substitute quantified expression for lambda in current "
+            "solver.");
+        }
 
         defined_expressions[expr] = id;
       }

--- a/src/solvers/smt2/smt2_conv.cpp
+++ b/src/solvers/smt2/smt2_conv.cpp
@@ -4721,21 +4721,32 @@ void smt2_convt::find_symbols(const exprt &expr)
         convert_type(array_type);
         out << ")\n";
 
-        // use a quantifier-based initialization instead of lambda
-        out << "(assert (forall ((i ";
-        convert_type(array_type.size().type());
-        out << ")) (= (select " << id << " i) ";
-        if(array_type.element_type().id() == ID_bool && !use_array_of_bool)
+        // The code below only works in Z3 and CVC4, it was added (and
+        // approved/merged) despite breaking other solvers.
+        // This conditional removes this for other solvers
+        if(solver == solvert::CVC4 || solver == solvert::Z3)
         {
-          out << "(ite ";
-          convert_expr(array_of.what());
-          out << " #b1 #b0)";
+          // use a quantifier-based initialization instead of lambda
+          out << "(assert (forall ((i ";
+          convert_type(array_type.size().type());
+          out << ")) (= (select " << id << " i) ";
+          if(array_type.element_type().id() == ID_bool && !use_array_of_bool)
+          {
+            out << "(ite ";
+            convert_expr(array_of.what());
+            out << " #b1 #b0)";
+          }
+          else
+          {
+            convert_expr(array_of.what());
+          }
+          out << ")))\n";
         }
-        else
-        {
-          convert_expr(array_of.what());
-        }
-        out << ")))\n";
+        // else
+        // {
+        //   // This is where an alternate for other solvers that does not use
+        //   // quantifiers should go.
+        // }
 
         defined_expressions[expr] = id;
       }


### PR DESCRIPTION
This commit fixes an error introduced in #5974 where quantifiers
were produced for all SMT2 solvers despite only being supported by
Z3 and CVC4. The fix here reverts to the older behaviour for other
solvers.

Fixes #6263

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
