### PR TITLE
SMT2 back-end and solver: it's fp.isInfinite, not fp.isInf

### DIFF
--- a/regression/cbmc/Float4/test.desc
+++ b/regression/cbmc/Float4/test.desc
@@ -1,4 +1,4 @@
-CORE broken-smt-backend
+CORE
 main.c
 --floatbv
 ^EXIT=0$

--- a/regression/cbmc/Float8/smt.desc
+++ b/regression/cbmc/Float8/smt.desc
@@ -1,6 +1,6 @@
-CORE
+CORE smt-backend
 main.c
---floatbv --no-simplify
+--smt2 --fpa
 ^EXIT=0$
 ^SIGNAL=0$
 ^VERIFICATION SUCCESSFUL$

--- a/regression/cbmc/pragma_cprover_enable_all/test.desc
+++ b/regression/cbmc/pragma_cprover_enable_all/test.desc
@@ -1,4 +1,4 @@
-CORE broken-smt-backend
+CORE
 main.c
 --object-bits 8 --bounds-check --pointer-check --pointer-primitive-check --div-by-zero-check --enum-range-check --unsigned-overflow-check --signed-overflow-check --pointer-overflow-check --float-overflow-check --conversion-check --undefined-shift-check --nan-check --pointer-primitive-check
 ^\[main\.pointer_primitives\.\d+\] line 77 pointer invalid in R_OK\(q, \(unsigned (long (long )?)?int\)1\): FAILURE$

--- a/src/solvers/smt2/smt2_conv.cpp
+++ b/src/solvers/smt2/smt2_conv.cpp
@@ -1859,7 +1859,7 @@ void smt2_convt::convert_expr(const exprt &expr)
         convert_expr(isfinite_expr.op());
         out << "))";
 
-        out << "(not (fp.isInf ";
+        out << "(not (fp.isInfinite ";
         convert_expr(isfinite_expr.op());
         out << "))";
 

--- a/src/solvers/smt2/smt2_parser.cpp
+++ b/src/solvers/smt2/smt2_parser.cpp
@@ -1245,14 +1245,14 @@ void smt2_parsert::setup_expressions()
     return unary_predicate_exprt(ID_isnan, op[0]);
   };
 
-  expressions["fp.isInf"] = [this] {
+  expressions["fp.isInfinite"] = [this] {
     auto op = operands();
 
     if(op.size() != 1)
-      throw error("fp.isInf takes one operand");
+      throw error("fp.isInfinite takes one operand");
 
     if(op[0].type().id() != ID_floatbv)
-      throw error("fp.isInf takes FloatingPoint operand");
+      throw error("fp.isInfinite takes FloatingPoint operand");
 
     return unary_predicate_exprt(ID_isinf, op[0]);
   };


### PR DESCRIPTION
We already had gotten this right in one place, but got in wrong in 5
other places.

Fixes: #1782

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
