### PR TITLE
Function contracts: check loop freeness before instrumentation, skip assignments to locals and prune write set using CFG info.

### DIFF
--- a/regression/contracts/assigns_enforce_04/test.desc
+++ b/regression/contracts/assigns_enforce_04/test.desc
@@ -3,12 +3,6 @@ main.c
 --enforce-contract f1
 ^EXIT=0$
 ^SIGNAL=0$
-^\[f1.\d+\] line \d+ Check that x2 is assignable: SUCCESS$
-^\[f1.\d+\] line \d+ Check that y2 is assignable: SUCCESS$
-^\[f1.\d+\] line \d+ Check that z2 is assignable: SUCCESS$
-^\[f2.\d+\] line \d+ Check that x3 is assignable: SUCCESS$
-^\[f2.\d+\] line \d+ Check that y3 is assignable: SUCCESS$
-^\[f2.\d+\] line \d+ Check that z3 is assignable: SUCCESS$
 ^\[f3.\d+\] line \d+ Check that \*x3 is assignable: SUCCESS$
 ^\[f3.\d+\] line \d+ Check that \*y3 is assignable: SUCCESS$
 ^\[f3.\d+\] line \d+ Check that \*z3 is assignable: SUCCESS$

--- a/regression/contracts/assigns_enforce_05/test.desc
+++ b/regression/contracts/assigns_enforce_05/test.desc
@@ -3,7 +3,6 @@ main.c
 --enforce-contract f1 --enforce-contract f2 --enforce-contract f3
 ^EXIT=0$
 ^SIGNAL=0$
-^\[f1.1\] line \d+ .*: SUCCESS$
 ^VERIFICATION SUCCESSFUL$
 --
 --

--- a/regression/contracts/assigns_enforce_18/test.desc
+++ b/regression/contracts/assigns_enforce_18/test.desc
@@ -7,9 +7,6 @@ main.c
 ^\[bar.\d+\] line \d+ Check that \*b is assignable: SUCCESS$
 ^\[baz.\d+\] line \d+ Check that POINTER_OBJECT\(\(void \*\)c\) is assignable: FAILURE$
 ^\[baz.\d+\] line \d+ Check that \*a is assignable: SUCCESS$
-^\[foo.\d+\] line \d+ Check that a is assignable: SUCCESS$
-^\[foo.\d+\] line \d+ Check that yp is assignable: SUCCESS$
-^\[foo.\d+\] line \d+ Check that z is assignable: SUCCESS$
 ^\[foo.\d+\] line \d+ Check that \*xp is assignable: SUCCESS$
 ^\[foo.\d+\] line \d+ Check that y is assignable: FAILURE$
 ^\[foo.\d+\] line \d+ Check that POINTER_OBJECT\(\(void \*\)yp\) is assignable: SUCCESS$

--- a/regression/contracts/assigns_enforce_21/test.desc
+++ b/regression/contracts/assigns_enforce_21/test.desc
@@ -6,9 +6,6 @@ main.c
 main.c function bar
 ^\[bar.\d+\] line \d+ Check that \*y is assignable: SUCCESS$
 ^\[bar.\d+\] line \d+ Check that x is assignable: FAILURE$
-^\[baz.\d+\] line \d+ Check that w is assignable: SUCCESS$
-^\[foo.\d+\] line \d+ Check that w is assignable: SUCCESS$
-^\[foo.\d+\] line \d+ Check that z is assignable: SUCCESS$
 ^VERIFICATION FAILED$
 --
 --

