### PR TITLE
Add separate overflow expr classes

### DIFF
--- a/src/ansi-c/c_typecheck_expr.cpp
+++ b/src/ansi-c/c_typecheck_expr.cpp
@@ -3161,7 +3161,7 @@ exprt c_typecheck_baset::do_special_functions(
 
     typecheck_expr_unary_arithmetic(tmp);
 
-    unary_overflow_exprt overflow{ID_unary_minus, tmp.operands().front()};
+    unary_minus_overflow_exprt overflow{tmp.operands().front()};
     overflow.add_source_location() = tmp.source_location();
     return std::move(overflow);
   }

--- a/src/ansi-c/expr2c.cpp
+++ b/src/ansi-c/expr2c.cpp
@@ -3921,7 +3921,7 @@ std::string expr2ct::convert_with_precedence(
     return convert_cond(src, precedence);
 
   else if(
-    src.id() == ID_overflow_unary_minus ||
+    can_cast_expr<unary_minus_overflow_exprt>(src) ||
     can_cast_expr<binary_overflow_exprt>(src))
   {
     return convert_overflow(src, precedence);

--- a/src/ansi-c/expr2c.cpp
+++ b/src/ansi-c/expr2c.cpp
@@ -3921,9 +3921,8 @@ std::string expr2ct::convert_with_precedence(
     return convert_cond(src, precedence);
 
   else if(
-    src.id() == ID_overflow_unary_minus || src.id() == ID_overflow_minus ||
-    src.id() == ID_overflow_mult || src.id() == ID_overflow_plus ||
-    src.id() == ID_overflow_shl)
+    src.id() == ID_overflow_unary_minus ||
+    can_cast_expr<binary_overflow_exprt>(src))
   {
     return convert_overflow(src, precedence);
   }

--- a/src/ansi-c/goto_check_c.cpp
+++ b/src/ansi-c/goto_check_c.cpp
@@ -1052,7 +1052,7 @@ void goto_check_ct::integer_overflow_check(
     std::string kind = type.id() == ID_unsignedbv ? "unsigned" : "signed";
 
     add_guarded_property(
-      not_exprt{unary_overflow_exprt{expr.id(), to_unary_expr(expr).op()}},
+      not_exprt{unary_minus_overflow_exprt{to_unary_expr(expr).op()}},
       "arithmetic overflow on " + kind + " " + expr.id_string(),
       "overflow",
       expr.find_source_location(),

--- a/src/solvers/flattening/boolbv.cpp
+++ b/src/solvers/flattening/boolbv.cpp
@@ -418,7 +418,7 @@ literalt boolbvt::convert_rest(const exprt &expr)
     return convert_onehot(to_unary_expr(expr));
   else if(
     can_cast_expr<binary_overflow_exprt>(expr) ||
-    expr.id() == ID_overflow_unary_minus)
+    can_cast_expr<unary_minus_overflow_exprt>(expr))
   {
     return convert_overflow(expr);
   }

--- a/src/solvers/flattening/boolbv.cpp
+++ b/src/solvers/flattening/boolbv.cpp
@@ -417,8 +417,7 @@ literalt boolbvt::convert_rest(const exprt &expr)
   else if(expr.id()==ID_onehot || expr.id()==ID_onehot0)
     return convert_onehot(to_unary_expr(expr));
   else if(
-    expr.id() == ID_overflow_plus || expr.id() == ID_overflow_mult ||
-    expr.id() == ID_overflow_minus || expr.id() == ID_overflow_shl ||
+    can_cast_expr<binary_overflow_exprt>(expr) ||
     expr.id() == ID_overflow_unary_minus)
   {
     return convert_overflow(expr);

--- a/src/solvers/flattening/boolbv_overflow.cpp
+++ b/src/solvers/flattening/boolbv_overflow.cpp
@@ -89,18 +89,17 @@ literalt boolbvt::convert_overflow(const exprt &expr)
       return !prop.lor(all_one, all_zero);
     }
   }
-  else if(expr.id() == ID_overflow_shl)
+  else if(
+    const auto shl_overflow = expr_try_dynamic_cast<shl_overflow_exprt>(expr))
   {
-    const auto &overflow_expr = to_binary_expr(expr);
-
-    const bvt &bv0 = convert_bv(overflow_expr.lhs());
-    const bvt &bv1 = convert_bv(overflow_expr.rhs());
+    const bvt &bv0 = convert_bv(shl_overflow->lhs());
+    const bvt &bv1 = convert_bv(shl_overflow->rhs());
 
     std::size_t old_size = bv0.size();
     std::size_t new_size = old_size * 2;
 
     bv_utilst::representationt rep =
-      overflow_expr.lhs().type().id() == ID_signedbv
+      shl_overflow->lhs().type().id() == ID_signedbv
         ? bv_utilst::representationt::SIGNED
         : bv_utilst::representationt::UNSIGNED;
 
@@ -109,7 +108,7 @@ literalt boolbvt::convert_overflow(const exprt &expr)
     bvt result=bv_utils.shift(bv_ext, bv_utilst::shiftt::SHIFT_LEFT, bv1);
 
     // a negative shift is undefined; yet this isn't an overflow
-    literalt neg_shift = overflow_expr.lhs().type().id() == ID_unsignedbv
+    literalt neg_shift = shl_overflow->lhs().type().id() == ID_unsignedbv
                            ? const_literal(false)
                            : bv1.back(); // sign bit
 

--- a/src/solvers/flattening/boolbv_overflow.cpp
+++ b/src/solvers/flattening/boolbv_overflow.cpp
@@ -6,9 +6,10 @@ Author: Daniel Kroening, kroening@kroening.com
 
 \*******************************************************************/
 
-#include "boolbv.h"
-
+#include <util/bitvector_expr.h>
 #include <util/invariant.h>
+
+#include "boolbv.h"
 
 literalt boolbvt::convert_overflow(const exprt &expr)
 {
@@ -32,25 +33,24 @@ literalt boolbvt::convert_overflow(const exprt &expr)
       bv_utils.overflow_sub(bv0, bv1, rep):
       bv_utils.overflow_add(bv0, bv1, rep);
   }
-  else if(expr.id()==ID_overflow_mult)
+  else if(
+    const auto mult_overflow = expr_try_dynamic_cast<mult_overflow_exprt>(expr))
   {
-    const auto &overflow_expr = to_binary_expr(expr);
-
     if(
-      overflow_expr.lhs().type().id() != ID_unsignedbv &&
-      overflow_expr.lhs().type().id() != ID_signedbv)
+      mult_overflow->lhs().type().id() != ID_unsignedbv &&
+      mult_overflow->lhs().type().id() != ID_signedbv)
       return SUB::convert_rest(expr);
 
-    bvt bv0 = convert_bv(overflow_expr.lhs());
-    bvt bv1 = convert_bv(overflow_expr.rhs(), bv0.size());
+    bvt bv0 = convert_bv(mult_overflow->lhs());
+    bvt bv1 = convert_bv(mult_overflow->rhs(), bv0.size());
 
     bv_utilst::representationt rep =
-      overflow_expr.lhs().type().id() == ID_signedbv
+      mult_overflow->lhs().type().id() == ID_signedbv
         ? bv_utilst::representationt::SIGNED
         : bv_utilst::representationt::UNSIGNED;
 
     DATA_INVARIANT(
-      overflow_expr.lhs().type() == overflow_expr.rhs().type(),
+      mult_overflow->lhs().type() == mult_overflow->rhs().type(),
       "operands of overflow_mult expression shall have same type");
 
     std::size_t old_size=bv0.size();

--- a/src/solvers/flattening/boolbv_overflow.cpp
+++ b/src/solvers/flattening/boolbv_overflow.cpp
@@ -161,11 +161,11 @@ literalt boolbvt::convert_overflow(const exprt &expr)
     return
       prop.land(!neg_shift, prop.lselect(undef, prop.lor(bv0), overflow));
   }
-  else if(expr.id()==ID_overflow_unary_minus)
+  else if(
+    const auto unary_minus_overflow =
+      expr_try_dynamic_cast<unary_minus_overflow_exprt>(expr))
   {
-    const auto &overflow_expr = to_unary_expr(expr);
-
-    const bvt &bv = convert_bv(overflow_expr.op());
+    const bvt &bv = convert_bv(unary_minus_overflow->op());
 
     return bv_utils.overflow_negate(bv);
   }

--- a/src/solvers/smt2/smt2_conv.cpp
+++ b/src/solvers/smt2/smt2_conv.cpp
@@ -1856,8 +1856,9 @@ void smt2_convt::convert_expr(const exprt &expr)
     else
       UNREACHABLE;
   }
-  else if(expr.id()==ID_overflow_plus ||
-          expr.id()==ID_overflow_minus)
+  else if(
+    can_cast_expr<plus_overflow_exprt>(expr) ||
+    can_cast_expr<minus_overflow_exprt>(expr))
   {
     const auto &op0 = to_binary_expr(expr).op0();
     const auto &op1 = to_binary_expr(expr).op1();
@@ -1866,7 +1867,7 @@ void smt2_convt::convert_expr(const exprt &expr)
       expr.type().id() == ID_bool,
       "overflow plus and overflow minus expressions shall be of Boolean type");
 
-    bool subtract=expr.id()==ID_overflow_minus;
+    bool subtract = can_cast_expr<minus_overflow_exprt>(expr);
     const typet &op_type = op0.type();
     std::size_t width=boolbv_width(op_type);
 

--- a/src/solvers/smt2/smt2_conv.cpp
+++ b/src/solvers/smt2/smt2_conv.cpp
@@ -1908,13 +1908,14 @@ void smt2_convt::convert_expr(const exprt &expr)
         "overflow check should not be performed on unsupported type",
         op_type.id_string());
   }
