### PR TITLE
Implement sending commands to solver in incremental SMT2 backend

### DIFF
--- a/regression/cbmc-incr-smt2/CMakeLists.txt
+++ b/regression/cbmc-incr-smt2/CMakeLists.txt
@@ -1,4 +1,10 @@
 
+if("${CMAKE_SYSTEM_NAME}" STREQUAL "Windows")
+    set(exclude_win_broken_tests -X winbug)
+else()
+    set(exclude_win_broken_tests "")
+endif()
+
 add_test_pl_tests(
-    "$<TARGET_FILE:cbmc> --validate-goto-model --validate-ssa-equation --slice-formula"
+    "$<TARGET_FILE:cbmc> --validate-goto-model --validate-ssa-equation --slice-formula" ${exclude_win_broken_tests}
 )

--- a/regression/cbmc-incr-smt2/Makefile
+++ b/regression/cbmc-incr-smt2/Makefile
@@ -3,8 +3,14 @@ default: test
 include ../../src/config.inc
 include ../../src/common
 
+ifeq ($(BUILD_ENV_),MSVC)
+	exclude_broken_windows_tests=-X winbug
+else
+	exclude_broken_windows_tests=
+endif
+
 test:
-	@../test.pl -e -p -c "../../../src/cbmc/cbmc --validate-goto-model --validate-ssa-equation --slice-formula"
+	@../test.pl -e -p -c "../../../src/cbmc/cbmc --validate-goto-model --validate-ssa-equation --slice-formula" $(exclude_broken_windows_tests)
 
 tests.log: ../test.pl test
 

--- a/regression/cbmc-incr-smt2/nondeterministic-int-assert/control_flow.c
+++ b/regression/cbmc-incr-smt2/nondeterministic-int-assert/control_flow.c
@@ -1,0 +1,16 @@
+
+int main()
+{
+  int x, y;
+  if(x != 0)
+  {
+    y = 9;
+  }
+  else
+  {
+    y = 4;
+  }
+  int z = y;
+  __CPROVER_assert(x != z, "Assert of integer equality.");
+  return 0;
+}

