### PR TITLE
Add --no-simplify-phi option

### DIFF
--- a/jbmc/src/jbmc/jbmc_parse_options.cpp
+++ b/jbmc/src/jbmc/jbmc_parse_options.cpp
@@ -98,6 +98,7 @@ void jbmc_parse_optionst::set_default_options(optionst &options)
   options.set_option("refine-strings", true);
   options.set_option("simple-slice", true);
   options.set_option("simplify", true);
+  options.set_option("simplify-phi", true);
   options.set_option("show-goto-symex-steps", false);
 
   // Other default
@@ -159,6 +160,9 @@ void jbmc_parse_optionst::get_command_line_options(optionst &options)
 
   if(cmdline.isset("no-simplify"))
     options.set_option("simplify", false);
+
+  if(cmdline.isset("no-simplify-phi"))
+    options.set_option("simplify-phi", false);
 
   if(cmdline.isset("stop-on-fail") ||
      cmdline.isset("dimacs") ||

--- a/jbmc/src/jbmc/jbmc_parse_options.h
+++ b/jbmc/src/jbmc/jbmc_parse_options.h
@@ -44,7 +44,7 @@ class optionst;
   OPT_FUNCTIONS \
   "(no-simplify)(full-slice)" \
   OPT_REACHABILITY_SLICER \
-  "(no-propagation)(no-simplify-if)" \
+  "(no-propagation)" \
   "(document-subgoals)" \
   "(object-bits):" \
   "(classpath):(cp):" \

--- a/jbmc/src/jbmc/jbmc_parse_options.h
+++ b/jbmc/src/jbmc/jbmc_parse_options.h
@@ -42,7 +42,7 @@ class optionst;
   OPT_BMC \
   "(preprocess)" \
   OPT_FUNCTIONS \
-  "(no-simplify)(full-slice)" \
+  "(full-slice)" \
   OPT_REACHABILITY_SLICER \
   "(no-propagation)" \
   "(document-subgoals)" \

--- a/regression/cbmc/no-simplify-phi/main.c
+++ b/regression/cbmc/no-simplify-phi/main.c
@@ -1,0 +1,11 @@
+int main()
+{
+  _Bool a;
+  int x;
+
+  if(a)
+    x = 1;
+  else
+    x = 1;
+  __CPROVER_assert(x > 0, "");
+}

--- a/regression/cbmc/no-simplify-phi/test.desc
+++ b/regression/cbmc/no-simplify-phi/test.desc
@@ -1,0 +1,11 @@
+CORE
+main.c
+--no-simplify-phi --program-only
+x!0@1#4 == \(\\guard#1 \? 1 : 1\)
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+x!0@1#4 == 1
+--
+With --no-simplify-phi the phi function producing x!0@1#4 is not simplified.

--- a/scripts/check_help.sh
+++ b/scripts/check_help.sh
@@ -70,7 +70,7 @@ for t in  \
       for undoc in \
         -all-claims -all-properties -claim -show-claims \
         -document-subgoals \
-        -no-propagation -no-simplify -no-simplify-if \
+        -no-propagation -no-simplify \
         -floatbv -no-unwinding-assertions \
         -slice-by-trace ; do
         echo "$undoc" >> help_string
@@ -102,7 +102,7 @@ for t in  \
       # -jar, -gb are documented, but in a different format
       for undoc in \
         -document-subgoals \
-        -no-propagation -no-simplify -no-simplify-if \
+        -no-propagation -no-simplify \
         -no-unwinding-assertions \
         -jar -gb ; do
         echo "$undoc" >> help_string

--- a/src/cbmc/cbmc_parse_options.cpp
+++ b/src/cbmc/cbmc_parse_options.cpp
@@ -107,6 +107,7 @@ void cbmc_parse_optionst::set_default_options(optionst &options)
   options.set_option("propagation", true);
   options.set_option("simple-slice", true);
   options.set_option("simplify", true);
+  options.set_option("simplify-phi", true);
   options.set_option("show-goto-symex-steps", false);
   options.set_option("show-points-to-sets", false);
   options.set_option("show-array-constraints", false);
@@ -224,6 +225,9 @@ void cbmc_parse_optionst::get_command_line_options(optionst &options)
 
   if(cmdline.isset("no-simplify"))
     options.set_option("simplify", false);
+
+  if(cmdline.isset("no-simplify-phi"))
+    options.set_option("simplify-phi", false);
 
   if(cmdline.isset("stop-on-fail") ||
      cmdline.isset("dimacs") ||

--- a/src/cbmc/cbmc_parse_options.h
+++ b/src/cbmc/cbmc_parse_options.h
@@ -39,6 +39,7 @@ class optionst;
   "(no-simplify)(full-slice)" \
   OPT_REACHABILITY_SLICER \
   "(no-propagation)(no-simplify-if)" \
+  "(no-simplify-phi)" \
   "(document-subgoals)(test-preprocessor)" \
   "(show-array-constraints)"  \
   OPT_CONFIG_C_CPP \

--- a/src/cbmc/cbmc_parse_options.h
+++ b/src/cbmc/cbmc_parse_options.h
@@ -36,10 +36,9 @@ class optionst;
   OPT_BMC \
   "(preprocess)(slice-by-trace):" \
   OPT_FUNCTIONS \
-  "(no-simplify)(full-slice)" \
+  "(full-slice)" \
   OPT_REACHABILITY_SLICER \
   "(no-propagation)" \
-  "(no-simplify-phi)" \
   "(document-subgoals)(test-preprocessor)" \
   "(show-array-constraints)"  \
   OPT_CONFIG_C_CPP \

--- a/src/cbmc/cbmc_parse_options.h
+++ b/src/cbmc/cbmc_parse_options.h
@@ -38,7 +38,7 @@ class optionst;
   OPT_FUNCTIONS \
   "(no-simplify)(full-slice)" \
   OPT_REACHABILITY_SLICER \
-  "(no-propagation)(no-simplify-if)" \
+  "(no-propagation)" \
   "(no-simplify-phi)" \
   "(document-subgoals)(test-preprocessor)" \
   "(show-array-constraints)"  \

--- a/src/goto-checker/bmc_util.h
+++ b/src/goto-checker/bmc_util.h
@@ -170,6 +170,10 @@ void run_property_decider(
   bool set_pass = true);
 
 // clang-format off
+#define OPT_SYMEX_SIMPLIFY \
+  "(no-simplify)" \
+  "(no-simplify-phi)" \
+
 #define OPT_BMC \
   "(program-only)" \
   "(show-byte-ops)" \
@@ -195,6 +199,13 @@ void run_property_decider(
   "(ignore-properties-before-unwind-min)" \
   "(symex-cache-dereferences)" \
   OPT_UNWINDSET \
+  OPT_SYMEX_SIMPLIFY \
+
+#define HELP_SYMEX_SIMPLIFY \
+  " --no-simplify                do not simplify any expressions during" \
+  "                              symbolic execution\n" \
+  " --no-simplify-phi            do not simplify phi functions during" \
+  "                              symbolic execution\n" \
 
 #define HELP_BMC \
   " --paths [strategy]           explore paths one at a time\n" \
@@ -246,6 +257,7 @@ void run_property_decider(
   "                              gets blacklisted\n" \
   " --graphml-witness filename   write the witness in GraphML format to filename\n" /* NOLINT(*) */ \
   " --symex-cache-dereferences   enable caching of repeated dereferences" \
+  HELP_SYMEX_SIMPLIFY \
 // clang-format on
 
 #endif // CPROVER_GOTO_CHECKER_BMC_UTIL_H

--- a/src/goto-symex/symex_config.h
+++ b/src/goto-symex/symex_config.h
@@ -32,6 +32,8 @@ struct symex_configt final
 
   bool simplify_opt;
 
+  bool simplify_phi;
+
   bool unwinding_assertions;
 
   bool partial_loops;

--- a/src/goto-symex/symex_goto.cpp
+++ b/src/goto-symex/symex_goto.cpp
@@ -724,7 +724,7 @@ void goto_symext::merge_goto(
 /// \param ns: namespace
 /// \param diff_guard: difference between the guards of the two states
 /// \param [out] log: logger for debug messages
-/// \param do_simplify: should the right-hand-side of the assignment that is
+/// \param do_simplify_phi: should the right-hand-side of the assignment that is
 ///   added to the target be simplified
 /// \param [out] target: equation that will receive the resulting assignment
 /// \param dirty: dirty-object analysis
@@ -738,7 +738,7 @@ static void merge_names(
   const namespacet &ns,
   const guardt &diff_guard,
   messaget &log,
-  const bool do_simplify,
+  const bool do_simplify_phi,
   symex_target_equationt &target,
   const incremental_dirtyt &dirty,
   const ssa_exprt &ssa,
@@ -830,7 +830,7 @@ static void merge_names(
   else
   {
     rhs = if_exprt(diff_guard.as_expr(), goto_state_rhs, dest_state_rhs);
-    if(do_simplify)
+    if(do_simplify_phi)
       simplify(rhs, ns);
   }
 
@@ -887,7 +887,7 @@ void goto_symext::phi_function(
       ns,
       diff_guard,
       log,
-      symex_config.simplify_opt,
+      symex_config.simplify_phi,
       target,
       path_storage.dirty,
       ssa,
@@ -914,7 +914,7 @@ void goto_symext::phi_function(
       ns,
       diff_guard,
       log,
-      symex_config.simplify_opt,
+      symex_config.simplify_phi,
       target,
       path_storage.dirty,
       ssa,

--- a/src/goto-symex/symex_main.cpp
+++ b/src/goto-symex/symex_main.cpp
@@ -37,6 +37,7 @@ symex_configt::symex_configt(const optionst &options)
     self_loops_to_assumptions(
       options.get_bool_option("self-loops-to-assumptions")),
     simplify_opt(options.get_bool_option("simplify")),
+    simplify_phi(options.get_bool_option("simplify-phi")),
     unwinding_assertions(options.get_bool_option("unwinding-assertions")),
     partial_loops(options.get_bool_option("partial-loops")),
     havoc_undefined_functions(


### PR DESCRIPTION
Allow disabling the simplification of phi functions as this is very expensive operation.

Using this option is not recommended in general, but in certain cases it has been observed to cut symex time in half without noticeable influence on SAT solving time.

Also removes the orphaned --no-simplify-if option in a separate commit.

- [X] Each commit message has a non-empty body, explaining why the change was made.
- [n/a] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [no] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [X] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [no] My commit message includes data points confirming performance improvements (if claimed).
- [almost] My PR is restricted to a single feature or bugfix.
- [n/a] White-space or formatting changes outside the feature-related changed lines are in commits of their own.
