### PR TITLE
SMT2 back-end: improve support for zero-sized components

### DIFF
--- a/regression/cbmc/Float-flags-no-simp1/test.desc
+++ b/regression/cbmc/Float-flags-no-simp1/test.desc
@@ -1,4 +1,4 @@
-CORE broken-smt-backend thorough-paths
+CORE broken-cprover-smt-backend thorough-paths
 main.c
 --floatbv --no-simplify
 ^EXIT=0$

--- a/regression/cbmc/Float-flags-simp1/test.desc
+++ b/regression/cbmc/Float-flags-simp1/test.desc
@@ -6,3 +6,7 @@ main.c
 ^VERIFICATION SUCCESSFUL$
 --
 ^warning: ignoring
+--
+This test only fails when running with the SMT solver on MacOS (with an
+invariant failure: "floatbv expressions should be flattened when using FPA
+theory").

--- a/regression/cbmc/Float-no-simp3/test.desc
+++ b/regression/cbmc/Float-no-simp3/test.desc
@@ -1,4 +1,4 @@
-CORE broken-cprover-smt-backend
+CORE
 main.c
 --floatbv --no-simplify
 ^EXIT=0$

--- a/regression/cbmc/Float-no-simp9/test.desc
+++ b/regression/cbmc/Float-no-simp9/test.desc
@@ -1,4 +1,4 @@
-CORE broken-smt-backend thorough-paths
+CORE broken-cprover-smt-backend thorough-paths
 main.c
 --floatbv --no-simplify
 ^EXIT=0$

--- a/regression/cbmc/Multi_Dimensional_Array2/test.desc
+++ b/regression/cbmc/Multi_Dimensional_Array2/test.desc
@@ -1,4 +1,4 @@
-CORE broken-smt-backend new-smt-backend
+CORE broken-cprover-smt-backend new-smt-backend
 main.c
 
 ^EXIT=0$

--- a/regression/cbmc/Multi_Dimensional_Array3/test.desc
+++ b/regression/cbmc/Multi_Dimensional_Array3/test.desc
@@ -1,4 +1,4 @@
-CORE broken-smt-backend new-smt-backend
+CORE broken-cprover-smt-backend new-smt-backend
 main.c
 
 ^EXIT=0$

--- a/regression/cbmc/Pointer_byte_extract5/no-simplify.desc
+++ b/regression/cbmc/Pointer_byte_extract5/no-simplify.desc
@@ -1,4 +1,4 @@
-CORE broken-smt-backend
+CORE broken-cprover-smt-backend
 main.i
 --bounds-check --32 --no-simplify
 ^EXIT=10$

--- a/regression/cbmc/Quantifiers-assertion/test.desc
+++ b/regression/cbmc/Quantifiers-assertion/test.desc
@@ -1,4 +1,4 @@
-CORE broken-z3-smt-backend
+CORE
 main.c
 
 ^\*\* Results:$

--- a/regression/cbmc/Quantifiers-two-dimension-array/fixed.desc
+++ b/regression/cbmc/Quantifiers-two-dimension-array/fixed.desc
@@ -1,4 +1,4 @@
-CORE broken-smt-backend
+CORE broken-cprover-smt-backend
 fixed.c
 
 ^\*\* Results:$

--- a/regression/cbmc/byte_update12/test.desc
+++ b/regression/cbmc/byte_update12/test.desc
@@ -1,4 +1,4 @@
-CORE broken-smt-backend
+CORE broken-cprover-smt-backend
 main.c
 
 ^EXIT=0$

--- a/regression/cbmc/field-sensitivity16/test.desc
+++ b/regression/cbmc/field-sensitivity16/test.desc
@@ -1,4 +1,4 @@
-CORE broken-z3-smt-backend
+CORE
 main.c
 
 ^VERIFICATION SUCCESSFUL$

--- a/regression/cbmc/havoc_slice/test_struct_raw_bytes.desc
+++ b/regression/cbmc/havoc_slice/test_struct_raw_bytes.desc
@@ -1,4 +1,4 @@
-CORE broken-smt-backend
+CORE broken-cprover-smt-backend
 test_struct_raw_bytes.c
 
 ^EXIT=10$

--- a/regression/cbmc/integer-assignments1/test.desc
+++ b/regression/cbmc/integer-assignments1/test.desc
@@ -1,4 +1,4 @@
-CORE smt-backend broken-smt-backend
+CORE smt-backend broken-cprover-smt-backend
 main.c
 --trace --smt2
 ^EXIT=10$

--- a/regression/cbmc/memory_allocation1/test.desc
+++ b/regression/cbmc/memory_allocation1/test.desc
@@ -11,3 +11,5 @@ main.c
 ^VERIFICATION FAILED$
 --
 ^warning: ignoring
+--
+This test only fails when using SMT solvers as back-end on Windows.

--- a/regression/cbmc/printf1/test.desc
+++ b/regression/cbmc/printf1/test.desc
@@ -9,3 +9,6 @@ main.c
 ^PRINT f1 123\.000000, -123\.000000, 123\.123000, 0\.123000$
 --
 ^warning: ignoring
+--
+This test only fails when using SMT solvers as back-end on Windows ("TODO
+typecast3 floatbv -> pointer", same problem as va_list3).

--- a/regression/cbmc/union10/union_list2.desc
+++ b/regression/cbmc/union10/union_list2.desc
@@ -1,4 +1,4 @@
-CORE broken-z3-smt-backend
+CORE
 union_list2.c
 
 ^EXIT=0$

--- a/regression/cbmc/union11/union_list.desc
+++ b/regression/cbmc/union11/union_list.desc
@@ -1,4 +1,4 @@
-CORE broken-z3-smt-backend
+CORE
 union_list.c
 
 ^EXIT=0$

--- a/regression/cbmc/union12/test.desc
+++ b/regression/cbmc/union12/test.desc
@@ -13,3 +13,5 @@ Despite the large array inside the union, the test should complete within 10
 seconds. Simplify extractbits(concatenation(...)) is essential to make this
 possible. With 77236cc34 (Avoid nesting of ID_with/byte_update by rewriting
 byte_extract to use the root object) the test already is trivial, however.
+
+This test only fails when using SMT solvers as back-end on Windows.

--- a/regression/cbmc/va_list3/test.desc
+++ b/regression/cbmc/va_list3/test.desc
@@ -6,3 +6,6 @@ main.c
 ^VERIFICATION SUCCESSFUL$
 --
 ^warning: ignoring
+--
+This test only fails when using SMT solvers as back-end on Windows ("TODO
+typecast3 floatbv -> pointer", same problem as va_list3).

--- a/regression/cbmc/void_pointer5/test.desc
+++ b/regression/cbmc/void_pointer5/test.desc
@@ -1,4 +1,4 @@
-CORE broken-smt-backend gcc-only
+CORE gcc-only
 main.c
 
 ^EXIT=10$

--- a/regression/cbmc/xml-trace/test.desc
+++ b/regression/cbmc/xml-trace/test.desc
@@ -1,4 +1,4 @@
-CORE broken-smt-backend
+CORE broken-cprover-smt-backend
 main.c
 --xml-ui --function test --little-endian
 activate-multi-line-match

--- a/regression/cbmc/z3/trace-char.desc
+++ b/regression/cbmc/z3/trace-char.desc
@@ -1,6 +1,6 @@
-CORE smt-backend broken-cprover-smt-backend
+CORE smt-backend
 trace-char.c
---trace --smt2 --z3
+--trace --z3
 ^EXIT=10$
 ^SIGNAL=0$
 arr=\{ '0', '1', '2', '3', '4', '5', '6', '7' \}

--- a/regression/cbmc/z3/trace.desc
+++ b/regression/cbmc/z3/trace.desc
@@ -1,6 +1,6 @@
-CORE smt-backend broken-cprover-smt-backend
+CORE smt-backend
 trace.c
---trace --smt2 --z3
+--trace --z3
 ^EXIT=10$
 ^SIGNAL=0$
 arr=\{ 0, 1, 2, 3, 4, 5, 6, 17 \}

--- a/src/solvers/smt2/smt2_conv.cpp
+++ b/src/solvers/smt2/smt2_conv.cpp
@@ -612,21 +612,14 @@ smt2_convt::parse_struct(const irept &src, const struct_typet &type)
   {
     // Structs look like:
     //  (mk-struct.1 <component0> <component1> ... <componentN>)
-    std::size_t j = 1;
+
+    if(src.get_sub().size()!=components.size()+1)
+      return result; // give up
+
     for(std::size_t i=0; i<components.size(); i++)
     {
       const struct_typet::componentt &c=components[i];
-      if(is_zero_width(components[i].type(), ns))
-      {
-        result.operands()[i] = nil_exprt{};
-      }
-      else
-      {
-        DATA_INVARIANT(
-          src.get_sub().size() > j, "insufficient number of component values");
-        result.operands()[i] = parse_rec(src.get_sub()[j], c.type());
-        ++j;
-      }
+      result.operands()[i]=parse_rec(src.get_sub()[i+1], c.type());
     }
   }
   else
@@ -3225,8 +3218,6 @@ void smt2_convt::convert_struct(const struct_exprt &expr)
     "number of struct components as indicated by the struct type shall be equal"
     "to the number of operands of the struct expression");
 
-  DATA_INVARIANT(!components.empty(), "struct shall have struct components");
-
   if(use_datatypes)
   {
     const std::string &smt_typename = datatype_map.at(struct_type);
@@ -3240,16 +3231,29 @@ void smt2_convt::convert_struct(const struct_exprt &expr)
         it!=components.end();
         it++, i++)
     {
-      if(is_zero_width(it->type(), ns))
+      if(
+        it->type().id() != ID_struct_tag && it->type().id() != ID_struct &&
+        is_zero_width(it->type(), ns))
+      {
         continue;
+      }
+
       out << " ";
       convert_expr(expr.operands()[i]);
+    }
+
+    if(components.empty())
+    {
+      out << " ";
+      convert_expr(from_integer(0, unsignedbv_typet{1}));
     }
 
     out << ")";
   }
   else
   {
+    DATA_INVARIANT(!components.empty(), "struct shall have struct components");
+
     if(components.size()==1)
     {
       const exprt &op = expr.op0();
@@ -4903,9 +4907,6 @@ void smt2_convt::unflatten(
             it!=components.end();
             it++, i++)
         {
-          if(is_zero_width(it->type(), ns))
-            continue;
-
           std::size_t member_width=boolbv_width(it->type());
 
           out << " ";
@@ -4914,6 +4915,12 @@ void smt2_convt::unflatten(
               << offset << ") ?ufop" << nesting << ")";
           unflatten(wheret::END, it->type(), nesting+1);
           offset+=member_width;
+        }
+
+        if(components.empty())
+        {
+          out << " ";
+          convert_expr(from_integer(0, unsignedbv_typet{1}));
         }
 
         out << "))"; // mk-, let
@@ -5940,12 +5947,24 @@ void smt2_convt::find_symbols_rec(
 
       for(const auto &component : components)
       {
-        if(is_zero_width(component.type(), ns))
+        if(
+          component.type().id() != ID_struct_tag &&
+          component.type().id() != ID_struct &&
+          is_zero_width(component.type(), ns))
+        {
           continue;
+        }
 
         out << "(" << smt_typename << "." << component.get_name()
                       << " ";
         convert_type(component.type());
+        out << ") ";
+      }
+
+      if(components.empty())
+      {
+        out << "(" << smt_typename << ".0 ";
+        convert_type(unsignedbv_typet{1});
         out << ") ";
       }
 

--- a/src/solvers/smt2/smt2_conv.h
+++ b/src/solvers/smt2/smt2_conv.h
@@ -187,6 +187,7 @@ protected:
     std::unordered_map<int64_t, exprt> *operands_map,
     const irept &src,
     const array_typet &type);
+  std::unordered_map<irep_idt, irept> current_bindings;
 
   // we use this to build a bit-vector encoding of the FPA theory
   void convert_floatbv(const exprt &expr);


### PR DESCRIPTION
Kani uses empty structs and unions on a regular basis, which necessitates better support for these in the SMT back-end. As SMT LIB has no provision for zero-sized bit vectors we need to filter out any such expressions.

Fixes: #7442

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
