### PR TITLE
remove uses of typet::subtype() const

### DIFF
--- a/jbmc/src/java_bytecode/assignments_from_json.cpp
+++ b/jbmc/src/java_bytecode/assignments_from_json.cpp
@@ -397,8 +397,8 @@ static code_with_references_listt assign_array_data_component_from_json(
 {
   const auto &java_class_type = followed_class_type(expr, info.symbol_table);
   const auto &data_component = java_class_type.components()[2];
-  const auto &element_type =
-    java_array_element_type(to_struct_tag_type(expr.type().subtype()));
+  const auto &element_type = java_array_element_type(
+    to_struct_tag_type(to_pointer_type(expr.type()).base_type()));
   const exprt data_member_expr = typecast_exprt::conditional_cast(
     member_exprt{dereference_exprt{expr}, "data", data_component.type()},
     pointer_type(element_type));
@@ -461,8 +461,8 @@ assign_det_length_array_from_json(
   object_creation_infot &info)
 {
   PRECONDITION(is_java_array_type(expr.type()));
-  const auto &element_type =
-    java_array_element_type(to_struct_tag_type(expr.type().subtype()));
+  const auto &element_type = java_array_element_type(
+    to_struct_tag_type(to_java_reference_type(expr.type()).base_type()));
   const json_arrayt json_array = get_untyped_array(json, element_type);
   const auto number_of_elements =
     from_integer(json_array.size(), java_int_type());
@@ -490,8 +490,8 @@ static code_with_references_listt assign_nondet_length_array_from_json(
   object_creation_infot &info)
 {
   PRECONDITION(is_java_array_type(array.type()));
-  const auto &element_type =
-    java_array_element_type(to_struct_tag_type(array.type().subtype()));
+  const auto &element_type = java_array_element_type(
+    to_struct_tag_type(to_java_reference_type(array.type()).base_type()));
   const json_arrayt json_array = get_untyped_array(json, element_type);
   code_with_references_listt result;
   exprt number_of_elements = from_integer(json_array.size(), java_int_type());
@@ -884,8 +884,8 @@ code_with_references_listt assign_from_json_rec(
       else
       {
         PRECONDITION(is_java_array_type(expr.type()));
-        const auto &element_type =
-          java_array_element_type(to_struct_tag_type(expr.type().subtype()));
+        const auto &element_type = java_array_element_type(
+          to_struct_tag_type(to_java_reference_type(expr.type()).base_type()));
         const std::size_t length = get_untyped_array(json, element_type).size();
         result.add(allocate_array(
           expr, from_integer(length, java_int_type()), info.loc));

--- a/jbmc/src/java_bytecode/java_types.cpp
+++ b/jbmc/src/java_bytecode/java_types.cpp
@@ -164,11 +164,12 @@ bool is_java_array_type(const typet &type)
 {
   if(
     !can_cast_type<pointer_typet>(type) ||
-    !can_cast_type<struct_tag_typet>(type.subtype()))
+    !can_cast_type<struct_tag_typet>(to_pointer_type(type).base_type()))
   {
     return false;
   }
-  const auto &subtype_struct_tag = to_struct_tag_type(type.subtype());
+  const auto &subtype_struct_tag =
+    to_struct_tag_type(to_pointer_type(type).base_type());
   return is_java_array_tag(subtype_struct_tag.get_identifier());
 }
 
@@ -177,8 +178,9 @@ bool is_java_array_type(const typet &type)
 /// an array type.
 bool is_multidim_java_array_type(const typet &type)
 {
-  return is_java_array_type(type) && is_java_array_type(java_array_element_type(
-                                       to_struct_tag_type(type.subtype())));
+  return is_java_array_type(type) &&
+         is_java_array_type(java_array_element_type(
+           to_struct_tag_type(to_pointer_type(type).base_type())));
 }
 
 /// Returns the underlying element type and array dimensionality of Java struct
@@ -190,8 +192,8 @@ java_array_dimension_and_element_type(const struct_tag_typet &type)
   typet underlying_type;
   for(underlying_type = java_reference_type(type);
       is_java_array_type(underlying_type);
-      underlying_type =
-        java_array_element_type(to_struct_tag_type(underlying_type.subtype())))
+      underlying_type = java_array_element_type(to_struct_tag_type(
+        to_java_reference_type(underlying_type).base_type())))
   {
     ++array_dimensions;
   }
@@ -539,7 +541,7 @@ size_t find_closing_semi_colon_for_reference_type(
 java_reference_typet java_reference_array_type(const struct_tag_typet &subtype)
 {
   java_reference_typet result = java_array_type('a');
-  result.subtype().set(ID_element_type, java_reference_type(subtype));
+  result.base_type().set(ID_element_type, java_reference_type(subtype));
   return result;
 }
 
@@ -892,11 +894,13 @@ bool equal_java_types(const typet &type1, const typet &type2)
   bool arrays_with_same_element_type = true;
   if(
     type1.id() == ID_pointer && type2.id() == ID_pointer &&
-    type1.subtype().id() == ID_struct_tag &&
-    type2.subtype().id() == ID_struct_tag)
+    to_pointer_type(type1).base_type().id() == ID_struct_tag &&
+    to_pointer_type(type2).base_type().id() == ID_struct_tag)
   {
-    const auto &subtype_symbol1 = to_struct_tag_type(type1.subtype());
-    const auto &subtype_symbol2 = to_struct_tag_type(type2.subtype());
+    const auto &subtype_symbol1 =
+      to_struct_tag_type(to_pointer_type(type1).base_type());
+    const auto &subtype_symbol2 =
+      to_struct_tag_type(to_pointer_type(type2).base_type());
     if(
       subtype_symbol1.get_identifier() == subtype_symbol2.get_identifier() &&
       is_java_array_tag(subtype_symbol1.get_identifier()))
@@ -952,7 +956,8 @@ void get_dependencies_from_generic_parameters_rec(
   // Java reference type
   else if(t.id() == ID_pointer)
   {
-    get_dependencies_from_generic_parameters_rec(t.subtype(), refs);
+    get_dependencies_from_generic_parameters_rec(
+      to_pointer_type(t).base_type(), refs);
   }
 
   // method type with parameters and return value
@@ -1102,9 +1107,10 @@ std::string pretty_java_type(const typet &type)
     return "byte";
   else if(is_reference(type))
   {
-    if(type.subtype().id() == ID_struct_tag)
+    if(to_reference_type(type).base_type().id() == ID_struct_tag)
     {
-      const auto &struct_tag_type = to_struct_tag_type(type.subtype());
+      const auto &struct_tag_type =
+        to_struct_tag_type(to_reference_type(type).base_type());
       const irep_idt &id = struct_tag_type.get_identifier();
       if(is_java_array_tag(id))
         return pretty_java_type(java_array_element_type(struct_tag_type)) +

--- a/jbmc/src/java_bytecode/remove_instanceof.cpp
+++ b/jbmc/src/java_bytecode/remove_instanceof.cpp
@@ -176,8 +176,8 @@ bool remove_instanceoft::lower_instanceof(
 
   if(target_type_is_reference_array)
   {
-    const auto &underlying_type =
-      to_struct_tag_type(underlying_type_and_dimension.first.subtype());
+    const auto &underlying_type = to_struct_tag_type(
+      to_pointer_type(underlying_type_and_dimension.first).base_type());
 
     test_conjuncts.push_back(equal_exprt(
       object_class_identifier_field,

--- a/jbmc/src/java_bytecode/remove_java_new.cpp
+++ b/jbmc/src/java_bytecode/remove_java_new.cpp
@@ -88,7 +88,7 @@ goto_programt::targett remove_java_newt::lower_java_new(
   PRECONDITION(rhs.operands().empty());
   PRECONDITION(rhs.type().id() == ID_pointer);
   source_locationt location = rhs.source_location();
-  typet object_type = rhs.type().subtype();
+  typet object_type = to_pointer_type(rhs.type()).base_type();
 
   // build size expression
   const auto object_size = size_of_expr(object_type, ns);
@@ -141,7 +141,8 @@ goto_programt::targett remove_java_newt::lower_java_new_array(
   PRECONDITION(rhs.type().id() == ID_pointer);
 
   source_locationt location = rhs.source_location();
-  struct_tag_typet object_type = to_struct_tag_type(rhs.type().subtype());
+  struct_tag_typet object_type =
+    to_struct_tag_type(to_pointer_type(rhs.type()).base_type());
   PRECONDITION(ns.follow(object_type).id() == ID_struct);
 
   // build size expression
@@ -201,7 +202,8 @@ goto_programt::targett remove_java_newt::lower_java_new_array(
       goto_programt::make_assignment(code_assignt(
         object_array_element_type,
         constant_exprt(
-          to_struct_tag_type(underlying_type_and_dimension.first.subtype())
+          to_struct_tag_type(
+            to_pointer_type(underlying_type_and_dimension.first).base_type())
             .get_identifier(),
           string_typet()),
         location)));
@@ -307,8 +309,8 @@ goto_programt::targett remove_java_newt::lower_java_new_array(
     sub_java_new.operands().erase(sub_java_new.operands().begin());
 
     // we already know that rhs has pointer type
-    typet sub_type =
-      static_cast<const typet &>(rhs.type().subtype().find(ID_element_type));
+    typet sub_type = static_cast<const typet &>(
+      to_pointer_type(rhs.type()).base_type().find(ID_element_type));
     CHECK_RETURN(sub_type.id() == ID_pointer);
     sub_java_new.type() = sub_type;
 

--- a/src/analyses/variable-sensitivity/constant_pointer_abstract_object.cpp
+++ b/src/analyses/variable-sensitivity/constant_pointer_abstract_object.cpp
@@ -201,7 +201,7 @@ abstract_object_pointert constant_pointer_abstract_objectt::read_dereference(
     // Return top if dereferencing a null pointer or we are top
     bool is_value_top = is_top() || value_stack.is_top_value();
     return env.abstract_object_factory(
-      type().subtype(), ns, is_value_top, !is_value_top);
+      to_pointer_type(type()).base_type(), ns, is_value_top, !is_value_top);
   }
   else
   {
@@ -230,7 +230,8 @@ abstract_object_pointert constant_pointer_abstract_objectt::write_dereference(
   if(stack.empty())
   {
     // We should not be changing the type of an abstract object
-    PRECONDITION(new_value->type() == ns.follow(type().subtype()));
+    PRECONDITION(
+      new_value->type() == ns.follow(to_pointer_type(type()).base_type()));
 
     // Get an expression that we can assign to
     exprt value = to_address_of_expr(value_stack.to_expression()).object();
@@ -273,7 +274,8 @@ abstract_object_pointert constant_pointer_abstract_objectt::typecast(
   {
     auto &env = const_cast<abstract_environmentt &>(environment);
 
-    auto heap_array_type = array_typet(new_type.subtype(), nil_exprt());
+    auto heap_array_type =
+      array_typet(to_pointer_type(new_type).base_type(), nil_exprt());
     auto array_object =
       environment.abstract_object_factory(heap_array_type, ns, true, false);
     auto heap_symbol = symbol_exprt(value.get(ID_identifier), heap_array_type);

--- a/src/analyses/variable-sensitivity/full_array_abstract_object.cpp
+++ b/src/analyses/variable-sensitivity/full_array_abstract_object.cpp
@@ -394,7 +394,8 @@ abstract_object_pointert full_array_abstract_objectt::get_top_entry(
   const abstract_environmentt &env,
   const namespacet &ns) const
 {
-  return env.abstract_object_factory(type().subtype(), ns, true, false);
+  return env.abstract_object_factory(
+    to_type_with_subtype(type()).subtype(), ns, true, false);
 }
 
 abstract_object_pointert full_array_abstract_objectt::write_location_context(

--- a/src/analyses/variable-sensitivity/value_set_pointer_abstract_object.cpp
+++ b/src/analyses/variable-sensitivity/value_set_pointer_abstract_object.cpp
@@ -70,7 +70,7 @@ abstract_object_pointert value_set_pointer_abstract_objectt::read_dereference(
   if(is_top() || is_bottom())
   {
     return env.abstract_object_factory(
-      type().subtype(), ns, is_top(), !is_top());
+      to_pointer_type(type()).base_type(), ns, is_top(), !is_top());
   }
 
   abstract_object_sett results;

--- a/src/analyses/variable-sensitivity/variable_sensitivity_domain.cpp
+++ b/src/analyses/variable-sensitivity/variable_sensitivity_domain.cpp
@@ -11,6 +11,7 @@ Date: April 2016
 #include "variable_sensitivity_domain.h"
 
 #include <util/cprover_prefix.h>
+#include <util/pointer_expr.h>
 #include <util/symbol_table.h>
 
 #include <algorithm>
@@ -325,7 +326,9 @@ void variable_sensitivity_domaint::transform_function_call(
         {
           if(
             called_arg.type().id() == ID_pointer &&
-            !called_arg.type().subtype().get_bool(ID_C_constant))
+            !to_pointer_type(called_arg.type())
+               .base_type()
+               .get_bool(ID_C_constant))
           {
             abstract_object_pointert pointer_value =
               abstract_state.eval(called_arg, ns);
@@ -339,7 +342,10 @@ void variable_sensitivity_domaint::transform_function_call(
               std::stack<exprt>(),
               nil_exprt(),
               abstract_state.abstract_object_factory(
-                called_arg.type().subtype(), ns, true, false),
+                to_pointer_type(called_arg.type()).base_type(),
+                ns,
+                true,
+                false),
               false);
           }
         }

--- a/src/goto-programs/remove_const_function_pointers.cpp
+++ b/src/goto-programs/remove_const_function_pointers.cpp
@@ -523,9 +523,10 @@ bool remove_const_function_pointerst::try_resolve_index_of(
     bool all_possible_const=true;
     for(const exprt &potential_array_expr : potential_array_exprs)
     {
-      all_possible_const=
+      all_possible_const =
         all_possible_const &&
-        is_const_type(potential_array_expr.type().subtype());
+        is_const_type(
+          to_array_type(potential_array_expr.type()).element_type());
 
       if(potential_array_expr.id()==ID_array)
       {

--- a/src/pointer-analysis/value_set.cpp
+++ b/src/pointer-analysis/value_set.cpp
@@ -595,7 +595,12 @@ void value_sett::get_value_set_rec(
       // integer-to-pointer
 
       if(op.is_zero())
-        insert(dest, exprt(ID_null_object, expr_type.subtype()), mp_integer{0});
+      {
+        insert(
+          dest,
+          exprt(ID_null_object, to_type_with_subtype(expr_type).subtype()),
+          mp_integer{0});
+      }
       else
       {
         // see if we have something for the integer
@@ -674,11 +679,12 @@ void value_sett::get_value_set_rec(
 
       if(ptr_operand.has_value() && i.has_value())
       {
-        typet pointer_sub_type = ptr_operand->type().subtype();
-        if(pointer_sub_type.id()==ID_empty)
-          pointer_sub_type=char_type();
+        typet pointer_base_type =
+          to_pointer_type(ptr_operand->type()).base_type();
+        if(pointer_base_type.id() == ID_empty)
+          pointer_base_type = char_type();
 
-        auto size = pointer_offset_size(pointer_sub_type, ns);
+        auto size = pointer_offset_size(pointer_base_type, ns);
 
         if(!size.has_value() || (*size) == 0)
         {

--- a/src/pointer-analysis/value_set_fi.cpp
+++ b/src/pointer-analysis/value_set_fi.cpp
@@ -180,7 +180,8 @@ void value_set_fit::flatten_rec(
       if(fi==values.end())
       {
         // this is some static object, keep it in.
-        const symbol_exprt se(o.get(ID_identifier), o.type().subtype());
+        const symbol_exprt se(
+          o.get(ID_identifier), to_type_with_subtype(o.type()).subtype());
         insert(dest, se, mp_integer{0});
       }
       else
@@ -521,7 +522,10 @@ void value_set_fit::get_value_set_rec(
     // check if NULL
     if(is_null_pointer(to_constant_expr(expr)))
     {
-      insert(dest, exprt(ID_null_object, expr.type().subtype()), mp_integer{0});
+      insert(
+        dest,
+        exprt(ID_null_object, to_pointer_type(expr.type()).base_type()),
+        mp_integer{0});
       return;
     }
   }
@@ -629,7 +633,8 @@ void value_set_fit::get_value_set_rec(
       PRECONDITION(suffix.empty());
       assert(expr.type().id()==ID_pointer);
 
-      dynamic_object_exprt dynamic_object(expr.type().subtype());
+      dynamic_object_exprt dynamic_object(
+        to_pointer_type(expr.type()).base_type());
       dynamic_object.set_instance(
         (from_function << 16) | from_target_index);
       dynamic_object.valid()=true_exprt();
@@ -834,7 +839,9 @@ void value_set_fit::get_reference_set_sharing_rec(
             insert(dest, t2_object_entry);
         }
         else
-          insert(dest, exprt(ID_unknown, obj.type().subtype()));
+          insert(
+            dest,
+            exprt(ID_unknown, to_type_with_subtype(obj.type()).subtype()));
       }
       else
         insert(dest, object_entry);
@@ -1086,7 +1093,7 @@ void value_set_fit::assign(
         const index_exprt op0_index(
           to_with_expr(rhs).old(),
           exprt(ID_unknown, c_index_type()),
-          type.subtype());
+          to_array_type(type).element_type());
 
         assign(lhs_index, op0_index, ns);
         assign(lhs_index, to_with_expr(rhs).new_value(), ns);
@@ -1094,7 +1101,9 @@ void value_set_fit::assign(
       else
       {
         const index_exprt rhs_index(
-          rhs, exprt(ID_unknown, c_index_type()), type.subtype());
+          rhs,
+          exprt(ID_unknown, c_index_type()),
+          to_array_type(type).element_type());
         assign(lhs_index, rhs_index, ns);
       }
     }
@@ -1132,7 +1141,8 @@ void value_set_fit::assign_rec(
     const irep_idt &ident = lhs.get(ID_identifier);
     object_mapt temp;
     gvs_recursion_sett recset;
-    get_value_set_rec(lhs, temp, "", lhs.type().subtype(), ns, recset);
+    get_value_set_rec(
+      lhs, temp, "", to_type_with_subtype(lhs.type()).subtype(), ns, recset);
 
     if(recursion_set.find(ident)!=recursion_set.end())
     {


### PR DESCRIPTION
This commit replaces uses of `typet::subtype()` const by casting the type to
the applicable subtype, and then using the appropriate accessor method.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
