### PR TITLE
C library/getenv test: actually try to dereference the result

### DIFF
--- a/regression/cbmc-library/getenv-01/main.c
+++ b/regression/cbmc-library/getenv-01/main.c
@@ -5,4 +5,8 @@ int main()
   char *something;
   // there should not be any overflow in there
   something = getenv("HOME");
+  if(something != NULL)
+    return something[0];
+  else
+    return 0;
 }

--- a/regression/cbmc-library/getenv-01/test.desc
+++ b/regression/cbmc-library/getenv-01/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---signed-overflow-check --unsigned-overflow-check --pointer-overflow-check --pointer-check --bounds-check
+--signed-overflow-check --unsigned-overflow-check --pointer-overflow-check --pointer-check --bounds-check --memory-leak-check
 ^EXIT=0$
 ^SIGNAL=0$
 ^VERIFICATION SUCCESSFUL$

--- a/src/ansi-c/library/stdlib.c
+++ b/src/ansi-c/library/stdlib.c
@@ -415,15 +415,13 @@ inline long atol(const char *nptr)
 
 #undef getenv
 
-#ifndef __CPROVER_LIMITS_H_INCLUDED
-#include <limits.h>
-#define __CPROVER_LIMITS_H_INCLUDED
+#ifndef __CPROVER_STDDEF_H_INCLUDED
+#  include <stddef.h>
+#  define __CPROVER_STDDEF_H_INCLUDED
 #endif
 
 __CPROVER_bool __VERIFIER_nondet___CPROVER_bool();
-__CPROVER_size_t __VERIFIER_nondet___CPROVER_size_t();
-
-inline void *__builtin_alloca(__CPROVER_size_t alloca_size);
+ptrdiff_t __VERIFIER_nondet_ptrdiff_t();
 
 inline char *getenv(const char *name)
 {
@@ -435,29 +433,35 @@ inline char *getenv(const char *name)
     "zero-termination of argument of getenv");
   #endif
 
-  #ifdef __CPROVER_CUSTOM_BITVECTOR_ANALYSIS
+#ifdef __CPROVER_CUSTOM_BITVECTOR_ANALYSIS
   __CPROVER_event("invalidate_pointer", "getenv_result");
   char *getenv_result;
   __CPROVER_set_must(getenv_result, "getenv_result");
   return getenv_result;
 
-  #else
+#else
 
   __CPROVER_bool found=__VERIFIER_nondet___CPROVER_bool();
   if(!found) return 0;
 
-  __CPROVER_size_t buf_size=__VERIFIER_nondet___CPROVER_size_t();
+  ptrdiff_t buf_size = __VERIFIER_nondet_ptrdiff_t();
 
   // It's reasonable to assume this won't exceed the signed
   // range in practice, but in principle, this could exceed
   // the range.
 
-  __CPROVER_assume(1<=buf_size && buf_size<=SSIZE_MAX);
-  char *buffer=(char *)__builtin_alloca(buf_size);
+  __CPROVER_assume(buf_size >= 1);
+  char *buffer = (char *)__CPROVER_allocate(buf_size * sizeof(char), 0);
   buffer[buf_size-1]=0;
 
+#  ifdef __CPROVER_STRING_ABSTRACTION
+  __CPROVER_assume(__CPROVER_buffer_size(buffer) == buf_size);
+  __CPROVER_is_zero_string(buffer) = 1;
+  __CPROVER_zero_string_length(buffer) = buf_size - 1;
+#  endif
+
   return buffer;
-  #endif
+#endif
 }
 
 /* FUNCTION: realloc */


### PR DESCRIPTION
Our regression test would previously succeed even when no implementation
of `getenv` was provided.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
