### PR TITLE
CONTRACTS: Avoid single conjunction in contracts instrumentation

### DIFF
--- a/regression/contracts/assigns-replace-ignored-return-value/test.desc
+++ b/regression/contracts/assigns-replace-ignored-return-value/test.desc
@@ -1,8 +1,8 @@
 CORE
 main.c
 --replace-call-with-contract bar --replace-call-with-contract baz --enforce-contract foo
-^\[bar.precondition.\d+\] line \d+ Check bar's requires clause in foo: SUCCESS$
-^\[baz.precondition.\d+\] line \d+ Check baz's requires clause in foo: SUCCESS$
+^\[bar.precondition.\d+\] line \d+ Check requires clause of bar in foo: SUCCESS$
+^\[baz.precondition.\d+\] line \d+ Check requires clause of baz in foo: SUCCESS$
 ^EXIT=0$
 ^SIGNAL=0$
 ^VERIFICATION SUCCESSFUL$

--- a/regression/contracts/assigns-replace-ignored-return-value/test.desc
+++ b/regression/contracts/assigns-replace-ignored-return-value/test.desc
@@ -1,6 +1,8 @@
 CORE
 main.c
 --replace-call-with-contract bar --replace-call-with-contract baz --enforce-contract foo
+^\[bar.precondition.\d+\] line \d+ Check bar's requires clause in foo: SUCCESS$
+^\[baz.precondition.\d+\] line \d+ Check baz's requires clause in foo: SUCCESS$
 ^EXIT=0$
 ^SIGNAL=0$
 ^VERIFICATION SUCCESSFUL$

--- a/regression/contracts/assigns-replace-malloc-zero/test.desc
+++ b/regression/contracts/assigns-replace-malloc-zero/test.desc
@@ -1,6 +1,7 @@
 CORE
 main.c
 --replace-call-with-contract foo _ --malloc-may-fail --malloc-fail-null
+^\[foo.precondition.\d+\] line \d+ Check foo's requires clause in main: SUCCESS$
 ^EXIT=0$
 ^SIGNAL=0$
 \[main\.assertion\.1\] line 35 expecting SUCCESS: SUCCESS$

--- a/regression/contracts/assigns-replace-malloc-zero/test.desc
+++ b/regression/contracts/assigns-replace-malloc-zero/test.desc
@@ -1,7 +1,7 @@
 CORE
 main.c
 --replace-call-with-contract foo _ --malloc-may-fail --malloc-fail-null
-^\[foo.precondition.\d+\] line \d+ Check foo's requires clause in main: SUCCESS$
+^\[foo.precondition.\d+\] line \d+ Check requires clause of foo in main: SUCCESS$
 ^EXIT=0$
 ^SIGNAL=0$
 \[main\.assertion\.1\] line 35 expecting SUCCESS: SUCCESS$

--- a/regression/contracts/history-pointer-replace-04/test.desc
+++ b/regression/contracts/history-pointer-replace-04/test.desc
@@ -3,7 +3,7 @@ main.c
 --replace-call-with-contract foo
 ^EXIT=10$
 ^SIGNAL=0$
-^\[foo.precondition.\d+\] line \d+ Check foo's requires clause in main: SUCCESS$
+^\[foo.precondition.\d+\] line \d+ Check requires clause of foo in main: SUCCESS$
 ^\[main.assertion.\d+\] line \d+ assertion p->y \!\= 7: FAILURE$
 ^VERIFICATION FAILED$
 --

--- a/regression/contracts/history-pointer-replace-04/test.desc
+++ b/regression/contracts/history-pointer-replace-04/test.desc
@@ -3,7 +3,7 @@ main.c
 --replace-call-with-contract foo
 ^EXIT=10$
 ^SIGNAL=0$
-^\[foo.precondition.\d+\] line \d+ Check requires clause: SUCCESS$
+^\[foo.precondition.\d+\] line \d+ Check foo's requires clause in main: SUCCESS$
 ^\[main.assertion.\d+\] line \d+ assertion p->y \!\= 7: FAILURE$
 ^VERIFICATION FAILED$
 --

--- a/regression/contracts/quantifiers-exists-both-replace/test.desc
+++ b/regression/contracts/quantifiers-exists-both-replace/test.desc
@@ -3,7 +3,7 @@ main.c
 --replace-call-with-contract f1
 ^EXIT=0$
 ^SIGNAL=0$
