### PR TITLE
SMT2 back-end: make declare-datatypes standards compatible

### DIFF
--- a/src/solvers/smt2/smt2_conv.cpp
+++ b/src/solvers/smt2/smt2_conv.cpp
@@ -5277,8 +5277,8 @@ void smt2_convt::find_symbols_rec(
         "complex." + std::to_string(datatype_map.size());
       datatype_map[type] = smt_typename;
 
-      out << "(declare-datatypes () ((" << smt_typename << " "
-          << "(mk-" << smt_typename;
+      out << "(declare-datatypes ((" << smt_typename << " 0)) "
+          << "(((mk-" << smt_typename;
 
       out << " (" << smt_typename << ".imag ";
       convert_type(to_complex_type(type).subtype());
@@ -5306,8 +5306,8 @@ void smt2_convt::find_symbols_rec(
         "vector." + std::to_string(datatype_map.size());
       datatype_map[type] = smt_typename;
 
-      out << "(declare-datatypes () ((" << smt_typename << " "
-          << "(mk-" << smt_typename;
+      out << "(declare-datatypes ((" << smt_typename << " 0)) "
+          << "(((mk-" << smt_typename;
 
       for(mp_integer i=0; i!=size; ++i)
       {
@@ -5348,12 +5348,12 @@ void smt2_convt::find_symbols_rec(
       // argument for each member of the struct.  The declaration that
       // creates this type looks like:
       //
-      // (declare-datatypes () ((struct.0 (mk-struct.0
+      // (declare-datatypes ((struct.0 0)) (((mk-struct.0
       //                                   (struct.0.component1 type1)
       //                                   ...
       //                                   (struct.0.componentN typeN)))))
-      out << "(declare-datatypes () ((" << smt_typename << " "
-          << "(mk-" << smt_typename << " ";
+      out << "(declare-datatypes ((" << smt_typename << " 0)) "
+          << "(((mk-" << smt_typename << " ";
 
       for(const auto &component : components)
       {


### PR DESCRIPTION
The standards-compatible syntax is understood by both Z3 (which also accepted the previous one) as well as CVC5 (which only accepts the new one).

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
