### PR TITLE
Add support for `__CPROVER_DYNAMIC_OBJECT` to incremental SMT decision procedure

### DIFF
--- a/regression/cbmc-incr-smt2/dynamic-memory/assert_dynamic.c
+++ b/regression/cbmc-incr-smt2/dynamic-memory/assert_dynamic.c
@@ -1,0 +1,17 @@
+#include <assert.h>
+#include <stdbool.h>
+#include <stdlib.h>
+
+bool nondet_bool();
+
+void main()
+{
+  char local;
+  void *pointer = &local;
+  const bool make_dynamic = nondet_bool();
+  if(make_dynamic)
+  {
+    pointer = malloc(1);
+  }
+  assert(__CPROVER_DYNAMIC_OBJECT(pointer));
+}

--- a/regression/cbmc-incr-smt2/dynamic-memory/assert_dynamic.desc
+++ b/regression/cbmc-incr-smt2/dynamic-memory/assert_dynamic.desc
@@ -1,0 +1,11 @@
+CORE
+assert_dynamic.c
+--trace
+Passing problem to incremental SMT2 solving
+line 16 assertion __CPROVER_DYNAMIC_OBJECT\(pointer\)\: FAILURE
+make_dynamic\=FALSE
+^EXIT=10$
+^SIGNAL=0$
+--
+make_dynamic\=TRUE
+--

--- a/regression/cbmc-incr-smt2/dynamic-memory/assert_not_dynamic.c
+++ b/regression/cbmc-incr-smt2/dynamic-memory/assert_not_dynamic.c
@@ -1,0 +1,17 @@
+#include <assert.h>
+#include <stdbool.h>
+#include <stdlib.h>
+
+bool nondet_bool();
+
+void main()
+{
+  char local;
+  void *pointer = &local;
+  const bool make_dynamic = nondet_bool();
+  if(make_dynamic)
+  {
+    pointer = malloc(1);
+  }
+  assert(!__CPROVER_DYNAMIC_OBJECT(pointer));
+}

--- a/regression/cbmc-incr-smt2/dynamic-memory/assert_not_dynamic.desc
+++ b/regression/cbmc-incr-smt2/dynamic-memory/assert_not_dynamic.desc
@@ -1,0 +1,11 @@
+CORE
+assert_not_dynamic.c
+--trace
+Passing problem to incremental SMT2 solving
+line 16 assertion \!__CPROVER_DYNAMIC_OBJECT\(pointer\)\: FAILURE
+make_dynamic\=TRUE
+^EXIT=10$
+^SIGNAL=0$
+--
+make_dynamic\=FALSE
+--

--- a/regression/cbmc-incr-smt2/dynamic-memory/valid.c
+++ b/regression/cbmc-incr-smt2/dynamic-memory/valid.c
@@ -1,0 +1,17 @@
+#include <assert.h>
+#include <stdbool.h>
+#include <stdlib.h>
+
+bool nondet_bool();
+
+void main()
+{
+  char local;
+  void *pointer = &local;
+  const bool make_dynamic = nondet_bool();
+  if(make_dynamic)
+  {
+    pointer = malloc(1);
+  }
+  assert(make_dynamic || !__CPROVER_DYNAMIC_OBJECT(pointer));
+}

--- a/regression/cbmc-incr-smt2/dynamic-memory/valid.desc
+++ b/regression/cbmc-incr-smt2/dynamic-memory/valid.desc
@@ -1,0 +1,10 @@
+CORE
+valid.c
+--trace
+Passing problem to incremental SMT2 solving
+line 16 assertion make_dynamic \|\| \!__CPROVER_DYNAMIC_OBJECT\(pointer\)\: SUCCESS
+VERIFICATION SUCCESSFUL
+^EXIT=0$
+^SIGNAL=0$
+--
+--

--- a/src/solvers/Makefile
+++ b/src/solvers/Makefile
@@ -204,6 +204,7 @@ SRC = $(BOOLEFORCE_SRC) \
       smt2_incremental/convert_expr_to_smt.cpp \
       smt2_incremental/object_tracking.cpp \
       smt2_incremental/type_size_mapping.cpp \
