### PR TITLE
String abstraction: gracefully handle type casts from non-char types

### DIFF
--- a/regression/cbmc/String_Abstraction24/main.c
+++ b/regression/cbmc/String_Abstraction24/main.c
@@ -1,0 +1,21 @@
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+int main()
+{
+  size_t len;
+  __CPROVER_assume(0 < len);
+  uint16_t *data = malloc(len * sizeof(uint16_t));
+  if(data)
+  {
+    len = (len + 1) * sizeof(uint16_t);
+    uint16_t *ptr = malloc(len);
+    if(ptr)
+    {
+      memcpy(ptr, data, len);
+      ptr[len] = 0;
+    }
+  }
+  return 0;
+}

--- a/regression/cbmc/String_Abstraction24/test.desc
+++ b/regression/cbmc/String_Abstraction24/test.desc
@@ -1,0 +1,12 @@
+CORE
+main.c
+--string-abstraction
+^VERIFICATION FAILED$
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring
+^Invariant check failed
+--
+String abstraction is not necessarily precise enough to reason across type casts
+from non-char pointer types, but must not fail to process such examples.

--- a/src/goto-programs/string_abstraction.cpp
+++ b/src/goto-programs/string_abstraction.cpp
@@ -651,12 +651,18 @@ exprt string_abstractiont::build(
   // take care of pointer typecasts now
   if(pointer.id()==ID_typecast)
   {
+    const exprt &op = to_typecast_expr(pointer).op();
+
     // cast from another pointer type?
-    if(to_typecast_expr(pointer).op().type().id() != ID_pointer)
+    if(
+      op.type().id() != ID_pointer ||
+      !is_char_type(to_pointer_type(op.type()).base_type()))
+    {
       return build_unknown(what, write);
+    }
 
     // recursive call
-    return build(to_typecast_expr(pointer).op(), what, write, source_location);
+    return build(op, what, write, source_location);
   }
 
   exprt str_struct;


### PR DESCRIPTION
The previous implementation would only work when type casts were limited
to casts to and from char-sized bitvector types. We lose precision when
casting from non-char types, but shouldn't end up hitting "UNREACHABLE."

Co-authored-by: Remi Delmas <delmasrd@amazon.com>

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
