### PR TITLE
Add new builtin __CPROVER_havoc_slice

### DIFF
--- a/doc/cprover-manual/api.md
+++ b/doc/cprover-manual/api.md
@@ -211,6 +211,57 @@ returns true when it is safe to do both.  These predicates can be given an
 optional size; when the size argument is not given, the size of the subtype
 (which must not be **void**) of the pointer type is used.
 
+#### \_\_CPROVER\_havoc\_object
+
+
+This function requires a valid pointer and updates **all bytes** of the
+underlying object with nondeterministic values.
+
+```C
+void __CPROVER_havoc_object(void *p);
+```
+
+**Warning**
+
+This primitive havocs object bytes before
+the given `p` and after `p + sizeof(*p)`:
+
+```C
+struct foo {
+  int x;
+  int y;
+  int z;
+};
+
+struct foo thefoo = {.x = 1; .y = 2, .z = 3};
+
+int* p = &thefoo.y; // pointing to thefoo.y
+
+__CPROVER_havoc_object(p); // makes the whole struct nondet
+__CPROVER_assert(thefoo.x == 1, "fails because `thefoo.x` is now nondet");
+__CPROVER_assert(thefoo.y == 2, "fails because `thefoo.y` is now nondet");
+__CPROVER_assert(thefoo.z == 3, "fails because `thefoo.z` is now nondet");
+```
+
+#### \_\_CPROVER\_havoc\_slice
+
+This function requires requires that `__CPROVER_w_ok(p, size)` holds,
+and updates `size` consecutive bytes of the underlying object, starting at `p`,
+with nondeterministic values.
+
+```C
+void __CPROVER_havoc_slice(void *p, __CPROVER_size_t size);
+```
+
+**Caveat**
+
+- If the slice contains bytes that can be interpreted as pointers by the
+  program, this will cause these pointers to become invalid
+  (i.e. they will not point to anything meaningful).
+- If this slice only contains bytes that are not interpreted as pointers
+  by the program, then havocing the slice is equivalent to making the
+  interpretation of these bytes nondeterministic.
+
 ### Predefined Types and Symbols
 
 #### \_\_CPROVER\_bitvector

--- a/regression/cbmc/havoc_slice/declarations.h
+++ b/regression/cbmc/havoc_slice/declarations.h
@@ -1,0 +1,26 @@
+#include <stdint.h>
+#include <stdlib.h>
+
+// HAVOC STRUCT MEMBERS
+// TODO take into account plaform/pointer size in the tests
+typedef struct
+{
+  uint16_t a;    // 2 bytes
+  uint16_t b[5]; // 10 bytes
+  uint32_t c;    // 4 bytes
+  uint16_t *d;   // 4 or 8 bytes
+  union {
+    uint16_t a;    // 2 bytes
+    uint16_t b[5]; // 10 bytes
+    uint32_t c;    // 4 bytes
+    uint16_t *d;   // 4 or 8 bytes
+  } u;             // 10 bytes
+} st;              // 30 or 34 bytes total
+
+//                0  2          12   16       24       34
+//                |  |          |    |        |        |
+// struct layout: aa bbbbbbbbbb cccc dddddddd uuuuuuuuuu
+// union layout :                             aa--------
+//                                            bbbbbbbbbb
+//                                            cccc------
+//                                            dddddddd--

--- a/regression/cbmc/havoc_slice/test_array_slice_1.c
+++ b/regression/cbmc/havoc_slice/test_array_slice_1.c
@@ -1,0 +1,17 @@
+void main(void)
+{
+  // INITIALIZE
+  int a[5] = {0, 1, 2, 3, 4};
+  int old_a[5] = {0, 1, 2, 3, 4};
+
+  // HAVOC ARRAY SLICE
+  __CPROVER_havoc_slice(a + 2, 2 * sizeof(*a));
+
+  // POSTCONDITIONS
+  __CPROVER_assert(a[0] == old_a[0], "expecting SUCCESS");
+  __CPROVER_assert(a[1] == old_a[1], "expecting SUCCESS");
+  __CPROVER_assert(a[2] == old_a[2], "expecting FAILURE");
+  __CPROVER_assert(a[3] == old_a[3], "expecting FAILURE");
+  __CPROVER_assert(a[4] == old_a[4], "expecting SUCCESS");
+  return;
+}

--- a/regression/cbmc/havoc_slice/test_array_slice_1.desc
+++ b/regression/cbmc/havoc_slice/test_array_slice_1.desc
@@ -1,0 +1,10 @@
+CORE
+test_array_slice_1.c
+
+^EXIT=10$
+^SIGNAL=0$
+^VERIFICATION FAILED$
+--
+^.*expecting FAILURE: SUCCESS$
+^.*expecting SUCCESS: FAILURE$
+^.*dereference .*: FAILURE$

--- a/regression/cbmc/havoc_slice/test_array_slice_2.c
+++ b/regression/cbmc/havoc_slice/test_array_slice_2.c
@@ -1,0 +1,17 @@
+void main(void)
+{
+  // INITIALIZE
+  int a[5] = {0, 1, 2, 3, 4};
+  int old_a[5] = {0, 1, 2, 3, 4};
+
+  // HAVOC ARRAY SLICE
+  __CPROVER_havoc_slice(&a[2] - 1, 2 * sizeof(*a));
+
+  // POSTCONDITIONS
+  __CPROVER_assert(a[0] == old_a[0], "expecting SUCCESS");
+  __CPROVER_assert(a[1] == old_a[1], "expecting FAILURE");
+  __CPROVER_assert(a[2] == old_a[2], "expecting FAILURE");
+  __CPROVER_assert(a[3] == old_a[3], "expecting SUCCESS");
+  __CPROVER_assert(a[4] == old_a[4], "expecting SUCCESS");
+  return;
+}

--- a/regression/cbmc/havoc_slice/test_array_slice_2.desc
+++ b/regression/cbmc/havoc_slice/test_array_slice_2.desc
@@ -1,0 +1,10 @@
+CORE
+test_array_slice_2.c
+
+^EXIT=10$
+^SIGNAL=0$
+^VERIFICATION FAILED$
+--
+^.*expecting FAILURE: SUCCESS$
+^.*expecting SUCCESS: FAILURE$
+^.*dereference .*: FAILURE$

