### PR TITLE
Perform remove_returns pass before constant_propagator

### DIFF
--- a/regression/goto-instrument/constant-propagation-function-call/main.c
+++ b/regression/goto-instrument/constant-propagation-function-call/main.c
@@ -1,0 +1,17 @@
+#include <assert.h>
+int ab, bc;
+int f(int x)
+{
+  ab = 1 + 1 + 1 + 1;
+  bc = ab + x;
+  return ab + bc;
+}
+int main()
+{
+  int a;
+  a = -4;
+  int b;
+  b = nondet();
+  a = f(a);
+  assert(!(0 <= a && a < 5 && 0 <= b && b < 5));
+}

--- a/regression/goto-instrument/constant-propagation-function-call/test.desc
+++ b/regression/goto-instrument/constant-propagation-function-call/test.desc
@@ -3,6 +3,7 @@ main.c
 --constant-propagator
 ^EXIT=10$
 ^SIGNAL=0$
+Removing returns
 VERIFICATION FAILED
 ASSIGN main\:\:1\:\:a \:\= 4
 ASSERT ¬\(main::1::b ≥ 0\) ∨ main::1::b ≥ 5

--- a/regression/goto-instrument/constant-propagation-function-call/test.desc
+++ b/regression/goto-instrument/constant-propagation-function-call/test.desc
@@ -1,0 +1,16 @@
+CORE
+main.c
+--constant-propagator
+^EXIT=10$
+^SIGNAL=0$
+VERIFICATION FAILED
+ASSIGN main\:\:1\:\:a \:\= 4
+ASSERT ¬\(main::1::b ≥ 0\) ∨ main::1::b ≥ 5
+--
+^warning: ignoring
+ASSERT true
+--
+This tests that constants are propagated through function calls, correctly
+taking into account the return value. Constant propagation should result in
+simplifying away the conditions in the assertion on `a` but not the conditions
+on `b`.

--- a/src/goto-instrument/goto_instrument_parse_options.cpp
+++ b/src/goto-instrument/goto_instrument_parse_options.cpp
@@ -1285,7 +1285,7 @@ void goto_instrument_parse_optionst::instrument_goto_program()
   if(cmdline.isset("constant-propagator"))
   {
     do_indirect_call_and_rtti_removal();
-    remove_returns(goto_model);
+    do_remove_returns();
 
     log.status() << "Propagating Constants" << messaget::eom;
 

--- a/src/goto-instrument/goto_instrument_parse_options.cpp
+++ b/src/goto-instrument/goto_instrument_parse_options.cpp
@@ -1285,6 +1285,7 @@ void goto_instrument_parse_optionst::instrument_goto_program()
   if(cmdline.isset("constant-propagator"))
   {
     do_indirect_call_and_rtti_removal();
+    remove_returns(goto_model);
 
     log.status() << "Propagating Constants" << messaget::eom;
 


### PR DESCRIPTION
The constant_propagator does not handle returns and gives unexpected
results for examples including returns. Carrying out the remove_returns
pass before contant propagation should resolve this issue.

This relates to https://github.com/diffblue/cbmc/issues/7041
<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
