### PR TITLE
SMT back-end: fix type when RHS will be flattened

### DIFF
--- a/regression/cbmc/Array_operations1/full-slice.desc
+++ b/regression/cbmc/Array_operations1/full-slice.desc
@@ -10,7 +10,7 @@ main.c
 ^\[test_unequal\.assertion\.4\] .* expected to fail: FAILURE
 ^\[test_unequal\.assertion\.5\] .* expected to fail: FAILURE
 ^\[test_unequal\.assertion\.6\] .* expected to fail: FAILURE
-^\*\* 5 of 14 failed
+^\*\* 5 of 15 failed
 ^VERIFICATION FAILED$
 --
 ^warning: ignoring

--- a/regression/cbmc/Array_operations1/main.c
+++ b/regression/cbmc/Array_operations1/main.c
@@ -54,6 +54,14 @@ void test_copy()
   __CPROVER_array_copy(array1, array3);
   __CPROVER_assert(array1[10] == 11, "array1[10] is OK");
   __CPROVER_assert(array1[99] == 42, "expected to fail");
+
+  int a[1];
+  struct
+  {
+    int a[1];
+  } s;
+  __CPROVER_array_copy(a, s.a);
+  __CPROVER_assert(a[0] == s.a[0], "array copied");
 }
 
 void test_replace()

--- a/regression/cbmc/Array_operations1/test.desc
+++ b/regression/cbmc/Array_operations1/test.desc
@@ -10,7 +10,7 @@ main.c
 ^\[test_unequal\.assertion\.4\] .* expected to fail: FAILURE
 ^\[test_unequal\.assertion\.5\] .* expected to fail: FAILURE
 ^\[test_unequal\.assertion\.6\] .* expected to fail: FAILURE
-^\*\* 5 of 14 failed
+^\*\* 5 of 15 failed
 ^VERIFICATION FAILED$
 --
 ^warning: ignoring

--- a/src/solvers/smt2/smt2_conv.cpp
+++ b/src/solvers/smt2/smt2_conv.cpp
@@ -4786,7 +4786,17 @@ void smt2_convt::set_to(const exprt &expr, bool value)
         {
           out << "(define-fun " << smt2_identifier;
           out << " () ";
-          convert_type(equal_expr.lhs().type());
+          if(
+            equal_expr.lhs().type().id() != ID_array ||
+            use_array_theory(prepared_rhs))
+          {
+            convert_type(equal_expr.lhs().type());
+          }
+          else
+          {
+            std::size_t width = boolbv_width(equal_expr.lhs().type());
+            out << "(_ BitVec " << width << ")";
+          }
           out << ' ';
           convert_expr(prepared_rhs);
           out << ')' << '\n';


### PR DESCRIPTION
When the right-hand side is a member expression the type has to be a bit vector (unless data types are used).

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
