### PR TITLE
bv_utils: add missing representationt::

### DIFF
--- a/src/solvers/flattening/bv_utils.cpp
+++ b/src/solvers/flattening/bv_utils.cpp
@@ -1231,7 +1231,7 @@ literalt bv_utilst::lt_or_le(
     compareBelow = prop.new_variables(bv0.size());
     result = prop.new_variable();
 
-    if(rep==SIGNED)
+    if(rep == representationt::SIGNED)
     {
       INVARIANT(
         bv0.size() >= 2, "signed bitvectors should have at least two bits");
@@ -1332,7 +1332,7 @@ literalt bv_utilst::unsigned_less_than(
   const bvt &op1)
 {
 #ifdef COMPACT_LT_OR_LE
-  return lt_or_le(false, op0, op1, UNSIGNED);
+  return lt_or_le(false, op0, op1, representationt::UNSIGNED);
 #else
   // A <= B  iff  there is an overflow on A-B
   return !carry_out(op0, inverted(op1), const_literal(true));


### PR DESCRIPTION
This was missing in two places that are only conditionally compiled when
COMPACT_LT_OR_LE is set.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
