### PR TITLE
Byte update lowering: never create extractbits over unbounded arrays

### DIFF
--- a/regression/cbmc/byte_update16/big-endian.desc
+++ b/regression/cbmc/byte_update16/big-endian.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+--big-endian
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring

--- a/regression/cbmc/byte_update16/little-endian.desc
+++ b/regression/cbmc/byte_update16/little-endian.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+--little-endian
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring

--- a/regression/cbmc/byte_update16/main.c
+++ b/regression/cbmc/byte_update16/main.c
@@ -1,0 +1,12 @@
+int main()
+{
+  unsigned len;
+  unsigned A[len];
+  if(len > 1 || len == 0 || sizeof(unsigned) != 4)
+    return 0;
+
+  A[0] = 0xA5FFFFA5U;
+  __CPROVER_bitvector[1] *bptr = &A[len - 1];
+  *bptr = 0;
+  __CPROVER_assert(A[0] == 0xA5FFFF25U || A[0] == 0x25FFFFA5U, "MSB cleared");
+}


### PR DESCRIPTION
With nondet pointers we may end up doing byte updates of weird
combinations, including doing byte updates of an unbounded array using a
value the size of which is not a multiple of byte widths. This resulted
in extractbits expressions trying to extract bits from an unbounded
array, which bitvector flattening does not support.

This commit puts a byte extract layer in between, which will then take
the right approach to ultimately enable the extractbits to succeed.

Also, put PRECONDITIONs in place to ensure we don't create such
extractbits expressions in any other place in byte-operator lowering.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
