### PR TITLE
Enable pointer tests from `regression/cbmc` to run using new SMT backend.

### DIFF
--- a/regression/cbmc/Pointer1/test.desc
+++ b/regression/cbmc/Pointer1/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 --pointer-check
 ^EXIT=0$

--- a/regression/cbmc/Pointer10/test.desc
+++ b/regression/cbmc/Pointer10/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 --pointer-check
 ^EXIT=0$

--- a/regression/cbmc/Pointer11/test.desc
+++ b/regression/cbmc/Pointer11/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 --pointer-check
 ^EXIT=0$

--- a/regression/cbmc/Pointer12/test.desc
+++ b/regression/cbmc/Pointer12/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 --pointer-check
 ^EXIT=0$

--- a/regression/cbmc/Pointer14/test.desc
+++ b/regression/cbmc/Pointer14/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 --pointer-check
 ^VERIFICATION FAILED$

--- a/regression/cbmc/Pointer15/test.desc
+++ b/regression/cbmc/Pointer15/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 --pointer-check
 ^EXIT=0$

--- a/regression/cbmc/Pointer17/test.desc
+++ b/regression/cbmc/Pointer17/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 --pointer-check
 ^EXIT=0$

--- a/regression/cbmc/Pointer18/full-slice.desc
+++ b/regression/cbmc/Pointer18/full-slice.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 --unwind 1 --no-unwinding-assertions --pointer-check --full-slice
 ^EXIT=0$

--- a/regression/cbmc/Pointer18/test.desc
+++ b/regression/cbmc/Pointer18/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 --unwind 1 --no-unwinding-assertions --pointer-check
 ^EXIT=0$

--- a/regression/cbmc/Pointer25/test.desc
+++ b/regression/cbmc/Pointer25/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 
 ^EXIT=0$

--- a/regression/cbmc/Pointer26/test.desc
+++ b/regression/cbmc/Pointer26/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 
 ^EXIT=0$

--- a/regression/cbmc/Pointer27/test.desc
+++ b/regression/cbmc/Pointer27/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 
 ^SIGNAL=0$

--- a/regression/cbmc/Pointer29/test.desc
+++ b/regression/cbmc/Pointer29/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 
 ^EXIT=0$

--- a/regression/cbmc/Pointer30/test.desc
+++ b/regression/cbmc/Pointer30/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 --pointer-check
 ^EXIT=0$

--- a/regression/cbmc/Pointer6/test.desc
+++ b/regression/cbmc/Pointer6/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 --pointer-check
 ^EXIT=0$

--- a/regression/cbmc/Pointer7/test.desc
+++ b/regression/cbmc/Pointer7/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 --pointer-check
 ^EXIT=0$

--- a/regression/cbmc/Pointer8/test.desc
+++ b/regression/cbmc/Pointer8/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 --pointer-check
 ^EXIT=0$

--- a/regression/cbmc/Pointer9/test.desc
+++ b/regression/cbmc/Pointer9/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 --pointer-check
 ^EXIT=0$

--- a/regression/cbmc/Pointer_Arithmetic10/test.desc
+++ b/regression/cbmc/Pointer_Arithmetic10/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 --pointer-check
 ^EXIT=0$

--- a/regression/cbmc/Pointer_Arithmetic12/test.desc
+++ b/regression/cbmc/Pointer_Arithmetic12/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.i
 --32 --little-endian
 ^EXIT=0$

--- a/regression/cbmc/Pointer_Arithmetic14/test.desc
+++ b/regression/cbmc/Pointer_Arithmetic14/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 
 ^EXIT=0$

--- a/regression/cbmc/Pointer_Arithmetic15/test.desc
+++ b/regression/cbmc/Pointer_Arithmetic15/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 
 ^EXIT=10$

--- a/regression/cbmc/Pointer_Arithmetic17/test.desc
+++ b/regression/cbmc/Pointer_Arithmetic17/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 
 ^EXIT=0$

