### PR TITLE
Remove an unused constructor from the interface of abstract_objectt

### DIFF
--- a/src/analyses/variable-sensitivity/abstract_aggregate_object.h
+++ b/src/analyses/variable-sensitivity/abstract_aggregate_object.h
@@ -30,12 +30,6 @@ class abstract_aggregate_objectt : public abstract_objectt,
                                    public abstract_aggregate_tag
 {
 public:
-  explicit abstract_aggregate_objectt(const typet &type)
-    : abstract_objectt(type)
-  {
-    PRECONDITION(type.id() == aggregate_traitst::TYPE_ID());
-  }
-
   abstract_aggregate_objectt(const typet &type, bool tp, bool bttm)
     : abstract_objectt(type, tp, bttm)
   {

--- a/src/analyses/variable-sensitivity/abstract_object.cpp
+++ b/src/analyses/variable-sensitivity/abstract_object.cpp
@@ -16,11 +16,6 @@
 
 #include "abstract_object.h"
 
-abstract_objectt::abstract_objectt(const typet &type)
-  : t(type), bottom(false), top(true)
-{
-}
-
 abstract_objectt::abstract_objectt(const typet &type, bool top, bool bottom)
   : t(type), bottom(bottom), top(top)
 {
@@ -32,15 +27,6 @@ abstract_objectt::abstract_objectt(
   const abstract_environmentt &environment,
   const namespacet &ns)
   : t(expr.type()), bottom(false), top(true)
-{
-}
-
-abstract_objectt::abstract_objectt(
-  const typet &type,
-  const exprt &expr,
-  const abstract_environmentt &environment,
-  const namespacet &ns)
-  : t(type), bottom(false), top(true)
 {
 }
 

--- a/src/analyses/variable-sensitivity/abstract_object.h
+++ b/src/analyses/variable-sensitivity/abstract_object.h
@@ -72,9 +72,6 @@ using abstract_object_visitedt = std::set<abstract_object_pointert>;
 class abstract_objectt : public std::enable_shared_from_this<abstract_objectt>
 {
 public:
-  /// \param type: the type the abstract_object is representing
-  explicit abstract_objectt(const typet &type);
-
   /// Start the abstract object at either top or bottom or neither
   /// Asserts if both top and bottom are true
   ///
@@ -91,19 +88,6 @@ public:
   ///   being created in
   /// \param ns: The namespace
   abstract_objectt(
-    const exprt &expr,
-    const abstract_environmentt &environment,
-    const namespacet &ns);
-
-  /// Ctor for building object of types that differ from the types of input
-  /// expressions
-  ///
-  /// \param type explicitly declared type the resulting object should have
-  /// \param expr expression used to build the object
-  /// \param environment abstract environment to evaluate the expression
-  /// \param ns namespace to uncover names inside the expression
-  abstract_objectt(
-    const typet &type,
     const exprt &expr,
     const abstract_environmentt &environment,
     const namespacet &ns);

--- a/src/analyses/variable-sensitivity/abstract_pointer_object.cpp
+++ b/src/analyses/variable-sensitivity/abstract_pointer_object.cpp
@@ -13,12 +13,6 @@
 
 #include "abstract_object_statistics.h"
 
-abstract_pointer_objectt::abstract_pointer_objectt(const typet &t)
-  : abstract_objectt(t)
-{
-  PRECONDITION(t.id() == ID_pointer);
-}
-
 abstract_pointer_objectt::abstract_pointer_objectt(
   const typet &type,
   bool top,

--- a/src/analyses/variable-sensitivity/abstract_pointer_object.h
+++ b/src/analyses/variable-sensitivity/abstract_pointer_object.h
@@ -21,9 +21,6 @@ class abstract_pointer_objectt : public abstract_objectt,
                                  public abstract_pointer_tag
 {
 public:
-  /// \param type: the type the abstract_object is representing
-  explicit abstract_pointer_objectt(const typet &type);
-
   /// Start the abstract object at either top or bottom or neither
   /// Asserts if both top and bottom are true
   ///

--- a/src/analyses/variable-sensitivity/abstract_value_object.h
+++ b/src/analyses/variable-sensitivity/abstract_value_object.h
@@ -240,10 +240,6 @@ class abstract_value_objectt : public abstract_objectt,
                                public abstract_value_tag
 {
 public:
-  explicit abstract_value_objectt(const typet &type) : abstract_objectt(type)
-  {
-  }
-
   abstract_value_objectt(const typet &type, bool tp, bool bttm)
     : abstract_objectt(type, tp, bttm)
   {

--- a/src/analyses/variable-sensitivity/constant_abstract_value.cpp
+++ b/src/analyses/variable-sensitivity/constant_abstract_value.cpp
@@ -37,11 +37,6 @@ make_constant_index_range(const exprt &val)
   return util_make_unique<constant_index_ranget>(val);
 }
 
-constant_abstract_valuet::constant_abstract_valuet(const typet &t)
-  : abstract_value_objectt(t), value()
-{
-}
-
 constant_abstract_valuet::constant_abstract_valuet(const exprt &e)
   : abstract_value_objectt(e.type(), false, false), value(e)
 {

--- a/src/analyses/variable-sensitivity/constant_abstract_value.h
+++ b/src/analyses/variable-sensitivity/constant_abstract_value.h
@@ -19,7 +19,6 @@
 class constant_abstract_valuet : public abstract_value_objectt
 {
 public:
-  explicit constant_abstract_valuet(const typet &t);
   explicit constant_abstract_valuet(const exprt &t);
   constant_abstract_valuet(const typet &t, bool tp, bool bttm);
   constant_abstract_valuet(

--- a/src/analyses/variable-sensitivity/constant_pointer_abstract_object.cpp
+++ b/src/analyses/variable-sensitivity/constant_pointer_abstract_object.cpp
@@ -21,13 +21,6 @@
 #include <ostream>
 
 constant_pointer_abstract_objectt::constant_pointer_abstract_objectt(
-  const typet &type)
-  : abstract_pointer_objectt(type)
-{
-  PRECONDITION(type.id() == ID_pointer);
-}
-
-constant_pointer_abstract_objectt::constant_pointer_abstract_objectt(
   const typet &type,
   bool top,
   bool bottom)

--- a/src/analyses/variable-sensitivity/constant_pointer_abstract_object.h
+++ b/src/analyses/variable-sensitivity/constant_pointer_abstract_object.h
@@ -24,9 +24,6 @@ private:
 
 public:
   /// \param type: the type the abstract_object is representing
-  explicit constant_pointer_abstract_objectt(const typet &type);
-
-  /// \param type: the type the abstract_object is representing
   /// \param top: is the abstract_object starting as top
   /// \param bottom: is the abstract_object starting as bottom
   ///

--- a/src/analyses/variable-sensitivity/context_abstract_object.h
+++ b/src/analyses/variable-sensitivity/context_abstract_object.h
@@ -23,14 +23,6 @@ class context_abstract_objectt : public abstract_objectt
 public:
   // These constructors mirror those in the base abstract_objectt, but with
   // the addition of an extra argument which is the abstract_objectt to wrap.
-  explicit context_abstract_objectt(
-    const abstract_object_pointert child,
-    const typet &type)
-    : abstract_objectt(type)
-  {
-    child_abstract_object = child;
-  }
-
   context_abstract_objectt(
     const abstract_object_pointert child,
     const typet &type,

--- a/src/analyses/variable-sensitivity/data_dependency_context.h
+++ b/src/analyses/variable-sensitivity/data_dependency_context.h
@@ -21,13 +21,6 @@ class data_dependency_contextt : public write_location_contextt
 public:
   // These constructors mirror those in the base abstract_objectt, but with
   // the addition of an extra argument which is the abstract_objectt to wrap.
-  explicit data_dependency_contextt(
-    const abstract_object_pointert child,
-    const typet &type)
-    : write_location_contextt(child, type)
-  {
-  }
-
   data_dependency_contextt(
     const abstract_object_pointert child,
     const typet &type,

--- a/src/analyses/variable-sensitivity/full_array_abstract_object.cpp
+++ b/src/analyses/variable-sensitivity/full_array_abstract_object.cpp
@@ -64,12 +64,6 @@ abstract_object_pointert apply_to_index_range(
   return result;
 }
 
-full_array_abstract_objectt::full_array_abstract_objectt(typet type)
-  : abstract_aggregate_baset(type)
-{
-  DATA_INVARIANT(verify(), "Structural invariants maintained");
-}
-
 full_array_abstract_objectt::full_array_abstract_objectt(
   typet type,
   bool top,

--- a/src/analyses/variable-sensitivity/full_array_abstract_object.h
+++ b/src/analyses/variable-sensitivity/full_array_abstract_object.h
@@ -29,9 +29,6 @@ public:
     array_aggregate_typet>
     abstract_aggregate_baset;
 
-  /// \param type: the type the abstract_object is representing
-  explicit full_array_abstract_objectt(typet type);
-
   /// Start the abstract object at either top or bottom or neither
   /// Asserts if both top and bottom are true
   ///

--- a/src/analyses/variable-sensitivity/full_struct_abstract_object.cpp
+++ b/src/analyses/variable-sensitivity/full_struct_abstract_object.cpp
@@ -27,13 +27,6 @@ full_struct_abstract_objectt::full_struct_abstract_objectt(
 {
 }
 
-full_struct_abstract_objectt::full_struct_abstract_objectt(const typet &t)
-  : abstract_aggregate_baset(t)
-{
-  PRECONDITION(t.id() == ID_struct);
-  DATA_INVARIANT(verify(), "Structural invariants maintained");
-}
-
 full_struct_abstract_objectt::full_struct_abstract_objectt(
   const typet &t,
   bool top,

--- a/src/analyses/variable-sensitivity/full_struct_abstract_object.h
+++ b/src/analyses/variable-sensitivity/full_struct_abstract_object.h
@@ -33,9 +33,6 @@ public:
    */
   full_struct_abstract_objectt(const full_struct_abstract_objectt &ao);
 
-  /// \param type: the type the abstract_object is representing
-  explicit full_struct_abstract_objectt(const typet &type);
-
   /// Start the abstract object at either top or bottom or
   /// neither asserts if both top and bottom are true
   ///

--- a/src/analyses/variable-sensitivity/interval_abstract_value.cpp
+++ b/src/analyses/variable-sensitivity/interval_abstract_value.cpp
@@ -224,11 +224,6 @@ static inline constant_interval_exprt interval_from_relation(const exprt &e)
     the_constant_part_of_the_relation, the_constant_part_of_the_relation);
 }
 
-interval_abstract_valuet::interval_abstract_valuet(const typet &t)
-  : abstract_value_objectt(t), interval(t)
-{
-}
-
 interval_abstract_valuet::interval_abstract_valuet(
   const typet &t,
   bool tp,

--- a/src/analyses/variable-sensitivity/interval_abstract_value.h
+++ b/src/analyses/variable-sensitivity/interval_abstract_value.h
@@ -21,7 +21,6 @@
 class interval_abstract_valuet : public abstract_value_objectt
 {
 public:
-  explicit interval_abstract_valuet(const typet &t);
   interval_abstract_valuet(const typet &t, bool tp, bool bttm);
 
   explicit interval_abstract_valuet(const constant_interval_exprt &e);

--- a/src/analyses/variable-sensitivity/liveness_context.h
+++ b/src/analyses/variable-sensitivity/liveness_context.h
@@ -33,13 +33,6 @@
 class liveness_contextt : public write_location_contextt
 {
 public:
-  explicit liveness_contextt(
-    const abstract_object_pointert child,
-    const typet &type)
-    : write_location_contextt(child, type)
-  {
-  }
-
   liveness_contextt(
     const abstract_object_pointert child,
     const typet &type,

--- a/src/analyses/variable-sensitivity/two_value_array_abstract_object.h
+++ b/src/analyses/variable-sensitivity/two_value_array_abstract_object.h
@@ -24,10 +24,6 @@ public:
     array_aggregate_typet>
     abstract_aggregate_baset;
 
-  explicit two_value_array_abstract_objectt(const typet &type)
-    : abstract_aggregate_baset(type)
-  {
-  }
   two_value_array_abstract_objectt(const typet &type, bool top, bool bottom)
     : abstract_aggregate_baset(type, top, bottom)
   {

--- a/src/analyses/variable-sensitivity/two_value_pointer_abstract_object.cpp
+++ b/src/analyses/variable-sensitivity/two_value_pointer_abstract_object.cpp
@@ -12,12 +12,6 @@
 #include <util/pointer_expr.h>
 
 two_value_pointer_abstract_objectt::two_value_pointer_abstract_objectt(
-  const typet &type)
-  : abstract_pointer_objectt(type)
-{
-}
-
-two_value_pointer_abstract_objectt::two_value_pointer_abstract_objectt(
   const typet &type,
   bool top,
   bool bottom)

--- a/src/analyses/variable-sensitivity/two_value_pointer_abstract_object.h
+++ b/src/analyses/variable-sensitivity/two_value_pointer_abstract_object.h
@@ -13,9 +13,6 @@
 class two_value_pointer_abstract_objectt : public abstract_pointer_objectt
 {
 public:
-  /// \param type: the type the abstract_object is representing
-  explicit two_value_pointer_abstract_objectt(const typet &type);
-
   /// Start the abstract object at either top or bottom or neither
   /// Asserts if both top and bottom are true
   ///

--- a/src/analyses/variable-sensitivity/two_value_struct_abstract_object.h
+++ b/src/analyses/variable-sensitivity/two_value_struct_abstract_object.h
@@ -24,10 +24,6 @@ public:
     struct_aggregate_typet>
     abstract_aggregate_baset;
 
-  explicit two_value_struct_abstract_objectt(const typet &type)
-    : abstract_aggregate_baset(type)
-  {
-  }
   two_value_struct_abstract_objectt(const typet &type, bool top, bool bottom)
     : abstract_aggregate_baset(type, top, bottom)
   {

--- a/src/analyses/variable-sensitivity/two_value_union_abstract_object.h
+++ b/src/analyses/variable-sensitivity/two_value_union_abstract_object.h
@@ -24,12 +24,6 @@ public:
     union_aggregate_typet>
     abstract_aggregate_baset;
 
-  /// \param type: the type the abstract_object is representing
-  explicit two_value_union_abstract_objectt(const typet &type)
-    : abstract_aggregate_baset(type)
-  {
-  }
-
   /// Start the abstract object at either top or bottom or neither
   /// Asserts if both top and bottom are true
   ///

--- a/src/analyses/variable-sensitivity/value_set_abstract_object.cpp
+++ b/src/analyses/variable-sensitivity/value_set_abstract_object.cpp
@@ -127,13 +127,6 @@ static abstract_object_sett widen_value_set(
   const constant_interval_exprt &lhs,
   const constant_interval_exprt &rhs);
 
-value_set_abstract_objectt::value_set_abstract_objectt(const typet &type)
-  : abstract_value_objectt(type)
-{
-  values.insert(std::make_shared<constant_abstract_valuet>(type));
-  verify();
-}
-
 value_set_abstract_objectt::value_set_abstract_objectt(
   const typet &type,
   bool top,
@@ -293,7 +286,8 @@ abstract_object_pointert value_set_abstract_objectt::resolve_values(
 void value_set_abstract_objectt::set_top_internal()
 {
   values.clear();
-  values.insert(std::make_shared<constant_abstract_valuet>(type()));
+  values.insert(
+    std::make_shared<constant_abstract_valuet>(type(), true, false));
 }
 
 void value_set_abstract_objectt::set_values(

--- a/src/analyses/variable-sensitivity/value_set_abstract_object.h
+++ b/src/analyses/variable-sensitivity/value_set_abstract_object.h
@@ -19,9 +19,6 @@ class value_set_abstract_objectt : public abstract_value_objectt,
                                    public value_set_tag
 {
 public:
-  /// \copydoc abstract_objectt::abstract_objectt(const typet&)
-  explicit value_set_abstract_objectt(const typet &type);
-
   /// \copydoc abstract_objectt::abstract_objectt(const typet &, bool, bool)
   value_set_abstract_objectt(const typet &type, bool top, bool bottom);
 

--- a/src/analyses/variable-sensitivity/value_set_pointer_abstract_object.cpp
+++ b/src/analyses/variable-sensitivity/value_set_pointer_abstract_object.cpp
@@ -30,13 +30,6 @@ static abstract_object_pointert
 maybe_extract_single_value(const abstract_object_pointert &maybe_singleton);
 
 value_set_pointer_abstract_objectt::value_set_pointer_abstract_objectt(
-  const typet &type)
-  : abstract_pointer_objectt(type)
-{
-  values.insert(std::make_shared<constant_pointer_abstract_objectt>(type));
-}
-
-value_set_pointer_abstract_objectt::value_set_pointer_abstract_objectt(
   const typet &new_type,
   bool top,
   bool bottom,

--- a/src/analyses/variable-sensitivity/value_set_pointer_abstract_object.h
+++ b/src/analyses/variable-sensitivity/value_set_pointer_abstract_object.h
@@ -19,9 +19,6 @@ class value_set_pointer_abstract_objectt : public abstract_pointer_objectt,
                                            public value_set_tag
 {
 public:
-  /// \copydoc abstract_objectt::abstract_objectt(const typet&)
-  explicit value_set_pointer_abstract_objectt(const typet &type);
-
   value_set_pointer_abstract_objectt(
     const typet &new_type,
     bool top,

--- a/src/analyses/variable-sensitivity/variable_sensitivity_object_factory.cpp
+++ b/src/analyses/variable-sensitivity/variable_sensitivity_object_factory.cpp
@@ -29,7 +29,7 @@ abstract_object_pointert
 create_context_abstract_object(const abstract_object_pointert &abstract_object)
 {
   return abstract_object_pointert(
-    new context_classt{abstract_object, abstract_object->type()});
+    new context_classt{abstract_object, abstract_object->type(), true, false});
 }
 
 template <class abstract_object_classt>

--- a/src/analyses/variable-sensitivity/write_location_context.h
+++ b/src/analyses/variable-sensitivity/write_location_context.h
@@ -34,13 +34,6 @@
 class write_location_contextt : public context_abstract_objectt
 {
 public:
-  explicit write_location_contextt(
-    const abstract_object_pointert child,
-    const typet &type)
-    : context_abstract_objectt(child, type)
-  {
-  }
-
   write_location_contextt(
     const abstract_object_pointert child,
     const typet &type,

--- a/unit/analyses/variable-sensitivity/variable_sensitivity_test_helpers.cpp
+++ b/unit/analyses/variable-sensitivity/variable_sensitivity_test_helpers.cpp
@@ -112,7 +112,8 @@ std::shared_ptr<const value_set_abstract_objectt> make_bottom_value_set()
 
 std::shared_ptr<const value_set_abstract_objectt> make_top_value_set()
 {
-  return std::make_shared<const value_set_abstract_objectt>(integer_typet());
+  return std::make_shared<const value_set_abstract_objectt>(
+    integer_typet(), true, false);
 }
 
 abstract_object_pointert make_bottom_object()


### PR DESCRIPTION
This was unused.  Implementations actually did the same as `abstract_objectt::abstract_object(type, true, false)` so any out-of-tree uses can easily enough be fixed.