--- a/regression/cbmc/havoc_slice/test_array_symbolic_size.c
+++ b/regression/cbmc/havoc_slice/test_array_symbolic_size.c
@@ -1,0 +1,46 @@
+#include <stdint.h>
+#include <stdlib.h>
+
+// byte-level comparison
+#define CHECK_SLICE(A, OLD_A, I, IDX, HAVOC_SIZE)                              \
+  {                                                                            \
+    __CPROVER_assert(                                                          \
+      !(IDX <= I && I <= IDX + HAVOC_SIZE) | A[I] == OLD_A[I],                 \
+      "expecting FAILURE");                                                    \
+                                                                               \
+    __CPROVER_assert(                                                          \
+      (IDX <= I && I <= IDX + HAVOC_SIZE) | A[I] == OLD_A[I],                  \
+      "expecting SUCCESS");                                                    \
+  }
+
+// ARRAY WITH SYMBOLIC SIZE.
+void main(void)
+{
+  // INITIALIZE
+  uint32_t size;
+  __CPROVER_assume(5 == size);
+
+  char a[size];
+  char old_a[size];
+
+  __CPROVER_array_set(a, 0);
+  __CPROVER_array_set(old_a, 0);
+
+  uint32_t idx;
+  __CPROVER_assume(idx < size);
+
+  uint32_t havoc_size;
+  __CPROVER_assume(1 <= havoc_size && havoc_size <= size);
+  __CPROVER_assume(idx + havoc_size <= size);
+
+  // HAVOC SINGLE CELL
+  __CPROVER_havoc_slice(&a[idx], havoc_size);
+
+  // POSTCONDITIONS
+  CHECK_SLICE(a, old_a, 0, idx, havoc_size);
+  CHECK_SLICE(a, old_a, 1, idx, havoc_size);
+  CHECK_SLICE(a, old_a, 2, idx, havoc_size);
+  CHECK_SLICE(a, old_a, 3, idx, havoc_size);
+  CHECK_SLICE(a, old_a, 4, idx, havoc_size);
+  return;
+}

--- a/regression/cbmc/havoc_slice/test_array_symbolic_size.desc
+++ b/regression/cbmc/havoc_slice/test_array_symbolic_size.desc
@@ -1,0 +1,10 @@
+CORE thorough-paths thorough-smt-backend
+test_array_symbolic_size.c
+
+^EXIT=10$
+^SIGNAL=0$
+^VERIFICATION FAILED$
+--
+^.*expecting FAILURE: SUCCESS$
+^.*expecting SUCCESS: FAILURE$
+^.*dereference .*: FAILURE$

--- a/regression/cbmc/havoc_slice/test_nondet_conditional.c
+++ b/regression/cbmc/havoc_slice/test_nondet_conditional.c
@@ -1,0 +1,34 @@
+void main(void)
+{
+  // HAVOC through nondet conditional
+  typedef struct
+  {
+    int i;
+    int j;
+  } st;
+  int i = 10;
+  int old_i = 10;
+  st s = {20, 30};
+  st old_s = s;
+
+  _Bool c;
+
+  int *p = c ? &i : &s.i;
+
+  __CPROVER_havoc_slice(p, sizeof(*p));
+
+  if(c)
+  {
+    __CPROVER_assert(i == old_i, "expecting FAILURE");
+    __CPROVER_assert(s.i == old_s.i, "expecting SUCCESS");
+    __CPROVER_assert(s.j == old_s.j, "expecting SUCCESS");
+  }
+  else
+  {
+    __CPROVER_assert(i == old_i, "expecting SUCCESS");
+    __CPROVER_assert(s.i == old_s.i, "expecting FAILURE");
+    __CPROVER_assert(s.j == old_s.j, "expecting SUCCESS");
+  }
+
+  return;
+}

--- a/regression/cbmc/havoc_slice/test_nondet_conditional.desc
+++ b/regression/cbmc/havoc_slice/test_nondet_conditional.desc
@@ -1,0 +1,10 @@
+CORE
+test_nondet_conditional.c
+
+^EXIT=10$
+^SIGNAL=0$
+^VERIFICATION FAILED$
+--
+^.*expecting FAILURE: SUCCESS$
+^.*expecting SUCCESS: FAILURE$
+^.*dereference .*: FAILURE$

--- a/regression/cbmc/havoc_slice/test_struct_a.c
+++ b/regression/cbmc/havoc_slice/test_struct_a.c
@@ -1,0 +1,32 @@
+#include "declarations.h"
+
+void main(void)
+{
+  // INITIALIZE
+  uint16_t a = 1;
+  st old_s = {
+    .a = 1, .b = {0, 1, 2, 3, 4}, .c = 2, .d = &a, .u.b = {0, 1, 2, 3, 4}};
+  st s = old_s;
+
+  // HAVOC FIRST MEMBER
+  __CPROVER_havoc_slice(&s.a, sizeof(s.a));
+
+  // POSTCONDITION
+  __CPROVER_assert(s.a == old_s.a, "expecting FAILURE");
+  __CPROVER_assert(s.b[0] == old_s.b[0], "expecting SUCCESS");
+  __CPROVER_assert(s.b[1] == old_s.b[1], "expecting SUCCESS");
+  __CPROVER_assert(s.b[2] == old_s.b[2], "expecting SUCCESS");
+  __CPROVER_assert(s.b[3] == old_s.b[3], "expecting SUCCESS");
+  __CPROVER_assert(s.b[4] == old_s.b[4], "expecting SUCCESS");
+  __CPROVER_assert(s.c == old_s.c, "expecting SUCCESS");
+  __CPROVER_assert(s.d == old_s.d, "expecting SUCCESS");
+  __CPROVER_assert(s.u.a == old_s.u.a, "expecting SUCCESS");
+  __CPROVER_assert(s.u.b[0] == old_s.u.b[0], "expecting SUCCESS");
+  __CPROVER_assert(s.u.b[1] == old_s.u.b[1], "expecting SUCCESS");
+  __CPROVER_assert(s.u.b[2] == old_s.u.b[2], "expecting SUCCESS");
+  __CPROVER_assert(s.u.b[3] == old_s.u.b[3], "expecting SUCCESS");
+  __CPROVER_assert(s.u.b[4] == old_s.u.b[4], "expecting SUCCESS");
+  __CPROVER_assert(s.u.c == old_s.u.c, "expecting SUCCESS");
+  __CPROVER_assert(s.u.d == old_s.u.d, "expecting SUCCESS");
+  return;
+}

