### PR TITLE
goto_rw/range_spect: gracefully handle arbitrarily large ranges

### DIFF
--- a/regression/cbmc/havoc_slice_checks/full-slice.desc
+++ b/regression/cbmc/havoc_slice_checks/full-slice.desc
@@ -1,0 +1,15 @@
+CORE
+main.c
+--full-slice
+^\[main\.assertion\.\d+\] line 9 assertion havoc_slice W_OK.*: FAILURE$
+^\[main\.assertion\.\d+\] line 13 assertion havoc_slice W_OK.*: FAILURE$
+^\[main\.assertion\.\d+\] line 18 assertion havoc_slice W_OK.*: FAILURE$
+^\[main\.assertion\.\d+\] line 21 assertion havoc_slice W_OK.*: FAILURE$
+^\[main\.assertion\.\d+\] line 24 assertion havoc_slice W_OK.*: FAILURE$
+^\[main\.assertion\.\d+\] line 27 assertion havoc_slice W_OK.*: FAILURE$
+^\[main\.assertion\.\d+\] line 30 assertion havoc_slice W_OK.*: FAILURE$
+\*\* 7 of [0-9]+ failed \(.*\)
+^VERIFICATION FAILED$
+^EXIT=10$
+^SIGNAL=0$
+--

--- a/src/analyses/goto_rw.h
+++ b/src/analyses/goto_rw.h
@@ -78,10 +78,20 @@ public:
 
   static range_spect to_range_spect(const mp_integer &size)
   {
-    PRECONDITION(size.is_long());
+    // The size need not fit into the analysis platform's width of a signed long
+    // (as an example, it could be an unsigned size_t max, or perhaps the source
+    // platform has much wider types than the analysis platform.
+    if(!size.is_long())
+      return range_spect::unknown();
+
     mp_integer::llong_t ll = size.to_long();
-    CHECK_RETURN(ll <= std::numeric_limits<range_spect::value_type>::max());
-    CHECK_RETURN(ll >= std::numeric_limits<range_spect::value_type>::min());
+    if(
+      ll > std::numeric_limits<range_spect::value_type>::max() ||
+      ll < std::numeric_limits<range_spect::value_type>::min())
+    {
+      return range_spect::unknown();
+    }
+
     return range_spect{(value_type)ll};
   }
 


### PR DESCRIPTION
When the value of an mp_integer doesn't fit into a range_spect::value_type we can safely fall back to using "unknown" instead, which is a safe over-approximation.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
