### PR TITLE
Add support for null pointer and address of expression conversion in incremental SMT2 backend.

### DIFF
--- a/regression/cbmc-incr-smt2/pointers/null_pointer.c
+++ b/regression/cbmc-incr-smt2/pointers/null_pointer.c
@@ -1,0 +1,21 @@
+#include <assert.h>
+#include <inttypes.h>
+#include <stdbool.h>
+#include <stddef.h>
+
+int main()
+{
+  int notdet_int;
+  int *ptr;
+  bool notdet_bool;
+  if(notdet_bool)
+  {
+    ptr = &notdet_int;
+    assert(((uint64_t)ptr) > 1);
+  }
+  else
+  {
+    ptr = NULL;
+  }
+  assert(((uint64_t)ptr) != 0);
+}

--- a/regression/cbmc-incr-smt2/pointers/null_pointer.desc
+++ b/regression/cbmc-incr-smt2/pointers/null_pointer.desc
@@ -1,0 +1,17 @@
+CORE
+null_pointer.c
+--trace
+Passing problem to incremental SMT2 solving
+line 14 assertion \(\(uint64_t\)ptr\) > 1: SUCCESS
+line 20 assertion \(\(uint64_t\)ptr\) != 0: FAILURE
+notdet_bool=FALSE \(0+\)
+^EXIT=10$
+^SIGNAL=0$
+--
+notdet_bool=TRUE
+--
+Tests for null related functionality.
+ * Assignment of the value NULL to a pointer.
+ * Comparison of NULL pointer value against 0.
+ * Check that the address of a non-null pointer is not an offset into the NULL
+   object.

--- a/src/solvers/Makefile
+++ b/src/solvers/Makefile
@@ -195,6 +195,7 @@ SRC = $(BOOLEFORCE_SRC) \
       smt2/smt2irep.cpp \
       smt2_incremental/construct_value_expr_from_smt.cpp \
       smt2_incremental/convert_expr_to_smt.cpp \
+      smt2_incremental/object_tracking.cpp \
       smt2_incremental/smt_bit_vector_theory.cpp \
       smt2_incremental/smt_commands.cpp \
       smt2_incremental/smt_core_theory.cpp \

--- a/src/solvers/smt2_incremental/convert_expr_to_smt.cpp
+++ b/src/solvers/smt2_incremental/convert_expr_to_smt.cpp
@@ -6,6 +6,7 @@
 #include <util/c_types.h>
 #include <util/expr.h>
 #include <util/expr_cast.h>
+#include <util/expr_util.h>
 #include <util/floatbv_expr.h>
 #include <util/mathematical_expr.h>
 #include <util/pointer_expr.h>
@@ -268,6 +269,15 @@ struct sort_based_literal_convertert : public smt_sort_const_downcast_visitort
 
 static smt_termt convert_expr_to_smt(const constant_exprt &constant_literal)
 {
+  if(is_null_pointer(constant_literal))
+  {
+    const size_t bit_width =
+      type_checked_cast<pointer_typet>(constant_literal.type()).get_width();
+    // An address of 0 encodes an object identifier of 0 for the NULL object
+    // and an offset of 0 into the object.
+    const auto address = 0;
+    return smt_bit_vector_constant_termt{address, bit_width};
+  }
   const auto sort = convert_type_to_smt_sort(constant_literal.type());
   sort_based_literal_convertert converter(constant_literal);
   sort.accept(converter);

--- a/src/solvers/smt2_incremental/convert_expr_to_smt.cpp
+++ b/src/solvers/smt2_incremental/convert_expr_to_smt.cpp
@@ -278,6 +278,15 @@ static smt_termt convert_expr_to_smt(const constant_exprt &constant_literal)
     const auto address = 0;
     return smt_bit_vector_constant_termt{address, bit_width};
   }
+  if(constant_literal.type() == integer_typet{})
+  {
+    // This is converting integer constants into bit vectors for use with
+    // bit vector based smt logics. As bit vector widths are not specified for
+    // non bit vector types, this chooses a width based on the minimum needed
+    // to hold the integer constant value.
+    const auto value = numeric_cast_v<mp_integer>(constant_literal);
+    return smt_bit_vector_constant_termt{value, address_bits(value + 1)};
+  }
   const auto sort = convert_type_to_smt_sort(constant_literal.type());
   sort_based_literal_convertert converter(constant_literal);
   sort.accept(converter);

