### PR TITLE
Add remaining SMT bv functions to theory

### DIFF
--- a/src/solvers/smt2_incremental/smt_bit_vector_theory.cpp
+++ b/src/solvers/smt2_incremental/smt_bit_vector_theory.cpp
@@ -700,3 +700,34 @@ void smt_bit_vector_theoryt::arithmetic_shift_rightt::validate(
 const smt_function_application_termt::factoryt<
   smt_bit_vector_theoryt::arithmetic_shift_rightt>
   smt_bit_vector_theoryt::arithmetic_shift_right{};
+
+const char *smt_bit_vector_theoryt::repeatt::identifier()
+{
+  return "repeat";
+}
+
+smt_sortt
+smt_bit_vector_theoryt::repeatt::return_sort(const smt_termt &operand) const
+{
+  const std::size_t operand_width =
+    operand.get_sort().cast<smt_bit_vector_sortt>()->bit_width();
+  return smt_bit_vector_sortt{i * operand_width};
+}
+
+std::vector<smt_indext> smt_bit_vector_theoryt::repeatt::indices() const
+{
+  return {smt_numeral_indext{i}};
+}
+
+void smt_bit_vector_theoryt::repeatt::validate(const smt_termt &operand) const
+{
+  PRECONDITION(i >= 1);
+  PRECONDITION(operand.get_sort().cast<smt_bit_vector_sortt>());
+}
+
+smt_function_application_termt::factoryt<smt_bit_vector_theoryt::repeatt>
+smt_bit_vector_theoryt::repeat(std::size_t i)
+{
+  PRECONDITION(i >= 1);
+  return smt_function_application_termt::factoryt<repeatt>(i);
+}

--- a/src/solvers/smt2_incremental/smt_bit_vector_theory.cpp
+++ b/src/solvers/smt2_incremental/smt_bit_vector_theory.cpp
@@ -731,3 +731,61 @@ smt_bit_vector_theoryt::repeat(std::size_t i)
   PRECONDITION(i >= 1);
   return smt_function_application_termt::factoryt<repeatt>(i);
 }
+
+const char *smt_bit_vector_theoryt::zero_extendt::identifier()
+{
+  return "zero_extend";
+}
+
+smt_sortt smt_bit_vector_theoryt::zero_extendt::return_sort(
+  const smt_termt &operand) const
+{
+  const std::size_t operand_width =
+    operand.get_sort().cast<smt_bit_vector_sortt>()->bit_width();
+  return smt_bit_vector_sortt{i + operand_width};
+}
+
+std::vector<smt_indext> smt_bit_vector_theoryt::zero_extendt::indices() const
+{
+  return {smt_numeral_indext{i}};
+}
+
+void smt_bit_vector_theoryt::zero_extendt::validate(const smt_termt &operand)
+{
+  PRECONDITION(operand.get_sort().cast<smt_bit_vector_sortt>());
+}
+
+smt_function_application_termt::factoryt<smt_bit_vector_theoryt::zero_extendt>
+smt_bit_vector_theoryt::zero_extend(std::size_t i)
+{
+  return smt_function_application_termt::factoryt<zero_extendt>(i);
+}
+
+const char *smt_bit_vector_theoryt::sign_extendt::identifier()
+{
+  return "sign_extend";
+}
+
+smt_sortt smt_bit_vector_theoryt::sign_extendt::return_sort(
+  const smt_termt &operand) const
+{
+  const std::size_t operand_width =
+    operand.get_sort().cast<smt_bit_vector_sortt>()->bit_width();
+  return smt_bit_vector_sortt{i + operand_width};
+}
+
+std::vector<smt_indext> smt_bit_vector_theoryt::sign_extendt::indices() const
+{
+  return {smt_numeral_indext{i}};
+}
+
+void smt_bit_vector_theoryt::sign_extendt::validate(const smt_termt &operand)
+{
+  PRECONDITION(operand.get_sort().cast<smt_bit_vector_sortt>());
+}
+
+smt_function_application_termt::factoryt<smt_bit_vector_theoryt::sign_extendt>
+smt_bit_vector_theoryt::sign_extend(std::size_t i)
+{
+  return smt_function_application_termt::factoryt<sign_extendt>(i);
+}

