### PR TITLE
Fix for getting values of pointers in traces in new SMT backend

### DIFF
--- a/regression/cbmc-incr-smt2/pointers/pointer_values.c
+++ b/regression/cbmc-incr-smt2/pointers/pointer_values.c
@@ -1,0 +1,12 @@
+int main()
+{
+  int *a;
+  int *b = 0;
+  int *c;
+  __CPROVER_assume(c != 0);
+
+  __CPROVER_assert(
+    a != b, "should fail because a can be any pointer val, including NULL");
+  __CPROVER_assert(
+    a != c, "should fail because a and c can point to same object");
+}

--- a/regression/cbmc-incr-smt2/pointers/pointer_values.desc
+++ b/regression/cbmc-incr-smt2/pointers/pointer_values.desc
@@ -1,0 +1,12 @@
+CORE
+pointer_values.c
+--trace
+\[main\.assertion\.1\] line \d+ should fail because a can be any pointer val, including NULL: FAILURE
+\[main\.assertion\.2\] line \d+ should fail because a and c can point to same object: FAILURE
+a=\(\(signed int \*\)NULL\)
+c=\(signed int \*\)1
+^EXIT=10$
+^SIGNAL=0$
+--
+--
+Test printing of NULL pointer values in trace.

--- a/regression/cbmc-incr-smt2/pointers/pointer_values_2.c
+++ b/regression/cbmc-incr-smt2/pointers/pointer_values_2.c
@@ -1,0 +1,8 @@
+int main()
+{
+  int *a;
+  int *b;
+  __CPROVER_assume(a == 0xDEADBEEF);
+
+  __CPROVER_assert(a != b, "should fail as b can also be assigned 0xDEADBEEF");
+}

--- a/regression/cbmc-incr-smt2/pointers/pointer_values_2.desc
+++ b/regression/cbmc-incr-smt2/pointers/pointer_values_2.desc
@@ -1,0 +1,12 @@
+CORE
+pointer_values_2.c
+--trace --slice-formula
+\[main\.assertion\.1\] line \d should fail as b can also be assigned 0xDEADBEEF: FAILURE
+a=\(signed int \*\)3735928559
+b=\(signed int \*\)3735928559
+^EXIT=10$
+^SIGNAL=0$
+--
+--
+3735928559 is the decimal value of the hex constant 0xDEADBEEF that
+the pointer is assumed to point to in this example.


### PR DESCRIPTION
This PR changes the code that constructs bit vector terms from solver
values so that it now supports pointers.

This allows us to now see pointer values in traces in the new SMT backend.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
