### PR TITLE
Add smt response storage classes

### DIFF
--- a/src/solvers/Makefile
+++ b/src/solvers/Makefile
@@ -199,6 +199,7 @@ SRC = $(BOOLEFORCE_SRC) \
       smt2_incremental/smt_core_theory.cpp \
       smt2_incremental/smt_logics.cpp \
       smt2_incremental/smt_options.cpp \
+      smt2_incremental/smt_responses.cpp \
       smt2_incremental/smt_solver_process.cpp \
       smt2_incremental/smt_sorts.cpp \
       smt2_incremental/smt_terms.cpp \

--- a/src/solvers/smt2_incremental/smt_responses.cpp
+++ b/src/solvers/smt2_incremental/smt_responses.cpp
@@ -1,0 +1,175 @@
+// Author: Diffblue Ltd.
+
+#include <solvers/smt2_incremental/smt_responses.h>
+
+#include <util/range.h>
+
+// Define the irep_idts for responses.
+#define RESPONSE_ID(the_id, the_base)                                          \
+  const irep_idt ID_smt_##the_id##_response{"smt_" #the_id "_response"};
+#include <solvers/smt2_incremental/smt_responses.def>
+#undef RESPONSE_ID
+
+bool smt_responset::operator==(const smt_responset &other) const
+{
+  return irept::operator==(other);
+}
+
+bool smt_responset::operator!=(const smt_responset &other) const
+{
+  return !(*this == other);
+}
+
+#define RESPONSE_ID(the_id, the_base)                                          \
+  template <>                                                                  \
+  const smt_##the_id##_responset *the_base::cast<smt_##the_id##_responset>()   \
+    const &                                                                    \
+  {                                                                            \
+    return id() == ID_smt_##the_id##_response                                  \
+             ? static_cast<const smt_##the_id##_responset *>(this)             \
+             : nullptr;                                                        \
+  }
+#include <solvers/smt2_incremental/smt_responses.def> // NOLINT(build/include)
+#undef RESPONSE_ID
+
+template <typename sub_classt>
+const sub_classt *smt_responset::cast() const &
+{
+  return nullptr;
+}
+
+bool smt_check_sat_response_kindt::
+operator==(const smt_check_sat_response_kindt &other) const
+{
+  return irept::operator==(other);
+}
+
+bool smt_check_sat_response_kindt::
+operator!=(const smt_check_sat_response_kindt &other) const
+{
+  return !(*this == other);
+}
+
+smt_success_responset::smt_success_responset()
+  : smt_responset{ID_smt_success_response}
+{
+}
+
+smt_sat_responset::smt_sat_responset()
+  : smt_check_sat_response_kindt{ID_smt_sat_response}
+{
+}
+
+smt_unsat_responset::smt_unsat_responset()
+  : smt_check_sat_response_kindt{ID_smt_unsat_response}
+{
+}
+
+smt_unknown_responset::smt_unknown_responset()
+  : smt_check_sat_response_kindt{ID_smt_unknown_response}
+{
+}
+
+template <typename derivedt>
+smt_check_sat_response_kindt::storert<derivedt>::storert()
+{
+  static_assert(
+    std::is_base_of<irept, derivedt>::value &&
+      std::is_base_of<storert<derivedt>, derivedt>::value,
+    "Only irept based classes need to upcast smt_termt to store it.");
+}
+
+template <typename derivedt>
+irept smt_check_sat_response_kindt::storert<derivedt>::upcast(
+  smt_check_sat_response_kindt check_sat_response_kind)
+{
+  return static_cast<irept &&>(std::move(check_sat_response_kind));
+}
+
+template <typename derivedt>
+const smt_check_sat_response_kindt &
+smt_check_sat_response_kindt::storert<derivedt>::downcast(const irept &irep)
+{
+  return static_cast<const smt_check_sat_response_kindt &>(irep);
+}
+
+smt_check_sat_responset::smt_check_sat_responset(
+  smt_check_sat_response_kindt kind)
+  : smt_responset{ID_smt_check_sat_response}
+{
+  set(ID_value, upcast(std::move(kind)));
+}
+
+const smt_check_sat_response_kindt &smt_check_sat_responset::kind() const
+{
+  return downcast(find(ID_value));
+}
+
+smt_get_value_responset::valuation_pairt::valuation_pairt(
+  smt_termt descriptor,
+  smt_termt value)
+{
+  get_sub().push_back(upcast(std::move(descriptor)));
+  get_sub().push_back(upcast(std::move(value)));
+}
+
+const smt_termt &smt_get_value_responset::valuation_pairt::descriptor() const
+{
+  return downcast(get_sub().at(0));
+}
+
+const smt_termt &smt_get_value_responset::valuation_pairt::value() const
+{
+  return downcast(get_sub().at(1));
+}
+
+bool smt_get_value_responset::valuation_pairt::
+operator==(const smt_get_value_responset::valuation_pairt &other) const
+{
+  return irept::operator==(other);
+}
+
+bool smt_get_value_responset::valuation_pairt::
+operator!=(const smt_get_value_responset::valuation_pairt &other) const
+{
+  return !(*this == other);
+}
+
+smt_get_value_responset::smt_get_value_responset(
+  std::vector<valuation_pairt> pairs)
+  : smt_responset(ID_smt_get_value_response)
+{
+  // SMT-LIB standard version 2.6 requires one or more pairs.
+  // See page 47, figure 3.9: Command responses.
+  INVARIANT(
+    !pairs.empty(), "Get value response must contain one or more pairs.");
+  for(auto &pair : pairs)
+  {
+    get_sub().push_back(std::move(pair));
+  }
+}
+
+std::vector<
+  std::reference_wrapper<const smt_get_value_responset::valuation_pairt>>
+smt_get_value_responset::pairs() const
+{
+  return make_range(get_sub()).map([](const irept &pair) {
+    return std::cref(static_cast<const valuation_pairt &>(pair));
+  });
+}
+
+smt_unsupported_responset::smt_unsupported_responset()
+  : smt_responset{ID_smt_unsupported_response}
+{
+}
+
+smt_error_responset::smt_error_responset(irep_idt message)
+  : smt_responset{ID_smt_error_response}
+{
+  set(ID_value, message);
+}
+
+const irep_idt &smt_error_responset::message() const
+{
+  return get(ID_value);
+}

