### PR TITLE
Avoid down casting to `binary_relation_exprt` in expr to (incremental) SMT2 conversion

### DIFF
--- a/src/solvers/smt2_incremental/convert_expr_to_smt.cpp
+++ b/src/solvers/smt2_incremental/convert_expr_to_smt.cpp
@@ -287,40 +287,41 @@ static smt_termt convert_relational_to_smt(
     binary_relation.pretty());
 }
 
-static smt_termt
-convert_expr_to_smt(const binary_relation_exprt &binary_relation)
+static optionalt<smt_termt> try_relational_conversion(const exprt &expr)
 {
-  if(can_cast_expr<greater_than_exprt>(binary_relation))
+  if(const auto greater_than = expr_try_dynamic_cast<greater_than_exprt>(expr))
   {
     return convert_relational_to_smt(
-      binary_relation,
+      *greater_than,
       smt_bit_vector_theoryt::unsigned_greater_than,
       smt_bit_vector_theoryt::signed_greater_than);
   }
-  if(can_cast_expr<greater_than_or_equal_exprt>(binary_relation))
+  if(
+    const auto greater_than_or_equal =
+      expr_try_dynamic_cast<greater_than_or_equal_exprt>(expr))
   {
     return convert_relational_to_smt(
-      binary_relation,
+      *greater_than_or_equal,
       smt_bit_vector_theoryt::unsigned_greater_than_or_equal,
       smt_bit_vector_theoryt::signed_greater_than_or_equal);
   }
-  if(can_cast_expr<less_than_exprt>(binary_relation))
+  if(const auto less_than = expr_try_dynamic_cast<less_than_exprt>(expr))
   {
     return convert_relational_to_smt(
-      binary_relation,
+      *less_than,
       smt_bit_vector_theoryt::unsigned_less_than,
       smt_bit_vector_theoryt::signed_less_than);
   }
-  if(can_cast_expr<less_than_or_equal_exprt>(binary_relation))
+  if(
+    const auto less_than_or_equal =
+      expr_try_dynamic_cast<less_than_or_equal_exprt>(expr))
   {
     return convert_relational_to_smt(
-      binary_relation,
+      *less_than_or_equal,
       smt_bit_vector_theoryt::unsigned_less_than_or_equal,
       smt_bit_vector_theoryt::signed_less_than_or_equal);
   }
-  UNIMPLEMENTED_FEATURE(
-    "Generation of SMT formula for binary relation expression: " +
-    binary_relation.pretty());
+  return {};
 }
 
 static smt_termt convert_expr_to_smt(const plus_exprt &plus)
@@ -686,11 +687,9 @@ smt_termt convert_expr_to_smt(const exprt &expr)
   {
     return convert_expr_to_smt(*float_not_equal);
   }
-  if(
-    const auto binary_relation =
-      expr_try_dynamic_cast<binary_relation_exprt>(expr))
+  if(const auto converted_relational = try_relational_conversion(expr))
   {
-    return convert_expr_to_smt(*binary_relation);
+    return *converted_relational;
   }
   if(const auto plus = expr_try_dynamic_cast<plus_exprt>(expr))
   {


### PR DESCRIPTION
`can_cast_expr<binary_relation_exprt>` allows casting expressions which do not derive from `binary_relation_exprt` to `binary_relation_exprt`. This includes expressions which are not relational operators all, such as `plus_exprt`. By casting to the relevant sub-classes individually instead of `binary_relation_exprt`, we avoid reaching the unimplemented binary relation invariant when processing expressions which are not binary relations.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
