### PR TITLE
CONTRACTS: Support slice targets in loop assigns clauses

### DIFF
--- a/regression/contracts-dfcc/assigns_enforce_address_of/test.desc
+++ b/regression/contracts-dfcc/assigns_enforce_address_of/test.desc
@@ -3,7 +3,7 @@ main.c
 --dfcc main --enforce-contract foo
 ^EXIT=(1|64)$
 ^SIGNAL=0$
-^.*error: assigns clause target must be a non-void lvalue, a call to __CPROVER_POINTER_OBJECT or a call to a function returning void$
+^.*error: assigns clause target must be a non-void lvalue or a call to a function returning void$
 ^CONVERSION ERROR$
 --
 --

--- a/regression/contracts-dfcc/assigns_enforce_conditional_non_lvalue_target/test.desc
+++ b/regression/contracts-dfcc/assigns_enforce_conditional_non_lvalue_target/test.desc
@@ -1,7 +1,7 @@
 CORE
 main.c
 --enforce-contract foo
-^.*error: assigns clause target must be a non-void lvalue, a call to __CPROVER_POINTER_OBJECT or a call to a function returning void$
+^.*error: assigns clause target must be a non-void lvalue or a call to a function returning void$
 ^CONVERSION ERROR
 ^EXIT=(1|64)$
 ^SIGNAL=0$

--- a/regression/contracts-dfcc/assigns_enforce_conditional_non_lvalue_target_list/test.desc
+++ b/regression/contracts-dfcc/assigns_enforce_conditional_non_lvalue_target_list/test.desc
@@ -1,7 +1,7 @@
 CORE
 main.c
 --enforce-contract foo
-^.*error: assigns clause target must be a non-void lvalue, a call to __CPROVER_POINTER_OBJECT or a call to a function returning void$
+^.*error: assigns clause target must be a non-void lvalue or a call to a function returning void$
 ^CONVERSION ERROR
 ^EXIT=(1|64)$
 ^SIGNAL=0$

--- a/regression/contracts-dfcc/assigns_enforce_literal/test.desc
+++ b/regression/contracts-dfcc/assigns_enforce_literal/test.desc
@@ -3,7 +3,7 @@ main.c
 --dfcc main --enforce-contract foo
 ^EXIT=(1|64)$
 ^SIGNAL=0$
-^.*error: assigns clause target must be a non-void lvalue, a call to __CPROVER_POINTER_OBJECT or a call to a function returning void$
+^.*error: assigns clause target must be a non-void lvalue or a call to a function returning void$
 ^CONVERSION ERROR$
 --
 --

--- a/regression/contracts-dfcc/assigns_enforce_side_effects_2/test.desc
+++ b/regression/contracts-dfcc/assigns_enforce_side_effects_2/test.desc
@@ -3,7 +3,7 @@ main.c
 --dfcc main --enforce-contract foo
 ^EXIT=(1|64)$
 ^SIGNAL=0$
-^.*error: assigns clause target must be a non-void lvalue, a call to __CPROVER_POINTER_OBJECT or a call to a function returning void$
+^.*error: assigns clause target must be a non-void lvalue or a call to a function returning void$
 ^CONVERSION ERROR$
 --
 --

--- a/regression/contracts-dfcc/assigns_enforce_side_effects_3/test.desc
+++ b/regression/contracts-dfcc/assigns_enforce_side_effects_3/test.desc
@@ -3,7 +3,7 @@ main.c
 --dfcc main --enforce-contract foo
 ^EXIT=(1|64)$
 ^SIGNAL=0$
-^.*error: assigns clause target must be a non-void lvalue, a call to __CPROVER_POINTER_OBJECT or a call to a function returning void$
+^.*error: assigns clause target must be a non-void lvalue or a call to a function returning void$
 ^CONVERSION ERROR$
 --
 --

--- a/regression/contracts-dfcc/assigns_type_checking_invalid_case_01/test.desc
+++ b/regression/contracts-dfcc/assigns_type_checking_invalid_case_01/test.desc
@@ -4,6 +4,6 @@ main.c
 ^EXIT=(1|64)$
 ^SIGNAL=0$
 ^CONVERSION ERROR$
