### PR TITLE
Evaluate any non-trivial switch condition just once

### DIFF
--- a/regression/cbmc/switch9/main.c
+++ b/regression/cbmc/switch9/main.c
@@ -1,0 +1,20 @@
+#include <stdlib.h>
+
+int main()
+{
+  int *p = malloc(sizeof(int));
+
+  if(!p)
+    return 1;
+
+  switch(*p)
+  {
+  case 1:
+  case 2:
+  case 3:
+    return 0;
+  case 4:
+  default:
+    return -1;
+  }
+}

--- a/regression/cbmc/switch9/test.desc
+++ b/regression/cbmc/switch9/test.desc
@@ -1,0 +1,14 @@
+CORE
+main.c
+--pointer-check --malloc-may-fail --malloc-fail-null
+activate-multi-line-match
+^\[main.pointer_dereference.\d+\] line 10 dereference failure: pointer NULL in \*p: SUCCESS$
+^VERIFICATION SUCCESSFUL$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+\[main.pointer_dereference.\d+\] line 10 dereference failure: pointer NULL in \*p: SUCCESS\n.*\[main.pointer_dereference.\d+\] line 10 dereference failure: pointer NULL in \*p: SUCCESS\n
+--
+A pointer check for the switch value should be generated, but there should only
+be one such check.


### PR DESCRIPTION
goto-program conversion should not turn switch(E) { case 1:... case 2:
...} into if(E == 1 || E == 2 || ...) for a non-trivial expression E.
Instead, the value of E must be copied into a temporary to avoid
repeated evaluation of E. We would already do this when E had side
effects, but even side-effect-free expression could result in expensive
assertions being generated when those expressions themselves would
trigger them with goto_check.

This change reduces verification time of a proof of
s2n_stuffer_skip_whitespace from several minutes down to seconds.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [x] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
