### PR TITLE
Rust API crate preparation

### DIFF
--- a/.github/workflows/pull-request-check-rust-api.yaml
+++ b/.github/workflows/pull-request-check-rust-api.yaml
@@ -61,9 +61,10 @@ jobs:
       # by the other jobs already present in `pull-request-checks.yaml`.
       - name: Run Rust API tests
         run: |
+          VERSION=$(ruby -ne 'puts $~.captures if /^CBMC_VERSION\ =\ (\d+.\d+.\d+)$/' src/config.inc)
           cd src/libcprover-rust;\
           cargo clean;\
-          CBMC_BUILD_DIR=../../${{env.default_build_dir}} SAT_IMPL=${{env.default_solver}} cargo test -- --test-threads=1
+          CBMC_BUILD_DIR=../../${{env.default_build_dir}} CBMC_VERSION=$VERSION cargo test -- --test-threads=1
 
 
   check-macos-12-cmake-clang-rust:
@@ -100,6 +101,7 @@ jobs:
       # by the other jobs already present in `pull-request-checks.yaml`.
       - name: Run Rust API tests
         run: |
+          VERSION=$(ruby -ne 'puts $~.captures if /^CBMC_VERSION\ =\ (\d+.\d+.\d+)$/' src/config.inc)
           cd src/libcprover-rust;\
           cargo clean;\
-          CBMC_BUILD_DIR=../../${{env.default_build_dir}} SAT_IMPL=${{env.default_solver}} cargo test -- --test-threads=1
+          CBMC_BUILD_DIR=../../${{env.default_build_dir}} CBMC_VERSION=$VERSION cargo test -- --test-threads=1

--- a/.github/workflows/pull-request-check-rust-api.yaml
+++ b/.github/workflows/pull-request-check-rust-api.yaml
@@ -52,7 +52,7 @@ jobs:
       # local experiments on the same platform, but it seems to be doing no harm to the build overall
       # and allows us to test the Rust API on Linux without issues.
       - name: Configure using CMake
-        run: cmake -S. -B${{env.default_build_dir}} -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DCMAKE_C_COMPILER=/usr/bin/clang-13 -DCMAKE_CXX_COMPILER=/usr/bin/clang++-13 -DWITH_RUST_API=ON
+        run: cmake -S. -B${{env.default_build_dir}} -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DCMAKE_C_COMPILER=/usr/bin/clang-13 -DCMAKE_CXX_COMPILER=/usr/bin/clang++-13
       - name: Build with CMake
         run: cmake --build ${{env.default_build_dir}} -j2
       - name: Print ccache stats
@@ -92,7 +92,7 @@ jobs:
       - name: Zero ccache stats and limit in size
         run: ccache -z --max-size=500M
       - name: Configure using CMake
-        run: cmake -S. -B${{env.default_build_dir}} -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=/usr/bin/clang -DCMAKE_CXX_COMPILER=/usr/bin/clang++ -DWITH_RUST_API=ON
+        run: cmake -S. -B${{env.default_build_dir}} -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=/usr/bin/clang -DCMAKE_CXX_COMPILER=/usr/bin/clang++
       - name: Build with Ninja
         run: cd ${{env.default_build_dir}}; ninja -j3
       - name: Print ccache stats

--- a/.github/workflows/pull-request-check-rust-api.yaml
+++ b/.github/workflows/pull-request-check-rust-api.yaml
@@ -64,7 +64,7 @@ jobs:
           VERSION=$(ruby -ne 'puts $~.captures if /^CBMC_VERSION\ =\ (\d+.\d+.\d+)$/' src/config.inc)
           cd src/libcprover-rust;\
           cargo clean;\
-          CBMC_BUILD_DIR=../../${{env.default_build_dir}} CBMC_VERSION=$VERSION cargo test -- --test-threads=1
+          CBMC_LIB_DIR=../../${{env.default_build_dir}}/lib CBMC_VERSION=$VERSION cargo test -- --test-threads=1
 
 
   check-macos-12-cmake-clang-rust:
@@ -104,4 +104,4 @@ jobs:
           VERSION=$(ruby -ne 'puts $~.captures if /^CBMC_VERSION\ =\ (\d+.\d+.\d+)$/' src/config.inc)
           cd src/libcprover-rust;\
           cargo clean;\
-          CBMC_BUILD_DIR=../../${{env.default_build_dir}} CBMC_VERSION=$VERSION cargo test -- --test-threads=1
+          CBMC_LIB_DIR=../../${{env.default_build_dir}}/lib CBMC_VERSION=$VERSION cargo test -- --test-threads=1