--- a/regression/contracts/assigns_enforce_arrays_01/main.c
+++ b/regression/contracts/assigns_enforce_arrays_01/main.c
@@ -1,4 +1,4 @@
-void f1(int a[], int len) __CPROVER_assigns(a)
+void f1(int a[], int len) __CPROVER_assigns()
 {
   int b[10];
   a = b;

--- a/regression/contracts/assigns_enforce_arrays_03/main.c
+++ b/regression/contracts/assigns_enforce_arrays_03/main.c
@@ -1,4 +1,4 @@
-void assign_out_under(int a[], int len) __CPROVER_assigns(a)
+void assign_out_under(int a[], int len) __CPROVER_assigns()
 {
   a[1] = 5;
 }

--- a/regression/contracts/assigns_enforce_arrays_03/test.desc
+++ b/regression/contracts/assigns_enforce_arrays_03/test.desc
@@ -6,5 +6,6 @@ main.c
 ^VERIFICATION FAILED$
 --
 --
-Checks whether verification fails when an assigns clause contains pointer,
-but function only modifies its content.
+Checks whether verification fails when a function has an array 
+as parameter, an empty assigns clause and attempts to modify the object
+pointed to by the pointer.

--- a/regression/contracts/assigns_enforce_arrays_04/main.c
+++ b/regression/contracts/assigns_enforce_arrays_04/main.c
@@ -1,21 +1,20 @@
-void assigns_single(int a[], int len) __CPROVER_assigns(a)
+void assigns_single(int a[], int len)
 {
+  int i;
+  __CPROVER_assume(0 <= i && i < len);
+  a[i] = 0;
 }
 
-void assigns_range(int a[], int len) __CPROVER_assigns(a)
-{
-}
-
-void assigns_big_range(int a[], int len) __CPROVER_assigns(a)
+void uses_assigns(int a[], int len)
+  __CPROVER_assigns(__CPROVER_POINTER_OBJECT(a))
 {
   assigns_single(a, len);
-  assigns_range(a, len);
 }
 
 int main()
 {
   int arr[10];
-  assigns_big_range(arr, 10);
+  uses_assigns(arr, 10);
 
   return 0;
 }

--- a/regression/contracts/assigns_enforce_arrays_04/test.desc
+++ b/regression/contracts/assigns_enforce_arrays_04/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---enforce-contract assigns_single --enforce-contract assigns_range --enforce-contract assigns_big_range
+--enforce-contract uses_assigns
 ^EXIT=0$
 ^SIGNAL=0$
 ^VERIFICATION SUCCESSFUL$

--- a/regression/contracts/assigns_enforce_arrays_05/main.c
+++ b/regression/contracts/assigns_enforce_arrays_05/main.c
@@ -1,18 +1,23 @@
-void assigns_ptr(int *x) __CPROVER_assigns(*x)
+void assigns_ptr(int *x)
 {
   *x = 200;
 }
 
-void assigns_range(int a[], int len) __CPROVER_assigns(a)
+void uses_assigns(int a[], int i, int len)
+  // clang-format off
+ __CPROVER_requires(0 <= i && i < len)
+  __CPROVER_assigns(*(&a[i]))
+// clang-format on
 {
-  int *ptr = &(a[7]);
+  int *ptr = &(a[i]);
   assigns_ptr(ptr);
 }
 
 int main()
 {
   int arr[10];
-  assigns_range(arr, 10);
-
+  int i;
+  __CPROVER_assume(0 <= i && i < 10);
+  uses_assigns(arr, i, 10);
   return 0;
 }

--- a/regression/contracts/assigns_enforce_arrays_05/test.desc
+++ b/regression/contracts/assigns_enforce_arrays_05/test.desc
@@ -1,11 +1,10 @@
 CORE
 main.c
---enforce-contract assigns_range
-^EXIT=10$
+--enforce-contract uses_assigns
+^EXIT=0$
 ^SIGNAL=0$
-^VERIFICATION FAILED$
+^\[assigns_ptr\.\d+\] line \d+ Check that \*x is assignable: SUCCESS$
+^VERIFICATION SUCCESSFUL$
 --
 --
-Checks whether verification fails when an assigns clause of a function
-indicates the pointer might change, but one of its internal function only
-modified its content.
+Checks whether verification succeeds for array elements at a symbolic index. 

--- a/regression/contracts/assigns_enforce_detect_local_statics/test.desc
+++ b/regression/contracts/assigns_enforce_detect_local_statics/test.desc
@@ -1,13 +1,12 @@
 CORE
 main.c
 --enforce-contract bar
+^\[foo.\d+\] line 14 Check that foo\$\$1\$\$x is assignable: SUCCESS
+^\[foo.\d+\] line 17 Check that \*y is assignable: SUCCESS
+^\[foo.\d+\] line 20 Check that \*yy is assignable: FAILURE
+^VERIFICATION FAILED$
 ^EXIT=10$
 ^SIGNAL=0$
-^\[foo.\d+\] line \d+ Check that y is assignable: SUCCESS$
-^\[foo.\d+\] line \d+ Check that foo\$\$1\$\$x is assignable: SUCCESS$
-^\[foo.\d+\] line \d+ Check that \*y is assignable: SUCCESS$
-^\[foo.\d+\] line \d+ Check that \*yy is assignable: FAILURE$
-^VERIFICATION FAILED$
 --
 --
 Checks whether static local and global variables are correctly tracked

--- a/regression/contracts/assigns_enforce_free_dead/test.desc
+++ b/regression/contracts/assigns_enforce_free_dead/test.desc
@@ -7,12 +7,6 @@ main.c
 ^\[foo.\d+\] line \d+ Check that \*q is assignable: SUCCESS$
 ^\[foo.\d+\] line \d+ Check that \*w is assignable: SUCCESS$
 ^\[foo.\d+\] line \d+ Check that \*x is assignable: SUCCESS$
-^\[foo.\d+\] line \d+ Check that a is assignable: SUCCESS$
-^\[foo.\d+\] line \d+ Check that q is assignable: SUCCESS$
-^\[foo.\d+\] line \d+ Check that w is assignable: SUCCESS$
-^\[foo.\d+\] line \d+ Check that x is assignable: SUCCESS$
-^\[foo.\d+\] line \d+ Check that y is assignable: SUCCESS$
-^\[foo.\d+\] line \d+ Check that z is assignable: SUCCESS$
 ^\[foo.\d+\] line \d+ Check that POINTER_OBJECT\(\(void \*\)z\) is assignable: SUCCESS$
 ^EXIT=10$
 ^SIGNAL=0$
@@ -22,16 +16,7 @@ main.c
 ^\[foo.\d+\] line \d+ Check that \*q is assignable: FAILURE$
 ^\[foo.\d+\] line \d+ Check that \*w is assignable: FAILURE$
 ^\[foo.\d+\] line \d+ Check that \*x is assignable: FAILURE$
-^\[foo.\d+\] line \d+ Check that a is assignable: FAILURE$
-^\[foo.\d+\] line \d+ Check that q is assignable: FAILURE$
-^\[foo.\d+\] line \d+ Check that w is assignable: FAILURE$
-^\[foo.\d+\] line \d+ Check that x is assignable: FAILURE$
-^\[foo.\d+\] line \d+ Check that y is assignable: FAILURE$
-^\[foo.\d+\] line \d+ Check that z is assignable: FAILURE$
 ^\[foo.\d+\] line \d+ Check that POINTER_OBJECT\(\(void \*\)z\) is assignable: FAILURE$
-^.*__car_valid.*: FAILURE$
-^.*__car_lb.*: FAILURE$
-^.*__car_ub.*: FAILURE$
 --
 Checks that invalidated CARs are correctly tracked on `free` and `DEAD`.
 
@@ -40,6 +25,3 @@ we rule out all failures using the negative regex matches above.
 
 We also check (using positive regex matches above) that
 `**p` should be assignable in one case and should not be assignable in the other.
-
-Finally, we check that there should be no "internal" assertion failures
-on `__car_valid`, `__car_ub`, `__car_lb` variables used to track CARs.

--- a/regression/contracts/assigns_enforce_malloc_01/main.c
+++ b/regression/contracts/assigns_enforce_malloc_01/main.c
@@ -1,16 +1,15 @@
 #include <stdlib.h>
 
-int f1(int *a, int *b) __CPROVER_assigns(*a, b)
+int f(int *a) __CPROVER_assigns()
 {
-  b = (int *)malloc(sizeof(int));
-  *b = 5;
+  a = (int *)malloc(sizeof(int));
+  *a = 5;
 }
 
 int main()
 {
   int m = 4;
-  int n = 3;
-  f1(&m, &n);
+  f(&m);
 
   return 0;
 }

--- a/regression/contracts/assigns_enforce_malloc_01/test.desc
+++ b/regression/contracts/assigns_enforce_malloc_01/test.desc
@@ -1,9 +1,12 @@
 CORE
 main.c
---enforce-contract f1
+--enforce-contract f
 ^EXIT=0$
 ^SIGNAL=0$
+^\[f\.\d+\] line \d+ Check that \*a is assignable: SUCCESS
 ^VERIFICATION SUCCESSFUL$
 --
 --
-This test checks that verification succeeds when a formal parameter pointer outside of the assigns clause is instead pointed as freshly allocated memory before being assigned.
+This test checks that verification succeeds when a formal parameter
+with a pointer type is first updated to point to a locally malloc'd object
+before being assigned to.

--- a/regression/contracts/assigns_enforce_malloc_02/test.desc
+++ b/regression/contracts/assigns_enforce_malloc_02/test.desc
@@ -1,9 +1,11 @@
 CORE
 main.c
 --enforce-contract f1
-^EXIT=6$
+^Invariant check failed$
+^Condition: is_loop_free
+^Reason: Loops remain in function 'f1', assigns clause checking instrumentation cannot be applied\.
+^EXIT=(127|134)$
 ^SIGNAL=0$
-Unable to complete instrumentation, as this malloc may be in a loop.$
 --
 --
 This test checks that an error is thrown when malloc is called within a loop.

--- a/regression/contracts/assigns_enforce_multi_file_02/header.h
+++ b/regression/contracts/assigns_enforce_multi_file_02/header.h
@@ -14,7 +14,7 @@ struct pair_of_pairs
 
 int f1(int *a, struct pair *b);
 
-int f1(int *a, struct pair *b) __CPROVER_assigns(*a, b)
+int f1(int *a, struct pair *b) __CPROVER_assigns(*a)
 {
   struct pair_of_pairs *pop =
     (struct pair_of_pairs *)malloc(sizeof(struct pair_of_pairs));

--- a/regression/contracts/assigns_enforce_multi_file_02/test.desc
+++ b/regression/contracts/assigns_enforce_multi_file_02/test.desc
@@ -3,6 +3,7 @@ main.c
 --enforce-contract f1
 ^EXIT=0$
 ^SIGNAL=0$
+^\[f1\.\d+\] line \d+ Check that b->y is assignable: SUCCESS$
 ^VERIFICATION SUCCESSFUL$
 --
 --

--- a/regression/contracts/assigns_enforce_statics/test.desc
+++ b/regression/contracts/assigns_enforce_statics/test.desc
@@ -3,7 +3,6 @@ main.c
 --enforce-contract foo _ --pointer-primitive-check
 ^EXIT=0$
 ^SIGNAL=0$
-^\[foo.\d+\] line \d+ Check that y is assignable: SUCCESS$
 ^\[foo.\d+\] line \d+ Check that foo\$\$1\$\$x is assignable: SUCCESS$
 ^\[foo.\d+\] line \d+ Check that \*y is assignable: SUCCESS$
 ^VERIFICATION SUCCESSFUL$

--- a/regression/contracts/assigns_enforce_structs_01/main.c
+++ b/regression/contracts/assigns_enforce_structs_01/main.c
@@ -6,18 +6,17 @@ struct pair
   int y;
 };
 
-int f1(int *a, int *b) __CPROVER_assigns(*a, b)
+int f(int *a) __CPROVER_assigns()
 {
   struct pair *p = (struct pair *)malloc(sizeof(struct pair));
-  b = &(p->y);
-  *b = 5;
+  a = &(p->y);
+  *a = 5;
 }
 
 int main()
 {
   int m = 4;
-  int n = 3;
-  f1(&m, &n);
+  f(&m);
 
   return 0;
 }

--- a/regression/contracts/assigns_enforce_structs_01/test.desc
+++ b/regression/contracts/assigns_enforce_structs_01/test.desc
@@ -1,11 +1,12 @@
 CORE
 main.c
---enforce-contract f1
+--enforce-contract f
 ^EXIT=0$
 ^SIGNAL=0$
+^\[f\.\d+\] line \d+ Check that \*a is assignable: SUCCESS$
 ^VERIFICATION SUCCESSFUL$
 --
 --
-Checks whether verification succeeds when a formal parameter pointer outside
-of the assigns clause is instead pointed at the location of a member of a
-freshly allocated struct before being assigned.
+Checks whether verification succeeds when a pointer deref that is not
+specified in the assigns clause is first pointed at a member of a
+locally malloc'd struct before being assigned.

--- a/regression/contracts/assigns_enforce_structs_02/main.c
+++ b/regression/contracts/assigns_enforce_structs_02/main.c
@@ -12,19 +12,18 @@ struct pair_of_pairs
   struct pair p2;
 };
 
