### PR TITLE
output "SET RETURN VALUE" when displaying goto programs

### DIFF
--- a/src/goto-programs/goto_program.cpp
+++ b/src/goto-programs/goto_program.cpp
@@ -133,7 +133,7 @@ std::ostream &goto_programt::output_instruction(
     break;
 
   case SET_RETURN_VALUE:
-    out << "RETURN " << format(instruction.return_value()) << '\n';
+    out << "SET RETURN VALUE " << format(instruction.return_value()) << '\n';
     break;
 
   case DECL:


### PR DESCRIPTION
To avoid the impression that the 'set return value' instruction alters
control flow, output "SET RETURN VALUE" instead of "RETURN" when displaying
goto programs.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
