### PR TITLE
Byte-extract lowering: extracting zero-width struct members is fine

### DIFF
--- a/regression/cbmc-library/memcpy-09/main.c
+++ b/regression/cbmc-library/memcpy-09/main.c
@@ -1,0 +1,37 @@
+#include <assert.h>
+#include <string.h>
+
+union _5557197549936569444_union
+{
+};
+
+struct _5557197549936569444
+{
+  // _case
+  unsigned char _case;
+  // cases -- this member makes all the difference
+  union _5557197549936569444_union cases;
+};
+
+struct _3036371764910125196
+{
+  // t
+  struct _5557197549936569444 t;
+  // array
+  unsigned char array[8l];
+};
+
+void main(void)
+{
+  struct _3036371764910125196 data = {.t = {._case = 0}, .array = {0}};
+  unsigned long int index;
+  if(index < 2)
+  {
+    unsigned char array[4] = {0, 0, 0, 0};
+    unsigned long start = index * 4ul;
+    unsigned long end = start + 4ul;
+
+    memcpy((unsigned char *)&data.array + start, array, end - start);
+    assert(data.t._case == 0);
+  }
+}

--- a/regression/cbmc-library/memcpy-09/test.desc
+++ b/regression/cbmc-library/memcpy-09/test.desc
@@ -1,0 +1,12 @@
+CORE
+main.c
+
+^VERIFICATION SUCCESSFUL$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--
+memcpy of objects with zero-width fields at a non-constant offset and with a
+non-constant copy width must not result in spurious verification failures.
+Example constructed from https://github.com/model-checking/kani/issues/1911.

--- a/src/util/lower_byte_operators.cpp
+++ b/src/util/lower_byte_operators.cpp
@@ -1286,7 +1286,7 @@ exprt lower_byte_extract(const byte_extract_exprt &src, const namespacet &ns)
 
       // the next member would be misaligned, abort
       if(
-        !component_bits.has_value() || *component_bits == 0 ||
+        !component_bits.has_value() ||
         *component_bits % src.get_bits_per_byte() != 0)
       {
         failed = true;
@@ -1992,7 +1992,7 @@ static exprt lower_byte_update_struct(
     else if(!offset_bytes.has_value())
     {
       // The offset to update is not constant; abort the attempt to update
-      // indiviual struct members and instead turn the operand-to-be-updated
+      // individual struct members and instead turn the operand-to-be-updated
       // into a byte array, which we know how to update even if the offset is
       // non-constant.
       auto src_size_opt = size_of_expr(src.type(), ns);


### PR DESCRIPTION
We can safely handle the case of extracting zero bits, and shouldn't fall back to a code path that would result in invalid typecast operations.

Also fix a typo in a comment on the affected code path.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
