### PR TITLE
introduce API for goto_instructiont::source_location

### DIFF
--- a/jbmc/src/java_bytecode/convert_java_nondet.cpp
+++ b/jbmc/src/java_bytecode/convert_java_nondet.cpp
@@ -102,7 +102,7 @@ static std::pair<goto_programt::targett, bool> insert_nondet_init_code(
     if(!nondet_expr.get_nullable())
       object_factory_parameters.min_null_tree_depth = 1;
 
-    const source_locationt &source_loc = target->source_location;
+    const source_locationt &source_loc = target->source_location();
 
     // Currently the code looks like this
     //   target: instruction containing op

--- a/jbmc/src/java_bytecode/remove_exceptions.cpp
+++ b/jbmc/src/java_bytecode/remove_exceptions.cpp
@@ -246,7 +246,7 @@ void remove_exceptionst::instrument_exception_handler(
       instr_it,
       goto_programt::make_assignment(
         code_assignt(thrown_global_symbol, null_voidptr),
-        instr_it->source_location));
+        instr_it->source_location()));
 
     // add the assignment exc = @inflight_exception (before the null assignment)
     goto_program.insert_after(
@@ -255,7 +255,7 @@ void remove_exceptionst::instrument_exception_handler(
         code_assignt(
           thrown_exception_local,
           typecast_exprt(thrown_global_symbol, thrown_exception_local.type())),
-        instr_it->source_location));
+        instr_it->source_location()));
   }
 
   instr_it->turn_into_skip();
@@ -362,7 +362,7 @@ void remove_exceptionst::add_exception_dispatch_sequence(
         goto_programt::targett t_exc = goto_program.insert_after(
           instr_it,
           goto_programt::make_goto(
-            new_state_pc, true_exprt(), instr_it->source_location));
+            new_state_pc, true_exprt(), instr_it->source_location()));
 
         // use instanceof to check that this is the correct handler
         struct_tag_typet type(stack_catch[i][j].first);
@@ -385,13 +385,13 @@ void remove_exceptionst::add_exception_dispatch_sequence(
   }
 
   *default_dispatch = goto_programt::make_goto(
-    default_target, true_exprt(), instr_it->source_location);
+    default_target, true_exprt(), instr_it->source_location());
 
   // add dead instructions
   for(const auto &local : locals)
   {
     goto_program.insert_after(
-      instr_it, goto_programt::make_dead(local, instr_it->source_location));
+      instr_it, goto_programt::make_dead(local, instr_it->source_location()));
   }
 }
 
@@ -476,7 +476,7 @@ remove_exceptionst::instrument_function_call(
         goto_programt::make_goto(
           next_it,
           no_exception_currently_in_flight,
-          instr_it->source_location));
+          instr_it->source_location()));
 
       return instrumentation_resultt::ADDED_CODE_WITH_MAY_THROW;
     }

--- a/jbmc/src/java_bytecode/replace_java_nondet.cpp
+++ b/jbmc/src/java_bytecode/replace_java_nondet.cpp
@@ -274,13 +274,13 @@ static goto_programt::targett check_and_replace_target(
     const auto &nondet_var = target_instruction->return_value();
 
     side_effect_expr_nondett inserted_expr(
-      nondet_var.type(), target_instruction->source_location);
+      nondet_var.type(), target_instruction->source_location());
     inserted_expr.set_nullable(
       instr_info.get_nullable_type() ==
       nondet_instruction_infot::is_nullablet::TRUE);
     target_instruction->code_nonconst() = code_returnt(inserted_expr);
     target_instruction->code_nonconst().add_source_location() =
-      target_instruction->source_location;
+      target_instruction->source_location();
   }
   else if(target_instruction->is_assign())
   {
@@ -288,14 +288,14 @@ static goto_programt::targett check_and_replace_target(
     const auto &nondet_var = target_instruction->assign_lhs();
 
     side_effect_expr_nondett inserted_expr(
-      nondet_var.type(), target_instruction->source_location);
+      nondet_var.type(), target_instruction->source_location());
     inserted_expr.set_nullable(
       instr_info.get_nullable_type() ==
       nondet_instruction_infot::is_nullablet::TRUE);
     target_instruction->code_nonconst() =
       code_assignt(nondet_var, inserted_expr);
     target_instruction->code_nonconst().add_source_location() =
-      target_instruction->source_location;
+      target_instruction->source_location();
   }
 
   goto_program.update();

