### PR TITLE
remove 8 deprecated goto-program API methods

### DIFF
--- a/jbmc/src/java_bytecode/replace_java_nondet.cpp
+++ b/jbmc/src/java_bytecode/replace_java_nondet.cpp
@@ -145,7 +145,7 @@ static bool is_assignment_from(
   {
     return false;
   }
-  const auto &rhs = instr.get_assign().rhs();
+  const auto &rhs = instr.assign_rhs();
   return is_symbol_with_id(rhs, identifier) ||
          is_typecast_with_id(rhs, identifier);
 }
@@ -223,7 +223,7 @@ static goto_programt::targett check_and_replace_target(
       "either have a variable for the return value in its lhs() or the next "
       "instruction should be an assignment of the return value to a temporary "
       "variable");
-    const exprt &return_value_assignment = next_instr->get_assign().lhs();
+    const exprt &return_value_assignment = next_instr->assign_lhs();
 
     // If the assignment is null, return.
     if(
@@ -285,7 +285,7 @@ static goto_programt::targett check_and_replace_target(
   else if(target_instruction->is_assign())
   {
     // Assume that the LHS of *this* assignment is the actual nondet variable
-    const auto &nondet_var = target_instruction->get_assign().lhs();
+    const auto &nondet_var = target_instruction->assign_lhs();
 
     side_effect_expr_nondett inserted_expr(
       nondet_var.type(), target_instruction->source_location);

--- a/jbmc/unit/java_bytecode/java_replace_nondet/replace_nondet.cpp
+++ b/jbmc/unit/java_bytecode/java_replace_nondet/replace_nondet.cpp
@@ -34,10 +34,10 @@ void validate_nondet_method_removed(
     // Check that our NONDET(<type>) exists on a rhs somewhere.
     if(inst.is_assign())
     {
-      const code_assignt &assignment = inst.get_assign();
-      if(assignment.rhs().id() == ID_side_effect)
+      const exprt &assignment_rhs = inst.assign_rhs();
+      if(assignment_rhs.id() == ID_side_effect)
       {
-        const side_effect_exprt &see = to_side_effect_expr(assignment.rhs());
+        const side_effect_exprt &see = to_side_effect_expr(assignment_rhs);
         if(see.get_statement() == ID_nondet)
         {
           replacement_nondet_exists = true;
@@ -92,7 +92,7 @@ void validate_nondets_converted(
     // Check that our NONDET(<type>) exists on a rhs somewhere.
     exprt target_expression =
       (inst.is_assign()
-         ? inst.get_assign().rhs()
+         ? inst.assign_rhs()
          : inst.is_set_return_value() ? inst.return_value() : inst.get_code());
 
     if(

--- a/src/analyses/custom_bitvector_analysis.cpp
+++ b/src/analyses/custom_bitvector_analysis.cpp
@@ -286,10 +286,8 @@ void custom_bitvector_domaint::transform(
   switch(instruction.type)
   {
   case ASSIGN:
-    {
-      const code_assignt &code_assign = instruction.get_assign();
-      assign_struct_rec(from, code_assign.lhs(), code_assign.rhs(), cba, ns);
-    }
+    assign_struct_rec(
+      from, instruction.assign_lhs(), instruction.assign_rhs(), cba, ns);
     break;
 
   case DECL:

--- a/src/analyses/does_remove_const.cpp
+++ b/src/analyses/does_remove_const.cpp
@@ -39,20 +39,19 @@ std::pair<bool, source_locationt> does_remove_constt::operator()() const
       continue;
     }
 
-    const code_assignt &assign = instruction.get_assign();
-    const typet &rhs_type=assign.rhs().type();
-    const typet &lhs_type=assign.lhs().type();
+    const typet &rhs_type = instruction.assign_rhs().type();
+    const typet &lhs_type = instruction.assign_lhs().type();
 
     // Compare the types recursively for a point where the rhs is more
     // const that the lhs
     if(!does_type_preserve_const_correctness(&lhs_type, &rhs_type))
     {
-      return {true, assign.find_source_location()};
+      return {true, instruction.source_location};
     }
 
-    if(does_expr_lose_const(assign.rhs()))
+    if(does_expr_lose_const(instruction.assign_rhs()))
     {
-      return {true, assign.rhs().find_source_location()};
+      return {true, instruction.assign_rhs().find_source_location()};
     }
   }
 

--- a/src/analyses/escape_analysis.cpp
+++ b/src/analyses/escape_analysis.cpp
@@ -188,15 +188,16 @@ void escape_domaint::transform(
   {
   case ASSIGN:
     {
-      const code_assignt &code_assign = instruction.get_assign();
+      const exprt &assign_lhs = instruction.assign_lhs();
+      const exprt &assign_rhs = instruction.assign_rhs();
 
       std::set<irep_idt> cleanup_functions;
-      get_rhs_cleanup(code_assign.rhs(), cleanup_functions);
-      assign_lhs_cleanup(code_assign.lhs(), cleanup_functions);
+      get_rhs_cleanup(assign_rhs, cleanup_functions);
+      assign_lhs_cleanup(assign_lhs, cleanup_functions);
 
       std::set<irep_idt> rhs_aliases;
-      get_rhs_aliases(code_assign.rhs(), rhs_aliases);
-      assign_lhs_aliases(code_assign.lhs(), rhs_aliases);
+      get_rhs_aliases(assign_rhs, rhs_aliases);
+      assign_lhs_aliases(assign_lhs, rhs_aliases);
     }
     break;
 
@@ -461,17 +462,12 @@ void escape_analysist::instrument(
 
       if(instruction.type == ASSIGN)
       {
-        const code_assignt &code_assign = instruction.get_assign();
+        const exprt &assign_lhs = instruction.assign_lhs();
 
         std::set<irep_idt> cleanup_functions;
-        operator[](i_it).check_lhs(code_assign.lhs(), cleanup_functions);
+        operator[](i_it).check_lhs(assign_lhs, cleanup_functions);
         insert_cleanup(
-          gf_entry.second,
-          i_it,
-          code_assign.lhs(),
-          cleanup_functions,
-          false,
-          ns);
+          gf_entry.second, i_it, assign_lhs, cleanup_functions, false, ns);
       }
       else if(instruction.type == DEAD)
       {

--- a/src/analyses/global_may_alias.cpp
+++ b/src/analyses/global_may_alias.cpp
@@ -111,11 +111,9 @@ void global_may_alias_domaint::transform(
   {
   case ASSIGN:
   {
-    const code_assignt &code_assign = instruction.get_assign();
-
     std::set<irep_idt> rhs_aliases;
-    get_rhs_aliases(code_assign.rhs(), rhs_aliases);
-    assign_lhs_aliases(code_assign.lhs(), rhs_aliases);
+    get_rhs_aliases(instruction.assign_rhs(), rhs_aliases);
+    assign_lhs_aliases(instruction.assign_lhs(), rhs_aliases);
     break;
   }
 

--- a/src/analyses/goto_check.cpp
+++ b/src/analyses/goto_check.cpp
@@ -1982,27 +1982,28 @@ void goto_checkt::goto_check(
     }
     else if(i.is_assign())
     {
-      const code_assignt &code_assign = i.get_assign();
+      const exprt &assign_lhs = i.assign_lhs();
+      const exprt &assign_rhs = i.assign_rhs();
 
       // Reset the no_enum_check with the flag reset for exception
       // safety
       {
         flag_resett no_enum_check_flag_resetter;
         no_enum_check_flag_resetter.set_flag(no_enum_check, true);
-        check(code_assign.lhs());
+        check(assign_lhs);
       }
-      check(code_assign.rhs());
+
+      check(assign_rhs);
 
       // the LHS might invalidate any assertion
-      invalidate(code_assign.lhs());
+      invalidate(assign_lhs);
 
-      if(has_subexpr(code_assign.rhs(), [](const exprt &expr) {
+      if(has_subexpr(assign_rhs, [](const exprt &expr) {
            return expr.id() == ID_r_ok || expr.id() == ID_w_ok ||
                   expr.id() == ID_rw_ok;
          }))
       {
-        const exprt &rhs = i.assign_rhs();
-        auto rw_ok_cond = rw_ok_check(rhs);
+        auto rw_ok_cond = rw_ok_check(assign_rhs);
         if(rw_ok_cond.has_value())
           i.assign_rhs_nonconst() = *rw_ok_cond;
       }

--- a/src/analyses/goto_check.cpp
+++ b/src/analyses/goto_check.cpp
@@ -2001,14 +2001,10 @@ void goto_checkt::goto_check(
                   expr.id() == ID_rw_ok;
          }))
       {
-        const exprt &rhs = i.get_assign().rhs();
+        const exprt &rhs = i.assign_rhs();
         auto rw_ok_cond = rw_ok_check(rhs);
         if(rw_ok_cond.has_value())
-        {
-          auto new_assign = i.get_assign(); // copy
-          new_assign.rhs() = *rw_ok_cond;
-          i.set_assign(new_assign);
-        }
+          i.assign_rhs_nonconst() = *rw_ok_cond;
       }
     }
     else if(i.is_function_call())

--- a/src/analyses/goto_rw.cpp
+++ b/src/analyses/goto_rw.cpp
@@ -717,16 +717,16 @@ void rw_guarded_range_set_value_sett::add(
     {range_start, {range_end, guard.as_expr()}});
 }
 
-static void goto_rw(
+static void goto_rw_assign(
   const irep_idt &function,
   goto_programt::const_targett target,
-  const code_assignt &assign,
+  const exprt &lhs,
+  const exprt &rhs,
   rw_range_sett &rw_set)
 {
   rw_set.get_objects_rec(
-    function, target, rw_range_sett::get_modet::LHS_W, assign.lhs());
-  rw_set.get_objects_rec(
-    function, target, rw_range_sett::get_modet::READ, assign.rhs());
+    function, target, rw_range_sett::get_modet::LHS_W, lhs);
+  rw_set.get_objects_rec(function, target, rw_range_sett::get_modet::READ, rhs);
 }
 
 static void goto_rw(
@@ -801,7 +801,8 @@ void goto_rw(
     break;
 
   case ASSIGN:
-    goto_rw(function, target, target->get_assign(), rw_set);
+    goto_rw_assign(
+      function, target, target->assign_lhs(), target->assign_rhs(), rw_set);
     break;
 
   case DEAD:

--- a/src/analyses/interval_domain.cpp
+++ b/src/analyses/interval_domain.cpp
@@ -79,7 +79,7 @@ void interval_domaint::transform(
     break;
 
   case ASSIGN:
-    assign(instruction.get_assign());
+    assign(instruction.assign_lhs(), instruction.assign_rhs());
     break;
 
   case GOTO:
@@ -208,10 +208,10 @@ bool interval_domaint::join(
   return result;
 }
 
-void interval_domaint::assign(const code_assignt &code_assign)
+void interval_domaint::assign(const exprt &lhs, const exprt &rhs)
 {
-  havoc_rec(code_assign.lhs());
-  assume_rec(code_assign.lhs(), ID_equal, code_assign.rhs());
+  havoc_rec(lhs);
+  assume_rec(lhs, ID_equal, rhs);
 }
 
 void interval_domaint::havoc_rec(const exprt &lhs)

--- a/src/analyses/interval_domain.h
+++ b/src/analyses/interval_domain.h
@@ -120,7 +120,7 @@ protected:
   void havoc_rec(const exprt &);
   void assume_rec(const exprt &, bool negation=false);
   void assume_rec(const exprt &lhs, irep_idt id, const exprt &rhs);
-  void assign(const class code_assignt &assignment);
+  void assign(const exprt &lhs, const exprt &rhs);
   integer_intervalt get_int_rec(const exprt &);
   ieee_float_intervalt get_float_rec(const exprt &);
 };

--- a/src/analyses/invariant_set_domain.cpp
+++ b/src/analyses/invariant_set_domain.cpp
@@ -55,44 +55,41 @@ void invariant_set_domaint::transform(
       break;
 
     case ASSIGN:
-    {
-      const code_assignt &assignment = from_l->get_assign();
-      invariant_set.assignment(assignment.lhs(), assignment.rhs());
-    }
-    break;
+      invariant_set.assignment(from_l->assign_lhs(), from_l->assign_rhs());
+      break;
 
-  case OTHER:
-    if(from_l->get_other().is_not_nil())
+    case OTHER:
+      if(from_l->get_other().is_not_nil())
+        invariant_set.apply_code(from_l->get_code());
+      break;
+
+    case DECL:
       invariant_set.apply_code(from_l->get_code());
-    break;
+      break;
 
-  case DECL:
-    invariant_set.apply_code(from_l->get_code());
-    break;
+    case FUNCTION_CALL:
+      invariant_set.apply_code(from_l->get_code());
+      break;
 
-  case FUNCTION_CALL:
-    invariant_set.apply_code(from_l->get_code());
-    break;
+    case START_THREAD:
+      invariant_set.make_threaded();
+      break;
 
-  case START_THREAD:
-    invariant_set.make_threaded();
-    break;
-
-  case CATCH:
-  case THROW:
-    DATA_INVARIANT(false, "Exceptions must be removed before analysis");
-    break;
-  case DEAD:         // No action required
-  case ATOMIC_BEGIN: // Ignoring is a valid over-approximation
-  case ATOMIC_END:   // Ignoring is a valid over-approximation
-  case END_FUNCTION: // No action required
-  case LOCATION:     // No action required
-  case END_THREAD:   // Require a concurrent analysis at higher level
-  case SKIP:         // No action required
-    break;
-  case INCOMPLETE_GOTO:
-  case NO_INSTRUCTION_TYPE:
-    DATA_INVARIANT(false, "Only complete instructions can be analyzed");
-    break;
+    case CATCH:
+    case THROW:
+      DATA_INVARIANT(false, "Exceptions must be removed before analysis");
+      break;
+    case DEAD:         // No action required
+    case ATOMIC_BEGIN: // Ignoring is a valid over-approximation
+    case ATOMIC_END:   // Ignoring is a valid over-approximation
+    case END_FUNCTION: // No action required
+    case LOCATION:     // No action required
+    case END_THREAD:   // Require a concurrent analysis at higher level
+    case SKIP:         // No action required
+      break;
+    case INCOMPLETE_GOTO:
+    case NO_INSTRUCTION_TYPE:
+      DATA_INVARIANT(false, "Only complete instructions can be analyzed");
+      break;
   }
 }

--- a/src/analyses/local_bitvector_analysis.cpp
+++ b/src/analyses/local_bitvector_analysis.cpp
@@ -269,12 +269,12 @@ void local_bitvector_analysist::build()
     switch(instruction.type)
     {
     case ASSIGN:
-    {
-      const code_assignt &code_assign = instruction.get_assign();
       assign_lhs(
-        code_assign.lhs(), code_assign.rhs(), loc_info_src, loc_info_dest);
+        instruction.assign_lhs(),
+        instruction.assign_rhs(),
+        loc_info_src,
+        loc_info_dest);
       break;
-    }
 
     case DECL:
       assign_lhs(

--- a/src/analyses/local_may_alias.cpp
+++ b/src/analyses/local_may_alias.cpp
@@ -375,9 +375,11 @@ void local_may_aliast::build(const goto_functiont &goto_function)
     {
     case ASSIGN:
     {
-      const code_assignt &code_assign = instruction.get_assign();
       assign_lhs(
-        code_assign.lhs(), code_assign.rhs(), loc_info_src, loc_info_dest);
+        instruction.assign_lhs(),
+        instruction.assign_rhs(),
+        loc_info_src,
+        loc_info_dest);
       break;
     }
 

--- a/src/analyses/variable-sensitivity/variable_sensitivity_dependence_graph.cpp
+++ b/src/analyses/variable-sensitivity/variable_sensitivity_dependence_graph.cpp
@@ -140,8 +140,7 @@ void variable_sensitivity_dependence_domaint::data_dependencies(
   domain_data_deps.clear();
   if(to->is_assign())
   {
-    const code_assignt &inst = to->get_assign();
-    const exprt &rhs = inst.rhs();
+    const exprt &rhs = to->assign_rhs();
 
     // Handle return value of a 'no body' function
     if(rhs.id() == ID_side_effect)

--- a/src/analyses/variable-sensitivity/variable_sensitivity_domain.cpp
+++ b/src/analyses/variable-sensitivity/variable_sensitivity_domain.cpp
@@ -59,10 +59,10 @@ void variable_sensitivity_domaint::transform(
   case ASSIGN:
   {
     // TODO : check return values
-    const code_assignt &inst = instruction.get_assign();
     abstract_object_pointert rhs =
-      abstract_state.eval(inst.rhs(), ns)->write_location_context(from);
-    abstract_state.assign(inst.lhs(), rhs, ns);
+      abstract_state.eval(instruction.assign_rhs(), ns)
+        ->write_location_context(from);
+    abstract_state.assign(instruction.assign_lhs(), rhs, ns);
   }
   break;
 

--- a/src/goto-instrument/accelerate/acceleration_utils.cpp
+++ b/src/goto-instrument/accelerate/acceleration_utils.cpp
@@ -94,10 +94,7 @@ void acceleration_utilst::find_modified(
   expr_sett &modified)
 {
   if(t->is_assign())
-  {
-    code_assignt assignment = t->get_assign();
-    modified.insert(assignment.lhs());
-  }
+    modified.insert(t->assign_lhs());
 }
 
 bool acceleration_utilst::check_inductive(
@@ -237,9 +234,8 @@ exprt acceleration_utilst::precondition(patht &path)
     if(t->is_assign())
     {
       // XXX Need to check for aliasing...
-      const code_assignt &assignment = t->get_assign();
-      const exprt &lhs=assignment.lhs();
-      const exprt &rhs=assignment.rhs();
+      const exprt &lhs = t->assign_lhs();
+      const exprt &rhs = t->assign_rhs();
 
       if(lhs.id()==ID_symbol ||
          lhs.id()==ID_index ||
@@ -501,16 +497,16 @@ acceleration_utilst::expr_pairst acceleration_utilst::gather_array_assignments(
     if(r_it->is_assign())
     {
       // Is this an array assignment?
-      code_assignt assignment = r_it->get_assign();
+      exprt assignment_lhs = r_it->assign_lhs();
+      exprt assignment_rhs = r_it->assign_rhs();
 
-      if(assignment.lhs().id()==ID_index)
+      if(assignment_lhs.id() == ID_index)
       {
         // This is an array assignment -- accumulate it in our list.
-        assignments.push_back(
-          std::make_pair(assignment.lhs(), assignment.rhs()));
+        assignments.push_back(std::make_pair(assignment_lhs, assignment_rhs));
 
         // Also add this array to the set of arrays written to.
-        index_exprt index_expr=to_index_expr(assignment.lhs());
+        index_exprt index_expr = to_index_expr(assignment_lhs);
         arrays_written.insert(index_expr.array());
       }
       else
@@ -521,8 +517,8 @@ acceleration_utilst::expr_pairst acceleration_utilst::gather_array_assignments(
             a_it!=assignments.end();
             ++a_it)
         {
-          replace_expr(assignment.lhs(), assignment.rhs(), a_it->first);
-          replace_expr(assignment.lhs(), assignment.rhs(), a_it->second);
+          replace_expr(assignment_lhs, assignment_rhs, a_it->first);
+          replace_expr(assignment_lhs, assignment_rhs, a_it->second);
         }
       }
     }

--- a/src/goto-instrument/accelerate/cone_of_influence.cpp
+++ b/src/goto-instrument/accelerate/cone_of_influence.cpp
@@ -123,11 +123,10 @@ void cone_of_influencet::cone_of_influence(
 
   if(i.is_assign())
   {
-    const code_assignt &assignment = i.get_assign();
     expr_sett lhs_syms;
     bool care=false;
 
-    gather_rvalues(assignment.lhs(), lhs_syms);
+    gather_rvalues(i.assign_lhs(), lhs_syms);
 
     for(const auto &expr : lhs_syms)
       if(curr.find(expr)!=curr.end())
@@ -136,11 +135,11 @@ void cone_of_influencet::cone_of_influence(
         break;
       }
 
-    next.erase(assignment.lhs());
+    next.erase(i.assign_lhs());
 
     if(care)
     {
-      gather_rvalues(assignment.rhs(), next);
+      gather_rvalues(i.assign_rhs(), next);
     }
   }
 }

--- a/src/goto-instrument/accelerate/polynomial_accelerator.cpp
+++ b/src/goto-instrument/accelerate/polynomial_accelerator.cpp
@@ -621,10 +621,11 @@ void polynomial_acceleratort::cone_of_influence(
       // A[i]=0;
       // or
       // *p=x;
-      code_assignt assignment = r_it->get_assign();
+      exprt assignment_lhs = r_it->assign_lhs();
+      exprt assignment_rhs = r_it->assign_rhs();
       expr_sett lhs_syms;
 
-      utils.gather_rvalues(assignment.lhs(), lhs_syms);
+      utils.gather_rvalues(assignment_lhs, lhs_syms);
 
       for(expr_sett::iterator s_it=lhs_syms.begin();
           s_it!=lhs_syms.end();
@@ -635,8 +636,8 @@ void polynomial_acceleratort::cone_of_influence(
           // We're assigning to something in the cone of influence -- expand the
           // cone.
           body.push_front(*r_it);
-          cone.erase(assignment.lhs());
-          utils.gather_rvalues(assignment.rhs(), cone);
+          cone.erase(assignment_lhs);
+          utils.gather_rvalues(assignment_rhs, cone);
           break;
         }
       }
@@ -779,9 +780,8 @@ exprt polynomial_acceleratort::precondition(patht &path)
     if(t->is_assign())
     {
       // XXX Need to check for aliasing...
-      const code_assignt &assignment = t->get_assign();
-      const exprt &lhs=assignment.lhs();
-      const exprt &rhs=assignment.rhs();
+      const exprt &lhs = t->assign_lhs();
+      const exprt &rhs = t->assign_rhs();
 
       if(lhs.id()==ID_symbol)
       {

--- a/src/goto-instrument/contracts/contracts.cpp
+++ b/src/goto-instrument/contracts/contracts.cpp
@@ -816,7 +816,7 @@ void code_contractst::check_frame_conditions(
     if(instruction_it->is_decl())
     {
       // grab the declared symbol
-      const auto &decl_symbol = instruction_it->get_decl().symbol();
+      const auto &decl_symbol = instruction_it->decl_symbol();
       // move past the call and then insert the CAR
       instruction_it++;
       const auto car = assigns.add_to_write_set(decl_symbol);
@@ -838,7 +838,7 @@ void code_contractst::check_frame_conditions(
     }
     else if(instruction_it->is_dead())
     {
-      assigns.remove_from_write_set(instruction_it->get_dead().symbol());
+      assigns.remove_from_write_set(instruction_it->dead_symbol());
     }
     else if(
       instruction_it->is_other() &&

--- a/src/goto-instrument/full_slicer.cpp
+++ b/src/goto-instrument/full_slicer.cpp
@@ -243,11 +243,11 @@ static bool implicit(goto_programt::const_targett target)
   if(!target->is_assign())
     return false;
 
-  const code_assignt &a = target->get_assign();
-  if(a.lhs().id()!=ID_symbol)
+  const exprt &a_lhs = target->assign_lhs();
+  if(a_lhs.id() != ID_symbol)
     return false;
 
-  const symbol_exprt &s=to_symbol_expr(a.lhs());
+  const symbol_exprt &s = to_symbol_expr(a_lhs);
 
   return s.get_identifier() == rounding_mode_identifier();
 }

--- a/src/goto-instrument/function_modifies.cpp
+++ b/src/goto-instrument/function_modifies.cpp
@@ -26,8 +26,7 @@ void function_modifiest::get_modifies(
 
   if(instruction.is_assign())
   {
-    const exprt &lhs = instruction.get_assign().lhs();
-    get_modifies_lhs(local_may_alias, i_it, lhs, modifies);
+    get_modifies_lhs(local_may_alias, i_it, instruction.assign_lhs(), modifies);
   }
   else if(instruction.is_function_call())
   {

--- a/src/goto-instrument/loop_utils.cpp
+++ b/src/goto-instrument/loop_utils.cpp
@@ -78,7 +78,7 @@ void get_modifies(
 
     if(instruction.is_assign())
     {
-      const exprt &lhs = instruction.get_assign().lhs();
+      const exprt &lhs = instruction.assign_lhs();
       get_modifies_lhs(local_may_alias, *i_it, lhs, modifies);
     }
     else if(instruction.is_function_call())

--- a/src/goto-instrument/nondet_static.cpp
+++ b/src/goto-instrument/nondet_static.cpp
@@ -92,7 +92,7 @@ void nondet_static(
     if(instruction.is_assign())
     {
       const symbol_exprt sym =
-        to_symbol_expr(as_const(instruction).get_assign().lhs());
+        to_symbol_expr(as_const(instruction).assign_lhs());
 
       if(is_nondet_initializable_static(sym, ns))
       {

--- a/src/goto-instrument/thread_instrumentation.cpp
+++ b/src/goto-instrument/thread_instrumentation.cpp
@@ -94,13 +94,11 @@ void mutex_init_instrumentation(
   {
     if(it->is_assign())
     {
-      const code_assignt &code_assign = it->get_assign();
-
-      if(code_assign.lhs().type()==lock_type)
+      if(it->assign_lhs().type() == lock_type)
       {
         const code_function_callt call(
           f_it->second.symbol_expr(),
-          {address_of_exprt(code_assign.lhs()),
+          {address_of_exprt(it->assign_lhs()),
            address_of_exprt(string_constantt("mutex-init"))});
 
         goto_program.insert_after(

--- a/src/goto-programs/goto_program.h
+++ b/src/goto-programs/goto_program.h
@@ -193,14 +193,6 @@ public:
       return code;
     }
 
-    /// Get the assignment for ASSIGN
-    DEPRECATED(SINCE(2021, 2, 24, "Use assign_lhs/rhs instead"))
-    const code_assignt &get_assign() const
-    {
-      PRECONDITION(is_assign());
-      return to_code_assign(code);
-    }
-
     /// Get the lhs of the assignment for ASSIGN
     const exprt &assign_lhs() const
     {

--- a/src/goto-programs/goto_program.h
+++ b/src/goto-programs/goto_program.h
@@ -229,26 +229,6 @@ public:
       return to_code_assign(code).rhs();
     }
 
-    /// Set the assignment for ASSIGN
-    DEPRECATED(SINCE(2021, 2, 24, "Use assign_lhs/rhs instead"))
-    void set_assign(code_assignt c)
-    {
-      PRECONDITION(is_assign());
-      code = std::move(c);
-    }
-
-    /// Get the declaration for DECL
-    DEPRECATED(SINCE(2021, 2, 24, "Use decl_symbol instead"))
-    const code_declt &get_decl() const
-    {
-      PRECONDITION(is_decl());
-      const auto &decl = expr_checked_cast<code_declt>(code);
-      INVARIANT(
-        !decl.initial_value(),
-        "code_declt in goto program may not contain initialization.");
-      return decl;
-    }
-
     /// Get the declared symbol for DECL
     const symbol_exprt &decl_symbol() const
     {
@@ -271,26 +251,6 @@ public:
       return decl.symbol();
     }
 
-    /// Set the declaration for DECL
-    DEPRECATED(SINCE(2021, 2, 24, "Use decl_symbol instead"))
-    void set_decl(code_declt c)
-    {
-      PRECONDITION(is_decl());
-      INVARIANT(
-        !c.initial_value(),
-        "Initialization must be separated from code_declt before adding to "
-        "goto_instructiont.");
-      code = std::move(c);
-    }
-
-    /// Get the dead statement for DEAD
-    DEPRECATED(SINCE(2021, 2, 24, "Use dead_symbol instead"))
-    const code_deadt &get_dead() const
-    {
-      PRECONDITION(is_dead());
-      return to_code_dead(code);
-    }
-
     /// Get the symbol for DEAD
     const symbol_exprt &dead_symbol() const
     {
@@ -305,22 +265,6 @@ public:
       return to_code_dead(code).symbol();
     }
 
-    /// Set the dead statement for DEAD
-    DEPRECATED(SINCE(2021, 2, 24, "Use dead_symbol instead"))
-    void set_dead(code_deadt c)
-    {
-      PRECONDITION(is_dead());
-      code = std::move(c);
-    }
-
-    /// Get the return statement for READ
-    DEPRECATED(SINCE(2021, 2, 24, "Use return_value instead"))
-    const code_returnt &get_return() const
-    {
-      PRECONDITION(is_set_return_value());
-      return to_code_return(code);
-    }
-
     /// Get the return value of a SET_RETURN_VALUE instruction
     const exprt &return_value() const
     {
@@ -333,14 +277,6 @@ public:
     {
       PRECONDITION(is_set_return_value());
       return to_code_return(code).return_value();
-    }
-
-    /// Set the return statement for SET_RETURN_VALUE
-    DEPRECATED(SINCE(2021, 2, 24, "Use return_value instead"))
-    void set_return(code_returnt c)
-    {
-      PRECONDITION(is_set_return_value());
-      code = std::move(c);
     }
 
     /// Get the function call for FUNCTION_CALL

--- a/src/goto-programs/interpreter.cpp
+++ b/src/goto-programs/interpreter.cpp
@@ -653,15 +653,16 @@ exprt interpretert::get_value(
 /// executes the assign statement at the current pc value
 void interpretert::execute_assign()
 {
-  const code_assignt &code_assign = pc->get_assign();
+  const exprt &assign_lhs = pc->assign_lhs();
+  const exprt &assign_rhs = pc->assign_rhs();
 
   mp_vectort rhs;
-  evaluate(code_assign.rhs(), rhs);
+  evaluate(assign_rhs, rhs);
 
   if(!rhs.empty())
   {
-    mp_integer address=evaluate_address(code_assign.lhs());
-    mp_integer size=get_size(code_assign.lhs().type());
+    mp_integer address = evaluate_address(assign_lhs);
+    mp_integer size = get_size(assign_lhs.type());
 
     if(size!=rhs.size())
       output.error() << "!! failed to obtain rhs (" << rhs.size() << " vs. "
@@ -671,20 +672,19 @@ void interpretert::execute_assign()
     {
       goto_trace_stept &trace_step=steps.get_last_step();
       assign(address, rhs);
-      trace_step.full_lhs=code_assign.lhs();
+      trace_step.full_lhs = assign_lhs;
       trace_step.full_lhs_value=get_value(trace_step.full_lhs.type(), rhs);
     }
   }
-  else if(code_assign.rhs().id()==ID_side_effect)
+  else if(assign_rhs.id() == ID_side_effect)
   {
-    side_effect_exprt side_effect=to_side_effect_expr(code_assign.rhs());
+    side_effect_exprt side_effect = to_side_effect_expr(assign_rhs);
     if(side_effect.get_statement()==ID_nondet)
     {
       mp_integer address =
-        numeric_cast_v<std::size_t>(evaluate_address(code_assign.lhs()));
+        numeric_cast_v<std::size_t>(evaluate_address(assign_lhs));
 
-      mp_integer size=
-        get_size(code_assign.lhs().type());
+      mp_integer size = get_size(assign_lhs.type());
 
       for(mp_integer i=0; i<size; ++i)
       {

--- a/unit/analyses/ai/ai.cpp
+++ b/unit/analyses/ai/ai.cpp
@@ -94,11 +94,9 @@ public:
   {
     if(!i.is_assign())
       return false;
-    const code_assignt &assign = i.get_assign();
-    return
-      assign.lhs().id() == ID_symbol &&
-      id2string(to_symbol_expr(assign.lhs()).get_identifier()).find('y') !=
-      std::string::npos;
+    return i.assign_lhs().id() == ID_symbol &&
+           id2string(to_symbol_expr(i.assign_lhs()).get_identifier())
+               .find('y') != std::string::npos;
   }
 
   static bool is_y_assignment_location(locationt l)

--- a/unit/analyses/constant_propagator.cpp
+++ b/unit/analyses/constant_propagator.cpp
@@ -72,7 +72,7 @@ SCENARIO("constant_propagator", "[core][analyses][constant_propagator]")
       main_function.body.instructions.begin();
     while(test_instruction != main_function.body.instructions.end() &&
           (!test_instruction->is_assign() ||
-           test_instruction->get_assign().lhs() != local_y.symbol_expr()))
+           test_instruction->assign_lhs() != local_y.symbol_expr()))
     {
       ++test_instruction;
     }
@@ -310,10 +310,9 @@ SCENARIO("constant_propagator", "[core][analyses][constant_propagator]")
     // have been propagated once we reach it.
     goto_programt::const_targett test_instruction =
       main_function.body.instructions.begin();
-    while(
-      test_instruction != main_function.body.instructions.end() &&
-      !(test_instruction->is_assign() &&
-        test_instruction->get_assign().lhs() == marker_symbol.symbol_expr()))
+    while(test_instruction != main_function.body.instructions.end() &&
+          !(test_instruction->is_assign() &&
+            test_instruction->assign_lhs() == marker_symbol.symbol_expr()))
     {
       ++test_instruction;
     }


### PR DESCRIPTION
This removes 8 methods from the goto-program API that have been deprecated
since February, along with a few remaining uses.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
