### PR TITLE
Function contracts: check target validity, simplify snapshot instrumentation

### DIFF
--- a/regression/contracts/assigns-enforce-malloc-zero/main.c
+++ b/regression/contracts/assigns-enforce-malloc-zero/main.c
@@ -6,7 +6,7 @@ int foo(char *a, int size)
   // clang-format off
   __CPROVER_requires(0 <= size && size <= __CPROVER_max_malloc_size)
   __CPROVER_requires(a == NULL || __CPROVER_is_fresh(a, size))
-  __CPROVER_assigns(__CPROVER_POINTER_OBJECT(a))
+  __CPROVER_assigns(a: __CPROVER_POINTER_OBJECT(a))
   __CPROVER_ensures(
     a && __CPROVER_return_value >= 0 ==> a[__CPROVER_return_value] == 0)
 // clang-format on

--- a/regression/contracts/assigns_enforce_free_dead/main.c
+++ b/regression/contracts/assigns_enforce_free_dead/main.c
@@ -1,7 +1,7 @@
 #include <assert.h>
 #include <stdlib.h>
 
-int foo(int *x, int **p) __CPROVER_assigns(*x, *p, **p)
+int foo(int *x, int **p) __CPROVER_assigns(*x; p : *p; p && *p : **p)
 {
   if(p && *p)
     **p = 0;
@@ -44,12 +44,12 @@ int foo(int *x, int **p) __CPROVER_assigns(*x, *p, **p)
     // q goes DEAD here, unconditionally
   }
 
-  free(z);
+  free(z); // should not fail because free(NULL) is allowed in C
 
   z = malloc(sizeof(int));
   if(nondet_bool())
   {
-    free(z);
+    free(z); // should not fail because free(NULL) is allowed in C
     // here z is deallocated, conditionally
   }
 

--- a/regression/contracts/assigns_enforce_free_dead/test.desc
+++ b/regression/contracts/assigns_enforce_free_dead/test.desc
@@ -1,8 +1,8 @@
 CORE
 main.c
 --enforce-contract foo _ --malloc-may-fail --malloc-fail-null --pointer-primitive-check
-^\[foo.\d+\] line \d+ Check that \*\(\*p\) is assignable: SUCCESS$
-^\[foo.\d+\] line \d+ Check that \*\(\*p\) is assignable: FAILURE$
+^\[foo.\d+\] line 7 Check that \*\(\*p\) is assignable: SUCCESS$
+^\[foo.\d+\] line 24 Check that \*\(\*p\) is assignable: FAILURE$
 ^\[foo.\d+\] line \d+ Check that \*p is assignable: SUCCESS$
 ^\[foo.\d+\] line \d+ Check that \*q is assignable: SUCCESS$
 ^\[foo.\d+\] line \d+ Check that \*w is assignable: SUCCESS$

--- a/regression/contracts/assigns_enforce_offsets_2/test.desc
+++ b/regression/contracts/assigns_enforce_offsets_2/test.desc
@@ -1,10 +1,15 @@
-KNOWNBUG
+CORE
 main.c
---enforce-contract foo
+--enforce-contract foo _ --pointer-check
+^\[.*\d+\].* line 5 Check assigns target validity 'TRUE: \*x': SUCCESS$
+^\[.*\d+\].* line 8 Check that x\[\(.*\)1\] is assignable: (SUCCESS|FAILURE)$
+^\[.*\d+\].* line 8 Check assigns target validity 'TRUE: x\[\(.*\)1\]': FAILURE$
 ^EXIT=10$
 ^SIGNAL=0$
 ^VERIFICATION FAILED$
 --
 --
-Check that a write at *x fails when the assigns clause specifies *(x + 1) and
-the actual underlying object is of size 1.
+Check that a write at *x+1 fails when the assigns clause specifies a valid *x
+and the actual underlying object is of size 1.
+In this case the specified target is valid, the lhs of the assignment is invalid
+so the inclusion check passes, but the pointer check must fail with an OOB.

