### PR TITLE
use divisor()/dividend() methods

### DIFF
--- a/src/ansi-c/goto_check_c.cpp
+++ b/src/ansi-c/goto_check_c.cpp
@@ -618,8 +618,8 @@ void goto_check_ct::mod_by_zero_check(
 
   // add divison by zero subgoal
 
-  exprt zero = from_integer(0, expr.op1().type());
-  const notequal_exprt inequality(expr.op1(), std::move(zero));
+  exprt zero = from_integer(0, expr.divisor().type());
+  const notequal_exprt inequality(expr.divisor(), std::move(zero));
 
   add_guarded_property(
     inequality,

--- a/src/solvers/flattening/boolbv_mod.cpp
+++ b/src/solvers/flattening/boolbv_mod.cpp
@@ -25,25 +25,25 @@ bvt boolbvt::convert_mod(const mod_exprt &expr)
   std::size_t width=boolbv_width(expr.type());
 
   DATA_INVARIANT(
-    expr.op0().type().id() == expr.type().id(),
-    "type of the first operand of a modulo operation shall equal the "
+    expr.dividend().type().id() == expr.type().id(),
+    "type of the dividend of a modulo operation shall equal the "
     "expression type");
 
   DATA_INVARIANT(
-    expr.op1().type().id() == expr.type().id(),
-    "type of the second operand of a modulo operation shall equal the "
+    expr.divisor().type().id() == expr.type().id(),
+    "type of the divisor of a modulo operation shall equal the "
     "expression type");
 
   bv_utilst::representationt rep=
     expr.type().id()==ID_signedbv?bv_utilst::representationt::SIGNED:
                                   bv_utilst::representationt::UNSIGNED;
 
-  const bvt &op0 = convert_bv(expr.op0(), width);
-  const bvt &op1 = convert_bv(expr.op1(), width);
+  const bvt &dividend_bv = convert_bv(expr.dividend(), width);
+  const bvt &divisor_bv = convert_bv(expr.divisor(), width);
 
   bvt res, rem;
 
-  bv_utils.divider(op0, op1, res, rem, rep);
+  bv_utils.divider(dividend_bv, divisor_bv, res, rem, rep);
 
   return rem;
 }


### PR DESCRIPTION
This commit replaces uses of `.op0()` and `.op1()` by accessor methods specific to division operators.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
