### PR TITLE
Automatic inference of decreases clauses

### DIFF
--- a/regression/contracts/invar_assigns_opt/test.desc
+++ b/regression/contracts/invar_assigns_opt/test.desc
@@ -5,11 +5,11 @@ main.c
 ^SIGNAL=0$
 ^\[main.1\] .* Check loop invariant before entry: SUCCESS$
 ^\[main.2\] .* Check that loop invariant is preserved: SUCCESS$
-^\[main.3\] .* Check decreases clause on loop iteration: SUCCESS$
+^\[main.3\] .* Check decreases clause r1 on loop iteration: SUCCESS$
 ^\[main.assertion.1\] .* assertion r1 == 0: SUCCESS$
 ^\[main.4\] .* Check loop invariant before entry: SUCCESS$
 ^\[main.5\] .* Check that loop invariant is preserved: SUCCESS$
-^\[main.6\] .* Check decreases clause on loop iteration: SUCCESS$
+^\[main.6\] .* Check decreases clause r2 on loop iteration: SUCCESS$
 ^\[main.assertion.2\] .* assertion r2 == 0: SUCCESS$
 ^VERIFICATION SUCCESSFUL$
 --

--- a/regression/contracts/invar_check_multiple_loops/test.desc
+++ b/regression/contracts/invar_check_multiple_loops/test.desc
@@ -5,10 +5,10 @@ main.c
 ^SIGNAL=0$
 ^\[main.1\] .* Check loop invariant before entry: SUCCESS$
 ^\[main.2\] .* Check that loop invariant is preserved: SUCCESS$
-^\[main.3\] .* Check decreases clause on loop iteration: SUCCESS$
+^\[main.3\] .* Check decreases clause n - r on loop iteration: SUCCESS$
 ^\[main.4\] .* Check loop invariant before entry: SUCCESS$
 ^\[main.5\] .* Check that loop invariant is preserved: SUCCESS$
-^\[main.6\] .* Check decreases clause on loop iteration: SUCCESS$
+^\[main.6\] .* Check decreases clause r on loop iteration: SUCCESS$
 ^\[main.assertion.1\] .* assertion x == y \+ 2 \* n: SUCCESS$
 ^VERIFICATION SUCCESSFUL$
 --

--- a/regression/contracts/invar_check_nested_loops/test.desc
+++ b/regression/contracts/invar_check_nested_loops/test.desc
@@ -5,10 +5,10 @@ main.c
 ^SIGNAL=0$
 ^\[main.1\] .* Check loop invariant before entry: SUCCESS$
 ^\[main.5\] .* Check that loop invariant is preserved: SUCCESS$
-^\[main.6\] .* Check decreases clause on loop iteration: SUCCESS$
+^\[main.6\] .* Check decreases clause n - i on loop iteration: SUCCESS$
 ^\[main.2\] .* Check loop invariant before entry: SUCCESS$
 ^\[main.3\] .* Check that loop invariant is preserved: SUCCESS$
-^\[main.4\] .* Check decreases clause on loop iteration: SUCCESS$
+^\[main.4\] .* Check decreases clause a on loop iteration: SUCCESS$
 ^\[main.assertion.1\] .* assertion s == n: SUCCESS$
 ^VERIFICATION SUCCESSFUL$
 --

--- a/regression/contracts/variant_init_inside_loop/test.desc
+++ b/regression/contracts/variant_init_inside_loop/test.desc
@@ -3,7 +3,7 @@ main.c
 --apply-loop-contracts _ --unsigned-overflow-check
 ^\[main.1\] .* Check loop invariant before entry: SUCCESS$
 ^\[main.2\] .* Check that loop invariant is preserved: SUCCESS$
-^\[main.3\] .* Check decreases clause on loop iteration: SUCCESS$
+^\[main.3\] .* Check decreases clause (max - i) on loop iteration: SUCCESS$
 ^\[main.overflow.1\] .* arithmetic overflow on unsigned - in max - i: SUCCESS$
 ^\[main.overflow.3\] .* arithmetic overflow on unsigned - in max - i: SUCCESS$
 ^\[main.overflow.2\] .* arithmetic overflow on unsigned \+ in i \+ 1u: SUCCESS$

--- a/regression/contracts/variant_missing_invariant_warning/test.desc
+++ b/regression/contracts/variant_missing_invariant_warning/test.desc
@@ -4,7 +4,7 @@ main.c
 ^The loop at file main.c line 4 function main does not have a loop invariant, but has a decreases clause. Hence, a default loop invariant \('true'\) is being used.$
 ^\[main.1\].*Check loop invariant before entry: SUCCESS$
 ^\[main.2\].*Check that loop invariant is preserved: SUCCESS$
-^\[main.3\].*Check decreases clause on loop iteration: SUCCESS$
+^\[main.3\].*Check decreases clause i on loop iteration: SUCCESS$
 ^VERIFICATION SUCCESSFUL$
 ^EXIT=0$
 ^SIGNAL=0$

--- a/regression/contracts/variant_multidimensional_ackermann/test.desc
+++ b/regression/contracts/variant_multidimensional_ackermann/test.desc
@@ -5,7 +5,7 @@ main.c
 ^\[precondition.2\] .* Check requires clause: SUCCESS$
 ^\[ackermann.1\] .* Check loop invariant before entry: SUCCESS$
 ^\[ackermann.2\] .* Check that loop invariant is preserved: SUCCESS$
-^\[ackermann.3\] .* Check decreases clause on loop iteration: SUCCESS$
+^\[ackermann.3\] .* Check decreases clause \(m, n\) on loop iteration: SUCCESS$
 ^VERIFICATION SUCCESSFUL$
 ^EXIT=0$
 ^SIGNAL=0$

--- a/regression/contracts/variant_multidimensional_not_decreasing_fail1/test.desc
+++ b/regression/contracts/variant_multidimensional_not_decreasing_fail1/test.desc
@@ -3,7 +3,7 @@ main.c
 --apply-loop-contracts
 ^\[main.1\] .* Check loop invariant before entry: SUCCESS$
 ^\[main.2\] .* Check that loop invariant is preserved: SUCCESS$
-^\[main.3\] .* Check decreases clause on loop iteration: FAILURE$
+^\[main.3\] .* Check decreases clause \(N - i, j\) on loop iteration: FAILURE$
 ^VERIFICATION FAILED$
 ^EXIT=10$
 ^SIGNAL=0$

--- a/regression/contracts/variant_multidimensional_not_decreasing_fail2/test.desc
+++ b/regression/contracts/variant_multidimensional_not_decreasing_fail2/test.desc
@@ -3,7 +3,7 @@ main.c
 --apply-loop-contracts
 ^\[main.1\] .* Check loop invariant before entry: SUCCESS$
 ^\[main.2\] .* Check that loop invariant is preserved: SUCCESS$
-^\[main.3\] .* Check decreases clause on loop iteration: FAILURE$
+^\[main.3\] .* Check decreases clause \(i, N - j\) on loop iteration: FAILURE$
 ^VERIFICATION FAILED$
 ^EXIT=10$
 ^SIGNAL=0$

--- a/regression/contracts/variant_multidimensional_two_index_variables/test.desc
+++ b/regression/contracts/variant_multidimensional_two_index_variables/test.desc
@@ -3,7 +3,7 @@ main.c
 --apply-loop-contracts
 ^\[main.1\] .* Check loop invariant before entry: SUCCESS$
 ^\[main.2\] .* Check that loop invariant is preserved: SUCCESS$
-^\[main.3\] .* Check decreases clause on loop iteration: SUCCESS$
+^\[main.3\] .* Check decreases clause \(N - i, N - j\) on loop iteration: SUCCESS$
 ^VERIFICATION SUCCESSFUL$
 ^EXIT=0$
 ^SIGNAL=0$

--- a/regression/contracts/variant_not_decreasing_fail/test.desc
+++ b/regression/contracts/variant_not_decreasing_fail/test.desc
@@ -3,7 +3,7 @@ main.c
 --apply-loop-contracts
 ^\[main.1\] .* Check loop invariant before entry: SUCCESS$
 ^\[main.2\] .* Check that loop invariant is preserved: SUCCESS$
-^\[main.3\] .* Check decreases clause on loop iteration: FAILURE$
+^\[main.3\] .* Check decreases clause i on loop iteration: FAILURE$
 ^VERIFICATION FAILED$
 ^EXIT=10$
 ^SIGNAL=0$

--- a/regression/contracts/variant_weak_invariant_fail/test.desc
+++ b/regression/contracts/variant_weak_invariant_fail/test.desc
@@ -3,7 +3,7 @@ main.c
 --apply-loop-contracts
 ^\[main.1\] .* Check loop invariant before entry: SUCCESS$
 ^\[main.2\] .* Check that loop invariant is preserved: SUCCESS$
-^\[main.3\] .* Check decreases clause on loop iteration: FAILURE$
+^\[main.3\] .* Check decreases clause N - i on loop iteration: FAILURE$
 ^VERIFICATION FAILED$
 ^EXIT=10$
 ^SIGNAL=0$

--- a/regression/contracts/variant_while_true_pass/test.desc
+++ b/regression/contracts/variant_while_true_pass/test.desc
@@ -3,7 +3,7 @@ main.c
 --apply-loop-contracts
 ^\[main.1\] .* Check loop invariant before entry: SUCCESS$
 ^\[main.2\] .* Check that loop invariant is preserved: SUCCESS$
-^\[main.3\] .* Check decreases clause on loop iteration: SUCCESS$
+^\[main.3\] .* Check decreases clause N - i on loop iteration: SUCCESS$
 ^VERIFICATION SUCCESSFUL$
 ^EXIT=0$
 ^SIGNAL=0$

--- a/regression/goto-analyzer/monotonic_change_conditionals/main.c
+++ b/regression/goto-analyzer/monotonic_change_conditionals/main.c
@@ -1,0 +1,18 @@
+int nondet_bool(void);
+
+int main()
+{
+  int x;
+  if(nondet_bool())
+    x++;
+  else
+    x += 6;
+
+  int y;
+  if(nondet_bool())
+    y++;
+  else
+    y -= 6;
+
+  return 0;
+}

--- a/regression/goto-analyzer/monotonic_change_conditionals/test.desc
+++ b/regression/goto-analyzer/monotonic_change_conditionals/test.desc
@@ -1,0 +1,20 @@
+CORE
+main.c
+--function main --vsd --vsd-values monotonic-change --show
+^main.*x .* -> Staying unchanged @ \[0\]$
+^main.*x .* -> Strictly and monotonically increasing @ \[4\]$
+^main.*x .* -> Strictly and monotonically increasing @ \[4, 6\]$
+^main.*y .* -> Staying unchanged @ \[8\]$
+^main.*y .* -> Strictly and monotonically increasing @ \[12\]$
+^main.*y .* -> TOP @ \[12, 14\]$
+^EXIT=0$
+^SIGNAL=0$
+--
+--
+This test case checks whether the abstract interpretation of monotonic change
+correctly handles if-else statements. 
+
+Consider the location in code immediately after we have exited the if-else
+statement (i.e. when the two branches of the if-else statement join). At this
+point, the abstract object must be the "join" (in the terminology of lattice
+theory) of the abstract values corresponding to the two branches. 

--- a/regression/goto-analyzer/monotonic_change_function_arguments/main.c
+++ b/regression/goto-analyzer/monotonic_change_function_arguments/main.c
@@ -1,0 +1,8 @@
+int foo(int x, int y)
+{
+  x++;
+  x += 6;
+
+  y--;
+  y -= 6;
+}

