### PR TITLE
Do not use optionalt::value() [blocks: #6749]

### DIFF
--- a/jbmc/src/java_bytecode/java_bytecode_convert_method.cpp
+++ b/jbmc/src/java_bytecode/java_bytecode_convert_method.cpp
@@ -255,7 +255,7 @@ java_method_typet member_type_lazy(
     try
     {
       auto member_type_from_signature =
-        java_type_from_string(signature.value(), class_name);
+        java_type_from_string(*signature, class_name);
       INVARIANT(
         member_type_from_signature.has_value() &&
           member_type_from_signature->id() == ID_code,
@@ -269,7 +269,7 @@ java_method_typet member_type_lazy(
       else
       {
         message.debug() << "Method: " << class_name << "." << method_name
-                        << "\n signature: " << signature.value()
+                        << "\n signature: " << *signature
                         << "\n descriptor: " << descriptor
                         << "\n different number of parameters, reverting to "
                            "descriptor"
@@ -279,8 +279,8 @@ java_method_typet member_type_lazy(
     catch(const unsupported_java_class_signature_exceptiont &e)
     {
       message.debug() << "Method: " << class_name << "." << method_name
-                      << "\n could not parse signature: " << signature.value()
-                      << "\n " << e.what() << "\n"
+                      << "\n could not parse signature: " << *signature << "\n "
+                      << e.what() << "\n"
                       << " reverting to descriptor: " << descriptor
                       << message.eom;
     }

--- a/jbmc/src/java_bytecode/java_bytecode_language.cpp
+++ b/jbmc/src/java_bytecode/java_bytecode_language.cpp
@@ -338,10 +338,10 @@ void java_bytecode_languaget::parse_from_main_class()
         throwMainClassLoadingError(id2string(main_class));
         return;
       }
-      status() << "Trying to load Java main class: " << maybe_class_name.value()
+      status() << "Trying to load Java main class: " << *maybe_class_name
                << eom;
       if(!java_class_loader.can_load_class(
-           maybe_class_name.value(), get_message_handler()))
+           *maybe_class_name, get_message_handler()))
       {
         throwMainClassLoadingError(id2string(main_class));
         return;
@@ -349,7 +349,7 @@ void java_bytecode_languaget::parse_from_main_class()
       // Everything went well. We have a loadable main class.
       // The entry point ('main') will be checked later.
       config.main = id2string(main_class);
-      main_class = maybe_class_name.value();
+      main_class = *maybe_class_name;
     }
     status() << "Found Java main class: " << main_class << eom;
     // Now really load it.
@@ -403,7 +403,7 @@ bool java_bytecode_languaget::parse(
       // If we have an entry method, we can derive a main class.
       if(config.main.has_value())
       {
-        const std::string &entry_method = config.main.value();
+        const std::string &entry_method = *config.main;
         const auto last_dot_position = entry_method.find_last_of('.');
         main_class = entry_method.substr(0, last_dot_position);
       }

--- a/jbmc/src/java_bytecode/java_entry_point.cpp
+++ b/jbmc/src/java_bytecode/java_entry_point.cpp
@@ -557,8 +557,8 @@ main_function_resultt get_main_symbol(
   if(config.main.has_value())
   {
     std::string error_message;
-    irep_idt main_symbol_id = resolve_friendly_method_name(
-      config.main.value(), symbol_table, error_message);
+    irep_idt main_symbol_id =
+      resolve_friendly_method_name(*config.main, symbol_table, error_message);
 
     if(main_symbol_id.empty())
     {

--- a/jbmc/src/java_bytecode/java_types.h
+++ b/jbmc/src/java_bytecode/java_types.h
@@ -1145,7 +1145,7 @@ inline optionalt<typet> java_type_from_string_with_exception(
 {
   try
   {
-    return java_type_from_string(signature.value(), class_name);
+    return java_type_from_string(*signature, class_name);
   }
   catch(unsupported_java_class_signature_exceptiont &)
   {

--- a/jbmc/unit/java-testing-utils/require_goto_statements.cpp
+++ b/jbmc/unit/java-testing-utils/require_goto_statements.cpp
@@ -102,7 +102,7 @@ require_goto_statements::find_struct_component_assignments(
             const member_exprt &superclass_expr =
               to_member_expr(member_expr.compound());
             const irep_idt supercomponent_name =
-              "@" + id2string(superclass_name.value());
+              "@" + id2string(*superclass_name);
 
             object_descriptor_exprt ode;
             const namespacet ns(symbol_table);

--- a/jbmc/unit/java-testing-utils/require_type.cpp
+++ b/jbmc/unit/java-testing-utils/require_type.cpp
@@ -23,7 +23,7 @@ pointer_typet require_type::require_pointer(
   const pointer_typet &pointer = to_pointer_type(type);
 
   if(subtype)
-    REQUIRE(pointer.subtype() == subtype.value());
+    REQUIRE(pointer.subtype() == *subtype);
 
   return pointer;
 }
@@ -248,7 +248,7 @@ const typet &require_type::require_java_non_generic_type(
   REQUIRE(!is_java_generic_parameter(type));
   REQUIRE(!is_java_generic_type(type));
   if(expect_subtype)
-    REQUIRE(type.subtype() == expect_subtype.value());
+    REQUIRE(type.subtype() == *expect_subtype);
   return type;
 }
 

--- a/jbmc/unit/java_bytecode/java_types/generic_type_index.cpp
+++ b/jbmc/unit/java_bytecode/java_types/generic_type_index.cpp
@@ -34,9 +34,9 @@ SCENARIO("generic_type_index", "[core][java_types]")
       THEN("X has index 0, Y index 1 and Z is not found")
       {
         REQUIRE(indexX.has_value());
-        REQUIRE(indexX.value() == 0);
+        REQUIRE(*indexX == 0);
         REQUIRE(index_value.has_value());
-        REQUIRE(index_value.value() == 1);
+        REQUIRE(*index_value == 1);
         REQUIRE_FALSE(indexZ.has_value());
       }
     }
@@ -66,9 +66,9 @@ SCENARIO("generic_type_index", "[core][java_types]")
       THEN("K has index 0, V index 1 and T is not found")
       {
         REQUIRE(index_param0.has_value());
-        REQUIRE(index_param0.value() == 0);
+        REQUIRE(*index_param0 == 0);
         REQUIRE(index_param1.has_value());
-        REQUIRE(index_param1.value() == 1);
+        REQUIRE(*index_param1 == 1);
         REQUIRE_FALSE(index_param2.has_value());
       }
     }

--- a/src/analyses/variable-sensitivity/abstract_environment.cpp
+++ b/src/analyses/variable-sensitivity/abstract_environment.cpp
@@ -140,7 +140,7 @@ abstract_object_pointert abstract_environmentt::resolve_symbol(
   const auto symbol_entry = map.find(symbol.get_identifier());
 
   if(symbol_entry.has_value())
-    return symbol_entry.value();
+    return *symbol_entry;
   return abstract_object_factory(expr.type(), ns, true, false);
 }
 
@@ -490,7 +490,7 @@ abstract_environmentt::modified_symbols(
     const auto &second_entry = second.map.find(entry.first);
     if(second_entry.has_value())
     {
-      if(second_entry.value().get()->has_been_modified(entry.second))
+      if(second_entry->get()->has_been_modified(entry.second))
       {
         CHECK_RETURN(!entry.first.empty());
         symbols_diff.push_back(entry.first);

--- a/src/analyses/variable-sensitivity/full_array_abstract_object.cpp
+++ b/src/analyses/variable-sensitivity/full_array_abstract_object.cpp
@@ -334,8 +334,7 @@ abstract_object_pointert full_array_abstract_objectt::write_leaf_element(
       {
         result->map.replace(
           index.value,
-          abstract_objectt::merge(old_value.value(), value, widen_modet::no)
-            .object);
+          abstract_objectt::merge(*old_value, value, widen_modet::no).object);
       }
 
       DATA_INVARIANT(result->verify(), "Structural invariants maintained");
@@ -371,8 +370,7 @@ void full_array_abstract_objectt::map_put(
     // if we're over the max_index, merge with existing value
     auto replacement_value =
       overrun
-        ? abstract_objectt::merge(old_value.value(), value, widen_modet::no)
-            .object
+        ? abstract_objectt::merge(*old_value, value, widen_modet::no).object
         : value;
 
     map.replace(index_value, replacement_value);
@@ -386,7 +384,7 @@ abstract_object_pointert full_array_abstract_objectt::map_find_or_top(
 {
   auto value = map.find(index_value);
   if(value.has_value())
-    return value.value();
+    return *value;
   return get_top_entry(env, ns);
 }
 

--- a/src/analyses/variable-sensitivity/full_struct_abstract_object.cpp
+++ b/src/analyses/variable-sensitivity/full_struct_abstract_object.cpp
@@ -97,7 +97,7 @@ abstract_object_pointert full_struct_abstract_objectt::read_component(
 
     if(value.has_value())
     {
-      return value.value();
+      return *value;
     }
     else
     {
@@ -144,8 +144,7 @@ abstract_object_pointert full_struct_abstract_objectt::write_component(
     else
     {
       result->map.replace(
-        c,
-        environment.write(old_value.value(), value, stack, ns, merging_write));
+        c, environment.write(*old_value, value, stack, ns, merging_write));
     }
 
     result->set_not_top();
@@ -178,9 +177,7 @@ abstract_object_pointert full_struct_abstract_objectt::write_component(
       }
 
       result->map.replace(
-        c,
-        abstract_objectt::merge(old_value.value(), value, widen_modet::no)
-          .object);
+        c, abstract_objectt::merge(*old_value, value, widen_modet::no).object);
     }
     else
     {
@@ -225,8 +222,8 @@ void full_struct_abstract_objectt::output(
         out << ", ";
       }
       out << '.' << field.get_name() << '=';
-      static_cast<const abstract_object_pointert &>(value.value())
-        ->output(out, ai, ns);
+      static_cast<const abstract_object_pointert &>(*value)->output(
+        out, ai, ns);
       first = false;
     }
   }

--- a/src/analyses/variable-sensitivity/interval_abstract_value.cpp
+++ b/src/analyses/variable-sensitivity/interval_abstract_value.cpp
@@ -120,7 +120,7 @@ static inline mp_integer force_value_from_expr(const exprt &value)
   PRECONDITION(constant_interval_exprt::is_int(value.type()));
   optionalt<mp_integer> maybe_integer_value = numeric_cast<mp_integer>(value);
   INVARIANT(maybe_integer_value.has_value(), "Input has to have a value");
-  return maybe_integer_value.value();
+  return *maybe_integer_value;
 }
 
 static inline constant_interval_exprt

--- a/src/analyses/variable-sensitivity/liveness_context.cpp
+++ b/src/analyses/variable-sensitivity/liveness_context.cpp
@@ -15,7 +15,7 @@ bool liveness_contextt::has_location() const
 
 abstract_objectt::locationt liveness_contextt::get_location() const
 {
-  return assign_location.value();
+  return *assign_location;
 }
 
 /**

--- a/src/ansi-c/ansi_c_entry_point.cpp
+++ b/src/ansi-c/ansi_c_entry_point.cpp
@@ -121,7 +121,7 @@ bool ansi_c_entry_point(
     std::list<irep_idt> matches;
 
     for(const auto &symbol_name_entry :
-        equal_range(symbol_table.symbol_base_map, config.main.value()))
+        equal_range(symbol_table.symbol_base_map, *config.main))
     {
       // look it up
       symbol_tablet::symbolst::const_iterator s_it =
@@ -137,7 +137,7 @@ bool ansi_c_entry_point(
     if(matches.empty())
     {
       messaget message(message_handler);
-      message.error() << "main symbol '" << config.main.value() << "' not found"
+      message.error() << "main symbol '" << *config.main << "' not found"
                       << messaget::eom;
       return true; // give up
     }
@@ -145,8 +145,8 @@ bool ansi_c_entry_point(
     if(matches.size()>=2)
     {
       messaget message(message_handler);
-      message.error() << "main symbol '" << config.main.value()
-                      << "' is ambiguous" << messaget::eom;
+      message.error() << "main symbol '" << *config.main << "' is ambiguous"
+                      << messaget::eom;
       return true;
     }
 

--- a/src/ansi-c/c_typecheck_expr.cpp
+++ b/src/ansi-c/c_typecheck_expr.cpp
@@ -632,8 +632,7 @@ void c_typecheck_baset::typecheck_expr_builtin_offsetof(exprt &expr)
             }
 
             result = plus_exprt(
-              result,
-              typecast_exprt::conditional_cast(o_opt.value(), size_type()));
+              result, typecast_exprt::conditional_cast(*o_opt, size_type()));
           }
 
           type=struct_union_type.get_component(component_name).type();
@@ -666,8 +665,7 @@ void c_typecheck_baset::typecheck_expr_builtin_offsetof(exprt &expr)
 
                   result = plus_exprt(
                     result,
-                    typecast_exprt::conditional_cast(
-                      o_opt.value(), size_type()));
+                    typecast_exprt::conditional_cast(*o_opt, size_type()));
                 }
 
                 typet tmp = follow(c.type());
@@ -716,7 +714,7 @@ void c_typecheck_baset::typecheck_expr_builtin_offsetof(exprt &expr)
 
       index = typecast_exprt::conditional_cast(index, size_type());
 
-      result = plus_exprt(result, mult_exprt(element_size_opt.value(), index));
+      result = plus_exprt(result, mult_exprt(*element_size_opt, index));
 
       typet tmp=type.subtype();
       type=tmp;
@@ -1012,7 +1010,7 @@ void c_typecheck_baset::typecheck_expr_sizeof(exprt &expr)
       throw 0;
     }
 
-    new_expr = size_of_opt.value();
+    new_expr = *size_of_opt;
   }
 
   new_expr.swap(expr);
@@ -2710,7 +2708,7 @@ exprt c_typecheck_baset::do_special_functions(
         throw 0;
       }
 
-      size_expr = std::move(size_expr_opt.value());
+      size_expr = std::move(*size_expr_opt);
     }
 
     irep_idt id = identifier == CPROVER_PREFIX "r_ok"

--- a/src/ansi-c/c_typecheck_type.cpp
+++ b/src/ansi-c/c_typecheck_type.cpp
@@ -710,9 +710,9 @@ void c_typecheck_baset::typecheck_vector_type(typet &type)
     throw 0;
   }
 
-  simplify(sub_size_expr_opt.value(), *this);
+  simplify(*sub_size_expr_opt, *this);
 
-  const auto sub_size = numeric_cast<mp_integer>(sub_size_expr_opt.value());
+  const auto sub_size = numeric_cast<mp_integer>(*sub_size_expr_opt);
 
   if(!sub_size.has_value())
   {

--- a/src/ansi-c/expr2c.cpp
+++ b/src/ansi-c/expr2c.cpp
@@ -1905,7 +1905,7 @@ std::string expr2ct::convert_constant(
         if(sizeof_expr_opt.has_value())
         {
           ++sizeof_nesting;
-          dest = convert(sizeof_expr_opt.value()) + " /*" + dest + "*/ ";
+          dest = convert(*sizeof_expr_opt) + " /*" + dest + "*/ ";
           --sizeof_nesting;
         }
       }

--- a/src/ansi-c/goto_check_c.cpp
+++ b/src/ansi-c/goto_check_c.cpp
@@ -1342,7 +1342,7 @@ void goto_check_ct::pointer_overflow_check(
   {
     auto size_of_expr_opt = size_of_expr(object_type, ns);
     CHECK_RETURN(size_of_expr_opt.has_value());
-    exprt object_size = size_of_expr_opt.value();
+    exprt object_size = *size_of_expr_opt;
 
     const binary_exprt &binary_expr = to_binary_expr(expr);
     exprt offset_operand = binary_expr.lhs().type().id() == ID_pointer
@@ -1401,7 +1401,7 @@ void goto_check_ct::pointer_validity_check(
   {
     auto size_of_expr_opt = size_of_expr(expr.type(), ns);
     CHECK_RETURN(size_of_expr_opt.has_value());
-    size = size_of_expr_opt.value();
+    size = *size_of_expr_opt;
   }
 
   auto conditions = get_pointer_dereferenceable_conditions(pointer, size);
@@ -1448,7 +1448,7 @@ void goto_check_ct::pointer_primitive_check(
 
   const exprt size = !size_of_expr_opt.has_value()
                        ? from_integer(1, size_type())
-                       : size_of_expr_opt.value();
+                       : *size_of_expr_opt;
 
   const conditionst &conditions =
     get_pointer_points_to_valid_memory_conditions(pointer, size);
@@ -1642,10 +1642,9 @@ void goto_check_ct::bounds_check_index(
     CHECK_RETURN(type_size_opt.has_value());
 
     binary_relation_exprt inequality(
-      typecast_exprt::conditional_cast(
-        ode.offset(), type_size_opt.value().type()),
+      typecast_exprt::conditional_cast(ode.offset(), type_size_opt->type()),
       ID_lt,
-      type_size_opt.value());
+      *type_size_opt);
 
     add_guarded_property(
       inequality,
@@ -1832,7 +1831,7 @@ bool goto_check_ct::check_rec_member(
       plus_exprt{
         char_pointer,
         typecast_exprt::conditional_cast(
-          member_offset_opt.value(), pointer_diff_type())},
+          *member_offset_opt, pointer_diff_type())},
       new_pointer_type);
 
     dereference_exprt new_deref{new_address_casted};
@@ -2053,7 +2052,7 @@ void goto_check_ct::goto_check(
       auto matched = match_named_check(d.first);
       if(matched.has_value())
       {
-        auto named_check = matched.value();
+        auto named_check = *matched;
         auto name = named_check.first;
         auto status = named_check.second;
         bool *flag = name_to_flag.find(name)->second;

--- a/src/ansi-c/padding.cpp
+++ b/src/ansi-c/padding.cpp
@@ -493,8 +493,8 @@ void add_padding(union_typet &type, const namespacet &ns)
       if(c.type().id() == ID_c_bit_field)
       {
         auto w = underlying_width(to_c_bit_field_type(c.type()), ns);
-        if(w.has_value() && w.value() > max_alignment_bits)
-          max_alignment_bits = w.value();
+        if(w.has_value() && *w > max_alignment_bits)
+          max_alignment_bits = *w;
       }
   }
 

--- a/src/cpp/cpp_constructor.cpp
+++ b/src/cpp/cpp_constructor.cpp
@@ -113,7 +113,7 @@ optionalt<codet> cpp_typecheckt::cpp_constructor(
         auto i_code = cpp_constructor(source_location, index, tmp_operands);
 
         if(i_code.has_value())
-          new_code.add(std::move(i_code.value()));
+          new_code.add(std::move(*i_code));
       }
       return std::move(new_code);
     }

--- a/src/cpp/cpp_destructor.cpp
+++ b/src/cpp/cpp_destructor.cpp
@@ -64,7 +64,7 @@ optionalt<codet> cpp_typecheckt::cpp_destructor(
 
       auto i_code = cpp_destructor(source_location, index);
       if(i_code.has_value())
-        new_code.add_to_operands(std::move(i_code.value()));
+        new_code.add_to_operands(std::move(*i_code));
     }
 
     return std::move(new_code);

--- a/src/cpp/cpp_typecheck.cpp
+++ b/src/cpp/cpp_typecheck.cpp
@@ -188,7 +188,7 @@ void cpp_typecheckt::static_and_dynamic_initialization()
       auto call = cpp_constructor(symbol.location, symbol_expr, ops);
 
       if(call.has_value())
-        init_block.add(call.value());
+        init_block.add(*call);
     }
   }
 

--- a/src/cpp/cpp_typecheck_code.cpp
+++ b/src/cpp/cpp_typecheck_code.cpp
@@ -374,7 +374,7 @@ void cpp_typecheckt::typecheck_member_initializer(codet &code)
           cpp_constructor(code.source_location(), symbol_expr, code.operands());
 
         if(call.has_value())
-          code.swap(call.value());
+          code.swap(*call);
         else
         {
           auto source_location = code.source_location();
@@ -491,7 +491,7 @@ void cpp_typecheckt::typecheck_decl(codet &code)
         symbol.location, object_expr, declarator.init_args().operands());
 
       if(constructor_call.has_value())
-        new_code.add_to_operands(std::move(constructor_call.value()));
+        new_code.add_to_operands(std::move(*constructor_call));
     }
   }
 

--- a/src/cpp/cpp_typecheck_compound_type.cpp
+++ b/src/cpp/cpp_typecheck_compound_type.cpp
@@ -760,7 +760,7 @@ void cpp_typecheckt::typecheck_compound_declarator(
         auto defcode = cpp_constructor(source_locationt(), symexpr, ops);
         CHECK_RETURN(defcode.has_value());
 
-        new_symbol->value.swap(defcode.value());
+        new_symbol->value.swap(*defcode);
       }
     }
   }

--- a/src/cpp/cpp_typecheck_declaration.cpp
+++ b/src/cpp/cpp_typecheck_declaration.cpp
@@ -182,7 +182,7 @@ void cpp_typecheckt::convert_non_template_declaration(
         declarator.init_args().operands());
 
       if(constructor.has_value())
-        symbol.value = constructor.value();
+        symbol.value = *constructor;
       else
         symbol.value = nil_exprt();
     }

--- a/src/cpp/cpp_typecheck_destructor.cpp
+++ b/src/cpp/cpp_typecheck_destructor.cpp
@@ -124,7 +124,7 @@ codet cpp_typecheckt::dtor(const symbolt &symbol, const symbol_exprt &this_expr)
     disable_access_control = disabled_access_control;
 
     if(dtor_code.has_value())
-      block.add(dtor_code.value());
+      block.add(*dtor_code);
   }
 
   if(symbol.type.id() == ID_union)
@@ -149,7 +149,7 @@ codet cpp_typecheckt::dtor(const symbolt &symbol, const symbol_exprt &this_expr)
     disable_access_control = disabled_access_control;
 
     if(dtor_code.has_value())
-      block.add(dtor_code.value());
+      block.add(*dtor_code);
   }
 
   return std::move(block);

--- a/src/cpp/cpp_typecheck_expr.cpp
+++ b/src/cpp/cpp_typecheck_expr.cpp
@@ -810,7 +810,7 @@ void cpp_typecheckt::typecheck_expr_new(exprt &expr)
     expr.find_source_location(), object_expr, initializer.operands());
 
   if(code.has_value())
-    expr.add(ID_initializer).swap(code.value());
+    expr.add(ID_initializer).swap(*code);
   else
     expr.add(ID_initializer) = nil_exprt();
 
@@ -821,7 +821,7 @@ void cpp_typecheckt::typecheck_expr_new(exprt &expr)
   if(size_of_opt.has_value())
   {
     auto &sizeof_expr = static_cast<exprt &>(expr.add(ID_sizeof));
-    sizeof_expr = size_of_opt.value();
+    sizeof_expr = *size_of_opt;
     sizeof_expr.add(ID_C_c_sizeof_type) = expr.type().subtype();
   }
 }
@@ -1041,8 +1041,8 @@ void cpp_typecheckt::typecheck_expr_delete(exprt &expr)
   if(destructor_code.has_value())
   {
     // this isn't typechecked yet
-    typecheck_code(destructor_code.value());
-    expr.set(ID_destructor, destructor_code.value());
+    typecheck_code(*destructor_code);
+    expr.set(ID_destructor, *destructor_code);
   }
   else
     expr.set(ID_destructor, nil_exprt());

--- a/src/cpp/cpp_typecheck_initializer.cpp
+++ b/src/cpp/cpp_typecheck_initializer.cpp
@@ -187,7 +187,7 @@ void cpp_typecheckt::convert_initializer(symbolt &symbol)
       cpp_constructor(symbol.value.source_location(), expr_symbol, ops);
 
     if(constructor.has_value())
-      symbol.value = constructor.value();
+      symbol.value = *constructor;
     else
       symbol.value = nil_exprt();
   }

--- a/src/crangler/c_wrangler.cpp
+++ b/src/crangler/c_wrangler.cpp
@@ -371,7 +371,7 @@ static void mangle_function(
   if(function_config.stub.has_value())
   {
     // replace by stub
-    out << function_config.stub.value();
+    out << *function_config.stub;
   }
   else
   {

--- a/src/goto-analyzer/show_on_source.cpp
+++ b/src/goto-analyzer/show_on_source.cpp
@@ -45,7 +45,7 @@ get_source_files(const goto_modelt &goto_model, const ai_baset &ai)
     {
       const auto file = show_location(ai, i_it);
       if(file.has_value())
-        files.insert(file.value());
+        files.insert(*file);
     }
   }
 
@@ -98,7 +98,7 @@ void show_on_source(
     forall_goto_program_instructions(i_it, f.second.body)
     {
       const auto file = show_location(ai, i_it);
-      if(file.has_value() && file.value() == source_file)
+      if(file.has_value() && *file == source_file)
       {
         const std::size_t line_no =
           stoull(id2string(i_it->source_location().get_line()));

--- a/src/goto-analyzer/taint_analysis.cpp
+++ b/src/goto-analyzer/taint_analysis.cpp
@@ -382,17 +382,17 @@ bool taint_analysist::operator()(
 
     if(use_json)
     {
-      std::ofstream json_out(json_file_name.value());
+      std::ofstream json_out(*json_file_name);
 
       if(!json_out)
       {
-        log.error() << "Failed to open json output '" << json_file_name.value()
-                    << "'" << messaget::eom;
+        log.error() << "Failed to open json output '" << *json_file_name << "'"
+                    << messaget::eom;
         return true;
       }
 
-      log.status() << "Analysis result is written to '"
-                   << json_file_name.value() << "'" << messaget::eom;
+      log.status() << "Analysis result is written to '" << *json_file_name
+                   << "'" << messaget::eom;
 
       json_out << json_result << '\n';
     }

--- a/src/goto-cc/cl_message_handler.cpp
+++ b/src/goto-cc/cl_message_handler.cpp
@@ -43,9 +43,9 @@ void cl_message_handlert::print(
   if(full_path.has_value() && !line.empty())
   {
 #ifdef _MSC_VER
-    std::ifstream in(widen(full_path.value()));
+    std::ifstream in(widen(*full_path));
 #else
-    std::ifstream in(full_path.value());
+    std::ifstream in(*full_path);
 #endif
     if(in)
     {

--- a/src/goto-cc/gcc_message_handler.cpp
+++ b/src/goto-cc/gcc_message_handler.cpp
@@ -69,9 +69,9 @@ void gcc_message_handlert::print(
     if(file_name.has_value() && !line.empty())
     {
 #ifdef _MSC_VER
-      std::ifstream in(widen(file_name.value()));
+      std::ifstream in(widen(*file_name));
 #else
-      std::ifstream in(file_name.value());
+      std::ifstream in(*file_name);
 #endif
       if(in)
       {

--- a/src/goto-harness/goto_harness_generator.cpp
+++ b/src/goto-harness/goto_harness_generator.cpp
@@ -46,7 +46,7 @@ std::size_t require_one_size_value(
   auto value = string2optional<std::size_t>(string_value, 10);
   if(value.has_value())
   {
-    return value.value();
+    return *value;
   }
   else
   {

--- a/src/goto-harness/goto_harness_parse_options.cpp
+++ b/src/goto-harness/goto_harness_parse_options.cpp
@@ -119,7 +119,7 @@ int goto_harness_parse_optionst::doit()
     throw deserialization_exceptiont{"failed to read goto program from file '" +
                                      got_harness_config.in_file + "'"};
   }
-  auto goto_model = std::move(read_goto_binary_result.value());
+  auto goto_model = std::move(*read_goto_binary_result);
   auto const goto_model_without_harness_symbols =
     get_symbol_names_from_goto_model(goto_model);
 

--- a/src/goto-harness/recursive_initialization.cpp
+++ b/src/goto-harness/recursive_initialization.cpp
@@ -39,7 +39,7 @@ bool recursive_initialization_configt::handle_option(
       string2optional<std::size_t>(value, 10);
     if(user_min_null_tree_depth.has_value())
     {
-      min_null_tree_depth = user_min_null_tree_depth.value();
+      min_null_tree_depth = *user_min_null_tree_depth;
     }
     else
     {
@@ -57,7 +57,7 @@ bool recursive_initialization_configt::handle_option(
       string2optional<std::size_t>(value, 10);
     if(user_max_nondet_tree_depth.has_value())
     {
-      max_nondet_tree_depth = user_max_nondet_tree_depth.value();
+      max_nondet_tree_depth = *user_max_nondet_tree_depth;
     }
     else
     {
@@ -203,7 +203,7 @@ void recursive_initializationt::initialize(
       if(size_var.has_value())
       {
         const symbol_exprt &size_symbol =
-          goto_model.symbol_table.lookup_ref(size_var.value()).symbol_expr();
+          goto_model.symbol_table.lookup_ref(*size_var).symbol_expr();
         body.add(code_function_callt{
           fun_symbol.symbol_expr(),
           {depth, address_of_exprt{lhs}, address_of_exprt{size_symbol}}});
@@ -303,8 +303,8 @@ irep_idt recursive_initializationt::build_constructor(const exprt &expr)
   if(expr.id() == ID_symbol)
   {
     expr_name = to_symbol_expr(expr).get_identifier();
-    is_nullable = initialization_config.potential_null_function_pointers.count(
-      expr_name.value());
+    is_nullable =
+      initialization_config.potential_null_function_pointers.count(*expr_name);
     if(should_be_treated_as_array(*expr_name))
     {
       size_var = get_associated_size_variable(*expr_name);

--- a/src/goto-instrument/aggressive_slicer.cpp
+++ b/src/goto-instrument/aggressive_slicer.cpp
@@ -100,7 +100,7 @@ void aggressive_slicert::doit()
     auto property_loc = find_property(p, goto_model.goto_functions);
     if(!property_loc.has_value())
       throw "unable to find property in call graph";
-    note_functions_to_keep(property_loc.value().get_function());
+    note_functions_to_keep(property_loc->get_function());
   }
 
   // Add functions within distance of shortest path functions

--- a/src/goto-instrument/contracts/contracts.cpp
+++ b/src/goto-instrument/contracts/contracts.cpp
@@ -889,7 +889,7 @@ void code_contractst::apply_function_contract(
   // ... for the return value
   if(call_ret_opt.has_value())
   {
-    auto &call_ret = call_ret_opt.value();
+    auto &call_ret = *call_ret_opt;
     auto &loc = call_ret.source_location();
     auto &type = call_ret.type();
 
@@ -920,7 +920,7 @@ void code_contractst::apply_function_contract(
   {
     function_body.output_instruction(ns, "", log.warning(), *target);
     auto dead_inst =
-      goto_programt::make_dead(to_symbol_expr(call_ret_opt.value()), location);
+      goto_programt::make_dead(to_symbol_expr(*call_ret_opt), location);
     function_body.insert_before_swap(target, dead_inst);
     ++target;
   }
@@ -1514,7 +1514,7 @@ void code_contractst::add_contract_check(
   if(code_type.return_type() != empty_typet())
   {
     check.add(goto_programt::make_set_return_value(
-      return_stmt.value().return_value(), skip->source_location()));
+      return_stmt->return_value(), skip->source_location()));
   }
 
   // prepend the new code to dest

--- a/src/goto-instrument/count_eloc.cpp
+++ b/src/goto-instrument/count_eloc.cpp
@@ -200,8 +200,8 @@ void print_global_state_size(const goto_modelt &goto_model)
     }
 
     const auto bits = pointer_offset_bits(symbol.type, ns);
-    if(bits.has_value() && bits.value() > 0)
-      total_size += bits.value();
+    if(bits.has_value() && *bits > 0)
+      total_size += *bits;
   }
 
   std::cout << "Total size of global objects: " << total_size << " bits\n";

--- a/src/goto-instrument/dump_c.cpp
+++ b/src/goto-instrument/dump_c.cpp
@@ -243,7 +243,7 @@ void dump_ct::operator()(std::ostream &os)
         !harness && func_entry != goto_functions.function_map.end() &&
         func_entry->second.body_available() &&
         (symbol.name == ID_main ||
-         (config.main.has_value() && symbol.name == config.main.value())))
+         (config.main.has_value() && symbol.name == *config.main)))
       {
         skip_function_main=true;
       }

--- a/src/goto-instrument/goto_instrument_parse_options.cpp
+++ b/src/goto-instrument/goto_instrument_parse_options.cpp
@@ -990,7 +990,7 @@ void goto_instrument_parse_optionst::get_goto_program()
   if(!result.has_value())
     throw 0;
 
-  goto_model = std::move(result.value());
+  goto_model = std::move(*result);
 
   config.set_from_symbol_table(goto_model.symbol_table);
 }

--- a/src/goto-instrument/model_argc_argv.cpp
+++ b/src/goto-instrument/model_argc_argv.cpp
@@ -54,7 +54,7 @@ bool model_argc_argv(
   }
 
   const symbolt &main_symbol =
-    ns.lookup(config.main.has_value() ? config.main.value() : ID_main);
+    ns.lookup(config.main.has_value() ? *config.main : ID_main);
 
   if(main_symbol.mode!=ID_C)
   {

--- a/src/goto-programs/allocate_objects.cpp
+++ b/src/goto-programs/allocate_objects.cpp
@@ -156,7 +156,7 @@ exprt allocate_objectst::allocate_dynamic_object_symbol(
   add_created_symbol(malloc_sym);
 
   code_frontend_assignt assign =
-    make_allocate_code(malloc_sym.symbol_expr(), object_size.value());
+    make_allocate_code(malloc_sym.symbol_expr(), *object_size);
   output_code.add(assign);
 
   exprt malloc_symbol_expr = typecast_exprt::conditional_cast(

--- a/src/goto-programs/goto_convert.cpp
+++ b/src/goto-programs/goto_convert.cpp
@@ -1800,8 +1800,8 @@ bool goto_convertt::get_string_constant(
           if(!i.has_value())
             return true;
 
-          if(i.value() != 0) // to skip terminating 0
-            result += static_cast<char>(i.value());
+          if(*i != 0) // to skip terminating 0
+            result += static_cast<char>(*i);
         }
 
       return value=result, false;

--- a/src/goto-programs/goto_program.cpp
+++ b/src/goto-programs/goto_program.cpp
@@ -983,9 +983,9 @@ void goto_programt::instructiont::transform(
     auto new_assign_lhs = f(assign_lhs());
     auto new_assign_rhs = f(assign_rhs());
     if(new_assign_lhs.has_value())
-      assign_lhs_nonconst() = new_assign_lhs.value();
+      assign_lhs_nonconst() = *new_assign_lhs;
     if(new_assign_rhs.has_value())
-      assign_rhs_nonconst() = new_assign_rhs.value();
+      assign_rhs_nonconst() = *new_assign_rhs;
   }
   break;
 
@@ -1051,7 +1051,7 @@ void goto_programt::instructiont::transform(
     {
       auto new_condition = f(get_condition());
       if(new_condition.has_value())
-        set_condition(new_condition.value());
+        set_condition(*new_condition);
     }
   }
 }

--- a/src/goto-programs/interpreter_evaluate.cpp
+++ b/src/goto-programs/interpreter_evaluate.cpp
@@ -261,7 +261,7 @@ bool interpretert::memory_offset_to_byte_offset(
         const auto member_offset_result =
           member_offset(st, comp.get_name(), ns);
         CHECK_RETURN(member_offset_result.has_value());
-        result = member_offset_result.value() + subtype_result;
+        result = *member_offset_result + subtype_result;
         return ret;
       }
       else

--- a/src/goto-programs/mm_io.cpp
+++ b/src/goto-programs/mm_io.cpp
@@ -75,8 +75,7 @@ void mm_io(
           auto call = goto_programt::make_function_call(
             mm_io_r_value,
             mm_io_r,
-            {typecast_exprt(d.pointer(), pt),
-             typecast_exprt(size_opt.value(), st)},
+            {typecast_exprt(d.pointer(), pt), typecast_exprt(*size_opt, st)},
             source_location);
           goto_function.body.insert_before_swap(it, call);
           it++;
@@ -98,7 +97,7 @@ void mm_io(
           const code_function_callt fc(
             mm_io_w,
             {typecast_exprt(d.pointer(), pt),
-             typecast_exprt(size_opt.value(), st),
+             typecast_exprt(*size_opt, st),
              typecast_exprt(a_rhs, vt)});
           goto_function.body.insert_before_swap(it);
           *it = goto_programt::make_function_call(fc, source_location);

--- a/src/goto-symex/symex_clean_expr.cpp
+++ b/src/goto-symex/symex_clean_expr.cpp
@@ -90,11 +90,11 @@ process_array_expr(exprt &expr, bool do_simplify, const namespacet &ns)
         auto array_size = size_of_expr(expr.type(), ns);
         CHECK_RETURN(array_size.has_value());
         if(do_simplify)
-          simplify(array_size.value(), ns);
+          simplify(*array_size, ns);
         expr = make_byte_extract(
           expr,
           from_integer(0, c_index_type()),
-          array_typet(char_type(), array_size.value()));
+          array_typet(char_type(), *array_size));
       }
 
       // given an array type T[N], i.e., an array of N elements of type T, and a
@@ -108,8 +108,8 @@ process_array_expr(exprt &expr, bool do_simplify, const namespacet &ns)
         typecast_exprt::conditional_cast(ode.offset(), array_size_type);
       auto subtype_size_opt = size_of_expr(subtype, ns);
       CHECK_RETURN(subtype_size_opt.has_value());
-      exprt subtype_size = typecast_exprt::conditional_cast(
-        subtype_size_opt.value(), array_size_type);
+      exprt subtype_size =
+        typecast_exprt::conditional_cast(*subtype_size_opt, array_size_type);
       new_offset = div_exprt(new_offset, subtype_size);
       minus_exprt subtraction{prev_array_type.size(), new_offset};
       if_exprt new_size{

--- a/src/goto-symex/symex_function_call.cpp
+++ b/src/goto-symex/symex_function_call.cpp
@@ -451,8 +451,8 @@ void goto_symext::symex_end_of_function(statet &state)
       return_value_symbol.has_value(),
       "must have return value symbol when assigning call lhs");
     // the type of the call lhs and the return type might not match
-    auto casted_return_value = typecast_exprt::conditional_cast(
-      return_value_symbol.value(), call_lhs.type());
+    auto casted_return_value =
+      typecast_exprt::conditional_cast(*return_value_symbol, call_lhs.type());
     symex_assign(state, call_lhs, casted_return_value);
   }
 }

--- a/src/goto-symex/symex_other.cpp
+++ b/src/goto-symex/symex_other.cpp
@@ -188,11 +188,11 @@ void goto_symext::symex_other(
     {
       auto array_size = size_of_expr(array_expr.type(), ns);
       CHECK_RETURN(array_size.has_value());
-      do_simplify(array_size.value());
+      do_simplify(*array_size);
       array_expr = make_byte_extract(
         array_expr,
         from_integer(0, c_index_type()),
-        array_typet(char_type(), array_size.value()));
+        array_typet(char_type(), *array_size));
     }
 
     const array_typet &array_type = to_array_type(array_expr.type());

--- a/src/goto-symex/symex_set_return_value.cpp
+++ b/src/goto-symex/symex_set_return_value.cpp
@@ -21,6 +21,6 @@ void goto_symext::symex_set_return_value(
   framet &frame = state.call_stack().top();
   if(frame.return_value_symbol.has_value())
   {
-    symex_assign(state, frame.return_value_symbol.value(), return_value);
+    symex_assign(state, *frame.return_value_symbol, return_value);
   }
 }

--- a/src/jsil/jsil_entry_point.cpp
+++ b/src/jsil/jsil_entry_point.cpp
@@ -65,7 +65,7 @@ bool jsil_entry_point(
     std::list<irep_idt> matches;
 
     for(const auto &symbol_name_entry :
-        equal_range(symbol_table.symbol_base_map, config.main.value()))
+        equal_range(symbol_table.symbol_base_map, *config.main))
     {
       // look it up
       symbol_tablet::symbolst::const_iterator s_it =
@@ -81,7 +81,7 @@ bool jsil_entry_point(
     if(matches.empty())
     {
       messaget message(message_handler);
-      message.error() << "main symbol '" << config.main.value() << "' not found"
+      message.error() << "main symbol '" << *config.main << "' not found"
                       << messaget::eom;
       return true; // give up
     }
@@ -89,8 +89,8 @@ bool jsil_entry_point(
     if(matches.size()>=2)
     {
       messaget message(message_handler);
-      message.error() << "main symbol '" << config.main.value()
-                      << "' is ambiguous" << messaget::eom;
+      message.error() << "main symbol '" << *config.main << "' is ambiguous"
+                      << messaget::eom;
       return true;
     }
 

--- a/src/linking/remove_internal_symbols.cpp
+++ b/src/linking/remove_internal_symbols.cpp
@@ -169,9 +169,8 @@ void remove_internal_symbols(
     {
       // body? not local (i.e., "static")?
       if(
-        has_body &&
-        (!is_file_local ||
-         (config.main.has_value() && symbol.base_name == config.main.value())))
+        has_body && (!is_file_local || (config.main.has_value() &&
+                                        symbol.base_name == *config.main)))
       {
         get_symbols(ns, symbol, exported);
       }

--- a/src/memory-analyzer/memory_analyzer_parse_options.cpp
+++ b/src/memory-analyzer/memory_analyzer_parse_options.cpp
@@ -113,7 +113,7 @@ int memory_analyzer_parse_optionst::doit()
       "cannot read goto binary '" + binary + "'");
   }
 
-  const goto_modelt goto_model(std::move(opt.value()));
+  const goto_modelt goto_model(std::move(*opt));
 
   gdb_value_extractort gdb_value_extractor(
     goto_model.symbol_table, cmdline.args);

--- a/src/pointer-analysis/value_set_dereference.cpp
+++ b/src/pointer-analysis/value_set_dereference.cpp
@@ -625,17 +625,16 @@ value_set_dereferencet::valuet value_set_dereferencet::build_reference_to(
       auto subexpr = get_subexpression_at_offset(
         root_object_subexpression, o.offset(), dereference_type, ns);
       if(subexpr.has_value())
-        simplify(subexpr.value(), ns);
+        simplify(*subexpr, ns);
       if(
-        subexpr.has_value() &&
-        subexpr.value().id() != ID_byte_extract_little_endian &&
-        subexpr.value().id() != ID_byte_extract_big_endian)
+        subexpr.has_value() && subexpr->id() != ID_byte_extract_little_endian &&
+        subexpr->id() != ID_byte_extract_big_endian)
       {
         // Successfully found a member, array index, or combination thereof
         // that matches the desired type and offset:
-        result.value = subexpr.value();
+        result.value = *subexpr;
         result.pointer = typecast_exprt::conditional_cast(
-          address_of_exprt{skip_typecast(subexpr.value())}, pointer_type);
+          address_of_exprt{skip_typecast(*subexpr)}, pointer_type);
         return result;
       }
 

--- a/src/solvers/flattening/boolbv_extractbits.cpp
+++ b/src/solvers/flattening/boolbv_extractbits.cpp
@@ -28,8 +28,8 @@ bvt boolbvt::convert_extractbits(const extractbits_exprt &expr)
   if(!maybe_upper_as_int.has_value() || !maybe_lower_as_int.has_value())
     return conversion_failed(expr);
 
-  auto upper_as_int = maybe_upper_as_int.value();
-  auto lower_as_int = maybe_lower_as_int.value();
+  auto upper_as_int = *maybe_upper_as_int;
+  auto lower_as_int = *maybe_lower_as_int;
 
   DATA_INVARIANT_WITH_DIAGNOSTICS(
     upper_as_int >= 0 && upper_as_int < src_bv.size(),

--- a/src/solvers/flattening/boolbv_index.cpp
+++ b/src/solvers/flattening/boolbv_index.cpp
@@ -97,7 +97,7 @@ bvt boolbvt::convert_index(const index_exprt &expr)
       auto maybe_index_value = numeric_cast<mp_integer>(index);
       if(maybe_index_value.has_value())
       {
-        return convert_index(array, maybe_index_value.value());
+        return convert_index(array, *maybe_index_value);
       }
     }
 

--- a/src/solvers/flattening/boolbv_quantifier.cpp
+++ b/src/solvers/flattening/boolbv_quantifier.cpp
@@ -195,8 +195,8 @@ static optionalt<exprt> eager_quantifier_instantiation(
   if(!min_i.has_value() || !max_i.has_value())
     return nullopt;
 
-  mp_integer lb = numeric_cast_v<mp_integer>(min_i.value());
-  mp_integer ub = numeric_cast_v<mp_integer>(max_i.value());
+  mp_integer lb = numeric_cast_v<mp_integer>(*min_i);
+  mp_integer ub = numeric_cast_v<mp_integer>(*max_i);
 
   if(lb > ub)
     return nullopt;

--- a/src/solvers/flattening/bv_pointers.cpp
+++ b/src/solvers/flattening/bv_pointers.cpp
@@ -952,8 +952,8 @@ void bv_pointerst::do_postponed(
       if(!size_expr.has_value())
         continue;
 
-      const exprt object_size = typecast_exprt::conditional_cast(
-        size_expr.value(), postponed.expr.type());
+      const exprt object_size =
+        typecast_exprt::conditional_cast(*size_expr, postponed.expr.type());
 
       // only compare object part
       pointer_typet pt = pointer_type(expr.type());

--- a/src/solvers/flattening/pointer_logic.cpp
+++ b/src/solvers/flattening/pointer_logic.cpp
@@ -116,7 +116,7 @@ exprt pointer_logict::pointer_expr(
   auto deep_object_opt =
     get_subexpression_at_offset(object_expr, pointer.offset, subtype, ns);
   CHECK_RETURN(deep_object_opt.has_value());
-  exprt deep_object = deep_object_opt.value();
+  exprt deep_object = *deep_object_opt;
   simplify(deep_object, ns);
   if(
     deep_object.id() != ID_byte_extract_little_endian &&

--- a/src/solvers/lowering/byte_operators.cpp
+++ b/src/solvers/lowering/byte_operators.cpp
@@ -1146,9 +1146,9 @@ exprt lower_byte_extract(const byte_extract_exprt &src, const namespacet &ns)
   {
     upper_bound_opt = simplify_expr(
       plus_exprt(
-        upper_bound_opt.value(),
+        *upper_bound_opt,
         typecast_exprt::conditional_cast(
-          src.offset(), upper_bound_opt.value().type())),
+          src.offset(), upper_bound_opt->type())),
       ns);
   }
   else if(src.type().id() == ID_empty)
@@ -1220,7 +1220,7 @@ exprt lower_byte_extract(const byte_extract_exprt &src, const namespacet &ns)
       plus_exprt new_offset(
         unpacked.offset(),
         typecast_exprt::conditional_cast(
-          member_offset_opt.value(), unpacked.offset().type()));
+          *member_offset_opt, unpacked.offset().type()));
 
       byte_extract_exprt tmp(unpacked);
       tmp.type()=comp.type();
@@ -1603,8 +1603,7 @@ static exprt lower_byte_update_array_vector_non_const(
   CHECK_RETURN(subtype_size_opt.has_value());
 
   const exprt subtype_size = simplify_expr(
-    typecast_exprt::conditional_cast(
-      subtype_size_opt.value(), src.offset().type()),
+    typecast_exprt::conditional_cast(*subtype_size_opt, src.offset().type()),
     ns);
 
   // compute the index of the first element of the array/vector that may be
@@ -1903,7 +1902,7 @@ static exprt lower_byte_update_struct(
         extract_opcode,
         src.op(),
         from_integer(0, src.offset().type()),
-        array_typet{bv_typet{8}, src_size_opt.value()}};
+        array_typet{bv_typet{8}, *src_size_opt}};
 
       byte_update_exprt bu = src;
       bu.set_op(lower_byte_extract(byte_extract_expr, ns));
@@ -2299,9 +2298,9 @@ exprt lower_byte_update(const byte_update_exprt &src, const namespacet &ns)
   exprt update_value = src.value();
   auto update_size_expr_opt = size_of_expr(update_value.type(), ns);
   CHECK_RETURN(update_size_expr_opt.has_value());
-  simplify(update_size_expr_opt.value(), ns);
+  simplify(*update_size_expr_opt, ns);
 
-  if(!update_size_expr_opt.value().is_constant())
+  if(!update_size_expr_opt->is_constant())
     non_const_update_bound = *update_size_expr_opt;
   else
   {

--- a/src/solvers/smt2/smt2_conv.cpp
+++ b/src/solvers/smt2/smt2_conv.cpp
@@ -492,7 +492,7 @@ exprt smt2_convt::parse_array(
   auto maybe_size = numeric_cast<std::int64_t>(type.size());
   if(maybe_size.has_value())
   {
-    while(i < maybe_size.value())
+    while(i < *maybe_size)
     {
       auto found_op = operands_map.find(i);
       if(found_op != operands_map.end())
@@ -1532,7 +1532,7 @@ void smt2_convt::convert_expr(const exprt &expr)
 
       if(distance_int_op.has_value())
       {
-        out << distance_int_op.value();
+        out << *distance_int_op;
       }
       else
         UNEXPECTEDCASE(
@@ -4212,8 +4212,8 @@ void smt2_convt::convert_member(const member_exprt &expr)
       CHECK_RETURN_WITH_DIAGNOSTICS(
         member_offset.has_value(), "failed to get struct member offset");
 
-      out << "((_ extract " << (member_offset.value() + member_width - 1) << " "
-          << member_offset.value() << ") ";
+      out << "((_ extract " << (*member_offset + member_width - 1) << " "
+          << *member_offset << ") ";
       convert_expr(struct_op);
       out << ")";
     }

--- a/src/solvers/smt2/smt2_dec.cpp
+++ b/src/solvers/smt2/smt2_dec.cpp
@@ -148,7 +148,7 @@ decision_proceduret::resultt smt2_dect::read_result(std::istream &in)
     if(!parsed_opt.has_value())
       break;
 
-    const auto &parsed = parsed_opt.value();
+    const auto &parsed = *parsed_opt;
 
     if(parsed.id()=="sat")
       res=resultt::D_SATISFIABLE;

--- a/src/solvers/smt2_incremental/smt_response_validation.cpp
+++ b/src/solvers/smt2_incremental/smt_response_validation.cpp
@@ -46,7 +46,7 @@ const smtt *response_or_errort<smtt>::get_if_valid() const
     smt.has_value() == messages.empty(),
     "The response_or_errort class must be in the valid state or error state, "
     "exclusively.");
-  return smt.has_value() ? &smt.value() : nullptr;
+  return smt.has_value() ? &(*smt) : nullptr;
 }
 
 template <class smtt>

--- a/src/solvers/strings/string_builtin_function.cpp
+++ b/src/solvers/strings/string_builtin_function.cpp
@@ -87,11 +87,10 @@ optionalt<exprt> string_concat_char_builtin_functiont::eval(
       "character valuation should only contain constants and unknown");
     return mp_integer(CHARACTER_FOR_UNKNOWN);
   }();
-  input_opt.value().push_back(char_val);
-  const auto length =
-    from_integer(input_opt.value().size(), result.length_type());
+  input_opt->push_back(char_val);
+  const auto length = from_integer(input_opt->size(), result.length_type());
   const array_typet type(to_type_with_subtype(result.type()).subtype(), length);
-  return make_string(input_opt.value(), type);
+  return make_string(*input_opt, type);
 }
 
 /// Set of constraints enforcing that `result` is the concatenation
@@ -133,12 +132,11 @@ optionalt<exprt> string_set_char_builtin_functiont::eval(
   const auto position_opt = numeric_cast<mp_integer>(get_value(position));
   if(!input_opt || !char_opt || !position_opt)
     return {};
-  if(0 <= *position_opt && *position_opt < input_opt.value().size())
-    input_opt.value()[numeric_cast_v<std::size_t>(*position_opt)] = *char_opt;
-  const auto length =
-    from_integer(input_opt.value().size(), result.length_type());
+  if(0 <= *position_opt && *position_opt < input_opt->size())
+    (*input_opt)[numeric_cast_v<std::size_t>(*position_opt)] = *char_opt;
+  const auto length = from_integer(input_opt->size(), result.length_type());
   const array_typet type(to_type_with_subtype(result.type()).subtype(), length);
-  return make_string(input_opt.value(), type);
+  return make_string(*input_opt, type);
 }
 
 /// Set of constraints ensuring that `result` is similar to `input`
@@ -219,15 +217,14 @@ optionalt<exprt> string_to_lower_case_builtin_functiont::eval(
   auto input_opt = eval_string(input, get_value);
   if(!input_opt)
     return {};
-  for(mp_integer &c : input_opt.value())
+  for(mp_integer &c : *input_opt)
   {
     if(eval_is_upper_case(c))
       c += 0x20;
   }
-  const auto length =
-    from_integer(input_opt.value().size(), result.length_type());
+  const auto length = from_integer(input_opt->size(), result.length_type());
   const array_typet type(to_type_with_subtype(result.type()).subtype(), length);
-  return make_string(input_opt.value(), type);
+  return make_string(*input_opt, type);
 }
 
 /// Expression which is true for uppercase characters of the Basic Latin and
@@ -313,15 +310,14 @@ optionalt<exprt> string_to_upper_case_builtin_functiont::eval(
   auto input_opt = eval_string(input, get_value);
   if(!input_opt)
     return {};
-  for(mp_integer &c : input_opt.value())
+  for(mp_integer &c : *input_opt)
   {
     if(eval_is_upper_case(c - 0x20))
       c -= 0x20;
   }
-  const auto length =
-    from_integer(input_opt.value().size(), result.length_type());
+  const auto length = from_integer(input_opt->size(), result.length_type());
   const array_typet type(to_type_with_subtype(result.type()).subtype(), length);
-  return make_string(input_opt.value(), type);
+  return make_string(*input_opt, type);
 }
 
 /// Set of constraints ensuring `result` corresponds to `input` in which
@@ -418,7 +414,7 @@ exprt string_of_int_builtin_functiont::length_constraint() const
 {
   const typet &type = result.length_type();
   const auto radix_opt = numeric_cast<std::size_t>(radix);
-  const auto radix_value = radix_opt.has_value() ? radix_opt.value() : 2;
+  const auto radix_value = radix_opt.value_or(2);
   const std::size_t upper_bound =
     max_printed_string_length(arg.type(), radix_value);
   const exprt negative_arg =

--- a/src/solvers/strings/string_constraint_instantiation.cpp
+++ b/src/solvers/strings/string_constraint_instantiation.cpp
@@ -70,7 +70,7 @@ linear_functiont::linear_functiont(const exprt &f)
     to_process.pop_back();
     if(auto integer = numeric_cast<mp_integer>(cur))
     {
-      constant_coefficient += positive ? integer.value() : -integer.value();
+      constant_coefficient += positive ? *integer : -*integer;
     }
     else if(cur.id() == ID_plus)
     {

--- a/src/solvers/strings/string_format_builtin_function.cpp
+++ b/src/solvers/strings/string_format_builtin_function.cpp
@@ -519,7 +519,7 @@ optionalt<exprt> string_format_builtin_functiont::eval(
     return {};
 
   const std::vector<format_elementt> format_strings =
-    parse_format_string(format_string.value());
+    parse_format_string(*format_string);
   std::vector<mp_integer> result_vector;
   std::size_t arg_count = 0;
 
@@ -593,7 +593,7 @@ string_constraintst string_format_builtin_functiont::constraints(
   auto result_constraint_pair = add_axioms_for_format(
     generator,
     result,
-    format_string.value(),
+    *format_string,
     inputs,
     // TODO: get rid of this argument
     messaget{message_handler});
@@ -771,7 +771,7 @@ exprt string_format_builtin_functiont::length_constraint() const
 
   exprt::operandst constraints;
   const std::vector<format_elementt> format_strings =
-    parse_format_string(format_string.value());
+    parse_format_string(*format_string);
   std::vector<exprt> intermediary_string_lengths;
   std::size_t arg_count = 0;
   const typet &index_type = result.length_type();

--- a/src/solvers/strings/string_refinement.cpp
+++ b/src/solvers/strings/string_refinement.cpp
@@ -964,7 +964,7 @@ static optionalt<exprt> get_valid_array_size(
   exprt size_val;
   if(size_from_pool.has_value())
   {
-    const exprt size = size_from_pool.value();
+    const exprt size = *size_from_pool;
     size_val = simplify_expr(super_get(size), ns);
     if(size_val.id() != ID_constant)
     {
@@ -1011,7 +1011,7 @@ static optionalt<exprt> get_array(
     return {};
   }
 
-  const size_t n = numeric_cast<std::size_t>(size.value()).value();
+  const size_t n = *numeric_cast<std::size_t>(*size);
 
   if(n > MAX_CONCRETE_STRING_SIZE)
   {
@@ -1032,7 +1032,7 @@ static optionalt<exprt> get_array(
 
   const exprt arr_val = simplify_expr(super_get(arr), ns);
   const typet char_type = to_array_type(arr.type()).subtype();
-  const typet &index_type = size.value().type();
+  const typet &index_type = size->type();
 
   if(
     const auto &array = interval_sparse_arrayt::of_expr(
@@ -1879,7 +1879,7 @@ exprt string_refinementt::get(const exprt &expr) const
       const auto &length_from_pool =
         generator.array_pool.get_length_if_exists(arr))
     {
-      const exprt length = super_get(length_from_pool.value());
+      const exprt length = super_get(*length_from_pool);
 
       if(const auto n = numeric_cast<std::size_t>(length))
       {

--- a/src/statement-list/statement_list_entry_point.cpp
+++ b/src/statement-list/statement_list_entry_point.cpp
@@ -209,10 +209,9 @@ bool statement_list_entry_point(
   // Find main symbol given by the user.
   if(config.main.has_value())
   {
-    if(is_main_symbol_invalid(
-         symbol_table, message_handler, config.main.value()))
+    if(is_main_symbol_invalid(symbol_table, message_handler, *config.main))
       return true;
-    main_symbol_name = config.main.value();
+    main_symbol_name = *config.main;
   }
   // Fallback: Search for block with TIA main standard name.
   // TODO: Support the standard entry point of STL (organisation blocks).

--- a/src/statement-list/statement_list_parse_tree_io.cpp
+++ b/src/statement-list/statement_list_parse_tree_io.cpp
@@ -187,7 +187,7 @@ void output_var_declaration(
   if(declaration.default_value)
   {
     const constant_exprt &constant =
-      to_constant_expr(declaration.default_value.value());
+      to_constant_expr(*declaration.default_value);
     output_constant(os, constant);
   }
   else

--- a/src/util/cmdline.cpp
+++ b/src/util/cmdline.cpp
@@ -232,7 +232,7 @@ cmdlinet::get_argument_suggestions(const std::string &unknown_argument)
       const auto long_name = "--" + option.optstring;
       if(auto distance = argument_matcher.get_edit_distance(long_name))
       {
-        argument_suggestions.push_back({distance.value(), long_name});
+        argument_suggestions.push_back({*distance, long_name});
       }
     }
     if(!option.islong)
@@ -240,7 +240,7 @@ cmdlinet::get_argument_suggestions(const std::string &unknown_argument)
       const auto short_name = std::string{"-"} + option.optchar;
       if(auto distance = argument_matcher.get_edit_distance(short_name))
       {
-        argument_suggestions.push_back({distance.value(), short_name});
+        argument_suggestions.push_back({*distance, short_name});
       }
     }
   }

--- a/src/util/pointer_expr.cpp
+++ b/src/util/pointer_expr.cpp
@@ -44,7 +44,7 @@ static void build_object_descriptor_rec(
       dest.offset(),
       mult_exprt(
         typecast_exprt::conditional_cast(index.index(), c_index_type()),
-        typecast_exprt::conditional_cast(sub_size.value(), c_index_type())));
+        typecast_exprt::conditional_cast(*sub_size, c_index_type())));
   }
   else if(expr.id() == ID_member)
   {
@@ -57,8 +57,7 @@ static void build_object_descriptor_rec(
     CHECK_RETURN(offset.has_value());
 
     dest.offset() = plus_exprt(
-      dest.offset(),
-      typecast_exprt::conditional_cast(offset.value(), c_index_type()));
+      dest.offset(), typecast_exprt::conditional_cast(*offset, c_index_type()));
   }
   else if(
     expr.id() == ID_byte_extract_little_endian ||

--- a/src/util/pointer_offset_size.cpp
+++ b/src/util/pointer_offset_size.cpp
@@ -270,7 +270,7 @@ optionalt<exprt> member_offset_expr(
       auto sub_size = size_of_expr(subtype, ns);
       if(!sub_size.has_value())
         return {}; // give up
-      result = plus_exprt(result, sub_size.value());
+      result = plus_exprt(result, *sub_size);
     }
   }
 
@@ -302,9 +302,9 @@ optionalt<exprt> size_of_expr(const typet &type, const namespacet &ns)
       return {};
 
     const auto size_casted =
-      typecast_exprt::conditional_cast(size, sub.value().type());
+      typecast_exprt::conditional_cast(size, sub->type());
 
-    return simplify_expr(mult_exprt{size_casted, sub.value()}, ns);
+    return simplify_expr(mult_exprt{size_casted, *sub}, ns);
   }
   else if(type.id()==ID_vector)
   {
@@ -329,9 +329,9 @@ optionalt<exprt> size_of_expr(const typet &type, const namespacet &ns)
       return {};
 
     const auto size_casted =
-      typecast_exprt::conditional_cast(size, sub.value().type());
+      typecast_exprt::conditional_cast(size, sub->type());
 
-    return simplify_expr(mult_exprt{size_casted, sub.value()}, ns);
+    return simplify_expr(mult_exprt{size_casted, *sub}, ns);
   }
   else if(type.id()==ID_complex)
   {
@@ -339,8 +339,8 @@ optionalt<exprt> size_of_expr(const typet &type, const namespacet &ns)
     if(!sub.has_value())
       return {};
 
-    exprt size = from_integer(2, sub.value().type());
-    return simplify_expr(mult_exprt{std::move(size), sub.value()}, ns);
+    exprt size = from_integer(2, sub->type());
+    return simplify_expr(mult_exprt{std::move(size), *sub}, ns);
   }
   else if(type.id()==ID_struct)
   {
@@ -382,7 +382,7 @@ optionalt<exprt> size_of_expr(const typet &type, const namespacet &ns)
         if(!sub_size_opt.has_value())
           return {};
 
-        result = plus_exprt(result, sub_size_opt.value());
+        result = plus_exprt(result, *sub_size_opt);
       }
     }
 
@@ -411,7 +411,7 @@ optionalt<exprt> size_of_expr(const typet &type, const namespacet &ns)
         auto sub_size_opt = size_of_expr(subtype, ns);
         if(!sub_size_opt.has_value())
           return {};
-        sub_size = sub_size_opt.value();
+        sub_size = *sub_size_opt;
       }
       else
       {

--- a/src/util/pointer_predicates.cpp
+++ b/src/util/pointer_predicates.cpp
@@ -79,7 +79,7 @@ exprt good_pointer_def(
 
   const and_exprt good_bounds{
     not_exprt{object_lower_bound(pointer, nil_exprt())},
-    not_exprt{object_upper_bound(pointer, size_of_expr_opt.value())}};
+    not_exprt{object_upper_bound(pointer, *size_of_expr_opt)}};
 
   return and_exprt(not_null, not_invalid, good_dynamic, good_bounds);
 }

--- a/src/util/simplify_expr.cpp
+++ b/src/util/simplify_expr.cpp
@@ -1699,7 +1699,7 @@ simplify_exprt::simplify_byte_extract(const byte_extract_exprt &expr)
     if(!const_bits_opt.has_value())
       return unchanged(expr);
 
-    std::string const_bits=const_bits_opt.value();
+    std::string const_bits = *const_bits_opt;
 
     DATA_INVARIANT(!const_bits.empty(), "bit representation must be non-empty");
 
@@ -1760,7 +1760,7 @@ simplify_exprt::simplify_byte_extract(const byte_extract_exprt &expr)
     !struct_has_flexible_array_member)
   {
     std::string bits_cut = std::string(
-      bits.value(),
+      *bits,
       numeric_cast_v<std::size_t>(*offset * 8),
       numeric_cast_v<std::size_t>(*el_size));
 
@@ -1806,10 +1806,10 @@ simplify_exprt::simplify_byte_extract(const byte_extract_exprt &expr)
           break;
         }
 
-        exprt new_offset = simplify_rec(
-          plus_exprt{expr.offset(),
-                     typecast_exprt::conditional_cast(
-                       member_offset_opt.value(), expr.offset().type())});
+        exprt new_offset = simplify_rec(plus_exprt{
+          expr.offset(),
+          typecast_exprt::conditional_cast(
+            *member_offset_opt, expr.offset().type())});
 
         byte_extract_exprt tmp = expr;
         tmp.type() = comp.type();
@@ -1839,10 +1839,10 @@ simplify_exprt::simplify_byte_extract(const byte_extract_exprt &expr)
   // try to refine it down to extracting from a member or an index in an array
   auto subexpr =
     get_subexpression_at_offset(expr.op(), *offset, expr.type(), ns);
-  if(!subexpr.has_value() || subexpr.value() == expr)
+  if(!subexpr.has_value() || *subexpr == expr)
     return unchanged(expr);
 
-  return changed(simplify_rec(subexpr.value())); // recursive call
+  return changed(simplify_rec(*subexpr)); // recursive call
 }
 
 simplify_exprt::resultt<>

--- a/src/util/simplify_expr_pointer.cpp
+++ b/src/util/simplify_expr_pointer.cpp
@@ -665,7 +665,7 @@ simplify_exprt::simplify_object_size(const unary_exprt &expr)
       if(size_opt.has_value())
       {
         const typet &expr_type = expr.type();
-        exprt size = size_opt.value();
+        exprt size = *size_opt;
 
         if(size.type() != expr_type)
           size = simplify_typecast(typecast_exprt(size, expr_type));

--- a/src/util/simplify_expr_struct.cpp
+++ b/src/util/simplify_expr_struct.cpp
@@ -181,7 +181,7 @@ simplify_exprt::simplify_member(const member_exprt &expr)
 
     if(target_size.has_value())
     {
-      mp_integer target_bits = target_size.value() * 8;
+      mp_integer target_bits = *target_size * 8;
       const auto bits = expr2bits(op, true, ns);
 
       if(bits.has_value() &&
@@ -227,10 +227,10 @@ simplify_exprt::simplify_member(const member_exprt &expr)
         // optimisation.
         if(
           equivalent_member.has_value() &&
-          equivalent_member.value().id() != ID_byte_extract_little_endian &&
-          equivalent_member.value().id() != ID_byte_extract_big_endian)
+          equivalent_member->id() != ID_byte_extract_little_endian &&
+          equivalent_member->id() != ID_byte_extract_big_endian)
         {
-          auto tmp = equivalent_member.value();
+          auto tmp = *equivalent_member;
           return changed(simplify_rec(tmp));
         }
       }

--- a/src/util/simplify_utils.cpp
+++ b/src/util/simplify_utils.cpp
@@ -471,7 +471,7 @@ expr2bits(const exprt &expr, bool little_endian, const namespacet &ns)
       auto tmp = expr2bits(*it, little_endian, ns);
       if(!tmp.has_value())
         return {}; // failed
-      result += tmp.value();
+      result += *tmp;
     }
 
     return result;

--- a/src/util/std_expr.cpp
+++ b/src/util/std_expr.cpp
@@ -164,10 +164,7 @@ static optionalt<exprt> substitute_symbols_rec(
       substitute_symbols_rec(new_substitutions, binding_expr.where());
     if(op_result.has_value())
       return binding_exprt(
-        src.id(),
-        binding_expr.variables(),
-        op_result.value(),
-        binding_expr.type());
+        src.id(), binding_expr.variables(), *op_result, binding_expr.type());
     else
       return {};
   }
@@ -190,7 +187,7 @@ static optionalt<exprt> substitute_symbols_rec(
 
       if(op_result.has_value())
       {
-        op = op_result.value();
+        op = *op_result;
         op_changed = true;
       }
     }
@@ -199,7 +196,7 @@ static optionalt<exprt> substitute_symbols_rec(
       substitute_symbols_rec(new_substitutions, binding_expr.where());
     if(op_result.has_value())
     {
-      new_let_expr.where() = op_result.value();
+      new_let_expr.where() = *op_result;
       op_changed = true;
     }
 
@@ -220,7 +217,7 @@ static optionalt<exprt> substitute_symbols_rec(
 
     if(op_result.has_value())
     {
-      op = op_result.value();
+      op = *op_result;
       op_changed = true;
     }
   }
@@ -256,7 +253,7 @@ exprt binding_exprt::instantiate(const operandst &values) const
   auto substitute_result = substitute_symbols_rec(substitutions, where());
 
   if(substitute_result.has_value())
-    return substitute_result.value();
+    return *substitute_result;
   else
     return where(); // trivial case, variables not used
 }

--- a/unit/solvers/strings/string_format_builtin_function/length_of_decimal_int.cpp
+++ b/unit/solvers/strings/string_format_builtin_function/length_of_decimal_int.cpp
@@ -39,8 +39,7 @@ SCENARIO(
         THEN("length expression is " << oracle)
         {
           const int actual_int =
-            numeric_cast<int>(to_constant_expr(simplify_expr(actual, ns)))
-              .value();
+            *numeric_cast<int>(to_constant_expr(simplify_expr(actual, ns)));
           REQUIRE(actual_int == oracle);
         }
       }

--- a/unit/util/edit_distance.cpp
+++ b/unit/util/edit_distance.cpp
@@ -11,7 +11,7 @@ TEST_CASE("edit distance 0", "[core][util][edit_distance]")
 
   // Distance 0
   REQUIRE(hello.matches("hello"));
-  REQUIRE(hello.get_edit_distance("hello").value() == 0);
+  REQUIRE(*hello.get_edit_distance("hello") == 0);
 
   // Distance 1
   REQUIRE_FALSE(hello.matches("hallo"));
@@ -39,17 +39,17 @@ TEST_CASE("edit distance 1", "[core][util][edit_distance]")
 
   // Distance 0
   REQUIRE(hello.matches("hello"));
-  REQUIRE(hello.get_edit_distance("hello").value() == 0);
+  REQUIRE(*hello.get_edit_distance("hello") == 0);
 
   // Distance 1
   REQUIRE(hello.matches("hallo"));
-  REQUIRE(hello.get_edit_distance("hallo").value() == 1);
+  REQUIRE(*hello.get_edit_distance("hallo") == 1);
   REQUIRE(hello.matches("hell"));
-  REQUIRE(hello.get_edit_distance("hell").value() == 1);
+  REQUIRE(*hello.get_edit_distance("hell") == 1);
   REQUIRE(hello.matches("helloo"));
-  REQUIRE(hello.get_edit_distance("helloo").value() == 1);
+  REQUIRE(*hello.get_edit_distance("helloo") == 1);
   REQUIRE(hello.matches("chello"));
-  REQUIRE(hello.get_edit_distance("chello").value() == 1);
+  REQUIRE(*hello.get_edit_distance("chello") == 1);
 
   // Distance 2
   REQUIRE_FALSE(hello.matches("helol"));
@@ -71,25 +71,25 @@ TEST_CASE("edit distance 2", "[core][util][edit_distance]")
 
   // Distance 0
   REQUIRE(hello.matches("hello"));
-  REQUIRE(hello.get_edit_distance("hello").value() == 0);
+  REQUIRE(*hello.get_edit_distance("hello") == 0);
 
   // Distance 1
   REQUIRE(hello.matches("hallo"));
-  REQUIRE(hello.get_edit_distance("hallo").value() == 1);
+  REQUIRE(*hello.get_edit_distance("hallo") == 1);
   REQUIRE(hello.matches("hell"));
-  REQUIRE(hello.get_edit_distance("hell").value() == 1);
+  REQUIRE(*hello.get_edit_distance("hell") == 1);
   REQUIRE(hello.matches("helloo"));
-  REQUIRE(hello.get_edit_distance("helloo").value() == 1);
+  REQUIRE(*hello.get_edit_distance("helloo") == 1);
   REQUIRE(hello.matches("chello"));
-  REQUIRE(hello.get_edit_distance("chello").value() == 1);
+  REQUIRE(*hello.get_edit_distance("chello") == 1);
 
   // Distance 2
   REQUIRE(hello.matches("helol"));
-  REQUIRE(hello.get_edit_distance("helol").value() == 2);
+  REQUIRE(*hello.get_edit_distance("helol") == 2);
   REQUIRE(hello.matches("help"));
-  REQUIRE(hello.get_edit_distance("help").value() == 2);
+  REQUIRE(*hello.get_edit_distance("help") == 2);
   REQUIRE(hello.matches("yohello"));
-  REQUIRE(hello.get_edit_distance("yohello").value() == 2);
+  REQUIRE(*hello.get_edit_distance("yohello") == 2);
 
   // Distance 3
   REQUIRE_FALSE(hello.matches("kelp"));
@@ -106,33 +106,33 @@ TEST_CASE("edit distance 3", "[core][util][edit_distance]")
 
   // Distance 0
   REQUIRE(hello.matches("hello"));
-  REQUIRE(hello.get_edit_distance("hello").value() == 0);
+  REQUIRE(*hello.get_edit_distance("hello") == 0);
 
   // Distance 1
   REQUIRE(hello.matches("hallo"));
-  REQUIRE(hello.get_edit_distance("hallo").value() == 1);
+  REQUIRE(*hello.get_edit_distance("hallo") == 1);
   REQUIRE(hello.matches("hell"));
-  REQUIRE(hello.get_edit_distance("hell").value() == 1);
+  REQUIRE(*hello.get_edit_distance("hell") == 1);
   REQUIRE(hello.matches("helloo"));
-  REQUIRE(hello.get_edit_distance("helloo").value() == 1);
+  REQUIRE(*hello.get_edit_distance("helloo") == 1);
   REQUIRE(hello.matches("chello"));
-  REQUIRE(hello.get_edit_distance("chello").value() == 1);
+  REQUIRE(*hello.get_edit_distance("chello") == 1);
 
   // Distance 2
   REQUIRE(hello.matches("helol"));
-  REQUIRE(hello.get_edit_distance("helol").value() == 2);
+  REQUIRE(*hello.get_edit_distance("helol") == 2);
   REQUIRE(hello.matches("help"));
-  REQUIRE(hello.get_edit_distance("help").value() == 2);
+  REQUIRE(*hello.get_edit_distance("help") == 2);
   REQUIRE(hello.matches("yohello"));
-  REQUIRE(hello.get_edit_distance("yohello").value() == 2);
+  REQUIRE(*hello.get_edit_distance("yohello") == 2);
 
   // Distance 3
   REQUIRE(hello.matches("kelp"));
-  REQUIRE(hello.get_edit_distance("kelp").value() == 3);
+  REQUIRE(*hello.get_edit_distance("kelp") == 3);
   REQUIRE(hello.matches("hilt"));
-  REQUIRE(hello.get_edit_distance("hilt").value() == 3);
+  REQUIRE(*hello.get_edit_distance("hilt") == 3);
   REQUIRE(hello.matches("wallow"));
-  REQUIRE(hello.get_edit_distance("wallow").value() == 3);
+  REQUIRE(*hello.get_edit_distance("wallow") == 3);
 
   // Distance > 3
   REQUIRE_FALSE(hello.matches("unrelated"));

--- a/unit/util/interval/eval.cpp
+++ b/unit/util/interval/eval.cpp
@@ -55,7 +55,7 @@ SCENARIO("Unary eval on intervals", "[core][analyses][interval][eval]")
       auto negated_val =
         numeric_cast<mp_integer>(five.eval(ID_unary_minus).get_lower());
       REQUIRE(negated_val.has_value());
-      REQUIRE(negated_val.value() == -5);
+      REQUIRE(*negated_val == -5);
 
       // TODO: unary minus does not work on intervals that contain extremes
       // ADA-535
@@ -68,7 +68,7 @@ SCENARIO("Unary eval on intervals", "[core][analyses][interval][eval]")
       auto bitwise_negated_val =
         numeric_cast<mp_integer>(five.eval(ID_bitnot).get_lower());
       REQUIRE(bitwise_negated_val.has_value());
-      REQUIRE(bitwise_negated_val.value() == (~5));
+      REQUIRE(*bitwise_negated_val == (~5));
     }
   }
   WHEN("Unary operations to an single element interval")

--- a/unit/util/interval/subtract.cpp
+++ b/unit/util/interval/subtract.cpp
@@ -113,7 +113,7 @@ SCENARIO(
       REQUIRE(result.is_single_value_interval());
       auto maybe_lower = numeric_cast<mp_integer>(result.get_lower());
       REQUIRE(maybe_lower.has_value());
-      REQUIRE(maybe_lower.value() == 7);
+      REQUIRE(*maybe_lower == 7);
     }
   }
 
@@ -128,7 +128,7 @@ SCENARIO(
       REQUIRE(result.is_single_value_interval());
       auto maybe_lower = numeric_cast<mp_integer>(result.get_lower());
       REQUIRE(maybe_lower.has_value());
-      REQUIRE(maybe_lower.value() == 10);
+      REQUIRE(*maybe_lower == 10);
     }
   }
 
@@ -141,10 +141,10 @@ SCENARIO(
       auto result = constant_interval_exprt::minus(lhs, rhs);
       auto maybe_lower = numeric_cast<mp_integer>(result.get_lower());
       REQUIRE(maybe_lower.has_value());
-      REQUIRE(maybe_lower.value() == 9);
+      REQUIRE(*maybe_lower == 9);
       auto maybe_upper = numeric_cast<mp_integer>(result.get_upper());
       REQUIRE(maybe_upper.has_value());
-      REQUIRE(maybe_upper.value() == 10);
+      REQUIRE(*maybe_upper == 10);
     }
   }
 }

--- a/unit/util/interval_union.cpp
+++ b/unit/util/interval_union.cpp
@@ -35,7 +35,7 @@ TEST_CASE("interval_union", "[core][test-gen-util][interval_union]")
 
   REQUIRE_FALSE(first.is_empty());
   REQUIRE(first.maximum().has_value());
-  REQUIRE(first.maximum().value() == 10);
+  REQUIRE(*first.maximum() == 10);
   REQUIRE_FALSE(first.minimum().has_value());
 
   REQUIRE_FALSE(second.is_empty());
@@ -45,7 +45,7 @@ TEST_CASE("interval_union", "[core][test-gen-util][interval_union]")
   REQUIRE_FALSE(third.is_empty());
   REQUIRE_FALSE(third.maximum().has_value());
   REQUIRE(third.minimum().has_value());
-  REQUIRE(third.minimum().value() == 12);
+  REQUIRE(*third.minimum() == 12);
 
   REQUIRE(first.make_union(second).to_string() == "[:-10][-8:2][4:]");
   REQUIRE(first.make_intersection(second).to_string() == "[:-15][5:5][8:10]");

--- a/unit/util/optional_utils.cpp
+++ b/unit/util/optional_utils.cpp
@@ -23,10 +23,10 @@ void do_optional_lookup_test(map_like_collectiont &map)
   map.insert({"pwd", "/home"});
   auto const hello_result = optional_lookup(map, "hello");
   REQUIRE(hello_result.has_value());
-  REQUIRE(hello_result.value() == "world");
+  REQUIRE(*hello_result == "world");
   auto const pwd_result = optional_lookup(map, "pwd");
   REQUIRE(pwd_result.has_value());
-  REQUIRE(pwd_result.value() == "/home");
+  REQUIRE(*pwd_result == "/home");
   REQUIRE_FALSE(optional_lookup(map, "does not exit").has_value());
 }
 } // namespace

--- a/unit/util/pointer_offset_size.cpp
+++ b/unit/util/pointer_offset_size.cpp
@@ -35,34 +35,34 @@ TEST_CASE("Build subexpression to access element at offset into array")
 
   {
     const auto result = get_subexpression_at_offset(a, 0, t, ns);
-    REQUIRE(result.value() == index_exprt(a, from_integer(0, c_index_type())));
+    REQUIRE(*result == index_exprt(a, from_integer(0, c_index_type())));
   }
 
   {
     const auto result = get_subexpression_at_offset(a, 32 / 8, t, ns);
-    REQUIRE(result.value() == index_exprt(a, from_integer(1, c_index_type())));
+    REQUIRE(*result == index_exprt(a, from_integer(1, c_index_type())));
   }
 
   {
     const auto result =
       get_subexpression_at_offset(a, from_integer(0, size_type()), t, ns);
-    REQUIRE(result.value() == index_exprt(a, from_integer(0, c_index_type())));
+    REQUIRE(*result == index_exprt(a, from_integer(0, c_index_type())));
   }
 
   {
     const auto result =
-      get_subexpression_at_offset(a, size_of_expr(t, ns).value(), t, ns);
-    REQUIRE(result.value() == index_exprt(a, from_integer(1, c_index_type())));
+      get_subexpression_at_offset(a, *size_of_expr(t, ns), t, ns);
+    REQUIRE(*result == index_exprt(a, from_integer(1, c_index_type())));
   }
 
   {
     const signedbv_typet small_t(8);
     const auto result = get_subexpression_at_offset(a, 1, small_t, ns);
     REQUIRE(
-      result.value() == make_byte_extract(
-                          index_exprt(a, from_integer(0, c_index_type())),
-                          from_integer(1, c_index_type()),
-                          small_t));
+      *result == make_byte_extract(
+                   index_exprt(a, from_integer(0, c_index_type())),
+                   from_integer(1, c_index_type()),
+                   small_t));
   }
 
   {
@@ -72,7 +72,7 @@ TEST_CASE("Build subexpression to access element at offset into array")
     // not enough to fill a 16 bit int, so this cannot be transformed in an
     // index_exprt.
     REQUIRE(
-      result.value() ==
+      *result ==
       make_byte_extract(a, from_integer(3, c_index_type()), int16_t));
   }
 }
@@ -95,31 +95,31 @@ TEST_CASE("Build subexpression to access element at offset into struct")
 
   {
     const auto result = get_subexpression_at_offset(s, 0, t, ns);
-    REQUIRE(result.value() == member_exprt(s, "foo", t));
+    REQUIRE(*result == member_exprt(s, "foo", t));
   }
 
   {
     const auto result = get_subexpression_at_offset(s, 32 / 8, t, ns);
-    REQUIRE(result.value() == member_exprt(s, "bar", t));
+    REQUIRE(*result == member_exprt(s, "bar", t));
   }
 
   {
     const auto result =
       get_subexpression_at_offset(s, from_integer(0, size_type()), t, ns);
-    REQUIRE(result.value() == member_exprt(s, "foo", t));
+    REQUIRE(*result == member_exprt(s, "foo", t));
   }
 
   {
     const auto result =
-      get_subexpression_at_offset(s, size_of_expr(t, ns).value(), t, ns);
-    REQUIRE(result.value() == member_exprt(s, "bar", t));
+      get_subexpression_at_offset(s, *size_of_expr(t, ns), t, ns);
+    REQUIRE(*result == member_exprt(s, "bar", t));
   }
 
   {
     const signedbv_typet small_t(8);
     const auto result = get_subexpression_at_offset(s, 1, small_t, ns);
     REQUIRE(
-      result.value() ==
+      *result ==
       make_byte_extract(
         member_exprt(s, "foo", t), from_integer(1, c_index_type()), small_t));
   }


### PR DESCRIPTION
std::optional::value() is unavailable in earlier versions of macOS. We
generally use operator* already, which always works.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
