### PR TITLE
Conversion of bitwise `exprt`s to SMT terms in new SMT backend

### DIFF
--- a/src/solvers/smt2_incremental/convert_expr_to_smt.cpp
+++ b/src/solvers/smt2_incremental/convert_expr_to_smt.cpp
@@ -174,9 +174,22 @@ static smt_termt convert_expr_to_smt(const bitand_exprt &bitwise_and_expr)
 
 static smt_termt convert_expr_to_smt(const bitor_exprt &bitwise_or_expr)
 {
-  UNIMPLEMENTED_FEATURE(
-    "Generation of SMT formula for bitwise or expression: " +
-    bitwise_or_expr.pretty());
+  if(std::all_of(
+       bitwise_or_expr.operands().cbegin(),
+       bitwise_or_expr.operands().cend(),
+       [](exprt operand) {
+         return can_cast_type<integer_bitvector_typet>(operand.type());
+       }))
+  {
+    return convert_multiary_operator_to_terms(
+      bitwise_or_expr, smt_bit_vector_theoryt::make_or);
+  }
+  else
+  {
+    UNIMPLEMENTED_FEATURE(
+      "Generation of SMT formula for bitwise or expression: " +
+      bitwise_or_expr.pretty());
+  }
 }
 
 static smt_termt convert_expr_to_smt(const bitxor_exprt &bitwise_xor)

--- a/src/solvers/smt2_incremental/convert_expr_to_smt.cpp
+++ b/src/solvers/smt2_incremental/convert_expr_to_smt.cpp
@@ -49,6 +49,19 @@ static smt_termt convert_multiary_operator_to_terms(
     factory);
 }
 
