### PR TITLE
goto-cc: newlines in command files are just whitespace

### DIFF
--- a/regression/goto-gcc/at_files/args
+++ b/regression/goto-gcc/at_files/args
@@ -1,1 +1,3 @@
+-o
+test.gb
 other.c

--- a/src/goto-cc/gcc_cmdline.cpp
+++ b/src/goto-cc/gcc_cmdline.cpp
@@ -12,8 +12,9 @@ Author: CM Wintersteiger, 2006
 #include "gcc_cmdline.h"
 
 #include <cstring>
-#include <iostream>
 #include <fstream>
+#include <iostream>
+#include <sstream>
 
 #include <util/prefix.h>
 
@@ -256,16 +257,18 @@ bool gcc_cmdlinet::parse_arguments(
     if(has_prefix(argv_i, "@"))
     {
       std::ifstream opts_file(argv_i.substr(1));
+      std::ostringstream all_lines;
       std::string line;
 
       while(std::getline(opts_file, line))
-      {
-        // erase leading whitespace
-        line.erase(0, line.find_first_not_of("\t "));
+        all_lines << ' ' << line;
 
-        if(!line.empty())
-          parse_specs_line(line, false);
-      }
+      line = all_lines.str();
+      // erase leading whitespace
+      line.erase(0, line.find_first_not_of("\t "));
+
+      if(!line.empty())
+        parse_specs_line(line, false);
 
       continue;
     }


### PR DESCRIPTION
GCC's doc says that options are separated by whitespace, with no
particular significance of newlines. Therefore, process the entire file
at once rather than line-by-line.

Fixes: #6592

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
