### PR TITLE
Allow to force-load symbols from the cprover library

### DIFF
--- a/src/ansi-c/ansi_c_language.cpp
+++ b/src/ansi-c/ansi_c_language.cpp
@@ -105,6 +105,15 @@ bool ansi_c_languaget::typecheck(
   const std::string &module,
   const bool keep_file_local)
 {
+  return typecheck(symbol_table, module, keep_file_local, {});
+}
+
+bool ansi_c_languaget::typecheck(
+  symbol_tablet &symbol_table,
+  const std::string &module,
+  const bool keep_file_local,
+  const std::set<irep_idt> &keep)
+{
   symbol_tablet new_symbol_table;
 
   if(ansi_c_typecheck(
@@ -117,7 +126,7 @@ bool ansi_c_languaget::typecheck(
   }
 
   remove_internal_symbols(
-    new_symbol_table, this->get_message_handler(), keep_file_local);
+    new_symbol_table, this->get_message_handler(), keep_file_local, keep);
 
   if(linking(symbol_table, new_symbol_table, get_message_handler()))
     return true;

--- a/src/ansi-c/ansi_c_language.h
+++ b/src/ansi-c/ansi_c_language.h
@@ -56,6 +56,12 @@ public:
     const std::string &module,
     const bool keep_file_local) override;
 
+  bool typecheck(
+    symbol_tablet &symbol_table,
+    const std::string &module,
+    const bool keep_file_local,
+    const std::set<irep_idt> &keep);
+
   bool can_keep_file_local() override
   {
     return true;

--- a/src/ansi-c/cprover_library.h
+++ b/src/ansi-c/cprover_library.h
@@ -27,16 +27,28 @@ std::string get_cprover_library_text(
   const std::set<irep_idt> &functions,
   const symbol_tablet &,
   const struct cprover_library_entryt[],
-  const std::string &prologue);
+  const std::string &prologue,
+  const bool force_load = false);
 
+/// Parses and typechecks the given src and adds its contents to the
+/// symbol table. Symbols with names found in `keep` will survive
+/// the symbol table cleanup pass and be found in the symbol_table.
 void add_library(
   const std::string &src,
   symbol_tablet &,
-  message_handlert &);
+  message_handlert &,
+  const std::set<irep_idt> &keep = {});
 
 void cprover_c_library_factory(
   const std::set<irep_idt> &functions,
   symbol_tablet &,
   message_handlert &);
 
+/// Load the requested function symbols from the cprover library
+/// and add them to the symbol table regardless of
+/// the library config flags and usage.
+void cprover_c_library_factory_force_load(
+  const std::set<irep_idt> &functions,
+  symbol_tablet &symbol_table,
+  message_handlert &message_handler);
 #endif // CPROVER_ANSI_C_CPROVER_LIBRARY_H

--- a/src/linking/remove_internal_symbols.cpp
+++ b/src/linking/remove_internal_symbols.cpp
@@ -109,6 +109,30 @@ void remove_internal_symbols(
   message_handlert &mh,
   const bool keep_file_local)
 {
+  remove_internal_symbols(symbol_table, mh, keep_file_local, {});
+}
+
+/// Removes internal symbols from a symbol table
+/// A symbol is EXPORTED if it is a
+/// * non-static function with body that is not extern inline
+/// * symbol used in an EXPORTED symbol
+/// * type used in an EXPORTED symbol
+///
+///          Read
+///          http://gcc.gnu.org/ml/gcc/2006-11/msg00006.html
+///          on "extern inline"
+/// \param symbol_table: symbol table to clean up
+/// \param mh: log handler
+/// \param keep_file_local: keep file-local functions with bodies even if we
+///                         would otherwise remove them
+/// \param keep: set of symbol names to keep in the symbol table regardless
+///              of usage or kind
+void remove_internal_symbols(
+  symbol_tablet &symbol_table,
+  message_handlert &mh,
+  const bool keep_file_local,
+  const std::set<irep_idt> &keep)
+{
   namespacet ns(symbol_table);
   find_symbols_sett exported;
   messaget log(mh);
@@ -130,6 +154,8 @@ void remove_internal_symbols(
   special.insert("__placement_new_array");
   special.insert("__delete");
   special.insert("__delete_array");
+  // plus any extra symbols we wish to keep
+  special.insert(keep.begin(), keep.end());
 
   for(symbol_tablet::symbolst::const_iterator
       it=symbol_table.symbols.begin();

--- a/src/linking/remove_internal_symbols.h
+++ b/src/linking/remove_internal_symbols.h
@@ -12,11 +12,21 @@ Author: Daniel Kroening
 #ifndef CPROVER_LINKING_REMOVE_INTERNAL_SYMBOLS_H
 #define CPROVER_LINKING_REMOVE_INTERNAL_SYMBOLS_H
 
+#include <util/irep.h>
+
+#include <set>
+
 class message_handlert;
 
 void remove_internal_symbols(
   class symbol_tablet &symbol_table,
   message_handlert &,
   const bool);
+
+void remove_internal_symbols(
+  class symbol_tablet &symbol_table,
+  message_handlert &,
+  const bool keep_file_local,
+  const std::set<irep_idt> &keep);
 
 #endif // CPROVER_LINKING_REMOVE_INTERNAL_SYMBOLS_H


### PR DESCRIPTION
The existing behaviour of `cprover_c_library_factory` is to load functions only if they already occur in the symbol table. This makes it impossible to load a library function unless a header declaring this function was included in the user's program and the function was actually used in the program.

This patch makes it possible to load functions of the cprover library even if they not already found in the symbol table and makes sure they survive the `remove_internal_symbols` cleanup pass.

The use case for this is to be able to programatically load functions in the symbol table before generating code that uses these functions as part of function contracts instrumentation. 

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [N/A] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [N/A] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [N/A] My commit message includes data points confirming performance improvements (if claimed).
- [N/A] My PR is restricted to a single feature or bugfix.
- [N/A] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

