### PR TITLE
Fix havocking of dependent assigns clause targets

### DIFF
--- a/regression/contracts/assigns-replace-ignored-return-value/main.c
+++ b/regression/contracts/assigns-replace-ignored-return-value/main.c
@@ -1,0 +1,37 @@
+#include <stdbool.h>
+#include <stdlib.h>
+
+int bar(int l, int r) __CPROVER_requires(0 <= l && l <= 10)
+  __CPROVER_requires(0 <= r && r <= 10) __CPROVER_assigns() __CPROVER_ensures(
+    __CPROVER_return_value == __CPROVER_old(l) + __CPROVER_old(r))
+{
+  return l + r;
+}
+
+int *baz(int l, int r) __CPROVER_requires(0 <= l && l <= 10)
+  __CPROVER_requires(0 <= r && r <= 10) __CPROVER_assigns() __CPROVER_ensures(
+    *__CPROVER_return_value == __CPROVER_old(l) + __CPROVER_old(r))
+{
+  int *res = malloc(sizeof(int));
+  *res = l + r;
+  return res;
+}
+
+int foo(int l, int r) __CPROVER_requires(0 <= l && l <= 10)
+  __CPROVER_requires(0 <= r && r <= 10) __CPROVER_assigns() __CPROVER_ensures(
+    __CPROVER_return_value == __CPROVER_old(l) + __CPROVER_old(r))
+{
+  bar(l, r);
+  bar(l, r);
+  baz(l, r);
+  baz(l, r);
+  return l + r;
+}
+
+int main()
+{
+  int l;
+  int r;
+  foo(l, r);
+  return 0;
+}

--- a/regression/contracts/assigns-replace-ignored-return-value/test.desc
+++ b/regression/contracts/assigns-replace-ignored-return-value/test.desc
@@ -1,0 +1,13 @@
+CORE
+main.c
+--replace-call-with-contract bar --replace-call-with-contract baz --enforce-contract foo
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^[.*] Check that .*ignored_return_value.* is assignable: FAILURE
+--
+This test checks that when replacing a call by a contract for a call that
+ignores the return value of the function, the temporary introduced to 
+receive the call result does not trigger errors with assigns clause Checking
+in the function under verification.

--- a/regression/contracts/assigns_enforce_21/test.desc
+++ b/regression/contracts/assigns_enforce_21/test.desc
@@ -4,8 +4,8 @@ main.c
 ^EXIT=10$
 ^SIGNAL=0$
 main.c function bar
-^\[bar.\d+\] line \d+ Check that \*y is assignable: SUCCESS$
-^\[bar.\d+\] line \d+ Check that x is assignable: FAILURE$
+^\[bar\.\d+\] line \d+ Check that \*y is assignable: SUCCESS$
+^\[bar\.\d+\] line \d+ Check that x \(assigned by the contract of quz\) is assignable: FAILURE
 ^VERIFICATION FAILED$
 --
 --

--- a/regression/contracts/assigns_replace_08/test.desc
+++ b/regression/contracts/assigns_replace_08/test.desc
@@ -3,7 +3,7 @@ main.c
 --enforce-contract foo --replace-call-with-contract bar _ --pointer-primitive-check
 ^EXIT=10$
 ^SIGNAL=0$
-\[foo.\d+\] line \d+ Check that \*z is assignable: FAILURE$
+\[foo.\d+\] line \d+ Check that \*z \(assigned by the contract of bar\) is assignable: FAILURE$
 ^.* 1 of \d+ failed \(\d+ iteration.*\)$
 ^VERIFICATION FAILED$
 --

--- a/regression/contracts/assigns_replace_09/test.desc
+++ b/regression/contracts/assigns_replace_09/test.desc
@@ -3,7 +3,7 @@ main.c
 --replace-call-with-contract bar --enforce-contract foo
 ^EXIT=0$
 ^SIGNAL=0$
-\[foo.\d+\] line \d+ Check that \*z is assignable: SUCCESS$
+\[foo.\d+\] line \d+ Check that \*z \(assigned by the contract of bar\) is assignable: SUCCESS$
 ^VERIFICATION SUCCESSFUL$
 --
 ^Condition: \!not\_found$

