### PR TITLE
A new implementation for assigns clauses

### DIFF
--- a/regression/contracts/assigns_enforce_18/test.desc
+++ b/regression/contracts/assigns_enforce_18/test.desc
@@ -3,21 +3,18 @@ main.c
 --enforce-contract foo --enforce-contract bar --enforce-contract baz _ --pointer-primitive-check
 ^EXIT=10$
 ^SIGNAL=0$
-^\[bar.\d+\] line \d+ Check that \*a is assignable: SUCCESS$
+^\[bar.\d+\] line \d+ Check that POINTER_OBJECT\(\(void \*\)a\) is assignable: SUCCESS$
 ^\[bar.\d+\] line \d+ Check that \*b is assignable: SUCCESS$
-^\[baz.\d+\] line \d+ Check that \*c is assignable: FAILURE$
+^\[baz.\d+\] line \d+ Check that POINTER_OBJECT\(\(void \*\)c\) is assignable: FAILURE$
 ^\[baz.\d+\] line \d+ Check that \*a is assignable: SUCCESS$
 ^\[foo.\d+\] line \d+ Check that a is assignable: SUCCESS$
 ^\[foo.\d+\] line \d+ Check that yp is assignable: SUCCESS$
 ^\[foo.\d+\] line \d+ Check that z is assignable: SUCCESS$
 ^\[foo.\d+\] line \d+ Check that \*xp is assignable: SUCCESS$
 ^\[foo.\d+\] line \d+ Check that y is assignable: FAILURE$
-^.* 2 of \d+ failed \(\d+ iteration.*\)$
+^\[foo.\d+\] line \d+ Check that POINTER_OBJECT\(\(void \*\)yp\) is assignable: SUCCESS$
 ^VERIFICATION FAILED$
 --
-^\[foo.\d+\] line \d+ Check that a is assignable: FAILURE$
-^\[foo.pointer\_primitives.\d+\] line \d+ deallocated dynamic object in POINTER_OBJECT\(tmp\_cc\$\d+\): FAILURE$
-^.* 3 of \d+ failed (\d+ iterations)$
 --
 Checks whether contract enforcement works with functions that deallocate memory.
 We had problems before when freeing a variable, but still keeping it on

--- a/regression/contracts/assigns_enforce_23/main.c
+++ b/regression/contracts/assigns_enforce_23/main.c
@@ -1,0 +1,41 @@
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct
+{
+  uint8_t *buf;
+  size_t size;
+} blob;
+
+void foo(blob *b, uint8_t *value)
+  // clang-format off
+__CPROVER_requires(b->size == 5)
+__CPROVER_assigns(__CPROVER_POINTER_OBJECT(b->buf))
+__CPROVER_assigns(__CPROVER_POINTER_OBJECT(value))
+__CPROVER_ensures(b->buf[0] == 1)
+__CPROVER_ensures(b->buf[1] == 1)
+__CPROVER_ensures(b->buf[2] == 1)
+__CPROVER_ensures(b->buf[3] == 1)
+__CPROVER_ensures(b->buf[4] == 1)
+// clang-format on
+{
+  b->buf[0] = *value;
+  b->buf[1] = *value;
+  b->buf[2] = *value;
+  b->buf[3] = *value;
+  b->buf[4] = *value;
+
+  *value = 2;
+}
+
+int main()
+{
+  blob b;
+  b.size = 5;
+  b.buf = malloc(b.size * (sizeof(*(b.buf))));
+  uint8_t value = 1;
+
+  foo(&b, &value);
+
+  return 0;
+}

--- a/regression/contracts/assigns_enforce_23/test.desc
+++ b/regression/contracts/assigns_enforce_23/test.desc
@@ -1,0 +1,9 @@
+CORE
+main.c
+--enforce-contract foo
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+--
+This test checks that POINTER_OBJECT can be used both on arrays and scalars.

--- a/regression/contracts/assigns_enforce_arrays_02/main.c
+++ b/regression/contracts/assigns_enforce_arrays_02/main.c
@@ -1,24 +1,24 @@
 #include <assert.h>
