### PR TITLE
CONTRACTS: Support object slices in assigns clauses

### DIFF
--- a/doc/cprover-manual/contracts-assigns.md
+++ b/doc/cprover-manual/contracts-assigns.md
@@ -13,6 +13,30 @@ design is based on the former. This means that memory not captured by an
 _assigns_ clause must not be written within the given function, even if the
 value(s) therein are not modified.
 
+### Object slice expressions
+
+The following functions can be used in assigns clause to specify ranges of 
+assignable addresses.
+
+Given a pointer `ptr` pointing into some object `o`, `__CPROVER_object_from(ptr)` 
+specifies that all bytes starting from the given pointer and until the end of 
+the object are assignable:
+```c
+__CPROVER_size_t __CPROVER_object_from(void *ptr); 
+```
+
+Given a pointer `ptr` pointing into some object `o`, `__CPROVER_object_from(ptr, size)` 
+specifies that `size` bytes starting from the given pointer and until the end of the object are assignable.
+The `size` value must such that `size <= __CPROVER_object_size(ptr) - __CPROVER_pointer_offset(ptr)` holds:
+
+```c
+__CPROVER_size_t __CPROVER_object_slice(void *ptr, __CPROVER_size_t size);
+```
+
+Caveats and limitations: The slices in question must *not*
+be interpreted as pointers by the program. During call-by-contract replacement, 
+`__CPROVER_havoc_slice(ptr, size)` is used to havoc these targets, 
+and `__CPROVER_havoc_slice` does not support havocing pointers. 
 ### Parameters
 
 An _assigns_ clause currently supports simple variable types and their pointers,

--- a/regression/contracts/assigns-slice-targets/main-enforce.c
+++ b/regression/contracts/assigns-slice-targets/main-enforce.c
@@ -1,0 +1,53 @@
+struct st
+{
+  int a;
+  char arr1[10];
+  int b;
+  char arr2[10];
+  int c;
+};
+
+void foo(struct st *s)
+  // clang-format off
+  __CPROVER_requires(__CPROVER_is_fresh(s, sizeof(*s)))
+  __CPROVER_assigns(__CPROVER_object_slice(s->arr1, 5))
+  __CPROVER_assigns(__CPROVER_object_from(s->arr2 + 5))
+// clang-format on
+{
+  // PASS
+  s->arr1[0] = 0;
+  s->arr1[1] = 0;
+  s->arr1[2] = 0;
+  s->arr1[3] = 0;
+  s->arr1[4] = 0;
+
+  // FAIL
+  s->arr1[5] = 0;
+  s->arr1[6] = 0;
+  s->arr1[7] = 0;
+  s->arr1[8] = 0;
+  s->arr1[9] = 0;
+
+  // FAIL
+  s->arr2[0] = 0;
+  s->arr2[1] = 0;
+  s->arr2[2] = 0;
+  s->arr2[3] = 0;
+  s->arr2[4] = 0;
+
+  // PASS
+  s->arr2[5] = 0;
+  s->arr2[6] = 0;
+  s->arr2[7] = 0;
+  s->arr2[8] = 0;
+  s->arr2[9] = 0;
+}
+
+int main()
+{
+  struct st s;
+
+  foo(&s);
+
+  return 0;
+}

