### PR TITLE
index_exprt now requires a type with subtype

### DIFF
--- a/src/analyses/variable-sensitivity/write_stack_entry.cpp
+++ b/src/analyses/variable-sensitivity/write_stack_entry.cpp
@@ -39,15 +39,10 @@ simple_entryt::simple_entryt(exprt expr) : simple_entry(expr)
 
 /// Get the expression part needed to read this stack entry. For simple
 /// expressions this is just the expression itself.
-/// \return The expression to read this part of the stack
-exprt simple_entryt::get_access_expr() const
+/// \return The expression to read this part of the stack and false
+std::pair<exprt, bool> simple_entryt::get_access_expr() const
 {
-  return simple_entry;
-}
-
-/// For a simple entry, no type adjustment is needed for the access expression
-void simple_entryt::adjust_access_type(exprt &expr) const
-{
+  return {simple_entry, false};
 }
 
 offset_entryt::offset_entryt(abstract_object_pointert offset_value)
@@ -61,26 +56,11 @@ offset_entryt::offset_entryt(abstract_object_pointert offset_value)
 }
 
 /// Get the expression part needed to read this stack entry. For offset entries
-/// this is an index expression with the index() part the offset.
-/// It is important to note that the returned index_exprt does not have a type,
-/// so it will be necessary for the caller to update the type whenever the index
-/// expression is completed using `adjust_access_type` on the resulting exprt.
-/// \return The untyped expression to read this part of the stack
-exprt offset_entryt::get_access_expr() const
+/// this is the offset for an index expression.
+/// \return The offset expression to read this part of the stack and true
+std::pair<exprt, bool> offset_entryt::get_access_expr() const
 {
-  // This constructs a something that is basicallyt '(null)[offset])'
-  // meaning that we don't know what the type is at this point, as the
-  // array part will be filled in later.
-  return index_exprt(nil_exprt(), offset->to_constant());
-}
-
-/// For an offset entry, the type of the access expression can only be
-/// determined once the access expression has been completed with the next
-/// entry on the write stack.
-void offset_entryt::adjust_access_type(exprt &expr) const
-{
-  PRECONDITION(expr.id() == ID_index);
-  expr.type() = to_index_expr(expr).array().type().subtype();
+  return {offset->to_constant(), true};
 }
 
 /// Try to combine a new stack element with the current top of the stack. This

--- a/src/analyses/variable-sensitivity/write_stack_entry.h
+++ b/src/analyses/variable-sensitivity/write_stack_entry.h
@@ -21,8 +21,7 @@ class write_stack_entryt
 {
 public:
   virtual ~write_stack_entryt() = default;
-  virtual exprt get_access_expr() const = 0;
-  virtual void adjust_access_type(exprt &expr) const = 0;
+  virtual std::pair<exprt, bool> get_access_expr() const = 0;
   virtual bool try_squash_in(
     std::shared_ptr<const write_stack_entryt> new_entry,
     const abstract_environmentt &enviroment,
@@ -33,8 +32,7 @@ class simple_entryt : public write_stack_entryt
 {
 public:
   explicit simple_entryt(exprt expr);
-  exprt get_access_expr() const override;
-  void adjust_access_type(exprt &expr) const override;
+  std::pair<exprt, bool> get_access_expr() const override;
 
 private:
   exprt simple_entry;
@@ -44,8 +42,7 @@ class offset_entryt : public write_stack_entryt
 {
 public:
   explicit offset_entryt(abstract_object_pointert offset_value);
-  exprt get_access_expr() const override;
-  void adjust_access_type(exprt &expr) const override;
+  std::pair<exprt, bool> get_access_expr() const override;
   bool try_squash_in(
     std::shared_ptr<const write_stack_entryt> new_entry,
     const abstract_environmentt &enviroment,

--- a/src/cpp/cpp_constructor.cpp
+++ b/src/cpp/cpp_constructor.cpp
@@ -100,7 +100,7 @@ optionalt<codet> cpp_typecheckt::cpp_constructor(
         exprt constant = from_integer(i, c_index_type());
         constant.add_source_location()=source_location;
 
-        index_exprt index(object, constant);
+        index_exprt index = index_exprt(object_tc, constant);
         index.add_source_location()=source_location;
 
         if(!operands.empty())

--- a/src/util/std_expr.h
+++ b/src/util/std_expr.h
@@ -1417,9 +1417,7 @@ public:
         _array,
         ID_index,
         std::move(_index),
-        _array.type().has_subtype()
-          ? to_type_with_subtype(_array.type()).subtype()
-          : typet(ID_nil))
+        to_type_with_subtype(_array.type()).subtype())
   {
   }
 

--- a/unit/solvers/smt2_incremental/object_tracking.cpp
+++ b/unit/solvers/smt2_incremental/object_tracking.cpp
@@ -29,8 +29,7 @@ TEST_CASE("find_object_base_expression", "[core][smt2_incremental]")
       {member_exprt{object_base, "baz", unsignedbv_typet{8}}, pointer_type}},
     rowt{
       "Address of index of struct member",
-      {index_exprt{
-         member_exprt{object_base, "baz", unsignedbv_typet{8}}, index},
+      {index_exprt{member_exprt{object_base, "baz", base_type}, index},
        pointer_type}},
     rowt{
       "Address of struct member at index",


### PR DESCRIPTION
This commit adds a precondition to the constructor of `index_exprt` that
enforces that the type of the 'array' operand has a subtype.

A function is provided that offers the previous behavior to ease the
transition.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- [X] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
