### PR TITLE
Byte updates using bit fields require extension to full bytes

### DIFF
--- a/regression/cbmc/Promotion3/test.desc
+++ b/regression/cbmc/Promotion3/test.desc
@@ -1,4 +1,4 @@
-CORE broken-smt-backend
+CORE
 main.c
 
 ^EXIT=0$

--- a/regression/cbmc/havoc_slice/test_struct_b_slice.desc
+++ b/regression/cbmc/havoc_slice/test_struct_b_slice.desc
@@ -1,4 +1,4 @@
-CORE broken-smt-backend
+CORE
 test_struct_b_slice.c
 
 ^EXIT=10$

--- a/src/goto-programs/builtin_functions.cpp
+++ b/src/goto-programs/builtin_functions.cpp
@@ -22,6 +22,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/prefix.h>
 #include <util/rational.h>
 #include <util/rational_tools.h>
+#include <util/simplify_expr.h>
 #include <util/symbol_table.h>
 
 #include <langapi/language_util.h>
@@ -699,7 +700,7 @@ void goto_convertt::do_havoc_slice(
   t->source_location_nonconst().set_comment(
     "assertion havoc_slice " + from_expr(ns, identifier, ok_expr));
 
-  const array_typet array_type(char_type(), arguments[1]);
+  const array_typet array_type(char_type(), simplify_expr(arguments[1], ns));
 
   const symbolt &nondet_contents =
     new_tmp_symbol(array_type, "nondet_contents", dest, source_location, mode);


### PR DESCRIPTION
A byte update with an update value that has a size that's not a multiple
of bytes must not overwrite bits that are not in the update value. We
previously generated extractbits expressions that would go out of
bounds, which tripped up the SMT solvers. No longer generating these
out-of-bounds expressions makes the SMT solvers happy on the Promotion3
test, which exercised this feature.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
