### PR TITLE
C library: define exactly one function per comment block

### DIFF
--- a/src/ansi-c/library/pthread_lib.c
+++ b/src/ansi-c/library/pthread_lib.c
@@ -531,16 +531,10 @@ inline int pthread_rwlock_wrlock(pthread_rwlock_t *lock)
   return 0; // we never fail
 }
 
-/* FUNCTION: pthread_create */
-
-#ifndef __CPROVER_PTHREAD_H_INCLUDED
-#include <pthread.h>
-#define __CPROVER_PTHREAD_H_INCLUDED
-#endif
+/* FUNCTION: __spawned_thread */
 
 extern __CPROVER_bool __CPROVER_threads_exited[];
 extern __CPROVER_thread_local unsigned long __CPROVER_thread_id;
-extern unsigned long __CPROVER_next_thread_id;
 
 extern __CPROVER_thread_local const void *__CPROVER_thread_keys[];
 extern __CPROVER_thread_local void (*__CPROVER_thread_key_dtors[])(void *);
@@ -594,6 +588,26 @@ __CPROVER_HIDE:;
 #endif
   __CPROVER_threads_exited[this_thread_id] = 1;
 }
+
+/* FUNCTION: pthread_create */
+
+#ifndef __CPROVER_PTHREAD_H_INCLUDED
+#  include <pthread.h>
+#  define __CPROVER_PTHREAD_H_INCLUDED
+#endif
+
+extern unsigned long __CPROVER_next_thread_id;
+
+void __spawned_thread(
+  unsigned long this_thread_id,
+#if 0
+  // Destructor support is disabled as it is too expensive due to its extensive
+  // use of shared variables.
+  void (**thread_key_dtors)(void *),
+#endif
+  unsigned long next_thread_key,
+  void *(*start_routine)(void *),
+  void *arg);
 
 inline int pthread_create(
   pthread_t *thread, // must not be null


### PR DESCRIPTION
Functions from the model library are loaded upon request, and their
definitions are found as labelled by comment blocks. When adding all
these functions to a single, common symbol table we were by chance able
to also find functions other than those explicitly referenced by those
comment labels. Moving forward, however, we might not actually use a
single symbol table anymore.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
