### PR TITLE
GitHub actions: use major version only

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -19,7 +19,7 @@ jobs:
 
       - name: Publish documentation
         if: ${{ github.event_name == 'push' && startsWith('refs/heads/develop', github.ref) }}
-        uses: JamesIves/github-pages-deploy-action@4.1.4
+        uses: JamesIves/github-pages-deploy-action@v4
         with:
           branch: gh-pages
           folder: doc/doxygen-root/html

--- a/.github/workflows/pull-request-checks.yaml
+++ b/.github/workflows/pull-request-checks.yaml
@@ -505,7 +505,7 @@ jobs:
       - name: Confirm cvc5 solver is available and log the version installed
         run: cvc5 --version
       - name: Setup Visual Studio environment
-        uses: microsoft/setup-msbuild@v1.1
+        uses: microsoft/setup-msbuild@v1
       - name: Prepare ccache
         uses: actions/cache@v3
         with:
@@ -524,7 +524,7 @@ jobs:
         run: cmake --build build --config Release -- /p:UseMultiToolTask=true /p:CLToolExe=clcache
       - name: Print ccache stats
         run: clcache -s
-      - uses: ilammy/msvc-dev-cmd@v1.4.1
+      - uses: ilammy/msvc-dev-cmd@v1
       - name: Test cbmc
         run: |
           Set-Location build
@@ -559,7 +559,7 @@ jobs:
       - name: Confirm cvc5 solver is available and log the version installed
         run: cvc5 --version
       - name: Setup MSBuild
-        uses: microsoft/setup-msbuild@v1.1
+        uses: microsoft/setup-msbuild@v1
       - name: Initialise Developer Command Line
         uses: ilammy/msvc-dev-cmd@v1
       - name: Prepare ccache
@@ -656,7 +656,7 @@ jobs:
           nuget install clcache -OutputDirectory "c:\tools" -ExcludeVersion -Version 4.1.0
           echo "c:\tools\clcache\clcache-4.1.0" >> $env:GITHUB_PATH
       - name: Setup Visual Studio environment
-        uses: microsoft/setup-msbuild@v1.1
+        uses: microsoft/setup-msbuild@v1
       - name: Prepare ccache
         uses: actions/cache@v3
         with:
@@ -835,7 +835,7 @@ jobs:
           echo "lcov_excl_line = UNREACHABLE" > ~/.lcovrc
           cmake --build build --target coverage -- -j2
       - name: Upload coverage statistics to Codecov
-        uses: codecov/codecov-action@v3.0.0
+        uses: codecov/codecov-action@v3
         with:
           files: build/html/coverage.info
           fail_ci_if_error: true

--- a/.github/workflows/release-packages.yaml
+++ b/.github/workflows/release-packages.yaml
@@ -63,7 +63,7 @@ jobs:
           echo "deb_package_name=ubuntu-20.04-$deb_package_name" >> $GITHUB_OUTPUT
       - name: Get release info
         id: get_release_info
-        uses: bruceadams/get-release@v1.2.0
+        uses: bruceadams/get-release@v1
       - name: Upload binary packages
         uses: actions/upload-release-asset@v1
         with:
@@ -151,7 +151,7 @@ jobs:
           echo "deb_package_name=ubuntu-18.04-$deb_package_name" >> $GITHUB_OUTPUT
       - name: Get release info
         id: get_release_info
-        uses: bruceadams/get-release@v1.2.0
+        uses: bruceadams/get-release@v1
       - name: Upload binary packages
         uses: actions/upload-release-asset@v1
         with:
@@ -219,7 +219,7 @@ jobs:
           nuget install clcache -OutputDirectory "c:\tools" -ExcludeVersion -Version 4.1.0
           echo "c:\tools\clcache\clcache-4.1.0" >> $env:GITHUB_PATH
       - name: Setup Visual Studio environment
-        uses: microsoft/setup-msbuild@v1.1
+        uses: microsoft/setup-msbuild@v1
       - name: Setup code sign environment
         run: |
           echo "$(Split-Path -Path $(Get-ChildItem -Path "${env:ProgramFiles(x86)}\Windows Kits\10\App Certification Kit\signtool.exe"))" >> $env:GITHUB_PATH
@@ -281,7 +281,7 @@ jobs:
           & signtool.exe verify /pa ${{ steps.create_packages.outputs.msi_installer }}
       - name: Get release info
         id: get_release_info
-        uses: bruceadams/get-release@v1.2.0
+        uses: bruceadams/get-release@v1
       - name: Upload binary packages
         uses: actions/upload-release-asset@v1
         with:


### PR DESCRIPTION
This will make sure we always get the latest release of a particular major version instead of having to repeatedly upgrade. (Also fixes one more instance of a node.js 12 deprecation warning.)

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
