### PR TITLE
    CONTRACTS: use vars auxiliary for DFCC

### DIFF
--- a/src/goto-instrument/contracts/dynamic-frames/dfcc_utils.cpp
+++ b/src/goto-instrument/contracts/dynamic-frames/dfcc_utils.cpp
@@ -105,6 +105,7 @@ const symbolt &dfcc_utilst::create_symbol(
   symbol.is_state_var = true;
   symbol.is_thread_local = true;
   symbol.is_file_local = true;
+  symbol.is_auxiliary = true;
   symbol.is_parameter = is_parameter;
   return symbol;
 }
@@ -134,6 +135,7 @@ const symbolt &dfcc_utilst::create_static_symbol(
   symbol.is_state_var = true;
   symbol.is_thread_local = true;
   symbol.is_file_local = true;
+  symbol.is_auxiliary = true;
   symbol.is_parameter = false;
   return symbol;
 }


### PR DESCRIPTION
The `is_auxiliary` flag is now set for instrumentation variables     created for DFCC. This will reduce noise in counter examples.

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.
