### PR TITLE
Disable redundant automatic checks on assigns clause checking instrumentation [depends-on: #6450]

### DIFF
--- a/jbmc/src/janalyzer/janalyzer_parse_options.cpp
+++ b/jbmc/src/janalyzer/janalyzer_parse_options.cpp
@@ -705,7 +705,11 @@ void janalyzer_parse_optionst::process_goto_function(
 
   // add generic checks
   goto_check(
-    function.get_function_id(), function.get_goto_function(), ns, options);
+    function.get_function_id(),
+    function.get_goto_function(),
+    ns,
+    options,
+    log.get_message_handler());
 }
 
 bool janalyzer_parse_optionst::can_generate_function_body(const irep_idt &name)

--- a/jbmc/src/jbmc/jbmc_parse_options.cpp
+++ b/jbmc/src/jbmc/jbmc_parse_options.cpp
@@ -812,7 +812,11 @@ void jbmc_parse_optionst::process_goto_function(
 
   // add generic checks
   goto_check(
-    function.get_function_id(), function.get_goto_function(), ns, options);
+    function.get_function_id(),
+    function.get_goto_function(),
+    ns,
+    options,
+    log.get_message_handler());
 
   // Replace Java new side effects
   remove_java_new(

--- a/jbmc/src/jdiff/jdiff_parse_options.cpp
+++ b/jbmc/src/jdiff/jdiff_parse_options.cpp
@@ -278,7 +278,7 @@ bool jdiff_parse_optionst::process_goto_program(
 
     // add generic checks
     log.status() << "Generic Property Instrumentation" << messaget::eom;
-    goto_check(options, goto_model);
+    goto_check(options, goto_model, log.get_message_handler());
 
     // checks don't know about adjusted float expressions
     adjust_float_expressions(goto_model);

--- a/regression/cbmc/pragma_cprover_enable1/main.c
+++ b/regression/cbmc/pragma_cprover_enable1/main.c
@@ -1,0 +1,16 @@
+int main()
+{
+  int x;
+  int y[1];
+
+#pragma CPROVER check push
+#pragma CPROVER check enable "bounds"
+#pragma CPROVER check enable "signed-overflow"
+  // generate assertions for the following statement
+  x = x + y[1];
+  // pop all annotations
+#pragma CPROVER check pop
+  // but do not generate assertions for this one
+  x = y[1];
+  return x;
+}

--- a/regression/cbmc/pragma_cprover_enable1/test.desc
+++ b/regression/cbmc/pragma_cprover_enable1/test.desc
@@ -1,0 +1,12 @@
+CORE
+main.c
+
+^\[main\.array_bounds\.1\] line \d+ array 'y' upper bound.*FAILURE$
+^\[main\.overflow\.1\] line \d+ arithmetic overflow on signed.*FAILURE$
+^\*\* 2 of 2 failed
+^VERIFICATION FAILED$
+^EXIT=10$
+^SIGNAL=0$
+--
+--
+Checks that we can selectively activate checks using pragmas.

--- a/regression/cbmc/pragma_cprover_enable2/main.c
+++ b/regression/cbmc/pragma_cprover_enable2/main.c
@@ -1,0 +1,24 @@
+int foo(int x)
+{
+  return x;
+}
+
+int main()
+{
+  int m, n;
+
+#pragma CPROVER check push
+#pragma CPROVER check enable "signed-overflow"
+  // generate assertions for the following statements
+  int x = m = n + n;
+  ++n;
+  n++;
+  n += 1;
+  foo(x + n);
+  // pop all annotations
+#pragma CPROVER check pop
+  // but do not generate assertions for these
+  x = n + n;
+  foo(x + n);
+  return x;
+}

--- a/regression/cbmc/pragma_cprover_enable2/test.desc
+++ b/regression/cbmc/pragma_cprover_enable2/test.desc
@@ -1,0 +1,14 @@
+CORE
+main.c
+
+^\[main\.overflow\.1\] line 13 arithmetic overflow on signed \+ in n \+ n: FAILURE$
+^\[main\.overflow\.2\] line 14 arithmetic overflow on signed \+ in n \+ 1: FAILURE$
+^\[main\.overflow\.3\] line 15 arithmetic overflow on signed \+ in n \+ 1: FAILURE$
+^\[main\.overflow\.4\] line 16 arithmetic overflow on signed \+ in n \+ 1: FAILURE$
+^\[main\.overflow\.5\] line 17 arithmetic overflow on signed \+ in x \+ n: FAILURE$
+^\*\* 5 of 5 failed
+^VERIFICATION FAILED$
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring

--- a/regression/cbmc/pragma_cprover_enable3/main.c
+++ b/regression/cbmc/pragma_cprover_enable3/main.c
@@ -1,0 +1,20 @@
+#include <stdlib.h>
+
+int main()
+{
+  char *p = malloc(sizeof(*p));
+  char *q;
+
+#pragma CPROVER check push
+#pragma CPROVER check enable "pointer-primitive"
+  // generate checks for the following statements and fail
+  if(__CPROVER_same_object(p, q))
+  {
+  }
+#pragma CPROVER check pop
+
+  // but do not generate checks on the following statements
+  if(__CPROVER_same_object(p, q))
+  {
+  }
+}

--- a/regression/cbmc/pragma_cprover_enable3/test.desc
+++ b/regression/cbmc/pragma_cprover_enable3/test.desc
@@ -1,0 +1,18 @@
+CORE
+main.c
+
+^main.c function main$
+^\[main.pointer_primitives.\d+\] line 11 pointer invalid in POINTER_OBJECT\(\(const void \*\)p\): SUCCESS$
+^\[main.pointer_primitives.\d+\] line 11 deallocated dynamic object in POINTER_OBJECT\(\(const void \*\)p\): SUCCESS$
+^\[main.pointer_primitives.\d+\] line 11 dead object in POINTER_OBJECT\(\(const void \*\)p\): SUCCESS$
+^\[main.pointer_primitives.\d+\] line 11 pointer outside object bounds in POINTER_OBJECT\(\(const void \*\)p\): SUCCESS$
+^\[main.pointer_primitives.\d+\] line 11 pointer invalid in POINTER_OBJECT\(\(const void \*\)q\): FAILURE$
+^\[main.pointer_primitives.\d+\] line 11 deallocated dynamic object in POINTER_OBJECT\(\(const void \*\)q\): SUCCESS$
+^\[main.pointer_primitives.\d+\] line 11 dead object in POINTER_OBJECT\(\(const void \*\)q\): SUCCESS$
+^\[main.pointer_primitives.\d+\] line 11 pointer outside object bounds in POINTER_OBJECT\(\(const void \*\)q\): FAILURE$
+^VERIFICATION FAILED$
+^EXIT=10$
+^SIGNAL=0$
+--
+^\[main.pointer_primitives.\d+\] line 17 
+--

--- a/regression/cbmc/pragma_cprover_enable_disable_global_off/main.c
+++ b/regression/cbmc/pragma_cprover_enable_disable_global_off/main.c
@@ -1,0 +1,42 @@
+#include <stdlib.h>
+
+int main()
+{
+  char *p = malloc(sizeof(*p));
+  char *q;
+
+#pragma CPROVER check push
+#pragma CPROVER check enable "pointer-primitive"
+  // must generate checks
+  if(__CPROVER_same_object(p, q))
+  {
+  }
+#pragma CPROVER check push
+#pragma CPROVER check disable "pointer-primitive"
+  // must not generate checks
+  if(__CPROVER_same_object(p, q))
+  {
+  }
+#pragma CPROVER check push
+#pragma CPROVER check enable "pointer-primitive"
+  // must generate checks
+  if(__CPROVER_same_object(p, q))
+  {
+  }
+#pragma CPROVER check pop
+  // must not generate generate checks
+  if(__CPROVER_same_object(p, q))
+  {
+  }
+#pragma CPROVER check pop
+  // must generate generate checks
+  if(__CPROVER_same_object(p, q))
+  {
+  }
+#pragma CPROVER check pop
+  // must not generate generate checks
+  if(__CPROVER_same_object(p, q))
+  {
+  }
+  return 0;
+}

--- a/regression/cbmc/pragma_cprover_enable_disable_global_off/test.desc
+++ b/regression/cbmc/pragma_cprover_enable_disable_global_off/test.desc
@@ -1,0 +1,36 @@
+CORE
+main.c
+
+^main.c function main$
+^\[main.pointer_primitives.\d+\] line 11 pointer invalid in POINTER_OBJECT\(\(const void \*\)p\): SUCCESS$
+^\[main.pointer_primitives.\d+\] line 11 deallocated dynamic object in POINTER_OBJECT\(\(const void \*\)p\): SUCCESS$
+^\[main.pointer_primitives.\d+\] line 11 dead object in POINTER_OBJECT\(\(const void \*\)p\): SUCCESS$
+^\[main.pointer_primitives.\d+\] line 11 pointer outside object bounds in POINTER_OBJECT\(\(const void \*\)p\): SUCCESS$
+^\[main.pointer_primitives.\d+\] line 11 pointer invalid in POINTER_OBJECT\(\(const void \*\)q\): FAILURE$
+^\[main.pointer_primitives.\d+\] line 11 deallocated dynamic object in POINTER_OBJECT\(\(const void \*\)q\): SUCCESS$
+^\[main.pointer_primitives.\d+\] line 11 dead object in POINTER_OBJECT\(\(const void \*\)q\): SUCCESS$
+^\[main.pointer_primitives.\d+\] line 11 pointer outside object bounds in POINTER_OBJECT\(\(const void \*\)q\): FAILURE$
+^\[main.pointer_primitives.\d+\] line 23 pointer invalid in POINTER_OBJECT\(\(const void \*\)p\): SUCCESS$
+^\[main.pointer_primitives.\d+\] line 23 deallocated dynamic object in POINTER_OBJECT\(\(const void \*\)p\): SUCCESS$
+^\[main.pointer_primitives.\d+\] line 23 dead object in POINTER_OBJECT\(\(const void \*\)p\): SUCCESS$
+^\[main.pointer_primitives.\d+\] line 23 pointer outside object bounds in POINTER_OBJECT\(\(const void \*\)p\): SUCCESS$
+^\[main.pointer_primitives.\d+\] line 23 pointer invalid in POINTER_OBJECT\(\(const void \*\)q\): FAILURE$
+^\[main.pointer_primitives.\d+\] line 23 deallocated dynamic object in POINTER_OBJECT\(\(const void \*\)q\): SUCCESS$
+^\[main.pointer_primitives.\d+\] line 23 dead object in POINTER_OBJECT\(\(const void \*\)q\): SUCCESS$
+^\[main.pointer_primitives.\d+\] line 23 pointer outside object bounds in POINTER_OBJECT\(\(const void \*\)q\): FAILURE$
+^\[main.pointer_primitives.\d+\] line 33 pointer invalid in POINTER_OBJECT\(\(const void \*\)p\): SUCCESS$
+^\[main.pointer_primitives.\d+\] line 33 deallocated dynamic object in POINTER_OBJECT\(\(const void \*\)p\): SUCCESS$
+^\[main.pointer_primitives.\d+\] line 33 dead object in POINTER_OBJECT\(\(const void \*\)p\): SUCCESS$
+^\[main.pointer_primitives.\d+\] line 33 pointer outside object bounds in POINTER_OBJECT\(\(const void \*\)p\): SUCCESS$
+^\[main.pointer_primitives.\d+\] line 33 pointer invalid in POINTER_OBJECT\(\(const void \*\)q\): FAILURE$
+^\[main.pointer_primitives.\d+\] line 33 deallocated dynamic object in POINTER_OBJECT\(\(const void \*\)q\): SUCCESS$
+^\[main.pointer_primitives.\d+\] line 33 dead object in POINTER_OBJECT\(\(const void \*\)q\): SUCCESS$
+^\[main.pointer_primitives.\d+\] line 33 pointer outside object bounds in POINTER_OBJECT\(\(const void \*\)q\): FAILURE$
+^VERIFICATION FAILED$
+^EXIT=10$
+^SIGNAL=0$
+--
+^\[main.pointer_primitives.\d+\] line 17 
+^\[main.pointer_primitives.\d+\] line 28 
+^\[main.pointer_primitives.\d+\] line 38 
+--

--- a/regression/cbmc/pragma_cprover_enable_disable_global_on/main.c
+++ b/regression/cbmc/pragma_cprover_enable_disable_global_on/main.c
@@ -1,0 +1,42 @@
+#include <stdlib.h>
+
+int main()
+{
+  char *p = malloc(sizeof(*p));
+  char *q;
+
+#pragma CPROVER check push
+#pragma CPROVER check enable "pointer-primitive"
+  // must generate checks
+  if(__CPROVER_same_object(p, q))
+  {
+  }
+#pragma CPROVER check push
+#pragma CPROVER check disable "pointer-primitive"
+  // must not generate checks
+  if(__CPROVER_same_object(p, q))
+  {
+  }
+#pragma CPROVER check push
+#pragma CPROVER check enable "pointer-primitive"
+  // must generate checks
+  if(__CPROVER_same_object(p, q))
+  {
+  }
+#pragma CPROVER check pop
+  // must not generate generate checks
+  if(__CPROVER_same_object(p, q))
+  {
+  }
+#pragma CPROVER check pop
+  // must generate generate checks
+  if(__CPROVER_same_object(p, q))
+  {
+  }
+#pragma CPROVER check pop
+  // must generate generate checks
+  if(__CPROVER_same_object(p, q))
+  {
+  }
+  return 0;
+}

--- a/regression/cbmc/pragma_cprover_enable_disable_global_on/test.desc
+++ b/regression/cbmc/pragma_cprover_enable_disable_global_on/test.desc
@@ -1,0 +1,43 @@
+CORE
+main.c
+--pointer-primitive-check
+^main.c function main$
+^\[main.pointer_primitives.\d+\] line 11 pointer invalid in POINTER_OBJECT\(\(const void \*\)p\): SUCCESS$
+^\[main.pointer_primitives.\d+\] line 11 deallocated dynamic object in POINTER_OBJECT\(\(const void \*\)p\): SUCCESS$
+^\[main.pointer_primitives.\d+\] line 11 dead object in POINTER_OBJECT\(\(const void \*\)p\): SUCCESS$
+^\[main.pointer_primitives.\d+\] line 11 pointer outside object bounds in POINTER_OBJECT\(\(const void \*\)p\): SUCCESS$
+^\[main.pointer_primitives.\d+\] line 11 pointer invalid in POINTER_OBJECT\(\(const void \*\)q\): FAILURE$
+^\[main.pointer_primitives.\d+\] line 11 deallocated dynamic object in POINTER_OBJECT\(\(const void \*\)q\): SUCCESS$
+^\[main.pointer_primitives.\d+\] line 11 dead object in POINTER_OBJECT\(\(const void \*\)q\): SUCCESS$
+^\[main.pointer_primitives.\d+\] line 11 pointer outside object bounds in POINTER_OBJECT\(\(const void \*\)q\): FAILURE$
+^\[main.pointer_primitives.\d+\] line 23 pointer invalid in POINTER_OBJECT\(\(const void \*\)p\): SUCCESS$
+^\[main.pointer_primitives.\d+\] line 23 deallocated dynamic object in POINTER_OBJECT\(\(const void \*\)p\): SUCCESS$
+^\[main.pointer_primitives.\d+\] line 23 dead object in POINTER_OBJECT\(\(const void \*\)p\): SUCCESS$
+^\[main.pointer_primitives.\d+\] line 23 pointer outside object bounds in POINTER_OBJECT\(\(const void \*\)p\): SUCCESS$
+^\[main.pointer_primitives.\d+\] line 23 pointer invalid in POINTER_OBJECT\(\(const void \*\)q\): FAILURE$
+^\[main.pointer_primitives.\d+\] line 23 deallocated dynamic object in POINTER_OBJECT\(\(const void \*\)q\): SUCCESS$
+^\[main.pointer_primitives.\d+\] line 23 dead object in POINTER_OBJECT\(\(const void \*\)q\): SUCCESS$
+^\[main.pointer_primitives.\d+\] line 23 pointer outside object bounds in POINTER_OBJECT\(\(const void \*\)q\): FAILURE$
+^\[main.pointer_primitives.\d+\] line 33 pointer invalid in POINTER_OBJECT\(\(const void \*\)p\): SUCCESS$
+^\[main.pointer_primitives.\d+\] line 33 deallocated dynamic object in POINTER_OBJECT\(\(const void \*\)p\): SUCCESS$
+^\[main.pointer_primitives.\d+\] line 33 dead object in POINTER_OBJECT\(\(const void \*\)p\): SUCCESS$
+^\[main.pointer_primitives.\d+\] line 33 pointer outside object bounds in POINTER_OBJECT\(\(const void \*\)p\): SUCCESS$
+^\[main.pointer_primitives.\d+\] line 33 pointer invalid in POINTER_OBJECT\(\(const void \*\)q\): FAILURE$
+^\[main.pointer_primitives.\d+\] line 33 deallocated dynamic object in POINTER_OBJECT\(\(const void \*\)q\): SUCCESS$
+^\[main.pointer_primitives.\d+\] line 33 dead object in POINTER_OBJECT\(\(const void \*\)q\): SUCCESS$
+^\[main.pointer_primitives.\d+\] line 33 pointer outside object bounds in POINTER_OBJECT\(\(const void \*\)q\): FAILURE$
+^\[main.pointer_primitives.\d+\] line 38 pointer invalid in POINTER_OBJECT\(\(const void \*\)p\): SUCCESS$
+^\[main.pointer_primitives.\d+\] line 38 deallocated dynamic object in POINTER_OBJECT\(\(const void \*\)p\): SUCCESS$
+^\[main.pointer_primitives.\d+\] line 38 dead object in POINTER_OBJECT\(\(const void \*\)p\): SUCCESS$
+^\[main.pointer_primitives.\d+\] line 38 pointer outside object bounds in POINTER_OBJECT\(\(const void \*\)p\): SUCCESS$
+^\[main.pointer_primitives.\d+\] line 38 pointer invalid in POINTER_OBJECT\(\(const void \*\)q\): FAILURE$
+^\[main.pointer_primitives.\d+\] line 38 deallocated dynamic object in POINTER_OBJECT\(\(const void \*\)q\): SUCCESS$
+^\[main.pointer_primitives.\d+\] line 38 dead object in POINTER_OBJECT\(\(const void \*\)q\): SUCCESS$
+^\[main.pointer_primitives.\d+\] line 38 pointer outside object bounds in POINTER_OBJECT\(\(const void \*\)q\): FAILURE$
+^VERIFICATION FAILED$
+^EXIT=10$
+^SIGNAL=0$
+--
+^\[main.pointer_primitives.\d+\] line 17 
+^\[main.pointer_primitives.\d+\] line 28 
+--

--- a/regression/cbmc/pragma_cprover_enable_disable_multiple/main.c
+++ b/regression/cbmc/pragma_cprover_enable_disable_multiple/main.c
@@ -1,0 +1,17 @@
+#include <stdlib.h>
+
+int main()
+{
+  char *p = malloc(sizeof(*p));
+  char *q;
+
+#pragma CPROVER check push
+#pragma CPROVER check enable "pointer-overflow"
+#pragma CPROVER check enable "pointer-overflow" // should not print an error message
+#pragma CPROVER check push
+#pragma CPROVER check disable "pointer-primitive"
+#pragma CPROVER check enable "pointer-primitive" // should print an error message
+#pragma CPROVER check pop
+#pragma CPROVER check pop
+  return 0;
+}

--- a/regression/cbmc/pragma_cprover_enable_disable_multiple/test.desc
+++ b/regression/cbmc/pragma_cprover_enable_disable_multiple/test.desc
@@ -1,0 +1,10 @@
+CORE
+main.c
+
+^file main.c line \d+ function main: Found enable and disable pragmas for pointer-primitive-check
+^PARSING ERROR$
+^EXIT=6$
+^SIGNAL=0$
+--
+^file main.c line \d+ function main: Found enable and disable pragmas for pointer-overflow-check
+--

--- a/regression/contracts/assigns_enforce_arrays_05/test.desc
+++ b/regression/contracts/assigns_enforce_arrays_05/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---enforce-contract assigns_ptr --enforce-contract assigns_range
+--enforce-contract assigns_range
 ^EXIT=10$
 ^SIGNAL=0$
 ^VERIFICATION FAILED$

--- a/regression/contracts/assigns_enforce_free_dead/test.desc
+++ b/regression/contracts/assigns_enforce_free_dead/test.desc
@@ -29,7 +29,9 @@ main.c
 ^\[foo.\d+\] line \d+ Check that y is assignable: FAILURE$
 ^\[foo.\d+\] line \d+ Check that z is assignable: FAILURE$
 ^\[foo.\d+\] line \d+ Check that POINTER_OBJECT\(\(void \*\)z\) is assignable: FAILURE$
-^.*tmp_cc\$\d+.*: FAILURE$
+^.*__car_valid.*: FAILURE$
+^.*__car_lb.*: FAILURE$
+^.*__car_ub.*: FAILURE$
 --
 Checks that invalidated CARs are correctly tracked on `free` and `DEAD`.
 
@@ -40,4 +42,4 @@ We also check (using positive regex matches above) that
 `**p` should be assignable in one case and should not be assignable in the other.
 
 Finally, we check that there should be no "internal" assertion failures
-on `tmp_cc` variables used to track CARs.
+on `__car_valid`, `__car_ub`, `__car_lb` variables used to track CARs.

--- a/regression/contracts/assigns_enforce_havoc_object/functions.txt
+++ b/regression/contracts/assigns_enforce_havoc_object/functions.txt
@@ -1,0 +1,1 @@
+Reading GOTO program from '__CPROVER_file_local_s2n_hash_c_s2n_evp_hash_reset_with_contracts_harness.c.goto'

--- a/regression/contracts/assigns_enforce_havoc_object/main.c
+++ b/regression/contracts/assigns_enforce_havoc_object/main.c
@@ -1,0 +1,47 @@
+#include <assert.h>
+#include <stdlib.h>
+
+int x = 0;
+typedef struct stc {
+  int i;
+  int j;
+} stc;
+
+typedef struct stb {
+  stc *c;
+} stb;
+
+typedef struct sta {
+  union {
+    stb *b;
+    int i;
+    int j;
+  } u;
+} sta;
+
+int nondet_int();
+
+void bar(sta *a)
+{
+  if (nondet_bool()) return;
+  __CPROVER_havoc_object(a->u.b->c);
+  return;
+}
+
+void foo(sta *a) __CPROVER_assigns(__CPROVER_POINTER_OBJECT(a->u.b->c))
+{
+  bar(a);
+  a->u.i = 2;
+  return;
+}
+
+int main()
+{
+  stc *c = malloc(sizeof(*c));
+  stb *b = malloc(sizeof(*b));
+  sta *a = malloc(sizeof(*a));
+  b->c = c;
+  a->u.b = b;
+  foo(a);
+  return 0;
+}

--- a/regression/contracts/assigns_enforce_havoc_object/test.desc
+++ b/regression/contracts/assigns_enforce_havoc_object/test.desc
@@ -1,0 +1,11 @@
+CORE
+main.c
+--enforce-contract foo
+^EXIT=10$
+^SIGNAL=0$
+^\[bar\.\d+\] line \d+ Check that \*a\->u\.b\->c is assignable: SUCCESS$
+^\[foo\.\d+\] line \d+ Check that a\->u\.i is assignable: FAILURE$
+^VERIFICATION FAILED$
+--
+--
+Checks wether contract enforcement works with arguments to __CPROVER_havoc_object.

--- a/regression/contracts/assigns_enforce_statics/main.c
+++ b/regression/contracts/assigns_enforce_statics/main.c
@@ -1,15 +1,18 @@
 #include <assert.h>
 #include <stdlib.h>
 
-static int x;
+static int x = 0;
 
 void foo() __CPROVER_assigns(x)
 {
   int *y = &x;
 
-  static int x;
+  static int x = 0;
+
+  // should pass (assigns local x)
   x++;
 
+  // should fail (assigns global x)
   (*y)++;
 }
 

--- a/regression/contracts/assigns_enforce_statics_subfunctions/main.c
+++ b/regression/contracts/assigns_enforce_statics_subfunctions/main.c
@@ -1,0 +1,31 @@
+#include <assert.h>
+#include <stdlib.h>
+
+static int x;
+static int xx;
+
+void foo()
+{
+  int *y = &x;
+  int *yy = &xx;
+
+  static int x;
+  // must pass (modifies local static)
+  x++;
+
+  // must pass (modifies assignable global static )
+  (*y)++;
+
+  // must fail (modifies non-assignable global static)
+  (*yy)++;
+}
+
+void bar() __CPROVER_assigns(x)
+{
+  foo();
+}
+
+int main()
+{
+  bar();
+}

--- a/regression/contracts/assigns_enforce_statics_subfunctions/test.desc
+++ b/regression/contracts/assigns_enforce_statics_subfunctions/test.desc
@@ -1,0 +1,14 @@
+CORE
+main.c
+--enforce-contract bar _ --pointer-primitive-check
+^EXIT=10$
+^SIGNAL=0$
+^\[foo.\d+\] line \d+ Check that y is assignable: SUCCESS$
+^\[foo.\d+\] line \d+ Check that foo\$\$1\$\$x is assignable: SUCCESS$
+^\[foo.\d+\] line \d+ Check that \*y is assignable: SUCCESS$
+^\[foo.\d+\] line \d+ Check that \*yy is assignable: FAILURE$
+^VERIFICATION FAILED$
+--
+--
+Checks whether static local and global variables are correctly tracked
+in assigns clause verification, accross subfunction calls.

--- a/regression/contracts/quantifiers-forall-ensures-enforce/main.c
+++ b/regression/contracts/quantifiers-forall-ensures-enforce/main.c
@@ -23,7 +23,7 @@ int f1(int *arr, int len)
 int main()
 {
   int len;
-  __CPROVER_assume(0 <= len && len <= MAX_LEN);
+  __CPROVER_assume(0 < len && len <= MAX_LEN);
 
   int *arr = malloc(len * sizeof(int));
   f1(arr, len);

--- a/src/analyses/goto_check.cpp
+++ b/src/analyses/goto_check.cpp
@@ -25,8 +25,8 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/ieee_float.h>
 #include <util/invariant.h>
 #include <util/make_unique.h>
-#include <util/options.h>
 #include <util/message.h>
+#include <util/options.h>
 #include <util/pointer_expr.h>
 #include <util/pointer_offset_size.h>
 #include <util/pointer_predicates.h>
@@ -50,10 +50,8 @@ public:
   goto_checkt(
     const namespacet &_ns,
     const optionst &_options,
-    message_handlert &_message_handler):
-    ns(_ns),
-    local_bitvector_analysis(nullptr),
-    log(_message_handler)
+    message_handlert &_message_handler)
+    : ns(_ns), local_bitvector_analysis(nullptr), log(_message_handler)
   {
     no_enum_check = false;
     enable_bounds_check=_options.get_bool_option("bounds-check");
@@ -1856,7 +1854,7 @@ optionalt<exprt> goto_checkt::rw_ok_check(exprt expr)
 class flag_resett
 {
 public:
-  /// \brief Store the current value of \p flag and 
+  /// \brief Store the current value of \p flag and
   /// then set its value to \p new_value.
   /// \returns true if the flag was already seen before
   bool set_flag(bool &flag, bool new_value)
@@ -1877,7 +1875,7 @@ public:
     return seen_flags.find(&flag) != seen_flags.end();
   }
 
-  /// \brief Restore the values of all flags that have been 
+  /// \brief Restore the values of all flags that have been
   /// modified via `set_flag`.
   ~flag_resett()
   {

--- a/src/analyses/goto_check.h
+++ b/src/analyses/goto_check.h
@@ -17,21 +17,25 @@ Author: Daniel Kroening, kroening@kroening.com
 class goto_modelt;
 class namespacet;
 class optionst;
+class message_handlert;
 
 void goto_check(
   const namespacet &ns,
   const optionst &options,
-  goto_functionst &goto_functions);
+  goto_functionst &goto_functions,
+  message_handlert &message_handler);
 
 void goto_check(
   const irep_idt &function_identifier,
   goto_functionst::goto_functiont &goto_function,
   const namespacet &ns,
-  const optionst &options);
+  const optionst &options,
+  message_handlert &message_handler);
 
 void goto_check(
   const optionst &options,
-  goto_modelt &goto_model);
+  goto_modelt &goto_model,
+  message_handlert &message_handler);
 
 #define OPT_GOTO_CHECK                                                         \
   "(bounds-check)(pointer-check)(memory-leak-check)"                           \

--- a/src/ansi-c/ansi_c_parser.cpp
+++ b/src/ansi-c/ansi_c_parser.cpp
@@ -19,21 +19,18 @@ ansi_c_id_classt ansi_c_parsert::lookup(
   bool label)
 {
   // labels and tags have a separate name space
-  const irep_idt scope_name=
-    tag?"tag-"+id2string(base_name):
-    label?"label-"+id2string(base_name):
-    base_name;
+  const irep_idt scope_name =
+    tag ? "tag-" + id2string(base_name)
+        : label ? "label-" + id2string(base_name) : base_name;
 
-  for(scopest::const_reverse_iterator it=scopes.rbegin();
-      it!=scopes.rend();
+  for(scopest::const_reverse_iterator it = scopes.rbegin(); it != scopes.rend();
       it++)
   {
-    scopet::name_mapt::const_iterator n_it=
-      it->name_map.find(scope_name);
+    scopet::name_mapt::const_iterator n_it = it->name_map.find(scope_name);
 
-    if(n_it!=it->name_map.end())
+    if(n_it != it->name_map.end())
     {
-      identifier=n_it->second.prefixed_name;
+      identifier = n_it->second.prefixed_name;
       return n_it->second.id_class;
     }
   }
@@ -42,33 +39,30 @@ ansi_c_id_classt ansi_c_parsert::lookup(
   // If it's a tag, we will add to current scope.
   if(tag)
   {
-    ansi_c_identifiert &i=
-      current_scope().name_map[scope_name];
-    i.id_class=ansi_c_id_classt::ANSI_C_TAG;
-    i.prefixed_name=current_scope().prefix+id2string(scope_name);
-    i.base_name=base_name;
-    identifier=i.prefixed_name;
+    ansi_c_identifiert &i = current_scope().name_map[scope_name];
+    i.id_class = ansi_c_id_classt::ANSI_C_TAG;
+    i.prefixed_name = current_scope().prefix + id2string(scope_name);
+    i.base_name = base_name;
+    identifier = i.prefixed_name;
     return ansi_c_id_classt::ANSI_C_TAG;
   }
 
-  identifier=base_name;
+  identifier = base_name;
   return ansi_c_id_classt::ANSI_C_UNKNOWN;
 }
 
 void ansi_c_parsert::add_tag_with_body(irept &tag)
 {
-  const std::string scope_name=
-    "tag-"+tag.get_string(ID_C_base_name);
+  const std::string scope_name = "tag-" + tag.get_string(ID_C_base_name);
 
-  irep_idt prefixed_name=current_scope().prefix+scope_name;
+  irep_idt prefixed_name = current_scope().prefix + scope_name;
 
-  if(prefixed_name!=tag.get(ID_identifier))
+  if(prefixed_name != tag.get(ID_identifier))
   {
     // re-defined in a deeper scope
-    ansi_c_identifiert &identifier=
-      current_scope().name_map[scope_name];
-    identifier.id_class=ansi_c_id_classt::ANSI_C_TAG;
-    identifier.prefixed_name=prefixed_name;
+    ansi_c_identifiert &identifier = current_scope().name_map[scope_name];
+    identifier.id_class = ansi_c_id_classt::ANSI_C_TAG;
+    identifier.prefixed_name = prefixed_name;
     tag.set(ID_identifier, prefixed_name);
   }
 }
@@ -81,21 +75,18 @@ int yyansi_cerror(const std::string &error)
   return 0;
 }
 
-void ansi_c_parsert::add_declarator(
-  exprt &declaration,
-  irept &declarator)
+void ansi_c_parsert::add_declarator(exprt &declaration, irept &declarator)
 {
   assert(declarator.is_not_nil());
-  ansi_c_declarationt &ansi_c_declaration=
-    to_ansi_c_declaration(declaration);
+  ansi_c_declarationt &ansi_c_declaration = to_ansi_c_declaration(declaration);
 
   ansi_c_declaratort new_declarator;
   new_declarator.build(declarator);
 
-  irep_idt base_name=new_declarator.get_base_name();
+  irep_idt base_name = new_declarator.get_base_name();
 
-  bool is_member=ansi_c_declaration.get_is_member();
-  bool is_parameter=ansi_c_declaration.get_is_parameter();
+  bool is_member = ansi_c_declaration.get_is_member();
+  bool is_parameter = ansi_c_declaration.get_is_parameter();
 
   if(is_member)
   {
@@ -113,39 +104,35 @@ void ansi_c_parsert::add_declarator(
   if(!base_name.empty())
   {
     c_storage_spect c_storage_spec(ansi_c_declaration.type());
-    bool is_typedef=c_storage_spec.is_typedef;
-    bool is_extern=c_storage_spec.is_extern;
+    bool is_typedef = c_storage_spec.is_typedef;
+    bool is_extern = c_storage_spec.is_extern;
 
-    bool force_root_scope=false;
+    bool force_root_scope = false;
 
     // Functions always go into global scope, unless
     // declared as a parameter or are typedefs.
-    if(new_declarator.type().id()==ID_code &&
-       !is_parameter &&
-       !is_typedef)
-      force_root_scope=true;
+    if(new_declarator.type().id() == ID_code && !is_parameter && !is_typedef)
+      force_root_scope = true;
 
     // variables marked as 'extern' always go into global scope
     if(is_extern)
-      force_root_scope=true;
+      force_root_scope = true;
 
-    ansi_c_id_classt id_class=is_typedef?
-      ansi_c_id_classt::ANSI_C_TYPEDEF:
-      ansi_c_id_classt::ANSI_C_SYMBOL;
+    ansi_c_id_classt id_class = is_typedef ? ansi_c_id_classt::ANSI_C_TYPEDEF
+                                           : ansi_c_id_classt::ANSI_C_SYMBOL;
 
-    scopet &scope=
-      force_root_scope?root_scope():current_scope();
+    scopet &scope = force_root_scope ? root_scope() : current_scope();
 
     // set the final name
-    irep_idt prefixed_name=force_root_scope?
-             base_name:
-             current_scope().prefix+id2string(base_name);
+    irep_idt prefixed_name = force_root_scope
+                               ? base_name
+                               : current_scope().prefix + id2string(base_name);
     new_declarator.set_name(prefixed_name);
 
     // add to scope
-    ansi_c_identifiert &identifier=scope.name_map[base_name];
-    identifier.id_class=id_class;
-    identifier.prefixed_name=prefixed_name;
+    ansi_c_identifiert &identifier = scope.name_map[base_name];
+    identifier.id_class = id_class;
+    identifier.prefixed_name = prefixed_name;
 
     if(force_root_scope)
       current_scope().name_map[base_name] = identifier;
@@ -156,13 +143,12 @@ void ansi_c_parsert::add_declarator(
 
 ansi_c_id_classt ansi_c_parsert::get_class(const typet &type)
 {
-  if(type.id()==ID_typedef)
+  if(type.id() == ID_typedef)
     return ansi_c_id_classt::ANSI_C_TYPEDEF;
-  else if(type.id()==ID_struct ||
-          type.id()==ID_union ||
-          type.id()==ID_c_enum)
+  else if(
+    type.id() == ID_struct || type.id() == ID_union || type.id() == ID_c_enum)
     return ansi_c_id_classt::ANSI_C_TAG;
-  else if(type.id()==ID_merged_type)
+  else if(type.id() == ID_merged_type)
   {
     for(const typet &subtype : to_type_with_subtypes(type).subtypes())
     {
@@ -174,4 +160,57 @@ ansi_c_id_classt ansi_c_parsert::get_class(const typet &type)
     return get_class(type.subtype());
 
   return ansi_c_id_classt::ANSI_C_SYMBOL;
+}
+
+bool ansi_c_parsert::pragma_cprover_empty()
+{
+  return pragma_cprover_stack.empty();
+}
+
+void ansi_c_parsert::pragma_cprover_push()
+{
+  std::map<irep_idt, bool> empty;
+  pragma_cprover_stack.push_back(std::move(empty));
+}
+
+void ansi_c_parsert::pragma_cprover_pop()
+{
+  pragma_cprover_stack.pop_back();
+}
+
+void ansi_c_parsert::pragma_cprover_add_check(irep_idt name, bool enabled)
+{
+  if(pragma_cprover_stack.empty())
+    pragma_cprover_push();
+
+  pragma_cprover_stack.back()[name] = enabled;
+}
+
+bool ansi_c_parsert::pragma_cprover_clash(irep_idt name, bool enabled)
+{
+  auto top = pragma_cprover_stack.back();
+  auto found = top.find(name);
+  return found != top.end() && found->second != enabled;
+}
+
+void ansi_c_parsert::set_pragma_cprover()
+{
+  // handle enable/disable shadowing
+  // by bottom-to-top flattening
+  std::map<irep_idt, bool> flattened;
+
+  for(const auto &pragma_set : pragma_cprover_stack)
+    for(const auto &pragma : pragma_set)
+      flattened[pragma.first] = pragma.second;
+
+  source_location.remove(ID_pragma);
+
+  for(const auto &pragma : flattened)
+  {
+    std::string check_name = id2string(pragma.first);
+    std::string full_name = pragma.second
+                              ? std::string("enable:") + check_name
+                              : std::string("disable:") + check_name;
+    source_location.add_pragma(full_name);
+  }
 }

--- a/src/ansi-c/scanner.l
+++ b/src/ansi-c/scanner.l
@@ -238,6 +238,7 @@ pointer_primitive "pointer-primitive"
 memory_check    ("bounds"|"pointer"|"memory_leak")
 overflow_check  ("signed"|"unsigned"|"pointer"|"float")"-overflow"
 named_check     ["]({arith_check}|{enum_check}|{memory_check}|{overflow_check}|{pointer_primitive})["]
+enable_or_disable ("enable"|"disable")
 
 %x GRAMMAR
 %x COMMENT1
@@ -402,29 +403,33 @@ void ansi_c_scanner_init()
 
                 /* CProver specific pragmas: hint to disable named checks */
 <CPROVER_PRAGMA>{ws}"check"{ws}"push" {
-                  PARSER.pragma_cprover.push_back({});
+                  PARSER.pragma_cprover_push();
                 }
 <CPROVER_PRAGMA>{ws}"check"{ws}"pop" {
-                  if(!PARSER.pragma_cprover.empty())
+                  if(!PARSER.pragma_cprover_empty())
                   {
-                    PARSER.pragma_cprover.pop_back();
+                    PARSER.pragma_cprover_pop();
                     PARSER.set_pragma_cprover();
                   }
                 }
-<CPROVER_PRAGMA>{ws}"check"{ws}"disable"{ws}{named_check} {
+<CPROVER_PRAGMA>{ws}"check"{ws}{enable_or_disable}{ws}{named_check} {
                   std::string tmp(yytext);
+                  bool enable = tmp.find("enable")!=std::string::npos;
                   std::string::size_type p = tmp.find('"') + 1;
-                  std::string value =
-                    std::string("disable:") +
+                  std::string check_name =
                     std::string(tmp, p, tmp.size() - p - 1) +
                     std::string("-check");
-                  if(PARSER.pragma_cprover.empty())
-                    PARSER.pragma_cprover.push_back({value});
-                  else
-                    PARSER.pragma_cprover.back().insert(value);
+                  bool clash = PARSER.pragma_cprover_clash(check_name, enable);
+                  if(clash)
+                  {
+                    yyansi_cerror(
+                      "Found enable and disable pragmas for " +
+                      id2string(check_name));
+                    return TOK_SCANNER_ERROR;
+                  }
+                  PARSER.pragma_cprover_add_check(check_name, enable);
                   PARSER.set_pragma_cprover();
                 }
-
 <CPROVER_PRAGMA>. {
                   yyansi_cerror("Unsupported #pragma CPROVER");
                   return TOK_SCANNER_ERROR;

--- a/src/goto-instrument/contracts/assigns.cpp
+++ b/src/goto-instrument/contracts/assigns.cpp
@@ -41,15 +41,17 @@ static const slicet normalize_to_slice(const exprt &expr, const namespacet &ns)
       size.has_value(),
       "`sizeof` must always be computable on l-value assigns clause targets.");
 
-    return {typecast_exprt::conditional_cast(
-              address_of_exprt{expr}, pointer_type(char_type())),
-            typecast_exprt::conditional_cast(size.value(), signed_size_type())};
+    return {
+      typecast_exprt::conditional_cast(
+        address_of_exprt{expr}, pointer_type(char_type())),
+      typecast_exprt::conditional_cast(size.value(), signed_size_type())};
   }
 
   UNREACHABLE;
 }
 
 const symbolt assigns_clauset::conditional_address_ranget::generate_new_symbol(
+  const std::string &prefix,
   const typet &type,
   const source_locationt &location) const
 {
@@ -57,7 +59,8 @@ const symbolt assigns_clauset::conditional_address_ranget::generate_new_symbol(
     type,
     location,
     parent.symbol_table.lookup_ref(parent.function_name).mode,
-    parent.symbol_table);
+    parent.symbol_table,
+    prefix);
 }
 
 assigns_clauset::conditional_address_ranget::conditional_address_ranget(
@@ -68,11 +71,13 @@ assigns_clauset::conditional_address_ranget::conditional_address_ranget(
     parent(parent),
     slice(normalize_to_slice(expr, parent.ns)),
     validity_condition_var(
-      generate_new_symbol(bool_typet(), location).symbol_expr()),
+      generate_new_symbol("__car_valid", bool_typet(), location).symbol_expr()),
     lower_bound_address_var(
-      generate_new_symbol(slice.first.type(), location).symbol_expr()),
+      generate_new_symbol("__car_lb", slice.first.type(), location)
+        .symbol_expr()),
     upper_bound_address_var(
-      generate_new_symbol(slice.first.type(), location).symbol_expr())
+      generate_new_symbol("__car_ub", slice.first.type(), location)
+        .symbol_expr())
 {
 }
 
@@ -81,41 +86,55 @@ assigns_clauset::conditional_address_ranget::generate_snapshot_instructions()
   const
 {
   goto_programt instructions;
+  // adding pragmas to the location to selectively disable checks
+  // where it is sound to do so
+  source_locationt location_no_checks = location;
+  location_no_checks.add_pragma("disable:pointer-check");
+  location_no_checks.add_pragma("disable:pointer-primitive-check");
+  location_no_checks.add_pragma("disable:pointer-overflow-check");
 
-  instructions.add(goto_programt::make_decl(validity_condition_var, location));
-  instructions.add(goto_programt::make_decl(lower_bound_address_var, location));
-  instructions.add(goto_programt::make_decl(upper_bound_address_var, location));
+  instructions.add(
+    goto_programt::make_decl(validity_condition_var, location_no_checks));
+  instructions.add(
+    goto_programt::make_decl(lower_bound_address_var, location_no_checks));
+  instructions.add(
+    goto_programt::make_decl(upper_bound_address_var, location_no_checks));
 
   instructions.add(goto_programt::make_assignment(
     lower_bound_address_var,
     null_pointer_exprt{to_pointer_type(slice.first.type())},
-    location));
+    location_no_checks));
   instructions.add(goto_programt::make_assignment(
     upper_bound_address_var,
     null_pointer_exprt{to_pointer_type(slice.first.type())},
-    location));
+    location_no_checks));
 
   goto_programt skip_program;
-  const auto skip_target = skip_program.add(goto_programt::make_skip(location));
+  const auto skip_target =
+    skip_program.add(goto_programt::make_skip(location_no_checks));
 
-  const auto validity_check_expr =
-    and_exprt{all_dereferences_are_valid(source_expr, parent.ns),
-              w_ok_exprt{slice.first, slice.second}};
+  const auto validity_check_expr = and_exprt{
+    all_dereferences_are_valid(source_expr, parent.ns),
+    w_ok_exprt{slice.first, slice.second}};
   instructions.add(goto_programt::make_assignment(
-    validity_condition_var, validity_check_expr, location));
+    validity_condition_var, validity_check_expr, location_no_checks));
 
   instructions.add(goto_programt::make_goto(
-    skip_target, not_exprt{validity_condition_var}, location));
+    skip_target, not_exprt{validity_condition_var}, location_no_checks));
 
   instructions.add(goto_programt::make_assignment(
-    lower_bound_address_var, slice.first, location));
+    lower_bound_address_var, slice.first, location_no_checks));
+
+  source_locationt location_overflow_check = location;
+  location_overflow_check.add_pragma("enable:pointer-overflow-check");
 
   instructions.add(goto_programt::make_assignment(
     upper_bound_address_var,
-    minus_exprt{plus_exprt{slice.first, slice.second},
-                from_integer(1, slice.second.type())},
-    location));
-
+    minus_exprt{
+      plus_exprt{slice.first, slice.second},
+      from_integer(1, slice.second.type())},
+    // activate pointer-overflow checks to guard against overflow on this addition
+    location_overflow_check));
   instructions.destructive_append(skip_program);
   return instructions;
 }
