### PR TITLE
Linking: accept the same contract from multiple translation units

### DIFF
--- a/regression/ansi-c/linking_contracts1/header.h
+++ b/regression/ansi-c/linking_contracts1/header.h
@@ -1,0 +1,20 @@
+#include <stdbool.h>
+
+bool util_func(int a)
+  // clang-format off
+  __CPROVER_ensures(
+    __CPROVER_return_value == true || __CPROVER_return_value == false)
+// clang-format on
+{
+  if(a > 0)
+  {
+    return true;
+  }
+  else
+  {
+    return false;
+  }
+}
+
+int test1(int a);
+int test2(int a);

--- a/regression/ansi-c/linking_contracts1/main.c
+++ b/regression/ansi-c/linking_contracts1/main.c
@@ -1,0 +1,6 @@
+#include "header.h"
+
+int test1(int a)
+{
+  return util_func(a);
+}

--- a/regression/ansi-c/linking_contracts1/module.c
+++ b/regression/ansi-c/linking_contracts1/module.c
@@ -1,0 +1,6 @@
+#include "header.h"
+
+int test2(int a)
+{
+  return util_func(a);
+}

--- a/regression/ansi-c/linking_contracts1/test.desc
+++ b/regression/ansi-c/linking_contracts1/test.desc
@@ -1,0 +1,12 @@
+CORE
+main.c
+module.c
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+^CONVERSION ERROR$
+conflict on code contract
+--
+This test makes sure we support contracts in header files, which may then end up
+in multiple translation units.

--- a/src/linking/linking.cpp
+++ b/src/linking/linking.cpp
@@ -1105,10 +1105,15 @@ void linkingt::duplicate_non_type_symbol(
   symbolt &old_symbol,
   symbolt &new_symbol)
 {
-  // we do not permit multiple contracts to be defined, or cases where only one
-  // of the symbols is a contract
-  if(old_symbol.is_property || new_symbol.is_property)
+  // we do not permit different contracts with the same name to be defined, or
+  // cases where only one of the symbols is a contract
+  if(
+    old_symbol.is_property != new_symbol.is_property ||
+    (old_symbol.is_property && new_symbol.is_property &&
+     old_symbol.type != new_symbol.type))
+  {
     link_error(old_symbol, new_symbol, "conflict on code contract");
+  }
 
   // see if it is a function or a variable
 


### PR DESCRIPTION
Contracts stored in header files may end up in multiple translation units. Linking such translation units was rejected in the initial contracts-in-symbols implementation. Such contracts, however, are equal and we can just keep a single copy of them.

Fixes: #7156

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