--- a/src/solvers/smt2_incremental/smt_responses.def
+++ b/src/solvers/smt2_incremental/smt_responses.def
@@ -1,0 +1,15 @@
+/// \file
+/// This set of definitions is used as part of the
+/// [X-macro](https://en.wikipedia.org/wiki/X_Macro) pattern. These define the
+/// set of responses which are implemented and it is used to automate repetitive
+/// parts of the implementation. These include -
+///  * The constant `irep_idt`s used to identify each of the response classes.
+///  * The public base classes used for implementing down casting.
+RESPONSE_ID(success, smt_responset)
+RESPONSE_ID(sat, smt_check_sat_response_kindt)
+RESPONSE_ID(unsat, smt_check_sat_response_kindt)
+RESPONSE_ID(unknown, smt_check_sat_response_kindt)
+RESPONSE_ID(check_sat, smt_responset)
+RESPONSE_ID(get_value, smt_responset)
+RESPONSE_ID(unsupported, smt_responset)
+RESPONSE_ID(error, smt_responset)

--- a/src/solvers/smt2_incremental/smt_responses.h
+++ b/src/solvers/smt2_incremental/smt_responses.h
@@ -3,6 +3,7 @@
 #ifndef CPROVER_SOLVERS_SMT2_INCREMENTAL_SMT_RESPONSES_H
 #define CPROVER_SOLVERS_SMT2_INCREMENTAL_SMT_RESPONSES_H
 
+#include "smt_terms.h"
 #include <util/irep.h>
 
 class smt_responset : protected irept
@@ -14,8 +15,121 @@ public:
 
   using irept::pretty;
 
+  bool operator==(const smt_responset &) const;
+  bool operator!=(const smt_responset &) const;
+
+  template <typename sub_classt>
+  const sub_classt *cast() const &;
+
 protected:
   using irept::irept;
