### PR TITLE
CONTRACTS: Populate function name in source locations

### DIFF
--- a/regression/contracts/assigns_repeated_ignored/test.desc
+++ b/regression/contracts/assigns_repeated_ignored/test.desc
@@ -1,7 +1,7 @@
 CORE
 main.c
 --enforce-contract foo
-^Ignored duplicate expression '\*x' in assigns clause spec at file main.c line \d+$
+^Ignored duplicate expression '\*x' in assigns clause spec at file main.c line \d+ function .*$
 ^EXIT=0$
 ^SIGNAL=0$
 ^VERIFICATION SUCCESSFUL$

--- a/regression/contracts/assigns_validity_pointer_02/test.desc
+++ b/regression/contracts/assigns_validity_pointer_02/test.desc
@@ -3,7 +3,7 @@ main.c
 --enforce-contract foo
 ^EXIT=0$
 ^SIGNAL=0$
-^\[postcondition.\d+\] file main.c line \d+ Check ensures clause: SUCCESS$
+^\[foo.postcondition.\d+\] line \d+ Check ensures clause: SUCCESS$
 ^\[bar.assigns.\d+\] line \d+ Check that \*x is assignable: SUCCESS$
 ^\[bar.assigns.\d+\] line \d+ Check that \*y is assignable: SUCCESS$
 ^\[baz.assigns.\d+\] line \d+ Check that \*z is assignable: SUCCESS$

--- a/regression/contracts/contracts_with_function_pointers/test.desc
+++ b/regression/contracts/contracts_with_function_pointers/test.desc
@@ -3,7 +3,7 @@ main.c
 --enforce-contract bar
 ^EXIT=0$
 ^SIGNAL=0$
-^\[postcondition.\d+\] file main.c line \d+ Check ensures clause: SUCCESS$
+^\[bar.postcondition.\d+\] line \d+ Check ensures clause: SUCCESS$
 ^\[bar.assigns.\d+\] line \d+ Check that \*return\_value\_baz is assignable: SUCCESS$
 ^\[foo.assigns.\d+\] line \d+ Check that \*y is assignable: SUCCESS$
 ^VERIFICATION SUCCESSFUL$

--- a/regression/contracts/embedded_contract_fail_01/main.c
+++ b/regression/contracts/embedded_contract_fail_01/main.c
@@ -1,0 +1,18 @@
+typedef void (*fun_ptr_t)(int x);
+
+void bar(int x)
+{
+  return;
+}
+
+void foo(void (*fun_ptr)(int x) __CPROVER_requires(x != 0))
+{
+  return;
+}
+
+void main()
+{
+  fun_ptr_t fun_ptr = bar;
+  foo(fun_ptr);
+  return;
+}

--- a/regression/contracts/embedded_contract_fail_01/test.desc
+++ b/regression/contracts/embedded_contract_fail_01/test.desc
@@ -1,0 +1,12 @@
+CORE
+main.c
+
+^.*: Function contracts allowed only at top-level declarations. .*$
+^PARSING ERROR$
+^EXIT=(1|64)$
+^SIGNAL=0$
+--
+--
+Checks if function contracts can be attached to function pointers
+(with non-empty parameter lists) in function parameters.  This should
+fail.  Exit code 64 for Windows servers.

--- a/regression/contracts/embedded_contract_fail_02/main.c
+++ b/regression/contracts/embedded_contract_fail_02/main.c
@@ -1,0 +1,18 @@
+typedef int (*fun_ptr_t)();
+
+int bar()
+{
+  return 1;
+}
+
+void foo(int (*fun_ptr)() __CPROVER_ensures(__CPROVER_return_value == 1))
+{
+  return;
+}
+
+void main()
+{
+  fun_ptr_t fun_ptr = bar;
+  foo(fun_ptr);
+  return;
+}

