### PR TITLE
SIMD1 test requires an architecture with MMX

### DIFF
--- a/regression/cbmc/SIMD1/main.c
+++ b/regression/cbmc/SIMD1/main.c
@@ -7,11 +7,14 @@
 #    define _mm_extract_pi16(a, b) _mm_extract_epi16(a, b)
 #  endif
 #else
-#  include <immintrin.h>
+#  ifdef __MMX__
+#    include <immintrin.h>
+#  endif
 #endif
 
 int main()
 {
+#if defined(_MSC_VER) || defined(__MMX__)
   __m128i values = _mm_setr_epi32(0x1234, 0x2345, 0x3456, 0x4567);
   int val1 = _mm_extract_epi32(values, 0);
   assert(val1 == 0x1234);
@@ -53,6 +56,7 @@ int main()
   __m128i result128 = _mm_subs_epu16(x, y);
   short s = _mm_extract_epi16(result128, 0);
   assert(s == 0);
+#endif
 
   return 0;
 }


### PR DESCRIPTION
The SIMD1 test uses an include that uses MMX intrinsics, which are only
available on Intel x86 architectures.  This commit adds preprocessor checks
to prevent the test to fail on other architectures.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [X] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