+/// \brief Ensures that all operands of the argument expression have related
+///   types.
+/// \param expr: The expression of which the operands we evaluate for type
+///   equality.
+template <typename target_typet>
+static bool operands_are_of_type(const exprt &expr)
+{
+  return std::all_of(
+    expr.operands().cbegin(), expr.operands().cend(), [](const exprt &operand) {
+      return can_cast_type<target_typet>(operand.type());
+    });
+}
+
 static smt_sortt convert_type_to_smt_sort(const bool_typet &type)
 {
   return smt_bool_sortt{};
@@ -154,12 +167,7 @@ static smt_termt convert_expr_to_smt(const concatenation_exprt &concatenation)
 
 static smt_termt convert_expr_to_smt(const bitand_exprt &bitwise_and_expr)
 {
-  if(std::all_of(
-       bitwise_and_expr.operands().cbegin(),
-       bitwise_and_expr.operands().cend(),
-       [](exprt operand) {
-         return can_cast_type<integer_bitvector_typet>(operand.type());
-       }))
+  if(operands_are_of_type<integer_bitvector_typet>(bitwise_and_expr))
   {
     return convert_multiary_operator_to_terms(
       bitwise_and_expr, smt_bit_vector_theoryt::make_and);
@@ -174,12 +182,7 @@ static smt_termt convert_expr_to_smt(const bitand_exprt &bitwise_and_expr)
 
 static smt_termt convert_expr_to_smt(const bitor_exprt &bitwise_or_expr)
 {
-  if(std::all_of(
-       bitwise_or_expr.operands().cbegin(),
-       bitwise_or_expr.operands().cend(),
-       [](exprt operand) {
-         return can_cast_type<integer_bitvector_typet>(operand.type());
-       }))
+  if(operands_are_of_type<integer_bitvector_typet>(bitwise_or_expr))
   {
     return convert_multiary_operator_to_terms(
       bitwise_or_expr, smt_bit_vector_theoryt::make_or);
@@ -194,12 +197,7 @@ static smt_termt convert_expr_to_smt(const bitor_exprt &bitwise_or_expr)
 
 static smt_termt convert_expr_to_smt(const bitxor_exprt &bitwise_xor)
 {
-  if(std::all_of(
-       bitwise_xor.operands().cbegin(),
-       bitwise_xor.operands().cend(),
-       [](exprt operand) {
-         return can_cast_type<integer_bitvector_typet>(operand.type());
-       }))
+  if(operands_are_of_type<integer_bitvector_typet>(bitwise_xor))
   {
     return convert_multiary_operator_to_terms(
       bitwise_xor, smt_bit_vector_theoryt::make_xor);

--- a/src/solvers/smt2_incremental/convert_expr_to_smt.cpp
+++ b/src/solvers/smt2_incremental/convert_expr_to_smt.cpp
@@ -214,9 +214,19 @@ static smt_termt convert_expr_to_smt(const bitxor_exprt &bitwise_xor)
 
 static smt_termt convert_expr_to_smt(const bitnot_exprt &bitwise_not)
 {
-  UNIMPLEMENTED_FEATURE(
-    "Generation of SMT formula for bitwise not expression: " +
-    bitwise_not.pretty());
+  const bool operand_is_bitvector =
+    can_cast_type<integer_bitvector_typet>(bitwise_not.op().type());
+
+  if(operand_is_bitvector)
+  {
+    return smt_bit_vector_theoryt::make_not(
+      convert_expr_to_smt(bitwise_not.op()));
+  }
+  else
+  {
+    UNIMPLEMENTED_FEATURE(
+      "Generation of SMT formula for bitnot_exprt: " + bitwise_not.pretty());
+  }
 }
 
 static smt_termt convert_expr_to_smt(const unary_minus_exprt &unary_minus)

--- a/src/solvers/smt2_incremental/convert_expr_to_smt.cpp
+++ b/src/solvers/smt2_incremental/convert_expr_to_smt.cpp
@@ -547,6 +547,14 @@ static smt_termt convert_expr_to_smt(const index_exprt &index)
 
 static smt_termt convert_expr_to_smt(const shift_exprt &shift)
 {
+  // TODO: Dispatch into different types of shifting
+  if(const auto left_shift = expr_try_dynamic_cast<shl_exprt>(shift))
+  {
+    return smt_bit_vector_theoryt::shift_left(
+      convert_expr_to_smt(left_shift->op0()),
+      convert_expr_to_smt(left_shift->op1()));
+  }
+
   // TODO: split into functions for separate types of shift including rotate.
   UNIMPLEMENTED_FEATURE(
     "Generation of SMT formula for shift expression: " + shift.pretty());

--- a/src/solvers/smt2_incremental/convert_expr_to_smt.cpp
+++ b/src/solvers/smt2_incremental/convert_expr_to_smt.cpp
@@ -154,9 +154,22 @@ static smt_termt convert_expr_to_smt(const concatenation_exprt &concatenation)
 
 static smt_termt convert_expr_to_smt(const bitand_exprt &bitwise_and_expr)
 {
-  UNIMPLEMENTED_FEATURE(
-    "Generation of SMT formula for bitwise and expression: " +
-    bitwise_and_expr.pretty());
+  if(std::all_of(
+       bitwise_and_expr.operands().cbegin(),
+       bitwise_and_expr.operands().cend(),
+       [](exprt operand) {
+         return can_cast_type<integer_bitvector_typet>(operand.type());
+       }))
+  {
+    return convert_multiary_operator_to_terms(
+      bitwise_and_expr, smt_bit_vector_theoryt::make_and);
+  }
+  else
+  {
+    UNIMPLEMENTED_FEATURE(
+      "Generation of SMT formula for bitwise and expression: " +
+      bitwise_and_expr.pretty());
+  }
 }
 
 static smt_termt convert_expr_to_smt(const bitor_exprt &bitwise_or_expr)

--- a/src/solvers/smt2_incremental/convert_expr_to_smt.cpp
+++ b/src/solvers/smt2_incremental/convert_expr_to_smt.cpp
@@ -548,16 +548,31 @@ static smt_termt convert_expr_to_smt(const index_exprt &index)
 static smt_termt convert_expr_to_smt(const shift_exprt &shift)
 {
   // TODO: Dispatch into different types of shifting
+  const auto &first_operand = shift.op0();
+  const auto &second_operand = shift.op1();
+
   if(const auto left_shift = expr_try_dynamic_cast<shl_exprt>(shift))
   {
     return smt_bit_vector_theoryt::shift_left(
-      convert_expr_to_smt(left_shift->op0()),
-      convert_expr_to_smt(left_shift->op1()));
+      convert_expr_to_smt(first_operand), convert_expr_to_smt(second_operand));
   }
-
-  // TODO: split into functions for separate types of shift including rotate.
-  UNIMPLEMENTED_FEATURE(
-    "Generation of SMT formula for shift expression: " + shift.pretty());
+  else if(
+    const auto right_logical_shift = expr_try_dynamic_cast<lshr_exprt>(shift))
+  {
+    return smt_bit_vector_theoryt::logical_shift_right(
+      convert_expr_to_smt(first_operand), convert_expr_to_smt(second_operand));
+  }
+  else if(
+    const auto right_arith_shift = expr_try_dynamic_cast<ashr_exprt>(shift))
+  {
+    return smt_bit_vector_theoryt::arithmetic_shift_right(
+      convert_expr_to_smt(first_operand), convert_expr_to_smt(second_operand));
+  }
+  else
+  {
+    UNIMPLEMENTED_FEATURE(
+      "Generation of SMT formula for shift expression: " + shift.pretty());
+  }
 }
 
 static smt_termt convert_expr_to_smt(const with_exprt &with)

--- a/src/solvers/smt2_incremental/convert_expr_to_smt.cpp
+++ b/src/solvers/smt2_incremental/convert_expr_to_smt.cpp
@@ -194,9 +194,22 @@ static smt_termt convert_expr_to_smt(const bitor_exprt &bitwise_or_expr)
 
 static smt_termt convert_expr_to_smt(const bitxor_exprt &bitwise_xor)
 {
-  UNIMPLEMENTED_FEATURE(
-    "Generation of SMT formula for bitwise xor expression: " +
-    bitwise_xor.pretty());
+  if(std::all_of(
+       bitwise_xor.operands().cbegin(),
+       bitwise_xor.operands().cend(),
+       [](exprt operand) {
+         return can_cast_type<integer_bitvector_typet>(operand.type());
+       }))
+  {
+    return convert_multiary_operator_to_terms(
+      bitwise_xor, smt_bit_vector_theoryt::make_xor);
+  }
+  else
+  {
+    UNIMPLEMENTED_FEATURE(
+      "Generation of SMT formula for bitwise xor expression: " +
+      bitwise_xor.pretty());
+  }
 }
 
 static smt_termt convert_expr_to_smt(const bitnot_exprt &bitwise_not)

--- a/src/util/bitvector_expr.h
+++ b/src/util/bitvector_expr.h
@@ -349,6 +349,12 @@ public:
   }
 };
 
+template <>
+inline bool can_cast_expr<ashr_exprt>(const exprt &base)
+{
+  return base.id() == ID_ashr;
+}
+
 /// \brief Logical right shift
 class lshr_exprt : public shift_exprt
 {
@@ -363,6 +369,12 @@ public:
   {
   }
 };
+
+template <>
+inline bool can_cast_expr<lshr_exprt>(const exprt &base)
+{
+  return base.id() == ID_lshr;
+}
 
 /// \brief Extracts a single bit of a bit-vector operand
 class extractbit_exprt : public binary_predicate_exprt

--- a/src/util/bitvector_expr.h
+++ b/src/util/bitvector_expr.h
@@ -305,6 +305,12 @@ public:
   }
 };
 
+template <>
+inline bool can_cast_expr<shl_exprt>(const exprt &base)
+{
+  return base.id() == ID_shl;
+}
+
 /// \brief Cast an exprt to a \ref shl_exprt
 ///
 /// \a expr must be known to be \ref shl_exprt.

--- a/unit/solvers/smt2_incremental/convert_expr_to_smt.cpp
+++ b/unit/solvers/smt2_incremental/convert_expr_to_smt.cpp
@@ -637,3 +637,38 @@ SCENARIO(
     }
   }
 }
+
+SCENARIO(
+  "Bitwise \"NOT\" expressions are converted to SMT terms (1's complement)",
+  "[core][smt2_incremental]")
+{
+  GIVEN("An integer bitvector")
+  {
+    const auto one_bvint = from_integer(1, signedbv_typet{8});
+
+    WHEN("A bitnot_exprt is constructed and converted to an SMT term")
+    {
+      const auto constructed_term =
+        convert_expr_to_smt(bitnot_exprt{one_bvint});
+      THEN("it should be converted to bvnot smt term")
+      {
+        const smt_termt smt_term_one = smt_bit_vector_constant_termt{1, 8};
+        const auto expected_term =
+          smt_bit_vector_theoryt::make_not(smt_term_one);
+
+        REQUIRE(constructed_term == expected_term);
+      }
+    }
+
+    WHEN("A bitnot_exprt is constructed with a false expression and converted")
+    {
+      const cbmc_invariants_should_throwt invariants_throw;
+      THEN(
+        "convert_expr_to_smt should throw an exception and not allow "
+        "construction")
+      {
+        REQUIRE_THROWS(convert_expr_to_smt(bitnot_exprt{false_exprt{}}));
+      }
+    }
+  }
+}

--- a/unit/solvers/smt2_incremental/convert_expr_to_smt.cpp
+++ b/unit/solvers/smt2_incremental/convert_expr_to_smt.cpp
@@ -714,3 +714,103 @@ SCENARIO(
     }
   }
 }