--- a/regression/contracts/assigns-slice-targets/main-replace.c
+++ b/regression/contracts/assigns-slice-targets/main-replace.c
@@ -1,0 +1,96 @@
+struct st
+{
+  int a;
+  char arr1[10];
+  int b;
+  char arr2[10];
+  int c;
+};
+
+void foo(struct st *s)
+  // clang-format off
+  __CPROVER_requires(__CPROVER_is_fresh(s, sizeof(*s)))
+  __CPROVER_assigns(__CPROVER_object_slice(s->arr1, 5))
+  __CPROVER_assigns(__CPROVER_object_from(s->arr2 + 5))
+// clang-format on
+{
+  s->arr1[0] = 0;
+  s->arr1[1] = 0;
+  s->arr1[2] = 0;
+  s->arr1[3] = 0;
+  s->arr1[4] = 0;
+
+  s->arr2[5] = 0;
+  s->arr2[6] = 0;
+  s->arr2[7] = 0;
+  s->arr2[8] = 0;
+  s->arr2[9] = 0;
+}
+
+int main()
+{
+  struct st s;
+  s.a = 0;
+  s.arr1[0] = 0;
+  s.arr1[1] = 0;
+  s.arr1[2] = 0;
+  s.arr1[3] = 0;
+  s.arr1[4] = 0;
+  s.arr1[5] = 0;
+  s.arr1[6] = 0;
+  s.arr1[7] = 0;
+  s.arr1[8] = 0;
+  s.arr1[9] = 0;
+
+  s.arr2[0] = 0;
+  s.arr2[1] = 0;
+  s.arr2[2] = 0;
+  s.arr2[3] = 0;
+  s.arr2[4] = 0;
+  s.arr2[5] = 0;
+  s.arr2[6] = 0;
+  s.arr2[7] = 0;
+  s.arr2[8] = 0;
+  s.arr2[9] = 0;
+  s.c = 0;
+
+  foo(&s);
+
+  // PASS
+  assert(s.a == 0);
+
+  // FAIL
+  assert(s.arr1[0] == 0);
+  assert(s.arr1[1] == 0);
+  assert(s.arr1[2] == 0);
+  assert(s.arr1[3] == 0);
+  assert(s.arr1[4] == 0);
+
+  // PASS
+  assert(s.arr1[5] == 0);
+  assert(s.arr1[6] == 0);
+  assert(s.arr1[7] == 0);
+  assert(s.arr1[8] == 0);
+  assert(s.arr1[9] == 0);
+
+  // PASS
+  assert(s.b == 0);
+
+  // PASS
+  assert(s.arr2[0] == 0);
+  assert(s.arr2[1] == 0);
+  assert(s.arr2[2] == 0);
+  assert(s.arr2[3] == 0);
+  assert(s.arr2[4] == 0);
+
+  // FAIL
+  assert(s.arr2[5] == 0);
+  assert(s.arr2[6] == 0);
+  assert(s.arr2[7] == 0);
+  assert(s.arr2[8] == 0);
+  assert(s.arr2[9] == 0);
+
+  // PASS
+  assert(s.c == 0);
+  return 0;
+}

--- a/regression/contracts/assigns-slice-targets/test-enforce.desc
+++ b/regression/contracts/assigns-slice-targets/test-enforce.desc
@@ -1,0 +1,32 @@
+CORE
+main-enforce.c
+--enforce-contract foo
+^\[foo.assigns.\d+\].* Check that __CPROVER_object_slice\(\(void \*\)s->arr1, \(.*\)5\) is valid: SUCCESS$
+^\[foo.assigns.\d+\].* Check that __CPROVER_object_from\(\(void \*\)\(s->arr2 \+ \(.*\)5\)\) is valid: SUCCESS$
+^\[foo.assigns.\d+\].* Check that s->arr1\[\(.*\)0\] is assignable: SUCCESS$
+^\[foo.assigns.\d+\].* Check that s->arr1\[\(.*\)1\] is assignable: SUCCESS$
+^\[foo.assigns.\d+\].* Check that s->arr1\[\(.*\)2\] is assignable: SUCCESS$
+^\[foo.assigns.\d+\].* Check that s->arr1\[\(.*\)3\] is assignable: SUCCESS$
+^\[foo.assigns.\d+\].* Check that s->arr1\[\(.*\)4\] is assignable: SUCCESS$
+^\[foo.assigns.\d+\].* Check that s->arr1\[\(.*\)5\] is assignable: FAILURE$
+^\[foo.assigns.\d+\].* Check that s->arr1\[\(.*\)6\] is assignable: FAILURE$
+^\[foo.assigns.\d+\].* Check that s->arr1\[\(.*\)7\] is assignable: FAILURE$
+^\[foo.assigns.\d+\].* Check that s->arr1\[\(.*\)8\] is assignable: FAILURE$
+^\[foo.assigns.\d+\].* Check that s->arr1\[\(.*\)9\] is assignable: FAILURE$
+^\[foo.assigns.\d+\].* Check that s->arr2\[\(.*\)0\] is assignable: FAILURE$
+^\[foo.assigns.\d+\].* Check that s->arr2\[\(.*\)1\] is assignable: FAILURE$
+^\[foo.assigns.\d+\].* Check that s->arr2\[\(.*\)2\] is assignable: FAILURE$
+^\[foo.assigns.\d+\].* Check that s->arr2\[\(.*\)3\] is assignable: FAILURE$
+^\[foo.assigns.\d+\].* Check that s->arr2\[\(.*\)4\] is assignable: FAILURE$
+^\[foo.assigns.\d+\].* Check that s->arr2\[\(.*\)5\] is assignable: SUCCESS$
+^\[foo.assigns.\d+\].* Check that s->arr2\[\(.*\)6\] is assignable: SUCCESS$
+^\[foo.assigns.\d+\].* Check that s->arr2\[\(.*\)7\] is assignable: SUCCESS$
+^\[foo.assigns.\d+\].* Check that s->arr2\[\(.*\)8\] is assignable: SUCCESS$
+^\[foo.assigns.\d+\].* Check that s->arr2\[\(.*\)9\] is assignable: SUCCESS$
+^VERIFICATION FAILED$
+^EXIT=10$
+^SIGNAL=0$
+--
+--
+Checks that assigns clause checking of slice expressions works as expected when 
+enforcing a contract.

