### PR TITLE
Remove well-alignedness assumption from pointer dereferencing

### DIFF
--- a/regression/cbmc/Array_operations2/main.c
+++ b/regression/cbmc/Array_operations2/main.c
@@ -1,0 +1,48 @@
+#include <assert.h>
+
+typedef struct my_struct
+{
+  char a;
+  char b;
+  char c[5];
+} my_struct;
+
+int main()
+{
+  my_struct arr[3] = {0};
+  char *ptr = &(arr[1].c[2]);
+  int offset;
+  __CPROVER_assume(offset < 1 && offset > -1);
+  void *ptr_plus = ptr + offset;
+  char nondet[3];
+
+  __CPROVER_array_replace(ptr_plus, &nondet[0]);
+
+  // expected valid and proved
+  assert(arr[0].a == 0);
+  assert(arr[0].b == 0);
+  assert(arr[0].c[0] == 0);
+  assert(arr[0].c[1] == 0);
+  assert(arr[0].c[2] == 0);
+  assert(arr[0].c[3] == 0);
+  assert(arr[0].c[4] == 0);
+
+  assert(arr[1].a == 0);    // expected valid, falsified
+  assert(arr[1].b == 0);    // expected valid, falsified
+  assert(arr[1].c[0] == 0); // expected valid, falsified
+  assert(arr[1].c[1] == 0); // expected valid, proved
+  assert(arr[1].c[2] == 0); // expected falsifiable, proved
+  assert(arr[1].c[3] == 0); // expected falsifiable, proved
+  assert(arr[1].c[4] == 0); // expected falsifiable, proved
+
+  // expected valid and proved
+  assert(arr[2].a == 0);
+  assert(arr[2].b == 0);
+  assert(arr[2].c[0] == 0);
+  assert(arr[2].c[1] == 0);
+  assert(arr[2].c[2] == 0);
+  assert(arr[2].c[3] == 0);
+  assert(arr[2].c[4] == 0);
+
+  return 0;
+}

--- a/regression/cbmc/Array_operations2/test.desc
+++ b/regression/cbmc/Array_operations2/test.desc
@@ -1,0 +1,14 @@
+CORE broken-smt-backend
+main.c
+
+^\[main.assertion.12\] line 34 assertion arr\[1\].c\[2\] == 0: FAILURE$
+^\[main.assertion.13\] line 35 assertion arr\[1\].c\[3\] == 0: FAILURE$
+^\[main.assertion.14\] line 36 assertion arr\[1\].c\[4\] == 0: FAILURE$
+^\*\* 3 of 21 failed
+^VERIFICATION FAILED$
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring
+--
+Verify the properties of various cprover array primitves

--- a/src/pointer-analysis/value_set_dereference.cpp
+++ b/src/pointer-analysis/value_set_dereference.cpp
@@ -572,12 +572,12 @@ value_set_dereferencet::valuet value_set_dereferencet::build_reference_to(
     else if(
       root_object_type.id() == ID_array &&
       dereference_type_compare(
-        to_array_type(root_object_type).element_type(), dereference_type, ns))
+        to_array_type(root_object_type).element_type(), dereference_type, ns) &&
+      pointer_offset_bits(to_array_type(root_object_type).element_type(), ns) ==
+        pointer_offset_bits(dereference_type, ns))
     {
       // We have an array with a subtype that matches
       // the dereferencing type.
-      // We will require well-alignedness!
-
       exprt offset;
 
       // this should work as the object is essentially the root object
@@ -609,13 +609,9 @@ value_set_dereferencet::valuet value_set_dereferencet::build_reference_to(
         adjusted_offset=binary_exprt(
           offset, ID_div, element_size_expr, offset.type());
 
-        // TODO: need to assert well-alignedness
       }
 
-      const index_exprt &index_expr = index_exprt(
-        root_object,
-        adjusted_offset,
-        to_array_type(root_object_type).element_type());
+      index_exprt index_expr{root_object, adjusted_offset};
       result.value =
         typecast_exprt::conditional_cast(index_expr, dereference_type);
       result.pointer = typecast_exprt::conditional_cast(

--- a/src/pointer-analysis/value_set_dereference.cpp
+++ b/src/pointer-analysis/value_set_dereference.cpp
@@ -595,8 +595,6 @@ value_set_dereferencet::valuet value_set_dereferencet::build_reference_to(
       else
         offset=pointer_offset(pointer_expr);
 
-      exprt adjusted_offset;
-
       // are we doing a byte?
       auto element_size =
         pointer_offset_size(to_array_type(root_object_type).element_type(), ns);
@@ -606,19 +604,11 @@ value_set_dereferencet::valuet value_set_dereferencet::build_reference_to(
         throw "unknown or invalid type size of:\n" +
           to_array_type(root_object_type).element_type().pretty();
       }
-      else if(*element_size == 1)
-      {
-        // no need to adjust offset
-        adjusted_offset = offset;
-      }
-      else
-      {
-        exprt element_size_expr = from_integer(*element_size, offset.type());
 
-        adjusted_offset=binary_exprt(
-          offset, ID_div, element_size_expr, offset.type());
+      exprt element_size_expr = from_integer(*element_size, offset.type());
 
-      }
+      exprt adjusted_offset =
+        simplify_expr(div_exprt{offset, element_size_expr}, ns);
 
       index_exprt index_expr{root_object, adjusted_offset};
       result.value =

--- a/src/pointer-analysis/value_set_dereference.h
+++ b/src/pointer-analysis/value_set_dereference.h
@@ -54,12 +54,6 @@ public:
   /// \param display_points_to_sets: Display size and contents of points to sets
   exprt dereference(const exprt &pointer, bool display_points_to_sets = false);
 
-  /// If `expr` is of the form (c1 ? e1[o1] : c2 ? e2[o2] : c3 ? ...)
-  /// then return `c1 ? e1[o1 + offset] : e2[o2 + offset] : c3 ? ...`
-  /// otherwise return an empty optionalt.
-  optionalt<exprt>
-  try_add_offset_to_indices(const exprt &expr, const exprt &offset);
-
   /// Return value for `build_reference_to`; see that method for documentation.
   class valuet
   {


### PR DESCRIPTION
With void* pointers, pointer dereferencing would permit any type for the
dereferenced object. For arrays, alignment at the root level was
implicitly assumed, not taking into account that there may be a
well-aligned pointer to a nested element.

For the regression test we got `arr[11 / 7]` when dereferencing `(void
*)ptr`, where `ptr` was `(char *)&arr[0] + 11` (and the size of `arr`'s
elements is 7 bytes).

Fixes: #7036

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
