### PR TITLE
Annotate flexible array members

### DIFF
--- a/src/analyses/goto_check_c.cpp
+++ b/src/analyses/goto_check_c.cpp
@@ -1621,7 +1621,7 @@ void goto_check_ct::bounds_check_index(
                         ? to_array_type(array_type).size()
                         : to_vector_type(array_type).size();
 
-  if(size.is_nil())
+  if(size.is_nil() && !array_type.get_bool(ID_C_flexible_array_member))
   {
     // Linking didn't complete, we don't have a size.
     // Not clear what to do.
@@ -1629,7 +1629,9 @@ void goto_check_ct::bounds_check_index(
   else if(size.id() == ID_infinity)
   {
   }
-  else if(size.is_zero() && expr.array().id() == ID_member)
+  else if(
+    expr.array().id() == ID_member &&
+    (size.is_zero() || array_type.get_bool(ID_C_flexible_array_member)))
   {
     // a variable sized struct member
     //

--- a/src/ansi-c/c_typecheck_type.cpp
+++ b/src/ansi-c/c_typecheck_type.cpp
@@ -1010,8 +1010,8 @@ void c_typecheck_baset::typecheck_compound_body(
         }
 
         // make it zero-length
-        c_type.id(ID_array);
-        c_type.set(ID_size, from_integer(0, c_index_type()));
+        to_array_type(c_type).size() = from_integer(0, c_index_type());
+        c_type.set(ID_C_flexible_array_member, true);
       }
     }
   }

--- a/src/util/irep_ids.def
+++ b/src/util/irep_ids.def
@@ -868,6 +868,7 @@ IREP_ID_ONE(bitreverse)
 IREP_ID_ONE(saturating_minus)
 IREP_ID_ONE(saturating_plus)
 IREP_ID_ONE(annotated_pointer_constant)
+IREP_ID_TWO(C_flexible_array_member, #flexible_array_member)
 
 // Projects depending on this code base that wish to extend the list of
 // available ids should provide a file local_irep_ids.def in their source tree

--- a/src/util/pointer_offset_size.cpp
+++ b/src/util/pointer_offset_size.cpp
@@ -368,6 +368,11 @@ optionalt<exprt> size_of_expr(const typet &type, const namespacet &ns)
         if(bytes > 0)
           result = plus_exprt(result, from_integer(bytes, result.type()));
       }
+      else if(c.type().get_bool(ID_C_flexible_array_member))
+      {
+        // flexible array members do not change the sizeof result
+        continue;
+      }
       else
       {
         DATA_INVARIANT(

--- a/src/util/simplify_expr.cpp
+++ b/src/util/simplify_expr.cpp
@@ -1746,6 +1746,9 @@ simplify_exprt::simplify_byte_extract(const byte_extract_exprt &expr)
       if(comps.empty() || comps.back().type().id() != ID_array)
         return false;
 
+      if(comps.back().type().get_bool(ID_C_flexible_array_member))
+        return true;
+
       const auto size =
         numeric_cast<mp_integer>(to_array_type(comps.back().type()).size());
       return !size.has_value() || *size <= 1;


### PR DESCRIPTION
Make sure we can distinguish flexible array members from other arrays,
for example when wanting to distinguish their compile-time from their
runtime size.

This is in preparation of #6661.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
