### PR TITLE
boolbv_width: distinguish zero from unknown size

### DIFF
--- a/regression/cbmc/dynamic_sizeof1/test.desc
+++ b/regression/cbmc/dynamic_sizeof1/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE broken-z3-smt-backend
 main.c
 
 ^EXIT=0$

--- a/regression/cbmc/vla1/test.desc
+++ b/regression/cbmc/vla1/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE broken-cprover-smt-backend
 main.c
 
 ^EXIT=0$
@@ -6,3 +6,6 @@ main.c
 ^VERIFICATION SUCCESSFUL$
 --
 ^warning: ignoring
+--
+The SMT back-end does not correctly support structs with non-constant size,
+unless named data types are used (as is the case with Z3).

--- a/src/solvers/flattening/boolbv_abs.cpp
+++ b/src/solvers/flattening/boolbv_abs.cpp
@@ -16,11 +16,6 @@ Author: Daniel Kroening, kroening@kroening.com
 
 bvt boolbvt::convert_abs(const abs_exprt &expr)
 {
-  const std::size_t width = boolbv_width(expr.type());
-
-  if(width==0)
-    return conversion_failed(expr);
-
   const bvt &op_bv=convert_bv(expr.op());
 
   if(expr.op().type()!=expr.type())

--- a/src/solvers/flattening/boolbv_add_sub.cpp
+++ b/src/solvers/flattening/boolbv_add_sub.cpp
@@ -32,9 +32,6 @@ bvt boolbvt::convert_add_sub(const exprt &expr)
 
   std::size_t width=boolbv_width(type);
 
-  if(width==0)
-    return conversion_failed(expr);
-
   const exprt::operandst &operands=expr.operands();
 
   DATA_INVARIANT(
@@ -159,9 +156,6 @@ bvt boolbvt::convert_saturating_add_sub(const binary_exprt &expr)
   }
 
   std::size_t width = boolbv_width(type);
-
-  if(width == 0)
-    return conversion_failed(expr);
 
   DATA_INVARIANT(
     expr.lhs().type() == type && expr.rhs().type() == type,

--- a/src/solvers/flattening/boolbv_array_of.cpp
+++ b/src/solvers/flattening/boolbv_array_of.cpp
@@ -24,28 +24,17 @@ bvt boolbvt::convert_array_of(const array_of_exprt &expr)
     return conversion_failed(expr);
 
   std::size_t width=boolbv_width(array_type);
-
-  if(width==0)
-  {
-    // A zero-length array is acceptable;
-    // an element with unknown size is not.
-    if(boolbv_width(array_type.element_type()) == 0)
-      return conversion_failed(expr);
-    else
-      return bvt();
-  }
+  if(width == 0)
+    return bvt{};
 
   const exprt &array_size=array_type.size();
 
-  const auto size = numeric_cast<mp_integer>(array_size);
-
-  if(!size.has_value())
-    return conversion_failed(expr);
+  const auto size = numeric_cast_v<mp_integer>(to_constant_expr(array_size));
 
   const bvt &tmp = convert_bv(expr.what());
 
   INVARIANT(
-    *size * tmp.size() == width,
+    size * tmp.size() == width,
     "total array bit width shall equal the number of elements times the "
     "element bit with");
 

--- a/src/solvers/flattening/boolbv_bitreverse.cpp
+++ b/src/solvers/flattening/boolbv_bitreverse.cpp
@@ -13,8 +13,6 @@ Author: Michael Tautschnig
 bvt boolbvt::convert_bitreverse(const bitreverse_exprt &expr)
 {
   const std::size_t width = boolbv_width(expr.type());
-  if(width == 0)
-    return conversion_failed(expr);
 
   bvt bv = convert_bv(expr.op(), width);
 

--- a/src/solvers/flattening/boolbv_bitwise.cpp
+++ b/src/solvers/flattening/boolbv_bitwise.cpp
@@ -13,8 +13,6 @@ Author: Daniel Kroening, kroening@kroening.com
 bvt boolbvt::convert_bitwise(const exprt &expr)
 {
   const std::size_t width = boolbv_width(expr.type());
-  if(width==0)
-    return conversion_failed(expr);
 
   if(expr.id()==ID_bitnot)
   {

--- a/src/solvers/flattening/boolbv_case.cpp
+++ b/src/solvers/flattening/boolbv_case.cpp
@@ -18,9 +18,6 @@ bvt boolbvt::convert_case(const exprt &expr)
 
   std::size_t width=boolbv_width(expr.type());
 
-  if(width==0)
-    return conversion_failed(expr);
-
   // make it free variables
   bvt bv = prop.new_variables(width);
 

--- a/src/solvers/flattening/boolbv_complex.cpp
+++ b/src/solvers/flattening/boolbv_complex.cpp
@@ -14,9 +14,6 @@ bvt boolbvt::convert_complex(const complex_exprt &expr)
 {
   std::size_t width=boolbv_width(expr.type());
 
-  if(width==0)
-    return conversion_failed(expr);
-
   DATA_INVARIANT(
     expr.type().id() == ID_complex,
     "complex expression shall have complex type");
@@ -41,9 +38,6 @@ bvt boolbvt::convert_complex_real(const complex_real_exprt &expr)
 {
   std::size_t width=boolbv_width(expr.type());
 
-  if(width==0)
-    return conversion_failed(expr);
-
   bvt bv = convert_bv(expr.op(), width * 2);
 
   bv.resize(width); // chop
@@ -54,9 +48,6 @@ bvt boolbvt::convert_complex_real(const complex_real_exprt &expr)
 bvt boolbvt::convert_complex_imag(const complex_imag_exprt &expr)
 {
   std::size_t width=boolbv_width(expr.type());
-
-  if(width==0)
-    return conversion_failed(expr);
 
   bvt bv = convert_bv(expr.op(), width * 2);
 

--- a/src/solvers/flattening/boolbv_concatenation.cpp
+++ b/src/solvers/flattening/boolbv_concatenation.cpp
@@ -15,9 +15,6 @@ bvt boolbvt::convert_concatenation(const concatenation_exprt &expr)
 {
   std::size_t width=boolbv_width(expr.type());
 
-  if(width==0)
-    return conversion_failed(expr);
-
   const exprt::operandst &operands=expr.operands();
 
   DATA_INVARIANT(

--- a/src/solvers/flattening/boolbv_cond.cpp
+++ b/src/solvers/flattening/boolbv_cond.cpp
@@ -16,9 +16,6 @@ bvt boolbvt::convert_cond(const cond_exprt &expr)
 
   std::size_t width=boolbv_width(expr.type());
 
-  if(width==0)
-    return conversion_failed(expr);
-
   bvt bv;
 
   DATA_INVARIANT(operands.size() >= 2, "cond must have at least two operands");

--- a/src/solvers/flattening/boolbv_constant.cpp
+++ b/src/solvers/flattening/boolbv_constant.cpp
@@ -14,9 +14,6 @@ bvt boolbvt::convert_constant(const constant_exprt &expr)
 {
   std::size_t width=boolbv_width(expr.type());
 
-  if(width==0)
-    return conversion_failed(expr);
-
   bvt bv;
   bv.resize(width);
 

--- a/src/solvers/flattening/boolbv_div.cpp
+++ b/src/solvers/flattening/boolbv_div.cpp
@@ -19,9 +19,6 @@ bvt boolbvt::convert_div(const div_exprt &expr)
 
   std::size_t width=boolbv_width(expr.type());
 
-  if(width==0)
-    return conversion_failed(expr);
-
   if(expr.op0().type().id()!=expr.type().id() ||
      expr.op1().type().id()!=expr.type().id())
     return conversion_failed(expr);

--- a/src/solvers/flattening/boolbv_extractbits.cpp
+++ b/src/solvers/flattening/boolbv_extractbits.cpp
@@ -15,9 +15,6 @@ bvt boolbvt::convert_extractbits(const extractbits_exprt &expr)
 {
   const std::size_t bv_width = boolbv_width(expr.type());
 
-  if(bv_width == 0)
-    return conversion_failed(expr);
-
   auto const &src_bv = convert_bv(expr.src());
 
   auto const maybe_upper_as_int = numeric_cast<mp_integer>(expr.upper());

--- a/src/solvers/flattening/boolbv_let.cpp
+++ b/src/solvers/flattening/boolbv_let.cpp
@@ -38,7 +38,12 @@ bvt boolbvt::convert_let(const let_exprt &expr)
   converted_values.reserve(variables.size());
 
   for(auto &value : values)
-    converted_values.push_back(convert_bv(value));
+  {
+    if(!bv_width.get_width_opt(value.type()).has_value())
+      converted_values.emplace_back();
+    else
+      converted_values.push_back(convert_bv(value));
+  }
 
   // get fresh bound symbols
   auto fresh_variables = fresh_binding(expr.binding());

--- a/src/solvers/flattening/boolbv_mod.cpp
+++ b/src/solvers/flattening/boolbv_mod.cpp
@@ -24,9 +24,6 @@ bvt boolbvt::convert_mod(const mod_exprt &expr)
 
   std::size_t width=boolbv_width(expr.type());
 
-  if(width==0)
-    return conversion_failed(expr);
-
   DATA_INVARIANT(
     expr.op0().type().id() == expr.type().id(),
     "type of the first operand of a modulo operation shall equal the "

--- a/src/solvers/flattening/boolbv_mult.cpp
+++ b/src/solvers/flattening/boolbv_mult.cpp
@@ -14,9 +14,6 @@ bvt boolbvt::convert_mult(const mult_exprt &expr)
 {
   std::size_t width=boolbv_width(expr.type());
 
-  if(width==0)
-    return conversion_failed(expr);
-
   bvt bv;
   bv.resize(width);
 

--- a/src/solvers/flattening/boolbv_power.cpp
+++ b/src/solvers/flattening/boolbv_power.cpp
@@ -15,9 +15,6 @@ bvt boolbvt::convert_power(const binary_exprt &expr)
 
   std::size_t width=boolbv_width(type);
 
-  if(width==0)
-    return conversion_failed(expr);
-
   if(type.id()==ID_unsignedbv ||
      type.id()==ID_signedbv)
   {

--- a/src/solvers/flattening/boolbv_replication.cpp
+++ b/src/solvers/flattening/boolbv_replication.cpp
@@ -15,9 +15,6 @@ bvt boolbvt::convert_replication(const replication_exprt &expr)
 {
   std::size_t width=boolbv_width(expr.type());
 
-  if(width==0)
-    return conversion_failed(expr);
-
   mp_integer times = numeric_cast_v<mp_integer>(expr.times());
 
   bvt bv;

--- a/src/solvers/flattening/boolbv_shift.cpp
+++ b/src/solvers/flattening/boolbv_shift.cpp
@@ -27,9 +27,6 @@ bvt boolbvt::convert_shift(const binary_exprt &expr)
 
   std::size_t width=boolbv_width(expr.type());
 
-  if(width==0)
-    return conversion_failed(expr);
-
   const bvt &op = convert_bv(expr.op0(), width);
 
   bv_utilst::shiftt shift;

--- a/src/solvers/flattening/boolbv_unary_minus.cpp
+++ b/src/solvers/flattening/boolbv_unary_minus.cpp
@@ -23,9 +23,6 @@ bvt boolbvt::convert_unary_minus(const unary_minus_exprt &expr)
 
   std::size_t width=boolbv_width(type);
 
-  if(width==0)
-    return conversion_failed(expr);
-
   const exprt &op = expr.op();
 
   const bvt &op_bv = convert_bv(op, width);

--- a/src/solvers/flattening/boolbv_union.cpp
+++ b/src/solvers/flattening/boolbv_union.cpp
@@ -12,9 +12,6 @@ bvt boolbvt::convert_union(const union_exprt &expr)
 {
   std::size_t width=boolbv_width(expr.type());
 
-  if(width==0)
-    return conversion_failed(expr);
-
   const bvt &op_bv=convert_bv(expr.op());
 
   INVARIANT(

--- a/src/solvers/flattening/boolbv_update.cpp
+++ b/src/solvers/flattening/boolbv_update.cpp
@@ -18,9 +18,6 @@ bvt boolbvt::convert_update(const update_exprt &expr)
 
   std::size_t width=boolbv_width(expr.type());
 
-  if(width==0)
-    return conversion_failed(expr);
-
   bvt bv=convert_bv(ops[0]);
 
   if(bv.size()!=width)

--- a/src/solvers/flattening/boolbv_vector.cpp
+++ b/src/solvers/flattening/boolbv_vector.cpp
@@ -13,9 +13,6 @@ bvt boolbvt::convert_vector(const vector_exprt &expr)
 {
   std::size_t width=boolbv_width(expr.type());
 
-  if(width==0)
-    return conversion_failed(expr);
-
   const exprt::operandst &operands = expr.operands();
 
   bvt bv;

--- a/src/solvers/flattening/boolbv_width.cpp
+++ b/src/solvers/flattening/boolbv_width.cpp
@@ -24,15 +24,13 @@ const boolbv_widtht::entryt &boolbv_widtht::get_entry(const typet &type) const
 {
   // check cache first
 
-  std::pair<cachet::iterator, bool> cache_result=
-    cache.insert(std::pair<typet, entryt>(type, entryt()));
+  std::pair<cachet::iterator, bool> cache_result =
+    cache.emplace(type, entryt{});
 
-  entryt &entry=cache_result.first->second;
+  auto &cache_entry = cache_result.first->second;
 
   if(!cache_result.second) // found!
-    return entry;
-
-  entry.total_width=0;
+    return cache_entry;
 
   const irep_idt type_id=type.id();
 
@@ -42,61 +40,73 @@ const boolbv_widtht::entryt &boolbv_widtht::get_entry(const typet &type) const
       to_struct_type(type).components();
 
     std::size_t offset=0;
+    defined_entryt entry{0};
     entry.members.resize(components.size());
 
     for(std::size_t i=0; i<entry.members.size(); i++)
     {
-      std::size_t sub_width=operator()(components[i].type());
+      auto sub_width = get_width_opt(components[i].type());
+      if(!sub_width.has_value())
+        return cache_entry;
       entry.members[i].offset=offset;
-      entry.members[i].width=sub_width;
-      offset+=sub_width;
+      entry.members[i].width = *sub_width;
+      offset += *sub_width;
     }
 
     entry.total_width=offset;
+
+    cache_entry = std::move(entry);
   }
   else if(type_id==ID_union)
   {
     const union_typet::componentst &components=
       to_union_type(type).components();
 
+    defined_entryt entry{0};
     entry.members.resize(components.size());
 
     std::size_t max_width=0;
 
     for(std::size_t i=0; i<entry.members.size(); i++)
     {
-      std::size_t sub_width=operator()(components[i].type());
-      entry.members[i].width=sub_width;
-      max_width=std::max(max_width, sub_width);
+      auto sub_width = get_width_opt(components[i].type());
+      if(!sub_width.has_value())
+        return cache_entry;
+      entry.members[i].width = *sub_width;
+      max_width = std::max(max_width, *sub_width);
     }
 
     entry.total_width=max_width;
+
+    cache_entry = std::move(entry);
   }
   else if(type_id==ID_bool)
-    entry.total_width=1;
+  {
+    cache_entry = defined_entryt{1};
+  }
   else if(type_id==ID_c_bool)
   {
-    entry.total_width=to_c_bool_type(type).get_width();
+    cache_entry = defined_entryt{to_c_bool_type(type).get_width()};
   }
   else if(type_id==ID_signedbv)
   {
-    entry.total_width=to_signedbv_type(type).get_width();
+    cache_entry = defined_entryt{to_signedbv_type(type).get_width()};
   }
   else if(type_id==ID_unsignedbv)
   {
-    entry.total_width=to_unsignedbv_type(type).get_width();
+    cache_entry = defined_entryt{to_unsignedbv_type(type).get_width()};
   }
   else if(type_id==ID_floatbv)
   {
-    entry.total_width=to_floatbv_type(type).get_width();
+    cache_entry = defined_entryt{to_floatbv_type(type).get_width()};
   }
   else if(type_id==ID_fixedbv)
   {
-    entry.total_width=to_fixedbv_type(type).get_width();
+    cache_entry = defined_entryt{to_fixedbv_type(type).get_width()};
   }
   else if(type_id==ID_bv)
   {
-    entry.total_width=to_bv_type(type).get_width();
+    cache_entry = defined_entryt{to_bv_type(type).get_width()};
   }
   else if(type_id==ID_verilog_signedbv ||
           type_id==ID_verilog_unsignedbv)
@@ -105,7 +115,7 @@ const boolbv_widtht::entryt &boolbv_widtht::get_entry(const typet &type) const
     std::size_t size = to_bitvector_type(type).get_width();
     DATA_INVARIANT(
       size > 0, "verilog bitvector width shall be greater than zero");
-    entry.total_width = size * 2;
+    cache_entry = defined_entryt{size * 2};
   }
   else if(type_id==ID_range)
   {
@@ -114,97 +124,117 @@ const boolbv_widtht::entryt &boolbv_widtht::get_entry(const typet &type) const
 
     mp_integer size=to-from+1;
 
-    if(size>=1)
-    {
-      entry.total_width = address_bits(size);
-      CHECK_RETURN(entry.total_width > 0);
-    }
+    if(size < 0)
+      return cache_entry;
+    else if(size == 0)
+      cache_entry = defined_entryt{0};
+    else
+      cache_entry = defined_entryt{address_bits(size)};
   }
   else if(type_id==ID_array)
   {
     const array_typet &array_type=to_array_type(type);
-    std::size_t sub_width = operator()(array_type.element_type());
+    auto sub_width = get_width_opt(array_type.element_type());
+    if(!sub_width.has_value())
+      return cache_entry;
 
     const auto array_size = numeric_cast<mp_integer>(array_type.size());
 
-    if(!array_size.has_value())
-    {
-      // we can still use the theory of arrays for this
-      entry.total_width=0;
-    }
+    if(!array_size.has_value() || *array_size < 0)
+      return cache_entry;
+
+    mp_integer total = *array_size * *sub_width;
+    if(total > (1 << 30)) // realistic limit
+      throw analysis_exceptiont("array too large for flattening");
     else
-    {
-      mp_integer total = *array_size * sub_width;
-      if(total>(1<<30)) // realistic limit
-        throw analysis_exceptiont("array too large for flattening");
-      if(total < 0)
-        entry.total_width = 0;
-      else
-        entry.total_width = numeric_cast_v<std::size_t>(total);
-    }
+      cache_entry = defined_entryt{numeric_cast_v<std::size_t>(total)};
   }
   else if(type_id==ID_vector)
   {
     const vector_typet &vector_type=to_vector_type(type);
-    std::size_t sub_width = operator()(vector_type.element_type());
+    auto sub_width = get_width_opt(vector_type.element_type());
+    if(!sub_width.has_value())
+      return cache_entry;
 
     const auto vector_size = numeric_cast_v<mp_integer>(vector_type.size());
 
-    mp_integer total = vector_size * sub_width;
+    mp_integer total = vector_size * *sub_width;
     if(total > (1 << 30)) // realistic limit
       throw analysis_exceptiont("vector too large for flattening");
-    if(total < 0)
-      entry.total_width = 0;
     else
-      entry.total_width = numeric_cast_v<std::size_t>(vector_size * sub_width);
+      cache_entry = defined_entryt{numeric_cast_v<std::size_t>(total)};
   }
   else if(type_id==ID_complex)
   {
-    const mp_integer sub_width = operator()(to_complex_type(type).subtype());
-    entry.total_width = numeric_cast_v<std::size_t>(2 * sub_width);
+    auto sub_width = get_width_opt(to_complex_type(type).subtype());
+    if(!sub_width.has_value())
+      return cache_entry;
+    cache_entry =
+      defined_entryt{numeric_cast_v<std::size_t>(2 * mp_integer{*sub_width})};
   }
   else if(type_id==ID_code)
   {
+    cache_entry = defined_entryt{0};
   }
   else if(type_id==ID_enumeration)
   {
     // get number of necessary bits
     std::size_t size=to_enumeration_type(type).elements().size();
-    entry.total_width = address_bits(size);
-    CHECK_RETURN(entry.total_width > 0);
+    if(size == 0)
+      cache_entry = defined_entryt{0};
+    else
+      cache_entry = defined_entryt{address_bits(size)};
   }
   else if(type_id==ID_c_enum)
   {
     // these have a subtype
-    entry.total_width =
-      to_bitvector_type(to_c_enum_type(type).underlying_type()).get_width();
-    CHECK_RETURN(entry.total_width > 0);
+    cache_entry = defined_entryt{
+      to_bitvector_type(to_c_enum_type(type).underlying_type()).get_width()};
+    CHECK_RETURN(cache_entry->total_width > 0);
   }
   else if(type_id==ID_pointer)
-    entry.total_width = type_checked_cast<pointer_typet>(type).get_width();
+  {
+    cache_entry =
+      defined_entryt{type_checked_cast<pointer_typet>(type).get_width()};
+  }
   else if(type_id==ID_struct_tag)
-    entry.total_width = operator()(ns.follow_tag(to_struct_tag_type(type)));
+  {
+    cache_entry = get_entry(ns.follow_tag(to_struct_tag_type(type)));
+  }
   else if(type_id==ID_union_tag)
-    entry.total_width = operator()(ns.follow_tag(to_union_tag_type(type)));
+  {
+    cache_entry = get_entry(ns.follow_tag(to_union_tag_type(type)));
+  }
   else if(type_id==ID_c_enum_tag)
-    entry.total_width = operator()(ns.follow_tag(to_c_enum_tag_type(type)));
+  {
+    cache_entry = get_entry(ns.follow_tag(to_c_enum_tag_type(type)));
+  }
   else if(type_id==ID_c_bit_field)
   {
-    entry.total_width=to_c_bit_field_type(type).get_width();
+    cache_entry = defined_entryt{to_c_bit_field_type(type).get_width()};
   }
   else if(type_id==ID_string)
-    entry.total_width=32;
-  else if(type_id != ID_empty)
+  {
+    cache_entry = defined_entryt{32};
+  }
+  else if(type_id == ID_empty)
+  {
+    cache_entry = defined_entryt{0};
+  }
+  else
     UNIMPLEMENTED;
 
-  return entry;
+  return cache_entry;
 }
 
 const boolbv_widtht::membert &boolbv_widtht::get_member(
   const struct_typet &type,
   const irep_idt &member) const
 {
+  const auto &entry_opt = get_entry(type);
+  CHECK_RETURN(entry_opt.has_value());
   std::size_t component_number=type.component_number(member);
+  PRECONDITION(entry_opt->members.size() > component_number);
 
-  return get_entry(type).members[component_number];
+  return entry_opt->members[component_number];
 }

--- a/src/solvers/flattening/boolbv_width.h
+++ b/src/solvers/flattening/boolbv_width.h
@@ -23,7 +23,17 @@ public:
 
   virtual std::size_t operator()(const typet &type) const
   {
-    return get_entry(type).total_width;
+    const auto &entry_opt = get_entry(type);
+    CHECK_RETURN(entry_opt.has_value());
+    return entry_opt->total_width;
+  }
+
+  virtual optionalt<std::size_t> get_width_opt(const typet &type) const
+  {
+    const auto &entry_opt = get_entry(type);
+    if(!entry_opt.has_value())
+      return {};
+    return entry_opt->total_width;
   }
 
   struct membert
@@ -31,18 +41,22 @@ public:
     std::size_t offset, width;
   };
 
-  const membert &get_member(
-    const struct_typet &type,
-    const irep_idt &member) const;
+  const membert &
+  get_member(const struct_typet &type, const irep_idt &member) const;
 
 protected:
   const namespacet &ns;
 
-  struct entryt
+  struct defined_entryt
   {
+    explicit defined_entryt(std::size_t total_width) : total_width(total_width)
+    {
+    }
+
     std::size_t total_width;
     std::vector<membert> members;
   };
+  using entryt = optionalt<defined_entryt>;
 
   typedef std::unordered_map<typet, entryt, irep_hash> cachet;
 

--- a/src/solvers/flattening/boolbv_with.cpp
+++ b/src/solvers/flattening/boolbv_with.cpp
@@ -22,14 +22,7 @@ bvt boolbvt::convert_with(const with_exprt &expr)
   if(width==0)
   {
     // A zero-length array is acceptable:
-    if(
-      expr.type().id() == ID_array &&
-      boolbv_width(to_array_type(expr.type()).element_type()) != 0)
-    {
-      return bvt();
-    }
-    else
-      return conversion_failed(expr);
+    return bvt{};
   }
 
   DATA_INVARIANT_WITH_DIAGNOSTICS(

--- a/src/solvers/flattening/bv_pointers.cpp
+++ b/src/solvers/flattening/bv_pointers.cpp
@@ -45,12 +45,11 @@ protected:
 
 void bv_endianness_mapt::build_little_endian(const typet &src)
 {
-  const std::size_t width = boolbv_width(src);
-
-  if(width == 0)
+  const auto &width_opt = boolbv_width.get_width_opt(src);
+  if(!width_opt.has_value())
     return;
 
-  const std::size_t new_size = map.size() + width;
+  const std::size_t new_size = map.size() + *width_opt;
   map.reserve(new_size);
 
   for(std::size_t i = map.size(); i < new_size; ++i)
@@ -611,9 +610,6 @@ bvt bv_pointerst::convert_bitvector(const exprt &expr)
   {
     std::size_t width=boolbv_width(expr.type());
 
-    if(width==0)
-      return conversion_failed(expr);
-
     // pointer minus pointer is subtraction over the offset divided by element
     // size, iff the pointers point to the same object
     const auto &minus_expr = to_minus_expr(expr);
@@ -690,9 +686,6 @@ bvt bv_pointerst::convert_bitvector(const exprt &expr)
   {
     std::size_t width=boolbv_width(expr.type());
 
-    if(width==0)
-      return conversion_failed(expr);
-
     const exprt &pointer = to_pointer_offset_expr(expr).pointer();
     const bvt &pointer_bv = convert_bv(pointer);
 
@@ -721,9 +714,6 @@ bvt bv_pointerst::convert_bitvector(const exprt &expr)
   {
     std::size_t width=boolbv_width(expr.type());
 
-    if(width==0)
-      return conversion_failed(expr);
-
     const exprt &pointer = to_pointer_object_expr(expr).pointer();
     const bvt &pointer_bv = convert_bv(pointer);
 
@@ -740,11 +730,7 @@ bvt bv_pointerst::convert_bitvector(const exprt &expr)
     bvt op0 = convert_pointer_type(to_typecast_expr(expr).op());
 
     // squeeze it in!
-
     std::size_t width=boolbv_width(expr.type());
-
-    if(width==0)
-      return conversion_failed(expr);
 
     return bv_utils.zero_extension(op0, width);
   }

--- a/src/solvers/refinement/refine_arrays.cpp
+++ b/src/solvers/refinement/refine_arrays.cpp
@@ -113,6 +113,8 @@ void bv_refinementt::freeze_lazy_constraints()
   {
     for(const auto &symbol : find_symbols(constraint.lazy))
     {
+      if(!bv_width.get_width_opt(symbol.type()).has_value())
+        continue;
       const bvt bv=convert_bv(symbol);
       for(const auto &literal : bv)
         if(!literal.is_constant())

--- a/src/solvers/smt2/smt2_conv.cpp
+++ b/src/solvers/smt2/smt2_conv.cpp
@@ -3051,12 +3051,8 @@ void smt2_convt::convert_union(const union_exprt &expr)
   const exprt &op=expr.op();
 
   std::size_t total_width=boolbv_width(union_type);
-  CHECK_RETURN_WITH_DIAGNOSTICS(
-    total_width != 0, "failed to get union width for union");
 
   std::size_t member_width=boolbv_width(op.type());
-  CHECK_RETURN_WITH_DIAGNOSTICS(
-    member_width != 0, "failed to get union member width for union");
 
   if(total_width==member_width)
   {
@@ -4057,7 +4053,7 @@ void smt2_convt::convert_with(const with_exprt &expr)
       std::size_t struct_width=boolbv_width(struct_type);
 
       // figure out the offset and width of the member
-      boolbv_widtht::membert m=
+      const boolbv_widtht::membert &m =
         boolbv_width.get_member(struct_type, component_name);
 
       out << "(let ((?withop ";
@@ -4107,12 +4103,8 @@ void smt2_convt::convert_with(const with_exprt &expr)
     const exprt &value = expr.new_value();
 
     std::size_t total_width=boolbv_width(union_type);
-    CHECK_RETURN_WITH_DIAGNOSTICS(
-      total_width != 0, "failed to get union width for with");
 
     std::size_t member_width=boolbv_width(value.type());
-    CHECK_RETURN_WITH_DIAGNOSTICS(
-      member_width != 0, "failed to get union member width for with");
 
     if(total_width==member_width)
     {
@@ -4140,24 +4132,19 @@ void smt2_convt::convert_with(const with_exprt &expr)
           expr_type.id()==ID_signedbv)
   {
     // Update bits in a bit-vector. We will use masking and shifts.
+    // TODO: SMT2-ify
+    SMT2_TODO("SMT2-ify");
 
+#if 0
     std::size_t total_width=boolbv_width(expr_type);
-    CHECK_RETURN_WITH_DIAGNOSTICS(
-      total_width != 0, "failed to get total width");
 
     const exprt &index=expr.operands()[1];
     const exprt &value=expr.operands()[2];
 
     std::size_t value_width=boolbv_width(value.type());
-    CHECK_RETURN_WITH_DIAGNOSTICS(
-      value_width != 0, "failed to get value width");
 
     typecast_exprt index_tc(index, expr_type);
 
-    // TODO: SMT2-ify
-    SMT2_TODO("SMT2-ify");
-
-#if 0
     out << "(bvor ";
     out << "(band ";
 
@@ -4232,7 +4219,6 @@ void smt2_convt::convert_index(const index_exprt &expr)
     {
       // fixed size
       std::size_t array_width=boolbv_width(array_type);
-      CHECK_RETURN(array_width != 0);
 
       unflatten(wheret::BEGIN, array_type.element_type());
 
@@ -4324,7 +4310,7 @@ void smt2_convt::convert_member(const member_exprt &expr)
     else
     {
       // we extract
-      const auto member_offset = boolbv_width.get_member(struct_type, name);
+      const auto &member_offset = boolbv_width.get_member(struct_type, name);
 
       if(expr.type().id() == ID_bool)
         out << "(= ";
@@ -5099,8 +5085,6 @@ void smt2_convt::convert_type(const typet &type)
     else
     {
       std::size_t width=boolbv_width(type);
-      CHECK_RETURN_WITH_DIAGNOSTICS(
-        width != 0, "failed to get width of struct");
 
       out << "(_ BitVec " << width << ")";
     }
@@ -5114,8 +5098,6 @@ void smt2_convt::convert_type(const typet &type)
     else
     {
       std::size_t width=boolbv_width(type);
-      CHECK_RETURN_WITH_DIAGNOSTICS(
-        width != 0, "failed to get width of vector");
 
       out << "(_ BitVec " << width << ")";
     }
@@ -5187,8 +5169,6 @@ void smt2_convt::convert_type(const typet &type)
     else
     {
       std::size_t width=boolbv_width(type);
-      CHECK_RETURN_WITH_DIAGNOSTICS(
-        width != 0, "failed to get width of complex");
 
       out << "(_ BitVec " << width << ")";
     }


### PR DESCRIPTION
Use optionalt to distinguish types of known-zero size from those with
unknown size, which previously had the default value of zero.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