--- a/regression/cbmc/havoc_slice/test_struct_a.desc
+++ b/regression/cbmc/havoc_slice/test_struct_a.desc
@@ -1,0 +1,10 @@
+CORE
+test_struct_a.c
+
+^EXIT=10$
+^SIGNAL=0$
+^VERIFICATION FAILED$
+--
+^.*expecting FAILURE: SUCCESS$
+^.*expecting SUCCESS: FAILURE$
+^.*dereference .*: FAILURE$

--- a/regression/cbmc/havoc_slice/test_struct_b.c
+++ b/regression/cbmc/havoc_slice/test_struct_b.c
@@ -1,0 +1,31 @@
+#include "declarations.h"
+
+void main(void)
+{
+  // INITIALIZE
+  uint16_t a = 1;
+  st old_s = {
+    .a = 1, .b = {0, 1, 2, 3, 4}, .c = 2, .d = &a, .u.b = {0, 1, 2, 3, 4}};
+  st s = old_s;
+
+  // HAVOC WHOLE SECOND MEMBER
+  __CPROVER_havoc_slice(s.b, sizeof(s.b));
+
+  // POSTCONDITION
+  __CPROVER_assert(s.a == old_s.a, "expecting SUCCESS");
+  __CPROVER_assert(s.b[0] == old_s.b[0], "expecting FAILURE");
+  __CPROVER_assert(s.b[1] == old_s.b[1], "expecting FAILURE");
+  __CPROVER_assert(s.b[2] == old_s.b[2], "expecting FAILURE");
+  __CPROVER_assert(s.b[3] == old_s.b[3], "expecting FAILURE");
+  __CPROVER_assert(s.b[4] == old_s.b[4], "expecting FAILURE");
+  __CPROVER_assert(s.c == old_s.c, "expecting SUCCESS");
+  __CPROVER_assert(s.d == old_s.d, "expecting SUCCESS");
+  __CPROVER_assert(s.u.a == old_s.u.a, "expecting SUCCESS");
+  __CPROVER_assert(s.u.b[0] == old_s.u.b[0], "expecting SUCCESS");
+  __CPROVER_assert(s.u.b[1] == old_s.u.b[1], "expecting SUCCESS");
+  __CPROVER_assert(s.u.b[2] == old_s.u.b[2], "expecting SUCCESS");
+  __CPROVER_assert(s.u.b[3] == old_s.u.b[3], "expecting SUCCESS");
+  __CPROVER_assert(s.u.b[4] == old_s.u.b[4], "expecting SUCCESS");
+  __CPROVER_assert(s.u.c == old_s.u.c, "expecting SUCCESS");
+  __CPROVER_assert(s.u.d == old_s.u.d, "expecting SUCCESS");
+}

--- a/regression/cbmc/havoc_slice/test_struct_b.desc
+++ b/regression/cbmc/havoc_slice/test_struct_b.desc
@@ -1,0 +1,10 @@
+CORE
+test_struct_b.c
+
+^EXIT=10$
+^SIGNAL=0$
+^VERIFICATION FAILED$
+--
+^.*expecting FAILURE: SUCCESS$
+^.*expecting SUCCESS: FAILURE$
+^.*dereference .*: FAILURE$

--- a/regression/cbmc/havoc_slice/test_struct_b_slice.c
+++ b/regression/cbmc/havoc_slice/test_struct_b_slice.c
@@ -1,0 +1,32 @@
+#include "declarations.h"
+
+void main(void)
+{
+  // INITIALIZE
+  uint16_t a = 1;
+  st old_s = {
+    .a = 1, .b = {0, 1, 2, 3, 4}, .c = 2, .d = &a, .u.b = {0, 1, 2, 3, 4}};
+  st s = old_s;
+
+  // HAVOC SECOND MEMBER SLICE
+  __CPROVER_havoc_slice(s.b + 1, 2 * sizeof(*s.b));
+
+  // POSTCONDITIONS
+  __CPROVER_assert(s.a == old_s.a, "expecting SUCCESS");
+  __CPROVER_assert(s.b[0] == old_s.b[0], "expecting SUCCESS");
+  __CPROVER_assert(s.b[1] == old_s.b[1], "expecting FAILURE");
+  __CPROVER_assert(s.b[2] == old_s.b[2], "expecting FAILURE");
+  __CPROVER_assert(s.b[3] == old_s.b[3], "expecting SUCCESS");
+  __CPROVER_assert(s.b[4] == old_s.b[4], "expecting SUCCESS");
+  __CPROVER_assert(s.c == old_s.c, "expecting SUCCESS");
+  __CPROVER_assert(s.d == old_s.d, "expecting SUCCESS");
+  __CPROVER_assert(s.u.a == old_s.u.a, "expecting SUCCESS");
+  __CPROVER_assert(s.u.b[0] == old_s.u.b[0], "expecting SUCCESS");
+  __CPROVER_assert(s.u.b[1] == old_s.u.b[1], "expecting SUCCESS");
+  __CPROVER_assert(s.u.b[2] == old_s.u.b[2], "expecting SUCCESS");
+  __CPROVER_assert(s.u.b[3] == old_s.u.b[3], "expecting SUCCESS");
+  __CPROVER_assert(s.u.b[4] == old_s.u.b[4], "expecting SUCCESS");
+  __CPROVER_assert(s.u.c == old_s.u.c, "expecting SUCCESS");
+  __CPROVER_assert(s.u.d == old_s.u.d, "expecting SUCCESS");
+  return;
+}

--- a/regression/cbmc/havoc_slice/test_struct_b_slice.desc
+++ b/regression/cbmc/havoc_slice/test_struct_b_slice.desc
@@ -1,0 +1,10 @@
+CORE broken-smt-backend
+test_struct_b_slice.c
+
+^EXIT=10$
+^SIGNAL=0$
+^VERIFICATION FAILED$
+--
+^.*expecting FAILURE: SUCCESS$
+^.*expecting SUCCESS: FAILURE$
+^.*dereference .*: FAILURE$

