### PR TITLE
get_subexpression_at_offset: do not permit out-of-bounds access

### DIFF
--- a/jbmc/src/java_bytecode/java_trace_validation.cpp
+++ b/jbmc/src/java_bytecode/java_trace_validation.cpp
@@ -285,18 +285,7 @@ static void check_rhs_assumptions(
   // check byte extract rhs structure
   else if(const auto byte = expr_try_dynamic_cast<byte_extract_exprt>(rhs))
   {
-    DATA_CHECK_WITH_DIAGNOSTICS(
-      vm,
-      byte->operands().size() == 2,
-      "RHS",
-      rhs.pretty(),
-      "Expecting a byte extract with two operands.");
-    DATA_CHECK_WITH_DIAGNOSTICS(
-      vm,
-      can_cast_expr<constant_exprt>(simplify_expr(byte->op(), ns)),
-      "RHS",
-      rhs.pretty(),
-      "Expecting a byte extract with constant value.");
+    check_rhs_assumptions(simplify_expr(byte->op(), ns), ns, vm);
     DATA_CHECK_WITH_DIAGNOSTICS(
       vm,
       can_cast_expr<constant_exprt>(simplify_expr(byte->offset(), ns)),

--- a/regression/cbmc/union-unequal-element-size1/test.desc
+++ b/regression/cbmc/union-unequal-element-size1/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.c
 --verbosity 10
 ^EXIT=0$
@@ -6,5 +6,3 @@ main.c
 ^VERIFICATION SUCCESSFUL$
 --
 ^warning: ignoring
---
-assert(s) fails with field sensitivity, but passes without

--- a/src/solvers/flattening/boolbv_get.cpp
+++ b/src/solvers/flattening/boolbv_get.cpp
@@ -297,16 +297,11 @@ exprt boolbvt::bv_get_unbounded_array(const exprt &expr) const
   exprt size=simplify_expr(get(size_expr), ns);
 
   // get the numeric value, unless it's infinity
-  mp_integer size_mpint = 0;
+  const auto size_opt = numeric_cast<mp_integer>(size);
 
-  if(size.is_not_nil() && size.id() != ID_infinity)
-  {
-    const auto size_opt = numeric_cast<mp_integer>(size);
-    if(size_opt.has_value() && *size_opt >= 0)
-      size_mpint = *size_opt;
-  }
-
-  // search array indices
+  // search array indices, and only use those applicable to a particular model
+  // (array theory may have seen other indices, which might only be live under a
+  // different model)
 
   typedef std::map<mp_integer, exprt> valuest;
   valuest values;
@@ -336,7 +331,9 @@ exprt boolbvt::bv_get_unbounded_array(const exprt &expr) const
       {
         const auto index_mpint = numeric_cast<mp_integer>(index_value);
 
-        if(index_mpint.has_value())
+        if(
+          index_mpint.has_value() && *index_mpint >= 0 &&
+          (!size_opt.has_value() || *index_mpint < *size_opt))
         {
           if(value.is_nil())
             values[*index_mpint] =
@@ -350,7 +347,7 @@ exprt boolbvt::bv_get_unbounded_array(const exprt &expr) const
 
   exprt result;
 
-  if(values.size() != size_mpint)
+  if(!size_opt.has_value() || values.size() != *size_opt)
   {
     result = array_list_exprt({}, to_array_type(type));
 
@@ -370,7 +367,7 @@ exprt boolbvt::bv_get_unbounded_array(const exprt &expr) const
     result=exprt(ID_array, type);
 
     // allocate operands
-    std::size_t size_int = numeric_cast_v<std::size_t>(size_mpint);
+    std::size_t size_int = numeric_cast_v<std::size_t>(*size_opt);
     result.operands().resize(size_int, exprt{ID_unknown});
 
     // search uninterpreted functions
@@ -378,9 +375,10 @@ exprt boolbvt::bv_get_unbounded_array(const exprt &expr) const
     for(valuest::iterator it=values.begin();
         it!=values.end();
         it++)
-      if(it->first>=0 && it->first<size_mpint)
-        result.operands()[numeric_cast_v<std::size_t>(it->first)].swap(
-          it->second);
+    {
+      result.operands()[numeric_cast_v<std::size_t>(it->first)].swap(
+        it->second);
+    }
   }
 
   return result;


### PR DESCRIPTION
An indexed access must not be out of bounds. This was surfaced by union field sensitivity, which ended up generating SSA symbols with indices beyond array bounds.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
