### PR TITLE
CONTRACTS: Allow NULL function pointer contracts

### DIFF
--- a/regression/contracts-dfcc/function-pointer-contracts-enforce-1/main.c
+++ b/regression/contracts-dfcc/function-pointer-contracts-enforce-1/main.c
@@ -1,0 +1,52 @@
+#include <assert.h>
+#include <stdbool.h>
+#include <stdlib.h>
+
+typedef int (*fun_t)(int);
+
+int add_one(int x)
+  __CPROVER_ensures(__CPROVER_return_value == __CPROVER_old(x) + 1);
+
+int foo(fun_t f_in, int x, fun_t *f_out)
+  // clang-format off
+__CPROVER_requires_contract(f_in, add_one, NULL)
+__CPROVER_assigns(f_out)
+__CPROVER_ensures(f_in ==>__CPROVER_return_value == __CPROVER_old(x) + 1)
+__CPROVER_ensures(!f_in ==>__CPROVER_return_value == __CPROVER_old(x))
+__CPROVER_ensures_contract(*f_out, add_one, NULL)
+// clang-format on
+{
+  *f_out = NULL;
+  if(f_in)
+  {
+    *f_out = f_in;
+    // this branch must be reachable
+    __CPROVER_assert(false, "then branch is reachable, expecting FAILURE");
+  CALL_F_IN:
+    return f_in(x);
+  }
+  else
+  {
+    // this branch must be reachable
+    __CPROVER_assert(false, "else branch is reachable, expecting FAILURE");
+    return x;
+  }
+}
+
+int main()
+{
+  fun_t f_in;
+  int x;
+  fun_t f_out;
+  foo(f_in, x, &f_out);
+  if(f_out)
+  {
+    __CPROVER_assert(false, "then branch is reachable, expecting FAILURE");
+  CALL_F_OUT:
+    __CPROVER_assert(f_out(1) == 2, "f_out satisfies add_one");
+  }
+  else
+  {
+    __CPROVER_assert(false, "else branch is reachable, expecting FAILURE");
+  }
+}

--- a/regression/contracts-dfcc/function-pointer-contracts-enforce-1/test.desc
+++ b/regression/contracts-dfcc/function-pointer-contracts-enforce-1/test.desc
@@ -1,0 +1,31 @@
+CORE
+main.c
+--restrict-function-pointer foo.CALL_F_IN/add_one --restrict-function-pointer main.CALL_F_OUT/add_one --dfcc main --enforce-contract foo
+main.c function foo
+^\[foo.postcondition.\d+\] line 14 Check ensures clause of contract contract::foo for function foo: SUCCESS$
+^\[foo.postcondition.\d+\] line 15 Check ensures clause of contract contract::foo for function foo: SUCCESS$
+^\[foo.postcondition.\d+\] line 16 Assert function pointer '\*f_out_wrapper' obeys contract 'add_one' or '\(fun_t\)NULL': SUCCESS$
+^\[foo.assigns.\d+\] line 19 Check that \*f_out is assignable: FAILURE$
+^\[foo.assigns.\d+\] line 22 Check that \*f_out is assignable: FAILURE$
+^\[foo.assertion.\d+\] line 24 then branch is reachable, expecting FAILURE: FAILURE$
+^\[foo.pointer_dereference.\d+\] line 26 dereferenced function pointer must be add_one: SUCCESS$
+^\[foo.assertion.\d+\] line 31 else branch is reachable, expecting FAILURE: FAILURE$
+^\[main.assertion.\d+\] line 44 then branch is reachable, expecting FAILURE: FAILURE$
+^\[main.assertion.\d+\] line 46 f_out satisfies add_one: SUCCESS$
+^\[main.pointer_dereference.\d+\] line 46 dereferenced function pointer must be add_one: SUCCESS$
+^\[main.assertion.\d+\] line 50 else branch is reachable, expecting FAILURE: FAILURE$
+^VERIFICATION FAILED$
+^EXIT=10$
+^SIGNAL=0$
+--
+--
+foo requires that function pointer f_in satisfies the contract add_one or is NULL.
+When f_in is not NULL, foo calls f_in and the post condition of foo is that
+of add_one `__CPROVER_return_value == old(x) + 1`.
+When f_in is not NULL, foo returns x directly post condition of foo is that
+of add_one `__CPROVER_return_value == old(x)`.
+The function pointer f_out is ensured to satisfy the add_one contract or be NULL
+as a post condition.
+The main program calls f_out on a particular value if it is not null and asserts
+that the add_one post condition holds for a particular value.
+Assertions `assert(false)` are added to all branches to demonstrate reachability.

