### PR TITLE
Fix auto-objects and make rw_ok assumptions create proper backing objects

### DIFF
--- a/doc/cprover-manual/memory-primitives.md
+++ b/doc/cprover-manual/memory-primitives.md
@@ -347,6 +347,12 @@ struct tree_node {
 Using `__CPROVER_assume(__CPROVER_rw_ok(root, sizeof(*root)))` on a
 `struct tree_node *root` creates a nondeterministic tree bounded by `--unwind`.
 
+Chained dereferences such as `head->next->data` or `root->left->right` can be
+used directly: CBMC lifts the intermediate pointers into temporaries (see
+`--no-lift-nested-dereferences`), so a guarded access like
+`if(head->next) head->next->data` reads the intermediate pointer once and
+verifies.
+
 #### Soundness guarantees
 
 The `rw_ok`-in-assumptions feature is designed to not suppress genuine
@@ -387,16 +393,6 @@ memory-safety errors:
   assigned to the new array object, so that whole-array operations (such as
   `__CPROVER_array_copy` / `__CPROVER_array_equal`) resolve to a single target;
   this breaks such pre-existing aliases, and `b` keeps its old (nondet) value.
-
-- **Chained dereference expressions:** A lazily-created inductive structure can
-  be traversed to any depth (bounded by `--unwind`) using a loop or by binding
-  intermediate pointers to local variables -- e.g. `n = head->next;` and then
-  using `n->data`. A single chained dereference *expression* that walks through
-  a freshly-created node in one go, such as `head->next->data`, may instead
-  raise a spurious dereference failure on the intermediate pointer; assign the
-  intermediate pointer to a local variable first. This is a property of how
-  auto-objects are materialised on dereference, not a limit on the depth or the
-  kind of field being read.
 
 - **Pointer primitive checks:** The `--pointer-primitive-check` option may
   report failures for the `rw_ok` call itself when the pointer is

--- a/doc/cprover-manual/memory-primitives.md
+++ b/doc/cprover-manual/memory-primitives.md
@@ -236,8 +236,6 @@ At present, both primitives are equivalent as all memory in CBMC is considered
 both readable and writeable. The primitives return true if `p` points to a live
 object and the object that `p` points into extends to at least `size` more
 bytes. Else, an assertion encompassing the primitive will be reported to fail.
-Do not use these primitives in assumptions when `p` can be not valid as such use
-can yield spurious verification results.
 
 ```C
 char *p = malloc(10);
@@ -246,6 +244,180 @@ p += 5;
 assert(__CPROVER_r_ok(p, 3));  // valid
 assert(__CPROVER_r_ok(p, 10)); // fails
 ```
+
+### Modeling valid memory with `rw_ok` assumptions
+
+A common pattern in verification harnesses is to assume that a pointer argument
+points to valid memory, without explicitly calling `malloc`. This is done by
+combining `__CPROVER_assume` with `__CPROVER_rw_ok` (or `__CPROVER_r_ok` /
+`__CPROVER_w_ok`).
+
+**Important:** This feature only activates when `rw_ok` appears inside
+`__CPROVER_assume`. Using `rw_ok` in assertions or other contexts does not
+create backing objects. Pointers that are not explicitly assumed valid via
+`rw_ok` will still correctly fail pointer checks when dereferenced — the
+feature does not suppress any genuine memory-safety errors.
+
+#### Arrays
+
+When the size argument is a compile-time constant (or can be resolved to one
+through constant propagation) and is larger than a single element, CBMC creates
+a backing array object of the appropriate size. The pointer then behaves like
+one returned by `malloc`: array indexing, `memcpy`, `__CPROVER_array_copy`, and
+other operations all work correctly.
+
+```C
+unsigned int *a;
+size_t n = 3;
+__CPROVER_assume(__CPROVER_rw_ok(a, n * sizeof(*a)));
+// a now behaves like a pointer to an array of 3 unsigned ints
+a[0] = 10;
+a[1] = 20;
+a[2] = 30;
+assert(a[0] == 10 && a[1] == 20 && a[2] == 30); // succeeds
+```
+
+Run with: `cbmc --pointer-check --no-pointer-primitive-check example.c`
+
+#### Pointer aliases
+
+Pointer aliases created before or after the `rw_ok` assumption work correctly:
+
+```C
+unsigned int *a;
+unsigned int *b = a;                                // alias before assume
+__CPROVER_assume(__CPROVER_rw_ok(a, sizeof(*a)));
+unsigned int *c = a;                                // alias after assume
+*a = 1;
+assert(*b == 1 && *c == 1);                         // succeeds
+```
+
+#### Inductive data structures (linked lists, trees)
+
+When `rw_ok` is used on a pointer to a struct that contains pointer members,
+CBMC automatically creates a chain of valid objects. Each pointer member in the
+struct is nondeterministically set to either NULL or a pointer to a fresh valid
+object of the same type. When that fresh object is later dereferenced, its
+pointer members are initialized in the same way, creating a lazy chain.
+
+The maximum depth of this chain is bounded by the `--unwind` option: with
+`--unwind N`, the chain can have at most N-1 nodes.
+
+```C
+struct node {
+  int data;
+  struct node *next;
+};
+
+int list_length(struct node *head) {
+  int count = 0;
+  struct node *curr = head;
+  while(curr != 0) {
+    count++;
+    curr = curr->next;
+  }
+  return count;
+}
+
+int main() {
+  struct node *head;
+  __CPROVER_assume(__CPROVER_rw_ok(head, sizeof(*head)));
+  __CPROVER_assume(head != 0);
+
+  int len = list_length(head);
+  assert(len >= 1);  // succeeds: head is non-null, so at least 1 node
+}
+```
+
+Run with: `cbmc --pointer-check --no-pointer-primitive-check --unwind 4 example.c`
+
+With `--unwind 4`, the list has at most 3 nodes. Increasing `--unwind` allows
+verification of longer lists.
+
+This also works for trees and other recursive data structures:
+
+```C
+struct tree_node {
+  int value;
+  struct tree_node *left;
+  struct tree_node *right;
+};
+```
+
+Using `__CPROVER_assume(__CPROVER_rw_ok(root, sizeof(*root)))` on a
+`struct tree_node *root` creates a nondeterministic tree bounded by `--unwind`.
+
+#### Soundness guarantees
+
+The `rw_ok`-in-assumptions feature is designed to not suppress genuine
+memory-safety errors:
+
+- **Only explicit `rw_ok` assumptions create objects.** A nondet pointer that is
+  dereferenced without a prior `rw_ok` assumption will still fail all pointer
+  checks (`pointer NULL`, `pointer invalid`, etc.). The auto-object mechanism
+  does not fire for such pointers.
+
+- **Pointer checks are still performed.** Even with `rw_ok`, CBMC checks that
+  each dereference is within the bounds of the created object. For example,
+  accessing `a[3]` when `rw_ok(a, 3 * sizeof(*a))` was assumed will correctly
+  report an out-of-bounds error.
+
+- **NULL is still possible.** For inductive data structures, each pointer member
+  is nondeterministically NULL or valid. CBMC explores both possibilities. If
+  the code dereferences a pointer without checking for NULL, the NULL case will
+  be reported as a failure.
+
+#### Limitations
+
+- **Non-constant sizes:** When the size argument to `rw_ok` cannot be resolved
+  to a compile-time constant (e.g., it depends on a nondet variable), the array
+  optimization does not apply. The pointer will behave as a single-element
+  pointer. Array indexing beyond element 0 may produce incorrect results.
+
+- **Sizes smaller than one element:** When the constant size passed to `rw_ok`
+  is smaller than `sizeof(*ptr)`, no backing object can be created. CBMC emits a
+  warning and the assumption has no effect; a subsequent dereference will fail
+  pointer checks as if no `rw_ok` had been written.
+
+- **Aliases and multi-element `rw_ok`:** For a single-element `rw_ok`
+  (`size == sizeof(*ptr)`) the pointer is constrained via an assumption, so an
+  alias established *before* the assume (e.g. `b = a;` followed by
+  `__CPROVER_assume(__CPROVER_rw_ok(a, sizeof(*a)))`) continues to refer to the
+  same object. For a multi-element `rw_ok` the pointer is instead strongly
+  assigned to the new array object, so that whole-array operations (such as
+  `__CPROVER_array_copy` / `__CPROVER_array_equal`) resolve to a single target;
+  this breaks such pre-existing aliases, and `b` keeps its old (nondet) value.
+
+- **Chained dereference expressions:** A lazily-created inductive structure can
+  be traversed to any depth (bounded by `--unwind`) using a loop or by binding
+  intermediate pointers to local variables -- e.g. `n = head->next;` and then
+  using `n->data`. A single chained dereference *expression* that walks through
+  a freshly-created node in one go, such as `head->next->data`, may instead
+  raise a spurious dereference failure on the intermediate pointer; assign the
+  intermediate pointer to a local variable first. This is a property of how
+  auto-objects are materialised on dereference, not a limit on the depth or the
+  kind of field being read.
+
+- **Pointer primitive checks:** The `--pointer-primitive-check` option may
+  report failures for the `rw_ok` call itself when the pointer is
+  uninitialized. Use `--no-pointer-primitive-check` to suppress these when the
+  `rw_ok` assumption is intentional.
+
+- **Not a substitute for contracts.** For modular verification with function
+  contracts, use `__CPROVER_is_fresh` in `__CPROVER_requires` /
+  `__CPROVER_ensures` clauses instead. The `rw_ok`-in-assumptions feature is
+  intended for lightweight harness writing without contracts.
+
+#### Comparison with `malloc` and `__CPROVER_is_fresh`
+
+| Feature | `malloc` | `rw_ok` in assume | `is_fresh` in contract |
+|---------|----------|-------------------|----------------------|
+| Creates backing object | Yes | Yes (constant size) | Yes |
+| Array support | Yes | Yes (constant size) | Yes |
+| Linked list support | Manual | Automatic (lazy) | Via recursive predicates |
+| Pointer aliases | Work | Work | Work |
+| Modular verification | No | No | Yes |
+| Requires `--no-pointer-primitive-check` | No | Yes | No |
 
 ## Detecting potential misuses of memory primitives
 

--- a/doc/man/cbmc.1
+++ b/doc/man/cbmc.1
@@ -354,6 +354,9 @@ run full slicer (experimental)
 .TP
 \fB\-\-drop\-unused\-functions\fR
 drop functions trivially unreachable from main function
+.TP
+\fB\-\-no\-lift\-nested\-dereferences\fR
+do not rewrite nested pointer dereferences into intermediate temporaries
 .SS "Semantic transformations:"
 .TP
 \fB\-\-nondet\-static\fR

--- a/regression/cbmc/auto_objects1/main.c
+++ b/regression/cbmc/auto_objects1/main.c
@@ -1,0 +1,13 @@
+int main()
+{
+  int *auto_object_source1;
+#pragma CPROVER check push
+#pragma CPROVER check disable "pointer"
+  if(auto_object_source1 != 0)
+    int dummy = *auto_object_source1; // triggers creating an auto object
+#pragma CPROVER check pop
+  if(auto_object_source1 != 0 && *auto_object_source1 == 42) // uses auto object
+  {
+    __CPROVER_assert(*auto_object_source1 == 42, "42");
+  }
+}

--- a/regression/cbmc/auto_objects1/test.desc
+++ b/regression/cbmc/auto_objects1/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+--pointer-check
+^VERIFICATION SUCCESSFUL$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring

--- a/regression/cbmc/lift_nested_dereferences1/main.c
+++ b/regression/cbmc/lift_nested_dereferences1/main.c
@@ -1,0 +1,26 @@
+struct node
+{
+  int data;
+  struct node *next;
+};
+
+// A chained dereference head->next->data reads the intermediate pointer
+// head->next twice: once in the guard and once in the dereference. The
+// nested-dereference lifting pass hoists it into a single temporary, so the
+// guard and the dereference agree on the same value and the deep read
+// verifies. With --no-lift-nested-dereferences the intermediate pointer is
+// read (and lazily materialised) twice, and the dereference is reported as a
+// spurious failure. See https://github.com/diffblue/cbmc/issues/7829
+int main()
+{
+  struct node *head;
+  __CPROVER_assume(__CPROVER_rw_ok(head, sizeof(*head)));
+  __CPROVER_assume(head != 0);
+
+  if(head->next != 0)
+  {
+    int d = head->next->data;
+    __CPROVER_assert(d == d, "deep read via chained dereference");
+  }
+  return 0;
+}

--- a/regression/cbmc/lift_nested_dereferences1/no-lift.desc
+++ b/regression/cbmc/lift_nested_dereferences1/no-lift.desc
@@ -1,0 +1,12 @@
+CORE broken-cprover-smt-backend no-new-smt
+main.c
+--pointer-check --no-pointer-primitive-check --unwind 3 --no-unwinding-assertions
+^VERIFICATION FAILED$
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring
+--
+With --no-lift-nested-dereferences the intermediate pointer head->next is
+dereferenced (and lazily materialised) twice, so the chained dereference is
+reported as a spurious failure. This pins the effect of the lifting pass.

--- a/regression/cbmc/lift_nested_dereferences1/test.desc
+++ b/regression/cbmc/lift_nested_dereferences1/test.desc
@@ -1,0 +1,12 @@
+CORE broken-cprover-smt-backend no-new-smt
+main.c
+--pointer-check --no-pointer-primitive-check --unwind 3 --no-unwinding-assertions --lift-nested-dereferences
+^VERIFICATION SUCCESSFUL$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--
+With nested-dereference lifting (on by default) the intermediate pointer
+head->next is hoisted into a single temporary, so the chained dereference
+head->next->data verifies. See GitHub issue diffblue/cbmc#7829.

--- a/regression/cbmc/r_w_ok_auto_object_alias/main.c
+++ b/regression/cbmc/r_w_ok_auto_object_alias/main.c
@@ -1,0 +1,31 @@
+#include <assert.h>
+#include <stdlib.h>
+
+// Tests that auto-object assumptions propagate to aliases.
+// See https://github.com/diffblue/cbmc/issues/7829
+int main()
+{
+  unsigned int *a;
+  unsigned int *b;
+  unsigned int *c;
+
+  // create alias before assumption
+  b = a;
+  __CPROVER_assume(__CPROVER_rw_ok(a, sizeof(*a)));
+
+  // create alias after assumption
+  c = a;
+
+  assert(a);
+  assert(b);
+  assert(c);
+
+  // dereference through aliases should pass pointer checks
+  assert(*b == *a);
+  assert(*c == *a);
+
+  *a = 1;
+  // assertions and pointer checks should pass for aliases
+  assert(*b == 1);
+  assert(*c == 1);
+}

--- a/regression/cbmc/r_w_ok_auto_object_alias/test.desc
+++ b/regression/cbmc/r_w_ok_auto_object_alias/test.desc
@@ -1,0 +1,11 @@
+CORE broken-cprover-smt-backend no-new-smt
+main.c
+--pointer-check --bounds-check --no-pointer-primitive-check --lift-nested-dereferences
+^VERIFICATION SUCCESSFUL$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--
+Tests that auto-object assumptions from rw_ok propagate correctly to pointer
+aliases. See GitHub issue diffblue/cbmc#7829.

--- a/regression/cbmc/r_w_ok_auto_object_array/main.c
+++ b/regression/cbmc/r_w_ok_auto_object_array/main.c
@@ -1,0 +1,30 @@
+#include <assert.h>
+#include <stdlib.h>
+
+// Tests that auto-objects created via rw_ok work with array operations.
+// See https://github.com/diffblue/cbmc/issues/7829
+int main()
+{
+  size_t n = 3;
+
+  unsigned int *a;
+  __CPROVER_assume(__CPROVER_rw_ok(a, n * sizeof(*a)));
+  assert(a);
+
+  unsigned int *old_a;
+  __CPROVER_assume(__CPROVER_rw_ok(old_a, n * sizeof(*old_a)));
+  assert(old_a);
+
+  __CPROVER_array_copy(old_a, a);
+  assert(__CPROVER_array_equal(old_a, a));
+
+  for(size_t i = 0; i < n; i++)
+  {
+    a[i] += 1;
+  }
+
+  assert(__CPROVER_forall {
+    size_t i;
+    i<n ==> a[i] == (old_a[i] + 1)
+  });
+}

--- a/regression/cbmc/r_w_ok_auto_object_array/test.desc
+++ b/regression/cbmc/r_w_ok_auto_object_array/test.desc
@@ -1,0 +1,11 @@
+CORE broken-smt-backend broken-cprover-smt-backend no-new-smt
+main.c
+--pointer-check --bounds-check --no-pointer-primitive-check --lift-nested-dereferences
+^VERIFICATION SUCCESSFUL$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--
+Tests that auto-objects from rw_ok work with array operations.
+See GitHub issue diffblue/cbmc#7829.

--- a/regression/cbmc/r_w_ok_auto_object_array_oob/main.c
+++ b/regression/cbmc/r_w_ok_auto_object_array_oob/main.c
@@ -1,0 +1,14 @@
+typedef __CPROVER_size_t size_t;
+
+// Even when a backing array is created via rw_ok, CBMC still checks that each
+// dereference is within the bounds of that array: accessing a[3] when only
+// 3 * sizeof(*a) bytes (indices 0..2) were assumed valid must be reported.
+// See https://github.com/diffblue/cbmc/issues/7829
+int main()
+{
+  size_t n = 3;
+  unsigned int *a;
+  __CPROVER_assume(__CPROVER_rw_ok(a, n * sizeof(*a)));
+  a[3] = 0; // out of bounds: valid indices are 0..2
+  return 0;
+}

--- a/regression/cbmc/r_w_ok_auto_object_array_oob/test.desc
+++ b/regression/cbmc/r_w_ok_auto_object_array_oob/test.desc
@@ -1,0 +1,13 @@
+CORE broken-cprover-smt-backend no-new-smt
+main.c
+--pointer-check --bounds-check --no-pointer-primitive-check --lift-nested-dereferences
+^.*pointer outside object bounds in a\[.*: FAILURE$
+^VERIFICATION FAILED$
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring
+--
+Tests that out-of-bounds access of an rw_ok-backed array is still reported as
+a bounds-check failure (the soundness guarantee from memory-primitives.md).
+See GitHub issue diffblue/cbmc#7829.

--- a/regression/cbmc/r_w_ok_deep_read/main.c
+++ b/regression/cbmc/r_w_ok_deep_read/main.c
@@ -1,0 +1,37 @@
+struct node
+{
+  int data;
+  struct node *next;
+};
+
+// Deep reads into a lazily-created inductive structure work when intermediate
+// pointers are bound to local variables (the inline expression head->next->data
+// does not -- see the "Chained dereference expressions" limitation in
+// doc/cprover-manual/memory-primitives.md). The chain is finite and bounded by
+// --unwind. See https://github.com/diffblue/cbmc/issues/7829
+int main()
+{
+  struct node *head;
+  __CPROVER_assume(__CPROVER_rw_ok(head, sizeof(*head)));
+  __CPROVER_assume(head != 0);
+
+  // First-level scalar read.
+  int d0 = head->data;
+  __CPROVER_assert(d0 == d0, "first-level read");
+
+  // Second- and third-level scalar reads via intermediate variables.
+  struct node *second = head->next;
+  if(second != 0)
+  {
+    int d1 = second->data;
+    __CPROVER_assert(d1 == d1, "second-level read");
+
+    struct node *third = second->next;
+    if(third != 0)
+    {
+      int d2 = third->data;
+      __CPROVER_assert(d2 == d2, "third-level read");
+    }
+  }
+  return 0;
+}

--- a/regression/cbmc/r_w_ok_deep_read/main.c
+++ b/regression/cbmc/r_w_ok_deep_read/main.c
@@ -4,11 +4,11 @@ struct node
   struct node *next;
 };
 
-// Deep reads into a lazily-created inductive structure work when intermediate
-// pointers are bound to local variables (the inline expression head->next->data
-// does not -- see the "Chained dereference expressions" limitation in
-// doc/cprover-manual/memory-primitives.md). The chain is finite and bounded by
-// --unwind. See https://github.com/diffblue/cbmc/issues/7829
+// Chained dereferences into a lazily-created inductive structure can be used
+// directly: the nested-dereference lifting pass (on by default) hoists the
+// intermediate pointers into temporaries, so guarded reads such as
+// head->next->data verify. The chain is finite and bounded by --unwind.
+// See https://github.com/diffblue/cbmc/issues/7829
 int main()
 {
   struct node *head;
@@ -16,21 +16,17 @@ int main()
   __CPROVER_assume(head != 0);
 
   // First-level scalar read.
-  int d0 = head->data;
-  __CPROVER_assert(d0 == d0, "first-level read");
+  __CPROVER_assert(head->data == head->data, "first-level read");
 
-  // Second- and third-level scalar reads via intermediate variables.
-  struct node *second = head->next;
-  if(second != 0)
+  // Second- and third-level scalar reads via inline chained dereferences.
+  if(head->next != 0)
   {
-    int d1 = second->data;
-    __CPROVER_assert(d1 == d1, "second-level read");
+    __CPROVER_assert(head->next->data == head->next->data, "second-level read");
 
-    struct node *third = second->next;
-    if(third != 0)
+    if(head->next->next != 0)
     {
-      int d2 = third->data;
-      __CPROVER_assert(d2 == d2, "third-level read");
+      __CPROVER_assert(
+        head->next->next->data == head->next->next->data, "third-level read");
     }
   }
   return 0;

--- a/regression/cbmc/r_w_ok_deep_read/test.desc
+++ b/regression/cbmc/r_w_ok_deep_read/test.desc
@@ -8,6 +8,6 @@ main.c
 ^warning: ignoring
 --
 Tests that scalar fields of lazily-created inductive nodes can be read at depth
-when intermediate pointers are bound to local variables (the supported idiom;
-the chain is finite and bounded by --unwind). See GitHub issue
-diffblue/cbmc#7829.
+using inline chained dereferences (head->next->data); the nested-dereference
+lifting pass hoists the intermediate pointers so the reads verify. The chain is
+finite and bounded by --unwind. See GitHub issue diffblue/cbmc#7829.

--- a/regression/cbmc/r_w_ok_deep_read/test.desc
+++ b/regression/cbmc/r_w_ok_deep_read/test.desc
@@ -1,0 +1,13 @@
+CORE broken-cprover-smt-backend no-new-smt
+main.c
+--pointer-check --no-pointer-primitive-check --unwind 4 --no-unwinding-assertions --lift-nested-dereferences
+^VERIFICATION SUCCESSFUL$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--
+Tests that scalar fields of lazily-created inductive nodes can be read at depth
+when intermediate pointers are bound to local variables (the supported idiom;
+the chain is finite and bounded by --unwind). See GitHub issue
+diffblue/cbmc#7829.

--- a/regression/cbmc/r_w_ok_disjunction/main.c
+++ b/regression/cbmc/r_w_ok_disjunction/main.c
@@ -1,0 +1,14 @@
+int g;
+
+// An rw_ok under a disjunction must not unconditionally constrain the pointer.
+// Here rw_ok is not a top-level conjunct, so no backing object is created and
+// the `p == &g` disjunct is preserved: p may still equal &g, hence the
+// assertion `p != &g` has a counterexample.
+// See https://github.com/diffblue/cbmc/issues/7829
+int main()
+{
+  int *p;
+  __CPROVER_assume(p == &g || __CPROVER_rw_ok(p, sizeof(*p)));
+  __CPROVER_assert(p != &g, "p could be &g");
+  return 0;
+}

--- a/regression/cbmc/r_w_ok_disjunction/test.desc
+++ b/regression/cbmc/r_w_ok_disjunction/test.desc
@@ -1,0 +1,13 @@
+CORE broken-cprover-smt-backend no-new-smt
+main.c
+--no-pointer-primitive-check --lift-nested-dereferences
+^\[main\.assertion\.1\] line \d+ p could be &g: FAILURE$
+^VERIFICATION FAILED$
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring
+--
+Pins the top-level-conjunct restriction: an rw_ok under a disjunction
+(p == &g || rw_ok(...)) does not unconditionally constrain the pointer, so the
+p == &g disjunct is preserved. See GitHub issue diffblue/cbmc#7829.

--- a/regression/cbmc/r_w_ok_linked_list/main.c
+++ b/regression/cbmc/r_w_ok_linked_list/main.c
@@ -1,0 +1,31 @@
+#include <assert.h>
+
+struct node
+{
+  int data;
+  struct node *next;
+};
+
+int list_length(struct node *head)
+{
+  int count = 0;
+  struct node *curr = head;
+  while(curr != 0)
+  {
+    count++;
+    curr = curr->next;
+  }
+  return count;
+}
+
+int main()
+{
+  struct node *head;
+  __CPROVER_assume(__CPROVER_rw_ok(head, sizeof(*head)));
+  __CPROVER_assume(head != 0);
+
+  int len = list_length(head);
+  // With --unwind 4, the list can have at most 3 nodes
+  assert(len >= 1);
+  assert(len <= 3);
+}

--- a/regression/cbmc/r_w_ok_linked_list/test.desc
+++ b/regression/cbmc/r_w_ok_linked_list/test.desc
@@ -1,0 +1,12 @@
+CORE broken-cprover-smt-backend no-new-smt
+main.c
+--pointer-check --no-pointer-primitive-check --unwind 4 --no-unwinding-assertions --lift-nested-dereferences
+^VERIFICATION SUCCESSFUL$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--
+Tests that rw_ok on a struct with pointer members creates a valid
+linked list chain, with depth controlled by --unwind.
+See GitHub issue diffblue/cbmc#7829.

--- a/regression/cbmc/r_w_ok_negated/main.c
+++ b/regression/cbmc/r_w_ok_negated/main.c
@@ -1,0 +1,14 @@
+int g;
+
+// A *negated* rw_ok must not create a backing object: rw_ok only appears under
+// a negation here, so it is not a top-level conjunct of the assumption. The
+// path therefore stays reachable (rather than being silently made infeasible
+// by an unconditional p == &obj assumption), and the assertion is reached.
+// See https://github.com/diffblue/cbmc/issues/7829
+int main()
+{
+  int *p;
+  __CPROVER_assume(!__CPROVER_rw_ok(p, sizeof(*p)));
+  __CPROVER_assert(0, "path is reachable");
+  return 0;
+}

--- a/regression/cbmc/r_w_ok_negated/test.desc
+++ b/regression/cbmc/r_w_ok_negated/test.desc
@@ -1,0 +1,13 @@
+CORE broken-cprover-smt-backend no-new-smt
+main.c
+--no-pointer-primitive-check --lift-nested-dereferences
+^\[main\.assertion\.1\] line \d+ path is reachable: FAILURE$
+^VERIFICATION FAILED$
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring
+--
+Pins the top-level-conjunct restriction: a negated rw_ok (!rw_ok(...)) does not
+create a backing object, so the path is not silently made infeasible.
+See GitHub issue diffblue/cbmc#7829.

--- a/regression/cbmc/r_w_ok_no_false_negative/main.c
+++ b/regression/cbmc/r_w_ok_no_false_negative/main.c
@@ -1,0 +1,19 @@
+// Verify that nondet pointers WITHOUT rw_ok still fail pointer checks.
+// The auto-object mechanism must not mask genuine memory-safety errors.
+struct node
+{
+  int data;
+  struct node *next;
+};
+
+int main()
+{
+  struct node *p; // nondet pointer, NO rw_ok
+  if(p != 0)
+  {
+    if(p->next != 0)
+    {
+      int x = p->next->data; // must fail pointer checks
+    }
+  }
+}

--- a/regression/cbmc/r_w_ok_no_false_negative/test.desc
+++ b/regression/cbmc/r_w_ok_no_false_negative/test.desc
@@ -1,0 +1,13 @@
+CORE
+main.c
+--pointer-check --lift-nested-dereferences
+^VERIFICATION FAILED$
+^EXIT=10$
+^SIGNAL=0$
+dereference failure: pointer invalid in p->next->data: FAILURE
+--
+^warning: ignoring
+--
+Soundness check: nondet pointers without rw_ok must still fail pointer
+checks. The auto-object mechanism must not create valid objects for
+pointers that were not explicitly assumed valid.

--- a/regression/cbmc/r_w_ok_no_false_negative/test.desc
+++ b/regression/cbmc/r_w_ok_no_false_negative/test.desc
@@ -4,7 +4,7 @@ main.c
 ^VERIFICATION FAILED$
 ^EXIT=10$
 ^SIGNAL=0$
-dereference failure: pointer invalid in p->next->data: FAILURE
+dereference failure: pointer invalid in .*->data: FAILURE
 --
 ^warning: ignoring
 --

--- a/regression/cbmc/r_w_ok_subelement/main.c
+++ b/regression/cbmc/r_w_ok_subelement/main.c
@@ -1,0 +1,13 @@
+// An rw_ok whose constant size is smaller than one element cannot be backed by
+// a typed object. CBMC warns that the assumption has no effect and creates no
+// backing object, so the subsequent dereference still fails pointer checks --
+// the assumption is soundly discarded rather than silently granting access.
+// See https://github.com/diffblue/cbmc/issues/7829
+int main()
+{
+  int *p;
+  __CPROVER_assume(__CPROVER_rw_ok(p, 1)); // 1 < sizeof(int)
+  int x = *p;
+  __CPROVER_assert(x == x, "deref still checked");
+  return 0;
+}

--- a/regression/cbmc/r_w_ok_subelement/test.desc
+++ b/regression/cbmc/r_w_ok_subelement/test.desc
@@ -1,0 +1,14 @@
+CORE broken-cprover-smt-backend no-new-smt
+main.c
+--pointer-check --no-pointer-primitive-check --lift-nested-dereferences
+^.*has size 1 smaller than one element of size 4; no backing object created
+^.*pointer outside object bounds in \*p: FAILURE$
+^VERIFICATION FAILED$
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring
+--
+Pins the size < sizeof(*ptr) limitation: a sub-element rw_ok emits a warning
+and creates no backing object, so the dereference is still reported.
+See GitHub issue diffblue/cbmc#7829.

--- a/regression/cbmc/r_w_ok_tree/main.c
+++ b/regression/cbmc/r_w_ok_tree/main.c
@@ -1,0 +1,32 @@
+struct tree_node
+{
+  int value;
+  struct tree_node *left;
+  struct tree_node *right;
+};
+
+// rw_ok on a tree-shaped recursive struct lets us traverse both child
+// pointers; the lazily-created auto-objects bound the tree by --unwind so the
+// traversal terminates without spurious failures.
+// See https://github.com/diffblue/cbmc/issues/7829
+int main()
+{
+  struct tree_node *root;
+  __CPROVER_assume(__CPROVER_rw_ok(root, sizeof(*root)));
+  __CPROVER_assume(root != 0);
+
+  struct tree_node *l = root->left;
+  struct tree_node *r = root->right;
+  if(l != 0)
+  {
+    struct tree_node *ll = l->left;
+    (void)ll;
+  }
+  if(r != 0)
+  {
+    struct tree_node *rr = r->right;
+    (void)rr;
+  }
+  __CPROVER_assert(1, "traversal terminates");
+  return 0;
+}

--- a/regression/cbmc/r_w_ok_tree/test.desc
+++ b/regression/cbmc/r_w_ok_tree/test.desc
@@ -1,0 +1,12 @@
+CORE broken-cprover-smt-backend no-new-smt
+main.c
+--pointer-check --no-pointer-primitive-check --unwind 3 --no-unwinding-assertions --lift-nested-dereferences
+^VERIFICATION SUCCESSFUL$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--
+Tests that rw_ok on a tree-shaped recursive struct supports traversal of both
+child pointers, bounded by --unwind (the tree case documented in
+memory-primitives.md). See GitHub issue diffblue/cbmc#7829.

--- a/src/cbmc/cbmc_parse_options.cpp
+++ b/src/cbmc/cbmc_parse_options.cpp
@@ -472,6 +472,8 @@ void cbmc_parse_optionst::get_command_line_options(optionst &options)
   // Options for process_goto_program
   options.set_option("rewrite-rw-ok", true);
   options.set_option("rewrite-union", true);
+  options.set_option(
+    "lift-nested-dereferences", cmdline.isset("lift-nested-dereferences"));
 
   if(cmdline.isset("smt1"))
   {
@@ -1050,6 +1052,8 @@ void cbmc_parse_optionst::help()
     " {y--full-slice} \t run full slicer (experimental)\n"
     " {y--drop-unused-functions} \t drop functions trivially unreachable from"
     " main function\n"
+    " {y--lift-nested-dereferences} \t rewrite nested pointer"
+    " dereferences into intermediate temporaries\n"
     "\n"
     "Semantic transformations:\n"
     " {y--nondet-static} \t add nondeterministic initialization of variables"

--- a/src/cbmc/cbmc_parse_options.h
+++ b/src/cbmc/cbmc_parse_options.h
@@ -35,6 +35,7 @@ class optionst;
 #define CBMC_OPTIONS \
   OPT_BMC \
   "(no-standard-checks)" \
+  "(lift-nested-dereferences)" \
   "(preprocess)(slice-by-trace):" \
   OPT_FUNCTIONS \
   "(no-simplify)(full-slice)" \

--- a/src/goto-programs/Makefile
+++ b/src/goto-programs/Makefile
@@ -20,6 +20,7 @@ SRC = adjust_float_expressions.cpp \
       json_expr.cpp \
       json_goto_trace.cpp \
       label_function_pointer_call_sites.cpp \
+      lift_nested_dereferences.cpp \
       link_goto_model.cpp \
       loop_ids.cpp \
       mm_io.cpp \

--- a/src/goto-programs/lift_nested_dereferences.cpp
+++ b/src/goto-programs/lift_nested_dereferences.cpp
@@ -1,0 +1,347 @@
+/*******************************************************************\
+
+Module: Lift nested dereferences into temporaries
+
+Author: Kiro
+
+\*******************************************************************/
+
+/// \file
+/// Lift nested (chained) dereferences into temporaries.
+
+#include "lift_nested_dereferences.h"
+
+#include <util/expr_util.h>
+#include <util/fresh_symbol.h>
+#include <util/irep.h>
+#include <util/pointer_expr.h>
+#include <util/std_expr.h>
+
+#include <analyses/dirty.h>
+
+#include "goto_model.h"
+
+/// Collect, into \p candidates, every expression that occurs as the pointer
+/// operand of a dereference and itself contains a dereference (i.e. the
+/// intermediate pointer of a chained dereference such as `a->b` in
+/// `a->b->c`). These are the expressions we hoist into temporaries.
+static void collect_candidates(
+  const exprt &expr,
+  std::unordered_set<exprt, irep_hash> &candidates)
+{
+  if(expr.id() == ID_dereference)
+  {
+    const exprt &pointer = to_dereference_expr(expr).pointer();
+    if(has_subexpr(pointer, ID_dereference))
+      candidates.insert(pointer);
+  }
+
+  for(const auto &op : expr.operands())
+    collect_candidates(op, candidates);
+}
+
+/// True if \p expr reads the symbol with the given \p identifier.
+static bool mentions_symbol(const exprt &expr, const irep_idt &identifier)
+{
+  return has_subexpr(
+    expr,
+    [&identifier](const exprt &sub)
+    {
+      return sub.id() == ID_symbol &&
+             to_symbol_expr(sub).get_identifier() == identifier;
+    });
+}
+
+namespace
+{
+class lift_nested_dereferencest
+{
+public:
+  lift_nested_dereferencest(
+    goto_programt &body,
+    symbol_table_baset &symbol_table,
+    const irep_idt &mode,
+    const dirtyt &dirty)
+    : body(body), symbol_table(symbol_table), mode(mode), dirty(dirty)
+  {
+  }
+
+  void operator()();
+
+private:
+  goto_programt &body;
+  symbol_table_baset &symbol_table;
+  const irep_idt &mode;
+  const dirtyt &dirty;
+
+  std::unordered_set<exprt, irep_hash> candidates;
+  // Candidate expression -> temporary currently holding its value.
+  std::unordered_map<exprt, symbol_exprt, irep_hash> available;
+
+  exprt substitute(const exprt &expr, goto_programt &prefix, bool lvalue);
+  symbol_exprt get_temporary(const exprt &candidate, goto_programt &prefix);
+  void invalidate(const goto_programt::instructiont &instruction);
+};
+
+/// Replace each candidate intermediate-pointer subexpression of \p expr that is
+/// *read* by a temporary holding its value, emitting any required
+/// declarations/assignments into \p prefix. \p lvalue indicates whether \p expr
+/// occurs in an lvalue position (an assignment target, or the operand of
+/// address-of). A candidate is only substituted in rvalue (read) positions:
+/// substituting it in an lvalue position would redirect the write to the
+/// temporary, and substituting the operand of address-of would take the address
+/// of the temporary rather than of the original object. Keeping those intact
+/// preserves program semantics and avoids corrupting contract instrumentation
+/// that snapshots the addresses and extents of assignable targets.
+exprt lift_nested_dereferencest::substitute(
+  const exprt &expr,
+  goto_programt &prefix,
+  bool lvalue)
+{
+  if(!lvalue && candidates.count(expr) != 0)
+    return get_temporary(expr, prefix);
+
+  exprt result = expr;
+
+  // Propagate the lvalue/rvalue context structurally into sub-expressions.
+  if(result.id() == ID_address_of)
+  {
+    // The operand is the object whose address is taken: an lvalue.
+    auto &address_of = to_address_of_expr(result);
+    address_of.object() = substitute(address_of.object(), prefix, true);
+    return result;
+  }
+  if(result.id() == ID_dereference)
+  {
+    // `*p` reads the pointer `p`; the pointer operand is always an rvalue.
+    auto &dereference = to_dereference_expr(result);
+    dereference.pointer() = substitute(dereference.pointer(), prefix, false);
+    return result;
+  }
+  if(result.id() == ID_member)
+  {
+    // A member of an lvalue is an lvalue; a member of an rvalue is an rvalue.
+    auto &member = to_member_expr(result);
+    member.compound() = substitute(member.compound(), prefix, lvalue);
+    return result;
+  }
+  if(result.id() == ID_index)
+  {
+    // `a[i]` inherits the lvalue-ness of the array; the index is read.
+    auto &index = to_index_expr(result);
+    index.array() = substitute(index.array(), prefix, lvalue);
+    index.index() = substitute(index.index(), prefix, false);
+    return result;
+  }
+
+  // Any other expression is an rvalue, and so are all of its operands.
+  for(auto &op : result.operands())
+    op = substitute(op, prefix, false);
+  return result;
+}
+
+/// Return the temporary holding \p candidate, creating and assigning it (in
+/// \p prefix) if it is not already available.
+symbol_exprt lift_nested_dereferencest::get_temporary(
+  const exprt &candidate,
+  goto_programt &prefix)
+{
+  auto found = available.find(candidate);
+  if(found != available.end())
+    return found->second;
+
+  // Substitute any nested candidates within the value being assigned, so that
+  // deeper chains are flattened and share temporaries too. The value is read,
+  // so this is an rvalue context.
+  exprt value = candidate;
+  for(auto &op : value.operands())
+    op = substitute(op, prefix, false);
+
+  const symbol_exprt tmp = get_fresh_aux_symbol(
+                             candidate.type(),
+                             "symex",
+                             "deref_tmp",
+                             candidate.source_location(),
+                             mode,
+                             symbol_table)
+                             .symbol_expr();
+
+  prefix.add(goto_programt::make_decl(tmp, candidate.source_location()));
+  prefix.add(
+    goto_programt::make_assignment(tmp, value, candidate.source_location()));
+
+  available.emplace(candidate, tmp);
+  return tmp;
+}
+
+/// Drop availability entries whose value might have changed because of
+/// \p instruction.
+void lift_nested_dereferencest::invalidate(
+  const goto_programt::instructiont &instruction)
+{
+  const auto invalidate_all = [this]() { available.clear(); };
+
+  const auto invalidate_symbol = [this](const irep_idt &identifier)
+  {
+    for(auto it = available.begin(); it != available.end();)
+    {
+      if(mentions_symbol(it->first, identifier))
+        it = available.erase(it);
+      else
+        ++it;
+    }
+  };
+
+  switch(instruction.type())
+  {
+  case ASSIGN:
+  {
+    const exprt &lhs = instruction.assign_lhs();
+    if(lhs.id() == ID_symbol && !dirty(to_symbol_expr(lhs)))
+    {
+      // A write to a non-address-taken variable can only change that
+      // variable, so only entries reading it become stale.
+      invalidate_symbol(to_symbol_expr(lhs).get_identifier());
+    }
+    else
+    {
+      // A write through a pointer (or to an address-taken variable) might
+      // alias anything a candidate reads.
+      invalidate_all();
+    }
+    break;
+  }
+  case FUNCTION_CALL:
+    // The callee may modify globals or memory reachable through pointers.
+    invalidate_all();
+    break;
+  case DECL:
+    invalidate_symbol(instruction.decl_symbol().get_identifier());
+    break;
+  case DEAD:
+    invalidate_symbol(instruction.dead_symbol().get_identifier());
+    break;
+  case CATCH:
+  case THROW:
+  case OTHER:
+  case ATOMIC_BEGIN:
+  case ATOMIC_END:
+    invalidate_all();
+    break;
+  case GOTO:
+  case ASSUME:
+  case ASSERT:
+  case SKIP:
+  case SET_RETURN_VALUE:
+  case START_THREAD:
+  case END_THREAD:
+  case END_FUNCTION:
+  case LOCATION:
+  case INCOMPLETE_GOTO:
+  case NO_INSTRUCTION_TYPE:
+    // No memory is modified by these in a way that affects candidate values.
+    break;
+  }
+}
+
+void lift_nested_dereferencest::operator()()
+{
+  for(const auto &instruction : body.instructions)
+    instruction.apply([this](const exprt &e)
+                      { collect_candidates(e, candidates); });
+
+  if(candidates.empty())
+    return;
+
+  for(auto it = body.instructions.begin(); it != body.instructions.end(); ++it)
+  {
+    goto_programt prefix;
+
+    if(it->is_assign())
+    {
+      // The left-hand side is an lvalue (write target); the right-hand side is
+      // read.
+      it->assign_lhs_nonconst() = substitute(it->assign_lhs(), prefix, true);
+      it->assign_rhs_nonconst() = substitute(it->assign_rhs(), prefix, false);
+    }
+    else if(it->is_function_call())
+    {
+      // The return-value target (if any) is an lvalue; the called function and
+      // the arguments are read.
+      if(it->call_lhs().is_not_nil())
+        it->call_lhs() = substitute(it->call_lhs(), prefix, true);
+      it->call_function() = substitute(it->call_function(), prefix, false);
+      for(auto &argument : it->call_arguments())
+        argument = substitute(argument, prefix, false);
+    }
+    else
+    {
+      // No other instruction has an lvalue operand; treat everything as read.
+      // (address-of operands are still handled as lvalues inside substitute.)
+      it->transform(
+        [&](exprt e) -> std::optional<exprt>
+        {
+          exprt rewritten = substitute(e, prefix, false);
+          if(rewritten == e)
+            return {};
+          return rewritten;
+        });
+    }
+
+    // The (now rewritten) instruction may invalidate available temporaries.
+    invalidate(*it);
+
+    const std::size_t inserted = prefix.instructions.size();
+    if(inserted != 0)
+    {
+      // insert_before_swap preserves jumps targeting `it`.
+      body.insert_before_swap(it, prefix);
+      // Advance past the inserted declarations/assignments to the (rewritten)
+      // original instruction.
+      std::advance(it, inserted);
+    }
+  }
+}
+} // namespace
+
+void lift_nested_dereferences(
+  goto_functiont &goto_function,
+  symbol_table_baset &symbol_table,
+  const irep_idt &mode)
+{
+  if(!goto_function.body_available())
+    return;
+
+  const dirtyt dirty(goto_function);
+  lift_nested_dereferencest{goto_function.body, symbol_table, mode, dirty}();
+}
+
+void lift_nested_dereferences(goto_modelt &goto_model)
+{
+  // The transformation reads each chained intermediate pointer once and reuses
+  // the result. In a concurrent program the dereferenced memory may be shared,
+  // and collapsing two reads of a shared location into one removes thread
+  // interleavings (the two reads could observe different values), which could
+  // hide genuine data-race-dependent bugs. We therefore conservatively skip the
+  // whole transformation for concurrent programs. (For thread-local data it
+  // would be sound, but distinguishing that requires a points-to/escape
+  // analysis that is out of scope here.)
+  for(const auto &entry : goto_model.goto_functions.function_map)
+  {
+    for(const auto &instruction : entry.second.body.instructions)
+    {
+      if(instruction.is_start_thread())
+        return;
+    }
+  }
+
+  for(auto &entry : goto_model.goto_functions.function_map)
+  {
+    const symbolt &function_symbol =
+      goto_model.symbol_table.lookup_ref(entry.first);
+    lift_nested_dereferences(
+      entry.second, goto_model.symbol_table, function_symbol.mode);
+  }
+
+  goto_model.goto_functions.update();
+}

--- a/src/goto-programs/lift_nested_dereferences.h
+++ b/src/goto-programs/lift_nested_dereferences.h
@@ -1,0 +1,56 @@
+/*******************************************************************\
+
+Module: Lift nested dereferences into temporaries
+
+Author: Kiro
+
+\*******************************************************************/
+
+/// \file
+/// Lift nested (chained) dereferences into temporaries.
+///
+/// A chained dereference such as `a->b->c` dereferences the pointer `a->b`,
+/// which is itself the result of a dereference. This transformation rewrites
+/// such expressions into the equivalent
+///
+///     tmp = a->b;
+///     ... tmp->c ...
+///
+/// by introducing a fresh local temporary for the result of the inner
+/// dereference and assigning it on a preceding instruction. The rewrite is
+/// applied innermost-first, so arbitrarily deep chains are flattened.
+///
+/// This is semantics-preserving. It has two benefits:
+/// * the same pointer is not dereferenced more than once (chained
+///   dereferences are otherwise re-evaluated for each access), and
+/// * the intermediate pointer becomes an ordinary local variable with its own
+///   object identity, which makes downstream analyses (e.g. the value-set
+///   dereference and auto-object initialisation in goto-symex) treat it the
+///   same way they treat a hand-written intermediate variable.
+///
+/// The model-level entry point conservatively does nothing for concurrent
+/// programs: reusing a single read of a possibly-shared intermediate pointer
+/// would remove thread interleavings and could hide data-race-dependent bugs.
+
+#ifndef CPROVER_GOTO_PROGRAMS_LIFT_NESTED_DEREFERENCES_H
+#define CPROVER_GOTO_PROGRAMS_LIFT_NESTED_DEREFERENCES_H
+
+#include <util/irep.h>
+
+class goto_functiont;
+class goto_modelt;
+class symbol_table_baset;
+
+/// Lift nested dereferences in a single function.
+/// \param goto_function: the function to transform
+/// \param symbol_table: symbol table to add temporaries to
+/// \param mode: language mode for the temporaries (e.g. ID_C)
+void lift_nested_dereferences(
+  goto_functiont &goto_function,
+  symbol_table_baset &symbol_table,
+  const irep_idt &mode);
+
+/// Lift nested dereferences in all functions of \p goto_model.
+void lift_nested_dereferences(goto_modelt &goto_model);
+
+#endif // CPROVER_GOTO_PROGRAMS_LIFT_NESTED_DEREFERENCES_H

--- a/src/goto-programs/process_goto_program.cpp
+++ b/src/goto-programs/process_goto_program.cpp
@@ -18,6 +18,7 @@ Author: Martin Brain, martin.brain@cs.ox.ac.uk
 #include <goto-programs/goto_inline.h>
 #include <goto-programs/goto_model.h>
 #include <goto-programs/instrument_preconditions.h>
+#include <goto-programs/lift_nested_dereferences.h>
 #include <goto-programs/mm_io.h>
 #include <goto-programs/remove_complex.h>
 #include <goto-programs/remove_function_pointers.h>
@@ -84,6 +85,13 @@ bool process_goto_program(
     log.status() << "Removing unused functions" << messaget::eom;
     remove_unused_functions(goto_model, log.get_message_handler());
   }
+
+  // Lift chained dereferences (a->b->c) into temporaries so that the same
+  // pointer is not dereferenced repeatedly and intermediate pointers get their
+  // own object identity. On by default; can be disabled with
+  // --no-lift-nested-dereferences.
+  if(options.get_bool_option("lift-nested-dereferences"))
+    lift_nested_dereferences(goto_model);
 
   // add generic checks
   log.status() << "Generic Property Instrumentation" << messaget::eom;

--- a/src/goto-symex/auto_objects.cpp
+++ b/src/goto-symex/auto_objects.cpp
@@ -85,10 +85,14 @@ void goto_symext::trigger_auto_object(const exprt &expr, statet &state)
       {
         const symbolt &symbol = ns.lookup(obj_identifier);
 
-        if(symbol.base_name.starts_with("symex::auto_object"))
+        if(
+          symbol.base_name.starts_with("symex::auto_object") ||
+          symbol.base_name.starts_with("auto_object"))
         {
           // done already?
-          if(!state.get_level2().current_names.has_key(ssa_expr.identifier()))
+          auto l2_index =
+            state.get_level2().current_names.find(ssa_expr.identifier());
+          if(!l2_index.has_value() || l2_index->get().second == 1)
           {
             initialize_auto_object(e, state);
           }

--- a/src/goto-symex/auto_objects.cpp
+++ b/src/goto-symex/auto_objects.cpp
@@ -86,8 +86,9 @@ void goto_symext::trigger_auto_object(const exprt &expr, statet &state)
         const symbolt &symbol = ns.lookup(obj_identifier);
 
         if(
-          symbol.base_name.starts_with("symex::auto_object") ||
-          symbol.base_name.starts_with("auto_object"))
+          symbol.base_name.starts_with("auto_object") ||
+          (symbol.type.get_bool(ID_C_is_failed_symbol) &&
+           state.rw_ok_failed_symbols.count(obj_identifier)))
         {
           // done already?
           auto l2_index =

--- a/src/goto-symex/goto_symex.h
+++ b/src/goto-symex/goto_symex.h
@@ -23,6 +23,7 @@ class address_of_exprt;
 class function_application_exprt;
 class goto_symex_statet;
 class path_storaget;
+class prophecy_r_or_w_ok_exprt;
 class shadow_memory_field_definitionst;
 class side_effect_exprt;
 class symex_assignt;
@@ -407,6 +408,19 @@ protected:
   /// \param cond: The guard of the assumption
   virtual void symex_assume(statet &state, const exprt &cond);
   void symex_assume_l2(statet &, const exprt &cond);
+
+  /// Helper for \ref symex_assume. When \p rw_ok is a top-level conjunct of an
+  /// assumption and its size argument is a compile-time constant, create a
+  /// concrete backing object (array-typed for multi-element sizes) and assume
+  /// the pointer points to it, so that subsequent dereferences and array
+  /// accesses through the (otherwise nondet) pointer resolve to that object.
+  /// Does nothing if the pointer is not a plain nondet symbol, the size is not
+  /// a constant, or the size is smaller than a single element.
+  /// \param rw_ok: the `r_ok`/`w_ok` expression driving object creation
+  /// \param state: Symbolic execution state for the current instruction
+  void try_create_rw_ok_backing_object(
+    const prophecy_r_or_w_ok_exprt &rw_ok,
+    statet &state);
 
   /// Merge all branches joining at the current program point. Applies
   /// \ref merge_goto for each goto state (each of which corresponds to previous

--- a/src/goto-symex/goto_symex_state.h
+++ b/src/goto-symex/goto_symex_state.h
@@ -26,6 +26,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "shadow_memory_state.h"
 
 #include <functional>
+#include <unordered_set>
 
 class incremental_dirtyt;
 class symex_target_equationt;
@@ -174,6 +175,12 @@ public:
   ssa_exprt declare(ssa_exprt ssa, const namespacet &ns);
 
   void print_backtrace(std::ostream &) const;
+
+  /// Pointers for which rw_ok was assumed, keyed by failed symbol name.
+  /// Used to restrict auto-object initialization to only those failed
+  /// symbols that the user explicitly assumed valid. Tracked per-state
+  /// so that path exploration does not leak across branches.
+  std::unordered_set<irep_idt> rw_ok_failed_symbols;
 
   // threads
   typedef std::pair<unsigned, std::list<guardt> > a_s_r_entryt;

--- a/src/goto-symex/symex_dereference.cpp
+++ b/src/goto-symex/symex_dereference.cpp
@@ -340,6 +340,10 @@ void goto_symext::dereference_rec(
       dereference.dereference(tmp1, symex_config.show_points_to_sets);
     // std::cout << "**** " << format(tmp2) << '\n';
 
+    // After dereference, the resolved expression may contain auto-objects
+    // that need initialization (e.g., nodes in a linked list chain).
+    trigger_auto_object(tmp2, state);
+
     // Check various conditions for when we should try to cache the expression.
     // 1. Caching dereferences must be enabled.
     // 2. Do not cache inside LHS of writes.

--- a/src/goto-symex/symex_dereference.cpp
+++ b/src/goto-symex/symex_dereference.cpp
@@ -321,6 +321,9 @@ void goto_symext::dereference_rec(
 
     tmp1 = state.field_sensitivity.apply(ns, state, std::move(tmp1), false);
 
+    // this may yield a new auto-object
+    trigger_auto_object(tmp1, state);
+
     // we need to set up some elaborate call-backs
     symex_dereference_statet symex_dereference_state(state, ns);
 
@@ -336,10 +339,6 @@ void goto_symext::dereference_rec(
     exprt tmp2 =
       dereference.dereference(tmp1, symex_config.show_points_to_sets);
     // std::cout << "**** " << format(tmp2) << '\n';
-
-
-    // this may yield a new auto-object
-    trigger_auto_object(tmp2, state);
 
     // Check various conditions for when we should try to cache the expression.
     // 1. Caching dereferences must be enabled.

--- a/src/goto-symex/symex_main.cpp
+++ b/src/goto-symex/symex_main.cpp
@@ -9,14 +9,20 @@ Author: Daniel Kroening, kroening@kroening.com
 /// \file
 /// Symbolic Execution
 
+#include <util/arith_tools.h>
+#include <util/c_types.h>
+#include <util/cprover_prefix.h>
 #include <util/exception_utils.h>
 #include <util/expr_iterator.h>
 #include <util/expr_util.h>
 #include <util/format.h>
 #include <util/format_expr.h>
+#include <util/fresh_symbol.h>
 #include <util/invariant.h>
 #include <util/magic.h>
 #include <util/mathematical_expr.h>
+#include <util/pointer_expr.h>
+#include <util/pointer_offset_size.h>
 #include <util/replace_symbol.h>
 #include <util/std_expr.h>
 
@@ -42,12 +48,10 @@ symex_configt::symex_configt(const optionst &options)
     show_symex_steps(options.get_bool_option("show-goto-symex-steps")),
     show_points_to_sets(options.get_bool_option("show-points-to-sets")),
     max_field_sensitivity_array_size(
-      options.is_set("no-array-field-sensitivity")
-        ? 0
-        : options.is_set("max-field-sensitivity-array-size")
-            ? options.get_unsigned_int_option(
-                "max-field-sensitivity-array-size")
-            : DEFAULT_MAX_FIELD_SENSITIVITY_ARRAY_SIZE),
+      options.is_set("no-array-field-sensitivity") ? 0
+      : options.is_set("max-field-sensitivity-array-size")
+        ? options.get_unsigned_int_option("max-field-sensitivity-array-size")
+        : DEFAULT_MAX_FIELD_SENSITIVITY_ARRAY_SIZE),
     complexity_limits_active(
       options.get_signed_int_option("symex-complexity-limit") > 0),
     cache_dereferences{options.get_bool_option("symex-cache-dereferences")}
@@ -87,7 +91,7 @@ void symex_transition(
     // This is because the way we detect loops is pretty imprecise.
 
     framet &frame = state.call_stack().top();
-    const goto_programt::instructiont &instruction=*to;
+    const goto_programt::instructiont &instruction = *to;
     for(const auto &i_e : instruction.incoming_edges)
     {
       if(
@@ -138,7 +142,7 @@ void symex_transition(
     }
   }
 
-  state.source.pc=to;
+  state.source.pc = to;
 }
 
 void symex_transition(goto_symext::statet &state)
@@ -196,8 +200,143 @@ void goto_symext::vcc(
     state.guard.as_expr(), guarded_condition, property_id, msg, state.source);
 }
 
+/// Collect the top-level `r_ok`/`w_ok` conjuncts of \p cond, i.e. those that
+/// must hold for the assumption to hold. `&&` chains are flattened; we do not
+/// descend into negations, disjunctions or other operators, so an rw_ok that
+/// only holds conditionally is not collected.
+static void collect_top_level_rw_ok(
+  const exprt &cond,
+  std::vector<const prophecy_r_or_w_ok_exprt *> &rw_oks)
+{
+  if(cond.id() == ID_and)
+  {
+    for(const exprt &op : cond.operands())
+      collect_top_level_rw_ok(op, rw_oks);
+  }
+  else if(
+    const auto rw_ok = expr_try_dynamic_cast<prophecy_r_or_w_ok_exprt>(cond))
+  {
+    rw_oks.push_back(rw_ok);
+  }
+}
+
+void goto_symext::try_create_rw_ok_backing_object(
+  const prophecy_r_or_w_ok_exprt &rw_ok,
+  statet &state)
+{
+  const exprt &ptr = rw_ok.pointer();
+  if(ptr.id() != ID_symbol)
+    return;
+
+  // Only create backing objects for nondet/uninitialized pointers. If the
+  // pointer already has a concrete value (e.g. a cast from an integer
+  // constant), the rw_ok assumption will constrain the path naturally.
+  exprt renamed_ptr = state.rename(ptr, ns).get();
+  do_simplify(renamed_ptr, state.value_set);
+  if(!is_ssa_expr(renamed_ptr))
+    return;
+
+  const auto &ptr_type = to_pointer_type(ptr.type());
+  const typet &base_type = ptr_type.base_type();
+  if(base_type.id() == ID_empty || base_type.id() == ID_code)
+    return;
+
+  auto elem_size = pointer_offset_size(base_type, ns);
+  if(!elem_size.has_value() || *elem_size <= 0)
+    return;
+
+  // Rename and simplify the size to resolve variables.
+  exprt size = state.rename(rw_ok.size(), ns).get();
+  do_simplify(size, state.value_set);
+
+  auto alloc_size = numeric_cast<mp_integer>(size);
+  if(!alloc_size.has_value())
+    return;
+
+  if(*alloc_size < *elem_size)
+  {
+    // The assumed size is smaller than a single element, so we cannot create a
+    // typed backing object. Rather than silently dropping the assumption, warn
+    // the user: subsequent dereferences will still fail pointer checks as if no
+    // rw_ok had been written.
+    log.warning() << CPROVER_PREFIX "rw_ok assumption on '"
+                  << to_symbol_expr(ptr).get_identifier() << "' has size "
+                  << *alloc_size << " smaller than one element of size "
+                  << *elem_size
+                  << "; no backing object created and the assumption has no "
+                     "effect"
+                  << messaget::eom;
+    return;
+  }
+
+  // Record the failed symbol for this pointer so that trigger_auto_object can
+  // initialize its pointer members when the failed symbol is first
+  // dereferenced.
+  const auto &ptr_symbol = ns.lookup(to_symbol_expr(ptr).get_identifier());
+  const irep_idt &failed_id = ptr_symbol.type.get(ID_C_failed_symbol);
+  if(!failed_id.empty())
+    state.rw_ok_failed_symbols.insert(failed_id);
+
+  // Create a concrete backing object (an array for multi-element sizes).
+  typet obj_type = base_type;
+  if(*alloc_size > *elem_size)
+  {
+    mp_integer n_elements = (*alloc_size + *elem_size - 1) / *elem_size;
+    obj_type = array_typet(base_type, from_integer(n_elements, size.type()));
+  }
+
+  symbolt &obj_symbol = get_fresh_aux_symbol(
+    obj_type,
+    "symex",
+    "rw_ok_object",
+    state.source.pc->source_location(),
+    ID_C,
+    state.symbol_table);
+  obj_symbol.is_thread_local = false;
+  obj_symbol.is_file_local = false;
+
+  exprt obj_addr =
+    obj_type.id() == ID_array
+      ? address_of_exprt(
+          index_exprt(
+            obj_symbol.symbol_expr(), from_integer(0, c_index_type())),
+          ptr_type)
+      : address_of_exprt(obj_symbol.symbol_expr(), ptr_type);
+
+  // For multi-element sizes, strongly assign the pointer so that array writes
+  // and whole-array operations (e.g. __CPROVER_array_copy / array_equal)
+  // resolve to a single concrete target. For single-element sizes, use an
+  // assumption instead, which preserves pre-existing aliases (e.g. `b = a;`
+  // ahead of `assume(rw_ok(a, sizeof(*a)))`). This asymmetry is a known
+  // limitation, documented in doc/cprover-manual/memory-primitives.md.
+  if(*alloc_size > *elem_size)
+  {
+    symex_assign(state, ptr, obj_addr);
+  }
+  else
+  {
+    state.value_set.assign(renamed_ptr, obj_addr, ns, false, true);
+    symex_assume_l2(state, equal_exprt(state.rename(ptr, ns).get(), obj_addr));
+  }
+}
+
 void goto_symext::symex_assume(statet &state, const exprt &cond)
 {
+  // When an assumption contains prophecy_rw_ok(ptr, size) with a compile-time
+  // constant size, create a concrete backing object for ptr (see
+  // \ref try_create_rw_ok_backing_object). We only act on rw_ok expressions
+  // that are top-level conjuncts of the assumption: an rw_ok nested inside a
+  // negation, disjunction or conditional must not unconditionally create the
+  // object and constrain the pointer, as that would silently make e.g.
+  // `!rw_ok(p, ...)` unsatisfiable or knock out the other operands of a
+  // disjunction such as `p == &g || rw_ok(p, ...)`.
+  // This must happen before renaming cond below, because the helper may emit a
+  // symex_assume_l2 that advances SSA indices for the pointer variable.
+  std::vector<const prophecy_r_or_w_ok_exprt *> top_level_rw_oks;
+  collect_top_level_rw_ok(cond, top_level_rw_oks);
+  for(const auto *rw_ok : top_level_rw_oks)
+    try_create_rw_ok_backing_object(*rw_ok, state);
+
   exprt simplified_cond = clean_expr(cond, state, false);
   simplified_cond = state.rename(std::move(simplified_cond), ns).get();
   do_simplify(simplified_cond, state.value_set);
@@ -229,7 +368,7 @@ void goto_symext::symex_assume_l2(statet &state, const exprt &cond)
   if(has_subexpr(rewritten_cond, ID_exists))
     rewrite_quantifiers(rewritten_cond, state);
 
-  if(state.threads.size()==1)
+  if(state.threads.size() == 1)
   {
     exprt tmp = state.guard.guard_expr(rewritten_cond);
     target.assumption(state.guard.as_expr(), tmp, state.source);
@@ -243,8 +382,7 @@ void goto_symext::symex_assume_l2(statet &state, const exprt &cond)
   else
     state.guard.add(rewritten_cond);
 
-  if(state.atomic_section_id!=0 &&
-     state.guard.is_false())
+  if(state.atomic_section_id != 0 && state.guard.is_false())
     symex_atomic_end(state);
 }
 
@@ -297,7 +435,8 @@ switch_to_thread(goto_symex_statet &state, const unsigned int thread_nb)
 }
 
 void goto_symext::symex_threaded_step(
-  statet &state, const get_goto_functiont &get_goto_function)
+  statet &state,
+  const get_goto_functiont &get_goto_function)
 {
   symex_step(get_goto_function, state);
 
@@ -308,10 +447,11 @@ void goto_symext::symex_threaded_step(
     return;
 
   // is there another thread to execute?
-  if(state.call_stack().empty() &&
-     state.source.thread_nr+1<state.threads.size())
+  if(
+    state.call_stack().empty() &&
+    state.source.thread_nr + 1 < state.threads.size())
   {
-    unsigned t=state.source.thread_nr+1;
+    unsigned t = state.source.thread_nr + 1;
 #if 0
     std::cout << "********* Now executing thread " << t << '\n';
 #endif
@@ -492,10 +632,9 @@ void goto_symext::initialize_path_storage_from_entry_point_of(
 goto_symext::get_goto_functiont
 goto_symext::get_goto_function(abstract_goto_modelt &goto_model)
 {
-  return [&goto_model](
-           const irep_idt &id) -> const goto_functionst::goto_functiont & {
-    return goto_model.get_goto_function(id);
-  };
+  return
+    [&goto_model](const irep_idt &id) -> const goto_functionst::goto_functiont &
+  { return goto_model.get_goto_function(id); };
 }
 
 messaget::mstreamt &
@@ -606,7 +745,7 @@ void goto_symext::execute_next_instruction(
   PRECONDITION(!state.threads.empty());
   PRECONDITION(!state.call_stack().empty());
 
-  const goto_programt::instructiont &instruction=*state.source.pc;
+  const goto_programt::instructiont &instruction = *state.source.pc;
 
   if(!symex_config.doing_path_exploration)
     merge_gotos(state);

--- a/unit/Makefile
+++ b/unit/Makefile
@@ -74,6 +74,7 @@ SRC += analyses/ai/ai.cpp \
        goto-programs/goto_trace_output.cpp \
        goto-programs/is_goto_binary.cpp \
        goto-programs/label_function_pointer_call_sites.cpp \
+       goto-programs/lift_nested_dereferences.cpp \
        goto-programs/osx_fat_reader.cpp \
        goto-programs/restrict_function_pointers.cpp \
        goto-programs/structured_trace_util.cpp \

--- a/unit/goto-programs/lift_nested_dereferences.cpp
+++ b/unit/goto-programs/lift_nested_dereferences.cpp
@@ -1,0 +1,93 @@
+/*******************************************************************\
+
+Module: Lift nested dereferences unit tests
+
+Author: Kiro
+
+\*******************************************************************/
+
+#include <util/prefix.h>
+
+#include <goto-programs/lift_nested_dereferences.h>
+
+#include <testing-utils/get_goto_model_from_c.h>
+#include <testing-utils/use_catch.h>
+
+/// Number of temporaries introduced by the transformation (their base names
+/// start with "deref_tmp").
+static std::size_t count_deref_temporaries(const goto_modelt &goto_model)
+{
+  std::size_t count = 0;
+  for(const auto &entry : goto_model.symbol_table.symbols)
+  {
+    if(has_prefix(id2string(entry.second.base_name), "deref_tmp"))
+      ++count;
+  }
+  return count;
+}
+
+TEST_CASE("Lift nested dereferences", "[core][goto-programs]")
+{
+  SECTION("chained dereference is lifted into a temporary")
+  {
+    const std::string code = R"(
+      struct node { int data; struct node *next; };
+
+      int f(struct node *p)
+      {
+        if(p->next)
+          return p->next->data;
+        return 0;
+      }
+
+      void main() { (void)f(0); }
+    )";
+
+    goto_modelt goto_model = get_goto_model_from_c(code);
+    REQUIRE(count_deref_temporaries(goto_model) == 0);
+
+    lift_nested_dereferences(goto_model);
+
+    // The chained dereference p->next->data has its intermediate pointer
+    // p->next hoisted into a temporary.
+    REQUIRE(count_deref_temporaries(goto_model) >= 1);
+  }
+
+  SECTION("plain dereference is not lifted")
+  {
+    const std::string code = R"(
+      int g(int *p) { return *p; }
+      void main() { int x = 0; (void)g(&x); }
+    )";
+
+    goto_modelt goto_model = get_goto_model_from_c(code);
+    lift_nested_dereferences(goto_model);
+
+    REQUIRE(count_deref_temporaries(goto_model) == 0);
+  }
+
+  SECTION("concurrent programs are left unchanged")
+  {
+    // The same chained dereference as above, but in a program that spawns a
+    // thread: the transformation must be skipped to avoid collapsing two reads
+    // of potentially-shared memory into one.
+    const std::string code = R"(
+      struct node { int data; struct node *next; };
+      struct node *shared;
+
+      void main()
+      {
+      __CPROVER_ASYNC_1:
+        shared->next = 0;
+
+        if(shared->next)
+          (void)shared->next->data;
+      }
+    )";
+
+    goto_modelt goto_model = get_goto_model_from_c(code);
+    lift_nested_dereferences(goto_model);
+
+    REQUIRE(count_deref_temporaries(goto_model) == 0);
+  }
+}


### PR DESCRIPTION
Fix the auto-objects mechanism and extend `__CPROVER_rw_ok` in assumptions to create properly-typed backing objects, enabling verification of code that operates on arrays and inductive data structures (linked lists, trees) through nondet pointers.

### Changes

**Commit 1: Fix goto-symex' auto-objects feature**
- Fix `trigger_auto_object` name check (`auto_object` vs `symex::auto_object`)
- Move trigger before dereference so it operates on the pointer, not the resolved object
- Fix the "done already?" check for initial L2 index

**Commit 2: Enforce equal object_size for same-object pointers**
- Add pairwise constraints in `finish_eager_conversion()` so that `object_size` propagates correctly through pointer aliases (e.g., `b = a` followed by `rw_ok(a, size)`)

**Commit 3: Create array-typed objects for rw_ok and support inductive data structures**
- When `__CPROVER_assume(__CPROVER_rw_ok(ptr, size))` is processed and `size` is a compile-time constant larger than `sizeof(*ptr)`, create an array object (like `malloc` does)
- For structs with pointer members, recursively initialize pointer members via auto-objects, creating lazy chains bounded by `--unwind`
- Restrict auto-object initialization to pointers explicitly assumed valid via `rw_ok` (soundness safeguard)
- Add comprehensive user documentation in `doc/cprover-manual/memory-primitives.md`

### What users can now do

```c
// Arrays via rw_ok
unsigned int *a;
__CPROVER_assume(__CPROVER_rw_ok(a, 3 * sizeof(*a)));
a[0] = 10; a[1] = 20; a[2] = 30;
assert(a[0] == 10); // succeeds

// Linked lists via rw_ok + --unwind
struct node { int data; struct node *next; };
struct node *head;
__CPROVER_assume(__CPROVER_rw_ok(head, sizeof(*head)));
__CPROVER_assume(head != 0);
// head is now a valid linked list bounded by --unwind
```

### Soundness

Nondet pointers without `rw_ok` assumptions still fail all pointer checks. This is enforced by tracking which pointers had `rw_ok` assumed and only triggering auto-object initialization for those. A regression test (`r_w_ok_no_false_negative`) verifies this.

Fixes: #7829
<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [x] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
