### PR TITLE
Support shuffle_vector_exprt in goto programs

### DIFF
--- a/src/ansi-c/c_typecheck_gcc_polymorphic_builtins.cpp
+++ b/src/ansi-c/c_typecheck_gcc_polymorphic_builtins.cpp
@@ -1459,7 +1459,7 @@ exprt c_typecheck_baset::typecheck_shuffle_vector(
       operands.push_back(std::move(mod_index));
     }
 
-    return shuffle_vector_exprt{arg0, arg1, std::move(operands)}.lower();
+    return shuffle_vector_exprt{arg0, arg1, std::move(operands)};
   }
   else if(identifier == "__builtin_shufflevector")
   {
@@ -1509,8 +1509,8 @@ exprt c_typecheck_baset::typecheck_shuffle_vector(
       }
     }
 
-    return shuffle_vector_exprt{arguments[0], arguments[1], std::move(operands)}
-      .lower();
+    return shuffle_vector_exprt{
+      arguments[0], arguments[1], std::move(operands)};
   }
   else
     UNREACHABLE;

--- a/src/goto-programs/remove_vector.cpp
+++ b/src/goto-programs/remove_vector.cpp
@@ -16,6 +16,8 @@ Date:   September 2014
 #include <util/arith_tools.h>
 #include <util/std_expr.h>
 
+#include <ansi-c/c_expr.h>
+
 #include "goto_model.h"
 
 static bool have_to_remove_vector(const typet &type);
@@ -41,6 +43,8 @@ static bool have_to_remove_vector(const exprt &expr)
     {
       return true;
     }
+    else if(expr.id() == ID_shuffle_vector)
+      return true;
     else if(expr.id()==ID_vector)
       return true;
   }
@@ -92,6 +96,14 @@ static void remove_vector(exprt &expr)
 {
   if(!have_to_remove_vector(expr))
     return;
+
+  if(expr.id() == ID_shuffle_vector)
+  {
+    exprt result = to_shuffle_vector_expr(expr).lower();
+    remove_vector(result);
+    expr.swap(result);
+    return;
+  }
 
   Forall_operands(it, expr)
     remove_vector(*it);


### PR DESCRIPTION
de4557fff added support for _builtin_shuffle/__builtin_shufflevector via
a shuffle_vector_exprt. This expression, however, was lowered right away
in the C front end, making it unavailable to other language front-ends.
By moving the lowering to `remove_vector` there no longer is such a
limitation. Kani will be able to use it directly for Rust programs.

Regression test cbmc/gcc_vector3 continues to pass, demonstrating that
processing via the C front-end works as before.

Fixes: #6297

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
