### PR TITLE
Flip passing FUTURE tests to CORE in `regression/cbmc-primitives`

### DIFF
--- a/regression/cbmc-primitives/dynamic-object-02/test-no-cp.desc
+++ b/regression/cbmc-primitives/dynamic-object-02/test-no-cp.desc
@@ -1,4 +1,4 @@
-FUTURE
+CORE
 main.c
 --no-simplify --no-propagation
 ^EXIT=10$
@@ -10,5 +10,6 @@ main.c
 --
 Check that the dynamic object property is nondet for uninitialized pointers. We
 use --no-simplify and --no-propagation to ensure that the case is not solved by
-the constant propagation and thus tests the constraint encoding. Recorded as
-ADA-526.
+the constant propagation and thus tests the constraint encoding. We expect
+that `__CPROVER_DYNAMIC_OBJECT` should be nondet for pointers that are neither
+null nor valid.

--- a/regression/cbmc-primitives/dynamic-object-02/test.desc
+++ b/regression/cbmc-primitives/dynamic-object-02/test.desc
@@ -1,4 +1,4 @@
-FUTURE
+CORE
 main.c
 
 ^EXIT=10$
@@ -9,4 +9,3 @@ main.c
 ^warning: ignoring
 --
 Check that the dynamic object property is nondet for uninitialized pointers.
-Recorded as ADA-526.

--- a/regression/cbmc-primitives/pointer-offset-01/test-no-cp.desc
+++ b/regression/cbmc-primitives/pointer-offset-01/test-no-cp.desc
@@ -1,4 +1,4 @@
-FUTURE
+CORE
 main.c
 --no-simplify --no-propagation
 ^EXIT=10$
@@ -11,4 +11,3 @@ main.c
 Check that both positive and negative offsets can be chosen for uninitialized
 pointers. We use --no-simplify and --no-propagation to ensure that the case is
 not solved by the constant propagation and thus tests the constraint encoding.
-Recorded as ADA-528.

--- a/regression/cbmc-primitives/pointer-offset-01/test.desc
+++ b/regression/cbmc-primitives/pointer-offset-01/test.desc
@@ -1,4 +1,4 @@
-FUTURE
+CORE
 main.c
 
 ^EXIT=10$
@@ -8,5 +8,10 @@ main.c
 --
 ^warning: ignoring
 --
-Check that both positive and negative offsets can be chosen for uninitialized
-pointers. Recorded as ADA-528.
+For uninitialised pointers, CBMC chooses a nondeterministic value (though no memory
+is allocated). Since the offset of pointers is signed, negative offsets should be
+able to be chosen (along with positive ones) non-deterministically.
+`__CPROVER_POINTER_OFFSET` is the CBMC primitive that gets the pointer offset
+from the base address of the object. This test guards this, and especially
+against the case where we could only observe some cases where offsets were only
+positive (in some CI configurations, for instance).


### PR DESCRIPTION
During testing for an unrelated feature I noticed that these tests marked
`FUTURE` are now passing when run under level `CORE` and have thus flipped
them to that level.

Additionally, I have cleaned up some of the comments and removed references
to internal bug tracker references that might be confusing to outside contributors.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
