### PR TITLE
Simplification of nested pointer arithmetic: do not assume same type

### DIFF
--- a/regression/cbmc/Pointer_Arithmetic15/main.c
+++ b/regression/cbmc/Pointer_Arithmetic15/main.c
@@ -15,5 +15,9 @@ int main()
 
   a = p - q;
 
+  // mixing types: the C front-end will insert casts
+  unsigned long long u;
+  p = (p + a) + u;
+
   assert(0);
 }

--- a/src/util/simplify_expr_int.cpp
+++ b/src/util/simplify_expr_int.cpp
@@ -440,17 +440,21 @@ simplify_exprt::resultt<> simplify_exprt::simplify_plus(const plus_exprt &expr)
       expr.op0().operands().size() == 2)
     {
       plus_exprt result = to_plus_expr(expr.op0());
+      if(as_const(result).op0().type().id() != ID_pointer)
+        result.op0().swap(result.op1());
       const exprt &op1 = as_const(result).op1();
 
       if(op1.id() == ID_plus)
       {
         plus_exprt new_op1 = to_plus_expr(op1);
-        new_op1.add_to_operands(expr.op1());
+        new_op1.add_to_operands(
+          typecast_exprt::conditional_cast(expr.op1(), new_op1.op0().type()));
         result.op1() = simplify_plus(new_op1);
       }
       else
       {
-        plus_exprt new_op1{op1, expr.op1()};
+        plus_exprt new_op1{
+          op1, typecast_exprt::conditional_cast(expr.op1(), op1.type())};
         result.op1() = simplify_plus(new_op1);
       }
 

--- a/src/util/simplify_expr_int.cpp
+++ b/src/util/simplify_expr_int.cpp
@@ -439,16 +439,20 @@ simplify_exprt::resultt<> simplify_exprt::simplify_plus(const plus_exprt &expr)
       expr.op0().id() == ID_plus && expr.op0().type().id() == ID_pointer &&
       expr.op0().operands().size() == 2)
     {
-      plus_exprt op0 = to_plus_expr(expr.op0());
+      plus_exprt result = to_plus_expr(expr.op0());
+      const exprt &op1 = as_const(result).op1();
 
-      if(op0.op1().id() == ID_plus)
-        to_plus_expr(op0.op1()).add_to_operands(expr.op1());
+      if(op1.id() == ID_plus)
+      {
+        plus_exprt new_op1 = to_plus_expr(op1);
+        new_op1.add_to_operands(expr.op1());
+        result.op1() = simplify_plus(new_op1);
+      }
       else
-        op0.op1()=plus_exprt(op0.op1(), expr.op1());
-
-      auto result = op0;
-
-      result.op1() = simplify_plus(to_plus_expr(result.op1()));
+      {
+        plus_exprt new_op1{op1, expr.op1()};
+        result.op1() = simplify_plus(new_op1);
+      }
 
       return changed(simplify_plus(result));
     }


### PR DESCRIPTION
Please review commit-by-commit: the first commit is a refactoring only.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
