### PR TITLE
Java front-end and allocate objects: do not use goto code types

### DIFF
--- a/jbmc/src/java_bytecode/java_static_initializers.cpp
+++ b/jbmc/src/java_bytecode/java_static_initializers.cpp
@@ -8,21 +8,22 @@ Author: Chris Smowton, chris.smowton@diffblue.com
 
 #include "java_static_initializers.h"
 
-#include "assignments_from_json.h"
-#include "ci_lazy_methods_needed.h"
-#include "java_object_factory.h"
-#include "java_object_factory_parameters.h"
-#include "java_types.h"
-#include "java_utils.h"
-
-#include <goto-programs/class_hierarchy.h>
-
 #include <util/arith_tools.h>
 #include <util/cprover_prefix.h>
 #include <util/json.h>
 #include <util/std_code.h>
 #include <util/suffix.h>
 #include <util/symbol_table.h>
+
+#include <goto-programs/class_hierarchy.h>
+#include <goto-programs/goto_instruction_code.h>
+
+#include "assignments_from_json.h"
+#include "ci_lazy_methods_needed.h"
+#include "java_object_factory.h"
+#include "java_object_factory_parameters.h"
+#include "java_types.h"
+#include "java_utils.h"
 
 /// The three states in which a `<clinit>` method for a class can be before,
 /// after, and during static class initialization. These states are only used
@@ -580,7 +581,7 @@ code_blockt get_thread_safe_clinit_wrapper_body(
 
   // bool init_complete;
   {
-    code_declt decl(init_complete.symbol_expr());
+    code_frontend_declt decl(init_complete.symbol_expr());
     function_body.add(decl);
   }
 

--- a/jbmc/src/java_bytecode/nondet.cpp
+++ b/jbmc/src/java_bytecode/nondet.cpp
@@ -49,7 +49,7 @@ symbol_exprt generate_nondet_int(
   // Declare a symbol for the non deterministic integer.
   const symbol_exprt &nondet_symbol =
     alocate_local_symbol(int_type, basename_prefix);
-  instructions.add(code_declt(nondet_symbol));
+  instructions.add(code_frontend_declt(nondet_symbol));
 
   // Assign the symbol any non deterministic integer value.
   //   int_type name_prefix::nondet_int = NONDET(int_type)

--- a/jbmc/src/java_bytecode/simple_method_stubbing.cpp
+++ b/jbmc/src/java_bytecode/simple_method_stubbing.cpp
@@ -188,7 +188,7 @@ void java_simple_method_stubst::create_method_stub(symbolt &symbol)
       symbol.name,
       symbol_table);
     const symbol_exprt &init_symbol_expression = init_symbol.symbol_expr();
-    code_assignt get_argument(
+    code_frontend_assignt get_argument(
       init_symbol_expression,
       symbol_exprt(this_argument.get_identifier(), this_type));
     get_argument.add_source_location() = synthesized_source_location;
@@ -242,7 +242,7 @@ void java_simple_method_stubst::create_method_stub(symbolt &symbol)
           0,
           false,
           false);
-      new_instructions.add(code_returnt(to_return));
+      new_instructions.add(code_frontend_returnt(to_return));
     }
   }
 

--- a/src/goto-programs/allocate_objects.cpp
+++ b/src/goto-programs/allocate_objects.cpp
@@ -14,6 +14,8 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/pointer_offset_size.h>
 #include <util/symbol.h>
 
+#include "goto_instruction_code.h"
+
 /// Allocates a new object, either by creating a local variable with automatic
 /// lifetime, a global variable with static lifetime, or by dynamically
 /// allocating memory via ALLOCATE(). Code is added to `assignments` which
@@ -233,7 +235,7 @@ void allocate_objectst::declare_created_symbols(code_blockt &init_code)
     const symbolt &symbol = ns.lookup(symbol_id);
     if(!symbol.is_static_lifetime)
     {
-      code_declt decl{symbol.symbol_expr()};
+      code_frontend_declt decl{symbol.symbol_expr()};
       decl.add_source_location() = source_location;
       init_code.add(decl);
     }

--- a/src/goto-programs/allocate_objects.h
+++ b/src/goto-programs/allocate_objects.h
@@ -9,10 +9,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #ifndef CPROVER_UTIL_ALLOCATE_OBJECTS_H
 #define CPROVER_UTIL_ALLOCATE_OBJECTS_H
 
-#include "goto_instruction_code.h"
-
 #include <util/namespace.h>
-#include <util/source_location.h>
 #include <util/std_code.h>
 
 /// Selects the kind of objects allocated


### PR DESCRIPTION
Code that deals with symbol tables only should not create codet
structures defined in goto-programs/goto_instruction_code.h.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
