### PR TITLE
Add short circuit evaluation to implies operator `==>`

### DIFF
--- a/regression/cbmc/short_circuit_implies/false_implies_failure_side_effect.c
+++ b/regression/cbmc/short_circuit_implies/false_implies_failure_side_effect.c
@@ -1,0 +1,15 @@
+#include <stdbool.h>
+
+bool fail()
+{
+  __CPROVER_assert(false, "fail function");
+  return true;
+}
+
+void main()
+{
+  // clang-format off
+  // clang-format would rewrite the "==>" as "== >"
+  __CPROVER_assert(false ==> fail(), "fail function");
+  // clang-format on
+}

--- a/regression/cbmc/short_circuit_implies/false_implies_failure_side_effect.desc
+++ b/regression/cbmc/short_circuit_implies/false_implies_failure_side_effect.desc
@@ -1,0 +1,14 @@
+CORE
+false_implies_failure_side_effect.c
+
+^EXIT=0$
+^SIGNAL=0$
+line 5 fail function: SUCCESS
+VERIFICATION SUCCESSFUL
+--
+^warning: ignoring
+--
+Test that side effects on the right hand side of the ==> operator that would
+otherwise result in verification failure do not do so when the left hand side
+is false. This confirms that the ==> operator employs short circuiting
+evaluation in the same way as the && and || operators.

--- a/regression/cbmc/short_circuit_implies/short-circuit-memory-checks.c
+++ b/regression/cbmc/short_circuit_implies/short-circuit-memory-checks.c
@@ -1,0 +1,14 @@
+#include <assert.h>
+#include <stdbool.h>
+#include <stdlib.h>
+
+int main()
+{
+  int *c = NULL;
+
+  // clang-format off
+  // clang-format would rewrite the "==>" as "== >"
+  assert(false ==> *c == 0);
+  assert(true ==> *c == 0);
+  // clang-format on
+}

--- a/regression/cbmc/short_circuit_implies/short-circuit-memory-checks.desc
+++ b/regression/cbmc/short_circuit_implies/short-circuit-memory-checks.desc
@@ -1,0 +1,14 @@
+CORE
+short-circuit-memory-checks.c
+--pointer-check
+^EXIT=10$
+^SIGNAL=0$
+line 11 dereference failure: pointer NULL in \*c: SUCCESS
+line 12 dereference failure: pointer NULL in \*c: FAILURE
+VERIFICATION FAILED
+--
+^warning: ignoring
+--
+Test that side effects on the right hand side of the ==> operator are correctly
+short-circuited or not where the side effect is a pointer check. Note that this
+test is based upon the originally reported github issue 6319.

--- a/regression/cbmc/short_circuit_implies/true_implies_failure_side_effect.c
+++ b/regression/cbmc/short_circuit_implies/true_implies_failure_side_effect.c
@@ -1,0 +1,15 @@
+#include <stdbool.h>
+
+bool fail()
+{
+  __CPROVER_assert(false, "fail function");
+  return true;
+}
+
+void main()
+{
+  // clang-format off
+  // clang-format would rewrite the "==>" as "== >"
+  __CPROVER_assert(true ==> fail(), "fail function");
+  // clang-format on
+}

--- a/regression/cbmc/short_circuit_implies/true_implies_failure_side_effect.desc
+++ b/regression/cbmc/short_circuit_implies/true_implies_failure_side_effect.desc
@@ -1,0 +1,12 @@
+CORE
+true_implies_failure_side_effect.c
+
+^EXIT=10$
+^SIGNAL=0$
+line 5 fail function: FAILURE
+VERIFICATION FAILED
+--
+^warning: ignoring
+--
+Test that side effects on the right hand side of the ==> operator can result
+in verification failure in the case where the left hand side is true.

--- a/src/goto-programs/goto_clean_expr.cpp
+++ b/src/goto-programs/goto_clean_expr.cpp
@@ -144,12 +144,15 @@ void goto_convertt::rewrite_boolean(exprt &expr)
     {
       if_exprt if_e(op, tmp, false_exprt());
       tmp.swap(if_e);
+      continue;
     }
-    else // ID_or
+    if(expr.id() == ID_or)
     {
       if_exprt if_e(op, true_exprt(), tmp);
       tmp.swap(if_e);
+      continue;
     }
+    UNREACHABLE;
   }
 
   expr.swap(tmp);


### PR DESCRIPTION
This PR adds short circuit evaluation to implies operator `==>`, in response to https://github.com/diffblue/cbmc/issues/6319
<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
