### PR TITLE
clang-format header include grouping: _class.h has top priority

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -49,6 +49,8 @@ PointerAlignment: Right
 ReflowComments: 'false'
 IncludeBlocks: Regroup
 IncludeCategories:
+  - Regex: '_class.h(>|")$'
+    Priority: 0
   - Regex: '<util/'
     Priority: 1
   - Regex: '<goto-programs/'


### PR DESCRIPTION
In some cases, the main include file has a suffix _class.h, and should
therefore be placed at the top. This is a follow-up to 3b7b19a50.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- n/a Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
