### PR TITLE
Adding more CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,13 +2,13 @@
 # approval within two weeks.
 #
 # These owners will be the default owners for everything in the repo.
-*       @kroening @tautschnig @peterschrammel @chrisr-diffblue
+*       @kroening @tautschnig @peterschrammel @chrisr-diffblue @TGWDB
 
 # These files should rarely change
 
 /src/big-int/ @kroening
-/src/ansi-c/ @kroening @tautschnig @chrisr-diffblue
-/src/assembler/ @kroening @tautschnig @chrisr-diffblue
+/src/ansi-c/ @kroening @tautschnig @chrisr-diffblue @peterschrammel @thomasspriggs @NlightNFotis @TGWDB
+/src/assembler/ @kroening @tautschnig @chrisr-diffblue @peterschrammel @thomasspriggs @NlightNFotis @TGWDB
 /src/goto-cc/ @kroening @tautschnig @chrisr-diffblue
 /src/linking/ @kroening @tautschnig @chrisr-diffblue
 /src/memory-models/ @kroening @tautschnig
@@ -30,9 +30,9 @@
 
 # These files change frequently and changes are high-risk
 
-/src/cbmc/ @kroening @tautschnig @peterschrammel
-/src/goto-programs/ @kroening @tautschnig @peterschrammel
-/src/util/ @kroening @tautschnig @peterschrammel
+/src/cbmc/ @kroening @tautschnig @peterschrammel @thomasspriggs @NlightNFotis @TGWDB
+/src/goto-programs/ @kroening @tautschnig @peterschrammel @thomasspriggs @NlightNFotis @TGWDB
+/src/util/ @kroening @tautschnig @peterschrammel @thomasspriggs @NlightNFotis @TGWDB
 /src/solvers/refinement @martin-cs @romainbrenguier @peterschrammel
 /src/solvers/strings @martin-cs @romainbrenguier @peterschrammel
 /jbmc/src/java_bytecode/ @romainbrenguier @peterschrammel
@@ -49,12 +49,12 @@
 /doc/cprover-manual/contracts* @tautschnig @feliperodri @SaswatPadhi
 /src/goto-diff/ @tautschnig @peterschrammel
 /src/jsil/ @kroening @tautschnig
-/src/memory-analyzer/ @tautschnig @chrisr-diffblue
+/src/memory-analyzer/ @tautschnig @chrisr-diffblue @peterschrammel
 /jbmc/src/jbmc/ @peterschrammel @romainbrenguier
 /jbmc/src/janalyzer/ @peterschrammel @romainbrenguier
-/jbmc/src/jdiff/ @peterschrammel
+/jbmc/src/jdiff/ @peterschrammel @chrisr-diffblue
 /src/cpp/ @kroening @tautschnig @peterschrammel
-/src/solvers/smt2 @kroening @martin-cs @tautschnig @peterschrammel @allredj @romainbrenguier
+/src/solvers/smt2 @kroening @martin-cs @tautschnig @peterschrammel @thomasspriggs @NlightNFotis @TGWDB
 /src/solvers/smt2_incremental @peterschrammel @thomasspriggs @NlightNFotis @TGWDB @chrisr-diffblue
 /src/statement-list/ @kroening @tautschnig @peterschrammel @pkesseli
 

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -7,8 +7,8 @@
 # These files should rarely change
 
 /src/big-int/ @kroening
-/src/ansi-c/ @kroening @tautschnig @chrisr-diffblue @peterschrammel @thomasspriggs @NlightNFotis @TGWDB
-/src/assembler/ @kroening @tautschnig @chrisr-diffblue @peterschrammel @thomasspriggs @NlightNFotis @TGWDB
+/src/ansi-c/ @kroening @tautschnig @chrisr-diffblue @peterschrammel @thomasspriggs @TGWDB
+/src/assembler/ @kroening @tautschnig @chrisr-diffblue @peterschrammel
 /src/goto-cc/ @kroening @tautschnig @chrisr-diffblue
 /src/linking/ @kroening @tautschnig @chrisr-diffblue
 /src/memory-models/ @kroening @tautschnig

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -54,7 +54,7 @@
 /jbmc/src/janalyzer/ @peterschrammel @romainbrenguier
 /jbmc/src/jdiff/ @peterschrammel @chrisr-diffblue
 /src/cpp/ @kroening @tautschnig @peterschrammel
-/src/solvers/smt2 @kroening @martin-cs @tautschnig @peterschrammel @thomasspriggs @NlightNFotis @TGWDB
+/src/solvers/smt2 @kroening @martin-cs @peterschrammel @thomasspriggs @NlightNFotis @TGWDB
 /src/solvers/smt2_incremental @peterschrammel @thomasspriggs @NlightNFotis @TGWDB @chrisr-diffblue
 /src/statement-list/ @kroening @tautschnig @peterschrammel @pkesseli
 

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -31,8 +31,8 @@
 # These files change frequently and changes are high-risk
 
 /src/cbmc/ @kroening @tautschnig @peterschrammel @thomasspriggs @NlightNFotis @TGWDB
-/src/goto-programs/ @kroening @tautschnig @peterschrammel @thomasspriggs @NlightNFotis @TGWDB
-/src/util/ @kroening @tautschnig @peterschrammel @thomasspriggs @NlightNFotis @TGWDB
+/src/goto-programs/ @kroening @tautschnig @peterschrammel
+/src/util/ @kroening @tautschnig @peterschrammel
 /src/solvers/refinement @martin-cs @romainbrenguier @peterschrammel
 /src/solvers/strings @martin-cs @romainbrenguier @peterschrammel
 /jbmc/src/java_bytecode/ @romainbrenguier @peterschrammel


### PR DESCRIPTION
This is a first draft of adding some more CODEOWNERS in different places.
The underlying goal here is to ensure that Diffblue has two (or more)
in house CODEOWNERS for all regularly updated parts of the code. This
is to enable Diffblue to respond to the vast majority of the code base
and also reduce reliance upon a single person (within or without of
Diffblue).

**NOTE:** this is put up now for discussion and refinement. Consider this a provisional starting point.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
