### PR TITLE
CONTRACTS: track multiple malloc'd regions

### DIFF
--- a/regression/contracts/assigns_enforce_malloc_03/main.c
+++ b/regression/contracts/assigns_enforce_malloc_03/main.c
@@ -1,0 +1,18 @@
+#include <stdlib.h>
+
+void foo() __CPROVER_assigns()
+{
+  char *loc1 = malloc(1);
+  char *loc2 = malloc(1);
+  int c;
+  if(c)
+    *loc1 = 0;
+  else
+    *loc2 = 0;
+}
+
+int main()
+{
+  foo();
+  return 0;
+}

--- a/regression/contracts/assigns_enforce_malloc_03/test.desc
+++ b/regression/contracts/assigns_enforce_malloc_03/test.desc
@@ -1,0 +1,11 @@
+CORE
+main.c
+--enforce-contract foo
+^\[foo.assigns.\d+\].* Check that \*loc1 is assignable: SUCCESS$
+^\[foo.assigns.\d+\].* Check that \*loc2 is assignable: SUCCESS$
+^VERIFICATION SUCCESSFUL$
+^EXIT=0$
+^SIGNAL=0$
+--
+--
+Checks that multiple malloc'd objects are tracked by assigns clause checking.

--- a/src/goto-instrument/contracts/havoc_assigns_clause_targets.cpp
+++ b/src/goto-instrument/contracts/havoc_assigns_clause_targets.cpp
@@ -48,8 +48,8 @@ void havoc_assigns_clause_targetst::get_instructions(goto_programt &dest)
   for(const auto &pair : from_stack_alloc)
     havoc_if_valid(pair.second, havoc_program);
 
-  for(const auto &pair : from_heap_alloc)
-    havoc_if_valid(pair.second, havoc_program);
+  for(const auto &car : from_heap_alloc)
+    havoc_if_valid(car, havoc_program);
 
   for(const auto &pair : from_static_local)
   {

--- a/src/goto-instrument/contracts/instrument_spec_assigns.h
+++ b/src/goto-instrument/contracts/instrument_spec_assigns.h
@@ -209,7 +209,8 @@ public:
       functions(_functions),
       st(_st),
       ns(_st),
-      log(_message_handler)
+      log(_message_handler),
+      mode(st.lookup_ref(function_id).mode)
   {
   }
 
@@ -507,6 +508,9 @@ protected:
   /// Logger
   messaget log;
 
+  /// Language mode
+  const irep_idt &mode;
+
   /// Track and generate snaphsot instructions and target validity
   /// checking assertions for a conditional target group from an assigns clause
   void track_spec_target_group(
@@ -655,8 +659,9 @@ protected:
   using exprt_to_car_mapt =
     std::unordered_map<const exprt, const car_exprt, irep_hash>;
 
-  /// Map from malloc'd symbols to corresponding conditional address ranges.
-  exprt_to_car_mapt from_heap_alloc;
+  /// List of malloc'd conditional address ranges.
+  using car_expr_listt = std::list<car_exprt>;
+  car_expr_listt from_heap_alloc;
 
   const car_exprt &create_car_from_heap_alloc(const exprt &target);
 


### PR DESCRIPTION
For malloc we were fetching the address range from the malloc_return_value which is a unique global variable.  As a result we would only track a single malloc'd location at a time. we now track a list of objects, from all occurrences of the variable.

Added new debug prints to visualise inclusion checks.
- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [n/a] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [n/a] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.