@@ -127,11 +146,14 @@ assigns_clauset::conditional_address_ranget::generate_unsafe_inclusion_check(
   return conjunction(
     {validity_condition_var,
      same_object(lower_bound_address_var, lhs.lower_bound_address_var),
-     same_object(lhs.upper_bound_address_var, upper_bound_address_var),
-     less_than_or_equal_exprt{lower_bound_address_var,
-                              lhs.lower_bound_address_var},
-     less_than_or_equal_exprt{lhs.upper_bound_address_var,
-                              upper_bound_address_var}});
+     // redudant now that we guard against pointer overflow
+     // same_object(lhs.upper_bound_address_var, upper_bound_address_var),
+     less_than_or_equal_exprt{
+       pointer_offset(lower_bound_address_var),
+       pointer_offset(lhs.lower_bound_address_var)},
+     less_than_or_equal_exprt{
+       pointer_offset(lhs.upper_bound_address_var),
+       pointer_offset(upper_bound_address_var)}});
 }
 
 assigns_clauset::assigns_clauset(

--- a/src/goto-instrument/contracts/assigns.h
+++ b/src/goto-instrument/contracts/assigns.h
@@ -61,7 +61,9 @@ public:
     generate_unsafe_inclusion_check(const conditional_address_ranget &) const;
 
     const symbolt
-    generate_new_symbol(const typet &, const source_locationt &) const;
+    generate_new_symbol(
+      const std::string &prefix,
+      const typet &, const source_locationt &) const;
 
     friend class assigns_clauset;
   };

