### PR TITLE
Allow checks to be performed inside quantifier statements.

### DIFF
--- a/regression/cbmc-primitives/CMakeLists.txt
+++ b/regression/cbmc-primitives/CMakeLists.txt
@@ -1,3 +1,11 @@
-add_test_pl_tests(
-    "$<TARGET_FILE:cbmc>"
-)
+find_program(Z3_EXISTS "z3")
+message(${Z3_EXISTS})
+if(Z3_EXISTS)
+    add_test_pl_tests(
+        "$<TARGET_FILE:cbmc>"
+    )
+else()
+    add_test_pl_tests(
+        "$<TARGET_FILE:cbmc>" -X smt-backend
+    )
+endif()

--- a/regression/cbmc-primitives/alternating_quantifiers_6231/exists_in_forall.c
+++ b/regression/cbmc-primitives/alternating_quantifiers_6231/exists_in_forall.c
@@ -1,0 +1,14 @@
+#include <stdlib.h>
+
+// clang-format off
+int main(int argc, char **argv)
+{
+    int *i = malloc(sizeof(int));
+    *i = 1;
+
+    __CPROVER_assert(
+        __CPROVER_forall { int z; (0 < z && z < 10) ==>
+            __CPROVER_exists { int y; ( 10 < y && y < 20) && y == z + 10 && y > *i } },
+        "for all z, there exists a y so that y = z + 10 and y > 1");
+}
+// clang-format on

--- a/regression/cbmc-primitives/alternating_quantifiers_6231/exists_in_forall.desc
+++ b/regression/cbmc-primitives/alternating_quantifiers_6231/exists_in_forall.desc
@@ -1,0 +1,16 @@
+CORE
+exists_in_forall.c
+--pointer-check
+^EXIT=0$
+^SIGNAL=0$
+\[main\.assertion\.1\] line \d* for all z, there exists a y so that y = z \+ 10 and y > 1: SUCCESS
+\[main\.pointer_dereference\.7\] line \d+ dereference failure: pointer NULL in \*i: SUCCESS
+\[main\.pointer_dereference\.8\] line \d+ dereference failure: pointer invalid in \*i: SUCCESS
+\[main\.pointer_dereference\.9\] line \d+ dereference failure: deallocated dynamic object in \*i: SUCCESS
+\[main\.pointer_dereference\.10\] line \d+ dereference failure: dead object in \*i: SUCCESS
+\[main\.pointer_dereference\.11\] line \d+ dereference failure: pointer outside object bounds in \*i: SUCCESS
+\[main\.pointer_dereference\.12\] line \d+ dereference failure: invalid integer address in \*i: SUCCESS
+--
+--
+The assertion reference number here is present so that we make sure
+we always match the properties of the dereference inside the exists.

--- a/regression/cbmc-primitives/alternating_quantifiers_6231/forall_in_exists.c
+++ b/regression/cbmc-primitives/alternating_quantifiers_6231/forall_in_exists.c
@@ -1,0 +1,14 @@
+#include <stdlib.h>
+
+// clang-format off
+int main(int argc, char **argv)
+{
+    int *i = malloc(sizeof(int));
+    *i = 1;
+
+    __CPROVER_assert(
+        __CPROVER_exists { int z; (0 < z && z < 2) &&
+            __CPROVER_forall { int o; (10 < o && o < 20) ==> o > z && z == * i }},
+        "there exists a z between 0 and 2 so that for all o between 10 and 20, o > z and z = 1");
+}
+// clang-format on

--- a/regression/cbmc-primitives/alternating_quantifiers_6231/forall_in_exists.desc
+++ b/regression/cbmc-primitives/alternating_quantifiers_6231/forall_in_exists.desc
@@ -1,0 +1,14 @@
+CORE
+forall_in_exists.c
+--pointer-check
+^EXIT=0$
+^SIGNAL=0$
+\[main\.assertion\.1\] line \d* there exists a z between 0 and 2 so that for all o between 10 and 20, o > z and z = 1: SUCCESS
+\[main\.pointer_dereference\.7\] line \d+ dereference failure: pointer NULL in \*i: SUCCESS
+\[main\.pointer_dereference\.8\] line \d+ dereference failure: pointer invalid in \*i: SUCCESS
+\[main\.pointer_dereference\.9\] line \d+ dereference failure: deallocated dynamic object in \*i: SUCCESS
+\[main\.pointer_dereference\.10\] line \d+ dereference failure: dead object in \*i: SUCCESS
+\[main\.pointer_dereference\.11\] line \d+ dereference failure: pointer outside object bounds in \*i: SUCCESS
+\[main\.pointer_dereference\.12\] line \d+ dereference failure: invalid integer address in \*i: SUCCESS
+--
+--

