### PR TITLE
Make propt::solver_text const

### DIFF
--- a/src/solvers/prop/prop.h
+++ b/src/solvers/prop/prop.h
@@ -93,7 +93,7 @@ public:
   virtual bvt new_variables(std::size_t width);
 
   // solving
-  virtual const std::string solver_text()=0;
+  virtual std::string solver_text() const = 0;
   enum class resultt { P_SATISFIABLE, P_UNSATISFIABLE, P_ERROR };
   resultt prop_solve();
 

--- a/src/solvers/qbf/qbf_bdd_core.cpp
+++ b/src/solvers/qbf/qbf_bdd_core.cpp
@@ -83,7 +83,7 @@ tvt qbf_bdd_coret::l_get(literalt a) const
   UNREACHABLE;
 }
 
-const std::string qbf_bdd_coret::solver_text()
+std::string qbf_bdd_coret::solver_text() const
 {
   return "QBF/BDD/CORE";
 }

--- a/src/solvers/qbf/qbf_bdd_core.h
+++ b/src/solvers/qbf/qbf_bdd_core.h
@@ -58,7 +58,7 @@ public:
   virtual literalt lor(literalt a, literalt b);
   virtual literalt lor(const bvt &bv);
 
-  virtual const std::string solver_text();
+  virtual std::string solver_text() const;
   virtual resultt prop_solve();
   virtual tvt l_get(literalt a) const;
 

--- a/src/solvers/qbf/qbf_bdd_core.h
+++ b/src/solvers/qbf/qbf_bdd_core.h
@@ -31,12 +31,12 @@ protected:
 
 public:
   qbf_bdd_certificatet(void);
-  virtual ~qbf_bdd_certificatet(void);
+  ~qbf_bdd_certificatet(void) override;
 
-  virtual literalt new_variable(void);
+  literalt new_variable(void) override;
 
-  virtual tvt l_get(literalt a) const;
-  virtual const exprt f_get(literalt l);
+  tvt l_get(literalt a) const override;
+  const exprt f_get(literalt l) override;
 };
 
 
@@ -50,20 +50,20 @@ private:
 
 public:
   qbf_bdd_coret();
-  virtual ~qbf_bdd_coret();
+  ~qbf_bdd_coret() override;
 
-  virtual literalt new_variable();
+  literalt new_variable() override;
 
-  virtual void lcnf(const bvt &bv);
-  virtual literalt lor(literalt a, literalt b);
-  virtual literalt lor(const bvt &bv);
+  void lcnf(const bvt &bv) override;
+  literalt lor(literalt a, literalt b) override;
+  literalt lor(const bvt &bv) override;
 
-  virtual std::string solver_text() const;
-  virtual resultt prop_solve();
-  virtual tvt l_get(literalt a) const;
+  std::string solver_text() const override;
+  resultt prop_solve() override;
+  tvt l_get(literalt a) const override;
 
-  virtual bool is_in_core(literalt l) const;
-  virtual modeltypet m_get(literalt a) const;
+  bool is_in_core(literalt l) const override;
+  modeltypet m_get(literalt a) const override;
 
 protected:
   void compress_certificate(void);

--- a/src/solvers/qbf/qbf_quantor.cpp
+++ b/src/solvers/qbf/qbf_quantor.cpp
@@ -27,7 +27,7 @@ tvt qbf_quantort::l_get(literalt) const
   UNREACHABLE;
 }
 
-const std::string qbf_quantort::solver_text()
+std::string qbf_quantort::solver_text() const
 {
   return "Quantor";
 }

--- a/src/solvers/qbf/qbf_quantor.h
+++ b/src/solvers/qbf/qbf_quantor.h
@@ -16,11 +16,11 @@ class qbf_quantort:public qdimacs_cnft
 {
 public:
   explicit qbf_quantort(message_handlert &message_handler);
-  virtual ~qbf_quantort();
+  ~qbf_quantort() override;
 
-  virtual std::string solver_text() const;
+  std::string solver_text() const override;
   virtual resultt prop_solve();
-  virtual tvt l_get(literalt a) const;
+  tvt l_get(literalt a) const override;
 };
 
 #endif // CPROVER_SOLVERS_QBF_QBF_QUANTOR_H

--- a/src/solvers/qbf/qbf_quantor.h
+++ b/src/solvers/qbf/qbf_quantor.h
@@ -18,7 +18,7 @@ public:
   explicit qbf_quantort(message_handlert &message_handler);
   virtual ~qbf_quantort();
 
