### PR TITLE
Wrap NULL/0 is-a-null-pointer in a utility function

### DIFF
--- a/src/analyses/custom_bitvector_analysis.cpp
+++ b/src/analyses/custom_bitvector_analysis.cpp
@@ -345,8 +345,9 @@ void custom_bitvector_domaint::transform(
 
             if(lhs.type().id()==ID_pointer)
             {
-              if(lhs.is_constant() &&
-                 to_constant_expr(lhs).get_value()==ID_NULL) // NULL means all
+              if(
+                lhs.is_constant() &&
+                is_null_pointer(to_constant_expr(lhs))) // NULL means all
               {
                 if(mode==modet::CLEAR_MAY)
                 {
@@ -473,8 +474,9 @@ void custom_bitvector_domaint::transform(
 
         if(lhs.type().id()==ID_pointer)
         {
-          if(lhs.is_constant() &&
-             to_constant_expr(lhs).get_value()==ID_NULL) // NULL means all
+          if(
+            lhs.is_constant() &&
+            is_null_pointer(to_constant_expr(lhs))) // NULL means all
           {
             if(mode==modet::CLEAR_MAY)
             {
@@ -708,8 +710,9 @@ exprt custom_bitvector_domaint::eval(
       if(pointer.type().id()!=ID_pointer)
         return src;
 
-      if(pointer.is_constant() &&
-         to_constant_expr(pointer).get_value()==ID_NULL) // NULL means all
+      if(
+        pointer.is_constant() &&
+        is_null_pointer(to_constant_expr(pointer))) // NULL means all
       {
         if(src.id() == ID_get_may)
         {

--- a/src/analyses/invariant_set.cpp
+++ b/src/analyses/invariant_set.cpp
@@ -121,9 +121,8 @@ std::string inv_object_storet::build_string(const exprt &expr) const
   if(expr.is_constant())
   {
     // NULL?
-    if(expr.type().id()==ID_pointer)
-      if(expr.get(ID_value)==ID_NULL)
-        return "0";
+    if(is_null_pointer(to_constant_expr(expr)))
+      return "0";
 
     const auto i = numeric_cast<mp_integer>(expr);
     if(i.has_value())

--- a/src/ansi-c/c_typecheck_expr.cpp
+++ b/src/ansi-c/c_typecheck_expr.cpp
@@ -1602,14 +1602,18 @@ void c_typecheck_baset::typecheck_expr_trinary(if_exprt &expr)
 
     // is one of them void * AND null? Convert that to the other.
     // (at least that's how GCC behaves)
-    if(operands[1].type().subtype().id()==ID_empty &&
-       tmp1.is_constant() &&
-       to_constant_expr(tmp1).get_value()==ID_NULL)
+    if(
+      operands[1].type().subtype().id() == ID_empty && tmp1.is_constant() &&
+      is_null_pointer(to_constant_expr(tmp1)))
+    {
       implicit_typecast(operands[1], operands[2].type());
-    else if(operands[2].type().subtype().id()==ID_empty &&
-            tmp2.is_constant() &&
-            to_constant_expr(tmp2).get_value()==ID_NULL)
+    }
+    else if(
+      operands[2].type().subtype().id() == ID_empty && tmp2.is_constant() &&
+      is_null_pointer(to_constant_expr(tmp2)))
+    {
       implicit_typecast(operands[2], operands[1].type());
+    }
     else if(operands[1].type().subtype().id()!=ID_code ||
             operands[2].type().subtype().id()!=ID_code)
     {

--- a/src/ansi-c/expr2c.cpp
+++ b/src/ansi-c/expr2c.cpp
@@ -7,16 +7,13 @@ Author: Daniel Kroening, kroening@kroening.com
 \*******************************************************************/
 
 #include "expr2c.h"
-
-#include <algorithm>
-#include <sstream>
-
-#include <map>
+#include "expr2c_class.h"
 
 #include <util/arith_tools.h>
 #include <util/c_types.h>
 #include <util/config.h>
 #include <util/cprover_prefix.h>
+#include <util/expr_util.h>
 #include <util/find_symbols.h>
 #include <util/fixedbv.h>
 #include <util/floatbv_expr.h>
@@ -33,7 +30,10 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "c_misc.h"
 #include "c_qualifiers.h"
-#include "expr2c_class.h"
+
+#include <algorithm>
+#include <map>
+#include <sstream>
 
 // clang-format off
 
@@ -1983,9 +1983,7 @@ std::string expr2ct::convert_constant(
   }
   else if(type.id()==ID_pointer)
   {
-    if(
-      value == ID_NULL ||
-      (value == std::string(value.size(), '0') && config.ansi_c.NULL_is_zero))
+    if(is_null_pointer(src))
     {
       if(configuration.use_library_macros)
         dest = "NULL";

--- a/src/cpp/cpp_typecheck_conversions.cpp
+++ b/src/cpp/cpp_typecheck_conversions.cpp
@@ -601,8 +601,7 @@ bool cpp_typecheckt::standard_conversion_pointer_to_member(
   if(expr.get_bool(ID_C_lvalue))
     return false;
 
-  if(expr.id()==ID_constant &&
-     expr.get(ID_value)==ID_NULL)
+  if(expr.id() == ID_constant && is_null_pointer(to_constant_expr(expr)))
   {
     new_expr = typecast_exprt::conditional_cast(expr, type);
     return true;

--- a/src/goto-instrument/dump_c_class.h
+++ b/src/goto-instrument/dump_c_class.h
@@ -12,12 +12,15 @@ Author: Daniel Kroening, kroening@kroening.com
 #ifndef CPROVER_GOTO_INSTRUMENT_DUMP_C_CLASS_H
 #define CPROVER_GOTO_INSTRUMENT_DUMP_C_CLASS_H
 
-#include <set>
-#include <string>
-
+#include <util/namespace.h>
+#include <util/std_code.h>
 #include <util/symbol_table.h>
 
 #include <goto-programs/system_library_symbols.h>
+
+#include <set>
+#include <string>
+#include <unordered_set>
 
 /// Used for configuring the behaviour of dump_c
 struct dump_c_configurationt final

--- a/src/goto-instrument/goto_program2code.cpp
+++ b/src/goto-instrument/goto_program2code.cpp
@@ -309,8 +309,7 @@ goto_programt::const_targett goto_program2codet::convert_assign_varargs(
   const exprt this_va_list_expr = target->assign_lhs();
   const exprt &r = skip_typecast(target->assign_rhs());
 
-  if(r.id()==ID_constant &&
-     (r.is_zero() || to_constant_expr(r).get_value()==ID_NULL))
+  if(r.id() == ID_constant && is_null_pointer(to_constant_expr(r)))
   {
     code_function_callt f(
       symbol_exprt("va_end", code_typet({}, empty_typet())),

--- a/src/goto-programs/xml_expr.cpp
+++ b/src/goto-programs/xml_expr.cpp
@@ -16,6 +16,7 @@ Author: Daniel Kroening
 #include <util/arith_tools.h>
 #include <util/c_types.h>
 #include <util/config.h>
+#include <util/expr_util.h>
 #include <util/fixedbv.h>
 #include <util/ieee_float.h>
 #include <util/invariant.h>
@@ -220,7 +221,7 @@ xmlt xml(const exprt &expr, const namespacet &ns)
       result.name = "pointer";
       result.set_attribute(
         "binary", integer2binary(bvrep2integer(value, width, false), width));
-      if(constant_expr.get(ID_value) == ID_NULL)
+      if(is_null_pointer(constant_expr))
         result.data = "NULL";
     }
     else if(type.id() == ID_bool)

--- a/src/goto-symex/symex_goto.cpp
+++ b/src/goto-symex/symex_goto.cpp
@@ -91,7 +91,7 @@ static optionalt<renamedt<exprt, L2>> try_evaluate_pointer_comparison(
 
   if(
     skip_typecast(other_operand).id() != ID_address_of &&
-    (!constant_expr || constant_expr->get_value() != ID_NULL))
+    (!constant_expr || !is_null_pointer(*constant_expr)))
   {
     return {};
   }

--- a/src/pointer-analysis/value_set.cpp
+++ b/src/pointer-analysis/value_set.cpp
@@ -11,11 +11,10 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "value_set.h"
 
-#include <ostream>
-
 #include <util/arith_tools.h>
 #include <util/byte_operators.h>
 #include <util/c_types.h>
+#include <util/expr_util.h>
 #include <util/format_expr.h>
 #include <util/format_type.h>
 #include <util/pointer_expr.h>
@@ -25,6 +24,8 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/simplify_expr.h>
 #include <util/std_code.h>
 #include <util/symbol_table.h>
+
+#include <ostream>
 
 #ifdef DEBUG
 #include <iostream>
@@ -560,8 +561,7 @@ void value_sett::get_value_set_rec(
   else if(expr.is_constant())
   {
     // check if NULL
-    if(expr.get(ID_value)==ID_NULL &&
-       expr_type.id()==ID_pointer)
+    if(is_null_pointer(to_constant_expr(expr)))
     {
       insert(
         dest, exprt(ID_null_object, to_pointer_type(expr_type).base_type()), 0);

--- a/src/pointer-analysis/value_set_fi.cpp
+++ b/src/pointer-analysis/value_set_fi.cpp
@@ -11,13 +11,10 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "value_set_fi.h"
 
-#include <ostream>
-
-#include <goto-programs/goto_instruction_code.h>
-
 #include <util/arith_tools.h>
 #include <util/byte_operators.h>
 #include <util/c_types.h>
+#include <util/expr_util.h>
 #include <util/namespace.h>
 #include <util/pointer_expr.h>
 #include <util/prefix.h>
@@ -25,7 +22,11 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/std_code.h>
 #include <util/symbol.h>
 
+#include <goto-programs/goto_instruction_code.h>
+
 #include <langapi/language_util.h>
+
+#include <ostream>
 
 const value_set_fit::object_map_dt value_set_fit::object_map_dt::blank{};
 
@@ -517,8 +518,7 @@ void value_set_fit::get_value_set_rec(
   else if(expr.is_constant())
   {
     // check if NULL
-    if(expr.get(ID_value)==ID_NULL &&
-       expr.type().id()==ID_pointer)
+    if(is_null_pointer(to_constant_expr(expr)))
     {
       insert(dest, exprt(ID_null_object, expr.type().subtype()), 0);
       return;

--- a/src/solvers/flattening/bv_pointers.cpp
+++ b/src/solvers/flattening/bv_pointers.cpp
@@ -13,6 +13,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/c_types.h>
 #include <util/config.h>
 #include <util/exception_utils.h>
+#include <util/expr_util.h>
 #include <util/namespace.h>
 #include <util/pointer_expr.h>
 #include <util/pointer_offset_size.h>
@@ -409,13 +410,13 @@ bvt bv_pointerst::convert_pointer_type(const exprt &expr)
   }
   else if(expr.id()==ID_constant)
   {
-    irep_idt value=to_constant_expr(expr).get_value();
+    const constant_exprt &c = to_constant_expr(expr);
 
-    if(value==ID_NULL)
+    if(is_null_pointer(c))
       return encode(pointer_logic.get_null_object(), type);
     else
     {
-      mp_integer i = bvrep2integer(value, bits, false);
+      mp_integer i = bvrep2integer(c.get_value(), bits, false);
       return bv_utils.build_constant(i, bits);
     }
   }

--- a/src/solvers/smt2/smt2_conv.cpp
+++ b/src/solvers/smt2/smt2_conv.cpp
@@ -3035,15 +3035,14 @@ void smt2_convt::convert_constant(const constant_exprt &expr)
   }
   else if(expr_type.id()==ID_pointer)
   {
-    const irep_idt &value = expr.get_value();
-
-    if(value==ID_NULL)
+    if(is_null_pointer(expr))
     {
       out << "(_ bv0 " << boolbv_width(expr_type)
           << ")";
     }
     else
-      UNEXPECTEDCASE("unknown pointer constant: "+id2string(value));
+      UNEXPECTEDCASE(
+        "unknown pointer constant: " + id2string(expr.get_value()));
   }
   else if(expr_type.id()==ID_bool)
   {

--- a/src/util/arith_tools.cpp
+++ b/src/util/arith_tools.cpp
@@ -9,6 +9,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "arith_tools.h"
 
 #include "c_types.h"
+#include "expr_util.h"
 #include "fixedbv.h"
 #include "ieee_float.h"
 #include "invariant.h"
@@ -24,7 +25,7 @@ bool to_integer(const constant_exprt &expr, mp_integer &int_value)
 
   if(type_id==ID_pointer)
   {
-    if(value==ID_NULL)
+    if(is_null_pointer(expr))
     {
       int_value=0;
       return false;

--- a/src/util/expr.cpp
+++ b/src/util/expr.cpp
@@ -13,6 +13,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "arith_tools.h"
 #include "bitvector_types.h"
 #include "expr_iterator.h"
+#include "expr_util.h"
 #include "fixedbv.h"
 #include "ieee_float.h"
 #include "rational.h"
@@ -97,8 +98,7 @@ bool exprt::is_zero() const
     }
     else if(type_id==ID_pointer)
     {
-      return constant.value_is_zero_string() ||
-             constant.get_value()==ID_NULL;
+      return is_null_pointer(constant);
     }
   }
 

--- a/src/util/expr_util.cpp
+++ b/src/util/expr_util.cpp
@@ -320,5 +320,14 @@ bool is_null_pointer(const constant_exprt &expr)
   if(expr.get_value() == ID_NULL)
     return true;
 
+    // We used to support "0" (when NULL_is_zero), but really front-ends should
+    // resolve this and generate ID_NULL instead.
+#if 0
   return config.ansi_c.NULL_is_zero && expr.value_is_zero_string();
+#else
+  INVARIANT(
+    !expr.value_is_zero_string() || !config.ansi_c.NULL_is_zero,
+    "front-end should use ID_NULL");
+  return false;
+#endif
 }

--- a/src/util/expr_util.cpp
+++ b/src/util/expr_util.cpp
@@ -8,15 +8,16 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "expr_util.h"
 
-#include <algorithm>
-#include <unordered_set>
-
 #include "arith_tools.h"
 #include "c_types.h"
+#include "config.h"
 #include "expr_iterator.h"
 #include "namespace.h"
 #include "pointer_expr.h"
 #include "std_expr.h"
+
+#include <algorithm>
+#include <unordered_set>
 
 bool is_assignable(const exprt &expr)
 {
@@ -309,4 +310,15 @@ exprt make_and(exprt a, exprt b)
     return b;
   }
   return and_exprt{std::move(a), std::move(b)};
+}
+
+bool is_null_pointer(const constant_exprt &expr)
+{
+  if(expr.type().id() != ID_pointer)
+    return false;
+
+  if(expr.get_value() == ID_NULL)
+    return true;
+
+  return config.ansi_c.NULL_is_zero && expr.value_is_zero_string();
 }

--- a/src/util/expr_util.h
+++ b/src/util/expr_util.h
@@ -107,4 +107,9 @@ constant_exprt make_boolean_expr(bool);
 /// return the other expression. If one is `false` returns `false`.
 exprt make_and(exprt a, exprt b);
 
+/// Returns true if \p expr has a pointer type and a value NULL; it also returns
+/// true when \p expr has value zero and NULL_is_zero is true; returns false in
+/// all other cases.
+bool is_null_pointer(const constant_exprt &expr);
+
 #endif // CPROVER_UTIL_EXPR_UTIL_H

--- a/src/util/format_expr.cpp
+++ b/src/util/format_expr.cpp
@@ -14,6 +14,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "arith_tools.h"
 #include "bitvector_expr.h"
 #include "byte_operators.h"
+#include "expr_util.h"
 #include "format_type.h"
 #include "ieee_float.h"
 #include "mathematical_expr.h"
@@ -183,7 +184,7 @@ static std::ostream &format_rec(std::ostream &os, const constant_exprt &src)
     return os << ieee_floatt(src);
   else if(type == ID_pointer)
   {
-    if(src.is_zero())
+    if(is_null_pointer(src))
       return os << ID_NULL;
     else if(has_prefix(id2string(src.get_value()), "INVALID-"))
     {

--- a/src/util/simplify_expr.cpp
+++ b/src/util/simplify_expr.cpp
@@ -875,10 +875,11 @@ simplify_exprt::simplify_typecast(const typecast_exprt &expr)
   {
     const auto &op_plus_expr = to_plus_expr(expr.op());
 
-    if(((op_plus_expr.op0().id() == ID_typecast &&
-         to_typecast_expr(op_plus_expr.op0()).op().is_zero()) ||
-        (op_plus_expr.op0().is_constant() &&
-         to_constant_expr(op_plus_expr.op0()).get_value() == ID_NULL)))
+    if(
+      (op_plus_expr.op0().id() == ID_typecast &&
+       to_typecast_expr(op_plus_expr.op0()).op().is_zero()) ||
+      (op_plus_expr.op0().is_constant() &&
+       is_null_pointer(to_constant_expr(op_plus_expr.op0()))))
     {
       auto sub_size =
         pointer_offset_size(to_pointer_type(op_type).base_type(), ns);

--- a/src/util/simplify_expr_int.cpp
+++ b/src/util/simplify_expr_int.cpp
@@ -1421,13 +1421,13 @@ simplify_exprt::resultt<> simplify_exprt::simplify_inequality_both_constant(
 static bool eliminate_common_addends(exprt &op0, exprt &op1)
 {
   // we can't eliminate zeros
-  if(op0.is_zero() ||
-     op1.is_zero() ||
-     (op0.is_constant() &&
-      to_constant_expr(op0).get_value()==ID_NULL) ||
-     (op1.is_constant() &&
-      to_constant_expr(op1).get_value()==ID_NULL))
+  if(
+    op0.is_zero() || op1.is_zero() ||
+    (op0.is_constant() && is_null_pointer(to_constant_expr(op0))) ||
+    (op1.is_constant() && is_null_pointer(to_constant_expr(op1))))
+  {
     return true;
+  }
 
   if(op0.id()==ID_plus)
   {
@@ -1572,9 +1572,12 @@ simplify_exprt::resultt<> simplify_exprt::simplify_inequality_rhs_is_constant(
     }
 
     // very special case for pointers
-    if(expr.id()==ID_equal &&
-       expr.op1().is_constant() &&
-       expr.op1().get(ID_value)==ID_NULL)
+    if(expr.id() != ID_equal)
+      return unchanged(expr);
+
+    const constant_exprt &op1_constant = to_constant_expr(expr.op1());
+
+    if(is_null_pointer(op1_constant))
     {
       // the address of an object is never NULL
 

--- a/src/util/simplify_expr_pointer.cpp
+++ b/src/util/simplify_expr_pointer.cpp
@@ -40,7 +40,7 @@ static bool is_dereference_integer_object(
     {
       const constant_exprt &constant = to_constant_expr(pointer);
 
-      if(constant.get_value() == ID_NULL && config.ansi_c.NULL_is_zero) // NULL
+      if(is_null_pointer(constant))
       {
         address=0;
         return true;
@@ -380,8 +380,7 @@ simplify_exprt::simplify_pointer_offset(const unary_exprt &expr)
   {
     const constant_exprt &c_ptr = to_constant_expr(ptr);
 
-    if(c_ptr.get_value()==ID_NULL ||
-       c_ptr.value_is_zero_string())
+    if(is_null_pointer(c_ptr))
     {
       return from_integer(0, expr.type());
     }
@@ -575,7 +574,7 @@ simplify_exprt::simplify_is_dynamic_object(const unary_exprt &expr)
   }
 
   // NULL is not dynamic
-  if(op.id() == ID_constant && op.get(ID_value) == ID_NULL)
+  if(op.id() == ID_constant && is_null_pointer(to_constant_expr(op)))
     return false_exprt();
 
   // &something depends on the something
@@ -623,7 +622,7 @@ simplify_exprt::simplify_is_invalid_pointer(const unary_exprt &expr)
   }
 
   // NULL is not invalid
-  if(op.id()==ID_constant && op.get(ID_value)==ID_NULL)
+  if(op.id() == ID_constant && is_null_pointer(to_constant_expr(op)))
   {
     return false_exprt();
   }

--- a/src/util/simplify_utils.cpp
+++ b/src/util/simplify_utils.cpp
@@ -12,6 +12,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "c_types.h"
 #include "config.h"
 #include "endianness_map.h"
+#include "expr_util.h"
 #include "namespace.h"
 #include "pointer_expr.h"
 #include "pointer_offset_size.h"
@@ -433,7 +434,7 @@ expr2bits(const exprt &expr, bool little_endian, const namespacet &ns)
     }
     else if(type.id() == ID_pointer)
     {
-      if(value == ID_NULL && config.ansi_c.NULL_is_zero)
+      if(config.ansi_c.NULL_is_zero && is_null_pointer(to_constant_expr(expr)))
         return std::string(to_bitvector_type(type).get_width(), '0');
       else
         return {};


### PR DESCRIPTION
A pointer-typed constant expression with value "NULL" is always a null
pointer expression. When NULL_is_zero is true in the platform
configuration, a value "0" is also a null pointer.

These possible options were repeatedly, but not consistently, evaluated
ad-hoc. This resulted in a least one missed simplification opportunity
as we noticed on an RMC-generated goto binary (which had 0 instead of
NULL in a pointer-typed constant).

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
