### PR TITLE
Conversion of `pointer_object_exprt` and `pointer_offset_exprt` for new SMT backend

### DIFF
--- a/regression/cbmc-incr-smt2/pointers/pointer_object.c
+++ b/regression/cbmc-incr-smt2/pointers/pointer_object.c
@@ -1,0 +1,20 @@
+int main()
+{
+  int a = 10;
+  int nondet_bool;
+  int flag = 1;
+
+  int *b = &a;
+  int *c = nondet_bool ? &a : 0;
+  int *d = flag ? &a : 0;
+  int *e;
+
+  // __CPROVER_same_object is True when
+  // `__CPROVER_pointer_object(a) == __CPROVER_pointer_object(b)`
+  __CPROVER_assert(
+    __CPROVER_same_object(b, c), "expected fail as c can be null");
+  __CPROVER_assert(
+    __CPROVER_same_object(b, d), "expected success because d is &a");
+  __CPROVER_assert(
+    __CPROVER_same_object(b, e), "expected fail as e can be null");
+}

--- a/regression/cbmc-incr-smt2/pointers/pointer_object.desc
+++ b/regression/cbmc-incr-smt2/pointers/pointer_object.desc
@@ -1,0 +1,10 @@
+CORE
+pointer_object.c
+--trace --verbosity 10
+\[main\.assertion\.1\] line \d+ expected fail as c can be null: FAILURE
+\[main\.assertion\.2\] line \d+ expected success because d is &a: SUCCESS
+\[main\.assertion\.3\] line \d+ expected fail as e can be null: FAILURE
+^EXIT=10$
+^SIGNAL=0$
+--
+--

--- a/regression/cbmc-incr-smt2/pointers/pointer_object2.c
+++ b/regression/cbmc-incr-smt2/pointers/pointer_object2.c
@@ -1,0 +1,14 @@
+#include <assert.h>
+#include <stdbool.h>
+
+int main()
+{
+  int x;
+  int y;
+  int z;
+  bool nondet1;
+  bool nondet2;
+  int *a = nondet1 ? &x : &y;
+  int *b = nondet2 ? &y : &z;
+  __CPROVER_assert(!__CPROVER_same_object(a, b), "Can be violated.");
+}

--- a/regression/cbmc-incr-smt2/pointers/pointer_object2.desc
+++ b/regression/cbmc-incr-smt2/pointers/pointer_object2.desc
@@ -1,0 +1,17 @@
+CORE
+pointer_object2.c
+--trace --verbosity 10
+\[main\.assertion\.1\] line 13 Can be violated.: FAILURE
+nondet1=FALSE
+nondet2=TRUE
+^VERIFICATION FAILED$
+^EXIT=10$
+^SIGNAL=0$
+--
+--
+Ensure that two variables which can get assigned the address of the
+same object satisfy the __CPROVER_same_object predicate. In the code
+under test, we negate the predicate to be able to get a failure and a
+trace which we can then match against expected values which guide
+through the path that leads to the two variables getting assigned the
+same object. 

--- a/regression/cbmc-incr-smt2/pointers/pointer_object3.c
+++ b/regression/cbmc-incr-smt2/pointers/pointer_object3.c
@@ -1,0 +1,19 @@
+#define NULL (void *)0
+
+int main()
+{
+  int foo;
+
+  // The identifiers are allocated deterministically, so we want to check the
+  // following properties hold:
+
+  // The pointer object of NULL is always going to be zero.
+  __CPROVER_assert(
+    __CPROVER_POINTER_OBJECT(NULL) != 0,
+    "expected to fail with object ID == 0");
+  // In the case where the program contains a single address of operation,
+  // the pointer object is going to be 1.
+  __CPROVER_assert(
+    __CPROVER_POINTER_OBJECT(&foo) != 1,
+    "expected to fail with object ID == 1");
+}

--- a/regression/cbmc-incr-smt2/pointers/pointer_object3.desc
+++ b/regression/cbmc-incr-smt2/pointers/pointer_object3.desc
@@ -1,0 +1,13 @@
+CORE
+pointer_object3.c
+
+\[main\.assertion\.1] line \d+ expected to fail with object ID == 0: FAILURE
+\[main\.assertion\.2] line \d+ expected to fail with object ID == 1: FAILURE
+^VERIFICATION FAILED$
+^EXIT=10$
+^SIGNAL=0$
+--
+--
+Test that the assignment of object IDs to objects is deterministic:
+* 0 for the NULL object, and
+* 1 for the single object which is the result of an address of operation

