### PR TITLE
Validity checking of `void` pointers in contracts

### DIFF
--- a/regression/contracts/assigns_enforce_21/main.c
+++ b/regression/contracts/assigns_enforce_21/main.c
@@ -1,0 +1,21 @@
+#include <assert.h>
+#include <stdlib.h>
+
+int x = 0;
+
+void foo(void *y) __CPROVER_assigns(*y) __CPROVER_assigns(x)
+{
+  x = 2;
+  int *bar = (int *)y;
+  *bar = 2;
+}
+
+int main()
+{
+  int *y = malloc(sizeof(*y));
+  *y = 0;
+  foo(y);
+  assert(x == 2);
+  assert(*y == 2);
+  return 0;
+}

--- a/regression/contracts/assigns_enforce_21/test.desc
+++ b/regression/contracts/assigns_enforce_21/test.desc
@@ -1,0 +1,9 @@
+CORE
+main.c
+--enforce-contract foo _ --pointer-check
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+--
+Checks whether contract enforcement does not try to dereference void pointers.

--- a/src/util/pointer_predicates.cpp
+++ b/src/util/pointer_predicates.cpp
@@ -89,7 +89,10 @@ exprt good_pointer_def(
   const typet &dereference_type=pointer_type.subtype();
 
   const auto size_of_expr_opt = size_of_expr(dereference_type, ns);
-  CHECK_RETURN(size_of_expr_opt.has_value());
+  PRECONDITION_WITH_DIAGNOSTICS(
+    size_of_expr_opt.has_value(),
+    "Could not compute sizeof on pointer's dereference type. "
+    "It may be a void pointer.");
 
   const exprt good_dynamic = not_exprt{deallocated(pointer, ns)};
 


### PR DESCRIPTION
PR #6365 introduced `good_pointer_def` checks on all pointers being deref'ed within code contracts. However, this function crashes on `void` pointers.

In this PR, we consider deref'ing `void` pointers as "invalid" as opposed to crashing.

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a ~~The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/~~
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a ~~My commit message includes data points confirming performance improvements (if claimed).~~
- [x] My PR is restricted to a single feature or bugfix.
- n/a ~~White-space or formatting changes outside the feature-related changed lines are in commits of their own.~~