### PR TITLE
Better diagnostics on with_exprt and ifexprt type mismatch

### DIFF
--- a/src/goto-symex/goto_symex_state.cpp
+++ b/src/goto-symex/goto_symex_state.cpp
@@ -261,14 +261,15 @@ goto_symex_statet::rename(exprt expr, const namespacet &ns)
       *it = rename<level>(std::move(*it), ns).get();
 
     const exprt &c_expr = as_const(expr);
-    INVARIANT(
+    INVARIANT_WITH_DIAGNOSTICS(
       (expr.id() != ID_with ||
        c_expr.type() == to_with_expr(c_expr).old().type()) &&
         (expr.id() != ID_if ||
          (c_expr.type() == to_if_expr(c_expr).true_case().type() &&
           c_expr.type() == to_if_expr(c_expr).false_case().type())),
       "Type of renamed expr should be the same as operands for with_exprt and "
-      "if_exprt");
+      "if_exprt",
+      irep_pretty_diagnosticst{expr});
 
     if(level == L2)
       expr = field_sensitivity.apply(ns, *this, std::move(expr), false);


### PR DESCRIPTION
Makes it easier to understand which types are not matching (e.g. ifexprt vs true_case vs false_case).

- [X] Each commit message has a non-empty body, explaining why the change was made.
- [n/a] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [n/a] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [n/a] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [n/a] My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- [n/a] White-space or formatting changes outside the feature-related changed lines are in commits of their own.
