### PR TITLE
Function pointer removal: create fall-back function call

### DIFF
--- a/regression/cbmc/Function_Pointer18/test.desc
+++ b/regression/cbmc/Function_Pointer18/test.desc
@@ -1,11 +1,13 @@
 CORE
 main.c
 
-^EXIT=0$
-^SIGNAL=0$
-\[f2.assertion.1\] line [0-9]+ assertion 0: SUCCESS
-\[main.assertion.1\] line [0-9]+ assertion x == 1: SUCCESS
+^\*\*\*\* WARNING: no body for function main::fptr_call
+^\*\*\*\* WARNING: no body for function main::fptr_call\$0
+\[f2.assertion.1\] line [0-9]+ assertion 0: FAILURE
+\[main.assertion.1\] line [0-9]+ assertion x == 1: FAILURE
 \[main.assertion.2\] line [0-9]+ assertion x == 2: SUCCESS
-^VERIFICATION SUCCESSFUL$
+^VERIFICATION FAILED$
+^EXIT=10$
+^SIGNAL=0$
 --
 ^warning: ignoring

--- a/regression/cbmc/Function_Pointer20/main.c
+++ b/regression/cbmc/Function_Pointer20/main.c
@@ -1,0 +1,26 @@
+#include <assert.h>
+
+struct PtrWrapper
+{
+  char *value_c;
+};
+
+void fn(struct PtrWrapper wrapper)
+{
+  assert(wrapper.value_c == 'B');
+}
+
+void indirect(int (*fn_ptr)(char *), char *data)
+{
+  fn_ptr(data);
+  assert(0);
+}
+
+int main()
+{
+  struct PtrWrapper wrapper;
+  wrapper.value_c = 'A';
+
+  int (*alias)(char *) = (int (*)(char *))fn;
+  indirect(alias, &wrapper.value_c);
+}

--- a/regression/cbmc/Function_Pointer20/test.desc
+++ b/regression/cbmc/Function_Pointer20/test.desc
@@ -1,0 +1,10 @@
+CORE
+main.c
+
+^\*\*\*\* WARNING: no body for function indirect::fptr_call
+^\[indirect.assertion.1\] line 16 assertion 0: FAILURE$
+^VERIFICATION FAILED$
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring

--- a/regression/cbmc/Function_Pointer_Init_No_Candidate/main.c
+++ b/regression/cbmc/Function_Pointer_Init_No_Candidate/main.c
@@ -4,9 +4,7 @@ typedef int (*other_function_type)(int n);
 
 void foo(other_function_type other_function)
 {
-  // returning from the function call is unreachable -> the following assertion
-  //   should succeed
-  // requesting `pointer-check` will then catch the fact that there is no valid
+  // requesting `pointer-check` will catch the fact that there is no valid
   //   candidate function to call resulting in an invalid function pointer
   //   failure
   assert(other_function(4) > 5);

--- a/regression/cbmc/Function_Pointer_Init_No_Candidate/test.desc
+++ b/regression/cbmc/Function_Pointer_Init_No_Candidate/test.desc
@@ -1,7 +1,7 @@
 CORE
 main.c
 --function foo --pointer-check
-^\[foo.assertion.\d+\] line \d+ assertion other_function\(4\) > 5: SUCCESS$
+^\[foo.assertion.\d+\] line \d+ assertion other_function\(4\) > 5: FAILURE$
 ^\[foo.pointer_dereference.\d+\] line \d+ no candidates for dereferenced function pointer: FAILURE$
 ^EXIT=10$
 ^SIGNAL=0$

--- a/regression/goto-analyzer/value-set-function-pointers-simple/test.desc
+++ b/regression/goto-analyzer/value-set-function-pointers-simple/test.desc
@@ -10,7 +10,7 @@ main.c
 ^main::1::fun1 \(\) -> value-set-begin: ptr ->\(f\) :value-set-end
 ^main::1::fun2_show \(\) -> value-set-begin: ptr ->\(f\), ptr ->\(g\) :value-set-end
 ^main::1::fun3_show \(\) -> value-set-begin: ptr ->\(f\), ptr ->\(g\) :value-set-end
-^fun_global_show \(\) -> value-set-begin: ptr ->\(f\), ptr ->\(g\) :value-set-end
+^fun_global_show \(\) -> value-set-begin: TOP :value-set-end
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/goto-instrument/value-set-fi-fp-removal4/test.desc
+++ b/regression/goto-instrument/value-set-fi-fp-removal4/test.desc
@@ -5,6 +5,7 @@ test.c
 ^SIGNAL=0$
 ^file test.c line 20 function main: replacing function pointer by 2 possible targets$
 --
+--
 This test checks that the value-set-fi-based function pointer removal
 precisely identifies the function to call for a particular function pointer
 call.

--- a/regression/goto-instrument/value-set-fi-fp-removal5/test.desc
+++ b/regression/goto-instrument/value-set-fi-fp-removal5/test.desc
@@ -5,6 +5,7 @@ test.c
 ^SIGNAL=0$
 ^file test.c line 19 function main: replacing function pointer by 0 possible targets$
 --
+--
 This test checks that the value-set-fi-based function pointer removal
 precisely identifies the function to call for a particular function pointer
 call.

--- a/src/goto-instrument/value_set_fi_fp_removal.cpp
+++ b/src/goto-instrument/value_set_fi_fp_removal.cpp
@@ -31,6 +31,7 @@ void value_set_fi_fp_removal(
   message.status() << "Instrumenting" << messaget::eom;
 
   // now replace aliases by addresses
+  std::list<irep_idt> fall_back_fns;
   for(auto &f : goto_model.goto_functions.function_map)
   {
     for(auto target = f.second.body.instructions.begin();
@@ -69,18 +70,26 @@ void value_set_fi_fp_removal(
 
           if(functions.size() > 0)
           {
-            remove_function_pointer(
+            fall_back_fns.push_back(remove_function_pointer(
               message_handler,
               goto_model.symbol_table,
               f.second.body,
               f.first,
               target,
               functions,
-              true);
+              true));
           }
         }
       }
     }
   }
-  goto_model.goto_functions.update();
+
+  for(const auto &id : fall_back_fns)
+  {
+    goto_model.goto_functions.function_map[id].set_parameter_identifiers(
+      to_code_type(ns.lookup(id).type));
+  }
+
+  if(!fall_back_fns.empty())
+    goto_model.goto_functions.update();
 }

