### PR TITLE
disallow flexible array members in unions

### DIFF
--- a/regression/ansi-c/union/union_flexible_array_member.c
+++ b/regression/ansi-c/union/union_flexible_array_member.c
@@ -1,0 +1,7 @@
+// C11 6.7.2.1 §18 allows flexible array members in structures,
+// but not unions.
+
+union
+{
+  char flexible_array_member[];
+};

--- a/regression/ansi-c/union/union_flexible_array_member.desc
+++ b/regression/ansi-c/union/union_flexible_array_member.desc
@@ -1,0 +1,7 @@
+CORE gcc-only
+union_flexible_array_member.c
+
+^EXIT=1$
+^SIGNAL=0$
+^CONVERSION ERROR$
+--

--- a/regression/ansi-c/union/union_flexible_array_member.desc
+++ b/regression/ansi-c/union/union_flexible_array_member.desc
@@ -1,0 +1,7 @@
+CORE gcc-only
+union_flexible_array_member.c
+
+^EXIT=(1|64)$
+^SIGNAL=0$
+^CONVERSION ERROR$
+--

--- a/regression/ansi-c/union/union_flexible_array_member_msvc.c
+++ b/regression/ansi-c/union/union_flexible_array_member_msvc.c
@@ -1,0 +1,13 @@
+// Flexible array members in unions are allowed as an extension on Windows.
+
+union U
+{
+  int n;
+  char flexible_array_member[];
+};
+
+int main()
+{
+  union U u;
+  u.n = 42;
+}

--- a/regression/ansi-c/union/union_flexible_array_member_msvc.desc
+++ b/regression/ansi-c/union/union_flexible_array_member_msvc.desc
@@ -1,0 +1,6 @@
+CORE
+union_flexible_array_member_msvc.c
+--i386-win32
+^EXIT=0$
+^SIGNAL=0$
+--

--- a/regression/ansi-c/union/union_flexible_array_member_msvc_address.c
+++ b/regression/ansi-c/union/union_flexible_array_member_msvc_address.c
@@ -1,0 +1,19 @@
+// This test exercises the Microsoft extension that allows flexible array
+// members in unions by actually taking the address of the member and
+// indexing into it, not just assigning to a sibling. This ensures the
+// zero-length encoding produced by the type-checker survives downstream
+// processing.
+
+union U
+{
+  int n;
+  char flexible_array_member[];
+};
+
+int main()
+{
+  union U u;
+  u.n = 42;
+  char *p = &u.flexible_array_member[0];
+  (void)p;
+}

--- a/regression/ansi-c/union/union_flexible_array_member_msvc_address.desc
+++ b/regression/ansi-c/union/union_flexible_array_member_msvc_address.desc
@@ -1,0 +1,7 @@
+CORE
+union_flexible_array_member_msvc_address.c
+--i386-win32
+^EXIT=0$
+^SIGNAL=0$
+--
+^CONVERSION ERROR$

--- a/regression/ansi-c/union/union_flexible_array_member_named.c
+++ b/regression/ansi-c/union/union_flexible_array_member_named.c
@@ -1,0 +1,9 @@
+// C11 6.7.2.1 §18 allows flexible array members in structures, but not in
+// unions. This file exercises the named-union form (the other, anonymous
+// form is covered by union_flexible_array_member.c).
+
+union U
+{
+  int n;
+  char flexible_array_member[];
+};

--- a/regression/ansi-c/union/union_flexible_array_member_named.desc
+++ b/regression/ansi-c/union/union_flexible_array_member_named.desc
@@ -1,0 +1,7 @@
+CORE gcc-only
+union_flexible_array_member_named.c
+
+^EXIT=(1|64)$
+^SIGNAL=0$
+^CONVERSION ERROR$
+--

--- a/regression/ansi-c/union/union_zero_length_array.c
+++ b/regression/ansi-c/union/union_zero_length_array.c
@@ -1,0 +1,18 @@
+// A zero-length array [0] is a gcc extension that has historically been
+// accepted anywhere in a struct or union, independently of the more recent
+// C11 rule on flexible array members ([]). This test guards that
+// distinction: zero-length arrays in unions must remain accepted on all
+// targets (both ISO and Windows), even after the tightening of flexible
+// array members in unions.
+
+union U
+{
+  int n;
+  char zero_length[0];
+};
+
+int main()
+{
+  union U u;
+  u.n = 42;
+}

--- a/regression/ansi-c/union/union_zero_length_array.desc
+++ b/regression/ansi-c/union/union_zero_length_array.desc
@@ -1,0 +1,7 @@
+CORE
+union_zero_length_array.c
+
+^EXIT=0$
+^SIGNAL=0$
+--
+^CONVERSION ERROR$

--- a/src/ansi-c/c_typecheck_type.cpp
+++ b/src/ansi-c/c_typecheck_type.cpp
@@ -1070,33 +1070,45 @@ void c_typecheck_baset::typecheck_compound_body(
     }
   }
 
-  // We allow an incomplete (C99) array as _last_ member!
-  // Zero-length is allowed everywhere.
-
-  if(type.id()==ID_struct ||
-     type.id()==ID_union)
+  // We allow an incomplete array as _last_ member of a struct,
+  // C11 6.7.2.1 §18. These are called "flexible array members".
+  // Zero-length (a gcc extension) is allowed everywhere.
+  // Flexible array members are not allowed in unions in ISO C, but we allow
+  // them as an extension on Windows.
+  if(type.id() == ID_struct || type.id() == ID_union)
   {
-    for(struct_union_typet::componentst::iterator
-        it=components.begin();
-        it!=components.end();
+    for(struct_union_typet::componentst::iterator it = components.begin();
+        it != components.end();
         it++)
     {
-      typet &c_type=it->type();
+      typet &component_type = it->type();
 
-      if(c_type.id()==ID_array &&
-         to_array_type(c_type).is_incomplete())
+      if(
+        component_type.id() != ID_array ||
+        !to_array_type(component_type).is_incomplete())
+      {
+        continue;
+      }
+
+      if(type.id() == ID_struct)
       {
         // needs to be last member
-        if(type.id()==ID_struct && it!=--components.end())
+        if(it != --components.end())
         {
           throw errort().with_location(it->source_location())
             << "flexible struct member must be last member";
         }
-
-        // make it zero-length
-        to_array_type(c_type).size() = from_integer(0, c_index_type());
-        c_type.set(ID_C_flexible_array_member, true);
       }
+      else if(config.ansi_c.os != configt::ansi_ct::ost::OS_WIN)
+      {
+        throw errort().with_location(it->source_location())
+          << "flexible array members in a union are a Microsoft "
+             "extension, and not permitted in ISO C";
+      }
+
+      // make it zero-length
+      to_array_type(component_type).size() = from_integer(0, c_index_type());
+      component_type.set(ID_C_flexible_array_member, true);
     }
   }
 


### PR DESCRIPTION
This change yields an error if a flexible array member is used in a union. C11 allows them in structs, but not unions.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [X] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
