### PR TITLE
Relational operators support for pointers in new SMT backend

### DIFF
--- a/regression/cbmc-incr-smt2/pointers-relational-operators/pointers_assume.c
+++ b/regression/cbmc-incr-smt2/pointers-relational-operators/pointers_assume.c
@@ -1,0 +1,27 @@
+#include <stdlib.h>
+
+int main()
+{
+  int x;
+  int *y = &x;
+  int *z = &x;
+
+  if(x)
+  {
+    y++;
+  }
+  else
+  {
+    z++;
+  }
+
+  __CPROVER_assume(y >= z);
+  __CPROVER_assert(x != y, "x != y: expected successful");
+  __CPROVER_assert(x == y, "x == y: expected failure");
+
+  __CPROVER_assume(z >= x);
+
+  __CPROVER_assert(z >= x, "z >= x: expected successful");
+  __CPROVER_assert(z <= y, "z <= y: expected successful");
+  __CPROVER_assert(z <= x, "z <= x: expected failure");
+}

--- a/regression/cbmc-incr-smt2/pointers-relational-operators/pointers_assume.desc
+++ b/regression/cbmc-incr-smt2/pointers-relational-operators/pointers_assume.desc
@@ -1,0 +1,14 @@
+CORE
+pointers_assume.c
+--trace
+\[main\.assertion\.1\] line \d+ x != y: expected successful: SUCCESS
+\[main\.assertion\.2\] line \d+ x == y: expected failure: FAILURE
+\[main\.assertion\.3\] line \d+ z >= x: expected successful: SUCCESS
+\[main\.assertion\.4\] line \d+ z <= y: expected successful: SUCCESS
+\[main\.assertion\.5\] line \d+ z <= x: expected failure: FAILURE
+^EXIT=10$
+^SIGNAL=0$
+--
+--
+This is testing basic pointer relational operator support for three objects
+defined in the function's stack frame.

--- a/regression/cbmc-incr-smt2/pointers-relational-operators/pointers_stack_lessthan.c
+++ b/regression/cbmc-incr-smt2/pointers-relational-operators/pointers_stack_lessthan.c
@@ -1,0 +1,19 @@
+#define NULL (void *)0
+
+int main()
+{
+  int i = 12;
+  int *x = &i;
+  int *y = x + 1;
+  int *z = x - 1;
+
+  // Assertions on y's relation to x
+  __CPROVER_assert(y != x, "y != x: expected successful");
+  __CPROVER_assert(y > x, "y > x: expected successful");
+  __CPROVER_assert(y < x, "y < x: expected failure");
+
+  // Assertions on z's relation to x
+  __CPROVER_assert(z != x, "z != x: expected successful");
+  __CPROVER_assert(z > x, "z > x: expected failure");
+  __CPROVER_assert(z < x, "z < x: expected success");
+}

--- a/regression/cbmc-incr-smt2/pointers-relational-operators/pointers_stack_lessthan.desc
+++ b/regression/cbmc-incr-smt2/pointers-relational-operators/pointers_stack_lessthan.desc
@@ -1,0 +1,15 @@
+CORE
+pointers_stack_lessthan.c
+--trace
+\[main\.assertion\.1] line \d+ y != x: expected successful: SUCCESS
+\[main\.assertion\.2] line \d+ y > x: expected successful: SUCCESS
+\[main\.assertion\.3] line \d+ y < x: expected failure: FAILURE
+\[main\.assertion\.4] line \d+ z != x: expected successful: SUCCESS
+\[main\.assertion\.5] line \d+ z > x: expected failure: FAILURE
+\[main\.assertion\.6] line \d+ z < x: expected success: SUCCESS
+^EXIT=10$
+^SIGNAL=0$
+--
+--
+This is testing basic pointer relational operator support for three objects
+defined in the function's stack frame.