-  virtual const std::string solver_text();
+  virtual std::string solver_text() const;
   virtual resultt prop_solve();
   virtual tvt l_get(literalt a) const;
 };

--- a/src/solvers/qbf/qbf_qube.cpp
+++ b/src/solvers/qbf/qbf_qube.cpp
@@ -29,7 +29,7 @@ tvt qbf_qubet::l_get(literalt) const
   UNREACHABLE;
 }
 
-const std::string qbf_qubet::solver_text()
+std::string qbf_qubet::solver_text() const
 {
   return "QuBE";
 }

--- a/src/solvers/qbf/qbf_qube.h
+++ b/src/solvers/qbf/qbf_qube.h
@@ -18,7 +18,7 @@ public:
   explicit qbf_qubet(message_handlert &message_handler);
   virtual ~qbf_qubet();
 
-  virtual const std::string solver_text();
+  virtual std::string solver_text() const;
   virtual resultt prop_solve();
   virtual tvt l_get(literalt a) const;
 };

--- a/src/solvers/qbf/qbf_qube.h
+++ b/src/solvers/qbf/qbf_qube.h
@@ -16,11 +16,11 @@ class qbf_qubet:public qdimacs_cnft
 {
 public:
   explicit qbf_qubet(message_handlert &message_handler);
-  virtual ~qbf_qubet();
+  ~qbf_qubet() override;
 
-  virtual std::string solver_text() const;
+  std::string solver_text() const override;
   virtual resultt prop_solve();
-  virtual tvt l_get(literalt a) const;
+  tvt l_get(literalt a) const override;
 };
 
 #endif // CPROVER_SOLVERS_QBF_QBF_QUBE_H

--- a/src/solvers/qbf/qbf_qube_core.cpp
+++ b/src/solvers/qbf/qbf_qube_core.cpp
@@ -26,7 +26,7 @@ qbf_qube_coret::~qbf_qube_coret()
 {
 }
 
-const std::string qbf_qube_coret::solver_text()
+std::string qbf_qube_coret::solver_text() const
 {
   return "QuBE w/ toplevel assignments";
 }

--- a/src/solvers/qbf/qbf_qube_core.h
+++ b/src/solvers/qbf/qbf_qube_core.h
@@ -26,7 +26,7 @@ public:
   explicit qbf_qube_coret(message_handlert &message_handler);
   virtual ~qbf_qube_coret();
 
-  virtual const std::string solver_text();
+  virtual std::string solver_text() const;
   virtual resultt prop_solve();
 
   virtual bool is_in_core(literalt l) const;

--- a/src/solvers/qbf/qbf_qube_core.h
+++ b/src/solvers/qbf/qbf_qube_core.h
@@ -24,14 +24,14 @@ protected:
 
 public:
   explicit qbf_qube_coret(message_handlert &message_handler);
-  virtual ~qbf_qube_coret();
+  ~qbf_qube_coret() override;
 
-  virtual std::string solver_text() const;
+  std::string solver_text() const override;
   virtual resultt prop_solve();
 
-  virtual bool is_in_core(literalt l) const;
+  bool is_in_core(literalt l) const override;
 
-  virtual tvt l_get(literalt a) const
+  tvt l_get(literalt a) const override
   {
     unsigned v=a.var_no();
 
@@ -49,9 +49,9 @@ public:
     return tvt::unknown();
   }
 
-  virtual modeltypet m_get(literalt a) const;
+  modeltypet m_get(literalt a) const override;
 
-  virtual const exprt f_get(literalt)
+  const exprt f_get(literalt) override
   {
     INVARIANT(false, "qube does not support full certificates.");
   }

--- a/src/solvers/qbf/qbf_skizzo.cpp
+++ b/src/solvers/qbf/qbf_skizzo.cpp
@@ -29,7 +29,7 @@ tvt qbf_skizzot::l_get(literalt) const
   UNREACHABLE;
 }
 
-const std::string qbf_skizzot::solver_text()
+std::string qbf_skizzot::solver_text() const
 {
   return "Skizzo";
 }

