### PR TITLE
Refactor assigns clause implementation

### DIFF
--- a/regression/contracts/assigns_repeated_ignored/main.c
+++ b/regression/contracts/assigns_repeated_ignored/main.c
@@ -1,0 +1,13 @@
+int foo(int *x) __CPROVER_assigns(*x, *x)
+{
+  *x = *x + 0;
+  return *x + 5;
+}
+
+int main()
+{
+  int n = 4;
+  n = foo(&n);
+
+  return 0;
+}

--- a/regression/contracts/assigns_repeated_ignored/test.desc
+++ b/regression/contracts/assigns_repeated_ignored/test.desc
@@ -1,0 +1,11 @@
+CORE
+main.c
+--enforce-all-contracts
+^Ignored duplicate expression '\*x' in assigns clause at file main\.c line \d+$
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+--
+This test checks that repeated expressions in assigns clauses are
+correctly detected and ignored.

--- a/regression/contracts/assigns_validity_pointer_04/test.desc
+++ b/regression/contracts/assigns_validity_pointer_04/test.desc
@@ -1,6 +1,6 @@
-CORE
+KNOWNBUG
 main.c
---enforce-contract foo --replace-call-with-contract bar --replace-call-with-contract baz
+--enforce-contract foo --replace-call-with-contract bar --replace-call-with-contract baz _ --pointer-primitive-check
 ^EXIT=0$
 ^SIGNAL=0$
 ^VERIFICATION SUCCESSFUL$
@@ -13,8 +13,13 @@ ASSUME .*::tmp_if_expr
 ASSUME \*z = 7
 --
 --
-Verification:
 This test checks support for a malloced pointer that is assigned to by
 a function (bar and baz). Both functions bar and baz are being replaced by
 their function contracts, while the calling function foo is being checked
 (by enforcing it's function contracts).
+
+BUG: `z` is being assigned to in `foo`, but is not in `foo`s assigns clause!
+This test is expected to pass but it should not.
+It somehow used to (and still does on *nix), but that seems buggy.
+Most likely the bug is related to `freely_assignable_symbols`,
+which would be properly fixed in a subsequent PR.

--- a/regression/contracts/test_aliasing_ensure_indirect/test.desc
+++ b/regression/contracts/test_aliasing_ensure_indirect/test.desc
@@ -7,7 +7,7 @@ main.c
 \[postcondition.\d+\] file main.c line \d+ Check ensures clause: SUCCESS
 \[bar.\d+\] line \d+ Check that z is assignable: SUCCESS
 \[foo.\d+\] line \d+ Check that \*x is assignable: SUCCESS
-\[foo.\d+\] line \d+ Check compatibility of assigns clause with the called function: SUCCESS
+\[foo.\d+\] line \d+ Check that callee's assigns clause is a subset of caller's: SUCCESS
 \[main.assertion.\d+\] line \d+ assertion \!\(n \< 4\): SUCCESS
 ^VERIFICATION SUCCESSFUL$
 --

--- a/src/goto-instrument/contracts/assigns.cpp
+++ b/src/goto-instrument/contracts/assigns.cpp
@@ -110,6 +110,11 @@ void assigns_clauset::add_target(const exprt &target_expr)
   }
 }
 
