### PR TITLE
Add workaround for issue described in #6168.

### DIFF
--- a/regression/contracts/github_6168_infinite_unwinding_bug/main.c
+++ b/regression/contracts/github_6168_infinite_unwinding_bug/main.c
@@ -1,0 +1,21 @@
+#include <assert.h>
+#include <stdlib.h>
+
+static int adder(const int *a, const int *b)
+{
+  return (*a + *b);
+}
+
+int main()
+{
+  int x = 1024;
+
+  int (*local_adder)(const int *, const int *) = adder;
+
+  while(x > 0)
+    __CPROVER_loop_invariant(1 == 1)
+    {
+      x += local_adder(&x, &x); // loop detection fails
+      //x += adder(&x, &x);       // works fine
+    }
+}

--- a/regression/contracts/github_6168_infinite_unwinding_bug/test.desc
+++ b/regression/contracts/github_6168_infinite_unwinding_bug/test.desc
@@ -1,0 +1,11 @@
+CORE
+main.c
+--apply-loop-contracts
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+^\[main.1\] line \d+ Check loop invariant before entry: SUCCESS$
+^\[main.2\] line \d+ Check that loop invariant is preserved: SUCCESS$
+--
+--
+This is guarding against an issue described in https://github.com/diffblue/cbmc/issues/6168.

--- a/src/goto-instrument/goto_instrument_parse_options.cpp
+++ b/src/goto-instrument/goto_instrument_parse_options.cpp
@@ -1154,6 +1154,7 @@ void goto_instrument_parse_optionst::instrument_goto_program()
     cmdline.isset(FLAG_ENFORCE_CONTRACT) ||
     cmdline.isset(FLAG_ENFORCE_ALL_CONTRACTS))
   {
+    do_indirect_call_and_rtti_removal();
     code_contractst cont(goto_model, log);
 
     if(cmdline.isset(FLAG_REPLACE_CALL))


### PR DESCRIPTION
This fixes the infinite unwinding by adding calls to `do_indirect_call_and_rtti_removal()`
before the contracts code invocation in `goto-instrument/`.

This is not yet finished, as it will need a test-case attached, but this is pushed so that
it can garner some initial comments regarding the approach.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
