### PR TITLE
Add escaping of `0x00..0x08` in XML output attribute/element escaping.

### DIFF
--- a/src/util/ui_message.cpp
+++ b/src/util/ui_message.cpp
@@ -40,7 +40,7 @@ ui_message_handlert::ui_message_handlert(
     break;
 
   case uit::XML_UI:
-    out << "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+    out << "<?xml version=\"1.1\" encoding=\"UTF-8\"?>"
         << "\n";
     out << "<cprover>"
         << "\n";

--- a/src/util/xml.cpp
+++ b/src/util/xml.cpp
@@ -101,6 +101,19 @@ void xmlt::escape(const std::string &s, std::ostream &out)
       out << '\n';
       break;
 
+    // These values are coming from hex values that have been resolved
+    // into just their literal values from previous steps in the pipeline,
+    // which we are now quoting again, to allow to be printed gracefully
+    // in the XML output.
+    case 0x0:
+    case 0x1:
+    case 0x2:
+    case 0x3:
+    case 0x4:
+    case 0x5:
+    case 0x6:
+    case 0x7:
+    case 0x8:
     case 0x9:  // TAB
     case 0x7F: // DEL
       out << "&#" << std::to_string((unsigned char)ch) << ';';
@@ -140,6 +153,19 @@ void xmlt::escape_attribute(const std::string &s, std::ostream &out)
       out << "&quot;";
       break;
 
+    // These values are coming from hex values that have been resolved
+    // into just their literal values from previous steps in the pipeline,
+    // which we are now quoting again, to allow to be printed gracefully
+    // in the XML output.
+    case 0x0:
+    case 0x1:
+    case 0x2:
+    case 0x3:
+    case 0x4:
+    case 0x5:
+    case 0x6:
+    case 0x7:
+    case 0x8:
     case 0x9:  // TAB
     case 0xA:  // LF
     case 0xD:  // CR


### PR DESCRIPTION
This allows us to dodge an invariant violation by escaping the literals that have been passed from previous steps in the pipeline.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
