### PR TITLE
remove deprecated goto_instructiont::get_function_call

### DIFF
--- a/src/goto-analyzer/taint_analysis.cpp
+++ b/src/goto-analyzer/taint_analysis.cpp
@@ -75,9 +75,7 @@ void taint_analysist::instrument(
 
     if(instruction.is_function_call())
     {
-      const code_function_callt &function_call =
-        instruction.get_function_call();
-      const exprt &function = function_call.function();
+      const exprt &function = instruction.call_function();
 
       if(function.id() == ID_symbol)
       {
@@ -144,8 +142,8 @@ void taint_analysist::instrument(
             {
               unsigned nr =
                 have_this ? rule.parameter_number : rule.parameter_number - 1;
-              if(function_call.arguments().size() > nr)
-                where = function_call.arguments()[nr];
+              if(instruction.call_arguments().size() > nr)
+                where = instruction.call_arguments()[nr];
               break;
             }
 
@@ -153,9 +151,9 @@ void taint_analysist::instrument(
               if(have_this)
               {
                 DATA_INVARIANT(
-                  !function_call.arguments().empty(),
+                  !instruction.call_arguments().empty(),
                   "`this` implies at least one argument in function call");
-                where = function_call.arguments()[0];
+                where = instruction.call_arguments()[0];
               }
               break;
             }

--- a/src/goto-instrument/dot.cpp
+++ b/src/goto-instrument/dot.cpp
@@ -144,7 +144,8 @@ void dott::write_dot_subgraph(
         tmp.str("Atomic End");
       else if(it->is_function_call())
       {
-        const auto &function_call = it->get_function_call();
+        const code_function_callt function_call(
+          it->call_lhs(), it->call_function(), it->call_arguments());
         std::string t = from_expr(ns, function_id, function_call);
         while(t[ t.size()-1 ]=='\n')
           t = t.substr(0, t.size()-1);

--- a/src/goto-programs/goto_program.h
+++ b/src/goto-programs/goto_program.h
@@ -271,20 +271,6 @@ public:
       return to_code_return(code).return_value();
     }
 
-    /// Get the function call for FUNCTION_CALL
-#if 1
-    DEPRECATED(SINCE(
-      2021,
-      2,
-      24,
-      "Use call_function(), call_lhs(), call_arguments() instead"))
-    const code_function_callt &get_function_call() const
-    {
-      PRECONDITION(is_function_call());
-      return to_code_function_call(code);
-    }
-#endif
-
     /// Get the function that is called for FUNCTION_CALL
     const exprt &call_function() const
     {

--- a/src/goto-programs/remove_virtual_functions.cpp
+++ b/src/goto-programs/remove_virtual_functions.cpp
@@ -289,7 +289,8 @@ static goto_programt::targett replace_virtual_function_with_dispatch_table(
     }
     else
     {
-      auto c = target->get_function_call();
+      auto c = code_function_callt(
+        target->call_lhs(), target->call_function(), target->call_arguments());
       create_static_function_call(c, *functions.front().symbol_expr, ns);
       target->call_function() = c.function();
       target->call_arguments() = c.arguments();
@@ -299,7 +300,8 @@ static goto_programt::targett replace_virtual_function_with_dispatch_table(
 
   const auto &vcall_source_loc=target->source_location;
 
-  code_function_callt code(target->get_function_call());
+  code_function_callt code(
+    target->call_lhs(), target->call_function(), target->call_arguments());
   goto_programt new_code_for_this_argument;
 
   process_this_argument(

--- a/src/goto-programs/restrict_function_pointers.cpp
+++ b/src/goto-programs/restrict_function_pointers.cpp
@@ -77,15 +77,15 @@ void restrict_function_pointer(
 
   // Check if this is calling a function pointer, and if so if it is one
   // we have a restriction for
-  const auto &original_function_call = location->get_function_call();
+  const auto &original_function = location->call_function();
 
-  if(!can_cast_expr<dereference_exprt>(original_function_call.function()))
+  if(!can_cast_expr<dereference_exprt>(original_function))
     return;
 
   // because we run the label function pointer calls transformation pass before
   // this stage a dereference can only dereference a symbol expression
   auto const &called_function_pointer =
-    to_dereference_expr(original_function_call.function()).pointer();
+    to_dereference_expr(original_function).pointer();
   PRECONDITION(can_cast_expr<symbol_exprt>(called_function_pointer));
   auto const &pointer_symbol = to_symbol_expr(called_function_pointer);
   auto const restriction_iterator =

--- a/src/goto-symex/symex_main.cpp
+++ b/src/goto-symex/symex_main.cpp
@@ -582,8 +582,8 @@ void goto_symext::print_symex_step(statet &state)
       print_callstack_entry(state.source) << messaget::eom;
 
       // Add the method we're about to enter with no location number.
-      log.status() << format(state.source.pc->get_function_call().function())
-                   << messaget::eom << messaget::eom;
+      log.status() << format(state.source.pc->call_function()) << messaget::eom
+                   << messaget::eom;
     }
   }
 }
@@ -675,8 +675,11 @@ void goto_symext::execute_next_instruction(
   case FUNCTION_CALL:
     if(state.reachable)
     {
-      symex_function_call(
-        get_goto_function, state, instruction.get_function_call());
+      code_function_callt call(
+        instruction.call_lhs(),
+        instruction.call_function(),
+        instruction.call_arguments());
+      symex_function_call(get_goto_function, state, call);
     }
     else
       symex_transition(state);


### PR DESCRIPTION
The method is deprecated; the commit includes some refactoring to enable the
removal of the final set of users.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
