### PR TITLE
Remove well-alignedness assumption from pointer-into-array

### DIFF
--- a/jbmc/src/java_bytecode/java_trace_validation.cpp
+++ b/jbmc/src/java_bytecode/java_trace_validation.cpp
@@ -79,7 +79,8 @@ bool can_evaluate_to_constant(const exprt &expression)
 {
   return can_cast_expr<constant_exprt>(skip_typecast(expression)) ||
          can_cast_expr<symbol_exprt>(skip_typecast(expression)) ||
-         can_cast_expr<plus_exprt>(skip_typecast(expression));
+         can_cast_expr<plus_exprt>(skip_typecast(expression)) ||
+         can_cast_expr<mult_exprt>(skip_typecast(expression));
 }
 
 bool check_index_structure(const exprt &index_expr)

--- a/regression/cbmc/Pointer_Arithmetic19/test.desc
+++ b/regression/cbmc/Pointer_Arithmetic19/test.desc
@@ -1,7 +1,7 @@
 CORE new-smt-backend
 main.c
 --program-only
-ASSERT\(\{ 42, 43 \}\[POINTER_OFFSET\(p!0@1#2\) / \d+l*\] == 43\)$
+ASSERT\(byte_extract_little_endian\(\{ 42, 43 \}, POINTER_OFFSET\(p!0@1#2\), signed int\) == 43\)$
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/regression/cbmc/Pointer_array7/big-endian.desc
+++ b/regression/cbmc/Pointer_array7/big-endian.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+--big-endian -D__BIG_ENDIAN__
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring

--- a/regression/cbmc/Pointer_array7/main.c
+++ b/regression/cbmc/Pointer_array7/main.c
@@ -1,0 +1,29 @@
+#include <assert.h>
+#include <stdint.h>
+
+#if !defined(__LITTLE_ENDIAN__) && !defined(__BIG_ENDIAN__)
+
+#  if defined(__avr32__) || defined(__hppa__) || defined(__m68k__) ||          \
+    defined(__mips__) || defined(__powerpc__) || defined(__s390__) ||          \
+    defined(__s390x__) || defined(__sparc__)
+
+#    define __BIG_ENDIAN__
+
+#  endif
+
+#endif
+
+int main()
+{
+  uint16_t x[2];
+  x[0] = 1;
+  x[1] = 2;
+  uint8_t *y = (uint8_t *)x;
+  uint16_t z = *((uint16_t *)(y + 1));
+
+#ifdef __BIG_ENDIAN__
+  assert(z == 256u);
+#else
+  assert(z == 512u);
+#endif
+}

--- a/regression/cbmc/Pointer_array7/test.desc
+++ b/regression/cbmc/Pointer_array7/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+--little-endian -D__LITTLE_ENDIAN__
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring

--- a/regression/cbmc/address_space_size_limit3/test.desc
+++ b/regression/cbmc/address_space_size_limit3/test.desc
@@ -1,4 +1,4 @@
-CORE broken-smt-backend
+CORE thorough-smt-backend
 main.i
 --32 --little-endian --object-bits 25 --pointer-check
 ^EXIT=10$

--- a/src/pointer-analysis/value_set_dereference.cpp
+++ b/src/pointer-analysis/value_set_dereference.cpp
@@ -575,8 +575,6 @@ value_set_dereferencet::valuet value_set_dereferencet::build_reference_to(
     const typet &object_type = object.type();
     const typet &root_object_type = root_object.type();
 
-    exprt root_object_subexpression=root_object;
-
     if(
       dereference_type_compare(object_type, dereference_type, ns) &&
       o.offset().is_zero())
@@ -640,7 +638,7 @@ value_set_dereferencet::valuet value_set_dereferencet::build_reference_to(
 
     // try to build a member/index expression - do not use byte_extract
     auto subexpr = get_subexpression_at_offset(
-      root_object_subexpression, o.offset(), dereference_type, ns);
+      root_object, o.offset(), dereference_type, ns);
     if(subexpr.has_value())
       simplify(subexpr.value(), ns);
     if(

--- a/src/pointer-analysis/value_set_dereference.cpp
+++ b/src/pointer-analysis/value_set_dereference.cpp
@@ -611,12 +611,8 @@ value_set_dereferencet::valuet value_set_dereferencet::build_reference_to(
       // are we doing a byte?
       auto element_size =
         pointer_offset_size(to_array_type(root_object_type).element_type(), ns);
-
-      if(!element_size.has_value() || *element_size == 0)
-      {
-        throw "unknown or invalid type size of:\n" +
-          to_array_type(root_object_type).element_type().pretty();
-      }
+      CHECK_RETURN(element_size.has_value());
+      CHECK_RETURN(*element_size > 0);
 
       const auto offset_int =
         numeric_cast_v<mp_integer>(to_constant_expr(offset));

--- a/src/pointer-analysis/value_set_dereference.cpp
+++ b/src/pointer-analysis/value_set_dereference.cpp
@@ -142,9 +142,9 @@ exprt value_set_dereferencet::dereference(
   const exprt &pointer,
   bool display_points_to_sets)
 {
-  if(pointer.type().id()!=ID_pointer)
-    throw "dereference expected pointer type, but got "+
-          pointer.type().pretty();
+  PRECONDITION_WITH_DIAGNOSTICS(
+    pointer.type().id() == ID_pointer,
+    "dereference expected pointer type, but got " + pointer.type().pretty());
 
   // we may get ifs due to recursive calls
   if(pointer.id()==ID_if)
@@ -465,8 +465,9 @@ value_set_dereferencet::valuet value_set_dereferencet::build_reference_to(
     return valuet();
   }
 
-  if(what.id()!=ID_object_descriptor)
-    throw "unknown points-to: "+what.id_string();
+  PRECONDITION_WITH_DIAGNOSTICS(
+    what.id() == ID_object_descriptor,
+    "unknown points-to: " + what.id_string());
 
   const object_descriptor_exprt &o=to_object_descriptor_expr(what);
 

--- a/src/solvers/flattening/bv_pointers.cpp
+++ b/src/solvers/flattening/bv_pointers.cpp
@@ -732,7 +732,7 @@ bvt bv_pointerst::convert_bitvector(const exprt &expr)
     to_typecast_expr(expr).op().type().id() == ID_pointer)
   {
     // pointer to int
-    bvt op0 = convert_pointer_type(to_typecast_expr(expr).op());
+    bvt op0 = convert_bv(to_typecast_expr(expr).op());
 
     // squeeze it in!
     std::size_t width=boolbv_width(expr.type());

--- a/src/solvers/flattening/bv_pointers.h
+++ b/src/solvers/flattening/bv_pointers.h
@@ -67,6 +67,12 @@ protected:
     const exprt &index);
   NODISCARD
   bvt offset_arithmetic(
+    const pointer_typet &type,
+    const bvt &bv,
+    const exprt &factor,
+    const exprt &index);
+  NODISCARD
+  bvt offset_arithmetic(
     const pointer_typet &,
     const bvt &,
     const mp_integer &factor,


### PR DESCRIPTION
84df81e5 fixed the case for unaligned access into arrays when the dereference type did not match the size of array elements. This was, however, missing the case that an unaligned access into an array is done with matching dereference type size.

Co-authored-by: Enrico Steffinlongo <enrico.steffinlongo@diffblue.com>

Fixes: #7265

Please review commit-by-commit.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