--- a/regression/cbmc-incr-smt2/pointers/pointer_offset.c
+++ b/regression/cbmc-incr-smt2/pointers/pointer_offset.c
@@ -1,0 +1,16 @@
+int main()
+{
+  int a;
+  int *p = &a;
+  int *q = &a;
+
+  __CPROVER_assert(
+    __CPROVER_POINTER_OFFSET(p) != __CPROVER_POINTER_OFFSET(q),
+    "expected failure because offsets should be the same");
+
+  // TODO: Remove comments once pointer arithmetic works:
+
+  // *q = p + 2;
+
+  // __CPROVER_assert(__CPROVER_POINTER_OFFSET(p) != __CPROVER_POINTER_OFFSET(q), "expected failure");
+}

--- a/regression/cbmc-incr-smt2/pointers/pointer_offset.desc
+++ b/regression/cbmc-incr-smt2/pointers/pointer_offset.desc
@@ -1,0 +1,16 @@
+CORE
+pointer_offset.c
+--trace
+\[main\.assertion\.1\] line \d+ expected failure because offsets should be the same: FAILURE
+^VERIFICATION FAILED$
+^EXIT=10$
+^SIGNAL=0$
+--
+--
+Test that the pointer offset bits of two pointers pointing to
+the same object are equal.
+
+The test also contains a fragment of the test which doesn't work
+for now, but would be good to be added as soon as we get pointer
+arithmetic to work, so we can make sure that pointer offset fails
+appropriately.

--- a/regression/cbmc-incr-smt2/pointers/pointers_simple.c
+++ b/regression/cbmc-incr-smt2/pointers/pointers_simple.c
@@ -1,0 +1,14 @@
+int main()
+{
+  int a = 10;
+  int *b = &a;
+  int c;
+
+  *b = 12;
+
+  __CPROVER_assert(a != *b, "a should be different than b");
+  __CPROVER_assert(a == *b, "a should not be different than b");
+  __CPROVER_assert(
+    *b != c,
+    "c can get assigned a value that makes it the same what b points to");
+}

--- a/regression/cbmc-incr-smt2/pointers/pointers_simple.desc
+++ b/regression/cbmc-incr-smt2/pointers/pointers_simple.desc
@@ -1,0 +1,12 @@
+CORE
+pointers_simple.c
+--trace
+Passing problem to incremental SMT2 solving
+\[main\.assertion.\d\] line \d a should be different than b: FAILURE
+\[main\.assertion.\d\] line \d+ a should not be different than b: SUCCESS
+\[main\.assertion.\d\] line \d+ c can get assigned a value that makes it the same what b points to: FAILURE
+c=12
+^EXIT=10$
+^SIGNAL=0$
+--
+--

--- a/src/solvers/smt2_incremental/convert_expr_to_smt.cpp
+++ b/src/solvers/smt2_incremental/convert_expr_to_smt.cpp
@@ -1143,6 +1143,29 @@ static smt_termt convert_expr_to_smt(
 }
 
 static smt_termt convert_expr_to_smt(
+  const pointer_object_exprt &pointer_object,
+  const sub_expression_mapt &converted)
+{
+  const auto type =
+    type_try_dynamic_cast<bitvector_typet>(pointer_object.type());
+  INVARIANT(type, "Pointer object should have a bitvector-based type.");
+  const auto converted_expr = converted.at(pointer_object.pointer());
+  const std::size_t width = type->get_width();
+  const std::size_t object_bits = config.bv_encoding.object_bits;
+  INVARIANT(
+    width >= object_bits,
+    "Width should be at least as big as the number of object bits.");
+  const std::size_t ext = width - object_bits;
+  const auto extract_op = smt_bit_vector_theoryt::extract(
+    width - 1, width - object_bits)(converted_expr);
+  if(ext > 0)
+  {
+    return smt_bit_vector_theoryt::zero_extend(ext)(extract_op);
+  }
+  return extract_op;
+}
+
+static smt_termt convert_expr_to_smt(
   const shl_overflow_exprt &shl_overflow,
   const sub_expression_mapt &converted)
 {
@@ -1437,10 +1460,13 @@ static smt_termt dispatch_expr_to_smt_conversion(
   else if(expr.id()==ID_pointer_offset)
   {
   }
-  else if(expr.id()==ID_pointer_object)
-  {
-  }
 #endif
+  else if(
+    const auto pointer_object =
+      expr_try_dynamic_cast<pointer_object_exprt>(expr))
+  {
+    return convert_expr_to_smt(*pointer_object, converted);
+  }
   if(
     const auto is_dynamic_object =
       expr_try_dynamic_cast<is_dynamic_object_exprt>(expr))

--- a/unit/solvers/smt2_incremental/convert_expr_to_smt.cpp
+++ b/unit/solvers/smt2_incremental/convert_expr_to_smt.cpp
@@ -1242,3 +1242,39 @@ TEST_CASE(
     CHECK(converted == expected);
   }
 }
+
+TEST_CASE("pointer_offset_exprt to SMT conversion", "[core][smt2_incremental]")
+{
+  // The config lines are necessary to ensure that pointer width in configured.
+  config.ansi_c.mode = configt::ansi_ct::flavourt::GCC;
+  config.ansi_c.set_arch_spec_x86_64();
+  config.bv_encoding.object_bits = 8;
+
+  const auto pointer_type = pointer_typet(unsigned_int_type(), 64 /* bits */);
+  const pointer_offset_exprt pointer_offset{
+    symbol_exprt{"foo", pointer_type}, pointer_type};
+
+  SECTION("simple pointer_offset_exprt conversion")
+  {
+    const auto converted = convert_expr_to_smt(pointer_offset);
+    const auto expected =
+      smt_bit_vector_theoryt::zero_extend(8)(smt_bit_vector_theoryt::extract(
+        55, 0)(smt_identifier_termt("foo", smt_bit_vector_sortt(64))));
+    CHECK(converted == expected);
+  }
+
+  SECTION("Invariant checks")
+  {
+    const cbmc_invariants_should_throwt invariants_throw;
+    SECTION("pointer_offset_exprt's operand type should be a bitvector type")
+    {
+      auto pointer_offset_copy = pointer_offset;
+      pointer_offset_copy.type() = bool_typet{};
+      REQUIRE_THROWS_MATCHES(
+        convert_expr_to_smt(pointer_offset_copy),
+        invariant_failedt,
+        invariant_failure_containing(
+          "Pointer offset should have a bitvector-based type."));
+    }
+  }
+}

--- a/unit/solvers/smt2_incremental/convert_expr_to_smt.cpp
+++ b/unit/solvers/smt2_incremental/convert_expr_to_smt.cpp
@@ -8,6 +8,7 @@
 #include <util/constructor_of.h>
 #include <util/format.h>
 #include <util/namespace.h>
+#include <util/pointer_predicates.h>
 #include <util/std_expr.h>
 #include <util/symbol_table.h>
 
@@ -1184,5 +1185,60 @@ TEST_CASE(
                      smt_bit_vector_theoryt::concat(
                        smt_bit_vector_constant_termt{1, 8},
                        smt_bit_vector_constant_termt{0, 56})));
