### PR TITLE
Data-flow analyzers: don't document show-intervals, show-non-null

### DIFF
--- a/jbmc/src/janalyzer/janalyzer_parse_options.cpp
+++ b/jbmc/src/janalyzer/janalyzer_parse_options.cpp
@@ -759,9 +759,8 @@ void janalyzer_parse_optionst::help()
     "\n"
     "Domain options:\n"
     " --constants                  constant domain\n"
-    " --intervals, --show-intervals\n"
-    "                              interval domain\n"
-    " --non-null, --show-non-null  non-null domain\n"
+    " --intervals                  interval domain\n"
+    " --non-null                   non-null domain\n"
     " --dependence-graph           data and control dependencies between instructions\n" // NOLINT(*)
     "\n"
     "Output options:\n"

--- a/src/goto-analyzer/goto_analyzer_parse_options.cpp
+++ b/src/goto-analyzer/goto_analyzer_parse_options.cpp
@@ -743,9 +743,8 @@ void goto_analyzer_parse_optionst::help()
     "\n"
     "Domain options:\n"
     " --constants                  a constant for each variable if possible\n"
-    " --intervals, --show-intervals\n"
-    "                              an interval for each variable\n"
-    " --non-null, --show-non-null  tracks which pointers are non-null\n"
+    " --intervals                  an interval for each variable\n"
+    " --non-null                   tracks which pointers are non-null\n"
     " --dependence-graph           data and control dependencies between instructions\n" // NOLINT(*)
     " --vsd, --variable-sensitivity\n"
     "                              a configurable non-relational domain\n"


### PR DESCRIPTION
These are deprecated and users should be using --show --intervals and
--show --non-null, respectively.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
