### PR TITLE
C nondet symbol factory: arrays may have zero size

### DIFF
--- a/regression/cbmc/pointer-to-struct-with-flexible-array-member-as-parameter-to-entry-point/test.desc
+++ b/regression/cbmc/pointer-to-struct-with-flexible-array-member-as-parameter-to-entry-point/test.desc
@@ -1,10 +1,9 @@
-KNOWNBUG
+CORE
 main.c
 --function testFunc
---
 ^EXIT=0$
 ^SIGNAL=0$
 --
-^EXIT=134$
 --
-Github issue #5093: Pointer to struct with flexible array member as parameter to entry point causes invariant violation
+Github issue #5093: Pointer to struct with flexible array member as parameter to
+entry point causes invariant violation

--- a/src/ansi-c/c_nondet_symbol_factory.cpp
+++ b/src/ansi-c/c_nondet_symbol_factory.cpp
@@ -172,9 +172,11 @@ void symbol_factoryt::gen_nondet_array_init(
   auto const &array_type = to_array_type(expr.type());
   const auto &size = array_type.size();
   PRECONDITION(size.id() == ID_constant);
-  auto const array_size = numeric_cast_v<size_t>(to_constant_expr(size));
-  DATA_INVARIANT(array_size > 0, "Arrays should have positive size");
-  for(size_t index = 0; index < array_size; ++index)
+  auto const array_size = numeric_cast<mp_integer>(to_constant_expr(size));
+  DATA_INVARIANT(
+    array_size.has_value() && *array_size >= 0,
+    "Arrays should have positive size");
+  for(mp_integer index = 0; index < *array_size; ++index)
   {
     gen_nondet_init(
       assignments,


### PR DESCRIPTION
There is nothing fundamentally wrong in an array having size 0.

Fixes: #5093

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
