### PR TITLE
Output solver stats on --stop-on-fail

### DIFF
--- a/regression/solver-hardness/solver-hardness-simple/test.desc
+++ b/regression/solver-hardness/solver-hardness-simple/test.desc
@@ -1,9 +1,8 @@
 CORE
 main.c
---write-solver-stats-to 'solver_hardness.json'
+--write-solver-stats-to 'solver_hardness.json' --stop-on-fail
 ^EXIT=10$
 ^SIGNAL=0$
-^\[main.assertion.\d+\] line \d+ assertion a \+ b \< 10: FAILURE$
 ^VERIFICATION FAILED$
 \"SAT_hardness\":\{(\"ClauseSet\":\[.*\]|\"Clauses\":\d+|\"Variables\":\d+|\"Literals\":\d+),(\"ClauseSet\":\[.*\]|\"Clauses\":\d+|\"Variables\":\d+|\"Literals\":\d+),(\"ClauseSet\":\[.*\]|\"Clauses\":\d+|\"Variables\":\d+|\"Literals\":\d+),(\"ClauseSet\":\[.*\]|\"Clauses\":\d+|\"Variables\":\d+|\"Literals\":\d+)\}
 --

--- a/src/goto-checker/stop_on_fail_verifier.h
+++ b/src/goto-checker/stop_on_fail_verifier.h
@@ -71,6 +71,7 @@ public:
       report_error(ui_message_handler);
       break;
     }
+    incremental_goto_checker.report();
   }
 
 protected:


### PR DESCRIPTION
We previously only output it when checking all properties.

- [X] Each commit message has a non-empty body, explaining why the change was made.
- [n/a] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [n/a] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [X Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [n/a] My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- [n/a] White-space or formatting changes outside the feature-related changed lines are in commits of their own.