--- a/.github/workflows/pull-request-check-rust-api.yaml
+++ b/.github/workflows/pull-request-check-rust-api.yaml
@@ -61,7 +61,7 @@ jobs:
       # by the other jobs already present in `pull-request-checks.yaml`.
       - name: Run Rust API tests
         run: |
-          VERSION=$(ruby -ne 'puts $~.captures if /^CBMC_VERSION\ =\ (\d+.\d+.\d+)$/' src/config.inc)
+          VERSION=$(cat src/config.inc | python3 -c "import sys,re;line = [line for line in sys.stdin if re.search('CBMC_VERSION = (\d+\.\d+\.\d+)', line)];sys.stdout.write(re.search('CBMC_VERSION = (\d+\.\d+\.\d+)', line[0]).group(1))")
           cd src/libcprover-rust;\
           cargo clean;\
           CBMC_LIB_DIR=../../${{env.default_build_dir}}/lib CBMC_VERSION=$VERSION cargo test -- --test-threads=1
@@ -101,7 +101,7 @@ jobs:
       # by the other jobs already present in `pull-request-checks.yaml`.
       - name: Run Rust API tests
         run: |
-          VERSION=$(ruby -ne 'puts $~.captures if /^CBMC_VERSION\ =\ (\d+.\d+.\d+)$/' src/config.inc)
+          VERSION=$(cat src/config.inc | python3 -c "import sys,re;line = [line for line in sys.stdin if re.search('CBMC_VERSION = (\d+\.\d+\.\d+)', line)];sys.stdout.write(re.search('CBMC_VERSION = (\d+\.\d+\.\d+)', line[0]).group(1))")
           cd src/libcprover-rust;\
           cargo clean;\
           CBMC_LIB_DIR=../../${{env.default_build_dir}}/lib CBMC_VERSION=$VERSION cargo test -- --test-threads=1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -274,7 +274,7 @@ else()
 
     corrosion_import_crate(MANIFEST_PATH src/libcprover-rust/Cargo.toml)
     list(JOIN sat_impl " " sat_impl_str)
-    corrosion_set_env_vars(cprover-api-rust CBMC_BUILD_DIR=${CMAKE_BINARY_DIR} "SAT_IMPL=${sat_impl_str}")
+    corrosion_set_env_vars(cprover-api-rust CBMC_BUILD_DIR=${CMAKE_BINARY_DIR})
     corrosion_link_libraries(cprover-api-rust cprover-api-cpp)
     install(TARGETS cprover-api-rust RUNTIME DESTINATION lib)
     # NOTE: We want to rename to a name consistent with the name of the

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,7 @@ file(
   STRINGS src/config.inc CBMC_VERSION
   REGEX "CBMC_VERSION = (.*)")
 string(REGEX REPLACE "CBMC_VERSION = (.*)" "\\1" CBMC_VERSION ${CBMC_VERSION})
+message(STATUS "Building CBMC version ${CBMC_VERSION}")
 
 project(CBMC VERSION ${CBMC_VERSION})
 
@@ -274,7 +275,7 @@ else()
 
     corrosion_import_crate(MANIFEST_PATH src/libcprover-rust/Cargo.toml)
     list(JOIN sat_impl " " sat_impl_str)
-    corrosion_set_env_vars(cprover-api-rust CBMC_BUILD_DIR=${CMAKE_BINARY_DIR})
+    corrosion_set_env_vars(cprover-api-rust CBMC_BUILD_DIR=${CMAKE_BINARY_DIR} CBMC_VERSION=${CBMC_VERSION})
     corrosion_link_libraries(cprover-api-rust cprover-api-cpp)
     install(TARGETS cprover-api-rust RUNTIME DESTINATION lib)
     # NOTE: We want to rename to a name consistent with the name of the

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -275,7 +275,7 @@ else()
 
     corrosion_import_crate(MANIFEST_PATH src/libcprover-rust/Cargo.toml)
     list(JOIN sat_impl " " sat_impl_str)
-    corrosion_set_env_vars(cprover-api-rust CBMC_BUILD_DIR=${CMAKE_BINARY_DIR} CBMC_VERSION=${CBMC_VERSION})
+    corrosion_set_env_vars(cprover-api-rust CBMC_LIB_DIR=${CMAKE_BINARY_DIR} CBMC_VERSION=${CBMC_VERSION})
     corrosion_link_libraries(cprover-api-rust cprover-api-cpp)
     install(TARGETS cprover-api-rust RUNTIME DESTINATION lib)
     # NOTE: We want to rename to a name consistent with the name of the

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -257,33 +257,4 @@ if(WITH_JBMC)
     add_subdirectory(jbmc)
 endif()
 
