### PR TITLE
Check inferred loop assigns clauses instead of blindly trusting them

### DIFF
--- a/regression/contracts/github_6168_infinite_unwinding_bug/test.desc
+++ b/regression/contracts/github_6168_infinite_unwinding_bug/test.desc
@@ -4,8 +4,8 @@ main.c
 ^EXIT=0$
 ^SIGNAL=0$
 ^VERIFICATION SUCCESSFUL$
-^\[main.1\] line \d+ Check loop invariant before entry: SUCCESS$
-^\[main.2\] line \d+ Check that loop invariant is preserved: SUCCESS$
+^\[main.\d+\] line \d+ Check loop invariant before entry: SUCCESS$
+^\[main.\d+\] line \d+ Check that loop invariant is preserved: SUCCESS$
 --
 --
 This is guarding against an issue described in https://github.com/diffblue/cbmc/issues/6168.

--- a/regression/contracts/invar_check_break_fail/test.desc
+++ b/regression/contracts/invar_check_break_fail/test.desc
@@ -3,9 +3,10 @@ main.c
 --apply-loop-contracts
 ^EXIT=10$
 ^SIGNAL=0$
-^\[main.1\] .* Check loop invariant before entry: SUCCESS$
-^\[main.2\] .* Check that loop invariant is preserved: SUCCESS$
-^\[main.assertion.1\] .* assertion r == 0: FAILURE$
+^\[main\.\d+\] .* Check loop invariant before entry: SUCCESS$
+^\[main\.\d+\] .* Check that loop invariant is preserved: SUCCESS$
+^\[main\.\d+\] .* Check that r is assignable: SUCCESS$
+^\[main\.assertion\.\d+\] .* assertion r == 0: FAILURE$
 ^VERIFICATION FAILED$
 --
 This test is expected to fail along the code path where r is an even integer

--- a/regression/contracts/invar_check_break_pass/test.desc
+++ b/regression/contracts/invar_check_break_pass/test.desc
@@ -3,9 +3,10 @@ main.c
 --apply-loop-contracts
 ^EXIT=0$
 ^SIGNAL=0$
-^\[main.1\] .* Check loop invariant before entry: SUCCESS$
-^\[main.2\] .* Check that loop invariant is preserved: SUCCESS$
-^\[main.assertion.1\] .* assertion r == 0 || r == 1: SUCCESS$
+^\[main\.\d+\] .* Check loop invariant before entry: SUCCESS$
+^\[main\.\d+\] .* Check that loop invariant is preserved: SUCCESS$
+^\[main\.\d+\] .* Check that r is assignable: SUCCESS$
+^\[main\.assertion\.\d+\] .* assertion r == 0 || r == 1: SUCCESS$
 ^VERIFICATION SUCCESSFUL$
 --
 This test checks that conditionals and `break` are correctly handled.

--- a/regression/contracts/invar_check_continue/test.desc
+++ b/regression/contracts/invar_check_continue/test.desc
@@ -3,9 +3,10 @@ main.c
 --apply-loop-contracts
 ^EXIT=0$
 ^SIGNAL=0$
-^\[main.1\] .* Check loop invariant before entry: SUCCESS$
-^\[main.2\] .* Check that loop invariant is preserved: SUCCESS$
-^\[main.assertion.1\] .* assertion r == 0: SUCCESS$
+^\[main\.\d+\] .* Check loop invariant before entry: SUCCESS$
+^\[main\.\d+\] .* Check that loop invariant is preserved: SUCCESS$
+^\[main\.\d+\] .* Check that r is assignable: SUCCESS$
+^\[main\.assertion\.\d+\] .* assertion r == 0: SUCCESS$
 ^VERIFICATION SUCCESSFUL$
 --
 This test checks that conditionals and `continue` are correctly handled.

--- a/regression/contracts/invar_check_multiple_loops/test.desc
+++ b/regression/contracts/invar_check_multiple_loops/test.desc
@@ -3,13 +3,17 @@ main.c
 --apply-loop-contracts
 ^EXIT=0$
 ^SIGNAL=0$
-^\[main.1\] .* Check loop invariant before entry: SUCCESS$
-^\[main.2\] .* Check that loop invariant is preserved: SUCCESS$
-^\[main.3\] .* Check decreases clause on loop iteration: SUCCESS$
-^\[main.4\] .* Check loop invariant before entry: SUCCESS$
-^\[main.5\] .* Check that loop invariant is preserved: SUCCESS$
-^\[main.6\] .* Check decreases clause on loop iteration: SUCCESS$
-^\[main.assertion.1\] .* assertion x == y \+ 2 \* n: SUCCESS$
+^\[main\.\d+\] .* Check loop invariant before entry: SUCCESS$
+^\[main\.\d+\] .* Check that loop invariant is preserved: SUCCESS$
+^\[main\.\d+\] .* Check decreases clause on loop iteration: SUCCESS$
+^\[main\.\d+\] .* Check loop invariant before entry: SUCCESS$
+^\[main\.\d+\] .* Check that loop invariant is preserved: SUCCESS$
+^\[main\.\d+\] .* Check decreases clause on loop iteration: SUCCESS$
+^\[main\.assertion\.\d+\] .* assertion x == y \+ 2 \* n: SUCCESS$
+^\[main\.\d+\] line 8 Check that r is assignable: SUCCESS$
+^\[main\.\d+\] line 15 Check that x is assignable: SUCCESS$
+^\[main\.\d+\] line 23 Check that y is assignable: SUCCESS$
+^\[main\.\d+\] line 24 Check that r is assignable: SUCCESS$
 ^VERIFICATION SUCCESSFUL$
 --
 This test checks that multiple loops and `for` loops are correctly handled.

--- a/regression/contracts/invar_check_nested_loops/test.desc
+++ b/regression/contracts/invar_check_nested_loops/test.desc
@@ -3,13 +3,16 @@ main.c
 --apply-loop-contracts
 ^EXIT=0$
 ^SIGNAL=0$
