### PR TITLE
Adding `#pragma CPROVER enable "named-check"`

### DIFF
--- a/doc/cprover-manual/properties.md
+++ b/doc/cprover-manual/properties.md
@@ -131,22 +131,77 @@ The goto-instrument program supports these checks:
 | `--error-label label`        |  check that given label is unreachable               |
 
 As all of these checks apply across the entire input program, we may wish to
-disable them for selected statements in the program. For example, unsigned
-overflows can be expected and acceptable in certain instructions even when
-elsewhere we do not expect them. As of version 5.12, CBMC supports selectively
-disabling automatically generated properties.  To disable property generation,
-use `#pragma CPROVER check disable "<name_of_check>"`, which remains in effect
-until a `#pragma CPROVER check pop` (to re-enable all properties
-disabled before or since the last `#pragma CPROVER check push`) is provided.
+disable or enable them for selected statements in the program. 
+For example, unsigned overflows can be expected and acceptable in certain 
+instructions even when elsewhere we do not expect them. 
+As of version 5.12, CBMC supports selectively disabling or enabling
+automatically generated properties using pragmas.
+
+
+CPROVER pragmas are handled using a stack:
+- `#pragma CPROVER check push` pushes a new level on the pragma stack
+- `#pragma CPROVER check disable "<name_of_check>"` adds a disable pragma
+  at the top of the stack
+- `#pragma CPROVER check enable "<name_of_check>"` adds a enable pragma
+  at the top of the stack
+- an `enable` or `disable` pragma for a given check present at the top level
+  of the stack shadows other pragmas for the same in lower levels of the stack
+- adding both `enable` and `disable` pragmas for a same check in a same level
+  of the stack creates a PARSING_ERROR.
+- `#pragma CPROVER check pop` pops a level in the stack and restores the state
+  of pragmas at the sub level
+
 For example, for unsigned overflow checks, use
+
 ```
 unsigned foo(unsigned x)
 {
 #pragma CPROVER check push
-#pragma CPROVER check disable "unsigned-overflow"
-  x = x + 1; // immediately follows the pragma, no unsigned overflow check here
+#pragma CPROVER check enable "unsigned-overflow"
+  // unsigned overflow check apply here
+  x = x + 1;
 #pragma CPROVER check pop
-  x = x + 2; // unsigned overflow checks are generated here
+  // unsigned overflow checks do not apply here
+  x = x + 2;
+```
+
+```
+unsigned foo(unsigned x)
+{
+#pragma CPROVER check push
+#pragma CPROVER check enable "unsigned-overflow"
+#pragma CPROVER check enable "signed-overflow"
+  // unsigned and signed overflow check apply here
+  x = x + 1;
+#pragma CPROVER check push
+#pragma CPROVER check disable "unsigned-overflow"
+  // only signed overflow check apply here
+  x = x + 2;
+#pragma CPROVER check pop
+  // unsigned and signed overflow check apply here
+  x = x + 3;
+#pragma CPROVER check pop
+  // unsigned overflow checks do not apply here
+  x = x + 2;
+```
+
+```
+unsigned foo(unsigned x)
+{
+#pragma CPROVER check push
+#pragma CPROVER check enable "unsigned-overflow"
+#pragma CPROVER check enable "signed-overflow"
+  // unsigned and signed overflow check apply here
+  x = x + 1;
+#pragma CPROVER check push
+#pragma CPROVER check disable "unsigned-overflow"
+#pragma CPROVER check enable "unsigned-overflow"
+  // PARSING_ERROR Found enable and disable pragmas for unsigned-overflow-check
+  x = x + 2;
+#pragma CPROVER check pop
+  x = x + 3;
+#pragma CPROVER check pop
+  x = x + 2;
 ```
 
 #### Flag --nan-check limitations

--- a/jbmc/src/janalyzer/janalyzer_parse_options.cpp
+++ b/jbmc/src/janalyzer/janalyzer_parse_options.cpp
@@ -705,7 +705,11 @@ void janalyzer_parse_optionst::process_goto_function(
 
   // add generic checks
   goto_check(
-    function.get_function_id(), function.get_goto_function(), ns, options);
+    function.get_function_id(),
+    function.get_goto_function(),
+    ns,
+    options,
+    ui_message_handler);
 }
 
 bool janalyzer_parse_optionst::can_generate_function_body(const irep_idt &name)

