### PR TITLE
Crangler: add loop invariants with loop numbers

### DIFF
--- a/regression/crangler/loop-invariant-03/main.c
+++ b/regression/crangler/loop-invariant-03/main.c
@@ -1,0 +1,26 @@
+int foo(int *arr, int size)
+{
+  arr[0] = 0;
+  arr[size - 1] = 0;
+  for(int i = 0; i < 2; i++)
+  {
+    arr[i] = 0;
+  }
+
+  int i = 0;
+  while(i < 2)
+  {
+    arr[i] = 0;
+    i++;
+  }
+
+  return size < 10 ? 0 : arr[5];
+}
+
+int main()
+{
+  int arr[10];
+  int retval = foo(arr, 10);
+  __CPROVER_assert(retval == arr[5], "should succeed");
+  return 0;
+}

--- a/regression/crangler/loop-invariant-03/test.desc
+++ b/regression/crangler/loop-invariant-03/test.desc
@@ -1,0 +1,10 @@
+CORE
+test.json
+
+^\s+while\(i \< 2\) \_\_CPROVER\_loop\_invariant
+^EXIT=0$
+^SIGNAL=0$
+--
+^\s+for\(int i = 0; i \< 2; i\+\+\) \_\_CPROVER
+--
+Annotate loop invariant only to the second loop.

--- a/regression/crangler/loop-invariant-03/test.json
+++ b/regression/crangler/loop-invariant-03/test.json
@@ -1,0 +1,5 @@
+{
+  "sources" : ["main.c"],
+              "functions" : [{"foo": ["loop 2 invariant 1==1"]}],
+                            "output" : "stdout"
+}

--- a/src/crangler/c_wrangler.cpp
+++ b/src/crangler/c_wrangler.cpp
@@ -213,8 +213,8 @@ void c_wranglert::configure_functions(const jsont &config)
           function_config.assertions.emplace_back(split[1], rest.str());
         }
         else if(
-          (split[0] == "for" && split.size() >= 3 && split[2] == "invariant") ||
-          (split[0] == "while" && split.size() >= 3 && split[2] == "invariant"))
+          (split[0] == "for" || split[0] == "while" || split[0] == "loop") &&
+          split.size() >= 3 && split[2] == "invariant")
         {
           std::ostringstream rest;
           join_strings(rest, split.begin() + 3, split.end(), ' ');
@@ -434,7 +434,10 @@ static void mangle_function(
         {
           while_count++;
           const auto &invariant =
-            loop_invariants["while" + std::to_string(while_count)];
+            loop_invariants.count("while" + std::to_string(while_count))
+              ? loop_invariants["while" + std::to_string(while_count)]
+              : loop_invariants
+                  ["loop" + std::to_string(while_count + for_count)];
 
           if(!invariant.empty())
           {
@@ -449,7 +452,10 @@ static void mangle_function(
         {
           for_count++;
           const auto &invariant =
-            loop_invariants["for" + std::to_string(for_count)];
+            loop_invariants.count("for" + std::to_string(for_count))
+              ? loop_invariants["for" + std::to_string(for_count)]
+              : loop_invariants
+                  ["loop" + std::to_string(while_count + for_count)];
 
           if(!invariant.empty())
           {


### PR DESCRIPTION
<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->
Crangler only supported to add a loop invariant to a specified for-loop or while-loop in a certain function. This PR adds support for adding loop invariants to loops specified by loop number, regardless they are for-loops or while-loops. 

This PR is required when we annotate synthesized loop invariants back to c source code, because we don't know whether a loop in goto translated from a for-loop or a while-loop in the c code.

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