-^\[main.1\] .* Check loop invariant before entry: SUCCESS$
-^\[main.5\] .* Check that loop invariant is preserved: SUCCESS$
-^\[main.6\] .* Check decreases clause on loop iteration: SUCCESS$
-^\[main.2\] .* Check loop invariant before entry: SUCCESS$
-^\[main.3\] .* Check that loop invariant is preserved: SUCCESS$
-^\[main.4\] .* Check decreases clause on loop iteration: SUCCESS$
-^\[main.assertion.1\] .* assertion s == n: SUCCESS$
+^\[main\.\d+\] .* Check loop invariant before entry: SUCCESS$
+^\[main\.\d+\] .* Check that loop invariant is preserved: SUCCESS$
+^\[main\.\d+\] .* Check decreases clause on loop iteration: SUCCESS$
+^\[main\.\d+\] .* Check loop invariant before entry: SUCCESS$
+^\[main\.\d+\] .* Check that loop invariant is preserved: SUCCESS$
+^\[main\.\d+\] .* Check decreases clause on loop iteration: SUCCESS$
+^\[main\.\d+] line 23 Check that s is assignable: SUCCESS$
+^\[main\.\d+] line 24 Check that a is assignable: SUCCESS$
+^\[main\.\d+] line 27 Check that s is assignable: SUCCESS$
+^\[main\.assertion.\d+\] .* assertion s == n: SUCCESS$
 ^VERIFICATION SUCCESSFUL$
 --
 This test checks that nested loops, `for` loops,

--- a/regression/contracts/invar_check_pointer_modifies-01/test.desc
+++ b/regression/contracts/invar_check_pointer_modifies-01/test.desc
@@ -3,9 +3,11 @@ main.c
 --apply-loop-contracts --pointer-check
 ^EXIT=0$
 ^SIGNAL=0$
-^\[main.1\] .* Check loop invariant before entry: SUCCESS$
-^\[main.2\] .* Check that loop invariant is preserved: SUCCESS$
-^\[main.assertion.1\] .* assertion \*data = 42: SUCCESS$
+^\[main\.\d+\] .* Check loop invariant before entry: SUCCESS$
+^\[main\.\d+\] .* Check that loop invariant is preserved: SUCCESS$
+^\[main\.\d+] .* Check that \*data is assignable: SUCCESS$
+^\[main\.\d+] .* Check that i is assignable: SUCCESS$
+^\[main\.assertion\.\d+\] .* assertion \*data = 42: SUCCESS$
 ^VERIFICATION SUCCESSFUL$
 --
 ^\[main.pointer_dereference.*\] line .* dereference failure: pointer NULL in \*data: FAILURE

--- a/regression/contracts/invar_check_pointer_modifies-02/test.desc
+++ b/regression/contracts/invar_check_pointer_modifies-02/test.desc
@@ -3,10 +3,12 @@ main.c
 --apply-loop-contracts --pointer-check
 ^EXIT=0$
 ^SIGNAL=0$
-^\[main.1\] .* Check loop invariant before entry: SUCCESS$
-^\[main.2\] .* Check that loop invariant is preserved: SUCCESS$
-^\[main.assertion.1\] .* assertion data == copy: SUCCESS$
-^\[main.assertion.2\] .* assertion \*copy = 42: SUCCESS$
+^\[main\.\d+\] .* Check loop invariant before entry: SUCCESS$
+^\[main\.\d+\] .* Check that loop invariant is preserved: SUCCESS$
+^\[main\.\d+\] .* Check that \*data is assignable: SUCCESS$
+^\[main\.\d+\] .* Check that i is assignable: SUCCESS$
+^\[main\.assertion\.\d+\] .* assertion data == copy: SUCCESS$
+^\[main\.assertion\.\d+\] .* assertion \*copy = 42: SUCCESS$
 ^VERIFICATION SUCCESSFUL$
 --
 ^\[main.pointer_dereference.*\] line .* dereference failure: pointer NULL in \*data: FAILURE

--- a/regression/contracts/invar_check_sufficiency/test.desc
+++ b/regression/contracts/invar_check_sufficiency/test.desc
@@ -3,9 +3,10 @@ main.c
 --apply-loop-contracts
 ^EXIT=0$
 ^SIGNAL=0$
-^\[main.1\] .* Check loop invariant before entry: SUCCESS$
-^\[main.2\] .* Check that loop invariant is preserved: SUCCESS$
-^\[main.assertion.1\] .* assertion r == 0: SUCCESS$
+^\[main\.\d+\] .* Check loop invariant before entry: SUCCESS$
+^\[main\.\d+\] .* Check that loop invariant is preserved: SUCCESS$
+^\[main\.\d+\] .* Check that r is assignable: SUCCESS$
+^\[main\.assertion\.1\] .* assertion r == 0: SUCCESS$
 ^VERIFICATION SUCCESSFUL$
 --
 This test checks that a loop invariant can be proven to be inductive,

--- a/regression/contracts/invar_dynamic_struct_member/test.desc
+++ b/regression/contracts/invar_dynamic_struct_member/test.desc
@@ -3,8 +3,11 @@ main.c
 --apply-loop-contracts
 ^EXIT=10$
 ^SIGNAL=0$
-^\[main.1\] .* Check loop invariant before entry: SUCCESS$
-^\[main.2\] .* Check that loop invariant is preserved: SUCCESS$
+^\[main\.\d+\] .* Check loop invariant before entry: SUCCESS$
+^\[main\.\d+\] .* Check that loop invariant is preserved: SUCCESS$
+^\[main\.\d+\] .* Check that i is assignable: SUCCESS$
+^\[main\.\d+\] line 22 Check that t->x is assignable: SUCCESS$
+^\[main\.\d+\] line 25 Check that t->x is assignable: SUCCESS$
 ^\[main.assertion.1\] .* assertion .*: FAILURE$
 ^VERIFICATION FAILED$
 --

--- a/regression/contracts/invar_havoc_dynamic_array/main.c
+++ b/regression/contracts/invar_havoc_dynamic_array/main.c
@@ -9,7 +9,10 @@ void main()
   data[5] = 0;
 
   for(unsigned i = 0; i < SIZE; i++)
+    // clang-format off
+    __CPROVER_assigns(i, __CPROVER_POINTER_OBJECT(data))
     __CPROVER_loop_invariant(i <= SIZE)
+    // clang-format on
     {
       data[i] = 1;
     }

