### PR TITLE
Added concept of core goto language form

### DIFF
--- a/doc/ADR/README.md
+++ b/doc/ADR/README.md
@@ -6,6 +6,9 @@ where taken at the time they were, so that future maintainers
 can more easily identify constraints that shaped the architecture
 of the system and the surrounding infrastructure.
 
+## Core goto form
+\subpage core-goto
+
 ## Release & Packaging
 
 * \subpage release-process

--- a/doc/ADR/core_goto.md
+++ b/doc/ADR/core_goto.md
@@ -1,0 +1,20 @@
+\page core-goto Core goto definition
+
+During the analysis of a program CBMC transforms the input program in an intermediate language
+called extended goto. Then the tool performs a series of simplifications on the obtained goto
+program until the program is given to the solver.
+
+We say that a program is in the **core goto form** when all the extended goto features have
+been simplified.
+
+More specifically, a program that is in **core goto form** is one that can be passed to **symex** by
+using any solver deriving from `goto_verifiert` without requiring any lowering step.
+
+At the time of writing, verifiers extending `goto_verifiert` are:
+
+* `all_properties_verifier_with_fault_localizationt`,
+* `all_properties_verifier_with_trace_storaget`,
+* `all_properties_verifiert`,
+* `cover_goals_verifier_with_trace_storaget`,
+* `stop_on_fail_verifier_with_fault_localizationt`,
+* `stop_on_fail_verifiert`.


### PR DESCRIPTION
This PR defines the requirements for a program to be in **canonical goto form**.

A **canonical goto program** is defined by means of a functional requirement: being able to be analyzed by any solver extending `goto_verifiert` without any prior lowering step.

The aim, in the future, is to replace such functional requirement with structural ones.

The definition of **canonical goto program** has been added for reference in the `doc/ADR/canonical_goto.md` file.