### PR TITLE
Reaching definitions: distinguish recursion from function-without-body

### DIFF
--- a/regression/goto-instrument/reaching-definitions/test.desc
+++ b/regression/goto-instrument/reaching-definitions/test.desc
@@ -1,0 +1,13 @@
+CORE
+../../cbmc/Recursion6/main.c
+--show-reaching-definitions
+activate-multi-line-match
+recursion::1::some_local\[0:32@\d+\]\n(\s+(__CPROVER|recursion).*\n)*\s*\n\s+//.*\n\s+ASSERT .*recursion::1::some_local = 1
+^EXIT=0$
+^SIGNAL=0$
+--
+^FALSE
+--
+Reaching definitions must not confuse recursion and functions without body, both
+of which yield transform calls where the to and from have the same function
+identifier.

--- a/src/analyses/reaching_definitions.cpp
+++ b/src/analyses/reaching_definitions.cpp
@@ -181,7 +181,8 @@ void rd_range_domaint::transform_function_call(
   reaching_definitions_analysist &rd)
 {
   // only if there is an actual call, i.e., we have a body
-  if(function_from != function_to)
+  const symbol_exprt &fn_symbol_expr = to_symbol_expr(from->call_function());
+  if(function_to == fn_symbol_expr.get_identifier())
   {
     for(valuest::iterator it=values.begin();
         it!=values.end();
@@ -206,7 +207,6 @@ void rd_range_domaint::transform_function_call(
         ++it;
     }
 
-    const symbol_exprt &fn_symbol_expr = to_symbol_expr(from->call_function());
     const code_typet &code_type=
       to_code_type(ns.lookup(fn_symbol_expr.get_identifier()).type);
 


### PR DESCRIPTION
Comparing function names addressed the problem of comparing iterators
over distinct objects (b2fba976d5b), but resulted in possible confusion
of recursion vs calling a function that doesn't have a body.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
