### PR TITLE
Pointer overflow checks should detect overflow in offset multiplication

### DIFF
--- a/regression/cbmc/pointer-overflow4/main.c
+++ b/regression/cbmc/pointer-overflow4/main.c
@@ -1,0 +1,11 @@
+#include <stdint.h>
+
+int main()
+{
+  int32_t i[5];
+  // Offset 1 resulted in spuriously failing to detect an overflow in pointer
+  // arithmetic in the next line for PTRDIFF_MAX * 4 + 4 = 0 in wrap-around
+  // semantics. Any other offset would yield the expected failure.
+  int32_t *p = &i[1];
+  int32_t *q = p + PTRDIFF_MAX;
+}

--- a/regression/cbmc/pointer-overflow4/test.desc
+++ b/regression/cbmc/pointer-overflow4/test.desc
@@ -1,0 +1,10 @@
+CORE
+main.c
+--pointer-overflow-check
+^\[main.overflow.1\] line 10 arithmetic overflow on signed \* in (0x)?[0-9a-fA-F]+l* \* \(signed (long (long )?)?int\)4ul*: FAILURE$
+^\*\* 1 of \d+ failed
+^VERIFICATION FAILED$
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring

--- a/src/analyses/goto_check_c.cpp
+++ b/src/analyses/goto_check_c.cpp
@@ -347,8 +347,8 @@ protected:
 class flag_resett
 {
 public:
-  explicit flag_resett(const goto_programt::instructiont &_instruction)
-    : instruction(_instruction)
+  explicit flag_resett(const source_locationt &source_location)
+    : source_location(source_location)
   {
   }
 
@@ -367,7 +367,7 @@ public:
     INVARIANT(
       flags_to_reset.find(&flag) == flags_to_reset.end(),
       "Flag " + id2string(flag_name) + " set twice at \n" +
-        instruction.source_location().pretty());
+        source_location.as_string());
     if(flag != new_value)
     {
       flags_to_reset[&flag] = flag;
@@ -384,7 +384,7 @@ public:
     INVARIANT(
       disabled_flags.find(&flag) == disabled_flags.end(),
       "Flag " + id2string(flag_name) + " disabled twice at \n" +
-        instruction.source_location().pretty());
+        source_location.as_string());
 
     disabled_flags.insert(&flag);
 
@@ -408,7 +408,7 @@ public:
   }
 
 private:
-  const goto_programt::instructiont &instruction;
+  const source_locationt &source_location;
   std::map<bool *, bool> flags_to_reset;
   std::set<bool *> disabled_flags;
 };
@@ -2027,7 +2027,7 @@ void goto_check_ct::goto_check(
     current_target = it;
     goto_programt::instructiont &i = *it;
 
-    flag_resett resetter(i);
+    flag_resett resetter(i.source_location());
     const auto &pragmas = i.source_location().get_pragmas();
     for(const auto &d : pragmas)
     {
@@ -2110,7 +2110,7 @@ void goto_check_ct::goto_check(
       // Disable enum range checks for left-hand sides as their values are yet
       // to be set (by this assignment).
       {
-        flag_resett resetter(i);
+        flag_resett resetter(i.source_location());
         resetter.disable_flag(enable_enum_range_check, "enum_range_check");
         check(assign_lhs);
       }

--- a/src/analyses/goto_check_c.cpp
+++ b/src/analyses/goto_check_c.cpp
@@ -344,10 +344,10 @@ protected:
 ///
 /// A flag's initial value (before any `set_flag` or `disable_flag`) is restored
 /// when the entire object goes out of scope.
-class flag_resett
+class flag_overridet
 {
 public:
-  explicit flag_resett(const source_locationt &source_location)
+  explicit flag_overridet(const source_locationt &source_location)
     : source_location(source_location)
   {
   }
@@ -401,7 +401,7 @@ public:
 
   /// \brief Restore the values of all flags that have been
   /// modified via `set_flag`.
-  ~flag_resett()
+  ~flag_overridet()
   {
     for(const auto &flag_pair : flags_to_reset)
       *flag_pair.first = flag_pair.second;
@@ -2027,7 +2027,7 @@ void goto_check_ct::goto_check(
     current_target = it;
     goto_programt::instructiont &i = *it;
 
-    flag_resett resetter(i.source_location());
+    flag_overridet resetter(i.source_location());
     const auto &pragmas = i.source_location().get_pragmas();
     for(const auto &d : pragmas)
     {
@@ -2110,7 +2110,7 @@ void goto_check_ct::goto_check(
       // Disable enum range checks for left-hand sides as their values are yet
       // to be set (by this assignment).
       {
-        flag_resett resetter(i.source_location());
+        flag_overridet resetter(i.source_location());
         resetter.disable_flag(enable_enum_range_check, "enum_range_check");
         check(assign_lhs);
       }


### PR DESCRIPTION
Pointer arithmetic requires multiplication of the offset by the size of
the base type (for any base type larger than 1 byte). Such a
multiplication isn't introduced until the back-end, where no opportunity
for adding properties exists anymore. Therefore, synthesize the
multiplication to generate arithmetic overflow checks at the GOTO level.

Fixes: #6631

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
