### PR TITLE
C front-end: reject code containing duplicate labels

### DIFF
--- a/regression/ansi-c/duplicate_label1/main.c
+++ b/regression/ansi-c/duplicate_label1/main.c
@@ -1,0 +1,9 @@
+int main()
+{
+  int x;
+label:
+  x = 1;
+  goto label;
+label:
+  x = 2;
+}

--- a/regression/ansi-c/duplicate_label1/test.desc
+++ b/regression/ansi-c/duplicate_label1/test.desc
@@ -1,0 +1,9 @@
+CORE test-c++-front-end
+main.c
+
+^EXIT=(1|64)$
+^SIGNAL=0$
+error: duplicate label 'label'
+^CONVERSION ERROR$
+--
+^warning: ignoring

--- a/regression/cbmc-concurrency/atomic_section_sc3/main.c
+++ b/regression/cbmc-concurrency/atomic_section_sc3/main.c
@@ -85,8 +85,10 @@ unsigned dec() {
 
 int main(){
 __CPROVER_ASYNC_1: inc();
-__CPROVER_ASYNC_2: dec();
-__CPROVER_ASYNC_3: dec();
+__CPROVER_ASYNC_2:
+  dec();
+__CPROVER_ASYNC_3:
+  dec();
 
   return 0;
 }

--- a/regression/cbmc-concurrency/atomic_section_sc3/main.c
+++ b/regression/cbmc-concurrency/atomic_section_sc3/main.c
@@ -85,8 +85,8 @@ unsigned dec() {
 
 int main(){
 __CPROVER_ASYNC_1: inc();
-__CPROVER_ASYNC_1: dec();
-__CPROVER_ASYNC_1: dec();
+__CPROVER_ASYNC_2: dec();
+__CPROVER_ASYNC_3: dec();
 
   return 0;
 }

--- a/regression/cbmc-concurrency/conditional_spawn2/main.c
+++ b/regression/cbmc-concurrency/conditional_spawn2/main.c
@@ -16,8 +16,10 @@ int main()
 __CPROVER_ASYNC_1: thread();
   }
 
-__CPROVER_ASYNC_2: thread();
-__CPROVER_ASYNC_3: thread();
+__CPROVER_ASYNC_2:
+  thread();
+__CPROVER_ASYNC_3:
+  thread();
 
   __CPROVER_assert(n<4, "3 threads spawned");
 

--- a/regression/cbmc-concurrency/conditional_spawn2/main.c
+++ b/regression/cbmc-concurrency/conditional_spawn2/main.c
@@ -16,8 +16,8 @@ int main()
 __CPROVER_ASYNC_1: thread();
   }
 
-__CPROVER_ASYNC_1: thread();
-__CPROVER_ASYNC_1: thread();
+__CPROVER_ASYNC_2: thread();
+__CPROVER_ASYNC_3: thread();
 
   __CPROVER_assert(n<4, "3 threads spawned");
 

--- a/regression/cbmc-concurrency/generic_hw_sw_benchmark1/main.c
+++ b/regression/cbmc-concurrency/generic_hw_sw_benchmark1/main.c
@@ -8,9 +8,9 @@
 
 #ifdef _ENABLE_CBMC_
 
-#define ASYNC(n, c) __CPROVER_ASYNC_ ## n: (c)
-#define ATOMIC_BEGIN  __CPROVER_atomic_begin()
-#define ATOMIC_END  __CPROVER_atomic_end()
+#  define ASYNC(n, c) __CPROVER_ASYNC_##n : (c)
+#  define ATOMIC_BEGIN __CPROVER_atomic_begin()
+#  define ATOMIC_END __CPROVER_atomic_end()
 
 char symbolic_char(char);
 
@@ -233,7 +233,7 @@ void* write_data_register(struct Hardware *hw, RegisterId reg_id, Register value
     pthread_create(&interrupt_thread, NULL, hw->interrupt_handler, (void *) hw->fw);
   }
 #else
-    ASYNC(1, hw->interrupt_handler((void *) hw->fw));
+    ASYNC(1, hw->interrupt_handler((void *)hw->fw));
 #endif
 
 SKIP:
