### PR TITLE
Exit with error if --outfile cannot be written

### DIFF
--- a/regression/cbmc/outfile_no_dir/main.c
+++ b/regression/cbmc/outfile_no_dir/main.c
@@ -1,0 +1,4 @@
+int main()
+{
+  return 0;
+}

--- a/regression/cbmc/outfile_no_dir/test.desc
+++ b/regression/cbmc/outfile_no_dir/test.desc
@@ -1,0 +1,8 @@
+CORE paths-lifo-expected-failure
+main.c
+--dimacs --outfile /xyz/out.dimacs
+^EXIT=1$
+^SIGNAL=0$
+failed to open file
+--
+^warning: ignoring

--- a/src/goto-checker/solver_factory.cpp
+++ b/src/goto-checker/solver_factory.cpp
@@ -71,6 +71,16 @@ solver_factoryt::solvert::solvert(
 {
 }
 
+solver_factoryt::solvert::solvert(
+  std::unique_ptr<boolbvt> p1,
+  std::unique_ptr<propt> p2,
+  std::unique_ptr<std::ofstream> p3)
+  : ofstream_ptr(std::move(p3)),
+    prop_ptr(std::move(p2)),
+    decision_procedure_is_boolbvt_ptr(std::move(p1))
+{
+}
+
 stack_decision_proceduret &solver_factoryt::solvert::decision_procedure() const
 {
   PRECONDITION(
@@ -324,6 +334,27 @@ get_sat_solver(message_handlert &message_handler, const optionst &options)
   }
 }
 
+static std::unique_ptr<std::ofstream> open_outfile_and_check(
+  const std::string &filename,
+  message_handlert &message_handler,
+  const std::string &arg_name)
+{
+  if(filename.empty())
+    return nullptr;
+
+  auto out = std::make_unique<std::ofstream>(widen_if_needed(filename));
+
+  if(!*out)
+  {
+    throw invalid_command_line_argument_exceptiont(
+      "failed to open file: " + filename, arg_name);
+  }
+
+  messaget log(message_handler);
+  log.status() << "Outputting formula to file: " << filename << messaget::eom;
+  return out;
+}
+
 std::unique_ptr<solver_factoryt::solvert> solver_factoryt::get_default()
 {
   auto sat_solver = get_sat_solver(message_handler, options);
@@ -353,10 +384,21 @@ std::unique_ptr<solver_factoryt::solvert> solver_factoryt::get_dimacs()
 
   std::string filename = options.get_option("outfile");
 
-  std::unique_ptr<boolbvt> bv_dimacs =
-    std::make_unique<bv_dimacst>(ns, *prop, message_handler, filename);
+  if(filename.empty() || filename == "-")
+  {
+    std::unique_ptr<boolbvt> bv_dimacs =
+      std::make_unique<bv_dimacst>(ns, *prop, message_handler, std::cout);
 
-  return std::make_unique<solvert>(std::move(bv_dimacs), std::move(prop));
+    return std::make_unique<solvert>(std::move(bv_dimacs), std::move(prop));
+  }
+
+  auto outfile = open_outfile_and_check(filename, message_handler, "--outfile");
+
+  std::unique_ptr<boolbvt> bv_dimacs =
+    std::make_unique<bv_dimacst>(ns, *prop, message_handler, *outfile);
+
+  return std::make_unique<solvert>(
+    std::move(bv_dimacs), std::move(prop), std::move(outfile));
 }
 
 std::unique_ptr<solver_factoryt::solvert> solver_factoryt::get_external_sat()
@@ -423,28 +465,6 @@ solver_factoryt::get_string_refinement()
   set_decision_procedure_time_limit(*decision_procedure);
   return std::make_unique<solvert>(
     std::move(decision_procedure), std::move(prop));
-}
-
-std::unique_ptr<std::ofstream> open_outfile_and_check(
-  const std::string &filename,
-  message_handlert &message_handler,
-  const std::string &arg_name)
-{
-  if(filename.empty())
-    return nullptr;
-
-  auto out = std::make_unique<std::ofstream>(widen_if_needed(filename));
-
-  if(!*out)
-  {
-    throw invalid_command_line_argument_exceptiont(
-      "failed to open file: " + filename, arg_name);
-  }
-
-  messaget log(message_handler);
-  log.status() << "Outputting SMTLib formula to file: " << filename
-               << messaget::eom;
-  return out;
 }
 
 std::unique_ptr<solver_factoryt::solvert>