--- a/src/solvers/smt2_incremental/smt_bit_vector_theory.cpp
+++ b/src/solvers/smt2_incremental/smt_bit_vector_theory.cpp
@@ -789,3 +789,57 @@ smt_bit_vector_theoryt::sign_extend(std::size_t i)
 {
   return smt_function_application_termt::factoryt<sign_extendt>(i);
 }
+
+const char *smt_bit_vector_theoryt::rotate_leftt::identifier()
+{
+  return "rotate_left";
+}
+
+smt_sortt
+smt_bit_vector_theoryt::rotate_leftt::return_sort(const smt_termt &operand)
+{
+  return operand.get_sort();
+}
+
+std::vector<smt_indext> smt_bit_vector_theoryt::rotate_leftt::indices() const
+{
+  return {smt_numeral_indext{i}};
+}
+
+void smt_bit_vector_theoryt::rotate_leftt::validate(const smt_termt &operand)
+{
+  PRECONDITION(operand.get_sort().cast<smt_bit_vector_sortt>());
+}
+
+smt_function_application_termt::factoryt<smt_bit_vector_theoryt::rotate_leftt>
+smt_bit_vector_theoryt::rotate_left(std::size_t i)
+{
+  return smt_function_application_termt::factoryt<rotate_leftt>(i);
+}
+
+const char *smt_bit_vector_theoryt::rotate_rightt::identifier()
+{
+  return "rotate_right";
+}
+
+smt_sortt
+smt_bit_vector_theoryt::rotate_rightt::return_sort(const smt_termt &operand)
+{
+  return operand.get_sort();
+}
+
+std::vector<smt_indext> smt_bit_vector_theoryt::rotate_rightt::indices() const
+{
+  return {smt_numeral_indext{i}};
+}
+
+void smt_bit_vector_theoryt::rotate_rightt::validate(const smt_termt &operand)
+{
+  PRECONDITION(operand.get_sort().cast<smt_bit_vector_sortt>());
+}
+
+smt_function_application_termt::factoryt<smt_bit_vector_theoryt::rotate_rightt>
+smt_bit_vector_theoryt::rotate_right(std::size_t i)
+{
+  return smt_function_application_termt::factoryt<rotate_rightt>(i);
+}

--- a/src/solvers/smt2_incremental/smt_bit_vector_theory.cpp
+++ b/src/solvers/smt2_incremental/smt_bit_vector_theory.cpp
@@ -245,6 +245,28 @@ void smt_bit_vector_theoryt::xnort::validate(
 const smt_function_application_termt::factoryt<smt_bit_vector_theoryt::xnort>
   smt_bit_vector_theoryt::xnor{};
 
+const char *smt_bit_vector_theoryt::comparet::identifier()
+{
+  return "bvcomp";
+}
+
+smt_sortt smt_bit_vector_theoryt::comparet::return_sort(
+  const smt_termt &lhs,
+  const smt_termt &rhs)
+{
+  return smt_bit_vector_sortt{1};
+}
+
+void smt_bit_vector_theoryt::comparet::validate(
+  const smt_termt &lhs,
+  const smt_termt &rhs)
+{
+  validate_matched_bit_vector_sorts(lhs, rhs);
+}
+
+const smt_function_application_termt::factoryt<smt_bit_vector_theoryt::comparet>
+  smt_bit_vector_theoryt::compare{};
+
 // Relational operator definitions
 
 const char *smt_bit_vector_theoryt::unsigned_less_thant::identifier()

--- a/src/solvers/smt2_incremental/smt_bit_vector_theory.h
+++ b/src/solvers/smt2_incremental/smt_bit_vector_theory.h
@@ -264,6 +264,17 @@ public:
   };
   static const smt_function_application_termt::factoryt<arithmetic_shift_rightt>
     arithmetic_shift_right;
