### PR TITLE
havoc call return value when replacing a call by its contract

### DIFF
--- a/regression/contracts/replace-nondet-return-value/main.c
+++ b/regression/contracts/replace-nondet-return-value/main.c
@@ -1,0 +1,23 @@
+int cmp(int i1, int i2)
+  // clang-format off
+  __CPROVER_ensures((i1 == i2) ==> (__CPROVER_return_value == 0))
+  __CPROVER_ensures((i1 != i2) ==> (__CPROVER_return_value == -1))
+// clang-format on
+{
+  if(i1 == i2)
+    return 0;
+  else
+    return -1;
+}
+
+int main()
+{
+  int ret = -1;
+  ret = cmp(0, 0);
+  __CPROVER_assert(ret == 0, "expecting SUCCESS");
+  ret = cmp(0, 1);
+  __CPROVER_assert(ret == 0, "expecting FAILURE");
+  __CPROVER_assert(ret == -1, "expecting SUCCESS");
+  __CPROVER_assert(0, "expecting FAILURE");
+  return 0;
+}

--- a/regression/contracts/replace-nondet-return-value/test.desc
+++ b/regression/contracts/replace-nondet-return-value/test.desc
@@ -1,0 +1,20 @@
+CORE
+main.c
+--replace-call-with-contract cmp
+^EXIT=10$
+^SIGNAL=0$
+^\[main\.assertion\.1\] line \d+ expecting SUCCESS: SUCCESS$
+^\[main\.assertion\.2\] line \d+ expecting FAILURE: FAILURE$
+^\[main\.assertion\.3\] line \d+ expecting SUCCESS: SUCCESS$
+^\[main\.assertion\.4\] line \d+ expecting FAILURE: FAILURE$
+^\*\* 2 of 4 failed
+^VERIFICATION FAILED$
+--
+--
+This test checks that the return value of a replaced function call is made 
+nondet at each replacement site.
+The replaced function is called twice. Each call is expected to have a different
+return value. If the return value of the call is not made nondet at each
+replacement, it would be subject to contradictory constraints
+(from the post conditions) and the assertions expected to fail would 
+be vacuously satisfied.


### PR DESCRIPTION
This PR adds havoc instructions for the return value of function call when it gets replaced by the function's contract.

This havocking was missing previously and could result in vacuous instances when a same function was replaced more than once in a same scope (e.g. in loops), and the same return value variable was subjected to a superposition of post-conditions that can be contradicting each other.

- [ x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ x] My PR is restricted to a single feature or bugfix.
- [ x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.
