### PR TITLE
Fix printing of SMT data structures in failed unit tests

### DIFF
--- a/regression/catch-framework/irep-printing/smt.desc
+++ b/regression/catch-framework/irep-printing/smt.desc
@@ -1,0 +1,13 @@
+CORE
+[smt_error_printing]
+
+Bool \=\= \(_ BitVec 8\)
+\(_ bv42 8\) \=\= false
+\(check\-sat\) \=\= \(set\-logic ALL\)
+^EXIT=0$
+^SIGNAL=0$
+--
+\{\?\}
+--
+Test that when unit tests fail on mismatching smt data structures, the ireps are
+pretty-printed and not printed as catch's default of {?}.

--- a/unit/solvers/smt2_incremental/smt_to_smt2_string.cpp
+++ b/unit/solvers/smt2_incremental/smt_to_smt2_string.cpp
@@ -244,3 +244,16 @@ TEST_CASE("SMT exists term to string conversion", "[core][smt2_incremental]")
       "(exists ((i (_ BitVec 8)) (j Bool)) (or (= i i) j))");
   }
 }
+
+// This test is expected to fail so that we can test the error printing of the
+// unit test framework for regressions. It is not included in the [core] or
+// default set of tests, so that the usual output is not polluted with
+// irrelevant error messages.
+TEST_CASE(
+  "Catch2 printing of SMT data structures for test failures.",
+  "[smt_error_printing]" XFAIL)
+{
+  CHECK(smt_bool_sortt{} == smt_bit_vector_sortt{8});
+  CHECK(smt_bit_vector_constant_termt{42, 8} == smt_bool_literal_termt{false});
+  CHECK(smt_check_sat_commandt{} == smt_set_logic_commandt{smt_logic_allt{}});
+}

--- a/unit/testing-utils/use_catch.h
+++ b/unit/testing-utils/use_catch.h
@@ -42,4 +42,6 @@ Author: Michael Tautschnig
 class irept;
 std::ostream &operator<<(std::ostream &os, const irept &value);
 
+#include <solvers/smt2_incremental/smt_to_smt2_string.h>
+
 #endif // CPROVER_TESTING_UTILS_USE_CATCH_H


### PR DESCRIPTION
The operator needed for the printing is defined in `smt_to_smt2_string.cpp`, but it needs to be forward declared for the catch framework to find and use it, instead of printing SMT data structures as `{?}`.

A regression test of a failing unit test is included in this PR to ensure that this functionality for fault finding of failing unit tests works as intended.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