-int f1(int *a, int *b) __CPROVER_assigns(*a, b)
+int f(int *a) __CPROVER_assigns()
 {
   struct pair_of_pairs *pop =
     (struct pair_of_pairs *)malloc(sizeof(struct pair_of_pairs));
-  b = &(pop->p2.x);
-  *b = 5;
+  a = &(pop->p2.x);
+  *a = 5;
 }
 
 int main()
 {
   int m = 4;
-  int n = 3;
-  f1(&m, &n);
+  f(&m);
 
   return 0;
 }

--- a/regression/contracts/assigns_enforce_structs_02/test.desc
+++ b/regression/contracts/assigns_enforce_structs_02/test.desc
@@ -1,13 +1,12 @@
 CORE
 main.c
---enforce-contract f1
+--enforce-contract f
 ^EXIT=0$
 ^SIGNAL=0$
+^\[f\.\d+\] line \d+ Check that \*a is assignable: SUCCESS$
 ^VERIFICATION SUCCESSFUL$
 --
 --
-Checks whether verification succeeds when a formal parameter pointer outside
-of the assigns clause is assigned after being pointed at the location of a
-member of a sub-struct of a freshly allocated struct before being assigned.
-This is meant to show that all contained members (and their contained members)
-of assignable structs are valid to assign.
+Checks whether verification succeeds when a pointer deref that is not
+specified in the assigns clause is first pointed at a member of a locally
+malloc'd struct before being assigned (with extra nesting).

