### PR TITLE
goto_programt::get_target: fix const-ness of operations

### DIFF
--- a/src/goto-programs/goto_convert.cpp
+++ b/src/goto-programs/goto_convert.cpp
@@ -243,7 +243,7 @@ void goto_convertt::optimize_guarded_gotos(goto_programt &dest)
 
   // mark the goto targets
   unsigned cnt = 0;
-  for(const auto &i : dest.instructions)
+  for(auto &i : dest.instructions)
     if(i.is_goto())
       i.get_target()->target_number = (++cnt);
 

--- a/src/goto-programs/goto_program.h
+++ b/src/goto-programs/goto_program.h
@@ -395,7 +395,15 @@ public:
 
     /// Returns the first (and only) successor for the usual case of a single
     /// target
-    targett get_target() const
+    const_targett get_target() const
+    {
+      PRECONDITION(targets.size() == 1);
+      return targets.front();
+    }
+
+    /// Returns the first (and only) successor for the usual case of a single
+    /// target
+    targett get_target()
     {
       PRECONDITION(targets.size()==1);
       return targets.front();


### PR DESCRIPTION
Return a const iterator in a const context to avoid providing a means to modify instructions in a goto program despite being in a const context.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
