### PR TITLE
Deprecate and remove from the build an unused 2-line utility function

### DIFF
--- a/src/pointer-analysis/Makefile
+++ b/src/pointer-analysis/Makefile
@@ -1,6 +1,5 @@
 SRC = add_failed_symbols.cpp \
       goto_program_dereference.cpp \
-      rewrite_index.cpp \
       show_value_sets.cpp \
       value_set.cpp \
       value_set_analysis.cpp \

--- a/src/pointer-analysis/rewrite_index.h
+++ b/src/pointer-analysis/rewrite_index.h
@@ -12,11 +12,13 @@ Author: Daniel Kroening, kroening@kroening.com
 #ifndef CPROVER_POINTER_ANALYSIS_REWRITE_INDEX_H
 #define CPROVER_POINTER_ANALYSIS_REWRITE_INDEX_H
 
+#include <util/deprecate.h>
+
 class dereference_exprt;
 class index_exprt;
 
 // rewrite a[i] to *(a+i)
-
+DEPRECATED(SINCE(2022, 07, 23, "implement the transform directly"))
 dereference_exprt rewrite_index(const index_exprt &index_expr);
 
 #endif // CPROVER_POINTER_ANALYSIS_REWRITE_INDEX_H


### PR DESCRIPTION
<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
