### PR TITLE
[HOTFIX] Add a pragma to silence warning for libcprover-cpp/options.h include

### DIFF
--- a/src/libcprover-cpp/api.h
+++ b/src/libcprover-cpp/api.h
@@ -10,9 +10,15 @@
 // Forward declaration of API dependencies
 class goto_modelt;
 class message_handlert;
-class optionst;
 
-#include "options.h"
+// There has been a design decision to allow users to include all of
+// the API headers by just including `api.h`, so we want to have an
+// include for all the API headers below. If we get any auxiliary
+// development tools complaining about the includes, please use
+// a pragma like below to silence the warning (at least as long
+// as the design principle is to be followed.)
+
+#include "options.h" // IWYU pragma: keep
 
 // An object in the pattern of Session Facade - owning all of the memory
 // the API is using and being responsible for the management of that.


### PR DESCRIPTION
This silences a CI warning by one of our auxiliary runs, which
checks whether an include inside a file is used.

This change adds the rationale as a comment, and it also adds
a `pragma` directive for the tool to silence the warning.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
