### PR TITLE
New option --mmio-region to specify memory regions

### DIFF
--- a/doc/cprover-manual/modeling-mmio.md
+++ b/doc/cprover-manual/modeling-mmio.md
@@ -71,7 +71,44 @@ the methods in the API.
 
 *If the device has no API,* meaning that the code refers directly to the address
 in the memory-mapped I/O region for the device without reference to accessor
-functions, use
+functions, there are two approaches available.
+
+#### Per-region object model (recommended)
+
+Use `--mmio-region <address>:<size>` (with `goto-instrument` or `cbmc`) to
+declare each contiguous MMIO region as an individual object. Each region becomes
+a byte array in the symbol table, named `__CPROVER_mmio_region_0x<address>`.
+Reads and writes to addresses within a declared region are redirected to the
+corresponding array element.
+
+This approach avoids the scalability problems of the single-array callback model:
+each write only updates the targeted region object rather than the entire memory
+array.
+
+For example, given firmware that accesses a UART at `0x40000000` (256 bytes) and
+a GPIO controller at `0x40001000` (64 bytes):
+
+```sh
+goto-cc -o firmware.gb firmware.c
+goto-instrument --mmio-region 0x40000000:256 \
+  --mmio-region 0x40001000:64 \
+  firmware.gb firmware-mod.gb
+cbmc --no-pointer-check --no-bounds-check firmware-mod.gb
+```
+
+The `--no-pointer-check` and `--no-bounds-check` flags are needed because
+integer addresses used for MMIO are not valid pointers from CBMC's perspective.
+
+Constant addresses are mapped directly to a specific array element at
+instrumentation time. Symbolic addresses (e.g., a pointer that could refer to
+either region) are handled via a conditional dispatch over all declared regions.
+
+Regions must not overlap; `goto-instrument` will report an error if overlapping
+regions are specified.
+
+#### Callback model
+
+Alternatively, use
 ```C
 __CPROVER_mm_io_r(address, size)
 __CPROVER_mm_io_w(address, size, value)
@@ -89,3 +126,13 @@ char __CPROVER_mm_io_r(void *a, unsigned s) {
 ```
 will return the value 2 upon any access at address 0x1000, and return a
 non-deterministic value in all other cases.
+
+The callback model can be combined with `--mmio-region`: per-region
+instrumentation runs first to give declared regions precise array-backed
+modeling, and the callbacks then handle any remaining dereferences. This is
+useful when some regions need custom read/write behaviour beyond simple
+nondeterministic access.
+
+Note that the callback model uses a single unbounded `__CPROVER_memory` array,
+which means every write implies an update of the entire array. For programs with
+many MMIO regions, the per-region object model described above is preferred.

--- a/doc/cprover-manual/modeling-mmio.md
+++ b/doc/cprover-manual/modeling-mmio.md
@@ -28,17 +28,26 @@ as an out-of-bounds memory reference. This is an example of
 implementation-defined behavior that must be modeled to avoid reporting false
 positives.
 
-CBMC uses the built-in function `__CPROVER_allocated_memory(address, size)` to
-mark ranges of memory as valid. Accesses within this region are exempt from the
-out-of-bounds assertion checking that CBMC would normally do. The function
-declares the half-open interval [address, address + size) as valid memory that
-can be read and written.
+CBMC provides two mechanisms for declaring memory-mapped I/O regions:
 