--- a/regression/goto-analyzer/monotonic_change_function_arguments/test.desc
+++ b/regression/goto-analyzer/monotonic_change_function_arguments/test.desc
@@ -1,0 +1,27 @@
+CORE
+main.c
+--function foo --vsd --vsd-values monotonic-change --show
+^__CPROVER__start.*x .* -> Staying unchanged @ \[28\]$
+^__CPROVER__start.*x .* -> TOP @ \[29\]$
+^__CPROVER__start.*y .* -> Staying unchanged @ \[31\]$
+^__CPROVER__start.*y .* -> TOP @ \[32\]$
+^foo.*x .* -> TOP @ \[34\]$
+^foo.*x .* -> TOP @ \[20\]$
+^foo.*x .* -> TOP @ \[21\]$
+^foo.*y .* -> TOP @ \[34\]$
+^foo.*y .* -> TOP @ \[22\]$
+^foo.*y .* -> TOP @ \[23\]$
+^EXIT=0$
+^SIGNAL=0$
+--
+--
+This test case tests whether formal arguments of a standalone function (i.e. a
+function that is not invoked by another function) are initialized correctly.
+When the abstract interpretation analyzes the function foo, its actual arguments
+(i.e. parameter) are set to __CPROVER__start::x and __CPROVER__start::y. They
+have the abstract value TOP. This is due to this GOTO instruction:
+ASSIGN __CPROVER__start::x := side_effect #source_location="" statement="nondet" is_nondet_nullable="1"
+
+Ideally, __CPROVER__start::x and __CPROVER__start::y should have the abstract
+value "unchanged" instead of TOP. However, this may require extensive
+modification of the code base.

--- a/regression/goto-analyzer/monotonic_change_function_call/main.c
+++ b/regression/goto-analyzer/monotonic_change_function_call/main.c
@@ -1,0 +1,19 @@
+int nondet_bool(void);
+
+int increment(int x)
+{
+  if(nondet_bool())
+    x++;
+  else
+    x += 6;
+  return x;
+}
+
+int main()
+{
+  int x;
+  x++;
+  int y = increment(x);
+  y--;
+  return 0;
+}

--- a/regression/goto-analyzer/monotonic_change_function_call/test.desc
+++ b/regression/goto-analyzer/monotonic_change_function_call/test.desc
@@ -1,0 +1,25 @@
+CORE
+main.c
+--function main --vsd --vsd-values monotonic-change --show
+^main.*x .* -> Staying unchanged @ \[0\]$
+^main.*x .* -> Strictly and monotonically increasing @ \[1\]$
+^main.*y .* -> Staying unchanged @ \[2\]$
+^main.*y .* -> TOP @ \[7\]$
+^main.*y .* -> TOP @ \[8\]$
+^increment.*x .* -> Strictly and monotonically increasing @ \[4\]$
+^increment.*x .* -> Strictly and monotonically increasing @ \[38\]$
+^increment.*x .* -> Strictly and monotonically increasing @ \[38, 40\]$
+^EXIT=0$
+^SIGNAL=0$
+--
+--
+This test case checks whether the predicate abstraction for monotonic change
+handles a function call properly. When the function "increment" is invoked, 
+the actual argument's abstract value is copied to the formal argument's initial
+abstract value. So, in this example, the initial abstract value of 
+increment::x is the same as the abstract value of main::1::x. 
+
+It is debatable whether this is a reasonable behavior for the abstract
+interpretation for monotonic change. It may be better if we can simply
+initialize the formal argument's abstract value to "unchanged," as opposed to
+the actual argument's abstract value. 

--- a/regression/goto-analyzer/monotonic_change_loops/main.c
+++ b/regression/goto-analyzer/monotonic_change_loops/main.c
@@ -1,0 +1,29 @@
+int main()
+{
+  int x;
+  while(x < 42)
+  {
+    x++;
+  }
+
+  int y;
+  while(y > 0)
+  {
+    y--;
+  }
+
+  int z;
+  while(z < 42)
+  {
+    z++;
+    z--;
+  }
+
+  int u;
+  while(1)
+  {
+    u++;
+  }
+
+  return 0;
+}

--- a/regression/goto-analyzer/monotonic_change_loops/test.desc
+++ b/regression/goto-analyzer/monotonic_change_loops/test.desc
@@ -1,0 +1,22 @@
+CORE
+main.c
+--function main --vsd --vsd-values monotonic-change --show
+^main.*x .* -> TOP @ \[0, 2\]$
+^main.*x .* -> TOP @ \[2\]$
+^main.*y .* -> TOP @ \[5, 7\]$
+^main.*y .* -> TOP @ \[7\]$
+^main.*z .* -> TOP @ \[10, 13\]$
+^main.*z .* -> TOP @ \[12\]$
+^main.*z .* -> TOP @ \[13\]$
+^EXIT=0$
+^SIGNAL=0$
+--
+--
+This test case checks whether the monotonic-change abstract interpretation
+correctly computes an abstract value for (possibly divergent) loops. This hinges
+on a correct implementation of the widening operator (which is subsumed by the
+merge function). 
+
+All abstract values are TOP, which is rather boring. However, if we add
+non-strict increase and non-strict decrease to the abstract domain, then the
+result of this test case will be more interesting.

--- a/regression/goto-analyzer/monotonic_change_malloc/main.c
+++ b/regression/goto-analyzer/monotonic_change_malloc/main.c
@@ -1,0 +1,9 @@
+#include <stdlib.h>
+
+int main()
+{
+  int *p = malloc(sizeof(int));
+  (*p)++;
+
+  return 0;
+}

--- a/regression/goto-analyzer/monotonic_change_malloc/test.desc
+++ b/regression/goto-analyzer/monotonic_change_malloc/test.desc
@@ -1,0 +1,23 @@
+KNOWNBUG
+--function main --vsd --vsd-values monotonic-change --vsd-pointers constants --vsd-structs every-field --vsd-arrays every-element --show
+^EXIT=0$
+^SIGNAL=0$
+--
+Under the current implementation of monotonic-change abstract interpretation,
+this test case fails. Specifically, it will report a run-time error that one of
+the preconditions in the code base is violated. I will now explain the reason
+for the failure. 
+
+First of all, *p is expanded to *(p+0). Here, the offset 0 will be represented
+by an abstract value in whatever value domain we choose. This is due to the fact
+that memory addresses and array indices are treated as values just like
+integers. 
+
+In this test case, the value domain is monotonic-change. Hence, 0 will be
+represented by one of the abstract values in this abstract domain. However,
+unlike interval analysis, monotonic-change abstract interpretation does not keep
+track of variables' concrete values. It only keeps track of variables' abstract
+values (i.e. monotonicity statuses). Consequently, once we convert a concrete
+value (i.e. the offset 0) to an abstract value of monotonic-change abstract
+interpretation, we have no way to recover the concrete value back from the
+abstract value. This is why this test case results in a precondition violation. 

--- a/regression/goto-analyzer/monotonic_change_pointer_to_stack_memory/main.c
+++ b/regression/goto-analyzer/monotonic_change_pointer_to_stack_memory/main.c
@@ -1,0 +1,15 @@
+struct cartesian_coorindate
+{
+  int x;
+  int y;
+};
+
+int main()
+{
+  struct cartesian_coorindate u;
+  struct cartesian_coorindate *p = &u;
+  p->x;
+  p->y;
+  p->x++;
+  p->y--;
+}

--- a/regression/goto-analyzer/monotonic_change_pointer_to_stack_memory/test.desc
+++ b/regression/goto-analyzer/monotonic_change_pointer_to_stack_memory/test.desc
@@ -1,0 +1,16 @@
+CORE
+main.c
+--function main --vsd --vsd-values monotonic-change --vsd-pointers constants --vsd-structs every-field --show
+^main.*u .* -> \{\} @ \[0\]$
+^main.*p .* -> TOP @ \[1\]$
+^main.*p .* -> ptr ->\(main::1::u\) @ \[2\]$
+^main.*u .* -> \{.x=Strictly and monotonically increasing @ \[5\]\} @ \[5\]$
+^main.*u .* -> \{.x=Strictly and monotonically increasing @ \[5\], .y=Strictly and monotonically decreasing @ \[6\]\} @ \[6\]$
+^EXIT=0$
+^SIGNAL=0$
+--
+--
+This test case checks whether we correctly handle the abstract interpretation of
+monotonic change for a pointer. Note that the pointer pointers to a structure on
+a "stack" as opposed to a "heap." A separate test case handles the case where a
+structure is allocated on a heap. 

--- a/regression/goto-analyzer/monotonic_change_struct/main.c
+++ b/regression/goto-analyzer/monotonic_change_struct/main.c
@@ -1,0 +1,25 @@
+int nondet(void);
+int nondet_bool(void);
+
+struct cartesian_coorindate
+{
+  int x;
+  int y;
+};
+
+int main()
+{
+  struct cartesian_coorindate u;
+  if(nondet_bool())
+  {
+    u.x++;
+    u.y--;
+  }
+  else
+  {
+    u.x += 6;
+    u.y -= 6;
+  }
+
+  return 0;
+}

--- a/regression/goto-analyzer/monotonic_change_struct/test.desc
+++ b/regression/goto-analyzer/monotonic_change_struct/test.desc
@@ -1,0 +1,14 @@
+CORE
+main.c
+--function main --vsd --vsd-values monotonic-change --vsd-structs every-field --show
+^main.*u .* -> \{\} @ \[0\]$
+^main.*u .* -> \{.x=Strictly and monotonically increasing @ \[4\]\} @ \[4\]$
+^main.*u .* -> \{.x=Strictly and monotonically increasing @ \[4\], .y=Strictly and monotonically decreasing @ \[5\]\} @ \[5\]$
+^main.*u .* -> \{.x=Strictly and monotonically increasing @ \[7\]\} @ \[7\]$
+^main.*u .* -> \{.x=Strictly and monotonically increasing @ \[4, 7\], .y=Strictly and monotonically decreasing @ \[5, 8\]\} @ \[5, 8\]$
+^EXIT=0$
+^SIGNAL=0$
+--
+--
+This test case checks whether the abstract interpretation of monotonic change
+can correctly handle structure members. 

--- a/regression/goto-analyzer/monotonic_change_ternary_expression/main.c
+++ b/regression/goto-analyzer/monotonic_change_ternary_expression/main.c
@@ -1,0 +1,10 @@
+int nondet_bool(void);
+
+int main()
+{
+  int x;
+  x = nondet_bool() ? (x + 1) : (x + 2);
+
+  int y;
+  y = nondet_bool() ? (y + 1) : (y - 1);
+}

--- a/regression/goto-analyzer/monotonic_change_ternary_expression/test.desc
+++ b/regression/goto-analyzer/monotonic_change_ternary_expression/test.desc
@@ -1,0 +1,13 @@
+CORE
+main.c
+--function main --vsd --vsd-values monotonic-change --show
+main.*x .* -> Staying unchanged @ \[0\]$
+main.*x .* -> Strictly and monotonically increasing @ \[3\]$
+main.*y .* -> Staying unchanged @ \[4\]$
+main.*y .* -> TOP @ \[7\]$
+^EXIT=0$
+^SIGNAL=0$
+--
+--
+This test case checks whether we correctly compute the abstract value for a
+ternary expression; i.e. bool_expr() ? expr1 : expr2.

