### PR TITLE
CONTRACTS: Handle all 4 inlining warning types in `inlining_decoratort`

### DIFF
--- a/regression/contracts/function-calls-03-1/test-enf-f1.desc
+++ b/regression/contracts/function-calls-03-1/test-enf-f1.desc
@@ -2,10 +2,8 @@ CORE
 main.c
 --enforce-contract f1 _ --unwind 20 --unwinding-assertions
 ^file main\.c line 13 function f2: recursion is ignored on call to 'f2'$
-^Invariant check failed$
-^Condition: decorated\.get_recursive_function_warnings_count\(\) == 0$
-^Reason: Recursive functions found during inlining$
-^EXIT=(127|134|137)$
+^Recursive call to 'f2' during inlining$
+^EXIT=6$
 ^SIGNAL=0$
 --
 --

--- a/regression/contracts/function-calls-03-1/test-enf-f2.desc
+++ b/regression/contracts/function-calls-03-1/test-enf-f2.desc
@@ -1,11 +1,9 @@
 CORE
 main.c
 --enforce-contract f2 _ --unwind 20 --unwinding-assertions
-^file main\.c line 13 function f2: recursion is ignored on call to 'f2'$
-^Invariant check failed$
-^Condition: decorated\.get_recursive_function_warnings_count\(\) == 0$
-^Reason: Recursive functions found during inlining$
-^EXIT=(127|134|137)$
+^file main.c line 13 function f2: recursion is ignored on call to 'f2'$
+^Recursive call to 'f2' during inlining$
+^EXIT=6$
 ^SIGNAL=0$
 --
 --

--- a/regression/contracts/function-calls-04-1/test-enf-f1.desc
+++ b/regression/contracts/function-calls-04-1/test-enf-f1.desc
@@ -1,11 +1,9 @@
 CORE
 main.c
 --enforce-contract f1 _ --unwind 20 --unwinding-assertions
-^file main\.c line 19 function f2_in: recursion is ignored on call to 'f2_out'$
-^Invariant check failed$
-^Condition: decorated\.get_recursive_function_warnings_count\(\) == 0$
-^Reason: Recursive functions found during inlining$
-^EXIT=(127|134|137)$
+^file main.c line 19 function f2_in: recursion is ignored on call to 'f2_out'$
+^Recursive call to 'f2_out' during inlining$
+^EXIT=6$
 ^SIGNAL=0$
 --
 --

--- a/regression/contracts/function-calls-04-1/test-enf-f2_in.desc
+++ b/regression/contracts/function-calls-04-1/test-enf-f2_in.desc
@@ -1,11 +1,9 @@
 CORE
 main.c
 --enforce-contract f2_in _ --unwind 20 --unwinding-assertions
-^file main\.c line 13 function f2_out: recursion is ignored on call to 'f2_in'$
-^Invariant check failed$
-^Condition: decorated\.get_recursive_function_warnings_count\(\) == 0$
-^Reason: Recursive functions found during inlining$
-^EXIT=(127|134|137)$
+^file main.c line 13 function f2_out: recursion is ignored on call to 'f2_in'$
+^Recursive call to 'f2_in' during inlining$
+^EXIT=6$
 ^SIGNAL=0$
 --
 --

--- a/regression/contracts/function-calls-04-1/test-enf-f2_out.desc
+++ b/regression/contracts/function-calls-04-1/test-enf-f2_out.desc
@@ -1,11 +1,9 @@
 CORE
 main.c
 --enforce-contract f2_out _ --unwind 20 --unwinding-assertions
-^file main\.c line 19 function f2_in: recursion is ignored on call to 'f2_out'$
-^Invariant check failed$
-^Condition: decorated\.get_recursive_function_warnings_count\(\) == 0$
-^Reason: Recursive functions found during inlining$
-^EXIT=(127|134|137)$
+^file main.c line 19 function f2_in: recursion is ignored on call to 'f2_out'$
+^Recursive call to 'f2_out' during inlining$
+^EXIT=6$
 ^SIGNAL=0$
 --
 --

--- a/regression/contracts/function-calls-recursive-01/test.desc
+++ b/regression/contracts/function-calls-recursive-01/test.desc
@@ -1,11 +1,9 @@
 CORE
 main.c
 --enforce-contract sum _ --trace
-^file main\.c line 6 function sum_rec: recursion is ignored on call to 'sum_rec'$
-^Invariant check failed$
-^Condition: decorated\.get_recursive_function_warnings_count\(\) == 0$
-^Reason: Recursive functions found during inlining$
-^EXIT=(127|134|137)$
+^file main.c line 6 function sum_rec: recursion is ignored on call to 'sum_rec'$
+^Recursive call to 'sum_rec' during inlining$
+^EXIT=6$
 ^SIGNAL=0$
 --
 --

