### PR TITLE
make smt2_conv extensible

### DIFF
--- a/src/solvers/smt2/smt2_conv.cpp
+++ b/src/solvers/smt2/smt2_conv.cpp
@@ -993,6 +993,14 @@ void smt2_convt::convert_floatbv(const exprt &expr)
 
 void smt2_convt::convert_expr(const exprt &expr)
 {
+  // try hash table first
+  auto converter_result = converters.find(expr.id());
+  if(converter_result != converters.end())
+  {
+    converter_result->second(expr);
+    return; // done
+  }
+
   // huge monster case split over expression id
   if(expr.id()==ID_symbol)
   {

--- a/src/solvers/smt2/smt2_conv.h
+++ b/src/solvers/smt2/smt2_conv.h
@@ -85,11 +85,19 @@ public:
 
   static std::string convert_identifier(const irep_idt &identifier);
 
+  void set_converter(irep_idt id, std::function<void(const exprt &)> converter)
+  {
+    converters[id] = std::move(converter);
+  }
+
 protected:
   const namespacet &ns;
   std::ostream &out;
   std::string benchmark, notes, logic;
   solvert solver;
+  using converterst = std::
+    unordered_map<irep_idt, std::function<void(const exprt &)>, irep_id_hash>;
+  converterst converters;
 
   std::vector<exprt> assumptions;
   boolbv_widtht boolbv_width;


### PR DESCRIPTION
This adds a mechanism to extend the SMT2 conversion with a functor for a
given expression id.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