-^.*error: assigns clause target must be a non-void lvalue, a call to __CPROVER_POINTER_OBJECT or a call to a function returning void$
+^.*error: assigns clause target must be a non-void lvalue or a call to a function returning void$
 --
 Checks whether type checking rejects literal constants in assigns clause.

--- a/regression/contracts-dfcc/reject_history_expr_in_assigns_clause/test.desc
+++ b/regression/contracts-dfcc/reject_history_expr_in_assigns_clause/test.desc
@@ -1,7 +1,7 @@
 CORE
 main.c
 --enforce-contract foo
-^main.c.*error: assigns clause target must be a non-void lvalue, a call to __CPROVER_POINTER_OBJECT or a call to a function returning void$
+^.*error: assigns clause target must be a non-void lvalue or a call to a function returning void$
 ^CONVERSION ERROR$
 ^EXIT=(1|64)$
 ^SIGNAL=0$

--- a/regression/contracts/assigns_enforce_address_of/test.desc
+++ b/regression/contracts/assigns_enforce_address_of/test.desc
@@ -3,7 +3,7 @@ main.c
 --enforce-contract foo
 ^EXIT=(1|64)$
 ^SIGNAL=0$
-^.*error: assigns clause target must be a non-void lvalue, a call to __CPROVER_POINTER_OBJECT or a call to a function returning void$
+^.*error: assigns clause target must be a non-void lvalue or a call to a function returning void$
 ^CONVERSION ERROR$
 --
 --

--- a/regression/contracts/assigns_enforce_conditional_non_lvalue_target/test.desc
+++ b/regression/contracts/assigns_enforce_conditional_non_lvalue_target/test.desc
@@ -1,7 +1,7 @@
 CORE
 main.c
 --enforce-contract foo
-^.*error: assigns clause target must be a non-void lvalue, a call to __CPROVER_POINTER_OBJECT or a call to a function returning void$
+^.*error: assigns clause target must be a non-void lvalue or a call to a function returning void$
 ^CONVERSION ERROR
 ^EXIT=(1|64)$
 ^SIGNAL=0$

--- a/regression/contracts/assigns_enforce_conditional_non_lvalue_target_list/test.desc
+++ b/regression/contracts/assigns_enforce_conditional_non_lvalue_target_list/test.desc
@@ -1,7 +1,7 @@
 CORE
 main.c
 --enforce-contract foo
-^.*error: assigns clause target must be a non-void lvalue, a call to __CPROVER_POINTER_OBJECT or a call to a function returning void$
+^.*error: assigns clause target must be a non-void lvalue or a call to a function returning void$
 ^CONVERSION ERROR
 ^EXIT=(1|64)$
 ^SIGNAL=0$

--- a/regression/contracts/assigns_enforce_literal/test.desc
+++ b/regression/contracts/assigns_enforce_literal/test.desc
@@ -3,7 +3,7 @@ main.c
 --enforce-contract foo
 ^EXIT=(1|64)$
 ^SIGNAL=0$
-^.*error: assigns clause target must be a non-void lvalue, a call to __CPROVER_POINTER_OBJECT or a call to a function returning void$
+^.*error: assigns clause target must be a non-void lvalue or a call to a function returning void$
 ^CONVERSION ERROR$
 --
 --

--- a/regression/contracts/assigns_enforce_side_effects_2/test.desc
+++ b/regression/contracts/assigns_enforce_side_effects_2/test.desc
@@ -3,7 +3,7 @@ main.c
 --enforce-contract foo
 ^EXIT=(1|64)$
 ^SIGNAL=0$
-^.*error: assigns clause target must be a non-void lvalue, a call to __CPROVER_POINTER_OBJECT or a call to a function returning void$
+^.*error: assigns clause target must be a non-void lvalue or a call to a function returning void$
 ^CONVERSION ERROR$
 --
 --

--- a/regression/contracts/assigns_enforce_side_effects_3/test.desc
+++ b/regression/contracts/assigns_enforce_side_effects_3/test.desc
@@ -3,7 +3,7 @@ main.c
 --enforce-contract foo
 ^EXIT=(1|64)$
 ^SIGNAL=0$
