### PR TITLE
SYNTHESIZER: Add counterexample-guided loop assigns synthesis

### DIFF
--- a/regression/goto-synthesizer/loop_contracts_synthesis_05/main.c
+++ b/regression/goto-synthesizer/loop_contracts_synthesis_05/main.c
@@ -1,0 +1,51 @@
+#include <assert.h>
+#include <stdlib.h>
+
+#define SIZE 8
+
+struct blob
+{
+  char *data;
+};
+
+void main()
+{
+  struct blob *b = malloc(sizeof(struct blob));
+  __CPROVER_assume(b != NULL);
+
+  b->data = malloc(SIZE);
+  __CPROVER_assume(b->data != NULL);
+
+  b->data[5] = 0;
+  unsigned result = 0;
+
+  unsigned arr[3] = {0, 0, 0};
+
+  for(unsigned int i = 0; i < SIZE; i++)
+  // clang-format off
+  // __CPROVER_assigns(i, result)
+  // clang-format on
+  {
+    result += 1;
+  }
+
+  for(unsigned int i = 0; i < SIZE; i++)
+  // clang-format off
+  // __CPROVER_assigns(i, arr[0])
+  // clang-format on
+  {
+    arr[0] += 1;
+  }
+
+  for(unsigned j = 0; j < SIZE; j++)
+  // __CPROVER_assigns(j, __CPROVER_POINTER_OBJECT(b->data))
+  {
+    for(unsigned i = 0; i < SIZE; i++)
+    // clang-format off
+    // __CPROVER_assigns(i, j, __CPROVER_POINTER_OBJECT(b->data))
+    // clang-format on
+    {
+      b->data[i] = 1;
+    }
+  }
+}

--- a/regression/goto-synthesizer/loop_contracts_synthesis_05/test.desc
+++ b/regression/goto-synthesizer/loop_contracts_synthesis_05/test.desc
@@ -1,0 +1,18 @@
+CORE
+main.c
+--pointer-check
+^EXIT=0$
+^SIGNAL=0$
+^\[main.\d+\] .* Check loop invariant before entry: SUCCESS$
+^\[main.assigns.\d+\] .* Check that i is assignable: SUCCESS$
+^\[main.assigns.\d+\] .* Check that j is assignable: SUCCESS$
+^\[main.assigns.\d+\] .* Check that result is assignable: SUCCESS$
+^\[main.assigns.\d+\] .* Check that b->data\[(.*)i\] is assignable: SUCCESS$
+^\[main.assigns.\d+\] .* Check that arr\[(.*)0\] is assignable: SUCCESS$
+^\[main.\d+\] .* Check that loop invariant is preserved: SUCCESS$
+^VERIFICATION SUCCESSFUL$
+--
+--
+This test is a variation of contracts/loop_assigns-01.
+It shows that we can synthesize loop assigns pointer_object(b->data) that
+cannot be inferred by goto-instrument.

