### PR TITLE
Program dependence graph: track SET_RETURN_VALUE instruction

### DIFF
--- a/regression/cbmc/return3/full-slice.desc
+++ b/regression/cbmc/return3/full-slice.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+--full-slice
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring

--- a/src/analyses/dependence_graph.cpp
+++ b/src/analyses/dependence_graph.cpp
@@ -188,6 +188,24 @@ void dep_graph_domaint::data_dependencies(
 
     dep_graph.reaching_definitions()[to].clear_cache(read_object_entry.first);
   }
+
+  if(to->is_set_return_value())
+  {
+    auto entry = dep_graph.end_function_map.find(function_to);
+    CHECK_RETURN(entry != dep_graph.end_function_map.end());
+
+    goto_programt::const_targett end_function = entry->second;
+
+    dep_graph_domaint *s =
+      dynamic_cast<dep_graph_domaint *>(&(dep_graph.get_state(end_function)));
+    CHECK_RETURN(s != nullptr);
+
+    if(s->is_bottom())
+      s->has_values = tvt::unknown();
+
+    if(s->data_deps.insert(to).second)
+      s->has_changed = true;
+  }
 }
 
 void dep_graph_domaint::transform(

--- a/src/analyses/dependence_graph.h
+++ b/src/analyses/dependence_graph.h
@@ -224,6 +224,16 @@ public:
   {
     ait<dep_graph_domaint>::initialize(goto_functions);
     rd(goto_functions, ns);
+
+    for(const auto &entry : goto_functions.function_map)
+    {
+      const goto_programt &goto_program = entry.second.body;
+      if(!goto_program.empty())
+      {
+        end_function_map.emplace(
+          entry.first, std::prev(goto_program.instructions.end()));
+      }
+    }
   }
 
   void initialize(const irep_idt &function, const goto_programt &goto_program)
@@ -238,6 +248,9 @@ public:
     {
       cfg_post_dominatorst &pd = post_dominators[function];
       pd(goto_program);
+
+      end_function_map.emplace(
+        function, std::prev(goto_program.instructions.end()));
     }
   }
 
@@ -273,6 +286,7 @@ protected:
 
   post_dominators_mapt post_dominators;
   reaching_definitions_analysist rd;
+  std::map<irep_idt, goto_programt::const_targett> end_function_map;
 };
 
 #endif // CPROVER_ANALYSES_DEPENDENCE_GRAPH_H

--- a/src/analyses/reaching_definitions.cpp
+++ b/src/analyses/reaching_definitions.cpp
@@ -126,41 +126,6 @@ void rd_range_domaint::transform(
   // initial (non-deterministic) value
   else if(from->is_decl())
     transform_assign(ns, from, function_from, from, *rd);
-
-#if 0
-  // handle return values
-  if(to->is_function_call())
-  {
-    const code_function_callt &code=to_code_function_call(to->code);
-
-    if(code.lhs().is_not_nil())
-    {
-      rw_range_set_value_sett rw_set(ns, rd->get_value_sets());
-      goto_rw(to, rw_set);
-      const bool is_must_alias=rw_set.get_w_set().size()==1;
-
-      for(const auto &written_object_entry : rw_set.get_w_set())
-      {
-        const irep_idt &identifier = written_object_entry.first;
-        // ignore symex::invalid_object
-        const symbolt *symbol_ptr;
-        if(ns.lookup(identifier, symbol_ptr))
-          continue;
-        assert(symbol_ptr!=0);
-
-        const range_domaint &ranges =
-          rw_set.get_ranges(written_object_entry.second);
-
-        if(is_must_alias &&
-           (!rd->get_is_threaded()(from) ||
-            (!symbol_ptr->is_shared() &&
-             !rd->get_is_dirty()(identifier))))
-          for(const auto &range : ranges)
-            kill(identifier, range.first, range.second);
-      }
-    }
-  }
-#endif
 }
 
 /// Computes an instance obtained from a `*this` by transformation over `DEAD v`
@@ -322,12 +287,6 @@ void rd_range_domaint::transform_end_function(
   // handle return values
   if(call->call_lhs().is_not_nil())
   {
-#if 0
-    rd_range_domaint *rd_state=
-      dynamic_cast<rd_range_domaint*>(&(rd.get_state(call)));
-    assert(rd_state!=0);
-    rd_state->
-#endif
     transform_assign(ns, from, function_to, call, rd);
   }
 }


### PR DESCRIPTION
We did track a dependency from END_FUNCTION towards the call site when a
return value was being assigned, but failed to keep track of the data
dependency between SET_RETURN_VALUE and END_FUNCTION.

Also clean up commented-out code that used to handle return values, but
has since been superseded.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