--- a/regression/contracts/assigns_enforce_offsets_4/main.c
+++ b/regression/contracts/assigns_enforce_offsets_4/main.c
@@ -13,8 +13,8 @@ int main()
 {
   int *x = malloc(2 * sizeof(int));
   *x = 0;
-  *(x + 1) == 0
-    // write should fail because x points to a size 2 object and the contracts expects size 10 at least.
-    foo(x);
+  *(x + 1) == 0;
+  // write should fail because x points to a size 2 object and the contracts expects size 10 at least.
+  foo(x);
   return 0;
 }

--- a/regression/contracts/assigns_enforce_offsets_4/test.desc
+++ b/regression/contracts/assigns_enforce_offsets_4/test.desc
@@ -1,9 +1,13 @@
-KNOWNBUG
+CORE
 main.c
---enforce-contract foo
+--enforce-contract foo _ --pointer-check
+^\[.*\d+\].* line 8 Check assigns target validity 'TRUE: x\[\(.*\)10\]': FAILURE$
 ^EXIT=10$
 ^SIGNAL=0$
 ^VERIFICATION FAILED$
 --
 --
-Check that a write at *x fails when the assigns clause specifies *(x + 1) and the actual underlying object is of size 1.
+Check that a write at *(x+10) fails when the assigns clause specifies *(x + 10)
+and the actual underlying object is too small.
+In that case the target inclusion succeeds because the LHS is in an invalid
+state, but the target validity check must fail.

--- a/regression/contracts/assigns_enforce_structs_07/test.desc
+++ b/regression/contracts/assigns_enforce_structs_07/test.desc
@@ -3,13 +3,14 @@ main.c
 --enforce-contract f1 --enforce-contract f2 _ --malloc-may-fail --malloc-fail-null --pointer-check
 ^EXIT=10$
 ^SIGNAL=0$
-^\[f1.\d+\] line \d+ Check that p->buf\[\(.*\)0\] is assignable: SUCCESS$
-^\[f1.pointer\_dereference.\d+\] line \d+ dereference failure: pointer invalid in p->buf\[\(.*\)0\]: FAILURE$
-^\[f1.pointer\_dereference.\d+\] line \d+ dereference failure: pointer NULL in p->buf: FAILURE$
-^\[f2.\d+\] line \d+ Check that pp->p->buf\[\(.*\)0\] is assignable: SUCCESS$
-^\[f2.pointer\_dereference.\d+\] line \d+ dereference failure: pointer invalid in pp->p->buf\[\(.*\)0\]: FAILURE$
+^\[f1.*\d+\].*line 18 Check assigns target validity 'TRUE: p->buf\[\(.*\)0\]': FAILURE$
+^\[f2.*\d+\].*line 23 Check assigns target validity 'TRUE: pp->p->buf\[\(.*\)0\]': FAILURE$
 ^VERIFICATION FAILED$
 --
 --
-Checks whether CBMC properly evaluates write set of members
-from invalid objects. In this case, they are not writable.
+In f1, the assigns clause specifies `*(p->buf)` as target (which can be invalid)
+and assigns `p->buf[0]` unconditionally. When both target and lhs are invalid,
+its inclusion check can be trivially satisfied (or not) but we expect the target
+validity check to fail.
+
+In f2 tests this behaviour with chained dereferences.

