### PR TITLE
[CI] Fix windows slack notification.

### DIFF
--- a/.github/workflows/release-packages.yaml
+++ b/.github/workflows/release-packages.yaml
@@ -288,12 +288,14 @@ jobs:
           asset_name: ${{ steps.create_packages.outputs.msi_name }}
           asset_content_type: application/x-msi
       - name: Slack notification of CI status
-        uses: rtCamp/action-slack-notify@v2
+        if: success() || failure()
         env:
           SLACK_CHANNEL: team_open_source
           SLACK_COLOR: ${{ job.status }}
           SLACK_USERNAME: Github Actions CI bot
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_MESSAGE: "${{ job.status == 'success' && 'Windows package built and uploaded successfully' || 'Windows package build failed' }}"
+        run: go run scripts/slack_notification_action.go
 
   push-docker-image-dockerhub:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
We currently have a small `go` utility to produce some notifications on Diffblue's Open Source team channel on Slack, so that we keep track of the release and any builds for associated artifacts.

The notifications work on Linux, but they required running the `go` program directly on MacOS, because the action is bootstrapping an Alpine Linux container which for some reason is incompatible with the MacOS and Windows runners.

This commit follows the same recipe (running the go binary directly) to allow us to keep track of the Windows `.msi` installer package build.