--- a/regression/contracts/invar_havoc_dynamic_array/test.desc
+++ b/regression/contracts/invar_havoc_dynamic_array/test.desc
@@ -3,10 +3,12 @@ main.c
 --apply-loop-contracts
 ^EXIT=10$
 ^SIGNAL=0$
-^\[main.1\] .* Check loop invariant before entry: SUCCESS$
-^\[main.2\] .* Check that loop invariant is preserved: SUCCESS$
-^\[main.assertion.1\] .* assertion data\[5\] == 0: FAILURE$
-^\[main.assertion.2\] .* assertion data\[5\] == 1: FAILURE$
+^\[main\.\d+\] .* Check loop invariant before entry: SUCCESS$
+^\[main\.\d+\] .* Check that loop invariant is preserved: SUCCESS$
+^\[main\.\d+\] .* Check that i is assignable: SUCCESS$
+^\[main\.\d+\] .* Check that data\[\(signed long (long )?int\)i\] is assignable: SUCCESS$
+^\[main\.assertion\.\d+\] .* assertion data\[5\] == 0: FAILURE$
+^\[main\.assertion\.\d+\] .* assertion data\[5\] == 1: FAILURE$
 ^VERIFICATION FAILED$
 --
 --

--- a/regression/contracts/invar_havoc_dynamic_array_const_idx/test.desc
+++ b/regression/contracts/invar_havoc_dynamic_array_const_idx/test.desc
@@ -3,10 +3,12 @@ main.c
 --apply-loop-contracts
 ^EXIT=10$
 ^SIGNAL=0$
-^\[main.1\] .* Check loop invariant before entry: SUCCESS$
-^\[main.2\] .* Check that loop invariant is preserved: SUCCESS$
-^\[main.assertion.1\] .* assertion data\[1\] == 0 \|\| data\[1\] == 1: FAILURE$
-^\[main.assertion.2\] .* assertion data\[4\] == 0: SUCCESS$
+^\[main\.\d+\] .* Check loop invariant before entry: SUCCESS$
+^\[main\.\d+\] .* Check that loop invariant is preserved: SUCCESS$
+^\[main\.\d+\] .* Check that i is assignable: SUCCESS$
+^\[main\.\d+\] .* Check that data\[\(signed long (long )?int\)1\] is assignable: SUCCESS$
+^\[main\.assertion\.\d+\] .* assertion data\[1\] == 0 \|\| data\[1\] == 1: FAILURE$
+^\[main\.assertion\.\d+\] .* assertion data\[4\] == 0: SUCCESS$
 ^VERIFICATION FAILED$
 --
 --

--- a/regression/contracts/invar_havoc_static_array/main.c
+++ b/regression/contracts/invar_havoc_static_array/main.c
@@ -9,7 +9,10 @@ void main()
   data[5] = 0;
 
   for(unsigned i = 0; i < SIZE; i++)
+    // clang-format off
+    __CPROVER_assigns(i, __CPROVER_POINTER_OBJECT(data))
     __CPROVER_loop_invariant(i <= SIZE)
+    // clang-format on
     {
       data[i] = 1;
     }

--- a/regression/contracts/invar_havoc_static_array/test.desc
+++ b/regression/contracts/invar_havoc_static_array/test.desc
@@ -3,10 +3,12 @@ main.c
 --apply-loop-contracts
 ^EXIT=10$
 ^SIGNAL=0$
-^\[main.1\] .* Check loop invariant before entry: SUCCESS$
-^\[main.2\] .* Check that loop invariant is preserved: SUCCESS$
-^\[main.assertion.1\] .* assertion data\[5\] == 0: FAILURE$
-^\[main.assertion.2\] .* assertion data\[5\] == 1: FAILURE$
+^\[main\.\d+\] .* Check loop invariant before entry: SUCCESS$
+^\[main\.\d+\] .* Check that loop invariant is preserved: SUCCESS$
+^\[main\.\d+\] .* Check that i is assignable: SUCCESS$
+^\[main\.\d+\] .* Check that data\[\(signed long (long )?int\)i\] is assignable: SUCCESS$
+^\[main\.assertion\.\d+\] .* assertion data\[5\] == 0: FAILURE$
+^\[main\.assertion\.\d+\] .* assertion data\[5\] == 1: FAILURE$
 ^VERIFICATION FAILED$
 --
 --

--- a/regression/contracts/invar_havoc_static_array_const_idx/test.desc
+++ b/regression/contracts/invar_havoc_static_array_const_idx/test.desc
@@ -3,10 +3,12 @@ main.c
 --apply-loop-contracts
 ^EXIT=10$
 ^SIGNAL=0$
-^\[main.1\] .* Check loop invariant before entry: SUCCESS$
-^\[main.2\] .* Check that loop invariant is preserved: SUCCESS$
-^\[main.assertion.1\] .* assertion data\[1\] == 0 \|\| data\[1\] == 1: FAILURE$
-^\[main.assertion.2\] .* assertion data\[4\] == 0: SUCCESS$
+^\[main\.\d+\] .* Check loop invariant before entry: SUCCESS$
+^\[main\.\d+\] .* Check that loop invariant is preserved: SUCCESS$
+^\[main\.\d+\] .* Check that i is assignable: SUCCESS$
+^\[main\.\d+\] .* Check that data\[\(signed long (long )?int\)1\] is assignable: SUCCESS$
+^\[main\.assertion\.\d+\] .* assertion data\[1\] == 0 \|\| data\[1\] == 1: FAILURE$
+^\[main\.assertion\.\d+\] .* assertion data\[4\] == 0: SUCCESS$
 ^VERIFICATION FAILED$
 --
 --

--- a/regression/contracts/invar_havoc_static_multi-dim_array/test.desc
+++ b/regression/contracts/invar_havoc_static_multi-dim_array/test.desc
@@ -3,10 +3,10 @@ main.c
 --apply-loop-contracts
 ^EXIT=10$
 ^SIGNAL=0$
