### PR TITLE
A predicate to validate all pointer derefs in an expression AST

### DIFF
--- a/regression/contracts/assigns_enforce_structs_07/main.c
+++ b/regression/contracts/assigns_enforce_structs_07/main.c
@@ -25,9 +25,12 @@ void f2(struct pair_of_pairs *pp) __CPROVER_assigns(*(pp->p->buf))
 
 int main()
 {
-  struct pair *p = nondet_bool() ? malloc(sizeof(*p)) : NULL;
+  struct pair *p = malloc(sizeof(*p));
   f1(p);
+
   struct pair_of_pairs *pp = malloc(sizeof(*pp));
+  if(pp)
+    pp->p = malloc(sizeof(*(pp->p)));
   f2(pp);
 
   return 0;

--- a/regression/contracts/assigns_enforce_structs_07/test.desc
+++ b/regression/contracts/assigns_enforce_structs_07/test.desc
@@ -1,17 +1,16 @@
-KNOWNBUG
+CORE
 main.c
---enforce-all-contracts _ --pointer-check
+--enforce-all-contracts _ --malloc-may-fail --malloc-fail-null --pointer-check
 ^EXIT=10$
 ^SIGNAL=0$
-^\[f1.\d+\] line \d+ Check that p->buf\[\(.*\)0\] is assignable: FAILURE$
+^\[f1.\d+\] line \d+ Check that p->buf\[\(.*\)0\] is assignable: SUCCESS$
+^\[f1.pointer\_dereference.\d+\] line \d+ dereference failure: pointer invalid in p->buf\[\(.*\)0\]: FAILURE$
 ^\[f1.pointer\_dereference.\d+\] line \d+ dereference failure: pointer NULL in p->buf: FAILURE$
-^\[f2.\d+\] line \d+ Check that pp->p->buf\[\(.*\)0\] is assignable: FAILURE$
+^\[f2.\d+\] line \d+ Check that pp->p->buf\[\(.*\)0\] is assignable: SUCCESS$
+^\[f2.pointer\_dereference.\d+\] line \d+ dereference failure: pointer invalid in pp->p->buf\[\(.*\)0\]: FAILURE$
 ^\[f2.pointer\_dereference.\d+\] line \d+ dereference failure: pointer NULL in pp->p->buf: FAILURE$
 ^VERIFICATION FAILED$
 --
 --
 Checks whether CBMC properly evaluates write set of members
 from invalid objects. In this case, they are not writable.
-
-Bug: We need to check the validity of each dereference
-when accessing struct members.

--- a/regression/contracts/assigns_replace_07/main.c
+++ b/regression/contracts/assigns_replace_07/main.c
@@ -2,24 +2,23 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-struct pair
+struct test
 {
-  uint8_t *buf;
-  size_t size;
+  uint8_t buf[8];
 };
 
-void f1(struct pair *p) __CPROVER_assigns(*(p->buf))
-  __CPROVER_ensures(p->buf[0] == 0)
+void f1(struct test *p) __CPROVER_assigns(p->buf)
+  __CPROVER_ensures((p == NULL) || p->buf[0] == 0)
 {
-  p->buf[0] = 0;
+  if(p != NULL)
+    p->buf[0] = 0;
 }
 
 int main()
 {
-  struct pair *p = nondet_bool() ? malloc(sizeof(*p)) : NULL;
+  struct test *p = malloc(sizeof(*p));
+  uint8_t buf_1 = (p == NULL) ? 0 : p->buf[1];
   f1(p);
-  // clang-format off
-  assert(p != NULL ==> p->buf[0] == 0);
-  // clang-format on
-  return 0;
+  assert(p == NULL || p->buf[0] == 0);
+  assert(p == NULL || p->buf[1] == buf_1);
 }

--- a/regression/contracts/assigns_replace_07/test.desc
+++ b/regression/contracts/assigns_replace_07/test.desc
@@ -1,12 +1,13 @@
 CORE
 main.c
---replace-all-calls-with-contracts _ --pointer-check
+--replace-all-calls-with-contracts _ --malloc-may-fail --malloc-fail-null --pointer-check
 ^EXIT=10$
 ^SIGNAL=0$
-^\[pointer\_dereference.\d+\] file main.c line \d+ dereference failure: pointer NULL in p->buf: FAILURE$
-^\[main.assertion.\d+\] line \d+ assertion p \!\= NULL \=\=> p->buf\[0\] \=\= 0: FAILURE$
+^\[main.assertion.\d+\] line \d+ assertion p == NULL \|\| p->buf\[0\] == 0: SUCCESS$
+^\[main.assertion.\d+\] line \d+ assertion p == NULL \|\| p->buf\[1\] == buf_1: FAILURE$
 ^VERIFICATION FAILED$
 --
 --
-Checks whether CBMC properly evaluates write set of members
-from invalid objects. In this case, they are not writable.
+Checks whether CBMC properly evaluates write set of members from invalid objects.
+Functions are not expected to write to invalid locations; CBMC flags such writes.
+For contract checking, we ignore invalid targets in assigns clauses and assignment LHS.

--- a/regression/contracts/invar_loop-entry_check/main.c
+++ b/regression/contracts/invar_loop-entry_check/main.c
@@ -33,17 +33,17 @@ void main()
   assert(x2 == z2);
 
   int y3;
-  s *s1, *s2;
+  s s0, s1, *s2 = &s0;
   s2->n = malloc(sizeof(int));
-  s1->n = s2->n;
+  s1.n = s2->n;
 
   while(y3 > 0)
-    __CPROVER_loop_invariant(s1->n == __CPROVER_loop_entry(s1->n))
+    __CPROVER_loop_invariant(s2->n == __CPROVER_loop_entry(s2->n))
     {
       --y3;
-      s1->n = s1->n + 1;
-      s1->n = s1->n - 1;
+      s0.n = s0.n + 1;
+      s2->n = s2->n - 1;
     }
 
-  assert(*(s1->n) == *(s2->n));
+  assert(*(s1.n) == *(s2->n));
 }

