### PR TITLE
associate original expressions to tmp_post

### DIFF
--- a/regression/goto-cc-cbmc/tmp_post_with_origin1/main.c
+++ b/regression/goto-cc-cbmc/tmp_post_with_origin1/main.c
@@ -1,0 +1,8 @@
+int main(int argc, char **argv)
+{
+  int *ptr;
+  ptr = malloc(2);
+  ptr += 2;
+  int v = *ptr++;
+  return 0;
+}

--- a/regression/goto-cc-cbmc/tmp_post_with_origin1/test.desc
+++ b/regression/goto-cc-cbmc/tmp_post_with_origin1/test.desc
@@ -1,0 +1,11 @@
+CORE
+main.c
+--pointer-check --trace
+^EXIT=10$
+^SIGNAL=0$
+^\[main\.pointer_dereference\.5\] line 6 dereference failure: pointer outside object bounds in \*ptr\+\+: FAILURE$
+^  POINTER_OFFSET\(ptr\+\+\) .*
+\*\* 1 of [0-9]* failed 
+^VERIFICATION FAILED$
+--
+^warning: ignoring

--- a/regression/goto-cc-cbmc/tmp_post_with_origin2/main.c
+++ b/regression/goto-cc-cbmc/tmp_post_with_origin2/main.c
@@ -1,0 +1,10 @@
+int main(int argc, char **argv)
+{
+  char **pptr;
+  pptr = malloc(8);
+  char *ptr = malloc(2);
+  ptr += 2;
+  *pptr = ptr;
+  char v = *(*pptr++)++;
+  return 0;
+}

--- a/regression/goto-cc-cbmc/tmp_post_with_origin2/test.desc
+++ b/regression/goto-cc-cbmc/tmp_post_with_origin2/test.desc
@@ -1,0 +1,11 @@
+CORE
+main.c
+--pointer-check --trace
+^EXIT=10$
+^SIGNAL=0$
+^\[main\.pointer_dereference\.17\] line 8 dereference failure: pointer outside object bounds in \*\(\*pptr\+\+\)\+\+: FAILURE$
+^  POINTER_OFFSET\(\(\*pptr\+\+\)\+\+\) .*
+\*\* 1 of [0-9]* failed 
+^VERIFICATION FAILED$
+--
+^warning: ignoring

--- a/regression/goto-cc-cbmc/tmp_post_with_origin3/main.c
+++ b/regression/goto-cc-cbmc/tmp_post_with_origin3/main.c
@@ -1,0 +1,9 @@
+int main(int argc, char **argv)
+{
+  char *arr_ptr[2];
+  char *ptr = malloc(2);
+  ptr += 2;
+  *arr_ptr = ptr;
+  char v = *(arr_ptr[0])++;
+  return 0;
+}

--- a/regression/goto-cc-cbmc/tmp_post_with_origin3/test.desc
+++ b/regression/goto-cc-cbmc/tmp_post_with_origin3/test.desc
@@ -1,0 +1,11 @@
+CORE
+main.c
+--pointer-check --trace
+^EXIT=10$
+^SIGNAL=0$
+^\[main\.pointer_dereference\.5\] line 7 dereference failure: pointer outside object bounds in \*arr_ptr\[\(signed long int\)0\]\+\+: FAILURE$
+^  POINTER_OFFSET\(arr_ptr\[\(signed long int\)0\]\+\+\).*
+\*\* 1 of [0-9]* failed 
+^VERIFICATION FAILED$
+--
+^warning: ignoring

--- a/src/ansi-c/expr2c.cpp
+++ b/src/ansi-c/expr2c.cpp
@@ -1663,6 +1663,10 @@ std::string expr2ct::convert_symbol(const exprt &src)
     #endif
   }
 
+  // src is a tmp_post variable
+  if(src.find(ID_tmp_post_origin).is_not_nil())
+    dest=convert(static_cast<const exprt &>(src.find(ID_tmp_post_origin)));
+
   if(src.id()==ID_next_symbol)
     dest="NEXT("+dest+")";
 

--- a/src/goto-programs/goto_convert_side_effect.cpp
+++ b/src/goto-programs/goto_convert_side_effect.cpp
@@ -20,6 +20,8 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <util/c_types.h>
 
+#include <langapi/language_util.h>
+
 #include <ansi-c/c_expr.h>
 
 bool goto_convertt::has_function_call(const exprt &expr)