-^\[main.1\] .* Check loop invariant before entry: SUCCESS$
-^\[main.2\] .* Check that loop invariant is preserved: SUCCESS$
-^\[main.assertion.1\] .* assertion __CPROVER_same_object\(old_data123, &\(data\[1\]\[2\]\[3\]\)\): SUCCESS$
-^\[main.assertion.2\] .* assertion data\[1\]\[2\]\[3\] == 0: FAILURE$
+^\[main\.\d+\] .* Check loop invariant before entry: SUCCESS$
+^\[main\.\d+\] .* Check that loop invariant is preserved: SUCCESS$
+^\[main\.assertion\.\d+\] .* assertion __CPROVER_same_object\(old_data123, &\(data\[1\]\[2\]\[3\]\)\): SUCCESS$
+^\[main\.assertion\.\d+\] .* assertion data\[1\]\[2\]\[3\] == 0: FAILURE$
 ^VERIFICATION FAILED$
 --
 --

--- a/regression/contracts/invar_havoc_static_multi-dim_array_all_const_idx/test.desc
+++ b/regression/contracts/invar_havoc_static_multi-dim_array_all_const_idx/test.desc
@@ -3,10 +3,11 @@ main.c
 --apply-loop-contracts
 ^EXIT=10$
 ^SIGNAL=0$
-^\[main.1\] .* Check loop invariant before entry: SUCCESS$
-^\[main.2\] .* Check that loop invariant is preserved: SUCCESS$
-^\[main.assertion.1\] .* assertion data\[4\]\[5\]\[6\] == 0: FAILURE$
-^\[main.assertion.2\] .* assertion data\[1\]\[2\]\[3\] == 0: SUCCESS$
+^\[main\.\d+\] .* Check loop invariant before entry: SUCCESS$
+^\[main\.\d+\] .* Check that loop invariant is preserved: SUCCESS$
+^\[main\.\d+\] .* Check that data\[\(signed long (long )?int\)4\]\[\(signed long (long )?int\)5\]\[\(signed long (long )?int\)6\] is assignable: SUCCESS$
+^\[main\.assertion\.\d+\] .* assertion data\[4\]\[5\]\[6\] == 0: FAILURE$
+^\[main\.assertion\.\d+\] .* assertion data\[1\]\[2\]\[3\] == 0: SUCCESS$
 ^VERIFICATION FAILED$
 --
 --

--- a/regression/contracts/invar_havoc_static_multi-dim_array_partial_const_idx/main.c
+++ b/regression/contracts/invar_havoc_static_multi-dim_array_partial_const_idx/main.c
@@ -11,7 +11,8 @@ void main()
   data[4][5][6] = 0;
 
   for(unsigned i = 0; i < SIZE; i++)
-    __CPROVER_loop_invariant(i <= SIZE)
+    __CPROVER_assigns(i, __CPROVER_POINTER_OBJECT(data))
+      __CPROVER_loop_invariant(i <= SIZE)
     {
       data[4][i][6] = 1;
     }

--- a/regression/contracts/invar_havoc_static_multi-dim_array_partial_const_idx/test.desc
+++ b/regression/contracts/invar_havoc_static_multi-dim_array_partial_const_idx/test.desc
@@ -3,10 +3,12 @@ main.c
 --apply-loop-contracts
 ^EXIT=10$
 ^SIGNAL=0$
-^\[main.1\] .* Check loop invariant before entry: SUCCESS$
-^\[main.2\] .* Check that loop invariant is preserved: SUCCESS$
-^\[main.assertion.1\] .* assertion data\[1\]\[2\]\[3\] == 0: FAILURE$
-^\[main.assertion.2\] .* assertion data\[4\]\[5\]\[6\] == 0: FAILURE$
+^\[main\.\d+\] .* Check loop invariant before entry: SUCCESS$
+^\[main\.\d+\] .* Check that loop invariant is preserved: SUCCESS$
+^\[main\.\d+\] .* Check that i is assignable: SUCCESS$
+^\[main\.\d+\] .* Check that data\[\(signed long (long )?int\)4\]\[\(signed long (long )?int\)i\]\[\(signed long (long )?int\)6\] is assignable: SUCCESS$
+^\[main\.assertion\.\d+\] .* assertion data\[1\]\[2\]\[3\] == 0: FAILURE$
+^\[main\.assertion\.\d+\] .* assertion data\[4\]\[5\]\[6\] == 0: FAILURE$
 ^VERIFICATION FAILED$
 --
 --

--- a/regression/contracts/invar_loop-entry_check/test.desc
+++ b/regression/contracts/invar_loop-entry_check/test.desc
@@ -3,15 +3,24 @@ main.c
 --apply-loop-contracts _ --pointer-primitive-check
 ^EXIT=0$
 ^SIGNAL=0$
-^\[main.1\] .* Check loop invariant before entry: SUCCESS$
-^\[main.2\] .* Check that loop invariant is preserved: SUCCESS$
-^\[main.assertion.1\] .* assertion \*x1 == z1: SUCCESS$
-^\[main.3\] .* Check loop invariant before entry: SUCCESS$
-^\[main.4\] .* Check that loop invariant is preserved: SUCCESS$
-^\[main.assertion.2\] .* assertion x2 == z2: SUCCESS$
-^\[main.5\] .* Check loop invariant before entry: SUCCESS$
-^\[main.6\] .* Check that loop invariant is preserved: SUCCESS$
-^\[main.assertion.3\] .* assertion \*\(s1\.n\) == \*\(s2->n\): SUCCESS$
+^\[main\.\d+\] .* Check loop invariant before entry: SUCCESS$
+^\[main\.\d+\] .* Check that loop invariant is preserved: SUCCESS$
+^\[main\.assertion\.\d+\] .* assertion \*x1 == z1: SUCCESS$
+^\[main\.\d+\] .* Check loop invariant before entry: SUCCESS$
+^\[main\.\d+\] .* Check that loop invariant is preserved: SUCCESS$
+^\[main\.assertion\.\d+\] .* assertion x2 == z2: SUCCESS$
+^\[main\.\d+\] .* Check loop invariant before entry: SUCCESS$
+^\[main\.\d+\] .* Check that loop invariant is preserved: SUCCESS$
+^\[main\.\d+\] .* Check that y1 is assignable: SUCCESS$
+^\[main\.\d+\] line 18 Check that \*x1 is assignable: SUCCESS$
+^\[main\.\d+\] line 19 Check that \*x1 is assignable: SUCCESS$
+^\[main\.\d+\] .* Check that y2 is assignable: SUCCESS$
+^\[main\.\d+\] line 30 Check that x2 is assignable: SUCCESS$
+^\[main\.\d+\] line 31 Check that x2 is assignable: SUCCESS$
+^\[main\.\d+\] .* Check that y3 is assignable: SUCCESS$
+^\[main\.\d+\] .* Check that s0\.n is assignable: SUCCESS$
+^\[main\.\d+\] .* Check that s2->n is assignable: SUCCESS$
+^\[main\.assertion\.\d+\] .* assertion \*\(s1\.n\) == \*\(s2->n\): SUCCESS$
 ^VERIFICATION SUCCESSFUL$
 --
 --

