### PR TITLE
Consistently use exprt::is_constant()

### DIFF
--- a/jbmc/src/java_bytecode/expr2java.cpp
+++ b/jbmc/src/java_bytecode/expr2java.cpp
@@ -427,7 +427,7 @@ std::string expr2javat::convert_with_precedence(
   {
     return '"' + MetaString(id2string(literal->value())) + '"';
   }
-  else if(src.id()==ID_constant)
+  else if(src.is_constant())
     return convert_constant(to_constant_expr(src), precedence=16);
   else
     return expr2ct::convert_with_precedence(src, precedence);

--- a/jbmc/src/java_bytecode/java_bytecode_convert_method.cpp
+++ b/jbmc/src/java_bytecode/java_bytecode_convert_method.cpp
@@ -1447,8 +1447,7 @@ java_bytecode_convert_methodt::convert_instructions(const methodt &method)
     {
       CHECK_RETURN(results.size() == 1);
       DATA_INVARIANT(
-        arg0.id()==ID_constant,
-        "ipush argument expected to be constant");
+        arg0.is_constant(), "ipush argument expected to be constant");
       results[0] = typecast_exprt::conditional_cast(arg0, java_int_type());
     }
     else if(bytecode == patternt("if_?cmp??"))

--- a/jbmc/src/java_bytecode/java_bytecode_language.cpp
+++ b/jbmc/src/java_bytecode/java_bytecode_language.cpp
@@ -581,7 +581,7 @@ static exprt get_ldc_result(
   else
   {
     INVARIANT(
-      ldc_arg0.id() == ID_constant,
+      ldc_arg0.is_constant(),
       "ldc argument should be constant, string literal or class literal");
     return ldc_arg0;
   }

--- a/jbmc/src/java_bytecode/java_trace_validation.cpp
+++ b/jbmc/src/java_bytecode/java_trace_validation.cpp
@@ -104,19 +104,15 @@ bool check_struct_structure(const struct_exprt &expr)
   {
     return false;
   }
-  if(
-    expr.operands().size() > 1 && std::any_of(
-                                    ++expr.operands().begin(),
-                                    expr.operands().end(),
-                                    [&](const exprt &operand) {
-                                      return operand.id() != ID_constant &&
-                                             operand.id() !=
-                                               ID_annotated_pointer_constant;
-                                    }))
-  {
-    return false;
-  }
-  return true;
+
+  return expr.operands().size() == 1 ||
+         std::all_of(
+           std::next(expr.operands().begin()),
+           expr.operands().end(),
+           [&](const exprt &operand) {
+             return can_cast_expr<constant_exprt>(operand) ||
+                    can_cast_expr<annotated_pointer_constant_exprt>(operand);
+           });
 }
 
 bool check_address_structure(const address_of_exprt &address)

