### PR TITLE
C library: fscanf for modern glibc

### DIFF
--- a/regression/cbmc-library/fscanf-01/main.c
+++ b/regression/cbmc-library/fscanf-01/main.c
@@ -3,7 +3,11 @@
 
 int main()
 {
-  fscanf();
-  assert(0);
+  FILE *f = fopen("main.c", "r");
+  if(f == NULL)
+    return 1;
+  char dest[10];
+  int result = fscanf(f, "%s", dest);
+  assert(result == 1);
   return 0;
 }

--- a/regression/cbmc-library/fscanf-01/test.desc
+++ b/regression/cbmc-library/fscanf-01/test.desc
@@ -1,8 +1,11 @@
 KNOWNBUG
 main.c
---pointer-check --bounds-check
+--pointer-check --bounds-check --string-abstraction
 ^EXIT=0$
 ^SIGNAL=0$
 ^VERIFICATION SUCCESSFUL$
 --
 ^warning: ignoring
+--
+This test demonstrates a bug in string abstraction which appears to introduce a
+type inconsistency that trips up the simplifier.

--- a/src/ansi-c/library/stdio.c
+++ b/src/ansi-c/library/stdio.c
@@ -844,6 +844,28 @@ __CPROVER_HIDE:;
   return result;
 }
 
+/* FUNCTION: __isoc99_fscanf */
+
+#ifndef __CPROVER_STDIO_H_INCLUDED
+#  include <stdio.h>
+#  define __CPROVER_STDIO_H_INCLUDED
+#endif
+
+#ifndef __CPROVER_STDARG_H_INCLUDED
+#  include <stdarg.h>
+#  define __CPROVER_STDARG_H_INCLUDED
+#endif
+
+int __isoc99_fscanf(FILE *restrict stream, const char *restrict format, ...)
+{
+__CPROVER_HIDE:;
+  va_list list;
+  va_start(list, format);
+  int result = vfscanf(stream, format, list);
+  va_end(list);
+  return result;
+}
+
 /* FUNCTION: scanf */
 
 #ifndef __CPROVER_STDIO_H_INCLUDED

--- a/src/goto-programs/string_instrumentation.cpp
+++ b/src/goto-programs/string_instrumentation.cpp
@@ -251,7 +251,7 @@ void string_instrumentationt::do_function_call(
       do_sprintf(dest, target, lhs, arguments);
     else if(identifier=="snprintf")
       do_snprintf(dest, target, lhs, arguments);
-    else if(identifier=="fscanf")
+    else if(identifier == "fscanf" || identifier == "__isoc99_fscanf")
       do_fscanf(dest, target, lhs, arguments);
 
     remove_skip(dest);


### PR DESCRIPTION
Recent versions of glibc rename fscanf (and also some others) to ones with a prefix of __isoc99_, rendering our previous C library model useless. This commit adds a copy of the existing model with that new name, and also seeks to use it in a regression test.

The original goal, however, was to exercise a piece of code in string abstraction.  Exercising this code now works, but results in an invariant failure. The test, therefore, remains marked KNOWNBUG.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