--- a/regression/cbmc/havoc_slice/test_struct_c.c
+++ b/regression/cbmc/havoc_slice/test_struct_c.c
@@ -1,0 +1,32 @@
+#include "declarations.h"
+
+void main(void)
+{
+  // INITIALIZE
+  uint16_t a = 1;
+  st old_s = {
+    .a = 1, .b = {0, 1, 2, 3, 4}, .c = 2, .d = &a, .u.b = {0, 1, 2, 3, 4}};
+  st s = old_s;
+
+  // HAVOC THIRD MEMBER
+  __CPROVER_havoc_slice(&s.c, sizeof(s.c));
+
+  // POSTCONDITIONS
+  __CPROVER_assert(s.a == old_s.a, "expecting SUCCESS");
+  __CPROVER_assert(s.b[0] == old_s.b[0], "expecting SUCCESS");
+  __CPROVER_assert(s.b[1] == old_s.b[1], "expecting SUCCESS");
+  __CPROVER_assert(s.b[2] == old_s.b[2], "expecting SUCCESS");
+  __CPROVER_assert(s.b[3] == old_s.b[3], "expecting SUCCESS");
+  __CPROVER_assert(s.b[4] == old_s.b[4], "expecting SUCCESS");
+  __CPROVER_assert(s.c == old_s.c, "expecting FAILURE");
+  __CPROVER_assert(s.d == old_s.d, "expecting SUCCESS");
+  __CPROVER_assert(s.u.a == old_s.u.a, "expecting SUCCESS");
+  __CPROVER_assert(s.u.b[0] == old_s.u.b[0], "expecting SUCCESS");
+  __CPROVER_assert(s.u.b[1] == old_s.u.b[1], "expecting SUCCESS");
+  __CPROVER_assert(s.u.b[2] == old_s.u.b[2], "expecting SUCCESS");
+  __CPROVER_assert(s.u.b[3] == old_s.u.b[3], "expecting SUCCESS");
+  __CPROVER_assert(s.u.b[4] == old_s.u.b[4], "expecting SUCCESS");
+  __CPROVER_assert(s.u.c == old_s.u.c, "expecting SUCCESS");
+  __CPROVER_assert(s.u.d == old_s.u.d, "expecting SUCCESS");
+  return;
+}

--- a/regression/cbmc/havoc_slice/test_struct_c.desc
+++ b/regression/cbmc/havoc_slice/test_struct_c.desc
@@ -1,0 +1,10 @@
+CORE
+test_struct_c.c
+
+^EXIT=10$
+^SIGNAL=0$
+^VERIFICATION FAILED$
+--
+^.*expecting FAILURE: SUCCESS$
+^.*expecting SUCCESS: FAILURE$
+^.*dereference .*: FAILURE$

--- a/regression/cbmc/havoc_slice/test_struct_d.c
+++ b/regression/cbmc/havoc_slice/test_struct_d.c
@@ -1,0 +1,31 @@
+#include "declarations.h"
+
+void main(void)
+{
+  // INITIALIZE
+  uint16_t a = 1;
+  st old_s = {
+    .a = 1, .b = {0, 1, 2, 3, 4}, .c = 2, .d = &a, .u.b = {0, 1, 2, 3, 4}};
+  st s = old_s;
+
+  // HAVOC FOURTH MEMBER (PTR)
+  __CPROVER_havoc_slice(&s.d, sizeof(s.d));
+
+  // POSTCONDITIONS
+  __CPROVER_assert(s.a == old_s.a, "expecting SUCCESS");
+  __CPROVER_assert(s.b[0] == old_s.b[0], "expecting SUCCESS");
+  __CPROVER_assert(s.b[1] == old_s.b[1], "expecting SUCCESS");
+  __CPROVER_assert(s.b[2] == old_s.b[2], "expecting SUCCESS");
+  __CPROVER_assert(s.b[3] == old_s.b[3], "expecting SUCCESS");
+  __CPROVER_assert(s.b[4] == old_s.b[4], "expecting SUCCESS");
+  __CPROVER_assert(s.c == old_s.c, "expecting SUCCESS");
+  __CPROVER_assert(s.d == old_s.d, "expecting FAILURE");
+  __CPROVER_assert(s.u.a == old_s.u.a, "expecting SUCCESS");
+  __CPROVER_assert(s.u.b[0] == old_s.u.b[0], "expecting SUCCESS");
+  __CPROVER_assert(s.u.b[1] == old_s.u.b[1], "expecting SUCCESS");
+  __CPROVER_assert(s.u.b[2] == old_s.u.b[2], "expecting SUCCESS");
+  __CPROVER_assert(s.u.b[3] == old_s.u.b[3], "expecting SUCCESS");
+  __CPROVER_assert(s.u.b[4] == old_s.u.b[4], "expecting SUCCESS");
+  __CPROVER_assert(s.u.c == old_s.u.c, "expecting SUCCESS");
+  __CPROVER_assert(s.u.d == old_s.u.d, "expecting SUCCESS");
+}

--- a/regression/cbmc/havoc_slice/test_struct_d.desc
+++ b/regression/cbmc/havoc_slice/test_struct_d.desc
@@ -1,0 +1,10 @@
+CORE
+test_struct_d.c
+
+^EXIT=10$
+^SIGNAL=0$
+^VERIFICATION FAILED$
+--
+^.*expecting FAILURE: SUCCESS$
+^.*expecting SUCCESS: FAILURE$
+^.*dereference .*: FAILURE$

--- a/regression/cbmc/havoc_slice/test_struct_raw_bytes.c
+++ b/regression/cbmc/havoc_slice/test_struct_raw_bytes.c
@@ -1,0 +1,41 @@
+#include "declarations.h"
+
+void main(void)
+{
+  // INITIALIZE
+  uint16_t a = 1;
+  st old_s = {
+    .a = 1, .b = {0, 1, 2, 3, 4}, .c = 2, .d = &a, .u.b = {0, 1, 2, 3, 4}};
+  st s = old_s;
+
+  // Interpret as bytes
+  char *c = (char *)&s;
+  char *old_c = (char *)&old_s;
+
+  // HAVOC SOME BYTE LEVEL SLICE
+  __CPROVER_havoc_slice(c + 7, 11);
+
+  // POSTCONDITION
+  // TODO
+  __CPROVER_assert(c[0] == old_c[0], "expecting SUCCESS");
+  __CPROVER_assert(c[1] == old_c[1], "expecting SUCCESS");
+  __CPROVER_assert(c[2] == old_c[2], "expecting SUCCESS");
+  __CPROVER_assert(c[3] == old_c[3], "expecting SUCCESS");
+  __CPROVER_assert(c[4] == old_c[4], "expecting SUCCESS");
+  __CPROVER_assert(c[5] == old_c[5], "expecting SUCCESS");
+  __CPROVER_assert(c[6] == old_c[6], "expecting SUCCESS");
+  __CPROVER_assert(c[7] == old_c[7], "expecting FAILURE");
+  __CPROVER_assert(c[8] == old_c[8], "expecting FAILURE");
+  __CPROVER_assert(c[9] == old_c[9], "expecting FAILURE");
+  __CPROVER_assert(c[10] == old_c[10], "expecting FAILURE");
+  __CPROVER_assert(c[11] == old_c[11], "expecting FAILURE");
+  __CPROVER_assert(c[12] == old_c[12], "expecting FAILURE");
+  __CPROVER_assert(c[13] == old_c[13], "expecting FAILURE");
+  __CPROVER_assert(c[14] == old_c[14], "expecting FAILURE");
+  __CPROVER_assert(c[15] == old_c[15], "expecting FAILURE");
+  __CPROVER_assert(c[16] == old_c[16], "expecting FAILURE");
+  __CPROVER_assert(c[17] == old_c[17], "expecting FAILURE");
+  __CPROVER_assert(c[18] == old_c[18], "expecting SUCCESS");
+  __CPROVER_assert(c[19] == old_c[20], "expecting SUCCESS");
+  return;
+}

