### PR TITLE
Value sets should permit any order of operands in pointer arithmetic

### DIFF
--- a/regression/cbmc/Pointer_Arithmetic19/main.c
+++ b/regression/cbmc/Pointer_Arithmetic19/main.c
@@ -1,0 +1,25 @@
+struct S
+{
+  int *p;
+  int s;
+};
+
+union U {
+  struct S st;
+  int i;
+};
+
+int main()
+{
+  int x;
+  int *ip = &x;
+
+  union U u;
+  u.st.p = ip;
+  u.st.s = 1;
+
+  int A[2] = {42, 43};
+  // the following should behave the same as "int *p = A + u.st.s;"
+  int *p = u.st.s + A;
+  assert(*p == 43);
+}

--- a/regression/cbmc/Pointer_Arithmetic19/test.desc
+++ b/regression/cbmc/Pointer_Arithmetic19/test.desc
@@ -1,0 +1,14 @@
+CORE
+main.c
+--program-only
+ASSERT\(\{ 42, 43 \}\[POINTER_OFFSET\(p!0@1#2\) / \d+l*\] == 43\)$
+^EXIT=0$
+^SIGNAL=0$
+--
+p\$object
+^warning: ignoring
+--
+Value sets should be sufficiently precise to infer that dereferencing p is an
+access into the array at some offset, and not an access into any other object
+(or perhaps the invalid object). If that were the case, the assert instruction
+would include "p$object," the absence of which we check for in the above.

--- a/regression/validate-trace-xml-schema/check.py
+++ b/regression/validate-trace-xml-schema/check.py
@@ -30,6 +30,7 @@ ExcludedTests = list(map(lambda s: os.path.join(test_base_dir, s[0], s[1]), [
     ['show_properties1', 'test.desc'],
     # program-only instead of trace
     ['vla1', 'program-only.desc'],
+    ['Pointer_Arithmetic19', 'test.desc'],
     ['Quantifiers-simplify', 'simplify_not_forall.desc'],
     ['array-cell-sensitivity15', 'test.desc'],
     # these test for invalid command line handling

--- a/src/pointer-analysis/value_set.cpp
+++ b/src/pointer-analysis/value_set.cpp
@@ -633,30 +633,45 @@ void value_sett::get_value_set_rec(
     object_mapt pointer_expr_set;
     optionalt<mp_integer> i;
 
-    // special case for pointer+integer
-
+    // special case for plus/minus and exactly one pointer
+    optionalt<exprt> ptr_operand;
     if(
-      expr.operands().size() == 2 && expr_type.id() == ID_pointer &&
+      expr_type.id() == ID_pointer &&
       (expr.id() == ID_plus || expr.id() == ID_minus))
     {
-      exprt ptr_operand;
+      bool non_const_offset = false;
+      for(const auto &op : expr.operands())
+      {
+        if(op.type().id() == ID_pointer)
+        {
+          if(ptr_operand.has_value())
+          {
+            ptr_operand.reset();
+            break;
+          }
 
-      if(
-        to_binary_expr(expr).op0().type().id() != ID_pointer &&
-        to_binary_expr(expr).op0().is_constant())
-      {
-        i = numeric_cast<mp_integer>(to_binary_expr(expr).op0());
-        ptr_operand = to_binary_expr(expr).op1();
-      }
-      else
-      {
-        i = numeric_cast<mp_integer>(to_binary_expr(expr).op1());
-        ptr_operand = to_binary_expr(expr).op0();
+          ptr_operand = op;
+        }
+        else if(!non_const_offset)
+        {
+          auto offset = numeric_cast<mp_integer>(op);
+          if(!offset.has_value())
+          {
+            i.reset();
+            non_const_offset = true;
+          }
+          else
+          {
+            if(!i.has_value())
+              i = mp_integer{0};
+            i = *i + *offset;
+          }
+        }
       }
 
-      if(i.has_value())
+      if(ptr_operand.has_value() && i.has_value())
       {
-        typet pointer_sub_type=ptr_operand.type().subtype();
+        typet pointer_sub_type = ptr_operand->type().subtype();
         if(pointer_sub_type.id()==ID_empty)
           pointer_sub_type=char_type();
 
@@ -671,12 +686,20 @@ void value_sett::get_value_set_rec(
           *i *= *size;
 
           if(expr.id()==ID_minus)
+          {
+            DATA_INVARIANT(
+              to_minus_expr(expr).lhs() == *ptr_operand,
+              "unexpected subtraction of pointer from integer");
             i->negate();
+          }
         }
       }
+    }
 
+    if(ptr_operand.has_value())
+    {
       get_value_set_rec(
-        ptr_operand, pointer_expr_set, "", ptr_operand.type(), ns);
+        *ptr_operand, pointer_expr_set, "", ptr_operand->type(), ns);
     }
     else
     {


### PR DESCRIPTION
Previously, only \<integer-constant\> +/- pointer or
pointer-as-first-operand worked correctly. In all other cases, value
sets did not recurse on the correct operand.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
