### PR TITLE
sharing_map::get_delta_view fix

### DIFF
--- a/src/util/sharing_map.h
+++ b/src/util/sharing_map.h
@@ -919,10 +919,11 @@ SHARING_MAPT(void)::add_item_if_not_shared(
       if(equalT()(leaf.get_key(), ip->get_key()))
       {
         delta_view.push_back({k, leaf.get_value(), ip->get_value()});
-        return;
       }
-
-      delta_view.push_back({k, leaf.get_value()});
+      else if(!only_common)
+      {
+        delta_view.push_back({k, leaf.get_value()});
+      }
 
       return;
     }

--- a/src/util/sharing_map.h
+++ b/src/util/sharing_map.h
@@ -13,7 +13,7 @@ Author: Daniel Poetzl
 #define CPROVER_UTIL_SHARING_MAP_H
 
 #ifdef SM_DEBUG
-#include <iostream>
+#  include <iostream>
 #endif
 
 #include <functional>
@@ -34,9 +34,9 @@ Author: Daniel Poetzl
 #include "threeval.h"
 
 #ifdef SM_INTERNAL_CHECKS
-#define SM_ASSERT(b) INVARIANT(b, "Sharing map internal invariant")
+#  define SM_ASSERT(b) INVARIANT(b, "Sharing map internal invariant")
 #else
-#define SM_ASSERT(b)
+#  define SM_ASSERT(b)
 #endif
 
 // clang-format off
@@ -344,8 +344,8 @@ public:
     map.swap(other.map);
 
     std::size_t tmp = num;
-    num=other.num;
-    other.num=tmp;
+    num = other.num;
+    other.num = tmp;
   }
 
   /// Get number of elements in map
@@ -359,14 +359,14 @@ public:
   /// Check if map is empty
   bool empty() const
   {
-    return num==0;
+    return num == 0;
   }
 
   /// Clear map
   void clear()
   {
     map.clear();
-    num=0;
+    num = 0;
   }
 
   /// Check if key is in map
@@ -376,7 +376,7 @@ public:
   /// - Best case: O(1)
   bool has_key(const key_type &k) const
   {
-    return get_leaf_node(k)!=nullptr;
+    return get_leaf_node(k) != nullptr;
   }
 
   // views
@@ -695,8 +695,7 @@ SHARING_MAPT(void)
         f(l.get_key(), l.get_value());
       }
     }
-  }
-  while(!stack.empty());
+  } while(!stack.empty());
 }
 
 SHARING_MAPT(std::size_t)
@@ -1113,8 +1112,7 @@ SHARING_MAPT(void)
         }
       }
     }
-  }
-  while(!stack.empty());
+  } while(!stack.empty());
 }
 
 SHARING_MAPT2(, delta_viewt)::get_delta_view(
@@ -1217,7 +1215,7 @@ SHARING_MAPT(void)::erase(const key_type &k)
     if(m.size() > 1 || del == nullptr)
     {
       del = ip;
-      del_bit=bit;
+      del_bit = bit;
     }
 
     ip = &ip->add_child(bit);

--- a/src/util/sharing_map.h
+++ b/src/util/sharing_map.h
@@ -906,7 +906,10 @@ SHARING_MAPT(void)::add_item_if_not_shared(
         }
       }
 
-      delta_view.push_back({k, leaf.get_value()});
+      if(!only_common)
+      {
+        delta_view.push_back({k, leaf.get_value()});
+      }
 
       return;
     }


### PR DESCRIPTION
In a system under test we're encountering an invariant failure
```
--- begin invariant violation report ---
Invariant check failed
File: ../util/sharing_map.h:428 function: get_other_map_value
Condition: is_in_both_maps()
Reason: Precondition
Backtrace:
```

In `abstract_environmentt::merge`, after a bit of preamble we do the actual merge
```
  for(const auto &entry : env.map.get_delta_view(map))
  {
    auto merge_result = abstract_objectt::merge(
      entry.get_other_map_value(), entry.m, merge_location, widen_mode);

    modified |= merge_result.modified;
    map.replace(entry.k, merge_result.object);
  }
```
The invariant violation occurs in the `entry.get_other_map_value()` call, because the entry is _not_, in fact, in the other map. 

There appears to be a problem in how the delta_view is calculated. I don't pretend to understand how the delta is calculated - I assume we're walking the map internal structures, but that's a little bit involved - but for the erroneous entry end up in `sharing_map::add_item_if_not_shared`, specifically at the line highlighted below 

```
  if(ip->is_leaf())
  {
    if(ip->shares_with(leaf))
      return;

    if(equalT()(leaf.get_key(), ip->get_key()))
    {
      delta_view.push_back({k, leaf.get_value(), ip->get_value()});
      return;
    }

    delta_view.push_back({k, leaf.get_value()});  <--- DANGER WILL ROBINSON
    return;
  }
```
At this point `leaf.get_value()` is `main_loop::$tmp::return_value___CPROVER_Ada_Range_Check__Range_Check_signedbv_64_signedbv_32$2` and `ip->get_value()` is `standard__boolean_true`. Obviously these values are not the same, so the if guard `equalT()(leaf.get_key(), ip->get_key())` has failed, and so we're clearly adding something into the `delta_view` with only one value.

But why?

I suspect oversight. 

The function is declared as 
```
SHARING_MAPT(void)::add_item_if_not_shared(
  const nodet &leaf,
  const nodet &inner,
  const std::size_t level,
  delta_viewt &delta_view,
  const bool only_common) const
```
`only_common` is flag that's passed around indicates if the returned delta view should only contain key-value pairs for keys that exist in both map. In this case, it is true.

Elsewhere in the code we see this kind of pattern repeated several times. 
```
  if(equalT()(ip1->get_key(), ip2->get_key()))
  {
    delta_view.push_back({ip1->get_key(), ip1->get_value(), ip2->get_value()});
  }
  else if(!only_common)
  {
    delta_view.push_back({ip1->get_key(), ip1->get_value()});
  }
```

I believe the case highlighted above should also be guarded with `!only_common`.

Making that change means our example runs to completion. 