--- a/regression/contracts/assigns_replace_havoc_dependent_targets_fail/enforce.desc
+++ b/regression/contracts/assigns_replace_havoc_dependent_targets_fail/enforce.desc
@@ -1,0 +1,9 @@
+CORE
+main_enforce.c
+--enforce-contract resize_vec _ --signed-overflow-check --unsigned-overflow-check --pointer-overflow-check
+^VERIFICATION SUCCESSFUL$
+^EXIT=0$
+^SIGNAL=0$
+--
+--
+Verifies the contract being replaced in `replace.desc`.

--- a/regression/contracts/assigns_replace_havoc_dependent_targets_fail/main_enforce.c
+++ b/regression/contracts/assigns_replace_havoc_dependent_targets_fail/main_enforce.c
@@ -1,0 +1,9 @@
+#include "vect.h"
+
+int main()
+{
+  vect *v;
+  size_t incr;
+  resize_vec(v, incr);
+  return 0;
+}

--- a/regression/contracts/assigns_replace_havoc_dependent_targets_fail/main_replace.c
+++ b/regression/contracts/assigns_replace_havoc_dependent_targets_fail/main_replace.c
@@ -1,0 +1,8 @@
+#include "vect.h"
+
+int main()
+{
+  vect *v;
+  resize_vec_incr10(v);
+  return 0;
+}

--- a/regression/contracts/assigns_replace_havoc_dependent_targets_fail/replace.desc
+++ b/regression/contracts/assigns_replace_havoc_dependent_targets_fail/replace.desc
@@ -1,0 +1,16 @@
+CORE
+main_replace.c
+--replace-call-with-contract resize_vec --enforce-contract resize_vec_incr10 _ --signed-overflow-check --unsigned-overflow-check --pointer-overflow-check
+^\[.*\] .* Check that v->size \(assigned by the contract of resize_vec\) is assignable: SUCCESS
+^\[.*\] .* Check that v->arr \(assigned by the contract of resize_vec\) is assignable: FAILURE
+^\[.*\] .* Check that POINTER_OBJECT\(\(const void \*\)v->arr\) \(assigned by the contract of resize_vec\) is assignable: FAILURE
+^VERIFICATION FAILED$
+^EXIT=10$
+^SIGNAL=0$
+--
+--
+Shows that when an assigns clause contains targets that are dependent, 
+in this case, a pointer variable `v->arr` and
+the object it points to `__CPROVER_POINTER_OBJECT(v->arr)`, we can correctly
+havoc them when replacing the call by the contract.
+In this version of the test the inclusion check must fail.

--- a/regression/contracts/assigns_replace_havoc_dependent_targets_fail/vect.h
+++ b/regression/contracts/assigns_replace_havoc_dependent_targets_fail/vect.h
@@ -1,0 +1,48 @@
+#include <assert.h>
+#include <stdlib.h>
+
+typedef struct vect
+{
+  char *arr;
+  size_t size;
+} vect;
+
+void resize_vec(vect *v, size_t incr)
+  // clang-format off
+__CPROVER_requires(
+  __CPROVER_is_fresh(v, sizeof(vect)) &&
+  0 < v->size && v->size <= __CPROVER_max_malloc_size &&
+  0 < incr && incr < __CPROVER_max_malloc_size - v->size &&
+  __CPROVER_is_fresh(v->arr, v->size)
+)
+__CPROVER_assigns(v->size, v->arr, __CPROVER_POINTER_OBJECT(v->arr))
+__CPROVER_ensures(
+  v->size == __CPROVER_old(v->size) + __CPROVER_old(incr) &&
+  __CPROVER_is_fresh(v->arr, v->size)
+)
+// clang-format on
+{
+  free(v->arr);
+  v->size += incr;
+  v->arr = malloc(v->size);
+  return;
+}
+
+void resize_vec_incr10(vect *v)
+  // clang-format off
+__CPROVER_requires(
+  __CPROVER_is_fresh(v, sizeof(vect)) &&
+  0 < v->size && v->size <= __CPROVER_max_malloc_size &&
+  v->size + 10 < __CPROVER_max_malloc_size &&
+  __CPROVER_is_fresh(v->arr, v->size)
+)
+__CPROVER_assigns(v->size)
+__CPROVER_ensures(
+  v->size == __CPROVER_old(v->size) + 10 &&
+  __CPROVER_is_fresh(v->arr, v->size)
+)
+// clang-format on
+{
+  resize_vec(v, 10);
+  return;
+}

