### PR TITLE
Enable rotate left/right tests on all platforms

### DIFF
--- a/regression/cbmc/clang_builtins/rotate.c
+++ b/regression/cbmc/clang_builtins/rotate.c
@@ -8,7 +8,20 @@
 #define ror(type, x, d)                                                        \
   ((type)(((x) >> (d)) | ((x) << ((8 * sizeof(type)) - (d)))))
 
-#ifdef __clang__
+#ifndef __clang__
+unsigned char __builtin_rotateleft8(unsigned char, unsigned char);
+unsigned short __builtin_rotateleft16(unsigned short, unsigned short);
+unsigned int __builtin_rotateleft32(unsigned int, unsigned int);
+unsigned long long
+__builtin_rotateleft64(unsigned long long, unsigned long long);
+
+unsigned char __builtin_rotateright8(unsigned char, unsigned char);
+unsigned short __builtin_rotateright16(unsigned short, unsigned short);
+unsigned int __builtin_rotateright32(unsigned int, unsigned int);
+unsigned long long
+__builtin_rotateright64(unsigned long long, unsigned long long);
+#endif
+
 void check_left8(void)
 {
   uint8_t op;
@@ -80,11 +93,9 @@ void check_right64(void)
   assert(__builtin_rotateright64(op, 3) == ror(uint64_t, op, 3));
   assert(__builtin_rotateright64(op, 4) == ror(uint64_t, op, 4));
 }
-#endif
 
 int main(void)
 {
-#ifdef __clang__
   check_left8();
   check_left16();
   check_left32();
@@ -93,5 +104,4 @@ int main(void)
   check_right16();
   check_right32();
   check_right64();
-#endif
 }

--- a/regression/cbmc/clang_builtins/rotate.desc
+++ b/regression/cbmc/clang_builtins/rotate.desc
@@ -1,6 +1,8 @@
-CORE gcc-only
+CORE
 rotate.c
 
 ^VERIFICATION SUCCESSFUL$
 ^EXIT=0$
 ^SIGNAL=0$
+--
+^warning: ignoring


### PR DESCRIPTION
We just need to provide the declarations on non-Clang builds. This is to
ensure test coverage irrespective of whether a test is run using Clang
or not.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