--- a/regression/contracts/embedded_contract_fail_02/test.desc
+++ b/regression/contracts/embedded_contract_fail_02/test.desc
@@ -1,0 +1,12 @@
+CORE
+main.c
+
+^.*: Function contracts allowed only at top-level declarations. .*$
+^PARSING ERROR$
+^EXIT=(1|64)$
+^SIGNAL=0$
+--
+--
+Checks if function contracts can be attached to function pointers
+(with empty parameter lists) in function parameters.  This should
+fail.  Exit code 64 for Windows servers.

--- a/regression/contracts/function-calls-05/test.desc
+++ b/regression/contracts/function-calls-05/test.desc
@@ -3,7 +3,7 @@ main.c
 --enforce-contract foo
 ^EXIT=0$
 ^SIGNAL=0$
-\[postcondition.\d+\] file main.c line \d+ Check ensures clause: SUCCESS
+\[foo.postcondition.\d+\] line \d+ Check ensures clause: SUCCESS
 \[main.assertion.\d+\] line \d+ assertion foo\(\&x, \&y\) \=\= 10: SUCCESS
 ^VERIFICATION SUCCESSFUL$
 --

--- a/regression/contracts/function-pointer-contracts-replace/test.desc
+++ b/regression/contracts/function-pointer-contracts-replace/test.desc
@@ -1,7 +1,7 @@
 CORE
 main.c
 --replace-call-with-contract foo
-^\[precondition.\d+] file main.c line 19 Assert function pointer 'infun' obeys contract 'contract': SUCCESS$
+^\[foo.precondition.\d+] line 19 Assert function pointer 'infun' obeys contract 'contract': SUCCESS$
 ^\[main.assertion.\d+].* assertion outfun1 == contract: SUCCESS$
 ^\[main.assertion.\d+].* assertion outfun2 == contract: SUCCESS$
 ^EXIT=0$

--- a/regression/contracts/history-pointer-enforce-09/test.desc
+++ b/regression/contracts/history-pointer-enforce-09/test.desc
@@ -3,7 +3,7 @@ main.c
 --enforce-contract foo
 ^EXIT=0$
 ^SIGNAL=0$
-^\[postcondition.\d+\] file main.c line \d+ Check ensures clause: SUCCESS$
+^\[foo.postcondition.\d+\] line \d+ Check ensures clause: SUCCESS$
 ^\[foo.assigns.\d+\] line \d+ Check that p->y is assignable: SUCCESS$
 ^VERIFICATION SUCCESSFUL$
 --

--- a/regression/contracts/history-pointer-enforce-10/test.desc
+++ b/regression/contracts/history-pointer-enforce-10/test.desc
@@ -3,9 +3,9 @@ main.c
 --enforce-contract foo --enforce-contract bar --enforce-contract baz
 ^EXIT=0$
 ^SIGNAL=0$
-^\[postcondition.\d+\] file main.c line \d+ Check ensures clause: SUCCESS$
-^\[postcondition.\d+\] file main.c line \d+ Check ensures clause: SUCCESS$
-^\[postcondition.\d+\] file main.c line \d+ Check ensures clause: SUCCESS$
+^\[bar.postcondition.\d+\] line \d+ Check ensures clause: SUCCESS$
+^\[baz.postcondition.\d+\] line \d+ Check ensures clause: SUCCESS$
+^\[foo.postcondition.\d+\] line \d+ Check ensures clause: SUCCESS$
 ^\[bar.assigns.\d+\] line \d+ Check that p->y is assignable: SUCCESS$
 ^\[foo.assigns.\d+\] line \d+ Check that \*p->y is assignable: SUCCESS$
 ^\[foo.assigns.\d+\] line \d+ Check that z is assignable: SUCCESS$

--- a/regression/contracts/history-pointer-replace-01/test.desc
+++ b/regression/contracts/history-pointer-replace-01/test.desc
@@ -5,7 +5,7 @@ main.c
 ^SIGNAL=0$
 ^VERIFICATION SUCCESSFUL$
 ASSERT \*\(address_of.*n.*\) > 0
