### PR TITLE
unwindset: Warn about non-existent loops

### DIFF
--- a/regression/cbmc/unwindset1/test.desc
+++ b/regression/cbmc/unwindset1/test.desc
@@ -1,10 +1,9 @@
 CORE
 main.c
 --unwindset main.0:2,main.2:2
-^Invalid User Input$
-^Option: unwindset$
-^Reason: invalid loop identifier main\.2$
-^EXIT=1$
+^loop identifier main.2 provided with unwindset does not match any loop$
+^VERIFICATION FAILED$
+^EXIT=10$
 ^SIGNAL=0$
 --
 ^warning: ignoring

--- a/src/goto-checker/bmc_util.cpp
+++ b/src/goto-checker/bmc_util.cpp
@@ -192,7 +192,8 @@ void setup_symex(
   symex.last_source_location.make_nil();
 
   symex.unwindset.parse_unwind(options.get_option("unwind"));
-  symex.unwindset.parse_unwindset(options.get_list_option("unwindset"));
+  symex.unwindset.parse_unwindset(
+    options.get_list_option("unwindset"), ui_message_handler);
 }
 
 void slice(

--- a/src/goto-instrument/goto_instrument_parse_options.cpp
+++ b/src/goto-instrument/goto_instrument_parse_options.cpp
@@ -171,10 +171,16 @@ int goto_instrument_parse_optionst::doit()
           unwindset.parse_unwind(cmdline.get_value("unwind"));
 
         if(unwindset_file_given)
-          unwindset.parse_unwindset_file(cmdline.get_value("unwindset-file"));
+        {
+          unwindset.parse_unwindset_file(
+            cmdline.get_value("unwindset-file"), ui_message_handler);
+        }
 
         if(unwindset_given)
-          unwindset.parse_unwindset(cmdline.get_values("unwindset"));
+        {
+          unwindset.parse_unwindset(
+            cmdline.get_values("unwindset"), ui_message_handler);
+        }
 
         bool unwinding_assertions=cmdline.isset("unwinding-assertions");
         bool partial_loops=cmdline.isset("partial-loops");

--- a/src/goto-instrument/unwindset.h
+++ b/src/goto-instrument/unwindset.h
@@ -18,6 +18,8 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <map>
 #include <string>
 
+class message_handlert;
+
 class unwindsett
 {
 public:
@@ -34,13 +36,17 @@ public:
   void parse_unwind(const std::string &unwind);
 
   // limit for instances of a loop
-  void parse_unwindset(const std::list<std::string> &unwindset);
+  void parse_unwindset(
+    const std::list<std::string> &unwindset,
+    message_handlert &message_handler);
 
   // queries
   optionalt<unsigned> get_limit(const irep_idt &loop, unsigned thread_id) const;
 
   // read unwindset directives from a file
-  void parse_unwindset_file(const std::string &file_name);
+  void parse_unwindset_file(
+    const std::string &file_name,
+    message_handlert &message_handler);
 
 protected:
   abstract_goto_modelt &goto_model;
@@ -57,7 +63,9 @@ protected:
     std::map<std::pair<irep_idt, unsigned>, optionalt<unsigned>>;
   thread_loop_mapt thread_loop_map;
 
-  void parse_unwindset_one_loop(std::string loop_limit);
+  void parse_unwindset_one_loop(
+    std::string loop_limit,
+    message_handlert &message_handler);
 };
 
 #define OPT_UNWINDSET                                                          \


### PR DESCRIPTION
f170ba17d1 introduced validation of loop identifiers. Syntactically
invalid ones result in exceptions being thrown. Syntactically valid, but
non-existent ones previously also failed an exception. This is now
reduced to a warning to avoid breaking verification workflows that use
the same unwindset specifications with `goto-instrument` followed by
`cbmc`: `goto-instrument` would unwind the loops already, therefore
removing them from the goto program seen by CBMC. Such workflows should
likely be cleaned up, but we shouldn't immediately break them.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