--- a/src/solvers/smt2_incremental/convert_expr_to_smt.h
+++ b/src/solvers/smt2_incremental/convert_expr_to_smt.h
@@ -3,6 +3,7 @@
 #ifndef CPROVER_SOLVERS_SMT2_INCREMENTAL_CONVERT_EXPR_TO_SMT_H
 #define CPROVER_SOLVERS_SMT2_INCREMENTAL_CONVERT_EXPR_TO_SMT_H
 
+#include <solvers/smt2_incremental/object_tracking.h>
 #include <solvers/smt2_incremental/smt_sorts.h>
 #include <solvers/smt2_incremental/smt_terms.h>
 
@@ -15,6 +16,7 @@ smt_sortt convert_type_to_smt_sort(const typet &type);
 
 /// \brief Converts the \p expression to an smt encoding of the same expression
 ///   stored as term ast (abstract syntax tree).
-smt_termt convert_expr_to_smt(const exprt &expression);
+smt_termt
+convert_expr_to_smt(const exprt &expression, const smt_object_mapt &object_map);
 
 #endif // CPROVER_SOLVERS_SMT2_INCREMENTAL_CONVERT_EXPR_TO_SMT_H

--- a/src/solvers/smt2_incremental/object_tracking.cpp
+++ b/src/solvers/smt2_incremental/object_tracking.cpp
@@ -1,0 +1,88 @@
+// Author: Diffblue Ltd.
+
+#include "object_tracking.h"
+
+#include <util/c_types.h>
+#include <util/pointer_offset_size.h>
+#include <util/std_code.h>
+#include <util/std_expr.h>
+#include <util/string_constant.h>
+
+exprt find_object_base_expression(const address_of_exprt &address_of)
+{
+  auto current = std::ref(address_of.object());
+  while(
+    !(can_cast_expr<symbol_exprt>(current) ||
+      can_cast_expr<constant_exprt>(current) ||
+      can_cast_expr<string_constantt>(current) ||
+      can_cast_expr<code_labelt>(current)))
+  {
+    if(const auto index = expr_try_dynamic_cast<index_exprt>(current.get()))
+    {
+      // For the case `my_array[bar]` the base expression is `my_array`.
+      current = index->array();
+      continue;
+    }
+    if(const auto member = expr_try_dynamic_cast<member_exprt>(current.get()))
+    {
+      // For the case `my_struct.field_name` the base expression is `my_struct`.
+      current = member->compound();
+      continue;
+    }
+    INVARIANT(
+      false,
+      "Unable to find base object of expression: " +
+        current.get().pretty(1, 0));
+  }
+  return current.get();
+}
+
+static decision_procedure_objectt make_null_object()
+{
+  decision_procedure_objectt null_object;
+  null_object.unique_id = 0;
+  null_object.base_expression = null_pointer_exprt{pointer_type(void_type())};
+  return null_object;
+}
+
+smt_object_mapt initial_smt_object_map()
+{
+  smt_object_mapt object_map;
+  decision_procedure_objectt null_object = make_null_object();
+  exprt base = null_object.base_expression;
+  object_map.emplace(std::move(base), std::move(null_object));
+  return object_map;
+}
+
+void track_expression_objects(
+  const exprt &expression,
+  const namespacet &ns,
+  smt_object_mapt &object_map)
+{
+  find_object_base_expressions(
+    expression, [&](const exprt &object_base) -> void {
+      const auto find_result = object_map.find(object_base);
+      if(find_result != object_map.cend())
+        return;
+      decision_procedure_objectt object;
+      object.base_expression = object_base;
+      object.unique_id = object_map.size();
+      object.size = size_of_expr(object_base.type(), ns);
+      object_map.emplace_hint(find_result, object_base, std::move(object));
+    });
+}
+
+bool objects_are_already_tracked(
+  const exprt &expression,
+  const smt_object_mapt &object_map)
+{
+  bool all_objects_tracked = true;
+  find_object_base_expressions(
+    expression, [&](const exprt &object_base) -> void {
+      const auto find_result = object_map.find(object_base);
+      if(find_result != object_map.cend())
+        return;
+      all_objects_tracked = false;
+    });
+  return all_objects_tracked;
+}

