### PR TITLE
Support byte-extracting empty structs

### DIFF
--- a/regression/cbmc/empty_compound_type4/main.c
+++ b/regression/cbmc/empty_compound_type4/main.c
@@ -1,0 +1,21 @@
+struct empty
+{
+};
+
+struct non_empty
+{
+  int x;
+};
+
+union U
+{
+  struct empty e;
+  struct non_empty n;
+};
+
+int main()
+{
+  union U u;
+  struct empty e = u.e;
+  __CPROVER_assert(0, "dummy assertion");
+}

--- a/regression/cbmc/empty_compound_type4/test.desc
+++ b/regression/cbmc/empty_compound_type4/test.desc
@@ -1,0 +1,12 @@
+CORE broken-smt-backend
+main.c
+--trace
+^VERIFICATION FAILED$
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring
+Invariant check failed
+--
+Byte-extracting (which is what union operations yield) an empty struct should
+not result in a conversion warning in the flattening back-end.

--- a/src/solvers/flattening/boolbv_byte_extract.cpp
+++ b/src/solvers/flattening/boolbv_byte_extract.cpp
@@ -59,9 +59,6 @@ bvt boolbvt::convert_byte_extract(const byte_extract_exprt &expr)
   }
   #endif
 
-  if(width==0)
-    return conversion_failed(expr);
-
   // see if the byte number is constant and within bounds, else work from the
   // root object
   const auto op_bytes_opt = pointer_offset_size(expr.op().type(), ns);


### PR DESCRIPTION
Empty structs are a GCC extension, which in general we do support.
Notably, boolbvt::convert_struct happily produces (empty) bitvectors for
empty structs. This commit makes sure byte-extracting empty structs is
equally supported.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
