### PR TITLE
Use source_locationt::nil() instead of local static_cast

### DIFF
--- a/src/cpp/cpp_name.h
+++ b/src/cpp/cpp_name.h
@@ -73,7 +73,7 @@ public:
   const source_locationt &source_location() const
   {
     if(get_sub().empty())
-      return static_cast<const source_locationt &>(get_nil_irep());
+      return source_locationt::nil();
     else
       return static_cast<const source_locationt &>(
         get_sub().front().find(ID_C_source_location));

--- a/src/goto-programs/goto_program.h
+++ b/src/goto-programs/goto_program.h
@@ -497,7 +497,7 @@ public:
 
     explicit instructiont(goto_program_instruction_typet __type)
       : code(static_cast<const codet &>(get_nil_irep())),
-        _source_location(static_cast<const source_locationt &>(get_nil_irep())),
+        _source_location(source_locationt::nil()),
         _type(__type),
         guard(true_exprt())
     {

--- a/src/util/expr.cpp
+++ b/src/util/expr.cpp
@@ -176,7 +176,7 @@ const source_locationt &exprt::find_source_location() const
       return op_l;
   }
 
-  return static_cast<const source_locationt &>(get_nil_irep());
+  return source_locationt::nil();
 }
 
 template <typename T>


### PR DESCRIPTION
Cleanup, no change in behaviour: just use the existing (and previously
already used in multiple places) static nil() member of source_locationt
instead of repeating its implementation in several places.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
