### PR TITLE
Performance improvement and cleanup of local bitvector analysis

### DIFF
--- a/src/analyses/local_bitvector_analysis.cpp
+++ b/src/analyses/local_bitvector_analysis.cpp
@@ -45,10 +45,7 @@ bool local_bitvector_analysist::merge(points_tot &a, points_tot &b)
     std::max(a.size(), b.size());
 
   for(std::size_t i=0; i<max_index; i++)
-  {
-    if(a[i].merge(b[i]))
-      result=true;
-  }
+    result |= a[i].merge(b[i]);
 
   return result;
 }

--- a/src/analyses/local_bitvector_analysis.cpp
+++ b/src/analyses/local_bitvector_analysis.cpp
@@ -70,7 +70,7 @@ void local_bitvector_analysist::assign_lhs(
 
     if(is_tracked(identifier))
     {
-      unsigned dest_pointer=pointers.number(identifier);
+      const auto dest_pointer = pointers.number(identifier);
       flagst rhs_flags=get_rec(rhs, loc_info_src);
       loc_info_dest[dest_pointer]=rhs_flags;
     }
@@ -125,7 +125,7 @@ local_bitvector_analysist::flagst local_bitvector_analysist::get_rec(
     const irep_idt &identifier=to_symbol_expr(rhs).get_identifier();
     if(is_tracked(identifier))
     {
-      unsigned src_pointer=pointers.number(identifier);
+      const auto src_pointer = pointers.number(identifier);
       return loc_info_src[src_pointer];
     }
     else
@@ -239,7 +239,7 @@ void local_bitvector_analysist::build()
   if(cfg.nodes.empty())
     return;
 
-  std::set<unsigned> work_queue;
+  std::set<local_cfgt::node_nrt> work_queue;
   work_queue.insert(0);
 
   loc_infos.resize(cfg.nodes.size());
@@ -255,7 +255,7 @@ void local_bitvector_analysist::build()
 
   while(!work_queue.empty())
   {
-    unsigned loc_nr = *work_queue.begin();
+    const auto loc_nr = *work_queue.begin();
     const local_cfgt::nodet &node=cfg.nodes[loc_nr];
     const goto_programt::instructiont &instruction=*node.t;
     work_queue.erase(work_queue.begin());
@@ -345,7 +345,7 @@ void local_bitvector_analysist::output(
   const goto_functiont &goto_function,
   const namespacet &ns) const
 {
-  unsigned l=0;
+  std::size_t l = 0;
 
   for(const auto &instruction : goto_function.body.instructions)
   {

--- a/src/analyses/local_bitvector_analysis.cpp
+++ b/src/analyses/local_bitvector_analysis.cpp
@@ -242,8 +242,8 @@ void local_bitvector_analysist::build()
   if(cfg.nodes.empty())
     return;
 
-  work_queuet work_queue;
-  work_queue.push(0);
+  std::set<unsigned> work_queue;
+  work_queue.insert(0);
 
   loc_infos.resize(cfg.nodes.size());
 
@@ -258,10 +258,10 @@ void local_bitvector_analysist::build()
 
   while(!work_queue.empty())
   {
-    unsigned loc_nr=work_queue.top();
+    unsigned loc_nr = *work_queue.begin();
     const local_cfgt::nodet &node=cfg.nodes[loc_nr];
     const goto_programt::instructiont &instruction=*node.t;
-    work_queue.pop();
+    work_queue.erase(work_queue.begin());
 
     auto &loc_info_src=loc_infos[loc_nr];
     auto loc_info_dest=loc_infos[loc_nr];
@@ -338,7 +338,7 @@ void local_bitvector_analysist::build()
     {
       assert(succ<loc_infos.size());
       if(merge(loc_infos[succ], (loc_info_dest)))
-        work_queue.push(succ);
+        work_queue.insert(succ);
     }
   }
 }

--- a/src/analyses/local_bitvector_analysis.h
+++ b/src/analyses/local_bitvector_analysis.h
@@ -12,8 +12,6 @@ Author: Daniel Kroening, kroening@kroening.com
 #ifndef CPROVER_ANALYSES_LOCAL_BITVECTOR_ANALYSIS_H
 #define CPROVER_ANALYSES_LOCAL_BITVECTOR_ANALYSIS_H
 
-#include <stack>
-
 #include <util/expanding_vector.h>
 #include <util/numbering.h>
 
@@ -181,8 +179,6 @@ public:
 protected:
   const namespacet &ns;
   void build();
-
-  typedef std::stack<unsigned> work_queuet;
 
   numberingt<irep_idt> pointers;
 


### PR DESCRIPTION
Please review commit-by-commit. The commit messages include performance evaluation data.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [x] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
