### PR TITLE
fixup! Simplify byte_extract(byte_update(...)) without overlap

### DIFF
--- a/src/util/simplify_expr.cpp
+++ b/src/util/simplify_expr.cpp
@@ -1727,7 +1727,8 @@ simplify_exprt::simplify_byte_extract(const byte_extract_exprt &expr)
         const auto update_size = pointer_offset_bits(bu.value().type(), ns);
         if(
           update_size.has_value() &&
-          *offset >= *update_offset * bu.get_bits_per_byte() + *update_size)
+          *offset * expr.get_bits_per_byte() >=
+            *update_offset * bu.get_bits_per_byte() + *update_size)
         {
           auto tmp = expr;
           tmp.op() = bu.op();


### PR DESCRIPTION
This fixes a bits/bytes confusing, resulting in missed optimisations of byte_extract(byte_update(...)) nestings when the byte_extract was at an offset higher than the update. Found while debugging https://github.com/model-checking/kani/issues/1958.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
