### PR TITLE
Remove deprecated string abstraction methods

### DIFF
--- a/src/goto-programs/string_abstraction.h
+++ b/src/goto-programs/string_abstraction.h
@@ -14,7 +14,6 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <util/bitvector_types.h>
 #include <util/config.h>
-#include <util/deprecate.h>
 #include <util/namespace.h>
 #include <util/std_expr.h>
 
@@ -34,32 +33,26 @@ class message_handlert;
 class string_abstractiont
 {
 public:
-  // To be deprecated once the operator() methods have been removed, at which
-  // point a new constructor that only takes a message_handler should be
-  // introduced.
-  string_abstractiont(
-    symbol_tablet &_symbol_table,
-    message_handlert &_message_handler);
-
-  DEPRECATED(SINCE(2020, 12, 14, "Use apply(goto_modelt &)"))
-  void operator()(goto_programt &dest);
-  DEPRECATED(SINCE(2020, 12, 14, "Use apply(goto_modelt &)"))
-  void operator()(goto_functionst &dest);
-
   /// Apply string abstraction to \p goto_model. If any abstractions are to be
   /// applied, the affected goto_functions and any affected symbols will be
   /// modified.
-  void apply(goto_modelt &goto_model);
+  string_abstractiont(
+    goto_modelt &goto_model,
+    message_handlert &_message_handler);
+
+  void apply();
 
 protected:
   std::string sym_suffix;
-  symbol_tablet &symbol_table;
+  goto_modelt &goto_model;
   namespacet ns;
   unsigned temporary_counter;
   message_handlert &message_handler;
 
   typedef ::std::map< typet, typet > abstraction_types_mapt;
   abstraction_types_mapt abstraction_types_map;
+
+  void apply(goto_programt &dest);
 
   static bool has_string_macros(const exprt &expr);
 
@@ -189,12 +182,5 @@ protected:
 void string_abstraction(
   goto_modelt &,
   message_handlert &);
-
-DEPRECATED(
-  SINCE(2020, 12, 14, "Use string_abstraction(goto_model, message_handler)"))
-void string_abstraction(
-  symbol_tablet &,
-  message_handlert &,
-  goto_functionst &);
 
 #endif // CPROVER_GOTO_PROGRAMS_STRING_ABSTRACTION_H


### PR DESCRIPTION
Parts of the string_abstractiont API were deprecated in 2020 and can
safely be removed.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
