### PR TITLE
remove uses of typet::subtype() nonconst

### DIFF
--- a/jbmc/src/java_bytecode/java_bytecode_convert_class.cpp
+++ b/jbmc/src/java_bytecode/java_bytecode_convert_class.cpp
@@ -964,9 +964,11 @@ void add_java_array_types(symbol_tablet &symbol_table)
     code_declt declare_index(index_symexpr);
 
     dereference_exprt old_cell(
-      plus_exprt(old_data, index_symexpr), old_data.type().subtype());
+      plus_exprt(old_data, index_symexpr),
+      to_type_with_subtype(old_data.type()).subtype());
     dereference_exprt new_cell(
-      plus_exprt(new_data, index_symexpr), new_data.type().subtype());
+      plus_exprt(new_data, index_symexpr),
+      to_type_with_subtype(new_data.type()).subtype());
 
     const code_fort copy_loop = code_fort::from_index_bounds(
       from_integer(0, index_symexpr.type()),

--- a/jbmc/src/java_bytecode/java_bytecode_typecheck_type.cpp
+++ b/jbmc/src/java_bytecode/java_bytecode_typecheck_type.cpp
@@ -31,11 +31,11 @@ void java_bytecode_typecheckt::typecheck_type(typet &type)
   }
   else if(type.id()==ID_pointer)
   {
-    typecheck_type(type.subtype());
+    typecheck_type(to_pointer_type(type).base_type());
   }
   else if(type.id()==ID_array)
   {
-    typecheck_type(type.subtype());
+    typecheck_type(to_array_type(type).element_type());
     typecheck_expr(to_array_type(type).size());
   }
   else if(type.id()==ID_code)

