### PR TITLE
Value sets must not return an empty set for nondet symbols

### DIFF
--- a/regression/cbmc/double_deref/double_deref_with_pointer_arithmetic.desc
+++ b/regression/cbmc/double_deref/double_deref_with_pointer_arithmetic.desc
@@ -2,7 +2,7 @@ CORE
 double_deref_with_pointer_arithmetic.c
 --show-vcc
 ^\{-[0-9]+\} derefd_pointer::derefd_pointer!0#1 = \{ symex_dynamic::dynamic_object1#3\[\[0\]\], symex_dynamic::dynamic_object1#3\[\[1\]\] \}\[cast\(mod #source_location=""\(main::argc!0@1#1, 2\), signedbv\[64\]\)\]
-^\{1\} \(derefd_pointer::derefd_pointer!0#1 = address_of\(symex_dynamic::dynamic_object[23]\) \? main::argc!0@1#1 = 2 : main::argc!0@1#1 = 1
+^\{1\} \(derefd_pointer::derefd_pointer!0#1 = address_of\(symex_dynamic::dynamic_object[23]\) \? main::argc!0@1#1 = 2 : \(derefd_pointer::derefd_pointer!0#1 = address_of\(symex_dynamic::dynamic_object[23]\) \? main::argc!0@1#1 = 1 : symex::invalid_object!0#0 = main::argc!0@1#1\)\)
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/cbmc/double_deref/double_deref_with_pointer_arithmetic_single_alias.desc
+++ b/regression/cbmc/double_deref/double_deref_with_pointer_arithmetic_single_alias.desc
@@ -1,7 +1,7 @@
 CORE
 double_deref_with_pointer_arithmetic_single_alias.c
 --show-vcc
-\{1\} main::argc!0@1#1 = 1
+\{1\} \(derefd_pointer::derefd_pointer!0#1 = address_of\(symex_dynamic::dynamic_object2\) \? main::argc!0@1#1 = 1 : symex::invalid_object!0#0 = main::argc!0@1#1\)
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/cbmc/symex_should_exclude_null_pointers/nondet.c
+++ b/regression/cbmc/symex_should_exclude_null_pointers/nondet.c
@@ -1,0 +1,15 @@
+#include <stdlib.h>
+
+struct S
+{
+  int *p;
+  int x;
+};
+
+int main()
+{
+  struct S *s = malloc(sizeof(struct S));
+  // Guard must not be removed (deemed trivially true) by try_filter_value_sets.
+  if(s->p != NULL)
+    __CPROVER_assert(s->p != NULL, "cannot be NULL");
+}

--- a/regression/cbmc/symex_should_exclude_null_pointers/nondet.desc
+++ b/regression/cbmc/symex_should_exclude_null_pointers/nondet.desc
@@ -1,0 +1,11 @@
+CORE
+nondet.c
+
+^VERIFICATION SUCCESSFUL$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--
+try_filter_value_sets must not end up in a situation where it deems the guard
+trivially true. This situation arises when the value set wrongly is empty.

--- a/src/pointer-analysis/value_set.cpp
+++ b/src/pointer-analysis/value_set.cpp
@@ -521,6 +521,8 @@ void value_sett::get_value_set_rec(
         exprt(ID_null_object, to_pointer_type(expr_type).subtype()),
         offsett());
     }
+    else
+      insert(dest, exprt(ID_unknown, original_type));
   }
   else if(expr.id()==ID_if)
   {


### PR DESCRIPTION
Even when the expression type is not immediately a pointer, some
component of the type may be a pointer. As such, it could legitimately
appear in pointer dereferencing, and we should at least add "unknown" to
the value set.

This is a follow-up fix to 378967075: the regression test included
yields a spurious counterexample in versions between 378967075 and this
bugfix commit.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
