### PR TITLE
goto_check_ct: Transforming assertions and assumptions is language-agnostic

### DIFF
--- a/jbmc/src/janalyzer/janalyzer_parse_options.cpp
+++ b/jbmc/src/janalyzer/janalyzer_parse_options.cpp
@@ -703,13 +703,7 @@ void janalyzer_parse_optionst::process_goto_function(
 
   remove_returns(function, function_is_stub);
 
-  // add generic checks
-  goto_check(
-    function.get_function_id(),
-    function.get_goto_function(),
-    ns,
-    options,
-    ui_message_handler);
+  transform_assertions_assumptions(options, function.get_goto_function().body);
 }
 
 bool janalyzer_parse_optionst::can_generate_function_body(const irep_idt &name)

--- a/jbmc/src/jbmc/jbmc_parse_options.cpp
+++ b/jbmc/src/jbmc/jbmc_parse_options.cpp
@@ -11,26 +11,12 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "jbmc_parse_options.h"
 
-#include <cstdlib> // exit()
-#include <iostream>
-#include <memory>
-
 #include <util/config.h>
 #include <util/exit_codes.h>
 #include <util/invariant.h>
 #include <util/make_unique.h>
 #include <util/version.h>
 #include <util/xml.h>
-
-#include <langapi/language.h>
-
-#include <ansi-c/ansi_c_language.h>
-
-#include <goto-checker/all_properties_verifier.h>
-#include <goto-checker/all_properties_verifier_with_fault_localization.h>
-#include <goto-checker/all_properties_verifier_with_trace_storage.h>
-#include <goto-checker/stop_on_fail_verifier.h>
-#include <goto-checker/stop_on_fail_verifier_with_fault_localization.h>
 
 #include <goto-programs/adjust_float_expressions.h>
 #include <goto-programs/goto_convert_functions.h>
@@ -45,18 +31,17 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <goto-programs/show_properties.h>
 #include <goto-programs/show_symbol_table.h>
 
+#include <analyses/goto_check.h>
+#include <ansi-c/ansi_c_language.h>
+#include <goto-checker/all_properties_verifier.h>
+#include <goto-checker/all_properties_verifier_with_fault_localization.h>
+#include <goto-checker/all_properties_verifier_with_trace_storage.h>
+#include <goto-checker/stop_on_fail_verifier.h>
+#include <goto-checker/stop_on_fail_verifier_with_fault_localization.h>
 #include <goto-instrument/full_slicer.h>
 #include <goto-instrument/nondet_static.h>
 #include <goto-instrument/reachability_slicer.h>
-
 #include <goto-symex/path_storage.h>
-
-#include <linking/static_lifetime_init.h>
-
-#include <pointer-analysis/add_failed_symbols.h>
-
-#include <langapi/mode.h>
-
 #include <java_bytecode/convert_java_nondet.h>
 #include <java_bytecode/java_bytecode_language.h>
 #include <java_bytecode/java_multi_path_symex_checker.h>
@@ -69,6 +54,14 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <java_bytecode/remove_java_new.h>
 #include <java_bytecode/replace_java_nondet.h>
 #include <java_bytecode/simple_method_stubbing.h>
+#include <langapi/language.h>
+#include <langapi/mode.h>
+#include <linking/static_lifetime_init.h>
+#include <pointer-analysis/add_failed_symbols.h>
+
+#include <cstdlib> // exit()
+#include <iostream>
+#include <memory>
 
 jbmc_parse_optionst::jbmc_parse_optionst(int argc, const char **argv)
   : parse_options_baset(
@@ -806,13 +799,7 @@ void jbmc_parse_optionst::process_goto_function(
       ui_message_handler);
   }
 