--- a/regression/contracts/invar_loop-entry_fail/test.desc
+++ b/regression/contracts/invar_loop-entry_fail/test.desc
@@ -3,8 +3,11 @@ main.c
 --apply-loop-contracts
 ^EXIT=(10|6)$
 ^SIGNAL=0$
-^\[main.1\] .* Check loop invariant before entry: SUCCESS$
-^\[main.2\] .* Check that loop invariant is preserved: FAILURE$
+^\[main\.\d+\] .* Check loop invariant before entry: SUCCESS$
+^\[main\.\d+\] .* Check that loop invariant is preserved: FAILURE$
+^\[main\.\d+\] line 11 Check that y is assignable: SUCCESS$
+^\[main\.\d+\] line 12 Check that x is assignable: SUCCESS$
+^\[main\.\d+\] line 13 Check that x is assignable: SUCCESS$
 ^VERIFICATION FAILED$
 --
 --

--- a/regression/contracts/invar_loop_constant_fail/test.desc
+++ b/regression/contracts/invar_loop_constant_fail/test.desc
@@ -3,10 +3,12 @@ main.c
 --apply-loop-contracts
 ^EXIT=10$
 ^SIGNAL=0$
-^\[main.1\] .* Check loop invariant before entry: SUCCESS$
-^\[main.2\] .* Check that loop invariant is preserved: SUCCESS$
-^\[main.assertion.1\] .* assertion r == 0: SUCCESS$
-^\[main.assertion.2\] .* assertion s == 1: FAILURE$
+^\[main\.\d+\] .* Check loop invariant before entry: SUCCESS$
+^\[main\.\d+\] .* Check that loop invariant is preserved: SUCCESS$
+^\[main\.\d+\] .* Check that s is assignable: SUCCESS$
+^\[main\.\d+\] .* Check that r is assignable: SUCCESS$
+^\[main\.assertion\.\d+\] .* assertion r == 0: SUCCESS$
+^\[main\.assertion\.\d+\] .* assertion s == 1: FAILURE$
 ^VERIFICATION FAILED$
 --
 This test is expected to fail because it modifies a variable within a loop,

--- a/regression/contracts/invar_loop_constant_no_modify/test.desc
+++ b/regression/contracts/invar_loop_constant_no_modify/test.desc
@@ -3,10 +3,11 @@ main.c
 --apply-loop-contracts
 ^EXIT=0$
 ^SIGNAL=0$
-^\[main.1\] .* Check loop invariant before entry: SUCCESS$
-^\[main.2\] .* Check that loop invariant is preserved: SUCCESS$
-^\[main.assertion.1\] .* assertion r == 0: SUCCESS$
-^\[main.assertion.2\] .* assertion s == 1: SUCCESS$
+^\[main\.\d+\] .* Check loop invariant before entry: SUCCESS$
+^\[main\.\d+\] .* Check that loop invariant is preserved: SUCCESS$
+^\[main\.\d+\] .* Check that r is assignable: SUCCESS$
+^\[main\.assertion\.\d+\] .* assertion r == 0: SUCCESS$
+^\[main\.assertion\.\d+\] .* assertion s == 1: SUCCESS$
 ^VERIFICATION SUCCESSFUL$
 --
 This test checks that variables that are not modified within the loop

--- a/regression/contracts/invar_loop_constant_pass/test.desc
+++ b/regression/contracts/invar_loop_constant_pass/test.desc
@@ -3,10 +3,12 @@ main.c
 --apply-loop-contracts
 ^EXIT=0$
 ^SIGNAL=0$
-^\[main.1\] .* Check loop invariant before entry: SUCCESS$
-^\[main.2\] .* Check that loop invariant is preserved: SUCCESS$
-^\[main.assertion.1\] .* assertion r == 0: SUCCESS$
-^\[main.assertion.2\] .* assertion s == 1: SUCCESS$
+^\[main\.\d+\] .* Check loop invariant before entry: SUCCESS$
+^\[main\.\d+\] .* Check that loop invariant is preserved: SUCCESS$
+^\[main\.\d+\] .* Check that s is assignable: SUCCESS$
+^\[main\.\d+\] .* Check that r is assignable: SUCCESS$
+^\[main\.assertion\.\d+\] .* assertion r == 0: SUCCESS$
+^\[main\.assertion\.\d+\] .* assertion s == 1: SUCCESS$
 ^VERIFICATION SUCCESSFUL$
 --
 This test checks that the invariant is correctly used to satisfy

--- a/regression/contracts/invar_struct_member/test.desc
+++ b/regression/contracts/invar_struct_member/test.desc
@@ -3,9 +3,10 @@ main.c
 --apply-loop-contracts
 ^EXIT=10$
 ^SIGNAL=0$
-^\[main.1\] .* Check loop invariant before entry: SUCCESS$
-^\[main.2\] .* Check that loop invariant is preserved: SUCCESS$
-^\[main.assertion.1\] .* assertion t.x == 0 || t.x == 2: FAILURE$
+^\[main\.\d+\] .* Check loop invariant before entry: SUCCESS$
+^\[main\.\d+\] .* Check that loop invariant is preserved: SUCCESS$
+^\[main\.\d+\] .* Check that t\.x is assignable: SUCCESS$
+^\[main\.assertion\.\d+\] .* assertion t.x == 0 || t.x == 2: FAILURE$
 ^VERIFICATION FAILED$
 --
 --

