### PR TITLE
Pointer casting regression tests for new SMT backend

### DIFF
--- a/regression/cbmc-incr-smt2/pointers-conversions/byte_extract_issue.c
+++ b/regression/cbmc-incr-smt2/pointers-conversions/byte_extract_issue.c
@@ -1,0 +1,12 @@
+#include <assert.h>
+#include <stdint.h>
+
+int main()
+{
+  uint32_t input;
+  uint32_t original = input;
+  uint8_t *ptr = (uint8_t *)(&input);
+  assert(*ptr == 0); // falsifiable
+  *ptr = ~(*ptr);
+  assert(input != original); // valid
+}

--- a/regression/cbmc-incr-smt2/pointers-conversions/byte_extract_issue.desc
+++ b/regression/cbmc-incr-smt2/pointers-conversions/byte_extract_issue.desc
@@ -1,0 +1,10 @@
+KNOWNBUG
+byte_extract_issue.c
+--trace
+^EXIT=10$
+^SIGNAL=0$
+--
+Reached unimplemented Generation of SMT formula for byte extract expression: byte_extract_little_endian
+--
+This test is here to document our lack of support for byte_extract_little_endian
+in the pointers support for the new SMT backend.

--- a/regression/cbmc-incr-smt2/pointers-conversions/byte_update_issue.c
+++ b/regression/cbmc-incr-smt2/pointers-conversions/byte_update_issue.c
@@ -1,0 +1,12 @@
+#include <assert.h>
+#include <stdint.h>
+
+int main()
+{
+  uint32_t x = 0;
+  uint8_t *ptr = (uint8_t *)(&x);
+  int offset;
+  __CPROVER_assume(offset >= 0 && offset < 4);
+  *(ptr + offset) = 1;
+  assert(x != 256);
+}

--- a/regression/cbmc-incr-smt2/pointers-conversions/byte_update_issue.desc
+++ b/regression/cbmc-incr-smt2/pointers-conversions/byte_update_issue.desc
@@ -1,0 +1,10 @@
+KNOWNBUG
+byte_update_issue.c
+--trace
+^EXIT=10$
+^SIGNAL=0$
+--
+Reached unimplemented Generation of SMT formula for byte extract expression: byte_update_little_endian
+--
+This test is here to document our lack of support for byte_update_little_endian
+in the pointers support for the new SMT backend.

--- a/regression/cbmc-incr-smt2/pointers-conversions/pointer_from_int.c
+++ b/regression/cbmc-incr-smt2/pointers-conversions/pointer_from_int.c
@@ -1,0 +1,13 @@
+int main()
+{
+  int *p = (int *)4;
+  __CPROVER_allocated_memory(4, sizeof(int));
+
+  __CPROVER_assert(p == 4, "p == 4: expected success");
+  __CPROVER_assert(p != 0, "p != 0: expected success");
+
+  p = (int *)0x1020304;
+  __CPROVER_assert(p == 0x1020304, "p == 0x1020304: expected success");
+  __CPROVER_assert(p != 0, "p != 0: expected success");
+  __CPROVER_assert(p == 0, "p != 0: expected failure");
+}

--- a/regression/cbmc-incr-smt2/pointers-conversions/pointer_from_int.desc
+++ b/regression/cbmc-incr-smt2/pointers-conversions/pointer_from_int.desc
@@ -1,0 +1,16 @@
+CORE
+pointer_from_int.c
+--trace
+\[main\.assertion\.1\] line \d+ p == 4: expected success: SUCCESS
+\[main\.assertion\.2\] line \d+ p != 0: expected success: SUCCESS
+\[main\.assertion\.3\] line \d+ p == 0x1020304: expected success: SUCCESS
+\[main\.assertion\.4\] line \d+ p != 0: expected success: SUCCESS
+\[main\.assertion\.5\] line \d+ p != 0: expected failure: FAILURE
+^VERIFICATION FAILED$
+^EXIT=10$
+^SIGNAL=0$
+--
+--
+This test is covering basic conversion of pointer values to integers.
+It contains two such conversions, one of an integer in decimal form,
+and one of an integer in a hexadecimal form.

--- a/regression/cbmc-incr-smt2/pointers-conversions/pointer_round_trip.c
+++ b/regression/cbmc-incr-smt2/pointers-conversions/pointer_round_trip.c
@@ -1,0 +1,13 @@
+int f(int x)
+{
+  void *p = (void *)x;
+  int r = (int)p;
+  return r;
+}
+
+int main()
+{
+  int a = f(5);
+  __CPROVER_assert(a == 5, "a == 5: expected success");
+  __CPROVER_assert(a != 5, "a != 5: expected failure");
+}

--- a/regression/cbmc-incr-smt2/pointers-conversions/pointer_round_trip.desc
+++ b/regression/cbmc-incr-smt2/pointers-conversions/pointer_round_trip.desc
@@ -1,0 +1,11 @@
+CORE
+pointer_round_trip.c
+--trace
+\[main\.assertion\.1\] line \d+ a == 5: expected success: SUCCESS
+\[main\.assertion\.2\] line \d+ a != 5: expected failure: FAILURE
+^VERIFICATION FAILED$
+^EXIT=10$
+^SIGNAL=0$
+--
+--
+This test is testing an integer value round trip (int -> pointer -> int) test.

--- a/regression/cbmc-incr-smt2/pointers-conversions/pointer_to_int.c
+++ b/regression/cbmc-incr-smt2/pointers-conversions/pointer_to_int.c
@@ -1,0 +1,19 @@
+int cmp(const void *p1, const void *p2)
+{
+  int x = *(int *)p1;
+  int y = *(int *)p2;
+
+  return (x < y) ? -1 : ((x == y) ? 0 : 1);
+}
+
+int main()
+{
+  int a = 5;
+  int b = 6;
+  int c = 7;
+
+  __CPROVER_assert(cmp(&a, &b) == -1, "expected result == -1: success");
+  __CPROVER_assert(cmp(&c, &b) == 1, "expected result == 1: success");
+  __CPROVER_assert(cmp(&c, &c) == 0, "expected result == 0: success");
+  __CPROVER_assert(cmp(&c, &c) == 1, "expected result == 1: failure");
+}

--- a/regression/cbmc-incr-smt2/pointers-conversions/pointer_to_int.desc
+++ b/regression/cbmc-incr-smt2/pointers-conversions/pointer_to_int.desc
@@ -1,0 +1,16 @@
+CORE
+pointer_to_int.c
+--trace
+\[main\.assertion\.1\] line \d+ expected result == -1: success: SUCCESS
+\[main\.assertion\.2\] line \d+ expected result == 1: success: SUCCESS
+\[main\.assertion\.3\] line \d+ expected result == 0: success: SUCCESS
+\[main\.assertion\.4\] line \d+ expected result == 1: failure: FAILURE
+^VERIFICATION FAILED$
+^EXIT=10$
+^SIGNAL=0$
+--
+--
+This test is covering basic conversion of casting of different pointer values,
+which are then dereferenced and used in the function. We are asserting against
+the result of the function, which cannot be right, unless the conversions
+work as they should.


### PR DESCRIPTION
This is adding some tests to gauge the level of support we currently have for the conversion of casting of pointers in the new SMT backend.

More tests to come, but draft for now so that we can get some internal reviews first.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
