### PR TITLE
Cleanup coverage CI job

### DIFF
--- a/.github/workflows/pull-request-checks.yaml
+++ b/.github/workflows/pull-request-checks.yaml
@@ -700,7 +700,9 @@ jobs:
       - name: Print ccache stats
         run: ccache -s
       - name: Run CTest and collect coverage statistics
-        run: cmake --build build --target coverage -- -j2
+        run: |
+          echo "lcov_excl_line = UNREACHABLE" > ~/.lcovrc
+          cmake --build build --target coverage -- -j2
       - name: Upload coverage statistics to Codecov
         uses: codecov/codecov-action@v2
         with:

--- a/.github/workflows/pull-request-checks.yaml
+++ b/.github/workflows/pull-request-checks.yaml
@@ -699,15 +699,11 @@ jobs:
         run: cmake --build build -- -j2
       - name: Print ccache stats
         run: ccache -s
-      - name: Run CTest
+      - name: Run CTest and collect coverage statistics
         run: cmake --build build --target coverage -- -j2
-      - name: Collect coverage statistics
-        run: |
-          lcov --capture --directory build --output-file lcov.info
-          lcov --remove lcov.info '/usr/*' --output-file lcov.info
       - name: Upload coverage statistics to Codecov
         uses: codecov/codecov-action@v2
         with:
-          files: ./lcov.info
+          files: build/html/coverage.info
           fail_ci_if_error: true
           verbose: true


### PR DESCRIPTION
This is an attempt to remove any code marked "UNREACHABLE" from the
coverage report. (Such code just artificially reduces our coverage
numbers.)

While at it I also suspected that we might be running lcov twice.

See individual commit messages for numeric data points.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [x] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
