### PR TITLE
export-file-local_symbols:: update base name and pretty name

### DIFF
--- a/regression/goto-cc-file-local/base-name-1/file1.c
+++ b/regression/goto-cc-file-local/base-name-1/file1.c
@@ -1,0 +1,7 @@
+int __CPROVER_file_local_file2_c_foo(int x);
+
+int main()
+{
+  int x = __CPROVER_file_local_file2_c_foo(1);
+  __CPROVER_assert(x == 2, "x == 2");
+}

--- a/regression/goto-cc-file-local/base-name-1/file2.c
+++ b/regression/goto-cc-file-local/base-name-1/file2.c
@@ -1,0 +1,9 @@
+static int foo(int x)
+{
+  return x + 1;
+}
+
+static int bar(int x)
+{
+  return x + 2;
+}

--- a/regression/goto-cc-file-local/base-name-1/test.desc
+++ b/regression/goto-cc-file-local/base-name-1/test.desc
@@ -1,0 +1,13 @@
+CORE
+file1.c
+final-link show-symbol-table assertion-check
+^Base name\.\.\.: __CPROVER_file_local_.*_foo$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+^Base name\.\.\.: foo$
+--
+The linking order must not affect the base name of the mangled symbol. See
+base-name-2 for a test that will yield a different linking order (while still
+producing the same base name).

--- a/regression/goto-cc-file-local/base-name-2/file1.c
+++ b/regression/goto-cc-file-local/base-name-2/file1.c
@@ -1,0 +1,9 @@
+static int foo(int x)
+{
+  return x + 1;
+}
+
+static int bar(int x)
+{
+  return x + 2;
+}

--- a/regression/goto-cc-file-local/base-name-2/file2.c
+++ b/regression/goto-cc-file-local/base-name-2/file2.c
@@ -1,0 +1,7 @@
+int __CPROVER_file_local_file1_c_foo(int x);
+
+int main()
+{
+  int x = __CPROVER_file_local_file1_c_foo(1);
+  __CPROVER_assert(x == 2, "x == 2");
+}

--- a/regression/goto-cc-file-local/base-name-2/test.desc
+++ b/regression/goto-cc-file-local/base-name-2/test.desc
@@ -1,0 +1,13 @@
+CORE
+file1.c
+final-link show-symbol-table assertion-check
+^Base name\.\.\.: __CPROVER_file_local_.*_foo$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+^Base name\.\.\.: foo$
+--
+The linking order must not affect the base name of the mangled symbol. See
+base-name-1 for a test that will yield a different linking order (while still
+producing the same base name).

--- a/regression/goto-cc-goto-analyzer/reachable-functions-export-file-local-symbols/test.desc
+++ b/regression/goto-cc-goto-analyzer/reachable-functions-export-file-local-symbols/test.desc
@@ -1,11 +1,10 @@
 CORE
 test.c
 --reachable-functions
-^.* foo 1 4$
+^.* __CPROVER_file_local_project_c_foo 1 4$
 ^EXIT=0$
 ^SIGNAL=0$
 --
-^.* [a-zA-Z0-9_]+foo \d+ \d+$
 --
 This test checks that after building the goto binary (see test.sh) with
 --export-file-local-symbols function "foo" is still reported as reachable. Note,

--- a/src/goto-programs/name_mangler.h
+++ b/src/goto-programs/name_mangler.h
@@ -70,6 +70,9 @@ public:
       symbolt new_sym;
       new_sym = sym;
       new_sym.name = mangled;
+      new_sym.base_name = mangled;
+      if(new_sym.pretty_name.empty())
+        new_sym.pretty_name = sym.base_name;
       new_sym.is_file_local = false;
 
       new_syms.push_back(new_sym);


### PR DESCRIPTION
Name mangling via --export-file-local-symbols used to introduce symbols
the name of which did not match the base name. Forward declarations of
the mangled name, however, did introduce a symbol where (mangled) name
and base name match. When linking later found the definition
corresponding to such a forward declaration, the base name (and pretty
name) were not updated. As a consequence the order of linking produced
two different final symbol tables.

Note that Crangler may be a superior alternative avoiding such problems,
but there is ample code that still uses `--export-file-local-symbols`.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
