### PR TITLE
New SMT2 backend: arithmetic operators implementation for fixed size bit vectors

### DIFF
--- a/src/solvers/smt2_incremental/convert_expr_to_smt.cpp
+++ b/src/solvers/smt2_incremental/convert_expr_to_smt.cpp
@@ -391,8 +391,22 @@ convert_expr_to_smt(const euclidean_mod_exprt &euclidean_modulo)
 
 static smt_termt convert_expr_to_smt(const mult_exprt &multiply)
 {
-  UNIMPLEMENTED_FEATURE(
-    "Generation of SMT formula for multiply expression: " + multiply.pretty());
+  if(std::all_of(
+       multiply.operands().cbegin(),
+       multiply.operands().cend(),
+       [](exprt operand) {
+         return can_cast_type<integer_bitvector_typet>(operand.type());
+       }))
+  {
+    return convert_multiary_operator_to_terms(
+      multiply, smt_bit_vector_theoryt::multiply);
+  }
+  else
+  {
+    UNIMPLEMENTED_FEATURE(
+      "Generation of SMT formula for multiply expression: " +
+      multiply.pretty());
+  }
 }
 
 static smt_termt convert_expr_to_smt(const address_of_exprt &address_of)

--- a/src/solvers/smt2_incremental/convert_expr_to_smt.cpp
+++ b/src/solvers/smt2_incremental/convert_expr_to_smt.cpp
@@ -400,9 +400,22 @@ static smt_termt convert_expr_to_smt(const ieee_float_op_exprt &float_operation)
 
 static smt_termt convert_expr_to_smt(const mod_exprt &truncation_modulo)
 {
-  UNIMPLEMENTED_FEATURE(
-    "Generation of SMT formula for truncation modulo expression: " +
-    truncation_modulo.pretty());
+  const bool both_operands_bitvector =
+    can_cast_type<integer_bitvector_typet>(truncation_modulo.lhs().type()) &&
+    can_cast_type<integer_bitvector_typet>(truncation_modulo.rhs().type());
+
+  if(both_operands_bitvector)
+  {
+    return smt_bit_vector_theoryt::unsigned_remainder(
+      convert_expr_to_smt(truncation_modulo.lhs()),
+      convert_expr_to_smt(truncation_modulo.rhs()));
+  }
+  else
+  {
+    UNIMPLEMENTED_FEATURE(
+      "Generation of SMT formula for remainder (modulus) expression: " +
+      truncation_modulo.pretty());
+  }
 }
 
 static smt_termt

--- a/src/solvers/smt2_incremental/convert_expr_to_smt.cpp
+++ b/src/solvers/smt2_incremental/convert_expr_to_smt.cpp
@@ -365,10 +365,22 @@ static smt_termt convert_expr_to_smt(const div_exprt &divide)
     can_cast_type<integer_bitvector_typet>(divide.lhs().type()) &&
     can_cast_type<integer_bitvector_typet>(divide.rhs().type());
 
