### PR TITLE
Make expr_try_dynamic_cast function work with various types of exprt

### DIFF
--- a/src/solvers/prop/literal_expr.h
+++ b/src/solvers/prop/literal_expr.h
@@ -36,6 +36,18 @@ public:
   }
 };
 
+template <>
+inline bool can_cast_expr<literal_exprt>(const exprt &base)
+{
+  return base.id() == ID_literal;
+}
+
+inline void validate_expr(const literal_exprt &literal)
+{
+  DATA_INVARIANT(
+    !literal.has_operands(), "literal expression should not have operands");
+}
+
 /// Cast a generic exprt to a \ref literal_exprt. This is an unchecked
 /// conversion. \a expr must be known to be \ref literal_exprt.
 /// \param expr: Source expression

--- a/src/util/mathematical_expr.h
+++ b/src/util/mathematical_expr.h
@@ -375,6 +375,17 @@ public:
   }
 };
 
+template <>
+inline bool can_cast_expr<exists_exprt>(const exprt &base)
+{
+  return base.id() == ID_exists;
+}
+
+inline void validate_expr(const exists_exprt &value)
+{
+  validate_expr(static_cast<const quantifier_exprt &>(value));
+}
+
 inline const exists_exprt &to_exists_expr(const exprt &expr)
 {
   PRECONDITION(expr.id() == ID_exists);

--- a/src/util/mathematical_expr.h
+++ b/src/util/mathematical_expr.h
@@ -338,6 +338,17 @@ public:
   }
 };
 
+template <>
+inline bool can_cast_expr<forall_exprt>(const exprt &base)
+{
+  return base.id() == ID_forall;
+}
+
+inline void validate_expr(const forall_exprt &value)
+{
+  validate_expr(static_cast<const quantifier_exprt &>(value));
+}
+
 inline const forall_exprt &to_forall_expr(const exprt &expr)
 {
   PRECONDITION(expr.id() == ID_forall);

--- a/src/util/pointer_expr.h
+++ b/src/util/pointer_expr.h
@@ -306,6 +306,17 @@ public:
   }
 };
 
+template <>
+inline bool can_cast_expr<is_dynamic_object_exprt>(const exprt &base)
+{
+  return base.id() == ID_is_invalid_pointer;
+}
+
+inline void validate_expr(const is_dynamic_object_exprt &value)
+{
+  validate_operands(value, 1, "is_dynamic_object must have one operand");
+}
+
 inline const is_dynamic_object_exprt &
 to_is_dynamic_object_expr(const exprt &expr)
 {

--- a/src/util/pointer_predicates.h
+++ b/src/util/pointer_predicates.h
@@ -59,4 +59,15 @@ public:
   }
 };
 
+template <>
+inline bool can_cast_expr<is_invalid_pointer_exprt>(const exprt &base)
+{
+  return base.id() == ID_is_invalid_pointer;
+}
+
+inline void validate_expr(const is_invalid_pointer_exprt &value)
+{
+  validate_operands(value, 1, "is_invalid_pointer must have one operand");
+}
+
 #endif // CPROVER_UTIL_POINTER_PREDICATES_H

--- a/src/util/string_constant.h
+++ b/src/util/string_constant.h
@@ -27,6 +27,17 @@ public:
   bool from_array_expr(const array_exprt &);
 };
 
+template <>
+inline bool can_cast_expr<string_constantt>(const exprt &base)
+{
+  return base.id() == ID_string_constant;
+}
+
+inline void validate_expr(const string_constantt &expr)
+{
+  validate_operands(expr, 0, "String constants must not have operands");
+}
+
 inline const string_constantt &to_string_constant(const exprt &expr)
 {
   PRECONDITION(expr.id() == ID_string_constant);


### PR DESCRIPTION
I found that `expr_try_dynamic_cast` didn't work with various types of `exprt`, due to missing `can_cast_expr` and `validate_expr` overloads. This PR adds the missing functions in order to allow usage of `expr_try_dynamic_cast` with these types of `exprt` to compile and work.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
