### PR TITLE
bump OS X version

### DIFF
--- a/src/common
+++ b/src/common
@@ -34,9 +34,9 @@ endif
   CP_CFLAGS = -MMD -MP
   CXXFLAGS ?= -Wall -O2
 ifeq ($(filter-out OSX OSX_Universal,$(BUILD_ENV_)),)
-  CP_CXXFLAGS += -MMD -MP -mmacosx-version-min=10.9 -std=c++11 -stdlib=libc++
-  LINKFLAGS += -mmacosx-version-min=10.9 -stdlib=libc++
-  LINKNATIVE += -mmacosx-version-min=10.9 -stdlib=libc++
+  CP_CXXFLAGS += -MMD -MP -mmacosx-version-min=10.15 -std=c++11 -stdlib=libc++
+  LINKFLAGS += -mmacosx-version-min=10.15 -stdlib=libc++
+  LINKNATIVE += -mmacosx-version-min=10.15 -stdlib=libc++
 else
   CP_CXXFLAGS += -MMD -MP -std=c++11
 endif


### PR DESCRIPTION
This increases the required version of OS X from 10.9 to 10.15, which is the
oldest version of OS X that Apple still supplies with security fixes.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- n/a Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