--- a/jbmc/src/jbmc/jbmc_parse_options.cpp
+++ b/jbmc/src/jbmc/jbmc_parse_options.cpp
@@ -812,7 +812,11 @@ void jbmc_parse_optionst::process_goto_function(
 
   // add generic checks
   goto_check(
-    function.get_function_id(), function.get_goto_function(), ns, options);
+    function.get_function_id(),
+    function.get_goto_function(),
+    ns,
+    options,
+    ui_message_handler);
 
   // Replace Java new side effects
   remove_java_new(

--- a/jbmc/src/jdiff/jdiff_parse_options.cpp
+++ b/jbmc/src/jdiff/jdiff_parse_options.cpp
@@ -278,7 +278,7 @@ bool jdiff_parse_optionst::process_goto_program(
 
     // add generic checks
     log.status() << "Generic Property Instrumentation" << messaget::eom;
-    goto_check(options, goto_model);
+    goto_check(options, goto_model, ui_message_handler);
 
     // checks don't know about adjusted float expressions
     adjust_float_expressions(goto_model);

--- a/regression/cbmc/pragma_cprover_enable1/main.c
+++ b/regression/cbmc/pragma_cprover_enable1/main.c
@@ -1,0 +1,15 @@
+int main()
+{
+  int x;
+  int y[1];
+
+#pragma CPROVER check push
+#pragma CPROVER check enable "bounds"
+#pragma CPROVER check enable "signed-overflow"
+  // generate assertions for the following statement
+  x = x + y[1];
+#pragma CPROVER check pop
+  // but do not generate assertions for this one
+  x = y[1];
+  return x;
+}

--- a/regression/cbmc/pragma_cprover_enable1/test.desc
+++ b/regression/cbmc/pragma_cprover_enable1/test.desc
@@ -1,0 +1,12 @@
+CORE
+main.c
+
+^\[main\.array_bounds\.1\] line \d+ array 'y' upper bound.*FAILURE$
+^\[main\.overflow\.1\] line \d+ arithmetic overflow on signed.*FAILURE$
+^\*\* 2 of 2 failed
+^VERIFICATION FAILED$
+^EXIT=10$
+^SIGNAL=0$
+--
+--
+Checks that we can selectively activate checks using pragmas.

--- a/regression/cbmc/pragma_cprover_enable2/main.c
+++ b/regression/cbmc/pragma_cprover_enable2/main.c
@@ -1,0 +1,23 @@
+int foo(int x)
+{
+  return x;
+}
+
+int main()
+{
+  int m, n;
+
+#pragma CPROVER check push
+#pragma CPROVER check enable "signed-overflow"
+  // generate assertions for the following statements
+  int x = m = n + n;
+  ++n;
+  n++;
+  n += 1;
+  foo(x + n);
+#pragma CPROVER check pop
+  // but do not generate assertions for these
+  x = n + n;
+  foo(x + n);
+  return x;
+}

--- a/regression/cbmc/pragma_cprover_enable2/test.desc
+++ b/regression/cbmc/pragma_cprover_enable2/test.desc
@@ -1,0 +1,14 @@
+CORE
+main.c
+
+^\[main\.overflow\.1\] line 13 arithmetic overflow on signed \+ in n \+ n: FAILURE$
+^\[main\.overflow\.2\] line 14 arithmetic overflow on signed \+ in n \+ 1: FAILURE$
+^\[main\.overflow\.3\] line 15 arithmetic overflow on signed \+ in n \+ 1: FAILURE$
+^\[main\.overflow\.4\] line 16 arithmetic overflow on signed \+ in n \+ 1: FAILURE$
+^\[main\.overflow\.5\] line 17 arithmetic overflow on signed \+ in x \+ n: FAILURE$
+^\*\* 5 of 5 failed
+^VERIFICATION FAILED$
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring

--- a/regression/cbmc/pragma_cprover_enable3/main.c
+++ b/regression/cbmc/pragma_cprover_enable3/main.c
@@ -1,0 +1,20 @@
+#include <stdlib.h>
+
+int main()
+{
+  char *p = malloc(sizeof(*p));
+  char *q;
+
+#pragma CPROVER check push
+#pragma CPROVER check enable "pointer-primitive"
+  // generate checks for the following statements and fail
+  if(__CPROVER_same_object(p, q))
+  {
+  }
+#pragma CPROVER check pop
+
+  // but do not generate checks on the following statements
+  if(__CPROVER_same_object(p, q))
+  {
+  }
+}

--- a/regression/cbmc/pragma_cprover_enable3/test.desc
+++ b/regression/cbmc/pragma_cprover_enable3/test.desc
@@ -1,0 +1,18 @@
+CORE
+main.c
+
+^main.c function main$
+^\[main.pointer_primitives.\d+\] line 11 pointer invalid in POINTER_OBJECT\(\(const void \*\)p\): SUCCESS$
+^\[main.pointer_primitives.\d+\] line 11 deallocated dynamic object in POINTER_OBJECT\(\(const void \*\)p\): SUCCESS$
+^\[main.pointer_primitives.\d+\] line 11 dead object in POINTER_OBJECT\(\(const void \*\)p\): SUCCESS$
+^\[main.pointer_primitives.\d+\] line 11 pointer outside object bounds in POINTER_OBJECT\(\(const void \*\)p\): SUCCESS$
+^\[main.pointer_primitives.\d+\] line 11 pointer invalid in POINTER_OBJECT\(\(const void \*\)q\): FAILURE$
+^\[main.pointer_primitives.\d+\] line 11 deallocated dynamic object in POINTER_OBJECT\(\(const void \*\)q\): SUCCESS$
+^\[main.pointer_primitives.\d+\] line 11 dead object in POINTER_OBJECT\(\(const void \*\)q\): SUCCESS$
+^\[main.pointer_primitives.\d+\] line 11 pointer outside object bounds in POINTER_OBJECT\(\(const void \*\)q\): FAILURE$
+^VERIFICATION FAILED$
+^EXIT=10$
+^SIGNAL=0$
+--
+^\[main.pointer_primitives.\d+\] line 17
+--

--- a/regression/cbmc/pragma_cprover_enable_all/main.c
+++ b/regression/cbmc/pragma_cprover_enable_all/main.c
@@ -1,0 +1,92 @@
+#include <stdbool.h>
+#include <stdlib.h>
+
+bool nondet_bool();
+
+typedef enum ABC
+{
+  A = 0,
+  B = 1,
+  C = 2
+} ABC;
+
+int main()
+{
+#pragma CPROVER check push
+#pragma CPROVER check disable "bounds"
+#pragma CPROVER check disable "pointer"
+#pragma CPROVER check disable "div-by-zero"
+#pragma CPROVER check disable "enum-range"
+#pragma CPROVER check disable "signed-overflow"
+#pragma CPROVER check disable "unsigned-overflow"
+#pragma CPROVER check disable "pointer-overflow"
+#pragma CPROVER check disable "float-overflow"
+#pragma CPROVER check disable "conversion"
+#pragma CPROVER check disable "undefined-shift"
+#pragma CPROVER check disable "nan"
+#pragma CPROVER check disable "pointer-primitive"
+  {
+    int N = 10;
+    char *p = malloc(N * sizeof(*p));
+    char *q;
+    char *r;
+    float den;
+    float x;
+    float y;
+    ABC e;
+    bool same;
+    char i;
+    signed int j;
+    same = __CPROVER_same_object(p, q);
+    q = p + 2000000000000;
+    q = r;
+    if(nondet_bool())
+      den = 0.0;
+    else
+      den = 1.0;
+    y = x / den;
+    e = 10;
+    i += 1;
+    j += 1;
+  }
+#pragma CPROVER check push
+#pragma CPROVER check enable "bounds"
+#pragma CPROVER check enable "pointer"
+#pragma CPROVER check enable "div-by-zero"
+#pragma CPROVER check enable "enum-range"
+#pragma CPROVER check enable "signed-overflow"
+#pragma CPROVER check enable "unsigned-overflow"
+#pragma CPROVER check enable "pointer-overflow"
+#pragma CPROVER check enable "float-overflow"
+#pragma CPROVER check enable "conversion"
+#pragma CPROVER check enable "undefined-shift"
+#pragma CPROVER check enable "nan"
+#pragma CPROVER check enable "pointer-primitive"
+  {
+    int N = 10;
+    char *p = malloc(N * sizeof(*p));
+    char *q;
+    char *r;
+    float den;
+    float x;
+    float y;
+    ABC e;
+    bool same;
+    char i;
+    signed int j;
+    same = __CPROVER_same_object(p, q);
+    q = p + 2000000000000;
+    q = r;
+    if(nondet_bool())
+      den = 0.0;
+    else
+      den = 1.0;
+    y = x / den;
+    e = 10;
+    i += 1;
+    j += 1;
+  }
+#pragma CPROVER check pop
+#pragma CPROVER check pop
+  return 0;
+}

--- a/regression/cbmc/pragma_cprover_enable_all/test.desc
+++ b/regression/cbmc/pragma_cprover_enable_all/test.desc
@@ -1,0 +1,27 @@
+CORE broken-smt-backend
+main.c
+--object-bits 8 --bounds-check --pointer-check --pointer-primitive-check --div-by-zero-check --enum-range-check --unsigned-overflow-check --signed-overflow-check --pointer-overflow-check --float-overflow-check --conversion-check --undefined-shift-check --nan-check --pointer-primitive-check
+^\[main\.pointer_primitives\.\d+\] line 77 pointer invalid in POINTER_OBJECT\(\(const void \*\)q\): FAILURE
+^\[main\.pointer_primitives\.\d+\] line 77 pointer outside object bounds in POINTER_OBJECT\(\(const void \*\)q\): FAILURE
+^\[main\.pointer_arithmetic\.\d+\] line 78 pointer arithmetic: pointer outside object bounds in p \+ 2000000000000(l|ll): FAILURE
+^\[main\.NaN\.\d+\] line 84 NaN on / in x / den: FAILURE
+^\[main\.division-by-zero\.\d+\] line 84 division by zero in x / den: FAILURE
+^\[main\.overflow\.\d+\] line 84 arithmetic overflow on floating-point division in x / den: FAILURE
+^\[main\.enum-range-check\.\d+\] line 85 enum range check in \(ABC\)10: FAILURE
+^\[main\.overflow\.\d+\] line 86 arithmetic overflow on signed type conversion in \(char\)\(\(signed int\)i \+ 1\): FAILURE
+^\[main\.overflow\.\d+\] line 87 arithmetic overflow on signed \+ in j \+ 1: FAILURE
+^VERIFICATION FAILED$
+^EXIT=10$
+^SIGNAL=0$
+--
+^\[main\.pointer_primitives\.\d+\] line 40 pointer invalid in POINTER_OBJECT\(const void \*\)q\): FAILURE
+^\[main\.pointer_primitives\.\d+\] line 40 pointer outside object bounds in POINTER_OBJECT\(const void \*\)q\): FAILURE
+^\[main\.pointer_arithmetic\.\d+\] line 41 pointer arithmetic: pointer outside object bounds in p \+ 2000000000000(l|ll): FAILURE
+^\[main\.NaN\.\d+\] line 47 NaN on / in x / den: FAILURE
+^\[main\.division-by-zero\.\d+\] line 47 division by zero in x / den: FAILURE
+^\[main\.overflow\.\d+\] line 47 arithmetic overflow on floating-point division in x / den: FAILURE
+^\[main\.enum-range-check\.\d+\] line 48 enum range check in \(ABC\)10: FAILURE
+^\[main\.overflow\.\d+\] line 49 arithmetic overflow on signed type conversion in \(char\)\(signed int\)i \+ 1\): FAILURE
+^\[main\.overflow\.\d+\] line 50 arithmetic overflow on signed \+ in j \+ 1: FAILURE
+--
+This test uses all possible named-checks to maximize coverage.

