### PR TITLE
Handle functions with mangled names in contract replacement

### DIFF
--- a/regression/contracts/assigns_replace_09/main.c
+++ b/regression/contracts/assigns_replace_09/main.c
@@ -1,0 +1,19 @@
+#include <stdlib.h>
+
+int x;
+int *z = &x;
+
+void bar() __CPROVER_assigns(*z)
+{
+}
+
+static void foo() __CPROVER_assigns(*z)
+{
+  bar();
+}
+
+int main()
+{
+  foo();
+  return 0;
+}

--- a/regression/contracts/assigns_replace_09/test.desc
+++ b/regression/contracts/assigns_replace_09/test.desc
@@ -1,0 +1,12 @@
+CORE
+main.c
+--replace-call-with-contract bar
+^EXIT=0$
+^SIGNAL=0$
+\[\d+\] file main.c line \d+ Check that bar\'s assigns clause is a subset of foo\'s assigns clause: SUCCESS$
+^VERIFICATION SUCCESSFUL$
+--
+^Condition: \!not\_found$
+--
+Checks whether CBMC properly evaluates subset relationship on assigns
+during replacement with static functions.

--- a/src/goto-instrument/contracts/contracts.h
+++ b/src/goto-instrument/contracts/contracts.h
@@ -195,8 +195,9 @@ protected:
   /// non-deterministic assignments for the write set, and assumptions
   /// based on ensures clauses.
   bool apply_function_contract(
-    goto_programt &goto_program,
-    goto_programt::targett target);
+    const irep_idt &,
+    goto_programt &,
+    goto_programt::targett &);
 
   /// Instruments `wrapper_function` adding assumptions based on requires
   /// clauses and assertions based on ensures clauses.


### PR DESCRIPTION
Signed-off-by: Felipe R. Monteiro <felisous@amazon.com>

In some cases, we use `source_location` to retrieve information (e.g., function name). However, if we are consuming a `goto_programt`, but also care about the name of that function, then it must be passed separately. We should not try to infer it via some means, such as the source location. In this case, `apply_function_contract` must also consume a `function_id`, so we can properly retrieve the symbol for the caller function.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
