### PR TITLE
Fix SMT object tracking test

### DIFF
--- a/unit/solvers/smt2_incremental/object_tracking.cpp
+++ b/unit/solvers/smt2_incremental/object_tracking.cpp
@@ -17,6 +17,8 @@ TEST_CASE("find_object_base_expression", "[core][smt2_incremental]")
   const std::size_t pointer_bits = 64;
   SECTION("Address of symbol")
   {
+    // Constructed address of expression should be equivalent to the following
+    // C expression - `&base`.
     const typet base_type = unsignedbv_typet{8};
     const symbol_exprt object_base{"base", base_type};
     const address_of_exprt address_of{
@@ -26,6 +28,8 @@ TEST_CASE("find_object_base_expression", "[core][smt2_incremental]")
   }
   SECTION("Address of index")
   {
+    // Constructed address of expression should be equivalent to the following
+    // C expression - `&(base[index])`.
     const unsignedbv_typet element_type{8};
     const signedbv_typet index_type{pointer_bits};
     const array_typet base_type{element_type, from_integer(42, index_type)};
@@ -39,6 +43,8 @@ TEST_CASE("find_object_base_expression", "[core][smt2_incremental]")
   }
   SECTION("Address of struct member")
   {
+    // Constructed address of expression should be equivalent to the following
+    // C expression - `&(base.baz)`.
     const struct_tag_typet base_type{"structt"};
     const symbol_exprt object_base{"base", base_type};
     const unsignedbv_typet member_type{8};
@@ -50,6 +56,8 @@ TEST_CASE("find_object_base_expression", "[core][smt2_incremental]")
   }
   SECTION("Address of index of struct member")
   {
+    // Constructed address of expression should be equivalent to the following
+    // C expression - `&(base.baz[index])`.
     const struct_tag_typet base_type{"structt"};
     const symbol_exprt object_base{"base", base_type};
 
@@ -66,6 +74,8 @@ TEST_CASE("find_object_base_expression", "[core][smt2_incremental]")
   }
   SECTION("Address of struct member at index")
   {
+    // Constructed address of expression should be equivalent to the following
+    // C expression - `&(base[index].qux)`.
     const struct_tag_typet element_type{"struct_elementt"};
     const signedbv_typet index_type{pointer_bits};
     const array_typet base_type{element_type, from_integer(42, index_type)};

--- a/unit/solvers/smt2_incremental/object_tracking.cpp
+++ b/unit/solvers/smt2_incremental/object_tracking.cpp
@@ -2,7 +2,6 @@
 
 #include <util/c_types.h>
 #include <util/namespace.h>
-#include <util/optional.h>
 #include <util/std_expr.h>
 #include <util/symbol_table.h>
 
@@ -18,27 +17,36 @@ TEST_CASE("find_object_base_expression", "[core][smt2_incremental]")
   const symbol_exprt object_base{"base", base_type};
   const symbol_exprt index{"index", base_type};
   const pointer_typet pointer_type{base_type, 12};
-  std::string description;
-  optionalt<address_of_exprt> address_of;
-  using rowt = std::pair<std::string, address_of_exprt>;
-  std::tie(description, address_of) = GENERATE_REF(
-    rowt{"Address of symbol", {object_base, pointer_type}},
-    rowt{"Address of index", {index_exprt{object_base, index}, pointer_type}},
-    rowt{
-      "Address of struct member",
-      {member_exprt{object_base, "baz", unsignedbv_typet{8}}, pointer_type}},
-    rowt{
-      "Address of index of struct member",
-      {index_exprt{member_exprt{object_base, "baz", base_type}, index},
-       pointer_type}},
-    rowt{
-      "Address of struct member at index",
-      {member_exprt{
-         index_exprt{object_base, index}, "baz", unsignedbv_typet{8}},
-       pointer_type}});
-  SECTION(description)
+  SECTION("Address of symbol")
   {
-    CHECK(find_object_base_expression(*address_of) == object_base);
+    const address_of_exprt address_of{object_base, pointer_type};
+    CHECK(find_object_base_expression(address_of) == object_base);
+  }
+  SECTION("Address of index")
+  {
+    const address_of_exprt address_of{
+      index_exprt{object_base, index}, pointer_type};
+    CHECK(find_object_base_expression(address_of) == object_base);
+  }
+  SECTION("Address of struct member")
+  {
+    const address_of_exprt address_of{
+      member_exprt{object_base, "baz", unsignedbv_typet{8}}, pointer_type};
+    CHECK(find_object_base_expression(address_of) == object_base);
+  }
+  SECTION("Address of index of struct member")
+  {
+    const address_of_exprt address_of{
+      index_exprt{member_exprt{object_base, "baz", base_type}, index},
+      pointer_type};
+    CHECK(find_object_base_expression(address_of) == object_base);
+  }
+  SECTION("Address of struct member at index")
+  {
+    const address_of_exprt address_of{
+      member_exprt{index_exprt{object_base, index}, "baz", unsignedbv_typet{8}},
+      pointer_type};
+    CHECK(find_object_base_expression(address_of) == object_base);
   }
 }
 

--- a/unit/solvers/smt2_incremental/object_tracking.cpp
+++ b/unit/solvers/smt2_incremental/object_tracking.cpp
@@ -21,6 +21,7 @@ TEST_CASE("find_object_base_expression", "[core][smt2_incremental]")
     const symbol_exprt object_base{"base", base_type};
     const address_of_exprt address_of{
       object_base, pointer_typet{base_type, pointer_bits}};
+    INFO("Address of expression is: " + address_of.pretty(2, 0));
     CHECK(find_object_base_expression(address_of) == object_base);
   }
   SECTION("Address of index")
@@ -33,6 +34,7 @@ TEST_CASE("find_object_base_expression", "[core][smt2_incremental]")
     const pointer_typet pointer_type{element_type, pointer_bits};
     const address_of_exprt address_of{
       index_exprt{object_base, index}, pointer_type};
+    INFO("Address of expression is: " + address_of.pretty(2, 0));
     CHECK(find_object_base_expression(address_of) == object_base);
   }
   SECTION("Address of struct member")
@@ -43,6 +45,7 @@ TEST_CASE("find_object_base_expression", "[core][smt2_incremental]")
     const address_of_exprt address_of{
       member_exprt{object_base, "baz", member_type},
       pointer_typet{member_type, pointer_bits}};
+    INFO("Address of expression is: " + address_of.pretty(2, 0));
     CHECK(find_object_base_expression(address_of) == object_base);
   }
   SECTION("Address of index of struct member")
@@ -58,6 +61,7 @@ TEST_CASE("find_object_base_expression", "[core][smt2_incremental]")
     const address_of_exprt address_of{
       index_exprt{member_exprt{object_base, "baz", member_type}, index},
       pointer_typet{element_type, pointer_bits}};
+    INFO("Address of expression is: " + address_of.pretty(2, 0));
     CHECK(find_object_base_expression(address_of) == object_base);
   }
   SECTION("Address of struct member at index")
@@ -71,6 +75,7 @@ TEST_CASE("find_object_base_expression", "[core][smt2_incremental]")
     const address_of_exprt address_of{
       member_exprt{index_exprt{object_base, index}, "qux", member_type},
       pointer_typet{member_type, pointer_bits}};
+    INFO("Address of expression is: " + address_of.pretty(2, 0));
     CHECK(find_object_base_expression(address_of) == object_base);
   }
 }


### PR DESCRIPTION
A unit test was removed in https://github.com/diffblue/cbmc/pull/6949 . This PR adds the test back and fixes it.
<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
