### PR TITLE
Shadow memory interface and integration hooks [blocks 7535]

### DIFF
--- a/src/goto-checker/multi_path_symex_only_checker.cpp
+++ b/src/goto-checker/multi_path_symex_only_checker.cpp
@@ -79,8 +79,8 @@ void multi_path_symex_only_checkert::generate_equation()
 
   const auto symex_start = std::chrono::steady_clock::now();
 
-  symex_symbol_table =
-    symex.symex_from_entry_point_of(goto_symext::get_goto_function(goto_model));
+  symex_symbol_table = symex.symex_from_entry_point_of(
+    goto_symext::get_goto_function(goto_model), fields);
 
   const auto symex_stop = std::chrono::steady_clock::now();
   std::chrono::duration<double> symex_runtime =

--- a/src/goto-checker/multi_path_symex_only_checker.cpp
+++ b/src/goto-checker/multi_path_symex_only_checker.cpp
@@ -13,6 +13,7 @@ Author: Daniel Kroening, Peter Schrammel
 
 #include <util/ui_message.h>
 
+#include <goto-symex/shadow_memory.h>
 #include <goto-symex/show_program.h>
 #include <goto-symex/show_vcc.h>
 
@@ -72,6 +73,10 @@ operator()(propertiest &properties)
 
 void multi_path_symex_only_checkert::generate_equation()
 {
+  // Gather fields for shadow memory instrumentation
+  const auto fields =
+    shadow_memoryt::gather_field_declarations(goto_model, ui_message_handler);
+
   const auto symex_start = std::chrono::steady_clock::now();
 
   symex_symbol_table =

--- a/src/goto-checker/single_path_symex_only_checker.cpp
+++ b/src/goto-checker/single_path_symex_only_checker.cpp
@@ -79,7 +79,7 @@ void single_path_symex_only_checkert::initialize_worklist()
     shadow_memoryt::gather_field_declarations(goto_model, ui_message_handler);
 
   symex.initialize_path_storage_from_entry_point_of(
-    goto_symext::get_goto_function(goto_model), symex_symbol_table);
+    goto_symext::get_goto_function(goto_model), symex_symbol_table, fields);
 }
 
 bool single_path_symex_only_checkert::has_finished_exploration(

--- a/src/goto-checker/single_path_symex_only_checker.cpp
+++ b/src/goto-checker/single_path_symex_only_checker.cpp
@@ -14,6 +14,7 @@ Author: Daniel Kroening, Peter Schrammel
 #include <util/ui_message.h>
 
 #include <goto-symex/path_storage.h>
+#include <goto-symex/shadow_memory.h>
 #include <goto-symex/show_program.h>
 #include <goto-symex/show_vcc.h>
 
@@ -72,6 +73,10 @@ void single_path_symex_only_checkert::initialize_worklist()
     guard_manager,
     unwindset);
   setup_symex(symex);
+
+  // Gather fields for shadow memory instrumentation
+  const auto fields =
+    shadow_memoryt::gather_field_declarations(goto_model, ui_message_handler);
 
   symex.initialize_path_storage_from_entry_point_of(
     goto_symext::get_goto_function(goto_model), symex_symbol_table);

--- a/src/goto-symex/Makefile
+++ b/src/goto-symex/Makefile
@@ -14,6 +14,7 @@ SRC = auto_objects.cpp \
       postcondition.cpp \
       precondition.cpp \
       renaming_level.cpp \
+      shadow_memory.cpp \
       show_program.cpp \
       show_vcc.cpp \
       slice.cpp \

--- a/src/goto-symex/goto_symex.cpp
+++ b/src/goto-symex/goto_symex.cpp
@@ -104,7 +104,7 @@ void goto_symext::symex_assign(
       assignment_type = symex_targett::assignment_typet::HIDDEN;
 
     symex_assignt symex_assign{
-      state, assignment_type, ns, symex_config, target};
+      shadow_memory, state, assignment_type, ns, symex_config, target};
 
     // Try to constant propagate potential side effects of the assignment, when
     // simplification is turned on and there is one thread only. Constant
@@ -118,8 +118,9 @@ void goto_symext::symex_assign(
     }
 
     exprt::operandst lhs_if_then_else_conditions;
