### PR TITLE
Only add assumption scope if not empty

### DIFF
--- a/src/goto-programs/graphml_witness.cpp
+++ b/src/goto-programs/graphml_witness.cpp
@@ -476,15 +476,18 @@ void graphml_witnesst::operator()(const goto_tracet &goto_trace)
           code_assignt assign{it->full_lhs, it->full_lhs_value};
           val.data = convert_assign_rec(lhs_id, assign);
 
-          xmlt &val_s = edge.new_element("data");
-          val_s.set_attribute("key", "assumption.scope");
-          irep_idt function_id = it->function_id;
-          const symbolt *symbol_ptr = nullptr;
-          if(!ns.lookup(lhs_id, symbol_ptr) && symbol_ptr->is_parameter)
+          if(!it->function_id.empty())
           {
-            function_id = lhs_id.substr(0, lhs_id.find("::"));
+            xmlt &val_s = edge.new_element("data");
+            val_s.set_attribute("key", "assumption.scope");
+            irep_idt function_id = it->function_id;
+            const symbolt *symbol_ptr = nullptr;
+            if(!ns.lookup(lhs_id, symbol_ptr) && symbol_ptr->is_parameter)
+            {
+              function_id = lhs_id.substr(0, lhs_id.find("::"));
+            }
+            val_s.data = id2string(function_id);
           }
-          val_s.data = id2string(function_id);
 
           if(has_prefix(val.data, "\\result ="))
           {


### PR DESCRIPTION
The GOTO trace may contain instructions from the global scope (e.g. assigning a value to a global variable). In such case, the scope should be global, i.e. no assumption.scope as per the witness specification.

I found this issue during 2LS SV-comp preruns due to witnesslint failing on a singular `assumption.scope` data tag. There is no scope on global variable definitions, therefore the scope should not be added.

@peterschrammel this should later be cherry-picked to 2LS's fork

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [x] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message). [Sorry, I am not very familiar with the code base and don't really know how to test changes around witnesses]
- [x] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.