### PR TITLE
Predicate abstraction for monotonic change

### DIFF
--- a/regression/goto-analyzer/monotonic_change_conditionals/main.c
+++ b/regression/goto-analyzer/monotonic_change_conditionals/main.c
@@ -1,0 +1,18 @@
+int nondet_bool(void);
+
+int main()
+{
+  int x = 42;
+  if(nondet_bool())
+    x++;
+  else
+    x += 6;
+
+  int y = 42;
+  if(nondet_bool())
+    y++;
+  else
+    y -= 6;
+
+  return 0;
+}

--- a/regression/goto-analyzer/monotonic_change_conditionals/test.desc
+++ b/regression/goto-analyzer/monotonic_change_conditionals/test.desc
@@ -1,0 +1,28 @@
+CORE
+main.c
+--function main --vsd --vsd-values monotonic-change --show
+^main.*x .* -> Declared but uninitialized @ \[0\]$
+^main.*x .* -> Staying constant @ \[1\]$
+^main.*x .* -> Monotonically increasing @ \[5\]$
+^main.*x .* -> Monotonically increasing @ \[5, 7\]$
+^main.*y .* -> Declared but uninitialized @ \[9\]$
+^main.*y .* -> Staying constant @ \[10\]$
+^main.*y .* -> Monotonically increasing @ \[14\]$
+^main.*y .* -> TOP @ \[14, 16\]$
+^EXIT=0$
+^SIGNAL=0$
+--
+--
+This test case checks whether the predicate abstraction of monotonicity change
+can correctly handle if-else statements. 
+
+Consider the location in code immediately after we have exited the if-else
+statement (i.e. when the two branches of the if-else statement join). At this
+point, the abstract object must be the "join" (in the terminology of lattice
+theory) of the abstract values corresponding to the two branches. 
+
+In the first if-else statement of this test case, the abstract objects 
+corresponding to the two branches are both "monotonic increase." Hence, their 
+join is monotonic increase. In the second if-else statement, the two abstract
+objects are "monotonic increase" and "monotonic decrease." Hence, their join is
+"top." 

--- a/regression/goto-analyzer/monotonic_change_function_arguments/main.c
+++ b/regression/goto-analyzer/monotonic_change_function_arguments/main.c
@@ -1,0 +1,8 @@
+int foo(int x, int y)
+{
+  x++;
+  x += 6;
+
+  y--;
+  y -= 6;
+}

--- a/regression/goto-analyzer/monotonic_change_function_arguments/test.desc
+++ b/regression/goto-analyzer/monotonic_change_function_arguments/test.desc
@@ -1,0 +1,20 @@
+CORE
+main.c
+--function foo --vsd --vsd-values monotonic-change --show
+^foo.*x .* -> Staying constant @ \[34\]$
+^foo.*x .* -> Monotonically increasing @ \[20\]$
+^foo.*x .* -> Monotonically increasing @ \[21\]$
+^foo.*y .* -> Staying constant @ \[34\]$
+^foo.*y .* -> Monotonically decreasing @ \[22\]$
+^foo.*y .* -> Monotonically decreasing @ \[23\]$
+^__CPROVER__start.*x .* -> Declared but uninitialized @ \[28\]$
+^__CPROVER__start.*x .* -> Staying constant @ \[29\]$
+^__CPROVER__start.*y .* -> Declared but uninitialized @ \[31\]$
+^__CPROVER__start.*y .* -> Staying constant @ \[32\]$
+^EXIT=0$
+^SIGNAL=0$
+--
+--
+This test case tests whether formal arguments of a standalone function (i.e. a
+function that is not invoked by another function) are initialized to the abstrac
+value "constant" correctly. 

--- a/regression/goto-analyzer/monotonic_change_function_call/main.c
+++ b/regression/goto-analyzer/monotonic_change_function_call/main.c
@@ -1,0 +1,19 @@
+int nondet_bool(void);
+
+int increment(int x)
+{
+  if(nondet_bool())
+    x++;
+  else
+    x += 6;
+  return x;
+}
+
+int main()
+{
+  int x = 42;
+  x++;
+  int y = increment(x);
+  y--;
+  return 0;
+}

--- a/regression/goto-analyzer/monotonic_change_function_call/test.desc
+++ b/regression/goto-analyzer/monotonic_change_function_call/test.desc
@@ -1,0 +1,26 @@
+CORE
+main.c
+--function main --vsd --vsd-values monotonic-change --show
+^main.*x .* -> Declared but uninitialized @ \[0\]$
+^main.*x .* -> Staying constant @ \[1\]$
+^main.*x .* -> Monotonically increasing @ \[2\]$
+^main.*y .* -> Declared but uninitialized @ \[3\]$
+^main.*y .* -> Staying constant @ \[8\]$
+^main.*y .* -> Monotonically decreasing @ \[9\]$
+^increment.*x .* -> Monotonically increasing @ \[5\]$
+^increment.*x .* -> Monotonically increasing @ \[39\]$
+^increment.*x .* -> Monotonically increasing @ \[39, 41\]$
+^EXIT=0$
+^SIGNAL=0$
+--
+--
+This test case checks whether the predicate abstraction for monotonic change
+handles a function call properly. When the function "increment" is invoked, 
+the actual argument's abstract value is copied to the formal argument's initial
+abstract value. So, in this example, the initial abstract value of 
+increment::x is the same as the abstract value of main::1::x. 
+
+It is debatable whether this is a reasonable behavior for predicate abstraction
+for monotonic change. It may be better if we can simply initialize the formal
+argument's abstract value to "declared but uninitialized," as opposed to the
+actual argument's abstract value. 

--- a/regression/goto-analyzer/monotonic_change_loops/main.c
+++ b/regression/goto-analyzer/monotonic_change_loops/main.c
@@ -1,0 +1,29 @@
+int main()
+{
+  int x = 0;
+  while(x != 42)
+  {
+    x++;
+  }
+
+  int y = 42;
+  while(y != 0)
+  {
+    y--;
+  }
+
+  int z = 0;
+  while(z != 42)
+  {
+    z++;
+    z--;
+  }
+
+  int u = 0;
+  while(1)
+  {
+    u++;
+  }
+
+  return 0;
+}

--- a/regression/goto-analyzer/monotonic_change_loops/test.desc
+++ b/regression/goto-analyzer/monotonic_change_loops/test.desc
@@ -1,0 +1,24 @@
+CORE
+main.c
+--function main --vsd --vsd-values monotonic-change --show
+^main.*x .* -> Declared but uninitialized @ \[0\]$
+^main.*x .* -> Monotonically increasing @ \[1, 3\]$
+^main.*x .* -> Monotonically increasing @ \[3\]$
+^main.*y .* -> Declared but uninitialized @ \[6\]$
+^main.*y .* -> Monotonically decreasing @ \[7, 9\]$
+^main.*y .* -> Monotonically decreasing @ \[9\]$
+^main.*z .* -> Declared but uninitialized @ \[12\]$
+^main.*z .* -> TOP @ \[13, 16\]$
+^main.*z .* -> TOP @ \[15\]$
+^main.*z .* -> TOP @ \[16\]$
+^main.*u .* -> Declared but uninitialized @ \[19\]$
+^main.*u .* -> Monotonically increasing @ \[20, 22\]$
+^main.*u .* -> Monotonically increasing @ \[22\]$
+^EXIT=0$
+^SIGNAL=0$
+--
+--
+This test case checks whether the monotonic-change predicate abstraction
+correctly computes an abstract value for (possibly divergent) loops. This hinges
+on a correct implementation of the widening operator (which is subsumed by the
+merge function).

--- a/regression/goto-analyzer/monotonic_change_malloc/main.c
+++ b/regression/goto-analyzer/monotonic_change_malloc/main.c
@@ -1,0 +1,9 @@
+#include <stdlib.h>
+
+int main()
+{
+  int *p = malloc(sizeof(int));
+  (*p)++;
+
+  return 0;
+}

