### PR TITLE
CONTRACTS: make `contracts.h` methods public.

### DIFF
--- a/src/goto-instrument/contracts/contracts.h
+++ b/src/goto-instrument/contracts/contracts.h
@@ -141,6 +141,7 @@ protected:
 
   std::unordered_set<irep_idt> summarized;
 
+public:
   /// Translates a function_pointer_obeys_contract_exprt into an assertion
   /// ```
   /// ASSERT function_pointer == contract;


### PR DESCRIPTION
Modification needed in order to reuse some methods with the upcoming dynamic frames implementation.
No behaviour or performance impact.

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [N/A] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [N/A] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [N/A] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [N/A] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.
