### PR TITLE
remove an include from goto-programs/goto_program.h

### DIFF
--- a/jbmc/src/java_bytecode/java_local_variable_table.cpp
+++ b/jbmc/src/java_bytecode/java_local_variable_table.cpp
@@ -16,6 +16,7 @@ Author: Chris Smowton, chris.smowton@diffblue.com
 #include <util/arith_tools.h>
 #include <util/invariant.h>
 #include <util/string2int.h>
+#include <util/symbol_table.h>
 
 #include <iostream>
 

--- a/jbmc/unit/java-testing-utils/require_goto_statements.cpp
+++ b/jbmc/unit/java-testing-utils/require_goto_statements.cpp
@@ -18,6 +18,7 @@ Author: Diffblue Ltd.
 #include <util/expr_util.h>
 #include <util/pointer_expr.h>
 #include <util/suffix.h>
+#include <util/symbol_table.h>
 
 /// Expand value of a function to include all child codets
 /// \param function_value: The value of the function (e.g. got by looking up

--- a/jbmc/unit/java_bytecode/java_trace_validation/java_trace_validation.cpp
+++ b/jbmc/unit/java_bytecode/java_trace_validation/java_trace_validation.cpp
@@ -16,6 +16,7 @@ Author: Diffblue Ltd.
 
 #include <util/byte_operators.h>
 #include <util/pointer_expr.h>
