### PR TITLE
CONTRACTS: add function-contract mapping to the CLI

### DIFF
--- a/regression/contracts-dfcc/function-contract-mapping/main.c
+++ b/regression/contracts-dfcc/function-contract-mapping/main.c
@@ -1,0 +1,40 @@
+#include <stdbool.h>
+#include <stdlib.h>
+
+bool my_contract(char *arr, size_t size, char *out)
+  // clang-format off
+__CPROVER_requires(__CPROVER_is_fresh(arr, size))
+__CPROVER_requires(__CPROVER_is_fresh(out, sizeof(*out)))
+__CPROVER_assigns((size > 0) : arr[0], *out)
+__CPROVER_ensures(
+    (size > 0) ==> __CPROVER_return_value &&
+                   (arr[0] == 0) &&
+                   (*out == __CPROVER_old(arr[0])))
+__CPROVER_ensures(
+    (size == 0) ==> !__CPROVER_return_value)
+  // clang-format on
+  ;
+
+bool bar(char *arr, size_t size, char *out)
+{
+  if(size > 0)
+  {
+    *out = arr[0];
+    arr[0] = 0;
+    return true;
+  }
+  return false;
+}
+
+bool foo(char *arr, size_t size, char *out)
+{
+  return bar(arr, size, out);
+}
+
+void main()
+{
+  char *arr;
+  size_t size;
+  char *out;
+  foo(arr, size, out);
+}

--- a/regression/contracts-dfcc/function-contract-mapping/test-enforce-fail-contract.desc
+++ b/regression/contracts-dfcc/function-contract-mapping/test-enforce-fail-contract.desc
@@ -1,0 +1,10 @@
+CORE
+main.c
+--malloc-may-fail --malloc-fail-null --dfcc main --enforce-contract foo/ _ --pointer-check --pointer-primitive-check --pointer-overflow-check
+^Invalid function-contract mapping$
+^Reason: couldn't find contract name after '/' in 'foo/'$
+^EXIT=(10|6)$
+^SIGNAL=0$
+--
+--
+Checks that when the contract name is missing an error is triggered.

--- a/regression/contracts-dfcc/function-contract-mapping/test-enforce-fail-function.desc
+++ b/regression/contracts-dfcc/function-contract-mapping/test-enforce-fail-function.desc
@@ -1,0 +1,10 @@
+CORE
+main.c
+--malloc-may-fail --malloc-fail-null --dfcc main --enforce-contract /my_contract _ --pointer-check --pointer-primitive-check --pointer-overflow-check
+^Invalid function-contract mapping$
+^Reason: couldn't find function name before '/' in '/my_contract'$
+^EXIT=(10|6)$
+^SIGNAL=0$
+--
+--
+Checks that when the function name is missing an error is triggered.

--- a/regression/contracts-dfcc/function-contract-mapping/test-enforce-fail-too-many.desc
+++ b/regression/contracts-dfcc/function-contract-mapping/test-enforce-fail-too-many.desc
@@ -1,0 +1,10 @@
+CORE
+main.c
+--malloc-may-fail --malloc-fail-null --dfcc main --enforce-contract foo/bar/my_contract _ --pointer-check --pointer-primitive-check --pointer-overflow-check
+^Invalid function-contract mapping$
+^Reason: couldn't parse 'foo/bar/my_contract'$
+^EXIT=(10|6)$
+^SIGNAL=0$
+--
+--
+Checks that when the function name is missing an error is triggered.

--- a/regression/contracts-dfcc/function-contract-mapping/test-enforce-pass.desc
+++ b/regression/contracts-dfcc/function-contract-mapping/test-enforce-pass.desc
@@ -1,0 +1,10 @@
+CORE
+main.c
+--malloc-may-fail --malloc-fail-null --dfcc main --enforce-contract foo/my_contract _ --pointer-check --pointer-primitive-check --pointer-overflow-check
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+--
+This test demonstrates the ability to specify a function_name/contract_name
+mapping for contract checking.

--- a/regression/contracts-dfcc/function-contract-mapping/test-enforce-replace-pass.desc
+++ b/regression/contracts-dfcc/function-contract-mapping/test-enforce-replace-pass.desc
@@ -1,0 +1,13 @@
+CORE
+main.c
+--malloc-may-fail --malloc-fail-null --dfcc main --enforce-contract foo/my_contract --replace-call-with-contract bar/my_contract _ --pointer-check --pointer-primitive-check --pointer-overflow-check
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+--
+This test demonstrates the ability to check specify a function_name/contract_name
+mapping for contract checking and contract replacement.
+
+The same contract `my_contract` is used for both `foo` and `bar` functions in
+checking and replacement mode, respectively.