--- a/regression/cbmc/pragma_cprover_enable_disable_global_off/main.c
+++ b/regression/cbmc/pragma_cprover_enable_disable_global_off/main.c
@@ -1,0 +1,42 @@
+#include <stdlib.h>
+
+int main()
+{
+  char *p = malloc(sizeof(*p));
+  char *q;
+
+#pragma CPROVER check push
+#pragma CPROVER check enable "pointer-primitive"
+  // must generate checks
+  if(__CPROVER_same_object(p, q))
+  {
+  }
+#pragma CPROVER check push
+#pragma CPROVER check disable "pointer-primitive"
+  // must not generate checks
+  if(__CPROVER_same_object(p, q))
+  {
+  }
+#pragma CPROVER check push
+#pragma CPROVER check enable "pointer-primitive"
+  // must generate checks
+  if(__CPROVER_same_object(p, q))
+  {
+  }
+#pragma CPROVER check pop
+  // must not generate generate checks
+  if(__CPROVER_same_object(p, q))
+  {
+  }
+#pragma CPROVER check pop
+  // must generate generate checks
+  if(__CPROVER_same_object(p, q))
+  {
+  }
+#pragma CPROVER check pop
+  // must not generate generate checks
+  if(__CPROVER_same_object(p, q))
+  {
+  }
+  return 0;
+}

