### PR TITLE
Add support for conversion of pointer arithmetic expressions to new SMT backend.

### DIFF
--- a/regression/cbmc-incr-smt2/pointer_arithmetic/addition_compound_expr.c
+++ b/regression/cbmc-incr-smt2/pointer_arithmetic/addition_compound_expr.c
@@ -1,0 +1,13 @@
+#include <stdint.h>
+
+#define NULL (void *)0
+
+int main()
+{
+  int32_t *a;
+  __CPROVER_assume(a != NULL);
+  int32_t *z = a + 2 * sizeof(int32_t);
+
+  __CPROVER_assert(a != z, "expected successful because of pointer arithmetic");
+  __CPROVER_assert(a == z, "expected failure because of pointer arithmetic");
+}

--- a/regression/cbmc-incr-smt2/pointer_arithmetic/addition_compound_expr.desc
+++ b/regression/cbmc-incr-smt2/pointer_arithmetic/addition_compound_expr.desc
@@ -1,0 +1,13 @@
+CORE
+addition_compound_expr.c
+--trace
+\[main\.assertion\.1\] line \d+ expected successful because of pointer arithmetic: SUCCESS
+\[main\.assertion\.2\] line \d+ expected failure because of pointer arithmetic: FAILURE
+^EXIT=10$
+^SIGNAL=0$
+--
+--
+This is testing the same thing as the test in addition_simple.desc, with the
+difference being that the addition expression here is compound, containing a
+more elaborate operand in the form of a multiplication containing a sizeof
+operator.

--- a/regression/cbmc-incr-smt2/pointer_arithmetic/addition_simple.c
+++ b/regression/cbmc-incr-smt2/pointer_arithmetic/addition_simple.c
@@ -1,0 +1,12 @@
+#define NULL (void *)0
+
+int main()
+{
+  int *x;
+  int *y = x + 1;
+  __CPROVER_assume(x != NULL);
+  __CPROVER_assume(y != NULL);
+
+  __CPROVER_assert(y == x, "expected false after pointer manipulation");
+  __CPROVER_assert(y != x, "expected true");
+}

--- a/regression/cbmc-incr-smt2/pointer_arithmetic/addition_simple.desc
+++ b/regression/cbmc-incr-smt2/pointer_arithmetic/addition_simple.desc
@@ -1,0 +1,12 @@
+CORE
+addition_simple.c
+--trace
+\[main\.assertion\.1\] line \d+ expected false after pointer manipulation: FAILURE
+\[main\.assertion\.2\] line \d+ expected true: SUCCESS
+^EXIT=10$
+^SIGNAL=0$
+--
+--
+This is testing basic pointer arithmetic by adding by incrementing a pointer's
+address and assigning that value to another pointer, then asserting that they
+don't point to the same thing.

--- a/regression/cbmc-incr-smt2/pointer_arithmetic/pointer_subtraction.c
+++ b/regression/cbmc-incr-smt2/pointer_arithmetic/pointer_subtraction.c
@@ -1,0 +1,10 @@
+#include <stdlib.h>
+int main()
+{
+  int *x = malloc(sizeof(int));
+  int *y = x + 3;
+  int z = y - x;
+  __CPROVER_assert(y == x, "expected failure after pointer manipulation");
+  __CPROVER_assert(z == 3, "expected successful after pointer manipulation");
+  __CPROVER_assert(z != 3, "expected failure after pointer manipulation");
+}

--- a/regression/cbmc-incr-smt2/pointer_arithmetic/pointer_subtraction.desc
+++ b/regression/cbmc-incr-smt2/pointer_arithmetic/pointer_subtraction.desc
@@ -1,0 +1,13 @@
+CORE
+pointer_subtraction.c
+--trace
+\[main\.assertion\.1\] line \d+ expected failure after pointer manipulation: FAILURE
+\[main\.assertion\.2\] line \d+ expected successful after pointer manipulation: SUCCESS
+\[main\.assertion\.3\] line \d+ expected failure after pointer manipulation: FAILURE
+z=3
+^EXIT=10$
+^SIGNAL=0$
+--
+--
+This test is testing that the subtraction between two pointers (giving us the
+increment between the two pointers) works as it should.

