### PR TITLE
member_exprt now checks type of compound operand

### DIFF
--- a/jbmc/unit/java_bytecode/java_trace_validation/java_trace_validation.cpp
+++ b/jbmc/unit/java_bytecode/java_trace_validation/java_trace_validation.cpp
@@ -22,12 +22,13 @@ TEST_CASE("java trace validation", "[core][java_trace_validation]")
 {
   const exprt plain_expr = exprt();
   const exprt expr_with_data = exprt("id", java_int_type());
-  const symbol_exprt valid_symbol_expr = symbol_exprt("id", java_int_type());
+  const symbol_exprt valid_symbol_expr =
+    symbol_exprt("id", struct_typet{{{"member", java_int_type()}}});
   const symbol_exprt invalid_symbol_expr = symbol_exprt(java_int_type());
   const member_exprt valid_member =
     member_exprt(valid_symbol_expr, "member", java_int_type());
-  const member_exprt invalid_member =
-    member_exprt(plain_expr, "member", java_int_type());
+  exprt invalid_member = unary_exprt{ID_member, plain_expr, java_int_type()};
+  invalid_member.set(ID_component_name, "member");
   const constant_exprt invalid_constant = constant_exprt("", java_int_type());
   const constant_exprt valid_constant = constant_exprt("0", java_int_type());
   const index_exprt valid_index = index_exprt(
@@ -88,7 +89,8 @@ TEST_CASE("java trace validation", "[core][java_trace_validation]")
     INFO("valid member structure")
     REQUIRE(check_member_structure(valid_member));
     INFO("invalid member structure, no symbol operand")
-    REQUIRE_FALSE(check_member_structure(invalid_member));
+    REQUIRE_FALSE(check_member_structure(
+      static_cast<const member_exprt &>(invalid_member)));
   }
 
   SECTION("can_evaluate_to_constant")

--- a/src/goto-programs/string_abstraction.cpp
+++ b/src/goto-programs/string_abstraction.cpp
@@ -817,24 +817,32 @@ bool string_abstractiont::build(const exprt &object, exprt &dest, bool write)
   if(object.id()==ID_member)
   {
     const member_exprt &o_mem=to_member_expr(object);
-    dest=member_exprt(exprt(), o_mem.get_component_name(), abstract_type);
-    return build_wrap(
-      o_mem.struct_op(), to_member_expr(dest).compound(), write);
+    exprt compound;
+    if(build_wrap(o_mem.struct_op(), compound, write))
+      return true;
+    dest = member_exprt{
+      std::move(compound), o_mem.get_component_name(), abstract_type};
+    return false;
   }
 
   if(object.id()==ID_dereference)
   {
     const dereference_exprt &o_deref=to_dereference_expr(object);
-    dest=dereference_exprt(exprt(), abstract_type);
-    return build_wrap(
-      o_deref.pointer(), to_dereference_expr(dest).pointer(), write);
+    exprt pointer;
+    if(build_wrap(o_deref.pointer(), pointer, write))
+      return true;
+    dest = dereference_exprt{std::move(pointer)};
+    return false;
   }
 
   if(object.id()==ID_index)
   {
     const index_exprt &o_index=to_index_expr(object);
-    dest=index_exprt(exprt(), o_index.index(), abstract_type);
-    return build_wrap(o_index.array(), to_index_expr(dest).array(), write);
+    exprt array;
+    if(build_wrap(o_index.array(), array, write))
+      return true;
+    dest = index_exprt{std::move(array), o_index.index()};
+    return false;
   }
 
   // handle pointer stuff

--- a/src/pointer-analysis/value_set.cpp
+++ b/src/pointer-analysis/value_set.cpp
@@ -1192,7 +1192,10 @@ void value_sett::get_reference_set_rec(
 
       if(object.id()==ID_unknown)
         insert(dest, exprt(ID_unknown, expr.type()));
-      else
+      else if(
+        object.type().id() == ID_struct ||
+        object.type().id() == ID_struct_tag || object.type().id() == ID_union ||
+        object.type().id() == ID_union_tag)
       {
         offsett o = it->second;
 
@@ -1218,6 +1221,8 @@ void value_sett::get_reference_set_rec(
         else
           insert(dest, exprt(ID_unknown, expr.type()));
       }
+      else
+        insert(dest, exprt(ID_unknown, expr.type()));
     }
 
     return;

--- a/src/pointer-analysis/value_set_fi.cpp
+++ b/src/pointer-analysis/value_set_fi.cpp
@@ -916,11 +916,10 @@ void value_set_fit::get_reference_set_sharing_rec(
       if(object.id()==ID_unknown)
         insert(dest, exprt(ID_unknown, expr.type()));
       else if(
-        object.id() == ID_dynamic_object && obj_type.id() != ID_struct &&
-        obj_type.id() != ID_union && obj_type.id() != ID_struct_tag &&
-        obj_type.id() != ID_union_tag)
+        obj_type.id() != ID_struct && obj_type.id() != ID_union &&
+        obj_type.id() != ID_struct_tag && obj_type.id() != ID_union_tag)
       {
-        // we catch dynamic objects of the wrong type,
+        // we catch objects of the wrong type,
         // to avoid non-integral typecasts.
         insert(dest, exprt(ID_unknown, expr.type()));
       }

--- a/src/util/std_expr.h
+++ b/src/util/std_expr.h
@@ -2789,12 +2789,20 @@ public:
   member_exprt(exprt op, const irep_idt &component_name, typet _type)
     : unary_exprt(ID_member, std::move(op), std::move(_type))
   {
+    const auto &compound_type_id = compound().type().id();
+    PRECONDITION(
+      compound_type_id == ID_struct_tag || compound_type_id == ID_union_tag ||
+      compound_type_id == ID_struct || compound_type_id == ID_union);
     set_component_name(component_name);
   }
 
   member_exprt(exprt op, const struct_typet::componentt &c)
     : unary_exprt(ID_member, std::move(op), c.type())
   {
+    const auto &compound_type_id = compound().type().id();
+    PRECONDITION(
+      compound_type_id == ID_struct_tag || compound_type_id == ID_union_tag ||
+      compound_type_id == ID_struct || compound_type_id == ID_union);
     set_component_name(c.get_name());
   }
 

--- a/unit/analyses/variable-sensitivity/full_struct_abstract_object/merge.cpp
+++ b/unit/analyses/variable-sensitivity/full_struct_abstract_object/merge.cpp
@@ -33,10 +33,13 @@ SCENARIO(
     // struct val2 = {.a = 1, .b = 4, .c = 5}
     auto val2 = std::map<std::string, int>{{"a", 1}, {"b", 4}, {"c", 5}};
 
-    // index_exprt for reading from an array
-    const member_exprt a(nil_exprt(), "a", integer_typet());
-    const member_exprt b(nil_exprt(), "b", integer_typet());
-    const member_exprt c(nil_exprt(), "c", integer_typet());
+    // member_exprt for reading from a struct
+    exprt dummy = nil_exprt{};
+    dummy.type() = struct_typet{
+      {{"a", integer_typet{}}, {"b", integer_typet{}}, {"c", integer_typet{}}}};
+    const auto a = member_exprt(dummy, "a", integer_typet());
+    const auto b = member_exprt(dummy, "b", integer_typet());
+    const auto c = member_exprt(dummy, "c", integer_typet());
 
     auto object_factory = variable_sensitivity_object_factoryt::configured_with(
       vsd_configt::constant_domain());

--- a/unit/analyses/variable-sensitivity/full_struct_abstract_object/struct_builder.cpp
+++ b/unit/analyses/variable-sensitivity/full_struct_abstract_object/struct_builder.cpp
@@ -19,6 +19,10 @@ full_struct_abstract_objectt::constant_struct_pointert build_struct(
 
   auto struct_type = to_struct_type(starting_value.type());
   size_t comp_index = 0;
+
+  auto nil_with_type = nil_exprt();
+  nil_with_type.type() = struct_type;
+
   for(const exprt &op : starting_value.operands())
   {
     const auto &component = struct_type.components()[comp_index];
@@ -26,7 +30,7 @@ full_struct_abstract_objectt::constant_struct_pointert build_struct(
       environment,
       ns,
       std::stack<exprt>(),
-      member_exprt(nil_exprt(), component.get_name(), component.type()),
+      member_exprt(nil_with_type, component.get_name(), component.type()),
       environment.eval(op, ns),
       false);
 

--- a/unit/goto-symex/expr_skeleton.cpp
+++ b/unit/goto-symex/expr_skeleton.cpp
@@ -15,27 +15,32 @@ Author: Romain Brenguier, romain.brenguier@diffblue.com
 
 SCENARIO("expr skeleton", "[core][goto-symex][symex-assign][expr-skeleton]")
 {
-  const symbol_exprt foo{"foo", typet{}};
+  const signedbv_typet int_type{32};
+  const array_typet array_type{int_type, from_integer(2, size_type())};
+  const symbol_exprt foo_a{"foo", array_type};
+  const symbol_exprt foo_s{"foo", struct_typet{{{"field1", array_type}}}};
+
   GIVEN("Skeletons `☐`, `☐[index]` and `☐.field1`")
   {
     const expr_skeletont empty_skeleton;
-    const signedbv_typet int_type{32};
-    const expr_skeletont index_skeleton =
-      expr_skeletont::remove_op0(index_exprt{
-        array_exprt{{}, array_typet{int_type, from_integer(2, size_type())}},
-        from_integer(1, size_type())});
-    const expr_skeletont member_skeleton = expr_skeletont::remove_op0(
-      member_exprt{symbol_exprt{"struct1", typet{}}, "field1", int_type});
+    const expr_skeletont index_skeleton = expr_skeletont::remove_op0(
+      index_exprt{array_exprt{{}, array_type}, from_integer(1, size_type())});
+    const expr_skeletont member_skeleton =
+      expr_skeletont::remove_op0(member_exprt{
+        symbol_exprt{"struct1", struct_typet{{{"field1", array_type}}}},
+        "field1",
+        array_type});
     THEN(
       "Applying the skeletons to `foo` gives `foo`, `foo[index]` and "
       "`foo.field1` respectively")
     {
-      REQUIRE(empty_skeleton.apply(foo) == foo);
+      REQUIRE(empty_skeleton.apply(foo_a) == foo_a);
       REQUIRE(
-        index_skeleton.apply(foo) ==
-        index_exprt{foo, from_integer(1, size_type()), int_type});
+        index_skeleton.apply(foo_a) ==
+        index_exprt{foo_a, from_integer(1, size_type()), int_type});
       REQUIRE(
-        member_skeleton.apply(foo) == member_exprt{foo, "field1", int_type});
+        member_skeleton.apply(foo_s) ==
+        member_exprt(foo_s, "field1", array_type));
     }
     THEN(
       "The composition of `☐[index]` with `☐.field1` applied to `foo` gives "
@@ -44,10 +49,10 @@ SCENARIO("expr skeleton", "[core][goto-symex][symex-assign][expr-skeleton]")
       const expr_skeletont composition =
         index_skeleton.compose(member_skeleton);
       REQUIRE(
-        composition.apply(foo) ==
-        index_exprt{member_exprt{foo, "field1", int_type},
-                    from_integer(1, size_type()),
-                    int_type});
+        composition.apply(foo_s) == index_exprt{
+                                      member_exprt(foo_s, "field1", array_type),
+                                      from_integer(1, size_type()),
+                                      int_type});
     }
     THEN(
       "The composition of `☐[index]` with `☐` applied to `foo` gives "
@@ -55,8 +60,8 @@ SCENARIO("expr skeleton", "[core][goto-symex][symex-assign][expr-skeleton]")
     {
       const expr_skeletont composition = index_skeleton.compose(empty_skeleton);
       REQUIRE(
-        composition.apply(foo) ==
-        index_exprt{foo, from_integer(1, size_type()), int_type});
+        composition.apply(foo_a) ==
+        index_exprt{foo_a, from_integer(1, size_type()), int_type});
     }
   }
 }

--- a/unit/pointer-analysis/value_set.cpp
+++ b/unit/pointer-analysis/value_set.cpp
@@ -135,7 +135,8 @@ SCENARIO(
     WHEN("We query what (a1 WITH x = NULL).x points to")
     {
       with_exprt a1_with(
-        a1_symbol.symbol_expr(), member_exprt(nil_exprt(), A_x), null_A_ptr);
+        a1_symbol.symbol_expr(), exprt{ID_member_name}, null_A_ptr);
+      a1_with.where().set(ID_component_name, A_x.get_name());
 
       member_exprt member_of_with(a1_with, A_x);
 
@@ -153,7 +154,8 @@ SCENARIO(
     WHEN("We query what (a1 WITH x = NULL).y points to")
     {
       with_exprt a1_with(
-        a1_symbol.symbol_expr(), member_exprt(nil_exprt(), A_x), null_A_ptr);
+        a1_symbol.symbol_expr(), exprt{ID_member_name}, null_A_ptr);
+      a1_with.where().set(ID_component_name, A_x.get_name());
 
       member_exprt member_of_with(a1_with, A_y);
 
@@ -171,7 +173,8 @@ SCENARIO(
     WHEN("We query what (a1 WITH x = NULL) points to")
     {
       with_exprt a1_with(
-        a1_symbol.symbol_expr(), member_exprt(nil_exprt(), A_x), null_A_ptr);
+        a1_symbol.symbol_expr(), exprt{ID_member_name}, null_A_ptr);
+      a1_with.where().set(ID_component_name, A_x.get_name());
 
       const std::vector<exprt> maybe_matching_with_result =
         value_set.get_value_set(a1_with, ns);


### PR DESCRIPTION
This commit adds a precondition to the constructors of `member_exprt` that
enforces that the compound operand has one of the compound types.

A legacy constructor is offered to ease the transition.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- [X] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