--- a/regression/cbmc/havoc_slice/test_struct_raw_bytes.desc
+++ b/regression/cbmc/havoc_slice/test_struct_raw_bytes.desc
@@ -1,0 +1,10 @@
+CORE broken-smt-backend
+test_struct_raw_bytes.c
+
+^EXIT=10$
+^SIGNAL=0$
+^VERIFICATION FAILED$
+--
+^.*expecting FAILURE: SUCCESS$
+^.*expecting SUCCESS: FAILURE$
+^.*dereference .*: FAILURE$

--- a/regression/cbmc/havoc_slice/test_struct_union_a.c
+++ b/regression/cbmc/havoc_slice/test_struct_union_a.c
@@ -1,0 +1,33 @@
+#include "declarations.h"
+
+void main(void)
+{
+  // INITIALIZE
+  uint16_t a = 1;
+  st old_s = {
+    .a = 1, .b = {0, 1, 2, 3, 4}, .c = 2, .d = &a, .u.b = {0, 1, 2, 3, 4}};
+  st s = old_s;
+
+  // HAVOC FIRST UNION MEMBER
+  __CPROVER_havoc_slice(&s.u.a, sizeof(s.u.a));
+
+  // POSTCONDITIONS
+  __CPROVER_assert(s.a == old_s.a, "expecting SUCCESS");
+  __CPROVER_assert(s.b[0] == old_s.b[0], "expecting SUCCESS");
+  __CPROVER_assert(s.b[1] == old_s.b[1], "expecting SUCCESS");
+  __CPROVER_assert(s.b[2] == old_s.b[2], "expecting SUCCESS");
+  __CPROVER_assert(s.b[3] == old_s.b[3], "expecting SUCCESS");
+  __CPROVER_assert(s.b[4] == old_s.b[4], "expecting SUCCESS");
+  __CPROVER_assert(s.c == old_s.c, "expecting SUCCESS");
+  __CPROVER_assert(s.d == old_s.d, "expecting SUCCESS");
+  __CPROVER_assert(s.u.a == old_s.u.a, "expecting FAILURE");
+  __CPROVER_assert(s.u.b[0] == old_s.u.b[0], "expecting FAILURE");
+  __CPROVER_assert(s.u.b[1] == old_s.u.b[1], "expecting SUCCESS");
+  __CPROVER_assert(s.u.b[2] == old_s.u.b[2], "expecting SUCCESS");
+  __CPROVER_assert(s.u.b[3] == old_s.u.b[3], "expecting SUCCESS");
+  __CPROVER_assert(s.u.b[4] == old_s.u.b[4], "expecting SUCCESS");
+  __CPROVER_assert(s.u.c == old_s.u.c, "expecting FAILURE");
+  __CPROVER_assert(s.u.d == old_s.u.d, "expecting FAILURE");
+
+  return;
+}

--- a/regression/cbmc/havoc_slice/test_struct_union_a.desc
+++ b/regression/cbmc/havoc_slice/test_struct_union_a.desc
@@ -1,0 +1,10 @@
+CORE
+test_struct_union_a.c
+
+^EXIT=10$
+^SIGNAL=0$
+^VERIFICATION FAILED$
+--
+^.*expecting FAILURE: SUCCESS$
+^.*expecting SUCCESS: FAILURE$
+^.*dereference .*: FAILURE$

--- a/regression/cbmc/havoc_slice/test_struct_union_b.c
+++ b/regression/cbmc/havoc_slice/test_struct_union_b.c
@@ -1,0 +1,32 @@
+#include "declarations.h"
+
+void main(void)
+{
+  // INITIALIZE
+  uint16_t a = 1;
+  st old_s = {
+    .a = 1, .b = {0, 1, 2, 3, 4}, .c = 2, .d = &a, .u.b = {0, 1, 2, 3, 4}};
+  st s = old_s;
+
+  // HAVOC WHOLE SECOND UNION MEMBER
+  __CPROVER_havoc_slice(s.u.b, sizeof(s.u.b));
+
+  // POSTCONDITION
+  __CPROVER_assert(s.a == old_s.a, "expecting SUCCESS");
+  __CPROVER_assert(s.b[0] == old_s.b[0], "expecting SUCCESS");
+  __CPROVER_assert(s.b[1] == old_s.b[1], "expecting SUCCESS");
+  __CPROVER_assert(s.b[2] == old_s.b[2], "expecting SUCCESS");
+  __CPROVER_assert(s.b[3] == old_s.b[3], "expecting SUCCESS");
+  __CPROVER_assert(s.b[4] == old_s.b[4], "expecting SUCCESS");
+  __CPROVER_assert(s.c == old_s.c, "expecting SUCCESS");
+  __CPROVER_assert(s.d == old_s.d, "expecting SUCCESS");
+  __CPROVER_assert(s.u.a == old_s.u.a, "expecting FAILURE");
+  __CPROVER_assert(s.u.b[0] == old_s.u.b[0], "expecting FAILURE");
+  __CPROVER_assert(s.u.b[1] == old_s.u.b[1], "expecting FAILURE");
+  __CPROVER_assert(s.u.b[2] == old_s.u.b[2], "expecting FAILURE");
+  __CPROVER_assert(s.u.b[3] == old_s.u.b[3], "expecting FAILURE");
+  __CPROVER_assert(s.u.b[4] == old_s.u.b[4], "expecting FAILURE");
+  __CPROVER_assert(s.u.c == old_s.u.c, "expecting FAILURE");
+  __CPROVER_assert(s.u.d == old_s.u.d, "expecting FAILURE");
+  return;
+}

