### PR TITLE
Allow characters with value >= 128 in XML output

### DIFF
--- a/regression/cbmc/xml-escaping/debug_output.desc
+++ b/regression/cbmc/xml-escaping/debug_output.desc
@@ -1,0 +1,13 @@
+CORE
+main.c
+--verbosity 10 --xml-ui
+^EXIT=10$
+^SIGNAL=0$
+VERIFICATION FAILED
+⇔ false
+\¬main\:\:1\:\:x\!0\@1\#1
+--
+XML does not support escaping non-printable character
+--
+Test that running cbmc with --verbosity 10 and --xml-ui does not violate any
+xml printing invariants.

--- a/regression/cbmc/xml-escaping/main.c
+++ b/regression/cbmc/xml-escaping/main.c
@@ -1,0 +1,8 @@
+#include <assert.h>
+
+int main(void)
+{
+  __CPROVER_bool x;
+  __CPROVER_assume(!x);
+  assert(0);
+}

--- a/src/util/xml.cpp
+++ b/src/util/xml.cpp
@@ -108,7 +108,7 @@ void xmlt::escape(const std::string &s, std::ostream &out)
 
     default:
       DATA_INVARIANT(
-        ch >= ' ',
+        static_cast<unsigned char>(ch) >= 32u,
         "XML does not support escaping non-printable character " +
           std::to_string((unsigned char)ch));
       out << ch;
@@ -149,7 +149,7 @@ void xmlt::escape_attribute(const std::string &s, std::ostream &out)
 
     default:
       DATA_INVARIANT(
-        ch >= ' ',
+        static_cast<unsigned char>(ch) >= 32u,
         "XML does not support escaping non-printable character " +
           std::to_string((unsigned char)ch));
       out << ch;


### PR DESCRIPTION
These values are used as part of printable characters which should be allowed in XML output. This invariant was previously violated for characters such as `¬` and `⇔` which are included in the output when cbmc is invoked with `--verbosity 10 --xml-ui`. This was due to the comparison formerly being a signed comparison. So byte values in the range 128 to 255 were treated as values in the -128 to -1 range which are less than ` ` which has value 32.

This PR should address issue https://github.com/diffblue/cbmc/issues/7038
<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
