### PR TITLE
CONTRACTS: remove redundant "::" in generated symbol names

### DIFF
--- a/regression/contracts/history-pointer-replace-01/test.desc
+++ b/regression/contracts/history-pointer-replace-01/test.desc
@@ -5,7 +5,7 @@ main.c
 ^SIGNAL=0$
 ^VERIFICATION SUCCESSFUL$
 ASSERT \*\(address_of.*n.*\) > 0
-ASSUME \*\(address_of.*n.*\) = .*::tmp_cc[\$\d]? \+ 2
+ASSUME \*\(address_of.*n.*\) = tmp_cc[\$\d]? \+ 2
 --
 --
 Verification:

--- a/regression/contracts/history-pointer-replace-02/test.desc
+++ b/regression/contracts/history-pointer-replace-02/test.desc
@@ -5,7 +5,7 @@ main.c
 ^SIGNAL=0$
 ^VERIFICATION SUCCESSFUL$
 ASSERT \*\(address_of.*n.*\) = 0
-ASSUME \*\(address_of.*n.*\) ≥ .*::tmp_cc[\$\d]? \+ 2
+ASSUME \*\(address_of.*n.*\) ≥ tmp_cc[\$\d]? \+ 2
 --
 --
 Verification:

--- a/src/goto-instrument/contracts/utils.cpp
+++ b/src/goto-instrument/contracts/utils.cpp
@@ -151,12 +151,7 @@ const symbolt &new_tmp_symbol(
   bool is_auxiliary)
 {
   symbolt &new_symbol = get_fresh_aux_symbol(
-    type,
-    id2string(location.get_function()) + "::",
-    suffix,
-    location,
-    mode,
-    symtab);
+    type, id2string(location.get_function()), suffix, location, mode, symtab);
   new_symbol.is_auxiliary = is_auxiliary;
   return new_symbol;
 }


### PR DESCRIPTION
This is just a beautification of goto programs generated for contracts
checking: get_fresh_aux_symbol will add "::" in this place already, so
we ended up with "::::" in symbol names.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