--- a/regression/contracts/assigns-slice-targets/test-replace.desc
+++ b/regression/contracts/assigns-slice-targets/test-replace.desc
@@ -1,0 +1,34 @@
+CORE
+main-replace.c
+--replace-call-with-contract foo
+^\[main.assertion.\d+\].*assertion s.a == 0: SUCCESS$
+^\[main.assertion.\d+\].*assertion \(.*\)s.arr1\[\(.*\)0\] == 0: FAILURE$
+^\[main.assertion.\d+\].*assertion \(.*\)s.arr1\[\(.*\)1\] == 0: FAILURE$
+^\[main.assertion.\d+\].*assertion \(.*\)s.arr1\[\(.*\)2\] == 0: FAILURE$
+^\[main.assertion.\d+\].*assertion \(.*\)s.arr1\[\(.*\)3\] == 0: FAILURE$
+^\[main.assertion.\d+\].*assertion \(.*\)s.arr1\[\(.*\)4\] == 0: FAILURE$
+^\[main.assertion.\d+\].*assertion \(.*\)s.arr1\[\(.*\)5\] == 0: SUCCESS$
+^\[main.assertion.\d+\].*assertion \(.*\)s.arr1\[\(.*\)6\] == 0: SUCCESS$
+^\[main.assertion.\d+\].*assertion \(.*\)s.arr1\[\(.*\)7\] == 0: SUCCESS$
+^\[main.assertion.\d+\].*assertion \(.*\)s.arr1\[\(.*\)8\] == 0: SUCCESS$
+^\[main.assertion.\d+\].*assertion \(.*\)s.arr1\[\(.*\)9\] == 0: SUCCESS$
+^\[main.assertion.\d+\].*assertion s.b == 0: FAILURE$
+^\[main.assertion.\d+\].*assertion \(.*\)s.arr2\[\(.*\)0\] == 0: SUCCESS$
+^\[main.assertion.\d+\].*assertion \(.*\)s.arr2\[\(.*\)1\] == 0: SUCCESS$
+^\[main.assertion.\d+\].*assertion \(.*\)s.arr2\[\(.*\)2\] == 0: SUCCESS$
+^\[main.assertion.\d+\].*assertion \(.*\)s.arr2\[\(.*\)3\] == 0: SUCCESS$
+^\[main.assertion.\d+\].*assertion \(.*\)s.arr2\[\(.*\)4\] == 0: SUCCESS$
+^\[main.assertion.\d+\].*assertion \(.*\)s.arr2\[\(.*\)5\] == 0: FAILURE$
+^\[main.assertion.\d+\].*assertion \(.*\)s.arr2\[\(.*\)6\] == 0: FAILURE$
+^\[main.assertion.\d+\].*assertion \(.*\)s.arr2\[\(.*\)7\] == 0: FAILURE$
+^\[main.assertion.\d+\].*assertion \(.*\)s.arr2\[\(.*\)8\] == 0: FAILURE$
+^\[main.assertion.\d+\].*assertion \(.*\)s.arr2\[\(.*\)9\] == 0: FAILURE$
+^\[main.assertion.\d+\].*assertion s.c == 0: FAILURE$
+^VERIFICATION FAILED$
+^EXIT=10$
+^SIGNAL=0$
+--
+--
+Checks that havocking of slice expressions works as expected when 
+replacing a call by a contract. We manually express frame conditions as 
+assertions in the main function.

--- a/regression/contracts/assigns_enforce_address_of/test.desc
+++ b/regression/contracts/assigns_enforce_address_of/test.desc
@@ -3,7 +3,7 @@ main.c
 --enforce-contract foo
 ^EXIT=(1|64)$
 ^SIGNAL=0$
-^.*error: assigns clause target must be an lvalue or __CPROVER_POINTER_OBJECT expression$
+^.*error: assigns clause target must be an lvalue or a __CPROVER_POINTER_OBJECT, __CPROVER_object_from, __CPROVER_object_slice expression$
 ^CONVERSION ERROR$
 --
 --

