### PR TITLE
GitHub actions: replace deprecated set-output

### DIFF
--- a/.github/workflows/pull-request-checks.yaml
+++ b/.github/workflows/pull-request-checks.yaml
@@ -684,8 +684,8 @@ jobs:
           $cpack = "$(Split-Path -Parent (Get-Command cmake).Source)\cpack.exe"
           & $cpack . -C Release
           $msi_name = (Get-ChildItem -name *.msi).Name
-          Write-Output "::set-output name=msi_installer::build/$msi_name"
-          Write-Output "::set-output name=msi_name::$msi_name"
+          echo "msi_installer=build/$msi_name" >> $env:GITHUB_OUTPUT
+          echo "msi_name=$msi_name" >> $env:GITHUB_OUTPUT
 
   ubuntu-18_04-package:
     runs-on: ubuntu-18.04
@@ -753,8 +753,8 @@ jobs:
           cd build
           ninja package
           deb_package_name="$(ls *.deb)"
-          echo "::set-output name=deb_package::./build/$deb_package_name"
-          echo "::set-output name=deb_package_name::ubuntu-18.04-$deb_package_name"
+          echo "deb_package=./build/$deb_package_name" >> $GITHUB_OUTPUT
+          echo "deb_package_name=ubuntu-18.04-$deb_package_name" >> $GITHUB_OUTPUT
 
 
   check-string-table:

--- a/.github/workflows/release-packages.yaml
+++ b/.github/workflows/release-packages.yaml
@@ -59,8 +59,8 @@ jobs:
           cd build
           ninja package
           deb_package_name="$(ls *.deb)"
-          echo "::set-output name=deb_package::./build/$deb_package_name"
-          echo "::set-output name=deb_package_name::ubuntu-20.04-$deb_package_name"
+          echo "deb_package=./build/$deb_package_name" >> $GITHUB_OUTPUT
+          echo "deb_package_name=ubuntu-20.04-$deb_package_name" >> $GITHUB_OUTPUT
       - name: Get release info
         id: get_release_info
         uses: bruceadams/get-release@v1.2.0
@@ -147,8 +147,8 @@ jobs:
           cd build
           ninja package
           deb_package_name="$(ls *.deb)"
-          echo "::set-output name=deb_package::./build/$deb_package_name"
-          echo "::set-output name=deb_package_name::ubuntu-18.04-$deb_package_name"
+          echo "deb_package=./build/$deb_package_name" >> $GITHUB_OUTPUT
+          echo "deb_package_name=ubuntu-18.04-$deb_package_name" >> $GITHUB_OUTPUT
       - name: Get release info
         id: get_release_info
         uses: bruceadams/get-release@v1.2.0
@@ -251,8 +251,8 @@ jobs:
           $cpack = "$(Split-Path -Parent (Get-Command cmake).Source)\cpack.exe"
           & $cpack . -C Release
           $msi_name = Get-ChildItem -Filter *.msi -Name
-          Write-Output "::set-output name=msi_installer::build/$msi_name"
-          Write-Output "::set-output name=msi_name::$msi_name"
+          echo "msi_installer=build/$msi_name" >> $env:GITHUB_OUTPUT
+        echo "msi_name=$msi_name" >> $env:GITHUB_OUTPUT
       - name: Decode signing certificate
         id: decode_certificate
         run: |


### PR DESCRIPTION
Use environment files as per
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
