### PR TITLE
rename_symbolt: renaming in return values should affect the result

### DIFF
--- a/src/util/rename_symbol.cpp
+++ b/src/util/rename_symbol.cpp
@@ -146,7 +146,8 @@ bool rename_symbolt::rename(typet &dest) const
   else if(dest.id()==ID_code)
   {
     code_typet &code_type=to_code_type(dest);
-    rename(code_type.return_type());
+    if(!rename(code_type.return_type()))
+      result = false;
 
     for(auto &p : code_type.parameters())
     {


### PR DESCRIPTION
If users want to check whether any renaming took place, they need to be
informed in case that renaming took place in the type of the return
value of a code_typet.

Only function_name_manglert currently checks this result value, but none
of its current use would really result in renaming within a return
value.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
