### PR TITLE
Fix Makefile `clean` target of `src/crangler`

### DIFF
--- a/src/crangler/Makefile
+++ b/src/crangler/Makefile
@@ -17,7 +17,9 @@ INCLUDES= -I ..
 include ../config.inc
 include ../../$(CPROVER_DIR)/src/common
 
-CLEANFILES = crangler$(LIBEXT)
+CLEANFILES = crangler$(LIBEXT) \
+  c_lex.yy.cpp \
+  crangler$(EXEEXT)
 
 all: crangler$(EXEEXT)
 


### PR DESCRIPTION
This target was previously not cleaning up the generated source file for
the lexer or the built binary. This issue was seen on Ubuntu and
resulted in cmake errors when using `make clean` as part of switching
from using the make build to using the cmake build.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
