### PR TITLE
C library: model currently supported behaviour of longjmp

### DIFF
--- a/regression/cbmc-library/CMakeLists.txt
+++ b/regression/cbmc-library/CMakeLists.txt
@@ -7,7 +7,7 @@ add_test_pl_tests(
     "$<TARGET_FILE:cbmc>"
     "cbmc-library"
     "$<TARGET_FILE:cbmc>"
-    "-C;-X;pthread"
+    "-C;-X;unix"
     "CORE"
 )
 endif()

--- a/regression/cbmc-library/Makefile
+++ b/regression/cbmc-library/Makefile
@@ -4,14 +4,14 @@ include ../../src/config.inc
 include ../../src/common
 
 ifeq ($(BUILD_ENV_),MSVC)
-	no_pthread = -X pthread
+	unix_only = -X unix
 endif
 
 test:
-	@../test.pl -e -p -c ../../../src/cbmc/cbmc $(no_pthread)
+	@../test.pl -e -p -c ../../../src/cbmc/cbmc $(unix_only)
 
 tests.log: ../test.pl
-	@../test.pl -e -p -c ../../../src/cbmc/cbmc $(no_pthread)
+	@../test.pl -e -p -c ../../../src/cbmc/cbmc $(unix_only)
 
 clean:
 	find . -name '*.out' -execdir $(RM) '{}' \;

--- a/regression/cbmc-library/_longjmp-01/main.c
+++ b/regression/cbmc-library/_longjmp-01/main.c
@@ -1,9 +1,10 @@
-#include <assert.h>
 #include <setjmp.h>
+
+static jmp_buf env;
 
 int main()
 {
-  _longjmp();
-  assert(0);
+  _longjmp(env, 1);
+  __CPROVER_assert(0, "unreachable");
   return 0;
 }

--- a/regression/cbmc-library/_longjmp-01/test.desc
+++ b/regression/cbmc-library/_longjmp-01/test.desc
@@ -1,8 +1,10 @@
-KNOWNBUG
+CORE
 main.c
 --pointer-check --bounds-check
-^EXIT=0$
+^\[_longjmp.assertion.1\] line 12 _longjmp requires instrumentation: FAILURE$
+^\[main.assertion.1\] line 8 unreachable: SUCCESS$
+^VERIFICATION FAILED$
+^EXIT=10$
 ^SIGNAL=0$
-^VERIFICATION SUCCESSFUL$
 --
 ^warning: ignoring

--- a/regression/cbmc-library/longjmp-01/main.c
+++ b/regression/cbmc-library/longjmp-01/main.c
@@ -1,9 +1,10 @@
-#include <assert.h>
 #include <setjmp.h>
+
+static jmp_buf env;
 
 int main()
 {
-  longjmp();
-  assert(0);
+  longjmp(env, 1);
+  __CPROVER_assert(0, "unreachable");
   return 0;
 }

--- a/regression/cbmc-library/longjmp-01/test.desc
+++ b/regression/cbmc-library/longjmp-01/test.desc
@@ -1,8 +1,10 @@
-KNOWNBUG
+CORE
 main.c
 --pointer-check --bounds-check
-^EXIT=0$
+^\[longjmp.assertion.1\] line 12 longjmp requires instrumentation: FAILURE$
+^\[main.assertion.1\] line 8 unreachable: SUCCESS$
+^VERIFICATION FAILED$
+^EXIT=10$
 ^SIGNAL=0$
-^VERIFICATION SUCCESSFUL$
 --
 ^warning: ignoring

--- a/regression/cbmc-library/pthread_barrier_destroy-01/test.desc
+++ b/regression/cbmc-library/pthread_barrier_destroy-01/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG pthread
+KNOWNBUG unix
 main.c
 --pointer-check --bounds-check
 ^EXIT=0$

--- a/regression/cbmc-library/pthread_barrier_init-01/test.desc
+++ b/regression/cbmc-library/pthread_barrier_init-01/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG pthread
+KNOWNBUG unix
 main.c
 --pointer-check --bounds-check
 ^EXIT=0$

--- a/regression/cbmc-library/pthread_barrier_wait-01/test.desc
+++ b/regression/cbmc-library/pthread_barrier_wait-01/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG pthread
+KNOWNBUG unix
 main.c
 --pointer-check --bounds-check
 ^EXIT=0$

