### PR TITLE
Introduce expression enumerators

### DIFF
--- a/src/goto-instrument/Makefile
+++ b/src/goto-instrument/Makefile
@@ -69,6 +69,7 @@ SRC = accelerate/accelerate.cpp \
       splice_call.cpp \
       stack_depth.cpp \
       synthesizer/enumerative_loop_invariant_synthesizer.cpp \
+      synthesizer/expr_enumerator.cpp \
       synthesizer/synthesizer_utils.cpp \
       thread_instrumentation.cpp \
       undefined_functions.cpp \

--- a/src/goto-instrument/synthesizer/expr_enumerator.cpp
+++ b/src/goto-instrument/synthesizer/expr_enumerator.cpp
@@ -1,0 +1,375 @@
+/*******************************************************************\
+Module: Enumerator Interface
+Author: Qinheping Hu
+\*******************************************************************/
+
+#include "expr_enumerator.h"
+
+#include <util/format_expr.h>
+#include <util/simplify_expr.h>
+
+expr_sett leaf_enumeratort::enumerate(const std::size_t size) const
+{
+  // Size of leaf expressions must be 1.
+  if(size != 1)
+    return {};
+
+  return leaf_exprs;
+}
+
+expr_sett non_leaf_enumeratort::enumerate(const std::size_t size) const
+{
+  expr_sett result;
+
+  // Enumerate nothing when `size` is too small to be partitioned.
+  if(size - 1 < arity)
+    return result;
+
+  // For every possible partition, set `size` of
+  // each sub-enumerator to be the corresponding component in the partition.
+  for(const auto &partition : get_partitions(size - 1, arity))
+  {
+    if(!is_good_partition(partition))
+      continue;
+
+    // Compute the Cartesian product as result.
+    for(const auto &product_tuple : cartesian_product_of_enumerators(
+          sub_enumerators,
+          sub_enumerators.begin(),
+          partition,
+          partition.begin()))
+    {
+      // Optimization: rule out equivalent expressions
+      // using certain equivalence class.
+      // Keep only representation tuple of each equivalence class.
+      if(is_equivalence_class_representation(product_tuple))
+        result.insert(simplify_expr(instantiate(product_tuple), ns));
+    }
+  }
+
+  return result;
+}
+
+std::set<expr_listt> non_leaf_enumeratort::cartesian_product_of_enumerators(
+  const enumeratorst &enumerators,
+  const enumeratorst::const_iterator &it_enumerators,
+  const partitiont &partition,
+  const partitiont::const_iterator &it_partition) const
+{
+  INVARIANT(
+    std::distance(it_enumerators, enumerators.end()) ==
+      std::distance(it_partition, partition.end()),
+    "Partition should have the same size as enumerators.");
+
+  std::set<expr_listt> result;
+
+  if(std::next(it_enumerators) == enumerators.end())
+  {
+    /// Current enumerator is the last enumerator.
+    /// Add all expressions enumerated by `it_enumerators` to `result`.
+    for(const auto &e : enumerators.back()->enumerate(*it_partition))
+    {
+      result.insert({e});
+    }
+  }
+  else
+  {
+    /// First compute the Cartesian product of enumerators after
+    /// `it_enumerators`. And then append the expressions enumerated by the
+    /// `it_enumerators` to every list in the Cartesian product.
+    for(const auto &sub_tuple : cartesian_product_of_enumerators(
+          enumerators,
+          std::next(it_enumerators),
+          partition,
+          std::next(it_partition)))
+    {
+      for(const auto &elem : (*it_enumerators)->enumerate(*it_partition))
+      {
+        expr_listt new_tuple(sub_tuple);
+        new_tuple.emplace_front(elem);
+        result.insert(new_tuple);
+      }
+    }
+  }
+  return result;
+}
+
+std::list<partitiont>
+get_partitions_long(const std::size_t n, const std::size_t k)
+{
+  std::list<partitiont> result;
+  // Cuts are an increasing vector of distinct indexes between 0 and n.
+  // Note that cuts[0] is always 0 and cuts[k+1] is always n.
+  // There is a bijection between partitions and cuts, i.e., for a given cuts,
+  // (cuts[1]-cuts[0], cuts[2]-cuts[1], ..., cuts[k+1]-cuts[k])
+  // is a partition of n into k components.
+  std::vector<std::size_t> cuts;
+
+  // Initialize cuts as (0, n-k+1, n-k+2, ..., n).
+  // O: elements
+  // |: cuts
+  // Initial cuts
+  // 000...0111...1
+  // So the first partition is (n-k+1, 1, 1, ..., 1).
+  cuts.emplace_back(0);
+  cuts.emplace_back(n - k + 1);
+  for(std::size_t i = 0; i < k - 1; i++)
+  {
+    cuts.emplace_back(n - k + 2 + i);
+  }
+
+  // Done when all cuts were enumerated.
+  bool done = false;
+
+  while(!done)
+  {
+    // Construct a partition from cuts using the bijection described above.
+    partitiont new_partition = partitiont();
+    for(std::size_t i = 1; i < k + 1; i++)
+    {
+      new_partition.emplace_back(cuts[i] - cuts[i - 1]);
+    }
+
+    // We move to the next cuts. The idea is that
+    // 1. we first find the largest index i such that there are space before
+    //    cuts[i] where cuts[i] can be moved to;
+    //    The index i is the rightmost index we move in this iteration.
+    // 2. we then move cuts[i] to its left by 1;
+    // 3. move all cuts next to cuts[rightmost_to_move].
+    //
+    // O: filler
+    // |: cuts
+    //
+    // Example:
+    //   Before moving:
+    // 00000010010111110
+    //            ^
+    //      rightmost_to_move
+    std::size_t rightmost_to_move = 0;
+    for(std::size_t i = 1; i < k; i++)
+    {
+      if(cuts[i] - cuts[i - 1] > 1)
+      {
+        rightmost_to_move = i;
+      }
+    }
+
+    // Move cuts[rightmost_to_move] to its left:
+    // 00000010011011110
+    //           ^
+    //    rightmost_to_move
+    cuts[rightmost_to_move] = cuts[rightmost_to_move] - 1;
+
+    // No cut can be moved---we have enumerated all cuts.
+    if(rightmost_to_move == 0)
+      done = true;
+    else
+    {
+      // Move all cuts (except for cuts[0]) after rightmost_to_move to their
+      // rightmost.
+      // 00000010011001111
+      //           ^
+      //    rightmost_to_move
+      std::size_t accum = 1;
+      for(std::size_t i = k - 1; i > rightmost_to_move; i--)
+      {
+        cuts[i] = n - accum;
+        accum++;
+      }
+    }
+    result.emplace_back(new_partition);
+  }
+  return result;
+}
+
+/// Compute all positions of ones in the bit vector `v` (1-indexed).
+std::vector<std::size_t> get_ones_pos(std::size_t v)
+{
+  const std::size_t length = sizeof(std::size_t) * 8;
+  std::vector<std::size_t> result;
+
+  // Start from the lowest bit at position `length`
+  std::size_t curr_pos = length;
+  while(v != 0)
+  {
+    if(v % 2)
+    {
+      result.insert(result.begin(), curr_pos);
+    }
+
+    // Move to the next bit.
+    v = v >> 1;
+    curr_pos--;
+  }
+
+  return result;
+}
+
+/// Construct parition of `n` elements from a bit vector `v`.
+/// For a bit vector with ones at positions (computed by `get_ones_pos`)
+/// (ones[0], ones[1], ..., ones[k-2]),
+/// the corresponding partition is
+/// (ones[0], ones[1]-ones[0], ..., ones[k-2]-ones[k-3], n-ones[k-2]).
+partitiont from_bits_to_partition(std::size_t v, std::size_t n)
+{
+  const std::vector<std::size_t> ones_pos = get_ones_pos(v);
+
+  INVARIANT(ones_pos.size() >= 1, "There should be at least one bit set in v");
+
+  partitiont result = {ones_pos[0]};
+
+  for(std::size_t i = 1; i < ones_pos.size(); i++)
+  {
+    result.emplace_back(ones_pos[i] - ones_pos[i - 1]);
+  }
+  result.emplace_back(n - ones_pos[ones_pos.size() - 1]);
+
+  return result;
+}
+
+std::list<partitiont> non_leaf_enumeratort::get_partitions(
+  const std::size_t n,
+  const std::size_t k) const
+{
+  // Every component should contain at least one element.
+  if(n < k)
+    return {};
+
+  // Number of bits at all.
+  const std::size_t length = sizeof(std::size_t) * 8;
+
+  // This bithack-based implementation works only for `n` no larger than
+  // `length`. Use the vector-based implementation `n` is too large.
+  if(n > length)
+    return get_partitions_long(n, k);
+
+  // We enumerate all bit vectors `v` with k-1 one's such that each component
+  // corresponds to one unique partition.
+  // For a bit vector with ones at positions (computed by `get_ones_pos`)
+  // (ones[0], ones[1], ..., ones[k-2]),
+  // the corresponding partition is
+  // (ones[0], ones[1]-ones[0], ..., ones[k-2]-ones[k-3], n-ones[k-2]).
+
+  // Initial `v` is with ones at positions (n-k+1, n-k+2, ..., n-2, n-1).
+  std::size_t v = 0;
+  // Initial `end` (the last bit vectorr we enumerate) is with ones at
+  // positions (1, 2, 3, ..., k-1).
+  std::size_t end = 0;
+  for(size_t i = 0; i < k - 1; i++)
+  {
+    v++;
+    v = v << 1;
+    end++;
+    end = end << 1;
+  }
+  v = v << (length - n);
+  end = end << (length - k);
+
+  std::list<partitiont> result;
+  while(v != end)
+  {
+    // Construct the partition for current bit vector and add it to `result`
+    result.emplace_back(from_bits_to_partition(v, n));
+
+    // https://graphics.stanford.edu/~seander/bithacks.html#NextBitPermutation
+    // Compute the lexicographically next bit permutation.
+    std::size_t t = (v | (v - 1)) + 1;
+    v = t | ((((t & -t) / (v & -v)) >> 1) - 1);
+  }
+  result.emplace_back(from_bits_to_partition(v, n));
+
+  return result;
+}
+
+bool binary_functional_enumeratort::is_commutative(const irep_idt &op) const
+{
+  return op_id == ID_equal || op_id == ID_plus || op_id == ID_notequal ||
+         op_id == ID_or || op_id == ID_and || op_id == ID_xor ||
+         op_id == ID_bitand || op_id == ID_bitor || op_id == ID_bitxor ||
+         op_id == ID_mult;
+}
+
+bool binary_functional_enumeratort::is_equivalence_class_representation(
+  const expr_listt &exprs) const
+{
+  std::stringstream left, right;
+  left << format(exprs.front());
+  right << format(exprs.back());
+  // When the two sub-enumerators are exchangeable---they enumerate the same
+  // set of expressions---, and the operator is commutative, `exprs` is a
+  // representation if its sub-expressions are sorted.
+  if(is_exchangeable && is_commutative(op_id) && left.str() > right.str())
+  {
+    return false;
+  }
+
+  /// We are not sure if `exprs` is represented by some other tuple.
+  return true;
+}
+
+exprt binary_functional_enumeratort::instantiate(const expr_listt &exprs) const
+{
+  INVARIANT(
+    exprs.size() == 2,
+    "number of arguments should be 2: " + integer2string(exprs.size()));
+  if(op_id == ID_equal)
+    return equal_exprt(exprs.front(), exprs.back());
+  if(op_id == ID_le)
+    return less_than_or_equal_exprt(exprs.front(), exprs.back());
+  if(op_id == ID_lt)
+    return less_than_exprt(exprs.front(), exprs.back());
+  if(op_id == ID_gt)
+    return greater_than_exprt(exprs.front(), exprs.back());
+  if(op_id == ID_ge)
+    return greater_than_or_equal_exprt(exprs.front(), exprs.back());
+  if(op_id == ID_and)
+    return and_exprt(exprs.front(), exprs.back());
+  if(op_id == ID_or)
+    return or_exprt(exprs.front(), exprs.back());
+  if(op_id == ID_plus)
+    return plus_exprt(exprs.front(), exprs.back());
+  if(op_id == ID_minus)
+    return minus_exprt(exprs.front(), exprs.back());
+  if(op_id == ID_notequal)
+    return notequal_exprt(exprs.front(), exprs.back());
+  return binary_exprt(exprs.front(), op_id, exprs.back());
+}
+
+expr_sett alternatives_enumeratort::enumerate(const std::size_t size) const
+{
+  expr_sett result;
+  for(const auto &enumerator : sub_enumerators)
+  {
+    for(const auto &e : enumerator->enumerate(size))
+    {
+      result.insert(e);
+    }
+  }
+  return result;
+}
+
+expr_sett
+recursive_enumerator_placeholdert::enumerate(const std::size_t size) const
+{
+  const auto &it = factory.productions_map.find(identifier);
+  INVARIANT(it != factory.productions_map.end(), "No nonterminal found.");
+  alternatives_enumeratort actual_enumerator(it->second, ns);
+  return actual_enumerator.enumerate(size);
+}
+
+void enumerator_factoryt::add_placeholder(
+  const recursive_enumerator_placeholdert &placeholder)
+{
+  // The new placeholder (nonterminal) belongs to this factory (grammar).
+  const auto &ret = nonterminal_set.insert(placeholder.identifier);
+  INVARIANT(ret.second, "Duplicated non-terminals");
+}
+
+void enumerator_factoryt::attach_productions(
+  const std::string &id,
+  const enumeratorst &enumerators)
+{
+  const auto &ret = productions_map.insert({id, enumerators});
+  INVARIANT(
+    ret.second, "Cannnot attach enumerators to a non-existing nonterminal.");
+}

