### PR TITLE
Remove wrong and unused member simplification code

### DIFF
--- a/src/util/simplify_expr_struct.cpp
+++ b/src/util/simplify_expr_struct.cpp
@@ -156,19 +156,6 @@ simplify_exprt::simplify_member(const member_exprt &expr)
 
       return changed(simplify_byte_extract(result)); // recursive call
     }
-    else if(op_type.id() == ID_union)
-    {
-      // rewrite byte_extract(X, 0).member to X
-      // if the type of X is that of the member
-      if(byte_extract_expr.offset().is_zero())
-      {
-        const union_typet &union_type = to_union_type(op_type);
-        const typet &subtype = union_type.component_type(component_name);
-
-        if(subtype == byte_extract_expr.op().type())
-          return byte_extract_expr.op();
-      }
-    }
   }
   else if(op.id()==ID_union && op_type.id()==ID_union)
   {


### PR DESCRIPTION
No test hits the branch simplifying byte_extract(x, o, u).member for a
union type u. The correct simplification would be a rewrite to
byte_extract(x, o, member_type), but since we don't seem to create
expressions of this kind there's no point in implementing this.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- n/a Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
