### PR TITLE
Limit dereferencing of `__CPROVER_bitvector` to objects with size multiple of 8

### DIFF
--- a/regression/ansi-c/Issue_7104_Bv_Size/deref.c
+++ b/regression/ansi-c/Issue_7104_Bv_Size/deref.c
@@ -1,0 +1,18 @@
+struct Foo1
+{
+  __CPROVER_bitvector[1] m_array[2];
+};
+struct Foo8
+{
+  __CPROVER_bitvector[8] m_array[2];
+};
+
+int main(void)
+{
+  struct Foo1 f1;
+  struct Foo8 f8;
+
+  __CPROVER_assert(f1.m_array[1] == *(f1.m_array + 1), "");
+  __CPROVER_assert(f8.m_array[1] == *(f8.m_array + 1), "");
+  return 0;
+}

--- a/regression/ansi-c/Issue_7104_Bv_Size/deref.desc
+++ b/regression/ansi-c/Issue_7104_Bv_Size/deref.desc
@@ -3,7 +3,7 @@ deref.c
 
 ^EXIT=1$
 ^SIGNAL=0$
-only bitvectors of size multiple of 8 can be dereferenced
+only bitvectors of size multiple of 8 bits can be dereferenced
 ^CONVERSION ERROR$
 --
 --

--- a/regression/ansi-c/Issue_7104_Bv_Size/deref.desc
+++ b/regression/ansi-c/Issue_7104_Bv_Size/deref.desc
@@ -1,0 +1,13 @@
+CORE
+deref.c
+
+^EXIT=1$
+^SIGNAL=0$
+only bitvectors of size multiple of 8 can be dereferenced
+^CONVERSION ERROR$
+--
+--
+This is checking that dereferenced __CPROVER_bitvectors always have a size
+that is a multiple of 8.
+
+For more information, please have a look at https://github.com/diffblue/cbmc/issues/7104

--- a/src/ansi-c/c_typecheck_expr.cpp
+++ b/src/ansi-c/c_typecheck_expr.cpp
@@ -1805,6 +1805,17 @@ void c_typecheck_baset::typecheck_expr_dereference(exprt &expr)
       error() << "dereferencing void pointer" << eom;
       throw 0;
     }
+
+    if(is_signed_or_unsigned_bitvector(expr.type()))
+    {
+      auto bv_type_width = to_bitvector_type(expr.type()).get_width();
+      if(bv_type_width % 8 != 0)
+      {
+        throw invalid_source_file_exceptiont{
+          "only bitvectors of size multiple of 8 can be dereferenced",
+          expr.source_location()};
+      }
+    }
   }
   else
   {

--- a/src/ansi-c/c_typecheck_expr.cpp
+++ b/src/ansi-c/c_typecheck_expr.cpp
@@ -1805,17 +1805,6 @@ void c_typecheck_baset::typecheck_expr_dereference(exprt &expr)
       error() << "dereferencing void pointer" << eom;
       throw 0;
     }
-
-    if(is_signed_or_unsigned_bitvector(expr.type()))
-    {
-      auto bv_type_width = to_bitvector_type(expr.type()).get_width();
-      if(bv_type_width % 8 != 0)
-      {
-        throw invalid_source_file_exceptiont{
-          "only bitvectors of size multiple of 8 can be dereferenced",
-          expr.source_location()};
-      }
-    }
   }
   else
   {

--- a/src/solvers/flattening/boolbv_byte_extract.cpp
+++ b/src/solvers/flattening/boolbv_byte_extract.cpp
@@ -40,6 +40,12 @@ bvt boolbvt::convert_byte_extract(const byte_extract_exprt &expr)
   }
 
   const std::size_t width = boolbv_width(expr.type());
+  if(width % 8 != 0)
+  {
+    throw invalid_source_file_exceptiont{
+      "only bitvectors of size multiple of 8 bits can be dereferenced",
+      expr.source_location()};
+  }
 
   // special treatment for bit-fields and big-endian:
   // we need byte granularity

--- a/src/solvers/flattening/boolbv_byte_extract.cpp
+++ b/src/solvers/flattening/boolbv_byte_extract.cpp
@@ -42,9 +42,10 @@ bvt boolbvt::convert_byte_extract(const byte_extract_exprt &expr)
   const std::size_t width = boolbv_width(expr.type());
   if(width % 8 != 0)
   {
-    throw invalid_source_file_exceptiont{
-      "only bitvectors of size multiple of 8 bits can be dereferenced",
-      expr.source_location()};
+    // throw invalid_source_file_exceptiont{
+    //   "only bitvectors of size multiple of 8 bits can be dereferenced",
+    //   expr.source_location()};
+    conversion_failed(expr);
   }
 
   // special treatment for bit-fields and big-endian:


### PR DESCRIPTION
This should be resolving the first issue reported in https://github.com/diffblue/cbmc/issues/7104 by limiting the derefencing/taking of address of bit vector objects whose size is less than 8.

This is for now a draft, as I continue to QA the changes in this PR.

This is a partial solution to the problem described in #7104. There's going to be another PR with the solution to the second issue described there.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
