### PR TITLE
cmdlinet::get_comma_separated_values: re-use split_string

### DIFF
--- a/regression/goto-instrument/fp-reachability-slice3/test.desc
+++ b/regression/goto-instrument/fp-reachability-slice3/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---fp-reachability-slice b,c
+--fp-reachability-slice b --fp-reachability-slice c
 ^EXIT=0$
 ^SIGNAL=0$
 1 file main.c line 34

--- a/src/util/cmdline.cpp
+++ b/src/util/cmdline.cpp
@@ -11,6 +11,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/edit_distance.h>
 #include <util/exception_utils.h>
 #include <util/invariant.h>
+#include <util/string_utils.h>
 
 cmdlinet::cmdlinet()
 {
@@ -120,16 +121,14 @@ std::list<std::string>
 cmdlinet::get_comma_separated_values(const char *option) const
 {
   std::list<std::string> separated_values;
-  auto i = getoptnr(option);
-  if(i.has_value() && !options[*i].values.empty())
+
+  for(const auto &csv : get_values(option))
   {
-    std::istringstream values_stream(options[*i].values.front());
-    std::string single_value;
-    while(std::getline(values_stream, single_value, ','))
-    {
-      separated_values.push_back(single_value);
-    }
+    const auto values = split_string(csv, ',');
+    separated_values.insert(
+      separated_values.end(), values.begin(), values.end());
   }
+
   return separated_values;
 }
 

--- a/src/util/cmdline.h
+++ b/src/util/cmdline.h
@@ -80,6 +80,8 @@ public:
   const std::list<std::string> &get_values(const std::string &option) const;
   const std::list<std::string> &get_values(char option) const;
 
+  /// Collect all occurrences of option \p option and split their values on each
+  /// comma, merging them into a single list of values.
   std::list<std::string> get_comma_separated_values(const char *option) const;
 
   virtual bool isset(char option) const;


### PR DESCRIPTION
Instead of (re-)implementing string parsing, use the existing
split_string function to turn comma-separated values into a sequence of
elements.

While at it, also teach cmdlinet::get_comma_separated_values to handle
multiple occurrences of the same option, and document that method.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
