### PR TITLE
Add a structured verification results class in the C++ API

### DIFF
--- a/src/libcprover-cpp/api.cpp
+++ b/src/libcprover-cpp/api.cpp
@@ -176,6 +176,60 @@ void api_sessiont::verify_model() const
   verifier.report();
 }
 
+// TODO: This is a temporary function - it's basically `verify_model`, tweaked
+// to return the results in a structured format. It's temporary in the sense
+// that this will get folded into the `verify_model` function, but I want to do
+// this slightly later because modifying the interface of `verify_model` from
+// the C++ end breaks the Rust API for now, and I want to take steps one at
+// a time.
+verification_resultt api_sessiont::produce_results()
+{
+  PRECONDITION(implementation->model);
+
+  // Remove inline assembler; this needs to happen before adding the library.
+  remove_asm(*implementation->model);
+
+  // add the library
+  messaget log{*implementation->message_handler};
+  log.status() << "Adding CPROVER library (" << config.ansi_c.arch << ")"
+               << messaget::eom;
+  link_to_library(
+    *implementation->model,
+    *implementation->message_handler,
+    cprover_c_library_factory);
+
+  // Common removal of types and complex constructs
+  if(::process_goto_program(
+       *implementation->model, *implementation->options, log))
+  {
+    return {};
+  }
+
+  // add failed symbols
+  // needs to be done before pointer analysis
+  add_failed_symbols(implementation->model->symbol_table);
+
+  // label the assertions
+  // This must be done after adding assertions and
+  // before using the argument of the "property" option.
+  // Do not re-label after using the property slicer because
+  // this would cause the property identifiers to change.
+  label_properties(*implementation->model);
+
+  remove_skip(*implementation->model);
+
+  ui_message_handlert ui_message_handler(*implementation->message_handler);
+  all_properties_verifier_with_trace_storaget<multi_path_symex_checkert>
+    verifier(
+      *implementation->options, ui_message_handler, *implementation->model);
+  verification_resultt result;
+  auto results = verifier();
+  result.set_result(results);
+  auto properties = verifier.get_properties();
+  result.set_properties(properties);
+  return result;
+}
+
 void api_sessiont::drop_unused_functions() const
 {
   INVARIANT(

--- a/src/libcprover-cpp/api.h
+++ b/src/libcprover-cpp/api.h
@@ -18,6 +18,7 @@ struct api_session_implementationt;
 // as the design principle is to be followed.)
 
 #include "api_options.h" // IWYU pragma: keep
+#include "verification_result.h" // IWYU pragma: keep
 
 /// Opaque message type. Properties of messages to be fetched through further
 /// api calls.
@@ -79,6 +80,9 @@ struct api_sessiont
 
   // A simple API version information function.
   std::unique_ptr<std::string> get_api_version() const;
+
+  /// Run the verification engine and return results.
+  verification_resultt produce_results();
 
 private:
   std::unique_ptr<api_session_implementationt> implementation;

--- a/src/libcprover-cpp/verification_result.cpp
+++ b/src/libcprover-cpp/verification_result.cpp
@@ -1,0 +1,151 @@
+// Copyright (c) 2023 Fotis Koutoulakis for Diffblue Ltd.
+
+/// \file
+/// Interface for the various verification engines providing results
+//  in a structured form.
+
+#include "verification_result.h"
+
+#include <util/invariant.h>
+#include <util/make_unique.h>
+
+#include <goto-checker/properties.h>
+
+#include <algorithm>
+#include <string>
+#include <vector>
+
+class verification_resultt::verification_result_implt
+{
+  propertiest _properties;
+  resultt _verifier_result;
+
+public:
+  verification_result_implt() = default;
+  verification_result_implt(const verification_result_implt &other) = default;
+  ~verification_result_implt() = default;
+
+  void set_properties(propertiest &properties);
+  void set_result(resultt &verification_result);
+
+  resultt get_result();
+  const propertiest &get_properties();
+};
+
+// Impl
+
+void verification_resultt::verification_result_implt::set_properties(
+  propertiest &properties)
+{
+  _properties = properties;
+}
+
+void verification_resultt::verification_result_implt::set_result(
+  resultt &result)
+{
+  _verifier_result = result;
+}
+
+resultt verification_resultt::verification_result_implt::get_result()
+{
+  return _verifier_result;
+}
+
+const propertiest &
+verification_resultt::verification_result_implt::get_properties()
+{
+  return _properties;
+}
+
+// Verification_result
+
+verification_resultt::verification_resultt()
+  : _impl(util_make_unique<verification_resultt::verification_result_implt>())
+{
+}
+
+verification_resultt::~verification_resultt()
+{
+}
+
+verification_resultt::verification_resultt(const verification_resultt &other)
+  : _impl(util_make_unique<verification_result_implt>(*other._impl))
+{
+}
+
+verification_resultt &
+verification_resultt::operator=(verification_resultt &&) = default;
+verification_resultt &
+verification_resultt::operator=(const verification_resultt &other)
+{
+  *_impl = *other._impl;
+  return *this;
+}
+
+void verification_resultt::set_properties(propertiest &properties)
+{
+  _impl->set_properties(properties);
+}
+
+void verification_resultt::set_result(resultt &result)
+{
+  _impl->set_result(result);
+}
+
+verifier_resultt verification_resultt::final_result() const
+{
+  switch(_impl->get_result())
+  {
+  case resultt::ERROR:
+    return verifier_resultt::ERROR;
+  case resultt::FAIL:
+    return verifier_resultt::FAIL;
+  case resultt::PASS:
+    return verifier_resultt::PASS;
+  case resultt::UNKNOWN:
+    return verifier_resultt::UNKNOWN;
+  }
+  // Required to silence compiler warnings that are promoted as errors!
+  UNREACHABLE;
+}
+
+std::vector<std::string> verification_resultt::get_property_ids() const
+{
+  std::vector<std::string> result;
+  for(const auto &props : _impl->get_properties())
+  {
+    result.push_back(as_string(props.first));
+  }
+  return result;
+}
+
+std::string verification_resultt::get_property_description(
+  const std::string &property_id) const
+{
+  auto irepidt_property = irep_idt(property_id);
+  const auto description =
+    _impl->get_properties().at(irepidt_property).description;
+  return description;
+}
+
+prop_statust
+verification_resultt::get_property_status(const std::string &property_id) const
+{
+  auto irepidt_property = irep_idt(property_id);
+  switch(_impl->get_properties().at(irepidt_property).status)
+  {
+  case property_statust::ERROR:
+    return prop_statust::ERROR;
+  case property_statust::FAIL:
+    return prop_statust::FAIL;
+  case property_statust::NOT_CHECKED:
+    return prop_statust::NOT_CHECKED;
+  case property_statust::NOT_REACHABLE:
+    return prop_statust::NOT_REACHABLE;
+  case property_statust::PASS:
+    return prop_statust::PASS;
+  case property_statust::UNKNOWN:
+    return prop_statust::UNKNOWN;
+  }
+  UNREACHABLE;
+}

--- a/src/libcprover-cpp/verification_result.h
+++ b/src/libcprover-cpp/verification_result.h
@@ -1,0 +1,83 @@
+// Copyright (c) 2023 Fotis Koutoulakis for Diffblue Ltd.
+
+/// \file
+/// Interface for the various verification engines providing results
+//  in a structured form.
+
+#ifndef CPROVER_LIBCPROVER_CPP_VERIFICATION_RESULT_H
+#define CPROVER_LIBCPROVER_CPP_VERIFICATION_RESULT_H
+
+#include <map>
+#include <memory>
+#include <string>
+#include <vector>
+
+#ifndef USE_STD_STRING
+#  define USE_DSTRING
+#endif
+
+#ifdef USE_DSTRING
+class dstringt;
+typedef dstringt irep_idt;
+#else
+typedef std::string irep_idt;
+#endif
+
+struct property_infot;
+using propertiest = std::map<irep_idt, property_infot>;
+enum class resultt;
+
+// The enumerations here mirror the ones in properties.h.
+// The reason we do so is that we want to expose the same information
+// to users of the API, without including (and therefore, exposing)
+// CBMC internal headers.
+
+enum class prop_statust
+{
+  /// The property was not checked (also used for initialization)
+  NOT_CHECKED,
+  /// The checker was unable to determine the status of the property
+  UNKNOWN,
+  /// The property was proven to be unreachable
+  NOT_REACHABLE,
+  /// The property was not violated
+  PASS,
+  /// The property was violated
+  FAIL,
+  /// An error occurred during goto checking
+  ERROR
+};
+
+enum class verifier_resultt
+{
+  UNKNOWN,
+  /// No properties were violated
+  PASS,
+  /// Some properties were violated
+  FAIL,
+  /// An error occurred during goto checking
+  ERROR
+};
+
+struct verification_resultt
+{
+  verification_resultt();
+  verification_resultt(const verification_resultt &other);
+  ~verification_resultt();
+  verification_resultt &operator=(verification_resultt &&);
+  verification_resultt &operator=(const verification_resultt &other);
+
+  void set_result(resultt &result);
+  void set_properties(propertiest &properties);
+
+  verifier_resultt final_result() const;
+  std::vector<std::string> get_property_ids() const;
+  std::string get_property_description(const std::string &property_id) const;
+  prop_statust get_property_status(const std::string &property_id) const;
+
+private:
+  class verification_result_implt;
+  std::unique_ptr<verification_result_implt> _impl;
+};
+
+#endif // CPROVER_GOTO_CHECKER_VERIFICATION_RESULT_H

--- a/unit/libcprover-cpp/test2.c
+++ b/unit/libcprover-cpp/test2.c
@@ -1,0 +1,8 @@
+// Input file to test reading through API, not for compiling!
+// Compared to test.c, this is supposed to have a passing assertion.
+
+int main(int argc, char *argv[])
+{
+  int arr[] = {0, 1, 2, 3, 4};
+  __CPROVER_assert(arr[3] == 3, "expected success: arr[3] to be 3");
+}

--- a/unit/libcprover-cpp/verification_resultt.cpp
+++ b/unit/libcprover-cpp/verification_resultt.cpp
@@ -1,0 +1,79 @@
+// Copyright (c) 2023 Fotis Koutoulakis for Diffblue Ltd.
+
+/// \file Integration tests for the the interface of the class for verification
+///       results produced by various verification engines (classes downstream
+///       of goto_verifiert).
+
+#include <libcprover-cpp/api.h>
+#include <libcprover-cpp/verification_result.h>
+
+#include <iostream>
+#include <sstream>
+#include <string>
+
+#include "../catch/catch.hpp"
+
+SCENARIO(
+  "When we analyse a model produced from some C code we get back verification "
+  "results in a structured format",
+  "[goto-checker][verification-result]")
+{
+  GIVEN("A model with a passing property from C source code")
+  {
+    api_sessiont api(api_optionst::create());
+    api.load_model_from_files({"test2.c"});
+
+    WHEN("We run that model past the verification engine")
+    {
+      const verification_resultt &results = api.produce_results();
+
+      THEN("The verification result should be success")
+      {
+        REQUIRE(results.final_result() == verifier_resultt::PASS);
+      }
+
+      THEN(
+        "We should have access to the property and the property status should "
+        "be PASS")
+      {
+        auto properties = results.get_property_ids();
+        REQUIRE(properties.size() == 1);
+        REQUIRE(properties.at(0) == "main.assertion.1");
+
+        THEN(
+          "The property description should be the same as the assertion "
+          "description in the model")
+        {
+          const std::string assertion_description{
+            "expected success: arr[3] to be 3"};
+          const std::string results_description =
+            results.get_property_description(properties.at(0));
+          REQUIRE(assertion_description == results_description);
+        }
+
+        THEN("The property status should be PASS")
+        {
+          const auto property_status =
+            results.get_property_status(properties.at(0));
+          REQUIRE(property_status == prop_statust::PASS);
+        }
+      }
+    }
+  }
+
+  GIVEN("A model with a failing property from C source code")
+  {
+    api_sessiont api(api_optionst::create());
+    api.load_model_from_files({"test.c"});
+
+    WHEN("We run that model past the verification engine")
+    {
+      const auto &results = api.produce_results();
+
+      THEN("The verification result should be failure")
+      {
+        REQUIRE(results.final_result() == verifier_resultt::FAIL);
+      }
+    }
+  }
+}


### PR DESCRIPTION
## One-sentence Description

This PR is adding the capacity to the C++ API to provide the end-results of a verification engine run to a client in a structured format.

## Review Guidance

* The gist of this change is the addition of the `libcprover-cpp/verification_result.h` file, along with the associated infrastructure in `all_properties_verifier_with_trace_storaget` class (moving the traces from the verifier at the end of the verification engine run).
* This was initially added in `src/goto-checker/`, but offline discussion with @peterschrammel identified that as a potentially disruptive change. It was then decided to move this closer to more experimental code in the C++ api, rather than keep it close to the solvers.
* To support testing of this new capacity, a new helper function has been added in `testing-utils/run_verification_engine.h` - it clones the functionality of the C++ API `verify_model()` function with the aim to quickly do a verification engine run in a convenient package and produce back the verification results that we expect from the engine.

## Checklist
<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
