### PR TITLE
Ensure one backedge per target: restore lexical loops

### DIFF
--- a/regression/goto-instrument/ensure-one-backedge-per-target-not-lexical/main.c
+++ b/regression/goto-instrument/ensure-one-backedge-per-target-not-lexical/main.c
@@ -1,0 +1,25 @@
+_Bool nondet_bool();
+
+int main()
+{
+  int j = 0;
+  int i;
+L2:
+  ++j;
+  if(j == 2)
+    return 0;
+  int extra_counter = 0;
+  for(int i = nondet_bool() ? -1 : -2; extra_counter < 10; ++i, ++extra_counter)
+  {
+    // The following causes a surprising loop unwinding failure (and an equally
+    // surprising sequence of loop unwinding status output) when using
+    // --unwind 4 --unwinding-assertions
+    // No such failure can be observed when using "goto L2X" instead and
+    // enabling the below label/goto pair.
+    if(i >= 1)
+      goto L2;
+  }
+  //L2X:
+  //   goto L2;
+  return 0;
+}

--- a/regression/goto-instrument/ensure-one-backedge-per-target-not-lexical/with-transform.desc
+++ b/regression/goto-instrument/ensure-one-backedge-per-target-not-lexical/with-transform.desc
@@ -1,0 +1,7 @@
+CORE
+main.c
+--ensure-one-backedge-per-target --show-lexical-loops
+^3 is head of \{ 3, 4, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26 \(backedge\) \}$
+^16 is head of \{ 16, 17, 22, 23, 24, 25 \(backedge\) \}$
+^EXIT=0$
+^SIGNAL=0$

--- a/regression/goto-instrument/ensure-one-backedge-per-target-not-lexical/without-transform.desc
+++ b/regression/goto-instrument/ensure-one-backedge-per-target-not-lexical/without-transform.desc
@@ -1,0 +1,7 @@
+CORE
+main.c
+--show-lexical-loops
+^16 is head of \{ 16, 17, 22, 23, 24, 25 \(backedge\) \}$
+Note not all loops were in lexical loop form
+^EXIT=0$
+^SIGNAL=0$


### PR DESCRIPTION
Figure-of-eight loop pairs may indeed have just one backedge, but still confused symex' unwinding counters. Re-create properly nested lexical loops from such loop pairs to avoid this problem.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