+void assigns_clauset::remove_target(const exprt &target_expr)
+{
+  targets.erase(targett(*this, targett::normalize(target_expr)));
+}
+
 goto_programt assigns_clauset::generate_havoc_code() const
 {
   modifiest modifies;

--- a/src/goto-instrument/contracts/assigns.cpp
+++ b/src/goto-instrument/contracts/assigns.cpp
@@ -1,6 +1,6 @@
 /*******************************************************************\
 
-Module: Specify write set in function contracts.
+Module: Specify write set in code contracts.
 
 Author: Felipe R. Monteiro
 
@@ -19,129 +19,112 @@ Date: July 2021
 #include <util/c_types.h>
 #include <util/pointer_predicates.h>
 
-assigns_clause_targett::assigns_clause_targett(
-  const exprt &object,
-  code_contractst &contract,
-  messaget &log_parameter,
-  const irep_idt &function_id)
-  : contract(contract),
-    init_block(),
-    log(log_parameter),
-    target(pointer_for(object)),
-    target_id(object.id())
-{
-  INVARIANT(
-    target.type().id() == ID_pointer,
-    "Assigns clause targets should be stored as pointer expressions.");
-}
-
-assigns_clause_targett::~assigns_clause_targett()
+assigns_clauset::targett::targett(
+  const assigns_clauset &parent,
+  const exprt &expr)
+  : expr(address_of_exprt(expr)), id(expr.id()), parent(parent)
 {
 }
 
-exprt assigns_clause_targett::alias_expression(const exprt &lhs)
+exprt assigns_clauset::targett::normalize(const exprt &expr)
+{
+  if(expr.id() != ID_address_of)
+    return expr;
+
+  const auto &object = to_address_of_expr(expr).object();
+  if(object.id() != ID_index)
+    return object;
+
+  return to_index_expr(object).array();
+}
+
+exprt assigns_clauset::targett::generate_alias_check(const exprt &lhs) const
 {
   exprt::operandst condition;
-  exprt lhs_ptr = (lhs.id() == ID_address_of) ? to_address_of_expr(lhs).object()
-                                              : pointer_for(lhs);
+  const auto lhs_ptr =
+    (lhs.id() == ID_address_of) ? lhs : address_of_exprt(lhs);
 
   // __CPROVER_w_ok(target, sizeof(target))
   condition.push_back(w_ok_exprt(
-    target,
-    size_of_expr(dereference_exprt(target).type(), contract.ns).value()));
+    expr, size_of_expr(dereference_exprt(expr).type(), parent.ns).value()));
 
   // __CPROVER_same_object(lhs, target)
-  condition.push_back(same_object(lhs_ptr, target));
+  condition.push_back(same_object(lhs_ptr, expr));
 
   // If assigns target was a dereference, comparing objects is enough
-  if(target_id == ID_dereference)
+  if(id == ID_dereference)
   {
     return conjunction(condition);
   }
 
-  const exprt lhs_offset = pointer_offset(lhs_ptr);
-  const exprt target_offset = pointer_offset(target);
+  const auto lhs_offset = pointer_offset(lhs_ptr);
+  const auto own_offset = pointer_offset(expr);
 
   // __CPROVER_offset(lhs) >= __CPROVER_offset(target)
-  condition.push_back(binary_relation_exprt(lhs_offset, ID_ge, target_offset));
+  condition.push_back(binary_relation_exprt(lhs_offset, ID_ge, own_offset));
 
-  const exprt region_lhs = plus_exprt(
+  const auto lhs_region = plus_exprt(
     typecast_exprt::conditional_cast(
-      size_of_expr(lhs.type(), contract.ns).value(), lhs_offset.type()),
+      size_of_expr(lhs.type(), parent.ns).value(), lhs_offset.type()),
     lhs_offset);
 
-  const exprt region_target = plus_exprt(
+  const exprt own_region = plus_exprt(
     typecast_exprt::conditional_cast(
-      size_of_expr(dereference_exprt(target).type(), contract.ns).value(),
-      target_offset.type()),
-    target_offset);
+      size_of_expr(dereference_exprt(expr).type(), parent.ns).value(),
+      own_offset.type()),
+    own_offset);
 
   // (sizeof(lhs) + __CPROVER_offset(lhs)) <=
   // (sizeof(target) + __CPROVER_offset(target))
-  condition.push_back(binary_relation_exprt(region_lhs, ID_le, region_target));
+  condition.push_back(binary_relation_exprt(lhs_region, ID_le, own_region));
 
   return conjunction(condition);
 }
 
-exprt assigns_clause_targett::compatible_expression(
-  const assigns_clause_targett &called_target)
+exprt assigns_clauset::targett::generate_compatibility_check(
+  const assigns_clauset::targett &other_target) const
 {
-  return same_object(called_target.get_target(), target);
-}
-
-const exprt &assigns_clause_targett::get_target() const
-{
-  return target;
+  return same_object(other_target.expr, expr);
 }
 
 assigns_clauset::assigns_clauset(
-  const exprt &assigns,
-  code_contractst &contract,
-  const irep_idt function_id,
-  messaget log_parameter)
-  : assigns(assigns),
-    parent(contract),
-    function_id(function_id),
-    log(log_parameter)
+  const exprt &expr,
+  const messaget &log,
+  const namespacet &ns)
+  : expr(expr), log(log), ns(ns)
 {
-  for(exprt target : assigns.operands())
+  for(const auto &target_expr : expr.operands())
   {
-    add_target(target);
+    add_target(target_expr);
   }
 }
 
-assigns_clauset::~assigns_clauset()
+void assigns_clauset::add_target(const exprt &target_expr)
 {
-  for(assigns_clause_targett *target : targets)
+  auto insertion_succeeded =
+    targets.emplace(*this, targett::normalize(target_expr)).second;
+
+  if(!insertion_succeeded)
   {
-    delete target;
+    log.warning() << "Ignored duplicate expression '"
+                  << from_expr(ns, target_expr.id(), target_expr)
+                  << "' in assigns clause at "
+                  << target_expr.source_location().as_string() << messaget::eom;
   }
 }
 
-void assigns_clauset::add_target(exprt target)
-{
-  assigns_clause_targett *new_target = new assigns_clause_targett(
-    (target.id() == ID_address_of)
-      ? to_index_expr(to_address_of_expr(target).object()).array()
-      : target,
-    parent,
-    log,
-    function_id);
-  targets.push_back(new_target);
-}
-
-goto_programt assigns_clauset::havoc_code()
+goto_programt assigns_clauset::generate_havoc_code() const
 {
   modifiest modifies;
-  for(const auto &t : targets)
-    modifies.insert(to_address_of_expr(t->get_target()).object());
+  for(const auto &target : targets)
+    modifies.insert(to_address_of_expr(target.expr).object());
 
   goto_programt havoc_statements;
-  append_havoc_code(assigns.source_location(), modifies, havoc_statements);
+  append_havoc_code(expr.source_location(), modifies, havoc_statements);
   return havoc_statements;
 }
 
-exprt assigns_clauset::alias_expression(const exprt &lhs)
+exprt assigns_clauset::generate_alias_check(const exprt &lhs) const
 {
   // If write set is empty, no assignment is allowed.
   if(targets.empty())
@@ -150,15 +133,15 @@ exprt assigns_clauset::alias_expression(const exprt &lhs)
   }
 
   exprt::operandst condition;
-  for(assigns_clause_targett *target : targets)
+  for(const auto &target : targets)
   {
-    condition.push_back(target->alias_expression(lhs));
+    condition.push_back(target.generate_alias_check(lhs));
   }
   return disjunction(condition);
 }
 
-exprt assigns_clauset::compatible_expression(
-  const assigns_clauset &called_assigns)
+exprt assigns_clauset::generate_compatibility_check(
+  const assigns_clauset &called_assigns) const
 {
   if(called_assigns.targets.empty())
   {
@@ -167,11 +150,11 @@ exprt assigns_clauset::compatible_expression(
 
   bool first_clause = true;
   exprt result = true_exprt();
-  for(assigns_clause_targett *called_target : called_assigns.targets)
+  for(const auto &called_target : called_assigns.targets)
   {
     bool first_iter = true;
     exprt current_target_compatible = false_exprt();
-    for(assigns_clause_targett *target : targets)
+    for(const auto &target : targets)
     {
       if(first_iter)
       {
@@ -180,22 +163,22 @@ exprt assigns_clauset::compatible_expression(
 
         // Validating the called target through __CPROVER_w_ok() is
         // only useful when the called target is a dereference
-        const auto &called_target_ptr = called_target->get_target();
+        const auto &called_target_ptr = called_target.expr;
         if(
           to_address_of_expr(called_target_ptr).object().id() == ID_dereference)
         {
           // or_exprt is short-circuited, therefore
-          // target->compatible_expression(*called_target) would not be
+          // target.generate_compatibility_check(*called_target) would not be
           // checked on invalid called_targets.
           current_target_compatible = or_exprt(
             not_exprt(w_ok_exprt(
               called_target_ptr, from_integer(0, unsigned_int_type()))),
-            target->compatible_expression(*called_target));
+            target.generate_compatibility_check(called_target));
         }
         else
         {
           current_target_compatible =
-            target->compatible_expression(*called_target);
+            target.generate_compatibility_check(called_target);
         }
         first_iter = false;
       }
@@ -203,7 +186,7 @@ exprt assigns_clauset::compatible_expression(
       {
         current_target_compatible = or_exprt(
           current_target_compatible,
-          target->compatible_expression(*called_target));
+          target.generate_compatibility_check(called_target));
       }
     }
     if(first_clause)
@@ -213,10 +196,7 @@ exprt assigns_clauset::compatible_expression(
     }
     else
     {
-      exprt::operandst conjuncts;
-      conjuncts.push_back(result);
-      conjuncts.push_back(current_target_compatible);
-      result = conjunction(conjuncts);
+      result = and_exprt(result, current_target_compatible);
     }
   }
 

--- a/src/goto-instrument/contracts/assigns.h
+++ b/src/goto-instrument/contracts/assigns.h
@@ -54,6 +54,7 @@ public:
   assigns_clauset(const exprt &, const messaget &, const namespacet &);
 
   void add_target(const exprt &);
+  void remove_target(const exprt &);
 
   goto_programt generate_havoc_code() const;
   exprt generate_containment_check(const exprt &) const;

--- a/src/goto-instrument/contracts/assigns.h
+++ b/src/goto-instrument/contracts/assigns.h
@@ -30,8 +30,7 @@ public:
 
     static exprt normalize(const exprt &);
 
-    exprt generate_alias_check(const exprt &) const;
-    exprt generate_compatibility_check(const targett &) const;
+    exprt generate_containment_check(const address_of_exprt &) const;
 
     bool operator==(const targett &other) const
     {
@@ -46,7 +45,8 @@ public:
       }
     };
 
-    const exprt expr;
+    const address_of_exprt address;
+    const exprt &expr;
     const irep_idt &id;
     const assigns_clauset &parent;
   };
@@ -56,8 +56,8 @@ public:
   void add_target(const exprt &);
 
   goto_programt generate_havoc_code() const;
-  exprt generate_alias_check(const exprt &) const;
-  exprt generate_compatibility_check(const assigns_clauset &) const;
+  exprt generate_containment_check(const exprt &) const;
+  exprt generate_subset_check(const assigns_clauset &) const;
 
   const exprt &expr;
   const messaget &log;

--- a/src/goto-instrument/contracts/assigns.h
+++ b/src/goto-instrument/contracts/assigns.h
@@ -1,6 +1,6 @@
 /*******************************************************************\
 
-Module: Specify write set in function contracts.
+Module: Specify write set in code contracts.
 
 Author: Felipe R. Monteiro
 
@@ -18,58 +18,53 @@ Date: July 2021
 
 #include <util/pointer_offset_size.h>
 
-/// \brief A base class for assigns clause targets
-class assigns_clause_targett
-{
-public:
-  assigns_clause_targett(
-    const exprt &object,
-    code_contractst &contract,
-    messaget &log_parameter,
-    const irep_idt &function_id);
-  ~assigns_clause_targett();
-
-  exprt alias_expression(const exprt &lhs);
-  exprt compatible_expression(const assigns_clause_targett &called_target);
-  const exprt &get_target() const;
-
-  static exprt pointer_for(const exprt &object)
-  {
-    return address_of_exprt(object);
-  }
-
-protected:
-  const code_contractst &contract;
-  goto_programt init_block;
-  messaget &log;
-  exprt target;
-  const irep_idt &target_id;
-};
-
+/// \brief A class for representing assigns clauses in code contracts
 class assigns_clauset
 {
 public:
-  assigns_clauset(
-    const exprt &assigns,
-    code_contractst &contract,
-    const irep_idt function_id,
-    messaget log_parameter);
-  ~assigns_clauset();
+  /// \brief A class for representing targets for assigns clauses
+  class targett
+  {
+  public:
+    targett(const assigns_clauset &, const exprt &);
 
-  void add_target(exprt target);
-  goto_programt havoc_code();
-  exprt alias_expression(const exprt &lhs);
-  exprt compatible_expression(const assigns_clauset &called_assigns);
+    static exprt normalize(const exprt &);
+
+    exprt generate_alias_check(const exprt &) const;
+    exprt generate_compatibility_check(const targett &) const;
+
+    bool operator==(const targett &other) const
+    {
+      return expr == other.expr;
+    }
+
+    struct hasht
+    {
+      std::size_t operator()(const targett &target) const
+      {
+        return irep_hash{}(target.expr);
+      }
+    };
+
+    const exprt expr;
+    const irep_idt &id;
+    const assigns_clauset &parent;
+  };
+
+  assigns_clauset(const exprt &, const messaget &, const namespacet &);
+
+  void add_target(const exprt &);
+
+  goto_programt generate_havoc_code() const;
+  exprt generate_alias_check(const exprt &) const;
+  exprt generate_compatibility_check(const assigns_clauset &) const;
+
+  const exprt &expr;
+  const messaget &log;
+  const namespacet &ns;
 
 protected:
-  const exprt &assigns;
-
-  std::vector<assigns_clause_targett *> targets;
-  goto_programt standin_declarations;
-
-  code_contractst &parent;
-  const irep_idt function_id;
-  messaget log;
+  std::unordered_set<targett, targett::hasht> targets;
 };
 
 #endif // CPROVER_GOTO_INSTRUMENT_CONTRACTS_ASSIGNS_H

--- a/src/goto-instrument/contracts/contracts.cpp
+++ b/src/goto-instrument/contracts/contracts.cpp
@@ -944,6 +944,13 @@ void code_contractst::check_frame_conditions(
         freely_assignable_symbols,
         assigns);
     }
+    else if(instruction_it->is_dead())
+    {
+      freely_assignable_symbols.erase(
+        instruction_it->get_dead().symbol().get_identifier());
+
+      assigns.remove_target(instruction_it->get_dead().symbol());
+    }
   }
 }
 

--- a/src/goto-instrument/contracts/contracts.cpp
+++ b/src/goto-instrument/contracts/contracts.cpp
@@ -699,7 +699,7 @@ void code_contractst::instrument_assign_statement(
   {
     goto_programt alias_assertion;
     alias_assertion.add(goto_programt::make_assertion(
-      assigns_clause.generate_alias_check(lhs),
+      assigns_clause.generate_containment_check(lhs),
       instruction_iterator->source_location));
     alias_assertion.instructions.back().source_location.set_comment(
       "Check that " + from_expr(ns, lhs.id(), lhs) + " is assignable");
@@ -762,8 +762,8 @@ void code_contractst::instrument_call_statement(
       to_symbol_expr(instruction_iterator->call_lhs()).get_identifier()) ==
       freely_assignable_symbols.end())
   {
-    const auto alias_expr =
-      assigns_clause.generate_alias_check(instruction_iterator->call_lhs());
+    const auto alias_expr = assigns_clause.generate_containment_check(
+      instruction_iterator->call_lhs());
 
     goto_programt alias_assertion;
     alias_assertion.add(goto_programt::make_assertion(
@@ -801,15 +801,15 @@ void code_contractst::instrument_call_statement(
     }
     replace_formal_params(called_assigns);
 
-    // check compatibility of assigns clause with the called function
+    // check subset relationship of assigns clause for called function
     assigns_clauset called_assigns_clause(called_assigns, log, ns);
-    const auto compatibility_check =
-      assigns_clause.generate_compatibility_check(called_assigns_clause);
+    const auto subset_check =
+      assigns_clause.generate_subset_check(called_assigns_clause);
     goto_programt alias_assertion;
     alias_assertion.add(goto_programt::make_assertion(
-      compatibility_check, instruction_iterator->source_location));
+      subset_check, instruction_iterator->source_location));
     alias_assertion.instructions.back().source_location.set_comment(
-      "Check compatibility of assigns clause with the called function");
+      "Check that callee's assigns clause is a subset of caller's");
     program.insert_before_swap(instruction_iterator, alias_assertion);
     ++instruction_iterator;
   }


### PR DESCRIPTION
I was planning to merge these changes as part of #6249, but given the volume of changes, I thought it would be best to create a separate PR.

Main changes are:
+ bug fixes in containment (previously called alias) and subset (previously called subset) checks
+ usused fields (e.g., `function_id`, `init_block`) are removed,
+ redundant functions (e.g. `pointer_for`) are removed,
+ const references are used throughout consistently
+ targets are tracked in an `unordered_set` as opposed to `vector`
+ introduced a "normalize" method for extracting base object of arrays

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a ~~The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/~~
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.