-^\[f1.precondition.\d+\] line \d+ Check requires clause: SUCCESS$
+^\[f1.precondition.\d+\] line \d+ Check f1's requires clause in main: SUCCESS$
 ^VERIFICATION SUCCESSFUL$
 --
 ^warning: ignoring

--- a/regression/contracts/quantifiers-exists-both-replace/test.desc
+++ b/regression/contracts/quantifiers-exists-both-replace/test.desc
@@ -3,7 +3,7 @@ main.c
 --replace-call-with-contract f1
 ^EXIT=0$
 ^SIGNAL=0$
-^\[f1.precondition.\d+\] line \d+ Check f1's requires clause in main: SUCCESS$
+^\[f1.precondition.\d+\] line \d+ Check requires clause of f1 in main: SUCCESS$
 ^VERIFICATION SUCCESSFUL$
 --
 ^warning: ignoring

--- a/regression/contracts/quantifiers-exists-requires-replace/test.desc
+++ b/regression/contracts/quantifiers-exists-requires-replace/test.desc
@@ -3,8 +3,8 @@ main.c
 --replace-call-with-contract f1 --replace-call-with-contract f2
 ^EXIT=10$
 ^SIGNAL=0$
-^\[f1.precondition.\d+\] line \d+ Check requires clause: SUCCESS$
-^\[f2.precondition.\d+\] line \d+ Check requires clause: FAILURE$
+^\[f1.precondition.\d+\] line \d+ Check f1's requires clause in main: SUCCESS$
+^\[f2.precondition.\d+\] line \d+ Check f2's requires clause in main: FAILURE$
 ^VERIFICATION FAILED$
 --
 ^warning: ignoring

--- a/regression/contracts/quantifiers-exists-requires-replace/test.desc
+++ b/regression/contracts/quantifiers-exists-requires-replace/test.desc
@@ -3,8 +3,8 @@ main.c
 --replace-call-with-contract f1 --replace-call-with-contract f2
 ^EXIT=10$
 ^SIGNAL=0$
-^\[f1.precondition.\d+\] line \d+ Check f1's requires clause in main: SUCCESS$
-^\[f2.precondition.\d+\] line \d+ Check f2's requires clause in main: FAILURE$
+^\[f1.precondition.\d+\] line \d+ Check requires clause of f1 in main: SUCCESS$
+^\[f2.precondition.\d+\] line \d+ Check requires clause of f2 in main: FAILURE$
 ^VERIFICATION FAILED$
 --
 ^warning: ignoring

--- a/regression/contracts/quantifiers-forall-both-replace/test.desc
+++ b/regression/contracts/quantifiers-forall-both-replace/test.desc
@@ -3,7 +3,7 @@ main.c
 --replace-call-with-contract f1
 ^EXIT=0$
 ^SIGNAL=0$
-^\[f1.precondition.\d+\] line \d+ Check requires clause: SUCCESS$
+^\[f1.precondition.\d+\] line \d+ Check f1's requires clause in main: SUCCESS$
 ^VERIFICATION SUCCESSFUL$
 --
 ^warning: ignoring

--- a/regression/contracts/quantifiers-forall-both-replace/test.desc
+++ b/regression/contracts/quantifiers-forall-both-replace/test.desc
@@ -3,7 +3,7 @@ main.c
 --replace-call-with-contract f1
 ^EXIT=0$
 ^SIGNAL=0$
-^\[f1.precondition.\d+\] line \d+ Check f1's requires clause in main: SUCCESS$
+^\[f1.precondition.\d+\] line \d+ Check requires clause of f1 in main: SUCCESS$
 ^VERIFICATION SUCCESSFUL$
 --
 ^warning: ignoring

--- a/regression/contracts/quantifiers-forall-requires-replace/test.desc
+++ b/regression/contracts/quantifiers-forall-requires-replace/test.desc
@@ -3,7 +3,7 @@ main.c
 --replace-call-with-contract f1
 ^EXIT=0$
 ^SIGNAL=0$
-^\[f1.precondition.\d+\] line \d+ Check requires clause: SUCCESS$
+^\[f1.precondition.\d+\] line \d+ Check f1's requires clause in main: SUCCESS$
 ^VERIFICATION SUCCESSFUL$
 --
 ^warning: ignoring

