### PR TITLE
C front-end: factor out adding parameters to symbol table

### DIFF
--- a/src/ansi-c/c_typecheck_base.cpp
+++ b/src/ansi-c/c_typecheck_base.cpp
@@ -521,34 +521,8 @@ void c_typecheck_baset::typecheck_function_body(symbolt &symbol)
   // set return type
   return_type=code_type.return_type();
 
-  unsigned anon_counter=0;
-
-  // Add the parameter declarations into the symbol table.
-  for(auto &p : code_type.parameters())
-  {
-    // may be anonymous
-    if(p.get_base_name().empty())
-    {
-      irep_idt base_name="#anon"+std::to_string(anon_counter++);
-      p.set_base_name(base_name);
-    }
-
-    // produce identifier
-    irep_idt base_name = p.get_base_name();
-    irep_idt identifier=id2string(symbol.name)+"::"+id2string(base_name);
-
-    p.set_identifier(identifier);
-
-    parameter_symbolt p_symbol;
-
-    p_symbol.type = p.type();
-    p_symbol.name=identifier;
-    p_symbol.base_name=base_name;
-    p_symbol.location = p.source_location();
-
-    symbolt *new_p_symbol;
-    move_symbol(p_symbol, new_p_symbol);
-  }
+  // Add the parameter declarations into the symbol table
+  add_parameters_to_symbol_table(symbol);
 
   // typecheck the body code
   typecheck_code(to_code(symbol.value));
@@ -772,5 +746,41 @@ void c_typecheck_baset::typecheck_declaration(
         }
       }
     }
+  }
+}
+
+void c_typecheck_baset::add_parameters_to_symbol_table(symbolt &symbol)
+{
+  PRECONDITION(can_cast_type<code_typet>(symbol.type));
+
+  code_typet &code_type = to_code_type(symbol.type);
+
+  unsigned anon_counter = 0;
+
+  // Add the parameter declarations into the symbol table.
+  for(auto &p : code_type.parameters())
+  {
+    // may be anonymous
+    if(p.get_base_name().empty())
+    {
+      irep_idt base_name = "#anon" + std::to_string(anon_counter++);
+      p.set_base_name(base_name);
+    }
+
+    // produce identifier
+    irep_idt base_name = p.get_base_name();
+    irep_idt identifier = id2string(symbol.name) + "::" + id2string(base_name);
+
+    p.set_identifier(identifier);
+
+    parameter_symbolt p_symbol;
+
+    p_symbol.type = p.type();
+    p_symbol.name = identifier;
+    p_symbol.base_name = base_name;
+    p_symbol.location = p.source_location();
+
+    symbolt *new_p_symbol;
+    move_symbol(p_symbol, new_p_symbol);
   }
 }

--- a/src/ansi-c/c_typecheck_base.h
+++ b/src/ansi-c/c_typecheck_base.h
@@ -268,6 +268,9 @@ protected:
     symbolt &old_symbol, symbolt &new_symbol);
   void typecheck_function_body(symbolt &symbol);
 
+  /// Create symbols for parameter of the code-typed symbol \p symbol.
+  void add_parameters_to_symbol_table(symbolt &symbol);
+
   virtual void do_initializer(symbolt &symbol);
 
   static bool is_numeric_type(const typet &src)


### PR DESCRIPTION
Upcoming code contracts related changes will want to use the same code.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
