### PR TITLE
Set GCC version in all tools possibly parsing C code

### DIFF
--- a/regression/goto-instrument/add-library1/main.c
+++ b/regression/goto-instrument/add-library1/main.c
@@ -1,0 +1,8 @@
+#include <math.h>
+
+int main()
+{
+  float f;
+  __CPROVER_assume(isnormal(f));
+  __CPROVER_assert(ceilf(f) >= f, "ceil rounds upwards");
+}

--- a/regression/goto-instrument/add-library1/test.desc
+++ b/regression/goto-instrument/add-library1/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+--add-library --generate-function-body-options assert-false --generate-function-body '([^_]*)'
+^EXIT=0$
+^SIGNAL=0$
+VERIFICATION SUCCESSFUL
+--
+^warning: ignoring

--- a/src/goto-analyzer/goto_analyzer_parse_options.cpp
+++ b/src/goto-analyzer/goto_analyzer_parse_options.cpp
@@ -11,16 +11,11 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "goto_analyzer_parse_options.h"
 
-#include <cstdlib> // exit()
-#include <fstream>
-#include <iostream>
-#include <memory>
-
-#include <ansi-c/cprover_library.h>
-
-#include <assembler/remove_asm.h>
-
-#include <cpp/cprover_library.h>
+#include <util/config.h>
+#include <util/exception_utils.h>
+#include <util/exit_codes.h>
+#include <util/options.h>
+#include <util/version.h>
 
 #include <goto-programs/initialize_goto_model.h>
 #include <goto-programs/link_to_library.h>
@@ -32,12 +27,10 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <analyses/ai.h>
 #include <analyses/local_may_alias.h>
-
-#include <util/config.h>
-#include <util/exception_utils.h>
-#include <util/exit_codes.h>
-#include <util/options.h>
-#include <util/version.h>
+#include <ansi-c/cprover_library.h>
+#include <ansi-c/gcc_version.h>
+#include <assembler/remove_asm.h>
+#include <cpp/cprover_library.h>
 
 #include "build_analyzer.h"
 #include "show_on_source.h"
@@ -46,6 +39,11 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "static_verifier.h"
 #include "taint_analysis.h"
 #include "unreachable_instructions.h"
+
+#include <cstdlib> // exit()
+#include <fstream>
+#include <iostream>
+#include <memory>
 
 goto_analyzer_parse_optionst::goto_analyzer_parse_optionst(
   int argc,
@@ -382,6 +380,14 @@ int goto_analyzer_parse_optionst::doit()
   log_version_and_architecture("GOTO-ANALYZER");
 
   register_languages();
+
+  // configure gcc, if required
+  if(config.ansi_c.preprocessor == configt::ansi_ct::preprocessort::GCC)
+  {
+    gcc_versiont gcc_version;
+    gcc_version.get("gcc");
+    configure_gcc(gcc_version);
+  }
 
   goto_model = initialize_goto_model(cmdline.args, ui_message_handler, options);
 

--- a/src/goto-diff/goto_diff_parse_options.cpp
+++ b/src/goto-diff/goto_diff_parse_options.cpp
@@ -11,10 +11,6 @@ Author: Peter Schrammel
 
 #include "goto_diff_parse_options.h"
 
-#include <cstdlib> // exit()
-#include <fstream>
-#include <iostream>
-
 #include <util/config.h>
 #include <util/exit_codes.h>
 #include <util/options.h>
@@ -28,17 +24,19 @@ Author: Peter Schrammel
 #include <goto-programs/set_properties.h>
 #include <goto-programs/show_properties.h>
 
+#include <ansi-c/cprover_library.h>
+#include <ansi-c/gcc_version.h>
+#include <assembler/remove_asm.h>
+#include <cpp/cprover_library.h>
 #include <goto-instrument/cover.h>
 
-#include <ansi-c/cprover_library.h>
-
-#include <assembler/remove_asm.h>
-
-#include <cpp/cprover_library.h>
-
+#include "change_impact.h"
 #include "syntactic_diff.h"
 #include "unified_diff.h"
-#include "change_impact.h"
+
+#include <cstdlib> // exit()
+#include <fstream>
+#include <iostream>
 
 goto_diff_parse_optionst::goto_diff_parse_optionst(int argc, const char **argv)
   : parse_options_baset(
@@ -99,6 +97,15 @@ int goto_diff_parse_optionst::doit()
 
   goto_modelt goto_model1 =
     initialize_goto_model({cmdline.args[0]}, ui_message_handler, options);
+
+  // configure gcc, if required -- initialize_goto_model will have set config
+  if(config.ansi_c.preprocessor == configt::ansi_ct::preprocessort::GCC)
+  {
+    gcc_versiont gcc_version;
+    gcc_version.get("gcc");
+    configure_gcc(gcc_version);
+  }
+
   if(process_goto_program(options, goto_model1))
     return CPROVER_EXIT_INTERNAL_ERROR;
   goto_modelt goto_model2 =

--- a/src/goto-instrument/goto_instrument_parse_options.cpp
+++ b/src/goto-instrument/goto_instrument_parse_options.cpp
@@ -69,6 +69,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <ansi-c/ansi_c_language.h>
 #include <ansi-c/c_object_factory_parameters.h>
 #include <ansi-c/cprover_library.h>
+#include <ansi-c/gcc_version.h>
 #include <assembler/remove_asm.h>
 #include <cpp/cprover_library.h>
 #include <pointer-analysis/add_failed_symbols.h>
@@ -129,6 +130,14 @@ int goto_instrument_parse_optionst::doit()
     register_languages();
 
     get_goto_program();
+
+    // configure gcc, if required -- get_goto_program will have set the config
+    if(config.ansi_c.preprocessor == configt::ansi_ct::preprocessort::GCC)
+    {
+      gcc_versiont gcc_version;
+      gcc_version.get("gcc");
+      configure_gcc(gcc_version);
+    }
 
     {
       const bool validate_only = cmdline.isset("validate-goto-binary");


### PR DESCRIPTION
The GCC version configures how our C lexer operates. Not setting it
before running the C parser may cause spurious syntax errors, for
example when parsing the system math headers. Tools that potentially
link the built-in library will need to be able to parse those headers
successfully.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
