### PR TITLE
Add support for incremental SMT traces containing C_bool

### DIFF
--- a/regression/cbmc-incr-smt2/nondeterministic-int-assert/stdbool.desc
+++ b/regression/cbmc-incr-smt2/nondeterministic-int-assert/stdbool.desc
@@ -1,0 +1,13 @@
+CORE
+stdbool_example.c
+--incremental-smt2-solver 'z3 --smt2 -in' --trace
+Passing problem to incremental SMT2 solving via "z3 --smt2 -in"
+VERIFICATION FAILED
+equal=FALSE\s*\([0 ]+\)
+equal=TRUE\s*\([0 ]+1\)
+^EXIT=10$
+^SIGNAL=0$
+--
+--
+Test that running cbmc with the `--incremental-smt2-solver` argument can be used
+to generate a trace including values of C bool variables.

--- a/regression/cbmc-incr-smt2/nondeterministic-int-assert/stdbool_example.c
+++ b/regression/cbmc-incr-smt2/nondeterministic-int-assert/stdbool_example.c
@@ -1,0 +1,10 @@
+#include <stdbool.h>
+
+int main()
+{
+  int x, y;
+  bool equal = x == y;
+  __CPROVER_assert(equal, "Assert of integer equality.");
+  __CPROVER_assert(!equal, "Assert of not integer equality.");
+  return 0;
+}

--- a/src/solvers/smt2_incremental/construct_value_expr_from_smt.cpp
+++ b/src/solvers/smt2_incremental/construct_value_expr_from_smt.cpp
@@ -38,11 +38,12 @@ private:
   void visit(const smt_bit_vector_constant_termt &bit_vector_constant) override
   {
     if(
-      const auto integer_type =
-        type_try_dynamic_cast<integer_bitvector_typet>(type_to_construct))
+      const auto bitvector_type =
+        type_try_dynamic_cast<bitvector_typet>(type_to_construct))
     {
       INVARIANT(
-        integer_type->get_width() == bit_vector_constant.get_sort().bit_width(),
+        bitvector_type->get_width() ==
+          bit_vector_constant.get_sort().bit_width(),
         "Width of smt bit vector term must match the width of bit vector "
         "type.");
       result = from_integer(bit_vector_constant.value(), type_to_construct);

--- a/unit/solvers/smt2_incremental/construct_value_expr_from_smt.cpp
+++ b/unit/solvers/smt2_incremental/construct_value_expr_from_smt.cpp
@@ -1,20 +1,17 @@
 // Author: Diffblue Ltd.
 
-#include <testing-utils/use_catch.h>
-
-#include <solvers/smt2_incremental/construct_value_expr_from_smt.h>
-
-#include <solvers/smt2_incremental/smt_core_theory.h>
-#include <solvers/smt2_incremental/smt_terms.h>
-#include <solvers/smt2_incremental/smt_to_smt2_string.h>
-
-#include <testing-utils/invariant.h>
-
 #include <util/arith_tools.h>
 #include <util/bitvector_types.h>
 #include <util/mp_arith.h>
 #include <util/std_expr.h>
 #include <util/std_types.h>
+
+#include <solvers/smt2_incremental/construct_value_expr_from_smt.h>
+#include <solvers/smt2_incremental/smt_core_theory.h>
+#include <solvers/smt2_incremental/smt_terms.h>
+#include <solvers/smt2_incremental/smt_to_smt2_string.h>
+#include <testing-utils/invariant.h>
+#include <testing-utils/use_catch.h>
 
 #include <string>
 

--- a/unit/solvers/smt2_incremental/construct_value_expr_from_smt.cpp
+++ b/unit/solvers/smt2_incremental/construct_value_expr_from_smt.cpp
@@ -2,6 +2,7 @@
 
 #include <util/arith_tools.h>
 #include <util/bitvector_types.h>
+#include <util/c_types.h>
 #include <util/mp_arith.h>
 #include <util/std_expr.h>
 #include <util/std_types.h>
@@ -65,6 +66,8 @@ TEST_CASE("Value expr construction from smt.", "[core][smt2_incremental]")
   std::tie(input_term, expected_result) = GENERATE(
     rowt{smt_bool_literal_termt{true}, true_exprt{}},
     rowt{smt_bool_literal_termt{false}, false_exprt{}},
+    rowt{smt_bit_vector_constant_termt{0, 8}, from_integer(0, c_bool_typet(8))},
+    rowt{smt_bit_vector_constant_termt{1, 8}, from_integer(1, c_bool_typet(8))},
     UNSIGNED_BIT_VECTOR_TESTS(8),
     SIGNED_BIT_VECTOR_TESTS(8),
     UNSIGNED_BIT_VECTOR_TESTS(16),


### PR DESCRIPTION
An "unsupported type" invariant violation would previously have been
encountered when attempting to generate traces featuring `c_bool_typet`.
This is due to `c_bool_typet` not being castable to
`integer_bitvector_typet`.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
