### PR TITLE
CONTRACTS: New classes for loop-invariant-synthesizer interface

### DIFF
--- a/regression/contracts/loop_invariant_synthesis_01/main.c
+++ b/regression/contracts/loop_invariant_synthesis_01/main.c
@@ -1,0 +1,27 @@
+#include <stdlib.h>
+
+int main()
+{
+  unsigned int size;
+  __CPROVER_assume(size < 50);
+  int *p = malloc(size * 4);
+  int result = 0;
+
+  for(unsigned int i = 0; i < size; i++)
+  {
+    result += p[i];
+  }
+
+  for(unsigned int i = 0; i < size; i++)
+    // clang-format off
+  __CPROVER_loop_invariant(1 == 1)
+    // clang-format on
+    {
+      result += p[i];
+    }
+
+  for(unsigned int i = 0; i < size; i++)
+  {
+    result += p[i];
+  }
+}

--- a/regression/contracts/loop_invariant_synthesis_01/test.desc
+++ b/regression/contracts/loop_invariant_synthesis_01/test.desc
@@ -1,0 +1,16 @@
+CORE
+main.c
+--synthesize-loop-invariants
+^EXIT=0$
+^SIGNAL=0$
+^\[main\.\d+\] line 11 Check loop invariant before entry: SUCCESS$
+^\[main\.\d+\] line 11 Check that loop invariant is preserved: SUCCESS$
+^\[main\.\d+\] line 16 Check loop invariant before entry: SUCCESS$
+^\[main\.\d+\] line 16 Check that loop invariant is preserved: SUCCESS$
+^\[main\.\d+\] line 24 Check loop invariant before entry: SUCCESS$
+^\[main\.\d+\] line 24 Check that loop invariant is preserved: SUCCESS$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring
+--
+This test case checks if invariants are generated for unannotated loops.

--- a/src/goto-instrument/Makefile
+++ b/src/goto-instrument/Makefile
@@ -68,6 +68,8 @@ SRC = accelerate/accelerate.cpp \
       source_lines.cpp \
       splice_call.cpp \
       stack_depth.cpp \
+      synthesizer/loop_invariant_synthesizer.cpp \
+      synthesizer/synthesizer_utils.cpp \
       thread_instrumentation.cpp \
       undefined_functions.cpp \
       uninitialized.cpp \

--- a/src/goto-instrument/goto_instrument_parse_options.cpp
+++ b/src/goto-instrument/goto_instrument_parse_options.cpp
@@ -1177,6 +1177,17 @@ void goto_instrument_parse_optionst::instrument_goto_program()
       contracts.apply_loop_contracts(to_exclude_from_nondet_static);
   }
 
