### PR TITLE
Change ownership of `src/config.inc` file 

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -75,3 +75,4 @@ CMakeLists.txt @diffblue/diffblue-opensource
 
 # CI pipeline is the responsibility of the Open Source maintenance team at Diffblue.
 /.github/ @diffblue/diffblue-opensource
+src/config.inc @diffblue/diffblue-opensource


### PR DESCRIPTION
Change ownership of `src/config.inc` file to @diffblue/diffblue-opensource 

This is a minor change to allow for faster releases, by requiring less people
to sign off a release PR (it is now okay if it's signed off by a member of the
team maintaining CBMC in diffblue - the people that have been handling releases
in any case).

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
