### PR TITLE
Library functions may require converting additional inline functions

### DIFF
--- a/regression/cbmc-library/__signbitd-01/main.c
+++ b/regression/cbmc-library/__signbitd-01/main.c
@@ -1,9 +1,14 @@
 #include <assert.h>
 #include <math.h>
 
+int __signbitd(double);
+int __signbitf(float);
+
 int main()
 {
-  __signbitd();
-  assert(0);
+  float f;
+  double df = (double)f;
+  __CPROVER_assert(
+    isnan(f) || __signbitd(df) == __signbitf(f), "cast preserves sign");
   return 0;
 }

--- a/regression/cbmc-library/__signbitd-01/test.desc
+++ b/regression/cbmc-library/__signbitd-01/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.c
 --pointer-check --bounds-check
 ^EXIT=0$

--- a/regression/cbmc-library/copysignf-01/main.c
+++ b/regression/cbmc-library/copysignf-01/main.c
@@ -1,9 +1,13 @@
-#include <assert.h>
-#include <math.h>
+// Use a forward declaration instead of including math.h to demonstrate a bugfix
+// in library linking.
+float copysignf(float, float);
 
 int main()
 {
-  copysignf();
-  assert(0);
+  float x;
+  float y;
+  float result = copysignf(x, y);
+  __CPROVER_assert(
+    __CPROVER_signf(result) == __CPROVER_signf(y), "signs match");
   return 0;
 }

--- a/regression/cbmc-library/copysignf-01/test.desc
+++ b/regression/cbmc-library/copysignf-01/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.c
 --pointer-check --bounds-check
 ^EXIT=0$

--- a/src/ansi-c/compiler_headers/gcc_builtin_headers_math.h
+++ b/src/ansi-c/compiler_headers/gcc_builtin_headers_math.h
@@ -339,7 +339,7 @@ long double __builtin_scalblnl(long double, long);
 double __builtin_scalbn(double, int);
 float __builtin_scalbnf(float, int);
 long double __builtin_scalbnl(long double, int);
-int __builtin_signbit(double);
+int __builtin_signbit(); // this is type-generic
 int __builtin_signbitf(float);
 int __builtin_signbitl(long double);
 double __builtin_significand(double);

--- a/src/ansi-c/library/math.c
+++ b/src/ansi-c/library/math.c
@@ -2400,7 +2400,7 @@ float fabsf (float d);
 
 float copysignf(float x, float y)
 {
-  float abs = fabs(x);
+  float abs = fabsf(x);
   return (signbit(y)) ? -abs : abs;
 }
 

--- a/src/goto-programs/link_to_library.cpp
+++ b/src/goto-programs/link_to_library.cpp
@@ -47,6 +47,19 @@ static std::pair<optionalt<replace_symbolt::expr_mapt>, bool> add_one_function(
       library_model.goto_functions,
       message_handler);
   }
+  // We might need a function that's outside our own library, but brought in via
+  // some header file included by the library. Those functions already exist in
+  // goto_model.symbol_table, but haven't been converted just yet.
+  else if(
+    goto_model.symbol_table.symbols.find(missing_function) !=
+    goto_model.symbol_table.symbols.end())
+  {
+    goto_convert(
+      missing_function,
+      goto_model.symbol_table,
+      library_model.goto_functions,
+      message_handler);
+  }
 
   // check whether additional initialization may be required
   bool init_required = false;


### PR DESCRIPTION
Library functions may make use of (inline) functions defined in header files. One such case is `copysignf`, which uses `signbit`, which in turn is inlined on macOS. When these functions hadn't been seen before linking the library, then converting just the `library_model` symbol table would be insufficient for it would not include functions outside our own model library. Fall back to the `goto_model` symbol table for those cases.

This was originally reported via Kani in
https://github.com/model-checking/kani/issues/1993.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
