### PR TITLE
Flattening: support quantifiers over unsigned variables

### DIFF
--- a/regression/cbmc/Quantifiers-type/main.c
+++ b/regression/cbmc/Quantifiers-type/main.c
@@ -1,16 +1,13 @@
 int main()
 {
   int a[2];
-  int b[2];
 
   // clang-format off
   // clang-format would rewrite the "==>" as "== >"
   __CPROVER_assume( __CPROVER_forall { float i; (i>=0 && i<2) ==> a[i]>=10 && a[i]<=10 } );
-  __CPROVER_assume( __CPROVER_forall { char i; (i>=0 && i<2) ==> b[i]>=10 && b[i]<=10 } );
   // clang-format on
 
   assert(a[0]==10 && a[1]==10);
-  assert(b[0]==10 && b[1]==10);
 
   return 0;
 }

--- a/regression/cbmc/Quantifiers-type/test.desc
+++ b/regression/cbmc/Quantifiers-type/test.desc
@@ -3,8 +3,7 @@ main.c
 
 ^\*\* Results:$
 ^\[main.assertion.1\] line 12 assertion tmp_if_expr(\$\d+)?: FAILURE$
-^\[main.assertion.2\] line 13 assertion tmp_if_expr\$\d+: SUCCESS$
-^\*\* 1 of 2 failed
+^\*\* 1 of 1 failed
 ^VERIFICATION FAILED$
 ^EXIT=10$
 ^SIGNAL=0$

--- a/regression/cbmc/Quantifiers-type2/main.c
+++ b/regression/cbmc/Quantifiers-type2/main.c
@@ -1,0 +1,16 @@
+int main()
+{
+  int b[2];
+  int c[2];
+
+  // clang-format off
+  // clang-format would rewrite the "==>" as "== >"
+  __CPROVER_assume( __CPROVER_forall { char i; (i>=0 && i<2) ==> b[i]>=10 && b[i]<=10 } );
+  __CPROVER_assume( __CPROVER_forall { unsigned i; (i>=0 && i<2) ==> c[i]>=10 && c[i]<=10 } );
+  // clang-format on
+
+  assert(b[0] == 10 && b[1] == 10);
+  assert(c[0] == 10 && c[1] == 10);
+
+  return 0;
+}

--- a/regression/cbmc/Quantifiers-type2/test.desc
+++ b/regression/cbmc/Quantifiers-type2/test.desc
@@ -1,0 +1,11 @@
+CORE
+main.c
+
+^\*\* Results:$
+^\[main.assertion.1\] line 12 assertion tmp_if_expr(\$\d+)?: SUCCESS$
+^\[main.assertion.2\] line 13 assertion tmp_if_expr\$\d+: SUCCESS$
+^VERIFICATION SUCCESSFUL$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring

--- a/src/solvers/flattening/boolbv_quantifier.cpp
+++ b/src/solvers/flattening/boolbv_quantifier.cpp
@@ -48,6 +48,9 @@ get_quantifier_var_min(const exprt &var_expr, const exprt &quantifier_expr)
         return to_constant_expr(y_binary.rhs());
       }
     }
+
+    if(var_expr.type().id() == ID_unsignedbv)
+      return from_integer(0, var_expr.type());
   }
   else if(quantifier_expr.id() == ID_and)
   {
@@ -66,6 +69,9 @@ get_quantifier_var_min(const exprt &var_expr, const exprt &quantifier_expr)
         return to_constant_expr(x_binary.rhs());
       }
     }
+
+    if(var_expr.type().id() == ID_unsignedbv)
+      return from_integer(0, var_expr.type());
   }
 
   return {};


### PR DESCRIPTION
The simplifier removes the trivially-true constraint `var >= 0`, which
made flattening fail to determine a lower bound.

The pre-existing test Quantifiers-type is now reduced to the failing
case of `float`-typed variables. The `char` case already worked before,
and is now merged with the newly-added `unsigned` test.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
