### PR TITLE
Block coverage reporting: do not use built-in locations

### DIFF
--- a/src/goto-instrument/cover_basic_blocks.cpp
+++ b/src/goto-instrument/cover_basic_blocks.cpp
@@ -65,6 +65,7 @@ cover_basic_blockst::cover_basic_blockst(const goto_programt &goto_program)
       !it->source_location().is_nil() &&
       !it->source_location().get_file().empty() &&
       !it->source_location().get_line().empty() &&
+      !it->source_location().is_built_in() &&
       block_info.source_location.is_nil())
     {
       block_info.representative_inst = it; // update


### PR DESCRIPTION
source_linest::insert will disregard any source locations that refer to
built-ins. cover_basic_blockst, however, only checked that any source
location used as basic-block representative had file and line
information. This resulted in cover_basic_blockst believing it had found
a representative source location when source_linest didn't quite agree.

This change makes the example presented in #6536 (which originates from
Rust/Kani) work. The issue wasn't reproducible with C examples.

Fixes: #6536

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
