### PR TITLE
Move goto_programt::(const_)targett comparison to a struct

### DIFF
--- a/jbmc/src/java_bytecode/java_bytecode_convert_method_class.h
+++ b/jbmc/src/java_bytecode/java_bytecode_convert_method_class.h
@@ -240,7 +240,23 @@ protected:
 
 public:
   typedef std::map<method_offsett, converted_instructiont> address_mapt;
-  typedef std::pair<const methodt &, const address_mapt &> method_with_amapt;
+  struct method_with_amapt
+  {
+    method_with_amapt(const methodt &m, const address_mapt &a)
+      : method_with_amap(m, a)
+    {
+    }
+
+    std::pair<const methodt &, const address_mapt &> method_with_amap;
+
+    struct target_less_than // NOLINT(readability/identifiers)
+    {
+      bool operator()(const method_offsett &a, const method_offsett &b) const
+      {
+        return a < b;
+      }
+    };
+  };
   typedef cfg_dominators_templatet<method_with_amapt, method_offsett, false>
     java_cfg_dominatorst;
 

--- a/jbmc/src/java_bytecode/java_local_variable_table.cpp
+++ b/jbmc/src/java_bytecode/java_local_variable_table.cpp
@@ -46,8 +46,8 @@ struct procedure_local_cfg_baset<
 
   void operator()(const method_with_amapt &args)
   {
-    const auto &method=args.first;
-    const auto &amap=args.second;
+    const auto &method = args.method_with_amap.first;
+    const auto &amap = args.method_with_amap.second;
     for(const auto &inst : amap)
     {
       // Map instruction PCs onto node indices:
@@ -109,18 +109,18 @@ struct procedure_local_cfg_baset<
   static java_bytecode_convert_methodt::method_offsett
   get_first_node(const method_with_amapt &args)
   {
-    return args.second.begin()->first;
+    return args.method_with_amap.second.begin()->first;
   }
 
   static java_bytecode_convert_methodt::method_offsett
   get_last_node(const method_with_amapt &args)
   {
-    return (--args.second.end())->first;
+    return (--args.method_with_amap.second.end())->first;
   }
 
   static bool nodes_empty(const method_with_amapt &args)
   {
-    return args.second.empty();
+    return args.method_with_amap.second.empty();
   }
 };
 

--- a/src/analyses/ai_storage.h
+++ b/src/analyses/ai_storage.h
@@ -100,7 +100,8 @@ public:
 class trace_map_storaget : public ai_storage_baset
 {
 protected:
-  typedef std::map<locationt, trace_set_ptrt> trace_mapt;
+  typedef std::map<locationt, trace_set_ptrt, goto_programt::target_less_than>
+    trace_mapt;
   trace_mapt trace_map;
 
   // This retains one part of a shared_ptr to the history object

--- a/src/analyses/call_graph.h
+++ b/src/analyses/call_graph.h
@@ -98,7 +98,7 @@ public:
   typedef goto_programt::const_targett locationt;
 
   /// Type of a set of callsites
-  typedef std::set<locationt> locationst;
+  typedef std::set<locationt, goto_programt::target_less_than> locationst;
 
   /// Type mapping from call-graph edges onto the set of call instructions
   /// that make that call.

--- a/src/analyses/cfg_dominators.h
+++ b/src/analyses/cfg_dominators.h
@@ -36,7 +36,7 @@ template <class P, class T, bool post_dom>
 class cfg_dominators_templatet
 {
 public:
-  typedef std::set<T> target_sett;
+  typedef std::set<T, typename P::target_less_than> target_sett;
 
   struct nodet
   {
@@ -218,12 +218,12 @@ void cfg_dominators_templatet<P, T, post_dom>::fixedpoint(P &program)
       {
         if(*n_it==current)
           ++n_it;
-        else if(*n_it<*o_it)
+        else if(typename P::target_less_than()(*n_it, *o_it))
         {
           changed=true;
           node.dominators.erase(n_it++);
         }
-        else if(*o_it<*n_it)
+        else if(typename P::target_less_than()(*o_it, *n_it))
           ++o_it;
         else
         {

--- a/src/analyses/dependence_graph.h
+++ b/src/analyses/dependence_graph.h
@@ -172,7 +172,9 @@ private:
   node_indext node_id;
   bool has_changed;
 
-  typedef std::set<goto_programt::const_targett> depst;
+  typedef std::
+    set<goto_programt::const_targett, goto_programt::target_less_than>
+      depst;
 
   // Set of locations with control instructions on which the instruction at this
   // location has a control dependency on

--- a/src/analyses/flow_insensitive_analysis.h
+++ b/src/analyses/flow_insensitive_analysis.h
@@ -93,9 +93,9 @@ public:
   typedef flow_insensitive_abstract_domain_baset statet;
   typedef goto_programt::const_targett locationt;
 
-  std::set<locationt> seen_locations;
+  std::set<locationt, goto_programt::target_less_than> seen_locations;
 
-  std::map<locationt, unsigned> statistics;
+  std::map<locationt, unsigned, goto_programt::target_less_than> statistics;
 
   bool seen(const locationt &l)
   {
@@ -155,7 +155,11 @@ public:
 protected:
   const namespacet &ns;
 
-  typedef std::priority_queue<locationt> working_sett;
+  typedef std::priority_queue<
+    locationt,
+    std::vector<locationt>,
+    goto_programt::target_less_than>
+    working_sett;
 
   locationt get_next(working_sett &working_set);
 

--- a/src/analyses/is_threaded.h
+++ b/src/analyses/is_threaded.h
@@ -44,7 +44,9 @@ public:
   }
 
 protected:
-  typedef std::set<goto_programt::const_targett> is_threaded_sett;
+  typedef std::
+    set<goto_programt::const_targett, goto_programt::target_less_than>
+      is_threaded_sett;
   is_threaded_sett is_threaded_set;
 
   void compute(

--- a/src/analyses/lexical_loops.h
+++ b/src/analyses/lexical_loops.h
@@ -60,10 +60,11 @@ Author: Diffblue Ltd
 ///   * [function] is_backwards_goto() returning a bool.
 ///   * [function] get_target() which returns an object that needs:
 ///     * [field] location_number which is an unsigned int.
-template <class P, class T>
-class lexical_loops_templatet : public loop_analysist<T>
+/// \tparam C: comparison to use over `T` typed elements
+template <class P, class T, typename C>
+class lexical_loops_templatet : public loop_analysist<T, C>
 {
-  typedef loop_analysist<T> parentt;
+  typedef loop_analysist<T, C> parentt;
 
 public:
   typedef typename parentt::loopt lexical_loopt;
@@ -103,7 +104,8 @@ protected:
 
 typedef lexical_loops_templatet<
   const goto_programt,
-  goto_programt::const_targett>
+  goto_programt::const_targett,
+  goto_programt::target_less_than>
   lexical_loopst;
 
 #ifdef DEBUG
@@ -111,8 +113,8 @@ typedef lexical_loops_templatet<
 #endif
 
 /// Finds all back-edges and computes the lexical loops
-template <class P, class T>
-void lexical_loops_templatet<P, T>::compute(P &program)
+template <class P, class T, typename C>
+void lexical_loops_templatet<P, T, C>::compute(P &program)
 {
   all_in_lexical_loop_form = true;
 
@@ -142,8 +144,8 @@ void lexical_loops_templatet<P, T>::compute(P &program)
 /// the tail, abandoning the candidate loop if we stray outside the bounds of
 /// the lexical region bounded by the head and tail, otherwise recording all
 /// instructions that can reach the backedge as falling within the loop.
-template <class P, class T>
-bool lexical_loops_templatet<P, T>::compute_lexical_loop(
+template <class P, class T, typename C>
+bool lexical_loops_templatet<P, T, C>::compute_lexical_loop(
   T loop_tail,
   T loop_head)
 {
@@ -152,7 +154,7 @@ bool lexical_loops_templatet<P, T>::compute_lexical_loop(
     "loop header should come lexically before the tail");
 
   std::stack<T> stack;
-  std::set<T> loop_instructions;
+  std::set<T, C> loop_instructions;
 
   loop_instructions.insert(loop_head);
   loop_instructions.insert(loop_tail);

--- a/src/analyses/local_cfg.h
+++ b/src/analyses/local_cfg.h
@@ -29,7 +29,9 @@ public:
     successorst successors;
   };
 
-  typedef std::map<goto_programt::const_targett, node_nrt> loc_mapt;
+  typedef std::
+    map<goto_programt::const_targett, node_nrt, goto_programt::target_less_than>
+      loc_mapt;
   loc_mapt loc_map;
 
   typedef std::vector<nodet> nodest;

--- a/src/analyses/local_may_alias.h
+++ b/src/analyses/local_may_alias.h
@@ -140,7 +140,9 @@ protected:
   typedef std::map<irep_idt, std::unique_ptr<local_may_aliast> > fkt_mapt;
   fkt_mapt fkt_map;
 
-  typedef std::map<goto_programt::const_targett, irep_idt > target_mapt;
+  typedef std::
+    map<goto_programt::const_targett, irep_idt, goto_programt::target_less_than>
+      target_mapt;
   target_mapt target_map;
 };
 

--- a/src/analyses/loop_analysis.h
+++ b/src/analyses/loop_analysis.h
@@ -15,17 +15,17 @@ Author: Diffblue Ltd
 
 #include <goto-programs/goto_model.h>
 
-template <class T>
+template <class T, typename C>
 class loop_analysist;
 
 /// A loop, specified as a set of instructions
-template <class T>
+template <class T, typename C>
 class loop_templatet
 {
-  typedef std::set<T> loop_instructionst;
+  typedef std::set<T, C> loop_instructionst;
   loop_instructionst loop_instructions;
 
-  friend loop_analysist<T>;
+  friend loop_analysist<T, C>;
 
 public:
   loop_templatet() = default;
@@ -77,13 +77,13 @@ public:
   }
 };
 
-template <class T>
+template <class T, typename C>
 class loop_analysist
 {
 public:
-  typedef loop_templatet<T> loopt;
+  typedef loop_templatet<T, C> loopt;
   // map loop headers to loops
-  typedef std::map<T, loopt> loop_mapt;
+  typedef std::map<T, loopt, C> loop_mapt;
 
   loop_mapt loop_map;
 
@@ -98,10 +98,10 @@ public:
   loop_analysist() = default;
 };
 
-template <typename T>
-class loop_with_parent_analysis_templatet : loop_templatet<T>
+template <typename T, typename C>
+class loop_with_parent_analysis_templatet : loop_templatet<T, C>
 {
-  typedef loop_analysist<T> parent_analysist;
+  typedef loop_analysist<T, C> parent_analysist;
 
 public:
   explicit loop_with_parent_analysis_templatet(parent_analysist &loop_analysis)
@@ -113,14 +113,14 @@ public:
   explicit loop_with_parent_analysis_templatet(
     parent_analysist &loop_analysis,
     InstructionSet &&instructions)
-    : loop_templatet<T>(std::forward<InstructionSet>(instructions)),
+    : loop_templatet<T, C>(std::forward<InstructionSet>(instructions)),
       loop_analysis(loop_analysis)
   {
   }
 
   /// Returns true if \p instruction is in \p loop
   bool loop_contains(
-    const typename loop_analysist<T>::loopt &loop,
+    const typename loop_analysist<T, C>::loopt &loop,
     const T instruction) const
   {
     return loop.loop_instructions.count(instruction);
@@ -141,15 +141,15 @@ private:
   parent_analysist &loop_analysis;
 };
 
-template <class T>
-class linked_loop_analysist : loop_analysist<T>
+template <class T, typename C>
+class linked_loop_analysist : loop_analysist<T, C>
 {
 public:
   linked_loop_analysist() = default;
 
   /// Returns true if \p instruction is in \p loop
   bool loop_contains(
-    const typename loop_analysist<T>::loopt &loop,
+    const typename loop_analysist<T, C>::loopt &loop,
     const T instruction) const
   {
     return loop.loop_instructions.count(instruction);
@@ -166,8 +166,8 @@ public:
 };
 
 /// Print all natural loops that were found
-template <class T>
-void loop_analysist<T>::output(std::ostream &out) const
+template <class T, typename C>
+void loop_analysist<T, C>::output(std::ostream &out) const
 {
   for(const auto &loop : loop_map)
   {

--- a/src/analyses/natural_loops.h
+++ b/src/analyses/natural_loops.h
@@ -43,10 +43,11 @@ Author: Georg Weissenbacher, georg@weissenbacher.name
 ///   * [function] is_backwards_goto() returning a bool.
 ///   * [function] get_target() which returns an object that needs:
 ///     * [field] location_number which is an unsigned int.
-template <class P, class T>
-class natural_loops_templatet : public loop_analysist<T>
+/// \tparam C: comparison to use over `T` typed elements
+template <class P, class T, typename C>
+class natural_loops_templatet : public loop_analysist<T, C>
 {
-  typedef loop_analysist<T> parentt;
+  typedef loop_analysist<T, C> parentt;
 
 public:
   typedef typename parentt::loopt natural_loopt;
@@ -80,14 +81,18 @@ protected:
 
 /// A concretized version of
 /// \ref natural_loops_templatet<const goto_programt, goto_programt::const_targett>
-class natural_loopst:
-    public natural_loops_templatet<const goto_programt,
-                                   goto_programt::const_targett>
+class natural_loopst : public natural_loops_templatet<
+                         const goto_programt,
+                         goto_programt::const_targett,
+                         goto_programt::target_less_than>
 {
 };
 
-typedef natural_loops_templatet<goto_programt, goto_programt::targett>
-    natural_loops_mutablet;
+typedef natural_loops_templatet<
+  goto_programt,
+  goto_programt::targett,
+  goto_programt::target_less_than>
+  natural_loops_mutablet;
 
 inline void show_natural_loops(const goto_modelt &goto_model, std::ostream &out)
 {
@@ -99,8 +104,8 @@ inline void show_natural_loops(const goto_modelt &goto_model, std::ostream &out)
 #endif
 
 /// Finds all back-edges and computes the natural loops
-template<class P, class T>
-void natural_loops_templatet<P, T>::compute(P &program)
+template <class P, class T, typename C>
+void natural_loops_templatet<P, T, C>::compute(P &program)
 {
   cfg_dominators(program);
 
@@ -133,8 +138,8 @@ void natural_loops_templatet<P, T>::compute(P &program)
 }
 
 /// Computes the natural loop for a given back-edge (see Muchnick section 7.4)
-template<class P, class T>
-void natural_loops_templatet<P, T>::compute_natural_loop(T m, T n)
+template <class P, class T, typename C>
+void natural_loops_templatet<P, T, C>::compute_natural_loop(T m, T n)
 {
   PRECONDITION(n->location_number <= m->location_number);
 

--- a/src/analyses/reaching_definitions.h
+++ b/src/analyses/reaching_definitions.h
@@ -114,9 +114,9 @@ inline bool operator<(
   const reaching_definitiont &a,
   const reaching_definitiont &b)
 {
-  if(a.definition_at<b.definition_at)
+  if(goto_programt::target_less_than()(a.definition_at, b.definition_at))
     return true;
-  if(b.definition_at<a.definition_at)
+  if(goto_programt::target_less_than()(b.definition_at, a.definition_at))
     return false;
 
   if(a.bit_begin.is_unknown() != b.bit_begin.is_unknown())
@@ -250,7 +250,8 @@ public:
 
   // each element x represents a range of bits [x.first, x.second)
   typedef std::multimap<range_spect, range_spect> rangest;
-  typedef std::map<locationt, rangest> ranges_at_loct;
+  typedef std::map<locationt, rangest, goto_programt::target_less_than>
+    ranges_at_loct;
 
   const ranges_at_loct &get(const irep_idt &identifier) const;
   void clear_cache(const irep_idt &identifier) const

--- a/src/analyses/static_analysis.h
+++ b/src/analyses/static_analysis.h
@@ -317,7 +317,7 @@ public:
   }
 
 protected:
-  typedef std::map<locationt, T> state_mapt;
+  typedef std::map<locationt, T, goto_programt::target_less_than> state_mapt;
   state_mapt state_map;
 
   virtual statet &get_state(locationt l)

--- a/src/analyses/variable-sensitivity/context_abstract_object.h
+++ b/src/analyses/variable-sensitivity/context_abstract_object.h
@@ -124,7 +124,7 @@ protected:
 
   exprt to_predicate_internal(const exprt &name) const override;
 
-  typedef std::set<locationt> locationst;
+  typedef std::set<locationt, goto_programt::target_less_than> locationst;
 
   virtual context_abstract_object_ptrt
   update_location_context_internal(const locationst &locations) const = 0;

--- a/src/analyses/variable-sensitivity/data_dependency_context.cpp
+++ b/src/analyses/variable-sensitivity/data_dependency_context.cpp
@@ -327,10 +327,11 @@ data_dependency_contextt::abstract_object_merge_internal(
  *
  * \return set of data dependencies
  */
-std::set<goto_programt::const_targett>
+std::set<goto_programt::const_targett, goto_programt::target_less_than>
 data_dependency_contextt::get_data_dependencies() const
 {
-  std::set<goto_programt::const_targett> result;
+  std::set<goto_programt::const_targett, goto_programt::target_less_than>
+    result;
   for(const auto &d : data_deps)
     result.insert(d);
   return result;
@@ -341,10 +342,11 @@ data_dependency_contextt::get_data_dependencies() const
  *
  * \return set of data dominators
  */
-std::set<goto_programt::const_targett>
+std::set<goto_programt::const_targett, goto_programt::target_less_than>
 data_dependency_contextt::get_data_dominators() const
 {
-  std::set<goto_programt::const_targett> result;
+  std::set<goto_programt::const_targett, goto_programt::target_less_than>
+    result;
   for(const auto &d : data_dominators)
     result.insert(d);
   return result;

--- a/src/analyses/variable-sensitivity/data_dependency_context.h
+++ b/src/analyses/variable-sensitivity/data_dependency_context.h
@@ -49,8 +49,10 @@ public:
 
   bool has_been_modified(const abstract_object_pointert &before) const override;
 
-  std::set<goto_programt::const_targett> get_data_dependencies() const;
-  std::set<goto_programt::const_targett> get_data_dominators() const;
+  std::set<goto_programt::const_targett, goto_programt::target_less_than>
+  get_data_dependencies() const;
+  std::set<goto_programt::const_targett, goto_programt::target_less_than>
+  get_data_dominators() const;
 
   void output(std::ostream &out, const class ai_baset &ai, const namespacet &ns)
     const override;

--- a/src/analyses/variable-sensitivity/variable_sensitivity_dependence_graph.cpp
+++ b/src/analyses/variable-sensitivity/variable_sensitivity_dependence_graph.cpp
@@ -326,10 +326,13 @@ bool variable_sensitivity_dependence_domaint::merge_control_dependencies(
   for(const auto &c_dep : other_control_deps)
   {
     // find position to insert
-    while(it != control_deps.end() && it->first < c_dep.first)
+    while(it != control_deps.end() &&
+          goto_programt::target_less_than()(it->first, c_dep.first))
       ++it;
 
-    if(it == control_deps.end() || c_dep.first < it->first)
+    if(
+      it == control_deps.end() ||
+      goto_programt::target_less_than()(c_dep.first, it->first))
     {
       // hint points at position that will follow the new element
       control_deps.insert(it, c_dep);
@@ -340,9 +343,11 @@ bool variable_sensitivity_dependence_domaint::merge_control_dependencies(
       INVARIANT(
         it != control_deps.end(), "Property of branch needed for safety");
       INVARIANT(
-        !(it->first < c_dep.first), "Property of loop needed for safety");
+        !(goto_programt::target_less_than()(it->first, c_dep.first)),
+        "Property of loop needed for safety");
       INVARIANT(
-        !(c_dep.first < it->first), "Property of loop needed for safety");
+        !(goto_programt::target_less_than()(c_dep.first, it->first)),
+        "Property of loop needed for safety");
 
       tvt &branch1 = it->second;
       const tvt &branch2 = c_dep.second;

--- a/src/analyses/variable-sensitivity/variable_sensitivity_dependence_graph.h
+++ b/src/analyses/variable-sensitivity/variable_sensitivity_dependence_graph.h
@@ -179,13 +179,19 @@ private:
       data_depst;
   data_depst domain_data_deps;
 
-  typedef std::map<goto_programt::const_targett, tvt> control_depst;
+  typedef std::
+    map<goto_programt::const_targett, tvt, goto_programt::target_less_than>
+      control_depst;
   control_depst control_deps;
 
-  typedef std::set<goto_programt::const_targett> control_dep_candidatest;
+  typedef std::
+    set<goto_programt::const_targett, goto_programt::target_less_than>
+      control_dep_candidatest;
   control_dep_candidatest control_dep_candidates;
 
-  typedef std::set<goto_programt::const_targett> control_dep_callst;
+  typedef std::
+    set<goto_programt::const_targett, goto_programt::target_less_than>
+      control_dep_callst;
   control_dep_callst control_dep_calls;
   control_dep_callst control_dep_call_candidates;
 

--- a/src/cprover/state_encoding.cpp
+++ b/src/cprover/state_encoding.cpp
@@ -93,7 +93,8 @@ protected:
   loct first_loc;
   symbol_exprt entry_state = symbol_exprt(irep_idt(), typet());
   exprt return_lhs = nil_exprt();
-  using incomingt = std::map<loct, std::vector<loct>>;
+  using incomingt =
+    std::map<loct, std::vector<loct>, goto_programt::target_less_than>;
   incomingt incoming;
 
   static symbol_exprt va_args(irep_idt function);

--- a/src/goto-checker/fault_localization_provider.h
+++ b/src/goto-checker/fault_localization_provider.h
@@ -21,7 +21,11 @@ class namespacet;
 
 struct fault_location_infot
 {
-  typedef std::map<goto_programt::const_targett, std::size_t> score_mapt;
+  typedef std::map<
+    goto_programt::const_targett,
+    std::size_t,
+    goto_programt::target_less_than>
+    score_mapt;
   score_mapt scores;
 };
 

--- a/src/goto-checker/symex_coverage.cpp
+++ b/src/goto-checker/symex_coverage.cpp
@@ -80,7 +80,11 @@ protected:
     }
 
     unsigned hits;
-    std::map<goto_programt::const_targett, coverage_conditiont> conditions;
+    std::map<
+      goto_programt::const_targett,
+      coverage_conditiont,
+      goto_programt::target_less_than>
+      conditions;
   };
 
   typedef std::map<unsigned, coverage_linet> coverage_lines_mapt;

--- a/src/goto-checker/symex_coverage.h
+++ b/src/goto-checker/symex_coverage.h
@@ -64,9 +64,16 @@ protected:
     goto_programt::const_targett succ;
   };
 
-  typedef std::map<goto_programt::const_targett, coverage_infot>
+  typedef std::map<
+    goto_programt::const_targett,
+    coverage_infot,
+    goto_programt::target_less_than>
     coverage_innert;
-  typedef std::map<goto_programt::const_targett, coverage_innert> coveraget;
+  typedef std::map<
+    goto_programt::const_targett,
+    coverage_innert,
+    goto_programt::target_less_than>
+    coveraget;
   coveraget coverage;
 
   bool

--- a/src/goto-diff/change_impact.cpp
+++ b/src/goto-diff/change_impact.cpp
@@ -236,8 +236,9 @@ protected:
     DEL_CTRL_DEP=1<<5
   };
 
-  typedef std::map<goto_programt::const_targett, unsigned>
-    goto_program_change_impactt;
+  typedef std::
+    map<goto_programt::const_targett, unsigned, goto_programt::target_less_than>
+      goto_program_change_impactt;
   typedef std::map<irep_idt, goto_program_change_impactt>
     goto_functions_change_impactt;
 

--- a/src/goto-instrument/accelerate/accelerate.h
+++ b/src/goto-instrument/accelerate/accelerate.h
@@ -117,7 +117,10 @@ protected:
   subsumed_pathst subsumed;
   acceleration_utilst utils;
 
-  typedef std::map<goto_programt::targett, goto_programt::targetst>
+  typedef std::map<
+    goto_programt::targett,
+    goto_programt::targetst,
+    goto_programt::target_less_than>
     overflow_mapt;
   overflow_mapt overflow_locs;
 

--- a/src/goto-instrument/accelerate/disjunctive_polynomial_acceleration.h
+++ b/src/goto-instrument/accelerate/disjunctive_polynomial_acceleration.h
@@ -90,7 +90,9 @@ protected:
   natural_loops_mutablet::natural_loopt &loop;
   goto_programt::targett loop_header;
 
-  typedef std::map<goto_programt::targett, exprt> distinguish_mapt;
+  typedef std::
+    map<goto_programt::targett, exprt, goto_programt::target_less_than>
+      distinguish_mapt;
   typedef std::map<exprt, bool> distinguish_valuest;
 
   acceleration_utilst utils;

--- a/src/goto-instrument/accelerate/sat_path_enumerator.h
+++ b/src/goto-instrument/accelerate/sat_path_enumerator.h
@@ -66,7 +66,9 @@ protected:
   natural_loops_mutablet::natural_loopt &loop;
   goto_programt::targett loop_header;
 
-  typedef std::map<goto_programt::targett, exprt> distinguish_mapt;
+  typedef std::
+    map<goto_programt::targett, exprt, goto_programt::target_less_than>
+      distinguish_mapt;
   typedef std::map<exprt, bool> distinguish_valuest;
 
   acceleration_utilst utils;

--- a/src/goto-instrument/accelerate/trace_automaton.h
+++ b/src/goto-instrument/accelerate/trace_automaton.h
@@ -74,7 +74,9 @@ class automatont
   static const statet no_state;
 
 // protected:
-  typedef std::multimap<goto_programt::targett, statet> transitionst;
+  typedef std::
+    multimap<goto_programt::targett, statet, goto_programt::target_less_than>
+      transitionst;
   typedef std::pair<transitionst::iterator, transitionst::iterator>
     transition_ranget;
   typedef std::vector<transitionst> transition_tablet;
@@ -113,7 +115,11 @@ class trace_automatont
   }
 
   typedef std::pair<statet, statet> state_pairt;
-  typedef std::multimap<goto_programt::targett, state_pairt> sym_mapt;
+  typedef std::multimap<
+    goto_programt::targett,
+    state_pairt,
+    goto_programt::target_less_than>
+    sym_mapt;
   typedef std::pair<sym_mapt::iterator, sym_mapt::iterator> sym_range_pairt;
 
   void get_transitions(sym_mapt &transitions);
@@ -123,7 +129,8 @@ class trace_automatont
     return dta.num_states;
   }
 
-  typedef std::set<goto_programt::targett> alphabett;
+  typedef std::set<goto_programt::targett, goto_programt::target_less_than>
+    alphabett;
   alphabett alphabet;
 
  protected:

--- a/src/goto-instrument/call_sequences.cpp
+++ b/src/goto-instrument/call_sequences.cpp
@@ -32,7 +32,7 @@ void show_call_sequences(
   // dfs on code blocks using stack
   std::cout << "# " << caller << '\n';
   std::stack<goto_programt::const_targett> stack;
-  std::set<goto_programt::const_targett> seen;
+  std::set<goto_programt::const_targett, goto_programt::target_less_than> seen;
   const goto_programt::const_targett start=goto_program.instructions.begin();
 
   if(start!=goto_program.instructions.end())

--- a/src/goto-instrument/contracts/contracts.cpp
+++ b/src/goto-instrument/contracts/contracts.cpp
@@ -487,7 +487,8 @@ void code_contractst::check_apply_loop_contracts(
   loop_end->turn_into_assume();
   loop_end->condition_nonconst() = boolean_negate(loop_end->condition());
 
-  std::set<goto_programt::targett> seen_targets;
+  std::set<goto_programt::targett, goto_programt::target_less_than>
+    seen_targets;
   // Find all exit points of the loop, make temporary variables `DEAD`,
   // and check that step case was checked for non-vacuous loops.
   for(const auto &t : loop)

--- a/src/goto-instrument/contracts/dynamic-frames/dfcc_instrument_loop.cpp
+++ b/src/goto-instrument/contracts/dynamic-frames/dfcc_instrument_loop.cpp
@@ -579,7 +579,8 @@ void dfcc_instrument_loopt::add_exit_instructions(
   const std::vector<symbol_exprt> &new_decreases_vars)
 {
   // Collect all exit targets of the loop.
-  std::set<goto_programt::targett> exit_targets;
+  std::set<goto_programt::targett, goto_programt::target_less_than>
+    exit_targets;
 
   for(goto_programt::instructiont::targett target =
         goto_function.body.instructions.begin();

--- a/src/goto-instrument/contracts/dynamic-frames/dfcc_loop_nesting_graph.cpp
+++ b/src/goto-instrument/contracts/dynamic-frames/dfcc_loop_nesting_graph.cpp
@@ -17,7 +17,8 @@ Date: March 2023
 dfcc_loop_nesting_graph_nodet::dfcc_loop_nesting_graph_nodet(
   const goto_programt::targett &head,
   const goto_programt::targett &latch,
-  const loop_templatet<goto_programt::targett> &instructions)
+  const loop_templatet<goto_programt::targett, goto_programt::target_less_than>
+    &instructions)
   : head(head), latch(latch), instructions(instructions)
 {
 }

--- a/src/goto-instrument/contracts/dynamic-frames/dfcc_loop_nesting_graph.h
+++ b/src/goto-instrument/contracts/dynamic-frames/dfcc_loop_nesting_graph.h
@@ -29,7 +29,9 @@ public:
   dfcc_loop_nesting_graph_nodet(
     const goto_programt::targett &head,
     const goto_programt::targett &latch,
-    const loop_templatet<goto_programt::targett> &instructions);
+    const loop_templatet<
+      goto_programt::targett,
+      goto_programt::target_less_than> &instructions);
 
   /// Loop head instruction
   goto_programt::targett head;
@@ -38,7 +40,8 @@ public:
   goto_programt::targett latch;
 
   /// Set of loop instructions
-  loop_templatet<goto_programt::targett> instructions;
+  loop_templatet<goto_programt::targett, goto_programt::target_less_than>
+    instructions;
 };
 
 typedef grapht<dfcc_loop_nesting_graph_nodet> dfcc_loop_nesting_grapht;

--- a/src/goto-instrument/contracts/memory_predicates.cpp
+++ b/src/goto-instrument/contracts/memory_predicates.cpp
@@ -79,7 +79,8 @@ void functions_in_scope_visitort::operator()(const goto_programt &prog)
   }
 }
 
-std::set<goto_programt::targett> &find_is_fresh_calls_visitort::is_fresh_calls()
+std::set<goto_programt::targett, goto_programt::target_less_than> &
+find_is_fresh_calls_visitort::is_fresh_calls()
 {
   return function_set;
 }

--- a/src/goto-instrument/contracts/memory_predicates.h
+++ b/src/goto-instrument/contracts/memory_predicates.h
@@ -105,12 +105,14 @@ public:
 
   // \brief return the set of functions invoked by
   // the call graph of this program.
-  std::set<goto_programt::targett> &is_fresh_calls();
+  std::set<goto_programt::targett, goto_programt::target_less_than> &
+  is_fresh_calls();
   void clear_set();
   void operator()(goto_programt &prog);
 
 protected:
-  std::set<goto_programt::targett> function_set;
+  std::set<goto_programt::targett, goto_programt::target_less_than>
+    function_set;
 };
 
 /// Predicate to be used with the exprt::visit() function. The function

--- a/src/goto-instrument/cover_basic_blocks.h
+++ b/src/goto-instrument/cover_basic_blocks.h
@@ -103,7 +103,11 @@ public:
   void output(std::ostream &out) const override;
 
 private:
-  typedef std::map<goto_programt::const_targett, std::size_t> block_mapt;
+  typedef std::map<
+    goto_programt::const_targett,
+    std::size_t,
+    goto_programt::target_less_than>
+    block_mapt;
 
   struct block_infot
   {

--- a/src/goto-instrument/dot.cpp
+++ b/src/goto-instrument/dot.cpp
@@ -56,10 +56,11 @@ protected:
                   const goto_programt::instructiont &,
                   const std::string &);
 
-  void find_next(const goto_programt::instructionst &,
-                 const goto_programt::const_targett &,
-                 std::set<goto_programt::const_targett> &,
-                 std::set<goto_programt::const_targett> &);
+  void find_next(
+    const goto_programt::instructionst &,
+    const goto_programt::const_targett &,
+    std::set<goto_programt::const_targett, goto_programt::target_less_than> &,
+    std::set<goto_programt::const_targett, goto_programt::target_less_than> &);
 };
 
 /// Write the dot graph that corresponds to the goto program to the output
@@ -91,7 +92,8 @@ void dott::write_dot_subgraph(
   {
     const namespacet ns(goto_model.symbol_table);
 
-    std::set<goto_programt::const_targett> seen;
+    std::set<goto_programt::const_targett, goto_programt::target_less_than>
+      seen;
     goto_programt::const_targetst worklist;
     worklist.push_back(instructions.begin());
 
@@ -186,8 +188,10 @@ void dott::write_dot_subgraph(
       out << tmp.str();
       out << "\"];\n";
 
-      std::set<goto_programt::const_targett> tres;
-      std::set<goto_programt::const_targett> fres;
+      std::set<goto_programt::const_targett, goto_programt::target_less_than>
+        tres;
+      std::set<goto_programt::const_targett, goto_programt::target_less_than>
+        fres;
       find_next(instructions, it, tres, fres);
 
       std::string tlabel;
@@ -198,7 +202,9 @@ void dott::write_dot_subgraph(
         flabel = "false";
       }
 
-      typedef std::set<goto_programt::const_targett> t;
+      typedef std::
+        set<goto_programt::const_targett, goto_programt::target_less_than>
+          t;
 
       for(t::iterator trit=tres.begin();
            trit!=tres.end();
@@ -311,8 +317,8 @@ std::string &dott::escape(std::string &str)
 void dott::find_next(
   const goto_programt::instructionst &instructions,
   const goto_programt::const_targett &it,
-  std::set<goto_programt::const_targett> &tres,
-  std::set<goto_programt::const_targett> &fres)
+  std::set<goto_programt::const_targett, goto_programt::target_less_than> &tres,
+  std::set<goto_programt::const_targett, goto_programt::target_less_than> &fres)
 {
   if(it->is_goto() && !it->condition().is_false())
   {

--- a/src/goto-instrument/goto_program2code.cpp
+++ b/src/goto-instrument/goto_program2code.cpp
@@ -656,7 +656,8 @@ goto_programt::const_targett goto_program2codet::get_cases(
   goto_programt::const_targett &default_target)
 {
   goto_programt::const_targett last_target=goto_program.instructions.end();
-  std::set<goto_programt::const_targett> unique_targets;
+  std::set<goto_programt::const_targett, goto_programt::target_less_than>
+    unique_targets;
 
   goto_programt::const_targett cases_it=target;
   for( ;
@@ -755,7 +756,8 @@ bool goto_program2codet::set_block_end_points(
   cases_listt &cases,
   std::set<unsigned> &processed_locations)
 {
-  std::set<goto_programt::const_targett> targets_done;
+  std::set<goto_programt::const_targett, goto_programt::target_less_than>
+    targets_done;
 
   for(cases_listt::iterator it=cases.begin();
       it!=cases.end();
@@ -936,7 +938,9 @@ goto_programt::const_targett goto_program2codet::convert_goto_switch(
        it->case_last->location_number > max_target->location_number)
       max_target=it->case_last;
 
-  std::map<goto_programt::const_targett, unsigned> targets_done;
+  std::
+    map<goto_programt::const_targett, unsigned, goto_programt::target_less_than>
+      targets_done;
   loop_last_stack.push_back(std::make_pair(max_target, false));
 
   // iterate over all <branch conditions, branch instruction, branch target>

--- a/src/goto-instrument/goto_program2code.h
+++ b/src/goto-instrument/goto_program2code.h
@@ -22,7 +22,10 @@ class code_blockt;
 class goto_program2codet
 {
   typedef std::list<irep_idt> id_listt;
-  typedef std::map<goto_programt::const_targett, goto_programt::const_targett>
+  typedef std::map<
+    goto_programt::const_targett,
+    goto_programt::const_targett,
+    goto_programt::target_less_than>
     loopt;
   typedef std::unordered_map<irep_idt, unsigned> dead_mapt;
   typedef std::list<std::pair<goto_programt::const_targett, bool> >

--- a/src/goto-instrument/horn_encoding.cpp
+++ b/src/goto-instrument/horn_encoding.cpp
@@ -389,7 +389,8 @@ protected:
   loct first_loc;
   symbol_exprt entry_state = symbol_exprt(irep_idt(), typet());
   exprt return_lhs = nil_exprt();
-  using incomingt = std::map<loct, std::vector<loct>>;
+  using incomingt =
+    std::map<loct, std::vector<loct>, goto_programt::target_less_than>;
   incomingt incoming;
 };
 

--- a/src/goto-instrument/unwind.cpp
+++ b/src/goto-instrument/unwind.cpp
@@ -32,7 +32,9 @@ void goto_unwindt::copy_segment(
   PRECONDITION(goto_program.empty());
 
   // build map for branch targets inside the loop
-  typedef std::map<goto_programt::const_targett, unsigned> target_mapt;
+  typedef std::
+    map<goto_programt::const_targett, unsigned, goto_programt::target_less_than>
+      target_mapt;
   target_mapt target_map;
 
   unsigned i=0;

--- a/src/goto-instrument/unwind.h
+++ b/src/goto-instrument/unwind.h
@@ -104,7 +104,11 @@ public:
       INVARIANT(r.second, "target already exists");
     }
 
-    typedef std::map<goto_programt::const_targett, unsigned> location_mapt;
+    typedef std::map<
+      goto_programt::const_targett,
+      unsigned,
+      goto_programt::target_less_than>
+      location_mapt;
     location_mapt location_map;
   };
 

--- a/src/goto-instrument/wmm/goto2graph.h
+++ b/src/goto-instrument/wmm/goto2graph.h
@@ -188,11 +188,15 @@ protected:
 
     /* previous nodes (fwd analysis) */
     typedef std::pair<event_idt, event_idt> nodet;
-    typedef std::map<goto_programt::const_targett, std::set<nodet> >
+    typedef std::map<
+      goto_programt::const_targett,
+      std::set<nodet>,
+      goto_programt::target_less_than>
       incoming_post;
 
     incoming_post in_pos;
-    std::set<goto_programt::const_targett> updated;
+    std::set<goto_programt::const_targett, goto_programt::target_less_than>
+      updated;
 
     /* "next nodes" (bwd steps in fwd/bck analysis) */
     incoming_post out_pos;

--- a/src/goto-programs/ensure_one_backedge_per_target.cpp
+++ b/src/goto-programs/ensure_one_backedge_per_target.cpp
@@ -86,30 +86,24 @@ bool ensure_one_backedge_per_target(
   return true;
 }
 
-struct instruction_location_numbert : public goto_programt::targett
+struct location_number_less_thant
 {
-  // Implicit conversion from a goto_programt::targett is permitted.
-  // NOLINTNEXTLINE(runtime/explicit)
-  instruction_location_numbert(goto_programt::targett target)
-    : goto_programt::targett(target)
+  inline bool operator()(
+    const goto_programt::targett &i1,
+    const goto_programt::targett &i2) const
   {
+    return location_number_less_than(i1, i2);
   }
-
-  instruction_location_numbert() = default;
 };
-
-inline bool operator<(
-  const instruction_location_numbert &i1,
-  const instruction_location_numbert &i2)
-{
-  return i1->location_number < i2->location_number;
-}
 
 bool ensure_one_backedge_per_target(goto_programt &goto_program)
 {
-  natural_loops_templatet<goto_programt, instruction_location_numbert>
+  natural_loops_templatet<
+    goto_programt,
+    goto_programt::targett,
+    location_number_less_thant>
     natural_loops{goto_program};
-  std::set<instruction_location_numbert> modified_loops;
+  std::set<goto_programt::targett, location_number_less_thant> modified_loops;
 
   for(auto it1 = natural_loops.loop_map.begin();
       it1 != natural_loops.loop_map.end();
@@ -136,7 +130,8 @@ bool ensure_one_backedge_per_target(goto_programt &goto_program)
            it1->second.begin(),
            it1->second.end(),
            it2->second.begin(),
-           it2->second.end()))
+           it2->second.end(),
+           location_number_less_thant()))
       {
         // make sure that loops with overlapping body are properly nested by a
         // back edge; this will be a disconnected edge, which

--- a/src/goto-programs/goto_convert_class.h
+++ b/src/goto-programs/goto_convert_class.h
@@ -378,7 +378,11 @@ protected:
   typedef std::list<goto_programt::targett> computed_gotost;
   typedef exprt::operandst caset;
   typedef std::list<std::pair<goto_programt::targett, caset> > casest;
-  typedef std::map<goto_programt::targett, casest::iterator> cases_mapt;
+  typedef std::map<
+    goto_programt::targett,
+    casest::iterator,
+    goto_programt::target_less_than>
+    cases_mapt;
 
   struct targetst
   {

--- a/src/goto-programs/goto_inline_class.h
+++ b/src/goto-programs/goto_inline_class.h
@@ -138,7 +138,9 @@ public:
     // map from segment start to inline info
     typedef std::map<
       goto_programt::const_targett,
-      goto_inline_log_infot> log_mapt;
+      goto_inline_log_infot,
+      goto_programt::target_less_than>
+      log_mapt;
 
     log_mapt log_map;
   };

--- a/src/goto-programs/goto_program.cpp
+++ b/src/goto-programs/goto_program.cpp
@@ -701,7 +701,7 @@ void goto_programt::compute_target_numbers()
 void goto_programt::copy_from(const goto_programt &src)
 {
   // Definitions for mapping between the two programs
-  typedef std::map<const_targett, targett> targets_mappingt;
+  typedef std::map<const_targett, targett, target_less_than> targets_mappingt;
   targets_mappingt targets_mapping;
 
   clear();

--- a/src/goto-programs/read_bin_goto_object.cpp
+++ b/src/goto-programs/read_bin_goto_object.cpp
@@ -107,7 +107,11 @@ static void read_bin_functions_object(
     irep_idt fname=irepconverter.read_gb_string(in);
     goto_functionst::goto_functiont &f = functions.function_map[fname];
 
-    typedef std::map<goto_programt::targett, std::list<unsigned> > target_mapt;
+    typedef std::map<
+      goto_programt::targett,
+      std::list<unsigned>,
+      goto_programt::target_less_than>
+      target_mapt;
     target_mapt target_map;
     typedef std::map<unsigned, goto_programt::targett> rev_target_mapt;
     rev_target_mapt rev_target_map;

--- a/src/goto-programs/remove_skip.cpp
+++ b/src/goto-programs/remove_skip.cpp
@@ -98,7 +98,10 @@ void remove_skip(
     old_size=goto_program.instructions.size();
 
     // maps deleted instructions to their replacement
-    typedef std::map<goto_programt::targett, goto_programt::targett>
+    typedef std::map<
+      goto_programt::targett,
+      goto_programt::targett,
+      goto_programt::target_less_than>
       new_targetst;
     new_targetst new_targets;
 

--- a/src/goto-programs/remove_unreachable.cpp
+++ b/src/goto-programs/remove_unreachable.cpp
@@ -19,7 +19,7 @@ Author: Daniel Kroening, kroening@kroening.com
 /// remove unreachable code
 void remove_unreachable(goto_programt &goto_program)
 {
-  std::set<goto_programt::targett> reachable;
+  std::set<goto_programt::targett, goto_programt::target_less_than> reachable;
   std::stack<goto_programt::targett> working;
 
   working.push(goto_program.instructions.begin());

--- a/src/goto-symex/frame.h
+++ b/src/goto-symex/frame.h
@@ -26,7 +26,11 @@ struct framet
 
   // function calls
   irep_idt function_identifier;
-  std::map<goto_programt::const_targett, goto_state_listt> goto_state_map;
+  std::map<
+    goto_programt::const_targett,
+    goto_state_listt,
+    goto_programt::target_less_than>
+    goto_state_map;
   symex_targett::sourcet calling_location;
   std::vector<irep_idt> parameter_names;
   guardt guard_at_function_start;

--- a/src/goto-symex/symex_target.cpp
+++ b/src/goto-symex/symex_target.cpp
@@ -16,7 +16,7 @@ bool operator<(
   const symex_targett::sourcet &b)
 {
   if(a.thread_nr==b.thread_nr)
-    return a.pc < b.pc;
+    return goto_programt::target_less_than()(a.pc, b.pc);
   else
     return a.thread_nr < b.thread_nr;
 }

--- a/src/goto-synthesizer/synthesizer_utils.cpp
+++ b/src/goto-synthesizer/synthesizer_utils.cpp
@@ -16,7 +16,9 @@ Author: Qinheping Hu
 
 goto_programt::const_targett get_loop_end_from_loop_head_and_content(
   const goto_programt::const_targett &loop_head,
-  const loop_templatet<goto_programt::const_targett> &loop)
+  const loop_templatet<
+    goto_programt::const_targett,
+    goto_programt::target_less_than> &loop)
 {
   goto_programt::const_targett loop_end = loop_head;
   for(const auto &t : loop)
@@ -38,7 +40,8 @@ goto_programt::const_targett get_loop_end_from_loop_head_and_content(
 
 goto_programt::targett get_loop_end_from_loop_head_and_content_mutable(
   const goto_programt::targett &loop_head,
-  const loop_templatet<goto_programt::targett> &loop)
+  const loop_templatet<goto_programt::targett, goto_programt::target_less_than>
+    &loop)
 {
   goto_programt::targett loop_end = loop_head;
   for(const auto &t : loop)

--- a/src/goto-synthesizer/synthesizer_utils.h
+++ b/src/goto-synthesizer/synthesizer_utils.h
@@ -15,7 +15,7 @@ Author: Qinheping Hu
 
 class goto_functiont;
 class messaget;
-template <class T>
+template <class T, typename C>
 class loop_templatet;
 
 typedef std::map<loop_idt, exprt> invariant_mapt;
@@ -23,10 +23,13 @@ typedef std::map<loop_idt, exprt> invariant_mapt;
 /// Find the goto instruction of `loop` that jumps to `loop_head`
 goto_programt::targett get_loop_end_from_loop_head_and_content_mutable(
   const goto_programt::targett &loop_head,
-  const loop_templatet<goto_programt::targett> &loop);
+  const loop_templatet<goto_programt::targett, goto_programt::target_less_than>
+    &loop);
 goto_programt::const_targett get_loop_end_from_loop_head_and_content(
   const goto_programt::const_targett &loop_head,
-  const loop_templatet<goto_programt::const_targett> &loop);
+  const loop_templatet<
+    goto_programt::const_targett,
+    goto_programt::target_less_than> &loop);
 
 /// Return loop head if `finding_head` is true,
 /// Otherwise return loop end.

--- a/src/util/container_utils.h
+++ b/src/util/container_utils.h
@@ -34,12 +34,12 @@ bool util_inplace_set_union(
 
   for(const auto &s : source)
   {
-    while(it != target.end() && *it < s)
+    while(it != target.end() && Compare()(*it, s))
     {
       ++it;
     }
 
-    if(it == target.end() || s < *it)
+    if(it == target.end() || Compare()(s, *it))
     {
       // Insertion hint should point at element that will follow the new element
       target.insert(it, s);

--- a/unit/analyses/dependence_graph.cpp
+++ b/unit/analyses/dependence_graph.cpp
@@ -20,14 +20,14 @@ Author: Chris Smowton, chris.smowton@diffblue.com
 #include <goto-programs/goto_convert_functions.h>
 #include <langapi/mode.h>
 
-const std::set<goto_programt::const_targett>&
-    dependence_graph_test_get_control_deps(const dep_graph_domaint &domain)
+const std::set<goto_programt::const_targett, goto_programt::target_less_than> &
+dependence_graph_test_get_control_deps(const dep_graph_domaint &domain)
 {
   return domain.control_deps;
 }
 
-const std::set<goto_programt::const_targett>&
-    dependence_graph_test_get_data_deps(const dep_graph_domaint &domain)
+const std::set<goto_programt::const_targett, goto_programt::target_less_than> &
+dependence_graph_test_get_data_deps(const dep_graph_domaint &domain)
 {
   return domain.data_deps;
 }
@@ -112,9 +112,13 @@ SCENARIO("dependence_graph", "[core][analyses][dependence_graph]")
         {
           const dep_nodet &node = dep_graph[node_idx];
           const dep_graph_domaint &node_domain = dep_graph[node.PC];
-          const std::set<goto_programt::const_targett> &control_deps =
+          const std::set<
+            goto_programt::const_targett,
+            goto_programt::target_less_than> &control_deps =
             dependence_graph_test_get_control_deps(node_domain);
-          const std::set<goto_programt::const_targett> &data_deps =
+          const std::set<
+            goto_programt::const_targett,
+            goto_programt::target_less_than> &data_deps =
             dependence_graph_test_get_data_deps(node_domain);
 
           std::size_t domain_dep_count =


### PR DESCRIPTION
This makes sure no one can inadvertently use less-than comparison on
those iterators, which may lead to non-reproducible behaviour
(see #6782).

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
