### PR TITLE
Fixes for address expressions

### DIFF
--- a/src/util/pointer_expr.cpp
+++ b/src/util/pointer_expr.cpp
@@ -138,9 +138,9 @@ field_address_exprt::field_address_exprt(
   pointer_typet _type)
   : unary_exprt(ID_field_address, std::move(compound_ptr), std::move(_type))
 {
-  const auto &compound_ptr_type = compound_ptr.type();
-  PRECONDITION(compound_ptr_type.id() == ID_pointer);
-  const auto &compound_type = to_pointer_type(compound_ptr_type).base_type();
+  const auto &base_type = field_address_exprt::base().type();
+  PRECONDITION(base_type.id() == ID_pointer);
+  const auto &compound_type = to_pointer_type(base_type).base_type();
   PRECONDITION(
     compound_type.id() == ID_struct || compound_type.id() == ID_struct_tag ||
     compound_type.id() == ID_union || compound_type.id() == ID_union_tag);

--- a/src/util/pointer_expr.cpp
+++ b/src/util/pointer_expr.cpp
@@ -147,13 +147,13 @@ field_address_exprt::field_address_exprt(
   set(ID_component_name, component_name);
 }
 
-element_address_exprt::element_address_exprt(exprt base, exprt index)
+element_address_exprt::element_address_exprt(const exprt &base, exprt index)
   : binary_exprt(
-      std::move(base),
+      base,
       ID_element_address,
       std::move(index),
       pointer_typet(
-        to_array_type(base.type()).element_type(),
+        to_pointer_type(base.type()).base_type(),
         to_pointer_type(base.type()).get_width()))
 {
 }

--- a/src/util/pointer_expr.h
+++ b/src/util/pointer_expr.h
@@ -450,7 +450,7 @@ inline bool can_cast_expr<object_address_exprt>(const exprt &base)
 
 inline void validate_expr(const object_address_exprt &value)
 {
-  validate_operands(value, 1, "object_address must have one operand");
+  validate_operands(value, 0, "object_address must have zero operands");
 }
 
 /// \brief Cast an exprt to an \ref object_address_exprt

--- a/src/util/pointer_expr.h
+++ b/src/util/pointer_expr.h
@@ -569,7 +569,7 @@ public:
   /// constructor for element addresses.
   /// The base address must be a pointer to an element.
   /// The index is expected to have an integer type.
-  element_address_exprt(exprt base, exprt index);
+  element_address_exprt(const exprt &base, exprt index);
 
   const pointer_typet &type() const
   {


### PR DESCRIPTION
This is a collection of fixes for the address constructor expressions.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