--- a/src/solvers/smt2_incremental/object_tracking.h
+++ b/src/solvers/smt2_incremental/object_tracking.h
@@ -1,0 +1,90 @@
+// Author: Diffblue Ltd.
+
+#ifndef CPROVER_SOLVERS_SMT2_INCREMENTAL_OBJECT_TRACKING_H
+#define CPROVER_SOLVERS_SMT2_INCREMENTAL_OBJECT_TRACKING_H
+
+#include <util/expr.h>
+#include <util/pointer_expr.h>
+
+#include <unordered_map>
+
+/// Information the decision procedure holds about each object.
+struct decision_procedure_objectt
+{
+  /// The expression for the root of the object. This is expression equivalent
+  /// to deferencing a pointer to this object with a zero offset.
+  exprt base_expression;
+  /// Number which uniquely identifies this particular object.
+  std::size_t unique_id;
+  /// Expression which evaluates to the size of the object in bytes.
+  optionalt<exprt> size;
+};
+
+/// The model of addresses we use consists of a unique object identifier and an
+/// offset. In order to encode the offset identifiers we need to assign unique
+/// identifiers to the objects. This function finds the base object expression
+/// in an address of expression for which a unique identifier needs to be
+/// assigned.
+exprt find_object_base_expression(const address_of_exprt &address_of);
+
+/// Arbitary expressions passed to the decision procedure may have multiple
+/// address of operations as its sub expressions. This means the overall
+/// expression may contain multiple base objects which need to be assigned
+/// unique identifiers.
+/// \param expression
+///   The expression within which to find base objects.
+/// \param output_object
+///   This function is called with each of the base object expressions found, as
+///   they are found.
+/// \details
+///   The found objects are returned through an output function in order to
+///   separate the implementation of the storage and deduplication of the
+///   results from finding the object expressions. The type of \p output_object
+///   is a template parameter in order to eliminate potential performance
+///   overheads of using `std::function`.
+template <typename output_object_functiont>
+void find_object_base_expressions(
+  const exprt &expression,
+  const output_object_functiont &output_object)
+{
+  expression.visit_pre([&](const exprt &node) {
+    if(const auto address_of = expr_try_dynamic_cast<address_of_exprt>(node))
+    {
+      output_object(find_object_base_expression(*address_of));
+    }
+  });
+}
+
+/// Mapping from an object's base expression to the set of information about it
+/// which we track.
+using smt_object_mapt =
+  std::unordered_map<exprt, decision_procedure_objectt, irep_hash>;
+
+/// Constructs an initial object map containing the null object. The null object
+/// must be added at construction in order to ensure it is allocated a unique
+/// identifier of 0.
+smt_object_mapt initial_smt_object_map();
+
+/// \brief
+///   Finds all the object expressions in the given expression and adds them to
+///   the object map for cases where the map does not contain them already.
+/// \param expression
+///   The expression within which to find and base object expressions.
+/// \param ns
+///   The namespace used to look up the size of object types.
+/// \param object_map
+///   The map into which any new tracking information should be inserted.
+void track_expression_objects(
+  const exprt &expression,
+  const namespacet &ns,
+  smt_object_mapt &object_map);
+
+/// Finds whether all base object expressions in the given expression are
+/// already tracked in the given object map. This supports writing invariants
+/// on the base object expressions already being tracked in the map in contexts
+/// where the map is const.
+bool objects_are_already_tracked(
+  const exprt &expression,
+  const smt_object_mapt &object_map);
+
+#endif // CPROVER_SOLVERS_SMT2_INCREMENTAL_OBJECT_TRACKING_H

--- a/src/solvers/smt2_incremental/smt2_incremental_decision_procedure.h
+++ b/src/solvers/smt2_incremental/smt2_incremental_decision_procedure.h
@@ -6,10 +6,12 @@
 #ifndef CPROVER_SOLVERS_SMT2_INCREMENTAL_SMT2_INCREMENTAL_DECISION_PROCEDURE_H
 #define CPROVER_SOLVERS_SMT2_INCREMENTAL_SMT2_INCREMENTAL_DECISION_PROCEDURE_H
 