-    symex_assign.assign_rec(
-      lhs, expr_skeletont{}, rhs, lhs_if_then_else_conditions);
+    symex_assignt{
+      shadow_memory, state, assignment_type, ns, symex_config, target}
+      .assign_rec(lhs, expr_skeletont{}, rhs, lhs_if_then_else_conditions);
   }
 }
 

--- a/src/goto-symex/goto_symex.h
+++ b/src/goto-symex/goto_symex.h
@@ -465,6 +465,16 @@ protected:
     statet &state,
     const goto_programt::instructiont &instruction);
 
+  /// Preserves locality of parameters of a given function by applying L1
+  /// renaming to them.
+  /// \param function_identifier The parameter identifier
+  /// \param state The current state
+  /// \param goto_function The goto function
+  virtual void locality(
+    const irep_idt &function_identifier,
+    goto_symext::statet &state,
+    const goto_functionst::goto_functiont &goto_function);
+
   /// Symbolically execute a END_FUNCTION instruction.
   /// \param state: Symbolic execution state for current instruction
   virtual void symex_end_of_function(statet &);

--- a/src/goto-symex/goto_symex.h
+++ b/src/goto-symex/goto_symex.h
@@ -22,6 +22,7 @@ class address_of_exprt;
 class function_application_exprt;
 class goto_symex_statet;
 class path_storaget;
+class shadow_memory_field_definitionst;
 class side_effect_exprt;
 class symex_assignt;
 class typet;
@@ -98,16 +99,24 @@ public:
   /// having the state around afterwards.
   /// \param get_goto_function: The delegate to retrieve function bodies (see
   ///   \ref get_goto_functiont)
+  /// \param fields The shadow memory field declarations
   /// \return A symbol table holding the symbols added during symbolic
   ///   execution.
   NODISCARD
-  virtual symbol_tablet
-  symex_from_entry_point_of(const get_goto_functiont &get_goto_function);
+  virtual symbol_tablet symex_from_entry_point_of(
+    const get_goto_functiont &get_goto_function,
+    const shadow_memory_field_definitionst &fields);
 
   /// Puts the initial state of the entry point function into the path storage
+  /// \param get_goto_function: The delegate to retrieve function bodies (see
+  ///   \ref get_goto_functiont)
+  /// \param new_symbol_table: A symbol table to store the symbols added during
+  /// symbolic execution
+  /// \param fields The shadow memory field declarations
   virtual void initialize_path_storage_from_entry_point_of(
     const get_goto_functiont &get_goto_function,
-    symbol_table_baset &new_symbol_table);
+    symbol_table_baset &new_symbol_table,
+    const shadow_memory_field_definitionst &fields);
 
   /// Performs symbolic execution using a state and equation that have
   /// already been used to symbolically execute part of the program. The state

--- a/src/goto-symex/goto_symex.h
+++ b/src/goto-symex/goto_symex.h
@@ -15,6 +15,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/message.h>
 
 #include "complexity_limiter.h"
+#include "shadow_memory.h"
 #include "symex_config.h"
 #include "symex_target_equation.h"
 
@@ -66,7 +67,16 @@ public:
       path_segment_vccs(0),
       _total_vccs(std::numeric_limits<unsigned>::max()),
       _remaining_vccs(std::numeric_limits<unsigned>::max()),
-      complexity_module(mh, options)
+      complexity_module(mh, options),
+      shadow_memory(
+        std::bind(
+          &goto_symext::symex_assign,
+          this,
+          std::placeholders::_1,
+          std::placeholders::_2,
+          std::placeholders::_3),
+        ns,
+        mh)
   {
   }
 
@@ -823,6 +833,9 @@ protected:
   ///@}
 
   complexity_limitert complexity_module;
+
+  /// Shadow memory instrumentation API
+  shadow_memoryt shadow_memory;
 
 public:
   unsigned get_total_vccs() const

--- a/src/goto-symex/goto_symex_state.h
+++ b/src/goto-symex/goto_symex_state.h
@@ -24,6 +24,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "field_sensitivity.h"
 #include "goto_state.h"
 #include "renaming_level.h"
+#include "shadow_memory_state.h"
 
 #include <functional>
 #include <memory>
@@ -120,6 +121,8 @@ public:
     bool allow_pointer_unsoundness = false);
 
   field_sensitivityt field_sensitivity;
+
+  shadow_memory_statet shadow_memory;
 
 protected:
   template <levelt>