--- a/regression/goto-analyzer/monotonic_change_malloc/test.desc
+++ b/regression/goto-analyzer/monotonic_change_malloc/test.desc
@@ -1,0 +1,23 @@
+KNOWNBUG
+--function main --vsd --vsd-values monotonic-change --vsd-pointers constants --vsd-structs every-field --vsd-arrays every-element --show
+^EXIT=0$
+^SIGNAL=0$
+--
+Under the current implementation of monotonic-change predicate abstraction, this
+test case fails. Specifically, it will report a run-time error that one of the
+preconditions in the code base is violated. I will now explain the reason for
+the failure. 
+
+First of all, *p is expanded to *(p+0). Here, the offset 0 will be represented
+by an abstract value in whatever value domain we choose. This is due to the fact
+that memory addresses and array indices are treated as values just like
+integers. 
+
+In this test case, the value domain is monotonic-change. Hence, 0 will be
+represented by one of the abstract values in this abstract domain. However,
+unlike interval analysis, monotonic-change predicate abstraction does not keep
+track of variables' values. It only keeps track of variables' monotonicity
+statuses. Consequently, once we convert a concrete value (i.e. the offset 0) to
+an abstract value of monotonic-change predicate abstraction, we have no way to
+recover the concrete value back from the abstract value. This is why this test
+case results in a precondition violation. 

--- a/regression/goto-analyzer/monotonic_change_pointer_to_stack_memory/main.c
+++ b/regression/goto-analyzer/monotonic_change_pointer_to_stack_memory/main.c
@@ -1,0 +1,15 @@
+struct cartesian_coorindate
+{
+  int x;
+  int y;
+};
+
+int main()
+{
+  struct cartesian_coorindate u;
+  struct cartesian_coorindate *p = &u;
+  p->x = 0;
+  p->y = 0;
+  p->x++;
+  p->y--;
+}

--- a/regression/goto-analyzer/monotonic_change_pointer_to_stack_memory/test.desc
+++ b/regression/goto-analyzer/monotonic_change_pointer_to_stack_memory/test.desc
@@ -1,0 +1,18 @@
+CORE
+main.c
+--function main --vsd --vsd-values monotonic-change --vsd-pointers constants --vsd-structs every-field --show
+^main.*u .* -> \{\} @ \[0\]$
+^main.*p .* -> TOP @ \[1\]$
+^main.*p .* -> ptr ->\(main::1::u\) @ \[2\]$
+^main.*u .* -> \{.x=Staying constant @ \[3\]\} @ \[3\]$
+^main.*u .* -> \{.x=Staying constant @ \[3\], .y=Staying constant @ \[4\]\} @ \[4\]$
+^main.*u .* -> \{.x=Monotonically increasing @ \[5\], .y=Staying constant @ \[4\]\} @ \[5\]$
+^main.*u .* -> \{.x=Monotonically increasing @ \[5\], .y=Monotonically decreasing @ \[6\]\} @ \[6\]$
+^EXIT=0$
+^SIGNAL=0$
+--
+--
+This test case checks whether we correctly handle the predicate abstraction of
+monotonic change for a pointer. Note that the pointer pointers to a structure on
+a "stack" as opposed to a "heap." A separate test case handles the case where a
+structure is allocated on a heap. 

--- a/regression/goto-analyzer/monotonic_change_struct/main.c
+++ b/regression/goto-analyzer/monotonic_change_struct/main.c
@@ -1,0 +1,25 @@
+int nondet(void);
+int nondet_bool(void);
+
+struct cartesian_coorindate
+{
+  int x;
+  int y;
+};
+
+int main()
+{
+  struct cartesian_coorindate u = {nondet(), nondet()};
+  if(nondet_bool())
+  {
+    u.x++;
+    u.y--;
+  }
+  else
+  {
+    u.x += 6;
+    u.y -= 6;
+  }
+
+  return 0;
+}

--- a/regression/goto-analyzer/monotonic_change_struct/test.desc
+++ b/regression/goto-analyzer/monotonic_change_struct/test.desc
@@ -1,0 +1,15 @@
+CORE
+main.c
+--function main --vsd --vsd-values monotonic-change --vsd-structs every-field --show
+^main.*u .* -> \{\} @ \[0\]$
+^main.*u .* -> \{\.x=Staying constant @ \[7\], .y=Staying constant @ \[7\]\} @ \[7\]$
+^main.*u .* -> \{\.x=Monotonically increasing @ \[11\], .y=Staying constant @ \[7\]\} @ \[11\]$
+^main.*u .* -> \{\.x=Monotonically increasing @ \[11\], .y=Monotonically decreasing @ \[12\]\} @ \[12\]$
+^main.*u .* -> \{\.x=Monotonically increasing @ \[14\], .y=Staying constant @ \[7\]\} @ \[14\]$
+^main.*u .* -> \{\.x=Monotonically increasing @ \[11, 14\], .y=Monotonically decreasing @ \[12, 15\]\} @ \[12, 15\]$
+^EXIT=0$
+^SIGNAL=0$
+--
+--
+This test case checks whether the predicate abstraction of monotonicity change
+can correctly handle structure members. 

--- a/regression/goto-analyzer/monotonic_change_ternary_expression/main.c
+++ b/regression/goto-analyzer/monotonic_change_ternary_expression/main.c
@@ -1,0 +1,10 @@
+int nondet_bool(void);
+
+int main()
+{
+  int x = 0;
+  x = nondet_bool() ? (x + 1) : (x + 2);
+
+  int y = 0;
+  y = nondet_bool() ? (y + 1) : (y - 1);
+}

--- a/regression/goto-analyzer/monotonic_change_ternary_expression/test.desc
+++ b/regression/goto-analyzer/monotonic_change_ternary_expression/test.desc
@@ -1,0 +1,15 @@
+CORE
+main.c
+--function main --vsd --vsd-values monotonic-change --show
+^main.*x .* -> Declared but uninitialized @ \[0\]$
+^main.*x .* -> Staying constant @ \[1\]$
+^main.*x .* -> Monotonically increasing @ \[4\]$
+^main.*y .* -> Declared but uninitialized @ \[5\]$
+^main.*y .* -> Staying constant @ \[6\]$
+^main.*y .* -> TOP @ \[9\]$
+^EXIT=0$
+^SIGNAL=0$
+--
+--
+This test case checks whether we correctly compute the abstract value for a
+ternary expression; i.e. bool_expr() ? expr1 : expr2.

--- a/regression/goto-analyzer/monotonic_change_values/main.c
+++ b/regression/goto-analyzer/monotonic_change_values/main.c
@@ -1,0 +1,22 @@
+int nondet(void);
+
+int main()
+{
+  int x = 42;
+  x++;
+  x = x + 2;
+
+  int y = 42;
+  y--;
+  y = y - 2;
+
+  int z = (y + 1729) * (x - 6);
+  z++;
+  z--;
+
+  int u = nondet();
+  u++;
+  u *= 2;
+
+  return 0;
+}