-  else if(expr.id()==ID_overflow_mult)
+  else if(
+    const auto mult_overflow = expr_try_dynamic_cast<mult_overflow_exprt>(expr))
   {
-    const auto &op0 = to_binary_expr(expr).op0();
-    const auto &op1 = to_binary_expr(expr).op1();
+    const auto &op0 = mult_overflow->op0();
+    const auto &op1 = mult_overflow->op1();
 
     DATA_INVARIANT(
-      expr.type().id() == ID_bool,
+      mult_overflow->type().id() == ID_bool,
       "overflow mult expression shall be of Boolean type");
 
     // No better idea than to multiply with double the bits and then compare

--- a/src/util/bitvector_expr.h
+++ b/src/util/bitvector_expr.h
@@ -892,6 +892,44 @@ inline void validate_expr(const unary_overflow_exprt &value)
     value, 1, "unary overflow expression must have one operand");
 }
 
+/// \brief A Boolean expression returning true, iff negation would result in an
+/// overflow when applied to the (single) operand.
+class unary_minus_overflow_exprt : public unary_overflow_exprt
+{
+public:
+  explicit unary_minus_overflow_exprt(exprt _op)
+    : unary_overflow_exprt(ID_unary_minus, std::move(_op))
+  {
+  }
+
+  static void check(
+    const exprt &expr,
+    const validation_modet vm = validation_modet::INVARIANT)
+  {
+    unary_exprt::check(expr, vm);
+  }
+
+  static void validate(
+    const exprt &expr,
+    const namespacet &,
+    const validation_modet vm = validation_modet::INVARIANT)
+  {
+    check(expr, vm);
+  }
+};
+
+template <>
+inline bool can_cast_expr<unary_minus_overflow_exprt>(const exprt &base)
+{
+  return base.id() == ID_overflow_unary_minus;
+}
+
+inline void validate_expr(const unary_minus_overflow_exprt &value)
+{
+  validate_operands(
+    value, 1, "unary minus overflow expression must have one operand");
+}
+
 /// \brief Cast an exprt to a \ref unary_overflow_exprt
 ///
 /// \a expr must be known to be \ref unary_overflow_exprt.

