### PR TITLE
Warn when --malloc-may-fail has no effect

### DIFF
--- a/regression/contracts/malloc-may-fail-warning/main.c
+++ b/regression/contracts/malloc-may-fail-warning/main.c
@@ -1,0 +1,7 @@
+#include <stdlib.h>
+
+void main()
+{
+  int *p = malloc(sizeof(int));
+  __CPROVER_assert(p != NULL, "malloc-may-fail is not set");
+}

--- a/regression/contracts/malloc-may-fail-warning/test.desc
+++ b/regression/contracts/malloc-may-fail-warning/test.desc
@@ -1,0 +1,11 @@
+CORE
+main.c
+--add-library _ --malloc-may-fail
+^malloc-may-fail has no effect when an implementation of malloc is already provided$
+^VERIFICATION SUCCESSFUL$
+^EXIT=0$
+^SIGNAL=0$
+--
+--
+This test is to confirm that ineffective use of malloc-may-fail yields a
+warning.

--- a/regression/contracts/malloc-may-fail-warning/with-malloc.c
+++ b/regression/contracts/malloc-may-fail-warning/with-malloc.c
@@ -1,0 +1,10 @@
+void *malloc(__CPROVER_size_t size)
+{
+  return __CPROVER_allocate(size, 0);
+}
+
+void main()
+{
+  int *p = malloc(sizeof(int));
+  __CPROVER_assert(p != NULL, "malloc-may-fail is not set");
+}

--- a/regression/contracts/malloc-may-fail-warning/with-malloc.desc
+++ b/regression/contracts/malloc-may-fail-warning/with-malloc.desc
@@ -1,0 +1,11 @@
+CORE
+with-malloc.desc
+--malloc-may-fail
+^malloc-may-fail has no effect when an implementation of malloc is already provided$
+^VERIFICATION SUCCESSFUL$
+^EXIT=0$
+^SIGNAL=0$
+--
+--
+This test is to confirm that ineffective use of malloc-may-fail yields a
+warning.

--- a/src/cbmc/cbmc_parse_options.cpp
+++ b/src/cbmc/cbmc_parse_options.cpp
@@ -812,6 +812,18 @@ int cbmc_parse_optionst::get_goto_program(
     return CPROVER_EXIT_SUCCESS;
   }
 
+  if(cmdline.isset("malloc-may-fail"))
+  {
+    auto malloc_entry = goto_model.goto_functions.function_map.find("malloc");
+    if(
+      malloc_entry != goto_model.goto_functions.function_map.end() &&
+      malloc_entry->second.body_available())
+    {
+      log.warning() << "malloc-may-fail has no effect when an implementation "
+                    << "of malloc is already provided" << messaget::eom;
+    }
+  }
+
   if(cbmc_parse_optionst::process_goto_program(goto_model, options, log))
     return CPROVER_EXIT_INTERNAL_ERROR;
 

--- a/src/goto-instrument/goto_instrument_parse_options.cpp
+++ b/src/goto-instrument/goto_instrument_parse_options.cpp
@@ -1066,6 +1066,18 @@ void goto_instrument_parse_optionst::instrument_goto_program()
 
   // we add the library in some cases, as some analyses benefit
 
+  if(cmdline.isset("malloc-may-fail"))
+  {
+    auto malloc_entry = goto_model.goto_functions.function_map.find("malloc");
+    if(
+      malloc_entry != goto_model.goto_functions.function_map.end() &&
+      malloc_entry->second.body_available())
+    {
+      log.warning() << "malloc-may-fail has no effect when an implementation "
+                    << "of malloc is already provided" << messaget::eom;
+    }
+  }
+
   if(cmdline.isset("add-library") ||
      cmdline.isset("mm"))
   {


### PR DESCRIPTION
f7958df5d1 documented that malloc-may-fail needs to be used whenever the
library is added, but users might not actually have had a chance to read
updated documentation. Print a warning at runtime to make it more likely
that users become aware.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
