### PR TITLE
CONTRACTS: make __CPROVER_is_fresh call-local.

### DIFF
--- a/regression/contracts/is_fresh_indirect_calls/main.c
+++ b/regression/contracts/is_fresh_indirect_calls/main.c
@@ -1,0 +1,43 @@
+#include <stdbool.h>
+#include <stdlib.h>
+
+char nondet_char();
+
+char *foo(char *a, char *b, size_t s)
+  // clang-format off
+__CPROVER_requires(s > 0)
+__CPROVER_requires(__CPROVER_is_fresh(a, s))
+__CPROVER_requires(__CPROVER_is_fresh(b, s))
+__CPROVER_assigns(a[0])
+__CPROVER_ensures(__CPROVER_is_fresh(__CPROVER_return_value, s))
+// clang-format on
+{
+  a[0] = nondet_char();
+  return malloc(s);
+}
+
+char *bar(char *a, char *b, size_t s)
+{
+  return foo(a, b, s);
+}
+
+int main()
+{
+  size_t s;
+  __CPROVER_assume(0 < s && s < __CPROVER_max_malloc_size);
+  char *a = malloc(s);
+  char *b = malloc(s);
+
+  char *c = bar(a, b, s);
+  __CPROVER_assert(__CPROVER_rw_ok(c, s), "c is rw_ok");
+  __CPROVER_assert(c != a, "c and a are distinct");
+  __CPROVER_assert(c != b, "c and b are distinct");
+
+  char *d = bar(a, b, s);
+  __CPROVER_assert(__CPROVER_rw_ok(d, s), "d is rw_ok");
+  __CPROVER_assert(d != a, "d and a are distinct");
+  __CPROVER_assert(d != b, "d and b are distinct");
+  __CPROVER_assert(d != c, "d and c distinct");
+
+  return 0;
+}

--- a/regression/contracts/is_fresh_indirect_calls/test.desc
+++ b/regression/contracts/is_fresh_indirect_calls/test.desc
@@ -1,0 +1,24 @@
+CORE
+main.c
+--replace-call-with-contract foo
+^\[foo.assigns.\d+\].*Check that a\[.*0\] is valid: SUCCESS$
+^\[main.assertion.\d+\].*c is rw_ok: SUCCESS$
+^\[main.assertion.\d+\].*c and a are distinct: SUCCESS$
+^\[main.assertion.\d+\].*c and b are distinct: SUCCESS$
+^\[main.assertion.\d+\].*d is rw_ok: SUCCESS$
+^\[main.assertion.\d+\].*d and a are distinct: SUCCESS$
+^\[main.assertion.\d+\].*d and b are distinct: SUCCESS$
+^\[main.assertion.\d+\].*d and c distinct: SUCCESS$
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+--
+This test checks that the interpretation of is_fresh predicates is 
+local to a call. `bar` is called twice with the same arguments.
+`bar` calls `foo` so `foo` also gets called twice with the same arguments.
+The is_fresh preconditions of `foo` are checked and satisfied independently
+for each call.
+This shows that the memory_map which keeps track of objects seen by the 
+is_fresh predicates and the input and output of a function call is local to
+that function call.

--- a/src/goto-instrument/contracts/memory_predicates.h
+++ b/src/goto-instrument/contracts/memory_predicates.h
@@ -32,6 +32,9 @@ public:
 
   virtual void create_declarations() = 0;
 
+  void add_memory_map_decl(goto_programt &program);
+  void add_memory_map_dead(goto_programt &program);
+
 protected:
   void add_declarations(const std::string &decl_string);
   void update_fn_call(
@@ -50,6 +53,9 @@ protected:
   std::string memmap_name;
   std::string requires_fn_name;
   std::string ensures_fn_name;
+  symbolt memmap_symbol;
+
+  array_typet get_memmap_type();
 };
 
 class is_fresh_enforcet : public is_fresh_baset


### PR DESCRIPTION
The previous implementation of the __CPROVER_is_fresh predicates used a global static map, which caused different occurrences of a function call from same call site to interfere.

We now use a locally allocated memory map which solves the problem.

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [N/A] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.
