### PR TITLE
Move rounding_mode_identifier() to configt

### DIFF
--- a/jbmc/src/java_bytecode/java_bytecode_internal_additions.cpp
+++ b/jbmc/src/java_bytecode/java_bytecode_internal_additions.cpp
@@ -9,22 +9,22 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "java_bytecode_internal_additions.h"
 
 // For INFLIGHT_EXCEPTION_VARIABLE_NAME
-#include "java_types.h"
-#include "remove_exceptions.h"
-
 #include <util/c_types.h>
+#include <util/config.h>
 #include <util/pointer_expr.h>
 #include <util/std_types.h>
 #include <util/symbol_table_base.h>
 
-#include <goto-programs/adjust_float_expressions.h>
+#include "java_types.h"
+#include "remove_exceptions.h"
 
 void java_internal_additions(symbol_table_baset &dest)
 {
   // add __CPROVER_rounding_mode
 
   {
-    symbolt symbol{rounding_mode_identifier(), signed_int_type(), ID_C};
+    symbolt symbol{
+      configt::rounding_mode_identifier(), signed_int_type(), ID_C};
     symbol.base_name = symbol.name;
     symbol.is_lvalue=true;
     symbol.is_state_var=true;

--- a/jbmc/src/java_bytecode/java_entry_point.cpp
+++ b/jbmc/src/java_bytecode/java_entry_point.cpp
@@ -14,7 +14,6 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/message.h>
 #include <util/suffix.h>
 
-#include <goto-programs/adjust_float_expressions.h>
 #include <goto-programs/class_identifier.h>
 #include <goto-programs/goto_functions.h>
 
@@ -239,7 +238,7 @@ void java_static_lifetime_init(
   code_blockt code_block;
 
   const symbol_exprt rounding_mode =
-    symbol_table.lookup_ref(rounding_mode_identifier()).symbol_expr();
+    symbol_table.lookup_ref(configt::rounding_mode_identifier()).symbol_expr();
   code_block.add(code_frontend_assignt{rounding_mode,
                                        from_integer(0, rounding_mode.type())});
 

--- a/src/analyses/constant_propagator.cpp
+++ b/src/analyses/constant_propagator.cpp
@@ -11,8 +11,6 @@ Author: Peter Schrammel
 
 #include "constant_propagator.h"
 
-#include <goto-programs/adjust_float_expressions.h>
-
 #ifdef DEBUG
 #include <iostream>
 #include <util/format_expr.h>
@@ -20,6 +18,7 @@ Author: Peter Schrammel
 
 #include <util/arith_tools.h>
 #include <util/c_types.h>
+#include <util/config.h>
 #include <util/cprover_prefix.h>
 #include <util/expr_util.h>
 #include <util/ieee_float.h>
@@ -663,7 +662,7 @@ bool constant_propagator_domaint::partial_evaluate(
   // if the current rounding mode is top we can
   // still get a non-top result by trying all rounding
   // modes and checking if the results are all the same
-  if(!known_values.is_constant(rounding_mode_identifier(), ns))
+  if(!known_values.is_constant(configt::rounding_mode_identifier(), ns))
     return partial_evaluate_with_all_rounding_modes(known_values, expr, ns);
 
   return replace_constants_and_simplify(known_values, expr, ns);
@@ -693,7 +692,7 @@ bool constant_propagator_domaint::partial_evaluate_with_all_rounding_modes(
   {
     valuest tmp_values = known_values;
     tmp_values.set_to(
-      symbol_exprt(rounding_mode_identifier(), integer_typet()),
+      symbol_exprt(configt::rounding_mode_identifier(), integer_typet()),
       from_integer(rounding_modes[i], integer_typet()));
     exprt result = expr;
     if(replace_constants_and_simplify(tmp_values, result, ns))

--- a/src/ansi-c/ansi_c_internal_additions.cpp
+++ b/src/ansi-c/ansi_c_internal_additions.cpp
@@ -11,8 +11,6 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/c_types.h>
 #include <util/config.h>
 
-#include <goto-programs/adjust_float_expressions.h>
-
 #include <linking/static_lifetime_init.h>
 
 #include "ansi_c_parser.h"
@@ -181,7 +179,7 @@ void ansi_c_internal_additions(std::string &code, bool support_float16_type)
 
     // float stuff
     "int " CPROVER_PREFIX "thread_local " +
-      id2string(rounding_mode_identifier()) + '='+
+      id2string(configt::rounding_mode_identifier()) + '='+
       std::to_string(config.ansi_c.rounding_mode)+";\n"
 
     // pipes, write, read, close

--- a/src/cpp/cpp_internal_additions.cpp
+++ b/src/cpp/cpp_internal_additions.cpp
@@ -17,8 +17,6 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <linking/static_lifetime_init.h>
 
-#include <goto-programs/adjust_float_expressions.h>
-
 std::string c2cpp(const std::string &s)
 {
   std::string result;
@@ -86,7 +84,7 @@ void cpp_internal_additions(std::ostream &out)
 
   // float
   // TODO: should be thread_local
-  out << "int " << rounding_mode_identifier() << " = "
+  out << "int " << configt::rounding_mode_identifier() << " = "
       << std::to_string(config.ansi_c.rounding_mode) << ';' << '\n';
 
   // pipes, write, read, close

--- a/src/goto-instrument/full_slicer.cpp
+++ b/src/goto-instrument/full_slicer.cpp
@@ -12,9 +12,9 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "full_slicer.h"
 #include "full_slicer_class.h"
 
+#include <util/config.h>
 #include <util/find_symbols.h>
 
-#include <goto-programs/adjust_float_expressions.h>
 #include <goto-programs/remove_skip.h>
 
 void full_slicert::add_dependencies(
@@ -248,7 +248,7 @@ static bool implicit(goto_programt::const_targett target)
 
   const symbol_exprt &s = to_symbol_expr(a_lhs);
 
-  return s.get_identifier() == rounding_mode_identifier();
+  return s.get_identifier() == configt::rounding_mode_identifier();
 }
 
 void full_slicert::operator()(

--- a/src/goto-programs/adjust_float_expressions.cpp
+++ b/src/goto-programs/adjust_float_expressions.cpp
@@ -12,7 +12,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "adjust_float_expressions.h"
 
 #include <util/arith_tools.h>
-#include <util/cprover_prefix.h>
+#include <util/config.h>
 #include <util/expr_util.h>
 #include <util/floatbv_expr.h>
 #include <util/ieee_float.h>
@@ -20,11 +20,6 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/symbol.h>
 
 #include "goto_model.h"
-
-irep_idt rounding_mode_identifier()
-{
-  return CPROVER_PREFIX "rounding_mode";
-}
 
 /// Iterate over an expression and check it or any of its subexpressions are
 /// floating point operations that haven't been adjusted with a rounding mode
@@ -195,7 +190,7 @@ void adjust_float_expressions(exprt &expr, const namespacet &ns)
     return;
 
   symbol_exprt rounding_mode =
-    ns.lookup(rounding_mode_identifier()).symbol_expr();
+    ns.lookup(configt::rounding_mode_identifier()).symbol_expr();
 
   rounding_mode.add_source_location() = expr.source_location();
 

--- a/src/goto-programs/adjust_float_expressions.h
+++ b/src/goto-programs/adjust_float_expressions.h
@@ -56,8 +56,4 @@ void adjust_float_expressions(
 /// \see adjust_float_expressions(goto_functionst &, const namespacet &)
 void adjust_float_expressions(goto_modelt &goto_model);
 
-/// Return the identifier of the program symbol used to
-/// store the current rounding mode.
-irep_idt rounding_mode_identifier();
-
 #endif // CPROVER_GOTO_PROGRAMS_ADJUST_FLOAT_EXPRESSIONS_H

--- a/src/linking/module_dependencies.txt
+++ b/src/linking/module_dependencies.txt
@@ -1,5 +1,4 @@
 ansi-c
-goto-programs
 langapi # should go away
 linking
 util

--- a/src/linking/remove_internal_symbols.cpp
+++ b/src/linking/remove_internal_symbols.cpp
@@ -19,8 +19,6 @@ Author: Daniel Kroening
 #include <util/std_types.h>
 #include <util/symbol_table_base.h>
 
-#include <goto-programs/adjust_float_expressions.h>
-
 #include "static_lifetime_init.h"
 
 static void get_symbols(
@@ -153,7 +151,7 @@ void remove_internal_symbols(
   special.insert(CPROVER_PREFIX "freeable");
   special.insert(CPROVER_PREFIX "is_freeable");
   special.insert(CPROVER_PREFIX "was_freed");
-  special.insert(rounding_mode_identifier());
+  special.insert(configt::rounding_mode_identifier());
   special.insert("__new");
   special.insert("__new_array");
   special.insert("__placement_new");

--- a/src/statement-list/statement_list_entry_point.cpp
+++ b/src/statement-list/statement_list_entry_point.cpp
@@ -18,7 +18,6 @@ Author: Matthias Weiss, matthias.weiss@diffblue.com
 #include <util/std_code.h>
 #include <util/symbol_table_base.h>
 
-#include <goto-programs/adjust_float_expressions.h>
 #include <goto-programs/goto_functions.h>
 
 #include <linking/static_lifetime_init.h>
@@ -142,7 +141,8 @@ generate_statement_list_init_function(symbol_table_baset &symbol_table)
 /// \param [out] symbol_table: Symbol table that should contain the symbol.
 static void generate_rounding_mode(symbol_table_baset &symbol_table)
 {
-  symbolt rounding_mode{rounding_mode_identifier(), signed_int_type(), ID_C};
+  symbolt rounding_mode{
+    configt::rounding_mode_identifier(), signed_int_type(), ID_C};
   rounding_mode.is_thread_local = true;
   rounding_mode.is_static_lifetime = true;
   const constant_exprt rounding_val{

--- a/src/util/config.cpp
+++ b/src/util/config.cpp
@@ -1612,3 +1612,8 @@ mp_integer configt::max_malloc_size() const
   const auto bits_for_positive_offset = offset_bits - 1;
   return ((mp_integer)1) << (mp_integer)bits_for_positive_offset;
 }
+
+irep_idt configt::rounding_mode_identifier()
+{
+  return CPROVER_PREFIX "rounding_mode";
+}

--- a/src/util/config.h
+++ b/src/util/config.h
@@ -402,6 +402,10 @@ public:
   static irep_idt this_architecture();
   static irep_idt this_operating_system();
 
+  /// Return the identifier of the program symbol used to
+  /// store the current rounding mode.
+  static irep_idt rounding_mode_identifier();
+
 private:
   void set_classpath(const std::string &cp);
 };


### PR DESCRIPTION
This removes a goto-programs dependency from linking/, which is all
about symbol tables, not goto programs.

Depends on #6554 for all CI checks to pass.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
