### PR TITLE
[DRAFT] Update linker to enable cross-language C/Rust linking

### DIFF
--- a/regression/linking-goto-binaries/kani_linking/c_side.c
+++ b/regression/linking-goto-binaries/kani_linking/c_side.c
@@ -11,3 +11,15 @@ uint32_t* returns_ptr(uint32_t a, uint32_t b) {
     if (p) *p = a + b;
     return p;
 }
+
+// Use a mix of types, and has padding
+struct MultiFieldStruct {
+    uint8_t c;
+    uint32_t d;
+    int64_t i;
+};
+
+struct MultiFieldStruct generates_mixed_field_struct(uint8_t c, uint32_t d, int64_t i) {
+    struct MultiFieldStruct s = {c, d, i};
+    return s;
+}

--- a/regression/linking-goto-binaries/kani_linking/c_side.c
+++ b/regression/linking-goto-binaries/kani_linking/c_side.c
@@ -1,0 +1,6 @@
+#include <stdint.h>
+#include <assert.h>
+
+void foo(uint32_t a, uint32_t b) {
+    assert(a > b);
+}

--- a/regression/linking-goto-binaries/kani_linking/c_side.c
+++ b/regression/linking-goto-binaries/kani_linking/c_side.c
@@ -1,6 +1,13 @@
 #include <stdint.h>
 #include <assert.h>
+#include <stdlib.h>
 
 void foo(uint32_t a, uint32_t b) {
     assert(a > b);
+}
+
+uint32_t* returns_ptr(uint32_t a, uint32_t b) {
+    uint32_t* p = malloc(sizeof(p));
+    if (p) *p = a + b;
+    return p;
 }

--- a/regression/linking-goto-binaries/kani_linking/rust_side.c
+++ b/regression/linking-goto-binaries/kani_linking/rust_side.c
@@ -42,9 +42,45 @@ void test_ptr() {
     struct OptionU32PtrWithPhantomDataFirst p = returns_ptr(a,b);
     assert(*p.ptr == a+b); // Should pass
     assert(*p.ptr == a); // Should fail
-
 }
 
+struct MultiFieldStruct {
+    uint8_t c;
+    uint32_t d;
+    int64_t i;
+};
+
+// Use a mix of types, and has padding
+struct MultiFieldStructA {
+    uint8_t c;
+    struct Unit u;
+    uint32_t d;
+    int64_t i;
+};
+
+// Change to make it not compatable
+struct MultiFieldStructB {
+    uint8_t c;
+    struct Unit u;
+    float d;
+    int64_t i;
+    char x;
+};
+
+struct MultiFieldStructB generates_mixed_field_struct(uint8_t c, uint32_t d, int64_t i);
+
+void test_mixed_field_struct() {
+    uint8_t c;
+    uint32_t d;
+    int64_t i;
+    struct MultiFieldStructB result =  generates_mixed_field_struct(c,d,i);
+    assert(c == result.c);
+    assert(d == result.d);
+    assert(i == result.i);
+}
+
+
+
 void main() {
-    test_ptr();
+    test_mixed_field_struct();
 }

