### PR TITLE
Function pointer restrictions: support labels in JSON input

### DIFF
--- a/regression/goto-instrument/restrict-function-pointer-by-label/json.desc
+++ b/regression/goto-instrument/restrict-function-pointer-by-label/json.desc
@@ -1,0 +1,11 @@
+CORE
+test.c
+--function-pointer-restrictions-file restriction.json
+\[use_f\.assertion\.1\] line \d+ assertion fptr\(10\) == 11: SUCCESS
+^EXIT=0$
+^SIGNAL=0$
+--
+--
+This test checks that the function f is called for the first function pointer
+call in function use_f when using the label to refer to the call site, with the
+restriction described in the JSON file instead of the command-line directly.

--- a/regression/goto-instrument/restrict-function-pointer-by-label/restriction.json
+++ b/regression/goto-instrument/restrict-function-pointer-by-label/restriction.json
@@ -1,0 +1,5 @@
+{
+  "use_f.labelled_call":[
+    "f"
+  ]
+}

--- a/src/goto-instrument/goto_instrument_parse_options.cpp
+++ b/src/goto-instrument/goto_instrument_parse_options.cpp
@@ -1029,12 +1029,7 @@ void goto_instrument_parse_optionst::instrument_goto_program()
     {
       label_function_pointer_call_sites(goto_model);
 
-      const auto function_pointer_restrictions =
-        function_pointer_restrictionst::from_options(
-          options, goto_model, log.get_message_handler());
-
-      restrict_function_pointers(
-        ui_message_handler, goto_model, function_pointer_restrictions);
+      restrict_function_pointers(ui_message_handler, goto_model, options);
     }
   }
 

--- a/src/goto-programs/restrict_function_pointers.cpp
+++ b/src/goto-programs/restrict_function_pointers.cpp
@@ -84,14 +84,14 @@ static void restrict_function_pointer(
 }
 } // namespace
 
-function_pointer_restrictionst::invalid_restriction_exceptiont::
-  invalid_restriction_exceptiont(std::string reason, std::string correct_format)
+invalid_restriction_exceptiont::invalid_restriction_exceptiont(
+  std::string reason,
+  std::string correct_format)
   : reason(std::move(reason)), correct_format(std::move(correct_format))
 {
 }
 
