### PR TITLE
CHC solver: add constraint to verbose output

### DIFF
--- a/src/cprover/propagate.cpp
+++ b/src/cprover/propagate.cpp
@@ -43,6 +43,15 @@ void propagate(
 
   for(const auto &implication : f.implications)
   {
+    if(verbose)
+    {
+      std::cout << consolet::green;
+      std::cout << 'C' << consolet::faint << std::setw(2) << work.frame.index
+                << consolet::reset << ' ';
+      std::cout << consolet::green << format(implication.as_expr());
+      std::cout << consolet::reset << '\n';
+    }
+
     auto &next_state = implication.rhs.arguments().front();
     auto lambda_expr = lambda_exprt({state_expr()}, work.invariant);
     auto instance = lambda_expr.instantiate({next_state});


### PR DESCRIPTION
The verbose output now includes the constraint that is used when propagating a candidate invariant.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