--- a/regression/contracts/invariant_side_effects/test.desc
+++ b/regression/contracts/invariant_side_effects/test.desc
@@ -3,9 +3,10 @@ main.c
 --apply-loop-contracts
 ^EXIT=0$
 ^SIGNAL=0$
-^\[main.1\] .* Check loop invariant before entry: SUCCESS$
-^\[main.2\] .* Check that loop invariant is preserved: SUCCESS$
-^\[main.assertion.1\] .* assertion \*a == N: SUCCESS$
+^\[main\.\d+\] .* Check loop invariant before entry: SUCCESS$
+^\[main\.\d+\] .* Check that loop invariant is preserved: SUCCESS$
+^\[main\.\d+\] .* Check that \*a is assignable: SUCCESS$
+^\[main\.assertion\.\d+\] .* assertion \*a == N: SUCCESS$
 ^VERIFICATION SUCCESSFUL$
 --
 This test checks that C expressions are correctly converted to logic

--- a/regression/contracts/loop_contracts_binary_search/test.desc
+++ b/regression/contracts/loop_contracts_binary_search/test.desc
@@ -3,10 +3,13 @@ main.c
 --apply-loop-contracts _ --pointer-check --bounds-check --signed-overflow-check
 ^EXIT=0$
 ^SIGNAL=0$
-^\[binary_search.1\] .* Check loop invariant before entry: SUCCESS$
-^\[binary_search.2\] .* Check that loop invariant is preserved: SUCCESS$
-^\[binary_search.3\] .* Check decreases clause on loop iteration: SUCCESS$
-^\[main.assertion.1\] .* assertion buf\[idx\] == val: SUCCESS$
+^\[binary_search\.\d+\] .* Check loop invariant before entry: SUCCESS$
+^\[binary_search\.\d+\] .* Check that loop invariant is preserved: SUCCESS$
+^\[binary_search\.\d+\] .* Check decreases clause on loop iteration: SUCCESS$
+^\[binary_search\.2\] .* Check that lb is assignable: SUCCESS$
+^\[binary_search\.3\] .* Check that ub is assignable: SUCCESS$
+^\[binary_search\.4\] .* Check that mid is assignable: SUCCESS$
+^\[main\.assertion\.\d+\] .* assertion buf\[idx\] == val: SUCCESS$
 ^VERIFICATION SUCCESSFUL$
 --
 --

--- a/regression/contracts/quantifiers-loop-01/main.c
+++ b/regression/contracts/quantifiers-loop-01/main.c
@@ -9,6 +9,7 @@ void main()
 
   for(int i = 0; i < N; ++i)
     // clang-format off