-ASSUME \*\(address_of.*n.*\) = tmp_cc[\$\d]? \+ 2
+ASSUME \*\(address_of.*n.*\) = .*tmp_cc[\$\d]? \+ 2
 --
 --
 Verification:

--- a/regression/contracts/history-pointer-replace-02/test.desc
+++ b/regression/contracts/history-pointer-replace-02/test.desc
@@ -5,7 +5,7 @@ main.c
 ^SIGNAL=0$
 ^VERIFICATION SUCCESSFUL$
 ASSERT \*\(address_of.*n.*\) = 0
-ASSUME \*\(address_of.*n.*\) ≥ tmp_cc[\$\d]? \+ 2
+ASSUME \*\(address_of.*n.*\) ≥ .*tmp_cc[\$\d]? \+ 2
 --
 --
 Verification:

--- a/regression/contracts/history-pointer-replace-04/test.desc
+++ b/regression/contracts/history-pointer-replace-04/test.desc
@@ -3,7 +3,7 @@ main.c
 --replace-call-with-contract foo
 ^EXIT=10$
 ^SIGNAL=0$
-^\[precondition.\d+\] file main.c line \d+ Check requires clause: SUCCESS$
+^\[foo.precondition.\d+\] line \d+ Check requires clause: SUCCESS$
 ^\[main.assertion.\d+\] line \d+ assertion p->y \!\= 7: FAILURE$
 ^VERIFICATION FAILED$
 --

--- a/regression/contracts/quantifiers-exists-both-enforce/test.desc
+++ b/regression/contracts/quantifiers-exists-both-enforce/test.desc
@@ -3,7 +3,7 @@ main.c
 --enforce-contract f1
 ^EXIT=0$
 ^SIGNAL=0$
-^\[postcondition.\d+\] file main.c line \d+ Check ensures clause: SUCCESS$
+^\[f1.postcondition.\d+\] line \d+ Check ensures clause: SUCCESS$
 ^VERIFICATION SUCCESSFUL$
 --
 ^warning: ignoring

--- a/regression/contracts/quantifiers-exists-both-replace/test.desc
+++ b/regression/contracts/quantifiers-exists-both-replace/test.desc
@@ -3,7 +3,7 @@ main.c
 --replace-call-with-contract f1
 ^EXIT=0$
 ^SIGNAL=0$
-^\[precondition.\d+\] file main.c line \d+ Check requires clause: SUCCESS$
+^\[f1.precondition.\d+\] line \d+ Check requires clause: SUCCESS$
 ^VERIFICATION SUCCESSFUL$
 --
 ^warning: ignoring

--- a/regression/contracts/quantifiers-exists-requires-enforce/test.desc
+++ b/regression/contracts/quantifiers-exists-requires-enforce/test.desc
@@ -3,7 +3,7 @@ main.c
 --enforce-contract f1
 ^EXIT=0$
 ^SIGNAL=0$
-^\[postcondition.\d+\] file main.c line \d+ Check ensures clause: SUCCESS$
+^\[f1.postcondition.\d+\] line \d+ Check ensures clause: SUCCESS$
 ^VERIFICATION SUCCESSFUL$
 --
 ^warning: ignoring

--- a/regression/contracts/quantifiers-exists-requires-replace/test.desc
+++ b/regression/contracts/quantifiers-exists-requires-replace/test.desc
@@ -3,8 +3,8 @@ main.c
 --replace-call-with-contract f1 --replace-call-with-contract f2
 ^EXIT=10$
 ^SIGNAL=0$
-^\[precondition.\d+\] file main.c line \d+ Check requires clause: SUCCESS$
-^\[precondition.\d+\] file main.c line \d+ Check requires clause: FAILURE$
+^\[f1.precondition.\d+\] line \d+ Check requires clause: SUCCESS$
+^\[f2.precondition.\d+\] line \d+ Check requires clause: FAILURE$
 ^VERIFICATION FAILED$
 --
 ^warning: ignoring

