### PR TITLE
Use help_formatter to consistently format help output

### DIFF
--- a/jbmc/src/janalyzer/janalyzer_parse_options.cpp
+++ b/jbmc/src/janalyzer/janalyzer_parse_options.cpp
@@ -727,76 +727,86 @@ void janalyzer_parse_optionst::help()
     "\n"
     " janalyzer [-?] [-h] [--help] show help\n"
     " janalyzer\n"
-    HELP_JAVA_METHOD_NAME
-    " janalyzer\n"
-    HELP_JAVA_CLASS_NAME
-    " janalyzer\n"
-    HELP_JAVA_JAR
-    " janalyzer\n"
-    HELP_JAVA_GOTO_BINARY
-    "\n"
-    HELP_JAVA_CLASSPATH
-    HELP_FUNCTIONS
-    "\n"
+    << HELP_JAVA_METHOD_NAME
+    << " janalyzer\n"
+    << HELP_JAVA_CLASS_NAME
+    << " janalyzer\n"
+    << HELP_JAVA_JAR
+    << " janalyzer\n"
+    << HELP_JAVA_GOTO_BINARY
+    << "\n"
+    << HELP_JAVA_CLASSPATH
+    << HELP_FUNCTIONS
+    << "\n"
     "Task options:\n"
-    " --show                       display the abstract domains\n"
-    // NOLINTNEXTLINE(whitespace/line_length)
-    " --verify                     use the abstract domains to check assertions\n"
-    // NOLINTNEXTLINE(whitespace/line_length)
-    " --simplify file_name         use the abstract domains to simplify the program\n"
-    " --no-simplify-slicing        do not remove instructions from which no\n"
-    "                              property can be reached (use with --simplify)\n" // NOLINT(*)
-    " --unreachable-instructions   list dead code\n"
-    // NOLINTNEXTLINE(whitespace/line_length)
-    " --unreachable-functions      list functions unreachable from the entry point\n"
-    // NOLINTNEXTLINE(whitespace/line_length)
-    " --reachable-functions        list functions reachable from the entry point\n"
-    "\n"
+    << help_entry("--show", "display the abstract domains")
+    << help_entry("--verify", "use the abstract domains to check assertions")
+    << help_entry(
+      "--simplify file_name",
+      "use the abstract domains to simplify the program")
+    << help_entry(
+      "--no-simplify-slicing",
+      "do not remove instructions from which no property can be reached (use "
+      "with --simplify)")
+    << help_entry("--unreachable-instructions", "list dead code")
+    << help_entry(
+      "--unreachable-functions",
+      "list functions unreachable from the entry point")
+    << help_entry(
+      "--reachable-functions", "list functions reachable from the entry point")
+    << "\n"
     "Abstract interpreter options:\n"
-    // NOLINTNEXTLINE(whitespace/line_length)
-    " --location-sensitive         use location-sensitive abstract interpreter\n"
-    " --concurrent                 use concurrency-aware abstract interpreter\n"
-    "\n"
+    << help_entry(
+      "--location-sensitive", "use location-sensitive abstract interpreter")
+    << help_entry("--concurrent", "use concurrency-aware abstract interpreter")
+    << "\n"
     "Domain options:\n"
-    " --constants                  constant domain\n"
-    " --intervals                  interval domain\n"
-    " --non-null                   non-null domain\n"
-    " --dependence-graph           data and control dependencies between instructions\n" // NOLINT(*)
-    "\n"
+    << help_entry("--constants", "constant domain")
+    << help_entry("--intervals", "interval domain")
+    << help_entry("--non-null", "non-null domain")
+    << help_entry(
+      "--dependence-graph",
+      "data and control dependencies between instructions")
+    << "\n"
     "Output options:\n"
-    " --text file_name             output results in plain text to given file\n"
-    // NOLINTNEXTLINE(whitespace/line_length)
-    " --json file_name             output results in JSON format to given file\n"
-    " --xml file_name              output results in XML format to given file\n"
-    " --dot file_name              output results in DOT format to given file\n"
-    "\n"
+    << help_entry(
+      "--text file_name", "output results in plain text to given file")
+    << help_entry(
+      "--json file_name", "output results in JSON format to given file")
+    << help_entry(
+      "--xml file_name", "output results in XML format to given file")
+    << help_entry(
+      "--dot file_name", "output results in DOT format to given file")
+    << "\n"
     "Specific analyses:\n"
-    // NOLINTNEXTLINE(whitespace/line_length)
-    " --taint file_name            perform taint analysis using rules in given file\n"
-    " --show-taint                 print taint analysis results on stdout\n"
-    " --show-local-may-alias       perform procedure-local may alias analysis\n"
-    "\n"
+    << help_entry(
+      "--taint file_name", "perform taint analysis using rules in given file")
+    << help_entry(
+      "--show-taint", "print taint analysis results on stdout")
+    << help_entry(
+      "--show-local-may-alias", "perform procedure-local may alias analysis")
+    << "\n"
     "Java Bytecode frontend options:\n"
-    JAVA_BYTECODE_LANGUAGE_OPTIONS_HELP
-    "\n"
+    << JAVA_BYTECODE_LANGUAGE_OPTIONS_HELP
+    << "\n"
     "Platform options:\n"
-    HELP_CONFIG_PLATFORM
-    "\n"
+    << HELP_CONFIG_PLATFORM
+    << "\n"
     "Program representations:\n"
-    " --show-parse-tree            show parse tree\n"
-    " --show-symbol-table          show loaded symbol table\n"
-    HELP_SHOW_GOTO_FUNCTIONS
-    HELP_SHOW_PROPERTIES
-    "\n"
+    << help_entry("--show-parse-tree", "show parse tree")
+    << help_entry("--show-symbol-table", "show loaded symbol table")
+    << HELP_SHOW_GOTO_FUNCTIONS
+    << HELP_SHOW_PROPERTIES
+    << "\n"
     "Program instrumentation options:\n"
-    " --no-assertions              ignore user assertions\n"
-    " --no-assumptions             ignore user assumptions\n"
-    " --property id                enable selected properties only\n"
-    "\n"
+    << help_entry("--no-assertions", "ignore user assertions")
+    << help_entry("--no-assumptions", "ignore user assumptions")
+    << help_entry("--property id", "enable selected properties only")
+    << "\n"
     "Other options:\n"
-    " --version                    show version and exit\n"
-    " --verbosity #                verbosity level\n"
-    HELP_TIMESTAMP
-    "\n";
+    << help_entry("--version", "show version and exit")
+    << help_entry("--verbosity #", "verbosity level")
+    << HELP_TIMESTAMP
+    << "\n";
   // clang-format on
 }

--- a/jbmc/src/janalyzer/janalyzer_parse_options.cpp
+++ b/jbmc/src/janalyzer/janalyzer_parse_options.cpp
@@ -13,6 +13,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <util/config.h>
 #include <util/exit_codes.h>
+#include <util/help_formatter.h>
 #include <util/options.h>
 #include <util/version.h>
 
@@ -720,93 +721,81 @@ void janalyzer_parse_optionst::help()
   std::cout << '\n' << banner_string("JANALYZER", CBMC_VERSION) << '\n'
             << align_center_with_border("Copyright (C) 2016-2018") << '\n'
             << align_center_with_border("Daniel Kroening, Diffblue") << '\n'
-            << align_center_with_border("kroening@kroening.com") << '\n'
-            <<
+            << align_center_with_border("kroening@kroening.com") << '\n';
+
+  std::cout << help_formatter(
     "\n"
-    "Usage:                       Purpose:\n"
+    "Usage:                     \tPurpose:\n"
     "\n"
-    " janalyzer [-?] [-h] [--help] show help\n"
-    " janalyzer\n"
-    << HELP_JAVA_METHOD_NAME
-    << " janalyzer\n"
-    << HELP_JAVA_CLASS_NAME
-    << " janalyzer\n"
-    << HELP_JAVA_JAR
-    << " janalyzer\n"
-    << HELP_JAVA_GOTO_BINARY
-    << "\n"
-    << HELP_JAVA_CLASSPATH
-    << HELP_FUNCTIONS
-    << "\n"
+    " {bjanalyzer} [{y-?}] [{y-h}] [{y--help}] \t show this help\n"
+    " {bjanalyzer}\n"
+    HELP_JAVA_METHOD_NAME
+    " {bjanalyzer}\n"
+    HELP_JAVA_CLASS_NAME
+    " {bjanalyzer}\n"
+    HELP_JAVA_JAR
+    " {bjanalyzer}\n"
+    HELP_JAVA_GOTO_BINARY
+    "\n"
+    HELP_JAVA_CLASSPATH
+    HELP_FUNCTIONS
+    "\n"
     "Task options:\n"
-    << help_entry("--show", "display the abstract domains")
-    << help_entry("--verify", "use the abstract domains to check assertions")
-    << help_entry(
-      "--simplify file_name",
-      "use the abstract domains to simplify the program")
-    << help_entry(
-      "--no-simplify-slicing",
-      "do not remove instructions from which no property can be reached (use "
-      "with --simplify)")
-    << help_entry("--unreachable-instructions", "list dead code")
-    << help_entry(
-      "--unreachable-functions",
-      "list functions unreachable from the entry point")
-    << help_entry(
-      "--reachable-functions", "list functions reachable from the entry point")
-    << "\n"
+    " {y--show} \t display the abstract domains\n"
+    " {y--verify} \t use the abstract domains to check assertions\n"
+    " {y--simplify} {ufile_name} \t use the abstract domains to simplify the"
+    " program\n"
+    " {y--no-simplify-slicing} \t do not remove instructions from which no"
+    " property can be reached (use with {y--simplify})\n"
+    " {y--unreachable-instructions} \t list dead code\n"
+    " {y--unreachable-functions} \t list functions unreachable from the entry"
+    " point"
+    " {y--reachable-functions} \t list functions reachable from the entry point"
+    "\n"
     "Abstract interpreter options:\n"
-    << help_entry(
-      "--location-sensitive", "use location-sensitive abstract interpreter")
-    << help_entry("--concurrent", "use concurrency-aware abstract interpreter")
-    << "\n"
+    " {y--location-sensitive} \t use location-sensitive abstract interpreter"
+    " {y--concurrent} \t use concurrency-aware abstract interpreter\n"
+    "\n"
     "Domain options:\n"
-    << help_entry("--constants", "constant domain")
-    << help_entry("--intervals", "interval domain")
-    << help_entry("--non-null", "non-null domain")
-    << help_entry(
-      "--dependence-graph",
-      "data and control dependencies between instructions")
-    << "\n"
+    " {y--constants} \t constant domain\n"
+    " {y--intervals} \t interval domain\n"
+    " {y--non-null} \t non-null domain\n"
+    " {y--dependence-graph} \t data and control dependencies between"
+    " instructions"
+    "\n"
     "Output options:\n"
-    << help_entry(
-      "--text file_name", "output results in plain text to given file")
-    << help_entry(
-      "--json file_name", "output results in JSON format to given file")
-    << help_entry(
-      "--xml file_name", "output results in XML format to given file")
-    << help_entry(
-      "--dot file_name", "output results in DOT format to given file")
-    << "\n"
+    " {y--text} {ufile_name} \t output results in plain text to given file\n"
+    " {y--json} {ufile_name} \t output results in JSON format to given file\n"
+    " {y--xml} {ufile_name} \t output results in XML format to given file\n"
+    " {y--dot} {ufile_name} \t output results in DOT format to given file\n"
+    "\n"
     "Specific analyses:\n"
-    << help_entry(
-      "--taint file_name", "perform taint analysis using rules in given file")
-    << help_entry(
-      "--show-taint", "print taint analysis results on stdout")
-    << help_entry(
-      "--show-local-may-alias", "perform procedure-local may alias analysis")
-    << "\n"
+    " {y--taint} {ufile_name} \t perform taint analysis using rules in given"
+    " file\n"
+    " {y--show-taint} \t print taint analysis results on stdout\n"
+    " {y--show-local-may-alias} \t perform procedure-local may alias analysis\n"
+    "\n"
     "Java Bytecode frontend options:\n"
-    << JAVA_BYTECODE_LANGUAGE_OPTIONS_HELP
-    << "\n"
+    JAVA_BYTECODE_LANGUAGE_OPTIONS_HELP
+    "\n"
     "Platform options:\n"
-    << HELP_CONFIG_PLATFORM
-    << "\n"
+    HELP_CONFIG_PLATFORM
+    "\n"
     "Program representations:\n"
-    << help_entry("--show-parse-tree", "show parse tree")
-    << help_entry("--show-symbol-table", "show loaded symbol table")
-    << HELP_SHOW_GOTO_FUNCTIONS
-    << HELP_SHOW_PROPERTIES
-    << "\n"
+    " {y--show-parse-tree} \t show parse tree\n"
+    " {y--show-symbol-table} \t show loaded symbol table\n"
+    HELP_SHOW_GOTO_FUNCTIONS
+    HELP_SHOW_PROPERTIES
+    "\n"
     "Program instrumentation options:\n"
-    << help_entry("--no-assertions", "ignore user assertions")
-    << help_entry("--no-assumptions", "ignore user assumptions")
-    << help_entry("--property id", "enable selected properties only")
-    << "\n"
+    " {y--no-assertions} \t ignore user assertions\n"
+    " {y--no-assumptions} \t ignore user assumptions\n"
+    " {y--property} {uid} \t enable selected properties only\n"
+    "\n"
     "Other options:\n"
-    << help_entry("--version", "show version and exit")
-    << help_entry("--verbosity #", "verbosity level")
-    << HELP_TIMESTAMP
-    << "\n";
+    " {y--version} \t show version and exit\n"
+    " {y--verbosity {u#} \t verbosity level\n"
+    HELP_TIMESTAMP
+    "\n");
   // clang-format on
 }

--- a/jbmc/src/java_bytecode/java_bytecode_language.h
+++ b/jbmc/src/java_bytecode/java_bytecode_language.h
@@ -53,81 +53,95 @@ Author: Daniel Kroening, kroening@kroening.com
   "(java-lift-clinit-calls)"
 
 #define JAVA_BYTECODE_LANGUAGE_OPTIONS_HELP /*NOLINT*/ \
-  " --disable-uncaught-exception-check\n" \
-  "                              ignore uncaught exceptions and errors\n" \
-  " --throw-assertion-error      throw java.lang.AssertionError on violated\n" \
-  "                              assert statements instead of failing\n" \
-  "                              at the location of the assert statement\n" \
-  " --throw-runtime-exceptions   make implicit runtime exceptions explicit\n" \
-  " --assert-no-exceptions-thrown\n"\
-  "                              transform `throw` instructions into `assert FALSE`\n"/* NOLINT(*) */ \
-  "                              followed by `assume FALSE`.\n" \
-  " --max-nondet-array-length N  limit nondet (e.g. input) array size to <= N\n" /* NOLINT(*) */ \
-  " --max-nondet-tree-depth N    limit size of nondet (e.g. input) object tree;\n" /* NOLINT(*) */ \
-  "                              at level N references are set to null\n" /* NOLINT(*) */ \
-  " --java-assume-inputs-non-null\n" \
-  "                              never initialize reference-typed parameter to the\n" /* NOLINT(*) */ \
-  "                              entry point with null\n" /* NOLINT(*) */ \
-  " --java-assume-inputs-interval [L:U] or [L:] or [:U]\n" \
-  "                              force numerical primitive-typed inputs\n" /* NOLINT(*) */ \
-  "                              (byte, short, int, long, float, double) to be\n" /* NOLINT(*) */ \
-  "                              initialized within the given range; lower bound\n" /* NOLINT(*) */ \
-  "                              L and upper bound U must be integers;\n" /* NOLINT(*) */ \
-  "                              does not work for arrays;\n" /* NOLINT(*) */ \
-  " --java-assume-inputs-integral\n" \
-  "                              force float and double inputs to have integer values;\n" /* NOLINT(*) */ \
-  "                              does not work for arrays;\n" /* NOLINT(*) */ \
-  " --java-max-vla-length N      limit the length of user-code-created arrays\n" /* NOLINT(*) */ \
-  " --java-cp-include-files r    regexp or JSON list of files to load\n" \
-  "                              (with '@' prefix)\n" \
-  " --java-load-class CLASS      also load code from class CLASS\n" \
-  " --java-no-load-class CLASS   never load code from class CLASS\n" \
-  " --ignore-manifest-main-class ignore Main-Class entries in JAR manifest files.\n" /* NOLINT(*) */ \
-  "                              If this option is specified and the options\n" /* NOLINT(*) */ \
-  "                              --function and --main-class are not, we can be\n" /* NOLINT(*) */ \
-  "                              certain that all classes in the JAR file are\n" /* NOLINT(*) */ \
-  "                              loaded.\n" \
-  " --context-include i          only analyze code matching specification i that\n" /* NOLINT(*) */ \
-  " --context-exclude e          does not match specification e.\n" \
-  "                              All other methods are excluded, i.e. we load their\n" /* NOLINT(*) */ \
-  "                              signatures and meta-information, but not their\n" /* NOLINT(*) */ \
-  "                              bodies.\n" \
-  "                              A specification is any prefix of a package, class\n" /* NOLINT(*) */ \
-  "                              or method name, e.g. \"org.cprover.\" or\n" /* NOLINT(*) */ \
-  "                              \"org.cprover.MyClass.\" or\n" \
-  "                              \"org.cprover.MyClass.methodToStub:(I)Z\".\n" \
-  "                              These options can be given multiple times.\n" \
-  "                              The default for context-include is 'all\n" \
-  "                              included'; default for context-exclude is\n" \
-  "                              'nothing excluded'.\n" \
-  " --no-lazy-methods            load and translate all methods given on\n" \
-  "                              the command line and in --classpath\n" \
-  "                              Default is to load methods that appear to be\n" /* NOLINT(*) */ \
-  "                              reachable from the --function entry point\n" \
-  "                              or main class\n" \
-  "                              Note that --show-symbol-table, --show-goto-functions\n" /* NOLINT(*) */ \
-  "                              and --show-properties output are restricted to\n" /* NOLINT(*) */ \
-  "                              loaded methods by default.\n" \
-  " --lazy-methods-extra-entry-point METHODNAME\n" \
-  "                              treat METHODNAME as a possible program entry\n" /* NOLINT(*) */ \
-  "                              point for the purpose of lazy method loading\n" /* NOLINT(*) */ \
-  "                              METHODNAME can be a regex that will be matched\n" /* NOLINT(*) */ \
-  "                              against all symbols. If missing a java:: prefix\n"    /* NOLINT(*) */ \
-  "                              will be added. If no descriptor is found, all\n"/* NOLINT(*) */ \
-  "                              overloads of a method will also be added.\n" \
-  " --static-values f            Load initial values of static fields from the given\n"/* NOLINT(*) */ \
-  "                              JSON file. We assign static fields to these values\n"/* NOLINT(*) */ \
-  "                              instead of calling the normal static initializer\n"/* NOLINT(*) */ \
-  "                              (clinit) method.\n" \
-  "                              The argument can be a relative or absolute path to\n"/* NOLINT(*) */ \
-  "                              the file.\n" \
-  " --java-lift-clinit-calls     Lifts clinit calls in function bodies to the top of the\n" /* NOLINT(*) */ \
-  "                              function. This may reduce the overall cost of static\n" /* NOLINT(*) */ \
-  "                              initialisation, but may be unsound if there are\n" /* NOLINT(*) */ \
-  "                              cyclic dependencies between static initializers due\n" /* NOLINT(*) */ \
-  "                              to potentially changing their order of execution,\n" /* NOLINT(*) */ \
-  "                              or if static initializers have side-effects such as\n" /* NOLINT(*) */ \
-  "                              updating another class' static field.\n" /* NOLINT(*) */
+  help_entry( \
+    "--disable-uncaught-exception-check", \
+    "ignore uncaught exceptions and errors") \
+  << help_entry( \
+    "--throw-assertion-error", \
+    "throw java.lang.AssertionError on violated assert statements instead of " \
+    "failing at the location of the assert statement") \
+  << help_entry( \
+    "--throw-runtime-exceptions", \
+    "make implicit runtime exceptions explicit") \
+  << help_entry( \
+    "--assert-no-exceptions-thrown", \
+    "transform `throw` instructions into `assert FALSE` followed by `assume " \
+    "FALSE`.") \
+  << help_entry( \
+    "--max-nondet-array-length N", \
+    "limit nondet (e.g. input) array size to <= N") \
+  << help_entry( \
+    "--max-nondet-tree-depth N", \
+    "limit size of nondet (e.g. input) object tree; at level N references " \
+    "are set to null") \
+  << help_entry( \
+    "--java-assume-inputs-non-null", \
+    "never initialize reference-typed parameter to the entry point with null") \
+  << help_entry( \
+    "--java-assume-inputs-interval [L:U] or [L:] or [:U]", \
+    "force numerical primitive-typed inputs (byte, short, int, long, float, " \
+    "double) to be initialized within the given range; lower bound L and " \
+    "upper bound U must be integers; does not work for arrays;") \
+  << help_entry( \
+    "--java-assume-inputs-integral", \
+    "force float and double inputs to have integer values; does not work for " \
+    "arrays;") \
+  << help_entry( \
+    "--java-max-vla-length N", \
+    "limit the length of user-code-created arrays") \
+  << help_entry( \
+    "--java-cp-include-files r", \
+    "regexp or JSON list of files to load (with '@' prefix)") \
+  << help_entry( \
+    "--java-load-class CLASS", \
+    "also load code from class CLASS") \
+  << help_entry( \
+    "--java-no-load-class_CLASS", \
+    "never load code from class CLASS") \
+  << help_entry( \
+    "--ignore-manifest-main-class", \
+    "ignore Main-Class entries in JAR manifest files. If this option is " \
+    "specified and the options --function and --main-class are not, we can " \
+    "be certain that all classes in the JAR file are loaded.") \
+  << help_entry( \
+    "--context-include i", \
+    "only analyze code matching specification i that") \
+  << help_entry( \
+    "--context-exclude e", \
+    "does not match specification e. All other methods are excluded, i.e. we " \
+    "load their signatures and meta-information, but not their bodies. A " \
+    "specification is any prefix of a package, class or method name, e.g. " \
+    "\"org.cprover.\" or \"org.cprover.MyClass.\" or " \
+    "\"org.cprover.MyClass.methodToStub:(I)Z\". These options can be given " \
+    "multiple times. The default for context-include is 'all included'; " \
+    "default for context-exclude is 'nothing excluded'.") \
+  << help_entry( \
+    "--no-lazy-methods", \
+    "load and translate all methods given on the command line and in " \
+    "--classpath. Default is to load methods that appear to be reachable " \
+    "from the --function entry point or main class Note that " \
+    "--show-symbol-table, --show-goto-functions and --show-properties output " \
+    "are restricted to loaded methods by default.") \
+  << help_entry( \
+    "--lazy-methods-extra-entry-point METHODNAME", \
+    "treat METHODNAME as a possible program entry point for the purpose of " \
+    "lazy method loading METHODNAME can be a regex that will be matched " \
+    "against all symbols. If missing a java:: prefix will be added. If no " \
+    "descriptor is found, all overloads of a method will also be added.") \
+  << help_entry( \
+    "--static-values f", \
+    "Load initial values of static fields from the given JSON file. We " \
+    "assign static fields to these values instead of calling the normal " \
+    "static initializer (clinit) method. The argument can be a relative or " \
+    "absolute path to the file.") \
+  << help_entry( \
+    "--java-lift-clinit-calls", \
+    "Lifts clinit calls in function bodies to the top of the function. This " \
+    "may reduce the overall cost of static initialisation, but may be " \
+    "unsound if there are cyclic dependencies between static initializers " \
+    "due to potentially changing their order of execution, or if static " \
+    "initializers have side-effects such as updating another class' static " \
+    "field.") \
 
 #ifdef _WIN32
   #define JAVA_CLASSPATH_SEPARATOR ";"
@@ -136,49 +150,46 @@ Author: Daniel Kroening, kroening@kroening.com
 #endif
 
 #define HELP_JAVA_CLASSPATH /* NOLINT(*) */ \
-  " -classpath dirs/jars\n" \
-  " -cp dirs/jars\n" \
-  " --classpath dirs/jars        set class search path of directories and\n" \
-  "                              jar files\n" \
-  "                              A " JAVA_CLASSPATH_SEPARATOR \
-  " separated list of directories and JAR\n" \
-  "                              archives to search for class files.\n" \
-  " --main-class class-name      set the name of the main class\n"
+  help_entry( \
+    "-classpath dirs/jars, -cp dirs/jars, --classpath dirs/jars", \
+    "set class search path of directories and jar files to a " \
+    JAVA_CLASSPATH_SEPARATOR "-separated list of directories and JAR " \
+    "archives to search for class files") \
+  << help_entry("--main-class class-name", "set the name of the main class")
 
 #define HELP_JAVA_METHOD_NAME /* NOLINT(*) */ \
-  "    method-name               fully qualified name of method\n" \
-  "                              used as entry point, e.g.\n" \
-  "                              mypackage.Myclass.foo:(I)Z\n"
+  help_entry( \
+    "method-name", \
+    "fully qualified name of method  used as entry point, e.g. " \
+    "mypackage.Myclass.foo:(I)Z")
 
 #define HELP_JAVA_CLASS_NAME /* NOLINT(*) */ \
-  "    class-name                name of class\n" \
-  "                              The entry point is the method specified by\n" \
-  "                              --function, or otherwise, the\n" \
-  "                              public static void main(String[])\n" \
-  "                              method of the given class.\n"
+  help_entry( \
+    "class-name", \
+    "name of class. The entry point is the method specified by --function, " \
+    "or otherwise, the public static void main(String[]) method of the given " \
+    "class.")
 
 #define OPT_JAVA_JAR /* NOLINT(*) */ \
   "(jar):"
 
 #define HELP_JAVA_JAR /* NOLINT(*) */ \
-  "    -jar jarfile              JAR file to be checked\n" \
-  "                              The entry point is the method specified by\n" \
-  "                              --function or otherwise, the\n" \
-  "                              public static void main(String[]) method\n" \
-  "                              of the class specified by --main-class or the main\n" /* NOLINT(*) */ \
-  "                              class specified in the JAR manifest\n" \
-  "                              (checked in this order).\n"
+  help_entry( \
+    "-jar jarfile", \
+    "JAR file to be checked. The entry point is the method specified by " \
+    "--function or otherwise, the public static void main(String[]) method " \
+    "of the class specified by --main-class or the main class specified in " \
+    "the JAR manifes (checked in this order).")
 
 #define OPT_JAVA_GOTO_BINARY /* NOLINT(*) */ \
   "(gb):"
 
 #define HELP_JAVA_GOTO_BINARY /* NOLINT(*) */ \
-  "    --gb goto-binary          goto-binary file to be checked\n" \
-  "                              The entry point is the method specified by\n" \
-  "                              --function, or otherwise, the\n" \
-  "                              public static void main(String[])\n" \
-  "                              of the class specified by --main-class\n" \
-  "                              (checked in this order).\n"
+  help_entry( \
+    "--gb goto-binary", \
+    "goto-binary file to be checked. The entry point is the method specified " \
+    "by --function, or otherwise, the public static void main(String[]) of " \
+    "the class specified by --main-class (checked in this order).")
 // clang-format on
 
 enum lazy_methods_modet

--- a/jbmc/src/java_bytecode/java_bytecode_language.h
+++ b/jbmc/src/java_bytecode/java_bytecode_language.h
@@ -52,96 +52,75 @@ Author: Daniel Kroening, kroening@kroening.com
   "(static-values):" \
   "(java-lift-clinit-calls)"
 
-#define JAVA_BYTECODE_LANGUAGE_OPTIONS_HELP /*NOLINT*/ \
-  help_entry( \
-    "--disable-uncaught-exception-check", \
-    "ignore uncaught exceptions and errors") \
-  << help_entry( \
-    "--throw-assertion-error", \
-    "throw java.lang.AssertionError on violated assert statements instead of " \
-    "failing at the location of the assert statement") \
-  << help_entry( \
-    "--throw-runtime-exceptions", \
-    "make implicit runtime exceptions explicit") \
-  << help_entry( \
-    "--assert-no-exceptions-thrown", \
-    "transform `throw` instructions into `assert FALSE` followed by `assume " \
-    "FALSE`.") \
-  << help_entry( \
-    "--max-nondet-array-length N", \
-    "limit nondet (e.g. input) array size to <= N") \
-  << help_entry( \
-    "--max-nondet-tree-depth N", \
-    "limit size of nondet (e.g. input) object tree; at level N references " \
-    "are set to null") \
-  << help_entry( \
-    "--java-assume-inputs-non-null", \
-    "never initialize reference-typed parameter to the entry point with null") \
-  << help_entry( \
-    "--java-assume-inputs-interval [L:U] or [L:] or [:U]", \
-    "force numerical primitive-typed inputs (byte, short, int, long, float, " \
-    "double) to be initialized within the given range; lower bound L and " \
-    "upper bound U must be integers; does not work for arrays;") \
-  << help_entry( \
-    "--java-assume-inputs-integral", \
-    "force float and double inputs to have integer values; does not work for " \
-    "arrays;") \
-  << help_entry( \
-    "--java-max-vla-length N", \
-    "limit the length of user-code-created arrays") \
-  << help_entry( \
-    "--java-cp-include-files r", \
-    "regexp or JSON list of files to load (with '@' prefix)") \
-  << help_entry( \
-    "--java-load-class CLASS", \
-    "also load code from class CLASS") \
-  << help_entry( \
-    "--java-no-load-class_CLASS", \
-    "never load code from class CLASS") \
-  << help_entry( \
-    "--ignore-manifest-main-class", \
-    "ignore Main-Class entries in JAR manifest files. If this option is " \
-    "specified and the options --function and --main-class are not, we can " \
-    "be certain that all classes in the JAR file are loaded.") \
-  << help_entry( \
-    "--context-include i", \
-    "only analyze code matching specification i that") \
-  << help_entry( \
-    "--context-exclude e", \
-    "does not match specification e. All other methods are excluded, i.e. we " \
-    "load their signatures and meta-information, but not their bodies. A " \
-    "specification is any prefix of a package, class or method name, e.g. " \
-    "\"org.cprover.\" or \"org.cprover.MyClass.\" or " \
-    "\"org.cprover.MyClass.methodToStub:(I)Z\". These options can be given " \
-    "multiple times. The default for context-include is 'all included'; " \
-    "default for context-exclude is 'nothing excluded'.") \
-  << help_entry( \
-    "--no-lazy-methods", \
-    "load and translate all methods given on the command line and in " \
-    "--classpath. Default is to load methods that appear to be reachable " \
-    "from the --function entry point or main class Note that " \
-    "--show-symbol-table, --show-goto-functions and --show-properties output " \
-    "are restricted to loaded methods by default.") \
-  << help_entry( \
-    "--lazy-methods-extra-entry-point METHODNAME", \
-    "treat METHODNAME as a possible program entry point for the purpose of " \
-    "lazy method loading METHODNAME can be a regex that will be matched " \
-    "against all symbols. If missing a java:: prefix will be added. If no " \
-    "descriptor is found, all overloads of a method will also be added.") \
-  << help_entry( \
-    "--static-values f", \
-    "Load initial values of static fields from the given JSON file. We " \
-    "assign static fields to these values instead of calling the normal " \
-    "static initializer (clinit) method. The argument can be a relative or " \
-    "absolute path to the file.") \
-  << help_entry( \
-    "--java-lift-clinit-calls", \
-    "Lifts clinit calls in function bodies to the top of the function. This " \
-    "may reduce the overall cost of static initialisation, but may be " \
-    "unsound if there are cyclic dependencies between static initializers " \
-    "due to potentially changing their order of execution, or if static " \
-    "initializers have side-effects such as updating another class' static " \
-    "field.") \
+#define JAVA_BYTECODE_LANGUAGE_OPTIONS_HELP \
+  " {y--disable-uncaught-exception-check} \t " \
+  "ignore uncaught exceptions and errors\n" \
+  " {y--throw-assertion-error} \t " \
+  "throw java.lang.AssertionError on violated assert statements instead of " \
+  "failing at the location of the assert statement\n" \
+  " {y--throw-runtime-exceptions} \t " \
+  "make implicit runtime exceptions explicit\n" \
+  " {y--assert-no-exceptions-thrown} \t " \
+  "transform `throw` instructions into `assert FALSE` followed by " \
+  "`assume FALSE`.\n" \
+  " {y--max-nondet-array-length} {uN} \t " \
+  "limit nondet (e.g. input) array size to <= {uN}\n" \
+  " {y--max-nondet-tree-depth} {uN} \t " \
+  "limit size of nondet (e.g. input) object tree; at level {uN} references " \
+  "are set to null\n" \
+  " {y--java-assume-inputs-non-null} \t " \
+  "never initialize reference-typed parameter to the entry point with null\n" \
+  " {y--java-assume-inputs-interval} {y[}{uL}{y:}{uU}|{uL}{y:}|{y:}{uU}{y]} " \
+  "\t " \
+  "force numerical primitive-typed inputs (byte, short, int, long, float, " \
+  "double) to be initialized within the given range; lower bound {uL} and " \
+  "upper bound {uU} must be integers; does not work for arrays\n" \
+  " {y--java-assume-inputs-integral} \t " \
+  "force float and double inputs to have integer values; does not work for " \
+  "arrays\n" \
+  " {y--java-max-vla-length} {uN} \t " \
+  "limit the length of user-code-created arrays\n" \
+  " {y--java-cp-include-files} {ur} \t " \
+  "regexp or JSON list of files to load (with '@' prefix)\n" \
+  " {y--java-load-class} {uCLASS} \t also load code from class {uCLASS}\n" \
+  " {y--java-no-load-class} {uCLASS} \t never load code from class " \
+  "{uCLASS}\n" \
+  " {y--ignore-manifest-main-class} \t " \
+  "ignore Main-Class entries in JAR manifest files. If this option is " \
+  "specified and the options {y--function} and {y--main-class} are not, we " \
+  "can be certain that all classes in the JAR file are loaded.\n" \
+  " {y--context-include} {ui} \t " \
+  "only analyze code matching specification {ui}\n" \
+  " {y--context-exclude} {ue} \t " \
+  "only analyze code does not match specification {ue}. All other methods " \
+  "are excluded, i.e. we load their signatures and meta-information, but not " \
+  "their bodies. A specification is any prefix of a package, class or method " \
+  "name, e.g. \"org.cprover.\" or \"org.cprover.MyClass.\" or " \
+  "\"org.cprover.MyClass.methodToStub:(I)Z\". These options can be given " \
+  "multiple times. The default for context-include is 'all included'; " \
+  "default for context-exclude is 'nothing excluded'.\n" \
+  " {y--no-lazy-methods} \t " \
+  "load and translate all methods given on the command line and in " \
+  "{y--classpath}. Default is to load methods that appear to be reachable " \
+  "from the {y--function} entry point or main class Note that " \
+  "{y--show-symbol-table}, {y--show-goto-functions} and " \
+  "{y--show-properties} output are restricted to loaded methods by default.\n" \
+  " {y--lazy-methods-extra-entry-point} {uMETHODNAME} \t " \
+  "treat {uMETHODNAME} as a possible program entry point for the purpose of " \
+  "lazy method loading {uMETHODNAME} can be a regex that will be matched " \
+  "against all symbols. If missing a java:: prefix will be added. If no " \
+  "descriptor is found, all overloads of a method will also be added.\n" \
+  " {y--static-values} {uf} \t " \
+  "Load initial values of static fields from the given JSON file {uf}. We " \
+  "assign static fields to these values instead of calling the normal " \
+  "static initializer (clinit) method. The argument can be a relative or " \
+  "absolute path to the file.\n" \
+  " {y--java-lift-clinit-calls} \t " \
+  "Lifts clinit calls in function bodies to the top of the function. This " \
+  "may reduce the overall cost of static initialisation, but may be unsound " \
+  "if there are cyclic dependencies between static initializers due to " \
+  "potentially changing their order of execution, or if static initializers " \
+  "have side-effects such as updating another class' static field.\n" \
 
 #ifdef _WIN32
   #define JAVA_CLASSPATH_SEPARATOR ";"
@@ -149,47 +128,43 @@ Author: Daniel Kroening, kroening@kroening.com
   #define JAVA_CLASSPATH_SEPARATOR ":"
 #endif
 
-#define HELP_JAVA_CLASSPATH /* NOLINT(*) */ \
-  help_entry( \
-    "-classpath dirs/jars, -cp dirs/jars, --classpath dirs/jars", \
-    "set class search path of directories and jar files to a " \
-    JAVA_CLASSPATH_SEPARATOR "-separated list of directories and JAR " \
-    "archives to search for class files") \
-  << help_entry("--main-class class-name", "set the name of the main class")
+#define HELP_JAVA_CLASSPATH \
+  " {y-classpath} {udirs/jars}, {y-cp} {udirs/jars}, " \
+  "{y--classpath} {udirs/jars} \t " \
+  "set class search path of directories and jar files to a " \
+  JAVA_CLASSPATH_SEPARATOR "-separated list of directories and JAR " \
+  "archives to search for class files\n" \
+  " {y--main-class} {uclass-name} \t set the name of the main class\n"
 
-#define HELP_JAVA_METHOD_NAME /* NOLINT(*) */ \
-  help_entry( \
-    "method-name", \
-    "fully qualified name of method  used as entry point, e.g. " \
-    "mypackage.Myclass.foo:(I)Z")
+#define HELP_JAVA_METHOD_NAME \
+  "  {umethod-name} \t " \
+  "fully qualified name of method  used as entry point, e.g. " \
+  "mypackage.Myclass.foo:(I)Z\n"
 
-#define HELP_JAVA_CLASS_NAME /* NOLINT(*) */ \
-  help_entry( \
-    "class-name", \
-    "name of class. The entry point is the method specified by --function, " \
-    "or otherwise, the public static void main(String[]) method of the given " \
-    "class.")
+#define HELP_JAVA_CLASS_NAME \
+  "  {uclass-name} \t " \
+  "name of class. The entry point is the method specified by --function, " \
+  "or otherwise, the public static void main(String[]) method of the given " \
+  "class.\n"
 
-#define OPT_JAVA_JAR /* NOLINT(*) */ \
+#define OPT_JAVA_JAR \
   "(jar):"
 
-#define HELP_JAVA_JAR /* NOLINT(*) */ \
-  help_entry( \
-    "-jar jarfile", \
-    "JAR file to be checked. The entry point is the method specified by " \
-    "--function or otherwise, the public static void main(String[]) method " \
-    "of the class specified by --main-class or the main class specified in " \
-    "the JAR manifes (checked in this order).")
+#define HELP_JAVA_JAR \
+  " {y-jar} {ujarfile} \t " \
+  "JAR file to be checked. The entry point is the method specified by " \
+  "{y--function} or otherwise, the public static void main(String[]) method " \
+  "of the class specified by {y--main-class} or the main class specified in " \
+  "the JAR manifest (checked in this order).\n"
 
-#define OPT_JAVA_GOTO_BINARY /* NOLINT(*) */ \
+#define OPT_JAVA_GOTO_BINARY \
   "(gb):"
 
-#define HELP_JAVA_GOTO_BINARY /* NOLINT(*) */ \
-  help_entry( \
-    "--gb goto-binary", \
-    "goto-binary file to be checked. The entry point is the method specified " \
-    "by --function, or otherwise, the public static void main(String[]) of " \
-    "the class specified by --main-class (checked in this order).")
+#define HELP_JAVA_GOTO_BINARY \
+  " {y--gb} {ugoto-binary} \t " \
+  "goto-binary file to be checked. The entry point is the method specified " \
+  "by {y--function}, or otherwise, the public static void main(String[]) of " \
+  "the class specified by {y--main-class} (checked in this order).\n"
 // clang-format on
 
 enum lazy_methods_modet

--- a/jbmc/src/java_bytecode/java_trace_validation.h
+++ b/jbmc/src/java_bytecode/java_trace_validation.h
@@ -27,9 +27,10 @@ class messaget;
   "(validate-trace)" \
 
 #define HELP_JAVA_TRACE_VALIDATION /*NOLINT*/ \
-    " --validate-trace             throw an error if the structure of the counterexample\n" /*NOLINT*/ \
-    "                              trace does not match certain assumptions\n" /*NOLINT*/ \
-    "                              (experimental, currently java only)\n" /*NOLINT*/ \
+  help_entry( \
+    "--validate-trace", \
+    "throw an error if the structure of the counterexample trace does not " \
+    "match certain assumptions (experimental, currently java only)")
 // clang-format on
 
 /// Checks that the structure of each step of the trace matches certain

--- a/jbmc/src/java_bytecode/java_trace_validation.h
+++ b/jbmc/src/java_bytecode/java_trace_validation.h
@@ -27,10 +27,9 @@ class messaget;
   "(validate-trace)" \
 
 #define HELP_JAVA_TRACE_VALIDATION /*NOLINT*/ \
-  help_entry( \
-    "--validate-trace", \
-    "throw an error if the structure of the counterexample trace does not " \
-    "match certain assumptions (experimental, currently java only)")
+  " {y--validate-trace} \t throw an error if the structure of the" \
+  " counterexample trace does not match certain assumptions (experimental," \
+  " currently java only)\n"
 // clang-format on
 
 /// Checks that the structure of each step of the trace matches certain

--- a/jbmc/src/jbmc/jbmc_parse_options.cpp
+++ b/jbmc/src/jbmc/jbmc_parse_options.cpp
@@ -966,82 +966,95 @@ void jbmc_parse_optionst::help()
     "\n"
     " jbmc [-?] [-h] [--help]      show help\n"
     " jbmc\n"
-    HELP_JAVA_METHOD_NAME
-    " jbmc\n"
-    HELP_JAVA_CLASS_NAME
-    " jbmc\n"
-    HELP_JAVA_JAR
-    " jbmc\n"
-    HELP_JAVA_GOTO_BINARY
-    "\n"
-    HELP_JAVA_CLASSPATH
-    HELP_FUNCTIONS
-    "\n"
+    << HELP_JAVA_METHOD_NAME
+    << " jbmc\n"
+    << HELP_JAVA_CLASS_NAME
+    << " jbmc\n"
+    << HELP_JAVA_JAR
+    << " jbmc\n"
+    << HELP_JAVA_GOTO_BINARY
+    << "\n"
+    << HELP_JAVA_CLASSPATH
+    << HELP_FUNCTIONS
+    << "\n"
     "Analysis options:\n"
-    HELP_SHOW_PROPERTIES
-    " --symex-coverage-report f    generate a Cobertura XML coverage report in f\n" // NOLINT(*)
-    " --property id                only check one specific property\n"
-    " --trace                      give a counterexample trace for failed properties\n" //NOLINT(*)
-    " --stop-on-fail               stop analysis once a failed property is detected\n" // NOLINT(*)
-    "                              (implies --trace)\n"
-    " --localize-faults            localize faults (experimental)\n"
-    HELP_JAVA_TRACE_VALIDATION
-    "\n"
+    << HELP_SHOW_PROPERTIES
+    << help_entry(
+      "--symex-coverage-report f",
+      "generate a Cobertura XML coverage report in f")
+    << help_entry("--property id", "only check one specific property")
+    << help_entry(
+      "--trace", "give a counterexample trace for failed properties")
+    << help_entry(
+      "--stop-on-fail",
+      "stop analysis once a failed property is detected (implies --trace)")
+    << help_entry("--localize-faults", "localize faults (experimental)")
+    << HELP_JAVA_TRACE_VALIDATION
+    << "\n"
     "Platform options:\n"
-    HELP_CONFIG_PLATFORM
-    "\n"
+    << HELP_CONFIG_PLATFORM
+    << "\n"
     "Program representations:\n"
-    " --show-parse-tree            show parse tree\n"
-    " --show-symbol-table          show loaded symbol table\n"
-    " --list-symbols               list symbols with type information\n"
-    HELP_SHOW_GOTO_FUNCTIONS
-    " --drop-unused-functions      drop functions trivially unreachable\n"
-    "                              from main function\n"
-    HELP_SHOW_CLASS_HIERARCHY
-    "\n"
+    << help_entry("--show-parse-tree", "show parse tree")
+    << help_entry("--show-symbol-table", "show loaded symbol table")
+    << help_entry("--list-symbols", "list symbols with type information")
+    << HELP_SHOW_GOTO_FUNCTIONS
+    << help_entry(
+      "--drop-unused-functions",
+      "drop functions trivially unreachable from main function")
+    << HELP_SHOW_CLASS_HIERARCHY
+    << "\n"
     "Program instrumentation options:\n"
-    " --no-assertions              ignore user assertions\n"
-    " --no-assumptions             ignore user assumptions\n"
-    " --mm MM                      memory consistency model for concurrent programs\n" // NOLINT(*)
-    HELP_REACHABILITY_SLICER
-    " --full-slice                 run full slicer (experimental)\n" // NOLINT(*)
-    "\n"
+    << help_entry("--no-assertions", "ignore user assertions")
+    << help_entry("--no-assumptions", "ignore user assumptions")
+    << help_entry("--mm MM", "memory consistency model for concurrent programs")
+    << HELP_REACHABILITY_SLICER
+    << help_entry("--full-slice", "run full slicer (experimental)")
+    << "\n"
     "Java Bytecode frontend options:\n"
-    JAVA_BYTECODE_LANGUAGE_OPTIONS_HELP
+    << JAVA_BYTECODE_LANGUAGE_OPTIONS_HELP
     // This one is handled by jbmc_parse_options not by the Java frontend,
     // hence its presence here:
-    " --java-threading             enable java multi-threading support (experimental)\n" // NOLINT(*)
-    " --java-unwind-enum-static    unwind loops in static initialization of enums\n" // NOLINT(*)
+    << help_entry(
+      "--java-threading",
+      "enable java multi-threading support (experimental)")
+    << help_entry(
+      "--java-unwind-enum-static",
+      "unwind loops in static initialization of enums")
     // Currently only supported in the JBMC frontend:
-    " --symex-driven-lazy-loading  only load functions when first entered by symbolic\n" // NOLINT(*)
-    "                              execution. Note that --show-symbol-table,\n"
-    "                              --show-goto-functions/properties output\n"
-    "                              will be restricted to loaded methods in this case,\n" // NOLINT(*)
-    "                              and only output after the symex phase.\n"
-    "\n"
+    << help_entry(
+      "--symex-driven-lazy-loading",
+      "only load functions when first entered by symbolic execution. Note that "
+      "--show-symbol-table, --show-goto-functions/properties output will be "
+      "restricted to loaded methods in this case, and only output after the "
+      "symex phase.")
+    << "\n"
     "Semantic transformations:\n"
-    // NOLINTNEXTLINE(whitespace/line_length)
-    " --nondet-static              add nondeterministic initialization of variables with static lifetime\n"
-    "\n"
+    << help_entry(
+      "--nondet-static",
+      "add nondeterministic initialization of variables with static lifetime")
+    << "\n"
     "BMC options:\n"
-    HELP_BMC
-    "\n"
+    << HELP_BMC
+    << "\n"
     "Backend options:\n"
-    HELP_CONFIG_BACKEND
-    HELP_SOLVER
-    HELP_STRING_REFINEMENT
-    " --arrays-uf-never            never turn arrays into uninterpreted functions\n" // NOLINT(*)
-    " --arrays-uf-always           always turn arrays into uninterpreted functions\n" // NOLINT(*)
-    "\n"
+    << HELP_CONFIG_BACKEND
+    << HELP_SOLVER
+    << HELP_STRING_REFINEMENT
+    << help_entry(
+      "--arrays-uf-never", "never turn arrays into uninterpreted functions")
+    << help_entry(
+      "--arrays-uf-always", "always turn arrays into uninterpreted functions")
+    << "\n"
     "Other options:\n"
-    " --version                    show version and exit\n"
-    HELP_XML_INTERFACE
-    HELP_JSON_INTERFACE
-    HELP_VALIDATE
-    HELP_GOTO_TRACE
-    HELP_FLUSH
-    " --verbosity #                verbosity level\n"
-    HELP_TIMESTAMP
-    "\n";
+    << help_entry("--version", "show version and exit")
+    << HELP_XML_INTERFACE
+    << HELP_JSON_INTERFACE
+    << HELP_VALIDATE
+    << HELP_GOTO_TRACE
+    << HELP_FLUSH
+    << help_entry("--verbosity #", "verbosity level")
+    << HELP_TIMESTAMP
+    << "\n";
   // clang-format on
 }

--- a/jbmc/src/jbmc/jbmc_parse_options.cpp
+++ b/jbmc/src/jbmc/jbmc_parse_options.cpp
@@ -13,6 +13,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <util/config.h>
 #include <util/exit_codes.h>
+#include <util/help_formatter.h>
 #include <util/invariant.h>
 #include <util/make_unique.h>
 #include <util/version.h>
@@ -960,101 +961,92 @@ void jbmc_parse_optionst::help()
             << align_center_with_border("Copyright (C) 2001-2018") << '\n'
             << align_center_with_border("Daniel Kroening, Edmund Clarke") << '\n' // NOLINT(*)
             << align_center_with_border("Carnegie Mellon University, Computer Science Department") << '\n' // NOLINT(*)
-            << align_center_with_border("kroening@kroening.com") << '\n'
-            << "\n"
-    "Usage:                       Purpose:\n"
+            << align_center_with_border("kroening@kroening.com") << '\n';
+
+  std::cout << help_formatter(
     "\n"
-    " jbmc [-?] [-h] [--help]      show help\n"
-    " jbmc\n"
-    << HELP_JAVA_METHOD_NAME
-    << " jbmc\n"
-    << HELP_JAVA_CLASS_NAME
-    << " jbmc\n"
-    << HELP_JAVA_JAR
-    << " jbmc\n"
-    << HELP_JAVA_GOTO_BINARY
-    << "\n"
-    << HELP_JAVA_CLASSPATH
-    << HELP_FUNCTIONS
-    << "\n"
+    "Usage:                     \tPurpose:\n"
+    "\n"
+    " {bjbmc} [{y-?}] [{y-h}] [{y--help}] \t show this help\n"
+    " {bjbmc}\n"
+    HELP_JAVA_METHOD_NAME
+    " {bjbmc}\n"
+    HELP_JAVA_CLASS_NAME
+    " {bjbmc}\n"
+    HELP_JAVA_JAR
+    " {bjbmc}\n"
+    HELP_JAVA_GOTO_BINARY
+    "\n"
+    HELP_JAVA_CLASSPATH
+    HELP_FUNCTIONS
+    "\n"
     "Analysis options:\n"
-    << HELP_SHOW_PROPERTIES
-    << help_entry(
-      "--symex-coverage-report f",
-      "generate a Cobertura XML coverage report in f")
-    << help_entry("--property id", "only check one specific property")
-    << help_entry(
-      "--trace", "give a counterexample trace for failed properties")
-    << help_entry(
-      "--stop-on-fail",
-      "stop analysis once a failed property is detected (implies --trace)")
-    << help_entry("--localize-faults", "localize faults (experimental)")
-    << HELP_JAVA_TRACE_VALIDATION
-    << "\n"
+    HELP_SHOW_PROPERTIES
+    " {y--symex-coverage-report} {uf} \t generate a Cobertura XML coverage"
+    " report in {uf}\n"
+    " {y--property} {uid} \t only check one specific property\n"
+    " {y--trace} \t give a counterexample trace for failed properties\n"
+    " {y--stop-on-fail} \t stop analysis once a failed property is detected"
+    " (implies {y--trace})\n"
+    " {y--localize-faults} \t localize faults (experimental)\n"
+    HELP_JAVA_TRACE_VALIDATION
+    "\n"
     "Platform options:\n"
-    << HELP_CONFIG_PLATFORM
-    << "\n"
+    HELP_CONFIG_PLATFORM
+    "\n"
     "Program representations:\n"
-    << help_entry("--show-parse-tree", "show parse tree")
-    << help_entry("--show-symbol-table", "show loaded symbol table")
-    << help_entry("--list-symbols", "list symbols with type information")
-    << HELP_SHOW_GOTO_FUNCTIONS
-    << help_entry(
-      "--drop-unused-functions",
-      "drop functions trivially unreachable from main function")
-    << HELP_SHOW_CLASS_HIERARCHY
-    << "\n"
+    " {y--show-parse-tree} \t show parse tree\n"
+    " {y--show-symbol-table} \t show loaded symbol table\n"
+    " {y--list-symbols} \t list symbols with type information\n"
+    HELP_SHOW_GOTO_FUNCTIONS
+    " {y--drop-unused-functions} \t drop functions trivially unreachable"
+    " from main function\n"
+    HELP_SHOW_CLASS_HIERARCHY
+    "\n"
     "Program instrumentation options:\n"
-    << help_entry("--no-assertions", "ignore user assertions")
-    << help_entry("--no-assumptions", "ignore user assumptions")
-    << help_entry("--mm MM", "memory consistency model for concurrent programs")
-    << HELP_REACHABILITY_SLICER
-    << help_entry("--full-slice", "run full slicer (experimental)")
-    << "\n"
+    " {y--no-assertions} \t ignore user assertions\n"
+    " {y--no-assumptions} \t ignore user assumptions\n"
+    " {y--mm} {uMM} \t memory consistency model for concurrent programs\n"
+    HELP_REACHABILITY_SLICER
+    " {y--full-slice} \t run full slicer (experimental)\n"
+    "\n"
     "Java Bytecode frontend options:\n"
-    << JAVA_BYTECODE_LANGUAGE_OPTIONS_HELP
+    JAVA_BYTECODE_LANGUAGE_OPTIONS_HELP
     // This one is handled by jbmc_parse_options not by the Java frontend,
     // hence its presence here:
-    << help_entry(
-      "--java-threading",
-      "enable java multi-threading support (experimental)")
-    << help_entry(
-      "--java-unwind-enum-static",
-      "unwind loops in static initialization of enums")
-    // Currently only supported in the JBMC frontend:
-    << help_entry(
-      "--symex-driven-lazy-loading",
-      "only load functions when first entered by symbolic execution. Note that "
-      "--show-symbol-table, --show-goto-functions/properties output will be "
-      "restricted to loaded methods in this case, and only output after the "
-      "symex phase.")
-    << "\n"
+    " {y--java-threading} \t enable java multi-threading support"
+    " (experimental)\n"
+    " {y--java-unwind-enum-static} \t unwind loops in static initialization of"
+    " enums\n"
+    " {y--symex-driven-lazy-loading} \t only load functions when first entered"
+    " by symbolic execution. Note that {y--show-symbol-table},"
+    " {y--show-goto-functions}, {y--show-properties} output will be restricted"
+    " to loaded methods in this case, and only output after the symex phase.\n"
+    "\n"
     "Semantic transformations:\n"
-    << help_entry(
-      "--nondet-static",
-      "add nondeterministic initialization of variables with static lifetime")
-    << "\n"
+    " {y--nondet-static} \t add nondeterministic initialization of variables"
+    " with static lifetime\n"
+    "\n"
     "BMC options:\n"
-    << HELP_BMC
-    << "\n"
+    HELP_BMC
+    "\n"
     "Backend options:\n"
-    << HELP_CONFIG_BACKEND
-    << HELP_SOLVER
-    << HELP_STRING_REFINEMENT
-    << help_entry(
-      "--arrays-uf-never", "never turn arrays into uninterpreted functions")
-    << help_entry(
-      "--arrays-uf-always", "always turn arrays into uninterpreted functions")
-    << "\n"
+    HELP_CONFIG_BACKEND
+    HELP_SOLVER
+    HELP_STRING_REFINEMENT
+    " {y--arrays-uf-never} \t never turn arrays into uninterpreted functions\n"
+    " {y--arrays-uf-always} \t always turn arrays into uninterpreted"
+    " functions\n"
+    "\n"
     "Other options:\n"
-    << help_entry("--version", "show version and exit")
-    << HELP_XML_INTERFACE
-    << HELP_JSON_INTERFACE
-    << HELP_VALIDATE
-    << HELP_GOTO_TRACE
-    << HELP_FLUSH
-    << help_entry("--verbosity #", "verbosity level")
-    << HELP_TIMESTAMP
-    << "\n";
+    " {y--version} \t show version and exit\n"
+    HELP_XML_INTERFACE
+    HELP_JSON_INTERFACE
+    HELP_VALIDATE
+    HELP_GOTO_TRACE
+    HELP_FLUSH
+    " {y--verbosity} {u#} \t verbosity level\n"
+    HELP_TIMESTAMP
+    "\n");
   // clang-format on
 }

--- a/jbmc/src/jdiff/jdiff_parse_options.cpp
+++ b/jbmc/src/jdiff/jdiff_parse_options.cpp
@@ -243,25 +243,25 @@ void jdiff_parse_optionst::help()
     " jdiff old new                 jars to be compared\n"
     "\n"
     "Diff options:\n"
-    HELP_SHOW_GOTO_FUNCTIONS
-    HELP_SHOW_PROPERTIES
-    " --show-loops                 show the loops in the programs\n"
-    " -u | --unified               output unified diff\n"
-    " --change-impact | \n"
-    "  --forward-impact |\n"
-    // NOLINTNEXTLINE(whitespace/line_length)
-    "  --backward-impact           output unified diff with forward&backward/forward/backward dependencies\n"
-    " --compact-output             output dependencies in compact mode\n"
-    "\n"
+    << HELP_SHOW_GOTO_FUNCTIONS
+    << HELP_SHOW_PROPERTIES
+    << help_entry("--show-loops", "show the loops in the programs")
+    << help_entry("-u, --unified", "output unified diff")
+    << help_entry(
+      "--change-impact, --forward-impact, --backward-impact",
+      "output unified diff with forward&backward/forward/backward dependencies")
+    << help_entry("--compact-output", "output dependencies in compact mode")
+    << "\n"
     "Program instrumentation options:\n"
-    " --no-assertions              ignore user assertions\n"
-    " --no-assumptions             ignore user assumptions\n"
-    HELP_COVER
+    << help_entry("--no-assertions", "ignore user assertions")
+    << help_entry("--no-assumptions", "ignore user assumptions")
+    << HELP_COVER
+    << "\n"
     "Other options:\n"
-    " --version                    show version and exit\n"
-    " --json-ui                    use JSON-formatted output\n"
-    " --verbosity #                verbosity level\n"
-    HELP_TIMESTAMP
-    "\n";
+    << help_entry("--version", "show version and exit")
+    << help_entry("--json-ui", "use JSON-formatted output")
+    << help_entry("--verbosity #", "verbosity level")
+    << HELP_TIMESTAMP
+    << "\n";
   // clang-format on
 }

--- a/jbmc/src/jdiff/jdiff_parse_options.cpp
+++ b/jbmc/src/jdiff/jdiff_parse_options.cpp
@@ -13,6 +13,7 @@ Author: Peter Schrammel
 
 #include <util/config.h>
 #include <util/exit_codes.h>
+#include <util/help_formatter.h>
 #include <util/options.h>
 #include <util/version.h>
 
@@ -234,34 +235,34 @@ void jdiff_parse_optionst::help()
   std::cout << '\n' << banner_string("JDIFF", CBMC_VERSION) << '\n'
             << align_center_with_border("Copyright (C) 2016-2018") << '\n'
             << align_center_with_border("Daniel Kroening, Peter Schrammel") << '\n' // NOLINT(*)
-            << align_center_with_border("kroening@kroening.com") << '\n'
-            <<
+            << align_center_with_border("kroening@kroening.com") << '\n';
+
+  std::cout << help_formatter(
     "\n"
-    "Usage:                       Purpose:\n"
+    "Usage:                     \tPurpose:\n"
     "\n"
-    " jdiff [-?] [-h] [--help]      show help\n"
-    " jdiff old new                 jars to be compared\n"
+    " {bjdiff} [{y-?}] [{y-h}] [{y--help}] \t show this help\n"
+    " {bjdiff} {uold} {unew} \t jars to be compared\n"
     "\n"
     "Diff options:\n"
-    << HELP_SHOW_GOTO_FUNCTIONS
-    << HELP_SHOW_PROPERTIES
-    << help_entry("--show-loops", "show the loops in the programs")
-    << help_entry("-u, --unified", "output unified diff")
-    << help_entry(
-      "--change-impact, --forward-impact, --backward-impact",
-      "output unified diff with forward&backward/forward/backward dependencies")
-    << help_entry("--compact-output", "output dependencies in compact mode")
-    << "\n"
+    HELP_SHOW_GOTO_FUNCTIONS
+    HELP_SHOW_PROPERTIES
+    " {y--show-loops} \t show the loops in the programs\n"
+    " {y-u}, {y--unified} \t output unified diff\n"
+    " {y--change-impact}, {y--forward-impact}, {y--backward-impact} \t output"
+    " unified diff with forward&backward/forward/backward dependencies\n"
+    " {y--compact-output} \t output dependencies in compact mode\n"
+    "\n"
     "Program instrumentation options:\n"
-    << help_entry("--no-assertions", "ignore user assertions")
-    << help_entry("--no-assumptions", "ignore user assumptions")
-    << HELP_COVER
-    << "\n"
+    " {y--no-assertions} \t ignore user assertions\n"
+    " {y--no-assumptions} \t ignore user assumptions\n"
+    HELP_COVER
+    "\n"
     "Other options:\n"
-    << help_entry("--version", "show version and exit")
-    << help_entry("--json-ui", "use JSON-formatted output")
-    << help_entry("--verbosity #", "verbosity level")
-    << HELP_TIMESTAMP
-    << "\n";
+    " {y--version} \t show version and exit\n"
+    " {y--json-ui} \t use JSON-formatted output\n"
+    " {y--verbosity} {u#} \t verbosity level\n"
+    HELP_TIMESTAMP
+    "\n");
   // clang-format on
 }

--- a/regression/goto-bmc/arguments/help.desc
+++ b/regression/goto-bmc/arguments/help.desc
@@ -6,7 +6,7 @@ CORE
 goto-bmc \d\.\d+\.\d+
 Usage\:
 Purpose\:
-show help
+show this help
 show version and exit
 --
 --

--- a/src/analyses/variable-sensitivity/variable_sensitivity_domain.h
+++ b/src/analyses/variable-sensitivity/variable_sensitivity_domain.h
@@ -83,25 +83,22 @@
   "(vsd-liveness)"
 
 #define HELP_VSD                                                               \
-  help_entry(                                                                  \
-    "--vsd-values [constants|intervals|set-of-constants]", "value tracking")   \
-    << help_entry(                                                             \
-         "--vsd-structs [top-bottom|every-field]",                             \
-         "struct field sensitive analysis")                                    \
-    << help_entry(                                                             \
-         "--vsd-arrays [top-bottom|smash|up-to-n-elements|every-element]",     \
-         "array entry sensitive analysis")                                     \
-    << help_entry(                                                             \
-         "--vsd-array-max-elements N",                                         \
-         "set the n in --vsd-arrays up-to-n-elements (defaults to 10 if not "  \
-         "given)")                                                             \
-    << help_entry(                                                             \
-         "--vsd-pointers [top-bottom|constants|value-set]",                    \
-         "pointer sensitive analysis")                                         \
-    << help_entry("--vsd-unions [top-bottom]", "union sensitive analysis")     \
-    << help_entry("--vsd-data-dependencies", "track data dependencies")        \
-    << help_entry("--vsd-liveness", "track variable liveness")                 \
-    << help_entry("--vsd-flow-insensitive", "disables flow sensitivity")
+  " {y--vsd-values} [{yconstants}|{yintervals}|{yset-of-constants}] \t "       \
+  "value tracking\n"                                                           \
+  " {y--vsd-structs} [{ytop-bottom}|{yevery-field}] \t "                       \
+  "struct field sensitive analysis\n"                                          \
+  " {y--vsd-arrays} [[ytop-bottom}|{ysmash}|{yup-to-n-elements}|"              \
+  "{yevery-element}] \t "                                                      \
+  "array entry sensitive analysis\n"                                           \
+  " {y--vsd-array-max-elements} {uN} \t "                                      \
+  "set the {un} in {y--vsd-arrays} {yup-to-n-elements} (defaults to 10 if "    \
+  "not given)\n"                                                               \
+  " {y--vsd-pointers} [{ytop-bottom}|{yconstants}|{yvalue-set}] \t "           \
+  "pointer sensitive analysis\n"                                               \
+  " {y--vsd-unions} [{ytop-bottom}] \t union sensitive analysis\n"             \
+  " {y--vsd-data-dependencies} \t track data dependencies\n"                   \
+  " {y--vsd-liveness} \t track variable liveness\n"                            \
+  " {y--vsd-flow-insensitive} \t disables flow sensitivity\n"
 
 #define PARSE_OPTIONS_VSD(cmdline, options)                                    \
   options.set_option("values", cmdline.get_value("vsd-values"));               \

--- a/src/analyses/variable-sensitivity/variable_sensitivity_domain.h
+++ b/src/analyses/variable-sensitivity/variable_sensitivity_domain.h
@@ -80,26 +80,28 @@
   "(vsd-unions):"                                                              \
   "(vsd-flow-insensitive)"                                                     \
   "(vsd-data-dependencies)"                                                    \
-  "(vsd-liveness)"                                                             \
-                                                                               \
-    // clang-format off
-#define HELP_VSD                                                               \
-  " --vsd-values                 value tracking - "                            \
-  "constants|intervals|set-of-constants\n" /* NOLINT(whitespace/line_length) */\
-  " --vsd-structs                struct field sensitive analysis - "           \
-  "top-bottom|every-field\n" /* NOLINT(whitespace/line_length) */              \
-  " --vsd-arrays                 array entry sensitive analysis - "            \
-  "top-bottom|smash|up-to-n-elements|every-element\n" /* NOLINT(whitespace/line_length) */ \
-  " --vsd-array-max-elements     the n in --vsd-arrays up-to-n-elements - "    \
-  "defaults to 10 if not given\n" /* NOLINT(whitespace/line_length) */         \
-  " --vsd-pointers               pointer sensitive analysis - "                \
-  "top-bottom|constants|value-set\n" /* NOLINT(whitespace/line_length) */      \
-  " --vsd-unions                 union sensitive analysis - top-bottom\n"      \
-  " --vsd-data-dependencies      track data dependencies\n"                    \
-  " --vsd-liveness               track variable liveness\n"                    \
-  " --vsd-flow-insensitive       disables flow sensitivity\n"                  \
+  "(vsd-liveness)"
 
-// cland-format on
+#define HELP_VSD                                                               \
+  help_entry(                                                                  \
+    "--vsd-values [constants|intervals|set-of-constants]", "value tracking")   \
+    << help_entry(                                                             \
+         "--vsd-structs [top-bottom|every-field]",                             \
+         "struct field sensitive analysis")                                    \
+    << help_entry(                                                             \
+         "--vsd-arrays [top-bottom|smash|up-to-n-elements|every-element]",     \
+         "array entry sensitive analysis")                                     \
+    << help_entry(                                                             \
+         "--vsd-array-max-elements N",                                         \
+         "set the n in --vsd-arrays up-to-n-elements (defaults to 10 if not "  \
+         "given)")                                                             \
+    << help_entry(                                                             \
+         "--vsd-pointers [top-bottom|constants|value-set]",                    \
+         "pointer sensitive analysis")                                         \
+    << help_entry("--vsd-unions [top-bottom]", "union sensitive analysis")     \
+    << help_entry("--vsd-data-dependencies", "track data dependencies")        \
+    << help_entry("--vsd-liveness", "track variable liveness")                 \
+    << help_entry("--vsd-flow-insensitive", "disables flow sensitivity")
 
 #define PARSE_OPTIONS_VSD(cmdline, options)                                    \
   options.set_option("values", cmdline.get_value("vsd-values"));               \

--- a/src/ansi-c/ansi_c_language.h
+++ b/src/ansi-c/ansi_c_language.h
@@ -25,14 +25,12 @@ Author: Daniel Kroening, kroening@kroening.com
   "(min-null-tree-depth):"
 
 #define HELP_ANSI_C_LANGUAGE \
-  help_entry( \
-    "--max-nondet-tree-depth N", \
-    "limit size of nondet (e.g. input) object tree; at level N pointers are " \
-    "set to null") \
-  << help_entry( \
-    "--min-null-tree-depth N", \
-    "minimum level at which a pointer can first be NULL in a recursively " \
-    "nondet initialized struct") \
+  " {y--max-nondet-tree-depth} {uN} \t " \
+  "limit size of nondet (e.g. input) object tree; at level {uN} pointers are " \
+  "set to null\n" \
+  " {y--min-null-tree-depth} {uN} \t " \
+  "minimum level at which a pointer can first be NULL in a recursively " \
+  "nondet initialized struct\n" \
 // clang-format on
 
 class ansi_c_languaget:public languaget

--- a/src/ansi-c/ansi_c_language.h
+++ b/src/ansi-c/ansi_c_language.h
@@ -25,10 +25,14 @@ Author: Daniel Kroening, kroening@kroening.com
   "(min-null-tree-depth):"
 
 #define HELP_ANSI_C_LANGUAGE \
-  " --max-nondet-tree-depth N    limit size of nondet (e.g. input) object tree;\n" /* NOLINT(*) */\
-  "                              at level N pointers are set to null\n" \
-  " --min-null-tree-depth N      minimum level at which a pointer can first be\n" /* NOLINT(*) */\
-  "                              NULL in a recursively nondet initialized struct\n" /* NOLINT(*) */
+  help_entry( \
+    "--max-nondet-tree-depth N", \
+    "limit size of nondet (e.g. input) object tree; at level N pointers are " \
+    "set to null") \
+  << help_entry( \
+    "--min-null-tree-depth N", \
+    "minimum level at which a pointer can first be NULL in a recursively " \
+    "nondet initialized struct") \
 // clang-format on
 
 class ansi_c_languaget:public languaget

--- a/src/ansi-c/goto_check_c.h
+++ b/src/ansi-c/goto_check_c.h
@@ -49,29 +49,46 @@ void goto_check_c(
   "(no-assertions)(no-assumptions)"                                            \
   "(assert-to-assume)"
 
-// clang-format off
-#define HELP_GOTO_CHECK \
-  " --bounds-check               enable array bounds checks\n" \
-  " --pointer-check              enable pointer checks\n" /* NOLINT(whitespace/line_length) */ \
-  " --memory-leak-check          enable memory leak checks\n" \
-  " --memory-cleanup-check       enable memory cleanup checks\n" \
-  " --div-by-zero-check          enable division by zero checks\n" \
-  " --signed-overflow-check      enable signed arithmetic over- and underflow checks\n" /* NOLINT(whitespace/line_length) */ \
-  " --unsigned-overflow-check    enable arithmetic over- and underflow checks\n" /* NOLINT(whitespace/line_length) */  \
-  " --pointer-overflow-check     enable pointer arithmetic over- and underflow checks\n" /* NOLINT(whitespace/line_length) */  \
-  " --conversion-check           check whether values can be represented after type cast\n" /* NOLINT(whitespace/line_length) */  \
-  " --undefined-shift-check      check shift greater than bit-width\n" \
-  " --float-overflow-check       check floating-point for +/-Inf\n" \
-  " --nan-check                  check floating-point for NaN\n" \
-  " --enum-range-check           checks that all enum type expressions have values in the enum range\n" /* NOLINT(whitespace/line_length) */ \
-  " --pointer-primitive-check    checks that all pointers in pointer primitives are valid or null\n" /* NOLINT(whitespace/line_length) */ \
-  " --retain-trivial-checks      include checks that are trivially true\n" \
-  " --error-label label          check that label is unreachable\n" \
-  " --no-built-in-assertions     ignore assertions in built-in library\n" \
-  " --no-assertions              ignore user assertions\n" \
-  " --no-assumptions             ignore user assumptions\n" \
-  " --assert-to-assume           convert user assertions to assumptions\n" \
+#define HELP_GOTO_CHECK                                                        \
+  help_entry("--bounds-check", "enable array bounds checks")                   \
+    << help_entry("--pointer-check", "enable pointer checks")                  \
+    << help_entry("--memory-leak-check", "enable memory leak checks")          \
+    << help_entry("--memory-cleanup-check", "enable memory cleanup checks")    \
+    << help_entry("--div-by-zero-check", "enable division by zero checks")     \
+    << help_entry(                                                             \
+         "--signed-overflow-check",                                            \
+         "enable signed arithmetic over- and underflow checks")                \
+    << help_entry(                                                             \
+         "--unsigned-overflow-check",                                          \
+         "enable arithmetic over- and underflow checks")                       \
+    << help_entry(                                                             \
+         "--pointer-overflow-check",                                           \
+         "enable pointer arithmetic over- and underflow checks")               \
+    << help_entry(                                                             \
+         "--conversion-check",                                                 \
+         "check whether values can be represented after type cast")            \
+    << help_entry(                                                             \
+         "--undefined-shift-check", "check shift greater than bit-width")      \
+    << help_entry("--float-overflow-check", "check floating-point for +/-Inf") \
+    << help_entry("--nan-check", "check floating-point for NaN")               \
+    << help_entry(                                                             \
+         "--enum-range-check",                                                 \
+         "checks that all enum type expressions have values in the enum "      \
+         "range")                                                              \
+    << help_entry(                                                             \
+         "--pointer-primitive-check",                                          \
+         "checks that all pointers in pointer primitives are valid or null")   \
+    << help_entry(                                                             \
+         "--retain-trivial-checks", "include checks that are trivially true")  \
+    << help_entry("--error-label label", "check that label is unreachable")    \
+    << help_entry(                                                             \
+         "--no-built-in-assertions", "ignore assertions in built-in library")  \
+    << help_entry("--no-assertions", "ignore user assertions")                 \
+    << help_entry("--no-assumptions", "ignore user assumptions")               \
+    << help_entry(                                                             \
+         "--assert-to-assume", "convert user assertions to assumptions")
 
+// clang-format off
 #define PARSE_OPTIONS_GOTO_CHECK(cmdline, options) \
   options.set_option("bounds-check", cmdline.isset("bounds-check")); \
   options.set_option("pointer-check", cmdline.isset("pointer-check")); \

--- a/src/ansi-c/goto_check_c.h
+++ b/src/ansi-c/goto_check_c.h
@@ -50,43 +50,32 @@ void goto_check_c(
   "(assert-to-assume)"
 
 #define HELP_GOTO_CHECK                                                        \
-  help_entry("--bounds-check", "enable array bounds checks")                   \
-    << help_entry("--pointer-check", "enable pointer checks")                  \
-    << help_entry("--memory-leak-check", "enable memory leak checks")          \
-    << help_entry("--memory-cleanup-check", "enable memory cleanup checks")    \
-    << help_entry("--div-by-zero-check", "enable division by zero checks")     \
-    << help_entry(                                                             \
-         "--signed-overflow-check",                                            \
-         "enable signed arithmetic over- and underflow checks")                \
-    << help_entry(                                                             \
-         "--unsigned-overflow-check",                                          \
-         "enable arithmetic over- and underflow checks")                       \
-    << help_entry(                                                             \
-         "--pointer-overflow-check",                                           \
-         "enable pointer arithmetic over- and underflow checks")               \
-    << help_entry(                                                             \
-         "--conversion-check",                                                 \
-         "check whether values can be represented after type cast")            \
-    << help_entry(                                                             \
-         "--undefined-shift-check", "check shift greater than bit-width")      \
-    << help_entry("--float-overflow-check", "check floating-point for +/-Inf") \
-    << help_entry("--nan-check", "check floating-point for NaN")               \
-    << help_entry(                                                             \
-         "--enum-range-check",                                                 \
-         "checks that all enum type expressions have values in the enum "      \
-         "range")                                                              \
-    << help_entry(                                                             \
-         "--pointer-primitive-check",                                          \
-         "checks that all pointers in pointer primitives are valid or null")   \
-    << help_entry(                                                             \
-         "--retain-trivial-checks", "include checks that are trivially true")  \
-    << help_entry("--error-label label", "check that label is unreachable")    \
-    << help_entry(                                                             \
-         "--no-built-in-assertions", "ignore assertions in built-in library")  \
-    << help_entry("--no-assertions", "ignore user assertions")                 \
-    << help_entry("--no-assumptions", "ignore user assumptions")               \
-    << help_entry(                                                             \
-         "--assert-to-assume", "convert user assertions to assumptions")
+  " {y--bounds-check} \t enable array bounds checks\n"                         \
+  " {y--pointer-check} \t enable pointer checks\n"                             \
+  " {y--memory-leak-check} \t enable memory leak checks\n"                     \
+  " {y--memory-cleanup-check} \t enable memory cleanup checks\n"               \
+  " {y--div-by-zero-check} \t enable division by zero checks\n"                \
+  " {y--signed-overflow-check} \t "                                            \
+  "enable signed arithmetic over- and underflow checks\n"                      \
+  " {y--unsigned-overflow-check} \t "                                          \
+  "enable arithmetic over- and underflow checks\n"                             \
+  " {y--pointer-overflow-check} \t "                                           \
+  "enable pointer arithmetic over- and underflow checks\n"                     \
+  " {y--conversion-check} \t "                                                 \
+  "check whether values can be represented after type cast\n"                  \
+  " {y--undefined-shift-check} \t check shift greater than bit-width"          \
+  " {y--float-overflow-check} \t check floating-point for +/-Inf\n"            \
+  " {y--nan-check} \t check floating-point for NaN\n"                          \
+  " {y--enum-range-check} \t "                                                 \
+  "checks that all enum type expressions have values in the enum range\n"      \
+  " {y--pointer-primitive-check} \t "                                          \
+  "checks that all pointers in pointer primitives are valid or null\n"         \
+  " {y--retain-trivial-checks} \t include checks that are trivially true\n"    \
+  " {y--error-label} {ulabel} \t check that label {ulabel} is unreachable\n"   \
+  " {y--no-built-in-assertions} \t ignore assertions in built-in library\n"    \
+  " {y--no-assertions} \t ignore user assertions\n"                            \
+  " {y--no-assumptions} \t ignore user assumptions\n"                          \
+  " {y--assert-to-assume} \t convert user assertions to assumptions\n"
 
 // clang-format off
 #define PARSE_OPTIONS_GOTO_CHECK(cmdline, options) \

--- a/src/cbmc/cbmc_parse_options.cpp
+++ b/src/cbmc/cbmc_parse_options.cpp
@@ -945,67 +945,81 @@ void cbmc_parse_optionst::help()
     " cbmc [options] file.c ...    perform bounded model checking\n"
     "\n"
     "Analysis options:\n"
-    HELP_SHOW_PROPERTIES
-    " --symex-coverage-report f    generate a Cobertura XML coverage report in f\n" // NOLINT(*)
-    " --property id                only check one specific property\n"
-    " --trace                      give a counterexample trace for failed properties\n" //NOLINT(*)
-    " --stop-on-fail               stop analysis once a failed property is detected\n" // NOLINT(*)
-    "                              (implies --trace)\n"
-    " --localize-faults            localize faults (experimental)\n"
-    "\n"
+    << HELP_SHOW_PROPERTIES
+    << help_entry(
+      "--symex-coverage-report f",
+      "generate a Cobertura XML coverage report in f")
+    << help_entry("--property id", "only check one specific property")
+    << help_entry(
+      "--trace",
+      "give a counterexample trace for failed properties")
+    << help_entry(
+      "--stop-on-fail",
+      "stop analysis once a failed property is detected (implies --trace)")
+    << help_entry("--localize-faults", "localize faults (experimental)")
+    << "\n"
     "C/C++ frontend options:\n"
-    " --preprocess                 stop after preprocessing\n"
-    " --test-preprocessor          stop after preprocessing, discard output\n"
-    HELP_CONFIG_C_CPP
-    HELP_ANSI_C_LANGUAGE
-    HELP_FUNCTIONS
-    "\n"
+    << help_entry("--preprocess", "stop after preprocessing")
+    << help_entry(
+      "--test-preprocessor", "stop after preprocessing, discard output")
+    << HELP_CONFIG_C_CPP
+    << HELP_ANSI_C_LANGUAGE
+    << HELP_FUNCTIONS
+    << "\n"
     "Platform options:\n"
-    HELP_CONFIG_PLATFORM
-    "\n"
+    << HELP_CONFIG_PLATFORM
+    << "\n"
     "Program representations:\n"
-    " --show-parse-tree            show parse tree\n"
-    " --show-symbol-table          show loaded symbol table\n"
-    HELP_SHOW_GOTO_FUNCTIONS
-    HELP_VALIDATE
-    " --export-symex-ready-goto f         serialise goto-program in symex-ready-goto form in f\n" // NOLINT(*)
-    "\n"
+    << help_entry("--show-parse-tree", "show parse tree")
+    << help_entry("--show-symbol-table", "show loaded symbol table")
+    << HELP_SHOW_GOTO_FUNCTIONS
+    << HELP_VALIDATE
+    << "\n"
     "Program instrumentation options:\n"
-    HELP_GOTO_CHECK
-    HELP_COVER
-    " --mm MM                      memory consistency model for concurrent programs (default: sc)\n" // NOLINT(*)
-    HELP_CONFIG_LIBRARY
-    HELP_REACHABILITY_SLICER
-    " --full-slice                 run full slicer (experimental)\n" // NOLINT(*)
-    " --drop-unused-functions      drop functions trivially unreachable from main function\n" // NOLINT(*)
-    " --havoc-undefined-functions\n"
-    "                              for any function that has no body, assign non-deterministic values to\n" // NOLINT(*)
-    "                              any parameters passed as non-const pointers and the return value\n" // NOLINT(*)
-    "\n"
+    << HELP_GOTO_CHECK
+    << HELP_COVER
+    << help_entry(
+      "--mm MM",
+      "memory consistency model for concurrent programs (default: sc)")
+    << HELP_CONFIG_LIBRARY
+    << HELP_REACHABILITY_SLICER
+    << help_entry("--full-slice", "run full slicer (experimental)")
+    << help_entry(
+      "--drop-unused-functions",
+      "drop functions trivially unreachable from main function")
+    << help_entry(
+      "--havoc-undefined-functions",
+      "for any function that has no body, assign non-deterministic values to "
+      "any parameters passed as non-const pointers and the return value")
+    << "\n"
     "Semantic transformations:\n"
-    // NOLINTNEXTLINE(whitespace/line_length)
-    " --nondet-static              add nondeterministic initialization of variables with static lifetime\n"
-    "\n"
+    << help_entry(
+      "--nondet-static",
+      "add nondeterministic initialization of variables with static lifetime")
+    << "\n"
     "BMC options:\n"
-    HELP_BMC
-    "\n"
+    << HELP_BMC
+    << "\n"
     "Backend options:\n"
-    HELP_CONFIG_BACKEND
-    HELP_SOLVER
-    HELP_STRING_REFINEMENT_CBMC
-    " --arrays-uf-never            never turn arrays into uninterpreted functions\n" // NOLINT(*)
-    " --arrays-uf-always           always turn arrays into uninterpreted functions\n" // NOLINT(*)
-    " --show-array-constraints     show array theory constraints added\n"
-    "                              during post processing.\n"
-    "                              Requires --json-ui.\n"
-    "\n"
+    << HELP_CONFIG_BACKEND
+    << HELP_SOLVER
+    << HELP_STRING_REFINEMENT_CBMC
+    << help_entry(
+      "--arrays-uf-never", "never turn arrays into uninterpreted functions")
+    << help_entry(
+      "--arrays-uf-always", "always turn arrays into uninterpreted functions")
+    << help_entry(
+      "--show-array-constraints",
+      "show array theory constraints added during post processing. Requires "
+      "--json-ui.")
+    << "\n"
     "User-interface options:\n"
-    HELP_XML_INTERFACE
-    HELP_JSON_INTERFACE
-    HELP_GOTO_TRACE
-    HELP_FLUSH
-    " --verbosity #                verbosity level\n"
-    HELP_TIMESTAMP
-    "\n";
+    << HELP_XML_INTERFACE
+    << HELP_JSON_INTERFACE
+    << HELP_GOTO_TRACE
+    << HELP_FLUSH
+    << help_entry("--verbosity #", "verbosity level")
+    << HELP_TIMESTAMP
+    << "\n";
   // clang-format on
 }

--- a/src/cbmc/cbmc_parse_options.cpp
+++ b/src/cbmc/cbmc_parse_options.cpp
@@ -13,6 +13,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <util/config.h>
 #include <util/exit_codes.h>
+#include <util/help_formatter.h>
 #include <util/invariant.h>
 #include <util/make_unique.h>
 #include <util/version.h>
@@ -935,91 +936,82 @@ void cbmc_parse_optionst::help()
             << align_center_with_border("Daniel Kroening, Edmund Clarke") << '\n' // NOLINT(*)
             << align_center_with_border("Carnegie Mellon University, Computer Science Department") << '\n' // NOLINT(*)
             << align_center_with_border("kroening@kroening.com") << '\n' // NOLINT(*)
-            << align_center_with_border("Protected in part by U.S. patent 7,225,417") << '\n' // NOLINT(*)
-            <<
+            << align_center_with_border("Protected in part by U.S. patent 7,225,417") << '\n'; // NOLINT(*)
+
+  std::cout << help_formatter(
     "\n"
-    "Usage:                       Purpose:\n"
+    "Usage:                     \tPurpose:\n"
     "\n"
-    " cbmc [-?] [-h] [--help]      show help\n"
-    " cbmc --version               show version and exit\n"
-    " cbmc [options] file.c ...    perform bounded model checking\n"
+    " {bcbmc} [{y-?}] [{y-h}] [{y--help}] \t show this help\n"
+    " {bcbmc} {y--version} \t show version and exit\n"
+    " {bcbmc} [options] {ufile.c} {u...} \t perform bounded model checking\n"
     "\n"
     "Analysis options:\n"
-    << HELP_SHOW_PROPERTIES
-    << help_entry(
-      "--symex-coverage-report f",
-      "generate a Cobertura XML coverage report in f")
-    << help_entry("--property id", "only check one specific property")
-    << help_entry(
-      "--trace",
-      "give a counterexample trace for failed properties")
-    << help_entry(
-      "--stop-on-fail",
-      "stop analysis once a failed property is detected (implies --trace)")
-    << help_entry("--localize-faults", "localize faults (experimental)")
-    << "\n"
+    HELP_SHOW_PROPERTIES
+    " {y--symex-coverage-report} {uf} \t generate a Cobertura XML coverage"
+    " report in {uf}\n"
+    " {y--property} {uid} \t only check one specific property\n"
+    " {y--trace} \t give a counterexample trace for failed properties\n"
+    " {y--stop-on-fail} \t stop analysis once a failed property is detected"
+    " (implies {y--trace})\n"
+    " {y--localize-faults} \t localize faults (experimental)\n"
+    "\n"
     "C/C++ frontend options:\n"
-    << help_entry("--preprocess", "stop after preprocessing")
-    << help_entry(
-      "--test-preprocessor", "stop after preprocessing, discard output")
-    << HELP_CONFIG_C_CPP
-    << HELP_ANSI_C_LANGUAGE
-    << HELP_FUNCTIONS
-    << "\n"
+    " {y--preprocess} \t stop after preprocessing\n"
+    " {y--test-preprocessor} \t stop after preprocessing, discard output\n"
+    HELP_CONFIG_C_CPP
+    HELP_ANSI_C_LANGUAGE
+    HELP_FUNCTIONS
+    "\n"
     "Platform options:\n"
-    << HELP_CONFIG_PLATFORM
-    << "\n"
+    HELP_CONFIG_PLATFORM
+    "\n"
     "Program representations:\n"
-    << help_entry("--show-parse-tree", "show parse tree")
-    << help_entry("--show-symbol-table", "show loaded symbol table")
-    << HELP_SHOW_GOTO_FUNCTIONS
-    << HELP_VALIDATE
-    << "\n"
+    " {y--show-parse-tree} \t show parse tree\n"
+    " {y--show-symbol-table} \t show loaded symbol table\n"
+    HELP_SHOW_GOTO_FUNCTIONS
+    HELP_VALIDATE
+    " {y--export-symex-ready-goto} {uf} \t "
+    "serialise goto-program in symex-ready-goto form in {uf}\n"
+    "\n"
     "Program instrumentation options:\n"
-    << HELP_GOTO_CHECK
-    << HELP_COVER
-    << help_entry(
-      "--mm MM",
-      "memory consistency model for concurrent programs (default: sc)")
-    << HELP_CONFIG_LIBRARY
-    << HELP_REACHABILITY_SLICER
-    << help_entry("--full-slice", "run full slicer (experimental)")
-    << help_entry(
-      "--drop-unused-functions",
-      "drop functions trivially unreachable from main function")
-    << help_entry(
-      "--havoc-undefined-functions",
-      "for any function that has no body, assign non-deterministic values to "
-      "any parameters passed as non-const pointers and the return value")
-    << "\n"
+    HELP_GOTO_CHECK
+    HELP_COVER
+    " {y--mm} {uMM} \t memory consistency model for concurrent programs"
+    " (default: {ysc})\n"
+    HELP_CONFIG_LIBRARY
+    HELP_REACHABILITY_SLICER
+    " {y--full-slice} \t run full slicer (experimental)\n"
+    " {y--drop-unused-functions} \t drop functions trivially unreachable from"
+    " main function\n"
+    " {y--havoc-undefined-functions} \t for any function that has no body,"
+    " assign non-deterministic values to any parameters passed as non-const"
+    " pointers and the return value\n"
+    "\n"
     "Semantic transformations:\n"
-    << help_entry(
-      "--nondet-static",
-      "add nondeterministic initialization of variables with static lifetime")
-    << "\n"
+    " {y--nondet-static} \t add nondeterministic initialization of variables"
+    " with static lifetime\n"
+    "\n"
     "BMC options:\n"
-    << HELP_BMC
-    << "\n"
+    HELP_BMC
+    "\n"
     "Backend options:\n"
-    << HELP_CONFIG_BACKEND
-    << HELP_SOLVER
-    << HELP_STRING_REFINEMENT_CBMC
-    << help_entry(
-      "--arrays-uf-never", "never turn arrays into uninterpreted functions")
-    << help_entry(
-      "--arrays-uf-always", "always turn arrays into uninterpreted functions")
-    << help_entry(
-      "--show-array-constraints",
-      "show array theory constraints added during post processing. Requires "
-      "--json-ui.")
-    << "\n"
+    HELP_CONFIG_BACKEND
+    HELP_SOLVER
+    HELP_STRING_REFINEMENT_CBMC
+    " {y--arrays-uf-never} \t never turn arrays into uninterpreted functions\n"
+    " {y--arrays-uf-always} \t always turn arrays into uninterpreted"
+    " functions\n"
+    " {y--show-array-constraints} \t show array theory constraints added"
+    " during post processing. Requires {y--json-ui}.\n"
+    "\n"
     "User-interface options:\n"
-    << HELP_XML_INTERFACE
-    << HELP_JSON_INTERFACE
-    << HELP_GOTO_TRACE
-    << HELP_FLUSH
-    << help_entry("--verbosity #", "verbosity level")
-    << HELP_TIMESTAMP
-    << "\n";
+    HELP_XML_INTERFACE
+    HELP_JSON_INTERFACE
+    HELP_GOTO_TRACE
+    HELP_FLUSH
+    " {y--verbosity} {u#} \t verbosity level\n"
+    HELP_TIMESTAMP
+    "\n");
   // clang-format on
 }

--- a/src/cprover/cprover_parse_options.cpp
+++ b/src/cprover/cprover_parse_options.cpp
@@ -313,7 +313,6 @@ void cprover_parse_optionst::help()
             << banner_string("CPROVER", CBMC_VERSION) << '\n'
             << align_center_with_border("Copyright 2022") << '\n';
 
-  // clang-format off
   std::cout << help_formatter(
     "\n"
     "Usage:                     \tPurpose:\n"

--- a/src/crangler/crangler_parse_options.cpp
+++ b/src/crangler/crangler_parse_options.cpp
@@ -13,13 +13,14 @@ Author: Daniel Kroening, dkr@amazon.com
 
 #include <util/cout_message.h>
 #include <util/exit_codes.h>
+#include <util/help_formatter.h>
 #include <util/version.h>
 
 #include <json/json_parser.h>
 
-#include <iostream>
-
 #include "c_wrangler.h"
+
+#include <iostream>
 
 int crangler_parse_optionst::doit()
 {
@@ -49,12 +50,13 @@ void crangler_parse_optionst::process_crangler_json(
 
 void crangler_parse_optionst::help()
 {
-  std::cout << '\n'
-            << banner_string("CRANGLER", CBMC_VERSION) << '\n'
-            << "\n"
-               "Usage:                       Purpose:\n"
-               "\n"
-               " crangler [-?] [-h] [--help]  show help\n"
-               " crangler file.json ...       configuration file names\n"
-               "\n";
+  std::cout << '\n' << banner_string("CRANGLER", CBMC_VERSION) << '\n';
+
+  std::cout << help_formatter(
+    "\n"
+    "Usage:                     \tPurpose:\n"
+    "\n"
+    " {bcrangler} [{y-?}] [{y-h}] [{y--help}] \t show this help\n"
+    " {bcrangler} {ufile.json} ... \t configuration file names\n"
+    "\n");
 }

--- a/src/goto-analyzer/goto_analyzer_parse_options.cpp
+++ b/src/goto-analyzer/goto_analyzer_parse_options.cpp
@@ -14,6 +14,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/config.h>
 #include <util/exception_utils.h>
 #include <util/exit_codes.h>
+#include <util/help_formatter.h>
 #include <util/options.h>
 #include <util/version.h>
 
@@ -681,134 +682,110 @@ bool goto_analyzer_parse_optionst::process_goto_program(
 /// display command line help
 void goto_analyzer_parse_optionst::help()
 {
-  // clang-format off
-  std::cout << '\n' << banner_string("GOTO-ANALYZER", CBMC_VERSION) << '\n'
+  std::cout << '\n'
+            << banner_string("GOTO-ANALYZER", CBMC_VERSION) << '\n'
             << align_center_with_border("Copyright (C) 2017-2018") << '\n'
             << align_center_with_border("Daniel Kroening, Diffblue") << '\n'
-            << align_center_with_border("kroening@kroening.com") << '\n'
-            <<
+            << align_center_with_border("kroening@kroening.com") << '\n';
+
+  // clang-format off
+  std::cout << help_formatter(
     "\n"
-    "Usage:                       Purpose:\n"
+    "Usage:                     \tPurpose:\n"
     "\n"
-    " goto-analyzer [-?|-h|--help] show help\n"
-    " goto-analyzer file.c ...     source file names\n"
+    " {bgoto-analyzer} [{y-?}|{y-h}|{y--help}] \t show this help\n"
+    " {bgoto-analyzer} {ufile.c...} \t source file names\n"
     "\n"
     "Task options:\n"
-    << help_entry("--show", "display the abstract states on the goto program")
-    << help_entry(
-      "--show-on-source", "display the abstract states on the source")
-    << help_entry("--verify", "use the abstract domains to check assertions")
-    << help_entry(
-      "--simplify file_name",
-      "use the abstract domains to simplify the program")
-    << help_entry(
-      "--no-simplify-slicing",
-      "do not remove instructions from which no property can be reached (use "
-      "with --simplify)")
-    << help_entry("--unreachable-instructions", "list dead code")
-    << help_entry(
-      "--unreachable-functions",
-      "list functions unreachable from the entry point")
-    << help_entry(
-      "--reachable-functions", "list functions reachable from the entry point")
-    << "\n"
+    " {y--show} \t display the abstract states on the goto program\n"
+    " {y--show-on-source} \t display the abstract states on the source\n"
+    " {y--verify} \t use the abstract domains to check assertions\n"
+    " {y--simplify} {ufile_name} \t use the abstract domains to simplify the"
+    " program\n"
+    " {y--no-simplify-slicing} \t do not remove instructions from which no"
+    " property can be reached (use with {y--simplify})\n"
+    " {y--unreachable-instructions} \t list dead code\n"
+    " {y--unreachable-functions} \t list functions unreachable from the entry"
+    " point\n"
+    " {y--reachable-functions} \t list functions reachable from the entry"
+    " point\n"
+    "\n"
     "Abstract interpreter options:\n"
-    << help_entry(
-      "--legacy-ait", "recursion for function and one domain per location")
-    << help_entry(
-      "--recursive-interprocedural",
-      "use recursion to handle interprocedural reasoning")
-    << help_entry(
-      "--three-way-merge",
-      "use VSD's three-way merge on return from function call")
-    << help_entry(
-      "--legacy-concurrent",
-      "legacy-ait with an extended fixed-point for concurrency")
-    << help_entry(
-      "--location-sensitive", "use location-sensitive abstract interpreter")
-    << "\n"
+    " {y--legacy-ait} \t recursion for function and one domain per location\n"
+    " {y--recursive-interprocedural} \t use recursion to handle interprocedural"
+    " reasoning\n"
+    " {y--three-way-merge} \t use VSD's three-way merge on return from function"
+    " call\n"
+    " {y--legacy-concurrent} \t legacy-ait with an extended fixed-point for"
+    " concurrency\n"
+    " {y--location-sensitive} \t use location-sensitive abstract interpreter\n"
+    "\n"
     "History options:\n"
-    << help_entry(
-      "--ahistorical", "the most basic history, tracks locations only")
-    << help_entry(
-      "--call-stack n",
-      "track the calling location stack for each function limiting to at most "
-      "n recursive loops, 0 to disable")
-    << help_entry(
-      "--loop-unwind n", "track the number of loop iterations within a "
-      "function limited to n histories per location, 0 is unlimited")
-    << help_entry(
-      "--branching n",
-      "track the forwards jumps (if, switch, etc.) within a function limited "
-      "to n histories per location, 0 is unlimited")
-    << help_entry(
-      "--loop-unwind-and-branching n",
-      "track all local control flow limited to n histories per location, 0 is "
-      "unlimited")
-    << "\n"
+    " {y--ahistorical} \t the most basic history, tracks locations only\n"
+    " {y--call-stack} {un} \t track the calling location stack for each"
+    " function limiting to at most {un} recursive loops, 0 to disable\n"
+    " {y--loop-unwind} {un} \t track the number of loop iterations within a"
+    " function limited to {un} histories per location, 0 is unlimited\n"
+    " {y--branching} {un} \t track the forwards jumps (if, switch, etc.) within"
+    " a function limited to {un} histories per location, 0 is unlimited\n"
+    " {y--loop-unwind-and-branching} {un} \t track all local control flow"
+    " limited to {un} histories per location, 0 is unlimited\n"
+    "\n"
     "Domain options:\n"
-    << help_entry("--constants", "a constant for each variable if possible")
-    << help_entry("--intervals", "an interval for each variable")
-    << help_entry("--non-null", "tracks which pointers are non-null")
-    << help_entry(
-      "--dependence-graph",
-      "data and control dependencies between instructions")
-    << help_entry(
-      "--vsd, --variable-sensitivity", "a configurable non-relational domain")
-    << help_entry(
-      "--dependence-graph-vs", "dependencies between instructions using VSD")
-    << "\n"
+    " {y--constants} \t a constant for each variable if possible\n"
+    " {y--intervals} \t an interval for each variable\n"
+    " {y--non-null} \t tracks which pointers are non-null\n"
+    " {y--dependence-graph} \t data and control dependencies between"
+    " instructions\n"
+    " {y--vsd}, {y--variable-sensitivity} \t a configurable non-relational"
+    " domain\n"
+    " {y--dependence-graph-vs} \t dependencies between instructions using VSD\n"
+    "\n"
     "Variable sensitivity domain (VSD) options:\n"
-    << HELP_VSD
-    << "\n"
+    HELP_VSD
+    "\n"
     "Storage options:\n"
-    << help_entry(
-      "--one-domain-per-location", "stores a domain for each location reached")
-    << help_entry(
-      "--one-domain-per-history",
-      "stores a domain for each history object created")
-    << "\n"
+    " {y--one-domain-per-location} \t stores a domain for each location"
+    " reached\n"
+    " {y--one-domain-per-history} \t stores a domain for each history object"
+    " created\n"
+    "\n"
     "Output options:\n"
-    << help_entry(
-      "--text file_name", "output results in plain text to given file")
-    << help_entry(
-      "--json file_name", "output results in JSON format to given file")
-    << help_entry(
-      "--xml file_name", "output results in XML format to given file")
-    << help_entry(
-      "--dot file_name", "output results in DOT format to given file")
-    << "\n"
+    " {y--text} {ufile_name} \t output results in plain text to given file\n"
+    " {y--json} {ufile_name} \t output results in JSON format to given file\n"
+    " {y--xml} {ufile_name} \t output results in XML format to given file\n"
+    " {y--dot} {ufile_name} \t output results in DOT format to given file\n"
+    "\n"
     "Specific analyses:\n"
-    << help_entry(
-      "--taint file_name", "perform taint analysis using rules in given file")
-    << help_entry("--show-taint", "print taint analysis results on stdout")
-    << help_entry(
-      "--show-local-may-alias", "perform procedure-local may alias analysis")
-    << "\n"
+    " {y--taint} {ufile_name} \t perform taint analysis using rules in given"
+    " file\n"
+    " {y--show-taint} \t print taint analysis results on stdout\n"
+    " {y--show-local-may-alias} \t perform procedure-local may alias analysis\n"
+    "\n"
     "C/C++ frontend options:\n"
-    << HELP_CONFIG_C_CPP
-    << HELP_FUNCTIONS
-    << "\n"
+    HELP_CONFIG_C_CPP
+    HELP_FUNCTIONS
+    "\n"
     "Platform options:\n"
-    << HELP_CONFIG_PLATFORM
-    << "\n"
+    HELP_CONFIG_PLATFORM
+    "\n"
     "Program representations:\n"
-    << help_entry("--show-parse-tree", "show parse tree")
-    << help_entry("--show-symbol-table", "show loaded symbol table")
-    << HELP_SHOW_GOTO_FUNCTIONS
-    << HELP_SHOW_PROPERTIES
-    << "\n"
+    " {y--show-parse-tree} \t show parse tree\n"
+    " {y--show-symbol-table} \t show loaded symbol table\n"
+    HELP_SHOW_GOTO_FUNCTIONS
+    HELP_SHOW_PROPERTIES
+    "\n"
     "Program instrumentation options:\n"
-    << help_entry("--property id", "enable selected properties only")
-    << HELP_GOTO_CHECK
-    << HELP_CONFIG_LIBRARY
-    << "\n"
+    " {y--property} {uid} \t enable selected properties only\n"
+    HELP_GOTO_CHECK
+    HELP_CONFIG_LIBRARY
+    "\n"
     "Other options:\n"
-    << HELP_VALIDATE
-    << help_entry("--version", "show version and exit")
-    << HELP_FLUSH
-    << help_entry("--verbosity #", "verbosity level")
-    << HELP_TIMESTAMP
-    << "\n";
+    HELP_VALIDATE
+    " {y--version} \t show version and exit\n"
+    HELP_FLUSH
+    " {y--verbosity} {u#} \t verbosity level\n"
+    HELP_TIMESTAMP
+    "\n");
   // clang-format on
 }

--- a/src/goto-analyzer/goto_analyzer_parse_options.cpp
+++ b/src/goto-analyzer/goto_analyzer_parse_options.cpp
@@ -694,107 +694,121 @@ void goto_analyzer_parse_optionst::help()
     " goto-analyzer file.c ...     source file names\n"
     "\n"
     "Task options:\n"
-    " --show                       display the abstract states on the goto program\n" // NOLINT(*)
-    " --show-on-source             display the abstract states on the source\n"
-    // NOLINTNEXTLINE(whitespace/line_length)
-    " --verify                     use the abstract domains to check assertions\n"
-    // NOLINTNEXTLINE(whitespace/line_length)
-    " --simplify file_name         use the abstract domains to simplify the program\n"
-    " --no-simplify-slicing        do not remove instructions from which no\n"
-    "                              property can be reached (use with --simplify)\n" // NOLINT(*)
-    " --unreachable-instructions   list dead code\n"
-    // NOLINTNEXTLINE(whitespace/line_length)
-    " --unreachable-functions      list functions unreachable from the entry point\n"
-    // NOLINTNEXTLINE(whitespace/line_length)
-    " --reachable-functions        list functions reachable from the entry point\n"
-    "\n"
+    << help_entry("--show", "display the abstract states on the goto program")
+    << help_entry(
+      "--show-on-source", "display the abstract states on the source")
+    << help_entry("--verify", "use the abstract domains to check assertions")
+    << help_entry(
+      "--simplify file_name",
+      "use the abstract domains to simplify the program")
+    << help_entry(
+      "--no-simplify-slicing",
+      "do not remove instructions from which no property can be reached (use "
+      "with --simplify)")
+    << help_entry("--unreachable-instructions", "list dead code")
+    << help_entry(
+      "--unreachable-functions",
+      "list functions unreachable from the entry point")
+    << help_entry(
+      "--reachable-functions", "list functions reachable from the entry point")
+    << "\n"
     "Abstract interpreter options:\n"
-    // NOLINTNEXTLINE(whitespace/line_length)
-    " --legacy-ait                 recursion for function and one domain per location\n"
-    // NOLINTNEXTLINE(whitespace/line_length)
-    " --recursive-interprocedural  use recursion to handle interprocedural reasoning\n"
-    // NOLINTNEXTLINE(whitespace/line_length)
-    " --three-way-merge            use VSD's three-way merge on return from function call\n"
-    // NOLINTNEXTLINE(whitespace/line_length)
-    " --legacy-concurrent          legacy-ait with an extended fixed-point for concurrency\n"
-    // NOLINTNEXTLINE(whitespace/line_length)
-    " --location-sensitive         use location-sensitive abstract interpreter\n"
-    "\n"
+    << help_entry(
+      "--legacy-ait", "recursion for function and one domain per location")
+    << help_entry(
+      "--recursive-interprocedural",
+      "use recursion to handle interprocedural reasoning")
+    << help_entry(
+      "--three-way-merge",
+      "use VSD's three-way merge on return from function call")
+    << help_entry(
+      "--legacy-concurrent",
+      "legacy-ait with an extended fixed-point for concurrency")
+    << help_entry(
+      "--location-sensitive", "use location-sensitive abstract interpreter")
+    << "\n"
     "History options:\n"
-    // NOLINTNEXTLINE(whitespace/line_length)
-    " --ahistorical                the most basic history, tracks locations only\n"
-    // NOLINTNEXTLINE(whitespace/line_length)
-    " --call-stack n               track the calling location stack for each function\n"
-    // NOLINTNEXTLINE(whitespace/line_length)
-    "                              limiting to at most n recursive loops, 0 to disable\n"
-    // NOLINTNEXTLINE(whitespace/line_length)
-    " --loop-unwind n              track the number of loop iterations within a function\n"
-    // NOLINTNEXTLINE(whitespace/line_length)
-    "                              limited to n histories per location, 0 is unlimited\n"
-    // NOLINTNEXTLINE(whitespace/line_length)
-    " --branching n                track the forwards jumps (if, switch, etc.) within a function\n"
-    // NOLINTNEXTLINE(whitespace/line_length)
-    "                              limited to n histories per location, 0 is unlimited\n"
-    // NOLINTNEXTLINE(whitespace/line_length)
-    " --loop-unwind-and-branching n track all local control flow\n"
-    // NOLINTNEXTLINE(whitespace/line_length)
-    "                              limited to n histories per location, 0 is unlimited\n"
-    "\n"
+    << help_entry(
+      "--ahistorical", "the most basic history, tracks locations only")
+    << help_entry(
+      "--call-stack n",
+      "track the calling location stack for each function limiting to at most "
+      "n recursive loops, 0 to disable")
+    << help_entry(
+      "--loop-unwind n", "track the number of loop iterations within a "
+      "function limited to n histories per location, 0 is unlimited")
+    << help_entry(
+      "--branching n",
+      "track the forwards jumps (if, switch, etc.) within a function limited "
+      "to n histories per location, 0 is unlimited")
+    << help_entry(
+      "--loop-unwind-and-branching n",
+      "track all local control flow limited to n histories per location, 0 is "
+      "unlimited")
+    << "\n"
     "Domain options:\n"
-    " --constants                  a constant for each variable if possible\n"
-    " --intervals                  an interval for each variable\n"
-    " --non-null                   tracks which pointers are non-null\n"
-    " --dependence-graph           data and control dependencies between instructions\n" // NOLINT(*)
-    " --vsd, --variable-sensitivity\n"
-    "                              a configurable non-relational domain\n"
-    " --dependence-graph-vs        dependencies between instructions using VSD\n" // NOLINT(*)
-    "\n"
+    << help_entry("--constants", "a constant for each variable if possible")
+    << help_entry("--intervals", "an interval for each variable")
+    << help_entry("--non-null", "tracks which pointers are non-null")
+    << help_entry(
+      "--dependence-graph",
+      "data and control dependencies between instructions")
+    << help_entry(
+      "--vsd, --variable-sensitivity", "a configurable non-relational domain")
+    << help_entry(
+      "--dependence-graph-vs", "dependencies between instructions using VSD")
+    << "\n"
     "Variable sensitivity domain (VSD) options:\n"
-    HELP_VSD
-    "\n"
+    << HELP_VSD
+    << "\n"
     "Storage options:\n"
-    // NOLINTNEXTLINE(whitespace/line_length)
-    " --one-domain-per-location    stores a domain for each location reached (default)\n"
-    // NOLINTNEXTLINE(whitespace/line_length)
-    " --one-domain-per-history     stores a domain for each history object created\n"
-    "\n"
+    << help_entry(
+      "--one-domain-per-location", "stores a domain for each location reached")
+    << help_entry(
+      "--one-domain-per-history",
+      "stores a domain for each history object created")
+    << "\n"
     "Output options:\n"
-    " --text file_name             output results in plain text to given file\n"
-    // NOLINTNEXTLINE(whitespace/line_length)
-    " --json file_name             output results in JSON format to given file\n"
-    " --xml file_name              output results in XML format to given file\n"
-    " --dot file_name              output results in DOT format to given file\n"
-    "\n"
+    << help_entry(
+      "--text file_name", "output results in plain text to given file")
+    << help_entry(
+      "--json file_name", "output results in JSON format to given file")
+    << help_entry(
+      "--xml file_name", "output results in XML format to given file")
+    << help_entry(
+      "--dot file_name", "output results in DOT format to given file")
+    << "\n"
     "Specific analyses:\n"
-    // NOLINTNEXTLINE(whitespace/line_length)
-    " --taint file_name            perform taint analysis using rules in given file\n"
-    " --show-taint                 print taint analysis results on stdout\n"
-    " --show-local-may-alias       perform procedure-local may alias analysis\n"
-    "\n"
+    << help_entry(
+      "--taint file_name", "perform taint analysis using rules in given file")
+    << help_entry("--show-taint", "print taint analysis results on stdout")
+    << help_entry(
+      "--show-local-may-alias", "perform procedure-local may alias analysis")
+    << "\n"
     "C/C++ frontend options:\n"
-    HELP_CONFIG_C_CPP
-    HELP_FUNCTIONS
-    "\n"
+    << HELP_CONFIG_C_CPP
+    << HELP_FUNCTIONS
+    << "\n"
     "Platform options:\n"
-    HELP_CONFIG_PLATFORM
-    "\n"
+    << HELP_CONFIG_PLATFORM
+    << "\n"
     "Program representations:\n"
-    " --show-parse-tree            show parse tree\n"
-    " --show-symbol-table          show loaded symbol table\n"
-    HELP_SHOW_GOTO_FUNCTIONS
-    HELP_SHOW_PROPERTIES
-    "\n"
+    << help_entry("--show-parse-tree", "show parse tree")
+    << help_entry("--show-symbol-table", "show loaded symbol table")
+    << HELP_SHOW_GOTO_FUNCTIONS
+    << HELP_SHOW_PROPERTIES
+    << "\n"
     "Program instrumentation options:\n"
-    " --property id                enable selected properties only\n"
-    HELP_GOTO_CHECK
-    HELP_CONFIG_LIBRARY
-    "\n"
+    << help_entry("--property id", "enable selected properties only")
+    << HELP_GOTO_CHECK
+    << HELP_CONFIG_LIBRARY
+    << "\n"
     "Other options:\n"
-    HELP_VALIDATE
-    " --version                    show version and exit\n"
-    HELP_FLUSH
-    " --verbosity #                verbosity level\n"
-    HELP_TIMESTAMP
-    "\n";
+    << HELP_VALIDATE
+    << help_entry("--version", "show version and exit")
+    << HELP_FLUSH
+    << help_entry("--verbosity #", "verbosity level")
+    << HELP_TIMESTAMP
+    << "\n";
   // clang-format on
 }

--- a/src/goto-bmc/goto_bmc_parse_options.cpp
+++ b/src/goto-bmc/goto_bmc_parse_options.cpp
@@ -3,6 +3,7 @@
 #include "goto_bmc_parse_options.h"
 
 #include <util/exit_codes.h>
+#include <util/help_formatter.h>
 #include <util/message.h>
 #include <util/version.h>
 
@@ -81,18 +82,18 @@ int goto_bmc_parse_optionst::doit()
 
 void goto_bmc_parse_optionst::help()
 {
-  // clang-format off
-  log.status() << '\n' << banner_string("goto-bmc", CBMC_VERSION) << '\n'
+  log.status() << '\n'
+               << banner_string("goto-bmc", CBMC_VERSION) << '\n'
                << align_center_with_border("Copyright (C) 2023") << '\n'
-               << align_center_with_border("Diffblue Ltd.") << '\n' // NOLINT(*)
-               <<
+               << align_center_with_border("Diffblue Ltd.") << '\n';
+
+  log.status() << help_formatter(
     "\n"
-    "Usage:                       Purpose:\n"
+    "Usage:                     \tPurpose:\n"
     "\n"
-    "goto-bmc [-?] [-h] [--help]      show help\n"
-    "goto-bmc --version               show version and exit\n"
-    // NOLINTNEXTLINE(*)
-    "goto-bmc [options] file.c ...    perform bounded model checking on symex-ready goto-binary\n";
-  // clang-format on
+    " {bgoto-bmc} [{y-?}] [{y-h}] [{y--help}] \t show this help\n"
+    " {bgoto-bmc} {y--version} \t show version and exit\n"
+    " {bgoto-bmc} [options] {ufile_name} \t perform bounded model checking on"
+    " symex-ready goto-binary {ufile_name}\n");
   log.status() << messaget::eom;
 }

--- a/src/goto-checker/bmc_util.h
+++ b/src/goto-checker/bmc_util.h
@@ -195,66 +195,49 @@ void run_property_decider(
   "(symex-cache-dereferences)" OPT_UNWINDSET
 
 #define HELP_BMC                                                               \
-  help_entry("--paths [strategy]", "explore paths one at a time")              \
-    << help_entry(                                                             \
-         "--show-symex-strategies", "list strategies for use with --paths")    \
-    << help_entry(                                                             \
-         "--show-goto-symex-steps",                                            \
-         "show which steps symex travels, includes diagnostic information")    \
-    << help_entry(                                                             \
-         "--show-points-to-sets",                                              \
-         "show points-to sets for pointer dereference. Requires --json-ui.")   \
-    << help_entry("--program-only", "only show program expression")            \
-    << help_entry("--show-byte-ops", "show all byte extracts and updates")     \
-    << help_entry("--depth nr", "limit search depth")                          \
-    << help_entry(                                                             \
-         "--max-field-sensitivity-array-size M",                               \
-         "maximum size M of arrays for which field sensitivity will be "       \
-         "applied to array, the default is 64")                                \
-    << help_entry(                                                             \
-         "--no-array-field-sensitivity",                                       \
-         "deactivate field sensitivity for arrays, this is equivalent to "     \
-         "setting the maximum field  sensitivity size for arrays to 0")        \
-    << HELP_UNWINDSET                                                          \
-    << help_entry(                                                             \
-         "--incremental-loop L",                                               \
-         "check properties after each unwinding of loop L (use --show-loops "  \
-         "to get the loop IDs)")                                               \
-    << help_entry(                                                             \
-         "--unwind-min nr",                                                    \
-         "start incremental-loop after nr unwindings but before solving that " \
-         "iteration. If for example it is 1, then the loop will be unwound "   \
-         "once, and immediately checked. Note: this means for min-unwind 1 "   \
-         "or 0 all properties are checked.")                                   \
-    << help_entry(                                                             \
-         "--unwind-max nr", "stop incremental-loop after nr unwindings")       \
-    << help_entry(                                                             \
-         "--ignore-properties-before-unwind-min",                              \
-         "do not check properties before unwind-min when using "               \
-         "incremental-loop")                                                   \
-    << help_entry("--show-vcc", "show the verification conditions")            \
-    << help_entry(                                                             \
-         "--slice-formula", "remove assignments unrelated to property")        \
-    << help_entry(                                                             \
-         "--unwinding-assertions",                                             \
-         "generate unwinding assertions (cannot be used with --cover)")        \
-    << help_entry("--partial-loops", "permit paths with partial loops")        \
-    << help_entry(                                                             \
-         "--no-self-loops-to-assumptions",                                     \
-         "do not simplify while(1){} to assume(0)")                            \
-    << help_entry(                                                             \
-         "--symex-complexity-limit N",                                         \
-         "how complex (N) a path can become before symex abandons it. "        \
-         "Currently uses guard size to calculate complexity.")                 \
-    << help_entry(                                                             \
-         "--symex-complexity-failed-child-loops-limit N",                      \
-         "how many child branches (N) in an iteration are allowed to fail "    \
-         "due to complexity violations before the loop gets blacklisted")      \
-    << help_entry(                                                             \
-         "--graphml-witness_filename",                                         \
-         "write the witness in GraphML format to filename")                    \
-    << help_entry(                                                             \
-         "--symex-cache-dereferences",                                         \
-         "enable caching of repeated dereferences")
+  " {y--paths} [strategy] \t explore paths one at a time\n"                    \
+  " {y--show-symex-strategies} \t list strategies for use with {y--paths}\n"   \
+  " {y--show-goto-symex-steps} \t show which steps symex travels, includes "   \
+  "diagnostic information\n"                                                   \
+  " {y--show-points-to-sets} \t show points-to sets for pointer dereference. " \
+  "Requires {y--json-ui}.\n"                                                   \
+  " {y--program-only} \t only show program expression\n"                       \
+  " {y--show-byte-ops} \t show all byte extracts and updates\n"                \
+  " {y--depth} {unr} \t limit search depth\n"                                  \
+  " {y--max-field-sensitivity-array-size} {uM} \t "                            \
+  "maximum size {uM} of arrays for which field sensitivity will be "           \
+  "applied to array, the default is 64\n"                                      \
+  " {y--no-array-field-sensitivity} \t "                                       \
+  "deactivate field sensitivity for arrays, this is equivalent to setting "    \
+  "the maximum field sensitivity size for arrays to 0\n" HELP_UNWINDSET        \
+  " {y--incremental-loop} {uL} \t "                                            \
+  "check properties after each unwinding of loop {uL} (use {y--show-loops} "   \
+  "to get the loop IDs)\n"                                                     \
+  " {y--unwind-min} {unr} \t "                                                 \
+  "start incremental-loop after {unr} unwindings but before solving that "     \
+  "iteration. If for example it is 1, then the loop will be unwound once, "    \
+  "and immediately checked. Note: this means for {y--unwind-min} 1 or 0 all "  \
+  "properties are checked.\n"                                                  \
+  " {--unwind-max} {unr} \t stop incremental-loop after {unr} unwindings\n"    \
+  " {y--ignore-properties-before-unwind-min} \t "                              \
+  "do not check properties before unwind-min when using "                      \
+  "{y--incremental-loop}\n"                                                    \
+  " {y--show-vcc} \t show the verification conditions\n"                       \
+  " {y--slice-formula} \t remove assignments unrelated to property\n"          \
+  " {y--unwinding-assertions} \t generate unwinding assertions (cannot be "    \
+  "used with {y--cover})\n"                                                    \
+  " {y--partial-loops} \t permit paths with partial loops\n"                   \
+  " {y--no-self-loops-to-assumptions} \t do not simplify while(1){} to "       \
+  "assume(0)\n"                                                                \
+  " {y--symex-complexity-limit} {uN} \t "                                      \
+  "how complex ({uN}) a path can become before symex abandons it. Currently "  \
+  "uses guard size to calculate complexity.\n"                                 \
+  " {y--symex-complexity-failed-child-loops-limit} {uN} \t "                   \
+  "how many child branches ({uN}) in an iteration are allowed to fail due to " \
+  "complexity violations before the loop gets blacklisted\n"                   \
+  " {y--graphml-witness} {ufilename} \t write the witness in GraphML format "  \
+  "to {ufilename}\n"                                                           \
+  " {y--symex-cache-dereferences} \t enable caching of repeated "              \
+  "dereferences\n"
 
 #endif // CPROVER_GOTO_CHECKER_BMC_UTIL_H

--- a/src/goto-checker/bmc_util.h
+++ b/src/goto-checker/bmc_util.h
@@ -169,83 +169,92 @@ void run_property_decider(
   std::chrono::duration<double> solver_runtime,
   bool set_pass = true);
 
-// clang-format off
-#define OPT_BMC \
-  "(program-only)" \
-  "(show-byte-ops)" \
-  "(show-vcc)" \
-  "(show-goto-symex-steps)" \
-  "(show-points-to-sets)" \
-  "(slice-formula)" \
-  "(unwinding-assertions)" \
-  "(no-unwinding-assertions)" \
-  "(no-self-loops-to-assumptions)" \
-  "(partial-loops)" \
-  "(paths):" \
-  "(show-symex-strategies)" \
-  "(depth):" \
-  "(max-field-sensitivity-array-size):" \
-  "(no-array-field-sensitivity)" \
-  "(graphml-witness):" \
-  "(symex-complexity-limit):" \
-  "(symex-complexity-failed-child-loops-limit):" \
-  "(incremental-loop):" \
-  "(unwind-min):" \
-  "(unwind-max):" \
-  "(ignore-properties-before-unwind-min)" \
-  "(symex-cache-dereferences)" \
-  OPT_UNWINDSET \
+#define OPT_BMC                                                                \
+  "(program-only)"                                                             \
+  "(show-byte-ops)"                                                            \
+  "(show-vcc)"                                                                 \
+  "(show-goto-symex-steps)"                                                    \
+  "(show-points-to-sets)"                                                      \
+  "(slice-formula)"                                                            \
+  "(unwinding-assertions)"                                                     \
+  "(no-unwinding-assertions)"                                                  \
+  "(no-self-loops-to-assumptions)"                                             \
+  "(partial-loops)"                                                            \
+  "(paths):"                                                                   \
+  "(show-symex-strategies)"                                                    \
+  "(depth):"                                                                   \
+  "(max-field-sensitivity-array-size):"                                        \
+  "(no-array-field-sensitivity)"                                               \
+  "(graphml-witness):"                                                         \
+  "(symex-complexity-limit):"                                                  \
+  "(symex-complexity-failed-child-loops-limit):"                               \
+  "(incremental-loop):"                                                        \
+  "(unwind-min):"                                                              \
+  "(unwind-max):"                                                              \
+  "(ignore-properties-before-unwind-min)"                                      \
+  "(symex-cache-dereferences)" OPT_UNWINDSET
 
-#define HELP_BMC \
-  " --paths [strategy]           explore paths one at a time\n" \
-  " --show-symex-strategies      list strategies for use with --paths\n" \
-  " --show-goto-symex-steps      show which steps symex travels, includes\n" \
-  "                              diagnostic information\n" \
-  " --show-points-to-sets        show points-to sets for\n" \
-  "                              pointer dereference. Requires --json-ui.\n" \
-  " --program-only               only show program expression\n" \
-  " --show-byte-ops              show all byte extracts and updates\n" \
-  " --depth nr                   limit search depth\n" \
-  " --max-field-sensitivity-array-size M\n" \
-  "                              maximum size M of arrays for which field\n" \
-  "                              sensitivity will be applied to array,\n" \
-  "                              the default is 64\n" \
-  " --no-array-field-sensitivity\n" \
-  "                              deactivate field sensitivity for arrays, " \
-  "this is\n" \
-  "                              equivalent to setting the maximum field \n" \
-  "                              sensitivity size for arrays to 0\n" \
-  HELP_UNWINDSET \
-  " --incremental-loop L         check properties after each unwinding\n" \
-  "                              of loop L\n" \
-  "                              (use --show-loops to get the loop IDs)\n" \
-  " --unwind-min nr              start incremental-loop after nr unwindings\n" \
-  "                              but before solving that iteration. If for\n" \
-  "                              example it is 1, then the loop will be\n" \
-  "                              unwound once, and immediately checked.\n" \
-  "                              Note: this means for min-unwind 1 or\n"\
-  "                              0 all properties are checked.\n" \
-  " --unwind-max nr              stop incremental-loop after nr unwindings\n" \
-  " --ignore-properties-before-unwind-min\n" \
-  "                              do not check properties before unwind-min\n" \
-  "                              when using incremental-loop\n" \
-  " --show-vcc                   show the verification conditions\n" \
-  " --slice-formula              remove assignments unrelated to property\n" \
-  " --unwinding-assertions       generate unwinding assertions (cannot be\n" \
-  "                              used with --cover)\n" \
-  " --partial-loops              permit paths with partial loops\n" \
-  " --no-self-loops-to-assumptions\n" \
-  "                              do not simplify while(1){} to assume(0)\n" \
-  " --symex-complexity-limit N   how complex (N) a path can become before\n" \
-  "                              symex abandons it. Currently uses guard\n" \
-  "                              size to calculate complexity. \n" \
-  " --symex-complexity-failed-child-loops-limit N\n" \
-  "                              how many child branches (N) in an\n" \
-  "                              iteration are allowed to fail due to\n" \
-  "                              complexity violations before the loop\n" \
-  "                              gets blacklisted\n" \
-  " --graphml-witness filename   write the witness in GraphML format to filename\n" /* NOLINT(*) */ \
-  " --symex-cache-dereferences   enable caching of repeated dereferences\n" \
-// clang-format on
+#define HELP_BMC                                                               \
+  help_entry("--paths [strategy]", "explore paths one at a time")              \
+    << help_entry(                                                             \
+         "--show-symex-strategies", "list strategies for use with --paths")    \
+    << help_entry(                                                             \
+         "--show-goto-symex-steps",                                            \
+         "show which steps symex travels, includes diagnostic information")    \
+    << help_entry(                                                             \
+         "--show-points-to-sets",                                              \
+         "show points-to sets for pointer dereference. Requires --json-ui.")   \
+    << help_entry("--program-only", "only show program expression")            \
+    << help_entry("--show-byte-ops", "show all byte extracts and updates")     \
+    << help_entry("--depth nr", "limit search depth")                          \
+    << help_entry(                                                             \
+         "--max-field-sensitivity-array-size M",                               \
+         "maximum size M of arrays for which field sensitivity will be "       \
+         "applied to array, the default is 64")                                \
+    << help_entry(                                                             \
+         "--no-array-field-sensitivity",                                       \
+         "deactivate field sensitivity for arrays, this is equivalent to "     \
+         "setting the maximum field  sensitivity size for arrays to 0")        \
+    << HELP_UNWINDSET                                                          \
+    << help_entry(                                                             \
+         "--incremental-loop L",                                               \
+         "check properties after each unwinding of loop L (use --show-loops "  \
+         "to get the loop IDs)")                                               \
+    << help_entry(                                                             \
+         "--unwind-min nr",                                                    \
+         "start incremental-loop after nr unwindings but before solving that " \
+         "iteration. If for example it is 1, then the loop will be unwound "   \
+         "once, and immediately checked. Note: this means for min-unwind 1 "   \
+         "or 0 all properties are checked.")                                   \
+    << help_entry(                                                             \
+         "--unwind-max nr", "stop incremental-loop after nr unwindings")       \
+    << help_entry(                                                             \
+         "--ignore-properties-before-unwind-min",                              \
+         "do not check properties before unwind-min when using "               \
+         "incremental-loop")                                                   \
+    << help_entry("--show-vcc", "show the verification conditions")            \
+    << help_entry(                                                             \
+         "--slice-formula", "remove assignments unrelated to property")        \
+    << help_entry(                                                             \
+         "--unwinding-assertions",                                             \
+         "generate unwinding assertions (cannot be used with --cover)")        \
+    << help_entry("--partial-loops", "permit paths with partial loops")        \
+    << help_entry(                                                             \
+         "--no-self-loops-to-assumptions",                                     \
+         "do not simplify while(1){} to assume(0)")                            \
+    << help_entry(                                                             \
+         "--symex-complexity-limit N",                                         \
+         "how complex (N) a path can become before symex abandons it. "        \
+         "Currently uses guard size to calculate complexity.")                 \
+    << help_entry(                                                             \
+         "--symex-complexity-failed-child-loops-limit N",                      \
+         "how many child branches (N) in an iteration are allowed to fail "    \
+         "due to complexity violations before the loop gets blacklisted")      \
+    << help_entry(                                                             \
+         "--graphml-witness_filename",                                         \
+         "write the witness in GraphML format to filename")                    \
+    << help_entry(                                                             \
+         "--symex-cache-dereferences",                                         \
+         "enable caching of repeated dereferences")
 
 #endif // CPROVER_GOTO_CHECKER_BMC_UTIL_H

--- a/src/goto-checker/solver_factory.h
+++ b/src/goto-checker/solver_factory.h
@@ -116,36 +116,40 @@ void parse_solver_options(const cmdlinet &cmdline, optionst &options);
   "(write-solver-stats-to):"
 
 #define HELP_SOLVER                                                            \
-  " --external-sat-solver cmd    command to invoke SAT solver process\n"       \
-  " --no-sat-preprocessor        disable the SAT solver's simplifier\n"        \
-  " --dimacs                     generate CNF in DIMACS format\n"              \
-  " --beautify                   beautify the counterexample\n"                \
-  "                              (greedy heuristic)\n"                         \
-  " --smt1                       use default SMT1 solver (obsolete)\n"         \
-  " --smt2                       use default SMT2 solver (Z3)\n"               \
-  " --bitwuzla                   use Bitwuzla\n"                               \
-  " --boolector                  use Boolector\n"                              \
-  " --sat-solver solver          use specified SAT solver\n"                   \
-  " --cprover-smt2               use CPROVER SMT2 solver\n"                    \
-  " --cvc3                       use CVC3\n"                                   \
-  " --cvc4                       use CVC4\n"                                   \
-  " --cvc5                       use CVC5\n"                                   \
-  " --mathsat                    use MathSAT\n"                                \
-  " --yices                      use Yices\n"                                  \
-  " --z3                         use Z3\n"                                     \
-  " --fpa                        use theory of floating-point arithmetic\n"    \
-  " --refine                     use refinement procedure (experimental)\n"    \
-  " --refine-arrays              use refinement for arrays only\n"             \
-  " --refine-arithmetic          refinement of arithmetic expressions only\n"  \
-  " --max-node-refinement        maximum refinement iterations for\n"          \
-  "                              arithmetic expressions\n"                     \
-  " --incremental-smt2-solver cmd\n"                                           \
-  "                              command to invoke external SMT solver for\n"  \
-  "                              incremental solving (experimental)\n"         \
-  " --outfile filename           output formula to given file\n"               \
-  " --dump-smt-formula filename  output smt incremental formula to the\n"      \
-  "                              given file\n"                                 \
-  " --write-solver-stats-to json-file\n"                                       \
-  "                              collect the solver query complexity\n"
+  help_entry("--sat-solver solver", "use specified SAT solver")                \
+    << help_entry(                                                             \
+         "--external-sat-solver cmd", "command to invoke SAT solver process")  \
+    << help_entry(                                                             \
+         "--no-sat-preprocessor", "disable the SAT solver's simplifier")       \
+    << help_entry("--dimacs", "generate CNF in DIMACS format")                 \
+    << help_entry(                                                             \
+         "--beautify", "beautify the counterexample (greedy heuristic)")       \
+    << help_entry("--smt1", "use default SMT1 solver (obsolete)")              \
+    << help_entry("--smt2", "use default SMT2 solver (Z3)")                    \
+    << help_entry("--bitwuzla", "use Bitwuzla")                                \
+    << help_entry("--boolector", "use Boolector")                              \
+    << help_entry("--cprover-smt2", "use CPROVER SMT2 solver")                 \
+    << help_entry("--cvc3", "use CVC3") << help_entry("--cvc4", "use CVC4")    \
+    << help_entry("--mathsat", "use MathSAT")                                  \
+    << help_entry("--yices", "use Yices") << help_entry("--z3", "use Z3")      \
+    << help_entry("--fpa", "use theory of floating-point arithmetic")          \
+    << help_entry("--refine", "use refinement procedure (experimental)")       \
+    << help_entry("--refine-arrays", "use refinement for arrays only")         \
+    << help_entry(                                                             \
+         "--refine-arithmetic", "refinement of arithmetic expressions only")   \
+    << help_entry(                                                             \
+         "--max-node-refinement",                                              \
+         "maximum refinement iterations for arithmetic expressions")           \
+    << help_entry(                                                             \
+         "--incremental-smt2-solver cmd",                                      \
+         "command to invoke external SMT solver for incremental solving "      \
+         "(experimental)")                                                     \
+    << help_entry("--outfile filename", "output formula to given file")        \
+    << help_entry(                                                             \
+         "--dump-smt-formula filename",                                        \
+         "output smt incremental formula to the given file")                   \
+    << help_entry(                                                             \
+         "--write-solver-stats-to json-file",                                  \
+         "collect the solver query complexity")
 
 #endif // CPROVER_GOTO_CHECKER_SOLVER_FACTORY_H

--- a/src/goto-checker/solver_factory.h
+++ b/src/goto-checker/solver_factory.h
@@ -116,40 +116,35 @@ void parse_solver_options(const cmdlinet &cmdline, optionst &options);
   "(write-solver-stats-to):"
 
 #define HELP_SOLVER                                                            \
-  help_entry("--sat-solver solver", "use specified SAT solver")                \
-    << help_entry(                                                             \
-         "--external-sat-solver cmd", "command to invoke SAT solver process")  \
-    << help_entry(                                                             \
-         "--no-sat-preprocessor", "disable the SAT solver's simplifier")       \
-    << help_entry("--dimacs", "generate CNF in DIMACS format")                 \
-    << help_entry(                                                             \
-         "--beautify", "beautify the counterexample (greedy heuristic)")       \
-    << help_entry("--smt1", "use default SMT1 solver (obsolete)")              \
-    << help_entry("--smt2", "use default SMT2 solver (Z3)")                    \
-    << help_entry("--bitwuzla", "use Bitwuzla")                                \
-    << help_entry("--boolector", "use Boolector")                              \
-    << help_entry("--cprover-smt2", "use CPROVER SMT2 solver")                 \
-    << help_entry("--cvc3", "use CVC3") << help_entry("--cvc4", "use CVC4")    \
-    << help_entry("--mathsat", "use MathSAT")                                  \
-    << help_entry("--yices", "use Yices") << help_entry("--z3", "use Z3")      \
-    << help_entry("--fpa", "use theory of floating-point arithmetic")          \
-    << help_entry("--refine", "use refinement procedure (experimental)")       \
-    << help_entry("--refine-arrays", "use refinement for arrays only")         \
-    << help_entry(                                                             \
-         "--refine-arithmetic", "refinement of arithmetic expressions only")   \
-    << help_entry(                                                             \
-         "--max-node-refinement",                                              \
-         "maximum refinement iterations for arithmetic expressions")           \
-    << help_entry(                                                             \
-         "--incremental-smt2-solver cmd",                                      \
-         "command to invoke external SMT solver for incremental solving "      \
-         "(experimental)")                                                     \
-    << help_entry("--outfile filename", "output formula to given file")        \
-    << help_entry(                                                             \
-         "--dump-smt-formula filename",                                        \
-         "output smt incremental formula to the given file")                   \
-    << help_entry(                                                             \
-         "--write-solver-stats-to json-file",                                  \
-         "collect the solver query complexity")
+  " {y--sat-solver} {usolver} \t use specified SAT solver\n"                   \
+  " {y--external-sat-solver} {ucmd} \t command to invoke SAT solver process\n" \
+  " {y--no-sat-preprocessor} \t disable the SAT solver's simplifier\n"         \
+  " {y--dimacs} \t generate CNF in DIMACS format\n"                            \
+  " {y--beautify} \t beautify the counterexample (greedy heuristic)\n"         \
+  " {y--smt1} \t use default SMT1 solver (obsolete)\n"                         \
+  " {y--smt2} \t use default SMT2 solver (Z3)\n"                               \
+  " {y--bitwuzla} \t use Bitwuzla\n"                                           \
+  " {y--boolector} \t use Boolector\n"                                         \
+  " {y--cprover-smt2} \t use CPROVER SMT2 solver\n"                            \
+  " {y--cvc3} \t use CVC3\n"                                                   \
+  " {y--cvc4} \t use CVC4\n"                                                   \
+  " {y--cvc5} \t use CVC5\n"                                                   \
+  " {y--mathsat} \t use MathSAT\n"                                             \
+  " {y--yices} \t use Yices\n"                                                 \
+  " {y--z3} \t use Z3\n"                                                       \
+  " {y--fpa} \t use theory of floating-point arithmetic\n"                     \
+  " {y--refine} \t use refinement procedure (experimental)\n"                  \
+  " {y--refine-arrays} \t use refinement for arrays only\n"                    \
+  " {y--refine-arithmetic} \t refinement of arithmetic expressions only\n"     \
+  " {y--max-node-refinement} \t "                                              \
+  "maximum refinement iterations for arithmetic expressions\n"                 \
+  " {y--incremental-smt2-solver} {ucmd} \t "                                   \
+  "command to invoke external SMT solver for incremental solving "             \
+  "(experimental)\n"                                                           \
+  " {y--outfile} {ufilename} \t output formula to given file\n"                \
+  " {y--dump-smt-formula} {ufilename} \t "                                     \
+  "output smt incremental formula to the given file\n"                         \
+  " {y--write-solver-stats-to} {ujson-file} \t "                               \
+  "collect the solver query complexity\n"
 
 #endif // CPROVER_GOTO_CHECKER_SOLVER_FACTORY_H

--- a/src/goto-diff/goto_diff_parse_options.cpp
+++ b/src/goto-diff/goto_diff_parse_options.cpp
@@ -13,6 +13,7 @@ Author: Peter Schrammel
 
 #include <util/config.h>
 #include <util/exit_codes.h>
+#include <util/help_formatter.h>
 #include <util/options.h>
 #include <util/version.h>
 
@@ -220,34 +221,34 @@ void goto_diff_parse_optionst::help()
   std::cout << '\n' << banner_string("GOTO_DIFF", CBMC_VERSION) << '\n'
             << align_center_with_border("Copyright (C) 2016") << '\n'
             << align_center_with_border("Daniel Kroening, Peter Schrammel") << '\n' // NOLINT (*)
-            << align_center_with_border("kroening@kroening.com") << '\n'
-            <<
+            << align_center_with_border("kroening@kroening.com") << '\n';
+
+  std::cout << help_formatter(
     "\n"
-    "Usage:                       Purpose:\n"
+    "Usage:                     \tPurpose:\n"
     "\n"
-    " goto_diff [-?] [-h] [--help]      show help\n"
-    " goto_diff old new                 goto binaries to be compared\n"
+    " {bgoto-diff} [{y-?}] [{y-h}] [{y--help}] \t show this help\n"
+    " {bgoto-diff} {uold} {unew} \t compare two goto binaries\n"
     "\n"
     "Diff options:\n"
-    << HELP_SHOW_GOTO_FUNCTIONS
-    << HELP_SHOW_PROPERTIES
-    << help_entry("--show-loops", "show the loops in the programs")
-    << help_entry("-u, --unified", "output unified diff")
-    << help_entry(
-      "--change-impact, --forward-impact, --backward-impact",
-      "output unified diff with forward&backward/forward/backward dependencies")
-    << help_entry("--compact-output", "output dependencies in compact mode")
-    << "\n"
+    HELP_SHOW_GOTO_FUNCTIONS
+    HELP_SHOW_PROPERTIES
+    " {y--show-loops} \t show the loops in the programs\n"
+    " {y-u}, {y--unified} \t output unified diff\n"
+    " {y--change-impact}, {y--forward-impact}, {y--backward-impact} \t output"
+    " unified diff with forward&backward/forward/backward dependencies\n"
+    " {y--compact-output} \t output dependencies in compact mode\n"
+    "\n"
     "Program instrumentation options:\n"
-    << HELP_GOTO_CHECK
-    << HELP_COVER
-    << "\n"
+    HELP_GOTO_CHECK
+    HELP_COVER
+    "\n"
     "Other options:\n"
-    << help_entry("--version", "show version and exit")
-    << help_entry("--json-ui", "use JSON-formatted output")
-    << HELP_FLUSH
-    << help_entry("--verbosity #", "verbosity level")
-    << HELP_TIMESTAMP
-    << "\n";
+    " {y--version} \t show version and exit\n"
+    " {y--json-ui} \t use JSON-formatted output\n"
+    HELP_FLUSH
+    " {y--verbosity} {u#} \t verbosity level\n"
+    HELP_TIMESTAMP
+    "\n");
   // clang-format on
 }

--- a/src/goto-diff/goto_diff_parse_options.cpp
+++ b/src/goto-diff/goto_diff_parse_options.cpp
@@ -229,26 +229,25 @@ void goto_diff_parse_optionst::help()
     " goto_diff old new                 goto binaries to be compared\n"
     "\n"
     "Diff options:\n"
-    HELP_SHOW_GOTO_FUNCTIONS
-    HELP_SHOW_PROPERTIES
-    " --show-loops                 show the loops in the programs\n"
-    " -u | --unified               output unified diff\n"
-    " --change-impact | \n"
-    "  --forward-impact |\n"
-    // NOLINTNEXTLINE(whitespace/line_length)
-    "  --backward-impact           output unified diff with forward&backward/forward/backward dependencies\n"
-    " --compact-output             output dependencies in compact mode\n"
-    "\n"
+    << HELP_SHOW_GOTO_FUNCTIONS
+    << HELP_SHOW_PROPERTIES
+    << help_entry("--show-loops", "show the loops in the programs")
+    << help_entry("-u, --unified", "output unified diff")
+    << help_entry(
+      "--change-impact, --forward-impact, --backward-impact",
+      "output unified diff with forward&backward/forward/backward dependencies")
+    << help_entry("--compact-output", "output dependencies in compact mode")
+    << "\n"
     "Program instrumentation options:\n"
-    HELP_GOTO_CHECK
-    HELP_COVER
-    "\n"
+    << HELP_GOTO_CHECK
+    << HELP_COVER
+    << "\n"
     "Other options:\n"
-    " --version                    show version and exit\n"
-    " --json-ui                    use JSON-formatted output\n"
-    HELP_FLUSH
-    " --verbosity #                verbosity level\n"
-    HELP_TIMESTAMP
-    "\n";
+    << help_entry("--version", "show version and exit")
+    << help_entry("--json-ui", "use JSON-formatted output")
+    << HELP_FLUSH
+    << help_entry("--verbosity #", "verbosity level")
+    << HELP_TIMESTAMP
+    << "\n";
   // clang-format on
 }

--- a/src/goto-harness/common_harness_generator_options.h
+++ b/src/goto-harness/common_harness_generator_options.h
@@ -32,27 +32,27 @@ Author: Diffblue Ltd.
   "(" COMMON_HARNESS_GENERATOR_HAVOC_MEMBER_OPT "):"
 
 #define COMMON_HARNESS_GENERATOR_HELP                                          \
-  help_entry(                                                                  \
-    "--" COMMON_HARNESS_GENERATOR_MIN_NULL_TREE_DEPTH_OPT " N",                \
-    "minimum level at which a pointer can first be NULL in a recursively "     \
-    "nondet initialized struct")                                               \
-    << help_entry(                                                             \
-         "--" COMMON_HARNESS_GENERATOR_MAX_NONDET_TREE_DEPTH_OPT " N",         \
-         "limit size of nondet (e.g. input) object tree; at level N pointers " \
-         "are set to null")                                                    \
-    << help_entry(                                                             \
-         "--" COMMON_HARNESS_GENERATOR_MIN_ARRAY_SIZE_OPT " N",                \
-         "minimum size of dynamically created arrays (default: 1)")            \
-    << help_entry(                                                             \
-         "--" COMMON_HARNESS_GENERATOR_MAX_ARRAY_SIZE_OPT " N",                \
-         "maximum size of dynamically created arrays (default: 2)")            \
-    << help_entry(                                                             \
-         "--" COMMON_HARNESS_GENERATOR_FUNCTION_POINTER_CAN_BE_NULL_OPT        \
-         " <function-name>",                                                   \
-         "name of the function(s) pointer parameters that can be NULL "        \
-         "pointing")                                                           \
-    << help_entry(                                                             \
-         "--" COMMON_HARNESS_GENERATOR_HAVOC_MEMBER_OPT " <member-expr>",      \
-         "path to the member to be havoced")
+  " {y--" COMMON_HARNESS_GENERATOR_MIN_NULL_TREE_DEPTH_OPT                     \
+  "} {uN} \t "                                                                 \
+  "minimum level at which a pointer can first be NULL in a recursively "       \
+  "nondet initialized struct\n"                                                \
+  " {y--" COMMON_HARNESS_GENERATOR_MAX_NONDET_TREE_DEPTH_OPT                   \
+  "} {uN} \t "                                                                 \
+  "limit size of nondet (e.g. input) object tree; at level {uN} pointers "     \
+  "are set to null\n"                                                          \
+  " {y--" COMMON_HARNESS_GENERATOR_MIN_ARRAY_SIZE_OPT                          \
+  "} {uN} \t "                                                                 \
+  "minimum size of dynamically created arrays (default: 1)\n"                  \
+  " {y--" COMMON_HARNESS_GENERATOR_MAX_ARRAY_SIZE_OPT                          \
+  "} {uN} \t "                                                                 \
+  "maximum size of dynamically created arrays (default: 2)\n"                  \
+  " {y--" COMMON_HARNESS_GENERATOR_FUNCTION_POINTER_CAN_BE_NULL_OPT            \
+  "} "                                                                         \
+  "{ufunction_name} \t "                                                       \
+  "name of the function(s) pointer parameters that can be NULL "               \
+  "pointing\n"                                                                 \
+  " {y--" COMMON_HARNESS_GENERATOR_HAVOC_MEMBER_OPT                            \
+  "} {umember_expr} \t "                                                       \
+  "path to the member to be havocked\n"
 
 #endif // CPROVER_GOTO_HARNESS_COMMON_HARNESS_GENERATOR_OPTIONS_H

--- a/src/goto-harness/common_harness_generator_options.h
+++ b/src/goto-harness/common_harness_generator_options.h
@@ -18,39 +18,41 @@ Author: Diffblue Ltd.
   "function-pointer-can-be-null"
 #define COMMON_HARNESS_GENERATOR_HAVOC_MEMBER_OPT "havoc-member"
 
-// clang-format off
 #define COMMON_HARNESS_GENERATOR_OPTIONS                                       \
-  "(" COMMON_HARNESS_GENERATOR_MIN_NULL_TREE_DEPTH_OPT "):"                    \
-  "(" COMMON_HARNESS_GENERATOR_MAX_NONDET_TREE_DEPTH_OPT "):"                  \
-  "(" COMMON_HARNESS_GENERATOR_MIN_ARRAY_SIZE_OPT "):"                         \
-  "(" COMMON_HARNESS_GENERATOR_MAX_ARRAY_SIZE_OPT "):"                         \
-  "(" COMMON_HARNESS_GENERATOR_FUNCTION_POINTER_CAN_BE_NULL_OPT "):"           \
-  "(" COMMON_HARNESS_GENERATOR_HAVOC_MEMBER_OPT "):"                           \
-// COMMON_HARNESS_GENERATOR_OPTIONS
+  "(" COMMON_HARNESS_GENERATOR_MIN_NULL_TREE_DEPTH_OPT                         \
+  "):"                                                                         \
+  "(" COMMON_HARNESS_GENERATOR_MAX_NONDET_TREE_DEPTH_OPT                       \
+  "):"                                                                         \
+  "(" COMMON_HARNESS_GENERATOR_MIN_ARRAY_SIZE_OPT                              \
+  "):"                                                                         \
+  "(" COMMON_HARNESS_GENERATOR_MAX_ARRAY_SIZE_OPT                              \
+  "):"                                                                         \
+  "(" COMMON_HARNESS_GENERATOR_FUNCTION_POINTER_CAN_BE_NULL_OPT                \
+  "):"                                                                         \
+  "(" COMMON_HARNESS_GENERATOR_HAVOC_MEMBER_OPT "):"
 
-// clang-format on
-
-// clang-format off
 #define COMMON_HARNESS_GENERATOR_HELP                                          \
-  "--" COMMON_HARNESS_GENERATOR_MIN_NULL_TREE_DEPTH_OPT                        \
-  " N       minimum level at which a pointer can first be NULL\n"              \
-  "                              in a recursively nondet initialized struct\n" \
-  "--" COMMON_HARNESS_GENERATOR_MAX_NONDET_TREE_DEPTH_OPT                      \
-  " N     limit size of nondet (e.g. input) object tree;\n"                    \
-  "                              at level N pointers are set to null\n"        \
-  "--" COMMON_HARNESS_GENERATOR_MIN_ARRAY_SIZE_OPT                             \
-  " N            minimum size of dynamically created arrays\n"                 \
-  "                              (default: 1)\n"                               \
-  "--" COMMON_HARNESS_GENERATOR_MAX_ARRAY_SIZE_OPT                             \
-  " N            maximum size of dynamically created arrays\n"                 \
-  "                              (default: 2)\n"                               \
-  "--" COMMON_HARNESS_GENERATOR_FUNCTION_POINTER_CAN_BE_NULL_OPT               \
-  " <function-name>,  name of the function(s) pointer parameters\n"            \
-  "              that can be NULL pointing.\n"                                 \
-  "--" COMMON_HARNESS_GENERATOR_HAVOC_MEMBER_OPT                               \
-  " <member-expr>  path to the member to be havoced\n"                         \
-  // COMMON_HARNESS_GENERATOR_HELP
-
-// clang-format on
+  help_entry(                                                                  \
+    "--" COMMON_HARNESS_GENERATOR_MIN_NULL_TREE_DEPTH_OPT " N",                \
+    "minimum level at which a pointer can first be NULL in a recursively "     \
+    "nondet initialized struct")                                               \
+    << help_entry(                                                             \
+         "--" COMMON_HARNESS_GENERATOR_MAX_NONDET_TREE_DEPTH_OPT " N",         \
+         "limit size of nondet (e.g. input) object tree; at level N pointers " \
+         "are set to null")                                                    \
+    << help_entry(                                                             \
+         "--" COMMON_HARNESS_GENERATOR_MIN_ARRAY_SIZE_OPT " N",                \
+         "minimum size of dynamically created arrays (default: 1)")            \
+    << help_entry(                                                             \
+         "--" COMMON_HARNESS_GENERATOR_MAX_ARRAY_SIZE_OPT " N",                \
+         "maximum size of dynamically created arrays (default: 2)")            \
+    << help_entry(                                                             \
+         "--" COMMON_HARNESS_GENERATOR_FUNCTION_POINTER_CAN_BE_NULL_OPT        \
+         " <function-name>",                                                   \
+         "name of the function(s) pointer parameters that can be NULL "        \
+         "pointing")                                                           \
+    << help_entry(                                                             \
+         "--" COMMON_HARNESS_GENERATOR_HAVOC_MEMBER_OPT " <member-expr>",      \
+         "path to the member to be havoced")
 
 #endif // CPROVER_GOTO_HARNESS_COMMON_HARNESS_GENERATOR_OPTIONS_H

--- a/src/goto-harness/function_harness_generator_options.h
+++ b/src/goto-harness/function_harness_generator_options.h
@@ -40,35 +40,36 @@ Author: Diffblue Ltd.
   "(" FUNCTION_HARNESS_GENERATOR_TREAT_POINTERS_EQUAL_MAYBE_OPT ")"
 
 #define FUNCTION_HARNESS_GENERATOR_HELP                                        \
-  "function harness generator (--harness-type call-function):\n"               \
-    << help_entry(                                                             \
-         "--" FUNCTION_HARNESS_GENERATOR_FUNCTION_OPT " <function-name>",      \
-         "the function the harness should call")                               \
-    << help_entry(                                                             \
-         "--" FUNCTION_HARNESS_GENERATOR_NONDET_GLOBALS_OPT,                   \
-         "set global variables to non-deterministic values in harness")        \
-    << COMMON_HARNESS_GENERATOR_HELP                                           \
-    << help_entry(                                                             \
-         "--" FUNCTION_HARNESS_GENERATOR_TREAT_POINTER_AS_ARRAY_OPT " p",      \
-         "treat the function parameter with the name `p' as an array")         \
-    << help_entry(                                                             \
-         "--" FUNCTION_HARNESS_GENERATOR_TREAT_POINTERS_EQUAL_OPT              \
-         " p,q,r[;s,t]",                                                       \
-         "treat the function parameters `q,r' equal to parameter `p'; `s` to " \
-         "`t` and so on")                                                      \
-    << help_entry(                                                             \
-         "--" FUNCTION_HARNESS_GENERATOR_TREAT_POINTERS_EQUAL_MAYBE_OPT,       \
-         "function parameters equality is non-deterministic")                  \
-    << help_entry(                                                             \
-         "--" FUNCTION_HARNESS_GENERATOR_ASSOCIATED_ARRAY_SIZE_OPT             \
-         " array_name:size_name",                                              \
-         "set the parameter <size_name> to the size of the array "             \
-         "<array_name> (implies "                                              \
-         "-- " FUNCTION_HARNESS_GENERATOR_TREAT_POINTER_AS_ARRAY_OPT           \
-         " <array_name>)")                                                     \
-    << help_entry(                                                             \
-         "--" FUNCTION_HARNESS_GENERATOR_TREAT_POINTER_AS_CSTRING " p",        \
-         "treat the function parameter with the name `p' as a string of "      \
-         "characters")
+  "function harness generator ({y--harness-type} {ycall-function}):\n"         \
+  " {y--" FUNCTION_HARNESS_GENERATOR_FUNCTION_OPT                              \
+  "} {ufunction_name} \t "                                                     \
+  "the function the harness should call\n"                                     \
+  " {y--" FUNCTION_HARNESS_GENERATOR_NONDET_GLOBALS_OPT                        \
+  "} \t "                                                                      \
+  "set global variables to non-deterministic values in "                       \
+  "harness\n" COMMON_HARNESS_GENERATOR_HELP                                    \
+  " {y--" FUNCTION_HARNESS_GENERATOR_TREAT_POINTER_AS_ARRAY_OPT                \
+  "} {up} \t "                                                                 \
+  "treat the function parameter with the name {up} as an array\n"              \
+  " {y--" FUNCTION_HARNESS_GENERATOR_TREAT_POINTERS_EQUAL_OPT                  \
+  "} "                                                                         \
+  "{up}{y,}{uq}{y,}{ur}[{y;}{us}{y,}{ut}] \t "                                 \
+  "treat the function parameters {uq}{y,}{ur} equal to parameter {up}; "       \
+  "{us} to {ut} and so on\n"                                                   \
+  " {y--" FUNCTION_HARNESS_GENERATOR_TREAT_POINTERS_EQUAL_MAYBE_OPT            \
+  "} \t "                                                                      \
+  "function parameters equality is non-deterministic\n"                        \
+  " {y--" FUNCTION_HARNESS_GENERATOR_ASSOCIATED_ARRAY_SIZE_OPT                 \
+  "} "                                                                         \
+  "{uarray_name}{y:}{usize_name} \t "                                          \
+  "set the parameter {usize_name} to the size of the array {uarray_name} "     \
+  "(implies "                                                                  \
+  "{y-- " FUNCTION_HARNESS_GENERATOR_TREAT_POINTER_AS_ARRAY_OPT                \
+  "} "                                                                         \
+  "{uarray_name})\n"                                                           \
+  " {y--" FUNCTION_HARNESS_GENERATOR_TREAT_POINTER_AS_CSTRING                  \
+  "} {up} \t "                                                                 \
+  "treat the function parameter with the name {up} as a string of "            \
+  "characters\n"
 
 #endif // CPROVER_GOTO_HARNESS_FUNCTION_HARNESS_GENERATOR_OPTIONS_H

--- a/src/goto-harness/function_harness_generator_options.h
+++ b/src/goto-harness/function_harness_generator_options.h
@@ -24,48 +24,51 @@ Author: Diffblue Ltd.
 #define FUNCTION_HARNESS_GENERATOR_TREAT_POINTERS_EQUAL_MAYBE_OPT              \
   "treat-pointers-equal-maybe"
 
-// clang-format off
 #define FUNCTION_HARNESS_GENERATOR_OPTIONS                                     \
-  "(" FUNCTION_HARNESS_GENERATOR_FUNCTION_OPT "):"                             \
-  "(" FUNCTION_HARNESS_GENERATOR_NONDET_GLOBALS_OPT ")"                        \
-  "(" FUNCTION_HARNESS_GENERATOR_TREAT_POINTER_AS_ARRAY_OPT "):"               \
-  "(" FUNCTION_HARNESS_GENERATOR_TREAT_POINTERS_EQUAL_OPT "):"                 \
-  "(" FUNCTION_HARNESS_GENERATOR_ASSOCIATED_ARRAY_SIZE_OPT "):"                \
-  "(" FUNCTION_HARNESS_GENERATOR_TREAT_POINTER_AS_CSTRING "):"                 \
-  "(" FUNCTION_HARNESS_GENERATOR_TREAT_POINTERS_EQUAL_MAYBE_OPT ")"            \
-// FUNCTION_HARNESS_GENERATOR_OPTIONS
+  "(" FUNCTION_HARNESS_GENERATOR_FUNCTION_OPT                                  \
+  "):"                                                                         \
+  "(" FUNCTION_HARNESS_GENERATOR_NONDET_GLOBALS_OPT                            \
+  ")"                                                                          \
+  "(" FUNCTION_HARNESS_GENERATOR_TREAT_POINTER_AS_ARRAY_OPT                    \
+  "):"                                                                         \
+  "(" FUNCTION_HARNESS_GENERATOR_TREAT_POINTERS_EQUAL_OPT                      \
+  "):"                                                                         \
+  "(" FUNCTION_HARNESS_GENERATOR_ASSOCIATED_ARRAY_SIZE_OPT                     \
+  "):"                                                                         \
+  "(" FUNCTION_HARNESS_GENERATOR_TREAT_POINTER_AS_CSTRING                      \
+  "):"                                                                         \
+  "(" FUNCTION_HARNESS_GENERATOR_TREAT_POINTERS_EQUAL_MAYBE_OPT ")"
 
-// clang-format on
-
-// clang-format off
 #define FUNCTION_HARNESS_GENERATOR_HELP                                        \
-  "function harness generator (--harness-type call-function)\n\n"              \
-  "--" FUNCTION_HARNESS_GENERATOR_FUNCTION_OPT                                 \
-  "                    the function the harness should call\n"                 \
-  "--" FUNCTION_HARNESS_GENERATOR_NONDET_GLOBALS_OPT                           \
-  "              set global variables to non-deterministic values\n"           \
-  "                              in harness\n"                                 \
-  COMMON_HARNESS_GENERATOR_HELP                                                \
-  "--" FUNCTION_HARNESS_GENERATOR_TREAT_POINTER_AS_ARRAY_OPT                   \
-  " p    treat the function parameter with the name `p' as\n"                  \
-  "                              an array\n"                                   \
-  "--" FUNCTION_HARNESS_GENERATOR_TREAT_POINTERS_EQUAL_OPT                     \
-  " p,q,r[;s,t]    treat the function parameters `q,r' equal\n"                \
-  "                              to parameter `p'; `s` to `t` and so on\n"     \
-  "--" FUNCTION_HARNESS_GENERATOR_TREAT_POINTERS_EQUAL_MAYBE_OPT               \
-  "                function parameters equality is non-deterministic\n"        \
-  "--" FUNCTION_HARNESS_GENERATOR_ASSOCIATED_ARRAY_SIZE_OPT                    \
-  " array_name:size_name\n"                                                    \
-  "                              set the parameter <size_name> to the size"    \
-  " of\n                              the array <array_name>\n"                \
-  "                              (implies "                                    \
-  "-- " FUNCTION_HARNESS_GENERATOR_TREAT_POINTER_AS_ARRAY_OPT                  \
-  " <array_name>)\n"                                                           \
-  "--" FUNCTION_HARNESS_GENERATOR_TREAT_POINTER_AS_CSTRING                     \
-  " p    treat the function parameter with the name `p' as\n"                  \
-  "                              a string of characters\n"                     \
-  // FUNCTION_HARNESS_GENERATOR_HELP
-
-// clang-format on
+  "function harness generator (--harness-type call-function):\n"               \
+    << help_entry(                                                             \
+         "--" FUNCTION_HARNESS_GENERATOR_FUNCTION_OPT " <function-name>",      \
+         "the function the harness should call")                               \
+    << help_entry(                                                             \
+         "--" FUNCTION_HARNESS_GENERATOR_NONDET_GLOBALS_OPT,                   \
+         "set global variables to non-deterministic values in harness")        \
+    << COMMON_HARNESS_GENERATOR_HELP                                           \
+    << help_entry(                                                             \
+         "--" FUNCTION_HARNESS_GENERATOR_TREAT_POINTER_AS_ARRAY_OPT " p",      \
+         "treat the function parameter with the name `p' as an array")         \
+    << help_entry(                                                             \
+         "--" FUNCTION_HARNESS_GENERATOR_TREAT_POINTERS_EQUAL_OPT              \
+         " p,q,r[;s,t]",                                                       \
+         "treat the function parameters `q,r' equal to parameter `p'; `s` to " \
+         "`t` and so on")                                                      \
+    << help_entry(                                                             \
+         "--" FUNCTION_HARNESS_GENERATOR_TREAT_POINTERS_EQUAL_MAYBE_OPT,       \
+         "function parameters equality is non-deterministic")                  \
+    << help_entry(                                                             \
+         "--" FUNCTION_HARNESS_GENERATOR_ASSOCIATED_ARRAY_SIZE_OPT             \
+         " array_name:size_name",                                              \
+         "set the parameter <size_name> to the size of the array "             \
+         "<array_name> (implies "                                              \
+         "-- " FUNCTION_HARNESS_GENERATOR_TREAT_POINTER_AS_ARRAY_OPT           \
+         " <array_name>)")                                                     \
+    << help_entry(                                                             \
+         "--" FUNCTION_HARNESS_GENERATOR_TREAT_POINTER_AS_CSTRING " p",        \
+         "treat the function parameter with the name `p' as a string of "      \
+         "characters")
 
 #endif // CPROVER_GOTO_HARNESS_FUNCTION_HARNESS_GENERATOR_OPTIONS_H

--- a/src/goto-harness/goto_harness_parse_options.cpp
+++ b/src/goto-harness/goto_harness_parse_options.cpp
@@ -11,6 +11,7 @@ Author: Diffblue Ltd.
 #include <util/config.h>
 #include <util/exception_utils.h>
 #include <util/exit_codes.h>
+#include <util/help_formatter.h>
 #include <util/invariant.h>
 #include <util/make_unique.h>
 #include <util/suffix.h>
@@ -172,35 +173,35 @@ int goto_harness_parse_optionst::doit()
 
 void goto_harness_parse_optionst::help()
 {
-  std::cout
-    << '\n'
-    << banner_string("Goto-Harness", CBMC_VERSION) << '\n'
-    << align_center_with_border("Copyright (C) 2019") << '\n'
-    << align_center_with_border("Diffblue Ltd.") << '\n'
-    << align_center_with_border("info@diffblue.com") << '\n'
-    << '\n'
-    << "Usage:                       Purpose:\n"
-    << '\n'
-    << " goto-harness [-?] [-h] [--help]  show help\n"
-    << " goto-harness --version           show version\n"
-    << " goto-harness <in> <out> --harness-function-name <name> --harness-type "
-       "<harness-type> [harness options]\n"
-    << "\n"
-    << "<in>                       goto binary to read from\n"
-    << "<out>                      file to write the harness to\n"
-    << "                           the harness is printed as C code, if <out> "
-       "has a .c suffix,\n"
-       "                           else a goto binary including the harness is "
-       "generated\n"
-    << help_entry(
-         "--harness-function-name <name>",
-         "the name of the harness function to "
-         "generate")
-    << help_entry(
-         "--harness-type <type>", "one of the harness types listed below")
-    << '\n'
-    << FUNCTION_HARNESS_GENERATOR_HELP << '\n'
-    << MEMORY_SNAPSHOT_HARNESS_GENERATOR_HELP << '\n';
+  std::cout << '\n'
+            << banner_string("Goto-Harness", CBMC_VERSION) << '\n'
+            << align_center_with_border("Copyright (C) 2019") << '\n'
+            << align_center_with_border("Diffblue Ltd.") << '\n'
+            << align_center_with_border("info@diffblue.com") << '\n';
+
+  // clang-format off
+  std::cout << help_formatter(
+    "\n"
+    "Usage:                     \tPurpose:\n"
+    "\n"
+    " {bgoto-harness} [{y-?}] [{y-h}] [{y--help}] \t show this help\n"
+    " {bgoto-harness} {y--version} \t show version and exit\n"
+    " {bgoto-harness} {uin} {uout} {y--harness-function-name} {uname}"
+    " {y--harness-type} {uharness-type} [harness options]\n"
+    "\n"
+    "  {uin} \t goto binary to read from\n"
+    "  {uout} \t file to write the harness to; the harness is printed as C"
+    " code, if {uout} has a .c suffix, else a goto binary including the harness"
+    " is generated\n"
+    " {y--harness-function-name} {uname} \t the name of the harness function to"
+    " generate\n"
+    " {y--harness-type} {utype} \t one of the harness types listed below\n"
+    "\n"
+    FUNCTION_HARNESS_GENERATOR_HELP
+    "\n"
+    MEMORY_SNAPSHOT_HARNESS_GENERATOR_HELP
+    "\n");
+  // clang-format on
 }
 
 goto_harness_parse_optionst::goto_harness_parse_optionst(

--- a/src/goto-harness/goto_harness_parse_options.cpp
+++ b/src/goto-harness/goto_harness_parse_options.cpp
@@ -192,11 +192,14 @@ void goto_harness_parse_optionst::help()
        "has a .c suffix,\n"
        "                           else a goto binary including the harness is "
        "generated\n"
-    << "--harness-function-name    the name of the harness function to "
-       "generate\n"
-    << "--harness-type             one of the harness types listed below\n"
-    << "\n\n"
-    << FUNCTION_HARNESS_GENERATOR_HELP << "\n\n"
+    << help_entry(
+         "--harness-function-name <name>",
+         "the name of the harness function to "
+         "generate")
+    << help_entry(
+         "--harness-type <type>", "one of the harness types listed below")
+    << '\n'
+    << FUNCTION_HARNESS_GENERATOR_HELP << '\n'
     << MEMORY_SNAPSHOT_HARNESS_GENERATOR_HELP << '\n';
 }
 

--- a/src/goto-harness/memory_snapshot_harness_generator_options.h
+++ b/src/goto-harness/memory_snapshot_harness_generator_options.h
@@ -18,46 +18,44 @@ Author: Diffblue Ltd.
 #define MEMORY_SNAPSHOT_HARNESS_TREAT_POINTER_AS_ARRAY_OPT "pointer-as-array"
 #define MEMORY_SNAPSHOT_HARNESS_ASSOCIATED_ARRAY_SIZE_OPT "size-of-array"
 
-// clang-format off
 #define MEMORY_SNAPSHOT_HARNESS_GENERATOR_OPTIONS                              \
-  "(" MEMORY_SNAPSHOT_HARNESS_SNAPSHOT_OPT "):"                                \
-  "(" MEMORY_SNAPSHOT_HARNESS_INITIAL_GOTO_LOC_OPT "):"                        \
-  "(" MEMORY_SNAPSHOT_HARNESS_INITIAL_SOURCE_LOC_OPT "):"                      \
-  "(" MEMORY_SNAPSHOT_HARNESS_HAVOC_VARIABLES_OPT "):"                         \
-  "(" MEMORY_SNAPSHOT_HARNESS_TREAT_POINTER_AS_ARRAY_OPT "):"                  \
-  "(" MEMORY_SNAPSHOT_HARNESS_ASSOCIATED_ARRAY_SIZE_OPT "):"                   \
-// MEMORY_SNAPSHOT_HARNESS_GENERATOR_OPTIONS
+  "(" MEMORY_SNAPSHOT_HARNESS_SNAPSHOT_OPT                                     \
+  "):"                                                                         \
+  "(" MEMORY_SNAPSHOT_HARNESS_INITIAL_GOTO_LOC_OPT                             \
+  "):"                                                                         \
+  "(" MEMORY_SNAPSHOT_HARNESS_INITIAL_SOURCE_LOC_OPT                           \
+  "):"                                                                         \
+  "(" MEMORY_SNAPSHOT_HARNESS_HAVOC_VARIABLES_OPT                              \
+  "):"                                                                         \
+  "(" MEMORY_SNAPSHOT_HARNESS_TREAT_POINTER_AS_ARRAY_OPT                       \
+  "):"                                                                         \
+  "(" MEMORY_SNAPSHOT_HARNESS_ASSOCIATED_ARRAY_SIZE_OPT "):"
 
-// clang-format on
-
-// clang-format off
 #define MEMORY_SNAPSHOT_HARNESS_GENERATOR_HELP                                 \
   "memory snapshot harness generator (--harness-type\n"                        \
-  "  initialize-with-memory-snapshot)\n\n"                                     \
-  "--" MEMORY_SNAPSHOT_HARNESS_SNAPSHOT_OPT " <file>      initialise memory "  \
-  "from JSON memory snapshot\n"                                                \
-  "--" MEMORY_SNAPSHOT_HARNESS_INITIAL_GOTO_LOC_OPT " <func[:<n>]>\n"          \
-  "                              use given function and location number as "   \
-  "entry\n                              point\n"                               \
-  "--" MEMORY_SNAPSHOT_HARNESS_INITIAL_SOURCE_LOC_OPT " <file:<n>>\n"          \
-  "                              use given file name and line number as "      \
-  "entry\n                              point\n"                               \
-  "--" MEMORY_SNAPSHOT_HARNESS_HAVOC_VARIABLES_OPT " vars        initialise"   \
-  " variables from `vars' to\n"                                                \
-  "                              non-deterministic values\n"                   \
-  COMMON_HARNESS_GENERATOR_HELP                                                \
-  "--" MEMORY_SNAPSHOT_HARNESS_TREAT_POINTER_AS_ARRAY_OPT                      \
-  " p    treat the global pointer with the name `p' as\n"                      \
-  "                              an array\n"                                   \
-  "--" MEMORY_SNAPSHOT_HARNESS_ASSOCIATED_ARRAY_SIZE_OPT                       \
-  " array_name:size_name\n"                                                    \
-  "                              set the parameter <size_name> to the size"    \
-  " of\n                              the array <array_name>\n"                \
-  "                              (implies "                                    \
-  "-- " MEMORY_SNAPSHOT_HARNESS_TREAT_POINTER_AS_ARRAY_OPT                     \
-  " <array_name>)\n"                                                           \
-// MEMORY_SNAPSHOT_HARNESS_GENERATOR_HELP
-
-// clang-format on
+  "  initialize-with-memory-snapshot):\n"                                      \
+    << help_entry(                                                             \
+         "--" MEMORY_SNAPSHOT_HARNESS_SNAPSHOT_OPT " <file>",                  \
+         "initialize memory from JSON memory snapshot")                        \
+    << help_entry(                                                             \
+         "--" MEMORY_SNAPSHOT_HARNESS_INITIAL_GOTO_LOC_OPT " <func[:<n>]>",    \
+         "use given function and location number as entry point")              \
+    << help_entry(                                                             \
+         "--" MEMORY_SNAPSHOT_HARNESS_INITIAL_SOURCE_LOC_OPT " <file:<n>>",    \
+         "use given file name and line number as entry point")                 \
+    << help_entry(                                                             \
+         "--" MEMORY_SNAPSHOT_HARNESS_HAVOC_VARIABLES_OPT " vars",             \
+         "initialize variables from `vars' to non-deterministic values")       \
+    << COMMON_HARNESS_GENERATOR_HELP                                           \
+    << help_entry(                                                             \
+         "--" MEMORY_SNAPSHOT_HARNESS_TREAT_POINTER_AS_ARRAY_OPT " p",         \
+         "treat the global pointer with the name `p' as an array")             \
+    << help_entry(                                                             \
+         "--" MEMORY_SNAPSHOT_HARNESS_ASSOCIATED_ARRAY_SIZE_OPT                \
+         " array_name:size_name",                                              \
+         "set the parameter <size_name> to the size of the array "             \
+         "<array_name> (implies "                                              \
+         "-- " MEMORY_SNAPSHOT_HARNESS_TREAT_POINTER_AS_ARRAY_OPT              \
+         " <array_name>)")
 
 #endif // CPROVER_GOTO_HARNESS_MEMORY_SNAPSHOT_HARNESS_GENERATOR_OPTIONS_H

--- a/src/goto-harness/memory_snapshot_harness_generator_options.h
+++ b/src/goto-harness/memory_snapshot_harness_generator_options.h
@@ -32,30 +32,33 @@ Author: Diffblue Ltd.
   "(" MEMORY_SNAPSHOT_HARNESS_ASSOCIATED_ARRAY_SIZE_OPT "):"
 
 #define MEMORY_SNAPSHOT_HARNESS_GENERATOR_HELP                                 \
-  "memory snapshot harness generator (--harness-type\n"                        \
-  "  initialize-with-memory-snapshot):\n"                                      \
-    << help_entry(                                                             \
-         "--" MEMORY_SNAPSHOT_HARNESS_SNAPSHOT_OPT " <file>",                  \
-         "initialize memory from JSON memory snapshot")                        \
-    << help_entry(                                                             \
-         "--" MEMORY_SNAPSHOT_HARNESS_INITIAL_GOTO_LOC_OPT " <func[:<n>]>",    \
-         "use given function and location number as entry point")              \
-    << help_entry(                                                             \
-         "--" MEMORY_SNAPSHOT_HARNESS_INITIAL_SOURCE_LOC_OPT " <file:<n>>",    \
-         "use given file name and line number as entry point")                 \
-    << help_entry(                                                             \
-         "--" MEMORY_SNAPSHOT_HARNESS_HAVOC_VARIABLES_OPT " vars",             \
-         "initialize variables from `vars' to non-deterministic values")       \
-    << COMMON_HARNESS_GENERATOR_HELP                                           \
-    << help_entry(                                                             \
-         "--" MEMORY_SNAPSHOT_HARNESS_TREAT_POINTER_AS_ARRAY_OPT " p",         \
-         "treat the global pointer with the name `p' as an array")             \
-    << help_entry(                                                             \
-         "--" MEMORY_SNAPSHOT_HARNESS_ASSOCIATED_ARRAY_SIZE_OPT                \
-         " array_name:size_name",                                              \
-         "set the parameter <size_name> to the size of the array "             \
-         "<array_name> (implies "                                              \
-         "-- " MEMORY_SNAPSHOT_HARNESS_TREAT_POINTER_AS_ARRAY_OPT              \
-         " <array_name>)")
+  "memory snapshot harness generator ({y--harness-type}\n"                     \
+  "  {yinitialize-with-memory-snapshot}):\n"                                   \
+  " {y--" MEMORY_SNAPSHOT_HARNESS_SNAPSHOT_OPT                                 \
+  "} {ufile} \t "                                                              \
+  "initialize memory from JSON memory snapshot\n"                              \
+  " {y--" MEMORY_SNAPSHOT_HARNESS_INITIAL_GOTO_LOC_OPT                         \
+  "} {ufunc}[{y:}{un}] "                                                       \
+  "\t "                                                                        \
+  "use given function and location number as entry point\n"                    \
+  " {y--" MEMORY_SNAPSHOT_HARNESS_INITIAL_SOURCE_LOC_OPT                       \
+  "} {ufile}{y:}{un} "                                                         \
+  "\t "                                                                        \
+  "use given file name and line number as entry point\n"                       \
+  " {y--" MEMORY_SNAPSHOT_HARNESS_HAVOC_VARIABLES_OPT                          \
+  "} {uvars} \t "                                                              \
+  "initialize variables from {uvars} to non-deterministic "                    \
+  "values\n" COMMON_HARNESS_GENERATOR_HELP                                     \
+  " {y--" MEMORY_SNAPSHOT_HARNESS_TREAT_POINTER_AS_ARRAY_OPT                   \
+  "} {up} \t "                                                                 \
+  "treat the global pointer with the name {up} as an array\n"                  \
+  " {y--" MEMORY_SNAPSHOT_HARNESS_ASSOCIATED_ARRAY_SIZE_OPT                    \
+  "} "                                                                         \
+  "{uarray_name}{y:}{usize_name} \t "                                          \
+  "set the parameter {usize_name} to the size of the array {uarray_name} "     \
+  "(implies "                                                                  \
+  "{y-- " MEMORY_SNAPSHOT_HARNESS_TREAT_POINTER_AS_ARRAY_OPT                   \
+  "} "                                                                         \
+  "{uarray_name})\n"
 
 #endif // CPROVER_GOTO_HARNESS_MEMORY_SNAPSHOT_HARNESS_GENERATOR_OPTIONS_H

--- a/src/goto-inspect/goto_inspect_parse_options.cpp
+++ b/src/goto-inspect/goto_inspect_parse_options.cpp
@@ -5,6 +5,7 @@
 #include <util/config.h>
 #include <util/exception_utils.h>
 #include <util/exit_codes.h>
+#include <util/help_formatter.h>
 #include <util/version.h>
 
 #include <goto-programs/goto_model.h>
@@ -76,16 +77,17 @@ void goto_inspect_parse_optionst::help()
             << banner_string("Goto-Inspect", CBMC_VERSION) << '\n'
             << align_center_with_border("Copyright (C) 2023") << '\n'
             << align_center_with_border("Diffblue Ltd.") << '\n'
-            << align_center_with_border("info@diffblue.com") << '\n'
-            << '\n'
-            << "Usage:                       Purpose:\n"
-            << '\n'
-            << " goto-inspect [-?] [-h] [--help]     show help\n"
-            << " goto-inspect --version              show version\n"
-            << " goto-inspect --show-goto-functions  show code for "
-               "goto-functions present in goto-binary\n"
-            << "\n"
-            << "<in>                       goto binary to read from\n";
+            << align_center_with_border("info@diffblue.com") << '\n';
+
+  std::cout << help_formatter(
+    "\n"
+    "Usage:                     \tPurpose:\n"
+    "\n"
+    " {bgoto-inspect} [{y-?}] [{y-h}] [{y--help}] \t show this help\n"
+    " {bgoto-inspect} {y--version} \t show version and exit\n"
+    " {bgoto-inspect} {y--show-goto-functions} {ufile_name} \t show code for"
+    " goto-functions present in goto-binary {ufile_name}\n"
+    "\n");
 }
 
 goto_inspect_parse_optionst::goto_inspect_parse_optionst(

--- a/src/goto-instrument/contracts/contracts.h
+++ b/src/goto-instrument/contracts/contracts.h
@@ -31,30 +31,26 @@ Date: February 2016
 
 #define FLAG_LOOP_CONTRACTS "apply-loop-contracts"
 #define HELP_LOOP_CONTRACTS                                                    \
-  help_entry(                                                                  \
-    "--apply-loop-contracts", "check and use loop contracts when provided")
+  " {y--apply-loop-contracts} \t check and use loop contracts when provided\n"
 
 #define FLAG_LOOP_CONTRACTS_NO_UNWIND "loop-contracts-no-unwind"
 #define HELP_LOOP_CONTRACTS_NO_UNWIND                                          \
-  help_entry("--loop-contracts-no-unwind", "do not unwind transformed loops")
+  " {y--loop-contracts-no-unwind} \t do not unwind transformed loops\n"
 
 #define FLAG_LOOP_CONTRACTS_FILE "loop-contracts-file"
 #define HELP_LOOP_CONTRACTS_FILE                                               \
-  help_entry(                                                                  \
-    "loop-contracts-file <file>",                                              \
-    "parse and annotate loop contracts from files")
+  " {y--loop-contracts-file} {ufile} \t "                                      \
+  "parse and annotate loop contracts from files\n"
 
 #define FLAG_REPLACE_CALL "replace-call-with-contract"
 #define HELP_REPLACE_CALL                                                      \
-  help_entry(                                                                  \
-    "--replace-call-with-contract <function>[/contract]",                      \
-    "replace calls to function with contract")
+  " {y--replace-call-with-contract} {ufunction}[/{ucontract}] \t "             \
+  "replace calls to {ufunction} with {ucontract}\n"
 
 #define FLAG_ENFORCE_CONTRACT "enforce-contract"
 #define HELP_ENFORCE_CONTRACT                                                  \
-  help_entry(                                                                  \
-    "--enforce-contract <function>[/contract]",                                \
-    "wrap function with an assertion of contract")
+  " {y--enforce-contract} {ufunction}[/{ucontract}] \t "                       \
+  "wrap function with an assertion of contract\n"
 
 class local_may_aliast;
 

--- a/src/goto-instrument/contracts/contracts.h
+++ b/src/goto-instrument/contracts/contracts.h
@@ -29,32 +29,32 @@ Date: February 2016
 #include <string>
 #include <unordered_set>
 
-// clang-format off
 #define FLAG_LOOP_CONTRACTS "apply-loop-contracts"
 #define HELP_LOOP_CONTRACTS                                                    \
-  " --apply-loop-contracts\n"                                                  \
-  "                              check and use loop contracts when provided\n"
+  help_entry(                                                                  \
+    "--apply-loop-contracts", "check and use loop contracts when provided")
 
 #define FLAG_LOOP_CONTRACTS_NO_UNWIND "loop-contracts-no-unwind"
 #define HELP_LOOP_CONTRACTS_NO_UNWIND                                          \
-  " --loop-contracts-no-unwind\n"                                              \
-  "                              do not unwind transformed loops\n"
+  help_entry("--loop-contracts-no-unwind", "do not unwind transformed loops")
 
 #define FLAG_LOOP_CONTRACTS_FILE "loop-contracts-file"
 #define HELP_LOOP_CONTRACTS_FILE                                               \
-  " --loop-contracts-file <file>\n"                                            \
-  "                              parse and annotate loop contracts from files\n"
+  help_entry(                                                                  \
+    "loop-contracts-file <file>",                                              \
+    "parse and annotate loop contracts from files")
 
 #define FLAG_REPLACE_CALL "replace-call-with-contract"
 #define HELP_REPLACE_CALL                                                      \
-  " --replace-call-with-contract <function>[/contract]\n"                      \
-  "                              replace calls to function with contract\n"
+  help_entry(                                                                  \
+    "--replace-call-with-contract <function>[/contract]",                      \
+    "replace calls to function with contract")
 
 #define FLAG_ENFORCE_CONTRACT "enforce-contract"
 #define HELP_ENFORCE_CONTRACT                                                  \
-  " --enforce-contract <function>[/contract]"                                  \
-  "                              wrap function with an assertion of contract\n"
-// clang-format on
+  help_entry(                                                                  \
+    "--enforce-contract <function>[/contract]",                                \
+    "wrap function with an assertion of contract")
 
 class local_may_aliast;
 

--- a/src/goto-instrument/count_eloc.h
+++ b/src/goto-instrument/count_eloc.h
@@ -28,12 +28,14 @@ void print_global_state_size(const goto_modelt &);
   "(print-path-lengths)"
 
 #define HELP_GOTO_PROGRAM_STATS                                                \
-  " --count-eloc                 count effective lines of code\n"              \
-  " --list-eloc                  list full path names of lines "               \
-  "containing code\n"                                                          \
-  " --print-global-state-size    count the total number of bits of global "    \
-  "objects\n"                                                                  \
-  " --print-path-lengths         print statistics about control-flow graph "   \
-  "paths\n"
+  help_entry("--count-eloc", "count effective lines of code")                  \
+    << help_entry(                                                             \
+         "--list-eloc", "list full path names of lines containing code")       \
+    << help_entry(                                                             \
+         "--print-global-state-size",                                          \
+         "count the total number of bits of global objects")                   \
+    << help_entry(                                                             \
+         "--print-path-lengths",                                               \
+         "print statistics about control-flow graph paths")
 
 #endif // CPROVER_GOTO_INSTRUMENT_COUNT_ELOC_H

--- a/src/goto-instrument/count_eloc.h
+++ b/src/goto-instrument/count_eloc.h
@@ -28,14 +28,11 @@ void print_global_state_size(const goto_modelt &);
   "(print-path-lengths)"
 
 #define HELP_GOTO_PROGRAM_STATS                                                \
-  help_entry("--count-eloc", "count effective lines of code")                  \
-    << help_entry(                                                             \
-         "--list-eloc", "list full path names of lines containing code")       \
-    << help_entry(                                                             \
-         "--print-global-state-size",                                          \
-         "count the total number of bits of global objects")                   \
-    << help_entry(                                                             \
-         "--print-path-lengths",                                               \
-         "print statistics about control-flow graph paths")
+  " {y--count-eloc} \t count effective lines of code\n"                        \
+  " {y--list-eloc} \t list full path names of lines containing code\n"         \
+  " {y--print-global-state-size} \t "                                          \
+  "count the total number of bits of global objects\n"                         \
+  " {y--print-path-lengths} \t "                                               \
+  "print statistics about control-flow graph paths\n"
 
 #endif // CPROVER_GOTO_INSTRUMENT_COUNT_ELOC_H

--- a/src/goto-instrument/cover.h
+++ b/src/goto-instrument/cover.h
@@ -31,18 +31,16 @@ class symbol_tablet;
   "(show-test-suite)"
 
 #define HELP_COVER                                                             \
-  help_entry(                                                                  \
-    "--cover CC",                                                              \
-    "create test-suite with coverage criterion CC, where CC is one of "        \
-    "assertion[s], assume[s], branch[es], condition[s], cover, decision[s], "  \
-    "location[s], or mcdc")                                                    \
-    << help_entry(                                                             \
-         "--cover-failed-assertions",                                          \
-         "do not stop coverage checking at failed assertions (this is the "    \
-         "default for --cover assertions)")                                    \
-    << help_entry(                                                             \
-         "--show-test-suite",                                                  \
-         "print test suite for coverage criterion (requires --cover)")
+  " {y--cover} {uCC} \t "                                                      \
+  "create test-suite with coverage criterion {uCC}, where {uCC} is one of "    \
+  "{yassertion}[{ys}], {yassume}[{ys}], {ybranch}[{yes}], "                    \
+  "{ycondition}[{ys}], {ycover}, {decision}[{ys}], {ylocation}[{ys}], "        \
+  "or {ymcdc}\n"                                                               \
+  " {y--cover-failed-assertions} \t "                                          \
+  "do not stop coverage checking at failed assertions (this is the default "   \
+  "for {y--cover} {yassertions})\n"                                            \
+  " {y--show-test-suite} \t "                                                  \
+  "print test suite for coverage criterion (requires {y--cover})\n"
 
 enum class coverage_criteriont
 {

--- a/src/goto-instrument/cover.h
+++ b/src/goto-instrument/cover.h
@@ -31,19 +31,18 @@ class symbol_tablet;
   "(show-test-suite)"
 
 #define HELP_COVER                                                             \
-  " --cover CC                   create test-suite with coverage criterion "   \
-  "CC,\n"                                                                      \
-  "                              where CC is one of assertion[s], "            \
-  "assume[s],\n"                                                               \
-  "                              branch[es], condition[s], cover, "            \
-  "decision[s],\n"                                                             \
-  "                              location[s], or mcdc\n"                       \
-  " --cover-failed-assertions    do not stop coverage checking at failed "     \
-  "assertions\n"                                                               \
-  "                              (this is the default for --cover "            \
-  "assertions)\n"                                                              \
-  " --show-test-suite            print test suite for coverage criterion "     \
-  "(requires --cover)\n"
+  help_entry(                                                                  \
+    "--cover CC",                                                              \
+    "create test-suite with coverage criterion CC, where CC is one of "        \
+    "assertion[s], assume[s], branch[es], condition[s], cover, decision[s], "  \
+    "location[s], or mcdc")                                                    \
+    << help_entry(                                                             \
+         "--cover-failed-assertions",                                          \
+         "do not stop coverage checking at failed assertions (this is the "    \
+         "default for --cover assertions)")                                    \
+    << help_entry(                                                             \
+         "--show-test-suite",                                                  \
+         "print test suite for coverage criterion (requires --cover)")
 
 enum class coverage_criteriont
 {

--- a/src/goto-instrument/document_properties.h
+++ b/src/goto-instrument/document_properties.h
@@ -29,10 +29,7 @@ void document_properties_html(
   "(document-properties-latex)(document-properties-html)"
 
 #define HELP_DOCUMENT_PROPERTIES                                               \
-  help_entry(                                                                  \
-    "--document-properties-html", "generate HTML property documentation")      \
-    << help_entry(                                                             \
-         "--document-properties-latex",                                        \
-         "generate Latex property documentation")
+  " {y--document-properties-html} \t generate HTML property documentation\n"   \
+  " {y--document-properties-latex} \t generate LaTeX property documentation\n"
 
 #endif // CPROVER_GOTO_INSTRUMENT_DOCUMENT_PROPERTIES_H

--- a/src/goto-instrument/document_properties.h
+++ b/src/goto-instrument/document_properties.h
@@ -28,11 +28,11 @@ void document_properties_html(
   "(document-claims-latex)(document-claims-html)"                              \
   "(document-properties-latex)(document-properties-html)"
 
-// clang-format off
 #define HELP_DOCUMENT_PROPERTIES                                               \
-  " --document-properties-html   generate HTML property documentation\n"       \
-  " --document-properties-latex  generate Latex property documentation\n"
-
-// clang-format on
+  help_entry(                                                                  \
+    "--document-properties-html", "generate HTML property documentation")      \
+    << help_entry(                                                             \
+         "--document-properties-latex",                                        \
+         "generate Latex property documentation")
 
 #endif // CPROVER_GOTO_INSTRUMENT_DOCUMENT_PROPERTIES_H

--- a/src/goto-instrument/dump_c.h
+++ b/src/goto-instrument/dump_c.h
@@ -49,13 +49,12 @@ void dump_cpp(
   "(no-system-headers)(use-all-headers)(harness)"
 
 #define HELP_DUMP_C                                                            \
-  help_entry("--dump-c", "generate C source")                                  \
-    << help_entry(                                                             \
-         "--dump-c-type-header m", "generate a C header for types local in m") \
-    << help_entry("--dump-cpp", "generate C++ source")                         \
-    << help_entry(                                                             \
-         "--no-system-headers", "generate C source expanding libc includes")   \
-    << help_entry("--use-all-headers", "generate C source with all includes")  \
-    << help_entry("--harness", "include input generator in output")
+  " {y--dump-c} \t generate C source\n"                                        \
+  " {y--dump-c-type-header} {um} \t "                                          \
+  "generate a C header for types local in {um}\n"                              \
+  " {y--dump-cpp} \t generate C++ source\n"                                    \
+  " {y--no-system-headers} \t generate C source expanding libc includes\n"     \
+  " {y--use-all-headers} \t generate C source with all includes\n"             \
+  " {y--harness} \t include input generator in output\n"
 
 #endif // CPROVER_GOTO_INSTRUMENT_DUMP_C_H

--- a/src/goto-instrument/dump_c.h
+++ b/src/goto-instrument/dump_c.h
@@ -48,15 +48,14 @@ void dump_cpp(
   "(dump-c-type-header):"                                                      \
   "(no-system-headers)(use-all-headers)(harness)"
 
-// clang-format off
 #define HELP_DUMP_C                                                            \
-    " --dump-c                     generate C source\n"                        \
-    " --dump-c-type-header m       generate a C header for types local in m\n" \
-    " --dump-cpp                   generate C++ source\n"                      \
-    " --no-system-headers          generate C source expanding libc includes\n"\
-    " --use-all-headers            generate C source with all includes\n"      \
-    " --harness                    include input generator in output\n"
-
-// clang-format on
+  help_entry("--dump-c", "generate C source")                                  \
+    << help_entry(                                                             \
+         "--dump-c-type-header m", "generate a C header for types local in m") \
+    << help_entry("--dump-cpp", "generate C++ source")                         \
+    << help_entry(                                                             \
+         "--no-system-headers", "generate C source expanding libc includes")   \
+    << help_entry("--use-all-headers", "generate C source with all includes")  \
+    << help_entry("--harness", "include input generator in output")
 
 #endif // CPROVER_GOTO_INSTRUMENT_DUMP_C_H

--- a/src/goto-instrument/generate_function_bodies.h
+++ b/src/goto-instrument/generate_function_bodies.h
@@ -84,29 +84,27 @@ void generate_function_bodies(
   goto_modelt &model,
   message_handlert &message_handler);
 
-// clang-format off
 #define OPT_REPLACE_FUNCTION_BODY \
   "(generate-function-body):" \
   "(generate-havocing-body):" \
   "(generate-function-body-options):"
 
-#define HELP_REPLACE_FUNCTION_BODY \
-  " --generate-function-body <regex>\n" \
-  /* NOLINTNEXTLINE(whitespace/line_length) */ \
-  "                              Generate bodies for functions matching regex\n" \
-  " --generate-havocing-body <option>\n" \
-  /* NOLINTNEXTLINE(whitespace/line_length) */ \
-  "                              <fun_name>,params:<p_n1;p_n2;..>\n" \
-  "                              or\n" \
-  /* NOLINTNEXTLINE(whitespace/line_length) */ \
-  "                              <fun_name>[,<call-site-id>,params:<p_n1;p_n2;..>]+\n" \
-  " --generate-function-body-options <option>\n" \
-  "                              One of assert-false, assume-false,\n" \
-  /* NOLINTNEXTLINE(whitespace/line_length) */ \
-  "                              nondet-return, assert-false-assume-false and\n" \
-  "                              havoc[,params:<regex>][,globals:<regex>]\n" \
-  "                                   [,params:<p_n1;p_n2;..>]\n" \
-  "                              (default: nondet-return)\n"
-// clang-format on
+#define HELP_REPLACE_FUNCTION_BODY                                             \
+  help_entry(                                                                  \
+    "--generate-function-body <regex>",                                        \
+    "generate bodies for functions matching regex")                            \
+    << help_entry(                                                             \
+         "--generate-havocing-body <option> <fun_name>,params:<p1;p2;..>",     \
+         "generate havocing body")                                             \
+    << help_entry(                                                             \
+         "--generate-havocing-body <option> "                                  \
+         "<fun_name>[,<call-site-id>,params:<p1;p2;..>]+",                     \
+         "generate havocing body")                                             \
+    << help_entry(                                                             \
+         "--generate-function-body-options <option>",                          \
+         "One of assert-false, assume-false, nondet-return, "                  \
+         "assert-false-assume-false and "                                      \
+         "havoc[,params:<regex>][,globals:<regex>][,params:<p1;p2;..>] "       \
+         "(default: nondet-return)")
 
 #endif // CPROVER_GOTO_PROGRAMS_GENERATE_FUNCTION_BODIES_H

--- a/src/goto-instrument/generate_function_bodies.h
+++ b/src/goto-instrument/generate_function_bodies.h
@@ -90,21 +90,18 @@ void generate_function_bodies(
   "(generate-function-body-options):"
 
 #define HELP_REPLACE_FUNCTION_BODY                                             \
-  help_entry(                                                                  \
-    "--generate-function-body <regex>",                                        \
-    "generate bodies for functions matching regex")                            \
-    << help_entry(                                                             \
-         "--generate-havocing-body <option> <fun_name>,params:<p1;p2;..>",     \
-         "generate havocing body")                                             \
-    << help_entry(                                                             \
-         "--generate-havocing-body <option> "                                  \
-         "<fun_name>[,<call-site-id>,params:<p1;p2;..>]+",                     \
-         "generate havocing body")                                             \
-    << help_entry(                                                             \
-         "--generate-function-body-options <option>",                          \
-         "One of assert-false, assume-false, nondet-return, "                  \
-         "assert-false-assume-false and "                                      \
-         "havoc[,params:<regex>][,globals:<regex>][,params:<p1;p2;..>] "       \
-         "(default: nondet-return)")
+  " {y--generate-function-body} {uregex} \t "                                  \
+  "generate bodies for functions matching {uregex}\n"                          \
+  " {y--generate-havocing-body} <option> "                                     \
+  "{ufun_name},{yparams}:{up1};{up2};.. \t "                                   \
+  "generate havocing body\n"                                                   \
+  " {y--generate-havocing-body} <option> "                                     \
+  "{ufun_name}[,{ucall-site-id},{yparams}:{up1};{up2};..]+ \t "                \
+  "generate havocing body\n"                                                   \
+  " {y--generate-function-body-options} {uoption} \t "                         \
+  "One of {yassert-false}, {yassume-false}, {ynondet-return}, "                \
+  "{yassert-false-assume-false} and "                                          \
+  "{yhavoc}[,{yparams}:{uregex}][,{yglobals}:{uregex}]"                        \
+  "[,{yparams}:{up1};{up2};..] (default: {ynondet-return})\n"
 
 #endif // CPROVER_GOTO_PROGRAMS_GENERATE_FUNCTION_BODIES_H

--- a/src/goto-instrument/goto_instrument_parse_options.cpp
+++ b/src/goto-instrument/goto_instrument_parse_options.cpp
@@ -13,6 +13,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <util/exception_utils.h>
 #include <util/exit_codes.h>
+#include <util/help_formatter.h>
 #include <util/json.h>
 #include <util/options.h>
 #include <util/string2int.h>
@@ -1856,256 +1857,198 @@ void goto_instrument_parse_optionst::instrument_goto_program()
 /// display command line help
 void goto_instrument_parse_optionst::help()
 {
-  // clang-format off
-  std::cout << '\n' << banner_string("Goto-Instrument", CBMC_VERSION) << '\n'
+  std::cout << '\n'
+            << banner_string("Goto-Instrument", CBMC_VERSION) << '\n'
             << align_center_with_border("Copyright (C) 2008-2013") << '\n'
             << align_center_with_border("Daniel Kroening") << '\n'
-            << align_center_with_border("kroening@kroening.com") << '\n'
-            <<
+            << align_center_with_border("kroening@kroening.com") << '\n';
+
+  // clang-format off
+  std::cout << help_formatter(
     "\n"
-    "Usage:                       Purpose:\n"
+    "Usage:                     \tPurpose:\n"
     "\n"
-    " goto-instrument [-?] [-h] [--help]  show help\n"
-    " goto-instrument --version           show version and exit\n"
-    " goto-instrument [options] in [out]  perform analysis or instrumentation\n"
+    " {bgoto-instrument} [{y-?}] [{y-h}] [{y--help}] \t show this help\n"
+    " {bgoto-instrument} {y--version} \t show version and exit\n"
+    " {bgoto-instrument} [options] {uin} [{uout}] \t perform analysis or"
+    " instrumentation\n"
     "\n"
     "Dump Source:\n"
-    << HELP_DUMP_C
-    << help_entry("--horn", "print program as constrained horn clauses")
-    << "\n"
+    HELP_DUMP_C
+    " {y--horn} \t print program as constrained horn clauses\n"
+    "\n"
     "Diagnosis:\n"
-    << HELP_SHOW_PROPERTIES
-    << HELP_DOCUMENT_PROPERTIES
-    << help_entry("--show-symbol-table", "show loaded symbol table")
-    << help_entry("--list-symbols", "list symbols with type information")
-    << HELP_SHOW_GOTO_FUNCTIONS
-    << HELP_GOTO_PROGRAM_STATS
-    << help_entry("--show-locations", "show all source locations")
-    << help_entry("--dot", "generate CFG graph in DOT format")
-    << help_entry(
-      "--print-internal-representation",
-      "show verbose internal representation of the program")
-    << help_entry("--list-undefined-functions", "list functions without body")
-    << help_entry(
-      "--list-calls-args",
-      "list all function calls with their arguments")
-    << help_entry("--call-graph", "show graph of function calls")
-    << help_entry(
-      "--reachable-call-graph",
-      "show graph of function calls potentially reachable from main function")
-    << HELP_SHOW_CLASS_HIERARCHY
-    << HELP_VALIDATE
-    << help_entry(
-      "--validate-goto-binary",
-      "check the well-formedness of the passed in goto binary and then exit")
-    << help_entry("--interpreter", "do concrete execution")
-    << "\n"
+    HELP_SHOW_PROPERTIES
+    HELP_DOCUMENT_PROPERTIES
+    " {y--show-symbol-table} \t show loaded symbol table\n"
+    " {y--list-symbols} \t list symbols with type information\n"
+    HELP_SHOW_GOTO_FUNCTIONS
+    HELP_GOTO_PROGRAM_STATS
+    " {y--show-locations} \t show all source locations\n"
+    " {y--dot} \t generate CFG graph in DOT format\n"
+    " {y--print-internal-representation} \t show verbose internal"
+    " representation of the program\n"
+    " {y--list-undefined-functions} \t list functions without body\n"
+    " {y--list-calls-args} \t list all function calls with their arguments\n"
+    " {y--call-graph} \t show graph of function calls\n"
+    " {y--reachable-call-graph} \t show graph of function calls potentially"
+    " reachable from main function\n"
+    HELP_SHOW_CLASS_HIERARCHY
+    HELP_VALIDATE
+    " {y--validate-goto-binary} \t check the well-formedness of the passed in"
+    " goto binary and then exit\n"
+    " {y--interpreter} \t do concrete execution\n"
+    "\n"
     "Data-flow analyses:\n"
-    << help_entry(
-      "--show-struct-alignment",
-      "show struct members that might be concurrently accessed")
-    << help_entry(
-      "--show-threaded",
-      "show instructions that may be executed by more than one thread")
-    << help_entry(
-      "--show-local-safe-pointers",
-      "show pointer expressions that are trivially dominated by a not-null "
-      "check")
-    << help_entry(
-      "--show-safe-dereferences",
-      "show pointer expressions that are trivially dominated by a not-null "
-      "check *and* used as a dereference operand")
-    << help_entry(
-      "--show-value-sets",
-      "show points-to information (using value sets)")
-    << help_entry(
-      "--show-global-may-alias",
-      "show may-alias information over globals")
-    << help_entry(
-      "--show-local-bitvector-analysis",
-      "show procedure-local pointer analysis")
-    << help_entry(
-      "--escape-analysis",
-      "perform escape analysis")
-    << help_entry(
-      "--show-escape-analysis",
-      "show results of escape analysis")
-    << help_entry(
-      "--custom-bitvector-analysis",
-      "perform configurable bitvector analysis")
-    << help_entry(
-      "--show-custom-bitvector-analysis",
-      "show results of configurable bitvector analysis")
-    << help_entry("--interval-analysis", "perform interval analysis")
-    << help_entry("--show-intervals", "show results of interval analysis")
-    << help_entry("--show-uninitialized", "show maybe-uninitialized variables")
-    << help_entry("--show-points-to", "show points-to information")
-    << help_entry("--show-rw-set", "show read-write sets")
-    << help_entry("--show-call-sequences", "show function call sequences")
-    << help_entry("--show-reaching-definitions", "show reaching definitions")
-    << help_entry("--show-dependence-graph", "show program-dependence graph")
-    << help_entry(
-      "--show-sese-regions",
-      "show single-entry-single-exit regions")
-    << "\n"
+    " {y--show-struct-alignment} \t show struct members that might be"
+    " concurrently accessed\n"
+    " {y--show-threaded} \t show instructions that may be executed by more than"
+    " one thread\n"
+    " {y--show-local-safe-pointers} \t show pointer expressions that are"
+    " trivially dominated by a not-null check\n"
+    " {y--show-safe-dereferences} \t show pointer expressions that are"
+    " trivially dominated by a not-null check *and* used as a dereference"
+    " operand\n"
+    " {y--show-value-sets} \t show points-to information (using value sets)\n"
+    " {y--show-global-may-alias} \t show may-alias information over globals\n"
+    " {y--show-local-bitvector-analysis} \t show procedure-local pointer"
+    " analysis\n"
+    " {y--escape-analysis} \t perform escape analysis\n"
+    " {y--show-escape-analysis} \t show results of escape analysis\n"
+    " {y--custom-bitvector-analysis} \t perform configurable bitvector"
+    " analysis\n"
+    " {y--show-custom-bitvector-analysis} \t show results of configurable"
+    " bitvector analysis\n"
+    " {y--interval-analysis} \t perform interval analysis\n"
+    " {y--show-intervals} \t show results of interval analysis\n"
+    " {y--show-uninitialized} \t show maybe-uninitialized variables\n"
+    " {y--show-points-to} \t show points-to information\n"
+    " {y--show-rw-set} \t show read-write sets\n"
+    " {y--show-call-sequences} \t show function call sequences\n"
+    " {y--show-reaching-definitions} \t show reaching definitions\n"
+    " {y--show-dependence-graph} \t show program-dependence graph\n"
+    " {y--show-sese-regions} \t show single-entry-single-exit regions\n"
+    "\n"
     "Safety checks:\n"
-    << help_entry("--no-assertions", "ignore user assertions")
-    << HELP_GOTO_CHECK
-    << HELP_UNINITIALIZED_CHECK
-    << help_entry(
-      "--stack-depth n",
-      "add check that call stack size of non-inlined functions never exceeds n")
-    << help_entry("--race-check", "add floating-point data race checks")
-    << "\n"
+    " {y--no-assertions} \t ignore user assertions\n"
+    HELP_GOTO_CHECK
+    HELP_UNINITIALIZED_CHECK
+    " {y--stack-depth} {un} \t add check that call stack size of non-inlined"
+    " functions never exceeds {un}\n"
+    " {y--race-check} \t add floating-point data race checks\n"
+    "\n"
     "Semantic transformations:\n"
-    << HELP_NONDET_VOLATILE
-    << help_entry(
-      "--isr <function>",
-      "instruments an interrupt service routine")
-    << help_entry("--mmio", "instruments memory-mapped I/O")
-    << help_entry(
-      "--nondet-static",
-      "add nondeterministic initialization of variables with static lifetime")
-    << help_entry(
-      "--nondet-static-exclude e",
-      "same as nondet-static except for the variable e (use multiple times if "
-      "required)")
-    << help_entry("--nondet-static-matching r", "add nondeterministic initialization of variables with static lifetime matching regex r")
-    << help_entry(
-      "--function-enter <f>, --function-exit <f>, --branch <f>",
-      "instruments a call to <f> at the beginning, the exit, or a branch "
-      "point, respectively")
-    << help_entry(
-      "--splice-call caller,callee",
-      "prepends a call to callee in the body of caller")
-    << help_entry(
-      "--check-call-sequence <seq>",
-      "instruments checks to assert that all call sequences match <seq>")
-    << help_entry(
-      "--undefined-function-is-assume-false",
-      "convert each call to an undefined function to assume(false)")
-    << HELP_INSERT_FINAL_ASSERT_FALSE
-    << HELP_REPLACE_FUNCTION_BODY
-    << HELP_RESTRICT_FUNCTION_POINTER
-    << HELP_REMOVE_CALLS_NO_BODY
-    << help_entry("--add-library", "add models of C library functions")
-    << HELP_CONFIG_LIBRARY
-    << help_entry(
-      "--model-argc-argv <n>",
-      "model up to <n> command line arguments")
-    << help_entry(
-      "--remove-function-body <f>",
-      "remove the implementation of function <f> (may be repeated)")
-    << HELP_REPLACE_CALLS
-    << HELP_ANSI_C_LANGUAGE
-    << "\n"
+    HELP_NONDET_VOLATILE
+    " {y--isr} {ufunction} \t instruments an interrupt service routine\n"
+    " {y--mmio} \t instruments memory-mapped I/O\n"
+    " {y--nondet-static} \t add nondeterministic initialization of variables"
+    " with static lifetime\n"
+    " {y--nondet-static-exclude} {ue} \t same as nondet-static except for the"
+    " variable {ue} (use multiple times if required)\n"
+    " {y--nondet-static-matching} {ur} \t add nondeterministic initialization"
+    " of variables with static lifetime matching regex {ur}\n"
+    " {y--function-enter} {uf}, {y--function-exit} {uf}, {y--branch} {uf} \t"
+    " instruments a call to {uf} at the beginning, the exit, or a branch point,"
+    " respectively\n"
+    " {y--splice-call} {ucaller},{ucallee} \t prepends a call to {ucallee} in"
+    " the body of {ucaller}\n"
+    " {y--check-call-sequence} {useq} \t instruments checks to assert that all"
+    " call sequences match {useq}\n"
+    " {y--undefined-function-is-assume-false} \t convert each call to an"
+    " undefined function to assume(false)\n"
+    HELP_INSERT_FINAL_ASSERT_FALSE
+    HELP_REPLACE_FUNCTION_BODY
+    HELP_RESTRICT_FUNCTION_POINTER
+    HELP_REMOVE_CALLS_NO_BODY
+    " {y--add-library} \t add models of C library functions\n"
+    HELP_CONFIG_LIBRARY
+    " {y--model-argc-argv} {un} \t model up to {un} command line arguments\n"
+    " {y--remove-function-body} {uf} remove the implementation of function {uf}"
+    " (may be repeated)\n"
+    HELP_REPLACE_CALLS
+    HELP_ANSI_C_LANGUAGE
+    "\n"
     "Semantics-preserving transformations:\n"
-    << help_entry(
-      "--ensure-one-backedge-per-target",
-      "transform loop bodies such that there is a single edge back to the loop "
-      "head")
-    << help_entry(
-      "--drop-unused-functions",
-      "drop functions trivially unreachable from main function")
-    << HELP_REMOVE_POINTERS
-    << help_entry(
-      "--constant-propagator",
-      "propagate constants and simplify expressions")
-    << help_entry("--inline", "perform full inlining")
-    << help_entry("--partial-inline", "perform partial inlining")
-    << help_entry(
-      "--function-inline <function>",
-      "transitively inline all calls <function> makes")
-    << help_entry(
-      "--no-caching",
-      "disable caching of intermediate results during transitive function "
-      "inlining")
-    << help_entry(
-      "--log <file>", "log in json format which code segments were inlined, "
-      "use with --function-inline")
-    << help_entry(
-      "--remove-function-pointers",
-      "replace function pointers by case statement over function calls")
-    << HELP_REMOVE_CONST_FUNCTION_POINTERS
-    << help_entry(
-      "--value-set-fi-fp-removal",
-      "build flow-insensitive value set and replace function pointers by a "
-      "case statement over the possible assignments. If the set of possible "
-      "assignments is empty the function pointer is removed using the standard "
-      "remove-function-pointers pass.")
-    << "\n"
+    " {y--ensure-one-backedge-per-target} \t transform loop bodies such that"
+    " there is a single edge back to the loop head\n"
+    " {y--drop-unused-functions} \t drop functions trivially unreachable from"
+    " main function\n"
+    HELP_REMOVE_POINTERS
+    " {y--constant-propagator} \t propagate constants and simplify"
+    " expressions\n"
+    " {y--inline} \t perform full inlining\n"
+    " {y--partial-inline} \t perform partial inlining\n"
+    " {y--function-inline} {ufunction} \t transitively inline all calls"
+    " {ufunction} makes\n"
+    " {y--no-caching} \t disable caching of intermediate results during"
+    " transitive function inlining\n"
+    " {y--log} {ufile} \t log in JSON format which code segments were inlined,"
+    " use with {y--function-inline}\n"
+    " {y--remove-function-pointers} \t replace function pointers by case"
+    " statement over function calls\n"
+    HELP_REMOVE_CONST_FUNCTION_POINTERS
+    " {y--value-set-fi-fp-removal} \t build flow-insensitive value set and"
+    " replace function pointers by a case statement over the possible"
+    " assignments. If the set of possible assignments is empty the function"
+    " pointer is removed using the standard remove-function-pointers pass.\n"
+    "\n"
     "Loop information and transformations:\n"
-    << HELP_UNWINDSET
-    << help_entry("--unwindset-file_<file>", "read unwindset from file")
-    << help_entry("--partial-loops", "permit paths with partial loops")
-    << help_entry("--unwinding-assertions", "generate unwinding assertions")
-    << help_entry(
-      "--continue-as-loops",
-      "add loop for remaining iterations after unwound part")
-    << help_entry("--k-induction <k>", "check loops with k-induction")
-    << help_entry("--step-case", "k-induction: do step-case")
-    << help_entry("--base-case", "k-induction: do base-case")
-    << help_entry("--havoc-loops", "over-approximate all loops")
-    << help_entry("--accelerate", "add loop accelerators")
-    << help_entry("--z3", "use Z3 when computing loop accelerators")
-    << help_entry(
-      "--skip-loops <loop-ids>",
-      "add gotos to skip selected loops during execution")
-    << help_entry(
-      "--show-lexical-loops",
-      "show single-entry-single-back-edge loops")
-    << help_entry("--show-natural-loops", "show natural loop heads")
-    << "\n"
+    HELP_UNWINDSET
+    " {y--unwindset-file_<file>} \t read unwindset from file\n"
+    " {y--partial-loops} \t permit paths with partial loops\n"
+    " {y--unwinding-assertions} \t generate unwinding assertions\n"
+    " {y--continue-as-loops} \t add loop for remaining iterations after"
+    " unwound part\n"
+    " {y--k-induction} {uk} \t check loops with k-induction\n"
+    " {y--step-case} \t k-induction: do step-case\n"
+    " {y--base-case} \t k-induction: do base-case\n"
+    " {y--havoc-loops} \t over-approximate all loops\n"
+    " {y--accelerate} \t add loop accelerators\n"
+    " {y--z3} \t use Z3 when computing loop accelerators\n"
+    " {y--skip-loops {uloop-ids} \t add gotos to skip selected loops during"
+    " execution\n"
+    " {y--show-lexical-loops} \t show single-entry-single-back-edge loops\n"
+    " {y--show-natural-loops} \t show natural loop heads\n"
+    "\n"
     "Memory model instrumentations:\n"
-    << HELP_WMM_FULL
-    << "\n"
+    HELP_WMM_FULL
+    "\n"
     "Slicing:\n"
-    << HELP_REACHABILITY_SLICER
-    << HELP_FP_REACHABILITY_SLICER
-    << help_entry(
-      "--full-slice",
-      "slice away instructions that don't affect assertions")
-    << help_entry(
-      "--property id",
-      "slice with respect to specific property only")
-    << help_entry(
-      "--slice-global-inits",
-      "slice away initializations of unused global variables")
-    << help_entry(
-      "--aggressive-slice",
-      "remove bodies of any functions not on the shortest path between "
-      "the start function and the function containing the property(s)")
-    << help_entry(
-      "--aggressive-slice-call-depth <n>",
-      "used with aggressive-slice, preserves all functions within <n> function "
-      "calls of the functions on the shortest path")
-    << help_entry(
-      "--aggressive-slice-preserve-function <f>",
-      "force the aggressive slicer to preserve function <f>")
-    << help_entry(
-      "--aggressive-slice-preserve-functions-containing <f>",
-      "force the aggressive slicer to preserve all functions with names "
-      "containing <f>")
-    << help_entry(
-      "--aggressive-slice-preserve-all-direct-paths",
-      "force aggressive slicer to preserve all direct paths")
-    << "\n"
+    HELP_REACHABILITY_SLICER
+    HELP_FP_REACHABILITY_SLICER
+    " {y--full-slice} \t slice away instructions that don't affect assertions\n"
+    " {y--property} {uid} \t slice with respect to specific property only\n"
+    " {y--slice-global-inits} \t slice away initializations of unused global"
+    " variables\n"
+    " {y--aggressive-slice} \t remove bodies of any functions not on the"
+    " shortest path between the start function and the function containing the"
+    " property/properties\n"
+    " {y--aggressive-slice-call-depth} {un} \t used with aggressive-slice,"
+    " preserves all functions within {un} function calls of the functions on"
+    " the shortest path\n"
+    " {y--aggressive-slice-preserve-function} {uf} \t force the aggressive"
+    " slicer to preserve function {uf}\n"
+    " {y--aggressive-slice-preserve-functions-containing} {uf} \t force the"
+    " aggressive slicer to preserve all functions with names containing {uf}\n"
+    " {y--aggressive-slice-preserve-all-direct-paths} \t force aggressive"
+    " slicer to preserve all direct paths\n"
+    "\n"
     "Code contracts:\n"
-    << HELP_DFCC
-    << HELP_LOOP_CONTRACTS
-    << HELP_LOOP_CONTRACTS_NO_UNWIND
-    << HELP_LOOP_CONTRACTS_FILE
-    << HELP_REPLACE_CALL
-    << HELP_ENFORCE_CONTRACT
-    << HELP_ENFORCE_CONTRACT_REC
-    << "\n"
+    HELP_DFCC
+    HELP_LOOP_CONTRACTS
+    HELP_LOOP_CONTRACTS_NO_UNWIND
+    HELP_LOOP_CONTRACTS_FILE
+    HELP_REPLACE_CALL
+    HELP_ENFORCE_CONTRACT
+    HELP_ENFORCE_CONTRACT_REC
+    "\n"
     "User-interface options:\n"
-    << HELP_FLUSH
-    << help_entry("--xml", "output files in XML where supported")
-    << help_entry("--xml-ui", "use XML-formatted output")
-    << help_entry("--json-ui", "use JSON-formatted output")
-    << help_entry("--verbosity #", "verbosity level")
-    << HELP_TIMESTAMP
-    << "\n";
+    HELP_FLUSH
+    " {y--xml} \t output files in XML where supported\n"
+    " {y--xml-ui} \t use XML-formatted output\n"
+    " {y--json-ui} \t use JSON-formatted output\n"
+    " {y--verbosity} {u#} \t verbosity level\n"
+    HELP_TIMESTAMP
+    "\n");
   // clang-format on
 }

--- a/src/goto-instrument/goto_instrument_parse_options.cpp
+++ b/src/goto-instrument/goto_instrument_parse_options.cpp
@@ -1870,167 +1870,242 @@ void goto_instrument_parse_optionst::help()
     " goto-instrument [options] in [out]  perform analysis or instrumentation\n"
     "\n"
     "Dump Source:\n"
-    HELP_DUMP_C
-    " --horn                       print program as constrained horn clauses\n"
-    "\n"
+    << HELP_DUMP_C
+    << help_entry("--horn", "print program as constrained horn clauses")
+    << "\n"
     "Diagnosis:\n"
-    HELP_SHOW_PROPERTIES
-    HELP_DOCUMENT_PROPERTIES
-    " --show-symbol-table          show loaded symbol table\n"
-    " --list-symbols               list symbols with type information\n"
-    HELP_SHOW_GOTO_FUNCTIONS
-    HELP_GOTO_PROGRAM_STATS
-    " --show-locations             show all source locations\n"
-    " --dot                        generate CFG graph in DOT format\n"
-    " --print-internal-representation\n" // NOLINTNEXTLINE(*)
-    "                              show verbose internal representation of the program\n"
-    " --list-undefined-functions   list functions without body\n"
-    // NOLINTNEXTLINE(whitespace/line_length)
-    " --list-calls-args            list all function calls with their arguments\n"
-    " --call-graph                 show graph of function calls\n"
-    // NOLINTNEXTLINE(whitespace/line_length)
-    " --reachable-call-graph       show graph of function calls potentially reachable from main function\n"
-    HELP_SHOW_CLASS_HIERARCHY
-    HELP_VALIDATE
-    // NOLINTNEXTLINE(whitespace/line_length)
-    " --validate-goto-binary       check the well-formedness of the passed in goto\n"
-    "                              binary and then exit\n"
-    " --interpreter                do concrete execution\n"
-    "\n"
+    << HELP_SHOW_PROPERTIES
+    << HELP_DOCUMENT_PROPERTIES
+    << help_entry("--show-symbol-table", "show loaded symbol table")
+    << help_entry("--list-symbols", "list symbols with type information")
+    << HELP_SHOW_GOTO_FUNCTIONS
+    << HELP_GOTO_PROGRAM_STATS
+    << help_entry("--show-locations", "show all source locations")
+    << help_entry("--dot", "generate CFG graph in DOT format")
+    << help_entry(
+      "--print-internal-representation",
+      "show verbose internal representation of the program")
+    << help_entry("--list-undefined-functions", "list functions without body")
+    << help_entry(
+      "--list-calls-args",
+      "list all function calls with their arguments")
+    << help_entry("--call-graph", "show graph of function calls")
+    << help_entry(
+      "--reachable-call-graph",
+      "show graph of function calls potentially reachable from main function")
+    << HELP_SHOW_CLASS_HIERARCHY
+    << HELP_VALIDATE
+    << help_entry(
+      "--validate-goto-binary",
+      "check the well-formedness of the passed in goto binary and then exit")
+    << help_entry("--interpreter", "do concrete execution")
+    << "\n"
     "Data-flow analyses:\n"
-    " --show-struct-alignment      show struct members that might be concurrently accessed\n" // NOLINT(*)
-    // NOLINTNEXTLINE(whitespace/line_length)
-    " --show-threaded              show instructions that may be executed by more than one thread\n"
-    " --show-local-safe-pointers   show pointer expressions that are trivially dominated by a not-null check\n" // NOLINT(*)
-    " --show-safe-dereferences     show pointer expressions that are trivially dominated by a not-null check\n" // NOLINT(*)
-    "                              *and* used as a dereference operand\n" // NOLINT(*)
-    " --show-value-sets            show points-to information (using value sets)\n" // NOLINT(*)
-    " --show-global-may-alias      show may-alias information over globals\n"
-    " --show-local-bitvector-analysis\n"
-    "                              show procedure-local pointer analysis\n"
-    " --escape-analysis            perform escape analysis\n"
-    " --show-escape-analysis       show results of escape analysis\n"
-    " --custom-bitvector-analysis  perform configurable bitvector analysis\n"
-    " --show-custom-bitvector-analysis\n"
-    "                              show results of configurable bitvector analysis\n" // NOLINT(*)
-    " --interval-analysis          perform interval analysis\n"
-    " --show-intervals             show results of interval analysis\n"
-    " --show-uninitialized         show maybe-uninitialized variables\n"
-    " --show-points-to             show points-to information\n"
-    " --show-rw-set                show read-write sets\n"
-    " --show-call-sequences        show function call sequences\n"
-    " --show-reaching-definitions  show reaching definitions\n"
-    " --show-dependence-graph      show program-dependence graph\n"
-    " --show-sese-regions          show single-entry-single-exit regions\n"
-    "\n"
+    << help_entry(
+      "--show-struct-alignment",
+      "show struct members that might be concurrently accessed")
+    << help_entry(
+      "--show-threaded",
+      "show instructions that may be executed by more than one thread")
+    << help_entry(
+      "--show-local-safe-pointers",
+      "show pointer expressions that are trivially dominated by a not-null "
+      "check")
+    << help_entry(
+      "--show-safe-dereferences",
+      "show pointer expressions that are trivially dominated by a not-null "
+      "check *and* used as a dereference operand")
+    << help_entry(
+      "--show-value-sets",
+      "show points-to information (using value sets)")
+    << help_entry(
+      "--show-global-may-alias",
+      "show may-alias information over globals")
+    << help_entry(
+      "--show-local-bitvector-analysis",
+      "show procedure-local pointer analysis")
+    << help_entry(
+      "--escape-analysis",
+      "perform escape analysis")
+    << help_entry(
+      "--show-escape-analysis",
+      "show results of escape analysis")
+    << help_entry(
+      "--custom-bitvector-analysis",
+      "perform configurable bitvector analysis")
+    << help_entry(
+      "--show-custom-bitvector-analysis",
+      "show results of configurable bitvector analysis")
+    << help_entry("--interval-analysis", "perform interval analysis")
+    << help_entry("--show-intervals", "show results of interval analysis")
+    << help_entry("--show-uninitialized", "show maybe-uninitialized variables")
+    << help_entry("--show-points-to", "show points-to information")
+    << help_entry("--show-rw-set", "show read-write sets")
+    << help_entry("--show-call-sequences", "show function call sequences")
+    << help_entry("--show-reaching-definitions", "show reaching definitions")
+    << help_entry("--show-dependence-graph", "show program-dependence graph")
+    << help_entry(
+      "--show-sese-regions",
+      "show single-entry-single-exit regions")
+    << "\n"
     "Safety checks:\n"
-    " --no-assertions              ignore user assertions\n"
-    HELP_GOTO_CHECK
-    HELP_UNINITIALIZED_CHECK
-    " --stack-depth n              add check that call stack size of non-inlined functions never exceeds n\n" // NOLINT(*)
-    " --race-check                 add floating-point data race checks\n"
-    "\n"
+    << help_entry("--no-assertions", "ignore user assertions")
+    << HELP_GOTO_CHECK
+    << HELP_UNINITIALIZED_CHECK
+    << help_entry(
+      "--stack-depth n",
+      "add check that call stack size of non-inlined functions never exceeds n")
+    << help_entry("--race-check", "add floating-point data race checks")
+    << "\n"
     "Semantic transformations:\n"
-    << HELP_NONDET_VOLATILE <<
-    " --isr <function>             instruments an interrupt service routine\n"
-    " --mmio                       instruments memory-mapped I/O\n"
-    " --nondet-static              add nondeterministic initialization of variables with static lifetime\n" // NOLINT(*)
-    " --nondet-static-exclude e    same as nondet-static except for the variable e\n" //NOLINT(*)
-    "                              (use multiple times if required)\n"
-    " --nondet-static-matching r   add nondeterministic initialization of variables\n" // NOLINT(*)
-    "                              with static lifetime matching regex r\n"
-    " --function-enter <f>, --function-exit <f>, --branch <f>\n"
-    "                              instruments a call to <f> at the beginning,\n" // NOLINT(*)
-    "                              the exit, or a branch point, respectively\n"
-    " --splice-call caller,callee  prepends a call to callee in the body of caller\n"  // NOLINT(*)
-    " --check-call-sequence <seq>  instruments checks to assert that all call\n"
-    "                              sequences match <seq>\n"
-    " --undefined-function-is-assume-false\n"
-    // NOLINTNEXTLINE(whitespace/line_length)
-    "                              convert each call to an undefined function to assume(false)\n"
-    HELP_INSERT_FINAL_ASSERT_FALSE
-    HELP_REPLACE_FUNCTION_BODY
-    HELP_RESTRICT_FUNCTION_POINTER
-    HELP_REMOVE_CALLS_NO_BODY
-    " --add-library                add models of C library functions\n"
-    HELP_CONFIG_LIBRARY
-    " --model-argc-argv <n>        model up to <n> command line arguments\n"
-    // NOLINTNEXTLINE(whitespace/line_length)
-    " --remove-function-body <f>   remove the implementation of function <f> (may be repeated)\n"
-    HELP_REPLACE_CALLS
-    HELP_ANSI_C_LANGUAGE
-    "\n"
+    << HELP_NONDET_VOLATILE
+    << help_entry(
+      "--isr <function>",
+      "instruments an interrupt service routine")
+    << help_entry("--mmio", "instruments memory-mapped I/O")
+    << help_entry(
+      "--nondet-static",
+      "add nondeterministic initialization of variables with static lifetime")
+    << help_entry(
+      "--nondet-static-exclude e",
+      "same as nondet-static except for the variable e (use multiple times if "
+      "required)")
+    << help_entry("--nondet-static-matching r", "add nondeterministic initialization of variables with static lifetime matching regex r")
+    << help_entry(
+      "--function-enter <f>, --function-exit <f>, --branch <f>",
+      "instruments a call to <f> at the beginning, the exit, or a branch "
+      "point, respectively")
+    << help_entry(
+      "--splice-call caller,callee",
+      "prepends a call to callee in the body of caller")
+    << help_entry(
+      "--check-call-sequence <seq>",
+      "instruments checks to assert that all call sequences match <seq>")
+    << help_entry(
+      "--undefined-function-is-assume-false",
+      "convert each call to an undefined function to assume(false)")
+    << HELP_INSERT_FINAL_ASSERT_FALSE
+    << HELP_REPLACE_FUNCTION_BODY
+    << HELP_RESTRICT_FUNCTION_POINTER
+    << HELP_REMOVE_CALLS_NO_BODY
+    << help_entry("--add-library", "add models of C library functions")
+    << HELP_CONFIG_LIBRARY
+    << help_entry(
+      "--model-argc-argv <n>",
+      "model up to <n> command line arguments")
+    << help_entry(
+      "--remove-function-body <f>",
+      "remove the implementation of function <f> (may be repeated)")
+    << HELP_REPLACE_CALLS
+    << HELP_ANSI_C_LANGUAGE
+    << "\n"
     "Semantics-preserving transformations:\n"
-    " --ensure-one-backedge-per-target\n"
-    "                              transform loop bodies such that there is a\n"
-    "                              single edge back to the loop head\n"
-    " --drop-unused-functions      drop functions trivially unreachable from main function\n" // NOLINT(*)
-    HELP_REMOVE_POINTERS
-    " --constant-propagator        propagate constants and simplify expressions\n" // NOLINT(*)
-    " --inline                     perform full inlining\n"
-    " --partial-inline             perform partial inlining\n"
-    " --function-inline <function> transitively inline all calls <function> makes\n" // NOLINT(*)
-    " --no-caching                 disable caching of intermediate results during transitive function inlining\n" // NOLINT(*)
-    " --log <file>                 log in json format which code segments were inlined, use with --function-inline\n" // NOLINT(*)
-    " --remove-function-pointers   replace function pointers by case statement over function calls\n" // NOLINT(*)
-    HELP_REMOVE_CONST_FUNCTION_POINTERS
-    " --value-set-fi-fp-removal    build flow-insensitive value set and replace function pointers by a case statement\n" // NOLINT(*)
-    "                              over the possible assignments. If the set of possible assignments is empty the function pointer\n" // NOLINT(*)
-    "                              is removed using the standard remove-function-pointers pass. \n" // NOLINT(*)
-    "\n"
+    << help_entry(
+      "--ensure-one-backedge-per-target",
+      "transform loop bodies such that there is a single edge back to the loop "
+      "head")
+    << help_entry(
+      "--drop-unused-functions",
+      "drop functions trivially unreachable from main function")
+    << HELP_REMOVE_POINTERS
+    << help_entry(
+      "--constant-propagator",
+      "propagate constants and simplify expressions")
+    << help_entry("--inline", "perform full inlining")
+    << help_entry("--partial-inline", "perform partial inlining")
+    << help_entry(
+      "--function-inline <function>",
+      "transitively inline all calls <function> makes")
+    << help_entry(
+      "--no-caching",
+      "disable caching of intermediate results during transitive function "
+      "inlining")
+    << help_entry(
+      "--log <file>", "log in json format which code segments were inlined, "
+      "use with --function-inline")
+    << help_entry(
+      "--remove-function-pointers",
+      "replace function pointers by case statement over function calls")
+    << HELP_REMOVE_CONST_FUNCTION_POINTERS
+    << help_entry(
+      "--value-set-fi-fp-removal",
+      "build flow-insensitive value set and replace function pointers by a "
+      "case statement over the possible assignments. If the set of possible "
+      "assignments is empty the function pointer is removed using the standard "
+      "remove-function-pointers pass.")
+    << "\n"
     "Loop information and transformations:\n"
-    HELP_UNWINDSET
-    " --unwindset-file <file>      read unwindset from file\n"
-    " --partial-loops              permit paths with partial loops\n"
-    " --unwinding-assertions       generate unwinding assertions\n"
-    " --continue-as-loops          add loop for remaining iterations after unwound part\n" // NOLINT(*)
-    " --k-induction <k>            check loops with k-induction\n"
-    " --step-case                  k-induction: do step-case\n"
-    " --base-case                  k-induction: do base-case\n"
-    " --havoc-loops                over-approximate all loops\n"
-    " --accelerate                 add loop accelerators\n"
-    " --z3                         use Z3 when computing loop accelerators\n"
-    " --skip-loops <loop-ids>      add gotos to skip selected loops during execution\n" // NOLINT(*)
-    " --show-lexical-loops         show single-entry-single-back-edge loops\n"
-    " --show-natural-loops         show natural loop heads\n"
-    "\n"
+    << HELP_UNWINDSET
+    << help_entry("--unwindset-file_<file>", "read unwindset from file")
+    << help_entry("--partial-loops", "permit paths with partial loops")
+    << help_entry("--unwinding-assertions", "generate unwinding assertions")
+    << help_entry(
+      "--continue-as-loops",
+      "add loop for remaining iterations after unwound part")
+    << help_entry("--k-induction <k>", "check loops with k-induction")
+    << help_entry("--step-case", "k-induction: do step-case")
+    << help_entry("--base-case", "k-induction: do base-case")
+    << help_entry("--havoc-loops", "over-approximate all loops")
+    << help_entry("--accelerate", "add loop accelerators")
+    << help_entry("--z3", "use Z3 when computing loop accelerators")
+    << help_entry(
+      "--skip-loops <loop-ids>",
+      "add gotos to skip selected loops during execution")
+    << help_entry(
+      "--show-lexical-loops",
+      "show single-entry-single-back-edge loops")
+    << help_entry("--show-natural-loops", "show natural loop heads")
+    << "\n"
     "Memory model instrumentations:\n"
-    HELP_WMM_FULL
-    "\n"
+    << HELP_WMM_FULL
+    << "\n"
     "Slicing:\n"
-    HELP_REACHABILITY_SLICER
-    HELP_FP_REACHABILITY_SLICER
-    " --full-slice                 slice away instructions that don't affect assertions\n" // NOLINT(*)
-    " --property id                slice with respect to specific property only\n" // NOLINT(*)
-    " --slice-global-inits         slice away initializations of unused global variables\n" // NOLINT(*)
-    " --aggressive-slice           remove bodies of any functions not on the shortest path between\n" // NOLINT(*)
-    "                              the start function and the function containing the property(s)\n" // NOLINT(*)
-    " --aggressive-slice-call-depth <n>\n"
-    "                              used with aggressive-slice, preserves all functions within <n> function calls\n" // NOLINT(*)
-    "                              of the functions on the shortest path\n"
-    " --aggressive-slice-preserve-function <f>\n"
-    "                              force the aggressive slicer to preserve function <f>\n" // NOLINT(*)
-    " --aggressive-slice-preserve-functions-containing <f>\n"
-    "                              force the aggressive slicer to preserve all functions with names containing <f>\n" // NOLINT(*)
-    " --aggressive-slice-preserve-all-direct-paths \n"
-    "                              force aggressive slicer to preserve all direct paths\n" // NOLINT(*)
-    "\n"
+    << HELP_REACHABILITY_SLICER
+    << HELP_FP_REACHABILITY_SLICER
+    << help_entry(
+      "--full-slice",
+      "slice away instructions that don't affect assertions")
+    << help_entry(
+      "--property id",
+      "slice with respect to specific property only")
+    << help_entry(
+      "--slice-global-inits",
+      "slice away initializations of unused global variables")
+    << help_entry(
+      "--aggressive-slice",
+      "remove bodies of any functions not on the shortest path between "
+      "the start function and the function containing the property(s)")
+    << help_entry(
+      "--aggressive-slice-call-depth <n>",
+      "used with aggressive-slice, preserves all functions within <n> function "
+      "calls of the functions on the shortest path")
+    << help_entry(
+      "--aggressive-slice-preserve-function <f>",
+      "force the aggressive slicer to preserve function <f>")
+    << help_entry(
+      "--aggressive-slice-preserve-functions-containing <f>",
+      "force the aggressive slicer to preserve all functions with names "
+      "containing <f>")
+    << help_entry(
+      "--aggressive-slice-preserve-all-direct-paths",
+      "force aggressive slicer to preserve all direct paths")
+    << "\n"
     "Code contracts:\n"
-    HELP_DFCC
-    HELP_LOOP_CONTRACTS
-    HELP_LOOP_CONTRACTS_NO_UNWIND
-    HELP_LOOP_CONTRACTS_FILE
-    HELP_REPLACE_CALL
-    HELP_ENFORCE_CONTRACT
-    HELP_ENFORCE_CONTRACT_REC
-    "\n"
+    << HELP_DFCC
+    << HELP_LOOP_CONTRACTS
+    << HELP_LOOP_CONTRACTS_NO_UNWIND
+    << HELP_LOOP_CONTRACTS_FILE
+    << HELP_REPLACE_CALL
+    << HELP_ENFORCE_CONTRACT
+    << HELP_ENFORCE_CONTRACT_REC
+    << "\n"
     "User-interface options:\n"
-    HELP_FLUSH
-    " --xml                        output files in XML where supported\n"
-    " --xml-ui                     use XML-formatted output\n"
-    " --json-ui                    use JSON-formatted output\n"
-    " --verbosity #                verbosity level\n"
-    HELP_TIMESTAMP
-    "\n";
+    << HELP_FLUSH
+    << help_entry("--xml", "output files in XML where supported")
+    << help_entry("--xml-ui", "use XML-formatted output")
+    << help_entry("--json-ui", "use JSON-formatted output")
+    << help_entry("--verbosity #", "verbosity level")
+    << HELP_TIMESTAMP
+    << "\n";
   // clang-format on
 }

--- a/src/goto-instrument/insert_final_assert_false.h
+++ b/src/goto-instrument/insert_final_assert_false.h
@@ -46,14 +46,12 @@ bool insert_final_assert_false(
   const std::string &function_to_instrument,
   message_handlert &message_handler);
 
-// clang-format off
 #define OPT_INSERT_FINAL_ASSERT_FALSE \
   "(insert-final-assert-false):"
 
-#define HELP_INSERT_FINAL_ASSERT_FALSE \
-  " --insert-final-assert-false <function>\n" \
-  /* NOLINTNEXTLINE(whitespace/line_length) */ \
-  "                              generate assert(false) at end of function\n"
-// clang-format on
+#define HELP_INSERT_FINAL_ASSERT_FALSE                                         \
+  help_entry(                                                                  \
+    "--insert-final-assert-false <function>",                                  \
+    "generate assert(false) at end of function")
 
 #endif // CPROVER_GOTO_INSTRUMENT_INSERT_FINAL_ASSERT_FALSE_H

--- a/src/goto-instrument/insert_final_assert_false.h
+++ b/src/goto-instrument/insert_final_assert_false.h
@@ -50,8 +50,7 @@ bool insert_final_assert_false(
   "(insert-final-assert-false):"
 
 #define HELP_INSERT_FINAL_ASSERT_FALSE                                         \
-  help_entry(                                                                  \
-    "--insert-final-assert-false <function>",                                  \
-    "generate assert(false) at end of function")
+  " {y--insert-final-assert-false} {ufunction} \t "                            \
+  "generate assert(false) at end of function {ufunction}\n"
 
 #endif // CPROVER_GOTO_INSTRUMENT_INSERT_FINAL_ASSERT_FALSE_H

--- a/src/goto-instrument/nondet_volatile.h
+++ b/src/goto-instrument/nondet_volatile.h
@@ -30,15 +30,12 @@ class optionst;
   "(" NONDET_VOLATILE_MODEL_OPT "):"
 
 #define HELP_NONDET_VOLATILE \
-  help_entry( \
-    "--" NONDET_VOLATILE_OPT, \
-    "makes reads from volatile variables non-deterministic") << \
-  help_entry( \
-    "--" NONDET_VOLATILE_VARIABLE_OPT " <variable>", \
-    "makes reads from given volatile variable non-deterministic") << \
-  help_entry( \
-    "--" NONDET_VOLATILE_MODEL_OPT " <variable>:<model>", \
-    "models reads from given volatile variable by a call to the given model")
+  " {y--" NONDET_VOLATILE_OPT "} \t " \
+  "makes reads from volatile variables non-deterministic\n" \
+  " {y--" NONDET_VOLATILE_VARIABLE_OPT "} {uvariable} \t " \
+  "makes reads from given volatile variable non-deterministic\n" \
+  " {y--" NONDET_VOLATILE_MODEL_OPT "} {uvariable}:{umodel} \t " \
+  "models reads from given volatile variable by a call to the given model\n" \
 // clang-format on
 
 void parse_nondet_volatile_options(const cmdlinet &cmdline, optionst &options);

--- a/src/goto-instrument/reachability_slicer.h
+++ b/src/goto-instrument/reachability_slicer.h
@@ -45,19 +45,16 @@ void reachability_slicer(
 #define OPT_REACHABILITY_SLICER "(reachability-slice)(reachability-slice-fb)"
 
 #define HELP_FP_REACHABILITY_SLICER                                            \
-  help_entry(                                                                  \
-    "--fp-reachability-slice f",                                               \
-    "remove instructions that cannot appear on a trace that visits all given " \
-    "functions. The list of functions has to be given as a comma separated "   \
-    "list f.")                                                                 \
-    << help_entry(                                                             \
-         "--reachability-slice",                                               \
-         "remove instructions that cannot appear on a trace from entry point " \
-         "to a property")
+  " {y--fp-reachability-slice} {uf} \t "                                       \
+  "remove instructions that cannot appear on a trace that visits all given "   \
+  "functions. The list of functions has to be given as a comma separated "     \
+  "list {uf}.\n"                                                               \
+  " {y--reachability-slice} \t "                                               \
+  "remove instructions that cannot appear on a trace from entry point to a "   \
+  "property\n"
 #define HELP_REACHABILITY_SLICER                                               \
-  help_entry(                                                                  \
-    "--reachability-slice-fb",                                                 \
-    "remove instructions that cannot appear on a trace from entry point "      \
-    "through a property")
+  " {y--reachability-slice-fb} \t "                                            \
+  "remove instructions that cannot appear on a trace from entry point "        \
+  "through a property\n"
 
 #endif // CPROVER_GOTO_INSTRUMENT_REACHABILITY_SLICER_H

--- a/src/goto-instrument/reachability_slicer.h
+++ b/src/goto-instrument/reachability_slicer.h
@@ -41,19 +41,23 @@ void reachability_slicer(
   const bool include_forward_reachability,
   message_handlert &);
 
-// clang-format off
 #define OPT_FP_REACHABILITY_SLICER "(fp-reachability-slice):"
 #define OPT_REACHABILITY_SLICER "(reachability-slice)(reachability-slice-fb)"
 
-#define HELP_FP_REACHABILITY_SLICER \
-  " --fp-reachability-slice f    remove instructions that cannot appear on\n" \
-  "                              trace that visits all given functions.\n" \
-  "                              The list of functions has to be given as a\n" \
-  "                              comma separated list f.\n"
-#define HELP_REACHABILITY_SLICER \
-  " --reachability-slice         remove instructions that cannot appear on\n" \
-  "                              a trace from entry point to a property\n" \
-  " --reachability-slice-fb      remove instructions that cannot appear on\n" \
-  "                              a trace from entry point through a property\n"
-// clang-format on
+#define HELP_FP_REACHABILITY_SLICER                                            \
+  help_entry(                                                                  \
+    "--fp-reachability-slice f",                                               \
+    "remove instructions that cannot appear on a trace that visits all given " \
+    "functions. The list of functions has to be given as a comma separated "   \
+    "list f.")                                                                 \
+    << help_entry(                                                             \
+         "--reachability-slice",                                               \
+         "remove instructions that cannot appear on a trace from entry point " \
+         "to a property")
+#define HELP_REACHABILITY_SLICER                                               \
+  help_entry(                                                                  \
+    "--reachability-slice-fb",                                                 \
+    "remove instructions that cannot appear on a trace from entry point "      \
+    "through a property")
+
 #endif // CPROVER_GOTO_INSTRUMENT_REACHABILITY_SLICER_H

--- a/src/goto-instrument/replace_calls.h
+++ b/src/goto-instrument/replace_calls.h
@@ -56,6 +56,7 @@ protected:
 #define OPT_REPLACE_CALLS "(replace-calls):"
 
 #define HELP_REPLACE_CALLS                                                     \
-  help_entry("--replace-calls f:g", "replace calls to f with calls to g")
+  " {y--replace-calls} {uf}:{ug} \t replace calls to {uf} with calls to "      \
+  "{ug}\n"
 
 #endif // CPROVER_GOTO_PROGRAMS_REPLACE_CALLS_H

--- a/src/goto-instrument/replace_calls.h
+++ b/src/goto-instrument/replace_calls.h
@@ -56,6 +56,6 @@ protected:
 #define OPT_REPLACE_CALLS "(replace-calls):"
 
 #define HELP_REPLACE_CALLS                                                     \
-  " --replace-calls f:g          replace calls to f with calls to g\n"
+  help_entry("--replace-calls f:g", "replace calls to f with calls to g")
 
 #endif // CPROVER_GOTO_PROGRAMS_REPLACE_CALLS_H

--- a/src/goto-instrument/uninitialized.h
+++ b/src/goto-instrument/uninitialized.h
@@ -27,7 +27,8 @@ void show_uninitialized(
 #define OPT_UNINITIALIZED_CHECK "(uninitialized-check)"
 
 #define HELP_UNINITIALIZED_CHECK                                               \
-  " --uninitialized-check        add checks for uninitialized locals "         \
-  "(experimental)\n" // NOLINT(whitespace/line_length)
+  help_entry(                                                                  \
+    "--uninitialized-check",                                                   \
+    "add checks for uninitialized locals (experimental)")
 
 #endif // CPROVER_GOTO_INSTRUMENT_UNINITIALIZED_H

--- a/src/goto-instrument/uninitialized.h
+++ b/src/goto-instrument/uninitialized.h
@@ -27,8 +27,7 @@ void show_uninitialized(
 #define OPT_UNINITIALIZED_CHECK "(uninitialized-check)"
 
 #define HELP_UNINITIALIZED_CHECK                                               \
-  help_entry(                                                                  \
-    "--uninitialized-check",                                                   \
-    "add checks for uninitialized locals (experimental)")
+  " {y--uninitialized-check} \t "                                              \
+  "add checks for uninitialized locals (experimental)\n"
 
 #endif // CPROVER_GOTO_INSTRUMENT_UNINITIALIZED_H

--- a/src/goto-instrument/unwindset.h
+++ b/src/goto-instrument/unwindset.h
@@ -76,11 +76,10 @@ protected:
   "(unwindset):"
 
 #define HELP_UNWINDSET                                                         \
-  help_entry("--show-loops", "show the loops in the program")                  \
-    << help_entry("--unwind nr", "unwind nr times")                            \
-    << help_entry(                                                             \
-         "--unwindset [T:]L:B,...",                                            \
-         "unwind loop L with a bound of B (optionally restricted to thread "   \
-         "T) (use --show-loops to get the loop IDs)")
+  " {y--show-loops} \t show the loops in the program\n"                        \
+  " {y--unwind} {unr} \t unwind loops {unr} times\n"                           \
+  " {y--unwindset} [{uT}{y:}]{uL}{y:}{uB},... \t "                             \
+  "unwind loop {uL} with a bound of {uB} (optionally restricted to thread "    \
+  "{uT}) (use {y--show-loops} to get the loop IDs)\n"
 
 #endif // CPROVER_GOTO_INSTRUMENT_UNWINDSET_H

--- a/src/goto-instrument/unwindset.h
+++ b/src/goto-instrument/unwindset.h
@@ -76,10 +76,11 @@ protected:
   "(unwindset):"
 
 #define HELP_UNWINDSET                                                         \
-  " --show-loops                 show the loops in the program\n"              \
-  " --unwind nr                  unwind nr times\n"                            \
-  " --unwindset [T:]L:B,...      unwind loop L with a bound of B\n"            \
-  "                              (optionally restricted to thread T)\n"        \
-  "                              (use --show-loops to get the loop IDs)\n"
+  help_entry("--show-loops", "show the loops in the program")                  \
+    << help_entry("--unwind nr", "unwind nr times")                            \
+    << help_entry(                                                             \
+         "--unwindset [T:]L:B,...",                                            \
+         "unwind loop L with a bound of B (optionally restricted to thread "   \
+         "T) (use --show-loops to get the loop IDs)")
 
 #endif // CPROVER_GOTO_INSTRUMENT_UNWINDSET_H

--- a/src/goto-instrument/wmm/weak_memory.h
+++ b/src/goto-instrument/wmm/weak_memory.h
@@ -90,42 +90,30 @@ void introduce_temporaries(
   OPT_WMM_MISC
 
 #define HELP_WMM_FULL                                                          \
-  help_entry("--mm <tso,pso,rmo,power>", "instruments a weak memory model")    \
-    << help_entry(                                                             \
-         "--scc", "detects critical cycles per SCC (one thread per SCC)")      \
-    << help_entry(                                                             \
-         "--one-event-per-cycle", "only instruments one event per cycle")      \
-    << help_entry(                                                             \
-         "--minimum-interference", "instruments an optimal number of events")  \
-    << help_entry(                                                             \
-         "--my-events",                                                        \
-         "only instruments events whose ids appear in inst.evt")               \
-    << help_entry(                                                             \
-         "--read-first, --write-first",                                        \
-         "only instrument cycles where a read or  write occurs as first "      \
-         "event, respectively")                                                \
-    << help_entry("--max-var N", "limit cycles to N variables read/written")   \
-    << help_entry("--max-po-trans N", "limit cycles to N program-order edges") \
-    << help_entry("--ignore-arrays", "instrument arrays as a single object")   \
-    << help_entry(                                                             \
-         "--cav11",                                                            \
-         "always instrument shared variables, even when they are not part of " \
-         "any cycle")                                                          \
-    << help_entry(                                                             \
-         "--force-loop-duplication, --no-loop-duplication",                    \
-         "optional program transformation to construct cycles in program "     \
-         "loops")                                                              \
-    << help_entry(                                                             \
-         "--cfg-kill",                                                         \
-         "enables symbolic execution used to reduce spurious cycles")          \
-    << help_entry("--no-dependencies", "no dependency analysis")               \
-    << help_entry(                                                             \
-         "--no-po-rendering", "no representation of the threads in the dot")   \
-    << help_entry(                                                             \
-         "--hide-internals",                                                   \
-         "do not include thread-internal (Rfi) events in dot output")          \
-    << help_entry("--render-cluster-file", "clusterises the dot by files")     \
-    << help_entry(                                                             \
-         "--render-cluster-function", "clusterises the dot by functions")
+  " {y--mm} [{ytso}|{ypso}|{yrmo}|{ypower}] \t "                               \
+  "instruments a weak memory model\n"                                          \
+  " {y--scc} \t detects critical cycles per SCC (one thread per SCC)\n"        \
+  " {y--one-event-per-cycle} \t only instruments one event per cycle\n"        \
+  " {y--minimum-interference} \t instruments an optimal number of events\n"    \
+  " {y--my-events} \t only instruments events whose ids appear in inst.evt\n"  \
+  " {y--read-first}, {y--write-first} \t "                                     \
+  "only instrument cycles where a read or write occurs as first event, "       \
+  "respectively\n"                                                             \
+  " {y--max-var} {uN} \t limit cycles to {uN} variables read/written\n"        \
+  " {y--max-po-trans} {uN} \t limit cycles to {uN} program-order edges\n"      \
+  " {y--ignore-arrays} \t instrument arrays as a single object\n"              \
+  " {y--cav11} \t "                                                            \
+  "always instrument shared variables, even when they are not part of "        \
+  "any cycle\n"                                                                \
+  " {y--force-loop-duplication}, {y--no-loop-duplication} \t "                 \
+  "optional program transformation to construct cycles in program loops\n"     \
+  " {y--cfg-kill} \t enables symbolic execution used to reduce spurious "      \
+  "cycles\n"                                                                   \
+  " {y--no-dependencies} \t no dependency analysis\n"                          \
+  " {y--no-po-rendering} \t no representation of the threads in the dot\n"     \
+  " {y--hide-internals} \t do not include thread-internal (Rfi) events in "    \
+  "dot output\n"                                                               \
+  " {y--render-cluster-file} \t clusterises the dot by files\n"                \
+  " {y--render-cluster-function} \t clusterises the dot by functions\n"
 
 #endif // CPROVER_GOTO_INSTRUMENT_WMM_WEAK_MEMORY_H

--- a/src/goto-instrument/wmm/weak_memory.h
+++ b/src/goto-instrument/wmm/weak_memory.h
@@ -54,7 +54,6 @@ void introduce_temporaries(
 #endif
   messaget &message);
 
-// clang-format off
 #define OPT_WMM_MEMORY_MODEL  "(mm):"
 
 #define OPT_WMM_INSTRUMENTATION_STRATEGIES                                     \
@@ -62,15 +61,15 @@ void introduce_temporaries(
   "(minimum-interference)"                                                     \
   "(read-first)"                                                               \
   "(write-first)"                                                              \
-  "(my-events)"                                                                \
+  "(my-events)"
 
 #define OPT_WMM_LIMITS                                                         \
   "(max-var):"                                                                 \
-  "(max-po-trans):"                                                            \
+  "(max-po-trans):"
 
 #define OPT_WMM_LOOPS                                                          \
   "(force-loop-duplication)"                                                   \
-  "(no-loop-duplication)"                                                      \
+  "(no-loop-duplication)"
 
 #define OPT_WMM_MISC                                                           \
   "(scc)"                                                                      \
@@ -81,40 +80,52 @@ void introduce_temporaries(
   "(render-cluster-function)"                                                  \
   "(cav11)"                                                                    \
   "(hide-internals)"                                                           \
-  "(ignore-arrays)"                                                            \
+  "(ignore-arrays)"
 
 #define OPT_WMM                                                                \
   OPT_WMM_MEMORY_MODEL                                                         \
   OPT_WMM_INSTRUMENTATION_STRATEGIES                                           \
   OPT_WMM_LIMITS                                                               \
   OPT_WMM_LOOPS                                                                \
-  OPT_WMM_MISC                                                                 \
-
+  OPT_WMM_MISC
 
 #define HELP_WMM_FULL                                                          \
-  " --mm <tso,pso,rmo,power>     instruments a weak memory model\n"            \
-  " --scc                        detects critical cycles per SCC (one thread per SCC)\n" /* NOLINT(whitespace/line_length) */ \
-  " --one-event-per-cycle        only instruments one event per cycle\n"       \
-  " --minimum-interference       instruments an optimal number of events\n"    \
-  " --my-events                  only instruments events whose ids appear in inst.evt\n" /* NOLINT(whitespace/line_length) */ \
-  " --read-first|--write-first   only instrument cycles where a read or \n"    \
-  "                              write occurs as first event, respectively\n"  \
-  " --max-var N                  limit cycles to N variables read/written\n"   \
-  " --max-po-trans N             limit cycles to N program-order edges\n"      \
-  " --ignore-arrays              instrument arrays as a single object\n"       \
-  " --cav11                      always instrument shared variables, even\n"   \
-  "                              when they are not part of any cycle\n"        \
-  " --force-loop-duplication|--no-loop-duplication\n"                          \
-  "                              optional program transformation to\n"         \
-  "                              construct cycles in program loops\n"          \
-  " --cfg-kill                   enables symbolic execution used to reduce spurious cycles\n" /* NOLINT(whitespace/line_length) */ \
-  " --no-dependencies            no dependency analysis\n"                     \
-  " --no-po-rendering            no representation of the threads in the dot\n"\
-  " --hide-internals             do not include thread-internal (Rfi)\n"       \
-  "                              events in dot output\n"                       \
-  " --render-cluster-file        clusterises the dot by files\n"               \
-  " --render-cluster-function    clusterises the dot by functions\n"
-
-// clang-format on
+  help_entry("--mm <tso,pso,rmo,power>", "instruments a weak memory model")    \
+    << help_entry(                                                             \
+         "--scc", "detects critical cycles per SCC (one thread per SCC)")      \
+    << help_entry(                                                             \
+         "--one-event-per-cycle", "only instruments one event per cycle")      \
+    << help_entry(                                                             \
+         "--minimum-interference", "instruments an optimal number of events")  \
+    << help_entry(                                                             \
+         "--my-events",                                                        \
+         "only instruments events whose ids appear in inst.evt")               \
+    << help_entry(                                                             \
+         "--read-first, --write-first",                                        \
+         "only instrument cycles where a read or  write occurs as first "      \
+         "event, respectively")                                                \
+    << help_entry("--max-var N", "limit cycles to N variables read/written")   \
+    << help_entry("--max-po-trans N", "limit cycles to N program-order edges") \
+    << help_entry("--ignore-arrays", "instrument arrays as a single object")   \
+    << help_entry(                                                             \
+         "--cav11",                                                            \
+         "always instrument shared variables, even when they are not part of " \
+         "any cycle")                                                          \
+    << help_entry(                                                             \
+         "--force-loop-duplication, --no-loop-duplication",                    \
+         "optional program transformation to construct cycles in program "     \
+         "loops")                                                              \
+    << help_entry(                                                             \
+         "--cfg-kill",                                                         \
+         "enables symbolic execution used to reduce spurious cycles")          \
+    << help_entry("--no-dependencies", "no dependency analysis")               \
+    << help_entry(                                                             \
+         "--no-po-rendering", "no representation of the threads in the dot")   \
+    << help_entry(                                                             \
+         "--hide-internals",                                                   \
+         "do not include thread-internal (Rfi) events in dot output")          \
+    << help_entry("--render-cluster-file", "clusterises the dot by files")     \
+    << help_entry(                                                             \
+         "--render-cluster-function", "clusterises the dot by functions")
 
 #endif // CPROVER_GOTO_INSTRUMENT_WMM_WEAK_MEMORY_H

--- a/src/goto-programs/class_hierarchy.h
+++ b/src/goto-programs/class_hierarchy.h
@@ -21,13 +21,11 @@ Date: April 2016
 #include <util/graph.h>
 #include <util/irep.h>
 
-// clang-format off
 #define OPT_SHOW_CLASS_HIERARCHY \
   "(show-class-hierarchy)"
 
-#define HELP_SHOW_CLASS_HIERARCHY \
-  " --show-class-hierarchy       show the class hierarchy\n"
-// clang-format on
+#define HELP_SHOW_CLASS_HIERARCHY                                              \
+  help_entry("--show-class-hierarchy", "show the class hierarchy")
 
 class symbol_table_baset;
 class json_stream_arrayt;

--- a/src/goto-programs/class_hierarchy.h
+++ b/src/goto-programs/class_hierarchy.h
@@ -25,7 +25,7 @@ Date: April 2016
   "(show-class-hierarchy)"
 
 #define HELP_SHOW_CLASS_HIERARCHY                                              \
-  help_entry("--show-class-hierarchy", "show the class hierarchy")
+  " {y--show-class-hierarchy} \t show the class hierarchy\n"
 
 class symbol_table_baset;
 class json_stream_arrayt;

--- a/src/goto-programs/goto_trace.h
+++ b/src/goto-programs/goto_trace.h
@@ -277,13 +277,12 @@ void show_goto_trace(
   "(stack-trace)"
 
 #define HELP_GOTO_TRACE                                                        \
-  help_entry("--trace-json-extended", "add rawLhs property to trace")          \
-    << help_entry(                                                             \
-         "--trace-show-function-calls", "show function calls in plain trace")  \
-    << help_entry("--trace-show-code", "show original code in plain trace")    \
-    << help_entry("--trace-hex", "represent plain trace values in hex")        \
-    << help_entry("--compact-trace", "give a compact trace")                   \
-    << help_entry("--stack-trace", "give a stack trace only")
+  " {y--trace-json-extended} \t add rawLhs property to trace\n"                \
+  " {y-trace-show-function-calls} \t show function calls in plain trace\n"     \
+  " {y--trace-show-code} \t show original code in plain trace\n"               \
+  " {y--trace-hex} \t represent plain trace values in hex\n"                   \
+  " {y--compact-trace} \t give a compact trace\n"                              \
+  " {y--stack-trace} \t give a stack trace only\n"
 
 #define PARSE_OPTIONS_GOTO_TRACE(cmdline, options)                             \
   if(cmdline.isset("trace-json-extended"))                                     \

--- a/src/goto-programs/goto_trace.h
+++ b/src/goto-programs/goto_trace.h
@@ -277,12 +277,13 @@ void show_goto_trace(
   "(stack-trace)"
 
 #define HELP_GOTO_TRACE                                                        \
-  " --trace-json-extended        add rawLhs property to trace\n"               \
-  " --trace-show-function-calls  show function calls in plain trace\n"         \
-  " --trace-show-code            show original code in plain trace\n"          \
-  " --trace-hex                  represent plain trace values in hex\n"        \
-  " --compact-trace              give a compact trace\n"                       \
-  " --stack-trace                give a stack trace only\n"
+  help_entry("--trace-json-extended", "add rawLhs property to trace")          \
+    << help_entry(                                                             \
+         "--trace-show-function-calls", "show function calls in plain trace")  \
+    << help_entry("--trace-show-code", "show original code in plain trace")    \
+    << help_entry("--trace-hex", "represent plain trace values in hex")        \
+    << help_entry("--compact-trace", "give a compact trace")                   \
+    << help_entry("--stack-trace", "give a stack trace only")
 
 #define PARSE_OPTIONS_GOTO_TRACE(cmdline, options)                             \
   if(cmdline.isset("trace-json-extended"))                                     \

--- a/src/goto-programs/rebuild_goto_start_function.h
+++ b/src/goto-programs/rebuild_goto_start_function.h
@@ -21,12 +21,6 @@ class message_handlert;
 class optionst;
 class symbol_table_baset;
 
-#define OPT_FUNCTIONS \
-  "(function):"
-
-#define HELP_FUNCTIONS \
-  " --function name              set main function name\n"
-
 /// Eliminate the existing entry point function symbol and any symbols created
 /// in that scope from the \p symbol_table.
 void remove_existing_entry_point(symbol_table_baset &);

--- a/src/goto-programs/remove_calls_no_body.h
+++ b/src/goto-programs/remove_calls_no_body.h
@@ -42,7 +42,6 @@ public:
 #define OPT_REMOVE_CALLS_NO_BODY "(remove-calls-no-body)"
 
 #define HELP_REMOVE_CALLS_NO_BODY                                              \
-  help_entry(                                                                  \
-    "--remove-calls-no-body", "remove calls to functions without a body")
+  " {y--remove-calls-no-body} \t remove calls to functions without a body\n"
 
 #endif // CPROVER_GOTO_PROGRAMS_REMOVE_CALLS_NO_BODY_H

--- a/src/goto-programs/remove_calls_no_body.h
+++ b/src/goto-programs/remove_calls_no_body.h
@@ -42,6 +42,7 @@ public:
 #define OPT_REMOVE_CALLS_NO_BODY "(remove-calls-no-body)"
 
 #define HELP_REMOVE_CALLS_NO_BODY                                              \
-  " --remove-calls-no-body       remove calls to functions without a body\n"
+  help_entry(                                                                  \
+    "--remove-calls-no-body", "remove calls to functions without a body")
 
 #endif // CPROVER_GOTO_PROGRAMS_REMOVE_CALLS_NO_BODY_H

--- a/src/goto-programs/remove_const_function_pointers.h
+++ b/src/goto-programs/remove_const_function_pointers.h
@@ -110,8 +110,7 @@ private:
   "(remove-const-function-pointers)"
 
 #define HELP_REMOVE_CONST_FUNCTION_POINTERS                                    \
-  help_entry(                                                                  \
-    "--remove-const-function-pointers",                                        \
-    "remove function pointers that are constant or constant part of an array")
+  " {y--remove-const-function-pointers} \t "                                   \
+  "remove function pointers that are constant or constant part of an array\n"
 
 #endif // CPROVER_GOTO_PROGRAMS_REMOVE_CONST_FUNCTION_POINTERS_H

--- a/src/goto-programs/remove_const_function_pointers.h
+++ b/src/goto-programs/remove_const_function_pointers.h
@@ -110,8 +110,8 @@ private:
   "(remove-const-function-pointers)"
 
 #define HELP_REMOVE_CONST_FUNCTION_POINTERS                                    \
-  " --remove-const-function-pointers\n"                                        \
-  "                              remove function pointers that are constant"   \
-  " or constant part of an array\n"
+  help_entry(                                                                  \
+    "--remove-const-function-pointers",                                        \
+    "remove function pointers that are constant or constant part of an array")
 
 #endif // CPROVER_GOTO_PROGRAMS_REMOVE_CONST_FUNCTION_POINTERS_H

--- a/src/goto-programs/restrict_function_pointers.h
+++ b/src/goto-programs/restrict_function_pointers.h
@@ -47,24 +47,19 @@ class optionst;
   "(" RESTRICT_FUNCTION_POINTER_BY_NAME_OPT "):"
 
 #define HELP_RESTRICT_FUNCTION_POINTER                                         \
-  " --" RESTRICT_FUNCTION_POINTER_OPT                                          \
-  " <pointer_name>/<target[,targets]*>\n"                                      \
-  "                              restrict a function pointer to a set of "     \
-  "possible targets\n"                                                         \
-  "                              targets must all exist in the symbol table"   \
-  " with a matching type\n"                                                    \
-  "                              works for globals and function parameters"    \
-  " right now\n"                                                               \
-  " --" RESTRICT_FUNCTION_POINTER_FROM_FILE_OPT                                \
-  " <file_name>\n"                                                             \
-  "                              add function pointer restrictions from "      \
-  "file\n"                                                                     \
-  " --" RESTRICT_FUNCTION_POINTER_BY_NAME_OPT                                  \
-  " <symbol_name>/target[targets]*>\n"                                         \
-  "                              restrict a function pointer where "           \
-  " <symbol_name>\n"                                                           \
-  "                              is the unmangled name, before labelling "     \
-  "function pointers\n"
+  help_entry(                                                                  \
+    "--" RESTRICT_FUNCTION_POINTER_OPT " <pointer_name>/<target[,targets]*>",  \
+    "restrict a function pointer to a set of possible targets; targets must "  \
+    "all exist in the symbol table with a matching type; works for globals "   \
+    "and function parameters right now")                                       \
+    << help_entry(                                                             \
+         "--" RESTRICT_FUNCTION_POINTER_FROM_FILE_OPT " <file_name>",          \
+         "add function pointer restrictions from file")                        \
+    << help_entry(                                                             \
+         "--" RESTRICT_FUNCTION_POINTER_BY_NAME_OPT                            \
+         " <symbol_name>/target[targets]*>",                                   \
+         "restrict a function pointer where <symbol_name> is the unmangled "   \
+         "name, before labelling function pointers")
 
 void parse_function_pointer_restriction_options_from_cmdline(
   const cmdlinet &cmdline,

--- a/src/goto-programs/restrict_function_pointers.h
+++ b/src/goto-programs/restrict_function_pointers.h
@@ -47,19 +47,20 @@ class optionst;
   "(" RESTRICT_FUNCTION_POINTER_BY_NAME_OPT "):"
 
 #define HELP_RESTRICT_FUNCTION_POINTER                                         \
-  help_entry(                                                                  \
-    "--" RESTRICT_FUNCTION_POINTER_OPT " <pointer_name>/<target[,targets]*>",  \
-    "restrict a function pointer to a set of possible targets; targets must "  \
-    "all exist in the symbol table with a matching type; works for globals "   \
-    "and function parameters right now")                                       \
-    << help_entry(                                                             \
-         "--" RESTRICT_FUNCTION_POINTER_FROM_FILE_OPT " <file_name>",          \
-         "add function pointer restrictions from file")                        \
-    << help_entry(                                                             \
-         "--" RESTRICT_FUNCTION_POINTER_BY_NAME_OPT                            \
-         " <symbol_name>/target[targets]*>",                                   \
-         "restrict a function pointer where <symbol_name> is the unmangled "   \
-         "name, before labelling function pointers")
+  " {y--" RESTRICT_FUNCTION_POINTER_OPT                                        \
+  "} "                                                                         \
+  "{upointer_name}/{utarget[,targets]*} \t "                                   \
+  "restrict a function pointer to a set of possible targets; targets must "    \
+  "all exist in the symbol table with a matching type; works for globals "     \
+  "and function parameters right now\n"                                        \
+  " {y--" RESTRICT_FUNCTION_POINTER_FROM_FILE_OPT                              \
+  "} {ufile_name} \t "                                                         \
+  "add function pointer restrictions from file {ufile_name}\n"                 \
+  " {y--" RESTRICT_FUNCTION_POINTER_BY_NAME_OPT                                \
+  "} "                                                                         \
+  "{usymbol_name}/{utarget[targets]*} \t "                                     \
+  "restrict a function pointer where {usymbol_name} is the unmangled "         \
+  "name, before labelling function pointers\n"
 
 void parse_function_pointer_restriction_options_from_cmdline(
   const cmdlinet &cmdline,

--- a/src/goto-programs/show_goto_functions.h
+++ b/src/goto-programs/show_goto_functions.h
@@ -17,15 +17,13 @@ class goto_modelt;
 class goto_functionst;
 class ui_message_handlert;
 
-// clang-format off
 #define OPT_SHOW_GOTO_FUNCTIONS \
   "(show-goto-functions)" \
   "(list-goto-functions)"
 
-#define HELP_SHOW_GOTO_FUNCTIONS \
-  " --show-goto-functions        show loaded goto program\n" \
-  " --list-goto-functions        list loaded goto functions\n"
-// clang-format on
+#define HELP_SHOW_GOTO_FUNCTIONS                                               \
+  help_entry("--show-goto-functions", "show loaded goto program")              \
+    << help_entry("--list-goto-functions", "list loaded goto functions")
 
 void show_goto_functions(
   const namespacet &ns,

--- a/src/goto-programs/show_goto_functions.h
+++ b/src/goto-programs/show_goto_functions.h
@@ -22,8 +22,8 @@ class ui_message_handlert;
   "(list-goto-functions)"
 
 #define HELP_SHOW_GOTO_FUNCTIONS                                               \
-  help_entry("--show-goto-functions", "show loaded goto program")              \
-    << help_entry("--list-goto-functions", "list loaded goto functions")
+  " {y--show-goto-functions} \t show loaded goto program\n"                    \
+  " {y--list-goto-functions} \t list loaded goto functions\n"
 
 void show_goto_functions(
   const namespacet &ns,

--- a/src/goto-programs/show_properties.h
+++ b/src/goto-programs/show_properties.h
@@ -23,13 +23,11 @@ class goto_functionst;
 class source_locationt;
 class ui_message_handlert;
 
-// clang-format off
 #define OPT_SHOW_PROPERTIES \
   "(show-properties)"
 
-#define HELP_SHOW_PROPERTIES \
-  " --show-properties            show the properties, but don't run analysis\n" // NOLINT(*)
-// clang-format on
+#define HELP_SHOW_PROPERTIES                                                   \
+  help_entry("--show-properties", "show the properties, but don't run analysis")
 
 void show_properties(
   const goto_modelt &,

--- a/src/goto-programs/show_properties.h
+++ b/src/goto-programs/show_properties.h
@@ -27,7 +27,7 @@ class ui_message_handlert;
   "(show-properties)"
 
 #define HELP_SHOW_PROPERTIES                                                   \
-  help_entry("--show-properties", "show the properties, but don't run analysis")
+  " {y--show-properties} \t show the properties, but don't run analysis\n"
 
 void show_properties(
   const goto_modelt &,

--- a/src/goto-synthesizer/goto_synthesizer_parse_options.cpp
+++ b/src/goto-synthesizer/goto_synthesizer_parse_options.cpp
@@ -9,6 +9,7 @@ Author: Qinheping Hu
 #include "goto_synthesizer_parse_options.h"
 
 #include <util/exit_codes.h>
+#include <util/help_formatter.h>
 #include <util/version.h>
 
 #include <goto-programs/read_goto_binary.h>
@@ -218,33 +219,32 @@ optionst goto_synthesizer_parse_optionst::get_options()
 /// display command line help
 void goto_synthesizer_parse_optionst::help()
 {
-  // clang-format off
-  std::cout << '\n' << banner_string("Goto-synthesizer", CBMC_VERSION) << '\n'
+  std::cout << '\n'
+            << banner_string("Goto-synthesizer", CBMC_VERSION) << '\n'
             << align_center_with_border("Copyright (C) 2022") << '\n'
             << align_center_with_border("Qinheping Hu") << '\n'
-            << align_center_with_border("qinhh@amazon.com") << '\n'
-            <<
+            << align_center_with_border("qinhh@amazon.com") << '\n';
+
+  std::cout << help_formatter(
     "\n"
-    "Usage:                       Purpose:\n"
+    "Usage:                     \tPurpose:\n"
     "\n"
-    " goto-synthesizer [-?] [-h] [--help]  show help\n"
-    " goto-synthesizer in out              synthesize and apply loop invariants.\n" // NOLINT(*)
+    " {bgoto-synthesizer} [{y-?}] [{y-h}] [{y--help}] \t show this help\n"
+    " {bgoto-synthesizer} {y--version} \t show version and exit\n"
+    " {bgoto-synthesizer} {uin} {uout} \t synthesize and apply loop"
+    " invariants.\n"
     "\n"
-    "Main options:\n"
-    << HELP_DUMP_LOOP_CONTRACTS
-    << HELP_LOOP_CONTRACTS_NO_UNWIND
-    << "\n"
-    "Backend options:\n"
-    << HELP_CONFIG_BACKEND
-    << HELP_SOLVER
-    << "\n"
-    " --arrays-uf-never            never turn arrays into uninterpreted functions\n" // NOLINT(*)
-    " --arrays-uf-always           always turn arrays into uninterpreted functions\n" // NOLINT(*)
+    "Main options:\n" HELP_DUMP_LOOP_CONTRACTS HELP_LOOP_CONTRACTS_NO_UNWIND
+    "\n"
+    "Backend options:\n" HELP_CONFIG_BACKEND HELP_SOLVER
+    "\n"
+    " {y--arrays-uf-never} \t never turn arrays into uninterpreted functions\n"
+    " {y--arrays-uf-always} \t always turn arrays into uninterpreted"
+    " functions\n"
+    "\n"
     "Other options:\n"
-    " --version                    show version and exit\n"
-    " --xml-ui                     use XML-formatted output\n"
-    " --json-ui                    use JSON-formatted output\n"
-    " --verbosity #                verbosity level\n"
-    "\n";
-  // clang-format on
+    " {y--xml-ui} \t use XML-formatted output\n"
+    " {y--json-ui} \t use JSON-formatted output\n"
+    " {y--verbosity} {u#} \t verbosity level\n"
+    "\n");
 }

--- a/src/goto-synthesizer/goto_synthesizer_parse_options.cpp
+++ b/src/goto-synthesizer/goto_synthesizer_parse_options.cpp
@@ -231,13 +231,13 @@ void goto_synthesizer_parse_optionst::help()
     " goto-synthesizer in out              synthesize and apply loop invariants.\n" // NOLINT(*)
     "\n"
     "Main options:\n"
-    HELP_DUMP_LOOP_CONTRACTS
-    HELP_LOOP_CONTRACTS_NO_UNWIND
-    "\n"
+    << HELP_DUMP_LOOP_CONTRACTS
+    << HELP_LOOP_CONTRACTS_NO_UNWIND
+    << "\n"
     "Backend options:\n"
-    HELP_CONFIG_BACKEND
-    HELP_SOLVER
-    "\n"
+    << HELP_CONFIG_BACKEND
+    << HELP_SOLVER
+    << "\n"
     " --arrays-uf-never            never turn arrays into uninterpreted functions\n" // NOLINT(*)
     " --arrays-uf-always           always turn arrays into uninterpreted functions\n" // NOLINT(*)
     "Other options:\n"

--- a/src/json/json_interface.h
+++ b/src/json/json_interface.h
@@ -37,14 +37,12 @@ class message_handlert;
 /// \endcode
 void json_interface(cmdlinet &, message_handlert &);
 
-// clang-format off
 #define OPT_JSON_INTERFACE \
   "(json-ui)" \
   "(json-interface)"
 
-#define HELP_JSON_INTERFACE \
-  " --json-ui                    use JSON-formatted output\n" \
-  " --json-interface             bi-directional JSON interface\n"
-// clang-format on
+#define HELP_JSON_INTERFACE                                                    \
+  help_entry("--json-ui", "use JSON-formatted output")                         \
+    << help_entry("--json-interface", "bi-directional JSON interface")
 
 #endif // CPROVER_JSON_JSON_INTERFACE_H

--- a/src/json/json_interface.h
+++ b/src/json/json_interface.h
@@ -42,7 +42,7 @@ void json_interface(cmdlinet &, message_handlert &);
   "(json-interface)"
 
 #define HELP_JSON_INTERFACE                                                    \
-  help_entry("--json-ui", "use JSON-formatted output")                         \
-    << help_entry("--json-interface", "bi-directional JSON interface")
+  " {y--json-ui} \t use JSON-formatted output\n"                               \
+  " {y--json-interface} \t bi-directional JSON interface\n"
 
 #endif // CPROVER_JSON_JSON_INTERFACE_H

--- a/src/langapi/language.h
+++ b/src/langapi/language.h
@@ -30,8 +30,7 @@ class typet;
 #define OPT_FUNCTIONS \
   "(function):"
 
-#define HELP_FUNCTIONS \
-  " --function name              set main function name\n"
+#define HELP_FUNCTIONS help_entry("--function name", "set main function name")
 
 class languaget:public messaget
 {

--- a/src/langapi/language.h
+++ b/src/langapi/language.h
@@ -30,7 +30,7 @@ class typet;
 #define OPT_FUNCTIONS \
   "(function):"
 
-#define HELP_FUNCTIONS help_entry("--function name", "set main function name")
+#define HELP_FUNCTIONS " {y--function} {uname} \t set main function name\n"
 
 class languaget:public messaget
 {

--- a/src/memory-analyzer/memory_analyzer_parse_options.cpp
+++ b/src/memory-analyzer/memory_analyzer_parse_options.cpp
@@ -14,6 +14,7 @@ Author: Malte Mues <mail.mues@gmail.com>
 
 #include <util/config.h>
 #include <util/exit_codes.h>
+#include <util/help_formatter.h>
 #include <util/message.h>
 #include <util/version.h>
 
@@ -164,25 +165,29 @@ int memory_analyzer_parse_optionst::doit()
 
 void memory_analyzer_parse_optionst::help()
 {
-  std::cout
-    << '\n'
-    << banner_string("Memory-Analyzer", CBMC_VERSION) << '\n'
-    << align_center_with_border("Copyright (C) 2019") << '\n'
-    << align_center_with_border("Malte Mues, Diffblue Ltd.") << '\n'
-    << align_center_with_border("info@diffblue.com") << '\n'
-    << '\n'
-    << "Usage:                       Purpose:\n"
-    << '\n'
-    << " memory-analyzer [-?] [-h] [--help]                         show help\n"
-    << " memory-analyzer --version                                  show"
-    << " version\n"
-    << " memory-analyzer --symbols <symbol-list> <options> <binary> analyze"
-    << " binary\n"
-    << "\n"
-    << help_entry("--core-file <file>", "analyze from core file")
-    << help_entry("--breakpoint <breakpoint>", "analyze from breakpoint")
-    << help_entry("--symbols <symbol-list>", "list of symbols to analyze")
-    << help_entry("--symtab-snapshot", "output snapshot as symbol table")
-    << help_entry("--output-file <file>", "write snapshot to file")
-    << help_entry("--json-ui", "output snapshot in JSON format") << '\n';
+  std::cout << '\n'
+            << banner_string("Memory-Analyzer", CBMC_VERSION) << '\n'
+            << align_center_with_border("Copyright (C) 2019") << '\n'
+            << align_center_with_border("Malte Mues, Diffblue Ltd.") << '\n'
+            << align_center_with_border("info@diffblue.com") << '\n';
+
+  // clang-format off
+  std::cout << help_formatter(
+    "\n"
+    "Usage:                     \tPurpose:\n"
+    "\n"
+    " {bmemory-analyzer} [{y-?}] [{y-h}] [{y--help}] \t show this help\n"
+    " {bmemory-analyzer} {y--version} \t show version\n"
+    " {bmemory-analyzer} [options] {y--symbols} {usymbol-list} {ubinary} \t"
+    " analyze {ubinary}\n"
+    "\n"
+    "Main options:\n"
+    " {y--core-file} {ufile_name} \t analyze from core file {ufile_name}\n"
+    " {y--breakpoint {uname} \t analyze from breakpoint {uname}\n"
+    " {y--symbols {usymbol-list} \t list of symbols to analyze\n"
+    " {y--symtab-snapshot} \t output snapshot as symbol table\n"
+    " {y--output-file} {ufile_name} \t write snapshot to file {ufile_name}\n"
+    " {y--json-ui} \t output snapshot in JSON format\n"
+    "\n");
+  // clang-format on
 }

--- a/src/memory-analyzer/memory_analyzer_parse_options.cpp
+++ b/src/memory-analyzer/memory_analyzer_parse_options.cpp
@@ -179,11 +179,10 @@ void memory_analyzer_parse_optionst::help()
     << " memory-analyzer --symbols <symbol-list> <options> <binary> analyze"
     << " binary\n"
     << "\n"
-    << " --core-file <file>           analyze from core file\n"
-    << " --breakpoint <breakpoint>    analyze from breakpoint\n"
-    << " --symbols <symbol-list>      list of symbols to analyze\n"
-    << " --symtab-snapshot            output snapshot as symbol table\n"
-    << " --output-file <file>         write snapshot to file\n"
-    << " --json-ui                    output snapshot in JSON format\n"
-    << '\n';
+    << help_entry("--core-file <file>", "analyze from core file")
+    << help_entry("--breakpoint <breakpoint>", "analyze from breakpoint")
+    << help_entry("--symbols <symbol-list>", "list of symbols to analyze")
+    << help_entry("--symtab-snapshot", "output snapshot as symbol table")
+    << help_entry("--output-file <file>", "write snapshot to file")
+    << help_entry("--json-ui", "output snapshot in JSON format") << '\n';
 }

--- a/src/pointer-analysis/goto_program_dereference.h
+++ b/src/pointer-analysis/goto_program_dereference.h
@@ -109,10 +109,9 @@ void remove_pointers(
 
 #define OPT_REMOVE_POINTERS "(remove-pointers)"
 
-// clang-format off
 #define HELP_REMOVE_POINTERS                                                   \
-  " --remove-pointers            converts pointer arithmetic to base+offset expressions\n" /* NOLINT(whitespace/line_length) */
-
-// clang-format on
+  help_entry(                                                                  \
+    "--remove-pointers",                                                       \
+    "converts pointer arithmetic to base+offset expressions")
 
 #endif // CPROVER_POINTER_ANALYSIS_GOTO_PROGRAM_DEREFERENCE_H

--- a/src/pointer-analysis/goto_program_dereference.h
+++ b/src/pointer-analysis/goto_program_dereference.h
@@ -110,8 +110,7 @@ void remove_pointers(
 #define OPT_REMOVE_POINTERS "(remove-pointers)"
 
 #define HELP_REMOVE_POINTERS                                                   \
-  help_entry(                                                                  \
-    "--remove-pointers",                                                       \
-    "converts pointer arithmetic to base+offset expressions")
+  " {y--remove-pointers} \t "                                                  \
+  "converts pointer arithmetic to base+offset expressions\n"
 
 #endif // CPROVER_POINTER_ANALYSIS_GOTO_PROGRAM_DEREFERENCE_H

--- a/src/solvers/strings/string_refinement.h
+++ b/src/solvers/strings/string_refinement.h
@@ -28,7 +28,6 @@ Author: Alberto Griggio, alberto.griggio@gmail.com
 #include "string_dependencies.h"
 #include "string_refinement_util.h"
 
-// clang-format off
 #define OPT_STRING_REFINEMENT \
   "(no-refine-strings)" \
   "(string-printable)" \
@@ -36,17 +35,22 @@ Author: Alberto Griggio, alberto.griggio@gmail.com
   "(string-non-empty)" \
   "(max-nondet-string-length):"
 
-#define HELP_STRING_REFINEMENT \
-  " --no-refine-strings          turn off string refinement\n" \
-  " --string-printable           restrict to printable strings and characters\n" /* NOLINT(*) */ \
-  " --string-non-empty           restrict to non-empty strings (experimental)\n" /* NOLINT(*) */ \
-  " --string-input-value st      restrict non-null strings to a fixed value st;\n" /* NOLINT(*) */ \
-  "                              the switch can be used multiple times to give\n" /* NOLINT(*) */ \
-  "                              several strings\n" /* NOLINT(*) */ \
-  " --max-nondet-string-length n bound the length of nondet (e.g. input) strings.\n" /* NOLINT(*) */ \
-  "                              Default is " + std::to_string(MAX_CONCRETE_STRING_SIZE - 1) + "; note that\n" /* NOLINT(*) */ \
-  "                              setting the value higher than this does not work\n" /* NOLINT(*) */ \
-  "                              with --trace or --validate-trace.\n" /* NOLINT(*) */
+#define HELP_STRING_REFINEMENT                                                 \
+  help_entry("--no-refine-strings", "turn off string refinement")              \
+    << help_entry(                                                             \
+         "--string-printable", "restrict to printable strings and characters") \
+    << help_entry(                                                             \
+         "--string-non-empty", "restrict to non-empty strings (experimental)") \
+    << help_entry(                                                             \
+         "--string-input-value st",                                            \
+         "restrict non-null strings to a fixed value st; the switch can be "   \
+         "used multiple times to give several strings")                        \
+    << help_entry(                                                             \
+         "--max-nondet-string-length_n",                                       \
+         "bound the length of nondet (e.g. input) strings. Default is " +      \
+           std::to_string(MAX_CONCRETE_STRING_SIZE - 1) +                      \
+           "; note that setting the value higher than this does not work "     \
+           "with --trace or --validate-trace.")
 
 // The integration of the string solver into CBMC is incomplete. Therefore,
 // it is not turned on by default and not all options are available.
@@ -54,10 +58,10 @@ Author: Alberto Griggio, alberto.griggio@gmail.com
   "(refine-strings)" \
   "(string-printable)"
 
-#define HELP_STRING_REFINEMENT_CBMC \
-  " --refine-strings             use string refinement (experimental)\n" \
-  " --string-printable           restrict to printable strings (experimental)\n" /* NOLINT(*) */
-// clang-format on
+#define HELP_STRING_REFINEMENT_CBMC                                            \
+  help_entry("--refine-strings", "use string refinement (experimental)")       \
+    << help_entry(                                                             \
+         "--string-printable", "restrict to printable strings (experimental)")
 
 #define DEFAULT_MAX_NB_REFINEMENT std::numeric_limits<size_t>::max()
 

--- a/src/solvers/strings/string_refinement.h
+++ b/src/solvers/strings/string_refinement.h
@@ -36,21 +36,17 @@ Author: Alberto Griggio, alberto.griggio@gmail.com
   "(max-nondet-string-length):"
 
 #define HELP_STRING_REFINEMENT                                                 \
-  help_entry("--no-refine-strings", "turn off string refinement")              \
-    << help_entry(                                                             \
-         "--string-printable", "restrict to printable strings and characters") \
-    << help_entry(                                                             \
-         "--string-non-empty", "restrict to non-empty strings (experimental)") \
-    << help_entry(                                                             \
-         "--string-input-value st",                                            \
-         "restrict non-null strings to a fixed value st; the switch can be "   \
-         "used multiple times to give several strings")                        \
-    << help_entry(                                                             \
-         "--max-nondet-string-length_n",                                       \
-         "bound the length of nondet (e.g. input) strings. Default is " +      \
-           std::to_string(MAX_CONCRETE_STRING_SIZE - 1) +                      \
-           "; note that setting the value higher than this does not work "     \
-           "with --trace or --validate-trace.")
+  " {y--no-refine-strings} \t turn off string refinement\n"                    \
+  " {y--string-printable} \t restrict to printable strings and characters\n"   \
+  " {y--string-non-empty} \t restrict to non-empty strings (experimental)\n"   \
+  " {y--string-input-value} {ust} \t "                                         \
+  "restrict non-null strings to a fixed value {ust}; the switch can be used "  \
+  "multiple times to give several strings\n"                                   \
+  " {y--max-nondet-string-length} {un} \t "                                    \
+  "bound the length of nondet (e.g. input) strings. Default is " +             \
+    std::to_string(MAX_CONCRETE_STRING_SIZE - 1) +                             \
+    "; note that setting the value higher than this does not work "            \
+    "with {y--trace} or {y--validate-trace}.\n"
 
 // The integration of the string solver into CBMC is incomplete. Therefore,
 // it is not turned on by default and not all options are available.
@@ -59,9 +55,8 @@ Author: Alberto Griggio, alberto.griggio@gmail.com
   "(string-printable)"
 
 #define HELP_STRING_REFINEMENT_CBMC                                            \
-  help_entry("--refine-strings", "use string refinement (experimental)")       \
-    << help_entry(                                                             \
-         "--string-printable", "restrict to printable strings (experimental)")
+  " {y--refine-strings} \t use string refinement (experimental)\n"             \
+  " {y--string-printable} \t restrict to printable strings (experimental)\n"
 
 #define DEFAULT_MAX_NB_REFINEMENT std::numeric_limits<size_t>::max()
 

--- a/src/symtab2gb/symtab2gb_parse_options.cpp
+++ b/src/symtab2gb/symtab2gb_parse_options.cpp
@@ -162,9 +162,8 @@ void symtab2gb_parse_optionst::help()
        "  [--out <outfile>]\n\n"
        "<json-symtab-file>                       a CBMC symbol table in\n"
        "                                         JSON format\n"
-       "--out <outfile>                          specify the filename of\n"
-       "                                         the resulting binary\n"
-       "                                         (default: a.out)\n"
-       " --verbosity #                verbosity level\n"
-    << messaget::eom;
+    << help_entry(
+         "--out <outfile>",
+         "specify the filename of the resulting binary (default: a.out)")
+    << help_entry("--verbosity #", "verbosity level") << messaget::eom;
 }

--- a/src/symtab2gb/symtab2gb_parse_options.cpp
+++ b/src/symtab2gb/symtab2gb_parse_options.cpp
@@ -8,25 +8,24 @@ Author: Diffblue Ltd.
 
 #include "symtab2gb_parse_options.h"
 
-#include <fstream>
-#include <iostream>
-#include <string>
-
-#include <ansi-c/ansi_c_language.h>
+#include <util/config.h>
+#include <util/exception_utils.h>
+#include <util/exit_codes.h>
+#include <util/help_formatter.h>
+#include <util/version.h>
 
 #include <goto-programs/goto_convert_functions.h>
 #include <goto-programs/goto_model.h>
 #include <goto-programs/write_goto_binary.h>
 
+#include <ansi-c/ansi_c_language.h>
 #include <json-symtab-language/json_symtab_language.h>
 #include <langapi/mode.h>
-
 #include <linking/linking.h>
 
-#include <util/config.h>
-#include <util/exception_utils.h>
-#include <util/exit_codes.h>
-#include <util/version.h>
+#include <fstream>
+#include <iostream>
+#include <string>
 
 symtab2gb_parse_optionst::symtab2gb_parse_optionst(int argc, const char *argv[])
   : parse_options_baset{SYMTAB2GB_OPTIONS,
@@ -147,23 +146,23 @@ int symtab2gb_parse_optionst::doit()
 
 void symtab2gb_parse_optionst::help()
 {
-  log.status()
-    << '\n'
-    << banner_string("symtab2gb", CBMC_VERSION) << '\n'
-    << align_center_with_border("Copyright (C) 2019") << '\n'
-    << align_center_with_border("Diffblue Ltd.") << '\n'
-    << align_center_with_border("info@diffblue.com") << '\n'
-    << '\n'
-    << "Usage:                                   Purpose:\n"
-    << '\n'
-    << "symtab2gb [-?] [-h] [--help]             show help\n"
-       "symtab2gb                                compile .json_symtabs\n"
-       "  <json-symtab-file>+                    to a single goto-binary\n"
-       "  [--out <outfile>]\n\n"
-       "<json-symtab-file>                       a CBMC symbol table in\n"
-       "                                         JSON format\n"
-    << help_entry(
-         "--out <outfile>",
-         "specify the filename of the resulting binary (default: a.out)")
-    << help_entry("--verbosity #", "verbosity level") << messaget::eom;
+  log.status() << '\n'
+               << banner_string("symtab2gb", CBMC_VERSION) << '\n'
+               << align_center_with_border("Copyright (C) 2019") << '\n'
+               << align_center_with_border("Diffblue Ltd.") << '\n'
+               << align_center_with_border("info@diffblue.com") << '\n';
+
+  log.status() << help_formatter(
+    "\n"
+    "Usage:                                  \tPurpose:\n"
+    "\n"
+    " {bsymtab2gb} [{y-?}] [{y-h}] [{y--help}] \t show this help\n"
+    " {bsymtab2gb} [options] {ujson-symtab-file...} \t compile CBMC symbol"
+    " table(s) in JSON format to a single goto-binary\n"
+    "\n"
+    "Options:\n"
+    " {y--out} {uoutfile} \t specify the filename of the resulting binary"
+    " (default: a.out)\n"
+    " {y--verbosity} {u#} \t verbosity level\n");
+  log.status() << messaget::eom;
 }

--- a/src/util/config.h
+++ b/src/util/config.h
@@ -30,63 +30,55 @@ class symbol_table_baset;
   "(no-library)"
 
 #define HELP_CONFIG_C_CPP                                                      \
-  help_entry("-I path", "set include path (C/C++)")                            \
-    << help_entry("--include file", "set include file (C/C++)")                \
-    << help_entry("-D macro", "define preprocessor macro (C/C++)")             \
-    << help_entry(                                                             \
-         "--c89, --c99, --c11",                                                \
-         "set C language standard (default: " +                                \
-           std::string(                                                        \
-             configt::ansi_ct::default_c_standard() ==                         \
-                 configt::ansi_ct::c_standardt::C89                            \
-               ? "c89"                                                         \
-             : configt::ansi_ct::default_c_standard() ==                       \
-                 configt::ansi_ct::c_standardt::C99                            \
-               ? "c99"                                                         \
-             : configt::ansi_ct::default_c_standard() ==                       \
-                 configt::ansi_ct::c_standardt::C11                            \
-               ? "c11"                                                         \
-               : "") +                                                         \
-           ")")                                                                \
-    << help_entry(                                                             \
-         "--cpp98, --cpp03, --cpp11",                                          \
-         "set C++ language standard (default: " +                              \
-           std::string(                                                        \
-             configt::cppt::default_cpp_standard() ==                          \
-                 configt::cppt::cpp_standardt::CPP98                           \
-               ? "cpp98"                                                       \
-             : configt::cppt::default_cpp_standard() ==                        \
-                 configt::cppt::cpp_standardt::CPP03                           \
-               ? "cpp03"                                                       \
-             : configt::cppt::default_cpp_standard() ==                        \
-                 configt::cppt::cpp_standardt::CPP11                           \
-               ? "cpp11"                                                       \
-               : "") +                                                         \
-           ")")                                                                \
-    << help_entry("--unsigned-char", "make \"char\" unsigned by default")      \
-    << help_entry(                                                             \
-         "--round-to-nearest, --round-to-even",                                \
-         "rounding towards nearest even (default)")                            \
-    << help_entry("--round-to-plus-inf", "rounding towards plus infinity")     \
-    << help_entry("--round-to-minus-inf", "rounding towards minus infinity")   \
-    << help_entry("--round-to-zero", "rounding towards zero")                  \
-    << help_entry("--no-library", "disable built-in abstract C library")
+  " {y-I} {upath} \t set include path (C/C++)\n"                               \
+  " {y--include} {ufile} \t set include file (C/C++)\n"                        \
+  " {y-D} {umacro} \t define preprocessor macro (C/C++)\n"                     \
+  " {y--c89}, {y--c99}, {y--c11} \t "                                          \
+  "set C language standard (default: " +                                       \
+    std::string(                                                               \
+      configt::ansi_ct::default_c_standard() ==                                \
+          configt::ansi_ct::c_standardt::C89                                   \
+        ? "c89"                                                                \
+      : configt::ansi_ct::default_c_standard() ==                              \
+          configt::ansi_ct::c_standardt::C99                                   \
+        ? "c99"                                                                \
+      : configt::ansi_ct::default_c_standard() ==                              \
+          configt::ansi_ct::c_standardt::C11                                   \
+        ? "c11"                                                                \
+        : "") +                                                                \
+    ")\n"                                                                      \
+    " {y--cpp98}, {y--cpp03}, {y--cpp11} \t "                                  \
+    "set C++ language standard (default: " +                                   \
+    std::string(                                                               \
+      configt::cppt::default_cpp_standard() ==                                 \
+          configt::cppt::cpp_standardt::CPP98                                  \
+        ? "cpp98"                                                              \
+      : configt::cppt::default_cpp_standard() ==                               \
+          configt::cppt::cpp_standardt::CPP03                                  \
+        ? "cpp03"                                                              \
+      : configt::cppt::default_cpp_standard() ==                               \
+          configt::cppt::cpp_standardt::CPP11                                  \
+        ? "cpp11"                                                              \
+        : "") +                                                                \
+    ")\n"                                                                      \
+    " {y--unsigned-char} \t make \"char\" unsigned by default\n"               \
+    " {y--round-to-nearest}, {y--round-to-even} \t "                           \
+    "rounding towards nearest even (default)\n"                                \
+    " {y--round-to-plus-inf} \t rounding towards plus infinity\n"              \
+    " {y--round-to-minus-inf} \t rounding towards minus infinity\n"            \
+    " {y--round-to-zero} \t rounding towards zero\n"                           \
+    " {y--no-library} \t disable built-in abstract C library\n"
 
 #define OPT_CONFIG_LIBRARY                                                     \
   "(malloc-fail-assert)(malloc-fail-null)(malloc-may-fail)"                    \
   "(string-abstraction)"
 
 #define HELP_CONFIG_LIBRARY                                                    \
-  help_entry(                                                                  \
-    "--malloc-may-fail", "allow malloc calls to return a null pointer")        \
-    << help_entry(                                                             \
-         "--malloc-fail-assert",                                               \
-         "set malloc failure mode to assert-then-assume")                      \
-    << help_entry(                                                             \
-         "--malloc-fail-null", "set malloc failure mode to return null")       \
-    << help_entry(                                                             \
-         "--string-abstraction",                                               \
-         "track C string lengths and zero-termination")
+  " {y--malloc-may-fail} \t allow malloc calls to return a null pointer\n"     \
+  " {y--malloc-fail-assert} \t "                                               \
+  "set malloc failure mode to assert-then-assume\n"                            \
+  " {y--malloc-fail-null} \t set malloc failure mode to return null\n"         \
+  " {y--string-abstraction} \t track C string lengths and zero-termination\n"
 
 #define OPT_CONFIG_JAVA "(classpath)(cp)(main-class)"
 
@@ -100,38 +92,36 @@ class symbol_table_baset;
   "(gcc)"
 
 #define HELP_CONFIG_PLATFORM                                                   \
-  help_entry(                                                                  \
-    "--arch",                                                                  \
-    "set architecture (default: " + id2string(configt::this_architecture()) +  \
-      ") to one of: alpha, arm, arm64, armel, armhf, hppa, i386, ia64, mips, " \
-      "mips64, mips64el, mipsel, mipsn32, mipsn32el, powerpc, ppc64, "         \
-      "ppc64le, riscv64, s390, s390x, sh4, sparc, sparc64, v850, x32, "        \
-      "x86_64, or none")                                                       \
-    << help_entry(                                                             \
-         "--os",                                                               \
-         "set operating system (default: " +                                   \
-           id2string(configt::this_operating_system()) +                       \
-           ") to one of: freebsd, linux, macos, solaris, or windows")          \
-    << help_entry(                                                             \
-         "--i386-linux, --i386-win32, --i386-macos, --ppc-macos, --win32, "    \
-         "--winx64",                                                           \
-         "set architecture and operating system")                              \
-    << help_entry(                                                             \
-         "--LP64, --ILP64, --LLP64, --ILP32, --LP32",                          \
-         "set width of int, long and pointers, but don't override default "    \
-         "architecture and operating system")                                  \
-    << help_entry(                                                             \
-         "--16, --32, --64",                                                   \
-         "equivalent to --LP32, --ILP32, --LP64 (on Windows: --LLP64)")        \
-    << help_entry(                                                             \
-         "--little-endian", "allow little-endian word-byte conversions")       \
-    << help_entry("--big-endian", "allow big-endian word-byte conversions")    \
-    << help_entry("--gcc", "use GCC as preprocessor")
+  " {y--arch} {uarch_name} \t "                                                \
+  "set architecture (default: " +                                              \
+    id2string(configt::this_architecture()) +                                  \
+    ") to one of: {yalpha}, {yarm}, {yarm64}, {yarmel}, {yarmhf}, {yhppa}, "   \
+    "{yi386}, {yia64}, {ymips}, {ymips64}, {ymips64el}, {ymipsel}, "           \
+    "{ymipsn32}, "                                                             \
+    "{ymipsn32el}, {ypowerpc}, {yppc64}, {yppc64le}, {yriscv64}, {ys390}, "    \
+    "{ys390x}, {ysh4}, {ysparc}, {ysparc64}, {yv850}, {yx32}, {yx86_64}, or "  \
+    "{ynone}\n"                                                                \
+    " {y--os} {uos_name} \t "                                                  \
+    "set operating system (default: " +                                        \
+    id2string(configt::this_operating_system()) +                              \
+    ") to one of: {yfreebsd}, {ylinux}, {ymacos}, {ysolaris}, or {ywindows}\n" \
+    " {y--i386-linux}, {y--i386-win32}, {y--i386-macos}, {y--ppc-macos}, "     \
+    "{y--win32}, {y--winx64} \t "                                              \
+    "set architecture and operating system\n"                                  \
+    " {y--LP64}, {y--ILP64}, {y--LLP64}, {y--ILP32}, {y--LP32} \t "            \
+    "set width of int, long and pointers, but don't override default "         \
+    "architecture and operating system\n"                                      \
+    " {y--16}, {y--32}, {y--64} \t "                                           \
+    "equivalent to {y--LP32}, {y--ILP32}, {y--LP64} (on Windows: "             \
+    "{y--LLP64})\n"                                                            \
+    " {y--little-endian} \t allow little-endian word-byte conversions\n"       \
+    " {y--big-endian} \t allow big-endian word-byte conversions\n"             \
+    " {y--gcc} \t use GCC as preprocessor\n"
 
 #define OPT_CONFIG_BACKEND "(object-bits):"
 
 #define HELP_CONFIG_BACKEND                                                    \
-  help_entry("--object-bits n", "number of bits used for object addresses")
+  " {y--object-bits} {un} \t number of bits used for object addresses\n"
 
 /*! \brief Globally accessible architectural configuration
 */

--- a/src/util/config.h
+++ b/src/util/config.h
@@ -21,56 +21,74 @@ class symbol_table_baset;
 // Configt is the one place beyond *_parse_options where options are ... parsed.
 // Options that are handled by configt are documented here.
 
-// clang-format off
 #define OPT_CONFIG_C_CPP                                                       \
   "D:I:(include)(function)"                                                    \
   "(c89)(c99)(c11)(cpp98)(cpp03)(cpp11)"                                       \
   "(unsigned-char)"                                                            \
   "(round-to-even)(round-to-nearest)"                                          \
   "(round-to-plus-inf)(round-to-minus-inf)(round-to-zero)"                     \
-  "(no-library)"                                                               \
+  "(no-library)"
 
 #define HELP_CONFIG_C_CPP                                                      \
-  " -I path                      set include path (C/C++)\n"                   \
-  " --include file               set include file (C/C++)\n"                   \
-  " -D macro                     define preprocessor macro (C/C++)\n"          \
-  " --c89, --c99, --c11          set C language standard (default: "           \
-                                 << (configt::ansi_ct::default_c_standard()==  \
-                                     configt::ansi_ct::c_standardt::C89?"c89": \
-                                     configt::ansi_ct::default_c_standard()==  \
-                                     configt::ansi_ct::c_standardt::C99?"c99": \
-                                     configt::ansi_ct::default_c_standard()==  \
-                          configt::ansi_ct::c_standardt::C11?"c11":"") << ")\n"\
-  " --cpp98, --cpp03, --cpp11    set C++ language standard (default: "         \
-                                 << (configt::cppt::default_cpp_standard()==   \
-                                   configt::cppt::cpp_standardt::CPP98?"cpp98":\
-                                     configt::cppt::default_cpp_standard()==   \
-                                   configt::cppt::cpp_standardt::CPP03?"cpp03":\
-                                     configt::cppt::default_cpp_standard()==   \
-                       configt::cppt::cpp_standardt::CPP11?"cpp11":"") << ")\n"\
-  " --unsigned-char              make \"char\" unsigned by default\n"          \
-  " --round-to-nearest, --round-to-even\n"                                     \
-  "                              rounding towards nearest even (default)\n"    \
-  " --round-to-plus-inf          rounding towards plus infinity\n"             \
-  " --round-to-minus-inf         rounding towards minus infinity\n"            \
-  " --round-to-zero              rounding towards zero\n"                      \
-  " --no-library                 disable built-in abstract C library\n"        \
-
+  help_entry("-I path", "set include path (C/C++)")                            \
+    << help_entry("--include file", "set include file (C/C++)")                \
+    << help_entry("-D macro", "define preprocessor macro (C/C++)")             \
+    << help_entry(                                                             \
+         "--c89, --c99, --c11",                                                \
+         "set C language standard (default: " +                                \
+           std::string(                                                        \
+             configt::ansi_ct::default_c_standard() ==                         \
+                 configt::ansi_ct::c_standardt::C89                            \
+               ? "c89"                                                         \
+             : configt::ansi_ct::default_c_standard() ==                       \
+                 configt::ansi_ct::c_standardt::C99                            \
+               ? "c99"                                                         \
+             : configt::ansi_ct::default_c_standard() ==                       \
+                 configt::ansi_ct::c_standardt::C11                            \
+               ? "c11"                                                         \
+               : "") +                                                         \
+           ")")                                                                \
+    << help_entry(                                                             \
+         "--cpp98, --cpp03, --cpp11",                                          \
+         "set C++ language standard (default: " +                              \
+           std::string(                                                        \
+             configt::cppt::default_cpp_standard() ==                          \
+                 configt::cppt::cpp_standardt::CPP98                           \
+               ? "cpp98"                                                       \
+             : configt::cppt::default_cpp_standard() ==                        \
+                 configt::cppt::cpp_standardt::CPP03                           \
+               ? "cpp03"                                                       \
+             : configt::cppt::default_cpp_standard() ==                        \
+                 configt::cppt::cpp_standardt::CPP11                           \
+               ? "cpp11"                                                       \
+               : "") +                                                         \
+           ")")                                                                \
+    << help_entry("--unsigned-char", "make \"char\" unsigned by default")      \
+    << help_entry(                                                             \
+         "--round-to-nearest, --round-to-even",                                \
+         "rounding towards nearest even (default)")                            \
+    << help_entry("--round-to-plus-inf", "rounding towards plus infinity")     \
+    << help_entry("--round-to-minus-inf", "rounding towards minus infinity")   \
+    << help_entry("--round-to-zero", "rounding towards zero")                  \
+    << help_entry("--no-library", "disable built-in abstract C library")
 
 #define OPT_CONFIG_LIBRARY                                                     \
   "(malloc-fail-assert)(malloc-fail-null)(malloc-may-fail)"                    \
-  "(string-abstraction)"                                                       \
+  "(string-abstraction)"
 
 #define HELP_CONFIG_LIBRARY                                                    \
-" --malloc-may-fail            allow malloc calls to return a null pointer\n"  \
-" --malloc-fail-assert         set malloc failure mode to assert-then-assume\n"\
-" --malloc-fail-null           set malloc failure mode to return null\n"       \
-" --string-abstraction         track C string lengths and zero-termination\n"  \
+  help_entry(                                                                  \
+    "--malloc-may-fail", "allow malloc calls to return a null pointer")        \
+    << help_entry(                                                             \
+         "--malloc-fail-assert",                                               \
+         "set malloc failure mode to assert-then-assume")                      \
+    << help_entry(                                                             \
+         "--malloc-fail-null", "set malloc failure mode to return null")       \
+    << help_entry(                                                             \
+         "--string-abstraction",                                               \
+         "track C string lengths and zero-termination")
 
-
-#define OPT_CONFIG_JAVA                                                        \
-  "(classpath)(cp)(main-class)"                                                \
-
+#define OPT_CONFIG_JAVA "(classpath)(cp)(main-class)"
 
 #define OPT_CONFIG_PLATFORM                                                    \
   "(arch):(os):"                                                               \
@@ -79,39 +97,41 @@ class symbol_table_baset;
   "(i386-linux)"                                                               \
   "(i386-win32)(win32)(winx64)"                                                \
   "(i386-macos)(ppc-macos)"                                                    \
-  "(gcc)"                                                                      \
+  "(gcc)"
 
-#define HELP_CONFIG_PLATFORM \
-  " --arch <arch>                set architecture (default: "                  \
-                                 << configt::this_architecture() << ")\n"      \
-  "                              to one of: alpha, arm, arm64, armel, armhf,\n"\
-  "                              hppa, i386, ia64, mips, mips64, mips64el,\n"  \
-  "                              mipsel, mipsn32, mipsn32el, powerpc, ppc64,\n"\
-  "                              ppc64le, riscv64, s390, s390x, sh4, sparc,\n" \
-  "                              sparc64, v850, x32, x86_64, or none\n"        \
-  " --os <os>                    set operating system (default: "              \
-                                 << configt::this_operating_system() << ")\n"  \
-  "                              to one of: freebsd, linux, macos, solaris,\n" \
-  "                              or windows\n"                                 \
-  " --i386-linux, --i386-win32, --i386-macos, --ppc-macos\n"                   \
-  "   --win32, --winx64          set architecture and operating system\n"      \
-  " --LP64, --ILP64, --LLP64,\n"                                               \
-  "   --ILP32, --LP32            set width of int, long and pointers, but\n"   \
-  "                              don't override default architecture and\n"    \
-  "                              operating system\n"                           \
-  " --16, --32, --64             equivalent to --LP32, --ILP32, --LP64 (on\n"  \
-  "                              Windows: --LLP64)\n"                          \
-  " --little-endian              allow little-endian word-byte conversions\n"  \
-  " --big-endian                 allow big-endian word-byte conversions\n"     \
-  " --gcc                        use GCC as preprocessor\n"                    \
+#define HELP_CONFIG_PLATFORM                                                   \
+  help_entry(                                                                  \
+    "--arch",                                                                  \
+    "set architecture (default: " + id2string(configt::this_architecture()) +  \
+      ") to one of: alpha, arm, arm64, armel, armhf, hppa, i386, ia64, mips, " \
+      "mips64, mips64el, mipsel, mipsn32, mipsn32el, powerpc, ppc64, "         \
+      "ppc64le, riscv64, s390, s390x, sh4, sparc, sparc64, v850, x32, "        \
+      "x86_64, or none")                                                       \
+    << help_entry(                                                             \
+         "--os",                                                               \
+         "set operating system (default: " +                                   \
+           id2string(configt::this_operating_system()) +                       \
+           ") to one of: freebsd, linux, macos, solaris, or windows")          \
+    << help_entry(                                                             \
+         "--i386-linux, --i386-win32, --i386-macos, --ppc-macos, --win32, "    \
+         "--winx64",                                                           \
+         "set architecture and operating system")                              \
+    << help_entry(                                                             \
+         "--LP64, --ILP64, --LLP64, --ILP32, --LP32",                          \
+         "set width of int, long and pointers, but don't override default "    \
+         "architecture and operating system")                                  \
+    << help_entry(                                                             \
+         "--16, --32, --64",                                                   \
+         "equivalent to --LP32, --ILP32, --LP64 (on Windows: --LLP64)")        \
+    << help_entry(                                                             \
+         "--little-endian", "allow little-endian word-byte conversions")       \
+    << help_entry("--big-endian", "allow big-endian word-byte conversions")    \
+    << help_entry("--gcc", "use GCC as preprocessor")
 
-#define OPT_CONFIG_BACKEND                                                     \
-  "(object-bits):"                                                             \
+#define OPT_CONFIG_BACKEND "(object-bits):"
 
 #define HELP_CONFIG_BACKEND                                                    \
-  " --object-bits n              number of bits used for object addresses\n"
-
-// clang-format on
+  help_entry("--object-bits n", "number of bits used for object addresses")
 
 /*! \brief Globally accessible architectural configuration
 */

--- a/src/util/parse_options.cpp
+++ b/src/util/parse_options.cpp
@@ -8,8 +8,6 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "parse_options.h"
 
-#include <algorithm>
-#include <cctype>
 #include <climits>
 
 #if defined (_WIN32)
@@ -177,55 +175,4 @@ banner_string(const std::string &front_end, const std::string &version)
                                   "-bit";
 
   return align_center_with_border(version_str);
-}
-
-std::string help_entry(
-  const std::string &option,
-  const std::string &description,
-  const std::size_t left_margin,
-  const std::size_t width)
-{
-  PRECONDITION(!option.empty());
-  PRECONDITION(!std::isspace(option.front()));
-  PRECONDITION(!std::isspace(option.back()));
-  PRECONDITION(option.length() <= width);
-
-  PRECONDITION(!description.empty());
-  PRECONDITION(!std::isspace(description.front()));
-  PRECONDITION(!std::isspace(description.back()));
-
-  PRECONDITION(left_margin < width);
-
-  std::string result;
-
-  if(option.length() >= left_margin - 1)
-  {
-    result = " " + option + "\n";
-    result += wrap_line(description, left_margin, width) + "\n";
-
-    return result;
-  }
-
-  std::string padding(left_margin - option.length() - 1, ' ');
-  result = " " + option + padding;
-
-  if(description.length() <= (width - left_margin))
-  {
-    return result + description + "\n";
-  }
-
-  auto it = description.cbegin() + (width - left_margin);
-  auto rit = std::reverse_iterator<decltype(it)>(it) - 1;
-
-  auto rit_space = std::find(rit, description.crend(), ' ');
-  auto it_space = rit_space.base() - 1;
-  CHECK_RETURN(*it_space == ' ');
-
-  result.append(description.cbegin(), it_space);
-  result.append("\n");
-
-  result +=
-    wrap_line(it_space + 1, description.cend(), left_margin, width) + "\n";
-
-  return result;
 }

--- a/src/util/parse_options.h
+++ b/src/util/parse_options.h
@@ -65,10 +65,4 @@ banner_string(const std::string &front_end, const std::string &version);
 /// ```
 std::string align_center_with_border(const std::string &text);
 
-std::string help_entry(
-  const std::string &option,
-  const std::string &description,
-  const std::size_t left_margin = 30,
-  const std::size_t width = 80);
-
 #endif // CPROVER_UTIL_PARSE_OPTIONS_H

--- a/src/util/timestamper.h
+++ b/src/util/timestamper.h
@@ -11,10 +11,11 @@
 #else
 #define OPT_TIMESTAMP "(timestamp):"
 
-#define HELP_TIMESTAMP                                                         \
-  " --timestamp <monotonic|wall> print microsecond-precision timestamps.\n"    \
-  "                              monotonic: stamps increase monotonically.\n"  \
-  "                              wall: ISO-8601 wall clock timestamps.\n"
+#  define HELP_TIMESTAMP                                                       \
+    help_entry(                                                                \
+      "--timestamp <monotonic|wall>",                                          \
+      "print microsecond-precision timestamps. monotonic: stamps increase "    \
+      "monotonically. wall: ISO-8601 wall clock timestamps.")
 #endif
 
 #include <memory>

--- a/src/util/timestamper.h
+++ b/src/util/timestamper.h
@@ -12,10 +12,9 @@
 #define OPT_TIMESTAMP "(timestamp):"
 
 #  define HELP_TIMESTAMP                                                       \
-    help_entry(                                                                \
-      "--timestamp <monotonic|wall>",                                          \
-      "print microsecond-precision timestamps. monotonic: stamps increase "    \
-      "monotonically. wall: ISO-8601 wall clock timestamps.")
+    " {y--timestamp} [{ymonotonic}|{ywall}] \t "                               \
+    "print microsecond-precision timestamps. {ymonotonic}: stamps increase "   \
+    "monotonically. {ywall}: ISO-8601 wall clock timestamps.\n"
 #endif
 
 #include <memory>

--- a/src/util/ui_message.h
+++ b/src/util/ui_message.h
@@ -105,6 +105,6 @@ protected:
 
 #define OPT_FLUSH "(flush)"
 
-#define HELP_FLUSH " --flush                      flush every line of output\n"
+#define HELP_FLUSH help_entry("--flush", "flush every line of output")
 
 #endif // CPROVER_UTIL_UI_MESSAGE_H

--- a/src/util/ui_message.h
+++ b/src/util/ui_message.h
@@ -105,6 +105,6 @@ protected:
 
 #define OPT_FLUSH "(flush)"
 
-#define HELP_FLUSH help_entry("--flush", "flush every line of output")
+#define HELP_FLUSH " {y--flush} \t flush every line of output\n"
 
 #endif // CPROVER_UTIL_UI_MESSAGE_H

--- a/src/util/validation_interface.h
+++ b/src/util/validation_interface.h
@@ -14,11 +14,11 @@ Author: Daniel Poetzl
   "(validate-ssa-equation)"
 
 #define HELP_VALIDATE                                                          \
-  " --validate-goto-model        enable additional well-formedness checks on " \
-  "the\n"                                                                      \
-  "                              goto program\n"                               \
-  " --validate-ssa-equation      enable additional well-formedness checks on " \
-  "the\n"                                                                      \
-  "                              SSA representation\n"
+  help_entry(                                                                  \
+    "--validate-goto-model",                                                   \
+    "enable additional well-formedness checks on the goto program")            \
+    << help_entry(                                                             \
+         "--validate-ssa-equation",                                            \
+         "enable additional well-formedness checks on the SSA representation")
 
 #endif /* CPROVER_UTIL_VALIDATION_INTERFACE_H */

--- a/src/util/validation_interface.h
+++ b/src/util/validation_interface.h
@@ -14,11 +14,9 @@ Author: Daniel Poetzl
   "(validate-ssa-equation)"
 
 #define HELP_VALIDATE                                                          \
-  help_entry(                                                                  \
-    "--validate-goto-model",                                                   \
-    "enable additional well-formedness checks on the goto program")            \
-    << help_entry(                                                             \
-         "--validate-ssa-equation",                                            \
-         "enable additional well-formedness checks on the SSA representation")
+  " {y--validate-goto-model} \t "                                              \
+  "enable additional well-formedness checks on the goto program\n"             \
+  " {y--validate-ssa-equation} \t "                                            \
+  "enable additional well-formedness checks on the SSA representation\n"
 
 #endif /* CPROVER_UTIL_VALIDATION_INTERFACE_H */

--- a/src/xmllang/xml_interface.h
+++ b/src/xmllang/xml_interface.h
@@ -37,8 +37,8 @@ void xml_interface(cmdlinet &, message_handlert &);
   "(xml-interface)"
 
 #define HELP_XML_INTERFACE \
-  " --xml-ui                     use XML-formatted output\n" \
-  " --xml-interface              bi-directional XML interface\n"
+  help_entry("--xml-ui", "use XML-formatted output") \
+  << help_entry("--xml-interface", "bi-directional XML interface")
 // clang-format on
 
 #endif // CPROVER_XMLLANG_XML_INTERFACE_H

--- a/src/xmllang/xml_interface.h
+++ b/src/xmllang/xml_interface.h
@@ -37,8 +37,8 @@ void xml_interface(cmdlinet &, message_handlert &);
   "(xml-interface)"
 
 #define HELP_XML_INTERFACE \
-  help_entry("--xml-ui", "use XML-formatted output") \
-  << help_entry("--xml-interface", "bi-directional XML interface")
+  " {y--xml-ui} \t use XML-formatted output\n" \
+  " {y--xml-interface} \t bi-directional XML interface\n"
 // clang-format on
 
 #endif // CPROVER_XMLLANG_XML_INTERFACE_H

--- a/unit/Makefile
+++ b/unit/Makefile
@@ -144,6 +144,7 @@ SRC += analyses/ai/ai.cpp \
        util/format_number_range.cpp \
        util/get_base_name.cpp \
        util/graph.cpp \
+       util/help_formatter.cpp \
        util/interval/add.cpp \
        util/interval/bitwise.cpp \
        util/interval/comparisons.cpp \

--- a/unit/util/help_formatter.cpp
+++ b/unit/util/help_formatter.cpp
@@ -1,0 +1,21 @@
+/******************************************************************\
+
+Module: help formatter unit tests
+
+Author: Michael Tautschnig
+
+\******************************************************************/
+
+#include <util/help_formatter.h>
+
+#include <testing-utils/use_catch.h>
+
+#include <sstream>
+
+TEST_CASE("help_formatter", "[core][util]")
+{
+  std::ostringstream oss;
+  oss.clear();
+  oss << help_formatter("--abc \t xyz\n");
+  REQUIRE(oss.str() == "--abc                         xyz\n");
+}

--- a/unit/util/parse_options.cpp
+++ b/unit/util/parse_options.cpp
@@ -15,12 +15,3 @@ TEST_CASE("align_center_with_border", "[core][util]")
     align_center_with_border("test-text") ==
     "* *                        test-text                        * *");
 }
-
-TEST_CASE("help_entry", "[core][util]")
-{
-  REQUIRE(help_entry("--abc", "xyz", 8, 12) == " --abc  xyz\n");
-  REQUIRE(help_entry("--abc", "xxxx x", 8, 12) == " --abc  xxxx\n        x\n");
-  REQUIRE(help_entry("--abc", "xx xx", 8, 12) == " --abc  xx\n        xx\n");
-  REQUIRE(help_entry("--abcdef", "xyz", 8, 12) == " --abcdef\n        xyz\n");
-  REQUIRE(help_entry("--abcdefg", "xyz", 8, 12) == " --abcdefg\n        xyz\n");
-}


### PR DESCRIPTION
We previously did manual line breaks that either suited the source code
line length or approximated the output line width. help_formatter, however,
was specifically built to take care of this (and just wasn't widely
used). We can then also happily have clang-format take care of source
code formatting without impacting the resulting display.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
