### PR TITLE
goto_rw: left shift may be larger than object size

### DIFF
--- a/regression/cbmc/overflow/leftshift_overflow-c99-full-slice.desc
+++ b/regression/cbmc/overflow/leftshift_overflow-c99-full-slice.desc
@@ -1,0 +1,17 @@
+CORE
+leftshift_overflow.c
+--signed-overflow-check --c99 --full-slice
+^EXIT=10$
+^SIGNAL=0$
+^\[.*\] line 8 arithmetic overflow on signed shl in .*: FAILURE$
+^\[.*\] line 11 arithmetic overflow on signed shl in .*: SUCCESS$
+^\[.*\] line 17 arithmetic overflow on signed shl in .*: SUCCESS$
+^\[.*\] line 20 arithmetic overflow on signed shl in .*: FAILURE$
+^\[.*\] line 26 arithmetic overflow on signed shl in .*: FAILURE$
+^\[.*\] line 30 arithmetic overflow on signed shl in .*: FAILURE$
+^\*\* 4 of 7 failed
+^VERIFICATION FAILED$
+--
+^warning: ignoring
+^\[.*\] line 14 arithmetic overflow on signed shl in .*: .*
+^\[.*\] line 23 arithmetic overflow on signed shl in .*: .*

--- a/src/analyses/goto_rw.cpp
+++ b/src/analyses/goto_rw.cpp
@@ -217,9 +217,8 @@ void rw_range_sett::get_objects_shift(
       if(sh_range_start>=0 && sh_range_start<src_size)
         get_objects_rec(mode, shift.op(), sh_range_start, sh_size);
     }
-    else
+    if(src_size - dist_r >= 0)
     {
-      assert(src_size-dist_r>=0);
       range_spect sh_size=std::min(size, src_size-dist_r);
 
       get_objects_rec(mode, shift.op(), range_start, sh_size);


### PR DESCRIPTION
While such an expression might have undefined behaviour in some source
languages, goto_rw should not assert that a goto program does not
contain such an expression.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