-std::string
-function_pointer_restrictionst::invalid_restriction_exceptiont::what() const
+std::string invalid_restriction_exceptiont::what() const
 {
   std::string res;
 
@@ -291,6 +291,66 @@ function_pointer_restrictionst::parse_function_pointer_restrictions_from_file(
   return merged_restrictions;
 }
 
+/// Parse \p candidate to distinguish whether it refers to a function pointer
+/// symbol directly (as produced by \ref label_function_pointer_call_sites), or
+/// a source location via its statement label. In the latter case, resolve the
+/// name to the underlying function pointer symbol.
+static std::string resolve_pointer_name(
+  const std::string &candidate,
+  const goto_modelt &goto_model)
+{
+  const auto last_dot = candidate.rfind('.');
+  if(
+    last_dot == std::string::npos || last_dot + 1 == candidate.size() ||
+    isdigit(candidate[last_dot + 1]))
+  {
+    return candidate;
+  }
+
+  std::string pointer_name = candidate;
+
+  const auto function_id = pointer_name.substr(0, last_dot);
+  const auto label = pointer_name.substr(last_dot + 1);
+
+  bool found = false;
+  const auto it = goto_model.goto_functions.function_map.find(function_id);
+  if(it != goto_model.goto_functions.function_map.end())
+  {
+    optionalt<source_locationt> location;
+    for(const auto &instruction : it->second.body.instructions)
+    {
+      if(
+        std::find(
+          instruction.labels.begin(), instruction.labels.end(), label) !=
+        instruction.labels.end())
+      {
+        location = instruction.source_location();
+      }
+
+      if(
+        instruction.is_function_call() &&
+        instruction.call_function().id() == ID_dereference &&
+        location.has_value() && instruction.source_location() == *location)
+      {
+        auto const &called_function_pointer =
+          to_dereference_expr(instruction.call_function()).pointer();
+        pointer_name =
+          id2string(to_symbol_expr(called_function_pointer).get_identifier());
+        found = true;
+        break;
+      }
+    }
+  }
+  if(!found)
+  {
+    throw invalid_restriction_exceptiont{
+      "non-existent pointer name " + pointer_name,
+      "pointers should be identifiers or <function_name>.<label>"};
+  }
+
+  return pointer_name;
+}
+
 function_pointer_restrictionst::restrictiont
 function_pointer_restrictionst::parse_function_pointer_restriction(
   const std::string &restriction_opt,
@@ -324,51 +384,8 @@ function_pointer_restrictionst::parse_function_pointer_restriction(
       "couldn't find target name before '/' in `" + restriction_opt + "'"};
   }
 
-  auto pointer_name = restriction_opt.substr(0, pointer_name_end);
-  const auto last_dot = pointer_name.rfind('.');
-  if(
-    last_dot != std::string::npos && last_dot + 1 != pointer_name.size() &&
-    !isdigit(pointer_name[last_dot + 1]))
-  {
-    const auto function_id = pointer_name.substr(0, last_dot);
-    const auto label = pointer_name.substr(last_dot + 1);
-
-    bool found = false;
-    const auto it = goto_model.goto_functions.function_map.find(function_id);
-    if(it != goto_model.goto_functions.function_map.end())
-    {
-      optionalt<source_locationt> location;
-      for(const auto &instruction : it->second.body.instructions)
-      {
-        if(
-          std::find(
-            instruction.labels.begin(), instruction.labels.end(), label) !=
-          instruction.labels.end())
-        {
-          location = instruction.source_location();
-        }
-
-        if(
-          instruction.is_function_call() &&
-          instruction.call_function().id() == ID_dereference &&
-          location.has_value() && instruction.source_location() == *location)
-        {
-          auto const &called_function_pointer =
-            to_dereference_expr(instruction.call_function()).pointer();
-          pointer_name =
-            id2string(to_symbol_expr(called_function_pointer).get_identifier());
-          found = true;
-          break;
-        }
-      }
-    }
-    if(!found)
-    {
-      throw invalid_restriction_exceptiont{"non-existent pointer name " +
-                                             pointer_name,
-                                           restriction_format_message};
-    }
-  }
+  std::string pointer_name = resolve_pointer_name(
+    restriction_opt.substr(0, pointer_name_end), goto_model);
 
   auto const target_names_substring =
     restriction_opt.substr(pointer_name_end + 1);

--- a/src/goto-programs/restrict_function_pointers.cpp
+++ b/src/goto-programs/restrict_function_pointers.cpp
@@ -169,8 +169,13 @@ void function_pointer_restrictionst::typecheck_function_pointer_restrictions(
 void restrict_function_pointers(
   message_handlert &message_handler,
   goto_modelt &goto_model,
-  const function_pointer_restrictionst &restrictions)
+  const optionst &options)
 {
+  const auto restrictions = function_pointer_restrictionst::from_options(
+    options, goto_model, message_handler);
+  if(restrictions.restrictions.empty())
+    return;
+
   for(auto &function_item : goto_model.goto_functions.function_map)
   {
     goto_functiont &goto_function = function_item.second;

--- a/src/goto-programs/restrict_function_pointers.h
+++ b/src/goto-programs/restrict_function_pointers.h
@@ -64,6 +64,19 @@ void parse_function_pointer_restriction_options_from_cmdline(
   const cmdlinet &cmdline,
   optionst &options);
 
+class invalid_restriction_exceptiont : public cprover_exception_baset
+{
+public:
+  explicit invalid_restriction_exceptiont(
+    std::string reason,
+    std::string correct_format = "");
+
+  std::string what() const override;
+
+  std::string reason;
+  std::string correct_format;
+};
+
 class function_pointer_restrictionst
 {
 public:
@@ -89,19 +102,6 @@ public:
   void write_to_file(const std::string &filename) const;
 
 protected:
-  class invalid_restriction_exceptiont : public cprover_exception_baset
-  {
-  public:
-    explicit invalid_restriction_exceptiont(
-      std::string reason,
-      std::string correct_format = "");
-
-    std::string what() const override;
-
-    std::string reason;
-    std::string correct_format;
-  };
-
   static void typecheck_function_pointer_restrictions(
     const goto_modelt &goto_model,
     const restrictionst &restrictions);

--- a/src/goto-programs/restrict_function_pointers.h
+++ b/src/goto-programs/restrict_function_pointers.h
@@ -93,10 +93,12 @@ public:
     message_handlert &message_handler);
 
   jsont to_json() const;
-  static function_pointer_restrictionst from_json(const jsont &json);
+  static function_pointer_restrictionst
+  from_json(const jsont &json, const goto_modelt &goto_model);
 
   static function_pointer_restrictionst read_from_file(
     const std::string &filename,
+    const goto_modelt &goto_model,
     message_handlert &message_handler);
 
   void write_to_file(const std::string &filename) const;
@@ -112,6 +114,7 @@ protected:
 
   static restrictionst parse_function_pointer_restrictions_from_file(
     const std::list<std::string> &filenames,
+    const goto_modelt &goto_model,
     message_handlert &message_handler);
 
   static restrictionst parse_function_pointer_restrictions_from_command_line(

--- a/src/goto-programs/restrict_function_pointers.h
+++ b/src/goto-programs/restrict_function_pointers.h
@@ -164,6 +164,6 @@ protected:
 void restrict_function_pointers(
   message_handlert &message_handler,
   goto_modelt &goto_model,
-  const function_pointer_restrictionst &restrictions);
+  const optionst &options);
 
 #endif // CPROVER_GOTO_PROGRAMS_RESTRICT_FUNCTION_POINTERS_H

--- a/unit/goto-programs/restrict_function_pointers.cpp
+++ b/unit/goto-programs/restrict_function_pointers.cpp
@@ -46,32 +46,32 @@ void restriction_parsing_test()
   REQUIRE_THROWS_AS(
     fp_restrictionst::parse_function_pointer_restriction(
       "func", "test", goto_model),
-    fp_restrictionst::invalid_restriction_exceptiont);
+    invalid_restriction_exceptiont);
 
   REQUIRE_THROWS_AS(
     fp_restrictionst::parse_function_pointer_restriction(
       "/func", "test", goto_model),
-    fp_restrictionst::invalid_restriction_exceptiont);
+    invalid_restriction_exceptiont);
 
   REQUIRE_THROWS_AS(
     fp_restrictionst::parse_function_pointer_restriction(
       "func/", "test", goto_model),
-    fp_restrictionst::invalid_restriction_exceptiont);
+    invalid_restriction_exceptiont);
 
   REQUIRE_THROWS_AS(
     fp_restrictionst::parse_function_pointer_restriction(
       "func/,", "test", goto_model),
-    fp_restrictionst::invalid_restriction_exceptiont);
+    invalid_restriction_exceptiont);
 
   REQUIRE_THROWS_AS(
     fp_restrictionst::parse_function_pointer_restriction(
       "func1/func2,", "test", goto_model),
-    fp_restrictionst::invalid_restriction_exceptiont);
+    invalid_restriction_exceptiont);
 
   REQUIRE_THROWS_AS(
     fp_restrictionst::parse_function_pointer_restriction(
       "func1/,func2", "test", goto_model),
-    fp_restrictionst::invalid_restriction_exceptiont);
+    invalid_restriction_exceptiont);
 }
 
 void merge_restrictions_test()

