### PR TITLE
Solver stats reporting: fix expression mapping for guards

### DIFF
--- a/regression/solver-hardness/guards/main.c
+++ b/regression/solver-hardness/guards/main.c
@@ -1,0 +1,15 @@
+int main()
+{
+  int a;
+  if(a > 0)
+  {
+    if(a > 10)
+    {
+      (void)a;
+      goto out;
+    }
+  }
+  __CPROVER_assert(a > 0, "should fail");
+out:
+  return 0;
+}

--- a/regression/solver-hardness/guards/test.desc
+++ b/regression/solver-hardness/guards/test.desc
@@ -1,0 +1,13 @@
+CORE
+main.c
+--write-solver-stats-to 'solver_hardness.json'
+^EXIT=10$
+^SIGNAL=0$
+^\[main.assertion.1\] line 12 should fail: FAILURE$
+^VERIFICATION FAILED$
+\{"GOTO":"GOTO \d+","GOTO_ID":\d+,"SAT_hardness":\{"ClauseSet":\[\d+.*\],"Clauses":[1-9]\d*,"Literals":[1-9]\d*,"Variables":[1-9]\d*},"SSA_expr":"goto_symex::\\\\guard#1 ∧ goto_symex::\\\\guard#2","Source":\{"file":"main.c","function":"main","line":"\d+","workingDirectory":".*"\}\}
+--
+^warning: ignoring
+\{"GOTO":"GOTO \d+","GOTO_ID":\d+,"SAT_hardness":\{"ClauseSet":\[\d+.*\],"Clauses":[1-9]\d*,"Literals":[1-9]\d*,"Variables":[1-9]\d*},"SSA_expr":"true","Source":\{"file":"main.c","function":"main","line":"\d+","workingDirectory":".*"\}\}
+--
+"true" must not yield any clauses.

--- a/src/goto-symex/symex_target_equation.cpp
+++ b/src/goto-symex/symex_target_equation.cpp
@@ -416,7 +416,9 @@ void symex_target_equationt::convert_guards(
 
       step.guard_handle = decision_procedure.handle(step.guard);
       with_solver_hardness(
-        decision_procedure, hardness_register_ssa(step_index, step));
+        decision_procedure, [step_index, &step](solver_hardnesst &hardness) {
+          hardness.register_ssa(step_index, step.guard, step.source.pc);
+        });
     }
     ++step_index;
   }


### PR DESCRIPTION
When converting guards we convert `SSA_stept::guard`, and not `SSA_stept::cond_expr`. This needs to be accounted for in solver stats reporting as we would otherwise misleadingly report that expressions like "true" yield a non-empty set of clauses.

Fixes: #6333

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