--- a/regression/contracts/quantifiers-forall-both-enforce/test.desc
+++ b/regression/contracts/quantifiers-forall-both-enforce/test.desc
@@ -3,7 +3,7 @@ main.c
 --enforce-contract f1
 ^EXIT=0$
 ^SIGNAL=0$
-^\[postcondition.\d+\] file main.c line \d+ Check ensures clause: SUCCESS$
+^\[f1.postcondition.\d+\] line \d+ Check ensures clause: SUCCESS$
 ^VERIFICATION SUCCESSFUL$
 --
 ^warning: ignoring

--- a/regression/contracts/quantifiers-forall-both-replace/test.desc
+++ b/regression/contracts/quantifiers-forall-both-replace/test.desc
@@ -3,7 +3,7 @@ main.c
 --replace-call-with-contract f1
 ^EXIT=0$
 ^SIGNAL=0$
-^\[precondition.\d+\] file main.c line \d+ Check requires clause: SUCCESS$
+^\[f1.precondition.\d+\] line \d+ Check requires clause: SUCCESS$
 ^VERIFICATION SUCCESSFUL$
 --
 ^warning: ignoring

--- a/regression/contracts/quantifiers-forall-ensures-enforce/test.desc
+++ b/regression/contracts/quantifiers-forall-ensures-enforce/test.desc
@@ -3,7 +3,7 @@ main.c
 --enforce-contract f1
 ^EXIT=0$
 ^SIGNAL=0$
-^\[postcondition.\d+\] file main.c line \d+ Check ensures clause: SUCCESS$
+^\[f1.postcondition.\d+\] line \d+ Check ensures clause: SUCCESS$
 ^\[f1.assigns.\d+\] line \d+ Check that arr\[\(.*\)\d\] is assignable: SUCCESS$
 ^VERIFICATION SUCCESSFUL$
 --

--- a/regression/contracts/quantifiers-forall-requires-enforce/test.desc
+++ b/regression/contracts/quantifiers-forall-requires-enforce/test.desc
@@ -3,7 +3,7 @@ main.c
 --enforce-contract f1
 ^EXIT=0$
 ^SIGNAL=0$
-^\[postcondition.\d+\] file main.c line \d+ Check ensures clause: SUCCESS$
+^\[f1.postcondition.\d+\] line \d+ Check ensures clause: SUCCESS$
 ^VERIFICATION SUCCESSFUL$
 --
 ^warning: ignoring

--- a/regression/contracts/quantifiers-forall-requires-replace/test.desc
+++ b/regression/contracts/quantifiers-forall-requires-replace/test.desc
@@ -3,7 +3,7 @@ main.c
 --replace-call-with-contract f1
 ^EXIT=0$
 ^SIGNAL=0$
-^\[precondition.\d+\] file main.c line \d+ Check requires clause: SUCCESS$
+^\[f1.precondition.\d+\] line \d+ Check requires clause: SUCCESS$
 ^VERIFICATION SUCCESSFUL$
 --
 ^warning: ignoring

--- a/regression/contracts/test_aliasing_enforce/test.desc
+++ b/regression/contracts/test_aliasing_enforce/test.desc
@@ -3,7 +3,7 @@ main.c
 --enforce-contract foo
 ^EXIT=0$
 ^SIGNAL=0$
-\[postcondition.\d+\] file main.c line \d+ Check ensures clause: SUCCESS
+\[foo.postcondition.\d+\] line \d+ Check ensures clause: SUCCESS
 \[foo.assigns.\d+\] line \d+ Check that \*x is assignable: SUCCESS
 \[foo.assigns.\d+\] line \d+ Check that \*y is assignable: SUCCESS
 \[foo.assigns.\d+\] line \d+ Check that z is assignable: SUCCESS

