### PR TITLE
format_expr now outputs constants of type c_bit_field

### DIFF
--- a/src/util/format_expr.cpp
+++ b/src/util/format_expr.cpp
@@ -171,7 +171,9 @@ static std::ostream &format_rec(std::ostream &os, const constant_exprt &src)
     else
       return os << src.pretty();
   }
-  else if(type == ID_unsignedbv || type == ID_signedbv || type == ID_c_bool)
+  else if(
+    type == ID_unsignedbv || type == ID_signedbv || type == ID_c_bool ||
+    type == ID_c_bit_field)
     return os << *numeric_cast<mp_integer>(src);
   else if(type == ID_integer)
     return os << src.get_value();


### PR DESCRIPTION
This adds a case for outputting constants that have `c_bit_field` type as
numbers.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