--- a/src/solvers/qbf/qbf_skizzo.h
+++ b/src/solvers/qbf/qbf_skizzo.h
@@ -16,11 +16,11 @@ class qbf_skizzot:public qdimacs_cnft
 {
 public:
   explicit qbf_skizzot(message_handlert &message_handler);
-  virtual ~qbf_skizzot();
+  ~qbf_skizzot() override;
 
-  virtual std::string solver_text() const;
+  std::string solver_text() const override;
   virtual resultt prop_solve();
-  virtual tvt l_get(literalt a) const;
+  tvt l_get(literalt a) const override;
 };
 
 #endif // CPROVER_SOLVERS_QBF_QBF_SKIZZO_H

--- a/src/solvers/qbf/qbf_skizzo.h
+++ b/src/solvers/qbf/qbf_skizzo.h
@@ -18,7 +18,7 @@ public:
   explicit qbf_skizzot(message_handlert &message_handler);
   virtual ~qbf_skizzot();
 
-  virtual const std::string solver_text();
+  virtual std::string solver_text() const;
   virtual resultt prop_solve();
   virtual tvt l_get(literalt a) const;
 };

--- a/src/solvers/qbf/qbf_skizzo_core.cpp
+++ b/src/solvers/qbf/qbf_skizzo_core.cpp
@@ -39,7 +39,7 @@ qbf_skizzo_coret::~qbf_skizzo_coret()
 {
 }
 
-const std::string qbf_skizzo_coret::solver_text()
+std::string qbf_skizzo_coret::solver_text() const
 {
   return "Skizzo/Core";
 }

--- a/src/solvers/qbf/qbf_skizzo_core.h
+++ b/src/solvers/qbf/qbf_skizzo_core.h
@@ -19,7 +19,7 @@ public:
   qbf_skizzo_coret();
   virtual ~qbf_skizzo_coret();
 
-  virtual const std::string solver_text();
+  virtual std::string solver_text() const;
   virtual resultt prop_solve();
 
   virtual bool is_in_core(literalt l) const;

--- a/src/solvers/qbf/qbf_skizzo_core.h
+++ b/src/solvers/qbf/qbf_skizzo_core.h
@@ -17,13 +17,13 @@ class qbf_skizzo_coret:public qbf_bdd_certificatet
 {
 public:
   qbf_skizzo_coret();
-  virtual ~qbf_skizzo_coret();
+  ~qbf_skizzo_coret() override;
 
-  virtual std::string solver_text() const;
-  virtual resultt prop_solve();
+  std::string solver_text() const override;
+  resultt prop_solve() override;
 
-  virtual bool is_in_core(literalt l) const;
-  virtual modeltypet m_get(literalt a) const;
+  bool is_in_core(literalt l) const override;
+  modeltypet m_get(literalt a) const override;
 
 protected:
   std::string qbf_tmp_file;

--- a/src/solvers/qbf/qbf_squolem.cpp
+++ b/src/solvers/qbf/qbf_squolem.cpp
@@ -26,7 +26,7 @@ tvt qbf_squolemt::l_get(literalt a) const
   UNREACHABLE;
 }
 
-const std::string qbf_squolemt::solver_text()
+std::string qbf_squolemt::solver_text() const
 {
   return "Squolem";
 }

--- a/src/solvers/qbf/qbf_squolem.h
+++ b/src/solvers/qbf/qbf_squolem.h
@@ -26,7 +26,7 @@ public:
   qbf_squolemt();
   virtual ~qbf_squolemt();
 
-  virtual const std::string solver_text();
+  virtual std::string solver_text() const;
   virtual resultt prop_solve();
   virtual tvt l_get(literalt a) const;
 

--- a/src/solvers/qbf/qbf_squolem.h
+++ b/src/solvers/qbf/qbf_squolem.h
@@ -24,16 +24,16 @@ protected:
 
 public:
   qbf_squolemt();
-  virtual ~qbf_squolemt();
+  ~qbf_squolemt() override;
 
-  virtual std::string solver_text() const;
-  virtual resultt prop_solve();
-  virtual tvt l_get(literalt a) const;
+  std::string solver_text() const override;
+  resultt prop_solve() override;
+  tvt l_get(literalt a) const override;
 
-  virtual void lcnf(const bvt &bv);
-  virtual void add_quantifier(const quantifiert &quantifier);
-  virtual void set_quantifier(const quantifiert::typet type, const literalt l);
-  virtual void set_no_variables(size_t no);
+  void lcnf(const bvt &bv) override;
+  void add_quantifier(const quantifiert &quantifier) override;
+  void set_quantifier(const quantifiert::typet type, const literalt l) override;
+  void set_no_variables(size_t no) override;
   virtual size_t no_clauses() const { return squolem.clauses(); }
 };
 

