### PR TITLE
Use null_pointer_exprt

### DIFF
--- a/src/ansi-c/c_typecast.cpp
+++ b/src/ansi-c/c_typecast.cpp
@@ -537,8 +537,7 @@ void c_typecastt::implicit_typecast_followed(
        src_type.id()==ID_natural ||
        src_type.id()==ID_integer))
     {
-      expr=exprt(ID_constant, orig_dest_type);
-      expr.set(ID_value, ID_NULL);
+      expr = null_pointer_exprt{to_pointer_type(orig_dest_type)};
       return; // ok
     }
 

--- a/src/ansi-c/c_typecheck_expr.cpp
+++ b/src/ansi-c/c_typecheck_expr.cpp
@@ -1382,14 +1382,14 @@ void c_typecheck_baset::typecheck_expr_rel(
     if(type0.id()==ID_pointer &&
        simplify_expr(op1, *this).is_zero())
     {
-      op1=constant_exprt(ID_NULL, type0);
+      op1 = null_pointer_exprt{to_pointer_type(type0)};
       return;
     }
 
     if(type1.id()==ID_pointer &&
        simplify_expr(op0, *this).is_zero())
     {
-      op0=constant_exprt(ID_NULL, type1);
+      op0 = null_pointer_exprt{to_pointer_type(type1)};
       return;
     }
 

--- a/src/cpp/parse.cpp
+++ b/src/cpp/parse.cpp
@@ -6743,7 +6743,7 @@ bool Parser::rPrimaryExpr(exprt &exp)
   case TOK_NULLPTR:
     lex.get_token(tk);
     // as an exception, we set the width of pointer
-    exp=constant_exprt(ID_NULL, pointer_type(typet(ID_nullptr)));
+    exp = null_pointer_exprt{pointer_type(typet(ID_nullptr))};
     set_location(exp, tk);
 #ifdef DEBUG
     std::cout << std::string(__indent, ' ') << "Parser::rPrimaryExpr 6\n";

--- a/unit/interpreter/interpreter.cpp
+++ b/unit/interpreter/interpreter.cpp
@@ -46,7 +46,7 @@ SCENARIO("interpreter evaluation null pointer expressions")
     unsignedbv_typet java_char(16);
     pointer_typet pointer_type(java_char, 64);
 
-    constant_exprt constant_expr(ID_NULL, pointer_type);
+    null_pointer_exprt constant_expr{pointer_type};
 
     mp_vectort mp_vector = interpreter_test.evaluate(constant_expr);
 


### PR DESCRIPTION
Some places still constructed a null pointer expression using
constant_exprt with ID_NULL. The resulting exprt is the same as what
null_pointer_exprt builds, but the higher-level API will help
maintainability.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
