### PR TITLE
unwindset parsing: Work around spurious GCC 12 warning

### DIFF
--- a/src/goto-instrument/unwindset.cpp
+++ b/src/goto-instrument/unwindset.cpp
@@ -36,7 +36,9 @@ void unwindsett::parse_unwindset_one_loop(
   if(val.empty())
     return;
 
-  optionalt<unsigned> thread_nr;
+  // we should use optionalt<unsigned> here, but then GCC 12 wrongly complains that we may be using an uninitialized variable
+  unsigned thread_nr = 0;
+  bool thread_nr_is_set = false;
   if(isdigit(val[0]))
   {
     auto c_pos = val.find(':');
@@ -44,6 +46,7 @@ void unwindsett::parse_unwindset_one_loop(
     {
       std::string nr = val.substr(0, c_pos);
       thread_nr = unsafe_string2unsigned(nr);
+      thread_nr_is_set = true;
       val.erase(0, nr.size() + 1);
     }
   }
@@ -171,8 +174,10 @@ void unwindsett::parse_unwindset_one_loop(
     else
       uw = unsafe_string2unsigned(uw_string);
 
-    if(thread_nr.has_value())
-      thread_loop_map[std::pair<irep_idt, unsigned>(id, *thread_nr)] = uw;
+    if(thread_nr_is_set)
+    {
+      thread_loop_map[std::make_pair(id, thread_nr)] = uw;
+    }
     else
       loop_map[id] = uw;
   }


### PR DESCRIPTION
GCC 12 wrongly complains about the use of an uninitialized variable. Work around by doing a poor man's version of a variable with an accompanying Boolean.

The build failure was:
```
In file included from /usr/include/c++/12/bits/stl_algobase.h:64,
                 from /usr/include/c++/12/bits/stl_tree.h:63,
                 from /usr/include/c++/12/map:60,
                 from ../util/symbol_table_base.h:9,
                 from ../util/symbol_table.h:9,
                 from ../goto-programs/goto_model.h:15,
                 from unwindset.h:15,
                 from unwindset.cpp:9:
In constructor ‘constexpr std::pair<_T1, _T2>::pair(_U1&&, _U2&&) [with _U1 = std::__cxx11::basic_string<char>&; _U2 = unsigned int&; typename std::enable_if<(std::_PCC<true, _T1, _T2>::_MoveConstructiblePair<_U1, _U2>() && std::_PCC<true, _T1, _T2>::_ImplicitlyMoveConvertiblePair<_U1, _U2>()), bool>::type <anonymous> = true; _T1 = dstringt; _T2 = unsigned int]’,
    inlined from ‘void unwindsett::parse_unwindset_one_loop(std::string, message_handlert&)’ at unwindset.cpp:174:28:
/usr/include/c++/12/bits/stl_pair.h:535:42: error: ‘*(unsigned int*)((char*)&thread_nr + offsetof(nonstd::optional_lite::optionalt<unsigned int>,nonstd::optional_lite::optional<unsigned int>::contained))’ may be used uninitialized [-Werror=maybe-uninitialized]
  535 |         : first(std::forward<_U1>(__x)), second(std::forward<_U2>(__y)) { }
      |                                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
unwindset.cpp: In member function ‘void unwindsett::parse_unwindset_one_loop(std::string, message_handlert&)’:
unwindset.cpp:39:23: note: ‘*(unsigned int*)((char*)&thread_nr + offsetof(nonstd::optional_lite::optionalt<unsigned int>,nonstd::optional_lite::optional<unsigned int>::contained))’ was declared here
   35 |   optionalt<unsigned> thread_nr;
      |                       ^~~~~~~~~
```
when using GCC 12: g++ (GCC) 12.2.1 20221121 (Red Hat 12.2.1-4)

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
