### PR TITLE
Make is_osx_mach_header declaration and definition consistent

### DIFF
--- a/src/goto-programs/osx_fat_reader.cpp
+++ b/src/goto-programs/osx_fat_reader.cpp
@@ -85,7 +85,8 @@ osx_fat_readert::osx_fat_readert(
   if(!in)
     throw system_exceptiont("failed to read OSX fat header");
 
-  if(!is_osx_fat_header(reinterpret_cast<char *>(&(fh.magic))))
+  static_assert(sizeof(fh) >= 8, "fat_header is at least 8 bytes");
+  if(!is_osx_fat_header(reinterpret_cast<char *>(&fh)))
     throw deserialization_exceptiont("OSX fat header malformed");
 
   static_assert(

--- a/src/goto-programs/osx_fat_reader.h
+++ b/src/goto-programs/osx_fat_reader.h
@@ -74,6 +74,6 @@ private:
   void process_sections_64(uint32_t nsects, bool need_swap);
 };
 
-bool is_osx_mach_object(char hdr[8]);
+bool is_osx_mach_object(char hdr[4]);
 
 #endif // CPROVER_GOTO_PROGRAMS_OSX_FAT_READER_H


### PR DESCRIPTION
clang 15 reported the type inconsistency.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
