### PR TITLE
add more formatters

### DIFF
--- a/src/util/format_expr.cpp
+++ b/src/util/format_expr.cpp
@@ -304,6 +304,12 @@ void format_expr_configt::setup()
     return format_rec(os, to_constant_expr(expr));
   };
 
+  expr_map[ID_address_of] =
+    [](std::ostream &os, const exprt &expr) -> std::ostream & {
+    const auto &address_of = to_address_of_expr(expr);
+    return os << "address_of(" << format(address_of.object()) << ')';
+  };
+
   expr_map[ID_annotated_pointer_constant] =
     [](std::ostream &os, const exprt &expr) -> std::ostream & {
     const auto &annotated_pointer = to_annotated_pointer_constant_expr(expr);

--- a/src/util/format_expr.cpp
+++ b/src/util/format_expr.cpp
@@ -456,6 +456,12 @@ void format_expr_configt::setup()
   expr_map[ID_array] = compound;
   expr_map[ID_struct] = compound;
 
+  expr_map[ID_array_of] =
+    [](std::ostream &os, const exprt &expr) -> std::ostream & {
+    const auto &array_of_expr = to_array_of_expr(expr);
+    return os << "array_of(" << format(array_of_expr.what()) << ')';
+  };
+
   expr_map[ID_if] = [](std::ostream &os, const exprt &expr) -> std::ostream & {
     const auto &if_expr = to_if_expr(expr);
     return os << '(' << format(if_expr.cond()) << " ? "

--- a/src/util/format_expr.cpp
+++ b/src/util/format_expr.cpp
@@ -186,7 +186,9 @@ static std::ostream &format_rec(std::ostream &os, const constant_exprt &src)
   {
     if(is_null_pointer(src))
       return os << ID_NULL;
-    else if(has_prefix(id2string(src.get_value()), "INVALID-"))
+    else if(
+      src.get_value() == "INVALID" ||
+      has_prefix(id2string(src.get_value()), "INVALID-"))
     {
       return os << "INVALID-POINTER";
     }

--- a/src/util/std_expr.h
+++ b/src/util/std_expr.h
@@ -69,7 +69,36 @@ public:
 
   const exprt &op3() const = delete;
   exprt &op3() = delete;
+
+  static void check(
+    const exprt &expr,
+    const validation_modet vm = validation_modet::INVARIANT)
+  {
+    DATA_CHECK(
+      vm,
+      expr.operands().size() == 3,
+      "ternary expression must have three operands");
+  }
 };
+
+/// \brief Cast an exprt to a \ref ternary_exprt
+///
+/// \a expr must be known to be \ref ternary_exprt.
+///
+/// \param expr: Source expression
+/// \return Object of type \ref ternary_exprt
+inline const ternary_exprt &to_ternary_expr(const exprt &expr)
+{
+  ternary_exprt::check(expr);
+  return static_cast<const ternary_exprt &>(expr);
+}
+
+/// \copydoc to_ternary_expr(const exprt &)
+inline ternary_exprt &to_ternary_expr(exprt &expr)
+{
+  ternary_exprt::check(expr);
+  return static_cast<ternary_exprt &>(expr);
+}
 
 /// Expression to hold a symbol (variable)
 class symbol_exprt : public nullary_exprt


### PR DESCRIPTION
This adds a set of additional formatters for `format_expr`.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
