### PR TITLE
Use random_shuffle in a future-proof way

### DIFF
--- a/unit/util/interval/get_extreme.cpp
+++ b/unit/util/interval/get_extreme.cpp
@@ -3,8 +3,6 @@
  Author: DiffBlue Limited
 \*******************************************************************/
 
-#include <testing-utils/use_catch.h>
-
 #include <util/arith_tools.h>
 #include <util/bitvector_types.h>
 #include <util/interval.h>
@@ -12,6 +10,10 @@
 #include <util/namespace.h>
 #include <util/simplify_expr.h>
 #include <util/symbol_table.h>
+
+#include <testing-utils/use_catch.h>
+
+#include <random>
 
 #define V(X) (bvrep2integer(X.get(ID_value).c_str(), 32, true))
 #define V_(X) (bvrep2integer(X.c_str(), 32, true))
@@ -147,7 +149,9 @@ SCENARIO("get extreme exprt value", "[core][analyses][interval][get_extreme]")
 
     WHEN("All from [-100:100] are shuffled and selected")
     {
-      std::random_shuffle(ve.begin(), ve.end());
+      std::random_device rd;
+      std::mt19937 g(rd());
+      std::shuffle(ve.begin(), ve.end(), g);
 
       exprt min = constant_interval_exprt::get_extreme(ve, true);
       exprt max = constant_interval_exprt::get_extreme(ve, false);


### PR DESCRIPTION
Variants of random_shuffle supported in C++11 have been deprecated in
later versions of the standard. Specifying a random-number generator is
supported as of C++11 and not (yet) deprecated in any later version.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
