### PR TITLE
De-duplicate initialize_goto_model's code [blocks: #5837]

### DIFF
--- a/jbmc/src/java_bytecode/lazy_goto_model.cpp
+++ b/jbmc/src/java_bytecode/lazy_goto_model.cpp
@@ -5,17 +5,17 @@
 
 #include "lazy_goto_model.h"
 
-#include "java_bytecode_language.h"
-
-#include <goto-programs/read_goto_binary.h>
-#include <goto-programs/rebuild_goto_start_function.h>
-
-#include <langapi/mode.h>
-
 #include <util/config.h>
 #include <util/exception_utils.h>
 #include <util/journalling_symbol_table.h>
 #include <util/options.h>
+
+#include <goto-programs/initialize_goto_model.h>
+#include <goto-programs/read_goto_binary.h>
+
+#include <langapi/mode.h>
+
+#include "java_bytecode_language.h"
 
 #ifdef _MSC_VER
 #  include <util/unicode.h>
@@ -164,93 +164,20 @@ void lazy_goto_modelt::initialize(
   }
   else
   {
-    for(const auto &filename : sources)
-    {
-#ifdef _MSC_VER
-      std::ifstream infile(widen(filename));
-#else
-      std::ifstream infile(filename);
-#endif
-
-      if(!infile)
-      {
-        throw system_exceptiont(
-          "failed to open input file '" + filename + '\'');
-      }
-
-      language_filet &lf = add_language_file(filename);
-      lf.language = get_language_from_filename(filename);
-
-      if(lf.language == nullptr)
-      {
-        throw invalid_source_file_exceptiont(
-          "failed to figure out type of file '" + filename + '\'');
-      }
-
-      languaget &language = *lf.language;
-      language.set_message_handler(message_handler);
-      language.set_language_options(options);
-
-      msg.status() << "Parsing " << filename << messaget::eom;
-
-      if(language.parse(infile, filename))
-      {
-        throw invalid_source_file_exceptiont("PARSING ERROR");
-      }
-
-      lf.get_modules();
-    }
-
-    msg.status() << "Converting" << messaget::eom;
-
-    if(language_files.typecheck(symbol_table))
-    {
-      throw invalid_source_file_exceptiont("CONVERSION ERROR");
-    }
+    initialize_from_source_files(
+      sources, options, language_files, symbol_table, message_handler);
   }
 
   if(read_objects_and_link(binaries, *goto_model, message_handler))
     throw incorrect_goto_program_exceptiont{"failed to read/link goto model"};
 
-  bool binaries_provided_start =
-    symbol_table.has_symbol(goto_functionst::entry_point());
-
-  bool entry_point_generation_failed = false;
-
-  if(binaries_provided_start && options.is_set("function"))
-  {
-    // The goto binaries provided already contain a __CPROVER_start
-    // function that may be tied to a different entry point `function`.
-    // Hence, we will rebuild the __CPROVER_start function.
-
-    // Get the language annotation of the existing __CPROVER_start function.
-    std::unique_ptr<languaget> language =
-      get_entry_point_language(symbol_table, options, message_handler);
-
-    // To create a new entry point we must first remove the old one
-    remove_existing_entry_point(symbol_table);
-
-    // Create the new entry-point
-    entry_point_generation_failed =
-      language->generate_support_functions(symbol_table);
-
-    // Remove the function from the goto functions so it is copied back in
-    // from the symbol table during goto_convert
-    if(!entry_point_generation_failed)
-      unload(goto_functionst::entry_point());
-  }
-  else if(!binaries_provided_start)
-  {
-    // Allow all language front-ends to try to provide the user-specified
-    // (--function) entry-point, or some language-specific default:
-    entry_point_generation_failed =
-      language_files.generate_support_functions(symbol_table);
-  }
-
-  if(entry_point_generation_failed)
-  {
-    throw invalid_source_file_exceptiont("SUPPORT FUNCTION GENERATION ERROR");
-  }
+  set_up_custom_entry_point(
+    language_files,
+    symbol_table,
+    [this](const irep_idt &id) { goto_functions.unload(id); },
+    options,
+    false,
+    message_handler);
 
   // stupid hack
   config.set_object_bits_from_symbol_table(symbol_table);

--- a/jbmc/src/java_bytecode/lazy_goto_model.h
+++ b/jbmc/src/java_bytecode/lazy_goto_model.h
@@ -183,11 +183,6 @@ public:
   /// Eagerly loads all functions from the symbol table.
   void load_all_functions() const;
 
-  void unload(const irep_idt &name) const
-  {
-    goto_functions.unload(name);
-  }
-
   language_filet &add_language_file(const std::string &filename)
   {
     return language_files.add_file(filename);

--- a/src/goto-programs/initialize_goto_model.h
+++ b/src/goto-programs/initialize_goto_model.h
@@ -14,6 +14,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "goto_model.h"
 
+class language_filest;
 class message_handlert;
 class optionst;
 
@@ -21,5 +22,38 @@ goto_modelt initialize_goto_model(
   const std::vector<std::string> &files,
   message_handlert &message_handler,
   const optionst &options);
+
+/// Populate \p symbol_table from \p sources by parsing and type checking via
+/// \p language_files. Throws exceptions if processing fails.
+/// \param sources: Collection of input source files. No operation is performed
+///   if the collection is empty.
+/// \param options: Configuration options.
+/// \param language_files: Language parsing and type checking facilities.
+/// \param [out] symbol_table: Symbol table to be populated.
+/// \param message_handler: Message handler.
+void initialize_from_source_files(
+  const std::list<std::string> &sources,
+  const optionst &options,
+  language_filest &language_files,
+  symbol_tablet &symbol_table,
+  message_handlert &message_handler);
+
+/// Process the "function" option in \p options to prepare a custom entry point
+/// to replace \c __CPROVER_start.
+/// \param language_files: Language parsing and type checking facilities.
+/// \param symbol_table: Symbol table for mode lookup and removal of an existing
+///   entry point.
+/// \param unload: Functor to remove an existing entry point.
+/// \param options: Configuration options.
+/// \param try_mode_lookup: Try to infer the entry point's mode from the symbol
+///   table.
+/// \param message_handler: Message handler.
+void set_up_custom_entry_point(
+  language_filest &language_files,
+  symbol_tablet &symbol_table,
+  const std::function<void(const irep_idt &)> &unload,
+  const optionst &options,
+  bool try_mode_lookup,
+  message_handlert &message_handler);
 
 #endif // CPROVER_GOTO_PROGRAMS_INITIALIZE_GOTO_MODEL_H

--- a/src/goto-programs/read_goto_binary.h
+++ b/src/goto-programs/read_goto_binary.h
@@ -27,7 +27,7 @@ bool is_goto_binary(const std::string &filename, message_handlert &);
 
 /// Reads object files and updates the config if any files were read.
 /// \param file_names: file names of goto binaries; if empty, just returns false
-/// \param dest: goto model to update
+/// \param [out] dest: GOTO model to update.
 /// \param message_handler: for diagnostics
 /// \return True on error, false otherwise
 bool read_objects_and_link(


### PR DESCRIPTION
lazy_goto_modelt used almost the same code. Refactor
initialize_goto_model's implementation to enable re-use from
lazy_goto_modelt.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
