### PR TITLE
Make liveness_contextt::get_location() public

### DIFF
--- a/src/analyses/variable-sensitivity/liveness_context.h
+++ b/src/analyses/variable-sensitivity/liveness_context.h
@@ -64,6 +64,8 @@ public:
   void output(std::ostream &out, const class ai_baset &ai, const namespacet &ns)
     const override;
 
+  locationt get_location() const;
+
 protected:
   CLONE
 
@@ -81,8 +83,6 @@ protected:
     const exprt &specifier,
     const abstract_object_pointert &value,
     bool merging_write) const override;
-
-  locationt get_location() const;
 
 private:
   using liveness_context_ptrt = std::shared_ptr<const liveness_contextt>;


### PR DESCRIPTION
This accessor was inadvertently left protected, when to be remotely useful it needs to be public.