### PR TITLE
Goto-cc: Map target names with clang's -target

### DIFF
--- a/regression/ansi-c/CMakeLists.txt
+++ b/regression/ansi-c/CMakeLists.txt
@@ -1,6 +1,6 @@
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
     add_test_pl_tests(
-        "$<TARGET_FILE:goto-cc>" -X gcc-only -X clang-x86-only
+        "$<TARGET_FILE:goto-cc>" -X gcc-only -X clang-only
     )
 elseif("${CMAKE_SYSTEM_NAME}" STREQUAL "Darwin")
     add_test_pl_tests(
@@ -22,28 +22,18 @@ else()
     find_program(CLANG_EXISTS "clang")
     find_program(GCC_EXISTS "gcc")
     if(CLANG_EXISTS)
-        if("${CMAKE_HOST_SYSTEM_PROCESSOR}" STREQUAL "x86_64" OR
-           "${CMAKE_HOST_SYSTEM_PROCESSOR}" STREQUAL "i386")
-            add_test_pl_profile(
-                "ansi-c-clang"
-                "$<TARGET_FILE:goto-cc> --native-compiler clang"
-                "-C;-s;ansi-c-clang"
-                "CORE"
-            )
-        else()
-            add_test_pl_profile(
-                "ansi-c-clang"
-                "$<TARGET_FILE:goto-cc> --native-compiler clang"
-                "-C;-X;clang-x86-only;-s;ansi-c-clang"
-                "CORE"
-            )
-        endif()
+        add_test_pl_profile(
+            "ansi-c-clang"
+            "$<TARGET_FILE:goto-cc> --native-compiler clang"
+            "-C;-s;ansi-c-clang"
+            "CORE"
+        )
     endif()
     if(GCC_EXISTS)
         add_test_pl_profile(
             "ansi-c-gcc"
             "$<TARGET_FILE:goto-cc> --native-compiler gcc"
-            "-C;-X;fake-gcc-version;-X;clang-x86-only;-s;ansi-c-gcc"
+            "-C;-X;fake-gcc-version;-X;clang-only;-s;ansi-c-gcc"
             "CORE"
         )
         add_test_pl_profile(
@@ -54,7 +44,7 @@ else()
         )
     elseif(NOT CLANG_EXISTS)
         add_test_pl_tests(
-            "$<TARGET_FILE:goto-cc>" -X clang-x86-only
+            "$<TARGET_FILE:goto-cc>" -X clang-only
         )
     endif()
 

--- a/regression/ansi-c/Makefile
+++ b/regression/ansi-c/Makefile
@@ -10,7 +10,7 @@ else
 endif
 
 ifeq ($(BUILD_ENV_),MSVC)
-	excluded_tests = -X gcc-only -X clang-x86-only
+	excluded_tests = -X gcc-only -X clang-only
 else
 ifeq ($(BUILD_ENV_),OSX)
 	# In MacOS, a change in the assert.h header file
@@ -20,9 +20,6 @@ ifeq ($(BUILD_ENV_),OSX)
 	# <assert.h> or <cassert> headers.
   excluded_tests = -X macos-assert-broken
 endif
-ifeq ($(filter x86_64 i386,$(shell uname -m)),)
-  excluded_tests += -X clang-x86-only
-endif
 endif
 
 test:
@@ -31,10 +28,10 @@ test:
 	fi
 	if which gcc ; then \
 	  ../test.pl -e -p -c "$(exe) --native-compiler gcc" $(excluded_tests) \
-		  -X fake-gcc-version -X clang-x86-only && \
+		  -X fake-gcc-version -X clang-only && \
 	  ../test.pl -e -p -c $(exe) $(excluded_tests) -I fake-gcc-version ; \
 	elif ! which clang ; then \
-	  ../test.pl -e -p -c $(exe) $(excluded_tests) -X clang-x86-only ; \
+	  ../test.pl -e -p -c $(exe) $(excluded_tests) -X clang-only ; \
 	fi
 ifneq ($(BUILD_ENV_),MSVC)
 	@../test.pl -e -p -c "$(exe) -xc++ -D_Bool=bool" -I test-c++-front-end -s c++-front-end $(excluded_tests)
@@ -46,10 +43,10 @@ tests.log: ../test.pl
 	fi
 	if which gcc ; then \
 	  ../test.pl -e -p -c "$(exe) --native-compiler gcc" $(excluded_tests) \
-		  -X fake-gcc-version -X clang-x86-only && \
+		  -X fake-gcc-version -X clang-only && \
 	  ../test.pl -e -p -c $(exe) $(excluded_tests) -I fake-gcc-version ; \
 	elif ! which clang ; then \
-	  ../test.pl -e -p -c $(exe) $(excluded_tests) -X clang-x86-only ; \
+	  ../test.pl -e -p -c $(exe) $(excluded_tests) -X clang-only ; \
 	fi
 ifneq ($(BUILD_ENV_),MSVC)
 	@../test.pl -e -p -c "$(exe) -xc++ -D_Bool=bool" -I test-c++-front-end -s c++-front-end $(excluded_tests)

--- a/regression/ansi-c/clang_target/aarch64.c
+++ b/regression/ansi-c/clang_target/aarch64.c
@@ -1,0 +1,5 @@
+_Static_assert(sizeof(void *) == 8, "error");
+
+int main()
+{
+}

--- a/regression/ansi-c/clang_target/aarch64.desc
+++ b/regression/ansi-c/clang_target/aarch64.desc
@@ -1,6 +1,6 @@
 CORE clang-only
-main.c
--target i386-unknown-linux-gnu
+aarch64.c
+-target aarch64-linux-gnu
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/src/goto-cc/gcc_mode.cpp
+++ b/src/goto-cc/gcc_mode.cpp
@@ -512,8 +512,55 @@ int gcc_modet::doit()
   // clang supports -target <arch-quadruple> and --target=<arch-quadruple>
   if(cmdline.isset("target"))
   {
+    // list of targets supported by LLVM 10.0, found using llc --version
+    static const std::map<std::string, std::string> target_map = {
+      {"aarch64", "arm64" /* AArch64 (little endian) */},
+      {"aarch64_32", "arm" /* AArch64 (little endian ILP32) */},
+      {"aarch64_be", "none" /* AArch64 (big endian) */},
+      {"amdgcn", "none" /* AMD GCN GPUs */},
+      {"arm", "arm" /* ARM */},
+      {"arm64", "arm64" /* ARM64 (little endian) */},
+      {"arm64_32", "arm" /* ARM64 (little endian ILP32) */},
+      {"armeb", "none" /* ARM (big endian) */},
+      {"avr", "none" /* Atmel AVR Microcontroller */},
+      {"bpf", "none" /* BPF (host endian) */},
+      {"bpfeb", "none" /* BPF (big endian) */},
+      {"bpfel", "none" /* BPF (little endian) */},
+      {"hexagon", "none" /* Hexagon */},
+      {"i386", "i386" /* (not in llc's list: 32-bit x86) */},
+      {"lanai", "none" /* Lanai */},
+      {"mips", "mips" /* MIPS (32-bit big endian) */},
+      {"mips64", "mips64" /* MIPS (64-bit big endian) */},
+      {"mips64el", "mips64el" /* MIPS (64-bit little endian) */},
+      {"mipsel", "mipsel" /* MIPS (32-bit little endian) */},
+      {"msp430", "none" /* MSP430 [experimental] */},
+      {"nvptx", "none" /* NVIDIA PTX 32-bit */},
+      {"nvptx64", "none" /* NVIDIA PTX 64-bit */},
+      {"ppc32", "powerpc" /* PowerPC 32 */},
+      {"ppc64", "ppc64" /* PowerPC 64 */},
+      {"ppc64le", "ppc64le" /* PowerPC 64 LE */},
+      {"r600", "none" /* AMD GPUs HD2XXX-HD6XXX */},
+      {"riscv32", "none" /* 32-bit RISC-V */},
+      {"riscv64", "riscv64" /* 64-bit RISC-V */},
+      {"sparc", "sparc" /* Sparc */},
+      {"sparcel", "none" /* Sparc LE */},
+      {"sparcv9", "sparc64" /* Sparc V9 */},
+      {"systemz", "none" /* SystemZ */},
+      {"thumb", "armhf" /* Thumb */},
+      {"thumbeb", "none" /* Thumb (big endian) */},
+      {"wasm32", "none" /* WebAssembly 32-bit */},
+      {"wasm64", "none" /* WebAssembly 64-bit */},
+      {"x86", "i386" /* 32-bit X86: Pentium-Pro and above */},
+      {"x86_64", "x86_64" /* 64-bit X86: EM64T and AMD64 */},
+      {"xcore", "none" /* XCore */},
+    };
     std::string arch_quadruple = cmdline.get_value("target");
-    config.set_arch(arch_quadruple.substr(0, arch_quadruple.find('-')));
+    auto it =
+      target_map.find(arch_quadruple.substr(0, arch_quadruple.find('-')));
+    if(it == target_map.end())
+      config.set_arch("none");
+    else
+      config.set_arch(it->second);
   }
 
   // -fshort-wchar makes wchar_t "short unsigned int"


### PR DESCRIPTION
This is a follow-up fix to 40859c824d1: the target names used by
Clang/LLVM need to be mapped to the architecture names used by
config.cpp.

Also, it's safe to run the regression tests across different platforms
as clang is not actually invoked for compilation, just for
preprocessing.

Fixes: #6912

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
