### PR TITLE
Prepare DECL/DEAD construction with location

### DIFF
--- a/src/goto-programs/goto_instruction_code.h
+++ b/src/goto-programs/goto_instruction_code.h
@@ -129,6 +129,11 @@ public:
   {
   }
 
+  code_deadt(symbol_exprt symbol, source_locationt loc)
+    : codet(ID_dead, {std::move(symbol)}, std::move(loc))
+  {
+  }
+
   symbol_exprt &symbol()
   {
     return static_cast<symbol_exprt &>(op0());
@@ -198,6 +203,11 @@ class code_declt : public codet
 {
 public:
   explicit code_declt(symbol_exprt symbol) : codet(ID_decl, {std::move(symbol)})
+  {
+  }
+
+  code_declt(symbol_exprt symbol, source_locationt loc)
+    : codet(ID_decl, {std::move(symbol)}, std::move(loc))
   {
   }
 

--- a/src/goto-programs/goto_program.h
+++ b/src/goto-programs/goto_program.h
@@ -930,10 +930,24 @@ public:
   }
 
   static instructiont make_decl(
+    const code_declt &_code,
+    const source_locationt &l = source_locationt::nil())
+  {
+    return instructiont(_code, l, DECL, nil_exprt(), {});
+  }
+
+  static instructiont make_decl(
     const symbol_exprt &symbol,
     const source_locationt &l = source_locationt::nil())
   {
     return instructiont(code_declt(symbol), l, DECL, nil_exprt(), {});
+  }
+
+  static instructiont make_dead(
+    const code_deadt &_code,
+    const source_locationt &l = source_locationt::nil())
+  {
+    return instructiont(_code, l, DEAD, nil_exprt(), {});
   }
 
   static instructiont make_dead(
@@ -1045,13 +1059,6 @@ public:
   {
     return instructiont(
       code_assignt(std::move(lhs), std::move(rhs)), l, ASSIGN, nil_exprt(), {});
-  }
-
-  static instructiont make_decl(
-    const code_declt &_code,
-    const source_locationt &l = source_locationt::nil())
-  {
-    return instructiont(_code, l, DECL, nil_exprt(), {});
   }
 
   /// Create a function call instruction


### PR DESCRIPTION
Add new constructors to code_{decl,dead}t that also take a location.
This will help avoid some *_nonconst() calls. To facilitate this,
an additional make_dead instruction builder is also needed (which just
mirrors what we already have for other instruction types).

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
