### PR TITLE
Initial documentation for loop contracts

### DIFF
--- a/doc/cprover-manual/contracts-assigns.md
+++ b/doc/cprover-manual/contracts-assigns.md
@@ -1,5 +1,7 @@
 # Assigns Clause
 
+## In Function Contracts
+
 ### Syntax
 
 ```c
@@ -174,3 +176,7 @@ int foo()
   return rval;
 }
 ```
+
+## In Loop Contracts
+
+TODO: Document `__CPROVER_assigns` for loops.

--- a/doc/cprover-manual/contracts-decreases.md
+++ b/doc/cprover-manual/contracts-decreases.md
@@ -1,0 +1,3 @@
+# Decreases Clause
+
+TODO: Document `__CPROVER_decreases`

--- a/doc/cprover-manual/contracts-functions.md
+++ b/doc/cprover-manual/contracts-functions.md
@@ -2,16 +2,9 @@
 
 CBMC offers support for function contracts, which includes three basic clauses:
 _requires_, _ensures_, and _assigns_.
-These clauses formally describe the specification of a function. CBMC
-also provides a series of built-in constructs to be used with functions
+These clauses formally describe the specification of a function.
+CBMC also provides a series of built-in constructs to be used with functions
 contracts (e.g., _history variables_, _quantifiers_, and _memory predicates_).