--- a/regression/contracts/quantifiers-forall-requires-replace/test.desc
+++ b/regression/contracts/quantifiers-forall-requires-replace/test.desc
@@ -3,7 +3,7 @@ main.c
 --replace-call-with-contract f1
 ^EXIT=0$
 ^SIGNAL=0$
-^\[f1.precondition.\d+\] line \d+ Check f1's requires clause in main: SUCCESS$
+^\[f1.precondition.\d+\] line \d+ Check requires clause of f1 in main: SUCCESS$
 ^VERIFICATION SUCCESSFUL$
 --
 ^warning: ignoring

--- a/regression/contracts/test_aliasing_replace/test.desc
+++ b/regression/contracts/test_aliasing_replace/test.desc
@@ -3,7 +3,7 @@ main.c
 --replace-call-with-contract foo
 ^EXIT=10$
 ^SIGNAL=0$
-\[foo.precondition.\d+\] line \d+ Check requires clause: FAILURE
+\[foo.precondition.\d+\] line \d+ Check foo's requires clause in main: FAILURE
 \[main.assertion.\d+\] line \d+ assertion \!\(n \< 4\): SUCCESS
 ^VERIFICATION FAILED$
 --

--- a/regression/contracts/test_aliasing_replace/test.desc
+++ b/regression/contracts/test_aliasing_replace/test.desc
@@ -3,7 +3,7 @@ main.c
 --replace-call-with-contract foo
 ^EXIT=10$
 ^SIGNAL=0$
-\[foo.precondition.\d+\] line \d+ Check foo's requires clause in main: FAILURE
+\[foo.precondition.\d+\] line \d+ Check requires clause of foo in main: FAILURE
 \[main.assertion.\d+\] line \d+ assertion \!\(n \< 4\): SUCCESS
 ^VERIFICATION FAILED$
 --

--- a/regression/contracts/test_array_memory_replace/test.desc
+++ b/regression/contracts/test_array_memory_replace/test.desc
@@ -3,7 +3,7 @@ main.c
 --replace-call-with-contract foo
 ^EXIT=0$
 ^SIGNAL=0$
-\[foo.precondition.\d+\] line \d+ Check foo's requires clause in main: SUCCESS
+\[foo.precondition.\d+\] line \d+ Check requires clause of foo in main: SUCCESS
 \[main.assertion.\d+\] line \d+ assertion o >\= 10 \&\& o \=\= \*n \+ 5: SUCCESS
 \[main.assertion.\d+\] line \d+ assertion n\[9\] == 113: SUCCESS
 ^VERIFICATION SUCCESSFUL$

--- a/regression/contracts/test_array_memory_replace/test.desc
+++ b/regression/contracts/test_array_memory_replace/test.desc
@@ -3,7 +3,7 @@ main.c
 --replace-call-with-contract foo
 ^EXIT=0$
 ^SIGNAL=0$
-\[foo.precondition.\d+\] line \d+ Check requires clause: SUCCESS
+\[foo.precondition.\d+\] line \d+ Check foo's requires clause in main: SUCCESS
 \[main.assertion.\d+\] line \d+ assertion o >\= 10 \&\& o \=\= \*n \+ 5: SUCCESS
 \[main.assertion.\d+\] line \d+ assertion n\[9\] == 113: SUCCESS
 ^VERIFICATION SUCCESSFUL$

--- a/regression/contracts/test_array_memory_too_small_replace/test.desc
+++ b/regression/contracts/test_array_memory_too_small_replace/test.desc
@@ -3,7 +3,7 @@ main.c
 --replace-call-with-contract foo
 ^EXIT=10$
 ^SIGNAL=0$
-\[foo.precondition.\d+\] line \d+ Check requires clause: FAILURE
+\[foo.precondition.\d+\] line \d+ Check foo's requires clause in main: FAILURE
 \[main.assertion.\d+\] line \d+ assertion o >\= 10 \&\& o \=\= \*n \+ 5: SUCCESS
 ^VERIFICATION FAILED$
 --

--- a/regression/contracts/test_array_memory_too_small_replace/test.desc
+++ b/regression/contracts/test_array_memory_too_small_replace/test.desc
@@ -3,7 +3,7 @@ main.c
 --replace-call-with-contract foo
 ^EXIT=10$
 ^SIGNAL=0$
