### PR TITLE
CHC encoder: fix function pointer removal

### DIFF
--- a/regression/cprover/function_calls/function_pointer1.desc
+++ b/regression/cprover/function_calls/function_pointer1.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 function_pointer1.c
 --safety
 ^EXIT=10$

--- a/src/cprover/cprover_parse_options.cpp
+++ b/src/cprover/cprover_parse_options.cpp
@@ -144,10 +144,8 @@ int cprover_parse_optionst::main()
         ? static_cast<message_handlert &>(message_handler)
         : static_cast<message_handlert &>(null_message_handler);
 
-    const bool safety = !cmdline.isset("no-safety");
-
     remove_function_pointers(
-      remove_function_pointers_message_handler, goto_model, safety);
+      remove_function_pointers_message_handler, goto_model, false);
 
     adjust_float_expressions(goto_model);
     instrument_given_invariants(goto_model);
@@ -166,7 +164,7 @@ int cprover_parse_optionst::main()
     if(!perform_inlining)
       instrument_contracts(goto_model);
 
-    if(safety)
+    if(!cmdline.isset("no-safety"))
       c_safety_checks(goto_model);
 
     if(cmdline.isset("no-assertions"))


### PR DESCRIPTION
This fixes the removal of function pointers following the API change in 86c818104d1f09f.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
-n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [X] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
