### PR TITLE
Report successfully verified properties with stop-on-fail

### DIFF
--- a/regression/cbmc/Address_of1/test.desc
+++ b/regression/cbmc/Address_of1/test.desc
@@ -1,6 +1,7 @@
 CORE
 main.c
 --stop-on-fail
+^\[main\.assertion
 ^EXIT=0$
 ^SIGNAL=0$
 ^VERIFICATION SUCCESSFUL$

--- a/src/goto-checker/stop_on_fail_verifier.h
+++ b/src/goto-checker/stop_on_fail_verifier.h
@@ -44,6 +44,7 @@ public:
     switch(determine_result(properties))
     {
     case resultt::PASS:
+      output_properties(properties, 1, ui_message_handler);
       report_success(ui_message_handler);
       incremental_goto_checker.output_proof();
       break;


### PR DESCRIPTION
Users should know about the properties that have been checked when running CBMC with --stop-on-fail succeeds.

Fixes: #7059

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