-This function can be used anywhere in the source code, but is most commonly used
-in the verification harness. Note that there is no flow sensitivity or scope
-restriction: CBMC considers accesses to memory regions marked as above valid for
-read or write access even before the call to the built-in function is
-encountered.
+1. **`--mmio-region address:size` (recommended):** Declare regions on the
+   command line. Each region becomes a byte-array object in the symbol table.
+   Reads and writes to addresses within a declared region are redirected to the
+   corresponding array element. See the
+   [per-region object model](#per-region-object-model-recommended) section below.
+
+2. **`__CPROVER_allocated_memory(address, size)` (deprecated):** A built-in
+   function that marks the half-open interval [address, address + size) as valid
+   memory. Accesses within this region are exempt from out-of-bounds assertion
+   checking. This function can be used anywhere in the source code, but is most
+   commonly used in the verification harness. Note that there is no flow
+   sensitivity or scope restriction: CBMC considers accesses to memory regions
+   marked as above valid for read or write access even before the call to the
+   built-in function is encountered.
+
+> **Deprecation notice:** `__CPROVER_allocated_memory` is deprecated. Use
+> `--mmio-region` instead, which provides better scalability and does not
+> require source-code changes.
 
 ### Device behavior
 

--- a/doc/cprover-manual/modeling-mmio.md
+++ b/doc/cprover-manual/modeling-mmio.md
@@ -75,11 +75,16 @@ functions, there are two approaches available.
 
 #### Per-region object model (recommended)
 
-Use `--mmio-region <address>:<size>` (with `goto-instrument` or `cbmc`) to
-declare each contiguous MMIO region as an individual object. Each region becomes
-a byte array in the symbol table, named `__CPROVER_mmio_region_0x<address>`.
-Reads and writes to addresses within a declared region are redirected to the
-corresponding array element.
+Use `--mmio-region <address>:<size>` to declare each
+contiguous MMIO region as an individual object. Each region becomes a byte array
+in the symbol table, named `__CPROVER_mmio_region_0x<address>`. Reads and writes
+to addresses within a declared region are redirected to the corresponding bytes
+of that array. An access wider than a single byte spans the appropriate number
+of consecutive bytes (`ceil(width / 8)`), honouring the endianness configured
+for the program, so multi-byte loads and stores are modelled faithfully (a
+32-bit store updates four bytes rather than truncating to one).
+
+This option is supported by both `cbmc` and `goto-instrument`.
 
 This approach avoids the scalability problems of the single-array callback model:
 each write only updates the targeted region object rather than the entire memory
@@ -89,6 +94,12 @@ For example, given firmware that accesses a UART at `0x40000000` (256 bytes) and
 a GPIO controller at `0x40001000` (64 bytes):
 
 ```sh
+# Directly with cbmc:
+cbmc --mmio-region 0x40000000:256 \
+  --mmio-region 0x40001000:64 \
+  --no-pointer-check --no-bounds-check firmware.c
+
+# Or via goto-instrument:
 goto-cc -o firmware.gb firmware.c
 goto-instrument --mmio-region 0x40000000:256 \
   --mmio-region 0x40001000:64 \
@@ -99,12 +110,17 @@ cbmc --no-pointer-check --no-bounds-check firmware-mod.gb
 The `--no-pointer-check` and `--no-bounds-check` flags are needed because
 integer addresses used for MMIO are not valid pointers from CBMC's perspective.
 
-Constant addresses are mapped directly to a specific array element at
-instrumentation time. Symbolic addresses (e.g., a pointer that could refer to
+Constant addresses are resolved at instrumentation time to a byte offset within
+the region's array. Symbolic addresses (e.g., a pointer that could refer to
 either region) are handled via a conditional dispatch over all declared regions.
 
-Regions must not overlap; `goto-instrument` will report an error if overlapping
-regions are specified.
+Regions must not overlap; both `cbmc` and `goto-instrument` will report an
+error if overlapping regions are specified.
+
+Storing and loading C pointer values through an MMIO region is not fully
+supported: a pointer written to a region is serialised to its bytes, and
+reading it back does not reconstruct the original pointer's object identity.
+Such accesses may therefore be modelled imprecisely.
 
 #### Callback model
 

--- a/doc/man/cbmc.1
+++ b/doc/man/cbmc.1
@@ -322,6 +322,29 @@ print test suite for coverage criterion (requires \fB\-\-cover\fR)
 \fB\-\-mm\fR MM
 memory consistency model for concurrent programs (default: sc)
 .TP
+\fB\-\-mmio\-region\fR \fIaddress\fR:\fIsize\fR
+Define a contiguous memory\-mapped I/O region starting at \fIaddress\fR with the
+given \fIsize\fR in bytes. The \fIaddress\fR may use a \fB0x\fR prefix for
+hexadecimal notation. This option may be repeated to define multiple regions.
+Regions must not overlap.
+.IP
+Each region is modeled as an individual byte\-array object in the symbol table.
+Reads from and writes to constant addresses that fall within a declared region
+are mapped directly to the corresponding array element. Symbolic addresses are
+handled via a conditional dispatch over all declared regions.
+.IP
+Use \fB\-\-no\-pointer\-check\fR and \fB\-\-no\-bounds\-check\fR when verifying
+programs with MMIO regions, since integer addresses used for memory\-mapped I/O
+are not valid pointers from CBMC's perspective.
+.IP
+Example:
+.EX
+.in +4n
+cbmc \-\-mmio\-region 0x40000000:256 \-\-mmio\-region 0x40001000:64 \\
+  \-\-no\-pointer\-check \-\-no\-bounds\-check firmware.c
+.in
+.EE
+.TP
 \fB\-\-malloc\-may\-fail\fR
 allow malloc calls to return a null pointer
 .TP

--- a/doc/man/goto-instrument.1
+++ b/doc/man/goto-instrument.1
@@ -407,6 +407,8 @@ This per\-region model avoids the scalability problems of the single unbounded
 write only updates the targeted region object rather than the entire memory
 array. Both options can be combined.
 .IP
+This option is also supported directly by \fBcbmc\fR(1).
+.IP
 Example:
 .EX
 .in +4n

--- a/doc/man/goto-instrument.1
+++ b/doc/man/goto-instrument.1
@@ -386,7 +386,36 @@ Now the final invocation of \fBcbmc\fR(1) reports verification success.
 instruments an interrupt service routine
 .TP
 \fB\-\-mmio\fR
-instruments memory\-mapped I/O
+instruments memory\-mapped I/O using the callback model
+(\fB__CPROVER_mm_io_r\fR / \fB__CPROVER_mm_io_w\fR).
+Can be combined with \fB\-\-mmio\-region\fR to add custom read/write handlers
+on top of per\-region modeling.
+.TP
+\fB\-\-mmio\-region\fR \fIaddress\fR:\fIsize\fR
+Define a contiguous memory\-mapped I/O region starting at \fIaddress\fR with the
+given \fIsize\fR in bytes. The \fIaddress\fR may use a \fB0x\fR prefix for
+hexadecimal notation. This option may be repeated to define multiple regions.
+Regions must not overlap.
+.IP
+Each region is modeled as an individual byte\-array object in the symbol table.
+Reads from and writes to constant addresses that fall within a declared region
+are mapped directly to the corresponding array element. Symbolic addresses are
+handled via a conditional dispatch over all declared regions.
+.IP
+This per\-region model avoids the scalability problems of the single unbounded
+\fB__CPROVER_memory\fR array used by the \fB\-\-mmio\fR callback model: each
+write only updates the targeted region object rather than the entire memory
+array. Both options can be combined.
+.IP
+Example:
+.EX
+.in +4n
+goto\-cc \-o firmware.gb firmware.c
+goto\-instrument \-\-mmio\-region 0x40000000:256 \\
+  \-\-mmio\-region 0x40001000:64 firmware.gb firmware\-mod.gb
+cbmc \-\-no\-pointer\-check \-\-no\-bounds\-check firmware\-mod.gb
+.in
+.EE
 .TP
 \fB\-\-nondet\-static\fR
 add nondeterministic initialization of variables with static lifetime

--- a/regression/cbmc-incr-smt2/pointers-conversions/pointer_from_int.c
+++ b/regression/cbmc-incr-smt2/pointers-conversions/pointer_from_int.c
@@ -1,7 +1,9 @@
 int main()
 {
   int *p = (int *)4;
+#ifndef CMDLINE
   __CPROVER_allocated_memory(4, sizeof(int));
+#endif
 
   __CPROVER_assert(p == 4, "p == 4: expected success");
   __CPROVER_assert(p != 0, "p != 0: expected success");

--- a/regression/cbmc-incr-smt2/pointers-conversions/pointer_from_int_cmdline.desc
+++ b/regression/cbmc-incr-smt2/pointers-conversions/pointer_from_int_cmdline.desc
@@ -1,0 +1,15 @@
+CORE
+pointer_from_int.c
+-DCMDLINE --mmio-region 0x4:4 --trace --no-pointer-check --no-bounds-check
+\[main\.assertion\.1\] line \d+ p == 4: expected success: SUCCESS
+\[main\.assertion\.2\] line \d+ p != 0: expected success: SUCCESS
+\[main\.assertion\.3\] line \d+ p == 0x1020304: expected success: SUCCESS
+\[main\.assertion\.4\] line \d+ p != 0: expected success: SUCCESS
+\[main\.assertion\.5\] line \d+ p != 0: expected failure: FAILURE
+^VERIFICATION FAILED$
+^EXIT=10$
+^SIGNAL=0$
+--
+--
+Same as pointer_from_int.desc but uses --mmio-region instead of
+__CPROVER_allocated_memory.

--- a/regression/cbmc/Pointer28/cmdline.desc
+++ b/regression/cbmc/Pointer28/cmdline.desc
@@ -1,0 +1,11 @@
+KNOWNBUG no-new-smt
+main.c
+-DCMDLINE --mmio-region 0x4:4 --mmio-region 0x8:8 --little-endian --no-pointer-check --no-bounds-check
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring
+--
+The per-region byte-array model does not support storing and loading
+pointer values through MMIO regions, so the **q test case fails.

--- a/regression/cbmc/Pointer28/main.c
+++ b/regression/cbmc/Pointer28/main.c
@@ -1,7 +1,9 @@
 int main()
 {
   int *p = (int *)4;
+#ifndef CMDLINE
   __CPROVER_allocated_memory(4, sizeof(int));
+#endif
   int i;
   int **q;
   char *pp;
@@ -21,7 +23,9 @@ int main()
     __CPROVER_assert(p == 0, "i==0 => p==NULL");
 
   q = (int **)8;
+#ifndef CMDLINE
   __CPROVER_allocated_memory(8, sizeof(int *));
+#endif
   *q = &i;
   **q = 0x01020304;
   __CPROVER_assert(i == 0x01020304, "**q");

--- a/regression/cbmc/memory_allocation1/cmdline.desc
+++ b/regression/cbmc/memory_allocation1/cmdline.desc
@@ -1,0 +1,10 @@
+CORE broken-smt-backend paths-lifo-expected-failure
+main.c
+-DCMDLINE --mmio-region 0x10:4 --no-pointer-check --no-bounds-check
+^EXIT=10$
+^SIGNAL=0$
+^\[main\.assertion\.1\] .* assertion \*p==42: SUCCESS$
+^\[main\.mmio-region\.2\] .* MMIO write address must be within a declared region: FAILURE$
+^VERIFICATION FAILED$
+--
+^warning: ignoring

--- a/regression/cbmc/memory_allocation1/main.c
+++ b/regression/cbmc/memory_allocation1/main.c
@@ -4,7 +4,9 @@ int main()
 {
   int *p=0x10;
 
+#ifndef CMDLINE
   __CPROVER_allocated_memory(0x10, sizeof(int));
+#endif
   *p=42;
   assert(*p==42);
   *(p+1)=42;

--- a/regression/cbmc/memory_allocation2/cmdline.desc
+++ b/regression/cbmc/memory_allocation2/cmdline.desc
@@ -1,0 +1,10 @@
+CORE
+main.c
+-DCMDLINE --mmio-region 0x1000:400 --mmio-region 0x11000:400 --mmio-region 0x21000:400 --mmio-region 0x31000:400 --no-pointer-check --no-bounds-check
+^EXIT=0$
+^SIGNAL=0$
+^\[main\.assertion\.1\] .* assertion buffers\[0\]->buffer\[0\] == 42: SUCCESS$
+^\[main\.assertion\.2\] .* assertion buffers\[1\]->buffer\[BUFFER_SIZE - 1\] == 99: SUCCESS$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring

--- a/regression/cbmc/memory_allocation2/main.c
+++ b/regression/cbmc/memory_allocation2/main.c
@@ -1,3 +1,7 @@
+#ifdef CMDLINE
+#  include <assert.h>
+#endif
+
 #define _cbmc_printf2(str, var)                                                \
   {                                                                            \
     unsigned int ValueOf_##str = (unsigned int)var;                            \
@@ -24,10 +28,12 @@ static buffert(*const buffers[4]) = {BUF0, BUF1, BUF2, BUF3};
 
 main()
 {
+#ifndef CMDLINE
   __CPROVER_allocated_memory(BUF0_BASE, sizeof(buffert));
   __CPROVER_allocated_memory(BUF1_BASE, sizeof(buffert));
   __CPROVER_allocated_memory(BUF2_BASE, sizeof(buffert));
   __CPROVER_allocated_memory(BUF3_BASE, sizeof(buffert));
+#endif
 
   _cbmc_printf2(sizeof_buffers, sizeof(buffers));
   _cbmc_printf2(sizeof_buffers_0, sizeof(buffers[0]));
@@ -36,4 +42,13 @@ main()
   buffers[0]->buffer[0];
   buffers[0]->buffer[BUFFER_SIZE - 1];
   buffers[0]->buffer[BUFFER_SIZE]; // should be out-of-bounds
+
+#ifdef CMDLINE
+  // With --mmio-region, verify write-then-read round-trips through the
+  // byte-array-backed region.
+  buffers[0]->buffer[0] = 42;
+  assert(buffers[0]->buffer[0] == 42);
+  buffers[1]->buffer[BUFFER_SIZE - 1] = 99;
+  assert(buffers[1]->buffer[BUFFER_SIZE - 1] == 99);
+#endif
 }

--- a/regression/cbmc/memory_allocation2/test.desc
+++ b/regression/cbmc/memory_allocation2/test.desc
@@ -4,7 +4,7 @@ main.c
 ^EXIT=10$
 ^SIGNAL=0$
 ^\[main\.array_bounds\.[1-2]\] .*: SUCCESS$
-^\[main\.array_bounds\.3\] line 38 array.buffer (dynamic object )?upper bound in buffers\[(\(signed long (long )?int\))?0\]->buffer\[(\(signed long (long )?int\))?100\]: FAILURE$
+^\[main\.array_bounds\.3\] line 44 array.buffer (dynamic object )?upper bound in buffers\[(\(signed long (long )?int\))?0\]->buffer\[(\(signed long (long )?int\))?100\]: FAILURE$
 ^\*\* 1 of \d failed
 ^VERIFICATION FAILED$
 --

--- a/regression/cbmc/mmio_bad_values/main.c
+++ b/regression/cbmc/mmio_bad_values/main.c
@@ -1,0 +1,4 @@
+int main()
+{
+  return 0;
+}

--- a/regression/cbmc/mmio_bad_values/test.desc
+++ b/regression/cbmc/mmio_bad_values/test.desc
@@ -1,0 +1,7 @@
+CORE
+main.c
+--mmio-region 0x1000:0
+^EXIT=1$
+^SIGNAL=0$
+MMIO region size must be positive
+--

--- a/regression/cbmc/mmio_invalid_number/main.c
+++ b/regression/cbmc/mmio_invalid_number/main.c
@@ -1,0 +1,4 @@
+int main()
+{
+  return 0;
+}

--- a/regression/cbmc/mmio_invalid_number/test.desc
+++ b/regression/cbmc/mmio_invalid_number/test.desc
@@ -1,0 +1,10 @@
+CORE
+main.c
+--mmio-region xyz:abc
+^EXIT=1$
+^SIGNAL=0$
+invalid number 'xyz' in MMIO region: xyz:abc
+--
+--
+Non-numeric MMIO region fields must be rejected rather than silently parsed as
+0 (which would create a bogus region). See also 0x-prefixed non-hex digits.

--- a/regression/cbmc/mmio_multibyte/main.c
+++ b/regression/cbmc/mmio_multibyte/main.c
@@ -1,0 +1,16 @@
+int main()
+{
+  // A 32-bit MMIO store must update all four bytes rather than truncating to
+  // a single byte, and a 32-bit load must read all four back.
+  volatile unsigned int *w = (volatile unsigned int *)0x1000;
+  *w = 0x12345678;
+  __CPROVER_assert(*w == 0x12345678, "32-bit MMIO value round-trips");
+
+  // The store spans consecutive bytes in little-endian order.
+  volatile unsigned char *b = (volatile unsigned char *)0x1000;
+  __CPROVER_assert(b[0] == 0x78, "byte 0 (LSB)");
+  __CPROVER_assert(b[1] == 0x56, "byte 1");
+  __CPROVER_assert(b[2] == 0x34, "byte 2");
+  __CPROVER_assert(b[3] == 0x12, "byte 3 (MSB)");
+  return 0;
+}

--- a/regression/cbmc/mmio_multibyte/test.desc
+++ b/regression/cbmc/mmio_multibyte/test.desc
@@ -1,0 +1,14 @@
+CORE
+main.c
+--mmio-region 0x1000:256 --little-endian --no-pointer-check --no-bounds-check
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+Replaced MMIO operations
+--
+--
+A 32-bit MMIO store must update all four region bytes (little-endian) and a
+32-bit load must read them all back. Without the byte_extract/byte_update
+multi-byte modelling the store would truncate to a single byte and the
+`*w == 0x12345678` assertion would fail. This guards the per-region multi-byte
+access soundness.

--- a/regression/cbmc/mmio_out_of_range/main.c
+++ b/regression/cbmc/mmio_out_of_range/main.c
@@ -1,0 +1,21 @@
+#include <stdint.h>
+
+int nondet_int(void);
+
+int main()
+{
+  if(nondet_int())
+  {
+    // Write to an address outside the declared region
+    volatile char *p = (volatile char *)0x3000;
+    *p = 42;
+  }
+  else
+  {
+    // Read from an address outside the declared region
+    volatile char *q = (volatile char *)0x4000;
+    char v = *q;
+  }
+
+  return 0;
+}

--- a/regression/cbmc/mmio_out_of_range/test.desc
+++ b/regression/cbmc/mmio_out_of_range/test.desc
@@ -1,0 +1,10 @@
+CORE
+main.c
+--mmio-region 0x1000:256 --no-pointer-check --no-bounds-check
+^EXIT=10$
+^SIGNAL=0$
+MMIO write address must be within a declared region: FAILURE
+MMIO read address must be within a declared region: FAILURE
+^VERIFICATION FAILED$
+--
+^warning: ignoring

--- a/regression/cbmc/mmio_overlap/main.c
+++ b/regression/cbmc/mmio_overlap/main.c
@@ -1,0 +1,4 @@
+int main()
+{
+  return 0;
+}

--- a/regression/cbmc/mmio_overlap/test.desc
+++ b/regression/cbmc/mmio_overlap/test.desc
@@ -1,0 +1,7 @@
+CORE
+main.c
+--mmio-region 0x1000:512 --mmio-region 0x1100:256
+^EXIT=1$
+^SIGNAL=0$
+MMIO regions overlap
+--

--- a/regression/cbmc/mmio_per_region/main.c
+++ b/regression/cbmc/mmio_per_region/main.c
@@ -1,0 +1,8 @@
+int main()
+{
+  volatile char *p = (volatile char *)0x1000;
+  *p = 0x42;
+  char val = *p;
+  __CPROVER_assert(val == 0x42, "MMIO read-back");
+  return 0;
+}

--- a/regression/cbmc/mmio_per_region/test.desc
+++ b/regression/cbmc/mmio_per_region/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+--mmio-region 0x1000:256 --no-pointer-check --no-bounds-check
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+Replaced MMIO operations
+--

--- a/regression/cbmc/mmio_top_of_space/main.c
+++ b/regression/cbmc/mmio_top_of_space/main.c
@@ -1,0 +1,8 @@
+int main()
+{
+  // Region ending exactly at 2^64 spans the top of the address space.
+  volatile unsigned char *p = (volatile unsigned char *)0xFFFFFFFFFFFFFFFFULL;
+  *p = 0x42;
+  __CPROVER_assert(*p == 0x42, "top-of-address-space MMIO read-back");
+  return 0;
+}

--- a/regression/cbmc/mmio_top_of_space/test.desc
+++ b/regression/cbmc/mmio_top_of_space/test.desc
@@ -1,0 +1,11 @@
+CORE
+main.c
+--mmio-region 0xFFFFFFFFFFFFFF00:256 --no-pointer-check --no-bounds-check
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+--
+A region ending exactly at 2^64 covers the top of the address space. The
+in-range upper bound must be omitted rather than wrapping to 0, so the access
+at 0xFFFFFFFFFFFFFFFF resolves to the region instead of falling through.

--- a/regression/cbmc/pointer-overflow2/cmdline.desc
+++ b/regression/cbmc/pointer-overflow2/cmdline.desc
@@ -1,0 +1,15 @@
+KNOWNBUG
+main.c
+-DCMDLINE --mmio-region 0x9:1 --pointer-overflow-check --no-bounds-check
+^EXIT=0$
+^SIGNAL=0$
+\[main.pointer_arithmetic.1\] line \d+ pointer arithmetic: invalid integer address in p - (\(signed long (long )?int\))?1: SUCCESS
+\[main.pointer_arithmetic.2\] line \d+ pointer arithmetic: invalid integer address in p \+ (\(signed long (long )?int\))?1: SUCCESS
+\[main.pointer_arithmetic.3\] line \d+ pointer arithmetic: invalid integer address in p \+ (\(signed long (long )?int\))?-1: SUCCESS
+\[main.pointer_arithmetic.4\] line \d+ pointer arithmetic: invalid integer address in p - (\(signed long (long )?int\))?-1: SUCCESS
+--
+^warning: ignoring
+--
+The per-region MMIO model does not mark integer addresses as valid for
+pointer arithmetic checks. Unlike __CPROVER_allocated_memory, it only
+redirects dereferences to the backing byte array.

--- a/regression/cbmc/pointer-overflow2/main.c
+++ b/regression/cbmc/pointer-overflow2/main.c
@@ -2,7 +2,9 @@
 
 void main()
 {
+#ifndef CMDLINE
   __CPROVER_allocated_memory(9, sizeof(char));
+#endif
   char *p = (char *)10;
   p -= 1;
   p += 1;

--- a/regression/cbmc/union12/cmdline.desc
+++ b/regression/cbmc/union12/cmdline.desc
@@ -1,0 +1,10 @@
+CORE broken-smt-backend
+main.c
+-DCMDLINE --mmio-region 0x50000000:1024 --mmio-region 0x40040000:4 --no-pointer-check --no-bounds-check
+^EXIT=10$
+^SIGNAL=0$
+^\[main\.assertion\.2\] line 22 should fail: FAILURE$
+^\*\* 1 of \d+ failed
+^VERIFICATION FAILED$
+--
+^warning: ignoring

--- a/regression/cbmc/union12/main.c
+++ b/regression/cbmc/union12/main.c
@@ -14,10 +14,14 @@ static S1(*const l[1]) = {((S1 *)((0x50000000UL) + 0x00000))};
 
 void main()
 {
+#ifndef CMDLINE
   __CPROVER_allocated_memory(0x50000000UL, sizeof(S1));
+#endif
   l[0]->access[0] = 0;
   __CPROVER_assert(l[0]->access[0] == 0, "holds");
   __CPROVER_assert(l[0]->access[1] == 0, "should fail");
+#ifndef CMDLINE
   __CPROVER_allocated_memory(0x40000000UL + 0x40000, sizeof(S2));
+#endif
   ((S2 *)((0x40000000UL) + 0x40000))->c = 0x0707;
 }

--- a/regression/cbmc/union12/test.desc
+++ b/regression/cbmc/union12/test.desc
@@ -3,7 +3,7 @@ main.c
 
 ^EXIT=10$
 ^SIGNAL=0$
-^\[main\.assertion\.2\] line 20 should fail: FAILURE$
+^\[main\.assertion\.2\] line 22 should fail: FAILURE$
 ^\*\* 1 of \d+ failed
 ^VERIFICATION FAILED$
 --

--- a/regression/goto-instrument/mmio_bad_format/main.c
+++ b/regression/goto-instrument/mmio_bad_format/main.c
@@ -1,0 +1,4 @@
+int main()
+{
+  return 0;
+}

--- a/regression/goto-instrument/mmio_bad_format/test.desc
+++ b/regression/goto-instrument/mmio_bad_format/test.desc
@@ -1,0 +1,7 @@
+CORE
+main.c
+--mmio --mmio-region 0x1000
+^EXIT=1$
+^SIGNAL=0$
+Invalid MMIO region format
+--

--- a/regression/goto-instrument/mmio_multibyte/main.c
+++ b/regression/goto-instrument/mmio_multibyte/main.c
@@ -1,0 +1,16 @@
+int main()
+{
+  // A 32-bit MMIO store must update all four bytes rather than truncating to
+  // a single byte, and a 32-bit load must read all four back.
+  volatile unsigned int *w = (volatile unsigned int *)0x1000;
+  *w = 0x12345678;
+  __CPROVER_assert(*w == 0x12345678, "32-bit MMIO value round-trips");
+
+  // The store spans consecutive bytes in little-endian order.
+  volatile unsigned char *b = (volatile unsigned char *)0x1000;
+  __CPROVER_assert(b[0] == 0x78, "byte 0 (LSB)");
+  __CPROVER_assert(b[1] == 0x56, "byte 1");
+  __CPROVER_assert(b[2] == 0x34, "byte 2");
+  __CPROVER_assert(b[3] == 0x12, "byte 3 (MSB)");
+  return 0;
+}

--- a/regression/goto-instrument/mmio_multibyte/test.desc
+++ b/regression/goto-instrument/mmio_multibyte/test.desc
@@ -1,0 +1,11 @@
+CORE
+main.c
+--mmio --mmio-region 0x1000:256 _ --no-pointer-check --no-bounds-check
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+--
+A 32-bit MMIO store must update all four region bytes and a 32-bit load must
+read them back. Without multi-byte byte_extract/byte_update modelling the store
+would truncate to one byte and `*w == 0x12345678` would fail.

--- a/regression/goto-instrument/mmio_offset_access/main.c
+++ b/regression/goto-instrument/mmio_offset_access/main.c
@@ -1,0 +1,26 @@
+// Test access at offsets within an MMIO region
+
+int main()
+{
+  volatile char *base = (volatile char *)0x1000;
+
+  // Write to different offsets
+  base[0] = 0xAA;
+  base[10] = 0xBB;
+  base[255] = 0xCC;
+
+  // Read back via intermediate variables
+  char v0 = base[0];
+  char v10 = base[10];
+  char v255 = base[255];
+
+  __CPROVER_assert(v0 == (char)0xAA, "offset 0");
+  __CPROVER_assert(v10 == (char)0xBB, "offset 10");
+  __CPROVER_assert(v255 == (char)0xCC, "offset 255");
+
+  // Verify independence of offsets
+  char v0_again = base[0];
+  __CPROVER_assert(v0_again == (char)0xAA, "offset 0 unchanged");
+
+  return 0;
+}

--- a/regression/goto-instrument/mmio_offset_access/test.desc
+++ b/regression/goto-instrument/mmio_offset_access/test.desc
@@ -1,0 +1,7 @@
+CORE
+main.c
+--mmio --mmio-region 0x1000:256 _ --no-pointer-check --no-bounds-check
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--

--- a/regression/goto-instrument/mmio_out_of_range/main.c
+++ b/regression/goto-instrument/mmio_out_of_range/main.c
@@ -1,0 +1,21 @@
+#include <stdint.h>
+
+int nondet_int(void);
+
+int main()
+{
+  if(nondet_int())
+  {
+    // Write to an address outside the declared region
+    volatile char *p = (volatile char *)0x3000;
+    *p = 42;
+  }
+  else
+  {
+    // Read from an address outside the declared region
+    volatile char *q = (volatile char *)0x4000;
+    char v = *q;
+  }
+
+  return 0;
+}

--- a/regression/goto-instrument/mmio_out_of_range/test.desc
+++ b/regression/goto-instrument/mmio_out_of_range/test.desc
@@ -1,0 +1,10 @@
+CORE
+main.c
+--mmio --mmio-region 0x1000:256 --no-pointer-check --no-bounds-check
+^EXIT=10$
+^SIGNAL=0$
+MMIO write address must be within a declared region: FAILURE
+MMIO read address must be within a declared region: FAILURE
+^VERIFICATION FAILED$
+--
+^warning: ignoring

--- a/regression/goto-instrument/mmio_overlap/main.c
+++ b/regression/goto-instrument/mmio_overlap/main.c
@@ -1,0 +1,4 @@
+int main()
+{
+  return 0;
+}

--- a/regression/goto-instrument/mmio_overlap/test.desc
+++ b/regression/goto-instrument/mmio_overlap/test.desc
@@ -1,0 +1,7 @@
+CORE
+main.c
+--mmio --mmio-region 0x1000:512 --mmio-region 0x1100:256
+^EXIT=1$
+^SIGNAL=0$
+MMIO regions overlap
+--

--- a/regression/goto-instrument/mmio_per_region/main.c
+++ b/regression/goto-instrument/mmio_per_region/main.c
@@ -1,0 +1,31 @@
+// Test for per-region MMIO object model
+
+int main()
+{
+  // Write to MMIO region at 0x1000
+  volatile char *p1 = (volatile char *)0x1000;
+  *p1 = 0x42;
+
+  // Read back and verify
+  char val1 = *p1;
+  __CPROVER_assert(val1 == 0x42, "MMIO read-back from region 1");
+
+  // Write to MMIO region at 0x2000
+  volatile char *p2 = (volatile char *)0x2000;
+  *p2 = 0x55;
+
+  // Read back and verify
+  char val2 = *p2;
+  __CPROVER_assert(val2 == 0x55, "MMIO read-back from region 2");
+
+  // Verify regions are independent
+  char val1_again = *p1;
+  __CPROVER_assert(val1_again == 0x42, "region 1 unaffected by region 2 write");
+
+  // Normal memory access still works
+  char normal_var = 100;
+  char *p4 = &normal_var;
+  __CPROVER_assert(*p4 == 100, "normal memory access works");
+
+  return 0;
+}

--- a/regression/goto-instrument/mmio_per_region/test.desc
+++ b/regression/goto-instrument/mmio_per_region/test.desc
@@ -1,0 +1,7 @@
+CORE
+main.c
+--mmio --mmio-region 0x1000:256 --mmio-region 0x2000:256 _ --no-pointer-check --no-bounds-check
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--

--- a/regression/goto-instrument/mmio_symbolic_addr/main.c
+++ b/regression/goto-instrument/mmio_symbolic_addr/main.c
@@ -1,0 +1,21 @@
+// Test symbolic address dispatch over MMIO regions
+
+int main()
+{
+  volatile char *p1 = (volatile char *)0x1000;
+  volatile char *p2 = (volatile char *)0x2000;
+
+  *p1 = 0x11;
+  *p2 = 0x22;
+
+  // Symbolic pointer: could be either region
+  char nondet;
+  volatile char *p = nondet ? p1 : p2;
+  char val = *p;
+
+  // val must be one of the two written values
+  __CPROVER_assert(
+    val == 0x11 || val == 0x22, "symbolic addr reads correct region");
+
+  return 0;
+}

--- a/regression/goto-instrument/mmio_symbolic_addr/test.desc
+++ b/regression/goto-instrument/mmio_symbolic_addr/test.desc
@@ -1,0 +1,7 @@
+CORE
+main.c
+--mmio --mmio-region 0x1000:256 --mmio-region 0x2000:256 _ --no-pointer-check --no-bounds-check
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--

--- a/src/ansi-c/goto-conversion/goto_check_c.cpp
+++ b/src/ansi-c/goto-conversion/goto_check_c.cpp
@@ -456,6 +456,11 @@ void goto_check_ct::collect_allocations(const goto_functionst &goto_functions)
         throw "expected two unsigned arguments to " CPROVER_PREFIX
               "allocated_memory";
 
+      log.warning() << instruction.source_location().as_string() << ": "
+                    << CPROVER_PREFIX "allocated_memory is deprecated, "
+                    << "use --mmio-region on the command line instead"
+                    << messaget::eom;
+
       DATA_INVARIANT(
         args[0].type() == args[1].type(),
         "arguments of allocated_memory must have same type");

--- a/src/cbmc/cbmc_parse_options.cpp
+++ b/src/cbmc/cbmc_parse_options.cpp
@@ -256,6 +256,9 @@ void cbmc_parse_optionst::get_command_line_options(optionst &options)
   if(cmdline.isset("mm"))
     options.set_option("mm", cmdline.get_value("mm"));
 
+  if(cmdline.isset("mmio-region"))
+    options.set_option("mmio-region", cmdline.get_values("mmio-region"));
+
   if(cmdline.isset("symex-complexity-limit"))
   {
     options.set_option(
@@ -1058,6 +1061,8 @@ void cbmc_parse_optionst::help()
     HELP_COVER
     " {y--mm} {uMM} \t memory consistency model for concurrent programs"
     " (default: {ysc})\n"
+    " {y--mmio-region} {uaddr:size} \t"
+    " model MMIO region as individual byte-array object\n"
     HELP_CONFIG_LIBRARY
     HELP_REACHABILITY_SLICER
     " {y--full-slice} \t run full slicer (experimental)\n"

--- a/src/cbmc/cbmc_parse_options.h
+++ b/src/cbmc/cbmc_parse_options.h
@@ -63,6 +63,7 @@ class optionst;
   OPT_COVER \
   "(symex-coverage-report):" \
   "(mm):" \
+  "(mmio-region):" \
   OPT_TIMESTAMP \
   "(arrays-uf-always)(arrays-uf-never)" \
   OPT_FLUSH \

--- a/src/goto-cc/linker_script_merge.cpp
+++ b/src/goto-cc/linker_script_merge.cpp
@@ -358,58 +358,21 @@ void linker_script_merget::symbols_to_pointerize(
     symbols_to_pointerize(linker_values, op, to_pointerize);
 }
 
-#if 0
-The current implementation of this function is less precise than the
-  commented-out version below. To understand the difference between these
-  implementations, consider the following example:
-
-Suppose we have a section in the linker script, 100 bytes long, where the
-address of the symbol sec_start is the start of the section (value 4096) and the
-address of sec_end is the end of that section (value 4196).
-
-The current implementation synthesizes the goto-version of the following C:
-
-    char __sec_array[100];
-    char *sec_start=(&__sec_array[0]);
-    char *sec_end=((&__sec_array[0])+100);
-      // Yes, it is 100 not 99. We're pointing to the end of the memory occupied
-      // by __sec_array, not the last element of __sec_array.
-
-This is imprecise for the following reason: the actual address of the array and
-the pointers shall be some random CBMC-internal address, instead of being 4096
-and 4196. The linker script, on the other hand, would have specified the exact
-position of the section, and we even know what the actual values of sec_start
-and sec_end are from the object file (these values are in the `addresses` list
-of the `data` argument to this function). If the correctness of the code depends
-on these actual values, then CBMCs model of the code is too imprecise to verify
-this.
-
-The commented-out version of this function below synthesizes the following:
-
-    char *sec_start=4096;
-    char *sec_end=4196;
-    __CPROVER_allocated_memory(4096, 100);
-
-This code has both the actual addresses of the start and end of the section and
-tells CBMC that the intermediate region is valid. However, the allocated_memory
-macro does not currently allocate an actual object at the address 4096, so
-symbolic execution can fail. In particular, the 'allocated memory' is part of
-__CPROVER_memory, which does not have a bounded size; this means that (for
-example) calls to memcpy or memset fail, because the first and third arguments
-do not have know n size. The commented-out implementation should be reinstated
-once this limitation of __CPROVER_allocated_memory has been fixed.
-
-In either case, no other changes to the rest of the code (outside this function)
-should be necessary. The rest of this file converts expressions containing the
-linker-defined symbol into pointer types if they were not already, and this is
-the right behaviour for both implementations.
-#endif
+// The implementation of ls_data2instructions synthesizes the goto-version of:
+//
+//     char __sec_array[100];
+//     char *sec_start=(&__sec_array[0]);
+//     char *sec_end=((&__sec_array[0])+100);
+//
+// This is imprecise because the actual address of the array will be a
+// CBMC-internal address rather than the real address from the linker script.
+// If the correctness of the code depends on the actual numeric addresses,
+// CBMC's model is too imprecise to verify this.
 int linker_script_merget::ls_data2instructions(
-    jsont &data,
-    const std::string &linker_script,
-    symbol_tablet &symbol_table,
-    linker_valuest &linker_values)
-#if 1
+  jsont &data,
+  const std::string &linker_script,
+  symbol_tablet &symbol_table,
+  linker_valuest &linker_values)
 {
   std::map<irep_idt, std::size_t> truncated_symbols;
   for(auto &d : to_json_array(data["regions"]))
@@ -596,69 +559,6 @@ int linker_script_merget::ls_data2instructions(
   }
   return 0;
 }
-#else
-{
-  goto_programt::instructionst initialize_instructions=gp.instructions;
-  for(const auto &d : to_json_array(data["regions"]))
-  {
-    unsigned start=safe_string2unsigned(d["start"].value);
-    unsigned size=safe_string2unsigned(d["size"].value);
-    constant_exprt first=from_integer(start, size_type());
-    constant_exprt second=from_integer(size, size_type());
-    const code_typet void_t({}, empty_typet());
-    code_function_callt f(
-      symbol_exprt(CPROVER_PREFIX "allocated_memory", void_t), {first, second});
-
-    source_locationt loc;
-    loc.set_file(linker_script);
-    loc.set_comment("linker script-defined region:\n"+d["commt"].value+":\n"+
-        d["annot"].value);
-    f.add_source_location()=loc;
-
-    goto_programt::instructiont i;
-    i.make_function_call(f);
-    initialize_instructions.push_front(i);
-  }
-
-  if(!symbol_table.has_symbol(CPROVER_PREFIX "allocated_memory"))
-  {
-    symbolt sym{
-      CPROVER_PREFIX "allocated_memory",
-      code_typet({}, empty_typet()),
-      ID_C} sym.pretty_name = CPROVER_PREFIX "allocated_memory";
-    sym.is_lvalue=sym.is_static_lifetime=true;
-    symbol_table.add(sym);
-  }
-
-  for(const auto &d : to_json_array(data["addresses"]))
-  {
-    source_locationt loc;
-    loc.set_file(linker_script);
-    loc.set_comment("linker script-defined symbol: char *"+
-        d["sym"].value+"="+"(char *)"+d["val"].value+"u;");
-
-    symbol_exprt lhs(d["sym"].value, pointer_type(char_type()));
-
-    constant_exprt rhs;
-    rhs.set_value(integer2bvrep(
-      string2integer(d["val"].value), unsigned_int_type().get_width()));
-    rhs.type()=unsigned_int_type();
-
-    exprt rhs_tc =
-      typecast_exprt::conditional_cast(rhs, pointer_type(char_type()));
-
-    linker_values.emplace(
-      irep_idt(d["sym"].value), std::make_pair(lhs, rhs_tc));
-
-    code_assignt assign(lhs, rhs_tc);
-    assign.add_source_location()=loc;
-    goto_programt::instructiont assign_i;
-    assign_i.make_assignment(assign);
-    initialize_instructions.push_front(assign_i);
-  }
-  return 0;
-}
-#endif
 
 int linker_script_merget::get_linker_script_data(
     std::list<irep_idt> &linker_defined_symbols,

--- a/src/goto-instrument/goto_instrument_parse_options.cpp
+++ b/src/goto-instrument/goto_instrument_parse_options.cpp
@@ -1525,11 +1525,10 @@ void goto_instrument_parse_optionst::instrument_goto_program()
 
   // some analyses require function pointer removal and partial inlining
 
-  if(cmdline.isset("remove-pointers") ||
-     cmdline.isset("race-check") ||
-     cmdline.isset("mm") ||
-     cmdline.isset("isr") ||
-     cmdline.isset("concurrency"))
+  if(
+    cmdline.isset("remove-pointers") || cmdline.isset("race-check") ||
+    cmdline.isset("mm") || cmdline.isset("isr") || cmdline.isset("mmio") ||
+    cmdline.isset("mmio-region") || cmdline.isset("concurrency"))
   {
     do_indirect_call_and_rtti_removal();
 
@@ -1650,10 +1649,96 @@ void goto_instrument_parse_optionst::instrument_goto_program()
     }
 
     // Memory-mapped I/O
-    if(cmdline.isset("mmio"))
+    if(cmdline.isset("mmio") || cmdline.isset("mmio-region"))
     {
       log.status() << "Instrumenting memory-mapped I/O" << messaget::eom;
-      mmio(value_set_analysis, goto_model, ui_message_handler);
+
+      // Per-region instrumentation runs first so that declared regions
+      // get precise array-backed modeling.
+      if(cmdline.isset("mmio-region"))
+      {
+        // Parse MMIO region specifications
+        std::vector<mmio_regiont> regions;
+
+        for(const auto &region_spec : cmdline.get_values("mmio-region"))
+        {
+          // Parse format: address:size (e.g., "0x1000:256")
+          std::size_t colon_pos = region_spec.find(':');
+          if(colon_pos == std::string::npos)
+          {
+            throw invalid_command_line_argument_exceptiont(
+              "Invalid MMIO region format: " + region_spec +
+                " (expected address:size)",
+              "--mmio-region");
+          }
+
+          std::string addr_str = region_spec.substr(0, colon_pos);
+          std::string size_str = region_spec.substr(colon_pos + 1);
+
+          mp_integer start_address;
+          mp_integer size;
+
+          // Parse address (supports hex with 0x prefix)
+          if(addr_str.find("0x") == 0 || addr_str.find("0X") == 0)
+          {
+            start_address = string2integer(addr_str.substr(2), 16);
+          }
+          else
+          {
+            start_address = string2integer(addr_str);
+          }
+
+          // Parse size
+          if(size_str.find("0x") == 0 || size_str.find("0X") == 0)
+          {
+            size = string2integer(size_str.substr(2), 16);
+          }
+          else
+          {
+            size = string2integer(size_str);
+          }
+
+          // Create object name including address
+          std::string object_name =
+            CPROVER_PREFIX "mmio_region_0x" + integer2string(start_address, 16);
+
+          regions.emplace_back(start_address, size, object_name);
+
+          log.status() << "Registered MMIO region at 0x"
+                       << integer2string(start_address, 16) << " size " << size
+                       << " bytes" << messaget::eom;
+        }
+
+        // Check for overlapping regions
+        for(std::size_t i = 0; i < regions.size(); i++)
+        {
+          for(std::size_t j = i + 1; j < regions.size(); j++)
+          {
+            const auto &a = regions[i];
+            const auto &b = regions[j];
+            if(
+              a.start_address < b.start_address + b.size &&
+              b.start_address < a.start_address + a.size)
+            {
+              throw invalid_command_line_argument_exceptiont(
+                "MMIO regions overlap: 0x" +
+                  integer2string(a.start_address, 16) + ":" +
+                  integer2string(a.size) + " and 0x" +
+                  integer2string(b.start_address, 16) + ":" +
+                  integer2string(b.size),
+                "--mmio-region");
+            }
+          }
+        }
+
+        mm_io(goto_model, regions, ui_message_handler);
+      }
+
+      // Concurrency shared-buffer instrumentation (--mmio).
+      // Runs after per-region so that callbacks can handle remaining
+      // dereferences not covered by declared regions.
+      if(cmdline.isset("mmio"))
+        mmio(value_set_analysis, goto_model, ui_message_handler);
     }
 
     if(cmdline.isset("concurrency"))
@@ -1946,6 +2031,8 @@ void goto_instrument_parse_optionst::help()
     HELP_NONDET_VOLATILE
     " {y--isr} {ufunction} \t instruments an interrupt service routine\n"
     " {y--mmio} \t instruments memory-mapped I/O\n"
+    " {y--mmio-region} {uaddr:size} \t define MMIO region as individual object"
+    " (can be combined with --mmio)\n"
     " {y--nondet-static} \t add nondeterministic initialization of variables"
     " with static lifetime\n"
     " {y--nondet-static-exclude} {ue} \t same as nondet-static except for the"

--- a/src/goto-instrument/goto_instrument_parse_options.cpp
+++ b/src/goto-instrument/goto_instrument_parse_options.cpp
@@ -1657,79 +1657,8 @@ void goto_instrument_parse_optionst::instrument_goto_program()
       // get precise array-backed modeling.
       if(cmdline.isset("mmio-region"))
       {
-        // Parse MMIO region specifications
-        std::vector<mmio_regiont> regions;
-
-        for(const auto &region_spec : cmdline.get_values("mmio-region"))
-        {
-          // Parse format: address:size (e.g., "0x1000:256")
-          std::size_t colon_pos = region_spec.find(':');
-          if(colon_pos == std::string::npos)
-          {
-            throw invalid_command_line_argument_exceptiont(
-              "Invalid MMIO region format: " + region_spec +
-                " (expected address:size)",
-              "--mmio-region");
-          }
-
-          std::string addr_str = region_spec.substr(0, colon_pos);
-          std::string size_str = region_spec.substr(colon_pos + 1);
-
-          mp_integer start_address;
-          mp_integer size;
-
-          // Parse address (supports hex with 0x prefix)
-          if(addr_str.find("0x") == 0 || addr_str.find("0X") == 0)
-          {
-            start_address = string2integer(addr_str.substr(2), 16);
-          }
-          else
-          {
-            start_address = string2integer(addr_str);
-          }
-
-          // Parse size
-          if(size_str.find("0x") == 0 || size_str.find("0X") == 0)
-          {
-            size = string2integer(size_str.substr(2), 16);
-          }
-          else
-          {
-            size = string2integer(size_str);
-          }
-
-          // Create object name including address
-          std::string object_name =
-            CPROVER_PREFIX "mmio_region_0x" + integer2string(start_address, 16);
-
-          regions.emplace_back(start_address, size, object_name);
-
-          log.status() << "Registered MMIO region at 0x"
-                       << integer2string(start_address, 16) << " size " << size
-                       << " bytes" << messaget::eom;
-        }
-
-        // Check for overlapping regions
-        for(std::size_t i = 0; i < regions.size(); i++)
-        {
-          for(std::size_t j = i + 1; j < regions.size(); j++)
-          {
-            const auto &a = regions[i];
-            const auto &b = regions[j];
-            if(
-              a.start_address < b.start_address + b.size &&
-              b.start_address < a.start_address + a.size)
-            {
-              throw invalid_command_line_argument_exceptiont(
-                "MMIO regions overlap: 0x" +
-                  integer2string(a.start_address, 16) + ":" +
-                  integer2string(a.size) + " and 0x" +
-                  integer2string(b.start_address, 16) + ":" +
-                  integer2string(b.size),
-                "--mmio-region");
-            }
-          }
-        }
+        const std::vector<mmio_regiont> regions = parse_mmio_regions(
+          cmdline.get_values("mmio-region"), ui_message_handler);
 
         mm_io(goto_model, regions, ui_message_handler);
       }

--- a/src/goto-instrument/goto_instrument_parse_options.h
+++ b/src/goto-instrument/goto_instrument_parse_options.h
@@ -57,6 +57,7 @@ Author: Daniel Kroening, kroening@kroening.com
   OPT_UNINITIALIZED_CHECK \
   OPT_WMM \
   "(race-check)" \
+  "(mmio)(mmio-region):" \
   OPT_UNWINDSET \
   "(unwindset-file):" \
   "(unwinding-assertions)(partial-loops)(continue-as-loops)" \

--- a/src/goto-programs/mm_io.cpp
+++ b/src/goto-programs/mm_io.cpp
@@ -13,21 +13,33 @@ Date:   April 2017
 
 #include "mm_io.h"
 
+#include <util/arith_tools.h>
+#include <util/bitvector_types.h>
+#include <util/byte_operators.h>
+#include <util/c_types.h>
 #include <util/fresh_symbol.h>
 #include <util/message.h>
 #include <util/pointer_expr.h>
 #include <util/pointer_offset_size.h>
 #include <util/pointer_predicates.h>
 #include <util/replace_expr.h>
+#include <util/simplify_expr.h>
+#include <util/std_code.h>
+#include <util/std_expr.h>
 
 #include "goto_model.h"
 
 #include <set>
 
+/// Implements MMIO instrumentation for a single function.
+/// Supports both the legacy callback model (when \p regions is empty)
+/// and the per-region object model (when \p regions is non-empty).
 class mm_iot
 {
 public:
-  explicit mm_iot(symbol_table_baset &symbol_table);
+  explicit mm_iot(
+    symbol_table_baset &symbol_table,
+    const std::vector<mmio_regiont> &_regions = {});
 
   void mm_io(goto_functionst::goto_functiont &goto_function);
 
@@ -42,13 +54,70 @@ protected:
   exprt mm_io_r;
   exprt mm_io_r_value;
   exprt mm_io_w;
+
+  // Per-region object model
+  const std::vector<mmio_regiont> regions;
+  symbol_table_baset &symbol_table;
+
+  /// Return an expression that reads the MMIO region object at \p address.
+  /// If \p address simplifies to a constant that falls within a known region,
+  /// returns a direct `index_exprt` into that region's array. Otherwise
+  /// delegates to \ref build_conditional_access.
+  exprt get_mmio_object_for_address(
+    const exprt &address,
+    const typet &value_type,
+    const source_locationt &location);
+
+  /// Build an if-then-else chain over all MMIO regions for a symbolic
+  /// \p address. The default (no region matches) is a nondet value.
+  exprt build_conditional_access(
+    const exprt &address,
+    const typet &value_type,
+    const source_locationt &location);
+
+  /// Build a disjunction: address is in region_0 || ... || region_N.
+  exprt address_in_some_region(const exprt &address);
+
+  /// Build the in-range condition `address >= start && address < start+size`
+  /// for \p region. If the region ends exactly at 2^width (the top of the
+  /// address space), the upper bound is omitted, because `from_integer` of
+  /// 2^width into the (unsigned) address type wraps to 0 and would otherwise
+  /// make the condition unsatisfiable.
+  exprt region_contains(const mmio_regiont &region, const exprt &address);
+
+  /// Read a value of \p value_type from \p region_symbol's backing byte array
+  /// starting at byte \p offset. The access spans ceil(width/8) consecutive
+  /// bytes via a `byte_extract` that honours the configured endianness, so
+  /// multi-byte MMIO accesses are modelled soundly rather than truncated to a
+  /// single byte.
+  exprt region_element(
+    const symbolt &region_symbol,
+    const exprt &offset,
+    const typet &value_type);
+
+  /// Replace a write through the dereference \p d (with right-hand side
+  /// \p a_rhs) at instruction \p it of \p goto_function with a conditional
+  /// dispatch that, for an integer address, stores into the matching region
+  /// object (via \ref region_element / byte_update) and otherwise performs the
+  /// original write; a fall-through assertion flags addresses outside every
+  /// declared region. The original assignment is erased. Returns the
+  /// instruction at which iteration should resume.
+  goto_programt::targett instrument_region_write(
+    goto_functionst::goto_functiont &goto_function,
+    goto_programt::targett it,
+    const dereference_exprt &d,
+    const exprt &a_rhs);
 };
 
-mm_iot::mm_iot(symbol_table_baset &symbol_table)
-  : ns(symbol_table),
+mm_iot::mm_iot(
+  symbol_table_baset &_symbol_table,
+  const std::vector<mmio_regiont> &_regions)
+  : ns(_symbol_table),
     mm_io_r(nil_exprt{}),
     mm_io_r_value(nil_exprt{}),
-    mm_io_w(nil_exprt{})
+    mm_io_w(nil_exprt{}),
+    regions(_regions),
+    symbol_table(_symbol_table)
 {
   if(const auto mm_io_r_symbol = symbol_table.lookup(id_r))
   {
@@ -71,15 +140,191 @@ mm_iot::mm_iot(symbol_table_baset &symbol_table)
 static std::set<dereference_exprt> collect_deref_expr(const exprt &src)
 {
   std::set<dereference_exprt> collected;
-  src.visit_pre([&collected](const exprt &e) {
-    if(e.id() == ID_dereference)
-      collected.insert(to_dereference_expr(e));
-  });
+  src.visit_pre(
+    [&collected](const exprt &e)
+    {
+      if(e.id() == ID_dereference)
+        collected.insert(to_dereference_expr(e));
+    });
   return collected;
+}
+
+goto_programt::targett mm_iot::instrument_region_write(
+  goto_functionst::goto_functiont &goto_function,
+  goto_programt::targett it,
+  const dereference_exprt &d,
+  const exprt &a_rhs)
+{
+  const source_locationt source_location = it->source_location();
+
+  // We build the following structure after the original assignment (which we
+  // then erase):
+  //
+  //   IF !integer_address(ptr) GOTO lbl_orig
+  //   IF in_region_0 GOTO lbl_r0
+  //   ...
+  //   GOTO lbl_end          // not in any known region
+  // lbl_r0: region0 = byte_update(region0, off, rhs); GOTO lbl_end
+  //   ...
+  // lbl_orig: *ptr = rhs; GOTO lbl_end
+  // lbl_end: SKIP
+
+  const exprt addr_as_int =
+    typecast_exprt::conditional_cast(d.pointer(), size_type());
+
+  // First pass: build region assignments in a temporary program and collect
+  // targets for the dispatch GOTOs.
+  goto_programt region_code;
+  struct region_infot
+  {
+    exprt condition;
+    goto_programt::targett label;
+  };
+  std::vector<region_infot> region_gotos;
+
+  for(const auto &region : regions)
+  {
+    const symbolt *sym = symbol_table.lookup(region.object_name);
+    if(!sym)
+      continue;
+
+    exprt in_range = region_contains(region, addr_as_int);
+
+    minus_exprt offset(
+      addr_as_int, from_integer(region.start_address, addr_as_int.type()));
+
+    // Update the bytes [offset, offset + ceil(width/8)) of the region array
+    // from the value being written, honouring the configured endianness, and
+    // assign the resulting array back to the region. This models multi-byte
+    // stores soundly instead of truncating the value to a single byte.
+    const exprt region_expr = sym->symbol_expr();
+    exprt updated = make_byte_update(region_expr, offset, a_rhs);
+
+    auto lbl_region = region_code.add(goto_programt::make_assignment(
+      region_expr, std::move(updated), source_location));
+
+    region_gotos.push_back({std::move(in_range), lbl_region});
+  }
+
+  // Original dereference write
+  auto lbl_orig =
+    region_code.add(goto_programt::make_assignment(d, a_rhs, source_location));
+
+  // lbl_end
+  auto lbl_end = region_code.add(goto_programt::make_skip(source_location));
+
+  // Insert GOTO lbl_end after each region assignment and after lbl_orig.
+  for(auto ri = region_code.instructions.begin(); ri != lbl_end;)
+  {
+    if(ri->is_assign())
+    {
+      auto next_ri = std::next(ri);
+      region_code.instructions.insert(
+        next_ri, goto_programt::make_goto(lbl_end, source_location));
+      ri = next_ri;
+    }
+    else
+      ++ri;
+  }
+
+  // Build the dispatch block.
+  goto_programt result;
+
+  // Guard: not integer address -> original dereference
+  result.add(goto_programt::make_goto(
+    lbl_orig, not_exprt(integer_address(d.pointer())), source_location));
+
+  // Conditional jumps to each region
+  for(const auto &rg : region_gotos)
+  {
+    result.add(
+      goto_programt::make_goto(rg.label, rg.condition, source_location));
+  }
+
+  // Fall-through: integer address not in any declared region
+  {
+    source_locationt assert_loc = source_location;
+    assert_loc.set_property_class("mmio-region");
+    assert_loc.set_comment(
+      "MMIO write address must be within a declared region");
+    result.add(goto_programt::make_assertion(false_exprt(), assert_loc));
+    result.add(goto_programt::make_assumption(false_exprt(), source_location));
+  }
+
+  // Append region assignments + original + end
+  result.destructive_append(region_code);
+
+  // Splice into the function body after `it`, then erase the original
+  // assignment. Iteration resumes from lbl_end.
+  auto next = std::next(it);
+  goto_function.body.destructive_insert(next, result);
+  goto_function.body.instructions.erase(it);
+
+  return lbl_end;
 }
 
 void mm_iot::mm_io(goto_functionst::goto_functiont &goto_function)
 {
+  // Use per-region object model if regions are specified
+  if(!regions.empty())
+  {
+    // Instrument with per-region object model
+    for(auto it = goto_function.body.instructions.begin();
+        it != goto_function.body.instructions.end();
+        it++)
+    {
+      if(!it->is_assign())
+        continue;
+
+      auto &a_lhs = it->assign_lhs();
+      auto &a_rhs = it->assign_rhs_nonconst();
+      const auto deref_expr_r = collect_deref_expr(a_rhs);
+
+      // Handle reads
+      if(deref_expr_r.size() == 1)
+      {
+        const dereference_exprt &d = *deref_expr_r.begin();
+        source_locationt source_location = it->source_location();
+
+        exprt addr_as_int =
+          typecast_exprt::conditional_cast(d.pointer(), size_type());
+
+        exprt mmio_access =
+          get_mmio_object_for_address(addr_as_int, d.type(), source_location);
+
+        if_exprt if_expr(integer_address(d.pointer()), mmio_access, d);
+
+        replace_expr(d, if_expr, a_rhs);
+
+        // Assert that the integer address falls within a declared region
+        source_locationt assert_loc = source_location;
+        assert_loc.set_property_class("mmio-region");
+        assert_loc.set_comment(
+          "MMIO read address must be within a declared region");
+        goto_programt assert_prog;
+        assert_prog.add(goto_programt::make_assertion(
+          implies_exprt(
+            integer_address(d.pointer()), address_in_some_region(addr_as_int)),
+          assert_loc));
+        goto_function.body.destructive_insert(it, assert_prog);
+
+        ++reads_replaced;
+      }
+
+      // Handle writes (the read instrumentation above only modifies a_rhs,
+      // so a_lhs is still the original dereference when both sides deref)
+      if(a_lhs.id() == ID_dereference)
+      {
+        it = instrument_region_write(
+          goto_function, it, to_dereference_expr(a_lhs), a_rhs);
+        ++writes_replaced;
+      }
+    }
+
+    return;
+  }
+
+  // Original implementation for backward compatibility
   // return early when there is nothing to be done
   if(mm_io_r.is_nil() && mm_io_w.is_nil())
     return;
@@ -173,4 +418,185 @@ void mm_io(
 void mm_io(goto_modelt &model, message_handlert &message_handler)
 {
   mm_io(model.symbol_table, model.goto_functions, message_handler);
+}
+
+/// Create byte-array symbols in \p symbol_table for each MMIO region.
+/// Each symbol is a static-lifetime array of `unsigned char` with size
+/// matching the region specification.
+void create_mmio_region_objects(
+  symbol_tablet &symbol_table,
+  const std::vector<mmio_regiont> &regions,
+  message_handlert &message_handler)
+{
+  messaget log{message_handler};
+
+  for(const auto &region : regions)
+  {
+    // Create a byte array object for this MMIO region
+    array_typet array_type(
+      unsignedbv_typet(8), from_integer(region.size, size_type()));
+
+    symbolt new_symbol;
+    new_symbol.name = region.object_name;
+    new_symbol.base_name = region.object_name;
+    new_symbol.type = array_type;
+    new_symbol.mode = ID_C;
+    new_symbol.is_lvalue = true;
+    new_symbol.is_state_var = true;
+    new_symbol.is_static_lifetime = true;
+
+    if(symbol_table.add(new_symbol))
+    {
+      log.warning() << "Failed to add MMIO region object: "
+                    << region.object_name << messaget::eom;
+    }
+    else
+    {
+      log.status() << "Created MMIO region: " << region.object_name
+                   << " at address 0x"
+                   << integer2string(region.start_address, 16) << " size "
+                   << region.size << " bytes" << messaget::eom;
+    }
+  }
+}
+
+exprt mm_iot::get_mmio_object_for_address(
+  const exprt &address,
+  const typet &value_type,
+  const source_locationt &location)
+{
+  // Simplify to fold typecasts of constants into plain constants
+  exprt simplified = simplify_expr(address, ns);
+
+  if(simplified.is_constant())
+  {
+    mp_integer addr_value;
+    if(!to_integer(to_constant_expr(simplified), addr_value))
+    {
+      // Find the matching MMIO region
+      for(const auto &region : regions)
+      {
+        if(
+          addr_value >= region.start_address &&
+          addr_value < region.start_address + region.size)
+        {
+          // Calculate offset within the region
+          mp_integer offset = addr_value - region.start_address;
+
+          // Get the symbol for this region
+          const symbolt *region_symbol =
+            symbol_table.lookup(region.object_name);
+          if(region_symbol)
+          {
+            return region_element(
+              *region_symbol, from_integer(offset, c_index_type()), value_type);
+          }
+        }
+      }
+    }
+  }
+
+  // For symbolic addresses or addresses not in MMIO regions,
+  // build conditional access
+  return build_conditional_access(address, value_type, location);
+}
+
+exprt mm_iot::build_conditional_access(
+  const exprt &address,
+  const typet &value_type,
+  const source_locationt &location)
+{
+  // Build a chain of if-then-else expressions for each MMIO region
+  exprt result = side_effect_expr_nondett(value_type, location);
+
+  for(auto it = regions.rbegin(); it != regions.rend(); ++it)
+  {
+    const auto &region = *it;
+
+    // Get the symbol for this region
+    const symbolt *region_symbol = symbol_table.lookup(region.object_name);
+    if(!region_symbol)
+      continue;
+
+    // Build condition: address is within this region
+    exprt in_range = region_contains(region, address);
+
+    // Calculate offset: address - start_address
+    minus_exprt offset_expr(
+      address, from_integer(region.start_address, address.type()));
+
+    // Read value_type from the region, spanning consecutive bytes
+    exprt region_access =
+      region_element(*region_symbol, offset_expr, value_type);
+
+    // Build if-then-else: if (in_range) region[offset] else result
+    result = if_exprt(in_range, region_access, result);
+  }
+
+  return result;
+}
+
+exprt mm_iot::address_in_some_region(const exprt &address)
+{
+  exprt::operandst disjuncts;
+  for(const auto &region : regions)
+    disjuncts.push_back(region_contains(region, address));
+  return disjunction(disjuncts);
+}
+
+exprt mm_iot::region_contains(const mmio_regiont &region, const exprt &address)
+{
+  const typet &address_type = address.type();
+  binary_predicate_exprt lower(
+    address, ID_ge, from_integer(region.start_address, address_type));
+
+  const mp_integer end = region.start_address + region.size;
+  // A region whose end is exactly 2^width spans the top of the address space.
+  // from_integer(2^width, address_type) wraps to 0, which would turn the upper
+  // bound into the always-false `address < 0`; omit it, since every value of
+  // this unsigned address type already satisfies `address < 2^width`.
+  if(end == power(2, to_bitvector_type(address_type).get_width()))
+    return std::move(lower);
+
+  binary_predicate_exprt upper(address, ID_lt, from_integer(end, address_type));
+  return and_exprt(lower, upper);
+}
+
+exprt mm_iot::region_element(
+  const symbolt &region_symbol,
+  const exprt &offset,
+  const typet &value_type)
+{
+  // The region object is a byte array; extract value_type starting at byte
+  // `offset`, spanning ceil(width/8) consecutive bytes. make_byte_extract
+  // uses the endianness configured for the analysed program, so multi-byte
+  // accesses are modelled with the correct byte order instead of being
+  // truncated to a single element.
+  return make_byte_extract(region_symbol.symbol_expr(), offset, value_type);
+}
+
+void mm_io(
+  goto_modelt &model,
+  const std::vector<mmio_regiont> &regions,
+  message_handlert &message_handler)
+{
+  // Create MMIO region objects first
+  if(!regions.empty())
+  {
+    create_mmio_region_objects(model.symbol_table, regions, message_handler);
+  }
+
+  // Now instrument with the per-region model
+  mm_iot rewrite{model.symbol_table, regions};
+
+  for(auto &f : model.goto_functions.function_map)
+    rewrite.mm_io(f.second);
+
+  if(rewrite.reads_replaced || rewrite.writes_replaced)
+  {
+    messaget log{message_handler};
+    log.status() << "Replaced MMIO operations: " << rewrite.reads_replaced
+                 << " read(s), " << rewrite.writes_replaced << " write(s)"
+                 << messaget::eom;
+  }
 }

--- a/src/goto-programs/mm_io.cpp
+++ b/src/goto-programs/mm_io.cpp
@@ -17,6 +17,7 @@ Date:   April 2017
 #include <util/bitvector_types.h>
 #include <util/byte_operators.h>
 #include <util/c_types.h>
+#include <util/exception_utils.h>
 #include <util/fresh_symbol.h>
 #include <util/message.h>
 #include <util/pointer_expr.h>
@@ -29,6 +30,8 @@ Date:   April 2017
 
 #include "goto_model.h"
 
+#include <algorithm>
+#include <cctype>
 #include <set>
 
 /// Implements MMIO instrumentation for a single function.
@@ -418,6 +421,129 @@ void mm_io(
 void mm_io(goto_modelt &model, message_handlert &message_handler)
 {
   mm_io(model.symbol_table, model.goto_functions, message_handler);
+}
+
+/// Parse a single `--mmio-region` numeric field (an address or a size). A
+/// leading `0x`/`0X` selects hexadecimal, otherwise decimal is used. Every
+/// remaining character must be a valid digit for the chosen base; a single
+/// leading `-` is permitted so that negative values are reported by the
+/// dedicated non-negativity check rather than as a parse error. Throws
+/// invalid_command_line_argument_exceptiont for empty or non-numeric input
+/// (e.g. `xyz` or `0xZZ`).
+static mp_integer
+parse_mmio_field(const std::string &field, const std::string &spec)
+{
+  std::string digits = field;
+  std::string sign;
+  if(!digits.empty() && digits[0] == '-')
+  {
+    sign = "-";
+    digits = digits.substr(1);
+  }
+
+  unsigned base = 10;
+  if(
+    digits.size() >= 2 && digits[0] == '0' &&
+    (digits[1] == 'x' || digits[1] == 'X'))
+  {
+    base = 16;
+    digits = digits.substr(2);
+  }
+
+  const bool valid =
+    !digits.empty() &&
+    std::all_of(
+      digits.begin(),
+      digits.end(),
+      [base](char c)
+      {
+        const unsigned char uc = static_cast<unsigned char>(c);
+        return base == 16 ? std::isxdigit(uc) != 0 : std::isdigit(uc) != 0;
+      });
+
+  if(!valid)
+  {
+    throw invalid_command_line_argument_exceptiont(
+      "invalid number '" + field + "' in MMIO region: " + spec,
+      "--mmio-region");
+  }
+
+  return string2integer(sign + digits, base);
+}
+
+std::vector<mmio_regiont> parse_mmio_regions(
+  const std::list<std::string> &region_specs,
+  message_handlert &message_handler)
+{
+  messaget log{message_handler};
+  std::vector<mmio_regiont> regions;
+
+  for(const auto &spec : region_specs)
+  {
+    const std::size_t colon_pos = spec.find(':');
+    if(colon_pos == std::string::npos)
+    {
+      throw invalid_command_line_argument_exceptiont(
+        "Invalid MMIO region format: " + spec + " (expected address:size)",
+        "--mmio-region");
+    }
+
+    const std::string addr_str = spec.substr(0, colon_pos);
+    const std::string size_str = spec.substr(colon_pos + 1);
+
+    mp_integer start_address = parse_mmio_field(addr_str, spec);
+    mp_integer size = parse_mmio_field(size_str, spec);
+
+    if(start_address < 0)
+    {
+      throw invalid_command_line_argument_exceptiont(
+        "MMIO region address must be non-negative: " + spec, "--mmio-region");
+    }
+
+    if(size <= 0)
+    {
+      throw invalid_command_line_argument_exceptiont(
+        "MMIO region size must be positive: " + spec, "--mmio-region");
+    }
+
+    // Ensure the region does not wrap around the 64-bit address space
+    if(start_address + size > power(2, 64))
+    {
+      throw invalid_command_line_argument_exceptiont(
+        "MMIO region exceeds 64-bit address space: " + spec, "--mmio-region");
+    }
+
+    std::string object_name =
+      CPROVER_PREFIX "mmio_region_0x" + integer2string(start_address, 16);
+
+    regions.emplace_back(start_address, size, object_name);
+
+    log.status() << "Registered MMIO region at 0x"
+                 << integer2string(start_address, 16) << " size " << size
+                 << " bytes" << messaget::eom;
+  }
+
+  // Check for overlapping regions
+  for(std::size_t i = 0; i < regions.size(); i++)
+  {
+    for(std::size_t j = i + 1; j < regions.size(); j++)
+    {
+      const auto &a = regions[i];
+      const auto &b = regions[j];
+      if(
+        a.start_address < b.start_address + b.size &&
+        b.start_address < a.start_address + a.size)
+      {
+        throw invalid_command_line_argument_exceptiont(
+          "MMIO regions overlap: 0x" + integer2string(a.start_address, 16) +
+            ":" + integer2string(a.size) + " and 0x" +
+            integer2string(b.start_address, 16) + ":" + integer2string(b.size),
+          "--mmio-region");
+      }
+    }
+  }
+
+  return regions;
 }
 
 /// Create byte-array symbols in \p symbol_table for each MMIO region.

--- a/src/goto-programs/mm_io.h
+++ b/src/goto-programs/mm_io.h
@@ -12,29 +12,83 @@ Date:   April 2017
 /// Perform Memory-mapped I/O instrumentation
 ///
 /// \details
-/// In the case where a modelling function named `__CPROVER_mm_io_r` exists in
-/// the symbol table, this pass will insert calls to this function before
-/// pointer dereference reads. Only the case where there is a single dereference
-/// on the right hand side of an assignment is included in the set of
-/// dereference reads.
+/// This pass instruments pointer dereferences that target integer addresses
+/// (memory-mapped I/O) so that they access modeled objects instead of raw
+/// memory.
 ///
-/// In the case where a modelling function named
-/// `__CPROVER_mm_io_w` exists in the symbol table, this pass will insert calls
-/// to this function before all pointer dereference writes. All pointer
-/// dereference writes are assumed to be on the left hand side of assignments.
+/// Two modes are supported and can be combined:
 ///
-/// For details as to how and why this is used see the "Device behavior" section
-/// of modeling-mmio.md
+/// **Callback model** (`--mmio`):
+/// If a modelling function named `__CPROVER_mm_io_r` exists in the symbol
+/// table, this pass inserts calls to it before pointer dereference reads
+/// (only when there is a single dereference on the RHS of an assignment).
+/// If `__CPROVER_mm_io_w` exists, calls are inserted before all pointer
+/// dereference writes (on the LHS of assignments). This enables custom
+/// read/write handlers that model device-specific behaviour.
+///
+/// **Per-region object model** (`--mmio-region addr:size`):
+/// Each declared MMIO region becomes an individual byte-array object in the
+/// symbol table (named `__CPROVER_mmio_region_0x<addr>`). Reads from
+/// addresses within a region are replaced by an `if_exprt` that selects the
+/// appropriate array element when the address is an integer address, and
+/// falls back to the original dereference otherwise. Writes are replaced by
+/// a conditional GOTO dispatch that directs the store to the matching region
+/// object. Constant addresses are resolved at instrumentation time; symbolic
+/// addresses produce a chain of conditionals over all declared regions.
+///
+/// For details on usage see the "Modeling Memory-mapped I/O" section of the
+/// CProver manual (doc/cprover-manual/modeling-mmio.md).
 
 #ifndef CPROVER_GOTO_PROGRAMS_MM_IO_H
 #define CPROVER_GOTO_PROGRAMS_MM_IO_H
+
+#include <util/irep.h>
+#include <util/mp_arith.h>
+
+#include <string>
+#include <vector>
 
 class goto_functionst;
 class goto_modelt;
 class message_handlert;
 class symbol_tablet;
 
-void mm_io(const symbol_tablet &, goto_functionst &, message_handlert &);
+/// Represents a contiguous MMIO region defined via `--mmio-region`.
+/// Each region is backed by a byte-array symbol in the symbol table
+/// whose name encodes the start address.
+struct mmio_regiont
+{
+  mp_integer start_address; ///< First byte address of the region
+  mp_integer size;          ///< Size of the region in bytes
+  irep_idt object_name;     ///< Backing array symbol name
+
+  mmio_regiont(
+    const mp_integer &_start_address,
+    const mp_integer &_size,
+    const irep_idt &_object_name)
+    : start_address(_start_address), size(_size), object_name(_object_name)
+  {
+  }
+};
+
+/// Instrument MMIO using the callback model
+/// (`__CPROVER_mm_io_r` / `__CPROVER_mm_io_w`).
+/// Can be combined with the per-region model; in that case the per-region
+/// pass should run first so that declared regions get precise modeling.
+void mm_io(symbol_tablet &, goto_functionst &, message_handlert &);
+
+/// \copydoc mm_io(symbol_tablet &, goto_functionst &, message_handlert &)
 void mm_io(goto_modelt &, message_handlert &);
+
+/// Instrument MMIO using the per-region object model.
+/// Each region in \p regions must have been previously registered via
+/// `--mmio-region`. The regions must not overlap.
+/// \param [in,out] model: the goto model to instrument
+/// \param regions: MMIO region specifications
+/// \param message_handler: message handler for status and diagnostics
+void mm_io(
+  goto_modelt &model,
+  const std::vector<mmio_regiont> &regions,
+  message_handlert &message_handler);
 
 #endif // CPROVER_GOTO_PROGRAMS_MM_IO_H

--- a/src/goto-programs/mm_io.h
+++ b/src/goto-programs/mm_io.h
@@ -35,6 +35,7 @@ Date:   April 2017
 /// a conditional GOTO dispatch that directs the store to the matching region
 /// object. Constant addresses are resolved at instrumentation time; symbolic
 /// addresses produce a chain of conditionals over all declared regions.
+/// This option is supported by both `cbmc` and `goto-instrument`.
 ///
 /// For details on usage see the "Modeling Memory-mapped I/O" section of the
 /// CProver manual (doc/cprover-manual/modeling-mmio.md).
@@ -45,6 +46,7 @@ Date:   April 2017
 #include <util/irep.h>
 #include <util/mp_arith.h>
 
+#include <list>
 #include <string>
 #include <vector>
 
@@ -81,14 +83,25 @@ void mm_io(symbol_tablet &, goto_functionst &, message_handlert &);
 void mm_io(goto_modelt &, message_handlert &);
 
 /// Instrument MMIO using the per-region object model.
-/// Each region in \p regions must have been previously registered via
-/// `--mmio-region`. The regions must not overlap.
+/// Each region in \p regions specifies an address range to be backed by a
+/// byte-array symbol. The regions must not overlap.
 /// \param [in,out] model: the goto model to instrument
 /// \param regions: MMIO region specifications
 /// \param message_handler: message handler for status and diagnostics
 void mm_io(
   goto_modelt &model,
   const std::vector<mmio_regiont> &regions,
+  message_handlert &message_handler);
+
+/// Parse `--mmio-region` command-line values into region specifications.
+/// Each string must have the format `address:size` (e.g. `0x1000:256`).
+/// Hex addresses with `0x`/`0X` prefix are supported.
+/// \param region_specs: raw command-line values
+/// \param message_handler: for status messages
+/// \return parsed and validated regions (checked for overlaps)
+/// \throws invalid_command_line_argument_exceptiont on bad format or overlap
+std::vector<mmio_regiont> parse_mmio_regions(
+  const std::list<std::string> &region_specs,
   message_handlert &message_handler);
 
 #endif // CPROVER_GOTO_PROGRAMS_MM_IO_H

--- a/src/goto-programs/process_goto_program.cpp
+++ b/src/goto-programs/process_goto_program.cpp
@@ -46,6 +46,18 @@ bool process_goto_program(
                << messaget::eom;
   remove_function_pointers(log.get_message_handler(), goto_model, false);
 
+  // Per-region MMIO instrumentation runs first so that declared regions
+  // get precise array-backed modeling. The callback model
+  // (__CPROVER_mm_io_r / __CPROVER_mm_io_w) runs second and can handle
+  // any remaining dereferences not covered by declared regions.
+  const auto &mmio_regions = options.get_list_option("mmio-region");
+  if(!mmio_regions.empty())
+  {
+    const auto regions =
+      parse_mmio_regions(mmio_regions, log.get_message_handler());
+    mm_io(goto_model, regions, log.get_message_handler());
+  }
+
   mm_io(goto_model, log.get_message_handler());
 
   // instrument library preconditions

--- a/unit/Makefile
+++ b/unit/Makefile
@@ -73,6 +73,7 @@ SRC += analyses/ai/ai.cpp \
        goto-programs/goto_program_validate.cpp \
        goto-programs/goto_trace_output.cpp \
        goto-programs/is_goto_binary.cpp \
+       goto-programs/mm_io.cpp \
        goto-programs/label_function_pointer_call_sites.cpp \
        goto-programs/osx_fat_reader.cpp \
        goto-programs/restrict_function_pointers.cpp \

--- a/unit/goto-programs/mm_io.cpp
+++ b/unit/goto-programs/mm_io.cpp
@@ -1,0 +1,126 @@
+/*******************************************************************\
+
+Module: Unit tests for mm_io per-region MMIO instrumentation
+
+Author: Michael Tautschnig
+
+\*******************************************************************/
+
+#include <util/arith_tools.h>
+#include <util/bitvector_types.h>
+#include <util/c_types.h>
+#include <util/cprover_prefix.h>
+#include <util/message.h>
+#include <util/namespace.h>
+#include <util/pointer_expr.h>
+#include <util/std_code.h>
+#include <util/std_expr.h>
+#include <util/symbol_table.h>
+
+#include <goto-programs/goto_function.h>
+#include <goto-programs/goto_model.h>
+#include <goto-programs/mm_io.h>
+
+#include <testing-utils/use_catch.h>
+
+/// Build a minimal goto_modelt with a single function containing
+/// an assignment `*ptr = rhs` where ptr is a cast from an integer constant.
+static goto_modelt
+build_model_with_deref_write(const mp_integer &address, const exprt &rhs)
+{
+  goto_modelt model;
+
+  // pointer type: char*
+  const typet char_type = signedbv_typet(8);
+  const auto ptr_type = pointer_type(char_type);
+
+  // ptr = (char*)<address>
+  const constant_exprt addr_const = from_integer(address, signedbv_typet(64));
+  const typecast_exprt ptr_val(addr_const, ptr_type);
+
+  // *ptr
+  const dereference_exprt deref(ptr_val);
+
+  // Build function body: ASSIGN *ptr = rhs
+  goto_programt body;
+  body.add(goto_programt::make_assignment(deref, rhs));
+  body.add(goto_programt::make_end_function());
+
+  // Add function to model
+  symbolt fun_sym;
+  fun_sym.name = "test_fun";
+  fun_sym.type = code_typet({}, empty_typet());
+  fun_sym.mode = ID_C;
+  model.symbol_table.add(fun_sym);
+
+  goto_functionst::goto_functiont &gf =
+    model.goto_functions.function_map["test_fun"];
+  gf.body.swap(body);
+
+  return model;
+}
+
+TEST_CASE("mm_io per-region creates symbols", "[core][goto-programs][mm_io]")
+{
+  std::vector<mmio_regiont> regions;
+  regions.emplace_back(
+    mp_integer(0x1000), mp_integer(256), CPROVER_PREFIX "mmio_region_0x1000");
+
+  goto_modelt model = build_model_with_deref_write(
+    mp_integer(0x1000), from_integer(0x42, signedbv_typet(8)));
+
+  null_message_handlert msg;
+  mm_io(model, regions, msg);
+
+  // The region symbol should exist in the symbol table
+  const symbolt *sym =
+    model.symbol_table.lookup(CPROVER_PREFIX "mmio_region_0x1000");
+  REQUIRE(sym != nullptr);
+  REQUIRE(sym->type.id() == ID_array);
+}
+
+TEST_CASE("mm_io per-region instruments writes", "[core][goto-programs][mm_io]")
+{
+  std::vector<mmio_regiont> regions;
+  regions.emplace_back(
+    mp_integer(0x1000), mp_integer(256), CPROVER_PREFIX "mmio_region_0x1000");
+
+  goto_modelt model = build_model_with_deref_write(
+    mp_integer(0x1000), from_integer(0x42, signedbv_typet(8)));
+
+  // Count instructions before
+  const auto &body_before =
+    model.goto_functions.function_map.at("test_fun").body;
+  const std::size_t count_before = body_before.instructions.size();
+
+  null_message_handlert msg;
+  mm_io(model, regions, msg);
+
+  // After instrumentation, the function should have more instructions
+  // (the write dispatch replaces the single assignment)
+  const auto &body_after =
+    model.goto_functions.function_map.at("test_fun").body;
+  REQUIRE(body_after.instructions.size() > count_before);
+
+  // The original dereference assignment should be gone; instead we
+  // should find an assignment to the region array symbol
+  bool found_region_write = false;
+  for(const auto &inst : body_after.instructions)
+  {
+    if(inst.is_assign())
+    {
+      const auto &lhs = inst.assign_lhs();
+      if(lhs.id() == ID_index)
+      {
+        const auto &array = to_index_expr(lhs).array();
+        if(
+          array.id() == ID_symbol && to_symbol_expr(array).get_identifier() ==
+                                       CPROVER_PREFIX "mmio_region_0x1000")
+        {
+          found_region_write = true;
+        }
+      }
+    }
+  }
+  REQUIRE(found_region_write);
+}


### PR DESCRIPTION
This new option will enable us to eventually drop support for
__CPROVER_allocated_memory, which
1) requires awkward scanning of goto functions in goto_check_c,
2) wrongly suggests these declarations are limited to some scope, and
3) yields a spurious undefined-function warning in symex.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
