### PR TITLE
Memory allocations produced via alloca have function scope

### DIFF
--- a/regression/cbmc-library/alloca-03/main.c
+++ b/regression/cbmc-library/alloca-03/main.c
@@ -1,0 +1,32 @@
+#include <stdlib.h>
+
+#ifdef _WIN32
+void *alloca(size_t alloca_size);
+#endif
+
+typedef int *int_ptr;
+
+int_ptr global;
+
+void foo()
+{
+  int_ptr ptr[2];
+  for(int i = 0; i < 2; ++i)
+  {
+    ptr[i] = alloca(sizeof(int));
+  }
+  *(ptr[0]) = 42;
+  *(ptr[1]) = 42;
+
+  _Bool nondet;
+  if(nondet)
+    global = ptr[0];
+  else
+    global = ptr[1];
+}
+
+int main()
+{
+  foo();
+  *global = 42;
+}

--- a/regression/cbmc-library/alloca-03/test.desc
+++ b/regression/cbmc-library/alloca-03/test.desc
@@ -1,0 +1,10 @@
+CORE
+main.c
+--pointer-check
+^\[main.pointer_dereference.\d+\] line 31 dereference failure: dead object in \*global: FAILURE$
+^\*\* 1 of \d+ failed
+^VERIFICATION FAILED$
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring

--- a/src/goto-programs/goto_convert_class.h
+++ b/src/goto-programs/goto_convert_class.h
@@ -382,6 +382,9 @@ protected:
 
   struct targetst
   {
+    goto_programt *prefix = nullptr;
+    goto_programt *suffix = nullptr;
+
     bool return_set, has_return_value, break_set, continue_set,
          default_set, throw_set, leave_set;
 
@@ -683,6 +686,12 @@ protected:
     const exprt::operandst &arguments,
     goto_programt &dest);
   void do_havoc_slice(
+    const exprt &lhs,
+    const symbol_exprt &function,
+    const exprt::operandst &arguments,
+    goto_programt &dest,
+    const irep_idt &mode);
+  void do_alloca(
     const exprt &lhs,
     const symbol_exprt &function,
     const exprt::operandst &arguments,

--- a/src/goto-programs/goto_convert_functions.cpp
+++ b/src/goto-programs/goto_convert_functions.cpp
@@ -196,6 +196,8 @@ void goto_convert_functionst::convert_function(
     tmp_end_function.add(goto_programt::make_end_function(end_location));
 
   targets = targetst();
+  targets.prefix = &f.body;
+  targets.suffix = &tmp_end_function;
   targets.set_return(end_function);
   targets.has_return_value = code_type.return_type().id() != ID_empty &&
                              code_type.return_type().id() != ID_constructor &&
@@ -235,6 +237,9 @@ void goto_convert_functionst::convert_function(
     f.make_hidden();
 
   lifetime = parent_lifetime;
+
+  targets.prefix = nullptr;
+  targets.suffix = nullptr;
 }
 
 void goto_convert(goto_modelt &goto_model, message_handlert &message_handler)


### PR DESCRIPTION
We must not mark the allocation as dead when leaving the block, but instead need to defer that until the end of the function.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
