### PR TITLE
C entry point generator: no unconditional conversion to pointer type

### DIFF
--- a/regression/ansi-c/main1/main.c
+++ b/regression/ansi-c/main1/main.c
@@ -1,0 +1,4 @@
+int main(char *argv, int arc)
+{
+  return 0;
+}

--- a/regression/ansi-c/main1/test.desc
+++ b/regression/ansi-c/main1/test.desc
@@ -1,0 +1,11 @@
+CORE test-c++-front-end
+main.c
+
+'main' with signature 'signed int \(char \*argv, signed int arc\)' found
+^EXIT=(64|1)$
+^SIGNAL=0$
+--
+Invariant check failed
+--
+This test is to ensure that non-standard C entry points are handled gracefully
+and with a message to the user.

--- a/src/ansi-c/ansi_c_entry_point.cpp
+++ b/src/ansi-c/ansi_c_entry_point.cpp
@@ -248,7 +248,16 @@ bool generate_ansi_c_start_function(
     {
       // ok
     }
-    else if(parameters.size()==2 || parameters.size()==3)
+    // The C standard (and any related architecture descriptions) enforces an
+    // order of parameters. The user, however, may supply arbitrary
+    // (syntactically valid) C code, even one that does not respect the calling
+    // conventions set out in the C standard. If the user does supply such code,
+    // then we can only tell them that they got it wrong, which is what we do
+    // via the error message in the else branch of this code.
+    else if(
+      parameters.size() >= 2 && parameters[1].type().id() == ID_pointer &&
+      (parameters.size() == 2 ||
+       (parameters.size() == 3 && parameters[2].type().id() == ID_pointer)))
     {
       namespacet ns(symbol_table);
 


### PR DESCRIPTION
Do not try to create a pointer_typet when the type might not actually be
a pointer type. This was triggerable by syntactically well-formed C
input and should instead be handled by a user-facing error message.

Fixes: #6975

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
