### PR TITLE
Enable printing of traces for arrays in new SMT backend

### DIFF
--- a/regression/cbmc-incr-smt2/arrays_traces/array_read.c
+++ b/regression/cbmc-incr-smt2/arrays_traces/array_read.c
@@ -1,0 +1,7 @@
+int main()
+{
+  int example_array[1025];
+  unsigned int index;
+  __CPROVER_assume(index < 1025);
+  __CPROVER_assert(example_array[index] != 42, "Array condition");
+}

--- a/regression/cbmc-incr-smt2/arrays_traces/array_read.desc
+++ b/regression/cbmc-incr-smt2/arrays_traces/array_read.desc
@@ -1,0 +1,15 @@
+CORE
+array_read.c
+--trace
+Passing problem to incremental SMT2 solving
+\[main\.assertion\.1\] line \d+ Array condition: FAILURE
+^Trace for main\.assertion\.1
+example_array=\{ 42, 42, 42, 42, 
+^EXIT=10$
+^SIGNAL=0$
+--
+--
+Test of reading a value at a non-deterministic index of an array.
+Similar to the test in ../arrays/array_read.c, but we want to assert
+the value of the array that comes back in the trace to make sure we're
+observing the correct values.

--- a/regression/cbmc-incr-smt2/arrays_traces/array_read_multi_dimension.c
+++ b/regression/cbmc-incr-smt2/arrays_traces/array_read_multi_dimension.c
@@ -1,0 +1,9 @@
+int main()
+{
+  int example_array[100][200];
+  unsigned int index_i;
+  unsigned int index_j;
+  __CPROVER_assume(index_i < 100);
+  __CPROVER_assume(index_j < 200);
+  __CPROVER_assert(example_array[index_i][index_j] != 42, "Array condition");
+}

--- a/regression/cbmc-incr-smt2/arrays_traces/array_read_multi_dimension.desc
+++ b/regression/cbmc-incr-smt2/arrays_traces/array_read_multi_dimension.desc
@@ -1,0 +1,14 @@
+KNOWNBUG
+array_read_multi_dimension.c
+--trace
+Passing problem to incremental SMT2 solving
+^Trace for main\.assertion\.1
+example_array=\{ 42, 42, 42, 42, 
+^EXIT=10$
+^SIGNAL=0$
+--
+Unrecognised SMT term - \"
+Invalid SMT response received from solver
+--
+Test of writing a value at a non-deterministic index of a two-dimensional array,
+then asserting the value we expect.

--- a/regression/cbmc-incr-smt2/arrays_traces/array_write.c
+++ b/regression/cbmc-incr-smt2/arrays_traces/array_write.c
@@ -1,0 +1,9 @@
+int main()
+{
+  int example_array[1025];
+  unsigned int index;
+  __CPROVER_assume(index < 1025);
+  example_array[index] = 42;
+  __CPROVER_assert(example_array[index] == 42, "Array condition");
+  __CPROVER_assert(example_array[index] != 42, "Array condition");
+}

--- a/regression/cbmc-incr-smt2/arrays_traces/array_write.desc
+++ b/regression/cbmc-incr-smt2/arrays_traces/array_write.desc
@@ -1,0 +1,12 @@
+KNOWNBUG
+array_write.c
+--trace
+Passing problem to incremental SMT2 solving
+^Trace for main\.assertion\.1
+example_array=\{ 42, 42, 42, 42, 
+^EXIT=10$
+^SIGNAL=0$
+--
+--
+Test of writing a value at a non-deterministic index of an array, then asserting
+the value we expect.

--- a/src/solvers/smt2_incremental/smt2_incremental_decision_procedure.cpp
+++ b/src/solvers/smt2_incremental/smt2_incremental_decision_procedure.cpp
@@ -87,6 +87,7 @@ void smt2_incremental_decision_proceduret::define_array_function(
     "sort.");
   const smt_identifier_termt array_identifier = smt_identifier_termt{
     "array_" + std::to_string(array_sequence()), array_sort};
+  identifier_table.emplace(array_identifier.identifier(), array_identifier);
   solver_process->send(smt_declare_function_commandt{array_identifier, {}});
   const std::vector<exprt> &elements = array.operands();
   const typet &index_type = array.type().index_type();
@@ -140,6 +141,7 @@ void smt2_incremental_decision_proceduret::define_dependent_functions(
             identifier, convert_type_to_smt_sort(symbol_expr->type())),
           {}};
         expression_identifiers.emplace(*symbol_expr, function.identifier());
+        identifier_table.emplace(identifier, function.identifier());
         solver_process->send(function);
       }
       else
@@ -149,6 +151,7 @@ void smt2_incremental_decision_proceduret::define_dependent_functions(
         const smt_define_function_commandt function{
           symbol->name, {}, convert_expr_to_smt(symbol->value)};
         expression_identifiers.emplace(*symbol_expr, function.identifier());
+        identifier_table.emplace(identifier, function.identifier());
         solver_process->send(function);
       }
     }
