### PR TITLE
Remove void* pointer arithmetic support from back-ends

### DIFF
--- a/regression/cbmc/ptr_arithmetic_on_null/test.desc
+++ b/regression/cbmc/ptr_arithmetic_on_null/test.desc
@@ -1,10 +1,10 @@
 CORE gcc-only
 main.c
 
-^\[main.assertion.1\] line .* assertion \(void \*\)0 != \(void \*\)0 \+ \(.*\)1: SUCCESS$
-^\[main.assertion.2\] line .* assertion \(void \*\)0 != \(void \*\)0 - \(.*\)1: SUCCESS$
-^\[main.assertion.3\] line .* assertion \(void \*\)0 != \(void \*\)0 \+ \(.*\)offset: SUCCESS$
-^\[main.assertion.4\] line .* assertion \(void \*\)0 - \(void \*\)0 == \(.*\)0: SUCCESS$
+^\[main.assertion.1\] line .* assertion \(\(char \*\)NULL\) != \(char \*\)\(void \*\)0 \+ \(.*\)1: SUCCESS$
+^\[main.assertion.2\] line .* assertion \(\(char \*\)NULL\) != \(char \*\)\(void \*\)0 - \(.*\)1: SUCCESS$
+^\[main.assertion.3\] line .* assertion \(\(char \*\)NULL\) != \(char \*\)\(void \*\)0 \+ \(.*\)offset: SUCCESS$
+^\[main.assertion.4\] line .* assertion \(char \*\)\(void \*\)0 - \(char \*\)\(void \*\)0 == \(.*\)0: SUCCESS$
 ^\[main.assertion.5\] line .* assertion ptr - \(signed int \*\)\(void \*\)0 == \(.*\)0: FAILURE$
 ^\[main.assertion.6\] line .* assertion \(ptr - \(.*\)1\) \+ \(.*\)1 == \(\(.* \*\)NULL\): SUCCESS$
 ^\[main.assertion.7\] line .* assertion \(ptr - \(.*\)1\) \+ \(.*\)1 == \(\(.* \*\)NULL\): FAILURE$

--- a/src/ansi-c/c_typecheck_base.h
+++ b/src/ansi-c/c_typecheck_base.h
@@ -196,7 +196,7 @@ protected:
   virtual void typecheck_expr_binary_arithmetic(exprt &expr);
   virtual void typecheck_expr_shifts(shift_exprt &expr);
   virtual void typecheck_expr_pointer_arithmetic(exprt &expr);
-  virtual void typecheck_arithmetic_pointer(const exprt &expr);
+  virtual void typecheck_arithmetic_pointer(exprt &expr);
   virtual void typecheck_expr_binary_boolean(exprt &expr);
   virtual void typecheck_expr_trinary(if_exprt &expr);
   virtual void typecheck_expr_address_of(exprt &expr);

--- a/src/solvers/flattening/bv_pointers.cpp
+++ b/src/solvers/flattening/bv_pointers.cpp
@@ -447,19 +447,12 @@ bvt bv_pointerst::convert_pointer_type(const exprt &expr)
         CHECK_RETURN(bv.size()==bits);
 
         typet pointer_base_type = to_pointer_type(op.type()).base_type();
-
-        if(pointer_base_type.id() == ID_empty)
-        {
-          // This is a gcc extension.
-          // https://gcc.gnu.org/onlinedocs/gcc-4.8.0/gcc/Pointer-Arith.html
-          size = 1;
-        }
-        else
-        {
-          auto size_opt = pointer_offset_size(pointer_base_type, ns);
-          CHECK_RETURN(size_opt.has_value() && *size_opt >= 0);
-          size = *size_opt;
-        }
+        DATA_INVARIANT(
+          pointer_base_type.id() != ID_empty,
+          "no pointer arithmetic over void pointers");
+        auto size_opt = pointer_offset_size(pointer_base_type, ns);
+        CHECK_RETURN(size_opt.has_value() && *size_opt >= 0);
+        size = *size_opt;
       }
     }
 
@@ -519,22 +512,12 @@ bvt bv_pointerst::convert_pointer_type(const exprt &expr)
 
     typet pointer_base_type =
       to_pointer_type(minus_expr.lhs().type()).base_type();
-    mp_integer element_size;
-
-    if(pointer_base_type.id() == ID_empty)
-    {
-      // This is a gcc extension.
-      // https://gcc.gnu.org/onlinedocs/gcc-4.8.0/gcc/Pointer-Arith.html
-      element_size = 1;
-    }
-    else
-    {
-      auto element_size_opt = pointer_offset_size(pointer_base_type, ns);
-      CHECK_RETURN(element_size_opt.has_value() && *element_size_opt > 0);
-      element_size = *element_size_opt;
-    }
-
-    return offset_arithmetic(type, bv, element_size, neg_op1);
+    DATA_INVARIANT(
+      pointer_base_type.id() != ID_empty,
+      "no pointer arithmetic over void pointers");
+    auto element_size_opt = pointer_offset_size(pointer_base_type, ns);
+    CHECK_RETURN(element_size_opt.has_value() && *element_size_opt > 0);
+    return offset_arithmetic(type, bv, *element_size_opt, neg_op1);
   }
   else if(expr.id()==ID_byte_extract_little_endian ||
           expr.id()==ID_byte_extract_big_endian)
