### PR TITLE
SMT2: fix pointer arithmetic

### DIFF
--- a/regression/cbmc/Pointer24/test.desc
+++ b/regression/cbmc/Pointer24/test.desc
@@ -1,4 +1,4 @@
-CORE broken-smt-backend
+CORE
 main.c
 --pointer-check
 ^EXIT=0$

--- a/regression/cbmc/pointer-overflow3/no-simplify.desc
+++ b/regression/cbmc/pointer-overflow3/no-simplify.desc
@@ -1,4 +1,4 @@
-CORE broken-smt-backend
+CORE
 main.c
 --pointer-overflow-check --no-simplify
 ^\[main.pointer_arithmetic.\d+\] line 6 pointer arithmetic: pointer outside object bounds in p \+ \(signed (long (long )?)?int\)10: FAILURE

--- a/src/solvers/smt2/smt2_conv.cpp
+++ b/src/solvers/smt2/smt2_conv.cpp
@@ -3645,21 +3645,35 @@ void smt2_convt::convert_plus(const plus_exprt &expr)
         element_size = *element_size_opt;
       }
 
-      out << "(bvadd ";
+      // First convert the pointer operand
+      out << "(let ((?pointerop ";
       convert_expr(p);
-      out << " ";
+      out << ")) ";
+
+      // The addition is done on the offset part only.
+      const std::size_t pointer_width = boolbv_width(p.type());
+      const std::size_t offset_bits =
+        pointer_width - config.bv_encoding.object_bits;
+
+      out << "(concat ";
+      out << "((_ extract " << pointer_width - 1 << ' ' << offset_bits
+          << ") ?pointerop) ";
+      out << "(bvadd ((_ extract " << offset_bits - 1 << " 0) ?pointerop) ";
 
       if(element_size >= 2)
       {
-        out << "(bvmul ";
+        out << "(bvmul ((_ extract " << offset_bits - 1 << " 0) ";
         convert_expr(i);
-        out << " (_ bv" << element_size << " " << boolbv_width(expr.type())
-            << "))";
+        out << ") (_ bv" << element_size << " " << offset_bits << "))";
       }
       else
+      {
+        out << "((_ extract " << offset_bits - 1 << " 0) ";
         convert_expr(i);
+        out << ')'; // extract
+      }
 
-      out << ')';
+      out << ")))"; // bvadd, concat, let
     }
     else
     {


### PR DESCRIPTION
This fixes the encoding of pointer arithmetic in the SMT2 backend.  Addition now no longer overflows from the offset into the object part.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [X] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