--- a/regression/cbmc-incr-smt2/pointer_arithmetic/pointer_subtraction_diff_types.c
+++ b/regression/cbmc-incr-smt2/pointer_arithmetic/pointer_subtraction_diff_types.c
@@ -1,0 +1,10 @@
+#include <stdlib.h>
+int main()
+{
+  int *x = malloc(sizeof(int));
+  float *y = x + 3;
+  int z = y - x;
+  __CPROVER_assert(y == x, "expected failure after pointer manipulation");
+  __CPROVER_assert(z == 3, "expected successful after pointer manipulation");
+  __CPROVER_assert(z != 3, "expected failure after pointer manipulation");
+}

--- a/regression/cbmc-incr-smt2/pointer_arithmetic/pointer_subtraction_diff_types.desc
+++ b/regression/cbmc-incr-smt2/pointer_arithmetic/pointer_subtraction_diff_types.desc
@@ -1,0 +1,10 @@
+CORE
+pointer_subtraction_diff_types.c
+--trace
+^Reason: only pointers of the same object type can be subtracted.
+^EXIT=(134|127)$
+^SIGNAL=0$
+--
+--
+This test is for making sure that we only subtract pointers with the
+same underlying (base) type.

--- a/regression/cbmc-incr-smt2/pointer_arithmetic/pointer_subtraction_unsigned.c
+++ b/regression/cbmc-incr-smt2/pointer_arithmetic/pointer_subtraction_unsigned.c
@@ -1,0 +1,15 @@
+#define NULL (void *)0
+
+int main()
+{
+  int *x;
+  unsigned int z;
+  __CPROVER_assume(z < 3);
+  __CPROVER_assume(z > 1);
+  int *y = x - z;
+  __CPROVER_assume(x != NULL);
+  __CPROVER_assume(y != NULL);
+
+  __CPROVER_assert(y == x, "expected failure after pointer manipulation");
+  __CPROVER_assert(y != x, "expected success after pointer manipulation");
+}

--- a/regression/cbmc-incr-smt2/pointer_arithmetic/pointer_subtraction_unsigned.desc
+++ b/regression/cbmc-incr-smt2/pointer_arithmetic/pointer_subtraction_unsigned.desc
@@ -1,0 +1,11 @@
+CORE
+pointer_subtraction_unsigned.c
+--trace
+\[main\.assertion\.1\] line \d+ expected failure after pointer manipulation: FAILURE
+\[main\.assertion\.2\] line \d+ expected success after pointer manipulation: SUCCESS
+^EXIT=10$
+^SIGNAL=0$
+--
+--
+The test is similar to the one in `pointer_subtraction.desc`, but with different
+types in the subtraction operands.

--- a/regression/cbmc-incr-smt2/pointer_arithmetic/subtraction_simple.c
+++ b/regression/cbmc-incr-smt2/pointer_arithmetic/subtraction_simple.c
@@ -1,0 +1,12 @@
+#define NULL (void *)0
+
+int main()
+{
+  int *x;
+  int *y = x - 2;
+  __CPROVER_assume(x != NULL);
+  __CPROVER_assume(y != NULL);
+
+  __CPROVER_assert(y == x, "expected failure after pointer manipulation");
+  __CPROVER_assert(y != x, "expected successful after pointer manipulation");
+}

--- a/regression/cbmc-incr-smt2/pointer_arithmetic/subtraction_simple.desc
+++ b/regression/cbmc-incr-smt2/pointer_arithmetic/subtraction_simple.desc
@@ -1,0 +1,11 @@
+CORE
+subtraction_simple.c
+--trace
+\[main\.assertion\.1\] line \d+ expected failure after pointer manipulation: FAILURE
+\[main\.assertion\.2\] line \d+ expected successful after pointer manipulation: SUCCESS
+^EXIT=10$
+^SIGNAL=0$
+--
+--
+This test is similar to the one in `addition_simple.desc`, but testing end-to-end
+the conversion of a subtraction case of pointer arithmetic.

