### PR TITLE
add comments to warn about experimental predicates

### DIFF
--- a/src/ansi-c/c_typecheck_expr.cpp
+++ b/src/ansi-c/c_typecheck_expr.cpp
@@ -2291,6 +2291,7 @@ exprt c_typecheck_baset::do_special_functions(
   }
   else if(identifier == CPROVER_PREFIX "is_list")
   {
+    // experimental feature for CHC encodings -- do not use
     if(expr.arguments().size() != 1)
     {
       error().source_location = f_op.source_location();
@@ -2318,6 +2319,7 @@ exprt c_typecheck_baset::do_special_functions(
   }
   else if(identifier == CPROVER_PREFIX "is_dll")
   {
+    // experimental feature for CHC encodings -- do not use
     if(expr.arguments().size() != 1)
     {
       error().source_location = f_op.source_location();
@@ -2345,6 +2347,7 @@ exprt c_typecheck_baset::do_special_functions(
   }
   else if(identifier == CPROVER_PREFIX "is_cyclic_dll")
   {
+    // experimental feature for CHC encodings -- do not use
     if(expr.arguments().size() != 1)
     {
       error().source_location = f_op.source_location();
@@ -2372,6 +2375,7 @@ exprt c_typecheck_baset::do_special_functions(
   }
   else if(identifier == CPROVER_PREFIX "is_sentinel_dll")
   {
+    // experimental feature for CHC encodings -- do not use
     if(expr.arguments().size() != 2 && expr.arguments().size() != 3)
     {
       error().source_location = f_op.source_location();
@@ -2402,6 +2406,7 @@ exprt c_typecheck_baset::do_special_functions(
   }
   else if(identifier == CPROVER_PREFIX "is_cstring")
   {
+    // experimental feature for CHC encodings -- do not use
     if(expr.arguments().size() != 1)
     {
       error().source_location = f_op.source_location();
@@ -2425,6 +2430,7 @@ exprt c_typecheck_baset::do_special_functions(
   }
   else if(identifier == CPROVER_PREFIX "cstrlen")
   {
+    // experimental feature for CHC encodings -- do not use
     if(expr.arguments().size() != 1)
     {
       error().source_location = f_op.source_location();

--- a/src/ansi-c/cprover_builtin_headers.h
+++ b/src/ansi-c/cprover_builtin_headers.h
@@ -10,18 +10,19 @@ __CPROVER_bool __CPROVER_equal();
 __CPROVER_bool __CPROVER_same_object(const void *, const void *);
 __CPROVER_bool __CPROVER_is_invalid_pointer(const void *);
 _Bool __CPROVER_is_zero_string(const void *);
-// a singly-linked null-terminated dynamically-allocated list
-__CPROVER_bool __CPROVER_is_list();
-__CPROVER_bool __CPROVER_is_dll();
-__CPROVER_bool __CPROVER_is_cyclic_dll();
-__CPROVER_bool __CPROVER_is_sentinel_dll();
 __CPROVER_size_t __CPROVER_zero_string_length(const void *);
-__CPROVER_bool __CPROVER_is_cstring(const char *);
-__CPROVER_size_t __CPROVER_cstrlen(const char *);
 __CPROVER_size_t __CPROVER_buffer_size(const void *);
 __CPROVER_bool __CPROVER_r_ok();
 __CPROVER_bool __CPROVER_w_ok();
 __CPROVER_bool __CPROVER_rw_ok();
+
+// experimental features for CHC encodings -- do not use
+__CPROVER_bool __CPROVER_is_list(); // a singly-linked null-terminated dynamically-allocated list
+__CPROVER_bool __CPROVER_is_dll();
+__CPROVER_bool __CPROVER_is_cyclic_dll();
+__CPROVER_bool __CPROVER_is_sentinel_dll();
+__CPROVER_bool __CPROVER_is_cstring(const char *);
+__CPROVER_size_t __CPROVER_cstrlen(const char *);
 
 // bitvector analysis
 __CPROVER_bool __CPROVER_get_flag(const void *, const char *);

--- a/src/util/pointer_expr.h
+++ b/src/util/pointer_expr.h
@@ -1060,7 +1060,8 @@ inline void validate_expr(const object_size_exprt &value)
 }
 
 /// A predicate that indicates that a zero-terminated string
-/// starts at the given address
+/// starts at the given address.
+/// This is an experimental feature for CHC encodings -- do not use.
 class is_cstring_exprt : public unary_predicate_exprt
 {
 public:
@@ -1118,6 +1119,7 @@ inline is_cstring_exprt &to_is_cstring_expr(exprt &expr)
 /// An expression, akin to ISO C's strlen, that denotes the
 /// length of a zero-terminated string that starts at the
 /// given address. The trailing zero is not included in the count.
+/// This is an experimental feature for CHC encodings -- do not use.
 class cstrlen_exprt : public unary_exprt
 {
 public:
@@ -1172,7 +1174,8 @@ inline cstrlen_exprt &to_cstrlen_expr(exprt &expr)
   return ret;
 }
 
-/// A predicate that indicates that the object pointed to is live
+/// A predicate that indicates that the object pointed to is live.
+/// This is an experimental feature for CHC encodings -- do not use.
 class live_object_exprt : public unary_predicate_exprt
 {
 public:
@@ -1227,7 +1230,8 @@ inline live_object_exprt &to_live_object_expr(exprt &expr)
   return ret;
 }
 
-/// A predicate that indicates that the object pointed to is writeable
+/// A predicate that indicates that the object pointed to is writeable.
+/// This is an experimental feature for CHC encodings -- do not use.
 class writeable_object_exprt : public unary_predicate_exprt
 {
 public:


### PR DESCRIPTION
This commit adds comments to warn about the use of a set of experimental predicates used for CHC encodings.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- n/a Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- n/a My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
