### PR TITLE
Simplify NULL + 1 == NULL to false

### DIFF
--- a/src/util/simplify_expr_int.cpp
+++ b/src/util/simplify_expr_int.cpp
@@ -1639,6 +1639,21 @@ simplify_exprt::resultt<> simplify_exprt::simplify_inequality_rhs_is_constant(
           new_expr.op1().type() = new_expr.op0().type();
         return changed(simplify_inequality(new_expr)); // do again!
       }
+      else if(expr.op0().id() == ID_plus)
+      {
+        // NULL + 1 == NULL is false
+        const plus_exprt &plus = to_plus_expr(expr.op0());
+        if(
+          plus.operands().size() == 2 && plus.op0().is_constant() &&
+          plus.op1().is_constant() &&
+          ((is_null_pointer(to_constant_expr(plus.op0())) &&
+            !plus.op1().is_zero()) ||
+           (is_null_pointer(to_constant_expr(plus.op1())) &&
+            !plus.op0().is_zero())))
+        {
+          return false_exprt();
+        }
+      }
     }
 
     // all we are doing with pointers


### PR DESCRIPTION
This expression appears to arise in Rust's MIR when iterating over slices. See https://github.com/model-checking/kani/issues/1767 for an example.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
