### PR TITLE
Test for union field sensitivity bug

### DIFF
--- a/regression/cbmc/union-unequal-element-size1/main.c
+++ b/regression/cbmc/union-unequal-element-size1/main.c
@@ -1,0 +1,24 @@
+#include <assert.h>
+
+union UNIONNAME
+{
+  int x1;
+  char x3[3];
+};
+
+int main()
+{
+  union UNIONNAME u;
+  u.x1 = 0x01010101;
+
+  assert(u.x3[0]);
+  assert(u.x3[1]);
+  assert(u.x3[2]);
+
+  assert(*((char *)&u.x1));
+  assert(*(((char *)&u.x1) + 1));
+  assert(*(((char *)&u.x1) + 2));
+  char s = *(((char *)&u.x1) + 3);
+  assert(s);
+  return 0;
+}

--- a/regression/cbmc/union-unequal-element-size1/test.desc
+++ b/regression/cbmc/union-unequal-element-size1/test.desc
@@ -1,0 +1,10 @@
+KNOWNBUG
+main.c
+--verbosity 10
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring
+--
+assert(s) fails with field sensitivity, but passes without


### PR DESCRIPTION
Field sensitivity for unions has problems with members of unequal length leading to wrong accesses.
I have also seen spurious pointer check violations for the same reasons (I can dig up further examples).

- [X] Each commit message has a non-empty body, explaining why the change was made.
- [n/a] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [n/a] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [X] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [n/a] My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- [n/a] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

