### PR TITLE
C and jsil front-ends: make to_symbol return by value

### DIFF
--- a/src/ansi-c/ansi_c_declaration.cpp
+++ b/src/ansi-c/ansi_c_declaration.cpp
@@ -125,14 +125,11 @@ typet ansi_c_declarationt::full_type(
   return result;
 }
 
-void ansi_c_declarationt::to_symbol(
-  const ansi_c_declaratort &declarator,
-  symbolt &symbol) const
+symbolt
+ansi_c_declarationt::to_symbol(const ansi_c_declaratort &declarator) const
 {
-  symbol.clear();
+  symbolt symbol{declarator.get_name(), full_type(declarator), ID_C};
   symbol.value=declarator.value();
-  symbol.type=full_type(declarator);
-  symbol.name=declarator.get_name();
   symbol.pretty_name=symbol.name;
   symbol.base_name=declarator.get_base_name();
   symbol.is_type=get_is_typedef();
@@ -190,4 +187,6 @@ void ansi_c_declarationt::to_symbol(
       symbol.is_macro || (!get_is_global() && !get_is_extern()) ||
       (get_is_global() && get_is_static()) || symbol.is_parameter;
   }
+
+  return symbol;
 }

--- a/src/ansi-c/ansi_c_declaration.h
+++ b/src/ansi-c/ansi_c_declaration.h
@@ -195,9 +195,7 @@ public:
     set(ID_is_weak, is_weak);
   }
 
-  void to_symbol(
-    const ansi_c_declaratort &,
-    symbolt &symbol) const;
+  symbolt to_symbol(const ansi_c_declaratort &) const;
 
   typet full_type(const ansi_c_declaratort &) const;
 

--- a/src/ansi-c/c_typecheck_base.cpp
+++ b/src/ansi-c/c_typecheck_base.cpp
@@ -781,8 +781,7 @@ void c_typecheck_baset::typecheck_declaration(
       declaration.set_is_typedef(full_spec.is_typedef);
       declaration.set_is_weak(full_spec.is_weak);
 
-      symbolt symbol;
-      declaration.to_symbol(declarator, symbol);
+      symbolt symbol = declaration.to_symbol(declarator);
       current_symbol=symbol;
 
       // now check other half of type

--- a/src/jsil/jsil_convert.cpp
+++ b/src/jsil/jsil_convert.cpp
@@ -43,8 +43,7 @@ bool jsil_convertt::operator()(
       it!=parse_tree.items.end();
       ++it)
   {
-    symbolt new_symbol;
-    it->to_symbol(new_symbol);
+    symbolt new_symbol = it->to_symbol();
 
     if(convert_code(new_symbol, to_code(new_symbol.value)))
       return true;

--- a/src/jsil/jsil_parse_tree.cpp
+++ b/src/jsil/jsil_parse_tree.cpp
@@ -40,10 +40,8 @@ static bool insert_at_label(
   return true;
 }
 
-void jsil_declarationt::to_symbol(symbolt &symbol) const
+symbolt jsil_declarationt::to_symbol() const
 {
-  symbol.clear();
-
   symbol_exprt s(to_symbol_expr(
       static_cast<const exprt&>(find(ID_declarator))));
 
@@ -56,10 +54,8 @@ void jsil_declarationt::to_symbol(symbolt &symbol) const
   else if(proc_type=="spec")
     symbol_type=jsil_spec_code_typet(symbol_type);
 
-  symbol.name=s.get_identifier();
+  symbolt symbol{s.get_identifier(), symbol_type, "jsil"};
   symbol.base_name=s.get_identifier();
-  symbol.mode="jsil";
-  symbol.type=symbol_type;
   symbol.location=s.source_location();
 
   code_blockt code(to_code_block(
@@ -79,6 +75,8 @@ void jsil_declarationt::to_symbol(symbolt &symbol) const
     throw "throw label "+throws.get_string(ID_label)+" not found";
 
   symbol.value.swap(code);
+
+  return symbol;
 }
 
 void jsil_declarationt::output(std::ostream &out) const

--- a/src/jsil/jsil_parse_tree.h
+++ b/src/jsil/jsil_parse_tree.h
@@ -92,7 +92,7 @@ public:
     return static_cast<code_blockt &>(add(ID_value));
   }
 
-  void to_symbol(symbolt &symbol) const;
+  symbolt to_symbol() const;
 
   void output(std::ostream &) const;
 };

--- a/src/util/symbol.h
+++ b/src/util/symbol.h
@@ -93,22 +93,6 @@ public:
   {
   }
 
-  /// Zero initialise a symbol object.
-  void clear()
-  {
-    type.make_nil();
-    value.make_nil();
-    location.make_nil();
-
-    name=module=base_name=mode=pretty_name=irep_idt();
-
-    is_type=is_macro=is_exported=
-    is_input=is_output=is_state_var=is_property=
-    is_static_lifetime=is_thread_local=
-    is_lvalue=is_file_local=is_extern=is_volatile=
-    is_parameter=is_auxiliary=is_weak=false;
-  }
-
   void swap(symbolt &b);
   void show(std::ostream &out) const;
 


### PR DESCRIPTION
Instead of creating and dummy-initialising a symbolt upfront, return a locally allocated symbol.

This removes the last users of symbolt::clear, which had maintenance risks in that it had to list all members.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
