### PR TITLE
Document and use malloc(0) behaviour

### DIFF
--- a/doc/cprover-manual/memory-primitives.md
+++ b/doc/cprover-manual/memory-primitives.md
@@ -122,12 +122,10 @@ configurations:
 |Flag                    |  Check                                            |
 |------------------------|---------------------------------------------------|
 | `--malloc-fail-null`   |  return NULL when emulating an allocation failure |
-| `--malloc-fail-assert` |  report a failed property upon allocation failure |
 | `--malloc-may-fail`    |  non-deterministically fail to allocate           |
 
-Note that the use of `--malloc-may-fail` also requires one of
-`--malloc-fail-null` or `--malloc-fail-assert` to be given. The following code
-example demonstrates the effect of these options:
+Note that the use of `--malloc-may-fail` also requires `--malloc-fail-null`. The
+following code example demonstrates the effect of these options:
 
 ```C
 int error = 0;
@@ -142,10 +140,6 @@ Under CBMC's default model of `malloc`, the `else` branch is unreachable.
 When running CBMC with `--malloc-fail-null --malloc-may-fail`, `p` would
 non-deterministically be set to `NULL`, making all branches in the above code
 reachable.
-
-When running CBMC with `--malloc-fail-assert --malloc-may-fail`, CBMC reports a
-failed property instead of returning `NULL`. The `else` branch remains
-unreachable.
 
 These malloc failure options need to be set when the C library model is added to
 the program. Typically this is upon invoking CBMC, but if the user has chosen to

--- a/doc/cprover-manual/properties.md
+++ b/doc/cprover-manual/properties.md
@@ -394,30 +394,3 @@ example, replacing functions or setting global variables with the `__CPROVER`
 prefix might make analysis impossible. To avoid doing this by accident, negative
 lookahead can be used. For example, `(?!__).*` matches all names not starting
 with `__`.
-
-### Malloc failure mode
-
-|Flag                    |  Check                                          |
-|------------------------|-------------------------------------------------|
-| `--malloc-fail-null`   |  in case malloc fails return NULL               |
-| `--malloc-fail-assert` |  in case malloc fails report as failed property |
-| `--malloc-may-fail`    |  malloc may non-deterministically fail          |
-
-Calling `malloc` may fail for a number of reasons and the function may return a
-NULL pointer. The users can choose if and how they want the `malloc`-related
-failures to occur. The option `--malloc-fail-null` results in `malloc` returning
-the NULL pointer when failing. The option `--malloc-fail-assert` places
-additional properties inside `malloc` that are checked and if failing the
-verification is terminated (by `assume(false)`). One such property is that the
-allocated size is not too large, i.e. internally representable. When neither of
-those two options are used, CBMC will assume that `malloc` does not fail.
-
-Malloc may also fail for external reasons which are not modelled by CProver. If
-you want to replicate this behaviour use the option `--malloc-may-fail` in
-conjunction with one of the above modes of failure.
-
-These malloc failure options need to be set when the C library model is added to
-the program. Typically this is upon invoking CBMC, but if the user has chosen to
-do so via `goto-instrument --add-library`, then the malloc failure mode needs to
-be specified with that `goto-instrument` invocation, i.e., as an option to
-`goto-instrument`.

--- a/src/ansi-c/library/stdlib.c
+++ b/src/ansi-c/library/stdlib.c
@@ -503,7 +503,7 @@ void *realloc(void *ptr, __CPROVER_size_t malloc_size)
   if(malloc_size==0)
   {
     free(ptr);
-    return malloc(1);
+    return malloc(0);
   }
 
   // this shouldn't move if the new size isn't bigger


### PR DESCRIPTION
realloc(ptr, 0) can return an object of minimal size. We used to use a
size of 1, but there does not seem to be any guarantee in the standard
that "minimal" refers to a value greater than 0, so use that size
instead. Using malloc(0) is safe with our library model, and is now also
documented.

While at it, also move this documentation to a place that has more
context.

Fixes: #6360

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [x] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
