### PR TITLE
Add class for object size expressions

### DIFF
--- a/src/ansi-c/c_typecheck_expr.cpp
+++ b/src/ansi-c/c_typecheck_expr.cpp
@@ -2363,8 +2363,7 @@ exprt c_typecheck_baset::do_special_functions(
 
     typecheck_function_call_arguments(expr);
 
-    unary_exprt object_size_expr(
-      ID_object_size, expr.arguments()[0], size_type());
+    object_size_exprt object_size_expr(expr.arguments()[0], size_type());
     object_size_expr.add_source_location() = source_location;
 
     return std::move(object_size_expr);

--- a/src/ansi-c/goto_check_c.cpp
+++ b/src/ansi-c/goto_check_c.cpp
@@ -1476,7 +1476,7 @@ bool goto_check_ct::requires_pointer_primitive_check(const exprt &expr)
   // pointer_object and pointer_offset just extract a subset of bits from the
   // pointer. If that pointer was unconstrained (non-deterministic), the result
   // will equally be non-deterministic.
-  return expr.id() == ID_object_size || expr.id() == ID_r_ok ||
+  return can_cast_expr<object_size_exprt>(expr) || expr.id() == ID_r_ok ||
          expr.id() == ID_w_ok || expr.id() == ID_rw_ok ||
          expr.id() == ID_is_dynamic_object;
 }

--- a/src/solvers/smt2/smt2_conv.h
+++ b/src/solvers/smt2/smt2_conv.h
@@ -10,12 +10,13 @@ Author: Daniel Kroening, kroening@kroening.com
 #ifndef CPROVER_SOLVERS_SMT2_SMT2_CONV_H
 #define CPROVER_SOLVERS_SMT2_SMT2_CONV_H
 
+#include <util/pointer_expr.h>
+#include <util/std_expr.h>
+#include <util/threeval.h>
+
 #include <map>
 #include <set>
 #include <sstream>
-
-#include <util/std_expr.h>
-#include <util/threeval.h>
 
 #if !HASH_CODE
 #  include <util/irep_hash_container.h>
@@ -216,7 +217,7 @@ protected:
   void convert_address_of_rec(
     const exprt &expr, const pointer_typet &result_type);
 
-  void define_object_size(const irep_idt &id, const exprt &expr);
+  void define_object_size(const irep_idt &id, const object_size_exprt &expr);
 
   // keeps track of all non-Boolean symbols and their value
   struct identifiert
@@ -256,7 +257,7 @@ protected:
   /// smt2 formula.
   std::unordered_map<irep_idt, bool> set_values;
 
-  defined_expressionst object_sizes;
+  std::map<object_size_exprt, irep_idt> object_sizes;
 
   typedef std::set<std::string> smt2_identifierst;
   smt2_identifierst smt2_identifiers;

--- a/src/solvers/smt2_incremental/convert_expr_to_smt.cpp
+++ b/src/solvers/smt2_incremental/convert_expr_to_smt.cpp
@@ -1192,6 +1192,15 @@ static smt_termt convert_expr_to_smt(
     "Generation of SMT formula for vector expression: " + vector.pretty());
 }
 
