### PR TITLE
add three doubly-linked list predicates

### DIFF
--- a/src/ansi-c/c_typecheck_expr.cpp
+++ b/src/ansi-c/c_typecheck_expr.cpp
@@ -2316,6 +2316,90 @@ exprt c_typecheck_baset::do_special_functions(
 
     return std::move(is_list_expr);
   }
+  else if(identifier == CPROVER_PREFIX "is_dll")
+  {
+    if(expr.arguments().size() != 1)
+    {
+      error().source_location = f_op.source_location();
+      error() << "is_dll expects one operand" << eom;
+      throw 0;
+    }
+
+    typecheck_function_call_arguments(expr);
+
+    if(
+      expr.arguments()[0].type().id() != ID_pointer ||
+      to_pointer_type(expr.arguments()[0].type()).base_type().id() !=
+        ID_struct_tag)
+    {
+      error().source_location = expr.arguments()[0].source_location();
+      error() << "is_dll expects a struct-pointer operand" << eom;
+      throw 0;
+    }
+
+    predicate_exprt is_dll_expr("is_dll");
+    is_dll_expr.operands() = expr.arguments();
+    is_dll_expr.add_source_location() = source_location;
+
+    return std::move(is_dll_expr);
+  }
+  else if(identifier == CPROVER_PREFIX "is_cyclic_dll")
+  {
+    if(expr.arguments().size() != 1)
+    {
+      error().source_location = f_op.source_location();
+      error() << "is_cyclic_dll expects one operand" << eom;
+      throw 0;
+    }
+
+    typecheck_function_call_arguments(expr);
+
+    if(
+      expr.arguments()[0].type().id() != ID_pointer ||
+      to_pointer_type(expr.arguments()[0].type()).base_type().id() !=
+        ID_struct_tag)
+    {
+      error().source_location = expr.arguments()[0].source_location();
+      error() << "is_cyclic_dll expects a struct-pointer operand" << eom;
+      throw 0;
+    }
+
+    predicate_exprt is_cyclic_dll_expr("is_cyclic_dll");
+    is_cyclic_dll_expr.operands() = expr.arguments();
+    is_cyclic_dll_expr.add_source_location() = source_location;
+
+    return std::move(is_cyclic_dll_expr);
+  }
+  else if(identifier == CPROVER_PREFIX "is_sentinel_dll")
+  {
+    if(expr.arguments().size() != 2 && expr.arguments().size() != 3)
+    {
+      error().source_location = f_op.source_location();
+      error() << "is_sentinel_dll expects two or three operands" << eom;
+      throw 0;
+    }
+
+    typecheck_function_call_arguments(expr);
+
+    for(const auto &argument : expr.arguments())
+    {
+      if(
+        argument.type().id() != ID_pointer ||
+        to_pointer_type(argument.type()).base_type().id() != ID_struct_tag)
+      {
+        error().source_location = expr.arguments()[0].source_location();
+        error() << "is_sentinel_dll_node expects struct-pointer operands"
+                << eom;
+        throw 0;
+      }
+    }
+
+    predicate_exprt is_sentinel_dll_expr("is_sentinel_dll");
+    is_sentinel_dll_expr.operands() = expr.arguments();
+    is_sentinel_dll_expr.add_source_location() = source_location;
+
+    return std::move(is_sentinel_dll_expr);
+  }
   else if(identifier == CPROVER_PREFIX "is_cstring")
   {
     if(expr.arguments().size() != 1)

--- a/src/ansi-c/cprover_builtin_headers.h
+++ b/src/ansi-c/cprover_builtin_headers.h
@@ -12,6 +12,9 @@ __CPROVER_bool __CPROVER_is_invalid_pointer(const void *);
 _Bool __CPROVER_is_zero_string(const void *);
 // a singly-linked null-terminated dynamically-allocated list
 __CPROVER_bool __CPROVER_is_list();
+__CPROVER_bool __CPROVER_is_dll();
+__CPROVER_bool __CPROVER_is_cyclic_dll();
+__CPROVER_bool __CPROVER_is_sentinel_dll();
 __CPROVER_size_t __CPROVER_zero_string_length(const void *);
 __CPROVER_bool __CPROVER_is_cstring(const char *);
 __CPROVER_size_t __CPROVER_cstrlen(const char *);


### PR DESCRIPTION
This adds three predicates to the C frontend, for the benefit of the CHC encoder.  They indicate 1) doubly-linked dynamically allocated null-terminated lists, 2) doubly-linked dynamically allocated cyclic lists, and 3) doubly-linked lists with dynamically allocated inner nodes and head and tail sentinel nodes.

Given the specific nature of these predicates, we'll want to look into replacing them by a mechanism that allows extending the front-end with user-defined predicates.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
