### PR TITLE
Function pointer restrictions: fix empty reason in error reporting

### DIFF
--- a/regression/goto-instrument/restrict-function-pointer-error-reporting/main.c
+++ b/regression/goto-instrument/restrict-function-pointer-error-reporting/main.c
@@ -1,0 +1,17 @@
+#include <assert.h>
+
+int foo()
+{
+  return 10;
+}
+
+int bar()
+{
+  return 5;
+}
+
+int main()
+{
+  int (*fun_ptr)() = nondet_bool() ? &foo : &bar;
+  assert(fun_ptr() == 10);
+}

--- a/regression/goto-instrument/restrict-function-pointer-error-reporting/test.desc
+++ b/regression/goto-instrument/restrict-function-pointer-error-reporting/test.desc
@@ -1,0 +1,10 @@
+CORE
+main.c
+--restrict-function-pointer fun_ptr.function_pointer_call.1/foo
+^Reason: fun_ptr.function_pointer_call.1 not found in the symbol table$
+^EXIT=1$
+^SIGNAL=0$
+--
+^Reason:\s*$
+--
+This test checks that invalid usage results in meaningful error reports.

--- a/src/goto-programs/restrict_function_pointers.cpp
+++ b/src/goto-programs/restrict_function_pointers.cpp
@@ -485,7 +485,9 @@ function_pointer_restrictionst function_pointer_restrictionst::from_options(
   catch(const invalid_restriction_exceptiont &e)
   {
     throw invalid_command_line_argument_exceptiont{
-      e.reason, "--" RESTRICT_FUNCTION_POINTER_OPT, e.correct_format};
+      static_cast<cprover_exception_baset>(e).what(),
+      "--" RESTRICT_FUNCTION_POINTER_OPT,
+      e.correct_format};
   }
 
   restrictionst file_restrictions;
@@ -514,7 +516,9 @@ function_pointer_restrictionst function_pointer_restrictionst::from_options(
   catch(const invalid_restriction_exceptiont &e)
   {
     throw invalid_command_line_argument_exceptiont{
-      e.reason, "--" RESTRICT_FUNCTION_POINTER_BY_NAME_OPT, e.correct_format};
+      static_cast<cprover_exception_baset>(e).what(),
+      "--" RESTRICT_FUNCTION_POINTER_BY_NAME_OPT,
+      e.correct_format};
   }
 
   return {merge_function_pointer_restrictions(

--- a/src/goto-programs/restrict_function_pointers.h
+++ b/src/goto-programs/restrict_function_pointers.h
@@ -79,7 +79,6 @@ public:
 
   std::string what() const override;
 
-  std::string reason;
   std::string correct_format;
 };
 


### PR DESCRIPTION
86b13e934481e introduced a member named reason in the parent class, making some of the code refer to the wrong `reason` member. This, in turn, resulted in printing an empty string as "Reason." Remove the no-longer-needed `reason` member.

Fixes: #7135

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
