### PR TITLE
SMT2 backend: implement saturating arithmetic

### DIFF
--- a/regression/cbmc/saturating_arithmetric/test.desc
+++ b/regression/cbmc/saturating_arithmetric/test.desc
@@ -1,4 +1,4 @@
-CORE broken-smt-backend
+CORE
 main.c
 
 ^EXIT=0$

--- a/src/solvers/smt2/smt2_conv.cpp
+++ b/src/solvers/smt2/smt2_conv.cpp
@@ -2209,6 +2209,81 @@ void smt2_convt::convert_expr(const exprt &expr)
         "overflow check should not be performed on unsupported type",
         op_type.id_string());
   }
+  else if(expr.id() == ID_saturating_plus || expr.id() == ID_saturating_minus)
+  {
+    const bool subtract = expr.id() == ID_saturating_minus;
+    const auto &op_type = expr.type();
+    const auto &op0 = to_binary_expr(expr).op0();
+    const auto &op1 = to_binary_expr(expr).op1();
+
+    if(op_type.id() == ID_signedbv)
+    {
+      auto width = to_signedbv_type(op_type).get_width();
+
+      // compute sum with one extra bit
+      out << "(let ((?sum (";
+      out << (subtract ? "bvsub" : "bvadd");
+      out << " ((_ sign_extend 1) ";
+      convert_expr(op0);
+      out << ")";
+      out << " ((_ sign_extend 1) ";
+      convert_expr(op1);
+      out << ")))) "; // sign_extend, bvadd/sub
+
+      // pick one of MAX, MIN, or the sum
+      out << "(ite (= "
+             "((_ extract "
+          << width << " " << width
+          << ") ?sum) "
+             "((_ extract "
+          << (width - 1) << " " << (width - 1) << ") ?sum)";
+      out << ") "; // =
+
+      // no overflow and no underflow case, return the sum
+      out << "((_ extract " << width - 1 << " 0) ?sum) ";
+
+      // MAX
+      out << "(ite (= ((_ extract " << width << " " << width << ") ?sum) #b0) ";
+      convert_expr(to_signedbv_type(op_type).largest_expr());
+
+      // MIN
+      convert_expr(to_signedbv_type(op_type).smallest_expr());
+      out << ")))"; // ite, ite, let
+    }
+    else if(op_type.id() == ID_unsignedbv)
+    {
+      auto width = to_unsignedbv_type(op_type).get_width();
+
+      // compute sum with one extra bit
+      out << "(let ((?sum (" << (subtract ? "bvsub" : "bvadd");
+      out << " ((_ zero_extend 1) ";
+      convert_expr(op0);
+      out << ")";
+      out << " ((_ zero_extend 1) ";
+      convert_expr(op1);
+      out << "))))"; // zero_extend, bvsub/bvadd
+
+      // pick one of MAX, MIN, or the sum
+      out << "(ite (= ((_ extract " << width << " " << width << ") ?sum) #b0) ";
+
+      // no overflow and no underflow case, return the sum
+      out << " ((_ extract " << width - 1 << " 0) ?sum) ";
+
+      // overflow when adding, underflow when subtracting
+      if(subtract)
+        convert_expr(to_unsignedbv_type(op_type).smallest_expr());
+      else
+        convert_expr(to_unsignedbv_type(op_type).largest_expr());
+
+      // MIN
+      out << "))"; // ite, let
+    }
+    else
+      INVARIANT_WITH_DIAGNOSTICS(
+        false,
+        "saturating_plus/minus on unsupported type",
+        op_type.id_string());
+  }
   else if(expr.id()==ID_array)
   {
     defined_expressionst::const_iterator it=defined_expressions.find(expr);


### PR DESCRIPTION
This adds support for saturating addition and subtraction to the SMT2 backend.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [X] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