--- a/regression/cbmc/pragma_cprover_enable_disable_global_off/test.desc
+++ b/regression/cbmc/pragma_cprover_enable_disable_global_off/test.desc
@@ -1,0 +1,36 @@
+CORE
+main.c
+
+^main.c function main$
+^\[main.pointer_primitives.\d+\] line 11 pointer invalid in POINTER_OBJECT\(\(const void \*\)p\): SUCCESS$
+^\[main.pointer_primitives.\d+\] line 11 deallocated dynamic object in POINTER_OBJECT\(\(const void \*\)p\): SUCCESS$
+^\[main.pointer_primitives.\d+\] line 11 dead object in POINTER_OBJECT\(\(const void \*\)p\): SUCCESS$
+^\[main.pointer_primitives.\d+\] line 11 pointer outside object bounds in POINTER_OBJECT\(\(const void \*\)p\): SUCCESS$
+^\[main.pointer_primitives.\d+\] line 11 pointer invalid in POINTER_OBJECT\(\(const void \*\)q\): FAILURE$
+^\[main.pointer_primitives.\d+\] line 11 deallocated dynamic object in POINTER_OBJECT\(\(const void \*\)q\): SUCCESS$
+^\[main.pointer_primitives.\d+\] line 11 dead object in POINTER_OBJECT\(\(const void \*\)q\): SUCCESS$
+^\[main.pointer_primitives.\d+\] line 11 pointer outside object bounds in POINTER_OBJECT\(\(const void \*\)q\): FAILURE$
+^\[main.pointer_primitives.\d+\] line 23 pointer invalid in POINTER_OBJECT\(\(const void \*\)p\): SUCCESS$
+^\[main.pointer_primitives.\d+\] line 23 deallocated dynamic object in POINTER_OBJECT\(\(const void \*\)p\): SUCCESS$
+^\[main.pointer_primitives.\d+\] line 23 dead object in POINTER_OBJECT\(\(const void \*\)p\): SUCCESS$
+^\[main.pointer_primitives.\d+\] line 23 pointer outside object bounds in POINTER_OBJECT\(\(const void \*\)p\): SUCCESS$
+^\[main.pointer_primitives.\d+\] line 23 pointer invalid in POINTER_OBJECT\(\(const void \*\)q\): FAILURE$
+^\[main.pointer_primitives.\d+\] line 23 deallocated dynamic object in POINTER_OBJECT\(\(const void \*\)q\): SUCCESS$
+^\[main.pointer_primitives.\d+\] line 23 dead object in POINTER_OBJECT\(\(const void \*\)q\): SUCCESS$
+^\[main.pointer_primitives.\d+\] line 23 pointer outside object bounds in POINTER_OBJECT\(\(const void \*\)q\): FAILURE$
+^\[main.pointer_primitives.\d+\] line 33 pointer invalid in POINTER_OBJECT\(\(const void \*\)p\): SUCCESS$
+^\[main.pointer_primitives.\d+\] line 33 deallocated dynamic object in POINTER_OBJECT\(\(const void \*\)p\): SUCCESS$
+^\[main.pointer_primitives.\d+\] line 33 dead object in POINTER_OBJECT\(\(const void \*\)p\): SUCCESS$
+^\[main.pointer_primitives.\d+\] line 33 pointer outside object bounds in POINTER_OBJECT\(\(const void \*\)p\): SUCCESS$
+^\[main.pointer_primitives.\d+\] line 33 pointer invalid in POINTER_OBJECT\(\(const void \*\)q\): FAILURE$
+^\[main.pointer_primitives.\d+\] line 33 deallocated dynamic object in POINTER_OBJECT\(\(const void \*\)q\): SUCCESS$
+^\[main.pointer_primitives.\d+\] line 33 dead object in POINTER_OBJECT\(\(const void \*\)q\): SUCCESS$
+^\[main.pointer_primitives.\d+\] line 33 pointer outside object bounds in POINTER_OBJECT\(\(const void \*\)q\): FAILURE$
+^VERIFICATION FAILED$
+^EXIT=10$
+^SIGNAL=0$
+--
+^\[main.pointer_primitives.\d+\] line 17
+^\[main.pointer_primitives.\d+\] line 28
+^\[main.pointer_primitives.\d+\] line 38
+--

--- a/regression/cbmc/pragma_cprover_enable_disable_global_on/main.c
+++ b/regression/cbmc/pragma_cprover_enable_disable_global_on/main.c
@@ -1,0 +1,42 @@
+#include <stdlib.h>
+
+int main()
+{
+  char *p = malloc(sizeof(*p));
+  char *q;
+
+#pragma CPROVER check push
+#pragma CPROVER check enable "pointer-primitive"
+  // must generate checks
+  if(__CPROVER_same_object(p, q))
+  {
+  }
+#pragma CPROVER check push
+#pragma CPROVER check disable "pointer-primitive"
+  // must not generate checks
+  if(__CPROVER_same_object(p, q))
+  {
+  }
+#pragma CPROVER check push
+#pragma CPROVER check enable "pointer-primitive"
+  // must generate checks
+  if(__CPROVER_same_object(p, q))
+  {
+  }
+#pragma CPROVER check pop
+  // must not generate generate checks
+  if(__CPROVER_same_object(p, q))
+  {
+  }
+#pragma CPROVER check pop
+  // must generate generate checks
+  if(__CPROVER_same_object(p, q))
+  {
+  }
+#pragma CPROVER check pop
+  // must generate generate checks
+  if(__CPROVER_same_object(p, q))
+  {
+  }
+  return 0;
+}

