### PR TITLE
Remove unused make_assertions_false

### DIFF
--- a/src/goto-programs/set_properties.cpp
+++ b/src/goto-programs/set_properties.cpp
@@ -129,21 +129,3 @@ void label_properties(goto_functionst &goto_functions)
       it++)
     label_properties(it->second.body, property_counters);
 }
-
-void make_assertions_false(goto_modelt &goto_model)
-{
-  make_assertions_false(goto_model.goto_functions);
-}
-
-void make_assertions_false(
-  goto_functionst &goto_functions)
-{
-  for(auto &f : goto_functions.function_map)
-  {
-    for(auto &i : f.second.body.instructions)
-    {
-      if(i.is_assert())
-        i.set_condition(false_exprt());
-    }
-  }
-}

--- a/src/goto-programs/set_properties.h
+++ b/src/goto-programs/set_properties.h
@@ -27,9 +27,6 @@ void set_properties(
   goto_modelt &goto_model,
   const std::list<std::string> &properties);
 
-void make_assertions_false(goto_functionst &);
-void make_assertions_false(goto_modelt &);
-
 void label_properties(goto_functionst &);
 void label_properties(goto_programt &);
 void label_properties(goto_modelt &);


### PR DESCRIPTION
This code was introduced in 35b430af58c and 76d543be894, but it seems to
be unused and its purpose is unclear.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