@@ -315,6 +317,7 @@ void goto_convertt::remove_post(
   {
     exprt tmp = op;
     make_temp_symbol(tmp, "post", dest, mode);
+    tmp.set(ID_tmp_post_origin, exprt(expr));
     expr.swap(tmp);
   }
   else

--- a/src/util/irep_ids.def
+++ b/src/util/irep_ids.def
@@ -873,6 +873,7 @@ IREP_ID_TWO(C_flexible_array_member, #flexible_array_member)
 IREP_ID_ONE(state)
 IREP_ID_ONE(evaluate)
 IREP_ID_ONE(update_state)
+IREP_ID_ONE(tmp_post_origin)
 
 // Projects depending on this code base that wish to extend the list of
 // available ids should provide a file local_irep_ids.def in their source tree


### PR DESCRIPTION
<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

This PR is an alternative approach to address the problem introduced in [#6847](https://github.com/diffblue/cbmc/pull/6847). Comparing to [#6847](https://github.com/diffblue/cbmc/pull/6847), in this patch,

- the original expressions, instead of the names of `symbol_exprt`, are associate to `tmp_post` variables. The description of the violated property becomes
`dereference failure: pointer outside object bounds in *ptr++`
- `from_expr_using_mode` will print the original expressions on tmp_post. So the assertion for the violated property becomes
` POINTER_OFFSET(ptr++) >= 0l && OBJECT_SIZE(ptr++) >= (unsigned long int)POINTER_OFFSET(ptr++) + 4ul`
Note that the original expression with side-effect is in the above predicate.

As am example, below is the result and the trace for the test `tmp_post_with_origin1` added in this PR.
```
** Results:
<builtin-library-malloc> function malloc
[malloc.assertion.1] line 26 max allocation size exceeded: SUCCESS
[malloc.assertion.2] line 31 max allocation may fail: SUCCESS

main.c function main
[main.pointer_dereference.1] line 6 dereference failure: pointer NULL in *ptr++: SUCCESS
[main.pointer_dereference.2] line 6 dereference failure: pointer invalid in *ptr++: SUCCESS
[main.pointer_dereference.3] line 6 dereference failure: deallocated dynamic object in *ptr++: SUCCESS
[main.pointer_dereference.4] line 6 dereference failure: dead object in *ptr++: SUCCESS
[main.pointer_dereference.5] line 6 dereference failure: pointer outside object bounds in *ptr++: FAILURE
[main.pointer_dereference.6] line 6 dereference failure: invalid integer address in *ptr++: SUCCESS

Trace for main.pointer_dereference.5:

Assumption:
  argc' >= 0

State 20 function __CPROVER__start thread 0
----------------------------------------------------
  INPUT argc: 1073741888 (01000000 00000000 00000000 01000000)

State 24 file main.c function __CPROVER__start line 1 thread 0
----------------------------------------------------
  argc=1073741888 (01000000 00000000 00000000 01000000)

State 25 file main.c function __CPROVER__start line 1 thread 0
----------------------------------------------------
  argv=argv' (00000010 00000000 00000000 00000000 00000000 00000000 00000000 00000000)

State 26 file main.c function main line 3 thread 0
----------------------------------------------------
  ptr=((signed int *)NULL) (00000000 00000000 00000000 00000000 00000000 00000000 00000000 00000000)

State 30 file main.c function main line 4 thread 0
----------------------------------------------------
  malloc_size=2ul (00000000 00000000 00000000 00000000 00000000 00000000 00000000 00000010)

State 53 file main.c function main line 4 thread 0
----------------------------------------------------
  ptr=(signed int *)&dynamic_object1 (00000011 00000000 00000000 00000000 00000000 00000000 00000000 00000000)

State 54 file main.c function main line 5 thread 0
----------------------------------------------------
  ptr=(signed int *)((char *)&dynamic_object1 + 8l) (00000011 00000000 00000000 00000000 00000000 00000000 00000000 00001000)

State 58 file main.c function main line 6 thread 0
----------------------------------------------------
  ptr=(signed int *)((char *)&dynamic_object1 + 12l) (00000011 00000000 00000000 00000000 00000000 00000000 00000000 00001100)

Violated property:
  file main.c function main line 6 thread 0
  dereference failure: pointer outside object bounds in *ptr++
  POINTER_OFFSET(ptr++) >= 0l && OBJECT_SIZE(ptr++) >= (unsigned long int)POINTER_OFFSET(ptr++) + 4ul



** 1 of 8 failed (2 iterations)
VERIFICATION FAILED
```


<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- [X] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [X] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

