### PR TITLE
goto_rw/range_spect: wrap in a class instead of using just a typedef [blocks: #6749, #6768]

### DIFF
--- a/src/analyses/dependence_graph.cpp
+++ b/src/analyses/dependence_graph.cpp
@@ -125,22 +125,28 @@ void dep_graph_domaint::control_dependencies(
 }
 
 static bool may_be_def_use_pair(
-  const mp_integer &w_start,
-  const mp_integer &w_end,
-  const mp_integer &r_start,
-  const mp_integer &r_end)
+  const range_spect &w_start,
+  const range_spect &w_end,
+  const range_spect &r_start,
+  const range_spect &r_end)
 {
-  assert(w_start>=0);
-  assert(r_start>=0);
+  PRECONDITION(w_start >= range_spect{0});
+  PRECONDITION(r_start >= range_spect{0});
 
-  if((w_end!=-1 && w_end <= r_start) || // we < rs
-     (r_end!=-1 && w_start >= r_end)) // re < we
+  if(
+    (!w_end.is_unknown() && w_end <= r_start) || // we < rs
+    (!r_end.is_unknown() && w_start >= r_end))   // re < we
+  {
     return false;
+  }
   else if(w_start >= r_start) // rs <= ws < we,re
     return true;
-  else if(w_end==-1 ||
-          (r_end!=-1 && w_end > r_start)) // ws <= rs < we,re
+  else if(
+    w_end.is_unknown() ||
+    (!r_end.is_unknown() && w_end > r_start)) // ws <= rs < we,re
+  {
     return true;
+  }
   else
     return false;
 }

--- a/src/analyses/reaching_definitions.h
+++ b/src/analyses/reaching_definitions.h
@@ -92,10 +92,20 @@ struct reaching_definitiont
   /// The two integers below define a range of bits (i.e. the begin and end bit
   /// indices) which represent the value of the variable. So, the integers
   /// represents the half-open interval `[bit_begin, bit_end)` of bits.
-  /// However, `bit_end` can also be set a special value `-1`, which means
-  /// infinite/unknown index.
   range_spect bit_begin;
   range_spect bit_end;
+
+  reaching_definitiont(
+    const irep_idt &identifier,
+    const ai_domain_baset::locationt &definition_at,
+    const range_spect &bit_begin,
+    const range_spect &bit_end)
+    : identifier(identifier),
+      definition_at(definition_at),
+      bit_begin(bit_begin),
+      bit_end(bit_end)
+  {
+  }
 };
 
 /// In order to use instances of this structure as keys in ordered containers,
@@ -109,15 +119,27 @@ inline bool operator<(
   if(b.definition_at<a.definition_at)
     return false;
 
-  if(a.bit_begin<b.bit_begin)
-    return true;
-  if(b.bit_begin<a.bit_begin)
-    return false;
+  if(a.bit_begin.is_unknown() != b.bit_begin.is_unknown())
+    return a.bit_begin.is_unknown();
 
-  if(a.bit_end<b.bit_end)
-    return true;
-  if(b.bit_end<a.bit_end)
-    return false;
+  if(!a.bit_begin.is_unknown())
+  {
+    if(a.bit_begin < b.bit_begin)
+      return true;
+    if(b.bit_begin < a.bit_begin)
+      return false;
+  }
+
+  if(a.bit_end.is_unknown() != b.bit_end.is_unknown())
+    return a.bit_end.is_unknown();
+
+  if(!a.bit_end.is_unknown())
+  {
+    if(a.bit_end < b.bit_end)
+      return true;
+    if(b.bit_end < a.bit_end)
+      return false;
+  }
 
   // we do not expect comparison of unrelated definitions
   // as this operator< is only used in sparse_bitvector_analysist


### PR DESCRIPTION
This helps avoiding magic "-1" constants in this code (which now is
range_spect::unknown()).

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