--- a/jbmc/src/java_bytecode/java_object_factory.cpp
+++ b/jbmc/src/java_bytecode/java_object_factory.cpp
@@ -1158,7 +1158,9 @@ static void allocate_nondet_length_array(
   side_effect_exprt java_new_array(ID_java_new_array, lhs.type(), location);
   java_new_array.copy_to_operands(length_sym_expr);
   java_new_array.set(ID_length_upper_bound, max_length_expr);
-  java_new_array.type().subtype().set(ID_element_type, element_type);
+  to_type_with_subtype(java_new_array.type())
+    .subtype()
+    .set(ID_element_type, element_type);
   code_frontend_assignt assign(lhs, java_new_array);
   assign.add_source_location() = location;
   assignments.add(assign);

--- a/jbmc/src/java_bytecode/java_pointer_casts.cpp
+++ b/jbmc/src/java_bytecode/java_pointer_casts.cpp
@@ -37,7 +37,7 @@ bool find_superclass_with_type(
   assert(ptr.type().id()==ID_pointer);
   while(true)
   {
-    const typet ptr_base=ns.follow(ptr.type().subtype());
+    const typet ptr_base = ns.follow(to_pointer_type(ptr.type()).base_type());
 
     if(ptr_base.id()!=ID_struct)
       return false;

--- a/jbmc/src/java_bytecode/java_types.cpp
+++ b/jbmc/src/java_bytecode/java_types.cpp
@@ -660,7 +660,7 @@ optionalt<typet> java_type_from_string(
       if(subtype_letter == 'a')
       {
         return java_reference_array_type(
-          to_struct_tag_type(subtype->subtype()));
+          to_struct_tag_type(to_java_reference_type(*subtype).base_type()));
       }
       else
         return java_array_type(subtype_letter);
@@ -684,7 +684,8 @@ optionalt<typet> java_type_from_string(
     return java_generic_parametert(
       type_var_name,
       to_struct_tag_type(
-        java_type_from_string("Ljava/lang/Object;")->subtype()));
+        to_java_reference_type(*java_type_from_string("Ljava/lang/Object;"))
+          .base_type()));
   }
   case 'L':
     {
@@ -785,7 +786,8 @@ std::vector<typet> java_generic_type_from_string(
     java_generic_parametert type_var_type(
       type_var_name,
       to_struct_tag_type(
-        java_type_from_string(bound_type, class_name)->subtype()));
+        to_java_reference_type(*java_type_from_string(bound_type, class_name))
+          .base_type()));
 
     types.push_back(type_var_type);
     signature=signature.substr(var_sep+1, std::string::npos);
@@ -807,7 +809,8 @@ static std::string slash_to_dot(const std::string &src)
 struct_tag_typet java_classname(const std::string &id)
 {
   if(!id.empty() && id[0]=='[')
-    return to_struct_tag_type(java_type_from_string(id)->subtype());
+    return to_struct_tag_type(
+      to_java_reference_type(*java_type_from_string(id)).base_type());
 
   std::string class_name=id;
 

--- a/src/ansi-c/c_typecast.cpp
+++ b/src/ansi-c/c_typecast.cpp
@@ -422,7 +422,7 @@ void c_typecastt::implicit_typecast_arithmetic(
   case PTR:
     if(expr.type().id() == ID_array)
     {
-      new_type = pointer_type(expr.type().subtype());
+      new_type = pointer_type(to_array_type(expr.type()).element_type());
       break;
     }
     return;
@@ -535,7 +535,7 @@ void c_typecastt::implicit_typecast_followed(
       src_type.id() == ID_pointer &&
       to_pointer_type(src_type).base_type().get_bool(ID_C_constant))
     {
-      src_type_no_const.subtype().remove(ID_C_constant);
+      to_pointer_type(src_type_no_const).base_type().remove(ID_C_constant);
     }
 
     // Check union members.

--- a/src/ansi-c/c_typecheck_code.cpp
+++ b/src/ansi-c/c_typecheck_code.cpp
@@ -1008,7 +1008,7 @@ void c_typecheck_baset::typecheck_spec_function_pointer_obeys_contract(
 
   if(
     function_pointer.type().id() != ID_pointer ||
-    to_pointer_type(function_pointer.type()).subtype().id() != ID_code)
+    to_pointer_type(function_pointer.type()).base_type().id() != ID_code)
   {
     error().source_location = expr.source_location();
     error() << "the first parameter of the clause must be a function pointer "
@@ -1047,7 +1047,7 @@ void c_typecheck_baset::typecheck_spec_function_pointer_obeys_contract(
     address_of_contract.id() != ID_address_of ||
     to_address_of_expr(address_of_contract).object().id() != ID_symbol ||
     address_of_contract.type().id() != ID_pointer ||
-    to_pointer_type(address_of_contract.type()).subtype().id() != ID_code)
+    to_pointer_type(address_of_contract.type()).base_type().id() != ID_code)
   {
     error().source_location = expr.source_location();
     error() << "the second parameter of the requires_contract/ensures_contract "

--- a/src/ansi-c/c_typecheck_initializer.cpp
+++ b/src/ansi-c/c_typecheck_initializer.cpp
@@ -149,7 +149,8 @@ exprt c_typecheck_baset::do_initializer_rec(
 
     string_constantt tmp1=to_string_constant(value);
     // adjust char type
-    tmp1.type().subtype() = to_array_type(full_type).element_type();
+    to_array_type(tmp1.type()).element_type() =
+      to_array_type(full_type).element_type();
 
     exprt tmp2=tmp1.to_array_expr();
 

--- a/src/ansi-c/expr2c.cpp
+++ b/src/ansi-c/expr2c.cpp
@@ -1784,9 +1784,9 @@ std::string expr2ct::convert_constant(
   else if(type.id()==ID_c_enum ||
           type.id()==ID_c_enum_tag)
   {
-    typet c_enum_type=
-      type.id()==ID_c_enum?to_c_enum_type(type):
-                           ns.follow_tag(to_c_enum_tag_type(type));
+    c_enum_typet c_enum_type = type.id() == ID_c_enum
+                                 ? to_c_enum_type(type)
+                                 : ns.follow_tag(to_c_enum_tag_type(type));
 
     if(c_enum_type.id()!=ID_c_enum)
       return convert_norep(src, precedence);
@@ -1804,8 +1804,9 @@ std::string expr2ct::convert_constant(
     }
 
     // lookup failed or enum is to be output as integer
-    const bool is_signed = c_enum_type.subtype().id() == ID_signedbv;
-    const auto width = to_bitvector_type(c_enum_type.subtype()).get_width();
+    const bool is_signed = c_enum_type.underlying_type().id() == ID_signedbv;
+    const auto width =
+      to_bitvector_type(c_enum_type.underlying_type()).get_width();
 
     std::string value_as_string =
       integer2string(bvrep2integer(value, width, is_signed));

--- a/src/ansi-c/literals/convert_string_literal.cpp
+++ b/src/ansi-c/literals/convert_string_literal.cpp
@@ -125,9 +125,8 @@ exprt convert_string_literal(const std::string &src)
 
     exprt result=exprt(ID_array);
     result.set(ID_C_string_constant, true);
-    result.type()=typet(ID_array);
-    result.type().subtype()=subtype;
-    result.type().set(ID_size, from_integer(value.size(), c_index_type()));
+    result.type() =
+      array_typet(subtype, from_integer(value.size(), c_index_type()));
 
     result.operands().resize(value.size());
     for(std::size_t i=0; i<value.size(); i++)

--- a/src/cpp/cpp_template_type.h
+++ b/src/cpp/cpp_template_type.h
@@ -60,7 +60,7 @@ inline const typet &template_subtype(const typet &type)
 inline typet &template_subtype(typet &type)
 {
   if(type.id()==ID_template)
-    return type.subtype();
+    return to_template_type(type).subtype();
 
   return type;
 }

--- a/src/goto-instrument/dump_c.cpp
+++ b/src/goto-instrument/dump_c.cpp
@@ -1341,7 +1341,7 @@ void dump_ct::cleanup_expr(exprt &expr)
     // add a typecast for NULL
     else if(
       u.op().id() == ID_constant && is_null_pointer(to_constant_expr(u.op())) &&
-      u.op().type().subtype().id() == ID_empty)
+      to_pointer_type(u.op().type()).base_type().id() == ID_empty)
     {
       const struct_union_typet::componentt &comp=
         u_type_f.get_component(u.get_component_name());

--- a/src/goto-instrument/function.cpp
+++ b/src/goto-instrument/function.cpp
@@ -35,8 +35,8 @@ code_function_callt function_to_call(
   if(s_it==symbol_table.symbols.end())
   {
     // not there
-    typet p=pointer_type(char_type());
-    p.subtype().set(ID_C_constant, true);
+    auto p = pointer_type(char_type());
+    p.base_type().set(ID_C_constant, true);
 
     const code_typet function_type({code_typet::parametert(p)}, empty_typet());
 

--- a/src/goto-instrument/goto_program2code.cpp
+++ b/src/goto-instrument/goto_program2code.cpp
@@ -1592,7 +1592,7 @@ void goto_program2codet::remove_const(typet &type)
     remove_const(symbol.type);
   }
   else if(type.id()==ID_array)
-    remove_const(type.subtype());
+    remove_const(to_array_type(type).element_type());
   else if(type.id()==ID_struct ||
           type.id()==ID_union)
   {

--- a/src/goto-programs/class_identifier.cpp
+++ b/src/goto-programs/class_identifier.cpp
@@ -65,7 +65,7 @@ exprt get_class_identifier_field(
   PRECONDITION(this_expr_in.type().id() == ID_pointer);
 
   exprt this_expr=this_expr_in;
-  const auto &points_to=this_expr.type().subtype();
+  const auto &points_to = to_pointer_type(this_expr.type()).base_type();
   if(points_to==empty_typet())
     this_expr=typecast_exprt(this_expr, pointer_type(suggested_type));
   const dereference_exprt deref{this_expr};

--- a/src/goto-programs/goto_convert_side_effect.cpp
+++ b/src/goto-programs/goto_convert_side_effect.cpp
@@ -216,8 +216,8 @@ void goto_convertt::remove_pre(
 
   if(constant_type.id() == ID_complex)
   {
-    exprt real = from_integer(1, constant_type.subtype());
-    exprt imag = from_integer(0, constant_type.subtype());
+    exprt real = from_integer(1, to_complex_type(constant_type).subtype());
+    exprt imag = from_integer(0, to_complex_type(constant_type).subtype());
     constant = complex_exprt(real, imag, to_complex_type(constant_type));
   }
   else
@@ -311,8 +311,8 @@ void goto_convertt::remove_post(
 
   if(constant_type.id() == ID_complex)
   {
-    exprt real = from_integer(1, constant_type.subtype());
-    exprt imag = from_integer(0, constant_type.subtype());
+    exprt real = from_integer(1, to_complex_type(constant_type).subtype());
+    exprt imag = from_integer(0, to_complex_type(constant_type).subtype());
     constant = complex_exprt(real, imag, to_complex_type(constant_type));
   }
   else

--- a/src/goto-programs/remove_complex.cpp
+++ b/src/goto-programs/remove_complex.cpp
@@ -248,16 +248,17 @@ static void remove_complex(typet &type)
           type.id()==ID_vector ||
           type.id()==ID_array)
   {
-    remove_complex(type.subtype());
+    remove_complex(to_type_with_subtype(type).subtype());
   }
   else if(type.id()==ID_complex)
   {
-    remove_complex(type.subtype());
+    remove_complex(to_complex_type(type).subtype());
 
     // Replace by a struct with two members.
     // The real part goes first.
     struct_typet struct_type(
-      {{ID_real, type.subtype()}, {ID_imag, type.subtype()}});
+      {{ID_real, to_complex_type(type).subtype()},
+       {ID_imag, to_complex_type(type).subtype()}});
     struct_type.add_source_location()=type.source_location();
 
     type = std::move(struct_type);

--- a/src/goto-programs/remove_vector.cpp
+++ b/src/goto-programs/remove_vector.cpp
@@ -320,7 +320,7 @@ static void remove_vector(typet &type)
           type.id()==ID_complex ||
           type.id()==ID_array)
   {
-    remove_vector(type.subtype());
+    remove_vector(to_type_with_subtype(type).subtype());
   }
   else if(type.id()==ID_vector)
   {

--- a/src/goto-symex/build_goto_trace.cpp
+++ b/src/goto-symex/build_goto_trace.cpp
@@ -187,8 +187,9 @@ replace_nondet_in_type(typet &type, const decision_proceduret &solver)
     array_typet &array_type = to_array_type(type);
     array_type.size() = solver.get(array_type.size());
   }
+
   if(type.has_subtype())
-    replace_nondet_in_type(type.subtype(), solver);
+    replace_nondet_in_type(to_type_with_subtype(type).subtype(), solver);
 }
 
 /// Replace nondet values that appear in the type of \p expr and its

--- a/src/goto-symex/symex_dereference.cpp
+++ b/src/goto-symex/symex_dereference.cpp
@@ -400,7 +400,8 @@ void goto_symext::dereference_rec(
       tc_op.id() == ID_address_of &&
       to_address_of_expr(tc_op).object().type().id() == ID_array &&
       expr.type() ==
-        pointer_type(to_address_of_expr(tc_op).object().type().subtype()))
+        pointer_type(to_array_type(to_address_of_expr(tc_op).object().type())
+                       .element_type()))
     {
       expr = address_of_exprt(index_exprt(
         to_address_of_expr(tc_op).object(), from_integer(0, c_index_type())));

--- a/src/pointer-analysis/add_failed_symbols.cpp
+++ b/src/pointer-analysis/add_failed_symbols.cpp
@@ -11,6 +11,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "add_failed_symbols.h"
 
+#include <util/c_types.h>
 #include <util/namespace.h>
 #include <util/std_expr.h>
 #include <util/symbol.h>
@@ -41,7 +42,7 @@ void add_failed_symbol(symbolt &symbol, symbol_table_baset &symbol_table)
     new_symbol.mode=symbol.mode;
     new_symbol.base_name=failed_symbol_id(symbol.base_name);
     new_symbol.name=failed_symbol_id(symbol.name);
-    new_symbol.type=symbol.type.subtype();
+    new_symbol.type = to_pointer_type(symbol.type).base_type();
     new_symbol.value.make_nil();
     new_symbol.type.set(ID_C_is_failed_symbol, true);
 

--- a/src/pointer-analysis/value_set_fi.cpp
+++ b/src/pointer-analysis/value_set_fi.cpp
@@ -467,8 +467,7 @@ void value_set_fit::get_value_set_rec(
     }
     else if(v_it!=values.end())
     {
-      typet t("#REF#");
-      t.subtype() = expr.type();
+      type_with_subtypet t("#REF#", expr.type());
       symbol_exprt sym(ident, t);
       insert(dest, sym, mp_integer{0});
       return;

--- a/src/solvers/strings/string_constraint_generator_main.cpp
+++ b/src/solvers/strings/string_constraint_generator_main.cpp
@@ -388,7 +388,8 @@ string_constraint_generatort::add_axioms_for_char_at(
 {
   PRECONDITION(f.arguments().size() == 2);
   array_string_exprt str = get_string_expr(array_pool, f.arguments()[0]);
-  symbol_exprt char_sym = fresh_symbol("char", str.type().subtype());
+  symbol_exprt char_sym =
+    fresh_symbol("char", to_array_type(str.type()).element_type());
   string_constraintst constraints;
   constraints.existential = {equal_exprt(char_sym, str[f.arguments()[1]])};
   return {std::move(char_sym), std::move(constraints)};

--- a/src/solvers/strings/string_refinement.cpp
+++ b/src/solvers/strings/string_refinement.cpp
@@ -1886,8 +1886,8 @@ exprt string_refinementt::get(const exprt &expr) const
 
       if(const auto n = numeric_cast<std::size_t>(length))
       {
-        const interval_sparse_arrayt sparse_array(
-          from_integer(CHARACTER_FOR_UNKNOWN, arr.type().subtype()));
+        const interval_sparse_arrayt sparse_array(from_integer(
+          CHARACTER_FOR_UNKNOWN, to_array_type(arr.type()).element_type()));
         return sparse_array.concretize(*n, length.type());
       }
     }

--- a/src/util/rename_symbol.cpp
+++ b/src/util/rename_symbol.cpp
@@ -125,7 +125,7 @@ bool rename_symbolt::rename(typet &dest) const
   bool result=true;
 
   if(dest.has_subtype())
-    if(!rename(dest.subtype()))
+    if(!rename(to_type_with_subtype(dest).subtype()))
       result=false;
 
   for(typet &subtype : to_type_with_subtypes(dest).subtypes())

--- a/src/util/replace_symbol.cpp
+++ b/src/util/replace_symbol.cpp
@@ -204,7 +204,7 @@ bool replace_symbolt::replace(typet &dest) const
   bool result=true;
 
   if(dest.has_subtype())
-    if(!replace(dest.subtype()))
+    if(!replace(to_type_with_subtype(dest).subtype()))
       result=false;
 
   for(typet &subtype : to_type_with_subtypes(dest).subtypes())

--- a/src/util/simplify_expr_pointer.cpp
+++ b/src/util/simplify_expr_pointer.cpp
@@ -348,11 +348,12 @@ simplify_exprt::simplify_pointer_offset(const pointer_offset_exprt &expr)
     if(ptr_expr.size()!=1 || int_expr.empty())
       return unchanged(expr);
 
-    typet pointer_sub_type=ptr_expr.front().type().subtype();
-    if(pointer_sub_type.id()==ID_empty)
-      pointer_sub_type=char_type();
+    typet pointer_base_type =
+      to_pointer_type(ptr_expr.front().type()).base_type();
+    if(pointer_base_type.id() == ID_empty)
+      pointer_base_type = char_type();
 
-    auto element_size = pointer_offset_size(pointer_sub_type, ns);
+    auto element_size = pointer_offset_size(pointer_base_type, ns);
 
     if(!element_size.has_value())
       return unchanged(expr);


### PR DESCRIPTION
This commit replaces uses of the nonconst `typet::subtype()` by casting
the type to the applicable subtype, and then using the appropriate accessor
method.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
