### PR TITLE
change make_return method name and signature

### DIFF
--- a/src/analyses/flow_insensitive_analysis.cpp
+++ b/src/analyses/flow_insensitive_analysis.cpp
@@ -202,8 +202,8 @@ bool flow_insensitive_analysis_baset::do_function_call(
     goto_programt temp;
 
     goto_programt::targett r =
-      temp.add(goto_programt::make_return(code_returnt(side_effect_expr_nondett(
-        l_call->call_lhs().type(), l_call->source_location()))));
+      temp.add(goto_programt::make_set_return_value(side_effect_expr_nondett(
+        l_call->call_lhs().type(), l_call->source_location())));
     r->location_number=0;
 
     goto_programt::targett t = temp.add(goto_programt::make_end_function());

--- a/src/goto-instrument/contracts/contracts.cpp
+++ b/src/goto-instrument/contracts/contracts.cpp
@@ -1178,8 +1178,8 @@ void code_contractst::add_contract_check(
 
   if(code_type.return_type() != empty_typet())
   {
-    check.add(
-      goto_programt::make_return(return_stmt.value(), skip->source_location()));
+    check.add(goto_programt::make_set_return_value(
+      return_stmt.value().return_value(), skip->source_location()));
   }
 
   // prepend the new code to dest

--- a/src/goto-instrument/generate_function_bodies.cpp
+++ b/src/goto-instrument/generate_function_bodies.cpp
@@ -357,7 +357,8 @@ protected:
       exprt return_expr =
         typecast_exprt::conditional_cast(aux_symbol.symbol_expr(), return_type);
 
-      add_instruction(goto_programt::make_return(code_returnt(return_expr)));
+      add_instruction(
+        goto_programt::make_set_return_value(std::move(return_expr)));
 
       add_instruction(goto_programt::make_dead(aux_symbol.symbol_expr()));
     }

--- a/src/goto-programs/goto_convert.cpp
+++ b/src/goto-programs/goto_convert.cpp
@@ -1296,9 +1296,9 @@ void goto_convertt::convert_return(
       "function must return value",
       new_code.find_source_location());
 
-    // Now add a return node to set the return value.
-    dest.add(goto_programt::make_return(
-      to_code_return(new_code), new_code.source_location()));
+    // Now add a 'set return value' instruction to set the return value.
+    dest.add(goto_programt::make_set_return_value(
+      new_code.return_value(), new_code.source_location()));
   }
   else
   {

--- a/src/goto-programs/goto_convert_functions.cpp
+++ b/src/goto-programs/goto_convert_functions.cpp
@@ -138,7 +138,7 @@ void goto_convert_functionst::add_return(
   side_effect_expr_nondett rhs(return_type, source_location);
 
   f.body.add(
-    goto_programt::make_return(code_returnt(std::move(rhs)), source_location));
+    goto_programt::make_set_return_value(std::move(rhs), source_location));
 }
 
 void goto_convert_functionst::convert_function(

--- a/src/goto-programs/goto_program.h
+++ b/src/goto-programs/goto_program.h
@@ -822,12 +822,21 @@ public:
     }
   }
 
-  static instructiont make_return(
-    code_returnt c,
+  static instructiont make_set_return_value(
+    exprt return_value,
     const source_locationt &l = source_locationt::nil())
   {
-    return instructiont(std::move(c), l, SET_RETURN_VALUE, nil_exprt(), {});
+    return instructiont(
+      code_returnt(std::move(return_value)),
+      l,
+      SET_RETURN_VALUE,
+      nil_exprt(),
+      {});
   }
+
+  static instructiont make_set_return_value(
+    const code_returnt &code,
+    const source_locationt &l = source_locationt::nil()) = delete;
 
   static instructiont
   make_skip(const source_locationt &l = source_locationt::nil())

--- a/src/goto-programs/remove_returns.cpp
+++ b/src/goto-programs/remove_returns.cpp
@@ -314,8 +314,8 @@ bool remove_returnst::restore_returns(
 
       // replace "fkt#return_value=x;" by "return x;"
       const exprt rhs = instruction.assign_rhs();
-      instruction = goto_programt::make_return(
-        code_returnt(rhs), instruction.source_location());
+      instruction = goto_programt::make_set_return_value(
+        rhs, instruction.source_location());
       did_something = true;
     }
   }


### PR DESCRIPTION
The method creates a 'set return value' instruction, and the new name reflects that.
    
The method now takes the return value as argument, and not a `code_returnt` expression.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
