### PR TITLE
Field sensitivity: using apply is now always safe

### DIFF
--- a/src/goto-symex/field_sensitivity.cpp
+++ b/src/goto-symex/field_sensitivity.cpp
@@ -23,7 +23,7 @@ exprt field_sensitivityt::apply(
   ssa_exprt ssa_expr,
   bool write) const
 {
-  if(!run_apply || write)
+  if(write)
     return std::move(ssa_expr);
   else
     return get_fields(ns, state, ssa_expr);
@@ -35,9 +35,6 @@ exprt field_sensitivityt::apply(
   exprt expr,
   bool write) const
 {
-  if(!run_apply)
-    return expr;
-
   if(expr.id() != ID_address_of)
   {
     Forall_operands(it, expr)
@@ -46,7 +43,7 @@ exprt field_sensitivityt::apply(
 
   if(!write && is_ssa_expr(expr))
   {
-    return apply(ns, state, to_ssa_expr(expr), write);
+    return get_fields(ns, state, to_ssa_expr(expr));
   }
   else if(
     !write && expr.id() == ID_member &&
@@ -231,17 +228,14 @@ void field_sensitivityt::field_assignments(
   const ssa_exprt &lhs,
   const exprt &rhs,
   symex_targett &target,
-  bool allow_pointer_unsoundness)
+  bool allow_pointer_unsoundness) const
 {
-  const exprt lhs_fs = apply(ns, state, lhs, false);
+  const exprt lhs_fs = get_fields(ns, state, lhs);
 
   if(lhs != lhs_fs)
   {
-    bool run_apply_bak = run_apply;
-    run_apply = false;
     field_assignments_rec(
       ns, state, lhs_fs, rhs, target, allow_pointer_unsoundness);
-    run_apply = run_apply_bak;
   }
 }
 
@@ -261,7 +255,7 @@ void field_sensitivityt::field_assignments_rec(
   const exprt &lhs_fs,
   const exprt &ssa_rhs,
   symex_targett &target,
-  bool allow_pointer_unsoundness)
+  bool allow_pointer_unsoundness) const
 {
   if(is_ssa_expr(lhs_fs))
   {

--- a/src/goto-symex/field_sensitivity.h
+++ b/src/goto-symex/field_sensitivity.h
@@ -108,7 +108,7 @@ public:
     const ssa_exprt &lhs,
     const exprt &rhs,
     symex_targett &target,
-    bool allow_pointer_unsoundness);
+    bool allow_pointer_unsoundness) const;
 
   /// Turn an expression \p expr into a field-sensitive SSA expression.
   /// Field-sensitive SSA expressions have individual symbols for each
@@ -154,12 +154,10 @@ public:
   /// \param expr: the expression to evaluate
   /// \return False, if and only if, \p expr would be a single field-sensitive
   /// SSA expression.
+  NODISCARD
   bool is_divisible(const ssa_exprt &expr) const;
 
 private:
-  /// whether or not to invoke \ref field_sensitivityt::apply
-  bool run_apply = true;
-
   const std::size_t max_field_sensitivity_array_size;
 
   const bool should_simplify;
@@ -170,7 +168,7 @@ private:
     const exprt &lhs_fs,
     const exprt &ssa_rhs,
     symex_targett &target,
-    bool allow_pointer_unsoundness);
+    bool allow_pointer_unsoundness) const;
 
   exprt simplify_opt(exprt e, const namespacet &ns) const;
 };


### PR DESCRIPTION
With the changes from 619353432 it is safe to call `apply` even when doing field assignments: the right-hand side will not be a divisible compound (which we previously sought to protect from field expansion).

This makes field sensitivity stateless, and all methods are `const`. They are not static, however, as the constructor initialises configuration options (which would otherwise need to be passed to each call).

We can then also avoid a level of indirection through `apply` and call `get_fields` directly in two cases.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
