### PR TITLE
fix expr2c on lambda expressions

### DIFF
--- a/src/ansi-c/expr2c.cpp
+++ b/src/ansi-c/expr2c.cpp
@@ -832,22 +832,22 @@ std::string expr2ct::convert_trinary(
   return dest;
 }
 
-std::string expr2ct::convert_quantifier(
-  const quantifier_exprt &src,
+std::string expr2ct::convert_binding(
+  const binding_exprt &src,
   const std::string &symbol,
   unsigned precedence)
 {
   // our made-up syntax can only do one symbol
-  if(src.op0().operands().size() != 1)
+  if(src.variables().size() != 1)
     return convert_norep(src, precedence);
 
   unsigned p0, p1;
 
-  std::string op0 = convert_with_precedence(src.symbol(), p0);
+  std::string op0 = convert_with_precedence(src.variables().front(), p0);
   std::string op1 = convert_with_precedence(src.where(), p1);
 
   std::string dest=symbol+" { ";
-  dest += convert(src.symbol().type());
+  dest += convert(src.variables().front().type());
   dest+=" "+op0+"; ";
   dest+=op1;
   dest+=" }";
@@ -3816,16 +3816,13 @@ std::string expr2ct::convert_with_precedence(
     return convert_trinary(to_if_expr(src), "?", ":", precedence = 3);
 
   else if(src.id()==ID_forall)
-    return convert_quantifier(
-      to_quantifier_expr(src), "forall", precedence = 2);
+    return convert_binding(to_quantifier_expr(src), "forall", precedence = 2);
 
   else if(src.id()==ID_exists)
-    return convert_quantifier(
-      to_quantifier_expr(src), "exists", precedence = 2);
+    return convert_binding(to_quantifier_expr(src), "exists", precedence = 2);
 
   else if(src.id()==ID_lambda)
-    return convert_quantifier(
-      to_quantifier_expr(src), "LAMBDA", precedence = 2);
+    return convert_binding(to_lambda_expr(src), "LAMBDA", precedence = 2);
 
   else if(src.id()==ID_with)
     return convert_with(src, precedence=16);

--- a/src/ansi-c/expr2c_class.h
+++ b/src/ansi-c/expr2c_class.h
@@ -141,8 +141,8 @@ protected:
   std::string convert_overflow(
     const exprt &src, unsigned &precedence);
 
-  std::string convert_quantifier(
-    const quantifier_exprt &,
+  std::string convert_binding(
+    const binding_exprt &,
     const std::string &symbol,
     unsigned precedence);
 


### PR DESCRIPTION
Lambda expressions are not quantifier expressions, but both quantifier expressions and lambda expressions are bindings.  This commit fixes the conversion of lambda expressions to C syntax by generalizing the conversion of quantifier expressions to binding expressions.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
