### PR TITLE
Skip checking frame conditions for local variables

### DIFF
--- a/regression/contracts/assigns_enforce_16/main.c
+++ b/regression/contracts/assigns_enforce_16/main.c
@@ -1,0 +1,16 @@
+void foo(int *xp) __CPROVER_assigns(*xp)
+{
+  {
+    int y;
+    y = 2;
+  }
+  int z = 3;
+  *xp = 1;
+}
+
+int main()
+{
+  int *xp = malloc(sizeof(*xp));
+  foo(xp);
+  return 0;
+}

--- a/regression/contracts/assigns_enforce_16/test.desc
+++ b/regression/contracts/assigns_enforce_16/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---enforce-all-contracts
+--enforce-all-contracts _ --pointer-primitive-check
 ^EXIT=0$
 ^SIGNAL=0$
 ^VERIFICATION SUCCESSFUL$

--- a/regression/contracts/assigns_enforce_16/test.desc
+++ b/regression/contracts/assigns_enforce_16/test.desc
@@ -1,0 +1,10 @@
+CORE
+main.c
+--enforce-all-contracts
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+--
+Checks whether verification fails when enforcing a contract
+for functions, without assigns clauses, that modify an input.

--- a/regression/contracts/assigns_enforce_17/main.c
+++ b/regression/contracts/assigns_enforce_17/main.c
@@ -1,0 +1,16 @@
+#include <assert.h>
+
+int x = 0;
+
+void pure() __CPROVER_assigns()
+{
+  int x;
+  x++;
+}
+
+int main()
+{
+  pure();
+  assert(x == 0);
+  return 0;
+}

--- a/regression/contracts/assigns_enforce_17/test.desc
+++ b/regression/contracts/assigns_enforce_17/test.desc
@@ -1,0 +1,11 @@
+CORE
+main.c
+--enforce-all-contracts
+^EXIT=0$
+^SIGNAL=0$
+^\[main.assertion.\d+\] line \d+ assertion x \=\= 0\: SUCCESS$
+^VERIFICATION SUCCESSFUL$
+--
+--
+Checks whether verification correctly distincts local variables
+and global variables with same name when checking frame conditions.

--- a/regression/contracts/assigns_enforce_scoping_01/test.desc
+++ b/regression/contracts/assigns_enforce_scoping_01/test.desc
@@ -3,7 +3,6 @@ main.c
 --enforce-all-contracts
 ^EXIT=10$
 ^SIGNAL=0$
-^\[f1.\d+\] line \d+ Check that f1\$\$1\$\$1\$\$b is assignable: SUCCESS$
 ^\[f1.\d+\] line \d+ Check that \*f1\$\$1\$\$1\$\$b is assignable: SUCCESS$
 ^\[f1.\d+\] line \d+ Check that \*b is assignable: FAILURE$
 ^VERIFICATION FAILED$

--- a/regression/contracts/assigns_replace_03/main.c
+++ b/regression/contracts/assigns_replace_03/main.c
@@ -1,17 +1,18 @@
 #include <assert.h>
+#include <stdlib.h>
 
 int y;
 double z;
 
-void bar(char **c) __CPROVER_assigns(y, z, **c) __CPROVER_ensures(**c == 6)
+void bar(char *c) __CPROVER_assigns(y, z, *c) __CPROVER_ensures(*c == 6)
 {
 }
 
 int main()
 {
-  char **b;
+  char *b = malloc(sizeof(*b));
   bar(b);
-  assert(**b == 6);
+  assert(*b == 6);
 
   return 0;
 }

--- a/regression/contracts/assigns_replace_03/test.desc
+++ b/regression/contracts/assigns_replace_03/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---replace-all-calls-with-contracts
+--replace-all-calls-with-contracts _ --pointer-primitive-check
 ^EXIT=0$
 ^SIGNAL=0$
 ^VERIFICATION SUCCESSFUL$