--- a/regression/contracts/assigns_enforce_conditional_non_lvalue_target/test.desc
+++ b/regression/contracts/assigns_enforce_conditional_non_lvalue_target/test.desc
@@ -1,7 +1,7 @@
 CORE
 main.c
 --enforce-contract foo
-^.*error: assigns clause target must be an lvalue or __CPROVER_POINTER_OBJECT expression$
+^.*error: assigns clause target must be an lvalue or a __CPROVER_POINTER_OBJECT, __CPROVER_object_from, __CPROVER_object_slice expression$
 ^CONVERSION ERROR
 ^EXIT=(1|64)$
 ^SIGNAL=0$

--- a/regression/contracts/assigns_enforce_conditional_non_lvalue_target_list/test.desc
+++ b/regression/contracts/assigns_enforce_conditional_non_lvalue_target_list/test.desc
@@ -1,7 +1,7 @@
 CORE
 main.c
 --enforce-contract foo
-^.*error: assigns clause target must be an lvalue or __CPROVER_POINTER_OBJECT expression$
+^.*error: assigns clause target must be an lvalue or a __CPROVER_POINTER_OBJECT, __CPROVER_object_from, __CPROVER_object_slice expression$
 ^CONVERSION ERROR
 ^EXIT=(1|64)$
 ^SIGNAL=0$

--- a/regression/contracts/assigns_enforce_function_calls/test.desc
+++ b/regression/contracts/assigns_enforce_function_calls/test.desc
@@ -3,8 +3,7 @@ main.c
 --enforce-contract foo
 ^EXIT=(1|64)$
 ^SIGNAL=0$
-^.*error: assigns clause target must be an lvalue or __CPROVER_POINTER_OBJECT expression$
-^.*error: side-effects not allowed in assigns clause targets$
+^.*error: function calls in assigns clause targets must be to __CPROVER_object_from, __CPROVER_object_slice$
 ^CONVERSION ERROR$
 --
 --

--- a/regression/contracts/assigns_enforce_literal/test.desc
+++ b/regression/contracts/assigns_enforce_literal/test.desc
@@ -3,7 +3,7 @@ main.c
 --enforce-contract foo
 ^EXIT=(1|64)$
 ^SIGNAL=0$
-^.*error: assigns clause target must be an lvalue or __CPROVER_POINTER_OBJECT expression$
+^.*error: assigns clause target must be an lvalue or a __CPROVER_POINTER_OBJECT, __CPROVER_object_from, __CPROVER_object_slice expression$
 ^CONVERSION ERROR$
 --
 --

--- a/regression/contracts/assigns_enforce_side_effects_1/test.desc
+++ b/regression/contracts/assigns_enforce_side_effects_1/test.desc
@@ -2,7 +2,7 @@ CORE
 main.c
 --enforce-contract foo
 activate-multi-line-match
-.*error: (dereferencing void pointer|void-typed expressions not allowed as assigns clause targets\n.*\n.*error: side-effects not allowed in assigns clause targets\n.*\n.*error: ternary expressions not allowed in assigns clause targets\n)
+.*error: (dereferencing void pointer|void-typed expressions not allowed as assigns clause targets)
 ^CONVERSION ERROR$
 ^EXIT=(1|64)$
 ^SIGNAL=0$

--- a/regression/contracts/assigns_enforce_side_effects_2/test.desc
+++ b/regression/contracts/assigns_enforce_side_effects_2/test.desc
@@ -3,8 +3,7 @@ main.c
 --enforce-contract foo
 ^EXIT=(1|64)$
 ^SIGNAL=0$
-^.*error: assigns clause target must be an lvalue or __CPROVER_POINTER_OBJECT expression$
-^.*error: side-effects not allowed in assigns clause targets$
+^.*error: assigns clause target must be an lvalue or a __CPROVER_POINTER_OBJECT, __CPROVER_object_from, __CPROVER_object_slice expression$
 ^CONVERSION ERROR$
 --
 --

--- a/regression/contracts/assigns_enforce_side_effects_3/test.desc
+++ b/regression/contracts/assigns_enforce_side_effects_3/test.desc
@@ -3,8 +3,7 @@ main.c
 --enforce-contract foo
 ^EXIT=(1|64)$
 ^SIGNAL=0$
