### PR TITLE
Value sets: type casts need not be towards a pointer type

### DIFF
--- a/src/pointer-analysis/value_set.cpp
+++ b/src/pointer-analysis/value_set.cpp
@@ -588,21 +588,18 @@ void value_sett::get_value_set_rec(
 
     if(op_type.id()==ID_pointer)
     {
-      // pointer-to-pointer -- we just ignore these
+      // pointer-to-something -- we just ignore the type cast
       get_value_set_rec(op, dest, suffix, original_type, ns);
     }
     else if(
       op_type.id() == ID_unsignedbv || op_type.id() == ID_signedbv ||
       op_type.id() == ID_bv)
     {
-      // integer-to-pointer
+      // integer-to-something
 
       if(op.is_zero())
       {
-        insert(
-          dest,
-          exprt(ID_null_object, to_type_with_subtype(expr_type).subtype()),
-          mp_integer{0});
+        insert(dest, exprt(ID_null_object, empty_typet{}), mp_integer{0});
       }
       else
       {


### PR DESCRIPTION
We cannot assume that the expression seen by get_value_set_rec is of pointer type. Therefore, type cast expressions need not be towards a pointer type, and unconditionally trying to take the subtype of the expression type is not safe. On the other hand, any access to NULL_object will be invalid, and fixing NULL_object to be void typed should be safe.

Found while working on #6590.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
