### PR TITLE
List supported coverage criteria in CBMC's help output

### DIFF
--- a/src/goto-instrument/cover.cpp
+++ b/src/goto-instrument/cover.cpp
@@ -130,7 +130,7 @@ parse_coverage_criterion(const std::string &criterion_string)
     c = coverage_criteriont::MCDC;
   else if(criterion_string == "cover")
     c = coverage_criteriont::COVER;
-  else if(criterion_string == "assume")
+  else if(criterion_string == "assume" || criterion_string == "assumes")
     c = coverage_criteriont::ASSUME;
   else
   {

--- a/src/goto-instrument/cover.h
+++ b/src/goto-instrument/cover.h
@@ -31,7 +31,12 @@ class optionst;
 
 #define HELP_COVER                                                             \
   " --cover CC                   create test-suite with coverage criterion "   \
-  "CC\n"                                                                       \
+  "CC,\n"                                                                      \
+  "                              where CC is one of assertion[s], "            \
+  "assume[s],\n"                                                               \
+  "                              branch[es], condition[s], cover, "            \
+  "decision[s],\n"                                                             \
+  "                              location[s], or mcdc\n"                       \
   " --cover-failed-assertions    do not stop coverage checking at failed "     \
   "assertions\n"                                                               \
   "                              (this is the default for --cover "            \


### PR DESCRIPTION
Rather than making the user read further documentation, list all
(currently) supported coverage criteria when running cbmc --help.

For consistency, also add "assumes" as an alternative way to request
coverage of assume statements (previously only "assume" was supported,
even though we otherwise included the plural variants where applicable).

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
