### PR TITLE
jdiff: cleanup command-line options

### DIFF
--- a/jbmc/src/java_bytecode/java_bytecode_language.cpp
+++ b/jbmc/src/java_bytecode/java_bytecode_language.cpp
@@ -109,6 +109,8 @@ void parse_java_language_options(const cmdlinet &cmd, optionst &options)
   }
   options.set_option(
     "java-lift-clinit-calls", cmd.isset("java-lift-clinit-calls"));
+
+  options.set_option("lazy-methods", !cmd.isset("no-lazy-methods"));
 }
 
 prefix_filtert get_context(const optionst &options)

--- a/jbmc/src/jbmc/jbmc_parse_options.cpp
+++ b/jbmc/src/jbmc/jbmc_parse_options.cpp
@@ -94,7 +94,6 @@ void jbmc_parse_optionst::set_default_options(optionst &options)
   options.set_option("assertions", true);
   options.set_option("assumptions", true);
   options.set_option("built-in-assertions", true);
-  options.set_option("lazy-methods", true);
   options.set_option("propagation", true);
   options.set_option("refine-strings", true);
   options.set_option("simple-slice", true);
@@ -303,9 +302,6 @@ void jbmc_parse_optionst::get_command_line_options(optionst &options)
     "symex-cache-dereferences", cmdline.isset("symex-cache-dereferences"));
 
   PARSE_OPTIONS_GOTO_TRACE(cmdline, options);
-
-  if(cmdline.isset("no-lazy-methods"))
-    options.set_option("lazy-methods", false);
 
   if(cmdline.isset("symex-driven-lazy-loading"))
   {

--- a/jbmc/src/jdiff/jdiff_parse_options.cpp
+++ b/jbmc/src/jdiff/jdiff_parse_options.cpp
@@ -58,11 +58,6 @@ void jdiff_parse_optionst::get_command_line_options(optionst &options)
     exit(1);
   }
 
-  // TODO: improve this when language front ends have been
-  //   disentangled from command line parsing
-  // we always require these options
-  cmdline.set("no-lazy-methods");
-  cmdline.set("no-refine-strings");
   parse_java_language_options(cmdline, options);
 
   // check assertions
@@ -263,11 +258,10 @@ void jdiff_parse_optionst::help()
     " --no-assertions              ignore user assertions\n"
     " --no-assumptions             ignore user assumptions\n"
     HELP_COVER
-    "Java Bytecode frontend options:\n"
-    JAVA_BYTECODE_LANGUAGE_OPTIONS_HELP
     "Other options:\n"
     " --version                    show version and exit\n"
     " --json-ui                    use JSON-formatted output\n"
+    " --verbosity #                verbosity level\n"
     HELP_TIMESTAMP
     "\n";
   // clang-format on

--- a/jbmc/src/jdiff/jdiff_parse_options.h
+++ b/jbmc/src/jdiff/jdiff_parse_options.h
@@ -31,8 +31,6 @@ class goto_modelt;
   "(no-assertions)(no-assumptions)" \
   OPT_COVER \
   "(verbosity):(version)" \
-  "(no-lazy-methods)" /* should go away */ \
-  "(no-refine-strings)" /* should go away */ \
   OPT_TIMESTAMP \
   "u(unified)(change-impact)(forward-impact)(backward-impact)" \
   "(compact-output)"

--- a/jbmc/unit/java-testing-utils/load_java_class.cpp
+++ b/jbmc/unit/java-testing-utils/load_java_class.cpp
@@ -170,7 +170,6 @@ symbol_tablet load_java_class(
 {
   free_form_cmdlinet command_line;
   command_line.add_flag("no-lazy-methods");
-  command_line.add_flag("no-refine-strings");
   return load_java_class(
     java_class_name, class_path, main, std::move(java_lang), command_line);
 }
@@ -203,9 +202,5 @@ goto_modelt load_goto_model_from_java_class(
   const std::string &main)
 {
   return load_goto_model_from_java_class(
-    java_class_name,
-    class_path,
-    {"no-lazy-methods", "no-refine-strings"},
-    {},
-    main);
+    java_class_name, class_path, {"no-lazy-methods"}, {}, main);
 }

--- a/jbmc/unit/java_bytecode/java_bytecode_parser/parse_java_annotations.cpp
+++ b/jbmc/unit/java_bytecode/java_bytecode_parser/parse_java_annotations.cpp
@@ -173,7 +173,6 @@ SCENARIO(
     {
       free_form_cmdlinet command_line;
       command_line.add_flag("no-lazy-methods");
-      command_line.add_flag("no-refine-strings");
       test_java_bytecode_languaget language;
       language.set_message_handler(null_message_handler);
       optionst options;


### PR DESCRIPTION
Remove no-refine-strings, which is no longer processed anywhere. Cleanup
handling of no-lazy-methods to do it centrally instead of making each
front-end do its own handling. Remove java options from help output as
those aren't actually accepted by jdiff.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