--- a/src/goto-instrument/synthesizer/expr_enumerator.h
+++ b/src/goto-instrument/synthesizer/expr_enumerator.h
@@ -1,0 +1,359 @@
+/*******************************************************************\
+Module: Enumerator Interface
+Author: Qinheping Hu
+\*******************************************************************/
+
+/// \file
+/// Enumerator Interface
+
+#ifndef CPROVER_GOTO_INSTRUMENT_SYNTHESIZER_EXPR_ENUMERATOR_H
+#define CPROVER_GOTO_INSTRUMENT_SYNTHESIZER_EXPR_ENUMERATOR_H
+
+#include <util/std_expr.h>
+
+#include "synthesizer_utils.h"
+
+#include <map>
+
+typedef std::list<exprt> expr_listt;
+typedef std::set<exprt> expr_sett;
+typedef std::list<std::size_t> partitiont;
+
+/*
+  This is the interface of grammar-based enumerators. Users can specify tree
+  grammars, and enumerate expressions derived by the grammars using these
+  enumerators. A tree grammar consists of a finite set of nonterminals and
+  a finite set of productions of the form A -> t where A is some nonterminal,
+  and t is some tree composed from nonterminal symbols and constants.
+
+  In the level of productions, we introduce three classes of enumerators:
+  1. `leaf_enumeratort` enumerates `exprt`-typed expressions. It is used
+     to enumerate leaves of trees derived from the tree grammar.
+     Example:
+     a `leaf_enumeratort` with `leaf_exprs` {0} enumerates expressions derived
+     from the production
+     * -> 0.
+  2. `non_leaf_enumeratort` enumerates expressions recursively built from
+     sub-trees---trees enumerated by sub-enumerators.
+     Example:
+     a `non_leaf_enumeratort` with `sub_enumerators` {A, B} and `op` +
+     enumerates expressions derived from the production
+     * -> A + B.
+  3. `alternatives_enumeratort` enumerates expressions that can be enumerated
+     by any of its `sub_enumerators`
+     Example:
+     a `alternatives_enumeratort` with `sub_enumerators` the enumerators in
+     the Example 1 and 2 enumerates expressions derived from the production
+     * -> 0 | A + B.
+
+  One missing part in the above enumerators is the left-hand-side of
+  productions, it should be a nonterminal symbol associated with a finite set
+  of productions. So we introduce `recursive_enumerator_placeholdert` for
+  nonterminal symbols, and `recursive_enumerator_factoryt` for grammars.
+  Each placeholder has an identifier, and corresponds to a nonterminal in the
+  grammar. Each factory maintains a map from identifier to placeholder, and a
+  map from identifiers to placeholder's productions.
+
+  As an example, to specify a grammar G with two nonterminals A and B, and two
+  productions
+  A -> A + B | 0
+  B -> 1.
+  We need to construct a factory with two placeholders ph_A and ph_b whose
+  identifiers are "A" and "B", respectively.
+  The factory should contain a set {ph_A, ph_B}, and a map
+  {("A", E_A), ("B", E_B)}
+  where the alternatives enumerator E_A is for the production
+  -> A + B | 0
+  and the alternatives enumerator E_B is for the production
+  -> 1 | 2.
+  Note that E_A contains a binary non-leaf enumerator E_plus with
+  sub-enumerators (ph_A, ph_B) and operator `ID_plus`, and a leaf enumerator
+  E_0 with `leaf_exprs` {0}. E_B contains a leaf enumerator E_1 with
+  `leaf_exprs` {1} and a leaf enumerator E_2 with `leaf_exprs` {2}.
+
+  Let [E, n] to be the result of enumeration E.enumerate(n)---expressions with
+  size n enumerated by the enumerator E. To enumerate expressions with size 5
+  in L(A) in the above example, the algorithm works as follow.
+  [ph_A, 5] = [E_A, 5]    looking up "A" from `productions_map` of ph_A.factory
+            = [E_plus, 5] \/ [E_0, 5]
+            = [E_plus, 5] \/ {} = [E_plus, 5]
+  [E_0, 5] = {} as leaf enumerator enumerates only expressions with size 1.
+
+  To enumerate [E_plus, 5], we first enumerate expressions from two
+  sub-enumerators E_A and E_B of E_plus, and then combine them using the
+  operator ID_plus. In E_plus, the size of the operator ID_plus is 1, so the
+  sum of sizes of two sub-expressions should be 4. There are three way to
+  partition 4: (3, 1), (2, 2), and (1, 3). So
+  [E_plus, 5] = [E_A, 3]*[E_B, 1] \/ [E_A, 2]*[E_B, 2] \/ [E_A, 1]*[E_B, 3]
+  Note that E_B contain only leaf expressions. Therefore [E_B, 1] = {1, 2}, and
+  [E_B, n] = {} for all n > 1. The * operator is the Cartesian products
+  instantiated with plus operator.
+  [E_plus, 5] = [E_A, 3]*[E_B, 1] \/ [E_A, 2]*[E_B, 2] \/ [E_A, 1]*[E_B, 3]
+              = [E_A, 3]*{1, 2} \/ [E_A, 2]*{} \/ [E_A, 2]*{}
+              = [E_A, 3]*{1, 2} \/ {} \/ {}
+              = [E_A, 3]*{1, 2}
+              = ([E_A, 1]*[E_B, 1])*{1, 2}
+              = ({0}*{1,2})*{1, 2}
+              = {0+1, 0+2}*{1, 2}
+              = {(0+1)+1, (0+2)+1, (0+1)+2, (0+2)+2}
+  So, expressions in L(A) are {(0+1)+1, (0+2)+1, (0+1)+2, (0+2)+2}.
+
+  Why Cartesian products.
+  For a grammar,
+  A -> B + B
+  B -> 1 | 2,
+  the expressions enumerated by B are {1, 2}. To enumerate expressions in L(A).
+  We need to combine sub-expressions {1, 2} into a plus-expression.
+  {1, 2} + {1, 2}
+  Because each nonterminal B can yield either 1 and 2 independently, we have to
+  combine sub-expressions as their cartesian products.
+  {1 + 1, 1 + 2, 2 + 1, 2 + 2}.
+*/
+
+/// A base class for expression enumerators.
+class enumerator_baset
+{
+public:
+  explicit enumerator_baset(const namespacet &ns) : ns(ns)
+  {
+  }
+
+  virtual expr_sett enumerate(const std::size_t size) const = 0;
+
+  enumerator_baset(const enumerator_baset &other) = delete;
+  enumerator_baset &operator=(const enumerator_baset &other) = delete;
+
+  virtual ~enumerator_baset() = default;
+
+protected:
+  const namespacet &ns;
+};
+
+typedef std::list<const enumerator_baset *> enumeratorst;
+
+/// Enumerator that enumerates leaf expressions from a given list.
+/// Leaf expressions are complete expressions with no placeholder.
+class leaf_enumeratort : public enumerator_baset
+{
+public:
+  leaf_enumeratort(const expr_sett &leaf_exprs, const namespacet &ns)
+    : enumerator_baset(ns), leaf_exprs(leaf_exprs)
+  {
+  }
+
+  /// Enumerate expressions in the set of `leaf_exprs`.
+  expr_sett enumerate(const std::size_t size) const override;
+
+protected:
+  const expr_sett leaf_exprs;
+};
+
+/// Non-leaf enumerator enumerates expressions of form
+/// f(a_1, a_2, ..., a_n)
+/// where a_i's are sub-expressions enumerated by sub-enumerators.
+class non_leaf_enumeratort : public enumerator_baset
+{
+public:
+  /// \param enumerators a list of enumerator (e_1,...,e_n),
+  /// where a_i in the expressions enumerated by this enumerator can be
+  /// enumerated by the enumerator e_i.
+  /// \param partition_check an optional function checking whether a partition
+  /// can be safely discarded.
+  /// \param ns namesapce used by `simplify_expr`.
+  non_leaf_enumeratort(
+    const enumeratorst &enumerators,
+    const std::function<bool(const partitiont &)> partition_check,
+    const namespacet &ns)
+    : enumerator_baset(ns),
+      arity(enumerators.size()),
+      sub_enumerators(enumerators),
+      is_good_partition(partition_check)
+  {
+    INVARIANT(
+      arity > 1, "arity should be greater than one for non_leaf_enumeratort");
+  }
+
+  /// As default: no optimization. `partition_check` Accept all partitions.
+  non_leaf_enumeratort(const enumeratorst &enumerators, const namespacet &ns)
+    : non_leaf_enumeratort(
+        enumerators,
+        [](const partitiont &) { return true; },
+        ns)
+  {
+  }
+
+  expr_sett enumerate(const std::size_t size) const override;
+
+  /// Given a list `enumerators` of enumerators, return the Cartesian product
+  /// of expressions enumerated by each enumerator in the list.
+  std::set<expr_listt> cartesian_product_of_enumerators(
+    const enumeratorst &enumerators,
+    const enumeratorst::const_iterator &it,
+    const partitiont &partition,
+    const partitiont::const_iterator &it_partition) const;
+
+  /// Enumerate all partitions of n into k components.
+  /// Order of partitions is considered relevant.
+  std::list<partitiont>
+  get_partitions(const std::size_t n, const std::size_t k) const;
+
+  /// As default, keep all expression tuples.
+  virtual bool is_equivalence_class_representation(const expr_listt &es) const
+  {
+    return true;
+  }
+
+protected:
+  /// Combine a list of sub-expressions to construct the top-level expression.
+  virtual exprt instantiate(const expr_listt &exprs) const = 0;
+
+  const std::size_t arity;
+  const enumeratorst sub_enumerators;
+  const std::function<bool(const partitiont &)> is_good_partition;
+};
+
+/// Enumerator that enumerates binary functional expressions.
+class binary_functional_enumeratort : public non_leaf_enumeratort
+{
+public:
+  binary_functional_enumeratort(
+    const irep_idt &op,
+    const enumerator_baset &enumerator_1,
+    const enumerator_baset &enumerator_2,
+    const std::function<bool(const partitiont &)> partition_check,
+    const bool exchangeable,
+    const namespacet &ns)
+    : non_leaf_enumeratort({&enumerator_1, &enumerator_2}, partition_check, ns),
+      is_exchangeable(exchangeable),
+      op_id(op)
+  {
+  }
+
+  binary_functional_enumeratort(
+    const irep_idt &op,
+    const enumerator_baset &enumerator_1,
+    const enumerator_baset &enumerator_2,
+    const std::function<bool(const partitiont &)> partition_check,
+    const namespacet &ns)
+    : binary_functional_enumeratort(
+        op,
+        enumerator_1,
+        enumerator_2,
+        partition_check,
+        &enumerator_1 == &enumerator_2,
+        ns)
+  {
+  }
+
+  binary_functional_enumeratort(
+    const irep_idt &op,
+    const enumerator_baset &enumerator_1,
+    const enumerator_baset &enumerator_2,
+    const namespacet &ns)
+    : binary_functional_enumeratort(
+        op,
+        enumerator_1,
+        enumerator_2,
+        [](const partitiont &) { return true; },
+        ns)
+  {
+  }
+
+  bool is_commutative(const irep_idt &op) const;
+
+  /// Determine whether a tuple of expressions is the representation of some
+  /// equivalence class.
+  bool
+  is_equivalence_class_representation(const expr_listt &exprs) const override;
+
+protected:
+  exprt instantiate(const expr_listt &exprs) const override;
+
+  // Whether the two sub-enumerators are exchangeable---they enumerate the same
+  // set of expressions.
+  const bool is_exchangeable = false;
+
+  const irep_idt &op_id;
+};
+
+/// Enumerators that enumerates expressions in the union of enumerated
+/// expressions of sub-enumerators.
+/// For sub enumerator E_1 | E_2 | ... | E_n, an alternatives enumerator
+/// enumerates e in one of `E_i.enumerate(size)`.
+class alternatives_enumeratort : public enumerator_baset
+{
+public:
+  alternatives_enumeratort(
+    const enumeratorst &enumerators,
+    const namespacet &ns)
+    : enumerator_baset(ns), sub_enumerators(enumerators)
+  {
+  }
+
+  expr_sett enumerate(const std::size_t size) const override;
+
+protected:
+  const enumeratorst sub_enumerators;
+};
+
+class recursive_enumerator_placeholdert;
+
+/// Factory for enumerator that can be used to represent a tree grammar.
+class enumerator_factoryt
+{
+public:
+  explicit enumerator_factoryt(const namespacet &ns) : ns(ns)
+  {
+  }
+
+  /// Add a new placeholder/nonterminal to the grammar.
+  void add_placeholder(const recursive_enumerator_placeholdert &placeholder);
+
+  /// Attach `enumerators` to the placeholder with `id`.
+  void
+  attach_productions(const std::string &id, const enumeratorst &enumerators);
+
+  /// Map from names of nonterminals to rhs of productions with lhs being them.
+  /// Example: consider a nonterminal S -> 1 | 1 + S. This map will map the id
+  /// "S" to a list of enumerators [E_1, E_2] where E_1 enumerates 1 and
+  /// E_2 enumerates 1 + S.
+  std::map<std::string, const enumeratorst> productions_map;
+
+protected:
+  const namespacet &ns;
+
+  /// Set of nonterminals in the grammar.
+  std::set<std::string> nonterminal_set;
+};
+
+/// Placeholders for actual enumerators, which represent nonterminals.
+/// Example: consider the grammar
+/// S -> N + N,
+/// N -> N + 1 | 1.
+/// The symbol N represents an enumerator in the lhs of the second production,
+/// while it represents a placeholder in the rhs of both productions.
+class recursive_enumerator_placeholdert : public enumerator_baset
+{
+public:
+  /// \param factory the enumerator factory---a grammar---this enumerator
+  /// belongs to.
+  /// \param id the identifier of this placeholder.
+  /// \param ns namesapce used for `simplify_expr`.
+  recursive_enumerator_placeholdert(
+    enumerator_factoryt &factory,
+    const std::string &id,
+    const namespacet &ns)
+    : enumerator_baset(ns), identifier(id), factory(factory)
+  {
+    factory.add_placeholder(*this);
+  }
+
+  expr_sett enumerate(const std::size_t size) const override;
+
+  const std::string identifier;
+
+protected:
+  const enumerator_factoryt &factory;
+};
+
+#endif // CPROVER_GOTO_INSTRUMENT_SYNTHESIZER_EXPR_ENUMERATOR_H

