### PR TITLE
Cleanup GOTO model validation of function calls

### DIFF
--- a/src/goto-programs/validate_goto_model.h
+++ b/src/goto-programs/validate_goto_model.h
@@ -18,18 +18,13 @@ public:
   // this check is disabled by default (not all goto programs
   // have an entry point)
   bool entry_point_exists = false;
-
-  bool function_pointer_calls_removed = true;
   bool check_returns_removed = true;
-  bool check_called_functions = true;
 
 private:
   void set_all_flags(bool options_value)
   {
     entry_point_exists = options_value;
-    function_pointer_calls_removed = options_value;
     check_returns_removed = options_value;
-    check_called_functions = options_value;
   }
 
 public:

--- a/unit/goto-programs/goto_program_validate.cpp
+++ b/unit/goto-programs/goto_program_validate.cpp
@@ -132,59 +132,6 @@ SCENARIO("Validation of a goto program", "[core][goto-programs][validate]")
     }
   }
 
-  /// check function_pointer_calls_removed()
-  WHEN("not all function calls via fn pointer have been removed")
-  {
-    THEN("fail!")
-    {
-      // introduce function k that has a function pointer call;
-      symbolt k;
-      k.name = "k";
-      k.mode = ID_C;
-      k.type = code_typet({}, empty_typet{}); // void return, take no params
-
-      code_function_callt function_call{
-        dereference_exprt{fn_ptr.symbol_expr(),
-                          pointer_typet(code_typet{{}, empty_typet{}}, 64)}};
-
-      code_blockt k_body{{function_call}};
-      k.value = k_body;
-
-      goto_model.symbol_table.add(k);
-      goto_convert(goto_model, null_message_handler);
-
-      goto_model_validation_optionst validation_options{
-        goto_model_validation_optionst ::set_optionst::all_false};
-
-      validation_options.function_pointer_calls_removed = true;
-
-      REQUIRE_THROWS_AS(
-        validate_goto_model(
-          goto_model.goto_functions,
-          validation_modet::EXCEPTION,
-          validation_options),
-        incorrect_goto_program_exceptiont);
-    }
-  }
-
-  WHEN("all function calls via fn pointer have been removed")
-  {
-    THEN("pass!")
-    {
-      goto_convert(goto_model, null_message_handler);
-
-      goto_model_validation_optionst validation_options{
-        goto_model_validation_optionst ::set_optionst::all_false};
-
-      validation_options.function_pointer_calls_removed = true;
-
-      REQUIRE_NOTHROW(validate_goto_model(
-        goto_model.goto_functions,
-        validation_modet::EXCEPTION,
-        validation_options));
-    }
-  }
-
   WHEN("all returns have been removed")
   {
     THEN("true!")
@@ -218,8 +165,6 @@ SCENARIO("Validation of a goto program", "[core][goto-programs][validate]")
       goto_model_validation_optionst validation_options{
         goto_model_validation_optionst ::set_optionst::all_false};
 
-      validation_options.check_called_functions = true;
-
       REQUIRE_THROWS_AS(
         validate_goto_model(
           goto_model.goto_functions,
@@ -242,8 +187,6 @@ SCENARIO("Validation of a goto program", "[core][goto-programs][validate]")
       goto_model_validation_optionst validation_options{
         goto_model_validation_optionst ::set_optionst::all_false};
 
-      validation_options.check_called_functions = true;
-
       REQUIRE_THROWS_AS(
         validate_goto_model(
           goto_model.goto_functions,
@@ -263,8 +206,6 @@ SCENARIO("Validation of a goto program", "[core][goto-programs][validate]")
 
       goto_model_validation_optionst validation_options{
         goto_model_validation_optionst ::set_optionst::all_false};
-
-      validation_options.check_called_functions = true;
 
       REQUIRE_NOTHROW(validate_goto_model(
         goto_model.goto_functions,


### PR DESCRIPTION
Function calls can use dereference expressions or symbol expressions,
but nothing else. There is no need to make this configurable for those
ought to be invariants.

Fixes: #7022

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