--- a/regression/cbmc-primitives/exists_assume_6231/test.c
+++ b/regression/cbmc-primitives/exists_assume_6231/test.c
@@ -1,0 +1,18 @@
+#include <stdlib.h>
+
+// clang-format off
+int main(int argc, char **argv)
+{
+    int *i = malloc(sizeof(int));
+    *i = 1;
+
+    // The exists inside the assume will evaluate to true,
+    // and be flipped by the negation in front of it, resulting
+    // to assume(false), which will allow the assertion to evaluate
+    // to true. 
+    __CPROVER_assume(
+        !__CPROVER_exists{int z; (z > 1 && z < 10) && z > *i}
+    );
+    __CPROVER_assert(0, "this assertion should be satified");
+}
+// clang-format on

--- a/regression/cbmc-primitives/exists_assume_6231/test.desc
+++ b/regression/cbmc-primitives/exists_assume_6231/test.desc
@@ -1,0 +1,10 @@
+CORE
+test.c
+--pointer-check
+^EXIT=0$
+^SIGNAL=0$
+\[main\.assertion\.1\] line \d+ this assertion should be satified: SUCCESS
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring forall
+--

--- a/regression/cbmc-primitives/exists_assume_6231/test2.c
+++ b/regression/cbmc-primitives/exists_assume_6231/test2.c
@@ -1,0 +1,16 @@
+#include <stdlib.h>
+
+// clang-format off
+int main(int argc, char **argv)
+{
+    int *i = malloc(sizeof(int));
+    *i = 1;
+
+    // The exists inside the assume will evaluate to true,
+    // and as such, the assertion below will fail as expected.
+    __CPROVER_assume(
+        __CPROVER_exists{int z; (z > 1 && z < 10) && z > *i}
+    );
+    __CPROVER_assert(0, "this should come out as failure");
+}
+// clang-format on

--- a/regression/cbmc-primitives/exists_assume_6231/test2.desc
+++ b/regression/cbmc-primitives/exists_assume_6231/test2.desc
@@ -1,0 +1,10 @@
+CORE
+test2.c
+--pointer-check
+^EXIT=10$
+^SIGNAL=0$
+\[main\.assertion\.1\] line \d+ this should come out as failure: FAILURE
+^VERIFICATION FAILED$
+--
+^warning: ignoring forall
+--

--- a/regression/cbmc-primitives/exists_memory_checks/invalid_index_range.c
+++ b/regression/cbmc-primitives/exists_memory_checks/invalid_index_range.c
@@ -1,0 +1,13 @@
+#include <assert.h>
+#include <stdlib.h>
+
+int main()
+{
+  int *a = calloc(10, sizeof(int));
+  a[5] = 25;
+
+  assert(__CPROVER_exists {
+    int i;
+    (0 <= i && i < 20) && a[i] == i *i
+  });
+}

--- a/regression/cbmc-primitives/exists_memory_checks/invalid_index_range.desc
+++ b/regression/cbmc-primitives/exists_memory_checks/invalid_index_range.desc
@@ -1,0 +1,12 @@
+CORE
+invalid_index_range.c
+--pointer-check
+^EXIT=10$
+^SIGNAL=0$
+^VERIFICATION FAILED$
+\[main\.assertion\.1\] line 9 assertion __CPROVER_exists \{ int i; \(0 <= i && i < 20\) && a\[i\] == i \*i \}: SUCCESS
+line 9 dereference failure: pointer outside object bounds in a\[\(signed (long|long long) int\)i\]: FAILURE
+--
+--
+Check that memory checks fail for pointer dereferences inside an existential
+qualifier, for out of bounds memory access.

