### PR TITLE
introduce goto_programt::instructiont::output

### DIFF
--- a/src/goto-programs/goto_program.h
+++ b/src/goto-programs/goto_program.h
@@ -575,6 +575,9 @@ public:
 
     /// Apply given function to all expressions
     void apply(std::function<void(const exprt &)>) const;
+
+    /// Output this instruction to the given stream
+    std::ostream &output(std::ostream &) const;
   };
 
   // Never try to change this to vector-we mutate the list while iterating
@@ -724,20 +727,28 @@ public:
   }
 
   /// Output goto program to given stream
+  DEPRECATED(SINCE(2022, 5, 29, "Use output(out) instead"))
   std::ostream &output(
     const namespacet &ns,
     const irep_idt &identifier,
-    std::ostream &out) const;
+    std::ostream &out) const
+  {
+    return output(out);
+  }
 
-  /// Output goto-program to given stream, using an empty symbol table
+  /// Output goto-program to given stream
   std::ostream &output(std::ostream &out) const;
 
   /// Output a single instruction
+  DEPRECATED(SINCE(2022, 5, 29, "Use instruction.output(out) instead"))
   std::ostream &output_instruction(
     const namespacet &ns,
     const irep_idt &identifier,
     std::ostream &out,
-    const instructionst::value_type &instruction) const;
+    const instructionst::value_type &instruction) const
+  {
+    return instruction.output(out);
+  }
 
   /// Compute the target numbers
   void compute_target_numbers();

--- a/src/goto-programs/show_goto_functions.cpp
+++ b/src/goto-programs/show_goto_functions.cpp
@@ -64,7 +64,7 @@ void show_goto_functions(
 
           msg.status() << messaget::bold << symbol.display_name()
                        << messaget::reset << " /* " << symbol.name << " */\n";
-          fun->second.body.output(ns, symbol.name, msg.status());
+          fun->second.body.output(msg.status());
           msg.status() << messaget::eom;
         }
       }


### PR DESCRIPTION
This introduces `goto_programt::instructiont::output` as a more idiomatic
substitute for `goto_programt::output_instruction`.  The `identifier`
parameter is no longer in use, and is thus removed from the API.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- [X] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
