### PR TITLE
Linking library functions: support constructor functions

### DIFF
--- a/regression/cbmc/constructor2/main.c
+++ b/regression/cbmc/constructor2/main.c
@@ -1,0 +1,21 @@
+#include <assert.h>
+#include <stdlib.h>
+
+#ifdef __GNUC__
+int x;
+
+__attribute__((constructor)) void init_heap()
+{
+  int *p = malloc(sizeof(int));
+  free(p);
+  x = 42;
+}
+#endif
+
+int main()
+{
+#ifdef __GNUC__
+  assert(x == 42);
+#endif
+  return 0;
+}

--- a/regression/cbmc/constructor2/test.desc
+++ b/regression/cbmc/constructor2/test.desc
@@ -1,0 +1,9 @@
+CORE
+main.c
+
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+map::at
+^warning: ignoring

--- a/src/ansi-c/library/stdlib.c
+++ b/src/ansi-c/library/stdlib.c
@@ -271,6 +271,7 @@ __CPROVER_HIDE:;
 
 #undef free
 
+void __CPROVER_deallocate(void *);
 __CPROVER_bool __VERIFIER_nondet___CPROVER_bool();
 #ifndef LIBRARY_CHECK
 const void *__CPROVER_alloca_object = 0;


### PR DESCRIPTION
With 7f1cc0f2055f3d we may remove `__CPROVER_initialize` from the goto model, which in turn made us fail to consider constructors called from it among the set of called functions (as well as any functions (transitively) called from these).

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