--- a/regression/linking-goto-binaries/kani_linking/rust_side.c
+++ b/regression/linking-goto-binaries/kani_linking/rust_side.c
@@ -21,12 +21,28 @@ struct OptionU32PtrWithPhantomDataFirst {
 struct Unit foo(uint32_t a, uint32_t b);
 struct Unit bar(struct OptionU32Ptr p);
 
+struct OptionU32PtrWithPhantomDataFirst returns_ptr(uint32_t a, uint32_t b);
 
 
-
-int main() {
+void test_foo() {
     uint32_t a;
     uint32_t b;
     __CPROVER_assume(a > b);
     struct Unit tmp = foo(a,b);
+}
+
+void test_ptr() {
+    uint32_t a;
+    uint32_t b;
+    // No overflow
+    __CPROVER_assume(a < 1000);
+    __CPROVER_assume(b < 1000);
+    struct OptionU32PtrWithPhantomDataFirst p = returns_ptr(a,b);
+    assert(*p.ptr == a+b);
+    assert(*p.ptr == a);
+
+}
+
+void main() {
+    test_ptr();
 }

--- a/regression/linking-goto-binaries/kani_linking/rust_side.c
+++ b/regression/linking-goto-binaries/kani_linking/rust_side.c
@@ -1,5 +1,7 @@
 
 #include <stdint.h>
+#include <assert.h>
+#include <stdlib.h>
 
 struct Unit {};
 struct PhantomData {};
@@ -38,8 +40,8 @@ void test_ptr() {
     __CPROVER_assume(a < 1000);
     __CPROVER_assume(b < 1000);
     struct OptionU32PtrWithPhantomDataFirst p = returns_ptr(a,b);
-    assert(*p.ptr == a+b);
-    assert(*p.ptr == a);
+    assert(*p.ptr == a+b); // Should pass
+    assert(*p.ptr == a); // Should fail
 
 }
 

--- a/regression/linking-goto-binaries/kani_linking/rust_side.c
+++ b/regression/linking-goto-binaries/kani_linking/rust_side.c
@@ -1,0 +1,32 @@
+
+#include <stdint.h>
+
+struct Unit {};
+struct PhantomData {};
+struct OptionU32Ptr {
+    uint32_t* ptr;
+};
+
+struct OptionU32PtrWithPhantomData {
+    uint32_t* ptr;
+    struct PhantomData pd;
+};
+
+
+struct OptionU32PtrWithPhantomDataFirst {
+    struct PhantomData pd;
+    uint32_t* ptr;
+};
+
+struct Unit foo(uint32_t a, uint32_t b);
+struct Unit bar(struct OptionU32Ptr p);
+
+
+
+
+int main() {
+    uint32_t a;
+    uint32_t b;
+    __CPROVER_assume(a > b);
+    struct Unit tmp = foo(a,b);
+}

--- a/regression/linking-goto-binaries/kani_linking/rust_side_fail.c
+++ b/regression/linking-goto-binaries/kani_linking/rust_side_fail.c
@@ -1,0 +1,32 @@
+
+#include <stdint.h>
+
+struct Unit {};
+struct PhantomData {};
+struct OptionU32Ptr {
+    uint32_t* ptr;
+};
+
+struct OptionU32PtrWithPhantomData {
+    uint32_t* ptr;
+    struct PhantomData pd;
+};
+
+
+struct OptionU32PtrWithPhantomDataFirst {
+    struct PhantomData pd;
+    uint32_t* ptr;
+};
+
+struct OptionU32Ptr foo(uint32_t a, uint32_t b);
+struct Unit bar(struct OptionU32Ptr p);
+
+
+
+
+int main() {
+    uint32_t a;
+    uint32_t b;
+    __CPROVER_assume(a > b);
+    struct OptionU32Ptr tmp = foo(a,b);
+}

--- a/regression/linking-goto-binaries/kani_linking/rust_side_struct.c
+++ b/regression/linking-goto-binaries/kani_linking/rust_side_struct.c
@@ -6,20 +6,20 @@ struct Unit {};
 struct PhantomData {};
 
 // Change to make it not compatable
-struct MultiFieldStructB {
+struct ABCDE {
     uint8_t c;
     struct Unit u;
     float d;
     int64_t i;
 };
 
-struct MultiFieldStructB generates_mixed_field_struct(uint8_t c, uint32_t d, int64_t i);
+struct ABCDE generates_mixed_field_struct(uint8_t c, uint32_t d, int64_t i);
 
 void test_mixed_field_struct() {
     uint8_t c;
     uint32_t d;
     int64_t i;
-    struct MultiFieldStructB result =  generates_mixed_field_struct(c,d,i);
+    struct ABCDE result =  generates_mixed_field_struct(c,d,i);
     assert(c == result.c);
     assert(d == result.d);
     assert(i == result.i);

--- a/regression/linking-goto-binaries/kani_linking/rust_side_struct.c
+++ b/regression/linking-goto-binaries/kani_linking/rust_side_struct.c
@@ -1,0 +1,30 @@
+#include <stdint.h>
+#include <assert.h>
+#include <stdlib.h>
+
+struct Unit {};
+struct PhantomData {};
+
+// Change to make it not compatable
+struct MultiFieldStructB {
+    uint8_t c;
+    struct Unit u;
+    float d;
+    int64_t i;
+};
+
+struct MultiFieldStructB generates_mixed_field_struct(uint8_t c, uint32_t d, int64_t i);
+
+void test_mixed_field_struct() {
+    uint8_t c;
+    uint32_t d;
+    int64_t i;
+    struct MultiFieldStructB result =  generates_mixed_field_struct(c,d,i);
+    assert(c == result.c);
+    assert(d == result.d);
+    assert(i == result.i);
+}
+
+void main() {
+    test_mixed_field_struct();
+}

--- a/src/goto-programs/link_goto_model.cpp
+++ b/src/goto-programs/link_goto_model.cpp
@@ -207,6 +207,7 @@ void finalize_linking(
               instruction.call_lhs().type() !=
               to_code_type(instruction.call_function().type()).return_type())
             {
+              assert(0);
               instruction.call_lhs() = typecast_exprt{
                 instruction.call_lhs(),
                 to_code_type(instruction.call_function().type()).return_type()};

--- a/src/linking/linking.cpp
+++ b/src/linking/linking.cpp
@@ -77,6 +77,7 @@ bool types_are_structurally_similar_rec(const typet &type1, const typet &type2, 
   if (type1.id()==ID_pointer && type2.id()==ID_pointer)
     return true;
 
+  //if type1.id()==ID_struct_tag
   // If we just have a transparent struct (i.e. one with a single non-zero sized field).
   // treat it as the wrapped type, and recurse.
   auto unwrapped1 = unwrap_transparent_type(type1, ns);


### PR DESCRIPTION
Currently, the CBMC linker takes a fairly strict interpreation of compabibility between compilation units.  Rust has a more relaxed view when doing FFI linking: two types are identical if they have the same bitpattern, even if they appear different at the surface level.

For example, the Rust linker would consider the following types equivalent:
```
// empty struct
struct Unit {};

//These are both considered equivilent to uint32_t*
struct OptionRef { uint32_t* p;};
struct OptionRefWithEmptyFields { struct Unit u; uint32_t* p;};
```

Update the linker to make this work


- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