-^.*error: assigns clause target must be a non-void lvalue, a call to __CPROVER_POINTER_OBJECT or a call to a function returning void$
+^.*error: assigns clause target must be a non-void lvalue or a call to a function returning void$
 ^CONVERSION ERROR$
 --
 --

--- a/regression/contracts/assigns_type_checking_invalid_case_01/test.desc
+++ b/regression/contracts/assigns_type_checking_invalid_case_01/test.desc
@@ -4,6 +4,6 @@ main.c
 ^EXIT=(1|64)$
 ^SIGNAL=0$
 ^CONVERSION ERROR$
-^.*error: assigns clause target must be a non-void lvalue, a call to __CPROVER_POINTER_OBJECT or a call to a function returning void$
+^.*error: assigns clause target must be a non-void lvalue or a call to a function returning void$
 --
 Checks whether type checking rejects literal constants in assigns clause.

--- a/regression/contracts/invar_havoc_dynamic_array/main.c
+++ b/regression/contracts/invar_havoc_dynamic_array/main.c
@@ -10,7 +10,7 @@ void main()
 
   for(unsigned i = 0; i < SIZE; i++)
     // clang-format off
-    __CPROVER_assigns(i, __CPROVER_POINTER_OBJECT(data))
+    __CPROVER_assigns(i, __CPROVER_object_whole(data))
     __CPROVER_loop_invariant(i <= SIZE)
     // clang-format on
     {

--- a/regression/contracts/invar_havoc_static_array/main.c
+++ b/regression/contracts/invar_havoc_static_array/main.c
@@ -10,7 +10,7 @@ void main()
 
   for(unsigned i = 0; i < SIZE; i++)
     // clang-format off
-    __CPROVER_assigns(i, __CPROVER_POINTER_OBJECT(data))
+    __CPROVER_assigns(i, __CPROVER_object_whole(data))
     __CPROVER_loop_invariant(i <= SIZE)
     // clang-format on
     {

--- a/regression/contracts/invar_havoc_static_multi-dim_array_partial_const_idx/main.c
+++ b/regression/contracts/invar_havoc_static_multi-dim_array_partial_const_idx/main.c
@@ -11,7 +11,7 @@ void main()
   data[4][5][6] = 0;
 
   for(unsigned i = 0; i < SIZE; i++)
-    __CPROVER_assigns(i, __CPROVER_POINTER_OBJECT(data))
+    __CPROVER_assigns(i, __CPROVER_object_whole(data))
       __CPROVER_loop_invariant(i <= SIZE)
     {
       data[4][i][6] = 1;

--- a/regression/contracts/loop_assigns-01/main.c
+++ b/regression/contracts/loop_assigns-01/main.c
@@ -16,7 +16,7 @@ void main()
   b->data[5] = 0;
   for(unsigned i = 0; i < SIZE; i++)
     // clang-format off
-    __CPROVER_assigns(i, __CPROVER_POINTER_OBJECT(b->data))
+    __CPROVER_assigns(i, __CPROVER_object_whole(b->data))
     __CPROVER_loop_invariant(i <= SIZE)
     // clang-format on
     {

--- a/regression/contracts/loop_assigns-03/main.c
+++ b/regression/contracts/loop_assigns-03/main.c
@@ -16,7 +16,7 @@ void main()
   b->data[5] = 0;
   for(unsigned i = 0; i < SIZE; i++)
     // clang-format off
-    __CPROVER_assigns(__CPROVER_POINTER_OBJECT(b->data))
+    __CPROVER_assigns(__CPROVER_object_whole(b->data))
     __CPROVER_loop_invariant(i <= SIZE)
     // clang-format on
     {

--- a/regression/contracts/loop_assigns-04/main.c
+++ b/regression/contracts/loop_assigns-04/main.c
@@ -17,7 +17,7 @@ void main()
   b->data[5] = 0;
   for(unsigned i = 0; i < SIZE; i++)
     // clang-format off
-    __CPROVER_assigns(i, __CPROVER_POINTER_OBJECT(b->data))
+    __CPROVER_assigns(i, __CPROVER_object_whole(b->data))
     __CPROVER_loop_invariant(i <= SIZE)
     // clang-format on
     {

--- a/regression/contracts/loop_assigns-slice-assignable-ptr/main.c
+++ b/regression/contracts/loop_assigns-slice-assignable-ptr/main.c
@@ -1,0 +1,42 @@
+#include <assert.h>
+#include <stdlib.h>
+
+#define SIZE 5
+
+struct blob
+{
+  char *data;
+};
+
+void main()
+{
+  struct blob *b = malloc(sizeof(struct blob));
+  b->data = malloc(SIZE);
+  b->data[0] = 0;
+  b->data[1] = 1;
+  b->data[2] = 2;
+  b->data[3] = 3;
+  b->data[4] = 4;
+
+  char *start = b->data;
+  char *end = b->data + SIZE;
+
+  for(unsigned i = 0; i < SIZE; i++)
+    // clang-format off
+    __CPROVER_assigns(i,
+      __CPROVER_object_upto(b->data, SIZE),
+      __CPROVER_typed_target(b->data))
+    __CPROVER_loop_invariant(
+      i <= SIZE &&
+      start <= b->data && b->data < end)
+    // clang-format on
+    {
+      b->data = b->data; // must pass
+      *(b->data) = 0;    // must pass
+    }
+
+  // must pass
+  assert(start <= b->data && b->data <= end);
+  // must fail
+  assert(b->data == start);
+}

--- a/regression/contracts/loop_assigns-slice-assignable-ptr/test.desc
+++ b/regression/contracts/loop_assigns-slice-assignable-ptr/test.desc
@@ -1,0 +1,22 @@
+CORE
+main.c
+--apply-loop-contracts
+^EXIT=10$
+^SIGNAL=0$
+^\[main.\d+\] .* Check loop invariant before entry: SUCCESS$
+^\[main.\d+\] .* Check that loop invariant is preserved: SUCCESS$
+^\[main.\d+\] .* Check that loop instrumentation was not truncated: SUCCESS$
+^\[main.assigns.\d+\] .* Check that i is assignable: SUCCESS$
+^\[main.assigns.\d+\] .* Check that i is valid: SUCCESS$
+^\[main.assigns.\d+\] .* Check that __CPROVER_object_upto\(\(.*\)b->data, \(.*\)5\) is valid: SUCCESS$
+^\[main.assigns.\d+\] .* Check that __CPROVER_assignable\(\(.*\)&b->data, (4|8).*, TRUE\) is valid: SUCCESS$
+^\[main.assigns.\d+\] .* Check that b->data is assignable: SUCCESS$
+^\[main.assigns.\d+\] .* Check that \*b->data is assignable: SUCCESS$
+^\[main.assertion.\d+\] .* assertion b->data == start: FAILURE$
+^\[main.assertion.\d+\] .* assertion start <= b->data && b->data <= end: SUCCESS$
+^VERIFICATION FAILED$
+--
+--
+This test checks that __CPROVER_typed_target(ptr) is supported in loop contracts
+for pointer typed targets and gets translated to
+__CPROVER_assignable(address_of(ptr), sizeof(ptr), TRUE).

--- a/regression/contracts/loop_assigns-slice-assignable-scalar/main.c
+++ b/regression/contracts/loop_assigns-slice-assignable-scalar/main.c
@@ -1,0 +1,40 @@
+#include <assert.h>
+#include <stdlib.h>
+
+#define SIZE 5
+
+struct blob
+{
+  char *data;
+};
+
+void main()
+{
+  struct blob *b = malloc(sizeof(struct blob));
+  b->data = malloc(SIZE);
+  b->data[0] = 0;
+  b->data[1] = 0;
+  b->data[2] = 0;
+  b->data[3] = 0;
+  b->data[4] = 0;
+
+  for(unsigned i = 0; i < SIZE; i++)
+    // clang-format off
+    __CPROVER_assigns(i, __CPROVER_typed_target(b->data[0]))
+    __CPROVER_loop_invariant(i <= SIZE)
+    // clang-format on
+    {
+      // must pass
+      b->data[0] = 1;
+      // must fail
+      b->data[i] = 1;
+    }
+
+  // must fail
+  assert(b->data[0] == 0);
+  // must pass
+  assert(b->data[1] == 0);
+  assert(b->data[2] == 0);
+  assert(b->data[3] == 0);
+  assert(b->data[4] == 0);
+}

--- a/regression/contracts/loop_assigns-slice-assignable-scalar/test.desc
+++ b/regression/contracts/loop_assigns-slice-assignable-scalar/test.desc
@@ -1,0 +1,23 @@
+CORE
+main.c
+--apply-loop-contracts
+^EXIT=10$
+^SIGNAL=0$
+^\[main.\d+\] .* Check loop invariant before entry: SUCCESS$
+^\[main.assigns.\d+\] .* Check that i is assignable: SUCCESS$
+^\[main.assigns.\d+\] .* Check that b->data\[\(.*\)0\] is assignable: SUCCESS$
+^\[main.assigns.\d+\] .* Check that b->data\[\(.*\)i\] is assignable: FAILURE$
+^\[main.\d+\] .* Check that loop invariant is preserved: SUCCESS$
+^\[main.assigns.\d+\] .* Check that __CPROVER_assignable\(\(.*\)&b->data\[\(.*\)0\], 1ul?l?, FALSE\) is valid: SUCCESS$
+^\[main.assertion.\d+\] .* assertion b->data\[0\] == 0: FAILURE$
+^\[main.assertion.\d+\] .* assertion b->data\[1\] == 0: SUCCESS$
+^\[main.assertion.\d+\] .* assertion b->data\[2\] == 0: SUCCESS$
+^\[main.assertion.\d+\] .* assertion b->data\[3\] == 0: SUCCESS$
+^\[main.assertion.\d+\] .* assertion b->data\[4\] == 0: SUCCESS$
+^VERIFICATION FAILED$
+--
+^\[main.assigns.\d+\] .* Check that b->data\[(.*)i\] is assignable: FAILED$
+--
+This test shows that __CPROVER_typed_target is supported in loop contracts,
+and gets translated to __CPROVER_assignable(&target, sizeof(target), FALSE)
+for scalar targets.

--- a/regression/contracts/loop_assigns-slice-from/main.c
+++ b/regression/contracts/loop_assigns-slice-from/main.c
@@ -1,0 +1,37 @@
+#include <assert.h>
+#include <stdlib.h>
+
+#define SIZE 5
+
+struct blob
+{
+  char *data;
+};
+
+void main()
+{
+  struct blob *b = malloc(sizeof(struct blob));
+  b->data = malloc(SIZE);
+  b->data[0] = 0;
+  b->data[1] = 0;
+  b->data[2] = 0;
+  b->data[3] = 0;
+  b->data[4] = 0;
+
+  for(unsigned i = 0; i < SIZE; i++)
+    // clang-format off
+    __CPROVER_assigns(i, __CPROVER_object_from(b->data))
+    __CPROVER_loop_invariant(i <= SIZE)
+    // clang-format on
+    {
+      // must pass
+      b->data[i] = 1;
+    }
+
+  // these should all fail
+  assert(b->data[0] == 0);
+  assert(b->data[1] == 0);
+  assert(b->data[2] == 0);
+  assert(b->data[3] == 0);
+  assert(b->data[4] == 0);
+}

--- a/regression/contracts/loop_assigns-slice-from/test.desc
+++ b/regression/contracts/loop_assigns-slice-from/test.desc
@@ -1,0 +1,19 @@
+CORE
+main.c
+--apply-loop-contracts
+^EXIT=10$
+^SIGNAL=0$
+^\[main.\d+\] .* Check loop invariant before entry: SUCCESS$
+^\[main.assigns.\d+\] .* Check that i is assignable: SUCCESS$
+^\[main.assigns.\d+\] .* Check that b->data\[(.*)i\] is assignable: SUCCESS$
+^\[main.\d+\] .* Check that loop invariant is preserved: SUCCESS$
+^\[main.assertion.\d+\] .* assertion b->data\[0\] == 0: FAILURE$
+^\[main.assertion.\d+\] .* assertion b->data\[1\] == 0: FAILURE$
+^\[main.assertion.\d+\] .* assertion b->data\[2\] == 0: FAILURE$
+^\[main.assertion.\d+\] .* assertion b->data\[3\] == 0: FAILURE$
+^\[main.assertion.\d+\] .* assertion b->data\[4\] == 0: FAILURE$
+^VERIFICATION FAILED$
+--
+^\[main.assigns.\d+\] .* Check that b->data\[(.*)i\] is assignable: FAILURE$
+--
+This test shows that __CPROVER_object_from is supported in loop contracts.

--- a/regression/contracts/loop_assigns-slice-upto-fail/main.c
+++ b/regression/contracts/loop_assigns-slice-upto-fail/main.c
@@ -1,0 +1,42 @@
+#include <assert.h>
+#include <stdlib.h>
+
+#define SIZE 5
+
+struct blob
+{
+  char *data;
+};
+
+void main()
+{
+  struct blob *b = malloc(sizeof(struct blob));
+  b->data = malloc(SIZE);
+  b->data[0] = 0;
+  b->data[1] = 0;
+  b->data[2] = 0;
+  b->data[3] = 0;
+  b->data[4] = 0;
+
+  for(unsigned i = 0; i < SIZE; i++)
+    // clang-format off
+    __CPROVER_assigns(i, __CPROVER_object_upto(b->data, SIZE-2))
+    __CPROVER_loop_invariant(i <= SIZE)
+    // clang-format on
+    {
+      // must pass
+      b->data[0] = 1;
+      b->data[1] = 1;
+      b->data[2] = 1;
+      // must fail
+      b->data[i] = 1;
+    }
+
+  // must fail
+  assert(b->data[0] == 0);
+  assert(b->data[1] == 0);
+  assert(b->data[2] == 0);
+  // must pass
+  assert(b->data[3] == 0);
+  assert(b->data[4] == 0);
+}

--- a/regression/contracts/loop_assigns-slice-upto-fail/test.desc
+++ b/regression/contracts/loop_assigns-slice-upto-fail/test.desc
@@ -1,0 +1,21 @@
+CORE
+main.c
+--apply-loop-contracts
+^\[main.\d+\] .* Check loop invariant before entry: SUCCESS$
+^\[main.\d+\] .* Check that loop invariant is preserved: SUCCESS$
+^\[main.assigns.\d+\] .* Check that i is assignable: SUCCESS$
+^\[main.assigns.\d+\] .* Check that b->data\[\(.*\)0\] is assignable: SUCCESS$
+^\[main.assigns.\d+\] .* Check that b->data\[\(.*\)1\] is assignable: SUCCESS$
+^\[main.assigns.\d+\] .* Check that b->data\[\(.*\)2\] is assignable: SUCCESS$
+^\[main.assigns.\d+\] .* Check that b->data\[\(.*\)i\] is assignable: FAILURE$
+^\[main.assertion.\d+\] .* assertion b->data\[0\] == 0: FAILURE$
+^\[main.assertion.\d+\] .* assertion b->data\[1\] == 0: FAILURE$
+^\[main.assertion.\d+\] .* assertion b->data\[2\] == 0: FAILURE$
+^\[main.assertion.\d+\] .* assertion b->data\[3\] == 0: SUCCESS$
+^\[main.assertion.\d+\] .* assertion b->data\[4\] == 0: SUCCESS$
+^VERIFICATION FAILED$
+^EXIT=10$
+^SIGNAL=0$
+--
+--
+This test shows that __CPROVER_object_upto is supported in loop contracts.

--- a/regression/contracts/loop_assigns-slice-upto-pass/main.c
+++ b/regression/contracts/loop_assigns-slice-upto-pass/main.c
@@ -1,0 +1,38 @@
+#include <assert.h>
+#include <stdlib.h>
+
+#define SIZE 5
+
+struct blob
+{
+  char *data;
+};
+
+void main()
+{
+  struct blob *b = malloc(sizeof(struct blob));
+  b->data = malloc(SIZE);
+  b->data[0] = 0;
+  b->data[1] = 0;
+  b->data[2] = 0;
+  b->data[3] = 0;
+  b->data[4] = 0;
+
+  for(unsigned i = 0; i < 3; i++)
+    // clang-format off
+    __CPROVER_assigns(i, __CPROVER_object_upto(b->data, 3))
+    __CPROVER_loop_invariant(i <= SIZE)
+    // clang-format on
+    {
+      // must pass
+      b->data[i] = 1;
+    }
+
+  // must fail
+  assert(b->data[0] == 0);
+  assert(b->data[1] == 0);
+  assert(b->data[2] == 0);
+  // must pass
+  assert(b->data[3] == 0);
+  assert(b->data[4] == 0);
+}

--- a/regression/contracts/loop_assigns-slice-upto-pass/test.desc
+++ b/regression/contracts/loop_assigns-slice-upto-pass/test.desc
@@ -1,0 +1,18 @@
+CORE
+main.c
+--apply-loop-contracts
+^\[main.\d+\] .* Check loop invariant before entry: SUCCESS$
+^\[main.\d+\] .* Check that loop invariant is preserved: SUCCESS$
+^\[main.assigns.\d+\] .* Check that i is assignable: SUCCESS$
+^\[main.assigns.\d+\] .* Check that b->data\[\(.*\)i\] is assignable: SUCCESS$
+^\[main.assertion.\d+\] .* assertion b->data\[0\] == 0: FAILURE$
+^\[main.assertion.\d+\] .* assertion b->data\[1\] == 0: FAILURE$
+^\[main.assertion.\d+\] .* assertion b->data\[2\] == 0: FAILURE$
+^\[main.assertion.\d+\] .* assertion b->data\[3\] == 0: SUCCESS$
+^\[main.assertion.\d+\] .* assertion b->data\[4\] == 0: SUCCESS$
+^VERIFICATION FAILED$
+^EXIT=10$
+^SIGNAL=0$
+--
+--
+This test hows that __CPROVER_object_upto is supported in loop contracts.

--- a/regression/contracts/quantifiers-loop-01/main.c
+++ b/regression/contracts/quantifiers-loop-01/main.c
@@ -9,7 +9,7 @@ void main()
 
   for(int i = 0; i < N; ++i)
     // clang-format off
-    __CPROVER_assigns(i, __CPROVER_POINTER_OBJECT(a))
+    __CPROVER_assigns(i, __CPROVER_object_whole(a))
     __CPROVER_loop_invariant(
       (0 <= i) && (i <= N) &&
       __CPROVER_forall {

--- a/regression/contracts/quantifiers-loop-02/main.c
+++ b/regression/contracts/quantifiers-loop-02/main.c
@@ -8,7 +8,7 @@ void main()
 
   for(int i = 0; i < N; ++i)
     // clang-format off
-    __CPROVER_assigns(i, __CPROVER_POINTER_OBJECT(a))
+    __CPROVER_assigns(i, __CPROVER_object_whole(a))
     __CPROVER_loop_invariant(
       (0 <= i) && (i <= N) &&
       __CPROVER_forall {

--- a/regression/contracts/quantifiers-loop-03/main.c
+++ b/regression/contracts/quantifiers-loop-03/main.c
@@ -12,7 +12,7 @@ void main()
 
   for(int i = 0; i < N; ++i)
     // clang-format off
-    __CPROVER_assigns(i, __CPROVER_POINTER_OBJECT(a))
+    __CPROVER_assigns(i, __CPROVER_object_whole(a))
     __CPROVER_loop_invariant(
       (0 <= i) && (i <= N) &&
       (i != 0 ==> __CPROVER_exists {

--- a/regression/contracts/reject_history_expr_in_assigns_clause/test.desc
+++ b/regression/contracts/reject_history_expr_in_assigns_clause/test.desc
@@ -1,7 +1,7 @@
 CORE
 main.c
 --enforce-contract foo
-^main.c.*error: assigns clause target must be a non-void lvalue, a call to __CPROVER_POINTER_OBJECT or a call to a function returning void$
+^.*error: assigns clause target must be a non-void lvalue or a call to a function returning void$
 ^CONVERSION ERROR$
 ^EXIT=(1|64)$
 ^SIGNAL=0$

--- a/src/ansi-c/c_typecheck_code.cpp
+++ b/src/ansi-c/c_typecheck_code.cpp
@@ -1013,11 +1013,6 @@ void c_typecheck_baset::typecheck_spec_assigns_target(exprt &target)
     throw_on_side_effects(target);
     return;
   }
-  else if(target.id() == ID_pointer_object)
-  {
-    throw_on_side_effects(target);
-    return;
-  }
   else if(can_cast_expr<side_effect_expr_function_callt>(target))
   {
     const auto &funcall = to_side_effect_expr_function_call(target);
@@ -1044,9 +1039,8 @@ void c_typecheck_baset::typecheck_spec_assigns_target(exprt &target)
   {
     // if we reach this point the target did not pass the checks
     throw invalid_source_file_exceptiont(
-      "assigns clause target must be a non-void lvalue, a call "
-      "to " CPROVER_PREFIX
-      "POINTER_OBJECT or a call to a function returning void",
+      "assigns clause target must be a non-void lvalue or a call to a function "
+      "returning void",
       target.source_location());
   }
 }

--- a/src/goto-instrument/contracts/contracts.cpp
+++ b/src/goto-instrument/contracts/contracts.cpp
@@ -314,7 +314,8 @@ void code_contractst::check_apply_loop_contracts(
     goto_programt::make_decl(in_loop_havoc_block, loop_head_location));
   pre_loop_head_instrs.add(
     goto_programt::make_assignment(in_loop_havoc_block, true_exprt{}));
-  havoc_assigns_targetst havoc_gen(to_havoc, ns);
+  havoc_assigns_targetst havoc_gen(
+    to_havoc, symbol_table, log.get_message_handler(), mode);
   havoc_gen.append_full_havoc_code(loop_head_location, pre_loop_head_instrs);
   pre_loop_head_instrs.add(
     goto_programt::make_assignment(in_loop_havoc_block, false_exprt{}));

--- a/src/goto-instrument/havoc_utils.cpp
+++ b/src/goto-instrument/havoc_utils.cpp
@@ -20,7 +20,7 @@ Date: July 2021
 
 void havoc_utilst::append_full_havoc_code(
   const source_locationt location,
-  goto_programt &dest) const
+  goto_programt &dest)
 {
   for(const auto &expr : assigns)
     append_havoc_code_for_expr(location, expr, dest);
@@ -29,7 +29,7 @@ void havoc_utilst::append_full_havoc_code(
 void havoc_utilst::append_havoc_code_for_expr(
   const source_locationt location,
   const exprt &expr,
-  goto_programt &dest) const
+  goto_programt &dest)
 {
   if(expr.id() == ID_index || expr.id() == ID_dereference)
   {

--- a/src/goto-instrument/havoc_utils.h
+++ b/src/goto-instrument/havoc_utils.h
@@ -61,9 +61,8 @@ public:
   ///
   /// \param location The source location to annotate on the havoc instruction
   /// \param dest The destination goto program to append the instructions to
-  void append_full_havoc_code(
-    const source_locationt location,
-    goto_programt &dest) const;
+  void
+  append_full_havoc_code(const source_locationt location, goto_programt &dest);
 
   /// \brief Append goto instructions to havoc a single expression `expr`
   ///
@@ -79,7 +78,7 @@ public:
   virtual void append_havoc_code_for_expr(
     const source_locationt location,
     const exprt &expr,
-    goto_programt &dest) const;
+    goto_programt &dest);
 
   /// \brief Append goto instructions to havoc the underlying object of `expr`
   ///


### PR DESCRIPTION
Depends on #7086 (first two commits).
Fixes https://github.com/diffblue/cbmc/issues/6979.

Drop support for `__CPROVER_POINTER_OBJECT` in function contract and loop assigns clauses. Extend support for `__CPROVER_typed_target`, `__CPROVER_assignable`, `__CPROVER_object_whole`, `__CPROVER_object_from`,  `__CPROVER_object_upto` to loop contracts.

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [x] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.
