### PR TITLE
goto_rw: do not assume that all types have constant size

### DIFF
--- a/regression/cbmc/byte_update5/full-slice.desc
+++ b/regression/cbmc/byte_update5/full-slice.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+--little-endian --full-slice
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring

--- a/src/analyses/goto_rw.cpp
+++ b/src/analyses/goto_rw.cpp
@@ -148,15 +148,20 @@ void rw_range_sett::get_objects_byte_extract(
   const range_spect &range_start,
   const range_spect &size)
 {
+  auto object_size_bits_opt = pointer_offset_bits(be.op().type(), ns);
   const exprt simp_offset=simplify_expr(be.offset(), ns);
 
   auto index = numeric_cast<mp_integer>(simp_offset);
-  if(range_start == -1 || !index.has_value())
+  if(
+    range_start == -1 || !index.has_value() ||
+    !object_size_bits_opt.has_value())
+  {
     get_objects_rec(mode, be.op(), -1, size);
+  }
   else
   {
     *index *= 8;
-    if(*index >= *pointer_offset_bits(be.op().type(), ns))
+    if(*index >= *object_size_bits_opt)
       return;
 
     endianness_mapt map(


### PR DESCRIPTION
pointer_offset_bits returns nullopt whenever the size of a type is not a
numeric constant. Such cases arise when arrays have runtime-determined
size, as is the case in regression test byte_update5.

All other places except the one fixed in this commit already considered
the case that pointer_offset_bits returns nullopt.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
