### PR TITLE
Purge --no-arch from the code base

### DIFF
--- a/doc/man/cbmc.1
+++ b/doc/man/cbmc.1
@@ -76,8 +76,6 @@ Make "char" unsigned by default
 Set target architecture
 .IP --os
 Set target operating system
-.IP --no-arch
-Don't set up an architecture
 .IP --no-library
 Disable built-in abstract C library
 .IP "--round-to-nearest, --round-to-plus-inf, --round-to-minus-inf, --round-to-zero"

--- a/jbmc/src/jbmc/jbmc_parse_options.h
+++ b/jbmc/src/jbmc/jbmc_parse_options.h
@@ -76,7 +76,7 @@ class optionst;
   "(i386-linux)(i386-macos)(i386-win32)(win32)(winx64)" \
   "(ppc-macos)" \
   "(arrays-uf-always)(arrays-uf-never)" \
-  "(no-arch)(arch):" \
+  "(arch):" \
   OPT_FLUSH \
   JAVA_BYTECODE_LANGUAGE_OPTIONS \
   "(java-unwind-enum-static)" \

--- a/src/goto-cc/armcc_cmdline.cpp
+++ b/src/goto-cc/armcc_cmdline.cpp
@@ -41,7 +41,6 @@ static const char *options_no_arg[]=
   "--i386-macos",
   "--i386-linux",
   "--i386-win32",
-  "--no-arch",
   "--no-library",
   "--string-abstraction",
 

--- a/src/goto-cc/gcc_cmdline.cpp
+++ b/src/goto-cc/gcc_cmdline.cpp
@@ -49,7 +49,6 @@ const char *goto_cc_options_without_argument[]=
   "--64",
   "--little-endian",
   "--big-endian",
-  "--no-arch",
   "--partial-inlining",
   "--validate-goto-model",
   "-?",

--- a/src/goto-cc/ms_cl_cmdline.cpp
+++ b/src/goto-cc/ms_cl_cmdline.cpp
@@ -38,7 +38,6 @@ const char *non_ms_cl_options[]=
   "--little-endian",
   "--big-endian",
   "--unsigned-char",
-  "--no-arch",
   "--help",
   "--xml",
   "--partial-inlining",


### PR DESCRIPTION
This option has no effect and was mostly removed in 159a3691 already.

Fixes: #5485

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
