### PR TITLE
Remove useless system_library_symbolst::is_type_internal

### DIFF
--- a/regression/goto-instrument/dump-typedef/main.c
+++ b/regression/goto-instrument/dump-typedef/main.c
@@ -1,0 +1,27 @@
+#include <stdint.h>
+
+// NOLINTNEXTLINE(whitespace/line_length)
+#line 1 "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/stdint.h"
+typedef short int16_t;
+
+// NOLINTNEXTLINE(whitespace/line_length)
+#line 1 "/Applications/Xcode_13.2.1.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/stdint.h"
+typedef unsigned short uint16_t;
+
+// NOLINTNEXTLINE(whitespace/line_length)
+#line 1 "C:\\Program Files (x86)\\Microsoft Visual Studio\\2017\\Community\\VC\\Tools\\MSVC\\14.10.25017\\include\\stdint.h"
+typedef int int32_t;
+
+// NOLINTNEXTLINE(whitespace/line_length)
+#line 1 "C:\\Program Files\\Microsoft Visual Studio\\2022\\Enterprise\\VC\\Tools\\MSVC\\14.30.30705\\include\\stdint.h"
+typedef unsigned int uint32_t;
+
+#line 20 "main.c"
+int main(int argc, char *argv[])
+{
+  intmax_t x;
+  int16_t y;
+  uint16_t uy;
+  int32_t z;
+  uint32_t uz;
+}

--- a/regression/goto-instrument/dump-typedef/test.desc
+++ b/regression/goto-instrument/dump-typedef/test.desc
@@ -1,0 +1,13 @@
+CORE
+main.c
+--dump-c --use-all-headers
+#include <(stdint.h|_types/_intmax_t.h)>
+intmax_t
+^EXIT=0$
+^SIGNAL=0$
+--
+typedef
+^warning: ignoring
+--
+Dump-c with --use-all-headers should re-generate the #include and not print a
+local typedef statement for intmax_t instead.

--- a/src/goto-instrument/dump_c.cpp
+++ b/src/goto-instrument/dump_c.cpp
@@ -714,9 +714,6 @@ void dump_ct::collect_typedefs_rec(
   bool early,
   std::unordered_set<irep_idt> &dependencies)
 {
-  if(system_symbols.is_type_internal(type, system_headers))
-    return;
-
   std::unordered_set<irep_idt> local_deps;
 
   if(type.id()==ID_code)

--- a/src/goto-programs/system_library_symbols.h
+++ b/src/goto-programs/system_library_symbols.h
@@ -35,10 +35,6 @@ public:
     const symbolt &symbol,
     std::set<std::string> &out_system_headers) const;
 
-  bool is_type_internal(
-    const typet &type,
-    std::set<std::string> &out_system_headers) const;
-
   void set_use_all_headers(bool use)
   {
     use_all_headers=use;


### PR DESCRIPTION
Passing a symbolt that only has its "type" member set to
is_symbol_internal_symbol is useless as that function never even looks
at the type. Although fixing is_type_internal was possible, it turns out
to be completely unnecessary as the single user (dump-c) appears to work
just fine as demonstrated in the included test case.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
