### PR TITLE
Linking/static lifetime init: do not use goto code types

### DIFF
--- a/src/linking/static_lifetime_init.cpp
+++ b/src/linking/static_lifetime_init.cpp
@@ -8,8 +8,6 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "static_lifetime_init.h"
 
-#include <goto-programs/goto_instruction_code.h>
-
 #include <util/arith_tools.h>
 #include <util/c_types.h>
 #include <util/expr_initializer.h>
@@ -90,10 +88,7 @@ static_lifetime_init(const irep_idt &identifier, symbol_tablet &symbol_table)
   else
     rhs = symbol.value;
 
-  code_assignt code(symbol.symbol_expr(), rhs);
-  code.add_source_location() = symbol.location;
-
-  return std::move(code);
+  return code_frontend_assignt{symbol.symbol_expr(), rhs, symbol.location};
 }
 
 void static_lifetime_init(
@@ -156,9 +151,8 @@ void static_lifetime_init(
       code_type.return_type().id() == ID_constructor &&
       code_type.parameters().empty())
     {
-      code_function_callt function_call(symbol.symbol_expr());
-      function_call.add_source_location()=source_location;
-      dest.add(function_call);
+      dest.add(code_expressiont{side_effect_expr_function_callt{
+        symbol.symbol_expr(), {}, code_type.return_type(), source_location}});
     }
   }
 }


### PR DESCRIPTION
The code in src/linking supposedly deals with symbol tables only, not
with goto programs (goto-programs/link_goto_model does this).
Consequently, static lifetime init should not create codet structures
defined in goto-programs/goto_instruction_code.h.

This is a first step to remove the goto-programs dependency from
src/linking.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
