### PR TITLE
Build with /usr/bin/clang on MacOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,15 @@
 cmake_minimum_required(VERSION 3.2)
 
+# Compile with /usr/bin/clang on MacOS
+# See https://github.com/diffblue/cbmc/issues/4956
+#
+if (CMAKE_HOST_SYSTEM_NAME STREQUAL Darwin)
+    if(NOT DEFINED CMAKE_C_COMPILER)
+        message(STATUS "Setting CMAKE_C_COMPILER to /usr/bin/clang for MacOS")
+        set(CMAKE_C_COMPILER "/usr/bin/clang")
+    endif()
+endif()
+
 # If cmake generates files inside of the cbmc source directory this can lead to important files being overwritten, so we prevent that here
 if("${CMAKE_BINARY_DIR}" STREQUAL "${CMAKE_SOURCE_DIR}")
   message(FATAL_ERROR


### PR DESCRIPTION
This replaces https://github.com/diffblue/cbmc/pull/6344.  The JDK 17 issues dealt with there are being fixed.

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
