### PR TITLE
Goto-symex: record value-at-declaration in the back-end

### DIFF
--- a/regression/cbmc/atomic_section_seq1/test.desc
+++ b/regression/cbmc/atomic_section_seq1/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE broken-smt-backend
 main.c
 
 ^EXIT=10$
@@ -6,3 +6,6 @@ main.c
 ^VERIFICATION FAILED$
 --
 ^warning: ignoring
+--
+This test involves empty structs, which the SMT2 back-end does not currently
+support.

--- a/regression/cbmc/trace-values/trace-values.c
+++ b/regression/cbmc/trace-values/trace-values.c
@@ -16,6 +16,7 @@ int main()
   int *q=&my_nested[1].f;
   int *null=0;
   int *junk;
+  struct S s;
 
   global_var=1;
   static_var=2;
@@ -33,6 +34,9 @@ int main()
 
   // assign entire struct
   my_nested[1]=my_nested[0];
+
+  // struct member
+  s.f = 42;
 
   // get a trace
   __CPROVER_assert(0, "");

--- a/regression/cbmc/trace-values/trace-values.desc
+++ b/regression/cbmc/trace-values/trace-values.desc
@@ -3,6 +3,7 @@ trace-values.c
 --trace
 ^EXIT=10$
 ^SIGNAL=0$
+^  s=\{ \.f=-?\d+, \.array=\{ -?\d+, -?\d+, -?\d+ \} \} \(\{ [01 ]+, \{ [01 ]+, [01 ]+, [01 ]+ \} \}\)$
 ^  global_var=1 .*$
 ^  static_var=2 .*$
 ^  local_var=3 .*$
@@ -12,6 +13,7 @@ trace-values.c
 ^  dynamic_object1\[1.*\]=8 .*$
 ^  my_nested\[1.*\](=\{ )?.f=0[ ,]
 ^  my_nested\[1.*\](=\{ .f=0, )?.array=\{ 0, 4, 0 \}
+^  s\.f=42 \([0 ]+ 00101010\)$
 ^VERIFICATION FAILED$
 --
 ^warning: ignoring

--- a/src/goto-symex/symex_target_equation.cpp
+++ b/src/goto-symex/symex_target_equation.cpp
@@ -389,6 +389,8 @@ void symex_target_equationt::convert_decls(
       // The result is not used, these have no impact on
       // the satisfiability of the formula.
       decision_procedure.handle(step.cond_expr);
+      decision_procedure.handle(
+        equal_exprt{step.ssa_full_lhs, step.ssa_full_lhs});
       step.converted = true;
       with_solver_hardness(
         decision_procedure, hardness_register_ssa(step_index, step));


### PR DESCRIPTION
Declarations are printed as part of a symex trace, and come with both a
symbol being declared as well as an (unconstrained) initial value for
that symbol. The decision procedure must learn about the initial value
to include it in the model. Else, the trace value would just be question
marks.

Fixes: #6845

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
