### PR TITLE
CONTRACTS: Fix conditional havoc code

### DIFF
--- a/regression/contracts-dfcc/havoc-conditional-target/check-foo.c
+++ b/regression/contracts-dfcc/havoc-conditional-target/check-foo.c
@@ -1,0 +1,20 @@
+#include <stdlib.h>
+
+void foo(int *out)
+  // clang-format off
+__CPROVER_requires(out ==> __CPROVER_is_fresh(out, sizeof(*out)))
+__CPROVER_assigns(out: *out)
+__CPROVER_ensures(out ==> *out == 1)
+// clang-format on
+{
+  if(out)
+    *out = 1;
+}
+
+int nondet_int();
+
+void main()
+{
+  int *out;
+  foo(out);
+}

--- a/regression/contracts-dfcc/havoc-conditional-target/check-foo.desc
+++ b/regression/contracts-dfcc/havoc-conditional-target/check-foo.desc
@@ -1,0 +1,9 @@
+CORE
+check-foo.c
+--dfcc main --enforce-contract foo _ --pointer-check
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+--
+This test checks conditional havocs are behaving as expected.

--- a/regression/contracts-dfcc/havoc-conditional-target/replace-foo.c
+++ b/regression/contracts-dfcc/havoc-conditional-target/replace-foo.c
@@ -1,0 +1,30 @@
+#include <stdlib.h>
+
+void foo(int *out)
+  // clang-format off
+__CPROVER_requires(out ==> __CPROVER_is_fresh(out, sizeof(*out)))
+__CPROVER_assigns(out: *out)
+__CPROVER_ensures(out ==> *out == 1)
+// clang-format on
+{
+  if(out)
+    *out = 1;
+}
+
+int nondet_int();
+
+void bar()
+{
+  int i = 0;
+  int *out = nondet_int() ? &i : NULL;
+  foo(out);
+  // clang-format off
+  __CPROVER_assert(!out ==> (i == 0), "out not null implies initial value");
+  __CPROVER_assert(out ==> (i == 1), "out null implies updated value");
+  // clang-format on
+}
+
+int main(void)
+{
+  bar();
+}

--- a/regression/contracts-dfcc/havoc-conditional-target/replace-foo.desc
+++ b/regression/contracts-dfcc/havoc-conditional-target/replace-foo.desc
@@ -1,0 +1,9 @@
+CORE
+replace-foo.c
+--dfcc main --enforce-contract bar --replace-call-with-contract foo _ --pointer-check
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+--
+This test checks conditional havocs are behaving as expected.

--- a/src/ansi-c/library/cprover_contracts.c
+++ b/src/ansi-c/library/cprover_contracts.c
@@ -1286,6 +1286,10 @@ void *__CPROVER_contracts_write_set_havoc_get_assignable_target(
   __CPROVER_size_t idx)
 {
 __CPROVER_HIDE:;
+#ifdef DFCC_DEBUG
+  __CPROVER_assert(write_set != 0, "write_set not NULL");
+#endif
+
   __CPROVER_contracts_car_t car = set->contract_assigns.elems[idx];
   if(car.is_writable)
     return car.lb;

--- a/src/goto-instrument/contracts/dynamic-frames/dfcc_spec_functions.cpp
+++ b/src/goto-instrument/contracts/dynamic-frames/dfcc_spec_functions.cpp
@@ -200,10 +200,9 @@ void dfcc_spec_functionst::generate_havoc_function(
       // Use same source location as original call
       source_locationt location(ins_it->source_location());
       auto hook = hook_opt.value();
-      auto write_set_var = write_set_symbol.symbol_expr();
       code_function_callt call(
         library.dfcc_fun_symbol.at(hook).symbol_expr(),
-        {write_set_var, from_integer(next_idx, size_type())});
+        {write_set_symbol.symbol_expr(), from_integer(next_idx, size_type())});
 
       if(hook == dfcc_funt::WRITE_SET_HAVOC_GET_ASSIGNABLE_TARGET)
       {
@@ -233,7 +232,8 @@ void dfcc_spec_functionst::generate_havoc_function(
         body.add(goto_programt::make_function_call(call, location));
 
         auto goto_instruction = body.add(goto_programt::make_incomplete_goto(
-          utils.make_null_check_expr(write_set_var)));
+          utils.make_null_check_expr(target_expr), location));
+
         // create nondet assignment to the target
         side_effect_expr_nondett nondet(target_type, location);
         body.add(goto_programt::make_assignment(


### PR DESCRIPTION
Fixes #7379 

The condition was being checked on the write set variable instead of write set element variable

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.
