### PR TITLE
External SAT back-end: not all variables are required

### DIFF
--- a/src/solvers/sat/external_sat.cpp
+++ b/src/solvers/sat/external_sat.cpp
@@ -75,7 +75,7 @@ external_satt::resultt external_satt::parse_result(std::string solver_output)
   std::string line;
   external_satt::resultt result = resultt::P_ERROR;
   std::vector<bool> assigned_variables(no_variables(), false);
-  assignment.insert(assignment.begin(), no_variables(), tvt(false));
+  assignment.insert(assignment.begin(), no_variables(), tvt::unknown());
 
   while(getline(response_istream, line))
   {
@@ -146,16 +146,19 @@ external_satt::resultt external_satt::parse_result(std::string solver_output)
 
   if(result == resultt::P_SATISFIABLE)
   {
-    // We don't need to check zero
-    for(size_t index = 1; index < no_variables(); index++)
-    {
-      if(!assigned_variables[index])
-      {
-        log.error() << "No assignment was found for literal: " << index
+    log.conditional_output(
+      log.debug(), [this, &assigned_variables](messaget::mstreamt &mstream) {
+        // We don't need to check zero
+        for(size_t index = 1; index < no_variables(); index++)
+        {
+          // this may happen when a variable does not appear in any clause
+          if(!assigned_variables[index])
+          {
+            mstream << "No assignment was found for literal: " << index
                     << messaget::eom;
-        return resultt::P_ERROR;
-      }
-    }
+          }
+        }
+      });
     return resultt::P_SATISFIABLE;
   }
 

--- a/unit/solvers/sat/external_sat.cpp
+++ b/unit/solvers/sat/external_sat.cpp
@@ -48,19 +48,6 @@ SCENARIO("external_sat", "[core][solvers][sat][external_sat]")
       }
     }
 
-    AND_GIVEN("the output is malformed")
-    {
-      auto result = "c too few assignments\ns SATISFIABLE\nv 1 2 3 4";
-      WHEN("the solver output contains:\n" << result)
-      {
-        THEN("the result is set to error")
-        {
-          satcheck.set_no_variables(100);
-          REQUIRE(satcheck.parse_result(result) == propt::resultt::P_ERROR);
-        }
-      }
-    }
-
     AND_GIVEN("SAT instance is unsatisfiable")
     {
       std::string unsat_result = GENERATE(


### PR DESCRIPTION
We may construct formulae the satisfiability of which does not depend on all variables' values (the Failing_Assert1 regression test is one such example).

Found while working on #6590.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