+      smt2_incremental/smt_is_dynamic_object.cpp \
       smt2_incremental/smt_object_size.cpp \
       smt2_incremental/smt_response_validation.cpp \
       smt2_incremental/smt_solver_process.cpp \

--- a/src/solvers/smt2_incremental/convert_expr_to_smt.cpp
+++ b/src/solvers/smt2_incremental/convert_expr_to_smt.cpp
@@ -1042,11 +1042,18 @@ static smt_termt convert_expr_to_smt(
 
 static smt_termt convert_expr_to_smt(
   const is_dynamic_object_exprt &is_dynamic_object,
-  const sub_expression_mapt &converted)
+  const sub_expression_mapt &converted,
+  const smt_is_dynamic_objectt::make_applicationt &apply_is_dynamic_object)
 {
-  UNIMPLEMENTED_FEATURE(
-    "Generation of SMT formula for is dynamic object expression: " +
-    is_dynamic_object.pretty());
+  const smt_termt &pointer = converted.at(is_dynamic_object.address());
+  const auto pointer_sort = pointer.get_sort().cast<smt_bit_vector_sortt>();
+  INVARIANT(
+    pointer_sort, "Pointers should be encoded as bit vector sorted terms.");
+  const std::size_t pointer_width = pointer_sort->bit_width();
+  return apply_is_dynamic_object(
+    std::vector<smt_termt>{smt_bit_vector_theoryt::extract(
+      pointer_width - 1,
+      pointer_width - config.bv_encoding.object_bits)(pointer)});
 }
 
 static smt_termt convert_expr_to_smt(
@@ -1458,7 +1465,8 @@ static smt_termt dispatch_expr_to_smt_conversion(
   const sub_expression_mapt &converted,
   const smt_object_mapt &object_map,
   const type_size_mapt &pointer_sizes,
-  const smt_object_sizet::make_applicationt &call_object_size)
+  const smt_object_sizet::make_applicationt &call_object_size,
+  const smt_is_dynamic_objectt::make_applicationt &apply_is_dynamic_object)
 {
   if(const auto symbol = expr_try_dynamic_cast<symbol_exprt>(expr))
   {
@@ -1660,7 +1668,8 @@ static smt_termt dispatch_expr_to_smt_conversion(
     const auto is_dynamic_object =
       expr_try_dynamic_cast<is_dynamic_object_exprt>(expr))
   {
-    return convert_expr_to_smt(*is_dynamic_object, converted);
+    return convert_expr_to_smt(
+      *is_dynamic_object, converted, apply_is_dynamic_object);
   }
   if(
     const auto is_invalid_pointer =
@@ -1837,7 +1846,8 @@ smt_termt convert_expr_to_smt(
   const exprt &expr,
   const smt_object_mapt &object_map,
   const type_size_mapt &pointer_sizes,
-  const smt_object_sizet::make_applicationt &object_size)
+  const smt_object_sizet::make_applicationt &object_size,
+  const smt_is_dynamic_objectt::make_applicationt &is_dynamic_object)
 {
 #ifndef CPROVER_INVARIANT_DO_NOT_CHECK
   static bool in_conversion = false;
@@ -1856,7 +1866,12 @@ smt_termt convert_expr_to_smt(
     if(find_result != sub_expression_map.cend())
       return;
     smt_termt term = dispatch_expr_to_smt_conversion(
-      expr, sub_expression_map, object_map, pointer_sizes, object_size);
+      expr,
+      sub_expression_map,
+      object_map,
+      pointer_sizes,
+      object_size,
+      is_dynamic_object);
     sub_expression_map.emplace_hint(find_result, expr, std::move(term));
   });
   return std::move(sub_expression_map.at(lowered_expr));

--- a/src/solvers/smt2_incremental/convert_expr_to_smt.h
+++ b/src/solvers/smt2_incremental/convert_expr_to_smt.h
@@ -6,6 +6,7 @@
 #include <solvers/smt2_incremental/ast/smt_sorts.h>
 #include <solvers/smt2_incremental/ast/smt_terms.h>
 #include <solvers/smt2_incremental/object_tracking.h>
+#include <solvers/smt2_incremental/smt_is_dynamic_object.h>
 #include <solvers/smt2_incremental/smt_object_size.h>
 #include <solvers/smt2_incremental/type_size_mapping.h>
 
@@ -27,6 +28,7 @@ smt_termt convert_expr_to_smt(
   const exprt &expression,
   const smt_object_mapt &object_map,
   const type_size_mapt &pointer_sizes,
-  const smt_object_sizet::make_applicationt &object_size);
+  const smt_object_sizet::make_applicationt &object_size,
+  const smt_is_dynamic_objectt::make_applicationt &is_dynamic_object);
 
 #endif // CPROVER_SOLVERS_SMT2_INCREMENTAL_CONVERT_EXPR_TO_SMT_H

