### PR TITLE
Fix `irept` printing in failed unit tests

### DIFF
--- a/regression/CMakeLists.txt
+++ b/regression/CMakeLists.txt
@@ -87,3 +87,5 @@ endif()
 if(NOT WIN32)
   add_subdirectory(crangler)
 endif()
+
+add_subdirectory(catch-framework)

--- a/regression/Makefile
+++ b/regression/Makefile
@@ -51,6 +51,7 @@ DIRS = cbmc \
        goto-interpreter \
        cbmc-sequentialization \
        cpp-linter \
+       catch-framework \
        # Empty last line
 
 ifeq ($(OS),Windows_NT)

--- a/regression/catch-framework/CMakeLists.txt
+++ b/regression/catch-framework/CMakeLists.txt
@@ -1,0 +1,4 @@
+
+add_test_pl_tests(
+    "$<TARGET_FILE:unit>"
+)

--- a/regression/catch-framework/Makefile
+++ b/regression/catch-framework/Makefile
@@ -1,0 +1,9 @@
+default: test
+
+test:
+	@../test.pl -e -p -c "../../../unit/unit_tests"
+
+tests.log: ../test.pl test
+
+clean:
+	$(RM) tests*.log

--- a/regression/catch-framework/irep-printing/test.desc
+++ b/regression/catch-framework/irep-printing/test.desc
@@ -1,0 +1,12 @@
+CORE
+[irep_error_printing]
+
+REQUIRE\( foo == bar \)
+key: value
+^EXIT=0$
+^SIGNAL=0$
+--
+\{\?\}
+--
+Test that when unit tests fail on mismatching ireps, the ireps are
+pretty-printed and not printed as catch's default of {?}.

--- a/unit/testing-utils/use_catch.h
+++ b/unit/testing-utils/use_catch.h
@@ -39,4 +39,7 @@ Author: Michael Tautschnig
 /// Add to the end of test tags to mark a test that is expected to fail
 #define XFAIL "[.][!shouldfail]"
 
+class irept;
+std::ostream &operator<<(std::ostream &os, const irept &value);
+
 #endif // CPROVER_TESTING_UTILS_USE_CATCH_H

--- a/unit/util/irep.cpp
+++ b/unit/util/irep.cpp
@@ -302,3 +302,16 @@ SCENARIO("irept_memory", "[core][utils][irept]")
     }
   }
 }
+
+// This test is expected to fail so that we can test the error printing of the
+// unit test framework for regressions. It is not included in the [core] or
+// default set of tests, so that the usual output is not polluted with
+// irrelevant error messages.
+TEST_CASE(
+  "Catch2 printing of `irept` for test failures.",
+  "[irep_error_printing]" XFAIL)
+{
+  const irept foo{"foo", irept::named_subt{{"key", irept{"value"}}}, {}};
+  const irept bar{"bar"};
+  REQUIRE(foo == bar);
+}


### PR DESCRIPTION
The operator needed for the printing is defined in `unit_tests.cpp`, but it  also needs to be forward declared for the catch framework to find and  use it, instead of printing ireps as `{?}`.

A regression test of a failing unit test is included in this PR to ensure that this functionality for fault finding of failing unit tests works as intended.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
