### PR TITLE
Unwindset parsing: warn when label-based identifier is ambiguous

### DIFF
--- a/regression/cbmc/unwindset2/main.c
+++ b/regression/cbmc/unwindset2/main.c
@@ -1,0 +1,7 @@
+int main()
+{
+  // clang-format off
+for_loop: for(int i=0; i<5; ++i) { while(i<5) ++i; }
+  // clang-format on
+  return 0;
+}

--- a/regression/cbmc/unwindset2/test.desc
+++ b/regression/cbmc/unwindset2/test.desc
@@ -1,0 +1,9 @@
+CORE
+main.c
+--unwindset main.for_loop:2 --unwinding-assertions
+^loop identifier main.for_loop provided with unwindset is ambiguous$
+^VERIFICATION SUCCESSFUL$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring

--- a/src/goto-instrument/unwindset.cpp
+++ b/src/goto-instrument/unwindset.cpp
@@ -134,8 +134,14 @@ void unwindsett::parse_unwindset_one_loop(
             location.has_value() && instruction.is_backwards_goto() &&
             instruction.source_location() == *location)
           {
+            if(nr.has_value())
+            {
+              messaget log{message_handler};
+              log.warning()
+                << "loop identifier " << id
+                << " provided with unwindset is ambiguous" << messaget::eom;
+            }
             nr = instruction.loop_number;
-            break;
           }
         }
         if(!nr.has_value())


### PR DESCRIPTION
There are multiple possible loops matching a label-based identifier when
all loop heads are on the same line. Warn when this case is detected
instead of silently picking the inner loop, and also pick the outermost
loop instead.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
