### PR TITLE
remove goto_programt::set_function_call

### DIFF
--- a/src/goto-analyzer/static_simplifier.cpp
+++ b/src/goto-analyzer/static_simplifier.cpp
@@ -125,14 +125,14 @@ bool static_simplifier(
       }
       else if(i_it->is_function_call())
       {
-        auto fcall = i_it->get_function_call();
+        // copy
+        auto call_function = as_const(*i_it).call_function();
+        auto call_arguments = as_const(*i_it).call_arguments();
 
         bool unchanged =
-          ai.abstract_state_before(i_it)->ai_simplify(fcall.function(), ns);
+          ai.abstract_state_before(i_it)->ai_simplify(call_function, ns);
 
-        exprt::operandst &args=fcall.arguments();
-
-        for(auto &o : args)
+        for(auto &o : call_arguments)
           unchanged &= ai.abstract_state_before(i_it)->ai_simplify(o, ns);
 
         if(unchanged)
@@ -140,7 +140,8 @@ bool static_simplifier(
         else
         {
           simplified.function_calls++;
-          i_it->set_function_call(fcall);
+          i_it->call_function() = std::move(call_function);
+          i_it->call_arguments() = std::move(call_arguments);
         }
       }
     }

--- a/src/goto-instrument/replace_calls.cpp
+++ b/src/goto-instrument/replace_calls.cpp
@@ -70,12 +70,11 @@ void replace_callst::operator()(
     if(!ins.is_function_call())
       continue;
 
-    auto cfc = ins.get_function_call();
-    exprt &function = cfc.function();
+    const exprt &function = ins.call_function();
 
     PRECONDITION(function.id() == ID_symbol);
 
-    symbol_exprt &se = to_symbol_expr(function);
+    const symbol_exprt &se = to_symbol_expr(function);
     const irep_idt &id = se.get_identifier();
 
     auto f_it1 = goto_functions.function_map.find(id);
@@ -109,10 +108,8 @@ void replace_callst::operator()(
     }
 
     // Finally modify the call
-    function.type() = ns.lookup(f_it2->first).type;
-    se.set_identifier(new_id);
-
-    ins.set_function_call(cfc);
+    ins.call_function().type() = ns.lookup(f_it2->first).type;
+    to_symbol_expr(ins.call_function()).set_identifier(new_id);
   }
 }
 

--- a/src/goto-programs/goto_program.h
+++ b/src/goto-programs/goto_program.h
@@ -327,20 +327,6 @@ public:
       return to_code_function_call(code).arguments();
     }
 
-    /// Set the function call for FUNCTION_CALL
-#if 1
-    DEPRECATED(SINCE(
-      2021,
-      2,
-      24,
-      "Use call_function(), call_lhs(), call_arguments() instead"))
-    void set_function_call(code_function_callt c)
-    {
-      PRECONDITION(is_function_call());
-      code = std::move(c);
-    }
-#endif
-
     /// Get the statement for OTHER
     const codet &get_other() const
     {

--- a/src/goto-programs/remove_virtual_functions.cpp
+++ b/src/goto-programs/remove_virtual_functions.cpp
@@ -291,7 +291,8 @@ static goto_programt::targett replace_virtual_function_with_dispatch_table(
     {
       auto c = target->get_function_call();
       create_static_function_call(c, *functions.front().symbol_expr, ns);
-      target->set_function_call(c);
+      target->call_function() = c.function();
+      target->call_arguments() = c.arguments();
     }
     return next_target;
   }


### PR DESCRIPTION
This removes the deprecated `goto_programt::set_function_call` method, along
with the two remaining uses.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
