### PR TITLE
[RFC] Make conversion failures in the propositional back-end fatal [depends-on: #6914, #6915]

### DIFF
--- a/src/solvers/prop/prop_conv_solver.cpp
+++ b/src/solvers/prop/prop_conv_solver.cpp
@@ -424,9 +424,7 @@ void prop_conv_solvert::add_constraints_to_prop(const exprt &expr, bool value)
 
 void prop_conv_solvert::ignoring(const exprt &expr)
 {
-  // fall through
-
-  log.warning() << "warning: ignoring " << expr.pretty() << messaget::eom;
+  INVARIANT(false, "No known conversion for " + expr.pretty());
 }
 
 void prop_conv_solvert::finish_eager_conversion()


### PR DESCRIPTION
With the exception of some uses of quantifiers that should not be any
cases left that are unsupported by the back-end (while generated by a
sane front-end).

I'm marking this as RFC as I may well be missing something, and the incomplete quantifier support could be a blocker for some users.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
