### PR TITLE
Update link to reference generated website

### DIFF
--- a/doc/architectural/central-data-structures.md
+++ b/doc/architectural/central-data-structures.md
@@ -110,8 +110,7 @@ in the symbol-table for their definitions.
 A  goto program  is a sequence of GOTO instructions (`goto_instructiont`). For
 details of the `goto_programt` class itself see the documentation in
 [`goto_program.h`](../../src/goto-programs/goto_program.h). For further details
-of the life cycle of goto programs see
-[`src/goto-programs/README.md`](https://github.com/diffblue/cbmc/blob/develop/src/goto-programs/README.md).
+of the life cycle of goto programs see \ref goto-programs "goto programs"
 
 An instruction (`goto_instructiont`) is a triple (an element with three subcomponents),
 describing a GOTO level instruction with the following 3 component subtypes,

--- a/doc/doxygen-root/doxygen-markdown/markdown.sh
+++ b/doc/doxygen-root/doxygen-markdown/markdown.sh
@@ -46,7 +46,7 @@ for file in $FILES; do
     # lines is unescaped using sed in order to fix doxygen tags, which are
     # broken by pandoc.
     pandoc --read=gfm --write=gfm --wrap=none --filter=mermaid-filter $tmp |
-        $BINDIR/pandoc-codeblock-repair.sh | sed 's/^\\\\/\\/' > $file
+        $BINDIR/pandoc-codeblock-repair.sh | sed 's/\\\\ref\s/\\ref /;s/^\\\\/\\/' > $file
 done
 
 cprovers=$(find . -name cprover-manual)


### PR DESCRIPTION
This PR updates the link from `doc/architectural/central-data-structures.md` to `src/goto-programs/README.md` so that it links to the generated website, rather than the markdown file on github. This is a follow-up from https://github.com/diffblue/cbmc/pull/7470

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