--- a/regression/cbmc/pragma_cprover_enable_disable_global_on/test.desc
+++ b/regression/cbmc/pragma_cprover_enable_disable_global_on/test.desc
@@ -1,0 +1,43 @@
+CORE
+main.c
+--pointer-primitive-check
+^main.c function main$
+^\[main.pointer_primitives.\d+\] line 11 pointer invalid in POINTER_OBJECT\(\(const void \*\)p\): SUCCESS$
+^\[main.pointer_primitives.\d+\] line 11 deallocated dynamic object in POINTER_OBJECT\(\(const void \*\)p\): SUCCESS$
+^\[main.pointer_primitives.\d+\] line 11 dead object in POINTER_OBJECT\(\(const void \*\)p\): SUCCESS$
+^\[main.pointer_primitives.\d+\] line 11 pointer outside object bounds in POINTER_OBJECT\(\(const void \*\)p\): SUCCESS$
+^\[main.pointer_primitives.\d+\] line 11 pointer invalid in POINTER_OBJECT\(\(const void \*\)q\): FAILURE$
+^\[main.pointer_primitives.\d+\] line 11 deallocated dynamic object in POINTER_OBJECT\(\(const void \*\)q\): SUCCESS$
+^\[main.pointer_primitives.\d+\] line 11 dead object in POINTER_OBJECT\(\(const void \*\)q\): SUCCESS$
+^\[main.pointer_primitives.\d+\] line 11 pointer outside object bounds in POINTER_OBJECT\(\(const void \*\)q\): FAILURE$
+^\[main.pointer_primitives.\d+\] line 23 pointer invalid in POINTER_OBJECT\(\(const void \*\)p\): SUCCESS$
+^\[main.pointer_primitives.\d+\] line 23 deallocated dynamic object in POINTER_OBJECT\(\(const void \*\)p\): SUCCESS$
+^\[main.pointer_primitives.\d+\] line 23 dead object in POINTER_OBJECT\(\(const void \*\)p\): SUCCESS$
+^\[main.pointer_primitives.\d+\] line 23 pointer outside object bounds in POINTER_OBJECT\(\(const void \*\)p\): SUCCESS$
+^\[main.pointer_primitives.\d+\] line 23 pointer invalid in POINTER_OBJECT\(\(const void \*\)q\): FAILURE$
+^\[main.pointer_primitives.\d+\] line 23 deallocated dynamic object in POINTER_OBJECT\(\(const void \*\)q\): SUCCESS$
+^\[main.pointer_primitives.\d+\] line 23 dead object in POINTER_OBJECT\(\(const void \*\)q\): SUCCESS$
+^\[main.pointer_primitives.\d+\] line 23 pointer outside object bounds in POINTER_OBJECT\(\(const void \*\)q\): FAILURE$
+^\[main.pointer_primitives.\d+\] line 33 pointer invalid in POINTER_OBJECT\(\(const void \*\)p\): SUCCESS$
+^\[main.pointer_primitives.\d+\] line 33 deallocated dynamic object in POINTER_OBJECT\(\(const void \*\)p\): SUCCESS$
+^\[main.pointer_primitives.\d+\] line 33 dead object in POINTER_OBJECT\(\(const void \*\)p\): SUCCESS$
+^\[main.pointer_primitives.\d+\] line 33 pointer outside object bounds in POINTER_OBJECT\(\(const void \*\)p\): SUCCESS$
+^\[main.pointer_primitives.\d+\] line 33 pointer invalid in POINTER_OBJECT\(\(const void \*\)q\): FAILURE$
+^\[main.pointer_primitives.\d+\] line 33 deallocated dynamic object in POINTER_OBJECT\(\(const void \*\)q\): SUCCESS$
+^\[main.pointer_primitives.\d+\] line 33 dead object in POINTER_OBJECT\(\(const void \*\)q\): SUCCESS$
+^\[main.pointer_primitives.\d+\] line 33 pointer outside object bounds in POINTER_OBJECT\(\(const void \*\)q\): FAILURE$
+^\[main.pointer_primitives.\d+\] line 38 pointer invalid in POINTER_OBJECT\(\(const void \*\)p\): SUCCESS$
+^\[main.pointer_primitives.\d+\] line 38 deallocated dynamic object in POINTER_OBJECT\(\(const void \*\)p\): SUCCESS$
+^\[main.pointer_primitives.\d+\] line 38 dead object in POINTER_OBJECT\(\(const void \*\)p\): SUCCESS$
+^\[main.pointer_primitives.\d+\] line 38 pointer outside object bounds in POINTER_OBJECT\(\(const void \*\)p\): SUCCESS$
+^\[main.pointer_primitives.\d+\] line 38 pointer invalid in POINTER_OBJECT\(\(const void \*\)q\): FAILURE$
+^\[main.pointer_primitives.\d+\] line 38 deallocated dynamic object in POINTER_OBJECT\(\(const void \*\)q\): SUCCESS$
+^\[main.pointer_primitives.\d+\] line 38 dead object in POINTER_OBJECT\(\(const void \*\)q\): SUCCESS$
+^\[main.pointer_primitives.\d+\] line 38 pointer outside object bounds in POINTER_OBJECT\(\(const void \*\)q\): FAILURE$
+^VERIFICATION FAILED$
+^EXIT=10$
+^SIGNAL=0$
+--
+^\[main.pointer_primitives.\d+\] line 17
+^\[main.pointer_primitives.\d+\] line 28
+--

--- a/regression/cbmc/pragma_cprover_enable_disable_multiple/main.c
+++ b/regression/cbmc/pragma_cprover_enable_disable_multiple/main.c
@@ -1,0 +1,19 @@
+#include <stdlib.h>
+
+int main()
+{
+  char *p = malloc(sizeof(*p));
+  char *q;
+
+#pragma CPROVER check push
+#pragma CPROVER check enable "pointer-overflow"
+// should not print an error message
+#pragma CPROVER check enable "pointer-overflow"
+#pragma CPROVER check push
+#pragma CPROVER check disable "pointer-primitive"
+// PARSE_ERROR
+#pragma CPROVER check enable "pointer-primitive"
+#pragma CPROVER check pop
+#pragma CPROVER check pop
+  return 0;
+}