--- a/regression/contracts/test_aliasing_ensure/test.desc
+++ b/regression/contracts/test_aliasing_ensure/test.desc
@@ -3,7 +3,7 @@ main.c
 --enforce-contract foo
 ^EXIT=0$
 ^SIGNAL=0$
-\[postcondition.\d+\] file main.c line \d+ Check ensures clause: SUCCESS
+\[foo.postcondition.\d+\] line \d+ Check ensures clause: SUCCESS
 \[foo.assigns.\d+\] line \d+ Check that \*x is assignable: SUCCESS
 \[foo.assigns.\d+\] line \d+ Check that \*y is assignable: SUCCESS
 \[foo.assigns.\d+\] line \d+ Check that z is assignable: SUCCESS

--- a/regression/contracts/test_aliasing_ensure_indirect/test.desc
+++ b/regression/contracts/test_aliasing_ensure_indirect/test.desc
@@ -3,7 +3,7 @@ main.c
 --enforce-contract foo
 ^EXIT=0$
 ^SIGNAL=0$
-\[postcondition.\d+\] file main.c line \d+ Check ensures clause: SUCCESS
+\[foo.postcondition.\d+\] line \d+ Check ensures clause: SUCCESS
 \[foo.assigns.\d+\] line \d+ Check that \*x is assignable: SUCCESS
 \[main.assertion.\d+\] line \d+ assertion \!\(n \< 4\): SUCCESS
 ^VERIFICATION SUCCESSFUL$

--- a/regression/contracts/test_aliasing_replace/test.desc
+++ b/regression/contracts/test_aliasing_replace/test.desc
@@ -3,7 +3,7 @@ main.c
 --replace-call-with-contract foo
 ^EXIT=10$
 ^SIGNAL=0$
-\[precondition.\d+\] file main.c line \d+ Check requires clause: FAILURE
+\[foo.precondition.\d+\] line \d+ Check requires clause: FAILURE
 \[main.assertion.\d+\] line \d+ assertion \!\(n \< 4\): SUCCESS
 ^VERIFICATION FAILED$
 --

--- a/regression/contracts/test_array_memory_enforce/test.desc
+++ b/regression/contracts/test_array_memory_enforce/test.desc
@@ -3,7 +3,7 @@ main.c
 --enforce-contract foo
 ^EXIT=0$
 ^SIGNAL=0$
-\[postcondition.\d+\] file main.c line \d+ Check ensures clause: SUCCESS
+\[foo.postcondition.\d+\] line \d+ Check ensures clause: SUCCESS
 \[foo.assigns.\d+\] line \d+ Check that \*x is assignable: SUCCESS
 \[foo.assigns.\d+\] line \d+ Check that x\[\(.* int\)5\] is assignable: SUCCESS
 \[foo.assigns.\d+\] line \d+ Check that x\[\(.* int\)9\] is assignable: SUCCESS

--- a/regression/contracts/test_array_memory_replace/test.desc
+++ b/regression/contracts/test_array_memory_replace/test.desc
@@ -3,7 +3,7 @@ main.c
 --replace-call-with-contract foo
 ^EXIT=0$
 ^SIGNAL=0$
-\[precondition.\d+\] file main.c line \d+ Check requires clause: SUCCESS
+\[foo.precondition.\d+\] line \d+ Check requires clause: SUCCESS
 \[main.assertion.\d+\] line \d+ assertion o >\= 10 \&\& o \=\= \*n \+ 5: SUCCESS
 \[main.assertion.\d+\] line \d+ assertion n\[9\] == 113: SUCCESS
 ^VERIFICATION SUCCESSFUL$

--- a/regression/contracts/test_array_memory_too_small_replace/test.desc
+++ b/regression/contracts/test_array_memory_too_small_replace/test.desc
@@ -3,7 +3,7 @@ main.c
 --replace-call-with-contract foo
 ^EXIT=10$
 ^SIGNAL=0$
