### PR TITLE
Add new smt backend label to regression tests

### DIFF
--- a/regression/cbmc/Associativity1/test.desc
+++ b/regression/cbmc/Associativity1/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 
 ^EXIT=0$

--- a/regression/cbmc/Assumption1/test.desc
+++ b/regression/cbmc/Assumption1/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 
 ^EXIT=10$

--- a/regression/cbmc/Bitfields2/test.desc
+++ b/regression/cbmc/Bitfields2/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 
 ^EXIT=0$

--- a/regression/cbmc/CMakeLists.txt
+++ b/regression/cbmc/CMakeLists.txt
@@ -24,6 +24,14 @@ add_test_pl_profile(
     "CORE"
 )
 
+# If `-I` (include flag) is passed, test.pl will run only the tests matching the label following it.
+add_test_pl_profile(
+  "cbmc-new-smt-backend"
+  "$<TARGET_FILE:cbmc> --incremental-smt2-solver 'z3 --smt2 -in' --slice-formula"
+  "-I;new-smt-backend;-s;new-smt-backend"
+  "CORE"
+)
+
 # solver appears on the PATH in Windows already
 if(NOT "${CMAKE_SYSTEM_NAME}" STREQUAL "Windows")
   set_property(

--- a/regression/cbmc/Fixedbv1/test.desc
+++ b/regression/cbmc/Fixedbv1/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 
 ^EXIT=0$

--- a/regression/cbmc/Fixedbv2/test.desc
+++ b/regression/cbmc/Fixedbv2/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 
 ^EXIT=0$

--- a/regression/cbmc/Fixedbv4/test.desc
+++ b/regression/cbmc/Fixedbv4/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 
 ^EXIT=0$

--- a/regression/cbmc/Fixedbv6/test.desc
+++ b/regression/cbmc/Fixedbv6/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 
 ^EXIT=0$

--- a/regression/cbmc/Fixedbv8/test.desc
+++ b/regression/cbmc/Fixedbv8/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 
 ^EXIT=0$

--- a/regression/cbmc/Function-KnR1/test.desc
+++ b/regression/cbmc/Function-KnR1/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 
 ^EXIT=0$

--- a/regression/cbmc/Function1/test.desc
+++ b/regression/cbmc/Function1/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 
 ^EXIT=0$

--- a/regression/cbmc/Function10/test.desc
+++ b/regression/cbmc/Function10/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 
 ^EXIT=0$

--- a/regression/cbmc/Function11/test.desc
+++ b/regression/cbmc/Function11/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 
 ^EXIT=0$

--- a/regression/cbmc/Function13/test.desc
+++ b/regression/cbmc/Function13/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 
 ^EXIT=0$

--- a/regression/cbmc/Function14/test.desc
+++ b/regression/cbmc/Function14/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 
 ^EXIT=0$

--- a/regression/cbmc/Function6/test.desc
+++ b/regression/cbmc/Function6/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 
 ^EXIT=0$

--- a/regression/cbmc/Function7/test.desc
+++ b/regression/cbmc/Function7/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 
 ^EXIT=0$

--- a/regression/cbmc/Function8/test.desc
+++ b/regression/cbmc/Function8/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 
 ^EXIT=10$

--- a/regression/cbmc/Function9/test.desc
+++ b/regression/cbmc/Function9/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 
 ^EXIT=10$

--- a/regression/cbmc/Function_Pointer5/test.desc
+++ b/regression/cbmc/Function_Pointer5/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 
 ^EXIT=0$

--- a/regression/cbmc/Makefile
+++ b/regression/cbmc/Makefile
@@ -29,6 +29,11 @@ test-paths-lifo:
 					  -X thorough-paths -X smt-backend -X paths-lifo-expected-failure \
 					  -s paths-lifo $(GCC_ONLY)
 
+test-new-smt-backend:
+	@../test.pl -e -p -c "../../../src/cbmc/cbmc --incremental-smt2-solver 'z3 --smt2 -in' --slice-formula" \
+					  -I new-smt-backend \
+					  -s new-smt-backend $(GCC_ONLY)
+
 tests.log: ../test.pl test
 
 clean:

--- a/regression/cbmc/Mod1/test.desc
+++ b/regression/cbmc/Mod1/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 
 ^EXIT=10$

--- a/regression/cbmc/Mod2/test.desc
+++ b/regression/cbmc/Mod2/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 
 ^EXIT=0$

--- a/regression/cbmc/Negation1/test.desc
+++ b/regression/cbmc/Negation1/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 
 ^EXIT=0$

--- a/regression/cbmc/Negation2/test.desc
+++ b/regression/cbmc/Negation2/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 --no-propagation
 ^EXIT=0$

--- a/regression/cbmc/Nondet1/test.desc
+++ b/regression/cbmc/Nondet1/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 
 ^EXIT=0$

--- a/regression/cbmc/always_inline1/test.desc
+++ b/regression/cbmc/always_inline1/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 
 ^EXIT=0$

--- a/regression/cbmc/assert_func_four/test.desc
+++ b/regression/cbmc/assert_func_four/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 
 function .* is not declared

--- a/regression/cbmc/assert_lhs/test.desc
+++ b/regression/cbmc/assert_lhs/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 
 function .* is not declared

--- a/regression/cbmc/assert_one/test.desc
+++ b/regression/cbmc/assert_one/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 
 function .* is not declared

--- a/regression/cbmc/char1/test.desc
+++ b/regression/cbmc/char1/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 --unsigned-char
 ^EXIT=0$

--- a/regression/cbmc/cprover_assert_two/test.desc
+++ b/regression/cbmc/cprover_assert_two/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 
 ^EXIT=6$

--- a/regression/cbmc/exit1/test.desc
+++ b/regression/cbmc/exit1/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 
 ^EXIT=0$

--- a/regression/cbmc/for1/test.desc
+++ b/regression/cbmc/for1/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 
 ^EXIT=0$

--- a/regression/cbmc/for2/test.desc
+++ b/regression/cbmc/for2/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 
 ^EXIT=10$

--- a/regression/cbmc/for3/test.desc
+++ b/regression/cbmc/for3/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 
 ^EXIT=0$

--- a/regression/cbmc/goto1/test.desc
+++ b/regression/cbmc/goto1/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 
 ^EXIT=0$

--- a/regression/cbmc/goto4/test.desc
+++ b/regression/cbmc/goto4/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 --unwind 1 --unwinding-assertions
 ^EXIT=10$

--- a/regression/cbmc/guard1/test.desc
+++ b/regression/cbmc/guard1/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 --depth 19
 ^EXIT=0$

--- a/regression/cbmc/if1/test.desc
+++ b/regression/cbmc/if1/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 
 ^EXIT=0$

--- a/regression/cbmc/if3/test.desc
+++ b/regression/cbmc/if3/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 
 ^EXIT=10$

--- a/regression/cbmc/if4/test.desc
+++ b/regression/cbmc/if4/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 
 ^EXIT=0$

--- a/regression/cbmc/no-propagation/test.desc
+++ b/regression/cbmc/no-propagation/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 --no-propagation
 Generated 1 VCC\(s\), 1 remaining after simplification

--- a/regression/cbmc/noop1/test.desc
+++ b/regression/cbmc/noop1/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 -winx64
 ^EXIT=0$

--- a/regression/cbmc/null1/test.desc
+++ b/regression/cbmc/null1/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 --no-simplify
 ^EXIT=0$

--- a/regression/cbmc/null4/test.desc
+++ b/regression/cbmc/null4/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 
 ^EXIT=0$

--- a/regression/cbmc/r_w_ok4/test.desc
+++ b/regression/cbmc/r_w_ok4/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 
 ^VERIFICATION SUCCESSFUL$

--- a/regression/cbmc/return1/test.desc
+++ b/regression/cbmc/return1/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 
 ^EXIT=0$

--- a/regression/cbmc/return3/test.desc
+++ b/regression/cbmc/return3/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 
 ^EXIT=0$

--- a/regression/cbmc/return4/test.desc
+++ b/regression/cbmc/return4/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
  --unwind 2
 ^EXIT=0$

--- a/regression/cbmc/return5/test.desc
+++ b/regression/cbmc/return5/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
  --unwind 2
 ^EXIT=10$


### PR DESCRIPTION
This PR sets up the infrastructure to allow us to run
any tests from `regression/cbmc` with configuration targeting
the new SMT backend.

The reason for this is that we want to re-use the tests present
on that folder, so that we don't have to re-write all of these
tests to drive the new SMT backend.

The final commit marks about 50 of those tests with the new
label, so that we can we can run them with that specific profile
on CI.


<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