@@ -206,6 +209,8 @@ void smt2_incremental_decision_proceduret::ensure_handle_for_expr_defined(
   smt_define_function_commandt function{
     "B" + std::to_string(handle_sequence()), {}, convert_expr_to_smt(expr)};
   expression_handle_identifiers.emplace(expr, function.identifier());
+  identifier_table.emplace(
+    function.identifier().identifier(), function.identifier());
   solver_process->send(function);
 }
 

--- a/src/solvers/smt2_incremental/smt2_incremental_decision_procedure.h
+++ b/src/solvers/smt2_incremental/smt2_incremental_decision_procedure.h
@@ -52,6 +52,12 @@ public:
   void push() override;
   void pop() override;
 
+  /// Gets the value of \p descriptor from the solver and returns the solver
+  /// response expressed as an exprt of type \p type. This is an implementation
+  /// detail of the `get(exprt)` member function.
+  exprt get_expr(const smt_termt &descriptor, const typet &type) const;
+  array_exprt get_expr(const smt_termt &array, const array_typet &type) const;
+
 protected:
   // Implementation of protected decision_proceduret member function.
   resultt dec_solve() override;

--- a/src/solvers/smt2_incremental/smt2_incremental_decision_procedure.h
+++ b/src/solvers/smt2_incremental/smt2_incremental_decision_procedure.h
@@ -119,6 +119,7 @@ protected:
   /// array expressions when support for them is implemented.
   std::unordered_map<exprt, smt_identifier_termt, irep_hash>
     expression_identifiers;
+  std::unordered_map<irep_idt, smt_identifier_termt> identifier_table;
   /// This map is used to track object related state. See documentation in
   /// object_tracking.h for details.
   smt_object_mapt object_map;

--- a/src/solvers/smt2_incremental/smt_response_validation.cpp
+++ b/src/solvers/smt2_incremental/smt_response_validation.cpp
@@ -353,7 +353,9 @@ valid_smt_get_value_response(const irept &parse_tree)
   }
 }
 
