### PR TITLE
solvers: also link MiniSat2 options

### DIFF
--- a/scripts/minisat-2.2.1-patch
+++ b/scripts/minisat-2.2.1-patch
@@ -179,6 +179,23 @@ index 2dba10f..7d2e83a 100644
          if (verbose){
              fprintf(stderr, "\n        %s\n", description);
              fprintf(stderr, "\n");
+diff --git a/minisat/utils/Options.cc b/minisat/utils/Options.cc
+index 83c40e8..15bfca1 100644
+--- a/minisat/utils/Options.cc
++++ b/minisat/utils/Options.cc
+@@ -43,10 +43,12 @@ void Minisat::parseOptions(int& argc, char** argv, bool strict)
+             }
+
+             if (!parsed_ok)
++            {
+                 if (strict && match(argv[i], "-"))
+                     fprintf(stderr, "ERROR! Unknown flag \"%s\". Use '--%shelp' for help.\n", argv[i], Option::getHelpPrefixString()), exit(1);
+                 else
+                     argv[j++] = argv[i];
++            }
+         }
+     }
+
 diff --git a/minisat/utils/ParseUtils.h b/minisat/utils/ParseUtils.h
 index d307164..7b46f09 100644
 --- a/minisat/utils/ParseUtils.h

--- a/scripts/minisat2_CMakeLists.txt
+++ b/scripts/minisat2_CMakeLists.txt
@@ -4,6 +4,7 @@
 add_library(minisat2-condensed
     minisat/simp/SimpSolver.cc
     minisat/core/Solver.cc
+    minisat/utils/Options.cc
 )
 
 set_target_properties(

--- a/src/solvers/Makefile
+++ b/src/solvers/Makefile
@@ -17,7 +17,7 @@ endif
 ifneq ($(MINISAT2),)
   MINISAT2_SRC=sat/satcheck_minisat2.cpp
   MINISAT2_INCLUDE=-I $(MINISAT2)
-  MINISAT2_LIB=$(MINISAT2)/minisat/simp/SimpSolver$(OBJEXT) $(MINISAT2)/minisat/core/Solver$(OBJEXT)
+  MINISAT2_LIB=$(MINISAT2)/minisat/simp/SimpSolver$(OBJEXT) $(MINISAT2)/minisat/core/Solver$(OBJEXT) $(MINISAT2)/minisat/utils/Options$(OBJEXT)
   CP_CXXFLAGS += -DHAVE_MINISAT2 -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS
   CLEANFILES += $(MINISAT2_LIB) $(patsubst %$(OBJEXT), %$(DEPEXT), $(MINISAT2_LIB))
 endif


### PR DESCRIPTION
This PR is created to supersede #3243.

It's object is to link against one of the object files of
Minisat that we're currently missing (`options.cc`).

For a more extensive discussion of the pros/cons of the change,
please refer to the original PR.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
