### PR TITLE
bv_utilst::sign_extension, zero_extension and zeros can be static

### DIFF
--- a/src/solvers/flattening/bv_utils.h
+++ b/src/solvers/flattening/bv_utils.h
@@ -179,17 +179,17 @@ public:
   static bvt
   extension(const bvt &bv, std::size_t new_size, representationt rep);
 
-  bvt sign_extension(const bvt &bv, std::size_t new_size)
+  static bvt sign_extension(const bvt &bv, std::size_t new_size)
   {
     return extension(bv, new_size, representationt::SIGNED);
   }
 
-  bvt zero_extension(const bvt &bv, std::size_t new_size)
+  static bvt zero_extension(const bvt &bv, std::size_t new_size)
   {
     return extension(bv, new_size, representationt::UNSIGNED);
   }
 
-  bvt zeros(std::size_t new_size) const
+  static bvt zeros(std::size_t new_size)
   {
     bvt result;
     result.resize(new_size, const_literal(false));


### PR DESCRIPTION
These methods do not use any state of `bv_utilst` and can therefore be static.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/aThe feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