--- a/regression/contracts/assigns_enforce_structs_08/main.c
+++ b/regression/contracts/assigns_enforce_structs_08/main.c
@@ -1,0 +1,48 @@
+#include <assert.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+struct pair
+{
+  uint8_t *buf;
+  size_t size;
+};
+
+struct pair_of_pairs
+{
+  struct pair *p;
+};
+
+void f1(struct pair *p) __CPROVER_assigns(p && p->buf : *(p->buf))
+{
+  if(p && p->buf)
+    p->buf[0] = 0;
+}
+
+void f2(struct pair_of_pairs *pp)
+  // clang-format off
+__CPROVER_assigns(pp && pp->p && pp->p->buf: *(pp->p->buf))
+// clang-format on
+{
+  if(pp && pp->p && pp->p->buf)
+    pp->p->buf[0] = 0;
+}
+
+int main()
+{
+  struct pair *p = malloc(sizeof(*p));
+  if(p)
+    p->buf = malloc(100 * sizeof(uint8_t));
+  f1(p);
+
+  struct pair_of_pairs *pp = malloc(sizeof(*pp));
+  if(pp)
+  {
+    pp->p = malloc(sizeof(*(pp->p)));
+    if(pp->p)
+      pp->p->buf = malloc(100 * sizeof(uint8_t));
+  }
+  f2(pp);
+
+  return 0;
+}

--- a/regression/contracts/assigns_enforce_structs_08/test.desc
+++ b/regression/contracts/assigns_enforce_structs_08/test.desc
@@ -1,0 +1,21 @@
+CORE
+main.c
+--enforce-contract f1 --enforce-contract f2 _ --malloc-may-fail --malloc-fail-null --pointer-check
+^\[f1.\d+\] line \d+ Check that p->buf\[\(.*\)0\] is assignable: SUCCESS$
+^\[f2.\d+\] line \d+ Check that pp->p->buf\[\(.*\)0\] is assignable: SUCCESS$
+^VERIFICATION SUCCESSFUL$
+^EXIT=0$
+^SIGNAL=0$
+--
+^\[f1.pointer\_dereference.\d+\] line \d+ dereference failure: pointer NULL in p->buf: FAILURE$
+^\[f1.pointer\_dereference.\d+\] line \d+ dereference failure: pointer invalid in p->buf\[\(.*\)0\]: FAILURE$
+^\[f2.pointer\_dereference.\d+\] line \d+ dereference failure: pointer NULL in pp->p->buf\[\(.*\)0\]: FAILURE$
+^\[f2.pointer\_dereference.\d+\] line \d+ dereference failure: pointer invalid in pp->p->buf\[\(.*\)0\]: FAILURE$
+--
+In f1, the assigns clause specifies `*(p->buf)` as target (which can be invalid)
+and assigns `p->buf[0]` unconditionally. When both target and lhs are invalid,
+its  inclusion check can be trivially satisfied or not but we expect in all
+cases a  null pointer failure and an invalid pointer error to occur 
+on the assignment.
+
+In f2 tests this behaviour with chained dereferences.

--- a/regression/contracts/assigns_enforce_subfunction_calls/test.desc
+++ b/regression/contracts/assigns_enforce_subfunction_calls/test.desc
@@ -4,15 +4,13 @@ main.c
 ^EXIT=10$
 ^SIGNAL=0$
 ^main.c function baz$
-^\[baz.1\] line \d+ Check that \*x is assignable: SUCCESS$
-^\[baz.2\] line \d+ Check that \*x is assignable: SUCCESS$
-^\[baz.3\] line \d+ Check that \*x is assignable: FAILURE$
-^\[baz.4\] line \d+ Check that \*x is assignable: FAILURE$
+^\[baz.\d+\] line 6 Check that \*x is assignable: SUCCESS$
+^\[baz.\d+\] line 6 Check that \*x is assignable: FAILURE$
 ^main.c function foo$
-^\[foo.assertion.1\] line \d+ foo.x.set: SUCCESS$
-^\[foo.assertion.2\] line \d+ foo.local.set: SUCCESS$
-^\[foo.assertion.3\] line \d+ foo.y.set: SUCCESS$
-^\[foo.assertion.4\] line \d+ foo.z.set: SUCCESS$
+^\[foo.assertion.\d+\] line 20 foo.x.set: SUCCESS$
+^\[foo.assertion.\d+\] line 25 foo.local.set: SUCCESS$
+^\[foo.assertion.\d+\] line 29 foo.y.set: SUCCESS$
+^\[foo.assertion.\d+\] line 33 foo.z.set: SUCCESS$
 ^VERIFICATION FAILED$
 --
 --

