### PR TITLE
Invoke functions marked __attribute__((destructor))

### DIFF
--- a/regression/cbmc/destructor1/main.c
+++ b/regression/cbmc/destructor1/main.c
@@ -1,0 +1,20 @@
+#include <assert.h>
+
+#ifdef __GNUC__
+// Will be implicitly invoked after main() completes if the attribute is
+// properly supported
+__attribute__((destructor))
+#endif
+void assert_false(void)
+{
+  assert(0);
+}
+
+int main()
+{
+#ifndef __GNUC__
+  // explicitly invoke assert_false as __attribute__((destructor)) isn't
+  // supported in non-GCC modes
+  assert_false();
+#endif
+}

--- a/regression/cbmc/destructor1/test.desc
+++ b/regression/cbmc/destructor1/test.desc
@@ -1,0 +1,9 @@
+CORE
+main.c
+
+^\[assert_false.assertion.1\] line 10 assertion 0: FAILURE$
+^VERIFICATION FAILED$
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring

--- a/src/ansi-c/ansi_c_entry_point.cpp
+++ b/src/ansi-c/ansi_c_entry_point.cpp
@@ -504,6 +504,26 @@ bool generate_ansi_c_start_function(
 
   record_function_outputs(symbol, init_code, symbol_table);
 
+  // now call destructor functions (a GCC extension)
+
+  for(const auto &symbol_table_entry : symbol_table.symbols)
+  {
+    const symbolt &symbol = symbol_table_entry.second;
+
+    if(symbol.type.id() != ID_code)
+      continue;
+
+    const code_typet &code_type = to_code_type(symbol.type);
+    if(
+      code_type.return_type().id() == ID_destructor &&
+      code_type.parameters().empty())
+    {
+      code_function_callt destructor_call(symbol.symbol_expr());
+      destructor_call.add_source_location() = symbol.location;
+      init_code.add(std::move(destructor_call));
+    }
+  }
+
   // add the entry point symbol
   symbolt new_symbol;
 


### PR DESCRIPTION
This is a GCC extension that our front-end parses, but an implementation
of the desired semantics was hitherto missing.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
