### PR TITLE
Add support for is_invalid_pointer in new SMT2 backend

### DIFF
--- a/regression/cbmc-incr-smt2/pointers/pointer_is_invalid.c
+++ b/regression/cbmc-incr-smt2/pointers/pointer_is_invalid.c
@@ -1,0 +1,14 @@
+#include <assert.h>
+#include <stdlib.h>
+
+void main()
+{
+  // special value of the invalid pointer (object bits = 1 and offset = 0), as
+  // checked for by __CPROVER_is_invalid_pointer()
+  char *p = (size_t)1 << (sizeof(char *) * 8 - 8);
+  __CPROVER_assert(
+    __CPROVER_is_invalid_pointer(p), "INVALID pointer, so passing");
+  int i;
+  __CPROVER_assert(
+    __CPROVER_is_invalid_pointer(&i), "VALID pointer, so failing");
+}

--- a/regression/cbmc-incr-smt2/pointers/pointer_is_invalid.desc
+++ b/regression/cbmc-incr-smt2/pointers/pointer_is_invalid.desc
@@ -1,0 +1,13 @@
+CORE
+pointer_is_invalid.c
+
+Passing problem to incremental SMT2 solving
+\[main\.assertion\.1\] line \d+ INVALID pointer, so passing: SUCCESS
+\[main\.assertion\.2\] line \d+ VALID pointer, so failing: FAILURE
+^VERIFICATION FAILED$
+^EXIT=10$
+^SIGNAL=0$
+--
+--
+Tests that an inconsistent assumption involving the special invalid pointer
+value and __CPROVER_r_ok() can be detected via assert(0).

--- a/regression/cbmc-incr-smt2/pointers/pointer_object3.c
+++ b/regression/cbmc-incr-smt2/pointers/pointer_object3.c
@@ -12,8 +12,9 @@ int main()
     __CPROVER_POINTER_OBJECT(NULL) != 0,
     "expected to fail with object ID == 0");
   // In the case where the program contains a single address of operation,
-  // the pointer object is going to be 1.
+  // the pointer object is going to be 2 (1 is invalid pointer that is tested
+  // somewhere else).
   __CPROVER_assert(
-    __CPROVER_POINTER_OBJECT(&foo) != 1,
-    "expected to fail with object ID == 1");
+    __CPROVER_POINTER_OBJECT(&foo) != 2,
+    "expected to fail with object ID == 2");
 }

--- a/regression/cbmc-incr-smt2/pointers/pointer_object3.desc
+++ b/regression/cbmc-incr-smt2/pointers/pointer_object3.desc
@@ -2,7 +2,7 @@ CORE
 pointer_object3.c
 
 \[main\.assertion\.1] line \d+ expected to fail with object ID == 0: FAILURE
-\[main\.assertion\.2] line \d+ expected to fail with object ID == 1: FAILURE
+\[main\.assertion\.2] line \d+ expected to fail with object ID == 2: FAILURE
 ^VERIFICATION FAILED$
 ^EXIT=10$
 ^SIGNAL=0$

--- a/src/solvers/smt2_incremental/object_tracking.cpp
+++ b/src/solvers/smt2_incremental/object_tracking.cpp
@@ -9,6 +9,11 @@
 #include <util/std_expr.h>
 #include <util/string_constant.h>
 
+exprt make_invalid_pointer_expr()
+{
+  return constant_exprt(ID_invalid, pointer_type(void_type()));
+}
+
 exprt find_object_base_expression(const address_of_exprt &address_of)
 {
   auto current = std::ref(address_of.object());
@@ -47,12 +52,28 @@ static decision_procedure_objectt make_null_object()
   return null_object;
 }
 
