### PR TITLE
performance improvement for large bitvectors

### DIFF
--- a/regression/cbmc/bounds_check1/test.desc
+++ b/regression/cbmc/bounds_check1/test.desc
@@ -1,4 +1,4 @@
-CORE broken-smt-backend
+CORE broken-z3-smt-backend
 main.c
 --bounds-check --pointer-check
 ^EXIT=10$

--- a/regression/cbmc/union/union_large_array.c
+++ b/regression/cbmc/union/union_large_array.c
@@ -1,0 +1,15 @@
+#define LARGE 100000
+
+// This is to test the efficiency of unions that contain a large array.
+union U
+{
+  char large_array[LARGE];
+  int something_else;
+};
+
+int main()
+{
+  union U u;
+  u.something_else = 1234;
+  __CPROVER_assert(0, "should fail");
+}

--- a/regression/cbmc/union/union_large_array.desc
+++ b/regression/cbmc/union/union_large_array.desc
@@ -1,4 +1,4 @@
-CORE broken-smt-backend
+CORE broken-z3-smt-backend
 union_large_array.c
 
 ^EXIT=10$

--- a/regression/cbmc/union/union_large_array.desc
+++ b/regression/cbmc/union/union_large_array.desc
@@ -1,0 +1,11 @@
+CORE broken-smt-backend
+union_large_array.c
+
+^EXIT=10$
+^SIGNAL=0$
+^\[main\.assertion\.1\] line \d+ should fail: FAILURE$
+^\*\* 1 of 1 failed
+^VERIFICATION FAILED$
+--
+^warning: ignoring
+--

--- a/src/solvers/flattening/boolbv_get.cpp
+++ b/src/solvers/flattening/boolbv_get.cpp
@@ -199,8 +199,8 @@ exprt boolbvt::bv_get_rec(const exprt &expr, const bvt &bv, std::size_t offset)
   const std::size_t width = boolbv_width(type);
   PRECONDITION(bv.size() >= offset + width);
 
-  // most significant bit first
   std::string value;
+  value.reserve(width);
 
   for(std::size_t bit_nr=offset; bit_nr<offset+width; bit_nr++)
   {
@@ -214,8 +214,12 @@ exprt boolbvt::bv_get_rec(const exprt &expr, const bvt &bv, std::size_t offset)
     }
     // clang-format on
 
-    value=ch+value;
+    value += ch;
   }
+
+  // The above collects bits starting with the least significant bit,
+  // but we need the most significant bit first.
+  std::reverse(value.begin(), value.end());
 
   switch(bvtype)
   {


### PR DESCRIPTION
This commit improves the complexity of `boolbvt::get(...)` from quadratic to
linear.  The difference is noticeable when using very large bitvectors, e.g.,
for encoding unions with large array members.
    
E.g., the time taken for regression/cbmc/union/union_large_array.c when using
--cprover-smt2 improves from 12s to 0.2s.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [X] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [X] My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
