### PR TITLE
Tests: do not unnecessarily constrain what models solvers can produce [blocks: #6439]

### DIFF
--- a/jbmc/regression/jbmc-strings/ConstantEvaluationContains/nondetArg.desc
+++ b/jbmc/regression/jbmc-strings/ConstantEvaluationContains/nondetArg.desc
@@ -1,6 +1,6 @@
 CORE
 Main
---function Main.nondetArg --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar ../../../lib/java-models-library/target/cprover-api.jar`
+--function Main.nondetArg --max-nondet-string-length 100 --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar ../../../lib/java-models-library/target/cprover-api.jar`
 ^Generated [1-9]\d* VCC\(s\), [1-9]\d* remaining after simplification$
 ^EXIT=10$
 ^SIGNAL=0$

--- a/jbmc/regression/jbmc-strings/ConstantEvaluationContains/noprop.desc
+++ b/jbmc/regression/jbmc-strings/ConstantEvaluationContains/noprop.desc
@@ -1,6 +1,6 @@
 CORE
 Main
---function Main.noprop --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar ../../../lib/java-models-library/target/cprover-api.jar`
+--function Main.noprop --max-nondet-string-length 100 --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar ../../../lib/java-models-library/target/cprover-api.jar`
 ^Generated [1-9]\d* VCC\(s\), [1-9]\d* remaining after simplification$
 ^EXIT=10$
 ^SIGNAL=0$

--- a/regression/cbmc-library/free-01/test.desc
+++ b/regression/cbmc-library/free-01/test.desc
@@ -1,7 +1,7 @@
 CORE
 main.c
 --pointer-check --bounds-check --stop-on-fail
-free argument must be NULL or valid pointer
+free argument must be (NULL or valid pointer|dynamic object)
 ^EXIT=10$
 ^SIGNAL=0$
 ^VERIFICATION FAILED$


### PR DESCRIPTION
The changes in this PR make regression tests also pass with the models produced by MergeSat (cf. #6439).

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
