### PR TITLE
CONTRACTS: havoc all statics by default

### DIFF
--- a/doc/cprover-manual/contracts-functions.md
+++ b/doc/cprover-manual/contracts-functions.md
@@ -6,6 +6,10 @@ These clauses formally describe the specification of a function.
 CBMC also provides a series of built-in constructs to be used with functions
 contracts (e.g., _history variables_, _quantifiers_, and _memory predicates_).
 
+When a function contract is checked, the tool automatically havocs all static variables
+of the program (to start the analysis in an arbitrary state), in the same way
+as using `--nondet-static` would do. If one wishes not to havoc some static variables,
+then `--nondet-static-exclude name-of-variable` can be used.
 ## Overview
 
 Take a look at the example below.

--- a/doc/cprover-manual/contracts-loops.md
+++ b/doc/cprover-manual/contracts-loops.md
@@ -9,6 +9,11 @@ These clauses formally describe an abstraction of a loop for the purpose of a pr
 CBMC also provides a series of built-in constructs
 to aid writing loop contracts (e.g., _history variables_ and _quantifiers_).
 
+When a function contract is checked, the tool automatically havocs all static variables
+of the program (to start the analysis in an arbitrary state), in the same way
+as using `--nondet-static` would do. If one wishes not to havoc some static variables,
+then `--nondet-static-exclude name-of-variable` can be used.
+
 ## Overview
 
 Consider an implementation of the [binary search algorithm] below.

--- a/regression/contracts/assigns_enforce_17/main.c
+++ b/regression/contracts/assigns_enforce_17/main.c
@@ -1,6 +1,6 @@
 #include <assert.h>
 
