### PR TITLE
smt2: convert mathematical_function types and function_application

### DIFF
--- a/regression/cbmc/uninterpreted_function/uf1.desc
+++ b/regression/cbmc/uninterpreted_function/uf1.desc
@@ -1,4 +1,4 @@
-CORE broken-smt-backend
+CORE
 uf1.c
 
 ^EXIT=10$

--- a/regression/cbmc/uninterpreted_function/uf2.desc
+++ b/regression/cbmc/uninterpreted_function/uf2.desc
@@ -1,4 +1,4 @@
-CORE broken-smt-backend
+CORE
 uf2.c
 
 ^EXIT=0$


### PR DESCRIPTION
This change enables the SMT-LIB2 backend to convert 1) function symbols with
type mathematical function and 2) applications of such functions given as
function_application expression.

This enables a number of use cases, e.g., encodings of programs into
constrained Horn clause systems.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