--- a/regression/goto-analyzer/monotonic_change_values/test.desc
+++ b/regression/goto-analyzer/monotonic_change_values/test.desc
@@ -1,0 +1,25 @@
+CORE
+main.c
+--function main --vsd --vsd-values monotonic-change --show
+^main.*x .* -> Declared but uninitialized @ \[0\]$
+^main.*x .* -> Staying constant @ \[1\]$
+^main.*x .* -> Monotonically increasing @ \[2\]$
+^main.*x .* -> Monotonically increasing @ \[3\]$
+^main.*y .* -> Declared but uninitialized @ \[4\]$
+^main.*y .* -> Staying constant @ \[5\]$
+^main.*y .* -> Monotonically decreasing @ \[6\]$
+^main.*y .* -> Monotonically decreasing @ \[7\]$
+^main.*z .* -> Declared but uninitialized @ \[8\]$
+^main.*z .* -> Staying constant @ \[9\]$
+^main.*z .* -> Monotonically increasing @ \[10\]$
+^main.*z .* -> TOP @ \[11\]$
+^main.*u .* -> Declared but uninitialized @ \[12\]$
+^main.*u .* -> Staying constant @ \[16\]$
+^main.*u .* -> Monotonically increasing @ \[17\]$
+^main.*u .* -> TOP @ \[18\]$
+^EXIT=0$
+^SIGNAL=0$
+--
+--
+This test case checks whether monotinic increase and decrease are correctly
+detected for integer-typed variables. 

--- a/src/analyses/Makefile
+++ b/src/analyses/Makefile
@@ -39,6 +39,7 @@ SRC = ai.cpp \
       variable-sensitivity/abstract_pointer_object.cpp \
       variable-sensitivity/abstract_value_object.cpp \
       variable-sensitivity/constant_abstract_value.cpp \
+      variable-sensitivity/monotonic_change.cpp \
       variable-sensitivity/constant_pointer_abstract_object.cpp \
       variable-sensitivity/context_abstract_object.cpp \
       variable-sensitivity/data_dependency_context.cpp \

--- a/src/analyses/variable-sensitivity/abstract_aggregate_object.h
+++ b/src/analyses/variable-sensitivity/abstract_aggregate_object.h
@@ -61,6 +61,29 @@ public:
       expr, operands, environment, ns);
   }
 
+  abstract_object_pointert assign_expression_transform(
+    const abstract_object_pointert &lhs_abstract_object,
+    const exprt &lhs,
+    const exprt &rhs,
+    const std::vector<abstract_object_pointert> &operands,
+    const abstract_environmentt &environment,
+    const namespacet &ns) const override
+  {
+    if(rhs.id() == aggregate_traitst::ACCESS_EXPR_ID())
+      return read_component(environment, rhs, ns);
+
+    return abstract_objectt::assign_expression_transform(
+      lhs_abstract_object, lhs, rhs, operands, environment, ns);
+  }
+
+  abstract_object_pointert read(
+    const abstract_environmentt &environment,
+    const exprt &specifier,
+    const namespacet &ns) const override
+  {
+    return read_component(environment, specifier, ns);
+  }
+
   abstract_object_pointert write(
     abstract_environmentt &environment,
     const namespacet &ns,

--- a/src/analyses/variable-sensitivity/abstract_object.cpp
+++ b/src/analyses/variable-sensitivity/abstract_object.cpp
@@ -141,6 +141,25 @@ abstract_object_pointert abstract_objectt::expression_transform(
   return environment.abstract_object_factory(copy.type(), copy, ns);
 }
 
+abstract_object_pointert abstract_objectt::assign_expression_transform(
+  const abstract_object_pointert &lhs_abstract_object,
+  const exprt &lhs,
+  const exprt &rhs,
+  const std::vector<abstract_object_pointert> &operands,
+  const abstract_environmentt &environment,
+  const namespacet &ns) const
+{
+  return expression_transform(rhs, operands, environment, ns);
+}
+
+abstract_object_pointert abstract_objectt::read(
+  const abstract_environmentt &environment,
+  const exprt &specifier,
+  const namespacet &ns) const
+{
+  return environment.abstract_object_factory(type(), ns, false, true);
+}
+
 abstract_object_pointert abstract_objectt::write(
   abstract_environmentt &environment,
   const namespacet &ns,

--- a/src/analyses/variable-sensitivity/abstract_object.h
+++ b/src/analyses/variable-sensitivity/abstract_object.h
@@ -160,6 +160,18 @@ public:
     const abstract_environmentt &environment,
     const namespacet &ns) const;
 
+  // assign_expression_transform is almost identical to expression_transform,
+  // except that the former is tailored to assignments. Specifically,
+  // assign_expression_transform takes in two additional arguments: (i) the
+  // left-hand side's abstract object and (ii) the left-hand side's expression.
+  virtual abstract_object_pointert assign_expression_transform(
+    const abstract_object_pointert &lhs_abstract_object,
+    const exprt &lhs,
+    const exprt &rhs,
+    const std::vector<abstract_object_pointert> &operands,
+    const abstract_environmentt &environment,
+    const namespacet &ns) const;
+
   /// Converts to a constant expression if possible
   ///
   /// \return Returns an exprt representing the value if the value is known and
@@ -194,6 +206,20 @@ public:
     const exprt &specifier,
     const abstract_object_pointert &value,
     bool merging_write) const;
+
+  // This function reads a component of an abstract object. For instance,
+  // suppose we want to read the abstract object of coordinate.x, where
+  // "coordinate" is a structure with two components (i.e. x and y), and x is a
+  // component. We first compute the abstract value of "coordinate." We then use
+  // the function "read" to extract the x-component of coordinate's abstract
+  // value. Why do we want to read an abstract object a structure's component?
+  // For MONOTONIC_CHANGE, in an assignment, we need to know the abstract object
+  // of the left-hand side. If the left-hand side is a struct's component, then
+  // we need to use the function "read."
+  virtual abstract_object_pointert read(
+    const abstract_environmentt &environment,
+    const exprt &specifier,
+    const namespacet &ns) const;
 
   /// Print the value of the abstract object
   ///
@@ -448,6 +474,7 @@ protected:
   void set_top()
   {
     top = true;
+    bottom = false;
     this->set_top_internal();
   }
   void set_not_top()

--- a/src/analyses/variable-sensitivity/abstract_pointer_object.cpp
+++ b/src/analyses/variable-sensitivity/abstract_pointer_object.cpp
@@ -62,6 +62,15 @@ abstract_object_pointert abstract_pointer_objectt::expression_transform(
     expr, operands, environment, ns);
 }
 
+abstract_object_pointert abstract_pointer_objectt::read(
+  const abstract_environmentt &environment,
+  const exprt &expr,
+  const namespacet &ns) const
+{
+  PRECONDITION(is_dereference(expr));
+  return read_dereference(environment, ns);
+}
+
 abstract_object_pointert abstract_pointer_objectt::write(
   abstract_environmentt &environment,
   const namespacet &ns,

--- a/src/analyses/variable-sensitivity/abstract_pointer_object.h
+++ b/src/analyses/variable-sensitivity/abstract_pointer_object.h
@@ -48,6 +48,11 @@ public:
     const abstract_environmentt &environment,
     const namespacet &ns) const override;
 
+  abstract_object_pointert read(
+    const abstract_environmentt &environment,
+    const exprt &expr,
+    const namespacet &ns) const override;
+
   abstract_object_pointert write(
     abstract_environmentt &environment,
     const namespacet &ns,

--- a/src/analyses/variable-sensitivity/abstract_value_object.h
+++ b/src/analyses/variable-sensitivity/abstract_value_object.h
@@ -287,8 +287,21 @@ public:
     const abstract_environmentt &environment,
     const namespacet &ns) const final;
 
+  abstract_object_pointert assign_expression_transform(
+    const abstract_object_pointert &lhs_abstract_object,
+    const exprt &lhs,
+    const exprt &rhs,
+    const std::vector<abstract_object_pointert> &operands,
+    const abstract_environmentt &environment,
+    const namespacet &ns) const final;
+
   virtual sharing_ptrt<const abstract_value_objectt>
   constrain(const exprt &lower, const exprt &upper) const = 0;
+
+  abstract_object_pointert read(
+    const abstract_environmentt &environment,
+    const exprt &specifier,
+    const namespacet &ns) const final;
 
   abstract_object_pointert write(
     abstract_environmentt &environment,
@@ -331,6 +344,11 @@ protected:
   sharing_ptrt<const abstract_value_objectt>
   as_value(const abstract_object_pointert &obj) const;
 };
