### PR TITLE
Simplify index: ensure consistent types

### DIFF
--- a/src/util/simplify_expr_array.cpp
+++ b/src/util/simplify_expr_array.cpp
@@ -183,8 +183,10 @@ simplify_exprt::simplify_index(const index_exprt &expr)
         return unchanged(expr);
 
       // add offset to index
-      exprt offset = simplify_mult(mult_exprt{
-        from_integer(*sub_size, byte_extract_expr.offset().type()), index});
+      exprt offset = simplify_rec(mult_exprt{
+        from_integer(*sub_size, byte_extract_expr.offset().type()),
+        typecast_exprt::conditional_cast(
+          index, byte_extract_expr.offset().type())});
       exprt final_offset =
         simplify_plus(plus_exprt(byte_extract_expr.offset(), offset));
 


### PR DESCRIPTION
When computing a new offset for a byte extract, do not implicitly assume
that byte-extract offsets and array index operations use exactly the
same type for we don't prescribe the type to use as a byte-extract
offset.

Fixes: #6298

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