--- a/src/solvers/qbf/qbf_squolem_core.cpp
+++ b/src/solvers/qbf/qbf_squolem_core.cpp
@@ -74,7 +74,7 @@ tvt qbf_squolem_coret::l_get(literalt a) const
     return tvt(tvt::tv_enumt::TV_UNKNOWN);
 }
 
-const std::string qbf_squolem_coret::solver_text()
+std::string qbf_squolem_coret::solver_text() const
 {
   return "Squolem (Certifying)";
 }

--- a/src/solvers/qbf/qbf_squolem_core.h
+++ b/src/solvers/qbf/qbf_squolem_core.h
@@ -26,7 +26,7 @@ public:
   qbf_squolem_coret();
   virtual ~qbf_squolem_coret();
 
-  virtual const std::string solver_text();
+  virtual std::string solver_text() const;
   virtual resultt prop_solve();
 
   virtual tvt l_get(literalt a) const;

--- a/src/solvers/qbf/qbf_squolem_core.h
+++ b/src/solvers/qbf/qbf_squolem_core.h
@@ -24,29 +24,29 @@ protected:
 
 public:
   qbf_squolem_coret();
-  virtual ~qbf_squolem_coret();
+  ~qbf_squolem_coret() override;
 
-  virtual std::string solver_text() const;
-  virtual resultt prop_solve();
+  std::string solver_text() const override;
+  resultt prop_solve() override;
 
-  virtual tvt l_get(literalt a) const;
-  virtual bool is_in_core(literalt l) const;
+  tvt l_get(literalt a) const override;
+  bool is_in_core(literalt l) const override;
 
   void set_debug_filename(const std::string &str);
 
-  virtual void lcnf(const bvt &bv);
-  virtual void add_quantifier(const quantifiert &quantifier);
-  virtual void set_quantifier(const quantifiert::typet type, const literalt l);
-  virtual void set_no_variables(size_t no);
+  void lcnf(const bvt &bv) override;
+  void add_quantifier(const quantifiert &quantifier) override;
+  void set_quantifier(const quantifiert::typet type, const literalt l) override;
+  void set_no_variables(size_t no) override;
   virtual size_t no_clauses() const { return squolem->clauses(); }
 
-  virtual modeltypet m_get(literalt a) const;
+  modeltypet m_get(literalt a) const override;
 
-  virtual void write_qdimacs_cnf(std::ostream &out);
+  void write_qdimacs_cnf(std::ostream &out) override;
 
   void reset(void);
 
-  virtual const exprt f_get(literalt l);
+  const exprt f_get(literalt l) override;
 
 private:
   typedef std::unordered_map<unsigned, exprt> function_cachet;

--- a/src/solvers/qbf/qdimacs_cnf.h
+++ b/src/solvers/qbf/qdimacs_cnf.h
@@ -21,13 +21,12 @@ public:
     : dimacs_cnft(message_handler)
   {
   }
-  virtual ~qdimacs_cnft() { }
 
   virtual void write_qdimacs_cnf(std::ostream &out);
 
   // dummy functions
 
-  virtual std::string solver_text() const
+  std::string solver_text() const override
   {
     return "QDIMACS CNF";
   }

--- a/src/solvers/qbf/qdimacs_cnf.h
+++ b/src/solvers/qbf/qdimacs_cnf.h
@@ -27,7 +27,7 @@ public:
 
   // dummy functions
 
-  virtual const std::string solver_text()
+  virtual std::string solver_text() const
   {
     return "QDIMACS CNF";
   }

--- a/src/solvers/sat/cnf_clause_list.h
+++ b/src/solvers/sat/cnf_clause_list.h
@@ -31,7 +31,7 @@ public:
 
   void lcnf(const bvt &bv) override;
 
-  const std::string solver_text() override
+  std::string solver_text() const override
   { return "CNF clause list"; }
 
   tvt l_get(literalt) const override

--- a/src/solvers/sat/dimacs_cnf.h
+++ b/src/solvers/sat/dimacs_cnf.h
@@ -24,7 +24,7 @@ public:
 
   // dummy functions
 
-  const std::string solver_text() override
+  std::string solver_text() const override
   {
     return "DIMACS CNF";
   }
