### PR TITLE
bv_get_rec: ensure all expressions are properly typed

### DIFF
--- a/regression/cbmc/Unbounded_Array6/main.c
+++ b/regression/cbmc/Unbounded_Array6/main.c
@@ -1,0 +1,12 @@
+struct S
+{
+  int x;
+};
+
+int main()
+{
+  unsigned size;
+  __CPROVER_assume(size > 0);
+  struct S array[size];
+  __CPROVER_assert(array[0].x == 0, "not always zero");
+}

--- a/regression/cbmc/Unbounded_Array6/test.desc
+++ b/regression/cbmc/Unbounded_Array6/test.desc
@@ -1,0 +1,10 @@
+CORE
+main.c
+--trace
+^VERIFICATION FAILED$
+^EXIT=10$
+^SIGNAL=0$
+--
+^Invariant check failed
+--
+This test requires that bv_get_rec always uses properly typed expressions.

--- a/src/solvers/flattening/boolbv.h
+++ b/src/solvers/flattening/boolbv.h
@@ -243,11 +243,8 @@ protected:
 
   virtual exprt bv_get_unbounded_array(const exprt &) const;
 
-  virtual exprt bv_get_rec(
-    const exprt &expr,
-    const bvt &bv,
-    std::size_t offset,
-    const typet &type) const;
+  virtual exprt
+  bv_get_rec(const exprt &expr, const bvt &bv, std::size_t offset) const;
 
   exprt bv_get(const bvt &bv, const typet &type) const;
   exprt bv_get_cache(const exprt &expr) const;

--- a/src/solvers/flattening/bv_pointers.cpp
+++ b/src/solvers/flattening/bv_pointers.cpp
@@ -769,11 +769,12 @@ static std::string bits_to_string(const propt &prop, const bvt &bv)
 exprt bv_pointerst::bv_get_rec(
   const exprt &expr,
   const bvt &bv,
-  std::size_t offset,
-  const typet &type) const
+  std::size_t offset) const
 {
+  const typet &type = expr.type();
+
   if(type.id() != ID_pointer)
-    return SUB::bv_get_rec(expr, bv, offset, type);
+    return SUB::bv_get_rec(expr, bv, offset);
 
   const pointer_typet &pt = to_pointer_type(type);
   const std::size_t bits = boolbv_width(pt);

--- a/src/solvers/flattening/bv_pointers.h
+++ b/src/solvers/flattening/bv_pointers.h
@@ -52,8 +52,7 @@ protected:
   bvt convert_bitvector(const exprt &) override; // no cache
 
   exprt
-  bv_get_rec(const exprt &, const bvt &, std::size_t offset, const typet &)
-    const override;
+  bv_get_rec(const exprt &, const bvt &, std::size_t offset) const override;
 
   NODISCARD
   optionalt<bvt> convert_address_of_rec(const exprt &);


### PR DESCRIPTION
The regression test included here failed as of 55fc1928 for a
member_exprt over an untyped nil_exprt was being constructed. While at
it, get rid of the split-brain problem that passing the type separately
from the expression had created.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