--- a/regression/cbmc/Pointer_Arithmetic19/test.desc
+++ b/regression/cbmc/Pointer_Arithmetic19/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 --program-only
 ASSERT\(\{ 42, 43 \}\[POINTER_OFFSET\(p!0@1#2\) / \d+l*\] == 43\)$

--- a/regression/cbmc/Pointer_Arithmetic2/test.desc
+++ b/regression/cbmc/Pointer_Arithmetic2/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 --pointer-check
 ^EXIT=0$

--- a/regression/cbmc/Pointer_Arithmetic3/test.desc
+++ b/regression/cbmc/Pointer_Arithmetic3/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 --pointer-check
 ^EXIT=0$

--- a/regression/cbmc/Pointer_Arithmetic4/test.desc
+++ b/regression/cbmc/Pointer_Arithmetic4/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 --pointer-check
 ^EXIT=0$

--- a/regression/cbmc/Pointer_Arithmetic5/test.desc
+++ b/regression/cbmc/Pointer_Arithmetic5/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 --pointer-check --bounds-check --function f
 ^EXIT=10$

--- a/regression/cbmc/Pointer_Arithmetic6/test.desc
+++ b/regression/cbmc/Pointer_Arithmetic6/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 --pointer-check
 ^EXIT=0$

--- a/regression/cbmc/Pointer_Arithmetic7/test.desc
+++ b/regression/cbmc/Pointer_Arithmetic7/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 --pointer-check
 ^EXIT=0$

--- a/regression/cbmc/Pointer_Arithmetic9/test.desc
+++ b/regression/cbmc/Pointer_Arithmetic9/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 --pointer-check
 ^EXIT=0$

--- a/regression/cbmc/Pointer_Assume1/test.desc
+++ b/regression/cbmc/Pointer_Assume1/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 
 ^EXIT=0$

--- a/regression/cbmc/Pointer_array5/test.desc
+++ b/regression/cbmc/Pointer_array5/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 
 ^EXIT=0$

--- a/regression/cbmc/Pointer_byte_extract1/test.desc
+++ b/regression/cbmc/Pointer_byte_extract1/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 
 ^EXIT=0$

--- a/regression/cbmc/Pointer_byte_extract3/test.desc
+++ b/regression/cbmc/Pointer_byte_extract3/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 
 ^EXIT=0$

--- a/regression/cbmc/Pointer_byte_extract6/test.desc
+++ b/regression/cbmc/Pointer_byte_extract6/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 
 ^EXIT=0$

--- a/regression/cbmc/Pointer_byte_extract9/test.desc
+++ b/regression/cbmc/Pointer_byte_extract9/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 
 ^EXIT=10$

--- a/regression/cbmc/pointer-overflow1/test.desc
+++ b/regression/cbmc/pointer-overflow1/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 --pointer-overflow-check --unsigned-overflow-check
 ^EXIT=10$

--- a/regression/cbmc/pointer-overflow2/test.desc
+++ b/regression/cbmc/pointer-overflow2/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 --pointer-overflow-check
 ^EXIT=0$

--- a/regression/cbmc/pointer-overflow3/test.desc
+++ b/regression/cbmc/pointer-overflow3/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 --pointer-overflow-check
 ^\[main.pointer_arithmetic.\d+\] line 6 pointer arithmetic: pointer outside object bounds in p \+ \(signed (long (long )?)?int\)10: FAILURE

--- a/regression/cbmc/pointer-overflow4/test.desc
+++ b/regression/cbmc/pointer-overflow4/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 --pointer-overflow-check
 ^\[main.overflow.1\] line 10 arithmetic overflow on signed \* in (0x)?[0-9a-fA-F]+l* \* \(signed (long (long )?)?int\)4ul*: FAILURE$


### PR DESCRIPTION
This PR enables extra tests from the `regression/cbmc` folder, targeting
pointers, so that we can gauge our current level of support for pointers
in the new SMT backend.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