--- a/src/solvers/Makefile
+++ b/src/solvers/Makefile
@@ -196,6 +196,7 @@ SRC = $(BOOLEFORCE_SRC) \
       smt2_incremental/construct_value_expr_from_smt.cpp \
       smt2_incremental/convert_expr_to_smt.cpp \
       smt2_incremental/object_tracking.cpp \
+      smt2_incremental/type_size_mapping.cpp \
       smt2_incremental/smt_bit_vector_theory.cpp \
       smt2_incremental/smt_commands.cpp \
       smt2_incremental/smt_core_theory.cpp \

--- a/src/solvers/smt2_incremental/convert_expr_to_smt.h
+++ b/src/solvers/smt2_incremental/convert_expr_to_smt.h
@@ -7,6 +7,7 @@
 #include <solvers/smt2_incremental/smt_object_size.h>
 #include <solvers/smt2_incremental/smt_sorts.h>
 #include <solvers/smt2_incremental/smt_terms.h>
+#include <solvers/smt2_incremental/type_size_mapping.h>
 
 class exprt;
 class typet;
@@ -20,6 +21,7 @@ smt_sortt convert_type_to_smt_sort(const typet &type);
 smt_termt convert_expr_to_smt(
   const exprt &expression,
   const smt_object_mapt &object_map,
+  const type_size_mapt &pointer_sizes,
   const smt_object_sizet::make_applicationt &object_size);
 
 #endif // CPROVER_SOLVERS_SMT2_INCREMENTAL_CONVERT_EXPR_TO_SMT_H

--- a/src/solvers/smt2_incremental/smt2_incremental_decision_procedure.h
+++ b/src/solvers/smt2_incremental/smt2_incremental_decision_procedure.h
@@ -12,6 +12,7 @@
 #include <solvers/smt2_incremental/object_tracking.h>
 #include <solvers/smt2_incremental/smt_object_size.h>
 #include <solvers/smt2_incremental/smt_terms.h>
+#include <solvers/smt2_incremental/type_size_mapping.h>
 #include <solvers/stack_decision_procedure.h>
 
 #include <memory>
@@ -89,6 +90,7 @@ protected:
   smt_object_mapt object_map;
   std::vector<bool> object_size_defined;
   smt_object_sizet object_size_function;
+  type_size_mapt pointer_sizes_map;
 };
 
 #endif // CPROVER_SOLVERS_SMT2_INCREMENTAL_SMT2_INCREMENTAL_DECISION_PROCEDURE_H

--- a/src/solvers/smt2_incremental/type_size_mapping.cpp
+++ b/src/solvers/smt2_incremental/type_size_mapping.cpp
@@ -1,0 +1,50 @@
+// Author: Diffblue Ltd.
+
+#include "type_size_mapping.h"
+
+#include <util/arith_tools.h>
+#include <util/c_types.h>
+#include <util/invariant.h>
+#include <util/pointer_expr.h>
+#include <util/pointer_offset_size.h>
+
+#include <solvers/smt2_incremental/convert_expr_to_smt.h>
+
+void associate_pointer_sizes(
+  const exprt &expression,
+  const namespacet &ns,
+  type_size_mapt &type_size_map,
+  const smt_object_mapt &object_map,
+  const smt_object_sizet::make_applicationt &object_size)
+{
+  expression.visit_pre([&](const exprt &sub_expression) {
+    if(
+      const auto &pointer_type =
+        type_try_dynamic_cast<pointer_typet>(sub_expression.type()))
+    {
+      const auto find_result = type_size_map.find(pointer_type->base_type());
+      if(find_result != type_size_map.cend())
+        return;
+      exprt pointer_size_expr;
+      // There's a special case for a pointer subtype here: the case where the
+      // pointer is `void *`. This means that we don't know the underlying base
+      // type, so we're just assigning a size expression value of 1 (given that
+      // this is going to be used in a multiplication and 1 is the identity
+      // value for multiplication)
+      if(is_void_pointer(*pointer_type))
+      {
+        pointer_size_expr = from_integer(1, size_type());
+      }
+      else
+      {
+        auto pointer_size_opt = size_of_expr(pointer_type->base_type(), ns);
+        PRECONDITION(pointer_size_opt.has_value());
+        pointer_size_expr = pointer_size_opt.value();
+      }
+      auto pointer_size_term = convert_expr_to_smt(
+        pointer_size_expr, object_map, type_size_map, object_size);
+      type_size_map.emplace_hint(
+        find_result, pointer_type->base_type(), pointer_size_term);
+    }
+  });
+}

