### PR TITLE
Refactor c_typecheck_baset::do_initializer

### DIFF
--- a/src/ansi-c/c_typecheck_initializer.cpp
+++ b/src/ansi-c/c_typecheck_initializer.cpp
@@ -232,43 +232,25 @@ void c_typecheck_baset::do_initializer(symbolt &symbol)
   if(has_prefix(id2string(symbol.name), CPROVER_PREFIX "constant_infinity"))
     return;
 
-  if(symbol.is_static_lifetime)
-  {
-    if(symbol.value.is_not_nil())
-    {
-      typecheck_expr(symbol.value);
-      do_initializer(symbol.value, symbol.type, true);
+  if(symbol.is_type)
+    return;
 
-      // need to adjust size?
-      if(
-        symbol.type.id() == ID_array &&
-        to_array_type(symbol.type).size().is_nil())
-        symbol.type=symbol.value.type();
+  if(symbol.value.is_not_nil())
+  {
+    typecheck_expr(symbol.value);
+    do_initializer(symbol.value, symbol.type, true);
+
+    // need to adjust size?
+    if(
+      !symbol.is_macro && symbol.type.id() == ID_array &&
+      to_array_type(symbol.type).size().is_nil())
+    {
+      symbol.type = symbol.value.type();
     }
   }
-  else if(!symbol.is_type)
-  {
-    if(symbol.is_macro)
-    {
-      // these must have a constant value
-      assert(symbol.value.is_not_nil());
-      typecheck_expr(symbol.value);
-      source_locationt location=symbol.value.source_location();
-      do_initializer(symbol.value, symbol.type, true);
-      make_constant(symbol.value);
-    }
-    else if(symbol.value.is_not_nil())
-    {
-      typecheck_expr(symbol.value);
-      do_initializer(symbol.value, symbol.type, true);
 
-      // need to adjust size?
-      if(
-        symbol.type.id() == ID_array &&
-        to_array_type(symbol.type).size().is_nil())
-        symbol.type=symbol.value.type();
-    }
-  }
+  if(symbol.is_macro)
+    make_constant(symbol.value);
 }
 
 void c_typecheck_baset::designator_enter(


### PR DESCRIPTION
This function had (almost) the same code across several branches. The
refactoring reduces the number of lines of code and removes an "assert"
statement: `make_constant` will report an error if the result isn't a
constant, making this assertion unnecessary.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
