### PR TITLE
Fix wrong name ```__CPROVER_invariant``` of invariant clauses

### DIFF
--- a/regression/crangler/loop-invariant-01/main.c
+++ b/regression/crangler/loop-invariant-01/main.c
@@ -1,0 +1,27 @@
+int foo(int *arr, int size)
+{
+  arr[0] = 0;
+  arr[size - 1] = 0;
+
+  for(int i = 0; i < 2; i++)
+  {
+    arr[i] = 0;
+  }
+
+  int i = 0;
+  while(i < 2)
+  {
+    arr[i] = 0;
+    i++;
+  }
+
+  return size < 10 ? 0 : arr[5];
+}
+
+int main()
+{
+  int arr[10];
+  int retval = foo(arr, 10);
+  __CPROVER_assert(retval == arr[5], "should succeed");
+  return 0;
+}

--- a/regression/crangler/loop-invariant-01/test.desc
+++ b/regression/crangler/loop-invariant-01/test.desc
@@ -1,0 +1,10 @@
+CORE
+test.json
+
+^\s+while\(i \< 2\) \_\_CPROVER\_loop\_invariant
+^EXIT=0$
+^SIGNAL=0$
+--
+^\s+for\(int i = 0; i \< 2; i\+\+\) \_\_CPROVER
+--
+Annotate loop invariant only to the for-loop.

--- a/regression/crangler/loop-invariant-01/test.json
+++ b/regression/crangler/loop-invariant-01/test.json
@@ -1,0 +1,13 @@
+{
+  "sources": [
+    "main.c"
+  ],
+  "functions": [
+    {
+      "foo": [
+        "while 1 invariant 1==1"
+      ]
+    }
+  ],
+  "output": "stdout"
+}

--- a/regression/crangler/loop-invariant-02/main.c
+++ b/regression/crangler/loop-invariant-02/main.c
@@ -1,0 +1,26 @@
+int foo(int *arr, int size)
+{
+  arr[0] = 0;
+  arr[size - 1] = 0;
+  for(int i = 0; i < 2; i++)
+  {
+    arr[i] = 0;
+  }
+
+  int i = 0;
+  while(i < 2)
+  {
+    arr[i] = 0;
+    i++;
+  }
+
+  return size < 10 ? 0 : arr[5];
+}
+
+int main()
+{
+  int arr[10];
+  int retval = foo(arr, 10);
+  __CPROVER_assert(retval == arr[5], "should succeed");
+  return 0;
+}

--- a/regression/crangler/loop-invariant-02/test.desc
+++ b/regression/crangler/loop-invariant-02/test.desc
@@ -1,0 +1,10 @@
+CORE
+test.json
+
+^\s+for\(int i = 0; i \< 2; i\+\+\) \_\_CPROVER\_loop\_invariant
+^EXIT=0$
+^SIGNAL=0$
+--
+^\s+while\(i \< 2\) \_\_CPROVER
+--
+Annotate loop invariant only to the while-loop.

--- a/regression/crangler/loop-invariant-02/test.json
+++ b/regression/crangler/loop-invariant-02/test.json
@@ -1,0 +1,13 @@
+{
+  "sources": [
+    "main.c"
+  ],
+  "functions": [
+    {
+      "foo": [
+        "for 1 invariant 1==1"
+      ]
+    }
+  ],
+  "output": "stdout"
+}

--- a/src/crangler/c_wrangler.cpp
+++ b/src/crangler/c_wrangler.cpp
@@ -456,8 +456,8 @@ static void mangle_function(
             auto t_end = match_bracket(t, '(', ')');
             for(; t != t_end; t++)
               out << t->text;
-            out << ' ' << CPROVER_PREFIX << "invariant(" << defines(invariant)
-                << ')';
+            out << ' ' << CPROVER_PREFIX << "loop_invariant("
+                << defines(invariant) << ')';
           }
         }
       }


### PR DESCRIPTION
<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

This commit replaces the wrong name ```__CPROVER_invariant``` of invariant clauses with the correct name ```__CPROVER_loop_invariant```.

- [x] Each commit message has a non-empty body, explaining why the change was made.
n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
