### PR TITLE
SMT2 back-end: support empty compound types

### DIFF
--- a/regression/cbmc/Empty_struct1/test.desc
+++ b/regression/cbmc/Empty_struct1/test.desc
@@ -1,4 +1,4 @@
-CORE broken-smt-backend
+CORE
 main.c
 
 ^EXIT=0$

--- a/regression/cbmc/empty_compound_type2/test.desc
+++ b/regression/cbmc/empty_compound_type2/test.desc
@@ -1,4 +1,4 @@
-CORE broken-smt-backend
+CORE
 main.c
 --pointer-check
 ^EXIT=10$

--- a/regression/cbmc/empty_compound_type3/test.desc
+++ b/regression/cbmc/empty_compound_type3/test.desc
@@ -1,4 +1,4 @@
-CORE broken-smt-backend
+CORE
 main.c
 
 ^EXIT=10$

--- a/regression/cbmc/empty_compound_type4/test.desc
+++ b/regression/cbmc/empty_compound_type4/test.desc
@@ -1,4 +1,4 @@
-CORE broken-smt-backend
+CORE
 main.c
 --trace
 ^VERIFICATION FAILED$


### PR DESCRIPTION
Do not construct equalities over expressions the type of which has zero bit width. Also, permit pointer arithmetic over objects of such type (which was previously fixed in 6b093595 for the propositional back-end).

Fixes: #7185

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