+#include <stdlib.h>
 
-int idx = 4;
+int *arr;
 
-int nextIdx() __CPROVER_assigns(idx)
+void f1(int *a, int len) __CPROVER_assigns(*a)
 {
-  idx++;
-  return idx;
+  a[0] = 0;
+  a[5] = 5;
 }
 
-void f1(int a[], int len) __CPROVER_assigns(*a, idx)
+void f2(int *a, int len) __CPROVER_assigns(__CPROVER_POINTER_OBJECT(a))
 {
-  a[nextIdx()] = 5;
+  a[0] = 0;
+  a[5] = 5;
+  free(a);
 }
 
 int main()
 {
-  int arr[10];
-  f1(arr, 10);
-
-  assert(idx == 5);
-
-  return 0;
+  arr = malloc(100 * sizeof(int));
+  f1(arr, 100);
+  f2(arr, 100);
 }

--- a/regression/contracts/assigns_enforce_arrays_02/test.desc
+++ b/regression/contracts/assigns_enforce_arrays_02/test.desc
@@ -1,14 +1,15 @@
 CORE
 main.c
---enforce-contract f1 --enforce-contract nextIdx
-^EXIT=0$
+--enforce-contract f1 --enforce-contract f2
+^\[f1.\d+\] line \d+ Check that a\[.*0\] is assignable: SUCCESS$
+^\[f1.\d+\] line \d+ Check that a\[.*5\] is assignable: FAILURE$
+^\[f2.\d+\] line \d+ Check that a\[.*0\] is assignable: SUCCESS$
+^\[f2.\d+\] line \d+ Check that a\[.*5\] is assignable: SUCCESS$
+^\[f2.\d+\] line \d+ Check that POINTER_OBJECT\(\(void \*\)a\) is assignable: SUCCESS$
+^EXIT=10$
 ^SIGNAL=0$
-^VERIFICATION SUCCESSFUL$
+^VERIFICATION FAILED$
 --
 --
-Checks whether the instrumentation process does not duplicate function calls
-used as part of array-index operations, i.e., if a function call is used in
-the computation of the index of an array assignment, then instrumenting that
-statement with an assigns clause will not result in multiple function calls.
-This test also ensures that assigns clauses correctly check for global
-variables modified by subcalls.
+This test ensures that assigns clauses correctly check for global variables,
+and access using *ptr vs POINTER_OBJECT(ptr).

--- a/regression/contracts/assigns_enforce_elvis_5/test.desc
+++ b/regression/contracts/assigns_enforce_elvis_5/test.desc
@@ -8,3 +8,5 @@ main.c
 --
 Check that Elvis operator expressions of form '(cond ? *if_true : *if_false)'
 are supported in assigns clauses.
+
+BUG: `is_lvalue` in goto is not consistent with `target.get_bool(ID_C_lvalue)`.

--- a/regression/contracts/assigns_enforce_function_calls/test.desc
+++ b/regression/contracts/assigns_enforce_function_calls/test.desc
@@ -3,7 +3,7 @@ main.c
 --enforce-contract foo
 ^EXIT=(1|64)$
 ^SIGNAL=0$
-^.*error: Assigns clause is not side-effect free.$
+^.*error: illegal target in assigns clause$
 ^CONVERSION ERROR$
 --
 --

--- a/regression/contracts/assigns_enforce_object_wrong_args/main.c
+++ b/regression/contracts/assigns_enforce_object_wrong_args/main.c
@@ -2,12 +2,7 @@
 #include <stdbool.h>
 #include <stdlib.h>
 