-#include <solvers/smt2_incremental/smt_terms.h>
-#include <solvers/stack_decision_procedure.h>
 #include <util/message.h>
 #include <util/std_expr.h>
+
+#include <solvers/smt2_incremental/object_tracking.h>
+#include <solvers/smt2_incremental/smt_terms.h>
+#include <solvers/stack_decision_procedure.h>
 
 #include <memory>
 #include <unordered_map>
@@ -55,6 +57,9 @@ protected:
   ///   been defined, along with their dependencies in turn.
   void define_dependent_functions(const exprt &expr);
   void ensure_handle_for_expr_defined(const exprt &expr);
+  /// \brief Add objects in \p expr to object_map if needed and convert to smt.
+  /// \note This function is non-const because it mutates the object_map.
+  smt_termt convert_expr_to_smt(const exprt &expr);
 
   const namespacet &ns;
 
@@ -78,6 +83,7 @@ protected:
     expression_handle_identifiers;
   std::unordered_map<exprt, smt_identifier_termt, irep_hash>
     expression_identifiers;
+  smt_object_mapt object_map;
 };
 
 #endif // CPROVER_SOLVERS_SMT2_INCREMENTAL_SMT2_INCREMENTAL_DECISION_PROCEDURE_H

--- a/unit/Makefile
+++ b/unit/Makefile
@@ -102,6 +102,7 @@ SRC += analyses/ai/ai.cpp \
        solvers/smt2/smt2irep.cpp \
        solvers/smt2_incremental/construct_value_expr_from_smt.cpp \
        solvers/smt2_incremental/convert_expr_to_smt.cpp \
+       solvers/smt2_incremental/object_tracking.cpp \
        solvers/smt2_incremental/smt2_incremental_decision_procedure.cpp \
        solvers/smt2_incremental/smt_bit_vector_theory.cpp \
        solvers/smt2_incremental/smt_commands.cpp \

--- a/unit/solvers/smt2_incremental/convert_expr_to_smt.cpp
+++ b/unit/solvers/smt2_incremental/convert_expr_to_smt.cpp
@@ -66,6 +66,24 @@ TEST_CASE(
       convert_expr_to_smt(from_integer({-1}, signedbv_typet{16})) ==
       smt_bit_vector_constant_termt{65535, 16});
   }
+  SECTION("Null pointer")
+  {
+    // These config lines are necessary because pointer widths depend on the
+    // configuration.
+    config.ansi_c.mode = configt::ansi_ct::flavourt::GCC;
+    config.ansi_c.set_arch_spec_i386();
+    const smt_termt null_pointer_term =
+      smt_bit_vector_constant_termt{0, config.ansi_c.pointer_width};
+    CHECK(
+      convert_expr_to_smt(null_pointer_exprt{pointer_type(void_type())}) ==
+      null_pointer_term);
+    CHECK(
+      convert_expr_to_smt(null_pointer_exprt{
+        pointer_type(unsignedbv_typet{100})}) == null_pointer_term);
+    CHECK(
+      convert_expr_to_smt(null_pointer_exprt{
+        pointer_type(pointer_type(void_type()))}) == null_pointer_term);
+  }
 }
 
 TEST_CASE(

--- a/unit/solvers/smt2_incremental/convert_expr_to_smt.cpp
+++ b/unit/solvers/smt2_incremental/convert_expr_to_smt.cpp
@@ -7,13 +7,17 @@
 #include <util/config.h>
 #include <util/constructor_of.h>
 #include <util/format.h>
+#include <util/namespace.h>
 #include <util/std_expr.h>
+#include <util/symbol_table.h>
 
 #include <solvers/smt2_incremental/convert_expr_to_smt.h>
+#include <solvers/smt2_incremental/object_tracking.h>
 #include <solvers/smt2_incremental/smt_bit_vector_theory.h>
 #include <solvers/smt2_incremental/smt_core_theory.h>
 #include <solvers/smt2_incremental/smt_terms.h>
 #include <solvers/smt2_incremental/smt_to_smt2_string.h>
+#include <testing-utils/invariant.h>
 #include <testing-utils/use_catch.h>
 
 TEST_CASE("\"typet\" to smt sort conversion", "[core][smt2_incremental]")
@@ -36,6 +40,11 @@ TEST_CASE("\"typet\" to smt sort conversion", "[core][smt2_incremental]")
     const cbmc_invariants_should_throwt invariants_throw;
     CHECK_THROWS(convert_type_to_smt_sort(empty_typet{}));
   }