-\[precondition.\d+\] file main.c line \d+ Check requires clause: FAILURE
+\[foo.precondition.\d+\] line \d+ Check requires clause: FAILURE
 \[main.assertion.\d+\] line \d+ assertion o >\= 10 \&\& o \=\= \*n \+ 5: SUCCESS
 ^VERIFICATION FAILED$
 --

--- a/regression/contracts/test_possibly_aliased_arguments/test.desc
+++ b/regression/contracts/test_possibly_aliased_arguments/test.desc
@@ -3,7 +3,7 @@ main.c
 --replace-call-with-contract sub_ptr_values
 ^EXIT=0$
 ^SIGNAL=0$
-\[precondition.\d+\] file main.c line \d+ Check requires clause: SUCCESS
+\[sub_ptr_values.precondition.\d+\] line \d+ Check requires clause: SUCCESS
 ^VERIFICATION SUCCESSFUL$
 --
 --

--- a/regression/contracts/test_scalar_memory_enforce/test.desc
+++ b/regression/contracts/test_scalar_memory_enforce/test.desc
@@ -3,7 +3,7 @@ main.c
 --enforce-contract foo
 ^EXIT=0$
 ^SIGNAL=0$
-\[postcondition.\d+\] file main.c line \d+ Check ensures clause: SUCCESS
+\[foo.postcondition.\d+\] line \d+ Check ensures clause: SUCCESS
 \[foo.assigns.\d+\] line \d+ Check that \*x is assignable: SUCCESS
 ^VERIFICATION SUCCESSFUL$
 --

--- a/regression/contracts/test_scalar_memory_replace/test.desc
+++ b/regression/contracts/test_scalar_memory_replace/test.desc
@@ -3,7 +3,7 @@ main.c
 --replace-call-with-contract foo
 ^EXIT=0$
 ^SIGNAL=0$
-\[precondition.\d+\] file main.c line \d+ Check requires clause: SUCCESS
+\[foo.precondition.\d+\] line \d+ Check requires clause: SUCCESS
 \[main.assertion.\d+\] line \d+ assertion \_\_CPROVER\_r\_ok\(n, sizeof\(int\)\): SUCCESS
 \[main.assertion.\d+\] line \d+ assertion o >\= 10 \&\& o \=\= \*n \+ 5: SUCCESS
 ^VERIFICATION SUCCESSFUL$

--- a/regression/contracts/test_struct_enforce/test.desc
+++ b/regression/contracts/test_struct_enforce/test.desc
@@ -3,7 +3,7 @@ main.c
 --enforce-contract foo
 ^EXIT=0$
 ^SIGNAL=0$
-\[postcondition.\d+\] file main.c line \d+ Check ensures clause: SUCCESS
+\[foo.postcondition.\d+\] line \d+ Check ensures clause: SUCCESS
 \[foo.assigns.\d+\] line \d+ Check that x->baz is assignable: SUCCESS
 \[foo.assigns.\d+\] line \d+ Check that x->qux is assignable: SUCCESS
 \[main.assertion.\d+\] line \d+ assertion rval \=\= 10: SUCCESS

--- a/regression/contracts/test_struct_member_enforce/test.desc
+++ b/regression/contracts/test_struct_member_enforce/test.desc
@@ -3,7 +3,7 @@ main.c
 --enforce-contract foo
 ^EXIT=0$
 ^SIGNAL=0$
-\[postcondition.\d+\] file main.c line \d+ Check ensures clause: SUCCESS
+\[foo.postcondition.\d+\] line \d+ Check ensures clause: SUCCESS
 \[foo.assigns.\d+\] line \d+ Check that x->str\[\(.*\)\(x->len - 1\)\] is assignable: SUCCESS
 \[main.assertion.\d+\] line \d+ assertion rval \=\= 128: SUCCESS
 ^VERIFICATION SUCCESSFUL$

