### PR TITLE
CONTRACTS: Fix targett comparison in loop instrumentation

### DIFF
--- a/src/goto-instrument/contracts/contracts.cpp
+++ b/src/goto-instrument/contracts/contracts.cpp
@@ -1106,7 +1106,7 @@ void code_contractst::apply_loop_contract(
     // - `GOTO` jumps out of the loops, which model C `break` statements.
     // These instructions are allowed to be missing from `loop_content`,
     // and may be safely ignored for the purpose of our instrumentation.
-    for(auto i = loop_head; i < loop_end; ++i)
+    for(auto i = loop_head; i != loop_end; ++i)
     {
       if(loop_content.contains(i))
         continue;
@@ -1124,7 +1124,7 @@ void code_contractst::apply_loop_contract(
       {
         do
           i++;
-        while(i->is_dead());
+        while(i != loop_end && i->is_dead());
 
         // because we increment `i` in the outer `for` loop
         i--;


### PR DESCRIPTION
An inequality comparison on iterators was leading to undefined behavior and flakiness: incorrect instrumentation loop contracts.

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a ~~Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.~~
- n/a ~~The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/~~
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a ~~My commit message includes data points confirming performance improvements (if claimed).~~
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.