### PR TITLE
Extend expr_initializer to support byte-wise initialization

### DIFF
--- a/src/util/expr_initializer.h
+++ b/src/util/expr_initializer.h
@@ -27,4 +27,12 @@ optionalt<exprt> nondet_initializer(
   const source_locationt &source_location,
   const namespacet &ns);
 
+optionalt<exprt> expr_initializer(
+  const typet &type,
+  const source_locationt &source_location,
+  const namespacet &ns,
+  const exprt &init_byte_expr);
+
+exprt duplicate_per_byte(const exprt &init_byte_expr, const typet &output_type);
+
 #endif // CPROVER_UTIL_EXPR_INITIALIZER_H


### PR DESCRIPTION
Each byte of the expression is initialized to the given initialization expression, if possible.

This building block will be required for the shadow memory implementation.

- [X] Each commit message has a non-empty body, explaining why the change was made.
- [X] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.
