### PR TITLE
Replace the goto_check indirection by direct use of goto_check_c [blocks: #6688]

### DIFF
--- a/src/goto-instrument/accelerate/acceleration_utils.cpp
+++ b/src/goto-instrument/accelerate/acceleration_utils.cpp
@@ -475,7 +475,7 @@ void acceleration_utilst::ensure_no_overflows(scratch_programt &program)
 
   // goto_functionst::goto_functiont fn;
   // fn.body.instructions.swap(program.instructions);
-  // goto_check(ns, checker_options, fn);
+  // goto_check_c(ns, checker_options, fn);
   // fn.body.instructions.swap(program.instructions);
 
 #ifdef DEBUG

--- a/src/goto-instrument/goto_instrument_parse_options.cpp
+++ b/src/goto-instrument/goto_instrument_parse_options.cpp
@@ -1328,7 +1328,7 @@ void goto_instrument_parse_optionst::instrument_goto_program()
   }
 
   // add generic checks, if needed
-  goto_check(options, goto_model, ui_message_handler);
+  goto_check_c(options, goto_model, ui_message_handler);
   transform_assertions_assumptions(options, goto_model);
 
   // check for uninitalized local variables

--- a/src/goto-programs/goto_check.cpp
+++ b/src/goto-programs/goto_check.cpp
@@ -12,45 +12,9 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "goto_check.h"
 
 #include <util/options.h>
-#include <util/symbol.h>
 
-#include <goto-programs/goto_model.h>
-#include <goto-programs/remove_skip.h>
-
-#include <ansi-c/goto_check_c.h>
-
-void goto_check(
-  const irep_idt &function_identifier,
-  goto_functionst::goto_functiont &goto_function,
-  const namespacet &ns,
-  const optionst &options,
-  message_handlert &message_handler)
-{
-  const auto &function_symbol = ns.lookup(function_identifier);
-
-  if(function_symbol.mode == ID_C)
-  {
-    goto_check_c(
-      function_identifier, goto_function, ns, options, message_handler);
-  }
-}
-
-void goto_check(
-  const namespacet &ns,
-  const optionst &options,
-  goto_functionst &goto_functions,
-  message_handlert &message_handler)
-{
-  goto_check_c(ns, options, goto_functions, message_handler);
-}
-
-void goto_check(
-  const optionst &options,
-  goto_modelt &goto_model,
-  message_handlert &message_handler)
-{
-  goto_check_c(options, goto_model, message_handler);
-}
+#include "goto_model.h"
+#include "remove_skip.h"
 
 static void transform_assertions_assumptions(
   goto_programt &goto_program,

--- a/src/goto-programs/goto_check.h
+++ b/src/goto-programs/goto_check.h
@@ -12,27 +12,9 @@ Author: Daniel Kroening, kroening@kroening.com
 #ifndef CPROVER_GOTO_PROGRAMS_GOTO_CHECK_H
 #define CPROVER_GOTO_PROGRAMS_GOTO_CHECK_H
 
-#include "goto_functions.h"
-
 class goto_modelt;
-class namespacet;
+class goto_programt;
 class optionst;
-class message_handlert;
-
-void goto_check(
-  const namespacet &,
-  const optionst &,
-  goto_functionst &,
-  message_handlert &);
-
-void goto_check(
-  const irep_idt &function_identifier,
-  goto_functionst::goto_functiont &,
-  const namespacet &,
-  const optionst &,
-  message_handlert &);
-
-void goto_check(const optionst &, goto_modelt &, message_handlert &);
 
 /// Handle the options "assertions", "built-in-assertions", "assumptions" to
 /// remove assertions and assumptions in \p goto_model when these are set to

--- a/src/goto-programs/process_goto_program.cpp
+++ b/src/goto-programs/process_goto_program.cpp
@@ -27,6 +27,8 @@ Author: Martin Brain, martin.brain@cs.ox.ac.uk
 #include <goto-programs/string_abstraction.h>
 #include <goto-programs/string_instrumentation.h>
 
+#include <ansi-c/goto_check_c.h>
+
 #include "goto_check.h"
 
 bool process_goto_program(
@@ -73,7 +75,7 @@ bool process_goto_program(
 
   // add generic checks
   log.status() << "Generic Property Instrumentation" << messaget::eom;
-  goto_check(options, goto_model, log.get_message_handler());
+  goto_check_c(options, goto_model, log.get_message_handler());
   transform_assertions_assumptions(options, goto_model);
 
   // checks don't know about adjusted float expressions


### PR DESCRIPTION
All existing calls necessarily end up calling goto_check_c.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
