### PR TITLE
Remove c_enum_constant_type

### DIFF
--- a/src/util/c_types.cpp
+++ b/src/util/c_types.cpp
@@ -24,19 +24,6 @@ bitvector_typet index_type()
   return c_index_type();
 }
 
-/// return type of enum constants
-bitvector_typet c_enum_constant_type()
-{
-  // usually same as 'int',
-  // but might be unsigned, or shorter than 'int'
-  return signed_int_type();
-}
-
-bitvector_typet enum_constant_type()
-{
-  return c_enum_constant_type();
-}
-
 signedbv_typet signed_int_type()
 {
   signedbv_typet result(config.ansi_c.int_width);

--- a/src/util/c_types.h
+++ b/src/util/c_types.h
@@ -463,10 +463,6 @@ DEPRECATED(
   SINCE(2022, 1, 13, "use c_index_type() or array_typet::index_type() instead"))
 bitvector_typet index_type();
 
-DEPRECATED(SINCE(2022, 1, 13, "use c_enum_constant_type() instead"))
-bitvector_typet enum_constant_type();
-
-bitvector_typet c_enum_constant_type();
 bitvector_typet c_index_type();
 signedbv_typet signed_int_type();
 unsignedbv_typet unsigned_int_type();


### PR DESCRIPTION
This was put in place to succeed enum_constant_type (which was then deprecated), but neither of which are used for the C front-end has it's own (much more elaborate) way of doing enum_constant_type.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- n/a Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
