### PR TITLE
Add annotated_pointer_constant_exprt

### DIFF
--- a/src/ansi-c/expr2c_class.h
+++ b/src/ansi-c/expr2c_class.h
@@ -23,6 +23,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/mathematical_expr.h>
 #include <util/std_code.h>
 
+class annotated_pointer_constant_exprt;
 class qualifierst;
 class namespacet;
 
@@ -257,6 +258,9 @@ protected:
   // NOLINTNEXTLINE(whitespace/line_length)
   virtual std::string convert_constant(const constant_exprt &src, unsigned &precedence);
   virtual std::string convert_constant_bool(bool boolean_value);
+  virtual std::string convert_annotated_pointer_constant(
+    const annotated_pointer_constant_exprt &src,
+    unsigned &precedence);
 
   std::string convert_norep(const exprt &src, unsigned &precedence);
 

--- a/src/goto-programs/goto_trace.h
+++ b/src/goto-programs/goto_trace.h
@@ -296,32 +296,4 @@ void show_goto_trace(
   if(cmdline.isset("stack-trace"))                                             \
     options.set_option("stack-trace", true);
 
-/// Variety of constant expression only used in the context of a GOTO trace, to
-/// give both the numeric value and the symbolic value of a pointer,
-/// e.g. numeric value "0xabcd0004" but symbolic value "&some_object + 4". The
-/// numeric value is stored in the `constant_exprt`'s usual value slot (see
-/// \ref constant_exprt::get_value) and the symbolic value is accessed using the
-/// `symbolic_pointer` method introduced by this class.
-class goto_trace_constant_pointer_exprt : public constant_exprt
-{
-public:
-  const exprt &symbolic_pointer() const
-  {
-    return static_cast<const exprt &>(operands()[0]);
-  }
-};
-
-template <>
-inline bool can_cast_expr<goto_trace_constant_pointer_exprt>(const exprt &base)
-{
-  return can_cast_expr<constant_exprt>(base) && base.operands().size() == 1;
-}
-
-inline const goto_trace_constant_pointer_exprt &
-to_goto_trace_constant_pointer_expr(const exprt &expr)
-{
-  PRECONDITION(can_cast_expr<goto_trace_constant_pointer_exprt>(expr));
-  return static_cast<const goto_trace_constant_pointer_exprt &>(expr);
-}
-
 #endif // CPROVER_GOTO_PROGRAMS_GOTO_TRACE_H

--- a/src/solvers/flattening/boolbv_constant.cpp
+++ b/src/solvers/flattening/boolbv_constant.cpp
@@ -22,29 +22,7 @@ bvt boolbvt::convert_constant(const constant_exprt &expr)
 
   const typet &expr_type=expr.type();
 
-  if(expr_type.id()==ID_array)
-  {
-    std::size_t op_width=width/expr.operands().size();
-    std::size_t offset=0;
-
-    forall_operands(it, expr)
-    {
-      const bvt &tmp=convert_bv(*it);
-
-      DATA_INVARIANT_WITH_DIAGNOSTICS(
-        tmp.size() == op_width,
-        "convert_constant: unexpected operand width",
-        irep_pretty_diagnosticst{expr});
-
-      for(std::size_t j=0; j<op_width; j++)
-        bv[offset+j]=tmp[j];
-
-      offset+=op_width;
-    }
-
-    return bv;
-  }
-  else if(expr_type.id()==ID_string)
+  if(expr_type.id() == ID_string)
   {
     // we use the numbering for strings
     std::size_t number = string_numbering.number(expr.get_value());

--- a/src/solvers/flattening/bv_pointers.cpp
+++ b/src/solvers/flattening/bv_pointers.cpp
@@ -805,10 +805,8 @@ exprt bv_pointerst::bv_get_rec(
     numeric_cast_v<std::size_t>(binary2integer(value_addr, false));
   pointer.offset=binary2integer(value_offset, true);
 
-  // we add the elaborated expression as operand
-  result.copy_to_operands(pointer_logic.pointer_expr(pointer, pt));
-
-  return std::move(result);
+  return annotated_pointer_constant_exprt{
+    bvrep, pointer_logic.pointer_expr(pointer, pt)};
 }
 
 bvt bv_pointerst::encode(std::size_t addr, const pointer_typet &type) const

--- a/src/util/format_expr.cpp
+++ b/src/util/format_expr.cpp
@@ -189,13 +189,6 @@ static std::ostream &format_rec(std::ostream &os, const constant_exprt &src)
     {
       return os << "INVALID-POINTER";
     }
-    else if(src.operands().size() == 1)
-    {
-      const auto &unary_expr = to_unary_expr(src);
-      const auto &pointer_type = to_pointer_type(src.type());
-      return os << "pointer(" << format(unary_expr.op()) << ", "
-                << format(pointer_type.base_type()) << ')';
-    }
     else
     {
       const auto &pointer_type = to_pointer_type(src.type());
@@ -306,6 +299,12 @@ void format_expr_configt::setup()
   expr_map[ID_constant] =
     [](std::ostream &os, const exprt &expr) -> std::ostream & {
     return format_rec(os, to_constant_expr(expr));
+  };
+
+  expr_map[ID_annotated_pointer_constant] =
+    [](std::ostream &os, const exprt &expr) -> std::ostream & {
+    const auto &annotated_pointer = to_annotated_pointer_constant_expr(expr);
+    return os << format(annotated_pointer.symbolic_pointer());
   };
 
   expr_map[ID_typecast] =

--- a/src/util/irep_ids.def
+++ b/src/util/irep_ids.def
@@ -867,6 +867,7 @@ IREP_ID_ONE(empty_union)
 IREP_ID_ONE(bitreverse)
 IREP_ID_ONE(saturating_minus)
 IREP_ID_ONE(saturating_plus)
+IREP_ID_ONE(annotated_pointer_constant)
 
 // Projects depending on this code base that wish to extend the list of
 // available ids should provide a file local_irep_ids.def in their source tree

--- a/src/util/pointer_expr.h
+++ b/src/util/pointer_expr.h
@@ -794,4 +794,83 @@ inline const w_ok_exprt &to_w_ok_expr(const exprt &expr)
   return ret;
 }
 
+/// \brief Pointer-typed bitvector constant annotated with the pointer
+/// expression that the bitvector is the numeric representation of.
+/// This variation of a constant expression is only used in the context of a
+/// GOTO trace, to give both the numeric value and the symbolic value of a
+/// pointer, e.g. numeric value "0xabcd0004" but symbolic value
+/// "&some_object + 4". The numeric value is stored in the usual value slot and
+/// the symbolic value is accessed using the `symbolic_pointer` method
+/// introduced by this class.
+class annotated_pointer_constant_exprt : public unary_exprt
+{
+public:
+  annotated_pointer_constant_exprt(
+    const irep_idt &_value,
+    const exprt &_pointer)
+    : unary_exprt(ID_annotated_pointer_constant, _pointer, _pointer.type())
+  {
+    set_value(_value);
+  }
+
+  const irep_idt &get_value() const
+  {
+    return get(ID_value);
+  }
+
+  void set_value(const irep_idt &value)
+  {
+    set(ID_value, value);
+  }
+
+  exprt &symbolic_pointer()
+  {
+    return op0();
+  }
+
+  const exprt &symbolic_pointer() const
+  {
+    return op0();
+  }
+};
+
+template <>
+inline bool can_cast_expr<annotated_pointer_constant_exprt>(const exprt &base)
+{
+  return base.id() == ID_annotated_pointer_constant;
+}
+
+inline void validate_expr(const annotated_pointer_constant_exprt &value)
+{
+  validate_operands(
+    value, 1, "Annotated pointer constant must have one operand");
+}
+
+/// \brief Cast an exprt to an \ref annotated_pointer_constant_exprt
+///
+/// \a expr must be known to be \ref annotated_pointer_constant_exprt.
+///
+/// \param expr: Source expression
+/// \return Object of type \ref annotated_pointer_constant_exprt
+inline const annotated_pointer_constant_exprt &
+to_annotated_pointer_constant_expr(const exprt &expr)
+{
+  PRECONDITION(expr.id() == ID_annotated_pointer_constant);
+  const annotated_pointer_constant_exprt &ret =
+    static_cast<const annotated_pointer_constant_exprt &>(expr);
+  validate_expr(ret);
+  return ret;
+}
+
+/// \copydoc to_annotated_pointer_constant_expr(const exprt &)
+inline annotated_pointer_constant_exprt &
+to_annotated_pointer_constant_expr(exprt &expr)
+{
+  PRECONDITION(expr.id() == ID_annotated_pointer_constant);
+  annotated_pointer_constant_exprt &ret =
+    static_cast<annotated_pointer_constant_exprt &>(expr);
+  validate_expr(ret);
+  return ret;
+}
+
 #endif // CPROVER_UTIL_POINTER_EXPR_H

--- a/src/util/std_expr.h
+++ b/src/util/std_expr.h
@@ -2799,11 +2799,11 @@ inline type_exprt &to_type_expr(exprt &expr)
 }
 
 /// \brief A constant literal expression
-class constant_exprt : public expr_protectedt
+class constant_exprt : public nullary_exprt
 {
 public:
   constant_exprt(const irep_idt &_value, typet _type)
-    : expr_protectedt(ID_constant, std::move(_type))
+    : nullary_exprt(ID_constant, std::move(_type))
   {
     set_value(_value);
   }
@@ -2825,6 +2825,11 @@ template <>
 inline bool can_cast_expr<constant_exprt>(const exprt &base)
 {
   return base.id() == ID_constant;
+}
+
+inline void validate_expr(const constant_exprt &value)
+{
+  validate_operands(value, 0, "Constants must not have operands");
 }
 
 /// \brief Cast an exprt to a \ref constant_exprt


### PR DESCRIPTION
The back-end previously created constant_exprt with an operand when
instantiating pointer-typed expressions with their solver-computed
model. This violates the contract of nullary_exprt, which a
constant_exprt is, and resulted in special-case treatment in several
places.

The annotated_pointer_constant_exprt formalises this concept of a
constant (as derived from the solver-computed model) with the additional
annotation of the original pointer that was instantiated.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
