### PR TITLE
Add array trace printing to incremental SMT2 decision procedure

### DIFF
--- a/regression/cbmc-incr-smt2/arrays_traces/array_read.c
+++ b/regression/cbmc-incr-smt2/arrays_traces/array_read.c
@@ -1,0 +1,7 @@
+int main()
+{
+  int example_array[1025];
+  unsigned int index;
+  __CPROVER_assume(index < 1025);
+  __CPROVER_assert(example_array[index] != 42, "Array condition");
+}

--- a/regression/cbmc-incr-smt2/arrays_traces/array_read.desc
+++ b/regression/cbmc-incr-smt2/arrays_traces/array_read.desc
@@ -1,0 +1,15 @@
+CORE
+array_read.c
+--trace
+Passing problem to incremental SMT2 solving
+\[main\.assertion\.1\] line \d+ Array condition: FAILURE
+^Trace for main\.assertion\.1
+example_array=\{ (\d+, )*42
+^EXIT=10$
+^SIGNAL=0$
+--
+--
+Test of reading a value at a non-deterministic index of an array.
+Similar to the test in ../arrays/array_read.c, but we want to assert
+the value of the array that comes back in the trace to make sure we're
+observing the correct values.

--- a/regression/cbmc-incr-smt2/arrays_traces/array_write.c
+++ b/regression/cbmc-incr-smt2/arrays_traces/array_write.c
@@ -1,0 +1,9 @@
+int main()
+{
+  int example_array[1025];
+  unsigned int index;
+  __CPROVER_assume(index < 1025);
+  example_array[index] = 42;
+  __CPROVER_assert(example_array[index] == 42, "Array condition");
+  __CPROVER_assert(example_array[index] != 42, "Array condition");
+}

--- a/regression/cbmc-incr-smt2/arrays_traces/array_write.desc
+++ b/regression/cbmc-incr-smt2/arrays_traces/array_write.desc
@@ -1,0 +1,12 @@
+CORE
+array_write.c
+--trace
+Passing problem to incremental SMT2 solving
+^Trace for main\.assertion\.2
+example_array\[\d{1,4}ll?\]=42
+^EXIT=10$
+^SIGNAL=0$
+--
+--
+Test of writing a value at a non-deterministic index of an array, then asserting
+the value we expect.

--- a/src/solvers/smt2_incremental/response_or_error.h
+++ b/src/solvers/smt2_incremental/response_or_error.h
@@ -1,0 +1,64 @@
+// Author: Diffblue Ltd.
+
+#ifndef CPROVER_SOLVERS_SMT2_INCREMENTAL_RESPONSE_OR_ERROR_H
+#define CPROVER_SOLVERS_SMT2_INCREMENTAL_RESPONSE_OR_ERROR_H
+
+#include <util/invariant.h>
+#include <util/optional.h>
+
+#include <string>
+#include <vector>
+
+/// Holds either a valid parsed response or response sub-tree of type \tparam
+/// smtt or a collection of message strings explaining why the given input was
+/// not valid.
+template <class smtt>
+class response_or_errort final
+{
+public:
+  explicit response_or_errort(smtt smt) : smt{std::move(smt)}
+  {
+  }
+
+  explicit response_or_errort(std::string message)
+    : messages{std::move(message)}
+  {
+  }
+
+  explicit response_or_errort(std::vector<std::string> messages)
+    : messages{std::move(messages)}
+  {
+  }
+
+  /// \brief Gets the smt response if the response is valid, or returns nullptr
+  ///   otherwise.
+  const smtt *get_if_valid() const
+  {
+    INVARIANT(
+      smt.has_value() == messages.empty(),
+      "The response_or_errort class must be in the valid state or error state, "
+      "exclusively.");
+    return smt.has_value() ? &smt.value() : nullptr;
+  }
+
+  /// \brief Gets the error messages if the response is invalid, or returns
+  ///   nullptr otherwise.
+  const std::vector<std::string> *get_if_error() const
+  {
+    INVARIANT(
+      smt.has_value() == messages.empty(),
+      "The response_or_errort class must be in the valid state or error state, "
+      "exclusively.");
+    return smt.has_value() ? nullptr : &messages;
+  }
+
+private:
+  // The below two fields could be a single `std::variant` field, if there was
+  // an implementation of it available in the cbmc repository. However at the
+  // time of writing we are targeting C++11, `std::variant` was introduced in
+  // C++17 and we have no backported version.
+  optionalt<smtt> smt;
+  std::vector<std::string> messages;
+};
+
+#endif // CPROVER_SOLVERS_SMT2_INCREMENTAL_RESPONSE_OR_ERROR_H

--- a/src/solvers/smt2_incremental/smt2_incremental_decision_procedure.cpp
+++ b/src/solvers/smt2_incremental/smt2_incremental_decision_procedure.cpp
@@ -319,6 +319,59 @@ static optionalt<smt_termt> get_identifier(
   return {};
 }
 
+array_exprt smt2_incremental_decision_proceduret::get_expr(
+  const smt_termt &array,
+  const array_typet &type) const
+{
+  INVARIANT(
+    type.is_complete(), "Array size is required for getting array values.");
+  const auto size = numeric_cast<std::size_t>(get(type.size()));
+  INVARIANT(
+    size,
+    "Size of array must be convertible to std::size_t for getting array value");
+  std::vector<exprt> elements;
+  const auto index_type = type.index_type();
+  elements.reserve(*size);
+  for(std::size_t index = 0; index < size; ++index)
+  {
+    elements.push_back(get_expr(
+      smt_array_theoryt::select(
+        array,
+        ::convert_expr_to_smt(
+          from_integer(index, index_type),
+          object_map,
+          pointer_sizes_map,
+          object_size_function.make_application)),
+      type.element_type()));
+  }
+  return array_exprt{elements, type};
+}
+
+exprt smt2_incremental_decision_proceduret::get_expr(
+  const smt_termt &descriptor,
+  const typet &type) const
+{
+  const smt_get_value_commandt get_value_command{descriptor};
+  const smt_responset response = get_response_to_command(
+    *solver_process, get_value_command, identifier_table);
+  const auto get_value_response = response.cast<smt_get_value_responset>();
+  if(!get_value_response)
+  {
+    throw analysis_exceptiont{
+      "Expected get-value response from solver, but received - " +
+      response.pretty()};
+  }
+  if(get_value_response->pairs().size() > 1)
+  {
+    throw analysis_exceptiont{
+      "Expected single valuation pair in get-value response from solver, but "
+      "received multiple pairs - " +
+      response.pretty()};
+  }
+  return construct_value_expr_from_smt(
+    get_value_response->pairs()[0].get().value(), type);
+}
+
 exprt smt2_incremental_decision_proceduret::get(const exprt &expr) const
 {
   log.conditional_output(log.debug(), [&](messaget::mstreamt &debug) {
@@ -359,25 +412,13 @@ exprt smt2_incremental_decision_proceduret::get(const exprt &expr) const
       return expr;
     }
   }
-  const smt_get_value_commandt get_value_command{*descriptor};
-  const smt_responset response = get_response_to_command(
-    *solver_process, get_value_command, identifier_table);
-  const auto get_value_response = response.cast<smt_get_value_responset>();
-  if(!get_value_response)
+  if(const auto array_type = type_try_dynamic_cast<array_typet>(expr.type()))
   {
-    throw analysis_exceptiont{
-      "Expected get-value response from solver, but received - " +
-      response.pretty()};
+    if(array_type->is_incomplete())
+      return expr;
+    return get_expr(*descriptor, *array_type);
   }
-  if(get_value_response->pairs().size() > 1)
-  {
-    throw analysis_exceptiont{
-      "Expected single valuation pair in get-value response from solver, but "
-      "received multiple pairs - " +
-      response.pretty()};
-  }
-  return construct_value_expr_from_smt(
-    get_value_response->pairs()[0].get().value(), expr.type());
+  return get_expr(*descriptor, expr.type());
 }
 
 void smt2_incremental_decision_proceduret::print_assignment(

--- a/src/solvers/smt2_incremental/smt2_incremental_decision_procedure.cpp
+++ b/src/solvers/smt2_incremental/smt2_incremental_decision_procedure.cpp
@@ -27,12 +27,13 @@
 /// return a success status followed by the actual response of interest.
 static smt_responset get_response_to_command(
   smt_base_solver_processt &solver_process,
-  const smt_commandt &command)
+  const smt_commandt &command,
+  const std::unordered_map<irep_idt, smt_identifier_termt> &identifier_table)
 {
   solver_process.send(command);
-  auto response = solver_process.receive_response();
+  auto response = solver_process.receive_response(identifier_table);
   if(response.cast<smt_success_responset>())
-    return solver_process.receive_response();
+    return solver_process.receive_response(identifier_table);
   else
     return response;
 }
@@ -317,6 +318,7 @@ exprt smt2_incremental_decision_proceduret::get(const exprt &expr) const
   });
   optionalt<smt_termt> descriptor =
     get_identifier(expr, expression_handle_identifiers, expression_identifiers);
