### PR TITLE
Add conversion of overflow expressions into terms for the new incremental SMT support

### DIFF
--- a/regression/cbmc-incr-smt2/bitvector-flag-tests/signed_overflow.desc
+++ b/regression/cbmc-incr-smt2/bitvector-flag-tests/signed_overflow.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 signed_overflow.c
 --incremental-smt2-solver 'z3 --smt2 -in' --signed-overflow-check --trace
 ^VERIFICATION FAILED$

--- a/regression/cbmc/overflow/leftshift_overflow-c89.desc
+++ b/regression/cbmc/overflow/leftshift_overflow-c89.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 leftshift_overflow.c
 --signed-overflow-check --c89
 ^EXIT=10$

--- a/regression/cbmc/overflow/leftshift_overflow-c99.desc
+++ b/regression/cbmc/overflow/leftshift_overflow-c99.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 leftshift_overflow.c
 --signed-overflow-check --c99
 ^EXIT=10$

--- a/regression/cbmc/overflow/mod_overflow.desc
+++ b/regression/cbmc/overflow/mod_overflow.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 mod_overflow.c
 --signed-overflow-check
 ^EXIT=10$

--- a/regression/cbmc/overflow/signed_addition_overflow1.desc
+++ b/regression/cbmc/overflow/signed_addition_overflow1.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 signed_addition_overflow1.c
 --signed-overflow-check
 ^EXIT=10$

--- a/regression/cbmc/overflow/signed_addition_overflow2.desc
+++ b/regression/cbmc/overflow/signed_addition_overflow2.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 signed_addition_overflow2.c
 --signed-overflow-check
 ^EXIT=10$

--- a/regression/cbmc/overflow/signed_addition_overflow3.desc
+++ b/regression/cbmc/overflow/signed_addition_overflow3.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 signed_addition_overflow3.c
 --signed-overflow-check --conversion-check
 ^EXIT=10$

--- a/regression/cbmc/overflow/signed_addition_overflow4.desc
+++ b/regression/cbmc/overflow/signed_addition_overflow4.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 signed_addition_overflow4.c
 --signed-overflow-check --conversion-check
 ^EXIT=10$

--- a/regression/cbmc/overflow/signed_multiplication1.desc
+++ b/regression/cbmc/overflow/signed_multiplication1.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 signed_multiplication1.c
 --signed-overflow-check
 ^EXIT=0$

--- a/regression/cbmc/overflow/signed_subtraction1.desc
+++ b/regression/cbmc/overflow/signed_subtraction1.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 signed_subtraction1.c
 --signed-overflow-check
 ^EXIT=0$

--- a/regression/cbmc/overflow/unary_minus_overflow.desc
+++ b/regression/cbmc/overflow/unary_minus_overflow.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 unary_minus_overflow.c
 --signed-overflow-check --unsigned-overflow-check
 ^EXIT=10$

--- a/regression/cbmc/pragma_cprover2/test.desc
+++ b/regression/cbmc/pragma_cprover2/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 --signed-overflow-check
 ^\[main.overflow\.1\] line 21 arithmetic overflow on signed \+ in n \+ n: FAILURE$

--- a/regression/cbmc/set-property-inline1/test.desc
+++ b/regression/cbmc/set-property-inline1/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 --property inc.overflow.1 --property inc.overflow.2 --slice-formula --signed-overflow-check --conversion-check
 ^EXIT=10$

--- a/regression/contracts/variant_init_inside_loop/test.desc
+++ b/regression/contracts/variant_init_inside_loop/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 --apply-loop-contracts _ --unsigned-overflow-check
 ^\[main\.\d+\] .* Check loop invariant before entry: SUCCESS$

--- a/src/solvers/smt2_incremental/convert_expr_to_smt.cpp
+++ b/src/solvers/smt2_incremental/convert_expr_to_smt.cpp
@@ -833,6 +833,34 @@ static smt_termt convert_expr_to_smt(const isnormal_exprt &is_normal_expr)
     is_normal_expr.pretty());
 }
 
+static smt_termt convert_expr_to_smt(const plus_overflow_exprt &plus_overflow)
+{
+  UNIMPLEMENTED_FEATURE(
+    "Generation of SMT formula for plus overflow expression: " +
+    plus_overflow.pretty());
+}
+
+static smt_termt convert_expr_to_smt(const minus_overflow_exprt &minus_overflow)
+{
+  UNIMPLEMENTED_FEATURE(
+    "Generation of SMT formula for minus overflow expression: " +
+    minus_overflow.pretty());
+}
+
+static smt_termt convert_expr_to_smt(const mult_overflow_exprt &mult_overflow)
+{
+  UNIMPLEMENTED_FEATURE(
+    "Generation of SMT formula for multiply overflow expression: " +
+    mult_overflow.pretty());
+}
+
+static smt_termt convert_expr_to_smt(const shl_overflow_exprt &shl_overflow)
+{
+  UNIMPLEMENTED_FEATURE(
+    "Generation of SMT formula for shift left overflow expression: " +
+    shl_overflow.pretty());
+}
+
 static smt_termt convert_expr_to_smt(const array_exprt &array_construction)
 {
   UNIMPLEMENTED_FEATURE(
@@ -1143,6 +1171,26 @@ smt_termt convert_expr_to_smt(const exprt &expr)
   if(const auto is_normal_expr = expr_try_dynamic_cast<isnormal_exprt>(expr))
   {
     return convert_expr_to_smt(*is_normal_expr);
+  }
+  if(
+    const auto plus_overflow = expr_try_dynamic_cast<plus_overflow_exprt>(expr))
+  {
+    return convert_expr_to_smt(*plus_overflow);
+  }
+  if(
+    const auto minus_overflow =
+      expr_try_dynamic_cast<minus_overflow_exprt>(expr))
+  {
+    return convert_expr_to_smt(*minus_overflow);
+  }
+  if(
+    const auto mult_overflow = expr_try_dynamic_cast<mult_overflow_exprt>(expr))
+  {
+    return convert_expr_to_smt(*mult_overflow);
+  }
+  if(const auto shl_overflow = expr_try_dynamic_cast<shl_overflow_exprt>(expr))
+  {
+    return convert_expr_to_smt(*shl_overflow);
   }
   if(const auto array_construction = expr_try_dynamic_cast<array_exprt>(expr))
   {

--- a/src/solvers/smt2_incremental/smt_bit_vector_theory.h
+++ b/src/solvers/smt2_incremental/smt_bit_vector_theory.h
@@ -245,6 +245,7 @@ public:
     static smt_sortt return_sort(const smt_termt &operand);
     static void validate(const smt_termt &operand);
   };
+  /// \brief Arithmetic negation in two's complement.
   static const smt_function_application_termt::factoryt<negatet> negate;
 
   // Shift operations


### PR DESCRIPTION
This PR adds conversion of overflow expressions into terms for the new incremental SMT support.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