-  // add generic checks
-  goto_check_java(
-    function.get_function_id(),
-    function.get_goto_function(),
-    ns,
-    options,
-    ui_message_handler);
+  transform_assertions_assumptions(options, function.get_goto_function().body);
 
   // Replace Java new side effects
   remove_java_new(

--- a/jbmc/src/jdiff/jdiff_parse_options.cpp
+++ b/jbmc/src/jdiff/jdiff_parse_options.cpp
@@ -11,9 +11,6 @@ Author: Peter Schrammel
 
 #include "jdiff_parse_options.h"
 
-#include <cstdlib> // exit()
-#include <iostream>
-
 #include <util/config.h>
 #include <util/exit_codes.h>
 #include <util/options.h>
@@ -31,15 +28,18 @@ Author: Peter Schrammel
 #include <goto-programs/set_properties.h>
 #include <goto-programs/show_properties.h>
 
+#include <analyses/goto_check.h>
+#include <goto-diff/change_impact.h>
+#include <goto-diff/unified_diff.h>
 #include <goto-instrument/cover.h>
-
 #include <java_bytecode/java_bytecode_language.h>
 #include <java_bytecode/remove_exceptions.h>
 #include <java_bytecode/remove_instanceof.h>
 
 #include "java_syntactic_diff.h"
-#include <goto-diff/change_impact.h>
-#include <goto-diff/unified_diff.h>
+
+#include <cstdlib> // exit()
+#include <iostream>
 
 jdiff_parse_optionst::jdiff_parse_optionst(int argc, const char **argv)
   : parse_options_baset(
@@ -190,9 +190,7 @@ bool jdiff_parse_optionst::process_goto_program(
   // remove returns
   remove_returns(goto_model);
 
-  // add generic checks
-  log.status() << "Generic Property Instrumentation" << messaget::eom;
-  goto_check_java(options, goto_model, ui_message_handler);
+  transform_assertions_assumptions(options, goto_model);
 
   // checks don't know about adjusted float expressions
   adjust_float_expressions(goto_model);

--- a/src/analyses/goto_check.cpp
+++ b/src/analyses/goto_check.cpp
@@ -11,9 +11,13 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "goto_check.h"
 
-#include "goto_check_c.h"
-
+#include <util/options.h>
 #include <util/symbol.h>
+
+#include <goto-programs/goto_model.h>
+#include <goto-programs/remove_skip.h>
+
+#include "goto_check_c.h"
 
 void goto_check(
   const irep_idt &function_identifier,
@@ -46,4 +50,85 @@ void goto_check(
   message_handlert &message_handler)
 {
   goto_check_c(options, goto_model, message_handler);
+}
+
+static void transform_assertions_assumptions(
+  goto_programt &goto_program,
+  bool enable_assertions,
+  bool enable_built_in_assertions,
+  bool enable_assumptions)
+{
+  bool did_something = false;
+
+  for(auto &instruction : goto_program.instructions)
+  {
+    if(instruction.is_assert())
+    {
+      bool is_user_provided =
+        instruction.source_location().get_bool("user-provided");
+
+      if(
+        (is_user_provided && !enable_assertions &&
+         instruction.source_location().get_property_class() != "error label") ||
+        (!is_user_provided && !enable_built_in_assertions))
+      {
+        instruction.turn_into_skip();
+        did_something = true;
+      }
+    }
+    else if(instruction.is_assume())
+    {
+      if(!enable_assumptions)
+      {
+        instruction.turn_into_skip();
+        did_something = true;
+      }
+    }
+  }
+
+  if(did_something)
+    remove_skip(goto_program);
+}
+
+void transform_assertions_assumptions(
+  const optionst &options,
+  goto_modelt &goto_model)
+{
+  const bool enable_assertions = options.get_bool_option("assertions");
+  const bool enable_built_in_assertions =
+    options.get_bool_option("built-in-assertions");
+  const bool enable_assumptions = options.get_bool_option("assumptions");
+
+  // check whether there could possibly be anything to do
+  if(enable_assertions && enable_built_in_assertions && enable_assumptions)
+    return;
+
+  for(auto &entry : goto_model.goto_functions.function_map)
+  {
+    transform_assertions_assumptions(
+      entry.second.body,
+      enable_assertions,
+      enable_built_in_assertions,
+      enable_assumptions);
+  }
+}
+
+void transform_assertions_assumptions(
+  const optionst &options,
+  goto_programt &goto_program)
+{
+  const bool enable_assertions = options.get_bool_option("assertions");
+  const bool enable_built_in_assertions =
+    options.get_bool_option("built-in-assertions");
+  const bool enable_assumptions = options.get_bool_option("assumptions");
+
+  // check whether there could possibly be anything to do
+  if(enable_assertions && enable_built_in_assertions && enable_assumptions)
+    return;
+
+  transform_assertions_assumptions(
+    goto_program,
+    enable_assertions,
+    enable_built_in_assertions,
+    enable_assumptions);
 }

--- a/src/analyses/goto_check.h
+++ b/src/analyses/goto_check.h
@@ -34,4 +34,18 @@ void goto_check(
 
 void goto_check(const optionst &, goto_modelt &, message_handlert &);
 
+/// Handle the options "assertions", "built-in-assertions", "assumptions" to
+/// remove assertions and assumptions in \p goto_model when these are set to
+/// false in \p options.
+void transform_assertions_assumptions(
+  const optionst &options,
+  goto_modelt &goto_model);
+
+/// Handle the options "assertions", "built-in-assertions", "assumptions" to
+/// remove assertions and assumptions in \p goto_program when these are set to
+/// false in \p options.
+void transform_assertions_assumptions(
+  const optionst &options,
+  goto_programt &goto_program);
+
 #endif // CPROVER_ANALYSES_GOTO_CHECK_H

--- a/src/analyses/goto_check_c.cpp
+++ b/src/analyses/goto_check_c.cpp
@@ -74,10 +74,6 @@ public:
     enable_nan_check = _options.get_bool_option("nan-check");
     retain_trivial = _options.get_bool_option("retain-trivial-checks");
     enable_assert_to_assume = _options.get_bool_option("assert-to-assume");
-    enable_assertions = _options.get_bool_option("assertions");
-    enable_built_in_assertions =
-      _options.get_bool_option("built-in-assertions");
-    enable_assumptions = _options.get_bool_option("assumptions");
     error_labels = _options.get_list_option("error-label");
     enable_pointer_primitive_check =
       _options.get_bool_option("pointer-primitive-check");
@@ -274,9 +270,6 @@ protected:
   bool enable_nan_check;
   bool retain_trivial;
   bool enable_assert_to_assume;
-  bool enable_assertions;
-  bool enable_built_in_assertions;
-  bool enable_assumptions;
   bool enable_pointer_primitive_check;
 
   /// Maps a named-check name to the corresponding boolean flag.
@@ -2193,27 +2186,6 @@ void goto_check_ct::goto_check(
 
       // this has no successor
       assertions.clear();
-    }
-    else if(i.is_assert())
-    {
-      bool is_user_provided = i.source_location().get_bool("user-provided");
-
-      if(
-        (is_user_provided && !enable_assertions &&
-         i.source_location().get_property_class() != "error label") ||
-        (!is_user_provided && !enable_built_in_assertions))
-      {
-        i.turn_into_skip();
-        did_something = true;
-      }
-    }
-    else if(i.is_assume())
-    {
-      if(!enable_assumptions)
-      {
-        i.turn_into_skip();
-        did_something = true;
-      }
     }
     else if(i.is_dead())
     {

--- a/src/goto-instrument/goto_instrument_parse_options.cpp
+++ b/src/goto-instrument/goto_instrument_parse_options.cpp
@@ -1328,6 +1328,7 @@ void goto_instrument_parse_optionst::instrument_goto_program()
 
   // add generic checks, if needed
   goto_check(options, goto_model, ui_message_handler);
+  transform_assertions_assumptions(options, goto_model);
 
   // check for uninitalized local variables
   if(cmdline.isset("uninitialized-check"))

--- a/src/goto-programs/process_goto_program.cpp
+++ b/src/goto-programs/process_goto_program.cpp
@@ -74,6 +74,7 @@ bool process_goto_program(
   // add generic checks
   log.status() << "Generic Property Instrumentation" << messaget::eom;
   goto_check(options, goto_model, log.get_message_handler());
+  transform_assertions_assumptions(options, goto_model);
 
   // checks don't know about adjusted float expressions
   adjust_float_expressions(goto_model);


### PR DESCRIPTION
There is nothing source language specific about the handling of the
options "assertions", "assumptions", "built-in-assertions" (which are
controlled via command-line options "--no-assertions" and
"--no-assumptions").

This cleanup will enable complete removal of goto_check_java.

This is a necessary step for #6686, which in turn will will simplify #6684 and #6658.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
