### PR TITLE
CONTRACTS: Allow pure contracts.

### DIFF
--- a/regression/contracts/named-contracts/main-fail1.c
+++ b/regression/contracts/named-contracts/main-fail1.c
@@ -1,0 +1,24 @@
+#include <stdlib.h>
+
+int foo(int *arr, size_t size)
+{
+  return 0;
+}
+
+int foo(int *arr, size_t size)
+  // clang-format off
+__CPROVER_requires(size > 0 && __CPROVER_is_fresh(arr, size))
+__CPROVER_assigns(
+  arr[0], arr[size-1]; 
+  size >= 10: arr[5];
+)
+__CPROVER_ensures(arr[0] == 0 && arr[size-1] == 0)
+__CPROVER_ensures(size >= 10 ==> arr[5] == __CPROVER_return_value)
+  // clang-format on
+  ;
+
+int main()
+{
+  int retval = foo(&arr, 10);
+  return 0;
+}

--- a/regression/contracts/named-contracts/main-fail2.c
+++ b/regression/contracts/named-contracts/main-fail2.c
@@ -1,0 +1,25 @@
+#include <assert.h>
+#include <stdlib.h>
+
+int foo(int *arr, size_t size)
+  // clang-format off
+__CPROVER_requires(size > 0 && __CPROVER_is_fresh(arr, size))
+__CPROVER_assigns(
+  arr[0], arr[size-1]; 
+  size >= 10: arr[5];
+)
+__CPROVER_ensures(arr[0] == 0 && arr[size-1] == 0)
+__CPROVER_ensures(size >= 10 ==> arr[5] == __CPROVER_return_value)
+  // clang-format on
+  ;
+
+int foo(int *arr, size_t size)
+{
+  return 0;
+}
+
+int main()
+{
+  int retval = foo(&arr, 10);
+  return 0;
+}

--- a/regression/contracts/named-contracts/main-pass.c
+++ b/regression/contracts/named-contracts/main-pass.c
@@ -1,0 +1,31 @@
+#include <assert.h>
+#include <stdlib.h>
+
+int foo(int *arr, size_t size)
+  // clang-format off
+__CPROVER_requires(size > 0 && __CPROVER_is_fresh(arr, size))
+__CPROVER_assigns(
+  arr[0], arr[size-1]; 
+  size >= 10: arr[5];
+)
+__CPROVER_ensures(arr[0] == 0 && arr[size-1] == 0)
+__CPROVER_ensures(size >= 10 ==> arr[5] == __CPROVER_return_value)
+  // clang-format on
+  ;
+
+int main()
+{
+  int arr[10] = {10, 9, 8, 7, 6, 5, 4, 3, 2, 1};
+  int retval = foo(&arr, 10);
+  assert(arr[0] == 0);
+  assert(arr[1] == 9);
+  assert(arr[2] == 8);
+  assert(arr[3] == 7);
+  assert(arr[4] == 6);
+  assert(arr[5] == retval);
+  assert(arr[6] == 4);
+  assert(arr[7] == 3);
+  assert(arr[8] == 2);
+  assert(arr[9] == 0);
+  return 0;
+}

--- a/regression/contracts/named-contracts/test-fail1.desc
+++ b/regression/contracts/named-contracts/test-fail1.desc
@@ -1,0 +1,11 @@
+CORE
+main-fail1.c
+--replace-call-with-contract
+error: function 'foo' cannot be redeclared as a pure contract
+^CONVERSION ERROR$
+^EXIT=(1|64)$
+^SIGNAL=0$
+--
+--
+This test checks that we cannot have a first declaration without contract 
+and a body followed by a redeclaration with a contract and without body.

--- a/regression/contracts/named-contracts/test-fail2.desc
+++ b/regression/contracts/named-contracts/test-fail2.desc
@@ -1,0 +1,11 @@
+CORE
+main-fail2.c
+--replace-call-with-contract foo
+function 'foo' was already declared as a pure contract
+^CONVERSION ERROR$
+^EXIT=(1|64)$
+^SIGNAL=0$
+--
+--
+This test checks that programs with function redeclarations 
+where one declaration is a pure contract are rejected.

--- a/regression/contracts/named-contracts/test-pass.desc
+++ b/regression/contracts/named-contracts/test-pass.desc
@@ -1,0 +1,10 @@
+CORE
+main-pass.c
+--replace-call-with-contract foo
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+--
+This test checks that we can have a function declaration with a contract and
+without body and replace a call to the function by the contract.

--- a/src/ansi-c/c_typecheck_base.cpp
+++ b/src/ansi-c/c_typecheck_base.cpp
@@ -521,34 +521,8 @@ void c_typecheck_baset::typecheck_function_body(symbolt &symbol)
   // set return type
   return_type=code_type.return_type();
 
