### PR TITLE
Field sensitivity: fully expand nested objects

### DIFF
--- a/regression/cbmc/field-sensitivity15/main.c
+++ b/regression/cbmc/field-sensitivity15/main.c
@@ -1,0 +1,55 @@
+#include <assert.h>
+
+struct _12817932758143517076
+{
+  unsigned char _0;
+};
+
+struct _14237415465709481864_union__Err
+{
+  unsigned char cap;
+};
+
+union _14237415465709481864_union
+{
+  struct _12817932758143517076 value;
+  struct _14237415465709481864_union__Err Err;
+};
+
+void main(void)
+{
+  unsigned int x; // nondet
+
+  // the following is crucial (else pn trivially simplifies to 0)
+  unsigned int var_7 = x;
+  unsigned int pn = x - var_7;
+
+  unsigned char raw;
+  unsigned char mask;
+  if(pn == 0)
+  {
+    raw = 1;
+    mask = 0;
+  }
+  else
+    assert(0);
+
+  union _14237415465709481864_union var_11;
+  if(mask != 0)
+  {
+    var_11.Err.cap = 0;
+  }
+  else
+  {
+    var_11.value._0 = 1;
+    goto bb5;
+  }
+
+  // required to make this test fail (before the fix)
+  int tmp = 1;
+
+bb5:;
+  struct _12817932758143517076 truncated_packet_number = var_11.value;
+  unsigned char r = truncated_packet_number._0;
+  assert(raw == r);
+}

--- a/regression/cbmc/field-sensitivity15/test.desc
+++ b/regression/cbmc/field-sensitivity15/test.desc
@@ -1,0 +1,9 @@
+CORE
+main.c
+
+^VERIFICATION SUCCESSFUL$
+^EXIT=0$
+^SIGNAL=0$
+--
+--
+The test is a minimized version of code generated from s2n-quic using Kani.

--- a/regression/cbmc/field-sensitivity16/main.c
+++ b/regression/cbmc/field-sensitivity16/main.c
@@ -1,0 +1,67 @@
+#include <assert.h>
+
+struct _17626587426415757163
+{
+  unsigned long int cap;
+};
+
+struct _14237415465709481864_union__Err
+{
+  struct _17626587426415757163 _0;
+};
+
+struct _12817932758143517076_union__U8
+{
+  unsigned char _0;
+};
+
+union _12817932758143517076_union_
+{
+  struct _12817932758143517076_union__U8 U8;
+};
+
+struct _2123760316064833246_
+{
+  union _12817932758143517076_union_ cases;
+};
+
+union _14237415465709481864_union
+{
+  struct _2123760316064833246_ Ok;
+  struct _14237415465709481864_union__Err Err;
+};
+
+void main(void)
+{
+  unsigned int x; // nondet
+
+  // the following is crucial (else pn trivially simplifies to 0)
+  unsigned int var_7 = x;
+  unsigned int pn = x - var_7;
+
+  unsigned char mask;
+  if(pn == 0)
+    mask = 0;
+  else
+    assert(0);
+
+  union _14237415465709481864_union var_11;
+  if(mask != 0)
+  {
+    assert(0);
+    var_11.Err._0.cap = 0;
+  }
+  else
+  {
+    var_11.Ok.cases.U8._0 = 1;
+    goto bb5;
+  }
+
+  // keep this
+  int tmp = 1;
+bb5:;
+
+  struct _2123760316064833246_ truncated_packet_number = var_11.Ok;
+  assert(1 == var_11.Ok.cases.U8._0);
+  assert(1 == truncated_packet_number.cases.U8._0);
+}

--- a/regression/cbmc/field-sensitivity16/test.desc
+++ b/regression/cbmc/field-sensitivity16/test.desc
@@ -1,0 +1,9 @@
+CORE broken-z3-smt-backend
+main.c
+
+^VERIFICATION SUCCESSFUL$
+^EXIT=0$
+^SIGNAL=0$
+--
+--
+The test is a minimized version of code generated from s2n-quic using Kani.

--- a/src/goto-symex/symex_assign.cpp
+++ b/src/goto-symex/symex_assign.cpp
@@ -215,14 +215,6 @@ void symex_assignt::assign_non_struct_symbol(
       assignment.rhs,
       target,
       symex_config.allow_pointer_unsoundness);
-    // Erase the composite symbol from our working state. Note that we need to
-    // have it in the propagation table and the value set while doing the field
-    // assignments, thus we cannot skip putting it in there above.
-    if(state.field_sensitivity.is_divisible(l1_lhs, true))
-    {
-      state.propagation.erase_if_exists(l1_lhs.get_identifier());
-      state.value_set.erase_symbol(l1_lhs, ns);
-    }
   }
 }
 


### PR DESCRIPTION
When applying field sensitivity to an expression we must expand all levels. In the included test we previously constructed a member symbol (`var_11..value`) as right-hand side that still was of struct type. Instead, we must create a struct expression composed of all its members (here: `{ var_11..value.._0 }`).

Also, we must not keep nested expandable members in the propagation map for phi nodes don't merge on them.

Fixes: #7462

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
