### PR TITLE
unwindset: Also warn about loops in functions without body

### DIFF
--- a/src/goto-instrument/unwindset.cpp
+++ b/src/goto-instrument/unwindset.cpp
@@ -71,10 +71,19 @@ void unwindsett::parse_unwindset_one_loop(
       std::string function_id = id.substr(0, last_dot_pos);
       std::string loop_nr_label = id.substr(last_dot_pos + 1);
 
-      if(loop_nr_label.empty() || !goto_model.can_produce_function(function_id))
+      if(loop_nr_label.empty())
       {
         throw invalid_command_line_argument_exceptiont{
           "invalid loop identifier " + id, "unwindset"};
+      }
+
+      if(!goto_model.can_produce_function(function_id))
+      {
+        messaget log{message_handler};
+        log.warning() << "loop identifier " << id
+                      << " for non-existent function provided with unwindset"
+                      << messaget::eom;
+        return;
       }
 
       const goto_functiont &goto_function =


### PR DESCRIPTION
f14cd09 demoted some failures to warnings. This commit does so for
another case: if no body for the function is available, issue a warning
rather than failing an exception.

This situation will typically arise when using an unwindset
specification originally meant for CBMC with goto-instrument, where
library functions might not yet be present.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
