### PR TITLE
Location coverage reporting should ignore globals

### DIFF
--- a/regression/cbmc-cover/location2/main.c
+++ b/regression/cbmc-cover/location2/main.c
@@ -1,0 +1,11 @@
+#include <string.h>
+
+#define BUFLEN 100
+
+static void *(*const volatile memset_func)(void *, int, size_t) = memset;
+
+int main()
+{
+  char buffer[BUFLEN];
+  memset_func(&buffer, 0, BUFLEN);
+}

--- a/regression/cbmc-cover/location2/test.desc
+++ b/regression/cbmc-cover/location2/test.desc
@@ -1,0 +1,14 @@
+CORE
+main.c
+--cover location
+^EXIT=0$
+^SIGNAL=0$
+^\[main.coverage.1\] file main.c line 9 function main block 1 \(lines main.c:main:9,10\): SATISFIED$
+^\[main.coverage.2\] file main.c line 11 function main block 2 \(lines main.c:main:11\): SATISFIED$
+^\*\* 2 of 2 covered \(100.0%\)
+--
+^warning: ignoring
+main.c::5
+--
+Expressions outside a function should not end up listed as part of source code
+blocks.

--- a/src/goto-instrument/cover_basic_blocks.cpp
+++ b/src/goto-instrument/cover_basic_blocks.cpp
@@ -163,8 +163,11 @@ void cover_basic_blockst::add_block_lines(
     }
   };
   add_location(instruction.source_location());
-  instruction.get_code().visit_pre(
-    [&](const exprt &expr) { add_location(expr.source_location()); });
+  instruction.get_code().visit_pre([&](const exprt &expr) {
+    const auto &location = expr.source_location();
+    if(!location.get_function().empty())
+      add_location(location);
+  });
 }
 
 cover_basic_blocks_javat::cover_basic_blocks_javat(


### PR DESCRIPTION
We iterate over instructions in non-built-in functions, and it is
therefore reasonable to expect that all source locations have functions
that they belong to. If symbols declared at global scope are part of
expressions then this shouldn't yield calling them out in location
coverage. (That's just where they were declared, it doesn't even
strictly imply their assignments were covered.)

Fixes: #6978

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