-\[foo.precondition.\d+\] line \d+ Check foo's requires clause in main: FAILURE
+\[foo.precondition.\d+\] line \d+ Check requires clause of foo in main: FAILURE
 \[main.assertion.\d+\] line \d+ assertion o >\= 10 \&\& o \=\= \*n \+ 5: SUCCESS
 ^VERIFICATION FAILED$
 --

--- a/regression/contracts/test_possibly_aliased_arguments/test.desc
+++ b/regression/contracts/test_possibly_aliased_arguments/test.desc
@@ -3,7 +3,7 @@ main.c
 --replace-call-with-contract sub_ptr_values
 ^EXIT=0$
 ^SIGNAL=0$
-\[sub_ptr_values.precondition.\d+\] line \d+ Check requires clause: SUCCESS
+\[sub_ptr_values.precondition.\d+\] line \d+ Check sub\_ptr\_values's requires clause in main: SUCCESS
 ^VERIFICATION SUCCESSFUL$
 --
 --

--- a/regression/contracts/test_possibly_aliased_arguments/test.desc
+++ b/regression/contracts/test_possibly_aliased_arguments/test.desc
@@ -3,7 +3,7 @@ main.c
 --replace-call-with-contract sub_ptr_values
 ^EXIT=0$
 ^SIGNAL=0$
-\[sub_ptr_values.precondition.\d+\] line \d+ Check sub\_ptr\_values's requires clause in main: SUCCESS
+\[sub_ptr_values.precondition.\d+\] line \d+ Check requires clause of sub\_ptr\_values in main: SUCCESS
 ^VERIFICATION SUCCESSFUL$
 --
 --

--- a/regression/contracts/test_scalar_memory_replace/test.desc
+++ b/regression/contracts/test_scalar_memory_replace/test.desc
@@ -3,7 +3,7 @@ main.c
 --replace-call-with-contract foo
 ^EXIT=0$
 ^SIGNAL=0$
-\[foo.precondition.\d+\] line \d+ Check requires clause: SUCCESS
+\[foo.precondition.\d+\] line \d+ Check foo's requires clause in main: SUCCESS
 \[main.assertion.\d+\] line \d+ assertion \_\_CPROVER\_r\_ok\(n, sizeof\(int\)\): SUCCESS
 \[main.assertion.\d+\] line \d+ assertion o >\= 10 \&\& o \=\= \*n \+ 5: SUCCESS
 ^VERIFICATION SUCCESSFUL$

--- a/regression/contracts/test_scalar_memory_replace/test.desc
+++ b/regression/contracts/test_scalar_memory_replace/test.desc
@@ -3,7 +3,7 @@ main.c
 --replace-call-with-contract foo
 ^EXIT=0$
 ^SIGNAL=0$
-\[foo.precondition.\d+\] line \d+ Check foo's requires clause in main: SUCCESS
+\[foo.precondition.\d+\] line \d+ Check requires clause of foo in main: SUCCESS
 \[main.assertion.\d+\] line \d+ assertion \_\_CPROVER\_r\_ok\(n, sizeof\(int\)\): SUCCESS
 \[main.assertion.\d+\] line \d+ assertion o >\= 10 \&\& o \=\= \*n \+ 5: SUCCESS
 ^VERIFICATION SUCCESSFUL$

--- a/regression/contracts/test_struct_replace/test.desc
+++ b/regression/contracts/test_struct_replace/test.desc
@@ -3,7 +3,7 @@ main.c
 --replace-call-with-contract foo
 ^EXIT=0$
 ^SIGNAL=0$
-\[foo.precondition.\d+\] line \d+ Check foo's requires clause in main: SUCCESS
+\[foo.precondition.\d+\] line \d+ Check requires clause of foo in main: SUCCESS
 \[main.assertion.\d+\] line \d+ assertion rval \=\= x->baz \+ x->qux: SUCCESS
 \[main.assertion.\d+\] line \d+ assertion \*x \=\= \*y: SUCCESS
 ^VERIFICATION SUCCESSFUL$

--- a/regression/contracts/test_struct_replace/test.desc
+++ b/regression/contracts/test_struct_replace/test.desc
@@ -3,7 +3,7 @@ main.c
 --replace-call-with-contract foo
 ^EXIT=0$
 ^SIGNAL=0$
