### PR TITLE
goto-convert: introduce assignment_lhs_needs_temporary

### DIFF
--- a/src/goto-programs/goto_clean_expr.cpp
+++ b/src/goto-programs/goto_clean_expr.cpp
@@ -384,7 +384,7 @@ void goto_convertt::clean_expr(
         clean_expr(side_effect_assign.lhs(), dest, mode);
         exprt lhs = side_effect_assign.lhs();
 
-        const bool must_use_rhs = needs_cleaning(lhs);
+        const bool must_use_rhs = assignment_lhs_needs_temporary(lhs);
         if(must_use_rhs)
         {
           remove_function_call(

--- a/src/goto-programs/goto_convert_class.h
+++ b/src/goto-programs/goto_convert_class.h
@@ -89,6 +89,15 @@ protected:
 
   static bool needs_cleaning(const exprt &expr);
 
+  // Do we need to introduce a temporary for the value of an assignment
+  // to the given lhs? E.g., a[i] needs a temporary as its value may change
+  // when i is changed; likewise, *p needs a temporary as its value may change
+  // when p is changed.
+  static bool assignment_lhs_needs_temporary(const exprt &lhs)
+  {
+    return lhs.id() != ID_symbol;
+  }
+
   void make_temp_symbol(
     exprt &expr,
     const std::string &suffix,

--- a/src/goto-programs/goto_convert_side_effect.cpp
+++ b/src/goto-programs/goto_convert_side_effect.cpp
@@ -50,7 +50,9 @@ void goto_convertt::remove_assignment(
   {
     auto &old_assignment = to_side_effect_expr_assign(expr);
 
-    if(result_is_used && !address_taken && needs_cleaning(old_assignment.lhs()))
+    if(
+      result_is_used && !address_taken &&
+      assignment_lhs_needs_temporary(old_assignment.lhs()))
     {
       if(!old_assignment.rhs().is_constant())
         make_temp_symbol(old_assignment.rhs(), "assign", dest, mode);
@@ -122,7 +124,9 @@ void goto_convertt::remove_assignment(
     exprt rhs = binary_exprt{binary_expr.op0(), new_id, binary_expr.op1()};
     rhs.add_source_location() = expr.source_location();
 
-    if(result_is_used && !address_taken && needs_cleaning(binary_expr.op0()))
+    if(
+      result_is_used && !address_taken &&
+      assignment_lhs_needs_temporary(binary_expr.op0()))
     {
       make_temp_symbol(rhs, "assign", dest, mode);
       replacement_expr_opt = rhs;
@@ -237,7 +241,7 @@ void goto_convertt::remove_pre(
   }
 
   const bool cannot_use_lhs =
-    result_is_used && !address_taken && needs_cleaning(lhs);
+    result_is_used && !address_taken && assignment_lhs_needs_temporary(lhs);
   if(cannot_use_lhs)
     make_temp_symbol(rhs, "pre", dest, mode);
 


### PR DESCRIPTION
This introduces `goto_convertt::assignment_lhs_needs_temporary`, to be used
instead of needs_cleaning when determining whether to introduce a temporary
for the value of an assignment expression, compound assignment expression,
or pre- or post-increment or decrement operator.

This allows weakening the condition computed by needs_cleaning.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- [X] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
