### PR TITLE
Ensure test coverage of remove_asmt::msc_asm_function_call

### DIFF
--- a/regression/cbmc-concurrency/memory_barrier2/msvc.c
+++ b/regression/cbmc-concurrency/memory_barrier2/msvc.c
@@ -1,0 +1,32 @@
+volatile int turn;
+int x;
+volatile int flag1 = 0, flag2 = 0;
+
+void *thr1(void *arg)
+{
+  flag1 = 1;
+  turn = 1;
+  __asm { mfence; }
+  __CPROVER_assume(!(flag2 == 1 && turn == 1));
+  x = 0;
+  __CPROVER_assert(x <= 0, "");
+  flag1 = 0;
+}
+
+void *thr2(void *arg)
+{
+  flag2 = 1;
+  turn = 0;
+  __asm { mfence; }
+  __CPROVER_assume(!(flag1 == 1 && turn == 0));
+  x = 1;
+  __CPROVER_assert(x >= 1, "");
+  flag2 = 0;
+}
+
+int main()
+{
+__CPROVER_ASYNC_1:
+  thr1(0);
+  thr2(0);
+}

--- a/regression/cbmc-concurrency/memory_barrier2/msvc.desc
+++ b/regression/cbmc-concurrency/memory_barrier2/msvc.desc
@@ -1,0 +1,11 @@
+CORE
+msvc.c
+--mm tso --winx64
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring
+--
+This is the same test as main.c/test.desc, but now using Visual Studio inline
+ASM syntax.

--- a/regression/cbmc-library/__asm_fstcw-01/main.c
+++ b/regression/cbmc-library/__asm_fstcw-01/main.c
@@ -1,9 +1,20 @@
 #include <assert.h>
-#include <x86_assembler.h>
+#include <fenv.h>
 
 int main()
 {
-  __asm_fstcw();
-  assert(0);
-  return 0;
+  unsigned short cw;
+#ifdef __GNUC__
+  __asm__("fstcw %0" : "=m"(cw));
+#else
+  __asm { fstcw cw; }
+#endif
+  assert((cw & 0xc00) == 0);
+  fesetround(FE_UPWARD);
+#ifdef __GNUC__
+  __asm__("fstcw %0" : "=m"(cw));
+#else
+  __asm { fstcw cw; }
+#endif
+  assert((cw & 0xc00) == 0x800);
 }

--- a/regression/cbmc-library/__asm_fstcw-01/msvc.c
+++ b/regression/cbmc-library/__asm_fstcw-01/msvc.c
@@ -1,0 +1,10 @@
+int main()
+{
+  unsigned short cw;
+  __asm { fstcw cw; }
+  __CPROVER_assert((cw & 0xc00) == 0, "default rounding mode");
+  // fesetround(FE_UPWARD);
+  __CPROVER_rounding_mode = 2;
+  __asm { fstcw cw; }
+  __CPROVER_assert((cw & 0xc00) == 0x800, "round upwards");
+}

--- a/regression/cbmc-library/__asm_fstcw-01/msvc.desc
+++ b/regression/cbmc-library/__asm_fstcw-01/msvc.desc
@@ -1,0 +1,11 @@
+CORE
+msvc.c
+--pointer-check --bounds-check --winx64
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring
+--
+This is the same test as main.c/test.desc, but now using Visual Studio inline
+ASM syntax.

--- a/regression/cbmc-library/__asm_fstcw-01/test.desc
+++ b/regression/cbmc-library/__asm_fstcw-01/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.c
 --pointer-check --bounds-check
 ^EXIT=0$


### PR DESCRIPTION
We had coverage of the GCC counterpart to this function. This commit now adds a variant of an existing test to use MSVC assembler syntax. Running this new test with --winx64 now ensures that the code paths reaching msc_asm_function_call are hit.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
