### PR TITLE
C library: Avoid arithmetic overflow with pipe operations

### DIFF
--- a/regression/cbmc-library/write-01/main.c
+++ b/regression/cbmc-library/write-01/main.c
@@ -1,9 +1,18 @@
-#include <assert.h>
+#include <limits.h>
 #include <unistd.h>
+
+extern const __CPROVER_size_t SIZE;
 
 int main()
 {
-  write();
-  assert(0);
-  return 0;
+  __CPROVER_assume(SIZE < SSIZE_MAX);
+
+  int fd;
+  char ptr[SIZE];
+  __CPROVER_size_t nbytes;
+
+  __CPROVER_assume(fd >= 0);
+  __CPROVER_assume(nbytes < SIZE);
+
+  write(fd, ptr, nbytes);
 }

--- a/regression/cbmc-library/write-01/test.desc
+++ b/regression/cbmc-library/write-01/test.desc
@@ -1,6 +1,6 @@
-KNOWNBUG
+CORE unix
 main.c
---pointer-check --bounds-check
+--pointer-check --bounds-check --conversion-check --unwind 1
 ^EXIT=0$
 ^SIGNAL=0$
 ^VERIFICATION SUCCESSFUL$


### PR DESCRIPTION
We may be trying to access file descriptors that haven't been fully initialised. Don't yield spurious arithmetic overflows (that are just caused by our modelling) in such situations.

Fixes: #5570

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
