### PR TITLE
introduce code_frontend_assignt

### DIFF
--- a/jbmc/src/java_bytecode/code_with_references.cpp
+++ b/jbmc/src/java_bytecode/code_with_references.cpp
@@ -23,7 +23,7 @@ codet allocate_array(
   pointer_type.subtype().set(ID_element_type, element_type);
   side_effect_exprt java_new_array{
     ID_java_new_array, {array_length_expr}, pointer_type, loc};
-  return code_assignt{expr, java_new_array, loc};
+  return code_frontend_assignt{expr, java_new_array, loc};
 }
 
 code_blockt
@@ -41,8 +41,8 @@ reference_allocationt::to_code(reference_substitutiont &references) const
   // or the "@id" json field corresponding to `reference_id` doesn't appear in
   // the file.
   code_blockt code;
-  code.add(code_assignt{*reference.array_length,
-                        side_effect_expr_nondett{java_int_type(), loc}});
+  code.add(code_frontend_assignt{
+    *reference.array_length, side_effect_expr_nondett{java_int_type(), loc}});
   code.add(code_assumet{binary_predicate_exprt{
     *reference.array_length, ID_ge, from_integer(0, java_int_type())}});
   code.add(allocate_array(reference.expr, *reference.array_length, loc));

--- a/jbmc/src/java_bytecode/create_array_with_type_intrinsic.cpp
+++ b/jbmc/src/java_bytecode/create_array_with_type_intrinsic.cpp
@@ -14,9 +14,9 @@ Author: Diffblue Ltd.
 #include <java_bytecode/java_types.h>
 
 #include <util/fresh_symbol.h>
-#include <util/goto_instruction_code.h>
 #include <util/namespace.h>
 #include <util/pointer_expr.h>
+#include <util/std_code.h>
 #include <util/symbol_table_base.h>
 
 /// Returns the symbol name for `org.cprover.CProver.createArrayWithType`
