### PR TITLE
Support -target in goto-cc GCC/Clang mode

### DIFF
--- a/regression/ansi-c/CMakeLists.txt
+++ b/regression/ansi-c/CMakeLists.txt
@@ -1,6 +1,6 @@
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
     add_test_pl_tests(
-        "$<TARGET_FILE:goto-cc>" -X gcc-only
+        "$<TARGET_FILE:goto-cc>" -X gcc-only -X clang-x86-only
     )
 elseif("${CMAKE_SYSTEM_NAME}" STREQUAL "Darwin")
     add_test_pl_tests(
@@ -22,18 +22,28 @@ else()
     find_program(CLANG_EXISTS "clang")
     find_program(GCC_EXISTS "gcc")
     if(CLANG_EXISTS)
-        add_test_pl_profile(
-            "ansi-c-clang"
-            "$<TARGET_FILE:goto-cc> --native-compiler clang"
-            "-C;-s;ansi-c-clang"
-            "CORE"
-        )
+        if("${CMAKE_HOST_SYSTEM_PROCESSOR}" STREQUAL "x86_64" OR
+           "${CMAKE_HOST_SYSTEM_PROCESSOR}" STREQUAL "i386")
+            add_test_pl_profile(
+                "ansi-c-clang"
+                "$<TARGET_FILE:goto-cc> --native-compiler clang"
+                "-C;-s;ansi-c-clang"
+                "CORE"
+            )
+        else()
+            add_test_pl_profile(
+                "ansi-c-clang"
+                "$<TARGET_FILE:goto-cc> --native-compiler clang"
+                "-C;-X;clang-x86-only;-s;ansi-c-clang"
+                "CORE"
+            )
+        endif()
     endif()
     if(GCC_EXISTS)
         add_test_pl_profile(
             "ansi-c-gcc"
             "$<TARGET_FILE:goto-cc> --native-compiler gcc"
-            "-C;-X;fake-gcc-version;-s;ansi-c-gcc"
+            "-C;-X;fake-gcc-version;-X;clang-x86-only;-s;ansi-c-gcc"
             "CORE"
         )
         add_test_pl_profile(
@@ -44,7 +54,7 @@ else()
         )
     elseif(NOT CLANG_EXISTS)
         add_test_pl_tests(
-            "$<TARGET_FILE:goto-cc>"
+            "$<TARGET_FILE:goto-cc>" -X clang-x86-only
         )
     endif()
 

--- a/regression/ansi-c/Makefile
+++ b/regression/ansi-c/Makefile
@@ -10,7 +10,7 @@ else
 endif
 
 ifeq ($(BUILD_ENV_),MSVC)
-	excluded_tests = -X gcc-only
+	excluded_tests = -X gcc-only -X clang-x86-only
 else
 ifeq ($(BUILD_ENV_),OSX)
 	# In MacOS, a change in the assert.h header file
@@ -20,6 +20,9 @@ ifeq ($(BUILD_ENV_),OSX)
 	# <assert.h> or <cassert> headers.
   excluded_tests = -X macos-assert-broken
 endif
+ifeq ($(filter x86_64 i386,$(shell uname -m)),)
+  excluded_tests += -X clang-x86-only
+endif
 endif
 
 test:
@@ -27,10 +30,11 @@ test:
 	  ../test.pl -e -p -c "$(exe) --native-compiler clang" $(excluded_tests) ; \
 	fi
 	if which gcc ; then \
-	  ../test.pl -e -p -c "$(exe) --native-compiler gcc" $(excluded_tests) -X fake-gcc-version && \
+	  ../test.pl -e -p -c "$(exe) --native-compiler gcc" $(excluded_tests) \
+		  -X fake-gcc-version -X clang-x86-only && \
 	  ../test.pl -e -p -c $(exe) $(excluded_tests) -I fake-gcc-version ; \
 	elif ! which clang ; then \
-	  ../test.pl -e -p -c $(exe) $(excluded_tests) ; \
+	  ../test.pl -e -p -c $(exe) $(excluded_tests) -X clang-x86-only ; \
 	fi
 ifneq ($(BUILD_ENV_),MSVC)
 	@../test.pl -e -p -c "$(exe) -xc++ -D_Bool=bool" -I test-c++-front-end -s c++-front-end $(excluded_tests)
@@ -41,10 +45,11 @@ tests.log: ../test.pl
 	  ../test.pl -e -p -c "$(exe) --native-compiler clang" $(excluded_tests) ; \
 	fi
 	if which gcc ; then \
-	  ../test.pl -e -p -c "$(exe) --native-compiler gcc" $(excluded_tests) -X fake-gcc-version && \
+	  ../test.pl -e -p -c "$(exe) --native-compiler gcc" $(excluded_tests) \
+		  -X fake-gcc-version -X clang-x86-only && \
 	  ../test.pl -e -p -c $(exe) $(excluded_tests) -I fake-gcc-version ; \
 	elif ! which clang ; then \
-	  ../test.pl -e -p -c $(exe) $(excluded_tests) ; \
+	  ../test.pl -e -p -c $(exe) $(excluded_tests) -X clang-x86-only ; \
 	fi
 ifneq ($(BUILD_ENV_),MSVC)
 	@../test.pl -e -p -c "$(exe) -xc++ -D_Bool=bool" -I test-c++-front-end -s c++-front-end $(excluded_tests)

--- a/regression/ansi-c/clang_target/main.c
+++ b/regression/ansi-c/clang_target/main.c
@@ -1,0 +1,4 @@
+int main()
+{
+  int A[sizeof(void *) == 4 ? 1 : -1];
+}

--- a/regression/ansi-c/clang_target/test.desc
+++ b/regression/ansi-c/clang_target/test.desc
@@ -1,0 +1,8 @@
+CORE clang-x86-only
+main.c
+-target i386-unknown-linux-gnu
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+^CONVERSION ERROR$

--- a/src/goto-cc/gcc_cmdline.cpp
+++ b/src/goto-cc/gcc_cmdline.cpp
@@ -111,6 +111,8 @@ const char *gcc_options_with_separated_argument[]=
   "--include", // undocumented
   "-current_version", // on the Mac
   "-compatibility_version",  // on the Mac
+  "-target",
+  "--target",
   "-z",
   nullptr
 };

--- a/src/goto-cc/gcc_mode.cpp
+++ b/src/goto-cc/gcc_mode.cpp
@@ -509,6 +509,13 @@ int gcc_modet::doit()
         }
   }
 
+  // clang supports -target <arch-quadruple> and --target=<arch-quadruple>
+  if(cmdline.isset("target"))
+  {
+    std::string arch_quadruple = cmdline.get_value("target");
+    config.set_arch(arch_quadruple.substr(0, arch_quadruple.find('-')));
+  }
+
   // -fshort-wchar makes wchar_t "short unsigned int"
   if(cmdline.isset("fshort-wchar"))
   {


### PR DESCRIPTION
Accept and parse Clang's -target <arch-quadruple>
(and --target=-<arch quadruple>) command-line option.

Fixes: #6906

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
