### PR TITLE
SYNTHESIZER: Handle the case of violation in loop guards

### DIFF
--- a/regression/goto-synthesizer/loop_contracts_synthesis_06/main.c
+++ b/regression/goto-synthesizer/loop_contracts_synthesis_06/main.c
@@ -1,0 +1,19 @@
+#include <stdlib.h>
+#define SIZE 80
+
+void main()
+{
+  unsigned long len;
+  __CPROVER_assume(len <= SIZE);
+  __CPROVER_assume(len >= 8);
+  char *array = malloc(len);
+  __CPROVER_assume(array != 0);
+
+  array[len - 1] = 0;
+  unsigned i = 0;
+
+  while(array[i] != 0)
+  {
+    i++;
+  }
+}

--- a/regression/goto-synthesizer/loop_contracts_synthesis_06/test.desc
+++ b/regression/goto-synthesizer/loop_contracts_synthesis_06/test.desc
@@ -1,0 +1,12 @@
+CORE
+main.c
+--pointer-check
+^EXIT=0$
+^SIGNAL=0$
+^\[main.*\d+\] .* Check loop invariant before entry: SUCCESS$
+^\[main.assigns.\d+\] .* Check that i is assignable: SUCCESS$
+^\[main.*\d+\] .* Check that loop invariant is preserved: SUCCESS$
+^VERIFICATION SUCCESSFUL$
+--
+--
+Checks whether CBMC synthesizes loop invariants for checks in the loop guard.

--- a/regression/goto-synthesizer/loop_contracts_synthesis_06/test_dump.desc
+++ b/regression/goto-synthesizer/loop_contracts_synthesis_06/test_dump.desc
@@ -1,0 +1,9 @@
+CORE
+main.c
+--pointer-check _ --dump-loop-contracts
+^EXIT=0$
+^SIGNAL=0$
+loop 1 invariant.*\_\_CPROVER\_POINTER\_OFFSET
+assigns i
+--
+Checks if synthesized contracts are dumped correctly.

--- a/regression/goto-synthesizer/loop_contracts_synthesis_07/main.c
+++ b/regression/goto-synthesizer/loop_contracts_synthesis_07/main.c
@@ -1,0 +1,19 @@
+#include <stdlib.h>
+#define SIZE 80
+
+void main()
+{
+  unsigned long len;
+  __CPROVER_assume(len <= SIZE);
+  __CPROVER_assume(len >= 8);
+  char *array = malloc(len);
+  __CPROVER_assume(array != 0);
+
+  unsigned i = 0;
+
+  while(i <= len - 2)
+  {
+    i++;
+  }
+  unsigned result = array[i];
+}

--- a/regression/goto-synthesizer/loop_contracts_synthesis_07/test.desc
+++ b/regression/goto-synthesizer/loop_contracts_synthesis_07/test.desc
@@ -1,0 +1,13 @@
+CORE
+main.c
+--pointer-check
+^EXIT=0$
+^SIGNAL=0$
+^\[main.\d+\] .* Check loop invariant before entry: SUCCESS$
+^\[main.assigns.\d+\] .* Check that i is assignable: SUCCESS$
+^\[main.\d+\] .* Check that loop invariant is preserved: SUCCESS$
+^\[main.pointer\_dereference.\d+].*SUCCESS$
+^VERIFICATION SUCCESSFUL$
+--
+--
+Checks whether CBMC synthesizes loop invariants for checks located after the loop body.

--- a/regression/goto-synthesizer/loop_contracts_synthesis_07/test_dump.desc
+++ b/regression/goto-synthesizer/loop_contracts_synthesis_07/test_dump.desc
@@ -1,0 +1,9 @@
+CORE
+main.c
+--pointer-check _ --dump-loop-contracts
+^EXIT=0$
+^SIGNAL=0$
+loop 1 assigns i
+loop 1 invariant.*\_\_CPROVER\_POINTER\_OFFSET
+--
+Checks if synthesized contracts are dumped correctly.


### PR DESCRIPTION
<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

In current loop-invariant synthesizer, we synthesize two kinds of clauses separately.
1. `in_clause` that should hold when we enter the loop body---when the loop guard holds, that is ```loop_guard -> in_clause```.
2. `pos_clause` that should hold when we leave the loop---when the loop guard doesn't hold, that is ```!loop_guard -> pos_clause```.

We synthesize `in_clause` when the violations happen in the loop body. We synthesize `pos_clause` when the violation happen after the loop.

This PR handles the case that the violations happen in the loop guard ([loop_contracts_synthesis_06/main.c](https://github.com/diffblue/cbmc/compare/develop...qinheping:goto-synthesizer-violation-location?expand=1#diff-8a05899ddc66b61918f2e6180bfc08f09f895f6a78066c65086a5e7c470a880a) as an example). In the case, the new clause we synthesize should hold for both of the cases that loop guard holds and loop guards doesn't hold.

We introduce a new variable `violation_location` to indicate whether the violation happen in the loop, after the loop, or in the loop guard, and add the new synthesized clause as `in_clause`, `pos_clause`, or both, respectively.

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