--- a/jbmc/unit/java_bytecode/goto-programs/remove_virtual_functions_without_fallback.cpp
+++ b/jbmc/unit/java_bytecode/goto-programs/remove_virtual_functions_without_fallback.cpp
@@ -33,9 +33,7 @@ exprt resolve_classid_test(
 
   const auto &expr_binary = to_binary_expr(expr);
 
-  if(
-    expr_binary.op0().id() == ID_constant &&
-    expr_binary.op1().id() != ID_constant)
+  if(expr_binary.op0().is_constant() && !expr_binary.op1().is_constant())
   {
     binary_exprt swapped = expr_binary;
     std::swap(swapped.op0(), swapped.op1());
@@ -46,7 +44,7 @@ exprt resolve_classid_test(
     expr_binary.op0().id() == ID_member &&
     to_member_expr(expr_binary.op0()).get_component_name() ==
       "@class_identifier" &&
-    expr_binary.op1().id() == ID_constant &&
+    expr_binary.op1().is_constant() &&
     expr_binary.op1().type().id() == ID_string)
   {
     binary_exprt resolved = expr_binary;

--- a/jbmc/unit/java_bytecode/java_virtual_functions/virtual_functions.cpp
+++ b/jbmc/unit/java_bytecode/java_virtual_functions/virtual_functions.cpp
@@ -22,7 +22,7 @@ void check_function_call(
   const irep_idt &function_name,
   const goto_programt::targetst &targets)
 {
-  REQUIRE(eq_expr.op0().id() == ID_constant);
+  REQUIRE(eq_expr.op0().is_constant());
   REQUIRE(eq_expr.op0().type().id() == ID_string);
   REQUIRE(to_constant_expr(eq_expr.op0()).get_value() == class_name);
 
@@ -99,8 +99,9 @@ SCENARIO(
                   equal_exprt eq_expr1 =
                     to_equal_expr(disjunction.op1());
 
-                  if(eq_expr0.op0().id() == ID_constant &&
-                     to_constant_expr(eq_expr0.op0()).get_value() == "java::O")
+                  if(
+                    eq_expr0.op0().is_constant() &&
+                    to_constant_expr(eq_expr0.op0()).get_value() == "java::O")
                   {
                     // Allow either order of the D and O comparisons:
                     std::swap(eq_expr0, eq_expr1);

--- a/src/analyses/constant_propagator.cpp
+++ b/src/analyses/constant_propagator.cpp
@@ -777,7 +777,7 @@ void constant_propagator_ait::replace(
 
       if(!constant_propagator_domaint::partial_evaluate(d.values, rhs, ns))
       {
-        if(rhs.id() == ID_constant)
+        if(rhs.is_constant())
           rhs.add_source_location() = it->assign_lhs().source_location();
       }
     }

--- a/src/analyses/interval_domain.cpp
+++ b/src/analyses/interval_domain.cpp
@@ -272,7 +272,7 @@ void interval_domaint::assume_rec(
             << from_expr(rhs) << "\n";
   #endif
 
-  if(lhs.id()==ID_symbol && rhs.id()==ID_constant)
+  if(lhs.id() == ID_symbol && rhs.is_constant())
   {
     irep_idt lhs_identifier=to_symbol_expr(lhs).get_identifier();
 
@@ -297,7 +297,7 @@ void interval_domaint::assume_rec(
         make_bottom();
     }
   }
-  else if(lhs.id()==ID_constant && rhs.id()==ID_symbol)
+  else if(lhs.is_constant() && rhs.id() == ID_symbol)
   {
     irep_idt rhs_identifier=to_symbol_expr(rhs).get_identifier();
 

--- a/src/analyses/local_bitvector_analysis.cpp
+++ b/src/analyses/local_bitvector_analysis.cpp
@@ -113,7 +113,7 @@ local_bitvector_analysist::flagst local_bitvector_analysist::get_rec(
   const exprt &rhs,
   points_tot &loc_info_src)
 {
-  if(rhs.id()==ID_constant)
+  if(rhs.is_constant())
   {
     if(rhs.is_zero())
       return flagst::mk_null();

--- a/src/analyses/local_may_alias.cpp
+++ b/src/analyses/local_may_alias.cpp
@@ -169,7 +169,7 @@ void local_may_aliast::get_rec(
   const exprt &rhs,
   const loc_infot &loc_info_src) const
 {
-  if(rhs.id()==ID_constant)
+  if(rhs.is_constant())
   {
     if(rhs.is_zero())
       dest.insert(objects.number(exprt(ID_null_object)));

--- a/src/analyses/variable-sensitivity/constant_pointer_abstract_object.cpp
+++ b/src/analyses/variable-sensitivity/constant_pointer_abstract_object.cpp
@@ -181,7 +181,7 @@ void constant_pointer_abstract_objectt::output(
         {
           auto const &array_symbol = to_symbol_expr(array);
           out << array_symbol.get_identifier() << "[";
-          if(array_index.index().id() == ID_constant)
+          if(array_index.index().is_constant())
             out << to_constant_expr(array_index.index()).get_value();
           else
             out << "?";

--- a/src/analyses/variable-sensitivity/interval_abstract_value.cpp
+++ b/src/analyses/variable-sensitivity/interval_abstract_value.cpp
@@ -148,7 +148,7 @@ interval_from_x_gt_value(const exprt &value)
 static inline bool represents_interval(const exprt &expr)
 {
   const exprt &e = skip_typecast(expr);
-  return (e.id() == ID_constant_interval || e.id() == ID_constant);
+  return (e.id() == ID_constant_interval || e.is_constant());
 }
 
 static inline constant_interval_exprt make_interval_expr(const exprt &expr)
@@ -159,7 +159,7 @@ static inline constant_interval_exprt make_interval_expr(const exprt &expr)
   {
     return to_constant_interval_expr(e);
   }
-  else if(e.id() == ID_constant)
+  else if(e.is_constant())
   {
     return constant_interval_exprt(e, e);
   }
@@ -201,8 +201,8 @@ static inline constant_interval_exprt interval_from_relation(const exprt &e)
   PRECONDITION(
     relation == ID_le || relation == ID_lt || relation == ID_ge ||
     relation == ID_gt || relation == ID_equal);
-  PRECONDITION(lhs.id() == ID_constant || lhs.id() == ID_symbol);
-  PRECONDITION(rhs.id() == ID_constant || rhs.id() == ID_symbol);
+  PRECONDITION(lhs.is_constant() || lhs.id() == ID_symbol);
+  PRECONDITION(rhs.is_constant() || rhs.id() == ID_symbol);
   PRECONDITION(lhs.id() != rhs.id());
 
   const auto the_constant_part_of_the_relation =
@@ -334,8 +334,7 @@ void interval_abstract_valuet::output(
     else
     {
       INVARIANT(
-        interval.get_lower().id() == ID_constant,
-        "We only support constant limits");
+        interval.get_lower().is_constant(), "We only support constant limits");
       lower_string =
         id2string(to_constant_expr(interval.get_lower()).get_value());
     }
@@ -347,8 +346,7 @@ void interval_abstract_valuet::output(
     else
     {
       INVARIANT(
-        interval.get_upper().id() == ID_constant,
-        "We only support constant limits");
+        interval.get_upper().is_constant(), "We only support constant limits");
       upper_string =
         id2string(to_constant_expr(interval.get_upper()).get_value());
     }

--- a/src/ansi-c/c_nondet_symbol_factory.cpp
+++ b/src/ansi-c/c_nondet_symbol_factory.cpp
@@ -172,7 +172,7 @@ void symbol_factoryt::gen_nondet_array_init(
 {
   auto const &array_type = to_array_type(expr.type());
   const auto &size = array_type.size();
-  PRECONDITION(size.id() == ID_constant);
+  PRECONDITION(size.is_constant());
   auto const array_size = numeric_cast<mp_integer>(to_constant_expr(size));
   DATA_INVARIANT(
     array_size.has_value() && *array_size >= 0,

--- a/src/ansi-c/c_typecheck_expr.cpp
+++ b/src/ansi-c/c_typecheck_expr.cpp
@@ -176,7 +176,7 @@ void c_typecheck_baset::typecheck_expr_main(exprt &expr)
 {
   if(expr.id()==ID_side_effect)
     typecheck_expr_side_effect(to_side_effect_expr(expr));
-  else if(expr.id()==ID_constant)
+  else if(expr.is_constant())
     typecheck_expr_constant(expr);
   else if(expr.id()==ID_infinity)
   {
@@ -860,8 +860,7 @@ void c_typecheck_baset::typecheck_expr_symbol(exprt &expr)
     follow_macros(expr);
 
     #if 0
-    if(expr.id()==ID_constant &&
-       !base_name.empty())
+    if(expr.is_constant() && !base_name.empty())
       expr.set(ID_C_cformat, base_name);
     else
     #endif

--- a/src/ansi-c/c_typecheck_type.cpp
+++ b/src/ansi-c/c_typecheck_type.cpp
@@ -1248,8 +1248,7 @@ void c_typecheck_baset::typecheck_c_enum_type(typet &type)
       else if(tmp_v.is_false())
         value=0;
       else if(
-        tmp_v.id() == ID_constant &&
-        !to_integer(to_constant_expr(tmp_v), value))
+        tmp_v.is_constant() && !to_integer(to_constant_expr(tmp_v), value))
       {
       }
       else

--- a/src/ansi-c/expr2c.cpp
+++ b/src/ansi-c/expr2c.cpp
@@ -1273,7 +1273,7 @@ std::string expr2ct::convert_complex(
 {
   if(
     src.operands().size() == 2 && to_binary_expr(src).op0().is_zero() &&
-    to_binary_expr(src).op1().id() == ID_constant)
+    to_binary_expr(src).op1().is_constant())
   {
     // This is believed to be gcc only; check if this is sensible
     // in MSC mode.
@@ -3871,7 +3871,7 @@ std::string expr2ct::convert_with_precedence(
   else if(src.id()==ID_code)
     return convert_code(to_code(src));
 
-  else if(src.id()==ID_constant)
+  else if(src.is_constant())
     return convert_constant(to_constant_expr(src), precedence);
 
   else if(src.id() == ID_annotated_pointer_constant)

--- a/src/cpp/cpp_declarator_converter.cpp
+++ b/src/cpp/cpp_declarator_converter.cpp
@@ -478,10 +478,9 @@ symbolt &cpp_declarator_convertert::convert_new_symbol(
   }
   else
   {
-    symbol.is_lvalue =
-      !is_reference(symbol.type) &&
-      !(symbol.type.get_bool(ID_C_constant) && is_number(symbol.type) &&
-        symbol.value.id() == ID_constant);
+    symbol.is_lvalue = !is_reference(symbol.type) &&
+                       !(symbol.type.get_bool(ID_C_constant) &&
+                         is_number(symbol.type) && symbol.value.is_constant());
 
     symbol.is_static_lifetime =
       !symbol.is_macro && !symbol.is_type &&

--- a/src/cpp/cpp_typecheck_compound_type.cpp
+++ b/src/cpp/cpp_typecheck_compound_type.cpp
@@ -546,7 +546,7 @@ void cpp_typecheckt::typecheck_compound_declarator(
       component.type().set(ID_C_virtual_name, virtual_name);
 
       // Check if it is a pure virtual method
-      if(value.is_not_nil() && value.id() == ID_constant)
+      if(value.is_not_nil() && value.is_constant())
       {
         mp_integer i;
         to_integer(to_constant_expr(value), i);

--- a/src/cpp/cpp_typecheck_conversions.cpp
+++ b/src/cpp/cpp_typecheck_conversions.cpp
@@ -602,7 +602,7 @@ bool cpp_typecheckt::standard_conversion_pointer_to_member(
   if(expr.get_bool(ID_C_lvalue))
     return false;
 
-  if(expr.id() == ID_constant && is_null_pointer(to_constant_expr(expr)))
+  if(expr.is_constant() && is_null_pointer(to_constant_expr(expr)))
   {
     new_expr = typecast_exprt::conditional_cast(expr, type);
     return true;

--- a/src/cpp/cpp_typecheck_expr.cpp
+++ b/src/cpp/cpp_typecheck_expr.cpp
@@ -1150,7 +1150,7 @@ void cpp_typecheckt::typecheck_expr_member(
 
     DATA_INVARIANT(
       symbol_expr.id() == ID_symbol || symbol_expr.id() == ID_member ||
-        symbol_expr.id() == ID_constant,
+        symbol_expr.is_constant(),
       "expression kind unexpected");
 
     // If it is a symbol or a constant, just return it!
@@ -1188,7 +1188,7 @@ void cpp_typecheckt::typecheck_expr_member(
       expr=symbol_expr;
       return;
     }
-    else if(symbol_expr.id()==ID_constant)
+    else if(symbol_expr.is_constant())
     {
       expr=symbol_expr;
       return;

--- a/src/cpp/cpp_typecheck_resolve.cpp
+++ b/src/cpp/cpp_typecheck_resolve.cpp
@@ -360,7 +360,7 @@ exprt cpp_typecheck_resolvet::convert_identifier(
 
       if(
         constant && symbol.value.is_not_nil() && is_number(symbol.type) &&
-        symbol.value.id() == ID_constant)
+        symbol.value.is_constant())
       {
         e=symbol.value;
       }

--- a/src/cprover/bv_pointers_wide.cpp
+++ b/src/cprover/bv_pointers_wide.cpp
@@ -268,7 +268,7 @@ optionalt<bvt> bv_pointers_widet::convert_address_of_rec(const exprt &expr)
     return std::move(bv);
   }
   else if(
-    expr.id() == ID_constant || expr.id() == ID_string_constant ||
+    expr.is_constant() || expr.id() == ID_string_constant ||
     expr.id() == ID_array)
   { // constant
     return add_addr(expr);
@@ -382,7 +382,7 @@ bvt bv_pointers_widet::convert_pointer_type(const exprt &expr)
     const auto &object_address_expr = to_object_address_expr(expr);
     return add_addr(object_address_expr.object_expr());
   }
-  else if(expr.id() == ID_constant)
+  else if(expr.is_constant())
   {
     const constant_exprt &c = to_constant_expr(expr);
 

--- a/src/cprover/simplify_state_expr.cpp
+++ b/src/cprover/simplify_state_expr.cpp
@@ -628,7 +628,7 @@ static bool is_one(const exprt &src)
 {
   if(src.id() == ID_typecast)
     return is_one(to_typecast_expr(src).op());
-  else if(src.id() == ID_constant)
+  else if(src.is_constant())
   {
     auto value_opt = numeric_cast<mp_integer>(src);
     return value_opt.has_value() && *value_opt == 1;

--- a/src/goto-cc/linker_script_merge.cpp
+++ b/src/goto-cc/linker_script_merge.cpp
@@ -164,8 +164,8 @@ linker_script_merget::linker_script_merget(
                       .id() == ID_array &&
 
                   to_index_expr(to_address_of_expr(expr).object())
-                      .index()
-                      .id() == ID_constant &&
+                    .index()
+                    .is_constant() &&
                   to_index_expr(to_address_of_expr(expr).object())
                       .index()
                       .type()

--- a/src/goto-instrument/accelerate/overflow_instrumenter.cpp
+++ b/src/goto-instrument/accelerate/overflow_instrumenter.cpp
@@ -100,7 +100,7 @@ void overflow_instrumentert::overflow_expr(
   {
     const auto &typecast_expr = to_typecast_expr(expr);
 
-    if(typecast_expr.op().id() == ID_constant)
+    if(typecast_expr.op().is_constant())
       return;
 
     const typet &old_type = typecast_expr.op().type();

--- a/src/goto-instrument/accelerate/polynomial.cpp
+++ b/src/goto-instrument/accelerate/polynomial.cpp
@@ -136,7 +136,7 @@ void polynomialt::from_expr(const exprt &expr)
       mult(poly2);
     }
   }
-  else if(expr.id()==ID_constant)
+  else if(expr.is_constant())
   {
     monomialt monomial;
     monomial.coeff = numeric_cast_v<int>(to_constant_expr(expr));

--- a/src/goto-instrument/dump_c.cpp
+++ b/src/goto-instrument/dump_c.cpp
@@ -1386,7 +1386,7 @@ void dump_ct::cleanup_expr(exprt &expr)
     }
     // add a typecast for NULL
     else if(
-      u.op().id() == ID_constant && is_null_pointer(to_constant_expr(u.op())) &&
+      u.op().is_constant() && is_null_pointer(to_constant_expr(u.op())) &&
       to_pointer_type(u.op().type()).base_type().id() == ID_empty)
     {
       const struct_union_typet::componentt &comp=
@@ -1442,7 +1442,7 @@ void dump_ct::cleanup_expr(exprt &expr)
 
             // add a typecast for NULL or 0
             if(
-              argument.id() == ID_constant &&
+              argument.is_constant() &&
               is_null_pointer(to_constant_expr(argument)))
             {
               const typet &comp_type=
@@ -1458,8 +1458,7 @@ void dump_ct::cleanup_expr(exprt &expr)
       }
     }
   }
-  else if(expr.id()==ID_constant &&
-          expr.type().id()==ID_signedbv)
+  else if(expr.is_constant() && expr.type().id() == ID_signedbv)
   {
     #if 0
     const irep_idt &cformat=expr.get(ID_C_cformat);

--- a/src/goto-instrument/goto_program2code.cpp
+++ b/src/goto-instrument/goto_program2code.cpp
@@ -310,7 +310,7 @@ goto_programt::const_targett goto_program2codet::convert_assign_varargs(
   const exprt this_va_list_expr = target->assign_lhs();
   const exprt &r = skip_typecast(target->assign_rhs());
 
-  if(r.id() == ID_constant && is_null_pointer(to_constant_expr(r)))
+  if(r.is_constant() && is_null_pointer(to_constant_expr(r)))
   {
     code_function_callt f(
       symbol_exprt("va_end", code_typet({}, empty_typet())),
@@ -1901,7 +1901,7 @@ void goto_program2codet::cleanup_expr(exprt &expr, bool no_typecast)
   else if(expr.id()==ID_isnan ||
           expr.id()==ID_sign)
     system_headers.insert("math.h");
-  else if(expr.id()==ID_constant)
+  else if(expr.is_constant())
   {
     if(expr.type().id()==ID_floatbv)
     {

--- a/src/goto-programs/builtin_functions.cpp
+++ b/src/goto-programs/builtin_functions.cpp
@@ -140,8 +140,7 @@ void goto_convertt::do_prob_coin(
     throw 0;
   }
 
-  if(arguments[0].type().id()!=ID_unsignedbv ||
-     arguments[0].id()!=ID_constant)
+  if(arguments[0].type().id() != ID_unsignedbv || !arguments[0].is_constant())
   {
     error().source_location=function.find_source_location();
     error() << "'" << identifier << "' expected first operand to be "
@@ -149,9 +148,7 @@ void goto_convertt::do_prob_coin(
     throw 0;
   }
 
-  if(
-    arguments[1].type().id() != ID_unsignedbv ||
-    arguments[1].id() != ID_constant)
+  if(arguments[1].type().id() != ID_unsignedbv || !arguments[1].is_constant())
   {
     error().source_location = function.find_source_location();
     error() << "'" << identifier << "' expected second operand to be "

--- a/src/goto-programs/class_identifier.cpp
+++ b/src/goto-programs/class_identifier.cpp
@@ -95,8 +95,7 @@ void set_class_identifier(
 
   if(components.front().get_name() == JAVA_CLASS_IDENTIFIER_FIELD_NAME)
   {
-    INVARIANT(
-      expr.op0().id()==ID_constant, "@class_identifier must be a constant");
+    INVARIANT(expr.op0().is_constant(), "@class_identifier must be a constant");
     expr.op0()=constant_exprt(class_type.get_identifier(), string_typet());
   }
   else

--- a/src/goto-programs/goto_trace.cpp
+++ b/src/goto-programs/goto_trace.cpp
@@ -213,7 +213,7 @@ std::string trace_numeric_value(
 {
   const typet &type = expr.type();
 
-  if(expr.id()==ID_constant)
+  if(expr.is_constant())
   {
     if(type.id()==ID_unsignedbv ||
        type.id()==ID_signedbv ||

--- a/src/goto-programs/interpreter.cpp
+++ b/src/goto-programs/interpreter.cpp
@@ -488,7 +488,7 @@ exprt interpretert::get_value(
     const exprt &size_expr = to_array_type(type).size();
     mp_integer subtype_size = get_size(to_array_type(type).element_type());
     mp_integer count;
-    if(size_expr.id()!=ID_constant)
+    if(!size_expr.is_constant())
     {
       count=base_address_to_actual_size(offset)/subtype_size;
     }

--- a/src/goto-programs/interpreter_evaluate.cpp
+++ b/src/goto-programs/interpreter_evaluate.cpp
@@ -311,7 +311,7 @@ bool interpretert::memory_offset_to_byte_offset(
 /// \return vector in which the result of the evaluation is stored
 interpretert::mp_vectort interpretert::evaluate(const exprt &expr)
 {
-  if(expr.id()==ID_constant)
+  if(expr.is_constant())
   {
     if(expr.type().id()==ID_struct)
     {

--- a/src/goto-programs/json_expr.cpp
+++ b/src/goto-programs/json_expr.cpp
@@ -52,8 +52,7 @@ static exprt simplify_json_expr(const exprt &src)
       return simplify_json_expr(object);
     }
     else if(
-      object.id() == ID_index &&
-      to_index_expr(object).index().id() == ID_constant &&
+      object.id() == ID_index && to_index_expr(object).index().is_constant() &&
       to_constant_expr(to_index_expr(object).index()).value_is_zero_string())
     {
       // simplify expressions of the form  &array[0]
@@ -207,7 +206,7 @@ json_objectt json(const exprt &expr, const namespacet &ns, const irep_idt &mode)
 {
   json_objectt result;
 
-  if(expr.id() == ID_constant)
+  if(expr.is_constant())
   {
     const constant_exprt &constant_expr = to_constant_expr(expr);
 
@@ -254,8 +253,7 @@ json_objectt json(const exprt &expr, const namespacet &ns, const irep_idt &mode)
     else if(type.id() == ID_c_enum_tag)
     {
       constant_exprt tmp(
-        to_constant_expr(expr).get_value(),
-        ns.follow_tag(to_c_enum_tag_type(type)));
+        constant_expr.get_value(), ns.follow_tag(to_c_enum_tag_type(type)));
       return json(tmp, ns, mode);
     }
     else if(type.id() == ID_bv)
@@ -269,8 +267,7 @@ json_objectt json(const exprt &expr, const namespacet &ns, const irep_idt &mode)
       result["width"] =
         json_numbert(std::to_string(to_bitvector_type(type).get_width()));
       result["binary"] = json_stringt(binary(constant_expr));
-      result["data"] =
-        json_stringt(fixedbvt(to_constant_expr(expr)).to_ansi_c_string());
+      result["data"] = json_stringt(fixedbvt(constant_expr).to_ansi_c_string());
     }
     else if(type.id() == ID_floatbv)
     {
@@ -279,7 +276,7 @@ json_objectt json(const exprt &expr, const namespacet &ns, const irep_idt &mode)
         json_numbert(std::to_string(to_bitvector_type(type).get_width()));
       result["binary"] = json_stringt(binary(constant_expr));
       result["data"] =
-        json_stringt(ieee_floatt(to_constant_expr(expr)).to_ansi_c_string());
+        json_stringt(ieee_floatt(constant_expr).to_ansi_c_string());
     }
     else if(type.id() == ID_pointer)
     {
@@ -339,7 +336,7 @@ json_objectt json(const exprt &expr, const namespacet &ns, const irep_idt &mode)
         "pointer identifier should have non-empty components");
       result["data"] = json_stringt(identifier.components.back());
     }
-    else if(simpl_expr.id() == ID_constant)
+    else if(simpl_expr.is_constant())
       return json(simpl_expr, ns, mode);
     else
       result["name"] = json_stringt("unknown");

--- a/src/goto-programs/remove_const_function_pointers.cpp
+++ b/src/goto-programs/remove_const_function_pointers.cpp
@@ -168,7 +168,7 @@ bool remove_const_function_pointerst::try_resolve_function_call(
       resolved=false;
     }
   }
-  else if(simplified_expr.id()==ID_constant)
+  else if(simplified_expr.is_constant())
   {
     if(simplified_expr.is_zero())
     {
@@ -470,8 +470,9 @@ bool remove_const_function_pointerst::try_resolve_index_value(
   bool resolved=try_resolve_expression(expr, index_value_expressions, is_const);
   if(resolved)
   {
-    if(index_value_expressions.size()==1 &&
-       index_value_expressions.front().id()==ID_constant)
+    if(
+      index_value_expressions.size() == 1 &&
+      index_value_expressions.front().is_constant())
     {
       const constant_exprt &constant_expr=
         to_constant_expr(index_value_expressions.front());

--- a/src/goto-programs/vcd_goto_trace.cpp
+++ b/src/goto-programs/vcd_goto_trace.cpp
@@ -27,7 +27,7 @@ std::string as_vcd_binary(
 {
   const typet &type = expr.type();
 
-  if(expr.id()==ID_constant)
+  if(expr.is_constant())
   {
     if(type.id()==ID_unsignedbv ||
        type.id()==ID_signedbv ||

--- a/src/goto-programs/xml_expr.cpp
+++ b/src/goto-programs/xml_expr.cpp
@@ -131,7 +131,7 @@ xmlt xml(const exprt &expr, const namespacet &ns)
 {
   xmlt result;
 
-  if(expr.id() == ID_constant)
+  if(expr.is_constant())
   {
     const auto &constant_expr = to_constant_expr(expr);
     const auto &value = constant_expr.get_value();

--- a/src/goto-symex/field_sensitivity.cpp
+++ b/src/goto-symex/field_sensitivity.cpp
@@ -135,7 +135,7 @@ exprt field_sensitivityt::apply(
 
     if(
       is_ssa_expr(index.array()) && index.array().type().id() == ID_array &&
-      index.index().id() == ID_constant)
+      index.index().is_constant())
     {
       // place the entire index expression, not just the array operand, in an
       // SSA expression
@@ -157,11 +157,11 @@ exprt field_sensitivityt::apply(
       }
 
       if(
-        l2_size.id() == ID_constant &&
+        l2_size.is_constant() &&
         numeric_cast_v<mp_integer>(to_constant_expr(l2_size)) <=
           max_field_sensitivity_array_size)
       {
-        if(l2_index.get().id() == ID_constant)
+        if(l2_index.get().is_constant())
         {
           // place the entire index expression, not just the array operand,
           // in an SSA expression
@@ -238,7 +238,7 @@ exprt field_sensitivityt::get_fields(
 #ifdef ENABLE_ARRAY_FIELD_SENSITIVITY
   else if(
     ssa_expr.type().id() == ID_array &&
-    to_array_type(ssa_expr.type()).size().id() == ID_constant)
+    to_array_type(ssa_expr.type()).size().is_constant())
   {
     const mp_integer mp_array_size = numeric_cast_v<mp_integer>(
       to_constant_expr(to_array_type(ssa_expr.type()).size()));
@@ -496,7 +496,7 @@ bool field_sensitivityt::is_divisible(
 #ifdef ENABLE_ARRAY_FIELD_SENSITIVITY
   if(
     expr.type().id() == ID_array &&
-    to_array_type(expr.type()).size().id() == ID_constant &&
+    to_array_type(expr.type()).size().is_constant() &&
     numeric_cast_v<mp_integer>(to_constant_expr(
       to_array_type(expr.type()).size())) <= max_field_sensitivity_array_size)
   {

--- a/src/goto-symex/goto_symex.cpp
+++ b/src/goto-symex/goto_symex.cpp
@@ -375,7 +375,7 @@ goto_symext::try_evaluate_constant(const statet &state, const exprt &expr)
   const auto constant_expr_opt =
     state.propagation.find(to_symbol_expr(expr).get_identifier());
 
-  if(!constant_expr_opt || constant_expr_opt->get().id() != ID_constant)
+  if(!constant_expr_opt || !constant_expr_opt->get().is_constant())
   {
     return {};
   }

--- a/src/goto-symex/goto_symex_state.h
+++ b/src/goto-symex/goto_symex_state.h
@@ -252,7 +252,7 @@ public:
     // simplifies to a plain constant.
     return lvalue.id() == ID_string_constant || lvalue.id() == ID_null_object ||
            lvalue.id() == "zero_string" || lvalue.id() == "is_zero_string" ||
-           lvalue.id() == "zero_string_length" || lvalue.id() == ID_constant ||
+           lvalue.id() == "zero_string_length" || lvalue.is_constant() ||
            lvalue.id() == ID_array;
   }
 

--- a/src/jsil/jsil_typecheck.cpp
+++ b/src/jsil/jsil_typecheck.cpp
@@ -162,7 +162,7 @@ void jsil_typecheckt::typecheck_expr_main(exprt &expr)
   }
   else if(expr.id()==ID_symbol)
     typecheck_symbol_expr(to_symbol_expr(expr));
-  else if(expr.id()==ID_constant)
+  else if(expr.is_constant())
   {
   }
   else

--- a/src/memory-analyzer/analyze_symbol.cpp
+++ b/src/memory-analyzer/analyze_symbol.cpp
@@ -493,7 +493,7 @@ exprt gdb_value_extractort::get_pointer_value(
   const exprt &zero_expr,
   const source_locationt &location)
 {
-  PRECONDITION(zero_expr.id() == ID_constant);
+  PRECONDITION(zero_expr.is_constant());
 
   PRECONDITION(expr.type().id() == ID_pointer);
   PRECONDITION(expr.type() == zero_expr.type());

--- a/src/pointer-analysis/value_set.cpp
+++ b/src/pointer-analysis/value_set.cpp
@@ -1389,8 +1389,7 @@ void value_sett::assign(
           is_simplified,
           add_to_sets);
       }
-      else if(rhs.id()==ID_array ||
-              rhs.id()==ID_constant)
+      else if(rhs.id() == ID_array || rhs.is_constant())
       {
         for(const auto &op : rhs.operands())
         {

--- a/src/pointer-analysis/value_set_fi.cpp
+++ b/src/pointer-analysis/value_set_fi.cpp
@@ -1017,8 +1017,7 @@ void value_set_fit::assign(
                 "rhs.type():\n"+rhs.type().pretty()+"\n"+
                 "type:\n"+lhs.type().pretty();
 
-        if(rhs.id()==ID_struct ||
-           rhs.id()==ID_constant)
+        if(rhs.id() == ID_struct || rhs.is_constant())
         {
           DATA_INVARIANT(
             no < rhs.operands().size(), "component index must be in bounds");
@@ -1085,8 +1084,7 @@ void value_set_fit::assign(
       {
         assign(lhs_index, to_array_of_expr(rhs).what(), ns);
       }
-      else if(rhs.id()==ID_array ||
-              rhs.id()==ID_constant)
+      else if(rhs.id() == ID_array || rhs.is_constant())
       {
         for(const auto &op : rhs.operands())
         {

--- a/src/solvers/flattening/arrays.cpp
+++ b/src/solvers/flattening/arrays.cpp
@@ -202,9 +202,7 @@ void arrayst::collect_arrays(const exprt &a)
       "unexpected array expression: member with '" + struct_op.id_string() +
         "'");
   }
-  else if(a.id()==ID_constant ||
-          a.id()==ID_array ||
-          a.id()==ID_string_constant)
+  else if(a.is_constant() || a.id() == ID_array || a.id() == ID_string_constant)
   {
   }
   else if(a.id()==ID_array_of)
@@ -487,11 +485,10 @@ void arrayst::add_array_constraints(
     return add_array_constraints_comprehension(
       index_set, to_array_comprehension_expr(expr));
   }
-  else if(expr.id()==ID_symbol ||
-          expr.id()==ID_nondet_symbol ||
-          expr.id()==ID_constant ||
-          expr.id()=="zero_string" ||
-          expr.id()==ID_string_constant)
+  else if(
+    expr.id() == ID_symbol || expr.id() == ID_nondet_symbol ||
+    expr.is_constant() || expr.id() == "zero_string" ||
+    expr.id() == ID_string_constant)
   {
   }
   else if(

--- a/src/solvers/flattening/boolbv.cpp
+++ b/src/solvers/flattening/boolbv.cpp
@@ -114,7 +114,7 @@ bvt boolbvt::convert_bitvector(const exprt &expr)
     return convert_cond(to_cond_expr(expr));
   else if(expr.id()==ID_if)
     return convert_if(to_if_expr(expr));
-  else if(expr.id()==ID_constant)
+  else if(expr.is_constant())
     return convert_constant(to_constant_expr(expr));
   else if(expr.id()==ID_typecast)
     return convert_bv_typecast(to_typecast_expr(expr));

--- a/src/solvers/flattening/boolbv_index.cpp
+++ b/src/solvers/flattening/boolbv_index.cpp
@@ -105,7 +105,7 @@ bvt boolbvt::convert_index(const index_exprt &expr)
     #ifdef UNIFORM_ARRAY_HACK
     bool is_uniform = array.id() == ID_array_of;
 
-    if(array.id() == ID_constant || array.id() == ID_array)
+    if(array.is_constant() || array.id() == ID_array)
     {
       is_uniform = array.operands().size() <= 1 ||
                    std::all_of(
@@ -154,8 +154,7 @@ bvt boolbvt::convert_index(const index_exprt &expr)
     #ifdef ACTUAL_ARRAY_HACK
     // More useful when updates to concrete locations in
     // actual arrays are compacted by simplify_expr
-    if((array.id()==ID_constant || array.id()==ID_array) &&
-       prop.has_set_to())
+    if((array.is_constant() || array.id() == ID_array) && prop.has_set_to())
     {
       #ifdef CONSTANT_ARRAY_HACK
       // TODO : Compile the whole array into a single relation

--- a/src/solvers/flattening/boolbv_quantifier.cpp
+++ b/src/solvers/flattening/boolbv_quantifier.cpp
@@ -39,8 +39,7 @@ get_quantifier_var_min(const exprt &var_expr, const exprt &quantifier_expr)
       if(y.id()!=ID_ge)
         continue;
       const auto &y_binary = to_binary_relation_expr(y);
-      if(
-        expr_eq(var_expr, y_binary.lhs()) && y_binary.rhs().id() == ID_constant)
+      if(expr_eq(var_expr, y_binary.lhs()) && y_binary.rhs().is_constant())
       {
         return to_constant_expr(y_binary.rhs());
       }
@@ -60,8 +59,7 @@ get_quantifier_var_min(const exprt &var_expr, const exprt &quantifier_expr)
       if(x.id()!=ID_ge)
         continue;
       const auto &x_binary = to_binary_relation_expr(x);
-      if(
-        expr_eq(var_expr, x_binary.lhs()) && x_binary.rhs().id() == ID_constant)
+      if(expr_eq(var_expr, x_binary.lhs()) && x_binary.rhs().is_constant())
       {
         return to_constant_expr(x_binary.rhs());
       }
@@ -90,8 +88,7 @@ get_quantifier_var_max(const exprt &var_expr, const exprt &quantifier_expr)
       if(x.id()!=ID_ge)
         continue;
       const auto &x_binary = to_binary_relation_expr(x);
-      if(
-        expr_eq(var_expr, x_binary.lhs()) && x_binary.rhs().id() == ID_constant)
+      if(expr_eq(var_expr, x_binary.lhs()) && x_binary.rhs().is_constant())
       {
         const constant_exprt &over_expr = to_constant_expr(x_binary.rhs());
 
@@ -121,8 +118,7 @@ get_quantifier_var_max(const exprt &var_expr, const exprt &quantifier_expr)
       if(y.id()!=ID_ge)
         continue;
       const auto &y_binary = to_binary_relation_expr(y);
-      if(
-        expr_eq(var_expr, y_binary.lhs()) && y_binary.rhs().id() == ID_constant)
+      if(expr_eq(var_expr, y_binary.lhs()) && y_binary.rhs().is_constant())
       {
         const constant_exprt &over_expr = to_constant_expr(y_binary.rhs());
         mp_integer over_i = numeric_cast_v<mp_integer>(over_expr);

--- a/src/solvers/flattening/boolbv_update.cpp
+++ b/src/solvers/flattening/boolbv_update.cpp
@@ -76,7 +76,7 @@ void boolbvt::convert_update_rec(
     std::size_t element_size=boolbv_width(subtype);
 
     DATA_INVARIANT(
-      size_expr.id() == ID_constant,
+      size_expr.is_constant(),
       "array in update expression should be constant-sized");
 
     // iterate over array

--- a/src/solvers/flattening/bv_pointers.cpp
+++ b/src/solvers/flattening/bv_pointers.cpp
@@ -322,9 +322,9 @@ optionalt<bvt> bv_pointerst::convert_address_of_rec(const exprt &expr)
 
     return std::move(bv);
   }
-  else if(expr.id()==ID_constant ||
-          expr.id()==ID_string_constant ||
-          expr.id()==ID_array)
+  else if(
+    expr.is_constant() || expr.id() == ID_string_constant ||
+    expr.id() == ID_array)
   { // constant
     return add_addr(expr);
   }
@@ -415,7 +415,7 @@ bvt bv_pointerst::convert_pointer_type(const exprt &expr)
     const auto &object_address_expr = to_object_address_expr(expr);
     return add_addr(object_address_expr.object_expr());
   }
-  else if(expr.id()==ID_constant)
+  else if(expr.is_constant())
   {
     const constant_exprt &c = to_constant_expr(expr);
 

--- a/src/solvers/prop/prop_conv_solver.cpp
+++ b/src/solvers/prop/prop_conv_solver.cpp
@@ -153,7 +153,7 @@ optionalt<bool> prop_conv_solvert::get_bool(const exprt &expr) const
 
 literalt prop_conv_solvert::convert(const exprt &expr)
 {
-  if(!use_cache || expr.id() == ID_symbol || expr.id() == ID_constant)
+  if(!use_cache || expr.id() == ID_symbol || expr.is_constant())
   {
     literalt literal = convert_bool(expr);
     if(freeze_all && !literal.is_constant())

--- a/src/solvers/smt2/smt2_conv.cpp
+++ b/src/solvers/smt2/smt2_conv.cpp
@@ -701,10 +701,9 @@ void smt2_convt::convert_address_of_rec(
   const exprt &expr,
   const pointer_typet &result_type)
 {
-  if(expr.id()==ID_symbol ||
-     expr.id()==ID_constant ||
-     expr.id()==ID_string_constant ||
-     expr.id()==ID_label)
+  if(
+    expr.id() == ID_symbol || expr.is_constant() ||
+    expr.id() == ID_string_constant || expr.id() == ID_label)
   {
     out
       << "(concat (_ bv"
@@ -1133,7 +1132,7 @@ void smt2_convt::convert_expr(const exprt &expr)
   {
     convert_union(to_union_expr(expr));
   }
-  else if(expr.id()==ID_constant)
+  else if(expr.is_constant())
   {
     convert_constant(to_constant_expr(expr));
   }
@@ -3262,7 +3261,7 @@ void smt2_convt::flatten_array(const exprt &expr)
 {
   const array_typet &array_type = to_array_type(expr.type());
   const auto &size_expr = array_type.size();
-  PRECONDITION(size_expr.id() == ID_constant);
+  PRECONDITION(size_expr.is_constant());
 
   mp_integer size = numeric_cast_v<mp_integer>(to_constant_expr(size_expr));
   CHECK_RETURN_WITH_DIAGNOSTICS(size != 0, "can't convert zero-sized array");
@@ -3809,7 +3808,7 @@ void smt2_convt::convert_rounding_mode_FPA(const exprt &expr)
    * the macros from fenv.h to avoid portability problems.
    */
 
-  if(expr.id()==ID_constant)
+  if(expr.is_constant())
   {
     const constant_exprt &cexpr=to_constant_expr(expr);
 

--- a/src/solvers/smt2/smt2_format.cpp
+++ b/src/solvers/smt2/smt2_format.cpp
@@ -44,7 +44,7 @@ std::ostream &smt2_format_rec(std::ostream &out, const typet &type)
 
 std::ostream &smt2_format_rec(std::ostream &out, const exprt &expr)
 {
-  if(expr.id() == ID_constant)
+  if(expr.is_constant())
   {
     const auto &constant_expr = to_constant_expr(expr);
     const auto &value = constant_expr.get_value();

--- a/src/solvers/smt2/smt2_parser.cpp
+++ b/src/solvers/smt2/smt2_parser.cpp
@@ -742,7 +742,7 @@ exprt smt2_parsert::function_application()
           {
             // For now, we can only do this when
             // the source operand is a constant.
-            if(source_op.id() == ID_constant)
+            if(source_op.is_constant())
             {
               mp_integer significand, exponent;
 

--- a/src/solvers/strings/string_constraint_generator_main.cpp
+++ b/src/solvers/strings/string_constraint_generator_main.cpp
@@ -166,7 +166,7 @@ string_constraint_generatort::add_axioms_for_constrain_characters(
   const auto &args = f.arguments();
   PRECONDITION(3 <= args.size() && args.size() <= 5);
   PRECONDITION(args[2].type().id() == ID_string);
-  PRECONDITION(args[2].id() == ID_constant);
+  PRECONDITION(args[2].is_constant());
 
   const array_string_exprt s = array_pool.find(args[1], args[0]);
   const irep_idt &char_set_string = to_constant_expr(args[2]).get_value();

--- a/src/solvers/strings/string_format_builtin_function.cpp
+++ b/src/solvers/strings/string_format_builtin_function.cpp
@@ -49,7 +49,7 @@ string_format_builtin_functiont::string_format_builtin_functiont(
 
   // format_string is only initialized if the expression is constant
   if(
-    array_pool.get_or_create_length(format_string_expr).id() == ID_constant &&
+    array_pool.get_or_create_length(format_string_expr).is_constant() &&
     format_string_expr.content().id() == ID_array)
   {
     const auto length = numeric_cast_v<std::size_t>(

--- a/src/solvers/strings/string_refinement.cpp
+++ b/src/solvers/strings/string_refinement.cpp
@@ -967,14 +967,14 @@ static optionalt<exprt> get_valid_array_size(
   {
     const exprt size = size_from_pool.value();
     size_val = simplify_expr(super_get(size), ns);
-    if(size_val.id() != ID_constant)
+    if(!size_val.is_constant())
     {
       stream << "(sr::get_valid_array_size) string of unknown size: "
              << format(size_val) << messaget::eom;
       return {};
     }
   }
-  else if(to_array_type(arr.type()).size().id() == ID_constant)
+  else if(to_array_type(arr.type()).size().is_constant())
     size_val = simplify_expr(to_array_type(arr.type()).size(), ns);
   else
     return {};
@@ -1577,7 +1577,7 @@ static void add_to_index_set(
 {
   simplify(i, ns);
   const bool is_size_t = numeric_cast<std::size_t>(i).has_value();
-  if(i.id() != ID_constant || is_size_t)
+  if(!i.is_constant() || is_size_t)
   {
     std::vector<exprt> sub_arrays;
     get_sub_arrays(s, sub_arrays);

--- a/src/solvers/strings/string_refinement_util.cpp
+++ b/src/solvers/strings/string_refinement_util.cpp
@@ -51,8 +51,10 @@ bool has_char_array_subexpr(const exprt &expr, const namespacet &ns)
 std::string
 utf16_constant_array_to_java(const array_exprt &arr, std::size_t length)
 {
-  for(const auto &op : arr.operands())
-    PRECONDITION(op.id() == ID_constant);
+  PRECONDITION(std::all_of(
+    arr.operands().begin(),
+    arr.operands().end(),
+    can_cast_expr<constant_exprt>));
 
   std::wstring out(length, '?');
 

--- a/src/util/arith_tools.h
+++ b/src/util/arith_tools.h
@@ -39,7 +39,7 @@ struct numeric_castt<mp_integer> final
 {
   optionalt<mp_integer> operator()(const exprt &expr) const
   {
-    if(expr.id() != ID_constant)
+    if(!expr.is_constant())
       return {};
     else
       return operator()(to_constant_expr(expr));
@@ -100,7 +100,7 @@ public:
   // Conversion from expression
   optionalt<T> operator()(const exprt &expr) const
   {
-    if(expr.id() == ID_constant)
+    if(expr.is_constant())
       return numeric_castt<T>{}(to_constant_expr(expr));
     else
       return {};

--- a/src/util/config.cpp
+++ b/src/util/config.cpp
@@ -1236,7 +1236,7 @@ static unsigned unsigned_from_ns(
   simplify(tmp, ns);
 
   INVARIANT(
-    tmp.id() == ID_constant,
+    tmp.is_constant(),
     "symbol table configuration entry '" + id2string(id) +
       "' must be a constant");
 

--- a/src/util/expr.cpp
+++ b/src/util/expr.cpp
@@ -22,13 +22,6 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <stack>
 
-/// Return whether the expression is a constant.
-/// \return True if is a constant, false otherwise
-bool exprt::is_constant() const
-{
-  return id()==ID_constant;
-}
-
 /// Return whether the expression is a constant representing `true`.
 /// \return True if is a Boolean constant representing `true`, false otherwise.
 bool exprt::is_true() const

--- a/src/util/expr.h
+++ b/src/util/expr.h
@@ -199,7 +199,13 @@ public:
     op.push_back(std::move(e3));
   }
 
-  bool is_constant() const;
+  /// Return whether the expression is a constant.
+  /// \return True if is a constant, false otherwise
+  bool is_constant() const
+  {
+    return id() == ID_constant;
+  }
+
   bool is_true() const;
   bool is_false() const;
   bool is_zero() const;

--- a/src/util/interval.h
+++ b/src/util/interval.h
@@ -103,7 +103,7 @@ public:
 
     bool b = true;
 
-    b &= id == ID_constant || id == ID_min || id == ID_max;
+    b &= expr.is_constant() || id == ID_min || id == ID_max;
 
     if(type().id() == ID_bool && id == ID_constant)
     {

--- a/src/util/lower_byte_operators.cpp
+++ b/src/util/lower_byte_operators.cpp
@@ -975,7 +975,7 @@ static exprt unpack_rec(
       ns,
       unpack_byte_array);
   }
-  else if(src.id() == ID_constant && src.type().id() == ID_string)
+  else if(src.is_constant() && src.type().id() == ID_string)
   {
     return unpack_rec(
       string_constantt(to_constant_expr(src).get_value()).to_array_expr(),

--- a/src/util/rational_tools.cpp
+++ b/src/util/rational_tools.cpp
@@ -26,7 +26,7 @@ static mp_integer power10(size_t i)
 
 bool to_rational(const exprt &expr, rationalt &rational_value)
 {
-  if(expr.id()!=ID_constant)
+  if(!expr.is_constant())
     return true;
 
   const std::string &value=expr.get_string(ID_value);

--- a/src/util/simplify_expr.cpp
+++ b/src/util/simplify_expr.cpp
@@ -304,7 +304,7 @@ static simplify_exprt::resultt<> simplify_string_is_empty(
   const refined_string_exprt &s =
     to_string_expr(function_app.arguments().at(0));
 
-  if(s.length().id() != ID_constant)
+  if(!s.length().is_constant())
     return simplify_exprt::unchanged(expr);
 
   const auto numeric_length =
@@ -381,7 +381,7 @@ static simplify_exprt::resultt<> simplify_string_index_of(
   {
     auto &starting_index_expr = expr.arguments().at(2);
 
-    if(starting_index_expr.id() != ID_constant)
+    if(!starting_index_expr.is_constant())
     {
       return simplify_exprt::unchanged(expr);
     }
@@ -466,7 +466,7 @@ static simplify_exprt::resultt<> simplify_string_index_of(
           std::distance(s1_data.operands().begin(), it), expr.type());
     }
   }
-  else if(expr.arguments().at(1).id() == ID_constant)
+  else if(expr.arguments().at(1).is_constant())
   {
     // Second argument is a constant character
 
@@ -518,7 +518,7 @@ static simplify_exprt::resultt<> simplify_string_char_at(
   const function_application_exprt &expr,
   const namespacet &ns)
 {
-  if(expr.arguments().at(1).id() != ID_constant)
+  if(!expr.arguments().at(1).is_constant())
   {
     return simplify_exprt::unchanged(expr);
   }
@@ -661,7 +661,7 @@ static simplify_exprt::resultt<> simplify_string_startswith(
   if(expr.arguments().size() == 3)
   {
     auto &offset = expr.arguments()[2];
-    if(offset.id() != ID_constant)
+    if(!offset.is_constant())
       return simplify_exprt::unchanged(expr);
     offset_int = numeric_cast_v<mp_integer>(to_constant_expr(offset));
   }
@@ -1445,7 +1445,7 @@ simplify_exprt::resultt<> simplify_exprt::simplify_with(const with_exprt &expr)
 
   if(old_type_followed.id() == ID_struct)
   {
-    if(with_expr.old().id() == ID_struct || with_expr.old().id() == ID_constant)
+    if(with_expr.old().id() == ID_struct || with_expr.old().is_constant())
     {
       while(with_expr.operands().size() > 1)
       {
@@ -1475,7 +1475,7 @@ simplify_exprt::resultt<> simplify_exprt::simplify_with(const with_exprt &expr)
     with_expr.old().type().id() == ID_vector)
   {
     if(
-      with_expr.old().id() == ID_array || with_expr.old().id() == ID_constant ||
+      with_expr.old().id() == ID_array || with_expr.old().is_constant() ||
       with_expr.old().id() == ID_vector)
     {
       while(with_expr.operands().size() > 1)
@@ -1777,8 +1777,9 @@ simplify_exprt::simplify_byte_extract(const byte_extract_exprt &expr)
   if(!el_size.has_value() || *el_size == 0)
     return unchanged(expr);
 
-  if(expr.op().id()==ID_array_of &&
-     to_array_of_expr(expr.op()).op().id()==ID_constant)
+  if(
+    expr.op().id() == ID_array_of &&
+    to_array_of_expr(expr.op()).op().is_constant())
   {
     const auto const_bits_opt = expr2bits(
       to_array_of_expr(expr.op()).op(),

--- a/src/util/simplify_expr_array.cpp
+++ b/src/util/simplify_expr_array.cpp
@@ -106,8 +106,7 @@ simplify_exprt::simplify_index(const index_exprt &expr)
     }
   }
   else if(
-    array.id() == ID_constant || array.id() == ID_array ||
-    array.id() == ID_vector)
+    array.is_constant() || array.id() == ID_array || array.id() == ID_vector)
   {
     const auto i = numeric_cast<mp_integer>(index);
 

--- a/src/util/simplify_expr_int.cpp
+++ b/src/util/simplify_expr_int.cpp
@@ -990,7 +990,7 @@ simplify_exprt::simplify_shifts(const shift_exprt &expr)
 
   if(
     !value.has_value() && expr.op().type().id() == ID_bv &&
-    expr.op().id() == ID_constant)
+    expr.op().is_constant())
   {
     const std::size_t width = to_bitvector_type(expr.op().type()).get_width();
     value =
@@ -1223,7 +1223,7 @@ simplify_exprt::simplify_unary_minus(const unary_minus_exprt &expr)
 
     return to_unary_minus_expr(operand).op();
   }
-  else if(operand.id()==ID_constant)
+  else if(operand.is_constant())
   {
     const irep_idt &type_id=expr.type().id();
     const auto &constant_expr = to_constant_expr(operand);
@@ -1279,7 +1279,7 @@ simplify_exprt::simplify_bitnot(const bitnot_exprt &expr)
 
     if(op.type() == type)
     {
-      if(op.id()==ID_constant)
+      if(op.is_constant())
       {
         const auto &value = to_constant_expr(op).get_value();
         const auto new_value =

--- a/src/util/simplify_expr_pointer.cpp
+++ b/src/util/simplify_expr_pointer.cpp
@@ -376,7 +376,7 @@ simplify_exprt::simplify_pointer_offset(const pointer_offset_exprt &expr)
 
     return changed(simplify_plus(new_expr));
   }
-  else if(ptr.id()==ID_constant)
+  else if(ptr.is_constant())
   {
     const constant_exprt &c_ptr = to_constant_expr(ptr);
 
@@ -499,7 +499,7 @@ simplify_exprt::resultt<> simplify_exprt::simplify_inequality_pointer_object(
         return unchanged(expr);
       }
     }
-    else if(op.id() != ID_constant || !op.is_zero())
+    else if(!op.is_constant() || !op.is_zero())
     {
       return unchanged(expr);
     }
@@ -580,7 +580,7 @@ simplify_exprt::simplify_is_dynamic_object(const unary_exprt &expr)
   }
 
   // NULL is not dynamic
-  if(op.id() == ID_constant && is_null_pointer(to_constant_expr(op)))
+  if(op.is_constant() && is_null_pointer(to_constant_expr(op)))
     return false_exprt();
 
   // &something depends on the something
@@ -628,7 +628,7 @@ simplify_exprt::simplify_is_invalid_pointer(const unary_exprt &expr)
   }
 
   // NULL is not invalid
-  if(op.id() == ID_constant && is_null_pointer(to_constant_expr(op)))
+  if(op.is_constant() && is_null_pointer(to_constant_expr(op)))
   {
     return false_exprt();
   }

--- a/src/util/simplify_utils.cpp
+++ b/src/util/simplify_utils.cpp
@@ -416,7 +416,7 @@ expr2bits(const exprt &expr, bool little_endian, const namespacet &ns)
   // extract bits from lowest to highest memory address
   const typet &type = expr.type();
 
-  if(expr.id() == ID_constant)
+  if(expr.is_constant())
   {
     const auto &value = to_constant_expr(expr).get_value();
 

--- a/src/util/std_expr.h
+++ b/src/util/std_expr.h
@@ -2975,7 +2975,7 @@ public:
 template <>
 inline bool can_cast_expr<constant_exprt>(const exprt &base)
 {
-  return base.id() == ID_constant;
+  return base.is_constant();
 }
 
 inline void validate_expr(const constant_exprt &value)
@@ -2991,14 +2991,14 @@ inline void validate_expr(const constant_exprt &value)
 /// \return Object of type \ref constant_exprt
 inline const constant_exprt &to_constant_expr(const exprt &expr)
 {
-  PRECONDITION(expr.id()==ID_constant);
+  PRECONDITION(expr.is_constant());
   return static_cast<const constant_exprt &>(expr);
 }
 
 /// \copydoc to_constant_expr(const exprt &)
 inline constant_exprt &to_constant_expr(exprt &expr)
 {
-  PRECONDITION(expr.id()==ID_constant);
+  PRECONDITION(expr.is_constant());
   return static_cast<constant_exprt &>(expr);
 }
 

--- a/src/util/validate_expressions.cpp
+++ b/src/util/validate_expressions.cpp
@@ -43,7 +43,7 @@ void call_on_expr(const exprt &expr, Args &&... args)
   {
     CALL_ON_EXPR(dereference_exprt);
   }
-  else if(expr.id() == ID_constant)
+  else if(expr.is_constant())
   {
     CALL_ON_EXPR(constant_exprt);
   }

--- a/unit/analyses/ai/ai_simplify_lhs.cpp
+++ b/unit/analyses/ai/ai_simplify_lhs.cpp
@@ -98,7 +98,7 @@ SCENARIO("ai_domain_baset::ai_simplify_lhs",
     REQUIRE_FALSE(compile_failed);
     REQUIRE(simplifiable_expression.id()==ID_plus);
     exprt simplified_version=simplify_expr(simplifiable_expression, ns);
-    REQUIRE(simplified_version.id()==ID_constant);
+    REQUIRE(simplified_version.is_constant());
 
     WHEN(
       "Simplifying an index expression with constant index but variable array")
@@ -115,7 +115,7 @@ SCENARIO("ai_domain_baset::ai_simplify_lhs",
         REQUIRE(index_expr.id()==ID_index);
 
         index_exprt simplified_index_expr=to_index_expr(out_expr);
-        REQUIRE(simplified_index_expr.index().id()==ID_constant);
+        REQUIRE(simplified_index_expr.index().is_constant());
 
         constant_exprt constant_index=
           to_constant_expr(simplified_index_expr.index());
@@ -171,7 +171,7 @@ SCENARIO("ai_domain_baset::ai_simplify_lhs",
         REQUIRE(out_expr.id()==ID_index);
 
         index_exprt simplified_index_expr=to_index_expr(out_expr);
-        REQUIRE(simplified_index_expr.index().id()==ID_constant);
+        REQUIRE(simplified_index_expr.index().is_constant());
 
         constant_exprt constant_index=
           to_constant_expr(simplified_index_expr.index());

--- a/unit/testing-utils/require_expr.cpp
+++ b/unit/testing-utils/require_expr.cpp
@@ -27,7 +27,7 @@ index_exprt require_expr::require_index(const exprt &expr, int expected_index)
 {
   REQUIRE(expr.id()==ID_index);
   const index_exprt &index_expr=to_index_expr(expr);
-  REQUIRE(index_expr.index().id()==ID_constant);
+  REQUIRE(index_expr.index().is_constant());
   const mp_integer index_integer_value =
     numeric_cast_v<mp_integer>(to_constant_expr(index_expr.index()));
   REQUIRE(index_integer_value==expected_index);

--- a/unit/util/simplify_expr.cpp
+++ b/unit/util/simplify_expr.cpp
@@ -38,7 +38,7 @@ TEST_CASE("Simplify pointer_offset(address of array index)", "[core][util]")
 
   exprt simp=simplify_expr(p_o, ns);
 
-  REQUIRE(simp.id()==ID_constant);
+  REQUIRE(simp.is_constant());
   const mp_integer offset_value =
     numeric_cast_v<mp_integer>(to_constant_expr(simp));
   REQUIRE(offset_value==1);
@@ -59,7 +59,7 @@ TEST_CASE("Simplify const pointer offset", "[core][util]")
 
   exprt simp=simplify_expr(p_o, ns);
 
-  REQUIRE(simp.id()==ID_constant);
+  REQUIRE(simp.is_constant());
   const mp_integer offset_value =
     numeric_cast_v<mp_integer>(to_constant_expr(simp));
   REQUIRE(offset_value==1234);


### PR DESCRIPTION
We would sometimes use is_constant and at other times id() ==
ID_constant (which is exactly what is_constant() does). One option was
to get rid of is_constant(), but it seemed safer to use this function
than to stick with the lower-level id() == ID_constant: the function is
type safer as it can only be used on exprt, while comparisons on id()
would work on any irept.

To ensure there is no performance penalty, is_constant() has been moved
to the header file to permit inlining.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
