### PR TITLE
Remove duplicate implementation of stash_variables

### DIFF
--- a/src/goto-instrument/accelerate/polynomial_accelerator.cpp
+++ b/src/goto-instrument/accelerate/polynomial_accelerator.cpp
@@ -730,32 +730,13 @@ void polynomial_acceleratort::stash_polynomials(
 {
   expr_sett modified;
   utils.find_modified(body, modified);
-  stash_variables(program, modified, substitution);
+  utils.stash_variables(program, modified, substitution);
 
   for(std::map<exprt, polynomialt>::iterator it=polynomials.begin();
       it!=polynomials.end();
       ++it)
   {
     it->second.substitute(substitution);
-  }
-}
-
-void polynomial_acceleratort::stash_variables(
-  scratch_programt &program,
-  expr_sett modified,
-  substitutiont &substitution)
-{
-  find_symbols_sett vars =
-    find_symbols_or_nexts(modified.begin(), modified.end());
-  irep_idt loop_counter_name=to_symbol_expr(loop_counter).get_identifier();
-  vars.erase(loop_counter_name);
-
-  for(const irep_idt &id : vars)
-  {
-    const symbolt &orig = symbol_table.lookup_ref(id);
-    symbolt stashed_sym=utils.fresh_symbol("polynomial::stash", orig.type);
-    substitution[orig.symbol_expr()]=stashed_sym.symbol_expr();
-    program.assign(stashed_sym.symbol_expr(), orig.symbol_expr());
   }
 }
 

--- a/src/goto-instrument/accelerate/polynomial_accelerator.h
+++ b/src/goto-instrument/accelerate/polynomial_accelerator.h
@@ -103,10 +103,6 @@ protected:
   bool check_inductive(
     std::map<exprt, polynomialt> polynomials,
     goto_programt::instructionst &body);
-  void stash_variables(
-    scratch_programt &program,
-    expr_sett modified,
-    substitutiont &substitution);
   void stash_polynomials(
     scratch_programt &program,
     std::map<exprt, polynomialt> &polynomials,


### PR DESCRIPTION
The implementation in acceleration_utilst has exactly the same code.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
