### PR TITLE
Improve slack notifications on releases for Linux packages

### DIFF
--- a/.github/workflows/regular-release.yaml
+++ b/.github/workflows/regular-release.yaml
@@ -105,3 +105,4 @@ jobs:
           SLACK_COLOR: ${{ job.status }}
           SLACK_USERNAME: Github Actions CI bot
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_MESSAGE: "${{ job.status == 'success' && 'Successful creation of new CBMC release page' || 'Failed to create new CBMC release page' }}"

--- a/.github/workflows/release-packages.yaml
+++ b/.github/workflows/release-packages.yaml
@@ -78,6 +78,7 @@ jobs:
           SLACK_COLOR: ${{ job.status }}
           SLACK_USERNAME: Github Actions CI bot
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_MESSAGE: 'Ubuntu 20.04 package built and uploaded successfully'
 
   ubuntu-18_04-package:
     runs-on: ubuntu-18.04
@@ -164,6 +165,7 @@ jobs:
           SLACK_COLOR: ${{ job.status }}
           SLACK_USERNAME: Github Actions CI bot
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_MESSAGE: 'Ubuntu 18.04 package built and uploaded successfully'
 
 
   homebrew-pr:
@@ -315,3 +317,4 @@ jobs:
           SLACK_COLOR: ${{ job.status }}
           SLACK_USERNAME: Github Actions CI bot
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_MESSAGE: 'Docker Image built and submitted to DockerHub successfully'

--- a/.github/workflows/release-packages.yaml
+++ b/.github/workflows/release-packages.yaml
@@ -79,7 +79,7 @@ jobs:
           SLACK_COLOR: ${{ job.status }}
           SLACK_USERNAME: Github Actions CI bot
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-          SLACK_MESSAGE: 'Ubuntu 20.04 package built and uploaded successfully'
+          SLACK_MESSAGE: "${{ job.status == 'success' && 'Ubuntu 20.04 package built and uploaded successfully' || 'Ubuntu 20.04 package build failed' }}"
 
   ubuntu-18_04-package:
     runs-on: ubuntu-18.04
@@ -167,7 +167,7 @@ jobs:
           SLACK_COLOR: ${{ job.status }}
           SLACK_USERNAME: Github Actions CI bot
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-          SLACK_MESSAGE: 'Ubuntu 18.04 package built and uploaded successfully'
+          SLACK_MESSAGE: "${{ job.status == 'success' && 'Ubuntu 18.04 package built and uploaded successfully' || 'Ubuntu 18.04 package build failed' }}"
 
 
   homebrew-pr:
@@ -320,4 +320,4 @@ jobs:
           SLACK_COLOR: ${{ job.status }}
           SLACK_USERNAME: Github Actions CI bot
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-          SLACK_MESSAGE: 'Docker Image built and submitted to DockerHub successfully'
+          SLACK_MESSAGE: "${{ job.status == 'success' && 'Docker Image built and submitted to DockerHub successfully' || 'Docker Image build failed' }}"

--- a/.github/workflows/release-packages.yaml
+++ b/.github/workflows/release-packages.yaml
@@ -73,6 +73,7 @@ jobs:
           asset_content_type: application/x-deb
       - name: Slack notification of CI status
         uses: rtCamp/action-slack-notify@v2
+        if: success() || failure()
         env:
           SLACK_CHANNEL: team_open_source
           SLACK_COLOR: ${{ job.status }}
@@ -160,6 +161,7 @@ jobs:
           asset_content_type: application/x-deb
       - name: Slack notification of CI status
         uses: rtCamp/action-slack-notify@v2
+        if: success() || failure()
         env:
           SLACK_CHANNEL: team_open_source
           SLACK_COLOR: ${{ job.status }}
@@ -312,6 +314,7 @@ jobs:
           docker logout
       - name: Slack notification of CI status
         uses: rtCamp/action-slack-notify@v2
+        if: success() || failure()
         env:
           SLACK_CHANNEL: team_open_source
           SLACK_COLOR: ${{ job.status }}


### PR DESCRIPTION
Right now we have some basic integration between Slack and Github actions
to notify us in case the release artefacts don't build correctly.

This improves the presentation of the notifications on the three (Linux)
platforms where the action is working reliably for now.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
