### PR TITLE
Introduce floatbv_rounding_mode(unsigned)

### DIFF
--- a/src/util/Makefile
+++ b/src/util/Makefile
@@ -22,6 +22,7 @@ SRC = allocate_objects.cpp \
       find_macros.cpp \
       find_symbols.cpp \
       fixedbv.cpp \
+      floatbv_expr.cpp \
       format_constant.cpp \
       format_expr.cpp \
       format_number_range.cpp \

--- a/src/util/floatbv_expr.cpp
+++ b/src/util/floatbv_expr.cpp
@@ -1,0 +1,20 @@
+/*******************************************************************\
+
+Module: API to expression classes for floating-point arithmetic
+
+Author: Daniel Kroening, kroening@kroening.com
+
+\*******************************************************************/
+
+#include "floatbv_expr.h"
+
+#include "arith_tools.h"
+#include "bitvector_types.h"
+
+constant_exprt floatbv_rounding_mode(unsigned rm)
+{
+  // The 32 bits are an arbitrary choice;
+  // e.g., float_utilst consumes other widths as well.
+  // The type is signed to match the signature of fesetround.
+  return ::from_integer(rm, signedbv_typet(32));
+}

--- a/src/util/floatbv_expr.h
+++ b/src/util/floatbv_expr.h
@@ -438,4 +438,9 @@ inline ieee_float_op_exprt &to_ieee_float_op_expr(exprt &expr)
   return ret;
 }
 
+/// \brief returns the a rounding mode expression for a given
+/// IEEE rounding mode, encoded using the recommendation in
+/// C11 5.2.4.2.2
+constant_exprt floatbv_rounding_mode(unsigned);
+
 #endif // CPROVER_UTIL_FLOATBV_EXPR_H

--- a/src/util/ieee_float.cpp
+++ b/src/util/ieee_float.cpp
@@ -12,7 +12,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "arith_tools.h"
 #include "bitvector_types.h"
-#include "c_types.h"
+#include "floatbv_expr.h"
 #include "invariant.h"
 #include "std_expr.h"
 
@@ -58,7 +58,7 @@ void ieee_float_spect::from_type(const floatbv_typet &type)
 
 constant_exprt ieee_floatt::rounding_mode_expr(rounding_modet rm)
 {
-  return ::from_integer(static_cast<int>(rm), unsigned_int_type());
+  return floatbv_rounding_mode(static_cast<unsigned>(rm));
 }
 
 void ieee_floatt::print(std::ostream &out) const

--- a/src/util/ieee_float.h
+++ b/src/util/ieee_float.h
@@ -120,7 +120,8 @@ class ieee_floatt
 public:
   // ROUND_TO_EVEN is also known as "round to nearest, ties to even", and
   // is the IEEE default.
-  // The numbering below is what x86 uses in the control word.
+  // The numbering below is what x86 uses in the control word and
+  // what is recommended in C11 5.2.4.2.2
   enum rounding_modet
   {
     ROUND_TO_EVEN=0, ROUND_TO_MINUS_INF=1,


### PR DESCRIPTION
This introduces a function to produce the constant expression that is
consumed by the floatbv_* expressions as the rounding mode.

Using this function in `ieee_floatt` removes the dependency on c_types.h.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- [X] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