--- a/src/goto-instrument/contracts/contracts.h
+++ b/src/goto-instrument/contracts/contracts.h
@@ -216,7 +216,6 @@ protected:
   ///
   /// @param function the function to search local static symbols in
   /// @param assigns assigns clause where search results are added
-  /// @return true if failure, false if success
   ///
   /// A symbol is considered a static local symbol iff:
   /// - it has a static lifetime annotation

--- a/src/goto-instrument/contracts/contracts.h
+++ b/src/goto-instrument/contracts/contracts.h
@@ -210,6 +210,30 @@ protected:
     codet &expression,
     source_locationt location,
     const irep_idt &mode);
+
+  
+  /// Finds static local symbols that occur in the body of the given function and adds them to the the write set of `assigns`.
+  ///
+  /// @param function the function to search local static symbols in
+  /// @param assigns assigns clause where search results are added
+  /// @return true if failure, false if success
+  ///
+  /// A symbol is considered a static local symbol iff:
+  /// - it has a static lifetime annotation
+  /// - its source location has a non-empty function attribute
+  ///
+  /// Symbol occurrences are searched in:
+  /// - ASSERT/ASSUME conditions
+  /// - ASSIGN lhs and rhs
+  /// - FUNCTION_CALL function, lhs and operands
+  /// - SET_RETURN_VALUE instructions
+  /// - OTHER code.
+  ///
+  /// The search does *not*:
+  /// - recurse into FUNCTION_CALL 
+  /// - test DECL or DEAD symbols (because local statics are never DECL'd or DEAD'd for being static).
+  /// - test attributes of GOTO, SET_RETURN_VALUE, THREAD*, ATOMIC*, THROW, CATCH  instructions
+  void find_static_locals(const goto_functiont &function, assigns_clauset &assigns);
 };
 
 #endif // CPROVER_GOTO_INSTRUMENT_CONTRACTS_CONTRACTS_H

