### PR TITLE
Java front-end: fix vector index type in populate_live_range_holes

### DIFF
--- a/jbmc/src/java_bytecode/java_local_variable_table.cpp
+++ b/jbmc/src/java_bytecode/java_local_variable_table.cpp
@@ -513,18 +513,18 @@ static void populate_live_range_holes(
     merge_vars.begin(), merge_vars.end());
   std::sort(sorted_by_startpc.begin(), sorted_by_startpc.end(), lt_startpc);
 
+  PRECONDITION(!sorted_by_startpc.empty());
   maybe_add_hole(
     merge_into,
     expanded_live_range_start,
     sorted_by_startpc[0]->var.start_pc);
-  for(java_bytecode_convert_methodt::method_offsett idx = 0;
-      idx < sorted_by_startpc.size() - 1;
-      ++idx)
+  for(auto it = std::next(sorted_by_startpc.begin());
+      it != sorted_by_startpc.end();
+      ++it)
   {
+    auto &local_var = (*std::prev(it))->var;
     maybe_add_hole(
-      merge_into,
-      sorted_by_startpc[idx]->var.start_pc+sorted_by_startpc[idx]->var.length,
-      sorted_by_startpc[idx+1]->var.start_pc);
+      merge_into, local_var.start_pc + local_var.length, (*it)->var.start_pc);
   }
 }
 


### PR DESCRIPTION
CodeQL rightly complained that there is comparison using a more narrow
type on the left-hand side of a less-than in a loop condition, which may
give rise to a non-terminating loop in case of integer overflow.

While at it, also add checks before unconditionally accessing the first
element.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