-int *bar(int *x)
-{
-  return *x;
-}
-
-int foo(int *x) __CPROVER_assigns(bar(x))
+int baz(int *x) __CPROVER_assigns(__CPROVER_POINTER_OBJECT())
 {
   *x = 0;
   return 0;
@@ -16,6 +11,5 @@ int foo(int *x) __CPROVER_assigns(bar(x))
 int main()
 {
   int x;
-  foo(&x);
   baz(&x);
 }

--- a/regression/contracts/assigns_enforce_object_wrong_args/test.desc
+++ b/regression/contracts/assigns_enforce_object_wrong_args/test.desc
@@ -1,0 +1,10 @@
+CORE
+main.c
+--enforce-contract baz
+^EXIT=(1|64)$
+^SIGNAL=0$
+^.*error: pointer_object expects one argument$
+^CONVERSION ERROR$
+--
+--
+Check that `__CPROVER_POINTER_OBJECT` in assigns clauses are invoked correctly.

--- a/regression/contracts/assigns_enforce_offsets_1/test.desc
+++ b/regression/contracts/assigns_enforce_offsets_1/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.c
 --enforce-contract foo
 ^EXIT=10$

--- a/regression/contracts/assigns_enforce_side_effects_1/main.c
+++ b/regression/contracts/assigns_enforce_side_effects_1/main.c
@@ -2,7 +2,7 @@
 #include <stdbool.h>
 #include <stdlib.h>
 
-int foo(bool a, int *x, long *y) __CPROVER_assigns(*(a ? x : y++))
+int foo(bool a, int *x, long long *y) __CPROVER_assigns(*(a ? x : y++))
 {
   if(a)
   {

--- a/regression/contracts/assigns_enforce_side_effects_1/test.desc
+++ b/regression/contracts/assigns_enforce_side_effects_1/test.desc
@@ -3,7 +3,7 @@ main.c
 --enforce-contract foo
 ^EXIT=(1|64)$
 ^SIGNAL=0$
-^.*error: Assigns clause is not side-effect free.$
+^.*error: void-typed targets not permitted$
 ^CONVERSION ERROR$
 --
 --

--- a/regression/contracts/assigns_enforce_side_effects_2/test.desc
+++ b/regression/contracts/assigns_enforce_side_effects_2/test.desc
@@ -3,7 +3,7 @@ main.c
 --enforce-contract foo
 ^EXIT=(1|64)$
 ^SIGNAL=0$
-^.*error: Assigns clause is not side-effect free.$
+^.*error: illegal target in assigns clause$
 ^CONVERSION ERROR$
 --
 --

--- a/regression/contracts/assigns_enforce_side_effects_3/test.desc
+++ b/regression/contracts/assigns_enforce_side_effects_3/test.desc
@@ -3,7 +3,7 @@ main.c
 --enforce-contract foo
 ^EXIT=(1|64)$
 ^SIGNAL=0$
-^.*error: Assigns clause is not side-effect free.$
+^.*error: illegal target in assigns clause$
 ^CONVERSION ERROR$
 --
 --

--- a/regression/contracts/assigns_enforce_statics/main.c
+++ b/regression/contracts/assigns_enforce_statics/main.c
@@ -1,0 +1,19 @@
+#include <assert.h>
+#include <stdlib.h>
+
+static int x;
+
+void foo() __CPROVER_assigns(x)
+{
+  int *y = &x;
+
+  static int x;
+  x++;
+
+  (*y)++;
+}
+
+int main()
+{
+  foo();
+}

--- a/regression/contracts/assigns_enforce_statics/test.desc
+++ b/regression/contracts/assigns_enforce_statics/test.desc
@@ -1,0 +1,13 @@
+CORE
+main.c
+--enforce-contract foo _ --pointer-primitive-check
+^EXIT=0$
+^SIGNAL=0$
+^\[foo.\d+\] line \d+ Check that y is assignable: SUCCESS$
+^\[foo.\d+\] line \d+ Check that foo\$\$1\$\$x is assignable: SUCCESS$
+^\[foo.\d+\] line \d+ Check that \*y is assignable: SUCCESS$
+^VERIFICATION SUCCESSFUL$
+--
+--
+Checks whether static local and global variables are correctly tracked
+in assigns clause verification.

--- a/regression/contracts/assigns_enforce_structs_06/main.c
+++ b/regression/contracts/assigns_enforce_structs_06/main.c
@@ -8,7 +8,7 @@ struct pair
   size_t size;
 };
 
-void f1(struct pair *p) __CPROVER_assigns(*(p->buf))
+void f1(struct pair *p) __CPROVER_assigns(__CPROVER_POINTER_OBJECT(p->buf))
 {
   p->buf[0] = 0;
   p->buf[1] = 1;

--- a/regression/contracts/assigns_enforce_structs_07/main.c
+++ b/regression/contracts/assigns_enforce_structs_07/main.c
@@ -26,11 +26,17 @@ void f2(struct pair_of_pairs *pp) __CPROVER_assigns(*(pp->p->buf))
 int main()
 {
   struct pair *p = malloc(sizeof(*p));
+  if(p)
+    p->buf = malloc(100 * sizeof(uint8_t));
   f1(p);
 
   struct pair_of_pairs *pp = malloc(sizeof(*pp));
   if(pp)
+  {
     pp->p = malloc(sizeof(*(pp->p)));
+    if(pp->p)
+      pp->p->buf = malloc(100 * sizeof(uint8_t));
+  }
   f2(pp);
 
   return 0;

--- a/regression/contracts/assigns_replace_06/main.c
+++ b/regression/contracts/assigns_replace_06/main.c
@@ -1,6 +1,7 @@
 #include <assert.h>
+#include <stdlib.h>
 
-void foo(char c[]) __CPROVER_assigns(c)
+void foo(char c[]) __CPROVER_assigns(__CPROVER_POINTER_OBJECT(c))
 {
 }
 
@@ -28,6 +29,4 @@ int main()
   assert(b[1] == '1');
   assert(b[2] == 'c');
   assert(b[3] == '3');
-
-  return 0;
 }

--- a/regression/contracts/assigns_type_checking_valid_cases/main.c
+++ b/regression/contracts/assigns_type_checking_valid_cases/main.c
@@ -59,7 +59,7 @@ void foo7(int a, struct buf *buffer) __CPROVER_assigns(*buffer)
   buffer->len = 1;
 }
 
-void foo8(int array[]) __CPROVER_assigns(*array)
+void foo8(int array[]) __CPROVER_assigns(__CPROVER_POINTER_OBJECT(array))
 {
   array[0] = 1;
   array[1] = 1;

--- a/regression/contracts/function_check_02/main.c
+++ b/regression/contracts/function_check_02/main.c
@@ -6,7 +6,7 @@
 
 // clang-format off
 int initialize(int *arr)
-  __CPROVER_assigns(*arr)
+  __CPROVER_assigns(__CPROVER_POINTER_OBJECT(arr))
   __CPROVER_ensures(
     __CPROVER_forall {
       int i;

--- a/regression/contracts/history-pointer-both-01/test.desc
+++ b/regression/contracts/history-pointer-both-01/test.desc
@@ -4,13 +4,8 @@ main.c
 ^EXIT=0$
 ^SIGNAL=0$
 ^VERIFICATION SUCCESSFUL$
-ASSUME .*::tmp_cc\$\d ≠ NULL
-ASSERT foo::n ≠ NULL
-ASSUME .*::tmp_cc = \*foo::n
-ASSERT .*::tmp_cc\$\d = \*.*::tmp_cc\$\d
 --
 --
-Verification:
 This test checks that history variables are supported for parameters of the
 the function under test. By using the --enforce-contract flag,
 the post-condition (which contains the history variable) is asserted.

--- a/regression/contracts/quantifiers-forall-ensures-enforce/main.c
+++ b/regression/contracts/quantifiers-forall-ensures-enforce/main.c
@@ -4,7 +4,7 @@
 
 // clang-format off
 int f1(int *arr, int len)
-  __CPROVER_assigns(*arr)
+  __CPROVER_assigns(__CPROVER_POINTER_OBJECT(arr))
   __CPROVER_ensures(__CPROVER_forall {
     int i;
     // test enforcement with symbolic bound

--- a/regression/contracts/quantifiers-nested-01/main.c
+++ b/regression/contracts/quantifiers-nested-01/main.c
@@ -1,6 +1,6 @@
 // clang-format off
 int f1(int *arr)
-  __CPROVER_assigns(*arr)
+  __CPROVER_assigns(__CPROVER_POINTER_OBJECT(arr))
   __CPROVER_ensures(__CPROVER_forall {
     int i;
     __CPROVER_forall

--- a/regression/contracts/quantifiers-nested-03/main.c
+++ b/regression/contracts/quantifiers-nested-03/main.c
@@ -1,6 +1,6 @@
 // clang-format off
 int f1(int *arr)
-__CPROVER_assigns(*arr)
+__CPROVER_assigns(__CPROVER_POINTER_OBJECT(arr))
   __CPROVER_ensures(
     __CPROVER_return_value == 0 &&
     __CPROVER_exists {

--- a/regression/contracts/test_array_memory_enforce/main.c
+++ b/regression/contracts/test_array_memory_enforce/main.c
@@ -14,7 +14,7 @@ bool return_ok(int ret_value, int *x)
 
 // clang-format off
 int foo(int *x)
-  __CPROVER_assigns(*x)
+  __CPROVER_assigns(__CPROVER_POINTER_OBJECT(x))
   __CPROVER_requires(
     __CPROVER_is_fresh(x, sizeof(int) * 10) &&
     x[0] > 0 &&

--- a/regression/contracts/test_struct_member_enforce/main.c
+++ b/regression/contracts/test_struct_member_enforce/main.c
@@ -8,7 +8,7 @@ struct string
 
 // clang-format off
 int foo(struct string *x)
-  __CPROVER_assigns(*(x->str))
+  __CPROVER_assigns(x->str[x->len-1])
   __CPROVER_requires(
     x->len == 128 &&
     __CPROVER_is_fresh(x->str, x->len * sizeof(char)))

--- a/src/ansi-c/ansi_c_convert_type.cpp
+++ b/src/ansi-c/ansi_c_convert_type.cpp
@@ -13,7 +13,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <util/c_types.h>
 #include <util/config.h>
-#include <util/expr_util.h>
+#include <util/std_code.h>
 #include <util/std_types.h>
 #include <util/string_constant.h>
 
@@ -255,15 +255,7 @@ void ansi_c_convert_typet::read_rec(const typet &type)
       static_cast<const exprt &>(static_cast<const irept &>(type));
 
     for(const exprt &target : to_unary_expr(as_expr).op().operands())
-    {
-      if(has_subexpr(target, ID_side_effect))
-      {
-        error().source_location = target.source_location();
-        error() << "Assigns clause is not side-effect free." << eom;
-        throw 0;
-      }
       assigns.push_back(target);
-    }
   }
   else if(type.id() == ID_C_spec_ensures)
   {

--- a/src/goto-instrument/contracts/contracts.cpp
+++ b/src/goto-instrument/contracts/contracts.cpp
@@ -169,14 +169,16 @@ void code_contractst::check_apply_loop_contracts(
   for(const auto &clause : decreases_clause.operands())
   {
     const auto old_decreases_var =
-      new_tmp_symbol(clause.type(), loop_head->source_location, mode)
+      new_tmp_symbol(
+        clause.type(), loop_head->source_location, mode, symbol_table)
         .symbol_expr();
     havoc_code.add(
       goto_programt::make_decl(old_decreases_var, loop_head->source_location));
     old_decreases_vars.push_back(old_decreases_var);
 
     const auto new_decreases_var =
-      new_tmp_symbol(clause.type(), loop_head->source_location, mode)
+      new_tmp_symbol(
+        clause.type(), loop_head->source_location, mode, symbol_table)
         .symbol_expr();
     havoc_code.add(
       goto_programt::make_decl(new_decreases_var, loop_head->source_location));
@@ -317,10 +319,8 @@ void code_contractst::add_quantified_variable(
       const auto &quantified_symbol = to_symbol_expr(quantified_variable);
 
       // 1. create fresh symbol
-      symbolt new_symbol = get_fresh_aux_symbol(
+      symbolt new_symbol = new_tmp_symbol(
         quantified_symbol.type(),
-        id2string(quantified_symbol.get_identifier()),
-        "tmp",
         quantified_symbol.source_location(),
         mode,
         symbol_table);
@@ -370,7 +370,8 @@ void code_contractst::replace_history_parameter(
         // 1. Create a temporary symbol expression that represents the
         // history variable
         symbol_exprt tmp_symbol =
-          new_tmp_symbol(parameter.type(), location, mode).symbol_expr();
+          new_tmp_symbol(parameter.type(), location, mode, symbol_table)
+            .symbol_expr();
 
         // 2. Associate the above temporary variable to it's corresponding
         // expression
@@ -607,20 +608,6 @@ void code_contractst::apply_loop_contract(
       loop.second,
       symbol_table.lookup_ref(function).mode);
   }
-}
-
-const symbolt &code_contractst::new_tmp_symbol(
-  const typet &type,
-  const source_locationt &source_location,
-  const irep_idt &mode)
-{
-  return get_fresh_aux_symbol(
-    type,
-    id2string(source_location.get_function()) + "::tmp_cc",
-    "tmp_cc",
-    source_location,
-    mode,
-    symbol_table);
 }
 
 symbol_tablet &code_contractst::get_symbol_table()
@@ -962,7 +949,8 @@ void code_contractst::add_contract_check(
     symbol_exprt r = new_tmp_symbol(
                        code_type.return_type(),
                        skip->source_location,
-                       function_symbol.mode)
+                       function_symbol.mode,
+                       symbol_table)
                        .symbol_expr();
     check.add(goto_programt::make_decl(r, skip->source_location));
 
@@ -986,7 +974,8 @@ void code_contractst::add_contract_check(
     symbol_exprt p = new_tmp_symbol(
                        parameter_symbol.type,
                        skip->source_location,
-                       parameter_symbol.mode)
+                       parameter_symbol.mode,
+                       symbol_table)
                        .symbol_expr();
     check.add(goto_programt::make_decl(p, skip->source_location));
     check.add(goto_programt::make_assignment(

--- a/src/goto-instrument/contracts/contracts.h
+++ b/src/goto-instrument/contracts/contracts.h
@@ -96,11 +96,6 @@ public:
 
   void apply_loop_contracts();
 
-  const symbolt &new_tmp_symbol(
-    const typet &type,
-    const source_locationt &source_location,
-    const irep_idt &mode);
-
   void check_apply_loop_contracts(
     goto_functionst::goto_functiont &goto_function,
     const local_may_aliast &local_may_alias,

--- a/src/goto-instrument/contracts/contracts.h
+++ b/src/goto-instrument/contracts/contracts.h
@@ -126,8 +126,11 @@ protected:
 
   /// Insert assertion statements into the goto program to ensure that
   /// assigned memory is within the assignable memory frame.
-  void
-  check_frame_conditions(const irep_idt &, goto_programt &, assigns_clauset &);
+  void check_frame_conditions(
+    const irep_idt &,
+    goto_programt &,
+    goto_programt::targett &,
+    assigns_clauset &);
 
   /// Inserts an assertion into the goto program to ensure that
   /// an expression is within the assignable memory frame.
@@ -171,6 +174,7 @@ protected:
   /// based on ensures clauses.
   bool apply_function_contract(
     const irep_idt &,
+    const source_locationt &,
     goto_programt &,
     goto_programt::targett &);
 

--- a/src/goto-instrument/contracts/utils.cpp
+++ b/src/goto-instrument/contracts/utils.cpp
@@ -10,6 +10,7 @@ Date: September 2021
 
 #include "utils.h"
 
+#include <util/fresh_symbol.h>
 #include <util/pointer_expr.h>
 #include <util/pointer_predicates.h>
 
@@ -120,4 +121,19 @@ void insert_before_swap_and_advance(
   const auto offset = payload.instructions.size();
   destination.insert_before_swap(target, payload);
   std::advance(target, offset);
+}
+
+const symbolt &new_tmp_symbol(
+  const typet &type,
+  const source_locationt &location,
+  const irep_idt &mode,
+  symbol_table_baset &symtab)
+{
+  return get_fresh_aux_symbol(
+    type,
+    id2string(location.get_function()) + "::tmp_cc",
+    "tmp_cc",
+    location,
+    mode,
+    symtab);
 }

--- a/src/goto-instrument/contracts/utils.h
+++ b/src/goto-instrument/contracts/utils.h
@@ -53,10 +53,10 @@ protected:
 /// over all dereferenced pointer expressions *(pexpr_1), *(pexpr_2), ...
 /// found in the AST of `expr`.
 ///
-/// \param expr The expression that contains dereferences to be validated
-/// \param ns The namespace that defines all symbols appearing in `expr`
+/// \param expr: The expression that contains dereferences to be validated.
+/// \param ns: The namespace that defines all symbols appearing in `expr`.
 /// \return A conjunctive expression that checks validity of all pointers
-///         that are dereferenced within `expr`
+///         that are dereferenced within `expr`.
 exprt all_dereferences_are_valid(const exprt &expr, const namespacet &ns);
 
 /// \brief Generate a lexicographic less-than comparison over ordered tuples
@@ -65,9 +65,9 @@ exprt all_dereferences_are_valid(const exprt &expr, const namespacet &ns);
 /// comparison, lhs < rhs, between two ordered tuples of variables.
 /// This is used in instrumentation of decreases clauses.
 ///
-/// \param lhs A vector of variables representing the LHS of the comparison
-/// \param rhs A vector of variables representing the RHS of the comparison
-/// \return A lexicographic less-than comparison expression: LHS < RHS
+/// \param lhs: A vector of variables representing the LHS of the comparison.
+/// \param rhs: A vector of variables representing the RHS of the comparison.
+/// \return A lexicographic less-than comparison expression: LHS < RHS.
 exprt generate_lexicographic_less_than_check(
   const std::vector<symbol_exprt> &lhs,
   const std::vector<symbol_exprt> &rhs);
@@ -81,12 +81,25 @@ exprt generate_lexicographic_less_than_check(
 /// After insertion, `target` is advanced by the size of the `payload`,
 /// and `payload` is destroyed.
 ///
-/// \param destination The destination program for inserting the `payload`
-/// \param target The instruction iterator at which to insert the `payload`
-/// \param payload The goto program to be inserted into the `destination`
+/// \param destination: The destination program for inserting the `payload`.
+/// \param target: The instruction iterator at which to insert the `payload`.
+/// \param payload: The goto program to be inserted into the `destination`.
 void insert_before_swap_and_advance(
   goto_programt &destination,
   goto_programt::targett &target,
   goto_programt &payload);
+
+/// \brief Adds a new temporary symbol to the symbol table.
+///
+/// \param type: The type of the new symbol.
+/// \param location: The source location for the new symbol.
+/// \param mode: The mode for the new symbol, e.g. ID_C, ID_java.
+/// \param symtab: The symbol table to which the new symbol is to be added.
+/// \return The new symbolt object.
+const symbolt &new_tmp_symbol(
+  const typet &type,
+  const source_locationt &location,
+  const irep_idt &mode,
+  symbol_table_baset &symtab);
 
 #endif // CPROVER_GOTO_INSTRUMENT_CONTRACTS_UTILS_H

--- a/src/goto-instrument/havoc_utils.h
+++ b/src/goto-instrument/havoc_utils.h
@@ -73,7 +73,7 @@ public:
   /// \param location The source location to annotate on the havoc instruction
   /// \param expr The expression to havoc
   /// \param dest The destination goto program to append the instructions to
-  void append_havoc_code_for_expr(
+  virtual void append_havoc_code_for_expr(
     const source_locationt location,
     const exprt &expr,
     goto_programt &dest) const;


### PR DESCRIPTION
This change is a complete rewrite of the assigns clause, based on a new formalization. Each assigns clause target is modeled as a "conditional address range" (CAR) that is an address range guarded by a validity condition.

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a ~~My commit message includes data points confirming performance improvements (if claimed).~~
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