--- a/regression/cbmc-incr-smt2/nondeterministic-int-assert/control_flow.desc
+++ b/regression/cbmc-incr-smt2/nondeterministic-int-assert/control_flow.desc
@@ -1,0 +1,32 @@
+CORE
+control_flow.c
+--incremental-smt2-solver "z3 --smt2 -in" --verbosity 10
+Passing problem to incremental SMT2 solving via "z3 --smt2 -in"
+Sending command to SMT2 solver - \(set-option :produce-models true\)
+Sending command to SMT2 solver - \(set-logic QF_UFBV\)
+Sending command to SMT2 solver - \(declare-fun |goto_symex::&92;guard#1| \(\) Bool\)
+Sending command to SMT2 solver - \(define-fun |B1| \(\) Bool |goto_symex::&92;guard#1|\)
+Sending command to SMT2 solver - \(declare-fun |main::1::x!0@1#1| \(\) \(_ BitVec 32\)\)
+Sending command to SMT2 solver - \(assert \(|=| |goto_symex::&92;guard#1| \(|not| \(|=| |main::1::x!0@1#1| \(_ bv0 32\)\)\)\)\)
+Sending command to SMT2 solver - \(declare-fun |main::1::y!0@1#4| \(\) \(_ BitVec 32\)\)
+Sending command to SMT2 solver - \(assert \(|=| |main::1::y!0@1#4| \(|ite| |goto_symex::&92;guard#1| \(_ bv9 32\) \(_ bv4 32\)\)\)\)
+Sending command to SMT2 solver - \(declare-fun |main::1::x!0@1#3| \(\) \(_ BitVec 32\)\)
+Sending command to SMT2 solver - \(assert \(|=| |main::1::x!0@1#3| \(|ite| |goto_symex::&92;guard#1| |main::1::x!0@1#1| \(_ bv0 32\)\)\)\)
+Sending command to SMT2 solver - \(declare-fun |main::1::z!0@1#2| \(\) \(_ BitVec 32\)\)
+Sending command to SMT2 solver - \(assert \(|=| |main::1::z!0@1#2| |main::1::y!0@1#4|\)\)
+Sending command to SMT2 solver - \(define-fun |B3| \(\) Bool \(|=| |main::1::x!0@1#1| \(_ bv0 32\)\)\)
+Sending command to SMT2 solver - \(assert \(|not| \(|not| \(|=| |main::1::x!0@1#3| |main::1::z!0@1#2|\)\)\)\)
+Sending command to SMT2 solver - \(define-fun |B4| \(\) Bool \(|not| false\)\)
+Sending command to SMT2 solver - \(assert |B4|\)
+Sending command to SMT2 solver - \(check-sat\)
+Solver response - sat
+^EXIT=(0|127|134|137)$
+^SIGNAL=0$
+--
+type: pointer
+--
+Test that running cbmc with the `--incremental-smt2-solver` argument can be used
+to send a valid SMT2 formula to a sub-process solver for an example input file
+which include control flow constructs. Note that at the time of adding this
+test, an invariant violation is expected due to the unimplemented response
+parsing.

--- a/regression/cbmc-incr-smt2/nondeterministic-int-assert/control_flow.desc
+++ b/regression/cbmc-incr-smt2/nondeterministic-int-assert/control_flow.desc
@@ -1,4 +1,4 @@
-CORE
+CORE winbug
 control_flow.c
 --incremental-smt2-solver "z3 --smt2 -in" --verbosity 10
 Passing problem to incremental SMT2 solving via "z3 --smt2 -in"

--- a/regression/cbmc-incr-smt2/nondeterministic-int-assert/incremental_solver_called.desc
+++ b/regression/cbmc-incr-smt2/nondeterministic-int-assert/incremental_solver_called.desc
@@ -1,7 +1,7 @@
 CORE
 test.c
---incremental-smt2-solver z3
-Passing problem to incremental SMT2 solving via "z3"
+--incremental-smt2-solver "z3 --smt2 -in"
+Passing problem to incremental SMT2 solving via "z3 --smt2 -in"
 ^EXIT=(0|127|134|137)$
 ^SIGNAL=0$
 identifier: main::1::x

--- a/regression/cbmc-incr-smt2/nondeterministic-int-assert/incremental_solver_called.desc
+++ b/regression/cbmc-incr-smt2/nondeterministic-int-assert/incremental_solver_called.desc
@@ -4,6 +4,12 @@ test.c
 Passing problem to incremental SMT2 solving via "z3 --smt2 -in"
 Sending command to SMT2 solver - \(set-option :produce-models true\)
 Sending command to SMT2 solver - \(set-logic QF_UFBV\)
+Sending command to SMT2 solver - \(define-fun |B0| \(\) Bool true\)
+Sending command to SMT2 solver - \(declare-fun |main::1::x!0@1#1| \(\) \(_ BitVec 32\)\)
+Sending command to SMT2 solver - \(define-fun |B1| \(\) Bool \(|=| |main::1::x!0@1#1| |main::1::x!0@1#1|\)\)
+Sending command to SMT2 solver - \(assert \(|not| \(|not| \(|=| |main::1::x!0@1#1| \(_ bv0 32\)\)\)\)\)
+Sending command to SMT2 solver - \(define-fun |B2| \(\) Bool \(|not| false\)\)
+Sending command to SMT2 solver - \(assert |B2|\)
 ^EXIT=(0|127|134|137)$
 ^SIGNAL=0$
 identifier: main::1::x

--- a/regression/cbmc-incr-smt2/nondeterministic-int-assert/incremental_solver_called.desc
+++ b/regression/cbmc-incr-smt2/nondeterministic-int-assert/incremental_solver_called.desc
@@ -1,4 +1,4 @@
-CORE
+CORE winbug
 test.c
 --incremental-smt2-solver "z3 --smt2 -in" --verbosity 10
 Passing problem to incremental SMT2 solving via "z3 --smt2 -in"

--- a/regression/cbmc-incr-smt2/nondeterministic-int-assert/incremental_solver_called.desc
+++ b/regression/cbmc-incr-smt2/nondeterministic-int-assert/incremental_solver_called.desc
@@ -10,16 +10,17 @@ Sending command to SMT2 solver - \(define-fun |B1| \(\) Bool \(|=| |main::1::x!0
 Sending command to SMT2 solver - \(assert \(|not| \(|not| \(|=| |main::1::x!0@1#1| \(_ bv0 32\)\)\)\)\)
 Sending command to SMT2 solver - \(define-fun |B2| \(\) Bool \(|not| false\)\)
 Sending command to SMT2 solver - \(assert |B2|\)
+Sending command to SMT2 solver - \(check-sat\)
+Solver response - sat
 ^EXIT=(0|127|134|137)$
 ^SIGNAL=0$
-identifier: main::1::x
 --
 type: pointer
 --
 Test that running cbmc with the `--incremental-smt2-solver` argument causes the
 incremental smt2 solving to be used. Note that at the time of adding this test,
-an invariant violation is expected due to the unimplemented solving.
-Regexes matching the printing in the expected failed invariant are included in
-order to test that `--slice-formula` is causing the first unimplemented
-expression passed to `smt2_incremental_decision_proceduret` to relate to the
-variable `x` in function `main` and not to `cprover_initialise`.
+an invariant violation is expected due to the unimplemented response parsing.
+
+The sliced formula is expected to use only the implemented subset of exprts.
+This is implementation is sufficient to send this example to the solver and
+receive a "sat" response.

--- a/regression/cbmc-incr-smt2/nondeterministic-int-assert/incremental_solver_called.desc
+++ b/regression/cbmc-incr-smt2/nondeterministic-int-assert/incremental_solver_called.desc
@@ -1,7 +1,9 @@
 CORE
 test.c
---incremental-smt2-solver "z3 --smt2 -in"
+--incremental-smt2-solver "z3 --smt2 -in" --verbosity 10
 Passing problem to incremental SMT2 solving via "z3 --smt2 -in"
+Sending command to SMT2 solver - \(set-option :produce-models true\)
+Sending command to SMT2 solver - \(set-logic QF_UFBV\)
 ^EXIT=(0|127|134|137)$
 ^SIGNAL=0$
 identifier: main::1::x

--- a/src/goto-checker/solver_factory.cpp
+++ b/src/goto-checker/solver_factory.cpp
@@ -33,6 +33,7 @@ Author: Daniel Kroening, Peter Schrammel
 #include <solvers/sat/external_sat.h>
 #include <solvers/sat/satcheck.h>
 #include <solvers/smt2_incremental/smt2_incremental_decision_procedure.h>
+#include <solvers/smt2_incremental/smt_solver_process.h>
 #include <solvers/strings/string_refinement.h>
 
 solver_factoryt::solver_factoryt(
@@ -330,10 +331,12 @@ std::unique_ptr<solver_factoryt::solvert>
 solver_factoryt::get_incremental_smt2(std::string solver_command)
 {
   no_beautification();
+  auto solver_process = util_make_unique<smt_piped_solver_processt>(
+    std::move(solver_command), message_handler);
 
   return util_make_unique<solvert>(
     util_make_unique<smt2_incremental_decision_proceduret>(
-      ns, std::move(solver_command), message_handler));
+      ns, std::move(solver_process), message_handler));
 }
 
 std::unique_ptr<solver_factoryt::solvert>

--- a/src/goto-checker/solver_factory.cpp
+++ b/src/goto-checker/solver_factory.cpp
@@ -333,7 +333,7 @@ solver_factoryt::get_incremental_smt2(std::string solver_command)
 
   return util_make_unique<solvert>(
     util_make_unique<smt2_incremental_decision_proceduret>(
-      std::move(solver_command), message_handler));
+      ns, std::move(solver_command), message_handler));
 }
 
 std::unique_ptr<solver_factoryt::solvert>

--- a/src/goto-checker/solver_factory.cpp
+++ b/src/goto-checker/solver_factory.cpp
@@ -333,7 +333,7 @@ solver_factoryt::get_incremental_smt2(std::string solver_command)
 
   return util_make_unique<solvert>(
     util_make_unique<smt2_incremental_decision_proceduret>(
-      std::move(solver_command)));
+      std::move(solver_command), message_handler));
 }
 
 std::unique_ptr<solver_factoryt::solvert>

--- a/src/solvers/Makefile
+++ b/src/solvers/Makefile
@@ -199,6 +199,7 @@ SRC = $(BOOLEFORCE_SRC) \
       smt2_incremental/smt_core_theory.cpp \
       smt2_incremental/smt_logics.cpp \
       smt2_incremental/smt_options.cpp \
+      smt2_incremental/smt_solver_process.cpp \
       smt2_incremental/smt_sorts.cpp \
       smt2_incremental/smt_terms.cpp \
       smt2_incremental/smt_to_smt2_string.cpp \

--- a/src/solvers/smt2_incremental/convert_expr_to_smt.cpp
+++ b/src/solvers/smt2_incremental/convert_expr_to_smt.cpp
@@ -46,8 +46,8 @@ smt_sortt convert_type_to_smt_sort(const typet &type)
 
 static smt_termt convert_expr_to_smt(const symbol_exprt &symbol_expr)
 {
-  UNIMPLEMENTED_FEATURE(
-    "Generation of SMT formula for symbol expression: " + symbol_expr.pretty());
+  return smt_identifier_termt{symbol_expr.get_identifier(),
+                              convert_type_to_smt_sort(symbol_expr.type())};
 }
 
 static smt_termt convert_expr_to_smt(const nondet_symbol_exprt &nondet_symbol)

--- a/src/solvers/smt2_incremental/smt2_incremental_decision_procedure.cpp
+++ b/src/solvers/smt2_incremental/smt2_incremental_decision_procedure.cpp
@@ -2,11 +2,15 @@
 
 #include "smt2_incremental_decision_procedure.h"
 
+#include <solvers/smt2_incremental/smt_to_smt2_string.h>
 #include <util/expr.h>
+#include <util/string_utils.h>
 
 smt2_incremental_decision_proceduret::smt2_incremental_decision_proceduret(
-  std::string solver_command)
-  : solver_command{std::move(solver_command)}, number_of_solver_calls{0}
+  std::string _solver_command)
+  : solver_command{std::move(_solver_command)},
+    number_of_solver_calls{0},
+    solver_process{split_string(solver_command, ' ', false, true)}
 {
 }
 
@@ -70,4 +74,10 @@ decision_proceduret::resultt smt2_incremental_decision_proceduret::dec_solve()
 {
   ++number_of_solver_calls;
   UNIMPLEMENTED_FEATURE("solving.");
+}
+
+void smt2_incremental_decision_proceduret::send_to_solver(
+  const smt_commandt &command)
+{
+  solver_process.send(smt_to_smt2_string(command) + "\n");
 }

--- a/src/solvers/smt2_incremental/smt2_incremental_decision_procedure.cpp
+++ b/src/solvers/smt2_incremental/smt2_incremental_decision_procedure.cpp
@@ -196,7 +196,10 @@ void smt2_incremental_decision_proceduret::pop()
 decision_proceduret::resultt smt2_incremental_decision_proceduret::dec_solve()
 {
   ++number_of_solver_calls;
-  UNIMPLEMENTED_FEATURE("solving.");
+  send_to_solver(smt_check_sat_commandt{});
+  const auto result = solver_process.wait_receive();
+  log.debug() << "Solver response - " << result << messaget::eom;
+  UNIMPLEMENTED_FEATURE("parsing of solver response.");
 }
 
 void smt2_incremental_decision_proceduret::send_to_solver(

--- a/src/solvers/smt2_incremental/smt2_incremental_decision_procedure.cpp
+++ b/src/solvers/smt2_incremental/smt2_incremental_decision_procedure.cpp
@@ -67,7 +67,7 @@ void smt2_incremental_decision_proceduret::define_dependent_functions(
     {
       const irep_idt &identifier = symbol_expr->get_identifier();
       const symbolt *symbol = nullptr;
-      if(!ns.lookup(identifier, symbol))
+      if(!ns.lookup(identifier, symbol) && !symbol->value.is_nil())
       {
         if(dependencies_needed(symbol->value))
           continue;

--- a/src/solvers/smt2_incremental/smt2_incremental_decision_procedure.cpp
+++ b/src/solvers/smt2_incremental/smt2_incremental_decision_procedure.cpp
@@ -2,6 +2,7 @@
 
 #include "smt2_incremental_decision_procedure.h"
 
+#include <solvers/smt2_incremental/smt_commands.h>
 #include <solvers/smt2_incremental/smt_to_smt2_string.h>
 #include <util/expr.h>
 #include <util/string_utils.h>
@@ -12,6 +13,9 @@ smt2_incremental_decision_proceduret::smt2_incremental_decision_proceduret(
     number_of_solver_calls{0},
     solver_process{split_string(solver_command, ' ', false, true)}
 {
+  send_to_solver(smt_set_option_commandt{smt_option_produce_modelst{true}});
+  send_to_solver(smt_set_logic_commandt{
+    smt_logic_quantifier_free_uninterpreted_functions_bit_vectorst{}});
 }
 
 exprt smt2_incremental_decision_proceduret::handle(const exprt &expr)

--- a/src/solvers/smt2_incremental/smt2_incremental_decision_procedure.cpp
+++ b/src/solvers/smt2_incremental/smt2_incremental_decision_procedure.cpp
@@ -5,12 +5,15 @@
 #include <solvers/smt2_incremental/smt_commands.h>
 #include <solvers/smt2_incremental/smt_to_smt2_string.h>
 #include <util/expr.h>
+#include <util/namespace.h>
 #include <util/string_utils.h>
 
 smt2_incremental_decision_proceduret::smt2_incremental_decision_proceduret(
+  const namespacet &_ns,
   std::string _solver_command,
   message_handlert &message_handler)
-  : solver_command(std::move(_solver_command)),
+  : ns{_ns},
+    solver_command(std::move(_solver_command)),
     number_of_solver_calls{0},
     solver_process{split_string(solver_command, ' ', false, true)},
     log{message_handler}

--- a/src/solvers/smt2_incremental/smt2_incremental_decision_procedure.cpp
+++ b/src/solvers/smt2_incremental/smt2_incremental_decision_procedure.cpp
@@ -67,21 +67,21 @@ void smt2_incremental_decision_proceduret::define_dependent_functions(
     {
       const irep_idt &identifier = symbol_expr->get_identifier();
       const symbolt *symbol = nullptr;
-      if(!ns.lookup(identifier, symbol) && !symbol->value.is_nil())
-      {
-        if(dependencies_needed(symbol->value))
-          continue;
-        const smt_define_function_commandt function{
-          symbol->name, {}, convert_expr_to_smt(symbol->value)};
-        expression_identifiers.emplace(*symbol_expr, function.identifier());
-        solver_process->send(function);
-      }
-      else
+      if(ns.lookup(identifier, symbol) || symbol->value.is_nil())
       {
         const smt_declare_function_commandt function{
           smt_identifier_termt(
             identifier, convert_type_to_smt_sort(symbol_expr->type())),
           {}};
+        expression_identifiers.emplace(*symbol_expr, function.identifier());
+        solver_process->send(function);
+      }
+      else
+      {
+        if(dependencies_needed(symbol->value))
+          continue;
+        const smt_define_function_commandt function{
+          symbol->name, {}, convert_expr_to_smt(symbol->value)};
         expression_identifiers.emplace(*symbol_expr, function.identifier());
         solver_process->send(function);
       }

--- a/src/solvers/smt2_incremental/smt2_incremental_decision_procedure.cpp
+++ b/src/solvers/smt2_incremental/smt2_incremental_decision_procedure.cpp
@@ -2,11 +2,93 @@
 
 #include "smt2_incremental_decision_procedure.h"
 
+#include <solvers/smt2_incremental/convert_expr_to_smt.h>
 #include <solvers/smt2_incremental/smt_commands.h>
+#include <solvers/smt2_incremental/smt_core_theory.h>
+#include <solvers/smt2_incremental/smt_terms.h>
 #include <solvers/smt2_incremental/smt_to_smt2_string.h>
 #include <util/expr.h>
 #include <util/namespace.h>
+#include <util/range.h>
+#include <util/std_expr.h>
 #include <util/string_utils.h>
+#include <util/symbol.h>
+
+#include <stack>
+
+/// \brief Find all sub expressions of the given \p expr which need to be
+///   expressed as separate smt commands.
+/// \note This pass over \p expr is tightly coupled to the implementation of
+///   `convert_expr_to_smt`. This is because any sub expressions which
+///   `convert_expr_to_smt` translates into function applications, must also be
+///   returned by this`gather_dependent_expressions` function.
+static std::unordered_set<exprt, irep_hash>
+gather_dependent_expressions(const exprt &expr)
+{
+  std::unordered_set<exprt, irep_hash> dependent_expressions;
+  expr.visit_pre([&](const exprt &expr_node) {
+    if(can_cast_expr<symbol_exprt>(expr_node))
+    {
+      dependent_expressions.insert(expr_node);
+    }
+  });
+  return dependent_expressions;
+}
+
+/// \brief Defines any functions which \p expr depends on, which have not yet
+///   been defined, along with their dependencies in turn.
+void smt2_incremental_decision_proceduret::define_dependent_functions(
+  const exprt &expr)
+{
+  std::unordered_set<exprt, irep_hash> seen_expressions =
+    make_range(expression_identifiers)
+      .map([](const std::pair<exprt, smt_identifier_termt> &expr_identifier) {
+        return expr_identifier.first;
+      });
+  std::stack<exprt> to_be_defined;
+  const auto dependencies_needed = [&](const exprt &expr) {
+    bool result = false;
+    for(const auto &dependency : gather_dependent_expressions(expr))
+    {
+      if(!seen_expressions.insert(dependency).second)
+        continue;
+      result = true;
+      to_be_defined.push(dependency);
+    }
+    return result;
+  };
+  dependencies_needed(expr);
+  while(!to_be_defined.empty())
+  {
+    const exprt current = to_be_defined.top();
+    if(dependencies_needed(current))
+      continue;
+    if(const auto symbol_expr = expr_try_dynamic_cast<symbol_exprt>(current))
+    {
+      const irep_idt &identifier = symbol_expr->get_identifier();
+      const symbolt *symbol = nullptr;
+      if(!ns.lookup(identifier, symbol))
+      {
+        if(dependencies_needed(symbol->value))
+          continue;
+        const smt_define_function_commandt function{
+          symbol->name, {}, convert_expr_to_smt(symbol->value)};
+        expression_identifiers.emplace(*symbol_expr, function.identifier());
+        send_to_solver(function);
+      }
+      else
+      {
+        const smt_declare_function_commandt function{
+          smt_identifier_termt(
+            identifier, convert_type_to_smt_sort(symbol_expr->type())),
+          {}};
+        expression_identifiers.emplace(*symbol_expr, function.identifier());
+        send_to_solver(function);
+      }
+    }
+    to_be_defined.pop();
+  }
+}
 
 smt2_incremental_decision_proceduret::smt2_incremental_decision_proceduret(
   const namespacet &_ns,
@@ -23,8 +105,27 @@ smt2_incremental_decision_proceduret::smt2_incremental_decision_proceduret(
     smt_logic_quantifier_free_uninterpreted_functions_bit_vectorst{}});
 }
 
+void smt2_incremental_decision_proceduret::ensure_handle_for_expr_defined(
+  const exprt &expr)
+{
+  if(
+    expression_handle_identifiers.find(expr) !=
+    expression_handle_identifiers.cend())
+  {
+    return;
+  }
+
+  define_dependent_functions(expr);
+  smt_define_function_commandt function{
+    "B" + std::to_string(handle_sequence()), {}, convert_expr_to_smt(expr)};
+  expression_handle_identifiers.emplace(expr, function.identifier());
+  send_to_solver(function);
+}
+
 exprt smt2_incremental_decision_proceduret::handle(const exprt &expr)
 {
+  log.debug() << "`handle`  -\n  " << expr.pretty(2, 0) << messaget::eom;
+  ensure_handle_for_expr_defined(expr);
   return expr;
 }
 
@@ -53,9 +154,22 @@ smt2_incremental_decision_proceduret::get_number_of_solver_calls() const
 
 void smt2_incremental_decision_proceduret::set_to(const exprt &expr, bool value)
 {
-  UNIMPLEMENTED_FEATURE(
-    "`set_to` (" + std::string{value ? "true" : "false"} + "):\n  " +
-    expr.pretty(2, 0));
+  PRECONDITION(can_cast_type<bool_typet>(expr.type()));
+  log.debug() << "`set_to` (" << std::string{value ? "true" : "false"}
+              << ") -\n  " << expr.pretty(2, 0) << messaget::eom;
+
+  define_dependent_functions(expr);
+  auto converted_term = [&]() -> smt_termt {
+    const auto expression_handle_identifier =
+      expression_handle_identifiers.find(expr);
+    if(expression_handle_identifier != expression_handle_identifiers.cend())
+      return expression_handle_identifier->second;
+    else
+      return convert_expr_to_smt(expr);
+  }();
+  if(!value)
+    converted_term = smt_core_theoryt::make_not(converted_term);
+  send_to_solver(smt_assert_commandt{converted_term});
 }
 
 void smt2_incremental_decision_proceduret::push(

--- a/src/solvers/smt2_incremental/smt2_incremental_decision_procedure.cpp
+++ b/src/solvers/smt2_incremental/smt2_incremental_decision_procedure.cpp
@@ -18,18 +18,21 @@
 
 /// \brief Find all sub expressions of the given \p expr which need to be
 ///   expressed as separate smt commands.
+/// \return A collection of sub expressions, which need to be expressed as
+///   separate smt commands. This collection is in traversal order. It will
+///   include duplicate subexpressions, which need to be removed by the caller
+///   in order to avoid duplicate definitions.
 /// \note This pass over \p expr is tightly coupled to the implementation of
 ///   `convert_expr_to_smt`. This is because any sub expressions which
 ///   `convert_expr_to_smt` translates into function applications, must also be
 ///   returned by this`gather_dependent_expressions` function.
-static std::unordered_set<exprt, irep_hash>
-gather_dependent_expressions(const exprt &expr)
+static std::vector<exprt> gather_dependent_expressions(const exprt &expr)
 {
-  std::unordered_set<exprt, irep_hash> dependent_expressions;
+  std::vector<exprt> dependent_expressions;
   expr.visit_pre([&](const exprt &expr_node) {
     if(can_cast_expr<symbol_exprt>(expr_node))
     {
-      dependent_expressions.insert(expr_node);
+      dependent_expressions.push_back(expr_node);
     }
   });
   return dependent_expressions;

--- a/src/solvers/smt2_incremental/smt2_incremental_decision_procedure.cpp
+++ b/src/solvers/smt2_incremental/smt2_incremental_decision_procedure.cpp
@@ -8,10 +8,12 @@
 #include <util/string_utils.h>
 
 smt2_incremental_decision_proceduret::smt2_incremental_decision_proceduret(
-  std::string _solver_command)
-  : solver_command{std::move(_solver_command)},
+  std::string _solver_command,
+  message_handlert &message_handler)
+  : solver_command(std::move(_solver_command)),
     number_of_solver_calls{0},
-    solver_process{split_string(solver_command, ' ', false, true)}
+    solver_process{split_string(solver_command, ' ', false, true)},
+    log{message_handler}
 {
   send_to_solver(smt_set_option_commandt{smt_option_produce_modelst{true}});
   send_to_solver(smt_set_logic_commandt{
@@ -83,5 +85,8 @@ decision_proceduret::resultt smt2_incremental_decision_proceduret::dec_solve()
 void smt2_incremental_decision_proceduret::send_to_solver(
   const smt_commandt &command)
 {
-  solver_process.send(smt_to_smt2_string(command) + "\n");
+  const std::string command_string = smt_to_smt2_string(command);
+  log.debug() << "Sending command to SMT2 solver - " << command_string
+              << messaget::eom;
+  solver_process.send(command_string + "\n");
 }

--- a/src/solvers/smt2_incremental/smt2_incremental_decision_procedure.h
+++ b/src/solvers/smt2_incremental/smt2_incremental_decision_procedure.h
@@ -9,15 +9,16 @@
 #include <solvers/smt2_incremental/smt_terms.h>
 #include <solvers/stack_decision_procedure.h>
 #include <util/message.h>
-#include <util/piped_process.h>
 #include <util/std_expr.h>
 
+#include <memory>
 #include <unordered_map>
 #include <unordered_set>
 
 class smt_commandt;
 class message_handlert;
 class namespacet;
+class smt_base_solver_processt;
 
 class smt2_incremental_decision_proceduret final
   : public stack_decision_proceduret
@@ -25,13 +26,13 @@ class smt2_incremental_decision_proceduret final
 public:
   /// \param _ns: Namespace for looking up the expressions which symbol_exprts
   ///   relate to.
-  /// \param solver_command:
-  ///   The command and arguments for invoking the smt2 solver.
+  /// \param solver_process:
+  ///   The smt2 solver process communication interface.
   /// \param message_handler:
   ///   The messaging system to be used for logging purposes.
   explicit smt2_incremental_decision_proceduret(
     const namespacet &_ns,
-    std::string solver_command,
+    std::unique_ptr<smt_base_solver_processt> solver_process,
     message_handlert &message_handler);
 
   // Implementation of public decision_proceduret member functions.
@@ -50,9 +51,6 @@ public:
 protected:
   // Implementation of protected decision_proceduret member function.
   resultt dec_solve() override;
-  /// \brief Converts given SMT2 command to SMT2 string and sends it to the
-  ///    solver process.
-  void send_to_solver(const smt_commandt &command);
   /// \brief Defines any functions which \p expr depends on, which have not yet
   ///   been defined, along with their dependencies in turn.
   void define_dependent_functions(const exprt &expr);
@@ -60,11 +58,9 @@ protected:
 
   const namespacet &ns;
 
-  /// This is where we store the solver command for reporting the solver used.
-  std::string solver_command;
   size_t number_of_solver_calls;
 
-  piped_processt solver_process;
+  std::unique_ptr<smt_base_solver_processt> solver_process;
   messaget log;
 
   class sequencet

--- a/src/solvers/smt2_incremental/smt2_incremental_decision_procedure.h
+++ b/src/solvers/smt2_incremental/smt2_incremental_decision_procedure.h
@@ -6,9 +6,14 @@
 #ifndef CPROVER_SOLVERS_SMT2_INCREMENTAL_SMT2_INCREMENTAL_DECISION_PROCEDURE_H
 #define CPROVER_SOLVERS_SMT2_INCREMENTAL_SMT2_INCREMENTAL_DECISION_PROCEDURE_H
 
+#include <solvers/smt2_incremental/smt_terms.h>
 #include <solvers/stack_decision_procedure.h>
 #include <util/message.h>
 #include <util/piped_process.h>
+#include <util/std_expr.h>
+
+#include <unordered_map>
+#include <unordered_set>
 
 class smt_commandt;
 class message_handlert;
@@ -48,6 +53,10 @@ protected:
   /// \brief Converts given SMT2 command to SMT2 string and sends it to the
   ///    solver process.
   void send_to_solver(const smt_commandt &command);
+  /// \brief Defines any functions which \p expr depends on, which have not yet
+  ///   been defined, along with their dependencies in turn.
+  void define_dependent_functions(const exprt &expr);
+  void ensure_handle_for_expr_defined(const exprt &expr);
 
   const namespacet &ns;
 
@@ -57,6 +66,22 @@ protected:
 
   piped_processt solver_process;
   messaget log;
+
+  class sequencet
+  {
+    size_t next_id = 0;
+
+  public:
+    size_t operator()()
+    {
+      return next_id++;
+    }
+  } handle_sequence;
+
+  std::unordered_map<exprt, smt_identifier_termt, irep_hash>
+    expression_handle_identifiers;
+  std::unordered_map<exprt, smt_identifier_termt, irep_hash>
+    expression_identifiers;
 };
 
 #endif // CPROVER_SOLVERS_SMT2_INCREMENTAL_SMT2_INCREMENTAL_DECISION_PROCEDURE_H

--- a/src/solvers/smt2_incremental/smt2_incremental_decision_procedure.h
+++ b/src/solvers/smt2_incremental/smt2_incremental_decision_procedure.h
@@ -7,6 +7,9 @@
 #define CPROVER_SOLVERS_SMT2_INCREMENTAL_SMT2_INCREMENTAL_DECISION_PROCEDURE_H
 
 #include <solvers/stack_decision_procedure.h>
+#include <util/piped_process.h>
+
+class smt_commandt;
 
 class smt2_incremental_decision_proceduret final
   : public stack_decision_proceduret
@@ -32,10 +35,15 @@ public:
 protected:
   // Implementation of protected decision_proceduret member function.
   resultt dec_solve() override;
+  /// \brief Converts given SMT2 command to SMT2 string and sends it to the
+  ///    solver process.
+  void send_to_solver(const smt_commandt &command);
 
   /// This is where we store the solver command for reporting the solver used.
   std::string solver_command;
   size_t number_of_solver_calls;
+
+  piped_processt solver_process;
 };
 
 #endif // CPROVER_SOLVERS_SMT2_INCREMENTAL_SMT2_INCREMENTAL_DECISION_PROCEDURE_H

--- a/src/solvers/smt2_incremental/smt2_incremental_decision_procedure.h
+++ b/src/solvers/smt2_incremental/smt2_incremental_decision_procedure.h
@@ -12,16 +12,20 @@
 
 class smt_commandt;
 class message_handlert;
+class namespacet;
 
 class smt2_incremental_decision_proceduret final
   : public stack_decision_proceduret
 {
 public:
+  /// \param _ns: Namespace for looking up the expressions which symbol_exprts
+  ///   relate to.
   /// \param solver_command:
   ///   The command and arguments for invoking the smt2 solver.
   /// \param message_handler:
   ///   The messaging system to be used for logging purposes.
   explicit smt2_incremental_decision_proceduret(
+    const namespacet &_ns,
     std::string solver_command,
     message_handlert &message_handler);
 
@@ -44,6 +48,8 @@ protected:
   /// \brief Converts given SMT2 command to SMT2 string and sends it to the
   ///    solver process.
   void send_to_solver(const smt_commandt &command);
+
+  const namespacet &ns;
 
   /// This is where we store the solver command for reporting the solver used.
   std::string solver_command;

--- a/src/solvers/smt2_incremental/smt2_incremental_decision_procedure.h
+++ b/src/solvers/smt2_incremental/smt2_incremental_decision_procedure.h
@@ -7,17 +7,23 @@
 #define CPROVER_SOLVERS_SMT2_INCREMENTAL_SMT2_INCREMENTAL_DECISION_PROCEDURE_H
 
 #include <solvers/stack_decision_procedure.h>
+#include <util/message.h>
 #include <util/piped_process.h>
 
 class smt_commandt;
+class message_handlert;
 
 class smt2_incremental_decision_proceduret final
   : public stack_decision_proceduret
 {
 public:
-  /// \param solver_command: The command and arguments for invoking the smt2
-  ///                        solver.
-  explicit smt2_incremental_decision_proceduret(std::string solver_command);
+  /// \param solver_command:
+  ///   The command and arguments for invoking the smt2 solver.
+  /// \param message_handler:
+  ///   The messaging system to be used for logging purposes.
+  explicit smt2_incremental_decision_proceduret(
+    std::string solver_command,
+    message_handlert &message_handler);
 
   // Implementation of public decision_proceduret member functions.
   exprt handle(const exprt &expr) override;
@@ -44,6 +50,7 @@ protected:
   size_t number_of_solver_calls;
 
   piped_processt solver_process;
+  messaget log;
 };
 
 #endif // CPROVER_SOLVERS_SMT2_INCREMENTAL_SMT2_INCREMENTAL_DECISION_PROCEDURE_H

--- a/src/solvers/smt2_incremental/smt_responses.h
+++ b/src/solvers/smt2_incremental/smt_responses.h
@@ -1,0 +1,21 @@
+// Author: Diffblue Ltd.
+
+#ifndef CPROVER_SOLVERS_SMT2_INCREMENTAL_SMT_RESPONSES_H
+#define CPROVER_SOLVERS_SMT2_INCREMENTAL_SMT_RESPONSES_H
+
+#include <util/irep.h>
+
+class smt_responset : protected irept
+{
+public:
+  // smt_responset does not support the notion of an empty / null state. Use
+  // optionalt<smt_responset> instead if an empty response is required.
+  smt_responset() = delete;
+
+  using irept::pretty;
+
+protected:
+  using irept::irept;
+};
+
+#endif // CPROVER_SOLVERS_SMT2_INCREMENTAL_SMT_RESPONSES_H

--- a/src/solvers/smt2_incremental/smt_solver_process.cpp
+++ b/src/solvers/smt2_incremental/smt_solver_process.cpp
@@ -1,0 +1,36 @@
+// Author: Diffblue Ltd.
+
+#include <solvers/smt2_incremental/smt_solver_process.h>
+
+#include <solvers/smt2_incremental/smt_to_smt2_string.h>
+#include <util/invariant.h>
+#include <util/string_utils.h>
+
+smt_piped_solver_processt::smt_piped_solver_processt(
+  std::string command_line,
+  message_handlert &message_handler)
+  : command_line_description{"\"" + command_line + "\""},
+    process{split_string(command_line, ' ', false, true)},
+    log{message_handler}
+{
+}
+
+const std::string &smt_piped_solver_processt::description()
+{
+  return command_line_description;
+}
+
+void smt_piped_solver_processt::send(const smt_commandt &smt_command)
+{
+  const std::string command_string = smt_to_smt2_string(smt_command);
+  log.debug() << "Sending command to SMT2 solver - " << command_string
+              << messaget::eom;
+  process.send(command_string + "\n");
+}
+
+smt_responset smt_piped_solver_processt::receive_response()
+{
+  const auto response_text = process.wait_receive();
+  log.debug() << "Solver response - " << response_text << messaget::eom;
+  UNIMPLEMENTED_FEATURE("parsing of solver response.");
+}

--- a/src/solvers/smt2_incremental/smt_solver_process.h
+++ b/src/solvers/smt2_incremental/smt_solver_process.h
@@ -1,0 +1,56 @@
+// Author: Diffblue Ltd.
+
+#ifndef CPROVER_SOLVERS_SMT2_INCREMENTAL_SMT_SOLVER_PROCESS_H
+#define CPROVER_SOLVERS_SMT2_INCREMENTAL_SMT_SOLVER_PROCESS_H
+
+class smt_commandt;
+
+#include <solvers/smt2_incremental/smt_responses.h>
+#include <util/message.h>
+#include <util/piped_process.h>
+
+#include <string>
+
+class smt_base_solver_processt
+{
+public:
+  virtual const std::string &description() = 0;
+
+  /// \brief Converts given SMT2 command to SMT2 string and sends it to the
+  ///    solver process.
+  virtual void send(const smt_commandt &command) = 0;
+
+  virtual smt_responset receive_response() = 0;
+
+  virtual ~smt_base_solver_processt() = default;
+};
+
+class smt_piped_solver_processt : public smt_base_solver_processt
+{
+public:
+  /// \param command_line:
+  ///   The command and arguments for invoking the smt2 solver.
+  /// \param message_handler:
+  ///   The messaging system to be used for logging purposes.
+  smt_piped_solver_processt(
+    std::string command_line,
+    message_handlert &message_handler);
+
+  const std::string &description() override;
+
+  void send(const smt_commandt &smt_command) override;
+
+  smt_responset receive_response() override;
+
+  ~smt_piped_solver_processt() override = default;
+
+protected:
+  /// The command line used to start the process.
+  std::string command_line_description;
+  /// The raw solver sub process.
+  piped_processt process;
+  /// For debug printing.
+  messaget log;
+};
+
+#endif // CPROVER_SOLVERS_SMT2_INCREMENTAL_SMT_SOLVER_PROCESS_H

--- a/src/solvers/smt2_incremental/smt_terms.cpp
+++ b/src/solvers/smt2_incremental/smt_terms.cpp
@@ -50,7 +50,7 @@ bool smt_bool_literal_termt::value() const
 
 static bool is_valid_smt_identifier(irep_idt identifier)
 {
-  static const std::regex valid{R"(^[^\|\\]*$)"};
+  static const std::regex valid{R"(^[^\|]*$)"};
   return std::regex_match(id2string(identifier), valid);
 }
 
@@ -59,7 +59,7 @@ smt_identifier_termt::smt_identifier_termt(irep_idt identifier, smt_sortt sort)
 {
   INVARIANT(
     is_valid_smt_identifier(identifier),
-    R"(Identifiers may not contain | or \ characters.)");
+    R"(Identifiers may not contain | characters.)");
   set(ID_identifier, identifier);
 }
 

--- a/unit/Makefile
+++ b/unit/Makefile
@@ -99,6 +99,7 @@ SRC += analyses/ai/ai.cpp \
        solvers/sat/satcheck_minisat2.cpp \
        solvers/smt2/smt2_conv.cpp \
        solvers/smt2_incremental/convert_expr_to_smt.cpp \
+       solvers/smt2_incremental/smt2_incremental_decision_procedure.cpp \
        solvers/smt2_incremental/smt_bit_vector_theory.cpp \
        solvers/smt2_incremental/smt_commands.cpp \
        solvers/smt2_incremental/smt_core_theory.cpp \

--- a/unit/solvers/smt2_incremental/convert_expr_to_smt.cpp
+++ b/unit/solvers/smt2_incremental/convert_expr_to_smt.cpp
@@ -34,6 +34,13 @@ TEST_CASE("\"typet\" to smt sort conversion", "[core][smt2_incremental]")
   }
 }
 
+TEST_CASE("\"symbol_exprt\" to smt term conversion", "[core][smt2_incremental]")
+{
+  CHECK(
+    convert_expr_to_smt(symbol_exprt{"foo", bool_typet{}}) ==
+    smt_identifier_termt("foo", smt_bool_sortt{}));
+}
+
 TEST_CASE(
   "\"exprt\" to smt term conversion for constants/literals",
   "[core][smt2_incremental]")

--- a/unit/solvers/smt2_incremental/smt2_incremental_decision_procedure.cpp
+++ b/unit/solvers/smt2_incremental/smt2_incremental_decision_procedure.cpp
@@ -143,23 +143,23 @@ TEST_CASE(
       REQUIRE(
         sent_commands ==
         std::vector<smt_commandt>{
-          smt_declare_function_commandt{nondet_int_b_term, {}},
           smt_declare_function_commandt{nondet_int_a_term, {}},
           smt_define_function_commandt{
-            "third_comparison",
-            {},
-            smt_core_theoryt::equal(nondet_int_a_term, nondet_int_b_term)},
-          smt_define_function_commandt{
             "forty_two", {}, smt_bit_vector_constant_termt{42, 16}},
+          smt_define_function_commandt{
+            "first_comparison",
+            {},
+            smt_core_theoryt::equal(nondet_int_a_term, forty_two_term)},
+          smt_declare_function_commandt{nondet_int_b_term, {}},
           smt_define_function_commandt{
             "second_comparison",
             {},
             smt_core_theoryt::make_not(
               smt_core_theoryt::equal(nondet_int_b_term, forty_two_term))},
           smt_define_function_commandt{
-            "first_comparison",
+            "third_comparison",
             {},
-            smt_core_theoryt::equal(nondet_int_a_term, forty_two_term)},
+            smt_core_theoryt::equal(nondet_int_a_term, nondet_int_b_term)},
           smt_define_function_commandt{
             "comparison_conjunction",
             {},

--- a/unit/solvers/smt2_incremental/smt2_incremental_decision_procedure.cpp
+++ b/unit/solvers/smt2_incremental/smt2_incremental_decision_procedure.cpp
@@ -14,6 +14,12 @@
 #include <util/namespace.h>
 #include <util/symbol_table.h>
 
+// Used by catch framework for printing in the case of test failures. This
+// means that we get error messages showing the smt formula expressed as SMT2
+// strings instead of `{?}` being printed. It works because catch uses the
+// appropriate overload of `operator<<` where it exists.
+#include <solvers/smt2_incremental/smt_to_smt2_string.h>
+
 class smt_mock_solver_processt : public smt_base_solver_processt
 {
 public:

--- a/unit/solvers/smt2_incremental/smt2_incremental_decision_procedure.cpp
+++ b/unit/solvers/smt2_incremental/smt2_incremental_decision_procedure.cpp
@@ -1,0 +1,206 @@
+// Author: Diffblue Ltd.
+
+#include <testing-utils/use_catch.h>
+
+#include <solvers/smt2_incremental/smt2_incremental_decision_procedure.h>
+#include <solvers/smt2_incremental/smt_commands.h>
+#include <solvers/smt2_incremental/smt_core_theory.h>
+#include <solvers/smt2_incremental/smt_solver_process.h>
+#include <solvers/smt2_incremental/smt_sorts.h>
+#include <solvers/smt2_incremental/smt_terms.h>
+#include <util/arith_tools.h>
+#include <util/bitvector_types.h>
+#include <util/make_unique.h>
+#include <util/namespace.h>
+#include <util/symbol_table.h>
+
+class smt_mock_solver_processt : public smt_base_solver_processt
+{
+public:
+  const std::string &description() override
+  {
+    UNREACHABLE;
+  }
+
+  void send(const smt_commandt &smt_command) override
+  {
+    sent_commands.push_back(smt_command);
+  }
+
+  smt_responset receive_response() override
+  {
+    UNREACHABLE;
+  }
+
+  std::vector<smt_commandt> sent_commands;
+
+  ~smt_mock_solver_processt() override = default;
+};
+
+static symbolt make_test_symbol(irep_idt id, typet type)
+{
+  symbolt new_symbol;
+  new_symbol.name = std::move(id);
+  new_symbol.type = std::move(type);
+  return new_symbol;
+}
+
+static symbolt make_test_symbol(irep_idt id, exprt value)
+{
+  symbolt new_symbol;
+  new_symbol.name = std::move(id);
+  new_symbol.type = value.type();
+  new_symbol.value = std::move(value);
+  return new_symbol;
+}
+
+TEST_CASE(
+  "smt2_incremental_decision_proceduret commands sent",
+  "[core][smt2_incremental]")
+{
+  symbol_tablet symbol_table;
+  namespacet ns{symbol_table};
+  auto mock_process = util_make_unique<smt_mock_solver_processt>();
+  auto &sent_commands = mock_process->sent_commands;
+  null_message_handlert message_handler;
+  SECTION("Construction / solver initialisation.")
+  {
+    smt2_incremental_decision_proceduret procedure{
+      ns, std::move(mock_process), message_handler};
+    REQUIRE(
+      sent_commands ==
+      std::vector<smt_commandt>{
+        smt_set_option_commandt{smt_option_produce_modelst{true}},
+        smt_set_logic_commandt{
+          smt_logic_quantifier_free_uninterpreted_functions_bit_vectorst{}}});
+    sent_commands.clear();
+    SECTION("Set symbol to true.")
+    {
+      const symbolt foo = make_test_symbol("foo", bool_typet{});
+      const smt_identifier_termt foo_term{"foo", smt_bool_sortt{}};
+      procedure.set_to(foo.symbol_expr(), true);
+      REQUIRE(
+        sent_commands ==
+        std::vector<smt_commandt>{smt_declare_function_commandt{foo_term, {}},
+                                  smt_assert_commandt{foo_term}});
+    }
+    SECTION("Set symbol to false.")
+    {
+      const symbolt foo = make_test_symbol("foo", bool_typet{});
+      const smt_identifier_termt foo_term{"foo", smt_bool_sortt{}};
+      procedure.set_to(foo.symbol_expr(), false);
+      REQUIRE(
+        sent_commands ==
+        std::vector<smt_commandt>{
+          smt_declare_function_commandt{foo_term, {}},
+          smt_assert_commandt{smt_core_theoryt::make_not(foo_term)}});
+    }
+    SECTION("Set using chaining of symbol expressions.")
+    {
+      const symbolt forty_two =
+        make_test_symbol("forty_two", from_integer({42}, signedbv_typet{16}));
+      symbol_table.insert(forty_two);
+      const smt_identifier_termt forty_two_term{"forty_two",
+                                                smt_bit_vector_sortt{16}};
+      const symbolt nondet_int_a =
+        make_test_symbol("nondet_int_a", signedbv_typet{16});
+      symbol_table.insert(nondet_int_a);
+      const smt_identifier_termt nondet_int_a_term{"nondet_int_a",
+                                                   smt_bit_vector_sortt{16}};
+      const symbolt nondet_int_b =
+        make_test_symbol("nondet_int_b", signedbv_typet{16});
+      symbol_table.insert(nondet_int_b);
+      const smt_identifier_termt nondet_int_b_term{"nondet_int_b",
+                                                   smt_bit_vector_sortt{16}};
+      const symbolt first_comparison = make_test_symbol(
+        "first_comparison",
+        equal_exprt{nondet_int_a.symbol_expr(), forty_two.symbol_expr()});
+      symbol_table.insert(first_comparison);
+      const symbolt second_comparison = make_test_symbol(
+        "second_comparison",
+        not_exprt{
+          equal_exprt{nondet_int_b.symbol_expr(), forty_two.symbol_expr()}});
+      symbol_table.insert(second_comparison);
+      const symbolt third_comparison = make_test_symbol(
+        "third_comparison",
+        equal_exprt{nondet_int_a.symbol_expr(), nondet_int_b.symbol_expr()});
+      symbol_table.insert(third_comparison);
+      const symbolt comparison_conjunction = make_test_symbol(
+        "comparison_conjunction",
+        and_exprt{{first_comparison.symbol_expr(),
+                   second_comparison.symbol_expr(),
+                   third_comparison.symbol_expr()}});
+      symbol_table.insert(comparison_conjunction);
+      smt_identifier_termt comparison_conjunction_term{"comparison_conjunction",
+                                                       smt_bool_sortt{}};
+      procedure.set_to(comparison_conjunction.symbol_expr(), true);
+      REQUIRE(
+        sent_commands ==
+        std::vector<smt_commandt>{
+          smt_declare_function_commandt{nondet_int_b_term, {}},
+          smt_declare_function_commandt{nondet_int_a_term, {}},
+          smt_define_function_commandt{
+            "third_comparison",
+            {},
+            smt_core_theoryt::equal(nondet_int_a_term, nondet_int_b_term)},
+          smt_define_function_commandt{
+            "forty_two", {}, smt_bit_vector_constant_termt{42, 16}},
+          smt_define_function_commandt{
+            "second_comparison",
+            {},
+            smt_core_theoryt::make_not(
+              smt_core_theoryt::equal(nondet_int_b_term, forty_two_term))},
+          smt_define_function_commandt{
+            "first_comparison",
+            {},
+            smt_core_theoryt::equal(nondet_int_a_term, forty_two_term)},
+          smt_define_function_commandt{
+            "comparison_conjunction",
+            {},
+            smt_core_theoryt::make_and(
+              smt_core_theoryt::make_and(
+                smt_identifier_termt{"first_comparison", smt_bool_sortt{}},
+                smt_identifier_termt{"second_comparison", smt_bool_sortt{}}),
+              smt_identifier_termt{"third_comparison", smt_bool_sortt{}})},
+          smt_assert_commandt{comparison_conjunction_term}});
+    }
+    SECTION("Handle of value-less symbol.")
+    {
+      const symbolt foo = make_test_symbol("foo", bool_typet{});
+      const smt_identifier_termt foo_term{"foo", smt_bool_sortt{}};
+      procedure.handle(foo.symbol_expr());
+      REQUIRE(
+        sent_commands == std::vector<smt_commandt>{
+                           smt_declare_function_commandt{foo_term, {}},
+                           smt_define_function_commandt{"B0", {}, foo_term}});
+      sent_commands.clear();
+      SECTION("Handle of previously handled expression.")
+      {
+        procedure.handle(foo.symbol_expr());
+        REQUIRE(sent_commands.empty());
+      }
+      SECTION("Handle of new expression containing previously defined symbol.")
+      {
+        procedure.handle(equal_exprt{foo.symbol_expr(), foo.symbol_expr()});
+        REQUIRE(
+          sent_commands ==
+          std::vector<smt_commandt>{smt_define_function_commandt{
+            "B1", {}, smt_core_theoryt::equal(foo_term, foo_term)}});
+      }
+    }
+    SECTION("Handle of symbol with value.")
+    {
+      const symbolt bar =
+        make_test_symbol("bar", from_integer({42}, signedbv_typet{8}));
+      symbol_table.insert(bar);
+      procedure.handle(bar.symbol_expr());
+      REQUIRE(
+        sent_commands ==
+        std::vector<smt_commandt>{
+          smt_define_function_commandt{
+            "bar", {}, smt_bit_vector_constant_termt{42, 8}},
+          smt_define_function_commandt{
+            "B0", {}, smt_identifier_termt{"bar", smt_bit_vector_sortt{8}}}});
+    }
+  }
+}

--- a/unit/solvers/smt2_incremental/smt_terms.cpp
+++ b/unit/solvers/smt2_incremental/smt_terms.cpp
@@ -39,7 +39,7 @@ TEST_CASE("smt_identifier_termt construction", "[core][smt2_incremental]")
   cbmc_invariants_should_throwt invariants_throw;
   CHECK_NOTHROW(smt_identifier_termt{"foo bar", smt_bool_sortt{}});
   CHECK_THROWS(smt_identifier_termt{"|foo bar|", smt_bool_sortt{}});
-  CHECK_THROWS(smt_identifier_termt{"foo\\ bar", smt_bool_sortt{}});
+  CHECK_NOTHROW(smt_identifier_termt{"foo\\ bar", smt_bool_sortt{}});
 }
 
 TEST_CASE("smt_identifier_termt getters.", "[core][smt2_incremental]")

--- a/unit/solvers/smt2_incremental/smt_to_smt2_string.cpp
+++ b/unit/solvers/smt2_incremental/smt_to_smt2_string.cpp
@@ -33,6 +33,18 @@ TEST_CASE(
 }
 
 TEST_CASE(
+  "Test smt_identifier_termt to string conversion",
+  "[core][smt2_incremental]")
+{
+  CHECK(
+    smt_to_smt2_string(smt_identifier_termt{"abc", smt_bool_sortt{}}) ==
+    "|abc|");
+  CHECK(
+    smt_to_smt2_string(smt_identifier_termt{"\\", smt_bool_sortt{}}) ==
+    "|&92;|");
+}
+
+TEST_CASE(
   "Test smt_function_application_termt to string conversion",
   "[core][smt2_incremental]")
 {


### PR DESCRIPTION
This PR includes implementation of sending commands to solver in incremental SMT2 backend, based on the exprts recieved. This is sufficient to get a sat/unsat response from the solver in sufficiently simple cases. However parsing the result from the solver is not included in this PR and will be in a follow up PR.
<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] N/A - Non claimed. ~~My commit message includes data points confirming performance improvements (if claimed).~~
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