+}
+
+smt_termt convert_expr_to_smt(const exprt &expression)
+{
+  return convert_expr_to_smt(expression, initial_smt_object_map());
 }
 
 TEST_CASE("\"symbol_exprt\" to smt term conversion", "[core][smt2_incremental]")
@@ -1070,5 +1079,110 @@ TEST_CASE("expr to smt conversion for type casts", "[core][smt2_incremental]")
           smt_bit_vector_constant_termt{1, width},
           smt_bit_vector_constant_termt{0, width}));
     }
+  }
+}
+
+TEST_CASE(
+  "expr to smt conversion for address of operator",
+  "[core][smt2_incremental]")
+{
+  // The config lines are necessary to ensure that pointer width in configured.
+  config.ansi_c.mode = configt::ansi_ct::flavourt::GCC;
+  config.ansi_c.set_arch_spec_x86_64();
+  const symbol_tablet symbol_table;
+  const namespacet ns{symbol_table};
+  smt_object_mapt object_map = initial_smt_object_map();
+  const symbol_exprt foo{"foo", unsignedbv_typet{32}};
+  const symbol_exprt bar{"bar", unsignedbv_typet{32}};
+  SECTION("Address of symbol")
+  {
+    const address_of_exprt address_of_foo{foo};
+    track_expression_objects(address_of_foo, ns, object_map);
+    INFO("Expression " + address_of_foo.pretty(1, 0));
+    SECTION("8 object bits")
+    {
+      config.bv_encoding.object_bits = 8;
+      const auto converted = convert_expr_to_smt(address_of_foo, object_map);
+      CHECK(object_map.at(foo).unique_id == 1);
+      CHECK(
+        converted == smt_bit_vector_theoryt::concat(
+                       smt_bit_vector_constant_termt{1, 8},
+                       smt_bit_vector_constant_termt{0, 56}));
+    }
+    SECTION("16 object bits")
+    {
+      config.bv_encoding.object_bits = 16;
+      const auto converted = convert_expr_to_smt(address_of_foo, object_map);
+      CHECK(object_map.at(foo).unique_id == 1);
+      CHECK(
+        converted == smt_bit_vector_theoryt::concat(
+                       smt_bit_vector_constant_termt{1, 16},
+                       smt_bit_vector_constant_termt{0, 48}));
+    }
+  }
+  SECTION("Invariant checks")
+  {
+    const cbmc_invariants_should_throwt invariants_throw;
+    SECTION("Address of should result in a pointer")
+    {
+      exprt address_of = address_of_exprt{foo};
+      address_of.type() = bool_typet{};
+      REQUIRE_THROWS_MATCHES(
+        convert_expr_to_smt(address_of, object_map),
+        invariant_failedt,
+        invariant_failure_containing(
+          "Result of the address_of operator should have pointer type."));
+    }
+    SECTION("Objects should already be tracked")
+    {
+      REQUIRE_THROWS_MATCHES(
+        convert_expr_to_smt(address_of_exprt{foo}, object_map),
+        invariant_failedt,
+        invariant_failure_containing("Objects should be tracked before "
+                                     "converting their address to SMT terms"));
+    }
+    SECTION("There should be enough bits for object id")
+    {
+      config.bv_encoding.object_bits = 8;
+      const address_of_exprt address_of_foo{foo};
+      track_expression_objects(address_of_foo, ns, object_map);
+      object_map.at(foo).unique_id = 256;
+      REQUIRE_THROWS_MATCHES(
+        convert_expr_to_smt(address_of_exprt{foo}, object_map),
+        invariant_failedt,
+        invariant_failure_containing("There should be sufficient bits to "
+                                     "encode unique object identifier."));
+    }
+    SECTION("Pointer should be wide enough to encode offset")
+    {
+      config.bv_encoding.object_bits = 64;
+      const address_of_exprt address_of_foo{foo};
+      track_expression_objects(address_of_foo, ns, object_map);
+      object_map.at(foo).unique_id = 256;
+      REQUIRE_THROWS_MATCHES(
+        convert_expr_to_smt(address_of_exprt{foo}, object_map),
+        invariant_failedt,
+        invariant_failure_containing("Pointer should be wider than object_bits "
+                                     "in order to allow for offset encoding."));
+    }
+  }
+  SECTION("Comparison of address of operations.")
+  {
+    config.bv_encoding.object_bits = 8;
+    const exprt comparison =
+      notequal_exprt{address_of_exprt{foo}, address_of_exprt{bar}};
+    track_expression_objects(comparison, ns, object_map);
+    INFO("Expression " + comparison.pretty(1, 0));
+    const auto converted = convert_expr_to_smt(comparison, object_map);
+    CHECK(object_map.at(foo).unique_id == 2);
+    CHECK(object_map.at(bar).unique_id == 1);
+    CHECK(
+      converted == smt_core_theoryt::distinct(
+                     smt_bit_vector_theoryt::concat(
+                       smt_bit_vector_constant_termt{2, 8},
+                       smt_bit_vector_constant_termt{0, 56}),
+                     smt_bit_vector_theoryt::concat(
+                       smt_bit_vector_constant_termt{1, 8},
+                       smt_bit_vector_constant_termt{0, 56})));
   }
 }

