### PR TITLE
Handle array_{copy,replace,set} in dependence graph

### DIFF
--- a/regression/cbmc/Bool5/full-slice.desc
+++ b/regression/cbmc/Bool5/full-slice.desc
@@ -1,0 +1,9 @@
+CORE
+main.c
+--full-slice
+Generated 4 VCC\(s\), 0 remaining after simplification
+^VERIFICATION SUCCESSFUL$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring

--- a/src/analyses/goto_rw.h
+++ b/src/analyses/goto_rw.h
@@ -148,6 +148,12 @@ public:
     get_objects_rec(type);
   }
 
+  virtual void get_array_objects(
+    const irep_idt &,
+    goto_programt::const_targett,
+    get_modet,
+    const exprt &);
+
   void output(std::ostream &out) const;
 
 protected:
@@ -286,6 +292,18 @@ public:
     target = _target;
 
     rw_range_sett::get_objects_rec(type);
+  }
+
+  void get_array_objects(
+    const irep_idt &_function,
+    goto_programt::const_targett _target,
+    get_modet mode,
+    const exprt &pointer) override
+  {
+    function = _function;
+    target = _target;
+
+    rw_range_sett::get_array_objects(_function, _target, mode, pointer);
   }
 
 protected:

--- a/src/analyses/reaching_definitions.cpp
+++ b/src/analyses/reaching_definitions.cpp
@@ -126,6 +126,9 @@ void rd_range_domaint::transform(
   // initial (non-deterministic) value
   else if(from->is_decl())
     transform_assign(ns, from, function_from, from, *rd);
+  // array_set, array_copy, array_replace have side effects
+  else if(from->is_other())
+    transform_assign(ns, from, function_from, from, *rd);
 }
 
 /// Computes an instance obtained from a `*this` by transformation over `DEAD v`


### PR DESCRIPTION
goto_rw previously only handled the "printf" case of an "OTHER"
statement, and failed to account for the array operations. Reaching
definitions didn't handle the "OTHER" case at all before.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
