### PR TITLE
SMT-LIB2: parse FloatX sorts

### DIFF
--- a/regression/smt2_solver/fp/basic-fp3.desc
+++ b/regression/smt2_solver/fp/basic-fp3.desc
@@ -1,0 +1,10 @@
+CORE
+basic-fp3.smt2
+
+^EXIT=0$
+^SIGNAL=0$
+\(define-fun a \(\) \(_ FloatingPoint 5 11\) .*\)
+\(define-fun b \(\) \(_ FloatingPoint 8 24\) .*\)
+\(define-fun c \(\) \(_ FloatingPoint 11 53\) .*\)
+\(define-fun d \(\) \(_ FloatingPoint 15 113\) .*\)
+--

--- a/regression/smt2_solver/fp/basic-fp3.smt2
+++ b/regression/smt2_solver/fp/basic-fp3.smt2
@@ -1,0 +1,9 @@
+(set-logic FP)
+
+(declare-fun a () Float16)
+(declare-fun b () Float32)
+(declare-fun c () Float64)
+(declare-fun d () Float128)
+
+(check-sat)
+(get-model)

--- a/src/solvers/smt2/smt2_parser.cpp
+++ b/src/solvers/smt2/smt2_parser.cpp
@@ -1395,6 +1395,19 @@ void smt2_parsert::setup_sorts()
   sorts["Int"] = [] { return integer_typet(); };
   sorts["Real"] = [] { return real_typet(); };
 
+  sorts["Float16"] = [] {
+    return ieee_float_spect::half_precision().to_type();
+  };
+  sorts["Float32"] = [] {
+    return ieee_float_spect::single_precision().to_type();
+  };
+  sorts["Float64"] = [] {
+    return ieee_float_spect::double_precision().to_type();
+  };
+  sorts["Float128"] = [] {
+    return ieee_float_spect::quadruple_precision().to_type();
+  };
+
   sorts["BitVec"] = [this] {
     if(next_token() != smt2_tokenizert::NUMERAL)
       throw error("expected numeral as bit-width");


### PR DESCRIPTION
This adds parsing for the FloatX sorts to the SMT-LIB2 parser.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [X] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