--- a/regression/contracts/assigns_replace_havoc_dependent_targets_pass/enforce.desc
+++ b/regression/contracts/assigns_replace_havoc_dependent_targets_pass/enforce.desc
@@ -1,0 +1,9 @@
+CORE
+main_enforce.c
+--enforce-contract resize_vec _ --signed-overflow-check --unsigned-overflow-check --pointer-overflow-check
+^VERIFICATION SUCCESSFUL$
+^EXIT=0$
+^SIGNAL=0$
+--
+--
+Verifies the contract being replaced in `replace.desc`.

--- a/regression/contracts/assigns_replace_havoc_dependent_targets_pass/main_enforce.c
+++ b/regression/contracts/assigns_replace_havoc_dependent_targets_pass/main_enforce.c
@@ -1,0 +1,9 @@
+#include "vect.h"
+
+int main()
+{
+  vect *v;
+  size_t incr;
+  resize_vec(v, incr);
+  return 0;
+}

--- a/regression/contracts/assigns_replace_havoc_dependent_targets_pass/main_replace.c
+++ b/regression/contracts/assigns_replace_havoc_dependent_targets_pass/main_replace.c
@@ -1,0 +1,8 @@
+#include "vect.h"
+
+int main()
+{
+  vect *v;
+  resize_vec_incr10(v);
+  return 0;
+}

--- a/regression/contracts/assigns_replace_havoc_dependent_targets_pass/replace.desc
+++ b/regression/contracts/assigns_replace_havoc_dependent_targets_pass/replace.desc
@@ -1,0 +1,16 @@
+CORE
+main_replace.c
+--replace-call-with-contract resize_vec --enforce-contract resize_vec_incr10 _ --signed-overflow-check --unsigned-overflow-check --pointer-overflow-check
+^VERIFICATION SUCCESSFUL$
+^\[.*\] .* Check that v->size \(assigned by the contract of resize_vec\) is assignable: SUCCESS
+^\[.*\] .* Check that v->arr \(assigned by the contract of resize_vec\) is assignable: SUCCESS
+^\[.*\] .* Check that POINTER_OBJECT\(\(const void \*\)v->arr\) \(assigned by the contract of resize_vec\) is assignable: SUCCESS
+^EXIT=0$
+^SIGNAL=0$
+--
+--
+Shows that when an assigns clause contains targets that are dependent, 
+in this case, a pointer variable `v->arr` and
+the object it points to `__CPROVER_POINTER_OBJECT(v->arr)`, we can correctly
+havoc them when replacing the call by the contract.
+In this version of the test the inclusion check must pass.

