### PR TITLE
Add saturating addition/subtraction

### DIFF
--- a/regression/cbmc/SIMD1/main.c
+++ b/regression/cbmc/SIMD1/main.c
@@ -1,6 +1,11 @@
 #include <assert.h>
+#include <limits.h>
+
 #ifdef _MSC_VER
 #  include <intrin.h>
+#  ifdef _WIN64
+#    define _mm_extract_pi16(a, b) _mm_extract_epi16(a, b)
+#  endif
 #else
 #  include <immintrin.h>
 #endif
@@ -10,5 +15,44 @@ int main()
   __m128i values = _mm_setr_epi32(0x1234, 0x2345, 0x3456, 0x4567);
   int val1 = _mm_extract_epi32(values, 0);
   assert(val1 == 0x1234);
+
+#ifndef _WIN64
+  __m64 a = _mm_setr_pi16(SHRT_MIN, 10, SHRT_MIN + 1, SHRT_MAX);
+  __m64 b = _mm_set_pi16(1, 1, 10, 1);
+  __m64 result = _mm_subs_pi16(a, b);
+#else
+  __m128i a = _mm_setr_epi16(SHRT_MIN, 10, SHRT_MIN + 1, SHRT_MAX, 0, 0, 0, 0);
+  __m128i b = _mm_set_epi16(0, 0, 0, 0, 1, 1, 10, 1);
+  __m128i result = _mm_subs_epi16(a, b);
+#endif
+  short s1 = _mm_extract_pi16(result, 0);
+  assert(s1 == SHRT_MIN);
+  short s2 = _mm_extract_pi16(result, 1);
+  assert(s2 == 0);
+  short s3 = _mm_extract_pi16(result, 2);
+  assert(s3 == SHRT_MIN);
+  short s4 = _mm_extract_pi16(result, 3);
+  assert(s4 == SHRT_MAX - 1);
+
+#ifndef _WIN64
+  result = _mm_adds_pi16(a, b);
+#else
+  result = _mm_adds_epi16(a, b);
+#endif
+  s1 = _mm_extract_pi16(result, 0);
+  assert(s1 == SHRT_MIN + 1);
+  s2 = _mm_extract_pi16(result, 1);
+  assert(s2 == 20);
+  s3 = _mm_extract_pi16(result, 2);
+  assert(s3 == SHRT_MIN + 2);
+  s4 = _mm_extract_pi16(result, 3);
+  assert(s4 == SHRT_MAX);
+
+  __m128i x = _mm_set_epi16(0, 0, 0, 0, 0, 0, 0, 0);
+  __m128i y = _mm_setr_epi16(1, 0, 0, 0, 0, 0, 0, 0);
+  __m128i result128 = _mm_subs_epu16(x, y);
+  short s = _mm_extract_epi16(result128, 0);
+  assert(s == 0);
+
   return 0;
 }

--- a/regression/cbmc/saturating_arithmetric/main.c
+++ b/regression/cbmc/saturating_arithmetric/main.c
@@ -1,0 +1,17 @@
+#include <limits.h>
+
+int main()
+{
+  __CPROVER_assert(
+    __CPROVER_saturating_minus(INT_MIN, 1) == INT_MIN,
+    "subtracting from INT_MIN");
+  __CPROVER_assert(
+    __CPROVER_saturating_plus(LONG_MAX, 1l) == LONG_MAX, "adding to LONG_MAX");
+  __CPROVER_assert(
+    __CPROVER_saturating_minus(-1, INT_MIN) == INT_MAX, "no overflow");
+  __CPROVER_assert(
+    __CPROVER_saturating_plus(ULONG_MAX, 1ul) == ULONG_MAX,
+    "adding to ULONG_MAX");
+  __CPROVER_assert(
+    __CPROVER_saturating_minus(10ul, ULONG_MAX) == 0, "subtracting ULONG_MAX");
+}

