### PR TITLE
Check frame conditions before __CPROVER_havoc_object

### DIFF
--- a/regression/contracts/assigns_enforce_20/main.c
+++ b/regression/contracts/assigns_enforce_20/main.c
@@ -1,0 +1,19 @@
+#include <assert.h>
+#include <stdlib.h>
+
+int x = 0;
+
+void foo(int *y) __CPROVER_assigns()
+{
+  __CPROVER_havoc_object(y);
+  x = 2;
+}
+
+int main()
+{
+  int *y = malloc(sizeof(*y));
+  *y = 0;
+  foo(y);
+  assert(x == 2);
+  return 0;
+}

--- a/regression/contracts/assigns_enforce_20/test.desc
+++ b/regression/contracts/assigns_enforce_20/test.desc
@@ -1,0 +1,11 @@
+CORE
+main.c
+--enforce-all-contracts
+^EXIT=10$
+^SIGNAL=0$
+^\[foo.\d+\] line \d+ Check that \*y is assignable: FAILURE$
+^\[foo.\d+\] line \d+ Check that x is assignable: FAILURE$
+^VERIFICATION FAILED$
+--
+--
+Checks whether contract enforcement works with __CPROVER_havoc_object.

--- a/src/goto-instrument/contracts/contracts.h
+++ b/src/goto-instrument/contracts/contracts.h
@@ -152,6 +152,14 @@ protected:
   /// assigned memory is within the assignable memory frame.
   void check_frame_conditions(goto_programt &, assigns_clauset &);
 
+  /// Inserts an assertion into the goto program to ensure that
+  /// an expression is within the assignable memory frame.
+  void add_containment_check(
+    goto_programt &,
+    const assigns_clauset &,
+    goto_programt::instructionst::iterator &,
+    const exprt &);
+
   /// Check if there are any malloc statements which may be repeated because of
   /// a goto statement that jumps back.
   bool check_for_looped_mallocs(const goto_programt &program);


### PR DESCRIPTION
Signed-off-by: Felipe R. Monteiro <felisous@amazon.com>

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
