### PR TITLE
Ensure result of to_predicates is deterministic

### DIFF
--- a/src/analyses/variable-sensitivity/abstract_environment.cpp
+++ b/src/analyses/variable-sensitivity/abstract_environment.cpp
@@ -9,9 +9,11 @@
 #include <analyses/variable-sensitivity/abstract_environment.h>
 #include <analyses/variable-sensitivity/abstract_object_statistics.h>
 #include <analyses/variable-sensitivity/variable_sensitivity_object_factory.h>
+
 #include <util/expr_util.h>
 #include <util/simplify_expr.h>
 #include <util/simplify_expr_class.h>
+#include <util/simplify_utils.h>
 
 #include <algorithm>
 #include <map>
@@ -427,7 +429,7 @@ exprt abstract_environmentt::to_predicate() const
   if(is_top())
     return true_exprt();
 
-  auto predicates = std::vector<exprt>{};
+  exprt::operandst predicates;
   for(const auto &entry : map.get_view())
   {
     auto sym = entry.first;
@@ -439,6 +441,8 @@ exprt abstract_environmentt::to_predicate() const
 
   if(predicates.size() == 1)
     return predicates.front();
+
+  sort_operands(predicates);
   return and_exprt(predicates);
 }
 

--- a/unit/analyses/variable-sensitivity/abstract_environment/to_predicate.cpp
+++ b/unit/analyses/variable-sensitivity/abstract_environment/to_predicate.cpp
@@ -67,7 +67,7 @@ SCENARIO(
       env.assign(x_name, val2, ns);
       env.assign(y_name, val3, ns);
 
-      THEN_PREDICATE(env, "y == 3 && x == 2");
+      THEN_PREDICATE(env, "x == 2 && y == 3");
     }
   }
 }


### PR DESCRIPTION
The order of entries in an unordered map would previously yield varying
results. This caused spurious unit test failures as unit tests perform
exact string matching on the output.

See https://github.com/diffblue/cbmc/pull/5740/checks?check_run_id=3321470809 for an example of a spuriously failing run.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
