### PR TITLE
XML counterexample trace: display member types

### DIFF
--- a/doc/assets/xml_spec.xsd
+++ b/doc/assets/xml_spec.xsd
@@ -39,7 +39,7 @@
   <xs:complexType>
     <xs:all>
       <xs:element ref="location" minOccurs="0"/>
-      <xs:element name="type" type="xs:string" minOccurs="0"/>
+      <xs:element name="full_lhs_type" type="xs:string" minOccurs="0"/>
       <xs:element name="full_lhs" type="xs:string"/>
       <xs:element name="full_lhs_value">
         <xs:complexType>

--- a/regression/cbmc/xml-trace/test.desc
+++ b/regression/cbmc/xml-trace/test.desc
@@ -1,23 +1,13 @@
 CORE broken-smt-backend
 main.c
 --xml-ui --function test --little-endian
+activate-multi-line-match
 ^EXIT=10$
 ^SIGNAL=0$
 VERIFICATION FAILED
-<assignment assignment_type="state" base_name="u" display_name="test::u" hidden="false" identifier="test::u" mode="C" step_nr="\d+" thread="0">
-<location file=".*" function="test" line="\d+" working-directory=".*"/>
-<type>union myunion</type>
-<full_lhs>byte_extract_little_endian\(u, 0ll?, .*int.*\)</full_lhs>
-<full_lhs_value binary="[01]+">\d+ll?</full_lhs_value>
-<value>\{ \.i=\d+ll? \}</value>
-<value_expression>
-<union>
-<member member_name="i">
-<integer binary="\d+" c_type=".*int.*" width="\d+">\d+</integer>
-</member>
-</union>
-</value_expression>
-</assignment>
+<assignment assignment_type="actual_parameter" base_name="u" display_name="test::u" hidden="false" identifier="test::u" mode="C" step_nr="\d+" thread="0">\n\s*<location file=".*" line="\d+" working-directory=".*"/>\n\s*<full_lhs_type>union myunion</full_lhs_type>\n\s*<full_lhs>u</full_lhs>
+<value>\{ \.i=\d+ll? \}</value>\n\s*<value_expression>\n\s*<union>\n\s*<member member_name="i">\n\s*<integer binary="\d+" c_type=".*int.*" width="\d+">\d+</integer>\n\s*</member>\n\s*</union>\n\s*</value_expression>
+<assignment assignment_type="state" base_name="u" display_name="test::u" hidden="false" identifier="test::u" mode="C" step_nr="\d+" thread="0">\n\s*<location file=".*" function="test" line="\d+" working-directory=".*"/>\n\s*<full_lhs_type>signed long( long)? int</full_lhs_type>\n\s*<full_lhs>byte_extract_little_endian\(u, 0ll?, .*int.*\)</full_lhs>\n\s*<full_lhs_value binary="[01]+">\d+ll?</full_lhs_value>\n\s*</assignment>
 --
 ^warning: ignoring
 --

--- a/src/goto-programs/xml_goto_trace.cpp
+++ b/src/goto-programs/xml_goto_trace.cpp
@@ -140,7 +140,8 @@ void convert(
           lhs_object.has_value() &&
           !ns.lookup(lhs_object->get_identifier(), symbol))
         {
-          std::string type_string = from_type(ns, symbol->name, symbol->type);
+          std::string type_string =
+            from_type(ns, symbol->name, step.full_lhs.type());
 
           xml_assignment.set_attribute("mode", id2string(symbol->mode));
           xml_assignment.set_attribute("identifier", id2string(symbol->name));
@@ -148,7 +149,7 @@ void convert(
             "base_name", id2string(symbol->base_name));
           xml_assignment.set_attribute(
             "display_name", id2string(symbol->display_name()));
-          xml_assignment.new_element("type").data = type_string;
+          xml_assignment.new_element("full_lhs_type").data = type_string;
         }
       }
 


### PR DESCRIPTION
Field-sensitive SSA yields assignments at member/element level. The XML
counterexamples, however, appeared to (continue to) assume that all
assignments take place at object level. Adjust the type (which is only
included in XML output, not in JSON nor plain output) to match that of
the element being assigned.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