--- a/src/solvers/smt2_incremental/object_tracking.h
+++ b/src/solvers/smt2_incremental/object_tracking.h
@@ -46,6 +46,8 @@ struct decision_procedure_objectt
   std::size_t unique_id;
   /// Expression which evaluates to the size of the object in bytes.
   exprt size;
+  /// This is true for heap allocated objects and false for stack allocated.
+  bool is_dynamic;
 };
 
 /// The model of addresses we use consists of a unique object identifier and an

--- a/src/solvers/smt2_incremental/object_tracking.h
+++ b/src/solvers/smt2_incremental/object_tracking.h
@@ -43,11 +43,11 @@ struct decision_procedure_objectt
   /// to deferencing a pointer to this object with a zero offset.
   exprt base_expression;
   /// Number which uniquely identifies this particular object.
-  std::size_t unique_id;
+  std::size_t unique_id = 0;
   /// Expression which evaluates to the size of the object in bytes.
   exprt size;
   /// This is true for heap allocated objects and false for stack allocated.
-  bool is_dynamic;
+  bool is_dynamic = false;
 };
 
 /// The model of addresses we use consists of a unique object identifier and an

--- a/src/solvers/smt2_incremental/smt2_incremental_decision_procedure.cpp
+++ b/src/solvers/smt2_incremental/smt2_incremental_decision_procedure.cpp
@@ -255,6 +255,7 @@ smt2_incremental_decision_proceduret::smt2_incremental_decision_proceduret(
     smt_set_option_commandt{smt_option_produce_modelst{true}});
   solver_process->send(smt_set_logic_commandt{smt_logic_allt{}});
   solver_process->send(object_size_function.declaration);
+  solver_process->send(is_dynamic_object_function.declaration);
 }
 
 void smt2_incremental_decision_proceduret::ensure_handle_for_expr_defined(
@@ -561,6 +562,8 @@ void smt2_incremental_decision_proceduret::define_object_sizes()
     define_dependent_functions(object.size);
     solver_process->send(object_size_function.make_definition(
       object.unique_id, convert_expr_to_smt(object.size)));
+    solver_process->send(is_dynamic_object_function.make_definition(
+      object.unique_id, object.is_dynamic));
   }
 }
 

--- a/src/solvers/smt2_incremental/smt2_incremental_decision_procedure.cpp
+++ b/src/solvers/smt2_incremental/smt2_incremental_decision_procedure.cpp
@@ -549,16 +549,16 @@ static decision_proceduret::resultt lookup_decision_procedure_result(
   UNREACHABLE;
 }
 