--- a/regression/contracts-dfcc/function-contract-mapping/test-enforce-warning-not-found.desc
+++ b/regression/contracts-dfcc/function-contract-mapping/test-enforce-warning-not-found.desc
@@ -1,0 +1,11 @@
+CORE
+main.c
+--malloc-may-fail --malloc-fail-null --dfcc main --enforce-contract foo/my_contractt _ --pointer-check --pointer-primitive-check --pointer-overflow-check
+^Contract 'my_contractt' not found, deriving empty pure contract 'contract::my_contractt' from function 'foo'$
+^VERIFICATION FAILED$
+^EXIT=10$
+^SIGNAL=0$
+--
+--
+Checks that we get a warning that a default contract is derived from the
+signature of the function being checked when specifying a non-existing contract.

--- a/src/goto-instrument/contracts/contracts.h
+++ b/src/goto-instrument/contracts/contracts.h
@@ -29,6 +29,7 @@ Date: February 2016
 #include <string>
 #include <unordered_set>
 
+// clang-format off
 #define FLAG_LOOP_CONTRACTS "apply-loop-contracts"
 #define HELP_LOOP_CONTRACTS                                                    \
   " --apply-loop-contracts\n"                                                  \
@@ -36,12 +37,14 @@ Date: February 2016
 
 #define FLAG_REPLACE_CALL "replace-call-with-contract"
 #define HELP_REPLACE_CALL                                                      \
-  " --replace-call-with-contract <fun>\n"                                      \
-  "                              replace calls to fun with fun's contract\n"
+  " --replace-call-with-contract <function>[/contract]\n"                      \
+  "                              replace calls to function with contract\n"
 
 #define FLAG_ENFORCE_CONTRACT "enforce-contract"
 #define HELP_ENFORCE_CONTRACT                                                  \
-  " --enforce-contract <fun>     wrap fun with an assertion of its contract\n"
+  " --enforce-contract <function>[/contract]"                                  \
+  "                              wrap function with an assertion of contract\n"
+// clang-format on
 
 class local_may_aliast;
 

--- a/src/goto-instrument/contracts/doc/user/contracts-cli.md
+++ b/src/goto-instrument/contracts/doc/user/contracts-cli.md
@@ -5,24 +5,27 @@
 The program transformation takes the following parameters:
 
 ```
-goto-instrument [--apply-loop-contracts] [--enforce-contract f] (--replace-call-with-contract g)* in.gb out.gb
+goto-instrument [--apply-loop-contracts] [--enforce-contract <function>] (--replace-call-with-contract <function>)* in.gb out.gb
 ```
 
 Where:
 - `--apply-loop-contracts` is optional and specifies to apply loop contracts globally;
-- `--enforce-contract f` is optional and specifies that `f` must be checked against its contract.
-- `--replace-call-with-contract g` is optional and specifies that all calls to `g` must be replaced with its contract;
+- `--enforce-contract <function>` is optional and specifies that `function` must be checked against its contract.
+- `--replace-call-with-contract <function>` is optional and specifies that all calls to `function` must be replaced with its contract;
 
 ## Applying the function contracts transformation (with the dynamic frames method)
 
 The program transformation takes the following parameters:
 
 ```
-goto-instrument --dfcc harness [--enforce-contract f] (--replace-call-with-contract g)* [--apply-loop-contracts] in.gb out.gb
+goto-instrument --dfcc harness [--enforce-contract <function>[/<contract>]] (--replace-call-with-contract <function>[/<contract>])* in.gb out.gb
 ```
 
 Where:
 - `--dfcc harness` specifies the proof harness (i.e. the entry point of the analysis);
-- `--enforce-contract f` is optional and specifies that `f` must be checked against its contract.
-- `--replace-call-with-contract g` is optional and specifies that all calls to `g` must be replaced with its contract;
+- `--enforce-contract <function>[/<contract>]` is optional and specifies that `function` must be checked against `contract`.
+  When `contract` is not specfied, the contract is assumed to be carried by the `function` itself.
+- `--replace-call-with-contract <function>[/<contract>]` is optional and specifies that all calls to `function` must be replaced with `contract`.
+  When `contract` is not specfied, the contract is assumed to be carried by the `function` itself.
+
 