+
   if(!descriptor)
   {
     if(gather_dependent_expressions(expr).empty())
@@ -350,8 +352,8 @@ exprt smt2_incremental_decision_proceduret::get(const exprt &expr) const
     }
   }
   const smt_get_value_commandt get_value_command{*descriptor};
-  const smt_responset response =
-    get_response_to_command(*solver_process, get_value_command);
+  const smt_responset response = get_response_to_command(
+    *solver_process, get_value_command, identifier_table);
   const auto get_value_response = response.cast<smt_get_value_responset>();
   if(!get_value_response)
   {
@@ -464,8 +466,8 @@ decision_proceduret::resultt smt2_incremental_decision_proceduret::dec_solve()
 {
   ++number_of_solver_calls;
   define_object_sizes();
-  const smt_responset result =
-    get_response_to_command(*solver_process, smt_check_sat_commandt{});
+  const smt_responset result = get_response_to_command(
+    *solver_process, smt_check_sat_commandt{}, identifier_table);
   if(const auto check_sat_response = result.cast<smt_check_sat_responset>())
   {
     if(check_sat_response->kind().cast<smt_unknown_responset>())

--- a/src/solvers/smt2_incremental/smt2_incremental_decision_procedure.h
+++ b/src/solvers/smt2_incremental/smt2_incremental_decision_procedure.h
@@ -52,6 +52,12 @@ public:
   void push() override;
   void pop() override;
 
+  /// Gets the value of \p descriptor from the solver and returns the solver
+  /// response expressed as an exprt of type \p type. This is an implementation
+  /// detail of the `get(exprt)` member function.
+  exprt get_expr(const smt_termt &descriptor, const typet &type) const;
+  array_exprt get_expr(const smt_termt &array, const array_typet &type) const;
+
 protected:
   // Implementation of protected decision_proceduret member function.
   resultt dec_solve() override;

--- a/src/solvers/smt2_incremental/smt2_incremental_decision_procedure.h
+++ b/src/solvers/smt2_incremental/smt2_incremental_decision_procedure.h
@@ -91,6 +91,7 @@ protected:
   /// \brief Add objects in \p expr to object_map if needed and convert to smt.
   /// \note This function is non-const because it mutates the object_map.
   smt_termt convert_expr_to_smt(const exprt &expr);
+  void define_index_identifiers(const exprt &expr);
   /// Sends the solver the definitions of the object sizes.
   void define_object_sizes();
 
@@ -118,7 +119,7 @@ protected:
     {
       return next_id++;
     }
-  } handle_sequence, array_sequence;
+  } handle_sequence, array_sequence, index_sequence;
   /// When the `handle(exprt)` member function is called, the decision procedure
   /// commands the SMT solver to define a new function corresponding to the
   /// given expression. The mapping of the expressions to the function

--- a/src/solvers/smt2_incremental/smt2_incremental_decision_procedure.h
+++ b/src/solvers/smt2_incremental/smt2_incremental_decision_procedure.h
@@ -131,6 +131,7 @@ protected:
   /// array expressions when support for them is implemented.
   std::unordered_map<exprt, smt_identifier_termt, irep_hash>
     expression_identifiers;
+  std::unordered_map<irep_idt, smt_identifier_termt> identifier_table;
   /// This map is used to track object related state. See documentation in
   /// object_tracking.h for details.
   smt_object_mapt object_map;

--- a/src/solvers/smt2_incremental/smt_array_theory.cpp
+++ b/src/solvers/smt2_incremental/smt_array_theory.cpp
@@ -14,15 +14,24 @@ smt_sortt smt_array_theoryt::selectt::return_sort(
   return array.get_sort().cast<smt_array_sortt>()->element_sort();
 }
 
-void smt_array_theoryt::selectt::validate(
+std::vector<std::string> smt_array_theoryt::selectt::validation_errors(
   const smt_termt &array,
   const smt_termt &index)
 {
   const auto array_sort = array.get_sort().cast<smt_array_sortt>();
-  INVARIANT(array_sort, "\"select\" may only select from an array.");
-  INVARIANT(
-    array_sort->index_sort() == index.get_sort(),
-    "Sort of arrays index must match the sort of the index supplied.");
+  if(!array_sort)
+    return {"\"select\" may only select from an array."};
+  if(array_sort->index_sort() != index.get_sort())
+    return {"Sort of arrays index must match the sort of the index supplied."};
+  return {};
+}
+
+void smt_array_theoryt::selectt::validate(
+  const smt_termt &array,
+  const smt_termt &index)
+{
+  const auto validation_errors = selectt::validation_errors(array, index);
+  INVARIANT(validation_errors.empty(), validation_errors[0]);
 }
 
 const smt_function_application_termt::factoryt<smt_array_theoryt::selectt>

--- a/src/solvers/smt2_incremental/smt_array_theory.h
+++ b/src/solvers/smt2_incremental/smt_array_theory.h
@@ -13,6 +13,8 @@ public:
     static const char *identifier();
     static smt_sortt
     return_sort(const smt_termt &array, const smt_termt &index);
+    static std::vector<std::string>
+    validation_errors(const smt_termt &array, const smt_termt &index);
     static void validate(const smt_termt &array, const smt_termt &index);
   };
   static const smt_function_application_termt::factoryt<selectt> select;

--- a/src/solvers/smt2_incremental/smt_response_validation.cpp
+++ b/src/solvers/smt2_incremental/smt_response_validation.cpp
@@ -353,7 +353,9 @@ valid_smt_get_value_response(const irept &parse_tree)
   }
 }
 