-response_or_errort<smt_responset> validate_smt_response(const irept &parse_tree)
+response_or_errort<smt_responset> validate_smt_response(
+  const irept &parse_tree,
+  const std::unordered_map<irep_idt, smt_identifier_termt> &identifier_table)
 {
   if(parse_tree.id() == "sat")
     return response_or_errort<smt_responset>{

--- a/src/solvers/smt2_incremental/smt_response_validation.h
+++ b/src/solvers/smt2_incremental/smt_response_validation.h
@@ -38,7 +38,8 @@ private:
   std::vector<std::string> messages;
 };
 
-NODISCARD response_or_errort<smt_responset>
-validate_smt_response(const irept &parse_tree);
+NODISCARD response_or_errort<smt_responset> validate_smt_response(
+  const irept &parse_tree,
+  const std::unordered_map<irep_idt, smt_identifier_termt> &identifier_table);
 
 #endif // CPROVER_SOLVERS_SMT2_INCREMENTAL_SMT_RESPONSE_VALIDATION_H

--- a/src/solvers/smt2_incremental/smt_solver_process.cpp
+++ b/src/solvers/smt2_incremental/smt_solver_process.cpp
@@ -53,7 +53,8 @@ static void handle_invalid_smt(
   throw analysis_exceptiont{"Invalid SMT response received from solver."};
 }
 
-smt_responset smt_piped_solver_processt::receive_response()
+smt_responset smt_piped_solver_processt::receive_response(
+  const std::unordered_map<irep_idt, smt_identifier_termt> &identifier_table)
 {
   const auto response_text = process.wait_receive();
   log.debug() << "Solver response - " << response_text << messaget::eom;
@@ -61,7 +62,8 @@ smt_responset smt_piped_solver_processt::receive_response()
   const auto parse_tree = smt2irep(response_stream, log.get_message_handler());
   if(!parse_tree)
     throw deserialization_exceptiont{"Incomplete SMT response."};
-  const auto validation_result = validate_smt_response(*parse_tree);
+  const auto validation_result =
+    validate_smt_response(*parse_tree, identifier_table);
   if(const auto validation_errors = validation_result.get_if_error())
     handle_invalid_smt(*validation_errors, log);
   return *validation_result.get_if_valid();

--- a/src/solvers/smt2_incremental/smt_solver_process.h
+++ b/src/solvers/smt2_incremental/smt_solver_process.h
@@ -21,7 +21,9 @@ public:
   ///    solver process.
   virtual void send(const smt_commandt &command) = 0;
 
-  virtual smt_responset receive_response() = 0;
+  virtual smt_responset
+  receive_response(const std::unordered_map<irep_idt, smt_identifier_termt>
+                     &identifier_table) = 0;
 
   virtual ~smt_base_solver_processt() = default;
 };
@@ -41,7 +43,9 @@ public:
 
   void send(const smt_commandt &smt_command) override;
 
-  smt_responset receive_response() override;
+  smt_responset receive_response(
+    const std::unordered_map<irep_idt, smt_identifier_termt> &identifier_table)
+    override;
 
   ~smt_piped_solver_processt() override = default;
 

--- a/unit/solvers/smt2_incremental/smt2_incremental_decision_procedure.cpp
+++ b/unit/solvers/smt2_incremental/smt2_incremental_decision_procedure.cpp
@@ -573,5 +573,27 @@ TEST_CASE(
       smt_declare_function_commandt{index_term, {}},
       smt_assert_commandt{smt_core_theoryt::equal(
         foo_term, smt_array_theoryt::select(array_term, index_term))}};
+
+    SECTION("Get values of array literal")
+    {
+      test.sent_commands.clear();
+      test.mock_responses = {
+        // get-value response for array_size
+        smt_get_value_responset{
+          {{{smt_bit_vector_constant_termt{2, 32}},
+            smt_bit_vector_constant_termt{2, 32}}}},
+        // get-value response for first element
+        smt_get_value_responset{
+          {{{smt_array_theoryt::select(
+              array_term, smt_bit_vector_constant_termt{0, 32})},
+            smt_bit_vector_constant_termt{9, 8}}}},
+        // get-value response for second element
+        smt_get_value_responset{
+          {{{smt_array_theoryt::select(
+              array_term, smt_bit_vector_constant_termt{1, 32})},
+            smt_bit_vector_constant_termt{12, 8}}}}
+      };
+      REQUIRE(test.procedure.get(array_literal) == array_literal);
+    }
   }
 }

--- a/unit/solvers/smt2_incremental/smt2_incremental_decision_procedure.cpp
+++ b/unit/solvers/smt2_incremental/smt2_incremental_decision_procedure.cpp
@@ -80,7 +80,9 @@ public:
     _send(smt_command);
   }
 
-  smt_responset receive_response() override
+  smt_responset receive_response(
+    const std::unordered_map<irep_idt, smt_identifier_termt> &identifier_table)
+    override
   {
     return _receive();
   }

--- a/unit/solvers/smt2_incremental/smt2_incremental_decision_procedure.cpp
+++ b/unit/solvers/smt2_incremental/smt2_incremental_decision_procedure.cpp
@@ -130,8 +130,14 @@ private:
   decision_procedure_test_environmentt() = default;
 };
 
+#include <iostream>
+#define WATCHVAR( var ) \
+  std::cerr << "DBG: " << __FILE__ << "(" << __LINE__ << ") " << #var << \
+    " = [" << (var) << "]" << std::endl
+
 void decision_procedure_test_environmentt::send(const smt_commandt &smt_command)
 {
+  WATCHVAR(smt_command);
   sent_commands.push_back(smt_command);
 }
 
@@ -140,6 +146,7 @@ smt_responset decision_procedure_test_environmentt::receive_response()
   INVARIANT(
     !mock_responses.empty(), "There must be responses remaining for test.");
   smt_responset response = mock_responses.front();
+  WATCHVAR(response.pretty());
   mock_responses.pop_front();
   return response;
 }


### PR DESCRIPTION
This PR enables us to request CBMC to print traces of arrays in certain cases.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
