### PR TITLE
Visual Studio rejects pointer arithmetic and dereferencing of void*

### DIFF
--- a/regression/ansi-c/sizeof5/test.desc
+++ b/regression/ansi-c/sizeof5/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE gcc-only
 main.c
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Function_Arguments1/test.desc
+++ b/regression/cbmc-cpp/Function_Arguments1/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE gcc-only
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc/null6/main.c
+++ b/regression/cbmc/null6/main.c
@@ -1,4 +1,4 @@
-void *guard_malloc_counter = 0;
+char *guard_malloc_counter = 0;
 
 void *my_malloc(int size)
 {

--- a/regression/cbmc/ptr_arithmetic_on_null/test.desc
+++ b/regression/cbmc/ptr_arithmetic_on_null/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE gcc-only
 main.c
 
 ^\[main.assertion.1\] line .* assertion \(void \*\)0 != \(void \*\)0 \+ \(.*\)1: SUCCESS$

--- a/regression/cbmc/void_pointer1/test.desc
+++ b/regression/cbmc/void_pointer1/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE gcc-only
 main.c
 --pointer-check
 ^EXIT=0$

--- a/regression/cbmc/void_pointer2/test.desc
+++ b/regression/cbmc/void_pointer2/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE gcc-only
 main.c
 --pointer-check --no-simplify --unwind 3
 ^EXIT=0$

--- a/regression/cbmc/void_pointer3/test.desc
+++ b/regression/cbmc/void_pointer3/test.desc
@@ -1,4 +1,4 @@
-CORE broken-smt-backend
+CORE broken-smt-backend gcc-only
 main.c
 
 ^EXIT=0$

--- a/regression/cbmc/void_pointer5/test.desc
+++ b/regression/cbmc/void_pointer5/test.desc
@@ -1,4 +1,4 @@
-CORE broken-smt-backend
+CORE broken-smt-backend gcc-only
 main.c
 
 ^EXIT=10$

--- a/regression/cbmc/void_pointer6/test.desc
+++ b/regression/cbmc/void_pointer6/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE gcc-only
 main.c
 --pointer-check
 ^EXIT=10$

--- a/regression/cbmc/void_pointer7/test.desc
+++ b/regression/cbmc/void_pointer7/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE gcc-only
 main.c
 --pointer-check
 ^EXIT=0$

--- a/regression/contracts/assigns_enforce_conditional_void_target/test.desc
+++ b/regression/contracts/assigns_enforce_conditional_void_target/test.desc
@@ -1,7 +1,7 @@
 CORE
 main.c
 --enforce-contract foo
-^.* error: void-typed expressions not allowed as assigns clause targets$
+^.* error: (void-typed expressions not allowed as assigns clause targets|dereferencing void pointer)$
 ^CONVERSION ERROR$
 ^EXIT=(1|64)$
 ^SIGNAL=0$

--- a/regression/contracts/assigns_enforce_conditional_void_target_list/test.desc
+++ b/regression/contracts/assigns_enforce_conditional_void_target_list/test.desc
@@ -1,7 +1,7 @@
 CORE
 main.c
 --enforce-contract foo
-^.* error: void-typed expressions not allowed as assigns clause targets$
+^.* error: (void-typed expressions not allowed as assigns clause targets|dereferencing void pointer)$
 ^CONVERSION ERROR$
 ^EXIT=(1|64)$
 ^SIGNAL=0$

--- a/regression/contracts/assigns_enforce_side_effects_1/test.desc
+++ b/regression/contracts/assigns_enforce_side_effects_1/test.desc
@@ -1,9 +1,8 @@
 CORE
 main.c
 --enforce-contract foo
-^.*error: void-typed expressions not allowed as assigns clause targets$
-^.*error: side-effects not allowed in assigns clause targets$
-^.*error: ternary expressions not allowed in assigns clause targets$
+activate-multi-line-match
+.*error: (dereferencing void pointer|void-typed expressions not allowed as assigns clause targets\n.*\n.*error: side-effects not allowed in assigns clause targets\n.*\n.*error: ternary expressions not allowed in assigns clause targets\n)
 ^CONVERSION ERROR$
 ^EXIT=(1|64)$
 ^SIGNAL=0$

--- a/regression/goto-cl/void-pointer/main.c
+++ b/regression/goto-cl/void-pointer/main.c
@@ -1,0 +1,15 @@
+void *malloc(__CPROVER_size_t);
+int printf(const char *, ...);
+
+int main(int argc, char *argv[])
+{
+  void *p = malloc(2);
+  printf("%p\n", p);
+#ifdef VOID1
+  (void)*p;
+#else
+  void *q = &p[1];
+  printf("%p\n", q);
+#endif
+  return 0;
+}

--- a/regression/goto-cl/void-pointer/ptr-arithmetic.desc
+++ b/regression/goto-cl/void-pointer/ptr-arithmetic.desc
@@ -1,0 +1,9 @@
+CORE
+main.c
+
+error: pointer arithmetic with unknown object size
+^CONVERSION ERROR$
+^EXIT=(64|1)$
+^SIGNAL=0$
+--
+Invariant check failed

--- a/regression/goto-cl/void-pointer/test.desc
+++ b/regression/goto-cl/void-pointer/test.desc
@@ -1,0 +1,9 @@
+CORE
+main.c
+-DVOID1
+error: dereferencing void pointer
+^CONVERSION ERROR$
+^EXIT=(64|1)$
+^SIGNAL=0$
+--
+Invariant check failed

--- a/src/ansi-c/c_typecheck_expr.cpp
+++ b/src/ansi-c/c_typecheck_expr.cpp
@@ -1784,6 +1784,15 @@ void c_typecheck_baset::typecheck_expr_dereference(exprt &expr)
   else if(op_type.id()==ID_pointer)
   {
     expr.type() = to_pointer_type(op_type).base_type();
+
+    if(
+      expr.type().id() == ID_empty &&
+      config.ansi_c.mode == configt::ansi_ct::flavourt::VISUAL_STUDIO)
+    {
+      error().source_location = expr.source_location();
+      error() << "dereferencing void pointer" << eom;
+      throw 0;
+    }
   }
   else
   {
@@ -3713,6 +3722,14 @@ void c_typecheck_baset::typecheck_arithmetic_pointer(const exprt &expr)
   else if(
     base_type.id() == ID_union_tag &&
     follow_tag(to_union_tag_type(base_type)).is_incomplete())
+  {
+    error().source_location = expr.source_location();
+    error() << "pointer arithmetic with unknown object size" << eom;
+    throw 0;
+  }
+  else if(
+    base_type.id() == ID_empty &&
+    config.ansi_c.mode == configt::ansi_ct::flavourt::VISUAL_STUDIO)
   {
     error().source_location = expr.source_location();
     error() << "pointer arithmetic with unknown object size" << eom;


### PR DESCRIPTION
Pointer arithmetic using void* is a (document) GCC extension.
Dereferencing void* pointers is permitted by GCC when the value is
unused. Visual Studio rejects both.

Fixes: #5275

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x]  My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
