### PR TITLE
Makefile builds: add install target

### DIFF
--- a/jbmc/src/Makefile
+++ b/jbmc/src/Makefile
@@ -61,7 +61,18 @@ setup-submodules:
 dist: setup-submodules all
 	mkdir -p $(ROOT)dist/lib
 	cp ../lib/java-models-library/target/core-models.jar $(ROOT)dist/lib
+	cp ../lib/java-models-library/target/cprover-api.jar $(ROOT)dist/lib
 	mkdir -p $(ROOT)dist/bin
 	cp jbmc/jbmc $(ROOT)dist/bin
 	cp janalyzer/janalyzer $(ROOT)dist/bin
 	cp jdiff/jdiff $(ROOT)dist/bin
+
+.PHONY: install
+install: setup-submodules all
+	$(MAKE) $(MAKEARGS) -C $(CPROVER_DIR)/src install
+	cp ../lib/java-models-library/target/core-models.jar $(PREFIX)/lib/
+	cp ../lib/java-models-library/target/cprover-api.jar $(PREFIX)/lib/
+	cp jbmc/jbmc $(PREFIX)/bin/
+	cp janalyzer/janalyzer $(PREFIX)/bin/
+	cp jdiff/jdiff $(PREFIX)/bin/
+	cp ../../doc/man/j* $(PREFIX)/doc/man/man1/

--- a/src/Makefile
+++ b/src/Makefile
@@ -169,4 +169,16 @@ cadical-download:
 doc :
 	doxygen
 
-.PHONY: minisat2-download cudd-download glucose-download cadical-download
+install: all
+	for b in \
+		cbmc crangler \
+		goto-analyzer goto-cc goto-diff goto-instrument goto-harness \
+		symtab2gb ; do \
+		  cp $$b/$$b $(PREFIX)/bin/ ; \
+			cp ../doc/man/$$b.1 $(PREFIX)/doc/man/man1/ ; \
+	done
+	ln -sf $(PREFIX)/bin/goto-cc $(PREFIX)/bin/goto-gcc
+	ln -sf $(PREFIX)/bin/goto-cc $(PREFIX)/bin/goto-ld
+	cp ../scripts/ls_parse.py $(PREFIX)/bin/
+
+.PHONY: minisat2-download cudd-download glucose-download cadical-download install


### PR DESCRIPTION
Our CMake-based builds already support an "install" target to put
various built binaries (and man pages) in place. Add a similar target to
Makefile-based builds.

Fixes: #6443

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