--- a/src/goto-symex/shadow_memory.cpp
+++ b/src/goto-symex/shadow_memory.cpp
@@ -1,0 +1,111 @@
+/*******************************************************************\
+
+Module: Symex Shadow Memory Instrumentation
+
+Author: Peter Schrammel
+
+\*******************************************************************/
+
+/// \file
+/// Symex Shadow Memory Instrumentation
+
+#include "shadow_memory.h"
+
+#include <util/fresh_symbol.h>
+
+#include <langapi/language_util.h>
+
+#include "goto_symex_state.h"
+
+void shadow_memoryt::initialize_shadow_memory(
+  goto_symex_statet &state,
+  const exprt &expr,
+  const shadow_memory_field_definitionst::field_definitiont &fields)
+{
+  // To be implemented
+}
+
+symbol_exprt shadow_memoryt::add_field(
+  goto_symex_statet &state,
+  const exprt &expr,
+  const irep_idt &field_name,
+  const typet &field_type)
+{
+  // To be completed
+
+  const auto &function_symbol = ns.lookup(state.source.function_id);
+
+  symbolt &new_symbol = get_fresh_aux_symbol(
+    field_type,
+    id2string(state.source.function_id),
+    SHADOW_MEMORY_PREFIX + from_expr(expr) + "__" + id2string(field_name),
+    state.source.pc->source_location(),
+    function_symbol.mode,
+    state.symbol_table);
+
+  // Call some function on ns to silence the compiler in the meanwhile.
+  ns.get_symbol_table();
+
+  return new_symbol.symbol_expr();
+}
+
+void shadow_memoryt::symex_set_field(
+  goto_symex_statet &state,
+  const exprt::operandst &arguments)
+{
+  // To be implemented
+}
+
+void shadow_memoryt::symex_get_field(
+  goto_symex_statet &state,
+  const exprt &lhs,
+  const exprt::operandst &arguments)
+{
+  // To be implemented
+}
+
+void shadow_memoryt::symex_field_static_init(
+  goto_symex_statet &state,
+  const ssa_exprt &lhs)
+{
+  // To be implemented
+}
+
+void shadow_memoryt::symex_field_static_init_string_constant(
+  goto_symex_statet &state,
+  const ssa_exprt &expr,
+  const exprt &rhs)
+{
+  // To be implemented
+}
+
+void shadow_memoryt::symex_field_local_init(
+  goto_symex_statet &state,
+  const ssa_exprt &expr)
+{
+  // To be implemented
+}
+
+void shadow_memoryt::symex_field_dynamic_init(
+  goto_symex_statet &state,
+  const exprt &expr,
+  const side_effect_exprt &code)
+{
+  // To be implemented
+}
+
+shadow_memory_field_definitionst shadow_memoryt::gather_field_declarations(
+  abstract_goto_modelt &goto_model,
+  message_handlert &message_handler)
+{
+  // To be implemented
+
+  return shadow_memory_field_definitionst();
+}
+
+void shadow_memoryt::convert_field_declaration(
+  const code_function_callt &code_function_call,
+  shadow_memory_field_definitionst::field_definitiont &fields)
+{
+  // To be implemented
+}

