### PR TITLE
Remove internal symbols: keep all symbols used in contracts

### DIFF
--- a/regression/ansi-c/static5/main.c
+++ b/regression/ansi-c/static5/main.c
@@ -1,0 +1,24 @@
+typedef struct vtable_s
+{
+  int (*f)(void);
+} vtable_t;
+
+int return_0()
+{
+  return 0;
+}
+
+static vtable_t vtable_0 = {.f = &return_0};
+
+void foo(vtable_t *vtable)
+  __CPROVER_requires((void *)0 == vtable || &vtable_0 == vtable)
+{
+  if(vtable->f)
+    vtable->f();
+}
+
+int main()
+{
+  vtable_t *vtable;
+  foo(vtable);
+}

--- a/regression/ansi-c/static5/test.desc
+++ b/regression/ansi-c/static5/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+--verbosity 10
+^Removing unused symbol
+^EXIT=0$
+^SIGNAL=0$
+--
+^Removing unused symbol vtable_0$

--- a/src/linking/remove_internal_symbols.cpp
+++ b/src/linking/remove_internal_symbols.cpp
@@ -76,16 +76,11 @@ static void get_symbols(
 
       for(const auto &s : new_symbols)
       {
-        // keep functions called in contracts within scope.
-        // should we keep local variables from the contract as well?
-        const symbolt *new_symbol = nullptr;
-        if(!ns.lookup(s, new_symbol))
-        {
-          if(new_symbol->type.id() == ID_code)
-          {
-            working_set.push_back(new_symbol);
-          }
-        }
+        const symbolt *symbol_ptr;
+        // identifiers for parameters of prototypes need not exist, and neither
+        // does __CPROVER_return_value
+        if(!ns.lookup(s, symbol_ptr))
+          working_set.push_back(symbol_ptr);
       }
     }
   }
@@ -239,6 +234,7 @@ void remove_internal_symbols(
     if(exported.find(it->first)==exported.end())
     {
       symbol_table_baset::symbolst::const_iterator next = std::next(it);
+      log.debug() << "Removing unused symbol " << it->first << messaget::eom;
       symbol_table.erase(it);
       it=next;
     }


### PR DESCRIPTION
In beb1353cf2 we had chosen to only keep code-typed symbols, but indeed we also need to retain objects (only) referred to from contracts.

Also add debug-level status information of what symbols are being removed (which is information I have previously needed more than once in debugging, and it's also now the only actual use of the messaget that we already had in place).

Fixes: #7414

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
