### PR TITLE
Increase nominal ccache cache size for coverage CI job

### DIFF
--- a/.github/workflows/pull-request-checks.yaml
+++ b/.github/workflows/pull-request-checks.yaml
@@ -803,7 +803,7 @@ jobs:
       - name: Configure CMake CBMC build with coverage instrumentation parameters
         run: cmake -S . -Bbuild -Denable_coverage=1 -Dparallel_tests=2 -DCMAKE_CXX_COMPILER=/usr/bin/g++
       - name: Zero ccache stats and limit in size
-        run: ccache -z --max-size=4G
+        run: ccache -z --max-size=7G
       - name: Execute CMake CBMC build
         run: cmake --build build -- -j2
       - name: Print ccache stats


### PR DESCRIPTION
Speeding up builds for coverage reporting is desirable for two reasons:
1. Coverage-checking builds are approximately twice as slow compared to release builds, even in absence of any ccache-supported caching on either side.
2. Test runs with coverage logging and coverage collection take approximately 46 minutes when regular test runs just take 17 minutes on a similar platform.

Therefore, effective caching during builds has the potential to considerably speed up the overall job. Caching using ccache, however, was not effective, because ccache cleanups kicked in: cached artifacts were being removed while the build was still in progress. The resulting cache archive, therefore, was necessarily incomplete. ccache initiates a cleanup when a subdirectory reaches max_size / 16. Increasing max_size from 4 GB to 7 GB (empirically devised value) avoids such automatic cleanup during builds while still keeping the overall cache size well below 5 GB.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [x] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
