### PR TITLE
C nondet factory: Ensure parameter initialisers use unique symbol names

### DIFF
--- a/jbmc/src/java_bytecode/java_object_factory.cpp
+++ b/jbmc/src/java_bytecode/java_object_factory.cpp
@@ -104,7 +104,7 @@ public:
     update_in_placet,
     const source_locationt &location);
 
-  void add_created_symbol(const symbolt *symbol);
+  void add_created_symbol(const symbolt &symbol);
 
   void declare_created_symbols(code_blockt &init_code);
 
@@ -1111,9 +1111,9 @@ void java_object_factoryt::gen_nondet_init(
   }
 }
 
-void java_object_factoryt::add_created_symbol(const symbolt *symbol_ptr)
+void java_object_factoryt::add_created_symbol(const symbolt &symbol)
 {
-  allocate_objects.add_created_symbol(symbol_ptr);
+  allocate_objects.add_created_symbol(symbol);
 }
 
 void java_object_factoryt::declare_created_symbols(code_blockt &init_code)
@@ -1578,7 +1578,7 @@ exprt object_factory(
     update_in_placet::NO_UPDATE_IN_PLACE,
     loc);
 
-  state.add_created_symbol(&main_symbol);
+  state.add_created_symbol(main_symbol);
   state.declare_created_symbols(init_code);
 
   assert_type_consistency(assignments);

--- a/jbmc/src/java_bytecode/java_object_factory.cpp
+++ b/jbmc/src/java_bytecode/java_object_factory.cpp
@@ -11,6 +11,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/arith_tools.h>
 #include <util/array_element_from_pointer.h>
 #include <util/expr_initializer.h>
+#include <util/fresh_symbol.h>
 #include <util/message.h>
 #include <util/nondet_bool.h>
 #include <util/prefix.h>