+#include <util/symbol_table.h>
 
 TEST_CASE("java trace validation", "[core][java_trace_validation]")
 {

--- a/src/analyses/local_bitvector_analysis.cpp
+++ b/src/analyses/local_bitvector_analysis.cpp
@@ -15,6 +15,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <util/pointer_expr.h>
 #include <util/std_code.h>
+#include <util/symbol_table.h>
 
 void local_bitvector_analysist::flagst::print(std::ostream &out) const
 {

--- a/src/analyses/local_cfg.h
+++ b/src/analyses/local_cfg.h
@@ -14,6 +14,8 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <goto-programs/goto_program.h>
 
+#include <map>
+
 class local_cfgt
 {
 public:

--- a/src/analyses/local_safe_pointers.cpp
+++ b/src/analyses/local_safe_pointers.cpp
@@ -14,6 +14,7 @@ Author: Diffblue Ltd
 #include <util/expr_iterator.h>
 #include <util/expr_util.h>
 #include <util/format_expr.h>
+#include <util/symbol_table.h>
 
 /// Return structure for `get_null_checked_expr` and
 /// `get_conditional_checked_expr`

--- a/src/analyses/local_safe_pointers.h
+++ b/src/analyses/local_safe_pointers.h
@@ -16,6 +16,8 @@ Author: Diffblue Ltd
 
 #include <util/pointer_expr.h>
 
+#include <map>
+
 /// A very simple, cheap analysis to determine when dereference operations are
 /// trivially guarded by a check against a null pointer access.
 /// In the interests of a very cheap analysis we only search for very local

--- a/src/analyses/uncaught_exceptions_analysis.cpp
+++ b/src/analyses/uncaught_exceptions_analysis.cpp
@@ -15,6 +15,7 @@ Author: Cristina David
 #include "uncaught_exceptions_analysis.h"
 
 #include <util/namespace.h>
+#include <util/symbol_table.h>
 
 #include <goto-programs/goto_functions.h>
 

--- a/src/analyses/variable-sensitivity/abstract_environment.cpp
+++ b/src/analyses/variable-sensitivity/abstract_environment.cpp
@@ -14,6 +14,7 @@
 #include <util/simplify_expr.h>
 #include <util/simplify_expr_class.h>
 #include <util/simplify_utils.h>
+#include <util/symbol_table.h>
 
 #include <algorithm>
 #include <map>

--- a/src/analyses/variable-sensitivity/variable_sensitivity_domain.cpp
+++ b/src/analyses/variable-sensitivity/variable_sensitivity_domain.cpp
@@ -11,6 +11,7 @@ Date: April 2016
 #include "variable_sensitivity_domain.h"
 
 #include <util/cprover_prefix.h>
+#include <util/symbol_table.h>
 
 #include <algorithm>
 

--- a/src/cbmc/c_test_input_generator.cpp
+++ b/src/cbmc/c_test_input_generator.cpp
@@ -19,6 +19,7 @@ Author: Daniel Kroening, Peter Schrammel
 #include <util/json_stream.h>
 #include <util/options.h>
 #include <util/string_utils.h>
+#include <util/symbol.h>
 #include <util/ui_message.h>
 #include <util/xml.h>
 

--- a/src/goto-checker/symex_coverage.cpp
+++ b/src/goto-checker/symex_coverage.cpp
@@ -19,6 +19,7 @@ Date: March 2016
 #include <iostream>
 
 #include <util/string2int.h>
+#include <util/symbol.h>
 #include <util/xml.h>
 
 #include <langapi/language_util.h>

--- a/src/goto-instrument/cover_filter.cpp
+++ b/src/goto-instrument/cover_filter.cpp
@@ -12,6 +12,7 @@ Author: Peter Schrammel
 #include "cover_filter.h"
 
 #include <util/prefix.h>
+#include <util/symbol.h>
 
 #include <linking/static_lifetime_init.h>
 

--- a/src/goto-instrument/cover_instrument.h
+++ b/src/goto-instrument/cover_instrument.h
@@ -14,6 +14,8 @@ Author: Peter Schrammel
 
 #include <memory>
 
+#include <util/symbol_table.h>
+
 #include <goto-programs/goto_program.h>
 
 enum class coverage_criteriont;

--- a/src/goto-instrument/function_modifies.h
+++ b/src/goto-instrument/function_modifies.h
@@ -14,6 +14,8 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <goto-programs/goto_program.h>
 
+#include <map>
+
 class goto_functionst;
 class local_may_aliast;
 

--- a/src/goto-instrument/splice_call.cpp
+++ b/src/goto-instrument/splice_call.cpp
@@ -17,6 +17,7 @@ Date: July 2017
 
 #include <util/message.h>
 #include <util/string_utils.h>
+#include <util/symbol_table.h>
 
 #include <goto-programs/goto_functions.h>
 

--- a/src/goto-instrument/wmm/fence.cpp
+++ b/src/goto-instrument/wmm/fence.cpp
@@ -14,6 +14,7 @@ Date: February 2012
 #include "fence.h"
 
 #include <util/namespace.h>
+#include <util/symbol.h>
 
 bool is_fence(
   const goto_programt::instructiont &instruction,

--- a/src/goto-instrument/wmm/shared_buffers.h
+++ b/src/goto-instrument/wmm/shared_buffers.h
@@ -14,9 +14,10 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <set>
 
 #include <goto-programs/goto_program.h>
-#include <util/namespace.h>
 #include <util/cprover_prefix.h>
+#include <util/namespace.h>
 #include <util/prefix.h>
+#include <util/symbol_table.h>
 
 #include "wmm.h"
 

--- a/src/goto-programs/builtin_functions.cpp
+++ b/src/goto-programs/builtin_functions.cpp
@@ -22,6 +22,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/prefix.h>
 #include <util/rational.h>
 #include <util/rational_tools.h>
+#include <util/symbol_table.h>
 
 #include <langapi/language_util.h>
 

--- a/src/goto-programs/goto_clean_expr.cpp
+++ b/src/goto-programs/goto_clean_expr.cpp
@@ -15,6 +15,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/fresh_symbol.h>
 #include <util/pointer_expr.h>
 #include <util/std_expr.h>
+#include <util/symbol.h>
 
 symbol_exprt goto_convertt::make_compound_literal(
   const exprt &expr,

--- a/src/goto-programs/goto_convert_exceptions.cpp
+++ b/src/goto-programs/goto_convert_exceptions.cpp
@@ -12,6 +12,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "goto_convert_class.h"
 
 #include <util/std_expr.h>
+#include <util/symbol_table.h>
 
 void goto_convertt::convert_msc_try_finally(
   const codet &code,

--- a/src/goto-programs/goto_function.cpp
+++ b/src/goto-programs/goto_function.cpp
@@ -13,6 +13,8 @@ Date: May 2018
 
 #include "goto_function.h"
 
+#include <util/symbol.h>
+
 /// Return in \p dest the identifiers of the local variables declared in the \p
 /// goto_function and the identifiers of the paramters of the \p goto_function.
 void get_local_identifiers(

--- a/src/goto-programs/goto_functions.cpp
+++ b/src/goto-programs/goto_functions.cpp
@@ -13,6 +13,8 @@ Date: June 2003
 
 #include "goto_functions.h"
 
+#include <util/symbol.h>
+
 #include <algorithm>
 
 void goto_functionst::compute_location_numbers()

--- a/src/goto-programs/goto_functions.h
+++ b/src/goto-programs/goto_functions.h
@@ -18,6 +18,8 @@ Date: June 2003
 
 #include <util/cprover_prefix.h>
 
+#include <map>
+
 /// A collection of goto functions
 class goto_functionst
 {

--- a/src/goto-programs/goto_inline_class.cpp
+++ b/src/goto-programs/goto_inline_class.cpp
@@ -18,6 +18,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/cprover_prefix.h>
 #include <util/invariant.h>
 #include <util/std_code.h>
+#include <util/symbol.h>
 
 void goto_inlinet::parameter_assignments(
   const goto_programt::targett target,

--- a/src/goto-programs/goto_program.cpp
+++ b/src/goto-programs/goto_program.cpp
@@ -21,9 +21,15 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/invariant.h>
 #include <util/pointer_expr.h>
 #include <util/std_expr.h>
+#include <util/symbol_table.h>
 #include <util/validate.h>
 
 #include <langapi/language_util.h>
+
+std::ostream &goto_programt::output(std::ostream &out) const
+{
+  return output(namespacet(symbol_tablet()), irep_idt(), out);
+}
 
 /// Writes to \p out a two/three line string representation of a given
 /// \p instruction. The output is of the format:

--- a/src/goto-programs/goto_program.h
+++ b/src/goto-programs/goto_program.h
@@ -22,7 +22,6 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/namespace.h>
 #include <util/source_location.h>
 #include <util/std_code.h>
-#include <util/symbol_table.h>
 
 enum class validation_modet;
 
@@ -776,11 +775,8 @@ public:
     const irep_idt &identifier,
     std::ostream &out) const;
 
-  /// Output goto-program to given stream
-  std::ostream &output(std::ostream &out) const
-  {
-    return output(namespacet(symbol_tablet()), irep_idt(), out);
-  }
+  /// Output goto-program to given stream, using an empty symbol table
+  std::ostream &output(std::ostream &out) const;
 
   /// Output a single instruction
   std::ostream &output_instruction(

--- a/src/goto-programs/graphml_witness.cpp
+++ b/src/goto-programs/graphml_witness.cpp
@@ -19,6 +19,7 @@ Author: Daniel Kroening
 #include <util/prefix.h>
 #include <util/ssa_expr.h>
 #include <util/string_constant.h>
+#include <util/symbol_table.h>
 
 #include <langapi/language_util.h>
 #include <langapi/mode.h>

--- a/src/goto-programs/interpreter_class.h
+++ b/src/goto-programs/interpreter_class.h
@@ -16,9 +16,10 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <util/arith_tools.h>
 #include <util/invariant.h>
-#include <util/std_types.h>
-#include <util/sparse_vector.h>
 #include <util/message.h>
+#include <util/sparse_vector.h>
+#include <util/std_types.h>
+#include <util/symbol_table.h>
 
 #include "goto_functions.h"
 #include "goto_trace.h"

--- a/src/goto-programs/json_goto_trace.cpp
+++ b/src/goto-programs/json_goto_trace.cpp
@@ -15,6 +15,7 @@ Author: Daniel Kroening
 
 #include <util/invariant.h>
 #include <util/simplify_expr.h>
+#include <util/symbol.h>
 
 #include <langapi/language_util.h>
 

--- a/src/goto-programs/rebuild_goto_start_function.cpp
+++ b/src/goto-programs/rebuild_goto_start_function.cpp
@@ -12,7 +12,7 @@ Author: Thomas Kiley, thomas@diffblue.com
 #include "rebuild_goto_start_function.h"
 
 #include <util/prefix.h>
-#include <util/symbol.h>
+#include <util/symbol_table.h>
 
 #include <langapi/mode.h>
 #include <langapi/language.h>

--- a/src/goto-programs/remove_virtual_functions.cpp
+++ b/src/goto-programs/remove_virtual_functions.cpp
@@ -16,6 +16,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/expr_util.h>
 #include <util/fresh_symbol.h>
 #include <util/prefix.h>
+#include <util/symbol_table.h>
 
 #include "class_hierarchy.h"
 #include "class_identifier.h"

--- a/src/goto-programs/remove_virtual_functions.h
+++ b/src/goto-programs/remove_virtual_functions.h
@@ -20,10 +20,13 @@ Date: April 2016
 
 #include "goto_program.h"
 
+#include <map>
+
 class class_hierarchyt;
 class goto_functionst;
 class goto_model_functiont;
 class goto_modelt;
+class symbol_tablet;
 class symbol_table_baset;
 
 // For all of the following the class-hierarchy and non-class-hierarchy

--- a/src/goto-programs/string_abstraction.h
+++ b/src/goto-programs/string_abstraction.h
@@ -20,6 +20,8 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "goto_function.h"
 
+#include <map>
+
 class goto_functionst;
 class goto_modelt;
 class message_handlert;

--- a/src/goto-symex/build_goto_trace.cpp
+++ b/src/goto-symex/build_goto_trace.cpp
@@ -16,6 +16,7 @@ Author: Daniel Kroening
 #include <util/arith_tools.h>
 #include <util/byte_operators.h>
 #include <util/simplify_expr.h>
+#include <util/symbol.h>
 
 #include <goto-programs/goto_functions.h>
 

--- a/src/jsil/jsil_entry_point.cpp
+++ b/src/jsil/jsil_entry_point.cpp
@@ -15,6 +15,7 @@ Author: Michael Tautschnig, tautschn@amazon.com
 #include <util/config.h>
 #include <util/message.h>
 #include <util/range.h>
+#include <util/symbol_table.h>
 
 #include <goto-programs/adjust_float_expressions.h>
 #include <goto-programs/goto_functions.h>

--- a/src/json-symtab-language/json_symtab_language.h
+++ b/src/json-symtab-language/json_symtab_language.h
@@ -16,8 +16,10 @@ Author: Chris Smowton, chris.smowton@diffblue.com
 
 #include <goto-programs/goto_functions.h>
 #include <langapi/language.h>
+
 #include <util/json.h>
 #include <util/make_unique.h>
+#include <util/symbol_table.h>
 
 class json_symtab_languaget : public languaget
 {

--- a/src/pointer-analysis/value_set.cpp
+++ b/src/pointer-analysis/value_set.cpp
@@ -23,6 +23,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/prefix.h>
 #include <util/range.h>
 #include <util/simplify_expr.h>
+#include <util/symbol_table.h>
 
 #ifdef DEBUG
 #include <iostream>

--- a/src/pointer-analysis/value_set_analysis_fi.cpp
+++ b/src/pointer-analysis/value_set_analysis_fi.cpp
@@ -12,6 +12,8 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "value_set_analysis_fi.h"
 
+#include <util/symbol_table.h>
+
 void value_set_analysis_fit::initialize(
   const goto_programt &goto_program)
 {

--- a/src/pointer-analysis/value_set_dereference.cpp
+++ b/src/pointer-analysis/value_set_dereference.cpp
@@ -30,6 +30,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/pointer_predicates.h>
 #include <util/range.h>
 #include <util/simplify_expr.h>
+#include <util/symbol_table.h>
 
 #include <deque>
 

--- a/src/statement-list/statement_list_entry_point.cpp
+++ b/src/statement-list/statement_list_entry_point.cpp
@@ -21,6 +21,7 @@ Author: Matthias Weiss, matthias.weiss@diffblue.com
 #include <util/message.h>
 #include <util/pointer_expr.h>
 #include <util/std_code.h>
+#include <util/symbol_table.h>
 
 /// Postfix for the artificial data block that is created when calling a main
 /// symbol that is a function block.

--- a/src/statement-list/statement_list_entry_point.h
+++ b/src/statement-list/statement_list_entry_point.h
@@ -12,8 +12,8 @@ Author: Matthias Weiss, matthias.weiss@diffblue.com
 #ifndef CPROVER_STATEMENT_LIST_STATEMENT_LIST_ENTRY_POINT_H
 #define CPROVER_STATEMENT_LIST_STATEMENT_LIST_ENTRY_POINT_H
 
-class symbol_tablet;
 class message_handlert;
+class symbol_tablet;
 
 /// Creates a new entry point for the Statement List language.
 /// \param [out] symbol_table: Symbol table of the current TIA program. Gets

--- a/unit/analyses/ai/ai_simplify_lhs.cpp
+++ b/unit/analyses/ai/ai_simplify_lhs.cpp
@@ -20,8 +20,9 @@ Author: Diffblue Ltd.
 #include <util/c_types.h>
 #include <util/config.h>
 #include <util/namespace.h>
-#include <util/ui_message.h>
 #include <util/simplify_expr.h>
+#include <util/symbol_table.h>
+#include <util/ui_message.h>
 
 class constant_simplification_mockt:public ai_domain_baset
 {

--- a/unit/analyses/does_remove_const/does_expr_lose_const.cpp
+++ b/unit/analyses/does_remove_const/does_expr_lose_const.cpp
@@ -15,6 +15,7 @@ Author: Diffblue Ltd.
 #include <util/mathematical_types.h>
 #include <util/pointer_expr.h>
 #include <util/std_expr.h>
+#include <util/symbol_table.h>
 
 #include <ansi-c/c_qualifiers.h>
 

--- a/unit/analyses/variable-sensitivity/abstract_environment/to_predicate.cpp
+++ b/unit/analyses/variable-sensitivity/abstract_environment/to_predicate.cpp
@@ -8,10 +8,13 @@
 
 #include <analyses/variable-sensitivity/variable_sensitivity_object_factory.h>
 #include <analyses/variable-sensitivity/variable_sensitivity_test_helpers.h>
+
 #include <testing-utils/use_catch.h>
+
 #include <util/arith_tools.h>
 #include <util/bitvector_types.h>
 #include <util/mathematical_types.h>
+#include <util/symbol_table.h>
 
 SCENARIO(
   "abstract_environment to predicate",

--- a/unit/analyses/variable-sensitivity/abstract_object/index_range.cpp
+++ b/unit/analyses/variable-sensitivity/abstract_object/index_range.cpp
@@ -15,6 +15,7 @@
 
 #include <util/arith_tools.h>
 #include <util/bitvector_types.h>
+#include <util/symbol_table.h>
 
 SCENARIO(
   "index_range for constant_abstract_values"

--- a/unit/analyses/variable-sensitivity/abstract_object/merge.cpp
+++ b/unit/analyses/variable-sensitivity/abstract_object/merge.cpp
@@ -15,6 +15,7 @@
 
 #include <util/arith_tools.h>
 #include <util/bitvector_types.h>
+#include <util/symbol_table.h>
 
 SCENARIO(
   "merge abstract object",

--- a/unit/analyses/variable-sensitivity/constant_abstract_value/meet.cpp
+++ b/unit/analyses/variable-sensitivity/constant_abstract_value/meet.cpp
@@ -12,6 +12,7 @@
 
 #include <util/arith_tools.h>
 #include <util/bitvector_types.h>
+#include <util/symbol_table.h>
 
 static std::shared_ptr<const constant_abstract_valuet>
 meet(abstract_object_pointert const &op1, abstract_object_pointert const &op2)

--- a/unit/analyses/variable-sensitivity/constant_abstract_value/merge.cpp
+++ b/unit/analyses/variable-sensitivity/constant_abstract_value/merge.cpp
@@ -12,6 +12,7 @@
 
 #include <util/arith_tools.h>
 #include <util/bitvector_types.h>
+#include <util/symbol_table.h>
 
 static merge_result<const constant_abstract_valuet>
 merge(abstract_object_pointert op1, abstract_object_pointert op2)

--- a/unit/analyses/variable-sensitivity/constant_abstract_value/to_predicate.cpp
+++ b/unit/analyses/variable-sensitivity/constant_abstract_value/to_predicate.cpp
@@ -8,9 +8,12 @@
 
 #include <analyses/variable-sensitivity/variable_sensitivity_object_factory.h>
 #include <analyses/variable-sensitivity/variable_sensitivity_test_helpers.h>
+
 #include <testing-utils/use_catch.h>
+
 #include <util/arith_tools.h>
 #include <util/bitvector_types.h>
+#include <util/symbol_table.h>
 
 SCENARIO(
   "constant_abstract_value to predicate",

--- a/unit/analyses/variable-sensitivity/constant_pointer_abstract_object/to_predicate.cpp
+++ b/unit/analyses/variable-sensitivity/constant_pointer_abstract_object/to_predicate.cpp
@@ -8,10 +8,13 @@
 
 #include <analyses/variable-sensitivity/variable_sensitivity_object_factory.h>
 #include <analyses/variable-sensitivity/variable_sensitivity_test_helpers.h>
+
 #include <testing-utils/use_catch.h>
+
 #include <util/arith_tools.h>
 #include <util/bitvector_types.h>
 #include <util/pointer_expr.h>
+#include <util/symbol_table.h>
 
 SCENARIO(
   "constant_pointer_abstract_object to predicate",

--- a/unit/analyses/variable-sensitivity/eval-member-access.cpp
+++ b/unit/analyses/variable-sensitivity/eval-member-access.cpp
@@ -5,14 +5,17 @@
  Author: Jez Higgins
 
 \*******************************************************************/
+
 #include <testing-utils/use_catch.h>
 
 #include <analyses/variable-sensitivity/abstract_environment.h>
 #include <analyses/variable-sensitivity/abstract_object.h>
 #include <analyses/variable-sensitivity/full_array_abstract_object.h>
 #include <analyses/variable-sensitivity/variable_sensitivity_object_factory.h>
+
 #include <util/arith_tools.h>
 #include <util/mathematical_types.h>
+#include <util/symbol_table.h>
 
 void test_array(
   std::vector<int> contents,

--- a/unit/analyses/variable-sensitivity/eval.cpp
+++ b/unit/analyses/variable-sensitivity/eval.cpp
@@ -7,6 +7,7 @@
 #include <util/arith_tools.h>
 #include <util/bitvector_types.h>
 #include <util/std_expr.h>
+#include <util/symbol_table.h>
 
 static symbolt simple_symbol(const irep_idt &identifier, const typet &type)
 {

--- a/unit/analyses/variable-sensitivity/full_array_abstract_object/maximum_length.cpp
+++ b/unit/analyses/variable-sensitivity/full_array_abstract_object/maximum_length.cpp
@@ -7,12 +7,16 @@
 \*******************************************************************/
 
 #include "array_builder.h"
+
 #include <analyses/variable-sensitivity/variable_sensitivity_object_factory.h>
 #include <analyses/variable-sensitivity/variable_sensitivity_test_helpers.h>
+
 #include <testing-utils/use_catch.h>
+
 #include <util/arith_tools.h>
 #include <util/bitvector_types.h>
 #include <util/mathematical_types.h>
+#include <util/symbol_table.h>
 
 using abstract_object_ptrt = std::shared_ptr<const abstract_objectt>;
 

--- a/unit/analyses/variable-sensitivity/full_array_abstract_object/to_predicate.cpp
+++ b/unit/analyses/variable-sensitivity/full_array_abstract_object/to_predicate.cpp
@@ -11,7 +11,10 @@
 
 #include <analyses/variable-sensitivity/full_array_abstract_object/array_builder.h>
 #include <analyses/variable-sensitivity/variable_sensitivity_test_helpers.h>
+
 #include <testing-utils/use_catch.h>
+
+#include <util/symbol_table.h>
 
 SCENARIO(
   "array to predicate",

--- a/unit/analyses/variable-sensitivity/full_struct_abstract_object/to_predicate.cpp
+++ b/unit/analyses/variable-sensitivity/full_struct_abstract_object/to_predicate.cpp
@@ -16,6 +16,7 @@
 
 #include <util/arith_tools.h>
 #include <util/mathematical_types.h>
+#include <util/symbol_table.h>
 
 SCENARIO(
   "struct to predicate",

--- a/unit/analyses/variable-sensitivity/interval_abstract_value/extremes-go-top.cpp
+++ b/unit/analyses/variable-sensitivity/interval_abstract_value/extremes-go-top.cpp
@@ -13,8 +13,10 @@
 #include <testing-utils/use_catch.h>
 
 #include <analyses/variable-sensitivity/variable_sensitivity_test_helpers.h>
+
 #include <util/arith_tools.h>
 #include <util/bitvector_types.h>
+#include <util/symbol_table.h>
 
 static void
 verify_extreme_interval(typet type, abstract_environmentt &env, namespacet &ns)

--- a/unit/analyses/variable-sensitivity/interval_abstract_value/meet.cpp
+++ b/unit/analyses/variable-sensitivity/interval_abstract_value/meet.cpp
@@ -14,8 +14,10 @@
 #include <analyses/variable-sensitivity/variable_sensitivity_object_factory.h>
 
 #include <analyses/variable-sensitivity/variable_sensitivity_test_helpers.h>
+
 #include <util/arith_tools.h>
 #include <util/bitvector_types.h>
+#include <util/symbol_table.h>
 
 static std::shared_ptr<const interval_abstract_valuet>
 meet(abstract_object_pointert const &op1, abstract_object_pointert const &op2)

--- a/unit/analyses/variable-sensitivity/interval_abstract_value/merge.cpp
+++ b/unit/analyses/variable-sensitivity/interval_abstract_value/merge.cpp
@@ -8,10 +8,12 @@
 
 #include <analyses/variable-sensitivity/variable_sensitivity_object_factory.h>
 #include <analyses/variable-sensitivity/variable_sensitivity_test_helpers.h>
+
 #include <testing-utils/use_catch.h>
 
 #include <util/arith_tools.h>
 #include <util/bitvector_types.h>
+#include <util/symbol_table.h>
 
 static merge_result<const interval_abstract_valuet>
 merge(abstract_object_pointert op1, abstract_object_pointert op2)

--- a/unit/analyses/variable-sensitivity/interval_abstract_value/to_predicate.cpp
+++ b/unit/analyses/variable-sensitivity/interval_abstract_value/to_predicate.cpp
@@ -8,9 +8,12 @@
 
 #include <analyses/variable-sensitivity/variable_sensitivity_object_factory.h>
 #include <analyses/variable-sensitivity/variable_sensitivity_test_helpers.h>
+
 #include <testing-utils/use_catch.h>
+
 #include <util/arith_tools.h>
 #include <util/bitvector_types.h>
+#include <util/symbol_table.h>
 
 SCENARIO(
   "interval_abstract_value to predicate",

--- a/unit/analyses/variable-sensitivity/interval_abstract_value/widening_merge.cpp
+++ b/unit/analyses/variable-sensitivity/interval_abstract_value/widening_merge.cpp
@@ -12,6 +12,7 @@
 
 #include <util/arith_tools.h>
 #include <util/bitvector_types.h>
+#include <util/symbol_table.h>
 
 static merge_result<const interval_abstract_valuet> widening_merge(
   const abstract_object_pointert &op1,

--- a/unit/analyses/variable-sensitivity/value_expression_evaluation/assume.cpp
+++ b/unit/analyses/variable-sensitivity/value_expression_evaluation/assume.cpp
@@ -8,10 +8,12 @@
 
 #include <analyses/variable-sensitivity/variable_sensitivity_object_factory.h>
 #include <analyses/variable-sensitivity/variable_sensitivity_test_helpers.h>
+
 #include <testing-utils/use_catch.h>
 
 #include <util/arith_tools.h>
 #include <util/bitvector_types.h>
+#include <util/symbol_table.h>
 
 exprt binary_expression(
   dstringt const &exprId,

--- a/unit/analyses/variable-sensitivity/value_expression_evaluation/assume_prune.cpp
+++ b/unit/analyses/variable-sensitivity/value_expression_evaluation/assume_prune.cpp
@@ -12,6 +12,7 @@
 
 #include <util/arith_tools.h>
 #include <util/bitvector_types.h>
+#include <util/symbol_table.h>
 
 static void ASSUME_TRUE(
   symbol_exprt const &x,

--- a/unit/analyses/variable-sensitivity/value_expression_evaluation/expression_evaluation.cpp
+++ b/unit/analyses/variable-sensitivity/value_expression_evaluation/expression_evaluation.cpp
@@ -8,10 +8,12 @@
 
 #include <analyses/variable-sensitivity/variable_sensitivity_object_factory.h>
 #include <analyses/variable-sensitivity/variable_sensitivity_test_helpers.h>
+
 #include <testing-utils/use_catch.h>
 
 #include <util/arith_tools.h>
 #include <util/bitvector_types.h>
+#include <util/symbol_table.h>
 
 SCENARIO(
   "value expression evaluation",

--- a/unit/analyses/variable-sensitivity/value_set_abstract_object/compacting.cpp
+++ b/unit/analyses/variable-sensitivity/value_set_abstract_object/compacting.cpp
@@ -19,6 +19,7 @@
 #include <util/arith_tools.h>
 #include <util/bitvector_types.h>
 #include <util/mathematical_types.h>
+#include <util/symbol_table.h>
 
 SCENARIO(
   "compacting value sets",

--- a/unit/analyses/variable-sensitivity/value_set_abstract_object/extremes-go-top.cpp
+++ b/unit/analyses/variable-sensitivity/value_set_abstract_object/extremes-go-top.cpp
@@ -10,11 +10,13 @@
 #include <analyses/variable-sensitivity/abstract_object.h>
 #include <analyses/variable-sensitivity/interval_abstract_value.h>
 #include <analyses/variable-sensitivity/variable_sensitivity_object_factory.h>
+#include <analyses/variable-sensitivity/variable_sensitivity_test_helpers.h>
+
 #include <testing-utils/use_catch.h>
 
-#include <analyses/variable-sensitivity/variable_sensitivity_test_helpers.h>
 #include <util/arith_tools.h>
 #include <util/bitvector_types.h>
+#include <util/symbol_table.h>
 
 SCENARIO(
   "value-sets spanning min-max go TOP",

--- a/unit/analyses/variable-sensitivity/value_set_abstract_object/meet.cpp
+++ b/unit/analyses/variable-sensitivity/value_set_abstract_object/meet.cpp
@@ -14,8 +14,10 @@
 #include <analyses/variable-sensitivity/variable_sensitivity_object_factory.h>
 
 #include <analyses/variable-sensitivity/variable_sensitivity_test_helpers.h>
+
 #include <util/arith_tools.h>
 #include <util/bitvector_types.h>
+#include <util/symbol_table.h>
 
 static std::shared_ptr<const value_set_abstract_objectt>
 meet(abstract_object_pointert const &op1, abstract_object_pointert const &op2)

--- a/unit/analyses/variable-sensitivity/value_set_abstract_object/merge.cpp
+++ b/unit/analyses/variable-sensitivity/value_set_abstract_object/merge.cpp
@@ -14,6 +14,7 @@
 
 #include <util/arith_tools.h>
 #include <util/bitvector_types.h>
+#include <util/symbol_table.h>
 
 static merge_result<const value_set_abstract_objectt>
 merge(abstract_object_pointert op1, abstract_object_pointert op2)

--- a/unit/analyses/variable-sensitivity/value_set_abstract_object/to_predicate.cpp
+++ b/unit/analyses/variable-sensitivity/value_set_abstract_object/to_predicate.cpp
@@ -8,9 +8,12 @@
 
 #include <analyses/variable-sensitivity/variable_sensitivity_object_factory.h>
 #include <analyses/variable-sensitivity/variable_sensitivity_test_helpers.h>
+
 #include <testing-utils/use_catch.h>
+
 #include <util/arith_tools.h>
 #include <util/bitvector_types.h>
+#include <util/symbol_table.h>
 
 SCENARIO(
   "value_set_abstract_object to predicate",

--- a/unit/analyses/variable-sensitivity/value_set_abstract_object/widening_merge.cpp
+++ b/unit/analyses/variable-sensitivity/value_set_abstract_object/widening_merge.cpp
@@ -12,6 +12,7 @@
 
 #include <util/arith_tools.h>
 #include <util/bitvector_types.h>
+#include <util/symbol_table.h>
 
 static merge_result<const value_set_abstract_objectt>
 widening_merge(abstract_object_pointert op1, abstract_object_pointert op2)

--- a/unit/analyses/variable-sensitivity/value_set_pointer_abstract_object/to_predicate.cpp
+++ b/unit/analyses/variable-sensitivity/value_set_pointer_abstract_object/to_predicate.cpp
@@ -9,10 +9,13 @@
 #include <analyses/variable-sensitivity/value_set_pointer_abstract_object.h>
 #include <analyses/variable-sensitivity/variable_sensitivity_object_factory.h>
 #include <analyses/variable-sensitivity/variable_sensitivity_test_helpers.h>
+
 #include <testing-utils/use_catch.h>
+
 #include <util/arith_tools.h>
 #include <util/bitvector_types.h>
 #include <util/pointer_expr.h>
+#include <util/symbol_table.h>
 
 template <typename... Args>
 std::shared_ptr<value_set_pointer_abstract_objectt> make_vsp(Args &&... args)

--- a/unit/analyses/variable-sensitivity/variable_sensitivity_domain/to_predicate.cpp
+++ b/unit/analyses/variable-sensitivity/variable_sensitivity_domain/to_predicate.cpp
@@ -9,10 +9,13 @@
 #include <analyses/variable-sensitivity/variable_sensitivity_domain.h>
 #include <analyses/variable-sensitivity/variable_sensitivity_object_factory.h>
 #include <analyses/variable-sensitivity/variable_sensitivity_test_helpers.h>
+
 #include <testing-utils/use_catch.h>
+
 #include <util/arith_tools.h>
 #include <util/bitvector_types.h>
 #include <util/mathematical_types.h>
+#include <util/symbol_table.h>
 
 SCENARIO(
   "variable_sensitivity_domain to predicate",

--- a/unit/analyses/variable-sensitivity/variable_sensitivity_test_helpers.cpp
+++ b/unit/analyses/variable-sensitivity/variable_sensitivity_test_helpers.cpp
@@ -22,6 +22,7 @@
 #include <util/bitvector_types.h>
 #include <util/mathematical_types.h>
 #include <util/string_utils.h>
+#include <util/symbol_table.h>
 
 std::shared_ptr<const constant_abstract_valuet>
 make_constant(exprt val, abstract_environmentt &env, namespacet &ns)

--- a/unit/goto-programs/goto_program_assume.cpp
+++ b/unit/goto-programs/goto_program_assume.cpp
@@ -10,6 +10,7 @@ Author: Diffblue Ltd.
 
 #include <util/arith_tools.h>
 #include <util/bitvector_types.h>
+#include <util/symbol_table.h>
 
 #include <goto-programs/goto_function.h>
 

--- a/unit/goto-programs/goto_program_dead.cpp
+++ b/unit/goto-programs/goto_program_dead.cpp
@@ -9,6 +9,7 @@ Author: Diffblue Ltd.
 #include <testing-utils/use_catch.h>
 
 #include <util/bitvector_types.h>
+#include <util/symbol_table.h>
 
 #include <goto-programs/goto_function.h>
 

--- a/unit/goto-programs/goto_program_declaration.cpp
+++ b/unit/goto-programs/goto_program_declaration.cpp
@@ -9,6 +9,7 @@ Author: Diffblue Ltd.
 #include <testing-utils/use_catch.h>
 
 #include <util/bitvector_types.h>
+#include <util/symbol_table.h>
 
 #include <goto-programs/goto_function.h>
 

--- a/unit/goto-programs/goto_program_function_call.cpp
+++ b/unit/goto-programs/goto_program_function_call.cpp
@@ -9,6 +9,7 @@ Author: Diffblue Ltd.
 #include <testing-utils/use_catch.h>
 
 #include <util/bitvector_types.h>
+#include <util/symbol_table.h>
 
 #include <goto-programs/goto_function.h>
 

--- a/unit/goto-programs/goto_program_goto_target.cpp
+++ b/unit/goto-programs/goto_program_goto_target.cpp
@@ -10,6 +10,7 @@ Author: Diffblue Ltd.
 
 #include <util/arith_tools.h>
 #include <util/bitvector_types.h>
+#include <util/symbol_table.h>
 
 #include <goto-programs/goto_function.h>
 

--- a/unit/goto-programs/goto_program_symbol_type_table_consistency.cpp
+++ b/unit/goto-programs/goto_program_symbol_type_table_consistency.cpp
@@ -10,6 +10,7 @@ Author: Diffblue Ltd.
 
 #include <util/arith_tools.h>
 #include <util/bitvector_types.h>
+#include <util/symbol_table.h>
 
 #include <goto-programs/goto_function.h>
 

--- a/unit/goto-programs/goto_program_table_consistency.cpp
+++ b/unit/goto-programs/goto_program_table_consistency.cpp
@@ -10,6 +10,7 @@ Author: Diffblue Ltd.
 
 #include <util/arith_tools.h>
 #include <util/bitvector_types.h>
+#include <util/symbol_table.h>
 
 #include <goto-programs/goto_function.h>
 

--- a/unit/goto-programs/goto_trace_output.cpp
+++ b/unit/goto-programs/goto_trace_output.cpp
@@ -8,8 +8,12 @@ Author: Diffblue Ltd.
 
 #include <goto-programs/goto_program.h>
 #include <goto-programs/goto_trace.h>
+
 #include <sstream>
+
 #include <testing-utils/use_catch.h>
+
+#include <util/symbol_table.h>
 
 SCENARIO(
   "Output trace with nil lhs object",

--- a/unit/goto-symex/ssa_equation.cpp
+++ b/unit/goto-symex/ssa_equation.cpp
@@ -10,6 +10,7 @@ Author: Diffblue Ltd.
 #include <testing-utils/use_catch.h>
 
 #include <util/bitvector_types.h>
+#include <util/symbol_table.h>
 
 #include <goto-symex/symex_target_equation.h>
 

--- a/unit/pointer-analysis/value_set.cpp
+++ b/unit/pointer-analysis/value_set.cpp
@@ -15,6 +15,7 @@ Author: Diffblue Ltd.
 
 #include <util/arith_tools.h>
 #include <util/pointer_expr.h>
+#include <util/symbol_table.h>
 
 static bool object_descriptor_matches(
   const exprt &descriptor_expr, const exprt &target)


### PR DESCRIPTION
This removes an unneeded include from goto-programs/goto_program.h, which is
widely used.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- n/a Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- n/a My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
