### PR TITLE
check type invariant of type_with_subtypet

### DIFF
--- a/src/ansi-c/ansi_c_convert_type.cpp
+++ b/src/ansi-c/ansi_c_convert_type.cpp
@@ -187,8 +187,11 @@ void ansi_c_convert_typet::read_rec(const typet &type)
   {
     c_qualifiers.is_transparent_union=true;
   }
-  else if(type.id()==ID_vector)
-    vector_size=to_vector_type(type).size();
+  else if(type.id() == ID_frontend_vector)
+  {
+    // note that this is not yet a vector_typet -- this is a size only
+    vector_size = static_cast<const constant_exprt &>(type.find(ID_size));
+  }
   else if(type.id()==ID_void)
   {
     // we store 'void' as 'empty'

--- a/src/ansi-c/ansi_c_convert_type.cpp
+++ b/src/ansi-c/ansi_c_convert_type.cpp
@@ -45,9 +45,13 @@ void ansi_c_convert_typet::read_rec(const typet &type)
     c_qualifiers.is_volatile=true;
   else if(type.id()==ID_asm)
   {
-    if(type.has_subtype() &&
-       type.subtype().id()==ID_string_constant)
-      c_storage_spec.asm_label = to_string_constant(type.subtype()).get_value();
+    // These can have up to 5 subtypes; we only use the first one.
+    const auto &type_with_subtypes = to_type_with_subtypes(type);
+    if(
+      !type_with_subtypes.subtypes().empty() &&
+      type_with_subtypes.subtypes()[0].id() == ID_string_constant)
+      c_storage_spec.asm_label =
+        to_string_constant(type_with_subtypes.subtypes()[0]).get_value();
   }
   else if(type.id()==ID_section &&
           type.has_subtype() &&

--- a/src/ansi-c/c_storage_spec.cpp
+++ b/src/ansi-c/c_storage_spec.cpp
@@ -52,11 +52,12 @@ void c_storage_spect::read(const typet &type)
   {
     alias = to_string_constant(type.subtype()).get_value();
   }
-  else if(type.id()==ID_asm &&
-          type.has_subtype() &&
-          type.subtype().id()==ID_string_constant)
+  else if(
+    type.id() == ID_asm && !to_type_with_subtypes(type).subtypes().empty() &&
+    to_type_with_subtypes(type).subtypes()[0].id() == ID_string_constant)
   {
-    asm_label = to_string_constant(type.subtype()).get_value();
+    asm_label =
+      to_string_constant(to_type_with_subtypes(type).subtypes()[0]).get_value();
   }
   else if(type.id()==ID_section &&
           type.has_subtype() &&

--- a/src/ansi-c/parser.y
+++ b/src/ansi-c/parser.y
@@ -1607,7 +1607,7 @@ gcc_type_attribute:
         | TOK_GCC_ATTRIBUTE_TRANSPARENT_UNION
         { $$=$1; set($$, ID_transparent_union); }
         | TOK_GCC_ATTRIBUTE_VECTOR_SIZE '(' comma_expression ')'
-        { $$=$1; set($$, ID_vector); parser_stack($$).add(ID_size)=parser_stack($3); }
+        { $$=$1; set($$, ID_frontend_vector); parser_stack($$).add(ID_size)=parser_stack($3); }
         | TOK_GCC_ATTRIBUTE_ALIGNED
         { $$=$1; set($$, ID_aligned); }
         | TOK_GCC_ATTRIBUTE_ALIGNED '(' comma_expression ')'

--- a/src/util/c_types.h
+++ b/src/util/c_types.h
@@ -58,6 +58,7 @@ inline bool can_cast_type<c_bit_field_typet>(const typet &type)
 inline const c_bit_field_typet &to_c_bit_field_type(const typet &type)
 {
   PRECONDITION(can_cast_type<c_bit_field_typet>(type));
+  type_with_subtypet::check(type);
   return static_cast<const c_bit_field_typet &>(type);
 }
 
@@ -65,6 +66,7 @@ inline const c_bit_field_typet &to_c_bit_field_type(const typet &type)
 inline c_bit_field_typet &to_c_bit_field_type(typet &type)
 {
   PRECONDITION(can_cast_type<c_bit_field_typet>(type));
+  type_with_subtypet::check(type);
   return static_cast<c_bit_field_typet &>(type);
 }
 
@@ -300,6 +302,7 @@ inline bool can_cast_type<c_enum_typet>(const typet &type)
 inline const c_enum_typet &to_c_enum_type(const typet &type)
 {
   PRECONDITION(can_cast_type<c_enum_typet>(type));
+  type_with_subtypet::check(type);
   return static_cast<const c_enum_typet &>(type);
 }
 
@@ -307,6 +310,7 @@ inline const c_enum_typet &to_c_enum_type(const typet &type)
 inline c_enum_typet &to_c_enum_type(typet &type)
 {
   PRECONDITION(can_cast_type<c_enum_typet>(type));
+  type_with_subtypet::check(type);
   return static_cast<c_enum_typet &>(type);
 }
 

--- a/src/util/pointer_expr.h
+++ b/src/util/pointer_expr.h
@@ -54,6 +54,7 @@ public:
     const typet &type,
     const validation_modet vm = validation_modet::INVARIANT)
   {
+    type_with_subtypet::check(type);
     DATA_CHECK(vm, !type.get(ID_width).empty(), "pointer must have width");
   }
 };
@@ -116,6 +117,8 @@ public:
     const validation_modet vm = validation_modet::INVARIANT)
   {
     PRECONDITION(type.id() == ID_pointer);
+    DATA_CHECK(
+      vm, type.get_sub().size() == 1, "reference must have one type parameter");
     const reference_typet &reference_type =
       static_cast<const reference_typet &>(type);
     DATA_CHECK(

--- a/src/util/std_types.cpp
+++ b/src/util/std_types.cpp
@@ -19,6 +19,7 @@ Author: Daniel Kroening, kroening@kroening.com
 void array_typet::check(const typet &type, const validation_modet vm)
 {
   PRECONDITION(type.id() == ID_array);
+  type_with_subtypet::check(type);
   const array_typet &array_type = static_cast<const array_typet &>(type);
   if(array_type.size().is_nil())
   {

--- a/src/util/std_types.h
+++ b/src/util/std_types.h
@@ -832,6 +832,7 @@ inline bool can_cast_type<array_typet>(const typet &type)
 inline const array_typet &to_array_type(const typet &type)
 {
   PRECONDITION(can_cast_type<array_typet>(type));
+  array_typet::check(type);
   return static_cast<const array_typet &>(type);
 }
 
@@ -839,6 +840,7 @@ inline const array_typet &to_array_type(const typet &type)
 inline array_typet &to_array_type(typet &type)
 {
   PRECONDITION(can_cast_type<array_typet>(type));
+  array_typet::check(type);
   return static_cast<array_typet &>(type);
 }
 
@@ -1038,6 +1040,7 @@ inline bool can_cast_type<vector_typet>(const typet &type)
 inline const vector_typet &to_vector_type(const typet &type)
 {
   PRECONDITION(can_cast_type<vector_typet>(type));
+  type_with_subtypet::check(type);
   return static_cast<const vector_typet &>(type);
 }
 
@@ -1045,6 +1048,7 @@ inline const vector_typet &to_vector_type(const typet &type)
 inline vector_typet &to_vector_type(typet &type)
 {
   PRECONDITION(can_cast_type<vector_typet>(type));
+  type_with_subtypet::check(type);
   return static_cast<vector_typet &>(type);
 }
 
@@ -1078,6 +1082,7 @@ inline bool can_cast_type<complex_typet>(const typet &type)
 inline const complex_typet &to_complex_type(const typet &type)
 {
   PRECONDITION(can_cast_type<complex_typet>(type));
+  type_with_subtypet::check(type);
   return static_cast<const complex_typet &>(type);
 }
 
@@ -1085,6 +1090,7 @@ inline const complex_typet &to_complex_type(const typet &type)
 inline complex_typet &to_complex_type(typet &type)
 {
   PRECONDITION(can_cast_type<complex_typet>(type));
+  type_with_subtypet::check(type);
   return static_cast<complex_typet &>(type);
 }
 

--- a/src/util/type.h
+++ b/src/util/type.h
@@ -16,6 +16,7 @@ Author: Daniel Kroening, kroening@kroening.com
 class namespacet;
 
 #include "source_location.h"
+#include "validate.h"
 #include "validate_types.h"
 #include "validation_mode.h"
 
@@ -63,7 +64,9 @@ public:
   { return !get_sub().empty(); }
 
   bool has_subtype() const
-  { return !get_sub().empty(); }
+  {
+    return get_sub().size() == 1;
+  }
 
   void remove_subtype()
   { get_sub().clear(); }
@@ -149,17 +152,37 @@ public:
     : typet(std::move(_id), std::move(_subtype))
   {
   }
+
+  const typet &subtype() const
+  {
+    // the existence of get_sub().front() is established by check()
+    return static_cast<const typet &>(get_sub().front());
+  }
+
+  typet &subtype()
+  {
+    // the existence of get_sub().front() is established by check()
+    return static_cast<typet &>(get_sub().front());
+  }
+
+  static void check(
+    const typet &type,
+    const validation_modet vm = validation_modet::INVARIANT)
+  {
+    DATA_CHECK(
+      vm, type.get_sub().size() == 1, "type must have one type parameter");
+  }
 };
 
 inline const type_with_subtypet &to_type_with_subtype(const typet &type)
 {
-  PRECONDITION(type.has_subtype());
+  type_with_subtypet::check(type);
   return static_cast<const type_with_subtypet &>(type);
 }
 
 inline type_with_subtypet &to_type_with_subtype(typet &type)
 {
-  PRECONDITION(type.has_subtype());
+  type_with_subtypet::check(type);
   return static_cast<type_with_subtypet &>(type);
 }
 


### PR DESCRIPTION
This commit does two things:

1) The type invariant of `type_with_subtypet` (that there is one subtype) is
now checked when casting to it.

2) The check in `.subtype()` that there is a subtype is removed.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