@@ -641,21 +624,17 @@ bvt bv_pointerst::convert_bitvector(const exprt &expr)
 
       bvt difference = bv_utils.sub(lhs_offset, rhs_offset);
 
-      // Support for void* is a gcc extension, with the size treated as 1 byte
-      // (no division required below).
-      // https://gcc.gnu.org/onlinedocs/gcc-4.8.0/gcc/Pointer-Arith.html
-      if(lhs_pt.base_type().id() != ID_empty)
-      {
-        auto element_size_opt = pointer_offset_size(lhs_pt.base_type(), ns);
-        CHECK_RETURN(element_size_opt.has_value() && *element_size_opt > 0);
+      DATA_INVARIANT(
+        lhs_pt.base_type().id() != ID_empty,
+        "no pointer arithmetic over void pointers");
+      auto element_size_opt = pointer_offset_size(lhs_pt.base_type(), ns);
+      CHECK_RETURN(element_size_opt.has_value() && *element_size_opt > 0);
 
-        if(*element_size_opt != 1)
-        {
-          bvt element_size_bv =
-            bv_utils.build_constant(*element_size_opt, width);
-          difference = bv_utils.divider(
-            difference, element_size_bv, bv_utilst::representationt::SIGNED);
-        }
+      if(*element_size_opt != 1)
+      {
+        bvt element_size_bv = bv_utils.build_constant(*element_size_opt, width);
+        difference = bv_utils.divider(
+          difference, element_size_bv, bv_utilst::representationt::SIGNED);
       }
 
       // test for null object (integer constants)

--- a/src/solvers/flattening/pointer_logic.cpp
+++ b/src/solvers/flattening/pointer_logic.cpp
@@ -95,7 +95,8 @@ exprt pointer_logict::pointer_expr(
     objects[numeric_cast_v<std::size_t>(pointer.object)];
 
   typet subtype = type.base_type();
-  // This is a gcc extension.
+  // In a counterexample we may up with void pointers with an offset; handle
+  // this just like GCC does and treat them as char pointers:
   // https://gcc.gnu.org/onlinedocs/gcc-4.8.0/gcc/Pointer-Arith.html
   if(subtype.id() == ID_empty)
     subtype = char_type();

--- a/src/solvers/smt2/smt2_conv.cpp
+++ b/src/solvers/smt2/smt2_conv.cpp
@@ -3701,20 +3701,12 @@ void smt2_convt::convert_plus(const plus_exprt &expr)
         "one of the operands should have pointer type");
 
       const auto &base_type = to_pointer_type(expr.type()).base_type();
+      DATA_INVARIANT(
+        base_type.id() != ID_empty, "no pointer arithmetic over void pointers");
 
-      mp_integer element_size;
-      if(base_type.id() == ID_empty)
-      {
-        // This is a gcc extension.
-        // https://gcc.gnu.org/onlinedocs/gcc-4.8.0/gcc/Pointer-Arith.html
-        element_size = 1;
-      }
-      else
-      {
-        auto element_size_opt = pointer_offset_size(base_type, ns);
-        CHECK_RETURN(element_size_opt.has_value() && *element_size_opt >= 0);
-        element_size = *element_size_opt;
-      }
+      auto element_size_opt = pointer_offset_size(base_type, ns);
+      CHECK_RETURN(element_size_opt.has_value() && *element_size_opt >= 0);
+      mp_integer element_size = *element_size_opt;
 
       // First convert the pointer operand
       out << "(let ((?pointerop ";
@@ -3911,20 +3903,11 @@ void smt2_convt::convert_minus(const minus_exprt &expr)
     {
       // Pointer difference
       const auto &base_type = to_pointer_type(expr.op0().type()).base_type();
-      mp_integer element_size;
-
-      if(base_type.id() == ID_empty)
-      {
-        // Pointer arithmetic on void is a gcc extension.
-        // https://gcc.gnu.org/onlinedocs/gcc-4.8.0/gcc/Pointer-Arith.html
-        element_size = 1;
-      }
-      else
-      {
-        auto element_size_opt = pointer_offset_size(base_type, ns);
-        CHECK_RETURN(element_size_opt.has_value() && *element_size_opt >= 1);
-        element_size = *element_size_opt;
-      }
+      DATA_INVARIANT(
+        base_type.id() != ID_empty, "no pointer arithmetic over void pointers");
+      auto element_size_opt = pointer_offset_size(base_type, ns);
+      CHECK_RETURN(element_size_opt.has_value() && *element_size_opt >= 1);
+      mp_integer element_size = *element_size_opt;
 
       if(element_size >= 2)
         out << "(bvsdiv ";


### PR DESCRIPTION
The semantics thereof are set by GCC, so we should fix this up in the front-end. This also avoids repeating the same code in multiple places in the back-ends.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
