### PR TITLE
Hide __CPROVER_deallocated updates behind a function

### DIFF
--- a/src/ansi-c/ansi_c_internal_additions.cpp
+++ b/src/ansi-c/ansi_c_internal_additions.cpp
@@ -179,6 +179,7 @@ void ansi_c_internal_additions(std::string &code)
     "void *" CPROVER_PREFIX "allocate("
       CPROVER_PREFIX "size_t size, " CPROVER_PREFIX "bool zero);\n"
     "const void *" CPROVER_PREFIX "alloca_object = 0;\n"
+    "void " CPROVER_PREFIX "deallocate(void *);\n"
 
     CPROVER_PREFIX "size_t " CPROVER_PREFIX "max_malloc_size="+
     integer2string(max_malloc_size(config.ansi_c.pointer_width, config

--- a/src/ansi-c/library/cprover.h
+++ b/src/ansi-c/library/cprover.h
@@ -19,6 +19,7 @@ typedef __typeof__(sizeof(int)) __CPROVER_size_t;
 typedef signed long long __CPROVER_ssize_t;
 
 void *__CPROVER_allocate(__CPROVER_size_t size, __CPROVER_bool zero);
+void __CPROVER_deallocate(void *);
 extern const void *__CPROVER_deallocated;
 extern const void *__CPROVER_new_object;
 extern __CPROVER_bool __CPROVER_malloc_is_new_array;

--- a/src/ansi-c/library/mman.c
+++ b/src/ansi-c/library/mman.c
@@ -112,8 +112,7 @@ int munmap(void *addr, __CPROVER_size_t length)
 {
   (void)length;
 
-  if(__VERIFIER_nondet___CPROVER_bool())
-    __CPROVER_deallocated = addr;
+  __CPROVER_deallocate(addr);
 
   return 0;
 }
@@ -126,8 +125,7 @@ int _munmap(void *addr, __CPROVER_size_t length)
 {
   (void)length;
 
-  if(__VERIFIER_nondet___CPROVER_bool())
-    __CPROVER_deallocated = addr;
+  __CPROVER_deallocate(addr);
 
   return 0;
 }

--- a/src/ansi-c/library/stdlib.c
+++ b/src/ansi-c/library/stdlib.c
@@ -271,9 +271,7 @@ inline void free(void *ptr)
 
   if(ptr!=0)
   {
-    // non-deterministically record as deallocated
-    __CPROVER_bool record=__VERIFIER_nondet___CPROVER_bool();
-    if(record) __CPROVER_deallocated=ptr;
+    __CPROVER_deallocate(ptr);
 
     // detect memory leaks
     if(__CPROVER_memory_leak==ptr)
@@ -589,4 +587,14 @@ __CPROVER_HIDE:;
   int result = __VERIFIER_nondet_int();
   __CPROVER_assume(result >= 0);
   return result;
+}
+
+/* FUNCTION: __CPROVER_deallocate */
+
+__CPROVER_bool __VERIFIER_nondet___CPROVER_bool();
+
+void __CPROVER_deallocate(void *ptr)
+{
+  if(__VERIFIER_nondet___CPROVER_bool())
+    __CPROVER_deallocated = ptr;
 }

--- a/src/cpp/library/new.c
+++ b/src/cpp/library/new.c
@@ -88,9 +88,7 @@ inline void __delete(void *ptr)
   // This is a requirement by the standard, not generosity!
   if(ptr!=0)
   {
-    // non-deterministically record as deallocated
-    __CPROVER_bool record=__VERIFIER_nondet___CPROVER_bool();
-    __CPROVER_deallocated=record?ptr:__CPROVER_deallocated;
+    __CPROVER_deallocate(ptr);
 
     // detect memory leaks
     if(__CPROVER_memory_leak==ptr)
@@ -125,9 +123,7 @@ inline void __delete_array(void *ptr)
 
   if(ptr!=0)
   {
-    // non-deterministically record as deallocated
-    __CPROVER_bool record=__VERIFIER_nondet___CPROVER_bool();
-    __CPROVER_deallocated=record?ptr:__CPROVER_deallocated;
+    __CPROVER_deallocate(ptr);
 
     // detect memory leaks
     if(__CPROVER_memory_leak==ptr) __CPROVER_memory_leak=0;


### PR DESCRIPTION
This avoids repeating similar code in several places.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