-void smt2_incremental_decision_proceduret::define_object_sizes()
+void smt2_incremental_decision_proceduret::define_object_properties()
 {
-  object_size_defined.resize(object_map.size());
+  object_properties_defined.resize(object_map.size());
   for(const auto &key_value : object_map)
   {
     const decision_procedure_objectt &object = key_value.second;
-    if(object_size_defined[object.unique_id])
+    if(object_properties_defined[object.unique_id])
       continue;
     else
-      object_size_defined[object.unique_id] = true;
+      object_properties_defined[object.unique_id] = true;
     define_dependent_functions(object.size);
     solver_process->send(object_size_function.make_definition(
       object.unique_id, convert_expr_to_smt(object.size)));
@@ -570,7 +570,7 @@ void smt2_incremental_decision_proceduret::define_object_sizes()
 decision_proceduret::resultt smt2_incremental_decision_proceduret::dec_solve()
 {
   ++number_of_solver_calls;
-  define_object_sizes();
+  define_object_properties();
   const smt_responset result = get_response_to_command(
     *solver_process, smt_check_sat_commandt{}, identifier_table);
   if(const auto check_sat_response = result.cast<smt_check_sat_responset>())

--- a/src/solvers/smt2_incremental/smt2_incremental_decision_procedure.cpp
+++ b/src/solvers/smt2_incremental/smt2_incremental_decision_procedure.cpp
@@ -322,12 +322,14 @@ smt2_incremental_decision_proceduret::convert_expr_to_smt(const exprt &expr)
     ns,
     pointer_sizes_map,
     object_map,
-    object_size_function.make_application);
+    object_size_function.make_application,
+    is_dynamic_object_function.make_application);
   return ::convert_expr_to_smt(
     substituted,
     object_map,
     pointer_sizes_map,
-    object_size_function.make_application);
+    object_size_function.make_application,
+    is_dynamic_object_function.make_application);
 }
 
 exprt smt2_incremental_decision_proceduret::handle(const exprt &expr)
@@ -377,7 +379,8 @@ array_exprt smt2_incremental_decision_proceduret::get_expr(
           from_integer(index, index_type),
           object_map,
           pointer_sizes_map,
-          object_size_function.make_application)),
+          object_size_function.make_application,
+          is_dynamic_object_function.make_application)),
       type.element_type()));
   }
   return array_exprt{elements, type};
@@ -443,7 +446,8 @@ exprt smt2_incremental_decision_proceduret::get(const exprt &expr) const
         expr,
         object_map,
         pointer_sizes_map,
-        object_size_function.make_application);
+        object_size_function.make_application,
+        is_dynamic_object_function.make_application);
     }
     else
     {

--- a/src/solvers/smt2_incremental/smt2_incremental_decision_procedure.h
+++ b/src/solvers/smt2_incremental/smt2_incremental_decision_procedure.h
@@ -11,6 +11,7 @@
 
 #include <solvers/smt2_incremental/ast/smt_terms.h>
 #include <solvers/smt2_incremental/object_tracking.h>
+#include <solvers/smt2_incremental/smt_is_dynamic_object.h>
 #include <solvers/smt2_incremental/smt_object_size.h>
 #include <solvers/smt2_incremental/type_size_mapping.h>
 #include <solvers/stack_decision_procedure.h>
@@ -159,6 +160,11 @@ protected:
   /// stateful because it depends on the configuration of the number of object
   /// bits and how many bits wide the size type is configured to be.
   smt_object_sizet object_size_function;
+  /// Implementation of the SMT formula for the dynamic object status lookup
+  /// function. This is stateful because it depends on the configuration of the
+  /// number of object bits and how many bits wide the size type is configured
+  /// to be.
+  smt_is_dynamic_objectt is_dynamic_object_function;
   /// Precalculated type sizes used for pointer arithmetic.
   type_size_mapt pointer_sizes_map;
 };

--- a/src/solvers/smt2_incremental/smt2_incremental_decision_procedure.h
+++ b/src/solvers/smt2_incremental/smt2_incremental_decision_procedure.h
@@ -93,8 +93,9 @@ protected:
   /// \note This function is non-const because it mutates the object_map.
   smt_termt convert_expr_to_smt(const exprt &expr);
   void define_index_identifiers(const exprt &expr);
-  /// Sends the solver the definitions of the object sizes.
-  void define_object_sizes();
+  /// Sends the solver the definitions of the object sizes and dynamic memory
+  /// statuses.
+  void define_object_properties();
 
   /// Namespace for looking up the expressions which symbol_exprts relate to.
   /// This includes the symbols defined outside of the decision procedure but
@@ -150,12 +151,12 @@ protected:
   /// This map is used to track object related state. See documentation in
   /// object_tracking.h for details.
   smt_object_mapt object_map;
