### PR TITLE
Assignments to bit-fields yield results of bit-field type

### DIFF
--- a/regression/cbmc/Bitfields4/main.c
+++ b/regression/cbmc/Bitfields4/main.c
@@ -1,0 +1,21 @@
+#include <assert.h>
+#include <stdint.h>
+
+struct S0
+{
+  signed int f1 : 2;
+};
+
+int main(int argc, char *argv[])
+{
+  struct S0 l_4590 = {1};
+  uint32_t g_307 = ++l_4590.f1;
+  assert(g_307 == 4294967294u);
+
+  l_4590 = (struct S0){1};
+  uint32_t g_308 = l_4590.f1 += 1;
+  assert(g_308 == 4294967294u);
+
+  uint32_t g_309 = l_4590.f1 = 62378u;
+  assert(g_309 == 4294967294u);
+}

--- a/regression/cbmc/Bitfields4/test.desc
+++ b/regression/cbmc/Bitfields4/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring

--- a/src/ansi-c/expr2c.cpp
+++ b/src/ansi-c/expr2c.cpp
@@ -1834,8 +1834,12 @@ std::string expr2ct::convert_constant(
   {
     const auto width = to_bitvector_type(type).get_width();
 
-    mp_integer int_value =
-      bvrep2integer(value, width, type.id() == ID_signedbv);
+    mp_integer int_value = bvrep2integer(
+      value,
+      width,
+      type.id() == ID_signedbv ||
+        (type.id() == ID_c_bit_field &&
+         to_c_bit_field_type(type).underlying_type().id() == ID_signedbv));
 
     const irep_idt &c_type =
       type.id() == ID_c_bit_field

--- a/src/goto-programs/goto_clean_expr.cpp
+++ b/src/goto-programs/goto_clean_expr.cpp
@@ -392,12 +392,12 @@ void goto_convertt::clean_expr(
         exprt new_lhs = skip_typecast(lhs);
         exprt new_rhs = typecast_exprt::conditional_cast(
           side_effect_assign.rhs(), new_lhs.type());
-        code_assignt assignment(std::move(new_lhs), std::move(new_rhs));
+        code_assignt assignment(std::move(new_lhs), new_rhs);
         assignment.add_source_location()=expr.source_location();
         convert_assign(assignment, dest, mode);
 
         if(result_is_used)
-          expr = must_use_rhs ? side_effect_assign.rhs() : lhs;
+          expr = must_use_rhs ? new_rhs : lhs;
         else
           expr.make_nil();
         return;


### PR DESCRIPTION
Do not use the type of the assignment expression (which is the underlying type) to store the result.

Also fixes C pretty-printing of bit-field typed constants.

Issue was found by CSmith (test generated with random seed 1665747314).

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
