### PR TITLE
Restore conditional bounds-checking of count_{leading,trailing}_zeros

### DIFF
--- a/src/ansi-c/goto_check_c.cpp
+++ b/src/ansi-c/goto_check_c.cpp
@@ -1508,7 +1508,10 @@ void goto_check_ct::bounds_check(const exprt &expr, const guardt &guard)
   if(expr.id() == ID_index)
     bounds_check_index(to_index_expr(expr), guard);
   else if(
-    expr.id() == ID_count_leading_zeros || expr.id() == ID_count_trailing_zeros)
+    (expr.id() == ID_count_leading_zeros &&
+     !to_count_leading_zeros_expr(expr).zero_permitted()) ||
+    (expr.id() == ID_count_trailing_zeros &&
+     !to_count_trailing_zeros_expr(expr).zero_permitted()))
   {
     bounds_check_bit_count(to_unary_expr(expr), guard);
   }


### PR DESCRIPTION
The cleanup of 4d4f9e7d182 (PR #6684) made bounds checking of these bit
count expressions unconditional. This did not affect any input coming
from the C front-end, but became apparent with the Rust front-end as
documented in model-checking/kani#886.

This commit restores conditional bounds checking, but now actually uses
the proper expression API rather than the low-level hack.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
