### PR TITLE
SYNTHESIZER: Synthesize loop assigns before loop invariants.

### DIFF
--- a/regression/goto-synthesizer/loop_contracts_synthesis_08/main.c
+++ b/regression/goto-synthesizer/loop_contracts_synthesis_08/main.c
@@ -1,0 +1,17 @@
+#include <stdlib.h>
+#define SIZE 80
+
+void main()
+{
+  unsigned long len;
+  __CPROVER_assume(len <= SIZE);
+  __CPROVER_assume(len >= 8);
+  const char *i = malloc(len);
+  const char *end = i + len;
+  char s = 0;
+
+  while(i != end)
+  {
+    s = *i++;
+  }
+}

--- a/regression/goto-synthesizer/loop_contracts_synthesis_08/test.desc
+++ b/regression/goto-synthesizer/loop_contracts_synthesis_08/test.desc
@@ -1,0 +1,12 @@
+CORE
+main.c
+--pointer-check
+^EXIT=0$
+^SIGNAL=0$
+^\[main.pointer\_dereference.\d+\] .* SUCCESS$
+^\[main.\d+\] .* Check loop invariant before entry: SUCCESS$
+^\[main.assigns.\d+\] .* Check that i is assignable: SUCCESS$
+^VERIFICATION SUCCESSFUL$
+--
+--
+Check whether assigns clauses are synthesize before invariant clauses.

--- a/src/goto-synthesizer/cegis_verifier.h
+++ b/src/goto-synthesizer/cegis_verifier.h
@@ -117,7 +117,7 @@ public:
 
   /// Result counterexample.
   propertiest properties;
-  irep_idt first_violation;
+  irep_idt target_violation;
 
 protected:
   // Get the options same as using CBMC api without any flag, and
@@ -136,6 +136,9 @@ protected:
   // We say a loop is the cause loop if the assignable check is in the loop.
   std::list<loop_idt>
   get_cause_loop_id_for_assigns(const goto_tracet &goto_trace);
+
+  // Extract the violation type from violation description.
+  cext::violation_typet extract_violation_type(const std::string &description);
 
   // Compute the location of the violation.
   cext::violation_locationt get_violation_location(

--- a/src/goto-synthesizer/dump_loop_contracts.cpp
+++ b/src/goto-synthesizer/dump_loop_contracts.cpp
@@ -91,16 +91,16 @@ void dump_loop_contracts(
         "loop " + std::to_string(invariant_entry.first.loop_number + 1) +
         " assigns ";
 
-      bool in_fisrt_iter = true;
+      bool in_first_iter = true;
       for(const auto &a : it_assigns->second)
       {
-        if(!in_fisrt_iter)
+        if(!in_first_iter)
         {
           assign_string += ",";
         }
         else
         {
-          in_fisrt_iter = false;
+          in_first_iter = false;
         }
         assign_string += expr2c(
           simplify_expr(a, ns), ns, expr2c_configurationt::clean_configuration);

--- a/src/goto-synthesizer/enumerative_loop_contracts_synthesizer.cpp
+++ b/src/goto-synthesizer/enumerative_loop_contracts_synthesizer.cpp
@@ -94,6 +94,9 @@ void enumerative_loop_contracts_synthesizert::init_candidates()
 
       loop_idt new_id(function_p.first, loop_end->loop_number);
 
+      log.debug() << "Initialize candidates for the loop at "
+                  << loop_end->source_location() << messaget::eom;
+
       // we only synthesize invariants and assigns for unannotated loops
       if(loop_end->condition().find(ID_C_spec_loop_invariant).is_nil())
       {
@@ -372,7 +375,7 @@ invariant_mapt enumerative_loop_contracts_synthesizert::synthesize_all()
       new_invariant_clause = synthesize_strengthening_clause(
         terminal_symbols,
         return_cex->cause_loop_ids.front(),
-        verifier.first_violation);
+        verifier.target_violation);
       break;
 
     case cext::violation_typet::cex_assignable:

--- a/src/goto-synthesizer/enumerative_loop_contracts_synthesizer.h
+++ b/src/goto-synthesizer/enumerative_loop_contracts_synthesizer.h
@@ -53,7 +53,7 @@ private:
   /// to their original variables.
   void build_tmp_post_map();
 
-  /// Compute the depedent symbols for a loop with invariant-not-preserved
+  /// Compute the dependent symbols for a loop with invariant-not-preserved
   /// violation which happen after `new_clause` was added.
   std::set<symbol_exprt> compute_dependent_symbols(
     const loop_idt &cause_loop_id,

--- a/src/goto-synthesizer/expr_enumerator.cpp
+++ b/src/goto-synthesizer/expr_enumerator.cpp
@@ -208,7 +208,7 @@ std::vector<std::size_t> get_ones_pos(std::size_t v)
   return result;
 }
 
-/// Construct parition of `n` elements from a bit vector `v`.
+/// Construct partition of `n` elements from a bit vector `v`.
 /// For a bit vector with ones at positions (computed by `get_ones_pos`)
 /// (ones[0], ones[1], ..., ones[k-2]),
 /// the corresponding partition is
@@ -255,7 +255,7 @@ std::list<partitiont> non_leaf_enumeratort::get_partitions(
 
   // Initial `v` is with ones at positions (n-k+1, n-k+2, ..., n-2, n-1).
   std::size_t v = 0;
-  // Initial `end` (the last bit vectorr we enumerate) is with ones at
+  // Initial `end` (the last bit vector we enumerate) is with ones at
   // positions (1, 2, 3, ..., k-1).
   std::size_t end = 0;
   for(size_t i = 0; i < k - 1; i++)
@@ -412,5 +412,5 @@ void enumerator_factoryt::attach_productions(
 {
   const auto &ret = productions_map.insert({id, enumerators});
   INVARIANT(
-    ret.second, "Cannnot attach enumerators to a non-existing nonterminal.");
+    ret.second, "Cannot attach enumerators to a non-existing nonterminal.");
 }

--- a/src/goto-synthesizer/expr_enumerator.h
+++ b/src/goto-synthesizer/expr_enumerator.h
@@ -158,7 +158,7 @@ public:
   /// enumerated by the enumerator e_i.
   /// \param partition_check an optional function checking whether a partition
   /// can be safely discarded.
-  /// \param ns namesapce used by `simplify_expr`.
+  /// \param ns namespace used by `simplify_expr`.
   non_leaf_enumeratort(
     const enumeratorst &enumerators,
     const std::function<bool(const partitiont &)> partition_check,
@@ -337,7 +337,7 @@ public:
   /// \param factory the enumerator factory---a grammar---this enumerator
   /// belongs to.
   /// \param id the identifier of this placeholder.
-  /// \param ns namesapce used for `simplify_expr`.
+  /// \param ns namespace used for `simplify_expr`.
   recursive_enumerator_placeholdert(
     enumerator_factoryt &factory,
     const std::string &id,


### PR DESCRIPTION
Loop invariants synthesis is dependent on loop-assigns clauses. So we target non assignable-violations until all assignable-violations are fixed.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
