### PR TITLE
Add support for subtracting a constant value from a pointer in the conversion code of new SMT backend

### DIFF
--- a/unit/solvers/smt2_incremental/convert_expr_to_smt.cpp
+++ b/unit/solvers/smt2_incremental/convert_expr_to_smt.cpp
@@ -557,20 +557,34 @@ TEST_CASE(
         smt_term_four_32bit));
   }
 
-  SECTION(
-    "Ensure that conversion of a minus node with only one operand"
-    "being a pointer fails")
+  SECTION("Subtraction of an integer value from a pointer")
   {
     // (*int32_t)a - 2
-    const cbmc_invariants_should_throwt invariants_throw;
-    // We don't support that - look at the test above.
+
+    // NOTE: This may look similar to the above, but the above test
+    // is a desugared version of this construct - with the difference
+    // being that there exist cases where the construct is not desugared,
+    // so we can still come across this expression as an input to
+    // convert_expr_to_smt.
+    const auto two_bvint = from_integer(2, signedbv_typet{pointer_width});
     const auto pointer_arith_expr = minus_exprt{pointer_a, two_bvint};
-    REQUIRE_THROWS_MATCHES(
-      test.convert(pointer_arith_expr),
-      invariant_failedt,
-      invariant_failure_containing(
-        "convert_expr_to_smt::minus_exprt doesn't handle expressions where"
-        "only one operand is a pointer - this is because these expressions"));
+
+    const symbol_tablet symbol_table;
+    const namespacet ns{symbol_table};
+    track_expression_objects(pointer_arith_expr, ns, test.object_map);
+    associate_pointer_sizes(
+      pointer_arith_expr,
+      ns,
+      test.pointer_sizes,
+      test.object_map,
+      test.object_size_function.make_application);
+    INFO("Input expr: " + pointer_arith_expr.pretty(2, 0));
+    const auto constructed_term = test.convert(pointer_arith_expr);
+    const auto expected_term = smt_bit_vector_theoryt::subtract(
+      smt_term_a,
+      smt_bit_vector_theoryt::multiply(
+        smt_term_two_32bit, smt_term_four_32bit));
+    REQUIRE(constructed_term == expected_term);
   }
 
   SECTION("Subtraction of two pointer arguments")

--- a/unit/solvers/smt2_incremental/convert_expr_to_smt.cpp
+++ b/unit/solvers/smt2_incremental/convert_expr_to_smt.cpp
@@ -587,6 +587,21 @@ TEST_CASE(
     REQUIRE(constructed_term == expected_term);
   }
 
+  SECTION("Subtraction of pointer from integer")
+  {
+    // 2 - (*int32_t)a -- Semantically void expression, need to make sure
+    // we throw in this case.
+    const cbmc_invariants_should_throwt invariants_throw;
+
+    const auto pointer_arith_expr = minus_exprt{two_bvint, pointer_a};
+
+    REQUIRE_THROWS_MATCHES(
+      test.convert(pointer_arith_expr),
+      invariant_failedt,
+      invariant_failure_containing("minus expressions of pointer and integer "
+                                   "expect lhs to be the pointer"));
+  }
+
   SECTION("Subtraction of two pointer arguments")
   {
     // (int32_t *)a - (int32_t *)b


### PR DESCRIPTION
Previously we didn't support expressions of the form `a - 3` where `a` is a pointer,
because we thought that it wouldn't be possible to get this code as input. Some regression tests however showed us that this assumption was incorrect, so now we needed to add support for this.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