+    __CPROVER_assigns(i, __CPROVER_POINTER_OBJECT(a))
     __CPROVER_loop_invariant(
       (0 <= i) && (i <= N) &&
       __CPROVER_forall {

--- a/regression/contracts/quantifiers-loop-01/test.desc
+++ b/regression/contracts/quantifiers-loop-01/test.desc
@@ -3,9 +3,11 @@ main.c
 --apply-loop-contracts
 ^EXIT=0$
 ^SIGNAL=0$
-^\[main.1\] line .* Check loop invariant before entry: SUCCESS
-^\[main.2\] line .* Check that loop invariant is preserved: SUCCESS
-^\[main.assertion.1\] line .* assertion a\[10\] == 1: SUCCESS
+^\[main\.\d+\] line .* Check loop invariant before entry: SUCCESS$
+^\[main\.\d+\] line .* Check that loop invariant is preserved: SUCCESS$
+^\[main\.\d+\] line .* Check that i is assignable: SUCCESS$
+^\[main\.\d+\] line .* Check that a\[\(signed long (long )?int\)i\] is assignable: SUCCESS$
+^\[main\.assertion\.\d+\] line .* assertion a\[10\] == 1: SUCCESS$
 ^VERIFICATION SUCCESSFUL$
 --
 ^warning: ignoring

--- a/regression/contracts/quantifiers-loop-02/main.c
+++ b/regression/contracts/quantifiers-loop-02/main.c
@@ -1,12 +1,14 @@
 #include <assert.h>
 
+#define MAX_ARRAY_SIZE 3
 void main()
 {
-  int N, a[64];
-  __CPROVER_assume(0 <= N && N < 64);
+  int N, a[MAX_ARRAY_SIZE];
+  __CPROVER_assume(0 <= N && N < MAX_ARRAY_SIZE);
 
   for(int i = 0; i < N; ++i)
     // clang-format off
+    __CPROVER_assigns(i, __CPROVER_POINTER_OBJECT(a))
     __CPROVER_loop_invariant(
       (0 <= i) && (i <= N) &&
       __CPROVER_forall {

--- a/regression/contracts/quantifiers-loop-02/test.desc
+++ b/regression/contracts/quantifiers-loop-02/test.desc
@@ -1,11 +1,13 @@
-CORE smt-backend broken-cprover-smt-backend
+CORE smt-backend broken-cprover-smt-backend thorough-smt-backend
 main.c
 --apply-loop-contracts _ --z3
 ^EXIT=0$
 ^SIGNAL=0$
-^\[main.\d+\] line .* Check loop invariant before entry: SUCCESS
-^\[main.\d+\] line .* Check that loop invariant is preserved: SUCCESS
-^\[main.assertion.\d+\] line .* assertion .*: SUCCESS
+^\[main.\d+\] line .* Check loop invariant before entry: SUCCESS$
+^\[main.\d+\] line .* Check that loop invariant is preserved: SUCCESS$
+^\[main\.\d+\] line .* Check that i is assignable: SUCCESS$
+^\[main\.\d+\] line .* Check that a\[\(signed long (long )?int\)i\] is assignable: SUCCESS$
+^\[main.assertion.\d+\] line .* assertion .*: SUCCESS$
 ^VERIFICATION SUCCESSFUL$
 --
 ^warning: ignoring

--- a/regression/contracts/quantifiers-loop-03/main.c
+++ b/regression/contracts/quantifiers-loop-03/main.c
@@ -6,12 +6,13 @@
 void main()
 {
   unsigned N;
-  __CPROVER_assume(N <= MAX_SIZE);
+  __CPROVER_assume(0 < N && N <= MAX_SIZE);
 
   int *a = malloc(N * sizeof(int));
 
   for(int i = 0; i < N; ++i)
     // clang-format off
+    __CPROVER_assigns(i, __CPROVER_POINTER_OBJECT(a))
     __CPROVER_loop_invariant(
       (0 <= i) && (i <= N) &&
       (i != 0 ==> __CPROVER_exists {

--- a/regression/contracts/quantifiers-loop-03/test.desc
+++ b/regression/contracts/quantifiers-loop-03/test.desc
@@ -3,9 +3,11 @@ main.c
 --apply-loop-contracts
 ^EXIT=0$
 ^SIGNAL=0$
-^\[main.1\] line .* Check loop invariant before entry: SUCCESS
-^\[main.2\] line .* Check that loop invariant is preserved: SUCCESS
-^\[main.assertion.1\] line .* assertion .*: SUCCESS
+^\[main\.\d+\] .* Check loop invariant before entry: SUCCESS$
+^\[main\.\d+\] .* Check that loop invariant is preserved: SUCCESS$
+^\[main\.\d+\] .* Check that i is assignable: SUCCESS$
+^\[main\.\d+\] .* Check that a\[\(signed long (long )?int\)i\] is assignable: SUCCESS$
+^\[main\.assertion\.\d+\] line .* assertion .*: SUCCESS$
 ^VERIFICATION SUCCESSFUL$
 --
 ^warning: ignoring

--- a/regression/contracts/variant_init_inside_loop/test.desc
+++ b/regression/contracts/variant_init_inside_loop/test.desc
@@ -1,12 +1,13 @@
 CORE
 main.c
 --apply-loop-contracts _ --unsigned-overflow-check
-^\[main.1\] .* Check loop invariant before entry: SUCCESS$
-^\[main.2\] .* Check that loop invariant is preserved: SUCCESS$
-^\[main.3\] .* Check decreases clause on loop iteration: SUCCESS$
-^\[main.overflow.1\] .* arithmetic overflow on unsigned - in max - i: SUCCESS$
-^\[main.overflow.3\] .* arithmetic overflow on unsigned - in max - i: SUCCESS$
-^\[main.overflow.2\] .* arithmetic overflow on unsigned \+ in i \+ 1u: SUCCESS$
+^\[main\.\d+\] .* Check loop invariant before entry: SUCCESS$
+^\[main\.\d+\] .* Check that loop invariant is preserved: SUCCESS$
+^\[main\.\d+\] .* Check decreases clause on loop iteration: SUCCESS$
+^\[main\.2\] .* Check that i is assignable: SUCCESS$
+^\[main\.overflow\.1\] .* arithmetic overflow on unsigned - in max - i: SUCCESS$
+^\[main\.overflow\.3\] .* arithmetic overflow on unsigned - in max - i: SUCCESS$
+^\[main\.overflow\.2\] .* arithmetic overflow on unsigned \+ in i \+ 1u: SUCCESS$
 ^VERIFICATION SUCCESSFUL$
 ^EXIT=0$
 ^SIGNAL=0$

--- a/regression/contracts/variant_missing_invariant_warning/test.desc
+++ b/regression/contracts/variant_missing_invariant_warning/test.desc
@@ -3,9 +3,10 @@ main.c
 --apply-loop-contracts
 activate-multi-line-match
 ^The loop at file main.c line 4 function main does not have an invariant.*.\nHence, a default invariant \('true'\) is being used to prove those.$
-^\[main.1\].*Check loop invariant before entry: SUCCESS$
-^\[main.2\].*Check that loop invariant is preserved: SUCCESS$
-^\[main.3\].*Check decreases clause on loop iteration: SUCCESS$
+^\[main\.\d+\] .* Check loop invariant before entry: SUCCESS$
+^\[main\.\d+\] .* Check that loop invariant is preserved: SUCCESS$
+^\[main\.\d+\] .* Check decreases clause on loop iteration: SUCCESS$
+^\[main\.\d+\] .* Check that i is assignable: SUCCESS$
 ^VERIFICATION SUCCESSFUL$
 ^EXIT=0$
 ^SIGNAL=0$

--- a/regression/contracts/variant_multidimensional_ackermann/test.desc
+++ b/regression/contracts/variant_multidimensional_ackermann/test.desc
@@ -1,11 +1,15 @@
 CORE
 main.c
 --apply-loop-contracts --replace-call-with-contract ackermann
-^\[precondition.1\] .* Check requires clause: SUCCESS$
-^\[precondition.2\] .* Check requires clause: SUCCESS$
-^\[ackermann.1\] .* Check loop invariant before entry: SUCCESS$
-^\[ackermann.2\] .* Check that loop invariant is preserved: SUCCESS$
-^\[ackermann.3\] .* Check decreases clause on loop iteration: SUCCESS$
+^\[precondition\.\d+\] .* line 17 Check requires clause: SUCCESS$
+^\[precondition\.\d+\] .* line 17 Check requires clause: SUCCESS$
+^\[ackermann\.\d+\] line 21 Check loop invariant before entry: SUCCESS$
+^\[ackermann\.\d+\] line 21 Check that loop invariant is preserved: SUCCESS$
+^\[ackermann\.\d+\] line 21 Check decreases clause on loop iteration: SUCCESS$
+^\[ackermann\.\d+\] line 29 Check that m is assignable: SUCCESS$
+^\[ackermann\.\d+\] line 30 Check that n is assignable: SUCCESS$
+^\[ackermann\.\d+\] line 34 Check that n is assignable: SUCCESS$
+^\[ackermann\.\d+\] line 35 Check that m is assignable: SUCCESS$
 ^VERIFICATION SUCCESSFUL$
 ^EXIT=0$
 ^SIGNAL=0$

--- a/regression/contracts/variant_multidimensional_not_decreasing_fail1/test.desc
+++ b/regression/contracts/variant_multidimensional_not_decreasing_fail1/test.desc
@@ -1,9 +1,12 @@
 CORE
 main.c
 --apply-loop-contracts
-^\[main.1\] .* Check loop invariant before entry: SUCCESS$
-^\[main.2\] .* Check that loop invariant is preserved: SUCCESS$
-^\[main.3\] .* Check decreases clause on loop iteration: FAILURE$
+^\[main\.\d+\] .* Check loop invariant before entry: SUCCESS$
+^\[main\.\d+\] .* Check that loop invariant is preserved: SUCCESS$
+^\[main\.\d+\] .* Check decreases clause on loop iteration: FAILURE$
+^\[main\.\d+\] line 14 Check that j is assignable: SUCCESS$
+^\[main\.\d+\] line 18 Check that i is assignable: SUCCESS$
+^\[main\.\d+\] line 19 Check that j is assignable: SUCCESS$
 ^VERIFICATION FAILED$
 ^EXIT=10$
 ^SIGNAL=0$

--- a/regression/contracts/variant_multidimensional_not_decreasing_fail2/test.desc
+++ b/regression/contracts/variant_multidimensional_not_decreasing_fail2/test.desc
@@ -1,9 +1,12 @@
 CORE
 main.c
 --apply-loop-contracts
-^\[main.1\] .* Check loop invariant before entry: SUCCESS$
-^\[main.2\] .* Check that loop invariant is preserved: SUCCESS$
-^\[main.3\] .* Check decreases clause on loop iteration: FAILURE$
+^\[main\.\d+\] .* Check loop invariant before entry: SUCCESS$
+^\[main\.\d+\] .* Check that loop invariant is preserved: SUCCESS$
+^\[main\.\d+\] .* Check decreases clause on loop iteration: FAILURE$
+^\[main\.\d+\] line 14 Check that j is assignable: SUCCESS$
+^\[main\.\d+\] line 18 Check that i is assignable: SUCCESS$
+^\[main\.\d+\] line 19 Check that j is assignable: SUCCESS$
 ^VERIFICATION FAILED$
 ^EXIT=10$
 ^SIGNAL=0$

--- a/regression/contracts/variant_multidimensional_two_index_variables/test.desc
+++ b/regression/contracts/variant_multidimensional_two_index_variables/test.desc
@@ -1,9 +1,12 @@
 CORE
 main.c
 --apply-loop-contracts
-^\[main.1\] .* Check loop invariant before entry: SUCCESS$
-^\[main.2\] .* Check that loop invariant is preserved: SUCCESS$
-^\[main.3\] .* Check decreases clause on loop iteration: SUCCESS$
+^\[main\.\d+\] .* Check loop invariant before entry: SUCCESS$
+^\[main\.\d+\] .* Check that loop invariant is preserved: SUCCESS$
+^\[main\.\d+\] .* Check decreases clause on loop iteration: SUCCESS$
+^\[main\.\d+\] line 14 Check that j is assignable: SUCCESS$
+^\[main\.\d+\] line 18 Check that i is assignable: SUCCESS$
+^\[main\.\d+\] line 19 Check that j is assignable: SUCCESS$
 ^VERIFICATION SUCCESSFUL$
 ^EXIT=0$
 ^SIGNAL=0$

--- a/regression/contracts/variant_not_decreasing_fail/test.desc
+++ b/regression/contracts/variant_not_decreasing_fail/test.desc
@@ -1,9 +1,10 @@
 CORE
 main.c
 --apply-loop-contracts
-^\[main.1\] .* Check loop invariant before entry: SUCCESS$
-^\[main.2\] .* Check that loop invariant is preserved: SUCCESS$
-^\[main.3\] .* Check decreases clause on loop iteration: FAILURE$
+^\[main\.\d+\] .* Check loop invariant before entry: SUCCESS$
+^\[main\.\d+\] .* Check that loop invariant is preserved: SUCCESS$
+^\[main\.\d+\] .* Check decreases clause on loop iteration: FAILURE$
+^\[main\.\d+] .* Check that i is assignable: SUCCESS$
 ^VERIFICATION FAILED$
 ^EXIT=10$
 ^SIGNAL=0$

--- a/regression/contracts/variant_weak_invariant_fail/test.desc
+++ b/regression/contracts/variant_weak_invariant_fail/test.desc
@@ -1,9 +1,10 @@
 CORE
 main.c
 --apply-loop-contracts
-^\[main.1\] .* Check loop invariant before entry: SUCCESS$
-^\[main.2\] .* Check that loop invariant is preserved: SUCCESS$
-^\[main.3\] .* Check decreases clause on loop iteration: FAILURE$
+^\[main\.\d+\] .* Check loop invariant before entry: SUCCESS$
+^\[main\.\d+\] .* Check that loop invariant is preserved: SUCCESS$
+^\[main\.\d+\] .* Check decreases clause on loop iteration: FAILURE$
+^\[main\.\d+\] .* Check that i is assignable: SUCCESS$
 ^VERIFICATION FAILED$
 ^EXIT=10$
 ^SIGNAL=0$

--- a/regression/contracts/variant_while_true_pass/test.desc
+++ b/regression/contracts/variant_while_true_pass/test.desc
@@ -1,9 +1,10 @@
 CORE
 main.c
 --apply-loop-contracts
-^\[main.1\] .* Check loop invariant before entry: SUCCESS$
-^\[main.2\] .* Check that loop invariant is preserved: SUCCESS$
-^\[main.3\] .* Check decreases clause on loop iteration: SUCCESS$
+^\[main\.\d+\] .* Check loop invariant before entry: SUCCESS$
+^\[main\.\d+\] .* Check that loop invariant is preserved: SUCCESS$
+^\[main\.\d+\] .* Check decreases clause on loop iteration: SUCCESS$
+^\[main\.\d+\] .* Check that i is assignable: SUCCESS$
 ^VERIFICATION SUCCESSFUL$
 ^EXIT=0$
 ^SIGNAL=0$


### PR DESCRIPTION
When no assigns clause is specified by the user for a loop, we infer one by inspecting assignment present in the loop body.

These inferred targets were havocked but not checked for correctness. This PR uses the inferred targets to instrument the loop as if it were user-provided. 

1. In some tests the inferred assigns clause did not pass verification so an explicit assigns clause was added;
2. major performance regression on `regression/contracts/quantifiers-loop-02`;
3. For remaining tests, we add the assigned targets in the tests.

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.