--- a/regression/cbmc-library/pthread_cancel-01/test.desc
+++ b/regression/cbmc-library/pthread_cancel-01/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG pthread
+KNOWNBUG unix
 main.c
 --pointer-check --bounds-check
 ^EXIT=0$

--- a/regression/cbmc-library/pthread_cond_broadcast-01/test.desc
+++ b/regression/cbmc-library/pthread_cond_broadcast-01/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG pthread
+KNOWNBUG unix
 main.c
 --pointer-check --bounds-check
 ^EXIT=0$

--- a/regression/cbmc-library/pthread_cond_init-01/test.desc
+++ b/regression/cbmc-library/pthread_cond_init-01/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG pthread
+KNOWNBUG unix
 main.c
 --pointer-check --bounds-check
 ^EXIT=0$

--- a/regression/cbmc-library/pthread_cond_signal-01/test.desc
+++ b/regression/cbmc-library/pthread_cond_signal-01/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG pthread
+KNOWNBUG unix
 main.c
 --pointer-check --bounds-check
 ^EXIT=0$

--- a/regression/cbmc-library/pthread_cond_wait-01/test.desc
+++ b/regression/cbmc-library/pthread_cond_wait-01/test.desc
@@ -1,4 +1,4 @@
-CORE pthread
+CORE unix
 main.c
 --bounds-check
 ^EXIT=10$

--- a/regression/cbmc-library/pthread_create-01/test.desc
+++ b/regression/cbmc-library/pthread_create-01/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG pthread
+KNOWNBUG unix
 main.c
 --pointer-check --bounds-check
 ^EXIT=0$

--- a/regression/cbmc-library/pthread_exit-01/test.desc
+++ b/regression/cbmc-library/pthread_exit-01/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG pthread
+KNOWNBUG unix
 main.c
 --pointer-check --bounds-check
 ^EXIT=0$

--- a/regression/cbmc-library/pthread_join-01/test.desc
+++ b/regression/cbmc-library/pthread_join-01/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG pthread
+KNOWNBUG unix
 main.c
 --pointer-check --bounds-check
 ^EXIT=0$

--- a/regression/cbmc-library/pthread_mutex_destroy-01/test.desc
+++ b/regression/cbmc-library/pthread_mutex_destroy-01/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG pthread
+KNOWNBUG unix
 main.c
 --pointer-check --bounds-check
 ^EXIT=0$

--- a/regression/cbmc-library/pthread_mutex_init-01/test.desc
+++ b/regression/cbmc-library/pthread_mutex_init-01/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG pthread
+KNOWNBUG unix
 main.c
 --pointer-check --bounds-check
 ^EXIT=0$

--- a/regression/cbmc-library/pthread_mutex_lock-01/test.desc
+++ b/regression/cbmc-library/pthread_mutex_lock-01/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG pthread
+KNOWNBUG unix
 main.c
 --pointer-check --bounds-check
 ^EXIT=0$

--- a/regression/cbmc-library/pthread_mutex_trylock-01/test.desc
+++ b/regression/cbmc-library/pthread_mutex_trylock-01/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG pthread
+KNOWNBUG unix
 main.c
 --pointer-check --bounds-check
 ^EXIT=0$

--- a/regression/cbmc-library/pthread_mutex_unlock-01/test.desc
+++ b/regression/cbmc-library/pthread_mutex_unlock-01/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG pthread
+KNOWNBUG unix
 main.c
 --pointer-check --bounds-check
 ^EXIT=0$

--- a/regression/cbmc-library/pthread_mutexattr_settype-01/test.desc
+++ b/regression/cbmc-library/pthread_mutexattr_settype-01/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG pthread
+KNOWNBUG unix
 main.c
 --pointer-check --bounds-check
 ^EXIT=0$

--- a/regression/cbmc-library/pthread_rwlock_destroy-01/test.desc
+++ b/regression/cbmc-library/pthread_rwlock_destroy-01/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG pthread
+KNOWNBUG unix
 main.c
 --pointer-check --bounds-check
 ^EXIT=0$

--- a/regression/cbmc-library/pthread_rwlock_init-01/test.desc
+++ b/regression/cbmc-library/pthread_rwlock_init-01/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG pthread
+KNOWNBUG unix
 main.c
 --pointer-check --bounds-check
 ^EXIT=0$

--- a/regression/cbmc-library/pthread_rwlock_rdlock-01/test.desc
+++ b/regression/cbmc-library/pthread_rwlock_rdlock-01/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG pthread
+KNOWNBUG unix
 main.c
 --pointer-check --bounds-check
 ^EXIT=0$

