### PR TITLE
ansi-c tests: add Makefile rule to rebuild goto binaries

### DIFF
--- a/regression/ansi-c/Makefile
+++ b/regression/ansi-c/Makefile
@@ -52,6 +52,15 @@ ifneq ($(BUILD_ENV_),MSVC)
 	@../test.pl -e -p -c "$(exe) -xc++ -D_Bool=bool" -I test-c++-front-end -s c++-front-end $(excluded_tests)
 endif
 
+build_goto_binaries:
+	uname -m | grep x86_64
+	cd arch_flags_mcpu_bad ; $(exe) -c source.c -o object.intel
+	cd arch_flags_mcpu_good ; \
+		$(exe) -o object.arm --native-compiler=arm-none-eabi-gcc -mcpu=cortex-a15 -c source.c
+	cd arch_flags_mthumb_bad ; $(exe) -c source.c -o object.intel
+	cd arch_flags_mthumb_good ; \
+		$(exe) -o object.arm --native-compiler=arm-none-eabi-gcc -mthumb -c source.c
+
 clean:
 	find . -name '*.out' -execdir $(RM) '{}' \;
 	find . -name '*.gb' -execdir $(RM) '{}' \;

--- a/regression/ansi-c/arch_flags_mcpu_bad/test.desc
+++ b/regression/ansi-c/arch_flags_mcpu_bad/test.desc
@@ -13,6 +13,9 @@ on a 64-bit platform:
 
   goto-cc -c source.c -o object.intel
 
+Use `make build_goto_binaries` in the parent directory to run the above for this
+and all other directories containing binaries.
+
 preproc.i is already pre-processed so that it can be linked in without
 needing to invoke a pre-processor from a cross-compile toolchain on your
 local machine. Linking it together with the Intel object file, while

--- a/regression/ansi-c/arch_flags_mcpu_good/test.desc
+++ b/regression/ansi-c/arch_flags_mcpu_good/test.desc
@@ -23,6 +23,9 @@ using:
 
 which will install arm-none-eabi-gcc (amongst other things).
 
+Use `make build_goto_binaries` in the parent directory to run the above for this
+and all other directories containing binaries.
+
 preproc.i is already pre-processed so that it can be linked in without
 needing to invoke a pre-processor from a cross-compile toolchain on your
 local machine. Linking it together with the ARM object file, while

--- a/regression/ansi-c/arch_flags_mthumb_bad/test.desc
+++ b/regression/ansi-c/arch_flags_mthumb_bad/test.desc
@@ -13,6 +13,9 @@ file 'object.intel' was compiled from 'source.c' with goto-cc on a
 
   goto-cc -c source.c -o object.intel
 
+Use `make build_goto_binaries` in the parent directory to run the above for this
+and all other directories containing binaries.
+
 preproc.i is already pre-processed so that it can be linked in without
 needing to invoke a pre-processor from a cross-compile toolchain on your
 local machine. Linking it together with the Intel object file, while

--- a/regression/ansi-c/arch_flags_mthumb_good/test.desc
+++ b/regression/ansi-c/arch_flags_mthumb_good/test.desc
@@ -23,6 +23,9 @@ using:
 
 which will install arm-none-eabi-gcc (amongst other things).
 
+Use `make build_goto_binaries` in the parent directory to run the above for this
+and all other directories containing binaries.
+
 preproc.i is already pre-processed so that it can be linked in without
 needing to invoke a pre-processor from a cross-compile toolchain on your
 local machine. Linking it together with the ARM object file, while


### PR DESCRIPTION
We ship goto binaries in the repository as they can only be re-built on 64-bit Linux platforms and require cross-compilers to be available. Rebuilds are required whenever changes to the goto binary version are made. Make those steps easy to execute by providing a Makefile rule.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