--- a/regression/cbmc/pragma_cprover_enable_disable_multiple/test.desc
+++ b/regression/cbmc/pragma_cprover_enable_disable_multiple/test.desc
@@ -1,0 +1,11 @@
+CORE
+main.c
+
+^file main.c line \d+ function main: Found enable and disable pragmas for pointer-primitive-check
+^file main.c line \d+ function main: syntax error before ' check enable "pointer-primitive"'
+^PARSING ERROR$
+^EXIT=6$
+^SIGNAL=0$
+--
+^file main.c line \d+ function main: Found enable and disable pragmas for pointer-overflow-check
+--

--- a/src/analyses/goto_check.cpp
+++ b/src/analyses/goto_check.cpp
@@ -12,6 +12,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "goto_check.h"
 
 #include <algorithm>
+#include <functional>
 
 #include <util/arith_tools.h>
 #include <util/array_name.h>

--- a/src/analyses/goto_check.cpp
+++ b/src/analyses/goto_check.cpp
@@ -25,6 +25,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/ieee_float.h>
 #include <util/invariant.h>
 #include <util/make_unique.h>
+#include <util/message.h>
 #include <util/options.h>
 #include <util/pointer_expr.h>
 #include <util/pointer_offset_size.h>
@@ -48,9 +49,9 @@ class goto_checkt
 public:
   goto_checkt(
     const namespacet &_ns,
-    const optionst &_options):
-    ns(_ns),
-    local_bitvector_analysis(nullptr)
+    const optionst &_options,
+    message_handlert &_message_handler)
+    : ns(_ns), local_bitvector_analysis(nullptr), log(_message_handler)
   {
     no_enum_check = false;
     enable_bounds_check=_options.get_bool_option("bounds-check");
@@ -99,6 +100,8 @@ protected:
   std::unique_ptr<local_bitvector_analysist> local_bitvector_analysis;
   goto_programt::const_targett current_target;
   guard_managert guard_manager;
+  messaget log;
+
   bool no_enum_check;
 
   /// Check an address-of expression:
@@ -2378,18 +2381,20 @@ void goto_check(
   const irep_idt &function_identifier,
   goto_functionst::goto_functiont &goto_function,
   const namespacet &ns,
-  const optionst &options)
+  const optionst &options,
+  message_handlert &message_handler)
 {
-  goto_checkt goto_check(ns, options);
+  goto_checkt goto_check(ns, options, message_handler);
   goto_check.goto_check(function_identifier, goto_function);
 }
 
 void goto_check(
   const namespacet &ns,
   const optionst &options,
-  goto_functionst &goto_functions)
+  goto_functionst &goto_functions,
+  message_handlert &message_handler)
 {
-  goto_checkt goto_check(ns, options);
+  goto_checkt goto_check(ns, options, message_handler);
 
   goto_check.collect_allocations(goto_functions);
 
@@ -2401,8 +2406,9 @@ void goto_check(
 
 void goto_check(
   const optionst &options,
-  goto_modelt &goto_model)
+  goto_modelt &goto_model,
+  message_handlert &message_handler)
 {
   const namespacet ns(goto_model.symbol_table);
-  goto_check(ns, options, goto_model.goto_functions);
+  goto_check(ns, options, goto_model.goto_functions, message_handler);
 }

--- a/src/analyses/goto_check.cpp
+++ b/src/analyses/goto_check.cpp
@@ -12,7 +12,6 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "goto_check.h"
 
 #include <algorithm>
-#include <functional>
 
 #include <util/arith_tools.h>
 #include <util/array_name.h>

--- a/src/analyses/goto_check.cpp
+++ b/src/analyses/goto_check.cpp
@@ -1916,36 +1916,62 @@ void goto_checkt::goto_check(
     current_target = it;
     goto_programt::instructiont &i=*it;
 
-    flag_resett flag_resetter;
+    flag_resett resetter(i);
     const auto &pragmas = i.source_location().get_pragmas();
     for(const auto &d : pragmas)
     {
       if(d.first == "disable:bounds-check")
-        flag_resetter.set_flag(enable_bounds_check, false);
+        resetter.set_flag(enable_bounds_check, false, d.first);
       else if(d.first == "disable:pointer-check")
-        flag_resetter.set_flag(enable_pointer_check, false);
+        resetter.set_flag(enable_pointer_check, false, d.first);
       else if(d.first == "disable:memory-leak-check")
-        flag_resetter.set_flag(enable_memory_leak_check, false);
+        resetter.set_flag(enable_memory_leak_check, false, d.first);
       else if(d.first == "disable:div-by-zero-check")
-        flag_resetter.set_flag(enable_div_by_zero_check, false);
+        resetter.set_flag(enable_div_by_zero_check, false, d.first);
       else if(d.first == "disable:enum-range-check")
-        flag_resetter.set_flag(enable_enum_range_check, false);
+        resetter.set_flag(enable_enum_range_check, false, d.first);
       else if(d.first == "disable:signed-overflow-check")
-        flag_resetter.set_flag(enable_signed_overflow_check, false);
+        resetter.set_flag(enable_signed_overflow_check, false, d.first);
       else if(d.first == "disable:unsigned-overflow-check")
-        flag_resetter.set_flag(enable_unsigned_overflow_check, false);
+        resetter.set_flag(enable_unsigned_overflow_check, false, d.first);
       else if(d.first == "disable:pointer-overflow-check")
-        flag_resetter.set_flag(enable_pointer_overflow_check, false);
+        resetter.set_flag(enable_pointer_overflow_check, false, d.first);
       else if(d.first == "disable:float-overflow-check")
-        flag_resetter.set_flag(enable_float_overflow_check, false);
+        resetter.set_flag(enable_float_overflow_check, false, d.first);
       else if(d.first == "disable:conversion-check")
-        flag_resetter.set_flag(enable_conversion_check, false);
+        resetter.set_flag(enable_conversion_check, false, d.first);
       else if(d.first == "disable:undefined-shift-check")
-        flag_resetter.set_flag(enable_undefined_shift_check, false);
+        resetter.set_flag(enable_undefined_shift_check, false, d.first);
       else if(d.first == "disable:nan-check")
-        flag_resetter.set_flag(enable_nan_check, false);
+        resetter.set_flag(enable_nan_check, false, d.first);
       else if(d.first == "disable:pointer-primitive-check")
-        flag_resetter.set_flag(enable_pointer_primitive_check, false);
+        resetter.set_flag(enable_pointer_primitive_check, false, d.first);
+      else if(d.first == "enable:bounds-check")
+        resetter.set_flag(enable_bounds_check, true, d.first);
+      else if(d.first == "enable:pointer-check")
+        resetter.set_flag(enable_pointer_check, true, d.first);
+      else if(d.first == "enable:memory_leak-check")
+        resetter.set_flag(enable_memory_leak_check, true, d.first);
+      else if(d.first == "enable:div-by-zero-check")
+        resetter.set_flag(enable_div_by_zero_check, true, d.first);
+      else if(d.first == "enable:enum-range-check")
+        resetter.set_flag(enable_enum_range_check, true, d.first);
+      else if(d.first == "enable:signed-overflow-check")
+        resetter.set_flag(enable_signed_overflow_check, true, d.first);
+      else if(d.first == "enable:unsigned-overflow-check")
+        resetter.set_flag(enable_unsigned_overflow_check, true, d.first);
+      else if(d.first == "enable:pointer-overflow-check")
+        resetter.set_flag(enable_pointer_overflow_check, true, d.first);
+      else if(d.first == "enable:float-overflow-check")
+        resetter.set_flag(enable_float_overflow_check, true, d.first);
+      else if(d.first == "enable:conversion-check")
+        resetter.set_flag(enable_conversion_check, true, d.first);
+      else if(d.first == "enable:undefined-shift-check")
+        resetter.set_flag(enable_undefined_shift_check, true, d.first);
+      else if(d.first == "enable:nan-check")
+        resetter.set_flag(enable_nan_check, true, d.first);
+      else if(d.first == "enable:pointer-primitive-check")
+        resetter.set_flag(enable_pointer_primitive_check, true, d.first);
     }
 
     new_code.clear();
@@ -2012,8 +2038,8 @@ void goto_checkt::goto_check(
       // Reset the no_enum_check with the flag reset for exception
       // safety
       {
-        flag_resett no_enum_check_flag_resetter;
-        no_enum_check_flag_resetter.set_flag(no_enum_check, true);
+        flag_resett resetter(i);
+        resetter.set_flag(no_enum_check, true, "no_enum_check");
         check(assign_lhs);
       }
 

--- a/src/analyses/goto_check.cpp
+++ b/src/analyses/goto_check.cpp
@@ -292,12 +292,6 @@ protected:
 void goto_checkt::collect_allocations(
   const goto_functionst &goto_functions)
 {
-  if(
-    !enable_pointer_check && !enable_bounds_check &&
-    !enable_pointer_overflow_check)
-  {
-    return;
-  }
 
   for(const auto &gf_entry : goto_functions.function_map)
   {

--- a/src/analyses/goto_check.h
+++ b/src/analyses/goto_check.h
@@ -17,21 +17,25 @@ Author: Daniel Kroening, kroening@kroening.com
 class goto_modelt;
 class namespacet;
 class optionst;
+class message_handlert;
 
 void goto_check(
   const namespacet &ns,
   const optionst &options,
-  goto_functionst &goto_functions);
+  goto_functionst &goto_functions,
+  message_handlert &message_handler);
 
 void goto_check(
   const irep_idt &function_identifier,
   goto_functionst::goto_functiont &goto_function,
   const namespacet &ns,
-  const optionst &options);
+  const optionst &options,
+  message_handlert &message_handler);
 
 void goto_check(
   const optionst &options,
-  goto_modelt &goto_model);
+  goto_modelt &goto_model,
+  message_handlert &message_handler);
 
 #define OPT_GOTO_CHECK                                                         \
   "(bounds-check)(pointer-check)(memory-leak-check)"                           \

--- a/src/ansi-c/ansi_c_parser.h
+++ b/src/ansi-c/ansi_c_parser.h
@@ -10,7 +10,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #ifndef CPROVER_ANSI_C_ANSI_C_PARSER_H
 #define CPROVER_ANSI_C_ANSI_C_PARSER_H
 
-#include <set>
+#include <map>
 
 #include <util/parser.h>
 #include <util/config.h>
@@ -53,7 +53,7 @@ public:
     parenthesis_counter=0;
     string_literal.clear();
     pragma_pack.clear();
-    pragma_cprover.clear();
+    pragma_cprover_stack.clear();
 
     // set up global scope
     scopes.clear();
@@ -66,7 +66,6 @@ public:
   unsigned parenthesis_counter;
   std::string string_literal;
   std::list<exprt> pragma_pack;
-  std::list<std::set<irep_idt>> pragma_cprover;
 
   typedef configt::ansi_ct::flavourt modet;
   modet mode;
@@ -143,15 +142,28 @@ public:
     return identifier;
   }
 
-  void set_pragma_cprover()
-  {
-    source_location.remove(ID_pragma);
-    for(const auto &pragma_set : pragma_cprover)
-    {
-      for(const auto &pragma : pragma_set)
-        source_location.add_pragma(pragma);
-    }
-  }
+  /// \brief True iff the CPROVER pragma stack is empty
+  bool pragma_cprover_empty();
+
+  /// \brief Pushes an empty level in the CPROVER pragma stack
+  void pragma_cprover_push();
+
+  /// \brief Pops a level in the CPROVER pragma stack
+  void pragma_cprover_pop();
+
+  /// \brief Adds a check to the CPROVER pragma stack
+  void pragma_cprover_add_check(const irep_idt &name, bool enabled);
+
+  /// Returns true iff the same check with  polarity
+  /// is already present at top of the stack
+  bool pragma_cprover_clash(const irep_idt &name, bool enabled);
+
+  /// \brief Tags \ref source_location with
+  /// the current CPROVER pragma stack
+  void set_pragma_cprover();
+
+private:
+  std::list<std::map<const irep_idt, bool>> pragma_cprover_stack;
 };
 
 extern ansi_c_parsert ansi_c_parser;