--- a/src/goto-checker/solver_factory.h
+++ b/src/goto-checker/solver_factory.h
@@ -47,6 +47,10 @@ public:
       std::unique_ptr<stack_decision_proceduret> p1,
       std::unique_ptr<std::ofstream> p2);
     solvert(std::unique_ptr<boolbvt> p1, std::unique_ptr<propt> p2);
+    solvert(
+      std::unique_ptr<boolbvt> p1,
+      std::unique_ptr<propt> p2,
+      std::unique_ptr<std::ofstream> p3);
 
     stack_decision_proceduret &decision_procedure() const;
     boolbvt &boolbv_decision_procedure() const;

--- a/src/solvers/flattening/bv_dimacs.cpp
+++ b/src/solvers/flattening/bv_dimacs.cpp
@@ -13,37 +13,16 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <solvers/sat/dimacs_cnf.h>
 
-#include <fstream> // IWYU pragma: keep
-#include <iostream>
-
 bv_dimacst::bv_dimacst(
   const namespacet &_ns,
   dimacs_cnft &_prop,
   message_handlert &message_handler,
-  const std::string &_filename)
-  : bv_pointerst(_ns, _prop, message_handler),
-    filename(_filename),
-    dimacs_cnf_prop(_prop)
+  std::ostream &_out)
+  : bv_pointerst(_ns, _prop, message_handler), out(_out), dimacs_cnf_prop(_prop)
 {
 }
 
-bool bv_dimacst::write_dimacs()
-{
-  if(filename.empty() || filename == "-")
-    return write_dimacs(std::cout);
-
-  std::ofstream out(filename);
-
-  if(!out)
-  {
-    log.error() << "failed to open " << filename << messaget::eom;
-    return false;
-  }
-
-  return write_dimacs(out);
-}
-
-bool bv_dimacst::write_dimacs(std::ostream &out)
+void bv_dimacst::write_dimacs()
 {
   dimacs_cnf_prop.write_dimacs_cnf(out);
 
@@ -79,6 +58,4 @@ bool bv_dimacst::write_dimacs(std::ostream &out)
 
     out << "\n";
   }
-
-  return false;
 }

--- a/src/solvers/flattening/bv_dimacs.h
+++ b/src/solvers/flattening/bv_dimacs.h
@@ -14,6 +14,8 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "bv_pointers.h"
 
+#include <iosfwd>
+
 class dimacs_cnft;
 
 class bv_dimacst : public bv_pointerst
@@ -23,7 +25,7 @@ public:
     const namespacet &_ns,
     dimacs_cnft &_prop,
     message_handlert &message_handler,
-    const std::string &_filename);
+    std::ostream &_out);
 
   virtual ~bv_dimacst()
   {
@@ -31,11 +33,10 @@ public:
   }
 
 protected:
-  const std::string filename;
+  std::ostream &out;
   const dimacs_cnft &dimacs_cnf_prop;
 
-  bool write_dimacs();
-  bool write_dimacs(std::ostream &);
+  void write_dimacs();
 };
 
 #endif // CPROVER_SOLVERS_FLATTENING_BV_DIMACS_H


### PR DESCRIPTION
This commit prevents CBMC from exiting with 0 if the file specified to
`cbmc --outfile` cannot be written. This allows build systems that
contain commands that depend on the file being written to abort the
build if the file was not written.

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.