### PR TITLE
Flexible array members: make type checking aware and fix bounds checking

### DIFF
--- a/regression/cbmc/struct17/main.c
+++ b/regression/cbmc/struct17/main.c
@@ -1,0 +1,16 @@
+#include <assert.h>
+
+struct famt
+{
+  char x;
+  char vl[];
+};
+
+extern struct famt vls;
+struct famt vls = {'a', {1, 2, 3, 4}};
+
+int main()
+{
+  assert(vls.vl[3] == 4);
+  return 0;
+}

--- a/regression/cbmc/struct17/test.desc
+++ b/regression/cbmc/struct17/test.desc
@@ -1,0 +1,9 @@
+CORE
+main.c
+
+^VERIFICATION SUCCESSFUL$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+^CONVERSION ERROR$

--- a/src/ansi-c/goto_check_c.cpp
+++ b/src/ansi-c/goto_check_c.cpp
@@ -1638,14 +1638,14 @@ void goto_check_ct::bounds_check_index(
     // that member, it behaves as if that member were replaced with the longest
     // array (with the same element type) that would not make the structure
     // larger than the object being accessed; [...]
-    const auto type_size_opt = size_of_expr(ode.root_object().type(), ns);
+    const auto type_size_opt =
+      pointer_offset_size(ode.root_object().type(), ns);
     CHECK_RETURN(type_size_opt.has_value());
 
     binary_relation_exprt inequality(
-      typecast_exprt::conditional_cast(
-        ode.offset(), type_size_opt.value().type()),
+      ode.offset(),
       ID_lt,
-      type_size_opt.value());
+      from_integer(type_size_opt.value(), ode.offset().type()));
 
     add_guarded_property(
       inequality,


### PR DESCRIPTION
Type checking must be ready to handle type changes between declaration
and definition, which b16c7d7cd4 introduced. Also, bounds checking must
not use `size_of_expr` with these as 24eba850 rightly introduced a
distinction between "sizeof" and the actual object size as mandated by
the C standard.

Fixes: #6787

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
