### PR TITLE
SMT2: implement flattening for arrays

### DIFF
--- a/regression/cbmc/union/union_initialization.desc
+++ b/regression/cbmc/union/union_initialization.desc
@@ -1,4 +1,4 @@
-CORE broken-smt-backend
+CORE
 union_initialization.c
 
 ^EXIT=10$

--- a/regression/cbmc/union/union_member.desc
+++ b/regression/cbmc/union/union_member.desc
@@ -1,4 +1,4 @@
-CORE broken-smt-backend
+CORE broken-z3-smt-backend
 union_member.c
 
 ^EXIT=10$

--- a/regression/cbmc/union/union_update.desc
+++ b/regression/cbmc/union/union_update.desc
@@ -1,4 +1,4 @@
-CORE broken-smt-backend
+CORE broken-z3-smt-backend
 union_update.c
 
 ^EXIT=10$


### PR DESCRIPTION
This adds flattening for arrays into the SMT2 backend, used, for instance, when lowering unions.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [X] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