--- a/src/ansi-c/scanner.l
+++ b/src/ansi-c/scanner.l
@@ -235,9 +235,10 @@ CPROVER_PREFIX  "__CPROVER_"
 arith_check     ("conversion"|"undefined-shift"|"nan"|"div-by-zero")
 enum_check      "enum-range"
 pointer_primitive "pointer-primitive"
-memory_check    ("bounds"|"pointer"|"memory_leak")
+memory_check    ("bounds"|"pointer"|"memory-leak")
 overflow_check  ("signed"|"unsigned"|"pointer"|"float")"-overflow"
 named_check     ["]({arith_check}|{enum_check}|{memory_check}|{overflow_check}|{pointer_primitive})["]
+enable_or_disable ("enable"|"disable")
 
 %x GRAMMAR
 %x COMMENT1
@@ -402,26 +403,31 @@ void ansi_c_scanner_init()
 
                 /* CProver specific pragmas: hint to disable named checks */
 <CPROVER_PRAGMA>{ws}"check"{ws}"push" {
-                  PARSER.pragma_cprover.push_back({});
+                  PARSER.pragma_cprover_push();
                 }
 <CPROVER_PRAGMA>{ws}"check"{ws}"pop" {
-                  if(!PARSER.pragma_cprover.empty())
+                  if(!PARSER.pragma_cprover_empty())
                   {
-                    PARSER.pragma_cprover.pop_back();
+                    PARSER.pragma_cprover_pop();
                     PARSER.set_pragma_cprover();
                   }
                 }
