### PR TITLE
Single-path symex must not fail an invariant when verification succeeds

### DIFF
--- a/regression/cbmc/Address_of1/test.desc
+++ b/regression/cbmc/Address_of1/test.desc
@@ -1,8 +1,12 @@
 CORE
 main.c
-
+--stop-on-fail
 ^EXIT=0$
 ^SIGNAL=0$
 ^VERIFICATION SUCCESSFUL$
 --
 ^warning: ignoring
+--
+Adding "--stop-on-fail" should not make a difference for successful
+verification, but previously caused an invariant failure when running CBMC with
+"--paths."

--- a/src/goto-checker/single_path_symex_checker.cpp
+++ b/src/goto-checker/single_path_symex_checker.cpp
@@ -75,6 +75,10 @@ operator()(propertiest &properties)
         return result;
     }
 
+    // leave the last worklist item in place for the benefit of output_proof
+    if(worklist->size() == 1)
+      break;
+
     worklist->pop();
   }
 
@@ -83,7 +87,7 @@ operator()(propertiest &properties)
 
   final_update_properties(properties, result.updated_properties);
 
-  // Worklist is empty: we are done.
+  // Worklist just has the last element left: we are done.
   return result;
 }
 
@@ -182,6 +186,8 @@ void single_path_symex_checkert::output_error_witness(
 void single_path_symex_checkert::output_proof()
 {
   // This is incorrect, but the best we can do at the moment.
+  // operator()(propertiest &properties) leaves in place the last worklist item
+  // just for this purpose.
   const path_storaget::patht &resume = worklist->peek();
   output_graphml(resume.equation, ns, options);
 }


### PR DESCRIPTION
Single-path symex takes a best-effort approach to produce a proof by
using the symex equation of that path that was last visited. This,
however, failed an invariant when trying to access the equation that had
already been popped from the worklist. Leave the last equation in place
to avoid this problem.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
