### PR TITLE
Lift alloca's deallocation behaviour out of goto_check_ct

### DIFF
--- a/regression/cbmc-library/CMakeLists.txt
+++ b/regression/cbmc-library/CMakeLists.txt
@@ -3,8 +3,7 @@ add_test_pl_tests(
     "$<TARGET_FILE:cbmc>"
 )
 else()
-add_test_pl_tests(
-    "$<TARGET_FILE:cbmc>"
+add_test_pl_profile(
     "cbmc-library"
     "$<TARGET_FILE:cbmc>"
     "-C;-X;unix"

--- a/regression/cbmc-library/alloca-01/main.c
+++ b/regression/cbmc-library/alloca-01/main.c
@@ -9,4 +9,5 @@ int main()
   int *p = alloca(sizeof(int));
   *p = 42;
   free(p);
+  (void)alloca(sizeof(int)); // useless, but result still needs to be released
 }

--- a/src/ansi-c/goto_check_c.cpp
+++ b/src/ansi-c/goto_check_c.cpp
@@ -2188,28 +2188,6 @@ void goto_check_ct::goto_check(
               std::move(lhs), std::move(rhs), i.source_location()));
           t->code_nonconst().add_source_location() = i.source_location();
         }
-
-        if(
-          variable.type().id() == ID_pointer &&
-          function_identifier != "alloca" &&
-          (ns.lookup(variable.get_identifier()).base_name ==
-             "return_value___builtin_alloca" ||
-           ns.lookup(variable.get_identifier()).base_name ==
-             "return_value_alloca"))
-        {
-          // mark pointer to alloca result as dead
-          exprt lhs = ns.lookup(CPROVER_PREFIX "dead_object").symbol_expr();
-          exprt alloca_result =
-            typecast_exprt::conditional_cast(variable, lhs.type());
-          if_exprt rhs(
-            side_effect_expr_nondett(bool_typet(), i.source_location()),
-            std::move(alloca_result),
-            lhs);
-          goto_programt::targett t =
-            new_code.add(goto_programt::make_assignment(
-              std::move(lhs), std::move(rhs), i.source_location()));
-          t->code_nonconst().add_source_location() = i.source_location();
-        }
       }
     }
     else if(i.is_end_function())


### PR DESCRIPTION
alloca always results in deallocation taking place, and not just when
pointer checks are enabled.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
