### PR TITLE
Fix symex coverage reporting of recursive calls

### DIFF
--- a/regression/cbmc/coverage_report2/main.c
+++ b/regression/cbmc/coverage_report2/main.c
@@ -1,0 +1,14 @@
+int factorial(int n)
+{
+  if(n == 0)
+  {
+    return 1;
+  }
+  return n * factorial(n - 1);
+}
+
+int main(void)
+{
+  int result = factorial(5);
+  return 0;
+}

--- a/regression/cbmc/coverage_report2/test.desc
+++ b/regression/cbmc/coverage_report2/test.desc
@@ -1,0 +1,10 @@
+CORE
+main.c
+--symex-coverage-report - --unwind 1
+<line branch="true" condition-coverage="50% \(1/2\)" hits="2" number="3">
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring
+^Invariant check failed

--- a/regression/validate-trace-xml-schema/check.py
+++ b/regression/validate-trace-xml-schema/check.py
@@ -50,6 +50,7 @@ ExcludedTests = list(map(lambda s: os.path.join(test_base_dir, s[0], s[1]), [
     # produces intermingled XML on the command line
     ['coverage_report1', 'test.desc'],
     ['coverage_report1', 'paths.desc'],
+    ['coverage_report2', 'test.desc'],
     ['graphml_witness1', 'test.desc'],
     ['switch8', 'program-only.desc'],
     ['Failing_Assert1', 'dimacs.desc'],

--- a/src/goto-checker/symex_coverage.cpp
+++ b/src/goto-checker/symex_coverage.cpp
@@ -236,15 +236,12 @@ void goto_program_coverage_recordt::compute_coverage_lines(
     symex_coveraget::coveraget::const_iterator c_entry = coverage.find(it);
     if(c_entry != coverage.end())
     {
-      if(!(c_entry->second.size() == 1 || is_branch))
-      {
-        std::cerr << it->location_number << '\n';
-        for(const auto &cov : c_entry->second)
-          std::cerr << cov.second.succ->location_number << '\n';
-      }
-      DATA_INVARIANT(
-        c_entry->second.size() == 1 || is_branch,
-        "instructions other than branch instructions have exactly 1 successor");
+      DATA_INVARIANT_WITH_DIAGNOSTICS(
+        c_entry->second.size() == 1 || is_branch || it->is_function_call(),
+        "instructions other than branch instructions or function calls have "
+        "exactly 1 successor",
+        "found at goto program instruction number " +
+          std::to_string(it->location_number));
 
       for(const auto &cov : c_entry->second)
       {


### PR DESCRIPTION
Recursive calls have two successors as far as coverage recording in symex is concerned: the edge back to the beginning of the function as well as the (pseudo-)edge to instruction after the call. Fix the invariant to account for this case.

Also, remove debugging-to-stderr.

Fixes: #7473

Co-authored-by: Qiuye-Hua

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
