### PR TITLE
CONTRACTS: Documenting semantic of loop invariant synthesizers

### DIFF
--- a/src/goto-instrument/synthesizer/enumerative_loop_invariant_synthesizer.h
+++ b/src/goto-instrument/synthesizer/enumerative_loop_invariant_synthesizer.h
@@ -21,8 +21,10 @@ Author: Qinheping Hu
 class messaget;
 
 /// Enumerative loop invariant synthesizers.
-/// It handles `goto_model` containing only checks instrumented by
+/// It is designed for `goto_model` containing only checks instrumented by
 /// `goto-instrument` with the `--pointer-check` flag.
+/// When other checks present, it will just enumerate candidates and check
+/// if they are valid.
 class enumerative_loop_invariant_synthesizert
   : public loop_invariant_synthesizer_baset
 {
@@ -34,6 +36,8 @@ public:
   {
   }
 
+  /// This synthesizer guarantees that, with the synthesized loop invariants,
+  /// all checks in the annotated GOTO program pass.
   invariant_mapt synthesize_all() override;
   exprt synthesize(loop_idt loop_id) override;
 

--- a/src/goto-instrument/synthesizer/loop_invariant_synthesizer_base.h
+++ b/src/goto-instrument/synthesizer/loop_invariant_synthesizer_base.h
@@ -38,12 +38,13 @@ public:
   }
   virtual ~loop_invariant_synthesizer_baset() = default;
 
-  /// Synthesize loop invariants with which all checks in `goto_model`
-  /// succeed. The result is a map from `loop_idt` ids of loops to `exprt`
-  /// the goto-expression representation of synthesized invariants.
+  /// Synthesize loop invariants that are inductive in the given GOTO program.
+  ///
+  /// The result is a map from `loop_idt` ids of loops to `exprt`
+  /// the GOTO-expression representation of synthesized invariants.
   virtual invariant_mapt synthesize_all() = 0;
 
-  /// Synthesize loop invariant for a specified loop in the `goto_model`
+  /// Synthesize loop invariant for a specified loop in the `goto_model`.
   virtual exprt synthesize(loop_idt) = 0;
 
 protected:


### PR DESCRIPTION
This PR contains only documentations. It explain the semantic of the loop-invariant synthesizer interface and the enumerative synthesizer. The motivating discussion is in the [PR#7007](https://github.com/diffblue/cbmc/pull/7007#discussion_r946117252).

> Yes, my original goals of this enumerative_loop_invariant_synthesizert were the scale B: synthesis with guarantees/hard constraints. You are right that there can be varied guarantees other than only B---all checks success.
So I think for the base class, we only expect the returned exprt are loop invariants in the sense that
> 1. the instrumented loop invariant checks success no matter other assertions fail or success---so we just ignore even if an assertion is false in the loop;
> 2. the base-case is from the whole program with a main function as entry.

>Derived classes can have their own guarantees. Each derived class should specify what the users can expect about the returned loop invariants. And users can choose which synthesizer to use with options under the --synthesize-loop-invariants flag.