--- a/regression/goto-analyzer/monotonic_change_values/main.c
+++ b/regression/goto-analyzer/monotonic_change_values/main.c
@@ -1,0 +1,22 @@
+int nondet(void);
+
+int main()
+{
+  int x;
+  x++;
+  x = x + 2;
+
+  int y;
+  y--;
+  y = y - 2;
+
+  int z;
+  z++;
+  z--;
+
+  int u;
+  u++;
+  u *= 2;
+
+  return 0;
+}

--- a/regression/goto-analyzer/monotonic_change_values/test.desc
+++ b/regression/goto-analyzer/monotonic_change_values/test.desc
@@ -1,0 +1,21 @@
+CORE
+main.c
+--function main --vsd --vsd-values monotonic-change --show
+^main.*x .* -> Staying unchanged @ \[0\]$
+^main.*x .* -> Strictly and monotonically increasing @ \[1\]$
+^main.*x .* -> Strictly and monotonically increasing @ \[2\]$
+^main.*y .* -> Staying unchanged @ \[3\]$
+^main.*y .* -> Strictly and monotonically decreasing @ \[4\]$
+^main.*y .* -> Strictly and monotonically decreasing @ \[5\]$
+^main.*z .* -> Staying unchanged @ \[6\]$
+^main.*z .* -> Strictly and monotonically increasing @ \[7\]$
+^main.*z .* -> TOP @ \[8\]$
+^main.*u .* -> Staying unchanged @ \[9\]$
+^main.*u .* -> Strictly and monotonically increasing @ \[10\]$
+^main.*u .* -> TOP @ \[11\]$
+^EXIT=0$
+^SIGNAL=0$
+--
+--
+This test case checks whether strict and monotonic increase and decrease are
+correctly detected for integer-typed variables. 

--- a/src/analyses/Makefile
+++ b/src/analyses/Makefile
@@ -39,6 +39,7 @@ SRC = ai.cpp \
       variable-sensitivity/abstract_pointer_object.cpp \
       variable-sensitivity/abstract_value_object.cpp \
       variable-sensitivity/constant_abstract_value.cpp \
+      variable-sensitivity/monotonic_change.cpp \
       variable-sensitivity/constant_pointer_abstract_object.cpp \
       variable-sensitivity/context_abstract_object.cpp \
       variable-sensitivity/data_dependency_context.cpp \

--- a/src/analyses/ai.h
+++ b/src/analyses/ai.h
@@ -175,6 +175,21 @@ public:
     finalize();
   }
 
+  // Run abstract interpretation on a whole program. function_id is the ID of
+  // the function that we want to analyze. goto_model is the whole GOTO program.
+  // It is necessary to pass the entire GOTO program because function_id may
+  // call other functions. This version of the ()-operator was added
+  // specifically for the purpose of the decreases clauses' automatic inference.
+  void operator()(const irep_idt &function_id, goto_modelt &goto_model)
+  {
+    const namespacet ns(goto_model.get_symbol_table());
+    initialize(goto_model.get_goto_functions());
+    const goto_programt &function_body = goto_model.get_goto_function(function_id).body;
+    trace_ptrt p = entry_state(function_body);
+    fixedpoint(p, function_id, function_body, goto_model.get_goto_functions(), ns);
+    finalize();
+  }
+
   /// Run abstract interpretation on a single function
   void operator()(
     const irep_idt &function_id,

--- a/src/analyses/variable-sensitivity/abstract_aggregate_object.h
+++ b/src/analyses/variable-sensitivity/abstract_aggregate_object.h
@@ -61,6 +61,29 @@ public:
       expr, operands, environment, ns);
   }
 
+  abstract_object_pointert assign_expression_transform(
+    const abstract_object_pointert &lhs_abstract_object,
+    const exprt &lhs,
+    const exprt &rhs,
+    const std::vector<abstract_object_pointert> &operands,
+    const abstract_environmentt &environment,
+    const namespacet &ns) const override
+  {
+    if(rhs.id() == aggregate_traitst::ACCESS_EXPR_ID())
+      return read_component(environment, rhs, ns);
+
+    return abstract_objectt::assign_expression_transform(
+      lhs_abstract_object, lhs, rhs, operands, environment, ns);
+  }
+
+  abstract_object_pointert read(
+    const abstract_environmentt &environment,
+    const exprt &specifier,
+    const namespacet &ns) const override
+  {
+    return read_component(environment, specifier, ns);
+  }
+
   abstract_object_pointert write(
     abstract_environmentt &environment,
     const namespacet &ns,

--- a/src/analyses/variable-sensitivity/abstract_environment.cpp
+++ b/src/analyses/variable-sensitivity/abstract_environment.cpp
@@ -131,6 +131,106 @@ abstract_environmentt::eval(const exprt &expr, const namespacet &ns) const
   return abstract_object_factory(simplified_expr.type(), ns, true, false);
 }
 
+abstract_object_pointert abstract_environmentt::assign_eval(
+  const code_assignt &inst,
+  const namespacet &ns) const
+{
+  const exprt lhs = inst.lhs();
+  const abstract_object_pointert lhs_abstract_object = work_out_lhs(lhs, ns);
+  const exprt expr = inst.rhs();
+
+  if(bottom)
+    return abstract_object_factory(expr.type(), ns, false, true);
+
+  // first try to canonicalise, including constant folding
+  const exprt &simplified_expr = simplify_expr(expr, ns);
+
+  const irep_idt simplified_id = simplified_expr.id();
+  if(simplified_id == ID_symbol)
+  {
+    if(object_factory->is_predicate_abstraction(simplified_expr.type(), ns))
+      return abstract_object_factory_arbitrary_assignment(
+        lhs_abstract_object->unwrap_context(),
+        simplified_expr.type(),
+        simplified_expr,
+        ns);
+    else
+      return resolve_symbol(simplified_expr, ns);
+  }
+
+  if(
+    is_access_expr(simplified_id) || is_ptr_diff(simplified_expr) ||
+    is_ptr_comparison(simplified_expr))
+  {
+    auto const operands = eval_operands(simplified_expr, *this, ns);
+    auto const &target = operands.front();
+
+    if(object_factory->is_predicate_abstraction(simplified_expr.type(), ns))
+      return target->assign_expression_transform(
+        lhs_abstract_object,
+        lhs,
+        simplified_expr,
+        operands,
+        *this,
+        ns);
+    else
+      return target->expression_transform(simplified_expr, operands, *this, ns);
+  }
+
+  if(is_object_creation(simplified_id))
+  {
+    if(object_factory->is_predicate_abstraction(simplified_expr.type(), ns))
+      return abstract_object_factory_arbitrary_assignment(
+        lhs_abstract_object->unwrap_context(),
+        simplified_expr.type(),
+        simplified_expr,
+        ns);
+    else
+      return abstract_object_factory(
+        simplified_expr.type(), simplified_expr, ns);
+  }
+
+  if(is_dynamic_allocation(simplified_expr))
+  {
+    if(object_factory->is_predicate_abstraction(simplified_expr.type(), ns))
+      return abstract_object_factory_arbitrary_assignment(
+        lhs_abstract_object->unwrap_context(),
+        simplified_expr.type(),
+        simplified_expr,
+        ns);
+    else
+      return abstract_object_factory(
+        typet(ID_dynamic_object),
+        exprt(ID_dynamic_object, simplified_expr.type()),
+        ns);
+  }
+
+  // No special handling required by the abstract environment
+  // delegate to the abstract object
+  if(!simplified_expr.operands().empty())
+  {
+    if(object_factory->is_predicate_abstraction(simplified_expr.type(), ns))
+      return assign_eval_expression(lhs_abstract_object, lhs, expr, ns);
+    else
+      return eval_expression(simplified_expr, ns);
+  }
+  else
+  {
+    if(object_factory->is_predicate_abstraction(simplified_expr.type(), ns))
+    {
+      return abstract_object_factory_arbitrary_assignment(
+        lhs_abstract_object->unwrap_context(),
+        simplified_expr.type(),
+        simplified_expr,
+        ns);
+    }
+    // It is important that this is top as the abstract object may not know
+    // how to handle the expression.
+    else
+      return abstract_object_factory(simplified_expr.type(), ns, true, false);
+  }
+}
+
 abstract_object_pointert abstract_environmentt::resolve_symbol(
   const exprt &expr,
   const namespacet &ns) const
