### PR TITLE
Support _Complex in the C++ front-end

### DIFF
--- a/regression/ansi-c/gcc_attributes6/test.desc
+++ b/regression/ansi-c/gcc_attributes6/test.desc
@@ -1,4 +1,4 @@
-CORE gcc-only
+CORE gcc-only test-c++-front-end
 main.c
 
 ^EXIT=0$

--- a/src/cpp/cpp_convert_type.cpp
+++ b/src/cpp/cpp_convert_type.cpp
@@ -330,14 +330,9 @@ void cpp_convert_plain_type(typet &type, message_handlert &message_handler)
     type.id() == ID_union || type.id() == ID_array || type.id() == ID_code ||
     type.id() == ID_unsignedbv || type.id() == ID_signedbv ||
     type.id() == ID_bool || type.id() == ID_floatbv || type.id() == ID_empty ||
-    type.id() == ID_constructor || type.id() == ID_destructor)
+    type.id() == ID_constructor || type.id() == ID_destructor ||
+    type.id() == ID_c_enum)
   {
-  }
-  else if(type.id()==ID_c_enum)
-  {
-    // add width -- we use int, but the standard
-    // doesn't guarantee that
-    type.set(ID_width, config.ansi_c.int_width);
   }
   else if(type.id() == ID_c_bool)
   {

--- a/src/cpp/cpp_typecheck_type.cpp
+++ b/src/cpp/cpp_typecheck_type.cpp
@@ -9,15 +9,15 @@ Author: Daniel Kroening, kroening@cs.cmu.edu
 /// \file
 /// C++ Language Type Checking
 
-#include "cpp_typecheck.h"
-
-#include <util/source_location.h>
-#include <util/simplify_expr.h>
 #include <util/c_types.h>
+#include <util/simplify_expr.h>
+#include <util/source_location.h>
 
 #include <ansi-c/c_qualifiers.h>
+#include <ansi-c/merged_type.h>
 
 #include "cpp_convert_type.h"
+#include "cpp_typecheck.h"
 #include "cpp_typecheck_fargs.h"
 
 void cpp_typecheckt::typecheck_type(typet &type)
@@ -274,6 +274,13 @@ void cpp_typecheckt::typecheck_type(typet &type)
   }
   else if(type.id() == ID_gcc_attribute_mode)
   {
+    PRECONDITION(type.has_subtype());
+    merged_typet as_parsed;
+    as_parsed.move_to_subtypes(type.subtype());
+    type.get_sub().clear();
+    as_parsed.move_to_subtypes(type);
+    type.swap(as_parsed);
+
     c_typecheck_baset::typecheck_type(type);
   }
   else if(type.id() == ID_complex)

--- a/src/cpp/cpp_typecheck_type.cpp
+++ b/src/cpp/cpp_typecheck_type.cpp
@@ -276,6 +276,10 @@ void cpp_typecheckt::typecheck_type(typet &type)
   {
     c_typecheck_baset::typecheck_type(type);
   }
+  else if(type.id() == ID_complex)
+  {
+    // already done
+  }
   else
   {
     error().source_location=type.source_location();


### PR DESCRIPTION
We typecheck this via the same code path as the C front-end, and just
need to accept that this type exists.

Clang-14 uses _Complex in system headers, and moving to Ubuntu 22.04
GitHub runners requires fixing this first.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
