### PR TITLE
protect goto_instructiont::guard

### DIFF
--- a/jbmc/src/java_bytecode/remove_exceptions.cpp
+++ b/jbmc/src/java_bytecode/remove_exceptions.cpp
@@ -368,7 +368,7 @@ void remove_exceptionst::add_exception_dispatch_sequence(
         struct_tag_typet type(stack_catch[i][j].first);
 
         java_instanceof_exprt check(exc_thrown, type);
-        t_exc->guard=check;
+        t_exc->condition_nonconst() = check;
 
         if(remove_added_instanceof)
         {

--- a/jbmc/src/java_bytecode/remove_instanceof.cpp
+++ b/jbmc/src/java_bytecode/remove_instanceof.cpp
@@ -243,7 +243,8 @@ bool remove_instanceoft::lower_instanceof(
 {
   if(
     target->is_target() &&
-    (contains_instanceof(target->code()) || contains_instanceof(target->guard)))
+    (contains_instanceof(target->code()) ||
+     (target->has_condition() && contains_instanceof(target->condition()))))
   {
     // If this is a branch target, add a skip beforehand so we can splice new
     // GOTO programs before the target instruction without inserting into the
@@ -256,8 +257,12 @@ bool remove_instanceoft::lower_instanceof(
 
   return lower_instanceof(
            function_identifier, target->code_nonconst(), goto_program, target) |
-         lower_instanceof(
-           function_identifier, target->guard, goto_program, target);
+         (target->has_condition() ? lower_instanceof(
+                                      function_identifier,
+                                      target->condition_nonconst(),
+                                      goto_program,
+                                      target)
+                                  : false);
 }
 
 /// Replace every instanceof in the passed function body with an explicit

--- a/jbmc/unit/java_bytecode/goto-programs/remove_virtual_functions_without_fallback.cpp
+++ b/jbmc/unit/java_bytecode/goto-programs/remove_virtual_functions_without_fallback.cpp
@@ -71,7 +71,7 @@ static bool is_call_to(
 
 static bool is_assume_false(goto_programt::const_targett inst)
 {
-  return inst->is_assume() && inst->guard.is_false();
+  return inst->is_assume() && inst->condition().is_false();
 }
 
 /// Interpret `program`, resolving classid comparisons assuming any actual
@@ -90,7 +90,7 @@ static goto_programt::const_targett interpret_classid_comparison(
   {
     if(pc->type() == GOTO)
     {
-      exprt guard = pc->guard;
+      exprt guard = pc->condition();
       guard = resolve_classid_test(guard, actual_class_id, ns);
       if(guard.is_true())
       {

--- a/jbmc/unit/java_bytecode/java_bytecode_instrument/virtual_call_null_checks.cpp
+++ b/jbmc/unit/java_bytecode/java_bytecode_instrument/virtual_call_null_checks.cpp
@@ -92,15 +92,20 @@ SCENARIO(
             }
           }
 
-          for(auto it = instrit->guard.depth_begin(),
-                itend = instrit->guard.depth_end();
-              it != itend; ++it)
+          if(instrit->has_condition())
           {
-            if(it->id() == ID_dereference)
+            const auto &condition = instrit->condition();
+
+            for(auto it = condition.depth_begin(),
+                     itend = condition.depth_end();
+                it != itend;
+                ++it)
             {
-              const auto &deref = to_dereference_expr(*it);
-              REQUIRE(
-                safe_pointers.is_safe_dereference(deref, instrit));
+              if(it->id() == ID_dereference)
+              {
+                const auto &deref = to_dereference_expr(*it);
+                REQUIRE(safe_pointers.is_safe_dereference(deref, instrit));
+              }
             }
           }
         }

--- a/jbmc/unit/java_bytecode/java_virtual_functions/virtual_functions.cpp
+++ b/jbmc/unit/java_bytecode/java_virtual_functions/virtual_functions.cpp
@@ -71,11 +71,12 @@ SCENARIO(
             // branching for class C and one for class D or O.
             if(instruction.type() == goto_program_instruction_typet::GOTO)
             {
-              if(instruction.guard.id() == ID_equal)
+              if(instruction.condition().id() == ID_equal)
               {
                 THEN("Class C should call its specific method")
                 {
-                  const equal_exprt &eq_expr = to_equal_expr(instruction.guard);
+                  const equal_exprt &eq_expr =
+                    to_equal_expr(instruction.condition());
                   check_function_call(
                     eq_expr,
                     "java::C",
@@ -84,11 +85,12 @@ SCENARIO(
                 }
               }
 
-              else if(instruction.guard.id() == ID_or)
+              else if(instruction.condition().id() == ID_or)
               {
                 THEN("Classes D and O should both call O.toString()")
                 {
-                  const or_exprt &disjunction = to_or_expr(instruction.guard);
+                  const or_exprt &disjunction =
+                    to_or_expr(instruction.condition());
                   REQUIRE(
                     (disjunction.op0().id() == ID_equal &&
                      disjunction.op1().id() == ID_equal));

--- a/src/analyses/interval_analysis.cpp
+++ b/src/analyses/interval_analysis.cpp
@@ -50,7 +50,7 @@ void instrument_intervals(
       {
         // we follow a branch, instrument
       }
-      else if(previous->is_function_call() && !previous->guard.is_true())
+      else if(previous->is_function_call())
       {
         // we follow a function call, instrument
       }

--- a/src/analyses/variable-sensitivity/variable_sensitivity_domain.cpp
+++ b/src/analyses/variable-sensitivity/variable_sensitivity_domain.cpp
@@ -79,13 +79,13 @@ void variable_sensitivity_domaint::transform(
         if(to == from->get_target())
         {
           // The AI is exploring the branch where the jump is taken
-          assume(instruction.guard, ns);
+          assume(instruction.condition(), ns);
         }
         else
         {
           // Exploring the path where the jump is not taken - therefore assume
           // the condition is false
-          assume(not_exprt(instruction.guard), ns);
+          assume(not_exprt(instruction.condition()), ns);
         }
       }
       // ignore jumps to the next line, we can assume nothing
@@ -94,7 +94,7 @@ void variable_sensitivity_domaint::transform(
   break;
 
   case ASSUME:
-    assume(instruction.guard, ns);
+    assume(instruction.condition(), ns);
     break;
 
   case FUNCTION_CALL:

--- a/src/goto-cc/linker_script_merge.cpp
+++ b/src/goto-cc/linker_script_merge.cpp
@@ -258,8 +258,11 @@ int linker_script_merget::pointerize_linker_defined_symbols(
     goto_programt &program=gf.second.body;
     for(auto &instruction : program.instructions)
     {
-      for(exprt *insts : std::list<exprt *>(
-            {&(instruction.code_nonconst()), &(instruction.guard)}))
+      std::list<exprt *> expressions = {&instruction.code_nonconst()};
+      if(instruction.has_condition())
+        expressions.push_back(&instruction.condition_nonconst());
+
+      for(exprt *insts : expressions)
       {
         std::list<symbol_exprt> to_pointerize;
         symbols_to_pointerize(linker_values, *insts, to_pointerize);

--- a/src/goto-checker/symex_coverage.cpp
+++ b/src/goto-checker/symex_coverage.cpp
@@ -214,7 +214,7 @@ void goto_program_coverage_recordt::compute_coverage_lines(
       it->is_end_function())
       continue;
 
-    const bool is_branch = it->is_goto() && !it->guard.is_constant();
+    const bool is_branch = it->is_goto() && !it->condition().is_constant();
 
     unsigned l =
       safe_string2unsigned(id2string(it->source_location().get_line()));

--- a/src/goto-harness/memory_snapshot_harness_generator.cpp
+++ b/src/goto-harness/memory_snapshot_harness_generator.cpp
@@ -165,7 +165,7 @@ void memory_snapshot_harness_generatort::add_init_section(
   auto ins_it1 = goto_program.insert_before(
     start_it,
     goto_programt::make_goto(goto_program.const_cast_target(start_it)));
-  ins_it1->guard = func_init_done_var;
+  ins_it1->condition_nonconst() = func_init_done_var;
 
   auto ins_it2 = goto_program.insert_after(
     ins_it1,

--- a/src/goto-instrument/cover_basic_blocks.cpp
+++ b/src/goto-instrument/cover_basic_blocks.cpp
@@ -21,7 +21,9 @@ optionalt<std::size_t> cover_basic_blockst::continuation_of_block(
     return {};
 
   const goto_programt::targett in_t = *instruction->incoming_edges.cbegin();
-  if(in_t->is_goto() && !in_t->is_backwards_goto() && in_t->guard.is_true())
+  if(
+    in_t->is_goto() && !in_t->is_backwards_goto() &&
+    in_t->condition().is_true())
     return block_map[in_t];
 
   return {};

--- a/src/goto-instrument/cover_instrument_other.cpp
+++ b/src/goto-instrument/cover_instrument_other.cpp
@@ -40,7 +40,7 @@ void cover_assertion_instrumentert::instrument(
   // turn into 'assert(false)' to avoid simplification
   if(is_non_cover_assertion(i_it))
   {
-    i_it->guard = false_exprt();
+    i_it->condition_nonconst() = false_exprt();
     initialize_source_location(
       i_it, id2string(i_it->source_location().get_comment()), function_id);
   }

--- a/src/goto-instrument/k_induction.cpp
+++ b/src/goto-instrument/k_induction.cpp
@@ -63,7 +63,7 @@ void k_inductiont::process_loop(
   assert(!loop.empty());
 
   // save the loop guard
-  const exprt loop_guard=loop_head->guard;
+  const exprt loop_guard = loop_head->condition();
 
   // compute the loop exit
   goto_programt::targett loop_exit=

--- a/src/goto-programs/ensure_one_backedge_per_target.cpp
+++ b/src/goto-programs/ensure_one_backedge_per_target.cpp
@@ -55,13 +55,13 @@ bool ensure_one_backedge_per_target(
 
   // If the last backedge is a conditional jump, add an extra unconditional
   // backedge after it:
-  if(!last_backedge->guard.is_true())
+  if(!last_backedge->condition().is_true())
   {
     auto new_goto =
       goto_program.insert_after(last_backedge, goto_programt::make_goto(it));
     // Turn the existing `if(x) goto head; succ: ...`
     // into `if(!x) goto succ; goto head; succ: ...`
-    last_backedge->guard = not_exprt(last_backedge->guard);
+    last_backedge->condition_nonconst() = not_exprt(last_backedge->condition());
     last_backedge->set_target(std::next(new_goto));
     // Use the new backedge as the one true way to the header:
     last_backedge = new_goto;

--- a/src/goto-programs/goto_convert.cpp
+++ b/src/goto-programs/goto_convert.cpp
@@ -866,7 +866,7 @@ void goto_convertt::convert_loop_contracts(
   if(assigns.is_not_nil())
   {
     PRECONDITION(loop->is_goto());
-    loop->guard.add(ID_C_spec_assigns).swap(assigns.op());
+    loop->condition_nonconst().add(ID_C_spec_assigns).swap(assigns.op());
   }
 
   auto invariant =

--- a/src/goto-programs/goto_program.h
+++ b/src/goto-programs/goto_program.h
@@ -358,12 +358,11 @@ public:
     // access method is provided.
     goto_program_instruction_typet _type;
 
-  public:
     /// Guard for gotos, assume, assert
     /// Use condition() method to access.
-    /// This member will eventually be protected.
     exprt guard;
 
+  public:
     /// Does this instruction have a condition?
     bool has_condition() const
     {

--- a/src/goto-programs/name_mangler.h
+++ b/src/goto-programs/name_mangler.h
@@ -107,7 +107,8 @@ public:
       for(auto &ins : fun.second.body.instructions)
       {
         rename(ins.code_nonconst());
-        rename(ins.guard);
+        if(ins.has_condition())
+          rename(ins.condition_nonconst());
       }
     }
 


### PR DESCRIPTION
This protects a field of goto_instructiont, in favor of using the
recommended accessor methods.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