-^.*error: assigns clause target must be an lvalue or __CPROVER_POINTER_OBJECT expression$
-^.*error: side-effects not allowed in assigns clause targets$
+^.*error: assigns clause target must be an lvalue or a __CPROVER_POINTER_OBJECT, __CPROVER_object_from, __CPROVER_object_slice expression$
 ^CONVERSION ERROR$
 --
 --

--- a/regression/contracts/assigns_type_checking_invalid_case_01/test.desc
+++ b/regression/contracts/assigns_type_checking_invalid_case_01/test.desc
@@ -4,6 +4,6 @@ main.c
 ^EXIT=(1|64)$
 ^SIGNAL=0$
 ^CONVERSION ERROR$
-^.*error: assigns clause target must be an lvalue or __CPROVER_POINTER_OBJECT expression$
+^.*error: assigns clause target must be an lvalue or a __CPROVER_POINTER_OBJECT, __CPROVER_object_from, __CPROVER_object_slice expression$
 --
 Checks whether type checking rejects literal constants in assigns clause.

--- a/src/ansi-c/cprover_builtin_headers.h
+++ b/src/ansi-c/cprover_builtin_headers.h
@@ -122,4 +122,8 @@ __CPROVER_bool __CPROVER_overflow_unary_minus();
 
 // enumerations
 __CPROVER_bool __CPROVER_enum_is_in_range();
+
+// contracts
+__CPROVER_size_t __CPROVER_object_from(void *); 
+__CPROVER_size_t __CPROVER_object_slice(void *, __CPROVER_size_t);
 // clang-format on

--- a/src/goto-instrument/contracts/havoc_assigns_clause_targets.h
+++ b/src/goto-instrument/contracts/havoc_assigns_clause_targets.h
@@ -86,6 +86,16 @@ private:
   /// DEAD __car_ub
   /// ```
   ///
+  /// Generates these instructions for an object slice target:
+  /// ```
+  /// IF !__car_writable GOTO skip_target
+  /// __CPROVER_havoc_slize(__car_lb, car.target_size)
+  /// skip_target: SKIP
+  /// DEAD __car_writable
+  /// DEAD __car_lb
+  /// DEAD __car_ub
+  /// ```
+  ///
   /// And generate these instructions otherwise:
   ///
   /// ```

--- a/src/goto-instrument/contracts/instrument_spec_assigns.h
+++ b/src/goto-instrument/contracts/instrument_spec_assigns.h
@@ -57,6 +57,14 @@ public:
   }
 };
 
+/// method to use to havoc a target
+enum class car_havoc_methodt
+{
+  HAVOC_OBJECT,
+  HAVOC_SLICE,
+  NONDET_ASSIGN
+};
+
 /// Class that represents a normalized conditional address range, with:
 /// - condition expression
 /// - target expression
@@ -73,7 +81,8 @@ public:
     const exprt &_target_size,
     const symbol_exprt &_validity_var,
     const symbol_exprt &_lower_bound_var,
-    const symbol_exprt &_upper_bound_var)
+    const symbol_exprt &_upper_bound_var,
+    const car_havoc_methodt _havoc_method)
     : exprt(
         irep_idt{},
         typet{},
@@ -83,10 +92,14 @@ public:
          _target_size,
          _validity_var,
          _lower_bound_var,
-         _upper_bound_var})
+         _upper_bound_var}),
+      havoc_method(_havoc_method)
   {
     add_source_location() = _target.source_location();
   }
+
+  /// Method to use to havod the target
+  const car_havoc_methodt havoc_method;
 
   /// Condition expression. When this condition holds the target is allowed
   const exprt &condition() const

--- a/src/goto-instrument/contracts/utils.h
+++ b/src/goto-instrument/contracts/utils.h
@@ -219,6 +219,15 @@ public:
   {
     goto_convertt::clean_expr(guard, dest, mode, true);
   }
+
+  void do_havoc_slice(
+    const symbol_exprt &function,
+    const exprt::operandst &arguments,
+    goto_programt &dest,
+    const irep_idt &mode)
+  {
+    goto_convertt::do_havoc_slice(nil_exprt{}, function, arguments, dest, mode);
+  }
 };
 
 /// Returns an \ref irep_idt that essentially says that


### PR DESCRIPTION
Adds support the following targets in assigns clauses:
-  ` __CPROVER_object_from(ptr)`:  allows to assign all remaining bytes of the object, starting at the given address.
- `__CPROVER_object_slice(ptr, size)`: allows to assign size bytes of the object starting at the given address.

Both targets are translated to `__CPROVER_havoc_slice` for contract replacement.

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [x] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [N/A] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.
