### PR TITLE
Cleanup build_sizeof_expr

### DIFF
--- a/src/ansi-c/expr2c.cpp
+++ b/src/ansi-c/expr2c.cpp
@@ -1736,7 +1736,10 @@ build_sizeof_expr(const constant_exprt &expr, const namespacet &ns)
   if(type.is_nil())
     return {};
 
-  const auto type_size = pointer_offset_size(type, ns);
+  const auto type_size_expr = size_of_expr(type, ns);
+  optionalt<mp_integer> type_size;
+  if(type_size_expr.has_value())
+    type_size = numeric_cast<mp_integer>(*type_size_expr);
   auto val = numeric_cast<mp_integer>(expr);
 
   if(
@@ -1746,9 +1749,9 @@ build_sizeof_expr(const constant_exprt &expr, const namespacet &ns)
     return {};
   }
 
-  const typet t(size_type());
+  const unsignedbv_typet t(size_type());
   DATA_INVARIANT(
-    address_bits(*val + 1) <= *pointer_offset_bits(t, ns),
+    address_bits(*val + 1) <= t.get_width(),
     "sizeof value does not fit size_type");
 
   mp_integer remainder = 0;

--- a/src/ansi-c/expr2c.cpp
+++ b/src/ansi-c/expr2c.cpp
@@ -1728,6 +1728,49 @@ std::string expr2ct::convert_object_descriptor(
   return result;
 }
 
+static optionalt<exprt>
+build_sizeof_expr(const constant_exprt &expr, const namespacet &ns)
+{
+  const typet &type = static_cast<const typet &>(expr.find(ID_C_c_sizeof_type));
+
+  if(type.is_nil())
+    return {};
+
+  const auto type_size = pointer_offset_size(type, ns);
+  auto val = numeric_cast<mp_integer>(expr);
+
+  if(
+    !type_size.has_value() || *type_size < 0 || !val.has_value() ||
+    *val < *type_size || (*type_size == 0 && *val > 0))
+  {
+    return {};
+  }
+
+  const typet t(size_type());
+  DATA_INVARIANT(
+    address_bits(*val + 1) <= *pointer_offset_bits(t, ns),
+    "sizeof value does not fit size_type");
+
+  mp_integer remainder = 0;
+
+  if(*type_size != 0)
+  {
+    remainder = *val % *type_size;
+    *val -= remainder;
+    *val /= *type_size;
+  }
+
+  exprt result(ID_sizeof, t);
+  result.set(ID_type_arg, type);
+
+  if(*val > 1)
+    result = mult_exprt(result, from_integer(*val, t));
+  if(remainder > 0)
+    result = plus_exprt(result, from_integer(remainder, t));
+
+  return typecast_exprt::conditional_cast(result, expr.type());
+}
+
 std::string expr2ct::convert_constant(
   const constant_exprt &src,
   unsigned &precedence)
@@ -1852,11 +1895,9 @@ std::string expr2ct::convert_constant(
       else if(c_type==ID_signed_long_long_int)
         dest+="ll";
 
-      if(src.find(ID_C_c_sizeof_type).is_not_nil() &&
-         sizeof_nesting==0)
+      if(sizeof_nesting == 0)
       {
-        const auto sizeof_expr_opt =
-          build_sizeof_expr(to_constant_expr(src), ns);
+        const auto sizeof_expr_opt = build_sizeof_expr(src, ns);
 
         if(sizeof_expr_opt.has_value())
         {

--- a/src/util/pointer_offset_size.cpp
+++ b/src/util/pointer_offset_size.cpp
@@ -560,50 +560,6 @@ compute_pointer_offset(const exprt &expr, const namespacet &ns)
   return {}; // don't know
 }
 
-optionalt<exprt>
-build_sizeof_expr(const constant_exprt &expr, const namespacet &ns)
-{
-  const typet &type=
-    static_cast<const typet &>(expr.find(ID_C_c_sizeof_type));
-
-  if(type.is_nil())
-    return {};
-
-  const auto type_size = pointer_offset_size(type, ns);
-  auto val = numeric_cast<mp_integer>(expr);
-
-  if(
-    !type_size.has_value() || *type_size < 0 || !val.has_value() ||
-    *val < *type_size || (*type_size == 0 && *val > 0))
-  {
-    return {};
-  }
-
-  const typet t(size_type());
-  DATA_INVARIANT(
-    address_bits(*val + 1) <= *pointer_offset_bits(t, ns),
-    "sizeof value does not fit size_type");
-
-  mp_integer remainder=0;
-
-  if(*type_size != 0)
-  {
-    remainder = *val % *type_size;
-    *val -= remainder;
-    *val /= *type_size;
-  }
-
-  exprt result(ID_sizeof, t);
-  result.set(ID_type_arg, type);
-
-  if(*val > 1)
-    result = mult_exprt(result, from_integer(*val, t));
-  if(remainder>0)
-    result=plus_exprt(result, from_integer(remainder, t));
-
-  return typecast_exprt::conditional_cast(result, expr.type());
-}
-
 optionalt<exprt> get_subexpression_at_offset(
   const exprt &expr,
   const mp_integer &offset_bytes,

--- a/src/util/pointer_offset_size.h
+++ b/src/util/pointer_offset_size.h
@@ -51,9 +51,6 @@ optionalt<exprt> member_offset_expr(
 
 optionalt<exprt> size_of_expr(const typet &type, const namespacet &ns);
 
-optionalt<exprt>
-build_sizeof_expr(const constant_exprt &expr, const namespacet &ns);
-
 optionalt<exprt> get_subexpression_at_offset(
   const exprt &expr,
   const mp_integer &offset,


### PR DESCRIPTION
This code is entirely specific to the C front-end. See each of the two commits for more details.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