--- a/regression/cbmc-primitives/exists_memory_checks/negated_exists.c
+++ b/regression/cbmc-primitives/exists_memory_checks/negated_exists.c
@@ -1,0 +1,13 @@
+#include <assert.h>
+#include <stdlib.h>
+
+int main()
+{
+  int *a = calloc(10, sizeof(int));
+  a[5] = 25;
+
+  assert(!__CPROVER_exists {
+    int i;
+    (0 <= i && i < 10) && a[i] == 42
+  });
+}

--- a/regression/cbmc-primitives/exists_memory_checks/negated_exists.desc
+++ b/regression/cbmc-primitives/exists_memory_checks/negated_exists.desc
@@ -1,0 +1,17 @@
+CORE
+negated_exists.c
+--pointer-check
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+\[main\.assertion\.1\] line 9 assertion !__CPROVER_exists \{ int i; \(0 <= i && i < 10\) && a\[i\] == 42 \}: SUCCESS
+\[main\.pointer_dereference\.7\] line 9 dereference failure: pointer NULL in a\[\(signed (long|long long) int\)i\]: SUCCESS
+\[main\.pointer_dereference\.8\] line 9 dereference failure: pointer invalid in a\[\(signed (long|long long) int\)i\]: SUCCESS
+\[main\.pointer_dereference\.9\] line 9 dereference failure: deallocated dynamic object in a\[\(signed (long|long long) int\)i\]: SUCCESS
+\[main\.pointer_dereference\.10\] line 9 dereference failure: dead object in a\[\(signed (long|long long) int\)i\]: SUCCESS
+\[main\.pointer_dereference\.11\] line 9 dereference failure: pointer outside object bounds in a\[\(signed (long|long long) int\)i\]: SUCCESS
+\[main\.pointer_dereference\.12\] line 9 dereference failure: invalid integer address in a\[\(signed (long|long long) int\)i\]: SUCCESS
+--
+--
+Check that memory checks pass for valid pointer dereferences inside a negated
+existential qualifier.

--- a/regression/cbmc-primitives/exists_memory_checks/smt_missing_range_check.c
+++ b/regression/cbmc-primitives/exists_memory_checks/smt_missing_range_check.c
@@ -1,0 +1,13 @@
+#include <assert.h>
+#include <stdlib.h>
+
+int main()
+{
+  int *a = calloc(10, sizeof(int));
+  a[5] = 25;
+
+  assert(__CPROVER_exists {
+    int i;
+    a[i] == i *i
+  });
+}

--- a/regression/cbmc-primitives/exists_memory_checks/smt_missing_range_check.desc
+++ b/regression/cbmc-primitives/exists_memory_checks/smt_missing_range_check.desc
@@ -1,0 +1,15 @@
+CORE smt-backend
+smt_missing_range_check.c
+--pointer-check -z3
+^EXIT=10$
+^SIGNAL=0$
+^VERIFICATION FAILED$
+\[main\.assertion\.1\] line \d assertion __CPROVER_exists \{ int i; a\[i\] == i \*i \}: SUCCESS
+\[main\.pointer_dereference\.11\] line \d dereference failure: pointer outside object bounds in a\[\(signed (long|long long) int\)i\]: FAILURE
+--
+--
+Check that memory checks fail for pointer dereferences inside an existential
+qualifier, for out of bounds memory access, when using the smt backend and
+the range of the index is unbound. Note that this test is not expected to work
+with the SAT backend at the time of writing, as the SAT backend does not support
+qualifiers in this form.

--- a/regression/cbmc-primitives/exists_memory_checks/valid_index_range.c
+++ b/regression/cbmc-primitives/exists_memory_checks/valid_index_range.c
@@ -1,0 +1,13 @@
+#include <assert.h>
+#include <stdlib.h>
+
+int main()
+{
+  int *a = calloc(10, sizeof(int));
+  a[5] = 25;
+
+  assert(__CPROVER_exists {
+    int i;
+    (0 <= i && i < 10) && a[i] == i *i
+  });
+}

