### PR TITLE
Fix ccache restore key for check-macos-12-cmake-clang

### DIFF
--- a/.github/workflows/pull-request-checks.yaml
+++ b/.github/workflows/pull-request-checks.yaml
@@ -521,10 +521,10 @@ jobs:
         uses: actions/cache@v3
         with:
           path: .ccache
-          key: ${{ runner.os }}-Release-Glucose${{ github.ref }}-${{ github.sha }}-PR
+          key: ${{ runner.os }}-Release-Glucose-${{ github.ref }}-${{ github.sha }}-PR
           restore-keys: |
-            ${{ runner.os }}-Release-Glucose${{ github.ref }}
-            ${{ runner.os }}-Release
+            ${{ runner.os }}-Release-Glucose-${{ github.ref }}
+            ${{ runner.os }}-Release-Glucose
       - name: ccache environment
         run: |
           echo "CCACHE_BASEDIR=$PWD" >> $GITHUB_ENV


### PR DESCRIPTION
We must not pick up a cache generated by the non-Glucose job, which has the same prefix. Doing so would result in a cache that mixes different configurations, and ccache may end up pruning the wrong ones.

While at it, also insert hyphens to make cache entry names easier to read.

Performance note: in https://github.com/diffblue/cbmc/pull/7428, check-macos-12-cmake-clang just spent 28 minutes building with 0 cache hits, despite 1115 entries in the cache. Other jobs completed the build stage within seconds. I have manually removed the possibly offending caches from https://github.com/diffblue/cbmc/actions/caches, but we may need to do another cleanup once this PR is merged.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