--- a/regression/contracts/assigns_type_checking_valid_cases/main.c
+++ b/regression/contracts/assigns_type_checking_valid_cases/main.c
@@ -45,8 +45,7 @@ void foo5(struct buf buffer) __CPROVER_assigns(buffer)
   buffer.len = 0;
 }
 
-void foo6(struct buf *buffer)
-  __CPROVER_assigns(buffer->data, *(buffer->data), buffer->len)
+void foo6(struct buf *buffer) __CPROVER_assigns(buffer->data, buffer->len)
 {
   buffer->data = malloc(sizeof(*(buffer->data)));
   *(buffer->data) = 1;

--- a/regression/contracts/assigns_type_checking_valid_cases/test.desc
+++ b/regression/contracts/assigns_type_checking_valid_cases/test.desc
@@ -5,6 +5,7 @@ main.c
 ^SIGNAL=0$
 ^\[foo1.\d+\] line \d+ Check that a is assignable: SUCCESS$
 ^\[foo10.\d+\] line \d+ Check that buffer\-\>len is assignable: SUCCESS$
+^\[foo10.\d+\] line \d+ Check that buffer\-\>aux\.allocated is assignable: SUCCESS$
 ^\[foo2.\d+\] line \d+ Check that b is assignable: SUCCESS$
 ^\[foo3.\d+\] line \d+ Check that b is assignable: SUCCESS$
 ^\[foo3.\d+\] line \d+ Check that y is assignable: SUCCESS$
@@ -27,7 +28,6 @@ main.c
 ^\[foo8.\d+\] line \d+ Check that array\[\(.* int\)7\] is assignable: SUCCESS$
 ^\[foo8.\d+\] line \d+ Check that array\[\(.* int\)8\] is assignable: SUCCESS$
 ^\[foo8.\d+\] line \d+ Check that array\[\(.* int\)9\] is assignable: SUCCESS$
-^\[foo9.\d+\] line \d+ Check that new_array is assignable: SUCCESS$
 ^\[foo9.\d+\] line \d+ Check that array is assignable: SUCCESS$
 ^VERIFICATION SUCCESSFUL$
 --

--- a/regression/contracts/assigns_type_checking_valid_cases/test.desc
+++ b/regression/contracts/assigns_type_checking_valid_cases/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---enforce-all-contracts
+--enforce-all-contracts _ --pointer-primitive-check
 ^EXIT=0$
 ^SIGNAL=0$
 ^\[foo1.\d+\] line \d+ Check that a is assignable: SUCCESS$

--- a/regression/contracts/function-calls-05/test.desc
+++ b/regression/contracts/function-calls-05/test.desc
@@ -4,7 +4,6 @@ main.c
 ^EXIT=0$
 ^SIGNAL=0$
 \[postcondition.\d+\] file main.c line \d+ Check ensures clause: SUCCESS
-\[foo.\d+\] line \d+ Check that sum is assignable: SUCCESS
 \[main.assertion.\d+\] line \d+ assertion foo\(\&x, \&y\) \=\= 10: SUCCESS
 ^VERIFICATION SUCCESSFUL$
 --

--- a/regression/contracts/history-pointer-enforce-10/test.desc
+++ b/regression/contracts/history-pointer-enforce-10/test.desc
@@ -7,8 +7,6 @@ main.c
 ^\[postcondition.\d+\] file main.c line \d+ Check ensures clause\: SUCCESS$
 ^\[postcondition.\d+\] file main.c line \d+ Check ensures clause\: SUCCESS$
 ^\[bar.\d+\] line \d+ Check that p\-\>y is assignable\: SUCCESS$
-^\[baz.\d+\] line \d+ Check that pp is assignable\: SUCCESS$
-^\[baz.\d+\] line \d+ Check that empty is assignable\: SUCCESS$
 ^\[baz.\d+\] line \d+ Check that p is assignable\: SUCCESS$
 ^\[baz.\d+\] line \d+ Check that p is assignable\: SUCCESS$
 ^\[foo.\d+\] line \d+ Check that \*p\-\>y is assignable\: SUCCESS$

--- a/regression/contracts/quantifiers-exists-requires-enforce/test.desc
+++ b/regression/contracts/quantifiers-exists-requires-enforce/test.desc
@@ -4,10 +4,6 @@ main.c
 ^EXIT=0$
 ^SIGNAL=0$
 ^\[postcondition.\d+\] file main.c line \d+ Check ensures clause: SUCCESS$
-^\[f1.\d+\] line \d+ Check that found\_four is assignable: SUCCESS$
-^\[f1.\d+\] line \d+ Check that i is assignable: SUCCESS$
-^\[f1.\d+\] line \d+ Check that i is assignable: SUCCESS$
-^\[f1.\d+\] line \d+ Check that found\_four is assignable: SUCCESS$
 ^VERIFICATION SUCCESSFUL$
 --
 ^warning: ignoring

--- a/regression/contracts/quantifiers-forall-ensures-enforce/test.desc
+++ b/regression/contracts/quantifiers-forall-ensures-enforce/test.desc
@@ -4,8 +4,6 @@ main.c
 ^EXIT=0$
 ^SIGNAL=0$
 ^\[postcondition.\d+\] file main.c line \d+ Check ensures clause: SUCCESS$
-^\[f1.\d+\] line \d+ Check that i is assignable: SUCCESS$
-^\[f1.\d+\] line \d+ Check that i is assignable: SUCCESS$
 ^\[f1.\d+\] line \d+ Check that arr\[\(.*\)i\] is assignable: SUCCESS$
 ^VERIFICATION SUCCESSFUL$
 --

--- a/regression/contracts/quantifiers-forall-requires-enforce/test.desc
+++ b/regression/contracts/quantifiers-forall-requires-enforce/test.desc
@@ -4,10 +4,6 @@ main.c
 ^EXIT=0$
 ^SIGNAL=0$
 ^\[postcondition.\d+\] file main.c line \d+ Check ensures clause: SUCCESS$
-^\[f1.\d+\] line \d+ Check that is\_identity is assignable: SUCCESS$
-^\[f1.\d+\] line \d+ Check that i is assignable: SUCCESS$
-^\[f1.\d+\] line \d+ Check that i is assignable: SUCCESS$
-^\[f1.\d+\] line \d+ Check that is\_identity is assignable: SUCCESS$
 ^VERIFICATION SUCCESSFUL$
 --
 ^warning: ignoring

--- a/regression/contracts/test_array_memory_enforce/test.desc
+++ b/regression/contracts/test_array_memory_enforce/test.desc
@@ -7,7 +7,6 @@ main.c
 \[foo.\d+\] line \d+ Check that \*x is assignable: SUCCESS
 \[foo.\d+\] line \d+ Check that x\[\(.* int\)5\] is assignable: SUCCESS
 \[foo.\d+\] line \d+ Check that x\[\(.* int\)9\] is assignable: SUCCESS
-\[foo.\d+\] line \d+ Check that y is assignable: SUCCESS
 ^VERIFICATION SUCCESSFUL$
 --
 --

--- a/src/goto-instrument/contracts/contracts.cpp
+++ b/src/goto-instrument/contracts/contracts.cpp
@@ -396,7 +396,7 @@ void code_contractst::replace_old_parameter(
 
     if(
       parameter.id() == ID_dereference || parameter.id() == ID_member ||
-      parameter.id() == ID_symbol)
+      parameter.id() == ID_symbol || parameter.id() == ID_ptrmember)
     {
       auto it = parameter2history.find(parameter);
 


### PR DESCRIPTION
Resolves #6154 

It avoids unnecessary assertions (improving performance) and it prevents cases where memory primitives are invoked with dead objects.

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