--- a/src/goto-symex/shadow_memory.h
+++ b/src/goto-symex/shadow_memory.h
@@ -1,0 +1,136 @@
+/*******************************************************************\
+
+Module: Symex Shadow Memory Instrumentation
+
+Author: Peter Schrammel
+
+\*******************************************************************/
+
+/// \file
+/// Symex Shadow Memory Instrumentation
+
+#ifndef CPROVER_GOTO_SYMEX_SHADOW_MEMORY_H
+#define CPROVER_GOTO_SYMEX_SHADOW_MEMORY_H
+
+#include <util/expr.h>
+#include <util/message.h>
+#include <util/std_expr.h>
+
+#include "shadow_memory_field_definitions.h"
+
+#define SHADOW_MEMORY_PREFIX "SM__"
+#define SHADOW_MEMORY_FIELD_DECL "field_decl"
+#define SHADOW_MEMORY_GLOBAL_SCOPE "_global"
+#define SHADOW_MEMORY_LOCAL_SCOPE "_local"
+#define SHADOW_MEMORY_GET_FIELD "get_field"
+#define SHADOW_MEMORY_SET_FIELD "set_field"
+
+class code_function_callt;
+class abstract_goto_modelt;
+class goto_symex_statet;
+class side_effect_exprt;
+class ssa_exprt;
+
+/// \brief The shadow memory instrumentation performed during symbolic execution
+class shadow_memoryt
+{
+public:
+  shadow_memoryt(
+    const std::function<void(goto_symex_statet &, const exprt &, const exprt &)>
+      symex_assign,
+    const namespacet &ns,
+    message_handlert &message_handler)
+    : symex_assign(symex_assign), ns(ns), log(message_handler)
+  {
+  }
+
+  /// Gathers the available shadow memory field definitions
+  /// (__CPROVER_field_decl calls) from the goto model.
+  /// \param goto_model The goto model
+  /// \param message_handler For logging
+  /// \return The field definitions
+  static shadow_memory_field_definitionst gather_field_declarations(
+    abstract_goto_modelt &goto_model,
+    message_handlert &message_handler);
+
+  /// Initialize global-scope shadow memory for global/static variables.
+  /// \param state The symex state
+  /// \param lhs The LHS expression of the initializer assignment
+  void symex_field_static_init(goto_symex_statet &state, const ssa_exprt &lhs);
+
+  /// Initialize global-scope shadow memory for string constants.
+  /// \param state The symex state
+  /// \param expr The defined symbol expression
+  /// \param rhs The RHS expression of the initializer assignment
+  void symex_field_static_init_string_constant(
+    goto_symex_statet &state,
+    const ssa_exprt &expr,
+    const exprt &rhs);
+
+  /// Initialize local-scope shadow memory for local variables and parameters.
+  /// \param state The symex state
+  /// \param expr The declared symbol expression
+  void symex_field_local_init(goto_symex_statet &state, const ssa_exprt &expr);
+
+  /// Initialize global-scope shadow memory for dynamically allocated memory.
+  /// \param state The symex state
+  /// \param expr The dynamic object symbol expression
+  /// \param code The allocation side effect code
+  void symex_field_dynamic_init(
+    goto_symex_statet &state,
+    const exprt &expr,
+    const side_effect_exprt &code);
+
+  /// Symbolically executes a __CPROVER_get_field call
+  /// \param state The symex state
+  /// \param lhs The LHS of the call
+  /// \param arguments The call arguments
+  void symex_get_field(
+    goto_symex_statet &state,
+    const exprt &lhs,
+    const exprt::operandst &arguments);
+
+  /// Symbolically executes a __CPROVER_set_field call
+  /// \param state The symex state
+  /// \param arguments The call arguments
+  void
+  symex_set_field(goto_symex_statet &state, const exprt::operandst &arguments);
+
+private:
+  /// Converts a field declaration
+  /// \param code_function_call The __CPROVER_field_decl_* call
+  /// \param fields The field declaration to be extended
+  void convert_field_declaration(
+    const code_function_callt &code_function_call,
+    shadow_memory_field_definitionst::field_definitiont &fields);
+
+  /// Allocates and initializes a shadow memory field for the given original
+  /// memory.
+  /// \param state The symex state
+  /// \param expr The expression for which shadow memory should be allocated
+  /// \param fields The field definition to be used
+  void initialize_shadow_memory(
+    goto_symex_statet &state,
+    const exprt &expr,
+    const shadow_memory_field_definitionst::field_definitiont &fields);
+
+  /// Registers a shadow memory field for the given original memory
+  /// \param state The symex state
+  /// \param expr The expression for which shadow memory should be allocated
+  /// \param field_name The field name
+  /// \param field_type The field type
+  /// \return The resulting shadow memory symbol expression
+  symbol_exprt add_field(
+    goto_symex_statet &state,
+    const exprt &expr,
+    const irep_idt &field_name,
+    const typet &field_type);
+
+private:
+  const std::function<void(goto_symex_statet &, const exprt &, const exprt)>
+    symex_assign;
+  const namespacet &ns;
+  messaget log;
+};
+
+#endif // CPROVER_GOTO_SYMEX_SHADOW_MEMORY_H