--- a/src/solvers/smt2_incremental/type_size_mapping.h
+++ b/src/solvers/smt2_incremental/type_size_mapping.h
@@ -1,0 +1,38 @@
+// Author: Diffblue Ltd.
+
+/// \file
+/// Utilities for making a map of types to associated sizes.
+
+#ifndef CPROVER_SOLVERS_SMT2_INCREMENTAL_TYPE_SIZE_MAPPING_H
+#define CPROVER_SOLVERS_SMT2_INCREMENTAL_TYPE_SIZE_MAPPING_H
+
+#include <util/expr.h>
+
+#include <solvers/smt2_incremental/object_tracking.h>
+#include <solvers/smt2_incremental/smt_object_size.h>
+#include <solvers/smt2_incremental/smt_terms.h>
+
+#include <unordered_map>
+
+using type_size_mapt = std::unordered_map<typet, smt_termt, irep_full_hash>;
+
+/// This function populates the (pointer) type -> size map.
+/// \param expression: the expression we're building the map for.
+/// \param ns:
+///   A namespace - passed to size_of_expr to lookup type symbols in case the
+///   pointers have type `tag_typet`, rather than a more completely defined
+///   type.
+/// \param type_size_map:
+///   A map of types to terms expressing the size of the type (in bytes). This
+///   function adds new entries to the map for instances of pointer.base_type()
+///   from \p expression which are not already keys in the map.
+/// \param object_map: passed through to convert_expr_to_smt
+/// \param object_size: passed through to convert_expr_to_smt
+void associate_pointer_sizes(
+  const exprt &expression,
+  const namespacet &ns,
+  type_size_mapt &type_size_map,
+  const smt_object_mapt &object_map,
+  const smt_object_sizet::make_applicationt &object_size);
+
+#endif

--- a/unit/solvers/smt2_incremental/convert_expr_to_smt.cpp
+++ b/unit/solvers/smt2_incremental/convert_expr_to_smt.cpp
@@ -14,6 +14,7 @@
 
 #include <solvers/smt2_incremental/convert_expr_to_smt.h>
 #include <solvers/smt2_incremental/object_tracking.h>
+#include <solvers/smt2_incremental/pointer_size_mapping.h>
 #include <solvers/smt2_incremental/smt_bit_vector_theory.h>
 #include <solvers/smt2_incremental/smt_core_theory.h>
 #include <solvers/smt2_incremental/smt_terms.h>
@@ -57,6 +58,7 @@ struct expr_to_smt_conversion_test_environmentt
 
   smt_object_mapt object_map;
   smt_object_sizet object_size_function;
+  pointer_size_mapt pointer_sizes;
 
 private:
   // This is private to ensure the above make() function is used to make
