### PR TITLE
Remove Throwing-NULL check from goto_check_ct

### DIFF
--- a/src/analyses/goto_check_c.cpp
+++ b/src/analyses/goto_check_c.cpp
@@ -2170,27 +2170,6 @@ void goto_check_ct::goto_check(
     }
     else if(i.is_throw())
     {
-      if(
-        i.get_code().get_statement() == ID_expression &&
-        i.get_code().operands().size() == 1 &&
-        i.get_code().op0().operands().size() == 1)
-      {
-        // must not throw NULL
-
-        exprt pointer = to_unary_expr(i.get_code().op0()).op();
-
-        const notequal_exprt not_eq_null(
-          pointer, null_pointer_exprt(to_pointer_type(pointer.type())));
-
-        add_guarded_property(
-          not_eq_null,
-          "throwing null",
-          "pointer dereference",
-          i.source_location(),
-          pointer,
-          identity);
-      }
-
       // this has no successor
       assertions.clear();
     }


### PR DESCRIPTION
This check was introduced in d2713b200, with no particular reason that
it should be enabled unconditionally. The test included in that commit
has --pointer-check set, suggesting that this always was the desired
behaviour. It was, however, only intended for the Java front-end: for
the C language, "throw" is not relevant, and C++ permits throwing NULL.
Therefore, remove this check from goto_check_ct.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