-\[foo.precondition.\d+\] line \d+ Check requires clause: SUCCESS
+\[foo.precondition.\d+\] line \d+ Check foo's requires clause in main: SUCCESS
 \[main.assertion.\d+\] line \d+ assertion rval \=\= x->baz \+ x->qux: SUCCESS
 \[main.assertion.\d+\] line \d+ assertion \*x \=\= \*y: SUCCESS
 ^VERIFICATION SUCCESSFUL$

--- a/regression/contracts/variant_multidimensional_ackermann/test.desc
+++ b/regression/contracts/variant_multidimensional_ackermann/test.desc
@@ -1,8 +1,8 @@
 CORE
 main.c
 --apply-loop-contracts --replace-call-with-contract ackermann
-^\[ackermann.precondition\.\d+\] line 9 Check ackermann's requires clause in main: SUCCESS$
-^\[ackermann.precondition\.\d+\] line 34 Check ackermann's requires clause in ackermann: SUCCESS$
+^\[ackermann.precondition\.\d+\] line \d+ Check requires clause of ackermann in main: SUCCESS$
+^\[ackermann.precondition\.\d+\] line \d+ Check requires clause of ackermann in ackermann: SUCCESS$
 ^\[ackermann\.\d+\] line 21 Check loop invariant before entry: SUCCESS$
 ^\[ackermann\.\d+\] line 21 Check that loop invariant is preserved: SUCCESS$
 ^\[ackermann\.\d+\] line 21 Check decreases clause on loop iteration: SUCCESS$

--- a/regression/contracts/variant_multidimensional_ackermann/test.desc
+++ b/regression/contracts/variant_multidimensional_ackermann/test.desc
@@ -1,8 +1,8 @@
 CORE
 main.c
 --apply-loop-contracts --replace-call-with-contract ackermann
-^\[ackermann.precondition\.\d+\] line 17 Check requires clause: SUCCESS$
-^\[ackermann.precondition\.\d+\] line 17 Check requires clause: SUCCESS$
+^\[ackermann.precondition\.\d+\] line 9 Check ackermann's requires clause in main: SUCCESS$
+^\[ackermann.precondition\.\d+\] line 34 Check ackermann's requires clause in ackermann: SUCCESS$
 ^\[ackermann\.\d+\] line 21 Check loop invariant before entry: SUCCESS$
 ^\[ackermann\.\d+\] line 21 Check that loop invariant is preserved: SUCCESS$
 ^\[ackermann\.\d+\] line 21 Check decreases clause on loop iteration: SUCCESS$

--- a/src/goto-instrument/contracts/contracts.h
+++ b/src/goto-instrument/contracts/contracts.h
@@ -219,6 +219,12 @@ public:
     codet &expression,
     source_locationt location,
     const irep_idt &mode);
+
+  // for "auxiliary" functions generate contract constrainst
+  goto_convertt &get_converter()
+  {
+    return converter;
+  }
 };
 
 #endif // CPROVER_GOTO_INSTRUMENT_CONTRACTS_CONTRACTS_H

--- a/src/goto-instrument/contracts/contracts.h
+++ b/src/goto-instrument/contracts/contracts.h
@@ -212,13 +212,12 @@ public:
     goto_programt &history,
     const irep_idt &id);
 
-  /// This function creates and returns an instruction that corresponds to the
-  /// ensures clause. It also returns a list of instructions related to
-  /// initializing history variables, if required.
-  std::pair<goto_programt, goto_programt> create_ensures_instruction(
-    codet &expression,
-    source_locationt location,
-    const irep_idt &mode);
+  /// This function generates all the instructions required to initialize
+  /// history variables.
+  void generate_history_variables_initialization(
+    exprt &clause,
+    const irep_idt &mode,
+    goto_programt &program);
 
   // for "auxiliary" functions generate contract constrainst
   goto_convertt &get_converter()


### PR DESCRIPTION
Currently, requires and ensures clauses are always combined into a single conjunction. The resulting clause is then used to create a single assertion or assumption, which makes really difficult to debug issues with large function contracts. This commit preserves the source location of the clauses by creating one assertion/assumption for each clause in the function contract (i.e., either requires or ensures).

Signed-off-by: Felipe R. Monteiro <felisous@amazon.com>

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
