### PR TITLE
introduce instructiont::call_function() and related methods

### DIFF
--- a/src/analyses/constant_propagator.cpp
+++ b/src/analyses/constant_propagator.cpp
@@ -192,8 +192,7 @@ void constant_propagator_domaint::transform(
   }
   else if(from->is_function_call())
   {
-    const auto &function_call = from->get_function_call();
-    const exprt &function=function_call.function();
+    const exprt &function = from->call_function();
 
     if(function.id()==ID_symbol)
     {
@@ -231,8 +230,8 @@ void constant_propagator_domaint::transform(
         const code_typet &code_type=to_code_type(symbol.type);
         const code_typet::parameterst &parameters=code_type.parameters();
 
-        const code_function_callt::argumentst &arguments=
-          function_call.arguments();
+        const code_function_callt::argumentst &arguments =
+          from->call_arguments();
 
         code_typet::parameterst::const_iterator p_it=parameters.begin();
         for(const auto &arg : arguments)
@@ -777,22 +776,11 @@ void constant_propagator_ait::replace(
     }
     else if(it->is_function_call())
     {
-      auto call = it->get_function_call();
+      constant_propagator_domaint::partial_evaluate(
+        d.values, it->call_function(), ns);
 
-      bool call_changed = false;
-
-      if(!constant_propagator_domaint::partial_evaluate(
-           d.values, call.function(), ns))
-      {
-        call_changed = true;
-      }
-
-      for(auto &arg : call.arguments())
-        if(!constant_propagator_domaint::partial_evaluate(d.values, arg, ns))
-          call_changed = true;
-
-      if(call_changed)
-        it->set_function_call(call);
+      for(auto &arg : it->call_arguments())
+        constant_propagator_domaint::partial_evaluate(d.values, arg, ns);
     }
     else if(it->is_other())
     {

--- a/src/goto-programs/cfg.h
+++ b/src/goto-programs/cfg.h
@@ -391,7 +391,7 @@ void cfg_baset<T, P, I>::compute_edges_function_call(
   goto_programt::const_targett next_PC,
   entryt &entry)
 {
-  const exprt &function = instruction.get_function_call().function();
+  const exprt &function = instruction.call_function();
 
   if(function.id()!=ID_symbol)
     return;
@@ -441,7 +441,7 @@ void procedure_local_cfg_baset<T, P, I>::compute_edges_function_call(
   goto_programt::const_targett next_PC,
   typename cfg_baset<T, P, I>::entryt &entry)
 {
-  const exprt &function = instruction.get_function_call().function();
+  const exprt &function = instruction.call_function();
 
   if(function.id()!=ID_symbol)
     return;

--- a/src/goto-programs/goto_inline_class.cpp
+++ b/src/goto-programs/goto_inline_class.cpp
@@ -436,11 +436,9 @@ void goto_inlinet::get_call(
 {
   PRECONDITION(it->is_function_call());
 
-  const code_function_callt &call = it->get_function_call();
-
-  lhs=call.lhs();
-  function=call.function();
-  arguments=call.arguments();
+  lhs = it->call_lhs();
+  function = it->call_function();
+  arguments = it->call_arguments();
 }
 
 /// Inline all of the given call locations.

--- a/src/goto-programs/goto_program.h
+++ b/src/goto-programs/goto_program.h
@@ -344,18 +344,74 @@ public:
     }
 
     /// Get the function call for FUNCTION_CALL
+#if 1
+    DEPRECATED(SINCE(
+      2021,
+      2,
+      24,
+      "Use call_function(), call_lhs(), call_arguments() instead"))
     const code_function_callt &get_function_call() const
     {
       PRECONDITION(is_function_call());
       return to_code_function_call(code);
     }
+#endif
+
+    /// Get the function that is called for FUNCTION_CALL
+    const exprt &call_function() const
+    {
+      PRECONDITION(is_function_call());
+      return to_code_function_call(code).function();
+    }
+
+    /// Get the function that is called for FUNCTION_CALL
+    exprt &call_function()
+    {
+      PRECONDITION(is_function_call());
+      return to_code_function_call(code).function();
+    }
+
+    /// Get the lhs of a FUNCTION_CALL (may be nil)
+    const exprt &call_lhs() const
+    {
+      PRECONDITION(is_function_call());
+      return to_code_function_call(code).lhs();
+    }
+
+    /// Get the lhs of a FUNCTION_CALL (may be nil)
+    exprt &call_lhs()
+    {
+      PRECONDITION(is_function_call());
+      return to_code_function_call(code).lhs();
+    }
+
+    /// Get the arguments of a FUNCTION_CALL
+    const exprt::operandst &call_arguments() const
+    {
+      PRECONDITION(is_function_call());
+      return to_code_function_call(code).arguments();
+    }
+
+    /// Get the arguments of a FUNCTION_CALL
+    exprt::operandst &call_arguments()
+    {
+      PRECONDITION(is_function_call());
+      return to_code_function_call(code).arguments();
+    }
 
     /// Set the function call for FUNCTION_CALL
+#if 1
+    DEPRECATED(SINCE(
+      2021,
+      2,
+      24,
+      "Use call_function(), call_lhs(), call_arguments() instead"))
     void set_function_call(code_function_callt c)
     {
       PRECONDITION(is_function_call());
       code = std::move(c);
     }
+#endif
 
     /// Get the statement for OTHER
     const codet &get_other() const

--- a/src/goto-programs/instrument_preconditions.cpp
+++ b/src/goto-programs/instrument_preconditions.cpp
@@ -64,14 +64,14 @@ void remove_preconditions(goto_programt &goto_program)
 }
 
 replace_symbolt actuals_replace_map(
-  const code_function_callt &call,
+  const goto_programt::instructiont &call,
   const namespacet &ns)
 {
-  PRECONDITION(call.function().id()==ID_symbol);
-  const symbolt &s=ns.lookup(to_symbol_expr(call.function()));
+  PRECONDITION(call.call_function().id() == ID_symbol);
+  const symbolt &s = ns.lookup(to_symbol_expr(call.call_function()));
   const auto &code_type=to_code_type(s.type);
   const auto &parameters=code_type.parameters();
-  const auto &arguments=call.arguments();
+  const auto &arguments = call.call_arguments();
 
   replace_symbolt result;
   std::size_t count=0;
@@ -102,17 +102,16 @@ void instrument_preconditions(
     if(it->is_function_call())
     {
       // does the function we call have preconditions?
-      const auto &call = it->get_function_call();
+      const auto &called_function = it->call_function();
 
-      if(call.function().id()==ID_symbol)
+      if(called_function.id() == ID_symbol)
       {
-        auto preconditions=
-          get_preconditions(to_symbol_expr(call.function()),
-                            goto_model.goto_functions);
+        auto preconditions = get_preconditions(
+          to_symbol_expr(called_function), goto_model.goto_functions);
 
         source_locationt source_location=it->source_location;
 
-        replace_symbolt r=actuals_replace_map(call, ns);
+        replace_symbolt r = actuals_replace_map(*it, ns);
 
         // add before the call, with location of the call
         for(const auto &p : preconditions)

--- a/src/goto-programs/interpreter.cpp
+++ b/src/goto-programs/interpreter.cpp
@@ -739,10 +739,12 @@ void interpretert::execute_assert()
 
 void interpretert::execute_function_call()
 {
-  const code_function_callt &function_call = pc->get_function_call();
+  const auto &call_lhs = pc->call_lhs();
+  const auto &call_function = pc->call_function();
+  const auto &call_arguments = pc->call_arguments();
 
   // function to be called
-  mp_integer address=evaluate_address(function_call.function());
+  mp_integer address = evaluate_address(call_function);
 
   if(address==0)
     throw "function call to NULL";
@@ -767,19 +769,18 @@ void interpretert::execute_function_call()
   // return value
   mp_integer return_value_address;
 
-  if(function_call.lhs().is_not_nil())
-    return_value_address=
-      evaluate_address(function_call.lhs());
+  if(call_lhs.is_not_nil())
+    return_value_address = evaluate_address(call_lhs);
   else
     return_value_address=0;
 
   // values of the arguments
   std::vector<mp_vectort> argument_values;
 
-  argument_values.resize(function_call.arguments().size());
+  argument_values.resize(call_arguments.size());
 
-  for(std::size_t i=0; i<function_call.arguments().size(); i++)
-    evaluate(function_call.arguments()[i], argument_values[i]);
+  for(std::size_t i = 0; i < call_arguments.size(); i++)
+    evaluate(call_arguments[i], argument_values[i]);
 
   // do the call
 
@@ -821,8 +822,8 @@ void interpretert::execute_function_call()
   }
   else
   {
-    list_input_varst::iterator it = function_input_vars.find(
-      to_symbol_expr(function_call.function()).get_identifier());
+    list_input_varst::iterator it =
+      function_input_vars.find(to_symbol_expr(call_function).get_identifier());
 
     if(it!=function_input_vars.end())
     {

--- a/src/goto-programs/label_function_pointer_call_sites.cpp
+++ b/src/goto-programs/label_function_pointer_call_sites.cpp
@@ -21,14 +21,13 @@ void label_function_pointer_call_sites(goto_modelt &goto_model)
     for_each_instruction_if(
       goto_function.second,
       [](const goto_programt::targett it) {
-        return it->is_function_call() && can_cast_expr<dereference_exprt>(
-                                           it->get_function_call().function());
+        return it->is_function_call() &&
+               can_cast_expr<dereference_exprt>(it->call_function());
       },
       [&](goto_programt::targett &it) {
-        auto const &function_call = it->get_function_call();
         auto const &function_pointer_dereference =
-          to_dereference_expr(function_call.function());
-        auto const &source_location = function_call.source_location();
+          to_dereference_expr(it->call_function());
+        auto const &source_location = it->source_location;
         auto const &goto_function_symbol_mode =
           goto_model.symbol_table.lookup_ref(goto_function.first).mode;
 
@@ -43,7 +42,7 @@ void label_function_pointer_call_sites(goto_modelt &goto_model)
             function_call_site_symbol.pretty_name = call_site_symbol_name;
           function_call_site_symbol.type =
             function_pointer_dereference.pointer().type();
-          function_call_site_symbol.location = function_call.source_location();
+          function_call_site_symbol.location = source_location;
           function_call_site_symbol.is_lvalue = true;
           function_call_site_symbol.mode = goto_function_symbol_mode;
           return function_call_site_symbol;

--- a/src/goto-programs/parameter_assignments.cpp
+++ b/src/goto-programs/parameter_assignments.cpp
@@ -44,14 +44,12 @@ void parameter_assignmentst::do_function_calls(
   {
     if(i_it->is_function_call())
     {
-      const code_function_callt &function_call = i_it->get_function_call();
-
       // add x=y for f(y) where x is the parameter
 
-      PRECONDITION(function_call.function().id() == ID_symbol);
+      PRECONDITION(i_it->call_function().id() == ID_symbol);
 
-      const irep_idt &identifier=
-        to_symbol_expr(function_call.function()).get_identifier();
+      const irep_idt &identifier =
+        to_symbol_expr(i_it->call_function()).get_identifier();
 
       // see if we have it
       const namespacet ns(symbol_table);
@@ -67,12 +65,12 @@ void parameter_assignmentst::do_function_calls(
         if(p_identifier.empty())
           continue;
 
-        if(nr<function_call.arguments().size())
+        if(nr < i_it->call_arguments().size())
         {
           const symbolt &lhs_symbol=ns.lookup(p_identifier);
           symbol_exprt lhs=lhs_symbol.symbol_expr();
           exprt rhs = typecast_exprt::conditional_cast(
-            function_call.arguments()[nr], lhs.type());
+            i_it->call_arguments()[nr], lhs.type());
           tmp.add(goto_programt::make_assignment(
             code_assignt(lhs, rhs), i_it->source_location));
         }

--- a/src/goto-programs/remove_calls_no_body.cpp
+++ b/src/goto-programs/remove_calls_no_body.cpp
@@ -69,8 +69,7 @@ bool remove_calls_no_bodyt::is_opaque_function_call(
   if(!target->is_function_call())
     return false;
 
-  const code_function_callt &cfc = target->get_function_call();
-  const exprt &f = cfc.function();
+  const exprt &f = target->call_function();
 
   if(f.id() != ID_symbol)
     return false;
@@ -103,8 +102,8 @@ operator()(goto_programt &goto_program, const goto_functionst &goto_functions)
   {
     if(is_opaque_function_call(it, goto_functions))
     {
-      const code_function_callt &cfc = it->get_function_call();
-      remove_call_no_body(goto_program, it, cfc.lhs(), cfc.arguments());
+      remove_call_no_body(
+        goto_program, it, it->call_lhs(), it->call_arguments());
     }
     else
     {

--- a/src/goto-programs/validate_goto_model.cpp
+++ b/src/goto-programs/validate_goto_model.cpp
@@ -170,9 +170,8 @@ void validate_goto_modelt::check_called_functions()
       // check functions that are called
       if(instr.is_function_call())
       {
-        const auto &function_call = instr.get_function_call();
         const irep_idt &identifier =
-          to_symbol_expr(function_call.function()).get_identifier();
+          to_symbol_expr(instr.call_function()).get_identifier();
 
         DATA_CHECK(
           vm,


### PR DESCRIPTION
This completes the new API of `goto_programt::instructiont` by introducing methods for accessing the properties of function calls.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- n/a Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