--- a/src/util/bitvector_expr.h
+++ b/src/util/bitvector_expr.h
@@ -705,10 +705,7 @@ class binary_overflow_exprt : public binary_predicate_exprt
 {
 public:
   binary_overflow_exprt(exprt _lhs, const irep_idt &kind, exprt _rhs)
-    : binary_predicate_exprt(
-        std::move(_lhs),
-        "overflow-" + id2string(kind),
-        std::move(_rhs))
+    : binary_predicate_exprt(std::move(_lhs), make_id(kind), std::move(_rhs))
   {
   }
 
@@ -735,13 +732,28 @@ public:
   {
     check(expr, vm);
   }
+
+  /// Returns true iff \p id is a valid identifier of a `binary_overflow_exprt`.
+  static bool valid_id(const irep_idt &id)
+  {
+    return id == ID_overflow_plus || id == ID_overflow_mult ||
+           id == ID_overflow_minus || id == ID_overflow_shl;
+  }
+
+private:
+  static irep_idt make_id(const irep_idt &kind)
+  {
+    if(valid_id(kind))
+      return kind;
+    else
+      return "overflow-" + id2string(kind);
+  }
 };
 
 template <>
 inline bool can_cast_expr<binary_overflow_exprt>(const exprt &base)
 {
-  return base.id() == ID_overflow_plus || base.id() == ID_overflow_mult ||
-         base.id() == ID_overflow_minus || base.id() == ID_overflow_shl;
+  return binary_overflow_exprt::valid_id(base.id());
 }
 
 inline void validate_expr(const binary_overflow_exprt &value)
