### PR TITLE
Remove deprecated variants of exprt::{add,copy}_to_operands

### DIFF
--- a/src/util/expr.h
+++ b/src/util/expr.h
@@ -10,7 +10,6 @@ Author: Daniel Kroening, kroening@kroening.com
 #define CPROVER_UTIL_EXPR_H
 
 #include "as_const.h"
-#include "deprecate.h"
 #include "type.h"
 #include "validate_expressions.h"
 #include "validate_types.h"
@@ -172,29 +171,6 @@ public:
     operands().push_back(std::move(expr));
   }
 
-  /// Copy the given arguments to the end of `exprt`'s operands.
-  /// \param e1: first `exprt` to append to the operands
-  /// \param e2: second `exprt` to append to the operands
-  DEPRECATED(SINCE(2022, 2, 15, "use add_to_operands(&&, &&) instead"))
-  void copy_to_operands(const exprt &e1, const exprt &e2)
-  {
-    operandst &op = operands();
-    #ifndef USE_LIST
-    op.reserve(op.size() + 2);
-    #endif
-    op.push_back(e1);
-    op.push_back(e2);
-  }
-
-  /// Add the given arguments to the end of `exprt`'s operands.
-  /// \param e1: first `exprt` to append to the operands
-  /// \param e2: second `exprt` to append to the operands
-  DEPRECATED(SINCE(2022, 2, 15, "use add_to_operands(&&, &&) instead"))
-  void add_to_operands(const exprt &e1, const exprt &e2)
-  {
-    copy_to_operands(e1, e2);
-  }
-
   /// Add the given arguments to the end of `exprt`'s operands.
   /// \param e1: first `exprt` to append to the operands
   /// \param e2: second `exprt` to append to the operands
@@ -206,32 +182,6 @@ public:
     #endif
     op.push_back(std::move(e1));
     op.push_back(std::move(e2));
-  }
-
-  /// Add the given arguments to the end of `exprt`'s operands.
-  /// \param e1: first `exprt` to append to the operands
-  /// \param e2: second `exprt` to append to the operands
-  /// \param e3: third `exprt` to append to the operands
-  DEPRECATED(SINCE(2022, 2, 15, "use add_to_operands(&&, &&, &&) instead"))
-  void add_to_operands(const exprt &e1, const exprt &e2, const exprt &e3)
-  {
-    copy_to_operands(e1, e2, e3);
-  }
-
-  /// Copy the given arguments to the end of `exprt`'s operands.
-  /// \param e1: first `exprt` to append to the operands
-  /// \param e2: second `exprt` to append to the operands
-  /// \param e3: third `exprt` to append to the operands
-  DEPRECATED(SINCE(2022, 2, 15, "use add_to_operands(&&, &&, &&) instead"))
-  void copy_to_operands(const exprt &e1, const exprt &e2, const exprt &e3)
-  {
-    operandst &op = operands();
-    #ifndef USE_LIST
-    op.reserve(op.size() + 3);
-    #endif
-    op.push_back(e1);
-    op.push_back(e2);
-    op.push_back(e3);
   }
 
   /// Add the given arguments to the end of `exprt`'s operands.


### PR DESCRIPTION
These were deprecated in 8dde888fe3b and are no longer used.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- n/a Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