-  /// The size of each object is separately defined as a pre-solving step.
-  /// `object_size_defined[object ID]` is set to true for objects where the size
-  /// has been defined. This is used to avoid defining the size of the same
-  /// object multiple times in the case where multiple rounds of solving are
-  /// carried out.
-  std::vector<bool> object_size_defined;
+  /// The size of each object and the dynamic object stus is separately defined
+  /// as a pre-solving step. `object_properties_defined[object ID]` is set to
+  /// true for objects where the size has been defined. This is used to avoid
+  /// defining the size of the same object multiple times in the case where
+  /// multiple rounds of solving are carried out.
+  std::vector<bool> object_properties_defined;
   /// Implementation of the SMT formula for the object size function. This is
   /// stateful because it depends on the configuration of the number of object
   /// bits and how many bits wide the size type is configured to be.

--- a/src/solvers/smt2_incremental/smt_is_dynamic_object.cpp
+++ b/src/solvers/smt2_incremental/smt_is_dynamic_object.cpp
@@ -1,0 +1,36 @@
+// Author: Diffblue Ltd.
+
+#include "smt_is_dynamic_object.h"
+
+#include <util/c_types.h>
+#include <util/config.h>
+
+#include <solvers/smt2_incremental/theories/smt_core_theory.h>
+
+static smt_declare_function_commandt
+make_is_dynamic_object_function_declaration()
+{
+  return smt_declare_function_commandt{
+    smt_identifier_termt{"is_dynamic_object", smt_bool_sortt{}},
+    {smt_bit_vector_sortt{config.bv_encoding.object_bits}}};
+}
+
+smt_is_dynamic_objectt::smt_is_dynamic_objectt()
+  : declaration{make_is_dynamic_object_function_declaration()},
+    make_application{smt_command_functiont{declaration}}
+{
+}
+
+smt_commandt smt_is_dynamic_objectt::make_definition(
+  std::size_t unique_id,
+  bool is_dynamic_object) const
+{
+  const auto id_sort =
+    declaration.parameter_sorts().at(0).get().cast<smt_bit_vector_sortt>();
+  INVARIANT(id_sort, "Object identifiers are expected to have bit vector sort");
+  const auto bit_vector_of_id =
+    smt_bit_vector_constant_termt{unique_id, *id_sort};
+  return smt_assert_commandt{smt_core_theoryt::equal(
+    make_application(std::vector<smt_termt>{bit_vector_of_id}),
+    smt_bool_literal_termt{is_dynamic_object})};
+}

--- a/src/solvers/smt2_incremental/smt_is_dynamic_object.h
+++ b/src/solvers/smt2_incremental/smt_is_dynamic_object.h
@@ -1,0 +1,31 @@
+// Author: Diffblue Ltd.
+
+#ifndef CPROVER_SOLVERS_SMT2_INCREMENTAL_SMT_IS_DYNAMIC_OBJECT_H
+#define CPROVER_SOLVERS_SMT2_INCREMENTAL_SMT_IS_DYNAMIC_OBJECT_H
+
+#include <solvers/smt2_incremental/ast/smt_commands.h>
+#include <solvers/smt2_incremental/ast/smt_terms.h>
+
+/// Specifics of how the dynamic object status lookup is implemented in SMT
+/// terms. This uses an uninterpreted function as a lookup. Because these
+/// functions must return the same result for a specific input, we can just
+/// assert the value of the function output for the inputs where we want to
+/// define specific ID input / dynamic_object output pairs.
+struct smt_is_dynamic_objectt final
+{
+  smt_is_dynamic_objectt();
+  /// The command for declaring the is_dynamic_object function. The defined
+  /// function takes a bit vector encoded unique object identifier and returns
+  /// a boolean value.
+  smt_declare_function_commandt declaration;
+  /// Function which makes applications of the smt function.
+  using make_applicationt =
+    smt_function_application_termt::factoryt<smt_command_functiont>;
+  make_applicationt make_application;
+  /// Makes the command to define the resulting \p is_dynamic_object status for
+  /// calls to the `is_dynamic_object` function with \p unique_id.
+  smt_commandt
+  make_definition(std::size_t unique_id, bool is_dynamic_object) const;
+};
+
+#endif // CPROVER_SOLVERS_SMT2_INCREMENTAL_SMT_IS_DYNAMIC_OBJECT_H

