### PR TITLE
C front-end: floating-point built-ins are in the symbol table

### DIFF
--- a/src/goto-programs/builtin_functions.cpp
+++ b/src/goto-programs/builtin_functions.cpp
@@ -24,7 +24,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/rational.h>
 #include <util/rational_tools.h>
 #include <util/simplify_expr.h>
-#include <util/symbol_table_base.h>
+#include <util/symbol.h>
 
 #include <langapi/language_util.h>
 
@@ -1473,20 +1473,16 @@ void goto_convertt::do_function_call_symbol(
     // append d or f for double/float
     name+=use_double?'d':'f';
 
+    DATA_INVARIANT(
+      ns.lookup(name).type == f_type,
+      "builtin declaration should match constructed type");
+
     symbol_exprt new_function=function;
     new_function.set_identifier(name);
     new_function.type()=f_type;
 
     code_function_callt function_call(lhs, new_function, new_arguments);
     function_call.add_source_location()=function.source_location();
-
-    if(!symbol_table.has_symbol(name))
-    {
-      symbolt new_symbol{name, f_type, mode};
-      new_symbol.base_name=name;
-      new_symbol.location=function.source_location();
-      symbol_table.add(new_symbol);
-    }
 
     copy(function_call, FUNCTION_CALL, dest);
   }


### PR DESCRIPTION
It should never be the case that no symbol for `__CPROVER_isgreaterf`, `__CPROVER_isgreaterd` and similar floating-point built-ins is present for these are declared in cprover_builtin_headers.h. This commit removes dead code and adds an additional consistency check.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