+
+abstract_object_pointert monotonic_change_expression_transform(
+  const abstract_object_pointert &lhs_abstract_object,
+  const exprt &lhs,
+  const exprt &rhs);
 
 using abstract_value_pointert = sharing_ptrt<const abstract_value_objectt>;
 

--- a/src/analyses/variable-sensitivity/context_abstract_object.h
+++ b/src/analyses/variable-sensitivity/context_abstract_object.h
@@ -81,6 +81,18 @@ public:
     const abstract_environmentt &environment,
     const namespacet &ns) const override;
 
+  // assign_expression_transform is almost identical to expression_transform,
+  // except that the former is tailored to assignments. Specifically,
+  // assign_expression_transform takes in two additional arguments: (i) the
+  // left-hand side's abstract object and (ii) the left-hand side's expression.
+  abstract_object_pointert assign_expression_transform(
+    const abstract_object_pointert &lhs_abstract_object,
+    const exprt &lhs,
+    const exprt &rhs,
+    const std::vector<abstract_object_pointert> &operands,
+    const abstract_environmentt &environment,
+    const namespacet &ns) const override;
+
   void output(std::ostream &out, const class ai_baset &ai, const namespacet &ns)
     const override;
 
@@ -107,6 +119,11 @@ protected:
   // actions when an abstract_object is set/unset to TOP
   void set_top_internal() override;
   void set_not_top_internal() override;
