### PR TITLE
Do not generate enum-value checks for function call left-hand sides

### DIFF
--- a/regression/cbmc/enum_is_in_range/enum_test3-simplified.desc
+++ b/regression/cbmc/enum_is_in_range/enum_test3-simplified.desc
@@ -1,0 +1,10 @@
+CORE
+enum_test3.c
+--show-goto-functions
+0 ≤ cast\(main::1::ev1, (un)?signedbv\[\d+\]\) ∧ cast\(main::1::ev1, (un)?signedbv\[\d+\]\) ≤ 4$
+^EXIT=0$
+^SIGNAL=0$
+--
+main::1::ev1 = 0
+--
+This test is to demonstrate simplification of enumerated ranges of integers.

--- a/regression/cbmc/enum_is_in_range/format.desc
+++ b/regression/cbmc/enum_is_in_range/format.desc
@@ -1,0 +1,10 @@
+CORE
+no_duplicate.c
+--show-goto-functions
+main::1::e = 1 ∨ main::1::e = 2 ∨ main::1::e = 4 ∨ main::1::e = 8
+^EXIT=0$
+^SIGNAL=0$
+--
+type: c_enum_tag
+--
+This test is to show that format(expr) also works for enum-typed constants.

--- a/regression/cbmc/enum_is_in_range/no_duplicate.c
+++ b/regression/cbmc/enum_is_in_range/no_duplicate.c
@@ -1,0 +1,19 @@
+enum enm
+{
+  first = 1,
+  second = 1 << 1,
+  third = 1 << 2,
+  fourth = 1 << 3,
+};
+
+static enum enm efunc(void)
+{
+  return second;
+}
+
+int main(void)
+{
+  enum enm e = efunc();
+  __CPROVER_assert(__CPROVER_enum_is_in_range(e), "enum failure");
+  return (e);
+}

--- a/regression/cbmc/enum_is_in_range/no_duplicate.desc
+++ b/regression/cbmc/enum_is_in_range/no_duplicate.desc
@@ -5,4 +5,7 @@ no_duplicate.c
 ^EXIT=0$
 ^SIGNAL=0$
 --
+line 17 enum range check in e: SUCCESS$
 --
+Test that enum range checks aren't applied to function-call left-hand sides, and
+that no extra checks are generated for uses of __CPROVER_enum_is_in_range.

--- a/regression/cbmc/enum_is_in_range/no_duplicate.desc
+++ b/regression/cbmc/enum_is_in_range/no_duplicate.desc
@@ -1,0 +1,8 @@
+CORE
+no_duplicate.c
+--enum-range-check
+^VERIFICATION SUCCESSFUL$
+^EXIT=0$
+^SIGNAL=0$
+--
+--