--- a/src/goto-symex/shadow_memory_field_definitions.h
+++ b/src/goto-symex/shadow_memory_field_definitions.h
@@ -1,0 +1,33 @@
+/*******************************************************************\
+
+Module: Symex Shadow Memory Instrumentation
+
+Author: Peter Schrammel
+
+\*******************************************************************/
+
+/// \file
+/// Symex Shadow Memory Field Definitions
+
+#ifndef CPROVER_GOTO_SYMEX_SHADOW_MEMORY_FIELD_DEFINITIONS_H
+#define CPROVER_GOTO_SYMEX_SHADOW_MEMORY_FIELD_DEFINITIONS_H
+
+#include <util/expr.h>
+
+#include <map>
+
+/// \brief The shadow memory field definitions
+class shadow_memory_field_definitionst
+{
+public:
+  /// A field definition mapping a field name to its initial value
+  using field_definitiont = std::map<irep_idt, exprt>;
+
+  /// Field definitions for global-scope fields
+  field_definitiont global_fields;
+
+  /// Field definitions for local-scope fields
+  field_definitiont local_fields;
+};
+
+#endif // CPROVER_GOTO_SYMEX_SHADOW_MEMORY_FIELD_DEFINITIONS_H

--- a/src/goto-symex/shadow_memory_state.h
+++ b/src/goto-symex/shadow_memory_state.h
@@ -1,0 +1,41 @@
+/*******************************************************************\
+
+Module: Symex Shadow Memory Instrumentation
+
+Author: Peter Schrammel
+
+\*******************************************************************/
+
+/// \file
+/// Symex Shadow Memory Instrumentation State
+
+#ifndef CPROVER_GOTO_SYMEX_SHADOW_MEMORY_STATE_H
+#define CPROVER_GOTO_SYMEX_SHADOW_MEMORY_STATE_H
+
+#include <util/std_expr.h>
+
+#include "shadow_memory_field_definitions.h"
+
+#include <map>
+
+class address_of_exprt;
+
+/// \brief The state maintained by the shadow memory instrumentation
+/// during symbolic execution.
+class shadow_memory_statet
+{
+public:
+  /// The available shadow memory field definitions
+  shadow_memory_field_definitionst fields;
+
+  struct shadowed_addresst
+  {
+    exprt address;
+    symbol_exprt shadow;
+  };
+
+  // addresses must remain in sequence
+  std::map<irep_idt, std::vector<shadowed_addresst>> address_fields;
+};
+
+#endif // CPROVER_GOTO_SYMEX_SHADOW_MEMORY_STATE_H

--- a/src/goto-symex/symex_assign.cpp
+++ b/src/goto-symex/symex_assign.cpp
@@ -11,12 +11,12 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "symex_assign.h"
 
-#include "expr_skeleton.h"
-#include "goto_symex_state.h"
 #include <util/byte_operators.h>
 #include <util/expr_util.h>
 #include <util/range.h>
 
+#include "expr_skeleton.h"
+#include "goto_symex_state.h"
 #include "symex_config.h"
 
 // We can either use with_exprt or update_exprt when building expressions that

--- a/src/goto-symex/symex_assign.cpp
+++ b/src/goto-symex/symex_assign.cpp
@@ -13,6 +13,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <util/byte_operators.h>
 #include <util/expr_util.h>
+#include <util/pointer_expr.h>
 #include <util/range.h>
 
 #include "expr_skeleton.h"
@@ -33,6 +34,27 @@ constexpr bool use_update()
 #endif
 }
 