--- a/regression/contracts-dfcc/function-pointer-contracts-replace-1/main.c
+++ b/regression/contracts-dfcc/function-pointer-contracts-replace-1/main.c
@@ -1,0 +1,57 @@
+#include <assert.h>
+#include <stdbool.h>
+#include <stdlib.h>
+
+typedef int (*fun_t)(int);
+
+int add_one(int x)
+  __CPROVER_ensures(__CPROVER_return_value == __CPROVER_old(x) + 1);
+
+// returns either a pointer to a function that satisfies add_one or NULL
+fun_t get_add_one()
+  __CPROVER_ensures_contract(__CPROVER_return_value, add_one, NULL);
+
+int foo(int x, fun_t *f_out)
+  // clang-format off
+__CPROVER_assigns(*f_out)
+__CPROVER_ensures(
+  __CPROVER_return_value == __CPROVER_old(x) + 1 ||
+  __CPROVER_return_value == __CPROVER_old(x))
+__CPROVER_ensures_contract(*f_out, add_one, NULL)
+// clang-format on
+{
+  *f_out = NULL;
+  // obtain a pointer to a function that satisfies add_one;
+  fun_t f_in = get_add_one();
+  if(f_in)
+  {
+    *f_out = f_in;
+    // this branch must be reachable
+    __CPROVER_assert(false, "then branch is reachable, expecting FAILURE");
+  CALL_F_IN:
+    return f_in(x);
+  }
+  else
+  {
+    // this branch must be reachable
+    __CPROVER_assert(false, "else branch is reachable, expecting FAILURE");
+    return x;
+  }
+}
+
+int main()
+{
+  int x;
+  fun_t f_out;
+  foo(x, &f_out);
+  if(f_out)
+  {
+    __CPROVER_assert(false, "then branch is reachable, expecting FAILURE");
+  CALL_F_OUT:
+    __CPROVER_assert(f_out(1) == 2, "f_out satisfies add_one");
+  }
+  else
+  {
+    __CPROVER_assert(false, "else branch is reachable, expecting FAILURE");
+  }
+}

--- a/regression/contracts-dfcc/function-pointer-contracts-replace-1/test.desc
+++ b/regression/contracts-dfcc/function-pointer-contracts-replace-1/test.desc
@@ -1,0 +1,28 @@
+CORE
+main.c
+--restrict-function-pointer foo.CALL_F_IN/add_one --restrict-function-pointer main.CALL_F_OUT/add_one --dfcc main --enforce-contract foo --replace-call-with-contract get_add_one
+^\[foo.postcondition.\d+\] line 18 Check ensures clause of contract contract::foo for function foo: SUCCESS$
+^\[foo.postcondition.\d+\] line 20 Assert function pointer '\*f_out_wrapper' obeys contract 'add_one' or '\(fun_t\)NULL': SUCCESS$
+^\[foo.assertion.\d+\] line 30 then branch is reachable, expecting FAILURE: FAILURE$
+^\[foo.pointer_dereference.\d+\] line 32 dereferenced function pointer must be add_one: SUCCESS$
+^\[foo.assertion.\d+\] line 37 else branch is reachable, expecting FAILURE: FAILURE$
+^\[main.assertion.\d+\] line 49 then branch is reachable, expecting FAILURE: FAILURE$
+^\[main.assertion.\d+\] line 51 f_out satisfies add_one: SUCCESS$
+^\[main.pointer_dereference.\d+\] line 51 dereferenced function pointer must be add_one: SUCCESS$
+^\[main.assertion.\d+\] line 55 else branch is reachable, expecting FAILURE: FAILURE$
+^VERIFICATION FAILED$
+^EXIT=10$
+^SIGNAL=0$
+--
+--
+foo obtains function pointer f_in through get_add_one, which is replaced by
+its contract.
+When f_in is not NULL, foo calls f_in and the post condition of foo is that
+of add_one `__CPROVER_return_value == old(x) + 1`.
+When f_in is not NULL, foo returns x directly post condition of foo is that
+of add_one `__CPROVER_return_value == old(x)`.
+The function pointer f_out is ensured to satisfy the add_one contract or be NULL
+as a post condition.
+The main program calls f_out on a particular value if it is not null and asserts
+that the add_one post condition holds for a particular value.
+Assertions `assert(false)` are added to all branches to demonstrate reachability.