--- a/regression/cbmc/havoc_slice/test_struct_union_b.desc
+++ b/regression/cbmc/havoc_slice/test_struct_union_b.desc
@@ -1,0 +1,10 @@
+CORE
+test_struct_union_b.c
+
+^EXIT=10$
+^SIGNAL=0$
+^VERIFICATION FAILED$
+--
+^.*expecting FAILURE: SUCCESS$
+^.*expecting SUCCESS: FAILURE$
+^.*dereference .*: FAILURE$

--- a/regression/cbmc/havoc_slice/test_struct_union_b_slice.c
+++ b/regression/cbmc/havoc_slice/test_struct_union_b_slice.c
@@ -1,0 +1,32 @@
+#include "declarations.h"
+
+void main(void)
+{
+  // INITIALIZE
+  uint16_t a = 1;
+  st old_s = {
+    .a = 1, .b = {0, 1, 2, 3, 4}, .c = 2, .d = &a, .u.b = {0, 1, 2, 3, 4}};
+  st s = old_s;
+
+  // HAVOC SECOND UNION MEMBER SLICE
+  __CPROVER_havoc_slice(s.u.b + 1, 2 * sizeof(*s.u.b));
+
+  // POSTCONDITION
+  __CPROVER_assert(s.a == old_s.a, "expecting SUCCESS");
+  __CPROVER_assert(s.b[0] == old_s.b[0], "expecting SUCCESS");
+  __CPROVER_assert(s.b[1] == old_s.b[1], "expecting SUCCESS");
+  __CPROVER_assert(s.b[2] == old_s.b[2], "expecting SUCCESS");
+  __CPROVER_assert(s.b[3] == old_s.b[3], "expecting SUCCESS");
+  __CPROVER_assert(s.b[4] == old_s.b[4], "expecting SUCCESS");
+  __CPROVER_assert(s.c == old_s.c, "expecting SUCCESS");
+  __CPROVER_assert(s.d == old_s.d, "expecting SUCCESS");
+  __CPROVER_assert(s.u.a == old_s.u.a, "expecting SUCCESS");
+  __CPROVER_assert(s.u.b[0] == old_s.u.b[0], "expecting SUCCESS");
+  __CPROVER_assert(s.u.b[1] == old_s.u.b[1], "expecting FAILURE");
+  __CPROVER_assert(s.u.b[2] == old_s.u.b[2], "expecting FAILURE");
+  __CPROVER_assert(s.u.b[3] == old_s.u.b[3], "expecting SUCCESS");
+  __CPROVER_assert(s.u.b[4] == old_s.u.b[4], "expecting SUCCESS");
+  __CPROVER_assert(s.u.c == old_s.u.c, "expecting FAILURE");
+  __CPROVER_assert(s.u.d == old_s.u.d, "expecting FAILURE");
+  return;
+}

--- a/regression/cbmc/havoc_slice/test_struct_union_b_slice.desc
+++ b/regression/cbmc/havoc_slice/test_struct_union_b_slice.desc
@@ -1,0 +1,10 @@
+CORE
+test_struct_union_b_slice.c
+
+^EXIT=10$
+^SIGNAL=0$
+^VERIFICATION FAILED$
+--
+^.*expecting FAILURE: SUCCESS$
+^.*expecting SUCCESS: FAILURE$
+^.*dereference .*: FAILURE$

--- a/regression/cbmc/havoc_slice/test_struct_union_c.c
+++ b/regression/cbmc/havoc_slice/test_struct_union_c.c
@@ -1,0 +1,33 @@
+#include "declarations.h"
+
+void main(void)
+{
+  // INITIALIZE
+  uint16_t a = 1;
+  st old_s = {
+    .a = 1, .b = {0, 1, 2, 3, 4}, .c = 2, .d = &a, .u.b = {0, 1, 2, 3, 4}};
+  st s = old_s;
+
+  // HAVOC THIRD UNION MEMBER
+  __CPROVER_havoc_slice(&s.u.c, sizeof(s.u.c));
+
+  // POSTCONDITION
+  __CPROVER_assert(s.a == old_s.a, "expecting SUCCESS");
+  __CPROVER_assert(s.b[0] == old_s.b[0], "expecting SUCCESS");
+  __CPROVER_assert(s.b[1] == old_s.b[1], "expecting SUCCESS");
+  __CPROVER_assert(s.b[2] == old_s.b[2], "expecting SUCCESS");
+  __CPROVER_assert(s.b[3] == old_s.b[3], "expecting SUCCESS");
+  __CPROVER_assert(s.b[4] == old_s.b[4], "expecting SUCCESS");
+  __CPROVER_assert(s.c == old_s.c, "expecting SUCCESS");
+  __CPROVER_assert(s.d == old_s.d, "expecting SUCCESS");
+  __CPROVER_assert(s.u.a == old_s.u.a, "expecting FAILURE");
+  __CPROVER_assert(s.u.b[0] == old_s.u.b[0], "expecting FAILURE");
+  __CPROVER_assert(s.u.b[1] == old_s.u.b[1], "expecting FAILURE");
+  __CPROVER_assert(s.u.b[2] == old_s.u.b[2], "expecting SUCCESS");
+  __CPROVER_assert(s.u.b[3] == old_s.u.b[3], "expecting SUCCESS");
+  __CPROVER_assert(s.u.b[4] == old_s.u.b[4], "expecting SUCCESS");
+  __CPROVER_assert(s.u.c == old_s.u.c, "expecting FAILURE");
+  __CPROVER_assert(s.u.d == old_s.u.d, "expecting FAILURE");
+
+  return;
+}

--- a/regression/cbmc/havoc_slice/test_struct_union_c.desc
+++ b/regression/cbmc/havoc_slice/test_struct_union_c.desc
@@ -1,0 +1,10 @@
+CORE
+test_struct_union_b.c
+
+^EXIT=10$
+^SIGNAL=0$
+^VERIFICATION FAILED$
+--
+^.*expecting FAILURE: SUCCESS$
+^.*expecting SUCCESS: FAILURE$
+^.*dereference .*: FAILURE$