-option(WITH_RUST_API "Build with the CPROVER Rust API" OFF)
-if(${CMAKE_VERSION} VERSION_LESS "3.19.0" AND WITH_RUST_API)
-    message("Unable to build the Rust API without version CMake 3.19.0")
-    message(FATAL_ERROR "(The Rust build depends on CMake plugins with dependencies on CMake 3.19.0 and above)")
-else()
-    if(WITH_RUST_API)
-    include(FetchContent)
-
-    FetchContent_Declare(
-        Corrosion
-        GIT_REPOSITORY https://github.com/corrosion-rs/corrosion.git
-        GIT_TAG v0.3.1
-    )
-
-    FetchContent_MakeAvailable(Corrosion)
-
-    corrosion_import_crate(MANIFEST_PATH src/libcprover-rust/Cargo.toml)
-    list(JOIN sat_impl " " sat_impl_str)
-    corrosion_set_env_vars(cprover-api-rust CBMC_LIB_DIR=${CMAKE_BINARY_DIR} CBMC_VERSION=${CBMC_VERSION})
-    corrosion_link_libraries(cprover-api-rust cprover-api-cpp)
-    install(TARGETS cprover-api-rust RUNTIME DESTINATION lib)
-    # NOTE: We want to rename to a name consistent with the name of the
-    # rest of the static libraries built as a result of a build. The reason
-    # we cannot set the target name directly is that Cargo doesn't support
-    # hyphens in names of packages, so it builds the name by default with
-    # an underscore.
-    endif()
-endif()
-
 include(cmake/packaging.cmake)

--- a/src/libcprover-rust/Cargo.lock
+++ b/src/libcprover-rust/Cargo.lock
@@ -19,14 +19,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cprover-api-rust"
-version = "0.1.0"
-dependencies = [
- "cxx",
- "cxx-build",
-]
-
-[[package]]
 name = "cxx"
 version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -68,6 +60,14 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "libcprover_rust"
+version = "0.1.0"
+dependencies = [
+ "cxx",
+ "cxx-build",
 ]
 
 [[package]]

--- a/src/libcprover-rust/Cargo.toml
+++ b/src/libcprover-rust/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "cprover-api-rust"
+name = "libcprover_rust"
 version = "0.1.0"
 edition = "2021"
 description = "Rust API for CBMC and assorted CProver tools"
@@ -17,4 +17,4 @@ cxx = "1.0"
 cxx-build = "1.0"
 
 [lib]
-crate-type = ["staticlib"]
+crate-type = ["rlib"]

--- a/src/libcprover-rust/Cargo.toml
+++ b/src/libcprover-rust/Cargo.toml
@@ -2,6 +2,11 @@
 name = "cprover-api-rust"
 version = "0.1.0"
 edition = "2021"
+description = "Rust API for CBMC and assorted CProver tools"
+repository = "https://github.com/diffblue/cbmc"
+documentation = "https://diffblue.github.io/cbmc/"
+license = "BSD-4-Clause"
+exclude = ["other/", "module_dependencies.txt"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/src/libcprover-rust/build.rs
+++ b/src/libcprover-rust/build.rs
@@ -26,47 +26,6 @@ fn get_library_build_dir() -> std::io::Result<PathBuf> {
     ))
 }
 
