### PR TITLE
Fix invalidation of CARs on free and DEAD instructions

### DIFF
--- a/regression/contracts/assigns_enforce_free_dead/main.c
+++ b/regression/contracts/assigns_enforce_free_dead/main.c
@@ -1,0 +1,65 @@
+#include <assert.h>
+#include <stdlib.h>
+
+int foo(int *x, int **p) __CPROVER_assigns(*x, *p, **p)
+{
+  if(p && *p)
+    **p = 0;
+
+  {
+    int y;
+    y = 1;
+    *x = 0;
+
+    if(nondet_bool())
+      return 0;
+
+    if(p)
+      *p = &y;
+
+    // y goes DEAD here, unconditionally
+  }
+
+  if(p && *p)
+    **p = 0;
+
+  int a = 1;
+
+  if(x == NULL)
+  {
+    return 1;
+    // a goes DEAD here, conditionally
+  }
+
+  int *z = malloc(100 * sizeof(int));
+  int *w = NULL;
+
+  if(z)
+  {
+    w = &(z[10]);
+    *w = 0;
+
+    int *q = &(z[20]);
+    *q = 1;
+    // q goes DEAD here, unconditionally
+  }
+
+  free(z);
+
+  z = malloc(sizeof(int));
+  if(nondet_bool())
+  {
+    free(z);
+    // here z is deallocated, conditionally
+  }
+
+  *x = 1;
+  x = 0;
+}
+
+int main()
+{
+  int z;
+  int *x = malloc(sizeof(int));
+  foo(&z, &x);
+}

--- a/regression/contracts/assigns_enforce_free_dead/test.desc
+++ b/regression/contracts/assigns_enforce_free_dead/test.desc
@@ -1,0 +1,43 @@
+CORE
+main.c
+--enforce-contract foo _ --malloc-may-fail --malloc-fail-null --pointer-primitive-check
+^\[foo.\d+\] line \d+ Check that \*\(\*p\) is assignable: SUCCESS$
+^\[foo.\d+\] line \d+ Check that \*\(\*p\) is assignable: FAILURE$
+^\[foo.\d+\] line \d+ Check that \*p is assignable: SUCCESS$
+^\[foo.\d+\] line \d+ Check that \*q is assignable: SUCCESS$
+^\[foo.\d+\] line \d+ Check that \*w is assignable: SUCCESS$
+^\[foo.\d+\] line \d+ Check that \*x is assignable: SUCCESS$
+^\[foo.\d+\] line \d+ Check that a is assignable: SUCCESS$
+^\[foo.\d+\] line \d+ Check that q is assignable: SUCCESS$
+^\[foo.\d+\] line \d+ Check that w is assignable: SUCCESS$
+^\[foo.\d+\] line \d+ Check that x is assignable: SUCCESS$
+^\[foo.\d+\] line \d+ Check that y is assignable: SUCCESS$
+^\[foo.\d+\] line \d+ Check that z is assignable: SUCCESS$
+^\[foo.\d+\] line \d+ Check that POINTER_OBJECT\(\(void \*\)z\) is assignable: SUCCESS$
+^EXIT=10$
+^SIGNAL=0$
+^VERIFICATION FAILED$
+--
+^\[foo.\d+\] line \d+ Check that \*p is assignable: FAILURE$
+^\[foo.\d+\] line \d+ Check that \*q is assignable: FAILURE$
+^\[foo.\d+\] line \d+ Check that \*w is assignable: FAILURE$
+^\[foo.\d+\] line \d+ Check that \*x is assignable: FAILURE$
+^\[foo.\d+\] line \d+ Check that a is assignable: FAILURE$
+^\[foo.\d+\] line \d+ Check that q is assignable: FAILURE$
+^\[foo.\d+\] line \d+ Check that w is assignable: FAILURE$
+^\[foo.\d+\] line \d+ Check that x is assignable: FAILURE$
+^\[foo.\d+\] line \d+ Check that y is assignable: FAILURE$
+^\[foo.\d+\] line \d+ Check that z is assignable: FAILURE$
+^\[foo.\d+\] line \d+ Check that POINTER_OBJECT\(\(void \*\)z\) is assignable: FAILURE$
+^.*tmp_cc\$\d+.*: FAILURE$
+--
+Checks that invalidated CARs are correctly tracked on `free` and `DEAD`.
+
+Since several variables are assigned multiple times,
+we rule out all failures using the negative regex matches above.
+
+We also check (using positive regex matches above) that
+`**p` should be assignable in one case and should not be assignable in the other.
+
+Finally, we check that there should be no "internal" assertion failures
+on `tmp_cc` variables used to track CARs.

--- a/regression/contracts/test_aliasing_ensure_indirect/test.desc
+++ b/regression/contracts/test_aliasing_ensure_indirect/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---enforce-contract foo --enforce-contract bar
+--enforce-contract foo
 ^EXIT=0$
 ^SIGNAL=0$
 \[postcondition.\d+\] file main.c line \d+ Check ensures clause: SUCCESS

--- a/src/goto-instrument/contracts/assigns.cpp
+++ b/src/goto-instrument/contracts/assigns.cpp
@@ -86,6 +86,15 @@ assigns_clauset::conditional_address_ranget::generate_snapshot_instructions()
   instructions.add(goto_programt::make_decl(lower_bound_address_var, location));
   instructions.add(goto_programt::make_decl(upper_bound_address_var, location));
 
