### PR TITLE
Simplify byte extract of empty union or struct

### DIFF
--- a/src/solvers/smt2/smt2_conv.cpp
+++ b/src/solvers/smt2/smt2_conv.cpp
@@ -965,12 +965,17 @@ static bool is_zero_width(const typet &type, const namespacet &ns)
     return true;
   else if(type.id() == ID_struct_tag)
     return is_zero_width(ns.follow_tag(to_struct_tag_type(type)), ns);
-  else if(type.id() == ID_struct)
-    return to_struct_type(type).components().empty();
   else if(type.id() == ID_union_tag)
     return is_zero_width(ns.follow_tag(to_union_tag_type(type)), ns);
-  else if(type.id() == ID_union)
-    return to_union_type(type).components().empty();
+  else if(type.id() == ID_struct || type.id() == ID_union)
+  {
+    for(const auto &comp : to_struct_union_type(type).components())
+    {
+      if(!is_zero_width(comp.type(), ns))
+        return false;
+    }
+    return true;
+  }
   else
     return false;
 }

--- a/src/util/simplify_expr.cpp
+++ b/src/util/simplify_expr.cpp
@@ -1705,6 +1705,19 @@ simplify_exprt::simplify_byte_extract(const byte_extract_exprt &expr)
     }
   }
 
+  if(
+    (expr.type().id() == ID_union || expr.type().id() == ID_union_tag) &&
+    to_union_type(ns.follow(expr.type())).components().empty())
+  {
+    return empty_union_exprt{expr.type()};
+  }
+  else if(
+    (expr.type().id() == ID_struct || expr.type().id() == ID_struct_tag) &&
+    to_struct_type(ns.follow(expr.type())).components().empty())
+  {
+    return struct_exprt{{}, expr.type()};
+  }
+
   // no proper simplification for expr.type()==void
   // or types of unknown size
   if(!el_size.has_value() || *el_size == 0)

--- a/src/util/simplify_utils.cpp
+++ b/src/util/simplify_utils.cpp
@@ -264,6 +264,9 @@ optionalt<exprt> bits2expr(
     const union_typet &union_type = to_union_type(type);
     const union_typet::componentst &components = union_type.components();
 
+    if(components.empty() && bits.empty())
+      return empty_union_exprt{type};
+
     for(const auto &component : components)
     {
       auto val = bits2expr(bits, component.type(), little_endian, ns);


### PR DESCRIPTION
Byte-extracting an empty compound object trivially yields a constant expression.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
