### PR TITLE
C library: __asm("<X>fence") is x86-only

### DIFF
--- a/src/ansi-c/library/gcc.c
+++ b/src/ansi-c/library/gcc.c
@@ -1,23 +1,35 @@
 /* FUNCTION: __builtin_ia32_sfence */
 
+#if defined(__i386__) || defined(__x86_64__)
+
 void __builtin_ia32_sfence(void)
 {
   __asm("sfence");
 }
 
+#endif
+
 /* FUNCTION: __builtin_ia32_lfence */
+
+#if defined(__i386__) || defined(__x86_64__)
 
 void __builtin_ia32_lfence(void)
 {
   __asm("lfence");
 }
 
+#endif
+
 /* FUNCTION: __builtin_ia32_mfence */
+
+#if defined(__i386__) || defined(__x86_64__)
 
 void __builtin_ia32_mfence(void)
 {
   __asm("mfence");
 }
+
+#endif
 
 /* FUNCTION: __sync_synchronize */
 


### PR DESCRIPTION
Builds on Mac M1 were failing when (rightly) reporting that these were
unrecognised mnemonics.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