--- a/regression/contracts/assigns_replace_04/main.c
+++ b/regression/contracts/assigns_replace_04/main.c
@@ -1,6 +1,6 @@
 #include <assert.h>
 
-void f2(int *x2, int *y2) __CPROVER_assigns(*x2) __CPROVER_ensures(*x2 > 5)
+void f2(int *x2, int *y2) __CPROVER_assigns(*x2) __CPROVER_ensures(*x2 == 10)
 {
   *x2 = 10;
 }
@@ -28,6 +28,7 @@ int main()
   }
   assert(p > 100);
   assert(q == 2);
+  __CPROVER_assert(0, "reachability test");
 
   return 0;
 }

--- a/regression/contracts/assigns_replace_04/test.desc
+++ b/regression/contracts/assigns_replace_04/test.desc
@@ -1,9 +1,16 @@
 CORE
 main.c
 --replace-call-with-contract f2 --replace-call-with-contract f3
-^EXIT=0$
+main.c function main
+^\[.*\d+\] line 29 assertion p > 100: SUCCESS$
+^\[.*\d+\] line 30 assertion q == 2: SUCCESS$
+^\[.*\d+\] line 31 reachability test: FAILURE$
+^\*\* 1 of 3 failed
+^VERIFICATION FAILED$
+^EXIT=10$
 ^SIGNAL=0$
-^VERIFICATION SUCCESSFUL$
 --
 --
-This test checks that verification succeeds when an assigns clause is combined with a function contract in a loop properly.
+This test checks that replacing function calls with their contracts within a
+loop, when the contracts impose contradictory post conditions at different loop
+iterations on a same program variable, do not cause vacuity.

--- a/regression/contracts/assigns_replace_05/main.c
+++ b/regression/contracts/assigns_replace_05/main.c
@@ -1,8 +1,8 @@
 #include <assert.h>
 
-void f2(int *x2, int *y2) __CPROVER_assigns(*x2) __CPROVER_ensures(*x2 > 5)
+void f2(int *x2, int *y2) __CPROVER_assigns(*x2) __CPROVER_ensures(*x2 < 5)
 {
-  *x2 = 10;
+  *x2 = 1;
 }
 
 void f3(int *x3, int *y3) __CPROVER_ensures(*x3 > 100)
@@ -26,8 +26,9 @@ int main()
       f3(&p, &q);
     }
   }
-  assert(p > 100);
-  assert(q == 2);
+  assert(p < 0);
+  assert(q == 32);
+  __CPROVER_assert(0, "reachability test");
 
   return 0;
 }

--- a/regression/contracts/assigns_replace_05/test.desc
+++ b/regression/contracts/assigns_replace_05/test.desc
@@ -1,12 +1,16 @@
-KNOWNBUG
+CORE
 main.c
 --replace-call-with-contract f2 --replace-call-with-contract f3
-^EXIT=10$
+main.c function main
+^\[.*\d+\] line 29 assertion p < 0: SUCCESS$
+^\[.*\d+\] line 30 assertion q == 32: SUCCESS$
+^\[.*\d+\] line 31 reachability test: SUCCESS$
+^VERIFICATION SUCCESSFUL$
+^EXIT=0$
 ^SIGNAL=0$
-^VERIFICATION FAILED$
 --
 --
-This test checks that verification fails when assigns clauses are combined with function contracts
-in a loop improperly, i.e., always assumes memory not mention in ensures clauses are unchanged.
-
-BUG: Currently, function call replacement using 'ensures' specifications encodes an implicit assumption that any memory not mentioned in the ensures clause remains unchanged throughout the function, even when an 'assigns' clause is not present.
+This test demonstrates that replacing a function call with a contract that has
+an empty assigns clause and a post condition involving its input parameters can 
+causes vacuous proofs. Checking the contract against the function would fail
+the assigns clause checks. *This is not a bug*.

