### PR TITLE
Contracts/DFCC: do not access invalidated references

### DIFF
--- a/src/goto-instrument/contracts/dynamic-frames/dfcc_is_freeable.cpp
+++ b/src/goto-instrument/contracts/dynamic-frames/dfcc_is_freeable.cpp
@@ -55,8 +55,7 @@ void dfcc_is_freeablet::rewrite_calls(
             .set_identifier(library.get_dfcc_fun_name(dfcc_funt::IS_FREEABLE));
           target->call_arguments().push_back(write_set);
         }
-
-        if(fun_name == CPROVER_PREFIX "was_freed")
+        else if(fun_name == CPROVER_PREFIX "was_freed")
         {
           // insert call to precondition for vacuity checking
           auto inst = goto_programt::make_function_call(

--- a/src/goto-instrument/contracts/dynamic-frames/dfcc_library.cpp
+++ b/src/goto-instrument/contracts/dynamic-frames/dfcc_library.cpp
@@ -454,8 +454,7 @@ void dfcc_libraryt::fix_malloc_free_calls()
 
           if(fun_name == (CONTRACTS_PREFIX "malloc"))
             to_symbol_expr(ins->call_function()).set_identifier("malloc");
-
-          if(fun_name == (CONTRACTS_PREFIX "free"))
+          else if(fun_name == (CONTRACTS_PREFIX "free"))
             to_symbol_expr(ins->call_function()).set_identifier("free");
         }
       }


### PR DESCRIPTION
In a sequence of `if` statements an earlier condition evaluated to true, the body updated the irep a reference into which was held, making the reference invalid when evaluating the next condition. This resulted in intermittent segmentation faults.

Use `if`/`else if` instead to avoid evaluating later conditions.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