--- a/regression/cbmc/havoc_slice/test_struct_union_d.c
+++ b/regression/cbmc/havoc_slice/test_struct_union_d.c
@@ -1,0 +1,33 @@
+#include "declarations.h"
+
+void main(void)
+{
+  // INITIALIZE
+  uint16_t a = 1;
+  st old_s = {
+    .a = 1, .b = {0, 1, 2, 3, 4}, .c = 2, .d = &a, .u.b = {0, 1, 2, 3, 4}};
+  st s = old_s;
+
+  // HAVOC FOURTH UNION MEMBER
+  __CPROVER_havoc_slice(&s.u.d, sizeof(s.u.d));
+
+  // POSTCONDITION
+  __CPROVER_assert(s.a == old_s.a, "expecting SUCCESS");
+  __CPROVER_assert(s.b[0] == old_s.b[0], "expecting SUCCESS");
+  __CPROVER_assert(s.b[1] == old_s.b[1], "expecting SUCCESS");
+  __CPROVER_assert(s.b[2] == old_s.b[2], "expecting SUCCESS");
+  __CPROVER_assert(s.b[3] == old_s.b[3], "expecting SUCCESS");
+  __CPROVER_assert(s.b[4] == old_s.b[4], "expecting SUCCESS");
+  __CPROVER_assert(s.c == old_s.c, "expecting SUCCESS");
+  __CPROVER_assert(s.d == old_s.d, "expecting SUCCESS");
+  __CPROVER_assert(s.u.a == old_s.u.a, "expecting FAILURE");
+  __CPROVER_assert(s.u.b[0] == old_s.u.b[0], "expecting FAILURE");
+  __CPROVER_assert(s.u.b[1] == old_s.u.b[1], "expecting FAILURE");
+  __CPROVER_assert(s.u.b[2] == old_s.u.b[2], "expecting SUCCESS or FAILURE");
+  __CPROVER_assert(s.u.b[3] == old_s.u.b[3], "expecting SUCCESS or FAILURE");
+  __CPROVER_assert(s.u.b[4] == old_s.u.b[4], "expecting SUCCESS");
+  __CPROVER_assert(s.u.c == old_s.u.c, "expecting FAILURE");
+  __CPROVER_assert(s.u.d == old_s.u.d, "expecting FAILURE");
+
+  return;
+}

--- a/regression/cbmc/havoc_slice/test_struct_union_d.desc
+++ b/regression/cbmc/havoc_slice/test_struct_union_d.desc
@@ -1,0 +1,10 @@
+CORE
+test_struct_union_d.c
+
+^EXIT=10$
+^SIGNAL=0$
+^VERIFICATION FAILED$
+--
+^.*expecting FAILURE: SUCCESS$
+^.*expecting SUCCESS: FAILURE$
+^.*dereference .*: FAILURE$

--- a/regression/cbmc/havoc_slice/test_whole_array.c
+++ b/regression/cbmc/havoc_slice/test_whole_array.c
@@ -1,0 +1,20 @@
+#include "declarations.h"
+
+void main(void)
+{
+  // INITIALIZE
+  int a[5] = {0, 1, 2, 3, 4};
+  int old_a[5] = {0, 1, 2, 3, 4};
+
+  // HAVOC WHOLE ARRAY
+  __CPROVER_havoc_slice(a, __CPROVER_OBJECT_SIZE(a));
+
+  // POSTCONDITIONS
+  __CPROVER_assert(a[0] == old_a[0], "expecting FAILURE");
+  __CPROVER_assert(a[1] == old_a[1], "expecting FAILURE");
+  __CPROVER_assert(a[2] == old_a[2], "expecting FAILURE");
+  __CPROVER_assert(a[3] == old_a[3], "expecting FAILURE");
+  __CPROVER_assert(a[4] == old_a[4], "expecting FAILURE");
+
+  return;
+}

--- a/regression/cbmc/havoc_slice/test_whole_array.desc
+++ b/regression/cbmc/havoc_slice/test_whole_array.desc
@@ -1,0 +1,10 @@
+CORE
+test_whole_array.c
+
+^EXIT=10$
+^SIGNAL=0$
+^VERIFICATION FAILED$
+--
+^.*expecting FAILURE: SUCCESS$
+^.*expecting SUCCESS: FAILURE$
+^.*dereference .*: FAILURE$

--- a/regression/cbmc/havoc_slice/test_whole_array_with_offset.c
+++ b/regression/cbmc/havoc_slice/test_whole_array_with_offset.c
@@ -1,0 +1,20 @@
+#include "declarations.h"
+
+void main(void)
+{
+  // INITIALIZE
+  int a[5] = {0, 1, 2, 3, 4};
+  int old_a[5] = {0, 1, 2, 3, 4};
+
+  // HAVOC WHOLE ARRAY WITH POINTER ARITH
+  __CPROVER_havoc_slice(&a[2] - 2, __CPROVER_OBJECT_SIZE(a));
+
+  // POSTCONDITIONS
+  __CPROVER_assert(a[0] == old_a[0], "expecting FAILURE");
+  __CPROVER_assert(a[1] == old_a[1], "expecting FAILURE");
+  __CPROVER_assert(a[2] == old_a[2], "expecting FAILURE");
+  __CPROVER_assert(a[3] == old_a[3], "expecting FAILURE");
+  __CPROVER_assert(a[4] == old_a[4], "expecting FAILURE");
+
+  return;
+}

--- a/regression/cbmc/havoc_slice/test_whole_array_with_offset.desc
+++ b/regression/cbmc/havoc_slice/test_whole_array_with_offset.desc
@@ -1,0 +1,10 @@
+CORE
+test_whole_array_with_offset.c
+
+^EXIT=10$
+^SIGNAL=0$
+^VERIFICATION FAILED$
+--
+^.*expecting FAILURE: SUCCESS$
+^.*expecting SUCCESS: FAILURE$
+^.*dereference .*: FAILURE$

--- a/regression/cbmc/havoc_slice_checks/main.c
+++ b/regression/cbmc/havoc_slice_checks/main.c
@@ -1,0 +1,31 @@
+// Here we test that __CPROVER_havoc_slice checks fail as expected
+#include <stdint.h>
+#include <stdlib.h>
+
+int main()
+{
+  // invalid pointer
+  int *invalid_ptr;
+  __CPROVER_havoc_slice(invalid_ptr, 1);
+
+  // null pointer
+  int *null_ptr = NULL;
+  __CPROVER_havoc_slice(null_ptr, 1);
+
+  int a[4];
+
+  // positive size but out of bounds
+  __CPROVER_havoc_slice(&a[2], 3 * sizeof(*a));
+
+  // positive size but out of bounds
+  __CPROVER_havoc_slice(a, 5 * sizeof(*a));
+
+  // pointer invalidated by overflow
+  __CPROVER_havoc_slice(&a[0] + 6, sizeof(*a));
+
+  // pointer invalidated by underflow
+  __CPROVER_havoc_slice(&a[0] - 1, sizeof(*a));
+
+  // negative size
+  __CPROVER_havoc_slice(&a[0], -2);
+}