+
+  abstract_object_pointert read(
+    const abstract_environmentt &environment,
+    const exprt &specifier,
+    const namespacet &ns) const override;
 
   abstract_object_pointert write(
     abstract_environmentt &environment,

--- a/src/analyses/variable-sensitivity/full_struct_abstract_object.cpp
+++ b/src/analyses/variable-sensitivity/full_struct_abstract_object.cpp
@@ -80,13 +80,15 @@ abstract_object_pointert full_struct_abstract_objectt::read_component(
   std::cout << "Reading component " << member_expr.get_component_name() << '\n';
 #endif
 
+  const member_exprt &member_expr = to_member_expr(expr);
+
   if(is_top())
   {
-    return environment.abstract_object_factory(expr.type(), ns, true, false);
+    return environment.abstract_declared_object_factory(
+      member_expr.type(), member_expr, ns);
   }
   else
   {
-    const member_exprt &member_expr = to_member_expr(expr);
     PRECONDITION(!is_bottom());
 
     const irep_idt c = member_expr.get_component_name();
@@ -99,8 +101,8 @@ abstract_object_pointert full_struct_abstract_objectt::read_component(
     }
     else
     {
-      return environment.abstract_object_factory(
-        member_expr.type(), ns, true, false);
+      return environment.abstract_declared_object_factory(
+        member_expr.type(), member_expr, ns);
     }
   }
 }

--- a/src/analyses/variable-sensitivity/monotonic_change.cpp
+++ b/src/analyses/variable-sensitivity/monotonic_change.cpp
@@ -1,0 +1,355 @@
+/*******************************************************************\
+
+ Module: Predicate abstraction for monotonic change
+
+ Authors: Long Pham, Saswat Padhi
+
+\*******************************************************************/
+
+// For the documentation of the class monotonic_changet, have a look at
+// the header file monotonic_change.h.
+
+#include <langapi/language_util.h>
+
+#include <util/interval.h>
+#include <util/std_expr.h>
+
+#include "abstract_object_statistics.h"
+#include "monotonic_change.h"
+
+// We will print out a message on the standard output when we encouter a
+// pathological case. An example is when we are try to merge the abstract value
+// "uninitialized" with other abstract values (e.g. "increase"). This is why we
+// need <iostream>.
+#include <iostream>
+
+monotonic_changet::monotonic_changet(const typet &t)
+  : abstract_value_objectt(t, false, false), monotonicity_value(uninitialized)
+{
+}
+
+monotonic_changet::monotonic_changet(const typet &t, bool tp, bool bttm)
+  : abstract_value_objectt(t, tp, bttm),
+    monotonicity_value((tp || bttm) ? top_or_bottom : uninitialized)
+{
+}
+
+monotonic_changet::monotonic_changet(
+  const typet &t,
+  bool tp,
+  bool bttm,
+  monotonicity_flags initial_value)
+  : abstract_value_objectt(t, tp, bttm),
+    monotonicity_value((tp || bttm) ? top_or_bottom : initial_value)
+{
+}
+
+monotonic_changet::monotonic_changet(
+  const exprt &e,
+  const abstract_environmentt &environment,
+  const namespacet &ns)
+  : abstract_value_objectt(e.type(), false, false), monotonicity_value(constant)
+{
+}
+
+index_range_implementation_ptrt
+monotonic_changet::index_range_implementation(const namespacet &ns) const
+{
+  return make_empty_index_range();
+}
+
+value_range_implementation_ptrt
+monotonic_changet::value_range_implementation() const
+{
+  return make_single_value_range(shared_from_this());
+}
+
+constant_interval_exprt monotonic_changet::to_interval() const
+{
+  return constant_interval_exprt(type());
+}
+
+void monotonic_changet::set_top_internal()
+{
+  monotonicity_value = top_or_bottom;
+}
+
+void monotonic_changet::output(
+  std::ostream &out,
+  const ai_baset &ai,
+  const namespacet &ns) const
+{
+  if(is_top() || is_bottom())
+    abstract_objectt::output(out, ai, ns);
+  else
+  {
+    switch(monotonicity_value)
+    {
+    case increase:
+      out << "Monotonically increasing";
+      break;
+    case decrease:
+      out << "Monotonically decreasing";
+      break;
+    case constant:
+      out << "Staying constant";
+      break;
+    case uninitialized:
+      out << "Declared but uninitialized";
+      break;
+    case top_or_bottom:
+      // fall through
+    default:
+      UNREACHABLE;
+    }
+  }
+}
+
+abstract_object_pointert monotonic_changet::merge_with_value(
+  const abstract_value_pointert &other,
+  const widen_modet &widen_mode) const
+{
+  auto other_monotonic_change =
+    std::dynamic_pointer_cast<const monotonic_changet>(other);
+  if(other_monotonic_change != nullptr)
+    return merge_with_monotonic_change(other_monotonic_change);
+  else
+    return abstract_objectt::merge(other, widen_mode);
+}
+
+// It is weird if we ever try to merge uninitialized with increase, constant, or
+// decrease. In such a pathological case, we print out a message on the standard
+// output and simply return the top.
+abstract_object_pointert monotonic_changet::merge_with_monotonic_change(
+  const sharing_ptrt<const monotonic_changet> &other) const
+{
+  if(this->is_bottom() || other->is_top())
+    return std::make_shared<const monotonic_changet>(*other);
+  if(this->is_top() || other->is_bottom())
+    return shared_from_this();
+
+  if(this->monotonicity_value == increase)
+  {
+    switch(other->monotonicity_value)
+    {
+    case increase:
+      // fall through
+    case constant:
+      // If the result of merge is semantically the same as the current abstract
+      // value, then we should return shared_from_this(), instead of a new copy
+      // with the same abstract value. This is because, in the function
+      // abstract_objectt::merge, to checks whether merging changes the abstract
+      // value, we compare pointers rather than the contents of abstract
+      // objects. This is important for widening for loops in abstract
+      // interpretation. If we inadvertently returned a new copy of the same
+      // abstract value, the widening for loops would diverge (i.e.
+      // non-termination).
+      return shared_from_this();
+    case decrease:
+      return std::make_shared<monotonic_changet>(
+        this->type(), true, false); // top
+    case uninitialized:
+      std::cout << "We are trying to merge increase with uninitialized\n";
+      break;
+    case top_or_bottom:
+      // fall through
+    default:
+      UNREACHABLE;
+    }
+  }
+  else if(this->monotonicity_value == decrease)
+  {
+    switch(other->monotonicity_value)
+    {
+    case increase:
+      return std::make_shared<monotonic_changet>(
+        this->type(), true, false); // top
+    case constant:
+      // fall through
+    case decrease:
+      return shared_from_this();
+    case uninitialized:
+      std::cout << "We are trying to merge decrease with uninitialized\n";
+      break;
+    case top_or_bottom:
+      // fall through
+    default:
+      UNREACHABLE;
+    }
+  }
+  else if(this->monotonicity_value == constant)
+  {
+    switch(other->monotonicity_value)
+    {
+    case increase:
+      return std::make_shared<monotonic_changet>(
+        this->type(), false, false, increase);
+    case constant:
+      return shared_from_this();
+    case decrease:
+      return std::make_shared<monotonic_changet>(
+        this->type(), false, false, decrease);
+    case uninitialized:
+      std::cout << "We are trying to merge constant with uninitialized\n";
+      break;
+    case top_or_bottom:
+      // fall through
+    default:
+      UNREACHABLE;
+    }
+  }
+  else if(this->monotonicity_value == uninitialized)
+  {
+    switch(other->monotonicity_value)
+    {
+    case increase:
+      // fall through
+    case constant:
+      // fall through
+    case decrease:
+      std::cout << "We are trying to merge uninitialized with increase, "
+                   "constant, or decrease\n";
+      break;
+    case uninitialized:
+      return shared_from_this();
+    case top_or_bottom:
+      // fall through
+    default:
+      UNREACHABLE;
+    }
+  }
+  else // this->monotonicity_value == top_or_bottom
+    UNREACHABLE;
+
+  // We return the top by default.
+  return std::make_shared<monotonic_changet>(this->type(), true, false);
+}
+
+abstract_object_pointert
+monotonic_changet::meet_with_value(const abstract_value_pointert &other) const
+{
+  auto other_monotonic_change =
+    std::dynamic_pointer_cast<const monotonic_changet>(other);
+  if(other_monotonic_change != nullptr)
+    return meet_with_monotonic_change(other_monotonic_change);
+  else
+    return abstract_objectt::meet(other);
+}
+
+abstract_object_pointert monotonic_changet::meet_with_monotonic_change(
+  const sharing_ptrt<const monotonic_changet> &other) const
+{
+  if(this->is_bottom() || other->is_top())
+    return shared_from_this();
+  if(this->is_top() || other->is_bottom())
+    return std::make_shared<monotonic_changet>(*other);
+
+  std::shared_ptr<monotonic_changet> result_pointer =
+    std::make_shared<monotonic_changet>(
+      this->type(), false, false, uninitialized);
+
+  if(this->monotonicity_value == increase)
+  {
+    switch(other->monotonicity_value)
+    {
+    case increase:
+      return std::make_shared<monotonic_changet>(
+        this->type(), false, false, increase);
+    case constant:
+      // fall through
+    case decrease:
+      return std::make_shared<monotonic_changet>(
+        this->type(), false, false, constant);
+    case uninitialized:
+      std::cout << "Meet of increase and uninitialized\n";
+      break;
+    case top_or_bottom:
+      // fall through
+    default:
+      UNREACHABLE;
+    }
+  }
+  else if(this->monotonicity_value == constant)
+  {
+    switch(other->monotonicity_value)
+    {
+    case increase:
+      // fall through
+    case constant:
+      // fall through
+    case decrease:
+      return std::make_shared<monotonic_changet>(
+        this->type(), false, false, constant);
+    case uninitialized:
+      std::cout << "Meet of constant and uninitialized\n";
+      break;
+    case top_or_bottom:
+      // fall through
+    default:
+      UNREACHABLE;
+    }
+  }
+  else if(this->monotonicity_value == decrease)
+  {
+    switch(other->monotonicity_value)
+    {
+    case increase:
+      // fall through
+    case constant:
+      return std::make_shared<monotonic_changet>(
+        this->type(), false, false, constant);
+    case decrease:
+      return std::make_shared<monotonic_changet>(
+        this->type(), false, false, decrease);
+    case uninitialized:
+      std::cout << "Meet of decrease and uninitialized\n";
+      break;
+    case top_or_bottom:
+      // fall through
+    default:
+      UNREACHABLE;
+    }
+  }
+  else if(this->monotonicity_value == uninitialized)
+  {
+    switch(other->monotonicity_value)
+    {
+    case increase:
+      // fall through
+    case constant:
+      // fall through
+    case decrease:
+      std::cout
+        << "Meet of uninitialized with increase, constant, or decrease\n";
+      break;
+    case uninitialized:
+      return std::make_shared<monotonic_changet>(
+        this->type(), false, false, uninitialized);
+    case top_or_bottom:
+      // fall through
+    default:
+      UNREACHABLE;
+    }
+  }
+  else
+    UNREACHABLE;
+
+  // We return the bottom by default.
+  return std::make_shared<monotonic_changet>(this->type(), false, true);
+}
+
+abstract_value_pointert
+monotonic_changet::constrain(const exprt &lower, const exprt &upper) const
+{
+  return as_value(mutable_clone());
+}
+
+void monotonic_changet::get_statistics(
+  abstract_object_statisticst &statistics,
+  abstract_object_visitedt &visited,
+  const abstract_environmentt &env,
+  const namespacet &ns) const
+{
+  abstract_objectt::get_statistics(statistics, visited, env, ns);
+  statistics.objects_memory_usage += memory_sizet::from_bytes(sizeof(*this));
+}

--- a/src/analyses/variable-sensitivity/monotonic_change.h
+++ b/src/analyses/variable-sensitivity/monotonic_change.h
@@ -1,0 +1,192 @@
+/*******************************************************************\
+
+ Module: Predicate abstraction for monotonic change
+
+ Authors: Long Pham, Saswat Padhi
+
+\*******************************************************************/
+
+// We have based this class on constant_abstract_value.h. We are grateful to its
+// authors.
+
+/*
+Overview: 
+This predicate abstraction checks whether variables have monotonically increased
+or decreased since the beginning of given GOTO code. We will use this predicate
+abstraction in the automatic inference of decreases clauses (aka ranking
+functions or loop variants). For example, consider a while-loop whose loop guard
+is x < y, where x and y are variables. If we know that x always monotonically
+increases in the loop body and that y always stays constant, we can successfully
+infer that y - x is a correct decreases clause.
+
+Example: 
+For illustration, consider this C code:
+int x = 42;
+x++;
+x--;
+
+This will be translated to the following GOTO code:
+DECL x
+ASSIGN x := 42
+ASSIGN x := x + 1
+ASSIGN x := x - 1
+
+Immediately after the declaration of x, x is said to be "declared but
+uninitialized." Next, after the declaration of x, we initialize x to 42 by the
+command ASSIGN x:= 42. Immediately after this assignment, x is said to be
+"constant"; that is, x has stayed constant since the beginning of the code. 
+
+Subsequently, after the command x++, x is said to be "monotonically increasing."
+In this context, "monotonic" increase means "strict" increase. If x is "not
+strictly" increasing but "non-strictly" increasing, then it means x has stayed
+constant. 
+
+Finally, we execute x-- after x++. Unlike interval analysis, this predicate
+abstraction does NOT keep track of how much x has changed. Instead, it only
+keeps track of the current monotonic-change status of x (e.g. monotonic
+increase, constant, monotonic decrease). Hence, in the above example, we cannot
+tell the net effect on x after x--. Consequently, after x--, the
+monotonic-change status of x is "top"; i.e. we know nothing about x. 
+
+Implementation overview:
+The class monotonic_changet inherits from the class abstract_value_objectt. This
+makes sense becuase predicate abstraction is a special case of abstract
+interpretation. The base class abstract_value_objectt already contains two
+abstract values: 
+(i) top 
+(ii) bottom. 
+
+In addition to these two values, monotonic_changet has the following abstract
+values to represent the current monotonic-change status: 
+(iii) monotonic increase 
+(iv) monotonic decrease 
+(v) constant 
+(vi) declared but uninitialized. 
+
+What happens if we try to increment a variable that has been declared but
+uninitialized? Incrementing such a variable is possible in the GOTO language,
+but I believe it is impossible in C. 
+
+Technical challenge: 
+Existing derived classes of abstract_value_objectt include
+(i) constant_abstract_valuet, 
+(ii) interval_abstract_valuet, and
+(iii) value_set_abstract_objectt. 
+When computing the abstract value of an assignment, these classes only need to
+consider the right-hand side of the assignment. By contrast, monotonic_changet
+needs to know not only the right-hand side but also the left-hand side. 
+
+For example, consider two assignments: x := x + 1 and x := y + 1. For the
+existing derived classes of abstract_value_objectt, x's abstract value after
+this assignment can be computed by just looking at the right-hand side.
+
+On the other hand, monotonic_changet cannot computer x's abstract value by
+looking at the right-hand side in isolation. It needs to check whether the
+variable being incremented is the same as the variable on the left-hand side.
+Furthermore, it needs to know the current monotonic-change status of x. If x's
+current status is "constant," x := x + 1 will change x's status to "monotonic
+increase." Instead, if x's current status is "monotonic decrease," x := x + 1
+will change the status to "top."
+
+In this way, to compute the abstract value of an assignment, we need information
+about the left-hand side. As a consequence, to implement this predicate
+abstraction, we have made fairly extensive modification to the existing code
+base.
+*/
+
+#ifndef CPROVER_ANALYSES_VARIABLE_SENSITIVITY_MONOTONIC_CHANGE_H
+#define CPROVER_ANALYSES_VARIABLE_SENSITIVITY_MONOTONIC_CHANGE_H
+
+#include <iosfwd>
+
+#include <analyses/variable-sensitivity/abstract_value_object.h>
+
+enum monotonicity_flags
+{
+  increase,
+  decrease,
+  constant,
+  uninitialized,
+  // We can tell whether it is top or bottom by is_top() and is_bottom(), which
+  // are inherited from abstract_objectt.
+  top_or_bottom
+};
+
+class monotonic_changet : public abstract_value_objectt
+{
+public:
+  explicit monotonic_changet(const typet &t);
+  monotonic_changet(const typet &t, bool tp, bool bttm);
+  monotonic_changet(
+    const typet &t,
+    bool tp,
+    bool bttm,
+    monotonicity_flags initial_value);
+  monotonic_changet(
+    const exprt &e,
+    const abstract_environmentt &environment,
+    const namespacet &ns);
+
+  ~monotonic_changet() override = default;
+
+  index_range_implementation_ptrt
+  index_range_implementation(const namespacet &ns) const override;
+
+  value_range_implementation_ptrt value_range_implementation() const override;
+
+  constant_interval_exprt to_interval() const override;
+
+  abstract_value_pointert
+  constrain(const exprt &lower, const exprt &upper) const override;
+
+  void output(
+    std::ostream &out,
+    const class ai_baset &ai,
+    const class namespacet &ns) const override;
+
+  void get_statistics(
+    abstract_object_statisticst &statistics,
+    abstract_object_visitedt &visited,
+    const abstract_environmentt &env,
+    const namespacet &ns) const override;
+
+  size_t internal_hash() const override
+  {
+    return std::hash<int>{}(monotonicity_value);
+  }
+
+  bool internal_equality(const abstract_object_pointert &other) const override
+  {
+    auto cast_other = std::dynamic_pointer_cast<const monotonic_changet>(other);
+    return cast_other && monotonicity_value == cast_other->monotonicity_value;
+  }
+
+  monotonicity_flags monotonicity_value;
+
+protected:
+  CLONE
+
+  /// Merges another abstract value into this one
+  ///
+  /// \param other: the abstract object to merge with
+  /// \param widen_mode: Indicates if this is a widening merge
+  ///
+  /// \return Returns a new abstract object that is the result of the merge
+  ///         unless the merge is the same as this abstract object, in which
+  ///         case it returns this.
+  abstract_object_pointert merge_with_value(
+    const abstract_value_pointert &other,
+    const widen_modet &widen_mode) const override;
+  abstract_object_pointert merge_with_monotonic_change(
+    const sharing_ptrt<const monotonic_changet> &other) const;
+
+  abstract_object_pointert
+  meet_with_value(const abstract_value_pointert &other) const override;
+  abstract_object_pointert meet_with_monotonic_change(
+    const sharing_ptrt<const monotonic_changet> &other) const;
+
+private:
+  void set_top_internal() override;
+};
+
+#endif // CPROVER_ANALYSES_VARIABLE_SENSITIVITY_MONOTONIC_CHANGE_H

--- a/src/analyses/variable-sensitivity/variable_sensitivity_configuration.cpp
+++ b/src/analyses/variable-sensitivity/variable_sensitivity_configuration.cpp
@@ -75,10 +75,22 @@ vsd_configt vsd_configt::intervals()
   return config;
 }
 
