### PR TITLE
Document steps to perform CMake configuration without network access

### DIFF
--- a/COMPILING.md
+++ b/COMPILING.md
@@ -82,6 +82,16 @@ files.
    to generate IDE projects by supplying the `-G` flag.  Run `cmake -G` for a
    comprehensive list of supported back-ends.
 
+   As part of this step, CMake will download the back-end solver (see Section
+   "Compiling with alternative SAT solvers" in this document for configuration
+   options). Should it be necessary to perform this step without network access,
+   a solver can be downloaded ahead of the above `cmake` invocation as follows:
+   ```
+   mkdir -p build/minisat2-download/minisat2-download-prefix/src/
+   wget http://ftp.debian.org/debian/pool/main/m/minisat2/minisat2_2.2.1.orig.tar.gz \
+     -O build/minisat2-download/minisat2-download-prefix/src/minisat2_2.2.1.orig.tar.gz
+   ```
+
    On macOS >10.14, the build will fail unless you explicitly specify
    the full path to the compiler. This issue is being tracked
    [here](https://github.com/diffblue/cbmc/issues/4956). The invocation thus


### PR DESCRIPTION
Build environments may be configured in a way that disallows network
access. The make-based build system already supported this as
downloading and building solvers is a separate step. For CMake, document
the procedure to facilitate this.

Fixes: #6582

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [x] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
