### PR TITLE
SYNTHESIZER: Fix the bug of getting bad checked pointer

### DIFF
--- a/src/goto-synthesizer/cegis_verifier.cpp
+++ b/src/goto-synthesizer/cegis_verifier.cpp
@@ -655,13 +655,25 @@ optionalt<cext> cegis_verifiert::verify()
     // The pointer checked in the null-pointer-check violation.
     if(violation_type == cext::violation_typet::cex_null_pointer)
     {
+      // ! POINTER_OBJECT(ptr) == POINTER_OBJECT(NULL)
+      // or
+      // ! POINTER_OBJECT(NULL) == POINTER_OBJECT(ptr)
+
       return_cex.checked_pointer = property_it.second.pc->condition()
                                      .operands()[0]
                                      .operands()[1]
                                      .operands()[0];
-      INVARIANT(
-        return_cex.checked_pointer.id() == ID_symbol,
-        "Checking pointer symbol");
+
+      // return the lhs if the rhs is NULL, which is a constant.
+      if(
+        return_cex.checked_pointer ==
+        null_pointer_exprt(to_pointer_type(return_cex.checked_pointer.type())))
+      {
+        return_cex.checked_pointer = property_it.second.pc->condition()
+                                       .operands()[0]
+                                       .operands()[0]
+                                       .operands()[0];
+      }
     }
 
     return return_cex;


### PR DESCRIPTION
<!---
Thank you for your contribution. Please make sure your pull request fulfills all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

The NULL-pointer checks are a same object predicate between a pointer `ptr` and `NULL:
```c
! POINTER_OBJECT(NULL) == POINTER_OBJECT(ptr)
```

However, after simplification, it could also be

```c
! POINTER_OBJECT(ptr) == POINTER_OBJECT(NULL)
```

That is, the checked pointer `ptr` can be either the `lhs` or the `rhs` of the equation.

In this PR, we check that if whether `lhs` or `rhs` is `NULL` and return the other one as the checked pointer.


- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
