### PR TITLE
Do not clear the clause set between calls to the external SAT solver

### DIFF
--- a/src/solvers/sat/external_sat.cpp
+++ b/src/solvers/sat/external_sat.cpp
@@ -180,7 +180,6 @@ external_satt::resultt external_satt::do_prop_solve()
   // create a temporary file
   temporary_filet cnf_file("external-sat", ".cnf");
   write_cnf_file(cnf_file());
-  clauses.clear();
   auto output = execute_solver(cnf_file());
   return parse_result(output);
 }


### PR DESCRIPTION
<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

Revert the change done in https://github.com/diffblue/cbmc/pull/7346. Deleting all clauses between calls to the external SAT solver results in losing all the clauses for the equation. The generated CNF for subsequent calls thus ends up including the clauses for the remaining properties/goals only.

Fixes: #7416 

- [X] Each commit message has a non-empty body, explaining why the change was made.
- [X] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [X] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [X] My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- [X] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

Call out: I wasn't able to include a test because this requires an external SAT solver.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
