### PR TITLE
Byte-operator lowering: struct and union constants are not ID_constant

### DIFF
--- a/src/util/simplify_expr_struct.cpp
+++ b/src/util/simplify_expr_struct.cpp
@@ -104,21 +104,20 @@ simplify_exprt::simplify_member(const member_exprt &expr)
       }
     }
   }
-  else if(op.id()==ID_struct ||
-          op.id()==ID_constant)
+  else if(op.id() == ID_struct)
   {
-    if(op_type.id()==ID_struct)
+    // pull out the right member
+    const struct_typet &struct_type = to_struct_type(op_type);
+    if(struct_type.has_component(component_name))
     {
-      // pull out the right member
-      const struct_typet &struct_type=to_struct_type(op_type);
-      if(struct_type.has_component(component_name))
-      {
-        std::size_t number=struct_type.component_number(component_name);
-        DATA_INVARIANT(
-          op.operands()[number].type() == expr.type(),
-          "member expression type must match component type");
-        return op.operands()[number];
-      }
+      std::size_t number = struct_type.component_number(component_name);
+      DATA_INVARIANT(
+        op.operands().size() > number,
+        "struct expression must have sufficiently many operands");
+      DATA_INVARIANT(
+        op.operands()[number].type() == expr.type(),
+        "member expression type must match component type");
+      return op.operands()[number];
     }
   }
   else if(op.id()==ID_byte_extract_little_endian ||


### PR DESCRIPTION
These are struct- and union expressions, or possible empty_union_exprt. Creating constant_exprt resulted in a segmentation fault in simplifying member expressions, as witnessed when working on
https://github.com/model-checking/kani/issues/705.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