+  const bool both_operands_unsigned =
+    can_cast_type<unsignedbv_typet>(divide.lhs().type()) &&
+    can_cast_type<unsignedbv_typet>(divide.rhs().type());
+
   if(both_operands_bitvector)
   {
-    return smt_bit_vector_theoryt::unsigned_divide(
-      convert_expr_to_smt(divide.lhs()), convert_expr_to_smt(divide.rhs()));
+    if(both_operands_unsigned)
+    {
+      return smt_bit_vector_theoryt::unsigned_divide(
+        convert_expr_to_smt(divide.lhs()), convert_expr_to_smt(divide.rhs()));
+    }
+    else
+    {
+      return smt_bit_vector_theoryt::signed_divide(
+        convert_expr_to_smt(divide.lhs()), convert_expr_to_smt(divide.rhs()));
+    }
   }
   else
   {

--- a/src/solvers/smt2_incremental/convert_expr_to_smt.cpp
+++ b/src/solvers/smt2_incremental/convert_expr_to_smt.cpp
@@ -361,8 +361,20 @@ static smt_termt convert_expr_to_smt(const minus_exprt &minus)
 
 static smt_termt convert_expr_to_smt(const div_exprt &divide)
 {
-  UNIMPLEMENTED_FEATURE(
-    "Generation of SMT formula for divide expression: " + divide.pretty());
+  const bool both_operands_bitvector =
+    can_cast_type<integer_bitvector_typet>(divide.lhs().type()) &&
+    can_cast_type<integer_bitvector_typet>(divide.rhs().type());
+
+  if(both_operands_bitvector)
+  {
+    return smt_bit_vector_theoryt::unsigned_divide(
+      convert_expr_to_smt(divide.lhs()), convert_expr_to_smt(divide.rhs()));
+  }
+  else
+  {
+    UNIMPLEMENTED_FEATURE(
+      "Generation of SMT formula for divide expression: " + divide.pretty());
+  }
 }
 
 static smt_termt convert_expr_to_smt(const ieee_float_op_exprt &float_operation)

--- a/src/solvers/smt2_incremental/convert_expr_to_smt.cpp
+++ b/src/solvers/smt2_incremental/convert_expr_to_smt.cpp
@@ -326,8 +326,19 @@ static optionalt<smt_termt> try_relational_conversion(const exprt &expr)
 
 static smt_termt convert_expr_to_smt(const plus_exprt &plus)
 {
-  UNIMPLEMENTED_FEATURE(
-    "Generation of SMT formula for plus expression: " + plus.pretty());
+  if(std::all_of(
+       plus.operands().cbegin(), plus.operands().cend(), [](exprt operand) {
+         return can_cast_type<integer_bitvector_typet>(operand.type());
+       }))
+  {
+    return convert_multiary_operator_to_terms(
+      plus, smt_bit_vector_theoryt::add);
+  }
+  else
+  {
+    UNIMPLEMENTED_FEATURE(
+      "Generation of SMT formula for plus expression: " + plus.pretty());
+  }
 }
 
 static smt_termt convert_expr_to_smt(const minus_exprt &minus)

--- a/src/solvers/smt2_incremental/convert_expr_to_smt.cpp
+++ b/src/solvers/smt2_incremental/convert_expr_to_smt.cpp
@@ -404,11 +404,24 @@ static smt_termt convert_expr_to_smt(const mod_exprt &truncation_modulo)
     can_cast_type<integer_bitvector_typet>(truncation_modulo.lhs().type()) &&
     can_cast_type<integer_bitvector_typet>(truncation_modulo.rhs().type());
 
+  const bool both_operands_unsigned =
+    can_cast_type<unsignedbv_typet>(truncation_modulo.lhs().type()) &&
+    can_cast_type<unsignedbv_typet>(truncation_modulo.rhs().type());
+
   if(both_operands_bitvector)
   {
-    return smt_bit_vector_theoryt::unsigned_remainder(
-      convert_expr_to_smt(truncation_modulo.lhs()),
-      convert_expr_to_smt(truncation_modulo.rhs()));
+    if(both_operands_unsigned)
+    {
+      return smt_bit_vector_theoryt::unsigned_remainder(
+        convert_expr_to_smt(truncation_modulo.lhs()),
+        convert_expr_to_smt(truncation_modulo.rhs()));
+    }
+    else
+    {
+      return smt_bit_vector_theoryt::signed_remainder(
+        convert_expr_to_smt(truncation_modulo.lhs()),
+        convert_expr_to_smt(truncation_modulo.rhs()));
+    }
   }
   else
   {

--- a/src/solvers/smt2_incremental/convert_expr_to_smt.cpp
+++ b/src/solvers/smt2_incremental/convert_expr_to_smt.cpp
@@ -343,8 +343,20 @@ static smt_termt convert_expr_to_smt(const plus_exprt &plus)
 
 static smt_termt convert_expr_to_smt(const minus_exprt &minus)
 {
-  UNIMPLEMENTED_FEATURE(
-    "Generation of SMT formula for minus expression: " + minus.pretty());
+  const bool both_operands_bitvector =
+    can_cast_type<integer_bitvector_typet>(minus.lhs().type()) &&
+    can_cast_type<integer_bitvector_typet>(minus.rhs().type());
+
+  if(both_operands_bitvector)
+  {
+    return smt_bit_vector_theoryt::subtract(
+      convert_expr_to_smt(minus.lhs()), convert_expr_to_smt(minus.rhs()));
+  }
+  else
+  {
+    UNIMPLEMENTED_FEATURE(
+      "Generation of SMT formula for minus expression: " + minus.pretty());
+  }
 }
 
 static smt_termt convert_expr_to_smt(const div_exprt &divide)

--- a/src/solvers/smt2_incremental/convert_expr_to_smt.cpp
+++ b/src/solvers/smt2_incremental/convert_expr_to_smt.cpp
@@ -154,9 +154,19 @@ static smt_termt convert_expr_to_smt(const bitnot_exprt &bitwise_not)
 
 static smt_termt convert_expr_to_smt(const unary_minus_exprt &unary_minus)
 {
-  UNIMPLEMENTED_FEATURE(
-    "Generation of SMT formula for unary minus expression: " +
-    unary_minus.pretty());
+  const bool operand_is_bitvector =
+    can_cast_type<integer_bitvector_typet>(unary_minus.op().type());
+  if(operand_is_bitvector)
+  {
+    return smt_bit_vector_theoryt::negate(
+      convert_expr_to_smt(unary_minus.op()));
+  }
+  else
+  {
+    UNIMPLEMENTED_FEATURE(
+      "Generation of SMT formula for unary minus expression: " +
+      unary_minus.pretty());
+  }
 }
 
 static smt_termt convert_expr_to_smt(const unary_plus_exprt &unary_plus)

--- a/src/solvers/smt2_incremental/smt_bit_vector_theory.cpp
+++ b/src/solvers/smt2_incremental/smt_bit_vector_theory.cpp
@@ -273,3 +273,26 @@ void smt_bit_vector_theoryt::multiplyt::validate(
 const smt_function_application_termt::factoryt<
   smt_bit_vector_theoryt::multiplyt>
   smt_bit_vector_theoryt::multiply{};
+
+const char *smt_bit_vector_theoryt::unsigned_dividet::identifier()
+{
+  return "bvudiv";
+}
+
+smt_sortt smt_bit_vector_theoryt::unsigned_dividet::return_sort(
+  const smt_termt &lhs,
+  const smt_termt &rhs)
+{
+  return lhs.get_sort();
+}
+
+void smt_bit_vector_theoryt::unsigned_dividet::validate(
+  const smt_termt &lhs,
+  const smt_termt &rhs)
+{
+  validate_bit_vector_predicate_arguments(lhs, rhs);
+}
+
+const smt_function_application_termt::factoryt<
+  smt_bit_vector_theoryt::unsigned_dividet>
+  smt_bit_vector_theoryt::unsigned_divide{};

--- a/src/solvers/smt2_incremental/smt_bit_vector_theory.cpp
+++ b/src/solvers/smt2_incremental/smt_bit_vector_theory.cpp
@@ -250,3 +250,26 @@ void smt_bit_vector_theoryt::subtractt::validate(
 const smt_function_application_termt::factoryt<
   smt_bit_vector_theoryt::subtractt>
   smt_bit_vector_theoryt::subtract{};
+
+const char *smt_bit_vector_theoryt::multiplyt::identifier()
+{
+  return "bvmul";
+}
+
+smt_sortt smt_bit_vector_theoryt::multiplyt::return_sort(
+  const smt_termt &lhs,
+  const smt_termt &rhs)
+{
+  return lhs.get_sort();
+}
+
+void smt_bit_vector_theoryt::multiplyt::validate(
+  const smt_termt &lhs,
+  const smt_termt &rhs)
+{
+  validate_bit_vector_predicate_arguments(lhs, rhs);
+}
+
+const smt_function_application_termt::factoryt<
+  smt_bit_vector_theoryt::multiplyt>
+  smt_bit_vector_theoryt::multiply{};

--- a/src/solvers/smt2_incremental/smt_bit_vector_theory.cpp
+++ b/src/solvers/smt2_incremental/smt_bit_vector_theory.cpp
@@ -365,3 +365,22 @@ void smt_bit_vector_theoryt::signed_remaindert::validate(
 const smt_function_application_termt::factoryt<
   smt_bit_vector_theoryt::signed_remaindert>
   smt_bit_vector_theoryt::signed_remainder{};
+
+const char *smt_bit_vector_theoryt::negatet::identifier()
+{
+  return "bvneg";
+}
+
+smt_sortt smt_bit_vector_theoryt::negatet::return_sort(const smt_termt &operand)
+{
+  return operand.get_sort();
+}
+
+void smt_bit_vector_theoryt::negatet::validate(const smt_termt &operand)
+{
+  const auto operand_sort = operand.get_sort().cast<smt_bit_vector_sortt>();
+  INVARIANT(operand_sort, "The operand is expected to have a bit-vector sort.");
+}
+
+const smt_function_application_termt::factoryt<smt_bit_vector_theoryt::negatet>
+  smt_bit_vector_theoryt::negate{};

--- a/src/solvers/smt2_incremental/smt_bit_vector_theory.cpp
+++ b/src/solvers/smt2_incremental/smt_bit_vector_theory.cpp
@@ -4,7 +4,7 @@
 
 #include <util/invariant.h>
 
-static void validate_bit_vector_predicate_arguments(
+static void validate_bit_vector_operator_arguments(
   const smt_termt &left,
   const smt_termt &right)
 {
@@ -37,7 +37,7 @@ void smt_bit_vector_theoryt::unsigned_less_thant::validate(
   const smt_termt &lhs,
   const smt_termt &rhs)
 {
-  validate_bit_vector_predicate_arguments(lhs, rhs);
+  validate_bit_vector_operator_arguments(lhs, rhs);
 }
 
 const smt_function_application_termt::factoryt<
@@ -60,7 +60,7 @@ void smt_bit_vector_theoryt::unsigned_less_than_or_equalt::validate(
   const smt_termt &lhs,
   const smt_termt &rhs)
 {
-  validate_bit_vector_predicate_arguments(lhs, rhs);
+  validate_bit_vector_operator_arguments(lhs, rhs);
 }
 
 const smt_function_application_termt::factoryt<
@@ -83,7 +83,7 @@ void smt_bit_vector_theoryt::unsigned_greater_thant::validate(
   const smt_termt &lhs,
   const smt_termt &rhs)
 {
-  validate_bit_vector_predicate_arguments(lhs, rhs);
+  validate_bit_vector_operator_arguments(lhs, rhs);
 }
 
 const smt_function_application_termt::factoryt<
@@ -107,7 +107,7 @@ void smt_bit_vector_theoryt::unsigned_greater_than_or_equalt::validate(
   const smt_termt &lhs,
   const smt_termt &rhs)
 {
-  validate_bit_vector_predicate_arguments(lhs, rhs);
+  validate_bit_vector_operator_arguments(lhs, rhs);
 }
 
 const smt_function_application_termt::factoryt<
@@ -130,7 +130,7 @@ void smt_bit_vector_theoryt::signed_less_thant::validate(
   const smt_termt &lhs,
   const smt_termt &rhs)
 {
-  validate_bit_vector_predicate_arguments(lhs, rhs);
+  validate_bit_vector_operator_arguments(lhs, rhs);
 }
 
 const smt_function_application_termt::factoryt<
@@ -153,7 +153,7 @@ void smt_bit_vector_theoryt::signed_less_than_or_equalt::validate(
   const smt_termt &lhs,
   const smt_termt &rhs)
 {
-  validate_bit_vector_predicate_arguments(lhs, rhs);
+  validate_bit_vector_operator_arguments(lhs, rhs);
 }
 
 const smt_function_application_termt::factoryt<
@@ -176,7 +176,7 @@ void smt_bit_vector_theoryt::signed_greater_thant::validate(
   const smt_termt &lhs,
   const smt_termt &rhs)
 {
-  validate_bit_vector_predicate_arguments(lhs, rhs);
+  validate_bit_vector_operator_arguments(lhs, rhs);
 }
 
 const smt_function_application_termt::factoryt<
@@ -199,7 +199,7 @@ void smt_bit_vector_theoryt::signed_greater_than_or_equalt::validate(
   const smt_termt &lhs,
   const smt_termt &rhs)
 {
-  validate_bit_vector_predicate_arguments(lhs, rhs);
+  validate_bit_vector_operator_arguments(lhs, rhs);
 }
 
 const smt_function_application_termt::factoryt<
@@ -222,7 +222,7 @@ void smt_bit_vector_theoryt::addt::validate(
   const smt_termt &lhs,
   const smt_termt &rhs)
 {
-  validate_bit_vector_predicate_arguments(lhs, rhs);
+  validate_bit_vector_operator_arguments(lhs, rhs);
 }
 
 const smt_function_application_termt::factoryt<smt_bit_vector_theoryt::addt>
@@ -244,7 +244,7 @@ void smt_bit_vector_theoryt::subtractt::validate(
   const smt_termt &lhs,
   const smt_termt &rhs)
 {
-  validate_bit_vector_predicate_arguments(lhs, rhs);
+  validate_bit_vector_operator_arguments(lhs, rhs);
 }
 
 const smt_function_application_termt::factoryt<
@@ -267,7 +267,7 @@ void smt_bit_vector_theoryt::multiplyt::validate(
   const smt_termt &lhs,
   const smt_termt &rhs)
 {
-  validate_bit_vector_predicate_arguments(lhs, rhs);
+  validate_bit_vector_operator_arguments(lhs, rhs);
 }
 
 const smt_function_application_termt::factoryt<
@@ -290,7 +290,7 @@ void smt_bit_vector_theoryt::unsigned_dividet::validate(
   const smt_termt &lhs,
   const smt_termt &rhs)
 {
-  validate_bit_vector_predicate_arguments(lhs, rhs);
+  validate_bit_vector_operator_arguments(lhs, rhs);
 }
 
 const smt_function_application_termt::factoryt<
@@ -313,7 +313,7 @@ void smt_bit_vector_theoryt::signed_dividet::validate(
   const smt_termt &lhs,
   const smt_termt &rhs)
 {
-  validate_bit_vector_predicate_arguments(lhs, rhs);
+  validate_bit_vector_operator_arguments(lhs, rhs);
 }
 
 const smt_function_application_termt::factoryt<
@@ -336,7 +336,7 @@ void smt_bit_vector_theoryt::unsigned_remaindert::validate(
   const smt_termt &lhs,
   const smt_termt &rhs)
 {
-  validate_bit_vector_predicate_arguments(lhs, rhs);
+  validate_bit_vector_operator_arguments(lhs, rhs);
 }
 
 const smt_function_application_termt::factoryt<
@@ -359,7 +359,7 @@ void smt_bit_vector_theoryt::signed_remaindert::validate(
   const smt_termt &lhs,
   const smt_termt &rhs)
 {
-  validate_bit_vector_predicate_arguments(lhs, rhs);
+  validate_bit_vector_operator_arguments(lhs, rhs);
 }
 
 const smt_function_application_termt::factoryt<

--- a/src/solvers/smt2_incremental/smt_bit_vector_theory.cpp
+++ b/src/solvers/smt2_incremental/smt_bit_vector_theory.cpp
@@ -319,3 +319,26 @@ void smt_bit_vector_theoryt::signed_dividet::validate(
 const smt_function_application_termt::factoryt<
   smt_bit_vector_theoryt::signed_dividet>
   smt_bit_vector_theoryt::signed_divide{};
+
+const char *smt_bit_vector_theoryt::unsigned_remaindert::identifier()
+{
+  return "bvurem";
+}
+
+smt_sortt smt_bit_vector_theoryt::unsigned_remaindert::return_sort(
+  const smt_termt &lhs,
+  const smt_termt &rhs)
+{
+  return lhs.get_sort();
+}
+
+void smt_bit_vector_theoryt::unsigned_remaindert::validate(
+  const smt_termt &lhs,
+  const smt_termt &rhs)
+{
+  validate_bit_vector_predicate_arguments(lhs, rhs);
+}
+
+const smt_function_application_termt::factoryt<
+  smt_bit_vector_theoryt::unsigned_remaindert>
+  smt_bit_vector_theoryt::unsigned_remainder{};

--- a/src/solvers/smt2_incremental/smt_bit_vector_theory.cpp
+++ b/src/solvers/smt2_incremental/smt_bit_vector_theory.cpp
@@ -296,3 +296,26 @@ void smt_bit_vector_theoryt::unsigned_dividet::validate(
 const smt_function_application_termt::factoryt<
   smt_bit_vector_theoryt::unsigned_dividet>
   smt_bit_vector_theoryt::unsigned_divide{};
+
+const char *smt_bit_vector_theoryt::signed_dividet::identifier()
+{
+  return "bvsdiv";
+}
+
+smt_sortt smt_bit_vector_theoryt::signed_dividet::return_sort(
+  const smt_termt &lhs,
+  const smt_termt &rhs)
+{
+  return lhs.get_sort();
+}
+
+void smt_bit_vector_theoryt::signed_dividet::validate(
+  const smt_termt &lhs,
+  const smt_termt &rhs)
+{
+  validate_bit_vector_predicate_arguments(lhs, rhs);
+}
+
+const smt_function_application_termt::factoryt<
+  smt_bit_vector_theoryt::signed_dividet>
+  smt_bit_vector_theoryt::signed_divide{};

--- a/src/solvers/smt2_incremental/smt_bit_vector_theory.cpp
+++ b/src/solvers/smt2_incremental/smt_bit_vector_theory.cpp
@@ -205,3 +205,25 @@ void smt_bit_vector_theoryt::signed_greater_than_or_equalt::validate(
 const smt_function_application_termt::factoryt<
   smt_bit_vector_theoryt::signed_greater_than_or_equalt>
   smt_bit_vector_theoryt::signed_greater_than_or_equal{};
+
+const char *smt_bit_vector_theoryt::addt::identifier()
+{
+  return "bvadd";
+}
+
+smt_sortt smt_bit_vector_theoryt::addt::return_sort(
+  const smt_termt &lhs,
+  const smt_termt &rhs)
+{
+  return lhs.get_sort();
+}
+
+void smt_bit_vector_theoryt::addt::validate(
+  const smt_termt &lhs,
+  const smt_termt &rhs)
+{
+  validate_bit_vector_predicate_arguments(lhs, rhs);
+}
+
+const smt_function_application_termt::factoryt<smt_bit_vector_theoryt::addt>
+  smt_bit_vector_theoryt::add{};

--- a/src/solvers/smt2_incremental/smt_bit_vector_theory.cpp
+++ b/src/solvers/smt2_incremental/smt_bit_vector_theory.cpp
@@ -227,3 +227,26 @@ void smt_bit_vector_theoryt::addt::validate(
 
 const smt_function_application_termt::factoryt<smt_bit_vector_theoryt::addt>
   smt_bit_vector_theoryt::add{};
+
+const char *smt_bit_vector_theoryt::subtractt::identifier()
+{
+  return "bvsub";
+}
+
+smt_sortt smt_bit_vector_theoryt::subtractt::return_sort(
+  const smt_termt &lhs,
+  const smt_termt &rhs)
+{
+  return lhs.get_sort();
+}
+
+void smt_bit_vector_theoryt::subtractt::validate(
+  const smt_termt &lhs,
+  const smt_termt &rhs)
+{
+  validate_bit_vector_predicate_arguments(lhs, rhs);
+}
+
+const smt_function_application_termt::factoryt<
+  smt_bit_vector_theoryt::subtractt>
+  smt_bit_vector_theoryt::subtract{};

--- a/src/solvers/smt2_incremental/smt_bit_vector_theory.cpp
+++ b/src/solvers/smt2_incremental/smt_bit_vector_theory.cpp
@@ -342,3 +342,26 @@ void smt_bit_vector_theoryt::unsigned_remaindert::validate(
 const smt_function_application_termt::factoryt<
   smt_bit_vector_theoryt::unsigned_remaindert>
   smt_bit_vector_theoryt::unsigned_remainder{};
+
+const char *smt_bit_vector_theoryt::signed_remaindert::identifier()
+{
+  return "bvsrem";
+}
+
+smt_sortt smt_bit_vector_theoryt::signed_remaindert::return_sort(
+  const smt_termt &lhs,
+  const smt_termt &rhs)
+{
+  return lhs.get_sort();
+}
+
+void smt_bit_vector_theoryt::signed_remaindert::validate(
+  const smt_termt &lhs,
+  const smt_termt &rhs)
+{
+  validate_bit_vector_predicate_arguments(lhs, rhs);
+}
+
+const smt_function_application_termt::factoryt<
+  smt_bit_vector_theoryt::signed_remaindert>
+  smt_bit_vector_theoryt::signed_remainder{};

--- a/src/solvers/smt2_incremental/smt_bit_vector_theory.h
+++ b/src/solvers/smt2_incremental/smt_bit_vector_theory.h
@@ -92,6 +92,14 @@ public:
     static void validate(const smt_termt &lhs, const smt_termt &rhs);
   };
   static const smt_function_application_termt::factoryt<addt> add;
+
+  struct subtractt final
+  {
+    static const char *identifier();
+    static smt_sortt return_sort(const smt_termt &lhs, const smt_termt &rhs);
+    static void validate(const smt_termt &lhs, const smt_termt &rhs);
+  };
+  static const smt_function_application_termt::factoryt<subtractt> subtract;
 };
 
 #endif // CPROVER_SOLVERS_SMT2_INCREMENTAL_SMT_BIT_VECTOR_THEORY_H

--- a/src/solvers/smt2_incremental/smt_bit_vector_theory.h
+++ b/src/solvers/smt2_incremental/smt_bit_vector_theory.h
@@ -117,6 +117,15 @@ public:
   };
   static const smt_function_application_termt::factoryt<unsigned_dividet>
     unsigned_divide;
+
+  struct signed_dividet final
+  {
+    static const char *identifier();
+    static smt_sortt return_sort(const smt_termt &lhs, const smt_termt &rhs);
+    static void validate(const smt_termt &lhs, const smt_termt &rhs);
+  };
+  static const smt_function_application_termt::factoryt<signed_dividet>
+    signed_divide;
 };
 
 #endif // CPROVER_SOLVERS_SMT2_INCREMENTAL_SMT_BIT_VECTOR_THEORY_H

--- a/src/solvers/smt2_incremental/smt_bit_vector_theory.h
+++ b/src/solvers/smt2_incremental/smt_bit_vector_theory.h
@@ -144,6 +144,14 @@ public:
   };
   static const smt_function_application_termt::factoryt<signed_remaindert>
     signed_remainder;
+
+  struct negatet final
+  {
+    static const char *identifier();
+    static smt_sortt return_sort(const smt_termt &operand);
+    static void validate(const smt_termt &operand);
+  };
+  static const smt_function_application_termt::factoryt<negatet> negate;
 };
 
 #endif // CPROVER_SOLVERS_SMT2_INCREMENTAL_SMT_BIT_VECTOR_THEORY_H

--- a/src/solvers/smt2_incremental/smt_bit_vector_theory.h
+++ b/src/solvers/smt2_incremental/smt_bit_vector_theory.h
@@ -126,6 +126,15 @@ public:
   };
   static const smt_function_application_termt::factoryt<signed_dividet>
     signed_divide;
+
+  struct unsigned_remaindert final
+  {
+    static const char *identifier();
+    static smt_sortt return_sort(const smt_termt &lhs, const smt_termt &rhs);
+    static void validate(const smt_termt &lhs, const smt_termt &rhs);
+  };
+  static const smt_function_application_termt::factoryt<unsigned_remaindert>
+    unsigned_remainder;
 };
 
 #endif // CPROVER_SOLVERS_SMT2_INCREMENTAL_SMT_BIT_VECTOR_THEORY_H

--- a/src/solvers/smt2_incremental/smt_bit_vector_theory.h
+++ b/src/solvers/smt2_incremental/smt_bit_vector_theory.h
@@ -108,6 +108,15 @@ public:
     static void validate(const smt_termt &lhs, const smt_termt &rhs);
   };
   static const smt_function_application_termt::factoryt<multiplyt> multiply;
+
+  struct unsigned_dividet final
+  {
+    static const char *identifier();
+    static smt_sortt return_sort(const smt_termt &lhs, const smt_termt &rhs);
+    static void validate(const smt_termt &lhs, const smt_termt &rhs);
+  };
+  static const smt_function_application_termt::factoryt<unsigned_dividet>
+    unsigned_divide;
 };
 
 #endif // CPROVER_SOLVERS_SMT2_INCREMENTAL_SMT_BIT_VECTOR_THEORY_H

--- a/src/solvers/smt2_incremental/smt_bit_vector_theory.h
+++ b/src/solvers/smt2_incremental/smt_bit_vector_theory.h
@@ -84,6 +84,14 @@ public:
   static const smt_function_application_termt::factoryt<
     signed_greater_than_or_equalt>
     signed_greater_than_or_equal;
+
+  struct addt final
+  {
+    static const char *identifier();
+    static smt_sortt return_sort(const smt_termt &lhs, const smt_termt &rhs);
+    static void validate(const smt_termt &lhs, const smt_termt &rhs);
+  };
+  static const smt_function_application_termt::factoryt<addt> add;
 };
 
 #endif // CPROVER_SOLVERS_SMT2_INCREMENTAL_SMT_BIT_VECTOR_THEORY_H

--- a/src/solvers/smt2_incremental/smt_bit_vector_theory.h
+++ b/src/solvers/smt2_incremental/smt_bit_vector_theory.h
@@ -135,6 +135,15 @@ public:
   };
   static const smt_function_application_termt::factoryt<unsigned_remaindert>
     unsigned_remainder;
