### PR TITLE
Full slicing: fix bugs in handling array_equal

### DIFF
--- a/regression/cbmc/Array_operations1/full-slice.desc
+++ b/regression/cbmc/Array_operations1/full-slice.desc
@@ -1,0 +1,18 @@
+CORE
+main.c
+--full-slice
+^EXIT=10$
+^SIGNAL=0$
+^\[test_copy\.assertion\.4\] .* expected to fail: FAILURE$
+^\[test_unequal\.assertion\.1\] .* different sizes arrays are unequal: SUCCESS
+^\[test_unequal\.assertion\.2\] .* expected to fail: FAILURE
+^\[test_unequal\.assertion\.3\] .* different typed arrays are unequal: SUCCESS
+^\[test_unequal\.assertion\.4\] .* expected to fail: FAILURE
+^\[test_unequal\.assertion\.5\] .* expected to fail: FAILURE
+^\[test_unequal\.assertion\.6\] .* expected to fail: FAILURE
+^\*\* 5 of 14 failed
+^VERIFICATION FAILED$
+--
+^warning: ignoring
+--
+Verify the properties of various cprover array primitves

--- a/src/analyses/goto_rw.cpp
+++ b/src/analyses/goto_rw.cpp
@@ -772,11 +772,14 @@ static void goto_rw_other(
   else if(statement == ID_array_equal)
   {
     // mark the dereferenced operands as being read
-    for(const auto &op : code.operands())
-    {
-      rw_set.get_array_objects(
-        function, target, rw_range_sett::get_modet::READ, op);
-    }
+    PRECONDITION(code.operands().size() == 3);
+    rw_set.get_array_objects(
+      function, target, rw_range_sett::get_modet::READ, code.op0());
+    rw_set.get_array_objects(
+      function, target, rw_range_sett::get_modet::READ, code.op1());
+    // the third operand is the result
+    rw_set.get_objects_rec(
+      function, target, rw_range_sett::get_modet::LHS_W, code.op2());
   }
   else if(statement == ID_array_set)
   {

--- a/src/pointer-analysis/value_set.cpp
+++ b/src/pointer-analysis/value_set.cpp
@@ -1613,8 +1613,7 @@ void value_sett::apply_code_rec(
   {
     // can be ignored, we don't expect side effects here
   }
-  else if(statement=="cpp_delete" ||
-          statement=="cpp_delete[]")
+  else if(statement == ID_cpp_delete || statement == ID_cpp_delete_array)
   {
     // does nothing
   }
@@ -1649,6 +1648,9 @@ void value_sett::apply_code_rec(
   {
   }
   else if(statement==ID_array_replace)
+  {
+  }
+  else if(statement == ID_array_equal)
   {
   }
   else if(statement==ID_assume)

--- a/src/pointer-analysis/value_set_fi.cpp
+++ b/src/pointer-analysis/value_set_fi.cpp
@@ -1390,9 +1390,9 @@ void value_set_fit::apply_code(const codet &code, const namespacet &ns)
   else if(statement==ID_fence)
   {
   }
-  else if(statement==ID_array_copy ||
-          statement==ID_array_replace ||
-          statement==ID_array_set)
+  else if(
+    statement == ID_array_copy || statement == ID_array_replace ||
+    statement == ID_array_set || statement == ID_array_equal)
   {
   }
   else if(can_cast_expr<code_inputt>(code) || can_cast_expr<code_outputt>(code))


### PR DESCRIPTION
This statement has three operands, where the third holds the comparison
result. Make sure value sets know about this statement.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