--- a/regression/cbmc-incr-smt2/pointers-relational-operators/pointers_stack_malloc.c
+++ b/regression/cbmc-incr-smt2/pointers-relational-operators/pointers_stack_malloc.c
@@ -1,0 +1,17 @@
+#include <stdlib.h>
+
+int main()
+{
+  int *a = malloc(sizeof(int) * 5);
+
+  for(int i = 0; i < 5; i++)
+    *(a + i) = i;
+
+  for(int i = 0; i < 5; i++)
+  {
+    __CPROVER_assert(*(a + i) >= i, "*(a + i) >= i: expected successful");
+    __CPROVER_assert(*(a + i) <= i, "*(a + i) <= i: expected successful");
+    __CPROVER_assert(*(a + i) == i, "*(a + i) <= i: expected successful");
+    __CPROVER_assert(*(a + i) != i, "*(a + i) <= i: expected failure");
+  }
+}

--- a/regression/cbmc-incr-smt2/pointers-relational-operators/pointers_stack_malloc.desc
+++ b/regression/cbmc-incr-smt2/pointers-relational-operators/pointers_stack_malloc.desc
@@ -1,0 +1,13 @@
+CORE
+pointers_stack_malloc.c
+--trace
+\[main\.assertion\.1\] line \d+ \*\(a \+ i\) >= i: expected successful: SUCCESS
+\[main\.assertion\.2\] line \d+ \*\(a \+ i\) <= i: expected successful: SUCCESS
+\[main\.assertion\.3\] line \d+ \*\(a \+ i\) <= i: expected successful: SUCCESS
+\[main\.assertion\.4\] line \d+ \*\(a \+ i\) <= i: expected failure: FAILURE
+^EXIT=10$
+^SIGNAL=0$
+--
+--
+This is testing the support for relational operators as applied to pointer objects
+backed by a malloc and initialised to some values.

--- a/unit/solvers/smt2_incremental/convert_expr_to_smt.cpp
+++ b/unit/solvers/smt2_incremental/convert_expr_to_smt.cpp
@@ -328,6 +328,51 @@ TEST_CASE(
 }
 
 TEST_CASE(
+  "expr to smt conversion for relational operators as applied to pointers",
+  "[core][smt2_incremental]")
+{
+  auto test = expr_to_smt_conversion_test_environmentt::make(test_archt::i386);
+  // Pointer variables, used for comparisons
+  const std::size_t pointer_width = 32;
+  const auto pointer_type = pointer_typet(signedbv_typet{32}, pointer_width);
+  const symbol_exprt pointer_a("a", pointer_type);
+  const symbol_exprt pointer_b("b", pointer_type);
+  // SMT terms needed for pointer comparisons
+  const smt_termt smt_term_a =
+    smt_identifier_termt{"a", smt_bit_vector_sortt{pointer_width}};
+  const smt_termt smt_term_b =
+    smt_identifier_termt{"b", smt_bit_vector_sortt{pointer_width}};
+
+  SECTION("Greater than on pointers")
+  {
+    CHECK(
+      test.convert(greater_than_exprt{pointer_a, pointer_b}) ==
+      smt_bit_vector_theoryt::unsigned_greater_than(smt_term_a, smt_term_b));
+  }
+
+  SECTION("Greater than or equal on pointer operands")
+  {
+    CHECK(
+      test.convert(greater_than_or_equal_exprt{pointer_a, pointer_b}) ==
+      smt_bit_vector_theoryt::unsigned_greater_than_or_equal(
+        smt_term_a, smt_term_b));
+  }
+  SECTION("Less than on pointer operands")
+  {
+    CHECK(
+      test.convert(less_than_exprt{pointer_a, pointer_b}) ==
+      smt_bit_vector_theoryt::unsigned_less_than(smt_term_a, smt_term_b));
+  }
+  SECTION("Less than or equal on pointer operands")
+  {
+    CHECK(
+      test.convert(less_than_or_equal_exprt{pointer_a, pointer_b}) ==
+      smt_bit_vector_theoryt::unsigned_less_than_or_equal(
+        smt_term_a, smt_term_b));
+  }
+}
+
+TEST_CASE(
   "expr to smt conversion for arithmetic operators",
   "[core][smt2_incremental]")
 {


### PR DESCRIPTION
This PR is adding support for relational operators as applied
to pointers in the new SMT backend.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
