### PR TITLE
Crangler: silence lexer build warnings

### DIFF
--- a/src/crangler/scanner.l
+++ b/src/crangler/scanner.l
@@ -54,6 +54,16 @@ PreprocessorDirective           {PreprocessorStart}[^\r\n]*
 static int isatty(int) { return 0; }
 #endif
 
+#if defined _MSC_VER
+// signed/unsigned mismatch
+#pragma warning(disable:4365)
+// macro re-definition: flex conditonally defines INT32_MAX et al. and thus
+// they are set before library headers get to define them
+#pragma warning(disable:4005)
+#endif
+
+#include <util/pragma_wsign_compare.def>
+#include <util/pragma_wnull_conversion.def>
 #include <util/pragma_wdeprecated_register.def>
 
 #include <set>


### PR DESCRIPTION
Some versions of compilers (combined with particular flex variants) will
result in compiler warnings that we already silence for various others
lexers.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
