### PR TITLE
Fix documentation links

### DIFF
--- a/doc/doxygen-root/user_guide.md
+++ b/doc/doxygen-root/user_guide.md
@@ -3,7 +3,7 @@
 For a quick start with CBMC on simple problems, read
 
 * The \ref installation_guide
-* A [short tutorial](cprover-manual/md_cbmc-tutorial.html)
+* A [short tutorial](cprover-manual/md_cbmc_tutorial.html)
 * A [short manual](cprover-manual/index.html)
 
 For a quick start with CBMC on large software projects, read
@@ -23,7 +23,7 @@ Key concepts:
 
 * The \ref reference_guide describes CBMC and the CBMC tool chain
 * CBMC [primitives](cprover-manual/md_api.html) and
-  [memory primitives](cprover-manual/md_memory-primitives.html)
+  [memory primitives](cprover-manual/md_memory_primitives.html)
   are useful when writing CBMC assumptions and CBMC assertions.
 * \ref goto-programs "goto programs" are the intermediate representation
   of C code used by the CBMC tool chain

--- a/doc/satabs-user-manual.md
+++ b/doc/satabs-user-manual.md
@@ -57,7 +57,7 @@ and the directories that contain the header files. You must run SATABS
 from within the *Visual Studio Command Prompt*.
 
 Note that the distribution files for the [Eclipse
-plugin](installation-plugin.shtml) include the command-line tools.
+plugin](http://www.cprover.org/eclipse-plugin/) include the command-line tools.
 Therefore, if you intend to run SATABS exclusively within Eclipse, you
 can skip the installation of the command-line tools. However, you still
 have to install the compiler environment as described above.


### PR DESCRIPTION
Ensure that all links on diffblue.github.io/cbmc/ resolve to an existing page. Fixes the reported issue (#7450) as well as others found by running
`wget --spider -r -nd -nv --level 10 https://diffblue.github.io/cbmc/`.

Fixes: #7450

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
