### PR TITLE
CHC solver: redesigned verbose output

### DIFF
--- a/src/cprover/axioms.cpp
+++ b/src/cprover/axioms.cpp
@@ -74,8 +74,10 @@ void axiomst::evaluate_fc()
         operands_equal,
         equal_exprt(
           *a_it, typecast_exprt::conditional_cast(*b_it, a_it->type())));
+#if 0
       if(verbose)
         std::cout << "EVALUATE: " << format(implication) << '\n';
+#endif
       dest << replace(implication);
     }
   }
@@ -752,11 +754,13 @@ void axiomst::emit()
     constraint.visit_pre([this](const exprt &src) { node(src); });
 
     auto constraint_replaced = replace(constraint);
+#if 0
     if(verbose)
     {
       std::cout << "CONSTRAINT1: " << format(constraint) << "\n";
       std::cout << "CONSTRAINT2: " << format(constraint_replaced) << "\n";
     }
+#endif
     dest << constraint_replaced;
   }
 

--- a/src/cprover/counterexample_found.cpp
+++ b/src/cprover/counterexample_found.cpp
@@ -33,11 +33,13 @@ void show_assignment(const bv_pointers_widet &solver)
     if(expr.id() == ID_and || expr.id() == ID_or || expr.id() == ID_not)
       continue;
     auto value = solver.l_get(entry.second);
+#  if 0
     std::cout << "|| " << format(expr) << " --> " << value << "\n";
+#  endif
   }
 #endif
 
-#if 1
+#if 0
   for(auto &entry : solver.get_map().get_mapping())
   {
     const auto &identifier = entry.first;
@@ -47,12 +49,14 @@ void show_assignment(const bv_pointers_widet &solver)
   }
 #endif
 
+#if 0
   for(auto &entry : solver.get_symbols())
   {
     const auto &identifier = entry.first;
     auto value = solver.l_get(entry.second);
     std::cout << "|| " << identifier << " --> " << value << "\n";
   }
+#endif
 }
 
 static exprt evaluator_rec(

--- a/src/cprover/solver_progress.cpp
+++ b/src/cprover/solver_progress.cpp
@@ -19,6 +19,10 @@ void solver_progresst::operator()(size_t current)
 {
   if(verbose)
   {
+    if(current != 0)
+      std::cout << '\n';
+    std::cout << consolet::orange << "Processing property " << (current + 1)
+              << '/' << total << consolet::reset << '\n';
   }
   else
   {
@@ -44,6 +48,7 @@ void solver_progresst::finished()
 {
   if(verbose)
   {
+    std::cout << '\n';
   }
   else
   {

--- a/src/cprover/state_encoding.cpp
+++ b/src/cprover/state_encoding.cpp
@@ -1245,11 +1245,13 @@ solver_resultt state_encoding_solver(
 
   equality_propagation(container.constraints);
 
+#if 0
   if(solver_options.verbose)
   {
     ascii_encoding_targett dest(std::cout);
     dest << container;
   }
+#endif
 
   return solver(container.constraints, solver_options, ns);
 }


### PR DESCRIPTION
The solver's output when using `--verbose` is cleaned up (and now less verbose).

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
