### PR TITLE
Cleanup of pointer-in-range predicate handling

### DIFF
--- a/src/ansi-c/c_typecheck_expr.cpp
+++ b/src/ansi-c/c_typecheck_expr.cpp
@@ -2671,7 +2671,6 @@ exprt c_typecheck_baset::do_special_functions(
   }
   else if(identifier == CPROVER_PREFIX "pointer_in_range")
   {
-    // experimental feature for CHC encodings -- do not use
     if(expr.arguments().size() != 3)
     {
       error().source_location = f_op.source_location();

--- a/src/ansi-c/expr2c.cpp
+++ b/src/ansi-c/expr2c.cpp
@@ -3572,6 +3572,24 @@ std::string expr2ct::convert_r_or_w_ok(const r_or_w_ok_exprt &src)
   return dest;
 }
 
+std::string expr2ct::convert_pointer_in_range(const pointer_in_range_exprt &src)
+{
+  std::string dest = CPROVER_PREFIX "pointer_in_range";
+
+  dest += '(';
+
+  unsigned p;
+  dest += convert_with_precedence(src.lower_bound(), p);
+  dest += ", ";
+  dest += convert_with_precedence(src.pointer(), p);
+  dest += ", ";
+  dest += convert_with_precedence(src.upper_bound(), p);
+
+  dest += ')';
+
+  return dest;
+}
+
 std::string expr2ct::convert_with_precedence(
   const exprt &src,
   unsigned &precedence)
@@ -3983,6 +4001,9 @@ std::string expr2ct::convert_with_precedence(
 
   else if(src.id() == ID_r_ok || src.id() == ID_w_ok || src.id() == ID_rw_ok)
     return convert_r_or_w_ok(to_r_or_w_ok_expr(src));
+
+  else if(src.id() == ID_pointer_in_range)
+    return convert_pointer_in_range(to_pointer_in_range_expr(src));
 
   auto function_string_opt = convert_function(src);
   if(function_string_opt.has_value())

--- a/src/ansi-c/expr2c_class.h
+++ b/src/ansi-c/expr2c_class.h
@@ -27,6 +27,7 @@ class annotated_pointer_constant_exprt;
 class qualifierst;
 class namespacet;
 class r_or_w_ok_exprt;
+class pointer_in_range_exprt;
 
 class expr2ct
 {
@@ -284,6 +285,7 @@ protected:
   std::string convert_bitreverse(const bitreverse_exprt &src);
 
   std::string convert_r_or_w_ok(const r_or_w_ok_exprt &src);
+  std::string convert_pointer_in_range(const pointer_in_range_exprt &src);
 };
 
 #endif // CPROVER_ANSI_C_EXPR2C_CLASS_H

--- a/src/util/pointer_expr.h
+++ b/src/util/pointer_expr.h
@@ -385,6 +385,21 @@ public:
     PRECONDITION(op2().type().id() == ID_pointer);
   }
 
+  const exprt &lower_bound() const
+  {
+    return op0();
+  }
+
+  const exprt &pointer() const
+  {
+    return op1();
+  }
+
+  const exprt &upper_bound() const
+  {
+    return op2();
+  }
+
   // translate into equivalent conjunction
   exprt lower() const;
 };
@@ -414,7 +429,7 @@ inline pointer_in_range_exprt &to_pointer_in_range_expr(exprt &expr)
 {
   PRECONDITION(expr.id() == ID_pointer_in_range);
   DATA_INVARIANT(
-    expr.operands().size() == 3, "pointer_in_range must have one operand");
+    expr.operands().size() == 3, "pointer_in_range must have three operands");
   return static_cast<pointer_in_range_exprt &>(expr);
 }
 


### PR DESCRIPTION
Make sure expr2ct knows how to print it, add a full API, cleanup comments.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