--- a/regression/contracts/invar_loop-entry_check/test.desc
+++ b/regression/contracts/invar_loop-entry_check/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---apply-loop-contracts
+--apply-loop-contracts _ --pointer-primitive-check
 ^EXIT=0$
 ^SIGNAL=0$
 ^\[main.1\] .* Check loop invariant before entry: SUCCESS$
@@ -11,7 +11,7 @@ main.c
 ^\[main.assertion.2\] .* assertion x2 == z2: SUCCESS$
 ^\[main.5\] .* Check loop invariant before entry: SUCCESS$
 ^\[main.6\] .* Check that loop invariant is preserved: SUCCESS$
-^\[main.assertion.3\] .* assertion \*\(s1->n\) == \*\(s2->n\): SUCCESS$
+^\[main.assertion.3\] .* assertion \*\(s1\.n\) == \*\(s2->n\): SUCCESS$
 ^VERIFICATION SUCCESSFUL$
 --
 --

--- a/src/goto-instrument/Makefile
+++ b/src/goto-instrument/Makefile
@@ -17,8 +17,9 @@ SRC = accelerate/accelerate.cpp \
       branch.cpp \
       call_sequences.cpp \
       contracts/assigns.cpp \
-      contracts/memory_predicates.cpp \
       contracts/contracts.cpp \
+      contracts/memory_predicates.cpp \
+      contracts/utils.cpp \
       concurrency.cpp \
       count_eloc.cpp \
       cover.cpp \

--- a/src/goto-instrument/contracts/assigns.cpp
+++ b/src/goto-instrument/contracts/assigns.cpp
@@ -15,8 +15,11 @@ Date: July 2021
 
 #include <goto-instrument/havoc_utils.h>
 
