### PR TITLE
Implement conversion to SMT for more bit wise expressions

### DIFF
--- a/src/solvers/smt2_incremental/convert_expr_to_smt.cpp
+++ b/src/solvers/smt2_incremental/convert_expr_to_smt.cpp
@@ -652,34 +652,35 @@ static smt_termt convert_expr_to_smt(const index_exprt &index)
     "Generation of SMT formula for index expression: " + index.pretty());
 }
 
+template <typename factoryt, typename shiftt>
+static smt_termt
+convert_to_smt_shift(const factoryt &factory, const shiftt &shift)
+{
+  const smt_termt first_operand = convert_expr_to_smt(shift.op0());
+  const smt_termt second_operand = convert_expr_to_smt(shift.op1());
+  return factory(first_operand, second_operand);
+}
+
 static smt_termt convert_expr_to_smt(const shift_exprt &shift)
 {
-  // TODO: Dispatch into different types of shifting
-  const auto &first_operand = shift.op0();
-  const auto &second_operand = shift.op1();
-
+  // TODO: Dispatch for rotation expressions. A `shift_exprt` can be a rotation.
   if(const auto left_shift = expr_try_dynamic_cast<shl_exprt>(shift))
   {
-    return smt_bit_vector_theoryt::shift_left(
-      convert_expr_to_smt(first_operand), convert_expr_to_smt(second_operand));
+    return convert_to_smt_shift(
+      smt_bit_vector_theoryt::shift_left, *left_shift);
   }
-  else if(
-    const auto right_logical_shift = expr_try_dynamic_cast<lshr_exprt>(shift))
+  if(const auto right_logical_shift = expr_try_dynamic_cast<lshr_exprt>(shift))
   {
-    return smt_bit_vector_theoryt::logical_shift_right(
-      convert_expr_to_smt(first_operand), convert_expr_to_smt(second_operand));
+    return convert_to_smt_shift(
+      smt_bit_vector_theoryt::logical_shift_right, *right_logical_shift);
   }
-  else if(
-    const auto right_arith_shift = expr_try_dynamic_cast<ashr_exprt>(shift))
+  if(const auto right_arith_shift = expr_try_dynamic_cast<ashr_exprt>(shift))
   {
-    return smt_bit_vector_theoryt::arithmetic_shift_right(
-      convert_expr_to_smt(first_operand), convert_expr_to_smt(second_operand));
+    return convert_to_smt_shift(
+      smt_bit_vector_theoryt::arithmetic_shift_right, *right_arith_shift);
   }
-  else
-  {
-    UNIMPLEMENTED_FEATURE(
-      "Generation of SMT formula for shift expression: " + shift.pretty());
-  }
+  UNIMPLEMENTED_FEATURE(
+    "Generation of SMT formula for shift expression: " + shift.pretty());
 }
 
 static smt_termt convert_expr_to_smt(const with_exprt &with)

--- a/src/solvers/smt2_incremental/convert_expr_to_smt.cpp
+++ b/src/solvers/smt2_incremental/convert_expr_to_smt.cpp
@@ -733,6 +733,11 @@ static smt_termt convert_expr_to_smt(const extractbit_exprt &extract_bit)
 
 static smt_termt convert_expr_to_smt(const extractbits_exprt &extract_bits)
 {
+  const smt_termt from = convert_expr_to_smt(extract_bits.src());
+  const auto upper_value = numeric_cast<std::size_t>(extract_bits.upper());
+  const auto lower_value = numeric_cast<std::size_t>(extract_bits.lower());
+  if(upper_value && lower_value)
+    return smt_bit_vector_theoryt::extract(*upper_value, *lower_value)(from);
   UNIMPLEMENTED_FEATURE(
     "Generation of SMT formula for extract bits expression: " +
     extract_bits.pretty());

--- a/unit/solvers/smt2_incremental/convert_expr_to_smt.cpp
+++ b/unit/solvers/smt2_incremental/convert_expr_to_smt.cpp
@@ -819,6 +819,27 @@ SCENARIO(
   }
 }
 
