### PR TITLE
Linking: do not modify source symbol table

### DIFF
--- a/src/linking/linking.h
+++ b/src/linking/linking.h
@@ -15,13 +15,12 @@ Author: Daniel Kroening, kroening@kroening.com
 class message_handlert;
 class symbol_tablet;
 
-// This merges the symbol table "new_symbol_table" into "dest_symbol_table",
-// applying appropriate renamings to symbols in "new_symbol_table"
-// when necessary.
-
+/// Merges the symbol table \p new_symbol_table into \p dest_symbol_table,
+/// renaming symbols from \p new_symbol_table when necessary.
+/// \return True, iff linking failed with unresolvable conflicts.
 bool linking(
   symbol_tablet &dest_symbol_table,
-  symbol_tablet &new_symbol_table,
+  const symbol_tablet &new_symbol_table,
   message_handlert &message_handler);
 
 #endif // CPROVER_LINKING_LINKING_H

--- a/src/linking/linking_class.h
+++ b/src/linking/linking_class.h
@@ -30,7 +30,7 @@ class linkingt:public typecheckt
 public:
   linkingt(
     symbol_table_baset &_main_symbol_table,
-    symbol_table_baset &_src_symbol_table,
+    const symbol_table_baset &_src_symbol_table,
     message_handlert &_message_handler)
     : typecheckt(_message_handler),
       main_symbol_table(_main_symbol_table),
@@ -65,8 +65,9 @@ protected:
 
   void do_type_dependencies(std::unordered_set<irep_idt> &);
 
-  void rename_symbols(const std::unordered_set<irep_idt> &needs_to_be_renamed);
-  void copy_symbols();
+  std::unordered_map<irep_idt, irep_idt>
+  rename_symbols(const std::unordered_set<irep_idt> &needs_to_be_renamed);
+  void copy_symbols(const std::unordered_map<irep_idt, irep_idt> &);
 
   void duplicate_non_type_symbol(
     symbolt &old_symbol,
@@ -169,14 +170,14 @@ protected:
     const struct_typet &new_type);
 
   symbol_table_baset &main_symbol_table;
-  symbol_table_baset &src_symbol_table;
+  const symbol_table_baset &src_symbol_table;
 
   namespacet ns;
 
   // X -> Y iff Y uses X for new symbol type IDs X and Y
   typedef std::unordered_map<irep_idt, std::unordered_set<irep_idt>> used_byt;
 
-  irep_idt rename(irep_idt);
+  irep_idt rename(const irep_idt &);
 
   // the new IDs created by renaming
   std::unordered_set<irep_idt> renamed_ids;


### PR DESCRIPTION
This makes the interface more intuitive and ensures that we do not leave
behind an inconsistent symbol table.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
