### PR TITLE
SMT2 backend: remove extra whitespace

### DIFF
--- a/src/solvers/smt2/smt2_conv.cpp
+++ b/src/solvers/smt2/smt2_conv.cpp
@@ -2137,20 +2137,25 @@ void smt2_convt::convert_expr(const exprt &expr)
     else if(quantifier_expr.id() == ID_exists)
       out << "(exists ";
 
-    out << "( ";
+    out << '(';
+    bool first = true;
     for(const auto &bound : quantifier_expr.variables())
     {
-      out << "(";
+      if(first)
+        first = false;
+      else
+        out << ' ';
+      out << '(';
       convert_expr(bound);
-      out << " ";
+      out << ' ';
       convert_type(bound.type());
-      out << ") ";
+      out << ')';
     }
     out << ") ";
 
     convert_expr(quantifier_expr.where());
 
-    out << ")";
+    out << ')';
   }
   else if(expr.id()==ID_vector)
   {
@@ -2383,7 +2388,7 @@ void smt2_convt::convert_typecast(const typecast_exprt &expr)
     convert_expr(src);
     out << " ";
     convert_expr(from_integer(0, src_type));
-    out << ")) "; // not, =
+    out << "))"; // not, =
     out << " (_ bv1 " << to_width << ")";
     out << " (_ bv0 " << to_width << ")";
     out << ")"; // ite


### PR DESCRIPTION
This removes redundant whitespace in the output of the SMT2 backend.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
