### PR TITLE
Simplify byte extract: use lowering when expression is a constant

### DIFF
--- a/regression/cbmc-library/memcpy-01/constant-propagation.desc
+++ b/regression/cbmc-library/memcpy-01/constant-propagation.desc
@@ -1,7 +1,7 @@
 CORE
 main.c
---show-vcc
-main::1::m!0@1#2 = .*byte_extract_(big|little)_endian\(cast\(44, signedbv\[\d+\]\*\), 0, signedbv\[\d+\]\).*
+
+^Generated 1\d* VCC\(s\), 0 remaining after simplification$
 ^EXIT=0$
 ^SIGNAL=0$
 --

--- a/src/util/simplify_expr.cpp
+++ b/src/util/simplify_expr.cpp
@@ -1976,10 +1976,13 @@ simplify_exprt::simplify_byte_extract(const byte_extract_exprt &expr)
   // try to refine it down to extracting from a member or an index in an array
   auto subexpr =
     get_subexpression_at_offset(expr.op(), *offset, expr.type(), ns);
-  if(!subexpr.has_value() || subexpr.value() == expr)
-    return unchanged(expr);
+  if(subexpr.has_value() && subexpr.value() != expr)
+    return changed(simplify_rec(subexpr.value())); // recursive call
 
-  return changed(simplify_rec(subexpr.value())); // recursive call
+  if(is_constantt(ns)(expr))
+    return changed(simplify_rec(lower_byte_extract(expr, ns)));
+
+  return unchanged(expr);
 }
 
 simplify_exprt::resultt<>

--- a/src/util/simplify_expr_int.cpp
+++ b/src/util/simplify_expr_int.cpp
@@ -906,7 +906,14 @@ simplify_exprt::simplify_concatenation(const concatenation_exprt &expr)
             .set_width(
               to_bitvector_type(eb_i.type()).get_width() +
               to_bitvector_type(eb_n.type()).get_width());
-          opi = eb_merged;
+          if(expr.type().id() != eb_merged.type().id())
+          {
+            bitvector_typet bt = to_bitvector_type(expr.type());
+            bt.set_width(to_bitvector_type(eb_merged.type()).get_width());
+            opi = simplify_typecast(typecast_exprt{eb_merged, bt});
+          }
+          else
+            opi = eb_merged;
           // erase opn
           new_expr.operands().erase(new_expr.operands().begin() + i + 1);
           no_change = false;


### PR DESCRIPTION
When none of the earlier simplification rules apply, rewrite the expression to to apply simplification rules for arithmetic and logic expressions.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
