### PR TITLE
Rewrite use of *_nonconst()

### DIFF
--- a/jbmc/src/java_bytecode/remove_exceptions.cpp
+++ b/jbmc/src/java_bytecode/remove_exceptions.cpp
@@ -358,17 +358,16 @@ void remove_exceptionst::add_exception_dispatch_sequence(
         stack_catch[i][j].second;
       if(!stack_catch[i][j].first.empty())
       {
-        // Normal exception handler, make an instanceof check.
-        goto_programt::targett t_exc = goto_program.insert_after(
-          instr_it,
-          goto_programt::make_goto(
-            new_state_pc, true_exprt(), instr_it->source_location()));
-
         // use instanceof to check that this is the correct handler
         struct_tag_typet type(stack_catch[i][j].first);
 
         java_instanceof_exprt check(exc_thrown, type);
-        t_exc->condition_nonconst() = check;
+
+        // Normal exception handler, make an instanceof check.
+        goto_programt::targett t_exc = goto_program.insert_after(
+          instr_it,
+          goto_programt::make_goto(
+            new_state_pc, check, instr_it->source_location()));
 
         if(remove_added_instanceof)
         {

--- a/jbmc/src/java_bytecode/replace_java_nondet.cpp
+++ b/jbmc/src/java_bytecode/replace_java_nondet.cpp
@@ -294,10 +294,7 @@ static goto_programt::targett check_and_replace_target(
     inserted_expr.set_nullable(
       instr_info.get_nullable_type() ==
       nondet_instruction_infot::is_nullablet::TRUE);
-    target_instruction->code_nonconst() =
-      code_assignt(nondet_var, inserted_expr);
-    target_instruction->code_nonconst().add_source_location() =
-      target_instruction->source_location();
+    target_instruction->assign_rhs_nonconst() = inserted_expr;
   }
 
   goto_program.update();

--- a/src/analyses/interval_analysis.cpp
+++ b/src/analyses/interval_analysis.cpp
@@ -77,9 +77,9 @@ void instrument_intervals(
     {
       goto_programt::targett t=i_it;
       goto_function.body.insert_before_swap(i_it);
-      *t = goto_programt::make_assumption(conjunction(assertion));
       i_it++; // goes to original instruction
-      t->source_location_nonconst() = i_it->source_location();
+      *t = goto_programt::make_assumption(
+        conjunction(assertion), i_it->source_location());
     }
   }
 }

--- a/src/goto-analyzer/taint_analysis.cpp
+++ b/src/goto-analyzer/taint_analysis.cpp
@@ -179,12 +179,13 @@ void taint_analysist::instrument(
                 where,
                 ID_get_may,
                 address_of_exprt(string_constantt(rule.taint))};
-              goto_programt::targett t =
-                insert_before.add(goto_programt::make_assertion(
-                  not_exprt(get_may), instruction.source_location()));
-              t->source_location_nonconst().set_property_class(
+              source_locationt annotated_location =
+                instruction.source_location();
+              annotated_location.set_property_class(
                 "taint rule " + id2string(rule.id));
-              t->source_location_nonconst().set_comment(rule.message);
+              annotated_location.set_comment(rule.message);
+              insert_before.add(goto_programt::make_assertion(
+                not_exprt(get_may), annotated_location));
               break;
             }
 

--- a/src/goto-harness/memory_snapshot_harness_generator.cpp
+++ b/src/goto-harness/memory_snapshot_harness_generator.cpp
@@ -164,8 +164,8 @@ void memory_snapshot_harness_generatort::add_init_section(
 
   auto ins_it1 = goto_program.insert_before(
     start_it,
-    goto_programt::make_goto(goto_program.const_cast_target(start_it)));
-  ins_it1->condition_nonconst() = func_init_done_var;
+    goto_programt::make_goto(
+      goto_program.const_cast_target(start_it), func_init_done_var));
 
   auto ins_it2 = goto_program.insert_after(
     ins_it1,

--- a/src/goto-instrument/accelerate/overflow_instrumenter.cpp
+++ b/src/goto-instrument/accelerate/overflow_instrumenter.cpp
@@ -52,15 +52,13 @@ void overflow_instrumentert::add_overflow_checks(
 
   if(t->is_assign())
   {
-    code_assignt &assignment = to_code_assign(t->code_nonconst());
-
-    if(assignment.lhs()==overflow_var)
+    if(t->assign_lhs() == overflow_var)
     {
       return;
     }
 
-    add_overflow_checks(t, assignment.lhs(), added);
-    add_overflow_checks(t, assignment.rhs(), added);
+    add_overflow_checks(t, t->assign_lhs_nonconst(), added);
+    add_overflow_checks(t, t->assign_rhs_nonconst(), added);
   }
 
   if(t->has_condition())

--- a/src/goto-instrument/accelerate/scratch_program.cpp
+++ b/src/goto-instrument/accelerate/scratch_program.cpp
@@ -145,12 +145,10 @@ void scratch_programt::fix_types()
   {
     if(it->is_assign())
     {
-      code_assignt &code = to_code_assign(it->code_nonconst());
-
-      if(code.lhs().type()!=code.rhs().type())
+      if(it->assign_lhs().type() != it->assign_rhs().type())
       {
-        typecast_exprt typecast(code.rhs(), code.lhs().type());
-        code.rhs()=typecast;
+        typecast_exprt typecast{it->assign_rhs(), it->assign_lhs().type()};
+        it->assign_rhs_nonconst() = typecast;
       }
     }
     else if(it->is_assume() || it->is_assert())

--- a/src/goto-instrument/contracts/havoc_assigns_clause_targets.cpp
+++ b/src/goto-instrument/contracts/havoc_assigns_clause_targets.cpp
@@ -83,9 +83,9 @@ void havoc_assigns_clause_targetst::havoc_if_valid(
   {
     // OTHER __CPROVER_havoc_object(target_snapshot_var)
     codet code(ID_havoc_object, {car.lower_bound_var()});
-    const auto &inst =
-      dest.add(goto_programt::make_other(code, source_location));
-    inst->source_location_nonconst().set_comment(tracking_comment);
+    source_locationt annotated_location = source_location;
+    annotated_location.set_comment(tracking_comment);
+    dest.add(goto_programt::make_other(code, annotated_location));
   }
   else if(car.havoc_method == car_havoc_methodt::HAVOC_SLICE)
   {
@@ -106,12 +106,13 @@ void havoc_assigns_clause_targetst::havoc_if_valid(
     // ASSIGN *(target.type() *)__car_lb = nondet(car.target().type())
     const auto &target_type = car.target().type();
     side_effect_expr_nondett nondet(target_type, source_location);
-    const auto &inst = dest.add(goto_programt::make_assignment(
+    source_locationt annotated_location = source_location;
+    annotated_location.set_comment(tracking_comment);
+    dest.add(goto_programt::make_assignment(
       dereference_exprt{typecast_exprt::conditional_cast(
         car.lower_bound_var(), pointer_type(target_type))},
       nondet,
-      source_location));
-    inst->source_location_nonconst().set_comment(tracking_comment);
+      annotated_location));
   }
   else
   {
@@ -154,10 +155,11 @@ void havoc_assigns_clause_targetst::havoc_static_local(
 
   const auto &target_type = car.target().type();
   side_effect_expr_nondett nondet(target_type, source_location);
-  const auto &inst = dest.add(
-    goto_programt::make_assignment(car.target(), nondet, source_location));
-  inst->source_location_nonconst().set_comment(tracking_comment);
-  add_propagate_static_local_pragma(inst->source_location_nonconst());
+  source_locationt annotated_location = source_location;
+  annotated_location.set_comment(tracking_comment);
+  add_propagate_static_local_pragma(annotated_location);
+  dest.add(
+    goto_programt::make_assignment(car.target(), nondet, annotated_location));
 
   dest.destructive_append(skip_program);
 

--- a/src/goto-instrument/cover_instrument.h
+++ b/src/goto-instrument/cover_instrument.h
@@ -81,15 +81,14 @@ protected:
     const assertion_factoryt &) const = 0;
 
   void initialize_source_location(
-    goto_programt::targett t,
+    source_locationt &source_location,
     const std::string &comment,
     const irep_idt &function_id) const
   {
-    t->source_location_nonconst().set_comment(comment);
-    t->source_location_nonconst().set(
-      ID_coverage_criterion, coverage_criterion);
-    t->source_location_nonconst().set_property_class(property_class);
-    t->source_location_nonconst().set_function(function_id);
+    source_location.set_comment(comment);
+    source_location.set(ID_coverage_criterion, coverage_criterion);
+    source_location.set_property_class(property_class);
+    source_location.set_function(function_id);
   }
 
   bool is_non_cover_assertion(goto_programt::const_targett t) const

--- a/src/goto-instrument/cover_instrument_assume.cpp
+++ b/src/goto-instrument/cover_instrument_assume.cpp
@@ -23,7 +23,6 @@ void cover_assume_instrumentert::instrument(
 {
   if(i_it->is_assume())
   {
-    const auto location = i_it->source_location();
     const auto assume_condition =
       expr2c(i_it->condition(), namespacet{symbol_tablet()});
     const auto comment_before =
@@ -31,13 +30,14 @@ void cover_assume_instrumentert::instrument(
     const auto comment_after =
       "assert(false) after assume(" + assume_condition + ")";
 
+    source_locationt location = i_it->source_location();
+    initialize_source_location(location, comment_before, function_id);
     const auto assert_before = make_assertion(false_exprt{}, location);
-    goto_programt::targett t = goto_program.insert_before(i_it, assert_before);
-    initialize_source_location(t, comment_before, function_id);
+    goto_program.insert_before(i_it, assert_before);
 
+    initialize_source_location(location, comment_after, function_id);
     const auto assert_after = make_assertion(false_exprt{}, location);
-    t = goto_program.insert_after(i_it, assert_after);
-    initialize_source_location(t, comment_after, function_id);
+    goto_program.insert_after(i_it, assert_after);
   }
   // Otherwise, skip existing assertions.
   else if(i_it->is_assert())

--- a/src/goto-instrument/cover_instrument_branch.cpp
+++ b/src/goto-instrument/cover_instrument_branch.cpp
@@ -40,10 +40,9 @@ void cover_branch_instrumentert::instrument(
     std::string comment = "entry point";
 
     source_locationt source_location = i_it->source_location();
-
-    goto_programt::targett t = goto_program.insert_before(
+    initialize_source_location(source_location, comment, function_id);
+    goto_program.insert_before(
       i_it, make_assertion(false_exprt(), source_location));
-    initialize_source_location(t, comment, function_id);
   }
 
   if(is_conditional_goto)
@@ -57,12 +56,12 @@ void cover_branch_instrumentert::instrument(
     source_locationt source_location = i_it->source_location();
 
     goto_program.insert_before_swap(i_it);
+    initialize_source_location(source_location, true_comment, function_id);
     *i_it = make_assertion(not_exprt(guard), source_location);
-    initialize_source_location(i_it, true_comment, function_id);
 
     goto_program.insert_before_swap(i_it);
+    initialize_source_location(source_location, false_comment, function_id);
     *i_it = make_assertion(guard, source_location);
-    initialize_source_location(i_it, false_comment, function_id);
 
     std::advance(i_it, 2);
   }

--- a/src/goto-instrument/cover_instrument_condition.cpp
+++ b/src/goto-instrument/cover_instrument_condition.cpp
@@ -30,7 +30,7 @@ void cover_condition_instrumentert::instrument(
   {
     const std::set<exprt> conditions = collect_conditions(i_it);
 
-    const source_locationt source_location = i_it->source_location();
+    source_locationt source_location = i_it->source_location();
 
     for(const auto &c : conditions)
     {
@@ -38,13 +38,13 @@ void cover_condition_instrumentert::instrument(
 
       const std::string comment_t = "condition '" + c_string + "' true";
       goto_program.insert_before_swap(i_it);
+      initialize_source_location(source_location, comment_t, function_id);
       *i_it = make_assertion(c, source_location);
-      initialize_source_location(i_it, comment_t, function_id);
 
       const std::string comment_f = "condition '" + c_string + "' false";
       goto_program.insert_before_swap(i_it);
+      initialize_source_location(source_location, comment_f, function_id);
       *i_it = make_assertion(not_exprt(c), source_location);
-      initialize_source_location(i_it, comment_f, function_id);
     }
 
     for(std::size_t i = 0; i < conditions.size() * 2; i++)

--- a/src/goto-instrument/cover_instrument_decision.cpp
+++ b/src/goto-instrument/cover_instrument_decision.cpp
@@ -30,7 +30,7 @@ void cover_decision_instrumentert::instrument(
   {
     const std::set<exprt> decisions = collect_decisions(i_it);
 
-    const source_locationt source_location = i_it->source_location();
+    source_locationt source_location = i_it->source_location();
 
     for(const auto &d : decisions)
     {
@@ -38,13 +38,13 @@ void cover_decision_instrumentert::instrument(
 
       const std::string comment_t = "decision '" + d_string + "' true";
       goto_program.insert_before_swap(i_it);
+      initialize_source_location(source_location, comment_t, function_id);
       *i_it = make_assertion(d, source_location);
-      initialize_source_location(i_it, comment_t, function_id);
 
       const std::string comment_f = "decision '" + d_string + "' false";
       goto_program.insert_before_swap(i_it);
+      initialize_source_location(source_location, comment_f, function_id);
       *i_it = make_assertion(not_exprt(d), source_location);
-      initialize_source_location(i_it, comment_f, function_id);
     }
 
     // advance iterator beyond the inserted instructions

--- a/src/goto-instrument/cover_instrument_location.cpp
+++ b/src/goto-instrument/cover_instrument_location.cpp
@@ -31,7 +31,8 @@ void cover_location_instrumentert::instrument(
   {
     const std::string b = std::to_string(block_nr + 1); // start with 1
     const std::string id = id2string(function_id) + "#" + b;
-    auto source_location = basic_blocks.source_location_of(block_nr);
+    source_locationt source_location =
+      basic_blocks.source_location_of(block_nr);
 
     // filter goals
     if(goal_filters(source_location))
@@ -41,8 +42,8 @@ void cover_location_instrumentert::instrument(
         "block " + b + " (lines " + source_lines.to_string() + ")";
       source_location.set_basic_block_source_lines(source_lines.to_irep());
       goto_program.insert_before_swap(i_it);
+      initialize_source_location(source_location, comment, function_id);
       *i_it = make_assertion(false_exprt(), source_location);
-      initialize_source_location(i_it, comment, function_id);
       i_it++;
     }
   }

--- a/src/goto-instrument/cover_instrument_mcdc.cpp
+++ b/src/goto-instrument/cover_instrument_mcdc.cpp
@@ -662,21 +662,21 @@ void cover_mcdc_instrumentert::instrument(
 
       std::string comment_t = description + " '" + p_string + "' true";
       goto_program.insert_before_swap(i_it);
-      *i_it = make_assertion(not_exprt(p), source_location);
-      i_it->source_location_nonconst().set_comment(comment_t);
-      i_it->source_location_nonconst().set(
-        ID_coverage_criterion, coverage_criterion);
-      i_it->source_location_nonconst().set_property_class(property_class);
-      i_it->source_location_nonconst().set_function(function_id);
+      source_locationt annotated_location = source_location;
+      annotated_location.set_comment(comment_t);
+      annotated_location.set(ID_coverage_criterion, coverage_criterion);
+      annotated_location.set_property_class(property_class);
+      annotated_location.set_function(function_id);
+      *i_it = make_assertion(not_exprt(p), annotated_location);
 
       std::string comment_f = description + " '" + p_string + "' false";
       goto_program.insert_before_swap(i_it);
-      *i_it = make_assertion(p, source_location);
-      i_it->source_location_nonconst().set_comment(comment_f);
-      i_it->source_location_nonconst().set(
-        ID_coverage_criterion, coverage_criterion);
-      i_it->source_location_nonconst().set_property_class(property_class);
-      i_it->source_location_nonconst().set_function(function_id);
+      annotated_location = source_location;
+      annotated_location.set_comment(comment_f);
+      annotated_location.set(ID_coverage_criterion, coverage_criterion);
+      annotated_location.set_property_class(property_class);
+      annotated_location.set_function(function_id);
+      *i_it = make_assertion(p, annotated_location);
     }
 
     std::set<exprt> controlling;
@@ -697,12 +697,12 @@ void cover_mcdc_instrumentert::instrument(
         "MC/DC independence condition '" + p_string + "'";
 
       goto_program.insert_before_swap(i_it);
-      *i_it = make_assertion(not_exprt(p), source_location);
-      i_it->source_location_nonconst().set_comment(description);
-      i_it->source_location_nonconst().set(
-        ID_coverage_criterion, coverage_criterion);
-      i_it->source_location_nonconst().set_property_class(property_class);
-      i_it->source_location_nonconst().set_function(function_id);
+      source_locationt annotated_location = source_location;
+      annotated_location.set_comment(description);
+      annotated_location.set(ID_coverage_criterion, coverage_criterion);
+      annotated_location.set_property_class(property_class);
+      annotated_location.set_function(function_id);
+      *i_it = make_assertion(not_exprt(p), annotated_location);
     }
 
     for(std::size_t i = 0; i < both.size() * 2 + controlling.size(); i++)

--- a/src/goto-instrument/cover_instrument_other.cpp
+++ b/src/goto-instrument/cover_instrument_other.cpp
@@ -42,7 +42,9 @@ void cover_assertion_instrumentert::instrument(
   {
     i_it->condition_nonconst() = false_exprt();
     initialize_source_location(
-      i_it, id2string(i_it->source_location().get_comment()), function_id);
+      i_it->source_location_nonconst(),
+      id2string(i_it->source_location().get_comment()),
+      function_id);
   }
 }
 
@@ -65,7 +67,8 @@ void cover_cover_instrumentert::instrument(
       const exprt c = i_it->call_arguments()[0];
       *i_it = make_assertion(not_exprt(c), i_it->source_location());
       std::string comment = "condition '" + from_expr(ns, function_id, c) + "'";
-      initialize_source_location(i_it, comment, function_id);
+      initialize_source_location(
+        i_it->source_location_nonconst(), comment, function_id);
     }
   }
   else if(is_non_cover_assertion(i_it))
@@ -94,9 +97,9 @@ void cover_instrument_end_of_function(
   const std::string &comment =
     "additional goal to ensure reachability of end of function";
   goto_program.insert_before_swap(if_it);
-  *if_it = make_assertion(false_exprt(), location);
-  if_it->source_location_nonconst().set_comment(comment);
-  if_it->source_location_nonconst().set_property_class(
-    "reachability_constraint");
-  if_it->source_location_nonconst().set_function(function_id);
+  source_locationt annotated_location = location;
+  annotated_location.set_comment(comment);
+  annotated_location.set_property_class("reachability_constraint");
+  annotated_location.set_function(function_id);
+  *if_it = make_assertion(false_exprt(), annotated_location);
 }

--- a/src/goto-instrument/havoc_utils.cpp
+++ b/src/goto-instrument/havoc_utils.cpp
@@ -60,7 +60,6 @@ void havoc_utilst::append_scalar_havoc_code_for_expr(
   goto_programt &dest) const
 {
   side_effect_expr_nondett rhs(expr.type(), location);
-  goto_programt::targett t =
-    dest.add(goto_programt::make_assignment(expr, std::move(rhs), location));
-  t->code_nonconst().add_source_location() = location;
+  dest.add(goto_programt::make_assignment(
+    code_assignt{expr, std::move(rhs), location}, location));
 }

--- a/src/goto-instrument/race_check.cpp
+++ b/src/goto-instrument/race_check.cpp
@@ -198,20 +198,18 @@ static void race_check(
         if(!is_shared(ns, w_entry.second.symbol_expr))
           continue;
 
-        goto_programt::targett t = goto_program.insert_before(
+        goto_program.insert_before(
           i_it,
           goto_programt::make_assignment(
             w_guards.get_w_guard_expr(w_entry.second),
             w_entry.second.guard,
             original_instruction.source_location()));
-        i_it=++t;
       }
 
       // insert original statement here
       {
         goto_programt::targett t=goto_program.insert_before(i_it);
         *t=original_instruction;
-        i_it=++t;
       }
 
       // now add assignments for what is written -- reset
@@ -220,13 +218,12 @@ static void race_check(
         if(!is_shared(ns, w_entry.second.symbol_expr))
           continue;
 
-        goto_programt::targett t = goto_program.insert_before(
+        goto_program.insert_before(
           i_it,
           goto_programt::make_assignment(
             w_guards.get_w_guard_expr(w_entry.second),
             false_exprt(),
             original_instruction.source_location()));
-        i_it = std::next(t);
       }
 
       // now add assertions for what is read and written
@@ -235,14 +232,13 @@ static void race_check(
         if(!is_shared(ns, r_entry.second.symbol_expr))
           continue;
 
-        goto_programt::targett t = goto_program.insert_before(
+        source_locationt annotated_location =
+          original_instruction.source_location();
+        annotated_location.set_comment(comment(r_entry.second, false));
+        goto_program.insert_before(
           i_it,
           goto_programt::make_assertion(
-            w_guards.get_assertion(r_entry.second),
-            original_instruction.source_location()));
-        t->source_location_nonconst().set_comment(
-          comment(r_entry.second, false));
-        i_it=++t;
+            w_guards.get_assertion(r_entry.second), annotated_location));
       }
 
       for(const auto &w_entry : rw_set.w_entries)
@@ -250,14 +246,13 @@ static void race_check(
         if(!is_shared(ns, w_entry.second.symbol_expr))
           continue;
 
-        goto_programt::targett t = goto_program.insert_before(
+        source_locationt annotated_location =
+          original_instruction.source_location();
+        annotated_location.set_comment(comment(w_entry.second, true));
+        goto_program.insert_before(
           i_it,
           goto_programt::make_assertion(
-            w_guards.get_assertion(w_entry.second),
-            original_instruction.source_location()));
-        t->source_location_nonconst().set_comment(
-          comment(w_entry.second, true));
-        i_it=++t;
+            w_guards.get_assertion(w_entry.second), annotated_location));
       }
 
       i_it--; // the for loop already counts us up

--- a/src/goto-instrument/stack_depth.cpp
+++ b/src/goto-instrument/stack_depth.cpp
@@ -69,12 +69,12 @@ static void stack_depth(
   goto_programt::targett first=goto_program.instructions.begin();
 
   binary_relation_exprt guard(symbol, ID_le, max_depth);
-  goto_programt::targett assert_ins = goto_program.insert_before(
-    first, goto_programt::make_assertion(guard, first->source_location()));
-
-  assert_ins->source_location_nonconst().set_comment(
+  source_locationt annotated_location = first->source_location();
+  annotated_location.set_comment(
     "Stack depth exceeds " + std::to_string(i_depth));
-  assert_ins->source_location_nonconst().set_property_class("stack-depth");
+  annotated_location.set_property_class("stack-depth");
+  goto_program.insert_before(
+    first, goto_programt::make_assertion(guard, annotated_location));
 
   goto_program.insert_before(
     first,

--- a/src/goto-instrument/synthesizer/synthesizer_utils.cpp
+++ b/src/goto-instrument/synthesizer/synthesizer_utils.cpp
@@ -106,7 +106,6 @@ void annotate_invariants(
     goto_programt::targett loop_end = get_loop_end(loop_number, function);
 
     // annotate the invariant to the condition of `loop_end`
-    exprt condition = loop_end->condition();
     loop_end->condition_nonconst().add(ID_C_spec_loop_invariant) =
       invariant_map_entry.second;
   }

--- a/src/goto-instrument/thread_instrumentation.cpp
+++ b/src/goto-instrument/thread_instrumentation.cpp
@@ -35,8 +35,6 @@ void thread_exit_instrumentation(goto_programt &goto_program)
 
   assert(end->is_end_function());
 
-  source_locationt source_location = end->source_location();
-
   goto_program.insert_before_swap(end);
 
   const string_constantt mutex_locked_string("mutex-locked");
@@ -47,10 +45,9 @@ void thread_exit_instrumentation(goto_programt &goto_program)
     ID_get_may,
     address_of_exprt(mutex_locked_string)};
 
+  source_locationt source_location = end->source_location();
+  source_location.set_comment("mutexes must not be locked on thread exit");
   *end = goto_programt::make_assertion(not_exprt(get_may), source_location);
-
-  end->source_location_nonconst().set_comment(
-    "mutexes must not be locked on thread exit");
 }
 
 void thread_exit_instrumentation(goto_modelt &goto_model)

--- a/src/goto-instrument/undefined_functions.cpp
+++ b/src/goto-instrument/undefined_functions.cpp
@@ -58,10 +58,10 @@ void undefined_function_abort_path(goto_modelt &goto_model)
       if(entry->second.body_available())
         continue;
 
-      ins =
-        goto_programt::make_assumption(false_exprt(), ins.source_location());
-      ins.source_location_nonconst().set_comment(
+      source_locationt annotated_location = ins.source_location();
+      annotated_location.set_comment(
         "'" + id2string(function_identifier) + "' is undefined");
+      ins = goto_programt::make_assumption(false_exprt(), annotated_location);
     }
   }
 }

--- a/src/goto-instrument/uninitialized.cpp
+++ b/src/goto-instrument/uninitialized.cpp
@@ -153,14 +153,13 @@ void uninitializedt::add_assertions(
             const irep_idt new_identifier=id2string(identifier)+"#initialized";
 
             // insert assertion
+            source_locationt annotated_location = instruction.source_location();
+            annotated_location.set_comment(
+              "use of uninitialized local variable " + id2string(identifier));
+            annotated_location.set_property_class("uninitialized local");
             goto_programt::instructiont assertion =
               goto_programt::make_assertion(
-                symbol_exprt(new_identifier, bool_typet()),
-                instruction.source_location());
-            assertion.source_location_nonconst().set_comment(
-              "use of uninitialized local variable " + id2string(identifier));
-            assertion.source_location_nonconst().set_property_class(
-              "uninitialized local");
+                symbol_exprt(new_identifier, bool_typet()), annotated_location);
 
             goto_program.insert_before_swap(i_it, assertion);
             i_it++;

--- a/src/goto-programs/goto_convert.cpp
+++ b/src/goto-programs/goto_convert.cpp
@@ -833,9 +833,9 @@ void goto_convertt::convert_assert(
 
   clean_expr(cond, dest, mode);
 
-  goto_programt::targett t =
-    dest.add(goto_programt::make_assertion(cond, code.source_location()));
-  t->source_location_nonconst().set("user-provided", true);
+  source_locationt annotated_location = code.source_location();
+  annotated_location.set("user-provided", true);
+  dest.add(goto_programt::make_assertion(cond, annotated_location));
 }
 
 void goto_convertt::convert_skip(
@@ -1606,8 +1606,8 @@ void goto_convertt::generate_ifthenelse(
 
   // do the x label
   goto_programt tmp_x;
-  goto_programt::targett x =
-    tmp_x.add(goto_programt::make_incomplete_goto(true_exprt()));
+  goto_programt::targett x = tmp_x.add(goto_programt::make_incomplete_goto(
+    true_exprt(), true_case.instructions.back().source_location()));
 
   // do the z label
   goto_programt tmp_z;
@@ -1636,7 +1636,6 @@ void goto_convertt::generate_ifthenelse(
   // x: goto z;
   CHECK_RETURN(!tmp_w.instructions.empty());
   x->complete_goto(z);
-  x->source_location_nonconst() = tmp_w.instructions.back().source_location();
 
   dest.destructive_append(tmp_v);
   dest.destructive_append(tmp_w);
@@ -1957,13 +1956,12 @@ void goto_convertt::generate_thread_block(
   goto_programt::targett c = body.add(goto_programt::make_skip());
   convert(thread_body, body, mode);
 
-  goto_programt::targett e = postamble.add(goto_programt::instructiont(
+  postamble.add(goto_programt::instructiont(
     static_cast<const codet &>(get_nil_irep()),
     thread_body.source_location(),
     END_THREAD,
     nil_exprt(),
     {}));
-  e->source_location_nonconst() = thread_body.source_location();
   goto_programt::targett z = postamble.add(goto_programt::make_skip());
 
   preamble.add(goto_programt::instructiont(

--- a/src/goto-programs/goto_convert_functions.cpp
+++ b/src/goto-programs/goto_convert_functions.cpp
@@ -213,10 +213,8 @@ void goto_convert_functionst::convert_function(
     !f.body.instructions.empty() &&
     has_prefix(id2string(identifier), "__VERIFIER_atomic_"))
   {
-    goto_programt::instructiont a_begin;
-    a_begin = goto_programt::make_atomic_begin();
-    a_begin.source_location_nonconst() =
-      f.body.instructions.front().source_location();
+    goto_programt::instructiont a_begin = goto_programt::make_atomic_begin(
+      f.body.instructions.front().source_location());
     f.body.insert_before_swap(f.body.instructions.begin(), a_begin);
 
     goto_programt::targett a_end =

--- a/src/goto-programs/goto_inline_class.cpp
+++ b/src/goto-programs/goto_inline_class.cpp
@@ -47,9 +47,9 @@ void goto_inlinet::parameter_assignments(
     // this is the type the n-th argument should have
     const typet &parameter_type = symbol.type;
 
-    goto_programt::targett decl =
-      dest.add(goto_programt::make_decl(symbol.symbol_expr(), source_location));
-    decl->code_nonconst().add_source_location() = source_location;
+    code_declt decl{symbol.symbol_expr()};
+    decl.add_source_location() = source_location;
+    dest.add(goto_programt::make_decl(std::move(decl), source_location));
 
     // this is the actual parameter
     exprt actual;

--- a/src/goto-programs/instrument_preconditions.cpp
+++ b/src/goto-programs/instrument_preconditions.cpp
@@ -129,11 +129,10 @@ void instrument_preconditions(
           goto_program.insert_before_swap(it);
           exprt instance = p->condition();
           r(instance);
-          *it = goto_programt::make_assertion(instance, source_location);
-          it->source_location_nonconst().set_property_class(
-            ID_precondition_instance);
-          it->source_location_nonconst().set_comment(
-            p->source_location().get_comment());
+          source_locationt annotated_location = source_location;
+          annotated_location.set_property_class(ID_precondition_instance);
+          annotated_location.set_comment(p->source_location().get_comment());
+          *it = goto_programt::make_assertion(instance, annotated_location);
           it++;
         }
       }

--- a/unit/goto-checker/report_util/is_property_less_than.cpp
+++ b/unit/goto-checker/report_util/is_property_less_than.cpp
@@ -12,9 +12,13 @@ static goto_programt::instructiont instruction_for_location(
   location.set_file(file);
   location.set_function(function);
   location.set_line(line_no);
-  goto_programt::instructiont instruction;
-  instruction.source_location_nonconst() = location;
-  return instruction;
+
+  return goto_programt::instructiont{
+    codet{ID_nil},
+    location,
+    goto_program_instruction_typet::NO_INSTRUCTION_TYPE,
+    {},
+    {}};
 }
 
 static property_infot test_info(const goto_programt::const_targett &target)

--- a/unit/goto-programs/structured_trace_util.cpp
+++ b/unit/goto-programs/structured_trace_util.cpp
@@ -22,9 +22,13 @@ goto_programt::targett add_instruction(
   const source_locationt &location,
   goto_programt::instructionst &instructions)
 {
-  goto_programt::instructiont instruction;
+  goto_programt::instructiont instruction{
+    codet{ID_nil},
+    location,
+    goto_program_instruction_typet::NO_INSTRUCTION_TYPE,
+    {},
+    {}};
   instruction.location_number = instructions.size();
-  instruction.source_location_nonconst() = location;
   instructions.push_back(instruction);
   return std::next(instructions.begin(), instruction.location_number);
 }


### PR DESCRIPTION
Construct instructions with the intended value right away rather than fixing them up afterwards.

~~Requires #6420 to be merged first.~~

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