--- a/unit/solvers/smt2_incremental/convert_expr_to_smt.cpp
+++ b/unit/solvers/smt2_incremental/convert_expr_to_smt.cpp
@@ -920,20 +920,34 @@ TEST_CASE(
   "[core][smt2_incremental]")
 {
   const typet operand_type = unsignedbv_typet{8};
-  const exprt input = extractbits_exprt{
-    symbol_exprt{"foo", operand_type},
-    from_integer(4, operand_type),
-    from_integer(2, operand_type),
-    unsignedbv_typet{3}};
+  std::string description;
+  exprt input;
+  using rowt = std::pair<std::string, exprt>;
+  std::tie(description, input) = GENERATE_REF(
+    rowt{
+      "Bit vector typed bounds",
+      extractbits_exprt{
+        symbol_exprt{"foo", operand_type},
+        from_integer(4, operand_type),
+        from_integer(2, operand_type),
+        unsignedbv_typet{3}}},
+    rowt{
+      "Constant integer bounds",
+      extractbits_exprt{
+        symbol_exprt{"foo", operand_type}, 4, 2, unsignedbv_typet{3}}});
   const smt_termt expected_result = smt_bit_vector_theoryt::extract(4, 2)(
     smt_identifier_termt{"foo", smt_bit_vector_sortt{8}});
-  CHECK(convert_expr_to_smt(input) == expected_result);
-  const cbmc_invariants_should_throwt invariants_throw;
-  CHECK_THROWS(convert_expr_to_smt(extractbits_exprt{
-    symbol_exprt{"foo", operand_type},
-    symbol_exprt{"bar", operand_type},
-    symbol_exprt{"bar", operand_type},
-    unsignedbv_typet{3}}));
+  SECTION(description)
+  {
+    INFO("Input expression - " + input.pretty(1, 0));
+    CHECK(convert_expr_to_smt(input) == expected_result);
+    const cbmc_invariants_should_throwt invariants_throw;
+    CHECK_THROWS(convert_expr_to_smt(extractbits_exprt{
+      symbol_exprt{"foo", operand_type},
+      symbol_exprt{"bar", operand_type},
+      symbol_exprt{"bar", operand_type},
+      unsignedbv_typet{3}}));
+  }
 }
 
 TEST_CASE("expr to smt conversion for type casts", "[core][smt2_incremental]")

