### PR TITLE
SMT back-end: use_array_theory compatibility with unions

### DIFF
--- a/regression/cbmc/bounds_check1/test.desc
+++ b/regression/cbmc/bounds_check1/test.desc
@@ -1,4 +1,4 @@
-CORE broken-z3-smt-backend
+CORE thorough-smt-backend
 main.c
 --bounds-check --pointer-check
 ^EXIT=10$
@@ -12,3 +12,6 @@ payload\[\(.*\)[kl]2\]: FAILURE
 \[\(.*\)i\]: FAILURE
 dest\[\(.*\)j\]: FAILURE
 payload\[\(.*\)[kl]\]: FAILURE
+--
+Appears to take Z3 more than 10 minutes to solve, and approximately 500 seconds
+when using the in-tree SMT solver.

--- a/regression/cbmc/union/union_member.desc
+++ b/regression/cbmc/union/union_member.desc
@@ -1,4 +1,4 @@
-CORE broken-z3-smt-backend
+CORE
 union_member.c
 
 ^EXIT=10$
@@ -8,6 +8,3 @@ union_member.c
 ^VERIFICATION FAILED$
 --
 ^warning: ignoring
---
-This fails when using the SMT backend with Z3 with the error message
-"select requires 1 arguments, but was provided with 2 arguments"

--- a/regression/cbmc/union/union_update.desc
+++ b/regression/cbmc/union/union_update.desc
@@ -1,4 +1,4 @@
-CORE broken-z3-smt-backend
+CORE
 union_update.c
 
 ^EXIT=10$
@@ -8,6 +8,3 @@ union_update.c
 ^VERIFICATION FAILED$
 --
 ^warning: ignoring
---
-This fails when using the SMT backend with Z3 with the error message
-"store expects the first argument sort to be an array".


### PR DESCRIPTION
Unions are always flattened, implying that array-typed members in unions are flattened. use_array_theory needs to account for this.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
