### PR TITLE
Dump-C: support struct/union types without tags

### DIFF
--- a/regression/goto-instrument/dump-non-tag-struct/main.c
+++ b/regression/goto-instrument/dump-non-tag-struct/main.c
@@ -1,0 +1,9 @@
+#include <stdlib.h>
+
+int main()
+{
+  // CBMC's model of calloc includes an overflow check, which in turn creates a
+  // struct that holds both the arithmetic result and the overflow information.
+  // dump-c did not support this struct defined in place.
+  calloc(10, 1);
+}

--- a/regression/goto-instrument/dump-non-tag-struct/test.desc
+++ b/regression/goto-instrument/dump-non-tag-struct/test.desc
@@ -1,0 +1,13 @@
+CORE
+main.c
+--dump-c
+VERIFICATION SUCCESSFUL
+^EXIT=0$
+^SIGNAL=0$
+--
+^Invariant check failed
+^warning: ignoring
+irep
+--
+This test must pass compiling the output generated using dump-c, which implies
+that dump-c succeeded and that all struct declarations are present.


### PR DESCRIPTION
Dump-C assumed that all occurrences of struct or union types would be via their tags. This was never a documented invariant, but largely true until 5ea97b3e8ec0: that commit does introduce struct types in place, without making any effort to create tags. Dump-C now supports this case.

Fixes: #7158

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