+  instructions.add(goto_programt::make_assignment(
+    lower_bound_address_var,
+    null_pointer_exprt{to_pointer_type(slice.first.type())},
+    location));
+  instructions.add(goto_programt::make_assignment(
+    upper_bound_address_var,
+    null_pointer_exprt{to_pointer_type(slice.first.type())},
+    location));
+
   goto_programt skip_program;
   const auto skip_target = skip_program.add(goto_programt::make_skip(location));
 

--- a/src/goto-instrument/contracts/contracts.cpp
+++ b/src/goto-instrument/contracts/contracts.cpp
@@ -637,7 +637,7 @@ void code_contractst::instrument_assign_statement(
     "The first instruction of instrument_assign_statement should always be"
     " an assignment");
 
-  add_containment_check(
+  add_inclusion_check(
     program, assigns_clause, instruction_it, instruction_it->assign_lhs());
 }
 
@@ -678,7 +678,7 @@ void code_contractst::instrument_call_statement(
   }
   else if(callee_name == "free")
   {
-    add_containment_check(
+    add_inclusion_check(
       body,
       assigns,
       instruction_it,
@@ -846,12 +846,12 @@ void code_contractst::check_frame_conditions(
     {
       const exprt &havoc_argument = dereference_exprt(
         to_typecast_expr(instruction_it->get_other().operands().front()).op());
-      add_containment_check(body, assigns, instruction_it, havoc_argument);
+      add_inclusion_check(body, assigns, instruction_it, havoc_argument);
     }
   }
 }
 
-void code_contractst::add_containment_check(
+void code_contractst::add_inclusion_check(
   goto_programt &program,
   const assigns_clauset &assigns,
   goto_programt::instructionst::iterator &instruction_it,

--- a/src/goto-instrument/contracts/contracts.h
+++ b/src/goto-instrument/contracts/contracts.h
@@ -30,6 +30,8 @@ Date: February 2016
 #include <util/namespace.h>
 #include <util/pointer_expr.h>
 
+#include "assigns.h"
+
 #define FLAG_LOOP_CONTRACTS "apply-loop-contracts"
 #define HELP_LOOP_CONTRACTS                                                    \
   " --apply-loop-contracts\n"                                                  \
@@ -44,7 +46,6 @@ Date: February 2016
 #define HELP_ENFORCE_CONTRACT                                                  \
   " --enforce-contract <fun>     wrap fun with an assertion of its contract\n"
 
-class assigns_clauset;
 class local_may_aliast;
 class replace_symbolt;
 
@@ -134,7 +135,7 @@ protected:
 
   /// Inserts an assertion into the goto program to ensure that
   /// an expression is within the assignable memory frame.
-  void add_inclusion_check(
+  const assigns_clauset::conditional_address_ranget add_inclusion_check(
     goto_programt &,
     const assigns_clauset &,
     goto_programt::instructionst::iterator &,

--- a/src/goto-instrument/contracts/contracts.h
+++ b/src/goto-instrument/contracts/contracts.h
@@ -134,7 +134,7 @@ protected:
 
   /// Inserts an assertion into the goto program to ensure that
   /// an expression is within the assignable memory frame.
-  void add_containment_check(
+  void add_inclusion_check(
     goto_programt &,
     const assigns_clauset &,
     goto_programt::instructionst::iterator &,
@@ -144,19 +144,17 @@ protected:
   /// a goto statement that jumps back.
   bool check_for_looped_mallocs(const goto_programt &program);
 
-  /// Inserts an assertion statement into program before the assignment
+  /// Inserts an assertion into program immediately before the assignment
   /// instruction_it, to ensure that the left-hand-side of the assignment
-  /// aliases some expression in original_references, unless it is contained
-  /// in freely assignable set.
+  /// is "included" in the (conditional address ranges in the) write set.
   void instrument_assign_statement(
     goto_programt::instructionst::iterator &,
     goto_programt &,
     assigns_clauset &);
 
-  /// Inserts an assertion statement into program before the function call at
-  /// ins_it, to ensure that any memory which may be written by the call is
-  /// aliased by some expression in assigns_references, unless it is contained
-  /// in freely assignable set.
+  /// Inserts an assertion into program immediately before the function call at
+  /// instruction_it, to ensure that all memory locations written to by the
+  // callee are "included" in the (conditional address ranges in the) write set.
   void instrument_call_statement(
     goto_programt::instructionst::iterator &,
     const irep_idt &,


### PR DESCRIPTION
Previously, corresponding CARs were completely removed on `DEAD` instructions. While this is "okay" for unconditionally dead symbols, it resulted in spurious non-assignable errors when symbols were conditionally `DEAD`, e.g. `RETURN` within a conditional block.
Previously, invalid CARs from `free` calls were simply left behind, because (in theory) the CAR validation condition should automatically guard against conditions.

However, in both these cases, we need to check dead/deallocated status of individual objects to avoid spurious errors from CBMC's internal pointer checks. This PR fixes this.

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a ~~The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/~~
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a ~~My commit message includes data points confirming performance improvements (if claimed).~~
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.