### PR TITLE
SMT-LIB2 parser: extract repeated code for operand type checking

### DIFF
--- a/src/solvers/smt2/smt2_parser.cpp
+++ b/src/solvers/smt2/smt2_parser.cpp
@@ -345,11 +345,9 @@ exprt smt2_parsert::cast_bv_to_unsigned(const exprt &expr)
   return typecast_exprt(expr, unsignedbv_typet(width));
 }
 
-exprt smt2_parsert::multi_ary(irep_idt id, const exprt::operandst &op)
+void smt2_parsert::check_matching_operand_types(
+  const exprt::operandst &op) const
 {
-  if(op.empty())
-    throw error("expression must have at least one operand");
-
   for(std::size_t i = 1; i < op.size(); i++)
   {
     if(op[i].type() != op[0].type())
@@ -360,6 +358,14 @@ exprt smt2_parsert::multi_ary(irep_idt id, const exprt::operandst &op)
                     << smt2_format(op[i].type()) << '\'';
     }
   }
+}
+
+exprt smt2_parsert::multi_ary(irep_idt id, const exprt::operandst &op)
+{
+  if(op.empty())
+    throw error("expression must have at least one operand");
+
+  check_matching_operand_types(op);
 
   exprt result(id, op[0].type());
   result.operands() = op;
@@ -371,13 +377,7 @@ exprt smt2_parsert::binary_predicate(irep_idt id, const exprt::operandst &op)
   if(op.size()!=2)
     throw error("expression must have two operands");
 
-  if(op[0].type() != op[1].type())
-  {
-    throw error() << "expression must have operands with matching types,"
-                     " but got '"
-                  << smt2_format(op[0].type()) << "' and '"
-                  << smt2_format(op[1].type()) << '\'';
-  }
+  check_matching_operand_types(op);
 
   return binary_predicate_exprt(op[0], id, op[1]);
 }
@@ -395,8 +395,7 @@ exprt smt2_parsert::binary(irep_idt id, const exprt::operandst &op)
   if(op.size()!=2)
     throw error("expression must have two operands");
 
-  if(op[0].type() != op[1].type())
-    throw error("expression must have operands with matching types");
+  check_matching_operand_types(op);
 
   return binary_exprt(op[0], id, op[1], op[0].type());
 }

--- a/src/solvers/smt2/smt2_parser.h
+++ b/src/solvers/smt2/smt2_parser.h
@@ -75,12 +75,12 @@ public:
 
   bool exit;
 
-  smt2_tokenizert::smt2_errort error(const std::string &message)
+  smt2_tokenizert::smt2_errort error(const std::string &message) const
   {
     return smt2_tokenizer.error(message);
   }
 
-  smt2_tokenizert::smt2_errort error()
+  smt2_tokenizert::smt2_errort error() const
   {
     return smt2_tokenizer.error();
   }
@@ -158,6 +158,7 @@ protected:
   exprt::operandst operands();
   typet function_signature_declaration();
   signature_with_parameter_idst function_signature_definition();
+  void check_matching_operand_types(const exprt::operandst &) const;
   exprt multi_ary(irep_idt, const exprt::operandst &);
   exprt binary_predicate(irep_idt, const exprt::operandst &);
   exprt binary(irep_idt, const exprt::operandst &);

--- a/src/solvers/smt2/smt2_tokenizer.h
+++ b/src/solvers/smt2/smt2_tokenizer.h
@@ -92,13 +92,13 @@ public:
   }
 
   /// generate an error exception, pre-filled with a message
-  smt2_errort error(const std::string &message)
+  smt2_errort error(const std::string &message) const
   {
     return smt2_errort(message, line_no);
   }
 
   /// generate an error exception
-  smt2_errort error()
+  smt2_errort error() const
   {
     return smt2_errort(line_no);
   }


### PR DESCRIPTION
This extracts repeated code for checking that the types of an SMT-LIB2
expression are the same into a method.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
