### PR TITLE
Do pretty printing for debug logging only when verbosity is high in incremental SMT2 decision procedure

### DIFF
--- a/src/solvers/smt2_incremental/smt2_incremental_decision_procedure.cpp
+++ b/src/solvers/smt2_incremental/smt2_incremental_decision_procedure.cpp
@@ -159,7 +159,9 @@ void smt2_incremental_decision_proceduret::ensure_handle_for_expr_defined(
 
 exprt smt2_incremental_decision_proceduret::handle(const exprt &expr)
 {
-  log.debug() << "`handle`  -\n  " << expr.pretty(2, 0) << messaget::eom;
+  log.conditional_output(log.debug(), [&](messaget::mstreamt &debug) {
+    debug << "`handle`  -\n  " << expr.pretty(2, 0) << messaget::eom;
+  });
   ensure_handle_for_expr_defined(expr);
   return expr;
 }
@@ -182,7 +184,9 @@ static optionalt<smt_termt> get_identifier(
 
 exprt smt2_incremental_decision_proceduret::get(const exprt &expr) const
 {
-  log.debug() << "`get` - \n  " + expr.pretty(2, 0) << messaget::eom;
+  log.conditional_output(log.debug(), [&](messaget::mstreamt &debug) {
+    debug << "`get` - \n  " + expr.pretty(2, 0) << messaget::eom;
+  });
   optionalt<smt_termt> descriptor =
     get_identifier(expr, expression_handle_identifiers, expression_identifiers);
   if(!descriptor)
@@ -251,8 +255,10 @@ smt2_incremental_decision_proceduret::get_number_of_solver_calls() const
 void smt2_incremental_decision_proceduret::set_to(const exprt &expr, bool value)
 {
   PRECONDITION(can_cast_type<bool_typet>(expr.type()));
-  log.debug() << "`set_to` (" << std::string{value ? "true" : "false"}
-              << ") -\n  " << expr.pretty(2, 0) << messaget::eom;
+  log.conditional_output(log.debug(), [&](messaget::mstreamt &debug) {
+    debug << "`set_to` (" << std::string{value ? "true" : "false"} << ") -\n  "
+          << expr.pretty(2, 0) << messaget::eom;
+  });
 
   define_dependent_functions(expr);
   auto converted_term = [&]() -> smt_termt {


### PR DESCRIPTION
This avoids wasting execution time in `irept::pretty` in the case where
verbosity is set to the default level. Before this performance fix, the
pretty printed output was generated and then discarded when the
verbosity was set to the default level.

Comparing this change against the `develop` branch, using a benchmark
has been shown to reduce the runtime from approximately 12 seconds to
approximately 3 seconds for that particular example.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
