### PR TITLE
associate variables' names to tmp_post

### DIFF
--- a/regression/goto-cc-cbmc/tmp_post_with_name/main.c
+++ b/regression/goto-cc-cbmc/tmp_post_with_name/main.c
@@ -1,0 +1,10 @@
+#include <assert.h>
+
+int main(int argc, char **argv)
+{
+  char *ptr;
+  ptr = malloc(2);
+  ptr += 2;
+  char c = *ptr++;
+  return 0;
+}

--- a/regression/goto-cc-cbmc/tmp_post_with_name/test.desc
+++ b/regression/goto-cc-cbmc/tmp_post_with_name/test.desc
@@ -1,0 +1,10 @@
+CORE
+main.c
+--pointer-check
+^EXIT=10$
+^SIGNAL=0$
+^\[main\.pointer_dereference\.5\] line 8 dereference failure: pointer outside object bounds in \*tmp_post_ptr: FAILURE
+\*\* 1 of [0-9]* failed 
+^VERIFICATION FAILED$
+--
+^warning: ignoring

--- a/src/goto-programs/goto_convert_side_effect.cpp
+++ b/src/goto-programs/goto_convert_side_effect.cpp
@@ -314,7 +314,14 @@ void goto_convertt::remove_post(
   if(result_is_used)
   {
     exprt tmp = op;
-    make_temp_symbol(tmp, "post", dest, mode);
+    std::string suffix = "post";
+    if(auto sym_expr = expr_try_dynamic_cast<symbol_exprt>(tmp))
+    {
+      const irep_idt &base_name = ns.lookup(*sym_expr).base_name;
+      suffix += "_" + id2string(base_name);
+    }
+
+    make_temp_symbol(tmp, suffix, dest, mode);
     expr.swap(tmp);
   }
   else


### PR DESCRIPTION
<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->
For pointer dereference `(*ptr++)` with side effect, the existing CBMC `goto_convert_side_effect.cpp` creates a temporary variables `tmp_post` and later dereference `tmp_post` instead of `ptr`. One problem of this approach is that the temporary variable `tmp_post` lose all the information about the original pointer `ptr`. So the trace cannot correctly tell which pointers cause the failure. 

This patch associate the name of the original variable to the temporary variable, so that the trace will reflect a more precise cause of failure. 

Example:
``` cpp
int memcmp(const void *s1, const void *s2, size_t n)
{
  int res=0;
  const unsigned char *sc1=s1, *sc2=s2;
  for(; n!=0; n--)
  {
    res = (*sc1++) - (*sc2++);
    if (res != 0)
      return res;
  }
  return res;
}
```
In the above function, if the out-of-boundary check fails on the pointer dereference `(*sc1++)`, the trace will give the violated property as
```
dereference failure: pointer outside object bounds in *tmp_post
```
However, without looking at the goto program, users will have no clue what is `tmp_post`. With this patch, the violated property will become 
```
dereference failure: pointer outside object bounds in *tmp_post_memcmp::1::sc1
```
where the suffix of the temporary variable indicate the cause of the failure.

- [X] Each commit message has a non-empty body, explaining why the change was made.
- [X] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [N/A] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [X] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [N/A] My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- [N/A] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