--- a/src/ansi-c/c_expr.h
+++ b/src/ansi-c/c_expr.h
@@ -329,11 +329,11 @@ class function_pointer_obeys_contract_exprt : public exprt
 public:
   explicit function_pointer_obeys_contract_exprt(
     exprt _function_pointer,
-    exprt _contract)
+    exprt _contract_pointers)
     : exprt(ID_function_pointer_obeys_contract, empty_typet{})
   {
     add_to_operands(std::move(_function_pointer));
-    add_to_operands(std::move(_contract));
+    add_to_operands(std::move(_contract_pointers));
   }
 
   static void check(
@@ -344,6 +344,13 @@ public:
       vm,
       expr.operands().size() == 2,
       "function pointer obeys contract expression must have two operands");
+
+    DATA_CHECK(
+      vm,
+      expr.operands()[1].id() == ID_expression_list,
+      "function pointer obeys contract expression second operand must be an "
+      "ID_expression_list expression, found " +
+        id2string(expr.operands()[1].id()));
   }
 
   static void validate(
@@ -364,24 +371,14 @@ public:
     return op0();
   }
 
-  const symbol_exprt &contract_symbol_expr() const
+  const exprt::operandst &contract_pointers() const
   {
-    return to_symbol_expr(op1().operands().at(0));
+    return op1().operands();
   }
 
-  symbol_exprt &contract_symbol_expr()
+  exprt::operandst &contract_pointers()
   {
-    return to_symbol_expr(op1().operands().at(0));
-  }
-
-  const exprt &address_of_contract() const
-  {
-    return op1();
-  }
-
-  exprt &address_of_contract()
-  {
-    return op1();
+    return op1().operands();
   }
 };
 

--- a/src/ansi-c/parser.y
+++ b/src/ansi-c/parser.y
@@ -3299,7 +3299,7 @@ cprover_function_contract:
           set($$, ID_C_spec_requires);
           mto($$, $3);
         }
-        | TOK_CPROVER_ENSURES_CONTRACT '(' unary_expression ',' unary_expression ')'
+        | TOK_CPROVER_ENSURES_CONTRACT '(' unary_expression ',' unary_expression_list ')'
         {
           $$=$1;
           set($$, ID_C_spec_ensures_contract);
@@ -3309,7 +3309,7 @@ cprover_function_contract:
           tmp.add_source_location()=parser_stack($$).source_location();
           parser_stack($$).add_to_operands(std::move(tmp));
         }