-
-To learn more about contracts, take a look at the chapter [Design by
-Contract](http://se.inf.ethz.ch/~meyer/publications/old/dbc_chapter.pdf) from
-the book Object-Oriented Software Construction by Bertrand Meyer or read the
-notes [Contract-based
-Design](https://www.georgefairbanks.com/york-university-contract-based-design-2021)
-by George Fairbanks.
 
 ## Overview
 
@@ -157,4 +150,3 @@ program using contracts.
 - [Memory Predicates](contracts-memory-predicates.md)
 - [History Variables](contracts-history-variables.md)
 - [Quantifiers](contracts-quantifiers.md)
-- [Loop Contracts]()

--- a/doc/cprover-manual/contracts-functions.md
+++ b/doc/cprover-manual/contracts-functions.md
@@ -75,7 +75,7 @@ example, developers can use the built-in construct `__CPROVER_return_value`,
 which represents the return value of a function. As postconditions, one may list
 possible return values (in this case, either `SUCCESS` or `FAILURE`) as well as
 describe the main property of this function: if the function returns `SUCCESS`,
-then `*out` stores the result of `*a + *b`.  We can also check that the value in
+then `*out` stores the result of `a + b`.  We can also check that the value in
 `*out` will be preserved in case of failure by using `__CPROVER_old`, which
 refers to the value of a given object in the pre-state of a function (see
 [History Variables](contracts-history-variables.md) Section for details). Thus, for the `sum` function, the

--- a/doc/cprover-manual/contracts-history-variables.md
+++ b/doc/cprover-manual/contracts-history-variables.md
@@ -1,5 +1,7 @@
 # History Variables
 
+## In Function Contracts
+
 ### Syntax
 
 ```c
@@ -33,3 +35,7 @@ __CPROVER_assigns(*out)
   /* ... */
 }
 ```
+
+## In Loop Contracts
+
+TODO: Document `__CPROVER_loop_entry` and `__CPROVER_loop_old`.

--- a/doc/cprover-manual/contracts-invariant.md
+++ b/doc/cprover-manual/contracts-invariant.md
@@ -1,0 +1,152 @@
+# Invariant Clause
+
+An _invariant_ clause specifies a property that must be preserved
+by every iteration of a loop.
+In general a loop has infinitely many invariants.
+For instance, `true` is a trivial invariant that holds before the loop,
+and after each iteration of the loop (thus, inductive).
+However, `true` is rarely useful --
+it is an extremely imprecise abstraction of a loop,
+which is generally not _sufficient_ to prove any subsequent assertions.
+
+### Syntax
+
+An _invariant_ clause accepts a valid Boolean expression
+over the variables visible at the same scope as the loop.
+Additionally, [history variables] are also allowed within invariant clauses.
+
+```c
+__CPROVER_loop_invariant(bool cond)
+```
+
+Invariant clauses may be specified just after the loop guard.
+Multiple invariant clauses on the same loop are allowed,
+and is equivalent to a single invariant clause that is a conjunction of those clauses.
+A few examples are shown below.
+
+```c
+while(i < n)
+__CPROVER_loop_invariant(0 <= i && i <= n)
+{ ... }
+```
+
+```c
+for(int i = 0; i < n; ++i)
+__CPROVER_loop_invariant(0 <= i)
+__CPROVER_loop_invariant(i <= n)
+{ ... }
+```
+
+```c
+do { ... }
+while (i < n)
+__CPROVER_loop_invariant(0 <= i)
+__CPROVER_loop_invariant(i <= n);
+```
+
+**Important.** Invariant clauses must be free of _side effects_,
+for example, mutation of local or global variables.
+
+
+### Semantics
+
+The loop invariant clause expands to several assumptions and assertions:
+1. The invariant is _asserted_ just before the first iteration.
+2. The invariant is _assumed_ on a non-deterministic state to model a non-deterministic iteration.
+3. The invariant is finally _asserted_ again to establish its inductiveness.
+
+Mathematical induction is the working principle here.
+(1) establishes the base case for induction, and
+(2) & (3) establish the inductive case.
+Therefore, the invariant must hold _after_ the loop execution for _any_ number of iterations.
+The invariant, together with the negation of the loop guard,
+must be sufficient to establish subsequent assertions.
+If it is not, the abstraction is too imprecise and the user must supply a stronger invariant.
+
+To illustrate the key idea,
+consider the following [binary search] loop with invariant clauses:
+
+```c
+int binary_search(int val, int *buf, int size)
+{
+  if(size <= 0 || buf == NULL) return NOT_FOUND;
+
+  long lb = 0, ub = size - 1;
+  long mid = (lb + ub) / 2;
+
+  while(lb <= ub)
+  __CPROVER_loop_invariant(0L <= lb && lb - 1L <= ub && ub < size)
+  __CPROVER_loop_invariant(mid == (lb + ub) / 2L)
+  __CPROVER_decreases(ub - lb)
+  {
+     if(buf[mid] == val) break;
+     if(buf[mid] < val)
+       lb = mid + 1;
+     else
+       ub = mid - 1;
+     mid = (lb + ub) / 2;
+  }
+  return lb > ub ? NOT_FOUND : mid;
+}
+```
+
+The instrumented GOTO program is conceptually similar to the following high-level C program:
+
+```c
+int binary_search(int val, int *buf, int size)
+{
+  if(size <= 0 || buf == NULL) return NOT_FOUND;
+
+  long lb = 0, ub = size - 1;
+  long mid = (lb + ub) / 2;
+
+  /* 1. assert invariant at loop entry */
+  assert(0L <= lb && lb - 1L <= ub && ub < size);
+  assert(mid == (lb + ub) / 2L);
+
+  /* 2. create a non-deterministic state for modified variables */
+  havoc(lb, ub, mid);
+
+  /* 3. establish invariant to model state at an arbitrary iteration */
+  __CPROVER_assume(0L <= lb && lb - 1L <= ub && ub < size)
+  __CPROVER_assume(mid == (lb + ub) / 2L)
+
+  /* 4. perform a single arbitrary iteration (or exit the loop) */
+  if(lb <= ub)
+  {
+    if(buf[mid] == val) break;
+    if(buf[mid] < val)
+      lb = mid + 1;
+    else
+      ub = mid - 1;
+    mid = (lb + ub) / 2;
+
+    /* 5. assert the invariant to establish inductiveness */
+    assert(0L <= lb && lb - 1L <= ub && ub < size);
+    assert(mid == (lb + ub) / 2L);
+
+    /* 6. terminate this symbolic execution path; similar to "exit" */
+    __CPROVER_assume(false);
+  }
+  return lb > ub ? NOT_FOUND : mid;
+}
+```
+
+A few things to note here:
+
+- At instrumented code point (2), when we `havoc` the modified variables,
+  this set of modified variables is automatically computed
+  using alias analysis of l-values appearing in the loop body.
+  However, the analysis is incomplete and may fail to characterize the set for complex loops.
+  In such cases, the user must manually annotate the set of modified variables
+  using an [_assigns clause_](contracts-assigns.md).
+
+- At instrumented code point (6), when we _assume_ `false`,
+  observe that this assumption only exists within the `lb <= ub` conditional.
+  Therefore, only the symbolic execution path _inside_ this conditional block terminates.
+  The code outside of the conditional block continues to be symbolically executed,
+  and subsequent assertions do not become vacuously `true`.
+
+[history variables]: contracts-history-variables.md
+
+[binary search]: https://en.wikipedia.org/wiki/Binary_search_algorithm

--- a/doc/cprover-manual/contracts-loops.md
+++ b/doc/cprover-manual/contracts-loops.md
@@ -1,0 +1,147 @@
+# Loop Contracts
+
+CBMC offers support for loop contracts, which includes three basic clauses:
+- _invariant_ clause for establishing safety properties
+- _decreases_ clause for establishing termination, and
+- _assigns_ clause for declaring the subset of variables that is modifiable in the loop.
+
+These clauses formally describe an abstraction of a loop for the purpose of a proof.
+CBMC also provides a series of built-in constructs
+to aid writing loop contracts (e.g., _history variables_ and _quantifiers_).
+
+## Overview
+
+Consider an implementation of the [binary search algorithm] below.
+
+```c
+#include <assert.h>
+#include <stdlib.h>
+#include <stdbool.h>
+
+#define NOT_FOUND (-1)
+
+int binary_search(int val, int *buf, int size)
+{
+  if(size <= 0 || buf == NULL) return NOT_FOUND;
+
+  long lb = 0, ub = size - 1;
+  long mid = (lb + ub) / 2;
+
+  while(lb <= ub)
+  {
+     if(buf[mid] == val) break;
+     if(buf[mid] < val)
+       lb = mid + 1;
+     else
+       ub = mid - 1;
+     mid = (lb + ub) / 2;
+  }
+  return lb > ub ? NOT_FOUND : mid;
+}
+
+int main() {
+  int val, size;
+  int *buf = size >= 0 ? malloc(size * sizeof(int)) : NULL;
+
+  int idx = binary_search(val, buf, size);
+  if(idx != NOT_FOUND)
+    assert(buf[idx] == val);
+}
+```
+
+The function stores a lower bound `lb` and an upper bound `ub`
+initialized to the bounds on the buffer `buf`, i.e., to `0` and `size-1` respectively.
+In each iteration, the midpoint `mid` is compared against the target value `val`
+and in case of a mismatch either the lower half or the upper half of the buffer is searched recursively.
+A developer might be interested in verifying two high-level properties on the loop on all possible buffers `buf` and values `val`:
+1. an out-of-bound access should never occur (at `buf[mid]` lookup)
+2. the loop must eventually always terminate
+
+To prove the first (memory-safety) property,
+we may declare [_loop invariants_](contracts-invariant.md)
+that must be preserved across all loop iterations.
+In this case, two invariant clauses would together imply that `buf[mid]` lookup is always safe.
+The first invariant clause would establish that the bounds (`lb` and `ub`) are always valid:
+```c
+__CPROVER_loop_invariant(0L <= lb && lb - 1L <= ub && ub < size)
+```
+Note that in the second conjunct,
+the `lb - 1 == ub` case is possible when the value `val` is not found in the buffer `buf`.
+The second invariant clause would establish that the midpoint `mid` is always a valid index.
+In this particular case we can in fact establish a stronger invariant,
+that `mid` is indeed always the midpoint of `lb` and `ub` in every iteration:
+```c
+__CPROVER_loop_invariant(mid == (lb + ub) / 2L)
+```
+
+To prove the second (termination) property,
+we may declare a [_decreases clause_](contracts-decreases.md)
+that indicates a bounded numeric measure
+which must monotonically decrease with each loop iteration.
+In this case, it is easy to see that `lb` and `ub` are approaching closer together with each iteration, since either `lb` must increase or `ub` must decrease in each iteration.
+```c
+__CPROVER_decreases(ub - lb)
+```
+
+The loop together with all its contracts is shown below.
+
+```c
+#include <assert.h>
+#include <stdlib.h>
+#include <stdbool.h>
+
+#define NOT_FOUND (-1)
+
+int binary_search(int val, int *buf, int size)
+{
+  if(size <= 0 || buf == NULL) return NOT_FOUND;
+
+  long lb = 0, ub = size - 1;
+  long mid = (lb + ub) / 2;
+
+  while(lb <= ub)
+  __CPROVER_loop_invariant(0L <= lb && lb - 1L <= ub && ub < size)
+  __CPROVER_loop_invariant(mid == (lb + ub) / 2L)
+  __CPROVER_decreases(ub - lb)
+  {
+     if(buf[mid] == val) break;
+     if(buf[mid] < val)
+       lb = mid + 1;
+     else
+       ub = mid - 1;
+     mid = (lb + ub) / 2;
+  }
+  return lb > ub ? NOT_FOUND : mid;
+}
+
+int main() {
+  int val, size;
+  int *buf = size >= 0 ? malloc(size * sizeof(int)) : NULL;
+
+  int idx = binary_search(val, buf, size);
+  if(idx != NOT_FOUND)
+    assert(buf[idx] == val);
+}
+```
+
+With CBMC we can now generate an unbounded proof using these contracts:
+
+```sh
+goto-cc -o binary_search.goto binary_search.c
+goto-instrument --apply-loop-contracts binary_search.goto binary_search_inst.goto
+cbmc binary_search_inst.goto --pointer-check --bounds-check --signed-overflow-check
+```
+
+The first command compiles the program to a GOTO binary,
+next we instrument the loops using the annotated loop contracts,
+and finally we verify the instrumented GOTO binary with desired checks.
+
+## Additional Resources
+
+- [Assigns Clause](contracts-assigns.md)
+- [Decreases Clause](contracts-decreases.md)
+- [History Variables](contracts-history-variables.md)
+- [Invariant Clause](contracts-invariant.md)
+- [Quantifiers](contracts-quantifiers.md)
+
+[binary search algorithm]: https://en.wikipedia.org/wiki/Binary_search_algorithm

--- a/doc/cprover-manual/contracts-quantifiers.md
+++ b/doc/cprover-manual/contracts-quantifiers.md
@@ -9,7 +9,7 @@ __CPROVER_exists { *type* *identifier*; *boolean expression* }
 
 While quantified expressions with arbitrary Boolean expressions are supported with an SMT backend, the SAT backend only supports bounded quantification under _constant_ lower & upper bounds. This is because the SAT backend currently expands a universal quantifier (`__CPROVER_forall`) to a conjunction and an existential quantifier (`__CPROVER_exists`) to a disjunction on each value within the specified bound.
 
-Concretely, with the SAT backend, the following syntax must be used for quantifiers within function contracts:
+Concretely, with the SAT backend, the following syntax must be used for quantifiers:
 
 ```
 __CPROVER_forall { *id* *type*; *range* => *boolean expression* }
@@ -19,10 +19,13 @@ __CPROVER_exists { *id* *type*; *range* && *boolean expression* }
 where `*range*` is an expression of the form
 
 ```
-*lower bound* <= *id* && *id* <= *upper bound*
+*lower bound* <= *id* && *id* < *upper bound*
 ```
 
 where `*lower bound*`and `*upper bound*` are constants.
+The bound predicates could be strict (e.g., `*lower bound* < *id*`),
+or non-strict (e.g., `*upper bound* <= *id*`),
+but both the bounds **must** be constants.
 
 
 ### Semantics
@@ -35,10 +38,10 @@ int foo(int *arr, int len)
   /* ... */
   __CPROVER_ensures(__CPROVER_forall {
     int i;
-    (0 <= i && i < len) ==> arr[i] == i
+    (0 <= i && i < len) ==> arr[i] == 0
   })
 {
-  /* ... */
+  /* every element in arr must be set to 0 */
 }
 ```
 
@@ -53,8 +56,34 @@ int bar(int *arr, int len)
   })
   /* ... */
 {
-  /* ... */
+  /* at least one element in arr must be set to 1 */
 }
 ```
 
 The examples above only work with the SMT backend, since `len` is not constant.
+However, if a constant maximum upper bound, say `MAX_LEN`, is known,
+then the following workaround may be used with the SAT backend:
+
+```c
+int foo_sat(int *arr, int len)
+  /* ... */
+  __CPROVER_ensures(__CPROVER_forall {
+    int i;
+    (0 <= i && i < MAX_LEN) ==>
+      (i < len ==> arr[i] == 0)
+  })
+{
+  /* every element in arr must be set to 0 */
+}
+
+int bar_sat(int *arr, int len)
+  __CPROVER_requires(__CPROVER_exists {
+    int i;
+    (0 <= i && i < MAX_LEN) &&
+      (i < len && arr[i] == 1)
+  })
+  /* ... */
+{
+  /* at least one element in arr must be set to 1 */
+}
+```

--- a/doc/cprover-manual/contracts.md
+++ b/doc/cprover-manual/contracts.md
@@ -1,0 +1,17 @@
+# Contracts
+
+Code contracts in CBMC provide way to safely abstract parts of a program,
+typically in order to accelerate the verification process.
+The key idea is to overapproximate the possible set of program states,
+while still being precise enough to be able to prove the desired property.
+
+To learn more about contracts, take a look at the chapter [Design by
+Contract](http://se.inf.ethz.ch/~meyer/publications/old/dbc_chapter.pdf) from
+the book Object-Oriented Software Construction by Bertrand Meyer or read the
+notes [Contract-based
+Design](https://www.georgefairbanks.com/york-university-contract-based-design-2021)
+by George Fairbanks.
+
+CBMC currently supports contracts on functions and loops:
+- [Function Contracts](contracts-functions.md)
+- [Loop Contracts](contracts-loops.md)


### PR DESCRIPTION
- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a ~~Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.~~
- [x] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- n/a ~~Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).~~
- n/a ~~My commit message includes data points confirming performance improvements (if claimed).~~
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.