### PR TITLE
Set standard to C++17 when -std=c++17 or -std=gnu++17 are used

### DIFF
--- a/src/analyses/goto_check.cpp
+++ b/src/analyses/goto_check.cpp
@@ -834,7 +834,8 @@ void goto_checkt::integer_overflow_check(
       {
         if(
           config.cpp.cpp_standard == configt::cppt::cpp_standardt::CPP11 ||
-          config.cpp.cpp_standard == configt::cppt::cpp_standardt::CPP14)
+          config.cpp.cpp_standard == configt::cppt::cpp_standardt::CPP14 ||
+          config.cpp.cpp_standard == configt::cppt::cpp_standardt::CPP17)
         {
           allow_shift_into_sign_bit = false;
         }

--- a/src/ansi-c/c_preprocess.cpp
+++ b/src/ansi-c/c_preprocess.cpp
@@ -551,6 +551,15 @@ bool c_preprocess_gcc_clang(
 #endif
         argv.push_back("-std=gnu++14");
       break;
+
+    case configt::cppt::cpp_standardt::CPP17:
+#if defined(__OpenBSD__)
+      if(preprocessor == configt::ansi_ct::preprocessort::CLANG)
+        argv.push_back("-std=c++17");
+      else
+#endif
+        argv.push_back("-std=gnu++17");
+      break;
     }
   }
   else

--- a/src/ansi-c/gcc_version.cpp
+++ b/src/ansi-c/gcc_version.cpp
@@ -120,6 +120,8 @@ void gcc_versiont::get(const std::string &executable)
               default_cxx_standard = configt::cppt::cpp_standardt::CPP11;
             else if(split[1] == "201402L")
               default_cxx_standard = configt::cppt::cpp_standardt::CPP14;
+            else if(split[1] == "201703L")
+              default_cxx_standard = configt::cppt::cpp_standardt::CPP17;
           }
         }
       }

--- a/src/cpp/cpp_parser.cpp
+++ b/src/cpp/cpp_parser.cpp
@@ -21,9 +21,10 @@ bool cpp_parsert::parse()
 {
   // We use the ANSI-C scanner
   ansi_c_parser.cpp98=true;
-  ansi_c_parser.cpp11=
-    config.cpp.cpp_standard==configt::cppt::cpp_standardt::CPP11 ||
-    config.cpp.cpp_standard==configt::cppt::cpp_standardt::CPP14;
+  ansi_c_parser.cpp11 =
+    config.cpp.cpp_standard == configt::cppt::cpp_standardt::CPP11 ||
+    config.cpp.cpp_standard == configt::cppt::cpp_standardt::CPP14 ||
+    config.cpp.cpp_standard == configt::cppt::cpp_standardt::CPP17;
   ansi_c_parser.ts_18661_3_Floatn_types=false;
   ansi_c_parser.in=in;
   ansi_c_parser.mode=mode;

--- a/src/goto-cc/gcc_mode.cpp
+++ b/src/goto-cc/gcc_mode.cpp
@@ -593,6 +593,9 @@ int gcc_modet::doit()
 
     if(std_string=="gnu++14" || std_string=="c++14")
       config.cpp.set_cpp14();
+
+    if(std_string == "gnu++17" || std_string == "c++17")
+      config.cpp.set_cpp17();
   }
   else
   {

--- a/src/util/config.h
+++ b/src/util/config.h
@@ -6,7 +6,6 @@ Author: Daniel Kroening, kroening@kroening.com
 
 \*******************************************************************/
 
-
 #ifndef CPROVER_UTIL_CONFIG_H
 #define CPROVER_UTIL_CONFIG_H
 
@@ -125,12 +124,29 @@ public:
     bool ts_18661_3_Floatn_types; // ISO/IEC TS 18661-3:2015
     bool gcc__float128_type;      // __float128, a gcc extension since 4.3/4.5
     bool single_precision_constant;
-    enum class c_standardt { C89, C99, C11 } c_standard;
+    enum class c_standardt
+    {
+      C89,
+      C99,
+      C11
+    } c_standard;
     static c_standardt default_c_standard();
 
-    void set_c89() { c_standard=c_standardt::C89; for_has_scope=false; }
-    void set_c99() { c_standard=c_standardt::C99; for_has_scope=true; }
-    void set_c11() { c_standard=c_standardt::C11; for_has_scope=true; }
+    void set_c89()
+    {
+      c_standard = c_standardt::C89;
+      for_has_scope = false;
+    }
+    void set_c99()
+    {
+      c_standard = c_standardt::C99;
+      for_has_scope = true;
+    }
+    void set_c11()
+    {
+      c_standard = c_standardt::C11;
+      for_has_scope = true;
+    }
 
     ieee_floatt::rounding_modet rounding_mode;
 
@@ -152,10 +168,21 @@ public:
     // instruction (in bytes)
     std::size_t memory_operand_size;
 
-    enum class endiannesst { NO_ENDIANNESS, IS_LITTLE_ENDIAN, IS_BIG_ENDIAN };
+    enum class endiannesst
+    {
+      NO_ENDIANNESS,
+      IS_LITTLE_ENDIAN,
+      IS_BIG_ENDIAN
+    };
     endiannesst endianness;
 
-    enum class ost { NO_OS, OS_LINUX, OS_MACOS, OS_WIN };
+    enum class ost
+    {
+      NO_OS,
+      OS_LINUX,
+      OS_MACOS,
+      OS_WIN
+    };
     ost os;
 
     static std::string os_to_string(ost);
@@ -194,8 +221,15 @@ public:
     };
     flavourt mode; // the syntax of source files
 
