### PR TITLE
CBMC/JBMC: do not attempt to parse unused option pretty-names

### DIFF
--- a/doc/man/cbmc.1
+++ b/doc/man/cbmc.1
@@ -149,8 +149,6 @@ Show the verification conditions
 Remove assignments unrelated to property
 .IP --no-unwinding-assertions
 Do not generate unwinding assertions
-.IP --no-pretty-names
-Do not simplify identifiers
 .SS "BACKEND OPTIONS (cbmc)"
 .IP --dimacs
 Generate CNF in DIMACS format for use by external SAT solvers

--- a/jbmc/src/jbmc/jbmc_parse_options.cpp
+++ b/jbmc/src/jbmc/jbmc_parse_options.cpp
@@ -95,7 +95,6 @@ void jbmc_parse_optionst::set_default_options(optionst &options)
   options.set_option("assumptions", true);
   options.set_option("built-in-assertions", true);
   options.set_option("lazy-methods", true);
-  options.set_option("pretty-names", true);
   options.set_option("propagation", true);
   options.set_option("refine-strings", true);
   options.set_option("simple-slice", true);
@@ -288,10 +287,6 @@ void jbmc_parse_optionst::get_command_line_options(optionst &options)
       "cannot use --max-nondet-string-length with --no-refine-strings",
       "--max-nondet-string-length");
   }
-
-  options.set_option(
-    "pretty-names",
-    !cmdline.isset("no-pretty-names"));
 
   if(cmdline.isset("graphml-witness"))
   {

--- a/src/cbmc/cbmc_parse_options.cpp
+++ b/src/cbmc/cbmc_parse_options.cpp
@@ -104,7 +104,6 @@ void cbmc_parse_optionst::set_default_options(optionst &options)
 {
   // Default true
   options.set_option("built-in-assertions", true);
-  options.set_option("pretty-names", true);
   options.set_option("propagation", true);
   options.set_option("simple-slice", true);
   options.set_option("simplify", true);
@@ -340,9 +339,6 @@ void cbmc_parse_optionst::get_command_line_options(optionst &options)
       exit(CPROVER_EXIT_USAGE_ERROR);
     }
   }
-
-  if(cmdline.isset("no-pretty-names"))
-    options.set_option("pretty-names", false);
 
   if(cmdline.isset("graphml-witness"))
   {

--- a/src/goto-checker/bmc_util.h
+++ b/src/goto-checker/bmc_util.h
@@ -180,7 +180,6 @@ void run_property_decider(
   "(slice-formula)" \
   "(unwinding-assertions)" \
   "(no-unwinding-assertions)" \
-  "(no-pretty-names)" \
   "(no-self-loops-to-assumptions)" \
   "(partial-loops)" \
   "(paths):" \
@@ -238,7 +237,6 @@ void run_property_decider(
   " --partial-loops              permit paths with partial loops\n" \
   " --no-self-loops-to-assumptions\n" \
   "                              do not simplify while(1){} to assume(0)\n" \
-  " --no-pretty-names            do not simplify identifiers\n" \
   " --symex-complexity-limit N   how complex (N) a path can become before\n" \
   "                              symex abandons it. Currently uses guard\n" \
   "                              size to calculate complexity. \n" \


### PR DESCRIPTION
It is not clear when this command-line option last had any effect.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
