### PR TITLE
Add overflow_result_exprt: compute result and overflow in one expression

### DIFF
--- a/src/solvers/flattening/boolbv.cpp
+++ b/src/solvers/flattening/boolbv.cpp
@@ -228,6 +228,12 @@ bvt boolbvt::convert_bitvector(const exprt &expr)
     return convert_bitreverse(to_bitreverse_expr(expr));
   else if(expr.id() == ID_saturating_minus || expr.id() == ID_saturating_plus)
     return convert_saturating_add_sub(to_binary_expr(expr));
+  else if(
+    const auto overflow_with_result =
+      expr_try_dynamic_cast<overflow_result_exprt>(expr))
+  {
+    return convert_overflow_result(*overflow_with_result);
+  }
 
   return conversion_failed(expr);
 }

--- a/src/solvers/flattening/boolbv.h
+++ b/src/solvers/flattening/boolbv.h
@@ -38,6 +38,7 @@ class extractbits_exprt;
 class floatbv_typecast_exprt;
 class ieee_float_op_exprt;
 class member_exprt;
+class overflow_result_exprt;
 class replication_exprt;
 class unary_overflow_exprt;
 class union_typet;
@@ -197,6 +198,7 @@ protected:
     const function_application_exprt &expr);
   virtual bvt convert_bitreverse(const bitreverse_exprt &expr);
   virtual bvt convert_saturating_add_sub(const binary_exprt &expr);
