### PR TITLE
Remove and replace use of look_through_casts

### DIFF
--- a/jbmc/src/java_bytecode/java_pointer_casts.cpp
+++ b/jbmc/src/java_bytecode/java_pointer_casts.cpp
@@ -11,6 +11,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "java_pointer_casts.h"
 
+#include <util/expr_util.h>
 #include <util/namespace.h>
 #include <util/pointer_expr.h>
 #include <util/std_expr.h>
@@ -64,21 +65,6 @@ bool find_superclass_with_type(
   }
 }
 
-
-/// \par parameters: input expression
-/// \return recursively search target of typecast
-static const exprt &look_through_casts(const exprt &in)
-{
-  if(in.id()==ID_typecast)
-  {
-    assert(in.type().id()==ID_pointer);
-    return look_through_casts(to_typecast_expr(in).op());
-  }
-  else
-    return in;
-}
-
-
 /// \par parameters: raw pointer
 /// target type
 /// namespace
@@ -88,7 +74,7 @@ exprt make_clean_pointer_cast(
   const pointer_typet &target_type,
   const namespacet &ns)
 {
-  const exprt &ptr=look_through_casts(rawptr);
+  const exprt &ptr = skip_typecast(rawptr);
 
   PRECONDITION(ptr.type().id()==ID_pointer);
 

--- a/src/analyses/variable-sensitivity/interval_abstract_value.cpp
+++ b/src/analyses/variable-sensitivity/interval_abstract_value.cpp
@@ -10,6 +10,7 @@
 
 #include <util/arith_tools.h>
 #include <util/bitvector_types.h>
+#include <util/expr_util.h>
 #include <util/invariant.h>
 #include <util/make_unique.h>
 #include <util/simplify_expr.h>
@@ -72,15 +73,6 @@ static index_range_implementation_ptrt make_interval_index_range(
   const namespacet &n)
 {
   return util_make_unique<interval_index_ranget>(interval, n);
-}
-
-static inline exprt look_through_casts(exprt e)
-{
-  while(e.id() == ID_typecast)
-  {
-    e = to_typecast_expr(e).op();
-  }
-  return e;
 }
 
 static inline bool
@@ -153,15 +145,16 @@ interval_from_x_gt_value(const exprt &value)
     return constant_interval_exprt::bottom(value.type());
 }
 
-static inline bool represents_interval(exprt e)
+static inline bool represents_interval(const exprt &expr)
 {
-  e = look_through_casts(e);
+  const exprt &e = skip_typecast(expr);
   return (e.id() == ID_constant_interval || e.id() == ID_constant);
 }
 
-static inline constant_interval_exprt make_interval_expr(exprt e)
+static inline constant_interval_exprt make_interval_expr(const exprt &expr)
 {
-  e = look_through_casts(e);
+  const exprt &e = skip_typecast(expr);
+
   if(e.id() == ID_constant_interval)
   {
     return to_constant_interval_expr(e);


### PR DESCRIPTION
A function of this name was defined in two places, and all uses can
safely be replaced by skip_typecast.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