+
+  struct signed_remaindert final
+  {
+    static const char *identifier();
+    static smt_sortt return_sort(const smt_termt &lhs, const smt_termt &rhs);
+    static void validate(const smt_termt &lhs, const smt_termt &rhs);
+  };
+  static const smt_function_application_termt::factoryt<signed_remaindert>
+    signed_remainder;
 };
 
 #endif // CPROVER_SOLVERS_SMT2_INCREMENTAL_SMT_BIT_VECTOR_THEORY_H

--- a/src/solvers/smt2_incremental/smt_bit_vector_theory.h
+++ b/src/solvers/smt2_incremental/smt_bit_vector_theory.h
@@ -100,6 +100,14 @@ public:
     static void validate(const smt_termt &lhs, const smt_termt &rhs);
   };
   static const smt_function_application_termt::factoryt<subtractt> subtract;
+
+  struct multiplyt final
+  {
+    static const char *identifier();
+    static smt_sortt return_sort(const smt_termt &lhs, const smt_termt &rhs);
+    static void validate(const smt_termt &lhs, const smt_termt &rhs);
+  };
+  static const smt_function_application_termt::factoryt<multiplyt> multiply;
 };
 
 #endif // CPROVER_SOLVERS_SMT2_INCREMENTAL_SMT_BIT_VECTOR_THEORY_H

