### PR TITLE
Add tests for `--div-by-zero` and `--signed-overflow` checks for the new SMT backend

### DIFF
--- a/regression/cbmc-incr-smt2/bitvector-flag-tests/div_by_zero.c
+++ b/regression/cbmc-incr-smt2/bitvector-flag-tests/div_by_zero.c
@@ -1,0 +1,15 @@
+int main()
+{
+  int x = 5;
+  int y;
+  int z = 8;
+
+  // Negative case
+  __CPROVER_assert(x / y != 0, "This assertion is falsifiable");
+
+  // Positive case
+  __CPROVER_assert(
+    x / z != 0, "This assertion is valid under all interpretations");
+
+  return 0;
+}

--- a/regression/cbmc-incr-smt2/bitvector-flag-tests/div_by_zero.desc
+++ b/regression/cbmc-incr-smt2/bitvector-flag-tests/div_by_zero.desc
@@ -1,0 +1,14 @@
+CORE
+div_by_zero.c
+--incremental-smt2-solver 'z3 --smt2 -in' --div-by-zero-check --trace
+\[main\.division-by-zero\.1\] line \d division by zero in x / y: FAILURE
+\[main\.division-by-zero\.2\] line \d+ division by zero in x / z: SUCCESS
+y=0
+^VERIFICATION FAILED$
+^EXIT=10$
+^SIGNAL=0$
+--
+--
+This test is designed to drive the `--div-by-zero-check` in both the positive
+and the negative case, and show that it's working for our current implementation-in-progress
+of the new SMT backend.

--- a/regression/cbmc-incr-smt2/bitvector-flag-tests/readme.md
+++ b/regression/cbmc-incr-smt2/bitvector-flag-tests/readme.md
@@ -1,0 +1,12 @@
+# Flag tests
+
+Up until this point, the tests we have for the new SMT backend focus on getting
+simple arithmetic or relational operator verification runs done.
+
+This folder contains a couple of tests that are being run with CBMC flags, adding
+extra assertions such as `--div-by-zero` or `--signed-overflow-check`.
+
+Long term the plan is for this folder to be deleted, and the tests that are being
+run as part of the old SMT backend (or maybe even the whole of CBMC's regression
+test suite) to be run through a label or a flag. But for now, this should do well
+enough to allow us to track the progress of our completion of the new backend.

--- a/regression/cbmc-incr-smt2/bitvector-flag-tests/signed_overflow.c
+++ b/regression/cbmc-incr-smt2/bitvector-flag-tests/signed_overflow.c
@@ -1,0 +1,10 @@
+#include <limits.h>
+
+int main()
+{
+  int x = INT_MAX;
+  int y;
+  int z = x + y;
+
+  __CPROVER_assert(z < INT_MIN, "This assertion is falsifiable");
+}

--- a/regression/cbmc-incr-smt2/bitvector-flag-tests/signed_overflow.desc
+++ b/regression/cbmc-incr-smt2/bitvector-flag-tests/signed_overflow.desc
@@ -1,0 +1,11 @@
+KNOWNBUG
+signed_overflow.c
+--incremental-smt2-solver 'z3 --smt2 -in' --signed-overflow-check --trace
+^VERIFICATION FAILED$
+^EXIT=10$
+^SIGNAL=0$
+--
+Invariant check failed
+Reason: Reached unimplemented Generation of SMT formula for unknown kind of expression: overflow-\+
+--
+This tests exercise the driving of the `--signed-overflow-check` flag.


### PR DESCRIPTION
This PR adds two more tests to the regression test-suite of the new SMT
backend, that are exercising the code under two flags adding extra assertions.

The status right now is that `--div-by-zero` works, whereas `--signed-overflow-check`
fails with an unimplemented invariant.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
