### PR TITLE
Address incremental SMT2 related code review comments from PR6357

### DIFF
--- a/src/solvers/smt2_incremental/smt2_incremental_decision_procedure.cpp
+++ b/src/solvers/smt2_incremental/smt2_incremental_decision_procedure.cpp
@@ -49,7 +49,7 @@ void smt2_incremental_decision_proceduret::define_dependent_functions(
         return expr_identifier.first;
       });
   std::stack<exprt> to_be_defined;
-  const auto dependencies_needed = [&](const exprt &expr) {
+  const auto push_dependencies_needed = [&](const exprt &expr) {
     bool result = false;
     for(const auto &dependency : gather_dependent_expressions(expr))
     {
@@ -60,11 +60,11 @@ void smt2_incremental_decision_proceduret::define_dependent_functions(
     }
     return result;
   };
-  dependencies_needed(expr);
+  push_dependencies_needed(expr);
   while(!to_be_defined.empty())
   {
     const exprt current = to_be_defined.top();
-    if(dependencies_needed(current))
+    if(push_dependencies_needed(current))
       continue;
     if(const auto symbol_expr = expr_try_dynamic_cast<symbol_exprt>(current))
     {
@@ -81,7 +81,7 @@ void smt2_incremental_decision_proceduret::define_dependent_functions(
       }
       else
       {
-        if(dependencies_needed(symbol->value))
+        if(push_dependencies_needed(symbol->value))
           continue;
         const smt_define_function_commandt function{
           symbol->name, {}, convert_expr_to_smt(symbol->value)};

--- a/src/solvers/smt2_incremental/smt_terms.cpp
+++ b/src/solvers/smt2_incremental/smt_terms.cpp
@@ -52,7 +52,7 @@ static bool is_valid_smt_identifier(irep_idt identifier)
 {
   // The below regex matches a complete string which does not contain the `|`
   // character. So it would match the string `foo bar`, but not `|foo bar|`.
-  static const std::regex valid{R"(^[^\|]*$)"};
+  static const std::regex valid{"[^\\|]*"};
   return std::regex_match(id2string(identifier), valid);
 }
 

--- a/src/solvers/smt2_incremental/smt_terms.cpp
+++ b/src/solvers/smt2_incremental/smt_terms.cpp
@@ -59,6 +59,10 @@ static bool is_valid_smt_identifier(irep_idt identifier)
 smt_identifier_termt::smt_identifier_termt(irep_idt identifier, smt_sortt sort)
   : smt_termt(ID_smt_identifier_term, std::move(sort))
 {
+  // The below invariant exists as a sanity check that the string being used for
+  // the identifier is in unescaped form. This is because the escaping and
+  // unescaping are implementation details of the printing to string and
+  // response parsing respectively, not part of the underlying data.
   INVARIANT(
     is_valid_smt_identifier(identifier),
     R"(Identifiers may not contain | characters.)");

--- a/src/solvers/smt2_incremental/smt_terms.cpp
+++ b/src/solvers/smt2_incremental/smt_terms.cpp
@@ -50,6 +50,8 @@ bool smt_bool_literal_termt::value() const
 
 static bool is_valid_smt_identifier(irep_idt identifier)
 {
+  // The below regex matches a complete string which does not contain the `|`
+  // character. So it would match the string `foo bar`, but not `|foo bar|`.
   static const std::regex valid{R"(^[^\|]*$)"};
   return std::regex_match(id2string(identifier), valid);
 }


### PR DESCRIPTION
This PR addresses incremental SMT2 related code review comments from 
https://github.com/diffblue/cbmc/pull/6357. Some of the outstanding comments on this PR were not blocking and the PR was therefore merged without addressing them. This is the follow up PR which cleans this up.
<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