--- a/unit/solvers/smt2_incremental/convert_expr_to_smt.cpp
+++ b/unit/solvers/smt2_incremental/convert_expr_to_smt.cpp
@@ -345,4 +345,23 @@ TEST_CASE(
     const cbmc_invariants_should_throwt invariants_throw;
     REQUIRE_THROWS(convert_expr_to_smt(mult_exprt{one_bvint, false_exprt{}}));
   }
+
+  // Division is defined over unsigned numbers only (theory notes say it
+  // truncates over zero)
+  SECTION("Division of two constant size bit-vectors")
+  {
+    const auto constructed_term =
+      convert_expr_to_smt(div_exprt{one_bvint_unsigned, two_bvint_unsigned});
+    const auto expected_term =
+      smt_bit_vector_theoryt::unsigned_divide(smt_term_one, smt_term_two);
+    CHECK(constructed_term == expected_term);
+  }
+
+  SECTION(
+    "Ensure that division node conversion fails if the operands are not "
+    "bit-vector based")
+  {
+    const cbmc_invariants_should_throwt invariants_throw;
+    REQUIRE_THROWS(convert_expr_to_smt(div_exprt{one_bvint, false_exprt{}}));
+  }
 }

--- a/unit/solvers/smt2_incremental/convert_expr_to_smt.cpp
+++ b/unit/solvers/smt2_incremental/convert_expr_to_smt.cpp
@@ -374,14 +374,22 @@ TEST_CASE(
   }
 
   SECTION(
-    "Unsigned remainder (modulus) from truncating division of two constant "
+    "Remainder (modulus) from truncating division of two constant "
     "size bit-vectors")
   {
+    // Remainder expression with unsigned operands.
     const auto constructed_term =
       convert_expr_to_smt(mod_exprt{one_bvint_unsigned, two_bvint_unsigned});
     const auto expected_term =
       smt_bit_vector_theoryt::unsigned_remainder(smt_term_one, smt_term_two);
     CHECK(constructed_term == expected_term);
+
+    // Remainder expression with signed operands
+    const auto constructed_term_signed =
+      convert_expr_to_smt(mod_exprt{one_bvint, two_bvint});
+    const auto expected_term_signed =
+      smt_bit_vector_theoryt::signed_remainder(smt_term_one, smt_term_two);
+    CHECK(constructed_term_signed == expected_term_signed);
   }
 
   SECTION(

--- a/unit/solvers/smt2_incremental/convert_expr_to_smt.cpp
+++ b/unit/solvers/smt2_incremental/convert_expr_to_smt.cpp
@@ -239,3 +239,75 @@ TEST_CASE(
       smt_bit_vector_theoryt::unsigned_less_than_or_equal(one_term, two_term));
   }
 }
