### PR TITLE
CONTRACTS: dont typecheck typed_target operands twice

### DIFF
--- a/src/ansi-c/c_typecheck_expr.cpp
+++ b/src/ansi-c/c_typecheck_expr.cpp
@@ -1944,7 +1944,7 @@ void c_typecheck_baset::typecheck_typed_target_call(
   }
 
   auto arg0 = expr.arguments().front();
-  typecheck_expr(arg0);
+
   if(!is_assignable(arg0) || !arg0.get_bool(ID_C_lvalue))
   {
     throw invalid_source_file_exceptiont{
@@ -1976,7 +1976,7 @@ void c_typecheck_baset::typecheck_typed_target_call(
     arguments.push_back(false_exprt());
 
   expr.arguments().swap(arguments);
-  typecheck_side_effect_function_call(expr);
+  expr.type() = empty_typet();
 }
 
 void c_typecheck_baset::typecheck_side_effect_function_call(


### PR DESCRIPTION
Typechecking operands twice could result in typechecking errors when pointer types were involved.

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.