@@ -88,7 +90,10 @@ smt_termt
 expr_to_smt_conversion_test_environmentt::convert(const exprt &expression) const
 {
   return convert_expr_to_smt(
-    expression, object_map, object_size_function.make_application);
+    expression,
+    object_map,
+    pointer_sizes,
+    object_size_function.make_application);
 }
 
 TEST_CASE("\"symbol_exprt\" to smt term conversion", "[core][smt2_incremental]")

--- a/unit/solvers/smt2_incremental/convert_expr_to_smt.cpp
+++ b/unit/solvers/smt2_incremental/convert_expr_to_smt.cpp
@@ -14,11 +14,11 @@
 
 #include <solvers/smt2_incremental/convert_expr_to_smt.h>
 #include <solvers/smt2_incremental/object_tracking.h>
-#include <solvers/smt2_incremental/pointer_size_mapping.h>
 #include <solvers/smt2_incremental/smt_bit_vector_theory.h>
 #include <solvers/smt2_incremental/smt_core_theory.h>
 #include <solvers/smt2_incremental/smt_terms.h>
 #include <solvers/smt2_incremental/smt_to_smt2_string.h>
+#include <solvers/smt2_incremental/type_size_mapping.h>
 #include <testing-utils/invariant.h>
 #include <testing-utils/use_catch.h>
 
@@ -58,7 +58,7 @@ struct expr_to_smt_conversion_test_environmentt
 
   smt_object_mapt object_map;
   smt_object_sizet object_size_function;
-  pointer_size_mapt pointer_sizes;
+  type_size_mapt pointer_sizes;
 
 private:
   // This is private to ensure the above make() function is used to make