--- a/regression/contracts/assigns_replace_havoc_dependent_targets_pass/vect.h
+++ b/regression/contracts/assigns_replace_havoc_dependent_targets_pass/vect.h
@@ -1,0 +1,48 @@
+#include <assert.h>
+#include <stdlib.h>
+
+typedef struct vect
+{
+  char *arr;
+  size_t size;
+} vect;
+
+void resize_vec(vect *v, size_t incr)
+  // clang-format off
+__CPROVER_requires(
+  __CPROVER_is_fresh(v, sizeof(vect)) &&
+  0 < v->size && v->size <= __CPROVER_max_malloc_size &&
+  0 < incr && incr < __CPROVER_max_malloc_size - v->size &&
+  __CPROVER_is_fresh(v->arr, v->size)
+)
+__CPROVER_assigns(v->size, v->arr, __CPROVER_POINTER_OBJECT(v->arr))
+__CPROVER_ensures(
+  v->size == __CPROVER_old(v->size) + __CPROVER_old(incr) &&
+  __CPROVER_is_fresh(v->arr, v->size)
+)
+// clang-format on
+{
+  free(v->arr);
+  v->size += incr;
+  v->arr = malloc(v->size);
+  return;
+}
+
+void resize_vec_incr10(vect *v)
+  // clang-format off
+__CPROVER_requires(
+  __CPROVER_is_fresh(v, sizeof(vect)) &&
+  0 < v->size && v->size <= __CPROVER_max_malloc_size &&
+  v->size + 10 < __CPROVER_max_malloc_size &&
+  __CPROVER_is_fresh(v->arr, v->size)
+)
+__CPROVER_assigns(*v, __CPROVER_POINTER_OBJECT(v->arr))
+__CPROVER_ensures(
+  v->size == __CPROVER_old(v->size) + 10 &&
+  __CPROVER_is_fresh(v->arr, v->size)
+)
+// clang-format on
+{
+  resize_vec(v, 10);
+  return;
+}

--- a/regression/contracts/history-constant/main.c
+++ b/regression/contracts/history-constant/main.c
@@ -1,0 +1,15 @@
+#include <stdio.h>
+
+int foo(int l) __CPROVER_requires(-10 <= l && l <= 10) __CPROVER_ensures(
+  __CPROVER_return_value == __CPROVER_old(l) + __CPROVER_old(10))
+{
+  return l + 10;
+}
+
+int main()
+{
+  int l;
+  __CPROVER_assume(-10 <= l && l <= 10);
+  foo(l);
+  return 0;
+}

--- a/regression/contracts/history-constant/test.desc
+++ b/regression/contracts/history-constant/test.desc
@@ -1,0 +1,10 @@
+CORE
+main.c
+--enforce-contract foo
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^Tracking history of constant expressions is not supported yet
+--
+This test checks that history variables are supported for constant expressions.

--- a/regression/contracts/history-typecast/main.c
+++ b/regression/contracts/history-typecast/main.c
@@ -1,0 +1,23 @@
+#include <stdio.h>
+
+long bar(long l, long r) __CPROVER_requires(-10 <= l && l <= 10)
+  __CPROVER_requires(-10 <= r && r <= 10) __CPROVER_ensures(
+    __CPROVER_return_value == __CPROVER_old(l) + __CPROVER_old(r))
+{
+  return l + r;
+}
+
+int foo(int l, int r) __CPROVER_requires(-10 <= l && l <= 10)
+  __CPROVER_requires(-10 <= r && r <= 10) __CPROVER_ensures(
+    __CPROVER_return_value == __CPROVER_old(l) + __CPROVER_old(r))
+{
+  return bar((long)l, (long)r);
+}
+
+int main()
+{
+  int n;
+  __CPROVER_assume(-10 <= n && n <= 10);
+  foo(n, n);
+  return 0;
+}

--- a/regression/contracts/history-typecast/test.desc
+++ b/regression/contracts/history-typecast/test.desc
@@ -1,0 +1,10 @@
+CORE
+main.c
+--replace-call-with-contract bar --enforce-contract foo 
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^Tracking history of typecast expressions is not supported yet
+--
+This test checks that history variables are supported for typecast expressions.

--- a/src/goto-instrument/Makefile
+++ b/src/goto-instrument/Makefile
@@ -18,6 +18,7 @@ SRC = accelerate/accelerate.cpp \
       call_sequences.cpp \
       contracts/assigns.cpp \
       contracts/contracts.cpp \
+      contracts/havoc_assigns_clause_targets.cpp \
       contracts/memory_predicates.cpp \
       contracts/utils.cpp \
       concurrency.cpp \

