### PR TITLE
Add nondet_symbol_exprt translation to new SMT2 backend

### DIFF
--- a/regression/cbmc-incr-smt2/nondeterministic-int-assert/nondet_symbol.c
+++ b/regression/cbmc-incr-smt2/nondeterministic-int-assert/nondet_symbol.c
@@ -1,0 +1,11 @@
+extern int undefined_function();
+
+int main()
+{
+  int nondet1 = undefined_function();
+  __CPROVER_assume(nondet1 == 10);
+  __CPROVER_assert(nondet1 < 11, "");
+  __CPROVER_assert(undefined_function() == 0, "");
+
+  __CPROVER_assert(undefined_function() == undefined_function(), "");
+}

--- a/regression/cbmc-incr-smt2/nondeterministic-int-assert/nondet_symbol.desc
+++ b/regression/cbmc-incr-smt2/nondeterministic-int-assert/nondet_symbol.desc
@@ -1,0 +1,12 @@
+CORE
+nondet_symbol.c
+
+Passing problem to incremental SMT2 solving
+\[main\.assertion\.1\] line 7 assertion: SUCCESS
+\[main\.assertion\.2\] line 8 assertion: FAILURE
+\[main\.assertion\.3\] line 10 assertion: FAILURE
+^EXIT=10$
+^SIGNAL=0$
+--
+--
+Test that running cbmc with the `--incremental-smt2-solver` supports nondet_symbol expressions.

--- a/src/solvers/smt2_incremental/convert_expr_to_smt.cpp
+++ b/src/solvers/smt2_incremental/convert_expr_to_smt.cpp
@@ -124,9 +124,11 @@ static smt_termt convert_expr_to_smt(
   const nondet_symbol_exprt &nondet_symbol,
   const sub_expression_mapt &converted)
 {
-  UNIMPLEMENTED_FEATURE(
-    "Generation of SMT formula for nondet symbol expression: " +
-    nondet_symbol.pretty());
+  // A nondet_symbol is a reference to an unconstrained function. This function
+  // will already have been added as a dependency.
+  return smt_identifier_termt{
+    nondet_symbol.get_identifier(),
+    convert_type_to_smt_sort(nondet_symbol.type())};
 }
 
 /// \brief Makes a term which is true if \p input is not 0 / false.

--- a/unit/solvers/smt2_incremental/convert_expr_to_smt.cpp
+++ b/unit/solvers/smt2_incremental/convert_expr_to_smt.cpp
@@ -120,6 +120,20 @@ TEST_CASE("\"symbol_exprt\" to smt term conversion", "[core][smt2_incremental]")
 }
 
 TEST_CASE(
+  "\"nondet_symbol_exprt\" to smt term conversion",
+  "[core][smt2_incremental]")
+{
+  auto test = expr_to_smt_conversion_test_environmentt::make(test_archt::i386);
+  CHECK(
+    test.convert(nondet_symbol_exprt{"nondet_symbol1", bool_typet{}}) ==
+    smt_identifier_termt("nondet_symbol1", smt_bool_sortt{}));
+  CHECK(
+    test.convert(
+      nondet_symbol_exprt{"nondet_symbol2", bitvector_typet{ID_bv, 42}}) ==
+    smt_identifier_termt{"nondet_symbol2", smt_bit_vector_sortt{42}});
+}
+
+TEST_CASE(
   "\"exprt\" to smt term conversion for constants/literals",
   "[core][smt2_incremental]")
 {
@@ -1350,7 +1364,7 @@ TEST_CASE("expr to smt conversion for type casts", "[core][smt2_incremental]")
         exprt{false_exprt{}});
       const smt_termt from_term = test.convert(from_expr);
       const std::size_t width = GENERATE(1, 8, 16, 32, 64);
-      const typecast_exprt cast{from_expr, bitvector_typet{ID_bv, width}};
+      const typecast_exprt cast{from_expr, bv_typet(width)};
       CHECK(
         test.convert(cast) == smt_core_theoryt::if_then_else(
                                 from_term,

--- a/unit/solvers/smt2_incremental/module_dependencies.txt
+++ b/unit/solvers/smt2_incremental/module_dependencies.txt
@@ -1,3 +1,4 @@
+goto-symex
 solvers/smt2_incremental
 testing-utils
 util


### PR DESCRIPTION
Add support for `nondet_symbol_exprt` in new SMT2 backend.

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.
