### PR TITLE
CONTRACTS: Replace return_value_visitor by has_subexpr

### DIFF
--- a/src/goto-instrument/contracts/contracts.cpp
+++ b/src/goto-instrument/contracts/contracts.cpp
@@ -780,9 +780,10 @@ void code_contractst::apply_function_contract(
     {
       // If the function does return a value, but the return value is
       // disregarded, check if the postcondition includes the return value.
-      return_value_visitort v;
-      ensures.visit(v);
-      if(v.found_return_value())
+      if(has_subexpr(ensures, [](const exprt &e) {
+           return e.id() == ID_symbol && to_symbol_expr(e).get_identifier() ==
+                                           CPROVER_PREFIX "return_value";
+         }))
       {
         // The postcondition does mention __CPROVER_return_value, so mint a
         // fresh variable to replace __CPROVER_return_value with.

--- a/src/goto-instrument/contracts/memory_predicates.cpp
+++ b/src/goto-instrument/contracts/memory_predicates.cpp
@@ -23,19 +23,6 @@ Date: July 2021
 #include <util/config.h>
 #include <util/prefix.h>
 
-bool return_value_visitort::found_return_value()
-{
-  return found;
-}
-
-void return_value_visitort::operator()(const exprt &exp)
-{
-  if(exp.id() != ID_symbol)
-    return;
-  const symbol_exprt &sym = to_symbol_expr(exp);
-  found |= sym.get_identifier() == CPROVER_PREFIX "return_value";
-}
-
 std::set<irep_idt> &functions_in_scope_visitort::function_calls()
 {
   return function_set;

--- a/src/goto-instrument/contracts/memory_predicates.h
+++ b/src/goto-instrument/contracts/memory_predicates.h
@@ -104,25 +104,6 @@ protected:
 /// Predicate to be used with the exprt::visit() function. The function
 /// found_return_value() will return `true` iff this predicate is called on an
 /// expr that contains `__CPROVER_return_value`.
-class return_value_visitort : public const_expr_visitort
-{
-public:
-  return_value_visitort() : const_expr_visitort(), found(false)
-  {
-  }
-
-  // \brief Has this object been passed to exprt::visit() on an exprt whose
-  //        descendants contain __CPROVER_return_value?
-  bool found_return_value();
-  void operator()(const exprt &exp) override;
-
-protected:
-  bool found;
-};
-
-/// Predicate to be used with the exprt::visit() function. The function
-/// found_return_value() will return `true` iff this predicate is called on an
-/// expr that contains `__CPROVER_return_value`.
 class functions_in_scope_visitort
 {
 public:


### PR DESCRIPTION
There is no need to create infrastructure when an existing utility can
be used instead.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
