### PR TITLE
Extend unit test of bits2expr/expr2bits with struct type

### DIFF
--- a/unit/util/simplify_expr.cpp
+++ b/unit/util/simplify_expr.cpp
@@ -108,6 +108,30 @@ TEST_CASE("expr2bits and bits2expr respect bit order", "[core][util]")
   const auto should_be_deadbeef2 =
     bits2expr(*be, unsignedbv_typet(32), false, ns);
   REQUIRE(deadbeef == *should_be_deadbeef2);
+
+  c_bit_field_typet four_bits{unsignedbv_typet{8}, 4};
+  struct_typet st{{{"s", unsignedbv_typet{16}},
+                   {"bf1", four_bits},
+                   {"bf2", four_bits},
+                   {"b", unsignedbv_typet{8}}}};
+
+  const auto fill_struct_le = bits2expr(*le, st, true, ns);
+  REQUIRE(fill_struct_le.has_value());
+  REQUIRE(
+    to_struct_expr(*fill_struct_le).operands()[1] ==
+    from_integer(0xd, four_bits));
+  REQUIRE(
+    to_struct_expr(*fill_struct_le).operands()[2] ==
+    from_integer(0xa, four_bits));
+
+  const auto fill_struct_be = bits2expr(*be, st, false, ns);
+  REQUIRE(fill_struct_be.has_value());
+  REQUIRE(
+    to_struct_expr(*fill_struct_be).operands()[1] ==
+    from_integer(0xb, four_bits));
+  REQUIRE(
+    to_struct_expr(*fill_struct_be).operands()[2] ==
+    from_integer(0xe, four_bits));
 }
 
 TEST_CASE("Simplify extractbit", "[core][util]")


### PR DESCRIPTION
Structs with sub-byte bit fields demonstrate that big-endian ordering
also re-orders the bits within a byte. An executable variant of this
unit test was validated on mips (using qemu-mips), demonstrating the
same bit ordering.

No bug fixes/code changes required, this test just confirms that our
endianness interpretation matches actual hardware.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