@@ -81,7 +81,7 @@ codet create_array_with_type_body(
   side_effect_exprt new_array_expr{
     ID_java_new_array, new_array_symbol.type, source_locationt{}};
   new_array_expr.copy_to_operands(length_argument_symbol_expr);
-  code_block.add(code_assignt(new_array_symbol_expr, new_array_expr));
+  code_block.add(code_frontend_assignt(new_array_symbol_expr, new_array_expr));
 
   dereference_exprt existing_array(existing_array_argument_symbol_expr);
   dereference_exprt new_array(new_array_symbol_expr);
@@ -99,9 +99,10 @@ codet create_array_with_type_body(
   member_exprt new_array_element_classid(
     new_array, JAVA_ARRAY_ELEMENT_CLASSID_FIELD_NAME, string_typet());
 
-  code_block.add(code_assignt(new_array_dimension, old_array_dimension));
   code_block.add(
-    code_assignt(new_array_element_classid, old_array_element_classid));
+    code_frontend_assignt(new_array_dimension, old_array_dimension));
+  code_block.add(code_frontend_assignt(
+    new_array_element_classid, old_array_element_classid));
 
   // return new_array
   code_block.add(code_returnt(new_array_symbol_expr));

--- a/jbmc/src/java_bytecode/java_bytecode_convert_class.cpp
+++ b/jbmc/src/java_bytecode/java_bytecode_convert_class.cpp
@@ -909,7 +909,7 @@ void add_java_array_types(symbol_tablet &symbol_table)
     member_exprt old_length(
       old_array, length_component.get_name(), length_component.type());
     java_new_array.copy_to_operands(old_length);
-    code_assignt create_blank(local_symexpr, java_new_array);
+    code_frontend_assignt create_blank(local_symexpr, java_new_array);
 
     codet copy_type_information = code_skipt();
     if(l == 'a')
@@ -930,8 +930,9 @@ void add_java_array_types(symbol_tablet &symbol_table)
         new_array, array_element_classid_component);
 
       copy_type_information = code_blockt{
-        {code_assignt(new_array_dimension, old_array_dimension),
-         code_assignt(new_array_element_classid, old_array_element_classid)}};
+        {code_frontend_assignt(new_array_dimension, old_array_dimension),
+         code_frontend_assignt(
+           new_array_element_classid, old_array_element_classid)}};
     }
 
     member_exprt old_data(
@@ -971,7 +972,7 @@ void add_java_array_types(symbol_tablet &symbol_table)
       from_integer(0, index_symexpr.type()),
       old_length,
       index_symexpr,
-      code_assignt(std::move(new_cell), std::move(old_cell)),
+      code_frontend_assignt(std::move(new_cell), std::move(old_cell)),
       location);
 
     member_exprt new_base_class(

--- a/jbmc/src/java_bytecode/java_bytecode_typecheck_code.cpp
+++ b/jbmc/src/java_bytecode/java_bytecode_typecheck_code.cpp
@@ -19,7 +19,7 @@ void java_bytecode_typecheckt::typecheck_code(codet &code)
 
   if(statement==ID_assign)
   {
-    code_assignt &code_assign=to_code_assign(code);
+    code_frontend_assignt &code_assign = to_code_frontend_assign(code);
     typecheck_expr(code_assign.lhs());
     typecheck_expr(code_assign.rhs());
 

--- a/jbmc/src/java_bytecode/java_entry_point.cpp
+++ b/jbmc/src/java_bytecode/java_entry_point.cpp
@@ -122,8 +122,8 @@ void java_static_lifetime_init(
 
   const symbol_exprt rounding_mode =
     symbol_table.lookup_ref(rounding_mode_identifier()).symbol_expr();
-  code_block.add(
-    code_assignt{rounding_mode, from_integer(0, rounding_mode.type())});
+  code_block.add(code_frontend_assignt{rounding_mode,
+                                       from_integer(0, rounding_mode.type())});
 
   object_factory_parameters.function_id = initialize_symbol.name;
 
@@ -226,7 +226,7 @@ void java_static_lifetime_init(
           to_struct_expr(*zero_object), ns, to_struct_tag_type(sym.type));
 
         code_block.add(
-          std::move(code_assignt(sym.symbol_expr(), *zero_object)));
+          std::move(code_frontend_assignt(sym.symbol_expr(), *zero_object)));
 
         // Then call the init function:
         code_block.add(std::move(initializer_call));
@@ -257,7 +257,7 @@ void java_static_lifetime_init(
       }
       else if(sym.value.is_not_nil())
       {
-        code_assignt assignment(sym.symbol_expr(), sym.value);
+        code_frontend_assignt assignment(sym.symbol_expr(), sym.value);
         assignment.add_source_location()=source_location;
         code_block.add(assignment);
       }
@@ -333,7 +333,7 @@ std::pair<code_blockt, std::vector<exprt>> java_build_arguments(
                                     .symbol_expr();
       main_arguments[param_number] = result;
       init_code.add(code_declt{result});
-      init_code.add(code_assignt{
+      init_code.add(code_frontend_assignt{
         result,
         side_effect_exprt{ID_java_new, {}, p.type(), function.location}});
       continue;
@@ -417,10 +417,9 @@ std::pair<code_blockt, std::vector<exprt>> java_build_arguments(
           function.location,
           pointer_type_selector,
           message_handler);
-        init_code_for_type.add(
-          code_assignt(
-            result_symbol.symbol_expr(),
-            typecast_exprt(init_expr_for_parameter, p.type())));
+        init_code_for_type.add(code_frontend_assignt(
+          result_symbol.symbol_expr(),
+          typecast_exprt(init_expr_for_parameter, p.type())));
         cases.push_back(init_code_for_type);
       }
 
@@ -672,7 +671,7 @@ bool generate_java_start_function(
   symbol_table.add(exc_symbol);
 
   // Zero-initialise the top-level exception catch variable:
-  init_code.add(code_assignt(
+  init_code.add(code_frontend_assignt(
     exc_symbol.symbol_expr(),
     null_pointer_exprt(to_pointer_type(exc_symbol.type))));
 

--- a/jbmc/src/java_bytecode/java_static_initializers.cpp
+++ b/jbmc/src/java_bytecode/java_static_initializers.cpp
@@ -179,20 +179,20 @@ static irep_idt clinit_local_init_complete_var_name(const irep_idt &class_name)
   return id2string(class_name) + CPROVER_PREFIX "clinit_wrapper::init_complete";
 }
 
-/// Generates a code_assignt for clinit_statest
+/// Generates a code_frontend_assignt for clinit_statest
 /// /param expr:
 ///   expression to be used as the LHS of generated assignment.
 /// /param state:
 ///   execution state of the clint_wrapper, used as the RHS of the generated
 ///   assignment.
-/// /return returns a code_assignt, assigning \p expr to the integer
+/// /return returns a code_frontend_assignt, assigning \p expr to the integer
 ///   representation of \p state
-static code_assignt
+static code_frontend_assignt
 gen_clinit_assign(const exprt &expr, const clinit_statest state)
 {
   mp_integer initv(static_cast<int>(state));
   constant_exprt init_s = from_integer(initv, clinit_states_type());
-  return code_assignt(expr, init_s);
+  return code_frontend_assignt(expr, init_s);
 }
 
 /// Generates an equal_exprt for clinit_statest
@@ -596,7 +596,7 @@ code_blockt get_thread_safe_clinit_wrapper_body(
 
   // C::__CPROVER_PREFIX_clinit_thread_local_state = INIT_COMPLETE;
   {
-    code_assignt assign = gen_clinit_assign(
+    code_frontend_assignt assign = gen_clinit_assign(
       clinit_thread_local_state_sym.symbol_expr(),
       clinit_statest::INIT_COMPLETE);
     function_body.add(assign);
@@ -629,7 +629,8 @@ code_blockt get_thread_safe_clinit_wrapper_body(
     code_ifthenelset init_conditional(
       gen_clinit_eqexpr(
         clinit_state_sym.symbol_expr(), clinit_statest::INIT_COMPLETE),
-      code_blockt({code_assignt(init_complete.symbol_expr(), true_exprt())}));
+      code_blockt(
+        {code_frontend_assignt(init_complete.symbol_expr(), true_exprt())}));
 
     code_ifthenelset not_init_conditional(
       gen_clinit_eqexpr(
@@ -637,7 +638,7 @@ code_blockt get_thread_safe_clinit_wrapper_body(
       code_blockt(
         {gen_clinit_assign(
            clinit_state_sym.symbol_expr(), clinit_statest::IN_PROGRESS),
-         code_assignt(init_complete.symbol_expr(), false_exprt())}),
+         code_frontend_assignt(init_complete.symbol_expr(), false_exprt())}),
       std::move(init_conditional));
 
     function_body.add(std::move(not_init_conditional));
@@ -757,7 +758,8 @@ code_ifthenelset get_clinit_wrapper_body(
     false_exprt());
 
   // add the "already-run = false" statement
-  code_assignt set_already_run(already_run_symbol.symbol_expr(), true_exprt());
+  code_frontend_assignt set_already_run(
+    already_run_symbol.symbol_expr(), true_exprt());
   code_blockt init_body({set_already_run});
 
   clinit_wrapper_do_recursive_calls(

--- a/jbmc/src/java_bytecode/lambda_synthesis.cpp
+++ b/jbmc/src/java_bytecode/lambda_synthesis.cpp
@@ -531,7 +531,7 @@ codet invokedynamic_synthetic_constructor(
     if(parameter.get_this())
       continue;
 
-    code_assignt assign_field(
+    code_frontend_assignt assign_field(
       member_exprt(deref_this, field_iterator->get_name(), parameter.type()),
       symbol_exprt(parameter.get_identifier(), parameter.type()));
     result.add(assign_field);
@@ -605,7 +605,7 @@ static symbol_exprt instantiate_new_object(
 
   // Instantiate the object:
   side_effect_exprt java_new_expr(ID_java_new, created_type, {});
-  result.add(code_assignt{new_instance_var, java_new_expr});
+  result.add(code_frontend_assignt{new_instance_var, java_new_expr});
 
   return new_instance_var;
 }

--- a/src/ansi-c/ansi_c_entry_point.cpp
+++ b/src/ansi-c/ansi_c_entry_point.cpp
@@ -411,7 +411,7 @@ bool generate_ansi_c_start_function(
         // disable bounds check on that one
         index_expr.set(ID_C_bounds_check, false);
 
-        init_code.add(code_assignt(index_expr, null));
+        init_code.add(code_frontend_assignt(index_expr, null));
       }
 
       if(parameters.size()==3)

--- a/src/ansi-c/c_nondet_symbol_factory.cpp
+++ b/src/ansi-c/c_nondet_symbol_factory.cpp
@@ -57,8 +57,8 @@ void symbol_factoryt::gen_nondet_init(
       // Handle the pointer-to-code case separately:
       // leave as nondet_ptr to allow `remove_function_pointers`
       // to replace the pointer.
-      assignments.add(
-        code_assignt{expr, side_effect_expr_nondett{pointer_type, loc}});
+      assignments.add(code_frontend_assignt{
+        expr, side_effect_expr_nondett{pointer_type, loc}});
       return;
     }
 
@@ -71,7 +71,7 @@ void symbol_factoryt::gen_nondet_init(
         depth >= object_factory_params.max_nondet_tree_depth)
       {
         assignments.add(
-          code_assignt{expr, null_pointer_exprt{pointer_type}, loc});
+          code_frontend_assignt{expr, null_pointer_exprt{pointer_type}, loc});
 
         return;
       }
@@ -104,7 +104,7 @@ void symbol_factoryt::gen_nondet_init(
       //           <code from recursive call to gen_nondet_init() with
       //             tmp$<temporary_counter>>
       // And the next line is labelled label2
-      const code_assignt set_null_inst{
+      const code_frontend_assignt set_null_inst{
         expr, null_pointer_exprt{pointer_type}, loc};
 
       code_ifthenelset null_check(
@@ -154,7 +154,7 @@ void symbol_factoryt::gen_nondet_init(
     //   <expr> = NONDET(type);
     exprt rhs = type.id() == ID_c_bool ? get_nondet_bool(type, loc)
                                        : side_effect_expr_nondett(type, loc);
-    code_assignt assign(expr, rhs);
+    code_frontend_assignt assign(expr, rhs);
     assign.add_source_location()=loc;
 
     assignments.add(std::move(assign));

--- a/src/ansi-c/c_typecheck_type.cpp
+++ b/src/ansi-c/c_typecheck_type.cpp
@@ -637,7 +637,7 @@ void c_typecheck_baset::typecheck_array_type(array_typet &type)
       code_declt declaration(symbol_expr);
       declaration.add_source_location() = size_source_location;
 
-      code_assignt assignment;
+      code_frontend_assignt assignment;
       assignment.lhs()=symbol_expr;
       assignment.rhs() = new_symbol.value;
       assignment.add_source_location() = size_source_location;

--- a/src/ansi-c/expr2c.cpp
+++ b/src/ansi-c/expr2c.cpp
@@ -3022,7 +3022,7 @@ std::string expr2ct::convert_code(
     return convert_code_dead(src, indent);
 
   if(statement==ID_assign)
-    return convert_code_assign(to_code_assign(src), indent);
+    return convert_code_frontend_assign(to_code_frontend_assign(src), indent);
 
   if(statement=="lock")
     return convert_code_lock(src, indent);
@@ -3062,8 +3062,8 @@ std::string expr2ct::convert_code(
   return convert_norep(src, precedence);
 }
 
-std::string expr2ct::convert_code_assign(
-  const code_assignt &src,
+std::string expr2ct::convert_code_frontend_assign(
+  const code_frontend_assignt &src,
   unsigned indent)
 {
   return indent_str(indent) +

--- a/src/ansi-c/expr2c_class.h
+++ b/src/ansi-c/expr2c_class.h
@@ -199,7 +199,8 @@ protected:
   // NOLINTNEXTLINE(whitespace/line_length)
   std::string convert_code_switch_case(const code_switch_caset &src, unsigned indent);
   std::string convert_code_asm(const code_asmt &src, unsigned indent);
-  std::string convert_code_assign(const code_assignt &src, unsigned indent);
+  std::string
+  convert_code_frontend_assign(const code_frontend_assignt &, unsigned indent);
   // NOLINTNEXTLINE(whitespace/line_length)
   std::string convert_code_ifthenelse(const code_ifthenelset &src, unsigned indent);
   std::string convert_code_for(const code_fort &src, unsigned indent);

--- a/src/cpp/cpp_typecheck_constructor.cpp
+++ b/src/cpp/cpp_typecheck_constructor.cpp
@@ -42,7 +42,7 @@ static void copy_parent(
   op1.get_sub().push_back(cpp_namet(arg_name, source_location));
   op1.add_source_location()=source_location;
 
-  code_assignt code(dereference_exprt(op0), op1);
+  code_frontend_assignt code(dereference_exprt(op0), op1);
   code.add_source_location() = source_location;
 
   block.operands().push_back(code);
@@ -239,7 +239,7 @@ void cpp_typecheckt::default_cpctor(
       ptrmember.set(ID_component_name, mem_c.get_name());
       ptrmember.operands().push_back(exprt("cpp-this"));
 
-      code_assignt assign(ptrmember, address);
+      code_frontend_assignt assign(ptrmember, address);
       initializers.move_to_sub(assign);
       continue;
     }
@@ -691,7 +691,7 @@ void cpp_typecheckt::full_member_initialization(
       ptrmember.set(ID_component_name, c.get_name());
       ptrmember.operands().push_back(exprt("cpp-this"));
 
-      code_assignt assign(ptrmember, address);
+      code_frontend_assignt assign(ptrmember, address);
       final_initializers.move_to_sub(assign);
       continue;
     }

--- a/src/cpp/cpp_typecheck_destructor.cpp
+++ b/src/cpp/cpp_typecheck_destructor.cpp
@@ -88,7 +88,7 @@ codet cpp_typecheckt::dtor(const symbolt &symbol, const symbol_exprt &this_expr)
       ptrmember.set(ID_component_name, c.get_name());
       ptrmember.operands().push_back(this_expr);
 
-      code_assignt assign(ptrmember, address);
+      code_frontend_assignt assign(ptrmember, address);
       block.add(assign);
       continue;
     }

--- a/src/cpp/cpp_typecheck_initializer.cpp
+++ b/src/cpp/cpp_typecheck_initializer.cpp
@@ -303,7 +303,7 @@ void cpp_typecheckt::zero_initializer(
       typecast_exprt::conditional_cast(from_integer(0, enum_type), type);
     already_typechecked_exprt::make_already_typechecked(zero);
 
-    code_assignt assign;
+    code_frontend_assignt assign;
     assign.lhs()=object;
     assign.rhs()=zero;
     assign.add_source_location()=source_location;
@@ -326,7 +326,7 @@ void cpp_typecheckt::zero_initializer(
       throw 0;
     }
 
-    code_assignt assign(object, *value);
+    code_frontend_assignt assign(object, *value);
     assign.add_source_location()=source_location;
 
     typecheck_expr(assign.lhs());

--- a/src/util/allocate_objects.cpp
+++ b/src/util/allocate_objects.cpp
@@ -129,9 +129,10 @@ exprt allocate_objectst::allocate_dynamic_object_symbol(
   if(allocate_type.id() == ID_empty)
   {
     // make null
-    code_assignt code{target_expr,
-                      null_pointer_exprt{to_pointer_type(target_expr.type())},
-                      source_location};
+    code_frontend_assignt code{
+      target_expr,
+      null_pointer_exprt{to_pointer_type(target_expr.type())},
+      source_location};
     output_code.add(std::move(code));
 
     return exprt();
@@ -154,14 +155,14 @@ exprt allocate_objectst::allocate_dynamic_object_symbol(
 
   symbols_created.push_back(&malloc_sym);
 
-  code_assignt assign =
+  code_frontend_assignt assign =
     make_allocate_code(malloc_sym.symbol_expr(), object_size.value());
   output_code.add(assign);
 
   exprt malloc_symbol_expr = typecast_exprt::conditional_cast(
     malloc_sym.symbol_expr(), target_expr.type());
 
-  code_assignt code(target_expr, malloc_symbol_expr);
+  code_frontend_assignt code(target_expr, malloc_symbol_expr);
   code.add_source_location() = source_location;
   output_code.add(code);
 
@@ -198,7 +199,7 @@ exprt allocate_objectst::allocate_non_dynamic_object(
   exprt aoe = typecast_exprt::conditional_cast(
     address_of_exprt(aux_symbol.symbol_expr()), target_expr.type());
 
-  code_assignt code(target_expr, aoe);
+  code_frontend_assignt code(target_expr, aoe);
   code.add_source_location() = source_location;
   assignments.add(code);
 
@@ -252,9 +253,10 @@ void allocate_objectst::mark_created_symbols_as_input(code_blockt &init_code)
   }
 }
 
-code_assignt make_allocate_code(const symbol_exprt &lhs, const exprt &size)
+code_frontend_assignt
+make_allocate_code(const symbol_exprt &lhs, const exprt &size)
 {
   side_effect_exprt alloc{
     ID_allocate, {size, false_exprt()}, lhs.type(), lhs.source_location()};
-  return code_assignt(lhs, alloc);
+  return code_frontend_assignt(lhs, alloc);
 }

--- a/src/util/allocate_objects.h
+++ b/src/util/allocate_objects.h
@@ -119,6 +119,7 @@ private:
 /// \param lhs: pointer which will be allocated
 /// \param size: size of the object
 /// \return code allocating the object and assigning it to `lhs`
-code_assignt make_allocate_code(const symbol_exprt &lhs, const exprt &size);
+code_frontend_assignt
+make_allocate_code(const symbol_exprt &lhs, const exprt &size);
 
 #endif // CPROVER_UTIL_ALLOCATE_OBJECTS_H

--- a/src/util/nondet.cpp
+++ b/src/util/nondet.cpp
@@ -52,7 +52,7 @@ symbol_exprt generate_nondet_int(
 
   // Assign the symbol any non deterministic integer value.
   //   int_type name_prefix::nondet_int = NONDET(int_type)
-  instructions.add(code_assignt(
+  instructions.add(code_frontend_assignt(
     nondet_symbol, side_effect_expr_nondett(int_type, source_location)));
 
   // Constrain the non deterministic integer with a lower bound of `min_value`.

--- a/src/util/std_code.cpp
+++ b/src/util/std_code.cpp
@@ -227,7 +227,7 @@ code_fort code_fort::from_index_bounds(
     location);
 
   return code_fort{
-    code_assignt{loop_index, std::move(start_index)},
+    code_frontend_assignt{loop_index, std::move(start_index)},
     binary_relation_exprt{loop_index, ID_lt, std::move(end_index)},
     std::move(inc),
     std::move(body)};


### PR DESCRIPTION
Basically all frontends are using `code_assignt`, which is meant to be used in
goto program instructions only.  This commit separates out the two uses.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