-        | TOK_CPROVER_REQUIRES_CONTRACT '(' unary_expression ',' unary_expression ')'
+        | TOK_CPROVER_REQUIRES_CONTRACT '(' unary_expression ',' unary_expression_list ')'
         {
           $$=$1;
           set($$, ID_C_spec_requires_contract);

--- a/src/goto-instrument/contracts/doc/user/contracts-assigns.md
+++ b/src/goto-instrument/contracts/doc/user/contracts-assigns.md
@@ -502,6 +502,7 @@ int foo()
 
 - @ref contracts-functions
   - @ref contracts-requires-ensures
+  - @ref contracts-requires-ensures-contract
   - @ref contracts-assigns
   - @ref contracts-frees
 - @ref contracts-loops

--- a/src/goto-instrument/contracts/doc/user/contracts-decreases.md
+++ b/src/goto-instrument/contracts/doc/user/contracts-decreases.md
@@ -179,6 +179,7 @@ then the weakest possible invariant (i.e, `true`) is used to model an arbitrary 
 
 - @ref contracts-functions
   - @ref contracts-requires-ensures
+  - @ref contracts-requires-ensures-contract
   - @ref contracts-assigns
   - @ref contracts-frees
 - @ref contracts-loops

--- a/src/goto-instrument/contracts/doc/user/contracts-functions.md
+++ b/src/goto-instrument/contracts/doc/user/contracts-functions.md
@@ -154,6 +154,7 @@ program using contracts.
 
 - @ref contracts-functions
   - @ref contracts-requires-ensures
+  - @ref contracts-requires-ensures-contract
   - @ref contracts-assigns
   - @ref contracts-frees
 - @ref contracts-loops

--- a/src/goto-instrument/contracts/doc/user/contracts-history-variables.md
+++ b/src/goto-instrument/contracts/doc/user/contracts-history-variables.md
@@ -48,6 +48,7 @@ TODO: Document `__CPROVER_loop_entry` and `__CPROVER_loop_old`.
 
 - @ref contracts-functions
   - @ref contracts-requires-ensures
+  - @ref contracts-requires-ensures-contract
   - @ref contracts-assigns
   - @ref contracts-frees
 - @ref contracts-loops

--- a/src/goto-instrument/contracts/doc/user/contracts-loop-invariants.md
+++ b/src/goto-instrument/contracts/doc/user/contracts-loop-invariants.md
@@ -157,6 +157,7 @@ A few things to note here:
 
 - @ref contracts-functions
   - @ref contracts-requires-ensures
+  - @ref contracts-requires-ensures-contract
   - @ref contracts-assigns
   - @ref contracts-frees
 - @ref contracts-loops

--- a/src/goto-instrument/contracts/doc/user/contracts-loops.md
+++ b/src/goto-instrument/contracts/doc/user/contracts-loops.md
@@ -147,6 +147,7 @@ and finally we verify the instrumented GOTO binary with desired checks.
 
 - @ref contracts-functions
   - @ref contracts-requires-ensures
+  - @ref contracts-requires-ensures-contract
   - @ref contracts-assigns
   - @ref contracts-frees
 - @ref contracts-loops

--- a/src/goto-instrument/contracts/doc/user/contracts-memory-predicates.md
+++ b/src/goto-instrument/contracts/doc/user/contracts-memory-predicates.md
@@ -124,6 +124,7 @@ int foo()
 
 - @ref contracts-functions
   - @ref contracts-requires-ensures
+  - @ref contracts-requires-ensures-contract
   - @ref contracts-assigns
   - @ref contracts-frees
 - @ref contracts-loops

--- a/src/goto-instrument/contracts/doc/user/contracts-quantifiers.md
+++ b/src/goto-instrument/contracts/doc/user/contracts-quantifiers.md
@@ -96,6 +96,7 @@ int bar_sat(int *arr, int len)
 
 - @ref contracts-functions
   - @ref contracts-requires-ensures
+  - @ref contracts-requires-ensures-contract
   - @ref contracts-assigns
   - @ref contracts-frees
 - @ref contracts-loops

--- a/src/goto-instrument/contracts/doc/user/contracts-requires-ensures-contract.md
+++ b/src/goto-instrument/contracts/doc/user/contracts-requires-ensures-contract.md
@@ -1,0 +1,180 @@
+# Requires and Ensures Clauses {#contracts-requires-ensures-contract}
+
+Back to @ref contracts-user
+
+@tableofcontents
+
+## Syntax
+
+```c
+__CPROVER_requires_contract(function_pointer, contract_id (, NULL)?)
+```
+
+A _requires contract_ clause specifies the precondition that a function pointer
+points to a function satisfying a given contract, or is optionally NULL.
+
+```c
+__CPROVER_ensures_contract(function_pointer, contract_id (, NULL)?)
+```
+
+A _ensures contract_ clause specifies the postcondition that a function pointer
+points to a function satisfying a given contract, or is optionally NULL.
+
+## Semantics
+
+The semantics of _requires contract_ and _ensures contract_ clauses can be
+understood in two contexts: enforcement and replacement.
+
+To illustrate these two perspectives, consider the following program:
+
+```c
+#include <assert.h>
+#include <stdbool.h>
+#include <stdlib.h>
+
+typedef int (*fun_t)(int);
+
+int add_one(int x)
+__CPROVER_ensures(__CPROVER_return_value == __CPROVER_old(x) + 1);
+
+// returns either a pointer to a function that satisfies add_one or NULL
+fun_t get_add_one()
+__CPROVER_ensures_contract(__CPROVER_return_value, add_one);
+
+int foo(fun_t f_in, int x, fun_t *f_out)
+__CPROVER_requires_contract(f_in, add_one, NULL)
+__CPROVER_assigns(*f_out)
+__CPROVER_ensures(__CPROVER_return_value == __CPROVER_old(x) + 1)
+__CPROVER_ensures_contract(*f_out, add_one)
+{
+  if (f_in)
+  {
+    *f_out = f_in;
+  }
+  else
+  {
+    *f_out = get_add_one();
+  }
+
+CALL:
+  return (*f_out)(x);
+}
+
+int main()
+{
+  fun_t f_in;
+  int x;
+  fun_t f_out;
+  foo(f_in, x, &f_out);
+CALL:
+  __CPROVER_assert(f_out(1) == 2, "f_out satisfies add_one");
+}
+```
+
+The function `add_one` is a contract that describes a function that adds one
+to its input.
+The function `get_add_one` is a contract that describes a function returning a
+pointer to a function satisfying the contract `add_one`.
+
+The Function `foo` takes a function pointer `f_in` as input and requires that
+it either satisfies `add_one` or is NULL;
+If `f_in` is not NULL, `foo` set `f_out` to `f_in`;
+If `f_in` is NULL, `foo` calls `get_add_one` to set `f_out`  to a non-NULL
+  pointer to a function that satisfies `add_one`;
+The function `foo` returns the result of applying `f_out` to its input, which
+allows to establish its post condition.
+The `main` function calls `f_out(1)` and checks if the `add_one` contract holds
+for this particular input.
+
+This program is instrumented using the following commands:
+
+```
+goto-cc main.c -o a.out
+goto-instrument --dfcc main --restrict-function-pointer foo.CALL/add_one --restrict-function-pointer main.CALL/add_one --enforce-contract foo --replace-call-with-contract get_add_one a.out b.out
+```
+
+The function pointer restrictions are let CBMC know that the function pointers
+in `foo` and `main` must be pointing to the function `add_one`, which serves as
+the cannonical representation of the assumed contract. These assumptions will be
+checked by CBMC, i.e. if it is possible that the function pointer points to
+another function the analysis will fail.
+
+The analysis results are the following:
+
+```
+cbmc b.out
+
+...
+
+main.c function foo
+[foo.postcondition.1] line 15 Check ensures clause of contract contract::foo for function foo: SUCCESS
+[foo.postcondition.2] line 16 Assert function pointer '*f_out_wrapper' obeys contract 'add_one': SUCCESS
+[foo.assigns.1] line 18 Check that *f_out is assignable: SUCCESS
+[foo.assigns.3] line 20 Check that *f_out is assignable: SUCCESS
+[foo.pointer_dereference.1] line 22 dereferenced function pointer must be add_one: SUCCESS
+
+main.c function main
+[main.assertion.1] line 31 f_out satisfies add_one: SUCCESS
+[main.pointer_dereference.1] line 31 dereferenced function pointer must be add_one: SUCCESS
+
+** 0 of 56 failed (1 iterations)
+VERIFICATION SUCCESSFUL
+```
+
+### Enforcement
+
+When enforcing a contract, a clause
+
+```c
+__CPROVER_requires(function_pointer, contract_id, NULL)
+```
+
+is turned into a non-deterministic assignment and inserted before the call site
+of the function under verification:
+
+
+```c
+function_pointer = nondet() ? &contract_id : NULL;
+```
+
+That way, the function under verification receives a pointer to the
+`contract_id` function. The instrumentation pass also generates a body for the
+function `contract_id` from its contract clauses, so it becomes the canonical
+representation of the contract.
+
+An _ensures contract_ clause:
+
+```c
+__CPROVER_ensures(function_pointer, contract_id, NULL)
+```
+
+is turned into an assertion:
+
+```c
+assert(function_pointer ==> function_pointer == &contract_id);
+```
+
+That checks that whenever the `function_pointer` is not null, it points to the
+function `contract_id`, the canonical representation of the contract.
+
+### Replacement
+
+For contract replacement, the dual transformation is used: _requires contract_
+clauses are turned into assertions, and _ensures contract_ clauses are turned
+into nondeterministic assignments.
+
+## Additional Resources
+
+- @ref contracts-functions
+  - @ref contracts-requires-ensures
+  - @ref contracts-requires-ensures-contract
+  - @ref contracts-assigns
+  - @ref contracts-frees
+- @ref contracts-loops
+  - @ref contracts-loop-invariants
+  - @ref contracts-decreases
+  - @ref contracts-assigns
+  - @ref contracts-frees
+- @ref contracts-memory-predicates
+- @ref contracts-history-variables
+- @ref contracts-quantifiers

--- a/src/goto-instrument/contracts/doc/user/contracts-requires-ensures.md
+++ b/src/goto-instrument/contracts/doc/user/contracts-requires-ensures.md
@@ -179,6 +179,7 @@ int foo()
 
 - @ref contracts-functions
   - @ref contracts-requires-ensures
+  - @ref contracts-requires-ensures-contract
   - @ref contracts-assigns
   - @ref contracts-frees
 - @ref contracts-loops


### PR DESCRIPTION
depends on https://github.com/diffblue/cbmc/pull/7328

Adds a third optional `NULL` parameter to the `__CPROVER_requires_contract` and `__CPROVER_ensures_contract` clauses. When specified, the meaning is that the function pointer in question can be either pointing to a function
satisfying the contract or be NULL.

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [x] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.
