### PR TITLE
CONTRACTS: Error-out on unknown functions (replace/enforce).

### DIFF
--- a/regression/contracts/enforce-replace-unknown-function/enforce.desc
+++ b/regression/contracts/enforce-replace-unknown-function/enforce.desc
@@ -1,0 +1,10 @@
+CORE
+main.c
+--enforce-contract goo
+^Function 'goo' was not found in the GOTO program.$
+^EXIT=6$
+^SIGNAL=0$
+--
+--
+Checks that attempting to enforce the contract of an unknown function creates
+an error.

--- a/regression/contracts/enforce-replace-unknown-function/main.c
+++ b/regression/contracts/enforce-replace-unknown-function/main.c
@@ -1,0 +1,4 @@
+int main()
+{
+  return 0;
+}

--- a/regression/contracts/enforce-replace-unknown-function/replace.desc
+++ b/regression/contracts/enforce-replace-unknown-function/replace.desc
@@ -1,0 +1,10 @@
+CORE
+main.c
+--replace-call-with-contract goo
+^Function 'goo' was not found in the GOTO program.$
+^EXIT=6$
+^SIGNAL=0$
+--
+--
+Checks that attempting call replacement with an unknown function creates an
+error.

--- a/src/goto-instrument/contracts/contracts.cpp
+++ b/src/goto-instrument/contracts/contracts.cpp
@@ -13,22 +13,6 @@ Date: February 2016
 
 #include "contracts.h"
 
-#include <algorithm>
-#include <map>
-
-#include <analyses/local_bitvector_analysis.h>
-#include <analyses/local_may_alias.h>
-
-#include <ansi-c/c_expr.h>
-
-#include <goto-instrument/havoc_utils.h>
-
-#include <goto-programs/goto_inline.h>
-#include <goto-programs/goto_program.h>
-#include <goto-programs/remove_skip.h>
-
-#include <langapi/language_util.h>
-
 #include <util/c_types.h>
 #include <util/exception_utils.h>
 #include <util/expr_util.h>
@@ -44,10 +28,23 @@ Date: February 2016
 #include <util/replace_symbol.h>
 #include <util/std_code.h>
 
+#include <goto-programs/goto_inline.h>
+#include <goto-programs/goto_program.h>
+#include <goto-programs/remove_skip.h>
+
+#include <analyses/local_bitvector_analysis.h>
+#include <analyses/local_may_alias.h>
+#include <ansi-c/c_expr.h>
+#include <goto-instrument/havoc_utils.h>
+#include <langapi/language_util.h>
+
 #include "havoc_assigns_clause_targets.h"
 #include "instrument_spec_assigns.h"
 #include "memory_predicates.h"
 #include "utils.h"
+
+#include <algorithm>
+#include <map>
 
 /// Decorator for \ref message_handlert that keeps track of warnings
 /// occuring when inlining a function.

--- a/src/goto-instrument/contracts/contracts.h
+++ b/src/goto-instrument/contracts/contracts.h
@@ -62,8 +62,13 @@ public:
   {
   }
 
-  /// \brief Replace all calls to each function in the list with that function's
-  ///        contract
+  /// Throws an exception if some function `functions` is found in the program.
+  void check_all_functions_found(const std::set<std::string> &functions) const;
+
+  /// \brief Replace all calls to each function in the `to_replace` set
+  /// with that function's contract
+  ///
+  /// Throws an exception if some `to_replace` functions are not found.
   ///
   /// Use this function when proving code that calls into an expensive function,
   /// `F`. You can write a contract for F using __CPROVER_requires and
@@ -73,12 +78,12 @@ public:
   /// actually abides by its `ensures` and `requires` clauses, you should
   /// separately call `code_constractst::enforce_contracts()` on `F` and verify
   /// it using `cbmc --function F`.
-  ///
-  /// \return `true` on failure, `false` otherwise
-  bool replace_calls(const std::set<std::string> &);
+  void replace_calls(const std::set<std::string> &to_replace);
 
   /// \brief Turn requires & ensures into assumptions and assertions for each of
   ///        the named functions
+  ///
+  /// Throws an exception if some `to_enforce` functions are not found.
   ///
   /// Use this function to prove the correctness of a function F independently
   /// of its calling context. If you have proved that F is correct, then you can
@@ -92,8 +97,7 @@ public:
   /// function called `F` that assumes `CF`'s `requires` clause, calls `CF`, and
   /// then asserts `CF`'s `ensures` clause.
   ///
-  /// \return `true` on failure, `false` otherwise
-  bool enforce_contracts(const std::set<std::string> &functions);
+  void enforce_contracts(const std::set<std::string> &to_enforce);
 
   void apply_loop_contracts();
 
@@ -125,10 +129,10 @@ protected:
   std::unordered_set<irep_idt> summarized;
 
   /// \brief Enforce contract of a single function
-  bool enforce_contract(const irep_idt &function);
+  void enforce_contract(const irep_idt &function);
 
   /// Instrument functions to check frame conditions.
-  bool check_frame_conditions_function(const irep_idt &function);
+  void check_frame_conditions_function(const irep_idt &function);
 
   /// Apply loop contracts, whenever available, to all loops in `function`.
   /// Loop invariants, loop variants, and loop assigns clauses.
@@ -139,7 +143,7 @@ protected:
   /// Replaces function calls with assertions based on requires clauses,
   /// non-deterministic assignments for the write set, and assumptions
   /// based on ensures clauses.
-  bool apply_function_contract(
+  void apply_function_contract(
     const irep_idt &function,
     const source_locationt &location,
     goto_programt &function_body,


### PR DESCRIPTION
goto-instrument now errors out when attempting to enforce or replace the contract of an unknown function. 

`replace_calls` and `enforce_contracts` are now checking that functions exist upfront and are failing fast by throwing exceptions from `util/exception_utils.h`, and are now returning void instead of a boolean error flag.

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [X] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- [X] White-space or formatting changes outside the feature-related changed lines are in commits of their own.
