### PR TITLE
is_invalid_pointer is now defined as a bi-implication

### DIFF
--- a/regression/cbmc-primitives/r_w_ok_bug/test.desc
+++ b/regression/cbmc-primitives/r_w_ok_bug/test.desc
@@ -1,10 +1,7 @@
 CORE
 main.c
 --pointer-check --no-simplify --no-propagation
-^\[main.pointer_dereference.\d+\] line 8 dereference failure: pointer outside object bounds in \*p1: FAILURE$
-^\*\* 1 of \d+ failed
-^VERIFICATION FAILED$
-^EXIT=10$
+^VERIFICATION SUCCESSFUL$
+^EXIT=0$
 ^SIGNAL=0$
 --
-^warning: ignoring

--- a/regression/cbmc-primitives/r_w_ok_inconsistent_integer/test-no-cp.desc
+++ b/regression/cbmc-primitives/r_w_ok_inconsistent_integer/test-no-cp.desc
@@ -1,11 +1,10 @@
-FUTURE
+CORE
 main.c
 --pointer-check --no-simplify --no-propagation
 ^EXIT=0$
 ^SIGNAL=0$
 ^VERIFICATION SUCCESSFUL$
 --
-^warning: ignoring
 --
 Tests that an inconsistent assumption involving a pointer initialized to an
 integer address not pointing to memory and __CPROVER_r_ok() can be detected via

--- a/regression/cbmc-primitives/r_w_ok_inconsistent_integer/test.desc
+++ b/regression/cbmc-primitives/r_w_ok_inconsistent_integer/test.desc
@@ -1,11 +1,10 @@
-FUTURE
+CORE
 main.c
 --pointer-check
 ^EXIT=0$
 ^SIGNAL=0$
 ^VERIFICATION SUCCESSFUL$
 --
-^warning: ignoring
 --
 Tests that an inconsistent assumption involving a pointer initialized to an
 integer address not pointing to memory and __CPROVER_r_ok() can be detected via

--- a/regression/cbmc-primitives/r_w_ok_inconsistent_nondet/test-no-cp.desc
+++ b/regression/cbmc-primitives/r_w_ok_inconsistent_nondet/test-no-cp.desc
@@ -1,11 +1,10 @@
-FUTURE
+CORE
 main.c
 --pointer-check --no-simplify --no-propagation
 ^EXIT=0$
 ^SIGNAL=0$
 ^VERIFICATION SUCCESSFUL$
 --
-^warning: ignoring
 --
 Tests that an inconsistent assumption involving a nondet pointer and
 __CPROVER_r_ok() can be detected via assert(0). We use --no-simplify and

--- a/regression/cbmc-primitives/r_w_ok_inconsistent_nondet/test.desc
+++ b/regression/cbmc-primitives/r_w_ok_inconsistent_nondet/test.desc
@@ -1,11 +1,10 @@
-FUTURE
+CORE
 main.c
 --pointer-check
 ^EXIT=0$
 ^SIGNAL=0$
 ^VERIFICATION SUCCESSFUL$
 --
-^warning: ignoring
 --
 Tests that an inconsistent assumption involving a nondet pointer and
 __CPROVER_r_ok() can be detected via assert(0).

--- a/regression/cbmc-primitives/same-object-01/main.c
+++ b/regression/cbmc-primitives/same-object-01/main.c
@@ -4,10 +4,10 @@
 void main()
 {
   char *p = malloc(1);
-  assert(__CPROVER_POINTER_OBJECT(p) == 2);
+  assert(__CPROVER_POINTER_OBJECT(p) == 1);
 
   assert(
-    __CPROVER_same_object(p, (char *)((size_t)2 << (sizeof(char *) * 8 - 8))));
+    __CPROVER_same_object(p, (char *)((size_t)1 << (sizeof(char *) * 8 - 8))));
   assert(
-    !__CPROVER_same_object(p, (char *)((size_t)3 << (sizeof(char *) * 8 - 8))));
+    !__CPROVER_same_object(p, (char *)((size_t)2 << (sizeof(char *) * 8 - 8))));
 }

--- a/src/solvers/flattening/bv_pointers.cpp
+++ b/src/solvers/flattening/bv_pointers.cpp
@@ -119,37 +119,7 @@ literalt bv_pointerst::convert_rest(const exprt &expr)
 
   const exprt::operandst &operands=expr.operands();
 
