### PR TITLE
SMT back-end: Extend trace value evaluation

### DIFF
--- a/regression/cbmc/Empty_struct3/main.c
+++ b/regression/cbmc/Empty_struct3/main.c
@@ -1,0 +1,15 @@
+#include <assert.h>
+
+struct Unit
+{
+};
+
+int main()
+{
+  struct Unit var_0;
+  int x;
+  int y = x;
+  assert(0);
+  assert(y == x);
+  return 0;
+}

--- a/regression/cbmc/Empty_struct3/test.desc
+++ b/regression/cbmc/Empty_struct3/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+--json-ui
+VERIFICATION FAILED
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring

--- a/regression/cbmc/trace-values/trace-values.desc
+++ b/regression/cbmc/trace-values/trace-values.desc
@@ -1,4 +1,4 @@
-CORE broken-smt-backend
+CORE
 trace-values.c
 --trace
 ^EXIT=10$

--- a/regression/cbmc/trace_options_json_extended/extended.desc
+++ b/regression/cbmc/trace_options_json_extended/extended.desc
@@ -1,4 +1,4 @@
-CORE broken-smt-backend
+CORE
 test.c
 --trace --json-ui --trace-json-extended
 ^EXIT=10$

--- a/regression/cbmc/trace_options_json_extended/non-extended.desc
+++ b/regression/cbmc/trace_options_json_extended/non-extended.desc
@@ -1,4 +1,4 @@
-CORE broken-smt-backend
+CORE
 test.c
 --trace --json-ui
 ^EXIT=10$

--- a/regression/validate-trace-xml-schema/check.py
+++ b/regression/validate-trace-xml-schema/check.py
@@ -56,6 +56,7 @@ ExcludedTests = list(map(lambda s: os.path.join(test_base_dir, s[0], s[1]), [
     # this uses json-ui (fails for a different reason actually, but should also
     #   fail because of command line incompatibility)
     ['json1', 'test.desc'],
+    ['Empty_struct3', 'test.desc'],
     # uses show-goto-functions
     ['reachability-slice', 'test.desc'],
     ['reachability-slice', 'test2.desc'],

--- a/src/solvers/smt2/smt2_conv.cpp
+++ b/src/solvers/smt2/smt2_conv.cpp
@@ -297,14 +297,6 @@ exprt smt2_convt::get(const exprt &expr) const
     if(it!=identifier_map.end())
       return it->second.value;
   }
-  else if(expr.id()==ID_member)
-  {
-    const member_exprt &member_expr=to_member_expr(expr);
-    exprt tmp=get(member_expr.struct_op());
-    if(tmp.is_nil())
-      return nil_exprt();
-    return member_exprt(tmp, member_expr.get_component_name(), expr.type());
-  }
   else if(expr.id() == ID_literal)
   {
     auto l = to_literal_expr(expr).get_literal();
@@ -321,16 +313,23 @@ exprt smt2_convt::get(const exprt &expr) const
     else if(op.is_false())
       return true_exprt();
   }
-  else if(expr.is_constant())
-    return expr;
-  else if(const auto &array = expr_try_dynamic_cast<array_exprt>(expr))
+  else if(
+    expr.is_constant() || expr.id() == ID_empty_union ||
+    (!expr.has_operands() && (expr.id() == ID_struct || expr.id() == ID_array)))
   {
-    exprt array_copy = *array;
-    for(auto &element : array_copy.operands())
+    return expr;
+  }
+  else if(expr.has_operands())
+  {
+    exprt copy = expr;
+    for(auto &op : copy.operands())
     {
-      element = get(element);
+      exprt eval_op = get(op);
+      if(eval_op.is_nil())
+        return nil_exprt{};
+      op = std::move(eval_op);
     }
-    return array_copy;
+    return copy;
   }
 
   return nil_exprt();
@@ -4780,7 +4779,9 @@ void smt2_convt::set_to(const exprt &expr, bool value)
       const irep_idt &identifier=
         to_symbol_expr(equal_expr.lhs()).get_identifier();
 
-      if(identifier_map.find(identifier)==identifier_map.end())
+      if(
+        identifier_map.find(identifier) == identifier_map.end() &&
+        equal_expr.lhs() != equal_expr.rhs())
       {
         identifiert &id=identifier_map[identifier];
         CHECK_RETURN(id.type.is_nil());


### PR DESCRIPTION
We record the values of expressions by adding `expr == expr` as constraints in order to be able to fetch and display them in the GOTO trace (for declaration; we presently also introduce new symbols in other cases). Constructing a trace then requires the ability to evaluate all kinds of expressions to obtain the value for those expressions.

Fixes: #7308

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
