### PR TITLE
Remove internal symbols: use API to access code contract

### DIFF
--- a/src/linking/remove_internal_symbols.cpp
+++ b/src/linking/remove_internal_symbols.cpp
@@ -11,14 +11,15 @@ Author: Daniel Kroening
 
 #include "remove_internal_symbols.h"
 
-#include <goto-programs/adjust_float_expressions.h>
-
+#include <util/c_types.h>
 #include <util/config.h>
 #include <util/find_symbols.h>
 #include <util/message.h>
 #include <util/namespace.h>
 #include <util/std_types.h>
 #include <util/symbol_table.h>
+
+#include <goto-programs/adjust_float_expressions.h>
 
 #include "static_lifetime_init.h"
 
@@ -62,14 +63,16 @@ static void get_symbols(
       }
 
       // check for contract definitions
-      const exprt ensures =
-        static_cast<const exprt &>(code_type.find(ID_C_spec_ensures));
-      const exprt requires =
-        static_cast<const exprt &>(code_type.find(ID_C_spec_requires));
+      const code_with_contract_typet &maybe_contract =
+        to_code_with_contract_type(code_type);
 
       find_symbols_sett new_symbols;
-      find_type_and_expr_symbols(ensures, new_symbols);
-      find_type_and_expr_symbols(requires, new_symbols);
+      for(const exprt &e : maybe_contract.ensures())
+        find_type_and_expr_symbols(e, new_symbols);
+      for(const exprt &r : maybe_contract.requires())
+        find_type_and_expr_symbols(r, new_symbols);
+      for(const exprt &a : maybe_contract.assigns())
+        find_type_and_expr_symbols(a, new_symbols);
 
       for(const auto &s : new_symbols)
       {


### PR DESCRIPTION
Instead of trying access parts of a code contract via their irep keys,
use the API provided by code_with_contract_typet. While at it, also make
sure we cater for any future use of functions in assigns clauses.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
