### PR TITLE
Fix count-trailing-zeros lowering for value zero

### DIFF
--- a/regression/cbmc/__builtin_ctz-01/main.c
+++ b/regression/cbmc/__builtin_ctz-01/main.c
@@ -43,7 +43,9 @@ int main()
       [((unsigned)((u & -u) * 0x077CB531U)) >> 27] == __builtin_ctz(u));
 
   // a failing assertion should be generated as __builtin_ctz is undefined for 0
-  __builtin_ctz(0U);
+  int r = __builtin_ctz(0U);
+  __CPROVER_assert(
+    r == sizeof(unsigned) * 8, "count trailing zeros of 0 is bit width");
 
   return 0;
 }

--- a/regression/cbmc/__builtin_ctz-01/test.desc
+++ b/regression/cbmc/__builtin_ctz-01/test.desc
@@ -2,6 +2,7 @@ CORE
 main.c
 --bounds-check
 ^\[main.bit_count.\d+\] line 46 count trailing zeros is undefined for value zero in __builtin_ctz\(0u\): FAILURE$
+^\[main.assertion.2\] line 47 count trailing zeros of 0 is bit width: SUCCESS$
 ^\*\* 1 of \d+ failed
 ^VERIFICATION FAILED$
 ^EXIT=10$


### PR DESCRIPTION
The previous implementation would produce an off-by-one error in case of
an argument 0, which count_trailing_zeros is defined for (even when
__builtin_ctz is undefined in that case).

Fixes: #6702

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