+
+TEST_CASE(
+  "expr to smt conversion for arithmetic operators",
+  "[core][smt2_incremental]")
+{
+  const smt_termt smt_term_one = smt_bit_vector_constant_termt{1, 8};
+  const smt_termt smt_term_two = smt_bit_vector_constant_termt{2, 8};
+
+  // Just regular (bit-vector) integers, to be used for the comparison
+  const auto one_bvint = from_integer({1}, signedbv_typet{8});
+  const auto two_bvint = from_integer({2}, signedbv_typet{8});
+  const auto one_bvint_unsigned = from_integer({1}, unsignedbv_typet{8});
+  const auto two_bvint_unsigned = from_integer({2}, unsignedbv_typet{8});
+
+  SECTION("Addition of two constant size bit-vectors")
+  {
+    const auto constructed_term =
+      convert_expr_to_smt(plus_exprt{one_bvint, two_bvint});
+    const auto expected_term =
+      smt_bit_vector_theoryt::add(smt_term_one, smt_term_two);
+    CHECK(constructed_term == expected_term);
+  }
+
+  SECTION(
+    "Addition of four constant size bit-vectors - testing multi-ary handling "
+    "of plus_exprt")
+  {
+    const auto three_bv_int = from_integer({3}, signedbv_typet{8});
+    const auto four_bv_int = from_integer({4}, signedbv_typet{8});
+
+    const auto three_smt_term = smt_bit_vector_constant_termt{3, 8};
+    const auto four_smt_term = smt_bit_vector_constant_termt{4, 8};
+
+    const exprt::operandst plus_operands{
+      one_bvint, two_bvint, three_bv_int, four_bv_int};
+    const auto constructed_term =
+      convert_expr_to_smt(plus_exprt{plus_operands, signedbv_typet{8}});
+    const auto expected_term = smt_bit_vector_theoryt::add(
+      smt_bit_vector_theoryt::add(
+        smt_bit_vector_theoryt::add(smt_term_one, smt_term_two),
+        three_smt_term),
+      four_smt_term);
+
+    CHECK(constructed_term == expected_term);
+  }
+
+  SECTION(
+    "Ensure that addition node conversion fails if the operands are not "
+    "bit-vector based")
+  {
+    const cbmc_invariants_should_throwt invariants_throw;
+    REQUIRE_THROWS(
+      convert_expr_to_smt(plus_exprt{true_exprt{}, false_exprt{}}));
+  }
+
+  SECTION(
+    "Ensure that addition node conversion fails if it has a malformed "
+    "expression")
+  {
+    const cbmc_invariants_should_throwt invariants_throw;
+    // No operands to expression
+    exprt::operandst zero_operands;
+    REQUIRE_THROWS(
+      convert_expr_to_smt(plus_exprt{zero_operands, signedbv_typet{8}}));
+
+    // One operand to expression
+    const auto four_bv_int = from_integer({4}, signedbv_typet{8});
+    exprt::operandst one_operand{four_bv_int};
+    REQUIRE_THROWS(
+      convert_expr_to_smt(plus_exprt{one_operand, signedbv_typet{8}}));
+  }
+}

