### PR TITLE
Check subset relationship of assigns clause during replacement

### DIFF
--- a/regression/contracts/assigns_enforce_structs_07/test.desc
+++ b/regression/contracts/assigns_enforce_structs_07/test.desc
@@ -1,4 +1,4 @@
-CORE
+KNOWNBUG
 main.c
 --enforce-all-contracts _ --pointer-check
 ^EXIT=10$
@@ -12,3 +12,6 @@ main.c
 --
 Checks whether CBMC properly evaluates write set of members
 from invalid objects. In this case, they are not writable.
+
+Bug: We need to check the validity of each dereference
+when accessing struct members.

--- a/regression/contracts/assigns_replace_08/main.c
+++ b/regression/contracts/assigns_replace_08/main.c
@@ -1,0 +1,19 @@
+#include <stdlib.h>
+
+int x;
+int *z = &x;
+
+void bar() __CPROVER_assigns(*z)
+{
+}
+
+void foo() __CPROVER_assigns()
+{
+  bar();
+}
+
+int main()
+{
+  foo();
+  return 0;
+}

--- a/regression/contracts/assigns_replace_08/test.desc
+++ b/regression/contracts/assigns_replace_08/test.desc
@@ -1,0 +1,16 @@
+CORE
+main.c
+--enforce-contract foo --replace-call-with-contract bar _ --pointer-primitive-check
+^EXIT=10$
+^SIGNAL=0$
+\[\d+\] file main.c line \d+ Check that bar\'s assigns clause is a subset of foo\'s assigns clause: FAILURE$
+\[\d+\] file main.c line \d+ Check that \*z is assignable: FAILURE$
+^.* 2 of \d+ failed \(\d+ iteration.*\)$
+^VERIFICATION FAILED$
+--
+\[\d+\] file main.c line \d+ Check that bar\'s assigns clause is a subset of foo\'s assigns clause: SUCCESS$
+\[\d+\] file main.c line \d+ Check that \*z is assignable: SUCCESS$
+^VERIFICATION SUCCESSFUL$
+--
+Checks whether CBMC properly evaluates subset relationship on assigns
+during replacement.

--- a/regression/contracts/assigns_validity_pointer_01/main.c
+++ b/regression/contracts/assigns_validity_pointer_01/main.c
@@ -17,17 +17,17 @@ void baz() __CPROVER_assigns(*z) __CPROVER_ensures(z == NULL || *z == 7)
     *z = 7;
 }
 