--- a/regression/cbmc-primitives/exists_memory_checks/valid_index_range.desc
+++ b/regression/cbmc-primitives/exists_memory_checks/valid_index_range.desc
@@ -1,0 +1,17 @@
+CORE
+valid_index_range.c
+--pointer-check
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+\[main\.assertion\.1\] line 9 assertion __CPROVER_exists \{ int i; \(0 <= i && i < 10\) && a\[i\] == i \*i \}: SUCCESS
+\[main\.pointer_dereference\.7\] line 9 dereference failure: pointer NULL in a\[\(signed (long|long long) int\)i\]: SUCCESS
+\[main\.pointer_dereference\.8\] line 9 dereference failure: pointer invalid in a\[\(signed (long|long long) int\)i\]: SUCCESS
+\[main\.pointer_dereference\.9\] line 9 dereference failure: deallocated dynamic object in a\[\(signed (long|long long) int\)i\]: SUCCESS
+\[main\.pointer_dereference\.10\] line 9 dereference failure: dead object in a\[\(signed (long|long long) int\)i\]: SUCCESS
+\[main\.pointer_dereference\.11\] line 9 dereference failure: pointer outside object bounds in a\[\(signed (long|long long) int\)i\]: SUCCESS
+\[main\.pointer_dereference\.12\] line 9 dereference failure: invalid integer address in a\[\(signed (long|long long) int\)i\]: SUCCESS
+--
+--
+Check that memory checks pass for valid pointer dereferences inside an
+existential qualifier.

--- a/regression/cbmc-primitives/forall_6231_1/test.c
+++ b/regression/cbmc-primitives/forall_6231_1/test.c
@@ -1,0 +1,20 @@
+#include <assert.h>
+#include <stdlib.h>
+
+// clang-format off
+int main() {
+  char *a = malloc(1);
+
+  assert(*a == *a);
+
+  // BUG: In https://github.com/diffblue/cbmc/issues/6231, it was reported that
+  // no checks would be performed on the derefence inside the quantified statement,
+  // even when explicitly requested via for instance `--pointer-check`, because
+  // we would simply skip over these quantified statements in goto-check.
+  assert(
+    __CPROVER_forall {
+      int i ; (0 <= i && i < 1) ==> *(a+i) == *(a+i)
+    }
+  );
+}
+// clang-format on

--- a/regression/cbmc-primitives/forall_6231_1/test.desc
+++ b/regression/cbmc-primitives/forall_6231_1/test.desc
@@ -1,0 +1,16 @@
+CORE
+test.c
+--pointer-check
+^EXIT=0$
+^SIGNAL=0$
+\[main\.assertion\.2\] line \d+ assertion __CPROVER_forall \{ int i ; \(0 <= i && i < 1\) ==> \*\(a\+i\) == \*\(a\+i\) \}: SUCCESS
+\[main\.pointer_dereference\.7\] line \d+ dereference failure: pointer NULL in a\[\(signed (long|long long) int\)i\]: SUCCESS
+\[main\.pointer_dereference\.8\] line \d+ dereference failure: pointer invalid in a\[\(signed (long|long long) int\)i\]: SUCCESS
+\[main\.pointer_dereference\.9\] line \d+ dereference failure: deallocated dynamic object in a\[\(signed (long|long long) int\)i\]: SUCCESS
+\[main\.pointer_dereference\.10\] line \d+ dereference failure: dead object in a\[\(signed (long|long long) int\)i\]: SUCCESS
+\[main\.pointer_dereference\.11\] line \d+ dereference failure: pointer outside object bounds in a\[\(signed (long|long long) int\)i\]: SUCCESS
+\[main\.pointer_dereference\.12\] line \d+ dereference failure: invalid integer address in a\[\(signed (long|long long) int\)i\]: SUCCESS
+^VERIFICATION SUCCESSFUL$
+--
+--
+This is fixing an issue first reported in https://github.com/diffblue/cbmc/issues/6231

