### PR TITLE
Use propt::lcnf when cnf_handled_well is true

### DIFF
--- a/src/solvers/flattening/boolbv_bv_rel.cpp
+++ b/src/solvers/flattening/boolbv_bv_rel.cpp
@@ -73,10 +73,20 @@ literalt boolbvt::convert_bv_rel(const binary_relation_exprt &expr)
         {
           literalt equal_lit = equality(lhs, rhs);
 
-          if(or_equal)
-            prop.l_set_to_true(prop.limplies(equal_lit, literal));
+          if(prop.cnf_handled_well())
+          {
+            if(or_equal)
+              prop.lcnf(!equal_lit, literal);
+            else
+              prop.lcnf(!equal_lit, !literal);
+          }
           else
-            prop.l_set_to_true(prop.limplies(equal_lit, !literal));
+          {
+            if(or_equal)
+              prop.l_set_to_true(prop.limplies(equal_lit, literal));
+            else
+              prop.l_set_to_true(prop.limplies(equal_lit, !literal));
+          }
         }
       }
 

--- a/src/solvers/flattening/boolbv_case.cpp
+++ b/src/solvers/flattening/boolbv_case.cpp
@@ -68,8 +68,10 @@ bvt boolbvt::convert_case(const exprt &expr)
       {
         literalt value_literal=bv_utils.equal(bv, op);
 
-        prop.l_set_to_true(
-          prop.limplies(compare_literal, value_literal));
+        if(prop.cnf_handled_well())
+          prop.lcnf({!compare_literal, value_literal});
+        else
+          prop.l_set_to_true(prop.limplies(compare_literal, value_literal));
       }
 
       what=COMPARE;

--- a/src/solvers/flattening/boolbv_cond.cpp
+++ b/src/solvers/flattening/boolbv_cond.cpp
@@ -45,9 +45,19 @@ bvt boolbvt::convert_cond(const cond_exprt &expr)
       {
         const bvt &op = convert_bv(operand, bv.size());
 
-        literalt value_literal=bv_utils.equal(bv, op);
-
-        prop.l_set_to_true(prop.limplies(cond_literal, value_literal));
+        if(prop.cnf_handled_well())
+        {
+          for(std::size_t i = 0; i < bv.size(); ++i)
+          {
+            prop.lcnf({!cond_literal, !bv[i], op[i]});
+            prop.lcnf({!cond_literal, bv[i], !op[i]});
+          }
+        }
+        else
+        {
+          literalt value_literal = bv_utils.equal(bv, op);
+          prop.l_set_to_true(prop.limplies(cond_literal, value_literal));
+        }
       }
 
       condition=!condition;

--- a/src/solvers/flattening/boolbv_extractbit.cpp
+++ b/src/solvers/flattening/boolbv_extractbit.cpp
@@ -65,8 +65,17 @@ literalt boolbvt::convert_extractbit(const extractbit_exprt &expr)
       for(std::size_t i = 0; i < src_bv.size(); i++)
       {
         equal_exprt equality(index_casted, from_integer(i, index_type));
-        literalt equal = prop.lequal(literal, src_bv[i]);
-        prop.l_set_to_true(prop.limplies(convert(equality), equal));
+        if(prop.cnf_handled_well())
+        {
+          literalt index_eq = convert(equality);
+          prop.lcnf({!index_eq, !literal, src_bv[i]});
+          prop.lcnf({!index_eq, literal, !src_bv[i]});
+        }
+        else
+        {
+          literalt equal = prop.lequal(literal, src_bv[i]);
+          prop.l_set_to_true(prop.limplies(convert(equality), equal));
+        }
       }
 
       return literal;

--- a/src/solvers/flattening/bv_pointers.cpp
+++ b/src/solvers/flattening/bv_pointers.cpp
@@ -697,8 +697,20 @@ bvt bv_pointerst::convert_bitvector(const exprt &expr)
           prop.lor(in_bounds, prop.land(lhs_in_bounds, rhs_in_bounds));
       }
 
-      prop.l_set_to_true(prop.limplies(
-        prop.land(same_object_lit, in_bounds), bv_utils.equal(difference, bv)));
+      if(prop.cnf_handled_well())
+      {
+        for(std::size_t i = 0; i < width; ++i)
+        {
+          prop.lcnf({!same_object_lit, !in_bounds, !difference[i], bv[i]});
+          prop.lcnf({!same_object_lit, !in_bounds, difference[i], !bv[i]});
+        }
+      }
+      else
+      {
+        prop.l_set_to_true(prop.limplies(
+          prop.land(same_object_lit, in_bounds),
+          bv_utils.equal(difference, bv)));
+      }
     }
 
     return bv;
@@ -1071,10 +1083,18 @@ void bv_pointerst::finish_eager_conversion()
       replace_expr(replacements, is_not_dyn);
 
       PRECONDITION(postponed.bv.size() == 1);
