### PR TITLE
Fix macOS home-brew PR slack notifications for new release

### DIFF
--- a/.github/workflows/release-packages.yaml
+++ b/.github/workflows/release-packages.yaml
@@ -183,13 +183,20 @@ jobs:
           brew bump-formula-pr --tag "$RELEASE_TAG" --revision "$GITHUB_SHA" cbmc
         env:
           HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.DB_CI_CPROVER_ACCESS_TOKEN }}
+      - name: Checkout CBMC project source code to obtain access to scripts
+        if: always()
+        uses: actions/checkout@v2
+      - name: Install golang toolchain to run the notification step
+        if: always()
+        run: brew install go
       - name: Slack notification of CI status
-        uses: rtCamp/action-slack-notify@v2
+        if: success() || failure()
         env:
           SLACK_CHANNEL: team_open_source
           SLACK_COLOR: ${{ job.status }}
           SLACK_USERNAME: Github Actions CI bot
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+        run: go run scripts/slack_notification_action.go
 
   windows-msi-package:
     runs-on: windows-2019

--- a/scripts/slack_notification_action.go
+++ b/scripts/slack_notification_action.go
@@ -192,7 +192,8 @@ func main() {
 	case "failure":
 		color = "danger"
 	default:
-		color = envOr(EnvSlackColor, "good")
+		// yellow for default, unless environment variable present
+		color = envOr(EnvSlackColor, "#FFFF00")
 	}
 
 	msg := Webhook{
@@ -208,7 +209,7 @@ func main() {
 				AuthorName: envOr(EnvGithubActor, ""),
 				AuthorLink: os.Getenv("GITHUB_SERVER_URL") + "/" + os.Getenv(EnvGithubActor),
 				AuthorIcon: os.Getenv("GITHUB_SERVER_URL") + "/" + os.Getenv(EnvGithubActor) + ".png?size=32",
-				Footer:     envOr(EnvSlackFooter, "<https://github.com/rtCamp/github-actions-library|Powered By rtCamp's GitHub Actions Library>"),
+				Footer:     envOr(EnvSlackFooter, ""),
 				Fields:     fields,
 			},
 		},

