### PR TITLE
Remove ID_C_bounds_check special-case in goto_check_ct

### DIFF
--- a/src/analyses/goto_check_c.cpp
+++ b/src/analyses/goto_check_c.cpp
@@ -1505,13 +1505,6 @@ void goto_check_ct::bounds_check(const exprt &expr, const guardt &guard)
   if(!enable_bounds_check)
     return;
 
-  if(
-    expr.find(ID_C_bounds_check).is_not_nil() &&
-    !expr.get_bool(ID_C_bounds_check))
-  {
-    return;
-  }
-
   if(expr.id() == ID_index)
     bounds_check_index(to_index_expr(expr), guard);
   else if(

--- a/src/ansi-c/ansi_c_entry_point.cpp
+++ b/src/ansi-c/ansi_c_entry_point.cpp
@@ -410,10 +410,10 @@ bool generate_ansi_c_start_function(
         index_exprt index_expr(
           argv_symbol.symbol_expr(), argc_symbol.symbol_expr());
 
-        // disable bounds check on that one
-        index_expr.set(ID_C_bounds_check, false);
-
         init_code.add(code_frontend_assignt(index_expr, null));
+        // disable bounds check on that one
+        init_code.statements().back().add_source_location().add_pragma(
+          "disable:bounds-check");
       }
 
       if(parameters.size()==3)
@@ -427,12 +427,13 @@ bool generate_ansi_c_start_function(
 
         index_exprt index_expr(
           envp_symbol.symbol_expr(), envp_size_symbol.symbol_expr());
-        // disable bounds check on that one
-        index_expr.set(ID_C_bounds_check, false);
 
         equal_exprt is_null(std::move(index_expr), std::move(null));
 
         init_code.add(code_assumet(is_null));
+        // disable bounds check on that one
+        init_code.statements().back().add_source_location().add_pragma(
+          "disable:bounds-check");
       }
 
       {
@@ -452,9 +453,8 @@ bool generate_ansi_c_start_function(
         {
           index_exprt index_expr(
             argv_symbol.symbol_expr(), from_integer(0, c_index_type()));
-
           // disable bounds check on that one
-          index_expr.set(ID_C_bounds_check, false);
+          index_expr.add_source_location().add_pragma("disable:bounds-check");
 
           const pointer_typet &pointer_type =
             to_pointer_type(parameters[1].type());

--- a/src/goto-programs/string_abstraction.cpp
+++ b/src/goto-programs/string_abstraction.cpp
@@ -568,9 +568,6 @@ void string_abstractiont::abstract_function_call(
         "argument array type differs from formal parameter pointer type");
 
       index_exprt idx(str_args.back(), from_integer(0, c_index_type()));
-      // disable bounds check on that one
-      idx.set(ID_C_bounds_check, false);
-
       str_args.back()=address_of_exprt(idx);
     }
 


### PR DESCRIPTION
This is never used in the Java front-end, and the C front-end can safely
use the pragma-based approach that is more general.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