+
+  struct repeatt final
+  {
+    std::size_t i;
+    static const char *identifier();
+    smt_sortt return_sort(const smt_termt &operand) const;
+    std::vector<smt_indext> indices() const;
+    void validate(const smt_termt &operand) const;
+  };
+  static smt_function_application_termt::factoryt<repeatt>
+  repeat(std::size_t i);
 };
 
 #endif // CPROVER_SOLVERS_SMT2_INCREMENTAL_SMT_BIT_VECTOR_THEORY_H

--- a/src/solvers/smt2_incremental/smt_bit_vector_theory.h
+++ b/src/solvers/smt2_incremental/smt_bit_vector_theory.h
@@ -85,6 +85,14 @@ public:
   };
   static const smt_function_application_termt::factoryt<xnort> xnor;
 
+  struct comparet final
+  {
+    static const char *identifier();
+    static smt_sortt return_sort(const smt_termt &lhs, const smt_termt &rhs);
+    static void validate(const smt_termt &lhs, const smt_termt &rhs);
+  };
+  static const smt_function_application_termt::factoryt<comparet> compare;
+
   // Relational operator class declarations
   struct unsigned_less_thant final
   {

--- a/src/solvers/smt2_incremental/smt_bit_vector_theory.h
+++ b/src/solvers/smt2_incremental/smt_bit_vector_theory.h
@@ -297,6 +297,28 @@ public:
   };
   static smt_function_application_termt::factoryt<sign_extendt>
   sign_extend(std::size_t i);
+
+  struct rotate_leftt final
+  {
+    std::size_t i;
+    static const char *identifier();
+    static smt_sortt return_sort(const smt_termt &operand);
+    std::vector<smt_indext> indices() const;
+    static void validate(const smt_termt &operand);
+  };
+  static smt_function_application_termt::factoryt<rotate_leftt>
+  rotate_left(std::size_t i);
+
+  struct rotate_rightt final
+  {
+    std::size_t i;
+    static const char *identifier();
+    static smt_sortt return_sort(const smt_termt &operand);
+    std::vector<smt_indext> indices() const;
+    static void validate(const smt_termt &operand);
+  };
+  static smt_function_application_termt::factoryt<rotate_rightt>
+  rotate_right(std::size_t i);
 };
 
 #endif // CPROVER_SOLVERS_SMT2_INCREMENTAL_SMT_BIT_VECTOR_THEORY_H

--- a/src/solvers/smt2_incremental/smt_bit_vector_theory.h
+++ b/src/solvers/smt2_incremental/smt_bit_vector_theory.h
@@ -275,6 +275,28 @@ public:
   };
   static smt_function_application_termt::factoryt<repeatt>
   repeat(std::size_t i);
+
+  struct zero_extendt final
+  {
+    std::size_t i;
+    static const char *identifier();
+    smt_sortt return_sort(const smt_termt &operand) const;
+    std::vector<smt_indext> indices() const;
+    static void validate(const smt_termt &operand);
+  };
+  static smt_function_application_termt::factoryt<zero_extendt>
+  zero_extend(std::size_t i);
+
+  struct sign_extendt final
+  {
+    std::size_t i;
+    static const char *identifier();
+    smt_sortt return_sort(const smt_termt &operand) const;
+    std::vector<smt_indext> indices() const;
+    static void validate(const smt_termt &operand);
+  };
+  static smt_function_application_termt::factoryt<sign_extendt>
+  sign_extend(std::size_t i);
 };
 
 #endif // CPROVER_SOLVERS_SMT2_INCREMENTAL_SMT_BIT_VECTOR_THEORY_H

--- a/unit/solvers/smt2_incremental/smt_bit_vector_theory.cpp
+++ b/unit/solvers/smt2_incremental/smt_bit_vector_theory.cpp
@@ -577,3 +577,21 @@ TEST_CASE("SMT bit vector shifts", "[core][smt2_incremental]")
       smt_bit_vector_theoryt::arithmetic_shift_right(true_val, three));
   }
 }
