### PR TITLE
Flattening: support index expressions over zero bitwidth arrays [blocks: #6862]

### DIFF
--- a/src/solvers/flattening/boolbv_index.cpp
+++ b/src/solvers/flattening/boolbv_index.cpp
@@ -36,9 +36,6 @@ bvt boolbvt::convert_index(const index_exprt &expr)
 
     std::size_t width=boolbv_width(expr.type());
 
-    if(width==0)
-      return conversion_failed(expr);
-
     // see if the array size is constant
 
     if(is_unbounded_array(array_type))
@@ -289,9 +286,6 @@ bvt boolbvt::convert_index(
   const array_typet &array_type = to_array_type(array.type());
 
   std::size_t width = boolbv_width(array_type.element_type());
-
-  if(width==0)
-    return conversion_failed(array);
 
   // TODO: If the underlying array can use one of the
   // improvements given above then it may be better to use


### PR DESCRIPTION
There is not really anything wrong in having empty bitvectors, which we
otherwise already support (as of e021eef4).

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
