### PR TITLE
Mark tests that timeout on ubuntu 18.04 job as KNOWNBUG

### DIFF
--- a/jbmc/regression/jbmc/CMakeLists.txt
+++ b/jbmc/regression/jbmc/CMakeLists.txt
@@ -13,7 +13,7 @@ else()
     add_test_pl_profile(
             "jbmc-symex-driven-lazy-loading"
             "$<TARGET_FILE:jbmc> --validate-goto-model --validate-ssa-equation --validate-trace --symex-driven-lazy-loading"
-            "-C;-X;symex-driven-lazy-loading-expected-failure;-X;bdd-expected-timeout;-s;symex-driven-loading"
+            "-C;-X;symex-driven-lazy-loading-expected-failure;-X;bdd-expected-timeout;-s;symex-driven-loading;-X;broken-1804-test;"
             "CORE"
     )
 endif()

--- a/jbmc/regression/jbmc/context-include-exclude/test_exclude_absent.desc
+++ b/jbmc/regression/jbmc/context-include-exclude/test_exclude_absent.desc
@@ -1,4 +1,4 @@
-CORE
+CORE broken-1804-test
 Main
 --context-exclude org.cprover.oh
 ^EXIT=0$

--- a/jbmc/regression/jbmc/context-include-exclude/test_exclude_from_all.desc
+++ b/jbmc/regression/jbmc/context-include-exclude/test_exclude_from_all.desc
@@ -1,4 +1,4 @@
-CORE
+CORE broken-1804-test
 Main
 --context-exclude 'org.cprover.MyClass$Inner.'
 ^EXIT=10$

--- a/jbmc/regression/jbmc/context-include-exclude/test_exclude_from_include.desc
+++ b/jbmc/regression/jbmc/context-include-exclude/test_exclude_from_include.desc
@@ -1,4 +1,4 @@
-CORE
+KNOWNBUG
 Main
 --context-include Main.main --context-include 'Main.<clinit' --context-include org.cprover.MyClass --context-exclude 'org.cprover.MyClass$Inner.'
 ^EXIT=10$

--- a/jbmc/regression/jbmc/context-include-exclude/test_exclude_package_prefix.desc
+++ b/jbmc/regression/jbmc/context-include-exclude/test_exclude_package_prefix.desc
@@ -1,4 +1,4 @@
-CORE
+CORE broken-1804-test
 Main
 --context-include Main --context-include org.cprover --context-exclude org.cprover.ot
 ^EXIT=10$

--- a/jbmc/regression/jbmc/context-include-exclude/test_excluded_deleted_original_body.desc
+++ b/jbmc/regression/jbmc/context-include-exclude/test_excluded_deleted_original_body.desc
@@ -1,4 +1,4 @@
-CORE
+CORE broken-1804-test
 ExcludedProperties
 --context-exclude org.cprover.other --function ExcludedProperties.runtimeReturnType
 ^EXIT=10$

--- a/jbmc/regression/jbmc/context-include-exclude/test_excluded_entry_point.desc
+++ b/jbmc/regression/jbmc/context-include-exclude/test_excluded_entry_point.desc
@@ -1,4 +1,4 @@
-CORE
+CORE broken-1804-test
 Main
 --context-exclude 'org.cprover.MyClass$Inner.' --function 'org.cprover.MyClass$Inner.doIt:(I)I'
 ^EXIT=1$

--- a/jbmc/regression/jbmc/context-include-exclude/test_excluded_has_nondet_body.desc
+++ b/jbmc/regression/jbmc/context-include-exclude/test_excluded_has_nondet_body.desc
@@ -1,4 +1,4 @@
-CORE
+CORE broken-1804-test
 ExcludedProperties
 --context-exclude org.cprover.other --function ExcludedProperties.compileTimeReturnType
 ^EXIT=10$

--- a/jbmc/regression/jbmc/context-include-exclude/test_excluded_has_parameter_info.desc
+++ b/jbmc/regression/jbmc/context-include-exclude/test_excluded_has_parameter_info.desc
@@ -1,4 +1,4 @@
-CORE
+CORE broken-1804-test
 ExcludedProperties
 --context-exclude org.cprover.other --show-symbol-table --function ExcludedProperties.parameters
 ^EXIT=0$

--- a/jbmc/regression/jbmc/context-include-exclude/test_include.desc
+++ b/jbmc/regression/jbmc/context-include-exclude/test_include.desc
@@ -1,4 +1,4 @@
-CORE
+CORE broken-1804-test
 Main
 --context-include Main.
 ^EXIT=10$

--- a/jbmc/regression/jbmc/context-include-exclude/test_include_all.desc
+++ b/jbmc/regression/jbmc/context-include-exclude/test_include_all.desc
@@ -1,4 +1,4 @@
-CORE
+CORE broken-1804-test
 Main
 
 ^EXIT=0$


### PR DESCRIPTION
Recently a number of PRs have been failing the Ubuntu 18.04 package build PR job, with a mysterious 137 exit code that seems to be indicating a out-of-memory SIGKILL received.

This PR is deactivating the failing tests so that the latest release can go forward while we take some more time to investigate this.
<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
