### PR TITLE
Deprecate multi-argument variants of exprt::copy_to_operands

### DIFF
--- a/jbmc/src/java_bytecode/remove_java_new.cpp
+++ b/jbmc/src/java_bytecode/remove_java_new.cpp
@@ -280,8 +280,7 @@ goto_programt::targett remove_java_newt::lower_java_new_array(
     const auto zero_element =
       zero_initializer(data.type().subtype(), location, ns);
     CHECK_RETURN(zero_element.has_value());
-    codet array_set(ID_array_set);
-    array_set.copy_to_operands(new_array_data_symbol, *zero_element);
+    codet array_set{ID_array_set, {new_array_data_symbol, *zero_element}};
     dest.insert_before(next, goto_programt::make_other(array_set, location));
   }
 

--- a/src/ansi-c/c_typecheck_expr.cpp
+++ b/src/ansi-c/c_typecheck_expr.cpp
@@ -1035,8 +1035,8 @@ void c_typecheck_baset::typecheck_expr_sizeof(exprt &expr)
     // It is not obvious whether the type or 'e' should be evaluated
     // first.
 
-    exprt comma_expr(ID_comma, expr.type());
-    comma_expr.copy_to_operands(side_effect_expr, expr);
+    binary_exprt comma_expr{
+      std::move(side_effect_expr), ID_comma, expr, expr.type()};
     expr.swap(comma_expr);
   }
 }
@@ -1085,8 +1085,8 @@ void c_typecheck_baset::typecheck_expr_typecast(exprt &expr)
     // It is not obvious whether the type or 'e' should be evaluated
     // first.
 
-    exprt comma_expr(ID_comma, op.type());
-    comma_expr.copy_to_operands(side_effect_expr, op);
+    binary_exprt comma_expr{
+      std::move(side_effect_expr), ID_comma, op, op.type()};
     op.swap(comma_expr);
   }
 

--- a/src/goto-programs/builtin_functions.cpp
+++ b/src/goto-programs/builtin_functions.cpp
@@ -100,7 +100,7 @@ void goto_convertt::do_prob_uniform(
     throw 0;
   }
 
-  rhs.copy_to_operands(arguments[0], arguments[1]);
+  rhs.add_to_operands(exprt{arguments[0]}, exprt{arguments[1]});
 
   code_assignt assignment(lhs, rhs);
   assignment.add_source_location()=function.source_location();

--- a/src/jsil/jsil_convert.cpp
+++ b/src/jsil/jsil_convert.cpp
@@ -93,7 +93,7 @@ bool jsil_convertt::convert_code(const symbolt &symbol, codet &code)
       code_try_catcht t_c(std::move(t));
       // Adding empty symbol to catch decl
       code_frontend_declt d(symbol_exprt::typeless("decl_symbol"));
-      t_c.add_catch(d, g);
+      t_c.add_catch(std::move(d), std::move(g));
       t_c.add_source_location()=code.source_location();
 
       code.swap(t_c);

--- a/src/solvers/flattening/boolbv_get.cpp
+++ b/src/solvers/flattening/boolbv_get.cpp
@@ -356,7 +356,7 @@ exprt boolbvt::bv_get_unbounded_array(const exprt &expr) const
         it++)
     {
       exprt index=from_integer(it->first, size.type());
-      result.copy_to_operands(index, it->second);
+      result.add_to_operands(std::move(index), exprt{it->second});
     }
   }
   else

--- a/src/solvers/lowering/byte_operators.cpp
+++ b/src/solvers/lowering/byte_operators.cpp
@@ -1408,7 +1408,7 @@ static exprt lower_byte_update_byte_array_vector(
   {
     const exprt &element = value_as_byte_array.operands()[i];
 
-    const exprt where = simplify_expr(
+    exprt where = simplify_expr(
       plus_exprt{src.offset(), from_integer(i, src.offset().type())}, ns);
 
     // skip elements that wouldn't change (skip over typecasts as we might have
@@ -1437,9 +1437,9 @@ static exprt lower_byte_update_byte_array_vector(
       update_value = typecast_exprt::conditional_cast(element, subtype);
 
     if(result.id() != ID_with)
-      result = with_exprt{result, where, update_value};
+      result = with_exprt{result, std::move(where), std::move(update_value)};
     else
-      result.add_to_operands(where, update_value);
+      result.add_to_operands(std::move(where), std::move(update_value));
   }
 
   return simplify_expr(std::move(result), ns);

--- a/src/util/expr.h
+++ b/src/util/expr.h
@@ -10,6 +10,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #define CPROVER_UTIL_EXPR_H
 
 #include "as_const.h"
+#include "deprecate.h"
 #include "type.h"
 #include "validate_expressions.h"
 #include "validate_types.h"
@@ -148,6 +149,7 @@ public:
   /// Copy the given arguments to the end of `exprt`'s operands.
   /// \param e1: first `exprt` to append to the operands
   /// \param e2: second `exprt` to append to the operands
+  DEPRECATED(SINCE(2022, 2, 15, "use add_to_operands(&&, &&) instead"))
   void copy_to_operands(const exprt &e1, const exprt &e2)
   {
     operandst &op = operands();
@@ -161,6 +163,7 @@ public:
   /// Add the given arguments to the end of `exprt`'s operands.
   /// \param e1: first `exprt` to append to the operands
   /// \param e2: second `exprt` to append to the operands
+  DEPRECATED(SINCE(2022, 2, 15, "use add_to_operands(&&, &&) instead"))
   void add_to_operands(const exprt &e1, const exprt &e2)
   {
     copy_to_operands(e1, e2);
@@ -183,6 +186,7 @@ public:
   /// \param e1: first `exprt` to append to the operands
   /// \param e2: second `exprt` to append to the operands
   /// \param e3: third `exprt` to append to the operands
+  DEPRECATED(SINCE(2022, 2, 15, "use add_to_operands(&&, &&, &&) instead"))
   void add_to_operands(const exprt &e1, const exprt &e2, const exprt &e3)
   {
     copy_to_operands(e1, e2, e3);
@@ -192,6 +196,7 @@ public:
   /// \param e1: first `exprt` to append to the operands
   /// \param e2: second `exprt` to append to the operands
   /// \param e3: third `exprt` to append to the operands
+  DEPRECATED(SINCE(2022, 2, 15, "use add_to_operands(&&, &&, &&) instead"))
   void copy_to_operands(const exprt &e1, const exprt &e2, const exprt &e3)
   {
     operandst &op = operands();

--- a/src/util/std_code.h
+++ b/src/util/std_code.h
@@ -2025,9 +2025,9 @@ public:
     return to_code(operands()[2*i+2]);
   }
 
-  void add_catch(const code_frontend_declt &to_catch, const codet &code_catch)
+  void add_catch(code_frontend_declt &&to_catch, codet &&code_catch)
   {
-    add_to_operands(to_catch, code_catch);
+    add_to_operands(std::move(to_catch), std::move(code_catch));
   }
 
 protected:


### PR DESCRIPTION
add_to_operands or constructors with move semantics are preferable. All
existing uses of the newly deprecated methods have been reworked to use
non-deprecated methods.

Fixes: #2809

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
