### PR TITLE
CONTRACTS: Fix inferring assigns clause with symbols out of scope

### DIFF
--- a/regression/contracts/loop_assigns_inference/main.c
+++ b/regression/contracts/loop_assigns_inference/main.c
@@ -1,0 +1,58 @@
+#include <assert.h>
+
+int j;
+
+int lowerbound()
+{
+  return 0;
+}
+
+int upperbound()
+{
+  return 10;
+}
+
+void incr(int *i)
+{
+  (*i)++;
+}
+
+void body_1(int i)
+{
+  j = i;
+}
+
+void body_2(int *i)
+{
+  (*i)++;
+  (*i)--;
+}
+
+int body_3(int *i)
+{
+  (*i)++;
+  if(*i == 4)
+    return 1;
+
+  (*i)--;
+  return 0;
+}
+
+int main()
+{
+  for(int i = lowerbound(); i < upperbound(); incr(&i))
+    // clang-format off
+    __CPROVER_loop_invariant(0 <= i && i <= 10)
+    __CPROVER_loop_invariant(i != 0 ==> j + 1 == i)
+    // clang-format on
+    {
+      body_1(i);
+
+      if(body_3(&i))
+        return 1;
+
+      body_2(&i);
+    }
+
+  assert(j == 9);
+}

--- a/regression/contracts/loop_assigns_inference/test.desc
+++ b/regression/contracts/loop_assigns_inference/test.desc
@@ -1,0 +1,17 @@
+CORE
+main.c
+--apply-loop-contracts
+^EXIT=0$
+^SIGNAL=0$
+^\[body_1.assigns.\d+\] .* Check that j is assignable: SUCCESS$
+^\[body_2.assigns.\d+\] .* Check that \*i is assignable: SUCCESS$
+^\[body_3.assigns.\d+\] .* Check that \*i is assignable: SUCCESS$
+^\[incr.assigns.\d+\] .* Check that \*i is assignable: SUCCESS$
+^\[main.\d+\] .* Check loop invariant before entry: SUCCESS$
+^\[main.\d+\] .* Check that loop invariant is preserved: SUCCESS$
+^\[main.assertion.\d+\] .* assertion j == 9: SUCCESS$
+^VERIFICATION SUCCESSFUL$
+--
+--
+This test checks loop locals are correctly removed during assigns inference so
+that the assign clause is correctly inferred.

--- a/src/goto-instrument/contracts/cfg_info.h
+++ b/src/goto-instrument/contracts/cfg_info.h
@@ -19,6 +19,7 @@ Date: June 2022
 
 #include <util/byte_operators.h>
 #include <util/expr_cast.h>
+#include <util/find_symbols.h>
 #include <util/message.h>
 
 #include <goto-programs/goto_model.h>
@@ -172,8 +173,12 @@ public:
     auto it = exprs.begin();
     while(it != exprs.end())
     {
+      const std::unordered_set<irep_idt> symbols = find_symbol_identifiers(*it);
+
       if(
-        it->id() == ID_symbol && is_local(to_symbol_expr(*it).get_identifier()))
+        std::find_if(symbols.begin(), symbols.end(), [this](const irep_idt &s) {
+          return is_local(s);
+        }) != symbols.end())
       {
         it = exprs.erase(it);
       }


### PR DESCRIPTION
<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

**UPDATE:** there was a function for removing loop locals, which includes all locals from other functions, from the inferred assigns clause. But it only checked against ````symbol_exprt```. This PR update the function to check if the whole expression tree contain some leave symbol that is loop locals.

This PR fix a bug of loop-assigns-clauses inference. The inference algorithm inferred out-of-scope symbols because it do the alias analysis in the function with inlining. So a symbol in the inferred assign clauses could be local in an inlined function and not local in the function of the loop, and should be excluded from the inferred assign clauses. An example with detailed explanation is following. 

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

The following program is from the regression test `contracts/loop_assigns-05`. Note that, with the assign clause `(i, j)`, we can successfully instrument loop contracts and prove the instrumented goto-program with CBMC.
```c
#include <assert.h>

int j;

int lowerbound()
{
  return 0;
}

int upperbound()
{
  return 10;
}

void incr(int *i)
{
  (*i)++;
}

void body_1(int i)
{
  j = i;
}

void body_2(int *i)
{
  (*i)++;
  (*i)--;
}

int body_3(int *i)
{
  (*i)++;
  if(*i == 4)
    return 1;

  (*i)--;
  return 0;
}

int main()
{
  for(int i = lowerbound(); i < upperbound(); incr(&i))
    // clang-format off
    __CPROVER_assigns(i, j)
    __CPROVER_loop_invariant(0 <= i && i <= 10)
    __CPROVER_loop_invariant(i != 0 ==> j + 1 == i)
    // clang-format on
    {
      body_1(i);

      if(body_3(&i))
        return 1;

      body_2(&i);
    }

  assert(j == 9);
}

```
However, if we remove the provided assigns clause, the inference algorithm inferred assign clause as follow.
```
{*(cast(address_of(main::1::1::i), signedbv[32]*)), 
 *(cast(body_2::i, signedbv[32]*)), 
 *(cast(body_3::i, signedbv[32]*)), 
 *(cast(incr::i, signedbv[32]*)), 
 j}
```
Three of them (`body_2::i`, `body_3::i`, and `incr::i`) contain local symbols of other functions! With out-of-scope symbols in the inferred assigns clause, the proof will fail with confusing trace.
```
...
** Results:
function main
[main.1] assertion: SUCCESS
[main.2] assertion: FAILURE
[main.3] assertion: FAILURE
[main.4] assertion: FAILURE
...

Trace for main.2:

State 27 file main.c function main line 43 thread 0
----------------------------------------------------
  i=0 (00000000 00000000 00000000 00000000)

Violated property:
  function main thread 0
  assertion
  !(POINTER_OBJECT(i) == POINTER_OBJECT(((char *)NULL))) && !IS_INVALID_POINTER(i) && !(POINTER_OBJECT(i) == POINTER_OBJECT(__CPROVER_deallocated)) && !(POINTER_OBJECT(i) == POINTER_OBJECT(__CPROVER_dead_object)) && POINTER_OFFSET(i) >= 0l && OBJECT_SIZE(i) >= (unsigned long int)POINTER_OFFSET(i) + 4ul && (!(POINTER_OBJECT(((char *)NULL)) == POINTER_OBJECT(i)) || i == ((signed int *)NULL)) || POINTER_OBJECT(i) == POINTER_OBJECT(((char *)NULL))
...
```
The validity check of `i` failed because it is actually `body_2::i` instead of `main::1::1::i`. This PR fix this bug by excluding locals of inlined functions.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
