### PR TITLE
Document all supported options for --arch and --os

### DIFF
--- a/src/util/config.h
+++ b/src/util/config.h
@@ -82,15 +82,25 @@ class symbol_tablet;
   "(gcc)"                                                                      \
 
 #define HELP_CONFIG_PLATFORM \
-  " --arch                       set architecture (default: "                  \
+  " --arch <arch>                set architecture (default: "                  \
                                  << configt::this_architecture() << ")\n"      \
-  " --os                         set operating system (default: "              \
+  "                              to one of: alpha, arm, arm64, armel, armhf,\n"\
+  "                              hppa, i386, ia64, mips, mips64, mips64el,\n"  \
+  "                              mipsel, mipsn32, mipsn32el, powerpc, ppc64,\n"\
+  "                              ppc64le, riscv64, s390, s390x, sh4, sparc,\n" \
+  "                              sparc64, v850, x32, x86_64, or none\n"        \
+  " --os <os>                    set operating system (default: "              \
                                  << configt::this_operating_system() << ")\n"  \
+  "                              to one of: freebsd, linux, macos, solaris,\n" \
+  "                              or windows\n"                                 \
   " --i386-linux, --i386-win32, --i386-macos, --ppc-macos\n"                   \
   "   --win32, --winx64          set architecture and operating system\n"      \
-  " --16, --32, --64             set width of int\n"                           \
   " --LP64, --ILP64, --LLP64,\n"                                               \
-  "   --ILP32, --LP32            set width of int, long and pointers\n"        \
+  "   --ILP32, --LP32            set width of int, long and pointers, but\n"   \
+  "                              don't override default architecture and\n"    \
+  "                              operating system\n"                           \
+  " --16, --32, --64             equivalent to --LP32, --ILP32, --LP64 (on\n"  \
+  "                              Windows: --LLP64)\n"                          \
   " --little-endian              allow little-endian word-byte conversions\n"  \
   " --big-endian                 allow big-endian word-byte conversions\n"     \
   " --gcc                        use GCC as preprocessor\n"                    \


### PR DESCRIPTION
We support a specific set of architectures and operating system
configurations, and we should let the user know which ones these are.
Else the user has to dig into the source code to reverse-engineer it
from config.cpp.

Fixes: #5267
Fixes: #5268

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
