### PR TITLE
Exception utils: remove redundant what() implementations

### DIFF
--- a/src/goto-programs/restrict_function_pointers.cpp
+++ b/src/goto-programs/restrict_function_pointers.cpp
@@ -87,7 +87,8 @@ static void restrict_function_pointer(
 invalid_restriction_exceptiont::invalid_restriction_exceptiont(
   std::string reason,
   std::string correct_format)
-  : reason(std::move(reason)), correct_format(std::move(correct_format))
+  : cprover_exception_baset(std::move(reason)),
+    correct_format(std::move(correct_format))
 {
 }
 

--- a/src/goto-programs/slice_global_inits.h
+++ b/src/goto-programs/slice_global_inits.h
@@ -23,17 +23,9 @@ class user_input_error_exceptiont : public cprover_exception_baset
 {
 public:
   explicit user_input_error_exceptiont(std::string message)
-    : message(std::move(message))
+    : cprover_exception_baset(std::move(message))
   {
   }
-
-  std::string what() const override
-  {
-    return message;
-  }
-
-private:
-  std::string message;
 };
 
 /// Remove initialization of global variables that are not used in any function

--- a/src/goto-programs/string_instrumentation.h
+++ b/src/goto-programs/string_instrumentation.h
@@ -26,16 +26,16 @@ public:
   incorrect_source_program_exceptiont(
     std::string message,
     source_locationt source_location)
-    : message(std::move(message)), source_location(std::move(source_location))
+    : cprover_exception_baset(std::move(message)),
+      source_location(std::move(source_location))
   {
   }
   std::string what() const override
   {
-    return message + " (at: " + source_location.as_string() + ")";
+    return reason + " (at: " + source_location.as_string() + ")";
   }
 
 private:
-  std::string message;
   source_locationt source_location;
 };
 

--- a/src/memory-analyzer/gdb_api.h
+++ b/src/memory-analyzer/gdb_api.h
@@ -229,16 +229,10 @@ protected:
 class gdb_interaction_exceptiont : public cprover_exception_baset
 {
 public:
-  explicit gdb_interaction_exceptiont(std::string reason) : reason(reason)
+  explicit gdb_interaction_exceptiont(std::string reason)
+    : cprover_exception_baset(std::move(reason))
   {
   }
-  std::string what() const override
-  {
-    return reason;
-  }
-
-private:
-  std::string reason;
 };
 
 #endif // CPROVER_MEMORY_ANALYZER_GDB_API_H

--- a/src/solvers/smt2/smt2_tokenizer.h
+++ b/src/solvers/smt2/smt2_tokenizer.h
@@ -9,8 +9,6 @@ Author: Daniel Kroening, kroening@kroening.com
 #ifndef CPROVER_SOLVERS_SMT2_SMT2_TOKENIZER_H
 #define CPROVER_SOLVERS_SMT2_SMT2_TOKENIZER_H
 
-#include <util/exception_utils.h>
-
 #include <sstream>
 #include <string>
 
@@ -23,7 +21,7 @@ public:
     line_no=1;
   }
 
-  class smt2_errort : public cprover_exception_baset
+  class smt2_errort
   {
   public:
     smt2_errort(const std::string &_message, unsigned _line_no)
@@ -36,7 +34,7 @@ public:
     {
     }
 
-    std::string what() const override
+    std::string what() const
     {
       return message.str();
     }

--- a/src/util/exception_utils.cpp
+++ b/src/util/exception_utils.cpp
@@ -9,6 +9,11 @@ Author: Fotis Koutoulakis, fotis.koutoulakis@diffblue.com
 #include "exception_utils.h"
 #include <utility>
 
+std::string cprover_exception_baset::what() const
+{
+  return reason;
+}
+
 std::string invalid_command_line_argument_exceptiont::what() const
 {
   std::string res;
@@ -28,42 +33,32 @@ invalid_command_line_argument_exceptiont::
     std::string reason,
     std::string option,
     std::string correct_input)
-  : reason(std::move(reason)),
+  : cprover_exception_baset(std::move(reason)),
     option(std::move(option)),
     correct_input(std::move(correct_input))
 {
 }
 
 system_exceptiont::system_exceptiont(std::string message)
-  : message(std::move(message))
+  : cprover_exception_baset(std::move(message))
 {
-}
-
-std::string system_exceptiont::what() const
-{
-  return message;
 }
 
 deserialization_exceptiont::deserialization_exceptiont(std::string message)
-  : message(std::move(message))
+  : cprover_exception_baset(std::move(message))
 {
-}
-
-std::string deserialization_exceptiont::what() const
-{
-  return message;
 }
 
 incorrect_goto_program_exceptiont::incorrect_goto_program_exceptiont(
   std::string message)
-  : message(std::move(message))
+  : cprover_exception_baset(std::move(message)),
+    source_location(source_locationt::nil())
 {
-  source_location.make_nil();
 }
 
 std::string incorrect_goto_program_exceptiont::what() const
 {
-  std::string ret(message);
+  std::string ret(reason);
 
   if(!source_location.is_nil())
     ret += " (at: " + source_location.as_string() + ")";
@@ -76,32 +71,17 @@ std::string incorrect_goto_program_exceptiont::what() const
 
 unsupported_operation_exceptiont::unsupported_operation_exceptiont(
   std::string message)
-  : message(std::move(message))
+  : cprover_exception_baset(std::move(message))
 {
-}
-
-std::string unsupported_operation_exceptiont::what() const
-{
-  return message;
 }
 
 analysis_exceptiont::analysis_exceptiont(std::string reason)
-  : reason(std::move(reason))
+  : cprover_exception_baset(std::move(reason))
 {
-}
-
-std::string analysis_exceptiont::what() const
-{
-  return reason;
 }
 
 invalid_source_file_exceptiont::invalid_source_file_exceptiont(
   std::string reason)
-  : reason(std::move(reason))
+  : cprover_exception_baset(std::move(reason))
 {
-}
-
-std::string invalid_source_file_exceptiont::what() const
-{
-  return reason;
 }


### PR DESCRIPTION
Make a `std::string reason` a member of the base class, and make
`what()` default to returning `reason`. This avoids duplicating the same
implementation across several child classes.

While at it, also fix the missing init-to-nil in one of
incorrect_goto_program_exceptiont's constructors.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
