### PR TITLE
Move has_byte_operator to util

### DIFF
--- a/src/solvers/flattening/boolbv_equality.cpp
+++ b/src/solvers/flattening/boolbv_equality.cpp
@@ -6,12 +6,13 @@ Author: Daniel Kroening, kroening@kroening.com
 
 \*******************************************************************/
 
-#include "boolbv.h"
-
-#include <util/std_expr.h>
+#include <util/byte_operators.h>
 #include <util/invariant.h>
+#include <util/std_expr.h>
 
 #include <solvers/lowering/expr_lowering.h>
+
+#include "boolbv.h"
 
 literalt boolbvt::convert_equality(const equal_exprt &expr)
 {

--- a/src/solvers/lowering/byte_operators.cpp
+++ b/src/solvers/lowering/byte_operators.cpp
@@ -2483,21 +2483,6 @@ exprt lower_byte_update(const byte_update_exprt &src, const namespacet &ns)
   return result;
 }
 
-bool has_byte_operator(const exprt &src)
-{
-  if(src.id()==ID_byte_update_little_endian ||
-     src.id()==ID_byte_update_big_endian ||
-     src.id()==ID_byte_extract_little_endian ||
-     src.id()==ID_byte_extract_big_endian)
-    return true;
-
-  forall_operands(it, src)
-    if(has_byte_operator(*it))
-      return true;
-
-  return false;
-}
-
 exprt lower_byte_operators(const exprt &src, const namespacet &ns)
 {
   exprt tmp=src;

--- a/src/solvers/lowering/expr_lowering.h
+++ b/src/solvers/lowering/expr_lowering.h
@@ -41,6 +41,4 @@ exprt lower_byte_update(const byte_update_exprt &src, const namespacet &ns);
 ///   byte_extract_exprt or \ref byte_update_exprt.
 exprt lower_byte_operators(const exprt &src, const namespacet &ns);
 
-bool has_byte_operator(const exprt &src);
-
 #endif /* CPROVER_SOLVERS_LOWERING_EXPR_LOWERING_H */

--- a/src/util/byte_operators.cpp
+++ b/src/util/byte_operators.cpp
@@ -57,3 +57,23 @@ make_byte_update(const exprt &_op, const exprt &_offset, const exprt &_value)
   return byte_update_exprt{
     byte_update_id(), _op, _offset, _value, config.ansi_c.char_width};
 }
+
+bool has_byte_operator(const exprt &src)
+{
+  if(
+    src.id() == ID_byte_update_little_endian ||
+    src.id() == ID_byte_update_big_endian ||
+    src.id() == ID_byte_extract_little_endian ||
+    src.id() == ID_byte_extract_big_endian)
+  {
+    return true;
+  }
+
+  for(const auto &op : src.operands())
+  {
+    if(has_byte_operator(op))
+      return true;
+  }
+
+  return false;
+}

--- a/src/util/byte_operators.h
+++ b/src/util/byte_operators.h
@@ -162,4 +162,8 @@ make_byte_extract(const exprt &_op, const exprt &_offset, const typet &_type);
 byte_update_exprt
 make_byte_update(const exprt &_op, const exprt &_offset, const exprt &_value);
 
+/// Return true iff \p src or one of its operands contain a byte extract or byte
+/// update expression.
+bool has_byte_operator(const exprt &src);
+
 #endif // CPROVER_UTIL_BYTE_OPERATORS_H


### PR DESCRIPTION
There is nothing solvers-specific to this function. Cleanup in preparation of moving all byte-operator lowering to util.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
