### PR TITLE
Java bytecode: type checking symbol expressions cannot yield a fresh …

### DIFF
--- a/jbmc/src/java_bytecode/java_bytecode_typecheck_expr.cpp
+++ b/jbmc/src/java_bytecode/java_bytecode_typecheck_expr.cpp
@@ -69,50 +69,14 @@ void java_bytecode_typecheckt::typecheck_expr_java_new_array(
 
 void java_bytecode_typecheckt::typecheck_expr_symbol(symbol_exprt &expr)
 {
-  irep_idt identifier=expr.get_identifier();
+  const irep_idt &identifier = expr.get_identifier();
 
-  // does it exist already in the destination symbol table?
-  symbol_tablet::symbolst::const_iterator s_it=
-    symbol_table.symbols.find(identifier);
+  // the java_bytecode_convert_class and java_bytecode_convert_method made sure
+  // "identifier" exists in the symbol table
+  const symbolt &symbol = symbol_table.lookup_ref(identifier);
 
-  if(s_it==symbol_table.symbols.end())
-  {
-    PRECONDITION(
-      has_prefix(id2string(identifier), "java::") ||
-      has_prefix(id2string(identifier), CPROVER_PREFIX));
+  INVARIANT(!symbol.is_type, "symbol identifier should not be a type");
 
-    // no, create the symbol
-    symbolt new_symbol;
-    new_symbol.name=identifier;
-    new_symbol.type=expr.type();
-    new_symbol.base_name=expr.get(ID_C_base_name);
-    new_symbol.pretty_name=id2string(identifier).substr(6, std::string::npos);
-    new_symbol.mode=ID_java;
-    new_symbol.is_type=false;
-
-    if(new_symbol.type.id()==ID_code)
-    {
-      new_symbol.is_lvalue=false;
-    }
-    else
-    {
-      new_symbol.is_lvalue=true;
-    }
-
-    if(symbol_table.add(new_symbol))
-    {
-      error() << "failed to add expression symbol to symbol table" << eom;
-      throw 0;
-    }
-  }
-  else
-  {
-    // yes!
-    INVARIANT(!s_it->second.is_type, "symbol identifier should not be a type");
-
-    const symbolt &symbol=s_it->second;
-
-    // type the expression
-    expr.type()=symbol.type;
-  }
+  // type the expression
+  expr.type() = symbol.type;
 }


### PR DESCRIPTION
…symbol

java_bytecode_convert_class and java_bytecode_convert_method take care of adding all symbols to the symbol table ahead of type checking. Therefore, typecheck_expr_symbol could never end up in the branch where a symbol was missing. This commit removes this branch.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
