### PR TITLE
Value sets: track pointers through shifts

### DIFF
--- a/regression/cbmc/Pointer2/main.c
+++ b/regression/cbmc/Pointer2/main.c
@@ -1,0 +1,10 @@
+int main()
+{
+  int x;
+  unsigned long long x_i;
+  _Static_assert(sizeof(&x) == sizeof(x_i), "pointer width");
+  __CPROVER_assert(((unsigned long long)&x & 0x1ULL) == 0, "LSB is zero");
+  x_i = (unsigned long long)&x >> 1;
+  x_i <<= 1;
+  __CPROVER_assert(*(int *)x_i == x, "pointer to x is tracked through shifts");
+}

--- a/regression/cbmc/Pointer2/test.desc
+++ b/regression/cbmc/Pointer2/test.desc
@@ -1,0 +1,11 @@
+CORE
+main.c
+
+^VERIFICATION SUCCESSFUL$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--
+Value sets must also track pointers the integer conversion of which is subject
+to shifts (just like we already tracked them through other bit operations).

--- a/src/pointer-analysis/value_set.cpp
+++ b/src/pointer-analysis/value_set.cpp
@@ -760,6 +760,24 @@ void value_sett::get_value_set_rec(
       insert(dest, it->first, offset);
     }
   }
+  else if(expr.id() == ID_lshr || expr.id() == ID_ashr || expr.id() == ID_shl)
+  {
+    const binary_exprt &binary_expr = to_binary_expr(expr);
+
+    object_mapt pointer_expr_set;
+    get_value_set_rec(
+      binary_expr.op0(), pointer_expr_set, "", binary_expr.op0().type(), ns);
+
+    for(const auto &object_map_entry : pointer_expr_set.read())
+    {
+      offsett offset = object_map_entry.second;
+
+      // kill any offset
+      offset.reset();
+
+      insert(dest, object_map_entry.first, offset);
+    }
+  }
   else if(expr.id()==ID_side_effect)
   {
     const irep_idt &statement = to_side_effect_expr(expr).get_statement();


### PR DESCRIPTION
We already tracked pointers through other bit operations, but had not
taken shifts into account.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
