### PR TITLE
Remove `nullary_exprt::move_to_operands` deletion

### DIFF
--- a/src/util/std_expr.h
+++ b/src/util/std_expr.h
@@ -39,10 +39,6 @@ public:
   const exprt &op3() const = delete;
   exprt &op3() = delete;
 
-  void move_to_operands(exprt &) = delete;
-  void move_to_operands(exprt &, exprt &) = delete;
-  void move_to_operands(exprt &, exprt &, exprt &) = delete;
-
   void copy_to_operands(const exprt &expr) = delete;
   void copy_to_operands(const exprt &, const exprt &) = delete;
   void copy_to_operands(const exprt &, const exprt &, const exprt &) = delete;


### PR DESCRIPTION
There are no other instances of `move_to_operands` across the code base and no implementation here. Therefore this removal is clean-up assuming that this member function has been removed from everywhere else and this instance has accidentally been left behind.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