--- a/unit/solvers/smt2_incremental/convert_expr_to_smt.cpp
+++ b/unit/solvers/smt2_incremental/convert_expr_to_smt.cpp
@@ -350,11 +350,19 @@ TEST_CASE(
   // truncates over zero)
   SECTION("Division of two constant size bit-vectors")
   {
+    // Check of division expression with unsigned operands
     const auto constructed_term =
       convert_expr_to_smt(div_exprt{one_bvint_unsigned, two_bvint_unsigned});
     const auto expected_term =
       smt_bit_vector_theoryt::unsigned_divide(smt_term_one, smt_term_two);
     CHECK(constructed_term == expected_term);
+
+    // Check of division expression with signed operands
+    const auto constructed_term_signed =
+      convert_expr_to_smt(div_exprt{one_bvint, two_bvint});
+    const auto expected_term_signed =
+      smt_bit_vector_theoryt::signed_divide(smt_term_one, smt_term_two);
+    CHECK(constructed_term_signed == expected_term_signed);
   }
 
   SECTION(

--- a/unit/solvers/smt2_incremental/convert_expr_to_smt.cpp
+++ b/unit/solvers/smt2_incremental/convert_expr_to_smt.cpp
@@ -310,4 +310,22 @@ TEST_CASE(
     REQUIRE_THROWS(
       convert_expr_to_smt(plus_exprt{one_operand, signedbv_typet{8}}));
   }
+
+  SECTION("Subtraction of two constant size bit-vectors")
+  {
+    const auto constructed_term =
+      convert_expr_to_smt(minus_exprt{two_bvint, one_bvint});
+    const auto expected_term =
+      smt_bit_vector_theoryt::subtract(smt_term_two, smt_term_one);
+    CHECK(constructed_term == expected_term);
+  }
+
+  SECTION(
+    "Ensure that subtraction node conversion fails if the operands are not "
+    "bit-vector based")
+  {
+    const cbmc_invariants_should_throwt invariants_throw;
+    REQUIRE_THROWS(
+      convert_expr_to_smt(minus_exprt{true_exprt{}, false_exprt{}}));
+  }
 }

--- a/unit/solvers/smt2_incremental/convert_expr_to_smt.cpp
+++ b/unit/solvers/smt2_incremental/convert_expr_to_smt.cpp
@@ -399,4 +399,20 @@ TEST_CASE(
     const cbmc_invariants_should_throwt invariants_throw;
     REQUIRE_THROWS(convert_expr_to_smt(mod_exprt{one_bvint, false_exprt{}}));
   }
+
+  SECTION("Unary minus of constant size bit-vector")
+  {
+    const auto constructed_term =
+      convert_expr_to_smt(unary_minus_exprt{one_bvint});
+    const auto expected_term = smt_bit_vector_theoryt::negate(smt_term_one);
+    CHECK(constructed_term == expected_term);
+  }
+
+  SECTION(
+    "Ensure that unary minus node conversion fails if the operand is not a "
+    "bit-vector")
+  {
+    const cbmc_invariants_should_throwt invariants_throw;
+    REQUIRE_THROWS(convert_expr_to_smt(unary_minus_exprt{true_exprt{}}));
+  }
 }

