### PR TITLE
Codify grouping and order of includes

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -47,7 +47,18 @@ NamespaceIndentation: None
 PenaltyBreakString: 10000
 PointerAlignment: Right
 ReflowComments: 'false'
-SortIncludes: 'true'
+IncludeBlocks: Regroup
+IncludeCategories:
+  - Regex: '<util/'
+    Priority: 1
+  - Regex: '<goto-programs/'
+    Priority: 2
+  - Regex: '<.+/.+>'
+    Priority: 3
+  - Regex: '^"[^/]+"$'
+    Priority: 4
+  - Regex: '<[^/]+>'
+    Priority: 5
 SpaceAfterCStyleCast: 'false'
 SpaceBeforeAssignmentOperators: 'true'
 SpaceBeforeParens: Never

--- a/CODING_STANDARD.md
+++ b/CODING_STANDARD.md
@@ -148,7 +148,7 @@ Formatting is enforced using clang-format. For more information about this, see
 - The corresponding header for a given source file should always be the *first*
   include in the source file. For example, given `foo.h` and `foo.cpp`, the
   line `#include "foo.h"` should precede all other include statements in
-  `foo.cpp`.
+  `foo.cpp`. clang-format will enforce this.
 - Use the C++ versions of C headers (e.g. `cmath` instead of `math.h`).
   Some of the C headers use macros instead of functions which can have
   unexpected consequences.

--- a/integration/linux/compile_linux.sh
+++ b/integration/linux/compile_linux.sh
@@ -21,7 +21,7 @@ make -C src CXX='ccache /usr/bin/g++' cbmc.dir goto-cc.dir goto-diff.dir -j$(npr
 [ -d one-line-scan ] || git clone https://github.com/awslabs/one-line-scan.git one-line-scan
 
 # Get Linux v5.10, if we do not have it already
-[ -d linux_5_10 ] || git clone -b v5.10 --depth=1 https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable.git linux_5_10
+[ -d linux_5_10 ] || git clone -b v5.10 --depth=1 https://github.com/torvalds/linux/ linux_5_10
 
 # Prepare compile a part of the kernel with CBMC via one-line-scan
 ln -s goto-cc src/goto-cc/goto-ld


### PR DESCRIPTION
clang-format supports describing groups of includes via regular
expressions and assigning priorities to them. The include file
corresponding to an implementation will always have priority 0. Other
priorities are now set in the clang-format configuration. Includes not
specified will be auto-assigned INT_MAX as priority.

If people disagree with the proposed order (implementation-header file; util; goto-programs; any other directory; current directory; standard library) then please just voice this.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [x] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- n/a Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