-<CPROVER_PRAGMA>{ws}"check"{ws}"disable"{ws}{named_check} {
+<CPROVER_PRAGMA>{ws}"check"{ws}{enable_or_disable}{ws}{named_check} {
                   std::string tmp(yytext);
+                  bool enable = tmp.find("enable")!=std::string::npos;
                   std::string::size_type p = tmp.find('"') + 1;
-                  std::string value =
-                    std::string("disable:") +
+                  std::string check_name =
                     std::string(tmp, p, tmp.size() - p - 1) +
                     std::string("-check");
-                  if(PARSER.pragma_cprover.empty())
-                    PARSER.pragma_cprover.push_back({value});
-                  else
-                    PARSER.pragma_cprover.back().insert(value);
+                  bool clash = PARSER.pragma_cprover_clash(check_name, enable);
+                  if(clash)
+                  {
+                    yyansi_cerror(
+                      "Found enable and disable pragmas for " +
+                      id2string(check_name));
+                    return TOK_SCANNER_ERROR;
+                  }
+                  PARSER.pragma_cprover_add_check(check_name, enable);
                   PARSER.set_pragma_cprover();
                 }
 

--- a/src/goto-instrument/goto_instrument_parse_options.cpp
+++ b/src/goto-instrument/goto_instrument_parse_options.cpp
@@ -1332,7 +1332,7 @@ void goto_instrument_parse_optionst::instrument_goto_program()
   }
 
   // add generic checks, if needed
-  goto_check(options, goto_model);
+  goto_check(options, goto_model, ui_message_handler);
 
   // check for uninitalized local variables
   if(cmdline.isset("uninitialized-check"))

--- a/src/goto-programs/process_goto_program.cpp
+++ b/src/goto-programs/process_goto_program.cpp
@@ -66,7 +66,7 @@ bool process_goto_program(
 
   // add generic checks
   log.status() << "Generic Property Instrumentation" << messaget::eom;
-  goto_check(options, goto_model);
+  goto_check(options, goto_model, log.get_message_handler());
 
   // checks don't know about adjusted float expressions
   adjust_float_expressions(goto_model);


### PR DESCRIPTION
This PR adds the possibility to selectively activate checks :
- on blocks of C code using `#pragma CPROVER enable "named-check"`
- to individual GOTO instructions and expressions using `source_location.add_pragma("enable:named-check")`

It is possible to enable/disable a check, to push a level on the stack and override the check status using another pragma enable/disable pragma.
Attempts to enable and disable a same check at the same stack level are detected and cause a PARSING_ERROR in the C front end and a INVARIANT violation in `goto_check`.

Modifications:
- the collection of allocations on the whole goto program using `goto_checkt::collect_allocation` is now always on
- a `messaget log` attribute is added to `goto_checkt` to be able to log warnings in case a same check is enabled/disabled more than once on a given GOTO instruction
- the `flag_resett` class is extended to detect multiple 'set_flag' operations on a same flag
- the ansi-c lexer/parser is modified to accept `#pragma CPROVER enable "named check"` and flag shadowing
- tests are added in `regression/cbmc/pragma_cprover_enable*` to test the feature

This feature is needed as part of the function and loop contracts verification, to be able to selectively activate checks on  instructions used for assigns-clause checking, in order to guarantee the soundness of the analysis, even if these checks are not globally activated in the current or ulterior `goto-instrument` or `cbmc` passes

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [x] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.
