### PR TITLE
Refinement of guard based on antecedent of implication statement

### DIFF
--- a/regression/cbmc-primitives/implication_statement_checks_1/test.c
+++ b/regression/cbmc-primitives/implication_statement_checks_1/test.c
@@ -1,0 +1,10 @@
+// clang-format off
+int main(int argc, char **argv)
+{
+    int y;
+
+    __CPROVER_assert(
+        y != 0 ==> 10 / y <= 10,
+        "10 / y is expected to succeed");
+}
+// clang-format on

--- a/regression/cbmc-primitives/implication_statement_checks_1/test.desc
+++ b/regression/cbmc-primitives/implication_statement_checks_1/test.desc
@@ -1,0 +1,16 @@
+CORE
+--div-by-zero-check
+test.c
+^EXIT=0$
+^SIGNAL=0$
+\[main\.assertion\.1\] line \d 10 / y is expected to succeed: SUCCESS
+\[main\.division-by-zero\.1\] line \d division by zero in 10 / y: SUCCESS
+^VERIFICATION SUCCESSFUL$
+--
+\[main\.division-by-zero\.1\] line \d division by zero in 10 / y: FAILURE
+--
+Without the change that drives the refinement of the guard for a `ID_implies`
+statement in `goto-check`, this will fail with a counterexample of `y = 0`.
+With the bug fix, the `--div-by-zero-check` will succeed because the
+antecedent of the conditional is becoming the guard for the consequent,
+guarding any checks performed there.

--- a/src/analyses/goto_check.cpp
+++ b/src/analyses/goto_check.cpp
@@ -1736,7 +1736,7 @@ void goto_checkt::check_rec(const exprt &expr, guardt &guard)
     check_rec_address(to_address_of_expr(expr).object(), guard);
     return;
   }
-  else if(expr.id() == ID_and || expr.id() == ID_or)
+  else if(expr.id() == ID_and || expr.id() == ID_or || expr.id() == ID_implies)
   {
     check_rec_logical_op(expr, guard);
     return;

--- a/src/analyses/goto_check.cpp
+++ b/src/analyses/goto_check.cpp
@@ -1606,6 +1606,8 @@ void goto_checkt::check_rec_address(const exprt &expr, guardt &guard)
 
 void goto_checkt::check_rec_logical_op(const exprt &expr, guardt &guard)
 {
+  PRECONDITION(
+    expr.id() == ID_and || expr.id() == ID_or || expr.id() == ID_implies);
   INVARIANT(
     expr.is_boolean(),
     "'" + expr.id_string() + "' must be Boolean, but got " + expr.pretty());


### PR DESCRIPTION
This PR contains a bug fix isolated from #6399, which allows the `guard` for checks performed
in an implication statement to be refined based on the antecedent part of the statement.

There may be further refactorings/tests added to this PR, so this is a draft for now.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