-int x = 0;
+int x;
 
 void pure() __CPROVER_assigns()
 {
@@ -10,6 +10,7 @@ void pure() __CPROVER_assigns()
 
 int main()
 {
+  x = 0;
   pure();
   assert(x == 0);
   return 0;

--- a/regression/contracts/assigns_enforce_17/test.desc
+++ b/regression/contracts/assigns_enforce_17/test.desc
@@ -7,5 +7,5 @@ main.c
 ^VERIFICATION SUCCESSFUL$
 --
 --
-Checks whether verification correctly distincts local variables
+Checks whether verification correctly distinguishes local variables
 and global variables with same name when checking frame conditions.

--- a/regression/contracts/assigns_function_pointer/main.c
+++ b/regression/contracts/assigns_function_pointer/main.c
@@ -1,7 +1,7 @@
 #include <assert.h>
 #include <stddef.h>
 
-int x = 0;
+int x;
 
 struct fptr_t
 {
@@ -26,7 +26,7 @@ void bar(struct fptr_t *s, void (**f)()) __CPROVER_assigns(s->f, *f)
 
 int main()
 {
-  assert(x == 0);
+  x = 0;
   struct fptr_t s;
   void (*f)();
   bar(&s, &f);

--- a/regression/contracts/assigns_function_pointer/test.desc
+++ b/regression/contracts/assigns_function_pointer/test.desc
@@ -3,7 +3,6 @@ main.c
 --enforce-contract bar
 ^EXIT=0$
 ^SIGNAL=0$
-^\[main.assertion.\d+\] line \d+ assertion x \=\= 0: SUCCESS$
 ^\[bar.assigns.\d+\] line \d+ Check that s->f is assignable: SUCCESS$
 ^\[bar.assigns.\d+\] line \d+ Check that \*f is assignable: SUCCESS$
 ^\[main.assertion.\d+\] line \d+ assertion x \=\= 1: SUCCESS$

--- a/regression/contracts/assigns_replace_08/main.c
+++ b/regression/contracts/assigns_replace_08/main.c
@@ -1,7 +1,6 @@
 #include <stdlib.h>
 
-int x;
-int *z = &x;
+int *z;
 
 void bar() __CPROVER_assigns(*z)
 {
@@ -14,6 +13,8 @@ void foo() __CPROVER_assigns()
 
 int main()
 {
+  int x;
+  z = &x;
   foo();
   return 0;
 }

--- a/regression/contracts/assigns_replace_08/test.desc
+++ b/regression/contracts/assigns_replace_08/test.desc
@@ -11,4 +11,4 @@ main.c
 ^VERIFICATION SUCCESSFUL$
 --
 Checks whether CBMC properly evaluates subset relationship on assigns
-during replacement.
+during replacement when the targets are global variables.

--- a/regression/contracts/assigns_replace_09/main.c
+++ b/regression/contracts/assigns_replace_09/main.c
@@ -1,7 +1,6 @@
 #include <stdlib.h>
 
-int x;
-int *z = &x;
+int *z;
 
 void bar() __CPROVER_assigns(*z)
 {
@@ -14,6 +13,8 @@ static void foo() __CPROVER_assigns(*z)
 
 int main()
 {
+  int x;
+  z = &x;
   foo();
   return 0;
 }

--- a/regression/contracts/assigns_replace_09/test.desc
+++ b/regression/contracts/assigns_replace_09/test.desc
@@ -10,4 +10,4 @@ main.c
 ^Condition: \!not\_found$
 --
 Checks whether CBMC properly evaluates subset relationship on assigns
-during replacement with static functions.
+during replacement with static functions when targets are global variables.

--- a/regression/contracts/assigns_validity_pointer_02/main.c
+++ b/regression/contracts/assigns_validity_pointer_02/main.c
@@ -3,17 +3,18 @@
 
 int *z;
 
-void bar(int *x, int *y) __CPROVER_assigns(*x, *y) __CPROVER_requires(*x > 0)
-  __CPROVER_ensures(*x == 3 && (y == NULL || *y == 5))
+void bar(int *x, int *y)
 {
   *x = 3;
   if(y != NULL)
     *y = 5;
 }
 
-void baz() __CPROVER_assigns(*z) __CPROVER_ensures(z == NULL || *z == 7)
+void baz(int c)
 {
-  if(z != NULL)
+  // does a side effect on a global, but
+  // in the calling context of foo the branch is dead
+  if(c)
     *z = 7;
 }
 
@@ -22,15 +23,13 @@ void foo(int *x) __CPROVER_assigns(*x) __CPROVER_requires(*x > 0)
 {
   bar(x, NULL);
   *x = 3;
-  z == NULL;
-  baz();
+  baz(0);
 }
 
 int main()
 {
   int n;
   foo(&n);
-
   assert(n == 3);
   return 0;
 }

--- a/regression/contracts/assigns_validity_pointer_02/test.desc
+++ b/regression/contracts/assigns_validity_pointer_02/test.desc
@@ -13,8 +13,7 @@ main.c
 ^\[postcondition.\d+\] file main.c line \d+ Check ensures clause: FAILURE$
 ^\[foo.\d+\] line \d+ Check that \*x is assignable: FAILURE$
 --
-Verification:
-This test checks support for a NULL pointer that is assigned to by
-a function (bar and baz). The calling function foo is being checked
-(by enforcing it's function contracts). As for bar and baz, their
-function contracts are ot being considered for this test.
+This test checks that assigns clause checking 
+is control-flow sensitive. The assignment to the global *z
+in baz is inhibited in the calling context of foo, so it does
+not violate the assigns clause of foo.

--- a/regression/contracts/contracts_with_function_pointers/main.c
+++ b/regression/contracts/contracts_with_function_pointers/main.c
@@ -1,7 +1,7 @@
 #include <assert.h>
 #include <stddef.h>
 
-int x = 0;
+int x;
 
 void foo(int *y)
 {
@@ -22,7 +22,7 @@ void bar(void (*fun_ptr)(), int *x) __CPROVER_requires(fun_ptr != NULL)
 
 int main()
 {
-  assert(x == 0);
+  x = 0;
   void (*fun_ptr)() = foo;
   bar(fun_ptr, &x);
   assert(x == 1);

--- a/regression/contracts/havoc-static/main.c
+++ b/regression/contracts/havoc-static/main.c
@@ -1,0 +1,20 @@
+int a = 0;       // should be havoced
+const int b = 0; // should not be havoced (const)
+int c = 0;       // should be havoced
+
+void foo() __CPROVER_requires(1) __CPROVER_ensures(1) __CPROVER_assigns()
+{
+  if(a)
+    __CPROVER_assert(0, "guarded by a");
+
+  if(b)
+    __CPROVER_assert(0, "guarded by b");
+
+  if(c)
+    __CPROVER_assert(0, "guarded by c");
+}
+
+void main()
+{
+  foo();
+}

--- a/regression/contracts/havoc-static/test-exclude.desc
+++ b/regression/contracts/havoc-static/test-exclude.desc
@@ -1,0 +1,12 @@
+CORE
+main.c
+--enforce-contract foo --nondet-static-exclude main.c:a --nondet-static-exclude main.c:c
+^\[foo.assertion.\d+\].* guarded by a: SUCCESS$
+^\[foo.assertion.\d+\].* guarded by b: SUCCESS$
+^\[foo.assertion.\d+\].* guarded by c: SUCCESS$
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+--
+Checks that we can exclude some statics from havocing.

--- a/regression/contracts/havoc-static/test.desc
+++ b/regression/contracts/havoc-static/test.desc
@@ -1,0 +1,13 @@
+CORE
+main.c
+--enforce-contract foo
+^\[foo.assertion.\d+\].* guarded by a: FAILURE$
+^\[foo.assertion.\d+\].* guarded by b: SUCCESS$
+^\[foo.assertion.\d+\].* guarded by c: FAILURE$
+^EXIT=10$
+^SIGNAL=0$
+^VERIFICATION FAILED$
+--
+--
+Checks that statics are havoced when using contracts, 
+unless they are marked const.

--- a/regression/contracts/history-pointer-enforce-10/main.c
+++ b/regression/contracts/history-pointer-enforce-10/main.c
@@ -8,7 +8,6 @@ struct pair
 };
 
 int z = 5;
-int w[10] = {0};
 
 void foo(struct pair *p) __CPROVER_assigns(*(p->y), z)
   __CPROVER_ensures(*(p->y) == __CPROVER_old(*(p->y)) + __CPROVER_old(z))
@@ -34,6 +33,8 @@ void baz(struct pair p) __CPROVER_assigns()
 
 int main()
 {
+  z = 5;
+  int w[10] = {0};
   struct pair *p = malloc(sizeof(*p));
   p->y = malloc(sizeof(*(p->y)));
   p->x = 2;
@@ -45,6 +46,5 @@ int main()
   bar(p);
   assert(*(p->y) == -1);
   baz(*p);
-
   return 0;
 }

--- a/src/goto-instrument/contracts/contracts.cpp
+++ b/src/goto-instrument/contracts/contracts.cpp
@@ -36,6 +36,7 @@ Date: February 2016
 #include <analyses/local_may_alias.h>
 #include <ansi-c/c_expr.h>
 #include <goto-instrument/havoc_utils.h>
+#include <goto-instrument/nondet_static.h>
 #include <langapi/language_util.h>
 
 #include "havoc_assigns_clause_targets.h"
@@ -1643,13 +1644,21 @@ void code_contractst::replace_calls(const std::set<std::string> &to_replace)
   goto_functions.update();
 }
 
-void code_contractst::apply_loop_contracts()
+void code_contractst::apply_loop_contracts(
+  const std::set<std::string> &to_exclude_from_nondet_init)
 {
   for(auto &goto_function : goto_functions.function_map)
     apply_loop_contract(goto_function.first, goto_function.second);
+
+  log.status() << "Adding nondeterministic initialization "
+                  "of static/global variables."
+               << messaget::eom;
+  nondet_static(goto_model, to_exclude_from_nondet_init);
 }
 
-void code_contractst::enforce_contracts(const std::set<std::string> &to_enforce)
+void code_contractst::enforce_contracts(
+  const std::set<std::string> &to_enforce,
+  const std::set<std::string> &to_exclude_from_nondet_init)
 {
   if(to_enforce.empty())
     return;
@@ -1660,4 +1669,9 @@ void code_contractst::enforce_contracts(const std::set<std::string> &to_enforce)
 
   for(const auto &function : to_enforce)
     enforce_contract(function);
+
+  log.status() << "Adding nondeterministic initialization "
+                  "of static/global variables."
+               << messaget::eom;
+  nondet_static(goto_model, to_exclude_from_nondet_init);
 }

--- a/src/goto-instrument/goto_instrument_parse_options.cpp
+++ b/src/goto-instrument/goto_instrument_parse_options.cpp
@@ -11,16 +11,17 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "goto_instrument_parse_options.h"
 
-#include <fstream>
-#include <iostream>
-#include <memory>
-
 #include <util/exception_utils.h>
 #include <util/exit_codes.h>
 #include <util/json.h>
+#include <util/options.h>
 #include <util/string2int.h>
 #include <util/string_utils.h>
 #include <util/version.h>
+
+#include <fstream>
+#include <iostream>
+#include <memory>
 
 #ifdef _MSC_VER
 #  include <util/unicode.h>
@@ -1146,15 +1147,19 @@ void goto_instrument_parse_optionst::instrument_goto_program()
       cmdline.get_values(FLAG_ENFORCE_CONTRACT).begin(),
       cmdline.get_values(FLAG_ENFORCE_CONTRACT).end());
 
+    std::set<std::string> to_exclude_from_nondet_static(
+      cmdline.get_values("nondet-static-exclude").begin(),
+      cmdline.get_values("nondet-static-exclude").end());
+
     // It’s important to keep the order of contracts instrumentation, i.e.,
     // first replacement then enforcement. We rely on contract replacement
     // and inlining of sub-function calls to properly annotate all
     // assignments.
     contracts.replace_calls(to_replace);
-    contracts.enforce_contracts(to_enforce);
+    contracts.enforce_contracts(to_enforce, to_exclude_from_nondet_static);
 
     if(cmdline.isset(FLAG_LOOP_CONTRACTS))
-      contracts.apply_loop_contracts();
+      contracts.apply_loop_contracts(to_exclude_from_nondet_static);
   }
 
   if(cmdline.isset("value-set-fi-fp-removal"))
@@ -1357,8 +1362,10 @@ void goto_instrument_parse_optionst::instrument_goto_program()
                     "of static/global variables except for "
                     "the specified ones."
                  << messaget::eom;
-
-    nondet_static(goto_model, cmdline.get_values("nondet-static-exclude"));
+    std::set<std::string> to_exclude(
+      cmdline.get_values("nondet-static-exclude").begin(),
+      cmdline.get_values("nondet-static-exclude").end());
+    nondet_static(goto_model, to_exclude);
   }
   else if(cmdline.isset("nondet-static"))
   {

--- a/src/goto-instrument/nondet_static.cpp
+++ b/src/goto-instrument/nondet_static.cpp
@@ -145,7 +145,7 @@ void nondet_static(goto_modelt &goto_model)
 /// \param except_values: list of symbol names that should not be updated.
 void nondet_static(
   goto_modelt &goto_model,
-  const optionst::value_listt &except_values)
+  const std::set<std::string> &except_values)
 {
   const namespacet ns(goto_model.symbol_table);
   std::set<std::string> to_exclude;

--- a/src/goto-instrument/nondet_static.h
+++ b/src/goto-instrument/nondet_static.h
@@ -20,7 +20,8 @@ Date: November 2011
 #ifndef CPROVER_GOTO_INSTRUMENT_NONDET_STATIC_H
 #define CPROVER_GOTO_INSTRUMENT_NONDET_STATIC_H
 
-#include <util/options.h>
+#include <set>
+#include <string>
 
 class goto_modelt;
 class namespacet;
@@ -37,6 +38,6 @@ void nondet_static(
 
 void nondet_static(goto_modelt &);
 
-void nondet_static(goto_modelt &, const optionst::value_listt &);
+void nondet_static(goto_modelt &, const std::set<std::string> &);
 
 #endif // CPROVER_GOTO_INSTRUMENT_NONDET_STATIC_H


### PR DESCRIPTION
For soundness, automatically havoc all statics as soon as loop or function contracts are checked (same effect as `--nondet-static`). Variables can still be manually excluded using `--nondet-static-exclude`.

Havocing is not activated if only `--replace-call-with-contract` is used in an otherwise classic harness-based proof (we already automatically detect static variables modified by a function and havoc them during replacement).

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [x] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.