@@ -48,7 +48,7 @@ public:
   dimacs_cnf_dumpt(std::ostream &_out, message_handlert &message_handler);
   virtual ~dimacs_cnf_dumpt() { }
 
-  const std::string solver_text() override
+  std::string solver_text() const override
   {
     return "DIMACS CNF Dumper";
   }

--- a/src/solvers/sat/external_sat.cpp
+++ b/src/solvers/sat/external_sat.cpp
@@ -21,7 +21,7 @@ external_satt::external_satt(message_handlert &message_handler, std::string cmd)
 {
 }
 
-const std::string external_satt::solver_text()
+std::string external_satt::solver_text() const
 {
   return "External SAT solver";
 }

--- a/src/solvers/sat/external_sat.h
+++ b/src/solvers/sat/external_sat.h
@@ -22,7 +22,7 @@ public:
     return false;
   }
 
-  const std::string solver_text() override;
+  std::string solver_text() const override;
 
   bool is_in_conflict(literalt) const override;
   void set_assignment(literalt, bool) override;

--- a/src/solvers/sat/pbs_dimacs_cnf.h
+++ b/src/solvers/sat/pbs_dimacs_cnf.h
@@ -52,7 +52,7 @@ public:
 
   // dummy functions
 
-  const std::string solver_text() override
+  std::string solver_text() const override
   {
     return "PBS - Pseudo Boolean/CNF Solver and Optimizer";
   }

--- a/src/solvers/sat/satcheck_booleforce.cpp
+++ b/src/solvers/sat/satcheck_booleforce.cpp
@@ -58,7 +58,7 @@ tvt satcheck_booleforce_baset::l_get(literalt a) const
   return result;
 }
 
-const std::string satcheck_booleforce_baset::solver_text()
+std::string satcheck_booleforce_baset::solver_text() const
 {
   return std::string("Booleforce version ")+booleforce_version();
 }

--- a/src/solvers/sat/satcheck_booleforce.h
+++ b/src/solvers/sat/satcheck_booleforce.h
@@ -20,7 +20,7 @@ class satcheck_booleforce_baset:public cnf_solvert
 public:
   virtual ~satcheck_booleforce_baset();
 
-  const std::string solver_text() override;
+  std::string solver_text() const override;
   tvt l_get(literalt a) const override;
 
   void lcnf(const bvt &bv) override;

--- a/src/solvers/sat/satcheck_cadical.cpp
+++ b/src/solvers/sat/satcheck_cadical.cpp
@@ -38,7 +38,7 @@ tvt satcheck_cadicalt::l_get(literalt a) const
   return result;
 }
 
-const std::string satcheck_cadicalt::solver_text()
+std::string satcheck_cadicalt::solver_text() const
 {
   return std::string("CaDiCaL ") + solver->version();
 }

--- a/src/solvers/sat/satcheck_cadical.h
+++ b/src/solvers/sat/satcheck_cadical.h
@@ -25,7 +25,7 @@ public:
   explicit satcheck_cadicalt(message_handlert &message_handler);
   virtual ~satcheck_cadicalt();
 
-  const std::string solver_text() override;
+  std::string solver_text() const override;
   tvt l_get(literalt a) const override;
 
   void lcnf(const bvt &bv) override;

--- a/src/solvers/sat/satcheck_glucose.cpp
+++ b/src/solvers/sat/satcheck_glucose.cpp
@@ -78,12 +78,12 @@ void satcheck_glucose_baset<T>::set_polarity(literalt a, bool value)
   }
 }
 
-const std::string satcheck_glucose_no_simplifiert::solver_text()
+std::string satcheck_glucose_no_simplifiert::solver_text() const
 {
   return "Glucose Syrup without simplifier";
 }
 
-const std::string satcheck_glucose_simplifiert::solver_text()
+std::string satcheck_glucose_simplifiert::solver_text() const
 {
   return "Glucose Syrup with simplifier";
 }

--- a/src/solvers/sat/satcheck_glucose.h
+++ b/src/solvers/sat/satcheck_glucose.h
@@ -71,7 +71,7 @@ class satcheck_glucose_no_simplifiert:
 {
 public:
   using satcheck_glucose_baset<Glucose::Solver>::satcheck_glucose_baset;
-  const std::string solver_text() override;
+  std::string solver_text() const override;
 };
 
 class satcheck_glucose_simplifiert:
