### PR TITLE
Switch to clang-format-10 to support more recent platforms

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -58,7 +58,7 @@ SpacesInCStyleCastParentheses: 'false'
 SpacesInContainerLiterals: 'false'
 SpacesInParentheses: 'false'
 SpacesInSquareBrackets: 'false'
-Standard: Cpp11
+Standard: c++11
 TabWidth: '2'
 UseTab: Never
 ---

--- a/.github/workflows/pull-request-check-clang-format.sh
+++ b/.github/workflows/pull-request-check-clang-format.sh
@@ -7,7 +7,7 @@ set -e
 echo "Pull request's base branch is: ${BASE_BRANCH}"
 echo "Pull request's merge branch is: ${MERGE_BRANCH}"
 echo "Pull request's source branch is: ${GITHUB_HEAD_REF}"
-clang-format-7 --version
+clang-format-10 --version
 
 # The checkout action leaves us in detatched head state. The following line
 # names the checked out commit, for simpler reference later.
@@ -26,7 +26,7 @@ echo "Checking for formatting errors introduced since $MERGE_BASE"
 
 # Do the checking. "eval" is used so that quotes (as inserted into $EXCLUDES
 # above) are not interpreted as parts of file names.
-eval git-clang-format-7 --binary clang-format-7 $MERGE_BASE -- $EXCLUDES
+eval git-clang-format --binary clang-format-10 $MERGE_BASE -- $EXCLUDES
 git diff > formatted.diff
 if [[ -s formatted.diff ]] ; then
   echo 'Formatting error! The following diff shows the required changes'

--- a/.github/workflows/pull-request-checks.yaml
+++ b/.github/workflows/pull-request-checks.yaml
@@ -502,8 +502,8 @@ jobs:
           DEBIAN_FRONTEND: noninteractive
         run: |
           sudo apt-get update
-          sudo apt-get install --no-install-recommends -yq clang-format-7
-      - name: Check updated lines of code match clang-format-7 style
+          sudo apt-get install --no-install-recommends -yq clang-format
+      - name: Check updated lines of code match clang-format-10 style
         env:
           BASE_BRANCH: ${{ github.base_ref }}
           MERGE_BRANCH: ${{ github.ref }}

--- a/CODING_STANDARD.md
+++ b/CODING_STANDARD.md
@@ -340,13 +340,13 @@ To avoid waiting until you've made a PR to find formatting issues, you can
 install clang-format locally and run it against your code as you are working.
 
 Different versions of clang-format have slightly different behaviors. CBMC uses
-clang-format-7 as it is available the repositories for Ubuntu 18.04 and
+clang-format-10 as it is available the repositories for Ubuntu 18.04 and
 Homebrew.
 To install on a Unix-like system, try installing using the system package
 manager:
 ```
-apt-get install clang-format-7  # Run this on Ubuntu, Debian etc.
-brew install clang-format@7     # Run this on a Mac with Homebrew installed
+apt-get install clang-format-10  # Run this on Ubuntu, Debian etc.
+brew install clang-format@10     # Run this on a Mac with Homebrew installed
 ```
 
 If your platform doesn't have a package for clang-format, you can download a
@@ -358,12 +358,12 @@ the [LLVM Snapshot Builds page](http://llvm.org/builds/).
 
 ### FORMATTING A RANGE OF COMMITS
 
-Clang-format is distributed with a driver script called git-clang-format-7.
+Clang-format is distributed with a driver script called git-clang-format.
 This script can be used to format git diffs (rather than entire files).
 
 After committing some code, it is recommended to run:
 ```
-git-clang-format-7 upstream/develop
+git-clang-format upstream/develop
 ```
 *Important:* If your branch is based on a branch other than `upstream/develop`,
 use the name or checksum of that branch instead. It is strongly recommended to
@@ -373,7 +373,7 @@ rebase your work onto the tip of the branch it's based on before running
 Note: By default, git-clang-format uses the git config variable
 `clangformat.binary`. If you have multiple versions of clang-format installed,
 you might need to update this, or explicitly specify the binary to use via
-`--binary clang-format-7`.
+`--binary clang-format-10`.
 
 ### RETROACTIVELY FORMATTING INDIVIDUAL COMMITS
 
@@ -385,7 +385,7 @@ The following command will stop at each commit in the range and run
 clang-format on the diff at that point.  This rewrites git history, so it's
 *unsafe*, and you should back up your branch before running this command:
 ```
-git filter-branch --tree-filter 'git-clang-format-7 upstream/develop' \
+git filter-branch --tree-filter 'git-clang-format upstream/develop' \
   -- upstream/develop..HEAD
 ```
 *Important*: `upstream/develop` should be changed in *both* places in the

--- a/integration/linux/compile_linux.sh
+++ b/integration/linux/compile_linux.sh
@@ -21,7 +21,7 @@ make -C src CXX='ccache /usr/bin/g++' cbmc.dir goto-cc.dir goto-diff.dir -j$(npr
 [ -d one-line-scan ] || git clone https://github.com/awslabs/one-line-scan.git one-line-scan
 
 # Get Linux v5.10, if we do not have it already
-[ -d linux_5_10 ] || git clone -b v5.10 --depth=1 https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable.git linux_5_10
+[ -d linux_5_10 ] || git clone -b v5.10 --depth=1 https://github.com/torvalds/linux/ linux_5_10
 
 # Prepare compile a part of the kernel with CBMC via one-line-scan
 ln -s goto-cc src/goto-cc/goto-ld


### PR DESCRIPTION
clang-format-7 (or older) might not even be available anymore on some
systems, and will certainly not be the default. clang-format-10 has
improved support for initializer lists, resulting in different
formatting of these:
```
foo bar{value_1,
        value_2};
```
now is formatted as
```
foo bar{
  value_1,
  value_2};
```
which is more consistent with how the same would have been formatted
had parentheses been used.

clang-format-10 is even available on Ubuntu 18.04, which is the most
dated system our CI builds are still running on.

Fixes: #6457

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [x] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