+#include <langapi/language_util.h>
+
 #include <util/arith_tools.h>
 #include <util/c_types.h>
+#include <util/pointer_offset_size.h>
 #include <util/pointer_predicates.h>
 
 assigns_clauset::targett::targett(

--- a/src/goto-instrument/contracts/assigns.cpp
+++ b/src/goto-instrument/contracts/assigns.cpp
@@ -17,10 +17,10 @@ Date: July 2021
 
 #include <langapi/language_util.h>
 
-#include <util/arith_tools.h>
-#include <util/c_types.h>
 #include <util/pointer_offset_size.h>
 #include <util/pointer_predicates.h>
+
+#include "utils.h"
 
 assigns_clauset::targett::targett(
   const assigns_clauset &parent,
@@ -46,27 +46,16 @@ exprt assigns_clauset::targett::normalize(const exprt &expr)
 exprt assigns_clauset::targett::generate_containment_check(
   const address_of_exprt &lhs_address) const
 {
-  exprt::operandst address_validity;
+  const auto address_validity = and_exprt{
+    all_dereferences_are_valid(dereference_exprt{address}, parent.ns),
+    all_dereferences_are_valid(dereference_exprt{lhs_address}, parent.ns)};
+
   exprt::operandst containment_check;
-
-  // __CPROVER_w_ok(target, sizeof(target))
-  address_validity.push_back(w_ok_exprt(
-    address,
-    size_of_expr(dereference_exprt(address).type(), parent.ns).value()));
-
-  // __CPROVER_w_ok(lhs, sizeof(lhs))
-  address_validity.push_back(w_ok_exprt(
-    lhs_address,
-    size_of_expr(dereference_exprt(lhs_address).type(), parent.ns).value()));
-
-  // __CPROVER_same_object(lhs, target)
   containment_check.push_back(same_object(lhs_address, address));
 
   // If assigns target was a dereference, comparing objects is enough
-  // and the resulting condition will be
-  // __CPROVER_w_ok(target, sizeof(target))
-  // && __CPROVER_w_ok(lhs, sizeof(lhs))
-  // ==> __CPROVER_same_object(lhs, target)
+  // and the resulting condition will be:
+  // VALID(self) && VALID(lhs) ==> __CPROVER_same_object(lhs, self)
   if(id != ID_dereference)
   {
     const auto lhs_offset = pointer_offset(lhs_address);
@@ -89,19 +78,17 @@ exprt assigns_clauset::targett::generate_containment_check(
       own_offset);
 
     // (sizeof(lhs) + __CPROVER_offset(lhs)) <=
-    // (sizeof(target) + __CPROVER_offset(target))
+    // (sizeof(self) + __CPROVER_offset(self))
     containment_check.push_back(
       binary_relation_exprt(lhs_region, ID_le, own_region));
   }
 
-  // __CPROVER_w_ok(target, sizeof(target))
-  // && __CPROVER_w_ok(lhs, sizeof(lhs))
-  // ==> __CPROVER_same_object(lhs, target)
-  //     && __CPROVER_offset(lhs) >= __CPROVER_offset(target)
-  //     && (sizeof(lhs) + __CPROVER_offset(lhs)) <=
-  //        (sizeof(target) + __CPROVER_offset(target))
-  return binary_relation_exprt(
-    conjunction(address_validity), ID_implies, conjunction(containment_check));
+  // VALID(self) && VALID(lhs)
+  // ==> __CPROVER_same_object(lhs, self)
+  //  && __CPROVER_offset(lhs) >= __CPROVER_offset(self)
+  //  && (sizeof(lhs) + __CPROVER_offset(lhs)) <=
+  //        (sizeof(self) + __CPROVER_offset(self))
+  return or_exprt{not_exprt{address_validity}, conjunction(containment_check)};
 }
 
 assigns_clauset::assigns_clauset(
@@ -150,12 +137,13 @@ goto_programt assigns_clauset::generate_havoc_code() const
   modifiest modifies;
   for(const auto &target : global_write_set)
     modifies.insert(target.address.object());
-
   for(const auto &target : local_write_set)
     modifies.insert(target.address.object());
 
   goto_programt havoc_statements;
-  append_havoc_code(location, modifies, havoc_statements);
+  havoc_if_validt havoc_gen(modifies, ns);
+  havoc_gen.append_full_havoc_code(location, havoc_statements);
+
   return havoc_statements;
 }
 

--- a/src/goto-instrument/contracts/assigns.h
+++ b/src/goto-instrument/contracts/assigns.h
@@ -14,9 +14,12 @@ Date: July 2021
 #ifndef CPROVER_GOTO_INSTRUMENT_CONTRACTS_ASSIGNS_H
 #define CPROVER_GOTO_INSTRUMENT_CONTRACTS_ASSIGNS_H
 
-#include "contracts.h"
+#include <unordered_set>
 
-#include <util/pointer_offset_size.h>
+#include <goto-programs/goto_model.h>
+
+#include <util/message.h>
+#include <util/pointer_expr.h>
 
 /// \brief A class for representing assigns clauses in code contracts
 class assigns_clauset

--- a/src/goto-instrument/contracts/contracts.h
+++ b/src/goto-instrument/contracts/contracts.h
@@ -25,8 +25,6 @@ Date: February 2016
 #include <goto-programs/goto_functions.h>
 #include <goto-programs/goto_model.h>
 
-#include <langapi/language_util.h>
-
 #include <util/message.h>
 #include <util/namespace.h>
 #include <util/pointer_expr.h>

--- a/src/goto-instrument/contracts/utils.cpp
+++ b/src/goto-instrument/contracts/utils.cpp
@@ -1,0 +1,65 @@
+/*******************************************************************\
+
+Module: Utility functions for code contracts.
+
+Author: Saswat Padhi, saspadhi@amazon.com
+
+Date: September 2021
+
+\*******************************************************************/
+
+#include "utils.h"
+
+exprt generate_lexicographic_less_than_check(
+  const std::vector<symbol_exprt> &lhs,
+  const std::vector<symbol_exprt> &rhs)
+{
+  PRECONDITION(lhs.size() == rhs.size());
+
+  if(lhs.empty())
+  {
+    return false_exprt();
+  }
+
+  // Store conjunctions of equalities.
+  // For example, suppose that the two input vectors are <s1, s2, s3> and <l1,
+  // l2, l3>.
+  // Then this vector stores <s1 == l1, s1 == l1 && s2 == l2,
+  // s1 == l1 && s2 == l2 && s3 == l3>.
+  // In fact, the last element is unnecessary, so we do not create it.
+  exprt::operandst equality_conjunctions(lhs.size());
+  equality_conjunctions[0] = binary_relation_exprt(lhs[0], ID_equal, rhs[0]);
+  for(size_t i = 1; i < equality_conjunctions.size() - 1; i++)
+  {
+    binary_relation_exprt component_i_equality{lhs[i], ID_equal, rhs[i]};
+    equality_conjunctions[i] =
+      and_exprt(equality_conjunctions[i - 1], component_i_equality);
+  }
+
+  // Store inequalities between the i-th components of the input vectors
+  // (i.e. lhs and rhs).
+  // For example, suppose that the two input vectors are <s1, s2, s3> and <l1,
+  // l2, l3>.
+  // Then this vector stores <s1 < l1, s1 == l1 && s2 < l2, s1 == l1 &&
+  // s2 == l2 && s3 < l3>.
+  exprt::operandst lexicographic_individual_comparisons(lhs.size());
+  lexicographic_individual_comparisons[0] =
+    binary_relation_exprt(lhs[0], ID_lt, rhs[0]);
+  for(size_t i = 1; i < lexicographic_individual_comparisons.size(); i++)
+  {
+    binary_relation_exprt component_i_less_than{lhs[i], ID_lt, rhs[i]};
+    lexicographic_individual_comparisons[i] =
+      and_exprt(equality_conjunctions[i - 1], component_i_less_than);
+  }
+  return disjunction(lexicographic_individual_comparisons);
+}
+
+void insert_before_swap_and_advance(
+  goto_programt &destination,
+  goto_programt::targett &target,
+  goto_programt &payload)
+{
+  const auto offset = payload.instructions.size();
+  destination.insert_before_swap(target, payload);
+  std::advance(target, offset);
+}

--- a/src/goto-instrument/contracts/utils.h
+++ b/src/goto-instrument/contracts/utils.h
@@ -13,7 +13,51 @@ Date: September 2021
 
 #include <vector>
 
+#include <goto-instrument/havoc_utils.h>
+
 #include <goto-programs/goto_model.h>
+
+/// \brief A class that overrides the low-level havocing functions in the base
+///        utility class, to havoc only when expressions point to valid memory,
+///        i.e. if all dereferences within an expression are valid
+class havoc_if_validt : public havoc_utilst
+{
+public:
+  havoc_if_validt(const modifiest &mod, const namespacet &ns)
+    : havoc_utilst(mod), ns(ns)
+  {
+  }
+
+  void append_object_havoc_code_for_expr(
+    const source_locationt location,
+    const exprt &expr,
+    goto_programt &dest) const override;
+
+  void append_scalar_havoc_code_for_expr(
+    const source_locationt location,
+    const exprt &expr,
+    goto_programt &dest) const override;
+
+protected:
+  const namespacet &ns;
+};
+
+/// \brief Generate a validity check over all dereferences in an expression
+///
+/// This function generates a formula:
+///
+///   good_pointer_def(pexpr_1, ns) &&
+///   good_pointer_def(pexpr_2, n2) &&
+///   ...
+///
+/// over all dereferenced pointer expressions *(pexpr_1), *(pexpr_2), ...
+/// found in the AST of `expr`.
+///
+/// \param expr The expression that contains dereferences to be validated
+/// \param ns The namespace that defines all symbols appearing in `expr`
+/// \return A conjunctive expression that checks validity of all pointers
+///         that are dereferenced within `expr`
+exprt all_dereferences_are_valid(const exprt &expr, const namespacet &ns);
 
 /// \brief Generate a lexicographic less-than comparison over ordered tuples
 ///
@@ -37,7 +81,7 @@ exprt generate_lexicographic_less_than_check(
 /// After insertion, `target` is advanced by the size of the `payload`,
 /// and `payload` is destroyed.
 ///
-/// \param program The destination program for inserting the `payload`
+/// \param destination The destination program for inserting the `payload`
 /// \param target The instruction iterator at which to insert the `payload`
 /// \param payload The goto program to be inserted into the `destination`
 void insert_before_swap_and_advance(

--- a/src/goto-instrument/contracts/utils.h
+++ b/src/goto-instrument/contracts/utils.h
@@ -1,0 +1,48 @@
+/*******************************************************************\
+
+Module: Utility functions for code contracts.
+
+Author: Saswat Padhi, saspadhi@amazon.com
+
+Date: September 2021
+
+\*******************************************************************/
+
+#ifndef CPROVER_GOTO_INSTRUMENT_CONTRACTS_UTILS_H
+#define CPROVER_GOTO_INSTRUMENT_CONTRACTS_UTILS_H
+
+#include <vector>
+
+#include <goto-programs/goto_model.h>
+
+/// \brief Generate a lexicographic less-than comparison over ordered tuples
+///
+/// This function creates an expression representing a lexicographic less-than
+/// comparison, lhs < rhs, between two ordered tuples of variables.
+/// This is used in instrumentation of decreases clauses.
+///
+/// \param lhs A vector of variables representing the LHS of the comparison
+/// \param rhs A vector of variables representing the RHS of the comparison
+/// \return A lexicographic less-than comparison expression: LHS < RHS
+exprt generate_lexicographic_less_than_check(
+  const std::vector<symbol_exprt> &lhs,
+  const std::vector<symbol_exprt> &rhs);
+
+/// \brief Insert a goto program before a target instruction iterator
+///        and advance the iterator.
+///
+/// This function inserts all instruction from a goto program `payload` into a
+/// destination program `destination` immediately before a specified instruction
+/// iterator `target`.
+/// After insertion, `target` is advanced by the size of the `payload`,
+/// and `payload` is destroyed.
+///
+/// \param program The destination program for inserting the `payload`
+/// \param target The instruction iterator at which to insert the `payload`
+/// \param payload The goto program to be inserted into the `destination`
+void insert_before_swap_and_advance(
+  goto_programt &destination,
+  goto_programt::targett &target,
+  goto_programt &payload);
+
+#endif // CPROVER_GOTO_INSTRUMENT_CONTRACTS_UTILS_H

--- a/src/goto-instrument/havoc_loops.cpp
+++ b/src/goto-instrument/havoc_loops.cpp
@@ -68,7 +68,8 @@ void havoc_loopst::havoc_loop(
 
   // build the havocking code
   goto_programt havoc_code;
-  append_havoc_code(loop_head->source_location, modifies, havoc_code);
+  havoc_utilst havoc_gen(modifies);
+  havoc_gen.append_full_havoc_code(loop_head->source_location, havoc_code);
 
   // Now havoc at the loop head. Use insert_swap to
   // preserve jumps to loop head.

--- a/src/goto-instrument/havoc_utils.cpp
+++ b/src/goto-instrument/havoc_utils.cpp
@@ -17,78 +17,49 @@ Date: July 2021
 #include <util/c_types.h>
 #include <util/pointer_expr.h>
 
-void append_safe_havoc_code_for_expr(
-  const source_locationt source_location,
-  const exprt &expr,
-  goto_programt &dest,
-  const std::function<void()> &havoc_code_impl)
+void havoc_utilst::append_full_havoc_code(
+  const source_locationt location,
+  goto_programt &dest) const
 {
-  goto_programt skip_program;
-  const auto skip_target =
-    skip_program.add(goto_programt::make_skip(source_location));
-
-  // for deref expressions, check for validity of underlying pointer,
-  // and skip havocing if invalid (to avoid spurious pointer deref errors)
-  if(expr.id() == ID_dereference)
-  {
-    const auto condition = not_exprt(w_ok_exprt(
-      to_dereference_expr(expr).pointer(),
-      from_integer(0, unsigned_int_type())));
-    dest.add(goto_programt::make_goto(skip_target, condition, source_location));
-  }
-
-  havoc_code_impl();
-
-  // for deref expressions, add the final skip target
-  if(expr.id() == ID_dereference)
-    dest.destructive_append(skip_program);
-}
-
-void append_object_havoc_code_for_expr(
-  const source_locationt source_location,
-  const exprt &expr,
-  goto_programt &dest)
-{
-  append_safe_havoc_code_for_expr(source_location, expr, dest, [&]() {
-    codet havoc(ID_havoc_object);
-    havoc.add_source_location() = source_location;
-    havoc.add_to_operands(expr);
-    dest.add(goto_programt::make_other(havoc, source_location));
-  });
-}
-
-void append_scalar_havoc_code_for_expr(
-  const source_locationt source_location,
-  const exprt &expr,
-  goto_programt &dest)
-{
-  append_safe_havoc_code_for_expr(source_location, expr, dest, [&]() {
-    side_effect_expr_nondett rhs(expr.type(), source_location);
-    goto_programt::targett t = dest.add(
-      goto_programt::make_assignment(expr, std::move(rhs), source_location));
-    t->code_nonconst().add_source_location() = source_location;
-  });
-}
-
-void append_havoc_code(
-  const source_locationt source_location,
-  const modifiest &modifies,
-  goto_programt &dest)
-{
-  havoc_utils_is_constantt is_constant(modifies);
   for(const auto &expr : modifies)
-  {
-    if(expr.id() == ID_index || expr.id() == ID_dereference)
-    {
-      address_of_exprt address_of_expr(expr);
-      if(!is_constant(address_of_expr))
-      {
-        append_object_havoc_code_for_expr(
-          source_location, address_of_expr, dest);
-        continue;
-      }
-    }
+    append_havoc_code_for_expr(location, expr, dest);
+}
 
-    append_scalar_havoc_code_for_expr(source_location, expr, dest);
+void havoc_utilst::append_havoc_code_for_expr(
+  const source_locationt location,
+  const exprt &expr,
+  goto_programt &dest) const
+{
+  if(expr.id() == ID_index || expr.id() == ID_dereference)
+  {
+    address_of_exprt address_of_expr(expr);
+    if(!is_constant(address_of_expr))
+    {
+      append_object_havoc_code_for_expr(location, address_of_expr, dest);
+      return;
+    }
   }
+  append_scalar_havoc_code_for_expr(location, expr, dest);
+}
+
+void havoc_utilst::append_object_havoc_code_for_expr(
+  const source_locationt location,
+  const exprt &expr,
+  goto_programt &dest) const
+{
+  codet havoc(ID_havoc_object);
+  havoc.add_source_location() = location;
+  havoc.add_to_operands(expr);
+  dest.add(goto_programt::make_other(havoc, location));
+}
+
+void havoc_utilst::append_scalar_havoc_code_for_expr(
+  const source_locationt location,
+  const exprt &expr,
+  goto_programt &dest) const
+{
+  side_effect_expr_nondett rhs(expr.type(), location);
+  goto_programt::targett t =
+    dest.add(goto_programt::make_assignment(expr, std::move(rhs), location));
+  t->code_nonconst().add_source_location() = location;
 }

--- a/src/goto-instrument/k_induction.cpp
+++ b/src/goto-instrument/k_induction.cpp
@@ -97,7 +97,8 @@ void k_inductiont::process_loop(
 
     // build the havocking code
     goto_programt havoc_code;
-    append_havoc_code(loop_head->source_location, modifies, havoc_code);
+    havoc_utilst havoc_gen(modifies);
+    havoc_gen.append_full_havoc_code(loop_head->source_location, havoc_code);
 
     // unwind to get k+1 copies
     std::vector<goto_programt::targett> iteration_points;

--- a/src/goto-instrument/loop_utils.cpp
+++ b/src/goto-instrument/loop_utils.cpp
@@ -50,10 +50,11 @@ void get_modifies_lhs(
     const pointer_arithmetict ptr(to_dereference_expr(lhs).pointer());
     for(const auto &mod : local_may_alias.get(t, ptr.pointer))
     {
+      const typecast_exprt typed_mod{mod, ptr.pointer.type()};
       if(ptr.offset.is_nil())
-        modifies.insert(dereference_exprt{mod});
+        modifies.insert(dereference_exprt{typed_mod});
       else
-        modifies.insert(dereference_exprt{plus_exprt{mod, ptr.offset}});
+        modifies.insert(dereference_exprt{plus_exprt{typed_mod, ptr.offset}});
     }
   }
   else if(lhs.id()==ID_if)


### PR DESCRIPTION
This is useful for:
+ checking containment in assigns clause verification
+ havocing only valid memory locations in assigns clause replacement
+ havocing only valid memory locations in loop contracts application
+ creating history snapshots only for valid `old` expressions

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a ~~The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/~~
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a ~~My commit message includes data points confirming performance improvements (if claimed).~~
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.