### PR TITLE
Remove goto_programt::instructiont::type_nonconst

### DIFF
--- a/src/goto-programs/goto_program.h
+++ b/src/goto-programs/goto_program.h
@@ -345,16 +345,9 @@ public:
       return _type;
     }
 
-    /// Set the kind of the instruction.
-    /// This method is best avoided to prevent mal-formed instructions.
-    /// Consider using the goto_programt::make_X methods instead.
-    goto_program_instruction_typet &type_nonconst()
-    {
-      return _type;
-    }
-
   protected:
-    // Use type() and type_nonconst() to access.
+    // Use type() to access. To prevent malformed instructions, no non-const
+    // access method is provided.
     goto_program_instruction_typet _type;
 
   public:

--- a/src/goto-programs/read_bin_goto_object.cpp
+++ b/src/goto-programs/read_bin_goto_object.cpp
@@ -97,17 +97,20 @@ static bool read_bin_goto_object(
     for(std::size_t ins_index = 0; ins_index < ins_count; ++ins_index)
     {
       goto_programt::targett itarget = f.body.add_instruction();
-      goto_programt::instructiont &instruction=*itarget;
 
-      instruction.code_nonconst() =
+      // take copies as references into irepconverter are not stable
+      codet code =
         static_cast<const codet &>(irepconverter.reference_convert(in));
-      instruction.source_location_nonconst() =
-        static_cast<const source_locationt &>(
-          irepconverter.reference_convert(in));
-      instruction.type_nonconst() =
+      source_locationt source_location = static_cast<const source_locationt &>(
+        irepconverter.reference_convert(in));
+      goto_program_instruction_typet instruction_type =
         (goto_program_instruction_typet)irepconverter.read_gb_word(in);
-      instruction.guard =
+      exprt guard =
         static_cast<const exprt &>(irepconverter.reference_convert(in));
+
+      goto_programt::instructiont instruction{
+        code, source_location, instruction_type, guard, {}};
+
       instruction.target_number = irepconverter.read_gb_word(in);
       if(instruction.is_target() &&
          rev_target_map.insert(
@@ -131,6 +134,8 @@ static bool read_bin_goto_object(
         // The above info is also held in the goto_functiont object, and could
         // be stored in the binary.
       }
+
+      itarget->swap(instruction);
     }
 
     // Resolve targets


### PR DESCRIPTION
Use of this method was never advised, and the remaining two uses can be
rewritten to use more appropriate (and modern) APIs.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
