### PR TITLE
New test checking that __CPROVER_havoc_object are detected as writes

### DIFF
--- a/regression/contracts/assigns_enforce_havoc_object/main.c
+++ b/regression/contracts/assigns_enforce_havoc_object/main.c
@@ -1,0 +1,59 @@
+#include <assert.h>
+#include <stdlib.h>
+
+int x = 0;
+typedef struct stc
+{
+  int i;
+  int j;
+} stc;
+
+typedef struct stb
+{
+  stc *c;
+} stb;
+
+typedef struct sta
+{
+  union {
+    stb *b;
+    int i;
+    int j;
+  } u;
+} sta;
+
+int nondet_int();
+
+void bar(sta *a)
+{
+  if(nondet_bool())
+    return;
+  __CPROVER_havoc_object(a->u.b->c);
+  return;
+}
+
+void foo(sta *a1, sta *a2)
+  __CPROVER_assigns(__CPROVER_POINTER_OBJECT(a1->u.b->c))
+{
+  bar(a1);
+  bar(a2);
+  return;
+}
+
+sta *allocate_sta()
+{
+  stc *c = malloc(sizeof(*c));
+  stb *b = malloc(sizeof(*b));
+  sta *a = malloc(sizeof(*a));
+  b->c = c;
+  a->u.b = b;
+  return a;
+}
+
+int main()
+{
+  sta *a1 = allocate_sta();
+  sta *a2 = allocate_sta();
+  foo(a1, a2);
+  return 0;
+}

--- a/regression/contracts/assigns_enforce_havoc_object/test.desc
+++ b/regression/contracts/assigns_enforce_havoc_object/test.desc
@@ -1,0 +1,11 @@
+CORE
+main.c
+--enforce-contract foo
+^EXIT=10$
+^SIGNAL=0$
+^\[bar.\d+\] line \d+ Check that POINTER_OBJECT\(\(void \*\)a->u\.b->c\) is assignable: SUCCESS$
+^\[bar.\d+\] line \d+ Check that POINTER_OBJECT\(\(void \*\)a->u\.b->c\) is assignable: FAILURE$
+^VERIFICATION FAILED$
+--
+--
+Checks that __CPROVER_havoc_object(x) is detected as a write to POINTER_OBJECT(x).


### PR DESCRIPTION
New test checking that __CPROVER_havoc_object are detected as writes by assigns clause checking.

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.
