### PR TITLE
Update CODEOWNERS to add Daniel Kroening as an owner for src/memory-analyzer

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -49,7 +49,7 @@
 /doc/cprover-manual/contracts* @tautschnig @feliperodri @remi-delmas-3000
 /src/goto-diff/ @tautschnig @peterschrammel
 /src/jsil/ @kroening @tautschnig
-/src/memory-analyzer/ @tautschnig @chris-ryder
+/src/memory-analyzer/ @tautschnig @chris-ryder @kroening
 /jbmc/src/jbmc/ @peterschrammel @romainbrenguier
 /jbmc/src/janalyzer/ @peterschrammel @romainbrenguier
 /jbmc/src/jdiff/ @peterschrammel


### PR DESCRIPTION
Adding @kroening as a code-owner to /src/memory-analyzer to maintain at least two active owners for each unit.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- [X] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [X] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [X] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [X] My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- [X] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
