### PR TITLE
Fixed documentation typos

### DIFF
--- a/src/goto-instrument/contracts/doc/user/contracts-assigns.md
+++ b/src/goto-instrument/contracts/doc/user/contracts-assigns.md
@@ -241,6 +241,7 @@ int main() {
   vec_clear(vec);
 }
 ```
+
 ---
 
 ```c

--- a/src/goto-instrument/contracts/doc/user/contracts-requires-ensures.md
+++ b/src/goto-instrument/contracts/doc/user/contracts-requires-ensures.md
@@ -29,7 +29,7 @@ the conjunction of the _ensures_ clauses, or `true` if none are specified.
 Both _requires_ clauses and _ensures_ clauses take a Boolean expression over the
 arguments of a function and/or global variables. The expression can include
 calls to CBMC built-in functions, to
-[Memory Predicates](@ref contracts-memory-predicates)) or to
+[Memory Predicates](@ref contracts-memory-predicates) or to
 [function pointer predicates](@ref contracts-function-pointer-predicates).
 User-defined functions can also be called inside _requires_ clauses as long as
 they are deterministic and do not have any side-effects


### PR DESCRIPTION
<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [x] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [x] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->

Missing line break is preventing code laying out correctly.