--- a/unit/solvers/smt2_incremental/convert_expr_to_smt.cpp
+++ b/unit/solvers/smt2_incremental/convert_expr_to_smt.cpp
@@ -372,4 +372,23 @@ TEST_CASE(
     const cbmc_invariants_should_throwt invariants_throw;
     REQUIRE_THROWS(convert_expr_to_smt(div_exprt{one_bvint, false_exprt{}}));
   }
+
+  SECTION(
+    "Unsigned remainder (modulus) from truncating division of two constant "
+    "size bit-vectors")
+  {
+    const auto constructed_term =
+      convert_expr_to_smt(mod_exprt{one_bvint_unsigned, two_bvint_unsigned});
+    const auto expected_term =
+      smt_bit_vector_theoryt::unsigned_remainder(smt_term_one, smt_term_two);
+    CHECK(constructed_term == expected_term);
+  }
+
+  SECTION(
+    "Ensure that remainder (truncated modulo) node conversion fails if the "
+    "operands are not bit-vector based")
+  {
+    const cbmc_invariants_should_throwt invariants_throw;
+    REQUIRE_THROWS(convert_expr_to_smt(mod_exprt{one_bvint, false_exprt{}}));
+  }
 }

--- a/unit/solvers/smt2_incremental/convert_expr_to_smt.cpp
+++ b/unit/solvers/smt2_incremental/convert_expr_to_smt.cpp
@@ -328,4 +328,21 @@ TEST_CASE(
     REQUIRE_THROWS(
       convert_expr_to_smt(minus_exprt{true_exprt{}, false_exprt{}}));
   }
+
+  SECTION("Multiplication of two constant size bit-vectors")
+  {
+    const auto constructed_term =
+      convert_expr_to_smt(mult_exprt{one_bvint, two_bvint});
+    const auto expected_term =
+      smt_bit_vector_theoryt::multiply(smt_term_one, smt_term_two);
+    CHECK(constructed_term == expected_term);
+  }
+
+  SECTION(
+    "Ensure that multiplication node conversion fails if the operands are not "
+    "bit-vector based")
+  {
+    const cbmc_invariants_should_throwt invariants_throw;
+    REQUIRE_THROWS(convert_expr_to_smt(mult_exprt{one_bvint, false_exprt{}}));
+  }
 }

--- a/unit/solvers/smt2_incremental/smt_bit_vector_theory.cpp
+++ b/unit/solvers/smt2_incremental/smt_bit_vector_theory.cpp
@@ -252,4 +252,23 @@ TEST_CASE(
     // A division of a bool and a bitvector should hit an invariant violation.
     REQUIRE_THROWS(smt_bit_vector_theoryt::unsigned_divide(true_val, three));
   }
+
+  SECTION("Signed Division")
+  {
+    const auto function_application =
+      smt_bit_vector_theoryt::signed_divide(two, three);
+    REQUIRE(
+      function_application.function_identifier() ==
+      smt_identifier_termt("bvsdiv", smt_bit_vector_sortt{8}));
+    REQUIRE(function_application.get_sort() == smt_bit_vector_sortt{8});
+    REQUIRE(function_application.arguments().size() == 2);
+    REQUIRE(function_application.arguments()[0].get() == two);
+    REQUIRE(function_application.arguments()[1].get() == three);
+
+    cbmc_invariants_should_throwt invariants_throw;
+    // Bit-vectors of mismatched sorts are going to hit an invariant violation.
+    REQUIRE_THROWS(smt_bit_vector_theoryt::signed_divide(three, four));
+    // A division of a bool and a bitvector should hit an invariant violation.
+    REQUIRE_THROWS(smt_bit_vector_theoryt::signed_divide(true_val, three));
+  }
 }

--- a/unit/solvers/smt2_incremental/smt_bit_vector_theory.cpp
+++ b/unit/solvers/smt2_incremental/smt_bit_vector_theory.cpp
@@ -166,3 +166,31 @@ TEST_CASE("SMT bit vector predicates", "[core][smt2_incremental]")
       smt_bit_vector_theoryt::signed_greater_than_or_equal(two, wider));
   }
 }
+
+TEST_CASE(
+  "SMT bit vector arithmetic operator implementation tests",
+  "[core][smt2_incremental]")
+{
+  const smt_bit_vector_constant_termt two{2, 8};
+  const smt_bit_vector_constant_termt three{3, 8};
+  const smt_bit_vector_constant_termt four{4, 16};
+  const smt_bool_literal_termt true_val{true};
+
+  SECTION("Addition")
+  {
+    const auto function_application = smt_bit_vector_theoryt::add(two, three);
+    REQUIRE(
+      function_application.function_identifier() ==
+      smt_identifier_termt("bvadd", smt_bit_vector_sortt{8}));
+    REQUIRE(function_application.get_sort() == smt_bit_vector_sortt{8});
+    REQUIRE(function_application.arguments().size() == 2);
+    REQUIRE(function_application.arguments()[0].get() == two);
+    REQUIRE(function_application.arguments()[1].get() == three);
+
+    cbmc_invariants_should_throwt invariants_throw;
+    // Bit-vectors of mismatched sorts are going to hit an invariant violation.
+    REQUIRE_THROWS(smt_bit_vector_theoryt::add(three, four));
+    // An addition of a bool and a bitvector should hit an invariant violation.
+    REQUIRE_THROWS(smt_bit_vector_theoryt::add(three, true_val));
+  }
+}

--- a/unit/solvers/smt2_incremental/smt_bit_vector_theory.cpp
+++ b/unit/solvers/smt2_incremental/smt_bit_vector_theory.cpp
@@ -309,4 +309,19 @@ TEST_CASE(
     // A remainder of a bool and a bitvector should hit an invariant violation.
     REQUIRE_THROWS(smt_bit_vector_theoryt::signed_remainder(true_val, three));
   }
+
+  SECTION("Unary Minus")
+  {
+    const auto function_application = smt_bit_vector_theoryt::negate(two);
+    REQUIRE(
+      function_application.function_identifier() ==
+      smt_identifier_termt("bvneg", smt_bit_vector_sortt{8}));
+    REQUIRE(function_application.get_sort() == smt_bit_vector_sortt{8});
+    REQUIRE(function_application.arguments().size() == 1);
+    REQUIRE(function_application.arguments()[0].get() == two);
+
+    cbmc_invariants_should_throwt invariants_throw;
+    // Negation of a value of bool sort should fail with an invariant violation.
+    REQUIRE_THROWS(smt_bit_vector_theoryt::negate(true_val));
+  }
 }

--- a/unit/solvers/smt2_incremental/smt_bit_vector_theory.cpp
+++ b/unit/solvers/smt2_incremental/smt_bit_vector_theory.cpp
@@ -213,4 +213,24 @@ TEST_CASE(
     // invariant violation.
     REQUIRE_THROWS(smt_bit_vector_theoryt::subtract(true_val, three));
   }
