### PR TITLE
C library: getrandom requires glibc >= 2.25

### DIFF
--- a/regression/cbmc-library/getrandom-01/main.c
+++ b/regression/cbmc-library/getrandom-01/main.c
@@ -1,7 +1,8 @@
-#ifdef __linux__
-#  include <sys/random.h>
-
 #  include <assert.h>
+
+#if defined(__GLIBC__) &&                                                      \
+  (__GLIBC__ > 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 25))
+#  include <sys/random.h>
 
 int main()
 {

--- a/src/ansi-c/library/random.c
+++ b/src/ansi-c/library/random.c
@@ -1,6 +1,12 @@
 /* FUNCTION: getrandom */
 
-#ifdef __linux__
+#ifndef __CPROVER_ERRNO_H_INCLUDED
+#include <errno.h>
+#define __CPROVER_ERRNO_H_INCLUDED
+#endif
+
+#if defined(__GLIBC__) &&                                                      \
+  (__GLIBC__ > 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 25))
 
 #  ifndef __CPROVER_SYS_RANDOM_H_INCLUDED
 #    include <sys/random.h>


### PR DESCRIPTION
As noticed in https://github.com/Homebrew/homebrew-core/pull/102337,
which attempts to build on Ubuntu 16.04, sys/random.h isn't available
with glibc versions prior to 2.25. Therefore, replace the __linux__
inclusion check by one that tests for a particular glibc version.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
