### PR TITLE
Remove deprecated dynamic_object pointer predicate

### DIFF
--- a/src/pointer-analysis/value_set_dereference.cpp
+++ b/src/pointer-analysis/value_set_dereference.cpp
@@ -480,7 +480,7 @@ value_set_dereferencet::valuet value_set_dereferencet::build_reference_to(
   {
     // constraint that it actually is a dynamic object
     // this is also our guard
-    result.pointer_guard = dynamic_object(pointer_expr);
+    result.pointer_guard = is_dynamic_object_exprt(pointer_expr);
 
     // can't remove here, turn into *p
     result.value = dereference_exprt{pointer_expr};

--- a/src/util/pointer_predicates.cpp
+++ b/src/util/pointer_predicates.cpp
@@ -56,13 +56,6 @@ exprt dead_object(const exprt &pointer, const namespacet &ns)
   return same_object(pointer, deallocated_symbol.symbol_expr());
 }
 
-exprt dynamic_object(const exprt &pointer)
-{
-  exprt dynamic_expr(ID_is_dynamic_object, bool_typet());
-  dynamic_expr.copy_to_operands(pointer);
-  return dynamic_expr;
-}
-
 exprt good_pointer(const exprt &pointer)
 {
   return unary_exprt(ID_good_pointer, pointer, bool_typet());

--- a/src/util/pointer_predicates.h
+++ b/src/util/pointer_predicates.h
@@ -12,7 +12,6 @@ Author: Daniel Kroening, kroening@kroening.com
 #ifndef CPROVER_UTIL_POINTER_PREDICATES_H
 #define CPROVER_UTIL_POINTER_PREDICATES_H
 
-#include "deprecate.h"
 #include "std_expr.h"
 
 #define SYMEX_DYNAMIC_PREFIX "symex_dynamic::"
@@ -23,8 +22,6 @@ exprt dead_object(const exprt &pointer, const namespacet &);
 exprt pointer_offset(const exprt &pointer);
 exprt pointer_object(const exprt &pointer);
 exprt object_size(const exprt &pointer);
-DEPRECATED(SINCE(2021, 5, 6, "Use is_dynamic_object_exprt instead"))
-exprt dynamic_object(const exprt &pointer);
 exprt good_pointer(const exprt &pointer);
 exprt good_pointer_def(const exprt &pointer, const namespacet &);
 exprt null_object(const exprt &pointer);


### PR DESCRIPTION
It has been marked deprecated for more than six months. Any uses outside
the code base should use is_dynamic_object_exprt.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