-      prop.l_set_to_true(
-        prop.limplies(convert_bv(is_dyn)[0], postponed.bv.front()));
-      prop.l_set_to_true(
-        prop.limplies(convert_bv(is_not_dyn)[0], !postponed.bv.front()));
+      if(prop.cnf_handled_well())
+      {
+        prop.lcnf({!convert_bv(is_dyn)[0], postponed.bv.front()});
+        prop.lcnf({!convert_bv(is_not_dyn)[0], !postponed.bv.front()});
+      }
+      else
+      {
+        prop.l_set_to_true(
+          prop.limplies(convert_bv(is_dyn)[0], postponed.bv.front()));
+        prop.l_set_to_true(
+          prop.limplies(convert_bv(is_not_dyn)[0], !postponed.bv.front()));
+      }
     }
     else if(
       const auto postponed_object_size =
@@ -1121,7 +1141,10 @@ void bv_pointerst::finish_eager_conversion()
 #ifndef COMPACT_OBJECT_SIZE_EQ
         literalt l2 = bv_utils.equal(postponed.bv, size_bv);
 
-        prop.l_set_to_true(prop.limplies(l1, l2));
+        if(prop.cnf_handled_well())
+          prop.lcnf({!l1, l2});
+        else
+          prop.l_set_to_true(prop.limplies(l1, l2));
 #else
         for(std::size_t i = 0; i < postponed.bv.size(); ++i)
         {

--- a/src/solvers/prop/prop_conv_solver.cpp
+++ b/src/solvers/prop/prop_conv_solver.cpp
@@ -251,7 +251,10 @@ literalt prop_conv_solvert::convert_bool(const exprt &expr)
     for(unsigned i = 1; i < op_bv.size(); i++)
       b.push_back(prop.lequal(op_bv[0], op_bv[i]));
 
-    prop.l_set_to_true(prop.lor(b));
+    if(prop.cnf_handled_well())
+      prop.lcnf(b);
+    else
+      prop.l_set_to_true(prop.lor(b));
 
     return op_bv[0];
   }

--- a/src/solvers/refinement/refine_arithmetic.cpp
+++ b/src/solvers/refinement/refine_arithmetic.cpp
@@ -82,16 +82,31 @@ bvt bv_refinementt::convert_mult(const mult_exprt &expr)
     literalt op0_zero=bv_utils.is_zero(a.op0_bv);
     literalt op1_zero=bv_utils.is_zero(a.op1_bv);
     literalt res_zero=bv_utils.is_zero(a.result_bv);
-    prop.l_set_to_true(
-      prop.limplies(prop.lor(op0_zero, op1_zero), res_zero));
+    if(prop.cnf_handled_well())
+    {
+      prop.lcnf({!op0_zero, res_zero});
+      prop.lcnf({!op1_zero, res_zero});
+    }
+    else
+    {
+      prop.l_set_to_true(prop.limplies(prop.lor(op0_zero, op1_zero), res_zero));
+    }
 
     // x*1==x and 1*x==x
     literalt op0_one=bv_utils.is_one(a.op0_bv);
     literalt op1_one=bv_utils.is_one(a.op1_bv);
     literalt res_op0=bv_utils.equal(a.op0_bv, a.result_bv);
     literalt res_op1=bv_utils.equal(a.op1_bv, a.result_bv);
-    prop.l_set_to_true(prop.limplies(op0_one, res_op1));
-    prop.l_set_to_true(prop.limplies(op1_one, res_op0));
+    if(prop.cnf_handled_well())
+    {
+      prop.lcnf({!op0_one, res_op1});
+      prop.lcnf({!op1_one, res_op0});
+    }
+    else
+    {
+      prop.l_set_to_true(prop.limplies(op0_one, res_op1));
+      prop.l_set_to_true(prop.limplies(op1_one, res_op0));
+    }
   }
 
   return bv;
@@ -238,11 +253,16 @@ void bv_refinementt::check_SAT(approximationt &a)
       literalt result_equal=
         bv_utils.equal(a.result_bv, float_utils.build_constant(result));
 
-      literalt op0_and_op1_equal=
-        prop.land(op0_equal, op1_equal);
+      if(prop.cnf_handled_well())
+      {
+        prop.lcnf({!op0_equal, !op1_equal, result_equal});
+      }
+      else
+      {
+        literalt op0_and_op1_equal = prop.land(op0_equal, op1_equal);
 
-      prop.l_set_to_true(
-        prop.limplies(op0_and_op1_equal, result_equal));
+        prop.l_set_to_true(prop.limplies(op0_and_op1_equal, result_equal));
+      }
     }
     else
     {


### PR DESCRIPTION
We can avoid Tseitin variables when using lcnf directly instead of using set_to_{true,false}. Pending performance evaluation.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
