### PR TITLE
Fix handling of DEAD instructions and function call inlining

### DIFF
--- a/regression/contracts/loop_assigns-05/main.c
+++ b/regression/contracts/loop_assigns-05/main.c
@@ -1,0 +1,59 @@
+#include <assert.h>
+
+int j;
+
+int lowerbound()
+{
+  return 0;
+}
+
+int upperbound()
+{
+  return 10;
+}
+
+void incr(int *i)
+{
+  (*i)++;
+}
+
+void body_1(int i)
+{
+  j = i;
+}
+
+void body_2(int *i)
+{
+  (*i)++;
+  (*i)--;
+}
+
+int body_3(int *i)
+{
+  (*i)++;
+  if(*i == 4)
+    return 1;
+
+  (*i)--;
+  return 0;
+}
+
+int main()
+{
+  for(int i = lowerbound(); i < upperbound(); incr(&i))
+    // clang-format off
+    __CPROVER_assigns(i, j)
+    __CPROVER_loop_invariant(0 <= i && i <= 10)
+    __CPROVER_loop_invariant(i != 0 ==> j + 1 == i)
+    // clang-format on
+    {
+      body_1(i);
+
+      if(body_3(&i))
+        return 1;
+
+      body_2(&i);
+    }
+
+  assert(j == 9);
+}

--- a/regression/contracts/loop_assigns-05/test.desc
+++ b/regression/contracts/loop_assigns-05/test.desc
@@ -1,0 +1,19 @@
+CORE
+main.c
+--apply-loop-contracts
+^EXIT=0$
+^SIGNAL=0$
+^\[body_1.\d+\] .* Check that j is assignable: SUCCESS$
+^\[body_2.\d+\] .* Check that \*i is assignable: SUCCESS$
+^\[body_3.\d+\] .* Check that \*i is assignable: SUCCESS$
+^\[incr.\d+\] .* Check that \*i is assignable: SUCCESS$
+^\[main.\d+\] .* Check that i is assignable: SUCCESS$
+^\[main.\d+\] .* Check loop invariant before entry: SUCCESS$
+^\[main.\d+\] .* Check that loop invariant is preserved: SUCCESS$
+^\[main.assertion.\d+\] .* assertion j == 9: SUCCESS$
+^VERIFICATION SUCCESSFUL$
+--
+--
+This test checks write set inclusion checks in presence of function calls,
+which are inlined, and also checks that DEAD instructions introduced during
+inlining is correctly handled.


### PR DESCRIPTION
In this PR, we fix 3 minor issues related to code contracts:
1. an overflow error in handling `DEAD` instructions during write set inclusion checking.
2. refactor and optimize function call inlining during code contracts instrumentation
3. extend write set inclusion checks to loop head instructions (in addition to loop body) to check for possible side effects in the guard

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a ~~The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/~~
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a ~~My commit message includes data points confirming performance improvements (if claimed).~~
- [x] My PR is restricted to a single feature or bugfix.
- n/a ~~White-space or formatting changes outside the feature-related changed lines are in commits of their own.~~