### PR TITLE
CONTRACTS: handle locals with composite types when checking assigns clauses

### DIFF
--- a/regression/contracts/assigns-local-composite/main.c
+++ b/regression/contracts/assigns-local-composite/main.c
@@ -1,0 +1,104 @@
+struct st1
+{
+  int a;
+  int arr[10];
+};
+
+struct st2
+{
+  int a;
+  struct st1 arr[10];
+};
+
+struct st3
+{
+  struct st1 *s1;
+  struct st2 *s2;
+  struct st1 arr1[10];
+  struct st2 arr2[10];
+};
+
+enum tagt
+{
+  CHAR,
+  INT,
+  CHAR_PTR,
+  INT_ARR,
+  STRUCT_ST1_ARR
+};
+
+// clang-format off
+struct taggedt {
+  enum tagt tag;
+  union {
+    struct{ char a; };
+    struct{ int b; };
+    struct{ char *ptr; };
+    struct{ int arr[10]; };
+    struct{ struct st1 arr1[10]; };
+  };
+};
+// clang-format on
+
+int foo(int i) __CPROVER_assigns()
+{
+  // all accesses to locals should pass
+  int arr[10];
+  struct st1 s1;
+  struct st2 s2;
+  struct st1 dirty_s1;
+  struct st3 s3;
+  s3.s1 = &dirty_s1;
+  s3.s2 = malloc(sizeof(struct st2));
+
+  if(0 <= i && i < 10)
+  {
+    arr[i] = 0;
+    s1.a = 0;
+    s1.arr[i] = 0;
+    s2.a = 0;
+    s2.arr[i].a = 0;
+    s2.arr[i].arr[i] = 0;
+    s3.s1->a = 0;
+    s3.s1->arr[i] = 0;
+    s3.s2->a = 0;
+    s3.s2->arr[i].a = 0;
+    s3.s2->arr[i].arr[i] = 0;
+    *(&(s3.s2->arr[i].arr[0]) + i) = 0;
+    (&(s3.arr1[0]) + i)->arr[i] = 0;
+    (&((&(s3.arr2[0]) + i)->arr[i]))->a = 0;
+  }
+
+  struct taggedt tagged;
+  switch(tagged.tag)
+  {
+  case CHAR:
+    tagged.a = 0;
+    break;
+  case INT:
+    tagged.b = 0;
+    break;
+  case CHAR_PTR:
+    tagged.ptr = 0;
+    break;
+  case INT_ARR:
+    if(0 <= i && i < 10)
+      tagged.arr[i] = 0;
+    break;
+  case STRUCT_ST1_ARR:
+    if(0 <= i && i < 10)
+    {
+      tagged.arr1[i].a = 0;
+      tagged.arr1[i].arr[i] = 0;
+    }
+    break;
+  }
+
+  return 0;
+}
+
+void main()
+{
+  int i;
+  foo(i);
+}

--- a/regression/contracts/assigns-local-composite/test.desc
+++ b/regression/contracts/assigns-local-composite/test.desc
@@ -1,0 +1,12 @@
+CORE
+main.c
+--enforce-contract foo
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+--
+Checks that assigns clause checking explicitly checks assignments to locally 
+declared symbols with composite types, when they are dirty.
+Out of bounds accesses to locally declared arrays, structs, etc. 
+will be detected by assigns clause checking.

--- a/regression/contracts/assigns_type_checking_valid_cases/main.c
+++ b/regression/contracts/assigns_type_checking_valid_cases/main.c
@@ -41,6 +41,8 @@ void foo4(int a, int *b, int *c) __CPROVER_requires(c != NULL)
 
 void foo5(struct buf buffer) __CPROVER_assigns()
 {
+  // these are assignments to the function parameter which is a local symbol
+  // and should not generate checks
   buffer.data = NULL;
   buffer.len = 0;
 }

--- a/regression/contracts/assigns_type_checking_valid_cases/test.desc
+++ b/regression/contracts/assigns_type_checking_valid_cases/test.desc
@@ -8,8 +8,6 @@ main.c
 ^\[foo3.assigns.\d+\] line \d+ Check that y is assignable: SUCCESS$
 ^\[foo4.assigns.\d+\] line \d+ Check that \*c is assignable: SUCCESS$
 ^\[foo4.assigns.\d+\] line \d+ Check that \*x is assignable: SUCCESS$
-^\[foo5.assigns.\d+\] line \d+ Check that buffer.data is assignable: SUCCESS$
-^\[foo5.assigns.\d+\] line \d+ Check that buffer.len is assignable: SUCCESS$
 ^\[foo6.assigns.\d+\] line \d+ Check that \*buffer->data is assignable: SUCCESS$
 ^\[foo6.assigns.\d+\] line \d+ Check that buffer->len is assignable: SUCCESS$
 ^\[foo7.assigns.\d+\] line \d+ Check that \*buffer->data is assignable: SUCCESS$

--- a/src/goto-instrument/contracts/instrument_spec_assigns.h
+++ b/src/goto-instrument/contracts/instrument_spec_assigns.h
@@ -574,23 +574,29 @@ protected:
     const car_exprt &freed_car,
     goto_programt &dest) const;
 
