### PR TITLE
Disambiguate overloaded insert(...) calls [blocks: #6749]

### DIFF
--- a/src/pointer-analysis/value_set.cpp
+++ b/src/pointer-analysis/value_set.cpp
@@ -564,7 +564,9 @@ void value_sett::get_value_set_rec(
     if(is_null_pointer(to_constant_expr(expr)))
     {
       insert(
-        dest, exprt(ID_null_object, to_pointer_type(expr_type).base_type()), 0);
+        dest,
+        exprt(ID_null_object, to_pointer_type(expr_type).base_type()),
+        mp_integer{0});
     }
     else if(expr_type.id()==ID_unsignedbv ||
             expr_type.id()==ID_signedbv)
@@ -593,7 +595,7 @@ void value_sett::get_value_set_rec(
       // integer-to-pointer
 
       if(op.is_zero())
-        insert(dest, exprt(ID_null_object, expr_type.subtype()), 0);
+        insert(dest, exprt(ID_null_object, expr_type.subtype()), mp_integer{0});
       else
       {
         // see if we have something for the integer
@@ -778,7 +780,7 @@ void value_sett::get_value_set_rec(
       dynamic_object.set_instance(location_number);
       dynamic_object.valid()=true_exprt();
 
-      insert(dest, dynamic_object, 0);
+      insert(dest, dynamic_object, mp_integer{0});
     }
     else if(statement==ID_cpp_new ||
             statement==ID_cpp_new_array)
@@ -791,7 +793,7 @@ void value_sett::get_value_set_rec(
       dynamic_object.set_instance(location_number);
       dynamic_object.valid()=true_exprt();
 
-      insert(dest, dynamic_object, 0);
+      insert(dest, dynamic_object, mp_integer{0});
     }
     else
       insert(dest, exprt(ID_unknown, original_type));
@@ -1092,7 +1094,7 @@ void value_sett::get_reference_set_rec(
       to_array_type(expr.type()).element_type().id() == ID_array)
       insert(dest, expr);
     else
-      insert(dest, expr, 0);
+      insert(dest, expr, mp_integer{0});
 
     return;
   }

--- a/src/pointer-analysis/value_set_fi.cpp
+++ b/src/pointer-analysis/value_set_fi.cpp
@@ -181,7 +181,7 @@ void value_set_fit::flatten_rec(
       {
         // this is some static object, keep it in.
         const symbol_exprt se(o.get(ID_identifier), o.type().subtype());
-        insert(dest, se, 0);
+        insert(dest, se, mp_integer{0});
       }
       else
       {
@@ -461,7 +461,7 @@ void value_set_fit::get_value_set_rec(
 
     if(has_prefix(id2string(ident), alloc_adapter_prefix))
     {
-      insert(dest, expr, 0);
+      insert(dest, expr, mp_integer{0});
       return;
     }
     else if(v_it!=values.end())
@@ -469,7 +469,7 @@ void value_set_fit::get_value_set_rec(
       typet t("#REF#");
       t.subtype() = expr.type();
       symbol_exprt sym(ident, t);
-      insert(dest, sym, 0);
+      insert(dest, sym, mp_integer{0});
       return;
     }
   }
@@ -521,7 +521,7 @@ void value_set_fit::get_value_set_rec(
     // check if NULL
     if(is_null_pointer(to_constant_expr(expr)))
     {
-      insert(dest, exprt(ID_null_object, expr.type().subtype()), 0);
+      insert(dest, exprt(ID_null_object, expr.type().subtype()), mp_integer{0});
       return;
     }
   }
@@ -620,7 +620,7 @@ void value_set_fit::get_value_set_rec(
         (from_function << 16) | from_target_index);
       dynamic_object.valid()=true_exprt();
 
-      insert(dest, dynamic_object, 0);
+      insert(dest, dynamic_object, mp_integer{0});
       return;
     }
     else if(statement==ID_cpp_new ||
@@ -634,14 +634,14 @@ void value_set_fit::get_value_set_rec(
         (from_function << 16) | from_target_index);
       dynamic_object.valid()=true_exprt();
 
-      insert(dest, dynamic_object, 0);
+      insert(dest, dynamic_object, mp_integer{0});
       return;
     }
   }
   else if(expr.id()==ID_struct)
   {
     // this is like a static struct object
-    insert(dest, address_of_exprt(expr), 0);
+    insert(dest, address_of_exprt(expr), mp_integer{0});
     return;
   }
   else if(expr.id()==ID_with)
@@ -785,7 +785,7 @@ void value_set_fit::get_reference_set_sharing_rec(
        expr.type().subtype().id()==ID_array)
       insert(dest, expr);
     else
-      insert(dest, expr, 0);
+      insert(dest, expr, mp_integer{0});
 
     return;
   }


### PR DESCRIPTION
Once we move to std::optional, the use of int results in an ambiguous
overload resolution. Avoid that by explicitly constructing an
mp_integer.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
