### PR TITLE
Fix fmod(x, INFINITY)

### DIFF
--- a/regression/cbmc/fmod1/main.c
+++ b/regression/cbmc/fmod1/main.c
@@ -1,0 +1,25 @@
+#include <assert.h>
+#include <math.h>
+
+void main()
+{
+  // If x is +-0 and y is not zero, +-0 is returned
+  assert(fmod(0.0, 1.0) == 0.0);
+  assert(fmod(-0.0, 1.0) == -0.0);
+
+  // If x is +-oo and y is not NaN, NaN is returned and FE_INVALID is raised
+  assert(isnan(fmod(INFINITY, 1.0)));
+  assert(isnan(fmod(-INFINITY, 1.0)));
+
+  // If y is +-0 and x is not NaN, NaN is returned and FE_INVALID is raised
+  assert(isnan(fmod(1.0, 0.0)));
+  assert(isnan(fmod(1.0, -0.0)));
+
+  // If y is +-oo and x is finite, x is returned.
+  assert(fmod(1.0, INFINITY) == 1.0);
+  assert(fmod(1.0, -INFINITY) == 1.0);
+
+  // If either argument is NaN, NaN is returned
+  assert(isnan(fmod(1.0, NAN)));
+  assert(isnan(fmod(NAN, 1.0)));
+}

--- a/regression/cbmc/fmod1/test.desc
+++ b/regression/cbmc/fmod1/test.desc
@@ -1,0 +1,11 @@
+KNOWNBUG
+main.c
+
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring
+--
+Currently, the case where the second argument is +-inf is wrongly
+implemented by float_utils.rem.

--- a/regression/cbmc/fmod1/test.desc
+++ b/regression/cbmc/fmod1/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE broken-z3-smt-backend broken-smt-backend
 main.c
 
 ^EXIT=0$
@@ -7,5 +7,3 @@ main.c
 --
 ^warning: ignoring
 --
-Currently, the case where the second argument is +-inf is wrongly
-implemented by float_utils.rem.

--- a/src/solvers/floatbv/float_utils.cpp
+++ b/src/solvers/floatbv/float_utils.cpp
@@ -547,8 +547,11 @@ bvt float_utilst::rem(const bvt &src1, const bvt &src2)
      We have some approaches that are correct but they really
      don't scale. */
 
-  // stub: do src1-(src1/src2)*src2
-  return sub(src1, mul(div(src1, src2), src2));
+  const unbiased_floatt unpacked2 = unpack(src2);
+
+  // stub: do (src2.infinity ? src1 : (src1/src2)*src2))
+  return bv_utils.select(
+    unpacked2.infinity, src1, sub(src1, mul(div(src1, src2), src2)));
 }
 
 bvt float_utilst::negate(const bvt &src)


### PR DESCRIPTION
The case where the second argument of `fmod` is `+-inf` does not give the correct result with the current implementation in `float_utils.rem`.
I've added a regression test that does basic checks on the most important cases.

- [X] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [X] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.