@@ -1551,23 +1552,17 @@ exprt object_factory(
   const select_pointer_typet &pointer_type_selector,
   message_handlert &log)
 {
-  irep_idt identifier=id2string(goto_functionst::entry_point())+
-    "::"+id2string(base_name);
+  const symbolt &main_symbol = get_fresh_aux_symbol(
+    type,
+    id2string(goto_functionst::entry_point()),
+    id2string(base_name),
+    loc,
+    ID_java,
+    symbol_table);
 
-  auxiliary_symbolt main_symbol;
-  main_symbol.mode=ID_java;
-  main_symbol.is_static_lifetime=false;
-  main_symbol.name=identifier;
-  main_symbol.base_name=base_name;
-  main_symbol.type=type;
-  main_symbol.location=loc;
   parameters.function_id = goto_functionst::entry_point();
 
   exprt object=main_symbol.symbol_expr();
-
-  symbolt *main_symbol_ptr;
-  bool moving_symbol_failed=symbol_table.move(main_symbol, main_symbol_ptr);
-  CHECK_RETURN(!moving_symbol_failed);
 
   java_object_factoryt state(
     loc, parameters, symbol_table, pointer_type_selector, log);
@@ -1583,7 +1578,7 @@ exprt object_factory(
     update_in_placet::NO_UPDATE_IN_PLACE,
     loc);
 
-  state.add_created_symbol(main_symbol_ptr);
+  state.add_created_symbol(&main_symbol);
   state.declare_created_symbols(init_code);
 
   assert_type_consistency(assignments);

--- a/regression/cbmc/pointer-function-parameters/main.c
+++ b/regression/cbmc/pointer-function-parameters/main.c
@@ -1,0 +1,3 @@
+void f(int *b, int tmp)
+{
+}

--- a/regression/cbmc/pointer-function-parameters/test.desc
+++ b/regression/cbmc/pointer-function-parameters/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+--function f
+^EXIT=0$
+^SIGNAL=0$
+VERIFICATION SUCCESSFUL
+--
+^warning: ignoring

--- a/src/ansi-c/c_nondet_symbol_factory.cpp
+++ b/src/ansi-c/c_nondet_symbol_factory.cpp
@@ -15,6 +15,7 @@ Author: Diffblue Ltd.
 
 #include <util/arith_tools.h>
 #include <util/c_types.h>
+#include <util/fresh_symbol.h>
 #include <util/namespace.h>
 #include <util/nondet_bool.h>
 #include <util/pointer_expr.h>
@@ -204,22 +205,14 @@ symbol_exprt c_nondet_symbol_factory(
   const c_object_factory_parameterst &object_factory_parameters,
   const lifetimet lifetime)
 {
-  irep_idt identifier=id2string(goto_functionst::entry_point())+
-    "::"+id2string(base_name);
-
-  auxiliary_symbolt main_symbol;
-  main_symbol.mode=ID_C;
-  main_symbol.is_static_lifetime=false;
-  main_symbol.name=identifier;
-  main_symbol.base_name=base_name;
-  main_symbol.type=type;
-  main_symbol.location=loc;
-
+  const symbolt &main_symbol = get_fresh_aux_symbol(
+    type,
+    id2string(goto_functionst::entry_point()),
+    id2string(base_name),
+    loc,
+    ID_C,
+    symbol_table);
   symbol_exprt main_symbol_expr=main_symbol.symbol_expr();
-
-  symbolt *main_symbol_ptr;
-  bool moving_symbol_failed=symbol_table.move(main_symbol, main_symbol_ptr);
-  CHECK_RETURN(!moving_symbol_failed);
 
   symbol_factoryt state(
     symbol_table,
@@ -231,7 +224,7 @@ symbol_exprt c_nondet_symbol_factory(
   code_blockt assignments;
   state.gen_nondet_init(assignments, main_symbol_expr);
 
-  state.add_created_symbol(main_symbol_ptr);
+  state.add_created_symbol(&main_symbol);
   state.declare_created_symbols(init_code);
 
   init_code.append(assignments);

--- a/src/ansi-c/c_nondet_symbol_factory.cpp
+++ b/src/ansi-c/c_nondet_symbol_factory.cpp
@@ -224,7 +224,7 @@ symbol_exprt c_nondet_symbol_factory(
   code_blockt assignments;
   state.gen_nondet_init(assignments, main_symbol_expr);
 
-  state.add_created_symbol(&main_symbol);
+  state.add_created_symbol(main_symbol);
   state.declare_created_symbols(init_code);
 
   init_code.append(assignments);

--- a/src/ansi-c/c_nondet_symbol_factory.h
+++ b/src/ansi-c/c_nondet_symbol_factory.h
@@ -56,9 +56,9 @@ public:
     recursion_sett recursion_set = recursion_sett(),
     const bool assign_const = true);
 
-  void add_created_symbol(const symbolt *symbol_ptr)
+  void add_created_symbol(const symbolt &symbol)
   {
-    allocate_objects.add_created_symbol(symbol_ptr);
+    allocate_objects.add_created_symbol(symbol);
   }
 
   void declare_created_symbols(code_blockt &init_code)

--- a/src/goto-programs/allocate_objects.h
+++ b/src/goto-programs/allocate_objects.h
@@ -93,7 +93,7 @@ public:
     const typet &allocate_type,
     const irep_idt &basename_prefix = "tmp");
 
-  void add_created_symbol(const symbolt *symbol_ptr);
+  void add_created_symbol(const symbolt &symbol);
 
   void declare_created_symbols(code_blockt &init_code);
 
@@ -107,7 +107,7 @@ private:
   symbol_table_baset &symbol_table;
   const namespacet ns;
 
-  std::vector<const symbolt *> symbols_created;
+  std::vector<irep_idt> symbols_created;
 
   exprt allocate_non_dynamic_object(
     code_blockt &assignments,


### PR DESCRIPTION
The nondet symbol factory uses "tmp" as a default basename prefix, and
in all other places already generated unique names using
`get_fresh_aux_symbol`. This function, however, will happily use exactly
that basename when there wouldn't be a conflict. The code fixed in this
commit, however, did not yet use this facility, and just assumed that
each parameter of the target function would result in a unique local
name. A parameter named "tmp," then, resulted in a conflict.
Consistently using `get_fresh_aux_symbol` addresses this problem.

Fixes: #6566

Co-authored-by: Matthias Güdemann <matthias.guedemann@hm.edu>

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
