### PR TITLE
goto-analyzer --(un)reachable-functions should not rely on base names

### DIFF
--- a/regression/goto-cc-goto-analyzer/reachable-functions-export-file-local-symbols/project.c
+++ b/regression/goto-cc-goto-analyzer/reachable-functions-export-file-local-symbols/project.c
@@ -1,0 +1,9 @@
+static int foo(int x)
+{
+  return x + 1;
+}
+
+static int bar(int x)
+{
+  return x + 2;
+}

--- a/regression/goto-cc-goto-analyzer/reachable-functions-export-file-local-symbols/proof.c
+++ b/regression/goto-cc-goto-analyzer/reachable-functions-export-file-local-symbols/proof.c
@@ -1,0 +1,7 @@
+int __CPROVER_file_local_project_c_foo(int x);
+
+int main()
+{
+  int x = __CPROVER_file_local_project_c_foo(1);
+  assert(x == 2);
+}

--- a/regression/goto-cc-goto-analyzer/reachable-functions-export-file-local-symbols/test.desc
+++ b/regression/goto-cc-goto-analyzer/reachable-functions-export-file-local-symbols/test.desc
@@ -1,0 +1,13 @@
+CORE
+test.c
+--reachable-functions
+^.* foo 1 4$
+^EXIT=0$
+^SIGNAL=0$
+--
+^.* [a-zA-Z0-9_]+foo \d+ \d+$
+--
+This test checks that after building the goto binary (see test.sh) with
+--export-file-local-symbols function "foo" is still reported as reachable. Note,
+that the symbol representing "foo" has a mangled name in the goto binary, which
+makes the symbol name different from its base name.

--- a/regression/goto-cc-goto-analyzer/reachable-functions-export-file-local-symbols/test.sh
+++ b/regression/goto-cc-goto-analyzer/reachable-functions-export-file-local-symbols/test.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -e
+
+goto_cc=$1
+is_windows=$2
+
+if [[ "${is_windows}" == "true" ]]; then
+  ${goto_cc} "/c" "/Foproject.gb" --export-file-local-symbols project.c
+  ${goto_cc} "/c" "/Foproof.gb" --export-file-local-symbols proof.c
+  ${goto_cc} "/Fetest.gb" project.gb proof.gb
+else
+  ${goto_cc} -o project.gb --export-file-local-symbols project.c
+  ${goto_cc} -o proof.gb --export-file-local-symbols proof.c
+  ${goto_cc} -o test.gb project.gb proof.gb
+fi

--- a/src/goto-analyzer/unreachable_instructions.cpp
+++ b/src/goto-analyzer/unreachable_instructions.cpp
@@ -179,10 +179,8 @@ void unreachable_instructions(
 
     const symbolt &decl = ns.lookup(gf_entry.first);
 
-    // gf_entry.first may be a link-time renamed version, use the
-    // base_name instead; do not list inlined functions
     if(
-      called.find(decl.base_name) != called.end() ||
+      called.find(decl.name) != called.end() ||
       to_code_type(decl.type).get_inlined())
     {
       unreachable_instructions(goto_program, dead_map);
@@ -314,10 +312,8 @@ static void list_functions(
   {
     const symbolt &decl = ns.lookup(gf_entry.first);
 
-    // gf_entry.first may be a link-time renamed version, use the
-    // base_name instead; do not list inlined functions
     if(
-      unreachable == (called.find(decl.base_name) != called.end() ||
+      unreachable == (called.find(decl.name) != called.end() ||
                       to_code_type(decl.type).get_inlined()))
     {
       continue;


### PR DESCRIPTION
Functions are called by their symbol names, not their base names. The
output may still safely use the base name for more user-friendly
results, but call trees should not rely on a match of base names and
symbol names.

Fixes: #6330

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