+/// Determine whether the RHS expression is a string constant initialization
+/// \param rhs The RHS expression
+/// \return True if the expression points to the first character of a string
+///    constant
+static bool is_string_constant_initialization(const exprt &rhs)
+{
+  if(const auto &address_of = expr_try_dynamic_cast<address_of_exprt>(rhs))
+  {
+    if(
+      const auto &index =
+        expr_try_dynamic_cast<index_exprt>(address_of->object()))
+    {
+      if(index->array().id() == ID_string_constant && index->index().is_zero())
+      {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
 void symex_assignt::assign_rec(
   const exprt &lhs,
   const expr_skeletont &full_lhs,
@@ -42,6 +64,21 @@ void symex_assignt::assign_rec(
   if(is_ssa_expr(lhs))
   {
     assign_symbol(to_ssa_expr(lhs), full_lhs, rhs, guard);
+
+    // Allocate shadow memory
+    if(shadow_memory.has_value())
+    {
+      bool is_string_constant_init = is_string_constant_initialization(rhs);
+      if(is_string_constant_init)
+      {
+        shadow_memory->symex_field_static_init_string_constant(
+          state, to_ssa_expr(lhs), rhs);
+      }
+      else
+      {
+        shadow_memory->symex_field_static_init(state, to_ssa_expr(lhs));
+      }
+    }
   }
   else if(lhs.id() == ID_index)
     assign_array<use_update()>(to_index_expr(lhs), full_lhs, rhs, guard);

--- a/src/goto-symex/symex_assign.h
+++ b/src/goto-symex/symex_assign.h
@@ -12,8 +12,10 @@ Author: Romain Brenguier, romain.brenguier@diffblue.com
 #ifndef CPROVER_GOTO_SYMEX_SYMEX_ASSIGN_H
 #define CPROVER_GOTO_SYMEX_SYMEX_ASSIGN_H
 
-#include "symex_target.h"
 #include <util/expr.h>
+
+#include "shadow_memory.h"
+#include "symex_target.h"
 
 class byte_extract_exprt;
 class expr_skeletont;
@@ -26,12 +28,14 @@ class symex_assignt
 {
 public:
   symex_assignt(
+    optionalt<shadow_memoryt> shadow_memory,
     goto_symex_statet &state,
     symex_targett::assignment_typet assignment_type,
     const namespacet &ns,
     const symex_configt &symex_config,
     symex_targett &target)
-    : state(state),
+    : shadow_memory(shadow_memory),
+      state(state),
       assignment_type(assignment_type),
       ns(ns),
       symex_config(symex_config),
@@ -56,6 +60,7 @@ public:
     exprt::operandst &guard);
 
 private:
+  optionalt<shadow_memoryt> shadow_memory;
   goto_symex_statet &state;
   symex_targett::assignment_typet assignment_type;
   const namespacet &ns;

--- a/src/goto-symex/symex_builtin_functions.cpp
+++ b/src/goto-symex/symex_builtin_functions.cpp
@@ -201,6 +201,8 @@ void goto_symext::symex_allocate(
     rhs=address_of_exprt(
       value_symbol.symbol_expr(), pointer_type(value_symbol.type));
   }
+  shadow_memory.symex_field_dynamic_init(
+    state, value_symbol.symbol_expr(), code);
 
   symex_assign(state, lhs, typecast_exprt::conditional_cast(rhs, lhs.type()));
 }

--- a/src/goto-symex/symex_clean_expr.cpp
+++ b/src/goto-symex/symex_clean_expr.cpp
@@ -184,7 +184,12 @@ void goto_symext::lift_let(statet &state, const let_exprt &let_expr)
 
   exprt::operandst value_assignment_guard;
   symex_assignt{
-    state, symex_targett::assignment_typet::HIDDEN, ns, symex_config, target}
+    shadow_memory,
+    state,
+    symex_targett::assignment_typet::HIDDEN,
+    ns,
+    symex_config,
+    target}
     .assign_symbol(
       to_ssa_expr(state.rename<L1>(let_expr.symbol(), ns).get()),
       expr_skeletont{},

--- a/src/goto-symex/symex_decl.cpp
+++ b/src/goto-symex/symex_decl.cpp
@@ -58,4 +58,6 @@ void goto_symext::symex_decl(statet &state, const symbol_exprt &expr)
       ssa,
       state.atomic_section_id,
       state.source);
+
+  shadow_memory.symex_field_local_init(state, ssa);
 }

--- a/src/goto-symex/symex_dereference.cpp
+++ b/src/goto-symex/symex_dereference.cpp
@@ -230,7 +230,12 @@ goto_symext::cache_dereference(exprt &dereference_result, statet &state)
   lift_lets(state, cache_value);
 
   auto assign = symex_assignt{
-    state, symex_targett::assignment_typet::STATE, ns, symex_config, target};
+    shadow_memory,
+    state,
+    symex_targett::assignment_typet::STATE,
+    ns,
+    symex_config,
+    target};
 
   auto cache_symbol_expr = cache_symbol.symbol_expr();
   assign.assign_symbol(

--- a/src/goto-symex/symex_function_call.cpp
+++ b/src/goto-symex/symex_function_call.cpp
@@ -207,8 +207,24 @@ void goto_symext::symex_function_call_symbol(
 
   target.location(state.guard.as_expr(), state.source);
 
-  symex_function_call_post_clean(
-    get_goto_function, state, cleaned_lhs, function, cleaned_arguments);
+  PRECONDITION(function.id() == ID_symbol);
+  const irep_idt &identifier = to_symbol_expr(function).get_identifier();
+
+  if(identifier == CPROVER_PREFIX SHADOW_MEMORY_GET_FIELD)
+  {
+    shadow_memory.symex_get_field(state, cleaned_lhs, cleaned_arguments);
+    symex_transition(state);
+  }
+  else if(identifier == CPROVER_PREFIX SHADOW_MEMORY_SET_FIELD)
+  {
+    shadow_memory.symex_set_field(state, cleaned_arguments);
+    symex_transition(state);
+  }
+  else
+  {
+    symex_function_call_post_clean(
+      get_goto_function, state, cleaned_lhs, function, cleaned_arguments);
+  }
 }
 
 void goto_symext::symex_function_call_post_clean(

--- a/src/goto-symex/symex_function_call.cpp
+++ b/src/goto-symex/symex_function_call.cpp
@@ -130,7 +130,8 @@ void goto_symext::parameter_assignments(
       rhs = clean_expr(std::move(rhs), state, false);
 
       exprt::operandst lhs_conditions;
-      symex_assignt{state, assignment_type, ns, symex_config, target}
+      symex_assignt{
+        shadow_memory, state, assignment_type, ns, symex_config, target}
         .assign_rec(lhs, expr_skeletont{}, rhs, lhs_conditions);
     }
 

--- a/src/goto-symex/symex_function_call.cpp
+++ b/src/goto-symex/symex_function_call.cpp
@@ -24,13 +24,6 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "path_storage.h"
 #include "symex_assign.h"
 
-static void locality(
-  const irep_idt &function_identifier,
-  goto_symext::statet &state,
-  path_storaget &path_storage,
-  const goto_functionst::goto_functiont &goto_function,
-  const namespacet &ns);
-
 bool goto_symext::get_unwind_recursion(const irep_idt &, unsigned, unsigned)
 {
   return false;
@@ -328,7 +321,7 @@ void goto_symext::symex_function_call_post_clean(
   }
 
   // preserve locality of local variables
-  locality(identifier, state, path_storage, goto_function, ns);
+  locality(identifier, state, goto_function);
 
   // assign actuals to formal parameters
   parameter_assignments(identifier, goto_function, state, cleaned_arguments);
@@ -457,14 +450,10 @@ void goto_symext::symex_end_of_function(statet &state)
   }
 }
 
-/// Preserves locality of parameters of a given function by applying L1
-/// renaming to them.
-static void locality(
+void goto_symext::locality(
   const irep_idt &function_identifier,
   goto_symext::statet &state,
-  path_storaget &path_storage,
-  const goto_functionst::goto_functiont &goto_function,
-  const namespacet &ns)
+  const goto_functionst::goto_functiont &goto_function)
 {
   unsigned &frame_nr=
     state.threads[state.source.thread_nr].function_frame[function_identifier];
@@ -472,11 +461,15 @@ static void locality(
 
   for(const auto &param : goto_function.parameter_identifiers)
   {
-    (void)state.add_object(
+    const ssa_exprt &renamed_param = state.add_object(
       ns.lookup(param).symbol_expr(),
-      [&path_storage, &frame_nr](const irep_idt &l0_name) {
+      [this, &frame_nr](const irep_idt &l0_name) {
         return path_storage.get_unique_l1_index(l0_name, frame_nr);
       },
       ns);
+
+    // Allocate shadow memory for parameters.
+    // They are like local variables.
+    shadow_memory.symex_field_local_init(state, renamed_param);
   }
 }

--- a/src/goto-symex/symex_main.cpp
+++ b/src/goto-symex/symex_main.cpp
@@ -465,18 +465,24 @@ std::unique_ptr<goto_symext::statet> goto_symext::initialize_entry_point_state(
 }
 
 symbol_tablet goto_symext::symex_from_entry_point_of(
-  const get_goto_functiont &get_goto_function)
+  const get_goto_functiont &get_goto_function,
+  const shadow_memory_field_definitionst &fields)
 {
   auto state = initialize_entry_point_state(get_goto_function);
+  // Initialize declared shadow memory fields
+  state->shadow_memory.fields = fields;
 
   return symex_with_state(*state, get_goto_function);
 }
 
 void goto_symext::initialize_path_storage_from_entry_point_of(
   const get_goto_functiont &get_goto_function,
-  symbol_table_baset &new_symbol_table)
+  symbol_table_baset &new_symbol_table,
+  const shadow_memory_field_definitionst &fields)
 {
   auto state = initialize_entry_point_state(get_goto_function);
+  // Initialize declared shadow memory fields
+  state->shadow_memory.fields = fields;
 
   path_storaget::patht entry_point_start(target, *state);
   entry_point_start.state.saved_target = state->source.pc;

--- a/src/goto-symex/symex_start_thread.cpp
+++ b/src/goto-symex/symex_start_thread.cpp
@@ -94,7 +94,12 @@ void goto_symext::symex_start_thread(statet &state)
     exprt::operandst lhs_conditions;
     state.record_events.push(false);
     symex_assignt{
-      state, symex_targett::assignment_typet::HIDDEN, ns, symex_config, target}
+      shadow_memory,
+      state,
+      symex_targett::assignment_typet::HIDDEN,
+      ns,
+      symex_config,
+      target}
       .assign_symbol(lhs_l1, expr_skeletont{}, rhs, lhs_conditions);
     const exprt l2_lhs = state.rename(lhs_l1, ns).get();
     state.record_events.pop();
@@ -140,7 +145,12 @@ void goto_symext::symex_start_thread(statet &state)
 
     exprt::operandst lhs_conditions;
     symex_assignt{
-      state, symex_targett::assignment_typet::HIDDEN, ns, symex_config, target}
+      shadow_memory,
+      state,
+      symex_targett::assignment_typet::HIDDEN,
+      ns,
+      symex_config,
+      target}
       .assign_symbol(lhs, expr_skeletont{}, rhs, lhs_conditions);
   }
 }

--- a/unit/goto-symex/symex_assign.cpp
+++ b/unit/goto-symex/symex_assign.cpp
@@ -82,11 +82,13 @@ SCENARIO(
     WHEN("Symbol `foo` is assigned constant integer `475`")
     {
       const exprt rhs1 = from_integer(475, int_type);
-      symex_assignt{state,
-                    symex_targett::assignment_typet::STATE,
-                    ns,
-                    symex_config,
-                    target_equation}
+      symex_assignt{
+        {},
+        state,
+        symex_targett::assignment_typet::STATE,
+        ns,
+        symex_config,
+        target_equation}
         .assign_symbol(ssa_foo, expr_skeletont{}, rhs1, guard);
       THEN("An equation is added to the target")
       {
@@ -136,11 +138,13 @@ SCENARIO(
     {
       const exprt rhs1 = from_integer(5721, int_type);
       symex_target_equationt target_equation{null_message_handler};
-      symex_assignt symex_assign{state,
-                                 symex_targett::assignment_typet::STATE,
-                                 ns,
-                                 symex_config,
-                                 target_equation};
+      symex_assignt symex_assign{
+        {},
+        state,
+        symex_targett::assignment_typet::STATE,
+        ns,
+        symex_config,
+        target_equation};
       symex_assign.assign_symbol(ssa_foo, expr_skeletont{}, rhs1, guard);
       THEN("An equation with an empty guard is added to the target")
       {
@@ -217,11 +221,13 @@ SCENARIO(
 
     WHEN("Symbol `struct1` is assigned `struct1 with [field1 <- 234]`")
     {
-      symex_assignt{state,
-                    symex_targett::assignment_typet::STATE,
-                    ns,
-                    symex_config,
-                    target_equation}
+      symex_assignt{
+        {},
+        state,
+        symex_targett::assignment_typet::STATE,
+        ns,
+        symex_config,
+        target_equation}
         .assign_symbol(struct1_ssa, skeleton, rhs, guard);
       THEN("Two equations are added to the target")
       {

--- a/unit/path_strategies.cpp
+++ b/unit/path_strategies.cpp
@@ -426,7 +426,9 @@ void _check_with_strategy(
     setup_symex(symex, ns, options, ui_message_handler);
 
     symex.initialize_path_storage_from_entry_point_of(
-      goto_symext::get_goto_function(goto_model), symex_symbol_table);
+      goto_symext::get_goto_function(goto_model),
+      symex_symbol_table,
+      shadow_memory_field_definitionst{});
   }
 
   std::size_t expected_results_cnt = 0;


### PR DESCRIPTION
This adds the shadow memory integration interface and integrates it into goto-symex.
The implementation is left empty and will be filled in incrementally in follow-up PRs.

No functional change to CBMC at this point.

- [X] Each commit message has a non-empty body, explaining why the change was made.
- [X] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [n/a] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [n/a] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [n/a] My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- [n/a] White-space or formatting changes outside the feature-related changed lines are in commits of their own.
