### PR TITLE
CHC solver: use address_of on RHS in counterexample traces

### DIFF
--- a/regression/cprover/trace/trace_malloc1.desc
+++ b/regression/cprover/trace/trace_malloc1.desc
@@ -4,7 +4,7 @@ trace_malloc1.c
 ^EXIT=10$
 ^SIGNAL=0$
 ^Trace for main\.assertion\.1:$
-^   5 main::\$tmp::return_value_malloc := ❝heap-1❞$
+^   5 main::\$tmp::return_value_malloc := address_of\(heap-1\)$
 ^   5 main::1::p := cast\(❝heap-1❞, signedbv\[32\]\*\)$
 ^   7 \[cast\(❝heap-1❞, signedbv\[32\]\*\) \+ 10\] := 1$
 ^   8 \[cast\(❝heap-1❞, signedbv\[32\]\*\) \+ 20\] := 2$

--- a/regression/cprover/trace/trace_pointer2.desc
+++ b/regression/cprover/trace/trace_pointer2.desc
@@ -4,6 +4,6 @@ trace_pointer2.c
 ^EXIT=10$
 ^SIGNAL=0$
 ^Trace for main\.assertion\.1:$
-^   6 main::1::x := element_address\(❝main::1::array❞, 0\)$
+^   6 main::1::x := address_of\(main::1::array\[0\]\)$
 ^   7 main::1::array\[2\] := 123$
 --

--- a/regression/cprover/trace/trace_pointer3.desc
+++ b/regression/cprover/trace/trace_pointer3.desc
@@ -4,6 +4,6 @@ trace_pointer3.c
 ^EXIT=10$
 ^SIGNAL=0$
 ^Trace for main\.assertion\.1:$
-^   8 main::1::p := ❝x❞$
+^   8 main::1::p := address_of\(x\)$
 ^   9 x\.b := 123$
 --

--- a/regression/cprover/trace/trace_struct1.desc
+++ b/regression/cprover/trace/trace_struct1.desc
@@ -4,6 +4,6 @@ trace_struct1.c
 ^EXIT=10$
 ^SIGNAL=0$
 ^Trace for main\.assertion\.1:$
-^  10 main::1::p := ❝x❞\.❝c❞$
+^  10 main::1::p := address_of\(x\.c\)$
 ^  11 x\.c := 789$
 --

--- a/src/cprover/report_traces.cpp
+++ b/src/cprover/report_traces.cpp
@@ -61,6 +61,15 @@ optionalt<exprt> address_to_lvalue(exprt src)
     return {};
 }
 
+static exprt use_address_of(exprt src)
+{
+  auto src_lvalue_opt = address_to_lvalue(src);
+  if(src_lvalue_opt.has_value())
+    return address_of_exprt(*src_lvalue_opt);
+  else
+    return src;
+}
+
 void show_trace(
   const std::vector<framet> &frames,
   const propertyt &property,
@@ -123,13 +132,17 @@ void show_trace(
           consolet::out() << std::setw(4) << ' ';
         }
 
-        auto lvalue_opt = address_to_lvalue(update.address);
-        if(lvalue_opt.has_value())
-          consolet::out() << format(*lvalue_opt);
+        // use an l-value expression for better readability, if possible
+        auto lhs_lvalue_opt = address_to_lvalue(update.address);
+        if(lhs_lvalue_opt.has_value())
+          consolet::out() << format(*lhs_lvalue_opt);
         else
           consolet::out() << '[' << format(update.address) << ']';
 
-        consolet::out() << " := " << format(update.value);
+        // use address_of for better readability
+        auto value_with_address_of = use_address_of(update.value);
+
+        consolet::out() << " := " << format(value_with_address_of);
         consolet::out() << '\n';
       }
     }


### PR DESCRIPTION
This changes the output of address-of expressions on the right hand side of assignments in counterexample traces to use address_of(...), for improved clarity.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [X] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