@@ -776,6 +788,66 @@ inline binary_overflow_exprt &to_binary_overflow_expr(exprt &expr)
   binary_overflow_exprt &ret = static_cast<binary_overflow_exprt &>(expr);
   validate_expr(ret);
   return ret;
+}
+
+class plus_overflow_exprt : public binary_overflow_exprt
+{
+public:
+  plus_overflow_exprt(exprt _lhs, exprt _rhs)
+    : binary_overflow_exprt(std::move(_lhs), ID_overflow_plus, std::move(_rhs))
+  {
+  }
+};
+
+template <>
+inline bool can_cast_expr<plus_overflow_exprt>(const exprt &base)
+{
+  return base.id() == ID_overflow_plus;
+}
+
+class minus_overflow_exprt : public binary_overflow_exprt
+{
+public:
+  minus_overflow_exprt(exprt _lhs, exprt _rhs)
+    : binary_overflow_exprt(std::move(_lhs), ID_overflow_minus, std::move(_rhs))
+  {
+  }
+};
+
+template <>
+inline bool can_cast_expr<minus_overflow_exprt>(const exprt &base)
+{
+  return base.id() == ID_overflow_minus;
+}
+
+class mult_overflow_exprt : public binary_overflow_exprt
+{
+public:
+  mult_overflow_exprt(exprt _lhs, exprt _rhs)
+    : binary_overflow_exprt(std::move(_lhs), ID_overflow_mult, std::move(_rhs))
+  {
+  }
+};
+
+template <>
+inline bool can_cast_expr<mult_overflow_exprt>(const exprt &base)
+{
+  return base.id() == ID_overflow_mult;
+}
+
+class shl_overflow_exprt : public binary_overflow_exprt
+{
+public:
+  shl_overflow_exprt(exprt _lhs, exprt _rhs)
+    : binary_overflow_exprt(std::move(_lhs), ID_overflow_shl, std::move(_rhs))
+  {
+  }
+};
+
+template <>
+inline bool can_cast_expr<shl_overflow_exprt>(const exprt &base)
+{
+  return base.id() == ID_overflow_shl;
 }
 
 /// \brief A Boolean expression returning true, iff operation \c kind would

