### PR TITLE
Remove unused function_depth variable

### DIFF
--- a/src/goto-programs/goto_trace.cpp
+++ b/src/goto-programs/goto_trace.cpp
@@ -397,15 +397,8 @@ void show_compact_goto_trace(
   const goto_tracet &goto_trace,
   const trace_optionst &options)
 {
-  std::size_t function_depth = 0;
-
   for(const auto &step : goto_trace.steps)
   {
-    if(step.is_function_call())
-      function_depth++;
-    else if(step.is_function_return())
-      function_depth--;
-
     // hide the hidden ones
     if(step.hidden)
       continue;


### PR DESCRIPTION
Compact goto traces never print depth information (unlike full trace output): `function_depth` was initialised and being written to, but never read. This was always the case (the code was added in b62ffe9fa28), it's not a matter of printing having been removed.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
