### PR TITLE
goto_rw: byte extracts may have a negative offset

### DIFF
--- a/regression/cbmc/full_slice3/test.desc
+++ b/regression/cbmc/full_slice3/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.c
 --full-slice
 ^EXIT=0$

--- a/src/analyses/goto_rw.cpp
+++ b/src/analyses/goto_rw.cpp
@@ -163,8 +163,9 @@ void rw_range_sett::get_objects_byte_extract(
       be.op().type(),
       be.id()==ID_byte_extract_little_endian,
       ns);
-    range_spect offset =
-      range_start + map.map_bit(numeric_cast_v<std::size_t>(*index));
+    range_spect offset = range_start;
+    if(*index > 0)
+      offset += map.map_bit(numeric_cast_v<std::size_t>(*index));
     get_objects_rec(mode, be.op(), offset, size);
   }
 }


### PR DESCRIPTION
A negative offset can be safely ignored as there is nothing to be read
from or to be written to.

Fixes: #2524

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
