### PR TITLE
SMT back-end: support floatbv to raw bitvector cast

### DIFF
--- a/regression/cbmc/Float-no-simp2/test.desc
+++ b/regression/cbmc/Float-no-simp2/test.desc
@@ -1,4 +1,4 @@
-CORE broken-smt-backend
+CORE broken-cprover-smt-backend
 main.c
 --floatbv --no-simplify
 ^EXIT=0$

--- a/regression/cbmc/Float-no-simp3/test.desc
+++ b/regression/cbmc/Float-no-simp3/test.desc
@@ -1,4 +1,4 @@
-CORE broken-smt-backend
+CORE broken-cprover-smt-backend
 main.c
 --floatbv --no-simplify
 ^EXIT=0$

--- a/regression/cbmc/Float-no-simp5/test.desc
+++ b/regression/cbmc/Float-no-simp5/test.desc
@@ -1,4 +1,4 @@
-CORE broken-smt-backend
+CORE broken-cprover-smt-backend
 main.c
 --floatbv --no-simplify
 ^EXIT=0$

--- a/regression/cbmc/Float-zero-sum1/test.desc
+++ b/regression/cbmc/Float-zero-sum1/test.desc
@@ -1,4 +1,4 @@
-CORE broken-smt-backend
+CORE broken-cprover-smt-backend
 main.c
 --floatbv --no-simplify
 ^EXIT=0$

--- a/regression/cbmc/Float12/test.desc
+++ b/regression/cbmc/Float12/test.desc
@@ -1,4 +1,4 @@
-CORE broken-smt-backend
+CORE broken-cprover-smt-backend
 main.c
 
 ^EXIT=0$

--- a/regression/cbmc/Float22/test.desc
+++ b/regression/cbmc/Float22/test.desc
@@ -1,4 +1,4 @@
-CORE broken-smt-backend
+CORE broken-cprover-smt-backend
 main.c
 --floatbv
 ^EXIT=0$
@@ -6,3 +6,6 @@ main.c
 ^VERIFICATION SUCCESSFUL$
 --
 ^warning: ignoring
+--
+Fixing this test for the CPROVER SMT2 solver (or any other SMT2 solver
+supporting FPA) requires addressing the TODO "bit-wise floatbv to bv".

--- a/regression/cbmc/Float3/test.desc
+++ b/regression/cbmc/Float3/test.desc
@@ -1,4 +1,4 @@
-CORE broken-z3-smt-backend
+CORE
 main.c
 --floatbv
 ^EXIT=0$

--- a/src/solvers/floatbv/float_bv.cpp
+++ b/src/solvers/floatbv/float_bv.cpp
@@ -78,6 +78,23 @@ exprt float_bvt::convert(const exprt &expr) const
   {
     return not_exprt(is_zero(to_typecast_expr(expr).op()));
   }
+  else if(
+    expr.id() == ID_typecast && expr.type().id() == ID_bv &&
+    to_typecast_expr(expr).op().type().id() == ID_floatbv) // float -> raw bv
+  {
+    const typecast_exprt &tc = to_typecast_expr(expr);
+    const bitvector_typet &dest_type = to_bitvector_type(expr.type());
+    const floatbv_typet &src_type = to_floatbv_type(tc.op().type());
+    if(
+      dest_type.get_width() != src_type.get_width() ||
+      dest_type.get_width() == 0)
+    {
+      return nil_exprt{};
+    }
+
+    return extractbits_exprt{
+      to_typecast_expr(expr).op(), dest_type.get_width() - 1, 0, dest_type};
+  }
   else if(expr.id()==ID_floatbv_plus)
   {
     const auto &float_expr = to_ieee_float_op_expr(expr);

--- a/src/solvers/smt2/smt2_conv.cpp
+++ b/src/solvers/smt2/smt2_conv.cpp
@@ -987,6 +987,10 @@ std::string smt2_convt::type2id(const typet &type) const
     ieee_float_spect spec(to_floatbv_type(type));
     return "f"+std::to_string(spec.width())+"_"+std::to_string(spec.f);
   }
+  else if(type.id() == ID_bv)
+  {
+    return "B" + std::to_string(to_bitvector_type(type).get_width());
+  }
   else if(type.id()==ID_unsignedbv)
   {
     return "u"+std::to_string(to_unsignedbv_type(type).get_width());


### PR DESCRIPTION
This adds support for any byte-extract operations out of float-typed components to the SMT2 back-end, unless FPA theory is enabled. That latter case requires addressing the TODO "bit-wise floatbv to bv", the challenges around which are noted in the comment at the place of that TODO.

Fixes: #6266
Fixes: #6348
Fixes: #6369

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
