### PR TITLE
Dependence graph: entry points may have additional control dependencies

### DIFF
--- a/regression/cbmc/Pointer18/full-slice.desc
+++ b/regression/cbmc/Pointer18/full-slice.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+--unwind 1 --no-unwinding-assertions --pointer-check --full-slice
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring

--- a/src/analyses/dependence_graph.cpp
+++ b/src/analyses/dependence_graph.cpp
@@ -224,23 +224,13 @@ void dep_graph_domaint::transform(
 
   // We do not propagate control dependencies on function calls, i.e., only the
   // entry point of a function should have a control dependency on the call
-  if(!control_deps.empty())
-  {
-    const goto_programt::const_targett &dep = *control_deps.begin();
-    if(dep->is_function_call())
-    {
-      INVARIANT(
-        std::all_of(
-          std::next(control_deps.begin()),
-          control_deps.end(),
-          [](const goto_programt::const_targett &d) {
-            return d->is_function_call();
-          }),
-        "All entries must be function calls");
-
-      control_deps.clear();
-    }
-  }
+  depst filtered_control_deps;
+  std::copy_if(
+    control_deps.begin(),
+    control_deps.end(),
+    std::inserter(filtered_control_deps, filtered_control_deps.end()),
+    [](goto_programt::const_targett dep) { return !dep->is_function_call(); });
+  control_deps = std::move(filtered_control_deps);
 
   // propagate control dependencies across function calls
   if(from->is_function_call())


### PR DESCRIPTION
The first instruction of a function can reasonably have control
dependencies other than that of the function call. Pointer18 is such an
example, because there is a back edge to the beginning of the main
function.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
