### PR TITLE
Byte extract and extract bits can be constant

### DIFF
--- a/regression/cbmc-library/memcpy-01/constant-propagation.desc
+++ b/regression/cbmc-library/memcpy-01/constant-propagation.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+--show-vcc
+main::1::m!0@1#1 = .*byte_extract_(big|little)_endian\(cast\(44, signedbv\[\d+\]\*\), 0, signedbv\[\d+\]\).*
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring

--- a/src/analyses/constant_propagator.cpp
+++ b/src/analyses/constant_propagator.cpp
@@ -100,7 +100,7 @@ void constant_propagator_domaint::assign_rec(
     exprt tmp = rhs;
     partial_evaluate(dest_values, tmp, ns);
 
-    if(dest_values.is_constant(tmp))
+    if(dest_values.is_constant(tmp, ns))
     {
       DATA_INVARIANT(
         ns.lookup(s).type == tmp.type(),
@@ -393,7 +393,7 @@ bool constant_propagator_domaint::two_way_propagate_rec(
     // two-way propagation
     valuest copy_values=values;
     assign_rec(copy_values, lhs, rhs, ns, cp, false);
-    if(!values.is_constant(rhs) || values.is_constant(lhs))
+    if(!values.is_constant(rhs, ns) || values.is_constant(lhs, ns))
       assign_rec(values, rhs, lhs, ns, cp, false);
     change = values.meet(copy_values, ns);
   }
@@ -419,9 +419,10 @@ bool constant_propagator_domaint::ai_simplify(
 class constant_propagator_is_constantt : public is_constantt
 {
 public:
-  explicit constant_propagator_is_constantt(
-    const replace_symbolt &replace_const)
-    : replace_const(replace_const)
+  constant_propagator_is_constantt(
+    const replace_symbolt &replace_const,
+    const namespacet &ns)
+    : is_constantt(ns), replace_const(replace_const)
   {
   }
 
@@ -442,14 +443,18 @@ protected:
   const replace_symbolt &replace_const;
 };
 
-bool constant_propagator_domaint::valuest::is_constant(const exprt &expr) const
+bool constant_propagator_domaint::valuest::is_constant(
+  const exprt &expr,
+  const namespacet &ns) const
 {
-  return constant_propagator_is_constantt(replace_const)(expr);
+  return constant_propagator_is_constantt(replace_const, ns)(expr);
 }
 
-bool constant_propagator_domaint::valuest::is_constant(const irep_idt &id) const
+bool constant_propagator_domaint::valuest::is_constant(
+  const irep_idt &id,
+  const namespacet &ns) const
 {
-  return constant_propagator_is_constantt(replace_const).is_constant(id);
+  return constant_propagator_is_constantt(replace_const, ns).is_constant(id);
 }
 
 /// Do not call this when iterating over replace_const.expr_map!
@@ -657,7 +662,7 @@ bool constant_propagator_domaint::partial_evaluate(
   // if the current rounding mode is top we can
   // still get a non-top result by trying all rounding
   // modes and checking if the results are all the same
-  if(!known_values.is_constant(rounding_mode_identifier()))
+  if(!known_values.is_constant(rounding_mode_identifier(), ns))
     return partial_evaluate_with_all_rounding_modes(known_values, expr, ns);
 
   return replace_constants_and_simplify(known_values, expr, ns);

--- a/src/analyses/constant_propagator.h
+++ b/src/analyses/constant_propagator.h
@@ -123,9 +123,9 @@ public:
 
     void set_dirty_to_top(const dirtyt &dirty, const namespacet &ns);
 
-    bool is_constant(const exprt &expr) const;
+    bool is_constant(const exprt &expr, const namespacet &ns) const;
 
-    bool is_constant(const irep_idt &id) const;
+    bool is_constant(const irep_idt &id, const namespacet &ns) const;
 
     bool is_empty() const
     {

--- a/src/ansi-c/c_typecheck_expr.cpp
+++ b/src/ansi-c/c_typecheck_expr.cpp
@@ -4394,13 +4394,11 @@ void c_typecheck_baset::typecheck_side_effect_assignment(
 class is_compile_time_constantt : public is_constantt
 {
 public:
-  explicit is_compile_time_constantt(const namespacet &ns) : ns(ns)
+  explicit is_compile_time_constantt(const namespacet &ns) : is_constantt(ns)
   {
   }
 
 protected:
-  const namespacet &ns;
-
   bool is_constant(const exprt &e) const override
   {
     if(e.id() == ID_infinity)

--- a/src/goto-instrument/contracts/contracts.cpp
+++ b/src/goto-instrument/contracts/contracts.cpp
@@ -213,7 +213,7 @@ void code_contractst::check_apply_loop_contracts(
 
       // If the set contains pairs (i, a[i]),
       // we widen them to (i, __CPROVER_POINTER_OBJECT(a))
-      widen_assigns(to_havoc);
+      widen_assigns(to_havoc, ns);
 
       log.debug() << "No loop assigns clause provided. Inferred targets: {";
       // Add inferred targets to the loop assigns clause.

--- a/src/goto-instrument/contracts/utils.cpp
+++ b/src/goto-instrument/contracts/utils.cpp
@@ -247,11 +247,11 @@ bool is_assigns_clause_replacement_tracking_comment(const irep_idt &comment)
          std::string::npos;
 }
 
-void widen_assigns(assignst &assigns)
+void widen_assigns(assignst &assigns, const namespacet &ns)
 {
   assignst result;
 
-  havoc_utils_is_constantt is_constant(assigns);
+  havoc_utils_is_constantt is_constant(assigns, ns);
 
   for(const auto &e : assigns)
   {

--- a/src/goto-instrument/contracts/utils.h
+++ b/src/goto-instrument/contracts/utils.h
@@ -24,7 +24,7 @@ class havoc_if_validt : public havoc_utilst
 {
 public:
   havoc_if_validt(const assignst &mod, const namespacet &ns)
-    : havoc_utilst(mod), ns(ns)
+    : havoc_utilst(mod, ns), ns(ns)
   {
   }
 
@@ -175,7 +175,7 @@ bool is_assigns_clause_replacement_tracking_comment(const irep_idt &comment);
 /// with a non-constant offset, e.g. a[i] or *(b+i) with a non-constant `i`,
 /// then replace it by the entire underlying object. Otherwise, e.g. for a[i] or
 /// *(b+i) when `i` is a known constant, keep the expression in the result.
-void widen_assigns(assignst &assigns);
+void widen_assigns(assignst &assigns, const namespacet &ns);
 
 /// This function recursively searches \p expression to find nested or
 /// non-nested quantified expressions. When a quantified expression is found,

--- a/src/goto-instrument/havoc_loops.cpp
+++ b/src/goto-instrument/havoc_loops.cpp
@@ -27,11 +27,13 @@ public:
 
   havoc_loopst(
     function_assignst &_function_assigns,
-    goto_functiont &_goto_function)
+    goto_functiont &_goto_function,
+    const namespacet &ns)
     : goto_function(_goto_function),
       local_may_alias(_goto_function),
       function_assigns(_function_assigns),
-      natural_loops(_goto_function.body)
+      natural_loops(_goto_function.body),
+      ns(ns)
   {
     havoc_loops();
   }
@@ -41,6 +43,7 @@ protected:
   local_may_aliast local_may_alias;
   function_assignst &function_assigns;
   natural_loops_mutablet natural_loops;
+  const namespacet &ns;
 
   typedef std::set<exprt> assignst;
   typedef const natural_loops_mutablet::natural_loopt loopt;
@@ -66,7 +69,7 @@ void havoc_loopst::havoc_loop(
 
   // build the havocking code
   goto_programt havoc_code;
-  havoc_utilst havoc_gen(assigns);
+  havoc_utilst havoc_gen(assigns, ns);
   havoc_gen.append_full_havoc_code(loop_head->source_location(), havoc_code);
 
   // Now havoc at the loop head. Use insert_swap to
@@ -118,5 +121,8 @@ void havoc_loops(goto_modelt &goto_model)
   function_assignst function_assigns(goto_model.goto_functions);
 
   for(auto &gf_entry : goto_model.goto_functions.function_map)
-    havoc_loopst(function_assigns, gf_entry.second);
+  {
+    havoc_loopst(
+      function_assigns, gf_entry.second, namespacet{goto_model.symbol_table});
+  }
 }

--- a/src/goto-instrument/havoc_utils.h
+++ b/src/goto-instrument/havoc_utils.h
@@ -27,7 +27,8 @@ typedef std::set<exprt> assignst;
 class havoc_utils_is_constantt : public is_constantt
 {
 public:
-  explicit havoc_utils_is_constantt(const assignst &mod) : assigns(mod)
+  explicit havoc_utils_is_constantt(const assignst &mod, const namespacet &ns)
+    : is_constantt(ns), assigns(mod)
   {
   }
 
@@ -48,7 +49,8 @@ protected:
 class havoc_utilst
 {
 public:
-  explicit havoc_utilst(const assignst &mod) : assigns(mod), is_constant(mod)
+  explicit havoc_utilst(const assignst &mod, const namespacet &ns)
+    : assigns(mod), is_constant(mod, ns)
   {
   }
 

--- a/src/goto-instrument/k_induction.cpp
+++ b/src/goto-instrument/k_induction.cpp
@@ -28,14 +28,16 @@ public:
     goto_functiont &_goto_function,
     bool _base_case,
     bool _step_case,
-    unsigned _k)
+    unsigned _k,
+    const namespacet &ns)
     : function_id(_function_id),
       goto_function(_goto_function),
       local_may_alias(_goto_function),
       natural_loops(_goto_function.body),
       base_case(_base_case),
       step_case(_step_case),
-      k(_k)
+      k(_k),
+      ns(ns)
   {
     k_induction();
   }
@@ -48,6 +50,8 @@ protected:
 
   const bool base_case, step_case;
   const unsigned k;
+
+  const namespacet &ns;
 
   void k_induction();
 
@@ -97,7 +101,7 @@ void k_inductiont::process_loop(
 
     // build the havocking code
     goto_programt havoc_code;
-    havoc_utilst havoc_gen(assigns);
+    havoc_utilst havoc_gen(assigns, ns);
     havoc_gen.append_full_havoc_code(loop_head->source_location(), havoc_code);
 
     // unwind to get k+1 copies
@@ -165,5 +169,13 @@ void k_induction(
   unsigned k)
 {
   for(auto &gf_entry : goto_model.goto_functions.function_map)
-    k_inductiont(gf_entry.first, gf_entry.second, base_case, step_case, k);
+  {
+    k_inductiont(
+      gf_entry.first,
+      gf_entry.second,
+      base_case,
+      step_case,
+      k,
+      namespacet{goto_model.symbol_table});
+  }
 }

--- a/src/goto-symex/goto_state.cpp
+++ b/src/goto-symex/goto_state.cpp
@@ -91,7 +91,7 @@ void goto_statet::apply_condition(
     if(is_ssa_expr(rhs))
       std::swap(lhs, rhs);
 
-    if(is_ssa_expr(lhs) && goto_symex_is_constantt()(rhs))
+    if(is_ssa_expr(lhs) && goto_symex_is_constantt(ns)(rhs))
     {
       const ssa_exprt &ssa_lhs = to_ssa_expr(lhs);
       INVARIANT(
@@ -141,7 +141,7 @@ void goto_statet::apply_condition(
     if(is_ssa_expr(rhs))
       std::swap(lhs, rhs);
 
-    if(!is_ssa_expr(lhs) || !goto_symex_is_constantt()(rhs))
+    if(!is_ssa_expr(lhs) || !goto_symex_is_constantt(ns)(rhs))
       return;
 
     if(rhs.is_true())

--- a/src/goto-symex/goto_symex_is_constant.h
+++ b/src/goto-symex/goto_symex_is_constant.h
@@ -17,6 +17,11 @@ Author: Michael Tautschig, tautschn@amazon.com
 
 class goto_symex_is_constantt : public is_constantt
 {
+public:
+  explicit goto_symex_is_constantt(const namespacet &ns) : is_constantt(ns)
+  {
+  }
+
 protected:
   bool is_constant(const exprt &expr) const override
   {

--- a/src/goto-symex/goto_symex_state.cpp
+++ b/src/goto-symex/goto_symex_state.cpp
@@ -110,7 +110,7 @@ renamedt<ssa_exprt, L2> goto_symex_statet::assignment(
       "pointer handling for concurrency is unsound");
 
   // Update constant propagation map -- the RHS is L2
-  if(!is_shared && record_value && goto_symex_is_constantt()(rhs))
+  if(!is_shared && record_value && goto_symex_is_constantt(ns)(rhs))
   {
     const auto propagation_entry = propagation.find(l1_identifier);
     if(!propagation_entry.has_value())

--- a/src/goto-symex/symex_goto.cpp
+++ b/src/goto-symex/symex_goto.cpp
@@ -204,7 +204,7 @@ static optionalt<renamedt<exprt, L2>> try_evaluate_pointer_comparison(
   if(!symbol_expr_lhs)
     return {};
 
-  if(!goto_symex_is_constantt()(rhs))
+  if(!goto_symex_is_constantt(ns)(rhs))
     return {};
 
   return try_evaluate_pointer_comparison(

--- a/src/util/expr_util.cpp
+++ b/src/util/expr_util.cpp
@@ -9,12 +9,14 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "expr_util.h"
 
 #include "arith_tools.h"
+#include "bitvector_expr.h"
+#include "byte_operators.h"
 #include "c_types.h"
 #include "config.h"
 #include "expr_iterator.h"
 #include "namespace.h"
 #include "pointer_expr.h"
-#include "std_expr.h"
+#include "pointer_offset_size.h"
 
 #include <algorithm>
 #include <unordered_set>
@@ -238,7 +240,6 @@ bool is_constantt::is_constant(const exprt &expr) const
     expr.id() == ID_plus || expr.id() == ID_mult || expr.id() == ID_array ||
     expr.id() == ID_with || expr.id() == ID_struct || expr.id() == ID_union ||
     expr.id() == ID_empty_union ||
-    // byte_update works, byte_extract may be out-of-bounds
     expr.id() == ID_byte_update_big_endian ||
     expr.id() == ID_byte_update_little_endian)
   {
@@ -246,6 +247,46 @@ bool is_constantt::is_constant(const exprt &expr) const
       expr.operands().begin(), expr.operands().end(), [this](const exprt &e) {
         return is_constant(e);
       });
+  }
+  else if(auto be = expr_try_dynamic_cast<byte_extract_exprt>(expr))
+  {
+    if(!is_constant(be->op()) || !be->offset().is_constant())
+      return false;
+
+    const auto op_bits = pointer_offset_bits(be->op().type(), ns);
+    if(!op_bits.has_value())
+      return false;
+
+    const auto extract_bits = pointer_offset_bits(be->type(), ns);
+    if(!extract_bits.has_value())
+      return false;
+
+    const mp_integer offset_bits =
+      numeric_cast_v<mp_integer>(to_constant_expr(be->offset())) *
+      be->get_bits_per_byte();
+
+    return offset_bits + *extract_bits <= *op_bits;
+  }
+  else if(auto eb = expr_try_dynamic_cast<extractbits_exprt>(expr))
+  {
+    if(
+      !is_constant(eb->src()) || !eb->lower().is_constant() ||
+      !eb->upper().is_constant())
+    {
+      return false;
+    }
+
+    const auto src_bits = pointer_offset_bits(eb->src().type(), ns);
+    if(!src_bits.has_value())
+      return false;
+
+    const mp_integer lower_bound =
+      numeric_cast_v<mp_integer>(to_constant_expr(eb->lower()));
+    const mp_integer upper_bound =
+      numeric_cast_v<mp_integer>(to_constant_expr(eb->upper()));
+
+    return lower_bound >= 0 && lower_bound <= upper_bound &&
+           upper_bound < src_bits;
   }
 
   return false;

--- a/src/util/expr_util.h
+++ b/src/util/expr_util.h
@@ -88,6 +88,10 @@ const exprt &skip_typecast(const exprt &expr);
 class is_constantt
 {
 public:
+  explicit is_constantt(const namespacet &ns) : ns(ns)
+  {
+  }
+
   /// returns true iff the expression can be considered constant
   bool operator()(const exprt &e) const
   {
@@ -95,6 +99,8 @@ public:
   }
 
 protected:
+  const namespacet &ns;
+
   virtual bool is_constant(const exprt &) const;
   virtual bool is_constant_address_of(const exprt &) const;
 };

--- a/unit/analyses/constant_propagator.cpp
+++ b/unit/analyses/constant_propagator.cpp
@@ -89,8 +89,8 @@ SCENARIO("constant_propagator", "[core][analyses][constant_propagator]")
       {
         const auto &final_domain = constant_propagator[test_instruction];
 
-        REQUIRE(final_domain.values.is_constant(local_x.symbol_expr()));
-        REQUIRE(final_domain.values.is_constant(local_y.symbol_expr()));
+        REQUIRE(final_domain.values.is_constant(local_x.symbol_expr(), ns));
+        REQUIRE(final_domain.values.is_constant(local_y.symbol_expr(), ns));
       }
     }
 
@@ -103,8 +103,8 @@ SCENARIO("constant_propagator", "[core][analyses][constant_propagator]")
       {
         const auto &final_domain = constant_propagator[test_instruction];
 
-        REQUIRE(final_domain.values.is_constant(local_x.symbol_expr()));
-        REQUIRE(!final_domain.values.is_constant(local_y.symbol_expr()));
+        REQUIRE(final_domain.values.is_constant(local_x.symbol_expr(), ns));
+        REQUIRE(!final_domain.values.is_constant(local_y.symbol_expr(), ns));
       }
     }
   }
@@ -181,8 +181,9 @@ SCENARIO("constant_propagator", "[core][analyses][constant_propagator]")
       {
         const auto &final_domain = constant_propagator[test_instruction];
 
-        REQUIRE(final_domain.values.is_constant(bool_local.symbol_expr()));
-        REQUIRE(final_domain.values.is_constant(c_bool_local.symbol_expr()));
+        REQUIRE(final_domain.values.is_constant(bool_local.symbol_expr(), ns));
+        REQUIRE(
+          final_domain.values.is_constant(c_bool_local.symbol_expr(), ns));
       }
     }
   }
@@ -332,7 +333,7 @@ SCENARIO("constant_propagator", "[core][analyses][constant_propagator]")
         {
           exprt bool_local = bool_locals[i].symbol_expr();
 
-          REQUIRE(final_domain.values.is_constant(bool_local));
+          REQUIRE(final_domain.values.is_constant(bool_local, ns));
 
           final_domain.values.replace_const.replace(bool_local);
 
@@ -349,7 +350,7 @@ SCENARIO("constant_propagator", "[core][analyses][constant_propagator]")
         {
           exprt c_bool_local = c_bool_locals[i].symbol_expr();
 
-          REQUIRE(final_domain.values.is_constant(c_bool_local));
+          REQUIRE(final_domain.values.is_constant(c_bool_local, ns));
 
           final_domain.values.replace_const.replace(c_bool_local);
 

--- a/unit/goto-symex/is_constant.cpp
+++ b/unit/goto-symex/is_constant.cpp
@@ -6,21 +6,25 @@ Author: Diffblue Ltd.
 
 \*******************************************************************/
 
-#include <testing-utils/use_catch.h>
+#include <util/bitvector_types.h>
+#include <util/namespace.h>
+#include <util/std_expr.h>
+#include <util/symbol_table.h>
 
 #include <goto-symex/goto_symex_is_constant.h>
-
-#include <util/bitvector_types.h>
-#include <util/std_expr.h>
+#include <testing-utils/use_catch.h>
 
 SCENARIO("goto-symex-is-constant", "[core][goto-symex][is_constant]")
 {
+  symbol_tablet symbol_table;
+  namespacet ns{symbol_table};
+
   signedbv_typet int_type(32);
   constant_exprt sizeof_constant("4", int_type);
   sizeof_constant.set(ID_C_c_sizeof_type, int_type);
   symbol_exprt non_constant("x", int_type);
 
-  goto_symex_is_constantt is_constant;
+  goto_symex_is_constantt is_constant(ns);
 
   GIVEN("Sizeof expression multiplied by a non-constant")
   {


### PR DESCRIPTION
When all operands are constants and the extract is fully within bounds of the source object then the result is constant.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
