### PR TITLE
remove usage of typet::subtype()

### DIFF
--- a/jbmc/src/java_bytecode/java_bytecode_convert_method.cpp
+++ b/jbmc/src/java_bytecode/java_bytecode_convert_method.cpp
@@ -2431,8 +2431,8 @@ void java_bytecode_convert_methodt::convert_athrow(
 {
   if(
     assert_no_exceptions_thrown ||
-    ((uncaught_exceptions_domaint::get_exception_type(op[0].type()) ==
-      "java::java.lang.AssertionError") &&
+    ((uncaught_exceptions_domaint::get_exception_type(
+        to_reference_type(op[0].type())) == "java::java.lang.AssertionError") &&
      !throw_assertion_error))
   {
     // we translate athrow into

--- a/jbmc/src/java_bytecode/java_types.h
+++ b/jbmc/src/java_bytecode/java_types.h
@@ -809,7 +809,8 @@ public:
 template <>
 inline bool can_cast_type<java_generic_parametert>(const typet &base)
 {
-  return is_reference(base) && is_java_generic_parameter_tag(base.subtype());
+  return is_reference(base) &&
+         is_java_generic_parameter_tag(to_reference_type(base).base_type());
 }
 
 /// Checks whether the type is a java generic parameter/variable, e.g., `T` in
@@ -937,7 +938,8 @@ public:
 template <>
 inline bool can_cast_type<java_generic_typet>(const typet &type)
 {
-  return is_reference(type) && is_java_generic_struct_tag_type(type.subtype());
+  return is_reference(type) &&
+         is_java_generic_struct_tag_type(to_reference_type(type).base_type());
 }
 
 /// \param type: the type to check

--- a/jbmc/unit/java_bytecode/java_bytecode_convert_class/convert_java_annotations.cpp
+++ b/jbmc/unit/java_bytecode/java_bytecode_convert_class/convert_java_annotations.cpp
@@ -37,7 +37,8 @@ SCENARIO(
         REQUIRE(annotations.size() == 1);
         const auto &annotation = annotations.front();
         const auto &identifier =
-          to_struct_tag_type(annotation.type.subtype()).get_identifier();
+          to_struct_tag_type(to_reference_type(annotation.type).base_type())
+            .get_identifier();
         REQUIRE(id2string(identifier) == "java::MyClassAnnotation");
         const auto &element_value_pair = annotation.element_value_pairs.front();
         const auto &element_name = element_value_pair.element_name;
@@ -64,7 +65,8 @@ SCENARIO(
         REQUIRE(annotations.size() == 1);
         const auto &annotation = annotations.front();
         const auto &identifier =
-          to_struct_tag_type(annotation.type.subtype()).get_identifier();
+          to_struct_tag_type(to_reference_type(annotation.type).base_type())
+            .get_identifier();
         REQUIRE(id2string(identifier) == "java::MyMethodAnnotation");
         const auto &element_value_pair = annotation.element_value_pairs.front();
         const auto &element_name = element_value_pair.element_name;

--- a/jbmc/unit/java_bytecode/java_bytecode_parser/parse_java_annotations.cpp
+++ b/jbmc/unit/java_bytecode/java_bytecode_parser/parse_java_annotations.cpp
@@ -93,8 +93,9 @@ SCENARIO(
         const auto &id =
           to_symbol_expr(element_value_pair.value).get_identifier();
         const auto &java_type = java_type_from_string(id2string(id));
-        const std::string &class_name =
-          id2string(to_struct_tag_type(java_type->subtype()).get_identifier());
+        const std::string &class_name = id2string(
+          to_struct_tag_type(to_reference_type(*java_type).base_type())
+            .get_identifier());
         REQUIRE(id2string(class_name) == "java::java.lang.String");
       }
     }

--- a/jbmc/unit/java_bytecode/java_trace_validation/java_trace_validation.cpp
+++ b/jbmc/unit/java_bytecode/java_trace_validation/java_trace_validation.cpp
@@ -30,9 +30,10 @@ TEST_CASE("java trace validation", "[core][java_trace_validation]")
     member_exprt(plain_expr, "member", java_int_type());
   const constant_exprt invalid_constant = constant_exprt("", java_int_type());
   const constant_exprt valid_constant = constant_exprt("0", java_int_type());
-  const index_exprt valid_index =
-    index_exprt(valid_symbol_expr, valid_constant);
-  const index_exprt index_plain = index_exprt(exprt(), exprt());
+  const index_exprt valid_index = index_exprt(
+    symbol_exprt("id", array_typet(typet(), nil_exprt())), valid_constant);
+  const index_exprt index_plain =
+    index_exprt(exprt(ID_nil, array_typet(typet(), nil_exprt())), exprt());
   const byte_extract_exprt byte_little_endian = byte_extract_exprt(
     ID_byte_extract_little_endian, exprt(), exprt(), typet());
   const byte_extract_exprt byte_big_endian =

--- a/src/analyses/does_remove_const.cpp
+++ b/src/analyses/does_remove_const.cpp
@@ -12,9 +12,10 @@ Author: Diffblue Ltd.
 #include "does_remove_const.h"
 
 #include <goto-programs/goto_program.h>
-#include <util/type.h>
-#include <util/std_code.h>
+
 #include <util/base_type.h>
+#include <util/pointer_expr.h>
+#include <util/std_code.h>
 
 /// A naive analysis to look for casts that remove const-ness from pointers.
 /// \param goto_program: the goto program to check
@@ -122,16 +123,20 @@ bool does_remove_constt::does_type_preserve_const_correctness(
 {
   while(target_type->id()==ID_pointer)
   {
-    bool direct_subtypes_at_least_as_const=
-      is_type_at_least_as_const_as(
-        target_type->subtype(), source_type->subtype());
+    PRECONDITION(source_type->id() == ID_pointer);
+
+    const auto &target_pointer_type = to_pointer_type(*target_type);
+    const auto &source_pointer_type = to_pointer_type(*source_type);
+
+    bool direct_subtypes_at_least_as_const = is_type_at_least_as_const_as(
+      target_pointer_type.base_type(), source_pointer_type.base_type());
     // We have a pointer to something, but the thing it is pointing to can't be
     // modified normally, but can through this pointer
     if(!direct_subtypes_at_least_as_const)
       return false;
     // Check the subtypes if they are pointers
-    target_type=&target_type->subtype();
-    source_type=&source_type->subtype();
+    target_type = &target_pointer_type.base_type();
+    source_type = &source_pointer_type.base_type();
   }
   return true;
 }

--- a/src/analyses/goto_check_c.cpp
+++ b/src/analyses/goto_check_c.cpp
@@ -1352,7 +1352,8 @@ void goto_check_ct::pointer_primitive_check(
       return;
   }
 
-  const auto size_of_expr_opt = size_of_expr(pointer.type().subtype(), ns);
+  const auto size_of_expr_opt =
+    size_of_expr(to_pointer_type(pointer.type()).base_type(), ns);
 
   const exprt size = !size_of_expr_opt.has_value()
                        ? from_integer(1, size_type())

--- a/src/analyses/goto_rw.cpp
+++ b/src/analyses/goto_rw.cpp
@@ -98,7 +98,8 @@ void rw_range_sett::get_objects_complex_imag(
 {
   const exprt &op = expr.op();
 
-  auto subtype_bits = pointer_offset_bits(op.type().subtype(), ns);
+  auto subtype_bits =
+    pointer_offset_bits(to_complex_type(op.type()).subtype(), ns);
   CHECK_RETURN(subtype_bits.has_value());
 
   range_spect sub_size = to_range_spect(*subtype_bits);

--- a/src/analyses/uncaught_exceptions_analysis.cpp
+++ b/src/analyses/uncaught_exceptions_analysis.cpp
@@ -15,17 +15,17 @@ Author: Cristina David
 #include "uncaught_exceptions_analysis.h"
 
 #include <util/namespace.h>
+#include <util/pointer_expr.h>
 #include <util/symbol_table.h>
 
 #include <goto-programs/goto_functions.h>
 
 /// Returns the compile type of an exception
-irep_idt uncaught_exceptions_domaint::get_exception_type(const typet &type)
+irep_idt
+uncaught_exceptions_domaint::get_exception_type(const pointer_typet &type)
 {
-  PRECONDITION(type.id()==ID_pointer);
-
-  if(type.subtype().id() == ID_struct_tag)
-    return to_struct_tag_type(type.subtype()).get_identifier();
+  if(type.base_type().id() == ID_struct_tag)
+    return to_struct_tag_type(type.base_type()).get_identifier();
   else
     return ID_empty;
 }
@@ -73,7 +73,8 @@ void uncaught_exceptions_domaint::transform(
   {
     const exprt &exc_symbol = get_exception_symbol(instruction.get_code());
     // retrieve the static type of the thrown exception
-    const irep_idt &type_id=get_exception_type(exc_symbol.type());
+    const irep_idt &type_id =
+      get_exception_type(to_pointer_type(exc_symbol.type()));
     join(type_id);
     // we must consider all the subtypes given that
     // the runtime type is a subtype of the static type

--- a/src/analyses/uncaught_exceptions_analysis.h
+++ b/src/analyses/uncaught_exceptions_analysis.h
@@ -20,6 +20,7 @@ Author: Cristina David
 
 class goto_functionst;
 class namespacet;
+class pointer_typet;
 
 /// defines the domain used by the uncaught  exceptions analysis
 class uncaught_exceptions_analysist;
@@ -41,7 +42,7 @@ class uncaught_exceptions_domaint
     stack_caught.clear();
   }
 
-  static irep_idt get_exception_type(const typet &type);
+  static irep_idt get_exception_type(const pointer_typet &);
 
   static exprt get_exception_symbol(const exprt &exor);
 

--- a/src/ansi-c/ansi_c_convert_type.cpp
+++ b/src/ansi-c/ansi_c_convert_type.cpp
@@ -53,11 +53,12 @@ void ansi_c_convert_typet::read_rec(const typet &type)
       c_storage_spec.asm_label =
         to_string_constant(type_with_subtypes.subtypes()[0]).get_value();
   }
-  else if(type.id()==ID_section &&
-          type.has_subtype() &&
-          type.subtype().id()==ID_string_constant)
+  else if(
+    type.id() == ID_section && type.has_subtype() &&
+    to_type_with_subtype(type).subtype().id() == ID_string_constant)
   {
-    c_storage_spec.section = to_string_constant(type.subtype()).get_value();
+    c_storage_spec.section =
+      to_string_constant(to_type_with_subtype(type).subtype()).get_value();
   }
   else if(type.id()==ID_const)
     c_qualifiers.is_constant=true;
@@ -69,7 +70,7 @@ void ansi_c_convert_typet::read_rec(const typet &type)
   {
     // this gets turned into the qualifier, uh
     c_qualifiers.is_atomic=true;
-    read_rec(type.subtype());
+    read_rec(to_type_with_subtype(type).subtype());
   }
   else if(type.id()==ID_char)
     char_cnt++;
@@ -228,18 +229,20 @@ void ansi_c_convert_typet::read_rec(const typet &type)
     constructor=true;
   else if(type.id()==ID_destructor)
     destructor=true;
-  else if(type.id()==ID_alias &&
-          type.has_subtype() &&
-          type.subtype().id()==ID_string_constant)
+  else if(
+    type.id() == ID_alias && type.has_subtype() &&
+    to_type_with_subtype(type).subtype().id() == ID_string_constant)
   {
-    c_storage_spec.alias = to_string_constant(type.subtype()).get_value();
+    c_storage_spec.alias =
+      to_string_constant(to_type_with_subtype(type).subtype()).get_value();
   }
   else if(type.id()==ID_frontend_pointer)
   {
     // We turn ID_frontend_pointer to ID_pointer
     // Pointers have a width, much like integers,
     // which is added here.
-    pointer_typet tmp(type.subtype(), config.ansi_c.pointer_width);
+    pointer_typet tmp(
+      to_type_with_subtype(type).subtype(), config.ansi_c.pointer_width);
     tmp.add_source_location()=type.source_location();
     const irep_idt typedef_identifier=type.get(ID_C_typedef);
     if(!typedef_identifier.empty())

--- a/src/ansi-c/ansi_c_entry_point.cpp
+++ b/src/ansi-c/ansi_c_entry_point.cpp
@@ -405,7 +405,7 @@ bool generate_ansi_c_start_function(
       {
         // assign argv[argc] to NULL
         const null_pointer_exprt null(
-          to_pointer_type(argv_symbol.type.subtype()));
+          to_pointer_type(to_array_type(argv_symbol.type).element_type()));
 
         index_exprt index_expr(
           argv_symbol.symbol_expr(), argc_symbol.symbol_expr());
@@ -422,7 +422,8 @@ bool generate_ansi_c_start_function(
         const symbolt &envp_size_symbol=ns.lookup("envp_size'");
 
         // assume envp[envp_size] is NULL
-        null_pointer_exprt null(to_pointer_type(envp_symbol.type.subtype()));
+        null_pointer_exprt null(
+          to_pointer_type(to_array_type(envp_symbol.type).element_type()));
 
         index_exprt index_expr(
           envp_symbol.symbol_expr(), envp_size_symbol.symbol_expr());

--- a/src/ansi-c/ansi_c_parser.cpp
+++ b/src/ansi-c/ansi_c_parser.cpp
@@ -171,7 +171,7 @@ ansi_c_id_classt ansi_c_parsert::get_class(const typet &type)
     }
   }
   else if(type.has_subtype())
-    return get_class(type.subtype());
+    return get_class(to_type_with_subtype(type).subtype());
 
   return ansi_c_id_classt::ANSI_C_SYMBOL;
 }

--- a/src/ansi-c/c_storage_spec.cpp
+++ b/src/ansi-c/c_storage_spec.cpp
@@ -46,11 +46,12 @@ void c_storage_spect::read(const typet &type)
       if(it->id()==ID_thread)
         is_thread_local=true;
   }
-  else if(type.id()==ID_alias &&
-          type.has_subtype() &&
-          type.subtype().id()==ID_string_constant)
+  else if(
+    type.id() == ID_alias && type.has_subtype() &&
+    to_type_with_subtype(type).subtype().id() == ID_string_constant)
   {
-    alias = to_string_constant(type.subtype()).get_value();
+    alias =
+      to_string_constant(to_type_with_subtype(type).subtype()).get_value();
   }
   else if(
     type.id() == ID_asm && !to_type_with_subtypes(type).subtypes().empty() &&
@@ -59,10 +60,11 @@ void c_storage_spect::read(const typet &type)
     asm_label =
       to_string_constant(to_type_with_subtypes(type).subtypes()[0]).get_value();
   }
-  else if(type.id()==ID_section &&
-          type.has_subtype() &&
-          type.subtype().id()==ID_string_constant)
+  else if(
+    type.id() == ID_section && type.has_subtype() &&
+    to_type_with_subtype(type).subtype().id() == ID_string_constant)
   {
-    section = to_string_constant(type.subtype()).get_value();
+    section =
+      to_string_constant(to_type_with_subtype(type).subtype()).get_value();
   }
 }

--- a/src/ansi-c/c_typecheck_base.cpp
+++ b/src/ansi-c/c_typecheck_base.cpp
@@ -237,10 +237,11 @@ void c_typecheck_baset::typecheck_redefinition_type(
       // under Windows, ignore this silently;
       // MSC doesn't think this is a problem, but GCC complains.
     }
-    else if(config.ansi_c.os==configt::ansi_ct::ost::OS_WIN &&
-            final_new.id()==ID_pointer && final_old.id()==ID_pointer &&
-            follow(final_new.subtype()).id()==ID_c_enum &&
-            follow(final_old.subtype()).id()==ID_c_enum)
+    else if(
+      config.ansi_c.os == configt::ansi_ct::ost::OS_WIN &&
+      final_new.id() == ID_pointer && final_old.id() == ID_pointer &&
+      follow(to_pointer_type(final_new).base_type()).id() == ID_c_enum &&
+      follow(to_pointer_type(final_old).base_type()).id() == ID_c_enum)
     {
       // under Windows, ignore this silently;
       // MSC doesn't think this is a problem, but GCC complains.
@@ -268,20 +269,23 @@ void c_typecheck_baset::typecheck_redefinition_non_type(
   const typet &final_old=follow(old_symbol.type);
   const typet &initial_new=follow(new_symbol.type);
 
-  if(final_old.id()==ID_array &&
-     to_array_type(final_old).size().is_not_nil() &&
-     initial_new.id()==ID_array &&
-     to_array_type(initial_new).size().is_nil() &&
-     final_old.subtype()==initial_new.subtype())
+  if(
+    final_old.id() == ID_array &&
+    to_array_type(final_old).size().is_not_nil() &&
+    initial_new.id() == ID_array &&
+    to_array_type(initial_new).size().is_nil() &&
+    to_array_type(final_old).element_type() ==
+      to_array_type(initial_new).element_type())
   {
     // this is ok, just use old type
     new_symbol.type=old_symbol.type;
   }
-  else if(final_old.id()==ID_array &&
-          to_array_type(final_old).size().is_nil() &&
-          initial_new.id()==ID_array &&
-          to_array_type(initial_new).size().is_not_nil() &&
-          final_old.subtype()==initial_new.subtype())
+  else if(
+    final_old.id() == ID_array && to_array_type(final_old).size().is_nil() &&
+    initial_new.id() == ID_array &&
+    to_array_type(initial_new).size().is_not_nil() &&
+    to_array_type(final_old).element_type() ==
+      to_array_type(initial_new).element_type())
   {
     // update the type to enable the use of sizeof(x) on the
     // right-hand side of a definition of x
@@ -410,18 +414,21 @@ void c_typecheck_baset::typecheck_redefinition_non_type(
 
   if(final_old!=final_new)
   {
-    if(final_old.id()==ID_array &&
-       to_array_type(final_old).size().is_nil() &&
-       final_new.id()==ID_array &&
-       to_array_type(final_new).size().is_not_nil() &&
-       final_old.subtype()==final_new.subtype())
+    if(
+      final_old.id() == ID_array && to_array_type(final_old).size().is_nil() &&
+      final_new.id() == ID_array &&
+      to_array_type(final_new).size().is_not_nil() &&
+      to_array_type(final_old).element_type() ==
+        to_array_type(final_new).element_type())
     {
       old_symbol.type=new_symbol.type;
     }
     else if(
-      final_old.id() == ID_pointer && final_old.subtype().id() == ID_code &&
-      to_code_type(final_old.subtype()).has_ellipsis() &&
-      final_new.id() == ID_pointer && final_new.subtype().id() == ID_code)
+      final_old.id() == ID_pointer &&
+      to_pointer_type(final_old).base_type().id() == ID_code &&
+      to_code_type(to_pointer_type(final_old).base_type()).has_ellipsis() &&
+      final_new.id() == ID_pointer &&
+      to_pointer_type(final_new).base_type().id() == ID_code)
     {
       // to allow
       // int (*f) ();
@@ -429,9 +436,11 @@ void c_typecheck_baset::typecheck_redefinition_non_type(
       old_symbol.type=new_symbol.type;
     }
     else if(
-      final_old.id() == ID_pointer && final_old.subtype().id() == ID_code &&
-      final_new.id() == ID_pointer && final_new.subtype().id() == ID_code &&
-      to_code_type(final_new.subtype()).has_ellipsis())
+      final_old.id() == ID_pointer &&
+      to_pointer_type(final_old).base_type().id() == ID_code &&
+      final_new.id() == ID_pointer &&
+      to_pointer_type(final_new).base_type().id() == ID_code &&
+      to_code_type(to_pointer_type(final_new).base_type()).has_ellipsis())
     {
       // to allow
       // int (*f) (int)=0;

--- a/src/ansi-c/c_typecheck_code.cpp
+++ b/src/ansi-c/c_typecheck_code.cpp
@@ -367,9 +367,12 @@ bool c_typecheck_baset::is_complete_type(const typet &type) const
 {
   if(type.id() == ID_array)
   {
-    if(to_array_type(type).size().is_nil())
+    const auto &array_type = to_array_type(type);
+
+    if(array_type.size().is_nil())
       return false;
-    return is_complete_type(type.subtype());
+
+    return is_complete_type(array_type.element_type());
   }
   else if(type.id()==ID_struct || type.id()==ID_union)
   {
@@ -383,7 +386,7 @@ bool c_typecheck_baset::is_complete_type(const typet &type) const
         return false;
   }
   else if(type.id()==ID_vector)
-    return is_complete_type(type.subtype());
+    return is_complete_type(to_vector_type(type).element_type());
   else if(type.id() == ID_struct_tag || type.id() == ID_union_tag)
   {
     return is_complete_type(follow(type));

--- a/src/ansi-c/c_typecheck_gcc_polymorphic_builtins.cpp
+++ b/src/ansi-c/c_typecheck_gcc_polymorphic_builtins.cpp
@@ -51,9 +51,11 @@ static symbol_exprt typecheck_sync_with_pointer_parameter(
     throw 0;
   }
 
+  const auto &pointer_type = to_pointer_type(ptr_arg.type());
+
   code_typet t{{code_typet::parametert(ptr_arg.type()),
-                code_typet::parametert(ptr_arg.type().subtype())},
-               ptr_arg.type().subtype()};
+                code_typet::parametert(pointer_type.base_type())},
+               pointer_type.base_type()};
   t.make_ellipsis();
   symbol_exprt result{identifier, std::move(t)};
   result.add_source_location() = source_location;
@@ -88,14 +90,14 @@ static symbol_exprt typecheck_sync_compare_swap(
     throw 0;
   }
 
-  const typet &subtype = ptr_arg.type().subtype();
-  typet sync_return_type = subtype;
+  const typet &base_type = to_pointer_type(ptr_arg.type()).base_type();
+  typet sync_return_type = base_type;
   if(identifier == ID___sync_bool_compare_and_swap)
     sync_return_type = c_bool_type();
 
   code_typet t{{code_typet::parametert(ptr_arg.type()),
-                code_typet::parametert(subtype),
-                code_typet::parametert(subtype)},
+                code_typet::parametert(base_type),
+                code_typet::parametert(base_type)},
                sync_return_type};
   t.make_ellipsis();
   symbol_exprt result{identifier, std::move(t)};
@@ -168,7 +170,7 @@ static symbol_exprt typecheck_atomic_load_n(
   const code_typet t(
     {code_typet::parametert(ptr_arg.type()),
      code_typet::parametert(signed_int_type())},
-    ptr_arg.type().subtype());
+    to_pointer_type(ptr_arg.type()).base_type());
   symbol_exprt result(identifier, t);
   result.add_source_location() = source_location;
   return result;
@@ -200,9 +202,11 @@ static symbol_exprt typecheck_atomic_store_n(
     throw 0;
   }
 
+  const auto &base_type = to_pointer_type(ptr_arg.type()).base_type();
+
   const code_typet t(
     {code_typet::parametert(ptr_arg.type()),
-     code_typet::parametert(ptr_arg.type().subtype()),
+     code_typet::parametert(base_type),
      code_typet::parametert(signed_int_type())},
     void_type());
   symbol_exprt result(identifier, t);
@@ -236,11 +240,13 @@ static symbol_exprt typecheck_atomic_exchange_n(
     throw 0;
   }
 
+  const auto &base_type = to_pointer_type(ptr_arg.type()).base_type();
+
   const code_typet t(
     {code_typet::parametert(ptr_arg.type()),
-     code_typet::parametert(ptr_arg.type().subtype()),
+     code_typet::parametert(base_type),
      code_typet::parametert(signed_int_type())},
-    ptr_arg.type().subtype());
+    base_type);
   symbol_exprt result(identifier, t);
   result.add_source_location() = source_location;
   return result;
@@ -398,7 +404,8 @@ static symbol_exprt typecheck_atomic_compare_exchange(
   if(identifier == ID___atomic_compare_exchange)
     parameters.push_back(code_typet::parametert(ptr_arg.type()));
   else
-    parameters.push_back(code_typet::parametert(ptr_arg.type().subtype()));
+    parameters.push_back(
+      code_typet::parametert(to_pointer_type(ptr_arg.type()).base_type()));
 
   parameters.push_back(code_typet::parametert(c_bool_type()));
   parameters.push_back(code_typet::parametert(signed_int_type()));
@@ -438,9 +445,9 @@ static symbol_exprt typecheck_atomic_op_fetch(
 
   code_typet t(
     {code_typet::parametert(ptr_arg.type()),
-     code_typet::parametert(ptr_arg.type().subtype()),
+     code_typet::parametert(to_pointer_type(ptr_arg.type()).base_type()),
      code_typet::parametert(signed_int_type())},
-    ptr_arg.type().subtype());
+    to_pointer_type(ptr_arg.type()).base_type());
   symbol_exprt result(identifier, std::move(t));
   result.add_source_location() = source_location;
   return result;
@@ -475,9 +482,9 @@ static symbol_exprt typecheck_atomic_fetch_op(
 
   code_typet t(
     {code_typet::parametert(ptr_arg.type()),
-     code_typet::parametert(ptr_arg.type().subtype()),
+     code_typet::parametert(to_pointer_type(ptr_arg.type()).base_type()),
      code_typet::parametert(signed_int_type())},
-    ptr_arg.type().subtype());
+    to_pointer_type(ptr_arg.type()).base_type());
   symbol_exprt result(identifier, std::move(t));
   result.add_source_location() = source_location;
   return result;

--- a/src/ansi-c/c_typecheck_initializer.cpp
+++ b/src/ansi-c/c_typecheck_initializer.cpp
@@ -76,30 +76,32 @@ exprt c_typecheck_baset::do_initializer_rec(
   if(
     value.id() == ID_array && value.get_bool(ID_C_string_constant) &&
     full_type.id() == ID_array &&
-    (full_type.subtype().id() == ID_signedbv ||
-     full_type.subtype().id() == ID_unsignedbv) &&
-    to_bitvector_type(full_type.subtype()).get_width() ==
-      to_bitvector_type(value.type().subtype()).get_width())
+    (to_array_type(full_type).element_type().id() == ID_signedbv ||
+     to_array_type(full_type).element_type().id() == ID_unsignedbv) &&
+    to_bitvector_type(to_array_type(full_type).element_type()).get_width() ==
+      to_bitvector_type(to_array_type(value.type()).element_type()).get_width())
   {
     exprt tmp=value;
 
     // adjust char type
-    tmp.type().subtype()=full_type.subtype();
+    to_array_type(tmp.type()).element_type() =
+      to_array_type(full_type).element_type();
 
     Forall_operands(it, tmp)
-      it->type()=full_type.subtype();
+      it->type() = to_array_type(full_type).element_type();
 
     if(full_type.id()==ID_array &&
        to_array_type(full_type).is_complete())
     {
+      const auto &array_type = to_array_type(full_type);
+
       // check size
-      const auto array_size =
-        numeric_cast<mp_integer>(to_array_type(full_type).size());
+      const auto array_size = numeric_cast<mp_integer>(array_type.size());
       if(!array_size.has_value())
       {
         error().source_location = value.source_location();
         error() << "array size needs to be constant, got "
-                << to_string(to_array_type(full_type).size()) << eom;
+                << to_string(array_type.size()) << eom;
         throw 0;
       }
 
@@ -120,13 +122,13 @@ exprt c_typecheck_baset::do_initializer_rec(
       {
         // fill up
         tmp.type()=type;
-        const auto zero =
-          zero_initializer(full_type.subtype(), value.source_location(), *this);
+        const auto zero = zero_initializer(
+          array_type.element_type(), value.source_location(), *this);
         if(!zero.has_value())
         {
           error().source_location = value.source_location();
           error() << "cannot zero-initialize array with subtype '"
-                  << to_string(full_type.subtype()) << "'" << eom;
+                  << to_string(array_type.element_type()) << "'" << eom;
           throw 0;
         }
         tmp.operands().resize(numeric_cast_v<std::size_t>(*array_size), *zero);
@@ -138,16 +140,16 @@ exprt c_typecheck_baset::do_initializer_rec(
 
   if(
     value.id() == ID_string_constant && full_type.id() == ID_array &&
-    (full_type.subtype().id() == ID_signedbv ||
-     full_type.subtype().id() == ID_unsignedbv) &&
-    to_bitvector_type(full_type.subtype()).get_width() ==
+    (to_array_type(full_type).element_type().id() == ID_signedbv ||
+     to_array_type(full_type).element_type().id() == ID_unsignedbv) &&
+    to_bitvector_type(to_array_type(full_type).element_type()).get_width() ==
       char_type().get_width())
   {
     // will go away, to be replaced by the above block
 
     string_constantt tmp1=to_string_constant(value);
     // adjust char type
-    tmp1.type().subtype()=full_type.subtype();
+    tmp1.type().subtype() = to_array_type(full_type).element_type();
 
     exprt tmp2=tmp1.to_array_expr();
 
@@ -182,13 +184,16 @@ exprt c_typecheck_baset::do_initializer_rec(
       {
         // fill up
         tmp2.type()=type;
-        const auto zero =
-          zero_initializer(full_type.subtype(), value.source_location(), *this);
+        const auto zero = zero_initializer(
+          to_array_type(full_type).element_type(),
+          value.source_location(),
+          *this);
         if(!zero.has_value())
         {
           error().source_location = value.source_location();
           error() << "cannot zero-initialize array with subtype '"
-                  << to_string(full_type.subtype()) << "'" << eom;
+                  << to_string(to_array_type(full_type).element_type()) << "'"
+                  << eom;
           throw 0;
         }
         tmp2.operands().resize(numeric_cast_v<std::size_t>(*array_size), *zero);
@@ -410,8 +415,9 @@ exprt::operandst::const_iterator c_typecheck_baset::do_designated_initializer(
         if(!array_size.has_value())
         {
           error().source_location = value.source_location();
-          error() << "cannot zero-initialize array with subtype '"
-                  << to_string(full_type.subtype()) << "'" << eom;
+          error() << "cannot zero-initialize array with element type '"
+                  << to_string(to_type_with_subtype(full_type).subtype()) << "'"
+                  << eom;
           throw 0;
         }
         const exprt zero = to_array_of_expr(*dest).what();
@@ -427,12 +433,15 @@ exprt::operandst::const_iterator c_typecheck_baset::do_designated_initializer(
         {
           // we are willing to grow an incomplete or zero-sized array
           const auto zero = zero_initializer(
-            full_type.subtype(), value.source_location(), *this);
+            to_array_type(full_type).element_type(),
+            value.source_location(),
+            *this);
           if(!zero.has_value())
           {
             error().source_location = value.source_location();
-            error() << "cannot zero-initialize array with subtype '"
-                    << to_string(full_type.subtype()) << "'" << eom;
+            error() << "cannot zero-initialize array with element type '"
+                    << to_string(to_type_with_subtype(full_type).subtype())
+                    << "'" << eom;
             throw 0;
           }
           dest->operands().resize(
@@ -644,8 +653,8 @@ exprt::operandst::const_iterator c_typecheck_baset::do_designated_initializer(
       // initialize an array of scalars.
       if(
         full_type.id() == ID_array &&
-        (full_type.subtype().id() == ID_signedbv ||
-         full_type.subtype().id() == ID_unsignedbv))
+        (to_array_type(full_type).element_type().id() == ID_signedbv ||
+         to_array_type(full_type).element_type().id() == ID_unsignedbv))
       {
         *dest=do_initializer_rec(value, type, force_constant);
         return ++init_it; // done
@@ -822,7 +831,7 @@ designatort c_typecheck_baset::make_designator(
 
       entry.index = numeric_cast_v<std::size_t>(index);
       entry.size = numeric_cast_v<std::size_t>(size);
-      entry.subtype=full_type.subtype();
+      entry.subtype = to_array_type(full_type).element_type();
     }
     else if(full_type.id()==ID_struct ||
             full_type.id()==ID_union)
@@ -933,9 +942,9 @@ exprt c_typecheck_baset::do_initializer_list(
   if(
     full_type.id() == ID_array && value.operands().size() >= 1 &&
     to_multi_ary_expr(value).op0().id() == ID_string_constant &&
-    (full_type.subtype().id() == ID_signedbv ||
-     full_type.subtype().id() == ID_unsignedbv) &&
-    to_bitvector_type(full_type.subtype()).get_width() ==
+    (to_array_type(full_type).element_type().id() == ID_signedbv ||
+     to_array_type(full_type).element_type().id() == ID_unsignedbv) &&
+    to_bitvector_type(to_array_type(full_type).element_type()).get_width() ==
       char_type().get_width())
   {
     if(value.operands().size() > 1)

--- a/src/ansi-c/padding.cpp
+++ b/src/ansi-c/padding.cpp
@@ -58,7 +58,7 @@ mp_integer alignment(const typet &type, const namespacet &ns)
   mp_integer result;
 
   if(type.id()==ID_array)
-    result=alignment(type.subtype(), ns);
+    result = alignment(to_array_type(type).element_type(), ns);
   else if(type.id()==ID_struct || type.id()==ID_union)
   {
     result=1;
@@ -78,7 +78,7 @@ mp_integer alignment(const typet &type, const namespacet &ns)
     result = *pointer_offset_size(type, ns);
   }
   else if(type.id()==ID_c_enum)
-    result=alignment(type.subtype(), ns);
+    result = alignment(to_c_enum_type(type).underlying_type(), ns);
   else if(type.id()==ID_c_enum_tag)
     result=alignment(ns.follow_tag(to_c_enum_tag_type(type)), ns);
   else if(type.id() == ID_struct_tag)
@@ -88,7 +88,7 @@ mp_integer alignment(const typet &type, const namespacet &ns)
   else if(type.id()==ID_c_bit_field)
   {
     // we align these according to the 'underlying type'
-    result=alignment(type.subtype(), ns);
+    result = alignment(to_c_bit_field_type(type).underlying_type(), ns);
   }
   else
     result=1;

--- a/src/ansi-c/type2name.cpp
+++ b/src/ansi-c/type2name.cpp
@@ -251,7 +251,8 @@ static std::string type2name(
   if(type.has_subtype())
   {
     result+='{';
-    result+=type2name(type.subtype(), ns, symbol_number);
+    result +=
+      type2name(to_type_with_subtype(type).subtype(), ns, symbol_number);
     result+='}';
   }
 

--- a/src/cpp/cpp_convert_type.cpp
+++ b/src/cpp/cpp_convert_type.cpp
@@ -94,7 +94,8 @@ void cpp_convert_typet::read_rec(const typet &type)
   else if(type.id()==ID_frontend_pointer)
   {
     // add width and turn into ID_pointer
-    pointer_typet tmp(type.subtype(), config.ansi_c.pointer_width);
+    pointer_typet tmp(
+      to_type_with_subtype(type).subtype(), config.ansi_c.pointer_width);
     tmp.add_source_location()=type.source_location();
     if(type.get_bool(ID_C_reference))
       tmp.set(ID_C_reference, true);

--- a/src/cpp/cpp_declarator_converter.h
+++ b/src/cpp/cpp_declarator_converter.h
@@ -82,8 +82,9 @@ protected:
 
   bool is_code_type(const typet &type) const
   {
-    return type.id()==ID_code ||
-           (type.id()==ID_template && type.subtype().id()==ID_code);
+    return type.id() == ID_code ||
+           (type.id() == ID_template &&
+            to_template_type(type).subtype().id() == ID_code);
   }
 
   void combine_types(

--- a/src/cpp/cpp_exception_id.cpp
+++ b/src/cpp/cpp_exception_id.cpp
@@ -28,12 +28,14 @@ void cpp_exception_list_rec(
     if(src.get_bool(ID_C_reference))
     {
       // do not change
-      cpp_exception_list_rec(src.subtype(), ns, suffix, dest);
+      cpp_exception_list_rec(
+        to_reference_type(src).base_type(), ns, suffix, dest);
     }
     else
     {
       // append suffix _ptr
-      cpp_exception_list_rec(src.subtype(), ns, "_ptr"+suffix, dest);
+      cpp_exception_list_rec(
+        to_reference_type(src).base_type(), ns, "_ptr" + suffix, dest);
     }
   }
   else if(src.id() == ID_union_tag)

--- a/src/cpp/cpp_is_pod.cpp
+++ b/src/cpp/cpp_is_pod.cpp
@@ -71,7 +71,7 @@ bool cpp_typecheckt::cpp_is_pod(const typet &type) const
   }
   else if(type.id()==ID_array)
   {
-    return cpp_is_pod(type.subtype());
+    return cpp_is_pod(to_array_type(type).element_type());
   }
   else if(type.id()==ID_pointer)
   {

--- a/src/cpp/cpp_template_type.h
+++ b/src/cpp/cpp_template_type.h
@@ -33,6 +33,8 @@ public:
   {
     return (const template_parameterst &)find(ID_template_parameters).get_sub();
   }
+
+  using typet::subtype;
 };
 
 inline template_typet &to_template_type(typet &type)
@@ -50,7 +52,7 @@ inline const template_typet &to_template_type(const typet &type)
 inline const typet &template_subtype(const typet &type)
 {
   if(type.id()==ID_template)
-    return type.subtype();
+    return to_type_with_subtype(type).subtype();
 
   return type;
 }

--- a/src/cpp/cpp_type2name.cpp
+++ b/src/cpp/cpp_type2name.cpp
@@ -120,11 +120,11 @@ std::string cpp_type2name(const typet &type)
   else if(type.id()==ID_pointer)
   {
     if(is_reference(type))
-      result+="ref_"+cpp_type2name(type.subtype());
+      result += "ref_" + cpp_type2name(to_reference_type(type).base_type());
     else if(is_rvalue_reference(type))
-      result+="rref_"+cpp_type2name(type.subtype());
+      result += "rref_" + cpp_type2name(to_pointer_type(type).base_type());
     else
-      result+="ptr_"+cpp_type2name(type.subtype());
+      result += "ptr_" + cpp_type2name(to_pointer_type(type).base_type());
   }
   else if(type.id()==ID_signedbv || type.id()==ID_unsignedbv)
   {

--- a/src/cpp/cpp_typecheck.cpp
+++ b/src/cpp/cpp_typecheck.cpp
@@ -13,6 +13,7 @@ Author: Daniel Kroening, kroening@cs.cmu.edu
 
 #include <algorithm>
 
+#include <util/pointer_expr.h>
 #include <util/source_location.h>
 #include <util/symbol.h>
 
@@ -68,7 +69,7 @@ const struct_typet &cpp_typecheckt::this_struct_type()
   assert(this_expr.is_not_nil());
   assert(this_expr.type().id()==ID_pointer);
 
-  const typet &t=follow(this_expr.type().subtype());
+  const typet &t = follow(to_pointer_type(this_expr.type()).base_type());
   assert(t.id()==ID_struct);
   return to_struct_type(t);
 }

--- a/src/cpp/cpp_typecheck_compound_type.cpp
+++ b/src/cpp/cpp_typecheck_compound_type.cpp
@@ -524,7 +524,8 @@ void cpp_typecheckt::typecheck_compound_declarator(
           assert(!code_type.parameters().empty());
           const typet &pointer_type=code_type.parameters()[0].type();
           assert(pointer_type.id()==ID_pointer);
-          virtual_bases.insert(pointer_type.subtype().get(ID_identifier));
+          virtual_bases.insert(
+            to_pointer_type(pointer_type).base_type().get(ID_identifier));
         }
       }
     }
@@ -1704,11 +1705,11 @@ void cpp_typecheckt::make_ptr_typecast(
   assert(src_type.id()==  ID_pointer);
   assert(dest_type.id()== ID_pointer);
 
-  const struct_typet &src_struct =
-    to_struct_type(static_cast<const typet &>(follow(src_type.subtype())));
+  const struct_typet &src_struct = to_struct_type(
+    static_cast<const typet &>(follow(to_pointer_type(src_type).base_type())));
 
-  const struct_typet &dest_struct =
-    to_struct_type(static_cast<const typet &>(follow(dest_type.subtype())));
+  const struct_typet &dest_struct = to_struct_type(
+    static_cast<const typet &>(follow(to_pointer_type(dest_type).base_type())));
 
   PRECONDITION(
     subtype_typecast(src_struct, dest_struct) ||

--- a/src/cpp/cpp_typecheck_constructor.cpp
+++ b/src/cpp/cpp_typecheck_constructor.cpp
@@ -224,7 +224,7 @@ void cpp_typecheckt::default_cpctor(
       const cpp_namet cppname(mem_c.get_base_name(), source_location);
 
       const symbolt &virtual_table_symbol_type =
-        lookup(mem_c.type().subtype().get(ID_identifier));
+        lookup(to_pointer_type(mem_c.type()).base_type().get(ID_identifier));
 
       const symbolt &virtual_table_symbol_var = lookup(
         id2string(virtual_table_symbol_type.name) + "@" +
@@ -676,7 +676,7 @@ void cpp_typecheckt::full_member_initialization(
       const cpp_namet cppname(c.get_base_name(), c.source_location());
 
       const symbolt &virtual_table_symbol_type =
-        lookup(c.type().subtype().get(ID_identifier));
+        lookup(to_pointer_type(c.type()).base_type().get(ID_identifier));
 
       const symbolt &virtual_table_symbol_var  =
         lookup(id2string(virtual_table_symbol_type.name) + "@" +
@@ -785,8 +785,12 @@ bool cpp_typecheckt::find_cpctor(const symbolt &symbol) const
     if(!is_reference(parameter1_type))
       continue;
 
-    if(parameter1_type.subtype().get(ID_identifier)!=symbol.name)
+    if(
+      to_reference_type(parameter1_type).base_type().get(ID_identifier) !=
+      symbol.name)
+    {
       continue;
+    }
 
     bool defargs=true;
     for(std::size_t i=2; i<parameters.size(); i++)
@@ -835,7 +839,9 @@ bool cpp_typecheckt::find_assignop(const symbolt &symbol) const
     if(!is_reference(arg1_type))
       continue;
 
-    if(arg1_type.subtype().get(ID_identifier)!=symbol.name)
+    if(
+      to_reference_type(arg1_type).base_type().get(ID_identifier) !=
+      symbol.name)
       continue;
 
     return true;

--- a/src/cpp/cpp_typecheck_destructor.cpp
+++ b/src/cpp/cpp_typecheck_destructor.cpp
@@ -73,7 +73,7 @@ codet cpp_typecheckt::dtor(const symbolt &symbol, const symbol_exprt &this_expr)
       const cpp_namet cppname(c.get_base_name());
 
       const symbolt &virtual_table_symbol_type =
-        lookup(c.type().subtype().get(ID_identifier));
+        lookup(to_pointer_type(c.type()).base_type().get(ID_identifier));
 
       const symbolt &virtual_table_symbol_var = lookup(
         id2string(virtual_table_symbol_type.name) + "@" +

--- a/src/cpp/cpp_typecheck_function.cpp
+++ b/src/cpp/cpp_typecheck_function.cpp
@@ -184,7 +184,7 @@ irep_idt cpp_typecheckt::function_identifier(const typet &type)
   if(it != parameters.end() && it->get_this())
   {
     const typet &pointer=it->type();
-    const typet &symbol =pointer.subtype();
+    const typet &symbol = to_pointer_type(pointer).base_type();
     if(symbol.get_bool(ID_C_constant))
       result += "$const";
     if(symbol.get_bool(ID_C_volatile))

--- a/src/cpp/expr2cpp.cpp
+++ b/src/cpp/expr2cpp.cpp
@@ -20,6 +20,7 @@ Author: Daniel Kroening, kroening@cs.cmu.edu
 #include <ansi-c/expr2c_class.h>
 
 #include "cpp_name.h"
+#include "cpp_template_type.h"
 
 class expr2cppt:public expr2ct
 {
@@ -139,11 +140,11 @@ std::string expr2cppt::convert_rec(
 
   if(is_reference(src))
   {
-    return q+convert(src.subtype())+" &"+d;
+    return q + convert(to_reference_type(src).base_type()) + " &" + d;
   }
   else if(is_rvalue_reference(src))
   {
-    return q+convert(src.subtype())+" &&"+d;
+    return q + convert(to_pointer_type(src).base_type()) + " &&" + d;
   }
   else if(!src.get(ID_C_c_type).empty())
   {
@@ -254,7 +255,7 @@ std::string expr2cppt::convert_rec(
       }
     }
 
-    dest+="> "+convert(src.subtype());
+    dest += "> " + convert(to_template_type(src).subtype());
     return dest;
   }
   else if(src.id()==ID_pointer && src.subtype().id()==ID_nullptr)

--- a/src/goto-instrument/dump_c.cpp
+++ b/src/goto-instrument/dump_c.cpp
@@ -394,7 +394,11 @@ void dump_ct::convert_compound(
     if(!recursive)
       return;
 
-    convert_compound(type.subtype(), type.subtype(), recursive, os);
+    convert_compound(
+      to_type_with_subtype(type).subtype(),
+      to_type_with_subtype(type).subtype(),
+      recursive,
+      os);
 
     // sizeof may contain a type symbol that has to be declared first
     if(type.id()==ID_array)
@@ -491,7 +495,7 @@ void dump_ct::convert_compound(
 
     const typet *non_array_type = &comp_type;
     while(non_array_type->id()==ID_array)
-      non_array_type = &(non_array_type->subtype());
+      non_array_type = &(to_array_type(*non_array_type).element_type());
 
     if(recursive)
     {
@@ -725,7 +729,8 @@ void dump_ct::collect_typedefs_rec(
   }
   else if(type.id()==ID_pointer || type.id()==ID_array)
   {
-    collect_typedefs_rec(type.subtype(), early, local_deps);
+    collect_typedefs_rec(
+      to_type_with_subtype(type).subtype(), early, local_deps);
   }
   else if(
     type.id() == ID_c_enum_tag || type.id() == ID_struct_tag ||

--- a/src/goto-instrument/generate_function_bodies.cpp
+++ b/src/goto-instrument/generate_function_bodies.cpp
@@ -280,7 +280,9 @@ protected:
       const symbolt &parameter_symbol = ns.lookup(parameter);
       if(
         parameter_symbol.type.id() == ID_pointer &&
-        !parameter_symbol.type.subtype().get_bool(ID_C_constant) &&
+        !to_pointer_type(parameter_symbol.type)
+           .base_type()
+           .get_bool(ID_C_constant) &&
         should_havoc_param(id2string(parameter_symbol.base_name), i))
       {
         auto goto_instruction =
@@ -289,7 +291,8 @@ protected:
             null_pointer_exprt(to_pointer_type(parameter_symbol.type)))));
 
         dereference_exprt dereference_expr(
-          parameter_symbol.symbol_expr(), parameter_symbol.type.subtype());
+          parameter_symbol.symbol_expr(),
+          to_pointer_type(parameter_symbol.type).base_type());
 
         goto_programt dest;
         havoc_expr_rec(

--- a/src/goto-instrument/goto_program2code.cpp
+++ b/src/goto-instrument/goto_program2code.cpp
@@ -1394,7 +1394,7 @@ void goto_program2codet::add_local_types(const typet &type)
   else if(type.id()==ID_pointer ||
           type.id()==ID_array)
   {
-    add_local_types(type.subtype());
+    add_local_types(to_type_with_subtype(type).subtype());
   }
 }
 

--- a/src/goto-programs/adjust_float_expressions.cpp
+++ b/src/goto-programs/adjust_float_expressions.cpp
@@ -44,7 +44,8 @@ static bool have_to_adjust_float_expressions(const exprt &expr)
 
   if(
     type.id() == ID_floatbv ||
-    (type.id() == ID_complex && type.subtype().id() == ID_floatbv))
+    (type.id() == ID_complex &&
+     to_complex_type(type).subtype().id() == ID_floatbv))
   {
     if(
       expr.id() == ID_plus || expr.id() == ID_minus || expr.id() == ID_mult ||
@@ -98,7 +99,8 @@ void adjust_float_expressions(exprt &expr, const exprt &rounding_mode)
 
   if(
     type.id() == ID_floatbv ||
-    (type.id() == ID_complex && type.subtype().id() == ID_floatbv))
+    (type.id() == ID_complex &&
+     to_complex_type(type).subtype().id() == ID_floatbv))
   {
     if(
       expr.id() == ID_plus || expr.id() == ID_minus || expr.id() == ID_mult ||

--- a/src/goto-programs/builtin_functions.cpp
+++ b/src/goto-programs/builtin_functions.cpp
@@ -276,7 +276,8 @@ void goto_convertt::do_scanf(
               const index_exprt new_lhs(
                 dereference_exprt{ptr}, from_integer(0, c_index_type()));
               const side_effect_expr_nondett rhs(
-                type->subtype(), function.source_location());
+                to_array_type(*type).element_type(),
+                function.source_location());
               code_assignt assign(new_lhs, rhs);
               assign.add_source_location()=function.source_location();
               copy(assign, ASSIGN, dest);
@@ -441,7 +442,8 @@ void goto_convertt::do_cpp_new(
     if(new_array)
       new_call.arguments().push_back(count);
     new_call.arguments().push_back(object_size);
-    new_call.set(ID_C_cxx_alloc_type, lhs.type().subtype());
+    new_call.set(
+      ID_C_cxx_alloc_type, to_type_with_subtype(lhs.type()).subtype());
     new_call.lhs()=tmp_symbol_expr;
     new_call.add_source_location()=rhs.source_location();
 
@@ -472,7 +474,8 @@ void goto_convertt::do_cpp_new(
       new_call.arguments().push_back(count);
     new_call.arguments().push_back(object_size);
     new_call.arguments().push_back(to_unary_expr(rhs).op()); // memory location
-    new_call.set(ID_C_cxx_alloc_type, lhs.type().subtype());
+    new_call.set(
+      ID_C_cxx_alloc_type, to_type_with_subtype(lhs.type()).subtype());
     new_call.lhs()=tmp_symbol_expr;
     new_call.add_source_location()=rhs.source_location();
 
@@ -521,7 +524,8 @@ void goto_convertt::cpp_new_initializer(
     else if(rhs.get_statement()==ID_cpp_new)
     {
       // just one object
-      const dereference_exprt deref_lhs(lhs, rhs.type().subtype());
+      const dereference_exprt deref_lhs(
+        lhs, to_pointer_type(rhs.type()).base_type());
 
       replace_new_object(deref_lhs, initializer);
       convert(to_code(initializer), dest, ID_cpp);

--- a/src/goto-programs/compute_called_functions.cpp
+++ b/src/goto-programs/compute_called_functions.cpp
@@ -30,7 +30,7 @@ void compute_address_taken_functions(
 
     if(
       address.type().id() == ID_pointer &&
-      address.type().subtype().id() == ID_code)
+      to_pointer_type(address.type()).base_type().id() == ID_code)
     {
       const exprt &target = address.object();
       if(target.id() == ID_symbol)

--- a/src/goto-programs/destructor.cpp
+++ b/src/goto-programs/destructor.cpp
@@ -13,6 +13,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "goto_instruction_code.h"
 
 #include <util/namespace.h>
+#include <util/pointer_expr.h>
 
 code_function_callt get_destructor(
   const namespacet &ns,
@@ -37,8 +38,9 @@ code_function_callt get_destructor(
         {
           const typet &arg_type=code_type.parameters().front().type();
 
-          if(arg_type.id()==ID_pointer &&
-             ns.follow(arg_type.subtype())==type)
+          if(
+            arg_type.id() == ID_pointer &&
+            ns.follow(to_pointer_type(arg_type).base_type()) == type)
           {
             const symbol_exprt symbol_expr(it->get(ID_name), it->type());
             return code_function_callt(symbol_expr);

--- a/src/goto-programs/goto_inline_class.cpp
+++ b/src/goto-programs/goto_inline_class.cpp
@@ -81,11 +81,11 @@ void goto_inlinet::parameter_assignments(
         const typet &f_acttype = actual.type();
 
         // we are willing to do some conversion
-        if((f_partype.id()==ID_pointer &&
-            f_acttype.id()==ID_pointer) ||
-           (f_partype.id()==ID_pointer &&
-            f_acttype.id()==ID_array &&
-            f_partype.subtype()==f_acttype.subtype()))
+        if(
+          (f_partype.id() == ID_pointer && f_acttype.id() == ID_pointer) ||
+          (f_partype.id() == ID_pointer && f_acttype.id() == ID_array &&
+           to_type_with_subtype(f_partype).subtype() ==
+             to_type_with_subtype(f_acttype).subtype()))
         {
           actual = typecast_exprt(actual, f_partype);
         }

--- a/src/goto-programs/interpreter.cpp
+++ b/src/goto-programs/interpreter.cpp
@@ -488,7 +488,7 @@ exprt interpretert::get_value(
     // Get size of array
     array_exprt result({}, to_array_type(real_type));
     const exprt &size_expr = to_array_type(type).size();
-    mp_integer subtype_size=get_size(type.subtype());
+    mp_integer subtype_size = get_size(to_array_type(type).element_type());
     mp_integer count;
     if(size_expr.id()!=ID_constant)
     {
@@ -503,9 +503,8 @@ exprt interpretert::get_value(
     result.reserve_operands(numeric_cast_v<std::size_t>(count));
     for(mp_integer i=0; i<count; ++i)
     {
-      const exprt operand=get_value(
-        type.subtype(),
-        offset+i*subtype_size);
+      const exprt operand = get_value(
+        to_array_type(type).element_type(), offset + i * subtype_size);
       result.copy_to_operands(operand);
     }
     return std::move(result);
@@ -556,7 +555,7 @@ exprt interpretert::get_value(
     const exprt &size_expr = to_array_type(real_type).size();
 
     // Get size of array
-    mp_integer subtype_size=get_size(type.subtype());
+    mp_integer subtype_size = get_size(to_array_type(type).element_type());
 
     mp_integer count;
     if(unbounded_size(type))
@@ -572,8 +571,8 @@ exprt interpretert::get_value(
     result.reserve_operands(numeric_cast_v<std::size_t>(count));
     for(mp_integer i=0; i<count; ++i)
     {
-      const exprt operand=get_value(type.subtype(), rhs,
-          offset+i*subtype_size);
+      const exprt operand = get_value(
+        to_array_type(type).element_type(), rhs, offset + i * subtype_size);
       result.copy_to_operands(operand);
     }
     return std::move(result);
@@ -895,10 +894,9 @@ typet interpretert::concretize_type(const typet &type)
     {
       output.result() << "Concretized array with size " << computed_size[0]
                       << messaget::eom;
-      return
-        array_typet(
-          type.subtype(),
-          from_integer(computed_size[0], integer_typet()));
+      return array_typet(
+        to_array_type(type).element_type(),
+        from_integer(computed_size[0], integer_typet()));
     }
     else
     {
@@ -949,7 +947,7 @@ bool interpretert::unbounded_size(const typet &type)
     const exprt &size=to_array_type(type).size();
     if(size.id()==ID_infinity)
       return true;
-    return unbounded_size(type.subtype());
+    return unbounded_size(to_array_type(type).element_type());
   }
   else if(type.id()==ID_struct)
   {
@@ -1008,7 +1006,7 @@ mp_integer interpretert::get_size(const typet &type)
   {
     const exprt &size_expr = to_array_type(type).size();
 
-    mp_integer subtype_size=get_size(type.subtype());
+    mp_integer subtype_size = get_size(to_array_type(type).element_type());
 
     mp_vectort i = evaluate(size_expr);
     if(i.size()==1)

--- a/src/goto-programs/interpreter_evaluate.cpp
+++ b/src/goto-programs/interpreter_evaluate.cpp
@@ -445,13 +445,14 @@ interpretert::mp_vectort interpretert::evaluate(const exprt &expr)
     {
       if(show)
         output.error() << "heap memory allocation not fully implemented "
-                       << expr.type().subtype().pretty() << messaget::eom;
+                       << to_pointer_type(expr.type()).base_type().pretty()
+                       << messaget::eom;
       std::stringstream buffer;
       num_dynamic_objects++;
       buffer << "interpreter::dynamic_object" << num_dynamic_objects;
       irep_idt id(buffer.str().c_str());
-      mp_integer address =
-        build_memory_map(symbol_exprt{id, expr.type().subtype()});
+      mp_integer address = build_memory_map(
+        symbol_exprt{id, to_pointer_type(expr.type()).base_type()});
       // TODO: check array of type
       // TODO: interpret zero-initialization argument
       return {address};
@@ -954,7 +955,7 @@ interpretert::mp_vectort interpretert::evaluate(const exprt &expr)
     mp_vectort where = evaluate(wexpr.where());
     mp_vectort new_value = evaluate(wexpr.new_value());
 
-    const auto &subtype=expr.type().subtype();
+    const auto &subtype = to_array_type(expr.type()).element_type();
 
     if(!new_value.empty() && where.size()==1 && !unbounded_size(subtype))
     {

--- a/src/goto-programs/remove_complex.cpp
+++ b/src/goto-programs/remove_complex.cpp
@@ -86,7 +86,7 @@ static bool have_to_remove_complex(const typet &type)
   else if(type.id()==ID_pointer ||
           type.id()==ID_vector ||
           type.id()==ID_array)
-    return have_to_remove_complex(type.subtype());
+    return have_to_remove_complex(to_type_with_subtype(type).subtype());
   else if(type.id()==ID_complex)
     return true;
 
@@ -180,7 +180,7 @@ static void remove_complex(exprt &expr)
     else if(expr.id()==ID_typecast)
     {
       auto const &typecast_expr = to_typecast_expr(expr);
-      typet subtype = typecast_expr.type().subtype();
+      typet subtype = to_complex_type(typecast_expr.type()).subtype();
 
       if(typecast_expr.op().type().id() == ID_struct)
       {

--- a/src/goto-programs/remove_const_function_pointers.cpp
+++ b/src/goto-programs/remove_const_function_pointers.cpp
@@ -784,10 +784,10 @@ bool remove_const_function_pointerst::is_const_expression(
 ///   arrays are implicitly const in C.
 bool remove_const_function_pointerst::is_const_type(const typet &type) const
 {
-  if(type.id() == ID_array && type.subtype().get_bool(ID_C_constant))
-    return true;
-
-  return type.get_bool(ID_C_constant);
+  if(type.id() == ID_array)
+    return to_array_type(type).element_type().get_bool(ID_C_constant);
+  else
+    return type.get_bool(ID_C_constant);
 }
 
 /// To extract the value of the specific component within a struct

--- a/src/goto-programs/remove_vector.cpp
+++ b/src/goto-programs/remove_vector.cpp
@@ -78,7 +78,7 @@ static bool have_to_remove_vector(const typet &type)
   else if(type.id()==ID_pointer ||
           type.id()==ID_complex ||
           type.id()==ID_array)
-    return have_to_remove_vector(type.subtype());
+    return have_to_remove_vector(to_type_with_subtype(type).subtype());
   else if(type.id()==ID_vector)
     return true;
 
@@ -182,7 +182,8 @@ static void remove_vector(exprt &expr)
       operands.reserve(dimension);
 
       const bool is_float =
-        binary_expr.lhs().type().subtype().id() == ID_floatbv;
+        to_array_type(binary_expr.lhs().type()).element_type().id() ==
+        ID_floatbv;
       irep_idt new_id;
       if(binary_expr.id() == ID_vector_notequal)
       {

--- a/src/goto-programs/remove_virtual_functions.cpp
+++ b/src/goto-programs/remove_virtual_functions.cpp
@@ -15,6 +15,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/expr_iterator.h>
 #include <util/expr_util.h>
 #include <util/fresh_symbol.h>
+#include <util/pointer_expr.h>
 #include <util/prefix.h>
 #include <util/symbol_table.h>
 
@@ -329,7 +330,7 @@ static goto_programt::targett replace_virtual_function_with_dispatch_table(
   INVARIANT(
     this_expr.type().id() == ID_pointer, "this parameter must be a pointer");
   INVARIANT(
-    this_expr.type().subtype() != empty_typet(),
+    to_pointer_type(this_expr.type()).base_type() != empty_typet(),
     "this parameter must not be a void pointer");
 
   // So long as `this` is already not `void*` typed, the second parameter

--- a/src/goto-programs/string_instrumentation.cpp
+++ b/src/goto-programs/string_instrumentation.cpp
@@ -144,10 +144,11 @@ protected:
 
   bool is_string_type(const typet &t) const
   {
-    return
-      (t.id()==ID_pointer || t.id()==ID_array) &&
-      (t.subtype().id()==ID_signedbv || t.subtype().id()==ID_unsignedbv) &&
-      (to_bitvector_type(t.subtype()).get_width()==config.ansi_c.char_width);
+    return (t.id() == ID_pointer || t.id() == ID_array) &&
+           (to_type_with_subtype(t).subtype().id() == ID_signedbv ||
+            to_type_with_subtype(t).subtype().id() == ID_unsignedbv) &&
+           (to_bitvector_type(to_type_with_subtype(t).subtype()).get_width() ==
+            config.ansi_c.char_width);
   }
 
   void invalidate_buffer(
@@ -841,7 +842,9 @@ void string_instrumentationt::invalidate_buffer(
   else
   {
     index_exprt index(
-      buffer, from_integer(0, c_index_type()), buf_type.subtype());
+      buffer,
+      from_integer(0, c_index_type()),
+      to_type_with_subtype(buf_type).subtype());
     bufp=address_of_exprt(index);
   }
 

--- a/src/goto-symex/symex_dereference.cpp
+++ b/src/goto-symex/symex_dereference.cpp
@@ -65,7 +65,7 @@ exprt goto_symext::address_arithmetic(
       // turn &a of type T[i][j] into &(a[0][0])
       for(const typet *t = &(a.type().subtype());
           t->id() == ID_array && expr.type() != *t;
-          t = &(t->subtype()))
+          t = &(to_array_type(*t).element_type()))
         a.object() = index_exprt(a.object(), from_integer(0, c_index_type()));
     }
 
@@ -83,7 +83,7 @@ exprt goto_symext::address_arithmetic(
     typet dest_type_subtype;
 
     if(expr_type.id()==ID_array && !keep_array)
-      dest_type_subtype=expr_type.subtype();
+      dest_type_subtype = to_array_type(expr_type).element_type();
     else
       dest_type_subtype=expr_type;
 
@@ -174,7 +174,7 @@ exprt goto_symext::address_arithmetic(
     typet dest_type_subtype;
 
     if(expr_type.id() == ID_array && !keep_array)
-      dest_type_subtype = expr_type.subtype();
+      dest_type_subtype = to_array_type(expr_type).element_type();
     else
       dest_type_subtype = expr_type;
 

--- a/src/goto-symex/symex_function_call.cpp
+++ b/src/goto-symex/symex_function_call.cpp
@@ -299,10 +299,11 @@ void goto_symext::symex_function_call_post_clean(
       {
         if(
           arg.type().id() == ID_pointer &&
-          !arg.type().subtype().get_bool(ID_C_constant) &&
-          arg.type().subtype().id() != ID_code)
+          !to_pointer_type(arg.type()).base_type().get_bool(ID_C_constant) &&
+          to_pointer_type(arg.type()).base_type().id() != ID_code)
         {
-          exprt object = dereference_exprt(arg, arg.type().subtype());
+          exprt object =
+            dereference_exprt(arg, to_pointer_type(arg.type()).base_type());
           exprt cleaned_object = clean_expr(object, state, true);
           const guardt guard(true_exprt(), state.guard_manager);
           havoc_rec(state, guard, cleaned_object);

--- a/src/linking/linking.cpp
+++ b/src/linking/linking.cpp
@@ -119,7 +119,9 @@ std::string linkingt::type_to_string_verbose(
   }
   else if(followed.id()==ID_pointer)
   {
-    return type_to_string_verbose(symbol, followed.subtype()) + " *";
+    return type_to_string_verbose(
+             symbol, to_pointer_type(followed).base_type()) +
+           " *";
   }
 
   return type_to_string(symbol.name, type);
@@ -147,8 +149,11 @@ void linkingt::detailed_conflict_report_rec(
   else if(t1.id()==ID_pointer ||
           t1.id()==ID_array)
   {
-    if(depth>0 &&
-       !base_type_eq(t1.subtype(), t2.subtype(), ns))
+    if(
+      depth > 0 && !base_type_eq(
+                     to_type_with_subtype(t1).subtype(),
+                     to_type_with_subtype(t2).subtype(),
+                     ns))
     {
       if(conflict_path.type().id() == ID_pointer)
         conflict_path = dereference_exprt(conflict_path);
@@ -156,9 +161,9 @@ void linkingt::detailed_conflict_report_rec(
       detailed_conflict_report_rec(
         old_symbol,
         new_symbol,
-        t1.subtype(),
-        t2.subtype(),
-        depth-1,
+        to_type_with_subtype(t1).subtype(),
+        to_type_with_subtype(t2).subtype(),
+        depth - 1,
         conflict_path);
     }
     else if(t1.id()==ID_pointer)
@@ -267,11 +272,17 @@ void linkingt::detailed_conflict_report_rec(
     const c_enum_typet::memberst &members2=
       to_c_enum_type(t2).members();
 
-    if(t1.subtype()!=t2.subtype())
+    if(
+      to_c_enum_type(t1).underlying_type() !=
+      to_c_enum_type(t2).underlying_type())
     {
       msg="enum value types are different (";
-      msg += type_to_string(old_symbol.name, t1.subtype()) + '/';
-      msg += type_to_string(new_symbol.name, t2.subtype()) + ')';
+      msg +=
+        type_to_string(old_symbol.name, to_c_enum_type(t1).underlying_type()) +
+        '/';
+      msg +=
+        type_to_string(new_symbol.name, to_c_enum_type(t2).underlying_type()) +
+        ')';
     }
     else if(members1.size()!=members2.size())
     {
@@ -915,8 +926,10 @@ bool linkingt::adjust_object_type_rec(
 
     return false;
   }
-  else if(t1.id()==ID_array &&
-          !adjust_object_type_rec(t1.subtype(), t2.subtype(), info))
+  else if(
+    t1.id() == ID_array &&
+    !adjust_object_type_rec(
+      to_array_type(t1).element_type(), to_array_type(t2).element_type(), info))
   {
     // still need to compare size
     const exprt &old_size=to_array_type(t1).size();
@@ -1180,9 +1193,12 @@ void linkingt::duplicate_type_symbol(
     return;
   }
 
-  if(old_symbol.type.id()==ID_array &&
-     new_symbol.type.id()==ID_array &&
-     base_type_eq(old_symbol.type.subtype(), new_symbol.type.subtype(), ns))
+  if(
+    old_symbol.type.id() == ID_array && new_symbol.type.id() == ID_array &&
+    base_type_eq(
+      to_array_type(old_symbol.type).element_type(),
+      to_array_type(new_symbol.type).element_type(),
+      ns))
   {
     if(to_array_type(old_symbol.type).size().is_nil() &&
        to_array_type(new_symbol.type).size().is_not_nil())
@@ -1252,9 +1268,12 @@ bool linkingt::needs_renaming_type(
     to_union_type(new_symbol.type).is_incomplete())
     return false; // not different
 
-  if(old_symbol.type.id()==ID_array &&
-     new_symbol.type.id()==ID_array &&
-     base_type_eq(old_symbol.type.subtype(), new_symbol.type.subtype(), ns))
+  if(
+    old_symbol.type.id() == ID_array && new_symbol.type.id() == ID_array &&
+    base_type_eq(
+      to_array_type(old_symbol.type).element_type(),
+      to_array_type(new_symbol.type).element_type(),
+      ns))
   {
     if(to_array_type(old_symbol.type).size().is_nil() &&
        to_array_type(new_symbol.type).size().is_not_nil())

--- a/src/memory-analyzer/analyze_symbol.h
+++ b/src/memory-analyzer/analyze_symbol.h
@@ -22,6 +22,7 @@ Author: Malte Mues <mail.mues@gmail.com>
 
 #include <util/message.h>
 #include <util/namespace.h>
+#include <util/pointer_expr.h>
 #include <util/std_code.h>
 #include <util/symbol_table.h>
 
@@ -329,8 +330,9 @@ private:
   /// \param pointer_value: pointer value to be analyzed
   /// \param expected_type: type of the potential member
   /// \return true if pointing to a member
-  bool
-  points_to_member(pointer_valuet &pointer_value, const typet &expected_type);
+  bool points_to_member(
+    pointer_valuet &pointer_value,
+    const pointer_typet &expected_type);
 };
 
 #endif // CPROVER_MEMORY_ANALYZER_ANALYZE_SYMBOL_H

--- a/src/pointer-analysis/value_set_analysis_fi.cpp
+++ b/src/pointer-analysis/value_set_analysis_fi.cpp
@@ -12,6 +12,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "value_set_analysis_fi.h"
 
+#include <util/pointer_expr.h>
 #include <util/symbol_table.h>
 
 void value_set_analysis_fit::initialize(
@@ -102,7 +103,8 @@ void value_set_analysis_fit::get_entries_rec(
   }
   else if(t.id()==ID_array)
   {
-    get_entries_rec(identifier, suffix+"[]", t.subtype(), dest);
+    get_entries_rec(
+      identifier, suffix + "[]", to_array_type(t).element_type(), dest);
   }
   else if(check_type(t))
   {
@@ -163,7 +165,8 @@ bool value_set_analysis_fit::check_type(const typet &type)
         if(type.id()==ID_pointer)
         {
           const typet *t = &type;
-          while(t->id()==ID_pointer) t = &(t->subtype());
+          while(t->id() == ID_pointer)
+            t = &(to_pointer_type(*t).base_type());
 
           return (t->id()==ID_code);
         }
@@ -184,7 +187,7 @@ bool value_set_analysis_fit::check_type(const typet &type)
     }
   }
   else if(type.id()==ID_array)
-    return check_type(type.subtype());
+    return check_type(to_array_type(type).element_type());
   else if(type.id() == ID_struct_tag || type.id() == ID_union_tag)
     return check_type(ns.follow(type));
 

--- a/src/solvers/flattening/arrays.cpp
+++ b/src/solvers/flattening/arrays.cpp
@@ -359,7 +359,8 @@ void arrayst::add_array_Ackermann_constraints()
 
           if(indices_equal_lit!=const_literal(false))
           {
-            const typet &subtype = arrays[i].type().subtype();
+            const typet &subtype =
+              to_array_type(arrays[i].type()).element_type();
             index_exprt index_expr1(arrays[i], *i1, subtype);
 
             index_exprt index_expr2=index_expr1;
@@ -438,11 +439,13 @@ void arrayst::add_array_constraints_equality(
 
   for(const auto &index : index_set)
   {
-    const typet &subtype1 = array_equality.f1.type().subtype();
-    index_exprt index_expr1(array_equality.f1, index, subtype1);
+    const typet &element_type1 =
+      to_array_type(array_equality.f1.type()).element_type();
+    index_exprt index_expr1(array_equality.f1, index, element_type1);
 
-    const typet &subtype2 = array_equality.f2.type().subtype();
-    index_exprt index_expr2(array_equality.f2, index, subtype2);
+    const typet &element_type2 =
+      to_array_type(array_equality.f2.type()).element_type();
+    index_exprt index_expr2(array_equality.f2, index, element_type2);
 
     DATA_INVARIANT(
       index_expr1.type()==index_expr2.type(),
@@ -507,9 +510,9 @@ void arrayst::add_array_constraints(
     // add a[i]=b[i]
     for(const auto &index : index_set)
     {
-      const typet &subtype = expr.type().subtype();
-      index_exprt index_expr1(expr, index, subtype);
-      index_exprt index_expr2(expr_typecast_op, index, subtype);
+      const typet &element_type = to_array_type(expr.type()).element_type();
+      index_exprt index_expr1(expr, index, element_type);
+      index_exprt index_expr2(expr_typecast_op, index, element_type);
 
       DATA_INVARIANT(
         index_expr1.type()==index_expr2.type(),
@@ -548,7 +551,8 @@ void arrayst::add_array_constraints_with(
     const exprt &index = operands[i];
     const exprt &value = operands[i + 1];
 
-    index_exprt index_expr(expr, index, expr.type().subtype());
+    index_exprt index_expr(
+      expr, index, to_array_type(expr.type()).element_type());
 
     DATA_INVARIANT_WITH_DIAGNOSTICS(
       index_expr.type() == value.type(),
@@ -583,9 +587,9 @@ void arrayst::add_array_constraints_with(
 
       if(guard_lit!=const_literal(true))
       {
-        const typet &subtype = expr.type().subtype();
-        index_exprt index_expr1(expr, other_index, subtype);
-        index_exprt index_expr2(expr.old(), other_index, subtype);
+        const typet &element_type = to_array_type(expr.type()).element_type();
+        index_exprt index_expr1(expr, other_index, element_type);
+        index_exprt index_expr2(expr.old(), other_index, element_type);
 
         equal_exprt equality_expr(index_expr1, index_expr2);
 
@@ -814,9 +818,9 @@ void arrayst::add_array_constraints_if(
 
   for(const auto &index : index_set)
   {
-    const typet subtype = expr.type().subtype();
-    index_exprt index_expr1(expr, index, subtype);
-    index_exprt index_expr2(expr.true_case(), index, subtype);
+    const typet &element_type = to_array_type(expr.type()).element_type();
+    index_exprt index_expr1(expr, index, element_type);
+    index_exprt index_expr2(expr.true_case(), index, element_type);
 
     // add implication
     lazy_constraintt lazy(lazy_typet::ARRAY_IF,
@@ -833,9 +837,9 @@ void arrayst::add_array_constraints_if(
   // now the false case
   for(const auto &index : index_set)
   {
-    const typet subtype = expr.type().subtype();
-    index_exprt index_expr1(expr, index, subtype);
-    index_exprt index_expr2(expr.false_case(), index, subtype);
+    const typet &element_type = to_array_type(expr.type()).element_type();
+    index_exprt index_expr1(expr, index, element_type);
+    index_exprt index_expr2(expr.false_case(), index, element_type);
 
     // add implication
     lazy_constraintt lazy(

--- a/src/solvers/flattening/boolbv_add_sub.cpp
+++ b/src/solvers/flattening/boolbv_add_sub.cpp
@@ -53,8 +53,9 @@ bvt boolbvt::convert_add_sub(const exprt &expr)
   bool no_overflow=(expr.id()=="no-overflow-plus" ||
                     expr.id()=="no-overflow-minus");
 
-  typet arithmetic_type =
-    (type.id() == ID_vector || type.id() == ID_complex) ? type.subtype() : type;
+  typet arithmetic_type = (type.id() == ID_vector || type.id() == ID_complex)
+                            ? to_type_with_subtype(type).subtype()
+                            : type;
 
   bv_utilst::representationt rep=
     (arithmetic_type.id()==ID_signedbv ||
@@ -72,7 +73,8 @@ bvt boolbvt::convert_add_sub(const exprt &expr)
 
     if(type.id()==ID_vector || type.id()==ID_complex)
     {
-      std::size_t sub_width = boolbv_width(type.subtype());
+      std::size_t sub_width =
+        boolbv_width(to_type_with_subtype(type).subtype());
 
       INVARIANT(sub_width != 0, "vector elements shall have nonzero bit width");
       INVARIANT(
@@ -104,10 +106,11 @@ bvt boolbvt::convert_add_sub(const exprt &expr)
           tmp_result[j] = bv[index];
         }
 
-        if(type.subtype().id()==ID_floatbv)
+        if(to_type_with_subtype(type).subtype().id() == ID_floatbv)
         {
           // needs to change due to rounding mode
-          float_utilst float_utils(prop, to_floatbv_type(type.subtype()));
+          float_utilst float_utils(
+            prop, to_floatbv_type(to_type_with_subtype(type).subtype()));
           tmp_result=float_utils.add_sub(tmp_result, tmp_op, subtract);
         }
         else

--- a/src/solvers/flattening/boolbv_floatbv_op.cpp
+++ b/src/solvers/flattening/boolbv_floatbv_op.cpp
@@ -12,6 +12,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <iostream>
 
 #include <util/bitvector_types.h>
+#include <util/c_types.h>
 #include <util/floatbv_expr.h>
 
 #include <solvers/floatbv/float_utils.h>
@@ -34,7 +35,9 @@ bvt boolbvt::convert_floatbv_typecast(const floatbv_typecast_exprt &expr)
   {
     // go through underlying type
     return convert_floatbv_typecast(floatbv_typecast_exprt(
-      typecast_exprt(op0, src_type.subtype()), op1, dest_type));
+      typecast_exprt(op0, to_c_bit_field_type(src_type).underlying_type()),
+      op1,
+      dest_type));
   }
 
   float_utilst float_utils(prop);
@@ -116,7 +119,7 @@ bvt boolbvt::convert_floatbv_op(const ieee_float_op_exprt &expr)
   }
   else if(expr.type().id() == ID_vector || expr.type().id() == ID_complex)
   {
-    const typet &subtype = expr.type().subtype();
+    const typet &subtype = to_type_with_subtype(expr.type()).subtype();
 
     if(subtype.id()==ID_floatbv)
     {

--- a/src/solvers/flattening/boolbv_get.cpp
+++ b/src/solvers/flattening/boolbv_get.cpp
@@ -183,7 +183,7 @@ exprt boolbvt::bv_get_rec(
     }
     else if(type.id()==ID_complex)
     {
-      const typet &subtype = type.subtype();
+      const typet &subtype = to_complex_type(type).subtype();
       std::size_t sub_width=boolbv_width(subtype);
 
       if(sub_width!=0 && width==sub_width*2)
@@ -334,7 +334,8 @@ exprt boolbvt::bv_get_unbounded_array(const exprt &expr) const
         if(index_mpint.has_value())
         {
           if(value.is_nil())
-            values[*index_mpint] = exprt(ID_unknown, type.subtype());
+            values[*index_mpint] =
+              exprt(ID_unknown, to_array_type(type).subtype());
           else
             values[*index_mpint] = value;
         }

--- a/src/solvers/flattening/boolbv_typecast.cpp
+++ b/src/solvers/flattening/boolbv_typecast.cpp
@@ -64,7 +64,7 @@ bool boolbvt::type_conversion(
 
   if(dest_type.id()==ID_complex)
   {
-    if(src_type==dest_type.subtype())
+    if(src_type == to_complex_type(dest_type).subtype())
     {
       dest.insert(dest.end(), src.begin(), src.end());
 
@@ -81,9 +81,15 @@ bool boolbvt::type_conversion(
       lower.assign(src.begin(), src.begin()+src.size()/2);
       upper.assign(src.begin()+src.size()/2, src.end());
       type_conversion(
-        src_type.subtype(), lower, dest_type.subtype(), lower_res);
+        to_complex_type(src_type).subtype(),
+        lower,
+        to_complex_type(dest_type).subtype(),
+        lower_res);
       type_conversion(
-        src_type.subtype(), upper, dest_type.subtype(), upper_res);
+        to_complex_type(src_type).subtype(),
+        upper,
+        to_complex_type(dest_type).subtype(),
+        upper_res);
       INVARIANT(
         lower_res.size() + upper_res.size() == dest_width,
         "lower result bitvector size plus upper result bitvector size shall "
@@ -112,7 +118,8 @@ bool boolbvt::type_conversion(
       // is (T) __real__ x.
       bvt tmp_src(src);
       tmp_src.resize(src.size()/2); // cut off imag part
-      return type_conversion(src_type.subtype(), tmp_src, dest_type, dest);
+      return type_conversion(
+        to_complex_type(src_type).subtype(), tmp_src, dest_type, dest);
     }
   }
 

--- a/src/solvers/flattening/boolbv_unary_minus.cpp
+++ b/src/solvers/flattening/boolbv_unary_minus.cpp
@@ -36,7 +36,7 @@ bvt boolbvt::convert_unary_minus(const unary_minus_exprt &expr)
   if(bvtype==bvtypet::IS_UNKNOWN &&
      (type.id()==ID_vector || type.id()==ID_complex))
   {
-    const typet &subtype = type.subtype();
+    const typet &subtype = to_type_with_subtype(type).subtype();
 
     std::size_t sub_width=boolbv_width(subtype);
 
@@ -58,7 +58,7 @@ bvt boolbvt::convert_unary_minus(const unary_minus_exprt &expr)
       const auto sub_it = std::next(op_bv.begin(), sub_idx);
       std::copy_n(sub_it, sub_width, std::back_inserter(tmp_op));
 
-      if(type.subtype().id() == ID_floatbv)
+      if(subtype.id() == ID_floatbv)
       {
         float_utilst float_utils(prop, to_floatbv_type(subtype));
         tmp_op = float_utils.negate(tmp_op);

--- a/src/solvers/flattening/boolbv_width.cpp
+++ b/src/solvers/flattening/boolbv_width.cpp
@@ -160,7 +160,7 @@ const boolbv_widtht::entryt &boolbv_widtht::get_entry(const typet &type) const
   }
   else if(type_id==ID_complex)
   {
-    const mp_integer sub_width = operator()(type.subtype());
+    const mp_integer sub_width = operator()(to_complex_type(type).subtype());
     entry.total_width = numeric_cast_v<std::size_t>(2 * sub_width);
   }
   else if(type_id==ID_code)
@@ -176,7 +176,8 @@ const boolbv_widtht::entryt &boolbv_widtht::get_entry(const typet &type) const
   else if(type_id==ID_c_enum)
   {
     // these have a subtype
-    entry.total_width = to_bitvector_type(type.subtype()).get_width();
+    entry.total_width =
+      to_bitvector_type(to_c_enum_type(type).underlying_type()).get_width();
     CHECK_RETURN(entry.total_width > 0);
   }
   else if(type_id==ID_pointer)

--- a/src/solvers/flattening/boolbv_with.cpp
+++ b/src/solvers/flattening/boolbv_with.cpp
@@ -22,8 +22,12 @@ bvt boolbvt::convert_with(const with_exprt &expr)
   if(width==0)
   {
     // A zero-length array is acceptable:
-    if(expr.type().id()==ID_array && boolbv_width(expr.type().subtype())!=0)
+    if(
+      expr.type().id() == ID_array &&
+      boolbv_width(to_array_type(expr.type()).element_type()) != 0)
+    {
       return bvt();
+    }
     else
       return conversion_failed(expr);
   }

--- a/src/solvers/lowering/byte_operators.cpp
+++ b/src/solvers/lowering/byte_operators.cpp
@@ -428,8 +428,10 @@ static exprt::operandst instantiate_byte_array(
 
   PRECONDITION(src.type().id() == ID_array || src.type().id() == ID_vector);
   PRECONDITION(
-    can_cast_type<bitvector_typet>(src.type().subtype()) &&
-    to_bitvector_type(src.type().subtype()).get_width() == 8);
+    can_cast_type<bitvector_typet>(
+      to_type_with_subtype(src.type()).subtype()) &&
+    to_bitvector_type(to_type_with_subtype(src.type()).subtype()).get_width() ==
+      8);
   exprt::operandst bytes;
   bytes.reserve(upper_bound - lower_bound);
   for(std::size_t i = lower_bound; i < upper_bound; ++i)

--- a/src/solvers/smt2/smt2_format.cpp
+++ b/src/solvers/smt2/smt2_format.cpp
@@ -151,7 +151,9 @@ std::ostream &smt2_format_rec(std::ostream &out, const exprt &expr)
       out << "(store ";
 
     out << "((as const " << smt2_format(expr.type()) << ")) "
-        << smt2_format(from_integer(0, expr.type().subtype())) << ')';
+        << smt2_format(
+             from_integer(0, to_array_type(expr.type()).element_type()))
+        << ')';
 
     for(std::size_t i = 0; i < array_list_expr.operands().size(); i += 2)
     {

--- a/src/solvers/strings/array_pool.cpp
+++ b/src/solvers/strings/array_pool.cpp
@@ -78,8 +78,8 @@ array_string_exprt array_poolt::make_char_array_for_char_pointer(
   PRECONDITION(char_pointer.type().id() == ID_pointer);
   PRECONDITION(char_array_type.id() == ID_array);
   PRECONDITION(
-    char_array_type.subtype().id() == ID_unsignedbv ||
-    char_array_type.subtype().id() == ID_signedbv);
+    to_array_type(char_array_type).element_type().id() == ID_unsignedbv ||
+    to_array_type(char_array_type).element_type().id() == ID_signedbv);
 
   if(char_pointer.id() == ID_if)
   {
@@ -89,7 +89,7 @@ array_string_exprt array_poolt::make_char_array_for_char_pointer(
     const array_string_exprt f =
       make_char_array_for_char_pointer(if_expr.false_case(), char_array_type);
     const array_typet array_type(
-      char_array_type.subtype(),
+      to_array_type(char_array_type).element_type(),
       if_exprt(
         if_expr.cond(),
         to_array_type(t.type()).size(),
@@ -183,7 +183,8 @@ array_poolt::created_strings() const
 
 array_string_exprt array_poolt::find(const exprt &pointer, const exprt &length)
 {
-  const array_typet array_type(pointer.type().subtype(), length);
+  const array_typet array_type(
+    to_pointer_type(pointer.type()).base_type(), length);
   const array_string_exprt array =
     make_char_array_for_char_pointer(pointer, array_type);
   return array;

--- a/src/solvers/strings/string_builtin_function.cpp
+++ b/src/solvers/strings/string_builtin_function.cpp
@@ -90,7 +90,7 @@ optionalt<exprt> string_concat_char_builtin_functiont::eval(
   input_opt.value().push_back(char_val);
   const auto length =
     from_integer(input_opt.value().size(), result.length_type());
-  const array_typet type(result.type().subtype(), length);
+  const array_typet type(to_type_with_subtype(result.type()).subtype(), length);
   return make_string(input_opt.value(), type);
 }
 
@@ -137,7 +137,7 @@ optionalt<exprt> string_set_char_builtin_functiont::eval(
     input_opt.value()[numeric_cast_v<std::size_t>(*position_opt)] = *char_opt;
   const auto length =
     from_integer(input_opt.value().size(), result.length_type());
-  const array_typet type(result.type().subtype(), length);
+  const array_typet type(to_type_with_subtype(result.type()).subtype(), length);
   return make_string(input_opt.value(), type);
 }
 
@@ -226,7 +226,7 @@ optionalt<exprt> string_to_lower_case_builtin_functiont::eval(
   }
   const auto length =
     from_integer(input_opt.value().size(), result.length_type());
-  const array_typet type(result.type().subtype(), length);
+  const array_typet type(to_type_with_subtype(result.type()).subtype(), length);
   return make_string(input_opt.value(), type);
 }
 
@@ -292,7 +292,7 @@ string_constraintst string_to_lower_case_builtin_functiont::constraints(
     const exprt conditional_convert = [&] {
       // The difference between upper-case and lower-case for the basic
       // latin and latin-1 supplement is 0x20.
-      const typet &char_type = result.type().subtype();
+      const typet &char_type = to_type_with_subtype(result.type()).subtype();
       const exprt diff = from_integer(0x20, char_type);
       const exprt converted =
         equal_exprt(result[idx], plus_exprt(input[idx], diff));
@@ -320,7 +320,7 @@ optionalt<exprt> string_to_upper_case_builtin_functiont::eval(
   }
   const auto length =
     from_integer(input_opt.value().size(), result.length_type());
-  const array_typet type(result.type().subtype(), length);
+  const array_typet type(to_type_with_subtype(result.type()).subtype(), length);
   return make_string(input_opt.value(), type);
 }
 
@@ -341,7 +341,8 @@ string_constraintst string_to_upper_case_builtin_functiont::constraints(
   constraints.universal.push_back([&] {
     const symbol_exprt idx =
       fresh_symbol("QA_upper_case", result.length_type());
-    const typet &char_type = input.content().type().subtype();
+    const typet &char_type =
+      to_type_with_subtype(input.content().type()).subtype();
     const exprt converted =
       minus_exprt(input[idx], from_integer(0x20, char_type));
     return string_constraintt(
@@ -398,7 +399,8 @@ optionalt<exprt> string_of_int_builtin_functiont::eval(
 
   const auto length = right_to_left_characters.size();
   const auto length_expr = from_integer(length, result.length_type());
-  const array_typet type(result.type().subtype(), length_expr);
+  const array_typet type(
+    to_type_with_subtype(result.type()).subtype(), length_expr);
   return make_string(
     right_to_left_characters.rbegin(), right_to_left_characters.rend(), type);
 }

--- a/src/solvers/strings/string_concatenation_builtin_function.cpp
+++ b/src/solvers/strings/string_concatenation_builtin_function.cpp
@@ -177,7 +177,7 @@ string_constraint_generatort::add_axioms_for_concat_code_point(
   const array_string_exprt res =
     array_pool.find(f.arguments()[1], f.arguments()[0]);
   const array_string_exprt s1 = get_string_expr(array_pool, f.arguments()[2]);
-  const typet &char_type = s1.content().type().subtype();
+  const typet &char_type = to_type_with_subtype(s1.content().type()).subtype();
   const typet &index_type = s1.length_type();
   const array_string_exprt code_point =
     array_pool.fresh_string(index_type, char_type);

--- a/src/solvers/strings/string_constraint_generator_code_points.cpp
+++ b/src/solvers/strings/string_constraint_generator_code_points.cpp
@@ -25,7 +25,7 @@ string_constraint_generatort::add_axioms_for_code_point(
   const exprt &code_point)
 {
   string_constraintst constraints;
-  const typet &char_type = res.content().type().subtype();
+  const typet &char_type = to_type_with_subtype(res.content().type()).subtype();
   const typet &type = code_point.type();
   PRECONDITION(type.id() == ID_signedbv);
 

--- a/src/solvers/strings/string_constraint_generator_comparison.cpp
+++ b/src/solvers/strings/string_constraint_generator_comparison.cpp
@@ -141,7 +141,7 @@ string_constraint_generatort::add_axioms_for_equals_ignore_case(
   const symbol_exprt eq = fresh_symbol("equal_ignore_case");
   const array_string_exprt s1 = get_string_expr(array_pool, f.arguments()[0]);
   const array_string_exprt s2 = get_string_expr(array_pool, f.arguments()[1]);
-  const typet char_type = s1.content().type().subtype();
+  const typet char_type = to_type_with_subtype(s1.content().type()).subtype();
   const exprt char_a = from_integer('a', char_type);
   const exprt char_A = from_integer('A', char_type);
   const exprt char_Z = from_integer('Z', char_type);

--- a/src/solvers/strings/string_constraint_generator_constants.cpp
+++ b/src/solvers/strings/string_constraint_generator_constants.cpp
@@ -28,7 +28,7 @@ string_constraint_generatort::add_axioms_for_constant(
 {
   string_constraintst constraints;
   const typet index_type = array_pool.get_or_create_length(res).type();
-  const typet &char_type = res.content().type().subtype();
+  const typet &char_type = to_type_with_subtype(res.content().type()).subtype();
   std::string c_str = id2string(sval);
   std::wstring str;
 

--- a/src/solvers/strings/string_constraint_generator_float.cpp
+++ b/src/solvers/strings/string_constraint_generator_float.cpp
@@ -196,7 +196,7 @@ string_constraint_generatort::add_axioms_for_string_of_float(
 {
   const floatbv_typet &type = to_floatbv_type(f.type());
   const ieee_float_spect float_spec(type);
-  const typet &char_type = res.content().type().subtype();
+  const typet &char_type = to_type_with_subtype(res.content().type()).subtype();
   const typet &index_type = res.length_type();
 
   // We will look at the first 5 digits of the fractional part.
@@ -251,7 +251,7 @@ string_constraint_generatort::add_axioms_for_fractional_part(
   PRECONDITION(max_size >= 2);
   string_constraintst constraints;
   const typet &type = int_expr.type();
-  const typet &char_type = res.content().type().subtype();
+  const typet &char_type = to_type_with_subtype(res.content().type()).subtype();
   const typet &index_type = res.length_type();
   const exprt ten = from_integer(10, type);
   const exprt zero_char = from_integer('0', char_type);
@@ -344,7 +344,7 @@ string_constraint_generatort::add_axioms_from_float_scientific_notation(
   const typet float_type = float_spec.to_type();
   const signedbv_typet int_type(32);
   const typet &index_type = res.length_type();
-  const typet &char_type = res.content().type().subtype();
+  const typet &char_type = to_type_with_subtype(res.content().type()).subtype();
 
   // This is used for rounding float to integers.
   exprt round_to_zero_expr = from_integer(ieee_floatt::ROUND_TO_ZERO, int_type);

--- a/src/solvers/strings/string_constraint_generator_indexof.cpp
+++ b/src/solvers/strings/string_constraint_generator_indexof.cpp
@@ -310,7 +310,7 @@ string_constraint_generatort::add_axioms_for_index_of(
   const array_string_exprt str = get_string_expr(array_pool, args[0]);
   const exprt &c = args[1];
   const typet &index_type = str.length_type();
-  const typet &char_type = str.content().type().subtype();
+  const typet &char_type = to_type_with_subtype(str.content().type()).subtype();
   PRECONDITION(f.type() == index_type);
   const exprt from_index =
     args.size() == 2 ? from_integer(0, index_type) : args[2];
@@ -432,7 +432,7 @@ string_constraint_generatort::add_axioms_for_last_index_of(
   const array_string_exprt str = get_string_expr(array_pool, args[0]);
   const exprt c = args[1];
   const typet &index_type = str.length_type();
-  const typet &char_type = str.content().type().subtype();
+  const typet &char_type = to_type_with_subtype(str.content().type()).subtype();
   PRECONDITION(f.type() == index_type);
 
   const exprt from_index =

--- a/src/solvers/strings/string_constraint_generator_transformation.cpp
+++ b/src/solvers/strings/string_constraint_generator_transformation.cpp
@@ -46,7 +46,7 @@ string_constraint_generatort::add_axioms_for_set_length(
   const array_string_exprt s1 = get_string_expr(array_pool, f.arguments()[2]);
   const exprt &k = f.arguments()[3];
   const typet &index_type = s1.length_type();
-  const typet &char_type = s1.content().type().subtype();
+  const typet &char_type = to_type_with_subtype(s1.content().type()).subtype();
 
   // We add axioms:
   // a1 : |res|=max(k, 0)
@@ -186,7 +186,7 @@ string_constraint_generatort::add_axioms_for_trim(
   const array_string_exprt &res =
     array_pool.find(f.arguments()[1], f.arguments()[0]);
   const typet &index_type = str.length_type();
-  const typet &char_type = str.content().type().subtype();
+  const typet &char_type = to_type_with_subtype(str.content().type()).subtype();
   const symbol_exprt idx = fresh_symbol("index_trim", index_type);
   const exprt space_char = from_integer(' ', char_type);
 
@@ -381,7 +381,7 @@ string_constraint_generatort::add_axioms_for_delete(
   PRECONDITION(start.type() == str.length_type());
   PRECONDITION(end.type() == str.length_type());
   const typet &index_type = str.length_type();
-  const typet &char_type = str.content().type().subtype();
+  const typet &char_type = to_type_with_subtype(str.content().type()).subtype();
   const array_string_exprt sub1 =
     array_pool.fresh_string(index_type, char_type);
   const array_string_exprt sub2 =

--- a/src/solvers/strings/string_constraint_generator_valueof.cpp
+++ b/src/solvers/strings/string_constraint_generator_valueof.cpp
@@ -66,7 +66,7 @@ string_constraint_generatort::add_axioms_from_bool(
   const array_string_exprt &res,
   const exprt &b)
 {
-  const typet &char_type = res.content().type().subtype();
+  const typet &char_type = to_type_with_subtype(res.content().type()).subtype();
   PRECONDITION(b.type() == bool_typet() || b.type().id() == ID_c_bool);
   string_constraintst constraints;
   typecast_exprt eq(b, bool_typet());
@@ -155,7 +155,7 @@ string_constraint_generatort::add_axioms_for_string_of_int_with_radix(
     CHECK_RETURN(max_size < std::numeric_limits<size_t>::max());
   }
 
-  const typet &char_type = res.content().type().subtype();
+  const typet &char_type = to_type_with_subtype(res.content().type()).subtype();
   const typecast_exprt radix_as_char(radix, char_type);
   const typecast_exprt radix_input_type(radix, type);
   const bool strict_formatting = true;
@@ -205,7 +205,7 @@ string_constraint_generatort::add_axioms_from_int_hex(
   PRECONDITION(type.id() == ID_signedbv);
   string_constraintst constraints;
   const typet &index_type = res.length_type();
-  const typet &char_type = res.content().type().subtype();
+  const typet &char_type = to_type_with_subtype(res.content().type()).subtype();
   exprt sixteen = from_integer(16, index_type);
   exprt minus_char = from_integer('-', char_type);
   exprt zero_char = from_integer('0', char_type);
@@ -284,7 +284,7 @@ string_constraint_generatort::get_conjuncts_for_correct_number_format(
   const bool strict_formatting)
 {
   std::vector<exprt> conjuncts;
-  const typet &char_type = str.content().type().subtype();
+  const typet &char_type = to_type_with_subtype(str.content().type()).subtype();
   const typet &index_type = str.length_type();
 
   const exprt &chr = str[0];
@@ -380,7 +380,7 @@ string_constraint_generatort::add_axioms_for_characters_in_integer_string(
   const unsigned long radix_ul)
 {
   string_constraintst constraints;
-  const typet &char_type = str.content().type().subtype();
+  const typet &char_type = to_type_with_subtype(str.content().type()).subtype();
 
   const equal_exprt starts_with_minus(str[0], from_integer('-', char_type));
   const constant_exprt zero_expr = from_integer(0, type);
@@ -497,7 +497,8 @@ string_constraint_generatort::add_axioms_for_is_valid_int(
     called_function == ID_cprover_string_is_valid_int_func ? 32 : 64)};
   auto args = unpack_parseint_arguments(f, target_int_type);
 
-  const typet &char_type = args.str.content().type().subtype();
+  const typet &char_type =
+    to_type_with_subtype(args.str.content().type()).subtype();
   const typecast_exprt radix_as_char(args.radix, char_type);
   const bool strict_formatting = false;
 

--- a/src/solvers/strings/string_format_builtin_function.cpp
+++ b/src/solvers/strings/string_format_builtin_function.cpp
@@ -302,7 +302,7 @@ static std::pair<exprt, string_constraintst> add_axioms_for_format(
   const std::vector<format_elementt> format_strings = parse_format_string(s);
   std::vector<array_string_exprt> intermediary_strings;
   std::size_t arg_count = 0;
-  const typet &char_type = res.content().type().subtype();
+  const typet &char_type = to_type_with_subtype(res.content().type()).subtype();
   const typet &index_type = res.length_type();
 
   array_string_exprt string_arg;

--- a/src/solvers/strings/string_insertion_builtin_function.cpp
+++ b/src/solvers/strings/string_insertion_builtin_function.cpp
@@ -82,7 +82,7 @@ optionalt<exprt> string_insertion_builtin_functiont::eval(
 
   const auto result_value = eval(*input1_value, *input2_value, arg_values);
   const auto length = from_integer(result_value.size(), result.length_type());
-  const array_typet type(result.type().subtype(), length);
+  const array_typet type(to_type_with_subtype(result.type()).subtype(), length);
   return make_string(result_value, type);
 }
 

--- a/src/solvers/strings/string_refinement.cpp
+++ b/src/solvers/strings/string_refinement.cpp
@@ -925,7 +925,8 @@ void string_refinementt::add_lemma(
     if(it->id() == ID_array && it->operands().empty())
     {
       it.mutate() = array_of_exprt(
-        from_integer(CHARACTER_FOR_UNKNOWN, it->type().subtype()),
+        from_integer(
+          CHARACTER_FOR_UNKNOWN, to_array_type(it->type()).subtype()),
         to_array_type(it->type()));
       it.next_sibling_or_parent();
     }
@@ -1030,7 +1031,7 @@ static optionalt<exprt> get_array(
   }
 
   const exprt arr_val = simplify_expr(super_get(arr), ns);
-  const typet char_type = arr.type().subtype();
+  const typet char_type = to_array_type(arr.type()).subtype();
   const typet &index_type = size.value().type();
 
   if(

--- a/src/solvers/strings/string_refinement_util.cpp
+++ b/src/solvers/strings/string_refinement_util.cpp
@@ -29,12 +29,14 @@ bool is_char_array_type(const typet &type, const namespacet &ns)
 {
   if(type.id() == ID_struct_tag)
     return is_char_array_type(ns.follow_tag(to_struct_tag_type(type)), ns);
-  return type.id() == ID_array && is_char_type(type.subtype());
+  return type.id() == ID_array &&
+         is_char_type(to_array_type(type).element_type());
 }
 
 bool is_char_pointer_type(const typet &type)
 {
-  return type.id() == ID_pointer && is_char_type(type.subtype());
+  return type.id() == ID_pointer &&
+         is_char_type(to_pointer_type(type).base_type());
 }
 
 bool has_char_pointer_subtype(const typet &type, const namespacet &ns)

--- a/src/statement-list/statement_list_entry_point.cpp
+++ b/src/statement-list/statement_list_entry_point.cpp
@@ -106,7 +106,8 @@ static void add_main_function_block_call(
   symbolt instance_data_block;
   instance_data_block.name =
     id2string(data_block_interface.get_base_name()) + DB_ENTRY_POINT_POSTFIX;
-  instance_data_block.type = data_block_interface.type().subtype();
+  instance_data_block.type =
+    to_type_with_subtype(data_block_interface.type()).subtype();
   instance_data_block.is_static_lifetime = true;
   instance_data_block.mode = ID_statement_list;
   symbol_table.add(instance_data_block);

--- a/src/statement-list/statement_list_typecheck.cpp
+++ b/src/statement-list/statement_list_typecheck.cpp
@@ -1554,8 +1554,8 @@ exprt statement_list_typecheckt::typecheck_identifier(
     const symbolt &data_block{symbol_table.get_writeable_ref(
       id2string(tia_element.name) + "::" + DATA_BLOCK_PARAMETER_NAME)};
     const symbol_exprt db_expr = data_block.symbol_expr();
-    const struct_typet *const db_type =
-      type_try_dynamic_cast<struct_typet>(db_expr.type().subtype());
+    const struct_typet *const db_type = type_try_dynamic_cast<struct_typet>(
+      to_type_with_subtype(db_expr.type()).subtype());
     if(!db_type)
       UNREACHABLE;
     for(const struct_union_typet::componentt &member : db_type->components())

--- a/src/util/c_types_util.h
+++ b/src/util/c_types_util.h
@@ -56,7 +56,8 @@ inline bool is_c_integral_type(const typet &type)
 /// of the pointer has been a char type in the c program.
 inline bool is_c_char_pointer_type(const typet &type)
 {
-  return type.id() == ID_pointer && is_c_char_type(type.subtype());
+  return type.id() == ID_pointer &&
+         is_c_char_type(to_pointer_type(type).base_type());
 }
 
 /// This function checks, whether type is a pointer and the target type
@@ -64,7 +65,8 @@ inline bool is_c_char_pointer_type(const typet &type)
 /// is_c_int_derivate answers is used for checking the int type.
 inline bool is_c_integral_pointer_type(const typet &type)
 {
-  return type.id() == ID_pointer && is_c_integral_type(type.subtype());
+  return type.id() == ID_pointer &&
+         is_c_integral_type(to_pointer_type(type).base_type());
 }
 
 /// This function checks, whether the type

--- a/src/util/interval.cpp
+++ b/src/util/interval.cpp
@@ -18,13 +18,13 @@
 
 #include <ostream>
 
-#include <util/arith_tools.h>
-#include <util/namespace.h>
-#include <util/std_expr.h>
-#include <util/symbol_table.h>
-
+#include "arith_tools.h"
 #include "bitvector_expr.h"
+#include "c_types.h"
+#include "namespace.h"
 #include "simplify_expr.h"
+#include "std_expr.h"
+#include "symbol_table.h"
 
 const exprt &constant_interval_exprt::get_lower() const
 {
@@ -1126,20 +1126,23 @@ bool constant_interval_exprt::is_bitvector(const typet &t)
 {
   return t.id() == ID_bv || t.id() == ID_signedbv || t.id() == ID_unsignedbv ||
          t.id() == ID_c_bool ||
-         (t.id() == ID_c_bit_field && is_bitvector(t.subtype()));
+         (t.id() == ID_c_bit_field &&
+          is_bitvector(to_c_bit_field_type(t).underlying_type()));
 }
 
 bool constant_interval_exprt::is_signed(const typet &t)
 {
   return t.id() == ID_signedbv ||
-         (t.id() == ID_c_bit_field && is_signed(t.subtype()));
+         (t.id() == ID_c_bit_field &&
+          is_signed(to_c_bit_field_type(t).underlying_type()));
 }
 
 bool constant_interval_exprt::is_unsigned(const typet &t)
 {
   return t.id() == ID_bv || t.id() == ID_unsignedbv || t.id() == ID_c_bool ||
          t.id() == ID_c_enum ||
-         (t.id() == ID_c_bit_field && is_unsigned(t.subtype()));
+         (t.id() == ID_c_bit_field &&
+          is_unsigned(to_c_bit_field_type(t).underlying_type()));
 }
 
 bool constant_interval_exprt::is_signed(const constant_interval_exprt &interval)

--- a/src/util/rename_symbol.cpp
+++ b/src/util/rename_symbol.cpp
@@ -191,7 +191,7 @@ bool rename_symbolt::have_to_rename(const typet &dest) const
     return false;
 
   if(dest.has_subtype())
-    if(have_to_rename(dest.subtype()))
+    if(have_to_rename(to_type_with_subtype(dest).subtype()))
       return true;
 
   for(const typet &subtype : to_type_with_subtypes(dest).subtypes())

--- a/src/util/replace_symbol.cpp
+++ b/src/util/replace_symbol.cpp
@@ -210,7 +210,7 @@ bool replace_symbolt::have_to_replace(const typet &dest) const
     return false;
 
   if(dest.has_subtype())
-    if(have_to_replace(dest.subtype()))
+    if(have_to_replace(to_type_with_subtype(dest).subtype()))
       return true;
 
   for(const typet &subtype : to_type_with_subtypes(dest).subtypes())

--- a/src/util/simplify_expr.cpp
+++ b/src/util/simplify_expr.cpp
@@ -2098,7 +2098,8 @@ simplify_exprt::simplify_byte_update(const byte_update_exprt &expr)
   // byte_extract
   if(root.id()==ID_array)
   {
-    auto el_size = pointer_offset_bits(op_type.subtype(), ns);
+    auto el_size =
+      pointer_offset_bits(to_type_with_subtype(op_type).subtype(), ns);
 
     if(!el_size.has_value() || *el_size == 0 ||
        (*el_size) % 8 != 0 || (*val_size) % 8 != 0)

--- a/src/util/std_expr.h
+++ b/src/util/std_expr.h
@@ -1331,7 +1331,13 @@ public:
   // must be array_type.index_type().
   // This will eventually be enforced using a precondition.
   index_exprt(const exprt &_array, exprt _index)
-    : binary_exprt(_array, ID_index, std::move(_index), _array.type().subtype())
+    : binary_exprt(
+        _array,
+        ID_index,
+        std::move(_index),
+        _array.type().has_subtype()
+          ? to_type_with_subtype(_array.type()).subtype()
+          : typet(ID_nil))
   {
   }
 

--- a/unit/analyses/variable-sensitivity/full_array_abstract_object/maximum_length.cpp
+++ b/unit/analyses/variable-sensitivity/full_array_abstract_object/maximum_length.cpp
@@ -33,7 +33,9 @@ static abstract_object_ptrt write_array(
     env,
     ns,
     std::stack<exprt>(),
-    index_exprt(nil_exprt(), from_integer(index, type)),
+    index_exprt(
+      exprt(ID_nil, array_typet(typet(), nil_exprt())),
+      from_integer(index, type)),
     env.eval(from_integer(new_value, type), ns),
     false);
 }

--- a/unit/analyses/variable-sensitivity/full_array_abstract_object/merge.cpp
+++ b/unit/analyses/variable-sensitivity/full_array_abstract_object/merge.cpp
@@ -37,9 +37,12 @@ SCENARIO(
     auto val2 = std::vector<int>{1, 4, 5};
 
     // index_exprt for reading from an array
-    const index_exprt i0 = index_exprt(nil_exprt(), from_integer(0, type));
-    const index_exprt i1 = index_exprt(nil_exprt(), from_integer(1, type));
-    const index_exprt i2 = index_exprt(nil_exprt(), from_integer(2, type));
+    const index_exprt i0 = index_exprt(
+      exprt(ID_nil, array_typet(typet(), nil_exprt())), from_integer(0, type));
+    const index_exprt i1 = index_exprt(
+      exprt(ID_nil, array_typet(typet(), nil_exprt())), from_integer(1, type));
+    const index_exprt i2 = index_exprt(
+      exprt(ID_nil, array_typet(typet(), nil_exprt())), from_integer(2, type));
 
     auto object_factory = variable_sensitivity_object_factoryt::configured_with(
       vsd_configt::constant_domain());

--- a/unit/analyses/variable-sensitivity/variable_sensitivity_test_helpers.cpp
+++ b/unit/analyses/variable-sensitivity/variable_sensitivity_test_helpers.cpp
@@ -301,7 +301,9 @@ void EXPECT_INDEX(
   namespacet &ns)
 {
   auto type = signedbv_typet(32);
-  auto index_expr = index_exprt(nil_exprt(), from_integer(index, type));
+  auto index_expr = index_exprt(
+    exprt(ID_nil, array_typet(typet(), nil_exprt())),
+    from_integer(index, type));
   auto expr = result->expression_transform(index_expr, {}, environment, ns)
                 ->to_constant();
 
@@ -320,7 +322,9 @@ void EXPECT_INDEX(
   namespacet &ns)
 {
   auto type = signedbv_typet(32);
-  auto index_expr = index_exprt(nil_exprt(), from_integer(index, type));
+  auto index_expr = index_exprt(
+    exprt(ID_nil, array_typet(typet(), nil_exprt())),
+    from_integer(index, type));
   auto value =
     as_value_set(result->expression_transform(index_expr, {}, environment, ns));
 
@@ -340,7 +344,9 @@ void EXPECT_INDEX_TOP(
   namespacet &ns)
 {
   auto type = signedbv_typet(32);
-  auto index_expr = index_exprt(nil_exprt(), from_integer(index, type));
+  auto index_expr = index_exprt(
+    exprt(ID_nil, array_typet(typet(), nil_exprt())),
+    from_integer(index, type));
   auto value = result->expression_transform(index_expr, {}, environment, ns);
 
   INFO("Expect array[" + std::to_string(index) + "] to be TOP");

--- a/unit/pointer-analysis/value_set.cpp
+++ b/unit/pointer-analysis/value_set.cpp
@@ -28,9 +28,9 @@ static bool object_descriptor_matches(
     target.type().id() == ID_pointer &&
     target == null_pointer_exprt(to_pointer_type(target.type())))
   {
-    return
-      descriptor.object().id() == "NULL-object" &&
-      descriptor.object().type() == target.type().subtype();
+    return descriptor.object().id() == "NULL-object" &&
+           descriptor.object().type() ==
+             to_pointer_type(target.type()).base_type();
   }
   else
   {


### PR DESCRIPTION
This commit replaces invocations of `typet::subtype()` by the appropriate
methods offered by the more specific types, e.g., `pointer_typet`,
`array_typet`, and so on.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