+
+SCENARIO(
+  "Logical Right-shift expressions are converted to SMT terms",
+  "[core][smt2_incremental]")
+{
+  GIVEN("Two integer bitvectors, one for the value and one for the places")
+  {
+    const auto to_be_shifted = from_integer(1, signedbv_typet{8});
+    const auto places = from_integer(2, signedbv_typet{8});
+
+    WHEN("We construct a lshr_exprt and convert it to an SMT term")
+    {
+      const auto shift_expr = lshr_exprt{to_be_shifted, places};
+      const auto constructed_term = convert_expr_to_smt(shift_expr);
+
+      THEN("We should get an logical shift right SMT term")
+      {
+        const smt_termt smt_term_value = smt_bit_vector_constant_termt{1, 8};
+        const smt_termt smt_term_places = smt_bit_vector_constant_termt{2, 8};
+        const auto expected_term = smt_bit_vector_theoryt::logical_shift_right(
+          smt_term_value, smt_term_places);
+        REQUIRE(constructed_term == expected_term);
+      }
+    }
+
+    WHEN(
+      "We construct a malformed lshr_exprt and attempt to convert it to an SMT"
+      " term")
+    {
+      const cbmc_invariants_should_throwt invariants_throw;
+      THEN(
+        "convert_expr_to_smt should throw an exception because of validation "
+        "failure")
+      {
+        REQUIRE_THROWS(
+          convert_expr_to_smt(lshr_exprt{to_be_shifted, false_exprt{}}));
+      }
+    }
+  }
+}
+
+SCENARIO(
+  "Arithmetic Right-shift expressions are converted to SMT terms",
+  "[core][smt2_incremental]")
+{
+  GIVEN("Two integer bitvectors, one for the value and one for the places")
+  {
+    const auto to_be_shifted = from_integer(1, signedbv_typet{8});
+    const auto places = from_integer(2, signedbv_typet{8});
+
+    WHEN("We construct a ashr_exprt and convert it to an SMT term")
+    {
+      const auto shift_expr = ashr_exprt{to_be_shifted, places};
+      const auto constructed_term = convert_expr_to_smt(shift_expr);
+
+      THEN("We should get an arithmetic shift-right SMT term")
+      {
+        const smt_termt smt_term_value = smt_bit_vector_constant_termt{1, 8};
+        const smt_termt smt_term_places = smt_bit_vector_constant_termt{2, 8};
+        const auto expected_term =
+          smt_bit_vector_theoryt::arithmetic_shift_right(
+            smt_term_value, smt_term_places);
+        REQUIRE(constructed_term == expected_term);
+      }
+    }
+
+    WHEN("We construct an ashr_exprt and with a shift of 0 places")
+    {
+      const auto zero_places = from_integer(0, signedbv_typet{8});
+      const auto shift_expr = ashr_exprt{to_be_shifted, zero_places};
+      const auto constructed_term = convert_expr_to_smt(shift_expr);
+
+      THEN(
+        "When we convert it, we should be getting an arithmetic shift-right "
+        "term")
+      {
+        const smt_termt smt_term_value = smt_bit_vector_constant_termt{1, 8};
+        const smt_termt smt_term_places = smt_bit_vector_constant_termt{0, 8};
+        const auto expected_term =
+          smt_bit_vector_theoryt::arithmetic_shift_right(
+            smt_term_value, smt_term_places);
+        REQUIRE(constructed_term == expected_term);
+      }
+    }
+
+    WHEN(
+      "We construct a malformed ashr_exprt and attempt to convert it to an SMT "
+      "term")
+    {
+      const cbmc_invariants_should_throwt invariants_throw;
+      THEN(
+        "convert_expr_to_smt should throw an exception because of validation "
+        "failure")
+      {
+        REQUIRE_THROWS(
+          convert_expr_to_smt(ashr_exprt{to_be_shifted, false_exprt{}}));
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR adds support for the conversion of bitwise `exprt`s to the various SMT terms that they correspond to.

The following operators have been implemented:

* Bitwise or
* Bitwise and
* Bitwise not (1's complement)
* Logical left shift
* Logical Right shift
* Arithmetic Right shift

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
