### PR TITLE
introduce goto_programt::instructiont::type() and _nonconst()

### DIFF
--- a/jbmc/unit/java_bytecode/goto-programs/remove_virtual_functions_without_fallback.cpp
+++ b/jbmc/unit/java_bytecode/goto-programs/remove_virtual_functions_without_fallback.cpp
@@ -88,7 +88,7 @@ static goto_programt::const_targett interpret_classid_comparison(
 
   while(pc != program.instructions.end())
   {
-    if(pc->type == GOTO)
+    if(pc->type() == GOTO)
     {
       exprt guard = pc->guard;
       guard = resolve_classid_test(guard, actual_class_id, ns);
@@ -105,7 +105,7 @@ static goto_programt::const_targett interpret_classid_comparison(
         return pc;
       }
     }
-    else if(pc->type == SKIP)
+    else if(pc->type() == SKIP)
     {
       ++pc;
     }

--- a/jbmc/unit/java_bytecode/java_bytecode_instrument/virtual_call_null_checks.cpp
+++ b/jbmc/unit/java_bytecode/java_bytecode_instrument/virtual_call_null_checks.cpp
@@ -19,7 +19,7 @@ Author: Diffblue Limited.
 static bool is_expected_virtualmethod_call(
   const goto_programt::instructiont &instruction)
 {
-  if(instruction.type != FUNCTION_CALL)
+  if(instruction.type() != FUNCTION_CALL)
     return false;
   const auto &called_function = instruction.call_function();
   if(!can_cast_expr<class_method_descriptor_exprt>(called_function))

--- a/jbmc/unit/java_bytecode/java_virtual_functions/virtual_functions.cpp
+++ b/jbmc/unit/java_bytecode/java_virtual_functions/virtual_functions.cpp
@@ -30,7 +30,7 @@ void check_function_call(
 
   for(const auto &target : targets)
   {
-    REQUIRE(target->type == goto_program_instruction_typet::FUNCTION_CALL);
+    REQUIRE(target->type() == goto_program_instruction_typet::FUNCTION_CALL);
     REQUIRE(target->call_function().id() == ID_symbol);
     REQUIRE(
       to_symbol_expr(target->call_function()).get_identifier() ==
@@ -69,7 +69,7 @@ SCENARIO(
           {
             // There should be two guarded GOTOs with non-constant guards. One
             // branching for class C and one for class D or O.
-            if(instruction.type == goto_program_instruction_typet::GOTO)
+            if(instruction.type() == goto_program_instruction_typet::GOTO)
             {
               if(instruction.guard.id() == ID_equal)
               {
@@ -146,7 +146,7 @@ SCENARIO(
         {
           irep_idt current_index;
 
-          while(it->type != goto_program_instruction_typet::END_FUNCTION)
+          while(it->type() != goto_program_instruction_typet::END_FUNCTION)
           {
             const source_locationt &loc = it->source_location();
             REQUIRE(loc != source_locationt::nil());
@@ -157,7 +157,7 @@ SCENARIO(
             {
               current_index = new_index;
               // instruction with a new bytecode index begins with ASSERT
-              REQUIRE(it->type == goto_program_instruction_typet::ASSERT);
+              REQUIRE(it->type() == goto_program_instruction_typet::ASSERT);
               // the assertion corresponds to a line coverage goal
               REQUIRE_FALSE(loc.get_basic_block_covered_lines().empty());
             }

--- a/src/analyses/custom_bitvector_analysis.cpp
+++ b/src/analyses/custom_bitvector_analysis.cpp
@@ -283,7 +283,7 @@ void custom_bitvector_domaint::transform(
 
   const goto_programt::instructiont &instruction=*from;
 
-  switch(instruction.type)
+  switch(instruction.type())
   {
   case ASSIGN:
     assign_struct_rec(

--- a/src/analyses/escape_analysis.cpp
+++ b/src/analyses/escape_analysis.cpp
@@ -184,7 +184,7 @@ void escape_domaint::transform(
 
   const goto_programt::instructiont &instruction=*from;
 
-  switch(instruction.type)
+  switch(instruction.type())
   {
   case ASSIGN:
     {
@@ -460,7 +460,7 @@ void escape_analysist::instrument(
 
       const goto_programt::instructiont &instruction=*i_it;
 
-      if(instruction.type == ASSIGN)
+      if(instruction.type() == ASSIGN)
       {
         const exprt &assign_lhs = instruction.assign_lhs();
 
@@ -469,7 +469,7 @@ void escape_analysist::instrument(
         insert_cleanup(
           gf_entry.second, i_it, assign_lhs, cleanup_functions, false, ns);
       }
-      else if(instruction.type == DEAD)
+      else if(instruction.type() == DEAD)
       {
         const auto &dead_symbol = instruction.dead_symbol();
 

--- a/src/analyses/global_may_alias.cpp
+++ b/src/analyses/global_may_alias.cpp
@@ -107,7 +107,7 @@ void global_may_alias_domaint::transform(
 
   const goto_programt::instructiont &instruction=*from;
 
-  switch(instruction.type)
+  switch(instruction.type())
   {
   case ASSIGN:
   {

--- a/src/analyses/goto_rw.cpp
+++ b/src/analyses/goto_rw.cpp
@@ -756,7 +756,7 @@ void goto_rw(
   goto_programt::const_targett target,
   rw_range_sett &rw_set)
 {
-  switch(target->type)
+  switch(target->type())
   {
   case NO_INSTRUCTION_TYPE:
   case INCOMPLETE_GOTO:

--- a/src/analyses/interval_domain.cpp
+++ b/src/analyses/interval_domain.cpp
@@ -68,7 +68,7 @@ void interval_domaint::transform(
   locationt to{trace_to->current_location()};
 
   const goto_programt::instructiont &instruction=*from;
-  switch(instruction.type)
+  switch(instruction.type())
   {
   case DECL:
     havoc_rec(instruction.decl_symbol());

--- a/src/analyses/invariant_set_domain.cpp
+++ b/src/analyses/invariant_set_domain.cpp
@@ -25,7 +25,7 @@ void invariant_set_domaint::transform(
   locationt from_l(trace_from->current_location());
   locationt to_l(trace_to->current_location());
 
-  switch(from_l->type)
+  switch(from_l->type())
   {
   case GOTO:
     {

--- a/src/analyses/local_bitvector_analysis.cpp
+++ b/src/analyses/local_bitvector_analysis.cpp
@@ -266,7 +266,7 @@ void local_bitvector_analysist::build()
     auto &loc_info_src=loc_infos[loc_nr];
     auto loc_info_dest=loc_infos[loc_nr];
 
-    switch(instruction.type)
+    switch(instruction.type())
     {
     case ASSIGN:
       assign_lhs(

--- a/src/analyses/local_cfg.cpp
+++ b/src/analyses/local_cfg.cpp
@@ -32,7 +32,7 @@ void local_cfgt::build(const goto_programt &goto_program)
     nodet &node=nodes[loc_nr];
     const goto_programt::instructiont &instruction=*node.t;
 
-    switch(instruction.type)
+    switch(instruction.type())
     {
     case GOTO:
       if(!instruction.get_condition().is_true())

--- a/src/analyses/local_may_alias.cpp
+++ b/src/analyses/local_may_alias.cpp
@@ -371,7 +371,7 @@ void local_may_aliast::build(const goto_functiont &goto_function)
     const loc_infot &loc_info_src=loc_infos[loc_nr];
     loc_infot loc_info_dest=loc_infos[loc_nr];
 
-    switch(instruction.type)
+    switch(instruction.type())
     {
     case ASSIGN:
     {

--- a/src/analyses/local_safe_pointers.cpp
+++ b/src/analyses/local_safe_pointers.cpp
@@ -108,7 +108,7 @@ void local_safe_pointerst::operator()(const goto_programt &goto_program)
         instruction.location_number, checked_expressions);
     }
 
-    switch(instruction.type)
+    switch(instruction.type())
     {
     // Instruction types that definitely don't write anything, and therefore
     // can't store a null pointer:

--- a/src/analyses/uncaught_exceptions_analysis.cpp
+++ b/src/analyses/uncaught_exceptions_analysis.cpp
@@ -67,7 +67,7 @@ void uncaught_exceptions_domaint::transform(
 {
   const goto_programt::instructiont &instruction=*from;
 
-  switch(instruction.type)
+  switch(instruction.type())
   {
   case THROW:
   {

--- a/src/analyses/variable-sensitivity/variable_sensitivity_domain.cpp
+++ b/src/analyses/variable-sensitivity/variable_sensitivity_domain.cpp
@@ -36,7 +36,7 @@ void variable_sensitivity_domaint::transform(
 #endif
 
   const goto_programt::instructiont &instruction = *from;
-  switch(instruction.type)
+  switch(instruction.type())
   {
   case DECL:
   {
@@ -290,7 +290,7 @@ void variable_sensitivity_domaint::transform_function_call(
   ai_baset &ai,
   const namespacet &ns)
 {
-  PRECONDITION(from->type == FUNCTION_CALL);
+  PRECONDITION(from->type() == FUNCTION_CALL);
 
   const exprt &function = from->call_function();
 

--- a/src/goto-instrument/accelerate/disjunctive_polynomial_acceleration.cpp
+++ b/src/goto-instrument/accelerate/disjunctive_polynomial_acceleration.cpp
@@ -845,9 +845,7 @@ void disjunctive_polynomial_accelerationt::build_fixed()
   for(auto &instruction : fixed.instructions)
   {
     if(instruction.is_assert())
-    {
-      instruction.type = ASSUME;
-    }
+      instruction.turn_into_assume();
   }
 
   // We're only interested in paths that loop back to the loop header.

--- a/src/goto-instrument/accelerate/sat_path_enumerator.cpp
+++ b/src/goto-instrument/accelerate/sat_path_enumerator.cpp
@@ -196,7 +196,7 @@ void sat_path_enumeratort::build_fixed()
   for(auto &instruction : fixed.instructions)
   {
     if(instruction.is_assert())
-      instruction.type = ASSUME;
+      instruction.turn_into_assume();
   }
 
   // We're only interested in paths that loop back to the loop header.

--- a/src/goto-instrument/contracts/contracts.cpp
+++ b/src/goto-instrument/contracts/contracts.cpp
@@ -261,8 +261,8 @@ void code_contractst::check_apply_loop_contracts(
   insert_before_swap_and_advance(goto_function.body, loop_end, havoc_code);
 
   // change the back edge into assume(false) or assume(guard)
-  loop_end->targets.clear();
-  loop_end->type = ASSUME;
+  loop_end->turn_into_assume();
+
   if(loop_head->is_goto())
     loop_end->set_condition(false_exprt());
   else

--- a/src/goto-instrument/cover.cpp
+++ b/src/goto-instrument/cover.cpp
@@ -311,7 +311,8 @@ static void instrument_cover_goals(
           {
             successor->turn_into_skip();
           }
-          i_it->type = goto_program_instruction_typet::ASSUME;
+
+          i_it->turn_into_assume();
         }
         else
         {

--- a/src/goto-instrument/goto_program2code.cpp
+++ b/src/goto-instrument/goto_program2code.cpp
@@ -138,7 +138,9 @@ goto_programt::const_targett goto_program2codet::convert_instruction(
 {
   assert(target!=goto_program.instructions.end());
 
-  if(target->type != ASSERT && !target->source_location().get_comment().empty())
+  if(
+    target->type() != ASSERT &&
+    !target->source_location().get_comment().empty())
   {
     dest.add(code_skipt());
     dest.statements().back().add_source_location().set_comment(
@@ -158,7 +160,7 @@ goto_programt::const_targett goto_program2codet::convert_instruction(
 
   convert_labels(target, dest);
 
-  switch(target->type)
+  switch(target->type())
   {
     case SKIP:
     case LOCATION:
@@ -764,10 +766,9 @@ bool goto_program2codet::set_block_end_points(
       continue;
 
     // compute the block that belongs to this case
-    for(goto_programt::const_targett case_end=it->case_start;
-        case_end!=goto_program.instructions.end() &&
-        case_end->type!=END_FUNCTION &&
-        case_end!=upper_bound;
+    for(goto_programt::const_targett case_end = it->case_start;
+        case_end != goto_program.instructions.end() &&
+        case_end->type() != END_FUNCTION && case_end != upper_bound;
         ++case_end)
     {
       const auto &case_end_node = dominators.get_node(case_end);

--- a/src/goto-instrument/k_induction.cpp
+++ b/src/goto-instrument/k_induction.cpp
@@ -131,7 +131,7 @@ void k_inductiont::process_loop(
     {
       assert(t!=goto_function.body.instructions.end());
       if(t->is_assert())
-        t->type=ASSUME;
+        t->turn_into_assume();
     }
 
     // assume the loop condition has become false

--- a/src/goto-instrument/points_to.cpp
+++ b/src/goto-instrument/points_to.cpp
@@ -56,7 +56,7 @@ bool points_tot::transform(const cfgt::nodet &e)
   bool result=false;
   const goto_programt::instructiont &instruction=*(e.PC);
 
-  switch(instruction.type)
+  switch(instruction.type())
   {
   case SET_RETURN_VALUE:
     // TODO

--- a/src/goto-instrument/uninitialized.cpp
+++ b/src/goto-instrument/uninitialized.cpp
@@ -112,21 +112,20 @@ void uninitializedt::add_assertions(
 
       if(tracking.find(identifier)!=tracking.end())
       {
-        goto_programt::targett i1=goto_program.insert_after(i_it);
-        goto_programt::targett i2=goto_program.insert_after(i1);
-        i_it++, i_it++;
-
         const irep_idt new_identifier=
           id2string(identifier)+"#initialized";
 
         symbol_exprt symbol_expr(new_identifier, bool_typet());
-        i1->type=DECL;
-        i1->source_location_nonconst() = instruction.source_location();
-        i1->code_nonconst() = code_declt(symbol_expr);
+        goto_programt::instructiont i1 =
+          goto_programt::make_decl(symbol_expr, instruction.source_location());
 
-        i2->type=ASSIGN;
-        i2->source_location_nonconst() = instruction.source_location();
-        i2->code_nonconst() = code_assignt(symbol_expr, false_exprt());
+        goto_programt::instructiont i2 = goto_programt::make_assignment(
+          symbol_expr, false_exprt(), instruction.source_location());
+
+        goto_programt::targett i1_it =
+          goto_program.insert_after(i_it, std::move(i1));
+        goto_program.insert_after(i1_it, std::move(i2));
+        i_it++, i_it++;
       }
     }
     else
@@ -180,12 +179,11 @@ void uninitializedt::add_assertions(
           {
             const irep_idt new_identifier=id2string(identifier)+"#initialized";
 
-            goto_programt::instructiont assignment;
-            assignment.type=ASSIGN;
-            assignment.code_nonconst() = code_assignt(
-              symbol_exprt(new_identifier, bool_typet()), true_exprt());
-            assignment.source_location_nonconst() =
-              instruction.source_location();
+            goto_programt::instructiont assignment =
+              goto_programt::make_assignment(
+                symbol_exprt(new_identifier, bool_typet()),
+                true_exprt(),
+                instruction.source_location());
 
             goto_program.insert_before_swap(i_it, assignment);
             i_it++;

--- a/src/goto-instrument/value_set_fi_fp_removal.cpp
+++ b/src/goto-instrument/value_set_fi_fp_removal.cpp
@@ -175,10 +175,8 @@ void remove_function_pointer(
 
   // We preserve the original dereferencing to possibly catch
   // further pointer-related errors.
-  code_expressiont code_expression(function);
-  code_expression.add_source_location() = function.source_location();
-  target->code_nonconst().swap(code_expression);
-  target->type = OTHER;
+  *target = goto_programt::make_other(
+    code_expressiont(function), function.source_location());
 }
 
 void value_set_fi_fp_removal(

--- a/src/goto-instrument/wmm/goto2graph.cpp
+++ b/src/goto-instrument/wmm/goto2graph.cpp
@@ -186,8 +186,8 @@ void instrumentert::cfg_visitort::visit_cfg_function(
       current_thread=coming_from;
     thread=current_thread;
 
-    instrumenter.message.debug() << "visit instruction "<<instruction.type
-      << messaget::eom;
+    instrumenter.message.debug()
+      << "visit instruction " << instruction.type() << messaget::eom;
 
     if(instruction.is_start_thread() || instruction.is_end_thread())
     {

--- a/src/goto-instrument/wmm/shared_buffers.cpp
+++ b/src/goto-instrument/wmm/shared_buffers.cpp
@@ -159,11 +159,8 @@ void shared_bufferst::assignment(
   {
     const exprt symbol=ns.lookup(identifier).symbol_expr();
 
-    t=goto_program.insert_before(t);
-    t->type=ASSIGN;
-    t->code_nonconst() = code_assignt(symbol, value);
-    t->code_nonconst().add_source_location() = source_location;
-    t->source_location_nonconst() = source_location;
+    t = goto_program.insert_before(
+      t, goto_programt::make_assignment(symbol, value, source_location));
 
     // instrumentations.insert((const irep_idt) (t->code.id()));
 
@@ -1072,8 +1069,8 @@ void shared_bufferst::cfg_visitort::weak_memory(
   {
     goto_programt::instructiont &instruction=*i_it;
 
-    shared_buffers.message.debug() << "instruction "<<instruction.type
-                                   << messaget::eom;
+    shared_buffers.message.debug()
+      << "instruction " << instruction.type() << messaget::eom;
 
     /* thread marking */
     if(instruction.is_start_thread())

--- a/src/goto-programs/cfg.h
+++ b/src/goto-programs/cfg.h
@@ -463,7 +463,7 @@ void cfg_baset<T, P, I>::compute_edges(
   next_PC++;
 
   // compute forward edges first
-  switch(instruction.type)
+  switch(instruction.type())
   {
   case GOTO:
     compute_edges_goto(goto_program, instruction, next_PC, entry);

--- a/src/goto-programs/goto_convert.cpp
+++ b/src/goto-programs/goto_convert.cpp
@@ -208,8 +208,8 @@ void goto_convertt::finish_computed_gotos(goto_programt &goto_program)
     const exprt pointer = destination.pointer();
 
     // remember the expression for later checks
-    i.type=OTHER;
-    i.code_nonconst() = code_expressiont(pointer);
+    i =
+      goto_programt::make_other(code_expressiont(pointer), i.source_location());
 
     // insert huge case-split
     for(const auto &label : targets.labels)

--- a/src/goto-programs/goto_inline_class.cpp
+++ b/src/goto-programs/goto_inline_class.cpp
@@ -162,15 +162,15 @@ void goto_inlinet::replace_return(
       {
         // a typecast may be necessary if the declared return type at the call
         // site differs from the defined return type
-        it->code_nonconst() = code_assignt(
+        *it = goto_programt::make_assignment(
           lhs,
-          typecast_exprt::conditional_cast(it->return_value(), lhs.type()));
-        it->type=ASSIGN;
+          typecast_exprt::conditional_cast(it->return_value(), lhs.type()),
+          it->source_location());
       }
       else
       {
-        it->code_nonconst() = code_expressiont(it->return_value());
-        it->type=OTHER;
+        *it = goto_programt::make_other(
+          code_expressiont(it->return_value()), it->source_location());
       }
     }
   }
@@ -232,7 +232,7 @@ void goto_inlinet::insert_function_body(
   DATA_INVARIANT(
     end.is_end_function(),
     "final instruction of a function must be an END_FUNCTION");
-  end.type=LOCATION;
+  end = goto_programt::make_location(end.source_location());
 
   // make sure the inlined function does not introduce hiding
   if(goto_function.is_hidden())
@@ -290,8 +290,7 @@ void goto_inlinet::insert_function_body(
   }
 
   // kill call
-  target->type=LOCATION;
-  target->code_nonconst().clear();
+  *target = goto_programt::make_location(target->source_location());
   target++;
 
   dest.destructive_insert(target, tmp);

--- a/src/goto-programs/goto_program.cpp
+++ b/src/goto-programs/goto_program.cpp
@@ -83,7 +83,7 @@ std::ostream &goto_programt::output_instruction(
   else
     out << "        ";
 
-  switch(instruction.type)
+  switch(instruction.type())
   {
   case NO_INSTRUCTION_TYPE:
     out << "NO INSTRUCTION TYPE SET" << '\n';
@@ -331,7 +331,7 @@ std::list<exprt> expressions_read(
 {
   std::list<exprt> dest;
 
-  switch(instruction.type)
+  switch(instruction.type())
   {
   case ASSUME:
   case ASSERT:
@@ -380,7 +380,7 @@ std::list<exprt> expressions_written(
 {
   std::list<exprt> dest;
 
-  switch(instruction.type)
+  switch(instruction.type())
   {
   case FUNCTION_CALL:
     if(instruction.call_lhs().is_not_nil())
@@ -486,7 +486,7 @@ std::string as_string(
 {
   std::string result;
 
-  switch(i.type)
+  switch(i.type())
   {
   case NO_INSTRUCTION_TYPE:
     return "(NO INSTRUCTION TYPE)";
@@ -743,7 +743,7 @@ bool goto_programt::instructiont::equals(const instructiont &other) const
 {
   // clang-format off
   return
-    type == other.type &&
+    _type == other._type &&
     code == other.code &&
     guard == other.guard &&
     targets.size() == other.targets.size() &&
@@ -842,7 +842,7 @@ void goto_programt::instructiont::validate(
     };
 
   const symbolt *table_symbol;
-  switch(type)
+  switch(_type)
   {
   case NO_INSTRUCTION_TYPE:
     break;
@@ -955,7 +955,7 @@ void goto_programt::instructiont::validate(
 void goto_programt::instructiont::transform(
   std::function<optionalt<exprt>(exprt)> f)
 {
-  switch(type)
+  switch(_type)
   {
   case OTHER:
     if(get_other().get_statement() == ID_expression)
@@ -1059,7 +1059,7 @@ void goto_programt::instructiont::transform(
 void goto_programt::instructiont::apply(
   std::function<void(const exprt &)> f) const
 {
-  switch(type)
+  switch(_type)
   {
   case OTHER:
     if(get_other().get_statement() == ID_expression)

--- a/src/goto-programs/goto_program.h
+++ b/src/goto-programs/goto_program.h
@@ -340,8 +340,24 @@ public:
     }
 
     /// What kind of instruction?
-    goto_program_instruction_typet type;
+    goto_program_instruction_typet type() const
+    {
+      return _type;
+    }
 
+    /// Set the kind of the instruction.
+    /// This method is best avoided to prevent mal-formed instructions.
+    /// Consider using the goto_programt::make_X methods instead.
+    goto_program_instruction_typet &type_nonconst()
+    {
+      return _type;
+    }
+
+  protected:
+    // Use type() and type_nonconst() to access.
+    goto_program_instruction_typet _type;
+
+  public:
     /// Guard for gotos, assume, assert
     /// Use condition() method to access.
     /// This member will eventually be protected.
@@ -426,9 +442,9 @@ public:
     { return target_number!=nil_target; }
 
     /// Clear the node
-    void clear(goto_program_instruction_typet _type)
+    void clear(goto_program_instruction_typet __type)
     {
-      type=_type;
+      _type = __type;
       targets.clear();
       guard=true_exprt();
       code.make_nil();
@@ -453,32 +469,32 @@ public:
 
     void complete_goto(targett _target)
     {
-      PRECONDITION(type == INCOMPLETE_GOTO);
+      PRECONDITION(_type == INCOMPLETE_GOTO);
       code.make_nil();
       targets.push_back(_target);
-      type = GOTO;
+      _type = GOTO;
     }
 
     // clang-format off
-    bool is_goto            () const { return type == GOTO;             }
-    bool is_set_return_value() const { return type == SET_RETURN_VALUE; }
-    bool is_assign          () const { return type == ASSIGN;           }
-    bool is_function_call   () const { return type == FUNCTION_CALL;    }
-    bool is_throw           () const { return type == THROW;            }
-    bool is_catch           () const { return type == CATCH;            }
-    bool is_skip            () const { return type == SKIP;             }
-    bool is_location        () const { return type == LOCATION;         }
-    bool is_other           () const { return type == OTHER;            }
-    bool is_decl            () const { return type == DECL;             }
-    bool is_dead            () const { return type == DEAD;             }
-    bool is_assume          () const { return type == ASSUME;           }
-    bool is_assert          () const { return type == ASSERT;           }
-    bool is_atomic_begin    () const { return type == ATOMIC_BEGIN;     }
-    bool is_atomic_end      () const { return type == ATOMIC_END;       }
-    bool is_start_thread    () const { return type == START_THREAD;     }
-    bool is_end_thread      () const { return type == END_THREAD;       }
-    bool is_end_function    () const { return type == END_FUNCTION;     }
-    bool is_incomplete_goto () const { return type == INCOMPLETE_GOTO;  }
+    bool is_goto            () const { return _type == GOTO;             }
+    bool is_set_return_value() const { return _type == SET_RETURN_VALUE; }
+    bool is_assign          () const { return _type == ASSIGN;           }
+    bool is_function_call   () const { return _type == FUNCTION_CALL;    }
+    bool is_throw           () const { return _type == THROW;            }
+    bool is_catch           () const { return _type == CATCH;            }
+    bool is_skip            () const { return _type == SKIP;             }
+    bool is_location        () const { return _type == LOCATION;         }
+    bool is_other           () const { return _type == OTHER;            }
+    bool is_decl            () const { return _type == DECL;             }
+    bool is_dead            () const { return _type == DEAD;             }
+    bool is_assume          () const { return _type == ASSUME;           }
+    bool is_assert          () const { return _type == ASSERT;           }
+    bool is_atomic_begin    () const { return _type == ATOMIC_BEGIN;     }
+    bool is_atomic_end      () const { return _type == ATOMIC_END;       }
+    bool is_start_thread    () const { return _type == START_THREAD;     }
+    bool is_end_thread      () const { return _type == END_THREAD;       }
+    bool is_end_function    () const { return _type == END_FUNCTION;     }
+    bool is_incomplete_goto () const { return _type == INCOMPLETE_GOTO;  }
     // clang-format on
 
     instructiont():
@@ -486,10 +502,10 @@ public:
     {
     }
 
-    explicit instructiont(goto_program_instruction_typet _type)
+    explicit instructiont(goto_program_instruction_typet __type)
       : code(static_cast<const codet &>(get_nil_irep())),
         _source_location(static_cast<const source_locationt &>(get_nil_irep())),
-        type(_type),
+        _type(__type),
         guard(true_exprt())
     {
     }
@@ -498,12 +514,12 @@ public:
     instructiont(
       codet _code,
       source_locationt __source_location,
-      goto_program_instruction_typet _type,
+      goto_program_instruction_typet __type,
       exprt _guard,
       targetst _targets)
       : code(std::move(_code)),
         _source_location(std::move(__source_location)),
-        type(_type),
+        _type(__type),
         guard(std::move(_guard)),
         targets(std::move(_targets))
     {
@@ -515,7 +531,7 @@ public:
       using std::swap;
       swap(instruction.code, code);
       swap(instruction._source_location, _source_location);
-      swap(instruction.type, type);
+      swap(instruction._type, _type);
       swap(instruction.guard, guard);
       swap(instruction.targets, targets);
     }
@@ -552,7 +568,7 @@ public:
     std::string to_string() const
     {
       std::ostringstream instruction_id_builder;
-      instruction_id_builder << type;
+      instruction_id_builder << _type;
       return instruction_id_builder.str();
     }
 

--- a/src/goto-programs/goto_program.h
+++ b/src/goto-programs/goto_program.h
@@ -441,6 +441,16 @@ public:
       clear(SKIP);
     }
 
+    /// Transforms either an assertion or a GOTO instruction
+    /// into an assumption, with the same condition.
+    void turn_into_assume()
+    {
+      PRECONDITION(_type == GOTO || _type == ASSERT);
+      _type = ASSUME;
+      targets.clear();
+      code.make_nil();
+    }
+
     void complete_goto(targett _target)
     {
       PRECONDITION(type == INCOMPLETE_GOTO);

--- a/src/goto-programs/goto_trace.cpp
+++ b/src/goto-programs/goto_trace.cpp
@@ -115,7 +115,7 @@ void goto_trace_stept::output(
   if(!pc->source_location().is_nil())
     out << pc->source_location() << '\n';
 
-  out << pc->type << '\n';
+  out << pc->type() << '\n';
 
   if(pc->is_assert())
   {

--- a/src/goto-programs/instrument_preconditions.cpp
+++ b/src/goto-programs/instrument_preconditions.cpp
@@ -62,7 +62,7 @@ void remove_preconditions(goto_programt &goto_program)
       instruction.is_assert() &&
       instruction.source_location().get_property_class() == ID_precondition)
     {
-      instruction.type=LOCATION;
+      instruction = goto_programt::make_location(instruction.source_location());
     }
     else
       break; // preconditions must be at the front

--- a/src/goto-programs/interpreter.cpp
+++ b/src/goto-programs/interpreter.cpp
@@ -258,7 +258,7 @@ void interpretert::step()
   goto_trace_stept &trace_step=steps.get_last_step();
   trace_step.thread_nr=thread_id;
   trace_step.pc=pc;
-  switch(pc->type)
+  switch(pc->type())
   {
   case GOTO:
     trace_step.type=goto_trace_stept::typet::GOTO;
@@ -337,7 +337,7 @@ void interpretert::step()
     break;
   case THROW:
     trace_step.type=goto_trace_stept::typet::GOTO;
-    while(!done && (pc->type!=CATCH))
+    while(!done && (pc->type() != CATCH))
     {
       if(pc==function->second.body.instructions.end())
       {

--- a/src/goto-programs/read_bin_goto_object.cpp
+++ b/src/goto-programs/read_bin_goto_object.cpp
@@ -104,8 +104,8 @@ static bool read_bin_goto_object(
       instruction.source_location_nonconst() =
         static_cast<const source_locationt &>(
           irepconverter.reference_convert(in));
-      instruction.type = (goto_program_instruction_typet)
-                              irepconverter.read_gb_word(in);
+      instruction.type_nonconst() =
+        (goto_program_instruction_typet)irepconverter.read_gb_word(in);
       instruction.guard =
         static_cast<const exprt &>(irepconverter.reference_convert(in));
       instruction.target_number = irepconverter.read_gb_word(in);

--- a/src/goto-programs/remove_calls_no_body.cpp
+++ b/src/goto-programs/remove_calls_no_body.cpp
@@ -52,8 +52,7 @@ void remove_calls_no_bodyt::remove_call_no_body(
   }
 
   // kill call
-  target->type = LOCATION;
-  target->code_nonconst().clear();
+  *target = goto_programt::make_location(target->source_location());
   target++;
 
   goto_program.destructive_insert(target, tmp);

--- a/src/goto-programs/remove_function_pointers.cpp
+++ b/src/goto-programs/remove_function_pointers.cpp
@@ -446,8 +446,8 @@ void remove_function_pointerst::remove_function_pointer(
   // further pointer-related errors.
   code_expressiont code_expression(function);
   code_expression.add_source_location()=function.source_location();
-  target->code_nonconst().swap(code_expression);
-  target->type=OTHER;
+  *target =
+    goto_programt::make_other(code_expression, target->source_location());
 
   // report statistics
   log.statistics().source_location = target->source_location();

--- a/src/goto-programs/remove_unused_functions.cpp
+++ b/src/goto-programs/remove_unused_functions.cpp
@@ -73,7 +73,7 @@ void find_used_functions(
     {
       for(const auto &instruction : f_it->second.body.instructions)
       {
-        if(instruction.type == FUNCTION_CALL)
+        if(instruction.is_function_call())
         {
           const auto &function = instruction.call_function();
 

--- a/src/goto-programs/remove_virtual_functions.cpp
+++ b/src/goto-programs/remove_virtual_functions.cpp
@@ -153,12 +153,12 @@ static goto_programt analyse_checks_directly_preceding_function_call(
   {
     instr_it = std::prev(instr_it);
 
-    if(instr_it->type == ASSERT)
+    if(instr_it->is_assert())
     {
       continue;
     }
 
-    if(instr_it->type != ASSUME)
+    if(!instr_it->is_assume())
     {
       break;
     }

--- a/src/goto-programs/string_abstraction.cpp
+++ b/src/goto-programs/string_abstraction.cpp
@@ -465,7 +465,7 @@ goto_programt::targett string_abstractiont::abstract(
   goto_programt &dest,
   goto_programt::targett it)
 {
-  switch(it->type)
+  switch(it->type())
   {
   case ASSIGN:
     it=abstract_assign(dest, it);

--- a/src/goto-programs/write_goto_binary.cpp
+++ b/src/goto-programs/write_goto_binary.cpp
@@ -97,7 +97,7 @@ bool write_goto_binary(
       {
         irepconverter.reference_convert(instruction.get_code(), out);
         irepconverter.reference_convert(instruction.source_location(), out);
-        write_gb_word(out, (long)instruction.type);
+        write_gb_word(out, (long)instruction.type());
 
         const auto condition =
           instruction.has_condition() ? instruction.condition() : true_exprt();

--- a/src/goto-symex/symex_main.cpp
+++ b/src/goto-symex/symex_main.cpp
@@ -516,9 +516,9 @@ void goto_symext::print_symex_step(statet &state)
   // debugging and if there's no code block at this point.
   if(
     !symex_config.show_symex_steps || !state.reachable ||
-    state.source.pc->type == DEAD ||
+    state.source.pc->type() == DEAD ||
     (state.source.pc->get_code().is_nil() &&
-     state.source.pc->type != END_FUNCTION))
+     state.source.pc->type() != END_FUNCTION))
   {
     return;
   }
@@ -551,7 +551,7 @@ void goto_symext::print_symex_step(statet &state)
 
   // Print the method we're returning too.
   const auto &call_stack = state.threads[state.source.thread_nr].call_stack;
-  if(state.source.pc->type == END_FUNCTION)
+  if(state.source.pc->type() == END_FUNCTION)
   {
     log.status() << messaget::eom;
 
@@ -566,7 +566,7 @@ void goto_symext::print_symex_step(statet &state)
   }
 
   // On a function call print the entire call stack.
-  if(state.source.pc->type == FUNCTION_CALL)
+  if(state.source.pc->type() == FUNCTION_CALL)
   {
     log.status() << messaget::eom;
 
@@ -620,7 +620,7 @@ void goto_symext::execute_next_instruction(
   state.depth++;
 
   // actually do instruction
-  switch(instruction.type)
+  switch(instruction.type())
   {
   case SKIP:
     if(state.reachable)

--- a/src/pointer-analysis/value_set_domain.h
+++ b/src/pointer-analysis/value_set_domain.h
@@ -70,7 +70,7 @@ void value_set_domain_templatet<VST>::transform(
   const irep_idt &function_to,
   locationt to_l)
 {
-  switch(from_l->type)
+  switch(from_l->type())
   {
   case GOTO:
     // ignore for now

--- a/src/pointer-analysis/value_set_domain_fi.cpp
+++ b/src/pointer-analysis/value_set_domain_fi.cpp
@@ -30,7 +30,7 @@ bool value_set_domain_fit::transform(
   //      from_l->function << " " << from_l->location_number << " to " <<
   //      to_l->function << " " << to_l->location_number << '\n';
 
-  switch(from_l->type)
+  switch(from_l->type())
   {
   case GOTO:
     // ignore for now

--- a/src/solvers/solver_hardness.cpp
+++ b/src/solvers/solver_hardness.cpp
@@ -236,7 +236,7 @@ solver_hardnesst::goto_instruction2string(goto_programt::const_targett pc)
   if(instruction.is_target())
     out << std::setw(6) << instruction.target_number << ": ";
 
-  switch(instruction.type)
+  switch(instruction.type())
   {
   case NO_INSTRUCTION_TYPE:
     out << "NO INSTRUCTION TYPE SET";

--- a/unit/goto-programs/structured_trace_util.cpp
+++ b/unit/goto-programs/structured_trace_util.cpp
@@ -56,7 +56,7 @@ TEST_CASE("structured_trace_util", "[core][util][trace]")
   add_instruction(loop_head_location, instructions);
   // 2: goto 1 # back_edge
   const auto back_edge = add_instruction(back_edge_location, instructions);
-  back_edge->type = GOTO;
+  back_edge->type_nonconst() = GOTO;
   // 3: no_location
   goto_programt::instructiont no_location;
   no_location.location_number = 3;


### PR DESCRIPTION
This introduces two methods to read and write the type of a GOTO program
instruction, and replaces various direct accesses.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- [X] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