--- a/src/goto-instrument/Makefile
+++ b/src/goto-instrument/Makefile
@@ -21,6 +21,7 @@ SRC = accelerate/accelerate.cpp \
       contracts/instrument_spec_assigns.cpp \
       contracts/memory_predicates.cpp \
       contracts/utils.cpp \
+      contracts/inlining_decorator.cpp \
       concurrency.cpp \
       count_eloc.cpp \
       cover.cpp \

--- a/src/goto-instrument/contracts/inlining_decorator.cpp
+++ b/src/goto-instrument/contracts/inlining_decorator.cpp
@@ -1,0 +1,124 @@
+/*******************************************************************\
+
+Module: Utility functions for code contracts.
+
+Author: Remi Delmas, delmasrd@amazon.com
+
+Date: August 2022
+
+\*******************************************************************/
+
+#include "inlining_decorator.h"
+
+inlining_decoratort::inlining_decoratort(message_handlert &_wrapped)
+  : wrapped(_wrapped),
+    no_body_regex(std::regex(".*no body for function '(.*)'.*")),
+    missing_function_regex(
+      std::regex(".*missing function '(.*)' is ignored.*")),
+    recursive_call_regex(
+      std::regex(".*recursion is ignored on call to '(.*)'.*")),
+    not_enough_arguments_regex(
+      std::regex(".*call to '(.*)': not enough arguments.*"))
+{
+}
+
+void inlining_decoratort::match_no_body_warning(const std::string &message)
+{
+  std::smatch sm;
+  std::regex_match(message, sm, no_body_regex);
+  if(sm.size() == 2)
+    no_body_set.insert(sm.str(1));
+}
+
+void inlining_decoratort::match_missing_function_warning(
+  const std::string &message)
+{
+  std::smatch sm;
+  std::regex_match(message, sm, missing_function_regex);
+  if(sm.size() == 2)
+    missing_function_set.insert(sm.str(1));
+}
+
+void inlining_decoratort::match_recursive_call_warning(
+  const std::string &message)
+{
+  std::smatch sm;
+  std::regex_match(message, sm, recursive_call_regex);
+  if(sm.size() == 2)
+    recursive_call_set.insert(sm.str(1));
+}
+
+void inlining_decoratort::match_not_enough_arguments_warning(
+  const std::string &message)
+{
+  std::smatch sm;
+  std::regex_match(message, sm, not_enough_arguments_regex);
+  if(sm.size() == 2)
+    not_enough_arguments_set.insert(sm.str(1));
+}
+
+void inlining_decoratort::parse_message(const std::string &message)
+{
+  match_no_body_warning(message);
+  match_missing_function_warning(message);
+  match_recursive_call_warning(message);
+  match_not_enough_arguments_warning(message);
+}
+
+void inlining_decoratort::throw_on_no_body(messaget &log, const int error_code)
+{
+  if(no_body_set.size() != 0)
+  {
+    for(auto it : no_body_set)
+    {
+      log.error() << "No body for '" << it << "' during inlining"
+                  << messaget::eom;
+    }
+    throw error_code;
+  }
+}
+
+void inlining_decoratort::throw_on_recursive_calls(
+  messaget &log,
+  const int error_code)
+{
+  if(recursive_call_set.size() != 0)
+  {
+    for(auto it : recursive_call_set)
+    {
+      log.error() << "Recursive call to '" << it << "' during inlining"
+                  << messaget::eom;
+    }
+    throw error_code;
+  }
+}
+
+void inlining_decoratort::throw_on_missing_function(
+  messaget &log,
+  const int error_code)
+{
+  if(missing_function_set.size() != 0)
+  {
+    for(auto it : missing_function_set)
+    {
+      log.error() << "Missing function '" << it << "' during inlining"
+                  << messaget::eom;
+    }
+    throw error_code;
+  }
+}
+
+void inlining_decoratort::throw_on_not_enough_arguments(
+  messaget &log,
+  const int error_code)
+{
+  if(not_enough_arguments_set.size() != 0)
+  {
+    for(auto it : not_enough_arguments_set)
+    {
+      log.error() << "Not enough arguments for '" << it << "' during inlining"
+                  << messaget::eom;
+    }
+    throw error_code;
+  }
+}

