### PR TITLE
C parser: Remove unused rule cprover_contract_frees_opt

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -29,11 +29,14 @@ macro(generic_bison name)
         message(FATAL_ERROR "Generated file ${bison_source} found in source tree. If you previously built with `make`, run `make clean` and try again")
     endif()
 
+    if(${BISON_VERSION} VERSION_GREATER "2.3")
+      set(bison_warnings_as_errors "-Werror")
+    endif()
     bison_target(
         parser
         "${CMAKE_CURRENT_SOURCE_DIR}/parser.y"
         "${CMAKE_CURRENT_BINARY_DIR}/${bison_source}"
-        COMPILE_FLAGS "-pyy${name}"
+        COMPILE_FLAGS "${bison_warnings_as_errors} -pyy${name}"
     )
     set(renamed_parser_header "${CMAKE_CURRENT_BINARY_DIR}/${bison_header}")
     add_custom_command(OUTPUT "${renamed_parser_header}"

--- a/src/ansi-c/Makefile
+++ b/src/ansi-c/Makefile
@@ -83,7 +83,7 @@ all: ansi-c$(LIBEXT)
 ###############################################################################
 
 ansi_c_y.tab.cpp: parser.y
-	$(YACC) $(YFLAGS) $$flags -pyyansi_c parser.y --defines=ansi_c_y.tab.h -o $@
+	$(YACC) $(YFLAGS) -pyyansi_c parser.y --defines=ansi_c_y.tab.h -o $@
 
 ansi_c_y.tab.h: ansi_c_y.tab.cpp
 

--- a/src/ansi-c/parser.y
+++ b/src/ansi-c/parser.y
@@ -3413,12 +3413,6 @@ cprover_contract_frees:
         }
         ;
 
-cprover_contract_frees_opt:
-        /* nothing */
-        { init($$); parser_stack($$).make_nil(); }
-        | cprover_contract_frees
-        ;
-
 cprover_function_contract_sequence:
           cprover_function_contract
         | cprover_function_contract_sequence cprover_function_contract

--- a/src/common
+++ b/src/common
@@ -61,6 +61,7 @@ ifeq ($(filter-out OSX OSX_Universal,$(BUILD_ENV_)),)
   ifeq ($(origin CXX),default)
     CXX    = clang++
   endif
+  YFLAGS ?= -v
 else ifeq ($(filter-out FreeBSD,$(BUILD_ENV_)),)
   CP_CXXFLAGS +=
   LINKLIB = ar rcT $@ $^
@@ -72,6 +73,7 @@ else ifeq ($(filter-out FreeBSD,$(BUILD_ENV_)),)
   ifeq ($(origin CXX),default)
     CXX    = clang++
   endif
+  YFLAGS ?= -v -Werror
 else
   LINKLIB = ar rcT $@ $^
   LINKBIN = $(CXX) $(LINKFLAGS) -o $@ -Wl,--start-group $^ -Wl,--end-group $(LIBS)
@@ -84,11 +86,11 @@ else
     CXX    = g++
     #CXX    = icpc
   endif
+  YFLAGS ?= -v -Werror
 endif
 ifeq ($(origin YACC),default)
   YACC   = bison
 endif
-  YFLAGS ?= -v
 ifeq ($(origin LEX),default)
   LEX    = flex
 endif
@@ -119,9 +121,9 @@ ifeq ($(origin CXX),default)
   CXX = x86_64-w64-mingw32-g++
 endif
 ifeq ($(origin YACC),default)
-  YACC   = bison -y
+  YACC   = bison -y -Wno-error=yacc
 endif
-  YFLAGS ?= -v
+  YFLAGS ?= -v -Werror
 ifeq ($(origin LEX),default)
   LEX    = flex
 endif
@@ -147,9 +149,9 @@ ifeq ($(origin CXX),default)
   CXX = cl
 endif
 ifeq ($(origin YACC),default)
-  YACC   = win_bison -y
+  YACC   = win_bison -y -Wno-error=yacc
 endif
-  YFLAGS ?= -v
+  YFLAGS ?= -v -Werror
 ifeq ($(origin LEX),default)
   LEX    = win_flex
 endif

--- a/src/jsil/Makefile
+++ b/src/jsil/Makefile
@@ -28,7 +28,7 @@ jsil$(LIBEXT): $(OBJ)
 	$(LINKLIB)
 
 jsil_y.tab.cpp: parser.y
-	$(YACC) $(YFLAGS) $$flags -pyyjsil parser.y --defines=jsil_y.tab.h -o $@
+	$(YACC) $(YFLAGS) -pyyjsil parser.y --defines=jsil_y.tab.h -o $@
 
 jsil_y.tab.h: jsil_y.tab.cpp
 

--- a/src/json/Makefile
+++ b/src/json/Makefile
@@ -19,7 +19,7 @@ json$(LIBEXT): $(OBJ)
 	$(LINKLIB)
 
 json_y.tab.cpp: parser.y
-	$(YACC) $(YFLAGS) $$flags -pyyjson parser.y --defines=json_y.tab.h -o $@
+	$(YACC) $(YFLAGS) -pyyjson parser.y --defines=json_y.tab.h -o $@
 
 json_y.tab.h: json_y.tab.cpp
 

--- a/src/statement-list/Makefile
+++ b/src/statement-list/Makefile
@@ -30,7 +30,7 @@ all: statement-list$(LIBEXT)
 ###############################################################################
 
 statement_list_y.tab.cpp: parser.y
-	$(YACC) $(YFLAGS) $$flags -pyystatement_list parser.y --defines=statement_list_y.tab.h -o $@
+	$(YACC) $(YFLAGS) -pyystatement_list parser.y --defines=statement_list_y.tab.h -o $@
 
 statement_list_y.tab.h: statement_list_y.tab.cpp
 

--- a/src/xmllang/Makefile
+++ b/src/xmllang/Makefile
@@ -21,7 +21,7 @@ xmllang$(LIBEXT): $(OBJ)
 	$(LINKLIB)
 
 xml_y.tab.cpp: parser.y
-	$(YACC) $(YFLAGS) $$flags -pyyxml parser.y --defines=xml_y.tab.h -o $@
+	$(YACC) $(YFLAGS) -pyyxml parser.y --defines=xml_y.tab.h -o $@
 
 xml_y.tab.h: xml_y.tab.cpp
 


### PR DESCRIPTION
This was introduced in 5982243 but does not seem to be used.

The second commit turns Bison warnings into errors to ensure we avoid such problems in future.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