-response_or_errort<smt_responset> validate_smt_response(const irept &parse_tree)
+response_or_errort<smt_responset> validate_smt_response(
+  const irept &parse_tree,
+  const std::unordered_map<irep_idt, smt_identifier_termt> &identifier_table)
 {
   if(parse_tree.id() == "sat")
     return response_or_errort<smt_responset>{

--- a/src/solvers/smt2_incremental/smt_response_validation.cpp
+++ b/src/solvers/smt2_incremental/smt_response_validation.cpp
@@ -29,45 +29,6 @@ static response_or_errort<smt_termt> validate_term(
   const irept &parse_tree,
   const std::unordered_map<irep_idt, smt_identifier_termt> &identifier_table);
 
-template <class smtt>
-response_or_errort<smtt>::response_or_errort(smtt smt) : smt{std::move(smt)}
-{
-}
-
-template <class smtt>
-response_or_errort<smtt>::response_or_errort(std::string message)
-  : messages{std::move(message)}
-{
-}
-
-template <class smtt>
-response_or_errort<smtt>::response_or_errort(std::vector<std::string> messages)
-  : messages{std::move(messages)}
-{
-}
-
-template <class smtt>
-const smtt *response_or_errort<smtt>::get_if_valid() const
-{
-  INVARIANT(
-    smt.has_value() == messages.empty(),
-    "The response_or_errort class must be in the valid state or error state, "
-    "exclusively.");
-  return smt.has_value() ? &smt.value() : nullptr;
-}
-
-template <class smtt>
-const std::vector<std::string> *response_or_errort<smtt>::get_if_error() const
-{
-  INVARIANT(
-    smt.has_value() == messages.empty(),
-    "The response_or_errort class must be in the valid state or error state, "
-    "exclusively.");
-  return smt.has_value() ? nullptr : &messages;
-}
-
-template class response_or_errort<smt_responset>;
-
 // Implementation detail of `collect_messages` below.
 template <typename argumentt, typename... argumentst>
 void collect_messages_impl(
@@ -297,8 +258,8 @@ static optionalt<response_or_errort<smt_termt>> try_select_validation(
   const auto messages = collect_messages(array, index);
   if(!messages.empty())
     return response_or_errort<smt_termt>{messages};
-  return response_or_errort<smt_termt>{
-    smt_array_theoryt::select(*array.get_if_valid(), *index.get_if_valid())};
+  return {smt_array_theoryt::select.validation(
+    *array.get_if_valid(), *index.get_if_valid())};
 }
 
 static response_or_errort<smt_termt> validate_term(

--- a/src/solvers/smt2_incremental/smt_response_validation.h
+++ b/src/solvers/smt2_incremental/smt_response_validation.h
@@ -38,7 +38,8 @@ private:
   std::vector<std::string> messages;
 };
 
-NODISCARD response_or_errort<smt_responset>
-validate_smt_response(const irept &parse_tree);
+NODISCARD response_or_errort<smt_responset> validate_smt_response(
+  const irept &parse_tree,
+  const std::unordered_map<irep_idt, smt_identifier_termt> &identifier_table);
 
 #endif // CPROVER_SOLVERS_SMT2_INCREMENTAL_SMT_RESPONSE_VALIDATION_H

--- a/src/solvers/smt2_incremental/smt_response_validation.h
+++ b/src/solvers/smt2_incremental/smt_response_validation.h
@@ -3,40 +3,10 @@
 #ifndef CPROVER_SOLVERS_SMT2_INCREMENTAL_SMT_RESPONSE_VALIDATION_H
 #define CPROVER_SOLVERS_SMT2_INCREMENTAL_SMT_RESPONSE_VALIDATION_H
 
-#include <solvers/smt2_incremental/smt_responses.h>
-#include <util/invariant.h>
 #include <util/nodiscard.h>
-#include <util/optional.h>
 
-#include <string>
-#include <vector>
-
-/// Holds either a valid parsed response or response sub-tree of type \tparam
-/// smtt or a collection of message strings explaining why the given input was
-/// not valid.
-template <class smtt>
-class response_or_errort final
-{
-public:
-  explicit response_or_errort(smtt smt);
-  explicit response_or_errort(std::string message);
-  explicit response_or_errort(std::vector<std::string> messages);
-
-  /// \brief Gets the smt response if the response is valid, or returns nullptr
-  ///   otherwise.
-  const smtt *get_if_valid() const;
-  /// \brief Gets the error messages if the response is invalid, or returns
-  ///   nullptr otherwise.
-  const std::vector<std::string> *get_if_error() const;
-
-private:
-  // The below two fields could be a single `std::variant` field, if there was
-  // an implementation of it available in the cbmc repository. However at the
-  // time of writing we are targeting C++11, `std::variant` was introduced in
-  // C++17 and we have no backported version.
-  optionalt<smtt> smt;
-  std::vector<std::string> messages;
-};
+#include <solvers/smt2_incremental/response_or_error.h>
+#include <solvers/smt2_incremental/smt_responses.h>
 
 NODISCARD response_or_errort<smt_responset> validate_smt_response(
   const irept &parse_tree,

--- a/src/solvers/smt2_incremental/smt_solver_process.cpp
+++ b/src/solvers/smt2_incremental/smt_solver_process.cpp
@@ -53,7 +53,8 @@ static void handle_invalid_smt(
   throw analysis_exceptiont{"Invalid SMT response received from solver."};
 }
 
-smt_responset smt_piped_solver_processt::receive_response()
+smt_responset smt_piped_solver_processt::receive_response(
+  const std::unordered_map<irep_idt, smt_identifier_termt> &identifier_table)
 {
   const auto response_text = process.wait_receive();
   log.debug() << "Solver response - " << response_text << messaget::eom;
@@ -61,7 +62,8 @@ smt_responset smt_piped_solver_processt::receive_response()
   const auto parse_tree = smt2irep(response_stream, log.get_message_handler());
   if(!parse_tree)
     throw deserialization_exceptiont{"Incomplete SMT response."};
-  const auto validation_result = validate_smt_response(*parse_tree);
+  const auto validation_result =
+    validate_smt_response(*parse_tree, identifier_table);
   if(const auto validation_errors = validation_result.get_if_error())
     handle_invalid_smt(*validation_errors, log);
   return *validation_result.get_if_valid();

--- a/src/solvers/smt2_incremental/smt_solver_process.h
+++ b/src/solvers/smt2_incremental/smt_solver_process.h
@@ -21,7 +21,9 @@ public:
   ///    solver process.
   virtual void send(const smt_commandt &command) = 0;
 
-  virtual smt_responset receive_response() = 0;
+  virtual smt_responset
+  receive_response(const std::unordered_map<irep_idt, smt_identifier_termt>
+                     &identifier_table) = 0;
 
   virtual ~smt_base_solver_processt() = default;
 };
@@ -41,7 +43,9 @@ public:
 
   void send(const smt_commandt &smt_command) override;
 
-  smt_responset receive_response() override;
+  smt_responset receive_response(
+    const std::unordered_map<irep_idt, smt_identifier_termt> &identifier_table)
+    override;
 
   ~smt_piped_solver_processt() override = default;
 

--- a/src/solvers/smt2_incremental/smt_terms.h
+++ b/src/solvers/smt2_incremental/smt_terms.h
@@ -5,6 +5,7 @@
 
 #include <util/irep.h>
 
+#include <solvers/smt2_incremental/response_or_error.h>
 #include <solvers/smt2_incremental/smt_index.h>
 #include <solvers/smt2_incremental/smt_sorts.h>
 #include <solvers/smt2_incremental/type_traits.h>
@@ -203,6 +204,20 @@ public:
         smt_identifier_termt{
           function.identifier(), std::move(return_sort), indices(function)},
         {std::forward<argument_typest>(arguments)...}};
+    }
+
+    template <typename... argument_typest>
+    response_or_errort<smt_termt>
+    validation(argument_typest &&... arguments) const
+    {
+      const auto validation_errors = function.validation_errors(arguments...);
+      if(!validation_errors.empty())
+        return response_or_errort<smt_termt>{validation_errors};
+      auto return_sort = function.return_sort(arguments...);
+      return response_or_errort<smt_termt>{smt_function_application_termt{
+        smt_identifier_termt{
+          function.identifier(), std::move(return_sort), indices(function)},
+        {std::forward<argument_typest>(arguments)...}}};
     }
   };
 };

