### PR TITLE
Pretty-printing of multi-variable let expressions

### DIFF
--- a/src/ansi-c/expr2c.cpp
+++ b/src/ansi-c/expr2c.cpp
@@ -924,18 +924,24 @@ std::string expr2ct::convert_let(
   const let_exprt &src,
   unsigned precedence)
 {
-  if(src.operands().size()<3)
-    return convert_norep(src, precedence);
+  std::string dest = "LET ";
 
-  unsigned p0;
-  std::string op0=convert_with_precedence(src.op0(), p0);
+  bool first = true;
 
-  std::string dest="LET ";
-  dest+=convert(src.symbol());
-  dest+='=';
-  dest+=convert(src.value());
-  dest+=" IN ";
-  dest+=convert(src.where());
+  const auto &values = src.values();
+  auto values_it = values.begin();
+  for(auto &v : src.variables())
+  {
+    if(first)
+      first = false;
+    else
+      dest += ", ";
+
+    dest += convert(v) + "=" + convert(*values_it);
+    ++values_it;
+  }
+
+  dest += " IN " + convert(src.where());
 
   return dest;
 }

--- a/src/util/format_expr.cpp
+++ b/src/util/format_expr.cpp
@@ -369,9 +369,26 @@ void format_expr_configt::setup()
   };
 
   expr_map[ID_let] = [](std::ostream &os, const exprt &expr) -> std::ostream & {
-    return os << "LET " << format(to_let_expr(expr).symbol()) << " = "
-              << format(to_let_expr(expr).value()) << " IN "
-              << format(to_let_expr(expr).where());
+    const auto &let_expr = to_let_expr(expr);
+
+    os << "LET ";
+
+    bool first = true;
+
+    const auto &values = let_expr.values();
+    auto values_it = values.begin();
+    for(auto &v : let_expr.variables())
+    {
+      if(first)
+        first = false;
+      else
+        os << ", ";
+
+      os << format(v) << " = " << format(*values_it);
+      ++values_it;
+    }
+
+    return os << " IN " << format(let_expr.where());
   };
 
   expr_map[ID_lambda] =


### PR DESCRIPTION
Fix expr2c and format to support LET expressions over multiple
variables. expr2c in fact wouldn't even correctly support
single-variable LET expressions anymore as it wasn't updated in
71a20e96589.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