--- a/regression/validate-trace-xml-schema/check.py
+++ b/regression/validate-trace-xml-schema/check.py
@@ -25,6 +25,7 @@ ExcludedTests = list(map(lambda s: os.path.join(test_base_dir, s[0], s[1]), [
     ['integer-assignments1', 'integer-typecheck.desc'],
     ['destructors', 'compound_literal.desc'],
     ['destructors', 'enter_lexical_block.desc'],
+    ['enum_is_in_range', 'format.desc'],
     ['r_w_ok9', 'simplify.desc'],
     ['reachability-slice-interproc2', 'test.desc'],
     # this one wants show-properties instead producing a trace

--- a/regression/validate-trace-xml-schema/check.py
+++ b/regression/validate-trace-xml-schema/check.py
@@ -25,6 +25,7 @@ ExcludedTests = list(map(lambda s: os.path.join(test_base_dir, s[0], s[1]), [
     ['integer-assignments1', 'integer-typecheck.desc'],
     ['destructors', 'compound_literal.desc'],
     ['destructors', 'enter_lexical_block.desc'],
+    ['enum_is_in_range', 'enum_test3-simplified.desc'],
     ['enum_is_in_range', 'format.desc'],
     ['r_w_ok9', 'simplify.desc'],
     ['reachability-slice-interproc2', 'test.desc'],

--- a/src/analyses/goto_check_c.cpp
+++ b/src/analyses/goto_check_c.cpp
@@ -517,8 +517,7 @@ void goto_check_ct::enum_range_check(const exprt &expr, const guardt &guard)
     return;
 
   const c_enum_tag_typet &c_enum_tag_type = to_c_enum_tag_type(expr.type());
-  symbolt enum_type = ns.lookup(c_enum_tag_type.get_identifier());
-  const c_enum_typet &c_enum_type = to_c_enum_type(enum_type.type);
+  const c_enum_typet &c_enum_type = ns.follow_tag(c_enum_tag_type);
 
   const c_enum_typet::memberst enum_values = c_enum_type.members();
 
@@ -2148,7 +2147,13 @@ void goto_check_ct::goto_check(
     }
     else if(i.is_function_call())
     {
-      check(i.call_lhs());
+      // Disable enum range checks for left-hand sides as their values are yet
+      // to be set (by this function call).
+      {
+        flag_overridet resetter(i.source_location());
+        resetter.disable_flag(enable_enum_range_check, "enum_range_check");
+        check(i.call_lhs());
+      }
       check(i.call_function());
 
       for(const auto &arg : i.call_arguments())

--- a/src/goto-programs/builtin_functions.cpp
+++ b/src/goto-programs/builtin_functions.cpp
@@ -638,6 +638,7 @@ void goto_convertt::do_enum_is_in_range(
 
   code_assignt assignment(lhs, disjunction(disjuncts));
   assignment.add_source_location() = function.source_location();
+  assignment.add_source_location().add_pragma("disable:enum-range-check");
   copy(assignment, ASSIGN, dest);
 }
 

--- a/src/goto-programs/builtin_functions.cpp
+++ b/src/goto-programs/builtin_functions.cpp
@@ -636,7 +636,7 @@ void goto_convertt::do_enum_is_in_range(
     disjuncts.push_back(equal_exprt(enum_expr, std::move(val)));
   }
 
-  code_assignt assignment(lhs, disjunction(disjuncts));
+  code_assignt assignment(lhs, simplify_expr(disjunction(disjuncts), ns));
   assignment.add_source_location() = function.source_location();
   assignment.add_source_location().add_pragma("disable:enum-range-check");
   copy(assignment, ASSIGN, dest);

--- a/src/util/arith_tools.cpp
+++ b/src/util/arith_tools.cpp
@@ -59,13 +59,13 @@ bool to_integer(const constant_exprt &expr, mp_integer &int_value)
     const typet &underlying_type = to_c_enum_type(type).underlying_type();
     if(underlying_type.id() == ID_signedbv)
     {
-      const auto width = to_signedbv_type(type).get_width();
+      const auto width = to_signedbv_type(underlying_type).get_width();
       int_value = bvrep2integer(value, width, true);
       return false;
     }
     else if(underlying_type.id() == ID_unsignedbv)
     {
-      const auto width = to_unsignedbv_type(type).get_width();
+      const auto width = to_unsignedbv_type(underlying_type).get_width();
       int_value = bvrep2integer(value, width, false);
       return false;
     }

--- a/src/util/format_expr.cpp
+++ b/src/util/format_expr.cpp
@@ -204,6 +204,10 @@ static std::ostream &format_rec(std::ostream &os, const constant_exprt &src)
                 << format(pointer_type.base_type()) << ')';
     }
   }
+  else if(type == ID_c_enum_tag)
+  {
+    return os << string2integer(id2string(src.get_value()), 16);
+  }
   else
     return os << src.pretty();
 }


### PR DESCRIPTION
We already disabled these checks for assignment left-hand sides, but
need to do the same for function calls. Else we'd be asserting validity
before the value has been assigned.

Fixes: #6586

Co-authored-by: Ilia Levin <eli@literatecode.com>

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
