### PR TITLE
Add cbmc primitive regression tests

### DIFF
--- a/regression/cbmc-primitives/dynamic-object-02/test-no-cp.desc
+++ b/regression/cbmc-primitives/dynamic-object-02/test-no-cp.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 --no-simplify --no-propagation
 ^EXIT=10$

--- a/regression/cbmc-primitives/dynamic-object-02/test.desc
+++ b/regression/cbmc-primitives/dynamic-object-02/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 
 ^EXIT=10$

--- a/regression/cbmc-primitives/exists_memory_checks/negated_exists.desc
+++ b/regression/cbmc-primitives/exists_memory_checks/negated_exists.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 negated_exists.c
 --pointer-check
 ^EXIT=0$

--- a/regression/cbmc-primitives/pointer-offset-01/test-no-cp.desc
+++ b/regression/cbmc-primitives/pointer-offset-01/test-no-cp.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 --no-simplify --no-propagation
 ^EXIT=10$

--- a/regression/cbmc-primitives/pointer-offset-01/test.desc
+++ b/regression/cbmc-primitives/pointer-offset-01/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 
 ^EXIT=10$

--- a/regression/cbmc-primitives/r_w_ok_bug/test.desc
+++ b/regression/cbmc-primitives/r_w_ok_bug/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 --pointer-check --no-simplify --no-propagation
 ^\[main.pointer_dereference.\d+\] line 8 dereference failure: pointer outside object bounds in \*p1: FAILURE$

--- a/regression/cbmc-primitives/r_w_ok_valid_negated/test-no-cp.desc
+++ b/regression/cbmc-primitives/r_w_ok_valid_negated/test-no-cp.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 --pointer-check --no-simplify --no-propagation
 ^EXIT=0$

--- a/regression/cbmc-primitives/same-object-03/test-no-cp.desc
+++ b/regression/cbmc-primitives/same-object-03/test-no-cp.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 --no-simplify --no-propagation
 ^EXIT=0$

--- a/src/solvers/smt2_incremental/convert_expr_to_smt.cpp
+++ b/src/solvers/smt2_incremental/convert_expr_to_smt.cpp
@@ -1351,7 +1351,7 @@ static smt_termt convert_expr_to_smt(
     smt_bit_vector_theoryt::extract(offset_bits - 1, 0)(converted_expr);
   if(width > offset_bits)
   {
-    return smt_bit_vector_theoryt::zero_extend(width - offset_bits)(extract_op);
+    return smt_bit_vector_theoryt::sign_extend(width - offset_bits)(extract_op);
   }
   return extract_op;
 }

--- a/unit/solvers/smt2_incremental/convert_expr_to_smt.cpp
+++ b/unit/solvers/smt2_incremental/convert_expr_to_smt.cpp
@@ -1633,7 +1633,7 @@ TEST_CASE("pointer_offset_exprt to SMT conversion", "[core][smt2_incremental]")
   {
     const auto converted = test.convert(pointer_offset);
     const auto expected =
-      smt_bit_vector_theoryt::zero_extend(8)(smt_bit_vector_theoryt::extract(
+      smt_bit_vector_theoryt::sign_extend(8)(smt_bit_vector_theoryt::extract(
         55, 0)(smt_identifier_termt("foo", smt_bit_vector_sortt(64))));
     CHECK(converted == expected);
   }


### PR DESCRIPTION
This PR is composed of 3 parts (commits):
 1. Run all now working `cbmc-primitive` regression tests with the incremental SMT2 solver,
 2. Fix an issue in the incremental SMT2 backed converter when a pointer offset was wrongly considered unsigned,
 3. Run other 3 now working (fixed by step 2) `cbmc-primitive` regression tests with the incremental SMT2 solver.

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