@@ -79,7 +79,7 @@ class satcheck_glucose_simplifiert:
 {
 public:
   using satcheck_glucose_baset<Glucose::SimpSolver>::satcheck_glucose_baset;
-  const std::string solver_text() override;
+  std::string solver_text() const override;
   void set_frozen(literalt a) override;
   bool is_eliminated(literalt a) const;
 };

--- a/src/solvers/sat/satcheck_ipasir.cpp
+++ b/src/solvers/sat/satcheck_ipasir.cpp
@@ -59,7 +59,7 @@ tvt satcheck_ipasirt::l_get(literalt a) const
   return result;
 }
 
-const std::string satcheck_ipasirt::solver_text()
+std::string satcheck_ipasirt::solver_text() const
 {
   return std::string(ipasir_signature());
 }

--- a/src/solvers/sat/satcheck_ipasir.h
+++ b/src/solvers/sat/satcheck_ipasir.h
@@ -24,7 +24,7 @@ public:
   virtual ~satcheck_ipasirt() override;
 
   /// This method returns the description produced by the linked SAT solver
-  const std::string solver_text() override;
+  std::string solver_text() const override;
 
   /// This method returns the truth value for a literal of the current SAT model
   tvt l_get(literalt a) const override final;

--- a/src/solvers/sat/satcheck_lingeling.cpp
+++ b/src/solvers/sat/satcheck_lingeling.cpp
@@ -43,7 +43,7 @@ tvt satcheck_lingelingt::l_get(literalt a) const
   return result;
 }
 
-const std::string satcheck_lingelingt::solver_text()
+std::string satcheck_lingelingt::solver_text() const
 {
   return "Lingeling";
 }

--- a/src/solvers/sat/satcheck_lingeling.h
+++ b/src/solvers/sat/satcheck_lingeling.h
@@ -21,7 +21,7 @@ public:
   satcheck_lingelingt();
   virtual ~satcheck_lingelingt();
 
-  const std::string solver_text() override;
+  std::string solver_text() const override;
   tvt l_get(literalt a) const override;
 
   void lcnf(const bvt &bv) override;

--- a/src/solvers/sat/satcheck_minisat.cpp
+++ b/src/solvers/sat/satcheck_minisat.cpp
@@ -108,7 +108,7 @@ tvt satcheck_minisat1_baset::l_get(literalt a) const
   return result;
 }
 
-const std::string satcheck_minisat1_baset::solver_text()
+std::string satcheck_minisat1_baset::solver_text() const
 {
   return "MiniSAT 1.14p";
 }
@@ -257,7 +257,7 @@ satcheck_minisat1_baset::~satcheck_minisat1_baset()
   delete solver;
 }
 
-const std::string satcheck_minisat1_prooft::solver_text()
+std::string satcheck_minisat1_prooft::solver_text() const
 {
   return "MiniSAT + Proof";
 }
@@ -277,7 +277,7 @@ propt::resultt satcheck_minisat1_coret::do_prop_solve()
   return r;
 }
 
-const std::string satcheck_minisat1_coret::solver_text()
+std::string satcheck_minisat1_coret::solver_text() const
 {
   return "MiniSAT + Core";
 }

--- a/src/solvers/sat/satcheck_minisat.h
+++ b/src/solvers/sat/satcheck_minisat.h
@@ -24,7 +24,7 @@ public:
 
   virtual ~satcheck_minisat1_baset();
 
-  const std::string solver_text() override;
+  std::string solver_text() const override;
   tvt l_get(literalt a) const override;
 
   void lcnf(const bvt &bv) final;
@@ -68,7 +68,7 @@ public:
   satcheck_minisat1_prooft();
   ~satcheck_minisat1_prooft();
 
-  const std::string solver_text() override;
+  std::string solver_text() const override;
   simple_prooft &get_resolution_proof();
   // void set_partition_id(unsigned p_id);
 
@@ -84,7 +84,7 @@ public:
   satcheck_minisat1_coret();
   ~satcheck_minisat1_coret();
 
-  const std::string solver_text() override;
+  std::string solver_text() const override;
 
   bool has_in_core() const
   {

--- a/src/solvers/sat/satcheck_minisat2.cpp
+++ b/src/solvers/sat/satcheck_minisat2.cpp
@@ -99,12 +99,12 @@ void satcheck_minisat2_baset<T>::clear_interrupt()
   solver->clearInterrupt();
 }
 