--- a/regression/contracts/assigns_enforce_structs_03/main.c
+++ b/regression/contracts/assigns_enforce_structs_03/main.c
@@ -12,19 +12,18 @@ struct pair_of_pairs
   struct pair p2;
 };
 
-int f1(int *a, struct pair *b) __CPROVER_assigns(*a, b)
+int f(struct pair *a) __CPROVER_assigns()
 {
   struct pair_of_pairs *pop =
     (struct pair_of_pairs *)malloc(sizeof(struct pair_of_pairs));
-  b = &(pop->p2);
-  b->y = 5;
+  a = &(pop->p2);
+  a->y = 5;
 }
 
 int main()
 {
-  int m = 4;
-  struct pair n;
-  f1(&m, &n);
+  struct pair m;
+  f(&m);
 
   return 0;
 }

--- a/regression/contracts/assigns_enforce_structs_03/test.desc
+++ b/regression/contracts/assigns_enforce_structs_03/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---enforce-contract f1
+--enforce-contract f
 ^EXIT=0$
 ^SIGNAL=0$
 ^VERIFICATION SUCCESSFUL$

--- a/regression/contracts/assigns_enforce_structs_04/test.desc
+++ b/regression/contracts/assigns_enforce_structs_04/test.desc
@@ -6,7 +6,6 @@ main.c
 ^\[f1.\d+\] line \d+ Check that p->y is assignable: FAILURE$
 ^\[f2.\d+\] line \d+ Check that p->x is assignable: FAILURE$
 ^\[f3.\d+\] line \d+ Check that p->y is assignable: SUCCESS$
-^\[f4.\d+\] line \d+ Check that p is assignable: SUCCESS$
 ^VERIFICATION FAILED$
 --
 --

--- a/regression/contracts/assigns_enforce_subfunction_calls/test.desc
+++ b/regression/contracts/assigns_enforce_subfunction_calls/test.desc
@@ -3,28 +3,15 @@ main.c
 --enforce-contract foo
 ^EXIT=10$
 ^SIGNAL=0$
-^main.c function bar$
-^\[bar.1\] line \d+ Check that x is assignable: SUCCESS$
-^\[bar.2\] line \d+ Check that y is assignable: SUCCESS$
-^\[bar.3\] line \d+ Check that x is assignable: SUCCESS$
-^\[bar.4\] line \d+ Check that y is assignable: SUCCESS$
 ^main.c function baz$
 ^\[baz.1\] line \d+ Check that \*x is assignable: SUCCESS$
 ^\[baz.2\] line \d+ Check that \*x is assignable: SUCCESS$
 ^\[baz.3\] line \d+ Check that \*x is assignable: FAILURE$
 ^\[baz.4\] line \d+ Check that \*x is assignable: FAILURE$
 ^main.c function foo$
-^\[foo.1\] line \d+ Check that x is assignable: SUCCESS$
-^\[foo.2\] line \d+ Check that y is assignable: SUCCESS$
 ^\[foo.assertion.1\] line \d+ foo.x.set: SUCCESS$
-^\[foo.3\] line \d+ Check that x is assignable: SUCCESS$
-^\[foo.4\] line \d+ Check that y is assignable: SUCCESS$
 ^\[foo.assertion.2\] line \d+ foo.local.set: SUCCESS$
-^\[foo.5\] line \d+ Check that x is assignable: SUCCESS$
-^\[foo.6\] line \d+ Check that y is assignable: SUCCESS$
 ^\[foo.assertion.3\] line \d+ foo.y.set: SUCCESS$
-^\[foo.7\] line \d+ Check that x is assignable: SUCCESS$
-^\[foo.8\] line \d+ Check that y is assignable: SUCCESS$
 ^\[foo.assertion.4\] line \d+ foo.z.set: SUCCESS$
 ^VERIFICATION FAILED$
 --