--- a/regression/cbmc/havoc_slice_checks/test.desc
+++ b/regression/cbmc/havoc_slice_checks/test.desc
@@ -1,0 +1,15 @@
+CORE
+main.c
+
+^\[main\.assertion\.\d+\] line 9 assertion havoc_slice W_OK.*: FAILURE$
+^\[main\.assertion\.\d+\] line 13 assertion havoc_slice W_OK.*: FAILURE$
+^\[main\.assertion\.\d+\] line 18 assertion havoc_slice W_OK.*: FAILURE$
+^\[main\.assertion\.\d+\] line 21 assertion havoc_slice W_OK.*: FAILURE$
+^\[main\.assertion\.\d+\] line 24 assertion havoc_slice W_OK.*: FAILURE$
+^\[main\.assertion\.\d+\] line 27 assertion havoc_slice W_OK.*: FAILURE$
+^\[main\.assertion\.\d+\] line 30 assertion havoc_slice W_OK.*: FAILURE$
+\*\* 7 of [0-9]+ failed \(.*\)
+^VERIFICATION FAILED$
+^EXIT=10$
+^SIGNAL=0$
+--

--- a/src/ansi-c/cprover_builtin_headers.h
+++ b/src/ansi-c/cprover_builtin_headers.h
@@ -4,6 +4,7 @@ void __CPROVER_assert(__CPROVER_bool assertion, const char *description);
 void __CPROVER_precondition(__CPROVER_bool precondition, const char *description);
 void __CPROVER_postcondition(__CPROVER_bool assertion, const char *description);
 void __CPROVER_havoc_object(void *);
+void __CPROVER_havoc_slice(void *, __CPROVER_size_t);
 __CPROVER_bool __CPROVER_equal();
 __CPROVER_bool __CPROVER_same_object(const void *, const void *);
 __CPROVER_bool __CPROVER_is_invalid_pointer(const void *);

--- a/src/goto-programs/goto_convert_class.h
+++ b/src/goto-programs/goto_convert_class.h
@@ -203,7 +203,8 @@ protected:
     const exprt &lhs,
     const symbol_exprt &function,
     const exprt::operandst &arguments,
-    goto_programt &dest);
+    goto_programt &dest,
+    const irep_idt &mode);
 
   virtual void do_function_call_symbol(const symbolt &)
   {
@@ -672,6 +673,12 @@ protected:
     const symbol_exprt &function,
     const exprt::operandst &arguments,
     goto_programt &dest);
+  void do_havoc_slice(
+    const exprt &lhs,
+    const symbol_exprt &function,
+    const exprt::operandst &arguments,
+    goto_programt &dest,
+    const irep_idt &mode);
 
   exprt get_array_argument(const exprt &src);
 };

--- a/src/goto-programs/goto_convert_function_call.cpp
+++ b/src/goto-programs/goto_convert_function_call.cpp
@@ -60,7 +60,7 @@ void goto_convertt::do_function_call(
   else if(new_function.id()==ID_symbol)
   {
     do_function_call_symbol(
-      new_lhs, to_symbol_expr(new_function), new_arguments, dest);
+      new_lhs, to_symbol_expr(new_function), new_arguments, dest, mode);
   }
   else if(new_function.id() == ID_null_object)
   {

--- a/src/goto-programs/goto_instruction_code.cpp
+++ b/src/goto-programs/goto_instruction_code.cpp
@@ -13,7 +13,10 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <util/arith_tools.h>
 #include <util/c_types.h>
+#include <util/namespace.h>
+#include <util/std_expr.h>
 #include <util/string_constant.h>
+#include <util/symbol_table_base.h>
 
 code_inputt::code_inputt(
   std::vector<exprt> arguments,
@@ -69,4 +72,14 @@ void code_outputt::check(const codet &code, const validation_modet vm)
 {
   DATA_CHECK(
     vm, code.operands().size() >= 2, "output must have at least two operands");
+}
+
+inline code_function_callt
+havoc_slice_call(const exprt &p, const exprt &size, const namespacet &ns)
+{
+  irep_idt identifier = CPROVER_PREFIX "havoc_slice";
+  symbol_exprt havoc_slice_function = ns.lookup(identifier).symbol_expr();
+  code_function_callt::argumentst arguments = {p, size};
+  return code_function_callt{std::move(havoc_slice_function),
+                             std::move(arguments)};
 }

--- a/src/goto-programs/goto_instruction_code.h
+++ b/src/goto-programs/goto_instruction_code.h
@@ -9,6 +9,7 @@ Author: Daniel Kroening, dkr@amazon.com
 #ifndef CPROVER_UTIL_GOTO_INSTRUCTION_CODE_H
 #define CPROVER_UTIL_GOTO_INSTRUCTION_CODE_H
 
+#include <util/cprover_prefix.h>
 #include <util/std_code_base.h>
 #include <util/std_expr.h>
 
@@ -536,5 +537,19 @@ inline code_returnt &to_code_return(codet &code)
   code_returnt::check(code);
   return static_cast<code_returnt &>(code);
 }
+
+/// \brief Builds a \ref code_function_callt
+/// to `__CPROVER_havoc_slice(p, size)`.
+///
+/// \param p The pointer argument.
+/// \param size The size argument.
+/// \param ns Namespace where the `__CPROVER_havoc_slice symbol` can be found.
+/// \remarks: It is a PRECONDITION that `__CPROVER_havoc_slice` exists
+///   in the namespace
+///
+/// \return A \ref code_function_callt expression
+///         `nil_exprt() := __CPROVER_havoc_slice(p, size)`.
+inline code_function_callt
+havoc_slice_call(const exprt &p, const exprt &size, const namespacet &ns);
 
 #endif // CPROVER_GOTO_PROGRAMS_GOTO_INSTRUCTION_CODE_H


### PR DESCRIPTION
Resolves #6351.

This PR adds a new builtin function :

```C
void __CPROVER_havoc_slice(void *p, __CPROVER_size_t size);
```
Which lets you update `size` consecutive bytes to nondet values in the object underlying a given pointer `p`. It requires that `__CPROVER_w_ok(p, size)` holds.
It is rewritten at goto level to an `array_replace(p, q)` operation where `q` is declared a nondet array of size `size`.

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [x] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

