### PR TITLE
goto-instrument --unwind: identify loop unwinding assertions as such

### DIFF
--- a/regression/goto-instrument/unwind-assert1/test.desc
+++ b/regression/goto-instrument/unwind-assert1/test.desc
@@ -1,8 +1,10 @@
 CORE
 main.c
 --unwind 10 --unwinding-assertions
+^\[main.unwind.1\] line 5 unwinding assertion loop 0: SUCCESS$
 ^EXIT=0$
 ^SIGNAL=0$
 ^VERIFICATION SUCCESSFUL$
 --
 ^warning: ignoring
+^\[main.\d+\] line 5 assertion: SUCCESS$

--- a/src/goto-instrument/unwind.cpp
+++ b/src/goto-instrument/unwind.cpp
@@ -153,8 +153,13 @@ void goto_unwindt::unwind(
       unwind_strategy == unwind_strategyt::ASSERT_ASSUME ||
       unwind_strategy == unwind_strategyt::ASSERT_PARTIAL)
     {
+      const std::string loop_number = std::to_string(t->loop_number);
+      source_locationt source_location_annotated = loop_head->source_location();
+      source_location_annotated.set_property_class("unwind");
+      source_location_annotated.set_comment(
+        "unwinding assertion loop " + loop_number);
       goto_programt::targett assertion = rest_program.add(
-        goto_programt::make_assertion(exit_cond, loop_head->source_location()));
+        goto_programt::make_assertion(exit_cond, source_location_annotated));
       unwind_log.insert(assertion, loop_head->location_number);
     }
 


### PR DESCRIPTION
We previously generated an assertion without setting either comments or the property class. Make sure verification reports allow the user to understand what the failing/succeeding assertion is about.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
