### PR TITLE
SMT2 solver: remove spurious parenthesis in result output

### DIFF
--- a/src/solvers/smt2/smt2_format.cpp
+++ b/src/solvers/smt2/smt2_format.cpp
@@ -150,7 +150,7 @@ std::ostream &smt2_format_rec(std::ostream &out, const exprt &expr)
     for(std::size_t i = 0; i < array_list_expr.operands().size(); i += 2)
       out << "(store ";
 
-    out << "((as const " << smt2_format(expr.type()) << ")) "
+    out << "((as const " << smt2_format(expr.type()) << ") "
         << smt2_format(
              from_integer(0, to_array_type(expr.type()).element_type()))
         << ')';


### PR DESCRIPTION
The output had more closing parentheses than opening ones.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
