### PR TITLE
Fix and cleanup __CPROVER_{r,w,rw}_ok expansion

### DIFF
--- a/regression/cbmc/r_w_ok9/main.c
+++ b/regression/cbmc/r_w_ok9/main.c
@@ -1,0 +1,14 @@
+int check(int cond)
+{
+  return cond;
+}
+
+int main()
+{
+  int x;
+  int *p = &x;
+  if(check(!__CPROVER_r_ok(p, sizeof(int))))
+  {
+    __CPROVER_assert(0, "must be unreachable");
+  }
+}

--- a/regression/cbmc/r_w_ok9/simplify.desc
+++ b/regression/cbmc/r_w_ok9/simplify.desc
@@ -1,0 +1,11 @@
+CORE
+main.c
+--show-goto-functions
+^EXIT=0$
+^SIGNAL=0$
+--
+false ∨
+∨ false
+--
+__CPROVER_{r,w,rw}_ok must be rewritten everywhere, and the resulting expression
+should be simplified (and, therefore, not contain "false" in a disjunction).

--- a/regression/cbmc/r_w_ok9/test.desc
+++ b/regression/cbmc/r_w_ok9/test.desc
@@ -1,0 +1,11 @@
+CORE
+main.c
+
+VERIFICATION SUCCESSFUL
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--
+__CPROVER_{r,w,rw}_ok must be rewritten everywhere, which includes function call
+arguments.

--- a/regression/validate-trace-xml-schema/check.py
+++ b/regression/validate-trace-xml-schema/check.py
@@ -25,6 +25,7 @@ ExcludedTests = list(map(lambda s: os.path.join(test_base_dir, s[0], s[1]), [
     ['integer-assignments1', 'integer-typecheck.desc'],
     ['destructors', 'compound_literal.desc'],
     ['destructors', 'enter_lexical_block.desc'],
+    ['r_w_ok9', 'simplify.desc'],
     ['reachability-slice-interproc2', 'test.desc'],
     # this one wants show-properties instead producing a trace
     ['show_properties1', 'test.desc'],

--- a/src/analyses/goto_check_c.cpp
+++ b/src/analyses/goto_check_c.cpp
@@ -1918,7 +1918,10 @@ optionalt<exprt> goto_check_ct::rw_ok_check(exprt expr)
     for(const auto &c : conditions)
       conjuncts.push_back(c.assertion);
 
-    return conjunction(conjuncts);
+    exprt c = conjunction(conjuncts);
+    if(enable_simplify)
+      simplify(c, ns);
+    return c;
   }
   else if(modified)
     return std::move(expr);


### PR DESCRIPTION
See the two commit messages for details: `__CPROVER_{r,w,rw}_ok` was not being replaced everywhere, and results weren't simplified.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
