### PR TITLE
Update base Ubuntu image to 22.04 from 20.04 in `Dockerfile`.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04 as builder
+FROM ubuntu:22.04 as builder
 ENV DEBIAN_FRONTEND noninteractive
 ENV DEBCONF_NONINTERACTIVE_SEEN true
 # Timezone data is needed during the installation of dependencies,
@@ -22,6 +22,6 @@ COPY . /tmp/cbmc
 WORKDIR /tmp/cbmc
 RUN cmake -S . -Bbuild -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=/usr/bin/gcc -DCMAKE_CXX_COMPILER=/usr/bin/g++ && cd build; ninja -j2
 
-FROM ubuntu:20.04 as runner
+FROM ubuntu:22.04 as runner
 COPY --from=builder /tmp/cbmc/build/bin/* /usr/local/bin/
 RUN apt-get update && apt-get install -y gcc


### PR DESCRIPTION
This allows us to tap into the udpated software registry that Ubuntu 22.04 uses, which allows us to use a new CMake version (`3.22`), which we want to be able to build the Rust API, for which we depend on a package that needs `CMake 3.19`.

It's worth mentioning that the rest of our CI infrastructure is already at `3.25`, and personal development machines should be between `3.22` and `3.25-3.26` (for MacOS machines using `brew`).

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