-const std::string satcheck_minisat_no_simplifiert::solver_text()
+std::string satcheck_minisat_no_simplifiert::solver_text() const
 {
   return "MiniSAT 2.2.1 without simplifier";
 }
 
-const std::string satcheck_minisat_simplifiert::solver_text()
+std::string satcheck_minisat_simplifiert::solver_text() const
 {
   return "MiniSAT 2.2.1 with simplifier";
 }

--- a/src/solvers/sat/satcheck_minisat2.h
+++ b/src/solvers/sat/satcheck_minisat2.h
@@ -83,7 +83,7 @@ class satcheck_minisat_no_simplifiert:
 {
 public:
   using satcheck_minisat2_baset<Minisat::Solver>::satcheck_minisat2_baset;
-  const std::string solver_text() override;
+  std::string solver_text() const override;
 };
 
 class satcheck_minisat_simplifiert:
@@ -91,7 +91,7 @@ class satcheck_minisat_simplifiert:
 {
 public:
   using satcheck_minisat2_baset<Minisat::SimpSolver>::satcheck_minisat2_baset;
-  const std::string solver_text() override final;
+  std::string solver_text() const override final;
   void set_frozen(literalt a) override final;
   bool is_eliminated(literalt a) const;
 };

--- a/src/solvers/sat/satcheck_picosat.cpp
+++ b/src/solvers/sat/satcheck_picosat.cpp
@@ -43,7 +43,7 @@ tvt satcheck_picosatt::l_get(literalt a) const
   return result;
 }
 
-const std::string satcheck_picosatt::solver_text()
+std::string satcheck_picosatt::solver_text() const
 {
   return "PicoSAT";
 }

--- a/src/solvers/sat/satcheck_picosat.h
+++ b/src/solvers/sat/satcheck_picosat.h
@@ -21,7 +21,7 @@ public:
   satcheck_picosatt();
   ~satcheck_picosatt();
 
-  const std::string solver_text() override;
+  std::string solver_text() const override;
   tvt l_get(literalt a) const override;
 
   void lcnf(const bvt &bv) override;

--- a/src/solvers/sat/satcheck_zchaff.cpp
+++ b/src/solvers/sat/satcheck_zchaff.cpp
@@ -51,7 +51,7 @@ tvt satcheck_zchaff_baset::l_get(literalt a) const
   return result;
 }
 
-const std::string satcheck_zchaff_baset::solver_text()
+std::string satcheck_zchaff_baset::solver_text() const
 {
   return solver->version();
 }

--- a/src/solvers/sat/satcheck_zchaff.h
+++ b/src/solvers/sat/satcheck_zchaff.h
@@ -24,7 +24,7 @@ public:
   explicit satcheck_zchaff_baset(CSolver *_solver);
   virtual ~satcheck_zchaff_baset();
 
-  const std::string solver_text() override;
+  std::string solver_text() const override;
   tvt l_get(literalt a) const override;
   void set_assignment(literalt a, bool value) override;
   virtual void copy_cnf();

--- a/src/solvers/sat/satcheck_zcore.cpp
+++ b/src/solvers/sat/satcheck_zcore.cpp
@@ -29,7 +29,7 @@ tvt satcheck_zcoret::l_get(literalt a) const
   return tvt(tvt::tv_enumt::TV_UNKNOWN);
 }
 
-const std::string satcheck_zcoret::solver_text()
+std::string satcheck_zcoret::solver_text() const
 {
   return "ZCore";
 }

--- a/src/solvers/sat/satcheck_zcore.h
+++ b/src/solvers/sat/satcheck_zcore.h
@@ -20,7 +20,7 @@ public:
   satcheck_zcoret();
   virtual ~satcheck_zcoret();
 
-  const std::string solver_text() override;
+  std::string solver_text() const override;
   tvt l_get(literalt a) const override;
 
   bool is_in_core(literalt l) const

--- a/unit/solvers/bdd/miniBDD/miniBDD.cpp
+++ b/unit/solvers/bdd/miniBDD/miniBDD.cpp
@@ -147,7 +147,7 @@ public:
     return bdd_map.size();
   }
 
-  const std::string solver_text() override
+  std::string solver_text() const override
   {
     return "BDDs";
   }


### PR DESCRIPTION
There is no point in marking the string returned by value `const`, it's really about marking the method itself `const`.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
