### PR TITLE
Move CI runners away from `macOS-10.15` because of sunsetting by Github.

### DIFF
--- a/.github/workflows/pull-request-checks.yaml
+++ b/.github/workflows/pull-request-checks.yaml
@@ -382,8 +382,8 @@ jobs:
       - name: Run tests
         run: cd build; ctest . -V -L THOROUGH -j2
 
-  check-macos-10_15-make-clang:
-    runs-on: macos-10.15
+  check-macos-11-make-clang:
+    runs-on: macos-11
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/pull-request-checks.yaml
+++ b/.github/workflows/pull-request-checks.yaml
@@ -432,48 +432,6 @@ jobs:
       - name: Run JBMC regression tests
         run: make -C jbmc/regression test-parallel JOBS=3
 
-  check-macos-11-cmake-clang:
-    runs-on: macos-11
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          submodules: recursive
-      - name: Fetch dependencies
-        run: brew install cmake ninja maven flex bison ccache z3
-      - name: Confirm z3 solver is available and log the version installed
-        run: z3 --version
-      - name: Download cvc5 binary and make sure it can be deployed
-        run: |
-          curl -L https://github.com/cvc5/cvc5/releases/download/cvc5-${{env.cvc5-version}}/cvc5-macOS --output cvc5
-          chmod u+x cvc5
-          mv cvc5 /usr/local/bin
-          cvc5 --version
-      - name: Prepare ccache
-        uses: actions/cache@v2
-        with:
-          path: .ccache
-          key: ${{ runner.os }}-Release-${{ github.ref }}-${{ github.sha }}-PR
-          restore-keys: |
-            ${{ runner.os }}-Release-${{ github.ref }}
-            ${{ runner.os }}-Release
-      - name: ccache environment
-        run: |
-          echo "CCACHE_BASEDIR=$PWD" >> $GITHUB_ENV
-          echo "CCACHE_DIR=$PWD/.ccache" >> $GITHUB_ENV
-      - name: Zero ccache stats and limit in size
-        run: ccache -z --max-size=500M
-      - name: Configure using CMake
-        run: |
-          mkdir build
-          cd build
-          cmake .. -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=/usr/bin/clang -DCMAKE_CXX_COMPILER=/usr/bin/clang++ -Dsat_impl=glucose
-      - name: Build with Ninja
-        run: cd build; ninja -j3
-      - name: Print ccache stats
-        run: ccache -s
-      - name: Run CTest
-        run: cd build; ctest -V -L CORE . -j3
-
   check-macos-12-cmake-clang:
     runs-on: macos-12
     steps:

--- a/.github/workflows/release-packages.yaml
+++ b/.github/workflows/release-packages.yaml
@@ -144,7 +144,7 @@ jobs:
 
 
   homebrew-pr:
-    runs-on: macos-10.15
+    runs-on: macos-11
     steps:
       - name: Get release tag name
         # The GITHUB_REF we get has refs/tags/ in front of the tag name so we


### PR DESCRIPTION
There's a scheduled removal of the image by 30 Aug 2022, with intermittent
failing of those runners to raise awareness to that effect. We need to
move our CI runners to at least `macOS-11` to preempt any failures.

Fixes #7027.