### PR TITLE
index_exprt now checks type of index operand

### DIFF
--- a/src/util/std_expr.cpp
+++ b/src/util/std_expr.cpp
@@ -48,6 +48,30 @@ void constant_exprt::check(const exprt &expr, const validation_modet vm)
     "bitvector constant must not have leading zeros");
 }
 
+index_exprt::index_exprt(exprt _array, exprt _index, typet _type)
+  : binary_exprt(
+      std::move(_array),
+      ID_index,
+      std::move(_index),
+      std::move(_type))
+{
+  const auto &array_op_type = array().type();
+  PRECONDITION(
+    array_op_type.id() == ID_array || array_op_type.id() == ID_vector);
+
+  if(array_op_type.id() == ID_array)
+  {
+    // There is too much code at the moment that uses the wrong type
+    // for the index argument. We add a cast, but this will eventually
+    // become a precondition.
+    auto index_type = to_array_type(array_op_type).index_type();
+    if(index().type() != index_type)
+      index() = typecast_exprt(index(), index_type);
+  }
+  else if(array_op_type.id() == ID_vector)
+    PRECONDITION(index().type() == to_vector_type(array_op_type).index_type());
+}
+
 exprt disjunction(const exprt::operandst &op)
 {
   if(op.empty())

--- a/src/util/std_expr.cpp
+++ b/src/util/std_expr.cpp
@@ -237,6 +237,30 @@ void constant_exprt::check(const exprt &expr, const validation_modet vm)
     "bitvector constant must not have leading zeros");
 }
 
+index_exprt::index_exprt(exprt _array, exprt _index, typet _type)
+  : binary_exprt(
+      std::move(_array),
+      ID_index,
+      std::move(_index),
+      std::move(_type))
+{
+  const auto &array_op_type = array().type();
+  PRECONDITION(
+    array_op_type.id() == ID_array || array_op_type.id() == ID_vector);
+
+  if(array_op_type.id() == ID_array)
+  {
+    // There is too much code at the moment that uses the wrong type
+    // for the index argument. We add a cast, but this will eventually
+    // become a precondition.
+    auto index_type = to_array_type(array_op_type).index_type();
+    if(index().type() != index_type)
+      index() = typecast_exprt(index(), index_type);
+  }
+  else if(array_op_type.id() == ID_vector)
+    PRECONDITION(index().type() == to_vector_type(array_op_type).index_type());
+}
+
 exprt disjunction(const exprt::operandst &op)
 {
   if(op.empty())

--- a/src/util/std_expr.h
+++ b/src/util/std_expr.h
@@ -1414,28 +1414,14 @@ public:
   // must be array_type.index_type().
   // This will eventually be enforced using a precondition.
   index_exprt(const exprt &_array, exprt _index)
-    : binary_exprt(
+    : index_exprt(
         _array,
-        ID_index,
         std::move(_index),
         to_type_with_subtype(_array.type()).subtype())
   {
-    const auto &array_op_type = _array.type();
-    PRECONDITION(
-      array_op_type.id() == ID_array || array_op_type.id() == ID_vector);
   }
 
-  index_exprt(exprt _array, exprt _index, typet _type)
-    : binary_exprt(
-        std::move(_array),
-        ID_index,
-        std::move(_index),
-        std::move(_type))
-  {
-    const auto &array_op_type = array().type();
-    PRECONDITION(
-      array_op_type.id() == ID_array || array_op_type.id() == ID_vector);
-  }
+  index_exprt(exprt _array, exprt _index, typet);
 
   exprt &array()
   {

--- a/src/util/std_expr.h
+++ b/src/util/std_expr.h
@@ -1435,28 +1435,14 @@ public:
   // must be array_type.index_type().
   // This will eventually be enforced using a precondition.
   index_exprt(const exprt &_array, exprt _index)
-    : binary_exprt(
+    : index_exprt(
         _array,
-        ID_index,
         std::move(_index),
         to_type_with_subtype(_array.type()).subtype())
   {
-    const auto &array_op_type = _array.type();
-    PRECONDITION(
-      array_op_type.id() == ID_array || array_op_type.id() == ID_vector);
   }
 
-  index_exprt(exprt _array, exprt _index, typet _type)
-    : binary_exprt(
-        std::move(_array),
-        ID_index,
-        std::move(_index),
-        std::move(_type))
-  {
-    const auto &array_op_type = array().type();
-    PRECONDITION(
-      array_op_type.id() == ID_array || array_op_type.id() == ID_vector);
-  }
+  index_exprt(exprt _array, exprt _index, typet);
 
   exprt &array()
   {


### PR DESCRIPTION
This adds a precondition to the constructors of `index_exprt` that enforces that the type of the index argument matches the index type of the array/vector operand.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