--- a/src/goto-instrument/contracts/dynamic-frames/dfcc.h
+++ b/src/goto-instrument/contracts/dynamic-frames/dfcc.h
@@ -29,6 +29,7 @@ Author: Remi Delmas, delmasrd@amazon.com
 #ifndef CPROVER_GOTO_INSTRUMENT_CONTRACTS_DYNAMIC_FRAMES_DFCC_H
 #define CPROVER_GOTO_INSTRUMENT_CONTRACTS_DYNAMIC_FRAMES_DFCC_H
 
+#include <util/exception_utils.h>
 #include <util/irep.h>
 #include <util/message.h>
 
@@ -56,18 +57,31 @@ class optionst;
 
 // clang-format off
 #define HELP_DFCC                                                              \
-  "--dfcc             activate dynamic frame condition checking for function\n"\
-  "                   contracts using given function as entry point"
-// clang-format on
+  "--dfcc <harness>   activate dynamic frame condition checking for function\n"\
+  "                   contracts using the given harness as entry point"
 
-// clang-format off
 #define FLAG_ENFORCE_CONTRACT_REC "enforce-contract-rec"
 #define OPT_ENFORCE_CONTRACT_REC "(" FLAG_ENFORCE_CONTRACT_REC "):"
 #define HELP_ENFORCE_CONTRACT_REC                                              \
-  " --enforce-contract-rec <fun>  wrap fun with an assertion of its contract\n"\
+  " --enforce-contract-rec <function>[/<contract>]"                            \
+  "                               wrap fun with an assertion of the contract\n"\
   "                               and assume recursive calls to fun satisfy \n"\
   "                               the contract"
 // clang-format on
+
+/// Exception thrown for bad function/contract specification pairs passed on
+/// the CLI.
+class invalid_function_contract_pair_exceptiont : public cprover_exception_baset
+{
+public:
+  explicit invalid_function_contract_pair_exceptiont(
+    std::string reason,
+    std::string correct_format = "");
+
+  std::string what() const override;
+
+  std::string correct_format;
+};
 
 /// \ingroup dfcc-module
 /// \brief Applies function contracts transformation to GOTO model,

--- a/src/goto-instrument/contracts/dynamic-frames/dfcc_contract_handler.h
+++ b/src/goto-instrument/contracts/dynamic-frames/dfcc_contract_handler.h
@@ -101,18 +101,17 @@ public:
   const std::size_t get_assigns_clause_size(const irep_idt &contract_id);
 
   /// Searches for a symbol named "contract::contract_id" in the symbol table.
-  ///
-  /// If a symbol "contract::contract_id" was found and its type signature is
-  /// compatible with that of "contract_id" a reference to the symbol is
-  /// returned.
-  ///
-  /// If a symbol "contract::contract_id" was found but its type signature is
-  /// not compatible with that of "contract_id" an exception is thrown.
-  ///
-  /// If a symbol "contract::contract_id" was found, a fresh symbol representing
-  /// a contract with empty clauses is inserted in the symbol table and a
-  /// reference to that symbol is returned.
-  const symbolt &get_pure_contract_symbol(const irep_idt &contract_id);
+  /// If the "contract::contract_id" is found and \p function_id_opt is present,
+  /// type signature compatibility is checked between the contract and
+  /// the function, and an exception is thrown if they are incompatible.
+  /// If the symbol was not found and \p function_id_opt was provided,
+  /// the function is used as a template to derive a new default contract with
+  /// empty requires, empty assigns, empty frees, empty ensures clauses.
+  /// If the symbol was not found and \p function_id_opt was not provided, a
+  /// PRECONDITION is triggered.
+  const symbolt &get_pure_contract_symbol(
+    const irep_idt &contract_id,
+    const optionalt<irep_idt> function_id_opt = {});
 
 protected:
   goto_modelt &goto_model;


### PR DESCRIPTION
Enables checking or replacing a contract against a function of a different name as long as signatures are compatible, using :

```
--enforce-contract <function>/<contract>
--enforce-contract-rec <function>/<contract>
--replace-call-with-contract <function>/<contract>
```

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [x] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.