@@ -346,7 +346,7 @@ int main(void)
   pthread_t firmware_thread;
   pthread_create(&firmware_thread, NULL, poll, (void *) fw);
 #else
-  ASYNC(1, poll((void *) fw));
+  ASYNC(1, poll((void *)fw));
 #endif
 
 #ifdef _EXPOSE_BUG_
@@ -358,7 +358,7 @@ int main(void)
   pthread_t stimulus_thread;
   pthread_create(&stimulus_thread, NULL, stimulus, (void *) hw);
 #else
-  ASYNC(2, stimulus((void *) hw));
+  ASYNC(2, stimulus((void *)hw));
 #endif
 
 #ifdef _EXPOSE_BUG_

--- a/regression/cbmc-concurrency/generic_hw_sw_benchmark1/main.c
+++ b/regression/cbmc-concurrency/generic_hw_sw_benchmark1/main.c
@@ -8,7 +8,7 @@
 
 #ifdef _ENABLE_CBMC_
 
-#define ASYNC(c) __CPROVER_ASYNC_1: (c)
+#define ASYNC(n, c) __CPROVER_ASYNC_ ## n: (c)
 #define ATOMIC_BEGIN  __CPROVER_atomic_begin()
 #define ATOMIC_END  __CPROVER_atomic_end()
 
@@ -233,7 +233,7 @@ void* write_data_register(struct Hardware *hw, RegisterId reg_id, Register value
     pthread_create(&interrupt_thread, NULL, hw->interrupt_handler, (void *) hw->fw);
   }
 #else
-    ASYNC(hw->interrupt_handler((void *) hw->fw));
+    ASYNC(1, hw->interrupt_handler((void *) hw->fw));
 #endif
 
 SKIP:
@@ -346,7 +346,7 @@ int main(void)
   pthread_t firmware_thread;
   pthread_create(&firmware_thread, NULL, poll, (void *) fw);
 #else
-  ASYNC(poll((void *) fw));
+  ASYNC(1, poll((void *) fw));
 #endif
 
 #ifdef _EXPOSE_BUG_
@@ -358,7 +358,7 @@ int main(void)
   pthread_t stimulus_thread;
   pthread_create(&stimulus_thread, NULL, stimulus, (void *) hw);
 #else
-  ASYNC(stimulus((void *) hw));
+  ASYNC(2, stimulus((void *) hw));
 #endif
 
 #ifdef _EXPOSE_BUG_

--- a/regression/cbmc-concurrency/invalid_object1/main.c
+++ b/regression/cbmc-concurrency/invalid_object1/main.c
@@ -283,7 +283,7 @@ static signed int ethoc_reset(struct ethoc *dev)
 __CPROVER_ASYNC_1:
   open_eth_reg_write(dev->open_eth, (unsigned int)0, mode);
 
-__CPROVER_ASYNC_1:
+__CPROVER_ASYNC_2:
   open_eth_reg_write(dev->open_eth, (unsigned int)0, mode);
   return 0;
 }

--- a/regression/cbmc-concurrency/recursion1/main.c
+++ b/regression/cbmc-concurrency/recursion1/main.c
@@ -13,7 +13,7 @@ __CPROVER_ASYNC_1:
 
 start2:
   (void)0;
-__CPROVER_ASYNC_1:
+__CPROVER_ASYNC_2:
   goto start2;
 
   rec_spawn();

