### PR TITLE
Crangler: also apply remove-static to declarations

### DIFF
--- a/regression/crangler/remove-static/remove_static1.c
+++ b/regression/crangler/remove-static/remove_static1.c
@@ -5,6 +5,8 @@ int foo()
 
 int bar();
 
+static void foobar2();
+
 static void foobar1()
 {
 }

--- a/regression/crangler/remove-static/remove_static1.desc
+++ b/regression/crangler/remove-static/remove_static1.desc
@@ -6,3 +6,4 @@ remove_static1.json
 ^EXIT=0$
 ^SIGNAL=0$
 --
+static\s+(void\s+)?foobar[12]\(\)$

--- a/src/crangler/c_wrangler.cpp
+++ b/src/crangler/c_wrangler.cpp
@@ -368,7 +368,7 @@ static void mangle_function(
   const c_wranglert::functiont &function_config,
   std::ostream &out)
 {
-  if(function_config.stub.has_value())
+  if(function_config.stub.has_value() && declaration.has_body())
   {
     // replace by stub
     out << function_config.stub.value();
@@ -398,6 +398,13 @@ static void mangle_function(
       out << t.text;
     for(auto &t : declaration.post_declarator)
       out << t.text;
+
+    if(!declaration.has_body())
+    {
+      for(auto &t : declaration.initializer)
+        out << t.text;
+      return;
+    }
 
     for(const auto &entry : function_config.contract)
       out << ' ' << CPROVER_PREFIX << entry.clause << '('
@@ -498,8 +505,7 @@ static void mangle(
   std::ostream &out)
 {
   auto name_opt = declaration.declared_identifier();
-  if(
-    declaration.is_function() && name_opt.has_value() && declaration.has_body())
+  if(declaration.is_function() && name_opt.has_value())
   {
     for(const auto &entry : config.functions)
     {


### PR DESCRIPTION
Taking functions out of file-local scope requires removing the "static"
keyword from both definitions as well as declarations.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