--- a/jbmc/unit/java_bytecode/java_virtual_functions/virtual_functions.cpp
+++ b/jbmc/unit/java_bytecode/java_virtual_functions/virtual_functions.cpp
@@ -148,7 +148,7 @@ SCENARIO(
 
           while(it->type != goto_program_instruction_typet::END_FUNCTION)
           {
-            const source_locationt &loc = it->source_location;
+            const source_locationt &loc = it->source_location();
             REQUIRE(loc != source_locationt::nil());
             REQUIRE_FALSE(loc.get_java_bytecode_index().empty());
             const auto new_index = loc.get_java_bytecode_index();

--- a/src/analyses/ai.cpp
+++ b/src/analyses/ai.cpp
@@ -45,8 +45,8 @@ void ai_baset::output(
 {
   forall_goto_program_instructions(i_it, goto_program)
   {
-    out << "**** " << i_it->location_number << " "
-        << i_it->source_location << "\n";
+    out << "**** " << i_it->location_number << " " << i_it->source_location()
+        << "\n";
 
     abstract_state_before(i_it)->output(out, *this, ns);
     out << "\n";
@@ -94,7 +94,7 @@ jsont ai_baset::output_json(
 
     json_objectt location{
       {"locationNumber", json_numbert(std::to_string(i_it->location_number))},
-      {"sourceLocation", json_stringt(i_it->source_location.as_string())},
+      {"sourceLocation", json_stringt(i_it->source_location().as_string())},
       {"abstractState", abstract_state_before(i_it)->output_json(*this, ns)},
       {"instruction", json_stringt(out.str())}};
 
@@ -142,7 +142,7 @@ xmlt ai_baset::output_xml(
     xmlt location(
       "",
       {{"location_number", std::to_string(i_it->location_number)},
-       {"source_location", i_it->source_location.as_string()}},
+       {"source_location", i_it->source_location().as_string()}},
       {abstract_state_before(i_it)->output_xml(*this, ns)});
 
     // Ideally we need output_instruction_xml

--- a/src/analyses/custom_bitvector_analysis.cpp
+++ b/src/analyses/custom_bitvector_analysis.cpp
@@ -800,7 +800,7 @@ void custom_bitvector_analysist::check(
         const namespacet ns(goto_model.symbol_table);
         result = simplify_expr(std::move(tmp), ns);
 
-        description=i_it->source_location.get_comment();
+        description = i_it->source_location().get_comment();
       }
       else
         continue;
@@ -815,7 +815,7 @@ void custom_bitvector_analysist::check(
         else
           out << "UNKNOWN";
         out << "\">\n";
-        out << xml(i_it->source_location);
+        out << xml(i_it->source_location());
         out << "<description>"
             << description
             << "</description>\n";
@@ -823,7 +823,7 @@ void custom_bitvector_analysist::check(
       }
       else
       {
-        out << i_it->source_location;
+        out << i_it->source_location();
         if(!description.empty())
           out << ", " << description;
         out << ": ";

--- a/src/analyses/dependence_graph.cpp
+++ b/src/analyses/dependence_graph.cpp
@@ -311,7 +311,7 @@ jsont dep_graph_domaint::output_json(
   {
     json_objectt link{
       {"locationNumber", json_numbert(std::to_string(cd->location_number))},
-      {"sourceLocation", json(cd->source_location)},
+      {"sourceLocation", json(cd->source_location())},
       {"type", json_stringt("control")}};
     graph.push_back(std::move(link));
   }
@@ -320,7 +320,7 @@ jsont dep_graph_domaint::output_json(
   {
     json_objectt link{
       {"locationNumber", json_numbert(std::to_string(dd->location_number))},
-      {"sourceLocation", json(dd->source_location)},
+      {"sourceLocation", json(dd->source_location())},
       {"type", json_stringt("data")}};
     graph.push_back(std::move(link));
   }

--- a/src/analyses/does_remove_const.cpp
+++ b/src/analyses/does_remove_const.cpp
@@ -46,7 +46,7 @@ std::pair<bool, source_locationt> does_remove_constt::operator()() const
     // const that the lhs
     if(!does_type_preserve_const_correctness(&lhs_type, &rhs_type))
     {
-      return {true, instruction.source_location};
+      return {true, instruction.source_location()};
     }
 
     if(does_expr_lose_const(instruction.assign_rhs()))

--- a/src/analyses/escape_analysis.cpp
+++ b/src/analyses/escape_analysis.cpp
@@ -420,7 +420,7 @@ void escape_analysist::insert_cleanup(
   bool is_object,
   const namespacet &ns)
 {
-  source_locationt source_location=location->source_location;
+  source_locationt source_location = location->source_location();
 
   for(const auto &cleanup : cleanup_functions)
   {

--- a/src/analyses/flow_insensitive_analysis.cpp
+++ b/src/analyses/flow_insensitive_analysis.cpp
@@ -203,7 +203,7 @@ bool flow_insensitive_analysis_baset::do_function_call(
 
     goto_programt::targett r =
       temp.add(goto_programt::make_return(code_returnt(side_effect_expr_nondett(
-        l_call->call_lhs().type(), l_call->source_location))));
+        l_call->call_lhs().type(), l_call->source_location()))));
     r->location_number=0;
 
     goto_programt::targett t = temp.add(goto_programt::make_end_function());

--- a/src/analyses/interval_analysis.cpp
+++ b/src/analyses/interval_analysis.cpp
@@ -79,7 +79,7 @@ void instrument_intervals(
       goto_function.body.insert_before_swap(i_it);
       *t = goto_programt::make_assumption(conjunction(assertion));
       i_it++; // goes to original instruction
-      t->source_location=i_it->source_location;
+      t->source_location_nonconst() = i_it->source_location();
     }
   }
 }

--- a/src/analyses/local_bitvector_analysis.cpp
+++ b/src/analyses/local_bitvector_analysis.cpp
@@ -352,7 +352,7 @@ void local_bitvector_analysist::output(
 
   for(const auto &instruction : goto_function.body.instructions)
   {
-    out << "**** " << instruction.source_location << "\n";
+    out << "**** " << instruction.source_location() << "\n";
 
     const auto &loc_info=loc_infos[l];
 

--- a/src/analyses/local_may_alias.cpp
+++ b/src/analyses/local_may_alias.cpp
@@ -471,7 +471,7 @@ void local_may_aliast::output(
 
   for(const auto &instruction : goto_function.body.instructions)
   {
-    out << "**** " << instruction.source_location << "\n";
+    out << "**** " << instruction.source_location() << "\n";
 
     const loc_infot &loc_info=loc_infos[l];
 

--- a/src/analyses/local_safe_pointers.cpp
+++ b/src/analyses/local_safe_pointers.cpp
@@ -195,7 +195,7 @@ void local_safe_pointerst::output(
   for(const auto &instruction : goto_program.instructions)
   {
     out << "**** " << instruction.location_number << " "
-        << instruction.source_location << "\n";
+        << instruction.source_location() << "\n";
 
     out << "Non-null expressions: ";
 
@@ -239,7 +239,7 @@ void local_safe_pointerst::output_safe_dereferences(
   for(const auto &instruction : goto_program.instructions)
   {
     out << "**** " << instruction.location_number << " "
-        << instruction.source_location << "\n";
+        << instruction.source_location() << "\n";
 
     out << "Safe (known-not-null) dereferences: ";
 

--- a/src/analyses/static_analysis.cpp
+++ b/src/analyses/static_analysis.cpp
@@ -88,8 +88,8 @@ void static_analysis_baset::output(
 {
   forall_goto_program_instructions(i_it, goto_program)
   {
-    out << "**** " << i_it->location_number << " "
-        << i_it->source_location << "\n";
+    out << "**** " << i_it->location_number << " " << i_it->source_location()
+        << "\n";
 
     get_state(i_it).output(ns, out);
     out << "\n";

--- a/src/analyses/variable-sensitivity/variable_sensitivity_dependence_graph.cpp
+++ b/src/analyses/variable-sensitivity/variable_sensitivity_dependence_graph.cpp
@@ -550,7 +550,7 @@ jsont variable_sensitivity_dependence_domaint::output_json(
 
     link["locationNumber"] =
       json_numbert(std::to_string(target->location_number));
-    link["sourceLocation"] = json(target->source_location);
+    link["sourceLocation"] = json(target->source_location());
     link["type"] = json_stringt("control");
     link["branch"] = json_stringt(branch.to_string());
   }
@@ -560,7 +560,7 @@ jsont variable_sensitivity_dependence_domaint::output_json(
     json_objectt &link = graph.push_back().make_object();
     link["locationNumber"] =
       json_numbert(std::to_string(target->location_number));
-    link["sourceLocation"] = json(target->source_location);
+    link["sourceLocation"] = json(target->source_location());
     link["type"] = json_stringt("control");
     link["branch"] = json_stringt("UNCONDITIONAL");
   }
@@ -570,8 +570,8 @@ jsont variable_sensitivity_dependence_domaint::output_json(
     json_objectt &link = graph.push_back().make_object();
     link["locationNumber"] =
       json_numbert(std::to_string(dep.first->location_number));
-    link["sourceLocation"] = json(dep.first->source_location);
-    json_stringt(dep.first->source_location.as_string());
+    link["sourceLocation"] = json(dep.first->source_location());
+    json_stringt(dep.first->source_location().as_string());
     link["type"] = json_stringt("data");
 
     const std::set<exprt> &expr_set = dep.second;

--- a/src/goto-analyzer/show_on_source.cpp
+++ b/src/goto-analyzer/show_on_source.cpp
@@ -27,10 +27,10 @@ show_location(const ai_baset &ai, ai_baset::locationt loc)
   if(abstract_state->is_top())
     return {};
 
-  if(loc->source_location.get_line().empty())
+  if(loc->source_location().get_line().empty())
     return {};
 
-  return loc->source_location.full_path();
+  return loc->source_location().full_path();
 }
 
 /// get the source files with non-top abstract states
@@ -101,7 +101,7 @@ void show_on_source(
       if(file.has_value() && file.value() == source_file)
       {
         const std::size_t line_no =
-          stoull(id2string(i_it->source_location.get_line()));
+          stoull(id2string(i_it->source_location().get_line()));
         if(line_map.find(line_no) == line_map.end())
           line_map[line_no] = i_it;
       }

--- a/src/goto-analyzer/static_verifier.cpp
+++ b/src/goto-analyzer/static_verifier.cpp
@@ -222,7 +222,7 @@ static_verifier_resultt::static_verifier_resultt(
     }
   }
 
-  source_location = assert_location->source_location;
+  source_location = assert_location->source_location();
   function_id = func_id;
 }
 

--- a/src/goto-analyzer/taint_analysis.cpp
+++ b/src/goto-analyzer/taint_analysis.cpp
@@ -168,7 +168,7 @@ void taint_analysist::instrument(
               code_set_may.op1() =
                 address_of_exprt(string_constantt(rule.taint));
               insert_after.add(goto_programt::make_other(
-                code_set_may, instruction.source_location));
+                code_set_may, instruction.source_location()));
               break;
             }
 
@@ -180,10 +180,10 @@ void taint_analysist::instrument(
                 address_of_exprt(string_constantt(rule.taint))};
               goto_programt::targett t =
                 insert_before.add(goto_programt::make_assertion(
-                  not_exprt(get_may), instruction.source_location));
-              t->source_location.set_property_class(
+                  not_exprt(get_may), instruction.source_location()));
+              t->source_location_nonconst().set_property_class(
                 "taint rule " + id2string(rule.id));
-              t->source_location.set_comment(rule.message);
+              t->source_location_nonconst().set_comment(rule.message);
               break;
             }
 
@@ -195,7 +195,7 @@ void taint_analysist::instrument(
               code_clear_may.op1() =
                 address_of_exprt(string_constantt(rule.taint));
               insert_after.add(goto_programt::make_other(
-                code_clear_may, instruction.source_location));
+                code_clear_may, instruction.source_location()));
               break;
             }
             }
@@ -358,21 +358,21 @@ bool taint_analysist::operator()(
         {
           json_objectt json{
             {"bugClass",
-             json_stringt(i_it->source_location.get_property_class())},
-            {"file", json_stringt(i_it->source_location.get_file())},
+             json_stringt(i_it->source_location().get_property_class())},
+            {"file", json_stringt(i_it->source_location().get_file())},
             {"line",
-             json_numbert(id2string(i_it->source_location.get_line()))}};
+             json_numbert(id2string(i_it->source_location().get_line()))}};
           json_result.push_back(std::move(json));
         }
         else
         {
-          std::cout << i_it->source_location;
-          if(!i_it->source_location.get_comment().empty())
-            std::cout << ": " << i_it->source_location.get_comment();
+          std::cout << i_it->source_location();
+          if(!i_it->source_location().get_comment().empty())
+            std::cout << ": " << i_it->source_location().get_comment();
 
-          if(!i_it->source_location.get_property_class().empty())
-            std::cout << " ("
-                      << i_it->source_location.get_property_class() << ")";
+          if(!i_it->source_location().get_property_class().empty())
+            std::cout << " (" << i_it->source_location().get_property_class()
+                      << ")";
 
           std::cout << '\n';
         }

--- a/src/goto-analyzer/unreachable_instructions.cpp
+++ b/src/goto-analyzer/unreachable_instructions.cpp
@@ -94,8 +94,8 @@ static void add_to_xml(
     xmlt &inst = x.new_element("instruction");
     inst.set_attribute("location_number",
                        std::to_string(it->second->location_number));
-    inst.set_attribute("source_location",
-                       it->second->source_location.as_string());
+    inst.set_attribute(
+      "source_location", it->second->source_location().as_string());
   }
   return;
 }
@@ -126,7 +126,7 @@ static void add_to_json(
                  "The last instruction in a goto-program must be END_FUNCTION");
 
   json_objectt entry{{"function", json_stringt(function_identifier)}};
-  if(auto file_name_opt = file_name_string_opt(end_function->source_location))
+  if(auto file_name_opt = file_name_string_opt(end_function->source_location()))
     entry["file"] = json_stringt{*file_name_opt};
 
   json_arrayt &dead_ins=entry["unreachableInstructions"].make_array();
@@ -149,7 +149,7 @@ static void add_to_json(
     s.erase(s.size()-1);
 
     // print info for file actually with full path
-    const source_locationt &l=it->second->source_location;
+    const source_locationt &l = it->second->source_location();
     json_objectt i_entry{{"sourceLocation", json(l)},
                          {"statement", json_stringt(s)}};
     dead_ins.push_back(std::move(i_entry));
@@ -335,7 +335,7 @@ static void list_functions(
       do
       {
         --end_function;
-        last_location = end_function->source_location;
+        last_location = end_function->source_location();
       }
       while(
         end_function != goto_program.instructions.begin() &&

--- a/src/goto-cc/linker_script_merge.cpp
+++ b/src/goto-cc/linker_script_merge.cpp
@@ -280,7 +280,7 @@ int linker_script_merget::pointerize_linker_defined_symbols(
           log.error() << " Could not pointerize '" << sym.get_identifier()
                       << "' in function " << gf.first << ". Pretty:\n"
                       << sym.pretty() << "\n";
-          log.error().source_location = instruction.source_location;
+          log.error().source_location = instruction.source_location();
         }
         log.error() << messaget::eom;
       }

--- a/src/goto-checker/cover_goals_report_util.cpp
+++ b/src/goto-checker/cover_goals_report_util.cpp
@@ -46,8 +46,8 @@ static void output_goals_plain(const propertiest &properties, messaget &log)
   {
     log.result() << "[" << property_pair.first << "]";
 
-    if(property_pair.second.pc->source_location.is_not_nil())
-      log.result() << ' ' << property_pair.second.pc->source_location;
+    if(property_pair.second.pc->source_location().is_not_nil())
+      log.result() << ' ' << property_pair.second.pc->source_location();
 
     if(!property_pair.second.description.empty())
       log.result() << ' ' << property_pair.second.description;
@@ -75,8 +75,9 @@ static void output_goals_xml(const propertiest &properties, messaget &log)
                                                               : "FAILED"}},
       {});
 
-    if(property_pair.second.pc->source_location.is_not_nil())
-      xml_result.new_element() = xml(property_pair.second.pc->source_location);
+    if(property_pair.second.pc->source_location().is_not_nil())
+      xml_result.new_element() =
+        xml(property_pair.second.pc->source_location());
 
     log.result() << xml_result;
   }
@@ -102,8 +103,8 @@ static void output_goals_json(
     json_goal["goal"] = json_stringt(property_pair.first);
     json_goal["description"] = json_stringt(property_info.description);
 
-    if(property_info.pc->source_location.is_not_nil())
-      json_goal["sourceLocation"] = json(property_info.pc->source_location);
+    if(property_info.pc->source_location().is_not_nil())
+      json_goal["sourceLocation"] = json(property_info.pc->source_location());
 
     goals_array.push_back(std::move(json_goal));
   }

--- a/src/goto-checker/properties.cpp
+++ b/src/goto-checker/properties.cpp
@@ -87,11 +87,12 @@ void update_properties_from_goto_model(
       if(!i_it->is_assert())
         continue;
 
-      std::string description = id2string(i_it->source_location.get_comment());
+      std::string description =
+        id2string(i_it->source_location().get_comment());
       if(description.empty())
         description = "assertion";
       properties.emplace(
-        i_it->source_location.get_property_id(),
+        i_it->source_location().get_property_id(),
         property_infot{i_it, description, property_statust::NOT_CHECKED});
     }
   }

--- a/src/goto-checker/report_util.cpp
+++ b/src/goto-checker/report_util.cpp
@@ -147,7 +147,7 @@ static void output_single_property_plain(
   messaget &log,
   irep_idt current_file = irep_idt())
 {
-  const auto &l = property_info.pc->source_location;
+  const auto &l = property_info.pc->source_location();
   log.result() << messaget::faint << '[' << property_id << "] "
                << messaget::reset;
   if(l.get_file() != current_file)
@@ -193,8 +193,8 @@ using propertyt = std::pair<irep_idt, property_infot>;
 static bool
 is_property_less_than(const propertyt &property1, const propertyt &property2)
 {
-  const auto &p1 = property1.second.pc->source_location;
-  const auto &p2 = property2.second.pc->source_location;
+  const auto &p1 = property1.second.pc->source_location();
+  const auto &p2 = property2.second.pc->source_location();
   if(p1.get_file() != p2.get_file())
     return id2string(p1.get_file()) < id2string(p2.get_file());
   if(p1.get_function() != p2.get_function())
@@ -271,7 +271,7 @@ static void output_properties_plain(
   irep_idt current_file;
   for(const auto &p : sorted_properties)
   {
-    const auto &l = p->second.pc->source_location;
+    const auto &l = p->second.pc->source_location();
     if(l.get_function() != previous_function)
     {
       if(!previous_function.empty())
@@ -427,7 +427,7 @@ void output_fault_localization_scores(
       out << "Fault localization scores:" << messaget::eom;
       for(auto &score_pair : fault_location.scores)
       {
-        out << score_pair.first->source_location
+        out << score_pair.first->source_location()
             << "\n  score: " << score_pair.second << messaget::eom;
       }
     });
@@ -462,9 +462,10 @@ static void output_fault_localization_plain(
   }
 
   output_fault_localization_scores(fault_location, log);
-  log.result() << "[" + id2string(property_id) + "]: \n  "
-               << max_fault_localization_score(fault_location)->source_location
-               << messaget::eom;
+  log.result()
+    << "[" + id2string(property_id) + "]: \n  "
+    << max_fault_localization_score(fault_location)->source_location()
+    << messaget::eom;
 }
 
 static void output_fault_localization_plain(
@@ -497,7 +498,7 @@ static xmlt xml(
   output_fault_localization_scores(fault_location, log);
 
   xmlt xml_location =
-    xml(max_fault_localization_score(fault_location)->source_location);
+    xml(max_fault_localization_score(fault_location)->source_location());
   xml_diagnosis.new_element("result").new_element().swap(xml_location);
 
   return xml_diagnosis;
@@ -527,7 +528,7 @@ static json_objectt json(const fault_location_infot &fault_location)
   else
   {
     json_result["result"] =
-      json(max_fault_localization_score(fault_location)->source_location);
+      json(max_fault_localization_score(fault_location)->source_location());
   }
   return json_result;
 }

--- a/src/goto-checker/symex_bmc.cpp
+++ b/src/goto-checker/symex_bmc.cpp
@@ -42,7 +42,7 @@ void symex_bmct::symex_step(
   const get_goto_functiont &get_goto_function,
   statet &state)
 {
-  const source_locationt &source_location = state.source.pc->source_location;
+  const source_locationt &source_location = state.source.pc->source_location();
 
   if(!source_location.is_nil() && last_source_location != source_location)
   {
@@ -60,10 +60,10 @@ void symex_bmct::symex_step(
     simplify_expr(state.source.pc->condition(), ns).is_false())
   {
     log.statistics() << "aborting path on assume(false) at "
-                     << state.source.pc->source_location << " thread "
+                     << state.source.pc->source_location() << " thread "
                      << state.source.thread_nr;
 
-    const irep_idt &c = state.source.pc->source_location.get_comment();
+    const irep_idt &c = state.source.pc->source_location().get_comment();
     if(!c.empty())
       log.statistics() << ": " << c;
 
@@ -153,7 +153,7 @@ bool symex_bmct::should_stop_unwind(
   if(this_loop_limit != std::numeric_limits<unsigned>::max())
     log.statistics() << " (" << this_loop_limit << " max)";
 
-  log.statistics() << " " << source.pc->source_location << " thread "
+  log.statistics() << " " << source.pc->source_location() << " thread "
                    << source.thread_nr << log.eom;
 
   return abort;

--- a/src/goto-checker/symex_bmc_incremental_one_loop.cpp
+++ b/src/goto-checker/symex_bmc_incremental_one_loop.cpp
@@ -98,7 +98,7 @@ bool symex_bmc_incremental_one_loopt::should_stop_unwind(
   if(this_loop_limit != std::numeric_limits<unsigned>::max())
     log.statistics() << " (" << this_loop_limit << " max)";
 
-  log.statistics() << " " << source.pc->source_location << " thread "
+  log.statistics() << " " << source.pc->source_location() << " thread "
                    << source.thread_nr << log.eom;
 
   return abort;

--- a/src/goto-checker/symex_coverage.cpp
+++ b/src/goto-checker/symex_coverage.cpp
@@ -140,7 +140,7 @@ goto_program_coverage_recordt::goto_program_coverage_recordt(
   DATA_INVARIANT(
     end_function->is_end_function(),
     "last instruction in a function body is end function");
-  file_name = end_function->source_location.get_file();
+  file_name = end_function->source_location().get_file();
   DATA_INVARIANT(!file_name.empty(), "should have a valid source location");
 
   // compute the maximum coverage of individual source-code lines
@@ -209,15 +209,15 @@ void goto_program_coverage_recordt::compute_coverage_lines(
   forall_goto_program_instructions(it, goto_program)
   {
     if(
-      it->source_location.is_nil() ||
-      it->source_location.get_file() != file_name || it->is_dead() ||
+      it->source_location().is_nil() ||
+      it->source_location().get_file() != file_name || it->is_dead() ||
       it->is_end_function())
       continue;
 
     const bool is_branch = it->is_goto() && !it->guard.is_constant();
 
     unsigned l =
-      safe_string2unsigned(id2string(it->source_location.get_line()));
+      safe_string2unsigned(id2string(it->source_location().get_line()));
     std::pair<coverage_lines_mapt::iterator, bool> entry =
       dest.insert(std::make_pair(l, coverage_linet()));
 

--- a/src/goto-diff/change_impact.cpp
+++ b/src/goto-diff/change_impact.cpp
@@ -739,8 +739,8 @@ void change_impactt::output_instruction(
   {
     if(prefix == ' ')
       return;
-    const irep_idt &file=target->source_location.get_file();
-    const irep_idt &line=target->source_location.get_line();
+    const irep_idt &file = target->source_location().get_file();
+    const irep_idt &line = target->source_location().get_line();
     if(!file.empty() && !line.empty())
       std::cout << prefix << " " << id2string(file)
                 << " " << id2string(line) << '\n';

--- a/src/goto-diff/goto_diff_base.cpp
+++ b/src/goto-diff/goto_diff_base.cpp
@@ -104,7 +104,7 @@ void goto_difft::output_function(
       if(!ins.is_assert())
         continue;
 
-      const source_locationt &source_location = ins.source_location;
+      const source_locationt &source_location = ins.source_location();
       irep_idt property_id = source_location.get_property_id();
       msg.result() << "\n    " << property_id;
     }

--- a/src/goto-harness/memory_snapshot_harness_generator.cpp
+++ b/src/goto-harness/memory_snapshot_harness_generator.cpp
@@ -552,15 +552,15 @@ memory_snapshot_harness_generatort::entry_source_locationt::
     instructions.begin(),
     instructions.end(),
     [this](const goto_programt::instructiont &instruction) {
-      return instruction.source_location.get_file() == file_name &&
+      return instruction.source_location().get_file() == file_name &&
              safe_string2unsigned(id2string(
-               instruction.source_location.get_line())) >= line_number;
+               instruction.source_location().get_line())) >= line_number;
     });
 
   if(it == instructions.end())
     return {it, 0};
   else
     return {it,
-            safe_string2unsigned(id2string(it->source_location.get_line())) -
+            safe_string2unsigned(id2string(it->source_location().get_line())) -
               line_number};
 }

--- a/src/goto-instrument/accelerate/accelerate.cpp
+++ b/src/goto-instrument/accelerate/accelerate.cpp
@@ -208,8 +208,8 @@ void acceleratet::insert_looping_path(
     loop_body,
     goto_programt::make_goto(
       loop_body,
-      side_effect_expr_nondett(bool_typet(), loop_body->source_location),
-      loop_body->source_location));
+      side_effect_expr_nondett(bool_typet(), loop_body->source_location()),
+      loop_body->source_location()));
 
   program.destructive_insert(loop_body, looping_path);
 

--- a/src/goto-instrument/contracts/memory_predicates.cpp
+++ b/src/goto-instrument/contracts/memory_predicates.cpp
@@ -49,7 +49,7 @@ void functions_in_scope_visitort::operator()(const goto_programt &prog)
 
       if(function.id() != ID_symbol)
       {
-        log.error().source_location = ins->source_location;
+        log.error().source_location = ins->source_location();
         log.error() << "Function pointer used in function invoked by "
                        "function contract: "
                     << messaget::eom;

--- a/src/goto-instrument/count_eloc.cpp
+++ b/src/goto-instrument/count_eloc.cpp
@@ -38,7 +38,7 @@ static void collect_eloc(
   {
     for(const auto &instruction : gf_entry.second.body.instructions)
     {
-      const auto &source_location = instruction.source_location;
+      const auto &source_location = instruction.source_location();
 
       filest &files = dest[source_location.get_working_directory()];
       const irep_idt &file = source_location.get_file();

--- a/src/goto-instrument/cover_basic_blocks.cpp
+++ b/src/goto-instrument/cover_basic_blocks.cpp
@@ -62,13 +62,13 @@ cover_basic_blockst::cover_basic_blockst(const goto_programt &goto_program)
 
     // set representative program location to instrument
     if(
-      !it->source_location.is_nil() &&
-      !it->source_location.get_file().empty() &&
-      !it->source_location.get_line().empty() &&
+      !it->source_location().is_nil() &&
+      !it->source_location().get_file().empty() &&
+      !it->source_location().get_line().empty() &&
       block_info.source_location.is_nil())
     {
       block_info.representative_inst = it; // update
-      block_info.source_location = it->source_location;
+      block_info.source_location = it->source_location();
     }
 
     next_is_target =
@@ -125,7 +125,7 @@ void cover_basic_blockst::report_block_anomalies(
       block_info.representative_inst == goto_program.instructions.end())
     {
       msg.warning() << "Ignoring block " << (block_nr + 1) << " location "
-                    << it->location_number << " " << it->source_location
+                    << it->location_number << " " << it->source_location()
                     << " (bytecode-index already instrumented)"
                     << messaget::eom;
     }
@@ -145,7 +145,7 @@ void cover_basic_blockst::report_block_anomalies(
 void cover_basic_blockst::output(std::ostream &out) const
 {
   for(const auto &block_pair : block_map)
-    out << block_pair.first->source_location << " -> " << block_pair.second
+    out << block_pair.first->source_location() << " -> " << block_pair.second
         << '\n';
 }
 
@@ -161,7 +161,7 @@ void cover_basic_blockst::add_block_lines(
       block.source_lines.insert(location);
     }
   };
-  add_location(instruction.source_location);
+  add_location(instruction.source_location());
   instruction.get_code().visit_pre(
     [&](const exprt &expr) { add_location(expr.source_location()); });
 }
@@ -197,7 +197,7 @@ cover_basic_blocks_javat::cover_basic_blocks_javat(
 
   forall_goto_program_instructions(it, _goto_program)
   {
-    const auto &location = it->source_location;
+    const auto &location = it->source_location();
     const auto &bytecode_index = location.get_java_bytecode_index();
     auto entry = index_to_block.emplace(bytecode_index, block_infos.size());
     if(entry.second)
@@ -225,7 +225,7 @@ cover_basic_blocks_javat::cover_basic_blocks_javat(
 std::size_t
 cover_basic_blocks_javat::block_of(goto_programt::const_targett t) const
 {
-  const auto &bytecode_index = t->source_location.get_java_bytecode_index();
+  const auto &bytecode_index = t->source_location().get_java_bytecode_index();
   const auto it = index_to_block.find(bytecode_index);
   INVARIANT(it != index_to_block.end(), "instruction must be part of a block");
   return it->second;

--- a/src/goto-instrument/cover_filter.cpp
+++ b/src/goto-instrument/cover_filter.cpp
@@ -40,7 +40,7 @@ bool internal_functions_filtert::operator()(
   // ignore if built-in library
   if(
     !goto_function.body.instructions.empty() &&
-    goto_function.body.instructions.front().source_location.is_built_in())
+    goto_function.body.instructions.front().source_location().is_built_in())
     return false;
 
   return true;

--- a/src/goto-instrument/cover_instrument.h
+++ b/src/goto-instrument/cover_instrument.h
@@ -85,16 +85,17 @@ protected:
     const std::string &comment,
     const irep_idt &function_id) const
   {
-    t->source_location.set_comment(comment);
-    t->source_location.set(ID_coverage_criterion, coverage_criterion);
-    t->source_location.set_property_class(property_class);
-    t->source_location.set_function(function_id);
+    t->source_location_nonconst().set_comment(comment);
+    t->source_location_nonconst().set(
+      ID_coverage_criterion, coverage_criterion);
+    t->source_location_nonconst().set_property_class(property_class);
+    t->source_location_nonconst().set_function(function_id);
   }
 
   bool is_non_cover_assertion(goto_programt::const_targett t) const
   {
     return t->is_assert() &&
-           t->source_location.get_property_class() != property_class;
+           t->source_location().get_property_class() != property_class;
   }
 };
 

--- a/src/goto-instrument/cover_instrument_assume.cpp
+++ b/src/goto-instrument/cover_instrument_assume.cpp
@@ -23,7 +23,7 @@ void cover_assume_instrumentert::instrument(
 {
   if(i_it->is_assume())
   {
-    const auto location = i_it->source_location;
+    const auto location = i_it->source_location();
     const auto assume_condition =
       expr2c(i_it->get_condition(), namespacet{symbol_tablet()});
     const auto comment_before =
@@ -42,7 +42,7 @@ void cover_assume_instrumentert::instrument(
   // Otherwise, skip existing assertions.
   else if(i_it->is_assert())
   {
-    const auto location = i_it->source_location;
+    const auto location = i_it->source_location();
     // Filter based on if assertion was added by us as part of instrumentation.
     if(location.get_property_class() != "coverage")
     {

--- a/src/goto-instrument/cover_instrument_branch.cpp
+++ b/src/goto-instrument/cover_instrument_branch.cpp
@@ -30,7 +30,7 @@ void cover_branch_instrumentert::instrument(
   if(!is_function_entry_point && !is_conditional_goto)
     return;
 
-  if(!goal_filters(i_it->source_location))
+  if(!goal_filters(i_it->source_location()))
     return;
 
   if(is_function_entry_point)
@@ -39,7 +39,7 @@ void cover_branch_instrumentert::instrument(
     // coverage
     std::string comment = "entry point";
 
-    source_locationt source_location = i_it->source_location;
+    source_locationt source_location = i_it->source_location();
 
     goto_programt::targett t = goto_program.insert_before(
       i_it, make_assertion(false_exprt(), source_location));
@@ -54,7 +54,7 @@ void cover_branch_instrumentert::instrument(
     std::string false_comment = "block " + b + " branch false";
 
     exprt guard = i_it->condition();
-    source_locationt source_location = i_it->source_location;
+    source_locationt source_location = i_it->source_location();
 
     goto_program.insert_before_swap(i_it);
     *i_it = make_assertion(not_exprt(guard), source_location);

--- a/src/goto-instrument/cover_instrument_condition.cpp
+++ b/src/goto-instrument/cover_instrument_condition.cpp
@@ -26,11 +26,11 @@ void cover_condition_instrumentert::instrument(
     i_it->turn_into_skip();
 
   // Conditions are all atomic predicates in the programs.
-  if(!i_it->source_location.is_built_in())
+  if(!i_it->source_location().is_built_in())
   {
     const std::set<exprt> conditions = collect_conditions(i_it);
 
-    const source_locationt source_location = i_it->source_location;
+    const source_locationt source_location = i_it->source_location();
 
     for(const auto &c : conditions)
     {

--- a/src/goto-instrument/cover_instrument_decision.cpp
+++ b/src/goto-instrument/cover_instrument_decision.cpp
@@ -26,11 +26,11 @@ void cover_decision_instrumentert::instrument(
     i_it->turn_into_skip();
 
   // Decisions are maximal Boolean combinations of conditions.
-  if(!i_it->source_location.is_built_in())
+  if(!i_it->source_location().is_built_in())
   {
     const std::set<exprt> decisions = collect_decisions(i_it);
 
-    const source_locationt source_location = i_it->source_location;
+    const source_locationt source_location = i_it->source_location();
 
     for(const auto &d : decisions)
     {

--- a/src/goto-instrument/cover_instrument_mcdc.cpp
+++ b/src/goto-instrument/cover_instrument_mcdc.cpp
@@ -634,7 +634,7 @@ void cover_mcdc_instrumentert::instrument(
   // 3. Each condition in a decision takes every possible outcome
   // 4. Each condition in a decision is shown to independently
   //    affect the outcome of the decision.
-  if(!i_it->source_location.is_built_in())
+  if(!i_it->source_location().is_built_in())
   {
     const std::set<exprt> conditions = collect_conditions(i_it);
     const std::set<exprt> decisions = collect_decisions(i_it);
@@ -647,7 +647,7 @@ void cover_mcdc_instrumentert::instrument(
       decisions.end(),
       inserter(both, both.end()));
 
-    const source_locationt source_location = i_it->source_location;
+    const source_locationt source_location = i_it->source_location();
 
     for(const auto &p : both)
     {
@@ -663,18 +663,20 @@ void cover_mcdc_instrumentert::instrument(
       std::string comment_t = description + " '" + p_string + "' true";
       goto_program.insert_before_swap(i_it);
       *i_it = make_assertion(not_exprt(p), source_location);
-      i_it->source_location.set_comment(comment_t);
-      i_it->source_location.set(ID_coverage_criterion, coverage_criterion);
-      i_it->source_location.set_property_class(property_class);
-      i_it->source_location.set_function(function_id);
+      i_it->source_location_nonconst().set_comment(comment_t);
+      i_it->source_location_nonconst().set(
+        ID_coverage_criterion, coverage_criterion);
+      i_it->source_location_nonconst().set_property_class(property_class);
+      i_it->source_location_nonconst().set_function(function_id);
 
       std::string comment_f = description + " '" + p_string + "' false";
       goto_program.insert_before_swap(i_it);
       *i_it = make_assertion(p, source_location);
-      i_it->source_location.set_comment(comment_f);
-      i_it->source_location.set(ID_coverage_criterion, coverage_criterion);
-      i_it->source_location.set_property_class(property_class);
-      i_it->source_location.set_function(function_id);
+      i_it->source_location_nonconst().set_comment(comment_f);
+      i_it->source_location_nonconst().set(
+        ID_coverage_criterion, coverage_criterion);
+      i_it->source_location_nonconst().set_property_class(property_class);
+      i_it->source_location_nonconst().set_function(function_id);
     }
 
     std::set<exprt> controlling;
@@ -696,10 +698,11 @@ void cover_mcdc_instrumentert::instrument(
 
       goto_program.insert_before_swap(i_it);
       *i_it = make_assertion(not_exprt(p), source_location);
-      i_it->source_location.set_comment(description);
-      i_it->source_location.set(ID_coverage_criterion, coverage_criterion);
-      i_it->source_location.set_property_class(property_class);
-      i_it->source_location.set_function(function_id);
+      i_it->source_location_nonconst().set_comment(description);
+      i_it->source_location_nonconst().set(
+        ID_coverage_criterion, coverage_criterion);
+      i_it->source_location_nonconst().set_property_class(property_class);
+      i_it->source_location_nonconst().set_function(function_id);
     }
 
     for(std::size_t i = 0; i < both.size() * 2 + controlling.size(); i++)

--- a/src/goto-instrument/cover_instrument_other.cpp
+++ b/src/goto-instrument/cover_instrument_other.cpp
@@ -42,7 +42,7 @@ void cover_assertion_instrumentert::instrument(
   {
     i_it->guard = false_exprt();
     initialize_source_location(
-      i_it, id2string(i_it->source_location.get_comment()), function_id);
+      i_it, id2string(i_it->source_location().get_comment()), function_id);
   }
 }
 
@@ -63,7 +63,7 @@ void cover_cover_instrumentert::instrument(
       i_it->call_arguments().size() == 1)
     {
       const exprt c = i_it->call_arguments()[0];
-      *i_it = make_assertion(not_exprt(c), i_it->source_location);
+      *i_it = make_assertion(not_exprt(c), i_it->source_location());
       std::string comment = "condition '" + from_expr(ns, function_id, c) + "'";
       initialize_source_location(i_it, comment, function_id);
     }
@@ -90,12 +90,13 @@ void cover_instrument_end_of_function(
     last_function_call != goto_program.instructions.rbegin(),
     "Goto program shouldn't end with a function call");
   const auto if_it = last_function_call.base();
-  const auto location = if_it->source_location;
+  const auto location = if_it->source_location();
   const std::string &comment =
     "additional goal to ensure reachability of end of function";
   goto_program.insert_before_swap(if_it);
   *if_it = make_assertion(false_exprt(), location);
-  if_it->source_location.set_comment(comment);
-  if_it->source_location.set_property_class("reachability_constraint");
-  if_it->source_location.set_function(function_id);
+  if_it->source_location_nonconst().set_comment(comment);
+  if_it->source_location_nonconst().set_property_class(
+    "reachability_constraint");
+  if_it->source_location_nonconst().set_function(function_id);
 }

--- a/src/goto-instrument/document_properties.cpp
+++ b/src/goto-instrument/document_properties.cpp
@@ -280,7 +280,7 @@ void document_propertiest::doit()
     {
       if(instruction.is_assert())
       {
-        const auto &source_location = instruction.source_location;
+        const auto &source_location = instruction.source_location();
         source_locationt new_source_location;
 
         new_source_location.set_file(source_location.get_file());

--- a/src/goto-instrument/full_slicer_class.h
+++ b/src/goto-instrument/full_slicer_class.h
@@ -150,8 +150,8 @@ public:
     if(!target->is_assert())
       return false;
 
-    const std::string &p_id=
-      id2string(target->source_location.get_property_id());
+    const std::string &p_id =
+      id2string(target->source_location().get_property_id());
 
     for(std::list<std::string>::const_iterator
         it=property_ids.begin();

--- a/src/goto-instrument/generate_function_bodies.cpp
+++ b/src/goto-instrument/generate_function_bodies.cpp
@@ -79,7 +79,7 @@ protected:
     // NOLINTNEXTLINE
     auto add_instruction = [&](goto_programt::instructiont &&i) {
       auto instruction = function.body.add(std::move(i));
-      instruction->source_location = function_symbol.location;
+      instruction->source_location_nonconst() = function_symbol.location;
       return instruction;
     };
     add_instruction(goto_programt::make_assumption(false_exprt()));
@@ -99,8 +99,8 @@ protected:
     // NOLINTNEXTLINE
     auto add_instruction = [&](goto_programt::instructiont &&i) {
       auto instruction = function.body.add(std::move(i));
-      instruction->source_location = function_symbol.location;
-      instruction->source_location.set_function(function_name);
+      instruction->source_location_nonconst() = function_symbol.location;
+      instruction->source_location_nonconst().set_function(function_name);
       return instruction;
     };
     auto assert_instruction =
@@ -109,8 +109,10 @@ protected:
     std::ostringstream comment_stream;
     comment_stream << id2string(ID_assertion) << " "
                    << format(assert_instruction->get_condition());
-    assert_instruction->source_location.set_comment(comment_stream.str());
-    assert_instruction->source_location.set_property_class(ID_assertion);
+    assert_instruction->source_location_nonconst().set_comment(
+      comment_stream.str());
+    assert_instruction->source_location_nonconst().set_property_class(
+      ID_assertion);
     add_instruction(goto_programt::make_end_function());
   }
 };
@@ -128,8 +130,8 @@ protected:
     // NOLINTNEXTLINE
     auto add_instruction = [&](goto_programt::instructiont &&i) {
       auto instruction = function.body.add(std::move(i));
-      instruction->source_location = function_symbol.location;
-      instruction->source_location.set_function(function_name);
+      instruction->source_location_nonconst() = function_symbol.location;
+      instruction->source_location_nonconst().set_function(function_name);
       return instruction;
     };
     auto assert_instruction =
@@ -138,8 +140,10 @@ protected:
     std::ostringstream comment_stream;
     comment_stream << id2string(ID_assertion) << " "
                    << format(assert_instruction->get_condition());
-    assert_instruction->source_location.set_comment(comment_stream.str());
-    assert_instruction->source_location.set_property_class(ID_assertion);
+    assert_instruction->source_location_nonconst().set_comment(
+      comment_stream.str());
+    assert_instruction->source_location_nonconst().set_property_class(
+      ID_assertion);
     add_instruction(goto_programt::make_assumption(false_exprt()));
     add_instruction(goto_programt::make_end_function());
   }
@@ -266,7 +270,7 @@ protected:
     // NOLINTNEXTLINE
     auto add_instruction = [&](goto_programt::instructiont &&i) {
       auto instruction = function.body.add(std::move(i));
-      instruction->source_location = function_symbol.location;
+      instruction->source_location_nonconst() = function_symbol.location;
       return instruction;
     };
 

--- a/src/goto-instrument/goto_program2code.cpp
+++ b/src/goto-instrument/goto_program2code.cpp
@@ -138,12 +138,11 @@ goto_programt::const_targett goto_program2codet::convert_instruction(
 {
   assert(target!=goto_program.instructions.end());
 
-  if(target->type!=ASSERT &&
-     !target->source_location.get_comment().empty())
+  if(target->type != ASSERT && !target->source_location().get_comment().empty())
   {
     dest.add(code_skipt());
     dest.statements().back().add_source_location().set_comment(
-      target->source_location.get_comment());
+      target->source_location().get_comment());
   }
 
   // try do-while first
@@ -194,7 +193,7 @@ goto_programt::const_targett goto_program2codet::convert_instruction(
       system_headers.insert("assert.h");
       dest.add(code_assertt(target->get_condition()));
       dest.statements().back().add_source_location().set_comment(
-        target->source_location.get_comment());
+        target->source_location().get_comment());
       return target;
 
     case ASSUME:
@@ -252,7 +251,7 @@ void goto_program2codet::convert_labels(
     std::stringstream label;
     label << CPROVER_PREFIX "DUMP_L" << target->target_number;
     code_labelt l(label.str(), code_blockt());
-    l.add_source_location()=target->source_location;
+    l.add_source_location() = target->source_location();
     target_label=l.get_label();
     latest_block->add(std::move(l));
     latest_block =
@@ -275,7 +274,7 @@ void goto_program2codet::convert_labels(
     labels_in_use.insert(*it);
 
     code_labelt l(*it, code_blockt());
-    l.add_source_location()=target->source_location;
+    l.add_source_location() = target->source_location();
     latest_block->add(std::move(l));
     latest_block =
       &to_code_block(to_code_label(latest_block->statements().back()).code());
@@ -1266,7 +1265,7 @@ goto_programt::const_targett goto_program2codet::convert_start_thread(
         labels_in_use.insert(*it);
 
         code_labelt l(*it, std::move(b));
-        l.add_source_location()=target->source_location;
+        l.add_source_location() = target->source_location();
         b = std::move(l);
       }
 
@@ -1332,7 +1331,7 @@ goto_programt::const_targett goto_program2codet::convert_start_thread(
       labels_in_use.insert(*it);
 
       code_labelt l(*it, std::move(b));
-      l.add_source_location()=target->source_location;
+      l.add_source_location() = target->source_location();
       b = std::move(l);
     }
 
@@ -1950,6 +1949,6 @@ void goto_program2codet::copy_source_location(
 {
   if(src->get_code().source_location().is_not_nil())
     dst.add_source_location() = src->get_code().source_location();
-  else if(src->source_location.is_not_nil())
-    dst.add_source_location() = src->source_location;
+  else if(src->source_location().is_not_nil())
+    dst.add_source_location() = src->source_location();
 }

--- a/src/goto-instrument/havoc_loops.cpp
+++ b/src/goto-instrument/havoc_loops.cpp
@@ -69,7 +69,7 @@ void havoc_loopst::havoc_loop(
   // build the havocking code
   goto_programt havoc_code;
   havoc_utilst havoc_gen(modifies);
-  havoc_gen.append_full_havoc_code(loop_head->source_location, havoc_code);
+  havoc_gen.append_full_havoc_code(loop_head->source_location(), havoc_code);
 
   // Now havoc at the loop head. Use insert_swap to
   // preserve jumps to loop head.

--- a/src/goto-instrument/insert_final_assert_false.cpp
+++ b/src/goto-instrument/insert_final_assert_false.cpp
@@ -41,7 +41,7 @@ operator()(goto_modelt &goto_model, const std::string &function_to_instrument)
   DATA_INVARIANT(
     last_instruction->is_end_function(),
     "last instruction in function should be END_FUNCTION");
-  source_locationt assert_location = last_instruction->source_location;
+  source_locationt assert_location = last_instruction->source_location();
   assert_location.set_property_class(ID_assertion);
   assert_location.set_comment("insert-final-assert-false (should fail) ");
   goto_programt::instructiont false_assert =

--- a/src/goto-instrument/interrupt.cpp
+++ b/src/goto-instrument/interrupt.cpp
@@ -101,8 +101,8 @@ static void interrupt(
       goto_programt::instructiont original_instruction;
       original_instruction.swap(instruction);
 
-      const source_locationt &source_location=
-        original_instruction.source_location;
+      const source_locationt &source_location =
+        original_instruction.source_location();
 
       code_function_callt isr_call(interrupt_handler);
       isr_call.add_source_location()=source_location;
@@ -129,7 +129,7 @@ static void interrupt(
       goto_programt::targett t_orig=i_it;
       t_orig++;
 
-      const source_locationt &source_location=i_it->source_location;
+      const source_locationt &source_location = i_it->source_location();
 
       code_function_callt isr_call(interrupt_handler);
       isr_call.add_source_location()=source_location;

--- a/src/goto-instrument/k_induction.cpp
+++ b/src/goto-instrument/k_induction.cpp
@@ -98,7 +98,7 @@ void k_inductiont::process_loop(
     // build the havocking code
     goto_programt havoc_code;
     havoc_utilst havoc_gen(modifies);
-    havoc_gen.append_full_havoc_code(loop_head->source_location, havoc_code);
+    havoc_gen.append_full_havoc_code(loop_head->source_location(), havoc_code);
 
     // unwind to get k+1 copies
     std::vector<goto_programt::targett> iteration_points;

--- a/src/goto-instrument/model_argc_argv.cpp
+++ b/src/goto-instrument/model_argc_argv.cpp
@@ -152,7 +152,7 @@ bool model_argc_argv(
     main_symbol.mode);
 
   for(auto &instruction : init_instructions.instructions)
-    instruction.source_location.set_file("<built-in-library>");
+    instruction.source_location_nonconst().set_file("<built-in-library>");
 
   goto_functionst::function_mapt::iterator start_entry=
     goto_model.goto_functions.function_map.find(

--- a/src/goto-instrument/nondet_static.cpp
+++ b/src/goto-instrument/nondet_static.cpp
@@ -96,7 +96,7 @@ void nondet_static(
 
       if(is_nondet_initializable_static(sym, ns))
       {
-        const auto source_location = instruction.source_location;
+        const auto source_location = instruction.source_location();
         instruction = goto_programt::make_assignment(
           code_assignt(
             sym, side_effect_expr_nondett(sym.type(), source_location)),

--- a/src/goto-instrument/race_check.cpp
+++ b/src/goto-instrument/race_check.cpp
@@ -189,7 +189,7 @@ static void race_check(
       original_instruction.swap(instruction);
 
       instruction =
-        goto_programt::make_skip(original_instruction.source_location);
+        goto_programt::make_skip(original_instruction.source_location());
       i_it++;
 
       // now add assignments for what is written -- set
@@ -203,7 +203,7 @@ static void race_check(
           goto_programt::make_assignment(
             w_guards.get_w_guard_expr(w_entry.second),
             w_entry.second.guard,
-            original_instruction.source_location));
+            original_instruction.source_location()));
         i_it=++t;
       }
 
@@ -225,7 +225,7 @@ static void race_check(
           goto_programt::make_assignment(
             w_guards.get_w_guard_expr(w_entry.second),
             false_exprt(),
-            original_instruction.source_location));
+            original_instruction.source_location()));
         i_it = std::next(t);
       }
 
@@ -239,8 +239,9 @@ static void race_check(
           i_it,
           goto_programt::make_assertion(
             w_guards.get_assertion(r_entry.second),
-            original_instruction.source_location));
-        t->source_location.set_comment(comment(r_entry.second, false));
+            original_instruction.source_location()));
+        t->source_location_nonconst().set_comment(
+          comment(r_entry.second, false));
         i_it=++t;
       }
 
@@ -253,8 +254,9 @@ static void race_check(
           i_it,
           goto_programt::make_assertion(
             w_guards.get_assertion(w_entry.second),
-            original_instruction.source_location));
-        t->source_location.set_comment(comment(w_entry.second, true));
+            original_instruction.source_location()));
+        t->source_location_nonconst().set_comment(
+          comment(w_entry.second, true));
         i_it=++t;
       }
 

--- a/src/goto-instrument/reachability_slicer.cpp
+++ b/src/goto-instrument/reachability_slicer.cpp
@@ -345,7 +345,7 @@ void reachability_slicert::slice(goto_functionst &goto_functions)
           !i_it->is_end_function())
         {
           *i_it = goto_programt::make_assumption(
-            false_exprt(), i_it->source_location);
+            false_exprt(), i_it->source_location());
         }
       }
 

--- a/src/goto-instrument/show_locations.cpp
+++ b/src/goto-instrument/show_locations.cpp
@@ -27,7 +27,7 @@ void show_locations(
       it!=goto_program.instructions.end();
       it++)
   {
-    const source_locationt &source_location=it->source_location;
+    const source_locationt &source_location = it->source_location();
 
     switch(ui)
     {
@@ -50,9 +50,8 @@ void show_locations(
       break;
 
     case ui_message_handlert::uit::PLAIN:
-      std::cout << function_id << " "
-                << it->location_number << " "
-                << it->source_location << '\n';
+      std::cout << function_id << " " << it->location_number << " "
+                << it->source_location() << '\n';
       break;
 
     case ui_message_handlert::uit::JSON_UI:

--- a/src/goto-instrument/skip_loops.cpp
+++ b/src/goto-instrument/skip_loops.cpp
@@ -47,7 +47,8 @@ static bool skip_loops(
 
     goto_program.insert_before(
       loop_head,
-      goto_programt::make_goto(next, true_exprt(), loop_head->source_location));
+      goto_programt::make_goto(
+        next, true_exprt(), loop_head->source_location()));
 
     ++l_it;
   }

--- a/src/goto-instrument/stack_depth.cpp
+++ b/src/goto-instrument/stack_depth.cpp
@@ -53,24 +53,24 @@ void stack_depth(
 
   binary_relation_exprt guard(symbol, ID_le, max_depth);
   goto_programt::targett assert_ins = goto_program.insert_before(
-    first, goto_programt::make_assertion(guard, first->source_location));
+    first, goto_programt::make_assertion(guard, first->source_location()));
 
-  assert_ins->source_location.set_comment(
-    "Stack depth exceeds "+std::to_string(i_depth));
-  assert_ins->source_location.set_property_class("stack-depth");
+  assert_ins->source_location_nonconst().set_comment(
+    "Stack depth exceeds " + std::to_string(i_depth));
+  assert_ins->source_location_nonconst().set_property_class("stack-depth");
 
   goto_program.insert_before(
     first,
     goto_programt::make_assignment(
       code_assignt(symbol, plus_exprt(symbol, from_integer(1, symbol.type()))),
-      first->source_location));
+      first->source_location()));
 
   goto_programt::targett last=--goto_program.instructions.end();
   assert(last->is_end_function());
 
   goto_programt::instructiont minus_ins = goto_programt::make_assignment(
     code_assignt(symbol, minus_exprt(symbol, from_integer(1, symbol.type()))),
-    last->source_location);
+    last->source_location());
 
   goto_program.insert_before_swap(last, minus_ins);
 }

--- a/src/goto-instrument/thread_instrumentation.cpp
+++ b/src/goto-instrument/thread_instrumentation.cpp
@@ -35,7 +35,7 @@ void thread_exit_instrumentation(goto_programt &goto_program)
 
   assert(end->is_end_function());
 
-  source_locationt source_location=end->source_location;
+  source_locationt source_location = end->source_location();
 
   goto_program.insert_before_swap(end);
 
@@ -49,7 +49,8 @@ void thread_exit_instrumentation(goto_programt &goto_program)
 
   *end = goto_programt::make_assertion(not_exprt(get_may), source_location);
 
-  end->source_location.set_comment("mutexes must not be locked on thread exit");
+  end->source_location_nonconst().set_comment(
+    "mutexes must not be locked on thread exit");
 }
 
 void thread_exit_instrumentation(goto_modelt &goto_model)
@@ -102,7 +103,7 @@ void mutex_init_instrumentation(
            address_of_exprt(string_constantt("mutex-init"))});
 
         goto_program.insert_after(
-          it, goto_programt::make_function_call(call, it->source_location));
+          it, goto_programt::make_function_call(call, it->source_location()));
       }
     }
   }

--- a/src/goto-instrument/undefined_functions.cpp
+++ b/src/goto-instrument/undefined_functions.cpp
@@ -58,8 +58,9 @@ void undefined_function_abort_path(goto_modelt &goto_model)
       if(entry->second.body_available())
         continue;
 
-      ins = goto_programt::make_assumption(false_exprt(), ins.source_location);
-      ins.source_location.set_comment(
+      ins =
+        goto_programt::make_assumption(false_exprt(), ins.source_location());
+      ins.source_location_nonconst().set_comment(
         "'" + id2string(function_identifier) + "' is undefined");
     }
   }

--- a/src/goto-instrument/uninitialized.cpp
+++ b/src/goto-instrument/uninitialized.cpp
@@ -121,11 +121,11 @@ void uninitializedt::add_assertions(
 
         symbol_exprt symbol_expr(new_identifier, bool_typet());
         i1->type=DECL;
-        i1->source_location=instruction.source_location;
+        i1->source_location_nonconst() = instruction.source_location();
         i1->code_nonconst() = code_declt(symbol_expr);
 
         i2->type=ASSIGN;
-        i2->source_location=instruction.source_location;
+        i2->source_location_nonconst() = instruction.source_location();
         i2->code_nonconst() = code_assignt(symbol_expr, false_exprt());
       }
     }
@@ -157,10 +157,11 @@ void uninitializedt::add_assertions(
             goto_programt::instructiont assertion =
               goto_programt::make_assertion(
                 symbol_exprt(new_identifier, bool_typet()),
-                instruction.source_location);
-            assertion.source_location.set_comment(
+                instruction.source_location());
+            assertion.source_location_nonconst().set_comment(
               "use of uninitialized local variable");
-            assertion.source_location.set_property_class("uninitialized local");
+            assertion.source_location_nonconst().set_property_class(
+              "uninitialized local");
 
             goto_program.insert_before_swap(i_it, assertion);
             i_it++;
@@ -183,7 +184,8 @@ void uninitializedt::add_assertions(
             assignment.type=ASSIGN;
             assignment.code_nonconst() = code_assignt(
               symbol_exprt(new_identifier, bool_typet()), true_exprt());
-            assignment.source_location=instruction.source_location;
+            assignment.source_location_nonconst() =
+              instruction.source_location();
 
             goto_program.insert_before_swap(i_it, assignment);
             i_it++;

--- a/src/goto-instrument/unwind.cpp
+++ b/src/goto-instrument/unwind.cpp
@@ -116,7 +116,7 @@ void goto_unwindt::unwind(
   if(unwind_strategy==unwind_strategyt::PARTIAL)
   {
     goto_programt::targett t =
-      rest_program.add(goto_programt::make_skip(loop_head->source_location));
+      rest_program.add(goto_programt::make_skip(loop_head->source_location()));
 
     t->location_number=loop_head->location_number;
 
@@ -157,7 +157,7 @@ void goto_unwindt::unwind(
     else
       UNREACHABLE;
 
-    new_t->source_location=loop_head->source_location;
+    new_t->source_location_nonconst() = loop_head->source_location();
     new_t->location_number=loop_head->location_number;
     unwind_log.insert(new_t, loop_head->location_number);
   }
@@ -183,7 +183,7 @@ void goto_unwindt::unwind(
         goto_programt::make_goto(
           goto_program.const_cast_target(loop_exit),
           true_exprt(),
-          loop_exit->source_location));
+          loop_exit->source_location()));
       t_goto->location_number=loop_exit->location_number;
 
       unwind_log.insert(t_goto, loop_exit->location_number);
@@ -192,7 +192,7 @@ void goto_unwindt::unwind(
     // add a skip before the loop exit
 
     goto_programt::targett t_skip = goto_program.insert_before(
-      loop_exit, goto_programt::make_skip(loop_head->source_location));
+      loop_exit, goto_programt::make_skip(loop_head->source_location()));
     t_skip->location_number=loop_head->location_number;
 
     unwind_log.insert(t_skip, loop_exit->location_number);
@@ -233,7 +233,7 @@ void goto_unwindt::unwind(
     // insert skip for loop body
 
     goto_programt::targett t_skip = goto_program.insert_before(
-      loop_head, goto_programt::make_skip(loop_head->source_location));
+      loop_head, goto_programt::make_skip(loop_head->source_location()));
     t_skip->location_number=loop_head->location_number;
 
     unwind_log.insert(t_skip, loop_head->location_number);

--- a/src/goto-instrument/value_set_fi_fp_removal.cpp
+++ b/src/goto-instrument/value_set_fi_fp_removal.cpp
@@ -122,7 +122,7 @@ void remove_function_pointer(
         as_const(*target).call_lhs(),
         fun,
         as_const(*target).call_arguments(),
-        target->source_location));
+        target->source_location()));
 
     // the signature of the function might not match precisely
     const namespacet ns(goto_model.symbol_table);
@@ -145,8 +145,8 @@ void remove_function_pointer(
 
   goto_programt::targett t =
     new_code_gotos.add(goto_programt::make_assertion(false_exprt()));
-  t->source_location.set_property_class("pointer dereference");
-  t->source_location.set_comment("invalid function pointer");
+  t->source_location_nonconst().set_property_class("pointer dereference");
+  t->source_location_nonconst().set_comment("invalid function pointer");
 
   goto_programt new_code;
 
@@ -158,13 +158,14 @@ void remove_function_pointer(
   // set locations
   for(auto &instruction : new_code.instructions)
   {
-    irep_idt property_class = instruction.source_location.get_property_class();
-    irep_idt comment = instruction.source_location.get_comment();
-    instruction.source_location = target->source_location;
+    irep_idt property_class =
+      instruction.source_location().get_property_class();
+    irep_idt comment = instruction.source_location().get_comment();
+    instruction.source_location_nonconst() = target->source_location();
     if(!property_class.empty())
-      instruction.source_location.set_property_class(property_class);
+      instruction.source_location_nonconst().set_property_class(property_class);
     if(!comment.empty())
-      instruction.source_location.set_comment(comment);
+      instruction.source_location_nonconst().set_comment(comment);
   }
 
   goto_programt::targett next_target = target;
@@ -205,7 +206,7 @@ void value_set_fi_fp_removal(
         const auto &function = as_const(*target).call_function();
         if(function.id() == ID_dereference)
         {
-          message.status() << "CALL at " << target->source_location << ":"
+          message.status() << "CALL at " << target->source_location() << ":"
                            << messaget::eom;
 
           const auto &pointer = to_dereference_expr(function).pointer();

--- a/src/goto-instrument/wmm/shared_buffers.cpp
+++ b/src/goto-instrument/wmm/shared_buffers.cpp
@@ -162,7 +162,7 @@ void shared_bufferst::assignment(
     t->type=ASSIGN;
     t->code_nonconst() = code_assignt(symbol, value);
     t->code_nonconst().add_source_location() = source_location;
-    t->source_location=source_location;
+    t->source_location_nonconst() = source_location;
 
     // instrumentations.insert((const irep_idt) (t->code.id()));
 
@@ -1112,8 +1112,8 @@ void shared_bufferst::cfg_visitort::weak_memory(
 
         goto_programt::instructiont original_instruction;
         original_instruction.swap(instruction);
-        const source_locationt &source_location=
-          original_instruction.source_location;
+        const source_locationt &source_location =
+          original_instruction.source_location();
 
         // ATOMIC_BEGIN: we make the whole thing atomic
         instruction = goto_programt::make_atomic_begin(source_location);
@@ -1296,8 +1296,8 @@ void shared_bufferst::cfg_visitort::weak_memory(
     {
       goto_programt::instructiont original_instruction;
       original_instruction.swap(instruction);
-      const source_locationt &source_location=
-        original_instruction.source_location;
+      const source_locationt &source_location =
+        original_instruction.source_location();
 
       // ATOMIC_BEGIN
       instruction = goto_programt::make_atomic_begin(source_location);
@@ -1322,7 +1322,7 @@ void shared_bufferst::cfg_visitort::weak_memory(
     else if(is_lwfence(instruction, ns))
     {
       // po -- remove the lwfence
-      *i_it = goto_programt::make_skip(i_it->source_location);
+      *i_it = goto_programt::make_skip(i_it->source_location());
     }
     else if(instruction.is_function_call())
     {

--- a/src/goto-instrument/wmm/weak_memory.cpp
+++ b/src/goto-instrument/wmm/weak_memory.cpp
@@ -55,7 +55,7 @@ void introduce_temporaries(
   {
     goto_programt::instructiont &instruction=*i_it;
 
-    message.debug() <<instruction.source_location<< messaget::eom;
+    message.debug() << instruction.source_location() << messaget::eom;
 
     if(instruction.is_goto() ||
        instruction.is_assert() ||
@@ -78,7 +78,7 @@ void introduce_temporaries(
         bool_typet(),
         id2string(function_id),
         "$tmp_guard",
-        instruction.source_location,
+        instruction.source_location(),
         ns.lookup(function_id).mode,
         symbol_table);
       new_symbol.is_static_lifetime=true;
@@ -89,7 +89,7 @@ void introduce_temporaries(
 
       goto_programt::instructiont new_i = goto_programt::make_assignment(
         code_assignt(symbol_expr, instruction.get_condition()),
-        instruction.source_location);
+        instruction.source_location());
 
       // replace guard
       instruction.set_condition(symbol_expr);

--- a/src/goto-programs/builtin_functions.cpp
+++ b/src/goto-programs/builtin_functions.cpp
@@ -696,7 +696,7 @@ void goto_convertt::do_function_call_symbol(
       typecast_exprt::conditional_cast(arguments.front(), bool_typet()),
       function.source_location()));
 
-    t->source_location.set("user-provided", true);
+    t->source_location_nonconst().set("user-provided", true);
 
     if(lhs.is_not_nil())
     {
@@ -717,8 +717,8 @@ void goto_convertt::do_function_call_symbol(
     goto_programt::targett t = dest.add(
       goto_programt::make_assertion(false_exprt(), function.source_location()));
 
-    t->source_location.set("user-provided", true);
-    t->source_location.set_property_class(ID_assertion);
+    t->source_location_nonconst().set("user-provided", true);
+    t->source_location_nonconst().set_property_class(ID_assertion);
 
     if(lhs.is_not_nil())
     {
@@ -731,7 +731,7 @@ void goto_convertt::do_function_call_symbol(
     // are being checked
     goto_programt::targett a = dest.add(goto_programt::make_assumption(
       false_exprt(), function.source_location()));
-    a->source_location.set("user-provided", true);
+    a->source_location_nonconst().set("user-provided", true);
   }
   else if(
     identifier == "assert" &&
@@ -748,9 +748,9 @@ void goto_convertt::do_function_call_symbol(
     goto_programt::targett t = dest.add(goto_programt::make_assertion(
       typecast_exprt::conditional_cast(arguments.front(), bool_typet()),
       function.source_location()));
-    t->source_location.set("user-provided", true);
-    t->source_location.set_property_class(ID_assertion);
-    t->source_location.set_comment(
+    t->source_location_nonconst().set("user-provided", true);
+    t->source_location_nonconst().set_property_class(ID_assertion);
+    t->source_location_nonconst().set_comment(
       "assertion " + from_expr(ns, identifier, arguments.front()));
 
     if(lhs.is_not_nil())
@@ -790,21 +790,20 @@ void goto_convertt::do_function_call_symbol(
 
     if(is_precondition)
     {
-      t->source_location.set_property_class(ID_precondition);
+      t->source_location_nonconst().set_property_class(ID_precondition);
     }
     else if(is_postcondition)
     {
-      t->source_location.set_property_class(ID_postcondition);
+      t->source_location_nonconst().set_property_class(ID_postcondition);
     }
     else
     {
-      t->source_location.set(
-        "user-provided",
-        !function.source_location().is_built_in());
-      t->source_location.set_property_class(ID_assertion);
+      t->source_location_nonconst().set(
+        "user-provided", !function.source_location().is_built_in());
+      t->source_location_nonconst().set_property_class(ID_assertion);
     }
 
-    t->source_location.set_comment(description);
+    t->source_location_nonconst().set_comment(description);
 
     if(lhs.is_not_nil())
     {
@@ -999,9 +998,9 @@ void goto_convertt::do_function_call_symbol(
     goto_programt::targett t = dest.add(
       goto_programt::make_assertion(false_exprt(), function.source_location()));
 
-    t->source_location.set("user-provided", true);
-    t->source_location.set_property_class(ID_assertion);
-    t->source_location.set_comment(description);
+    t->source_location_nonconst().set("user-provided", true);
+    t->source_location_nonconst().set_property_class(ID_assertion);
+    t->source_location_nonconst().set_comment(description);
     // we ignore any LHS
   }
   else if(identifier=="__assert_rtn" ||
@@ -1037,9 +1036,9 @@ void goto_convertt::do_function_call_symbol(
     goto_programt::targett t = dest.add(
       goto_programt::make_assertion(false_exprt(), function.source_location()));
 
-    t->source_location.set("user-provided", true);
-    t->source_location.set_property_class(ID_assertion);
-    t->source_location.set_comment(description);
+    t->source_location_nonconst().set("user-provided", true);
+    t->source_location_nonconst().set_property_class(ID_assertion);
+    t->source_location_nonconst().set_comment(description);
     // we ignore any LHS
   }
   else if(identifier=="__assert_func")
@@ -1071,9 +1070,9 @@ void goto_convertt::do_function_call_symbol(
     goto_programt::targett t = dest.add(
       goto_programt::make_assertion(false_exprt(), function.source_location()));
 
-    t->source_location.set("user-provided", true);
-    t->source_location.set_property_class(ID_assertion);
-    t->source_location.set_comment(description);
+    t->source_location_nonconst().set("user-provided", true);
+    t->source_location_nonconst().set_property_class(ID_assertion);
+    t->source_location_nonconst().set_comment(description);
     // we ignore any LHS
   }
   else if(identifier==CPROVER_PREFIX "fence")

--- a/src/goto-programs/goto_convert.cpp
+++ b/src/goto-programs/goto_convert.cpp
@@ -164,21 +164,21 @@ void goto_convertt::finish_gotos(goto_programt &dest, const irep_idt &mode)
         // is illegal for C++ non-pod types and impossible in Java in any case.
         if(not_prefix)
         {
-          debug().source_location = i.source_location;
+          debug().source_location = i.source_location();
           debug() << "encountered goto '" << goto_label
                   << "' that enters one or more lexical blocks; "
                   << "omitting constructors and destructors" << eom;
         }
         else
         {
-          debug().source_location = i.source_location;
+          debug().source_location = i.source_location();
           debug() << "adding goto-destructor code on jump to '" << goto_label
                   << "'" << eom;
 
           node_indext end_destruct = intersection_result.common_ancestor;
           goto_programt destructor_code;
           unwind_destructor_stack(
-            i.source_location,
+            i.source_location(),
             destructor_code,
             mode,
             end_destruct,
@@ -221,7 +221,8 @@ void goto_convertt::finish_computed_gotos(goto_programt &goto_program)
 
       goto_program.insert_after(
         g_it,
-        goto_programt::make_goto(label.second.first, guard, i.source_location));
+        goto_programt::make_goto(
+          label.second.first, guard, i.source_location()));
     }
   }
 
@@ -833,8 +834,8 @@ void goto_convertt::convert_assert(
 
   goto_programt::targett t =
     dest.add(goto_programt::make_assertion(cond, code.source_location()));
-  t->source_location.set(ID_property, ID_assertion);
-  t->source_location.set("user-provided", true);
+  t->source_location_nonconst().set(ID_property, ID_assertion);
+  t->source_location_nonconst().set("user-provided", true);
 }
 
 void goto_convertt::convert_skip(
@@ -1228,7 +1229,7 @@ void goto_convertt::convert_switch(
   }
 
   tmp_cases.add(goto_programt::make_goto(
-    targets.default_target, targets.default_target->source_location));
+    targets.default_target, targets.default_target->source_location()));
 
   dest.destructive_append(sideeffects);
   dest.destructive_append(tmp_cases);
@@ -1607,7 +1608,7 @@ void goto_convertt::generate_ifthenelse(
   // x: goto z;
   CHECK_RETURN(!tmp_w.instructions.empty());
   x->complete_goto(z);
-  x->source_location = tmp_w.instructions.back().source_location;
+  x->source_location_nonconst() = tmp_w.instructions.back().source_location();
 
   dest.destructive_append(tmp_v);
   dest.destructive_append(tmp_w);
@@ -1934,7 +1935,7 @@ void goto_convertt::generate_thread_block(
     END_THREAD,
     nil_exprt(),
     {}));
-  e->source_location=thread_body.source_location();
+  e->source_location_nonconst() = thread_body.source_location();
   goto_programt::targett z = postamble.add(goto_programt::make_skip());
 
   preamble.add(goto_programt::instructiont(

--- a/src/goto-programs/goto_convert_functions.cpp
+++ b/src/goto-programs/goto_convert_functions.cpp
@@ -208,7 +208,8 @@ void goto_convert_functionst::convert_function(
   {
     goto_programt::instructiont a_begin;
     a_begin = goto_programt::make_atomic_begin();
-    a_begin.source_location = f.body.instructions.front().source_location;
+    a_begin.source_location_nonconst() =
+      f.body.instructions.front().source_location();
     f.body.insert_before_swap(f.body.instructions.begin(), a_begin);
 
     goto_programt::targett a_end =

--- a/src/goto-programs/goto_inline_class.cpp
+++ b/src/goto-programs/goto_inline_class.cpp
@@ -30,7 +30,7 @@ void goto_inlinet::parameter_assignments(
   PRECONDITION(target->is_function_call());
   PRECONDITION(dest.empty());
 
-  const source_locationt &source_location=target->source_location;
+  const source_locationt &source_location = target->source_location();
 
   // iterates over the operands
   exprt::operandst::const_iterator it1=arguments.begin();
@@ -129,7 +129,7 @@ void goto_inlinet::parameter_destruction(
   PRECONDITION(target->is_function_call());
   PRECONDITION(dest.empty());
 
-  const source_locationt &source_location=target->source_location;
+  const source_locationt &source_location = target->source_location();
 
   for(const auto &identifier : parameter_identifiers)
   {
@@ -277,13 +277,14 @@ void goto_inlinet::insert_function_body(
   {
     for(auto &instruction : tmp.instructions)
     {
-      replace_location(instruction.source_location, target->source_location);
-      replace_location(instruction.code_nonconst(), target->source_location);
+      replace_location(
+        instruction.source_location_nonconst(), target->source_location());
+      replace_location(instruction.code_nonconst(), target->source_location());
 
       if(instruction.has_condition())
       {
         replace_location(
-          instruction.condition_nonconst(), target->source_location);
+          instruction.condition_nonconst(), target->source_location());
       }
     }
   }

--- a/src/goto-programs/goto_program.cpp
+++ b/src/goto-programs/goto_program.cpp
@@ -52,8 +52,8 @@ std::ostream &goto_programt::output_instruction(
 {
   out << "        // " << instruction.location_number << " ";
 
-  if(!instruction.source_location.is_nil())
-    out << instruction.source_location.as_string();
+  if(!instruction.source_location().is_nil())
+    out << instruction.source_location().as_string();
   else
     out << "no location";
 
@@ -171,7 +171,7 @@ std::ostream &goto_programt::output_instruction(
     {
       out << format(instruction.get_condition());
 
-      const irep_idt &comment=instruction.source_location.get_comment();
+      const irep_idt &comment = instruction.source_location().get_comment();
       if(!comment.empty())
         out << " // " << comment;
     }
@@ -518,7 +518,7 @@ std::string as_string(
     result += from_expr(ns, function, i.get_condition());
 
     {
-      const irep_idt &comment=i.source_location.get_comment();
+      const irep_idt &comment = i.source_location().get_comment();
       if(!comment.empty())
         result+=" /* "+id2string(comment)+" */";
     }
@@ -759,11 +759,11 @@ void goto_programt::instructiont::validate(
         vm,
         !ns.lookup(identifier, symbol),
         id2string(identifier) + " not found",
-        source_location);
+        source_location());
     }
   };
 
-  auto &current_source_location = source_location;
+  auto &current_source_location = source_location();
   auto type_finder =
     [&ns, vm, &current_source_location](const exprt &e) {
       if(e.id() == ID_symbol)
@@ -841,27 +841,27 @@ void goto_programt::instructiont::validate(
       vm,
       has_target(),
       "goto instruction expects at least one target",
-      source_location);
+      source_location());
     // get_target checks that targets.size()==1
     DATA_CHECK_WITH_DIAGNOSTICS(
       vm,
       get_target()->is_target() && get_target()->target_number != 0,
       "goto target has to be a target",
-      source_location);
+      source_location());
     break;
   case ASSUME:
     DATA_CHECK_WITH_DIAGNOSTICS(
       vm,
       targets.empty(),
       "assume instruction should not have a target",
-      source_location);
+      source_location());
     break;
   case ASSERT:
     DATA_CHECK_WITH_DIAGNOSTICS(
       vm,
       targets.empty(),
       "assert instruction should not have a target",
-      source_location);
+      source_location());
 
     std::for_each(guard.depth_begin(), guard.depth_end(), expr_symbol_finder);
     std::for_each(guard.depth_begin(), guard.depth_end(), type_finder);
@@ -887,7 +887,7 @@ void goto_programt::instructiont::validate(
       vm,
       code.get_statement() == ID_return,
       "SET_RETURN_VALUE instruction should contain a return statement",
-      source_location);
+      source_location());
     break;
   case ASSIGN:
     DATA_CHECK(
@@ -902,33 +902,33 @@ void goto_programt::instructiont::validate(
       vm,
       code.get_statement() == ID_decl,
       "declaration instructions should contain a declaration statement",
-      source_location);
+      source_location());
     DATA_CHECK_WITH_DIAGNOSTICS(
       vm,
       !ns.lookup(decl_symbol().get_identifier(), table_symbol),
       "declared symbols should be known",
       id2string(decl_symbol().get_identifier()),
-      source_location);
+      source_location());
     break;
   case DEAD:
     DATA_CHECK_WITH_DIAGNOSTICS(
       vm,
       code.get_statement() == ID_dead,
       "dead instructions should contain a dead statement",
-      source_location);
+      source_location());
     DATA_CHECK_WITH_DIAGNOSTICS(
       vm,
       !ns.lookup(dead_symbol().get_identifier(), table_symbol),
       "removed symbols should be known",
       id2string(dead_symbol().get_identifier()),
-      source_location);
+      source_location());
     break;
   case FUNCTION_CALL:
     DATA_CHECK_WITH_DIAGNOSTICS(
       vm,
       code.get_statement() == ID_function_call,
       "function call instruction should contain a call statement",
-      source_location);
+      source_location());
 
     std::for_each(code.depth_begin(), code.depth_end(), expr_symbol_finder);
     std::for_each(code.depth_begin(), code.depth_end(), type_finder);

--- a/src/goto-programs/goto_program.h
+++ b/src/goto-programs/goto_program.h
@@ -321,8 +321,21 @@ public:
       code = std::move(c);
     }
 
-    /// The location of the instruction in the source file
-    source_locationt source_location;
+    /// The location of the instruction in the source file.
+    /// Use source_location() to access.
+  protected:
+    source_locationt _source_location;
+
+  public:
+    const source_locationt &source_location() const
+    {
+      return _source_location;
+    }
+
+    source_locationt &source_location_nonconst()
+    {
+      return _source_location;
+    }
 
     /// What kind of instruction?
     goto_program_instruction_typet type;
@@ -463,7 +476,7 @@ public:
 
     explicit instructiont(goto_program_instruction_typet _type)
       : code(static_cast<const codet &>(get_nil_irep())),
-        source_location(static_cast<const source_locationt &>(get_nil_irep())),
+        _source_location(static_cast<const source_locationt &>(get_nil_irep())),
         type(_type),
         guard(true_exprt())
     {
@@ -472,12 +485,12 @@ public:
     /// Constructor that can set all members, passed by value
     instructiont(
       codet _code,
-      source_locationt _source_location,
+      source_locationt __source_location,
       goto_program_instruction_typet _type,
       exprt _guard,
       targetst _targets)
       : code(std::move(_code)),
-        source_location(std::move(_source_location)),
+        _source_location(std::move(__source_location)),
         type(_type),
         guard(std::move(_guard)),
         targets(std::move(_targets))
@@ -489,7 +502,7 @@ public:
     {
       using std::swap;
       swap(instruction.code, code);
-      swap(instruction.source_location, source_location);
+      swap(instruction._source_location, _source_location);
       swap(instruction.type, type);
       swap(instruction.guard, guard);
       swap(instruction.targets, targets);

--- a/src/goto-programs/goto_trace.cpp
+++ b/src/goto-programs/goto_trace.cpp
@@ -112,8 +112,8 @@ void goto_trace_stept::output(
         << '\n';
   }
 
-  if(!pc->source_location.is_nil())
-    out << pc->source_location << '\n';
+  if(!pc->source_location().is_nil())
+    out << pc->source_location() << '\n';
 
   out << pc->type << '\n';
 
@@ -122,8 +122,8 @@ void goto_trace_stept::output(
     if(!cond_value)
     {
       out << "Violated property:" << '\n';
-      if(pc->source_location.is_nil())
-        out << "  " << pc->source_location << '\n';
+      if(pc->source_location().is_nil())
+        out << "  " << pc->source_location() << '\n';
 
       if(!comment.empty())
         out << "  " << comment << '\n';
@@ -312,7 +312,7 @@ state_location(const goto_trace_stept &state, const namespacet &ns)
 {
   std::string result;
 
-  const auto &source_location = state.pc->source_location;
+  const auto &source_location = state.pc->source_location();
 
   if(!source_location.get_file().empty())
     result += "file " + id2string(source_location.get_file());
@@ -406,7 +406,7 @@ void show_compact_goto_trace(
       {
         out << '\n';
         out << messaget::red << "Violated property:" << messaget::reset << '\n';
-        if(!step.pc->source_location.is_nil())
+        if(!step.pc->source_location().is_nil())
           out << "  " << state_location(step, ns) << '\n';
 
         out << "  " << messaget::red << step.comment << messaget::reset << '\n';
@@ -432,9 +432,9 @@ void show_compact_goto_trace(
 
       out << "  ";
 
-      if(!step.pc->source_location.get_line().empty())
+      if(!step.pc->source_location().get_line().empty())
       {
-        out << messaget::faint << step.pc->source_location.get_line() << ':'
+        out << messaget::faint << step.pc->source_location().get_line() << ':'
             << messaget::reset << ' ';
       }
 
@@ -450,13 +450,14 @@ void show_compact_goto_trace(
     case goto_trace_stept::typet::FUNCTION_CALL:
       // downwards arrow
       out << '\n' << messaget::faint << u8"\u21b3" << messaget::reset << ' ';
-      if(!step.pc->source_location.get_file().empty())
+      if(!step.pc->source_location().get_file().empty())
       {
-        out << messaget::faint << step.pc->source_location.get_file();
+        out << messaget::faint << step.pc->source_location().get_file();
 
-        if(!step.pc->source_location.get_line().empty())
+        if(!step.pc->source_location().get_line().empty())
         {
-          out << messaget::faint << ':' << step.pc->source_location.get_line();
+          out << messaget::faint << ':'
+              << step.pc->source_location().get_line();
         }
 
         out << messaget::reset << ' ';
@@ -531,7 +532,7 @@ void show_full_goto_trace(
       {
         out << '\n';
         out << messaget::red << "Violated property:" << messaget::reset << '\n';
-        if(!step.pc->source_location.is_nil())
+        if(!step.pc->source_location().is_nil())
         {
           out << "  " << state_location(step, ns) << '\n';
         }
@@ -555,8 +556,8 @@ void show_full_goto_trace(
         out << "\n";
         out << "Assumption:\n";
 
-        if(!step.pc->source_location.is_nil())
-          out << "  " << step.pc->source_location << '\n';
+        if(!step.pc->source_location().is_nil())
+          out << "  " << step.pc->source_location() << '\n';
 
         out << "  " << from_expr(ns, step.function_id, step.pc->get_condition())
             << '\n';
@@ -751,8 +752,8 @@ static void show_goto_stack_trace(
     if(step.is_assert())
     {
       out << "  assertion failure";
-      if(!step.pc->source_location.is_nil())
-        out << ' ' << step.pc->source_location;
+      if(!step.pc->source_location().is_nil())
+        out << ' ' << step.pc->source_location();
       out << '\n';
     }
     else if(step.is_function_call())
@@ -773,8 +774,8 @@ static void show_goto_stack_trace(
 
       out << ')';
 
-      if(!step.pc->source_location.is_nil())
-        out << ' ' << step.pc->source_location;
+      if(!step.pc->source_location().is_nil())
+        out << ' ' << step.pc->source_location();
 
       out << '\n';
     }

--- a/src/goto-programs/graphml_witness.cpp
+++ b/src/goto-programs/graphml_witness.cpp
@@ -243,14 +243,15 @@ static bool filter_out(
   // we filter out steps with the same source location
   // TODO: if these are assignments we should accumulate them into
   //       a single edge
-  if(prev_it!=goto_trace.steps.end() &&
-     prev_it->pc->source_location==it->pc->source_location)
+  if(
+    prev_it != goto_trace.steps.end() &&
+    prev_it->pc->source_location() == it->pc->source_location())
     return true;
 
   if(it->is_goto() && it->pc->get_condition().is_true())
     return true;
 
-  const source_locationt &source_location=it->pc->source_location;
+  const source_locationt &source_location = it->pc->source_location();
 
   if(source_location.is_nil() ||
      source_location.get_file().empty() ||
@@ -362,10 +363,11 @@ void graphml_witnesst::operator()(const goto_tracet &goto_trace)
     // skip declarations followed by an immediate assignment
     goto_tracet::stepst::const_iterator next=it;
     ++next;
-    if(next!=goto_trace.steps.end() &&
-       next->type==goto_trace_stept::typet::ASSIGNMENT &&
-       it->full_lhs==next->full_lhs &&
-       it->pc->source_location==next->pc->source_location)
+    if(
+      next != goto_trace.steps.end() &&
+      next->type == goto_trace_stept::typet::ASSIGNMENT &&
+      it->full_lhs == next->full_lhs &&
+      it->pc->source_location() == next->pc->source_location())
     {
       step_to_node[it->step_nr]=sink;
 
@@ -374,7 +376,7 @@ void graphml_witnesst::operator()(const goto_tracet &goto_trace)
 
     prev_it=it;
 
-    const source_locationt &source_location=it->pc->source_location;
+    const source_locationt &source_location = it->pc->source_location();
 
     const graphmlt::node_indext node=graphml.add_node();
     graphml[node].node_name=
@@ -546,7 +548,7 @@ void graphml_witnesst::operator()(const symex_target_equationt &equation)
       it!=equation.SSA_steps.end();
       it++, step_nr++) // we cannot replace this by a ranged for
   {
-    const source_locationt &source_location=it->source.pc->source_location;
+    const source_locationt &source_location = it->source.pc->source_location();
 
     if(
       it->hidden ||
@@ -563,10 +565,10 @@ void graphml_witnesst::operator()(const symex_target_equationt &equation)
     // skip declarations followed by an immediate assignment
     symex_target_equationt::SSA_stepst::const_iterator next=it;
     ++next;
-    if(next!=equation.SSA_steps.end() &&
-       next->is_assignment() &&
-       it->ssa_full_lhs==next->ssa_full_lhs &&
-       it->source.pc->source_location==next->source.pc->source_location)
+    if(
+      next != equation.SSA_steps.end() && next->is_assignment() &&
+      it->ssa_full_lhs == next->ssa_full_lhs &&
+      it->source.pc->source_location() == next->source.pc->source_location())
     {
       step_to_node[step_nr]=sink;
 

--- a/src/goto-programs/instrument_preconditions.cpp
+++ b/src/goto-programs/instrument_preconditions.cpp
@@ -37,9 +37,12 @@ std::vector<goto_programt::const_targett> get_preconditions(
        i_it->is_skip())
       continue; // ignore
 
-    if(i_it->is_assert() &&
-       i_it->source_location.get_property_class()==ID_precondition)
+    if(
+      i_it->is_assert() &&
+      i_it->source_location().get_property_class() == ID_precondition)
+    {
       result.push_back(i_it);
+    }
     else
       break; // preconditions must be at the front
   }
@@ -55,9 +58,12 @@ void remove_preconditions(goto_programt &goto_program)
        instruction.is_skip())
       continue; // ignore
 
-    if(instruction.is_assert() &&
-       instruction.source_location.get_property_class()==ID_precondition)
+    if(
+      instruction.is_assert() &&
+      instruction.source_location().get_property_class() == ID_precondition)
+    {
       instruction.type=LOCATION;
+    }
     else
       break; // preconditions must be at the front
   }
@@ -109,7 +115,7 @@ void instrument_preconditions(
           to_symbol_expr(as_const(*it).call_function()),
           goto_model.goto_functions);
 
-        source_locationt source_location=it->source_location;
+        source_locationt source_location = it->source_location();
 
         replace_symbolt r = actuals_replace_map(
           as_const(*it).call_lhs(),
@@ -124,8 +130,10 @@ void instrument_preconditions(
           exprt instance = p->get_condition();
           r(instance);
           *it = goto_programt::make_assertion(instance, source_location);
-          it->source_location.set_property_class(ID_precondition_instance);
-          it->source_location.set_comment(p->source_location.get_comment());
+          it->source_location_nonconst().set_property_class(
+            ID_precondition_instance);
+          it->source_location_nonconst().set_comment(
+            p->source_location().get_comment());
           it++;
         }
       }

--- a/src/goto-programs/json_goto_trace.h
+++ b/src/goto-programs/json_goto_trace.h
@@ -120,7 +120,7 @@ void convert(
 
   for(const auto &step : goto_trace.steps)
   {
-    const source_locationt &source_location = step.pc->source_location;
+    const source_locationt &source_location = step.pc->source_location();
 
     jsont json_location;
 

--- a/src/goto-programs/label_function_pointer_call_sites.cpp
+++ b/src/goto-programs/label_function_pointer_call_sites.cpp
@@ -27,7 +27,7 @@ void label_function_pointer_call_sites(goto_modelt &goto_model)
       [&](goto_programt::targett &it) {
         auto const &function_pointer_dereference =
           to_dereference_expr(it->call_function());
-        auto const &source_location = it->source_location;
+        auto const &source_location = it->source_location();
         auto const &goto_function_symbol_mode =
           goto_model.symbol_table.lookup_ref(goto_function.first).mode;
 
@@ -42,7 +42,7 @@ void label_function_pointer_call_sites(goto_modelt &goto_model)
             function_call_site_symbol.pretty_name = call_site_symbol_name;
           function_call_site_symbol.type =
             function_pointer_dereference.pointer().type();
-          function_call_site_symbol.location = it->source_location;
+          function_call_site_symbol.location = it->source_location();
           function_call_site_symbol.is_lvalue = true;
           function_call_site_symbol.mode = goto_function_symbol_mode;
           return function_call_site_symbol;

--- a/src/goto-programs/loop_ids.cpp
+++ b/src/goto-programs/loop_ids.cpp
@@ -42,7 +42,7 @@ void show_loop_ids(
                     << goto_programt::loop_id(function_id, instruction) << ":"
                     << "\n";
 
-          std::cout << "  " << instruction.source_location << "\n";
+          std::cout << "  " << instruction.source_location() << "\n";
           std::cout << "\n";
         }
       }
@@ -59,7 +59,7 @@ void show_loop_ids(
 
           xmlt xml_loop("loop", {{"name", id}}, {});
           xml_loop.new_element("loop-id").data=id;
-          xml_loop.new_element() = xml(instruction.source_location);
+          xml_loop.new_element() = xml(instruction.source_location());
           std::cout << xml_loop << "\n";
         }
       }
@@ -85,9 +85,9 @@ void show_loop_ids_json(
       std::string id =
         id2string(goto_programt::loop_id(function_id, instruction));
 
-      loops.push_back(
-        json_objectt({{"name", json_stringt(id)},
-                      {"sourceLocation", json(instruction.source_location)}}));
+      loops.push_back(json_objectt(
+        {{"name", json_stringt(id)},
+         {"sourceLocation", json(instruction.source_location())}}));
     }
   }
 }

--- a/src/goto-programs/mm_io.cpp
+++ b/src/goto-programs/mm_io.cpp
@@ -57,7 +57,7 @@ void mm_io(
         if(deref_expr_r.size()==1)
         {
           const dereference_exprt &d=*deref_expr_r.begin();
-          source_locationt source_location=it->source_location;
+          source_locationt source_location = it->source_location();
           const code_typet &ct=to_code_type(mm_io_r.type());
 
           irep_idt identifier=to_symbol_expr(mm_io_r).get_identifier();
@@ -84,7 +84,7 @@ void mm_io(
         if(a_lhs.id() == ID_dereference)
         {
           const dereference_exprt &d = to_dereference_expr(a_lhs);
-          source_locationt source_location=it->source_location;
+          source_locationt source_location = it->source_location();
           const code_typet &ct=to_code_type(mm_io_w.type());
           const typet &pt=ct.parameters()[0].type();
           const typet &st=ct.parameters()[1].type();

--- a/src/goto-programs/parameter_assignments.cpp
+++ b/src/goto-programs/parameter_assignments.cpp
@@ -71,7 +71,7 @@ void parameter_assignmentst::do_function_calls(
           exprt rhs = typecast_exprt::conditional_cast(
             as_const(*i_it).call_arguments()[nr], lhs.type());
           tmp.add(goto_programt::make_assignment(
-            code_assignt(lhs, rhs), i_it->source_location));
+            code_assignt(lhs, rhs), i_it->source_location()));
         }
       }
 

--- a/src/goto-programs/read_bin_goto_object.cpp
+++ b/src/goto-programs/read_bin_goto_object.cpp
@@ -101,8 +101,9 @@ static bool read_bin_goto_object(
 
       instruction.code_nonconst() =
         static_cast<const codet &>(irepconverter.reference_convert(in));
-      instruction.source_location = static_cast<const source_locationt &>(
-        irepconverter.reference_convert(in));
+      instruction.source_location_nonconst() =
+        static_cast<const source_locationt &>(
+          irepconverter.reference_convert(in));
       instruction.type = (goto_program_instruction_typet)
                               irepconverter.read_gb_word(in);
       instruction.guard =

--- a/src/goto-programs/remove_calls_no_body.cpp
+++ b/src/goto-programs/remove_calls_no_body.cpp
@@ -36,18 +36,18 @@ void remove_calls_no_bodyt::remove_call_no_body(
   for(const exprt &argument : arguments)
   {
     tmp.add(goto_programt::make_other(
-      code_expressiont(argument), target->source_location));
+      code_expressiont(argument), target->source_location()));
   }
 
   // return value
   if(lhs.is_not_nil())
   {
-    side_effect_expr_nondett rhs(lhs.type(), target->source_location);
+    side_effect_expr_nondett rhs(lhs.type(), target->source_location());
 
     code_assignt code(lhs, rhs);
-    code.add_source_location() = target->source_location;
+    code.add_source_location() = target->source_location();
 
-    tmp.add(goto_programt::make_assignment(code, target->source_location));
+    tmp.add(goto_programt::make_assignment(code, target->source_location()));
   }
 
   // kill call

--- a/src/goto-programs/remove_function_pointers.cpp
+++ b/src/goto-programs/remove_function_pointers.cpp
@@ -410,8 +410,8 @@ void remove_function_pointerst::remove_function_pointer(
   {
     goto_programt::targett t =
       new_code_gotos.add(goto_programt::make_assertion(false_exprt()));
-    t->source_location.set_property_class("pointer dereference");
-    t->source_location.set_comment("invalid function pointer");
+    t->source_location_nonconst().set_property_class("pointer dereference");
+    t->source_location_nonconst().set_comment("invalid function pointer");
   }
   new_code_gotos.add(goto_programt::make_assumption(false_exprt()));
 
@@ -425,11 +425,11 @@ void remove_function_pointerst::remove_function_pointer(
   // set locations
   for(auto &instruction : new_code.instructions)
   {
-    source_locationt &source_location = instruction.source_location;
+    source_locationt &source_location = instruction.source_location_nonconst();
 
     irep_idt property_class = source_location.get_property_class();
     irep_idt comment = source_location.get_comment();
-    source_location = target->source_location;
+    source_location = target->source_location();
     if(!property_class.empty())
       source_location.set_property_class(property_class);
     if(!comment.empty())
@@ -449,7 +449,7 @@ void remove_function_pointerst::remove_function_pointer(
   target->type=OTHER;
 
   // report statistics
-  log.statistics().source_location = target->source_location;
+  log.statistics().source_location = target->source_location();
   log.statistics() << "replacing function pointer by " << functions.size()
                    << " possible targets" << messaget::eom;
 

--- a/src/goto-programs/remove_returns.cpp
+++ b/src/goto-programs/remove_returns.cpp
@@ -128,7 +128,7 @@ void remove_returnst::replace_returns(
 
         // now turn the `return' into `assignment'
         instruction = goto_programt::make_assignment(
-          assignment, instruction.source_location);
+          assignment, instruction.source_location());
       }
       else
         instruction.turn_into_skip();
@@ -185,13 +185,13 @@ bool remove_returnst::do_function_calls(
         else
         {
           rhs = side_effect_expr_nondett(
-            i_it->call_lhs().type(), i_it->source_location);
+            i_it->call_lhs().type(), i_it->source_location());
         }
 
         goto_programt::targett t_a = goto_program.insert_after(
           i_it,
           goto_programt::make_assignment(
-            code_assignt(i_it->call_lhs(), rhs), i_it->source_location));
+            code_assignt(i_it->call_lhs(), rhs), i_it->source_location()));
 
         // fry the previous assignment
         i_it->call_lhs().make_nil();
@@ -200,7 +200,7 @@ bool remove_returnst::do_function_calls(
         {
           goto_program.insert_after(
             t_a,
-            goto_programt::make_dead(*return_value, i_it->source_location));
+            goto_programt::make_dead(*return_value, i_it->source_location()));
         }
 
         requires_update = true;
@@ -315,7 +315,7 @@ bool remove_returnst::restore_returns(
       // replace "fkt#return_value=x;" by "return x;"
       const exprt rhs = instruction.assign_rhs();
       instruction = goto_programt::make_return(
-        code_returnt(rhs), instruction.source_location);
+        code_returnt(rhs), instruction.source_location());
       did_something = true;
     }
   }

--- a/src/goto-programs/remove_virtual_functions.cpp
+++ b/src/goto-programs/remove_virtual_functions.cpp
@@ -298,7 +298,7 @@ static goto_programt::targett replace_virtual_function_with_dispatch_table(
     return next_target;
   }
 
-  const auto &vcall_source_loc=target->source_location;
+  const auto &vcall_source_loc = target->source_location();
 
   code_function_callt code(
     target->call_lhs(), target->call_function(), target->call_arguments());
@@ -380,7 +380,7 @@ static goto_programt::targett replace_virtual_function_with_dispatch_table(
           goto_programt::make_assertion(false_exprt(), vcall_source_loc));
 
         // No definition for this type; shouldn't be possible...
-        t1->source_location.set_comment(
+        t1->source_location_nonconst().set_comment(
           "cannot find calls for " +
           id2string(code.function().get(ID_identifier)) + " dispatching " +
           id2string(fun.class_id));
@@ -443,11 +443,11 @@ static goto_programt::targett replace_virtual_function_with_dispatch_table(
   // set locations
   for(auto &instruction : new_code.instructions)
   {
-    source_locationt &source_location = instruction.source_location;
+    source_locationt &source_location = instruction.source_location_nonconst();
 
     const irep_idt property_class = source_location.get_property_class();
     const irep_idt comment = source_location.get_comment();
-    source_location = target->source_location;
+    source_location = target->source_location();
     if(!property_class.empty())
       source_location.set_property_class(property_class);
     if(!comment.empty())

--- a/src/goto-programs/restrict_function_pointers.cpp
+++ b/src/goto-programs/restrict_function_pointers.cpp
@@ -105,12 +105,12 @@ void restrict_function_pointer(
   *location = goto_programt::make_assertion(
     false_exprt{},
     make_function_pointer_restriction_assertion_source_location(
-      original_function_call_instruction.source_location, restriction));
+      original_function_call_instruction.source_location(), restriction));
 
   auto const assume_false_location = goto_function.body.insert_after(
     location,
     goto_programt::make_assumption(
-      false_exprt{}, original_function_call_instruction.source_location));
+      false_exprt{}, original_function_call_instruction.source_location()));
 
   // this is mutable because we'll update this at the end of each
   // loop iteration to always point at the start of the branch
@@ -131,7 +131,7 @@ void restrict_function_pointer(
     auto const goto_end_if_location = goto_function.body.insert_before(
       else_location,
       goto_programt::make_goto(
-        end_if_location, original_function_call_instruction.source_location));
+        end_if_location, original_function_call_instruction.source_location()));
     auto const replaced_instruction_location =
       goto_function.body.insert_before(goto_end_if_location, new_instruction);
     else_location = goto_function.body.insert_before(

--- a/src/goto-programs/set_properties.cpp
+++ b/src/goto-programs/set_properties.cpp
@@ -30,7 +30,7 @@ void set_properties(
     if(!it->is_assert())
       continue;
 
-    irep_idt property_id=it->source_location.get_property_id();
+    irep_idt property_id = it->source_location().get_property_id();
 
     std::unordered_set<irep_idt>::iterator c_it =
       property_set.find(property_id);
@@ -59,16 +59,16 @@ void label_properties(
     if(!it->is_assert())
       continue;
 
-    irep_idt function=it->source_location.get_function();
+    irep_idt function = it->source_location().get_function();
 
     std::string prefix=id2string(function);
-    if(!it->source_location.get_property_class().empty())
+    if(!it->source_location().get_property_class().empty())
     {
       if(!prefix.empty())
         prefix+=".";
 
-      std::string class_infix=
-        id2string(it->source_location.get_property_class());
+      std::string class_infix =
+        id2string(it->source_location().get_property_class());
 
       // replace the spaces by underscores
       std::replace(class_infix.begin(), class_infix.end(), ' ', '_');
@@ -85,7 +85,7 @@ void label_properties(
 
     std::string property_id=prefix+std::to_string(count);
 
-    it->source_location.set_property_id(property_id);
+    it->source_location_nonconst().set_property_id(property_id);
   }
 }
 

--- a/src/goto-programs/show_properties.cpp
+++ b/src/goto-programs/show_properties.cpp
@@ -31,9 +31,9 @@ optionalt<source_locationt> find_property(
     {
       if(ins.is_assert())
       {
-        if(ins.source_location.get_property_id() == property)
+        if(ins.source_location().get_property_id() == property)
         {
-          return ins.source_location;
+          return ins.source_location();
         }
       }
     }
@@ -54,7 +54,7 @@ void show_properties(
     if(!ins.is_assert())
       continue;
 
-    const source_locationt &source_location=ins.source_location;
+    const source_locationt &source_location = ins.source_location();
 
     const irep_idt &comment=source_location.get_comment();
     const irep_idt &property_class=source_location.get_property_class();
@@ -91,7 +91,7 @@ void show_properties(
     case ui_message_handlert::uit::PLAIN:
       msg.result() << "Property " << property_id << ":\n";
 
-      msg.result() << "  " << ins.source_location << '\n'
+      msg.result() << "  " << ins.source_location() << '\n'
                    << "  " << description << '\n'
                    << "  " << from_expr(ns, identifier, ins.get_condition())
                    << '\n';
@@ -116,7 +116,7 @@ void convert_properties_json(
     if(!ins.is_assert())
       continue;
 
-    const source_locationt &source_location=ins.source_location;
+    const source_locationt &source_location = ins.source_location();
 
     const irep_idt &comment=source_location.get_comment();
     // const irep_idt &function=location.get_function();

--- a/src/goto-programs/string_abstraction.cpp
+++ b/src/goto-programs/string_abstraction.cpp
@@ -301,8 +301,8 @@ void string_abstractiont::make_decl_and_def(goto_programt &dest,
   symbol_exprt sym_expr=symbol.symbol_expr();
 
   goto_programt::targett decl1 =
-    dest.add(goto_programt::make_decl(sym_expr, ref_instr->source_location));
-  decl1->code_nonconst().add_source_location() = ref_instr->source_location;
+    dest.add(goto_programt::make_decl(sym_expr, ref_instr->source_location()));
+  decl1->code_nonconst().add_source_location() = ref_instr->source_location();
 
   exprt val=symbol.value;
   // initialize pointers with suitable objects
@@ -317,9 +317,9 @@ void string_abstractiont::make_decl_and_def(goto_programt &dest,
   {
     goto_programt::targett assignment1 =
       dest.add(goto_programt::make_assignment(
-        code_assignt(sym_expr, val), ref_instr->source_location));
+        code_assignt(sym_expr, val), ref_instr->source_location()));
     assignment1->code_nonconst().add_source_location() =
-      ref_instr->source_location;
+      ref_instr->source_location();
   }
 }
 
@@ -377,9 +377,9 @@ exprt string_abstractiont::make_val_or_dummy_rec(goto_programt &dest,
 
         goto_programt::targett assignment1 =
           dest.add(goto_programt::make_assignment(
-            code_assignt(member, sym_expr), ref_instr->source_location));
+            code_assignt(member, sym_expr), ref_instr->source_location()));
         assignment1->code_nonconst().add_source_location() =
-          ref_instr->source_location;
+          ref_instr->source_location();
       }
 
       ++seen;
@@ -411,7 +411,7 @@ symbol_exprt string_abstractiont::add_dummy_symbol_and_value(
   auxiliary_symbolt new_symbol;
   new_symbol.type=type;
   new_symbol.value.make_nil();
-  new_symbol.location=ref_instr->source_location;
+  new_symbol.location = ref_instr->source_location();
   new_symbol.name=dummy_identifier;
   new_symbol.module=symbol.module;
   new_symbol.base_name=id2string(symbol.base_name)+suffix;
@@ -423,8 +423,8 @@ symbol_exprt string_abstractiont::add_dummy_symbol_and_value(
 
   // make sure it is declared before the recursive call
   goto_programt::targett decl =
-    dest.add(goto_programt::make_decl(sym_expr, ref_instr->source_location));
-  decl->code_nonconst().add_source_location() = ref_instr->source_location;
+    dest.add(goto_programt::make_decl(sym_expr, ref_instr->source_location()));
+  decl->code_nonconst().add_source_location() = ref_instr->source_location();
 
   // set the value - may be nil
   if(
@@ -449,9 +449,10 @@ symbol_exprt string_abstractiont::add_dummy_symbol_and_value(
   {
     goto_programt::targett assignment1 =
       dest.add(goto_programt::make_assignment(
-        code_assignt(sym_expr, new_symbol.value), ref_instr->source_location));
+        code_assignt(sym_expr, new_symbol.value),
+        ref_instr->source_location()));
     assignment1->code_nonconst().add_source_location() =
-      ref_instr->source_location;
+      ref_instr->source_location();
   }
 
   symbol_table.insert(std::move(new_symbol));
@@ -475,7 +476,7 @@ goto_programt::targett string_abstractiont::abstract(
     if(has_string_macros(it->get_condition()))
     {
       exprt tmp = it->get_condition();
-      replace_string_macros(tmp, false, it->source_location);
+      replace_string_macros(tmp, false, it->source_location());
       it->set_condition(tmp);
     }
     break;
@@ -522,12 +523,12 @@ goto_programt::targett string_abstractiont::abstract_assign(
 
     if(has_string_macros(lhs))
     {
-      replace_string_macros(lhs, true, target->source_location);
+      replace_string_macros(lhs, true, target->source_location());
       move_lhs_arithmetic(lhs, rhs);
     }
 
     if(has_string_macros(rhs))
-      replace_string_macros(rhs, false, target->source_location);
+      replace_string_macros(rhs, false, target->source_location());
   }
 
   const typet &type = target->assign_lhs().type();
@@ -1025,7 +1026,7 @@ void string_abstractiont::build_new_symbol(const symbolt &symbol,
   {
     goto_programt::targett dummy_loc =
       initialization.add(goto_programt::instructiont());
-    dummy_loc->source_location=symbol.location;
+    dummy_loc->source_location_nonconst() = symbol.location;
     make_decl_and_def(initialization, dummy_loc, identifier, symbol.name);
     initialization.instructions.erase(dummy_loc);
   }
@@ -1128,8 +1129,9 @@ goto_programt::targett string_abstractiont::abstract_pointer_assign(
   {
     goto_programt::instructiont assignment;
     assignment = goto_programt::make_assignment(
-      code_assignt(new_lhs, new_rhs), target->source_location);
-    assignment.code_nonconst().add_source_location() = target->source_location;
+      code_assignt(new_lhs, new_rhs), target->source_location());
+    assignment.code_nonconst().add_source_location() =
+      target->source_location();
     dest.insert_before_swap(target, assignment);
 
     return std::next(target);
@@ -1218,12 +1220,14 @@ goto_programt::targett string_abstractiont::char_assign(
     "failed to create is_zero-component for the left-hand-side");
 
   goto_programt::targett assignment1 = tmp.add(goto_programt::make_assignment(
-    code_assignt(i1, from_integer(1, i1.type())), target->source_location));
-  assignment1->code_nonconst().add_source_location() = target->source_location;
+    code_assignt(i1, from_integer(1, i1.type())), target->source_location()));
+  assignment1->code_nonconst().add_source_location() =
+    target->source_location();
 
   goto_programt::targett assignment2 = tmp.add(goto_programt::make_assignment(
-    code_assignt(lhs, rhs), target->source_location));
-  assignment2->code_nonconst().add_source_location() = target->source_location;
+    code_assignt(lhs, rhs), target->source_location()));
+  assignment2->code_nonconst().add_source_location() =
+    target->source_location();
 
   move_lhs_arithmetic(
     assignment2->code_nonconst().op0(), assignment2->code_nonconst().op1());
@@ -1291,13 +1295,13 @@ goto_programt::targett string_abstractiont::value_assignments_if(
 
   goto_programt::targett goto_else =
     tmp.add(goto_programt::make_incomplete_goto(
-      boolean_negate(rhs.cond()), target->source_location));
-  goto_programt::targett goto_out = tmp.add(
-    goto_programt::make_incomplete_goto(true_exprt(), target->source_location));
+      boolean_negate(rhs.cond()), target->source_location()));
+  goto_programt::targett goto_out = tmp.add(goto_programt::make_incomplete_goto(
+    true_exprt(), target->source_location()));
   goto_programt::targett else_target =
-    tmp.add(goto_programt::make_skip(target->source_location));
+    tmp.add(goto_programt::make_skip(target->source_location()));
   goto_programt::targett out_target =
-    tmp.add(goto_programt::make_skip(target->source_location));
+    tmp.add(goto_programt::make_skip(target->source_location()));
 
   goto_else->complete_goto(else_target);
   goto_out->complete_goto(out_target);
@@ -1325,24 +1329,27 @@ goto_programt::targett string_abstractiont::value_assignments_string_struct(
     goto_programt::targett assignment = tmp.add(goto_programt::make_assignment(
       member(lhs, whatt::IS_ZERO),
       member(rhs, whatt::IS_ZERO),
-      target->source_location));
-    assignment->code_nonconst().add_source_location() = target->source_location;
+      target->source_location()));
+    assignment->code_nonconst().add_source_location() =
+      target->source_location();
   }
 
   {
     goto_programt::targett assignment = tmp.add(goto_programt::make_assignment(
       member(lhs, whatt::LENGTH),
       member(rhs, whatt::LENGTH),
-      target->source_location));
-    assignment->code_nonconst().add_source_location() = target->source_location;
+      target->source_location()));
+    assignment->code_nonconst().add_source_location() =
+      target->source_location();
   }
 
   {
     goto_programt::targett assignment = tmp.add(goto_programt::make_assignment(
       member(lhs, whatt::SIZE),
       member(rhs, whatt::SIZE),
-      target->source_location));
-    assignment->code_nonconst().add_source_location() = target->source_location;
+      target->source_location()));
+    assignment->code_nonconst().add_source_location() =
+      target->source_location();
   }
 
   goto_programt::targett last=target;

--- a/src/goto-programs/string_instrumentation.cpp
+++ b/src/goto-programs/string_instrumentation.cpp
@@ -267,7 +267,7 @@ void string_instrumentationt::do_sprintf(
   {
     throw incorrect_source_program_exceptiont(
       "sprintf expected to have two or more arguments",
-      target->source_location);
+      target->source_location());
   }
 
   goto_programt tmp;
@@ -275,17 +275,18 @@ void string_instrumentationt::do_sprintf(
   // in the abstract model, we have to report a
   // (possibly false) positive here
   goto_programt::targett assertion = tmp.add(
-    goto_programt::make_assertion(false_exprt(), target->source_location));
-  assertion->source_location.set_property_class("string");
-  assertion->source_location.set_comment("sprintf buffer overflow");
+    goto_programt::make_assertion(false_exprt(), target->source_location()));
+  assertion->source_location_nonconst().set_property_class("string");
+  assertion->source_location_nonconst().set_comment("sprintf buffer overflow");
 
   do_format_string_read(tmp, target, arguments, 1, 2, "sprintf");
 
   if(lhs.is_not_nil())
   {
-    exprt rhs = side_effect_expr_nondett(lhs.type(), target->source_location);
+    exprt rhs = side_effect_expr_nondett(lhs.type(), target->source_location());
 
-    tmp.add(goto_programt::make_assignment(lhs, rhs, target->source_location));
+    tmp.add(
+      goto_programt::make_assignment(lhs, rhs, target->source_location()));
   }
 
   target->turn_into_skip();
@@ -302,7 +303,7 @@ void string_instrumentationt::do_snprintf(
   {
     throw incorrect_source_program_exceptiont(
       "snprintf expected to have three or more arguments",
-      target->source_location);
+      target->source_location());
   }
 
   goto_programt tmp;
@@ -311,17 +312,18 @@ void string_instrumentationt::do_snprintf(
 
   goto_programt::targett assertion = tmp.add(goto_programt::make_assertion(
     binary_relation_exprt(bufsize, ID_ge, arguments[1]),
-    target->source_location));
-  assertion->source_location.set_property_class("string");
-  assertion->source_location.set_comment("snprintf buffer overflow");
+    target->source_location()));
+  assertion->source_location_nonconst().set_property_class("string");
+  assertion->source_location_nonconst().set_comment("snprintf buffer overflow");
 
   do_format_string_read(tmp, target, arguments, 2, 3, "snprintf");
 
   if(lhs.is_not_nil())
   {
-    exprt rhs = side_effect_expr_nondett(lhs.type(), target->source_location);
+    exprt rhs = side_effect_expr_nondett(lhs.type(), target->source_location());
 
-    tmp.add(goto_programt::make_assignment(lhs, rhs, target->source_location));
+    tmp.add(
+      goto_programt::make_assignment(lhs, rhs, target->source_location()));
   }
 
   target->turn_into_skip();
@@ -337,7 +339,8 @@ void string_instrumentationt::do_fscanf(
   if(arguments.size()<2)
   {
     throw incorrect_source_program_exceptiont(
-      "fscanf expected to have two or more arguments", target->source_location);
+      "fscanf expected to have two or more arguments",
+      target->source_location());
   }
 
   goto_programt tmp;
@@ -346,9 +349,10 @@ void string_instrumentationt::do_fscanf(
 
   if(lhs.is_not_nil())
   {
-    exprt rhs = side_effect_expr_nondett(lhs.type(), target->source_location);
+    exprt rhs = side_effect_expr_nondett(lhs.type(), target->source_location());
 
-    tmp.add(goto_programt::make_assignment(lhs, rhs, target->source_location));
+    tmp.add(
+      goto_programt::make_assignment(lhs, rhs, target->source_location()));
   }
 
   target->turn_into_skip();
@@ -396,11 +400,11 @@ void string_instrumentationt::do_format_string_read(
 
           goto_programt::targett assertion =
             dest.add(goto_programt::make_assertion(
-              is_zero_string(temp), target->source_location));
-          assertion->source_location.set_property_class("string");
+              is_zero_string(temp), target->source_location()));
+          assertion->source_location_nonconst().set_property_class("string");
           std::string comment("zero-termination of string argument of ");
           comment += function_name;
-          assertion->source_location.set_comment(comment);
+          assertion->source_location_nonconst().set_comment(comment);
         }
       }
 
@@ -418,9 +422,9 @@ void string_instrumentationt::do_format_string_read(
   else // non-const format string
   {
     goto_programt::targett format_ass = dest.add(goto_programt::make_assertion(
-      is_zero_string(arguments[1]), target->source_location));
-    format_ass->source_location.set_property_class("string");
-    format_ass->source_location.set_comment(
+      is_zero_string(arguments[1]), target->source_location()));
+    format_ass->source_location_nonconst().set_property_class("string");
+    format_ass->source_location_nonconst().set_comment(
       "zero-termination of format string of " + function_name);
 
     for(std::size_t i=2; i<arguments.size(); i++)
@@ -439,9 +443,9 @@ void string_instrumentationt::do_format_string_read(
 
         goto_programt::targett assertion =
           dest.add(goto_programt::make_assertion(
-            is_zero_string(temp), target->source_location));
-        assertion->source_location.set_property_class("string");
-        assertion->source_location.set_comment(
+            is_zero_string(temp), target->source_location()));
+        assertion->source_location_nonconst().set_property_class("string");
+        assertion->source_location_nonconst().set_comment(
           "zero-termination of string argument of " + function_name);
       }
     }
@@ -516,12 +520,13 @@ void string_instrumentationt::do_format_string_write(
             condition = false_exprt();
           }
 
-          goto_programt::targett assertion = dest.add(
-            goto_programt::make_assertion(condition, target->source_location));
-          assertion->source_location.set_property_class("string");
+          goto_programt::targett assertion =
+            dest.add(goto_programt::make_assertion(
+              condition, target->source_location()));
+          assertion->source_location_nonconst().set_property_class("string");
           std::string comment("format string buffer overflow in ");
           comment += function_name;
-          assertion->source_location.set_comment(comment);
+          assertion->source_location_nonconst().set_comment(comment);
 
           // now kill the contents
           invalidate_buffer(
@@ -544,10 +549,10 @@ void string_instrumentationt::do_format_string_write(
           const exprt &argument=arguments[argument_start_inx+args];
           const dereference_exprt lhs{argument};
 
-          side_effect_expr_nondett rhs(lhs.type(), target->source_location);
+          side_effect_expr_nondett rhs(lhs.type(), target->source_location());
 
-          dest.add(
-            goto_programt::make_assignment(lhs, rhs, target->source_location));
+          dest.add(goto_programt::make_assignment(
+            lhs, rhs, target->source_location()));
 
           args++;
           break;
@@ -572,11 +577,11 @@ void string_instrumentationt::do_format_string_write(
         // possibly false positive
         goto_programt::targett assertion =
           dest.add(goto_programt::make_assertion(
-            false_exprt(), target->source_location));
-        assertion->source_location.set_property_class("string");
+            false_exprt(), target->source_location()));
+        assertion->source_location_nonconst().set_property_class("string");
         std::string comment("format string buffer overflow in ");
         comment += function_name;
-        assertion->source_location.set_comment(comment);
+        assertion->source_location_nonconst().set_comment(comment);
 
         invalidate_buffer(dest, target, arguments[i], arg_type, 0);
       }
@@ -584,10 +589,10 @@ void string_instrumentationt::do_format_string_write(
       {
         dereference_exprt lhs{arguments[i]};
 
-        side_effect_expr_nondett rhs(lhs.type(), target->source_location);
+        side_effect_expr_nondett rhs(lhs.type(), target->source_location());
 
         dest.add(
-          goto_programt::make_assignment(lhs, rhs, target->source_location));
+          goto_programt::make_assignment(lhs, rhs, target->source_location()));
       }
     }
   }
@@ -610,15 +615,15 @@ void string_instrumentationt::do_strchr(
   if(arguments.size()!=2)
   {
     throw incorrect_source_program_exceptiont(
-      "strchr expected to have two arguments", target->source_location);
+      "strchr expected to have two arguments", target->source_location());
   }
 
   goto_programt tmp;
 
   goto_programt::targett assertion = tmp.add(goto_programt::make_assertion(
-    is_zero_string(arguments[0]), target->source_location));
-  assertion->source_location.set_property_class("string");
-  assertion->source_location.set_comment(
+    is_zero_string(arguments[0]), target->source_location()));
+  assertion->source_location_nonconst().set_property_class("string");
+  assertion->source_location_nonconst().set_comment(
     "zero-termination of string argument of strchr");
 
   target->turn_into_skip();
@@ -634,15 +639,15 @@ void string_instrumentationt::do_strrchr(
   if(arguments.size()!=2)
   {
     throw incorrect_source_program_exceptiont(
-      "strrchr expected to have two arguments", target->source_location);
+      "strrchr expected to have two arguments", target->source_location());
   }
 
   goto_programt tmp;
 
   goto_programt::targett assertion = tmp.add(goto_programt::make_assertion(
-    is_zero_string(arguments[0]), target->source_location));
-  assertion->source_location.set_property_class("string");
-  assertion->source_location.set_comment(
+    is_zero_string(arguments[0]), target->source_location()));
+  assertion->source_location_nonconst().set_property_class("string");
+  assertion->source_location_nonconst().set_comment(
     "zero-termination of string argument of strrchr");
 
   target->turn_into_skip();
@@ -658,21 +663,21 @@ void string_instrumentationt::do_strstr(
   if(arguments.size()!=2)
   {
     throw incorrect_source_program_exceptiont(
-      "strstr expected to have two arguments", target->source_location);
+      "strstr expected to have two arguments", target->source_location());
   }
 
   goto_programt tmp;
 
   goto_programt::targett assertion0 = tmp.add(goto_programt::make_assertion(
-    is_zero_string(arguments[0]), target->source_location));
-  assertion0->source_location.set_property_class("string");
-  assertion0->source_location.set_comment(
+    is_zero_string(arguments[0]), target->source_location()));
+  assertion0->source_location_nonconst().set_property_class("string");
+  assertion0->source_location_nonconst().set_comment(
     "zero-termination of 1st string argument of strstr");
 
   goto_programt::targett assertion1 = tmp.add(goto_programt::make_assertion(
-    is_zero_string(arguments[1]), target->source_location));
-  assertion1->source_location.set_property_class("string");
-  assertion1->source_location.set_comment(
+    is_zero_string(arguments[1]), target->source_location()));
+  assertion1->source_location_nonconst().set_property_class("string");
+  assertion1->source_location_nonconst().set_comment(
     "zero-termination of 2nd string argument of strstr");
 
   target->turn_into_skip();
@@ -688,21 +693,21 @@ void string_instrumentationt::do_strtok(
   if(arguments.size()!=2)
   {
     throw incorrect_source_program_exceptiont(
-      "strtok expected to have two arguments", target->source_location);
+      "strtok expected to have two arguments", target->source_location());
   }
 
   goto_programt tmp;
 
   goto_programt::targett assertion0 = tmp.add(goto_programt::make_assertion(
-    is_zero_string(arguments[0]), target->source_location));
-  assertion0->source_location.set_property_class("string");
-  assertion0->source_location.set_comment(
+    is_zero_string(arguments[0]), target->source_location()));
+  assertion0->source_location_nonconst().set_property_class("string");
+  assertion0->source_location_nonconst().set_comment(
     "zero-termination of 1st string argument of strtok");
 
   goto_programt::targett assertion1 = tmp.add(goto_programt::make_assertion(
-    is_zero_string(arguments[1]), target->source_location));
-  assertion1->source_location.set_property_class("string");
-  assertion1->source_location.set_comment(
+    is_zero_string(arguments[1]), target->source_location()));
+  assertion1->source_location_nonconst().set_property_class("string");
+  assertion1->source_location_nonconst().set_comment(
     "zero-termination of 2nd string argument of strtok");
 
   target->turn_into_skip();
@@ -758,17 +763,17 @@ void string_instrumentationt::do_strerror(
 
   {
     exprt nondet_size =
-      side_effect_expr_nondett(size_type(), it->source_location);
+      side_effect_expr_nondett(size_type(), it->source_location());
     tmp.add(goto_programt::make_assignment(
       code_assignt(symbol_size.symbol_expr(), nondet_size),
-      it->source_location));
+      it->source_location()));
 
     tmp.add(goto_programt::make_assumption(
       binary_relation_exprt(
         symbol_size.symbol_expr(),
         ID_notequal,
         from_integer(0, symbol_size.type)),
-      it->source_location));
+      it->source_location()));
   }
 
   // return a pointer to some magic buffer
@@ -783,14 +788,14 @@ void string_instrumentationt::do_strerror(
   tmp.add(goto_programt::make_assignment(
     unary_exprt{"is_zero_string", ptr, c_bool_type()},
     from_integer(1, c_bool_type()),
-    it->source_location));
+    it->source_location()));
 
   // assign address
   {
     exprt rhs=ptr;
     make_type(rhs, lhs.type());
     tmp.add(goto_programt::make_assignment(
-      code_assignt(lhs, rhs), it->source_location));
+      code_assignt(lhs, rhs), it->source_location()));
   }
 
   it->turn_into_skip();
@@ -829,7 +834,7 @@ void string_instrumentationt::invalidate_buffer(
   dest.add(goto_programt::make_assignment(
     cntr_sym.symbol_expr(),
     from_integer(0, cntr_sym.type),
-    target->source_location));
+    target->source_location()));
 
   exprt bufp;
 
@@ -852,11 +857,11 @@ void string_instrumentationt::invalidate_buffer(
       cntr_sym.symbol_expr(), ID_gt, from_integer(limit, unsigned_int_type()));
 
   goto_programt::targett check = dest.add(
-    goto_programt::make_incomplete_goto(condition, target->source_location));
+    goto_programt::make_incomplete_goto(condition, target->source_location()));
 
   goto_programt::targett invalidate = dest.add(goto_programt::instructiont(
     static_cast<const codet &>(get_nil_irep()),
-    target->source_location,
+    target->source_location(),
     ASSIGN,
     nil_exprt(),
     {}));
@@ -865,13 +870,13 @@ void string_instrumentationt::invalidate_buffer(
     cntr_sym.symbol_expr(), from_integer(1, unsigned_int_type()));
 
   dest.add(goto_programt::make_assignment(
-    cntr_sym.symbol_expr(), plus, target->source_location));
+    cntr_sym.symbol_expr(), plus, target->source_location()));
 
   dest.add(
-    goto_programt::make_goto(check, true_exprt(), target->source_location));
+    goto_programt::make_goto(check, true_exprt(), target->source_location()));
 
   goto_programt::targett exit =
-    dest.add(goto_programt::make_skip(target->source_location));
+    dest.add(goto_programt::make_skip(target->source_location()));
 
   check->complete_goto(exit);
 
@@ -879,7 +884,7 @@ void string_instrumentationt::invalidate_buffer(
   const dereference_exprt deref(b_plus_i, buf_type.subtype());
 
   const side_effect_expr_nondett nondet(
-    buf_type.subtype(), target->source_location);
+    buf_type.subtype(), target->source_location());
 
   invalidate->code_nonconst() = code_assignt(deref, nondet);
 }

--- a/src/goto-programs/structured_trace_util.cpp
+++ b/src/goto-programs/structured_trace_util.cpp
@@ -40,7 +40,7 @@ optionalt<default_trace_stept> default_step(
   const goto_trace_stept &step,
   const source_locationt &previous_source_location)
 {
-  const source_locationt &source_location = step.pc->source_location;
+  const source_locationt &source_location = step.pc->source_location();
   if(source_location.is_nil() || source_location.get_file().empty())
     return {};
 

--- a/src/goto-programs/write_goto_binary.cpp
+++ b/src/goto-programs/write_goto_binary.cpp
@@ -96,7 +96,7 @@ bool write_goto_binary(
       for(const auto &instruction : fct.second.body.instructions)
       {
         irepconverter.reference_convert(instruction.get_code(), out);
-        irepconverter.reference_convert(instruction.source_location, out);
+        irepconverter.reference_convert(instruction.source_location(), out);
         write_gb_word(out, (long)instruction.type);
 
         const auto condition =

--- a/src/goto-programs/xml_goto_trace.cpp
+++ b/src/goto-programs/xml_goto_trace.cpp
@@ -98,7 +98,7 @@ void convert(
 
   for(const auto &step : goto_trace.steps)
   {
-    const source_locationt &source_location=step.pc->source_location;
+    const source_locationt &source_location = step.pc->source_location();
 
     xmlt xml_location;
     if(source_location.is_not_nil() && !source_location.get_file().empty())

--- a/src/goto-symex/build_goto_trace.cpp
+++ b/src/goto-symex/build_goto_trace.cpp
@@ -155,7 +155,7 @@ static void update_internal_field(
   // set internal field to CPROVER functions (e.g., __CPROVER_initialize)
   if(SSA_step.is_function_call())
   {
-    if(SSA_step.source.pc->source_location.as_string().empty())
+    if(SSA_step.source.pc->source_location().as_string().empty())
       goto_trace_step.internal=true;
   }
 

--- a/src/goto-symex/complexity_limiter.cpp
+++ b/src/goto-symex/complexity_limiter.cpp
@@ -158,8 +158,8 @@ complexity_limitert::check_complexity(goto_symex_statet &state)
       {
         log.warning()
           << "[symex-complexity] Loop operations considered too complex"
-          << (state.source.pc->source_location.is_not_nil()
-                ? " at: " + state.source.pc->source_location.as_string()
+          << (state.source.pc->source_location().is_not_nil()
+                ? " at: " + state.source.pc->source_location().as_string()
                 : ", location number: " +
                     std::to_string(state.source.pc->location_number) + ".")
           << messaget::eom;
@@ -169,8 +169,9 @@ complexity_limitert::check_complexity(goto_symex_statet &state)
     }
 
     log.warning() << "[symex-complexity] Branch considered too complex"
-                  << (state.source.pc->source_location.is_not_nil()
-                        ? " at: " + state.source.pc->source_location.as_string()
+                  << (state.source.pc->source_location().is_not_nil()
+                        ? " at: " +
+                            state.source.pc->source_location().as_string()
                         : ", location number: " +
                             std::to_string(state.source.pc->location_number) +
                             ".")
@@ -189,8 +190,9 @@ complexity_limitert::check_complexity(goto_symex_statet &state)
   if(in_blacklisted_loop(current_call_stack, state.source.pc))
   {
     log.warning() << "[symex-complexity] Trying to enter blacklisted loop"
-                  << (state.source.pc->source_location.is_not_nil()
-                        ? " at: " + state.source.pc->source_location.as_string()
+                  << (state.source.pc->source_location().is_not_nil()
+                        ? " at: " +
+                            state.source.pc->source_location().as_string()
                         : ", location number: " +
                             std::to_string(state.source.pc->location_number) +
                             ".")

--- a/src/goto-symex/goto_symex.cpp
+++ b/src/goto-symex/goto_symex.cpp
@@ -97,7 +97,7 @@ void goto_symext::symex_assign(
       assignment_type = symex_targett::assignment_typet::HIDDEN;
 
     // We hide if we are executing a hidden instruction.
-    if(state.source.pc->source_location.get_hide())
+    if(state.source.pc->source_location().get_hide())
       assignment_type = symex_targett::assignment_typet::HIDDEN;
 
     symex_assignt symex_assign{

--- a/src/goto-symex/show_program.cpp
+++ b/src/goto-symex/show_program.cpp
@@ -64,7 +64,7 @@ void show_program(const namespacet &ns, const symex_target_equationt &equation)
   for(const auto &step : equation.SSA_steps)
   {
     std::cout << "// " << step.source.pc->location_number << " ";
-    std::cout << step.source.pc->source_location.as_string() << "\n";
+    std::cout << step.source.pc->source_location().as_string() << "\n";
 
     if(step.is_assignment())
       show_step(ns, step, "", count);
@@ -118,7 +118,7 @@ void show_ssa_step_plain(
   const std::string ssa_expr_as_string = from_expr(ns, function_id, ssa_expr);
 
   out << messaget::faint << "// " << ssa_step.source.pc->location_number << " ";
-  out << ssa_step.source.pc->source_location.as_string() << "\n"
+  out << ssa_step.source.pc->source_location().as_string() << "\n"
       << messaget::reset;
   out << ssa_expr_as_string << "\n";
 }
@@ -136,7 +136,7 @@ json_objectt get_ssa_step_json(
   const std::string ssa_expr_as_string = from_expr(ns, function_id, ssa_expr);
 
   json_objectt json_ssa_step{
-    {key_srcloc, json(ssa_step.source.pc->source_location)},
+    {key_srcloc, json(ssa_step.source.pc->source_location())},
     {key_ssa_expr_as_string, json_stringt(ssa_expr_as_string)},
     {key_ssa_expr, json_irept(false).convert_from_irep(ssa_expr)}};
 

--- a/src/goto-symex/show_vcc.cpp
+++ b/src/goto-symex/show_vcc.cpp
@@ -42,8 +42,8 @@ show_vcc_plain(messaget::mstreamt &out, const symex_target_equationt &equation)
     else
       out << '\n';
 
-    if(s_it->source.pc->source_location.is_not_nil())
-      out << s_it->source.pc->source_location << '\n';
+    if(s_it->source.pc->source_location().is_not_nil())
+      out << s_it->source.pc->source_location() << '\n';
 
     if(!s_it->comment.empty())
       out << s_it->comment << '\n';
@@ -126,7 +126,8 @@ show_vcc_json(std::ostream &out, const symex_target_equationt &equation)
     // vcc object
     json_objectt &object = json_vccs.push_back(jsont()).make_object();
 
-    const source_locationt &source_location = s_it->source.pc->source_location;
+    const source_locationt &source_location =
+      s_it->source.pc->source_location();
     if(source_location.is_not_nil())
       object["sourceLocation"] = json(source_location);
 

--- a/src/goto-symex/ssa_step.cpp
+++ b/src/goto-symex/ssa_step.cpp
@@ -14,8 +14,8 @@ void SSA_stept::output(std::ostream &out) const
 {
   out << "Thread " << source.thread_nr;
 
-  if(source.pc->source_location.is_not_nil())
-    out << " " << source.pc->source_location << '\n';
+  if(source.pc->source_location().is_not_nil())
+    out << " " << source.pc->source_location() << '\n';
   else
     out << '\n';
 
@@ -192,19 +192,19 @@ irep_idt SSA_stept::get_property_id() const
 
   if(source.pc->is_assert())
   {
-    property_id = source.pc->source_location.get_property_id();
+    property_id = source.pc->source_location().get_property_id();
   }
   else if(source.pc->is_goto())
   {
     // this is likely an unwinding assertion
-    property_id = id2string(source.pc->source_location.get_function()) +
+    property_id = id2string(source.pc->source_location().get_function()) +
                   ".unwind." + std::to_string(source.pc->loop_number);
   }
   else if(source.pc->is_function_call())
   {
     // this is likely a recursion unwinding assertion
     property_id =
-      id2string(source.pc->source_location.get_function()) + ".recursion";
+      id2string(source.pc->source_location().get_function()) + ".recursion";
   }
   else
   {

--- a/src/goto-symex/symex_atomic_section.cpp
+++ b/src/goto-symex/symex_atomic_section.cpp
@@ -21,7 +21,7 @@ void goto_symext::symex_atomic_begin(statet &state)
   if(state.atomic_section_id != 0)
     throw incorrect_goto_program_exceptiont(
       "we don't support nesting of atomic sections",
-      state.source.pc->source_location);
+      state.source.pc->source_location());
 
   state.atomic_section_id=++atomic_section_counter;
   state.read_in_atomic_section.clear();
@@ -40,7 +40,7 @@ void goto_symext::symex_atomic_end(statet &state)
 
   if(state.atomic_section_id == 0)
     throw incorrect_goto_program_exceptiont(
-      "ATOMIC_END unmatched", state.source.pc->source_location);
+      "ATOMIC_END unmatched", state.source.pc->source_location());
 
   const unsigned atomic_section_id=state.atomic_section_id;
   state.atomic_section_id=0;

--- a/src/goto-symex/symex_builtin_functions.cpp
+++ b/src/goto-symex/symex_builtin_functions.cpp
@@ -285,7 +285,7 @@ void goto_symext::symex_va_start(
     array.type(),
     id2string(state.source.function_id),
     "va_args",
-    state.source.pc->source_location,
+    state.source.pc->source_location(),
     ns.lookup(state.source.function_id).mode,
     state.symbol_table);
   va_array.value = array;

--- a/src/goto-symex/symex_decl.cpp
+++ b/src/goto-symex/symex_decl.cpp
@@ -42,7 +42,7 @@ void goto_symext::symex_decl(statet &state, const symbol_exprt &expr)
   // and if the statement itself is hidden
   bool hidden = ns.lookup(expr.get_identifier()).is_auxiliary ||
                 state.call_stack().top().hidden_function ||
-                state.source.pc->source_location.get_hide();
+                state.source.pc->source_location().get_hide();
 
   target.decl(
     state.guard.as_expr(),

--- a/src/goto-symex/symex_function_call.cpp
+++ b/src/goto-symex/symex_function_call.cpp
@@ -63,7 +63,7 @@ void goto_symext::parameter_assignments(
     // if you run out of actual arguments there was a mismatch
     if(it1==arguments.end())
     {
-      log.warning() << state.source.pc->source_location.as_string()
+      log.warning() << state.source.pc->source_location().as_string()
                     << ": "
                        "call to '"
                     << id2string(function_identifier)
@@ -72,7 +72,7 @@ void goto_symext::parameter_assignments(
                     << log.eom;
 
       rhs = side_effect_expr_nondett(
-        parameter_type, state.source.pc->source_location);
+        parameter_type, state.source.pc->source_location());
     }
     else
       rhs=*it1;
@@ -115,7 +115,7 @@ void goto_symext::parameter_assignments(
         else
         {
           std::ostringstream error;
-          error << state.source.pc->source_location.as_string() << ": "
+          error << state.source.pc->source_location().as_string() << ": "
                 << "function call: parameter \"" << identifier
                 << "\" type mismatch:\ngot " << rhs.type().pretty()
                 << "\nexpected " << parameter_type.pretty();
@@ -154,7 +154,7 @@ void goto_symext::parameter_assignments(
         it1->type(),
         id2string(function_identifier),
         "va_arg",
-        state.source.pc->source_location,
+        state.source.pc->source_location(),
         ns.lookup(function_identifier).mode,
         state.symbol_table);
       va_arg.is_parameter = true;

--- a/src/goto-symex/symex_goto.cpp
+++ b/src/goto-symex/symex_goto.cpp
@@ -385,13 +385,13 @@ void goto_symext::symex_goto(statet &state)
     new_state_pc = state_pc;
     state_pc = tmp;
 
-    log.debug() << "Resuming from jump target '" << state_pc->source_location
+    log.debug() << "Resuming from jump target '" << state_pc->source_location()
                 << "'" << log.eom;
   }
   else if(state.has_saved_next_instruction)
   {
     log.debug() << "Resuming from next instruction '"
-                << state_pc->source_location << "'" << log.eom;
+                << state_pc->source_location() << "'" << log.eom;
   }
   else if(symex_config.doing_path_exploration)
   {
@@ -410,10 +410,10 @@ void goto_symext::symex_goto(statet &state)
     // so let its truth value for `backwards` be the same as ours for `forward`.
 
     log.debug() << "Saving next instruction '"
-                << next_instruction.state.saved_target->source_location << "'"
+                << next_instruction.state.saved_target->source_location() << "'"
                 << log.eom;
     log.debug() << "Saving jump target '"
-                << jump_target.state.saved_target->source_location << "'"
+                << jump_target.state.saved_target->source_location() << "'"
                 << log.eom;
     path_storage.push(next_instruction);
     path_storage.push(jump_target);
@@ -675,7 +675,7 @@ void goto_symext::merge_goto(
   if(state.atomic_section_id != goto_state.atomic_section_id)
     throw incorrect_goto_program_exceptiont(
       "atomic sections differ across branches",
-      state.source.pc->source_location);
+      state.source.pc->source_location());
 
   // Merge guards. Don't write this to `state` yet because we might move
   // goto_state over it below.

--- a/src/goto-symex/symex_main.cpp
+++ b/src/goto-symex/symex_main.cpp
@@ -175,7 +175,7 @@ void goto_symext::symex_assert(
   // now try simplifier on it
   do_simplify(l2_condition);
 
-  std::string msg = id2string(instruction.source_location.get_comment());
+  std::string msg = id2string(instruction.source_location().get_comment());
   if(msg.empty())
     msg = "assertion";
 
@@ -538,12 +538,12 @@ void goto_symext::print_symex_step(statet &state)
                  << format(state.source.pc->get_code());
 
     if(
-      state.source.pc->source_location.is_not_nil() &&
-      !state.source.pc->source_location.get_java_bytecode_index().empty())
+      state.source.pc->source_location().is_not_nil() &&
+      !state.source.pc->source_location().get_java_bytecode_index().empty())
     {
       log.status()
         << " bytecode index: "
-        << state.source.pc->source_location.get_java_bytecode_index();
+        << state.source.pc->source_location().get_java_bytecode_index();
     }
 
     log.status() << messaget::eom;

--- a/src/goto-symex/symex_other.cpp
+++ b/src/goto-symex/symex_other.cpp
@@ -32,7 +32,7 @@ void goto_symext::havoc_rec(
         guard.as_expr(), dest, exprt(ID_null_object, dest.type()));
 
     auto rhs =
-      side_effect_expr_nondett(dest.type(), state.source.pc->source_location);
+      side_effect_expr_nondett(dest.type(), state.source.pc->source_location());
 
     symex_assign(state, lhs, rhs);
   }

--- a/src/goto-symex/symex_start_thread.cpp
+++ b/src/goto-symex/symex_start_thread.cpp
@@ -27,7 +27,7 @@ void goto_symext::symex_start_thread(statet &state)
     throw incorrect_goto_program_exceptiont(
       "spawning threads out of atomic sections is not allowed; "
       "this would require amendments to ordering constraints",
-      state.source.pc->source_location);
+      state.source.pc->source_location());
 
   // record this
   target.spawn(state.guard.as_expr(), state.source);

--- a/src/pointer-analysis/value_set_analysis.cpp
+++ b/src/pointer-analysis/value_set_analysis.cpp
@@ -23,7 +23,7 @@ void value_sets_to_xml(
 
   forall_goto_program_instructions(i_it, goto_program)
   {
-    const source_locationt &location=i_it->source_location;
+    const source_locationt &location = i_it->source_location();
 
     if(location==previous_location)
       continue;

--- a/src/solvers/solver_hardness.cpp
+++ b/src/solvers/solver_hardness.cpp
@@ -31,8 +31,8 @@ operator==(const solver_hardnesst::hardness_ssa_keyt &other) const
 {
   if(ssa_expression != other.ssa_expression)
     return false;
-  return pc->source_location.as_string() ==
-         other.pc->source_location.as_string();
+  return pc->source_location().as_string() ==
+         other.pc->source_location().as_string();
 }
 
 bool solver_hardnesst::assertion_statst::empty() const
@@ -154,7 +154,7 @@ void solver_hardnesst::produce_report()
       // identifier for each one.
       hardness_stats_json["GOTO_ID"] =
         json_numbert{std::to_string((i << ssa_set_bit_offset) + j)};
-      hardness_stats_json["Source"] = json(ssa.pc->source_location);
+      hardness_stats_json["Source"] = json(ssa.pc->source_location());
 
       auto sat_hardness_json = json_objectt{};
       sat_hardness_json["Clauses"] =
@@ -191,7 +191,7 @@ void solver_hardnesst::produce_report()
       auto assertion_stats_pc_json = json_objectt{};
       assertion_stats_pc_json["GOTO"] =
         json_stringt{goto_instruction2string(pc)};
-      assertion_stats_pc_json["Source"] = json(pc->source_location);
+      assertion_stats_pc_json["Source"] = json(pc->source_location());
       assertion_stats_pcs_json.push_back(assertion_stats_pc_json);
     }
     assertion_stats_json["Sources"] = assertion_stats_pcs_json;

--- a/src/solvers/solver_hardness.h
+++ b/src/solvers/solver_hardness.h
@@ -155,7 +155,7 @@ struct hash<solver_hardnesst::hardness_ssa_keyt>
   {
     return std::hash<std::string>{}(
       hashed_stats.ssa_expression +
-      hashed_stats.pc->source_location.as_string());
+      hashed_stats.pc->source_location().as_string());
   }
 };
 } // namespace std

--- a/unit/goto-checker/report_util/is_property_less_than.cpp
+++ b/unit/goto-checker/report_util/is_property_less_than.cpp
@@ -13,7 +13,7 @@ static goto_programt::instructiont instruction_for_location(
   location.set_function(function);
   location.set_line(line_no);
   goto_programt::instructiont instruction;
-  instruction.source_location = location;
+  instruction.source_location_nonconst() = location;
   return instruction;
 }
 
@@ -32,9 +32,10 @@ std::ostream &operator<<(std::ostream &os, const propertyt &value)
 {
   os << "{ property_id=" << value.first << ", "
      << " property_location={ "
-     << " file=" << value.second.pc->source_location.get_file() << ", "
-     << " function=" << value.second.pc->source_location.get_function() << ", "
-     << " line=" << value.second.pc->source_location.get_line() << "}}";
+     << " file=" << value.second.pc->source_location().get_file() << ", "
+     << " function=" << value.second.pc->source_location().get_function()
+     << ", "
+     << " line=" << value.second.pc->source_location().get_line() << "}}";
   return os;
 }
 

--- a/unit/goto-instrument/cover_instrument.cpp
+++ b/unit/goto-instrument/cover_instrument.cpp
@@ -26,7 +26,7 @@ TEST_CASE("cover_intrument_end_of_function", "[core]")
   const auto newly_inserted = std::next(goto_program.instructions.begin(), 2);
   REQUIRE(newly_inserted->is_assert());
   REQUIRE(newly_inserted->get_condition() == false_exprt{});
-  REQUIRE(newly_inserted->source_location.get_function() == "foo");
+  REQUIRE(newly_inserted->source_location().get_function() == "foo");
 }
 
 TEST_CASE("cover_instrument_end_of_function with custom expression", "[core]")
@@ -49,5 +49,5 @@ TEST_CASE("cover_instrument_end_of_function with custom expression", "[core]")
   const auto newly_inserted = std::next(goto_program.instructions.begin(), 2);
   REQUIRE(newly_inserted->is_assert());
   REQUIRE(newly_inserted->get_condition() == true_exprt{});
-  REQUIRE(newly_inserted->source_location.get_function() == "foo");
+  REQUIRE(newly_inserted->source_location().get_function() == "foo");
 }

--- a/unit/goto-programs/structured_trace_util.cpp
+++ b/unit/goto-programs/structured_trace_util.cpp
@@ -30,7 +30,7 @@ goto_programt::targett add_instruction(
 {
   goto_programt::instructiont instruction;
   instruction.location_number = instructions.size();
-  instruction.source_location = location;
+  instruction.source_location_nonconst() = location;
   instructions.push_back(instruction);
   return std::next(instructions.begin(), instruction.location_number);
 }

--- a/unit/path_strategies.cpp
+++ b/unit/path_strategies.cpp
@@ -335,8 +335,8 @@ void symex_eventt::validate_resume(
   REQUIRE(!events.empty());
 
   int dst = 0;
-  if(!state.saved_target->source_location.get_line().empty())
-    dst = std::stoi(state.saved_target->source_location.get_line().c_str());
+  if(!state.saved_target->source_location().get_line().empty())
+    dst = std::stoi(state.saved_target->source_location().get_line().c_str());
 
   if(state.has_saved_next_instruction)
   {


### PR DESCRIPTION
This introduces two methods for wrapping the accesses to
`goto_instructiont::source_location`.  The field is now protected to prevent
direct access.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
