### PR TITLE
Use boolbv_width::get_member

### DIFF
--- a/src/solvers/smt2/smt2_conv.cpp
+++ b/src/solvers/smt2/smt2_conv.cpp
@@ -4207,14 +4207,10 @@ void smt2_convt::convert_member(const member_exprt &expr)
     else
     {
       // we extract
-      const std::size_t member_width = boolbv_width(expr.type());
-      const auto member_offset = member_offset_bits(struct_type, name, ns);
+      const auto member_offset = boolbv_width.get_member(struct_type, name);
 
-      CHECK_RETURN_WITH_DIAGNOSTICS(
-        member_offset.has_value(), "failed to get struct member offset");
-
-      out << "((_ extract " << (member_offset.value() + member_width - 1) << " "
-          << member_offset.value() << ") ";
+      out << "((_ extract " << (member_offset.offset + member_offset.width - 1)
+          << " " << member_offset.offset << ") ";
       convert_expr(struct_op);
       out << ")";
     }


### PR DESCRIPTION
boolbv_widtht kept track of the offset and width of struct members, but
we never used that information. Avoid re-computing the same information
(without caching!) in convert_member_struct and thereby simplify its
implementation to the extent that inlining it made the code even
simpler.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
