### PR TITLE
Crangler: support semicolon in post-declarator expressions

### DIFF
--- a/regression/crangler/assigns-clause-syntax/main-contract-after-declaration.c
+++ b/regression/crangler/assigns-clause-syntax/main-contract-after-declaration.c
@@ -1,0 +1,28 @@
+int foo(int *arr, int size);
+
+int foo(int *arr, int size)
+  // clang-format off
+__CPROVER_requires(size > 0 && __CPROVER_is_fresh(arr, size))
+__CPROVER_assigns(
+  arr[0], arr[size-1];
+  size >= 10: arr[5];
+)
+__CPROVER_ensures(arr[0] == 0 && arr[size-1] == 0)
+__CPROVER_ensures(size >= 10 ==> arr[5] == __CPROVER_return_value)
+  // clang-format on
+  ;
+
+int foo(int *arr, int size)
+{
+  arr[0] = 0;
+  arr[size - 1] = 0;
+  return size < 10 ? 0 : arr[5];
+}
+
+int main()
+{
+  int arr[10];
+  int retval = foo(arr, 10);
+  __CPROVER_assert(retval == arr[5], "should succeed");
+  return 0;
+}

--- a/regression/crangler/assigns-clause-syntax/test.desc
+++ b/regression/crangler/assigns-clause-syntax/test.desc
@@ -1,0 +1,9 @@
+CORE
+test.json
+
+__CPROVER_assigns
+^EXIT=0$
+^SIGNAL=0$
+--
+--
+Make sure the semicolon in assigns clauses does not trip up parsing.

--- a/regression/crangler/assigns-clause-syntax/test.json
+++ b/regression/crangler/assigns-clause-syntax/test.json
@@ -1,0 +1,6 @@
+{
+  "sources": [
+    "main-contract-after-declaration.c"
+  ],
+  "output": "stdout"
+}

--- a/src/crangler/mini_c_parser.cpp
+++ b/src/crangler/mini_c_parser.cpp
@@ -282,11 +282,26 @@ mini_c_parsert::tokenst mini_c_parsert::parse_post_declarator()
   // 3) '=' (initializer)
 
   tokenst result;
+  std::size_t open_parentheses = 0;
 
   while(true)
   {
     if(eof())
       return result;
+
+    if(peek() == '(')
+    {
+      ++open_parentheses;
+      result.push_back(consume_token());
+      continue;
+    }
+    else if(open_parentheses > 0)
+    {
+      if(peek() == ')')
+        --open_parentheses;
+      result.push_back(consume_token());
+      continue;
+    }
 
     if(peek() == ';' || peek() == '{' || peek() == '=')
       return result;


### PR DESCRIPTION
assigns clauses used in contracts use semicolons to delimit expressions.
Make sure crangler just accepts whatever occurs between matching pairs
of parentheses.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
