### PR TITLE
[CI] Move to the latest release of the get-release action

### DIFF
--- a/.github/workflows/release-packages.yaml
+++ b/.github/workflows/release-packages.yaml
@@ -63,7 +63,7 @@ jobs:
           echo "deb_package_name=ubuntu-20.04-$deb_package_name" >> $GITHUB_OUTPUT
       - name: Get release info
         id: get_release_info
-        uses: bruceadams/get-release@v1
+        uses: bruceadams/get-release@v1.3.2
       - name: Upload binary packages
         uses: actions/upload-release-asset@v1
         with:
@@ -151,7 +151,7 @@ jobs:
           echo "deb_package_name=ubuntu-18.04-$deb_package_name" >> $GITHUB_OUTPUT
       - name: Get release info
         id: get_release_info
-        uses: bruceadams/get-release@v1
+        uses: bruceadams/get-release@v1.3.2
       - name: Upload binary packages
         uses: actions/upload-release-asset@v1
         with:
@@ -281,7 +281,7 @@ jobs:
           & signtool.exe verify /pa ${{ steps.create_packages.outputs.msi_installer }}
       - name: Get release info
         id: get_release_info
-        uses: bruceadams/get-release@v1
+        uses: bruceadams/get-release@v1.3.2
       - name: Upload binary packages
         uses: actions/upload-release-asset@v1
         with:


### PR DESCRIPTION
The `get-release` action at version 1 has now been deleted, and as a result our [latest release](https://github.com/diffblue/cbmc/actions/runs/3337143291/jobs/5523116995) package building errors out with "unable to find version 1".

This should fix the problem.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
