### PR TITLE
CONTRACTS: Front-end extensions for assigns clauses

### DIFF
--- a/doc/cprover-manual/contracts-assigns.md
+++ b/doc/cprover-manual/contracts-assigns.md
@@ -1,75 +1,373 @@
 [CPROVER Manual TOC](../../)
 
-# Assigns Clause
+# Assigns Clauses
 
-## In Function Contracts
+An _assigns clause_ lets the user to specify which memory locations may be
+assigned to by a function or a loop.
 
-### Syntax
+Knowing the memory footprint of a function contract or a loop contract in turn
+allows us to replace a function call or a loop by an nondeterministic
+approximation in which assignable locations are havoced. To make sure this
+approximation is sound and is an actual abstraction of the original function
+call or loop, we need to verify that the actual function or loop never assigns
+memory locations not listed in the clause.
 
-```c
-__CPROVER_assigns(*identifier*, ...)
-```
+For a function contract, if no assigns clause is provided, the default is the
+empty set. For a loop contract, if no assigns clause is provided, CBMC attempts
+to infer the set of locations assigned by the loop from the loop body,
+and then checks that the inferred set is correct (as if specified by the user).
 
-An _assigns_ clause allows the user to specify that a memory location may be written by a function. The set of locations writable by a function is the union of the locations specified by the assigns clauses, or the empty set of no _assigns_ clause is specified. While, in general, an _assigns_ clause could be interpreted with either _writes_ or _modifies_ semantics, this
-design is based on the former. This means that memory not captured by an
-_assigns_ clause must not be written within the given function, even if the
-value(s) therein are not modified.
+For both functions and loop contracts, if more than one assigns clause is
+provided, their contents are unioned into a single clause.
 
-### Object slice expressions
+We use the _assigns_ interpretation for these memory locations, which means that
+memory locations that are not listed in the assigns clause
+(or the _inferred_ assigns clause for a loop contract) must not be assigned to
+by the function (or the loop), even if they end up holding the same value as they
+held before the function call (or before entering the loop).
 
-The following functions can be used in assigns clause to specify ranges of 
-assignable addresses.
+Memory locations that are locally stack- or heap-allocated during function
+execution or loop execution can always be assigned to by the function or the
+loop.
 
-Given a pointer `ptr` pointing into some object `o`, `__CPROVER_object_from(ptr)` 
-specifies that all bytes starting from the given pointer and until the end of 
-the object are assignable:
-```c
-__CPROVER_size_t __CPROVER_object_from(void *ptr); 
-```
-
-Given a pointer `ptr` pointing into some object `o`, `__CPROVER_object_from(ptr, size)` 
-specifies that `size` bytes starting from the given pointer and until the end of the object are assignable.
-The `size` value must such that `size <= __CPROVER_object_size(ptr) - __CPROVER_pointer_offset(ptr)` holds:
-
-```c
-__CPROVER_size_t __CPROVER_object_slice(void *ptr, __CPROVER_size_t size);
-```
-
-Caveats and limitations: The slices in question must *not*
-be interpreted as pointers by the program. During call-by-contract replacement, 
-`__CPROVER_havoc_slice(ptr, size)` is used to havoc these targets, 
-and `__CPROVER_havoc_slice` does not support havocing pointers. 
-### Parameters
-
-An _assigns_ clause currently supports simple variable types and their pointers,
-structs, and arrays.  Recursive pointer structures are left to future work, as
-their support would require changes to CBMC's memory model.
+## Syntax
 
 ```c
-/* Examples */
-int err_signal; // Global variable
-
-int sum(const uint32_t a, const uint32_t b, uint32_t* out)
-__CPROVER_assigns(*out)
-
-int sum(const uint32_t a, const uint32_t b, uint32_t* out)
-__CPROVER_assigns(err_signal)
-
-int sum(const uint32_t a, const uint32_t b, uint32_t* out)
-__CPROVER_assigns(*out, err_signal)
+__CPROVER_assigns(targets)
 ```
 
-### Semantics
+Where `targets` has the following syntax:
 
-The semantics of an _assigns_ clause of a given function can be understood
-in two contexts: enforcement and replacement.
+```
+targets           ::= cond-target-group (';' cond-target-group)* ';'?
+cond-target-group ::= (condition ':')? target (',' target)*
+target            ::= lvalue-expr
+                    | __CPROVER_typed_target(lvalue-expr)
+                    | __CPROVER_object_whole(ptr-expr)
+                    | __CPROVER_object_from(ptr-expr)
+                    | __CPROVER_object_upto(ptr-expr, uint-expr)
+```
 
-#### Enforcement
 