--- a/unit/solvers/smt2_incremental/smt2_incremental_decision_procedure.cpp
+++ b/unit/solvers/smt2_incremental/smt2_incremental_decision_procedure.cpp
@@ -81,7 +81,9 @@ public:
     _send(smt_command);
   }
 
-  smt_responset receive_response() override
+  smt_responset receive_response(
+    const std::unordered_map<irep_idt, smt_identifier_termt> &identifier_table)
+    override
   {
     return _receive();
   }

--- a/unit/solvers/smt2_incremental/smt2_incremental_decision_procedure.cpp
+++ b/unit/solvers/smt2_incremental/smt2_incremental_decision_procedure.cpp
@@ -616,6 +616,27 @@ TEST_CASE(
       smt_assert_commandt{smt_core_theoryt::equal(
         foo_term, smt_array_theoryt::select(array_term, index_term))}};
     REQUIRE(test.sent_commands == expected_commands);
+
+    SECTION("Get values of array literal")
+    {
+      test.sent_commands.clear();
+      test.mock_responses = {
+        // get-value response for array_size
+        smt_get_value_responset{
+          {{{smt_bit_vector_constant_termt{2, 32}},
+            smt_bit_vector_constant_termt{2, 32}}}},
+        // get-value response for first element
+        smt_get_value_responset{
+          {{{smt_array_theoryt::select(
+              array_term, smt_bit_vector_constant_termt{0, 32})},
+            smt_bit_vector_constant_termt{9, 8}}}},
+        // get-value response for second element
+        smt_get_value_responset{
+          {{{smt_array_theoryt::select(
+              array_term, smt_bit_vector_constant_termt{1, 32})},
+            smt_bit_vector_constant_termt{12, 8}}}}};
+      REQUIRE(test.procedure.get(array_literal) == array_literal);
+    }
   }
   SECTION("array_of_exprt - all elements set to a given value")
   {

--- a/unit/solvers/smt2_incremental/smt_response_validation.cpp
+++ b/unit/solvers/smt2_incremental/smt_response_validation.cpp
@@ -275,6 +275,14 @@ TEST_CASE("smt get-value response validation", "[core][smt2_incremental]")
     CHECK(
       *empty_value_response.get_if_error() ==
       std::vector<std::string>{"Unrecognised SMT term - \"\"."});
+    const response_or_errort<smt_responset> unknown_identifier_response =
+      validate_smt_response(
+        *smt2irep("((foo bar)))").parsed_output, identifier_table);
+    CHECK(
+      *unknown_identifier_response.get_if_error() ==
+      std::vector<std::string>{
+        "Unrecognised SMT term - \"foo\".",
+        "Unrecognised SMT term - \"bar\"."});
     const response_or_errort<smt_responset> pair_value_response =
       validate_smt_response(
         *smt2irep("((a (#xF00D #xBAD))))").parsed_output, identifier_table);


### PR DESCRIPTION
This PR includes the functionality from https://github.com/diffblue/cbmc/pull/7066 , but with the additional fixes required to support traces where individual elements of an array are written to.
<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