--- a/unit/Makefile
+++ b/unit/Makefile
@@ -59,6 +59,7 @@ SRC += analyses/ai/ai.cpp \
        goto-checker/report_util/is_property_less_than.cpp \
        goto-instrument/cover_instrument.cpp \
        goto-instrument/cover/cover_only.cpp \
+       goto-instrument/expr_enumerator/expr_enumerator.cpp \
        goto-programs/allocate_objects.cpp \
        goto-programs/goto_program_assume.cpp \
        goto-programs/goto_program_dead.cpp \
@@ -245,6 +246,7 @@ BMC_DEPS =../src/cbmc/c_test_input_generator$(OBJEXT) \
           ../src/goto-instrument/nondet_static$(OBJEXT) \
           ../src/goto-instrument/full_slicer$(OBJEXT) \
           ../src/goto-instrument/unwindset$(OBJEXT) \
+          ../src/goto-instrument/synthesizer/expr_enumerator$(OBJEXT) \
           ../src/xmllang/xmllang$(LIBEXT) \
           ../src/goto-symex/goto-symex$(LIBEXT) \
           ../src/jsil/jsil$(LIBEXT) \

--- a/unit/goto-instrument/expr_enumerator/expr_enumerator.cpp
+++ b/unit/goto-instrument/expr_enumerator/expr_enumerator.cpp
@@ -1,0 +1,349 @@
+/*******************************************************************\
+
+Module: Tests for Expression Enumerator
+
+Author: Qinheping Hu
+
+\*******************************************************************/
+
+#include <util/c_types.h>
+#include <util/format_expr.h>
+#include <util/simplify_expr.h>
+
+#include <goto-instrument/synthesizer/expr_enumerator.h>
+#include <testing-utils/use_catch.h>
+
+TEST_CASE("enumeratingsummation expressions", "[core]")
+{
+  int num_var = 3;
+
+  symbol_tablet symbol_table;
+  namespacet ns(symbol_table);
+
+  symbolt a0_symbol;
+  a0_symbol.base_name = "a0";
+  a0_symbol.name = "a0";
+  a0_symbol.type = size_type();
+  a0_symbol.is_lvalue = true;
+  symbol_table.add(a0_symbol);
+
+  symbolt a1_symbol;
+  a1_symbol.base_name = "a1";
+  a1_symbol.name = "a1";
+  a1_symbol.type = size_type();
+  a1_symbol.is_lvalue = true;
+  symbol_table.add(a1_symbol);
+
+  symbolt a2_symbol;
+  a2_symbol.base_name = "a2";
+  a2_symbol.name = "a2";
+  a2_symbol.type = size_type();
+  a2_symbol.is_lvalue = true;
+  symbol_table.add(a2_symbol);
+
+  // Initialize factory representing grammar
+  // Start -> Start + Start | a0 | a1 |a2
+  // where a0, a1, and a2 are symbol expressions.
+  enumerator_factoryt factory = enumerator_factoryt(ns);
+  recursive_enumerator_placeholdert start_ph(factory, "Start", ns);
+
+  enumeratorst start_args;
+
+  // a0 | a1 | a2
+  expr_sett leafexprs;
+  for(int i = 0; i < num_var; i++)
+  {
+    leafexprs.insert(symbol_exprt("a" + std::to_string(i), size_type()));
+  }
+  leaf_enumeratort leaf_g(leafexprs, ns);
+  start_args.push_back(&leaf_g);
+
+  // Start + Start
+  // Optimization: restrict enumerated expressions to be
+  // right linear regular---the lambada expression.
+  binary_functional_enumeratort plus_g(
+    ID_plus,
+    start_ph,
+    start_ph,
+    [](const partitiont &partition) {
+      if(partition.size() <= 1)
+        return true;
+      return partition.front() == 1;
+    },
+    ns);
+  start_args.push_back(&plus_g);
+
+  factory.attach_productions("Start", start_args);
+
+  // enumerate expressions with size `size_term`.
+  unsigned int size_term = 5;
+  expr_sett result = start_ph.enumerate(size_term);
+  std::list<std::string> result_str;
+
+  for(const auto &e : result)
+  {
+    std::stringstream ss;
+    ss << format(e);
+    result_str.push_back(ss.str());
+  }
+
+  // there are 10 summation expressions with size 5 and 3 variables.
+  REQUIRE(result.size() == 10);
+  REQUIRE(
+    std::find(result_str.begin(), result_str.end(), "a0 + a0 + a0") !=
+    result_str.end());
+  REQUIRE(
+    std::find(result_str.begin(), result_str.end(), "a0 + a0 + a1") !=
+    result_str.end());
+  REQUIRE(
+    std::find(result_str.begin(), result_str.end(), "a0 + a1 + a1") !=
+    result_str.end());
+  REQUIRE(
+    std::find(result_str.begin(), result_str.end(), "a1 + a1 + a1") !=
+    result_str.end());
+  REQUIRE(
+    std::find(result_str.begin(), result_str.end(), "a0 + a0 + a2") !=
+    result_str.end());
+  REQUIRE(
+    std::find(result_str.begin(), result_str.end(), "a0 + a1 + a2") !=
+    result_str.end());
+  REQUIRE(
+    std::find(result_str.begin(), result_str.end(), "a1 + a1 + a2") !=
+    result_str.end());
+  REQUIRE(
+    std::find(result_str.begin(), result_str.end(), "a0 + a2 + a2") !=
+    result_str.end());
+  REQUIRE(
+    std::find(result_str.begin(), result_str.end(), "a1 + a2 + a2") !=
+    result_str.end());
+  REQUIRE(
+    std::find(result_str.begin(), result_str.end(), "a2 + a2 + a2") !=
+    result_str.end());
+}
+
+TEST_CASE("predicate expression enumeration", "[core]")
+{
+  size_t size_term = 9;
+
+  symbol_tablet symbol_table;
+  namespacet ns(symbol_table);
+
+  symbolt a1_symbol;
+  a1_symbol.base_name = "a1";
+  a1_symbol.name = "a1";
+  a1_symbol.type = size_type();
+  a1_symbol.is_lvalue = true;
+  symbol_table.add(a1_symbol);
+
+  symbolt a0_symbol;
+  a0_symbol.base_name = "a0";
+  a0_symbol.name = "a0";
+  a0_symbol.type = size_type();
+  a0_symbol.is_lvalue = true;
+  symbol_table.add(a0_symbol);
+
+  // Initialize factory representing grammar
+  // StartBool -> StartBool && StartBool | Start == Start
+  // Start -> Start + Start | a0 | a1
+  // where a0, and a1 are symbol expressions.
+  enumerator_factoryt factory = enumerator_factoryt(ns);
+  recursive_enumerator_placeholdert start_bool_ph(factory, "StartBool", ns);
+  recursive_enumerator_placeholdert start_ph(factory, "Start", ns);
+
+  // Start -> a0 | a1
+  expr_sett leafexprs;
+  symbol_exprt a_0("a0", size_type());
+  symbol_exprt a_1("a1", size_type());
+  leafexprs.insert(a_0);
+  leafexprs.insert(a_1);
+
+  enumeratorst start_args;
+  leaf_enumeratort leaf_g(leafexprs, ns);
+  start_args.push_back(&leaf_g);
+
+  // Start -> Start + Start
+  binary_functional_enumeratort plus_g(
+    ID_plus,
+    start_ph,
+    start_ph,
+    [](const partitiont &partition) {
+      if(partition.size() <= 1)
+        return true;
+      return partition.front() == 1;
+    },
+    ns);
+  start_args.push_back(&plus_g);
+
+  // StartBool -> StartBool && StartBool | Start == Start
+  enumeratorst start_bool_args;
+  binary_functional_enumeratort and_g(ID_and, start_bool_ph, start_bool_ph, ns);
+  start_bool_args.push_back(&and_g);
+  binary_functional_enumeratort equal_g(ID_equal, start_ph, start_ph, ns);
+  start_bool_args.push_back(&equal_g);
+
+  factory.attach_productions("Start", start_args);
+  factory.attach_productions("StartBool", start_bool_args);
+
+  expr_sett result = start_bool_ph.enumerate(size_term);
+
+  // Enumerated 16 expressions.
+  REQUIRE(result.size() == 16);
+
+  // a0 + a0 == a1 + a1 + a1
+  REQUIRE(
+    std::find(
+      result.begin(),
+      result.end(),
+      simplify_expr(
+        equal_exprt(
+          plus_exprt(a_0, a_0), plus_exprt(a_1, plus_exprt(a_1, a_1))),
+        ns)) != result.end());
+
+  // a0 + a0 == a1
+  REQUIRE(
+    std::find(
+      result.begin(),
+      result.end(),
+      simplify_expr(equal_exprt(plus_exprt(a_0, a_0), a_1), ns)) !=
+    result.end());
+
+  // a0 + a0 + a0 == a1 + a1
+  REQUIRE(
+    std::find(
+      result.begin(),
+      result.end(),
+      simplify_expr(
+        equal_exprt(
+          plus_exprt(a_0, plus_exprt(a_0, a_0)), plus_exprt(a_1, a_1)),
+        ns)) != result.end());
+
+  // a0 + a0 + a0 == 0ul
+  REQUIRE(
+    std::find(
+      result.begin(),
+      result.end(),
+      simplify_expr(
+        equal_exprt(
+          plus_exprt(a_0, plus_exprt(a_0, a_0)),
+          constant_exprt("0", size_type())),
+        ns)) != result.end());
+
+  // a0 + a0 + a1 == 0ul
+  REQUIRE(
+    std::find(
+      result.begin(),
+      result.end(),
+      simplify_expr(
+        equal_exprt(
+          plus_exprt(a_0, plus_exprt(a_0, a_1)),
+          constant_exprt("0", size_type())),
+        ns)) != result.end());
+
+  // a0 + a1 + a1 == 0ul
+  REQUIRE(
+    std::find(
+      result.begin(),
+      result.end(),
+      simplify_expr(
+        equal_exprt(
+          plus_exprt(a_0, plus_exprt(a_1, a_1)),
+          constant_exprt("0", size_type())),
+        ns)) != result.end());
+
+  // a1 + a1 + a1 == 0ul
+  REQUIRE(
+    std::find(
+      result.begin(),
+      result.end(),
+      simplify_expr(
+        equal_exprt(
+          plus_exprt(a_1, plus_exprt(a_1, a_1)),
+          constant_exprt("0", size_type())),
+        ns)) != result.end());
+
+  // a0 + a0 + a0 + a0 == a1
+  REQUIRE(
+    std::find(
+      result.begin(),
+      result.end(),
+      simplify_expr(
+        equal_exprt(
+          plus_exprt(a_0, plus_exprt(a_0, plus_exprt(a_0, a_0))), a_1),
+        ns)) != result.end());
+
+  // a0 == a1 + a1
+  REQUIRE(
+    std::find(
+      result.begin(),
+      result.end(),
+      simplify_expr(equal_exprt(a_0, plus_exprt(a_1, a_1)), ns)) !=
+    result.end());
+
+  // a0 == a1 + a1 + a1 + a1
+  REQUIRE(
+    std::find(
+      result.begin(),
+      result.end(),
+      simplify_expr(
+        equal_exprt(
+          a_0, plus_exprt(a_1, plus_exprt(a_1, plus_exprt(a_1, a_1)))),
+        ns)) != result.end());
+
+  // a0 == 0ul
+  REQUIRE(
+    std::find(
+      result.begin(),
+      result.end(),
+      simplify_expr(equal_exprt(a_0, constant_exprt("0", size_type())), ns)) !=
+    result.end());
+
+  // a1 == 0ul
+  REQUIRE(
+    std::find(
+      result.begin(),
+      result.end(),
+      simplify_expr(equal_exprt(a_0, constant_exprt("0", size_type())), ns)) !=
+    result.end());
+
+  // a0 + a0 == a1 && a0 == a1
+  REQUIRE(
+    std::find(
+      result.begin(),
+      result.end(),
+      simplify_expr(
+        and_exprt(
+          equal_exprt(plus_exprt(a_0, a_0), a_1), equal_exprt(a_0, a_1)),
+        ns)) != result.end());
+
+  // a0 == 0ul && a0 == a1
+  REQUIRE(
+    std::find(
+      result.begin(),
+      result.end(),
+      simplify_expr(
+        and_exprt(
+          equal_exprt(a_0, constant_exprt("0", size_type())),
+          equal_exprt(a_0, a_1)),
+        ns)) != result.end());
+
+  // a0 == a1 && a0 == a1 + a1
+  REQUIRE(
+    std::find(
+      result.begin(),
+      result.end(),
+      simplify_expr(
+        and_exprt(
+          equal_exprt(a_0, a_1), equal_exprt(a_0, plus_exprt(a_1, a_1))),
+        ns)) != result.end());
+
+  // a0 == a1 && a1 == 0
+  REQUIRE(
+    std::find(
+      result.begin(),
+      result.end(),
+      simplify_expr(
+        and_exprt(
+          equal_exprt(a_0, a_1),
+          equal_exprt(a_1, constant_exprt("0", size_type()))),
+        ns)) != result.end());
+}

