### PR TITLE
CONTRACTS: filter out contract symbols when resolving entry points and interrupt handlers

### DIFF
--- a/regression/contracts/entry_point/main.c
+++ b/regression/contracts/entry_point/main.c
@@ -1,0 +1,9 @@
+int foo(char *arr, unsigned int size)
+  // clang-format off
+__CPROVER_requires(__CPROVER_is_fresh(arr, size))
+__CPROVER_assigns(arr &&size > 0: arr[0])
+// clang-format on
+{
+  if(arr && size > 0)
+    arr[0] = 1;
+}

--- a/regression/contracts/entry_point/test.desc
+++ b/regression/contracts/entry_point/test.desc
@@ -1,0 +1,10 @@
+CORE
+main.c
+--enforce-contract foo _ --function foo
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+--
+This test checks that we can use a function with a contract as entry point
+for the analysis when its contract gets enforced.

--- a/src/ansi-c/ansi_c_entry_point.cpp
+++ b/src/ansi-c/ansi_c_entry_point.cpp
@@ -130,7 +130,7 @@ bool ansi_c_entry_point(
       if(s_it==symbol_table.symbols.end())
         continue;
 
-      if(s_it->second.type.id()==ID_code)
+      if(s_it->second.type.id() == ID_code && !s_it->second.is_property)
         matches.push_back(symbol_name_entry.second);
     }
 

--- a/src/ansi-c/c_typecheck_base.cpp
+++ b/src/ansi-c/c_typecheck_base.cpp
@@ -877,8 +877,8 @@ void c_typecheck_baset::typecheck_declaration(
         // create a contract symbol
         symbolt contract;
         contract.name = "contract::" + id2string(new_symbol.name);
-        contract.base_name = new_symbol.name;
-        contract.pretty_name = new_symbol.name;
+        contract.base_name = new_symbol.base_name;
+        contract.pretty_name = new_symbol.pretty_name;
         contract.is_property = true;
         contract.type = code_type;
         contract.mode = new_symbol.mode;

--- a/src/goto-instrument/interrupt.cpp
+++ b/src/goto-instrument/interrupt.cpp
@@ -165,7 +165,7 @@ get_isr(const symbol_tablet &symbol_table, const irep_idt &interrupt_handler)
     if(s_it==symbol_table.symbols.end())
       continue;
 
-    if(s_it->second.type.id()==ID_code)
+    if(s_it->second.type.id() == ID_code && !s_it->second.is_property)
       matches.push_back(s_it->second.symbol_expr());
   }
 

--- a/src/jsil/jsil_entry_point.cpp
+++ b/src/jsil/jsil_entry_point.cpp
@@ -74,7 +74,7 @@ bool jsil_entry_point(
       if(s_it==symbol_table.symbols.end())
         continue;
 
-      if(s_it->second.type.id()==ID_code)
+      if(s_it->second.type.id() == ID_code && !s_it->second.is_property)
         matches.push_back(symbol_name_entry.second);
     }
 


### PR DESCRIPTION
Contract symbols (#6799) have the same base name as the function symbol they are derived from.
This causes both the function and its contract to be found when doing a lookup by base name,
when resolving entry points for instance. 

We now filter out symbols that have the `is_property` set when resolving entry points and interrupt handlers.

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [N/A] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [N/A] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [N/A] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.
