### PR TITLE
GitHub Actions: cpplint and clang-format checks on PRs only

### DIFF
--- a/.github/workflows/pull-request-checks.yaml
+++ b/.github/workflows/pull-request-checks.yaml
@@ -593,50 +593,6 @@ jobs:
       - name: Run CBMC regression tests
         run: make CXX=clcache BUILD_ENV=MSVC -C regression test
 
-  # This job takes approximately 1 minute
-  check-clang-format:
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          submodules: recursive
-          fetch-depth: 0
-      - name: Fetch dependencies
-        env:
-          # This is needed in addition to -yq to prevent apt-get from asking for
-          # user input
-          DEBIAN_FRONTEND: noninteractive
-        run: |
-          sudo apt-get update
-          sudo apt-get install --no-install-recommends -yq clang-format-11
-      - name: Check updated lines of code match clang-format-11 style
-        env:
-          BASE_BRANCH: ${{ github.base_ref }}
-          MERGE_BRANCH: ${{ github.ref }}
-        run: ./.github/workflows/pull-request-check-clang-format.sh
-
-  # This job takes approximately 1 minute
-  check-cpplint:
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          submodules: recursive
-          fetch-depth: 0
-      - name: Fetch dependencies
-        env:
-          # This is needed in addition to -yq to prevent apt-get from asking for
-          # user input
-          DEBIAN_FRONTEND: noninteractive
-        run: |
-          sudo apt-get update
-          sudo apt-get install --no-install-recommends -yq python3-unidiff
-      - name: Check updated lines of code meet linting standards
-        env:
-          BASE_BRANCH: ${{ github.base_ref }}
-          MERGE_BRANCH: ${{ github.ref }}
-        run: ./.github/workflows/pull-request-check-cpplint.sh
-
   # This job takes approximately 32 minutes
   windows-msi-package:
     runs-on: windows-2019

--- a/.github/workflows/syntax-checks.yaml
+++ b/.github/workflows/syntax-checks.yaml
@@ -1,0 +1,49 @@
+name: Syntactic checks
+on:
+  pull_request:
+    branches: [ develop ]
+
+jobs:
+  # This job takes approximately 1 minute
+  check-clang-format:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+          fetch-depth: 0
+      - name: Fetch dependencies
+        env:
+          # This is needed in addition to -yq to prevent apt-get from asking for
+          # user input
+          DEBIAN_FRONTEND: noninteractive
+        run: |
+          sudo apt-get update
+          sudo apt-get install --no-install-recommends -yq clang-format-11
+      - name: Check updated lines of code match clang-format-11 style
+        env:
+          BASE_BRANCH: ${{ github.base_ref }}
+          MERGE_BRANCH: ${{ github.ref }}
+        run: ./.github/workflows/pull-request-check-clang-format.sh
+
+  # This job takes approximately 1 minute
+  check-cpplint:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+          fetch-depth: 0
+      - name: Fetch dependencies
+        env:
+          # This is needed in addition to -yq to prevent apt-get from asking for
+          # user input
+          DEBIAN_FRONTEND: noninteractive
+        run: |
+          sudo apt-get update
+          sudo apt-get install --no-install-recommends -yq python3-unidiff
+      - name: Check updated lines of code meet linting standards
+        env:
+          BASE_BRANCH: ${{ github.base_ref }}
+          MERGE_BRANCH: ${{ github.ref }}
+        run: ./.github/workflows/pull-request-check-cpplint.sh


### PR DESCRIPTION
With 2964edf941216c various checks are now also being run after the merge into develop (so as to make sure that GitHub's cache is adequately populated). The syntactic checks of the PR-specific diff neither work nor make sense upon push. This commit moves them into a YAML file of their own and limits their execution to pull requests only. No code changes.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
