### PR TITLE
Add deprecation warning for intrinsic `__CPROVER_allocated_memory` 

### DIFF
--- a/regression/cbmc/memory_allocation1/test.desc
+++ b/regression/cbmc/memory_allocation1/test.desc
@@ -3,6 +3,7 @@ main.c
 --pointer-check
 ^EXIT=10$
 ^SIGNAL=0$
+^\*\*\*\* WARNING: `__CPROVER_allocated_memory' in file main\.c line \d+ function main$
 ^\[main\.pointer_dereference\.2\] .* dereference failure: invalid integer address in \*p: SUCCESS$
 ^\[main\.assertion\.1\] .* assertion \*p==42: SUCCESS$
 ^\[main\.pointer_dereference\.[0-9]+\] .* dereference failure: invalid integer address in p\[.*1\]: FAILURE$

--- a/src/ansi-c/goto_check_c.cpp
+++ b/src/ansi-c/goto_check_c.cpp
@@ -436,6 +436,17 @@ void goto_check_ct::collect_allocations(const goto_functionst &goto_functions)
           "allocated_memory")
         continue;
 
+      const auto function_line = function.source_location().as_string();
+      log.warning() << "**** WARNING: `" CPROVER_PREFIX "allocated_memory' in "
+                    << function_line << messaget::eom;
+      log.warning() << "**** WARNING: `" CPROVER_PREFIX
+                       "allocated_memory' is "
+                       "deprecated and scheduled for deletion "
+                    << "in version 6 and upwards." << messaget::eom;
+      log.warning() << "Please avoid using this intrinsic. For more "
+                       "information, please check issue "
+                    << "cbmc#6872 in Github" << messaget::eom;
+
       const code_function_callt::argumentst &args =
         instruction.call_arguments();
       if(


### PR DESCRIPTION
In line with https://github.com/diffblue/cbmc/issues/6872, this PR adds a deprecation warning for the usage of the intrinsic `__CPROVER_allocated_memory`.

Fixes: https://github.com/diffblue/cbmc/issues/6872
<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
