### PR TITLE
Set base_name member for __CPROVER_start

### DIFF
--- a/jbmc/src/java_bytecode/java_entry_point.cpp
+++ b/jbmc/src/java_bytecode/java_entry_point.cpp
@@ -767,6 +767,7 @@ bool generate_java_start_function(
   symbolt new_symbol;
 
   new_symbol.name=goto_functionst::entry_point();
+  new_symbol.base_name = goto_functionst::entry_point();
   new_symbol.type = java_method_typet({}, java_void_type());
   new_symbol.value.swap(init_code);
   new_symbol.mode=ID_java;

--- a/regression/goto-analyzer/reachable-functions-basic-json/test.desc
+++ b/regression/goto-analyzer/reachable-functions-basic-json/test.desc
@@ -10,3 +10,4 @@ CORE
 --
 "last line":[[:space:]]*$
 ^warning: ignoring
+"function": ""

--- a/regression/goto-analyzer/reachable-functions-basic-text/test.desc
+++ b/regression/goto-analyzer/reachable-functions-basic-text/test.desc
@@ -9,3 +9,4 @@ unreachable.c not_obviously_dead 25 31$
 ^SIGNAL=0$
 --
 ^warning: ignoring
+^ 35$

--- a/src/ansi-c/ansi_c_entry_point.cpp
+++ b/src/ansi-c/ansi_c_entry_point.cpp
@@ -535,6 +535,7 @@ bool generate_ansi_c_start_function(
   symbolt new_symbol;
 
   new_symbol.name=goto_functionst::entry_point();
+  new_symbol.base_name = goto_functionst::entry_point();
   new_symbol.type = code_typet({}, void_type());
   new_symbol.value.swap(init_code);
   new_symbol.mode=symbol.mode;

--- a/src/jsil/jsil_entry_point.cpp
+++ b/src/jsil/jsil_entry_point.cpp
@@ -152,6 +152,7 @@ bool jsil_entry_point(
   symbolt new_symbol;
 
   new_symbol.name=goto_functionst::entry_point();
+  new_symbol.base_name = goto_functionst::entry_point();
   new_symbol.type = code_typet({}, empty_typet());
   new_symbol.value.swap(init_code);
 

--- a/src/statement-list/statement_list_entry_point.cpp
+++ b/src/statement-list/statement_list_entry_point.cpp
@@ -180,6 +180,7 @@ bool generate_statement_list_start_function(
   // Add the start symbol.
   symbolt start_symbol;
   start_symbol.name = goto_functionst::entry_point();
+  start_symbol.base_name = goto_functionst::entry_point();
   start_symbol.type = code_typet({}, empty_typet{});
   start_symbol.value.swap(start_function_body);
   start_symbol.mode = main.mode;

--- a/unit/analyses/ai/ai.cpp
+++ b/unit/analyses/ai/ai.cpp
@@ -233,6 +233,7 @@ SCENARIO(
 
   symbolt start;
   start.name = goto_functionst::entry_point();
+  start.base_name = goto_functionst::entry_point();
   start.mode = ID_C;
   start.type = code_typet({}, empty_typet());
   start.value = make_void_call(f.symbol_expr());


### PR DESCRIPTION
The (un)reachable functions output uses the base_name in the output,
which previously resulted in the surprising behaviour that an empty
function name was printed. While falling back to the symbol's name may
be possible, there could well be other places that try to use the
`base_name`.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