--- a/src/solvers/smt2_incremental/type_size_mapping.cpp
+++ b/src/solvers/smt2_incremental/type_size_mapping.cpp
@@ -15,7 +15,8 @@ void associate_pointer_sizes(
   const namespacet &ns,
   type_size_mapt &type_size_map,
   const smt_object_mapt &object_map,
-  const smt_object_sizet::make_applicationt &object_size)
+  const smt_object_sizet::make_applicationt &object_size,
+  const smt_is_dynamic_objectt::make_applicationt &is_dynamic_object)
 {
   expression.visit_pre([&](const exprt &sub_expression) {
     if(
@@ -42,7 +43,11 @@ void associate_pointer_sizes(
         pointer_size_expr = pointer_size_opt.value();
       }
       auto pointer_size_term = convert_expr_to_smt(
-        pointer_size_expr, object_map, type_size_map, object_size);
+        pointer_size_expr,
+        object_map,
+        type_size_map,
+        object_size,
+        is_dynamic_object);
       type_size_map.emplace_hint(
         find_result, pointer_type->base_type(), pointer_size_term);
     }

--- a/src/solvers/smt2_incremental/type_size_mapping.h
+++ b/src/solvers/smt2_incremental/type_size_mapping.h
@@ -10,6 +10,7 @@
 
 #include <solvers/smt2_incremental/ast/smt_terms.h>
 #include <solvers/smt2_incremental/object_tracking.h>
+#include <solvers/smt2_incremental/smt_is_dynamic_object.h>
 #include <solvers/smt2_incremental/smt_object_size.h>
 
 #include <unordered_map>
@@ -28,11 +29,13 @@ using type_size_mapt = std::unordered_map<typet, smt_termt, irep_full_hash>;
 ///   from \p expression which are not already keys in the map.
 /// \param object_map: passed through to convert_expr_to_smt
 /// \param object_size: passed through to convert_expr_to_smt
+/// \param is_dynamic_object: passed through to convert_expr_to_smt
 void associate_pointer_sizes(
   const exprt &expression,
   const namespacet &ns,
   type_size_mapt &type_size_map,
   const smt_object_mapt &object_map,
-  const smt_object_sizet::make_applicationt &object_size);
+  const smt_object_sizet::make_applicationt &object_size,
+  const smt_is_dynamic_objectt::make_applicationt &is_dynamic_object);
 
 #endif

--- a/unit/Makefile
+++ b/unit/Makefile
@@ -110,6 +110,7 @@ SRC += analyses/ai/ai.cpp \
        solvers/smt2_incremental/convert_expr_to_smt.cpp \
        solvers/smt2_incremental/object_tracking.cpp \
        solvers/smt2_incremental/smt2_incremental_decision_procedure.cpp \
+       solvers/smt2_incremental/smt_is_dynamic_object.cpp \
        solvers/smt2_incremental/smt_object_size.cpp \
        solvers/smt2_incremental/smt_response_validation.cpp \
        solvers/smt2_incremental/smt_to_smt2_string.cpp \

--- a/unit/solvers/smt2_incremental/smt2_incremental_decision_procedure.cpp
+++ b/unit/solvers/smt2_incremental/smt2_incremental_decision_procedure.cpp
@@ -113,6 +113,7 @@ struct decision_procedure_test_environmentt final
   std::vector<smt_commandt> sent_commands;
   null_message_handlert message_handler;
   smt_object_sizet object_size_function;
+  smt_is_dynamic_objectt is_dynamic_object_function;
   smt2_incremental_decision_proceduret procedure{
     ns,
     util_make_unique<smt_mock_solver_processt>(
@@ -177,7 +178,8 @@ TEST_CASE(
       std::vector<smt_commandt>{
         smt_set_option_commandt{smt_option_produce_modelst{true}},
         smt_set_logic_commandt{smt_logic_allt{}},
-        test.object_size_function.declaration});
+        test.object_size_function.declaration,
+        test.is_dynamic_object_function.declaration});
     test.sent_commands.clear();
     SECTION("Set symbol to true.")
     {
@@ -464,6 +466,10 @@ TEST_CASE(
   const auto invalid_pointer_object_size_definition =
     test.object_size_function.make_definition(
       1, smt_bit_vector_constant_termt{0, 32});
+  const auto null_object_dynamic_definition =
+    test.is_dynamic_object_function.make_definition(0, false);
+  const auto invalid_pointer_object_dynamic_definition =
+    test.is_dynamic_object_function.make_definition(1, false);
   const symbolt foo = make_test_symbol("foo", signedbv_typet{16});
   const smt_identifier_termt foo_term{"foo", smt_bit_vector_sortt{16}};
   const exprt expr_42 = from_integer({42}, signedbv_typet{16});
@@ -480,6 +486,8 @@ TEST_CASE(
       smt_assert_commandt{smt_core_theoryt::equal(foo_term, term_42)},
       invalid_pointer_object_size_definition,
       null_object_size_definition,
+      null_object_dynamic_definition,
+      invalid_pointer_object_dynamic_definition,
       smt_check_sat_commandt{}};
     REQUIRE(
       (test.sent_commands.size() == expected_commands.size() &&

--- a/unit/solvers/smt2_incremental/smt_is_dynamic_object.cpp
+++ b/unit/solvers/smt2_incremental/smt_is_dynamic_object.cpp
@@ -1,0 +1,53 @@
+// Author: Diffblue Ltd.
+
+#include <util/c_types.h>
+#include <util/config.h>
+
+#include <solvers/smt2_incremental/smt_is_dynamic_object.h>
+#include <solvers/smt2_incremental/theories/smt_core_theory.h>
+#include <testing-utils/use_catch.h>
+
+TEST_CASE("Test smt_is_dynamic_objectt", "[core][smt2_incremental]")
+{
+  const std::size_t object_bits = GENERATE(8, 16);
+  INFO("Using " + std::to_string(object_bits) + " object id bits.");
+  // Configuration needs to be set because smt_is_dynamic_objectt uses it.
+  config.ansi_c.mode = configt::ansi_ct::flavourt::GCC;
+  config.ansi_c.set_arch_spec_x86_64();
+  config.bv_encoding.object_bits = object_bits;
+  const smt_is_dynamic_objectt is_dynamic_object;
+  SECTION("Declare function")
+  {
+    CHECK(
+      is_dynamic_object.declaration ==
+      smt_declare_function_commandt{
+        smt_identifier_termt{"is_dynamic_object", smt_bool_sortt{}},
+        {smt_bit_vector_sortt{object_bits}}});
+  }
+  SECTION("Apply function")
+  {
+    const smt_identifier_termt object_id{
+      "foo", smt_bit_vector_sortt{object_bits}};
+    const smt_function_application_termt function_application =
+      is_dynamic_object.make_application(std::vector<smt_termt>{object_id});
+    CHECK(
+      function_application.function_identifier() ==
+      smt_identifier_termt{"is_dynamic_object", smt_bool_sortt{}});
+    REQUIRE(function_application.arguments().size() == 1);
+    REQUIRE(function_application.arguments().at(0).get() == object_id);
+  }
+  SECTION("Define result")
+  {
+    const bool dynamic_status = GENERATE(true, false);
+    INFO(
+      "Testing for dynamic status of " +
+      std::string(dynamic_status ? "true" : "false"));
+    const smt_commandt definition =
+      is_dynamic_object.make_definition(42, dynamic_status);
+    CHECK(
+      definition == smt_assert_commandt{smt_core_theoryt::equal(
+                      is_dynamic_object.make_application(std::vector<smt_termt>{
+                        smt_bit_vector_constant_termt{42, object_bits}}),
+                      smt_bool_literal_termt{dynamic_status})});
+  }
+}


### PR DESCRIPTION
This PR adds support for `__CPROVER_DYNAMIC_OBJECT` to incremental SMT decision procedure. Note that it is currently based on top of https://github.com/diffblue/cbmc/pull/7311 . So the first commit titled "Add unit test of object size tracking" should be reviewed as part of that separate PR, rather than this one.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
