### PR TITLE
Swapping goto_programt::instructiont must preserve labels

### DIFF
--- a/regression/goto-instrument/labels1/main.c
+++ b/regression/goto-instrument/labels1/main.c
@@ -1,0 +1,32 @@
+#include <assert.h>
+#include <stdlib.h>
+
+int foo()
+{
+  return 1;
+}
+
+typedef int (*fptr_t)(void);
+
+int main()
+{
+label_zero:
+  assert(1);
+  int x;
+  int *p;
+  goto label_two;
+label_one:
+  assert(x < 0 || x >= 0);
+label_two:
+  p = malloc(sizeof(int));
+label_three:
+  if(foo())
+    x = 42;
+label_four:
+  assert(foo() == 1);
+label_five:
+  fptr_t fp = foo;
+  assert(fp() == 1);
+label_six:
+  return *p;
+}

--- a/regression/goto-instrument/labels1/test.desc
+++ b/regression/goto-instrument/labels1/test.desc
@@ -1,0 +1,16 @@
+CORE
+main.c
+
+Labels: label_zero$
+Labels: label_one$
+Labels: label_two$
+Labels: label_three$
+Labels: label_four$
+Labels: label_five$
+Labels: label_six$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--
+This test ensures that label names specified in the source code are preserved.

--- a/src/goto-programs/goto_program.h
+++ b/src/goto-programs/goto_program.h
@@ -527,6 +527,7 @@ public:
       swap(instruction._type, _type);
       swap(instruction.guard, guard);
       swap(instruction.targets, targets);
+      swap(instruction.labels, labels);
     }
 
     /// Uniquely identify an invalid target or location


### PR DESCRIPTION
The swap method should maintain all information that cannot be computed.
(As those are computed, instruction numbers, incoming edges, target
numbers, loop numbers need not be preserved.)

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
