### PR TITLE
External SAT back-end: handle whitespace at end of line gracefully

### DIFF
--- a/regression/cbmc/Failing_Assert1/external-z3.desc
+++ b/regression/cbmc/Failing_Assert1/external-z3.desc
@@ -1,0 +1,10 @@
+CORE gcc-only
+main.c
+--external-sat-solver ./z3-wrapper.sh --trace
+^VERIFICATION FAILED$
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring
+--
+This test is marked "gcc-only" as resolving ./ won't work with Windows.

--- a/regression/cbmc/Failing_Assert1/z3-wrapper.sh
+++ b/regression/cbmc/Failing_Assert1/z3-wrapper.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+# handle output by older Z3 versions where the output was not compatible with
+# current SAT solvers
+
+z3 $1 2>&1 | \
+  perl -n -e '
+    print "s ".uc($1)."ISFIABLE\n" if(/^((un)?sat)\s*$/);
+    print "v $_\n" if(/^-?\d+/);
+    print "$_\n" if(/^[sv]\s+/);' 2>&1

--- a/src/solvers/sat/external_sat.cpp
+++ b/src/solvers/sat/external_sat.cpp
@@ -109,7 +109,7 @@ external_satt::resultt external_satt::parse_result(std::string solver_output)
 
     if(line[0] == 'v')
     {
-      auto assignments = split_string(line, ' ');
+      auto assignments = split_string(line, ' ', false, true);
 
       // remove the first element which should be 'v' identifying
       // the line as the satisfying assignments


### PR DESCRIPTION
CryptoMiniSat produces assignment output that includes whitespace at the end of the line. Strip such (empty) elements before evaluating entries as literals.

Fixes: #7164

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
