### PR TITLE
Update CODEOWNERS: Add kroening and tautschnig to goto-instrument

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -44,7 +44,7 @@
 
 /src/goto-analyzer/ @martin-cs @chris-ryder @peterschrammel
 /src/goto-harness/ @martin-cs @chris-ryder @peterschrammel
-/src/goto-instrument/ @martin-cs @chris-ryder @peterschrammel
+/src/goto-instrument/ @martin-cs @chris-ryder @peterschrammel @tautschnig @kroening
 /src/goto-instrument/contracts/ @tautschnig @feliperodri @remi-delmas-3000
 /doc/cprover-manual/contracts* @tautschnig @feliperodri @remi-delmas-3000
 /src/goto-diff/ @tautschnig @peterschrammel


### PR DESCRIPTION
This PR adds kroening and tautschnig as owners to goto-instrument.
Those are both experienced developers who attest that they are comfortable in that code base.
The goto-instrument code currently has a rather small set of code owners that can limit
the pace of review.
<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
