### PR TITLE
VSD - neater clone member function.

### DIFF
--- a/src/analyses/variable-sensitivity/abstract_object.cpp
+++ b/src/analyses/variable-sensitivity/abstract_object.cpp
@@ -62,7 +62,7 @@ abstract_object_pointert abstract_objectt::abstract_object_merge(
   if(is_top() || other->bottom)
     return this->abstract_object_merge_internal(other);
 
-  internal_abstract_object_pointert merged = mutable_clone();
+  auto merged = mutable_clone();
   merged->set_top();
   merged->bottom = false;
   return merged->abstract_object_merge_internal(other);
@@ -90,7 +90,7 @@ abstract_object_pointert abstract_objectt::abstract_object_meet(
   if(is_bottom() || other->top)
     return this->abstract_object_meet_internal(other);
 
-  internal_abstract_object_pointert met = mutable_clone();
+  auto met = mutable_clone();
   met->bottom = true;
   met->top = false;
   return met->abstract_object_meet_internal(other);

--- a/src/analyses/variable-sensitivity/abstract_object.h
+++ b/src/analyses/variable-sensitivity/abstract_object.h
@@ -44,6 +44,11 @@ enum class widen_modet;
     typedef std::remove_const<                                                 \
       std::remove_reference<decltype(*this)>::type>::type current_typet;       \
     return internal_abstract_object_pointert(new current_typet(*this));        \
+  }                                                                            \
+  template <class T>                                                           \
+  std::shared_ptr<T> clone(const T *t) const                                   \
+  {                                                                            \
+    return std::dynamic_pointer_cast<T>(mutable_clone());                      \
   }
 
 /// Merge is designed to allow different abstractions to be merged

--- a/src/analyses/variable-sensitivity/constant_abstract_value.cpp
+++ b/src/analyses/variable-sensitivity/constant_abstract_value.cpp
@@ -141,7 +141,7 @@ abstract_value_pointert constant_abstract_valuet::constrain(
   const exprt &lower,
   const exprt &upper) const
 {
-  return as_value(mutable_clone());
+  return as_value(clone(this));
 }
 
 exprt constant_abstract_valuet::to_predicate_internal(const exprt &name) const

--- a/src/analyses/variable-sensitivity/context_abstract_object.cpp
+++ b/src/analyses/variable-sensitivity/context_abstract_object.cpp
@@ -113,8 +113,7 @@ context_abstract_objectt::envelop(abstract_object_pointert &object) const
     nullptr)
     return object;
 
-  const auto &envelope =
-    std::dynamic_pointer_cast<context_abstract_objectt>(mutable_clone());
+  auto envelope = clone(this);
   envelope->set_child(object);
   return envelope;
 }

