### PR TITLE
remove two uses of goto_instructiont::incoming_edges

### DIFF
--- a/src/analyses/loop_analysis.h
+++ b/src/analyses/loop_analysis.h
@@ -173,15 +173,18 @@ void loop_analysist<T>::output(std::ostream &out) const
   {
     unsigned n = loop.first->location_number;
 
-    std::unordered_set<std::size_t> backedge_location_numbers;
-    for(const auto &backedge : loop.first->incoming_edges)
-      backedge_location_numbers.insert(backedge->location_number);
-
     out << n << " is head of { ";
 
     std::vector<std::size_t> loop_location_numbers;
+    std::unordered_set<std::size_t> backedge_location_numbers;
+
     for(const auto &loop_instruction_it : loop.second)
+    {
       loop_location_numbers.push_back(loop_instruction_it->location_number);
+      if(loop_instruction_it->is_backwards_goto())
+        backedge_location_numbers.insert(loop_instruction_it->location_number);
+    }
+
     std::sort(loop_location_numbers.begin(), loop_location_numbers.end());
 
     for(const auto location_number : loop_location_numbers)


### PR DESCRIPTION
This removes two uses of `goto_instructiont::incoming_edges`, which is
deprecated.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