--- a/regression/cbmc-library/pthread_rwlock_tryrdlock-01/test.desc
+++ b/regression/cbmc-library/pthread_rwlock_tryrdlock-01/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG pthread
+KNOWNBUG unix
 main.c
 --pointer-check --bounds-check
 ^EXIT=0$

--- a/regression/cbmc-library/pthread_rwlock_trywrlock-01/test.desc
+++ b/regression/cbmc-library/pthread_rwlock_trywrlock-01/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG pthread
+KNOWNBUG unix
 main.c
 --pointer-check --bounds-check
 ^EXIT=0$

--- a/regression/cbmc-library/pthread_rwlock_unlock-01/test.desc
+++ b/regression/cbmc-library/pthread_rwlock_unlock-01/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG pthread
+KNOWNBUG unix
 main.c
 --pointer-check --bounds-check
 ^EXIT=0$

--- a/regression/cbmc-library/pthread_rwlock_wrlock-01/test.desc
+++ b/regression/cbmc-library/pthread_rwlock_wrlock-01/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG pthread
+KNOWNBUG unix
 main.c
 --pointer-check --bounds-check
 ^EXIT=0$

--- a/regression/cbmc-library/pthread_spin_lock-01/test.desc
+++ b/regression/cbmc-library/pthread_spin_lock-01/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG pthread
+KNOWNBUG unix
 main.c
 --pointer-check --bounds-check
 ^EXIT=0$

--- a/regression/cbmc-library/pthread_spin_trylock-01/test.desc
+++ b/regression/cbmc-library/pthread_spin_trylock-01/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG pthread
+KNOWNBUG unix
 main.c
 --pointer-check --bounds-check
 ^EXIT=0$

--- a/regression/cbmc-library/pthread_spin_unlock-01/test.desc
+++ b/regression/cbmc-library/pthread_spin_unlock-01/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG pthread
+KNOWNBUG unix
 main.c
 --pointer-check --bounds-check
 ^EXIT=0$

--- a/regression/cbmc-library/setjmp-01/main.c
+++ b/regression/cbmc-library/setjmp-01/main.c
@@ -1,9 +1,12 @@
-#include <assert.h>
 #include <setjmp.h>
+
+static jmp_buf env;
 
 int main()
 {
-  setjmp();
-  assert(0);
+  if(setjmp(env))
+    __CPROVER_assert(0, "reached via longjmp");
+  else
+    __CPROVER_assert(0, "setjmp called directly");
   return 0;
 }

--- a/regression/cbmc-library/setjmp-01/test.desc
+++ b/regression/cbmc-library/setjmp-01/test.desc
@@ -1,8 +1,10 @@
-KNOWNBUG
+CORE
 main.c
 --pointer-check --bounds-check
-^EXIT=0$
+^\[main.assertion.1\] line 8 reached via longjmp: SUCCESS$
+^\[main.assertion.2\] line 10 setjmp called directly: FAILURE$
+^VERIFICATION FAILED$
+^EXIT=10$
 ^SIGNAL=0$
-^VERIFICATION SUCCESSFUL$
 --
 ^warning: ignoring

--- a/regression/cbmc-library/siglongjmp-01/main.c
+++ b/regression/cbmc-library/siglongjmp-01/main.c
@@ -1,9 +1,10 @@
-#include <assert.h>
 #include <setjmp.h>
+
+static sigjmp_buf env;
 
 int main()
 {
-  siglongjmp();
-  assert(0);
+  siglongjmp(env, 1);
+  __CPROVER_assert(0, "unreachable");
   return 0;
 }

--- a/regression/cbmc-library/siglongjmp-01/test.desc
+++ b/regression/cbmc-library/siglongjmp-01/test.desc
@@ -1,8 +1,10 @@
-KNOWNBUG
+CORE unix
 main.c
 --pointer-check --bounds-check
-^EXIT=0$
+^\[siglongjmp.assertion.1\] line 14 siglongjmp requires instrumentation: FAILURE$
+^\[main.assertion.1\] line 8 unreachable: SUCCESS$
+^VERIFICATION FAILED$
+^EXIT=10$
 ^SIGNAL=0$
-^VERIFICATION SUCCESSFUL$
 --
 ^warning: ignoring