+static smt_termt convert_expr_to_smt(
+  const object_size_exprt &object_size,
+  const sub_expression_mapt &converted)
+{
+  UNIMPLEMENTED_FEATURE(
+    "Generation of SMT formula for object_size expression: " +
+    object_size.pretty());
+}
+
 static smt_termt
 convert_expr_to_smt(const let_exprt &let, const sub_expression_mapt &converted)
 {
@@ -1530,12 +1539,10 @@ static smt_termt dispatch_expr_to_smt_conversion(
   {
     return convert_expr_to_smt(*vector, converted);
   }
-#if 0
-  else if(expr.id()==ID_object_size)
+  if(const auto object_size = expr_try_dynamic_cast<object_size_exprt>(expr))
   {
-    out << "|" << object_sizes[expr] << "|";
+    return convert_expr_to_smt(*object_size, converted);
   }
-#endif
   if(const auto let = expr_try_dynamic_cast<let_exprt>(expr))
   {
     return convert_expr_to_smt(*let, converted);

--- a/src/util/pointer_expr.h
+++ b/src/util/pointer_expr.h
@@ -989,4 +989,39 @@ inline pointer_object_exprt &to_pointer_object_expr(exprt &expr)
   return ret;
 }
 
+/// Expression for finding the size (in bytes) of the object a pointer points
+/// to.
+class object_size_exprt : public unary_exprt
+{
+public:
+  explicit object_size_exprt(exprt pointer, typet type)
+    : unary_exprt(ID_object_size, std::move(pointer), std::move(type))
+  {
+  }
+
+  exprt &pointer()
+  {
+    return op();
+  }
+
+  const exprt &pointer() const
+  {
+    return op();
+  }
+};
+
+template <>
+inline bool can_cast_expr<object_size_exprt>(const exprt &base)
+{
+  return base.id() == ID_object_size;
+}
+
+inline void validate_expr(const object_size_exprt &value)
+{
+  validate_operands(value, 1, "Object size expression must have one operand.");
+  DATA_INVARIANT(
+    can_cast_type<pointer_typet>(value.pointer().type()),
+    "Object size expression must have pointer typed operand.");
+}
+
 #endif // CPROVER_UTIL_POINTER_EXPR_H

--- a/src/util/pointer_predicates.cpp
+++ b/src/util/pointer_predicates.cpp
@@ -32,7 +32,7 @@ exprt same_object(const exprt &p1, const exprt &p2)
 
 exprt object_size(const exprt &pointer)
 {
-  return unary_exprt(ID_object_size, pointer, size_type());
+  return object_size_exprt(pointer, size_type());
 }
 
 exprt pointer_offset(const exprt &pointer)

--- a/src/util/simplify_expr.cpp
+++ b/src/util/simplify_expr.cpp
@@ -2398,9 +2398,10 @@ simplify_exprt::resultt<> simplify_exprt::simplify_node(exprt node)
   {
     r = simplify_is_invalid_pointer(to_unary_expr(expr));
   }
-  else if(expr.id()==ID_object_size)
+  else if(
+    const auto object_size = expr_try_dynamic_cast<object_size_exprt>(expr))
   {
-    r = simplify_object_size(to_unary_expr(expr));
+    r = simplify_object_size(*object_size);
   }
   else if(expr.id()==ID_good_pointer)
   {

--- a/src/util/simplify_expr_class.h
+++ b/src/util/simplify_expr_class.h
@@ -58,6 +58,7 @@ class multi_ary_exprt;
 class mult_exprt;
 class namespacet;
 class not_exprt;
+class object_size_exprt;
 class plus_exprt;
 class pointer_object_exprt;
 class pointer_offset_exprt;
@@ -173,7 +174,7 @@ public:
   NODISCARD resultt<> simplify_byte_update(const byte_update_exprt &);
   NODISCARD resultt<> simplify_byte_extract(const byte_extract_exprt &);
   NODISCARD resultt<> simplify_pointer_object(const pointer_object_exprt &);
-  NODISCARD resultt<> simplify_object_size(const unary_exprt &);
+  NODISCARD resultt<> simplify_object_size(const object_size_exprt &);
   NODISCARD resultt<> simplify_is_dynamic_object(const unary_exprt &);
   NODISCARD resultt<> simplify_is_invalid_pointer(const unary_exprt &);
   NODISCARD resultt<> simplify_good_pointer(const unary_exprt &);

--- a/src/util/simplify_expr_pointer.cpp
+++ b/src/util/simplify_expr_pointer.cpp
@@ -640,11 +640,11 @@ simplify_exprt::simplify_is_invalid_pointer(const unary_exprt &expr)
 }
 
 simplify_exprt::resultt<>
-simplify_exprt::simplify_object_size(const unary_exprt &expr)
+simplify_exprt::simplify_object_size(const object_size_exprt &expr)
 {
   auto new_expr = expr;
   bool no_change = true;
-  exprt &op = new_expr.op();
+  exprt &op = new_expr.pointer();
   auto op_result = simplify_object(op);
 
   if(op_result.has_changed())

--- a/unit/util/pointer_expr.cpp
+++ b/unit/util/pointer_expr.cpp
@@ -122,3 +122,63 @@ TEST_CASE("pointer_object_exprt", "[core][util]")
     }
   }
 }
+
+TEST_CASE("object_size_exprt", "[core][util]")
+{
+  const exprt pointer = symbol_exprt{"foo", pointer_type(void_type())};
+  const object_size_exprt object_size{pointer, size_type()};
+  SECTION("Is equivalent to free function.")
+  {
+    CHECK(::object_size(pointer) == object_size);
+  }
+  SECTION("Result type")
+  {
+    CHECK(object_size.type() == size_type());
+  }
+  SECTION("Pointer operand accessor")
+  {
+    CHECK(object_size.pointer() == pointer);
+  }
+  SECTION("Downcasting")
+  {
+    const exprt &upcast = object_size;
+    CHECK(expr_try_dynamic_cast<object_size_exprt>(upcast));
+    CHECK_FALSE(expr_try_dynamic_cast<pointer_object_exprt>(upcast));
+    SECTION("Validation")
+    {
+      SECTION("Invalid operand")
+      {
+        unary_exprt invalid_type = object_size;
+        invalid_type.op().type() = bool_typet{};
+        const cbmc_invariants_should_throwt invariants_throw;
+        REQUIRE_THROWS_MATCHES(
+          expr_try_dynamic_cast<object_size_exprt>(invalid_type),
+          invariant_failedt,
+          invariant_failure_containing(
+            "Object size expression must have pointer typed operand."));
+      }
+      SECTION("Missing operand")
+      {
+        exprt missing_operand = object_size;
+        missing_operand.operands().clear();
+        const cbmc_invariants_should_throwt invariants_throw;
+        REQUIRE_THROWS_MATCHES(
+          expr_try_dynamic_cast<object_size_exprt>(missing_operand),
+          invariant_failedt,
+          invariant_failure_containing(
+            "Object size expression must have one operand"));
+      }
+      SECTION("Too many operands")
+      {
+        exprt two_operands = object_size;
+        two_operands.operands().push_back(pointer);
+        const cbmc_invariants_should_throwt invariants_throw;
+        REQUIRE_THROWS_MATCHES(
+          expr_try_dynamic_cast<object_size_exprt>(two_operands),
+          invariant_failedt,
+          invariant_failure_containing(
+            "Object size expression must have one operand"));
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR adds a class for object size expressions.
<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