+  virtual bvt convert_overflow_result(const overflow_result_exprt &expr);
 
   void convert_with(
     const typet &type,

--- a/src/solvers/flattening/boolbv_member.cpp
+++ b/src/solvers/flattening/boolbv_member.cpp
@@ -47,10 +47,14 @@ bvt boolbvt::convert_member(const member_exprt &expr)
 {
   const bvt &compound_bv = convert_bv(expr.compound());
 
-  if(expr.compound().type().id() == ID_struct_tag)
+  const typet &compound_type = expr.compound().type();
+
+  if(compound_type.id() == ID_struct_tag || compound_type.id() == ID_struct)
   {
     const struct_typet &struct_op_type =
-      ns.follow_tag(to_struct_tag_type(expr.compound().type()));
+      compound_type.id() == ID_struct_tag
+        ? ns.follow_tag(to_struct_tag_type(compound_type))
+        : to_struct_type(compound_type);
 
     const auto &member_bits =
       bv_width.get_member(struct_op_type, expr.get_component_name());
@@ -66,7 +70,8 @@ bvt boolbvt::convert_member(const member_exprt &expr)
   }
   else
   {
-    PRECONDITION(expr.compound().type().id() == ID_union_tag);
+    PRECONDITION(
+      compound_type.id() == ID_union_tag || compound_type.id() == ID_union);
     return convert_member_union(expr, compound_bv, *this, ns);
   }
 }

--- a/src/solvers/flattening/boolbv_overflow.cpp
+++ b/src/solvers/flattening/boolbv_overflow.cpp
@@ -6,11 +6,110 @@ Author: Daniel Kroening, kroening@kroening.com
 
 \*******************************************************************/
 
+#include <util/arith_tools.h>
 #include <util/bitvector_expr.h>
 #include <util/bitvector_types.h>
 #include <util/invariant.h>
 
 #include "boolbv.h"
+
+static bvt mult_overflow_result(
+  propt &prop,
+  const bvt &bv0,
+  const bvt &bv1,
+  bv_utilst::representationt rep)
+{
+  bv_utilst bv_utils{prop};
+
+  std::size_t old_size = bv0.size();
+  std::size_t new_size = old_size * 2;
+
+  // sign/zero extension
+  const bvt &bv0_extended = bv_utils.extension(bv0, new_size, rep);
+  const bvt &bv1_extended = bv_utils.extension(bv1, new_size, rep);
+
+  bvt result_extended = bv_utils.multiplier(bv0_extended, bv1_extended, rep);
+  bvt bv{result_extended.begin(), result_extended.begin() + old_size};
+  bvt bv_overflow{result_extended.begin() + old_size, result_extended.end()};
+
+  if(rep == bv_utilst::representationt::UNSIGNED)
+  {
+    bv.push_back(prop.lor(bv_overflow));
+  }
+  else
+  {
+    // get top result bits, plus one more
+    bv_overflow.push_back(bv.back());
+
+    // these need to be either all 1's or all 0's
+    literalt all_one = prop.land(bv_overflow);
+    literalt all_zero = !prop.lor(bv_overflow);
+    bv.push_back(!prop.lor(all_one, all_zero));
+  }
+
+  return bv;
+}
+
+static bvt shl_overflow_result(
+  propt &prop,
+  const bvt &bv0,
+  const bvt &bv1,
+  bv_utilst::representationt rep0,
+  bv_utilst::representationt rep1)
+{
+  bv_utilst bv_utils{prop};
+
+  std::size_t old_size = bv0.size();
+  std::size_t new_size = old_size * 2;
+
+  bvt result_extended = bv_utils.shift(
+    bv_utils.extension(bv0, new_size, rep0),
+    bv_utilst::shiftt::SHIFT_LEFT,
+    bv1);
+  bvt bv{result_extended.begin(), result_extended.begin() + old_size};
+  bvt bv_overflow{result_extended.begin() + old_size, result_extended.end()};
+
+  // a negative shift is undefined; yet this isn't an overflow
+  literalt neg_shift = rep1 == bv_utilst::representationt::UNSIGNED
+                         ? const_literal(false)
+                         : bv_utils.sign_bit(bv1);
+
+  // an undefined shift of a non-zero value always results in overflow
+  std::size_t cmp_width = std::max(bv1.size(), address_bits(old_size) + 1);
+  literalt undef = bv_utils.rel(
+    bv_utils.extension(bv1, cmp_width, rep1),
+    ID_gt,
+    bv_utils.build_constant(old_size, cmp_width),
+    rep1);
+
+  if(rep0 == bv_utilst::representationt::UNSIGNED)
+  {
+    // one of the top bits is non-zero
+    bv.push_back(prop.lor(bv_overflow));
+  }
+  else
+  {
+    // get top result bits, plus one more
+    bv_overflow.push_back(bv.back());
+
+    // the sign bit has changed
+    literalt sign_change =
+      !prop.lequal(bv_utils.sign_bit(bv0), bv_utils.sign_bit(bv));
+
+    // these need to be either all 1's or all 0's
+    literalt all_one = prop.land(bv_overflow);
+    literalt all_zero = !prop.lor(bv_overflow);
+
+    bv.push_back(prop.lor(sign_change, !prop.lor(all_one, all_zero)));
+  }
+
+  // a negative shift isn't an overflow; else check the conditions built
+  // above
+  bv.back() =
+    prop.land(!neg_shift, prop.lselect(undef, prop.lor(bv0), bv.back()));
+
+  return bv;
+}
 
 literalt boolbvt::convert_binary_overflow(const binary_overflow_exprt &expr)
 {
@@ -55,97 +154,24 @@ literalt boolbvt::convert_binary_overflow(const binary_overflow_exprt &expr)
       mult_overflow->lhs().type() == mult_overflow->rhs().type(),
       "operands of overflow_mult expression shall have same type");
 
-    std::size_t old_size=bv0.size();
-    std::size_t new_size=old_size*2;
+    DATA_INVARIANT(!bv0.empty(), "zero-sized operand");
 
-    // sign/zero extension
-    const bvt &bv0_extended = bv_utils.extension(bv0, new_size, rep);
-    const bvt &bv1_extended = bv_utils.extension(bv1, new_size, rep);
-
-    bvt result = bv_utils.multiplier(bv0_extended, bv1_extended, rep);
-
-    if(rep==bv_utilst::representationt::UNSIGNED)
-    {
-      bvt bv_overflow;
-      bv_overflow.reserve(old_size);
-
-      // get top result bits
-      for(std::size_t i=old_size; i<result.size(); i++)
-        bv_overflow.push_back(result[i]);
-
-      return prop.lor(bv_overflow);
-    }
-    else
-    {
-      bvt bv_overflow;
-      bv_overflow.reserve(old_size);
-
-      // get top result bits, plus one more
-      DATA_INVARIANT(old_size!=0, "zero-size operand");
-      for(std::size_t i=old_size-1; i<result.size(); i++)
-        bv_overflow.push_back(result[i]);
-
-      // these need to be either all 1's or all 0's
-      literalt all_one=prop.land(bv_overflow);
-      literalt all_zero=!prop.lor(bv_overflow);
-      return !prop.lor(all_one, all_zero);
-    }
+    return mult_overflow_result(prop, bv0, bv1, rep).back();
   }
   else if(
     const auto shl_overflow = expr_try_dynamic_cast<shl_overflow_exprt>(expr))
   {
-    std::size_t old_size = bv0.size();
-    std::size_t new_size = old_size * 2;
+    DATA_INVARIANT(!bv0.empty(), "zero-sized operand");
 
-    bvt bv_ext=bv_utils.extension(bv0, new_size, rep);
-
-    bvt result=bv_utils.shift(bv_ext, bv_utilst::shiftt::SHIFT_LEFT, bv1);
-
-    // a negative shift is undefined; yet this isn't an overflow
-    literalt neg_shift = rep == bv_utilst::representationt::UNSIGNED
-                           ? const_literal(false)
-                           : bv1.back(); // sign bit
-
-    // an undefined shift of a non-zero value always results in overflow; the
-    // use of unsigned comparision is safe here as we cover the signed negative
-    // case via neg_shift
-    literalt undef =
-      bv_utils.rel(
-        bv1,
-        ID_gt,
-        bv_utils.build_constant(old_size, bv1.size()),
-        bv_utilst::representationt::UNSIGNED);
-
-    literalt overflow;
-
-    if(rep == bv_utilst::representationt::UNSIGNED)
-    {
-      // get top result bits
-      result.erase(result.begin(), result.begin() + old_size);
-
-      // one of the top bits is non-zero
-      overflow=prop.lor(result);
-    }
-    else
-    {
-      // get top result bits plus sign bit
-      DATA_INVARIANT(old_size != 0, "zero-size operand");
-      result.erase(result.begin(), result.begin() + old_size - 1);
-
-      // the sign bit has changed
-      literalt sign_change=!prop.lequal(bv0.back(), result.front());
-
-      // these need to be either all 1's or all 0's
-      literalt all_one=prop.land(result);
-      literalt all_zero=!prop.lor(result);
-
-      overflow=prop.lor(sign_change, !prop.lor(all_one, all_zero));
-    }
-
-    // a negative shift isn't an overflow; else check the conditions built
-    // above
-    return
-      prop.land(!neg_shift, prop.lselect(undef, prop.lor(bv0), overflow));
+    return shl_overflow_result(
+             prop,
+             bv0,
+             bv1,
+             rep,
+             can_cast_type<signedbv_typet>(expr.op1().type())
+               ? bv_utilst::representationt::SIGNED
+               : bv_utilst::representationt::UNSIGNED)
+      .back();
   }
 
   return SUB::convert_rest(expr);
