### PR TITLE
Support byte update lowering of/from an array of bits [depends-on: #6488]

### DIFF
--- a/unit/util/lower_byte_operators.cpp
+++ b/unit/util/lower_byte_operators.cpp
@@ -426,6 +426,7 @@ SCENARIO("byte_update_lowering", "[core][util][lowering][byte_update]")
       union_typet({{"compA", u32}, {"compB", u64}}),
       c_enum_typet(u16),
       c_enum_typet(unsignedbv_typet(128)),
+      array_typet{bv_typet{1}, from_integer(128, size_type())},
       array_typet(u8, size),
       array_typet(s32, size),
       array_typet(u64, size),


### PR DESCRIPTION
Byte operator lowering made several assumptions about array elements
being byte aligned, which may be true for ANSI C, but isn't the case for
our C front-end (which supports arrays of single bits), and not true for
the overall framework in general.

A key part of this is factoring out code that was almost-the-same from
lower_byte_update_array_vector and lower_byte_update_struct.

Depends on #6488 for tests to pass.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
