### PR TITLE
C front-end: fix type checking with merged type

### DIFF
--- a/regression/ansi-c/gcc_attributes1/main.c
+++ b/regression/ansi-c/gcc_attributes1/main.c
@@ -39,6 +39,10 @@ void my_f1()
   while(1);
 }
 
+inline void a() __attribute__((noreturn))
+{
+}
+
 //
 // unused
 //

--- a/src/ansi-c/ansi_c_declaration.cpp
+++ b/src/ansi-c/ansi_c_declaration.cpp
@@ -141,9 +141,9 @@ void ansi_c_declarationt::to_symbol(
   symbol.is_weak=get_is_weak();
 
   // is it a function?
-  const typet &type = symbol.type.id() == ID_merged_type
-                        ? to_merged_type(symbol.type).last_type()
-                        : symbol.type;
+  typet &type = symbol.type.id() == ID_merged_type
+                  ? to_merged_type(symbol.type).last_type()
+                  : symbol.type;
 
   if(type.id() == ID_code && !symbol.is_type)
   {
@@ -153,7 +153,7 @@ void ansi_c_declarationt::to_symbol(
     symbol.is_file_local=get_is_static();
 
     if(get_is_inline())
-      to_code_type(symbol.type).set_inlined(true);
+      to_code_type(type).set_inlined(true);
 
     if(
       config.ansi_c.mode == configt::ansi_ct::flavourt::GCC ||


### PR DESCRIPTION
The changes of 4a50ac193c resulted in a branch still using symbol.type
when that wasn't necessarily the type being processed.

The additional test, which triggers this code path, was constructed
using creduce.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