+TEST_CASE(
+  "expr to smt conversion for extract bits expressions",
+  "[core][smt2_incremental]")
+{
+  const typet operand_type = unsignedbv_typet{8};
+  const exprt input = extractbits_exprt{
+    symbol_exprt{"foo", operand_type},
+    from_integer(4, operand_type),
+    from_integer(2, operand_type),
+    unsignedbv_typet{3}};
+  const smt_termt expected_result = smt_bit_vector_theoryt::extract(4, 2)(
+    smt_identifier_termt{"foo", smt_bit_vector_sortt{8}});
+  CHECK(convert_expr_to_smt(input) == expected_result);
+  const cbmc_invariants_should_throwt invariants_throw;
+  CHECK_THROWS(convert_expr_to_smt(extractbits_exprt{
+    symbol_exprt{"foo", operand_type},
+    symbol_exprt{"bar", operand_type},
+    symbol_exprt{"bar", operand_type},
+    unsignedbv_typet{3}}));
+}
+
 TEST_CASE("expr to smt conversion for type casts", "[core][smt2_incremental]")
 {
   const symbol_exprt bool_expr{"foo", bool_typet{}};

--- a/unit/solvers/smt2_incremental/convert_expr_to_smt.cpp
+++ b/unit/solvers/smt2_incremental/convert_expr_to_smt.cpp
@@ -820,6 +820,84 @@ SCENARIO(
 }
 
 TEST_CASE(
+  "expr to smt conversion for shifts of mismatched operands.",
+  "[core][smt2_incremental]")
+{
+  using make_typet = std::function<typet(std::size_t)>;
+  const make_typet make_unsigned = constructor_oft<unsignedbv_typet>{};
+  const make_typet make_signed = constructor_oft<signedbv_typet>{};
+  using make_extensiont =
+    std::function<std::function<smt_termt(smt_termt)>(std::size_t)>;
+  const make_extensiont zero_extend = smt_bit_vector_theoryt::zero_extend;
+  const make_extensiont sign_extend = smt_bit_vector_theoryt::sign_extend;
+  std::string type_description;
+  make_typet make_type;
+  make_extensiont make_extension;
+  using type_rowt = std::tuple<std::string, make_typet, make_extensiont>;
+  std::tie(type_description, make_type, make_extension) = GENERATE_REF(
+    type_rowt{"Unsigned operands.", make_unsigned, zero_extend},
+    type_rowt{"Signed operands.", make_signed, sign_extend});
+  SECTION(type_description)
+  {
+    using make_shift_exprt = std::function<exprt(exprt, exprt)>;
+    const make_shift_exprt left_shift_expr = constructor_of<shl_exprt>();
+    const make_shift_exprt arithmetic_right_shift_expr =
+      constructor_of<ashr_exprt>();
+    const make_shift_exprt logical_right_shift_expr =
+      constructor_of<lshr_exprt>();
+    using make_shift_termt = std::function<smt_termt(smt_termt, smt_termt)>;
+    const make_shift_termt left_shift_term = smt_bit_vector_theoryt::shift_left;
+    const make_shift_termt arithmetic_right_shift_term =
+      smt_bit_vector_theoryt::arithmetic_shift_right;
+    const make_shift_termt logical_right_shift_term =
+      smt_bit_vector_theoryt::logical_shift_right;
+    std::string shift_description;
+    make_shift_exprt make_shift_expr;
+    make_shift_termt make_shift_term;
+    using shift_rowt =
+      std::tuple<std::string, make_shift_exprt, make_shift_termt>;
+    std::tie(shift_description, make_shift_expr, make_shift_term) =
+      GENERATE_REF(
+        shift_rowt{"Left shift.", left_shift_expr, left_shift_term},
+        shift_rowt{
+          "Arithmetic right shift.",
+          arithmetic_right_shift_expr,
+          arithmetic_right_shift_term},
+        shift_rowt{
+          "Logical right shift.",
+          logical_right_shift_expr,
+          logical_right_shift_term});
+    SECTION(shift_description)
+    {
+      SECTION("Wider left hand side")
+      {
+        const exprt input = make_shift_expr(
+          symbol_exprt{"foo", make_type(32)},
+          symbol_exprt{"bar", make_type(8)});
+        INFO("Input expr: " + input.pretty(2, 0));
+        const smt_termt expected_result = make_shift_term(
+          smt_identifier_termt{"foo", smt_bit_vector_sortt{32}},
+          make_extension(24)(
+            smt_identifier_termt{"bar", smt_bit_vector_sortt{8}}));
+        CHECK(convert_expr_to_smt(input) == expected_result);
+      }
+      SECTION("Wider right hand side")
+      {
+        const exprt input = make_shift_expr(
+          symbol_exprt{"foo", make_type(8)},
+          symbol_exprt{"bar", make_type(32)});
+        INFO("Input expr: " + input.pretty(2, 0));
+        const smt_termt expected_result = make_shift_term(
+          make_extension(24)(
+            smt_identifier_termt{"foo", smt_bit_vector_sortt{8}}),
+          smt_identifier_termt{"bar", smt_bit_vector_sortt{32}});
+        CHECK(convert_expr_to_smt(input) == expected_result);
+      }
+    }
+  }
+}
+
+TEST_CASE(
   "expr to smt conversion for extract bits expressions",
   "[core][smt2_incremental]")
 {


### PR DESCRIPTION
This PR adds implements of conversion to SMT for more bit wise expressions.
<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [x] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
