### PR TITLE
goto_check_c: observe check pragmas annotated to individual expressions

### DIFF
--- a/regression/cbmc/gcc_builtin_add_overflow/conversion-check.c
+++ b/regression/cbmc/gcc_builtin_add_overflow/conversion-check.c
@@ -1,0 +1,10 @@
+#ifndef __GNUC__
+_Bool __builtin_add_overflow();
+#endif
+
+int main()
+{
+  unsigned a, b, c;
+  if(__builtin_add_overflow(a, b, &c))
+    return 0;
+}

--- a/regression/cbmc/gcc_builtin_add_overflow/conversion-check.desc
+++ b/regression/cbmc/gcc_builtin_add_overflow/conversion-check.desc
@@ -1,0 +1,10 @@
+CORE
+conversion-check.c
+--conversion-check --unsigned-overflow-check --signed-overflow-check
+^VERIFICATION SUCCESSFUL$
+^EXIT=0$
+^SIGNAL=0$
+--
+^Generated [1-9]\d* VCC\(s\)
+--
+Zero VCCs should be generated.

--- a/regression/cbmc/pragma_cprover4/main.c
+++ b/regression/cbmc/pragma_cprover4/main.c
@@ -1,0 +1,22 @@
+#include <assert.h>
+
+int nondet_int();
+
+void main()
+{
+  int a = nondet_int();
+  int b = nondet_int();
+  int c = a +
+#pragma CPROVER check disable "signed-overflow"
+          (a + b);
+#pragma CPROVER check pop
+
+#pragma CPROVER check disable "signed-overflow"
+  for(int i = 0; i < 10; ++i)
+  {
+    int temp = a + b;
+#pragma CPROVER check pop
+    int foo = temp + a;
+    assert(foo > 2);
+  }
+}

--- a/regression/cbmc/pragma_cprover4/test.desc
+++ b/regression/cbmc/pragma_cprover4/test.desc
@@ -1,0 +1,13 @@
+CORE
+main.c
+--signed-overflow-check
+^\[main.overflow.1\] line 9 arithmetic overflow on signed \+ in a \+ a \+ b: FAILURE$
+^\[main.overflow.2\] line 19 arithmetic overflow on signed \+ in temp \+ a: FAILURE$
+^\[main.assertion.1\] line 20 assertion foo > 2: FAILURE$
+^\*\* 3 of 3 failed
+^VERIFICATION FAILED$
+^EXIT=10$
+^SIGNAL=0$
+--
+--
+No assertions other than the above three are expected.

--- a/src/ansi-c/ansi_c_parser.cpp
+++ b/src/ansi-c/ansi_c_parser.cpp
@@ -203,6 +203,9 @@ void ansi_c_parsert::pragma_cprover_add_check(
 
 bool ansi_c_parsert::pragma_cprover_clash(const irep_idt &name, bool enabled)
 {
+  if(pragma_cprover_stack.empty())
+    return false;
+
   auto top = pragma_cprover_stack.back();
   auto found = top.find(name);
   return found != top.end() && found->second != enabled;

--- a/src/goto-programs/goto_convert_side_effect.cpp
+++ b/src/goto-programs/goto_convert_side_effect.cpp
@@ -656,9 +656,12 @@ void goto_convertt::remove_overflow(
   if(result.type().id() == ID_pointer)
   {
     result_type = to_pointer_type(result.type()).base_type();
-    code_assignt result_assignment{dereference_exprt{result},
-                                   typecast_exprt{operation, *result_type},
-                                   expr.source_location()};
+    source_locationt source_location_annotated = expr.source_location();
+    source_location_annotated.add_pragma("disable:conversion-check");
+    code_assignt result_assignment{
+      dereference_exprt{result},
+      typecast_exprt{operation, *result_type},
+      source_location_annotated};
     convert_assign(result_assignment, dest, mode);
   }
   else


### PR DESCRIPTION
This is required to make the conversion of __builtin_X_overflow not generate spurious conversion checks.

Please review commit-by-commit.

Fixes: #6452

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
