### PR TITLE
C/C++ entry-point: resolve full symbol names

### DIFF
--- a/regression/cbmc-cpp/entry_point1/main.cpp
+++ b/regression/cbmc-cpp/entry_point1/main.cpp
@@ -1,0 +1,4 @@
+void mymain()
+{
+  __CPROVER_assert(false, "expected to fail");
+}

--- a/regression/cbmc-cpp/entry_point1/test.desc
+++ b/regression/cbmc-cpp/entry_point1/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.cpp
+--function 'mymain()'
+^VERIFICATION FAILED$
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring

--- a/src/util/symbol_table_base.h
+++ b/src/util/symbol_table_base.h
@@ -109,6 +109,33 @@ public:
     return *symbol;
   }
 
+  /// Collect all symbols the name of which matches \p id or the base name of
+  /// which matches \p id.
+  std::list<symbolst::const_iterator>
+  match_name_or_base_name(const irep_idt &id) const
+  {
+    std::list<symbolst::const_iterator> results;
+
+    auto name_it = symbols.find(id);
+    if(name_it != symbols.end())
+      results.push_back(name_it);
+
+    auto base_name_it_pair = symbol_base_map.equal_range(id);
+    for(auto base_name_it = base_name_it_pair.first;
+        base_name_it != base_name_it_pair.second;
+        ++base_name_it)
+    {
+      name_it = symbols.find(base_name_it->second);
+      CHECK_RETURN(name_it != symbols.end());
+      // don't add entries where name and base name match as this amounts to the
+      // case already covered above
+      if(base_name_it->first != base_name_it->second)
+        results.push_back(name_it);
+    }
+
+    return results;
+  }
+
   /// Find a symbol in the symbol table for read-write access.
   /// \param name: The name of the symbol to look for
   /// \return A pointer to the found symbol if it exists, nullptr otherwise.


### PR DESCRIPTION
Do not try to use the base name only as that's inconsistent with generate_entry_point_for_function's way of doing lookups.

Fixes: #7057

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
