### PR TITLE
Add bit vector extract operation support to incremental SMT2 solving

### DIFF
--- a/src/solvers/Makefile
+++ b/src/solvers/Makefile
@@ -198,6 +198,7 @@ SRC = $(BOOLEFORCE_SRC) \
       smt2_incremental/smt_bit_vector_theory.cpp \
       smt2_incremental/smt_commands.cpp \
       smt2_incremental/smt_core_theory.cpp \
+      smt2_incremental/smt_index.cpp \
       smt2_incremental/smt_logics.cpp \
       smt2_incremental/smt_options.cpp \
       smt2_incremental/smt_response_validation.cpp \

--- a/src/solvers/smt2_incremental/smt_bit_vector_theory.cpp
+++ b/src/solvers/smt2_incremental/smt_bit_vector_theory.cpp
@@ -4,6 +4,37 @@
 
 #include <util/invariant.h>
 
+const char *smt_bit_vector_theoryt::extractt::identifier()
+{
+  return "extract";
+}
+
+smt_sortt
+smt_bit_vector_theoryt::extractt::return_sort(const smt_termt &operand) const
+{
+  return smt_bit_vector_sortt{i - j + 1};
+}
+
+std::vector<smt_indext> smt_bit_vector_theoryt::extractt::indices() const
+{
+  return {smt_numeral_indext{i}, smt_numeral_indext{j}};
+}
+
+void smt_bit_vector_theoryt::extractt::validate(const smt_termt &operand) const
+{
+  PRECONDITION(i >= j);
+  const auto bit_vector_sort = operand.get_sort().cast<smt_bit_vector_sortt>();
+  PRECONDITION(bit_vector_sort);
+  PRECONDITION(i < bit_vector_sort->bit_width());
+}
+
+smt_function_application_termt::factoryt<smt_bit_vector_theoryt::extractt>
+smt_bit_vector_theoryt::extract(std::size_t i, std::size_t j)
+{
+  PRECONDITION(i >= j);
+  return smt_function_application_termt::factoryt<extractt>(i, j);
+}
+
 static void validate_bit_vector_operator_arguments(
   const smt_termt &left,
   const smt_termt &right)

