### PR TITLE
Goto functions validation: provide parameter name

### DIFF
--- a/src/goto-programs/goto_function.cpp
+++ b/src/goto-programs/goto_function.cpp
@@ -40,10 +40,12 @@ void goto_functiont::validate(const namespacet &ns, const validation_modet vm)
 {
   for(const auto &identifier : parameter_identifiers)
   {
-    DATA_CHECK(
+    DATA_CHECK_WITH_DIAGNOSTICS(
       vm,
       identifier.empty() || ns.lookup(identifier).is_parameter,
-      "parameter should be marked 'is_parameter' in the symbol table");
+      "parameter should be marked 'is_parameter' in the symbol table",
+      "affected parameter: ",
+      identifier);
   }
 
   // function body must end with an END_FUNCTION instruction


### PR DESCRIPTION
This validation step failed for Kani-generated GOTO models (cf.
https://github.com/model-checking/kani/issues/957), but the
error message turned out not to be very useful.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
