### PR TITLE
CONTRACTS: Moving `check_frame_conditions` to `instrument_assigns_clauset`.

### DIFF
--- a/src/goto-instrument/contracts/contracts.h
+++ b/src/goto-instrument/contracts/contracts.h
@@ -111,13 +111,6 @@ public:
 
   namespacet ns;
 
-  /// Tells wether to skip or not skip an action
-  enum class skipt
-  {
-    DontSkip,
-    Skip
-  };
-
 protected:
   symbol_tablet &symbol_table;
   goto_functionst &goto_functions;
@@ -133,51 +126,9 @@ protected:
   /// Instrument functions to check frame conditions.
   bool check_frame_conditions_function(const irep_idt &function);
 
-  ///  \brief Insert assertion statements into the goto program to ensure that
-  /// assigned memory is within the assignable memory frame.
-  ///
-  /// \param function Name of the function getting instrumented.
-  /// \param body Body of the function getting instrumented.
-  /// \param instruction_it Iterator to the instruction from which to start
-  /// instrumentation (inclusive).
-  /// \param instruction_end Iterator to the instruction at which to stop
-  /// instrumentation (exclusive).
-  /// \param instrument_spec_assigns Assigns clause instrumenter of the function
-  /// \param skip_parameter_assigns If true, will cause assignments to symbol
-  /// marked as is_parameter to not be instrumented.
-  /// \param cfg_info_opt Control flow graph information can will be used
-  /// for write set optimisation if available.
-  void check_frame_conditions(
-    const irep_idt &function,
-    goto_programt &body,
-    goto_programt::targett instruction_it,
-    const goto_programt::targett &instruction_end,
-    instrument_spec_assignst &instrument_spec_assigns,
-    skipt skip_parameter_assigns,
-    optionalt<cfg_infot> &cfg_info_opt);
-
   /// Check if there are any malloc statements which may be repeated because of
   /// a goto statement that jumps back.
   bool check_for_looped_mallocs(const goto_programt &program);
-
-  /// Inserts an assertion into program immediately before the assignment
-  /// instruction_it, to ensure that the left-hand-side of the assignment
-  /// is "included" in the (conditional address ranges in the) write set.
-  void instrument_assign_statement(
-    goto_programt::targett &instruction_it,
-    goto_programt &program,
-    instrument_spec_assignst &instrument_spec_assigns,
-    optionalt<cfg_infot> &cfg_info_opt);
-
-  /// Inserts an assertion into program immediately before the function call at
-  /// instruction_it, to ensure that all memory locations written to by the
-  // callee are "included" in the (conditional address ranges in the) write set.
-  void instrument_call_statement(
-    goto_programt::targett &instruction_it,
-    const irep_idt &function,
-    goto_programt &body,
-    instrument_spec_assignst &instrument_spec_assigns,
-    optionalt<cfg_infot> &cfg_info_opt);
 
   /// Apply loop contracts, whenever available, to all loops in `function`.
   /// Loop invariants, loop variants, and loop assigns clauses.

--- a/src/goto-instrument/contracts/utils.cpp
+++ b/src/goto-instrument/contracts/utils.cpp
@@ -76,49 +76,6 @@ void havoc_assigns_targetst::append_havoc_code_for_expr(
   havoc_utilst::append_havoc_code_for_expr(location, expr, dest);
 }
 
