### PR TITLE
CHC encoder: universally quantify nondeterministic choices

### DIFF
--- a/regression/goto-instrument-chc/basic/nondet1.desc
+++ b/regression/goto-instrument-chc/basic/nondet1.desc
@@ -3,6 +3,6 @@ nondet1.c
 --horn
 ^EXIT=0$
 ^SIGNAL=0$
-^\(assert \(forall \( \(|__CPROVER_rounding_mode| \(_ BitVec 32\)\) \(|main::1::x| \(_ BitVec 32\)\) \(|main::1::y| \(_ BitVec 32\)\) \(|return_value| \(_ BitVec 32\)\) \) \(=> \(|S30Entry| |__CPROVER_rounding_mode| |main::1::x| |main::1::y| |return_value|\) \(|S30\.2| |__CPROVER_rounding_mode| |nondet::S30\.2| |main::1::y| |return_value|\)\)\)\)$
-^\(assert \(forall \( \(|__CPROVER_rounding_mode| \(_ BitVec 32\)\) \(|main::1::x| \(_ BitVec 32\)\) \(|main::1::y| \(_ BitVec 32\)\) \(|return_value| \(_ BitVec 32\)\) \) \(=> \(|S30\.2| |__CPROVER_rounding_mode| |main::1::x| |main::1::y| |return_value|\) \(= |main::1::x| \(_ bv20 32\)\)\)\)\)$
+^\(assert \(forall \( \(__CPROVER_rounding_mode \(_ BitVec 32\)\) \(|main::1::x| \(_ BitVec 32\)\) \(|main::1::y| \(_ BitVec 32\)\) \(return_value \(_ BitVec 32\)\) \(|nondet::S30\.2| \(_ BitVec 32\)\) \) \(=> \(S30Entry __CPROVER_rounding_mode |main::1::x| |main::1::y| return_value\) \(S30\.2 __CPROVER_rounding_mode |nondet::S30\.2| |main::1::y| return_value\)\)\)\)$
+^\(assert \(forall \( \(__CPROVER_rounding_mode \(_ BitVec 32\)\) \(|main::1::x| \(_ BitVec 32\)\) \(|main::1::y| \(_ BitVec 32\)\) \(return_value \(_ BitVec 32\)\) \) \(=> \(S30\.2 __CPROVER_rounding_mode |main::1::x| |main::1::y| return_value\) \(= |main::1::x| \(_ bv20 32\)\)\)\)\)$
 --


### PR DESCRIPTION
Nondeterministic choices must be universally quantified, as opposed to
existentially, to yield the desired adversarial nondeterminism.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [X] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