-  unsigned anon_counter=0;
-
-  // Add the parameter declarations into the symbol table.
-  for(auto &p : code_type.parameters())
-  {
-    // may be anonymous
-    if(p.get_base_name().empty())
-    {
-      irep_idt base_name="#anon"+std::to_string(anon_counter++);
-      p.set_base_name(base_name);
-    }
-
-    // produce identifier
-    irep_idt base_name = p.get_base_name();
-    irep_idt identifier=id2string(symbol.name)+"::"+id2string(base_name);
-
-    p.set_identifier(identifier);
-
-    parameter_symbolt p_symbol;
-
-    p_symbol.type = p.type();
-    p_symbol.name=identifier;
-    p_symbol.base_name=base_name;
-    p_symbol.location = p.source_location();
-
-    symbolt *new_p_symbol;
-    move_symbol(p_symbol, new_p_symbol);
-  }
+  // Add the parameter declarations into the symbol table
+  add_parameters_to_symbol_table(symbol);
 
   // typecheck the body code
   typecheck_code(to_code(symbol.value));
@@ -772,5 +746,41 @@ void c_typecheck_baset::typecheck_declaration(
         }
       }
     }
+  }
+}
+
+void c_typecheck_baset::add_parameters_to_symbol_table(symbolt &symbol)
+{
+  PRECONDITION(can_cast_type<code_typet>(symbol.type));
+
+  code_typet &code_type = to_code_type(symbol.type);
+
+  unsigned anon_counter = 0;
+
+  // Add the parameter declarations into the symbol table.
+  for(auto &p : code_type.parameters())
+  {
+    // may be anonymous
+    if(p.get_base_name().empty())
+    {
+      irep_idt base_name = "#anon" + std::to_string(anon_counter++);
+      p.set_base_name(base_name);
+    }
+
+    // produce identifier
+    irep_idt base_name = p.get_base_name();
+    irep_idt identifier = id2string(symbol.name) + "::" + id2string(base_name);
+
+    p.set_identifier(identifier);
+
+    parameter_symbolt p_symbol;
+
+    p_symbol.type = p.type();
+    p_symbol.name = identifier;
+    p_symbol.base_name = base_name;
+    p_symbol.location = p.source_location();
+
+    symbolt *new_p_symbol;
+    move_symbol(p_symbol, new_p_symbol);
   }
 }

--- a/src/ansi-c/c_typecheck_base.cpp
+++ b/src/ansi-c/c_typecheck_base.cpp
@@ -403,8 +403,17 @@ void c_typecheck_baset::typecheck_redefinition_non_type(
       if(new_symbol.is_macro)
         old_symbol.is_macro=true;
       else
+      {
+        // old symbol had no body but might have had a contract
+        if(to_code_with_contract_type(old_symbol.type).has_contract())
+        {
+          error().source_location = new_symbol.location;
+          error() << "function '" << new_symbol.display_name()
+                  << "' was already declared as a pure contract" << eom;
+          throw 0;
+        }
         typecheck_function_body(new_symbol);
-
+      }
       // overwrite location
       old_symbol.location=new_symbol.location;
 
@@ -414,7 +423,17 @@ void c_typecheck_baset::typecheck_redefinition_non_type(
       // overwrite type (because of parameter names)
       old_symbol.type=new_symbol.type;
     }
-
+    else
+    {
+      // new symbol has no body but might have a contract
+      if(to_code_with_contract_type(new_symbol.type).has_contract())
+      {
+        error().source_location = new_symbol.location;
+        error() << "function '" << new_symbol.display_name()
+                << "' cannot be redeclared as a pure contract" << eom;
+        throw 0;
+      }
+    }
     return;
   }
 

--- a/src/ansi-c/c_typecheck_base.cpp
+++ b/src/ansi-c/c_typecheck_base.cpp
@@ -153,6 +153,12 @@ void c_typecheck_baset::typecheck_new_symbol(symbolt &symbol)
     {
       typecheck_function_body(symbol);
     }
+    else if(
+      symbol.value.is_nil() && !symbol.is_macro &&
+      to_code_with_contract_type(symbol.type).has_contract())
+    {
+      add_parameters_to_symbol_table(symbol);
+    }
     else
     {
       // we don't need the identifiers

--- a/src/ansi-c/c_typecheck_base.h
+++ b/src/ansi-c/c_typecheck_base.h
@@ -268,6 +268,8 @@ protected:
     symbolt &old_symbol, symbolt &new_symbol);
   void typecheck_function_body(symbolt &symbol);
 
+  void add_parameters_to_symbol_table(symbolt &symbol);
+
   virtual void do_initializer(symbolt &symbol);
 
   static bool is_numeric_type(const typet &src)

--- a/src/util/c_types.h
+++ b/src/util/c_types.h
@@ -366,6 +366,11 @@ public:
   {
   }
 
+  bool has_contract() const
+  {
+    return !ensures().empty() || !requires().empty() || !assigns().empty();
+  }
+
   const exprt::operandst &assigns() const
   {
     return static_cast<const exprt &>(find(ID_C_spec_assigns)).operands();


### PR DESCRIPTION
A pure contract is modelled as a function declaration with a contract. 

```
int foo(args)
__CPROVER_requires(R)
__CPROVER_ensures(E)
__CPROVER_assigns(A)
;
```

We reject multiple declarations for such functions (with or without a body).

- [X] Each commit message has a non-empty body, explaining why the change was made.
- [X] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [X] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [n/a] My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- [X] White-space or formatting changes outside the feature-related changed lines are in commits of their own.
