### PR TITLE
Add CBMC primitive regression tests to new SMT2 backend

### DIFF
--- a/regression/cbmc-primitives/CMakeLists.txt
+++ b/regression/cbmc-primitives/CMakeLists.txt
@@ -4,6 +4,14 @@ if(Z3_EXISTS)
     add_test_pl_tests(
         "$<TARGET_FILE:cbmc>"
     )
+
+    # If `-I` (include flag) is passed, test.pl will run only the tests matching the label following it.
+    add_test_pl_profile(
+            "cbmc-new-smt-backend"
+            "$<TARGET_FILE:cbmc> --incremental-smt2-solver 'z3 --smt2 -in' --slice-formula"
+            "-I;new-smt-backend;-s;new-smt-backend"
+            "CORE"
+    )
 else()
     add_test_pl_tests(
         "$<TARGET_FILE:cbmc>" -X smt-backend

--- a/regression/cbmc-primitives/Makefile
+++ b/regression/cbmc-primitives/Makefile
@@ -3,6 +3,9 @@ default: tests.log
 test:
 	@../test.pl -e -p -c ../../../src/cbmc/cbmc
 
+test.smt2_incr:
+	@../test.pl -e -p -I new-smt-backend -c "../../../src/cbmc/cbmc --incremental-smt2-solver 'z3 --smt2 -in' --validate-goto-model --validate-ssa-equation --slice-formula"
+
 tests.log: ../test.pl
 	@../test.pl -e -p -c ../../../src/cbmc/cbmc
 

--- a/regression/cbmc-primitives/forall_6231_1/test.desc
+++ b/regression/cbmc-primitives/forall_6231_1/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 test.c
 --pointer-check
 ^EXIT=0$

--- a/regression/cbmc-primitives/forall_6231_2/test.desc
+++ b/regression/cbmc-primitives/forall_6231_2/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 test.c
 --pointer-check
 ^EXIT=0$

--- a/regression/cbmc-primitives/forall_6231_3/test.desc
+++ b/regression/cbmc-primitives/forall_6231_3/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 test.c
 --pointer-check
 ^EXIT=0$

--- a/regression/cbmc-primitives/forall_6231_3/test_malloc_less_than_bound.desc
+++ b/regression/cbmc-primitives/forall_6231_3/test_malloc_less_than_bound.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 test_malloc_less_than_bound.c
 --pointer-check
 ^EXIT=10$

--- a/regression/cbmc-primitives/forall_6231_4/test.desc
+++ b/regression/cbmc-primitives/forall_6231_4/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 test.c
 --div-by-zero-check
 ^EXIT=10$

--- a/regression/cbmc-primitives/r_w_ok_inconsistent_invalid/test-no-cp.desc
+++ b/regression/cbmc-primitives/r_w_ok_inconsistent_invalid/test-no-cp.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 --pointer-check --no-simplify --no-propagation
 ^EXIT=0$

--- a/regression/cbmc-primitives/r_w_ok_inconsistent_invalid/test.desc
+++ b/regression/cbmc-primitives/r_w_ok_inconsistent_invalid/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 --pointer-check
 ^EXIT=0$

--- a/regression/cbmc-primitives/r_w_ok_null/test-no-cp.desc
+++ b/regression/cbmc-primitives/r_w_ok_null/test-no-cp.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 --pointer-check --no-simplify --no-propagation
 ^EXIT=0$

--- a/regression/cbmc-primitives/r_w_ok_null/test.desc
+++ b/regression/cbmc-primitives/r_w_ok_null/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 --pointer-check
 ^EXIT=0$

--- a/regression/cbmc-primitives/r_w_ok_valid/test.desc
+++ b/regression/cbmc-primitives/r_w_ok_valid/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 --pointer-check
 ^EXIT=0$

--- a/regression/cbmc-primitives/r_w_ok_valid_negated/test.desc
+++ b/regression/cbmc-primitives/r_w_ok_valid_negated/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 --pointer-check
 ^EXIT=0$

--- a/regression/cbmc-primitives/same-object-01/test.desc
+++ b/regression/cbmc-primitives/same-object-01/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 
 ^EXIT=0$

--- a/regression/cbmc-primitives/same-object-02/test.desc
+++ b/regression/cbmc-primitives/same-object-02/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 
 ^EXIT=0$

--- a/regression/cbmc-primitives/same-object-03/test.desc
+++ b/regression/cbmc-primitives/same-object-03/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 
 ^EXIT=0$

--- a/regression/cbmc-primitives/same-object-04/test.desc
+++ b/regression/cbmc-primitives/same-object-04/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 
 ^EXIT=0$


### PR DESCRIPTION
Add all supported and working CBMC primitive regression tests to the new SMT2 backend.

At the moment the following CBMC primitives regressions are not supported or working.

A report on that will be adde shortly

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
