### PR TITLE
Full slice: support havoc_object

### DIFF
--- a/regression/cbmc/havoc_object1/full-slice.desc
+++ b/regression/cbmc/havoc_object1/full-slice.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+--full-slice
+^EXIT=10$
+^SIGNAL=0$
+^VERIFICATION FAILED$
+^\*\* 6 of 8 failed.*$
+--

--- a/src/analyses/goto_rw.cpp
+++ b/src/analyses/goto_rw.cpp
@@ -794,6 +794,14 @@ static void goto_rw_other(
     rw_set.get_array_objects(
       function, target, rw_range_sett::get_modet::READ, code.op1());
   }
+  else if(statement == ID_havoc_object)
+  {
+    PRECONDITION(code.operands().size() == 1);
+    // re-use get_array_objects as this havoc_object affects whatever is the
+    // object being the pointer that code.op0() is
+    rw_set.get_array_objects(
+      function, target, rw_range_sett::get_modet::LHS_W, code.op0());
+  }
 }
 
 static void goto_rw(

--- a/src/pointer-analysis/value_set.cpp
+++ b/src/pointer-analysis/value_set.cpp
@@ -1672,6 +1672,9 @@ void value_sett::apply_code_rec(
   {
     // Ignore by default; could prune the value set.
   }
+  else if(statement == ID_havoc_object)
+  {
+  }
   else
   {
     // std::cerr << code.pretty() << '\n';

--- a/src/pointer-analysis/value_set_fi.cpp
+++ b/src/pointer-analysis/value_set_fi.cpp
@@ -1399,6 +1399,9 @@ void value_set_fit::apply_code(const codet &code, const namespacet &ns)
   {
     // doesn't do anything
   }
+  else if(statement == ID_havoc_object)
+  {
+  }
   else
     throw
       code.pretty()+"\n"+


### PR DESCRIPTION
Value sets should at least accept this statement exists, and goto_rw
needs to ensure that it knows about the write side-effect of it.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
