### PR TITLE
SMT2 parser: implement to_fp_unsigned

### DIFF
--- a/regression/cbmc/Float-no-simp2/test.desc
+++ b/regression/cbmc/Float-no-simp2/test.desc
@@ -1,4 +1,4 @@
-CORE broken-cprover-smt-backend
+CORE
 main.c
 --floatbv --no-simplify
 ^EXIT=0$

--- a/regression/cbmc/Float-to-int1/test.desc
+++ b/regression/cbmc/Float-to-int1/test.desc
@@ -1,4 +1,4 @@
-CORE broken-smt-backend
+CORE broken-z3-smt-backend
 main.c
 --floatbv
 ^EXIT=0$

--- a/regression/cbmc/Float-to-int2/test.desc
+++ b/regression/cbmc/Float-to-int2/test.desc
@@ -1,4 +1,4 @@
-CORE broken-smt-backend
+CORE
 main.c
 --floatbv
 ^EXIT=0$

--- a/regression/cbmc/Float-to-int3/test.desc
+++ b/regression/cbmc/Float-to-int3/test.desc
@@ -1,4 +1,4 @@
-CORE broken-smt-backend
+CORE broken-z3-smt-backend
 main.c
 --floatbv
 ^EXIT=0$

--- a/regression/cbmc/Float12/test.desc
+++ b/regression/cbmc/Float12/test.desc
@@ -1,4 +1,4 @@
-CORE broken-cprover-smt-backend
+CORE
 main.c
 
 ^EXIT=0$

--- a/src/solvers/smt2/smt2_parser.cpp
+++ b/src/solvers/smt2/smt2_parser.cpp
@@ -1305,6 +1305,18 @@ void smt2_parsert::setup_expressions()
     return isnormal_exprt(op[0]);
   };
 
+  expressions["fp.isZero"] = [this] {
+    auto op = operands();
+
+    if(op.size() != 1)
+      throw error("fp.isZero takes one operand");
+
+    if(op[0].type().id() != ID_floatbv)
+      throw error("fp.isZero takes FloatingPoint operand");
+
+    return not_exprt(typecast_exprt(op[0], bool_typet()));
+  };
+
   expressions["fp"] = [this] { return function_application_fp(operands()); };
 
   expressions["fp.add"] = [this] {

--- a/src/solvers/smt2/smt2_parser.cpp
+++ b/src/solvers/smt2/smt2_parser.cpp
@@ -800,6 +800,42 @@ exprt smt2_parsert::function_application()
           else
             throw error() << "unexpected sort given as operand to to_fp";
         }
+        else if(id == "to_fp_unsigned")
+        {
+          if(next_token() != smt2_tokenizert::NUMERAL)
+            throw error("expected number after to_fp_unsigned");
+
+          auto width_e = std::stoll(smt2_tokenizer.get_buffer());
+
+          if(next_token() != smt2_tokenizert::NUMERAL)
+            throw error("expected second number after to_fp_unsigned");
+
+          auto width_f = std::stoll(smt2_tokenizer.get_buffer());
+
+          if(next_token() != smt2_tokenizert::CLOSE)
+            throw error("expected ')' after to_fp_unsigned");
+
+          // width_f *includes* the hidden bit
+          const ieee_float_spect spec(width_f - 1, width_e);
+
+          auto rounding_mode = expression();
+
+          auto source_op = expression();
+
+          if(next_token() != smt2_tokenizert::CLOSE)
+            throw error("expected ')' at the end of to_fp_unsigned");
+
+          if(source_op.type().id() == ID_unsignedbv)
+          {
+            // The operand is hard-wired to be interpreted
+            // as an unsigned number.
+            return floatbv_typecast_exprt(
+              source_op, rounding_mode, spec.to_type());
+          }
+          else
+            throw error()
+              << "unexpected sort given as operand to to_fp_unsigned";
+        }
         else
         {
           throw error() << "unknown indexed identifier '"

--- a/src/solvers/smt2/smt2_parser.cpp
+++ b/src/solvers/smt2/smt2_parser.cpp
@@ -836,6 +836,33 @@ exprt smt2_parsert::function_application()
             throw error()
               << "unexpected sort given as operand to to_fp_unsigned";
         }
+        else if(id == "fp.to_sbv" || id == "fp.to_ubv")
+        {
+          // These are indexed by the number of bits of the result.
+          if(next_token() != smt2_tokenizert::NUMERAL)
+            throw error() << "expected number after " << id;
+
+          auto width = std::stoll(smt2_tokenizer.get_buffer());
+
+          if(next_token() != smt2_tokenizert::CLOSE)
+            throw error() << "expected ')' after " << id;
+
+          auto op = operands();
+
+          if(op.size() != 2)
+            throw error() << id << " takes two operands";
+
+          if(op[1].type().id() != ID_floatbv)
+            throw error() << id << " takes a FloatingPoint operand";
+
+          if(id == "fp.to_sbv")
+            return typecast_exprt(
+              floatbv_typecast_exprt(op[1], op[0], signedbv_typet(width)),
+              unsignedbv_typet(width));
+          else
+            return floatbv_typecast_exprt(
+              op[1], op[0], unsignedbv_typet(width));
+        }
         else
         {
           throw error() << "unknown indexed identifier '"


### PR DESCRIPTION
This adds an implementation of to_fp_unsigned to the SMT2 parser.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [X] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
