### PR TITLE
expr2c/{r,w,rw}_ok: add a dedicated method

### DIFF
--- a/src/ansi-c/expr2c.cpp
+++ b/src/ansi-c/expr2c.cpp
@@ -3554,6 +3554,24 @@ std::string expr2ct::convert_bitreverse(const bitreverse_exprt &src)
   return convert_norep(src, precedence);
 }
 
+std::string expr2ct::convert_r_or_w_ok(const r_or_w_ok_exprt &src)
+{
+  std::string dest = src.id() == ID_r_ok   ? "R_OK"
+                     : src.id() == ID_w_ok ? "W_OK"
+                                           : "RW_OK";
+
+  dest += '(';
+
+  unsigned p;
+  dest += convert_with_precedence(src.pointer(), p);
+  dest += ", ";
+  dest += convert_with_precedence(src.size(), p);
+
+  dest += ')';
+
+  return dest;
+}
+
 std::string expr2ct::convert_with_precedence(
   const exprt &src,
   unsigned &precedence)
@@ -3963,6 +3981,9 @@ std::string expr2ct::convert_with_precedence(
   else if(src.id() == ID_bitreverse)
     return convert_bitreverse(to_bitreverse_expr(src));
 
+  else if(src.id() == ID_r_ok || src.id() == ID_w_ok || src.id() == ID_rw_ok)
+    return convert_r_or_w_ok(to_r_or_w_ok_expr(src));
+
   auto function_string_opt = convert_function(src);
   if(function_string_opt.has_value())
     return *function_string_opt;
@@ -4018,9 +4039,6 @@ optionalt<std::string> expr2ct::convert_function(const exprt &src)
     {ID_loop_entry, CPROVER_PREFIX "loop_entry"},
     {ID_saturating_minus, CPROVER_PREFIX "saturating_minus"},
     {ID_saturating_plus, CPROVER_PREFIX "saturating_plus"},
-    {ID_r_ok, "R_OK"},
-    {ID_w_ok, "W_OK"},
-    {ID_rw_ok, "RW_OK"},
     {ID_width, "WIDTH"},
   };
 

--- a/src/ansi-c/expr2c_class.h
+++ b/src/ansi-c/expr2c_class.h
@@ -26,6 +26,7 @@ Author: Daniel Kroening, kroening@kroening.com
 class annotated_pointer_constant_exprt;
 class qualifierst;
 class namespacet;
+class r_or_w_ok_exprt;
 
 class expr2ct
 {
@@ -281,6 +282,8 @@ protected:
 
   std::string convert_conditional_target_group(const exprt &src);
   std::string convert_bitreverse(const bitreverse_exprt &src);
+
+  std::string convert_r_or_w_ok(const r_or_w_ok_exprt &src);
 };
 
 #endif // CPROVER_ANSI_C_EXPR2C_CLASS_H


### PR DESCRIPTION
This will ensure stable output even if the internals of the expression change.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