--- a/regression/contracts/loop_contracts_binary_search/test.desc
+++ b/regression/contracts/loop_contracts_binary_search/test.desc
@@ -6,9 +6,9 @@ main.c
 ^\[binary_search\.\d+\] .* Check loop invariant before entry: SUCCESS$
 ^\[binary_search\.\d+\] .* Check that loop invariant is preserved: SUCCESS$
 ^\[binary_search\.\d+\] .* Check decreases clause on loop iteration: SUCCESS$
-^\[binary_search\.2\] .* Check that lb is assignable: SUCCESS$
-^\[binary_search\.3\] .* Check that ub is assignable: SUCCESS$
-^\[binary_search\.4\] .* Check that mid is assignable: SUCCESS$
+^\[binary_search\.\d+\] .* Check that lb is assignable: SUCCESS$
+^\[binary_search\.\d+\] .* Check that ub is assignable: SUCCESS$
+^\[binary_search\.\d+\] .* Check that mid is assignable: SUCCESS$
 ^\[main\.assertion\.\d+\] .* assertion buf\[idx\] == val: SUCCESS$
 ^VERIFICATION SUCCESSFUL$
 --

--- a/regression/contracts/variant_init_inside_loop/test.desc
+++ b/regression/contracts/variant_init_inside_loop/test.desc
@@ -4,10 +4,10 @@ main.c
 ^\[main\.\d+\] .* Check loop invariant before entry: SUCCESS$
 ^\[main\.\d+\] .* Check that loop invariant is preserved: SUCCESS$
 ^\[main\.\d+\] .* Check decreases clause on loop iteration: SUCCESS$
-^\[main\.2\] .* Check that i is assignable: SUCCESS$
-^\[main\.overflow\.1\] .* arithmetic overflow on unsigned - in max - i: SUCCESS$
-^\[main\.overflow\.3\] .* arithmetic overflow on unsigned - in max - i: SUCCESS$
-^\[main\.overflow\.2\] .* arithmetic overflow on unsigned \+ in i \+ 1u: SUCCESS$
+^\[main\.\d+\] .* Check that i is assignable: SUCCESS$
+^\[main\.overflow\.\d+\] .* arithmetic overflow on unsigned - in max - i: SUCCESS$
+^\[main\.overflow\.\d+\] .* arithmetic overflow on unsigned - in max - i: SUCCESS$
+^\[main\.overflow\.\d+\] .* arithmetic overflow on unsigned \+ in i \+ 1u: SUCCESS$
 ^VERIFICATION SUCCESSFUL$
 ^EXIT=0$
 ^SIGNAL=0$