-In order to determine whether an _assigns_ clause is a sound abstraction of
-the write set of a function *f*, the body of the function is instrumented with
+For function contracts, the condition and target expressions
+in the assigns clause may only involve function parameters,
+global variables or type identifiers (in `sizeof` or cast expressions).
+The target expression must be free of function calls and side-effects.
+The condition expression may contain calls to side-effect-free functions.
+
+For a loop contract, the condition and target expressions in the assigns clause
+may involve any identifier that is in scope at loop entry
+(parameters of the surrounding function, local variables, global variables,
+type identifiers in `sizeof` or cast expressions, etc.).
+The target expression must be free of function calls and side-effects.
+The condition expression may contain calls to side-effect-free functions.
+
+### Lvalue targets
+
+Roughly speaking, _lvalues_ are expressions that are associated with a memory
+location, the address of which can be computed using the address-of operator
+`&`.
+
+Examples of lvalues are: `x` if `x` is either a global or local variable
+identifier, `*ptr` if `ptr` is a pointer expression, `ptr[i]` or `ptr + i` if
+`ptr` is pointer variable or an array and `i` is an integer expression, etc.
+
+Examples of non-lvalues: literal constants like `0`, `1`, ..., arithmetic
+expressions like `x + y` when `x` and `y` are both arithmetic variables,
+function pointer expressions, etc.
+
+An lvalue target `expr` with a complete type `expr_t` specifies that the range
+starting at `&expr` and of size `sizeof(expr_t)` bytes is assignable.
+
+Lvalues can also be wrapped in `__CPROVER_typed_target` with the same
+meaning: for an lvalue `expr` with a complete type `expr_t`,
+`__CPROVER_typed_target(expr)` specifies that the range of `sizeof(expr_t)`
+bytes starting at `&expr` is assignable:
+
+```c
+void __CPROVER_typed_target(expr_t expr);
+```
+
+In order to specify that a memory location the contents of which is interpreted
+as a pointer by the program is assignable, one must use the notation
+`__CPROVER_assigns(ptr)` or the equivalent
+`__CPROVER_assigns(__CPROVER_typed_target(ptr))`, as opposed to the slice
+operators `__CPROVER_object_whole`, `__CPROVER_object_from`,
+or `__CPROVER_object_upto`.
+This ensures that during call-by-contract replacement the memory location gets
+turned into a non-deterministic pointer.
+
+For instance:
+
+```c
+struct circular_buffer_t {
+  int *first;
+  int *last;
+  int *current;
+}
+
+void step(struct circular_buffer_t *buf)
+// correct
+__CPROVER_assigns(__CPROVER_typed_target(buf->current))
+// not correct
+__CPROVER_assigns(__CPROVER_object_upto(&(buf->current), sizeof(buf->current))
+{
+  if(buf->current == buf->last)
+    buf->current = buf->first;
+  else
+    buf->current += 1;
+}
+```
+
+### Object slice targets
+
+```c
+void __CPROVER_object_upto(void *ptr, __CPROVER_size_t size);
+```
+
+Given a pointer `ptr` pointing into some object (possibly at some non-zero offset),
+`__CPROVER_object_upto(ptr, size)` specifies that the range of `size` bytes starting
+at `ptr` is assignable.
+
+
+The value of `size` must such that the range does not exceed
+the object's boundary, i.e.
+`size <= __CPROVER_OBJECT_SIZE(ptr) - __CPROVER_POINTER_OFFSET(ptr)` must hold
+(otherwise an assertion violation will occur and make the whole analysis fail).
+
+In the example below, the `struct vect_t`, its `data` array and an exta hidden
+byte are packed together in a single object by the `vec_alloc` function.
+The `vec_clear` function can only assign `vec->size` bytes starting from
+`vec->data`. As a result the assignments to `vec->size` and the hidden byte
+fail the verification.
+
+```c
+#include <stdlib.h>
+
+#define MAX_SIZE 10
+
+struct vec_t {
+  size_t size;
+  char *data;
+};
+
+// Allocates a vect_t struct together with its data and a hidden byte
+// in a same object.
+struct vec_t *vec_alloc(size_t size) {
+
+  if(size > MAX_SIZE)
+    size = MAX_SIZE;
+
+  // allocate the struct + data + 1 extra hidden byte
+  struct vec_t *vec = malloc(sizeof(struct vec_t) + size + 1);
+  if (vec) {
+    vec->size = size;
+    vec->data = ((char *)vec) + sizeof(struct vec_t);
+  }
+  return vec;
+}
+
+// Clear the vec->data array
+void vec_clear(struct vec_t *vec)
+  __CPROVER_assigns(
+    vec && vec->data: __CPROVER_object_upto(vec->data, vec->size))
+{
+  if (!vec)
+    return;
+
+  vec->size = vec->size; // FAILURE
+
+  for (size_t i = 0; i < vec->size; i++)
+    vec->data[i] = 0; // SUCCESS
+
+  char *hidden_byte = ((char *)vec + sizeof(*vec) + vec->size);
+  *hidden_byte = 0; // FAILURE
+}
+
+// Proof harness
+int main() {
+  size_t size;
+  struct vec_t *vec = vec_alloc(size);
+  vec_clear(vec);
+}
+```
+
+---
+
+```c
+void __CPROVER_object_from(void *ptr);
+```
+
+Given a pointer `ptr` pointing into some object (possibly at some non-zero offset),
+`__CPROVER_object_from(ptr)` specifies that the range of bytes starting at `ptr`
+and of size `__CPROVER_OBJECT_SIZE(ptr) - __CPROVER_POINTER_OFFSET(ptr)` is assignable.
+
+Revisiting our previous example, changing the target to
+`__CPROVER_object_from(vec->data)` still rejects the assignment to `vec->size`,
+but allows the assignment to the hidden byte which is located after the data
+array in memory.
+
+```c
+#include <stdlib.h>
+
+#define MAX_SIZE 10
+
+struct vec_t {
+  size_t size;
+  char *data;
+};
+
+// Allocates a vect_t struct together with its data and a hidden byte
+// in a same object.
+struct vec_t *vec_alloc(size_t size) {
+
+  if(size > MAX_SIZE)
+    size = MAX_SIZE;
+
+  // allocate the struct + data + 1 extra hidden byte
+  struct vec_t *vec = malloc(sizeof(struct vec_t) + size + 1);
+  if (vec) {
+    vec->size = size;
+    vec->data = ((char *)vec) + sizeof(struct vec_t);
+  }
+  return vec;
+}
+
+// Clear the vec->data array
+void vec_clear(struct vec_t *vec)
+  __CPROVER_assigns(
+    vec && vec->data: __CPROVER_object_from(vec->data))
+{
+  if (!vec)
+    return;
+
+  vec->size = vec->size; // FAILURE
+
+  for (size_t i = 0; i < vec->size; i++)
+    vec->data[i] = 0; // SUCCESS
+
+  char *hidden_byte = ((char *)vec + sizeof(*vec) + vec->size);
+  *hidden_byte = 0; // SUCCESS
+}
+
+// Proof harness
+int main() {
+  size_t size;
+  struct vec_t *vec = vec_alloc(size);
+  vec_clear(vec);
+}
+```
+---
+
+```c
+void __CPROVER_object_whole(void *ptr);
+```
+
+Given a pointer `ptr` pointing into some object (possibly at some non-zero offset),
+`__CPROVER_object_whole(ptr)` specifies that the range of bytes of size
+`__CPROVER_OBJECT_SIZE(ptr)` starting at address
+`ptr - __CPROVER_POINTER_OFFSET(ptr)` is assignable:
+
+If the pointer has a positive offset into some object, the range includes
+bytes that are in the object before the address pointed to by `ptr`.
+Revisiting our example one last time, changing the target to
+`__CPROVER_object_whole(vec->data)` allows the function (perhaps mistakenly)
+to assign to `vec->size`, the whole array of size `vec->size` pointed to by
+`vec->data` and the hidden byte.
+
+```c
+#include <stdlib.h>
+
+#define MAX_SIZE 10
+
+struct vec_t {
+  size_t size;
+  char *data;
+};
+
+// Allocates a vect_t struct together with its data and a hidden byte
+// in a same object.
+struct vec_t *vec_alloc(size_t size) {
+
+  if(size > MAX_SIZE)
+    size = MAX_SIZE;
+
+  // allocate the struct + data + 1 extra hidden byte
+  struct vec_t *vec = malloc(sizeof(struct vec_t) + size + 1);
+  if (vec) {
+    vec->size = size;
+    vec->data = ((char *)vec) + sizeof(struct vec_t);
+  }
+  return vec;
+}
+
+// Clear the vec->data array
+void vec_clear(struct vec_t *vec)
+  __CPROVER_assigns(
+    vec && vec->data: __CPROVER_object_whole(vec->data))
+{
+  if (!vec)
+    return;
+
+  vec->size = vec->size; // SUCCESS
+
+  for (size_t i = 0; i < vec->size; i++)
+    vec->data[i] = 0; // SUCCESS
+
+  char *hidden_byte = ((char *)vec + sizeof(*vec) + vec->size);
+  *hidden_byte = 0; // SUCCESS
+}
+
+// Proof harness
+int main() {
+  size_t size;
+  struct vec_t *vec = vec_alloc(size);
+  vec_clear(vec);
+}
+```
+### Function parameters
+
+For a function contract, the memory locations storing function parameters are
+considered as being local to the function and are hence always assignable.
+
+For a loop contract, the parameters of the enclosing function are not considered
+local to the loop and must be explicitly added to the loop to become assignable.
+### Inductive data structures
+Inductive data structures are not supported yet in assigns clauses.
+
+## Semantics
+
+Each target listed in an assigns clause defines a
+_conditionally assignable range_ of bytes represented by the following triple:
+
+```c
+struct {
+  void *start_address;
+  size_t size;
+  bool is_writable;
+}
+```
+
+where:
+- `start_address` is the start address of the range of bytes,
+- `size` is the size of the range in number of bytes,
+- `is_writable` is true iff the target's `condition` holds and
+  `__CPROVER_w_ok(start_address, size)` holds at the program location
+  where the clause is interpreted: right before function invocation for
+  function contracts and at loop entry for loops;
+
+For contract enforcement, assigns clause targets are turned into checks,
+to verify that the function only assigns locations allowed by the assigns clause.
+
+For contract replacement, assigns clause targets are turned into havoc statements,
+to model the non-deterministic behaviour specified by the contract.
+### Contract Enforcement
+
+In order to determine whether a function (or loop) complies with the _assigns_
+clause of the contract, the body of the function (or loop) is instrumented with
 assertion statements before each statement which may write to memory (e.g., an
-assignment).  These assertions are based on the writable locations identified by the _assigns_ clauses.
+assignment). These assertions check that  the location about to be assigned to
+is among the targets specified by the _assigns_ clauses.
 
 For example, consider the following implementation of `sum` function.
 
@@ -85,8 +383,11 @@ __CPROVER_assigns(*out)
 }
 ```
 
-Assignable variables in the function are just those specified so with
-`__CPROVER_assigns`, together with any local variables.
+Assignable locations for the `sum` function are the locations specified with
+`__CPROVER_assigns`, together with any location storing a function parameter,
+or any location that is locally stack- or heap-allocated as part of function (or loop)
+execution.
+
 In the case of `sum` that is `*out` and `result`.  Each assignment will be
 instrumented with an assertion to check that the target of the assignment
 is one of those options.
@@ -119,30 +420,40 @@ int sum(const uint32_t a, const uint32_t b, uint32_t* out)
 }
 ```
 
-Additionally, the set of assignable target expressions is updated while
-traversing the function body when new memory is allocated.  For example, the
-statement `x = (int *)malloc(sizeof(int))` would create a pointer, stored in
-`x`, to assignable memory. Since the memory is allocated within the current
-function, there is no way an assignment to this memory can affect the memory of
-the calling context.  If memory is allocated for a struct, the subcomponents are
-considered assignable as well.
+### Contract Replacement
 
-Finally, a set of freely-assignable symbols *free* is tracked during the
-traversal of the function body. These are locally-defined variables and formal
-parameters without dereferences.  For example, in a variable declaration `<type>
-x = <initial_value>`, `x` would be added to the *free* set. Assignment statements
-where the left-hand-side is in the *free* set are not instrumented with the above assertions.
+Assuming the _assigns_ clause of the contract correctly captures the set of
+locations assigned to by a function (checked during _contract enforcement_),
+CBMC will use the contract's [Requires \& Ensures Clauses](../../contracts/requires-and-ensures/#replacement),
+and its _assigns clause_ to generate a sound abstraction of the function behaviour from the contract.
 
-#### Replacement
+Given the contract:
 
-Assuming _assigns_ clauses are a sound abstraction of the write set for
-a given function, CBMC will use the function contract in place of the function
-implementation as described by
-[Requires \& Ensures Clauses](../../contracts/requires-and-ensures/#replacement), and it will add
-non-deterministic assignments for each object listed in the `__CPROVER_assigns`
-clause. Since these objects might be modified by the function, CBMC uses
-non-deterministic assignments to havoc them and restrict their values only by
-assuming the postconditions (i.e., ensures clauses).
+```c
+int f(params)
+__CPROVER_requires(R);
+__CPROVER_assigns(A);
+__CPROVER_ensures(E);
+{ ... }
+```
+
+Function calls `f(args)` get replaced with a sequence of instuctions equivalent to:
+
+```c
+// check preconditions
+__CPROVER_assert(R[args/params], "Check f preconditions");
+
+// havoc the assignable targets
+// for each target t1, t2, ... of A[args/params];
+t1 = nondet();
+t2 = nondet();
+...
+// assume post conditions
+__CPROVER_assume(E[args/params]);
+```
+Where `R[args/params]`, `A[args/params]`, `E[args/params]` denote the contract
+clause expressions rewritten by substituting
+function parameters with the argyments passed at the call site.
 
 In our example, consider that a function `foo` may call `sum`.
 
@@ -168,7 +479,7 @@ int foo()
   uint32_t b;
   uint32_t out;
   int rval = sum(a, b, &out);
-  if (rval == SUCCESS) 
+  if (rval == SUCCESS)
     return out;
   return rval;
 }
@@ -183,26 +494,22 @@ int foo()
   uint32_t a;
   uint32_t b;
   uint32_t out;
-	
+
   /* Function Contract Replacement */
   /* Precondition */
   __CPROVER_assert(__CPROVER_is_fresh(out, sizeof(*out)), "Check requires clause");
-	
+
   /* Writable Set */
   *(&out) = nondet_uint32_t();
