### PR TITLE
Run C regression tests using clang and gcc when both are available

### DIFF
--- a/regression/ansi-c/CMakeLists.txt
+++ b/regression/ansi-c/CMakeLists.txt
@@ -19,9 +19,34 @@ elseif("${CMAKE_SYSTEM_NAME}" STREQUAL "Darwin")
         "CORE"
     )
 else()
-    add_test_pl_tests(
-        "$<TARGET_FILE:goto-cc>"
-    )
+    find_program(CLANG_EXISTS "clang")
+    find_program(GCC_EXISTS "gcc")
+    if(CLANG_EXISTS)
+        add_test_pl_profile(
+            "ansi-c-clang"
+            "$<TARGET_FILE:goto-cc> --native-compiler clang"
+            "-C;-s;ansi-c-clang"
+            "CORE"
+        )
+    endif()
+    if(GCC_EXISTS)
+        add_test_pl_profile(
+            "ansi-c-gcc"
+            "$<TARGET_FILE:goto-cc> --native-compiler gcc"
+            "-C;-X;fake-gcc-version;-s;ansi-c-gcc"
+            "CORE"
+        )
+        add_test_pl_profile(
+            "ansi-c-fake-gcc"
+            "$<TARGET_FILE:goto-cc>"
+            "-C;-I;fake-gcc-version;-s;ansi-c-fake-gcc"
+            "CORE"
+        )
+    elseif(NOT CLANG_EXISTS)
+        add_test_pl_tests(
+            "$<TARGET_FILE:goto-cc>"
+        )
+    endif()
 
     add_test_pl_profile(
         "ansi-c-c++-front-end"

--- a/regression/ansi-c/Makefile
+++ b/regression/ansi-c/Makefile
@@ -23,13 +23,29 @@ endif
 endif
 
 test:
-	@../test.pl -e -p -c $(exe) $(excluded_tests)
+	if which clang ; then \
+	  ../test.pl -e -p -c "$(exe) --native-compiler clang" $(excluded_tests) ; \
+	fi
+	if which gcc ; then \
+	  ../test.pl -e -p -c "$(exe) --native-compiler gcc" $(excluded_tests) -X fake-gcc-version && \
+	  ../test.pl -e -p -c $(exe) $(excluded_tests) -I fake-gcc-version ; \
+	elif ! which clang ; then \
+	  ../test.pl -e -p -c $(exe) $(excluded_tests) ; \
+	fi
 ifneq ($(BUILD_ENV_),MSVC)
 	@../test.pl -e -p -c "$(exe) -xc++ -D_Bool=bool" -I test-c++-front-end -s c++-front-end $(excluded_tests)
 endif
 
 tests.log: ../test.pl
-	@../test.pl -e -p -c $(exe) $(excluded_tests)
+	if which clang ; then \
+	  ../test.pl -e -p -c "$(exe) --native-compiler clang" $(excluded_tests) ; \
+	fi
+	if which gcc ; then \
+	  ../test.pl -e -p -c "$(exe) --native-compiler gcc" $(excluded_tests) -X fake-gcc-version && \
+	  ../test.pl -e -p -c $(exe) $(excluded_tests) -I fake-gcc-version ; \
+	elif ! which clang ; then \
+	  ../test.pl -e -p -c $(exe) $(excluded_tests) ; \
+	fi
 ifneq ($(BUILD_ENV_),MSVC)
 	@../test.pl -e -p -c "$(exe) -xc++ -D_Bool=bool" -I test-c++-front-end -s c++-front-end $(excluded_tests)
 endif

--- a/regression/ansi-c/gcc_version1/test-gcc-4.desc
+++ b/regression/ansi-c/gcc_version1/test-gcc-4.desc
@@ -1,4 +1,4 @@
-CORE gcc-only
+CORE gcc-only fake-gcc-version
 gcc-4.c
 --native-compiler ./fake-gcc-4
 ^EXIT=0$

--- a/regression/ansi-c/gcc_version1/test-gcc-5.desc
+++ b/regression/ansi-c/gcc_version1/test-gcc-5.desc
@@ -1,4 +1,4 @@
-CORE gcc-only
+CORE gcc-only fake-gcc-version
 gcc-5.c
 --native-compiler ./fake-gcc-5
 ^EXIT=0$

--- a/regression/ansi-c/gcc_version1/test-gcc-7.desc
+++ b/regression/ansi-c/gcc_version1/test-gcc-7.desc
@@ -1,4 +1,4 @@
-CORE gcc-only
+CORE gcc-only fake-gcc-version
 gcc-7.c
 --native-compiler ./fake-gcc-7
 ^EXIT=0$

--- a/src/ansi-c/c_typecheck_expr.cpp
+++ b/src/ansi-c/c_typecheck_expr.cpp
@@ -3092,9 +3092,7 @@ exprt c_typecheck_baset::do_special_functions(
     {
       // clang returns 4 for _Bool, gcc treats these as 'int'.
       type_number =
-        config.ansi_c.preprocessor == configt::ansi_ct::preprocessort::CLANG
-          ? 4u
-          : 1u;
+        config.ansi_c.mode == configt::ansi_ct::flavourt::CLANG ? 4u : 1u;
     }
     else
     {


### PR DESCRIPTION
Our C front-end seeks to conform to whatever interpretation of the C
standard the underlying host C compiler has. To avoid incompatibilities
as documented in #2370, run regression tests using both Clang and GCC,
if available on a particular system.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
