### PR TITLE
CONTRACTS: Fix language mode on wrapper symbol

### DIFF
--- a/src/goto-instrument/contracts/dynamic-frames/dfcc_utils.cpp
+++ b/src/goto-instrument/contracts/dynamic-frames/dfcc_utils.cpp
@@ -100,6 +100,7 @@ const symbolt &dfcc_utilst::create_symbol(
     source_location,
     mode,
     goto_model.symbol_table);
+  symbol.module = module;
   symbol.is_lvalue = true;
   symbol.is_state_var = true;
   symbol.is_thread_local = true;
@@ -125,6 +126,7 @@ const symbolt &dfcc_utilst::create_static_symbol(
     source_location,
     mode,
     goto_model.symbol_table);
+  symbol.module = module;
   symbol.is_static_lifetime = true;
   symbol.value = initial_value;
   symbol.value.set(ID_C_no_nondet_initialization, no_nondet_initialization);

--- a/src/goto-instrument/contracts/dynamic-frames/dfcc_wrapper_program.cpp
+++ b/src/goto-instrument/contracts/dynamic-frames/dfcc_wrapper_program.cpp
@@ -228,8 +228,8 @@ dfcc_wrapper_programt::dfcc_wrapper_programt(
                            id2string(wrapper_symbol.name),
                            "__contract_return_value",
                            wrapper_symbol.location,
-                           wrapper_symbol.module,
                            wrapper_symbol.mode,
+                           wrapper_symbol.module,
                            false)
                          .symbol_expr();
 


### PR DESCRIPTION
Language mode was swapped with module name, would result in invariant violation in CBMC.

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.