@@ -163,4 +189,135 @@ literalt boolbvt::convert_unary_overflow(const unary_overflow_exprt &expr)
   }
 
   return SUB::convert_rest(expr);
+}
+
+bvt boolbvt::convert_overflow_result(const overflow_result_exprt &expr)
+{
+  const typet &type = expr.type();
+  const std::size_t width = boolbv_width(type);
+
+  if(expr.id() == ID_overflow_result_unary_minus)
+  {
+    const bvt op_bv = convert_bv(expr.op0());
+    bvt bv = bv_utils.negate(op_bv);
+    bv.push_back(bv_utils.overflow_negate(op_bv));
+    CHECK_RETURN(bv.size() == width);
+    return bv;
+  }
+  else if(expr.operands().size() != 2)
+    return conversion_failed(expr);
+
+  const bvt &bv0 = convert_bv(expr.op0());
+  const bvt &bv1 = convert_bv(expr.op1());
+  CHECK_RETURN(!bv0.empty() && !bv1.empty());
+
+  const bv_utilst::representationt rep =
+    can_cast_type<signedbv_typet>(expr.op0().type())
+      ? bv_utilst::representationt::SIGNED
+      : bv_utilst::representationt::UNSIGNED;
+
+  if(expr.id() == ID_overflow_result_plus)
+  {
+    CHECK_RETURN(bv0.size() == bv1.size());
+
+    if(rep == bv_utilst::representationt::SIGNED)
+    {
+      // An overflow occurs if the signs of the two operands are the same
+      // and the sign of the sum is the opposite.
+      bvt bv = bv_utils.add(bv0, bv1);
+
+      literalt old_sign = bv_utils.sign_bit(bv0);
+      literalt sign_the_same = prop.lequal(old_sign, bv_utils.sign_bit(bv1));
+      literalt new_sign = bv_utils.sign_bit(bv);
+      bv.push_back(prop.land(sign_the_same, prop.lxor(new_sign, old_sign)));
+
+      CHECK_RETURN(bv.size() == width);
+      return bv;
+    }
+    else
+    {
+      // overflow is simply carry-out
+      bvt bv;
+      bv.reserve(width);
+      literalt carry = const_literal(false);
+
+      for(std::size_t i = 0; i < bv0.size(); i++)
+        bv.push_back(bv_utils.full_adder(bv0[i], bv1[i], carry, carry));
+
+      bv.push_back(carry);
+
+      CHECK_RETURN(bv.size() == width);
+      return bv;
+    }
+  }
+  else if(expr.id() == ID_overflow_result_minus)
+  {
+    CHECK_RETURN(bv0.size() == bv1.size());
+
+    if(rep == bv_utilst::representationt::SIGNED)
+    {
+      bvt bv1_neg = bv_utils.negate(bv1);
+      bvt bv = bv_utils.add(bv0, bv1_neg);
+
+      // We special-case x-INT_MIN, which is >=0 if
+      // x is negative, always representable, and
+      // thus not an overflow.
+      literalt op1_is_int_min = bv_utils.is_int_min(bv1);
+      literalt op0_is_negative = bv_utils.sign_bit(bv0);
+
+      literalt old_sign = bv_utils.sign_bit(bv0);
+      literalt sign_the_same =
+        prop.lequal(old_sign, bv_utils.sign_bit(bv1_neg));
+      literalt new_sign = bv_utils.sign_bit(bv);
+      bv.push_back(prop.lselect(
+        op1_is_int_min,
+        !op0_is_negative,
+        prop.land(sign_the_same, prop.lxor(new_sign, old_sign))));
+
+      CHECK_RETURN(bv.size() == width);
+      return bv;
+    }
+    else if(rep == bv_utilst::representationt::UNSIGNED)
+    {
+      // overflow is simply _negated_ carry-out
+      bvt bv;
+      bv.reserve(width);
+      literalt carry = const_literal(true);
+
+      for(std::size_t i = 0; i < bv0.size(); i++)
+        bv.push_back(bv_utils.full_adder(bv0[i], !bv1[i], carry, carry));
+
+      bv.push_back(!carry);
+
+      CHECK_RETURN(bv.size() == width);
+      return bv;
+    }
+    else
+      UNREACHABLE;
+  }
+  else if(expr.id() == ID_overflow_result_mult)
+  {
+    CHECK_RETURN(bv0.size() == bv1.size());
+
+    bvt bv = mult_overflow_result(prop, bv0, bv1, rep);
+
+    CHECK_RETURN(bv.size() == width);
+    return bv;
+  }
+  else if(expr.id() == ID_overflow_result_shl)
+  {
+    bvt bv = shl_overflow_result(
+      prop,
+      bv0,
+      bv1,
+      rep,
+      can_cast_type<signedbv_typet>(expr.op1().type())
+        ? bv_utilst::representationt::SIGNED
+        : bv_utilst::representationt::UNSIGNED);
+
+    CHECK_RETURN(bv.size() == width);
+    return bv;
+  }
+
+  return conversion_failed(expr);
 }

