### PR TITLE
Make verbosity of symtab2gb configurable

### DIFF
--- a/doc/man/symtab2gb.1
+++ b/doc/man/symtab2gb.1
@@ -15,8 +15,12 @@ This is to support integration of external language frontends, such as Ada
 (using GNAT2GOTO: https://github.com/diffblue/gnat2goto) or Rust (using Kani:
 https://github.com/model-checking/kani).
 .SH OPTIONS
+.TP
 \fB\-\-out\fR \fIoutfile\fR
 Specify the filename of the resulting binary (default: a.out)
+.TP
+\fB\-\-verbosity\fR #
+verbosity level
 .SH ENVIRONMENT
 All tools honor the TMPDIR environment variable when generating temporary
 files and directories.

--- a/src/symtab2gb/symtab2gb_parse_options.cpp
+++ b/src/symtab2gb/symtab2gb_parse_options.cpp
@@ -43,7 +43,8 @@ static inline bool failed(bool error_indicator)
 
 static void run_symtab2gb(
   const std::vector<std::string> &symtab_filenames,
-  const std::string &gb_filename)
+  const std::string &gb_filename,
+  const std::string &cmdline_verbosity)
 {
   // try opening all the files first to make sure we can
   // even read/write what we want
@@ -65,6 +66,8 @@ static void run_symtab2gb(
   }
 
   stream_message_handlert message_handler{std::cerr};
+  messaget::eval_verbosity(
+    cmdline_verbosity, messaget::M_STATISTICS, message_handler);
 
   auto const symtab_language = new_json_symtab_language();
   symtab_language->set_message_handler(message_handler);
@@ -138,7 +141,7 @@ int symtab2gb_parse_optionst::doit()
   }
   register_languages();
   config.set(cmdline);
-  run_symtab2gb(symtab_filenames, gb_filename);
+  run_symtab2gb(symtab_filenames, gb_filename, cmdline.get_value("verbosity"));
   return CPROVER_EXIT_SUCCESS;
 }
 
@@ -162,5 +165,6 @@ void symtab2gb_parse_optionst::help()
        "--out <outfile>                          specify the filename of\n"
        "                                         the resulting binary\n"
        "                                         (default: a.out)\n"
+       " --verbosity #                verbosity level\n"
     << messaget::eom;
 }

--- a/src/symtab2gb/symtab2gb_parse_options.h
+++ b/src/symtab2gb/symtab2gb_parse_options.h
@@ -17,6 +17,7 @@ Author: Diffblue Ltd.
 
 #define SYMTAB2GB_OPTIONS                                                      \
   "(" SYMTAB2GB_OUT_FILE_OPT "):"                                              \
+  "(verbosity):"                                                               \
 // end options
 
 // clang-format on


### PR DESCRIPTION
Do not produce debug output (as goto_convert might do, e.g., reporting on destructor code being produced) by default.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [x] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
