### PR TITLE
solvers.a is not used in goto-analyzer so remove the dependency

### DIFF
--- a/src/goto-analyzer/Makefile
+++ b/src/goto-analyzer/Makefile
@@ -22,7 +22,6 @@ OBJ += ../ansi-c/ansi-c$(LIBEXT) \
       ../langapi/langapi$(LIBEXT) \
       ../json/json$(LIBEXT) \
       ../assembler/assembler$(LIBEXT) \
-      ../solvers/solvers$(LIBEXT) \
       ../util/util$(LIBEXT) \
       # Empty last line
 


### PR DESCRIPTION
Note that the module dependencies already blocks including files from
solvers/.
