### PR TITLE
Linking: shadowed symbols should not trigger warnings

### DIFF
--- a/regression/goto-cc-file-local/name-clash-with-suffix/test.desc
+++ b/regression/goto-cc-file-local/name-clash-with-suffix/test.desc
@@ -4,7 +4,7 @@ use_find out-file-counter final-link wall suffix assertion-check
 ^EXIT=0$
 ^SIGNAL=0$
 --
-^.*warning: function '__CPROVER_file_local_main_c_static_fun' in module 'main' is shadowed by a definition in module 'main'
+^.*: function '__CPROVER_file_local_main_c_static_fun' in module 'main' is shadowed by a definition in module 'main'
 ^warning: ignoring
 ^\*\*\*\* WARNING: no body for function
 --

--- a/regression/goto-cc-file-local/name-clash/test.desc
+++ b/regression/goto-cc-file-local/name-clash/test.desc
@@ -3,7 +3,7 @@ foo/bar/baz/main.c
 use_find out-file-counter final-link wall
 ^EXIT=0$
 ^SIGNAL=0$
-^.*warning: function '__CPROVER_file_local_main_c_static_fun' in module 'main' is shadowed by a definition in module 'main'
+^.*: function '__CPROVER_file_local_main_c_static_fun' in module 'main' is shadowed by a definition in module 'main'
 --
 ^warning: ignoring
 ^\*\*\*\* WARNING: no body for function

--- a/src/linking/linking.cpp
+++ b/src/linking/linking.cpp
@@ -796,12 +796,12 @@ void linkingt::duplicate_code_symbol(
     else if(base_type_eq(old_symbol.type, new_symbol.type, ns))
     {
       // keep the one in old_symbol -- libraries come last!
-      warning().source_location=new_symbol.location;
+      debug().source_location = new_symbol.location;
 
-      warning() << "function '" << old_symbol.name << "' in module '"
-                << new_symbol.module
-                << "' is shadowed by a definition in module '"
-                << old_symbol.module << "'" << eom;
+      debug() << "function '" << old_symbol.name << "' in module '"
+              << new_symbol.module
+              << "' is shadowed by a definition in module '"
+              << old_symbol.module << "'" << eom;
     }
     else
       link_error(


### PR DESCRIPTION
The Unix linker silently ignores (re-)definitions when these are already
present. We may even internally generate multiple definitions for GCC's
built-ins, warnings about which would always be spurious.

This avoids spurious build failures when linking with -Werror.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
