### PR TITLE
avoid deprecated std::iterator

### DIFF
--- a/src/util/cmdline.h
+++ b/src/util/cmdline.h
@@ -105,8 +105,8 @@ public:
   {
     explicit option_namest(const cmdlinet &command_line);
     struct option_names_iteratort
-      : public std::iterator<std::forward_iterator_tag, std::string>
     {
+      using iterator_category = std::forward_iterator_tag;
       option_names_iteratort() = default;
       explicit option_names_iteratort(
         const cmdlinet *command_line,

--- a/src/util/dense_integer_map.h
+++ b/src/util/dense_integer_map.h
@@ -116,8 +116,8 @@ private:
   // operator++ that skips unset values.
   template <class UnderlyingIterator, class UnderlyingValue>
   class iterator_templatet
-    : public std::iterator<std::forward_iterator_tag, UnderlyingValue>
   {
+    using iterator_category = std::forward_iterator_tag;
     // Type of the std::iterator support class we inherit
     typedef std::iterator<std::forward_iterator_tag, UnderlyingValue>
       base_typet;


### PR DESCRIPTION
C++17 deprecates `std::iterator`.  The recommended alternative is to use an `iterator_category` member.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