--- a/src/goto-instrument/contracts/contracts.cpp
+++ b/src/goto-instrument/contracts/contracts.cpp
@@ -1457,11 +1457,11 @@ void code_contractst::apply_loop_contracts(
       if(original_loop_number_map.count(it_instr) != 0)
         continue;
 
-      // Store loop number for
-      // ASSIGN ENTERED_LOOP = TRUE
+      // Store loop number for two type of instrumented instructions.
+      // ASSIGN ENTERED_LOOP = false  ---   head of transformed loops.
+      // ASSIGN ENTERED_LOOP = true   ---   end of transformed loops.
       if(
-        is_assignment_to_instrumented_variable(it_instr, ENTERED_LOOP) &&
-        it_instr->assign_rhs() == true_exprt())
+        is_transformed_loop_end(it_instr) || is_transformed_loop_head(it_instr))
       {
         const auto &assign_lhs =
           expr_try_dynamic_cast<symbol_exprt>(it_instr->assign_lhs());

--- a/src/goto-instrument/contracts/instrument_spec_assigns.cpp
+++ b/src/goto-instrument/contracts/instrument_spec_assigns.cpp
@@ -708,9 +708,14 @@ void instrument_spec_assignst::inclusion_check_assertion(
   comment += " is assignable";
   source_location.set_comment(comment);
 
-  dest.add(goto_programt::make_assertion(
-    inclusion_check_full(car, allow_null_lhs, include_stack_allocated),
-    source_location));
+  exprt inclusion_check =
+    inclusion_check_full(car, allow_null_lhs, include_stack_allocated);
+  // Record what target is checked.
+  auto &checked_assigns =
+    static_cast<exprt &>(inclusion_check.add(ID_checked_assigns));
+  checked_assigns = car.target();
+
+  dest.add(goto_programt::make_assertion(inclusion_check, source_location));
 }
 
 exprt instrument_spec_assignst::inclusion_check_single(

--- a/src/goto-instrument/contracts/utils.cpp
+++ b/src/goto-instrument/contracts/utils.cpp
@@ -448,14 +448,20 @@ void generate_history_variables_initialization(
   program.destructive_append(history);
 }
 
+bool is_transformed_loop_head(const goto_programt::const_targett &target)
+{
+  // The head of a transformed loop is
+  // ASSIGN entered_loop = false
+  return is_assignment_to_instrumented_variable(target, ENTERED_LOOP) &&
+         target->assign_rhs() == false_exprt();
+}
+
 bool is_transformed_loop_end(const goto_programt::const_targett &target)
 {
-  // The end of the loop end of transformed loop is
+  // The end of a transformed loop is
   // ASSIGN entered_loop = true
-  if(!is_assignment_to_instrumented_variable(target, ENTERED_LOOP))
-    return false;
-
-  return target->assign_rhs() == true_exprt();
+  return is_assignment_to_instrumented_variable(target, ENTERED_LOOP) &&
+         target->assign_rhs() == true_exprt();
 }
 
 bool is_assignment_to_instrumented_variable(

--- a/src/goto-instrument/contracts/utils.h
+++ b/src/goto-instrument/contracts/utils.h
@@ -210,7 +210,10 @@ void generate_history_variables_initialization(
   const irep_idt &mode,
   goto_programt &program);
 
-/// Return true if `target` is the loop end of some transformed code.
+/// Return true if `target` is the head of some transformed loop.
+bool is_transformed_loop_head(const goto_programt::const_targett &target);
+
+/// Return true if `target` is the end of some transformed loop.
 bool is_transformed_loop_end(const goto_programt::const_targett &target);
 
 /// Return true if `target` is an assignment to an instrumented variable with

--- a/src/goto-synthesizer/enumerative_loop_contracts_synthesizer.h
+++ b/src/goto-synthesizer/enumerative_loop_contracts_synthesizer.h
@@ -40,6 +40,11 @@ public:
   invariant_mapt synthesize_all() override;
   exprt synthesize(loop_idt loop_id) override;
 
+  std::map<loop_idt, std::set<exprt>> get_assigns_map() const
+  {
+    return assigns_map;
+  }
+
 private:
   /// Initialize invariants as true for all unannotated loops.
   void init_candidates();
@@ -68,11 +73,19 @@ private:
     const loop_idt &cause_loop_id,
     const irep_idt &violation_id);
 
-  ///  Synthesize invariant of form
-  ///   (in_inv || !guard) && (!guard -> pos_inv)
+  /// Synthesize assigns target and update assigns_map.
+  void synthesize_assigns(
+    const exprt &checked_pointer,
+    const std::list<loop_idt> cause_loop_ids);
+
+  /// Synthesize invariant of form
+  /// (in_inv || !guard) && (!guard -> pos_inv)
   invariant_mapt in_invariant_clause_map;
   invariant_mapt pos_invariant_clause_map;
   invariant_mapt neg_guards;
+
+  /// Synthesized assigns clauses.
+  std::map<loop_idt, std::set<exprt>> assigns_map;
 
   /// Map from tmp_post variables to their original variables.
   std::unordered_map<exprt, exprt, irep_hash> tmp_post_map;

--- a/src/goto-synthesizer/goto_synthesizer_parse_options.cpp
+++ b/src/goto-synthesizer/goto_synthesizer_parse_options.cpp
@@ -54,6 +54,7 @@ int goto_synthesizer_parse_optionst::doit()
     // Synthesize loop invariants and annotate them into `goto_model`
     enumerative_loop_contracts_synthesizert synthesizer(goto_model, log);
     annotate_invariants(synthesizer.synthesize_all(), goto_model);
+    annotate_assigns(synthesizer.get_assigns_map(), goto_model);
 
     // Apply loop contracts.
     std::set<std::string> to_exclude_from_nondet_static(

--- a/src/goto-synthesizer/synthesizer_utils.cpp
+++ b/src/goto-synthesizer/synthesizer_utils.cpp
@@ -116,6 +116,28 @@ void annotate_invariants(
   }
 }
 
+void annotate_assigns(
+  const std::map<loop_idt, std::set<exprt>> &assigns_map,
+  goto_modelt &goto_model)
+{
+  for(const auto &assigns_map_entry : assigns_map)
+  {
+    loop_idt loop_id = assigns_map_entry.first;
+    irep_idt function_id = loop_id.function_id;
+    unsigned int loop_number = loop_id.loop_number;
+
+    // get the last instruction of the target loop
+    auto &function = goto_model.goto_functions.function_map[function_id];
+    goto_programt::targett loop_end = get_loop_end(loop_number, function);
+
+    exprt &condition = loop_end->condition_nonconst();
+    auto assigns = exprt(ID_target_list);
+    for(const auto &e : assigns_map_entry.second)
+      assigns.add_to_operands(e);
+    condition.add(ID_C_spec_assigns) = assigns;
+  }
+}
+
 invariant_mapt combine_in_and_post_invariant_clauses(
   const invariant_mapt &in_clauses,
   const invariant_mapt &post_clauses,

--- a/src/goto-synthesizer/synthesizer_utils.h
+++ b/src/goto-synthesizer/synthesizer_utils.h
@@ -51,6 +51,12 @@ void annotate_invariants(
   const invariant_mapt &invariant_map,
   goto_modelt &goto_model);
 
+/// Annotate the assigns in `assigns_map` to their corresponding
+/// loops. Corresponding loops are specified by keys of `assigns_map`
+void annotate_assigns(
+  const std::map<loop_idt, std::set<exprt>> &assigns_map,
+  goto_modelt &goto_model);
+
 /// Combine invariant of form
 /// (in_inv || !guard) && (!guard -> pos_inv)
 invariant_mapt combine_in_and_post_invariant_clauses(

--- a/src/util/irep_ids.def
+++ b/src/util/irep_ids.def
@@ -902,6 +902,7 @@ IREP_ID_TWO(overflow_result_mult, overflow_result-*)
 IREP_ID_TWO(overflow_result_shl, overflow_result-shl)
 IREP_ID_TWO(overflow_result_unary_minus, overflow_result-unary-)
 IREP_ID_ONE(field_sensitive_ssa)
+IREP_ID_ONE(checked_assigns)
 
 // Projects depending on this code base that wish to extend the list of
 // available ids should provide a file local_irep_ids.def in their source tree


### PR DESCRIPTION

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.


Implement the functionality described below.

Motivation
---
This loop assigns synthesizer use the idea counter-example-guided synthesis (CEGIS) to synthesize loop assigns targets. It is based on the same CEGIS framework as the loop invariant synthesizer w ith the following difference.

Use Cases
---
Our loop invariants synthesizer will synthesize invariants clauses for all loops without loop invariant annotation. The loop assigns synthesizer will synthesize assigns clauses for all loops without loop invariant annotation **and** loop assigns annotation.

Cause Loop ID
---
In the loop invariant synthesizer, we say a loop is a cause loop if the violation is dependent on the loop's havoc instructions. Because invariant clauses affect the havoced values which could flow into variables outside the loop. In the loop assigns synthesizer, we say a loop is a cause loop if the violation is in the loop. Because assigns clauses only affect the CAR of its own loop body.

Synthesizer
---
For an assignable violation with checked target `T`, the new assigns target will be `T`. If `T` is a non-constant target, e.g., `ptr[i]` with `i` also an assigns target, we widen it to `__CPROVER_POINTER_OBJECT(T)`. We add the new target to cause loop one by one starting from the most-inner one. Until the assignable violation is resolved.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
