### PR TITLE
Remove unused contracts-related functions from ansi_c_declarationt

### DIFF
--- a/src/ansi-c/ansi_c_declaration.h
+++ b/src/ansi-c/ansi_c_declaration.h
@@ -243,21 +243,6 @@ public:
     assert(!declarators().empty());
     declarators().back().value().swap(value);
   }
-
-  const exprt &spec_assigns() const
-  {
-    return static_cast<const exprt &>(find(ID_C_spec_assigns));
-  }
-
-  const exprt &spec_requires() const
-  {
-    return static_cast<const exprt &>(find(ID_C_spec_requires));
-  }
-
-  const exprt &spec_ensures() const
-  {
-    return static_cast<const exprt &>(find(ID_C_spec_ensures));
-  }
 };
 
 inline ansi_c_declarationt &to_ansi_c_declaration(exprt &expr)


### PR DESCRIPTION
The parser communicates contracts by embedding them in the type, and
ans_c_convert_typet takes care of this.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