@@ -334,6 +334,7 @@ TEST_CASE(
   auto test = expr_to_smt_conversion_test_environmentt::make(test_archt::i386);
   const smt_termt smt_term_one = smt_bit_vector_constant_termt{1, 8};
   const smt_termt smt_term_two = smt_bit_vector_constant_termt{2, 8};
+  const auto two_bvint_32bit = from_integer({2}, signedbv_typet{32});
 
   // Just regular (bit-vector) integers, to be used for the comparison
   const auto one_bvint = from_integer({1}, signedbv_typet{8});
@@ -341,12 +342,49 @@ TEST_CASE(
   const auto one_bvint_unsigned = from_integer({1}, unsignedbv_typet{8});
   const auto two_bvint_unsigned = from_integer({2}, unsignedbv_typet{8});
 
+  // Pointer variables, used for comparisons
+  const std::size_t pointer_width = 32;
+  const auto pointer_type = pointer_typet(signedbv_typet{32}, pointer_width);
+  const symbol_exprt pointer_a("a", pointer_type);
+  const symbol_exprt pointer_b("b", pointer_type);
+  // SMT terms needed for pointer comparisons
+  const smt_termt smt_term_a =
+    smt_identifier_termt{"a", smt_bit_vector_sortt{pointer_width}};
+  const smt_termt smt_term_b =
+    smt_identifier_termt{"b", smt_bit_vector_sortt{pointer_width}};
+  const smt_termt smt_term_four_32bit = smt_bit_vector_constant_termt{4, 32};
+  const smt_termt smt_term_two_32bit = smt_bit_vector_constant_termt{2, 32};
+
   SECTION("Addition of two constant size bit-vectors")
   {
     const auto constructed_term =
       test.convert(plus_exprt{one_bvint, two_bvint});
     const auto expected_term =
       smt_bit_vector_theoryt::add(smt_term_one, smt_term_two);
+    CHECK(constructed_term == expected_term);
+  }
+
+  SECTION("Addition of a pointer and a constant")
+  {
+    // (int32_t *)a + 2
+    const auto pointer_arith_expr = plus_exprt{pointer_a, two_bvint_32bit};
+    const symbol_tablet symbol_table;
+    const namespacet ns{symbol_table};
+    track_expression_objects(pointer_arith_expr, ns, test.object_map);
+    associate_pointer_sizes(
+      pointer_arith_expr,
+      ns,
+      test.pointer_sizes,
+      test.object_map,
+      test.object_size_function.make_application);
+
+    INFO("Input expr: " + pointer_arith_expr.pretty(2, 0));
+    const auto constructed_term = test.convert(pointer_arith_expr);
+    const auto expected_term = smt_bit_vector_theoryt::add(
+      smt_term_a,
+      smt_bit_vector_theoryt::multiply(
+        smt_term_two_32bit, smt_term_four_32bit));
+
     CHECK(constructed_term == expected_term);
   }
 
@@ -394,6 +432,71 @@ TEST_CASE(
     const auto four_bv_int = from_integer({4}, signedbv_typet{8});
     exprt::operandst one_operand{four_bv_int};
     REQUIRE_THROWS(test.convert(plus_exprt{one_operand, signedbv_typet{8}}));
+  }
+
+  SECTION("Subtraction of constant value from pointer")
+  {
+    // (int32_t *)a - 2
+    const auto minus_two_bvint =
+      from_integer(-2, signedbv_typet{pointer_width});
+    // NOTE: not a mistake! An expression in source code of the form
+    // (int *)a - 2 is coming to us as (int *)a + (-2), so a design decision
+    // was made to handle only that form.
+    const auto pointer_arith_expr = plus_exprt{pointer_a, minus_two_bvint};
+    const symbol_tablet symbol_table;
+    const namespacet ns{symbol_table};
+    track_expression_objects(pointer_arith_expr, ns, test.object_map);
+    associate_pointer_sizes(
+      pointer_arith_expr,
+      ns,
+      test.pointer_sizes,
+      test.object_map,
+      test.object_size_function.make_application);
+
+    INFO("Input expr: " + pointer_arith_expr.pretty(2, 0));
+    const auto constructed_term = test.convert(pointer_arith_expr);
+    const auto expected_term = smt_bit_vector_theoryt::add(
+      smt_term_a,
+      smt_bit_vector_theoryt::multiply(
+        smt_bit_vector_theoryt::negate(smt_term_two_32bit),
+        smt_term_four_32bit));
+  }
+
+  SECTION(
+    "Ensure that conversion of a minus node with only one operand"
+    "being a pointer fails")
+  {
+    // (*int32_t)a - 2
+    const cbmc_invariants_should_throwt invariants_throw;
+    // We don't support that - look at the test above.
+    const auto pointer_arith_expr = minus_exprt{pointer_a, two_bvint};
+    REQUIRE_THROWS_MATCHES(
+      test.convert(pointer_arith_expr),
+      invariant_failedt,
+      invariant_failure_containing(
+        "convert_expr_to_smt::minus_exprt doesn't handle expressions where"
+        "only one operand is a pointer - this is because these expressions"));
+  }
+
+  SECTION("Subtraction of two pointer arguments")
+  {
+    // (int32_t *)a - (int32_t *)b
+    const auto pointer_subtraction = minus_exprt{pointer_b, pointer_a};
+    const symbol_tablet symbol_table;
+    const namespacet ns{symbol_table};
+    track_expression_objects(pointer_subtraction, ns, test.object_map);
+    associate_pointer_sizes(
+      pointer_subtraction,
+      ns,
+      test.pointer_sizes,
+      test.object_map,
+      test.object_size_function.make_application);
+    INFO("Input expr: " + pointer_subtraction.pretty(2, 0));
+    const auto constructed_term = test.convert(pointer_subtraction);
+    const auto expected_term = smt_bit_vector_theoryt::signed_divide(
+      smt_bit_vector_theoryt::subtract(smt_term_b, smt_term_a),
+      smt_term_four_32bit);
+    CHECK(constructed_term == expected_term);
   }
 
   SECTION("Subtraction of two constant size bit-vectors")


### PR DESCRIPTION
This PR adds the capability to handle expressions like the following:

```c
int *a;
int *b;

a + 1;
a + (2 * sizeof(int)
a - 2;
a - b;
```

to the new SMT backend, along with regression tests and unit tests.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