--- a/src/util/bitvector_expr.cpp
+++ b/src/util/bitvector_expr.cpp
@@ -152,3 +152,60 @@ exprt bitreverse_exprt::lower() const
 
   return let_exprt{to_reverse, op(), concatenation_exprt{result_bits, type()}};
 }
+
+exprt plus_overflow_exprt::lower() const
+{
+  std::size_t lhs_ssize = to_bitvector_type(lhs().type()).get_width();
+  if(lhs().type().id() == ID_unsignedbv)
+    ++lhs_ssize;
+  std::size_t rhs_ssize = to_bitvector_type(rhs().type()).get_width();
+  if(rhs().type().id() == ID_unsignedbv)
+    ++rhs_ssize;
+
+  std::size_t ssize = std::max(lhs_ssize, rhs_ssize) + 1;
+  signedbv_typet ssize_type{ssize};
+  plus_exprt exact_result{
+    typecast_exprt{lhs(), ssize_type}, typecast_exprt{rhs(), ssize_type}};
+
+  return notequal_exprt{
+    typecast_exprt{typecast_exprt{exact_result, lhs().type()}, ssize_type},
+    exact_result};
+}
+
+exprt minus_overflow_exprt::lower() const
+{
+  std::size_t lhs_ssize = to_bitvector_type(lhs().type()).get_width();
+  if(lhs().type().id() == ID_unsignedbv)
+    ++lhs_ssize;
+  std::size_t rhs_ssize = to_bitvector_type(rhs().type()).get_width();
+  if(rhs().type().id() == ID_unsignedbv)
+    ++rhs_ssize;
+
+  std::size_t ssize = std::max(lhs_ssize, rhs_ssize) + 1;
+  signedbv_typet ssize_type{ssize};
+  minus_exprt exact_result{
+    typecast_exprt{lhs(), ssize_type}, typecast_exprt{rhs(), ssize_type}};
+
+  return notequal_exprt{
+    typecast_exprt{typecast_exprt{exact_result, lhs().type()}, ssize_type},
+    exact_result};
+}
+
+exprt mult_overflow_exprt::lower() const
+{
+  std::size_t lhs_ssize = to_bitvector_type(lhs().type()).get_width();
+  if(lhs().type().id() == ID_unsignedbv)
+    ++lhs_ssize;
+  std::size_t rhs_ssize = to_bitvector_type(rhs().type()).get_width();
+  if(rhs().type().id() == ID_unsignedbv)
+    ++rhs_ssize;
+
+  std::size_t ssize = lhs_ssize + rhs_ssize;
+  signedbv_typet ssize_type{ssize};
+  mult_exprt exact_result{
+    typecast_exprt{lhs(), ssize_type}, typecast_exprt{rhs(), ssize_type}};
+
+  return notequal_exprt{
+    typecast_exprt{typecast_exprt{exact_result, lhs().type()}, ssize_type},
+    exact_result};
+}

