### PR TITLE
r/w/rw_ok: implement can_cast_expr and validate_expr

### DIFF
--- a/src/util/pointer_expr.h
+++ b/src/util/pointer_expr.h
@@ -818,6 +818,17 @@ public:
   }
 };
 
+template <>
+inline bool can_cast_expr<r_or_w_ok_exprt>(const exprt &base)
+{
+  return base.id() == ID_r_ok || base.id() == ID_w_ok || base.id() == ID_rw_ok;
+}
+
+inline void validate_expr(const r_or_w_ok_exprt &value)
+{
+  validate_operands(value, 2, "r_or_w_ok must have two operands");
+}
+
 inline const r_or_w_ok_exprt &to_r_or_w_ok_expr(const exprt &expr)
 {
   PRECONDITION(
@@ -837,6 +848,17 @@ public:
   }
 };
 
+template <>
+inline bool can_cast_expr<r_ok_exprt>(const exprt &base)
+{
+  return base.id() == ID_r_ok;
+}
+
+inline void validate_expr(const r_ok_exprt &value)
+{
+  validate_operands(value, 2, "r_ok must have two operands");
+}
+
 inline const r_ok_exprt &to_r_ok_expr(const exprt &expr)
 {
   PRECONDITION(expr.id() == ID_r_ok);
@@ -854,6 +876,17 @@ public:
   {
   }
 };
+
+template <>
+inline bool can_cast_expr<w_ok_exprt>(const exprt &base)
+{
+  return base.id() == ID_w_ok;
+}
+
+inline void validate_expr(const w_ok_exprt &value)
+{
+  validate_operands(value, 2, "w_ok must have two operands");
+}
 
 inline const w_ok_exprt &to_w_ok_expr(const exprt &expr)
 {


### PR DESCRIPTION
We should provide these for all expression classes.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