--- a/regression/contracts/assigns_function_pointer/main.c
+++ b/regression/contracts/assigns_function_pointer/main.c
@@ -3,22 +3,36 @@
 
 int x = 0;
 
+struct fptr_t
+{
+  void (*f)();
+};
+
 void foo()
 {
   x = 1;
 }
 
-void bar(void (*fun_ptr)()) __CPROVER_assigns(fun_ptr)
+void foofoo()
 {
-  fun_ptr = &foo;
+  x = 2;
+}
+
+void bar(struct fptr_t *s, void (**f)()) __CPROVER_assigns(s->f, *f)
+{
+  s->f = &foo;
+  *f = &foofoo;
 }
 
 int main()
 {
   assert(x == 0);
-  void (*fun_ptr)() = NULL;
-  bar(fun_ptr);
-  fun_ptr();
+  struct fptr_t s;
+  void (*f)();
+  bar(&s, &f);
+  s.f();
   assert(x == 1);
+  f();
+  assert(x == 2);
   return 0;
 }

--- a/regression/contracts/assigns_function_pointer/test.desc
+++ b/regression/contracts/assigns_function_pointer/test.desc
@@ -3,9 +3,12 @@ main.c
 --enforce-contract bar
 ^EXIT=0$
 ^SIGNAL=0$
-^\[bar.1\] line \d+ Check that fun\_ptr is assignable: SUCCESS$
 ^\[main.assertion.\d+\] line \d+ assertion x \=\= 0: SUCCESS$
+^\[bar\.\d+\] line \d+ Check that s->f is assignable: SUCCESS$
+^\[bar\.\d+\] line \d+ Check that \*f is assignable: SUCCESS$
 ^\[main.assertion.\d+\] line \d+ assertion x \=\= 1: SUCCESS$
+^\[main.assertion.\d+\] line \d+ assertion x \=\= 2: SUCCESS$
 ^VERIFICATION SUCCESSFUL$
 --
-Checks whether assigns clause accepts function pointers.
+Checks whether assigns clause accepts function pointers
+and pointers to function pointers.

--- a/regression/contracts/assigns_type_checking_valid_cases/main.c
+++ b/regression/contracts/assigns_type_checking_valid_cases/main.c
@@ -14,17 +14,17 @@ struct buf
   struct blob aux;
 };
 
-void foo1(int a) __CPROVER_assigns(a)
+void foo1(int a) __CPROVER_assigns()
 {
   a = 0;
 }
 
-void foo2(int *b) __CPROVER_assigns(b)
+void foo2(int *b) __CPROVER_assigns()
 {
   b = NULL;
 }
 
-void foo3(int a, int *b) __CPROVER_assigns(b, x, y)
+void foo3(int a, int *b) __CPROVER_assigns(x, y)
 {
   b = NULL;
   x = malloc(sizeof(*x));
@@ -32,14 +32,14 @@ void foo3(int a, int *b) __CPROVER_assigns(b, x, y)
 }
 
 void foo4(int a, int *b, int *c) __CPROVER_requires(c != NULL)
-  __CPROVER_requires(x != NULL) __CPROVER_assigns(b, *c, *x)
+  __CPROVER_requires(x != NULL) __CPROVER_assigns(*c, *x)
 {
   b = NULL;
   *c = 0;
   *x = 0;
 }
 
-void foo5(struct buf buffer) __CPROVER_assigns(buffer)
+void foo5(struct buf buffer) __CPROVER_assigns()
 {
   buffer.data = NULL;
   buffer.len = 0;
@@ -73,7 +73,7 @@ void foo8(int array[]) __CPROVER_assigns(__CPROVER_POINTER_OBJECT(array))
   array[9] = 1;
 }
 
