### PR TITLE
string_constantt::to_array_expr must maintain the source location

### DIFF
--- a/regression/cbmc/String_Literal1/main.c
+++ b/regression/cbmc/String_Literal1/main.c
@@ -52,4 +52,6 @@ int main()
 
   // generic wide string, OS-dependent
   assert(sizeof(L""[0])==sizeof(wchar_t));
+
+  assert(0);
 }

--- a/regression/cbmc/String_Literal1/test.desc
+++ b/regression/cbmc/String_Literal1/test.desc
@@ -1,8 +1,15 @@
 CORE
 main.c
-
-^EXIT=0$
+--trace
+^State \d+ file main.c function main line 20 thread 0$
+^State \d+ file main.c function main line 36 thread 0$
+^State \d+ file main.c function main line 44 thread 0$
+^\*\* 1 of \d+ failed \(\d+ iterations\)$
+^VERIFICATION FAILED$
+^EXIT=10$
 ^SIGNAL=0$
-^VERIFICATION SUCCESSFUL$
 --
 ^warning: ignoring
+^State \d+ (function main )?thread 0$
+--
+Each step in the trace must have a full source location, including line numbers.

--- a/src/util/expr.h
+++ b/src/util/expr.h
@@ -98,6 +98,30 @@ public:
   const operandst &operands() const
   { return (const operandst &)get_sub(); }
 
+  /// Add the source location from \p other, if it has any.
+  template <typename T>
+  T &with_source_location(const exprt &other) &
+  {
+    static_assert(
+      std::is_base_of<exprt, T>::value,
+      "The template argument T must be derived from exprt.");
+    if(other.source_location().is_not_nil())
+      add_source_location() = other.source_location();
+    return *static_cast<T *>(this);
+  }
+
+  /// Add the source location from \p other, if it has any.
+  template <typename T>
+  T &&with_source_location(const exprt &other) &&
+  {
+    static_assert(
+      std::is_base_of<exprt, T>::value,
+      "The template argument T must be derived from exprt.");
+    if(other.source_location().is_not_nil())
+      add_source_location() = other.source_location();
+    return std::move(*static_cast<T *>(this));
+  }
+
 protected:
   exprt &op0()
   { return operands().front(); }

--- a/src/util/std_expr.h
+++ b/src/util/std_expr.h
@@ -1571,6 +1571,16 @@ public:
   {
     return static_cast<array_typet &>(multi_ary_exprt::type());
   }
+
+  array_exprt &with_source_location(const exprt &other) &
+  {
+    return exprt::with_source_location<array_exprt>(other);
+  }
+
+  array_exprt &&with_source_location(const exprt &other) &&
+  {
+    return std::move(*this).exprt::with_source_location<array_exprt>(other);
+  }
 };
 
 template <>

--- a/src/util/string_constant.cpp
+++ b/src/util/string_constant.cpp
@@ -53,5 +53,8 @@ array_exprt string_constantt::to_array_expr() const
     *it = from_integer(ch, char_type);
   }
 
+  if(source_location().is_not_nil())
+    dest.add_source_location() = source_location();
+
   return dest;
 }

--- a/src/util/string_constant.cpp
+++ b/src/util/string_constant.cpp
@@ -53,8 +53,5 @@ array_exprt string_constantt::to_array_expr() const
     *it = from_integer(ch, char_type);
   }
 
-  if(source_location().is_not_nil())
-    dest.add_source_location() = source_location();
-
-  return dest;
+  return std::move(dest).with_source_location(*this);
 }

--- a/src/util/string_constant.h
+++ b/src/util/string_constant.h
@@ -24,7 +24,6 @@ public:
   }
 
   array_exprt to_array_expr() const;
-  bool from_array_expr(const array_exprt &);
 };
 
 template <>


### PR DESCRIPTION
The C front-end uses this method to create arrays from string literals.
The resulting expression must have a source location to ensure the
resulting GOTO instruction knows which source location to use.

Fixes: #6994

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
