### PR TITLE
rename post_process to finish_eager_conversion

### DIFF
--- a/src/solvers/flattening/arrays.h
+++ b/src/solvers/flattening/arrays.h
@@ -36,10 +36,10 @@ public:
     message_handlert &message_handler,
     bool get_array_constraints = false);
 
-  void post_process() override
+  void finish_eager_conversion() override
   {
-    post_process_arrays();
-    SUB::post_process();
+    finish_eager_conversion_arrays();
+    SUB::finish_eager_conversion();
     if(get_array_constraints)
       display_array_constraint_count();
   }
@@ -55,7 +55,7 @@ protected:
   messaget log;
   message_handlert &message_handler;
 
-  virtual void post_process_arrays()
+  virtual void finish_eager_conversion_arrays()
   {
     add_array_constraints();
   }

--- a/src/solvers/flattening/boolbv.h
+++ b/src/solvers/flattening/boolbv.h
@@ -72,11 +72,11 @@ public:
     bv_cache.clear();
   }
 
-  void post_process() override
+  void finish_eager_conversion() override
   {
-    post_process_quantifiers();
-    functions.post_process();
-    SUB::post_process();
+    finish_eager_conversion_quantifiers();
+    functions.finish_eager_conversion();
+    SUB::finish_eager_conversion();
   }
 
   enum class unbounded_arrayt { U_NONE, U_ALL, U_AUTO };
@@ -266,7 +266,7 @@ protected:
   typedef std::list<quantifiert> quantifier_listt;
   quantifier_listt quantifier_list;
 
-  void post_process_quantifiers();
+  void finish_eager_conversion_quantifiers();
 
   typedef std::vector<std::size_t> offset_mapt;
   offset_mapt build_offset_map(const struct_typet &src);

--- a/src/solvers/flattening/boolbv_quantifier.cpp
+++ b/src/solvers/flattening/boolbv_quantifier.cpp
@@ -271,7 +271,7 @@ literalt boolbvt::convert_quantifier(const quantifier_exprt &src)
   return quantifier_list.back().l;
 }
 
-void boolbvt::post_process_quantifiers()
+void boolbvt::finish_eager_conversion_quantifiers()
 {
   if(quantifier_list.empty())
     return;

--- a/src/solvers/flattening/bv_pointers.cpp
+++ b/src/solvers/flattening/bv_pointers.cpp
@@ -976,10 +976,10 @@ void bv_pointerst::do_postponed(
     UNREACHABLE;
 }
 
-void bv_pointerst::post_process()
+void bv_pointerst::finish_eager_conversion()
 {
   // post-processing arrays may yield further objects, do this first
-  SUB::post_process();
+  SUB::finish_eager_conversion();
 
   for(postponed_listt::const_iterator
       it=postponed_list.begin();

--- a/src/solvers/flattening/bv_pointers.h
+++ b/src/solvers/flattening/bv_pointers.h
@@ -24,7 +24,7 @@ public:
     message_handlert &message_handler,
     bool get_array_constraints = false);
 
-  void post_process() override;
+  void finish_eager_conversion() override;
 
   std::size_t boolbv_width(const typet &type) const override
   {

--- a/src/solvers/flattening/equality.h
+++ b/src/solvers/flattening/equality.h
@@ -26,10 +26,12 @@ public:
 
   virtual literalt equality(const exprt &e1, const exprt &e2);
 
-  void post_process() override
+  using SUB = prop_conv_solvert;
+
+  void finish_eager_conversion() override
   {
     add_equality_constraints();
-    prop_conv_solvert::post_process();
+    SUB::finish_eager_conversion();
     typemap.clear(); // if called incrementally, don't do it twice
   }
 
@@ -50,6 +52,8 @@ protected:
   typemapt typemap;
 
   virtual literalt equality2(const exprt &e1, const exprt &e2);
+
+  // an eager conversion of the transitivity constraints
   virtual void add_equality_constraints();
   virtual void add_equality_constraints(const typestructt &typestruct);
 };

--- a/src/solvers/lowering/functions.h
+++ b/src/solvers/lowering/functions.h
@@ -33,7 +33,7 @@ public:
 
   void record(const function_application_exprt &function_application);
 
-  virtual void post_process()
+  virtual void finish_eager_conversion()
   {
     add_function_constraints();
   }

--- a/src/solvers/prop/prop_conv_solver.cpp
+++ b/src/solvers/prop/prop_conv_solver.cpp
@@ -429,7 +429,7 @@ void prop_conv_solvert::ignoring(const exprt &expr)
   log.warning() << "warning: ignoring " << expr.pretty() << messaget::eom;
 }
 
-void prop_conv_solvert::post_process()
+void prop_conv_solvert::finish_eager_conversion()
 {
 }
 
@@ -441,7 +441,7 @@ decision_proceduret::resultt prop_conv_solvert::dec_solve()
     const auto post_process_start = std::chrono::steady_clock::now();
 
     log.statistics() << "Post-processing" << messaget::eom;
-    post_process();
+    finish_eager_conversion();
     post_processing_done = true;
 
     const auto post_process_stop = std::chrono::steady_clock::now();

--- a/src/solvers/prop/prop_conv_solver.h
+++ b/src/solvers/prop/prop_conv_solver.h
@@ -35,6 +35,9 @@ public:
 
   virtual ~prop_conv_solvert() = default;
 
+  // non-iterative eager conversion
+  virtual void finish_eager_conversion();
+
   // overloading from decision_proceduret
   decision_proceduret::resultt dec_solve() override;
   void print_assignment(std::ostream &out) const override;
@@ -99,8 +102,6 @@ public:
   void enable_hardness_collection() override;
 
 protected:
-  virtual void post_process();
-
   bool post_processing_done = false;
 
   /// Get a _boolean_ value from the model if the formula is satisfiable.

--- a/src/solvers/refinement/bv_refinement.h
+++ b/src/solvers/refinement/bv_refinement.h
@@ -49,7 +49,7 @@ public:
 protected:
 
   // Refine array
-  void post_process_arrays() override;
+  void finish_eager_conversion_arrays() override;
 
   // Refine arithmetic
   bvt convert_mult(const mult_exprt &expr) override;

--- a/src/solvers/refinement/bv_refinement_loop.cpp
+++ b/src/solvers/refinement/bv_refinement_loop.cpp
@@ -25,7 +25,7 @@ decision_proceduret::resultt bv_refinementt::dec_solve()
 {
   // do the usual post-processing
   log.status() << "BV-Refinement: post-processing" << messaget::eom;
-  post_process();
+  finish_eager_conversion();
 
   log.debug() << "Solving with " << prop.solver_text() << messaget::eom;
 

--- a/src/solvers/refinement/refine_arrays.cpp
+++ b/src/solvers/refinement/refine_arrays.cpp
@@ -18,7 +18,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <solvers/sat/satcheck.h>
 
 /// generate array constraints
-void bv_refinementt::post_process_arrays()
+void bv_refinementt::finish_eager_conversion_arrays()
 {
   collect_indices();
   // at this point all indices should in the index set


### PR DESCRIPTION
This renames a set of solver methods from post_process to
finish_eager_conversion.  The term 'post processing' may be used either in
lazy or eager solving.  The new name clarifies that this is about an eager
conversion.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