--- a/regression/cbmc-primitives/forall_6231_2/test.c
+++ b/regression/cbmc-primitives/forall_6231_2/test.c
@@ -1,0 +1,23 @@
+#include <assert.h>
+#include <stdlib.h>
+
+// clang-format off
+int main() {
+  char *a = malloc(128);
+
+  // BUG: In https://github.com/diffblue/cbmc/issues/6231, it was reported that
+  // no checks would be performed on the derefence inside the quantified statement,
+  // even when explicitly requested via for instance `--pointer-check`, because
+  // we would simply skip over these quantified statements in goto-check.
+  assert(
+    __CPROVER_forall {
+      int i ; (0 <= i && i < 1) ==> *(a+i) == *(a+i)
+    }
+  );
+
+  assert(
+  __CPROVER_forall {
+    int j; !(0 <= j && j < 1) || (j == 0 && *(a+j) == *(a+j))
+  });
+}
+// clang-format on

--- a/regression/cbmc-primitives/forall_6231_2/test.desc
+++ b/regression/cbmc-primitives/forall_6231_2/test.desc
@@ -1,0 +1,23 @@
+CORE
+test.c
+--pointer-check
+^EXIT=0$
+^SIGNAL=0$
+\[main\.assertion\.1\] line \d+ assertion __CPROVER_forall \{ int i ; \(0 <= i && i < 1\) ==> \*\(a\+i\) == \*\(a\+i\) \}: SUCCESS
+\[main\.pointer_dereference\.1\] line \d+ dereference failure: pointer NULL in a\[\(signed (long|long long) int\)i\]: SUCCESS
+\[main\.pointer_dereference\.2\] line \d+ dereference failure: pointer invalid in a\[\(signed (long|long long) int\)i\]: SUCCESS
+\[main\.pointer_dereference\.3\] line \d+ dereference failure: deallocated dynamic object in a\[\(signed (long|long long) int\)i\]: SUCCESS
+\[main\.pointer_dereference\.4\] line \d+ dereference failure: dead object in a\[\(signed (long|long long) int\)i\]: SUCCESS
+\[main\.pointer_dereference\.5\] line \d+ dereference failure: pointer outside object bounds in a\[\(signed (long|long long) int\)i\]: SUCCESS
+\[main\.pointer_dereference\.6\] line \d+ dereference failure: invalid integer address in a\[\(signed (long|long long) int\)i\]: SUCCESS
+\[main\.assertion.2] line \d+ assertion __CPROVER_forall \{ int j; \!\(0 <= j && j < 1\) || \(j == 0 && \*\(a\+j\) == \*\(a+j\)\) \}: SUCCESS
+\[main\.pointer_dereference\.7] line \d+ dereference failure: pointer NULL in a\[\(signed (long|long long) int\)j\]: SUCCESS
+\[main\.pointer_dereference\.8] line \d+ dereference failure: pointer invalid in a\[\(signed (long|long long) int\)j\]: SUCCESS
+\[main\.pointer_dereference\.9] line \d+ dereference failure: deallocated dynamic object in a\[\(signed (long|long long) int\)j\]: SUCCESS
+\[main\.pointer_dereference\.10] line \d+ dereference failure: dead object in a\[\(signed (long|long long) int\)j\]: SUCCESS
+\[main\.pointer_dereference\.11] line \d+ dereference failure: pointer outside object bounds in a\[\(signed (long|long long) int\)j\]: SUCCESS
+\[main\.pointer_dereference\.12] line \d+ dereference failure: invalid integer address in a\[\(signed (long|long long) int\)j\]: SUCCESS
+^VERIFICATION SUCCESSFUL$
+--
+--
+This is fixing an issue first reported in https://github.com/diffblue/cbmc/issues/6231

--- a/regression/cbmc-primitives/forall_6231_3/test.c
+++ b/regression/cbmc-primitives/forall_6231_3/test.c
@@ -1,0 +1,24 @@
+#include <assert.h>
+#include <stdlib.h>
+
+// This is essentially the same file as in test `forall_6231_1`, with the difference
+// being that the forall statement contains a bigger bound, so that we are to have
+// more concrete instantiations of the bound variable.
+
+// clang-format off
+int main() {
+  char *a = malloc(10);
+
+  assert(*a == *a);
+
+  // BUG: In https://github.com/diffblue/cbmc/issues/6231, it was reported that
+  // no checks would be performed on the derefence inside the quantified statement,
+  // even when explicitly requested via for instance `--pointer-check`, because
+  // we would simply skip over these quantified statements in goto-check.
+  assert(
+    __CPROVER_forall {
+      int i ; (0 <= i && i < 10) ==> *(a+i) == *(a+i)
+    }
+  );
+}
+// clang-format on

