### PR TITLE
Simplify overflow-mult when one operand is 1

### DIFF
--- a/src/util/simplify_expr.cpp
+++ b/src/util/simplify_expr.cpp
@@ -2174,10 +2174,19 @@ simplify_exprt::simplify_complex(const unary_exprt &expr)
 simplify_exprt::resultt<>
 simplify_exprt::simplify_overflow_binary(const binary_overflow_exprt &expr)
 {
-  // zero is a neutral element for all operations supported here
+  // When one operand is zero, an overflow can only occur for a subtraction from
+  // zero.
   if(
     expr.op1().is_zero() ||
     (expr.op0().is_zero() && expr.id() != ID_overflow_minus))
+  {
+    return false_exprt{};
+  }
+
+  // One is neutral element for multiplication
+  if(
+    expr.id() == ID_overflow_mult &&
+    (expr.op0().is_one() || expr.op1().is_one()))
   {
     return false_exprt{};
   }


### PR DESCRIPTION
1 (one) is a neutral element for multiplication.

Depending on the order of reviews/approvals, this PR or #6633 will require merge conflict resolution: #6633 introduces additional checks, some of which can be simplified away via the changes in this PR.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
