### PR TITLE
Regression tests/CMake: make SMT test labels unique

### DIFF
--- a/regression/cbmc-primitives/CMakeLists.txt
+++ b/regression/cbmc-primitives/CMakeLists.txt
@@ -7,7 +7,7 @@ if(Z3_EXISTS)
 
     # If `-I` (include flag) is passed, test.pl will run only the tests matching the label following it.
     add_test_pl_profile(
-            "cbmc-new-smt-backend"
+            "cbmc-primitives-new-smt-backend"
             "$<TARGET_FILE:cbmc> --incremental-smt2-solver 'z3 --smt2 -in' --slice-formula"
             "-I;new-smt-backend;-s;new-smt-backend"
             "CORE"


### PR DESCRIPTION
This fix is cherry-picked from https://github.com/diffblue/cbmc/pull/7395/commits/ecd98707755451406860500645330fb0c7d2257d
I have raised this as a separate PR, as I would like to get this merged asap and to get it merged regardless of the discussions about the architectural merits of the original PR.

We already have cbmc-new-smt-backend in regression/cbmc. Having duplicate labels confuses ctest for it won't able able to uniquely identify test sets.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