+  }
+}
+
+TEST_CASE(
+  "expr to smt conversion for pointer object expression",
+  "[core][smt2_incremental]")
+{
+  // The config lines are necessary to ensure that pointer width in configured.
+  config.ansi_c.mode = configt::ansi_ct::flavourt::GCC;
+  config.ansi_c.set_arch_spec_x86_64();
+  config.bv_encoding.object_bits = 8;
+
+  const auto pointer_type = pointer_typet(unsigned_int_type(), 64 /* bits */);
+  const pointer_object_exprt foo{
+    symbol_exprt{"foo", pointer_type}, pointer_type};
+  const pointer_object_exprt foobar{
+    symbol_exprt{"foobar", pointer_type}, pointer_type};
+
+  SECTION("Pointer object expression")
+  {
+    const auto converted = convert_expr_to_smt(foo);
+    const auto expected =
+      smt_bit_vector_theoryt::zero_extend(56)(smt_bit_vector_theoryt::extract(
+        63, 56)(smt_identifier_termt("foo", smt_bit_vector_sortt(64))));
+    CHECK(converted == expected);
+  }
+
+  SECTION("Invariant checks")
+  {
+    const cbmc_invariants_should_throwt invariants_throw;
+    SECTION("Pointer object's operand type should be a bitvector type")
+    {
+      auto copy_of_foo = foo;
+      copy_of_foo.type() = bool_typet{};
+      REQUIRE_THROWS_MATCHES(
+        convert_expr_to_smt(copy_of_foo),
+        invariant_failedt,
+        invariant_failure_containing(
+          "Pointer object should have a bitvector-based type."));
+    }
+  }
+
+  SECTION("Comparison of pointer objects.")
+  {
+    const exprt comparison = notequal_exprt{foobar, foo};
+    INFO("Expression " + comparison.pretty(1, 0));
+    const auto converted = convert_expr_to_smt(comparison);
+    const auto bv1 =
+      smt_bit_vector_theoryt::zero_extend(56)(smt_bit_vector_theoryt::extract(
+        63, 56)(smt_identifier_termt("foo", smt_bit_vector_sortt(64))));
+    const auto bv2 =
+      smt_bit_vector_theoryt::zero_extend(56)(smt_bit_vector_theoryt::extract(
+        63, 56)(smt_identifier_termt("foobar", smt_bit_vector_sortt(64))));
+    const auto expected = smt_core_theoryt::distinct(bv2, bv1);
+    CHECK(converted == expected);
   }
 }


### PR DESCRIPTION
This PR adds the implementation (along with unit and regression tests)
for the conversion of `pointer_object_exprt`s and `pointer_offset_exprt`s for the new SMT backend.

(Because of some limitations for now in our support for arrays, pointer arithmetic, `pointer_offset_exprt`s are covered by unit tests only) 

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
