### PR TITLE
WIP: Support bound variables

### DIFF
--- a/src/ansi-c/c_typecheck_expr.cpp
+++ b/src/ansi-c/c_typecheck_expr.cpp
@@ -750,6 +750,10 @@ void c_typecheck_baset::typecheck_expr_operands(exprt &expr)
     // These introduce new symbols, which need to be added to the symbol table
     // before the second operand is typechecked.
 
+    // TODO: we shouldn't actually need full declarations here, and it should be
+    // safe to remove the bound variables from the symbol table after
+    // typechecking the second operand.
+
     auto &binary_expr = to_binary_expr(expr);
     auto &bindings = binary_expr.op0().operands();
 

--- a/src/goto-instrument/contracts/contracts.cpp
+++ b/src/goto-instrument/contracts/contracts.cpp
@@ -154,10 +154,6 @@ void code_contractst::check_apply_loop_contracts(
   // at the start of and end of a loop body
   std::vector<symbol_exprt> old_decreases_vars, new_decreases_vars;
 
-  replace_symbolt replace;
-  code_contractst::add_quantified_variable(invariant, replace, mode);
-  replace(invariant);
-
   // instrument
   //
   //   ... preamble ...
@@ -565,72 +561,6 @@ void code_contractst::check_apply_loop_contracts(
   }
 }
 
