### PR TITLE
Regression tests for non-SMT2.6-standard array support

### DIFF
--- a/regression/cbmc-incr-smt2/arrays/bool_array_write.c
+++ b/regression/cbmc-incr-smt2/arrays/bool_array_write.c
@@ -1,0 +1,9 @@
+int main()
+{
+  __CPROVER_bool bool_array[100];
+  unsigned int index;
+  __CPROVER_assume(index < 10000);
+  bool_array[index] = 1;
+  __CPROVER_assert(bool_array[index], "Array condition");
+  __CPROVER_assert(!bool_array[index], "Array condition");
+}

--- a/regression/cbmc-incr-smt2/arrays/bool_array_write.desc
+++ b/regression/cbmc-incr-smt2/arrays/bool_array_write.desc
@@ -1,0 +1,11 @@
+KNOWNBUG
+bool_array_write.c
+
+Passing problem to incremental SMT2 solving
+\[main\.assertion\.1\] line \d+ Array condition: SUCCESS
+\[main\.assertion\.2\] line \d+ Array condition: FAILURE
+^EXIT=10$
+^SIGNAL=0$
+--
+--
+Test of updating the value at an index of a __CPROVER_bool (boolean) array.

--- a/regression/cbmc-incr-smt2/arrays/multi_dimension_array_write.c
+++ b/regression/cbmc-incr-smt2/arrays/multi_dimension_array_write.c
@@ -1,0 +1,11 @@
+int main()
+{
+  int example_array[10000][2000];
+  unsigned int index_i;
+  unsigned int index_j;
+  __CPROVER_assume(index_i < 10000);
+  __CPROVER_assume(index_j < 2000);
+  example_array[index_i][index_j] = 42;
+  __CPROVER_assert(example_array[index_i][index_j] == 42, "Array condition");
+  __CPROVER_assert(example_array[index_i][index_j] != 42, "Array condition");
+}

--- a/regression/cbmc-incr-smt2/arrays/multi_dimension_array_write.desc
+++ b/regression/cbmc-incr-smt2/arrays/multi_dimension_array_write.desc
@@ -1,0 +1,11 @@
+KNOWNBUG
+multi_dimension_array_write.c
+
+Passing problem to incremental SMT2 solving
+\[main\.assertion\.1\] line \d+ Array condition: SUCCESS
+\[main\.assertion\.2\] line \d+ Array condition: FAILURE
+^EXIT=10$
+^SIGNAL=0$
+--
+--
+Test of updating the value at an index of a __CPROVER_bool (boolean) array.


### PR DESCRIPTION
Add (disabled) regression tests for non-bit-vector arrays, specifically:
 - Arrays of booleans
 - Arrays of arrays

Although non SMTlib 2.6 standard the regression tests work with CVC5 and Z3 (>= 4.8.0), but fail on Z3 4.4 that is used in ubuntu 18.04.
For this reason, such tests have been marked `KNOWNBUG` until a decision is made on whether support them or not on ubuntu 18.04.

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.