--- a/src/goto-instrument/contracts/utils.cpp
+++ b/src/goto-instrument/contracts/utils.cpp
@@ -127,12 +127,13 @@ const symbolt &new_tmp_symbol(
   const typet &type,
   const source_locationt &location,
   const irep_idt &mode,
-  symbol_table_baset &symtab)
+  symbol_table_baset &symtab,
+  std::string suffix)
 {
   return get_fresh_aux_symbol(
     type,
-    id2string(location.get_function()) + "::tmp_cc",
-    "tmp_cc",
+    id2string(location.get_function()) + "::",
+    suffix,
     location,
     mode,
     symtab);

--- a/src/goto-instrument/contracts/utils.h
+++ b/src/goto-instrument/contracts/utils.h
@@ -100,6 +100,7 @@ const symbolt &new_tmp_symbol(
   const typet &type,
   const source_locationt &location,
   const irep_idt &mode,
-  symbol_table_baset &symtab);
+  symbol_table_baset &symtab,
+  std::string suffix = "tmp_cc");
 
 #endif // CPROVER_GOTO_INSTRUMENT_CONTRACTS_UTILS_H

--- a/src/goto-instrument/contracts/utils.h
+++ b/src/goto-instrument/contracts/utils.h
@@ -91,10 +91,16 @@ void insert_before_swap_and_advance(
 
 /// \brief Adds a new temporary symbol to the symbol table.
 ///
+/// The unique name is generated as:
+/// ```
+/// "location.function() + "::" + suffix + "$" + uid
+/// ```
+///
 /// \param type: The type of the new symbol.
 /// \param location: The source location for the new symbol.
 /// \param mode: The mode for the new symbol, e.g. ID_C, ID_java.
 /// \param symtab: The symbol table to which the new symbol is to be added.
+/// \param suffix: base suffix used to generate the unique name.
 /// \return The new symbolt object.
 const symbolt &new_tmp_symbol(
   const typet &type,

--- a/src/goto-instrument/goto_instrument_parse_options.cpp
+++ b/src/goto-instrument/goto_instrument_parse_options.cpp
@@ -1332,7 +1332,7 @@ void goto_instrument_parse_optionst::instrument_goto_program()
   }
 
   // add generic checks, if needed
-  goto_check(options, goto_model);
+  goto_check(options, goto_model, log.get_message_handler());
 
   // check for uninitalized local variables
   if(cmdline.isset("uninitialized-check"))

--- a/src/goto-programs/process_goto_program.cpp
+++ b/src/goto-programs/process_goto_program.cpp
@@ -66,7 +66,7 @@ bool process_goto_program(
 
   // add generic checks
   log.status() << "Generic Property Instrumentation" << messaget::eom;
-  goto_check(options, goto_model);
+  goto_check(options, goto_model, log.get_message_handler());
 
   // checks don't know about adjusted float expressions
   adjust_float_expressions(goto_model);


### PR DESCRIPTION
This PR depends on PRs:
- [#6450 ](https://github.com/diffblue/cbmc/pull/6450) (allows to enable checks at the instruction level) 

This PR fixes some performance issues with assigns clause checking for function and loop contracts.

The problem was that the goto variables and instructions generated to instrument the checks were themselves re-instrumented with automatic VCCs in subsequent passes, causing an explosion in the number of VCCs (with unwanted VCCs representing up to 85% of the total VCCs in some problems).

Instructions performing CAR inclusion checks are read-only logical expressions whose evaluation cannot fail so we can safely disable automatic checks on them. 

CAR snapshotting instructions however perform some pointer arithmetic and need to be ultimately checked for pointer overflow.

In this PR:
- we disable all pointer checks on CAR inclusion checking instructions 
- we enable pointer overflow checks on CAR snapshot instructions

The disable pragmas guard against reinstrumentation in later passes, and the enable pragmas make sure necessary checks will eventually be instantiated before analysis.

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
