### PR TITLE
Reassign CODEOWNER roles from @chrisr-diffblue to @chris-ryder

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,15 +2,15 @@
 # approval within two weeks.
 #
 # These owners will be the default owners for everything in the repo.
-*       @kroening @tautschnig @peterschrammel @chrisr-diffblue
+*       @kroening @tautschnig @peterschrammel @chris-ryder
 
 # These files should rarely change
 
 /src/big-int/ @kroening
-/src/ansi-c/ @kroening @tautschnig @chrisr-diffblue
-/src/assembler/ @kroening @tautschnig @chrisr-diffblue
-/src/goto-cc/ @kroening @tautschnig @chrisr-diffblue
-/src/linking/ @kroening @tautschnig @chrisr-diffblue
+/src/ansi-c/ @kroening @tautschnig @chris-ryder
+/src/assembler/ @kroening @tautschnig @chris-ryder
+/src/goto-cc/ @kroening @tautschnig @chris-ryder
+/src/linking/ @kroening @tautschnig @chris-ryder
 /src/memory-models/ @kroening @tautschnig
 /src/goto-checker/ @kroening @tautschnig @peterschrammel
 /src/goto-symex/ @kroening @tautschnig @peterschrammel @romainbrenguier
@@ -36,27 +36,27 @@
 /src/solvers/refinement @martin-cs @romainbrenguier @peterschrammel
 /src/solvers/strings @martin-cs @romainbrenguier @peterschrammel
 /jbmc/src/java_bytecode/ @romainbrenguier @peterschrammel
-/src/analyses/ @martin-cs @peterschrammel @chrisr-diffblue
-/src/pointer-analysis/ @martin-cs @peterschrammel @chrisr-diffblue
+/src/analyses/ @martin-cs @peterschrammel @chris-ryder
+/src/pointer-analysis/ @martin-cs @peterschrammel @chris-ryder
 
 
 # These files change frequently and changes are medium-risk
 
-/src/goto-analyzer/ @martin-cs @chrisr-diffblue @peterschrammel
-/src/goto-harness/ @martin-cs @chrisr-diffblue @peterschrammel
-/src/goto-instrument/ @martin-cs @chrisr-diffblue @peterschrammel
+/src/goto-analyzer/ @martin-cs @chris-ryder @peterschrammel
+/src/goto-harness/ @martin-cs @chris-ryder @peterschrammel
+/src/goto-instrument/ @martin-cs @chris-ryder @peterschrammel
 /src/goto-instrument/contracts/ @tautschnig @feliperodri @SaswatPadhi
 /doc/cprover-manual/contracts* @tautschnig @feliperodri @SaswatPadhi
 /src/goto-diff/ @tautschnig @peterschrammel
 /src/jsil/ @kroening @tautschnig
-/src/memory-analyzer/ @tautschnig @chrisr-diffblue
+/src/memory-analyzer/ @tautschnig @chris-ryder
 /jbmc/src/jbmc/ @peterschrammel @romainbrenguier
 /jbmc/src/janalyzer/ @peterschrammel @romainbrenguier
 /jbmc/src/jdiff/ @peterschrammel
 /src/cpp/ @kroening @tautschnig @peterschrammel
 /src/solvers/smt2 @kroening @martin-cs @peterschrammel @thomasspriggs @NlightNFotis @TGWDB
-/src/solvers/smt2_incremental @peterschrammel @thomasspriggs @NlightNFotis @TGWDB @chrisr-diffblue
-/src/solvers/Makefile @kroening @tautschnig @peterschrammel @chrisr-diffblue @thomasspriggs @NlightNFotis @TGWDB
+/src/solvers/smt2_incremental @peterschrammel @thomasspriggs @NlightNFotis @TGWDB @chris-ryder
+/src/solvers/Makefile @kroening @tautschnig @peterschrammel @chris-ryder @thomasspriggs @NlightNFotis @TGWDB
 /src/statement-list/ @kroening @tautschnig @peterschrammel @pkesseli
 
 /cmake/        @diffblue/diffblue-opensource


### PR DESCRIPTION
At the end of Feb 2022 I will be leaving Diffblue - however I still hope to be involved with CBMC as an individual developer, so I am proposing to reassign my current code owner roles from my Diffblue-linked GitHub account, to my personal GitHub account. I will retain control of my Diffblue-linked account, so will still receive notifications, etc if anyone tags me under the old account name - and also to reduce the risk of spoofing.

I'd suggest this change should not be merged without @peterschrammel approving.

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