+
+  SECTION("Multiplication")
+  {
+    const auto function_application =
+      smt_bit_vector_theoryt::multiply(two, three);
+    REQUIRE(
+      function_application.function_identifier() ==
+      smt_identifier_termt("bvmul", smt_bit_vector_sortt{8}));
+    REQUIRE(function_application.get_sort() == smt_bit_vector_sortt{8});
+    REQUIRE(function_application.arguments().size() == 2);
+    REQUIRE(function_application.arguments()[0].get() == two);
+    REQUIRE(function_application.arguments()[1].get() == three);
+
+    cbmc_invariants_should_throwt invariants_throw;
+    // Bit-vectors of mismatched sorts are going to hit an invariant violation.
+    REQUIRE_THROWS(smt_bit_vector_theoryt::multiply(three, four));
+    // A multiplication of a bool and a bitvector should hit an
+    // invariant violation.
+    REQUIRE_THROWS(smt_bit_vector_theoryt::multiply(true_val, three));
+  }
 }

--- a/unit/solvers/smt2_incremental/smt_bit_vector_theory.cpp
+++ b/unit/solvers/smt2_incremental/smt_bit_vector_theory.cpp
@@ -271,4 +271,23 @@ TEST_CASE(
     // A division of a bool and a bitvector should hit an invariant violation.
     REQUIRE_THROWS(smt_bit_vector_theoryt::signed_divide(true_val, three));
   }
+
+  SECTION("Unsigned Remainder")
+  {
+    const auto function_application =
+      smt_bit_vector_theoryt::unsigned_remainder(two, three);
+    REQUIRE(
+      function_application.function_identifier() ==
+      smt_identifier_termt("bvurem", smt_bit_vector_sortt{8}));
+    REQUIRE(function_application.get_sort() == smt_bit_vector_sortt{8});
+    REQUIRE(function_application.arguments().size() == 2);
+    REQUIRE(function_application.arguments()[0].get() == two);
+    REQUIRE(function_application.arguments()[1].get() == three);
+
+    cbmc_invariants_should_throwt invariants_throw;
+    // Bit-vectors of mismatched sorts are going to hit an invariant violation.
+    REQUIRE_THROWS(smt_bit_vector_theoryt::unsigned_remainder(three, four));
+    // A remainder of a bool and a bitvector should hit an invariant violation.
+    REQUIRE_THROWS(smt_bit_vector_theoryt::unsigned_remainder(true_val, three));
+  }
 }

--- a/unit/solvers/smt2_incremental/smt_bit_vector_theory.cpp
+++ b/unit/solvers/smt2_incremental/smt_bit_vector_theory.cpp
@@ -233,4 +233,23 @@ TEST_CASE(
     // invariant violation.
     REQUIRE_THROWS(smt_bit_vector_theoryt::multiply(true_val, three));
   }
+
+  SECTION("Unsigned Division")
+  {
+    const auto function_application =
+      smt_bit_vector_theoryt::unsigned_divide(two, three);
+    REQUIRE(
+      function_application.function_identifier() ==
+      smt_identifier_termt("bvudiv", smt_bit_vector_sortt{8}));
+    REQUIRE(function_application.get_sort() == smt_bit_vector_sortt{8});
+    REQUIRE(function_application.arguments().size() == 2);
+    REQUIRE(function_application.arguments()[0].get() == two);
+    REQUIRE(function_application.arguments()[1].get() == three);
+
+    cbmc_invariants_should_throwt invariants_throw;
+    // Bit-vectors of mismatched sorts are going to hit an invariant violation.
+    REQUIRE_THROWS(smt_bit_vector_theoryt::unsigned_divide(three, four));
+    // A division of a bool and a bitvector should hit an invariant violation.
+    REQUIRE_THROWS(smt_bit_vector_theoryt::unsigned_divide(true_val, three));
+  }
 }

--- a/unit/solvers/smt2_incremental/smt_bit_vector_theory.cpp
+++ b/unit/solvers/smt2_incremental/smt_bit_vector_theory.cpp
@@ -290,4 +290,23 @@ TEST_CASE(
     // A remainder of a bool and a bitvector should hit an invariant violation.
     REQUIRE_THROWS(smt_bit_vector_theoryt::unsigned_remainder(true_val, three));
   }
+
+  SECTION("Signed Remainder")
+  {
+    const auto function_application =
+      smt_bit_vector_theoryt::signed_remainder(two, three);
+    REQUIRE(
+      function_application.function_identifier() ==
+      smt_identifier_termt("bvsrem", smt_bit_vector_sortt{8}));
+    REQUIRE(function_application.get_sort() == smt_bit_vector_sortt{8});
+    REQUIRE(function_application.arguments().size() == 2);
+    REQUIRE(function_application.arguments()[0].get() == two);
+    REQUIRE(function_application.arguments()[1].get() == three);
+
+    cbmc_invariants_should_throwt invariants_throw;
+    // Bit-vectors of mismatched sorts are going to hit an invariant violation.
+    REQUIRE_THROWS(smt_bit_vector_theoryt::signed_remainder(three, four));
+    // A remainder of a bool and a bitvector should hit an invariant violation.
+    REQUIRE_THROWS(smt_bit_vector_theoryt::signed_remainder(true_val, three));
+  }
 }

--- a/unit/solvers/smt2_incremental/smt_bit_vector_theory.cpp
+++ b/unit/solvers/smt2_incremental/smt_bit_vector_theory.cpp
@@ -193,4 +193,24 @@ TEST_CASE(
     // An addition of a bool and a bitvector should hit an invariant violation.
     REQUIRE_THROWS(smt_bit_vector_theoryt::add(three, true_val));
   }
+
+  SECTION("Subtraction")
+  {
+    const auto function_application =
+      smt_bit_vector_theoryt::subtract(two, three);
+    REQUIRE(
+      function_application.function_identifier() ==
+      smt_identifier_termt("bvsub", smt_bit_vector_sortt{8}));
+    REQUIRE(function_application.get_sort() == smt_bit_vector_sortt{8});
+    REQUIRE(function_application.arguments().size() == 2);
+    REQUIRE(function_application.arguments()[0].get() == two);
+    REQUIRE(function_application.arguments()[1].get() == three);
+
+    cbmc_invariants_should_throwt invariants_throw;
+    // Bit-vectors of mismatched sorts are going to hit an invariant violation.
+    REQUIRE_THROWS(smt_bit_vector_theoryt::subtract(three, four));
+    // A subtraction of a bool and a bitvector should hit an
+    // invariant violation.
+    REQUIRE_THROWS(smt_bit_vector_theoryt::subtract(true_val, three));
+  }
 }


### PR DESCRIPTION
This adds implementations (and tests) for the binary arithmetic operators (and their conversion) to SMT2 data structures.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.


<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
