### PR TITLE
jsil: use new symbolt constructors

### DIFF
--- a/src/jsil/jsil_entry_point.cpp
+++ b/src/jsil/jsil_entry_point.cpp
@@ -26,12 +26,9 @@ Author: Michael Tautschnig, tautschn@amazon.com
 
 static void create_initialize(symbol_table_baset &symbol_table)
 {
-  symbolt initialize;
-  initialize.name = INITIALIZE_FUNCTION;
+  symbolt initialize{
+    INITIALIZE_FUNCTION, code_typet({}, empty_typet()), "jsil"};
   initialize.base_name = INITIALIZE_FUNCTION;
-  initialize.mode="jsil";
-
-  initialize.type = code_typet({}, empty_typet());
 
   code_blockt init_code;
 
@@ -150,11 +147,9 @@ bool jsil_entry_point(
   init_code.add(call_main);
 
   // add "main"
-  symbolt new_symbol;
-
-  new_symbol.name=goto_functionst::entry_point();
+  symbolt new_symbol{
+    goto_functionst::entry_point(), code_typet{{}, empty_typet{}}, "jsil"};
   new_symbol.base_name = goto_functionst::entry_point();
-  new_symbol.type = code_typet({}, empty_typet());
   new_symbol.value.swap(init_code);
 
   if(!symbol_table.insert(std::move(new_symbol)).second)

--- a/src/jsil/jsil_internal_additions.cpp
+++ b/src/jsil/jsil_internal_additions.cpp
@@ -24,11 +24,8 @@ void jsil_internal_additions(symbol_table_baset &dest)
   // add __CPROVER_rounding_mode
 
   {
-    symbolt symbol;
-    symbol.name = rounding_mode_identifier();
+    symbolt symbol{rounding_mode_identifier(), signed_int_type(), ID_C};
     symbol.base_name = symbol.name;
-    symbol.type=signed_int_type();
-    symbol.mode=ID_C;
     symbol.is_lvalue=true;
     symbol.is_state_var=true;
     symbol.is_thread_local=true;
@@ -42,22 +39,16 @@ void jsil_internal_additions(symbol_table_baset &dest)
   {
     code_typet eval_type({code_typet::parametert(typet())}, empty_typet());
 
-    symbolt symbol;
+    symbolt symbol{"eval", eval_type, "jsil"};
     symbol.base_name="eval";
-    symbol.name="eval";
-    symbol.type=eval_type;
-    symbol.mode="jsil";
     dest.add(symbol);
   }
 
   // add nan
 
   {
-    symbolt symbol;
+    symbolt symbol{"nan", floatbv_typet(), "jsil"};
     symbol.base_name="nan";
-    symbol.name="nan";
-    symbol.type=floatbv_typet();
-    symbol.mode="jsil";
     // mark as already typechecked
     symbol.is_extern=true;
     dest.add(symbol);
@@ -66,11 +57,8 @@ void jsil_internal_additions(symbol_table_baset &dest)
   // add empty symbol used for decl statements
 
   {
-    symbolt symbol;
+    symbolt symbol{"decl_symbol", empty_typet(), "jsil"};
     symbol.base_name="decl_symbol";
-    symbol.name="decl_symbol";
-    symbol.type=empty_typet();
-    symbol.mode="jsil";
     // mark as already typechecked
     symbol.is_extern=true;
     dest.add(symbol);
@@ -92,13 +80,8 @@ void jsil_internal_additions(symbol_table_baset &dest)
 
   for(const auto &identifier : builtin_objects)
   {
-    symbolt new_symbol;
-    new_symbol.name=identifier;
-    new_symbol.type=jsil_builtin_object_type();
+    symbolt new_symbol{identifier, jsil_builtin_object_type(), "jsil"};
     new_symbol.base_name=identifier;
-    new_symbol.mode="jsil";
-    new_symbol.is_type=false;
-    new_symbol.is_lvalue=false;
     // mark as already typechecked
     new_symbol.is_extern=true;
     dest.add(new_symbol);

--- a/src/jsil/jsil_typecheck.cpp
+++ b/src/jsil/jsil_typecheck.cpp
@@ -601,12 +601,8 @@ void jsil_typecheckt::typecheck_symbol_expr(symbol_exprt &symbol_expr)
     if(s_it==symbol_table.symbols.end())
     {
       // create new symbol
-      symbolt new_symbol;
-      new_symbol.name=identifier;
-      new_symbol.type=symbol_expr.type();
+      symbolt new_symbol{identifier, symbol_expr.type(), "jsil"};
       new_symbol.base_name=identifier_base;
-      new_symbol.mode="jsil";
-      new_symbol.is_type=false;
       new_symbol.is_lvalue=new_symbol.type.id()!=ID_code;
 
       // mark as already typechecked
@@ -786,11 +782,7 @@ void jsil_typecheckt::typecheck_function_call(
     else
     {
       // Should be function, declaration not found yet
-      symbolt new_symbol;
-      new_symbol.name=id;
-      new_symbol.type = code_typet({}, typet());
-      new_symbol.mode="jsil";
-      new_symbol.is_type=false;
+      symbolt new_symbol{id, code_typet({}, typet()), "jsil"};
       new_symbol.value=exprt("no-body-just-yet");
 
       make_type_compatible(lhs, jsil_any_type(), true);


### PR DESCRIPTION
To the extent possible, apply resource-acquisition-is-initialisation. The constructors ensure that at least the most essential fields (name, type, mode) are set.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
