### PR TITLE
Consistently use exprt::is_boolean()

### DIFF
--- a/jbmc/src/java_bytecode/expr2java.cpp
+++ b/jbmc/src/java_bytecode/expr2java.cpp
@@ -175,7 +175,7 @@ std::string expr2javat::convert_constant(
     else
       return "false";
   }
-  else if(src.type().id()==ID_bool)
+  else if(src.is_boolean())
   {
     if(src.is_true())
       return "true";

--- a/src/analyses/guard_expr.cpp
+++ b/src/analyses/guard_expr.cpp
@@ -37,7 +37,7 @@ exprt guard_exprt::guard_expr(exprt expr) const
 
 void guard_exprt::add(const exprt &expr)
 {
-  PRECONDITION(expr.type().id() == ID_bool);
+  PRECONDITION(expr.is_boolean());
 
   if(is_false() || expr.is_true())
     return;

--- a/src/analyses/invariant_set.cpp
+++ b/src/analyses/invariant_set.cpp
@@ -381,7 +381,7 @@ void invariant_sett::strengthen(const exprt &expr)
 
 void invariant_sett::strengthen_rec(const exprt &expr)
 {
-  if(expr.type().id()!=ID_bool)
+  if(!expr.is_boolean())
     throw "non-Boolean argument to strengthen()";
 
   #if 0
@@ -584,7 +584,7 @@ tvt invariant_sett::implies(const exprt &expr) const
 
 tvt invariant_sett::implies_rec(const exprt &expr) const
 {
-  if(expr.type().id()!=ID_bool)
+  if(!expr.is_boolean())
     throw "implies: non-Boolean expression";
 
   #if 0
@@ -696,7 +696,7 @@ void invariant_sett::get_bounds(unsigned a, boundst &bounds) const
 
 void invariant_sett::nnf(exprt &expr, bool negate)
 {
-  if(expr.type().id()!=ID_bool)
+  if(!expr.is_boolean())
     throw "nnf: non-Boolean expression";
 
   if(expr.is_true())

--- a/src/analyses/variable-sensitivity/abstract_environment.cpp
+++ b/src/analyses/variable-sensitivity/abstract_environment.cpp
@@ -262,7 +262,7 @@ bool abstract_environmentt::assume(const exprt &expr, const namespacet &ns)
   // We should only attempt to assume Boolean things
   // This should be enforced by the well-structured-ness of the
   // goto-program and the way assume is used.
-  PRECONDITION(expr.type().id() == ID_bool);
+  PRECONDITION(expr.is_boolean());
 
   auto simplified = simplify_expr(expr, ns);
   auto assumption = do_assume(simplified, ns);
@@ -270,8 +270,7 @@ bool abstract_environmentt::assume(const exprt &expr, const namespacet &ns)
   if(assumption.id() != ID_nil) // I.E. actually a value
   {
     // Should be of the right type
-    INVARIANT(
-      assumption.type().id() == ID_bool, "simplification preserves type");
+    INVARIANT(assumption.is_boolean(), "simplification preserves type");
 
     if(assumption.is_false())
     {

--- a/src/ansi-c/c_typecheck_expr.cpp
+++ b/src/ansi-c/c_typecheck_expr.cpp
@@ -431,7 +431,7 @@ void c_typecheck_baset::typecheck_expr_main(exprt &expr)
     // This is one of the few places where it's detectable
     // that we are using "bool" for boolean operators instead
     // of "int". We convert for this reason.
-    if(op.type().id() == ID_bool)
+    if(op.is_boolean())
       op = typecast_exprt(op, signed_int_type());
 
     irept::subt &generic_associations=
@@ -960,7 +960,7 @@ void c_typecheck_baset::typecheck_expr_sizeof(exprt &expr)
     // This is one of the few places where it's detectable
     // that we are using "bool" for boolean operators instead
     // of "int". We convert for this reason.
-    if(op.type().id() == ID_bool)
+    if(op.is_boolean())
       type = signed_int_type();
     else
       type = op.type();
@@ -1102,7 +1102,7 @@ void c_typecheck_baset::typecheck_expr_typecast(exprt &expr)
     // This is one of the few places where it's detectable
     // that we are using "bool" for boolean operators instead
     // of "int". We convert for this reason.
-    if(op.type().id() == ID_bool)
+    if(op.is_boolean())
       op = typecast_exprt(op, signed_int_type());
 
     // we need to find a member with the right type
@@ -1718,7 +1718,7 @@ void c_typecheck_baset::typecheck_expr_address_of(exprt &expr)
     throw 0;
   }
 
-  if(op.type().id() == ID_bool)
+  if(op.is_boolean())
   {
     error().source_location = expr.source_location();
     error() << "cannot take address of a single bit" << eom;
@@ -4352,7 +4352,7 @@ void c_typecheck_baset::typecheck_side_effect_assignment(
     {
       implicit_typecast_arithmetic(op0, op1);
       if(
-        op1.type().id() == ID_bool || op1.type().id() == ID_c_bool ||
+        op1.is_boolean() || op1.type().id() == ID_c_bool ||
         op1.type().id() == ID_c_enum_tag || op1.type().id() == ID_unsignedbv ||
         op1.type().id() == ID_signedbv || op1.type().id() == ID_c_bit_field)
       {
@@ -4418,7 +4418,7 @@ void c_typecheck_baset::typecheck_side_effect_assignment(
       implicit_typecast_arithmetic(op1);
 
       if(
-        is_number(op1.type()) || op1.type().id() == ID_bool ||
+        is_number(op1.type()) || op1.is_boolean() ||
         op1.type().id() == ID_c_bool || op1.type().id() == ID_c_enum_tag)
       {
         op1 = typecast_exprt(op1, o_type0);
@@ -4429,22 +4429,24 @@ void c_typecheck_baset::typecheck_side_effect_assignment(
             o_type0.id()==ID_c_bool)
     {
       implicit_typecast_arithmetic(op0, op1);
-      if(op1.type().id()==ID_bool ||
-         op1.type().id()==ID_c_bool ||
-         op1.type().id()==ID_c_enum_tag ||
-         op1.type().id()==ID_unsignedbv ||
-         op1.type().id()==ID_signedbv)
+      if(
+        op1.is_boolean() || op1.type().id() == ID_c_bool ||
+        op1.type().id() == ID_c_enum_tag || op1.type().id() == ID_unsignedbv ||
+        op1.type().id() == ID_signedbv)
+      {
         return;
+      }
     }
     else
     {
       implicit_typecast_arithmetic(op0, op1);
 
-      if(is_number(op1.type()) ||
-         op1.type().id()==ID_bool ||
-         op1.type().id()==ID_c_bool ||
-         op1.type().id()==ID_c_enum_tag)
+      if(
+        is_number(op1.type()) || op1.is_boolean() ||
+        op1.type().id() == ID_c_bool || op1.type().id() == ID_c_enum_tag)
+      {
         return;
+      }
     }
   }
 

--- a/src/ansi-c/padding.cpp
+++ b/src/ansi-c/padding.cpp
@@ -193,8 +193,7 @@ static void add_padding_msvc(struct_typet &type, const namespacet &ns)
       const auto width = to_c_bit_field_type(it->type()).get_width();
       bit_field_bits += width;
     }
-    else if(
-      it->type().id() == ID_bool && underlying_bits == config.ansi_c.char_width)
+    else if(it->is_boolean() && underlying_bits == config.ansi_c.char_width)
     {
       ++bit_field_bits;
     }
@@ -242,7 +241,7 @@ static void add_padding_msvc(struct_typet &type, const namespacet &ns)
         const auto width = to_c_bit_field_type(it->type()).get_width();
         bit_field_bits += width;
       }
-      else if(it->type().id() == ID_bool)
+      else if(it->is_boolean())
       {
         underlying_bits = config.ansi_c.char_width;
         ++bit_field_bits;
@@ -304,7 +303,7 @@ static void add_padding_gcc(struct_typet &type, const namespacet &ns)
         const std::size_t width = to_c_bit_field_type(it->type()).get_width();
         bit_field_bits+=width;
       }
-      else if(it->type().id() == ID_bool)
+      else if(it->is_boolean())
       {
         ++bit_field_bits;
       }

--- a/src/cpp/cpp_typecheck_conversions.cpp
+++ b/src/cpp/cpp_typecheck_conversions.cpp
@@ -221,7 +221,7 @@ bool cpp_typecheckt::standard_conversion_integral_promotion(
     return true;
   }
 
-  if(expr.type().id() == ID_bool || expr.type().id() == ID_c_bool)
+  if(expr.is_boolean() || expr.type().id() == ID_c_bool)
   {
     new_expr = typecast_exprt(expr, int_type);
     return true;
@@ -308,7 +308,7 @@ bool cpp_typecheckt::standard_conversion_integral_conversion(
 
   if(
     expr.type().id() != ID_signedbv && expr.type().id() != ID_unsignedbv &&
-    expr.type().id() != ID_c_bool && expr.type().id() != ID_bool &&
+    expr.type().id() != ID_c_bool && !expr.is_boolean() &&
     expr.type().id() != ID_c_enum_tag)
   {
     return false;
@@ -640,7 +640,7 @@ bool cpp_typecheckt::standard_conversion_boolean(
 
   if(
     expr.type().id() != ID_signedbv && expr.type().id() != ID_unsignedbv &&
-    expr.type().id() != ID_pointer && expr.type().id() != ID_bool &&
+    expr.type().id() != ID_pointer && !expr.is_boolean() &&
     expr.type().id() != ID_c_enum_tag)
   {
     return false;
@@ -1838,7 +1838,7 @@ bool cpp_typecheckt::reinterpret_typecast(
 
   if(
     (e.type().id() == ID_unsignedbv || e.type().id() == ID_signedbv ||
-     e.type().id() == ID_c_bool || e.type().id() == ID_bool) &&
+     e.type().id() == ID_c_bool || e.is_boolean()) &&
     type.id() == ID_pointer && !is_reference(type))
   {
     // integer to pointer

--- a/src/goto-instrument/accelerate/disjunctive_polynomial_acceleration.cpp
+++ b/src/goto-instrument/accelerate/disjunctive_polynomial_acceleration.cpp
@@ -88,7 +88,7 @@ bool disjunctive_polynomial_accelerationt::accelerate(
     polynomialt poly;
     exprt target=*it;
 
-    if(it->type().id()==ID_bool)
+    if(it->is_boolean())
     {
       // Hack: don't try to accelerate booleans.
       continue;
@@ -150,7 +150,7 @@ bool disjunctive_polynomial_accelerationt::accelerate(
     std::cout << "Trying to accelerate " << format(*it) << '\n';
 #endif
 
-    if(it->type().id()==ID_bool)
+    if(it->is_boolean())
     {
       // Hack: don't try to accelerate booleans.
       accelerator.dirty_vars.insert(*it);

--- a/src/goto-instrument/cover_util.cpp
+++ b/src/goto-instrument/cover_util.cpp
@@ -13,7 +13,7 @@ Author: Daniel Kroening
 
 bool is_condition(const exprt &src)
 {
-  if(src.type().id() != ID_bool)
+  if(!src.is_boolean())
     return false;
 
   // conditions are 'atomic predicates'
@@ -73,7 +73,7 @@ void collect_decisions_rec(const exprt &src, std::set<exprt> &dest)
     return;
   }
 
-  if(src.type().id() == ID_bool)
+  if(src.is_boolean())
   {
     if(src.is_constant())
     {

--- a/src/goto-programs/goto_program.h
+++ b/src/goto-programs/goto_program.h
@@ -1011,7 +1011,7 @@ public:
     const exprt &_cond,
     const source_locationt &l = source_locationt::nil())
   {
-    PRECONDITION(_cond.type().id() == ID_bool);
+    PRECONDITION(_cond.is_boolean());
     return instructiont(
       static_cast<const goto_instruction_codet &>(get_nil_irep()),
       l,

--- a/src/goto-programs/interpreter_evaluate.cpp
+++ b/src/goto-programs/interpreter_evaluate.cpp
@@ -380,7 +380,7 @@ interpretert::mp_vectort interpretert::evaluate(const exprt &expr)
       const auto width = to_c_bool_type(expr.type()).get_width();
       return {bvrep2integer(value, width, false)};
     }
-    else if(expr.type().id()==ID_bool)
+    else if(expr.is_boolean())
     {
       return {expr.is_true()};
     }
@@ -910,7 +910,7 @@ interpretert::mp_vectort interpretert::evaluate(const exprt &expr)
         const auto s = integer2bvrep(value, width);
         return {bvrep2integer(s, width, false)};
       }
-      else if((expr.type().id()==ID_bool) || (expr.type().id()==ID_c_bool))
+      else if(expr.is_boolean() || expr.type().id() == ID_c_bool)
         return {value != 0};
     }
   }

--- a/src/solvers/flattening/boolbv.cpp
+++ b/src/solvers/flattening/boolbv.cpp
@@ -95,7 +95,7 @@ bvt boolbvt::conversion_failed(const exprt &expr)
 ///   circuit
 bvt boolbvt::convert_bitvector(const exprt &expr)
 {
-  if(expr.type().id()==ID_bool)
+  if(expr.is_boolean())
     return {convert(expr)};
 
   if(expr.id()==ID_index)
@@ -317,7 +317,7 @@ bvt boolbvt::convert_function_application(
 
 literalt boolbvt::convert_rest(const exprt &expr)
 {
-  PRECONDITION(expr.type().id() == ID_bool);
+  PRECONDITION(expr.is_boolean());
 
   if(expr.id()==ID_typecast)
     return convert_typecast(to_typecast_expr(expr));
@@ -506,7 +506,7 @@ bool boolbvt::boolbv_set_equality_to_true(const equal_exprt &expr)
 
 void boolbvt::set_to(const exprt &expr, bool value)
 {
-  PRECONDITION(expr.type().id() == ID_bool);
+  PRECONDITION(expr.is_boolean());
 
   const auto equal_expr = expr_try_dynamic_cast<equal_exprt>(expr);
   if(value && equal_expr && !boolbv_set_equality_to_true(*equal_expr))

--- a/src/solvers/flattening/boolbv_get.cpp
+++ b/src/solvers/flattening/boolbv_get.cpp
@@ -278,7 +278,7 @@ exprt boolbvt::bv_get(const bvt &bv, const typet &type) const
 
 exprt boolbvt::bv_get_cache(const exprt &expr) const
 {
-  if(expr.type().id()==ID_bool) // boolean?
+  if(expr.is_boolean())
     return get(expr);
 
   // look up literals in cache

--- a/src/solvers/flattening/boolbv_let.cpp
+++ b/src/solvers/flattening/boolbv_let.cpp
@@ -51,11 +51,10 @@ bvt boolbvt::convert_let(const let_exprt &expr)
   // Now assign
   for(const auto &binding : make_range(fresh_variables).zip(converted_values))
   {
-    bool is_boolean = binding.first.type().id() == ID_bool;
     const auto &identifier = binding.first.get_identifier();
 
     // make the symbol visible
-    if(is_boolean)
+    if(binding.first.is_boolean())
     {
       DATA_INVARIANT(binding.second.size() == 1, "boolean values have one bit");
       symbols[identifier] = binding.second[0];

--- a/src/solvers/flattening/bv_pointers.cpp
+++ b/src/solvers/flattening/bv_pointers.cpp
@@ -121,7 +121,7 @@ bvt bv_pointerst::object_offset_encoding(const bvt &object, const bvt &offset)
 
 literalt bv_pointerst::convert_rest(const exprt &expr)
 {
-  PRECONDITION(expr.type().id() == ID_bool);
+  PRECONDITION(expr.is_boolean());
 
   const exprt::operandst &operands=expr.operands();
 

--- a/src/solvers/floatbv/float_bv.cpp
+++ b/src/solvers/floatbv/float_bv.cpp
@@ -73,7 +73,7 @@ exprt float_bvt::convert(const exprt &expr) const
       return nil_exprt();
   }
   else if(
-    expr.id() == ID_typecast && expr.type().id() == ID_bool &&
+    expr.id() == ID_typecast && expr.is_boolean() &&
     to_typecast_expr(expr).op().type().id() == ID_floatbv) // float -> bool
   {
     return not_exprt(is_zero(to_typecast_expr(expr).op()));

--- a/src/solvers/prop/bdd_expr.cpp
+++ b/src/solvers/prop/bdd_expr.cpp
@@ -18,7 +18,7 @@ Author: Michael Tautschnig, michael.tautschnig@qmul.ac.uk
 
 bddt bdd_exprt::from_expr_rec(const exprt &expr)
 {
-  PRECONDITION(expr.type().id() == ID_bool);
+  PRECONDITION(expr.is_boolean());
 
   if(expr.is_constant())
     return expr.is_false() ? bdd_mgr.bdd_false() : bdd_mgr.bdd_true();
@@ -49,8 +49,7 @@ bddt bdd_exprt::from_expr_rec(const exprt &expr)
 
     return n_lhs.bdd_or(rhs);
   }
-  else if(
-    expr.id() == ID_equal && to_equal_expr(expr).lhs().type().id() == ID_bool)
+  else if(expr.id() == ID_equal && to_equal_expr(expr).lhs().is_boolean())
   {
     const equal_exprt &eq_expr=to_equal_expr(expr);
 

--- a/src/solvers/prop/prop_conv_solver.cpp
+++ b/src/solvers/prop/prop_conv_solver.cpp
@@ -38,7 +38,7 @@ void prop_conv_solvert::set_all_frozen()
 exprt prop_conv_solvert::handle(const exprt &expr)
 {
   // We can only improve Booleans.
-  if(expr.type().id() != ID_bool)
+  if(!expr.is_boolean())
     return expr;
 
   // We convert to a literal to obtain a 'small' handle
@@ -107,7 +107,7 @@ optionalt<bool> prop_conv_solvert::get_bool(const exprt &expr) const
 
   if(expr.id() == ID_not)
   {
-    if(expr.type().id() == ID_bool)
+    if(expr.is_boolean())
     {
       auto tmp = get_bool(to_not_expr(expr).op());
       if(tmp.has_value())
@@ -118,7 +118,7 @@ optionalt<bool> prop_conv_solvert::get_bool(const exprt &expr) const
   }
   else if(expr.id() == ID_and || expr.id() == ID_or)
   {
-    if(expr.type().id() == ID_bool && expr.operands().size() >= 1)
+    if(expr.is_boolean() && expr.operands().size() >= 1)
     {
       for(const auto &op : expr.operands())
       {
@@ -189,7 +189,7 @@ literalt prop_conv_solvert::convert(const exprt &expr)
 
 literalt prop_conv_solvert::convert_bool(const exprt &expr)
 {
-  PRECONDITION(expr.type().id() == ID_bool);
+  PRECONDITION(expr.is_boolean());
 
   const exprt::operandst &op = expr.operands();
 
@@ -292,7 +292,7 @@ literalt prop_conv_solvert::convert_bool(const exprt &expr)
     INVARIANT(op.size() == 2, "equality takes two operands");
     bool equal = (expr.id() == ID_equal);
 
-    if(op[0].type().id() == ID_bool && op[1].type().id() == ID_bool)
+    if(op[0].is_boolean() && op[1].is_boolean())
     {
       literalt tmp1 = convert(op[0]), tmp2 = convert(op[1]);
       return equal ? prop.lequal(tmp1, tmp2) : prop.lxor(tmp1, tmp2);
@@ -345,11 +345,11 @@ bool prop_conv_solvert::set_equality_to_true(const equal_exprt &expr)
 
 void prop_conv_solvert::add_constraints_to_prop(const exprt &expr, bool value)
 {
-  PRECONDITION(expr.type().id() == ID_bool);
+  PRECONDITION(expr.is_boolean());
 
   const bool has_only_boolean_operands = std::all_of(
     expr.operands().begin(), expr.operands().end(), [](const exprt &expr) {
-      return expr.type().id() == ID_bool;
+      return expr.is_boolean();
     });
 
   if(has_only_boolean_operands)
@@ -474,7 +474,7 @@ decision_proceduret::resultt prop_conv_solvert::dec_solve()
 
 exprt prop_conv_solvert::get(const exprt &expr) const
 {
-  if(expr.type().id() == ID_bool)
+  if(expr.is_boolean())
   {
     auto value = get_bool(expr);
 

--- a/src/solvers/smt2/smt2_conv.cpp
+++ b/src/solvers/smt2/smt2_conv.cpp
@@ -801,7 +801,7 @@ static bool has_quantifier(const exprt &expr)
 
 literalt smt2_convt::convert(const exprt &expr)
 {
-  PRECONDITION(expr.type().id() == ID_bool);
+  PRECONDITION(expr.is_boolean());
 
   // Three cases where no new handle is needed.
 
@@ -858,7 +858,7 @@ literalt smt2_convt::convert(const exprt &expr)
 exprt smt2_convt::handle(const exprt &expr)
 {
   // We can only improve Booleans.
-  if(expr.type().id() != ID_bool)
+  if(!expr.is_boolean())
     return expr;
 
   return literal_exprt(convert(expr));
@@ -1341,7 +1341,7 @@ void smt2_convt::convert_expr(const exprt &expr)
           expr.id()==ID_xor)
   {
     DATA_INVARIANT(
-      expr.type().id() == ID_bool,
+      expr.is_boolean(),
       "logical and, or, and xor expressions should have Boolean type");
     DATA_INVARIANT(
       expr.operands().size() >= 2,
@@ -1360,8 +1360,7 @@ void smt2_convt::convert_expr(const exprt &expr)
     const implies_exprt &implies_expr = to_implies_expr(expr);
 
     DATA_INVARIANT(
-      implies_expr.type().id() == ID_bool,
-      "implies expression should have Boolean type");
+      implies_expr.is_boolean(), "implies expression should have Boolean type");
 
     out << "(=> ";
     convert_expr(implies_expr.op0());
@@ -1374,8 +1373,7 @@ void smt2_convt::convert_expr(const exprt &expr)
     const not_exprt &not_expr = to_not_expr(expr);
 
     DATA_INVARIANT(
-      not_expr.type().id() == ID_bool,
-      "not expression should have Boolean type");
+      not_expr.is_boolean(), "not expression should have Boolean type");
 
     out << "(not ";
     convert_expr(not_expr.op());
@@ -2030,7 +2028,7 @@ void smt2_convt::convert_expr(const exprt &expr)
     const auto &op1 = to_binary_expr(expr).op1();
 
     DATA_INVARIANT(
-      keep_result || expr.type().id() == ID_bool,
+      keep_result || expr.is_boolean(),
       "overflow plus and overflow minus expressions shall be of Boolean type");
 
     bool subtract = can_cast_expr<minus_overflow_exprt>(expr) ||
@@ -2126,7 +2124,7 @@ void smt2_convt::convert_expr(const exprt &expr)
     const auto &op1 = to_binary_expr(expr).op1();
 
     DATA_INVARIANT(
-      keep_result || expr.type().id() == ID_bool,
+      keep_result || expr.is_boolean(),
       "overflow mult expression shall be of Boolean type");
 
     // No better idea than to multiply with double the bits and then compare
@@ -4474,7 +4472,7 @@ void smt2_convt::convert_index(const index_exprt &expr)
 
     if(use_array_theory(expr.array()))
     {
-      if(expr.type().id() == ID_bool && !use_array_of_bool)
+      if(expr.is_boolean() && !use_array_of_bool)
       {
         out << "(= ";
         out << "(select ";
@@ -4841,7 +4839,7 @@ void smt2_convt::unflatten(
 
 void smt2_convt::set_to(const exprt &expr, bool value)
 {
-  PRECONDITION(expr.type().id() == ID_bool);
+  PRECONDITION(expr.is_boolean());
 
   if(expr.id()==ID_and && value)
   {

--- a/src/solvers/smt2/smt2_parser.cpp
+++ b/src/solvers/smt2/smt2_parser.cpp
@@ -285,7 +285,7 @@ exprt smt2_parsert::quantifier_expression(irep_idt id)
 {
   auto binding = this->binding(id);
 
-  if(binding.second.type().id() != ID_bool)
+  if(!binding.second.is_boolean())
     throw error() << id << " expects a boolean term";
 
   return quantifier_exprt(id, binding.first, binding.second);
@@ -557,7 +557,7 @@ exprt smt2_parsert::function_application()
         if(smt2_tokenizer.get_buffer() == "named")
         {
           // 'named terms' must be Boolean
-          if(term.type().id() != ID_bool)
+          if(!term.is_boolean())
             throw error("named terms must be Boolean");
 
           if(next_token() == smt2_tokenizert::SYMBOL)
@@ -1242,7 +1242,7 @@ void smt2_parsert::setup_expressions()
     if(op.size() != 3)
       throw error("ite takes three operands");
 
-    if(op[0].type().id() != ID_bool)
+    if(!op[0].is_boolean())
       throw error("ite takes a boolean as first operand");
 
     if(op[1].type() != op[2].type())

--- a/src/solvers/strings/string_refinement.cpp
+++ b/src/solvers/strings/string_refinement.cpp
@@ -282,7 +282,7 @@ replace_expr_copy(const union_find_replacet &symbol_resolve, exprt expr)
 /// \param value: the boolean value to set it to
 void string_refinementt::set_to(const exprt &expr, bool value)
 {
-  PRECONDITION(expr.type().id() == ID_bool);
+  PRECONDITION(expr.is_boolean());
   PRECONDITION(equality_propagation);
   if(!value)
     equations.push_back(not_exprt{expr});

--- a/src/statement-list/converters/expr2statement_list.cpp
+++ b/src/statement-list/converters/expr2statement_list.cpp
@@ -143,7 +143,7 @@ std::string expr2stlt::convert(const exprt &expr)
     convert(to_equal_expr(expr));
   else if(ID_symbol == expr.id())
     convert(to_symbol_expr(expr));
-  else if(ID_not == expr.id() && to_not_expr(expr).op().type().id() == ID_bool)
+  else if(ID_not == expr.id() && to_not_expr(expr).op().is_boolean())
     convert(to_not_expr(expr));
   else // TODO: support more instructions in expr2stl.
     return expr2c(expr, ns);

--- a/src/util/expr.cpp
+++ b/src/util/expr.cpp
@@ -33,25 +33,14 @@ bool exprt::is_constant() const
 /// \return True if is a Boolean constant representing `true`, false otherwise.
 bool exprt::is_true() const
 {
-  return is_constant() &&
-         type().id()==ID_bool &&
-         get(ID_value)!=ID_false;
+  return is_constant() && is_boolean() && get(ID_value) != ID_false;
 }
 
 /// Return whether the expression is a constant representing `false`.
 /// \return True if is a Boolean constant representing `false`, false otherwise.
 bool exprt::is_false() const
 {
-  return is_constant() &&
-         type().id()==ID_bool &&
-         get(ID_value)==ID_false;
-}
-
-/// Return whether the expression represents a Boolean.
-/// \return True if is a Boolean, false otherwise.
-bool exprt::is_boolean() const
-{
-  return type().id()==ID_bool;
+  return is_constant() && is_boolean() && get(ID_value) == ID_false;
 }
 
 /// Return whether the expression is a constant representing 0.

--- a/src/util/expr.h
+++ b/src/util/expr.h
@@ -204,7 +204,13 @@ public:
   bool is_false() const;
   bool is_zero() const;
   bool is_one() const;
-  bool is_boolean() const;
+
+  /// Return whether the expression represents a Boolean.
+  /// \return True if is a Boolean, false otherwise.
+  bool is_boolean() const
+  {
+    return type().id() == ID_bool;
+  }
 
   const source_locationt &find_source_location() const;
 

--- a/src/util/expr_util.cpp
+++ b/src/util/expr_util.cpp
@@ -332,7 +332,7 @@ constant_exprt make_boolean_expr(bool value)
 
 exprt make_and(exprt a, exprt b)
 {
-  PRECONDITION(a.type().id() == ID_bool && b.type().id() == ID_bool);
+  PRECONDITION(a.is_boolean() && b.is_boolean());
   if(b.is_constant())
   {
     if(b.get(ID_value) == ID_false)

--- a/src/util/format_expr.cpp
+++ b/src/util/format_expr.cpp
@@ -99,7 +99,7 @@ static std::ostream &format_rec(std::ostream &os, const multi_ary_exprt &src)
 
   std::string operator_str = id2string(src.id()); // default
 
-  if(src.id() == ID_equal && to_equal_expr(src).op0().type().id() == ID_bool)
+  if(src.id() == ID_equal && to_equal_expr(src).op0().is_boolean())
   {
     operator_str = u8"\u21d4"; // <=>, U+21D4
   }

--- a/src/util/interval.cpp
+++ b/src/util/interval.cpp
@@ -221,7 +221,7 @@ tvt constant_interval_exprt::is_definitely_true() const
 
 tvt constant_interval_exprt::is_definitely_false() const
 {
-  if(type().id() == ID_bool)
+  if(is_boolean())
   {
     if(is_single_value_interval())
     {
@@ -252,8 +252,8 @@ tvt constant_interval_exprt::is_definitely_false() const
 
 tvt constant_interval_exprt::logical_or(const constant_interval_exprt &o) const
 {
-  PRECONDITION(type().id() == ID_bool);
-  PRECONDITION(o.type().id() == ID_bool);
+  PRECONDITION(is_boolean());
+  PRECONDITION(o.is_boolean());
 
   tvt a = is_definitely_true();
   tvt b = o.is_definitely_true();
@@ -263,16 +263,16 @@ tvt constant_interval_exprt::logical_or(const constant_interval_exprt &o) const
 
 tvt constant_interval_exprt::logical_and(const constant_interval_exprt &o) const
 {
-  PRECONDITION(type().id() == ID_bool);
-  PRECONDITION(o.type().id() == ID_bool);
+  PRECONDITION(is_boolean());
+  PRECONDITION(o.is_boolean());
 
   return (is_definitely_true() && o.is_definitely_true());
 }
 
 tvt constant_interval_exprt::logical_xor(const constant_interval_exprt &o) const
 {
-  PRECONDITION(type().id() == ID_bool);
-  PRECONDITION(o.type().id() == ID_bool);
+  PRECONDITION(is_boolean());
+  PRECONDITION(o.is_boolean());
 
   return (
     (is_definitely_true() && !o.is_definitely_true()) ||
@@ -281,7 +281,7 @@ tvt constant_interval_exprt::logical_xor(const constant_interval_exprt &o) const
 
 tvt constant_interval_exprt::logical_not() const
 {
-  PRECONDITION(type().id() == ID_bool);
+  PRECONDITION(is_boolean());
 
   if(is_definitely_true().is_true())
   {
@@ -1623,7 +1623,7 @@ constant_interval_exprt::unary_minus(const constant_interval_exprt &a)
 constant_interval_exprt
 constant_interval_exprt::typecast(const typet &type) const
 {
-  if(this->type().id() == ID_bool && is_int(type))
+  if(is_boolean() && is_int(type))
   {
     bool lower = !has_no_lower_bound() && get_lower().is_true();
     bool upper = has_no_upper_bound() || get_upper().is_true();

--- a/src/util/interval.h
+++ b/src/util/interval.h
@@ -84,7 +84,7 @@ public:
     const exprt &lower = get_lower();
     const exprt &upper = get_upper();
 
-    b &= is_numeric() || type.id() == ID_bool || type.is_nil();
+    b &= is_numeric() || is_boolean() || type.is_nil();
 
     b &= type == lower.type();
     b &= type == upper.type();
@@ -97,7 +97,7 @@ public:
     return b;
   }
 
-  bool is_valid_bound(const exprt &expr) const
+  static bool is_valid_bound(const exprt &expr)
   {
     const irep_idt &id = expr.id();
 
@@ -105,7 +105,7 @@ public:
 
     b &= id == ID_constant || id == ID_min || id == ID_max;
 
-    if(type().id() == ID_bool && id == ID_constant)
+    if(expr.is_boolean() && id == ID_constant)
     {
       b &= expr == true_exprt() || expr == false_exprt();
     }

--- a/src/util/pointer_offset_size.cpp
+++ b/src/util/pointer_offset_size.cpp
@@ -42,7 +42,7 @@ optionalt<mp_integer> member_offset(
       result += bit_field_bits / config.ansi_c.char_width;
       bit_field_bits %= config.ansi_c.char_width;
     }
-    else if(comp.type().id() == ID_bool)
+    else if(comp.is_boolean())
     {
       ++bit_field_bits;
       result += bit_field_bits / config.ansi_c.char_width;
@@ -255,7 +255,7 @@ optionalt<exprt> member_offset_expr(
       if(bytes > 0)
         result = plus_exprt(result, from_integer(bytes, result.type()));
     }
-    else if(c.type().id() == ID_bool)
+    else if(c.is_boolean())
     {
       ++bit_field_bits;
       const std::size_t bytes = bit_field_bits / config.ansi_c.char_width;
@@ -365,7 +365,7 @@ optionalt<exprt> size_of_expr(const typet &type, const namespacet &ns)
         if(bytes > 0)
           result = plus_exprt(result, from_integer(bytes, result.type()));
       }
-      else if(c.type().id() == ID_bool)
+      else if(c.is_boolean())
       {
         ++bit_field_bits;
         const std::size_t bytes = bit_field_bits / config.ansi_c.char_width;

--- a/src/util/simplify_expr_boolean.cpp
+++ b/src/util/simplify_expr_boolean.cpp
@@ -22,16 +22,14 @@ simplify_exprt::resultt<> simplify_exprt::simplify_boolean(const exprt &expr)
   if(!expr.has_operands())
     return unchanged(expr);
 
-  if(expr.type().id()!=ID_bool)
+  if(!expr.is_boolean())
     return unchanged(expr);
 
   if(expr.id()==ID_implies)
   {
     const auto &implies_expr = to_implies_expr(expr);
 
-    if(
-      implies_expr.op0().type().id() != ID_bool ||
-      implies_expr.op1().type().id() != ID_bool)
+    if(!implies_expr.op0().is_boolean() || !implies_expr.op1().is_boolean())
     {
       return unchanged(expr);
     }
@@ -53,7 +51,7 @@ simplify_exprt::resultt<> simplify_exprt::simplify_boolean(const exprt &expr)
     for(exprt::operandst::const_iterator it = new_operands.begin();
         it != new_operands.end();)
     {
-      if(it->type().id()!=ID_bool)
+      if(!it->is_boolean())
         return unchanged(expr);
 
       bool erase;
@@ -107,7 +105,7 @@ simplify_exprt::resultt<> simplify_exprt::simplify_boolean(const exprt &expr)
     for(exprt::operandst::const_iterator it = new_operands.begin();
         it != new_operands.end();)
     {
-      if(it->type().id()!=ID_bool)
+      if(!it->is_boolean())
         return unchanged(expr);
 
       bool is_true=it->is_true();
@@ -201,7 +199,7 @@ simplify_exprt::resultt<> simplify_exprt::simplify_boolean(const exprt &expr)
     // search for a and !a
     for(const exprt &op : new_operands)
       if(
-        op.id() == ID_not && op.type().id() == ID_bool &&
+        op.id() == ID_not && op.is_boolean() &&
         expr_set.find(to_not_expr(op).op()) != expr_set.end())
       {
         return make_boolean_expr(expr.id() == ID_or);
@@ -231,8 +229,7 @@ simplify_exprt::resultt<> simplify_exprt::simplify_not(const not_exprt &expr)
 {
   const exprt &op = expr.op();
 
-  if(expr.type().id()!=ID_bool ||
-     op.type().id()!=ID_bool)
+  if(!expr.is_boolean() || !op.is_boolean())
   {
     return unchanged(expr);
   }

--- a/src/util/simplify_expr_if.cpp
+++ b/src/util/simplify_expr_if.cpp
@@ -76,7 +76,7 @@ bool simplify_exprt::simplify_if_recursive(
   const exprt &cond,
   bool truth)
 {
-  if(expr.type().id() == ID_bool)
+  if(expr.is_boolean())
   {
     bool new_truth;
 

--- a/src/util/simplify_expr_int.cpp
+++ b/src/util/simplify_expr_int.cpp
@@ -638,15 +638,13 @@ simplify_exprt::simplify_bitwise(const multi_ary_exprt &expr)
     return unchanged(expr);
 
   // check if these are really boolean
-  if(expr.type().id()!=ID_bool)
+  if(!expr.is_boolean())
   {
     bool all_bool=true;
 
     for(const auto &op : expr.operands())
     {
-      if(
-        op.id() == ID_typecast &&
-        to_typecast_expr(op).op().type().id() == ID_bool)
+      if(op.id() == ID_typecast && to_typecast_expr(op).op().is_boolean())
       {
       }
       else if(op.is_zero() || op.is_one())
@@ -1298,7 +1296,7 @@ simplify_exprt::simplify_bitnot(const bitnot_exprt &expr)
 simplify_exprt::resultt<>
 simplify_exprt::simplify_inequality(const binary_relation_exprt &expr)
 {
-  if(expr.type().id()!=ID_bool)
+  if(!expr.is_boolean())
     return unchanged(expr);
 
   exprt tmp0=expr.op0();
@@ -1877,7 +1875,7 @@ simplify_exprt::resultt<> simplify_exprt::simplify_inequality_rhs_is_constant(
   // are we comparing with a typecast from bool?
   if(
     expr.op0().id() == ID_typecast &&
-    to_typecast_expr(expr.op0()).op().type().id() == ID_bool)
+    to_typecast_expr(expr.op0()).op().is_boolean())
   {
     const auto &lhs_typecast_op = to_typecast_expr(expr.op0()).op();
 

--- a/src/util/simplify_expr_pointer.cpp
+++ b/src/util/simplify_expr_pointer.cpp
@@ -481,7 +481,7 @@ simplify_exprt::resultt<> simplify_exprt::simplify_inequality_pointer_object(
   const binary_relation_exprt &expr)
 {
   PRECONDITION(expr.id() == ID_equal || expr.id() == ID_notequal);
-  PRECONDITION(expr.type().id() == ID_bool);
+  PRECONDITION(expr.is_boolean());
 
   exprt::operandst new_inequality_ops;
   for(const auto &operand : expr.operands())

--- a/src/util/simplify_expr_struct.cpp
+++ b/src/util/simplify_expr_struct.cpp
@@ -136,7 +136,7 @@ simplify_exprt::simplify_member(const member_exprt &expr)
 
       if(
         component.is_nil() || component.type().id() == ID_c_bit_field ||
-        component.type().id() == ID_bool)
+        component.is_boolean())
       {
         return unchanged(expr);
       }

--- a/src/util/std_expr.h
+++ b/src/util/std_expr.h
@@ -696,7 +696,7 @@ public:
 
     DATA_CHECK(
       vm,
-      expr.type().id() == ID_bool,
+      expr.is_boolean(),
       "result of binary predicate expression should be of type bool");
   }
 };
@@ -2279,7 +2279,7 @@ class not_exprt:public unary_exprt
 public:
   explicit not_exprt(exprt _op) : unary_exprt(ID_not, std::move(_op))
   {
-    PRECONDITION(as_const(*this).op().type().id() == ID_bool);
+    PRECONDITION(as_const(*this).op().is_boolean());
   }
 };
 
@@ -3304,7 +3304,7 @@ public:
   /// \param value: the value for the case
   void add_case(const exprt &condition, const exprt &value)
   {
-    PRECONDITION(condition.type().id() == ID_bool);
+    PRECONDITION(condition.is_boolean());
     operands().reserve(operands().size() + 2);
     operands().push_back(condition);
     operands().push_back(value);

--- a/unit/analyses/variable-sensitivity/value_expression_evaluation/assume.cpp
+++ b/unit/analyses/variable-sensitivity/value_expression_evaluation/assume.cpp
@@ -802,7 +802,7 @@ void ASSUME_TRUE(
   {
     auto assumption = env.do_assume(expr, ns);
     REQUIRE(assumption.id() != ID_nil);
-    REQUIRE(assumption.type().id() == ID_bool);
+    REQUIRE(assumption.is_boolean());
     REQUIRE(assumption.is_true());
   }
 }
@@ -816,7 +816,7 @@ void ASSUME_FALSE(
   {
     auto assumption = env.do_assume(expr, ns);
     REQUIRE(assumption.id() != ID_nil);
-    REQUIRE(assumption.type().id() == ID_bool);
+    REQUIRE(assumption.is_boolean());
     REQUIRE(assumption.is_false());
   }
 }

--- a/unit/analyses/variable-sensitivity/value_expression_evaluation/assume_prune.cpp
+++ b/unit/analyses/variable-sensitivity/value_expression_evaluation/assume_prune.cpp
@@ -33,7 +33,7 @@ static void ASSUME_TRUE(
   auto assumption = env.do_assume(binary_relation_exprt(x, id, y), ns);
 
   REQUIRE(assumption.id() != ID_nil);
-  REQUIRE(assumption.type().id() == ID_bool);
+  REQUIRE(assumption.is_boolean());
   REQUIRE(assumption.is_true());
 }
 


### PR DESCRIPTION
We would sometimes use is_boolean and at other times type().id() ==
ID_bool (which is exactly what is_boolean() does). One option was to get
rid of is_boolean(), but it seemed safer to use this function than to
stick with the lower-level type().id() == ID_bool: the function is type
safer as it can only be used on exprt, while comparisons on id() would
work on any irept.

To ensure there is no performance penalty, is_boolean() has been moved
to the header file to permit inlining.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
