### PR TITLE
add missing source_location for assignments generated for initializers

### DIFF
--- a/regression/cbmc-cover/location-multiline-statement/multi-file.desc
+++ b/regression/cbmc-cover/location-multiline-statement/multi-file.desc
@@ -3,7 +3,7 @@ multi-file.c
 --cover location
 ^EXIT=0$
 ^SIGNAL=0$
-^\[main.coverage.2\] file multi-file.c line 13 function main block 2 \(lines [\w\- /\.\\:]*dereference.h:main:2; multi-file.c:main:10,13,14,16\): SATISFIED
+^\[main.coverage.2\] file multi-file.c line 10 function main block 2 \(lines [\w\- /\.\\:]*dereference.h:main:2; multi-file.c:main:10,13,14,16\): SATISFIED
 --
 ^warning: ignoring
 --

--- a/regression/cbmc-cover/location-multiline-statement/test.desc
+++ b/regression/cbmc-cover/location-multiline-statement/test.desc
@@ -3,7 +3,7 @@ example.c
 --cover location
 ^EXIT=0$
 ^SIGNAL=0$
-^\[main.coverage.2\] file example.c line 13 function main block 2 \(lines example.c:main:10,13,14\): SATISFIED$
+^\[main.coverage.2\] file example.c line 10 function main block 2 \(lines example.c:main:10,13,14\): SATISFIED$
 --
 ^warning: ignoring
 --

--- a/regression/cbmc-cover/location15/test.desc
+++ b/regression/cbmc-cover/location15/test.desc
@@ -4,7 +4,7 @@ main.c
 ^EXIT=0$
 ^SIGNAL=0$
 ^\[main.coverage.1\] file main.c line 10 function main block 1.*: SATISFIED$
-^\[main.coverage.2\] file main.c line 11 function main block 2.*: SATISFIED$
+^\[main.coverage.2\] file main.c line 10 function main block 2.*: SATISFIED$
 ^\[main.coverage.3\] file main.c line 13 function main block 3.*: FAILED$
 ^\[main.coverage.4\] file main.c line 16 function main block 4.*: SATISFIED$
 ^\[foo.coverage.1\] file main.c line 5 function foo block 1.*: FAILED$

--- a/src/goto-programs/goto_convert.cpp
+++ b/src/goto-programs/goto_convert.cpp
@@ -637,12 +637,13 @@ void goto_convertt::convert_frontend_decl(
     // Decl must be visible before initializer.
     copy(tmp, DECL, dest);
 
+    auto initializer_location = initializer.find_source_location();
     clean_expr(initializer, dest, mode);
 
     if(initializer.is_not_nil())
     {
       code_assignt assign(code.op0(), initializer);
-      assign.add_source_location() = initializer.find_source_location();
+      assign.add_source_location() = initializer_location;
 
       convert_assign(assign, dest, mode);
     }


### PR DESCRIPTION
A variable definition in C may include an initializer.  We split these into
a DECL instruction and an ASSIGN instruction.  This commit ensures that the
ASSIGN instruction has a source_location attached to it (clean_expr may
yield a temporary, which does not appear in the source code).

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