@@ -139,8 +239,60 @@ abstract_object_pointert abstract_environmentt::resolve_symbol(
   const auto symbol_entry = map.find(symbol.get_identifier());
 
   if(symbol_entry.has_value())
+  {
     return symbol_entry.value();
-  return abstract_object_factory(expr.type(), ns, true, false);
+  }
+  else
+  {
+    return abstract_declared_object_factory(expr.type(), expr, ns);
+  }
+}
+
+abstract_object_pointert abstract_environmentt::work_out_lhs(
+  const exprt &expr,
+  const namespacet &ns) const
+{
+  abstract_object_pointert lhs_value = nullptr;
+  // Build a stack of index, member and dereference accesses which
+  // we will work through the relevant abstract objects
+  exprt s = expr;
+  std::stack<exprt> stactions; // I'm not a continuation, honest guv'
+  while(s.id() != ID_symbol)
+  {
+    if(s.id() == ID_index || s.id() == ID_member || s.id() == ID_dereference)
+    {
+      stactions.push(s);
+      s = s.operands()[0];
+    }
+    else
+    {
+      lhs_value = eval(s, ns);
+      break;
+    }
+  }
+
+  if(!lhs_value)
+  {
+    INVARIANT(s.id() == ID_symbol, "Have a symbol or a stack");
+    lhs_value = resolve_symbol(s, ns);
+  }
+
+  abstract_object_pointert result = lhs_value;
+  while(!stactions.empty())
+  {
+    const exprt &next_expr = stactions.top();
+    stactions.pop();
+
+    const irep_idt &stack_head_id = next_expr.id();
+    INVARIANT(
+      stack_head_id == ID_index || stack_head_id == ID_member ||
+        stack_head_id == ID_dereference,
+      "Read stack expressions must be index, member, or dereference");
+
+    result = result->read(*this, next_expr, ns);
+  }
+
+  return result;
 }
 
 bool abstract_environmentt::assign(
@@ -302,10 +454,39 @@ exprt abstract_environmentt::do_assume(const exprt &expr, const namespacet &ns)
 
   auto fn = assume_functions[expr_id];
 
+  // In the case of MONOTONIC_CHANGE (i.e. abstract interpretation for monotonic
+  // change), we must explicitly return nil_exprt(). Otherwise, without the
+  // following "if" statement, the function do_assume will sometimes return
+  // an expression that evaluates to false. This happens because those functions
+  // inside assume_functions (e.g. assume_eq) are not designed for
+  // MONOTONIC_CHANGE.
+  if(object_factory->is_predicate_abstraction(expr.type(), ns))
+    return nil_exprt();
+
   if(fn)
     return fn(*this, expr, ns);
 
   return eval(expr, ns)->to_constant();
+}
+
+abstract_object_pointert
+abstract_environmentt::abstract_declared_object_factory(
+  const typet &type,
+  const exprt &expr,
+  const namespacet &ns) const
+{
+  return object_factory->get_abstract_object_declaration(type, expr, *this, ns);
+}
+
+abstract_object_pointert
+abstract_environmentt::abstract_object_factory_arbitrary_assignment(
+  const abstract_object_pointert &lhs_abstract_object,
+  const typet &type,
+  const exprt &e,
+  const namespacet &ns) const
+{
+  return object_factory->get_abstract_object_arbitrary_assignment(
+    lhs_abstract_object, type, e, *this, ns);
 }
 
 abstract_object_pointert abstract_environmentt::abstract_object_factory(
@@ -360,16 +541,71 @@ bool abstract_environmentt::merge(
   if(env.bottom)
     return false;
 
-  // For each element in the intersection of map and env.map merge
-  // If the result of the merge is top, remove from the map
   bool modified = false;
-  for(const auto &entry : env.map.get_delta_view(map))
-  {
-    auto merge_result = abstract_objectt::merge(
-      entry.get_other_map_value(), entry.m, merge_location, widen_mode);
 
-    modified |= merge_result.modified;
-    map.replace(entry.k, merge_result.object);
+  // For each entry in the delta view of env.map and map, we perform "merge." In
+  // this delta view, we have two kinds of entries: (i) a key exists in both
+  // maps but their values are not shared; (ii) a key only exists in env.map
+  // but is missing from map.
+  //
+  // In ordinary use of abstract interpretation, I believe we never need to
+  // merge two states where variable x only exists in one of them. However, as
+  // of now, when we apply abstract interpretation to the automatic inference of
+  // decreases clauses, we simply wrap a loop body inside a function. This means
+  // that some variables appearing in the loop body are not necessarily declared
+  // in advance. As a consequence of such variables, we may sometimes need to
+  // merge two abstract states where one state contains variable x and the other
+  // does not. This is why I had to modify and adapt the following two
+  // for-loops.
+  for(const auto &entry : env.map.get_delta_view(map, false))
+  {
+    // Hanlde the case where the key exists in both maps but their values are
+    // not shared
+    if (entry.is_in_both_maps())
+    {
+      auto merge_result = abstract_objectt::merge(
+        entry.get_other_map_value(), entry.m, merge_location, widen_mode);
+      modified |= merge_result.modified;
+      map.replace(entry.k, merge_result.object);
+    }
+    // Hanlde the case where the key only exists in env.map
+    else
+    {
+      INVARIANT(
+        env.map.has_key(entry.k),
+        "When the merge function is invoked, env.map must contain the key "
+        "entry.k");
+      // Becasue the key is missing from map, we will create a default abstract
+      // object.
+      abstract_object_pointert default_abstract_object =
+        object_factory->get_abstract_object_declaration(
+          (entry.m)->type(), nil_exprt(), *this, namespacet(nullptr, nullptr));
+      auto merge_result = abstract_objectt::merge(
+        default_abstract_object, entry.m, merge_location, widen_mode);
+      modified = true;
+      map.insert(entry.k, merge_result.object);
+    }
+  }
+
+  // This is similar to the above for-loop, but this time, we compute the delta
+  // view between map and env.map (as opposed to between env.map and map). In
+  // this loop, we want to process those entries whose keys only exist in
+  // env.map but are missing from map.
+  for(const auto &entry : map.get_delta_view(env.map, false))
+  {
+    if (!entry.is_in_both_maps())
+    {
+      INVARIANT(
+        map.has_key(entry.k),
+        "When the merge function is invoked, map must contain the key entry.k");
+      abstract_object_pointert default_abstract_object =
+        object_factory->get_abstract_object_declaration(
+          (entry.m)->type(), nil_exprt(), *this, namespacet(nullptr, nullptr));
+      auto merge_result =
+        abstract_objectt::merge(entry.m, default_abstract_object, merge_location, widen_mode);
+      modified |= merge_result.modified;
+      map.replace(entry.k, merge_result.object);
+    }
   }
 
   return modified;
@@ -470,6 +706,24 @@ abstract_object_pointert abstract_environmentt::eval_expression(
   auto operands = eval_operands(e, *this, ns);
 
   return eval_obj->expression_transform(e, operands, *this, ns);
+}
+
+abstract_object_pointert abstract_environmentt::assign_eval_expression(
+  const abstract_object_pointert &lhs_abstract_object,
+  const exprt &lhs,
+  const exprt &rhs,
+  const namespacet &ns) const
+{
+  // We create a temporary top abstract object (according to the
+  // type of the expression), and call expression transform on it.
+  // The value of the temporary abstract object is ignored, its
+  // purpose is just to dispatch the expression transform call to
+  // a concrete subtype of abstract_objectt.
+  auto eval_obj = abstract_object_factory(rhs.type(), ns, true, false);
+  auto operands = eval_operands(rhs, *this, ns);
+
+  return eval_obj->assign_expression_transform(
+    lhs_abstract_object, lhs, rhs, operands, *this, ns);
 }
 
 void abstract_environmentt::erase(const symbol_exprt &expr)

--- a/src/analyses/variable-sensitivity/abstract_environment.h
+++ b/src/analyses/variable-sensitivity/abstract_environment.h
@@ -50,7 +50,7 @@ public:
   {
   }
 
-  /// These three are really the heart of the method
+  /// These four are really the heart of the method
 
   /// Evaluate the value of an expression relative to the current domain
   ///
@@ -60,6 +60,12 @@ public:
   /// \return The abstract_object representing the value of the expression
   virtual abstract_object_pointert
   eval(const exprt &expr, const namespacet &ns) const;
+
+  // assign_eval is the same as eval, except that assign_eval takes in not only
+  // the right-hand side but also the left-hand side of an assignment. This will
+  // be used for the abstract interpretation of monotonic change.
+  virtual abstract_object_pointert
+  assign_eval(const code_assignt &inst, const namespacet &ns) const;
 
   /// Assign a value to an expression
   ///
@@ -142,6 +148,34 @@ public:
   ///
   /// \param expr:  A symbol to delete from the map
   void erase(const symbol_exprt &expr);
+
+  // Compute the abstract value of the left-hand side of an assignment. If the
+  // left-hand side is a variable, its abstract value can be immediately found
+  // in the variable "map," which stores the abstract environment. Otherwise, if
+  // the left-hand side is an array element (e.g. arr[42]) or a struct member
+  // (e.g. struct.x), we need to dig deeper to compute its abstract value.
+  abstract_object_pointert
+  work_out_lhs(const exprt &expr, const namespacet &ns) const;
+
+  // Create an appropriate abstract object when a variable is declared in GOTO
+  // code. In most cases, it is equivalent to abstract_object_factory(type, ns,
+  // true, false). However, in the case of MONOTONIC_CHANGE, it must be treated
+  // differently.
+  abstract_object_pointert abstract_declared_object_factory(
+    const typet &type,
+    const exprt &e,
+    const namespacet &ns) const;
+
+  // Create an appropriate abstract object for an assignment where we do not
+  // care about the right-hand side. This function is used when we have a symbol
+  // or a constant on the right-hand side. In most cases, it is equivalent to
+  // abstract_object_factory(type, ns, true, false). However, in the case of
+  // MONOTONIC_CHANGE, it must be treated differently.
+  abstract_object_pointert abstract_object_factory_arbitrary_assignment(
+    const abstract_object_pointert &lhs_abstract_object,
+    const typet &type,
+    const exprt &e,
+    const namespacet &ns) const;
 
   /// Look at the configuration for the sensitivity and create an
   /// appropriate abstract_object
@@ -255,6 +289,16 @@ protected:
   // We may need to break out more of these cases into these
   virtual abstract_object_pointert
   eval_expression(const exprt &e, const namespacet &ns) const;
+
+  // assign_eval_expression is the same as eval_expressoin, except that the
+  // former is tailored to assignments. Specifically, it takes in two additinoal
+  // arguments: (i) the left-hand side's abstract object and (ii) the left-hand
+  // side's expression.
+  virtual abstract_object_pointert assign_eval_expression(
+    const abstract_object_pointert &lhs_abstract_object,
+    const exprt &lhs,
+    const exprt &rhs,
+    const namespacet &ns) const;
 
   abstract_object_pointert
   resolve_symbol(const exprt &e, const namespacet &ns) const;

--- a/src/analyses/variable-sensitivity/abstract_object.cpp
+++ b/src/analyses/variable-sensitivity/abstract_object.cpp
@@ -141,6 +141,25 @@ abstract_object_pointert abstract_objectt::expression_transform(
   return environment.abstract_object_factory(copy.type(), copy, ns);
 }
 
+abstract_object_pointert abstract_objectt::assign_expression_transform(
+  const abstract_object_pointert &lhs_abstract_object,
+  const exprt &lhs,
+  const exprt &rhs,
+  const std::vector<abstract_object_pointert> &operands,
+  const abstract_environmentt &environment,
+  const namespacet &ns) const
+{
+  return expression_transform(rhs, operands, environment, ns);
+}
+
+abstract_object_pointert abstract_objectt::read(
+  const abstract_environmentt &environment,
+  const exprt &specifier,
+  const namespacet &ns) const
+{
+  return environment.abstract_object_factory(type(), ns, false, true);
+}
+
 abstract_object_pointert abstract_objectt::write(
   abstract_environmentt &environment,
   const namespacet &ns,

--- a/src/analyses/variable-sensitivity/abstract_object.h
+++ b/src/analyses/variable-sensitivity/abstract_object.h
@@ -160,6 +160,18 @@ public:
     const abstract_environmentt &environment,
     const namespacet &ns) const;
 
+  // assign_expression_transform is almost identical to expression_transform,
+  // except that the former is tailored to assignments. Specifically,
+  // assign_expression_transform takes in two additional arguments: (i) the
+  // left-hand side's abstract object and (ii) the left-hand side's expression.
+  virtual abstract_object_pointert assign_expression_transform(
+    const abstract_object_pointert &lhs_abstract_object,
+    const exprt &lhs,
+    const exprt &rhs,
+    const std::vector<abstract_object_pointert> &operands,
+    const abstract_environmentt &environment,
+    const namespacet &ns) const;
+
   /// Converts to a constant expression if possible
   ///
   /// \return Returns an exprt representing the value if the value is known and
@@ -205,6 +217,20 @@ public:
     const exprt &specifier,
     const abstract_object_pointert &value,
     bool merging_write) const;
+
+  // This function reads a component of an abstract object. For instance,
+  // suppose we want to read the abstract object of coordinate.x, where
+  // "coordinate" is a structure with two components (i.e. x and y), and x is a
+  // component. We first compute the abstract value of "coordinate." We then use
+  // the function "read" to extract the x-component of coordinate's abstract
+  // value. Why do we want to read an abstract object a structure's component?
+  // For MONOTONIC_CHANGE, in an assignment, we need to know the abstract object
+  // of the left-hand side. If the left-hand side is a struct's component, then
+  // we need to use the function "read."
+  virtual abstract_object_pointert read(
+    const abstract_environmentt &environment,
+    const exprt &specifier,
+    const namespacet &ns) const;
 
   /// Print the value of the abstract object
   ///
@@ -476,6 +502,7 @@ protected:
   void set_top()
   {
     top = true;
+    bottom = false;
     this->set_top_internal();
   }
   void set_not_top()

--- a/src/analyses/variable-sensitivity/abstract_pointer_object.cpp
+++ b/src/analyses/variable-sensitivity/abstract_pointer_object.cpp
@@ -62,6 +62,15 @@ abstract_object_pointert abstract_pointer_objectt::expression_transform(
     expr, operands, environment, ns);
 }
 
+abstract_object_pointert abstract_pointer_objectt::read(
+  const abstract_environmentt &environment,
+  const exprt &expr,
+  const namespacet &ns) const
+{
+  PRECONDITION(is_dereference(expr));
+  return read_dereference(environment, ns);
+}
+
 abstract_object_pointert abstract_pointer_objectt::write(
   abstract_environmentt &environment,
   const namespacet &ns,

--- a/src/analyses/variable-sensitivity/abstract_pointer_object.h
+++ b/src/analyses/variable-sensitivity/abstract_pointer_object.h
@@ -48,6 +48,11 @@ public:
     const abstract_environmentt &environment,
     const namespacet &ns) const override;
 
+  abstract_object_pointert read(
+    const abstract_environmentt &environment,
+    const exprt &expr,
+    const namespacet &ns) const override;
+
   abstract_object_pointert write(
     abstract_environmentt &environment,
     const namespacet &ns,

--- a/src/analyses/variable-sensitivity/abstract_value_object.cpp
+++ b/src/analyses/variable-sensitivity/abstract_value_object.cpp
@@ -11,6 +11,7 @@
 #include <analyses/variable-sensitivity/constant_abstract_value.h>
 #include <analyses/variable-sensitivity/context_abstract_object.h>
 #include <analyses/variable-sensitivity/interval_abstract_value.h>
+#include <analyses/variable-sensitivity/monotonic_change.h>
 #include <analyses/variable-sensitivity/value_set_abstract_object.h>
 
 #include <goto-programs/adjust_float_expressions.h>
@@ -156,6 +157,32 @@ bool any_intervals(const std::vector<abstract_object_pointert> &operands)
   return any_of_type<interval_abstract_valuet>(operands);
 }
 
+// Ideally, the implementation of this function should be just
+// return any_of_type<monotonic_changet>(operands);
+// However, this causes an error when we run
+// goto-cc toy.c -o toy.goto
+// goto-analyzer --function main --vsd --vsd-values --monotonic-change
+// --show toy.goto
+// in the following C code:
+// int main()
+// {
+//   int x = 0;
+//   int y = (x + 1) * (x - 1);
+// }
+bool any_monotonic_changes(
+  const std::vector<abstract_object_pointert> &operands)
+{
+  // return any_of_type<monotonic_changet>(operands);
+  return std::find_if(
+           operands.begin(),
+           operands.end(),
+           [](const abstract_object_pointert &p) {
+             return (
+               std::dynamic_pointer_cast<const monotonic_changet>(p) !=
+               nullptr);
+           }) != operands.end();
+}
+
 static abstract_object_pointert transform(
   const exprt &expr,
   const std::vector<abstract_object_pointert> &operands,
@@ -166,7 +193,26 @@ static abstract_object_pointert transform(
     return value_set_expression_transform(expr, operands, environment, ns);
   if(any_intervals(operands))
     return intervals_expression_transform(expr, operands, environment, ns);
+  if(any_monotonic_changes(operands))
+    return monotonic_change_expression_transform(nullptr, nil_exprt(), expr);
   return constants_expression_transform(expr, operands, environment, ns);
+}
+
+static abstract_object_pointert assign_transform(
+  const abstract_object_pointert &lhs_abstract_object,
+  const exprt &lhs,
+  const exprt &rhs,
+  const std::vector<abstract_object_pointert> &operands,
+  const abstract_environmentt &environment,
+  const namespacet &ns)
+{
+  if(any_value_sets(operands))
+    return value_set_expression_transform(rhs, operands, environment, ns);
+  if(any_intervals(operands))
+    return intervals_expression_transform(rhs, operands, environment, ns);
+  if(any_monotonic_changes(operands))
+    return monotonic_change_expression_transform(lhs_abstract_object, lhs, rhs);
+  return constants_expression_transform(rhs, operands, environment, ns);
 }
 
 abstract_object_pointert abstract_value_objectt::expression_transform(
@@ -176,6 +222,26 @@ abstract_object_pointert abstract_value_objectt::expression_transform(
   const namespacet &ns) const
 {
   return transform(expr, operands, environment, ns);
+}
+
+abstract_object_pointert abstract_value_objectt::assign_expression_transform(
+  const abstract_object_pointert &lhs_abstract_object,
+  const exprt &lhs,
+  const exprt &rhs,
+  const std::vector<abstract_object_pointert> &operands,
+  const abstract_environmentt &environment,
+  const namespacet &ns) const
+{
+  return assign_transform(
+    lhs_abstract_object, lhs, rhs, operands, environment, ns);
+}
+
+abstract_object_pointert abstract_value_objectt::read(
+  const abstract_environmentt &environment,
+  const exprt &specifier,
+  const namespacet &ns) const
+{
+  UNREACHABLE; // Should not ever call read on a value;
 }
 
 abstract_object_pointert abstract_value_objectt::write(
@@ -690,6 +756,141 @@ static abstract_object_pointert value_set_expression_transform(
   const namespacet &ns)
 {
   auto evaluator = value_set_evaluator(expr, operands, environment, ns);
+  return evaluator();
+}
+
+///////////////////////////////////////////////////////
+// Monotonic change expression transform
+class monotonic_change_evaluatort
+{
+public:
+  monotonic_change_evaluatort(
+    const abstract_object_pointert &l_object,
+    const exprt &l_expr,
+    const exprt &r_expr)
+    : lhs_abstract_object(l_object), lhs(l_expr), rhs(r_expr)
+  {
+    // PRECONDITION(rhs.operands().size() == operands.size());
+  }
+
+  abstract_object_pointert operator()() const
+  {
+    return transform(rhs);
+  }
+
+private:
+  using interval_abstract_value_pointert =
+    sharing_ptrt<const interval_abstract_valuet>;
+
+  abstract_object_pointert transform(const exprt &expr) const
+  {
+    // If we do not know the abstract object of the left-hand side of an
+    // assignment, we simply return the "top."
+    if(lhs_abstract_object == nullptr)
+      return make_top<monotonic_changet>(expr.type());
+
+    std::shared_ptr<const monotonic_changet> lhs_abstract_object_unwrapped =
+      std::dynamic_pointer_cast<const monotonic_changet>(
+        lhs_abstract_object->unwrap_context());
+
+    // If the left-hand side of an assignment is not a monotonic-change object,
+    // we simply return the "top." Can such a situation arise?
+    if(lhs_abstract_object_unwrapped == nullptr)
+      return make_top<monotonic_changet>(expr.type());
+
+    monotonicity_flags mvalue =
+      lhs_abstract_object_unwrapped->monotonicity_value;
+
+    // This case handles an assignment whose right-hand side is a ternary
+    // expression; e.g. x := bool_expr ? (x + 1) : (x - 1).
+    if(expr.id() == ID_if)
+    {
+      return evaluate_conditional();
+    }
+
+    // This case handles an assignment of the form x := x + n or x
+    // := x - n, where x is an lvalue and n is a constant number. When C is
+    // compiled to GOTO, x++ is translated to x := x + 1. Likewise, x-- is
+    // translated to x := x - 1. Hence, we do not need to be concerned with x++
+    // and x-- - we can focus on assignments of the form x := x + n and x := x -
+    // n.
+    // Is it correct to use == to test the equality of two expressions?
+    if(
+      (expr.id() == ID_plus || expr.id() == ID_minus) &&
+      expr.operands()[1].id() == ID_constant && expr.operands()[0] == lhs)
+    {
+      mp_integer constant_value =
+        numeric_cast_v<mp_integer>(to_constant_expr(expr.operands()[1]));
+
+      switch(mvalue)
+      {
+      case top_or_bottom:
+        if(lhs_abstract_object_unwrapped->is_bottom())
+          return std::make_shared<monotonic_changet>(expr.type(), false, true);
+        else
+          return make_top<monotonic_changet>(expr.type());
+        break;
+      case strict_increase:
+        if(
+          (expr.id() == ID_plus && constant_value >= 0) ||
+          (expr.id() == ID_minus && constant_value <= 0))
+          return std::make_shared<monotonic_changet>(
+            expr.type(), false, false, strict_increase);
+        else
+          return make_top<monotonic_changet>(expr.type());
+        break;
+      case unchanged:
+        if(
+          (expr.id() == ID_plus && constant_value > 0) ||
+          (expr.id() == ID_minus && constant_value < 0))
+          return std::make_shared<monotonic_changet>(
+            expr.type(), false, false, strict_increase);
+        else if(constant_value == 0)
+          return std::make_shared<monotonic_changet>(
+            expr.type(), false, false, unchanged);
+        else
+          return std::make_shared<monotonic_changet>(
+            expr.type(), false, false, strict_decrease);
+        break;
+      case strict_decrease:
+        if(
+          (expr.id() == ID_plus && constant_value <= 0) ||
+          (expr.id() == ID_minus && constant_value >= 0))
+          return std::make_shared<monotonic_changet>(
+            expr.type(), false, false, strict_decrease);
+        else
+          return make_top<monotonic_changet>(expr.type());
+        break;
+      }
+    }
+
+    return make_top<monotonic_changet>(expr.type());
+  }
+
+  abstract_object_pointert evaluate_conditional() const
+  {
+    const exprt &true_branch_expr = rhs.operands()[1];
+    const exprt &false_branch_expr = rhs.operands()[2];
+    abstract_object_pointert true_abstract_object = transform(true_branch_expr);
+    abstract_object_pointert false_abstract_object =
+      transform(false_branch_expr);
+
+    return abstract_objectt::merge(
+             true_abstract_object, false_abstract_object, widen_modet::no)
+      .object;
+  }
+
+  const abstract_object_pointert &lhs_abstract_object;
+  const exprt &lhs;
+  const exprt &rhs;
+};
+
+abstract_object_pointert monotonic_change_expression_transform(
+  const abstract_object_pointert &lhs_abstract_object,
+  const exprt &lhs,
+  const exprt &rhs)
+{
+  auto evaluator = monotonic_change_evaluatort(lhs_abstract_object, lhs, rhs);
   return evaluator();
 }
 

--- a/src/analyses/variable-sensitivity/abstract_value_object.h
+++ b/src/analyses/variable-sensitivity/abstract_value_object.h
@@ -287,8 +287,21 @@ public:
     const abstract_environmentt &environment,
     const namespacet &ns) const final;
 
+  abstract_object_pointert assign_expression_transform(
+    const abstract_object_pointert &lhs_abstract_object,
+    const exprt &lhs,
+    const exprt &rhs,
+    const std::vector<abstract_object_pointert> &operands,
+    const abstract_environmentt &environment,
+    const namespacet &ns) const final;
+
   virtual sharing_ptrt<const abstract_value_objectt>
   constrain(const exprt &lower, const exprt &upper) const = 0;
+
+  abstract_object_pointert read(
+    const abstract_environmentt &environment,
+    const exprt &specifier,
+    const namespacet &ns) const final;
 
   abstract_object_pointert write(
     abstract_environmentt &environment,
@@ -331,6 +344,11 @@ protected:
   sharing_ptrt<const abstract_value_objectt>
   as_value(const abstract_object_pointert &obj) const;
 };
+
+abstract_object_pointert monotonic_change_expression_transform(
+  const abstract_object_pointert &lhs_abstract_object,
+  const exprt &lhs,
+  const exprt &rhs);
 
 using abstract_value_pointert = sharing_ptrt<const abstract_value_objectt>;
 

--- a/src/analyses/variable-sensitivity/context_abstract_object.cpp
+++ b/src/analyses/variable-sensitivity/context_abstract_object.cpp
@@ -34,6 +34,14 @@ void context_abstract_objectt::set_not_top_internal()
     set_child(child_abstract_object->clear_top());
 }
 
+abstract_object_pointert context_abstract_objectt::read(
+  const abstract_environmentt &environment,
+  const exprt &specifier,
+  const namespacet &ns) const
+{
+  return child_abstract_object->read(environment, specifier, ns);
+}
+
 /**
  * A helper function to evaluate writing to a component of an
  * abstract object. More precise abstractions may override this to
@@ -114,6 +122,38 @@ abstract_object_pointert context_abstract_objectt::write_location_context(
   result->set_child(updated_child);
 
   return result;
+}
+
+// assign_expression_transform is almost identical to expression_transform,
+// except that the former is tailored to assignments. Specifically,
+// assign_expression_transform takes in two additional arguments: (i) the
+// left-hand side's abstract object and (ii) the left-hand side's expression.
+abstract_object_pointert context_abstract_objectt::assign_expression_transform(
+  const abstract_object_pointert &lhs_abstract_object,
+  const exprt &lhs,
+  const exprt &rhs,
+  const std::vector<abstract_object_pointert> &operands,
+  const abstract_environmentt &environment,
+  const namespacet &ns) const
+{
+  PRECONDITION(rhs.operands().size() == operands.size());
+
+  std::vector<abstract_object_pointert> child_operands;
+
+  std::transform(
+    operands.begin(),
+    operands.end(),
+    std::back_inserter(child_operands),
+    [](const abstract_object_pointert &op) {
+      PRECONDITION(op != nullptr);
+      auto p = std::dynamic_pointer_cast<const context_abstract_objectt>(op);
+      INVARIANT(p, "Operand shall be of type context_abstract_objectt");
+      return p->child_abstract_object;
+    });
+
+  auto result = child_abstract_object->assign_expression_transform(
+    lhs_abstract_object, lhs, rhs, child_operands, environment, ns);
+  return envelop(result);
 }
 
 abstract_object_pointert

--- a/src/analyses/variable-sensitivity/context_abstract_object.h
+++ b/src/analyses/variable-sensitivity/context_abstract_object.h
@@ -92,6 +92,18 @@ public:
   abstract_object_pointert
   write_location_context(const locationt &location) const override;
 
+  // assign_expression_transform is almost identical to expression_transform,
+  // except that the former is tailored to assignments. Specifically,
+  // assign_expression_transform takes in two additional arguments: (i) the
+  // left-hand side's abstract object and (ii) the left-hand side's expression.
+  abstract_object_pointert assign_expression_transform(
+    const abstract_object_pointert &lhs_abstract_object,
+    const exprt &lhs,
+    const exprt &rhs,
+    const std::vector<abstract_object_pointert> &operands,
+    const abstract_environmentt &environment,
+    const namespacet &ns) const override;
+
   void output(std::ostream &out, const class ai_baset &ai, const namespacet &ns)
     const override;
 
@@ -119,6 +131,11 @@ protected:
   // actions when an abstract_object is set/unset to TOP
   void set_top_internal() override;
   void set_not_top_internal() override;
+
+  abstract_object_pointert read(
+    const abstract_environmentt &environment,
+    const exprt &specifier,
+    const namespacet &ns) const override;
 
   abstract_object_pointert write(
     abstract_environmentt &environment,

--- a/src/analyses/variable-sensitivity/full_struct_abstract_object.cpp
+++ b/src/analyses/variable-sensitivity/full_struct_abstract_object.cpp
@@ -82,13 +82,15 @@ abstract_object_pointert full_struct_abstract_objectt::read_component(
   std::cout << "Reading component " << member_expr.get_component_name() << '\n';
 #endif
 
+  const member_exprt &member_expr = to_member_expr(expr);
+
   if(is_top())
   {
-    return environment.abstract_object_factory(expr.type(), ns, true, false);
+    return environment.abstract_declared_object_factory(
+      member_expr.type(), member_expr, ns);
   }
   else
   {
-    const member_exprt &member_expr = to_member_expr(expr);
     PRECONDITION(!is_bottom());
 
     const irep_idt c = member_expr.get_component_name();
@@ -101,8 +103,8 @@ abstract_object_pointert full_struct_abstract_objectt::read_component(
     }
     else
     {
-      return environment.abstract_object_factory(
-        member_expr.type(), ns, true, false);
+      return environment.abstract_declared_object_factory(
+        member_expr.type(), member_expr, ns);
     }
   }
 }

--- a/src/analyses/variable-sensitivity/monotonic_change.cpp
+++ b/src/analyses/variable-sensitivity/monotonic_change.cpp
@@ -1,0 +1,295 @@
+/*******************************************************************\
+
+ Module: Abstract interpretation for strict and monotonic change
+
+ Authors: Long Pham, Saswat Padhi
+
+\*******************************************************************/
+
+// For the documentation of the class monotonic_changet, have a look at
+// the header file monotonic_change.h.
+
+#include <langapi/language_util.h>
+
+#include <util/interval.h>
+#include <util/std_expr.h>
+
+#include "abstract_object_statistics.h"
+#include "monotonic_change.h"
+
+monotonic_changet::monotonic_changet(const typet &t)
+  : abstract_value_objectt(t, false, false), monotonicity_value(unchanged)
+{
+}
+
+monotonic_changet::monotonic_changet(const typet &t, bool tp, bool bttm)
+  : abstract_value_objectt(t, tp, bttm),
+    monotonicity_value((tp || bttm) ? top_or_bottom : unchanged)
+{
+}
+
+monotonic_changet::monotonic_changet(
+  const typet &t,
+  bool tp,
+  bool bttm,
+  monotonicity_flags initial_value)
+  : abstract_value_objectt(t, tp, bttm),
+    monotonicity_value((tp || bttm) ? top_or_bottom : initial_value)
+{
+}
+
+monotonic_changet::monotonic_changet(
+  const exprt &e,
+  const abstract_environmentt &environment,
+  const namespacet &ns)
+  : abstract_value_objectt(e.type(), false, false), monotonicity_value(unchanged)
+{
+}
+
+index_range_implementation_ptrt
+monotonic_changet::index_range_implementation(const namespacet &ns) const
+{
+  return make_empty_index_range();
+}
+
+value_range_implementation_ptrt
+monotonic_changet::value_range_implementation() const
+{
+  return make_single_value_range(shared_from_this());
+}
+
+constant_interval_exprt monotonic_changet::to_interval() const
+{
+  return constant_interval_exprt(type());
+}
+
+void monotonic_changet::set_top_internal()
+{
+  monotonicity_value = top_or_bottom;
+}
+
+void monotonic_changet::output(
+  std::ostream &out,
+  const ai_baset &ai,
+  const namespacet &ns) const
+{
+  if(is_top() || is_bottom())
+    abstract_objectt::output(out, ai, ns);
+  else
+  {
+    switch(monotonicity_value)
+    {
+    case strict_increase:
+      out << "Strictly and monotonically increasing";
+      break;
+    case strict_decrease:
+      out << "Strictly and monotonically decreasing";
+      break;
+    case unchanged:
+      out << "Staying unchanged";
+      break;
+    case top_or_bottom:
+      // fall through
+    default:
+      UNREACHABLE;
+    }
+  }
+}
+
+abstract_object_pointert monotonic_changet::merge_with_value(
+  const abstract_value_pointert &other,
+  const widen_modet &widen_mode) const
+{
+  auto other_monotonic_change =
+    std::dynamic_pointer_cast<const monotonic_changet>(other);
+  if(other_monotonic_change != nullptr)
+    return merge_with_monotonic_change(other_monotonic_change);
+  else
+    return abstract_objectt::merge(other, widen_mode);
+}
+
+
+/*
+The result of merging two abstract states is given by the join (i.e. least upper
+bound) of this lattice:
+              top
+           /   |   \
+          /    |    \
+         /     |     \
+        /      |      \
+increase   unchanged  decrease
+       \       |      /
+        \      |     /
+         \     |    /
+           \   |   /
+            bottom
+*/
+abstract_object_pointert monotonic_changet::merge_with_monotonic_change(
+  const sharing_ptrt<const monotonic_changet> &other) const
+{
+  if(this->is_bottom() || other->is_top())
+    return std::make_shared<const monotonic_changet>(*other);
+  if(this->is_top() || other->is_bottom())
+    return shared_from_this();
+
+  if(this->monotonicity_value == strict_increase)
+  {
+    switch(other->monotonicity_value)
+    {
+    case strict_increase:
+      // If the result of merge is semantically the same as the current abstract
+      // value, then we should return shared_from_this(), instead of a distinct
+      // copy of the same abstract value. This is because, in the function
+      // abstract_objectt::merge, to check whether merging changes the abstract
+      // value, we compare pointers rather than the contents of abstract
+      // objects. This is important for widening in fixed-point computation in
+      // abstract interpretation. If we inadvertently returned a new copy of the
+      // same abstract value, the widening for loops would diverge (i.e.
+      // non-termination).
+      return shared_from_this();
+    case unchanged:
+      // fall through
+    case strict_decrease:
+      return std::make_shared<monotonic_changet>(
+        this->type(), true, false); // top
+    case top_or_bottom:
+      // fall through
+    default:
+      UNREACHABLE;
+    }
+  }
+  else if(this->monotonicity_value == strict_decrease)
+  {
+    switch(other->monotonicity_value)
+    {
+    case strict_increase:
+      // fall through
+    case unchanged:
+      return std::make_shared<monotonic_changet>(
+        this->type(), true, false); // top
+    case strict_decrease:
+      return shared_from_this();
+    case top_or_bottom:
+      // fall through
+    default:
+      UNREACHABLE;
+    }
+  }
+  else if(this->monotonicity_value == unchanged)
+  {
+    switch(other->monotonicity_value)
+    {
+    case strict_increase:
+      return std::make_shared<monotonic_changet>(
+        this->type(), true, false); // top
+    case unchanged:
+      return shared_from_this();
+    case strict_decrease:
+      return std::make_shared<monotonic_changet>(
+        this->type(), true, false); // top
+    case top_or_bottom:
+      // fall through
+    default:
+      UNREACHABLE;
+    }
+  }
+  else // this->monotonicity_value == top_or_bottom
+    UNREACHABLE;
+
+  // We return the top by default.
+  return std::make_shared<monotonic_changet>(this->type(), true, false);
+}
+
+abstract_object_pointert
+monotonic_changet::meet_with_value(const abstract_value_pointert &other) const
+{
+  auto other_monotonic_change =
+    std::dynamic_pointer_cast<const monotonic_changet>(other);
+  if(other_monotonic_change != nullptr)
+    return meet_with_monotonic_change(other_monotonic_change);
+  else
+    return abstract_objectt::meet(other);
+}
+
+abstract_object_pointert monotonic_changet::meet_with_monotonic_change(
+  const sharing_ptrt<const monotonic_changet> &other) const
+{
+  if(this->is_bottom() || other->is_top())
+    return shared_from_this();
+  if(this->is_top() || other->is_bottom())
+    return std::make_shared<monotonic_changet>(*other);
+
+  if(this->monotonicity_value == strict_increase)
+  {
+    switch(other->monotonicity_value)
+    {
+    case strict_increase:
+      return shared_from_this();
+    case unchanged:
+      // fall through
+    case strict_decrease:
+      return std::make_shared<monotonic_changet>(
+        this->type(), false, true); // bottom
+    case top_or_bottom:
+      // fall through
+    default:
+      UNREACHABLE;
+    }
+  }
+  else if(this->monotonicity_value == unchanged)
+  {
+    switch(other->monotonicity_value)
+    {
+    case strict_increase:
+      return std::make_shared<monotonic_changet>(
+        this->type(), false, true); // bottom
+    case unchanged:
+      return shared_from_this();
+    case strict_decrease:
+      return std::make_shared<monotonic_changet>(
+        this->type(), false, true); // bottom
+    case top_or_bottom:
+      // fall through
+    default:
+      UNREACHABLE;
+    }
+  }
+  else if(this->monotonicity_value == strict_decrease)
+  {
+    switch(other->monotonicity_value)
+    {
+    case strict_increase:
+      // fall through
+    case unchanged:
+      return std::make_shared<monotonic_changet>(
+        this->type(), false, true);
+    case strict_decrease:
+      return shared_from_this();
+    case top_or_bottom:
+      // fall through
+    default:
+      UNREACHABLE;
+    }
+  }
+  else
+    UNREACHABLE;
+
+  // We return the bottom by default.
+  return std::make_shared<monotonic_changet>(this->type(), false, true);
+}
+
+abstract_value_pointert
+monotonic_changet::constrain(const exprt &lower, const exprt &upper) const
+{
+  return as_value(mutable_clone());
+}
+
+void monotonic_changet::get_statistics(
+  abstract_object_statisticst &statistics,
+  abstract_object_visitedt &visited,
+  const abstract_environmentt &env,
+  const namespacet &ns) const
+{
+  abstract_objectt::get_statistics(statistics, visited, env, ns);
+  statistics.objects_memory_usage += memory_sizet::from_bytes(sizeof(*this));
+}

--- a/src/analyses/variable-sensitivity/monotonic_change.h
+++ b/src/analyses/variable-sensitivity/monotonic_change.h
@@ -1,0 +1,209 @@
+/*******************************************************************\
+
+ Module: Abstract interpretation for strict and monotonic change
+
+ Authors: Long Pham, Saswat Padhi
+
+\*******************************************************************/
+
+// We have based this class on constant_abstract_value.h. We are grateful to its
+// authors.
+
+/*
+Overview:
+This abstract interpretation checks whether variables have "strictly" and
+"monotonically" increased/decreased since the beginning of given GOTO code. In
+this context, "strict" means the increase/decrease is strict - it is NOT allowed
+to stay unchanged. "Monotonic" means the variable keeps increasing (or
+decreasing) within a loop body. If a variable increases at first and then starts
+decreasing, this abstract interpretation cannot tell the overall change of the
+variable. 
+
+In another context, the word "monotonicity" refers to the fact that a candidate
+decreases clause must strictly decrease in "all" iterations of the loop. So we
+have two kinds of "monotonicity": (i) the monotonicity of the decreases clause
+within a single loop iteration/body and (ii) the monotonicity of the
+decreases clause across all iterations of the loop at run time. When there is a
+risk of confusion, I will try to distinguish between these two kinds of
+"monotonicity." However, usually, I will refer to monotonicity "within" a loop
+iteration/body.
+
+Motivation:
+We will use this abstract interpretation in the automatic inference of decreases
+clauses (aka ranking functions or loop variants). For example, consider a
+while-loop whose loop guard is x < y, where x and y are variables. If we know
+that x strictly increases in the loop body and that y stays unchanged, we can
+successfully infer that y - x is a correct decreases clause.
+
+Example: 
+For illustration, consider the following GOTO code:
+DECL x
+ASSIGN x := x + 1
+ASSIGN x := x - 1
+
+Immediately after the declaration of x, the abstract value of x is
+"unchanged." This means variable x has stayed unchanged since the "beginning" of
+the code.
+
+Next, after executing the command x++, the abstract value of x is "strict
+increase." It means variable x has been strictly and monotonically increasing
+since the "beginning" of the code.
+
+Finally, we execute x-- after x++. Unlike interval analysis, this predicate
+abstraction does NOT keep track of how much x has changed. Instead, it only
+keeps track of the current strict-and-monotonic-change-status (i.e. the current
+abstract value) of x. Hence, in the above example, we cannot tell the net effect
+on x after x--. Consequently, after x--, the abstract value of x is "top"; i.e.
+we know nothing about x. 
+
+Abstract domain:
+The class monotonic_changet inherits from the class abstract_value_objectt. This
+makes sense because abstract interpretation is a special case of abstract
+interpretation. The base class abstract_value_objectt already contains two
+abstract values:
+(i) top (i.e. inconclusive)
+(ii) bottom (i.e. infeasible). 
+These are the top and bottom elements of a lattice, respectively.
+
+In addition to these two values, monotonic_changet has the following abstract
+values:
+(iii) strict monotonic increase
+(iv) strict monotonic decrease
+(v) unchanged.
+
+The Hasse diagram of this abstract domain is displayed below.
+              top
+           /   |   \
+          /    |    \
+         /     |     \
+        /      |      \
+increase   unchanged  decrease
+       \       |      /
+        \      |     /
+         \     |    /
+           \   |   /
+            bottom
+
+Technical challenge: 
+Existing derived classes of abstract_value_objectt include
+(i) constant_abstract_valuet, 
+(ii) interval_abstract_valuet, and
+(iii) value_set_abstract_objectt. 
+When computing the abstract value of an assignment, these classes only need to
+consider the right-hand side of the assignment. Put simply, these abstract
+interpretation are "non-relational." By contrast, monotonic_changet needs to
+know not only the right-hand side but also the left-hand side. 
+
+For example, consider two assignments: x := x + 1 and x := y + 1. For the
+existing derived classes of abstract_value_objectt, x's abstract value after
+this assignment can be computed by just looking at the right-hand side.
+
+On the other hand, monotonic_changet cannot computer x's abstract value by
+looking at the right-hand side in isolation. It needs to check whether the
+variable being incremented is the same as the variable on the left-hand side.
+Furthermore, it needs to know the current abstract value of x. If x's current
+abstract value is "unchanged," x := x + 1 will change x's abstract value to
+"monotonic increase." Instead, if x's current abstract value is "monotonic
+decrease," x := x + 1 will change the abstract value to "top."
+
+In this way, to compute the abstract value of an assignment, we need information
+about the left-hand side. As a consequence, to implement this predicate
+abstraction, we have made fairly extensive modification to the existing code
+base.
+*/
+
+#ifndef CPROVER_ANALYSES_VARIABLE_SENSITIVITY_MONOTONIC_CHANGE_H
+#define CPROVER_ANALYSES_VARIABLE_SENSITIVITY_MONOTONIC_CHANGE_H
+
+#include <iosfwd>
+
+#include <analyses/variable-sensitivity/abstract_value_object.h>
+
+enum monotonicity_flags
+{
+  strict_increase,
+  strict_decrease,
+  unchanged,
+  // We can tell whether it is top or bottom by is_top() and is_bottom(), which
+  // are inherited from abstract_objectt.
+  top_or_bottom
+};
+
+class monotonic_changet : public abstract_value_objectt
+{
+public:
+  explicit monotonic_changet(const typet &t);
+  monotonic_changet(const typet &t, bool tp, bool bttm);
+  monotonic_changet(
+    const typet &t,
+    bool tp,
+    bool bttm,
+    monotonicity_flags initial_value);
+  monotonic_changet(
+    const exprt &e,
+    const abstract_environmentt &environment,
+    const namespacet &ns);
+
+  ~monotonic_changet() override = default;
+
+  index_range_implementation_ptrt
+  index_range_implementation(const namespacet &ns) const override;
+
+  value_range_implementation_ptrt value_range_implementation() const override;
+
+  constant_interval_exprt to_interval() const override;
+
+  abstract_value_pointert
+  constrain(const exprt &lower, const exprt &upper) const override;
+
+  void output(
+    std::ostream &out,
+    const class ai_baset &ai,
+    const class namespacet &ns) const override;
+
+  void get_statistics(
+    abstract_object_statisticst &statistics,
+    abstract_object_visitedt &visited,
+    const abstract_environmentt &env,
+    const namespacet &ns) const override;
+
+  size_t internal_hash() const override
+  {
+    return std::hash<int>{}(monotonicity_value);
+  }
+
+  bool internal_equality(const abstract_object_pointert &other) const override
+  {
+    auto cast_other = std::dynamic_pointer_cast<const monotonic_changet>(other);
+    return cast_other && monotonicity_value == cast_other->monotonicity_value;
+  }
+
+  monotonicity_flags monotonicity_value;
+
+protected:
+  CLONE
+
+  /// Merges another abstract value into this one
+  ///
+  /// \param other: the abstract object to merge with
+  /// \param widen_mode: Indicates if this is a widening merge
+  ///
+  /// \return Returns a new abstract object that is the result of the merge
+  ///         unless the merge is the same as this abstract object, in which
+  ///         case it returns this.
+  abstract_object_pointert merge_with_value(
+    const abstract_value_pointert &other,
+    const widen_modet &widen_mode) const override;
+  abstract_object_pointert merge_with_monotonic_change(
+    const sharing_ptrt<const monotonic_changet> &other) const;
+
+  abstract_object_pointert
+  meet_with_value(const abstract_value_pointert &other) const override;
+  abstract_object_pointert meet_with_monotonic_change(
+    const sharing_ptrt<const monotonic_changet> &other) const;
+
+private:
+  void set_top_internal() override;
+};
+
+#endif // CPROVER_ANALYSES_VARIABLE_SENSITIVITY_MONOTONIC_CHANGE_H

--- a/src/analyses/variable-sensitivity/variable_sensitivity_configuration.cpp
+++ b/src/analyses/variable-sensitivity/variable_sensitivity_configuration.cpp
@@ -87,10 +87,22 @@ vsd_configt vsd_configt::intervals()
   return config;
 }
 
+vsd_configt vsd_configt::monotonic_change()
+{
+  vsd_configt config{};
+  config.context_tracking.last_write_context = true;
+  config.value_abstract_type = MONOTONIC_CHANGE;
+  config.pointer_abstract_type = POINTER_SENSITIVE;
+  config.struct_abstract_type = STRUCT_SENSITIVE;
+  config.array_abstract_type = ARRAY_SENSITIVE;
+  return config;
+}
+
 const vsd_configt::option_mappingt vsd_configt::value_option_mappings = {
   {"intervals", INTERVAL},
   {"constants", CONSTANT},
-  {"set-of-constants", VALUE_SET}};
+  {"set-of-constants", VALUE_SET},
+  {"monotonic-change", MONOTONIC_CHANGE}};
 
 const vsd_configt::option_mappingt vsd_configt::pointer_option_mappings = {
   {"top-bottom", POINTER_INSENSITIVE},

--- a/src/analyses/variable-sensitivity/variable_sensitivity_configuration.h
+++ b/src/analyses/variable-sensitivity/variable_sensitivity_configuration.h
@@ -22,6 +22,7 @@ enum ABSTRACT_OBJECT_TYPET
   TWO_VALUE,
   CONSTANT,
   INTERVAL,
+  MONOTONIC_CHANGE,
   ARRAY_SENSITIVE,
   ARRAY_INSENSITIVE,
   VALUE_SET_OF_POINTERS,
@@ -65,6 +66,7 @@ struct vsd_configt
   static vsd_configt constant_domain();
   static vsd_configt value_set();
   static vsd_configt intervals();
+  static vsd_configt monotonic_change();
 
   vsd_configt()
     : value_abstract_type{CONSTANT},

--- a/src/analyses/variable-sensitivity/variable_sensitivity_domain.cpp
+++ b/src/analyses/variable-sensitivity/variable_sensitivity_domain.cpp
@@ -39,14 +39,16 @@ void variable_sensitivity_domaint::transform(
   {
   case DECL:
   {
-    abstract_object_pointert top_object =
+    abstract_object_pointert declared_object =
       abstract_state
-        .abstract_object_factory(
-          instruction.decl_symbol().type(), ns, true, false)
+        .abstract_declared_object_factory(
+          instruction.decl_symbol().type(), instruction.decl_symbol(), ns)
         ->write_location_context(from);
-    abstract_state.assign(instruction.decl_symbol(), top_object, ns);
+    abstract_state.assign(instruction.decl_symbol(), declared_object, ns);
   }
-  // We now store top.
+  // We now store top (for most cases). The only exception is the predicate
+  // abstraction of monotonic change. In that case, an abstract value is
+  // initialized to "unchanged" instead of the top.
   break;
 
   case DEAD:
@@ -60,7 +62,7 @@ void variable_sensitivity_domaint::transform(
     // TODO : check return values
     const code_assignt &inst = instruction.get_assign();
     abstract_object_pointert rhs =
-      abstract_state.eval(inst.rhs(), ns)->write_location_context(from);
+      abstract_state.assign_eval(inst, ns)->write_location_context(from);
     abstract_state.assign(inst.lhs(), rhs, ns);
   }
   break;

--- a/src/analyses/variable-sensitivity/variable_sensitivity_domain.h
+++ b/src/analyses/variable-sensitivity/variable_sensitivity_domain.h
@@ -85,7 +85,7 @@
     // clang-format off
 #define HELP_VSD                                                               \
   " --vsd-values                 value tracking - "                            \
-  "constants|intervals|set-of-constants\n" /* NOLINT(whitespace/line_length) */\
+  "constants|intervals|set-of-constants|monotonic-change\n" /* NOLINT(whitespace/line_length) */ \
   " --vsd-structs                struct field sensitive analysis - "           \
   "top-bottom|every-field\n" /* NOLINT(whitespace/line_length) */              \
   " --vsd-arrays                 array entry sensitive analysis - "            \

--- a/src/analyses/variable-sensitivity/variable_sensitivity_object_factory.h
+++ b/src/analyses/variable-sensitivity/variable_sensitivity_object_factory.h
@@ -20,6 +20,7 @@
 #include <analyses/variable-sensitivity/data_dependency_context.h>
 #include <analyses/variable-sensitivity/full_struct_abstract_object.h>
 #include <analyses/variable-sensitivity/interval_abstract_value.h>
+#include <analyses/variable-sensitivity/monotonic_change.h>
 #include <analyses/variable-sensitivity/two_value_array_abstract_object.h>
 #include <analyses/variable-sensitivity/two_value_pointer_abstract_object.h>
 #include <analyses/variable-sensitivity/two_value_struct_abstract_object.h>
@@ -47,6 +48,54 @@ public:
     : configuration{options}, heap_allocations(0)
   {
   }
+
+  // Return whether the current configuration is for the abstract interpretation
+  // of monotonic change (i.e. MONOTONIC_CHANGE). This information is necessry
+  // when we want to use a function designated to MONOTONIC_CHANGE.
+  bool is_predicate_abstraction(const typet &type, const namespacet &ns) const;
+
+  // Get the appropriate abstract object when a variable is declared in GOTO
+  // code. In most cases, we return the top. Hence, it is equivalent to
+  // get_abstract_object(type, true, false, ...). However, in the case of
+  // MONOTONIC_CHANGE, we return the abstrtact value "unchanged," which is
+  // not the top.
+  abstract_object_pointert get_abstract_object_declaration(
+    const typet &type,
+    const exprt &e,
+    const abstract_environmentt &environment,
+    const namespacet &ns) const;
+
+  // Get an appropriate abstract object for an assginment where we do not care
+  // about the right-hand side. This function is used, for example, when the
+  // right-hand side is a symbol/variable (e.g. x := y) or a constant (x := 42).
+  // If the right-hand side is a more complicated expression (e.g. arithmetic
+  // expressions), then we will examine the right-hand side more closely. For
+  // instance, if the assignment is x := x + 1, we will not invoke this
+  // function, but a different one.
+  //
+  // In most cases (apart from MONOTONIC_CHANGE), this function is equivalent to
+  // get_abstract_object(type, true, false, ...). However, MONOTONIC_CHANGE
+  // may need to be treated differently. In the current implementation of
+  // monotonic-change abstract interpretation, this function simply returns the
+  // top element. Hence, we can safely replace this function with
+  // get_abstract_object(type, true, false, ...). However, in the future, the
+  // monotonic-change abstract interpretation may be extended. For instance, we
+  // may extend the abstract domain of MONOTONIC_CHANGE with one more abstract
+  // value: "declared but uninitialized." This abstract value differs from
+  // "unchanged" as follows. The former indicates that the variable has been
+  // declared but has not been initialized to any value "explicitly" (i.e. by an
+  // ASSIGN instruction). On the other hand, the latter indicates that the
+  // variable has been declared and initialized (implicitly and
+  // non-deterministically), but has not been initialized "explicitly" by a
+  // programmer. In such an extension of the abstract interpretation, an arbitrary
+  // assignment may result in different abstract values, depending on the
+  // current abstract value of the variable.
+  abstract_object_pointert get_abstract_object_arbitrary_assignment(
+    const abstract_object_pointert &lhs_abstract_object,
+    const typet &type,
+    const exprt &rhs,
+    const abstract_environmentt &environment,
+    const namespacet &ns) const;
 
   /// Get the appropriate abstract object for the variable under
   /// consideration.

--- a/src/goto-instrument/contracts/contracts.h
+++ b/src/goto-instrument/contracts/contracts.h
@@ -31,10 +31,21 @@ Date: February 2016
 #include <util/namespace.h>
 #include <util/pointer_expr.h>
 
+#include <util/options.h>
+
+#include <util/ui_message.h>
+
+#include <analyses/ai.h>
+
 #define FLAG_LOOP_CONTRACTS "apply-loop-contracts"
 #define HELP_LOOP_CONTRACTS                                                    \
   " --apply-loop-contracts\n"                                                  \
   "                              check and use loop contracts when provided\n"
+
+#define FLAG_DECREASES_CLAUSES_INFERENCE "infer-decreases-clauses"
+#define HELP_DECREASES_CLAUSES_INFERENCE                                       \
+  " --infer-decreases-clauses\n"                                               \
+  "                              infer decreases clauses for loops without explicit decreases clauses\n"
 
 #define FLAG_REPLACE_CALL "replace-call-with-contract"
 #define HELP_REPLACE_CALL                                                      \
@@ -61,13 +72,17 @@ class replace_symbolt;
 class code_contractst
 {
 public:
-  code_contractst(goto_modelt &goto_model, messaget &log)
+  code_contractst(
+    goto_modelt &goto_model,
+    messaget &log,
+    ui_message_handlert &ui_message_handler)
     : ns(goto_model.symbol_table),
+      goto_model(goto_model),
       symbol_table(goto_model.symbol_table),
       goto_functions(goto_model.goto_functions),
       log(log),
+      ui_message_handler(ui_message_handler),
       converter(symbol_table, log.get_message_handler())
-
   {
   }
 
@@ -114,6 +129,8 @@ public:
   bool replace_calls();
 
   void apply_loop_contracts();
+  
+  void infer_decreases_clauses_in_program();
 
   const symbolt &new_tmp_symbol(
     const typet &type,
@@ -127,17 +144,24 @@ public:
     const loopt &loop,
     const irep_idt &mode);
 
+  void infer_decreases_clause(
+    goto_functionst::goto_functiont &goto_function,
+    goto_programt::targett loop_head,
+    const loopt &loop);
+
   // for "helper" classes to update symbol table.
   symbol_tablet &get_symbol_table();
   goto_functionst &get_goto_functions();
 
   namespacet ns;
+  goto_modelt &goto_model;
 
 protected:
   symbol_tablet &symbol_table;
   goto_functionst &goto_functions;
 
   messaget &log;
+  ui_message_handlert &ui_message_handler;
   goto_convertt converter;
 
   std::unordered_set<irep_idt> summarized;
@@ -191,6 +215,11 @@ protected:
     const irep_idt &function,
     goto_functionst::goto_functiont &goto_function);
 
+  // Attempt to infer decreases clauses for all loops in "function."
+  void infer_decreases_clauses_in_function(
+    const irep_idt &function,
+    goto_functionst::goto_functiont &goto_function);
+
   /// \brief Does the named function have a contract?
   bool has_contract(const irep_idt);
 
@@ -233,6 +262,20 @@ protected:
     codet &expression,
     source_locationt location,
     const irep_idt &mode);
+
+  // Convert a (possibly multidimensional) decreases clause to a string
+  std::string
+  decreases_clause_to_string(const exprt::operandst &decreases_clause_exprs);
+
+  // Construct an analyzer for monotonic-change abstract interpretation.
+  // loop_body_funtion_id is the name of the function that encapsulates a loop
+  // body to be analyzed.
+  std::unique_ptr<ai_baset> build_monotonic_change_analyzer();
+
+  // Preprocess a GOTO program before it is passed to an analyzer for abstract
+  // interpretation. This is identical to the function
+  // goto_analyzer_parse_optionst::process_goto_program.
+  bool preprocess_goto_program(const optionst &options);
 };
 
 #endif // CPROVER_GOTO_INSTRUMENT_CONTRACTS_CONTRACTS_H

--- a/src/goto-instrument/goto_instrument_parse_options.cpp
+++ b/src/goto-instrument/goto_instrument_parse_options.cpp
@@ -1149,12 +1149,14 @@ void goto_instrument_parse_optionst::instrument_goto_program()
   }
 
   if(
-    cmdline.isset(FLAG_LOOP_CONTRACTS) || cmdline.isset(FLAG_REPLACE_CALL) ||
+    cmdline.isset(FLAG_LOOP_CONTRACTS) || 
+    cmdline.isset(FLAG_DECREASES_CLAUSES_INFERENCE) ||
+    cmdline.isset(FLAG_REPLACE_CALL) ||
     cmdline.isset(FLAG_REPLACE_ALL_CALLS) ||
     cmdline.isset(FLAG_ENFORCE_CONTRACT) ||
     cmdline.isset(FLAG_ENFORCE_ALL_CONTRACTS))
   {
-    code_contractst cont(goto_model, log);
+    code_contractst cont(goto_model, log, ui_message_handler);
 
     if(cmdline.isset(FLAG_REPLACE_CALL))
     {
@@ -1184,6 +1186,9 @@ void goto_instrument_parse_optionst::instrument_goto_program()
 
     if(cmdline.isset(FLAG_LOOP_CONTRACTS))
       cont.apply_loop_contracts();
+
+    if(cmdline.isset(FLAG_DECREASES_CLAUSES_INFERENCE))
+      cont.infer_decreases_clauses_in_program();
   }
 
   if(cmdline.isset("value-set-fi-fp-removal"))
@@ -1874,6 +1879,7 @@ void goto_instrument_parse_optionst::help()
     "\n"
     "Code contracts:\n"
     HELP_LOOP_CONTRACTS
+    HELP_DECREASES_CLAUSES_INFERENCE
     HELP_REPLACE_CALL
     HELP_REPLACE_ALL_CALLS
     HELP_ENFORCE_CONTRACT

--- a/src/goto-instrument/goto_instrument_parse_options.h
+++ b/src/goto-instrument/goto_instrument_parse_options.h
@@ -100,6 +100,7 @@ Author: Daniel Kroening, kroening@kroening.com
   "(z3)(add-library)(show-dependence-graph)" \
   "(horn)(skip-loops):(model-argc-argv):" \
   "(" FLAG_LOOP_CONTRACTS ")" \
+  "(" FLAG_DECREASES_CLAUSES_INFERENCE ")" \
   "(" FLAG_REPLACE_CALL "):" \
   "(" FLAG_REPLACE_ALL_CALLS ")" \
   "(" FLAG_ENFORCE_CONTRACT "):" \


### PR DESCRIPTION
This pull request consists of two commits:
1. Monotonic-change abstract interpretation
2. Automatic inference of decreases clauses. 
The second commit relies on the first one. 



<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
