### PR TITLE
C front-end: support preprocessor line markers in inline asm

### DIFF
--- a/regression/ansi-c/asm2/main.c
+++ b/regression/ansi-c/asm2/main.c
@@ -6,7 +6,13 @@ int main()
 #ifdef __GNUC__
   asm goto ("jc %l[error];"
       : : "r"(x), "r"(&y) : "memory" : error);
-  asm __inline volatile("jc %l[error];" : : "r"(x), "r"(&y) : "memory" : error);
+  asm
+#   11
+    __inline volatile("jc %l[error];"
+                      :
+                      : "r"(x), "r"(&y)
+                      : "memory"
+                      : error);
 #endif
 error:
   return 0;

--- a/src/ansi-c/scanner.l
+++ b/src/ansi-c/scanner.l
@@ -1637,6 +1637,10 @@ __decltype          { if(PARSER.cpp98 &&
   /* The following ugly stuff avoids two-token lookahead in the parser;
      e.g., asm void f()  vs.  asm ("xyz") or asm { ... } */
 <GCC_ASM>{
+{cpplineno}     {
+                  preprocessor_line(yytext, PARSER);
+                  PARSER.set_line_no(PARSER.get_line_no()-1);
+                }
 {ws}            { /* ignore */ }
 {newline}       { /* ignore */ }
 "{"             { yyless(0); BEGIN(GRAMMAR); loc(); PARSER.asm_block_following=true; return TOK_GCC_ASM_PAREN; }


### PR DESCRIPTION
The lexer previously did not consider the case of preprocessor line
markers occurring in between keywords belonging to an inline assembly
block.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
