### PR TITLE
VSD - constant expression evaluation speedup

### DIFF
--- a/regression/goto-analyzer-simplify/simplify-deeply-nested-expression/main.c
+++ b/regression/goto-analyzer-simplify/simplify-deeply-nested-expression/main.c
@@ -1,0 +1,42 @@
+int nondet_int(void);
+
+struct MH
+{
+  int s;
+  int t;
+  int to;
+  int su;
+};
+
+int main(void)
+{
+  int l = nondet_int();
+  int s = nondet_int();
+  int n = nondet_int();
+  int o = nondet_int();
+  int nt = nondet_int();
+  int ns = nondet_int();
+
+  struct MH mh;
+  mh.s = nondet_int();
+  mh.t = nondet_int();
+  mh.to = nondet_int();
+  mh.su = nondet_int();
+
+  int result =
+    ((l >= mh.s ? 1 : 0) &
+     (((mh.s >= s ? 1 : 0) &
+       (((n >= mh.t ? 1 : 0) &
+         (((mh.t >= o ? 1 : 0) & ((((int)mh.to == (int)nt ? 0 : 1) &
+                                   ((int)mh.su == (int)ns ? 0 : 1)) == 0
+                                    ? 0
+                                    : 1)) == 0
+            ? 0
+            : 1)) == 0
+          ? 0
+          : 1)) == 0
+        ? 0
+        : 1)) == 0;
+
+  assert(result = 0);
+}

--- a/regression/goto-analyzer-simplify/simplify-deeply-nested-expression/test.desc
+++ b/regression/goto-analyzer-simplify/simplify-deeply-nested-expression/test.desc
@@ -1,0 +1,10 @@
+CORE
+main.c
+--vsd
+^SIGNAL=0$
+^EXIT=0$
+--
+--
+This expression is derived from a real system under test. Due to inadvertent reevaluation of expression operands, all expression evaluations had geometric complexity (even more so in the presence of TOP values). This particular expression took nearly two hours to evaluate. Reworking to prevent repeated reevaluation brings this down to a few tenths.
+See https://github.com/diffblue/cbmc/pull/6290
+If this test appears to hang, the constant_evaluator is probably your first port of call.

--- a/src/analyses/variable-sensitivity/abstract_value_object.cpp
+++ b/src/analyses/variable-sensitivity/abstract_value_object.cpp
@@ -255,19 +255,20 @@ private:
       auto lhs_value = eval_constant(op);
 
       // do not give up if a sub-expression is not a constant,
-      // because the whole expression may still be simplified in some cases
-      expr.operands().push_back(lhs_value.is_nil() ? op : lhs_value);
-    }
-
-    exprt simplified = simplify_expr(expr, ns);
-    for(const exprt &op : simplified.operands())
-    {
-      auto lhs_value = eval_constant(op);
       if(lhs_value.is_nil())
-        return top(simplified.type());
+      {
+        exprt simplified_op = simplify_expr(op, ns);
+        if(simplified_op.is_not_nil())
+          lhs_value = eval_constant(simplified_op);
+        if(lhs_value.is_nil())
+          return top(expr.type());
+      }
+
+      expr.operands().push_back(lhs_value);
     }
 
     // the expression is fully simplified
+    exprt simplified = simplify_expr(expr, ns);
     return std::make_shared<constant_abstract_valuet>(
       simplified, environment, ns);
   }


### PR DESCRIPTION
This PR reduces the number of times the operands in a constant_value expression are reevaluated. Usually, this overhead is small but for nested expressions this can result in excessive runtimes. 

The motivating example has the form 
```
(
 (l >= mh.s ? 1 : 0)
&(
  (
   (mh.s >= s ? 1 : 0) 
  &(
    (
     (n >= mh.t ? 1 : 0) 
    &(
      (
       (mh.t >= o ? 1 : 0) 
      &(
        (
         ((int)mh.to == (int)nt ? 0 : 1) 
        &((int)mh.su == (int)ns ? 0 : 1)
        ) == 0 ? 0 : 1
       )
      ) == 0 ? 0 : 1
     )
    ) == 0 ? 0 : 1
   )
  ) == 0 ? 0 : 1
 )
) == 0
```
This doesn't look particularly difficult, but evaluation time for the goto-program in question was close to two hours. With these changes evaluation time is approximately two tenths of a second (usual caveats - as reported by `time` on my machine, etc).




