### PR TITLE
Add a `justfile` with basic support for building CBMC and executing Rust API tests.

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -67,6 +67,7 @@
 
 /cmake/        @diffblue/diffblue-opensource
 CMakeLists.txt @diffblue/diffblue-opensource
+justfile       @NlightNFotis
 
 # These files change frequently and changes are low-risk
 

--- a/justfile
+++ b/justfile
@@ -1,0 +1,24 @@
+# This is a `justfile`, for the program `just`, a task runner.
+# Think of it as a better make for targets that are actions rather than
+# files. For more information, look at https://github.com/casey/just
+
+default_build_dir := 'build/'
+default_solver := 'minisat2'
+
+# Perform a default (debug) build on MacOS systems under folder `build/`
+[macos]
+build:
+    cmake -S. -B{{default_build_dir}} -DCMAKE_C_COMPILER=/usr/bin/clang -DCMAKE_CXX_COMPILER=/usr/bin/clang++
+    cmake --build build -j4
+
+# Perform a default (debug) build on Linux systems under folder `build/`
+[linux]
+build:
+    cmake -S. -B{{default_build_dir}}
+    cmake --build build -j4
+
+# Test the Rust API (under src/libcprover-rust/)
+test-rust-api: build
+    cd src/libcprover-rust;\
+    cargo clean;\
+    CBMC_BUILD_DIR={{justfile_directory()}}/{{default_build_dir}} SAT_IMPL={{default_solver}} cargo test -- --test-threads=1


### PR DESCRIPTION
This is a rudimentary `justfile` (for https://github.com/casey/just), added as a base for easy running of the Rust API tests locally and online - as it allows for literally one-step build + test.

Over time I intend for this to be used for two purposes:

1. Streamline building of CBMC for existing and new contributors
2. Streamline build infrastructure in CI.

Also adding myself as a codeowner for the file just so that I can be notified about any changes made to it (assuming I'm the person with the most `just` knowledge for now).