### PR TITLE
Bump clang-format version from 10 to 14

### DIFF
--- a/.github/workflows/pull-request-check-clang-format.sh
+++ b/.github/workflows/pull-request-check-clang-format.sh
@@ -7,7 +7,6 @@ set -e
 echo "Pull request's base branch is: ${BASE_BRANCH}"
 echo "Pull request's merge branch is: ${MERGE_BRANCH}"
 echo "Pull request's source branch is: ${GITHUB_HEAD_REF}"
-clang-format-14 --version
 
 # The checkout action leaves us in detatched head state. The following line
 # names the checked out commit, for simpler reference later.

--- a/.github/workflows/pull-request-check-clang-format.sh
+++ b/.github/workflows/pull-request-check-clang-format.sh
@@ -7,7 +7,7 @@ set -e
 echo "Pull request's base branch is: ${BASE_BRANCH}"
 echo "Pull request's merge branch is: ${MERGE_BRANCH}"
 echo "Pull request's source branch is: ${GITHUB_HEAD_REF}"
-clang-format-10 --version
+clang-format-14 --version
 
 # The checkout action leaves us in detatched head state. The following line
 # names the checked out commit, for simpler reference later.
@@ -26,7 +26,7 @@ echo "Checking for formatting errors introduced since $MERGE_BASE"
 
 # Do the checking. "eval" is used so that quotes (as inserted into $EXCLUDES
 # above) are not interpreted as parts of file names.
-eval git-clang-format --binary clang-format-10 $MERGE_BASE -- $EXCLUDES
+eval git-clang-format --binary clang-format-14 $MERGE_BASE -- $EXCLUDES
 git diff > formatted.diff
 if [[ -s formatted.diff ]] ; then
   echo 'Formatting error! The following diff shows the required changes'

--- a/.github/workflows/pull-request-checks.yaml
+++ b/.github/workflows/pull-request-checks.yaml
@@ -598,7 +598,7 @@ jobs:
         
 
   check-clang-format:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
         with:
@@ -612,7 +612,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install --no-install-recommends -yq clang-format
-      - name: Check updated lines of code match clang-format-10 style
+      - name: Check updated lines of code match clang-format-14 style
         env:
           BASE_BRANCH: ${{ github.base_ref }}
           MERGE_BRANCH: ${{ github.ref }}

--- a/.github/workflows/pull-request-checks.yaml
+++ b/.github/workflows/pull-request-checks.yaml
@@ -612,6 +612,8 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install --no-install-recommends -yq clang-format
+      - name: Log clang-format version
+        run: clang-format-14 --version
       - name: Check updated lines of code match clang-format-14 style
         env:
           BASE_BRANCH: ${{ github.base_ref }}

--- a/.github/workflows/pull-request-checks.yaml
+++ b/.github/workflows/pull-request-checks.yaml
@@ -612,6 +612,9 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install --no-install-recommends -yq clang-format
+          wget -O git-clang-format https://raw.githubusercontent.com/llvm/llvm-project/llvmorg-14.0.6/clang/tools/clang-format/git-clang-format
+          chmod u+x git-clang-format
+          mv git-clang-format /usr/local/bin
       - name: Log clang-format version
         run: clang-format-14 --version
       - name: Check updated lines of code match clang-format-14 style


### PR DESCRIPTION
This PR bumps the version of Ubuntu used for the clang-format job from
20.04 to 22.04, so that the version of clang-format used will be bumped
from 10 to 14. This should make it more straight forward for developers
with fresh Ubuntu (and MacOS) installs to locally setup tools for
applying formatting changes. Note that Ubuntu 22.04 has been made
generally available for GitHub hosted runners since 09 August 2022.
https://github.blog/changelog/2022-08-09-github-actions-ubuntu-22-04-is-now-generally-available-on-github-hosted-runners/

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
