### PR TITLE
Byte operator lowering: no type casts to/from compound types

### DIFF
--- a/regression/cbmc/byte_update17/main.c
+++ b/regression/cbmc/byte_update17/main.c
@@ -1,0 +1,24 @@
+#include <inttypes.h>
+#include <string.h>
+
+// a union that is exactly one byte wide
+union U
+{
+  unsigned char c;
+};
+
+int main()
+{
+  unsigned char size;
+  __CPROVER_assume(size > 1);
+  __CPROVER_assume(size < 5);
+  __CPROVER_assume(size % 4 == 0);
+  union U u[size];
+  u[0].c = 42;
+  u[1].c = 42;
+  u[2].c = 42;
+  u[3].c = 42;
+  int32_t dest;
+  memcpy(&dest, u, size);
+  __CPROVER_assert(dest == 42 | 42 << 8 | 42 << 16 | 42 << 24, "");
+}

--- a/regression/cbmc/byte_update17/test.desc
+++ b/regression/cbmc/byte_update17/test.desc
@@ -1,0 +1,11 @@
+CORE broken-cprover-smt-backend
+main.c
+
+^VERIFICATION SUCCESSFUL$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--
+This test currently does not pass with CPROVER SMT2 backend
+because the solver does not fully support quantified expressions.


### PR DESCRIPTION
We need to create proper struct or union expressions instead of doing a type cast, even when the compound type is no wider than a single byte. Equally, we must not fall back to just type casts to bit vectors when there is an array of structs/unions where those are exactly one byte wide.

Fixes: #7288

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