-void add_pragma_disable_pointer_checks(source_locationt &location)
-{
-  location.add_pragma("disable:pointer-check");
-  location.add_pragma("disable:pointer-primitive-check");
-  location.add_pragma("disable:pointer-overflow-check");
-  location.add_pragma("disable:signed-overflow-check");
-  location.add_pragma("disable:unsigned-overflow-check");
-  location.add_pragma("disable:conversion-check");
-}
-
-goto_programt::instructiont &
-add_pragma_disable_pointer_checks(goto_programt::instructiont &instr)
-{
-  add_pragma_disable_pointer_checks(instr.source_location_nonconst());
-  return instr;
-}
-
-goto_programt &add_pragma_disable_pointer_checks(goto_programt &prog)
-{
-  Forall_goto_program_instructions(it, prog)
-    add_pragma_disable_pointer_checks(*it);
-  return prog;
-}
-
-void add_pragma_disable_assigns_check(source_locationt &location)
-{
-  location.add_pragma(CONTRACT_PRAGMA_DISABLE_ASSIGNS_CHECK);
-}
-
-goto_programt::instructiont &
-add_pragma_disable_assigns_check(goto_programt::instructiont &instr)
-{
-  add_pragma_disable_assigns_check(instr.source_location_nonconst());
-  return instr;
-}
-
-goto_programt &add_pragma_disable_assigns_check(goto_programt &prog)
-{
-  Forall_goto_program_instructions(it, prog)
-    add_pragma_disable_assigns_check(*it);
-  return prog;
-}
-
 exprt all_dereferences_are_valid(const exprt &expr, const namespacet &ns)
 {
   exprt::operandst validity_checks;

--- a/src/goto-instrument/contracts/utils.h
+++ b/src/goto-instrument/contracts/utils.h
@@ -24,8 +24,6 @@ Date: September 2021
 #include <util/expr_cast.h>
 #include <util/message.h>
 
-#define CONTRACT_PRAGMA_DISABLE_ASSIGNS_CHECK "contracts:disable:assigns-check"
-
 /// \brief A class that overrides the low-level havocing functions in the base
 ///        utility class, to havoc only when expressions point to valid memory,
 ///        i.e. if all dereferences within an expression are valid
@@ -66,44 +64,6 @@ public:
     const exprt &expr,
     goto_programt &dest) const override;
 };
-
-/// \brief Adds a pragma on a source location disable all pointer checks.
-///
-/// The disabled checks are: "pointer-check", "pointer-primitive-check",
-/// "pointer-overflow-check", "signed-overflow-check",
-//  "unsigned-overflow-check", "conversion-check".
-void add_pragma_disable_pointer_checks(source_locationt &source_location);
-
-/// \brief Adds pragmas on a GOTO instruction to disable all pointer checks.
-///
-/// \param instr: A mutable reference to the GOTO instruction.
-/// \return The same reference after mutation (i.e., adding the pragma).
-goto_programt::instructiont &
-add_pragma_disable_pointer_checks(goto_programt::instructiont &instr);
-
-/// \brief Adds pragmas on all instructions in a GOTO program
-/// to disable all pointer checks.
-///
-/// \param prog: A mutable reference to the GOTO program.
-/// \return The same reference after mutation (i.e., adding the pragmas).
-goto_programt &add_pragma_disable_pointer_checks(goto_programt &prog);
-
-/// \brief Adds a pragma on a source_locationt to disable inclusion checking.
-void add_pragma_disable_assigns_check(source_locationt &source_location);
-
-/// \brief Adds a pragma on a GOTO instruction to disable inclusion checking.
-///
-/// \param instr: A mutable reference to the GOTO instruction.
-/// \return The same reference after mutation (i.e., adding the pragma).
-goto_programt::instructiont &
-add_pragma_disable_assigns_check(goto_programt::instructiont &instr);
-
-/// \brief Adds pragmas on all instructions in a GOTO program
-///        to disable inclusion checking on them.
-///
-/// \param prog: A mutable reference to the GOTO program.
-/// \return The same reference after mutation (i.e., adding the pragmas).
-goto_programt &add_pragma_disable_assigns_check(goto_programt &prog);
 
 /// \brief Generate a validity check over all dereferences in an expression
 ///


### PR DESCRIPTION
To further encapsulate the the assigns clause checking algorithm in `instrument_assigns_clause.cpp`

-  the `check_frame_conditions` method and related functions have been moved from `contracts.cpp` and `utils.cpp` to `instrument_assigns_clause.cpp`.
- the former `track_static_locals` method is now available in two different versions:
  - `track_static_locals(dest)` which tracks all local static variables touched directly or indirectly by the whole instrumented function (for function contracts)
  - `track_static_locals_from_calls(begin, end, dest)` which tracks all local static variables declared by functions that are called between the begin and end instructions (for loop contracts).

No functionality or performance impact expected.

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.