--- a/src/solvers/smt2_incremental/smt_bit_vector_theory.h
+++ b/src/solvers/smt2_incremental/smt_bit_vector_theory.h
@@ -8,6 +8,18 @@
 class smt_bit_vector_theoryt
 {
 public:
+  struct extractt final
+  {
+    std::size_t i;
+    std::size_t j;
+    static const char *identifier();
+    smt_sortt return_sort(const smt_termt &operand) const;
+    std::vector<smt_indext> indices() const;
+    void validate(const smt_termt &operand) const;
+  };
+  static smt_function_application_termt::factoryt<extractt>
+  extract(std::size_t i, std::size_t j);
+
   // Relational operator class declarations
   struct unsigned_less_thant final
   {

--- a/src/solvers/smt2_incremental/smt_index.cpp
+++ b/src/solvers/smt2_incremental/smt_index.cpp
@@ -1,0 +1,64 @@
+// Author: Diffblue Ltd.
+
+#include "smt_index.h"
+
+// Define the irep_idts for kinds of index.
+const irep_idt ID_smt_numeral_index{"smt_numeral_index"};
+const irep_idt ID_smt_symbol_index{"smt_symbol_index"};
+
+bool smt_indext::operator==(const smt_indext &other) const
+{
+  return irept::operator==(other);
+}
+
+bool smt_indext::operator!=(const smt_indext &other) const
+{
+  return !(*this == other);
+}
+
+template <>
+const smt_numeral_indext *smt_indext::cast<smt_numeral_indext>() const &
+{
+  return id() == ID_smt_numeral_index
+           ? static_cast<const smt_numeral_indext *>(this)
+           : nullptr;
+}
+
+template <>
+const smt_symbol_indext *smt_indext::cast<smt_symbol_indext>() const &
+{
+  return id() == ID_smt_symbol_index
+           ? static_cast<const smt_symbol_indext *>(this)
+           : nullptr;
+}
+
+void smt_indext::accept(smt_index_const_downcast_visitort &visitor) const
+{
+  if(const auto numeral = this->cast<smt_numeral_indext>())
+    return visitor.visit(*numeral);
+  if(const auto symbol = this->cast<smt_symbol_indext>())
+    return visitor.visit(*symbol);
+  UNREACHABLE;
+}
+
+smt_numeral_indext::smt_numeral_indext(std::size_t value)
+  : smt_indext{ID_smt_numeral_index}
+{
+  set_size_t(ID_value, value);
+}
+
+std::size_t smt_numeral_indext::value() const
+{
+  return get_size_t(ID_value);
+}
+
+smt_symbol_indext::smt_symbol_indext(irep_idt identifier)
+  : smt_indext{ID_smt_symbol_index}
+{
+  set(ID_identifier, identifier);
+}
+
+irep_idt smt_symbol_indext::identifier() const
+{
+  return get(ID_identifier);
+}

--- a/src/solvers/smt2_incremental/smt_index.cpp
+++ b/src/solvers/smt2_incremental/smt_index.cpp
@@ -55,6 +55,7 @@ std::size_t smt_numeral_indext::value() const
 smt_symbol_indext::smt_symbol_indext(irep_idt identifier)
   : smt_indext{ID_smt_symbol_index}
 {
+  PRECONDITION(!identifier.empty());
   set(ID_identifier, identifier);
 }
 

--- a/src/solvers/smt2_incremental/smt_index.h
+++ b/src/solvers/smt2_incremental/smt_index.h
@@ -1,0 +1,90 @@
+// Author: Diffblue Ltd.
+
+#ifndef CPROVER_SOLVERS_SMT2_INCREMENTAL_SMT_INDEX_H
+#define CPROVER_SOLVERS_SMT2_INCREMENTAL_SMT_INDEX_H
+
+#include <util/irep.h>
+
+class smt_index_const_downcast_visitort;
+
+/// \brief
+/// For implementation of indexed identifiers. See SMT-LIB Standard Version 2.6
+/// section 3.3.
+class smt_indext : protected irept
+{
+public:
+  // smt_indext does not support the notion of an empty / null state. Use
+  // optionalt<smt_indext> instead if an empty index is required.
+  smt_indext() = delete;
+
+  using irept::pretty;
+
+  bool operator==(const smt_indext &) const;
+  bool operator!=(const smt_indext &) const;
+
+  template <typename sub_classt>
+  const sub_classt *cast() const &;
+
+  void accept(smt_index_const_downcast_visitort &) const;
+
+  /// \brief Class for adding the ability to up and down cast smt_indext to and
+  ///   from irept. These casts are required by other irept derived classes in
+  ///   order to store instances of smt_termt inside them.
+  /// \tparam derivedt The type of class which derives from this class and from
+  ///   irept.
+  template <typename derivedt>
+  class storert
+  {
+  protected:
+    storert();
+    static irept upcast(smt_indext index);
+    static const smt_indext &downcast(const irept &);
+  };
+
+protected:
+  using irept::irept;
+};
+
+template <typename derivedt>
+smt_indext::storert<derivedt>::storert()
+{
+  static_assert(
+    std::is_base_of<irept, derivedt>::value &&
+      std::is_base_of<storert<derivedt>, derivedt>::value,
+    "Only irept based classes need to upcast smt_sortt to store it.");
+}
+
+template <typename derivedt>
+irept smt_indext::storert<derivedt>::upcast(smt_indext index)
+{
+  return static_cast<irept &&>(std::move(index));
+}
+
+template <typename derivedt>
+const smt_indext &smt_indext::storert<derivedt>::downcast(const irept &irep)
+{
+  return static_cast<const smt_indext &>(irep);
+}
+
+class smt_numeral_indext : public smt_indext
+{
+public:
+  explicit smt_numeral_indext(std::size_t value);
+  std::size_t value() const;
+};
+
+class smt_symbol_indext : public smt_indext
+{
+public:
+  explicit smt_symbol_indext(irep_idt identifier);
+  irep_idt identifier() const;
+};
+
+class smt_index_const_downcast_visitort
+{
+public:
+  virtual void visit(const smt_numeral_indext &) = 0;
+  virtual void visit(const smt_symbol_indext &) = 0;
+};
+
+#endif // CPROVER_SOLVERS_SMT2_INCREMENTAL_SMT_INDEX_H

--- a/src/solvers/smt2_incremental/smt_terms.cpp
+++ b/src/solvers/smt2_incremental/smt_terms.cpp
@@ -56,7 +56,10 @@ static bool is_valid_smt_identifier(irep_idt identifier)
   return std::regex_match(id2string(identifier), valid);
 }
 
-smt_identifier_termt::smt_identifier_termt(irep_idt identifier, smt_sortt sort)
+smt_identifier_termt::smt_identifier_termt(
+  irep_idt identifier,
+  smt_sortt sort,
+  std::vector<smt_indext> indices)
   : smt_termt(ID_smt_identifier_term, std::move(sort))
 {
   // The below invariant exists as a sanity check that the string being used for
@@ -67,11 +70,25 @@ smt_identifier_termt::smt_identifier_termt(irep_idt identifier, smt_sortt sort)
     is_valid_smt_identifier(identifier),
     R"(Identifiers may not contain | characters.)");
   set(ID_identifier, identifier);
+  for(auto &index : indices)
+  {
+    get_sub().push_back(
+      smt_indext::storert<smt_identifier_termt>::upcast(std::move(index)));
+  }
 }
 
 irep_idt smt_identifier_termt::identifier() const
 {
   return get(ID_identifier);
+}
+
+std::vector<std::reference_wrapper<const smt_indext>>
+smt_identifier_termt::indices() const
+{
+  return make_range(get_sub()).map([](const irept &index) {
+    return std::cref(
+      smt_indext::storert<smt_identifier_termt>::downcast(index));
+  });
 }
 
 smt_bit_vector_constant_termt::smt_bit_vector_constant_termt(

--- a/src/solvers/smt2_incremental/smt_terms.h
+++ b/src/solvers/smt2_incremental/smt_terms.h
@@ -3,8 +3,10 @@
 #ifndef CPROVER_SOLVERS_SMT2_INCREMENTAL_SMT_TERMS_H
 #define CPROVER_SOLVERS_SMT2_INCREMENTAL_SMT_TERMS_H
 
-#include <solvers/smt2_incremental/smt_sorts.h>
 #include <util/irep.h>
+
+#include <solvers/smt2_incremental/smt_index.h>
+#include <solvers/smt2_incremental/smt_sorts.h>
 
 #include <functional>
 
@@ -77,7 +79,14 @@ public:
 
 /// Stores identifiers in unescaped and unquoted form. Any escaping or quoting
 /// required should be performed during printing.
-class smt_identifier_termt : public smt_termt
+/// \details
+/// The SMT-LIB standard Version 2.6 refers to "indexed" identifiers which have
+/// 1 or more indices and "simple" identifiers which have no indicies. The
+/// internal `smt_identifier_termt` class is used for both kinds of identifier
+/// which are distinguished based on whether the collection of `indices` is
+/// empty or not.
+class smt_identifier_termt : public smt_termt,
+                             private smt_indext::storert<smt_identifier_termt>
 {
 public:
   /// \brief Constructs an identifier term with the given \p identifier and
@@ -91,8 +100,14 @@ public:
   /// \param sort: The sort which this term will have. All terms in our abstract
   ///   form must be sorted, even if those sorts are not printed in all
   ///   contexts.
-  smt_identifier_termt(irep_idt identifier, smt_sortt sort);
+  /// \param indices: This should be collection of indices for an indexed
+  ///   identifier, or an empty collection for simple (non-indexed) identifiers.
+  smt_identifier_termt(
+    irep_idt identifier,
+    smt_sortt sort,
+    std::vector<smt_indext> indices = {});
   irep_idt identifier() const;
+  std::vector<std::reference_wrapper<const smt_indext>> indices() const;
 };
 
 class smt_bit_vector_constant_termt : public smt_termt

--- a/src/solvers/smt2_incremental/smt_terms.h
+++ b/src/solvers/smt2_incremental/smt_terms.h
@@ -133,7 +133,7 @@ public:
 
   public:
     template <typename... function_type_argument_typest>
-    explicit factoryt(function_type_argument_typest &&... arguments)
+    explicit factoryt(function_type_argument_typest &&... arguments) noexcept
       : function{std::forward<function_type_argument_typest>(arguments)...}
     {
     }

--- a/src/solvers/smt2_incremental/smt_to_smt2_string.h
+++ b/src/solvers/smt2_incremental/smt_to_smt2_string.h
@@ -8,6 +8,7 @@
 #ifndef CPROVER_SOLVERS_SMT2_INCREMENTAL_SMT_TO_SMT2_STRING_H
 #define CPROVER_SOLVERS_SMT2_INCREMENTAL_SMT_TO_SMT2_STRING_H
 
+class smt_indext;
 class smt_sortt;
 class smt_termt;
 class smt_optiont;
@@ -17,12 +18,14 @@ class smt_logict;
 #include <iosfwd>
 #include <string>
 
+std::ostream &operator<<(std::ostream &os, const smt_indext &index);
 std::ostream &operator<<(std::ostream &os, const smt_sortt &sort);
 std::ostream &operator<<(std::ostream &os, const smt_termt &term);
 std::ostream &operator<<(std::ostream &os, const smt_optiont &option);
 std::ostream &operator<<(std::ostream &os, const smt_logict &logic);
 std::ostream &operator<<(std::ostream &os, const smt_commandt &command);
 
+std::string smt_to_smt2_string(const smt_indext &index);
 std::string smt_to_smt2_string(const smt_sortt &sort);
 std::string smt_to_smt2_string(const smt_termt &term);
 std::string smt_to_smt2_string(const smt_optiont &option);

--- a/src/solvers/smt2_incremental/type_traits.h
+++ b/src/solvers/smt2_incremental/type_traits.h
@@ -1,0 +1,37 @@
+// Author: Diffblue Ltd.
+
+/// \file
+/// Back ports of utilities available in the `<type_traits>` library for C++14
+/// or C++17 to C++11. These can be replaced with the standard library versions
+/// as and when we upgrade the version CBMC is compiled with.
+
+#ifndef CPROVER_SOLVERS_SMT2_INCREMENTAL_TYPE_TRAITS_H
+#define CPROVER_SOLVERS_SMT2_INCREMENTAL_TYPE_TRAITS_H
+
+#include <type_traits>
+
+namespace detail // NOLINT
+{
+// Implementation detail of `void_t`.
+template <typename... typest>
+struct make_voidt
+{
+  using type = void;
+};
+} // namespace detail
+
+// The below definition is of a back-ported version of the C++17 STL
+// `std::void_t` template. This makes this particular template available when
+// compiling for the C++11 or C++14 standard versions. It will also compile
+// as-is when targeting the C++17 standard. The back-ported version is not added
+// to the `std` namespace as this would be undefined behaviour. However once we
+// permanently move to the new standard the below code should be removed
+// and `std::void_t` should be used directly, to avoid polluting the global
+// namespace. For example -
+//   `void_t<decltype(foo.bar())>`
+// should be updated to -
+//   `std::void_t<decltype(foo.bar())>`
+template <typename... typest>
+using void_t = typename detail::make_voidt<typest...>::type;
+
+#endif // CPROVER_SOLVERS_SMT2_INCREMENTAL_TYPE_TRAITS_H

--- a/unit/Makefile
+++ b/unit/Makefile
@@ -106,6 +106,7 @@ SRC += analyses/ai/ai.cpp \
        solvers/smt2_incremental/smt_bit_vector_theory.cpp \
        solvers/smt2_incremental/smt_commands.cpp \
        solvers/smt2_incremental/smt_core_theory.cpp \
+       solvers/smt2_incremental/smt_index.cpp \
        solvers/smt2_incremental/smt_response_validation.cpp \
        solvers/smt2_incremental/smt_responses.cpp \
        solvers/smt2_incremental/smt_sorts.cpp \

--- a/unit/solvers/smt2_incremental/smt_bit_vector_theory.cpp
+++ b/unit/solvers/smt2_incremental/smt_bit_vector_theory.cpp
@@ -7,6 +7,33 @@
 
 #include <util/mp_arith.h>
 
+TEST_CASE("SMT bit vector extract", "[core][smt2_incremental]")
+{
+  const smt_bit_vector_constant_termt operand{42, 8};
+  const auto extract_4_3 = smt_bit_vector_theoryt::extract(4, 3);
+  SECTION("Valid construction")
+  {
+    const auto extraction = extract_4_3(operand);
+    const auto expected_return_sort = smt_bit_vector_sortt{2};
+    REQUIRE(
+      extraction.function_identifier() ==
+      smt_identifier_termt(
+        "extract",
+        expected_return_sort,
+        {smt_numeral_indext{4}, smt_numeral_indext{3}}));
+    REQUIRE(extraction.get_sort() == expected_return_sort);
+    REQUIRE(extraction.arguments().size() == 1);
+    REQUIRE(extraction.arguments()[0].get() == operand);
+  }
+  SECTION("Invalid constructions")
+  {
+    cbmc_invariants_should_throwt invariants_throw;
+    REQUIRE_THROWS(smt_bit_vector_theoryt::extract(3, 4));
+    REQUIRE_THROWS(extract_4_3(smt_bool_literal_termt{true}));
+    REQUIRE_THROWS(extract_4_3(smt_bit_vector_constant_termt{8, 4}));
+  }
+}
+
 TEST_CASE("SMT bit vector predicates", "[core][smt2_incremental]")
 {
   const smt_bit_vector_constant_termt two{2, 8};

--- a/unit/solvers/smt2_incremental/smt_index.cpp
+++ b/unit/solvers/smt2_incremental/smt_index.cpp
@@ -11,6 +11,13 @@ TEST_CASE("Test smt_indext.pretty is accessible.", "[core][smt2_incremental]")
   REQUIRE_FALSE(index.pretty().empty());
 }
 
+TEST_CASE("Test smt_symbol_index construction", "[core][smt2_incremental]")
+{
+  const cbmc_invariants_should_throwt invariants_throw;
+  CHECK_NOTHROW(smt_symbol_indext{"foo"});
+  CHECK_THROWS(smt_symbol_indext{""});
+}
+
 TEST_CASE("Test smt_index getters", "[core][smt2_incremental]")
 {
   SECTION("Numeral")

--- a/unit/solvers/smt2_incremental/smt_index.cpp
+++ b/unit/solvers/smt2_incremental/smt_index.cpp
@@ -1,0 +1,69 @@
+// Author: Diffblue Ltd.
+
+#include <util/optional.h>
+
+#include <solvers/smt2_incremental/smt_index.h>
+#include <testing-utils/use_catch.h>
+
+TEST_CASE("Test smt_indext.pretty is accessible.", "[core][smt2_incremental]")
+{
+  const smt_indext index = smt_numeral_indext{42};
+  REQUIRE_FALSE(index.pretty().empty());
+}
+
+TEST_CASE("Test smt_index getters", "[core][smt2_incremental]")
+{
+  SECTION("Numeral")
+  {
+    REQUIRE(smt_numeral_indext{42}.value() == 42);
+  }
+  SECTION("Symbol")
+  {
+    REQUIRE(smt_symbol_indext{"foo"}.identifier() == "foo");
+  }
+}
+
+TEST_CASE("Visiting smt_indext", "[core][smt2_incremental]")
+{
+  class : public smt_index_const_downcast_visitort
+  {
+  public:
+    optionalt<std::size_t> numeral_visited{};
+    optionalt<irep_idt> symbol_visited{};
+
+    void visit(const smt_numeral_indext &numeral) override
+    {
+      numeral_visited = numeral.value();
+    }
+
+    void visit(const smt_symbol_indext &symbol) override
+    {
+      symbol_visited = symbol.identifier();
+    }
+  } visitor;
+  SECTION("numeral")
+  {
+    smt_numeral_indext{8}.accept(visitor);
+    REQUIRE(visitor.numeral_visited);
+    CHECK(*visitor.numeral_visited == 8);
+    CHECK_FALSE(visitor.symbol_visited);
+  }
+  SECTION("symbol")
+  {
+    smt_symbol_indext{"bar"}.accept(visitor);
+    CHECK_FALSE(visitor.numeral_visited);
+    REQUIRE(visitor.symbol_visited);
+    CHECK(*visitor.symbol_visited == "bar");
+  }
+}
+
+TEST_CASE("smt_index equality", "[core][smt2_incremental]")
+{
+  const smt_symbol_indext foo_index{"foo"};
+  CHECK(foo_index == smt_symbol_indext{"foo"});
+  CHECK(foo_index != smt_symbol_indext{"bar"});
+  const smt_numeral_indext index_42{42};
+  CHECK(index_42 == smt_numeral_indext{42});
+  CHECK(index_42 != smt_numeral_indext{12});
+  CHECK(index_42 != foo_index);
+}

--- a/unit/solvers/smt2_incremental/smt_terms.cpp
+++ b/unit/solvers/smt2_incremental/smt_terms.cpp
@@ -44,9 +44,26 @@ TEST_CASE("smt_identifier_termt construction", "[core][smt2_incremental]")
 
 TEST_CASE("smt_identifier_termt getters.", "[core][smt2_incremental]")
 {
-  const smt_identifier_termt identifier{"foo", smt_bool_sortt{}};
-  CHECK(identifier.identifier() == "foo");
-  CHECK(identifier.get_sort() == smt_bool_sortt{});
+  SECTION("Simple identifier")
+  {
+    const smt_identifier_termt identifier{"foo", smt_bool_sortt{}};
+    CHECK(identifier.identifier() == "foo");
+    CHECK(identifier.get_sort() == smt_bool_sortt{});
+    CHECK(identifier.indices().empty());
+  }
+  SECTION("Indexed identifier")
+  {
+    const smt_symbol_indext baz{"baz"};
+    const smt_numeral_indext index_42{42};
+    const smt_identifier_termt indexed{
+      "bar", smt_bit_vector_sortt{8}, {baz, index_42}};
+    CHECK(indexed.identifier() == "bar");
+    CHECK(indexed.get_sort() == smt_bit_vector_sortt{8});
+    const auto indices = indexed.indices();
+    REQUIRE(indices.size() == 2);
+    CHECK(indices[0].get() == baz);
+    CHECK(indices[1].get() == index_42);
+  }
 }
 
 TEST_CASE("smt_bit_vector_constant_termt getters.", "[core][smt2_incremental]")

--- a/unit/solvers/smt2_incremental/smt_to_smt2_string.cpp
+++ b/unit/solvers/smt2_incremental/smt_to_smt2_string.cpp
@@ -2,6 +2,7 @@
 
 #include <util/mp_arith.h>
 
+#include <solvers/smt2_incremental/smt_bit_vector_theory.h>
 #include <solvers/smt2_incremental/smt_commands.h>
 #include <solvers/smt2_incremental/smt_core_theory.h>
 #include <solvers/smt2_incremental/smt_logics.h>
@@ -27,6 +28,15 @@ TEST_CASE(
   "[core][smt2_incremental]")
 {
   CHECK(smt_to_smt2_string(smt_bit_vector_constant_termt{0, 8}) == "(_ bv0 8)");
+}
+
+TEST_CASE(
+  "Test smt_bit_vector extract to string conversion",
+  "[core][smt2_incremental]")
+{
+  CHECK(
+    smt_to_smt2_string(smt_bit_vector_theoryt::extract(7, 3)(
+      smt_bit_vector_constant_termt{0, 8})) == "((_ |extract| 7 3) (_ bv0 8))");
 }
 
 TEST_CASE(

--- a/unit/solvers/smt2_incremental/smt_to_smt2_string.cpp
+++ b/unit/solvers/smt2_incremental/smt_to_smt2_string.cpp
@@ -1,6 +1,6 @@
 // Author: Diffblue Ltd.
 
-#include <testing-utils/use_catch.h>
+#include <util/mp_arith.h>
 
 #include <solvers/smt2_incremental/smt_commands.h>
 #include <solvers/smt2_incremental/smt_core_theory.h>
@@ -8,8 +8,7 @@
 #include <solvers/smt2_incremental/smt_sorts.h>
 #include <solvers/smt2_incremental/smt_terms.h>
 #include <solvers/smt2_incremental/smt_to_smt2_string.h>
-
-#include <util/mp_arith.h>
+#include <testing-utils/use_catch.h>
 
 TEST_CASE("Test smt_indext to string conversion", "[core][smt2_incremental]")
 {

--- a/unit/solvers/smt2_incremental/smt_to_smt2_string.cpp
+++ b/unit/solvers/smt2_incremental/smt_to_smt2_string.cpp
@@ -11,6 +11,12 @@
 
 #include <util/mp_arith.h>
 
+TEST_CASE("Test smt_indext to string conversion", "[core][smt2_incremental]")
+{
+  CHECK(smt_to_smt2_string(smt_symbol_indext{"green"}) == "|green|");
+  CHECK(smt_to_smt2_string(smt_numeral_indext{42}) == "42");
+}
+
 TEST_CASE("Test smt_sortt to string conversion", "[core][smt2_incremental]")
 {
   CHECK(smt_to_smt2_string(smt_bool_sortt{}) == "Bool");
@@ -36,12 +42,24 @@ TEST_CASE(
   "Test smt_identifier_termt to string conversion",
   "[core][smt2_incremental]")
 {
-  CHECK(
-    smt_to_smt2_string(smt_identifier_termt{"abc", smt_bool_sortt{}}) ==
-    "|abc|");
-  CHECK(
-    smt_to_smt2_string(smt_identifier_termt{"\\", smt_bool_sortt{}}) ==
-    "|&92;|");
+  SECTION("Simple identifiers")
+  {
+    CHECK(
+      smt_to_smt2_string(smt_identifier_termt{"abc", smt_bool_sortt{}}) ==
+      "|abc|");
+    CHECK(
+      smt_to_smt2_string(smt_identifier_termt{"\\", smt_bool_sortt{}}) ==
+      "|&92;|");
+  }
+  SECTION("Indexed identifier")
+  {
+    CHECK(
+      smt_to_smt2_string(smt_identifier_termt{
+        "foo",
+        smt_bool_sortt{},
+        {smt_symbol_indext{"bar"}, smt_numeral_indext{42}}}) ==
+      "(_ |foo| |bar| 42)");
+  }
 }
 
 TEST_CASE(


### PR DESCRIPTION
This PR adds support for the bit vector extract operation to the incremental SMT2 solving code. It is separated out from other additions to the bit vector theory, due to the need to add more generalised support for indexed identifiers and the dependency in turn on the back porting of `std::void_t`.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