-void foo(int *x) __CPROVER_assigns(*x) __CPROVER_requires(*x > 0)
+void foo(int *x) __CPROVER_assigns(*x, *z) __CPROVER_requires(*x > 0)
   __CPROVER_ensures(*x == 3)
 {
   bar(x, NULL);
-  z == NULL;
   baz();
 }
 
 int main()
 {
   int n;
+  z = malloc(sizeof(*z));
   foo(&n);
 
   assert(n == 3);

--- a/regression/contracts/assigns_validity_pointer_02/test.desc
+++ b/regression/contracts/assigns_validity_pointer_02/test.desc
@@ -3,11 +3,16 @@ main.c
 --enforce-contract foo
 ^EXIT=0$
 ^SIGNAL=0$
+^\[postcondition.\d+\] file main.c line \d+ Check ensures clause: SUCCESS$
+^\[foo.\d+\] line \d+ Check that bar\'s assigns clause is a subset of foo\'s assigns clause: SUCCESS$
+^\[foo.\d+\] line \d+ Check that \*x is assignable: SUCCESS$
+^\[foo.\d+\] line \d+ Check that baz\'s assigns clause is a subset of foo\'s assigns clause: SUCCESS$
 ^VERIFICATION SUCCESSFUL$
-//^([foo\.1] line 15 assertion: FAILURE)
 --
-\[foo\.1\] line 24 assertion: FAILURE
-\[foo\.3\] line 27 assertion: FAILURE
+^\[postcondition.\d+\] file main.c line \d+ Check ensures clause: FAILURE$
+^\[foo.\d+\] line \d+ Check that bar\'s assigns clause is a subset of foo\'s assigns clause: FAILURE$
+^\[foo.\d+\] line \d+ Check that \*x is assignable: FAILURE$
+^\[foo.\d+\] line \d+ Check that baz\'s assigns clause is a subset of foo\'s assigns clause: FAILURE$
 --
 Verification:
 This test checks support for a NULL pointer that is assigned to by

--- a/regression/contracts/assigns_validity_pointer_04/test.desc
+++ b/regression/contracts/assigns_validity_pointer_04/test.desc
@@ -3,8 +3,10 @@ main.c
 --enforce-contract foo --replace-call-with-contract bar --replace-call-with-contract baz _ --pointer-primitive-check
 ^EXIT=10$
 ^SIGNAL=0$
+^\[\d+\] file main.c line \d+ Check that bar\'s assigns clause is a subset of foo\'s assigns clause: FAILURE$
+^\[\d+\] file main.c line \d+ Check that baz\'s assigns clause is a subset of foo\'s assigns clause: FAILURE$
 ^\[foo.\d+\] line \d+ Check that z is assignable: FAILURE$
-^.* 1 of \d+ failed \(\d+ iteration.*\)$
+^.* 3 of \d+ failed \(\d+ iteration.*\)$
 ^VERIFICATION FAILED$
 // bar
 ASSERT \*foo::x > 0

--- a/regression/contracts/test_aliasing_ensure_indirect/test.desc
+++ b/regression/contracts/test_aliasing_ensure_indirect/test.desc
@@ -7,7 +7,7 @@ main.c
 \[postcondition.\d+\] file main.c line \d+ Check ensures clause: SUCCESS
 \[bar.\d+\] line \d+ Check that z is assignable: SUCCESS
 \[foo.\d+\] line \d+ Check that \*x is assignable: SUCCESS
-\[foo.\d+\] line \d+ Check that callee's assigns clause is a subset of caller's: SUCCESS
+\[foo.\d+\] line \d+ Check that bar\'s assigns clause is a subset of foo\'s assigns clause: SUCCESS
 \[main.assertion.\d+\] line \d+ assertion \!\(n \< 4\): SUCCESS
 ^VERIFICATION SUCCESSFUL$
 --

--- a/src/ansi-c/ansi_c_convert_type.cpp
+++ b/src/ansi-c/ansi_c_convert_type.cpp
@@ -272,6 +272,7 @@ void ansi_c_convert_typet::read_rec(const typet &type)
       for(auto &assignment : to_unary_expr(as_expr).op().operands())
         assigns.add_to_operands(std::move(assignment));
     }
+    assigns.add_source_location() = as_expr.source_location();
   }
   else if(type.id() == ID_C_spec_ensures)
   {

--- a/src/goto-instrument/contracts/assigns.cpp
+++ b/src/goto-instrument/contracts/assigns.cpp
@@ -56,6 +56,8 @@ exprt assigns_clauset::targett::generate_containment_check(
   // If assigns target was a dereference, comparing objects is enough
   if(id == ID_dereference)
   {
+    // __CPROVER_w_ok(target, sizeof(target)) &&
+    // __CPROVER_same_object(lhs, target)
     return conjunction(condition);
   }
 
@@ -81,6 +83,11 @@ exprt assigns_clauset::targett::generate_containment_check(
   // (sizeof(target) + __CPROVER_offset(target))
   condition.push_back(binary_relation_exprt(lhs_region, ID_le, own_region));
 
+  // __CPROVER_w_ok(target, sizeof(target)) &&
+  // __CPROVER_same_object(lhs, target) &&
+  // __CPROVER_offset(lhs) >= __CPROVER_offset(target) &&
+  // (sizeof(lhs) + __CPROVER_offset(lhs)) <=
+  // (sizeof(target) + __CPROVER_offset(target))
   return conjunction(condition);
 }
 


### PR DESCRIPTION
If CBMC replaces a function `bar()` with its contract, while enforcing the contract in function `foo()`, it must also check whether the `bar()`'s assigns clause is a subset of the `foo()`'s assigns clause.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
