### PR TITLE
MMIO rewriting must maintain type consistency

### DIFF
--- a/regression/cbmc/mm_io1/main.c
+++ b/regression/cbmc/mm_io1/main.c
@@ -16,6 +16,7 @@ int main()
 {
   long i=0x10;
   char *p=(char *)i;
+  unsigned char u = *(unsigned char *)i;
   char some_var=100;
   
   char z;

--- a/src/goto-programs/mm_io.cpp
+++ b/src/goto-programs/mm_io.cpp
@@ -62,7 +62,10 @@ void mm_io(
           source_locationt source_location = it->source_location();
           const code_typet &ct=to_code_type(mm_io_r.type());
 
-          if_exprt if_expr(integer_address(d.pointer()), mm_io_r_value, d);
+          if_exprt if_expr(
+            integer_address(d.pointer()),
+            typecast_exprt::conditional_cast(mm_io_r_value, d.type()),
+            d);
           replace_expr(d, if_expr, a_rhs);
 
           const typet &pt=ct.parameters()[0].type();


### PR DESCRIPTION
MMIO read functions may (have to) return values of varying types.
Expression replacement must maintain, via type casts, consistency with
whatever the type of the original expression was.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