+static decision_procedure_objectt make_invalid_pointer_object()
+{
+  decision_procedure_objectt invalid_pointer_object;
+  // Using unique_id = 1, so 0 is the NULL object, 1 is the invalid object and
+  // other valid objects have unique_id > 1.
+  invalid_pointer_object.unique_id = 1;
+  invalid_pointer_object.base_expression = make_invalid_pointer_expr();
+  invalid_pointer_object.size = from_integer(0, size_type());
+  return invalid_pointer_object;
+}
+
 smt_object_mapt initial_smt_object_map()
 {
   smt_object_mapt object_map;
   decision_procedure_objectt null_object = make_null_object();
-  exprt base = null_object.base_expression;
-  object_map.emplace(std::move(base), std::move(null_object));
+  exprt null_object_base = null_object.base_expression;
+  object_map.emplace(std::move(null_object_base), std::move(null_object));
+  decision_procedure_objectt invalid_pointer_object =
+    make_invalid_pointer_object();
+  exprt invalid_pointer_object_base = invalid_pointer_object.base_expression;
+  object_map.emplace(
+    std::move(invalid_pointer_object_base), std::move(invalid_pointer_object));
   return object_map;
 }
 

--- a/src/solvers/smt2_incremental/object_tracking.h
+++ b/src/solvers/smt2_incremental/object_tracking.h
@@ -115,4 +115,7 @@ bool objects_are_already_tracked(
   const exprt &expression,
   const smt_object_mapt &object_map);
 
+/// \brief Create the invalid pointer constant
+exprt make_invalid_pointer_expr();
+
 #endif // CPROVER_SOLVERS_SMT2_INCREMENTAL_OBJECT_TRACKING_H

--- a/unit/solvers/smt2_incremental/convert_expr_to_smt.cpp
+++ b/unit/solvers/smt2_incremental/convert_expr_to_smt.cpp
@@ -1358,20 +1358,20 @@ TEST_CASE(
     {
       config.bv_encoding.object_bits = 8;
       const auto converted = test.convert(address_of_foo);
-      CHECK(test.object_map.at(foo).unique_id == 1);
+      CHECK(test.object_map.at(foo).unique_id == 2);
       CHECK(
         converted == smt_bit_vector_theoryt::concat(
-                       smt_bit_vector_constant_termt{1, 8},
+                       smt_bit_vector_constant_termt{2, 8},
                        smt_bit_vector_constant_termt{0, 56}));
     }
     SECTION("16 object bits")
     {
       config.bv_encoding.object_bits = 16;
       const auto converted = test.convert(address_of_foo);
-      CHECK(test.object_map.at(foo).unique_id == 1);
+      CHECK(test.object_map.at(foo).unique_id == 2);
       CHECK(
         converted == smt_bit_vector_theoryt::concat(
-                       smt_bit_vector_constant_termt{1, 16},
+                       smt_bit_vector_constant_termt{2, 16},
                        smt_bit_vector_constant_termt{0, 48}));
     }
   }
@@ -1429,15 +1429,15 @@ TEST_CASE(
     track_expression_objects(comparison, ns, test.object_map);
     INFO("Expression " + comparison.pretty(1, 0));
     const auto converted = test.convert(comparison);
-    CHECK(test.object_map.at(foo).unique_id == 2);
-    CHECK(test.object_map.at(bar).unique_id == 1);
+    CHECK(test.object_map.at(foo).unique_id == 3);
+    CHECK(test.object_map.at(bar).unique_id == 2);
     CHECK(
       converted == smt_core_theoryt::distinct(
                      smt_bit_vector_theoryt::concat(
-                       smt_bit_vector_constant_termt{2, 8},
+                       smt_bit_vector_constant_termt{3, 8},
                        smt_bit_vector_constant_termt{0, 56}),
                      smt_bit_vector_theoryt::concat(
-                       smt_bit_vector_constant_termt{1, 8},
+                       smt_bit_vector_constant_termt{2, 8},
                        smt_bit_vector_constant_termt{0, 56})));
   }
 }
