### PR TITLE
Fix printing of `smt_get_value_commandt`

### DIFF
--- a/src/solvers/smt2_incremental/smt_commands.h
+++ b/src/solvers/smt2_incremental/smt_commands.h
@@ -87,6 +87,14 @@ class smt_get_value_commandt : public smt_commandt,
                                protected smt_termt::storert<smt_assert_commandt>
 {
 public:
+  /// \brief This constructor constructs the `get-value` command, such that it
+  ///   stores a single descriptor for which the solver will be commanded to
+  ///   respond with a value.
+  /// \note This class currently supports storing a single descriptor only,
+  ///   whereas the SMT-LIB standard version 2.6 supports one or more
+  ///   descriptors. Getting one value at a time is currently sufficient for our
+  ///   requirements. This class could be expanded should there be a need to get
+  ///   multiple values at once.
   explicit smt_get_value_commandt(smt_termt descriptor);
   const smt_termt &descriptor() const;
 };

--- a/src/solvers/smt2_incremental/smt_to_smt2_string.cpp
+++ b/src/solvers/smt2_incremental/smt_to_smt2_string.cpp
@@ -334,7 +334,7 @@ public:
 
   void visit(const smt_get_value_commandt &get_value) override
   {
-    os << "(get-value " << get_value.descriptor() << ")";
+    os << "(get-value (" << get_value.descriptor() << "))";
   }
 
   void visit(const smt_pop_commandt &pop) override

--- a/unit/solvers/smt2_incremental/smt_to_smt2_string.cpp
+++ b/unit/solvers/smt2_incremental/smt_to_smt2_string.cpp
@@ -75,7 +75,7 @@ TEST_CASE(
 {
   CHECK(
     smt_to_smt2_string(smt_get_value_commandt{
-      smt_identifier_termt{"foo", smt_bool_sortt{}}}) == "(get-value |foo|)");
+      smt_identifier_termt{"foo", smt_bool_sortt{}}}) == "(get-value (|foo|))");
 }
 
 TEST_CASE(

--- a/unit/solvers/smt2_incremental/smt_to_smt2_string.cpp
+++ b/unit/solvers/smt2_incremental/smt_to_smt2_string.cpp
@@ -70,6 +70,15 @@ TEST_CASE(
 }
 
 TEST_CASE(
+  "Test smt_get_value_commandt to string conversion",
+  "[core][smt2_incremental]")
+{
+  CHECK(
+    smt_to_smt2_string(smt_get_value_commandt{
+      smt_identifier_termt{"foo", smt_bool_sortt{}}}) == "(get-value |foo|)");
+}
+
+TEST_CASE(
   "Test smt_push_commandt to string conversion",
   "[core][smt2_incremental]")
 {


### PR DESCRIPTION
<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

This PR fixes the printing of `smt_get_value_commandt`. The get value command is supposed to be parameterised with a collection of one or more terms for which the solver should return the values. Our internal representation of the get-value command only supports a single term, which should be placed in brackets to make it into a collection containing a single term. The brackets were previously missing, which would have caused a solver error.

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
