### PR TITLE
Fix bug in solver hardness stats

### DIFF
--- a/regression/solver-hardness/solver-hardness-simple/main.c
+++ b/regression/solver-hardness/solver-hardness-simple/main.c
@@ -5,5 +5,6 @@ int main()
   int a;
   int b;
   assert(a + b < 10);
+  assert(a < 10);
   return 0;
 }

--- a/regression/solver-hardness/solver-hardness-simple/test.desc
+++ b/regression/solver-hardness/solver-hardness-simple/test.desc
@@ -5,5 +5,6 @@ main.c
 ^SIGNAL=0$
 ^VERIFICATION FAILED$
 \"SAT_hardness\":\{(\"ClauseSet\":\[.*\]|\"Clauses\":\d+|\"Variables\":\d+|\"Literals\":\d+),(\"ClauseSet\":\[.*\]|\"Clauses\":\d+|\"Variables\":\d+|\"Literals\":\d+),(\"ClauseSet\":\[.*\]|\"Clauses\":\d+|\"Variables\":\d+|\"Literals\":\d+),(\"ClauseSet\":\[.*\]|\"Clauses\":\d+|\"Variables\":\d+|\"Literals\":\d+)\}
+\"GOTO_ID\":32,\"SAT_hardness\":\{\"ClauseSet\":\[.*,571\],\"Clauses\":571
 --
 ^warning: ignoring

--- a/src/goto-symex/solver_hardness.cpp
+++ b/src/goto-symex/solver_hardness.cpp
@@ -77,11 +77,12 @@ void solver_hardnesst::register_assertion_ssas(
   const std::vector<goto_programt::const_targett> &pcs)
 {
   if(assertion_stats.empty())
-    return;
+  {
+    assertion_stats.ssa_expression = expr2string(ssa_expression);
+    assertion_stats.pcs = pcs;
+  }
 
-  assertion_stats.sat_hardness = current_hardness;
-  assertion_stats.ssa_expression = expr2string(ssa_expression);
-  assertion_stats.pcs = pcs;
+  assertion_stats.sat_hardness += current_hardness;
   current_ssa_key = {};
   current_hardness = {};
 }

--- a/src/goto-symex/solver_hardness.cpp
+++ b/src/goto-symex/solver_hardness.cpp
@@ -44,7 +44,7 @@ bool solver_hardnesst::assertion_statst::empty() const
 
 void solver_hardnesst::register_ssa(
   std::size_t ssa_index,
-  const exprt ssa_expression,
+  const exprt &ssa_expression,
   goto_programt::const_targett pc)
 {
   PRECONDITION(ssa_index < hardness_stats.size());
@@ -73,7 +73,7 @@ void solver_hardnesst::register_ssa_size(std::size_t size)
 }
 
 void solver_hardnesst::register_assertion_ssas(
-  const exprt ssa_expression,
+  const exprt &ssa_expression,
   const std::vector<goto_programt::const_targett> &pcs)
 {
   if(assertion_stats.empty())
@@ -378,7 +378,7 @@ solver_hardnesst::goto_instruction2string(goto_programt::const_targett pc)
   return out.str();
 }
 
-std::string solver_hardnesst::expr2string(const exprt expr)
+std::string solver_hardnesst::expr2string(const exprt &expr)
 {
   std::stringstream ss;
   ss << format(expr);

--- a/src/goto-symex/solver_hardness.h
+++ b/src/goto-symex/solver_hardness.h
@@ -82,7 +82,7 @@ struct solver_hardnesst : public clause_hardness_collectort
   /// \param pc: the GOTO instruction iterator for this SSA step
   void register_ssa(
     std::size_t ssa_index,
-    const exprt ssa_expression,
+    const exprt &ssa_expression,
     goto_programt::const_targett pc);
 
   void register_ssa_size(std::size_t size);
@@ -95,7 +95,7 @@ struct solver_hardnesst : public clause_hardness_collectort
   /// \param pcs: all GOTO instruction iterators that contributed in the
   ///   disjunction
   void register_assertion_ssas(
-    const exprt ssa_expression,
+    const exprt &ssa_expression,
     const std::vector<goto_programt::const_targett> &pcs);
 
   /// Called e.g. from the `satcheck_minisat2::lcnf`, this function adds the
@@ -130,7 +130,7 @@ private:
   // A minor modification of \ref goto_programt::output_instruction
   static std::string goto_instruction2string(goto_programt::const_targett pc);
 
-  static std::string expr2string(const exprt expr);
+  static std::string expr2string(const exprt &expr);
 
   std::string outfile;
   std::vector<std::unordered_map<hardness_ssa_keyt, sat_hardnesst>>


### PR DESCRIPTION
The disjunction of goal handles had been ignored, leading to missing clauses in the assertion stats.

- [X] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [X] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.