--- a/unit/goto-programs/restrict_function_pointers.cpp
+++ b/unit/goto-programs/restrict_function_pointers.cpp
@@ -250,6 +250,7 @@ TEST_CASE("Json conversion", "[core]")
   // representation for the same restrictions can differ, due to the array
   // elements appearing in different orders)
 
+  goto_modelt goto_model;
   std::istringstream ss(
     "{"
     "  \"use_f.function_pointer_call.1\": [\"f\", \"g\"],"
@@ -262,7 +263,7 @@ TEST_CASE("Json conversion", "[core]")
 
   // json1 -> restrictions1
   const auto function_pointer_restrictions1 =
-    function_pointer_restrictionst::from_json(json1);
+    function_pointer_restrictionst::from_json(json1, goto_model);
 
   const auto &restrictions = function_pointer_restrictions1.restrictions;
 
@@ -284,7 +285,7 @@ TEST_CASE("Json conversion", "[core]")
 
   // json2 -> restrictions2
   const auto function_pointer_restrictions2 =
-    function_pointer_restrictionst::from_json(json2);
+    function_pointer_restrictionst::from_json(json2, goto_model);
 
   REQUIRE(
     function_pointer_restrictions1.restrictions ==


### PR DESCRIPTION
This is a follow-up fix to 771a153b2187b08, which added support for
labels as function-pointer identifiers. That commit, however, failed to
consider JSON input, and instead only resulted in support for
command-line specified restrictions.

Fixes: #6609

Please review commit-by-commit.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
