### PR TITLE
goto_convertt: cannot take address of a side effect

### DIFF
--- a/src/goto-programs/goto_clean_expr.cpp
+++ b/src/goto-programs/goto_clean_expr.cpp
@@ -430,8 +430,7 @@ void goto_convertt::clean_expr(
 
   if(expr.id()==ID_side_effect)
   {
-    remove_side_effect(
-      to_side_effect_expr(expr), dest, mode, result_is_used, false);
+    remove_side_effect(to_side_effect_expr(expr), dest, mode, result_is_used);
   }
   else if(expr.id()==ID_compound_literal)
   {
@@ -504,7 +503,8 @@ void goto_convertt::clean_expr_address_of(
   }
   else if(expr.id() == ID_side_effect)
   {
-    remove_side_effect(to_side_effect_expr(expr), dest, mode, true, true);
+    // side effects yield rvalues, and thus cannot have their address taken
+    DATA_INVARIANT(false, "cannot take address of side effect");
   }
   else
     Forall_operands(it, expr)

--- a/src/goto-programs/goto_convert_class.h
+++ b/src/goto-programs/goto_convert_class.h
@@ -103,19 +103,16 @@ protected:
     side_effect_exprt &expr,
     goto_programt &dest,
     const irep_idt &mode,
-    bool result_is_used,
-    bool address_taken);
+    bool result_is_used);
   void remove_assignment(
     side_effect_exprt &expr,
     goto_programt &dest,
     bool result_is_used,
-    bool address_taken,
     const irep_idt &mode);
   void remove_pre(
     side_effect_exprt &expr,
     goto_programt &dest,
     bool result_is_used,
-    bool address_taken,
     const irep_idt &mode);
   void remove_post(
     side_effect_exprt &expr,


### PR DESCRIPTION
Side effects in C yield an rvalue, and thus, the address of a side effect
expression cannot be taken.  This commit removes dead code in `goto_convertt`
that attempted to handle this case.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
