### PR TITLE
Simplify typecast over ID_bv and pointers

### DIFF
--- a/src/util/simplify_expr.cpp
+++ b/src/util/simplify_expr.cpp
@@ -779,7 +779,8 @@ simplify_exprt::simplify_typecast(const typecast_exprt &expr)
   // (void*)(intX)expr -> (void*)expr
   if(
     expr_type.id() == ID_pointer && expr.op().id() == ID_typecast &&
-    (op_type.id() == ID_signedbv || op_type.id() == ID_unsignedbv) &&
+    (op_type.id() == ID_signedbv || op_type.id() == ID_unsignedbv ||
+     op_type.id() == ID_bv) &&
     to_bitvector_type(op_type).get_width() >=
       to_bitvector_type(expr_type).get_width())
   {
@@ -1305,7 +1306,8 @@ simplify_exprt::simplify_typecast(const typecast_exprt &expr)
     // where T1 has fewer bits than T2
     if(
       op_type_id == expr_type_id &&
-      (expr_type_id == ID_unsignedbv || expr_type_id == ID_signedbv) &&
+      (expr_type_id == ID_unsignedbv || expr_type_id == ID_signedbv ||
+       expr_type_id == ID_bv) &&
       to_bitvector_type(expr_type).get_width() <=
         to_bitvector_type(operand.type()).get_width())
     {


### PR DESCRIPTION
This has the same semantics as ID_signedbv or ID_unsignedbv.

There is no hard dependency on https://github.com/diffblue/cbmc/pull/7343, but the code might not be exercised without those changes.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