-  /// Returns true iff a `DECL x` must be added to the local write set.
-  ///
-  /// A variable is called 'dirty' if its address gets taken at some point in
-  /// the program.
-  ///
-  /// Assuming the goto program is obtained from a structured C program that
-  /// passed C compiler checks, non-dirty variables can only be assigned to
-  /// directly by name, cannot escape their lexical scope, and are always safe
-  /// to assign. Hence, we only track dirty variables in the write set.
+  /// Returns true iff a `DECL x` must be explicitly added to the write set.
+  /// @see must_track_decl_or_dead.
   bool must_track_decl(
     const goto_programt::const_targett &target,
     const optionalt<cfg_infot> &cfg_info_opt) const;
 
-  /// Returns true iff a `DEAD x` must be processed to update the local write
-  /// set. The conditions are the same than for tracking a `DECL x` instruction.
+  /// Returns true iff a `DEAD x` must be processed to update the write set.
+  /// @see must_track_decl_or_dead.
   bool must_track_dead(
     const goto_programt::const_targett &target,
+    const optionalt<cfg_infot> &cfg_info_opt) const;
+
+  /// \brief Returns true iff a function-local symbol must be tracked.
+  ///
+  /// A local is called 'dirty' if its address gets taken at some point in
+  /// the program.
+  ///
+  /// Assuming the goto program is obtained from a structured C program that
+  /// passed C compiler checks, non-dirty locals can only be assigned to
+  /// directly by name, cannot escape their lexical scope, and are always safe
+  /// to assign. Hence, we only track dirty locals in the write set.
+  bool must_track_decl_or_dead(
+    const irep_idt &ident,
     const optionalt<cfg_infot> &cfg_info_opt) const;
 
   /// Returns true iff an `ASSIGN lhs := rhs` instruction must be instrumented.

--- a/src/goto-instrument/contracts/utils.h
+++ b/src/goto-instrument/contracts/utils.h
@@ -11,6 +11,7 @@ Date: September 2021
 #ifndef CPROVER_GOTO_INSTRUMENT_CONTRACTS_UTILS_H
 #define CPROVER_GOTO_INSTRUMENT_CONTRACTS_UTILS_H
 
+// clang-format off
 #include <vector>
 
 #include <analyses/dirty.h>
@@ -22,7 +23,9 @@ Date: September 2021
 #include <goto-programs/goto_model.h>
 
 #include <util/expr_cast.h>
+#include <util/byte_operators.h>
 #include <util/message.h>
+// clang-format on
 
 /// \brief A class that overrides the low-level havocing functions in the base
 ///        utility class, to havoc only when expressions point to valid memory,
@@ -188,6 +191,65 @@ public:
   {
     const auto &symbol = ns.lookup(ident);
     return locals.is_local(ident) || symbol.is_parameter;
+  }
+
+  /// Returns true iff `expr` is an access to a locally declared symbol
+  /// or parameter symbol, without any dereference/address_of operations.
+  bool is_local_composite_access(const exprt &expr) const
+  {
+    // case-splitting on the lhs structure copied from symex_assignt::assign_rec
+    if(expr.id() == ID_symbol)
+    {
+      return is_local(to_symbol_expr(expr).get_identifier());
+    }
+    else if(expr.id() == ID_index)
+    {
+      return is_local_composite_access(to_index_expr(expr).array());
+    }
+    else if(expr.id() == ID_member)
+    {
+      const typet &type = to_member_expr(expr).struct_op().type();
+      if(
+        type.id() == ID_struct || type.id() == ID_struct_tag ||
+        type.id() == ID_union || type.id() == ID_union_tag)
+      {
+        return is_local_composite_access(to_member_expr(expr).compound());
+      }
+      else
+      {
+        throw unsupported_operation_exceptiont(
+          "is_local_composite_access: unexpected assignment to member of '" +
+          type.id_string() + "'");
+      }
+    }
+    else if(expr.id() == ID_if)
+    {
+      return is_local_composite_access(to_if_expr(expr).true_case()) &&
+             is_local_composite_access(to_if_expr(expr).false_case());
+    }
+    else if(expr.id() == ID_typecast)
+    {
+      return is_local_composite_access(to_typecast_expr(expr).op());
+    }
+    else if(
+      expr.id() == ID_byte_extract_little_endian ||
+      expr.id() == ID_byte_extract_big_endian)
+    {
+      return is_local_composite_access(to_byte_extract_expr(expr).op());
+    }
+    else if(expr.id() == ID_complex_real)
+    {
+      return is_local_composite_access(to_complex_real_expr(expr).op());
+    }
+    else if(expr.id() == ID_complex_imag)
+    {
+      return is_local_composite_access(to_complex_imag_expr(expr).op());
+    }
+    else
+    {
+      // matches ID_address_of, ID_dereference, etc.
+      return false;
+    }
   }
 
   /// returns the current target instruction


### PR DESCRIPTION
We now detect and skip checking assignments to members of local symbols that have composite types (i.e. local objects are not explicitly tracked and assignments to them are implicitly allowed).
As a results OOB accesses to locals must be checked using `--pointer-checks`.

Before, these assignments would cause assigns clause checking to systematically fail, because the targets are not tracked in the write set.

Added debug output prints (when `--verbosity 10`) to give users insight into which targets are tracked, which local statics are automatically included in the write set, which assignments are checked or skipped.

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.