+  if(cmdline.isset("synthesize-loop-invariants"))
+  {
+    log.warning() << "Loop invariant synthesizer is still work in progress. "
+                     "It only generates TRUE as invariants."
+                  << messaget::eom;
+
+    // Synthesize loop invariants and annotate them into `goto_model`
+    enumerative_loop_invariant_synthesizert synthesizer(goto_model, log);
+    annotate_invariants(synthesizer.synthesize(), goto_model, log);
+  }
+
   if(cmdline.isset("value-set-fi-fp-removal"))
   {
     value_set_fi_fp_removal(goto_model, ui_message_handler);
@@ -1897,6 +1908,7 @@ void goto_instrument_parse_optionst::help()
     "\n"
     "Code contracts:\n"
     HELP_LOOP_CONTRACTS
+    HELP_LOOP_INVARIANT_SYNTHESIZER
     HELP_REPLACE_CALL
     HELP_ENFORCE_CONTRACT
     "\n"

--- a/src/goto-instrument/goto_instrument_parse_options.h
+++ b/src/goto-instrument/goto_instrument_parse_options.h
@@ -41,6 +41,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "unwindset.h"
 
 #include "contracts/contracts.h"
+#include "synthesizer/loop_invariant_synthesizer.h"
 #include "wmm/weak_memory.h"
 
 // clang-format off
@@ -116,6 +117,7 @@ Author: Daniel Kroening, kroening@kroening.com
   OPT_NONDET_VOLATILE \
   "(ensure-one-backedge-per-target)" \
   OPT_CONFIG_LIBRARY \
+  OPT_SYNTHESIZE_LOOP_INVARIANTS \
   // empty last line
 
 // clang-format on

--- a/src/goto-instrument/module_dependencies.txt
+++ b/src/goto-instrument/module_dependencies.txt
@@ -10,5 +10,6 @@ langapi # should go away
 linking
 pointer-analysis
 solvers
+synthesizer
 util
 wmm

--- a/src/goto-instrument/synthesizer/loop_invariant_synthesizer.cpp
+++ b/src/goto-instrument/synthesizer/loop_invariant_synthesizer.cpp
@@ -1,0 +1,46 @@
+/*******************************************************************\
+
+Module: Synthesize Loop Invariants
+
+Author: Qinheping Hu
+
+\*******************************************************************/
+
+/// \file
+/// Synthesize Loop Invariants
+
+#include "loop_invariant_synthesizer.h"
+
+void enumerative_loop_invariant_synthesizert::init_candidates()
+{
+  for(auto &function_p : goto_model.goto_functions.function_map)
+  {
+    natural_loops_mutablet natural_loops(function_p.second.body);
+
+    // Initialize invairants for unannotated loops as true
+    for(unsigned int idx = 0; idx < natural_loops.loop_map.size(); idx++)
+    {
+      loop_idt new_id;
+      new_id.func_name = function_p.first;
+      new_id.loop_number = idx;
+
+      // find the `loop_number`th loop
+      goto_programt::targett loop_end = get_loop_end(idx, function_p.second);
+
+      // we only synthesize invariants for unannotated loops
+      if(loop_end->condition().find(ID_C_spec_loop_invariant).is_nil())
+      {
+        invariant_candiate_map[new_id] = true_exprt();
+      }
+    }
+  }
+}
+
+invariant_mapt enumerative_loop_invariant_synthesizert::synthesize()
+{
+  init_candidates();
+
+  // Now this method only generate true for all unnotated loops.
+  // The implementation will be added later.
+  return invariant_candiate_map;
+}

--- a/src/goto-instrument/synthesizer/loop_invariant_synthesizer.h
+++ b/src/goto-instrument/synthesizer/loop_invariant_synthesizer.h
@@ -1,0 +1,65 @@
+/*******************************************************************\
+
+Module: Loop Invariant Synthesizer Interface
+
+Author: Qinheping Hu
+
+\*******************************************************************/
+
+/// \file
+/// Loop Invariant Synthesizer Interface
+
+#ifndef CPROVER_GOTO_INSTRUMENT_SYNTHESIZER_LOOP_INVARIANT_SYNTHESIZER_H
+#define CPROVER_GOTO_INSTRUMENT_SYNTHESIZER_LOOP_INVARIANT_SYNTHESIZER_H
+
+#include <util/message.h>
+
+#include <goto-programs/goto_model.h>
+
+#include "synthesizer_utils.h"
+
+#define OPT_SYNTHESIZE_LOOP_INVARIANTS "(synthesize-loop-invariants)"
+#define HELP_LOOP_INVARIANT_SYNTHESIZER                                        \
+  " --synthesize-loop-invariants\n"                                            \
+  "                              synthesize and apply loop invariants\n"
+
+class loop_invariant_synthesizer_baset
+{
+public:
+  loop_invariant_synthesizer_baset(goto_modelt &goto_model, messaget &log)
+    : goto_model(goto_model), log(log)
+  {
+  }
+  virtual ~loop_invariant_synthesizer_baset() = default;
+
+  /// Synthesize loop invariants with which all checks in `goto_model`
+  /// succeed. The result is a map from `loop_idt` ids of loops to `exprt`
+  /// the goto-expression representation of synthesized invariants.
+  virtual invariant_mapt synthesize() = 0;
+
+protected:
+  goto_modelt &goto_model;
+  messaget &log;
+};
+
+class enumerative_loop_invariant_synthesizert
+  : public loop_invariant_synthesizer_baset
+{
+public:
+  enumerative_loop_invariant_synthesizert(
+    goto_modelt &goto_model,
+    messaget &log)
+    : loop_invariant_synthesizer_baset(goto_model, log)
+  {
+  }
+
+  invariant_mapt synthesize() override;
+
+private:
+  /// Initialize invariants as true for all unannotated loops.
+  void init_candidates();
+
+  invariant_mapt invariant_candiate_map{invariant_mapt()};
+};
+
+#endif // CPROVER_GOTO_INSTRUMENT_SYNTHESIZER_LOOP_INVARIANT_SYNTHESIZER_H

--- a/src/goto-instrument/synthesizer/module_dependencies.txt
+++ b/src/goto-instrument/synthesizer/module_dependencies.txt
@@ -1,0 +1,8 @@
+analyses
+ansi-c
+goto-instrument/contracts
+goto-instrument/synthesizer
+goto-instrument
+goto-programs
+langapi
+util

--- a/src/goto-instrument/synthesizer/synthesizer_utils.cpp
+++ b/src/goto-instrument/synthesizer/synthesizer_utils.cpp
@@ -1,0 +1,79 @@
+/*******************************************************************\
+
+Module: Utility functions for loop invariant synthesizer.
+
+Author: Qinheping Hu
+
+\*******************************************************************/
+
+#include "synthesizer_utils.h"
+
+goto_programt::targett get_loop_head_or_end(
+  const unsigned int target_loop_number,
+  goto_functiont &function,
+  bool finding_head)
+{
+  natural_loops_mutablet natural_loops(function.body);
+
+  // iterate over all natural loops to find the loop with `target_loop_number`
+  for(const auto &loop_p : natural_loops.loop_map)
+  {
+    const goto_programt::targett loop_head = loop_p.first;
+    goto_programt::targett loop_end = loop_p.first;
+    const loopt &loop = loop_p.second;
+    for(const auto &t : loop)
+    {
+      // an instruction is the loop end if it is a goto instruction
+      // and it jumps backward to the loop head
+      if(
+        t->is_goto() && t->get_target() == loop_head &&
+        t->location_number > loop_end->location_number)
+        loop_end = t;
+    }
+
+    // check if the current loop is the target loop by comparing loop number
+    if(loop_end->loop_number == target_loop_number)
+    {
+      if(finding_head)
+        return loop_head;
+      else
+        return loop_end;
+    }
+  }
+
+  UNREACHABLE;
+}
+
+goto_programt::targett
+get_loop_end(const unsigned int target_loop_number, goto_functiont &function)
+{
+  return get_loop_head_or_end(target_loop_number, function, false);
+}
+
+goto_programt::targett
+get_loop_head(const unsigned int target_loop_number, goto_functiont &function)
+{
+  return get_loop_head_or_end(target_loop_number, function, true);
+}
+
+void annotate_invariants(
+  const invariant_mapt &invariant_map,
+  goto_modelt &goto_model,
+  messaget &log)
+{
+  for(const auto &invariant_map_entry : invariant_map)
+  {
+    loop_idt loop_id = invariant_map_entry.first;
+    irep_idt func_name = loop_id.func_name;
+    unsigned int loop_number = loop_id.loop_number;
+
+    // get the last instruction of the target loop
+    auto &function = goto_model.goto_functions.function_map[func_name];
+    goto_programt::targett loop_end = get_loop_end(loop_number, function);
+
+    // annotate the invariant to the condition of `loop_end`
+    exprt condition = loop_end->condition();
+    loop_end->condition_nonconst().add(ID_C_spec_loop_invariant) =
+      invariant_map_entry.second;
+  }
+}

--- a/src/goto-instrument/synthesizer/synthesizer_utils.h
+++ b/src/goto-instrument/synthesizer/synthesizer_utils.h
@@ -1,0 +1,62 @@
+/*******************************************************************\
+
+Module: Utility functions for loop invariant synthesizer.
+
+Author: Qinheping Hu
+
+\*******************************************************************/
+
+#ifndef CPROVER_GOTO_INSTRUMENT_SYNTHESIZER_SYNTHESIZER_UTILS_H
+#define CPROVER_GOTO_INSTRUMENT_SYNTHESIZER_SYNTHESIZER_UTILS_H
+
+#include <util/message.h>
+
+#include <goto-programs/goto_model.h>
+#include <goto-programs/goto_program.h>
+
+#include <goto-instrument/loop_utils.h>
+
+struct loop_idt
+{
+  irep_idt func_name;
+  unsigned int loop_number;
+
+  bool operator==(const loop_idt &o) const
+  {
+    return func_name == o.func_name && loop_number == o.loop_number;
+  }
+
+  bool operator<(const loop_idt &o) const
+  {
+    return func_name < o.func_name ||
+           (func_name == o.func_name && loop_number < o.loop_number);
+  }
+};
+
+typedef std::map<loop_idt, exprt> invariant_mapt;
+
+/// Return loop head if `finding_head` is true,
+/// Otherwise return loop end.
+goto_programt::targett get_loop_head_or_end(
+  const unsigned int loop_number,
+  goto_functiont &function,
+  bool finding_head);
+
+/// Find and return the last instruction of the natural loop with
+/// `loop_number` in `function`. loop_end -> loop_head
+goto_programt::targett
+get_loop_end(const unsigned int loop_number, goto_functiont &function);
+
+/// Find and return the first instruction of the natural loop with
+/// `loop_number` in `function`. loop_end -> loop_head
+goto_programt::targett
+get_loop_head(const unsigned int loop_number, goto_functiont &function);
+
+/// Annotate the invariants in `invariant_map` to their corresponding
+/// loops. Corresponding loops are specified by keys of `invariant_map`
+void annotate_invariants(
+  const invariant_mapt &invariant_map,
+  goto_modelt &goto_model,
+  messaget &log);
+
+#endif // CPROVER_GOTO_INSTRUMENT_SYNTHESIZER_SYNTHESIZER_UTILS_H


### PR DESCRIPTION
<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->
- new class ```loop_invaraint_synthesizer_baset```. The abstract class for loop invariant synthesizers. it contain only one method ```synthesize``` which generate a map from `loop_idt` to `exprt` where `loop_idt` is a new struct used to identify loops with their `func_name` and `loop_number`, and `exprt` is the goto-epxression of the synthesized invariant.
- new class ```enumerative_loop_invariant_synthesizert``` derived from ```loop_invaraint_synthesizer_baset```. It is now only partially implemented---it generate ```true``` for all unannotated loops. The full implementation will added in another PR after a new verifier class and a new enumerator class being merged.
- utils methods for finding head or end of loops, and annotating invariant into goto-model.
- new flag for goto-instrument to call the new synthesizer class. Using goto-instrument with the flag ```synthesize-loop-invariants``` will first synthesize valid loop invariant (now only `true`), annotate them back into the goto-program, and output the goto-program after applying all loop contracts including synthesized ones and user-provided ones.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
