### PR TITLE
goto-symex: print status note and conditional warning for self-loops

### DIFF
--- a/regression/cbmc/self_loops_to_assumptions1/default.desc
+++ b/regression/cbmc/self_loops_to_assumptions1/default.desc
@@ -1,6 +1,8 @@
 CORE
 main.c
 --unwind 1 --unwinding-assertions
+^replacing self-loop at file main.c line 3 function main by assume\(FALSE\)$
+^no unwinding assertion will be generated for self-loop at file main.c line 3 function main$
 ^EXIT=0$
 ^SIGNAL=0$
 ^VERIFICATION SUCCESSFUL$

--- a/regression/cbmc/self_loops_to_assumptions1/no-assume.desc
+++ b/regression/cbmc/self_loops_to_assumptions1/no-assume.desc
@@ -5,3 +5,4 @@ main.c
 ^SIGNAL=0$
 ^VERIFICATION FAILED$
 --
+^replacing self-loop


### PR DESCRIPTION
Unless CBMC is invoked with --no-self-loops-to-assumptions, self-loops
are replaced by assumptions. This commit now introduces a status output
that such replacement is happening, and also a warning when
--unwinding-assertions is set: as the loop is replaced by an assumption,
no unwinding assertions can possible be generated. This behaviour may be
unexpected by the user, and we should therefore let them know what is
going on.

Fixes: #6433

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
