### PR TITLE
expand value_sett::apply_code_rec

### DIFF
--- a/jbmc/unit/pointer-analysis/custom_value_set_analysis.cpp
+++ b/jbmc/unit/pointer-analysis/custom_value_set_analysis.cpp
@@ -35,26 +35,12 @@ Author: Chris Smowton, chris@smowton.net
 class test_value_sett:public value_sett
 {
 public:
-  static bool assigns_to_ignored_variable(const code_assignt &assign)
+  static bool assigns_to_ignored_variable(const exprt &lhs)
   {
-    if(assign.lhs().id()!=ID_symbol)
+    if(lhs.id() != ID_symbol)
       return false;
-    const irep_idt &id=to_symbol_expr(assign.lhs()).get_identifier();
+    const irep_idt &id = to_symbol_expr(lhs).get_identifier();
     return id2string(id).find("ignored")!=std::string::npos;
-  }
-
-  void apply_code_rec(const codet &code, const namespacet &ns) override
-  {
-    // Ignore assignments to the local "ignored"
-    if(code.get_statement()==ID_assign &&
-       assigns_to_ignored_variable(to_code_assign(code)))
-    {
-      return;
-    }
-    else
-    {
-      value_sett::apply_code_rec(code, ns);
-    }
   }
 
   void assign_rec(
@@ -64,6 +50,12 @@ public:
     const namespacet &ns,
     bool add_to_sets) override
   {
+    // Ignore assignments to the local "ignored"
+    if(assigns_to_ignored_variable(lhs))
+    {
+      return;
+    }
+
     // Disregard writes against variables containing 'no_write':
     if(lhs.id()==ID_symbol)
     {

--- a/src/pointer-analysis/value_set.h
+++ b/src/pointer-analysis/value_set.h
@@ -325,18 +325,17 @@ public:
     const exprt &expr,
     const namespacet &ns);
 
-  /// Transforms this value-set by executing a given statement against it.
-  /// For example, assignment statements will update `valuest` by reading
-  /// the value-set corresponding to their right-hand side and assigning it
-  /// to their LHS.
-  /// \param code: instruction to apply
+  /// Transforms this value-set by executing a given DECL
+  /// instruction against it.
+  /// \param symbol: symbol that is declared
   /// \param ns: global namespace
-  void apply_code(
-    const codet &code,
-    const namespacet &ns)
-  {
-    apply_code_rec(code, ns);
-  }
+  void apply_decl(const symbol_exprt &symbol, const namespacet &ns);
+
+  /// Transforms this value-set by executing a given SET_RETURN_VALUE
+  /// instruction against it.
+  /// \param value: value that is returned
+  /// \param ns: global namespace
+  void apply_set_return_value(const exprt &value, const namespacet &ns);
 
   /// Transforms this value-set by executing executing the assignment
   /// `lhs := rhs` against it.
@@ -488,11 +487,6 @@ protected:
     const std::string &suffix,
     const namespacet &ns,
     bool add_to_sets);
-
-  /// Subclass customisation point for applying code to this domain:
-  virtual void apply_code_rec(
-    const codet &code,
-    const namespacet &ns);
 
  private:
   /// Subclass customisation point to filter or otherwise alter the value-set

--- a/src/pointer-analysis/value_set_domain.h
+++ b/src/pointer-analysis/value_set_domain.h
@@ -72,23 +72,33 @@ void value_set_domain_templatet<VST>::transform(
 {
   switch(from_l->type())
   {
+  case ASSIGN:
+    value_set.assign(
+      from_l->assign_lhs(), from_l->assign_rhs(), ns, false, false);
+    break;
+
+  case DEAD:
+    // ignore for now (could prune value set)
+    break;
+
+  case DECL:
+    value_set.apply_decl(from_l->decl_symbol(), ns);
+    break;
+
+  case END_FUNCTION:
+    value_set.do_end_function(static_analysis_baset::get_return_lhs(to_l), ns);
+    break;
+
   case GOTO:
     // ignore for now
     break;
 
-  case END_FUNCTION:
-  {
-    value_set.do_end_function(static_analysis_baset::get_return_lhs(to_l), ns);
-    break;
-  }
-
-  // Note intentional fall-through here:
   case SET_RETURN_VALUE:
+    value_set.apply_set_return_value(from_l->return_value(), ns);
+    break;
+
   case OTHER:
-  case ASSIGN:
-  case DECL:
-  case DEAD:
-    value_set.apply_code(from_l->get_code(), ns);
+    // ignore
     break;
 
   case ASSUME:

--- a/unit/pointer-analysis/value_set.cpp
+++ b/unit/pointer-analysis/value_set.cpp
@@ -103,8 +103,8 @@ SCENARIO(
     code_assignt assign_x(a1_x, address_of_exprt(a2_symbol.symbol_expr()));
     code_assignt assign_y(a1_y, address_of_exprt(a3_symbol.symbol_expr()));
 
-    value_set.apply_code(assign_x, ns);
-    value_set.apply_code(assign_y, ns);
+    value_set.assign(assign_x.lhs(), assign_x.rhs(), ns, false, false);
+    value_set.assign(assign_y.lhs(), assign_y.rhs(), ns, false, false);
 
     null_pointer_exprt null_A_ptr(to_pointer_type(a1_x.type()));
 


### PR DESCRIPTION
The method `value_sett::apply_code_rec` is expanded at its call site; this
removes the invocation of `get_code()`, which is earmarked for removal.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- X My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
