### PR TITLE
Remove deprecated functions from find_symbols

### DIFF
--- a/src/util/find_symbols.cpp
+++ b/src/util/find_symbols.cpp
@@ -13,7 +13,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "range.h"
 #include "std_expr.h"
 
-/// Kinds of symbols to be considered by \ref has_symbol or \ref find_symbols.
+/// Kinds of symbols to be considered by \ref find_symbols.
 enum class symbol_kindt
 {
   /// Struct, union, or enum tag symbols.
@@ -28,20 +28,6 @@ enum class symbol_kindt
   /// All of the above.
   F_ALL
 };
-
-bool has_symbol(const exprt &src, const find_symbols_sett &symbols)
-{
-  if(src.id() == ID_symbol)
-    return symbols.count(to_symbol_expr(src).get_identifier()) != 0;
-  else
-  {
-    forall_operands(it, src)
-      if(has_symbol(*it, symbols))
-        return true;
-  }
-
-  return false;
-}
 
 static bool find_symbols(
   symbol_kindt,
@@ -305,14 +291,6 @@ void find_type_and_expr_symbols(const exprt &src, find_symbols_sett &dest)
 void find_type_and_expr_symbols(const typet &src, find_symbols_sett &dest)
 {
   find_symbols(symbol_kindt::F_ALL, src, [&dest](const symbol_exprt &e) {
-    dest.insert(e.get_identifier());
-    return true;
-  });
-}
-
-void find_symbols_or_nexts(const exprt &src, find_symbols_sett &dest)
-{
-  find_symbols(symbol_kindt::F_EXPR, src, [&dest](const symbol_exprt &e) {
     dest.insert(e.get_identifier());
     return true;
   });

--- a/src/util/find_symbols.h
+++ b/src/util/find_symbols.h
@@ -10,7 +10,6 @@ Author: Daniel Kroening, kroening@kroening.com
 #ifndef CPROVER_UTIL_FIND_SYMBOLS_H
 #define CPROVER_UTIL_FIND_SYMBOLS_H
 
-#include "deprecate.h"
 #include "irep.h"
 
 #include <algorithm>
@@ -31,28 +30,9 @@ bool has_symbol_expr(
   const irep_idt &identifier,
   bool include_bound_symbols);
 
-DEPRECATED(SINCE(2022, 3, 14, "use find_symbols"))
-/// Add to the set \p dest the sub-expressions of \p src with id ID_symbol or
-/// ID_next_symbol
-void find_symbols_or_nexts(const exprt &src, find_symbols_sett &dest);
-
 /// Add to the set \p dest the sub-expressions of \p src with id ID_symbol, for
 /// both free and bound variables.
 void find_symbols(const exprt &src, find_symbols_sett &dest);
-
-/// \return set of sub-expressions of the expressions contained in the range
-///   defined by \p begin and \p end which have id ID_symbol or ID_next_symbol
-template <typename iteratort>
-DEPRECATED(SINCE(2022, 3, 14, "use find_symbols and a local iteration"))
-find_symbols_sett find_symbols_or_nexts(iteratort begin, iteratort end)
-{
-  static_assert(
-    std::is_base_of<exprt, typename iteratort::value_type>::value,
-    "find_symbols takes exprt iterators as arguments");
-  find_symbols_sett result;
-  std::for_each(begin, end, [&](const exprt &e) { find_symbols(e, result); });
-  return result;
-}
 
 /// Find sub expressions with id ID_symbol, considering both free and bound
 /// variables.
@@ -77,12 +57,6 @@ inline find_symbols_sett find_symbol_identifiers(const exprt &src)
   find_symbols(src, identifiers);
   return identifiers;
 }
-
-DEPRECATED(SINCE(2022, 3, 14, "use has_symbol_expr(exprt, irep_idt, bool)"))
-/// \return true if one of the symbols in \p src is present in \p symbols
-bool has_symbol(
-  const exprt &src,
-  const find_symbols_sett &symbols);
 
 /// Collect all type tags contained in \p src and add them to \p dest.
 void find_type_symbols(


### PR DESCRIPTION
These were deprecated more than 6 months ago (in 7b5eec6f2f354).

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- n/a Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