--- a/regression/contracts/test_struct_replace/test.desc
+++ b/regression/contracts/test_struct_replace/test.desc
@@ -3,7 +3,7 @@ main.c
 --replace-call-with-contract foo
 ^EXIT=0$
 ^SIGNAL=0$
-\[precondition.\d+\] file main.c line \d+ Check requires clause: SUCCESS
+\[foo.precondition.\d+\] line \d+ Check requires clause: SUCCESS
 \[main.assertion.\d+\] line \d+ assertion rval \=\= x->baz \+ x->qux: SUCCESS
 \[main.assertion.\d+\] line \d+ assertion \*x \=\= \*y: SUCCESS
 ^VERIFICATION SUCCESSFUL$

--- a/regression/contracts/variant_multidimensional_ackermann/test.desc
+++ b/regression/contracts/variant_multidimensional_ackermann/test.desc
@@ -1,8 +1,8 @@
 CORE
 main.c
 --apply-loop-contracts --replace-call-with-contract ackermann
-^\[precondition\.\d+\] .* line 17 Check requires clause: SUCCESS$
-^\[precondition\.\d+\] .* line 17 Check requires clause: SUCCESS$
+^\[ackermann.precondition\.\d+\] line 17 Check requires clause: SUCCESS$
+^\[ackermann.precondition\.\d+\] line 17 Check requires clause: SUCCESS$
 ^\[ackermann\.\d+\] line 21 Check loop invariant before entry: SUCCESS$
 ^\[ackermann\.\d+\] line 21 Check that loop invariant is preserved: SUCCESS$
 ^\[ackermann\.\d+\] line 21 Check decreases clause on loop iteration: SUCCESS$

--- a/src/goto-instrument/contracts/contracts.cpp
+++ b/src/goto-instrument/contracts/contracts.cpp
@@ -1382,15 +1382,12 @@ void code_contractst::enforce_contract(const irep_idt &function)
   goto_functions.function_map.erase(old_function);
 
   // Place a new symbol with the mangled name into the symbol table
-  source_locationt sl;
-  sl.set_file("instrumented for code contracts");
-  sl.set_line("0");
   symbolt mangled_sym;
   const symbolt *original_sym = symbol_table.lookup(original);
   mangled_sym = *original_sym;
   mangled_sym.name = mangled;
   mangled_sym.base_name = mangled;
-  mangled_sym.location = sl;
+  mangled_sym.location = original_sym->location;
   const auto mangled_found = symbol_table.insert(std::move(mangled_sym));
   INVARIANT(
     mangled_found.second,
@@ -1414,7 +1411,7 @@ void code_contractst::enforce_contract(const irep_idt &function)
 
   goto_functiont &wrapper = goto_functions.function_map[original];
   wrapper.parameter_identifiers = mangled_fun->second.parameter_identifiers;
-  wrapper.body.add(goto_programt::make_end_function(sl));
+  wrapper.body.add(goto_programt::make_end_function());
   add_contract_check(original, mangled, wrapper.body);
 }
 
@@ -1485,7 +1482,9 @@ void code_contractst::add_contract_check(
   // with expressions from the call site (e.g. the return value).
   exprt::operandst instantiation_values;
 
-  const auto &source_location = function_symbol.location;
+  source_locationt source_location = function_symbol.location;
+  // Set function in source location to original function
+  source_location.set_function(wrapper_function);
 
   // decl ret
   optionalt<code_returnt> return_stmt;


### PR DESCRIPTION
During parsing of function parameters, the function name should be set
in the source location, but only for top-level function declarations
and definitions.  In addition, function contracts should be only
allowed for top-level function declarations and definitions.

CBMC Viewer reports a failure when analyzing the incomplete coverage
report, causing the CMBC Starter Kit to fail during a standard build.

Also removed source location from "end function" command during
contract checking and added proper source location to function
contract instrumentation.

Resolves issues #7032, #7070

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- [X] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [X] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- [X] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