--- a/src/goto-instrument/contracts/inlining_decorator.h
+++ b/src/goto-instrument/contracts/inlining_decorator.h
@@ -1,0 +1,165 @@
+/*******************************************************************\
+
+Module: Utility functions for code contracts.
+
+Author: Remi Delmas, delmasrd@amazon.com
+
+Date: August 2022
+
+\*******************************************************************/
+
+#ifndef CPROVER_GOTO_INSTRUMENT_CONTRACTS_INLINING_DECORATOR_H
+#define CPROVER_GOTO_INSTRUMENT_CONTRACTS_INLINING_DECORATOR_H
+
+#include <util/irep.h>
+#include <util/message.h>
+
+#include <regex>
+#include <set>
+#include <sstream>
+
+/// Decorator for a \ref message_handlert used during function inlining that
+/// collect names of GOTO functions creating warnings and allows to turn
+/// inlining warnings into hard errors.
+///
+/// The decorator intercepts and parses messages sent to the decorated
+/// message handler and collects the names of GOTO functions involved in these
+/// 4 types warnings:
+/// - `recursive call` warnings,
+/// - `missing function` warnings,
+/// - `not enough arguments` warnings,
+/// - `no body for function` warnings.
+///
+/// For each warning type, the decorator offers:
+/// - a method that returns the set of function names that caused the warnings
+/// - a method that throws an error in case that set is not empty
+///
+/// So this decorator allows to inspect the sets of functions involved in
+/// warnings to check if the warnings are expected or not, and to turn warnings
+/// into hard errors if desired.
+///
+/// Decorator pattern info: https://en.wikipedia.org/wiki/Decorator_pattern
+class inlining_decoratort : public message_handlert
+{
+private:
+  message_handlert &wrapped;
+
+  std::regex no_body_regex;
+  std::set<irep_idt> no_body_set;
+
+  void match_no_body_warning(const std::string &message);
+
+  std::regex missing_function_regex;
+  std::set<irep_idt> missing_function_set;
+
+  void match_missing_function_warning(const std::string &message);
+
+  std::regex recursive_call_regex;
+  std::set<irep_idt> recursive_call_set;
+
+  void match_recursive_call_warning(const std::string &message);
+
+  std::regex not_enough_arguments_regex;
+  std::set<irep_idt> not_enough_arguments_set;
+
+  void match_not_enough_arguments_warning(const std::string &message);
+
+  void parse_message(const std::string &message);
+
+public:
+  explicit inlining_decoratort(message_handlert &_wrapped);
+
+  /// Throws the given error code if `no body for function`
+  /// warnings happend during inlining
+  void throw_on_no_body(messaget &log, const int error_code);
+
+  /// Throws the given error code if `recursive call`
+  /// warnings happend during inlining
+  void throw_on_recursive_calls(messaget &log, const int error_code);
+
+  /// Throws the given error code if `missing function`
+  /// warnings happend during inlining
+  void throw_on_missing_function(messaget &log, const int error_code);
+
+  /// Throws the given error code if `not enough arguments`
+  /// warnings happend during inlining
+  void throw_on_not_enough_arguments(messaget &log, const int error_code);
+
+  const std::set<irep_idt> &get_no_body_set() const
+  {
+    return no_body_set;
+  }
+
+  const std::set<irep_idt> &get_missing_function_set() const
+  {
+    return missing_function_set;
+  }
+
+  const std::set<irep_idt> &get_recursive_call_set() const
+  {
+    return recursive_call_set;
+  }
+
+  const std::set<irep_idt> &get_not_enough_arguments_set() const
+  {
+    return not_enough_arguments_set;
+  }
+
+  void print(unsigned level, const std::string &message) override
+  {
+    parse_message(message);
+    wrapped.print(level, message);
+  }
+
+  void print(unsigned level, const xmlt &xml) override
+  {
+    wrapped.print(level, xml);
+  }
+
+  void print(unsigned level, const jsont &json) override
+  {
+    wrapped.print(level, json);
+  }
+
+  void print(unsigned level, const structured_datat &data) override
+  {
+    wrapped.print(level, data);
+  }
+
+  void print(
+    unsigned level,
+    const std::string &message,
+    const source_locationt &location) override
+  {
+    parse_message(message);
+    wrapped.print(level, message, location);
+    return;
+  }
+
+  void flush(unsigned i) override
+  {
+    return wrapped.flush(i);
+  }
+
+  void set_verbosity(unsigned _verbosity)
+  {
+    wrapped.set_verbosity(_verbosity);
+  }
+
+  unsigned get_verbosity() const
+  {
+    return wrapped.get_verbosity();
+  }
+
+  std::size_t get_message_count(unsigned level) const
+  {
+    return wrapped.get_message_count(level);
+  }
+
+  std::string command(unsigned i) const override
+  {
+    return wrapped.command(i);
+  }
+};
+
+#endif


### PR DESCRIPTION
Modifications:
- move the class from contracts.cpp to its own file
- use regexes to track all 4 types of warnings
- add getter methods to inspect functions involved in warnings
- add methods to throw errors after warnings

No behaviour or performance impact.

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [N/A] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [N/A] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.