-fn get_cadical_build_dir() -> std::io::Result<PathBuf> {
-    let env_var_fetch_result = get_build_directory();
-    if let Ok(build_dir) = env_var_fetch_result {
-        let mut path = PathBuf::new();
-        path.push(build_dir);
-        path.push("cadical-src/build/");
-        return Ok(path);
-    }
-    Err(Error::new(
-        ErrorKind::Other,
-        "failed to get build output directory",
-    ))
-}
-
-fn get_sat_libraries() -> std::io::Result<Vec<&'static str>> {
-    let env_var_name = "SAT_IMPL";
-    let env_var_fetch_result = env::var(env_var_name);
-    if let Ok(sat_impls) = env_var_fetch_result {
-        let mut solver_libs = Vec::new();
-        for sat_impl in sat_impls.split(" ") {
-            let solver_lib = match sat_impl {
-                "minisat2" => "minisat2-condensed",
-                "glucose" => "glucose-condensed",
-                "cadical" => "cadical",
-                _ => {
-                    return Err(Error::new(
-                        ErrorKind::Other,
-                        "no identifiable solver detected",
-                    ))
-                }
-            };
-            solver_libs.push(solver_lib);
-        }
-        return Ok(solver_libs);
-    }
-    Err(Error::new(
-        ErrorKind::Other,
-        "SAT_IMPL environment variable not set",
-    ))
-}
-
 fn main() {
     let cbmc_source_path = Path::new("..");
     let cpp_api_path = Path::new("../libcprover-cpp/");
@@ -85,27 +44,6 @@ fn main() {
         Ok(path) => path,
         Err(err) => panic!("Error: {}", err),
     };
-
-    let solver_libs = match get_sat_libraries() {
-        Ok(solvers) => solvers,
-        Err(err) => panic!("Error: {}", err),
-    };
-
-    for solver_lib in solver_libs.iter() {
-        // Cadical is being built in its own directory, with the resultant artefacts being
-        // present only there. Hence, we need to instruct cargo to look for them in cadical's
-        // build directory, otherwise we're going to get build errors.
-        if *solver_lib == "cadical" {
-            let cadical_build_dir = match get_cadical_build_dir() {
-                Ok(cadical_directory) => cadical_directory,
-                Err(err) => panic!("Error: {}", err),
-            };
-            println!(
-                "cargo:rustc-link-search=native={}",
-                cadical_build_dir.display()
-            );
-        }
-    }
 
     println!(
         "cargo:rustc-link-search=native={}",

--- a/src/libcprover-rust/build.rs
+++ b/src/libcprover-rust/build.rs
@@ -8,8 +8,8 @@ fn get_current_working_dir() -> std::io::Result<PathBuf> {
     env::current_dir()
 }
 
-fn get_build_directory() -> Result<String, VarError> {
-    env::var("CBMC_BUILD_DIR")
+fn get_lib_directory() -> Result<String, VarError> {
+    env::var("CBMC_LIB_DIR")
 }
 
 // Passed by the top-level CMakeLists.txt to control which version of the
@@ -20,16 +20,15 @@ fn get_cbmc_version() -> Result<String, VarError> {
 }
 
 fn get_library_build_dir() -> std::io::Result<PathBuf> {
-    let env_var_fetch_result = get_build_directory();
+    let env_var_fetch_result = get_lib_directory();
     if let Ok(build_dir) = env_var_fetch_result {
         let mut path = PathBuf::new();
         path.push(build_dir);
-        path.push("lib/");
         return Ok(path);
     }
     Err(Error::new(
         ErrorKind::Other,
-        "failed to get build output directory",
+        "Please set the environment variable CBMC_LIB_DIR with the path that contains the libcprover.x.y.z.a library on your system",
     ))
 }
 

--- a/src/libcprover-rust/build.rs
+++ b/src/libcprover-rust/build.rs
@@ -12,6 +12,13 @@ fn get_build_directory() -> Result<String, VarError> {
     env::var("CBMC_BUILD_DIR")
 }
 
+// Passed by the top-level CMakeLists.txt to control which version of the
+// static library of CBMC we're linking against. A user can also change the
+// environment variable to link against different versions of CBMC.
+fn get_cbmc_version() -> Result<String, VarError> {
+    env::var("CBMC_VERSION")
+}
+
 fn get_library_build_dir() -> std::io::Result<PathBuf> {
     let env_var_fetch_result = get_build_directory();
     if let Ok(build_dir) = env_var_fetch_result {
@@ -50,5 +57,10 @@ fn main() {
         libraries_path.display()
     );
 
-    println!("cargo:rustc-link-lib=static=cprover.5.78.0");
+    let cprover_static_libname = match get_cbmc_version() {
+        Ok(version) => String::from("cprover.") + &version,
+        Err(err) => panic!("Error: {}", err),
+    };
+
+    println!("cargo:rustc-link-lib=static={}", cprover_static_libname);
 }

--- a/src/libcprover-rust/readme.md
+++ b/src/libcprover-rust/readme.md
@@ -1,0 +1,49 @@
+# CProver (CBMC) Rust API
+
+This folder contains the implementation of the Rust API of the CProver (CBMC) project.
+
+## Building instructions
+
+There are two ways to build the project:
+
+1. As part of the CBMC project (using `cmake`) by building CBMC with the flag
+   `-DWITH_RUST_API=ON`. The outcome of this process is a compilation artefact
+   `libcprover-x.y.z.a` under the `<build>/lib` directory.
+2. By executing `cargo build` under this (`src/libcprover-rust`) directory.
+
+   For this to work, you need to supply two environment variables to the
+   project:
+
+   * `CBMC_LIB_DIR`, for selecting where the `libcprover-x.y.z.a` is located
+     (say, if you have downloaded a pre-packaged release which contains
+      the static library), and
+   * `CBMC_VERSION`, for selecting the version of the library to link against
+     (this is useful if you have multiple versions of the library in the same
+      location and you want to control which version you compile against).
+
+As an example, a command sequence to build the API through `cargo` would look
+like this (assuming you're executing these instructions from the root level
+directory of the CBMC project.)
+
+```sh
+$ cd src/libcprover-rust
+$ cargo clean
+$ CBMC_LIB_DIR=../../build/lib CBMC_VERSION=5.78.0 cargo build
+```
+
+To build the project and run its associated tests, the command sequence would
+look like this:
+
+```sh
+$ cd src/libcprover-rust
+$ cargo clean
+$ CBMC_LIB_DIR=../../build/lib CBMC_VERSION=5.78.0 cargo test -- --test-threads=1 --nocapture
+```
+
+## Notes
+
+* The functions supported by the Rust API are catalogued within the `ffi` module within
+  `lib.rs`.
+* The API supports exception handling from inside CBMC by catching the exceptions in
+  a C++ shim, and then translating the exception into the Rust `Result` type.
+* Because of limitations from the C++ side of CBMC, the API is not thread-safe.

--- a/src/libcprover-rust/readme.md
+++ b/src/libcprover-rust/readme.md
@@ -4,22 +4,21 @@ This folder contains the implementation of the Rust API of the CProver (CBMC) pr
 
 ## Building instructions
 
-There are two ways to build the project:
+To build the Rust project you need the Rust language toolchain installed
+(you can install from [rustup.rs](https://rustup.rs)).
 
-1. As part of the CBMC project (using `cmake`) by building CBMC with the flag
-   `-DWITH_RUST_API=ON`. The outcome of this process is a compilation artefact
-   `libcprover-x.y.z.a` under the `<build>/lib` directory.
-2. By executing `cargo build` under this (`src/libcprover-rust`) directory.
+With that instaled, you can execute `cargo build` under this (`src/libcprover-rust`)
+directory.
 
-   For this to work, you need to supply two environment variables to the
-   project:
+For this to work, you need to supply two environment variables to the
+project:
 
-   * `CBMC_LIB_DIR`, for selecting where the `libcprover-x.y.z.a` is located
-     (say, if you have downloaded a pre-packaged release which contains
-      the static library), and
-   * `CBMC_VERSION`, for selecting the version of the library to link against
-     (this is useful if you have multiple versions of the library in the same
-      location and you want to control which version you compile against).
+* `CBMC_LIB_DIR`, for selecting where the `libcprover-x.y.z.a` is located
+  (say, if you have downloaded a pre-packaged release which contains
+   the static library), and
+* `CBMC_VERSION`, for selecting the version of the library to link against
+  (this is useful if you have multiple versions of the library in the same
+   location and you want to control which version you compile against).
 
 As an example, a command sequence to build the API through `cargo` would look
 like this (assuming you're executing these instructions from the root level

--- a/src/libcprover-rust/src/lib.rs
+++ b/src/libcprover-rust/src/lib.rs
@@ -1,4 +1,5 @@
 use cxx::{CxxString, CxxVector};
+
 #[cxx::bridge]
 pub mod ffi {
 


### PR DESCRIPTION
This PR is for tracking of the requirements/development of the Rust crate before publication on crates.io.

This is connected to https://github.com/diffblue/cbmc/issues/7491 - this PR's merging means that the crate is ready for publication, and the only thing left is the actual publication on `crates.io`.

## Review Guidance

* We have streamlined the build script (`build.rs`) but it now depends on two environment variables, `CBMC_LIB_DIR` which points to where the `libcprover.x.y.z.a` is located, and `CBMC_VERSION`, which hints the version of library to link against - this allows for selecting against different versions of CBMC to link against if they're all located in one path, quickly and easily.
* To be able to be used by a Rust program, we had to change the target to be a `rlib` (`Rust library`), as cargo wouldn't find that it specifies a linking target otherwise.
* We have removed the dependency on `corrosion` (a CMake plugin to build the Rust API along with the rest of the C++ project). I came to the realisation that with the current build dependency being `libcprover.x.y.z.a`, we no longer need to build the Rust API project along with the C++ project, and the Rust project is free to be built standalone at any point in time.


## Checklist

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [x] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
