### PR TITLE
Value sets: handle extractbits out of pointers

### DIFF
--- a/src/pointer-analysis/value_set.cpp
+++ b/src/pointer-analysis/value_set.cpp
@@ -12,6 +12,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "value_set.h"
 
 #include <util/arith_tools.h>
+#include <util/bitvector_expr.h>
 #include <util/byte_operators.h>
 #include <util/c_types.h>
 #include <util/expr_util.h>
@@ -589,8 +590,9 @@ void value_sett::get_value_set_rec(
       // pointer-to-pointer -- we just ignore these
       get_value_set_rec(op, dest, suffix, original_type, ns);
     }
-    else if(op_type.id()==ID_unsignedbv ||
-            op_type.id()==ID_signedbv)
+    else if(
+      op_type.id() == ID_unsignedbv || op_type.id() == ID_signedbv ||
+      op_type.id() == ID_bv)
     {
       // integer-to-pointer
 
@@ -1051,6 +1053,21 @@ void value_sett::get_value_set_rec(
 
     value_set_with_local_definition.get_value_set_rec(
       let_expr.where(), dest, suffix, original_type, ns);
+  }
+  else if(auto eb = expr_try_dynamic_cast<extractbits_exprt>(expr))
+  {
+    object_mapt pointer_expr_set;
+    get_value_set_rec(eb->src(), pointer_expr_set, "", eb->src().type(), ns);
+
+    for(const auto &object_map_entry : pointer_expr_set.read())
+    {
+      offsett offset = object_map_entry.second;
+
+      // kill any offset
+      offset.reset();
+
+      insert(dest, object_map_entry.first, offset);
+    }
   }
   else
   {

--- a/src/pointer-analysis/value_set.cpp
+++ b/src/pointer-analysis/value_set.cpp
@@ -1071,7 +1071,22 @@ void value_sett::get_value_set_rec(
   }
   else
   {
-    insert(dest, exprt(ID_unknown, original_type));
+    object_mapt pointer_expr_set;
+    for(const auto &op : expr.operands())
+      get_value_set_rec(op, pointer_expr_set, "", original_type, ns);
+
+    for(const auto &object_map_entry : pointer_expr_set.read())
+    {
+      offsett offset = object_map_entry.second;
+
+      // kill any offset
+      offset.reset();
+
+      insert(dest, object_map_entry.first, offset);
+    }
+
+    if(pointer_expr_set.read().empty())
+      insert(dest, exprt(ID_unknown, original_type));
   }
 
   #ifdef DEBUG


### PR DESCRIPTION
Tracking will not be precise, but we should not lose pointers that are split up via extractbits and later on pieced together.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