--- a/regression/cbmc-primitives/forall_6231_3/test.desc
+++ b/regression/cbmc-primitives/forall_6231_3/test.desc
@@ -1,0 +1,16 @@
+CORE
+test.c
+--pointer-check
+^EXIT=0$
+^SIGNAL=0$
+\[main\.assertion\.2\] line \d+ assertion __CPROVER_forall \{ int i ; \(0 <= i && i < 10\) ==> \*\(a\+i\) == \*\(a\+i\) \}: SUCCESS
+\[main\.pointer_dereference\.7\] line \d+ dereference failure: pointer NULL in a\[\(signed (long|long long) int\)i\]: SUCCESS
+\[main\.pointer_dereference\.8\] line \d+ dereference failure: pointer invalid in a\[\(signed (long|long long) int\)i\]: SUCCESS
+\[main\.pointer_dereference\.9\] line \d+ dereference failure: deallocated dynamic object in a\[\(signed (long|long long) int\)i\]: SUCCESS
+\[main\.pointer_dereference\.10\] line \d+ dereference failure: dead object in a\[\(signed (long|long long) int\)i\]: SUCCESS
+\[main\.pointer_dereference\.11\] line \d+ dereference failure: pointer outside object bounds in a\[\(signed (long|long long) int\)i\]: SUCCESS
+\[main\.pointer_dereference\.12\] line \d+ dereference failure: invalid integer address in a\[\(signed (long|long long) int\)i\]: SUCCESS
+^VERIFICATION SUCCESSFUL$
+--
+--
+This is fixing an issue first reported in https://github.com/diffblue/cbmc/issues/6231

--- a/regression/cbmc-primitives/forall_6231_3/test_malloc_less_than_bound.c
+++ b/regression/cbmc-primitives/forall_6231_3/test_malloc_less_than_bound.c
@@ -1,0 +1,21 @@
+#include <assert.h>
+#include <stdlib.h>
+
+// Similar to our test in `test.c` of this folder, with the difference being
+// that the malloc size is less than the bound checked, which implies that the
+// check for the pointer being outside the object bounds is expected to fail.
+
+// clang-format off
+int main() {
+  char *a = malloc(4);
+
+  assert(*a == *a);
+
+  // BUG: no errors even with `--pointer-check` enabled -- now fixed.
+  assert(
+    __CPROVER_forall {
+      int i ; (0 <= i && i < 10) ==> *(a+i) == *(a+i)
+    }
+  );
+}
+// clang-format on

--- a/regression/cbmc-primitives/forall_6231_3/test_malloc_less_than_bound.desc
+++ b/regression/cbmc-primitives/forall_6231_3/test_malloc_less_than_bound.desc
@@ -1,0 +1,16 @@
+CORE
+test_malloc_less_than_bound.c
+--pointer-check
+^EXIT=10$
+^SIGNAL=0$
+\[main\.assertion\.2\] line \d+ assertion __CPROVER_forall \{ int i ; \(0 <= i && i < 10\) ==> \*\(a\+i\) == \*\(a\+i\) \}: SUCCESS
+\[main\.pointer_dereference\.7\] line \d+ dereference failure: pointer NULL in a\[\(signed (long|long long) int\)i\]: SUCCESS
+\[main\.pointer_dereference\.8\] line \d+ dereference failure: pointer invalid in a\[\(signed (long|long long) int\)i\]: SUCCESS
+\[main\.pointer_dereference\.9\] line \d+ dereference failure: deallocated dynamic object in a\[\(signed (long|long long) int\)i\]: SUCCESS
+\[main\.pointer_dereference\.10\] line \d+ dereference failure: dead object in a\[\(signed (long|long long) int\)i\]: SUCCESS
+\[main\.pointer_dereference\.11\] line \d+ dereference failure: pointer outside object bounds in a\[\(signed (long|long long) int\)i\]: FAILURE
+\[main\.pointer_dereference\.12\] line \d+ dereference failure: invalid integer address in a\[\(signed (long|long long) int\)i\]: SUCCESS
+^VERIFICATION FAILED$
+--
+--
+This is fixing an issue first reported in https://github.com/diffblue/cbmc/issues/6231