-void foo9(int array[]) __CPROVER_assigns(array)
+void foo9(int array[]) __CPROVER_assigns()
 {
   int *new_array = NULL;
   array = new_array;

--- a/regression/contracts/assigns_type_checking_valid_cases/test.desc
+++ b/regression/contracts/assigns_type_checking_valid_cases/test.desc
@@ -3,13 +3,9 @@ main.c
 --enforce-contract foo1 --enforce-contract foo2 --enforce-contract foo3 --enforce-contract foo4 --enforce-contract foo5 --enforce-contract foo6 --enforce-contract foo7 --enforce-contract foo8 --enforce-contract foo9 --enforce-contract foo10 _ --pointer-primitive-check
 ^EXIT=0$
 ^SIGNAL=0$
-^\[foo1.\d+\] line \d+ Check that a is assignable: SUCCESS$
 ^\[foo10.\d+\] line \d+ Check that buffer->len is assignable: SUCCESS$
 ^\[foo10.\d+\] line \d+ Check that buffer->aux\.allocated is assignable: SUCCESS$
-^\[foo2.\d+\] line \d+ Check that b is assignable: SUCCESS$
-^\[foo3.\d+\] line \d+ Check that b is assignable: SUCCESS$
 ^\[foo3.\d+\] line \d+ Check that y is assignable: SUCCESS$
-^\[foo4.\d+\] line \d+ Check that b is assignable: SUCCESS$
 ^\[foo4.\d+\] line \d+ Check that \*c is assignable: SUCCESS$
 ^\[foo4.\d+\] line \d+ Check that \*x is assignable: SUCCESS$
 ^\[foo5.\d+\] line \d+ Check that buffer.data is assignable: SUCCESS$
@@ -28,7 +24,6 @@ main.c
 ^\[foo8.\d+\] line \d+ Check that array\[\(.* int\)7\] is assignable: SUCCESS$
 ^\[foo8.\d+\] line \d+ Check that array\[\(.* int\)8\] is assignable: SUCCESS$
 ^\[foo8.\d+\] line \d+ Check that array\[\(.* int\)9\] is assignable: SUCCESS$
-^\[foo9.\d+\] line \d+ Check that array is assignable: SUCCESS$
 ^VERIFICATION SUCCESSFUL$
 --
 Checks whether CBMC parses correctly all standard cases for assigns clauses.

--- a/regression/contracts/assigns_validity_pointer_01/test.desc
+++ b/regression/contracts/assigns_validity_pointer_01/test.desc
@@ -8,7 +8,6 @@ SUCCESS
 // bar
 ASSERT \*foo::x > 0
 IF ¬\(\*foo::x = 3\) THEN GOTO \d
-IF ¬\(.*0.* = NULL\) THEN GOTO \d
 ASSIGN .*::tmp_if_expr := \(\*\(.*0.*\) = 5 \? true : false\)
 ASSIGN .*::tmp_if_expr\$\d := .*::tmp_if_expr \? true : false
 ASSUME .*::tmp_if_expr\$\d

--- a/regression/contracts/assigns_validity_pointer_02/test.desc
+++ b/regression/contracts/assigns_validity_pointer_02/test.desc
@@ -7,8 +7,6 @@ main.c
 ^\[bar.\d+\] line \d+ Check that \*x is assignable: SUCCESS$
 ^\[bar.\d+\] line \d+ Check that \*y is assignable: SUCCESS$
 ^\[baz.\d+\] line \d+ Check that \*z is assignable: SUCCESS$
-^\[foo.\d+\] line \d+ Check that x is assignable: SUCCESS$
-^\[foo.\d+\] line \d+ Check that y is assignable: SUCCESS$
 ^\[foo.\d+\] line \d+ Check that \*x is assignable: SUCCESS$
 ^VERIFICATION SUCCESSFUL$
 --

--- a/regression/contracts/function_check_02/main.c
+++ b/regression/contracts/function_check_02/main.c
@@ -15,10 +15,16 @@ int initialize(int *arr)
   )
 // clang-format on
 {
-  for(int i = 0; i < 10; i++)
-  {
-    arr[i] = i;
-  }
+  arr[0] = 0;
+  arr[1] = 1;
+  arr[2] = 2;
+  arr[3] = 3;
+  arr[4] = 4;
+  arr[5] = 5;
+  arr[6] = 6;
+  arr[7] = 7;
+  arr[8] = 8;
+  arr[9] = 9;
 
   return 0;
 }

--- a/regression/contracts/history-pointer-enforce-10/main.c
+++ b/regression/contracts/history-pointer-enforce-10/main.c
@@ -23,7 +23,7 @@ void bar(struct pair *p) __CPROVER_assigns(p->y)
   p->y = (p->y + 5);
 }
 
-void baz(struct pair p) __CPROVER_assigns(p)
+void baz(struct pair p) __CPROVER_assigns()
   __CPROVER_ensures(p == __CPROVER_old(p))
 {
   struct pair pp = p;

--- a/regression/contracts/history-pointer-enforce-10/test.desc
+++ b/regression/contracts/history-pointer-enforce-10/test.desc
@@ -7,8 +7,6 @@ main.c
 ^\[postcondition.\d+\] file main.c line \d+ Check ensures clause: SUCCESS$
 ^\[postcondition.\d+\] file main.c line \d+ Check ensures clause: SUCCESS$
 ^\[bar.\d+\] line \d+ Check that p->y is assignable: SUCCESS$
-^\[baz.\d+\] line \d+ Check that p is assignable: SUCCESS$
-^\[baz.\d+\] line \d+ Check that p is assignable: SUCCESS$
 ^\[foo.\d+\] line \d+ Check that \*p->y is assignable: SUCCESS$
 ^\[foo.\d+\] line \d+ Check that z is assignable: SUCCESS$
 ^\[main.assertion.\d+\] line \d+ assertion \*\(p->y\) == 7: SUCCESS$
@@ -19,3 +17,5 @@ main.c
 This test checks that history variables are supported for structs, symbols, and
 struct members. By using the --enforce-contract flag, the postcondition
 (with history variable) is asserted. In this case, this assertion should pass.
+Note: A function is always authorized to assign the variables that store
+its arguments, there is no need to mention them in the assigns clause.

--- a/regression/contracts/loop-freeness-check/main.c
+++ b/regression/contracts/loop-freeness-check/main.c
@@ -1,0 +1,16 @@
+int foo(int *arr)
+  // clang-format off
+  __CPROVER_assigns(__CPROVER_POINTER_OBJECT(arr))
+// clang-format off
+{
+  for(int i = 0; i < 10; i++)
+    arr[i] = i;
+
+  return 0;
+}
+
+int main()
+{
+  int arr[10];
+  foo(arr);
+}

--- a/regression/contracts/loop-freeness-check/test.desc
+++ b/regression/contracts/loop-freeness-check/test.desc
@@ -1,0 +1,13 @@
+CORE
+main.c
+--enforce-contract foo
+^--- begin invariant violation report ---$
+^Invariant check failed$
+^Condition: is_loop_free\(.*\)
+^Reason: Loops remain in function 'foo', assigns clause checking instrumentation cannot be applied\.$
+^EXIT=(127|134)$
+^SIGNAL=0$
+--
+--
+This test checks that loops that remain in the program when attempting to 
+instrument assigns clauses are detected and trigger an INVARIANT.

--- a/regression/contracts/quantifiers-exists-ensures-enforce/main.c
+++ b/regression/contracts/quantifiers-exists-ensures-enforce/main.c
@@ -7,10 +7,16 @@ int f1(int *arr)
   })
 // clang-format on
 {
-  for(int i = 0; i < 10; i++)
-  {
-    arr[i] = i;
-  }
+  arr[0] = 0;
+  arr[1] = 1;
+  arr[2] = 2;
+  arr[3] = 3;
+  arr[4] = 4;
+  arr[5] = 5;
+  arr[6] = 6;
+  arr[7] = 7;
+  arr[8] = 8;
+  arr[9] = 9;
 
   return 0;
 }
