### PR TITLE
Hide declarations steps from trace when an initialisation follows

### DIFF
--- a/regression/cbmc-cover/location-multiline-statement/multi-file.desc
+++ b/regression/cbmc-cover/location-multiline-statement/multi-file.desc
@@ -3,7 +3,7 @@ multi-file.c
 --cover location
 ^EXIT=0$
 ^SIGNAL=0$
-^\[main.coverage.2\] file multi-file.c line 10 function main block 2 \(lines [\w\- /\.\\:]*dereference.h:main:2; multi-file.c:main:10,13,14,16\): SATISFIED
+^\[main.coverage.2\] file multi-file.c line 13 function main block 2 \(lines [\w\- /\.\\:]*dereference.h:main:2; multi-file.c:main:10,13,14,16\): SATISFIED
 --
 ^warning: ignoring
 --

--- a/regression/cbmc-cover/location-multiline-statement/test.desc
+++ b/regression/cbmc-cover/location-multiline-statement/test.desc
@@ -3,7 +3,7 @@ example.c
 --cover location
 ^EXIT=0$
 ^SIGNAL=0$
-^\[main.coverage.2\] file example.c line 10 function main block 2 \(lines example.c:main:10,13,14\): SATISFIED$
+^\[main.coverage.2\] file example.c line 13 function main block 2 \(lines example.c:main:10,13,14\): SATISFIED$
 --
 ^warning: ignoring
 --

--- a/regression/cbmc-cover/location15/test.desc
+++ b/regression/cbmc-cover/location15/test.desc
@@ -4,7 +4,7 @@ main.c
 ^EXIT=0$
 ^SIGNAL=0$
 ^\[main.coverage.1\] file main.c line 10 function main block 1.*: SATISFIED$
-^\[main.coverage.2\] file main.c line 10 function main block 2.*: SATISFIED$
+^\[main.coverage.2\] file main.c line 11 function main block 2.*: SATISFIED$
 ^\[main.coverage.3\] file main.c line 13 function main block 3.*: FAILED$
 ^\[main.coverage.4\] file main.c line 16 function main block 4.*: SATISFIED$
 ^\[foo.coverage.1\] file main.c line 5 function foo block 1.*: FAILED$

--- a/regression/cbmc/trace-values/trace-values.c
+++ b/regression/cbmc/trace-values/trace-values.c
@@ -11,7 +11,7 @@ struct S
 int main()
 {
   static int static_var;
-  int local_var;
+  int local_var = 3;
   int *p=&my_nested[0].array[1];
   int *q=&my_nested[1].f;
   int *null=0;
@@ -19,7 +19,6 @@ int main()
 
   global_var=1;
   static_var=2;
-  local_var=3;
   *p=4;
   *q=5;
   *null=6;

--- a/regression/cbmc/trace-values/trace-values.desc
+++ b/regression/cbmc/trace-values/trace-values.desc
@@ -3,7 +3,6 @@ trace-values.c
 --trace
 ^EXIT=10$
 ^SIGNAL=0$
-^  local_var=0 .*$
 ^  global_var=1 .*$
 ^  static_var=2 .*$
 ^  local_var=3 .*$
@@ -16,6 +15,7 @@ trace-values.c
 ^VERIFICATION FAILED$
 --
 ^warning: ignoring
+^  local_var=[^3]+ .*$
 --
 Note the assignment to "null" is not included because an assignment direct to
 a certainly-null pointer goes to symex::invalid_object, not null$object, and is

--- a/regression/cbmc/z3/trace-char.desc
+++ b/regression/cbmc/z3/trace-char.desc
@@ -3,7 +3,6 @@ trace-char.c
 --trace --smt2 --z3
 ^EXIT=10$
 ^SIGNAL=0$
-arr=\{ arr
 arr=\{ '0', '1', '2', '3', '4', '5', '6', '7' \}
 --
 arr=(assignment removed)

--- a/regression/cbmc/z3/trace.desc
+++ b/regression/cbmc/z3/trace.desc
@@ -3,7 +3,6 @@ trace.c
 --trace --smt2 --z3
 ^EXIT=10$
 ^SIGNAL=0$
-arr=\{ arr
 arr=\{ 0, 1, 2, 3, 4, 5, 6, 17 \}
 --
 arr=(assignment removed)

--- a/src/goto-instrument/unwindset.cpp
+++ b/src/goto-instrument/unwindset.cpp
@@ -126,6 +126,9 @@ void unwindsett::parse_unwindset_one_loop(
               loop_nr_label) != instruction.labels.end())
           {
             location = instruction.source_location();
+            // the label may be attached to the DECL part of an initializing
+            // declaration, which we may have marked as hidden
+            location->remove(ID_hide);
           }
           if(
             location.has_value() && instruction.is_backwards_goto() &&

--- a/src/goto-programs/goto_convert.cpp
+++ b/src/goto-programs/goto_convert.cpp
@@ -627,11 +627,12 @@ void goto_convertt::convert_frontend_decl(
   else
   {
     // this is expected to go away
-    exprt initializer;
+    exprt initializer = code.op1();
 
     codet tmp=code;
-    initializer=code.op1();
     tmp.operands().resize(1);
+    // hide this declaration-without-initializer step in the goto trace
+    tmp.add_source_location().set_hide();
 
     // Break up into decl and assignment.
     // Decl must be visible before initializer.
@@ -642,7 +643,7 @@ void goto_convertt::convert_frontend_decl(
     if(initializer.is_not_nil())
     {
       code_assignt assign(code.op0(), initializer);
-      assign.add_source_location() = tmp.source_location();
+      assign.add_source_location() = initializer.find_source_location();
 
       convert_assign(assign, dest, mode);
     }

--- a/src/goto-programs/goto_convert.cpp
+++ b/src/goto-programs/goto_convert.cpp
@@ -626,7 +626,6 @@ void goto_convertt::convert_frontend_decl(
   }
   else
   {
-    // this is expected to go away
     exprt initializer = code.op1();
 
     codet tmp=code;


### PR DESCRIPTION
If the front-end generated a declaration with an initialiser, then goto
conversion can mark the declaration statement (but not the
initialisation!) as hidden. This will avoid showing meaningless values
in a goto trace.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