-void code_contractst::add_quantified_variable(
-  const exprt &expression,
-  replace_symbolt &replace,
-  const irep_idt &mode)
-{
-  if(expression.id() == ID_not || expression.id() == ID_typecast)
-  {
-    // For unary connectives, recursively check for
-    // nested quantified formulae in the term
-    const auto &unary_expression = to_unary_expr(expression);
-    add_quantified_variable(unary_expression.op(), replace, mode);
-  }
-  if(expression.id() == ID_notequal || expression.id() == ID_implies)
-  {
-    // For binary connectives, recursively check for
-    // nested quantified formulae in the left and right terms
-    const auto &binary_expression = to_binary_expr(expression);
-    add_quantified_variable(binary_expression.lhs(), replace, mode);
-    add_quantified_variable(binary_expression.rhs(), replace, mode);
-  }
-  if(expression.id() == ID_if)
-  {
-    // For ternary connectives, recursively check for
-    // nested quantified formulae in all three terms
-    const auto &if_expression = to_if_expr(expression);
-    add_quantified_variable(if_expression.cond(), replace, mode);
-    add_quantified_variable(if_expression.true_case(), replace, mode);
-    add_quantified_variable(if_expression.false_case(), replace, mode);
-  }
-  if(expression.id() == ID_and || expression.id() == ID_or)
-  {
-    // For multi-ary connectives, recursively check for
-    // nested quantified formulae in all terms
-    const auto &multi_ary_expression = to_multi_ary_expr(expression);
-    for(const auto &operand : multi_ary_expression.operands())
-    {
-      add_quantified_variable(operand, replace, mode);
-    }
-  }
-  else if(expression.id() == ID_exists || expression.id() == ID_forall)
-  {
-    // When a quantifier expression is found,
-    // for each quantified variable ...
-    const auto &quantifier_expression = to_quantifier_expr(expression);
-    for(const auto &quantified_variable : quantifier_expression.variables())
-    {
-      const auto &quantified_symbol = to_symbol_expr(quantified_variable);
-
-      // 1. create fresh symbol
-      symbolt new_symbol = new_tmp_symbol(
-        quantified_symbol.type(),
-        quantified_symbol.source_location(),
-        mode,
-        symbol_table);
-
-      // 2. add created fresh symbol to expression map
-      symbol_exprt q(
-        quantified_symbol.get_identifier(), quantified_symbol.type());
-      replace.insert(q, new_symbol.symbol_expr());
-
-      // 3. recursively check for nested quantified formulae
-      add_quantified_variable(quantifier_expression.where(), replace, mode);
-    }
-  }
-}
-
 void code_contractst::replace_history_parameter(
   exprt &expr,
   std::map<exprt, exprt> &parameter2history,
@@ -826,9 +756,7 @@ void code_contractst::apply_function_contract(
   // Insert assertion of the precondition immediately before the call site.
   if(!requires.is_true())
   {
-    replace_symbolt replace(common_replace);
-    code_contractst::add_quantified_variable(requires, replace, mode);
-    replace(requires);
+    common_replace(requires);
 
     goto_programt assertion;
     converter.goto_convert(code_assertt(requires), assertion, mode);
@@ -847,9 +775,7 @@ void code_contractst::apply_function_contract(
   std::pair<goto_programt, goto_programt> ensures_pair;
   if(!ensures.is_false())
   {
-    replace_symbolt replace(common_replace);
-    code_contractst::add_quantified_variable(ensures, replace, mode);
-    replace(ensures);
+    common_replace(ensures);
 
     auto assumption = code_assumet(ensures);
     ensures_pair =
@@ -1454,12 +1380,7 @@ void code_contractst::add_contract_check(
   // Generate: assume(requires)
   if(!requires.is_false())
   {
-    // extend common_replace with quantified variables in REQUIRES,
-    // and then do the replacement
-    replace_symbolt replace(common_replace);
-    code_contractst::add_quantified_variable(
-      requires, replace, function_symbol.mode);
-    replace(requires);
+    common_replace(requires);
 
     goto_programt assumption;
     converter.goto_convert(
@@ -1474,12 +1395,7 @@ void code_contractst::add_contract_check(
   // Generate: copies for history variables
   if(!ensures.is_true())
   {
-    // extend common_replace with quantified variables in ENSURES,
-    // and then do the replacement
-    replace_symbolt replace(common_replace);
-    code_contractst::add_quantified_variable(
-      ensures, replace, function_symbol.mode);
-    replace(ensures);
+    common_replace(ensures);
 
     // get all the relevant instructions related to history variables
     auto assertion = code_assertt(ensures);

--- a/src/goto-instrument/contracts/contracts.h
+++ b/src/goto-instrument/contracts/contracts.h
@@ -156,15 +156,6 @@ protected:
     const irep_idt &mangled_function,
     goto_programt &dest);
 
-  /// This function recursively searches the expression to find nested or
-  /// non-nested quantified expressions. When a quantified expression is found,
-  /// the quantified variable is added to the symbol table
-  /// and to the expression map.
-  void add_quantified_variable(
-    const exprt &expression,
-    replace_symbolt &replace,
-    const irep_idt &mode);
-
   /// This function recursively identifies the "old" expressions within expr
   /// and replaces them with correspoding history variables.
   void replace_history_parameter(

--- a/src/goto-symex/goto_symex_state.h
+++ b/src/goto-symex/goto_symex_state.h
@@ -117,9 +117,30 @@ public:
     bool record_value,
     bool allow_pointer_unsoundness = false);
 
+  /// Mark \p vars as variables belonging to a binding expression.
+  void push_bound_variables(const std::vector<symbol_exprt> &vars)
+  {
+    for(const auto &var : vars)
+    {
+      bool inserted = bound_variables.insert(var.get_identifier()).second;
+      CHECK_RETURN(inserted);
+    }
+  }
+  /// Remove \p vars from the collection of variables belonging to some binding
+  /// expression.
+  void pop_bound_variables(const std::vector<symbol_exprt> &vars)
+  {
+    for(const auto &var : vars)
+      bound_variables.erase(var.get_identifier());
+  }
+
   field_sensitivityt field_sensitivity;
 
 protected:
+  // This set hold information while (recursively) processing expressions, it is
+  // _not_ copied when copying goto_statet.
+  std::set<irep_idt> bound_variables;
+
   template <levelt>
   void rename_address(exprt &expr, const namespacet &ns);
 

--- a/src/goto-symex/symex_clean_expr.cpp
+++ b/src/goto-symex/symex_clean_expr.cpp
@@ -212,7 +212,7 @@ void goto_symext::lift_lets(statet &state, exprt &rhs)
 
       it.next_sibling_or_parent();
     }
-    else if(it->id() == ID_exists || it->id() == ID_forall)
+    else if(can_cast_expr<binding_exprt>(*it))
     {
       // expressions within exists/forall may depend on bound variables, we
       // cannot safely lift let expressions out of those, just skip

--- a/src/goto-symex/symex_main.cpp
+++ b/src/goto-symex/symex_main.cpp
@@ -259,17 +259,12 @@ void goto_symext::rewrite_quantifiers(exprt &expr, statet &state)
     (is_assert && expr.id() == ID_forall) ||
     (!is_assert && expr.id() == ID_exists))
   {
-    // for assertions e can rewrite "forall X. P" to "P", and
-    // for assumptions we can rewrite "exists X. P" to "P"
-    // we keep the quantified variable unique by means of L2 renaming
+    // for assertions we can rewrite "forall X. P" to "lambda X. P", and
+    // for assumptions we can rewrite "exists X. P" to "lambda X. P"
     auto &quant_expr = to_quantifier_expr(expr);
-    symbol_exprt tmp0 =
-      to_symbol_expr(to_ssa_expr(quant_expr.symbol()).get_original_expr());
-    symex_decl(state, tmp0);
-    instruction_local_symbols.push_back(tmp0);
-    exprt tmp = quant_expr.where();
-    rewrite_quantifiers(tmp, state);
-    quant_expr.swap(tmp);
+    rewrite_quantifiers(quant_expr.where(), state);
+    lambda_exprt lambda{quant_expr.variables(), quant_expr.where()};
+    expr.swap(lambda);
   }
   else if(expr.id() == ID_or || expr.id() == ID_and)
   {

--- a/src/util/std_expr.h
+++ b/src/util/std_expr.h
@@ -3075,6 +3075,12 @@ public:
   exprt instantiate(const variablest &) const;
 };
 
+template <>
+inline bool can_cast_expr<binding_exprt>(const exprt &base)
+{
+  return base.id() == ID_forall || base.id() == ID_exists || base.id() == ID_lambda || base.id() == ID_array_comprehension;
+}
+
 inline void validate_expr(const binding_exprt &binding_expr)
 {
   validate_operands(
@@ -3090,7 +3096,7 @@ inline void validate_expr(const binding_exprt &binding_expr)
 inline const binding_exprt &to_binding_expr(const exprt &expr)
 {
   PRECONDITION(
-    expr.id() == ID_forall || expr.id() == ID_exists || expr.id() == ID_lambda);
+    expr.id() == ID_forall || expr.id() == ID_exists || expr.id() == ID_lambda || expr.id() == ID_array_comprehension);
   const binding_exprt &ret = static_cast<const binding_exprt &>(expr);
   validate_expr(ret);
   return ret;


### PR DESCRIPTION
If `binding_exprt` actually worked as they were supposed to be, quantifier expressions would not require declarations or additions to the symbol table, and lambda expressions could actually be used. It seems quite a bit more work is required to actually get there.

Known issue at this point: `lambda_exprt` is not supported in our back-end.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
