### PR TITLE
Symex: ignore assignments to string constant even through type casts

### DIFF
--- a/regression/cbmc/string_assignment1/main.c
+++ b/regression/cbmc/string_assignment1/main.c
@@ -1,0 +1,15 @@
+typedef char array_t[2][2];
+
+void foo(array_t(*a))
+{
+  unsigned char i = 0;
+  unsigned char j = 0;
+  (*a)[i][j] = 0;
+}
+
+unsigned char main()
+{
+  char *x = "abcd";
+  foo(x);
+  __CPROVER_assert(x[0] == 'a', "a");
+}

--- a/regression/cbmc/string_assignment1/test.desc
+++ b/regression/cbmc/string_assignment1/test.desc
@@ -1,0 +1,12 @@
+CORE
+main.c
+
+^VERIFICATION SUCCESSFUL$
+^EXIT=0$
+^SIGNAL=0$
+--
+^l2_rename_rvalues case `array' not handled
+^warning: ignoring
+--
+The assignment to a C string constant should be ignored by symex, even when it
+happens via a type cast to a two-dimensional array.

--- a/src/goto-symex/goto_symex_state.h
+++ b/src/goto-symex/goto_symex_state.h
@@ -251,7 +251,8 @@ public:
     // simplifies to a plain constant.
     return lvalue.id() == ID_string_constant || lvalue.id() == ID_null_object ||
            lvalue.id() == "zero_string" || lvalue.id() == "is_zero_string" ||
-           lvalue.id() == "zero_string_length" || lvalue.id() == ID_constant;
+           lvalue.id() == "zero_string_length" || lvalue.id() == ID_constant ||
+           lvalue.id() == ID_array;
   }
 
 private:


### PR DESCRIPTION
We previously ignored various forms of strings already, but failed to
consider the case where an array was created by simplification due to
type casts.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
