### PR TITLE
C library: add imaxabs

### DIFF
--- a/regression/cbmc-library/imaxabs-01/main.c
+++ b/regression/cbmc-library/imaxabs-01/main.c
@@ -1,0 +1,9 @@
+#include <assert.h>
+#include <inttypes.h>
+#include <stdlib.h>
+
+int main()
+{
+  assert(imaxabs(INTMAX_MIN + 1) == INTMAX_MAX);
+  return 0;
+}

--- a/regression/cbmc-library/imaxabs-01/test.desc
+++ b/regression/cbmc-library/imaxabs-01/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+--pointer-check --bounds-check --signed-overflow-check
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring

--- a/src/ansi-c/c_typecheck_expr.cpp
+++ b/src/ansi-c/c_typecheck_expr.cpp
@@ -2872,12 +2872,13 @@ exprt c_typecheck_baset::do_special_functions(
 
     return std::move(infl_expr);
   }
-  else if(identifier==CPROVER_PREFIX "abs" ||
-          identifier==CPROVER_PREFIX "labs" ||
-          identifier==CPROVER_PREFIX "llabs" ||
-          identifier==CPROVER_PREFIX "fabs" ||
-          identifier==CPROVER_PREFIX "fabsf" ||
-          identifier==CPROVER_PREFIX "fabsl")
+  else if(
+    identifier == CPROVER_PREFIX "abs" || identifier == CPROVER_PREFIX "labs" ||
+    identifier == CPROVER_PREFIX "llabs" ||
+    identifier == CPROVER_PREFIX "imaxabs" ||
+    identifier == CPROVER_PREFIX "fabs" ||
+    identifier == CPROVER_PREFIX "fabsf" ||
+    identifier == CPROVER_PREFIX "fabsl")
   {
     if(expr.arguments().size()!=1)
     {

--- a/src/ansi-c/library/stdlib.c
+++ b/src/ansi-c/library/stdlib.c
@@ -25,6 +25,22 @@ long long int llabs(long long int i)
   return __CPROVER_llabs(i);
 }
 
+/* FUNCTION: imaxabs */
+
+#ifndef __CPROVER_INTTYPES_H_INCLUDED
+#  include <inttypes.h>
+#  define __CPROVER_INTTYPES_H_INCLUDED
+#endif
+
+#undef imaxabs
+
+intmax_t __CPROVER_imaxabs(intmax_t);
+
+intmax_t imaxabs(intmax_t i)
+{
+  return __CPROVER_imaxabs(i);
+}
+
 /* FUNCTION: __builtin_abs */
 
 int __builtin_abs(int i)


### PR DESCRIPTION
This is another variant of absolute-value functions.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
