### PR TITLE
Add Open Source Team to /src/util CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -32,7 +32,7 @@
 
 /src/cbmc/ @kroening @tautschnig @peterschrammel @NlightNFotis @thomasspriggs
 /src/goto-programs/ @kroening @tautschnig @peterschrammel
-/src/util/ @kroening @tautschnig @peterschrammel
+/src/util/ @kroening @tautschnig @peterschrammel @thomasspriggs @NlightNFotis @TGWDB
 /src/solvers/refinement @martin-cs @romainbrenguier @peterschrammel
 /src/solvers/strings @martin-cs @romainbrenguier @peterschrammel
 /jbmc/src/java_bytecode/ @romainbrenguier @peterschrammel


### PR DESCRIPTION
This adds some members of the Open Source Team at Diffblue to
the /src/util CODEOWNERS list.

Note that this is to extend redundant PR coverage to areas of the codebase where they have expertise and can suitably PR. Due to the general nature of the code in `/src/util` this extended code ownership is to be used sparingly.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