@@ -1543,7 +1543,7 @@ TEST_CASE(
   const object_size_exprt object_size{
     address_of_exprt{foo}, unsignedbv_typet{64}};
   track_expression_objects(object_size, ns, test.object_map);
-  const auto foo_id = 1;
+  const auto foo_id = 2;
   CHECK(test.object_map.at(foo).unique_id == foo_id);
   const auto object_bits = config.bv_encoding.object_bits;
   const auto object = smt_bit_vector_constant_termt{foo_id, object_bits};

--- a/unit/solvers/smt2_incremental/convert_expr_to_smt.cpp
+++ b/unit/solvers/smt2_incremental/convert_expr_to_smt.cpp
@@ -223,6 +223,27 @@ TEST_CASE(
 }
 
 TEST_CASE(
+  "expr to smt conversion for \"is_invalid_pointer\" operator",
+  "[core][smt2_incremental]")
+{
+  const std::size_t object_bits = config.bv_encoding.object_bits;
+  const auto test =
+    expr_to_smt_conversion_test_environmentt::make(test_archt::x86_64);
+  const pointer_typet pointer_type = ::pointer_type(void_type());
+  const std::size_t pointer_width = pointer_type.get_width();
+  const constant_exprt invalid_ptr{
+    integer2bvrep(1ul << (pointer_width - object_bits), pointer_width),
+    pointer_type};
+  const is_invalid_pointer_exprt is_invalid_ptr{invalid_ptr};
+  const smt_termt expected_smt_term = smt_core_theoryt::equal(
+    smt_bit_vector_constant_termt{1, config.bv_encoding.object_bits},
+    smt_bit_vector_theoryt::extract(
+      pointer_width - 1,
+      pointer_width - object_bits)(test.convert(invalid_ptr)));
+  CHECK(test.convert(is_invalid_ptr) == expected_smt_term);
+}
+
+TEST_CASE(
   "expr to smt conversion for \"xor\" operator",
   "[core][smt2_incremental]")
 {

--- a/unit/solvers/smt2_incremental/object_tracking.cpp
+++ b/unit/solvers/smt2_incremental/object_tracking.cpp
@@ -118,11 +118,20 @@ TEST_CASE("Tracking object base expressions", "[core][smt2_incremental]")
   smt_object_mapt object_map = initial_smt_object_map();
   SECTION("Check initial object map has null pointer")
   {
-    REQUIRE(object_map.size() == 1);
+    REQUIRE(object_map.size() == 2);
     const exprt null_pointer = null_pointer_exprt{::pointer_type(void_type())};
-    CHECK(object_map.begin()->first == null_pointer);
-    CHECK(object_map.begin()->second.unique_id == 0);
-    CHECK(object_map.begin()->second.base_expression == null_pointer);
+    const auto actual_null_object = object_map.find(null_pointer);
+    CHECK(actual_null_object->first == null_pointer);
+    CHECK(actual_null_object->second.unique_id == 0);
+    CHECK(actual_null_object->second.base_expression == null_pointer);
+    const exprt invalid_object_pointer = make_invalid_pointer_expr();
+    const auto actual_invalid_object_pointer =
+      object_map.find(invalid_object_pointer);
+    CHECK(actual_invalid_object_pointer->first == invalid_object_pointer);
+    CHECK(actual_invalid_object_pointer->second.unique_id == 1);
+    CHECK(
+      actual_invalid_object_pointer->second.base_expression ==
+      invalid_object_pointer);
   }
   symbol_tablet symbol_table;
   namespacet ns{symbol_table};
@@ -133,15 +142,15 @@ TEST_CASE("Tracking object base expressions", "[core][smt2_incremental]")
   track_expression_objects(compound_expression, ns, object_map);
   SECTION("Tracking expression objects")
   {
-    CHECK(object_map.size() == 4);
+    CHECK(object_map.size() == 5);
     const auto foo_object = object_map.find(foo);
     REQUIRE(foo_object != object_map.end());
     CHECK(foo_object->second.base_expression == foo);
-    CHECK(foo_object->second.unique_id == 3);
+    CHECK(foo_object->second.unique_id == 4);
     const auto bar_object = object_map.find(bar);
     REQUIRE(bar_object != object_map.end());
     CHECK(bar_object->second.base_expression == bar);
-    CHECK(bar_object->second.unique_id == 1);
+    CHECK(bar_object->second.unique_id == 2);
   }
   SECTION("Confirming objects are tracked.")
   {


### PR DESCRIPTION
Add support for `is_invalid_pointer_exprt` in new SMT2 backend allowing support for `__CPROVER_is_invalid_pointer`.

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.