--- a/src/goto-programs/remove_function_pointers.h
+++ b/src/goto-programs/remove_function_pointers.h
@@ -14,6 +14,8 @@ Date: June 2003
 #ifndef CPROVER_GOTO_PROGRAMS_REMOVE_FUNCTION_POINTERS_H
 #define CPROVER_GOTO_PROGRAMS_REMOVE_FUNCTION_POINTERS_H
 
+#include <util/nodiscard.h>
+
 #include "goto_program.h"
 
 #include <unordered_set>
@@ -31,22 +33,6 @@ void remove_function_pointers(
   bool add_safety_assertion,
   bool only_remove_const_fps=false);
 
-void remove_function_pointers(
-  message_handlert &_message_handler,
-  symbol_tablet &symbol_table,
-  goto_functionst &goto_functions,
-  bool add_safety_assertion,
-  bool only_remove_const_fps=false);
-
-bool remove_function_pointers(
-  message_handlert &_message_handler,
-  symbol_tablet &symbol_table,
-  const goto_functionst &goto_functions,
-  goto_programt &goto_program,
-  const irep_idt &function_id,
-  bool add_safety_assertion,
-  bool only_remove_const_fps = false);
-
 /// Replace a call to a dynamic function at location
 /// target in the given goto-program by a case-split
 /// over a given set of functions
@@ -57,8 +43,10 @@ bool remove_function_pointers(
 /// \param target: location with function call with function pointer
 /// \param functions: The set of functions to consider
 /// \param add_safety_assertion: Iff true, include an assertion that the
-//         pointer matches one of the candidate functions
-void remove_function_pointer(
+///        pointer matches one of the candidate functions
+/// \return Name of fall back function symbol; this function must be added to
+///         GOTO functions by the caller.
+NODISCARD irep_idt remove_function_pointer(
   message_handlert &message_handler,
   symbol_tablet &symbol_table,
   goto_programt &goto_program,


### PR DESCRIPTION
The case where a function pointer matches none of the candidate
functions now introduces a call to a new function. No implementation of
this function is provided, leaving the choice to the user in case they
choose to use goto-instrument's generate-function-body.

As doing so requires updates to goto_functions by the caller, two unused
API variants of remove_function_pointers were removed.

Fixes: #6983

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
