### PR TITLE
deprecate source_locationt::get/set_function

### DIFF
--- a/src/util/source_location.h
+++ b/src/util/source_location.h
@@ -10,6 +10,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #ifndef CPROVER_UTIL_SOURCE_LOCATION_H
 #define CPROVER_UTIL_SOURCE_LOCATION_H
 
+#include "deprecate.h"
 #include "irep.h"
 #include "optional.h"
 
@@ -52,6 +53,14 @@ public:
     return get(ID_column);
   }
 
+  // This method is problematic for the following reasons:
+  // 1) There is ambiguity whether
+  //    the returned string is an identifier or human-readable.
+  // 2) Furthermore, the linker renames functions, and is unable
+  //    to adjust all source locations.
+  // 3) The name of the function is not strictly a source location.
+  // It will be removed.
+  DEPRECATED(SINCE(2022, 10, 13, "use identifier of containing function"))
   const irep_idt &get_function() const
   {
     return get(ID_function);
@@ -117,6 +126,7 @@ public:
     set(ID_column, column);
   }
 
+  DEPRECATED(SINCE(2022, 10, 13, "use identifier of containing function"))
   void set_function(const irep_idt &function)
   {
     set(ID_function, function);


### PR DESCRIPTION
Following #2149, this deprecates `source_locationt::get/set_function`; the reason is given as a comment.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- n/a Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
