### PR TITLE
enabling `#pragma disable "pointer-primitive"`

### DIFF
--- a/doc/cprover-manual/properties.md
+++ b/doc/cprover-manual/properties.md
@@ -122,6 +122,7 @@ The goto-instrument program supports these checks:
 | `--bounds-check`             |  add array bounds checks                             |
 | `--div-by-zero-check`        |  add division by zero checks                         |
 | `--pointer-check`            |  add pointer checks                                  |
+| `--pointer-primitive-check`  |  add pointer primitive checks                        |
 | `--signed-overflow-check`    |  add arithmetic over- and underflow checks           |
 | `--unsigned-overflow-check`  |  add arithmetic over- and underflow checks           |
 | `--undefined-shift-check`    |  add range checks for shift distances                |

--- a/regression/cbmc/pragma_cprover3/main.c
+++ b/regression/cbmc/pragma_cprover3/main.c
@@ -1,0 +1,20 @@
+#include <stdlib.h>
+
+int main()
+{
+  char *p = malloc(sizeof(*p));
+  char *q;
+
+#pragma CPROVER check push
+#pragma CPROVER check disable "pointer-primitive"
+  // do not generate checks for the following statements
+  if(__CPROVER_same_object(p, q))
+  {
+  }
+#pragma CPROVER check pop
+
+  // generate check and fail on the following statements
+  if(__CPROVER_same_object(p, q))
+  {
+  }
+}

--- a/regression/cbmc/pragma_cprover3/test.desc
+++ b/regression/cbmc/pragma_cprover3/test.desc
@@ -1,0 +1,16 @@
+CORE
+main.c
+--pointer-primitive-check
+^main.c function main$
+^\[main.pointer_primitives.\d+\] line 17 pointer invalid in POINTER_OBJECT\(\(const void \*\)p\): SUCCESS$
+^\[main.pointer_primitives.\d+\] line 17 deallocated dynamic object in POINTER_OBJECT\(\(const void \*\)p\): SUCCESS$
+^\[main.pointer_primitives.\d+\] line 17 dead object in POINTER_OBJECT\(\(const void \*\)p\): SUCCESS$
+^\[main.pointer_primitives.\d+\] line 17 pointer outside object bounds in POINTER_OBJECT\(\(const void \*\)p\): SUCCESS$
+^\[main.pointer_primitives.\d+\] line 17 pointer invalid in POINTER_OBJECT\(\(const void \*\)q\): FAILURE$
+^\[main.pointer_primitives.\d+\] line 17 deallocated dynamic object in POINTER_OBJECT\(\(const void \*\)q\): SUCCESS$
+^\[main.pointer_primitives.\d+\] line 17 dead object in POINTER_OBJECT\(\(const void \*\)q\): SUCCESS$
+^\[main.pointer_primitives.\d+\] line 17 pointer outside object bounds in POINTER_OBJECT\(\(const void \*\)q\): FAILURE$
+^VERIFICATION FAILED$
+^EXIT=10$
+^SIGNAL=0$
+--

--- a/src/ansi-c/scanner.l
+++ b/src/ansi-c/scanner.l
@@ -234,9 +234,10 @@ CPROVER_PREFIX  "__CPROVER_"
 
 arith_check     ("conversion"|"undefined-shift"|"nan"|"div-by-zero")
 enum_check      "enum-range"
+pointer_primitive "pointer-primitive"
 memory_check    ("bounds"|"pointer"|"memory_leak")
 overflow_check  ("signed"|"unsigned"|"pointer"|"float")"-overflow"
-named_check     ["]({arith_check}|{enum_check}|{memory_check}|{overflow_check})["]
+named_check     ["]({arith_check}|{enum_check}|{memory_check}|{overflow_check}|{pointer_primitive})["]
 
 %x GRAMMAR
 %x COMMENT1


### PR DESCRIPTION
Fixes #6239.

This PR enables `#pragma disable "pointer-primitive"` by adding "pointer-primitive" to the list of named checks accepted by the ansi-c lexer, to allow users to disable pointer primitive checks using pragmas embedded in C code. This addresses issue https://github.com/diffblue/cbmc/issues/6239. The `goto_check` function already handles "disable:pointer-primitive-check" so only a lexer modification was needed. 

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [x] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.
