### PR TITLE
Man pages: consistent spelling of GOTO binary

### DIFF
--- a/doc/man/goto-cc.1
+++ b/doc/man/goto-cc.1
@@ -18,11 +18,11 @@ goto\-cc \- C/C++ to goto compiler
 
 .SH DESCRIPTION
 .B goto\-cc
-reads source code, and generates a goto-binary. Its
+reads source code, and generates a GOTO binary. Its
 command-line interface is designed to mimic that of
 .BR gcc (1).
 Note in particular that \fBgoto-cc\fR distinguishes between compiling
-and linking phases, just as \fBgcc\fR(1) does. \fBcbmc\fR(1) expects a goto-binary
+and linking phases, just as \fBgcc\fR(1) does. \fBcbmc\fR(1) expects a GOTO binary
 for which linking has been completed.
 .PP
 The basename of the file that is used to invoke \fBgoto-cc\fR controls which
@@ -30,10 +30,10 @@ behavior will be emulated. This is typically accomplished by using symbolic
 links.
 .IP
 \fBgoto-cc\fR: invokes the default system compiler as preprocessor and just
-builds a goto-binary.
+builds a GOTO binary.
 .IP
 \fBgoto-gcc\fR: invokes \fBgcc\fR(1) as preprocessor and builds an \fBelf\fR(5)
-object file including an additional \fIgoto-cc\fR section that holds the goto
+object file including an additional \fIgoto-cc\fR section that holds the GOTO
 binary.
 .IP
 \fBgoto-ld\fR: only performs linking, and also builds an \fBelf\fR(5) object as

--- a/doc/man/goto-harness.1
+++ b/doc/man/goto-harness.1
@@ -11,7 +11,7 @@ show version
 .TP
 .B goto\-harness \fIin\fB \fIout\fB \-\-harness\-function\-name\ \fIname\fB \-\-harness\-type \fIharness\-type\fR [\fBharness-options\fR]
 build harness for \fIin\fR and write harness to \fIout\fR; the harness is
-printed as C code, if \fIout\fR has a .c suffix, else a goto binary including
+printed as C code, if \fIout\fR has a .c suffix, else a GOTO binary including
 the harness is generated
 .SH DESCRIPTION
 \fBgoto\-harness\fR constructs functions that set up an appropriate environment
@@ -104,7 +104,7 @@ Treat the function parameter with the name \fIp\fR as a string of characters.
 Initialize memory from JSON memory snapshot stored in \fIfile\fR.
 .TP
 \fB\-\-initial\-goto\-location\fR \fIfunc\fR[:\fIn\fR]
-Use function \fIfunc\fR and goto binary location number \fIn\fR as entry point.
+Use function \fIfunc\fR and GOTO binary location number \fIn\fR as entry point.
 .TP
 \fB\-\-initial\-source\-location\fR \fIfile\R:\fIn\fR
 Use given file name \fIfile\fR and line number \fIn\R in that file as entry

--- a/doc/man/symtab2gb.1
+++ b/doc/man/symtab2gb.1
@@ -1,6 +1,6 @@
 .TH SYMTAB2GB "1" "June 2022" "symtab2gb-5.59.0" "User Commands"
 .SH NAME
-symtab2gb \- Compile JSON symbol tables to a goto binary
+symtab2gb \- Compile JSON symbol tables to a GOTO binary
 .SH SYNOPSIS
 .TP
 .B symtab2gb [\-?] [\-h] [\-\-help]
@@ -8,9 +8,9 @@ show help
 .TP
 .B symtab2gb \fIjson\-symtab\-file\fR+ [\fB\-\-out \fIoutfile\fR]
 compile symbol tables in JSON format
-to a single goto binary
+to a single GOTO binary
 .SH DESCRIPTION
-This utility is to compile a \fBcbmc\fR(1) symbols table (in JSON format) into a goto binary.
+This utility is to compile a \fBcbmc\fR(1) symbols table (in JSON format) into a GOTO binary.
 This is to support integration of external language frontends, such as Ada
 (using GNAT2GOTO: https://github.com/diffblue/gnat2goto) or Rust (using Kani:
 https://github.com/model-checking/kani).


### PR DESCRIPTION
We sometimes used "goto-binary" or "goto binary." Use "GOTO binary" in all cases.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
