### PR TITLE
Diversify GitHub CI build platforms: add macOS 11, Windows 2022

### DIFF
--- a/.github/workflows/pull-request-checks.yaml
+++ b/.github/workflows/pull-request-checks.yaml
@@ -343,8 +343,8 @@ jobs:
       - name: Run JBMC regression tests
         run: make -C jbmc/regression test-parallel JOBS=3
 
-  check-macos-10_15-cmake-clang:
-    runs-on: macos-10.15
+  check-macos-11-cmake-clang:
+    runs-on: macos-11
     steps:
       - uses: actions/checkout@v2
         with:
@@ -426,8 +426,8 @@ jobs:
           Set-Location build
           ctest -V -L CORE -C Release . -j2
 
-  check-vs-2019-make-build-and-test:
-    runs-on: windows-2019
+  check-vs-2022-make-build-and-test:
+    runs-on: windows-2022
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:

--- a/src/ansi-c/clang_builtin_headers.h
+++ b/src/ansi-c/clang_builtin_headers.h
@@ -47,7 +47,30 @@ __gcc_v4sf __builtin_ia32_vfmsubss3_mask3(__gcc_v4sf, __gcc_v4sf, __gcc_v4sf, un
 
 __gcc_v4sf __builtin_ia32_cvtsd2ss_round_mask(__gcc_v4sf, __gcc_v2df, __gcc_v4sf, unsigned char, int);
 __gcc_v2df __builtin_ia32_cvtss2sd_round_mask(__gcc_v2df, __gcc_v4sf, __gcc_v2df, unsigned char, int);
-// clang-format on
+
+void __builtin_ia32_tile_loadconfig_internal(const void *);
+__gcc_v256si __builtin_ia32_tileloadd64_internal(unsigned short, unsigned short, const void *, __CPROVER_size_t);
+__gcc_v256si __builtin_ia32_tileloaddt164_internal(unsigned short, unsigned short, const void *, __CPROVER_size_t);
+__gcc_v256si __builtin_ia32_tdpbssd_internal(unsigned short, unsigned short, unsigned short, __gcc_v256si, __gcc_v256si, __gcc_v256si);
+__gcc_v256si __builtin_ia32_tdpbsud_internal(unsigned short, unsigned short, unsigned short, __gcc_v256si, __gcc_v256si, __gcc_v256si);
+__gcc_v256si __builtin_ia32_tdpbusd_internal(unsigned short, unsigned short, unsigned short, __gcc_v256si, __gcc_v256si, __gcc_v256si);
+__gcc_v256si __builtin_ia32_tdpbuud_internal(unsigned short, unsigned short, unsigned short, __gcc_v256si, __gcc_v256si, __gcc_v256si);
+void __builtin_ia32_tilestored64_internal(unsigned short, unsigned short, void *, __CPROVER_size_t, __gcc_v256si);
+__gcc_v256si __builtin_ia32_tilezero_internal(unsigned short, unsigned short);
+__gcc_v256si __builtin_ia32_tdpbf16ps_internal(unsigned short, unsigned short, unsigned short, __gcc_v256si, __gcc_v256si, __gcc_v256si);
+void __builtin_ia32_tile_loadconfig(const void *);
+void __builtin_ia32_tile_storeconfig(const void *);
+void __builtin_ia32_tilerelease(void);
+void __builtin_ia32_tilezero(unsigned char);
+void __builtin_ia32_tileloadd64(__tile, const void *, __CPROVER_size_t);
+void __builtin_ia32_tileloaddt164(__tile, const void *, __CPROVER_size_t);
+void __builtin_ia32_tilestored64(__tile, void *, __CPROVER_size_t);
+void __builtin_ia32_tdpbssd(__tile, __tile, __tile);
+void __builtin_ia32_tdpbsud(__tile, __tile, __tile);
+void __builtin_ia32_tdpbusd(__tile, __tile, __tile);
+void __builtin_ia32_tdpbuud(__tile, __tile, __tile);
+void __builtin_ia32_tdpbf16ps(__tile, __tile, __tile);
+void __builtin_ia32_ptwrite64(unsigned long long);
 
 void __builtin_nontemporal_store();
 void __builtin_nontemporal_load();

--- a/src/ansi-c/gcc_builtin_headers_types.h
+++ b/src/ansi-c/gcc_builtin_headers_types.h
@@ -12,6 +12,7 @@ typedef int    __gcc_v2si  __attribute__ ((__vector_size__ (8)));
 typedef int    __gcc_v4si  __attribute__ ((__vector_size__ (16)));
 typedef int    __gcc_v8si  __attribute__ ((__vector_size__ (32)));
 typedef int    __gcc_v16si  __attribute__ ((__vector_size__ (64)));
+typedef int    __gcc_v256si  __attribute__ ((__vector_size__ (1024)));
 typedef short  __gcc_v4hi  __attribute__ ((__vector_size__ (8)));
 typedef short  __gcc_v8hi  __attribute__ ((__vector_size__ (16)));
 typedef short  __gcc_v16hi __attribute__ ((__vector_size__ (32)));
@@ -32,4 +33,6 @@ typedef unsigned long long __gcc_di;
 enum __gcc_atomic_memmodels {
   __ATOMIC_RELAXED, __ATOMIC_CONSUME, __ATOMIC_ACQUIRE, __ATOMIC_RELEASE, __ATOMIC_ACQ_REL, __ATOMIC_SEQ_CST
 };
+
+typedef unsigned char __tile __attribute__ ((__vector_size__ (1024)));
 // clang-format on


### PR DESCRIPTION
GitHub runners have gained support for Windows 2022 and macOS 11. Switch
some of our CI jobs to these newer platforms to make sure we detect
platform-specific issues. There remain other CI jobs on the previous
platforms (Windows 2019 and macOS 10.15, respectively).

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