-    enum class preprocessort { NONE, GCC, CLANG, VISUAL_STUDIO,
-                               CODEWARRIOR, ARM };
+    enum class preprocessort
+    {
+      NONE,
+      GCC,
+      CLANG,
+      VISUAL_STUDIO,
+      CODEWARRIOR,
+      ARM
+    };
     preprocessort preprocessor; // the preprocessor to use
 
     std::list<std::string> defines;
@@ -204,7 +238,11 @@ public:
     std::list<std::string> include_paths;
     std::list<std::string> include_files;
 
-    enum class libt { LIB_NONE, LIB_FULL };
+    enum class libt
+    {
+      LIB_NONE,
+      LIB_FULL
+    };
     libt lib;
 
     bool string_abstraction;
@@ -219,21 +257,43 @@ public:
 
     malloc_failure_modet malloc_failure_mode = malloc_failure_mode_none;
 
-    static const std::size_t default_object_bits=8;
+    static const std::size_t default_object_bits = 8;
   } ansi_c;
 
   struct cppt
   {
-    enum class cpp_standardt { CPP98, CPP03, CPP11, CPP14, CPP17 } cpp_standard;
+    enum class cpp_standardt
+    {
+      CPP98,
+      CPP03,
+      CPP11,
+      CPP14,
+      CPP17
+    } cpp_standard;
     static cpp_standardt default_cpp_standard();
 
-    void set_cpp98() { cpp_standard=cpp_standardt::CPP98; }
-    void set_cpp03() { cpp_standard=cpp_standardt::CPP03; }
-    void set_cpp11() { cpp_standard=cpp_standardt::CPP11; }
-    void set_cpp14() { cpp_standard=cpp_standardt::CPP14; }
-    void set_cpp17() { cpp_standard=cpp_standardt::CPP17; }
+    void set_cpp98()
+    {
+      cpp_standard = cpp_standardt::CPP98;
+    }
+    void set_cpp03()
+    {
+      cpp_standard = cpp_standardt::CPP03;
+    }
+    void set_cpp11()
+    {
+      cpp_standard = cpp_standardt::CPP11;
+    }
+    void set_cpp14()
+    {
+      cpp_standard = cpp_standardt::CPP14;
+    }
+    void set_cpp17()
+    {
+      cpp_standard = cpp_standardt::CPP17;
+    }
 
-    static const std::size_t default_object_bits=8;
+    static const std::size_t default_object_bits = 8;
   } cpp;
 
   struct verilogt
@@ -247,7 +307,7 @@ public:
     classpatht classpath;
     irep_idt main_class;
 
-    static const std::size_t default_object_bits=16;
+    static const std::size_t default_object_bits = 16;
   } java;
 
   struct bv_encodingt

--- a/src/util/config.h
+++ b/src/util/config.h
@@ -224,13 +224,14 @@ public:
 
   struct cppt
   {
-    enum class cpp_standardt { CPP98, CPP03, CPP11, CPP14 } cpp_standard;
+    enum class cpp_standardt { CPP98, CPP03, CPP11, CPP14, CPP17 } cpp_standard;
     static cpp_standardt default_cpp_standard();
 
     void set_cpp98() { cpp_standard=cpp_standardt::CPP98; }
     void set_cpp03() { cpp_standard=cpp_standardt::CPP03; }
     void set_cpp11() { cpp_standard=cpp_standardt::CPP11; }
     void set_cpp14() { cpp_standard=cpp_standardt::CPP14; }
+    void set_cpp17() { cpp_standard=cpp_standardt::CPP17; }
 
     static const std::size_t default_object_bits=8;
   } cpp;


### PR DESCRIPTION
<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [x] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

Based on suggestions by @martin-cs and @tautschnig.
Fixes: #6090 
Obsoletes: #6144 

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
