### PR TITLE
Symex slicing: fixes and cleanup

### DIFF
--- a/regression/cbmc/Malloc11/slice-formula.desc
+++ b/regression/cbmc/Malloc11/slice-formula.desc
@@ -1,0 +1,7 @@
+CORE broken-smt-backend
+main.c
+--pointer-check --slice-formula
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--

--- a/src/goto-symex/show_program.cpp
+++ b/src/goto-symex/show_program.cpp
@@ -38,7 +38,10 @@ static void show_step(
   std::string string_value = (step.is_shared_read() || step.is_shared_write())
                                ? from_expr(ns, function_id, step.ssa_lhs)
                                : from_expr(ns, function_id, step.cond_expr);
-  std::cout << '(' << count << ") ";
+  if(step.ignore)
+    std::cout << "(sliced) ";
+  else
+    std::cout << '(' << count << ") ";
   if(annotation.empty())
     std::cout << string_value;
   else

--- a/src/goto-symex/symex_slice_class.h
+++ b/src/goto-symex/symex_slice_class.h
@@ -30,7 +30,6 @@ protected:
   symbol_sett depends;
 
   void get_symbols(const exprt &expr);
-  void get_symbols(const typet &type);
 
   void slice(SSA_stept &SSA_step);
   void slice_assignment(SSA_stept &SSA_step);


### PR DESCRIPTION
Symex slicing previously failed to track symbols appearing in types.
This commit resolves this "TODO" and replaces the implementation by
find_symbols, which knows how to get this right.

Also make sure we don't unnecessarily track goto guards when the path
condition is made part of the assertion anyway. Employ simple_slice
before doing symbol-based slicing to avoid dragging in unnecessary
dependencies from after the last assertion.

Requires #6727.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
