### PR TITLE
Warn on usage of `goto-instrument --constant-propagator`

### DIFF
--- a/src/goto-instrument/goto_instrument_parse_options.cpp
+++ b/src/goto-instrument/goto_instrument_parse_options.cpp
@@ -1288,6 +1288,11 @@ void goto_instrument_parse_optionst::instrument_goto_program()
     do_remove_returns();
 
     log.status() << "Propagating Constants" << messaget::eom;
+    log.warning() << "**** WARNING: Constant propagation as performed by "
+                     "goto-instrument is not expected to be sound. Do not use "
+                     "--constant-propagator if soundness is important for your "
+                     "use case."
+                  << messaget::eom;
 
     constant_propagator_ait constant_propagator_ai(goto_model);
     remove_skip(goto_model);


### PR DESCRIPTION
According to the doxygen in `analyses/constant_propagator.h`, this is "A simple, unsound constant propagator." It is worth warning users so that it is not accidentally applied to use cases where soundness is important.

This PR relates to the following issue - https://github.com/diffblue/cbmc/issues/7041

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