@@ -24,10 +30,16 @@ int f2(int *arr)
   })
 // clang-format on
 {
-  for(int i = 0; i < 10; i++)
-  {
-    arr[i] = 0;
-  }
+  arr[0] = 0;
+  arr[1] = 1;
+  arr[2] = 2;
+  arr[3] = 3;
+  arr[4] = 4;
+  arr[5] = 5;
+  arr[6] = 6;
+  arr[7] = 7;
+  arr[8] = 8;
+  arr[9] = 9;
 
   return 0;
 }

--- a/regression/contracts/quantifiers-exists-requires-enforce/main.c
+++ b/regression/contracts/quantifiers-exists-requires-enforce/main.c
@@ -1,7 +1,7 @@
 #include <stdbool.h>
 #include <stdlib.h>
 
-#define MAX_LEN 64
+#define MAX_LEN 10
 
 // clang-format off
 bool f1(int *arr, int len)
@@ -18,11 +18,27 @@ bool f1(int *arr, int len)
 // clang-format on
 {
   bool found_four = false;
-  for(int i = 0; i <= MAX_LEN; i++)
-  {
-    if(i < len)
-      found_four |= (arr[i] == 4);
-  }
+  if(0 < len)
+    found_four |= (arr[0] == 4);
+  if(1 < len)
+    found_four |= (arr[1] == 4);
+  if(2 < len)
+    found_four |= (arr[2] == 4);
+  if(3 < len)
+    found_four |= (arr[3] == 4);
+  if(4 < len)
+    found_four |= (arr[4] == 4);
+  if(5 < len)
+    found_four |= (arr[5] == 4);
+  if(6 < len)
+    found_four |= (arr[6] == 4);
+  if(7 < len)
+    found_four |= (arr[7] == 4);
+  if(8 < len)
+    found_four |= (arr[8] == 4);
+
+  if(9 < len)
+    found_four |= (arr[9] == 4);
 
   // clang-format off
   return (len > 0 ==> found_four);

--- a/regression/contracts/quantifiers-forall-ensures-enforce/main.c
+++ b/regression/contracts/quantifiers-forall-ensures-enforce/main.c
@@ -1,6 +1,6 @@
 #include <stdlib.h>
 
-#define MAX_LEN 16
+#define MAX_LEN 10
 
 // clang-format off
 int f1(int *arr, int len)
@@ -12,11 +12,27 @@ int f1(int *arr, int len)
   })
 // clang-format on
 {
-  for(int i = 0; i < MAX_LEN; i++)
-  {
-    if(i < len)
-      arr[i] = 0;
-  }
+  if(0 < len)
+    arr[0] = 0;
+  if(1 < len)
+    arr[1] = 0;
+  if(2 < len)
+    arr[2] = 0;
+  if(3 < len)
+    arr[3] = 0;
+  if(4 < len)
+    arr[4] = 0;
+  if(5 < len)
+    arr[5] = 0;
+  if(6 < len)
+    arr[6] = 0;
+  if(7 < len)
+    arr[7] = 0;
+  if(8 < len)
+    arr[8] = 0;
+  if(9 < len)
+    arr[9] = 0;
+
   return 0;
 }
 

--- a/regression/contracts/quantifiers-forall-ensures-enforce/test.desc
+++ b/regression/contracts/quantifiers-forall-ensures-enforce/test.desc
@@ -4,10 +4,11 @@ main.c
 ^EXIT=0$
 ^SIGNAL=0$
 ^\[postcondition.\d+\] file main.c line \d+ Check ensures clause: SUCCESS$
-^\[f1.\d+\] line \d+ Check that arr\[\(.*\)i\] is assignable: SUCCESS$
+^\[f1.\d+\] line \d+ Check that arr\[\(.*\)\d\] is assignable: SUCCESS$
 ^VERIFICATION SUCCESSFUL$
 --
 ^warning: ignoring
+^\[f1.\d+\] line \d+ Check that arr\[\(.*\)\d\] is assignable: FAILURE$
 --
 The purpose of this test is to ensure that we can safely use __CPROVER_forall
 within positive contexts (enforced ENSURES clauses).

--- a/regression/contracts/quantifiers-forall-requires-enforce/main.c
+++ b/regression/contracts/quantifiers-forall-requires-enforce/main.c
@@ -12,8 +12,16 @@ bool f1(int *arr)
 // clang-format on
 {
   bool is_identity = true;
-  for(int i = 0; i < 10; ++i)
-    is_identity &= (arr[i] == i);
+  is_identity &= (arr[0] == 0);
+  is_identity &= (arr[1] == 1);
+  is_identity &= (arr[2] == 2);
+  is_identity &= (arr[3] == 3);
+  is_identity &= (arr[4] == 4);
+  is_identity &= (arr[5] == 5);
+  is_identity &= (arr[6] == 6);
+  is_identity &= (arr[7] == 7);
+  is_identity &= (arr[8] == 8);
+  is_identity &= (arr[9] == 9);
   return is_identity;
 }
 