+
+TEST_CASE("SMT bit vector repeat", "[core][smt2_incremental]")
+{
+  const smt_bit_vector_constant_termt two{2, 8};
+  const auto expected_return_sort = smt_bit_vector_sortt{32};
+  const smt_bool_literal_termt true_val{true};
+  const auto function_application = smt_bit_vector_theoryt::repeat(4)(two);
+  REQUIRE(
+    function_application.function_identifier() ==
+    smt_identifier_termt(
+      "repeat", expected_return_sort, {smt_numeral_indext{4}}));
+  REQUIRE(function_application.get_sort() == expected_return_sort);
+  REQUIRE(function_application.arguments().size() == 1);
+  REQUIRE(function_application.arguments()[0].get() == two);
+  cbmc_invariants_should_throwt invariants_throw;
+  REQUIRE_THROWS(smt_bit_vector_theoryt::repeat(0));
+  REQUIRE_THROWS(smt_bit_vector_theoryt::repeat(1)(true_val));
+}

--- a/unit/solvers/smt2_incremental/smt_bit_vector_theory.cpp
+++ b/unit/solvers/smt2_incremental/smt_bit_vector_theory.cpp
@@ -174,6 +174,32 @@ TEST_CASE("SMT bit vector bitwise operators", "[core][smt2_incremental]")
   }
 }
 
+TEST_CASE("SMT bit vector comparison", "[core][smt2_incremental]")
+{
+  const smt_bit_vector_constant_termt a_valid{42, 16}, b_valid{8, 16};
+  SECTION("Valid operands")
+  {
+    const auto compare = smt_bit_vector_theoryt::compare(a_valid, b_valid);
+    const auto expected_return_sort = smt_bit_vector_sortt{1};
+    REQUIRE(
+      compare.function_identifier() ==
+      smt_identifier_termt("bvcomp", expected_return_sort));
+    REQUIRE(compare.get_sort() == expected_return_sort);
+    REQUIRE(compare.arguments().size() == 2);
+    REQUIRE(compare.arguments()[0].get() == a_valid);
+    REQUIRE(compare.arguments()[1].get() == b_valid);
+  }
+  SECTION("Invalid operands")
+  {
+    const smt_bool_literal_termt false_term{false};
+    const smt_bool_literal_termt true_term{true};
+    cbmc_invariants_should_throwt invariants_throw;
+    CHECK_THROWS(smt_bit_vector_theoryt::compare(a_valid, false_term));
+    CHECK_THROWS(smt_bit_vector_theoryt::compare(false_term, a_valid));
+    CHECK_THROWS(smt_bit_vector_theoryt::compare(false_term, true_term));
+  }
+}
+
 TEST_CASE("SMT bit vector predicates", "[core][smt2_incremental]")
 {
   const smt_bit_vector_constant_termt two{2, 8};

--- a/unit/solvers/smt2_incremental/smt_bit_vector_theory.cpp
+++ b/unit/solvers/smt2_incremental/smt_bit_vector_theory.cpp
@@ -595,3 +595,41 @@ TEST_CASE("SMT bit vector repeat", "[core][smt2_incremental]")
   REQUIRE_THROWS(smt_bit_vector_theoryt::repeat(0));
   REQUIRE_THROWS(smt_bit_vector_theoryt::repeat(1)(true_val));
 }