--- a/regression/cbmc-library/sigsetjmp-01/main.c
+++ b/regression/cbmc-library/sigsetjmp-01/main.c
@@ -1,0 +1,12 @@
+#include <setjmp.h>
+
+static sigjmp_buf env;
+
+int main()
+{
+  if(sigsetjmp(env, 0))
+    __CPROVER_assert(0, "reached via siglongjmp");
+  else
+    __CPROVER_assert(0, "sigsetjmp called directly");
+  return 0;
+}

--- a/regression/cbmc-library/sigsetjmp-01/test.desc
+++ b/regression/cbmc-library/sigsetjmp-01/test.desc
@@ -1,0 +1,10 @@
+CORE unix
+main.c
+--pointer-check --bounds-check
+^\[main.assertion.1\] line 8 reached via siglongjmp: SUCCESS$
+^\[main.assertion.2\] line 10 sigsetjmp called directly: FAILURE$
+^VERIFICATION FAILED$
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring

--- a/src/ansi-c/library/setjmp.c
+++ b/src/ansi-c/library/setjmp.c
@@ -11,6 +11,7 @@ inline void longjmp(jmp_buf env, int val)
   // does not return
   (void)env;
   (void)val;
+  __CPROVER_assert(0, "longjmp requires instrumentation");
   __CPROVER_assume(0);
 }
 
@@ -26,10 +27,13 @@ inline void _longjmp(jmp_buf env, int val)
   // does not return
   (void)env;
   (void)val;
+  __CPROVER_assert(0, "_longjmp requires instrumentation");
   __CPROVER_assume(0);
 }
 
 /* FUNCTION: siglongjmp */
+
+#ifndef _WIN32
 
 #ifndef __CPROVER_SETJMP_H_INCLUDED
 #include <setjmp.h>
@@ -41,8 +45,11 @@ inline void siglongjmp(sigjmp_buf env, int val)
   // does not return
   (void)env;
   (void)val;
+  __CPROVER_assert(0, "siglongjmp requires instrumentation");
   __CPROVER_assume(0);
 }
+
+#endif
 
 /* FUNCTION: setjmp */
 
@@ -51,12 +58,69 @@ inline void siglongjmp(sigjmp_buf env, int val)
 #define __CPROVER_SETJMP_H_INCLUDED
 #endif
 
-int __VERIFIER_nondet_int();
+#undef setjmp
 
 inline int setjmp(jmp_buf env)
 {
-  // store PC
-  int retval=__VERIFIER_nondet_int();
   (void)env;
-  return retval;
+  // returns via longjmp require instrumentation; only such returns would
+  // return a non-zero value
+  return 0;
 }
+
+/* FUNCTION: _setjmp */
+
+#ifndef __CPROVER_SETJMP_H_INCLUDED
+#include <setjmp.h>
+#define __CPROVER_SETJMP_H_INCLUDED
+#endif
+
+inline int _setjmp(jmp_buf env)
+{
+  (void)env;
+  // returns via longjmp require instrumentation; only such returns would
+  // return a non-zero value
+  return 0;
+}
+
+/* FUNCTION: sigsetjmp */
+
+#ifndef _WIN32
+
+#ifndef __CPROVER_SETJMP_H_INCLUDED
+#  include <setjmp.h>
+#  define __CPROVER_SETJMP_H_INCLUDED
+#endif
+
+#undef sigsetjmp
+
+inline int sigsetjmp(sigjmp_buf env, int savesigs)
+{
+  (void)env;
+  (void)savesigs;
+  // returns via siglongjmp require instrumentation; only such returns would
+  // return a non-zero value
+  return 0;
+}
+
+#endif
+
+/* FUNCTION: __sigsetjmp */
+
+#ifndef _WIN32
+
+#ifndef __CPROVER_SETJMP_H_INCLUDED
+#  include <setjmp.h>
+#  define __CPROVER_SETJMP_H_INCLUDED
+#endif
+
+inline int __sigsetjmp(sigjmp_buf env, int savesigs)
+{
+  (void)env;
+  (void)savesigs;
+  // returns via siglongjmp require instrumentation; only such returns would
+  // return a non-zero value
+  return 0;
+}
+
+#endif


### PR DESCRIPTION
We require (yet to be built) instrumentation to handle longjmp (and its
variants). Therefore:

1) The only possible return value of `setjmp` (and its variants) is 0
for it can never be reached via longjmp (or its variants).
2) Fail an assertion when invoking longjmp to ensure we do not produce
unsound verification results when longjmp is reachable on some path.

Enable all related regression tests.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