+};
+
+class smt_success_responset : public smt_responset
+{
+public:
+  smt_success_responset();
+};
+
+class smt_check_sat_response_kindt : protected irept
+{
+public:
+  // smt_responset does not support the notion of an empty / null state. Use
+  // optionalt<smt_responset> instead if an empty response is required.
+  smt_check_sat_response_kindt() = delete;
+
+  using irept::pretty;
+
+  bool operator==(const smt_check_sat_response_kindt &) const;
+  bool operator!=(const smt_check_sat_response_kindt &) const;
+
+  template <typename sub_classt>
+  const sub_classt *cast() const &;
+
+  /// \brief Class for adding the ability to up and down cast
+  ///   smt_check_sat_response_kindt to and from irept. These casts are required
+  ///   by other irept derived classes in order to store instances of smt_termt
+  ///   inside them.
+  /// \tparam derivedt The type of class which derives from this class and from
+  ///   irept.
+  template <typename derivedt>
+  class storert
+  {
+  protected:
+    storert();
+    static irept upcast(smt_check_sat_response_kindt check_sat_response_kind);
+    static const smt_check_sat_response_kindt &downcast(const irept &);
+  };
+
+protected:
+  using irept::irept;
+};
+
+class smt_sat_responset : public smt_check_sat_response_kindt
+{
+public:
+  smt_sat_responset();
+};
+
+class smt_unsat_responset : public smt_check_sat_response_kindt
+{
+public:
+  smt_unsat_responset();
+};
+
+class smt_unknown_responset : public smt_check_sat_response_kindt
+{
+public:
+  smt_unknown_responset();
+};
+
+class smt_check_sat_responset
+  : public smt_responset,
+    private smt_check_sat_response_kindt::storert<smt_check_sat_responset>
+{
+public:
+  explicit smt_check_sat_responset(smt_check_sat_response_kindt kind);
+  const smt_check_sat_response_kindt &kind() const;
+};
+
+class smt_get_value_responset
+  : public smt_responset,
+    private smt_termt::storert<smt_get_value_responset>
+{
+public:
+  class valuation_pairt : private irept,
+                          private smt_termt::storert<valuation_pairt>
+  {
+  public:
+    valuation_pairt() = delete;
+    valuation_pairt(smt_termt descriptor, smt_termt value);
+
+    using irept::pretty;
+
+    bool operator==(const valuation_pairt &) const;
+    bool operator!=(const valuation_pairt &) const;
+
+    const smt_termt &descriptor() const;
+    const smt_termt &value() const;
+
+    friend smt_get_value_responset;
+  };
+
+  explicit smt_get_value_responset(std::vector<valuation_pairt> pairs);
+  std::vector<std::reference_wrapper<const valuation_pairt>> pairs() const;
+};
+
+class smt_unsupported_responset : public smt_responset
+{
+public:
+  smt_unsupported_responset();
+};
+
+class smt_error_responset : public smt_responset
+{
+public:
+  explicit smt_error_responset(irep_idt message);
+  const irep_idt &message() const;
 };
 
 #endif // CPROVER_SOLVERS_SMT2_INCREMENTAL_SMT_RESPONSES_H

--- a/unit/Makefile
+++ b/unit/Makefile
@@ -105,6 +105,7 @@ SRC += analyses/ai/ai.cpp \
        solvers/smt2_incremental/smt_bit_vector_theory.cpp \
        solvers/smt2_incremental/smt_commands.cpp \
        solvers/smt2_incremental/smt_core_theory.cpp \
+       solvers/smt2_incremental/smt_responses.cpp \
        solvers/smt2_incremental/smt_sorts.cpp \
        solvers/smt2_incremental/smt_terms.cpp \
        solvers/smt2_incremental/smt_to_smt2_string.cpp \

--- a/unit/count_tests.py
+++ b/unit/count_tests.py
@@ -14,13 +14,22 @@ class argument_separator_countert:
         self.separators = 0
 
     def read_text(self, text):
+        previous_character = None
+        in_quotes = False
         for character in text:
-            if character == '(' or character == '<':
-                self.bracket_depth += 1
-            elif character == ')' or character == '(':
-                self.bracket_depth -= 1
-            elif character == ',' and self.bracket_depth == 1:
-                self.separators += 1
+            if in_quotes:
+                if character == '"' and previous_character != "\\":
+                    in_quotes = False
+            else:
+                if character == '"':
+                    in_quotes = True
+                elif character == '(' or character == '<':
+                    self.bracket_depth += 1
+                elif character == ')' or character == '(':
+                    self.bracket_depth -= 1
+                elif character == ',' and self.bracket_depth == 1:
+                    self.separators += 1
+            previous_character = character
 
 
 def tests_in_file(file_path):

