### PR TITLE
Cleanup the API of bv_utilst::adder

### DIFF
--- a/src/solvers/flattening/bv_utils.h
+++ b/src/solvers/flattening/bv_utils.h
@@ -11,6 +11,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #define CPROVER_SOLVERS_FLATTENING_BV_UTILS_H
 
 #include <util/mp_arith.h>
+#include <util/nodiscard.h>
 
 #include <solvers/prop/prop.h>
 
@@ -221,19 +222,18 @@ public:
 protected:
   propt &prop;
 
-  void adder(
-    bvt &sum,
-    const bvt &op,
-    literalt carry_in,
-    literalt &carry_out);
+  /// Return the sum and carry-out when adding \p op0 and \p op1 under initial
+  /// carry \p carry_in.
+  NODISCARD std::pair<bvt, literalt>
+  adder(const bvt &op0, const bvt &op1, literalt carry_in);
 
-  void adder_no_overflow(
-    bvt &sum,
-    const bvt &op,
+  NODISCARD bvt adder_no_overflow(
+    const bvt &op0,
+    const bvt &op1,
     bool subtract,
     representationt rep);
 
-  void adder_no_overflow(bvt &sum, const bvt &op);
+  NODISCARD bvt adder_no_overflow(const bvt &op0, const bvt &op1);
 
   bvt unsigned_multiplier_no_overflow(
     const bvt &op0, const bvt &op1);


### PR DESCRIPTION
Don't make every caller create an uninitialised literal.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
