### PR TITLE
Update documentation on quantifiers

### DIFF
--- a/doc/cprover-manual/cbmc-assertions.md
+++ b/doc/cprover-manual/cbmc-assertions.md
@@ -87,7 +87,7 @@ postconditions to create a function contract, which can be used for
 modular verification.
 
 
-Future CPROVER releases will support explicit quantifiers with a syntax
+CPROVER also supports explicit quantifiers with a syntax
 that resembles Spec\#:
 
 ```C
@@ -95,3 +95,11 @@ __CPROVER_forall { *type identifier* ; *expression* }
 __CPROVER_exists { *type identifier* ; *expression* }
 ```
 
+For example, the following can be used to check equality of
+two arrays `array` and `array2` to a bound `n`.
+```C
+assert(__CPROVER_forall { int i ;
+            (0 <= i && i < n) ==> arrary1[i] == array2[i]
+                     } );
+```
+Usage of `__CPROVER_exists` is similar.


### PR DESCRIPTION
Quantifiers are now broadly supported and work, so documentation
should reflect this.

Fixes #6449

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