-	
+
   /* Postconditions */
   int return_value_sum = nondet_int();
   __CPROVER_assume(return_value_sum == SUCCESS || return_value_sum == FAILURE);
   __CPROVER_assume((return_value_sum == SUCCESS) ==> (*out == (a + b)));
 
   int rval = return_value_sum;
-  if (rval == SUCCESS) 
+  if (rval == SUCCESS)
     return out;
   return rval;
 }
 ```
-
-## In Loop Contracts
-
-TODO: Document `__CPROVER_assigns` for loops.

--- a/regression/contracts/assigns-enforce-malloc-zero/main.c
+++ b/regression/contracts/assigns-enforce-malloc-zero/main.c
@@ -6,7 +6,7 @@ int foo(char *a, int size)
   // clang-format off
   __CPROVER_requires(0 <= size && size <= __CPROVER_max_malloc_size)
   __CPROVER_requires(a == NULL || __CPROVER_is_fresh(a, size))
-  __CPROVER_assigns(a: __CPROVER_POINTER_OBJECT(a))
+  __CPROVER_assigns(a: __CPROVER_object_whole(a))
   __CPROVER_ensures(
     a && __CPROVER_return_value >= 0 ==> a[__CPROVER_return_value] == 0)
 // clang-format on

--- a/regression/contracts/assigns-enforce-malloc-zero/test.desc
+++ b/regression/contracts/assigns-enforce-malloc-zero/test.desc
@@ -1,7 +1,7 @@
 CORE
 main.c
 --enforce-contract foo _ --malloc-may-fail --malloc-fail-null
-^\[foo.assigns.\d+\] line 9 Check that POINTER_OBJECT\(\(const void \*\)a\) is valid when a != \(\(char \*\)NULL\): SUCCESS$
+^\[foo.assigns.\d+\] line 9 Check that __CPROVER_object_whole\(\(.* \*\)a\) is valid when a != \(\(.* \*\)NULL\): SUCCESS$
 ^\[foo.assigns.\d+\] line 19 Check that a\[\(signed long (long )?int\)i\] is assignable: SUCCESS$
 ^EXIT=0$
 ^SIGNAL=0$

--- a/regression/contracts/assigns-replace-malloc-zero/main.c
+++ b/regression/contracts/assigns-replace-malloc-zero/main.c
@@ -6,7 +6,7 @@ int foo(char *a, int size)
   // clang-format off
 __CPROVER_requires(0 <= size && size <= __CPROVER_max_malloc_size)
 __CPROVER_requires(a == NULL || __CPROVER_rw_ok(a, size))
-__CPROVER_assigns(__CPROVER_POINTER_OBJECT(a))
+__CPROVER_assigns(__CPROVER_object_whole(a))
 __CPROVER_ensures(
     a && __CPROVER_return_value >= 0 ==> a[__CPROVER_return_value] == 0)
 // clang-format on

--- a/regression/contracts/assigns-slice-targets/main-enforce.c
+++ b/regression/contracts/assigns-slice-targets/main-enforce.c
@@ -7,11 +7,14 @@ struct st
   int c;
 };
 
-void foo(struct st *s)
+void foo(struct st *s, struct st *ss)
   // clang-format off
   __CPROVER_requires(__CPROVER_is_fresh(s, sizeof(*s)))
-  __CPROVER_assigns(__CPROVER_object_slice(s->arr1, 5))
-  __CPROVER_assigns(__CPROVER_object_from(s->arr2 + 5))
+  __CPROVER_assigns(
+    __CPROVER_object_upto(s->arr1, 5);
+    __CPROVER_object_from(s->arr2 + 5);
+    __CPROVER_object_whole(ss);
+)
 // clang-format on
 {
   // PASS
@@ -41,13 +44,24 @@ void foo(struct st *s)
   s->arr2[7] = 0;
   s->arr2[8] = 0;
   s->arr2[9] = 0;
+
+  // PASS
+  ss->a = 0;
+  ss->arr1[0] = 0;
+  ss->arr1[7] = 0;
+  ss->arr1[9] = 0;
+  ss->b = 0;
+  ss->arr2[6] = 0;
+  ss->arr2[8] = 0;
+  ss->c = 0;
 }
 
 int main()
 {
   struct st s;
+  struct st ss;
 
-  foo(&s);
+  foo(&s, &ss);
 
   return 0;
 }

--- a/regression/contracts/assigns-slice-targets/main-replace.c
+++ b/regression/contracts/assigns-slice-targets/main-replace.c
@@ -7,11 +7,14 @@ struct st
   int c;
 };
 
-void foo(struct st *s)
+void foo(struct st *s, struct st *ss)
   // clang-format off
   __CPROVER_requires(__CPROVER_is_fresh(s, sizeof(*s)))
-  __CPROVER_assigns(__CPROVER_object_slice(s->arr1, 5))
-  __CPROVER_assigns(__CPROVER_object_from(s->arr2 + 5))
+  __CPROVER_assigns(
+    __CPROVER_object_upto(s->arr1, 5);
+    __CPROVER_object_from(s->arr2 + 5);
+    __CPROVER_object_whole(ss);
+  )
 // clang-format on
 {
   s->arr1[0] = 0;
@@ -54,7 +57,32 @@ int main()
   s.arr2[9] = 0;
   s.c = 0;
 
-  foo(&s);
+  struct st ss;
+  ss.a = 0;
+  ss.arr1[0] = 0;
+  ss.arr1[1] = 0;
+  ss.arr1[2] = 0;
+  ss.arr1[3] = 0;
+  ss.arr1[4] = 0;
+  ss.arr1[5] = 0;
+  ss.arr1[6] = 0;
+  ss.arr1[7] = 0;
+  ss.arr1[8] = 0;
+  ss.arr1[9] = 0;
+
+  ss.arr2[0] = 0;
+  ss.arr2[1] = 0;
+  ss.arr2[2] = 0;
+  ss.arr2[3] = 0;
+  ss.arr2[4] = 0;
+  ss.arr2[5] = 0;
+  ss.arr2[6] = 0;
+  ss.arr2[7] = 0;
+  ss.arr2[8] = 0;
+  ss.arr2[9] = 0;
+  ss.c = 0;
+
+  foo(&s, &ss);
 
   // PASS
   assert(s.a == 0);
@@ -92,5 +120,31 @@ int main()
 
   // PASS
   assert(s.c == 0);
+
+  // FAIL
+  assert(ss.a == 0);
+  assert(ss.arr1[0] == 0);
+  assert(ss.arr1[1] == 0);
+  assert(ss.arr1[2] == 0);
+  assert(ss.arr1[3] == 0);
+  assert(ss.arr1[4] == 0);
+  assert(ss.arr1[5] == 0);
+  assert(ss.arr1[6] == 0);
+  assert(ss.arr1[7] == 0);
+  assert(ss.arr1[8] == 0);
+  assert(ss.arr1[9] == 0);
+  assert(ss.b == 0);
+  assert(ss.arr2[0] == 0);
+  assert(ss.arr2[1] == 0);
+  assert(ss.arr2[2] == 0);
+  assert(ss.arr2[3] == 0);
+  assert(ss.arr2[4] == 0);
+  assert(ss.arr2[5] == 0);
+  assert(ss.arr2[6] == 0);
+  assert(ss.arr2[7] == 0);
+  assert(ss.arr2[8] == 0);
+  assert(ss.arr2[9] == 0);
+  assert(ss.c == 0);
+
   return 0;
 }

--- a/regression/contracts/assigns-slice-targets/test-enforce.desc
+++ b/regression/contracts/assigns-slice-targets/test-enforce.desc
@@ -1,8 +1,6 @@
 CORE
 main-enforce.c
 --enforce-contract foo
-^\[foo.assigns.\d+\].* Check that __CPROVER_object_slice\(\(void \*\)s->arr1, \(.*\)5\) is valid: SUCCESS$
-^\[foo.assigns.\d+\].* Check that __CPROVER_object_from\(\(void \*\)\(s->arr2 \+ \(.*\)5\)\) is valid: SUCCESS$
 ^\[foo.assigns.\d+\].* Check that s->arr1\[\(.*\)0\] is assignable: SUCCESS$
 ^\[foo.assigns.\d+\].* Check that s->arr1\[\(.*\)1\] is assignable: SUCCESS$
 ^\[foo.assigns.\d+\].* Check that s->arr1\[\(.*\)2\] is assignable: SUCCESS$
@@ -23,6 +21,14 @@ main-enforce.c
 ^\[foo.assigns.\d+\].* Check that s->arr2\[\(.*\)7\] is assignable: SUCCESS$
 ^\[foo.assigns.\d+\].* Check that s->arr2\[\(.*\)8\] is assignable: SUCCESS$
 ^\[foo.assigns.\d+\].* Check that s->arr2\[\(.*\)9\] is assignable: SUCCESS$
+^\[foo.assigns.\d+\].* Check that ss->a is assignable: SUCCESS$
+^\[foo.assigns.\d+\].* Check that ss->arr1\[\(.*\)0\] is assignable: SUCCESS$
+^\[foo.assigns.\d+\].* Check that ss->arr1\[\(.*\)7\] is assignable: SUCCESS$
+^\[foo.assigns.\d+\].* Check that ss->arr1\[\(.*\)9\] is assignable: SUCCESS$
+^\[foo.assigns.\d+\].* Check that ss->b is assignable: SUCCESS$
+^\[foo.assigns.\d+\].* Check that ss->arr2\[\(.*\)6\] is assignable: SUCCESS$
+^\[foo.assigns.\d+\].* Check that ss->arr2\[\(.*\)8\] is assignable: SUCCESS$
+^\[foo.assigns.\d+\].* Check that ss->c is assignable: SUCCESS$
 ^VERIFICATION FAILED$
 ^EXIT=10$
 ^SIGNAL=0$

--- a/regression/contracts/assigns-slice-targets/test-replace.desc
+++ b/regression/contracts/assigns-slice-targets/test-replace.desc
@@ -24,6 +24,29 @@ main-replace.c
 ^\[main.assertion.\d+\].*assertion \(.*\)s.arr2\[\(.*\)8\] == 0: FAILURE$
 ^\[main.assertion.\d+\].*assertion \(.*\)s.arr2\[\(.*\)9\] == 0: FAILURE$
 ^\[main.assertion.\d+\].*assertion s.c == 0: FAILURE$
+^\[main.assertion.\d+\].*assertion ss.a == 0: FAILURE$
+^\[main.assertion.\d+\].*assertion \(.*\)ss.arr1\[\(.*\)0\] == 0: FAILURE$
+^\[main.assertion.\d+\].*assertion \(.*\)ss.arr1\[\(.*\)1\] == 0: FAILURE$
+^\[main.assertion.\d+\].*assertion \(.*\)ss.arr1\[\(.*\)2\] == 0: FAILURE$
+^\[main.assertion.\d+\].*assertion \(.*\)ss.arr1\[\(.*\)3\] == 0: FAILURE$
+^\[main.assertion.\d+\].*assertion \(.*\)ss.arr1\[\(.*\)4\] == 0: FAILURE$
+^\[main.assertion.\d+\].*assertion \(.*\)ss.arr1\[\(.*\)5\] == 0: FAILURE$
+^\[main.assertion.\d+\].*assertion \(.*\)ss.arr1\[\(.*\)6\] == 0: FAILURE$
+^\[main.assertion.\d+\].*assertion \(.*\)ss.arr1\[\(.*\)7\] == 0: FAILURE$
+^\[main.assertion.\d+\].*assertion \(.*\)ss.arr1\[\(.*\)8\] == 0: FAILURE$
+^\[main.assertion.\d+\].*assertion \(.*\)ss.arr1\[\(.*\)9\] == 0: FAILURE$
+^\[main.assertion.\d+\].*assertion ss.b == 0: FAILURE$
+^\[main.assertion.\d+\].*assertion \(.*\)ss.arr2\[\(.*\)0\] == 0: FAILURE$
+^\[main.assertion.\d+\].*assertion \(.*\)ss.arr2\[\(.*\)1\] == 0: FAILURE$
+^\[main.assertion.\d+\].*assertion \(.*\)ss.arr2\[\(.*\)2\] == 0: FAILURE$
+^\[main.assertion.\d+\].*assertion \(.*\)ss.arr2\[\(.*\)3\] == 0: FAILURE$
+^\[main.assertion.\d+\].*assertion \(.*\)ss.arr2\[\(.*\)4\] == 0: FAILURE$
+^\[main.assertion.\d+\].*assertion \(.*\)ss.arr2\[\(.*\)5\] == 0: FAILURE$
+^\[main.assertion.\d+\].*assertion \(.*\)ss.arr2\[\(.*\)6\] == 0: FAILURE$
+^\[main.assertion.\d+\].*assertion \(.*\)ss.arr2\[\(.*\)7\] == 0: FAILURE$
+^\[main.assertion.\d+\].*assertion \(.*\)ss.arr2\[\(.*\)8\] == 0: FAILURE$
+^\[main.assertion.\d+\].*assertion \(.*\)ss.arr2\[\(.*\)9\] == 0: FAILURE$
+^\[main.assertion.\d+\].*assertion ss.c == 0: FAILURE$
 ^VERIFICATION FAILED$
 ^EXIT=10$
 ^SIGNAL=0$

--- a/regression/contracts/assigns_enforce_23/main.c
+++ b/regression/contracts/assigns_enforce_23/main.c
@@ -10,8 +10,8 @@ typedef struct
 void foo(blob *b, uint8_t *value)
   // clang-format off
 __CPROVER_requires(b->size == 5)
-__CPROVER_assigns(__CPROVER_POINTER_OBJECT(b->buf))
-__CPROVER_assigns(__CPROVER_POINTER_OBJECT(value))
+__CPROVER_assigns(__CPROVER_object_whole(b->buf))
+__CPROVER_assigns(__CPROVER_object_whole(value))
 __CPROVER_ensures(b->buf[0] == 1)
 __CPROVER_ensures(b->buf[1] == 1)
 __CPROVER_ensures(b->buf[2] == 1)

--- a/regression/contracts/assigns_enforce_23/test.desc
+++ b/regression/contracts/assigns_enforce_23/test.desc
@@ -6,4 +6,4 @@ main.c
 ^VERIFICATION SUCCESSFUL$
 --
 --
-This test checks that POINTER_OBJECT can be used both on arrays and scalars.
+This test checks that __CPROVER_object_whole can be used both on arrays and scalars.

--- a/regression/contracts/assigns_enforce_address_of/test.desc
+++ b/regression/contracts/assigns_enforce_address_of/test.desc
@@ -3,7 +3,7 @@ main.c
 --enforce-contract foo
 ^EXIT=(1|64)$
 ^SIGNAL=0$
-^.*error: assigns clause target must be an lvalue or a __CPROVER_POINTER_OBJECT, __CPROVER_object_from, __CPROVER_object_slice expression$
+^.*error: assigns clause target must be a non-void lvalue or a call to one of __CPROVER_POINTER_OBJECT, __CPROVER_assignable, __CPROVER_object_whole, __CPROVER_object_upto, __CPROVER_object_from$
 ^CONVERSION ERROR$
 --
 --

--- a/regression/contracts/assigns_enforce_arrays_02/main.c
+++ b/regression/contracts/assigns_enforce_arrays_02/main.c
@@ -9,7 +9,7 @@ void f1(int *a, int len) __CPROVER_assigns(*a)
   a[5] = 5;
 }
 
-void f2(int *a, int len) __CPROVER_assigns(__CPROVER_POINTER_OBJECT(a))
+void f2(int *a, int len) __CPROVER_assigns(__CPROVER_object_whole(a))
 {
   a[0] = 0;
   a[5] = 5;

--- a/regression/contracts/assigns_enforce_arrays_02/test.desc
+++ b/regression/contracts/assigns_enforce_arrays_02/test.desc
@@ -4,14 +4,14 @@ main.c
 ^\[f1.assigns.\d+\] line 6 Check that \*a is valid: SUCCESS$
 ^\[f1.assigns.\d+\] line 8 Check that a\[.*0\] is assignable: SUCCESS$
 ^\[f1.assigns.\d+\] line 9 Check that a\[.*5\] is assignable: FAILURE$
-^\[f2.assigns.\d+\] line 12 Check that POINTER_OBJECT\(\(const void \*\)a\) is valid: SUCCESS$
+^\[f2.assigns.\d+\] line 12 Check that __CPROVER_object_whole\(\(.* \*\)a\) is valid: SUCCESS$
 ^\[f2.assigns.\d+\] line 14 Check that a\[.*0\] is assignable: SUCCESS$
 ^\[f2.assigns.\d+\] line 15 Check that a\[.*5\] is assignable: SUCCESS$
-^\[f2.assigns.\d+\] line 16 Check that POINTER_OBJECT\(\(void \*\)a\) is assignable: SUCCESS$
+^\[f2.assigns.\d+\] line 16 Check that POINTER_OBJECT\(\(.* \*\)a\) is assignable: SUCCESS$
 ^EXIT=10$
 ^SIGNAL=0$
 ^VERIFICATION FAILED$
 --
 --
 This test ensures that assigns clauses correctly check for global variables,
-and access using *ptr vs POINTER_OBJECT(ptr).
+and access using *ptr vs __CPROVER_object_whole(ptr).

--- a/regression/contracts/assigns_enforce_arrays_04/main.c
+++ b/regression/contracts/assigns_enforce_arrays_04/main.c
@@ -5,8 +5,7 @@ void assigns_single(int a[], int len)
   a[i] = 0;
 }
 
-void uses_assigns(int a[], int len)
-  __CPROVER_assigns(__CPROVER_POINTER_OBJECT(a))
+void uses_assigns(int a[], int len) __CPROVER_assigns(__CPROVER_object_whole(a))
 {
   assigns_single(a, len);
 }

--- a/regression/contracts/assigns_enforce_conditional_non_lvalue_target/test.desc
+++ b/regression/contracts/assigns_enforce_conditional_non_lvalue_target/test.desc
@@ -1,7 +1,7 @@
 CORE
 main.c
 --enforce-contract foo
-^.*error: assigns clause target must be an lvalue or a __CPROVER_POINTER_OBJECT, __CPROVER_object_from, __CPROVER_object_slice expression$
+^.*error: assigns clause target must be a non-void lvalue or a call to one of __CPROVER_POINTER_OBJECT, __CPROVER_assignable, __CPROVER_object_whole, __CPROVER_object_upto, __CPROVER_object_from$
 ^CONVERSION ERROR
 ^EXIT=(1|64)$
 ^SIGNAL=0$

--- a/regression/contracts/assigns_enforce_conditional_non_lvalue_target_list/test.desc
+++ b/regression/contracts/assigns_enforce_conditional_non_lvalue_target_list/test.desc
@@ -1,7 +1,7 @@
 CORE
 main.c
 --enforce-contract foo
-^.*error: assigns clause target must be an lvalue or a __CPROVER_POINTER_OBJECT, __CPROVER_object_from, __CPROVER_object_slice expression$
+^.*error: assigns clause target must be a non-void lvalue or a call to one of __CPROVER_POINTER_OBJECT, __CPROVER_assignable, __CPROVER_object_whole, __CPROVER_object_upto, __CPROVER_object_from$
 ^CONVERSION ERROR
 ^EXIT=(1|64)$
 ^SIGNAL=0$

--- a/regression/contracts/assigns_enforce_conditional_pointer_object/main.c
+++ b/regression/contracts/assigns_enforce_conditional_pointer_object/main.c
@@ -3,8 +3,8 @@
 int foo(bool a, char *x, char *y)
   // clang-format off
  __CPROVER_assigns(
-    a: __CPROVER_POINTER_OBJECT(x);
-   !a: __CPROVER_POINTER_OBJECT(y);
+    a: __CPROVER_object_whole(x);
+   !a: __CPROVER_object_whole(y);
   )
 // clang-format on
 {

--- a/regression/contracts/assigns_enforce_conditional_pointer_object/test.desc
+++ b/regression/contracts/assigns_enforce_conditional_pointer_object/test.desc
@@ -2,8 +2,8 @@ CORE
 main.c
 --enforce-contract foo
 main.c function foo
-^\[foo.assigns.\d+\] line 6 Check that POINTER_OBJECT\(\(const void \*\)x\) is valid when a != FALSE: SUCCESS$
-^\[foo.assigns.\d+\] line 7 Check that POINTER_OBJECT\(\(const void \*\)y\) is valid when !\(a != FALSE\): SUCCESS$
+^\[foo.assigns.\d+\] line 6 Check that __CPROVER_object_whole\(\(.* \*\)x\) is valid when a != FALSE: SUCCESS$
+^\[foo.assigns.\d+\] line 7 Check that __CPROVER_object_whole\(\(.* \*\)y\) is valid when !\(a != FALSE\): SUCCESS$
 ^\[foo.assigns.\d+\] line 13 Check that x\[\(signed (long )?long int\)0\] is assignable: SUCCESS$
 ^\[foo.assigns.\d+\] line 14 Check that y\[\(signed (long )?long int\)0\] is assignable: FAILURE$
 ^\[foo.assigns.\d+\] line 18 Check that x\[\(signed (long )?long int\)0\] is assignable: FAILURE$
@@ -15,5 +15,5 @@ main.c function foo
 ^SIGNAL=0$
 --
 --
-Check that conditional assigns clause  `c ? __CPROVER_POINTER_OBJECT((p)`
+Check that conditional assigns clause  `c ? __CPROVER_object_whole((p)`
 match with control flow path conditions.

--- a/regression/contracts/assigns_enforce_conditional_pointer_object_list/main.c
+++ b/regression/contracts/assigns_enforce_conditional_pointer_object_list/main.c
@@ -3,7 +3,7 @@
 int foo(bool a, char *x, char *y)
   // clang-format off
 __CPROVER_assigns(
-   a : __CPROVER_POINTER_OBJECT(x), __CPROVER_POINTER_OBJECT(y)
+   a : __CPROVER_object_whole(x), __CPROVER_object_whole(y)
 )
 // clang-format on
 {

--- a/regression/contracts/assigns_enforce_conditional_pointer_object_list/test.desc
+++ b/regression/contracts/assigns_enforce_conditional_pointer_object_list/test.desc
@@ -2,8 +2,8 @@ CORE
 main.c
 --enforce-contract foo
 main.c function foo
-^\[foo.assigns.\d+\] line 6 Check that POINTER_OBJECT\(\(const void \*\)x\) is valid when a != FALSE: SUCCESS$
-^\[foo.assigns.\d+\] line 6 Check that POINTER_OBJECT\(\(const void \*\)y\) is valid when a != FALSE: SUCCESS$
+^\[foo.assigns.\d+\] line 6 Check that __CPROVER_object_whole\(\(.*\)x\) is valid when a != FALSE: SUCCESS$
+^\[foo.assigns.\d+\] line 6 Check that __CPROVER_object_whole\(\(.*\)y\) is valid when a != FALSE: SUCCESS$
 ^\[foo.assigns.\d+\] line 12 Check that x\[\(signed (long )?long int\)0\] is assignable: SUCCESS$
 ^\[foo.assigns.\d+\] line 13 Check that y\[\(signed (long )?long int\)0\] is assignable: SUCCESS$
 ^\[foo.assigns.\d+\] line 17 Check that x\[\(signed (long )?long int\)0\] is assignable: FAILURE$

--- a/regression/contracts/assigns_enforce_conditional_unions/main.c
+++ b/regression/contracts/assigns_enforce_conditional_unions/main.c
@@ -70,10 +70,10 @@ __CPROVER_requires(
               sizeof(*(state->digest.high_level.second.ctx->digest))))
 __CPROVER_assigns(
   is_high_level():
-    __CPROVER_POINTER_OBJECT(state->digest.high_level.first.ctx->digest),
+    __CPROVER_object_whole(state->digest.high_level.first.ctx->digest),
     state->digest.high_level.first.ctx->flags;
   is_high_level() && also_second:
-    __CPROVER_POINTER_OBJECT(state->digest.high_level.second.ctx->digest),  
+    __CPROVER_object_whole(state->digest.high_level.second.ctx->digest),  
     state->digest.high_level.second.ctx->flags;
 )
 // clang-format on

--- a/regression/contracts/assigns_enforce_conditional_unions/test.desc
+++ b/regression/contracts/assigns_enforce_conditional_unions/test.desc
@@ -1,9 +1,9 @@
 CORE
 main.c
 --enforce-contract update _ --pointer-check --pointer-overflow-check --signed-overflow-check --unsigned-overflow-check --conversion-check
-^\[update.assigns.\d+] line 73 Check that POINTER_OBJECT\(\(const void \*\)state->digest.high_level.first.ctx->digest\) is valid when .*: SUCCESS
+^\[update.assigns.\d+] line 73 Check that __CPROVER_object_whole\(\(.*\)state->digest.high_level.first.ctx->digest\) is valid when .*: SUCCESS
 ^\[update.assigns.\d+] line 74 Check that state->digest.high_level.first.ctx->flags is valid when .*: SUCCESS
-^\[update.assigns.\d+] line 76 Check that POINTER_OBJECT\(\(const void \*\)state->digest.high_level.second.ctx->digest\) is valid when .*: SUCCESS
+^\[update.assigns.\d+] line 76 Check that __CPROVER_object_whole\(\(.*\)state->digest.high_level.second.ctx->digest\) is valid when .*: SUCCESS
 ^\[update.assigns.\d+] line 77 Check that state->digest.high_level.second.ctx->flags is valid when .*: SUCCESS
 ^\[is_high_level.assigns.\d+\] line 50 Check that latch is assignable: SUCCESS$
 ^\[is_high_level.assigns.\d+\] line 51 Check that once is assignable: SUCCESS$

--- a/regression/contracts/assigns_enforce_conditional_void_target/test.desc
+++ b/regression/contracts/assigns_enforce_conditional_void_target/test.desc
@@ -1,7 +1,7 @@
 CORE
 main.c
 --enforce-contract foo
-^.* error: (void-typed expressions not allowed as assigns clause targets|dereferencing void pointer)$
+^.* error: (dereferencing void pointer|lvalue expressions with void type not allowed in assigns clauses)$
 ^CONVERSION ERROR$
 ^EXIT=(1|64)$
 ^SIGNAL=0$

--- a/regression/contracts/assigns_enforce_conditional_void_target_list/test.desc
+++ b/regression/contracts/assigns_enforce_conditional_void_target_list/test.desc
@@ -1,7 +1,7 @@
 CORE
 main.c
 --enforce-contract foo
-^.* error: (void-typed expressions not allowed as assigns clause targets|dereferencing void pointer)$
+^.* error: (dereferencing void pointer|lvalue expressions with void type not allowed in assigns clauses)$
 ^CONVERSION ERROR$
 ^EXIT=(1|64)$
 ^SIGNAL=0$

--- a/regression/contracts/assigns_enforce_function_calls/test.desc
+++ b/regression/contracts/assigns_enforce_function_calls/test.desc
@@ -3,7 +3,7 @@ main.c
 --enforce-contract foo
 ^EXIT=(1|64)$
 ^SIGNAL=0$
-^.*error: function calls in assigns clause targets must be to __CPROVER_object_from, __CPROVER_object_slice$
+^.*error: assigns clause target must be a non-void lvalue or a call to one of __CPROVER_POINTER_OBJECT, __CPROVER_assignable, __CPROVER_object_whole, __CPROVER_object_upto, __CPROVER_object_from$
 ^CONVERSION ERROR$
 --
 --

--- a/regression/contracts/assigns_enforce_havoc_object/main.c
+++ b/regression/contracts/assigns_enforce_havoc_object/main.c
@@ -15,7 +15,8 @@ typedef struct stb
 
 typedef struct sta
 {
-  union {
+  union
+  {
     stb *b;
     int i;
     int j;
@@ -32,8 +33,7 @@ void bar(sta *a)
   return;
 }
 
-void foo(sta *a1, sta *a2)
-  __CPROVER_assigns(__CPROVER_POINTER_OBJECT(a1->u.b->c))
+void foo(sta *a1, sta *a2) __CPROVER_assigns(__CPROVER_object_whole(a1->u.b->c))
 {
   bar(a1);
   bar(a2);

--- a/regression/contracts/assigns_enforce_havoc_object/test.desc
+++ b/regression/contracts/assigns_enforce_havoc_object/test.desc
@@ -3,7 +3,7 @@ main.c
 --enforce-contract foo
 ^EXIT=10$
 ^SIGNAL=0$
-^\[foo.assigns.\d+\] line \d+ Check that POINTER_OBJECT\(\(const void \*\)a1->u.b->c\) is valid: SUCCESS$
+^\[foo.assigns.\d+\] line \d+ Check that __CPROVER_object_whole\(\(.*\)a1->u.b->c\) is valid: SUCCESS$
 ^\[bar.assigns.\d+\] line \d+ Check that POINTER_OBJECT\(\(void \*\)a->u\.b->c\) is assignable: SUCCESS$
 ^\[bar.assigns.\d+\] line \d+ Check that POINTER_OBJECT\(\(void \*\)a->u\.b->c\) is assignable: FAILURE$
 ^VERIFICATION FAILED$

--- a/regression/contracts/assigns_enforce_literal/test.desc
+++ b/regression/contracts/assigns_enforce_literal/test.desc
@@ -3,7 +3,7 @@ main.c
 --enforce-contract foo
 ^EXIT=(1|64)$
 ^SIGNAL=0$
-^.*error: assigns clause target must be an lvalue or a __CPROVER_POINTER_OBJECT, __CPROVER_object_from, __CPROVER_object_slice expression$
+^.*error: assigns clause target must be a non-void lvalue or a call to one of __CPROVER_POINTER_OBJECT, __CPROVER_assignable, __CPROVER_object_whole, __CPROVER_object_upto, __CPROVER_object_from$
 ^CONVERSION ERROR$
 --
 --

--- a/regression/contracts/assigns_enforce_object_wrong_args/main.c
+++ b/regression/contracts/assigns_enforce_object_wrong_args/main.c
@@ -2,7 +2,7 @@
 #include <stdbool.h>
 #include <stdlib.h>
 
-int baz(int *x) __CPROVER_assigns(__CPROVER_POINTER_OBJECT())
+int baz(int *x) __CPROVER_assigns(__CPROVER_object_whole())
 {
   *x = 0;
   return 0;

--- a/regression/contracts/assigns_enforce_object_wrong_args/test.desc
+++ b/regression/contracts/assigns_enforce_object_wrong_args/test.desc
@@ -3,8 +3,8 @@ main.c
 --enforce-contract baz
 ^EXIT=(1|64)$
 ^SIGNAL=0$
-^.*error: pointer_object expects one argument$
+^.*error: wrong number of function arguments: expected 1, but got 0$
 ^CONVERSION ERROR$
 --
 --
-Check that `__CPROVER_POINTER_OBJECT` in assigns clauses are invoked correctly.
+Check that incorrect uses of `__CPROVER_object_whole` in assigns clauses are detected.

--- a/regression/contracts/assigns_enforce_side_effects_1/test.desc
+++ b/regression/contracts/assigns_enforce_side_effects_1/test.desc
@@ -2,7 +2,7 @@ CORE
 main.c
 --enforce-contract foo
 activate-multi-line-match
-.*error: (dereferencing void pointer|void-typed expressions not allowed as assigns clause targets)
+.*error: (dereferencing void pointer|lvalue expressions with void type not allowed in assigns clauses)
 ^CONVERSION ERROR$
 ^EXIT=(1|64)$
 ^SIGNAL=0$

--- a/regression/contracts/assigns_enforce_side_effects_2/test.desc
+++ b/regression/contracts/assigns_enforce_side_effects_2/test.desc
@@ -3,7 +3,7 @@ main.c
 --enforce-contract foo
 ^EXIT=(1|64)$
 ^SIGNAL=0$
-^.*error: assigns clause target must be an lvalue or a __CPROVER_POINTER_OBJECT, __CPROVER_object_from, __CPROVER_object_slice expression$
+^.*error: assigns clause target must be a non-void lvalue or a call to one of __CPROVER_POINTER_OBJECT, __CPROVER_assignable, __CPROVER_object_whole, __CPROVER_object_upto, __CPROVER_object_from$
 ^CONVERSION ERROR$
 --
 --

--- a/regression/contracts/assigns_enforce_side_effects_3/test.desc
+++ b/regression/contracts/assigns_enforce_side_effects_3/test.desc
@@ -3,7 +3,7 @@ main.c
 --enforce-contract foo
 ^EXIT=(1|64)$
 ^SIGNAL=0$
-^.*error: assigns clause target must be an lvalue or a __CPROVER_POINTER_OBJECT, __CPROVER_object_from, __CPROVER_object_slice expression$
+^.*error: assigns clause target must be a non-void lvalue or a call to one of __CPROVER_POINTER_OBJECT, __CPROVER_assignable, __CPROVER_object_whole, __CPROVER_object_upto, __CPROVER_object_from$
 ^CONVERSION ERROR$
 --
 --

--- a/regression/contracts/assigns_enforce_structs_06/main.c
+++ b/regression/contracts/assigns_enforce_structs_06/main.c
@@ -8,7 +8,7 @@ struct pair
   size_t size;
 };
 
-void f1(struct pair *p) __CPROVER_assigns(__CPROVER_POINTER_OBJECT(p->buf))
+void f1(struct pair *p) __CPROVER_assigns(__CPROVER_object_whole(p->buf))
 {
   p->buf[0] = 0;
   p->buf[1] = 1;

--- a/regression/contracts/assigns_replace_06/main.c
+++ b/regression/contracts/assigns_replace_06/main.c
@@ -1,7 +1,7 @@
 #include <assert.h>
 #include <stdlib.h>
 
-void foo(char c[]) __CPROVER_assigns(__CPROVER_POINTER_OBJECT(c))
+void foo(char c[]) __CPROVER_assigns(__CPROVER_object_whole(c))
 {
 }
 

--- a/regression/contracts/assigns_replace_conditional_targets/main.c
+++ b/regression/contracts/assigns_replace_conditional_targets/main.c
@@ -11,7 +11,7 @@ __CPROVER_requires(x && y && z)
 __CPROVER_assigns(
    a && nz(*x): *x;
   !a && nz(*y): *y;
-  !nz(*x) && !nz(*y): __CPROVER_POINTER_OBJECT(z);
+  !nz(*x) && !nz(*y): __CPROVER_object_whole(z);
 )
 __CPROVER_ensures(true)
 // clang-format on

--- a/regression/contracts/assigns_replace_havoc_dependent_targets_fail/replace.desc
+++ b/regression/contracts/assigns_replace_havoc_dependent_targets_fail/replace.desc
@@ -3,7 +3,7 @@ main_replace.c
 --replace-call-with-contract resize_vec --enforce-contract resize_vec_incr10 _ --signed-overflow-check --unsigned-overflow-check --pointer-overflow-check
 ^\[.*\] .* Check that v->size \(assigned by the contract of resize_vec\) is assignable: SUCCESS
 ^\[.*\] .* Check that v->arr \(assigned by the contract of resize_vec\) is assignable: FAILURE
-^\[.*\] .* Check that POINTER_OBJECT\(\(const void \*\)v->arr\) \(assigned by the contract of resize_vec\) is assignable: FAILURE
+^\[.*\] .* Check that __CPROVER_object_whole\(\(.*\)v->arr\) \(assigned by the contract of resize_vec\) is assignable: FAILURE
 ^VERIFICATION FAILED$
 ^EXIT=10$
 ^SIGNAL=0$

--- a/regression/contracts/assigns_replace_havoc_dependent_targets_fail/vect.h
+++ b/regression/contracts/assigns_replace_havoc_dependent_targets_fail/vect.h
@@ -15,7 +15,7 @@ __CPROVER_requires(
   0 < incr && incr < __CPROVER_max_malloc_size - v->size &&
   __CPROVER_is_fresh(v->arr, v->size)
 )
-__CPROVER_assigns(v->size, v->arr, __CPROVER_POINTER_OBJECT(v->arr))
+__CPROVER_assigns(v->size, v->arr, __CPROVER_object_whole(v->arr))
 __CPROVER_ensures(
   v->size == __CPROVER_old(v->size) + __CPROVER_old(incr) &&
   __CPROVER_is_fresh(v->arr, v->size)

--- a/regression/contracts/assigns_replace_havoc_dependent_targets_pass/replace.desc
+++ b/regression/contracts/assigns_replace_havoc_dependent_targets_pass/replace.desc
@@ -4,7 +4,7 @@ main_replace.c
 ^VERIFICATION SUCCESSFUL$
 ^\[.*\] .* Check that v->size \(assigned by the contract of resize_vec\) is assignable: SUCCESS
 ^\[.*\] .* Check that v->arr \(assigned by the contract of resize_vec\) is assignable: SUCCESS
-^\[.*\] .* Check that POINTER_OBJECT\(\(const void \*\)v->arr\) \(assigned by the contract of resize_vec\) is assignable: SUCCESS
+^\[.*\] .* Check that __CPROVER_object_whole\(\(.*\)v->arr\) \(assigned by the contract of resize_vec\) is assignable: SUCCESS
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/contracts/assigns_replace_havoc_dependent_targets_pass/vect.h
+++ b/regression/contracts/assigns_replace_havoc_dependent_targets_pass/vect.h
@@ -15,7 +15,7 @@ __CPROVER_requires(
   0 < incr && incr < __CPROVER_max_malloc_size - v->size &&
   __CPROVER_is_fresh(v->arr, v->size)
 )
-__CPROVER_assigns(v->size, v->arr, __CPROVER_POINTER_OBJECT(v->arr))
+__CPROVER_assigns(v->size, v->arr, __CPROVER_object_whole(v->arr))
 __CPROVER_ensures(
   v->size == __CPROVER_old(v->size) + __CPROVER_old(incr) &&
   __CPROVER_is_fresh(v->arr, v->size)
@@ -36,7 +36,7 @@ __CPROVER_requires(
   v->size + 10 < __CPROVER_max_malloc_size &&
   __CPROVER_is_fresh(v->arr, v->size)
 )
-__CPROVER_assigns(*v, __CPROVER_POINTER_OBJECT(v->arr))
+__CPROVER_assigns(*v, __CPROVER_object_whole(v->arr))
 __CPROVER_ensures(
   v->size == __CPROVER_old(v->size) + 10 &&
   __CPROVER_is_fresh(v->arr, v->size)

--- a/regression/contracts/assigns_type_checking_invalid_case_01/test.desc
+++ b/regression/contracts/assigns_type_checking_invalid_case_01/test.desc
@@ -4,6 +4,6 @@ main.c
 ^EXIT=(1|64)$
 ^SIGNAL=0$
 ^CONVERSION ERROR$
-^.*error: assigns clause target must be an lvalue or a __CPROVER_POINTER_OBJECT, __CPROVER_object_from, __CPROVER_object_slice expression$
+^.*error: assigns clause target must be a non-void lvalue or a call to one of __CPROVER_POINTER_OBJECT, __CPROVER_assignable, __CPROVER_object_whole, __CPROVER_object_upto, __CPROVER_object_from$
 --
 Checks whether type checking rejects literal constants in assigns clause.

--- a/regression/contracts/assigns_type_checking_valid_cases/main.c
+++ b/regression/contracts/assigns_type_checking_valid_cases/main.c
@@ -61,7 +61,7 @@ void foo7(int a, struct buf *buffer) __CPROVER_assigns(*buffer)
   buffer->len = 1;
 }
 
-void foo8(int array[]) __CPROVER_assigns(__CPROVER_POINTER_OBJECT(array))
+void foo8(int array[]) __CPROVER_assigns(__CPROVER_object_whole(array))
 {
   array[0] = 1;
   array[1] = 1;

--- a/regression/contracts/cprover-assignable-fail/main.c
+++ b/regression/contracts/cprover-assignable-fail/main.c
@@ -1,0 +1,29 @@
+#include <stdlib.h>
+
+void my_write_set(char *arr, size_t size)
+{
+  __CPROVER_assert(
+    !arr || __CPROVER_rw_ok(arr, size), "target null or writable");
+
+  if(arr && size > 0)
+  {
+    __CPROVER_object_whole(arr);
+    __CPROVER_object_upto(arr, size);
+    __CPROVER_object_from(arr);
+    __CPROVER_typed_target(arr[0]);
+  }
+}
+
+void main()
+{
+  size_t size;
+  char *arr;
+  int do_init;
+  if(do_init)
+  {
+    int nondet;
+    arr = nondet ? malloc(size) : NULL;
+  }
+  // pointer can be invalid expecting failed checks
+  my_write_set(arr, size);
+}

--- a/regression/contracts/cprover-assignable-fail/test.desc
+++ b/regression/contracts/cprover-assignable-fail/test.desc
@@ -1,0 +1,21 @@
+CORE
+main.c
+
+CALL __CPROVER_object_whole
+CALL __CPROVER_object_upto
+CALL __CPROVER_object_from
+CALL __CPROVER_assignable
+^\[my_write_set.assertion.\d+\] .* target null or writable: FAILURE$
+^VERIFICATION FAILED$
+^EXIT=10$
+^SIGNAL=0$
+--
+CALL __CPROVER_typed_target
+--
+This test checks that:
+- built-ins __CPROVER_assignable, __CPROVER_object_whole, __CPROVER_object_from,
+  __CPROVER_object_upto are supported;
+- GOTO conversion preserves calls to __CPROVER_object_whole,
+  __CPROVER_object_upto, __CPROVER_object_from;
+- GOTO conversion translates __CPROVER_typed_target to __CPROVER_assignable;
+- user-defined checks embedded in `my_write_set` persist after conversion.

--- a/regression/contracts/cprover-assignable-pass/main.c
+++ b/regression/contracts/cprover-assignable-pass/main.c
@@ -1,0 +1,25 @@
+#include <stdlib.h>
+
+void my_write_set(char *arr, size_t size)
+{
+  __CPROVER_assert(
+    !arr || __CPROVER_rw_ok(arr, size), "target null or writable");
+
+  if(arr && size > 0)
+  {
+    __CPROVER_object_whole(arr);
+    __CPROVER_object_upto(arr, size);
+    __CPROVER_object_from(arr);
+    __CPROVER_typed_target(arr[0]);
+  }
+}
+
+void main()
+{
+  int nondet;
+  size_t size;
+  char *arr;
+  arr = nondet ? malloc(size) : NULL;
+  // pointer is not invalid
+  my_write_set(arr, size);
+}

--- a/regression/contracts/cprover-assignable-pass/test.desc
+++ b/regression/contracts/cprover-assignable-pass/test.desc
@@ -1,0 +1,20 @@
+CORE
+main.c
+
+CALL __CPROVER_object_whole
+CALL __CPROVER_object_upto
+CALL __CPROVER_object_from
+CALL __CPROVER_assignable
+^\[my_write_set.assertion.\d+\] .* target null or writable: SUCCESS$
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+CALL __CPROVER_typed_target
+--
+This test checks that:
+- built-in __CPROVER_assignable_t functions are supported;
+- GOTO conversion preserves calls to __CPROVER_object_whole,
+  __CPROVER_object_upto, __CPROVER_object_from;
+- GOTO conversion translates __CPROVER_typed_target to __CPROVER_assignable;
+- user-defined checks embedded in `my_write_set` persist after conversion.

--- a/regression/contracts/function_check_02/main.c
+++ b/regression/contracts/function_check_02/main.c
@@ -6,7 +6,7 @@
 
 // clang-format off
 int initialize(int *arr)
-  __CPROVER_assigns(__CPROVER_POINTER_OBJECT(arr))
+  __CPROVER_assigns(__CPROVER_object_whole(arr))
   __CPROVER_ensures(
     __CPROVER_forall {
       int i;

--- a/regression/contracts/loop-freeness-check/main.c
+++ b/regression/contracts/loop-freeness-check/main.c
@@ -1,6 +1,6 @@
 int foo(int *arr)
   // clang-format off
-  __CPROVER_assigns(__CPROVER_POINTER_OBJECT(arr))
+  __CPROVER_assigns(__CPROVER_object_whole(arr))
 // clang-format off
 {
   for(int i = 0; i < 10; i++)

--- a/regression/contracts/quantifiers-forall-ensures-enforce/main.c
+++ b/regression/contracts/quantifiers-forall-ensures-enforce/main.c
@@ -4,7 +4,7 @@
 
 // clang-format off
 int f1(int *arr, int len)
-  __CPROVER_assigns(__CPROVER_POINTER_OBJECT(arr))
+  __CPROVER_assigns(__CPROVER_object_whole(arr))
   __CPROVER_ensures(__CPROVER_forall {
     int i;
     // test enforcement with symbolic bound

--- a/regression/contracts/quantifiers-nested-01/main.c
+++ b/regression/contracts/quantifiers-nested-01/main.c
@@ -1,6 +1,6 @@
 // clang-format off
 int f1(int *arr)
-  __CPROVER_assigns(__CPROVER_POINTER_OBJECT(arr))
+  __CPROVER_assigns(__CPROVER_object_whole(arr))
   __CPROVER_ensures(__CPROVER_forall {
     int i;
     __CPROVER_forall

--- a/regression/contracts/quantifiers-nested-03/main.c
+++ b/regression/contracts/quantifiers-nested-03/main.c
@@ -1,6 +1,6 @@
 // clang-format off
 int f1(int *arr)
-__CPROVER_assigns(__CPROVER_POINTER_OBJECT(arr))
+__CPROVER_assigns(__CPROVER_object_whole(arr))
   __CPROVER_ensures(
     __CPROVER_return_value == 0 &&
     __CPROVER_exists {

--- a/regression/contracts/reject_history_expr_in_assigns_clause/main.c
+++ b/regression/contracts/reject_history_expr_in_assigns_clause/main.c
@@ -1,0 +1,11 @@
+int foo(int *x) __CPROVER_assigns(__CPROVER_old(*x))
+{
+  return 0;
+}
+
+int main()
+{
+  int x;
+  int ret = foo(&x);
+  return 0;
+}

--- a/regression/contracts/reject_history_expr_in_assigns_clause/test.desc
+++ b/regression/contracts/reject_history_expr_in_assigns_clause/test.desc
@@ -1,0 +1,11 @@
+CORE
+main.c
+--enforce-contract foo
+^main.c.*error: assigns clause target must be a non-void lvalue or a call to one of __CPROVER_POINTER_OBJECT, __CPROVER_assignable, __CPROVER_object_whole, __CPROVER_object_upto, __CPROVER_object_from$
+^CONVERSION ERROR$
+^EXIT=(1|64)$
+^SIGNAL=0$
+--
+--
+This test checks that __CPROVER_old occurences in assigns clauses
+are detected and rejected.

--- a/regression/contracts/reject_history_expr_in_preconditions/main.c
+++ b/regression/contracts/reject_history_expr_in_preconditions/main.c
@@ -1,0 +1,11 @@
+int foo(int *x) __CPROVER_requires(__CPROVER_old(*x))
+{
+  return 0;
+}
+
+int main()
+{
+  int x;
+  int retval = foo(&x);
+  return 0;
+}

--- a/regression/contracts/reject_history_expr_in_preconditions/test.desc
+++ b/regression/contracts/reject_history_expr_in_preconditions/test.desc
@@ -1,0 +1,11 @@
+CORE
+main.c
+--enforce-contract foo
+^main.c.*error: __CPROVER_old is not allowed in preconditions.$
+^CONVERSION ERROR$
+^EXIT=(1|64)$
+^SIGNAL=0$
+--
+--
+This test checks that __CPROVER_old occurences in preconditions
+are detected and rejected.

--- a/regression/contracts/reject_return_value_in_assigns_clause/main.c
+++ b/regression/contracts/reject_return_value_in_assigns_clause/main.c
@@ -1,0 +1,10 @@
+int foo() __CPROVER_assigns(__CPROVER_return_value)
+{
+  return 0;
+}
+
+int main()
+{
+  int x = foo();
+  return 0;
+}

--- a/regression/contracts/reject_return_value_in_assigns_clause/test.desc
+++ b/regression/contracts/reject_return_value_in_assigns_clause/test.desc
@@ -1,0 +1,11 @@
+CORE
+main.c
+--enforce-contract foo
+^main.c.*error: __CPROVER_return_value is not allowed in assigns clauses.$
+^CONVERSION ERROR$
+^EXIT=(1|64)$
+^SIGNAL=0$
+--
+--
+This test checks that __CPROVER_return_value occurences in assigns clauses
+are detected and rejected.

--- a/regression/contracts/reject_return_value_in_preconditions/main.c
+++ b/regression/contracts/reject_return_value_in_preconditions/main.c
@@ -1,0 +1,10 @@
+int foo() __CPROVER_requires(__CPROVER_return_value == 0)
+{
+  return 0;
+}
+
+int main()
+{
+  int x = foo();
+  return 0;
+}

--- a/regression/contracts/reject_return_value_in_preconditions/test.desc
+++ b/regression/contracts/reject_return_value_in_preconditions/test.desc
@@ -1,0 +1,11 @@
+CORE
+main.c
+--enforce-contract foo
+^main.c.*error: __CPROVER_return_value is not allowed in preconditions.$
+^CONVERSION ERROR$
+^EXIT=(1|64)$
+^SIGNAL=0$
+--
+--
+This test checks that __CPROVER_return_value occurences in preconditions
+are detected and rejected.

--- a/regression/contracts/test_array_memory_enforce/main.c
+++ b/regression/contracts/test_array_memory_enforce/main.c
@@ -14,7 +14,7 @@ bool return_ok(int ret_value, int *x)
 
 // clang-format off
 int foo(int *x)
-  __CPROVER_assigns(__CPROVER_POINTER_OBJECT(x))
+  __CPROVER_assigns(__CPROVER_object_whole(x))
   __CPROVER_requires(
     __CPROVER_is_fresh(x, sizeof(int) * 10) &&
     x[0] > 0 &&

--- a/regression/contracts/typed_target_fail_wrong_nof_operand/main.c
+++ b/regression/contracts/typed_target_fail_wrong_nof_operand/main.c
@@ -1,0 +1,10 @@
+int foo(int x, int y) __CPROVER_assigns(__CPROVER_typed_target(x, y))
+{
+  return 0;
+}
+
+int main()
+{
+  int ret = foo(1, 2);
+  return 0;
+}

--- a/regression/contracts/typed_target_fail_wrong_nof_operand/test.desc
+++ b/regression/contracts/typed_target_fail_wrong_nof_operand/test.desc
@@ -1,0 +1,11 @@
+CORE
+main.c
+--enforce-contract foo
+^main.c.*error: expected 1 argument for __CPROVER_typed_target, found 2$
+^CONVERSION ERROR$
+^EXIT=(1|64)$
+^SIGNAL=0$
+--
+--
+This test checks that incorrect uses of __CPROVER_typed_target are detected and
+rejected.

--- a/regression/contracts/typed_target_pointer/main.c
+++ b/regression/contracts/typed_target_pointer/main.c
@@ -1,0 +1,13 @@
+int foo(int *x, int *y)
+  __CPROVER_assigns(__CPROVER_typed_target(x), __CPROVER_typed_target(*y))
+{
+  return 0;
+}
+
+int main()
+{
+  int x;
+  int y;
+  int ret = foo(&x, &y);
+  return 0;
+}

--- a/regression/contracts/typed_target_pointer/test.desc
+++ b/regression/contracts/typed_target_pointer/test.desc
@@ -1,0 +1,14 @@
+CORE
+main.c
+--enforce-contract foo
+^\[foo.assigns.\d+\].* Check that __CPROVER_assignable\(\(void \*\)&x, .*, TRUE\) is valid: SUCCESS$
+^\[foo.assigns.\d+\].* Check that __CPROVER_assignable\(\(void \*\)&\(\*y\), .*, FALSE\) is valid: SUCCESS$
+^VERIFICATION SUCCESSFUL$
+^EXIT=0$
+^SIGNAL=0$
+--
+--
+This test checks __CPROVER_typed_target calls with pointer arguments
+get translated to __CPROVER_assignable(x, ... , TRUE),
+and that calls with non pointer arguments get translated to
+__CPROVER_assignable(x, ... , FALSE).

--- a/src/ansi-c/ansi_c_internal_additions.cpp
+++ b/src/ansi-c/ansi_c_internal_additions.cpp
@@ -216,6 +216,19 @@ void ansi_c_internal_additions(std::string &code)
     // This function needs to be declared, or otherwise can't be called
     // by the entry-point construction.
     "void " INITIALIZE_FUNCTION "(void);\n"
+    "\n"
+    // frame specifications for contracts
+    // Declares a range of bytes as assignable (internal representation)
+    "void " CPROVER_PREFIX "assignable(void *ptr,\n"
+    "  " CPROVER_PREFIX "size_t size,\n"
+    "  " CPROVER_PREFIX "bool is_ptr_to_ptr);\n"
+    // Declares a range of bytes as assignable
+    "void " CPROVER_PREFIX "object_upto(void *ptr, \n"
+    "  " CPROVER_PREFIX "size_t size);\n"
+    // Declares bytes from ptr to the end of the object as assignable
+    "void " CPROVER_PREFIX "object_from(void *ptr);\n"
+    // Declares the whole object pointer to by ptr
+    "void " CPROVER_PREFIX "object_whole(void *ptr);\n"
     "\n";
   // clang-format on
 

--- a/src/ansi-c/c_typecheck_base.h
+++ b/src/ansi-c/c_typecheck_base.h
@@ -146,12 +146,22 @@ protected:
   virtual void typecheck_start_thread(codet &code);
 
   // contracts
+  virtual void
+  typecheck_typed_target_call(side_effect_expr_function_callt &expr);
+  /// Checks that no history expr or return_value exists in expr
+  virtual void
+  check_history_expr_return_value(const exprt &expr, std::string &clause_type);
   virtual void typecheck_spec_function_pointer_obeys_contract(exprt &expr);
   virtual void typecheck_spec_assigns(exprt::operandst &targets);
-  virtual void typecheck_spec_assigns_condition(exprt &condition);
+  virtual void typecheck_conditional_targets(
+    exprt::operandst &targets,
+    const std::function<void(exprt &)> typecheck_target,
+    const std::string &clause_type);
+  virtual void typecheck_spec_condition(exprt &condition);
   virtual void typecheck_spec_assigns_target(exprt &target);
   virtual void typecheck_spec_loop_invariant(codet &code);
   virtual void typecheck_spec_decreases(codet &code);
+  virtual void throw_on_side_effects(const exprt &expr);
 
   bool break_is_allowed;
   bool continue_is_allowed;

--- a/src/ansi-c/cprover_builtin_headers.h
+++ b/src/ansi-c/cprover_builtin_headers.h
@@ -134,6 +134,9 @@ __CPROVER_bool __CPROVER_overflow_unary_minus();
 __CPROVER_bool __CPROVER_enum_is_in_range();
 
 // contracts
-__CPROVER_size_t __CPROVER_object_from(void *); 
-__CPROVER_size_t __CPROVER_object_slice(void *, __CPROVER_size_t);
+void __CPROVER_assignable(void *ptr, __CPROVER_size_t size,
+  __CPROVER_bool is_ptr_to_ptr);
+void __CPROVER_object_whole(void *ptr);
+void __CPROVER_object_from(void *ptr);
+void __CPROVER_object_upto(void *ptr, __CPROVER_size_t size);
 // clang-format on

--- a/src/linking/remove_internal_symbols.cpp
+++ b/src/linking/remove_internal_symbols.cpp
@@ -151,6 +151,10 @@ void remove_internal_symbols(
   special.insert(INITIALIZE_FUNCTION);
   special.insert(CPROVER_PREFIX "deallocated");
   special.insert(CPROVER_PREFIX "dead_object");
+  special.insert(CPROVER_PREFIX "assignable");
+  special.insert(CPROVER_PREFIX "object_upto");
+  special.insert(CPROVER_PREFIX "object_from");
+  special.insert(CPROVER_PREFIX "object_whole");
   special.insert(rounding_mode_identifier());
   special.insert("__new");
   special.insert("__new_array");


### PR DESCRIPTION
The first commit tags some JBMC tests as THOROUGH because they seem to exceed resources available for the ubuntu 18.04 target when building this PR

Add new functions to specify assignable targets in assigns clauses:
- add polymorhpic builtin __CPROVER_typed_target
- add builtin __CPROVER_assignable
- add builtin __CPROVER_object_whole
- add builtin __CPROVER_object_from
- add builtin __CPROVER_object_upto
- allow function call expressions as assigns
  clause targets as long as they are one of
  the new built-ins

Using __CPROVER_POINTER_OBJECT in assigns clauses is still allowed for now (needed for loop contracts),
will be deprecated in #7127.

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [x] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [n/a] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.
