### PR TITLE
Extend support for binding expressions beyond quantifiers

### DIFF
--- a/src/goto-symex/symex_clean_expr.cpp
+++ b/src/goto-symex/symex_clean_expr.cpp
@@ -212,7 +212,7 @@ void goto_symext::lift_lets(statet &state, exprt &rhs)
 
       it.next_sibling_or_parent();
     }
-    else if(it->id() == ID_exists || it->id() == ID_forall)
+    else if(can_cast_expr<binding_exprt>(*it))
     {
       // expressions within exists/forall may depend on bound variables, we
       // cannot safely lift let expressions out of those, just skip

--- a/src/goto-symex/symex_dereference.cpp
+++ b/src/goto-symex/symex_dereference.cpp
@@ -249,16 +249,16 @@ goto_symext::cache_dereference(exprt &dereference_result, statet &state)
 /// goto_symext::address_arithmetic) and certain common expression patterns
 /// such as `&struct.flexible_array[0]` (see inline comments in code).
 /// Note that \p write is used to alter behaviour when this function is
-/// operating on the LHS of an assignment. Similarly \p is_in_quantifier
-/// indicates when the dereference is inside a quantifier (related to scoping
-/// when dereference caching is enabled).
+/// operating on the LHS of an assignment. Similarly \p is_in_binding_expression
+/// indicates when the dereference is inside a binding expression (related to
+/// scoping when dereference caching is enabled).
 /// For full details of this method's pointer replacement and potential side-
 /// effects see \ref goto_symext::dereference
 void goto_symext::dereference_rec(
   exprt &expr,
   statet &state,
   bool write,
-  bool is_in_quantifier)
+  bool is_in_binding_expression)
 {
   if(expr.id()==ID_dereference)
   {
@@ -281,7 +281,7 @@ void goto_symext::dereference_rec(
     tmp1.swap(to_dereference_expr(expr).pointer());
 
     // first make sure there are no dereferences in there
-    dereference_rec(tmp1, state, false, is_in_quantifier);
+    dereference_rec(tmp1, state, false, is_in_binding_expression);
 
     // Depending on the nature of the pointer expression, the recursive deref
     // operation might have introduced a construct such as
@@ -345,7 +345,7 @@ void goto_symext::dereference_rec(
     //     (p == &something ? something : ...))
     // Otherwise we should just return it unchanged.
     if(
-      symex_config.cache_dereferences && !write && !is_in_quantifier &&
+      symex_config.cache_dereferences && !write && !is_in_binding_expression &&
       (tmp2.id() == ID_if || tmp2.id() == ID_let))
     {
       expr = cache_dereference(tmp2, state);
@@ -372,7 +372,7 @@ void goto_symext::dereference_rec(
     tmp.add_source_location()=expr.source_location();
 
     // recursive call
-    dereference_rec(tmp, state, write, is_in_quantifier);
+    dereference_rec(tmp, state, write, is_in_binding_expression);
 
     expr.swap(tmp);
   }
@@ -406,18 +406,22 @@ void goto_symext::dereference_rec(
       expr = address_of_exprt(index_exprt(
         to_address_of_expr(tc_op).object(), from_integer(0, c_index_type())));
 
-      dereference_rec(expr, state, write, is_in_quantifier);
+      dereference_rec(expr, state, write, is_in_binding_expression);
     }
     else
     {
-      dereference_rec(tc_op, state, write, is_in_quantifier);
+      dereference_rec(tc_op, state, write, is_in_binding_expression);
     }
   }
   else
   {
-    bool is_quantifier = expr.id() == ID_forall || expr.id() == ID_exists;
+    bool is_binding_expression =
+      can_cast_expr<binding_exprt>(expr) || can_cast_expr<let_exprt>(expr);
     Forall_operands(it, expr)
-      dereference_rec(*it, state, write, is_in_quantifier || is_quantifier);
+    {
+      dereference_rec(
+        *it, state, write, is_in_binding_expression || is_binding_expression);
+    }
   }
 }
 

--- a/src/util/std_expr.h
+++ b/src/util/std_expr.h
@@ -3099,6 +3099,13 @@ public:
   exprt instantiate(const variablest &) const;
 };
 
+template <>
+inline bool can_cast_expr<binding_exprt>(const exprt &base)
+{
+  return base.id() == ID_forall || base.id() == ID_exists ||
+         base.id() == ID_lambda || base.id() == ID_array_comprehension;
+}
+
 inline void validate_expr(const binding_exprt &binding_expr)
 {
   validate_operands(


### PR DESCRIPTION
Symex special-cased some code for quantifiers when really all binding
expressions have to be treated that way. To support this, add
can_cast_expr<binding_exprt>, and make sure all subclasses of
binding_exprt are covered by this cast.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
