### PR TITLE
Remove unqualified use of nullopt [blocks: #6749]

### DIFF
--- a/src/ansi-c/expr2c.cpp
+++ b/src/ansi-c/expr2c.cpp
@@ -4031,7 +4031,7 @@ optionalt<std::string> expr2ct::convert_function(const exprt &src)
 
   const auto function_entry = function_names.find(src.id());
   if(function_entry == function_names.end())
-    return nullopt;
+    return {};
 
   return convert_function(src, function_entry->second);
 }

--- a/src/goto-analyzer/unreachable_instructions.cpp
+++ b/src/goto-analyzer/unreachable_instructions.cpp
@@ -104,7 +104,7 @@ static optionalt<std::string>
 file_name_string_opt(const source_locationt &source_location)
 {
   if(source_location.get_file().empty())
-    return nullopt;
+    return {};
 
   return concat_dir_file(
     id2string(source_location.get_working_directory()),
@@ -255,7 +255,7 @@ line_string_opt(const source_locationt &source_location)
   const irep_idt &line = source_location.get_line();
 
   if(line.empty())
-    return nullopt;
+    return {};
   else
     return id2string(line);
 }

--- a/src/memory-analyzer/gdb_api.h
+++ b/src/memory-analyzer/gdb_api.h
@@ -80,7 +80,7 @@ public:
       const std::string &address = "",
       const std::string &pointee = "",
       const std::string &character = "",
-      const optionalt<std::string> &string = nullopt,
+      const optionalt<std::string> &string = {},
       const bool valid = false)
       : address(address),
         pointee(pointee),

--- a/src/solvers/flattening/boolbv.h
+++ b/src/solvers/flattening/boolbv.h
@@ -59,7 +59,7 @@ public:
 
   virtual const bvt &convert_bv( // check cache
     const exprt &expr,
-    const optionalt<std::size_t> expected_width = nullopt);
+    const optionalt<std::size_t> expected_width = {});
 
   virtual bvt convert_bitvector(const exprt &expr); // no cache
 

--- a/src/solvers/flattening/boolbv_quantifier.cpp
+++ b/src/solvers/flattening/boolbv_quantifier.cpp
@@ -193,13 +193,13 @@ static optionalt<exprt> eager_quantifier_instantiation(
     get_quantifier_var_max(var_expr, where_simplified);
 
   if(!min_i.has_value() || !max_i.has_value())
-    return nullopt;
+    return {};
 
   mp_integer lb = numeric_cast_v<mp_integer>(min_i.value());
   mp_integer ub = numeric_cast_v<mp_integer>(max_i.value());
 
   if(lb > ub)
-    return nullopt;
+    return {};
 
   auto expr_simplified =
     quantifier_exprt(expr.id(), expr.variables(), where_simplified);

--- a/src/util/edit_distance.cpp
+++ b/src/util/edit_distance.cpp
@@ -69,5 +69,5 @@ levenshtein_automatont::get_edit_distance(const std::string &string) const
       return distance;
     }
   }
-  return nullopt;
+  return {};
 }

--- a/src/util/optional_utils.h
+++ b/src/util/optional_utils.h
@@ -22,7 +22,7 @@ auto optional_lookup(const map_like_collectiont &map, const keyt &key)
   {
     return it->second;
   }
-  return nullopt;
+  return {};
 }
 
 #endif // CPROVER_UTIL_OPTIONAL_UTILS_H

--- a/src/util/string2int.cpp
+++ b/src/util/string2int.cpp
@@ -16,14 +16,14 @@ Author: Michael Tautschnig, michael.tautschnig@cs.ox.ac.uk
 unsigned safe_string2unsigned(const std::string &str, int base)
 {
   auto converted = string2optional<unsigned>(str, base);
-  CHECK_RETURN(converted != nullopt);
+  CHECK_RETURN(converted.has_value());
   return *converted;
 }
 
 std::size_t safe_string2size_t(const std::string &str, int base)
 {
   auto converted = string2optional<std::size_t>(str, base);
-  CHECK_RETURN(converted != nullopt);
+  CHECK_RETURN(converted.has_value());
   return *converted;
 }
 

--- a/unit/util/string2int.cpp
+++ b/unit/util/string2int.cpp
@@ -22,8 +22,8 @@ TEST_CASE(
   "optionally converting invalid string to integer should return nullopt",
   "[core][util][string2int]")
 {
-  REQUIRE(string2optional_int("thirteen") == nullopt);
-  REQUIRE(string2optional_int("c0fefe") == nullopt);
+  REQUIRE(!string2optional_int("thirteen").has_value());
+  REQUIRE(!string2optional_int("c0fefe").has_value());
 }
 
 TEST_CASE(
@@ -31,8 +31,8 @@ TEST_CASE(
   "[core][util][string2int]")
 {
   REQUIRE(
-    string2optional_int("0xfffffffffffffffffffffffffffffffffffffffffff", 16) ==
-    nullopt);
+    !string2optional_int("0xfffffffffffffffffffffffffffffffffffffffffff", 16)
+       .has_value());
 }
 
 TEST_CASE(
@@ -47,18 +47,18 @@ TEST_CASE(
   "optionally converting invalid string to unsigned should return nullopt",
   "[core][util][string2int]")
 {
-  REQUIRE(string2optional_unsigned("thirteen") == nullopt);
-  REQUIRE(string2optional_unsigned("c0fefe") == nullopt);
+  REQUIRE(!string2optional_unsigned("thirteen").has_value());
+  REQUIRE(!string2optional_unsigned("c0fefe").has_value());
 }
 
 TEST_CASE(
   "optionally converting string out of range to unsigned should return nullopt",
   "[core][util][string2int]")
 {
-  REQUIRE(
-    string2optional_unsigned(
-      "0xfffffffffffffffffffffffffffffffffffffffffff", 16) == nullopt);
-  REQUIRE(string2optional_unsigned("-5") == nullopt);
+  REQUIRE(!string2optional_unsigned(
+             "0xfffffffffffffffffffffffffffffffffffffffffff", 16)
+             .has_value());
+  REQUIRE(!string2optional_unsigned("-5").has_value());
 }
 
 TEST_CASE(
@@ -73,8 +73,8 @@ TEST_CASE(
   "optionally converting invalid string to size_t should return nullopt",
   "[core][util][string2int]")
 {
-  REQUIRE(string2optional_size_t("thirteen") == nullopt);
-  REQUIRE(string2optional_size_t("c0fefe") == nullopt);
+  REQUIRE(!string2optional_size_t("thirteen").has_value());
+  REQUIRE(!string2optional_size_t("c0fefe").has_value());
 }
 
 TEST_CASE(
@@ -82,7 +82,7 @@ TEST_CASE(
   "[core][util][string2int]")
 {
   REQUIRE(
-    string2optional_size_t(
-      "0xfffffffffffffffffffffffffffffffffffffffffff", 16) == nullopt);
-  REQUIRE(string2optional_size_t("-5") == nullopt);
+    !string2optional_size_t("0xfffffffffffffffffffffffffffffffffffffffffff", 16)
+       .has_value());
+  REQUIRE(!string2optional_size_t("-5").has_value());
 }


### PR DESCRIPTION
When moving to std::optional we'd have to use std::nullopt. Avoid doing
so by using {} instead, which works today and will work with
std::optional.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
