### PR TITLE
havoc as nondet_pointer [depends-on: #6236, #6366]

### DIFF
--- a/src/goto-instrument/havoc_utils.cpp
+++ b/src/goto-instrument/havoc_utils.cpp
@@ -59,8 +59,20 @@ void havoc_utilst::append_scalar_havoc_code_for_expr(
   const exprt &expr,
   goto_programt &dest) const
 {
-  side_effect_expr_nondett rhs(expr.type(), location);
-  goto_programt::targett t =
-    dest.add(goto_programt::make_assignment(expr, std::move(rhs), location));
-  t->code_nonconst().add_source_location() = location;
+  if (expr.type().id() == ID_pointer)
+  {
+    nondet_symbol_exprt rhs{"havoc::nondet", expr.type(), location};
+    goto_programt::targett t =
+      dest.add(goto_programt::make_assignment(expr, std::move(rhs), location));
+    t->code_nonconst().add_source_location() = location;
+    
+  }
+  else
+  { 
+    side_effect_expr_nondett rhs(expr.type(), location);
+    goto_programt::targett t =
+      dest.add(goto_programt::make_assignment(expr, std::move(rhs), location));
+    t->code_nonconst().add_source_location() = location;
+  }
+
 }


### PR DESCRIPTION
<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