--- a/src/goto-instrument/contracts/assigns.h
+++ b/src/goto-instrument/contracts/assigns.h
@@ -47,13 +47,36 @@ typedef struct guarded_slicet
 class assigns_clauset
 {
 public:
+  enum class check_target_validityt
+  {
+    YES,
+    YES_ALLOW_NULL,
+    NO
+  };
+
   /// \brief A class for representing Conditional Address Ranges
   class conditional_address_ranget
   {
   public:
     conditional_address_ranget(const assigns_clauset &, const exprt &);
 
-    goto_programt generate_snapshot_instructions() const;
+    /// \brief Returns a program that computes a snapshot of the CAR.
+    ///
+    /// In addition, if check_target_validity is Yes, generates:
+    /// ```
+    /// ASSERT
+    /// condition ==> w_ok(target_start_address, target_size)
+    /// ```
+    //
+    /// else if check_target_validity is YesAlloNull, generates:
+    /// ```
+    /// ASSERT
+    /// condition ==>
+    ///    (target_start_address==NULL ||
+    ///      w_ok(target_start_address, target_size))
+    /// ```
+    goto_programt generate_snapshot_instructions(
+      check_target_validityt check_target_validity) const;
 
     bool operator==(const conditional_address_ranget &other) const
     {
@@ -110,6 +133,7 @@ public:
 
   exprt generate_inclusion_check(
     const conditional_address_ranget &lhs,
+    check_target_validityt allow_null_target,
     optionalt<cfg_infot> &cfg_info_opt) const;
 
   const write_sett &get_write_set() const

--- a/src/goto-instrument/contracts/contracts.h
+++ b/src/goto-instrument/contracts/contracts.h
@@ -157,6 +157,13 @@ protected:
     skipt skip_parameter_assigns,
     optionalt<cfg_infot> &cfg_info_opt);
 
+  /// Allow or do not allow NULL targets in inclusion checks
+  enum class allow_null_lhst
+  {
+    YES,
+    NO
+  };
+
   /// Inserts an assertion into the goto program to ensure that
   /// an expression is within the assignable memory frame.
   const assigns_clauset::conditional_address_ranget add_inclusion_check(
@@ -164,6 +171,7 @@ protected:
     const assigns_clauset &assigns,
     goto_programt::targett &instruction_it,
     const exprt &lhs,
+    allow_null_lhst allow_null_lhs,
     optionalt<cfg_infot> &cfg_info_opt);
 
   /// Check if there are any malloc statements which may be repeated because of

--- a/src/goto-instrument/contracts/havoc_assigns_clause_targets.cpp
+++ b/src/goto-instrument/contracts/havoc_assigns_clause_targets.cpp
@@ -109,9 +109,12 @@ static void snapshot_if_valid(
 
   dest.add(goto_programt::make_decl(target_snapshot_var));
 
+  const not_exprt not_null(null_pointer(target_pointer));
+  const not_exprt not_invalid{is_invalid_pointer_exprt{target_pointer}};
+
   dest.add(goto_programt::make_assignment(
     target_valid_var,
-    and_exprt{condition, all_dereferences_are_valid(target_pointer, ns)},
+    and_exprt{condition, not_null, not_invalid},
     source_location_no_checks));
 
   dest.add(goto_programt::make_assignment(

--- a/src/goto-instrument/contracts/utils.cpp
+++ b/src/goto-instrument/contracts/utils.cpp
@@ -161,6 +161,9 @@ void disable_pointer_checks(source_locationt &source_location)
   source_location.add_pragma("disable:pointer-check");
   source_location.add_pragma("disable:pointer-primitive-check");
   source_location.add_pragma("disable:pointer-overflow-check");
+  source_location.add_pragma("disable:signed-overflow-check");
+  source_location.add_pragma("disable:unsigned-overflow-check");
+  source_location.add_pragma("disable:conversion-check");
 }
 
 void simplify_gotos(goto_programt &goto_program, namespacet &ns)


### PR DESCRIPTION
In assigns clause checking, for better usability and performance with conditional targets:

- Check that user-specified targets point to non-invalid locations when their condition holds
- Replace the `all_dereferences_valid` with a simpler `not_null` check in the validity condition, remove conditional jumps
- Rewrite inclusion checks to tolerate NULL targets only when necessary (calls to 'free')

Benefits:
- Detect and report errors user-specified target conditions
- Up to x1.5-x2 faster runs on large benchmarks (from ~1800s to ~900s on large `s2n-tls` benchmarks)

# Details

## Problem

We now support conditional assigns targets of the form `condition: target`.

The `condition` lets the user specify when the target expression is assignable by the function.

We also need to make sure the target expression denotes a valid memory location when the condition holds. 

Today this is achieved using this instrumentation code:

```
bool __car_valid := condition & all_dereferences_valid(target) & w_ok(target_start_address, target_size);
char *__car_lb := NULL;
char *__car_ub := NULL;
if(__car_valid)
{
  __car_lb := start_address_of(target);
  __car_ub := __car_lb + target_size(target); // this instruction is instrumented with pointer overflow checks
}
```


Inclusion checks are performed using:

```
ASSERT __car_valid ==> is_included(car, set-of-legit-locations)
```
 
With this encoding, if the target expression happens to be invalid when the user-provided condition is true, we silently compute an empty conditional address range and we will reject assignments to this invalid target location (as expected), 

The results can however be hard to interpret from the user's perspective since he does not know that the target is invalid when he specified it should be assignable. It is most likely the sign of an involuntary error in the target condition

Moreover, the use of `all_dereferences_valid` and `w_ok` predicates creates large formulas and causes long runtimes.

## Proposed Fix

We distinguish the following uses for an address range snaphsot  `(__car_valid, __car_lb, __car_ub)`:

1. Snapshotting a user-specified conditional target found in an assigns clause. In that case:
  a. when the condition holds, the `target_start_address` pointer shall be either `NULL` or writable with the expected size. We allow `NULL` because it can be passed as a valid argument to functions such as `free()`, and the user code might attempt to do this.
  b. we forbid invalid `target_start_address` pointers because they are not accepted in any meaningful operation.
2. Snapshotting the address range of a pointer passed to `free()`. The pointer must either be a `NULL` pointer or a pointer to the start address of a valid object (with offset 0, but we will not check that since `free` checks it itself).
3. Snapshotting the LHS of an assignment or an argument to a `havoc` function, in order to perform an inclusion check against a set of allowed target locations (themselves derived from cases 1 and 4). In that case:
  a. we want to check that the `target_start_address` is neither `NULL` nor `INVALID` when its condition holds.
4. Snapshotting a `DECL` or a pointer returned by `malloc`. Conditions 1.a. and 1.b. would apply here, but they are always satisfied by construction (a stack allocated var is always backed by an object of the right size for its type, and CBMC's `malloc` either returns a `NULL` pointer or a pointer backed by an object of the right size).

So, in order to check for target validity in cases 1. and 2. (user specified targets and parameters to free), we use:

```
ASSERT condition ==> (target_start_address == NULL || w_ok(target_start_address, target_size)) ;
```

To check for target validity in case 3. (assignment LHS), we use:

```
ASSERT condition ==> w_ok(target_start_address, target_size);
```

These assertions will be falsified if `target_start_address` is an invalid pointer.

As explained above, in case 4 the target is valid by construction, so we do not generate an assertion.

In cases 1, 2, 3 and 4 the snapshot is rid of conditional jumps and becomes:

```
bool __car_valid := condition & not_null(target_start_address);
__car_lb := target_start_address;
__car_ub := __car_lb + target_size(target);
```

Assuming the "target validity" assertion was proved, if `condition & not_null(target_start_address)` holds then `w_ok(target_start_address, target_size)` holds and the computed `__car_lb` and `__car_ub` are meaningful.

If the target happens to be `NULL`,  `__car_valid` will be false and `__car_lb` and `__car_ub` will contain garbage values but will never be used in inclusion checks, which are guarded by `__car_valid`.

If the target happens to be invalid, then all snapshot variables can take arbitrary and incoherent values which may or may not fail the inclusion checks.  In all cases, since the target validity assertions will surely fail, the assigns clause checking analysis as a whole will not succeed.

## Inclusion checks

The inclusion check for assignments and havoc parameters is written as:

```
ASSERT __car_valid & is_included(car, set-of-legit-locations);
```

An for parameters to `free` we allow NULL as a special case:

```
ASSERT target_start_address!=NULL ==> __car_valid & is_included(car, set-of-legit-locations);
```

## Summary

With this new encoding, 

- we can detect bad conditions which allow invalid targets in assigns clause specifications, 
- we remove conditional jumps and extra pointer assertions

For a full assigns clause check to be considered successful:
- the user specified targets must all pass the target validity checks
- all assignments and arguments to `havoc` or `free` must pass the inclusion check


-------
- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.
