### PR TITLE
Support non-NULL pointer constants in the SMT back-end

### DIFF
--- a/regression/cbmc/union13/no-arch.desc
+++ b/regression/cbmc/union13/no-arch.desc
@@ -1,4 +1,4 @@
-CORE broken-smt-backend
+CORE
 main.c
 --arch none --little-endian
 (Starting CEGAR Loop|^Generated 1 VCC\(s\), 1 remaining after simplification$)

--- a/src/solvers/smt2/smt2_conv.cpp
+++ b/src/solvers/smt2/smt2_conv.cpp
@@ -3318,8 +3318,14 @@ void smt2_convt::convert_constant(const constant_exprt &expr)
           << ")";
     }
     else
-      UNEXPECTEDCASE(
-        "unknown pointer constant: " + id2string(expr.get_value()));
+    {
+      // just treat the pointer as a bit vector
+      const std::size_t width = boolbv_width(expr_type);
+
+      const mp_integer value = bvrep2integer(expr.get_value(), width, false);
+
+      out << "(_ bv" << value << " " << width << ")";
+    }
   }
   else if(expr_type.id()==ID_bool)
   {


### PR DESCRIPTION
We just treat them as bit vectors. Such constants arise when more constant propagation is enabled (via union field sensitivity) in the havoc_slice regression tests.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