-  if(expr.id() == ID_is_invalid_pointer)
-  {
-    if(operands.size()==1 &&
-       operands[0].type().id()==ID_pointer)
-    {
-      const bvt &bv=convert_bv(operands[0]);
-
-      if(!bv.empty())
-      {
-        const pointer_typet &type = to_pointer_type(operands[0].type());
-        bvt object_bv = object_literals(bv, type);
-
-        bvt invalid_bv = object_literals(
-          encode(pointer_logic.get_invalid_object(), type), type);
-
-        const std::size_t object_bits =
-          bv_pointers_width.get_object_width(type);
-
-        bvt equal_invalid_bv;
-        equal_invalid_bv.reserve(object_bits);
-
-        for(std::size_t i=0; i<object_bits; i++)
-        {
-          equal_invalid_bv.push_back(prop.lequal(object_bv[i], invalid_bv[i]));
-        }
-
-        return prop.land(equal_invalid_bv);
-      }
-    }
-  }
-  else if(expr.id() == ID_is_dynamic_object)
+  if(expr.id() == ID_is_dynamic_object || expr.id() == ID_is_invalid_pointer)
   {
     if(operands.size()==1 &&
        operands[0].type().id()==ID_pointer)
@@ -909,6 +879,28 @@ void bv_pointerst::do_postponed(
 
       prop.l_set_to_true(prop.limplies(l1, l2));
     }
+  }
+  else if(postponed.expr.id() == ID_is_invalid_pointer)
+  {
+    const auto &type =
+      to_pointer_type(to_unary_expr(postponed.expr).op().type());
+    const auto &objects = pointer_logic.objects;
+
+    // only compare object part
+    bvt bv = object_literals(encode(objects.size(), type), type);
+
+    bvt saved_bv = object_literals(postponed.op, type);
+
+    POSTCONDITION(bv.size() == saved_bv.size());
+    PRECONDITION(postponed.bv.size() == 1);
+
+    // the pointer is invalid iff the object number is greater or
+    // equal objects.size()
+    literalt l1 = bv_utils.lt_or_le(
+      true, bv, saved_bv, bv_utilst::representationt::UNSIGNED);
+    literalt l2 = postponed.bv.front();
+
+    prop.l_set_to_true(prop.lequal(l1, l2));
   }
   else if(postponed.expr.id()==ID_object_size)
   {

--- a/src/solvers/flattening/pointer_logic.cpp
+++ b/src/solvers/flattening/pointer_logic.cpp
@@ -160,9 +160,6 @@ pointer_logict::pointer_logict(const namespacet &_ns):ns(_ns)
   // add NULL
   null_object=objects.number(exprt(ID_NULL));
   CHECK_RETURN(null_object == 0);
-
-  // add INVALID
-  invalid_object=objects.number(exprt("INVALID"));
 }
 
 pointer_logict::~pointer_logict()

--- a/src/solvers/flattening/pointer_logic.h
+++ b/src/solvers/flattening/pointer_logic.h
@@ -60,12 +60,6 @@ public:
     return null_object;
   }
 
-  /// \return number of INVALID object
-  std::size_t get_invalid_object() const
-  {
-    return invalid_object;
-  }
-
   bool is_dynamic_object(const exprt &expr) const;
 
   void get_dynamic_objects(std::vector<std::size_t> &objects) const;

--- a/src/solvers/smt2/smt2_conv.h
+++ b/src/solvers/smt2/smt2_conv.h
@@ -93,6 +93,10 @@ protected:
   std::vector<exprt> assumptions;
   boolbv_widtht boolbv_width;
 
+  // post-processing for number-of-objects
+  bool number_of_objects_declared = false;
+  void post_process();
+
   std::size_t number_of_solver_calls = 0;
 
   resultt dec_solve() override;

--- a/src/solvers/smt2/smt2_dec.cpp
+++ b/src/solvers/smt2/smt2_dec.cpp
@@ -33,6 +33,8 @@ std::string smt2_dect::decision_procedure_text() const
 
 decision_proceduret::resultt smt2_dect::dec_solve()
 {
+  post_process();
+
   ++number_of_solver_calls;
 
   temporary_filet temp_file_problem("smt2_dec_problem_", ""),


### PR DESCRIPTION
The previous encoding of is_invalid_pointer is an implication,
which means that constraints that a pointer is not an invalid
pointer have no meaning.

This commit changes the encoding to be a bi-implication, using
the numerical range of the valid pointers.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
