### PR TITLE
Simplify (T*)bitvector-constant to pointer-typed constant

### DIFF
--- a/src/util/simplify_expr.cpp
+++ b/src/util/simplify_expr.cpp
@@ -862,6 +862,17 @@ simplify_exprt::simplify_typecast(const typecast_exprt &expr)
     to_constant_expr(tmp).set_value(ID_NULL);
     return std::move(tmp);
   }
+  else if(
+    expr_type.id() == ID_pointer && expr.op().is_constant() &&
+    (op_type.id() == ID_signedbv || op_type.id() == ID_unsignedbv ||
+     op_type.id() == ID_bv) &&
+    to_bitvector_type(op_type).get_width() >=
+      to_bitvector_type(expr_type).get_width())
+  {
+    constant_exprt new_expr = to_constant_expr(expr.op());
+    new_expr.type() = expr_type;
+    return new_expr;
+  }
 
   // eliminate duplicate pointer typecasts
   // (T1 *)(T2 *)x -> (T1 *)x


### PR DESCRIPTION
This is to make sure that we can simplify equality tests over pointer-typed expressions where at least one of them was created via a sequence of simplification steps. Seen in
https://github.com/model-checking/kani/issues/1978, but the new simplification code is actually triggered by mm_io1, r_w_ok10, and union12 regression tests.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
