### PR TITLE
Add missing #include <cassert>

### DIFF
--- a/src/ansi-c/c_typecheck_expr.cpp
+++ b/src/ansi-c/c_typecheck_expr.cpp
@@ -9,11 +9,6 @@ Author: Daniel Kroening, kroening@kroening.com
 /// \file
 /// ANSI-C Language Type Checking
 
-#include "c_typecheck_base.h"
-
-#include <cassert>
-#include <sstream>
-
 #include <util/arith_tools.h>
 #include <util/bitvector_expr.h>
 #include <util/c_types.h>
@@ -40,9 +35,13 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "builtin_factory.h"
 #include "c_expr.h"
 #include "c_qualifiers.h"
+#include "c_typecheck_base.h"
 #include "expr2c.h"
 #include "padding.h"
 #include "type2name.h"
+
+#include <cassert>
+#include <sstream>
 
 void c_typecheck_baset::typecheck_expr(exprt &expr)
 {

--- a/src/ansi-c/c_typecheck_expr.cpp
+++ b/src/ansi-c/c_typecheck_expr.cpp
@@ -11,6 +11,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "c_typecheck_base.h"
 
+#include <cassert>
 #include <sstream>
 
 #include <util/arith_tools.h>

--- a/src/ansi-c/c_typecheck_initializer.cpp
+++ b/src/ansi-c/c_typecheck_initializer.cpp
@@ -23,6 +23,8 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "c_typecheck_base.h"
 #include "type2name.h"
 
+#include <cassert>
+
 void c_typecheck_baset::do_initializer(
   exprt &initializer,
   const typet &type,

--- a/src/ansi-c/c_typecheck_type.cpp
+++ b/src/ansi-c/c_typecheck_type.cpp
@@ -11,6 +11,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "c_typecheck_base.h"
 
+#include <cassert>
 #include <unordered_set>
 
 #include <goto-programs/goto_instruction_code.h>

--- a/src/ansi-c/c_typecheck_type.cpp
+++ b/src/ansi-c/c_typecheck_type.cpp
@@ -9,13 +9,6 @@ Author: Daniel Kroening, kroening@kroening.com
 /// \file
 /// C++ Language Type Checking
 
-#include "c_typecheck_base.h"
-
-#include <cassert>
-#include <unordered_set>
-
-#include <goto-programs/goto_instruction_code.h>
-
 #include <util/arith_tools.h>
 #include <util/c_types.h>
 #include <util/config.h>
@@ -25,13 +18,19 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/pointer_offset_size.h>
 #include <util/simplify_expr.h>
 
+#include <goto-programs/goto_instruction_code.h>
+
 #include "ansi_c_convert_type.h"
 #include "ansi_c_declaration.h"
 #include "c_qualifiers.h"
+#include "c_typecheck_base.h"
 #include "gcc_types.h"
 #include "padding.h"
 #include "type2name.h"
 #include "typedef_type.h"
+
+#include <cassert>
+#include <unordered_set>
 
 void c_typecheck_baset::typecheck_type(typet &type)
 {

--- a/src/cpp/cpp_instantiate_template.cpp
+++ b/src/cpp/cpp_instantiate_template.cpp
@@ -15,12 +15,12 @@ Author: Daniel Kroening, kroening@cs.cmu.edu
 #include <iostream>
 #endif
 
-#include <cassert>
-
 #include <util/arith_tools.h>
 #include <util/base_exceptions.h>
 
 #include "cpp_type2name.h"
+
+#include <cassert>
 
 std::string cpp_typecheckt::template_suffix(
   const cpp_template_args_tct &template_args)

--- a/src/cpp/cpp_instantiate_template.cpp
+++ b/src/cpp/cpp_instantiate_template.cpp
@@ -15,6 +15,8 @@ Author: Daniel Kroening, kroening@cs.cmu.edu
 #include <iostream>
 #endif
 
+#include <cassert>
+
 #include <util/arith_tools.h>
 #include <util/base_exceptions.h>
 

--- a/src/cpp/cpp_typecheck.cpp
+++ b/src/cpp/cpp_typecheck.cpp
@@ -12,6 +12,7 @@ Author: Daniel Kroening, kroening@cs.cmu.edu
 #include "cpp_typecheck.h"
 
 #include <algorithm>
+#include <cassert>
 
 #include <util/pointer_expr.h>
 #include <util/source_location.h>

--- a/src/cpp/cpp_typecheck.cpp
+++ b/src/cpp/cpp_typecheck.cpp
@@ -11,9 +11,6 @@ Author: Daniel Kroening, kroening@cs.cmu.edu
 
 #include "cpp_typecheck.h"
 
-#include <algorithm>
-#include <cassert>
-
 #include <util/pointer_expr.h>
 #include <util/source_location.h>
 #include <util/symbol.h>
@@ -23,6 +20,9 @@ Author: Daniel Kroening, kroening@cs.cmu.edu
 #include "cpp_declarator.h"
 #include "cpp_util.h"
 #include "expr2cpp.h"
+
+#include <algorithm>
+#include <cassert>
 
 void cpp_typecheckt::convert(cpp_itemt &item)
 {

--- a/src/cpp/cpp_typecheck_code.cpp
+++ b/src/cpp/cpp_typecheck_code.cpp
@@ -21,6 +21,8 @@ Author: Daniel Kroening, kroening@cs.cmu.edu
 #include "cpp_typecheck_fargs.h"
 #include "cpp_util.h"
 
+#include <cassert>
+
 void cpp_typecheckt::typecheck_code(codet &code)
 {
   const irep_idt &statement=code.get_statement();

--- a/src/cpp/cpp_typecheck_code.cpp
+++ b/src/cpp/cpp_typecheck_code.cpp
@@ -9,8 +9,6 @@ Author: Daniel Kroening, kroening@cs.cmu.edu
 /// \file
 /// C++ Language Type Checking
 
-#include "cpp_typecheck.h"
-
 #include <util/arith_tools.h>
 #include <util/bitvector_expr.h>
 #include <util/pointer_expr.h>
@@ -18,6 +16,7 @@ Author: Daniel Kroening, kroening@cs.cmu.edu
 
 #include "cpp_declarator_converter.h"
 #include "cpp_exception_id.h"
+#include "cpp_typecheck.h"
 #include "cpp_typecheck_fargs.h"
 #include "cpp_util.h"
 

--- a/src/cpp/cpp_typecheck_compound_type.cpp
+++ b/src/cpp/cpp_typecheck_compound_type.cpp
@@ -15,12 +15,9 @@ Author: Daniel Kroening, kroening@cs.cmu.edu
 #include <iostream>
 #endif
 
-#include <algorithm>
-#include <cassert>
-
 #include <util/arith_tools.h>
-#include <util/std_types.h>
 #include <util/c_types.h>
+#include <util/std_types.h>
 
 #include <ansi-c/c_qualifiers.h>
 
@@ -28,6 +25,9 @@ Author: Daniel Kroening, kroening@cs.cmu.edu
 #include "cpp_name.h"
 #include "cpp_type2name.h"
 #include "cpp_util.h"
+
+#include <algorithm>
+#include <cassert>
 
 bool cpp_typecheckt::has_const(const typet &type)
 {

--- a/src/cpp/cpp_typecheck_compound_type.cpp
+++ b/src/cpp/cpp_typecheck_compound_type.cpp
@@ -16,6 +16,7 @@ Author: Daniel Kroening, kroening@cs.cmu.edu
 #endif
 
 #include <algorithm>
+#include <cassert>
 
 #include <util/arith_tools.h>
 #include <util/std_types.h>

--- a/src/cpp/cpp_typecheck_constructor.cpp
+++ b/src/cpp/cpp_typecheck_constructor.cpp
@@ -9,14 +9,14 @@ Author: Daniel Kroening, kroening@cs.cmu.edu
 /// \file
 /// C++ Language Type Checking
 
-#include "cpp_typecheck.h"
-
-#include <goto-programs/goto_instruction_code.h>
-
 #include <util/arith_tools.h>
 #include <util/c_types.h>
 #include <util/pointer_expr.h>
 #include <util/std_code.h>
+
+#include <goto-programs/goto_instruction_code.h>
+
+#include "cpp_typecheck.h"
 
 #include <cassert>
 

--- a/src/cpp/cpp_typecheck_constructor.cpp
+++ b/src/cpp/cpp_typecheck_constructor.cpp
@@ -18,6 +18,8 @@ Author: Daniel Kroening, kroening@cs.cmu.edu
 #include <util/pointer_expr.h>
 #include <util/std_code.h>
 
+#include <cassert>
+
 /// Generate code to copy the parent.
 /// \param source_location: location for generated code
 /// \param parent_base_name: base name of typechecked parent

--- a/src/cpp/cpp_typecheck_conversions.cpp
+++ b/src/cpp/cpp_typecheck_conversions.cpp
@@ -23,6 +23,8 @@ Author:
 
 #include "cpp_util.h"
 
+#include <cassert>
+
 /// Lvalue-to-rvalue conversion
 ///
 ///  An lvalue (3.10) of a non-function, non-array type T can be

--- a/src/cpp/cpp_typecheck_conversions.cpp
+++ b/src/cpp/cpp_typecheck_conversions.cpp
@@ -9,8 +9,6 @@ Author:
 /// \file
 /// C++ Language Type Checking
 
-#include "cpp_typecheck.h"
-
 #include <util/arith_tools.h>
 #include <util/c_types.h>
 #include <util/config.h>
@@ -21,6 +19,7 @@ Author:
 
 #include <ansi-c/c_qualifiers.h>
 
+#include "cpp_typecheck.h"
 #include "cpp_util.h"
 
 #include <cassert>

--- a/src/cpp/cpp_typecheck_expr.cpp
+++ b/src/cpp/cpp_typecheck_expr.cpp
@@ -15,6 +15,8 @@ Author: Daniel Kroening, kroening@cs.cmu.edu
 #include <iostream>
 #endif
 
+#include <cassert>
+
 #include <util/arith_tools.h>
 #include <util/c_types.h>
 #include <util/config.h>

--- a/src/cpp/cpp_typecheck_expr.cpp
+++ b/src/cpp/cpp_typecheck_expr.cpp
@@ -15,8 +15,6 @@ Author: Daniel Kroening, kroening@cs.cmu.edu
 #include <iostream>
 #endif
 
-#include <cassert>
-
 #include <util/arith_tools.h>
 #include <util/c_types.h>
 #include <util/config.h>
@@ -32,6 +30,8 @@ Author: Daniel Kroening, kroening@cs.cmu.edu
 #include "cpp_typecheck_fargs.h"
 #include "cpp_util.h"
 #include "expr2cpp.h"
+
+#include <cassert>
 
 bool cpp_typecheckt::find_parent(
   const symbolt &symb,

--- a/src/cpp/cpp_typecheck_resolve.cpp
+++ b/src/cpp/cpp_typecheck_resolve.cpp
@@ -16,6 +16,7 @@ Author: Daniel Kroening, kroening@cs.cmu.edu
 #endif
 
 #include <algorithm>
+#include <cassert>
 
 #include <util/arith_tools.h>
 #include <util/c_types.h>

--- a/src/cpp/cpp_typecheck_resolve.cpp
+++ b/src/cpp/cpp_typecheck_resolve.cpp
@@ -15,9 +15,6 @@ Author: Daniel Kroening, kroening@cs.cmu.edu
 #include <iostream>
 #endif
 
-#include <algorithm>
-#include <cassert>
-
 #include <util/arith_tools.h>
 #include <util/c_types.h>
 #include <util/mathematical_types.h>
@@ -34,6 +31,9 @@ Author: Daniel Kroening, kroening@cs.cmu.edu
 #include "cpp_typecheck.h"
 #include "cpp_typecheck_fargs.h"
 #include "cpp_util.h"
+
+#include <algorithm>
+#include <cassert>
 
 cpp_typecheck_resolvet::cpp_typecheck_resolvet(cpp_typecheckt &_cpp_typecheck):
   cpp_typecheck(_cpp_typecheck),

--- a/src/cpp/cpp_typecheck_template.cpp
+++ b/src/cpp/cpp_typecheck_template.cpp
@@ -20,6 +20,8 @@ Author: Daniel Kroening, kroening@cs.cmu.edu
 #include "cpp_convert_type.h"
 #include "cpp_template_args.h"
 
+#include <cassert>
+
 void cpp_typecheckt::salvage_default_arguments(
   const template_typet &old_type,
   template_typet &new_type)

--- a/src/cpp/cpp_typecheck_template.cpp
+++ b/src/cpp/cpp_typecheck_template.cpp
@@ -9,16 +9,15 @@ Author: Daniel Kroening, kroening@cs.cmu.edu
 /// \file
 /// C++ Language Type Checking
 
-#include "cpp_typecheck.h"
-
 #include <util/base_exceptions.h>
 #include <util/simplify_expr.h>
 
-#include "cpp_type2name.h"
-#include "cpp_declarator_converter.h"
-#include "cpp_template_type.h"
 #include "cpp_convert_type.h"
+#include "cpp_declarator_converter.h"
 #include "cpp_template_args.h"
+#include "cpp_template_type.h"
+#include "cpp_type2name.h"
+#include "cpp_typecheck.h"
 
 #include <cassert>
 

--- a/src/cpp/cpp_typecheck_type.cpp
+++ b/src/cpp/cpp_typecheck_type.cpp
@@ -9,15 +9,14 @@ Author: Daniel Kroening, kroening@cs.cmu.edu
 /// \file
 /// C++ Language Type Checking
 
-#include "cpp_typecheck.h"
-
-#include <util/source_location.h>
-#include <util/simplify_expr.h>
 #include <util/c_types.h>
+#include <util/simplify_expr.h>
+#include <util/source_location.h>
 
 #include <ansi-c/c_qualifiers.h>
 
 #include "cpp_convert_type.h"
+#include "cpp_typecheck.h"
 #include "cpp_typecheck_fargs.h"
 
 #include <cassert>

--- a/src/cpp/cpp_typecheck_type.cpp
+++ b/src/cpp/cpp_typecheck_type.cpp
@@ -20,6 +20,8 @@ Author: Daniel Kroening, kroening@cs.cmu.edu
 #include "cpp_convert_type.h"
 #include "cpp_typecheck_fargs.h"
 
+#include <cassert>
+
 void cpp_typecheckt::typecheck_type(typet &type)
 {
   assert(!type.id().empty());

--- a/src/cpp/parse.cpp
+++ b/src/cpp/parse.cpp
@@ -9,20 +9,19 @@ Author: Daniel Kroening, kroening@cs.cmu.edu
 /// \file
 /// C++ Language Parsing
 
-#include "cpp_parser.h"
-
-#include <cassert>
-#include <map>
-
 #include <util/c_types.h>
 #include <util/std_code.h>
 
 #include <ansi-c/ansi_c_y.tab.h>
 #include <ansi-c/merged_type.h>
 
-#include "cpp_token_buffer.h"
-#include "cpp_member_spec.h"
 #include "cpp_enum_type.h"
+#include "cpp_member_spec.h"
+#include "cpp_parser.h"
+#include "cpp_token_buffer.h"
+
+#include <cassert>
+#include <map>
 
 #ifdef DEBUG
 #include <iostream>

--- a/src/cpp/parse.cpp
+++ b/src/cpp/parse.cpp
@@ -11,6 +11,7 @@ Author: Daniel Kroening, kroening@cs.cmu.edu
 
 #include "cpp_parser.h"
 
+#include <cassert>
 #include <map>
 
 #include <util/c_types.h>

--- a/src/goto-diff/change_impact.cpp
+++ b/src/goto-diff/change_impact.cpp
@@ -13,6 +13,7 @@ Date: April 2016
 
 #include "change_impact.h"
 
+#include <cassert>
 #include <iostream>
 
 #include <goto-programs/goto_model.h>

--- a/src/goto-diff/change_impact.cpp
+++ b/src/goto-diff/change_impact.cpp
@@ -13,14 +13,14 @@ Date: April 2016
 
 #include "change_impact.h"
 
-#include <cassert>
-#include <iostream>
-
 #include <goto-programs/goto_model.h>
 
 #include <analyses/dependence_graph.h>
 
 #include "unified_diff.h"
+
+#include <cassert>
+#include <iostream>
 
 #if 0
   struct cfg_nodet

--- a/src/goto-instrument/goto_program2code.cpp
+++ b/src/goto-instrument/goto_program2code.cpp
@@ -11,6 +11,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "goto_program2code.h"
 
+#include <cassert>
 #include <sstream>
 
 #include <util/arith_tools.h>

--- a/src/goto-instrument/goto_program2code.cpp
+++ b/src/goto-instrument/goto_program2code.cpp
@@ -11,9 +11,6 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "goto_program2code.h"
 
-#include <cassert>
-#include <sstream>
-
 #include <util/arith_tools.h>
 #include <util/c_types.h>
 #include <util/expr_util.h>
@@ -21,6 +18,9 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/pointer_expr.h>
 #include <util/prefix.h>
 #include <util/simplify_expr.h>
+
+#include <cassert>
+#include <sstream>
 
 void goto_program2codet::operator()()
 {

--- a/src/goto-instrument/k_induction.cpp
+++ b/src/goto-instrument/k_induction.cpp
@@ -20,6 +20,8 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "loop_utils.h"
 #include "unwind.h"
 
+#include <cassert>
+
 class k_inductiont
 {
 public:

--- a/src/goto-instrument/k_induction.cpp
+++ b/src/goto-instrument/k_induction.cpp
@@ -11,10 +11,10 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "k_induction.h"
 
-#include <analyses/natural_loops.h>
-#include <analyses/local_may_alias.h>
-
 #include <goto-programs/remove_skip.h>
+
+#include <analyses/local_may_alias.h>
+#include <analyses/natural_loops.h>
 
 #include "havoc_utils.h"
 #include "loop_utils.h"

--- a/src/goto-instrument/unwind.cpp
+++ b/src/goto-instrument/unwind.cpp
@@ -16,6 +16,8 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <iostream>
 #endif
 
+#include <cassert>
+
 #include <util/expr_util.h>
 #include <util/std_expr.h>
 

--- a/src/goto-instrument/unwind.cpp
+++ b/src/goto-instrument/unwind.cpp
@@ -16,14 +16,14 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <iostream>
 #endif
 
-#include <cassert>
-
 #include <util/expr_util.h>
 #include <util/std_expr.h>
 
 #include <goto-programs/goto_functions.h>
 
 #include "unwindset.h"
+
+#include <cassert>
 
 void goto_unwindt::copy_segment(
   const goto_programt::const_targett start,

--- a/src/goto-instrument/wmm/cycle_collection.cpp
+++ b/src/goto-instrument/wmm/cycle_collection.cpp
@@ -11,9 +11,9 @@ Date: 2012
 /// \file
 /// collection of cycles in graph of abstract events
 
-#include "event_graph.h"
-
 #include <util/message.h>
+
+#include "event_graph.h"
 
 #include <cassert>
 

--- a/src/goto-instrument/wmm/cycle_collection.cpp
+++ b/src/goto-instrument/wmm/cycle_collection.cpp
@@ -15,6 +15,8 @@ Date: 2012
 
 #include <util/message.h>
 
+#include <cassert>
+
 /// after the collection, eliminates the executions forbidden by an indirect
 /// thin-air
 void event_grapht::graph_explorert::filter_thin_air(

--- a/src/goto-instrument/wmm/event_graph.cpp
+++ b/src/goto-instrument/wmm/event_graph.cpp
@@ -15,6 +15,7 @@ Date: 2012
 
 #include <util/message.h>
 
+#include <cassert>
 #include <fstream>
 
 

--- a/src/goto-instrument/wmm/goto2graph.cpp
+++ b/src/goto-instrument/wmm/goto2graph.cpp
@@ -13,6 +13,7 @@ Date: 2012
 
 #include "goto2graph.h"
 
+#include <cassert>
 #include <vector>
 #include <string>
 #include <fstream>

--- a/src/goto-instrument/wmm/goto2graph.cpp
+++ b/src/goto-instrument/wmm/goto2graph.cpp
@@ -13,19 +13,18 @@ Date: 2012
 
 #include "goto2graph.h"
 
-#include <cassert>
-#include <vector>
-#include <string>
-#include <fstream>
-
 #include <util/options.h>
 #include <util/prefix.h>
 
+#include <goto-instrument/rw_set.h>
 #include <linking/static_lifetime_init.h>
 
-#include <goto-instrument/rw_set.h>
-
 #include "fence.h"
+
+#include <cassert>
+#include <fstream>
+#include <string>
+#include <vector>
 
 // #define PRINT_UNSAFES
 


### PR DESCRIPTION
cassert is implicitly provided via nonstd/optional, but this will change
with the move to std::optional. The even better fix would be the
replacement of all uses of assert(...) in these files, but this is a
larger endeavour.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
