### PR TITLE
Move left-hand side type casts to right-hand side

### DIFF
--- a/regression/goto-instrument/dump-side-effect/main.c
+++ b/regression/goto-instrument/dump-side-effect/main.c
@@ -1,0 +1,17 @@
+struct S
+{
+  int bf : 2;
+};
+
+int foo()
+{
+  return 0;
+}
+
+int main()
+{
+  struct S s;
+  struct S *sp = &s;
+  if(sp[0].bf = foo())
+    return 0;
+}

--- a/regression/goto-instrument/dump-side-effect/test.desc
+++ b/regression/goto-instrument/dump-side-effect/test.desc
@@ -1,0 +1,12 @@
+CORE
+main.c
+--dump-c
+VERIFICATION SUCCESSFUL
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--
+This test must verify successfully also for the output generated using dump-c,
+which previously would fail to compile for it included a type cast on a
+left-hand side.

--- a/src/goto-programs/goto_clean_expr.cpp
+++ b/src/goto-programs/goto_clean_expr.cpp
@@ -395,9 +395,10 @@ void goto_convertt::clean_expr(
         }
 
         // turn into code
-        code_assignt assignment;
-        assignment.lhs()=lhs;
-        assignment.rhs() = side_effect_assign.rhs();
+        exprt new_lhs = skip_typecast(lhs);
+        exprt new_rhs = typecast_exprt::conditional_cast(
+          side_effect_assign.rhs(), new_lhs.type());
+        code_assignt assignment(std::move(new_lhs), std::move(new_rhs));
         assignment.add_source_location()=expr.source_location();
         convert_assign(assignment, dest, mode);
 


### PR DESCRIPTION
Unlike `goto_convertt::remove_assignment`, the assignment handling code
in `goto_convertt::clean_expr` did not move type casts to the right-hand
side. This resulted in dump-c producing syntactically invalid code. The
modified code now uses the same approach as the `ID_assign` case of
`goto_convertt::remove_assignment` to avoid this problem.

This should address all failures of the CSmith CI job seen since March
2021.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