--- a/src/goto-instrument/contracts/contracts.cpp
+++ b/src/goto-instrument/contracts/contracts.cpp
@@ -562,9 +562,10 @@ void code_contractst::replace_history_parameter(
   {
     const auto &parameter = to_history_expr(expr, id).expression();
 
+    const auto &id = parameter.id();
     if(
-      parameter.id() == ID_dereference || parameter.id() == ID_member ||
-      parameter.id() == ID_symbol || parameter.id() == ID_ptrmember)
+      id == ID_dereference || id == ID_member || id == ID_symbol ||
+      id == ID_ptrmember || id == ID_constant || id == ID_typecast)
     {
       auto it = parameter2history.find(parameter);
 

--- a/src/goto-instrument/contracts/havoc_assigns_clause_targets.cpp
+++ b/src/goto-instrument/contracts/havoc_assigns_clause_targets.cpp
@@ -1,0 +1,250 @@
+/*******************************************************************\
+
+Module: Havoc multiple and possibly dependent targets simultaneously
+
+Author: Remi Delmas, delmasrd@amazon.com
+
+\*******************************************************************/
+
+/// \file
+/// Havoc multiple and possibly dependent targets simultaneously
+
+#include "havoc_assigns_clause_targets.h"
+
+#include <map>
+
+#include <langapi/language_util.h>
+
+#include <util/c_types.h>
+#include <util/format_expr.h>
+#include <util/format_type.h>
+#include <util/pointer_expr.h>
+#include <util/pointer_offset_size.h>
+#include <util/pointer_predicates.h>
+#include <util/std_code.h>
+
+#include "utils.h"
+
+static const char ASSIGNS_CLAUSE_REPLACEMENT_TRACKING[] =
+  " (assigned by the contract of ";
+
+static irep_idt make_tracking_comment(
+  const exprt &target,
+  const irep_idt &function_id,
+  const namespacet &ns)
+{
+  return from_expr(ns, target.id(), target) +
+         ASSIGNS_CLAUSE_REPLACEMENT_TRACKING + id2string(function_id) + ")";
+}
+
+bool is_assigns_clause_replacement_tracking_comment(const irep_idt &comment)
+{
+  return id2string(comment).find(ASSIGNS_CLAUSE_REPLACEMENT_TRACKING) !=
+         std::string::npos;
+}
+
+/// Returns a pointer expression to the start address of the target
+///
+/// - If the target is a `pointer_object(p)` expression,
+///   return a pointer to the same object with offset zero
+/// - else, if the target is a sized and assignable expression,
+///   return its address
+/// - else trigger an error.
+///
+static exprt build_address_of(
+  const exprt &target,
+  // context parameters
+  const namespacet &ns)
+{
+  if(target.id() == ID_pointer_object)
+  {
+    const auto &ptr = target.operands().front();
+    // bring the offset back to zero
+    return minus_exprt{ptr, pointer_offset(ptr)};
+  }
+  else if(is_assignable(target))
+  {
+    INVARIANT(
+      size_of_expr(target.type(), ns).has_value(),
+      "`sizeof` must always be computable on assignable assigns clause "
+      "targets.");
+
+    return address_of_exprt{target};
+  }
+  UNREACHABLE;
+}
+
+/// \brief Generates instructions to conditionally snapshot the value
+/// of `target_pointer` into `target_snapshot_var`.
+///
+/// ```
+/// DECL target_valid_var : bool
+/// DECL target_snapshot_var : <target_pointer.type()>
+/// ASSIGN target_valid_var := <all_dereferences_valid(target_pointer)>
+/// ASSIGN target_snapshot_var := NULL
+/// IF !target_valid_var GOTO skip_target
+/// ASSIGN target_snapshot_var := target_pointer;
+/// skip_target: SKIP
+/// ```
+///
+static void snapshot_if_valid(
+  const symbol_exprt &target_valid_var,
+  const symbol_exprt &target_snapshot_var,
+  const exprt &target_pointer,
+  goto_programt &dest,
+  // context parameters
+  const source_locationt &source_location,
+  const namespacet &ns)
+{
+  source_locationt source_location_no_checks(source_location);
+  disable_pointer_checks(source_location_no_checks);
+
+  dest.add(goto_programt::make_decl(target_valid_var));
+
+  dest.add(goto_programt::make_decl(target_snapshot_var));
+
+  dest.add(goto_programt::make_assignment(
+    target_valid_var,
+    all_dereferences_are_valid(target_pointer, ns),
+    source_location_no_checks));
+
+  dest.add(goto_programt::make_assignment(
+    target_snapshot_var,
+    null_pointer_exprt{to_pointer_type(target_pointer.type())},
+    source_location_no_checks));
+
+  goto_programt skip_program;
+  const auto skip_target =
+    skip_program.add(goto_programt::make_skip(source_location_no_checks));
+
+  dest.add(goto_programt::make_goto(
+    skip_target, not_exprt{target_valid_var}, source_location_no_checks));
+
+  dest.add(goto_programt::make_assignment(
+    target_snapshot_var, target_pointer, source_location_no_checks));
+
+  dest.destructive_append(skip_program);
+}
+
+/// \brief Generates instructions to conditionally havoc
+/// the given `target_snapshot_var`.
+///
+/// Generates these instructions if target is a `__CPROVER_POINTER_OBJECT(...)`:
+///
+/// ```
+/// IF !target_valid_var GOTO skip_target
+/// OTHER havoc_object(target_snapshot_var)
+/// skip_target: SKIP
+/// DEAD target_valid_var
+/// DEAD target_snapshot_var
+/// ```
+///
+/// And generate these instructions otherwise:
+///
+/// ```
+/// IF !target_valid_var GOTO skip_target
+/// ASSIGN *target_snapshot_var = nondet()
+/// skip_target: SKIP
+/// DEAD target_valid_var
+/// DEAD target_snapshot_var
+/// ```
+/// Adds a special comment on the havoc instructions in order to trace back
+/// the havoc to the replaced function.
+static void havoc_if_valid(
+  const symbol_exprt &target_valid_var,
+  const symbol_exprt &target_snapshot_var,
+  const exprt &target,
+  const irep_idt &tracking_comment,
+  goto_programt &dest,
+  // context parameters
+  const source_locationt &source_location,
+  const namespacet &ns)
+{
+  source_locationt source_location_no_checks(source_location);
+  disable_pointer_checks(source_location_no_checks);
+
+  goto_programt skip_program;
+  const auto skip_target =
+    skip_program.add(goto_programt::make_skip(source_location_no_checks));
+
+  dest.add(goto_programt::make_goto(
+    skip_target, not_exprt{target_valid_var}, source_location_no_checks));
+
+  if(target.id() == ID_pointer_object)
+  {
+    // OTHER __CPROVER_havoc_object(target_snapshot_var)
+    codet code(ID_havoc_object, {target_snapshot_var});
+    const auto &inst =
+      dest.add(goto_programt::make_other(code, source_location));
+    inst->source_location_nonconst().set_comment(tracking_comment);
+  }
+  else
+  {
+    // ASSIGN *target_snapshot_var = nondet()
+    side_effect_expr_nondett nondet(target.type(), source_location);
+    const auto &inst = dest.add(goto_programt::make_assignment(
+      dereference_exprt{target_snapshot_var}, nondet, source_location));
+    inst->source_location_nonconst().set_comment(tracking_comment);
+  }
+
+  dest.destructive_append(skip_program);
+
+  dest.add(
+    goto_programt::make_dead(target_valid_var, source_location_no_checks));
+
+  dest.add(
+    goto_programt::make_dead(target_snapshot_var, source_location_no_checks));
+}
+
+void havoc_assigns_clause_targets(
+  const irep_idt &replaced_function_id,
+  const std::vector<exprt> &targets,
+  goto_programt &dest,
+  // context parameters
+  const source_locationt &source_location,
+  const irep_idt &mode,
+  namespacet &ns,
+  symbol_tablet &st)
+{
+  goto_programt snapshot_program;
+  goto_programt havoc_program;
+
+  for(const auto &target : targets)
+  {
+    const auto &tracking_comment =
+      make_tracking_comment(target, replaced_function_id, ns);
+
+    const auto target_pointer = build_address_of(target, ns);
+    const auto target_snapshot_var = new_tmp_symbol(
+                                       target_pointer.type(),
+                                       source_location,
+                                       mode,
+                                       st,
+                                       "__target_snapshot_var",
+                                       true)
+                                       .symbol_expr();
+    const auto target_valid_var =
+      new_tmp_symbol(
+        bool_typet(), source_location, mode, st, "__target_valid_var", true)
+        .symbol_expr();
+
+    snapshot_if_valid(
+      target_valid_var,
+      target_snapshot_var,
+      target_pointer,
+      snapshot_program,
+      source_location,
+      ns);
+    havoc_if_valid(
+      target_valid_var,
+      target_snapshot_var,
+      target,
+      tracking_comment,
+      havoc_program,
+      source_location,
+      ns);
+  }
+
+  dest.destructive_append(snapshot_program);
+  dest.destructive_append(havoc_program);
+}

--- a/src/goto-instrument/contracts/havoc_assigns_clause_targets.h
+++ b/src/goto-instrument/contracts/havoc_assigns_clause_targets.h
@@ -1,0 +1,62 @@
+/*******************************************************************\
+
+Module: Havoc multiple and possibly dependent targets simultaneously
+
+Author: Remi Delmas, delmasrd@amazon.com
+
+\*******************************************************************/
+
+/// \file
+/// Havoc function assigns clauses
+
+#ifndef CPROVER_GOTO_INSTRUMENT_CONTRACTS_HAVOC_ASSIGNS_CLAUSE_TARGETS_H
+#define CPROVER_GOTO_INSTRUMENT_CONTRACTS_HAVOC_ASSIGNS_CLAUSE_TARGETS_H
+
+#include <util/expr.h>
+
+class namespacet;
+class symbol_tablet;
+class goto_programt;
+
+/// Generates havocking instructions for target expressions of a
+/// function contract's assign clause (replacement).
+///
+/// \param replaced_function_id Name of the replaced function
+/// \param targets Assigns clause targets
+/// \param dest Destination program where the instructions are generated
+/// \param source_location Source location of the replaced function call
+///        (added to all generated instructions)
+/// \param mode Language mode to use for newly generated symbols
+/// \param ns Namespace of the model
+/// \param st Symbol table of the model (new symbols will be added)
+///
+/// Assigns clause targets can be interdependent as shown in this example:
+///
+/// ```
+/// typedef struct vect { int *arr; int size; } vect;
+/// void resize(vect *v)
+/// __CPROVER_assigns(v->arr, v->size, __CPROVER_POINTER_OBJECT(v->arr))
+/// {
+///   free(v->arr);
+///   v->size += 10 * sizeof(int);
+///   v->arr = malloc(v->size);
+/// }
+/// ```
+///
+/// To havoc these dependent targets simultaneously, we first take snapshots
+/// of their addresses, and havoc them in a second time.
+/// Snapshotting and havocking are both guarded by the validity of the target.
+///
+void havoc_assigns_clause_targets(
+  const irep_idt &replaced_function_id,
+  const std::vector<exprt> &targets,
+  goto_programt &dest,
+  // context parameters
+  const source_locationt &source_location,
+  const irep_idt &mode,
+  namespacet &ns,
+  symbol_tablet &st);
+
+bool is_assigns_clause_replacement_tracking_comment(const irep_idt &comment);
+
+#endif // CPROVER_GOTO_INSTRUMENT_CONTRACTS_HAVOC_ASSIGNS_CLAUSE_TARGETS_H


### PR DESCRIPTION
The first commit fixes a minor issue with history variables (allow history variables for constant and typecast expressions).

The second commit fixes missing declarations for return value variables introduced during replacement of function calls by contracts.

The third commit fixes a problem with assigns clause havocking when replacing calls by contracts.

When replacing a function call by its contract, we would directly havoc the targets of the assigns clause in an unspecified order. If the assigns clause contained dependent targets such as `assigns(s->ptr, *(s->ptr))`, havocking `s->ptr` before `*s->ptr` would lead to errors and incorrect results. 

We now introduce independent snapshot variables storing the address of each target and havoc them in a second time to avoid this dependency on the ordering of havoc instructions.

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.
