### PR TITLE
Generate-function-bodies: generate a meaningful assertion

### DIFF
--- a/regression/goto-instrument/generate-function-body-assert-false-assume-false/test.desc
+++ b/regression/goto-instrument/generate-function-body-assert-false-assume-false/test.desc
@@ -5,4 +5,4 @@ main.c
 ^SIGNAL=0$
 ^VERIFICATION FAILED$
 ^\[main.assertion.1\] .* assertion 0: SUCCESS$
-^\[crashes_program.assertion.1\] .* assertion false: FAILURE$
+^\[crashes_program.assertion.1\] .* undefined function should be unreachable: FAILURE$

--- a/regression/goto-instrument/generate-function-body-assert-false/test.desc
+++ b/regression/goto-instrument/generate-function-body-assert-false/test.desc
@@ -3,6 +3,6 @@ main.c
 --generate-function-body do_not_call_this --generate-function-body-options assert-false
 ^EXIT=10$
 ^SIGNAL=0$
-^\[do_not_call_this.assertion.1\] .* assertion false: FAILURE$
+^\[do_not_call_this.assertion.1\] .* undefined function should be unreachable: FAILURE$
 --
 ^warning: ignoring

--- a/regression/goto-instrument/generate-function-body/test.desc
+++ b/regression/goto-instrument/generate-function-body/test.desc
@@ -5,4 +5,4 @@ main.c
 ^SIGNAL=0$
 ^VERIFICATION FAILED$
 ^\[main.assertion.1\] .* assertion does_not_get_reached: SUCCESS$
-^\[should_be_generated.assertion.1\] .* assertion false: FAILURE$
+^\[should_be_generated.assertion.1\] .* undefined function should be unreachable: FAILURE$

--- a/src/goto-instrument/generate_function_bodies.cpp
+++ b/src/goto-instrument/generate_function_bodies.cpp
@@ -105,12 +105,8 @@ protected:
     };
     auto assert_instruction =
       add_instruction(goto_programt::make_assertion(false_exprt()));
-    const namespacet ns(symbol_table);
-    std::ostringstream comment_stream;
-    comment_stream << id2string(ID_assertion) << " "
-                   << format(assert_instruction->condition());
     assert_instruction->source_location_nonconst().set_comment(
-      comment_stream.str());
+      "undefined function should be unreachable");
     assert_instruction->source_location_nonconst().set_property_class(
       ID_assertion);
     add_instruction(goto_programt::make_end_function());
@@ -136,12 +132,8 @@ protected:
     };
     auto assert_instruction =
       add_instruction(goto_programt::make_assertion(false_exprt()));
-    const namespacet ns(symbol_table);
-    std::ostringstream comment_stream;
-    comment_stream << id2string(ID_assertion) << " "
-                   << format(assert_instruction->condition());
     assert_instruction->source_location_nonconst().set_comment(
-      comment_stream.str());
+      "undefined function should be unreachable");
     assert_instruction->source_location_nonconst().set_property_class(
       ID_assertion);
     add_instruction(goto_programt::make_assumption(false_exprt()));


### PR DESCRIPTION
When using --generate-function-body with "assert-false" or
"assert-false-assume-false" make sure we produce a more meaningful
description than "assertion false." Instead, make the comment say
"undefined function should be unreachable."

Fixes: #6393

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
