### PR TITLE
Add conversion for concatenation of bit vector smt2 terms

### DIFF
--- a/src/solvers/smt2_incremental/convert_expr_to_smt.cpp
+++ b/src/solvers/smt2_incremental/convert_expr_to_smt.cpp
@@ -353,6 +353,11 @@ static smt_termt convert_expr_to_smt(
   const concatenation_exprt &concatenation,
   const sub_expression_mapt &converted)
 {
+  if(operands_are_of_type<bitvector_typet>(concatenation))
+  {
+    return convert_multiary_operator_to_terms(
+      concatenation, converted, smt_bit_vector_theoryt::concat);
+  }
   UNIMPLEMENTED_FEATURE(
     "Generation of SMT formula for concatenation expression: " +
     concatenation.pretty());

--- a/unit/solvers/smt2_incremental/convert_expr_to_smt.cpp
+++ b/unit/solvers/smt2_incremental/convert_expr_to_smt.cpp
@@ -1252,6 +1252,35 @@ TEST_CASE(
 }
 
 TEST_CASE(
+  "expr to smt conversion for concatenation_exprt expressions",
+  "[core][smt2_incremental]")
+{
+  auto test =
+    expr_to_smt_conversion_test_environmentt::make(test_archt::x86_64);
+  SECTION("Bit vector types")
+  {
+    const exprt bit_vector_1 =
+      symbol_exprt{"my_bit_vector_1", signedbv_typet{8}};
+    const exprt bit_vector_2 =
+      symbol_exprt{"my_bit_vector_2", signedbv_typet{9}};
+    const exprt bit_vector_3 =
+      symbol_exprt{"my_bit_vector_3", signedbv_typet{10}};
+    const concatenation_exprt concatenation{
+      {bit_vector_1, bit_vector_2, bit_vector_3}, signedbv_typet{27}};
+    INFO("Expression being converted: " + concatenation.pretty(2, 0));
+    const smt_identifier_termt smt_id_1{
+      "my_bit_vector_1", smt_bit_vector_sortt{8}};
+    const smt_identifier_termt smt_id_2{
+      "my_bit_vector_2", smt_bit_vector_sortt{9}};
+    const smt_identifier_termt smt_id_3{
+      "my_bit_vector_3", smt_bit_vector_sortt{10}};
+    const smt_termt expected = smt_bit_vector_theoryt::concat(
+      smt_bit_vector_theoryt::concat(smt_id_1, smt_id_2), smt_id_3);
+    CHECK(test.convert(concatenation) == expected);
+  }
+}
+
+TEST_CASE(
   "expr to smt conversion for extract bits expressions",
   "[core][smt2_incremental]")
 {


### PR DESCRIPTION
Add support for smt2 bit vector term concatenation.

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
