### PR TITLE
Mark memory hungry tests as THOROUGH

### DIFF
--- a/jbmc/regression/jbmc/context-include-exclude/test_exclude_from_include.desc
+++ b/jbmc/regression/jbmc/context-include-exclude/test_exclude_from_include.desc
@@ -1,4 +1,4 @@
-CORE
+THOROUGH
 Main
 --context-include Main.main --context-include 'Main.<clinit' --context-include org.cprover.MyClass --context-exclude 'org.cprover.MyClass$Inner.'
 ^EXIT=10$
@@ -12,3 +12,6 @@ WARNING: no body for function .*
 --
 Tests that only the specified methods and classes are included, while
 the inner class from MyClass is excluded.
+
+The test is marked "THOROUGH" as it requires more memory than may be available
+on some GitHub runners.

--- a/jbmc/regression/jbmc/context-include-exclude/test_include.desc
+++ b/jbmc/regression/jbmc/context-include-exclude/test_include.desc
@@ -1,4 +1,4 @@
-CORE
+THOROUGH
 Main
 --context-include Main.
 ^EXIT=10$
@@ -11,3 +11,6 @@ Main
 WARNING: no body for function .*
 --
 Tests that only methods from the specified class are included.
+
+The test is marked "THOROUGH" as it requires more memory than may be available
+on some GitHub runners.


### PR DESCRIPTION
These tests seem to require more memory than may be available on some GitHub runners.

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.