--- a/unit/solvers/smt2_incremental/smt_responses.cpp
+++ b/unit/solvers/smt2_incremental/smt_responses.cpp
@@ -1,0 +1,136 @@
+// Author: Diffblue Ltd.
+
+#include <testing-utils/use_catch.h>
+
+#include <solvers/smt2_incremental/smt_responses.h>
+#include <util/mp_arith.h>
+
+TEST_CASE("Test smt success response", "[core][smt2_incremental]")
+{
+  const smt_responset success{smt_success_responset{}};
+  CHECK(success.cast<smt_success_responset>());
+  CHECK_FALSE(success.cast<smt_error_responset>());
+}
+
+TEST_CASE(
+  "Check sat response kind instantiation and comparisons.",
+  "[core][smt2_incremental]")
+{
+  const smt_check_sat_response_kindt sat = smt_sat_responset{};
+  const smt_check_sat_response_kindt unsat = smt_unsat_responset{};
+  const smt_check_sat_response_kindt unknown = smt_unknown_responset{};
+  SECTION("Comparisons")
+  {
+    CHECK(sat == smt_sat_responset{});
+    CHECK(sat != unsat);
+    CHECK(sat != unknown);
+    CHECK(unsat == smt_unsat_responset{});
+    CHECK(unsat != sat);
+    CHECK(unsat != unknown);
+    CHECK(unknown == smt_unknown_responset{});
+    CHECK(unknown != sat);
+    CHECK(unknown != unsat);
+  }
+  SECTION("Casts")
+  {
+    CHECK(sat.cast<smt_sat_responset>());
+    CHECK_FALSE(sat.cast<smt_unsat_responset>());
+    CHECK_FALSE(sat.cast<smt_unknown_responset>());
+  }
+}
+
+TEMPLATE_TEST_CASE(
+  "Check sat response instantiation, casting and getter",
+  "[core][smt2_incremental]",
+  smt_sat_responset,
+  smt_unsat_responset,
+  smt_unknown_responset)
+{
+  const smt_responset check_sat = smt_check_sat_responset{TestType{}};
+  CHECK_FALSE(check_sat.cast<smt_error_responset>());
+  CHECK(check_sat.cast<smt_check_sat_responset>()->kind() == TestType{});
+}
+
+TEST_CASE(
+  "Test smt_get_value_response pair storage.",
+  "[core][smt2_incremental]")
+{
+  const smt_bit_vector_sortt sort{8};
+  const smt_bit_vector_constant_termt one{1, sort};
+  const smt_bit_vector_constant_termt two{2, sort};
+  const smt_get_value_responset::valuation_pairt pair1{
+    smt_identifier_termt{"foo", sort}, one};
+  const smt_get_value_responset::valuation_pairt pair2{
+    smt_identifier_termt{"bar", sort}, two};
+  SECTION("Valuation pair getters.")
+  {
+    REQUIRE(pair1.descriptor() == smt_identifier_termt{"foo", sort});
+    REQUIRE(pair1.value() == one);
+    REQUIRE(pair2.descriptor() == smt_identifier_termt{"bar", sort});
+    REQUIRE(pair2.value() == two);
+  }
+  SECTION("Valuation pair comparisons.")
+  {
+    REQUIRE(
+      pair1 == smt_get_value_responset::valuation_pairt{
+                 smt_identifier_termt{"foo", sort}, one});
+    REQUIRE(
+      pair1 != smt_get_value_responset::valuation_pairt{
+                 smt_identifier_termt{"bar", sort}, one});
+    REQUIRE(
+      pair1 != smt_get_value_responset::valuation_pairt{
+                 smt_identifier_termt{"foo", sort}, two});
+  }
+  SECTION("Missing valuation pair(s).")
+  {
+    const cbmc_invariants_should_throwt invariants_throw;
+    REQUIRE_THROWS(smt_get_value_responset{{}});
+  }
+  SECTION("Single valuation pair.")
+  {
+    const smt_get_value_responset one_pair_response{{pair1}};
+    REQUIRE(one_pair_response.pairs().size() == 1);
+    REQUIRE(one_pair_response.pairs().at(0).get() == pair1);
+  }
+  SECTION("Multiple valuation pairs.")
+  {
+    const smt_get_value_responset multi_pair_response{{pair1, pair2}};
+    REQUIRE(multi_pair_response.pairs().size() == 2);
+    REQUIRE(multi_pair_response.pairs().at(0).get() == pair1);
+    REQUIRE(multi_pair_response.pairs().at(1).get() == pair2);
+  }
+}
+
+TEST_CASE("Test smt unsupported response", "[core][smt2_incremental]")
+{
+  const smt_responset success{smt_unsupported_responset{}};
+  CHECK(success.cast<smt_unsupported_responset>());
+  CHECK_FALSE(success.cast<smt_error_responset>());
+}
+
+TEST_CASE("Test error response.", "[core][smt2_incremental]")
+{
+  const irep_idt message{"Test error message"};
+  const smt_error_responset error{message};
+  SECTION("message getter")
+  {
+    CHECK(error.message() == message);
+  }
+  SECTION("casting")
+  {
+    const smt_responset upcast{error};
+    CHECK(upcast.cast<smt_error_responset>());
+    CHECK_FALSE(upcast.cast<smt_success_responset>());
+  }
+}
+
+TEST_CASE("SMT response comparisons.", "[core][smt2_incremental]")
+{
+  const smt_check_sat_responset sat{smt_sat_responset{}};
+  CHECK(sat == smt_check_sat_responset{smt_sat_responset{}});
+  CHECK(sat != smt_check_sat_responset{smt_unsat_responset{}});
+  const smt_error_responset error{"Test error"};
+  CHECK(sat != error);
+  CHECK(error == smt_error_responset{"Test error"});
+  CHECK(error != smt_error_responset{"Other error"});
+}


### PR DESCRIPTION
This PR adds smt response storage classes for type safe storage of parsed responses from SMT2 solvers.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
