### PR TITLE
C front-end: zero-width bit-fields must not have a declarator

### DIFF
--- a/regression/ansi-c/bitfields2/main.c
+++ b/regression/ansi-c/bitfields2/main.c
@@ -1,0 +1,39 @@
+#include <limits.h>
+
+#define CONCAT(a, b) a##b
+#define CONCAT2(a, b) CONCAT(a, b)
+
+#define STATIC_ASSERT(condition)                                               \
+  int CONCAT2(some_array, __LINE__)[(condition) ? 1 : -1]
+
+#if CHAR_BIT == 8
+struct bits
+{
+  char a : 4;
+  char b : 4;
+  char c : 4;
+  char d : 4;
+  char : 0; // this is ok: no declarator
+  int i;
+};
+
+STATIC_ASSERT(sizeof(struct bits) == 2 * sizeof(int));
+
+#  pragma pack(1)
+struct packed_bits
+{
+  char a : 4;
+  char b : 4;
+  char c : 4;
+  char d : 4;
+  char x : 0; // this is not permitted
+  int i;
+};
+#  pragma pack()
+
+STATIC_ASSERT(sizeof(struct packed_bits) == sizeof(int) + 2);
+#endif
+
+int main()
+{
+}

--- a/regression/ansi-c/bitfields2/test.desc
+++ b/regression/ansi-c/bitfields2/test.desc
@@ -1,0 +1,9 @@
+CORE
+main.c
+
+zero-width bit-field with declarator not permitted$
+CONVERSION ERROR
+^EXIT=(64|1)$
+^SIGNAL=0$
+--
+^warning: ignoring

--- a/src/ansi-c/c_typecheck_type.cpp
+++ b/src/ansi-c/c_typecheck_type.cpp
@@ -964,6 +964,16 @@ void c_typecheck_baset::typecheck_compound_body(
           throw 0;
         }
 
+        if(
+          new_component.type().id() == ID_c_bit_field &&
+          to_c_bit_field_type(new_component.type()).get_width() == 0 &&
+          !new_component.get_name().empty())
+        {
+          throw invalid_source_file_exceptiont{
+            "zero-width bit-field with declarator not permitted",
+            source_location};
+        }
+
         components.push_back(new_component);
       }
     }


### PR DESCRIPTION
The C standard forbids this and compilers rightly reject this.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
