### PR TITLE
Fix architecture typo x64_64 -> x86_64

### DIFF
--- a/regression/ansi-c/sizeof1/main.c
+++ b/regression/ansi-c/sizeof1/main.c
@@ -12,16 +12,20 @@ STATIC_ASSERT(sizeof(void *)==sizeof(size_t));
 
 #ifdef _WIN32
 
-#ifdef _WIN64
+#  ifdef _WIN64
 
 STATIC_ASSERT(sizeof(void *)==8);
 STATIC_ASSERT(sizeof(int)==4);
 STATIC_ASSERT(sizeof(long int)==4);
 STATIC_ASSERT(sizeof(long long int)==8);
 STATIC_ASSERT(sizeof(wchar_t)==2);
+#    ifdef __MINGW64__
+STATIC_ASSERT(sizeof(long double) == 16);
+#    else
 STATIC_ASSERT(sizeof(long double)==8);
+#    endif
 
-#else
+#  else
 
 STATIC_ASSERT(sizeof(void *)==4);
 STATIC_ASSERT(sizeof(int)==4);
@@ -30,7 +34,7 @@ STATIC_ASSERT(sizeof(long long int)==8);
 STATIC_ASSERT(sizeof(wchar_t)==2);
 STATIC_ASSERT(sizeof(long double)==8);
 
-#endif
+#  endif
 
 #else
 

--- a/src/util/config.cpp
+++ b/src/util/config.cpp
@@ -993,7 +993,7 @@ bool configt::set(const cmdlinet &cmdline)
 
     // long double is the same as double in Visual Studio,
     // but it's 16 bytes with GCC with the 64-bit target.
-    if(arch=="x64_64" && cmdline.isset("gcc"))
+    if(arch == "x86_64" && cmdline.isset("gcc"))
       ansi_c.long_double_width=16*8;
     else
       ansi_c.long_double_width=8*8;


### PR DESCRIPTION
x64_64 does not seem to be a valid architecture, and likely is just a
typo for what should be x86_64.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
