### PR TITLE
CONTRACTS: remove leftover debug print

### DIFF
--- a/src/goto-instrument/contracts/dynamic-frames/dfcc_lift_memory_predicates.cpp
+++ b/src/goto-instrument/contracts/dynamic-frames/dfcc_lift_memory_predicates.cpp
@@ -357,10 +357,6 @@ void dfcc_lift_memory_predicatest::lift_parameters_and_update_body(
       }
     }
   }
-  for(auto instruction : body.instructions)
-  {
-    instruction.output(log.debug());
-  }
 }
 
 void dfcc_lift_memory_predicatest::lift_predicate(


### PR DESCRIPTION
Remove a leftover debug print which was flooding the terminal output.

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.
