### PR TITLE
Add address_of(array[index]) support to incremental SMT2 backend

### DIFF
--- a/regression/cbmc-incr-smt2/arrays/array_address_of.c
+++ b/regression/cbmc-incr-smt2/arrays/array_address_of.c
@@ -1,0 +1,8 @@
+int main()
+{
+  int example_array[10000];
+  __CPROVER_assert(
+    __CPROVER_OBJECT_SIZE(example_array) == 40000, "Array condition 1");
+  __CPROVER_assert(
+    __CPROVER_OBJECT_SIZE(example_array) == 40001, "Array condition 2");
+}

--- a/regression/cbmc-incr-smt2/arrays/array_address_of.desc
+++ b/regression/cbmc-incr-smt2/arrays/array_address_of.desc
@@ -1,0 +1,11 @@
+CORE
+array_address_of.c
+
+Passing problem to incremental SMT2 solving
+line \d+ Array condition 1: SUCCESS
+line \d+ Array condition 2: FAILURE
+^EXIT=10$
+^SIGNAL=0$
+--
+--
+Test of getting the size of an array resulting in a address_of(array[0]) expression.

--- a/regression/cbmc-primitives/exists_assume_6231/test2.desc
+++ b/regression/cbmc-primitives/exists_assume_6231/test2.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 test2.c
 --pointer-check
 ^EXIT=10$

--- a/regression/cbmc-primitives/implication_statement_checks_1/test.desc
+++ b/regression/cbmc-primitives/implication_statement_checks_1/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 --div-by-zero-check
 test.c
 ^EXIT=0$

--- a/regression/cbmc-primitives/r_w_ok_valid/test-no-cp.desc
+++ b/regression/cbmc-primitives/r_w_ok_valid/test-no-cp.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 --pointer-check --no-simplify --no-propagation
 ^EXIT=0$

--- a/regression/cbmc-primitives/same-object-01/test-no-cp.desc
+++ b/regression/cbmc-primitives/same-object-01/test-no-cp.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 --no-simplify --no-propagation
 ^EXIT=0$

--- a/regression/cbmc-primitives/same-object-02/test-no-cp.desc
+++ b/regression/cbmc-primitives/same-object-02/test-no-cp.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 --no-simplify --no-propagation
 ^EXIT=0$

--- a/regression/cbmc-primitives/same-object-04/test-no-cp.desc
+++ b/regression/cbmc-primitives/same-object-04/test-no-cp.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 --no-simplify --no-propagation
 ^EXIT=0$

--- a/src/solvers/smt2_incremental/convert_expr_to_smt.h
+++ b/src/solvers/smt2_incremental/convert_expr_to_smt.h
@@ -16,6 +16,11 @@ class typet;
 ///   stored as sort ast (abstract syntax tree).
 smt_sortt convert_type_to_smt_sort(const typet &type);
 
+/// \brief Lower the `address_of(array[idx])` sub expressions in \p expr to
+///   `idx + address_of(array)`, so that it can be fed to
+///   `convert_expr_to_smt`.
+exprt lower_address_of_array_index(exprt expr);
+
 /// \brief Converts the \p expression to an smt encoding of the same expression
 ///   stored as term ast (abstract syntax tree).
 smt_termt convert_expr_to_smt(


### PR DESCRIPTION
Add `address_of(array[index])` support to new incremental SMT2 backend.
Enabled all `cbmc-primitives` regressions tests working with new SMT2 backend.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