--- a/src/util/bitvector_expr.h
+++ b/src/util/bitvector_expr.h
@@ -707,6 +707,10 @@ public:
   binary_overflow_exprt(exprt _lhs, const irep_idt &kind, exprt _rhs)
     : binary_predicate_exprt(std::move(_lhs), make_id(kind), std::move(_rhs))
   {
+    INVARIANT(
+      valid_id(id()),
+      "The kind used to construct binary_overflow_exprt should be in the set "
+      "of expected valid kinds.");
   }
 
   static void check(

--- a/src/util/simplify_expr.cpp
+++ b/src/util/simplify_expr.cpp
@@ -2547,10 +2547,10 @@ simplify_exprt::resultt<> simplify_exprt::simplify_node(exprt node)
     r = simplify_complex(to_unary_expr(expr));
   }
   else if(
-    expr.id() == ID_overflow_plus || expr.id() == ID_overflow_minus ||
-    expr.id() == ID_overflow_mult || expr.id() == ID_overflow_shl)
+    const auto binary_overflow =
+      expr_try_dynamic_cast<binary_overflow_exprt>(expr))
   {
-    r = simplify_overflow_binary(to_binary_overflow_expr(expr));
+    r = simplify_overflow_binary(*binary_overflow);
   }
   else if(expr.id() == ID_overflow_unary_minus)
   {

--- a/src/util/simplify_expr.cpp
+++ b/src/util/simplify_expr.cpp
@@ -2224,7 +2224,7 @@ simplify_exprt::simplify_overflow_binary(const binary_overflow_exprt &expr)
     return unchanged(expr);
 
   mp_integer no_overflow_result;
-  if(expr.id() == ID_overflow_plus)
+  if(can_cast_expr<plus_overflow_exprt>(expr))
     no_overflow_result = *op0_value + *op1_value;
   else if(can_cast_expr<minus_overflow_exprt>(expr))
     no_overflow_result = *op0_value - *op1_value;

--- a/src/util/simplify_expr.cpp
+++ b/src/util/simplify_expr.cpp
@@ -2278,7 +2278,7 @@ simplify_exprt::simplify_overflow_unary(const unary_overflow_exprt &expr)
     return unchanged(expr);
 
   mp_integer no_overflow_result;
-  if(expr.id() == ID_overflow_unary_minus)
+  if(can_cast_expr<unary_minus_overflow_exprt>(expr))
     no_overflow_result = -*op_value;
   else
     UNREACHABLE;
@@ -2552,9 +2552,11 @@ simplify_exprt::resultt<> simplify_exprt::simplify_node(exprt node)
   {
     r = simplify_overflow_binary(*binary_overflow);
   }
-  else if(expr.id() == ID_overflow_unary_minus)
+  else if(
+    const auto unary_overflow =
+      expr_try_dynamic_cast<unary_overflow_exprt>(expr))
   {
-    r = simplify_overflow_unary(to_unary_overflow_expr(expr));
+    r = simplify_overflow_unary(*unary_overflow);
   }
   else if(expr.id() == ID_bitreverse)
   {

--- a/src/util/simplify_expr.cpp
+++ b/src/util/simplify_expr.cpp
@@ -2189,7 +2189,7 @@ simplify_exprt::simplify_overflow_binary(const binary_overflow_exprt &expr)
 
   // One is neutral element for multiplication
   if(
-    expr.id() == ID_overflow_mult &&
+    can_cast_expr<mult_overflow_exprt>(expr) &&
     (expr.op0().is_one() || expr.op1().is_one()))
   {
     return false_exprt{};
@@ -2228,7 +2228,7 @@ simplify_exprt::simplify_overflow_binary(const binary_overflow_exprt &expr)
     no_overflow_result = *op0_value + *op1_value;
   else if(can_cast_expr<minus_overflow_exprt>(expr))
     no_overflow_result = *op0_value - *op1_value;
-  else if(expr.id() == ID_overflow_mult)
+  else if(can_cast_expr<mult_overflow_exprt>(expr))
     no_overflow_result = *op0_value * *op1_value;
   else if(expr.id() == ID_overflow_shl)
     no_overflow_result = *op0_value << *op1_value;

--- a/src/util/simplify_expr.cpp
+++ b/src/util/simplify_expr.cpp
@@ -2182,7 +2182,7 @@ simplify_exprt::simplify_overflow_binary(const binary_overflow_exprt &expr)
   // zero.
   if(
     expr.op1().is_zero() ||
-    (expr.op0().is_zero() && expr.id() != ID_overflow_minus))
+    (expr.op0().is_zero() && !can_cast_expr<minus_overflow_exprt>(expr)))
   {
     return false_exprt{};
   }
@@ -2208,7 +2208,7 @@ simplify_exprt::simplify_overflow_binary(const binary_overflow_exprt &expr)
     return false_exprt{};
   }
 
-  if(op_type_id == ID_natural && expr.id() != ID_overflow_minus)
+  if(op_type_id == ID_natural && !can_cast_expr<minus_overflow_exprt>(expr))
     return false_exprt{};
 
   // we only handle constants over signedbv/unsignedbv for the remaining cases
@@ -2226,7 +2226,7 @@ simplify_exprt::simplify_overflow_binary(const binary_overflow_exprt &expr)
   mp_integer no_overflow_result;
   if(expr.id() == ID_overflow_plus)
     no_overflow_result = *op0_value + *op1_value;
-  else if(expr.id() == ID_overflow_minus)
+  else if(can_cast_expr<minus_overflow_exprt>(expr))
     no_overflow_result = *op0_value - *op1_value;
   else if(expr.id() == ID_overflow_mult)
     no_overflow_result = *op0_value * *op1_value;

--- a/src/util/simplify_expr.cpp
+++ b/src/util/simplify_expr.cpp
@@ -2230,7 +2230,7 @@ simplify_exprt::simplify_overflow_binary(const binary_overflow_exprt &expr)
     no_overflow_result = *op0_value - *op1_value;
   else if(can_cast_expr<mult_overflow_exprt>(expr))
     no_overflow_result = *op0_value * *op1_value;
-  else if(expr.id() == ID_overflow_shl)
+  else if(can_cast_expr<shl_overflow_exprt>(expr))
     no_overflow_result = *op0_value << *op1_value;
   else
     UNREACHABLE;

--- a/unit/Makefile
+++ b/unit/Makefile
@@ -123,6 +123,7 @@ SRC += analyses/ai/ai.cpp \
        solvers/strings/string_refinement/string_refinement.cpp \
        solvers/strings/string_refinement/substitute_array_list.cpp \
        solvers/strings/string_refinement/union_find_replace.cpp \
+       util/bitvector_expr.cpp \
        util/cmdline.cpp \
        util/dense_integer_map.cpp \
        util/edit_distance.cpp \

--- a/unit/util/bitvector_expr.cpp
+++ b/unit/util/bitvector_expr.cpp
@@ -1,0 +1,66 @@
+// Author: Diffblue Ltd.
+
+#include <util/bitvector_expr.h>
+#include <util/bitvector_types.h>
+
+#include <testing-utils/use_catch.h>
+
+TEST_CASE(
+  "Overflow expression construction as binary_overflow_exprt",
+  "[core][util][expr]")
+{
+  std::string kind;
+  std::function<bool(const exprt &)> can_cast;
+  using rowt = std::pair<std::string, std::function<bool(const exprt &)>>;
+  std::tie(kind, can_cast) = GENERATE(
+    rowt{"+", can_cast_expr<plus_overflow_exprt>},
+    rowt{"*", can_cast_expr<mult_overflow_exprt>},
+    rowt{"-", can_cast_expr<minus_overflow_exprt>},
+    rowt{"shl", can_cast_expr<shl_overflow_exprt>});
+  SECTION("For " + kind + " overflow.")
+  {
+    const symbol_exprt left{"left", unsignedbv_typet{8}};
+    const symbol_exprt right{"right", unsignedbv_typet{8}};
+    const binary_overflow_exprt overflow{left, kind, right};
+    SECTION("Expression can be downcast.")
+    {
+      REQUIRE(can_cast(overflow));
+    }
+    SECTION("Operand getters")
+    {
+      REQUIRE(overflow.lhs() == left);
+      REQUIRE(overflow.rhs() == right);
+    }
+  }
+}
+
+TEMPLATE_TEST_CASE(
+  "Overflow expression sub classes",
+  "[core][util][expr]",
+  plus_overflow_exprt,
+  mult_overflow_exprt,
+  minus_overflow_exprt,
+  shl_overflow_exprt)
+{
+  SECTION("Construction")
+  {
+    const symbol_exprt left{"left", unsignedbv_typet{8}};
+    const symbol_exprt right{"right", unsignedbv_typet{8}};
+    const TestType sub_class{left, right};
+    SECTION("Upcast")
+    {
+      const auto binary_overflow_expr =
+        expr_try_dynamic_cast<binary_overflow_exprt>(sub_class);
+      REQUIRE(binary_overflow_expr);
+      SECTION("Downcast")
+      {
+        REQUIRE(expr_try_dynamic_cast<TestType>(*binary_overflow_expr));
+      }
+    }
+    SECTION("Operand getters")
+    {
+      REQUIRE(sub_class.lhs() == left);
+      REQUIRE(sub_class.rhs() == right);
+    }
+  }
+}


### PR DESCRIPTION
This PR adds separate overflow expr classes. It is split out from https://github.com/diffblue/cbmc/pull/6736 so that the `expr` and smt changes can be reviewed separately.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
