### PR TITLE
Failing test to demonstrate need for extensionality rule

### DIFF
--- a/regression/cbmc/Array_UF22/main.c
+++ b/regression/cbmc/Array_UF22/main.c
@@ -1,0 +1,6 @@
+int main()
+{
+  int a[2] = {0};
+  int b[2] = {0};
+  __CPROVER_assert(__CPROVER_array_equal(a, b), "equal");
+}

--- a/regression/cbmc/Array_UF22/test.desc
+++ b/regression/cbmc/Array_UF22/test.desc
@@ -1,0 +1,10 @@
+KNOWNBUG broken-smt-backend
+main.c
+--arrays-uf-always --no-propagation
+^VERIFICATION SUCCESSFUL$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--
+This test demonstrates the need for implementing the extensionality rule.


### PR DESCRIPTION
All existing tests rely on indexed access to arrays, which is covered by
the read-over-write axiom.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
