### PR TITLE
Retain property ids when they are already set and unique

### DIFF
--- a/src/goto-programs/set_properties.cpp
+++ b/src/goto-programs/set_properties.cpp
@@ -12,6 +12,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "set_properties.h"
 
 #include <util/exception_utils.h>
+#include <util/string2int.h>
 
 #include "goto_model.h"
 
@@ -58,6 +59,21 @@ void label_properties(
   {
     if(!it->is_assert())
       continue;
+
+    if(!it->source_location().get_property_id().empty())
+    {
+      std::string id = id2string(it->source_location().get_property_id());
+      std::string::size_type prefix_end = id.rfind('.');
+      if(prefix_end != std::string::npos)
+      {
+        std::string prefix = id.substr(0, prefix_end + 1);
+        if(auto suffix = string2optional_size_t(id.substr(prefix_end + 1)))
+        {
+          if(property_counters.emplace(prefix, *suffix).second)
+            continue;
+        }
+      }
+    }
 
     irep_idt function = it->source_location().get_function();
 


### PR DESCRIPTION
This will enable setting loop unwinding assertion ids in GOTO programs
by goto-instrument's loop unwinder.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