+vsd_configt vsd_configt::monotonic_change()
+{
+  vsd_configt config{};
+  config.context_tracking.last_write_context = true;
+  config.value_abstract_type = MONOTONIC_CHANGE;
+  config.pointer_abstract_type = POINTER_SENSITIVE;
+  config.struct_abstract_type = STRUCT_SENSITIVE;
+  config.array_abstract_type = ARRAY_SENSITIVE;
+  return config;
+}
+
 const vsd_configt::option_mappingt vsd_configt::value_option_mappings = {
   {"intervals", INTERVAL},
   {"constants", CONSTANT},
-  {"set-of-constants", VALUE_SET}};
+  {"set-of-constants", VALUE_SET},
+  {"monotonic-change", MONOTONIC_CHANGE}};
 
 const vsd_configt::option_mappingt vsd_configt::pointer_option_mappings = {
   {"top-bottom", POINTER_INSENSITIVE},

--- a/src/analyses/variable-sensitivity/variable_sensitivity_configuration.h
+++ b/src/analyses/variable-sensitivity/variable_sensitivity_configuration.h
@@ -22,6 +22,7 @@ enum ABSTRACT_OBJECT_TYPET
   TWO_VALUE,
   CONSTANT,
   INTERVAL,
+  MONOTONIC_CHANGE,
   ARRAY_SENSITIVE,
   ARRAY_INSENSITIVE,
   VALUE_SET_OF_POINTERS,
@@ -67,6 +68,7 @@ struct vsd_configt
   static vsd_configt constant_domain();
   static vsd_configt value_set();
   static vsd_configt intervals();
+  static vsd_configt monotonic_change();
 
   vsd_configt()
     : value_abstract_type{CONSTANT},

--- a/src/analyses/variable-sensitivity/variable_sensitivity_domain.cpp
+++ b/src/analyses/variable-sensitivity/variable_sensitivity_domain.cpp
@@ -40,14 +40,16 @@ void variable_sensitivity_domaint::transform(
   case DECL:
   {
     const abstract_objectt::locationst write_location = {from};
-    abstract_object_pointert top_object =
+    abstract_object_pointert declared_object =
       abstract_state
-        .abstract_object_factory(
-          instruction.decl_symbol().type(), ns, true, false)
+        .abstract_declared_object_factory(
+          instruction.decl_symbol().type(), instruction.decl_symbol(), ns)
         ->update_location_context(write_location, true);
-    abstract_state.assign(instruction.decl_symbol(), top_object, ns);
+    abstract_state.assign(instruction.decl_symbol(), declared_object, ns);
   }
-  // We now store top.
+  // We now store top (for most cases). The only exception is the predicate
+  // abstraction of monotonic change. In that case, an abstract value is
+  // initialized to "uninitialized" instead of the top.
   break;
 
   case DEAD:
@@ -62,8 +64,8 @@ void variable_sensitivity_domaint::transform(
     const code_assignt &inst = instruction.get_assign();
     const abstract_objectt::locationst write_location = {from};
     abstract_object_pointert rhs =
-      abstract_state.eval(inst.rhs(), ns)
-        ->update_location_context(write_location, true);
+      abstract_state.assign_eval(inst, ns)->update_location_context(
+        write_location, true);
     abstract_state.assign(inst.lhs(), rhs, ns);
   }
   break;

--- a/src/analyses/variable-sensitivity/variable_sensitivity_domain.h
+++ b/src/analyses/variable-sensitivity/variable_sensitivity_domain.h
@@ -82,7 +82,7 @@
 
 // clang-format off
 #define HELP_VSD \
-    " --vsd-values                 value tracking - constants|intervals|set-of-constants\n" /* NOLINT(whitespace/line_length) */ \
+    " --vsd-values                 value tracking - constants|intervals|set-of-constants|monotonic-change\n" /* NOLINT(whitespace/line_length) */ \
     " --vsd-structs                struct field sensitive analysis - top-bottom|every-field\n" /* NOLINT(whitespace/line_length) */ \
     " --vsd-arrays                 array entry sensitive analysis - top-bottom|every-element\n" /* NOLINT(whitespace/line_length) */ \
     " --vsd-pointers               pointer sensitive analysis - top-bottom|constants|value-set\n" /* NOLINT(whitespace/line_length) */ \

--- a/src/analyses/variable-sensitivity/variable_sensitivity_object_factory.cpp
+++ b/src/analyses/variable-sensitivity/variable_sensitivity_object_factory.cpp
@@ -6,7 +6,9 @@
 
 \*******************************************************************/
 #include "variable_sensitivity_object_factory.h"
+#include "abstract_value_object.h"
 #include "full_array_abstract_object.h"
+#include "monotonic_change.h"
 #include "value_set_pointer_abstract_object.h"
 
 template <class context_classt>
@@ -122,6 +124,221 @@ variable_sensitivity_object_factoryt::get_abstract_object_type(
   return abstract_object_type;
 }
 
+bool variable_sensitivity_object_factoryt::is_predicate_abstraction(
+  const typet &type,
+  const namespacet &ns) const
+{
+  const typet &followed_type = ns.follow(type);
+  ABSTRACT_OBJECT_TYPET abstract_object_type =
+    get_abstract_object_type(followed_type);
+
+  if(abstract_object_type == MONOTONIC_CHANGE)
+    return true;
+  else
+    return false;
+}
+
+abstract_object_pointert
+variable_sensitivity_object_factoryt::get_abstract_object_declaration(
+  const typet &type,
+  const exprt &e,
+  const abstract_environmentt &environment,
+  const namespacet &ns) const
+{
+  const typet &followed_type = ns.follow(type);
+  ABSTRACT_OBJECT_TYPET abstract_object_type =
+    get_abstract_object_type(followed_type);
+
+  bool top = true;
+  bool bottom = false;
+
+  abstract_object_pointert abstract_object;
+
+  switch(abstract_object_type)
+  {
+  case TWO_VALUE:
+    abstract_object =
+      std::make_shared<abstract_objectt>(followed_type, top, bottom);
+    break;
+  case CONSTANT:
+    abstract_object =
+      std::make_shared<constant_abstract_valuet>(followed_type, top, bottom);
+    break;
+  case INTERVAL:
+    abstract_object =
+      std::make_shared<interval_abstract_valuet>(followed_type, top, bottom);
+    break;
+  case VALUE_SET:
+    abstract_object =
+      std::make_shared<value_set_abstract_objectt>(followed_type, top, bottom);
+    break;
+  case MONOTONIC_CHANGE:
+    // For MONOTONIC_CHANGE, an initial abstract object is NOT the top. Instead,
+    // it is the abstract value "uninitialized."
+    abstract_object = std::make_shared<monotonic_changet>(
+      followed_type, false, false, uninitialized);
+    break;
+
+  case ARRAY_INSENSITIVE:
+    abstract_object = std::make_shared<two_value_array_abstract_objectt>(
+      followed_type, top, bottom);
+    break;
+  case ARRAY_SENSITIVE:
+    abstract_object =
+      std::make_shared<full_array_abstract_objectt>(followed_type, top, bottom);
+    break;
+
+  case POINTER_INSENSITIVE:
+    abstract_object = std::make_shared<two_value_pointer_abstract_objectt>(
+      followed_type, top, bottom);
+    break;
+  case POINTER_SENSITIVE:
+    abstract_object = std::make_shared<constant_pointer_abstract_objectt>(
+      followed_type, top, bottom);
+    break;
+  case VALUE_SET_OF_POINTERS:
+    abstract_object = std::make_shared<value_set_pointer_abstract_objectt>(
+      followed_type, top, bottom);
+    break;
+
+  case STRUCT_INSENSITIVE:
+    abstract_object = std::make_shared<two_value_struct_abstract_objectt>(
+      followed_type, top, bottom);
+    break;
+  case STRUCT_SENSITIVE:
+    abstract_object = std::make_shared<full_struct_abstract_objectt>(
+      followed_type, top, bottom);
+    break;
+
+  case UNION_INSENSITIVE:
+    abstract_object = std::make_shared<two_value_union_abstract_objectt>(
+      followed_type, top, bottom);
+    break;
+
+  case HEAP_ALLOCATION:
+  {
+    auto dynamic_object = exprt(ID_dynamic_object);
+    dynamic_object.set(
+      ID_identifier, "heap-allocation-" + std::to_string(heap_allocations++));
+    auto heap_symbol = unary_exprt(ID_address_of, dynamic_object, e.type());
+    auto heap_pointer =
+      get_abstract_object(e.type(), false, false, heap_symbol, environment, ns);
+    return heap_pointer;
+  }
+
+  default:
+    UNREACHABLE;
+    abstract_object =
+      std::make_shared<abstract_objectt>(followed_type, top, bottom);
+  }
+
+  return wrap_with_context_object(abstract_object, configuration);
+}
+
+abstract_object_pointert
+variable_sensitivity_object_factoryt::get_abstract_object_arbitrary_assignment(
+  const abstract_object_pointert &lhs_abstract_object,
+  const typet &type,
+  const exprt &rhs,
+  const abstract_environmentt &environment,
+  const namespacet &ns) const
+{
+  const typet &followed_type = ns.follow(type);
+  ABSTRACT_OBJECT_TYPET abstract_object_type =
+    get_abstract_object_type(followed_type);
+
+  bool top = false;
+  bool bottom = false;
+
+  abstract_object_pointert abstract_object;
+
+  switch(abstract_object_type)
+  {
+  case TWO_VALUE:
+    abstract_object =
+      std::make_shared<abstract_objectt>(followed_type, top, bottom);
+    break;
+  case CONSTANT:
+    abstract_object =
+      std::make_shared<constant_abstract_valuet>(followed_type, top, bottom);
+    break;
+  case INTERVAL:
+    abstract_object =
+      std::make_shared<interval_abstract_valuet>(followed_type, top, bottom);
+    break;
+  case VALUE_SET:
+    abstract_object =
+      std::make_shared<value_set_abstract_objectt>(followed_type, top, bottom);
+    break;
+  case MONOTONIC_CHANGE:
+    // For MONOTONIC_CHANGE, we must check the left-hand side's current status
+    // of monotonic change. If it is "uninitialized," any assignment will set
+    // the new status to "constant." Otherwise, if the current status is
+    // something else, the new status after the assignment is "top."
+    abstract_object = monotonic_change_expression_transform(
+      lhs_abstract_object,
+      // We don't care about the left-hand side's expression, so we just pass
+      // nil_expret().
+      nil_exprt(),
+      rhs);
+    break;
+
+  case ARRAY_INSENSITIVE:
+    abstract_object = std::make_shared<two_value_array_abstract_objectt>(
+      followed_type, top, bottom);
+    break;
+  case ARRAY_SENSITIVE:
+    abstract_object =
+      std::make_shared<full_array_abstract_objectt>(followed_type, top, bottom);
+    break;
+
+  case POINTER_INSENSITIVE:
+    abstract_object = std::make_shared<two_value_pointer_abstract_objectt>(
+      followed_type, top, bottom);
+    break;
+  case POINTER_SENSITIVE:
+    abstract_object = std::make_shared<constant_pointer_abstract_objectt>(
+      followed_type, top, bottom);
+    break;
+  case VALUE_SET_OF_POINTERS:
+    abstract_object = std::make_shared<value_set_pointer_abstract_objectt>(
+      followed_type, top, bottom);
+    break;
+
+  case STRUCT_INSENSITIVE:
+    abstract_object = std::make_shared<two_value_struct_abstract_objectt>(
+      followed_type, top, bottom);
+    break;
+  case STRUCT_SENSITIVE:
+    abstract_object = std::make_shared<full_struct_abstract_objectt>(
+      followed_type, top, bottom);
+    break;
+
+  case UNION_INSENSITIVE:
+    abstract_object = std::make_shared<two_value_union_abstract_objectt>(
+      followed_type, top, bottom);
+    break;
+
+  case HEAP_ALLOCATION:
+  {
+    auto dynamic_object = exprt(ID_dynamic_object);
+    dynamic_object.set(
+      ID_identifier, "heap-allocation-" + std::to_string(heap_allocations++));
+    auto heap_symbol = unary_exprt(ID_address_of, dynamic_object, rhs.type());
+    auto heap_pointer = get_abstract_object(
+      rhs.type(), false, false, heap_symbol, environment, ns);
+    return heap_pointer;
+  }
+
+  default:
+    UNREACHABLE;
+    abstract_object =
+      std::make_shared<abstract_objectt>(followed_type, top, bottom);
+  }
+
+  return wrap_with_context_object(abstract_object, configuration);
+}
+
 abstract_object_pointert
 variable_sensitivity_object_factoryt::get_abstract_object(
   const typet &type,
@@ -148,6 +365,9 @@ variable_sensitivity_object_factoryt::get_abstract_object(
       followed_type, top, bottom, e, environment, ns, configuration);
   case VALUE_SET:
     return initialize_abstract_object<value_set_abstract_objectt>(
+      followed_type, top, bottom, e, environment, ns, configuration);
+  case MONOTONIC_CHANGE:
+    return initialize_abstract_object<monotonic_changet>(
       followed_type, top, bottom, e, environment, ns, configuration);
 
   case ARRAY_INSENSITIVE:

--- a/src/analyses/variable-sensitivity/variable_sensitivity_object_factory.h
+++ b/src/analyses/variable-sensitivity/variable_sensitivity_object_factory.h
@@ -20,6 +20,7 @@
 #include <analyses/variable-sensitivity/data_dependency_context.h>
 #include <analyses/variable-sensitivity/full_struct_abstract_object.h>
 #include <analyses/variable-sensitivity/interval_abstract_value.h>
+#include <analyses/variable-sensitivity/monotonic_change.h>
 #include <analyses/variable-sensitivity/two_value_array_abstract_object.h>
 #include <analyses/variable-sensitivity/two_value_pointer_abstract_object.h>
 #include <analyses/variable-sensitivity/two_value_struct_abstract_object.h>
@@ -47,6 +48,49 @@ public:
     : configuration{options}, heap_allocations(0)
   {
   }
+
+  // Return whether the current configuration is for the predicate abstraction
+  // of monotonic change (i.e. MONOTONIC_CHANGE). This information is necessry
+  // when we want to use a function designated to MONOTONIC_CHANGE.
+  bool is_predicate_abstraction(const typet &type, const namespacet &ns) const;
+
+  // Get the appropriate abstract object when a variable is declared in GOTO
+  // code. In most cases, we return the top. Hence, it is equivalent to
+  // get_abstract_object(type, true, false, ...). However, in the case of
+  // MONOTONIC_CHANGE, we return the abstrtact value "uninitialized," which is
+  // NOT the top.
+  abstract_object_pointert get_abstract_object_declaration(
+    const typet &type,
+    const exprt &e,
+    const abstract_environmentt &environment,
+    const namespacet &ns) const;
+
+  // Get the appropriate abstract object for an assginment where we do not care
+  // about the right-hand side. This is why this function's name contains the
+  // word "arbitrary." This function is used, for example, when the right-hand
+  // side is a symbol/variable (e.g. x := y) or a constant (x := 42). If the
+  // right-hand side is a more complicated expression (e.g. arithmetic
+  // expressions), then we will examine the right-hand side more closely. For
+  // instance, if the assignment is x := x + 1, we will not invoke this
+  // function, but a different one.
+  //
+  // In most cases (apart from MONOTONIC_CHANGE), this function is equivalent to
+  // get_abstract_object(type, true, false, ...). However, MONOTONIC_CHANGE
+  // needs to be treated differently.
+  //
+  // This function takes in the abstract object of the assignment's left-hand
+  // side. The left-hand side's abstract object is necessary for
+  // MONOTONIC_CHANGE. Suppose that the left-hand side is a variable x and that
+  // x's current status is "uninitialized." Then any (arbitrary) assignment to x
+  // will change its status to "constant." However, if the current status is x
+  // is "increase," an (arbitrary) assignment to x will set its status to "top"
+  // since we know nothing about the right-hand side of the assignment.
+  abstract_object_pointert get_abstract_object_arbitrary_assignment(
+    const abstract_object_pointert &lhs_abstract_object,
+    const typet &type,
+    const exprt &rhs,
+    const abstract_environmentt &environment,
+    const namespacet &ns) const;
 
   /// Get the appropriate abstract object for the variable under
   /// consideration.


### PR DESCRIPTION
<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

In this pull request, I have implemented predicate abstraction for monotonic change: it checks whether variables have monotonically increased or decreased since the beginning of given GOTO code. This predicate abstraction will be used in the automatic inference of decreases clauses (aka ranking functions or loop variants). For example, consider a while-loop whose loop guard is `x < y`. If we know that `x` monotonically increases in the loop body and that `y` stays constant, we can successfully infer that `y - x` is a correct decreases clause.

This predicate abstraction works as follows. For each variable, we keep track of its predicate, namely monotonic-change status. There are six possible statuses:
1. Declared but uninitialized
2. Constant
3. Monotonic increase: the variable has monotonically increased since the beginning of the code. In this context, "monotonic" increase/decrease means "strict" increase/decrease. 
4. Monotonic decrease
5. Top: inconclusive. That is, we have no information about the given variable.
6. Bottom: infeasible. That is, no variables can possess this status. 

Here is an example: 
```
DECL x            // x is declared but uninitialized
ASSIGN x := 42    // x has stayed constant
ASSIGN x := x + 1 // x has monotonically increased
ASSIGN x := x - 1 // x is now top
```

Note that this predicate abstraction does NOT keep track of how much a variable has changed. So if we have `x--` followed by `x++` as in the above example, the predicate abstraction cannot tell us the net effect on `x`. This is why `x`'s status after the last line of the above example is top. 

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