--- a/scripts/slack_notification_action.go
+++ b/scripts/slack_notification_action.go
@@ -1,0 +1,246 @@
+// Code taken from https://github.com/rtCamp/action-slack-notify
+// at revision c753c784. MIT Licensed, Copyright 2019
+
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+)
+
+const (
+	EnvSlackWebhook   = "SLACK_WEBHOOK"
+	EnvSlackIcon      = "SLACK_ICON"
+	EnvSlackIconEmoji = "SLACK_ICON_EMOJI"
+	EnvSlackChannel   = "SLACK_CHANNEL"
+	EnvSlackTitle     = "SLACK_TITLE"
+	EnvSlackMessage   = "SLACK_MESSAGE"
+	EnvSlackColor     = "SLACK_COLOR"
+	EnvSlackUserName  = "SLACK_USERNAME"
+	EnvSlackFooter    = "SLACK_FOOTER"
+	EnvGithubActor    = "GITHUB_ACTOR"
+	EnvSiteName       = "SITE_NAME"
+	EnvHostName       = "HOST_NAME"
+	EnvMinimal        = "MSG_MINIMAL"
+	EnvSlackLinkNames = "SLACK_LINK_NAMES"
+)
+
+type Webhook struct {
+	Text        string       `json:"text,omitempty"`
+	UserName    string       `json:"username,omitempty"`
+	IconURL     string       `json:"icon_url,omitempty"`
+	IconEmoji   string       `json:"icon_emoji,omitempty"`
+	Channel     string       `json:"channel,omitempty"`
+	LinkNames   string       `json:"link_names,omitempty"`
+	UnfurlLinks bool         `json:"unfurl_links"`
+	Attachments []Attachment `json:"attachments,omitempty"`
+}
+
+type Attachment struct {
+	Fallback   string  `json:"fallback"`
+	Pretext    string  `json:"pretext,omitempty"`
+	Color      string  `json:"color,omitempty"`
+	AuthorName string  `json:"author_name,omitempty"`
+	AuthorLink string  `json:"author_link,omitempty"`
+	AuthorIcon string  `json:"author_icon,omitempty"`
+	Footer     string  `json:"footer,omitempty"`
+	Fields     []Field `json:"fields,omitempty"`
+}
+
+type Field struct {
+	Title string `json:"title,omitempty"`
+	Value string `json:"value,omitempty"`
+	Short bool   `json:"short,omitempty"`
+}
+
+func main() {
+	endpoint := os.Getenv(EnvSlackWebhook)
+	if endpoint == "" {
+		fmt.Fprintln(os.Stderr, "URL is required")
+		os.Exit(1)
+	}
+	text := os.Getenv(EnvSlackMessage)
+	if text == "" {
+		fmt.Fprintln(os.Stderr, "Message is required")
+		os.Exit(1)
+	}
+	if strings.HasPrefix(os.Getenv("GITHUB_WORKFLOW"), ".github") {
+		os.Setenv("GITHUB_WORKFLOW", "Link to action run")
+	}
+
+	long_sha := os.Getenv("GITHUB_SHA")
+	commit_sha := long_sha[0:6]
+
+	minimal := os.Getenv(EnvMinimal)
+	fields := []Field{}
+	if minimal == "true" {
+		mainFields := []Field{
+			{
+				Title: os.Getenv(EnvSlackTitle),
+				Value: envOr(EnvSlackMessage, "EOM"),
+				Short: false,
+			},
+		}
+		fields = append(mainFields, fields...)
+	} else if minimal != "" {
+		requiredFields := strings.Split(minimal, ",")
+		mainFields := []Field{
+			{
+				Title: os.Getenv(EnvSlackTitle),
+				Value: envOr(EnvSlackMessage, "EOM"),
+				Short: false,
+			},
+		}
+		for _, requiredField := range requiredFields {
+			switch strings.ToLower(requiredField) {
+			case "ref":
+				field := []Field{
+					{
+						Title: "Ref",
+						Value: os.Getenv("GITHUB_REF"),
+						Short: true,
+					},
+				}
+				mainFields = append(field, mainFields...)
+			case "event":
+				field := []Field{
+					{
+						Title: "Event",
+						Value: os.Getenv("GITHUB_EVENT_NAME"),
+						Short: true,
+					},
+				}
+				mainFields = append(field, mainFields...)
+			case "actions url":
+				field := []Field{
+					{
+						Title: "Actions URL",
+						Value: "<" + os.Getenv("GITHUB_SERVER_URL") + "/" + os.Getenv("GITHUB_REPOSITORY") + "/commit/" + os.Getenv("GITHUB_SHA") + "/checks|" + os.Getenv("GITHUB_WORKFLOW") + ">",
+						Short: true,
+					},
+				}
+				mainFields = append(field, mainFields...)
+			case "commit":
+				field := []Field{
+					{
+						Title: "Commit",
+						Value: "<" + os.Getenv("GITHUB_SERVER_URL") + "/" + os.Getenv("GITHUB_REPOSITORY") + "/commit/" + os.Getenv("GITHUB_SHA") + "|" + commit_sha + ">",
+						Short: true,
+					},
+				}
+				mainFields = append(field, mainFields...)
+			}
+		}
+		fields = append(mainFields, fields...)
+	} else {
+		mainFields := []Field{
+			{
+				Title: "Ref",
+				Value: os.Getenv("GITHUB_REF"),
+				Short: true,
+			}, {
+				Title: "Event",
+				Value: os.Getenv("GITHUB_EVENT_NAME"),
+				Short: true,
+			},
+			{
+				Title: "Actions URL",
+				Value: "<" + os.Getenv("GITHUB_SERVER_URL") + "/" + os.Getenv("GITHUB_REPOSITORY") + "/commit/" + os.Getenv("GITHUB_SHA") + "/checks|" + os.Getenv("GITHUB_WORKFLOW") + ">",
+				Short: true,
+			},
+			{
+				Title: "Commit",
+				Value: "<" + os.Getenv("GITHUB_SERVER_URL") + "/" + os.Getenv("GITHUB_REPOSITORY") + "/commit/" + os.Getenv("GITHUB_SHA") + "|" + commit_sha + ">",
+				Short: true,
+			},
+			{
+				Title: os.Getenv(EnvSlackTitle),
+				Value: envOr(EnvSlackMessage, "EOM"),
+				Short: false,
+			},
+		}
+		fields = append(mainFields, fields...)
+	}
+
+	hostName := os.Getenv(EnvHostName)
+	if hostName != "" {
+		newfields := []Field{
+			{
+				Title: os.Getenv("SITE_TITLE"),
+				Value: os.Getenv(EnvSiteName),
+				Short: true,
+			},
+			{
+				Title: os.Getenv("HOST_TITLE"),
+				Value: os.Getenv(EnvHostName),
+				Short: true,
+			},
+		}
+		fields = append(newfields, fields...)
+	}
+
+	color := ""
+	switch os.Getenv(EnvSlackColor) {
+	case "success":
+		color = "good"
+	case "cancelled":
+		color = "#808080"
+	case "failure":
+		color = "danger"
+	default:
+		color = envOr(EnvSlackColor, "good")
+	}
+
+	msg := Webhook{
+		UserName:  os.Getenv(EnvSlackUserName),
+		IconURL:   os.Getenv(EnvSlackIcon),
+		IconEmoji: os.Getenv(EnvSlackIconEmoji),
+		Channel:   os.Getenv(EnvSlackChannel),
+		LinkNames: os.Getenv(EnvSlackLinkNames),
+		Attachments: []Attachment{
+			{
+				Fallback:   envOr(EnvSlackMessage, "GITHUB_ACTION="+os.Getenv("GITHUB_ACTION")+" \n GITHUB_ACTOR="+os.Getenv("GITHUB_ACTOR")+" \n GITHUB_EVENT_NAME="+os.Getenv("GITHUB_EVENT_NAME")+" \n GITHUB_REF="+os.Getenv("GITHUB_REF")+" \n GITHUB_REPOSITORY="+os.Getenv("GITHUB_REPOSITORY")+" \n GITHUB_WORKFLOW="+os.Getenv("GITHUB_WORKFLOW")),
+				Color:      color,
+				AuthorName: envOr(EnvGithubActor, ""),
+				AuthorLink: os.Getenv("GITHUB_SERVER_URL") + "/" + os.Getenv(EnvGithubActor),
+				AuthorIcon: os.Getenv("GITHUB_SERVER_URL") + "/" + os.Getenv(EnvGithubActor) + ".png?size=32",
+				Footer:     envOr(EnvSlackFooter, "<https://github.com/rtCamp/github-actions-library|Powered By rtCamp's GitHub Actions Library>"),
+				Fields:     fields,
+			},
+		},
+	}
+
+	if err := send(endpoint, msg); err != nil {
+		fmt.Fprintf(os.Stderr, "Error sending message: %s\n", err)
+		os.Exit(2)
+	}
+}
+
+func envOr(name, def string) string {
+	if d, ok := os.LookupEnv(name); ok {
+		return d
+	}
+	return def
+}
+
+func send(endpoint string, msg Webhook) error {
+	enc, err := json.Marshal(msg)
+	if err != nil {
+		return err
+	}
+	b := bytes.NewBuffer(enc)
+	res, err := http.Post(endpoint, "application/json", b)
+	if err != nil {
+		return err
+	}
+
+	if res.StatusCode >= 299 {
+		return fmt.Errorf("Error on message: %s\n", res.Status)
+	}
+	fmt.Println(res.Status)
+	return nil
+}


### PR DESCRIPTION
Currently, the slack notification action we use to notify
us in case jobs fail doesn't work on macOS and Windows (because
of a docker issue bootstrapping an Alpine linux environment on
top of those, see https://github.com/rtCamp/action-slack-notify/issues/22).

This is allowing us to do that, by cloning the action source code
into our `scripts/` folder, and then running it using a downloaded
`golang` toolchain - instead of needing to run the whole action on
top of docker.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
