### PR TITLE
SMT2 backend: workaround for Z3 get-value limitation

### DIFF
--- a/src/solvers/smt2/smt2_dec.cpp
+++ b/src/solvers/smt2/smt2_dec.cpp
@@ -184,24 +184,10 @@ decision_proceduret::resultt smt2_dect::read_result(std::istream &in)
       if(res != resultt::D_UNSATISFIABLE)
       {
         const auto &message = id2string(parsed.get_sub()[1].id());
-        // Special case error handling
-        if(
-          solver == solvert::Z3 &&
-          message.find("must not contain quantifiers") != std::string::npos)
-        {
-          // We tried to "(get-value |XXXX|)" where |XXXX| is determined to
-          // include a quantified expression
-          // Nothing to do, this should be caught and value assigned by the
-          // set_to defaults later.
-        }
-        // Unhandled error, log the error and report it back up to caller
-        else
-        {
-          messaget log{message_handler};
-          log.error() << "SMT2 solver returned error message:\n"
-                      << "\t\"" << message << "\"" << messaget::eom;
-          return decision_proceduret::resultt::D_ERROR;
-        }
+        messaget log{message_handler};
+        log.error() << "SMT2 solver returned error message:\n"
+                    << "\t\"" << message << "\"" << messaget::eom;
+        return decision_proceduret::resultt::D_ERROR;
       }
     }
   }


### PR DESCRIPTION
Z3 refuses to provide values for defined functions whose definition includes
a quantifier.  This commit works around this limitation by replacing
define-fun by equivalent declare-fun and assert commands.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
