### PR TITLE
protect typet::subtype() const

### DIFF
--- a/jbmc/unit/java-testing-utils/require_goto_statements.cpp
+++ b/jbmc/unit/java-testing-utils/require_goto_statements.cpp
@@ -424,7 +424,7 @@ const irep_idt &require_goto_statements::require_struct_component_assignment(
     require_goto_statements::require_declaration_of_name(
       symbol_identifier, entry_point_instructions);
   const typet &component_type =
-    to_pointer_type(component_declaration.symbol().type()).subtype();
+    to_pointer_type(component_declaration.symbol().type()).base_type();
   REQUIRE(component_type.id() == ID_struct_tag);
   const auto &component_struct =
     ns.follow_tag(to_struct_tag_type(component_type));
@@ -480,7 +480,7 @@ require_goto_statements::require_struct_array_component_assignment(
   REQUIRE(component_assignment_rhs.type().id() == ID_pointer);
   REQUIRE(
     to_struct_tag_type(
-      to_pointer_type(component_assignment_rhs.type()).subtype())
+      to_pointer_type(component_assignment_rhs.type()).base_type())
       .get(ID_identifier) == array_type_name);
 
   // Get the tmp_object name and find assignments to it, there should be only
@@ -501,7 +501,8 @@ require_goto_statements::require_struct_array_component_assignment(
   PRECONDITION(
     array_component_reference_assignment_rhs.type().id() == ID_pointer);
   const typet &array =
-    to_pointer_type(array_component_reference_assignment_rhs.type()).subtype();
+    to_pointer_type(array_component_reference_assignment_rhs.type())
+      .base_type();
   PRECONDITION(is_java_array_tag(array.get(ID_identifier)));
   REQUIRE(array.get(ID_identifier) == array_type_name);
 

--- a/jbmc/unit/java-testing-utils/require_type.cpp
+++ b/jbmc/unit/java-testing-utils/require_type.cpp
@@ -23,7 +23,7 @@ pointer_typet require_type::require_pointer(
   const pointer_typet &pointer = to_pointer_type(type);
 
   if(subtype)
-    REQUIRE(pointer.subtype() == subtype.value());
+    REQUIRE(pointer.base_type() == subtype.value());
 
   return pointer;
 }
@@ -155,8 +155,8 @@ bool require_java_generic_type_argument_expectation(
   {
     REQUIRE(!is_java_generic_parameter(type_argument));
     REQUIRE(
-      to_struct_tag_type(type_argument.subtype()).get_identifier() ==
-      expected.description);
+      to_struct_tag_type(to_pointer_type(type_argument).base_type())
+        .get_identifier() == expected.description);
     return true;
   }
   }
@@ -248,7 +248,7 @@ const typet &require_type::require_java_non_generic_type(
   REQUIRE(!is_java_generic_parameter(type));
   REQUIRE(!is_java_generic_type(type));
   if(expect_subtype)
-    REQUIRE(type.subtype() == expect_subtype.value());
+    REQUIRE(to_pointer_type(type).base_type() == expect_subtype.value());
   return type;
 }
 
@@ -474,7 +474,7 @@ pointer_typet
 require_type::require_pointer_to_tag(const typet &type, const irep_idt &tag)
 {
   const auto pointer_type = require_type::require_pointer(type, {});
-  require_type::require_struct_tag(pointer_type.subtype(), tag);
+  require_type::require_struct_tag(pointer_type.base_type(), tag);
   return pointer_type;
 }
 

--- a/src/cpp/cpp_typecheck_resolve.cpp
+++ b/src/cpp/cpp_typecheck_resolve.cpp
@@ -269,10 +269,14 @@ exprt cpp_typecheck_resolvet::convert_identifier(
       {
         // use this->...
         assert(this_expr.type().id()==ID_pointer);
-        object=exprt(ID_dereference, this_expr.type().subtype());
+        object =
+          exprt(ID_dereference, to_pointer_type(this_expr.type()).base_type());
         object.copy_to_operands(this_expr);
-        object.type().set(ID_C_constant,
-                          this_expr.type().subtype().get_bool(ID_C_constant));
+        object.type().set(
+          ID_C_constant,
+          to_pointer_type(this_expr.type())
+            .base_type()
+            .get_bool(ID_C_constant));
         object.set(ID_C_lvalue, true);
         object.add_source_location()=source_location;
       }
@@ -1838,19 +1842,24 @@ void cpp_typecheck_resolvet::guess_template_args(
   else if(is_reference(template_type) ||
           is_rvalue_reference(template_type))
   {
-    guess_template_args(template_type.subtype(), desired_type);
+    guess_template_args(
+      to_reference_type(template_type).base_type(), desired_type);
   }
   else if(template_type.id()==ID_pointer)
   {
     if(desired_type.id() == ID_pointer)
-      guess_template_args(template_type.subtype(), desired_type.subtype());
+      guess_template_args(
+        to_pointer_type(template_type).base_type(),
+        to_pointer_type(desired_type).base_type());
   }
   else if(template_type.id()==ID_array)
   {
     if(desired_type.id() == ID_array)
     {
       // look at subtype first
-      guess_template_args(template_type.subtype(), desired_type.subtype());
+      guess_template_args(
+        to_array_type(template_type).element_type(),
+        to_array_type(desired_type).element_type());
 
       // size (e.g., buffer size guessing)
       guess_template_args(
@@ -2134,7 +2143,8 @@ bool cpp_typecheck_resolvet::disambiguate_functions(
       if(type.return_type().id() == ID_constructor)
       {
         // it's a constructor
-        const typet &object_type=parameter.type().subtype();
+        const typet &object_type =
+          to_pointer_type(parameter.type()).base_type();
         symbol_exprt object(irep_idt(), object_type);
         object.set(ID_C_lvalue, true);
 

--- a/src/util/type.h
+++ b/src/util/type.h
@@ -45,6 +45,8 @@ public:
   }
 #endif
 
+  // Deliberately protected -- use type-specific accessor methods instead.
+protected:
   const typet &subtype() const
   {
     if(get_sub().empty())
@@ -52,6 +54,8 @@ public:
     return static_cast<const typet &>(get_sub().front());
   }
 
+public:
+  // This method will be protected eventually.
   typet &subtype()
   {
     subt &sub=get_sub();


### PR DESCRIPTION
Long-term readers of this sequence of PRs will be pleased to note that this is the final one for the `const` variant.

The non-const variant is to follow.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
