### PR TITLE
Preserve labels when removing return statements

### DIFF
--- a/regression/goto-analyzer/label/main.c
+++ b/regression/goto-analyzer/label/main.c
@@ -1,0 +1,8 @@
+int main()
+{
+  goto ERROR;
+
+  return 0;
+ERROR:
+  return 1;
+}

--- a/regression/goto-analyzer/label/test.desc
+++ b/regression/goto-analyzer/label/test.desc
@@ -1,0 +1,12 @@
+CORE
+main.c
+--show-goto-functions --error-label ERROR
+Labels: ERROR$
+ASSIGN main#return_value := 1$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--
+This test ensures that removal of return values (confirmed by the existence of
+the ASSIGN instruction) preserves labels attached to the return statement.

--- a/src/goto-programs/remove_returns.cpp
+++ b/src/goto-programs/remove_returns.cpp
@@ -128,8 +128,10 @@ void remove_returnst::replace_returns(
         code_assignt assignment(*return_symbol, instruction.return_value());
 
         // now turn the `return' into `assignment'
+        auto labels = std::move(instruction.labels);
         instruction = goto_programt::make_assignment(
           assignment, instruction.source_location());
+        instruction.labels = std::move(labels);
       }
       else
         instruction.turn_into_skip();


### PR DESCRIPTION
Removing return statements creates a fresh assignment instruction. When
doing so, however, labels attached to the original instruction must be
preserved.

Fixes: #6304

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