--- a/src/analyses/variable-sensitivity/data_dependency_context.cpp
+++ b/src/analyses/variable-sensitivity/data_dependency_context.cpp
@@ -107,8 +107,7 @@ abstract_object_pointert data_dependency_contextt::insert_data_deps(
   if(new_dependencies.empty())
     return shared_from_this();
 
-  const auto &result =
-    std::dynamic_pointer_cast<data_dependency_contextt>(mutable_clone());
+  auto result = clone(this);
 
   for(auto l : new_dependencies)
   {
@@ -153,8 +152,7 @@ data_dependency_contextt::set_data_deps(const dependencest &dependencies) const
     intersection.size() == dependencies.size())
     return shared_from_this();
 
-  const auto &result =
-    std::dynamic_pointer_cast<data_dependency_contextt>(mutable_clone());
+  auto result = clone(this);
 
   result->data_deps = dependencies;
 
@@ -280,8 +278,7 @@ abstract_object_pointert data_dependency_contextt::combine(
     std::dynamic_pointer_cast<const data_dependency_contextt>(
       parent->insert_data_deps(other->data_deps));
 
-  const auto &result = std::dynamic_pointer_cast<data_dependency_contextt>(
-    updated_parent->mutable_clone());
+  auto result = clone(this);
 
   // On a merge, data_dominators are the intersection of this object and the
   // other object. In other words, the dominators at this merge point are

--- a/src/analyses/variable-sensitivity/full_array_abstract_object.cpp
+++ b/src/analyses/variable-sensitivity/full_array_abstract_object.cpp
@@ -119,8 +119,7 @@ abstract_object_pointert full_array_abstract_objectt::full_array_merge(
   if(is_bottom())
     return std::make_shared<full_array_abstract_objectt>(*other);
 
-  const auto &result =
-    std::dynamic_pointer_cast<full_array_abstract_objectt>(mutable_clone());
+  auto result = clone(this);
 
   bool modified = merge_shared_maps(map, other->map, result->map, widen_mode);
   if(!modified)
@@ -261,8 +260,7 @@ abstract_object_pointert full_array_abstract_objectt::write_sub_element(
   const abstract_object_pointert &value,
   bool merging_write) const
 {
-  const auto &result =
-    std::dynamic_pointer_cast<full_array_abstract_objectt>(mutable_clone());
+  auto result = clone(this);
 
   mp_integer index_value;
   bool good_index = eval_index(expr, environment, ns, index_value);
@@ -316,8 +314,7 @@ abstract_object_pointert full_array_abstract_objectt::write_leaf_element(
   const abstract_object_pointert &value,
   bool merging_write) const
 {
-  const auto &result =
-    std::dynamic_pointer_cast<full_array_abstract_objectt>(mutable_clone());
+  auto result = clone(this);
 
   mp_integer index_value;
   bool good_index = eval_index(expr, environment, ns, index_value);
@@ -378,8 +375,7 @@ abstract_object_pointert full_array_abstract_objectt::get_top_entry(
 abstract_object_pointert full_array_abstract_objectt::visit_sub_elements(
   const abstract_object_visitort &visitor) const
 {
-  const auto &result =
-    std::dynamic_pointer_cast<full_array_abstract_objectt>(mutable_clone());
+  auto result = clone(this);
 
   bool modified = false;
   for(auto &item : result->map.get_view())

--- a/src/analyses/variable-sensitivity/full_struct_abstract_object.cpp
+++ b/src/analyses/variable-sensitivity/full_struct_abstract_object.cpp
@@ -124,8 +124,7 @@ abstract_object_pointert full_struct_abstract_objectt::write_component(
       member_expr.compound().type(), false, true);
   }
 
-  const auto &result =
-    std::dynamic_pointer_cast<full_struct_abstract_objectt>(mutable_clone());
+  auto result = clone(this);
 
   if(!stack.empty())
   {
@@ -257,8 +256,7 @@ abstract_object_pointert full_struct_abstract_objectt::merge_constant_structs(
   if(is_bottom())
     return std::make_shared<full_struct_abstract_objectt>(*other);
 
-  const auto &result =
-    std::dynamic_pointer_cast<full_struct_abstract_objectt>(mutable_clone());
+  auto result = clone(this);
 
   bool modified = merge_shared_maps(map, other->map, result->map, widen_mode);
 
@@ -279,8 +277,7 @@ abstract_object_pointert full_struct_abstract_objectt::merge_constant_structs(
 abstract_object_pointert full_struct_abstract_objectt::visit_sub_elements(
   const abstract_object_visitort &visitor) const
 {
-  const auto &result =
-    std::dynamic_pointer_cast<full_struct_abstract_objectt>(mutable_clone());
+  auto result = clone(this);
 
   bool modified = false;
 

--- a/src/analyses/variable-sensitivity/interval_abstract_value.cpp
+++ b/src/analyses/variable-sensitivity/interval_abstract_value.cpp
@@ -456,7 +456,7 @@ abstract_value_pointert interval_abstract_valuet::constrain(
     constant_interval_exprt::get_min(upper, interval.get_upper());
 
   if(constant_interval_exprt::greater_than(lower_bound, upper_bound))
-    return as_value(mutable_clone());
+    return as_value(clone(this));
 
   auto constrained_interval = constant_interval_exprt(lower_bound, upper_bound);
   return as_value(

--- a/src/analyses/variable-sensitivity/value_set_pointer_abstract_object.cpp
+++ b/src/analyses/variable-sensitivity/value_set_pointer_abstract_object.cpp
@@ -200,8 +200,7 @@ abstract_object_pointert value_set_pointer_abstract_objectt::resolve_values(
 
   auto unwrapped_values = unwrap_and_extract_values(new_values);
 
-  auto result = std::dynamic_pointer_cast<value_set_pointer_abstract_objectt>(
-    mutable_clone());
+  auto result = clone(this);
 
   if(unwrapped_values.size() > max_value_set_size)
   {

--- a/src/analyses/variable-sensitivity/write_location_context.cpp
+++ b/src/analyses/variable-sensitivity/write_location_context.cpp
@@ -25,8 +25,7 @@ abstract_object_pointert write_location_contextt::update_location_context(
   const abstract_objectt::locationst &locations,
   const bool update_sub_elements) const
 {
-  const auto &result =
-    std::dynamic_pointer_cast<write_location_contextt>(mutable_clone());
+  auto result = clone(this);
 
   if(update_sub_elements)
   {
@@ -80,8 +79,7 @@ abstract_object_pointert write_location_contextt::write(
 
   // Need to ensure the result of the write is still wrapped in a dependency
   // context
-  const auto &result =
-    std::dynamic_pointer_cast<write_location_contextt>(mutable_clone());
+  auto result = clone(this);
 
   // Update the child and record the updated write locations
   result->set_child(updated_child);
@@ -161,8 +159,7 @@ abstract_object_pointert write_location_contextt::combine(
 
   if(combined_child.modified || merge_locations)
   {
-    const auto &result =
-      std::dynamic_pointer_cast<write_location_contextt>(mutable_clone());
+    auto result = clone(this);
     if(combined_child.modified)
     {
       result->set_child(combined_child.object);
@@ -206,7 +203,7 @@ write_location_contextt::abstract_object_merge_internal(
     // If the union is larger than the initial set, then update.
     if(location_union.size() > get_last_written_locations().size())
     {
-      abstract_object_pointert result = mutable_clone();
+      auto result = clone(this);
       return result->update_location_context(location_union, false);
     }
   }


### PR DESCRIPTION
The VSD `abstract_objectt` hierarchy has a polymorphic `mutable_clone` member function, which abstract object's use when they need to return an updated copy of themselves. The member function declaration is 

  `virtual std::shared_ptr<abstract_objectt> mutable_clone() const`
 
Because `mutable_clone` returns a shared pointer to the base type, we almost always need to cast the return value, typically something like 

  `auto result = std::dynamic_pointer_cast<data_dependency_contextt>(mutable_clone());`

This is, frankly, a bit of a mouthful. 

This PR is pure refactoring which adds a non-virtual template member function to wrap up the pointer cast into a neater package. We can now write 

  `auto result = clone(this);`

and result will still have the correct shared pointer type. It's not absolutely ideal (if I could think of a way to eliminate the `this` parameter, believe me I'd take it), but it's much, much easier on the eye. 

