### PR TITLE
Add --nondet-static-matching regex option

### DIFF
--- a/doc/man/goto-instrument.1
+++ b/doc/man/goto-instrument.1
@@ -392,6 +392,10 @@ add nondeterministic initialization of variables with static lifetime
 same as nondet\-static except for the variable \fIe\fR
 (use multiple times if required)
 .TP
+\fB\-\-nondet\-static\-matching\fR \fIr\fR
+add nondeterministic initialization of variables
+with static lifetime matching regex \fIr\fR
+.TP
 \fB\-\-function\-enter\fR \fIf\fR
 .TQ
 \fB\-\-function\-exit\fR \fIf\fR

--- a/regression/goto-instrument/nondet_static_matching/main.c
+++ b/regression/goto-instrument/nondet_static_matching/main.c
@@ -1,0 +1,17 @@
+#include <assert.h>
+
+int do_nondet_init1;
+int init1;
+
+int main(int argc, char **argv)
+{
+  static int do_nondet_init2;
+  static int init2;
+
+  assert(do_nondet_init1 == 0);
+  assert(init1 == 0);
+  assert(do_nondet_init2 == 0);
+  assert(init2 == 0);
+
+  return 0;
+}

--- a/regression/goto-instrument/nondet_static_matching/test.desc
+++ b/regression/goto-instrument/nondet_static_matching/test.desc
@@ -1,0 +1,12 @@
+CORE
+main.c
+--nondet-static-matching '.*\.c:.*nondet.*'
+^VERIFICATION FAILED$
+^EXIT=10$
+^SIGNAL=0$
+assertion do_nondet_init1 == 0: FAILURE
+assertion init1 == 0: SUCCESS
+assertion do_nondet_init2 == 0: FAILURE
+assertion init2 == 0: SUCCESS
+--
+--

--- a/src/goto-instrument/goto_instrument_parse_options.cpp
+++ b/src/goto-instrument/goto_instrument_parse_options.cpp
@@ -1909,7 +1909,7 @@ void goto_instrument_parse_optionst::help()
     " --nondet-static              add nondeterministic initialization of variables with static lifetime\n" // NOLINT(*)
     " --nondet-static-exclude e    same as nondet-static except for the variable e\n" //NOLINT(*)
     "                              (use multiple times if required)\n"
-    " --nondet-static-matching r   add nondeterministic initialization of variables\n"
+    " --nondet-static-matching r   add nondeterministic initialization of variables\n" // NOLINT(*)
     "                              with static lifetime matching regex r\n"
     " --function-enter <f>, --function-exit <f>, --branch <f>\n"
     "                              instruments a call to <f> at the beginning,\n" // NOLINT(*)

--- a/src/goto-instrument/goto_instrument_parse_options.cpp
+++ b/src/goto-instrument/goto_instrument_parse_options.cpp
@@ -154,6 +154,17 @@ int goto_instrument_parse_optionst::doit()
       }
     }
 
+    // ignore default/user-specified initialization
+    // of matching variables with static lifetime
+    if(cmdline.isset("nondet-static-matching"))
+    {
+      log.status() << "Adding nondeterministic initialization "
+                      "of matching static/global variables"
+                   << messaget::eom;
+      nondet_static_matching(
+        goto_model, cmdline.get_value("nondet-static-matching"));
+    }
+
     instrument_goto_program();
 
     if(cmdline.isset("validate-goto-model"))
@@ -1898,6 +1909,8 @@ void goto_instrument_parse_optionst::help()
     " --nondet-static              add nondeterministic initialization of variables with static lifetime\n" // NOLINT(*)
     " --nondet-static-exclude e    same as nondet-static except for the variable e\n" //NOLINT(*)
     "                              (use multiple times if required)\n"
+    " --nondet-static-matching r   add nondeterministic initialization of variables\n"
+    "                              with static lifetime matching regex r\n"
     " --function-enter <f>, --function-exit <f>, --branch <f>\n"
     "                              instruments a call to <f> at the beginning,\n" // NOLINT(*)
     "                              the exit, or a branch point, respectively\n"

--- a/src/goto-instrument/goto_instrument_parse_options.h
+++ b/src/goto-instrument/goto_instrument_parse_options.h
@@ -65,6 +65,7 @@ Author: Daniel Kroening, kroening@kroening.com
   "(isr):" \
   "(stack-depth):(nondet-static)" \
   "(nondet-static-exclude):" \
+  "(nondet-static-matching):" \
   "(function-enter):(function-exit):(branch):" \
   OPT_SHOW_GOTO_FUNCTIONS \
   OPT_SHOW_PROPERTIES \

--- a/src/goto-instrument/nondet_static.h
+++ b/src/goto-instrument/nondet_static.h
@@ -40,4 +40,6 @@ void nondet_static(goto_modelt &);
 
 void nondet_static(goto_modelt &, const std::set<std::string> &);
 
+void nondet_static_matching(goto_modelt &, const std::string &);
+
 #endif // CPROVER_GOTO_INSTRUMENT_NONDET_STATIC_H


### PR DESCRIPTION
Adds a more general mechanism for selecting which static variables should be initialized nondeterministically.

The regex matches the string consisting of the filename and the variable display name separated by a colon, e.g. "main.c:x", a format that is already used by the `nondet_static(goto_model, except_values)` variant.

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [X] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [X] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [n/a] My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- [n/a] White-space or formatting changes outside the feature-related changed lines are in commits of their own.