--- a/src/util/irep_ids.def
+++ b/src/util/irep_ids.def
@@ -871,6 +871,11 @@ IREP_ID_TWO(C_flexible_array_member, #flexible_array_member)
 IREP_ID_ONE(state)
 IREP_ID_ONE(evaluate)
 IREP_ID_ONE(update_state)
+IREP_ID_TWO(overflow_result_plus, overflow_result-+)
+IREP_ID_TWO(overflow_result_minus, overflow_result--)
+IREP_ID_TWO(overflow_result_mult, overflow_result-*)
+IREP_ID_TWO(overflow_result_shl, overflow_result-shl)
+IREP_ID_TWO(overflow_result_unary_minus, overflow_result-unary-)
 
 // Projects depending on this code base that wish to extend the list of
 // available ids should provide a file local_irep_ids.def in their source tree

--- a/src/util/simplify_expr.cpp
+++ b/src/util/simplify_expr.cpp
@@ -2295,6 +2295,185 @@ simplify_exprt::simplify_overflow_unary(const unary_overflow_exprt &expr)
     return false_exprt{};
 }
 
+simplify_exprt::resultt<>
+simplify_exprt::simplify_overflow_result(const overflow_result_exprt &expr)
+{
+  if(expr.id() == ID_overflow_result_unary_minus)
+  {
+    // zero is a neutral element
+    if(expr.op0().is_zero())
+      return struct_exprt{{expr.op0(), false_exprt{}}, expr.type()};
+
+    // catch some cases over mathematical types
+    const irep_idt &op_type_id = expr.op0().type().id();
+    if(
+      op_type_id == ID_integer || op_type_id == ID_rational ||
+      op_type_id == ID_real)
+    {
+      return struct_exprt{{expr.op0(), false_exprt{}}, expr.type()};
+    }
+
+    // always an overflow for natural numbers, but the result is not
+    // representable
+    if(op_type_id == ID_natural)
+      return unchanged(expr);
+
+    // we only handle constants over signedbv/unsignedbv for the remaining cases
+    if(op_type_id != ID_signedbv && op_type_id != ID_unsignedbv)
+      return unchanged(expr);
+
+    if(!expr.op0().is_constant())
+      return unchanged(expr);
+
+    const auto op_value = numeric_cast<mp_integer>(expr.op0());
+    if(!op_value.has_value())
+      return unchanged(expr);
+
+    mp_integer no_overflow_result = -*op_value;
+
+    const std::size_t width = to_bitvector_type(expr.op0().type()).get_width();
+    const integer_bitvector_typet bv_type{op_type_id, width};
+    if(
+      no_overflow_result < bv_type.smallest() ||
+      no_overflow_result > bv_type.largest())
+    {
+      return struct_exprt{
+        {from_integer(no_overflow_result, expr.op0().type()), true_exprt{}},
+        expr.type()};
+    }
+    else
+    {
+      return struct_exprt{
+        {from_integer(no_overflow_result, expr.op0().type()), false_exprt{}},
+        expr.type()};
+    }
+  }
+  else
+  {
+    // When one operand is zero, an overflow can only occur for a subtraction
+    // from zero.
+    if(expr.op0().is_zero())
+    {
+      if(
+        expr.id() == ID_overflow_result_plus ||
+        expr.id() == ID_overflow_result_shl)
+      {
+        return struct_exprt{{expr.op1(), false_exprt{}}, expr.type()};
+      }
+      else if(expr.id() == ID_overflow_result_mult)
+      {
+        return struct_exprt{
+          {from_integer(0, expr.op0().type()), false_exprt{}}, expr.type()};
+      }
+    }
+    else if(expr.op1().is_zero())
+    {
+      if(
+        expr.id() == ID_overflow_result_plus ||
+        expr.id() == ID_overflow_result_minus ||
+        expr.id() == ID_overflow_result_shl)
+      {
+        return struct_exprt{{expr.op0(), false_exprt{}}, expr.type()};
+      }
+      else
+      {
+        return struct_exprt{
+          {from_integer(0, expr.op0().type()), false_exprt{}}, expr.type()};
+      }
+    }
+
+    // One is neutral element for multiplication
+    if(
+      expr.id() == ID_overflow_result_mult &&
+      (expr.op0().is_one() || expr.op1().is_one()))
+    {
+      return struct_exprt{
+        {expr.op0().is_one() ? expr.op1() : expr.op0(), false_exprt{}},
+        expr.type()};
+    }
+
+    // we only handle the case of same operand types
+    if(
+      expr.id() != ID_overflow_result_shl &&
+      expr.op0().type() != expr.op1().type())
+    {
+      return unchanged(expr);
+    }
+
+    // catch some cases over mathematical types
+    const irep_idt &op_type_id = expr.op0().type().id();
+    if(
+      expr.id() != ID_overflow_result_shl &&
+      (op_type_id == ID_integer || op_type_id == ID_rational ||
+       op_type_id == ID_real))
+    {
+      irep_idt id =
+        expr.id() == ID_overflow_result_plus
+          ? ID_plus
+          : expr.id() == ID_overflow_result_minus ? ID_minus : ID_mult;
+      return struct_exprt{
+        {simplify_node(binary_exprt{expr.op0(), id, expr.op1()}),
+         false_exprt{}},
+        expr.type()};
+    }
+
+    if(
+      (expr.id() == ID_overflow_result_plus ||
+       expr.id() == ID_overflow_result_mult) &&
+      op_type_id == ID_natural)
+    {
+      return struct_exprt{
+        {simplify_node(binary_exprt{
+           expr.op0(),
+           expr.id() == ID_overflow_result_plus ? ID_plus : ID_mult,
+           expr.op1()}),
+         false_exprt{}},
+        expr.type()};
+    }
+
+    // we only handle constants over signedbv/unsignedbv for the remaining cases
+    if(op_type_id != ID_signedbv && op_type_id != ID_unsignedbv)
+      return unchanged(expr);
+
+    if(!expr.op0().is_constant() || !expr.op1().is_constant())
+      return unchanged(expr);
+
+    const auto op0_value = numeric_cast<mp_integer>(expr.op0());
+    const auto op1_value = numeric_cast<mp_integer>(expr.op1());
+    if(!op0_value.has_value() || !op1_value.has_value())
+      return unchanged(expr);
+
+    mp_integer no_overflow_result;
+    if(expr.id() == ID_overflow_result_plus)
+      no_overflow_result = *op0_value + *op1_value;
+    else if(expr.id() == ID_overflow_result_minus)
+      no_overflow_result = *op0_value - *op1_value;
+    else if(expr.id() == ID_overflow_result_mult)
+      no_overflow_result = *op0_value * *op1_value;
+    else if(expr.id() == ID_overflow_result_shl)
+      no_overflow_result = *op0_value << *op1_value;
+    else
+      UNREACHABLE;
+
+    const std::size_t width = to_bitvector_type(expr.op0().type()).get_width();
+    const integer_bitvector_typet bv_type{op_type_id, width};
+    if(
+      no_overflow_result < bv_type.smallest() ||
+      no_overflow_result > bv_type.largest())
+    {
+      return struct_exprt{
+        {from_integer(no_overflow_result, expr.op0().type()), true_exprt{}},
+        expr.type()};
+    }
+    else
+    {
+      return struct_exprt{
+        {from_integer(no_overflow_result, expr.op0().type()), false_exprt{}},
+        expr.type()};
+    }
+  }
+}
+
 bool simplify_exprt::simplify_node_preorder(exprt &expr)
 {
   bool result=true;
@@ -2558,6 +2737,12 @@ simplify_exprt::resultt<> simplify_exprt::simplify_node(exprt node)
       expr_try_dynamic_cast<unary_overflow_exprt>(expr))
   {
     r = simplify_overflow_unary(*unary_overflow);
+  }
+  else if(
+    const auto overflow_result =
+      expr_try_dynamic_cast<overflow_result_exprt>(expr))
+  {
+    r = simplify_overflow_result(*overflow_result);
   }
   else if(expr.id() == ID_bitreverse)
   {

--- a/src/util/simplify_expr_class.h
+++ b/src/util/simplify_expr_class.h
@@ -59,6 +59,7 @@ class mult_exprt;
 class namespacet;
 class not_exprt;
 class object_size_exprt;
+class overflow_result_exprt;
 class plus_exprt;
 class pointer_object_exprt;
 class pointer_offset_exprt;
@@ -202,6 +203,12 @@ public:
   /// Simplification will be possible when the operand is constants or the
   /// type of the operand has an infinite domain.
   NODISCARD resultt<> simplify_overflow_unary(const unary_overflow_exprt &);
+
+  /// Try to simplify overflow_result-+, overflow_result-*, overflow_result--,
+  /// overflow_result-shl, overflow_result-unary--.
+  /// Simplification will be possible when the operands are constants or the
+  /// types of the operands have infinite domains.
+  NODISCARD resultt<> simplify_overflow_result(const overflow_result_exprt &);
 
   /// Attempt to simplify mathematical function applications if we have
   /// enough information to do so. Currently focused on constant comparisons.


### PR DESCRIPTION
Doing both the arithmetic operation and determining whether or not there
was an overflow previously required either multiple expressions or going
via `__builtin_X_overflow`, which should be specific to the C front-end.

The new expression returns a struct with two components, the first of
which has the type of the arithmetic operation, and the second is
Boolean.

Fixes: #6841

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
