### PR TITLE
Include source location in JSON/XML property output

### DIFF
--- a/doc/assets/xml_spec.xsd
+++ b/doc/assets/xml_spec.xsd
@@ -11,6 +11,7 @@
   <xs:complexType>
     <xs:attribute name="file" type="xs:string" use="optional"/>
     <xs:attribute name="line" type="xs:int" use="optional"/>
+    <xs:attribute name="column" type="xs:int" use="optional"/>
     <xs:attribute name="working-directory" type="xs:string"
                   use="optional"/>
     <xs:attribute name="function" type="xs:string" use="optional"/>
@@ -164,6 +165,7 @@
   <xs:element name="result">
     <xs:complexType>
       <xs:sequence>
+        <xs:element ref="location" minOccurs="0"/>
         <xs:element ref="goto_trace" minOccurs="0"/>
       </xs:sequence>
       <xs:attribute name="property" type="xs:string"/>

--- a/regression/cbmc/json-interface1/test.desc
+++ b/regression/cbmc/json-interface1/test.desc
@@ -5,8 +5,8 @@ activate-multi-line-match
 ^EXIT=10$
 ^SIGNAL=0$
 Not unwinding loop foo\.0 iteration 3 file main\.c line 5 function foo thread 0
-\{\n\s*"description": "assertion 0",\n\s*"property": "foo\.assertion\.(1|3)",\n\s*"status": "SUCCESS"\n\s*\}
-\{\n\s*"description": "assertion 0",\n\s*"property": "foo\.assertion\.(1|3)",\n\s*"status": "FAILURE",\n\s*"trace": \[
+\{\n\s*"description": "assertion 0",\n\s*"property": "foo\.assertion\.(1|3)",\n\s*"sourceLocation": \{\n\s*"file": "main.c",\n\s*"function": "foo",\n\s*"line": "(8|11)",\n\s*"workingDirectory": ".*json-interface1"\n\s*\},\n\s*"status": "SUCCESS"\n\s*\}
+\{\n\s*"description": "assertion 0",\n\s*"property": "foo\.assertion\.(1|3)",\n\s*"sourceLocation": \{\n\s*"file": "main.c",\n\s*"function": "foo",\n\s*"line": "(8|11)",\n\s*"workingDirectory": ".*json-interface1"\n\s*\},\n\s*"status": "FAILURE",\n\s*"trace": \[
 VERIFICATION FAILED
 --
 "property": "foo\.assertion\.2"

--- a/regression/cbmc/xml-interface1/test.desc
+++ b/regression/cbmc/xml-interface1/test.desc
@@ -4,7 +4,7 @@ CORE
 ^EXIT=10$
 ^SIGNAL=0$
 Not unwinding loop foo\.0 iteration 3 file main\.c line 5 function foo thread 0
-<result property="foo\.assertion\.3" status="SUCCESS"/>
+<result property="foo\.assertion\.3" status="SUCCESS">
 <result property="foo\.assertion\.1" status="FAILURE">
 <goto_trace>
 VERIFICATION FAILED

--- a/src/goto-checker/properties.cpp
+++ b/src/goto-checker/properties.cpp
@@ -14,8 +14,10 @@ Author: Daniel Kroening, Peter Schrammel
 #include <util/exit_codes.h>
 #include <util/invariant.h>
 #include <util/json.h>
+#include <util/json_irep.h>
 #include <util/json_stream.h>
 #include <util/xml.h>
+#include <util/xml_irep.h>
 
 #include <goto-programs/abstract_goto_model.h>
 
@@ -110,6 +112,7 @@ xmlt xml(const irep_idt &property_id, const property_infot &property_info)
   xmlt xml_result("result");
   xml_result.set_attribute("property", id2string(property_id));
   xml_result.set_attribute("status", as_string(property_info.status));
+  xml_result.new_element(xml(property_info.pc->source_location()));
   return xml_result;
 }
 
@@ -122,6 +125,7 @@ static void json(
   result["property"] = json_stringt(property_id);
   result["description"] = json_stringt(property_info.description);
   result["status"] = json_stringt(as_string(property_info.status));
+  result["sourceLocation"] = json(property_info.pc->source_location());
 }
 
 json_objectt


### PR DESCRIPTION
Unlike the plain-text variant, neither JSON nor XML included source
locations for each of the properties being reported upon by a
goto-checker.

Fixes: #6651

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
