### PR TITLE
introduce code_frontend_declt

### DIFF
--- a/src/ansi-c/c_typecheck_code.cpp
+++ b/src/ansi-c/c_typecheck_code.cpp
@@ -316,7 +316,7 @@ void c_typecheck_baset::typecheck_decl(codet &code)
     }
     else
     {
-      code_declt decl(symbol.symbol_expr());
+      code_frontend_declt decl(symbol.symbol_expr());
       decl.add_source_location() = symbol.location;
       decl.symbol().add_source_location() = symbol.location;
 

--- a/src/ansi-c/c_typecheck_expr.cpp
+++ b/src/ansi-c/c_typecheck_expr.cpp
@@ -323,7 +323,7 @@ void c_typecheck_baset::typecheck_expr_main(exprt &expr)
 
     // replace declarations by symbol expressions
     for(auto &binding : bindings)
-      binding = to_code_decl(to_code(binding)).symbol();
+      binding = to_code_frontend_decl(to_code(binding)).symbol();
 
     if(expr.id() == ID_lambda)
     {
@@ -788,7 +788,7 @@ void c_typecheck_baset::typecheck_expr_operands(exprt &expr)
         throw 0;
       }
 
-      code_declt decl(symbol.symbol_expr());
+      code_frontend_declt decl(symbol.symbol_expr());
       decl.add_source_location() = declaration.source_location();
 
       binding = decl;

--- a/src/ansi-c/c_typecheck_gcc_polymorphic_builtins.cpp
+++ b/src/ansi-c/c_typecheck_gcc_polymorphic_builtins.cpp
@@ -635,7 +635,7 @@ static void instantiate_atomic_fetch_op(
   const symbol_exprt result =
     result_symbol(identifier_with_type, type, source_location, symbol_table)
       .symbol_expr();
-  block.add(codet{ID_decl_block, {code_declt{result}}});
+  block.add(codet{ID_decl_block, {code_frontend_declt{result}}});
 
   // place operations on *ptr in an atomic section
   block.add(code_expressiont{side_effect_expr_function_callt{
@@ -697,7 +697,7 @@ static void instantiate_atomic_op_fetch(
   const symbol_exprt result =
     result_symbol(identifier_with_type, type, source_location, symbol_table)
       .symbol_expr();
-  block.add(codet{ID_decl_block, {code_declt{result}}});
+  block.add(codet{ID_decl_block, {code_frontend_declt{result}}});
 
   // place operations on *ptr in an atomic section
   block.add(code_expressiont{side_effect_expr_function_callt{
@@ -810,7 +810,7 @@ static void instantiate_sync_val_compare_and_swap(
   const symbol_exprt result =
     result_symbol(identifier_with_type, type, source_location, symbol_table)
       .symbol_expr();
-  block.add(codet{ID_decl_block, {code_declt{result}}});
+  block.add(codet{ID_decl_block, {code_frontend_declt{result}}});
 
   // place operations on *ptr in an atomic section
   block.add(code_expressiont{side_effect_expr_function_callt{
@@ -868,7 +868,7 @@ static void instantiate_sync_lock_test_and_set(
   const symbol_exprt result =
     result_symbol(identifier_with_type, type, source_location, symbol_table)
       .symbol_expr();
-  block.add(codet{ID_decl_block, {code_declt{result}}});
+  block.add(codet{ID_decl_block, {code_frontend_declt{result}}});
 
   // place operations on *ptr in an atomic section
   block.add(code_expressiont{side_effect_expr_function_callt{
@@ -990,7 +990,7 @@ static void instantiate_atomic_load_n(
   const symbol_exprt result =
     result_symbol(identifier_with_type, type, source_location, symbol_table)
       .symbol_expr();
-  block.add(codet{ID_decl_block, {code_declt{result}}});
+  block.add(codet{ID_decl_block, {code_frontend_declt{result}}});
 
   block.add(code_expressiont{side_effect_expr_function_callt{
     symbol_exprt::typeless(ID___atomic_load),
@@ -1105,7 +1105,7 @@ static void instantiate_atomic_exchange_n(
   const symbol_exprt result =
     result_symbol(identifier_with_type, type, source_location, symbol_table)
       .symbol_expr();
-  block.add(codet{ID_decl_block, {code_declt{result}}});
+  block.add(codet{ID_decl_block, {code_frontend_declt{result}}});
 
   block.add(code_expressiont{side_effect_expr_function_callt{
     symbol_exprt::typeless(ID___atomic_exchange),
@@ -1142,7 +1142,7 @@ static void instantiate_atomic_compare_exchange(
     result_symbol(
       identifier_with_type, c_bool_type(), source_location, symbol_table)
       .symbol_expr();
-  block.add(codet{ID_decl_block, {code_declt{result}}});
+  block.add(codet{ID_decl_block, {code_frontend_declt{result}}});
 
   // place operations on *ptr in an atomic section
   block.add(code_expressiont{side_effect_expr_function_callt{

--- a/src/ansi-c/c_typecheck_type.cpp
+++ b/src/ansi-c/c_typecheck_type.cpp
@@ -634,7 +634,7 @@ void c_typecheck_baset::typecheck_array_type(array_typet &type)
       // produce the code that declares and initializes the symbol
       symbol_exprt symbol_expr = new_symbol.symbol_expr();
 
-      code_declt declaration(symbol_expr);
+      code_frontend_declt declaration(symbol_expr);
       declaration.add_source_location() = size_source_location;
 
       code_assignt assignment;

--- a/src/ansi-c/expr2c.cpp
+++ b/src/ansi-c/expr2c.cpp
@@ -2761,9 +2761,8 @@ std::string expr2ct::convert_code_continue(unsigned indent)
   return dest;
 }
 
-std::string expr2ct::convert_code_decl(
-  const codet &src,
-  unsigned indent)
+std::string
+expr2ct::convert_code_frontend_decl(const codet &src, unsigned indent)
 {
   // initializer to go away
   if(src.operands().size()!=1 &&
@@ -3013,7 +3012,7 @@ std::string expr2ct::convert_code(
     return convert_code_continue(indent);
 
   if(statement==ID_decl)
-    return convert_code_decl(src, indent);
+    return convert_code_frontend_decl(src, indent);
 
   if(statement==ID_decl_block)
     return convert_code_decl_block(src, indent);

--- a/src/ansi-c/expr2c_class.h
+++ b/src/ansi-c/expr2c_class.h
@@ -214,7 +214,7 @@ protected:
   std::string convert_code_break(unsigned indent);
   std::string convert_code_switch(const codet &src, unsigned indent);
   std::string convert_code_continue(unsigned indent);
-  std::string convert_code_decl(const codet &src, unsigned indent);
+  std::string convert_code_frontend_decl(const codet &, unsigned indent);
   std::string convert_code_decl_block(const codet &src, unsigned indent);
   std::string convert_code_dead(const codet &src, unsigned indent);
   // NOLINTNEXTLINE(whitespace/line_length)

--- a/src/cpp/cpp_typecheck_code.cpp
+++ b/src/cpp/cpp_typecheck_code.cpp
@@ -120,7 +120,7 @@ void cpp_typecheckt::typecheck_try_catch(codet &code)
       {
         // turn references into non-references
         {
-          code_declt &decl = to_code_decl(statements.front());
+          code_frontend_declt &decl = to_code_frontend_decl(statements.front());
           cpp_declarationt &cpp_declaration = to_cpp_declaration(decl.symbol());
 
           assert(cpp_declaration.declarators().size()==1);
@@ -139,8 +139,8 @@ void cpp_typecheckt::typecheck_try_catch(codet &code)
           catch_block.statements().front().get_statement() == ID_decl_block);
 
         // get the declaration
-        const code_declt &code_decl =
-          to_code_decl(to_code(catch_block.statements().front().op0()));
+        const code_frontend_declt &code_decl = to_code_frontend_decl(
+          to_code(catch_block.statements().front().op0()));
 
         // get the type
         const typet &type = code_decl.symbol().type();
@@ -199,7 +199,7 @@ void cpp_typecheckt::typecheck_switch(codet &code)
     assert(decl.operands().size()==1);
 
     // replace declaration by its symbol
-    value = to_code_decl(to_code(to_unary_expr(decl).op())).symbol();
+    value = to_code_frontend_decl(to_code(to_unary_expr(decl).op())).symbol();
 
     c_typecheck_baset::typecheck_switch(code);
 
@@ -456,7 +456,7 @@ void cpp_typecheckt::typecheck_decl(codet &code)
       throw 0;
     }
 
-    code_declt decl_statement(cpp_symbol_expr(symbol));
+    code_frontend_declt decl_statement(cpp_symbol_expr(symbol));
     decl_statement.add_source_location()=symbol.location;
 
     // Do we have an initializer that's not code?

--- a/src/cpp/cpp_typecheck_declaration.cpp
+++ b/src/cpp/cpp_typecheck_declaration.cpp
@@ -58,7 +58,7 @@ codet cpp_typecheckt::convert_anonymous_union(cpp_declarationt &declaration)
     throw 0;
   }
 
-  new_code.add_to_operands(code_declt(cpp_symbol_expr(symbol)));
+  new_code.add_to_operands(code_frontend_declt(cpp_symbol_expr(symbol)));
 
   // do scoping
   symbolt union_symbol =

--- a/src/cpp/parse.cpp
+++ b/src/cpp/parse.cpp
@@ -679,7 +679,7 @@ optionalt<codet> Parser::rTypedefStatement()
   if(!rTypedef(declaration))
     return {};
 
-  return code_declt(
+  return code_frontend_declt(
     static_cast<symbol_exprt &>(static_cast<exprt &>(declaration)));
 }
 
@@ -7501,7 +7501,7 @@ optionalt<codet> Parser::rStatement()
         cpp_declarationt declaration;
         if(!rTypedefUsing(declaration))
           return {};
-        code_declt statement(
+        code_frontend_declt statement(
           static_cast<symbol_exprt &>(static_cast<exprt &>(declaration)));
         statement.add_source_location() = declaration.source_location();
         return std::move(statement);
@@ -7790,7 +7790,7 @@ optionalt<codet> Parser::rTryStatement()
       if(declaration.declarators().front().name().is_nil())
         declaration.declarators().front().name() = cpp_namet("#anon");
 
-      code_declt code_decl(
+      code_frontend_declt code_decl(
         static_cast<symbol_exprt &>(static_cast<exprt &>(declaration)));
       set_location(code_decl, catch_token);
 
@@ -8237,7 +8237,7 @@ optionalt<codet> Parser::rDeclarationStatement()
       cpp_declarationt declaration;
       if(!rConstDeclaration(declaration))
         return {};
-      return code_declt(
+      return code_frontend_declt(
         static_cast<symbol_exprt &>(static_cast<exprt &>(declaration)));
     }
     else
@@ -8268,7 +8268,7 @@ optionalt<codet> Parser::rIntegralDeclStatement(
   if(lex.LookAhead(0)==';')
   {
     lex.get_token(tk);
-    code_declt statement(
+    code_frontend_declt statement(
       static_cast<symbol_exprt &>(static_cast<exprt &>(declaration)));
     set_location(statement, tk);
     return std::move(statement);
@@ -8281,7 +8281,7 @@ optionalt<codet> Parser::rIntegralDeclStatement(
     if(lex.get_token(tk)!=';')
       return {};
 
-    code_declt statement(
+    code_frontend_declt statement(
       static_cast<symbol_exprt &>(static_cast<exprt &>(declaration)));
     set_location(statement, tk);
     return std::move(statement);
@@ -8333,7 +8333,7 @@ Parser::rOtherDeclStatement(cpp_storage_spect &storage_spec, typet &cv_q)
   if(lex.get_token(tk)!=';')
     return {};
 
-  code_declt statement(
+  code_frontend_declt statement(
     static_cast<symbol_exprt &>(static_cast<exprt &>(declaration)));
   set_location(statement, tk);
   return std::move(statement);

--- a/src/goto-instrument/dump_c.cpp
+++ b/src/goto-instrument/dump_c.cpp
@@ -649,7 +649,7 @@ void dump_ct::convert_compound_enum(
 }
 
 void dump_ct::cleanup_decl(
-  code_declt &decl,
+  code_frontend_declt &decl,
   std::list<irep_idt> &local_static,
   std::list<irep_idt> &local_type_decls)
 {
@@ -908,7 +908,7 @@ void dump_ct::convert_global_variable(
       !converted_global.insert(symbol.name).second)
     return;
 
-  code_declt d(symbol.symbol_expr());
+  code_frontend_declt d(symbol.symbol_expr());
 
   find_symbols_sett syms;
   if(symbol.value.is_not_nil())
@@ -1214,7 +1214,7 @@ void dump_ct::insert_local_static_decls(
       local_static_decls.find(*it);
     PRECONDITION(d_it!=local_static_decls.end());
 
-    code_declt d=d_it->second;
+    code_frontend_declt d = d_it->second;
     std::list<irep_idt> redundant;
     cleanup_decl(d, redundant, type_decls);
 

--- a/src/goto-instrument/dump_c_class.h
+++ b/src/goto-instrument/dump_c_class.h
@@ -198,7 +198,7 @@ protected:
       const typet &type)
   {
     symbol_exprt sym(identifier, type);
-    code_declt d(sym);
+    code_frontend_declt d(sym);
 
     std::string d_str=expr_to_string(d);
     assert(!d_str.empty());
@@ -232,7 +232,7 @@ protected:
     const typet &type,
     std::ostream &os);
 
-  typedef std::unordered_map<irep_idt, code_declt> local_static_declst;
+  typedef std::unordered_map<irep_idt, code_frontend_declt> local_static_declst;
 
   void convert_global_variable(
       const symbolt &symbol,
@@ -259,7 +259,7 @@ protected:
   void cleanup_expr(exprt &expr);
   void cleanup_type(typet &type);
   void cleanup_decl(
-    code_declt &decl,
+    code_frontend_declt &decl,
     std::list<irep_idt> &local_static,
     std::list<irep_idt> &local_type_decls);
   void cleanup_harness(code_blockt &b);

--- a/src/goto-instrument/goto_program2code.cpp
+++ b/src/goto-instrument/goto_program2code.cpp
@@ -449,7 +449,7 @@ goto_programt::const_targett goto_program2codet::convert_decl(
   goto_programt::const_targett upper_bound,
   code_blockt &dest)
 {
-  code_declt d = code_declt{target->decl_symbol()};
+  code_frontend_declt d = code_frontend_declt{target->decl_symbol()};
   symbol_exprt &symbol = d.symbol();
 
   goto_programt::const_targett next=target;

--- a/src/goto-programs/goto_convert.cpp
+++ b/src/goto-programs/goto_convert.cpp
@@ -436,7 +436,7 @@ void goto_convertt::convert(
   if(statement==ID_block)
     convert_block(to_code_block(code), dest, mode);
   else if(statement==ID_decl)
-    convert_decl(to_code_decl(code), dest, mode);
+    convert_frontend_decl(to_code_frontend_decl(code), dest, mode);
   else if(statement==ID_decl_type)
     convert_decl_type(code, dest);
   else if(statement==ID_expression)
@@ -606,8 +606,8 @@ void goto_convertt::convert_expression(
   }
 }
 
-void goto_convertt::convert_decl(
-  const code_declt &code,
+void goto_convertt::convert_frontend_decl(
+  const code_frontend_declt &code,
   goto_programt &dest,
   const irep_idt &mode)
 {
@@ -1845,9 +1845,9 @@ symbolt &goto_convertt::new_tmp_symbol(
     mode,
     symbol_table);
 
-  code_declt decl(new_symbol.symbol_expr());
+  code_frontend_declt decl(new_symbol.symbol_expr());
   decl.add_source_location()=source_location;
-  convert_decl(decl, dest, mode);
+  convert_frontend_decl(decl, dest, mode);
 
   return new_symbol;
 }

--- a/src/goto-programs/goto_convert_class.h
+++ b/src/goto-programs/goto_convert_class.h
@@ -222,9 +222,9 @@ protected:
     const code_blockt &code,
     goto_programt &dest,
     const irep_idt &mode);
-  void convert_decl(
-    const code_declt &code,
-    goto_programt &dest,
+  void convert_frontend_decl(
+    const code_frontend_declt &,
+    goto_programt &,
     const irep_idt &mode);
   void convert_decl_type(const codet &code, goto_programt &dest);
   void convert_expression(

--- a/src/goto-programs/goto_convert_side_effect.cpp
+++ b/src/goto-programs/goto_convert_side_effect.cpp
@@ -381,9 +381,9 @@ void goto_convertt::remove_function_call(
     symbol_table);
 
   {
-    code_declt decl(new_symbol.symbol_expr());
+    code_frontend_declt decl(new_symbol.symbol_expr());
     decl.add_source_location()=new_symbol.location;
-    convert_decl(decl, dest, mode);
+    convert_frontend_decl(decl, dest, mode);
   }
 
   {
@@ -421,9 +421,9 @@ void goto_convertt::remove_cpp_new(
     ID_cpp,
     symbol_table);
 
-  code_declt decl(new_symbol.symbol_expr());
+  code_frontend_declt decl(new_symbol.symbol_expr());
   decl.add_source_location()=new_symbol.location;
-  convert_decl(decl, dest, ID_cpp);
+  convert_frontend_decl(decl, dest, ID_cpp);
 
   const code_assignt call(new_symbol.symbol_expr(), expr);
 
@@ -467,9 +467,9 @@ void goto_convertt::remove_malloc(
       mode,
       symbol_table);
 
-    code_declt decl(new_symbol.symbol_expr());
+    code_frontend_declt decl(new_symbol.symbol_expr());
     decl.add_source_location()=new_symbol.location;
-    convert_decl(decl, dest, mode);
+    convert_frontend_decl(decl, dest, mode);
 
     code_assignt call(new_symbol.symbol_expr(), expr);
     call.add_source_location()=expr.source_location();

--- a/src/goto-programs/goto_program.h
+++ b/src/goto-programs/goto_program.h
@@ -226,9 +226,6 @@ public:
     {
       PRECONDITION(is_decl());
       auto &decl = expr_checked_cast<code_declt>(code);
-      INVARIANT(
-        !decl.initial_value(),
-        "code_declt in goto program may not contain initialization.");
       return decl.symbol();
     }
 
@@ -237,9 +234,6 @@ public:
     {
       PRECONDITION(is_decl());
       auto &decl = expr_checked_cast<code_declt>(code);
-      INVARIANT(
-        !decl.initial_value(),
-        "code_declt in goto program may not contain initialization.");
       return decl.symbol();
     }
 

--- a/src/goto-programs/wp.cpp
+++ b/src/goto-programs/wp.cpp
@@ -225,7 +225,6 @@ exprt wp_decl(
   const exprt &post,
   const namespacet &ns)
 {
-  PRECONDITION(!code.initial_value());
   // Model decl(var) as var = nondet()
   const exprt &var = code.symbol();
   side_effect_expr_nondett nondet(var.type(), source_locationt());

--- a/src/jsil/jsil_convert.cpp
+++ b/src/jsil/jsil_convert.cpp
@@ -91,7 +91,7 @@ bool jsil_convertt::convert_code(const symbolt &symbol, codet &code)
 
       code_try_catcht t_c(std::move(t));
       // Adding empty symbol to catch decl
-      code_declt d(symbol_exprt::typeless("decl_symbol"));
+      code_frontend_declt d(symbol_exprt::typeless("decl_symbol"));
       t_c.add_catch(d, g);
       t_c.add_source_location()=code.source_location();
 

--- a/src/util/format_expr.cpp
+++ b/src/util/format_expr.cpp
@@ -443,7 +443,7 @@ void format_expr_configt::setup()
     {
       return os << "dead " << format(to_code_dead(code).symbol()) << ";";
     }
-    else if(const auto decl = expr_try_dynamic_cast<code_declt>(code))
+    else if(const auto decl = expr_try_dynamic_cast<code_frontend_declt>(code))
     {
       const auto &declaration_symb = decl->symbol();
       os << "decl " << format(declaration_symb.type()) << " "

--- a/src/util/std_code.h
+++ b/src/util/std_code.h
@@ -311,47 +311,12 @@ public:
     return symbol().get_identifier();
   }
 
-  /// Returns the initial value to which the declared variable is initialized,
-  /// or empty in the case where no initialisation is included.
-  /// \note: Initial values may be present in the front end but they must be
-  ///   separated into a separate assignment when used in a `goto_instructiont`.
-  optionalt<exprt> initial_value() const
-  {
-    if(operands().size() < 2)
-      return {};
-    return {op1()};
-  }
-
-  /// Sets the value to which this declaration initializes the declared
-  /// variable. Empty optional maybe passed to remove existing initialisation.
-  /// \note: Initial values may be present in the front end but they must be
-  ///   separated into a separate assignment when used in a `goto_instructiont`.
-  void set_initial_value(optionalt<exprt> initial_value)
-  {
-    if(!initial_value)
-    {
-      operands().resize(1);
-    }
-    else if(operands().size() < 2)
-    {
-      PRECONDITION(operands().size() == 1);
-      add_to_operands(std::move(*initial_value));
-    }
-    else
-    {
-      op1() = std::move(*initial_value);
-    }
-  }
-
   static void check(
     const codet &code,
     const validation_modet vm = validation_modet::INVARIANT)
   {
-    // will be size()==1 in the future
     DATA_CHECK(
-      vm,
-      code.operands().size() >= 1,
-      "declaration must have one or more operands");
+      vm, code.operands().size() == 1, "declaration must have one operand");
     DATA_CHECK(
       vm,
       code.op0().id() == ID_symbol,

--- a/unit/util/format.cpp
+++ b/unit/util/format.cpp
@@ -16,7 +16,7 @@
 TEST_CASE("Format a declaration statement.", "[core][util][format]")
 {
   const signedbv_typet int_type{32};
-  code_declt declaration{symbol_exprt{"foo", int_type}};
+  code_frontend_declt declaration{symbol_exprt{"foo", int_type}};
   REQUIRE(format_to_string(declaration) == "decl signedbv[32] foo;");
   declaration.set_initial_value({int_type.zero_expr()});
   REQUIRE(format_to_string(declaration) == "decl signedbv[32] foo = 0;");


### PR DESCRIPTION
This introduces code_fontend_declt, which separates code_declt (for use in goto instructions) and the statement in C programs.

The two differ (the variant for goto programs has no initializer), and separating them enables changes.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
