### PR TITLE
goto-instrument --unwind: unwinding assertions do not disable unwinding assumptions

### DIFF
--- a/regression/goto-instrument/unwind-assert2/main.c
+++ b/regression/goto-instrument/unwind-assert2/main.c
@@ -3,4 +3,5 @@ int main()
 {
   int i;
   for(i = 0; i < 10; i++) {}
+  __CPROVER_assert(0, "fails when fully unwinding the loop");
 }

--- a/regression/goto-instrument/unwind-assert2/test.desc
+++ b/regression/goto-instrument/unwind-assert2/test.desc
@@ -1,6 +1,8 @@
 CORE
 main.c
 --unwind 9 --unwinding-assertions
+^\[main.assertion.1\] line 6 fails when fully unwinding the loop: SUCCESS$
+^\*\* 1 of 2 failed
 ^EXIT=10$
 ^SIGNAL=0$
 ^VERIFICATION FAILED$

--- a/src/goto-instrument/goto_instrument_parse_options.cpp
+++ b/src/goto-instrument/goto_instrument_parse_options.cpp
@@ -194,7 +194,7 @@ int goto_instrument_parse_optionst::doit()
 
         if(unwinding_assertions)
         {
-          unwind_strategy=goto_unwindt::unwind_strategyt::ASSERT;
+          unwind_strategy = goto_unwindt::unwind_strategyt::ASSERT_ASSUME;
         }
         else if(partial_loops)
         {

--- a/src/goto-instrument/unwind.h
+++ b/src/goto-instrument/unwind.h
@@ -21,7 +21,13 @@ class unwindsett;
 class goto_unwindt
 {
 public:
-  enum class unwind_strategyt { CONTINUE, PARTIAL, ASSERT, ASSUME };
+  enum class unwind_strategyt
+  {
+    CONTINUE,
+    PARTIAL,
+    ASSERT_ASSUME,
+    ASSUME
+  };
 
   // unwind loop
 


### PR DESCRIPTION
In keeping with CBMC's behaviour, generate unwinding assumptions even
when unwinding assertions are generated for (failing) assertions are not
considered fatal in GOTO programs. Unwinding assumptions should only be
skipped when partial loops are requested.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