--- a/regression/contracts/quantifiers-nested-01/main.c
+++ b/regression/contracts/quantifiers-nested-01/main.c
@@ -11,10 +11,16 @@ int f1(int *arr)
   })
 // clang-format on
 {
-  for(int i = 0; i < 10; i++)
-  {
-    arr[i] = i;
-  }
+  arr[0] = 0;
+  arr[1] = 1;
+  arr[2] = 2;
+  arr[3] = 3;
+  arr[4] = 4;
+  arr[5] = 5;
+  arr[6] = 6;
+  arr[7] = 7;
+  arr[8] = 8;
+  arr[9] = 9;
 
   return 0;
 }

--- a/regression/contracts/quantifiers-nested-03/main.c
+++ b/regression/contracts/quantifiers-nested-03/main.c
@@ -10,10 +10,16 @@ __CPROVER_assigns(__CPROVER_POINTER_OBJECT(arr))
   )
 // clang-format on
 {
-  for(int i = 0; i < 10; i++)
-  {
-    arr[i] = i;
-  }
+  arr[0] = 0;
+  arr[1] = 1;
+  arr[2] = 2;
+  arr[3] = 3;
+  arr[4] = 4;
+  arr[5] = 5;
+  arr[6] = 6;
+  arr[7] = 7;
+  arr[8] = 8;
+  arr[9] = 9;
 
   return 0;
 }

--- a/regression/contracts/test_aliasing_ensure/main.c
+++ b/regression/contracts/test_aliasing_ensure/main.c
@@ -6,7 +6,7 @@ int z;
 
 // clang-format off
 int foo(int *x, int *y)
-  __CPROVER_assigns(z, *x, y)
+  __CPROVER_assigns(z, *x)
   __CPROVER_requires(
     __CPROVER_is_fresh(x, sizeof(int)) &&
     *x > 0 &&

--- a/regression/contracts/test_aliasing_ensure_indirect/main.c
+++ b/regression/contracts/test_aliasing_ensure_indirect/main.c
@@ -2,7 +2,7 @@
 #include <stdbool.h>
 #include <stdlib.h>
 
-void bar(int *z) __CPROVER_assigns(z)
+void bar(int *z) __CPROVER_assigns()
   __CPROVER_ensures(__CPROVER_is_fresh(z, sizeof(int)))
 {
   z = malloc(sizeof(*z));
@@ -11,7 +11,7 @@ void bar(int *z) __CPROVER_assigns(z)
 
 // clang-format off
 int foo(int *x, int *y)
-  __CPROVER_assigns(*x, y)
+  __CPROVER_assigns(*x)
   __CPROVER_requires(
     __CPROVER_is_fresh(x, sizeof(int)) &&
     *x > 0 &&

--- a/regression/contracts/test_aliasing_ensure_indirect/test.desc
+++ b/regression/contracts/test_aliasing_ensure_indirect/test.desc
@@ -4,7 +4,6 @@ main.c
 ^EXIT=0$
 ^SIGNAL=0$
 \[postcondition.\d+\] file main.c line \d+ Check ensures clause: SUCCESS
-\[bar.\d+\] line \d+ Check that z is assignable: SUCCESS
 \[foo.\d+\] line \d+ Check that \*x is assignable: SUCCESS
 \[main.assertion.\d+\] line \d+ assertion \!\(n \< 4\): SUCCESS
 ^VERIFICATION SUCCESSFUL$

--- a/src/goto-instrument/contracts/assigns.h
+++ b/src/goto-instrument/contracts/assigns.h
@@ -47,6 +47,11 @@ public:
       }
     };
 
+    /// Returns true whenever this CAR's `source_expr` and associated address
+    /// range may be alive at the instruction currently pointed to by
+    /// `cfg_info.target`.
+    bool maybe_alive(cfg_infot &cfg_info) const;
+
     const exprt source_expr;
     const source_locationt &location;
     const assigns_clauset &parent;
@@ -82,7 +87,9 @@ public:
   write_sett::const_iterator add_to_write_set(const exprt &);
   void remove_from_write_set(const exprt &);
 
-  exprt generate_inclusion_check(const conditional_address_ranget &) const;
+  exprt generate_inclusion_check(
+    const conditional_address_ranget &lhs,
+    optionalt<cfg_infot> &cfg_info_opt) const;
 
   const write_sett &get_write_set() const
   {


### PR DESCRIPTION
The first two commits are from this draft PR https://github.com/diffblue/cbmc/pull/6525 which adds a `maybe_alive` bit to  `local_bitvector_analysist` and is needed by this PR.

This PR adds:

In `check_frame_conditions_function`:
- a pass that simplifies away GOTO instructions for which the guard is always false
- a check that the program is loop-free before attempting instrumentation
- manual loop unrolling in regression tests that still contained loops and are got rejected because of this new check

For assigns clause checking: 
- Assigning to local variables or function parameter variables is always legal so we skip instrumenting these assignments, 
- We avoid adding function parameters and local variables to the local write set, except when their address is taken at some point in the program and can later be assigned to indirectly via pointers.
- When generating inclusion checks for assignments, we remove from the local write set targets which are not possibly alive at the ASSIGN instruction that gets instrumented.
- Tests have been simplified by removing function parameters from assigns clauses, and removing function parameters and local variables from test specifications.

The net effect of these changes is a better proof performance because of a reduction in the number of generated assertions and of their size, but otherwise the contract checking functionality remains unchanged.

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.