--- a/regression/cbmc/saturating_arithmetric/output-formula.desc
+++ b/regression/cbmc/saturating_arithmetric/output-formula.desc
@@ -1,0 +1,9 @@
+CORE
+main.c
+--program-only
+ASSERT\(__CPROVER_saturating_minus\(.*\)
+ASSERT\(__CPROVER_saturating_plus\(.*\)
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring

--- a/regression/cbmc/saturating_arithmetric/output-goto.desc
+++ b/regression/cbmc/saturating_arithmetric/output-goto.desc
@@ -1,0 +1,9 @@
+CORE
+main.c
+--show-goto-functions
+ASSERT saturating-\(.*\)
+ASSERT saturating\+\(.*\)
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring

--- a/regression/cbmc/saturating_arithmetric/test.desc
+++ b/regression/cbmc/saturating_arithmetric/test.desc
@@ -1,0 +1,8 @@
+CORE broken-smt-backend
+main.c
+
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring

--- a/regression/validate-trace-xml-schema/check.py
+++ b/regression/validate-trace-xml-schema/check.py
@@ -29,6 +29,7 @@ ExcludedTests = list(map(lambda s: os.path.join(test_base_dir, s[0], s[1]), [
     ['enum_is_in_range', 'format.desc'],
     ['r_w_ok9', 'simplify.desc'],
     ['reachability-slice-interproc2', 'test.desc'],
+    ['saturating_arithmetric', 'output-goto.desc'],
     # this one wants show-properties instead producing a trace
     ['show_properties1', 'test.desc'],
     # program-only instead of trace
@@ -36,6 +37,7 @@ ExcludedTests = list(map(lambda s: os.path.join(test_base_dir, s[0], s[1]), [
     ['Pointer_Arithmetic19', 'test.desc'],
     ['Quantifiers-simplify', 'simplify_not_forall.desc'],
     ['array-cell-sensitivity15', 'test.desc'],
+    ['saturating_arithmetric', 'output-formula.desc'],
     # these test for invalid command line handling
     ['bad_option', 'test_multiple.desc'],
     ['bad_option', 'test.desc'],

--- a/src/ansi-c/c_typecheck_base.h
+++ b/src/ansi-c/c_typecheck_base.h
@@ -205,6 +205,8 @@ protected:
   exprt typecheck_builtin_overflow(
     side_effect_expr_function_callt &expr,
     const irep_idt &arith_op);
+  exprt
+  typecheck_saturating_arithmetic(const side_effect_expr_function_callt &expr);
   virtual optionalt<symbol_exprt> typecheck_gcc_polymorphic_builtin(
     const irep_idt &identifier,
     const exprt::operandst &arguments,

--- a/src/ansi-c/expr2c.cpp
+++ b/src/ansi-c/expr2c.cpp
@@ -3977,6 +3977,8 @@ optionalt<std::string> expr2ct::convert_function(const exprt &src)
     {ID_object_size, "OBJECT_SIZE"},
     {ID_pointer_object, "POINTER_OBJECT"},
     {ID_pointer_offset, "POINTER_OFFSET"},
+    {ID_saturating_minus, CPROVER_PREFIX "saturating_minus"},
+    {ID_saturating_plus, CPROVER_PREFIX "saturating_plus"},
     {ID_r_ok, "R_OK"},
     {ID_w_ok, "W_OK"},
     {ID_rw_ok, "RW_OK"},

--- a/src/ansi-c/library/gcc.c
+++ b/src/ansi-c/library/gcc.c
@@ -192,6 +192,24 @@ __CPROVER_HIDE:;
   return size <= sizeof(__CPROVER_size_t);
 }
 
+/* FUNCTION: __builtin_ia32_vec_ext_v4hi */
+
+typedef short __gcc_v4hi __attribute__((__vector_size__(8)));
+
+short __builtin_ia32_vec_ext_v4hi(__gcc_v4hi vec, int offset)
+{
+  return *((short *)&vec + offset);
+}
+
+/* FUNCTION: __builtin_ia32_vec_ext_v8hi */
+
+typedef short __gcc_v8hi __attribute__((__vector_size__(16)));
+
+short __builtin_ia32_vec_ext_v8hi(__gcc_v8hi vec, int offset)
+{
+  return *((short *)&vec + offset);
+}
+
 /* FUNCTION: __builtin_ia32_vec_ext_v4si */
 
 typedef int __gcc_v4si __attribute__((__vector_size__(16)));
@@ -226,4 +244,71 @@ typedef float __gcc_v4sf __attribute__((__vector_size__(16)));
 float __builtin_ia32_vec_ext_v4sf(__gcc_v4sf vec, int offset)
 {
   return *((float *)&vec + offset);
+}
+
+/* FUNCTION: __builtin_ia32_psubsw128 */
+
+#ifndef LIBRARY_CHECK
+typedef short __gcc_v8hi __attribute__((__vector_size__(16)));
+#else
+__gcc_v8hi __CPROVER_saturating_minus();
+#endif
+
+__gcc_v8hi __builtin_ia32_psubsw128(__gcc_v8hi a, __gcc_v8hi b)
+{
+  return __CPROVER_saturating_minus(a, b);
+}
+
+/* FUNCTION: __builtin_ia32_psubusw128 */
+
+#ifndef LIBRARY_CHECK
+typedef short __gcc_v8hi __attribute__((__vector_size__(16)));
+#endif
+
+__gcc_v8hi __builtin_ia32_psubusw128(__gcc_v8hi a, __gcc_v8hi b)
+{
+  typedef unsigned short v8hi_u __attribute__((__vector_size__(16)));
+  return (__gcc_v8hi)__CPROVER_saturating_minus((v8hi_u)a, (v8hi_u)b);
+}
+
+/* FUNCTION: __builtin_ia32_paddsw */
+
+#ifndef LIBRARY_CHECK
+typedef short __gcc_v4hi __attribute__((__vector_size__(8)));
+#else
+__gcc_v4hi __CPROVER_saturating_plus();
+#endif
+
+__gcc_v4hi __builtin_ia32_paddsw(__gcc_v4hi a, __gcc_v4hi b)
+{
+  return __CPROVER_saturating_plus(a, b);
+}
+
+/* FUNCTION: __builtin_ia32_psubsw */
+
+#ifndef LIBRARY_CHECK
+typedef short __gcc_v4hi __attribute__((__vector_size__(8)));
+#else
+__gcc_v4hi __CPROVER_saturating_minus_v4hi(__gcc_v4hi, __gcc_v4hi);
+#  define __CPROVER_saturating_minus __CPROVER_saturating_minus_v4hi
+#endif
+
+__gcc_v4hi __builtin_ia32_psubsw(__gcc_v4hi a, __gcc_v4hi b)
+{
+  return __CPROVER_saturating_minus(a, b);
+}
+
+#ifdef LIBRARY_CHECK
+#  undef __CPROVER_saturating_minus
+#endif
+
+/* FUNCTION: __builtin_ia32_vec_init_v4hi */
+
+#ifndef LIBRARY_CHECK
+typedef short __gcc_v4hi __attribute__((__vector_size__(8)));
+#endif
+
+__gcc_v4hi __builtin_ia32_vec_init_v4hi(short e0, short e1, short e2, short e3)
+{
+  return (__gcc_v4hi){e0, e1, e2, e3};
 }

--- a/src/ansi-c/library/intrin.c
+++ b/src/ansi-c/library/intrin.c
@@ -371,6 +371,78 @@ inline __m128i _mm_setr_epi32(int e3, int e2, int e1, int e0)
 }
 #endif
 
+/* FUNCTION: _mm_set_epi16 */
+
+#ifdef _MSC_VER
+#  ifndef __CPROVER_INTRIN_H_INCLUDED
+#    include <intrin.h>
+#    define __CPROVER_INTRIN_H_INCLUDED
+#  endif
+
+inline __m128i _mm_set_epi16(
+  short e7,
+  short e6,
+  short e5,
+  short e4,
+  short e3,
+  short e2,
+  short e1,
+  short e0)
+{
+  return (__m128i){.m128i_i16 = {e0, e1, e2, e3, e4, e5, e6, e7}};
+}
+#endif
+
+/* FUNCTION: _mm_setr_epi16 */
+
+#ifdef _MSC_VER
+#  ifndef __CPROVER_INTRIN_H_INCLUDED
+#    include <intrin.h>
+#    define __CPROVER_INTRIN_H_INCLUDED
+#  endif
+
+inline __m128i _mm_setr_epi16(
+  short e7,
+  short e6,
+  short e5,
+  short e4,
+  short e3,
+  short e2,
+  short e1,
+  short e0)
+{
+  return (__m128i){.m128i_i16 = {e7, e6, e5, e4, e3, e2, e1, e0}};
+}
+#endif
+
+/* FUNCTION: _mm_set_pi16 */
+
+#ifdef _MSC_VER
+#  ifndef __CPROVER_INTRIN_H_INCLUDED
+#    include <intrin.h>
+#    define __CPROVER_INTRIN_H_INCLUDED
+#  endif
+
+inline __m64 _mm_set_pi16(short e3, short e2, short e1, short e0)
+{
+  return (__m64){.m64_i16 = {e0, e1, e2, e3}};
+}
+#endif
+
+/* FUNCTION: _mm_setr_pi16 */
+
+#ifdef _MSC_VER
+#  ifndef __CPROVER_INTRIN_H_INCLUDED
+#    include <intrin.h>
+#    define __CPROVER_INTRIN_H_INCLUDED
+#  endif
+
+inline __m64 _mm_setr_pi16(short e3, short e2, short e1, short e0)
+{
+  return (__m64){.m64_i16 = {e3, e2, e1, e0}};
+}
+#endif
+
 /* FUNCTION: _mm_extract_epi32 */
 
 #ifdef _MSC_VER
@@ -382,5 +454,129 @@ inline __m128i _mm_setr_epi32(int e3, int e2, int e1, int e0)
 inline int _mm_extract_epi32(__m128i a, const int imm8)
 {
   return a.m128i_i32[imm8];
+}
+#endif
+
+/* FUNCTION: _mm_extract_epi16 */
+
+#ifdef _MSC_VER
+#  ifndef __CPROVER_INTRIN_H_INCLUDED
+#    include <intrin.h>
+#    define __CPROVER_INTRIN_H_INCLUDED
+#  endif
+
+inline int _mm_extract_epi16(__m128i a, const int imm8)
+{
+  return a.m128i_i16[imm8];
+}
+#endif
+
+/* FUNCTION: _mm_extract_pi16 */
+
+#ifdef _MSC_VER
+#  ifndef __CPROVER_INTRIN_H_INCLUDED
+#    include <intrin.h>
+#    define __CPROVER_INTRIN_H_INCLUDED
+#  endif
+
+inline int _mm_extract_pi16(__m64 a, const int imm8)
+{
+  return a.m64_i16[imm8];
+}
+#endif
+
+/* FUNCTION: _mm_adds_epi16 */
+
+#ifdef _MSC_VER
+#  ifndef __CPROVER_INTRIN_H_INCLUDED
+#    include <intrin.h>
+#    define __CPROVER_INTRIN_H_INCLUDED
+#  endif
+
+inline __m128i _mm_adds_epi16(__m128i a, __m128i b)
+{
+  return (__m128i){
+    .m128i_i16 = {
+      __CPROVER_saturating_plus(a.m128i_i16[0], b.m128i_i16[0]),
+      __CPROVER_saturating_plus(a.m128i_i16[1], b.m128i_i16[1]),
+      __CPROVER_saturating_plus(a.m128i_i16[2], b.m128i_i16[2]),
+      __CPROVER_saturating_plus(a.m128i_i16[3], b.m128i_i16[3]),
+      __CPROVER_saturating_plus(a.m128i_i16[4], b.m128i_i16[4]),
+      __CPROVER_saturating_plus(a.m128i_i16[5], b.m128i_i16[5]),
+      __CPROVER_saturating_plus(a.m128i_i16[6], b.m128i_i16[6]),
+      __CPROVER_saturating_plus(a.m128i_i16[7], b.m128i_i16[7]),
+    }};
+}
+#endif
+
+/* FUNCTION: _mm_subs_epi16 */
+
+#ifdef _MSC_VER
+#  ifndef __CPROVER_INTRIN_H_INCLUDED
+#    include <intrin.h>
+#    define __CPROVER_INTRIN_H_INCLUDED
+#  endif
+
+inline __m128i _mm_subs_epi16(__m128i a, __m128i b)
+{
+  return (__m128i){
+    .m128i_i16 = {
+      __CPROVER_saturating_minus(a.m128i_i16[0], b.m128i_i16[0]),
+      __CPROVER_saturating_minus(a.m128i_i16[1], b.m128i_i16[1]),
+      __CPROVER_saturating_minus(a.m128i_i16[2], b.m128i_i16[2]),
+      __CPROVER_saturating_minus(a.m128i_i16[3], b.m128i_i16[3]),
+      __CPROVER_saturating_minus(a.m128i_i16[4], b.m128i_i16[4]),
+      __CPROVER_saturating_minus(a.m128i_i16[5], b.m128i_i16[5]),
+      __CPROVER_saturating_minus(a.m128i_i16[6], b.m128i_i16[6]),
+      __CPROVER_saturating_minus(a.m128i_i16[7], b.m128i_i16[7]),
+    }};
+}
+#endif
+
+/* FUNCTION: _mm_subs_epi16 */
+
+#ifdef _MSC_VER
+#  ifndef __CPROVER_INTRIN_H_INCLUDED
+#    include <intrin.h>
+#    define __CPROVER_INTRIN_H_INCLUDED
+#  endif
+
+inline __m128i _mm_subs_epi16(__m128i a, __m128i b)
+{
+  return (__m128i){
+    .m128i_i16 = {
+      __CPROVER_saturating_minus(a.m128i_i16[0], b.m128i_i16[0]),
+      __CPROVER_saturating_minus(a.m128i_i16[1], b.m128i_i16[1]),
+      __CPROVER_saturating_minus(a.m128i_i16[2], b.m128i_i16[2]),
+      __CPROVER_saturating_minus(a.m128i_i16[3], b.m128i_i16[3]),
+      __CPROVER_saturating_minus(a.m128i_i16[4], b.m128i_i16[4]),
+      __CPROVER_saturating_minus(a.m128i_i16[5], b.m128i_i16[5]),
+      __CPROVER_saturating_minus(a.m128i_i16[6], b.m128i_i16[6]),
+      __CPROVER_saturating_minus(a.m128i_i16[7], b.m128i_i16[7]),
+    }};
+}
+#endif
+
+/* FUNCTION: _mm_subs_epu16 */
+
+#ifdef _MSC_VER
+#  ifndef __CPROVER_INTRIN_H_INCLUDED
+#    include <intrin.h>
+#    define __CPROVER_INTRIN_H_INCLUDED
+#  endif
+
+inline __m128i _mm_subs_epu16(__m128i a, __m128i b)
+{
+  return (__m128i){
+    .m128i_u16 = {
+      __CPROVER_saturating_minus(a.m128i_u16[0], b.m128i_u16[0]),
+      __CPROVER_saturating_minus(a.m128i_u16[1], b.m128i_u16[1]),
+      __CPROVER_saturating_minus(a.m128i_u16[2], b.m128i_u16[2]),
+      __CPROVER_saturating_minus(a.m128i_u16[3], b.m128i_u16[3]),
+      __CPROVER_saturating_minus(a.m128i_u16[4], b.m128i_u16[4]),
+      __CPROVER_saturating_minus(a.m128i_u16[5], b.m128i_u16[5]),
+      __CPROVER_saturating_minus(a.m128i_u16[6], b.m128i_u16[6]),
+      __CPROVER_saturating_minus(a.m128i_u16[7], b.m128i_u16[7]),
+    }};
 }
 #endif

--- a/src/solvers/flattening/boolbv.cpp
+++ b/src/solvers/flattening/boolbv.cpp
@@ -229,6 +229,8 @@ bvt boolbvt::convert_bitvector(const exprt &expr)
   }
   else if(expr.id() == ID_bitreverse)
     return convert_bitreverse(to_bitreverse_expr(expr));
+  else if(expr.id() == ID_saturating_minus || expr.id() == ID_saturating_plus)
+    return convert_saturating_add_sub(to_binary_expr(expr));
 
   return conversion_failed(expr);
 }

--- a/src/solvers/flattening/boolbv.h
+++ b/src/solvers/flattening/boolbv.h
@@ -194,6 +194,7 @@ protected:
   virtual bvt convert_function_application(
     const function_application_exprt &expr);
   virtual bvt convert_bitreverse(const bitreverse_exprt &expr);
+  virtual bvt convert_saturating_add_sub(const binary_exprt &expr);
 
   virtual exprt make_bv_expr(const typet &type, const bvt &bv);
   virtual exprt make_free_bv_expr(const typet &type);

--- a/src/solvers/flattening/bv_utils.h
+++ b/src/solvers/flattening/bv_utils.h
@@ -57,6 +57,11 @@ public:
     const bvt &op1,
     bool subtract,
     representationt rep);
+  bvt saturating_add_sub(
+    const bvt &op0,
+    const bvt &op1,
+    bool subtract,
+    representationt rep);
 
   bvt add(const bvt &op0, const bvt &op1) { return add_sub(op0, op1, false); }
   bvt sub(const bvt &op0, const bvt &op1) { return add_sub(op0, op1, true); }

--- a/src/util/bitvector_expr.h
+++ b/src/util/bitvector_expr.h
@@ -1056,4 +1056,103 @@ inline bitreverse_exprt &to_bitreverse_expr(exprt &expr)
   return ret;
 }
 
+/// \brief The saturating plus expression
+class saturating_plus_exprt : public binary_exprt
+{
+public:
+  saturating_plus_exprt(exprt _lhs, exprt _rhs)
+    : binary_exprt(std::move(_lhs), ID_saturating_plus, std::move(_rhs))
+  {
+  }
+
+  saturating_plus_exprt(exprt _lhs, exprt _rhs, typet _type)
+    : binary_exprt(
+        std::move(_lhs),
+        ID_saturating_plus,
+        std::move(_rhs),
+        std::move(_type))
+  {
+  }
+};
+
+template <>
+inline bool can_cast_expr<saturating_plus_exprt>(const exprt &base)
+{
+  return base.id() == ID_saturating_plus;
+}
+
+inline void validate_expr(const saturating_plus_exprt &value)
+{
+  validate_operands(value, 2, "saturating plus must have two operands");
+}
+
+/// \brief Cast an exprt to a \ref saturating_plus_exprt
+///
+/// \a expr must be known to be \ref saturating_plus_exprt.
+///
+/// \param expr: Source expression
+/// \return Object of type \ref saturating_plus_exprt
+inline const saturating_plus_exprt &to_saturating_plus_expr(const exprt &expr)
+{
+  PRECONDITION(expr.id() == ID_saturating_plus);
+  const saturating_plus_exprt &ret =
+    static_cast<const saturating_plus_exprt &>(expr);
+  validate_expr(ret);
+  return ret;
+}
+
+/// \copydoc to_saturating_plus_expr(const exprt &)
+inline saturating_plus_exprt &to_saturating_plus_expr(exprt &expr)
+{
+  PRECONDITION(expr.id() == ID_saturating_plus);
+  saturating_plus_exprt &ret = static_cast<saturating_plus_exprt &>(expr);
+  validate_expr(ret);
+  return ret;
+}
+
+/// \brief Saturating subtraction expression.
+class saturating_minus_exprt : public binary_exprt
+{
+public:
+  saturating_minus_exprt(exprt _lhs, exprt _rhs)
+    : binary_exprt(std::move(_lhs), ID_saturating_minus, std::move(_rhs))
+  {
+  }
+};
+
+template <>
+inline bool can_cast_expr<saturating_minus_exprt>(const exprt &base)
+{
+  return base.id() == ID_saturating_minus;
+}
+
+inline void validate_expr(const saturating_minus_exprt &value)
+{
+  validate_operands(value, 2, "saturating minus must have two operands");
+}
+
+/// \brief Cast an exprt to a \ref saturating_minus_exprt
+///
+/// \a expr must be known to be \ref saturating_minus_exprt.
+///
+/// \param expr: Source expression
+/// \return Object of type \ref saturating_minus_exprt
+inline const saturating_minus_exprt &to_saturating_minus_expr(const exprt &expr)
+{
+  PRECONDITION(expr.id() == ID_saturating_minus);
+  const saturating_minus_exprt &ret =
+    static_cast<const saturating_minus_exprt &>(expr);
+  validate_expr(ret);
+  return ret;
+}
+
+/// \copydoc to_saturating_minus_expr(const exprt &)
+inline saturating_minus_exprt &to_saturating_minus_expr(exprt &expr)
+{
+  PRECONDITION(expr.id() == ID_saturating_minus);
+  saturating_minus_exprt &ret = static_cast<saturating_minus_exprt &>(expr);
+  validate_expr(ret);
+  return ret;
+}
+
 #endif // CPROVER_UTIL_BITVECTOR_EXPR_H

--- a/src/util/format_expr.cpp
+++ b/src/util/format_expr.cpp
@@ -12,6 +12,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "format_expr.h"
 
 #include "arith_tools.h"
+#include "bitvector_expr.h"
 #include "byte_operators.h"
 #include "format_type.h"
 #include "ieee_float.h"
@@ -491,6 +492,20 @@ void format_expr_configt::setup()
     else
       os << format(dereference_expr.pointer());
     return os;
+  };
+
+  expr_map[ID_saturating_minus] =
+    [](std::ostream &os, const exprt &expr) -> std::ostream & {
+    const auto &saturating_minus = to_saturating_minus_expr(expr);
+    return os << "saturating-(" << format(saturating_minus.lhs()) << ", "
+              << format(saturating_minus.rhs()) << ')';
+  };
+
+  expr_map[ID_saturating_plus] =
+    [](std::ostream &os, const exprt &expr) -> std::ostream & {
+    const auto &saturating_plus = to_saturating_plus_expr(expr);
+    return os << "saturating+(" << format(saturating_plus.lhs()) << ", "
+              << format(saturating_plus.rhs()) << ')';
   };
 
   fallback = [](std::ostream &os, const exprt &expr) -> std::ostream & {

--- a/src/util/irep_ids.def
+++ b/src/util/irep_ids.def
@@ -865,6 +865,8 @@ IREP_ID_ONE(shuffle_vector)
 IREP_ID_ONE(count_trailing_zeros)
 IREP_ID_ONE(empty_union)
 IREP_ID_ONE(bitreverse)
+IREP_ID_ONE(saturating_minus)
+IREP_ID_ONE(saturating_plus)
 
 // Projects depending on this code base that wish to extend the list of
 // available ids should provide a file local_irep_ids.def in their source tree


### PR DESCRIPTION
Rust natively supports saturating arithmetic. For C code, it takes MMX
instructions to have access to this, and even then it is limited to
addition and subtraction. The implementation now is equally restricted
to these two arithmetic operations.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