--- a/regression/cbmc-concurrency/svcomp13_qrcu_safe/main.c
+++ b/regression/cbmc-concurrency/svcomp13_qrcu_safe/main.c
@@ -118,7 +118,9 @@ void* qrcu_updater() {
 
 int main() {
 __CPROVER_ASYNC_1: qrcu_reader1();
-__CPROVER_ASYNC_2: qrcu_reader2();
-__CPROVER_ASYNC_3: qrcu_updater();
+__CPROVER_ASYNC_2:
+  qrcu_reader2();
+__CPROVER_ASYNC_3:
+  qrcu_updater();
   return 0;
 }

--- a/regression/cbmc-concurrency/svcomp13_qrcu_safe/main.c
+++ b/regression/cbmc-concurrency/svcomp13_qrcu_safe/main.c
@@ -118,7 +118,7 @@ void* qrcu_updater() {
 
 int main() {
 __CPROVER_ASYNC_1: qrcu_reader1();
-__CPROVER_ASYNC_1: qrcu_reader2();
-__CPROVER_ASYNC_1: qrcu_updater();
+__CPROVER_ASYNC_2: qrcu_reader2();
+__CPROVER_ASYNC_3: qrcu_updater();
   return 0;
 }

--- a/regression/cbmc-concurrency/svcomp13_qrcu_unsafe/main.c
+++ b/regression/cbmc-concurrency/svcomp13_qrcu_unsafe/main.c
@@ -118,7 +118,9 @@ void* qrcu_updater() {
 
 int main() {
 __CPROVER_ASYNC_1: qrcu_reader1();
-__CPROVER_ASYNC_2: qrcu_reader2();
-__CPROVER_ASYNC_3: qrcu_updater();
+__CPROVER_ASYNC_2:
+  qrcu_reader2();
+__CPROVER_ASYNC_3:
+  qrcu_updater();
   return 0;
 }

--- a/regression/cbmc-concurrency/svcomp13_qrcu_unsafe/main.c
+++ b/regression/cbmc-concurrency/svcomp13_qrcu_unsafe/main.c
@@ -118,7 +118,7 @@ void* qrcu_updater() {
 
 int main() {
 __CPROVER_ASYNC_1: qrcu_reader1();
-__CPROVER_ASYNC_1: qrcu_reader2();
-__CPROVER_ASYNC_1: qrcu_updater();
+__CPROVER_ASYNC_2: qrcu_reader2();
+__CPROVER_ASYNC_3: qrcu_updater();
   return 0;
 }

--- a/regression/cbmc-concurrency/svcomp13_read_write_lock_safe/main.c
+++ b/regression/cbmc-concurrency/svcomp13_read_write_lock_safe/main.c
@@ -39,8 +39,11 @@ void *reader() { //reader
 
 int main() {
 __CPROVER_ASYNC_1: writer();
-__CPROVER_ASYNC_2: reader();
-__CPROVER_ASYNC_3: writer();
-__CPROVER_ASYNC_4: reader();
+__CPROVER_ASYNC_2:
+  reader();
+__CPROVER_ASYNC_3:
+  writer();
+__CPROVER_ASYNC_4:
+  reader();
   return 0;
 }

--- a/regression/cbmc-concurrency/svcomp13_read_write_lock_safe/main.c
+++ b/regression/cbmc-concurrency/svcomp13_read_write_lock_safe/main.c
@@ -39,8 +39,8 @@ void *reader() { //reader
 
 int main() {
 __CPROVER_ASYNC_1: writer();
-__CPROVER_ASYNC_1: reader();
-__CPROVER_ASYNC_1: writer();
-__CPROVER_ASYNC_1: reader();
+__CPROVER_ASYNC_2: reader();
+__CPROVER_ASYNC_3: writer();
+__CPROVER_ASYNC_4: reader();
   return 0;
 }

--- a/src/ansi-c/c_typecheck_code.cpp
+++ b/src/ansi-c/c_typecheck_code.cpp
@@ -505,7 +505,12 @@ void c_typecheck_baset::typecheck_for(codet &code)
 void c_typecheck_baset::typecheck_label(code_labelt &code)
 {
   // record the label
-  labels_defined[code.get_label()]=code.source_location();
+  if(!labels_defined.emplace(code.get_label(), code.source_location()).second)
+  {
+    error().source_location = code.source_location();
+    error() << "duplicate label '" << code.get_label() << "'" << eom;
+    throw 0;
+  }
 
   typecheck_code(code.code());
 }


### PR DESCRIPTION
We previously silently accepted such code, maintaining the labels and
attaching them to multiple instructions. `goto` resolved to the first
such occurrence of the label.

GCC firmly rejects such code.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