--- a/regression/cbmc-primitives/forall_6231_4/test.c
+++ b/regression/cbmc-primitives/forall_6231_4/test.c
@@ -1,0 +1,24 @@
+#include <assert.h>
+#include <stdlib.h>
+
+// Similar to the previous tests in forall_6231_1 but this one aims to check
+// the antecedent of the forall expression to make sure that checks are being
+// generated correctly for it.
+
+// clang-format off
+int main() {
+  char *a = malloc(10);
+  int n;
+
+  // BUG: In https://github.com/diffblue/cbmc/issues/6231, it was reported that
+  // no checks would be performed on the derefence inside the quantified statement,
+  // even when explicitly requested via for instance `--pointer-check`, because
+  // we would simply skip over these quantified statements in goto-check.
+  assert(
+    __CPROVER_forall {
+      int i ; (0 <= i && i < (n / 0))  /* (n / 0) should be caught by --div-by-zero-check */
+      ==> *(a+i) == *(a+i)
+    }
+  );
+}
+// clang-format on

--- a/regression/cbmc-primitives/forall_6231_4/test.desc
+++ b/regression/cbmc-primitives/forall_6231_4/test.desc
@@ -1,0 +1,11 @@
+CORE
+test.c
+--div-by-zero-check
+^EXIT=10$
+^SIGNAL=0$
+\[main\.division-by-zero\.1] line \d+ division by zero in n / 0: FAILURE
+^VERIFICATION FAILED$
+--
+--
+--div-by-zero-check should catch the failure in the antecedent.
+--pointer-check doesn't but gives an pointer outside object bounds issue.

--- a/regression/cbmc/enum_is_in_range/enum_test5.desc
+++ b/regression/cbmc/enum_is_in_range/enum_test5.desc
@@ -3,10 +3,10 @@ enum_test5.c
 --enum-range-check
 ^EXIT=10$
 ^SIGNAL=0$
-^\[main.enum-range-check.6\] line \d+ enum range check in ev3: SUCCESS$
-^\[main.enum-range-check.7\] line \d+ enum range check in ev2: FAILURE$
+^\[main.enum-range-check.\d\] line \d+ enum range check in ev3: SUCCESS$
+^\[main.enum-range-check.\d\] line \d+ enum range check in ev2: FAILURE$
 --
-^\[main.enum-range-check.6\] line \d+ enum range check in ev3: FAILURE$
+^\[main.enum-range-check.\d\] line \d+ enum range check in ev3: FAILURE$
 ^\*\*\*\* WARNING: no body for function __CPROVER_enum_is_in_range$
 --
 This test is for the enum_is_in_range working in assume statements

--- a/src/analyses/goto_check_c.cpp
+++ b/src/analyses/goto_check_c.cpp
@@ -26,6 +26,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/ieee_float.h>
 #include <util/invariant.h>
 #include <util/make_unique.h>
+#include <util/mathematical_expr.h>
 #include <util/message.h>
 #include <util/options.h>
 #include <util/pointer_expr.h>
@@ -1795,11 +1796,19 @@ void goto_check_ct::check_rec_arithmetic_op(
 
 void goto_check_ct::check_rec(const exprt &expr, const guardt &guard)
 {
-  // we don't look into quantifiers
   if(expr.id() == ID_exists || expr.id() == ID_forall)
-    return;
+  {
+    // the scoped variables may be used in the assertion
+    const auto &quantifier_expr = to_quantifier_expr(expr);
 
-  if(expr.id() == ID_address_of)
+    auto new_guard = [&guard, &quantifier_expr](exprt expr) {
+      return guard(forall_exprt(quantifier_expr.symbol(), expr));
+    };
+
+    check_rec(quantifier_expr.where(), new_guard);
+    return;
+  }
+  else if(expr.id() == ID_address_of)
   {
     check_rec_address(to_address_of_expr(expr).object(), guard);
     return;


### PR DESCRIPTION
This allows checks from CLI flags like `--pointer-check` to be performed inside
expressions in quantifier statements.

This should be addressing issue #6231 .

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
