### PR TITLE
CONTRACTS: Unwind transformed loops after loop contract transformation

### DIFF
--- a/regression/contracts/invar_assigns_empty/test.desc
+++ b/regression/contracts/invar_assigns_empty/test.desc
@@ -3,8 +3,8 @@ main.c
 --apply-loop-contracts
 ^EXIT=0$
 ^SIGNAL=0$
-^\[main.1\] .* Check loop invariant before entry: SUCCESS$
-^\[main.2\] .* Check that loop invariant is preserved: SUCCESS$
+^\[main.\d+\] .* Check loop invariant before entry: SUCCESS$
+^\[main.\d+\] .* Check that loop invariant is preserved: SUCCESS$
 ^VERIFICATION SUCCESSFUL$
 --
 --

--- a/regression/contracts/invar_loop_constant_pass/test_unwind.desc
+++ b/regression/contracts/invar_loop_constant_pass/test_unwind.desc
@@ -1,0 +1,14 @@
+CORE
+main.c
+--apply-loop-contracts --unwind 1 --unwinding-assertions
+^EXIT=0$
+^SIGNAL=0$
+^\[main\.\d+\] .* Check loop invariant before entry: SUCCESS$
+^\[main\.\d+\] .* Check that loop invariant is preserved: SUCCESS$
+^\[main.assigns.\d+\] .* Check that s is assignable: SUCCESS$
+^\[main.assigns.\d+\] .* Check that r is assignable: SUCCESS$
+^\[main\.assertion\.\d+\] .* assertion r == 0: SUCCESS$
+^\[main\.assertion\.\d+\] .* assertion s == 1: SUCCESS$
+^VERIFICATION SUCCESSFUL$
+--
+This test checks that there is no loop after contract transforamtion.

--- a/src/goto-instrument/contracts/contracts.h
+++ b/src/goto-instrument/contracts/contracts.h
@@ -141,6 +141,9 @@ protected:
 
   std::unordered_set<irep_idt> summarized;
 
+  /// Name of loops we are going to unwind.
+  std::list<std::string> loop_names;
+
 public:
   /// Translates a function_pointer_obeys_contract_exprt into an assertion
   /// ```


### PR DESCRIPTION
<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
Thank you for reporting a problem and suggesting improvements. Please provide the below information to make sure we can effectively deal with the issue reported. For the most precise version information, see the first line of console output or run with --version. Please attach or include example code that allows us to reproduce the problem.
--->

This PR unwinds transformed loops twice after applying loop contracts, so that users don't need to specify loop unwinding bounds for those loops. This PR will fix #7306.

# Problem description
Currently, the loop contract transformation will insert a backward jump (https://github.com/diffblue/cbmc/blob/develop/src/goto-instrument/contracts/contracts.cpp#L110) into the result goto program. So after applying loop contracts, there will be loops that execute only one iteration in the place of the original annotated loops, which require users to correctly specify the unwinding bounds for them: either not unwinding them, or unwind them for at least twice. It is an unnecessary usability pain point for users. So backward goto should be avoided during loop contract transformation.

# Example
A smaller example to illustrate the problem.
```c
int main()
{
  int i;
  for(i = 0; i < 1; i++)
    __CPROVER_loop_invariant(1 > 1)
    {
      i++;
    }
}
```
Note that the invariant ```1 > 1``` is invalid. So that a correct run of CBMC should report loop invariant doesn’t hold before entry of the loop.
Run ```goto-cc main.c```  ```goto-instrument --apply-loop-contracts a.out b.out``` to apply loop contracts and get the result goto program ```b.goto```. Then with command ```cbmc b.out``` (or ```cbmc --unwind 2 b.out```) CBMC will correctly report the failure 
```
[main.1] line 5 Check loop invariant before entry: FAILURE
```
However, running ```cbmc --unwind 1 b.out``` will report no failure.
Running ```cbmc --unwind 1 --unwinding-assertions b.out``` will report 
```
[main.unwind.0] line 5 unwinding assertion loop 0: FAILURE
```
<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