--- a/unit/goto-instrument/expr_enumerator/module_dependencies.txt
+++ b/unit/goto-instrument/expr_enumerator/module_dependencies.txt
@@ -1,0 +1,4 @@
+goto-instrument
+testing-utils
+util
+langapi


### PR DESCRIPTION
<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

This PR include expression enumerator interface that allow us to specify regular tree grammars over `exprt` and enumerate expressions from the grammar. It will be used in the enumerative loop-invariant synthesizer.

We use a placeholder class to represent non-terminal symbols, enumerator classes to represent productions, and a factory class to represent grammars. A factory contain a map from placeholders to enumerators (non-terminal symbols to their productions).  To enumerate expressions in the grammar with a given size, we repeatably expand placeholders with their productions until the expected size is reached. And then all productions without placeholders are instantiated to `exprt` objects.

* `enumerator_baset`: base class of enumerators.
* `leaf_enumeratort`: enumerators that enumerate leaf expressions---complete `exprt` without placeholder.
* `non_leaf_enumeratort`: enumerators that enumerate tree expressions of form `op(a_1, ...,  a_n)` where `op` is its operator symbol, `n` is the arity of `op`, and `a_i` are expressions enumerated by the `i`-th sub-enumerator.
* `binary_functional_enumeratort :  non_leaf_enumeratort`: enumerators that enumerate trees with two children. It is optimized for boolean operators, comparison operators, and the operator `+`.
* `alternatives_enumeratort`: enumerators that enumerate expressions from the union of expressions enumerated by their sub-enumerators. For example, an enumerator for productions `-> S + 1 | 1` in the grammar `S -> S + 1 | 1` should enumerate the union of `-> S + 1` and `-> 1`.
* `recursive_enumerator_placeholdert`: placeholders that represent non-terminals in the grammar.
* `enumerator_factory_baset`: factories that maintain enumerators, placeholders, and the map from placeholders to  enumerators.
<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->