### PR TITLE
prohibit pointers to bit-vectors that are not byte-aligned

### DIFF
--- a/regression/ansi-c/Pointer-to-non-byte/pointer-to-bool.c
+++ b/regression/ansi-c/Pointer-to-non-byte/pointer-to-bool.c
@@ -1,0 +1,6 @@
+__CPROVER_bool x;
+
+int main()
+{
+  void *p = &x; // should error
+}

--- a/regression/ansi-c/Pointer-to-non-byte/pointer-to-bool.desc
+++ b/regression/ansi-c/Pointer-to-non-byte/pointer-to-bool.desc
@@ -1,0 +1,7 @@
+CORE
+pointer-to-bool.c
+
+cannot take address of a proper Boolean$
+^EXIT=(1|64)$
+^SIGNAL=0$
+--

--- a/regression/ansi-c/Pointer-to-non-byte/pointer-to-bv-array1.c
+++ b/regression/ansi-c/Pointer-to-non-byte/pointer-to-bv-array1.c
@@ -1,0 +1,6 @@
+__CPROVER_bitvector[123] z[10];
+
+int main()
+{
+  void *p = z; // should error
+}

--- a/regression/ansi-c/Pointer-to-non-byte/pointer-to-bv-array1.desc
+++ b/regression/ansi-c/Pointer-to-non-byte/pointer-to-bv-array1.desc
@@ -1,0 +1,7 @@
+CORE
+pointer-to-bv-array1.c
+
+bitvector must have width that is a multiple of CHAR_BIT$
+^EXIT=(1|64)$
+^SIGNAL=0$
+--

--- a/regression/ansi-c/Pointer-to-non-byte/pointer-to-bv-array2.c
+++ b/regression/ansi-c/Pointer-to-non-byte/pointer-to-bv-array2.c
@@ -1,0 +1,6 @@
+__CPROVER_bitvector[123] z[10];
+
+int main()
+{
+  void *p = (int *)z; // should error
+}

--- a/regression/ansi-c/Pointer-to-non-byte/pointer-to-bv-array2.desc
+++ b/regression/ansi-c/Pointer-to-non-byte/pointer-to-bv-array2.desc
@@ -1,0 +1,7 @@
+CORE
+pointer-to-bv-array2.c
+
+bitvector must have width that is a multiple of CHAR_BIT$
+^EXIT=(1|64)$
+^SIGNAL=0$
+--

--- a/regression/ansi-c/Pointer-to-non-byte/pointer-to-bv.c
+++ b/regression/ansi-c/Pointer-to-non-byte/pointer-to-bv.c
@@ -1,0 +1,6 @@
+__CPROVER_bitvector[15] y;
+
+int main()
+{
+  void *p = &y; // should error
+}

--- a/regression/ansi-c/Pointer-to-non-byte/pointer-to-bv.desc
+++ b/regression/ansi-c/Pointer-to-non-byte/pointer-to-bv.desc
@@ -1,0 +1,7 @@
+CORE
+pointer-to-bv.c
+
+bitvector must have width that is a multiple of CHAR_BIT$
+^EXIT=(1|64)$
+^SIGNAL=0$
+--

--- a/src/ansi-c/c_typecast.h
+++ b/src/ansi-c/c_typecast.h
@@ -10,6 +10,8 @@ Author: Daniel Kroening, kroening@kroening.com
 #ifndef CPROVER_ANSI_C_C_TYPECAST_H
 #define CPROVER_ANSI_C_C_TYPECAST_H
 
+#include <util/optional.h>
+
 #include <list>
 #include <string>
 
@@ -64,6 +66,10 @@ public:
 
   std::list<std::string> errors;
   std::list<std::string> warnings;
+
+  /// \return empty when address can be taken,
+  /// error message otherwise
+  static optionalt<std::string> check_address_can_be_taken(const typet &);
 
 protected:
   const namespacet &ns;


### PR DESCRIPTION
This adds checks to the C front-end that prohibit taking the address of objects that cannot be addressed with byte-granularity pointers.  This includes proper Booleans (not to be confused with `_Bool`) and `__CPROVER_bitvector`-typed objects whose width is not a multiple of 8.

Fixes #7104.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- [X] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [X] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