+
+TEST_CASE("SMT bit vector extend", "[core][smt2_incremental]")
+{
+  const smt_bit_vector_constant_termt two{2, 8};
+  const smt_bool_literal_termt true_val{true};
+  SECTION("Zero extension")
+  {
+    const auto function_application =
+      smt_bit_vector_theoryt::zero_extend(4)(two);
+    const auto expected_return_sort = smt_bit_vector_sortt{12};
+    REQUIRE(
+      function_application.function_identifier() ==
+      smt_identifier_termt(
+        "zero_extend", expected_return_sort, {smt_numeral_indext{4}}));
+    REQUIRE(function_application.get_sort() == expected_return_sort);
+    REQUIRE(function_application.arguments().size() == 1);
+    REQUIRE(function_application.arguments()[0].get() == two);
+    cbmc_invariants_should_throwt invariants_throw;
+    REQUIRE_NOTHROW(smt_bit_vector_theoryt::zero_extend(0));
+    REQUIRE_THROWS(smt_bit_vector_theoryt::zero_extend(1)(true_val));
+  }
+  SECTION("Sign extension")
+  {
+    const auto function_application =
+      smt_bit_vector_theoryt::sign_extend(4)(two);
+    const auto expected_return_sort = smt_bit_vector_sortt{12};
+    REQUIRE(
+      function_application.function_identifier() ==
+      smt_identifier_termt(
+        "sign_extend", expected_return_sort, {smt_numeral_indext{4}}));
+    REQUIRE(function_application.get_sort() == expected_return_sort);
+    REQUIRE(function_application.arguments().size() == 1);
+    REQUIRE(function_application.arguments()[0].get() == two);
+    cbmc_invariants_should_throwt invariants_throw;
+    REQUIRE_NOTHROW(smt_bit_vector_theoryt::sign_extend(0));
+    REQUIRE_THROWS(smt_bit_vector_theoryt::sign_extend(1)(true_val));
+  }
+}

--- a/unit/solvers/smt2_incremental/smt_bit_vector_theory.cpp
+++ b/unit/solvers/smt2_incremental/smt_bit_vector_theory.cpp
@@ -633,3 +633,40 @@ TEST_CASE("SMT bit vector extend", "[core][smt2_incremental]")
     REQUIRE_THROWS(smt_bit_vector_theoryt::sign_extend(1)(true_val));
   }
 }
+
+TEST_CASE("SMT bit vector rotation", "[core][smt2_incremental]")
+{
+  const smt_bit_vector_constant_termt two{2, 8};
+  const smt_bool_literal_termt true_val{true};
+  const auto expected_return_sort = smt_bit_vector_sortt{8};
+  SECTION("Left rotation")
+  {
+    const auto function_application =
+      smt_bit_vector_theoryt::rotate_left(4)(two);
+    REQUIRE(
+      function_application.function_identifier() ==
+      smt_identifier_termt(
+        "rotate_left", expected_return_sort, {smt_numeral_indext{4}}));
+    REQUIRE(function_application.get_sort() == expected_return_sort);
+    REQUIRE(function_application.arguments().size() == 1);
+    REQUIRE(function_application.arguments()[0].get() == two);
+    cbmc_invariants_should_throwt invariants_throw;
+    REQUIRE_NOTHROW(smt_bit_vector_theoryt::rotate_left(0));
+    REQUIRE_THROWS(smt_bit_vector_theoryt::rotate_left(1)(true_val));
+  }
+  SECTION("Right rotation")
+  {
+    const auto function_application =
+      smt_bit_vector_theoryt::rotate_right(4)(two);
+    REQUIRE(
+      function_application.function_identifier() ==
+      smt_identifier_termt(
+        "rotate_right", expected_return_sort, {smt_numeral_indext{4}}));
+    REQUIRE(function_application.get_sort() == expected_return_sort);
+    REQUIRE(function_application.arguments().size() == 1);
+    REQUIRE(function_application.arguments()[0].get() == two);
+    cbmc_invariants_should_throwt invariants_throw;
+    REQUIRE_NOTHROW(smt_bit_vector_theoryt::rotate_right(0));
+    REQUIRE_THROWS(smt_bit_vector_theoryt::rotate_right(1)(true_val));
+  }
+}


### PR DESCRIPTION
This PR add remaining SMT bv functions to theory. This should entail a full set of functions being present once the PR is merged.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