--- a/unit/solvers/smt2_incremental/object_tracking.cpp
+++ b/unit/solvers/smt2_incremental/object_tracking.cpp
@@ -1,0 +1,101 @@
+// Author: Diffblue Ltd.
+
+#include <util/c_types.h>
+#include <util/namespace.h>
+#include <util/optional.h>
+#include <util/std_expr.h>
+#include <util/symbol_table.h>
+
+#include <solvers/smt2_incremental/object_tracking.h>
+#include <testing-utils/use_catch.h>
+
+#include <string>
+#include <utility>
+
+TEST_CASE("find_object_base_expression", "[core][smt2_incremental]")
+{
+  const typet base_type = pointer_typet{unsignedbv_typet{8}, 18};
+  const symbol_exprt object_base{"base", base_type};
+  const symbol_exprt index{"index", base_type};
+  const pointer_typet pointer_type{base_type, 12};
+  std::string description;
+  optionalt<address_of_exprt> address_of;
+  using rowt = std::pair<std::string, address_of_exprt>;
+  std::tie(description, address_of) = GENERATE_REF(
+    rowt{"Address of symbol", {object_base, pointer_type}},
+    rowt{"Address of index", {index_exprt{object_base, index}, pointer_type}},
+    rowt{
+      "Address of struct member",
+      {member_exprt{object_base, "baz", unsignedbv_typet{8}}, pointer_type}},
+    rowt{
+      "Address of index of struct member",
+      {index_exprt{
+         member_exprt{object_base, "baz", unsignedbv_typet{8}}, index},
+       pointer_type}},
+    rowt{
+      "Address of struct member at index",
+      {member_exprt{
+         index_exprt{object_base, index}, "baz", unsignedbv_typet{8}},
+       pointer_type}});
+  SECTION(description)
+  {
+    CHECK(find_object_base_expression(*address_of) == object_base);
+  }
+}
+
+TEST_CASE("Tracking object base expressions", "[core][smt2_incremental]")
+{
+  const typet base_type = pointer_typet{signedbv_typet{16}, 18};
+  const symbol_exprt foo{"foo", base_type};
+  const symbol_exprt bar{"bar", base_type};
+  const symbol_exprt index{"index", base_type};
+  const pointer_typet pointer_type{base_type, 32};
+  const exprt bar_address = address_of_exprt{bar, pointer_type};
+  const exprt compound_expression = and_exprt{
+    equal_exprt{
+      address_of_exprt{index_exprt{foo, index}, pointer_type}, bar_address},
+    notequal_exprt{
+      address_of_exprt{
+        member_exprt{foo, "baz", unsignedbv_typet{8}}, pointer_type},
+      bar_address}};
+  SECTION("Find base expressions")
+  {
+    std::vector<exprt> expressions;
+    find_object_base_expressions(compound_expression, [&](const exprt &expr) {
+      expressions.push_back(expr);
+    });
+    CHECK(expressions == std::vector<exprt>{bar, foo, bar, foo});
+  }
+  smt_object_mapt object_map = initial_smt_object_map();
+  SECTION("Check initial object map has null pointer")
+  {
+    REQUIRE(object_map.size() == 1);
+    const exprt null_pointer = null_pointer_exprt{::pointer_type(void_type())};
+    CHECK(object_map.begin()->first == null_pointer);
+    CHECK(object_map.begin()->second.unique_id == 0);
+    CHECK(object_map.begin()->second.base_expression == null_pointer);
+  }
+  symbol_tablet symbol_table;
+  namespacet ns{symbol_table};
+  SECTION("Check objects of compound expression not yet tracked")
+  {
+    CHECK_FALSE(objects_are_already_tracked(compound_expression, object_map));
+  }
+  track_expression_objects(compound_expression, ns, object_map);
+  SECTION("Tracking expression objects")
+  {
+    CHECK(object_map.size() == 3);
+    const auto foo_object = object_map.find(foo);
+    REQUIRE(foo_object != object_map.end());
+    CHECK(foo_object->second.base_expression == foo);
+    CHECK(foo_object->second.unique_id == 2);
+    const auto bar_object = object_map.find(bar);
+    REQUIRE(bar_object != object_map.end());
+    CHECK(bar_object->second.base_expression == bar);
+    CHECK(bar_object->second.unique_id == 1);
+  }
+  SECTION("Confirming objects are tracked.")
+  {
+    CHECK(objects_are_already_tracked(compound_expression, object_map));
+  }
+}


### PR DESCRIPTION
This PR adds support for null pointer and address of expression to SMT term conversion in the incremental SMT2 back end.
<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
