### PR TITLE
CONTRACTS: refactor DFCC code for loop contracts

### DIFF
--- a/src/goto-instrument/Makefile
+++ b/src/goto-instrument/Makefile
@@ -26,6 +26,7 @@ SRC = accelerate/accelerate.cpp \
       contracts/dynamic-frames/dfcc_lift_memory_predicates.cpp \
       contracts/dynamic-frames/dfcc_instrument.cpp \
       contracts/dynamic-frames/dfcc_spec_functions.cpp \
+      contracts/dynamic-frames/dfcc_contract_clauses_codegen.cpp \
       contracts/dynamic-frames/dfcc_contract_functions.cpp \
       contracts/dynamic-frames/dfcc_wrapper_program.cpp \
       contracts/dynamic-frames/dfcc_contract_handler.cpp \

--- a/src/goto-instrument/contracts/dynamic-frames/dfcc.cpp
+++ b/src/goto-instrument/contracts/dynamic-frames/dfcc.cpp
@@ -92,14 +92,14 @@ parse_function_contract_pair(const irep_idt &cli_flag)
   else if(split.size() == 2)
   {
     auto function_name = split[0];
-    if(function_name.size() == 0)
+    if(function_name.empty())
     {
       throw invalid_function_contract_pair_exceptiont{
         "couldn't find function name before '/' in '" + cli_flag_str + "'",
         correct_format_message};
     }
     auto contract_name = split[1];
-    if(contract_name.size() == 0)
+    if(contract_name.empty())
     {
       throw invalid_function_contract_pair_exceptiont{
         "couldn't find contract name after '/' in '" + cli_flag_str + "'",

--- a/src/goto-instrument/contracts/dynamic-frames/dfcc.cpp
+++ b/src/goto-instrument/contracts/dynamic-frames/dfcc.cpp
@@ -191,6 +191,12 @@ dfcct::dfcct(
     instrument(goto_model, message_handler, utils, library),
     memory_predicates(goto_model, utils, library, instrument, message_handler),
     spec_functions(goto_model, message_handler, utils, library, instrument),
+    contract_clauses_codegen(
+      goto_model,
+      message_handler,
+      utils,
+      library,
+      spec_functions),
     contract_handler(
       goto_model,
       message_handler,
@@ -198,7 +204,8 @@ dfcct::dfcct(
       library,
       instrument,
       memory_predicates,
-      spec_functions),
+      spec_functions,
+      contract_clauses_codegen),
     swap_and_wrap(
       goto_model,
       message_handler,
@@ -483,6 +490,8 @@ void dfcct::instrument_other_functions()
 
   goto_model.goto_functions.update();
 
+  // TODO specialise the library functions for the max size of
+  // loop and function contracts
   if(to_check.has_value())
   {
     log.status() << "Specializing cprover_contracts functions for assigns "

--- a/src/goto-instrument/contracts/dynamic-frames/dfcc.h
+++ b/src/goto-instrument/contracts/dynamic-frames/dfcc.h
@@ -33,6 +33,7 @@ Author: Remi Delmas, delmasrd@amazon.com
 #include <util/irep.h>
 #include <util/message.h>
 
+#include "dfcc_contract_clauses_codegen.h"
 #include "dfcc_contract_handler.h"
 #include "dfcc_instrument.h"
 #include "dfcc_library.h"
@@ -208,13 +209,15 @@ protected:
   message_handlert &message_handler;
   messaget log;
 
-  // hold the global state of the transformation (caches etc.)
+  // Singletons that hold the global state of the program transformation
+  // (caches etc.)
   dfcc_utilst utils;
   dfcc_libraryt library;
   namespacet ns;
   dfcc_instrumentt instrument;
   dfcc_lift_memory_predicatest memory_predicates;
   dfcc_spec_functionst spec_functions;
+  dfcc_contract_clauses_codegent contract_clauses_codegen;
   dfcc_contract_handlert contract_handler;
   dfcc_swap_and_wrapt swap_and_wrap;
 

--- a/src/goto-instrument/contracts/dynamic-frames/dfcc_contract_clauses_codegen.cpp
+++ b/src/goto-instrument/contracts/dynamic-frames/dfcc_contract_clauses_codegen.cpp
@@ -49,10 +49,11 @@ void dfcc_contract_clauses_codegent::gen_spec_assigns_instructions(
 {
   for(const auto &expr : assigns_clause)
   {
-    if(can_cast_expr<conditional_target_group_exprt>(expr))
+    if(
+      auto target_group =
+        expr_try_dynamic_cast<conditional_target_group_exprt>(expr))
     {
-      encode_assignable_target_group(
-        language_mode, to_conditional_target_group_expr(expr), dest);
+      encode_assignable_target_group(language_mode, *target_group, dest);
     }
     else
     {
@@ -75,10 +76,11 @@ void dfcc_contract_clauses_codegent::gen_spec_frees_instructions(
 {
   for(const auto &expr : frees_clause)
   {
-    if(can_cast_expr<conditional_target_group_exprt>(expr))
+    if(
+      auto target_group =
+        expr_try_dynamic_cast<conditional_target_group_exprt>(expr))
     {
-      encode_freeable_target_group(
-        language_mode, to_conditional_target_group_expr(expr), dest);
+      encode_freeable_target_group(language_mode, *target_group, dest);
     }
     else
     {
@@ -279,10 +281,9 @@ void dfcc_contract_clauses_codegent::inline_and_check_warnings(
   }
 
   INVARIANT(
-    recursive_call.size() == 0,
-    "recursive calls found when inlining goto program");
+    recursive_call.empty(), "recursive calls found when inlining goto program");
 
   INVARIANT(
-    not_enough_arguments.size() == 0,
+    not_enough_arguments.empty(),
     "not enough arguments when inlining goto program");
 }

--- a/src/goto-instrument/contracts/dynamic-frames/dfcc_contract_clauses_codegen.cpp
+++ b/src/goto-instrument/contracts/dynamic-frames/dfcc_contract_clauses_codegen.cpp
@@ -1,0 +1,288 @@
+/*******************************************************************\
+
+Module: Dynamic frame condition checking for function contracts
+
+Author: Remi Delmas, delmasrd@amazon.com
+Date: February 2023
+
+\*******************************************************************/
+#include "dfcc_contract_clauses_codegen.h"
+
+#include <util/expr_util.h>
+#include <util/fresh_symbol.h>
+#include <util/invariant.h>
+#include <util/mathematical_expr.h>
+#include <util/namespace.h>
+#include <util/pointer_offset_size.h>
+#include <util/std_expr.h>
+
+#include <goto-programs/goto_model.h>
+
+#include <ansi-c/c_expr.h>
+#include <goto-instrument/contracts/utils.h>
+#include <langapi/language_util.h>
+
+#include "dfcc_library.h"
+#include "dfcc_spec_functions.h"
+#include "dfcc_utils.h"
+
+dfcc_contract_clauses_codegent::dfcc_contract_clauses_codegent(
+  goto_modelt &goto_model,
+  message_handlert &message_handler,
+  dfcc_utilst &utils,
+  dfcc_libraryt &library,
+  dfcc_spec_functionst &spec_functions)
+  : goto_model(goto_model),
+    message_handler(message_handler),
+    log(message_handler),
+    utils(utils),
+    library(library),
+    spec_functions(spec_functions),
+    ns(goto_model.symbol_table)
+{
+}
+
+void dfcc_contract_clauses_codegent::gen_spec_assigns_instructions(
+  const irep_idt &language_mode,
+  const exprt::operandst &assigns_clause,
+  goto_programt &dest)
+{
+  for(const auto &expr : assigns_clause)
+  {
+    if(can_cast_expr<conditional_target_group_exprt>(expr))
+    {
+      encode_assignable_target_group(
+        language_mode, to_conditional_target_group_expr(expr), dest);
+    }
+    else
+    {
+      encode_assignable_target(language_mode, expr, dest);
+    }
+  }
+
+  // inline resulting program and check for loops
+  inline_and_check_warnings(dest);
+  PRECONDITION_WITH_DIAGNOSTICS(
+    utils.has_no_loops(dest),
+    "loops in assigns clause specification functions must be unwound before "
+    "contracts instrumentation");
+}
+
+void dfcc_contract_clauses_codegent::gen_spec_frees_instructions(
+  const irep_idt &language_mode,
+  const exprt::operandst &frees_clause,
+  goto_programt &dest)
+{
+  for(const auto &expr : frees_clause)
+  {
+    if(can_cast_expr<conditional_target_group_exprt>(expr))
+    {
+      encode_freeable_target_group(
+        language_mode, to_conditional_target_group_expr(expr), dest);
+    }
+    else
+    {
+      encode_freeable_target(language_mode, expr, dest);
+    }
+  }
+
+  // inline resulting program and check for loops
+  inline_and_check_warnings(dest);
+  PRECONDITION_WITH_DIAGNOSTICS(
+    utils.has_no_loops(dest),
+    "loops in assigns clause specification functions must be unwound before "
+    "contracts instrumentation");
+}
+
+void dfcc_contract_clauses_codegent::encode_assignable_target_group(
+  const irep_idt &language_mode,
+  const conditional_target_group_exprt &group,
+  goto_programt &dest)
+{
+  const source_locationt &source_location = group.source_location();
+
+  // clean up side effects from the condition expression if needed
+  cleanert cleaner(goto_model.symbol_table, log.get_message_handler());
+  exprt condition(group.condition());
+  if(has_subexpr(condition, ID_side_effect))
+    cleaner.clean(condition, dest, language_mode);
+
+  // Jump target if condition is false
+  auto goto_instruction = dest.add(
+    goto_programt::make_incomplete_goto(not_exprt{condition}, source_location));
+
+  for(const auto &target : group.targets())
+    encode_assignable_target(language_mode, target, dest);
+
+  auto label_instruction = dest.add(goto_programt::make_skip(source_location));
+  goto_instruction->complete_goto(label_instruction);
+}
+
+void dfcc_contract_clauses_codegent::encode_assignable_target(
+  const irep_idt &language_mode,
+  const exprt &target,
+  goto_programt &dest)
+{
+  const source_locationt &source_location = target.source_location();
+
+  if(can_cast_expr<side_effect_expr_function_callt>(target))
+  {
+    // A function call target `foo(params)` becomes `CALL foo(params);`
+    const auto &funcall = to_side_effect_expr_function_call(target);
+    code_function_callt code_function_call(to_symbol_expr(funcall.function()));
+    auto &arguments = code_function_call.arguments();
+    for(auto &arg : funcall.arguments())
+      arguments.emplace_back(arg);
+    dest.add(
+      goto_programt::make_function_call(code_function_call, source_location));
+  }
+  else if(is_assignable(target))
+  {
+    // An lvalue `target` becomes
+    //` CALL __CPROVER_assignable(&target, sizeof(target), is_ptr_to_ptr);`
+    const auto &size =
+      size_of_expr(target.type(), namespacet(goto_model.symbol_table));
+
+    if(!size.has_value())
+    {
+      throw invalid_source_file_exceptiont{
+        "no definite size for lvalue assigns clause target " +
+          from_expr_using_mode(ns, language_mode, target),
+        target.source_location()};
+    }
+    // we have to build the symbol manually because it might not
+    // be present in the symbol table if the user program does not already
+    // use it.
+    code_function_callt code_function_call(
+      symbol_exprt(CPROVER_PREFIX "assignable", empty_typet()));
+    auto &arguments = code_function_call.arguments();
+
+    // ptr
+    arguments.emplace_back(typecast_exprt::conditional_cast(
+      address_of_exprt{target}, pointer_type(empty_typet())));
+
+    // size
+    arguments.emplace_back(size.value());
+
+    // is_ptr_to_ptr
+    arguments.emplace_back(make_boolean_expr(target.type().id() == ID_pointer));
+
+    dest.add(
+      goto_programt::make_function_call(code_function_call, source_location));
+  }
+  else
+  {
+    // any other type of target is unsupported
+    throw invalid_source_file_exceptiont(
+      "unsupported assigns clause target " +
+        from_expr_using_mode(ns, language_mode, target),
+      target.source_location());
+  }
+}
+
+void dfcc_contract_clauses_codegent::encode_freeable_target_group(
+  const irep_idt &language_mode,
+  const conditional_target_group_exprt &group,
+  goto_programt &dest)
+{
+  const source_locationt &source_location = group.source_location();
+
+  // clean up side effects from the condition expression if needed
+  cleanert cleaner(goto_model.symbol_table, log.get_message_handler());
+  exprt condition(group.condition());
+  if(has_subexpr(condition, ID_side_effect))
+    cleaner.clean(condition, dest, language_mode);
+
+  // Jump target if condition is false
+  auto goto_instruction = dest.add(
+    goto_programt::make_incomplete_goto(not_exprt{condition}, source_location));
+
+  for(const auto &target : group.targets())
+    encode_freeable_target(language_mode, target, dest);
+
+  auto label_instruction = dest.add(goto_programt::make_skip(source_location));
+  goto_instruction->complete_goto(label_instruction);
+}
+
+void dfcc_contract_clauses_codegent::encode_freeable_target(
+  const irep_idt &language_mode,
+  const exprt &target,
+  goto_programt &dest)
+{
+  const source_locationt &source_location = target.source_location();
+
+  if(can_cast_expr<side_effect_expr_function_callt>(target))
+  {
+    const auto &funcall = to_side_effect_expr_function_call(target);
+    if(can_cast_expr<symbol_exprt>(funcall.function()))
+    {
+      // for calls to user-defined functions a call expression `foo(params)`
+      // becomes an instruction `CALL foo(params);`
+      code_function_callt code_function_call(
+        to_symbol_expr(funcall.function()));
+      auto &arguments = code_function_call.arguments();
+      for(auto &arg : funcall.arguments())
+        arguments.emplace_back(arg);
+      dest.add(
+        goto_programt::make_function_call(code_function_call, source_location));
+    }
+  }
+  else if(can_cast_type<pointer_typet>(target.type()))
+  {
+    // A plain `target` becomes `CALL __CPROVER_freeable(target);`
+    code_function_callt code_function_call(
+      utils.get_function_symbol(CPROVER_PREFIX "freeable").symbol_expr());
+    auto &arguments = code_function_call.arguments();
+    arguments.emplace_back(target);
+
+    dest.add(
+      goto_programt::make_function_call(code_function_call, source_location));
+  }
+  else
+  {
+    // any other type of target is unsupported
+    throw invalid_source_file_exceptiont(
+      "unsupported frees clause target " +
+        from_expr_using_mode(ns, language_mode, target),
+      target.source_location());
+  }
+}
+
+void dfcc_contract_clauses_codegent::inline_and_check_warnings(
+  goto_programt &goto_program)
+{
+  std::set<irep_idt> no_body;
+  std::set<irep_idt> missing_function;
+  std::set<irep_idt> recursive_call;
+  std::set<irep_idt> not_enough_arguments;
+
+  utils.inline_program(
+    goto_program,
+    no_body,
+    recursive_call,
+    missing_function,
+    not_enough_arguments);
+
+  // check that the only no body / missing functions are the cprover builtins
+  for(const auto &id : no_body)
+  {
+    INVARIANT(
+      library.is_front_end_builtin(id),
+      "no body for '" + id2string(id) + "' when inlining goto program");
+  }
+
+  for(auto it : missing_function)
+  {
+    INVARIANT(
+      library.is_front_end_builtin(it),
+      "missing function '" + id2string(it) + "' when inlining goto program");
+  }
+
+  INVARIANT(
+    recursive_call.size() == 0,
+    "recursive calls found when inlining goto program");
+
+  INVARIANT(
+    not_enough_arguments.size() == 0,
+    "not enough arguments when inlining goto program");
+}

--- a/src/goto-instrument/contracts/dynamic-frames/dfcc_contract_clauses_codegen.h
+++ b/src/goto-instrument/contracts/dynamic-frames/dfcc_contract_clauses_codegen.h
@@ -1,0 +1,125 @@
+/*******************************************************************\
+
+Module: Dynamic frame condition checking for function contracts
+
+Author: Remi Delmas, delmasrd@amazon.com
+Date: February 2023
+
+\*******************************************************************/
+
+/// \file
+/// Translates assigns and frees clauses of a function contract or
+/// loop contract into goto programs that build write sets or havoc write sets.
+
+#ifndef CPROVER_GOTO_INSTRUMENT_CONTRACTS_DYNAMIC_FRAMES_DFCC_CONTRACT_CLAUSES_CODEGEN_H
+#define CPROVER_GOTO_INSTRUMENT_CONTRACTS_DYNAMIC_FRAMES_DFCC_CONTRACT_CLAUSES_CODEGEN_H
+
+#include <goto-programs/goto_convert_class.h>
+
+#include <util/message.h>
+#include <util/namespace.h>
+#include <util/optional.h>
+#include <util/std_expr.h>
+
+#include "dfcc_contract_mode.h"
+
+#include <set>
+
+class goto_modelt;
+class message_handlert;
+class dfcc_libraryt;
+class dfcc_utilst;
+class dfcc_spec_functionst;
+class code_with_contract_typet;
+class conditional_target_group_exprt;
+
+class dfcc_contract_clauses_codegent
+{
+public:
+  /// \param goto_model goto model being transformed
+  /// \param message_handler used debug/warning/error messages
+  /// \param utils utility class for dynamic frames
+  /// \param library the contracts instrumentation library
+  /// \param spec_functions provides translation methods for assignable set
+  /// or freeable set specification functions.
+  dfcc_contract_clauses_codegent(
+    goto_modelt &goto_model,
+    message_handlert &message_handler,
+    dfcc_utilst &utils,
+    dfcc_libraryt &library,
+    dfcc_spec_functionst &spec_functions);
+
+  /// \brief Generates instructions encoding the \p assigns_clause targets and
+  /// adds them to \p dest.
+  ///
+  /// \details Assumes that all targets in the clause are represented as plain
+  /// expressions (i.e. an lambdas expressions introduced for function contract
+  /// targets may are already instanciated).
+  ///
+  /// \param language_mode Mode to use for fresh symbols
+  /// \param assigns_clause Sequence of targets to encode
+  /// \param dest Destination program
+  void gen_spec_assigns_instructions(
+    const irep_idt &language_mode,
+    const exprt::operandst &assigns_clause,
+    goto_programt &dest);
+
+  /// \brief Generates instructions encoding the \p frees_clause targets and
+  /// adds them to \p dest.
+  ///
+  /// \details Assumes that all targets in the clause are represented as plain
+  /// expressions (i.e. an lambdas expressions introduced for function contract
+  /// targets may are already instanciated).
+  ///
+  /// \param language_mode Mode to use for fresh symbols
+  /// \param frees_clause Sequence of targets to encode
+  /// \param dest Destination program
+  void gen_spec_frees_instructions(
+    const irep_idt &language_mode,
+    const exprt::operandst &frees_clause,
+    goto_programt &dest);
+
+protected:
+  goto_modelt &goto_model;
+  message_handlert &message_handler;
+  messaget log;
+  dfcc_utilst &utils;
+  dfcc_libraryt &library;
+  dfcc_spec_functionst &spec_functions;
+  namespacet ns;
+
+  /// Generates GOTO instructions to build the representation of the given
+  /// conditional target group.
+  void encode_assignable_target_group(
+    const irep_idt &language_mode,
+    const conditional_target_group_exprt &group,
+    goto_programt &dest);
+
+  /// Generates GOTO instructions to build the representation of the given
+  /// assignable target.
+  void encode_assignable_target(
+    const irep_idt &language_mode,
+    const exprt &target,
+    goto_programt &dest);
+
+  /// Generates GOTO instructions to build the representation of the given
+  /// conditional target group.
+  void encode_freeable_target_group(
+    const irep_idt &language_mode,
+    const conditional_target_group_exprt &group,
+    goto_programt &dest);
+
+  /// Generates GOTO instructions to build the representation of the given
+  /// freeable target.
+  void encode_freeable_target(
+    const irep_idt &language_mode,
+    const exprt &target,
+    goto_programt &dest);
+
+  /// Inlines all calls in the given program and checks that the only missing
+  /// functions or functions without bodies are built-in functions,
+  /// and that no other warnings happened.
+  void inline_and_check_warnings(goto_programt &goto_program);
+};
+
+#endif

--- a/src/goto-instrument/contracts/dynamic-frames/dfcc_contract_functions.cpp
+++ b/src/goto-instrument/contracts/dynamic-frames/dfcc_contract_functions.cpp
@@ -22,6 +22,7 @@ Date: August 2022
 #include <goto-instrument/contracts/utils.h>
 #include <langapi/language_util.h>
 
+#include "dfcc_contract_clauses_codegen.h"
 #include "dfcc_library.h"
 #include "dfcc_spec_functions.h"
 #include "dfcc_utils.h"
@@ -32,7 +33,8 @@ dfcc_contract_functionst::dfcc_contract_functionst(
   message_handlert &message_handler,
   dfcc_utilst &utils,
   dfcc_libraryt &library,
-  dfcc_spec_functionst &spec_functions)
+  dfcc_spec_functionst &spec_functions,
+  dfcc_contract_clauses_codegent &contract_clauses_codegen)
   : pure_contract_symbol(pure_contract_symbol),
     code_with_contract(to_code_with_contract_type(pure_contract_symbol.type)),
     spec_assigns_function_id(
@@ -47,6 +49,7 @@ dfcc_contract_functionst::dfcc_contract_functionst(
     utils(utils),
     library(library),
     spec_functions(spec_functions),
+    contract_clauses_codegen(contract_clauses_codegen),
     ns(goto_model.symbol_table)
 {
   gen_spec_assigns_function();
@@ -119,120 +122,22 @@ void dfcc_contract_functionst::gen_spec_assigns_function()
   // fetch the goto_function to add instructions to
   goto_functiont &goto_function =
     goto_model.goto_functions.function_map.at(spec_function_id);
-  goto_programt &body = goto_function.body;
 
-  for(const auto &assigns_expr : code_with_contract.assigns())
+  exprt::operandst targets;
+
+  for(const exprt &target : code_with_contract.assigns())
   {
-    auto expr = to_lambda_expr(assigns_expr).application(lambda_parameters);
-    expr.add_source_location() = assigns_expr.source_location();
-    if(can_cast_expr<conditional_target_group_exprt>(expr))
-    {
-      encode_assignable_target_group(
-        to_conditional_target_group_expr(expr), body);
-    }
-    else
-    {
-      encode_assignable_target(expr, body);
-    }
+    auto new_target = to_lambda_expr(target).application(lambda_parameters);
+    new_target.add_source_location() = target.source_location();
+    targets.push_back(new_target);
   }
 
+  goto_programt &body = goto_function.body;
+  contract_clauses_codegen.gen_spec_assigns_instructions(
+    spec_function_symbol.mode, targets, body);
   body.add(goto_programt::make_end_function(spec_function_symbol.location));
 
   goto_model.goto_functions.update();
-
-  inline_and_check_warnings(spec_function_id);
-
-  PRECONDITION_WITH_DIAGNOSTICS(
-    utils.has_no_loops(spec_function_id),
-    "loops in assigns clause specification functions must be unwound before "
-    "model instrumentation");
-
-  goto_model.goto_functions.update();
-}
-
-void dfcc_contract_functionst::encode_assignable_target_group(
-  const conditional_target_group_exprt &group,
-  goto_programt &dest)
-{
-  const source_locationt &source_location = group.source_location();
-
-  // clean up side effects from the condition expression if needed
-  cleanert cleaner(goto_model.symbol_table, log.get_message_handler());
-  exprt condition(group.condition());
-  if(has_subexpr(condition, ID_side_effect))
-    cleaner.clean(condition, dest, language_mode);
-
-  // Jump target if condition is false
-  auto goto_instruction = dest.add(
-    goto_programt::make_incomplete_goto(not_exprt{condition}, source_location));
-
-  for(const auto &target : group.targets())
-    encode_assignable_target(target, dest);
-
-  auto label_instruction = dest.add(goto_programt::make_skip(source_location));
-  goto_instruction->complete_goto(label_instruction);
-}
-
-void dfcc_contract_functionst::encode_assignable_target(
-  const exprt &target,
-  goto_programt &dest)
-{
-  const source_locationt &source_location = target.source_location();
-
-  if(can_cast_expr<side_effect_expr_function_callt>(target))
-  {
-    // A function call target `foo(params)` becomes `CALL foo(params);`
-    // ```
-    const auto &funcall = to_side_effect_expr_function_call(target);
-    code_function_callt code_function_call(to_symbol_expr(funcall.function()));
-    auto &arguments = code_function_call.arguments();
-    for(auto &arg : funcall.arguments())
-      arguments.emplace_back(arg);
-    dest.add(
-      goto_programt::make_function_call(code_function_call, source_location));
-  }
-  else if(is_assignable(target))
-  {
-    // An lvalue `target` becomes
-    //` CALL __CPROVER_assignable(&target, sizeof(target), is_ptr_to_ptr);`
-    const auto &size =
-      size_of_expr(target.type(), namespacet(goto_model.symbol_table));
-
-    if(!size.has_value())
-    {
-      throw invalid_source_file_exceptiont{
-        "no definite size for lvalue assigns clause target " +
-          from_expr_using_mode(ns, language_mode, target),
-        target.source_location()};
-    }
-    // we have to build the symbol manually because it might not
-    // be present in the symbol table if the user program does not already
-    // use it.
-    code_function_callt code_function_call(
-      symbol_exprt(CPROVER_PREFIX "assignable", empty_typet()));
-    auto &arguments = code_function_call.arguments();
-
-    // ptr
-    arguments.emplace_back(typecast_exprt::conditional_cast(
-      address_of_exprt{target}, pointer_type(empty_typet())));
-
-    // size
-    arguments.emplace_back(size.value());
-
-    // is_ptr_to_ptr
-    arguments.emplace_back(make_boolean_expr(target.type().id() == ID_pointer));
-
-    dest.add(
-      goto_programt::make_function_call(code_function_call, source_location));
-  }
-  else
-  {
-    // any other type of target is unsupported
-    throw invalid_source_file_exceptiont(
-      "unsupported assigns clause target " +
-        from_expr_using_mode(ns, language_mode, target),
-      target.source_location());
-  }
 }
 
 void dfcc_contract_functionst::gen_spec_frees_function()
@@ -268,144 +173,20 @@ void dfcc_contract_functionst::gen_spec_frees_function()
   // fetch the goto_function to add instructions to
   goto_functiont &goto_function =
     goto_model.goto_functions.function_map.at(spec_function_id);
-  goto_programt &body = goto_function.body;
 
-  for(const auto &frees_expr : code_with_contract.frees())
+  exprt::operandst targets;
+
+  for(const exprt &target : code_with_contract.frees())
   {
-    auto expr = to_lambda_expr(frees_expr).application(lambda_parameters);
-    expr.add_source_location() = frees_expr.source_location();
-    if(can_cast_expr<conditional_target_group_exprt>(expr))
-    {
-      encode_freeable_target_group(
-        to_conditional_target_group_expr(expr), body);
-    }
-    else
-    {
-      encode_freeable_target(expr, body);
-    }
+    auto new_target = to_lambda_expr(target).application(lambda_parameters);
+    new_target.add_source_location() = target.source_location();
+    targets.push_back(new_target);
   }
 
+  goto_programt &body = goto_function.body;
+  contract_clauses_codegen.gen_spec_frees_instructions(
+    spec_function_symbol.mode, targets, body);
   body.add(goto_programt::make_end_function(spec_function_symbol.location));
 
   goto_model.goto_functions.update();
-
-  inline_and_check_warnings(spec_function_id);
-
-  PRECONDITION_WITH_DIAGNOSTICS(
-    utils.has_no_loops(spec_function_id),
-    "loops in frees clause specification functions must be unwound before "
-    "model instrumentation");
-
-  goto_model.goto_functions.update();
-}
-
-void dfcc_contract_functionst::inline_and_check_warnings(
-  const irep_idt &function_id)
-{
-  std::set<irep_idt> no_body;
-  std::set<irep_idt> missing_function;
-  std::set<irep_idt> recursive_call;
-  std::set<irep_idt> not_enough_arguments;
-
-  utils.inline_function(
-    function_id,
-    no_body,
-    recursive_call,
-    missing_function,
-    not_enough_arguments);
-
-  // check that the only no body / missing functions are the cprover builtins
-  for(const auto &id : no_body)
-  {
-    INVARIANT(
-      library.is_front_end_builtin(id),
-      "no body for '" + id2string(id) + "' when inlining '" +
-        id2string(function_id) + "'");
-  }
-
-  for(auto it : missing_function)
-  {
-    INVARIANT(
-      library.is_front_end_builtin(it),
-      "missing function '" + id2string(it) + "' when inlining '" +
-        id2string(function_id) + "'");
-  }
-
-  INVARIANT(
-    recursive_call.size() == 0,
-    "recursive calls when inlining '" + id2string(function_id) + "'");
-
-  INVARIANT(
-    not_enough_arguments.size() == 0,
-    "not enough arguments when inlining '" + id2string(function_id) + "'");
-}
-
-void dfcc_contract_functionst::encode_freeable_target_group(
-  const conditional_target_group_exprt &group,
-  goto_programt &dest)
-{
-  const source_locationt &source_location = group.source_location();
-
-  // clean up side effects from the condition expression if needed
-  cleanert cleaner(goto_model.symbol_table, log.get_message_handler());
-  exprt condition(group.condition());
-  if(has_subexpr(condition, ID_side_effect))
-    cleaner.clean(condition, dest, language_mode);
-
-  // Jump target if condition is false
-  auto goto_instruction = dest.add(
-    goto_programt::make_incomplete_goto(not_exprt{condition}, source_location));
-
-  for(const auto &target : group.targets())
-    encode_freeable_target(target, dest);
-
-  auto label_instruction = dest.add(goto_programt::make_skip(source_location));
-  goto_instruction->complete_goto(label_instruction);
-}
-
-void dfcc_contract_functionst::encode_freeable_target(
-  const exprt &target,
-  goto_programt &dest)
-{
-  const source_locationt &source_location = target.source_location();
-
-  if(can_cast_expr<side_effect_expr_function_callt>(target))
-  {
-    const auto &funcall = to_side_effect_expr_function_call(target);
-    if(can_cast_expr<symbol_exprt>(funcall.function()))
-    {
-      // for calls to user-defined functions
-      // `foo(params)`
-      //
-      // ```
-      // CALL foo(params);
-      // ```
-      code_function_callt code_function_call(
-        to_symbol_expr(funcall.function()));
-      auto &arguments = code_function_call.arguments();
-      for(auto &arg : funcall.arguments())
-        arguments.emplace_back(arg);
-      dest.add(
-        goto_programt::make_function_call(code_function_call, source_location));
-    }
-  }
-  else if(can_cast_type<pointer_typet>(target.type()))
-  {
-    // A plain `target` becomes `CALL __CPROVER_freeable(target);`
-    code_function_callt code_function_call(
-      utils.get_function_symbol(CPROVER_PREFIX "freeable").symbol_expr());
-    auto &arguments = code_function_call.arguments();
-    arguments.emplace_back(target);
-
-    dest.add(
-      goto_programt::make_function_call(code_function_call, source_location));
-  }
-  else
-  {
-    // any other type of target is unsupported
-    throw invalid_source_file_exceptiont(
-      "unsupported frees clause target " +
-        from_expr_using_mode(ns, language_mode, target),
-      target.source_location());
-  }
 }

--- a/src/goto-instrument/contracts/dynamic-frames/dfcc_contract_functions.h
+++ b/src/goto-instrument/contracts/dynamic-frames/dfcc_contract_functions.h
@@ -30,6 +30,7 @@ class message_handlert;
 class dfcc_libraryt;
 class dfcc_utilst;
 class dfcc_spec_functionst;
+class dfcc_contract_clauses_codegent;
 class code_with_contract_typet;
 class conditional_target_group_exprt;
 
@@ -67,14 +68,16 @@ public:
   /// \param utils utility class for dynamic frames
   /// \param library the contracts instrumentation library
   /// \param spec_functions provides translation methods for assignable set
-  /// or freeable set specification functions.
+  /// \param contract_clauses_codegen provides GOTO code generation methods
+  /// for assigns and free clauses.
   dfcc_contract_functionst(
     const symbolt &pure_contract_symbol,
     goto_modelt &goto_model,
     message_handlert &message_handler,
     dfcc_utilst &utils,
     dfcc_libraryt &library,
-    dfcc_spec_functionst &spec_functions);
+    dfcc_spec_functionst &spec_functions,
+    dfcc_contract_clauses_codegent &contract_clauses_codegen);
 
   /// Returns the contract::assigns function symbol
   const symbolt &get_spec_assigns_function_symbol() const;
@@ -116,6 +119,7 @@ protected:
   dfcc_utilst &utils;
   dfcc_libraryt &library;
   dfcc_spec_functionst &spec_functions;
+  dfcc_contract_clauses_codegent &contract_clauses_codegen;
   namespacet ns;
   std::size_t nof_assigns_targets;
   std::size_t nof_frees_targets;
@@ -128,32 +132,6 @@ protected:
   /// Translates the contract's frees clause to a GOTO function that uses the
   /// `freeable` built-in to express targets.
   void gen_spec_frees_function();
-
-  /// Generates GOTO instructions to build the representation of the given
-  /// conditional target group.
-  void encode_assignable_target_group(
-    const conditional_target_group_exprt &group,
-    goto_programt &dest);
-
-  /// Generates GOTO instructions to build the representation of the given
-  /// assignable target.
-  void encode_assignable_target(const exprt &target, goto_programt &dest);
-
-  /// Generates GOTO instructions to build the representation of the given
-  /// conditional target group.
-  void encode_freeable_target_group(
-    const conditional_target_group_exprt &group,
-    goto_programt &dest);
-
-  /// Generates GOTO instructions to build the representation of the given
-  /// freeable target.
-  void encode_freeable_target(const exprt &target, goto_programt &dest);
-
-  /// Inlines the given function and checks that the only missign functions
-  /// or no body functions are front-end
-  // void or __CPROVER_freeable_t functions,
-  /// and that no other warnings happened.
-  void inline_and_check_warnings(const irep_idt &function_id);
 };
 
 #endif

--- a/src/goto-instrument/contracts/dynamic-frames/dfcc_contract_handler.cpp
+++ b/src/goto-instrument/contracts/dynamic-frames/dfcc_contract_handler.cpp
@@ -44,7 +44,8 @@ dfcc_contract_handlert::dfcc_contract_handlert(
   dfcc_libraryt &library,
   dfcc_instrumentt &instrument,
   dfcc_lift_memory_predicatest &memory_predicates,
-  dfcc_spec_functionst &spec_functions)
+  dfcc_spec_functionst &spec_functions,
+  dfcc_contract_clauses_codegent &contract_clauses_codegen)
   : goto_model(goto_model),
     message_handler(message_handler),
     log(message_handler),
@@ -53,6 +54,7 @@ dfcc_contract_handlert::dfcc_contract_handlert(
     instrument(instrument),
     memory_predicates(memory_predicates),
     spec_functions(spec_functions),
+    contract_clauses_codegen(contract_clauses_codegen),
     ns(goto_model.symbol_table)
 {
 }
@@ -76,7 +78,8 @@ dfcc_contract_handlert::get_contract_functions(const irep_idt &contract_id)
          message_handler,
          utils,
          library,
-         spec_functions)})
+         spec_functions,
+         contract_clauses_codegen)})
     .first->second;
 }
 

--- a/src/goto-instrument/contracts/dynamic-frames/dfcc_contract_handler.h
+++ b/src/goto-instrument/contracts/dynamic-frames/dfcc_contract_handler.h
@@ -31,6 +31,7 @@ class dfcc_utilst;
 class dfcc_instrumentt;
 class dfcc_lift_memory_predicatest;
 class dfcc_spec_functionst;
+class dfcc_contract_clauses_codegent;
 class code_with_contract_typet;
 class conditional_target_group_exprt;
 
@@ -72,7 +73,8 @@ public:
     dfcc_libraryt &library,
     dfcc_instrumentt &instrument,
     dfcc_lift_memory_predicatest &memory_predicates,
-    dfcc_spec_functionst &spec_functions);
+    dfcc_spec_functionst &spec_functions,
+    dfcc_contract_clauses_codegent &contract_clauses_codegen);
 
   /// Adds instructions in `dest` modeling contract checking, assuming
   /// that `ret_t wrapper_id(params)` is the function receiving
@@ -122,6 +124,7 @@ protected:
   dfcc_instrumentt &instrument;
   dfcc_lift_memory_predicatest &memory_predicates;
   dfcc_spec_functionst &spec_functions;
+  dfcc_contract_clauses_codegent &contract_clauses_codegen;
   namespacet ns;
 
   // Caches the functions generated from contracts

--- a/src/goto-instrument/contracts/dynamic-frames/dfcc_instrument.cpp
+++ b/src/goto-instrument/contracts/dynamic-frames/dfcc_instrument.cpp
@@ -380,8 +380,7 @@ void dfcc_instrumentt::instrument_function_body(
   for(const auto &local_static : local_statics)
   {
     // automatically add local statics to the write set
-    insert_add_allocated_call(
-      function_id, write_set, local_static, begin, body);
+    insert_add_decl_call(function_id, write_set, local_static, begin, body);
 
     // automatically remove local statics to the write set
     insert_record_dead_call(function_id, write_set, local_static, end, body);
@@ -510,7 +509,7 @@ bool dfcc_instrumentt::must_track_decl_or_dead(
   return retval;
 }
 
-void dfcc_instrumentt::insert_add_allocated_call(
+void dfcc_instrumentt::insert_add_decl_call(
   const irep_idt &function_id,
   const exprt &write_set,
   const symbol_exprt &symbol_expr,
@@ -523,7 +522,7 @@ void dfcc_instrumentt::insert_add_allocated_call(
 
   payload.add(goto_programt::make_function_call(
     code_function_callt{
-      library.dfcc_fun_symbol[dfcc_funt::WRITE_SET_ADD_ALLOCATED].symbol_expr(),
+      library.dfcc_fun_symbol[dfcc_funt::WRITE_SET_ADD_DECL].symbol_expr(),
       {write_set, address_of_exprt(symbol_expr)}},
     target->source_location()));
 
@@ -538,7 +537,7 @@ void dfcc_instrumentt::insert_add_allocated_call(
 /// ```c
 /// DECL x;
 /// ----
-/// insert_add_allocated_call(...);
+/// insert_add_decl_call(...);
 /// ```
 void dfcc_instrumentt::instrument_decl(
   const irep_idt &function_id,
@@ -552,7 +551,7 @@ void dfcc_instrumentt::instrument_decl(
 
   const auto &decl_symbol = target->decl_symbol();
   target++;
-  insert_add_allocated_call(
+  insert_add_decl_call(
     function_id, write_set, decl_symbol, target, goto_program);
   target--;
 }

--- a/src/goto-instrument/contracts/dynamic-frames/dfcc_instrument.h
+++ b/src/goto-instrument/contracts/dynamic-frames/dfcc_instrument.h
@@ -175,7 +175,7 @@ protected:
   /// forward.
   /// ```
   /// IF !write_set GOTO skip_target;
-  /// CALL __CPROVER_contracts_write_set_add_allocated(write_set, &x);
+  /// CALL __CPROVER_contracts_write_set_add_decl(write_set, &x);
   /// skip_target: SKIP;
   /// ```
   /// \param function_id Name of the function in which the instructions is added
@@ -183,7 +183,7 @@ protected:
   /// \param symbol_expr The symbol to add to the write set
   /// \param target The instruction pointer to insert at
   /// \param goto_program the goto_program being instrumented
-  void insert_add_allocated_call(
+  void insert_add_decl_call(
     const irep_idt &function_id,
     const exprt &write_set,
     const symbol_exprt &symbol_expr,

--- a/src/goto-instrument/contracts/dynamic-frames/dfcc_is_freeable.cpp
+++ b/src/goto-instrument/contracts/dynamic-frames/dfcc_is_freeable.cpp
@@ -60,12 +60,10 @@ void dfcc_is_freeablet::rewrite_calls(
         {
           // insert call to precondition for vacuity checking
           auto inst = goto_programt::make_function_call(
-            code_function_callt{
-              library
-                .dfcc_fun_symbol
-                  [dfcc_funt::REPLACE_ENSURES_WAS_FREED_PRECONDITIONS]
-                .symbol_expr(),
-              {target->call_arguments().at(0), write_set}},
+            library.check_replace_ensures_was_freed_preconditions_call(
+              target->call_arguments().at(0),
+              write_set,
+              target->source_location()),
             target->source_location());
           program.insert_before_swap(target, inst);
           target++;

--- a/src/goto-instrument/contracts/dynamic-frames/dfcc_library.cpp
+++ b/src/goto-instrument/contracts/dynamic-frames/dfcc_library.cpp
@@ -559,3 +559,312 @@ void dfcc_libraryt::add_instrumented_functions_map_init_instructions(
   }
   goto_model.goto_functions.update();
 }
+
+const code_function_callt dfcc_libraryt::write_set_create_call(
+  const exprt &address_of_write_set,
+  const exprt &max_assigns_clause_size,
+  const exprt &max_frees_clause_size,
+  const exprt &assume_requires_ctx,
+  const exprt &assert_requires_ctx,
+  const exprt &assume_ensures_ctx,
+  const exprt &assert_ensures_ctx,
+  const exprt &allow_allocate,
+  const exprt &allow_deallocate,
+  const source_locationt &source_location)
+{
+  auto function_symbol =
+    dfcc_fun_symbol[dfcc_funt::WRITE_SET_CREATE].symbol_expr();
+  code_function_callt call(function_symbol);
+  auto &arguments = call.arguments();
+  // check that address_of_write_set.type() is dfcc_typet::WRITE_SET_PTR
+  arguments.emplace_back(address_of_write_set);
+  PRECONDITION(max_assigns_clause_size.type() == size_type());
+  arguments.emplace_back(max_assigns_clause_size);
+  PRECONDITION(max_frees_clause_size.type() == size_type());
+  arguments.emplace_back(max_frees_clause_size);
+  arguments.push_back(assume_requires_ctx);
+  arguments.push_back(assert_requires_ctx);
+  arguments.push_back(assume_ensures_ctx);
+  arguments.push_back(assert_ensures_ctx);
+  arguments.push_back(allow_allocate);
+  arguments.push_back(allow_deallocate);
+  call.add_source_location() = source_location;
+  return call;
+}
+
+const code_function_callt dfcc_libraryt::write_set_release_call(
+  const exprt &write_set_ptr,
+  const source_locationt &source_location)
+{
+  code_function_callt call(
+    dfcc_fun_symbol[dfcc_funt::WRITE_SET_RELEASE].symbol_expr(),
+    {write_set_ptr});
+  call.add_source_location() = source_location;
+  return call;
+}
+
+const code_function_callt dfcc_libraryt::write_set_add_allocated_call(
+  const exprt &write_set_ptr,
+  const exprt &ptr,
+  const source_locationt &source_location)
+{
+  code_function_callt call(
+    dfcc_fun_symbol[dfcc_funt::WRITE_SET_ADD_ALLOCATED].symbol_expr(),
+    {write_set_ptr, ptr});
+  call.add_source_location() = source_location;
+  return call;
+}
+
+const code_function_callt dfcc_libraryt::write_set_add_decl_call(
+  const exprt &write_set_ptr,
+  const exprt &ptr,
+  const source_locationt &source_location)
+{
+  code_function_callt call(
+    dfcc_fun_symbol[dfcc_funt::WRITE_SET_ADD_DECL].symbol_expr(),
+    {write_set_ptr, ptr});
+  call.add_source_location() = source_location;
+  return call;
+}
+
+const code_function_callt dfcc_libraryt::write_set_record_dead_call(
+  const exprt &write_set_ptr,
+  const exprt &ptr,
+  const source_locationt &source_location)
+{
+  code_function_callt call(
+    dfcc_fun_symbol[dfcc_funt::WRITE_SET_RECORD_DEAD].symbol_expr(),
+    {write_set_ptr, ptr});
+  call.add_source_location() = source_location;
+  return call;
+}
+
+const code_function_callt dfcc_libraryt::write_set_record_deallocated_call(
+  const exprt &write_set_ptr,
+  const exprt &ptr,
+  const source_locationt &source_location)
+{
+  code_function_callt call(
+    dfcc_fun_symbol[dfcc_funt::WRITE_SET_RECORD_DEALLOCATED].symbol_expr(),
+    {write_set_ptr, ptr});
+  call.add_source_location() = source_location;
+  return call;
+}
+
+const code_function_callt
+dfcc_libraryt::write_set_check_allocated_deallocated_is_empty_call(
+  const exprt &check_var,
+  const exprt &write_set_ptr,
+  const source_locationt &source_location)
+{
+  code_function_callt call(
+    check_var,
+    dfcc_fun_symbol[dfcc_funt::WRITE_SET_CHECK_ALLOCATED_DEALLOCATED_IS_EMPTY]
+      .symbol_expr(),
+    {write_set_ptr});
+  call.add_source_location() = source_location;
+  return call;
+}
+
+const code_function_callt dfcc_libraryt::write_set_check_assignment_call(
+  const exprt &check_var,
+  const exprt &write_set_ptr,
+  const exprt &ptr,
+  const exprt &size,
+  const source_locationt &source_location)
+{
+  code_function_callt call(
+    check_var,
+    dfcc_fun_symbol[dfcc_funt::WRITE_SET_CHECK_ASSIGNMENT].symbol_expr(),
+    {write_set_ptr, ptr, size});
+  call.add_source_location() = source_location;
+  return call;
+}
+
+const code_function_callt dfcc_libraryt::write_set_check_array_set_call(
+  const exprt &check_var,
+  const exprt &write_set_ptr,
+  const exprt &dest,
+  const source_locationt &source_location)
+{
+  code_function_callt call(
+    check_var,
+    dfcc_fun_symbol[dfcc_funt::WRITE_SET_CHECK_ARRAY_SET].symbol_expr(),
+    {write_set_ptr, dest});
+  call.add_source_location() = source_location;
+  return call;
+}
+
+const code_function_callt dfcc_libraryt::write_set_check_array_copy_call(
+  const exprt &check_var,
+  const exprt &write_set_ptr,
+  const exprt &dest,
+  const source_locationt &source_location)
+{
+  code_function_callt call(
+    check_var,
+    dfcc_fun_symbol[dfcc_funt::WRITE_SET_CHECK_ARRAY_COPY].symbol_expr(),
+    {write_set_ptr, dest});
+  call.add_source_location() = source_location;
+  return call;
+}
+
+const code_function_callt dfcc_libraryt::write_set_check_array_replace_call(
+  const exprt &check_var,
+  const exprt &write_set_ptr,
+  const exprt &dest,
+  const exprt &src,
+  const source_locationt &source_location)
+{
+  code_function_callt call(
+    check_var,
+    dfcc_fun_symbol[dfcc_funt::WRITE_SET_CHECK_ARRAY_REPLACE].symbol_expr(),
+    {write_set_ptr, dest, src});
+  call.add_source_location() = source_location;
+  return call;
+}
+
+const code_function_callt dfcc_libraryt::write_set_check_havoc_object_call(
+  const exprt &check_var,
+  const exprt &write_set_ptr,
+  const exprt &ptr,
+  const source_locationt &source_location)
+{
+  code_function_callt call(
+    check_var,
+    dfcc_fun_symbol[dfcc_funt::WRITE_SET_CHECK_HAVOC_OBJECT].symbol_expr(),
+    {write_set_ptr, ptr});
+  call.add_source_location() = source_location;
+  return call;
+}
+
+const code_function_callt dfcc_libraryt::write_set_check_deallocate_call(
+  const exprt &check_var,
+  const exprt &write_set_ptr,
+  const exprt &ptr,
+  const source_locationt &source_location)
+{
+  code_function_callt call(
+    check_var,
+    dfcc_fun_symbol[dfcc_funt::WRITE_SET_CHECK_DEALLOCATE].symbol_expr(),
+    {write_set_ptr, ptr});
+  call.add_source_location() = source_location;
+  return call;
+}
+
+const code_function_callt
+dfcc_libraryt::write_set_check_assigns_clause_inclusion_call(
+  const exprt &check_var,
+  const exprt &reference_write_set_ptr,
+  const exprt &candidate_write_set_ptr,
+  const source_locationt &source_location)
+{
+  code_function_callt call(
+    check_var,
+    dfcc_fun_symbol[dfcc_funt::WRITE_SET_CHECK_ASSIGNS_CLAUSE_INCLUSION]
+      .symbol_expr(),
+    {reference_write_set_ptr, candidate_write_set_ptr});
+  call.add_source_location() = source_location;
+  return call;
+}
+
+const code_function_callt
+dfcc_libraryt::write_set_check_frees_clause_inclusion_call(
+  const exprt &check_var,
+  const exprt &reference_write_set_ptr,
+  const exprt &candidate_write_set_ptr,
+  const source_locationt &source_location)
+{
+  code_function_callt call(
+    check_var,
+    dfcc_fun_symbol[dfcc_funt::WRITE_SET_CHECK_FREES_CLAUSE_INCLUSION]
+      .symbol_expr(),
+    {reference_write_set_ptr, candidate_write_set_ptr});
+  call.add_source_location() = source_location;
+  return call;
+}
+
+const code_function_callt dfcc_libraryt::write_set_deallocate_freeable_call(
+  const exprt &write_set_ptr,
+  const exprt &target_write_set_ptr,
+  const source_locationt &source_location)
+{
+  code_function_callt call(
+    dfcc_fun_symbol[dfcc_funt::WRITE_SET_DEALLOCATE_FREEABLE].symbol_expr(),
+    {write_set_ptr, target_write_set_ptr});
+  call.add_source_location() = source_location;
+  return call;
+}
+
+const code_function_callt dfcc_libraryt::link_is_fresh_call(
+  const exprt &write_set_ptr,
+  const exprt &is_fresh_obj_set_ptr,
+  const source_locationt &source_location)
+{
+  code_function_callt call(
+    dfcc_fun_symbol[dfcc_funt::LINK_IS_FRESH].symbol_expr(),
+    {write_set_ptr, is_fresh_obj_set_ptr});
+  call.add_source_location() = source_location;
+  return call;
+}
+
+const code_function_callt dfcc_libraryt::link_allocated_call(
+  const exprt &write_set_postconditions_ptr,
+  const exprt &write_set_to_link_ptr,
+  const source_locationt &source_location)
+{
+  code_function_callt call(
+    dfcc_fun_symbol[dfcc_funt::LINK_ALLOCATED].symbol_expr(),
+    {write_set_postconditions_ptr, write_set_to_link_ptr});
+  call.add_source_location() = source_location;
+  return call;
+}
+
+const code_function_callt dfcc_libraryt::link_deallocated_call(
+  const exprt &write_set_postconditions_ptr,
+  const exprt &write_set_to_link_ptr,
+  const source_locationt &source_location)
+{
+  code_function_callt call(
+    dfcc_fun_symbol[dfcc_funt::LINK_DEALLOCATED].symbol_expr(),
+    {write_set_postconditions_ptr, write_set_to_link_ptr});
+  call.add_source_location() = source_location;
+  return call;
+}
+
+const code_function_callt
+dfcc_libraryt::check_replace_ensures_was_freed_preconditions_call(
+  const exprt &ptr,
+  const exprt &write_set_ptr,
+  const source_locationt &source_location)
+{
+  code_function_callt call(
+    dfcc_fun_symbol[dfcc_funt::REPLACE_ENSURES_WAS_FREED_PRECONDITIONS]
+      .symbol_expr(),
+    {ptr, write_set_ptr});
+  call.add_source_location() = source_location;
+  return call;
+}
+
+const code_function_callt
+dfcc_libraryt::obj_set_create_indexed_by_object_id_call(
+  const exprt &obj_set_ptr,
+  const source_locationt &source_location)
+{
+  code_function_callt call(
+    dfcc_fun_symbol[dfcc_funt::OBJ_SET_CREATE_INDEXED_BY_OBJECT_ID]
+      .symbol_expr(),
+    {obj_set_ptr});
+  call.add_source_location() = source_location;
+  return call;
+}
+
+const code_function_callt dfcc_libraryt::obj_set_release_call(
+  const exprt &obj_set_ptr,
+  const source_locationt &source_location)
+{
+  code_function_callt call(
+    dfcc_fun_symbol[dfcc_funt::OBJ_SET_RELEASE].symbol_expr(), {obj_set_ptr});
+  call.add_source_location() = source_location;
+  return call;
+}

--- a/src/goto-instrument/contracts/dynamic-frames/dfcc_library.cpp
+++ b/src/goto-instrument/contracts/dynamic-frames/dfcc_library.cpp
@@ -91,6 +91,7 @@ const std::map<dfcc_funt, irep_idt> create_dfcc_fun_to_name()
      CONTRACTS_PREFIX "write_set_add_freeable"},
     {dfcc_funt::WRITE_SET_ADD_ALLOCATED,
      CONTRACTS_PREFIX "write_set_add_allocated"},
+    {dfcc_funt::WRITE_SET_ADD_DECL, CONTRACTS_PREFIX "write_set_add_decl"},
     {dfcc_funt::WRITE_SET_RECORD_DEAD,
      CONTRACTS_PREFIX "write_set_record_dead"},
     {dfcc_funt::WRITE_SET_RECORD_DEALLOCATED,

--- a/src/goto-instrument/contracts/dynamic-frames/dfcc_library.h
+++ b/src/goto-instrument/contracts/dynamic-frames/dfcc_library.h
@@ -16,6 +16,8 @@ Author: Remi Delmas, delmasrd@amazon.com
 #include <util/message.h>
 #include <util/optional.h>
 
+#include <goto-programs/goto_instruction_code.h>
+
 #include <map>
 #include <set>
 
@@ -285,6 +287,169 @@ public:
     const std::set<irep_idt> &instrumented_functions,
     const source_locationt &source_location,
     goto_programt &dest);
+
+  /// \brief Builds call to \ref __CPROVER_contracts_write_set_create
+  const code_function_callt write_set_create_call(
+    const exprt &write_set_ptr,
+    const exprt &contract_assigns_size,
+    const exprt &contract_frees_size,
+    const exprt &assume_requires_ctx,
+    const exprt &assert_requires_ctx,
+    const exprt &assume_ensures_ctx,
+    const exprt &assert_ensures_ctx,
+    const exprt &allow_allocate,
+    const exprt &allow_deallocate,
+    const source_locationt &source_location);
+
+  /// \brief Builds call to \ref __CPROVER_contracts_write_set_release
+  const code_function_callt write_set_release_call(
+    const exprt &write_set_ptr,
+    const source_locationt &source_location);
+
+  /// \brief Builds call to \ref __CPROVER_contracts_write_set_add_allocated
+  const code_function_callt write_set_add_allocated_call(
+    const exprt &write_set_ptr,
+    const exprt &ptr,
+    const source_locationt &source_location);
+
+  /// \brief Builds call to \ref __CPROVER_contracts_write_set_add_decl
+  const code_function_callt write_set_add_decl_call(
+    const exprt &write_set_ptr,
+    const exprt &ptr,
+    const source_locationt &source_location);
+
+  /// \brief Builds call to \ref __CPROVER_contracts_write_set_record_dead
+  const code_function_callt write_set_record_dead_call(
+    const exprt &write_set_ptr,
+    const exprt &ptr,
+    const source_locationt &source_location);
+
+  /// \brief Builds call to
+  /// \ref __CPROVER_contracts_write_set_record_deallocated
+  const code_function_callt write_set_record_deallocated_call(
+    const exprt &write_set_ptr,
+    const exprt &ptr,
+    const source_locationt &source_location);
+
+  /// \brief Builds call to
+  /// \ref __CPROVER_contracts_write_set_check_allocated_deallocated_is_empty
+  const code_function_callt write_set_check_allocated_deallocated_is_empty_call(
+    const exprt &check_var,
+    const exprt &write_set_ptr,
+    const source_locationt &source_location);
+
+  /// \brief Builds call to
+  /// \ref __CPROVER_contracts_write_set_check_assignment
+  const code_function_callt write_set_check_assignment_call(
+    const exprt &check_var,
+    const exprt &write_set_ptr,
+    const exprt &ptr,
+    const exprt &size,
+    const source_locationt &source_location);
+
+  /// \brief Builds call to
+  /// \ref __CPROVER_contracts_write_set_check_array_set
+  const code_function_callt write_set_check_array_set_call(
+    const exprt &check_var,
+    const exprt &write_set_ptr,
+    const exprt &dest,
+    const source_locationt &source_location);
+
+  /// \brief Builds call to
+  /// \ref __CPROVER_contracts_write_set_check_array_copy
+  const code_function_callt write_set_check_array_copy_call(
+    const exprt &check_var,
+    const exprt &write_set_ptr,
+    const exprt &dest,
+    const source_locationt &source_location);
+
+  /// \brief Builds call to
+  /// \ref __CPROVER_contracts_write_set_check_array_replace
+  const code_function_callt write_set_check_array_replace_call(
+    const exprt &check_var,
+    const exprt &write_set_ptr,
+    const exprt &dest,
+    const exprt &src,
+    const source_locationt &source_location);
+
+  /// \brief Builds call to
+  /// \ref __CPROVER_contracts_write_set_check_havoc_object
+  const code_function_callt write_set_check_havoc_object_call(
+    const exprt &check_var,
+    const exprt &write_set_ptr,
+    const exprt &ptr,
+    const source_locationt &source_location);
+
+  /// \brief Builds call to
+  /// \ref __CPROVER_contracts_write_set_check_deallocate
+  const code_function_callt write_set_check_deallocate_call(
+    const exprt &check_var,
+    const exprt &write_set_ptr,
+    const exprt &ptr,
+    const source_locationt &source_location);
+
+  /// \brief Builds call to
+  /// \ref __CPROVER_contracts_write_set_check_assigns_clause_inclusion
+  const code_function_callt write_set_check_assigns_clause_inclusion_call(
+    const exprt &check_var,
+    const exprt &reference_write_set_ptr,
+    const exprt &candidate_write_set_ptr,
+    const source_locationt &source_location);
+
+  /// \brief Builds call to
+  /// \ref __CPROVER_contracts_write_set_check_frees_clause_inclusion
+  const code_function_callt write_set_check_frees_clause_inclusion_call(
+    const exprt &check_var,
+    const exprt &reference_write_set_ptr,
+    const exprt &candidate_write_set_ptr,
+    const source_locationt &source_location);
+
+  /// \brief Builds call to
+  /// \ref __CPROVER_contracts_write_set_deallocate_freeable
+  const code_function_callt write_set_deallocate_freeable_call(
+    const exprt &write_set_ptr,
+    const exprt &target_write_set_ptr,
+    const source_locationt &source_location);
+
+  /// \brief Builds call to
+  /// \ref __CPROVER_contracts_link_is_fresh
+  const code_function_callt link_is_fresh_call(
+    const exprt &write_set_ptr,
+    const exprt &is_fresh_obj_set_ptr,
+    const source_locationt &source_location);
+
+  /// \brief Builds call to
+  /// \ref __CPROVER_contracts_link_allocated
+  const code_function_callt link_allocated_call(
+    const exprt &write_set_postconditions_ptr,
+    const exprt &write_set_to_link_ptr,
+    const source_locationt &source_location);
+
+  /// \brief Builds call to
+  /// \ref __CPROVER_contracts_link_deallocated
+  const code_function_callt link_deallocated_call(
+    const exprt &write_set_postconditions_ptr,
+    const exprt &write_set_to_link_ptr,
+    const source_locationt &source_location);
+
+  /// \brief Builds call to
+  /// \ref __CPROVER_contracts_check_replace_ensures_was_freed_preconditions
+  const code_function_callt check_replace_ensures_was_freed_preconditions_call(
+    const exprt &ptr,
+    const exprt &write_set_ptr,
+    const source_locationt &source_location);
+
+  /// \brief Builds call to
+  /// \ref __CPROVER_contracts_obj_set_create_indexed_by_object_id
+  const code_function_callt obj_set_create_indexed_by_object_id_call(
+    const exprt &obj_set_ptr,
+    const source_locationt &source_location);
+
+  /// \brief Builds call to
+  /// \ref __CPROVER_contracts_obj_set_release
+  const code_function_callt obj_set_release_call(
+    const exprt &obj_set_ptr,
+    const source_locationt &source_location);
 };
 
 #endif

--- a/src/goto-instrument/contracts/dynamic-frames/dfcc_library.h
+++ b/src/goto-instrument/contracts/dynamic-frames/dfcc_library.h
@@ -87,6 +87,8 @@ enum class dfcc_funt
   WRITE_SET_ADD_FREEABLE,
   /// \see __CPROVER_contracts_write_set_add_allocated
   WRITE_SET_ADD_ALLOCATED,
+  /// \see __CPROVER_contracts_write_set_add_decl
+  WRITE_SET_ADD_DECL,
   /// \see __CPROVER_contracts_write_set_record_dead
   WRITE_SET_RECORD_DEAD,
   /// \see __CPROVER_contracts_write_set_record_deallocated

--- a/src/goto-instrument/contracts/dynamic-frames/dfcc_spec_functions.cpp
+++ b/src/goto-instrument/contracts/dynamic-frames/dfcc_spec_functions.cpp
@@ -162,9 +162,9 @@ void dfcc_spec_functionst::generate_havoc_instructions(
       if(ins_it->call_function().id() != ID_symbol)
       {
         throw invalid_source_file_exceptiont(
-          "Function pointer call '" +
+          "Function pointer calls are not supported in assigns clauses: '" +
             from_expr(ns, function_id, ins_it->call_function()) +
-            "' in function '" + id2string(function_id) + "' is not supported",
+            "' called in function '" + id2string(function_id) + "'",
           ins_it->source_location());
       }
 
@@ -265,7 +265,10 @@ void dfcc_spec_functionst::to_spec_assigns_function(
       .symbol_expr();
 
   to_spec_assigns_instructions(
-    write_set_to_fill, goto_function.body, nof_targets);
+    write_set_to_fill,
+    utils.get_function_symbol(function_id).mode,
+    goto_function.body,
+    nof_targets);
 
   goto_model.goto_functions.update();
 
@@ -273,13 +276,14 @@ void dfcc_spec_functionst::to_spec_assigns_function(
   std::set<irep_idt> function_pointer_contracts;
   instrument.instrument_function(function_id, function_pointer_contracts);
   INVARIANT(
-    function_pointer_contracts.size() == 0,
+    function_pointer_contracts.empty(),
     "discovered function pointer contracts unexpectedly");
   utils.set_hide(function_id, true);
 }
 
 void dfcc_spec_functionst::to_spec_assigns_instructions(
   const exprt &write_set_to_fill,
+  const irep_idt &language_mode,
   goto_programt &program,
   std::size_t &nof_targets)
 {
@@ -295,9 +299,9 @@ void dfcc_spec_functionst::to_spec_assigns_instructions(
       if(ins_it->call_function().id() != ID_symbol)
       {
         throw invalid_source_file_exceptiont(
-          "Function pointer call '" +
-            from_expr(ns, "", ins_it->call_function()) +
-            "' are supported in assigns clauses",
+          "Function pointer calls are not supported in assigns clauses '" +
+            from_expr_using_mode(ns, language_mode, ins_it->call_function()) +
+            "'",
           ins_it->source_location());
       }
 
@@ -350,7 +354,10 @@ void dfcc_spec_functionst::to_spec_frees_function(
       .symbol_expr();
 
   to_spec_frees_instructions(
-    write_set_to_fill, goto_function.body, nof_targets);
+    write_set_to_fill,
+    utils.get_function_symbol(function_id).mode,
+    goto_function.body,
+    nof_targets);
 
   goto_model.goto_functions.update();
 
@@ -358,7 +365,7 @@ void dfcc_spec_functionst::to_spec_frees_function(
   std::set<irep_idt> function_pointer_contracts;
   instrument.instrument_function(function_id, function_pointer_contracts);
   INVARIANT(
-    function_pointer_contracts.size() == 0,
+    function_pointer_contracts.empty(),
     "discovered function pointer contracts unexpectedly");
 
   utils.set_hide(function_id, true);
@@ -366,6 +373,7 @@ void dfcc_spec_functionst::to_spec_frees_function(
 
 void dfcc_spec_functionst::to_spec_frees_instructions(
   const exprt &write_set_to_fill,
+  const irep_idt &language_mode,
   goto_programt &program,
   std::size_t &nof_targets)
 {
@@ -378,9 +386,9 @@ void dfcc_spec_functionst::to_spec_frees_instructions(
       if(ins_it->call_function().id() != ID_symbol)
       {
         throw invalid_source_file_exceptiont(
-          "Function pointer call '" +
-            from_expr(ns, "", ins_it->call_function()) +
-            "' are not supported in frees clauses",
+          "Function pointer calls are not supported in frees clauses: '" +
+            from_expr_using_mode(ns, language_mode, ins_it->call_function()) +
+            "'",
           ins_it->source_location());
       }
 

--- a/src/goto-instrument/contracts/dynamic-frames/dfcc_spec_functions.cpp
+++ b/src/goto-instrument/contracts/dynamic-frames/dfcc_spec_functions.cpp
@@ -96,106 +96,20 @@ void dfcc_spec_functionst::generate_havoc_function(
     dummy_havoc_function);
 
   // body will be filled with instructions
-  auto &body =
+  auto &havoc_program =
     goto_model.goto_functions.function_map.at(havoc_function_id).body;
 
-  // index of the CAR to havoc in the write set
-  std::size_t next_idx = 0;
+  const goto_programt &original_program =
+    goto_model.goto_functions.function_map.at(function_id).body;
 
-  // iterate on the body of the original function and emit one havoc instruction
-  // per target
-  Forall_goto_program_instructions(
-    ins_it, goto_model.goto_functions.function_map.at(function_id).body)
-  {
-    if(ins_it->is_function_call())
-    {
-      if(ins_it->call_function().id() != ID_symbol)
-      {
-        throw invalid_source_file_exceptiont(
-          "Function pointer call '" +
-            from_expr(ns, function_id, ins_it->call_function()) +
-            "' in function '" + id2string(function_id) + "' is not supported",
-          ins_it->source_location());
-      }
-
-      const irep_idt &callee_id =
-        to_symbol_expr(ins_it->call_function()).get_identifier();
-
-      // only process built-in functions that return assignable_t,
-      // error out on any other function call
-      // find the corresponding instrumentation hook
-      auto hook_opt = library.get_havoc_hook(callee_id);
-      INVARIANT(
-        hook_opt.has_value(),
-        "dfcc_spec_functionst::generate_havoc_function: function calls must "
-        "be inlined before calling this function");
-
-      // Use same source location as original call
-      source_locationt location(ins_it->source_location());
-      auto hook = hook_opt.value();
-      code_function_callt call(
-        library.dfcc_fun_symbol.at(hook).symbol_expr(),
-        {write_set_symbol.symbol_expr(), from_integer(next_idx, size_type())});
-
-      if(hook == dfcc_funt::WRITE_SET_HAVOC_GET_ASSIGNABLE_TARGET)
-      {
-        // ```
-        // DECL __havoc_target;
-        // CALL __havoc_target = havoc_hook(set, next_idx);
-        // IF !__havoc_target GOTO label;
-        // ASSIGN *__havoc_target = nondet(target_type);
-        // label: DEAD __havoc_target;
-        // ```
-        // declare a local var to store targets havoced via nondet assignment
-        auto &target_type = get_target_type(ins_it->call_arguments().at(0));
-
-        const auto &target_symbol = utils.create_symbol(
-          pointer_type(target_type),
-          id2string(havoc_function_id),
-          "__havoc_target",
-          location,
-          function_symbol.mode,
-          function_symbol.module,
-          false);
-
-        auto target_expr = target_symbol.symbol_expr();
-        body.add(goto_programt::make_decl(target_expr));
-
-        call.lhs() = target_expr;
-        body.add(goto_programt::make_function_call(call, location));
-
-        auto goto_instruction = body.add(goto_programt::make_incomplete_goto(
-          utils.make_null_check_expr(target_expr), location));
-
-        // create nondet assignment to the target
-        side_effect_expr_nondett nondet(target_type, location);
-        body.add(goto_programt::make_assignment(
-          dereference_exprt{typecast_exprt::conditional_cast(
-            target_expr, pointer_type(target_type))},
-          nondet,
-          location));
-        auto label = body.add(goto_programt::make_dead(target_expr));
-        goto_instruction->complete_goto(label);
-      }
-      else if(
-        hook == dfcc_funt::WRITE_SET_HAVOC_OBJECT_WHOLE ||
-        hook == dfcc_funt::WRITE_SET_HAVOC_SLICE)
-      {
-        // ```
-        // CALL havoc_hook(set, next_idx);
-        // ```
-        body.add(goto_programt::make_function_call(call, location));
-      }
-      else
-      {
-        UNREACHABLE;
-      }
-      ++next_idx;
-    }
-    nof_targets = next_idx;
-  }
-
-  body.add(goto_programt::make_end_function());
+  generate_havoc_instructions(
+    havoc_function_id,
+    havoc_function_symbol.mode,
+    havoc_function_symbol.module,
+    original_program,
+    write_set_symbol.symbol_expr(),
+    havoc_program,
+    nof_targets);
 
   goto_model.goto_functions.update();
 
@@ -227,24 +141,21 @@ void dfcc_spec_functionst::generate_havoc_function(
   goto_model.goto_functions.update();
 }
 
-void dfcc_spec_functionst::to_spec_assigns_function(
+void dfcc_spec_functionst::generate_havoc_instructions(
   const irep_idt &function_id,
+  const irep_idt &mode,
+  const irep_idt &module,
+  const goto_programt &original_program,
+  const exprt &write_set_to_havoc,
+  goto_programt &havoc_program,
   std::size_t &nof_targets)
 {
-  // counts the number of calls to built-ins to get an over approximation
-  // of the size of the set
+  // index of the CAR to havoc in the write set
   std::size_t next_idx = 0;
 
-  auto &goto_function = goto_model.goto_functions.function_map.at(function_id);
-
-  // add write_set parameter
-  auto &set_symbol = utils.add_parameter(
-    function_id,
-    "__write_set_to_fill",
-    library.dfcc_type[dfcc_typet::WRITE_SET_PTR]);
-
-  // rewrite calls
-  Forall_goto_program_instructions(ins_it, goto_function.body)
+  // iterate on the body of the original function and emit one havoc instruction
+  // per target
+  forall_goto_program_instructions(ins_it, original_program)
   {
     if(ins_it->is_function_call())
     {
@@ -260,9 +171,143 @@ void dfcc_spec_functionst::to_spec_assigns_function(
       const irep_idt &callee_id =
         to_symbol_expr(ins_it->call_function()).get_identifier();
 
-      // only process built-in functions that return assignable_t,
-      // error out on any other function call
-      // find the corresponding instrumentation hook
+      // Only process built-in functions that represent assigns clause targets,
+      // and error-out on any other function call
+
+      // Find the corresponding instrumentation hook
+      auto hook_opt = library.get_havoc_hook(callee_id);
+      INVARIANT(
+        hook_opt.has_value(),
+        "dfcc_spec_functionst::generate_havoc_instructions: function calls "
+        "must be inlined before calling this function");
+
+      // Use same source location as original call
+      source_locationt location(ins_it->source_location());
+      auto hook = hook_opt.value();
+      code_function_callt call(
+        library.dfcc_fun_symbol.at(hook).symbol_expr(),
+        {write_set_to_havoc, from_integer(next_idx, size_type())});
+
+      if(hook == dfcc_funt::WRITE_SET_HAVOC_GET_ASSIGNABLE_TARGET)
+      {
+        // ```
+        // DECL __havoc_target;
+        // CALL __havoc_target = havoc_hook(set, next_idx);
+        // IF !__havoc_target GOTO label;
+        // ASSIGN *__havoc_target = nondet(target_type);
+        // label: DEAD __havoc_target;
+        // ```
+        // declare a local var to store targets havoced via nondet assignment
+        auto &target_type = get_target_type(ins_it->call_arguments().at(0));
+
+        const auto &target_symbol = utils.create_symbol(
+          pointer_type(target_type),
+          id2string(function_id),
+          "__havoc_target",
+          location,
+          mode,
+          module,
+          false);
+
+        auto target_expr = target_symbol.symbol_expr();
+        havoc_program.add(goto_programt::make_decl(target_expr));
+
+        call.lhs() = target_expr;
+        havoc_program.add(goto_programt::make_function_call(call, location));
+
+        auto goto_instruction =
+          havoc_program.add(goto_programt::make_incomplete_goto(
+            utils.make_null_check_expr(target_expr), location));
+
+        // create nondet assignment to the target
+        side_effect_expr_nondett nondet(target_type, location);
+        havoc_program.add(goto_programt::make_assignment(
+          dereference_exprt{typecast_exprt::conditional_cast(
+            target_expr, pointer_type(target_type))},
+          nondet,
+          location));
+        auto label = havoc_program.add(goto_programt::make_dead(target_expr));
+        goto_instruction->complete_goto(label);
+      }
+      else if(
+        hook == dfcc_funt::WRITE_SET_HAVOC_OBJECT_WHOLE ||
+        hook == dfcc_funt::WRITE_SET_HAVOC_SLICE)
+      {
+        // ```
+        // CALL havoc_hook(set, next_idx);
+        // ```
+        havoc_program.add(goto_programt::make_function_call(call, location));
+      }
+      else
+      {
+        UNREACHABLE;
+      }
+      ++next_idx;
+    }
+  }
+  nof_targets = next_idx;
+  havoc_program.add(goto_programt::make_end_function());
+}
+
+void dfcc_spec_functionst::to_spec_assigns_function(
+  const irep_idt &function_id,
+  std::size_t &nof_targets)
+{
+  auto &goto_function = goto_model.goto_functions.function_map.at(function_id);
+
+  // add write_set parameter
+  const exprt write_set_to_fill =
+    utils
+      .add_parameter(
+        function_id,
+        "__write_set_to_fill",
+        library.dfcc_type[dfcc_typet::WRITE_SET_PTR])
+      .symbol_expr();
+
+  to_spec_assigns_instructions(
+    write_set_to_fill, goto_function.body, nof_targets);
+
+  goto_model.goto_functions.update();
+
+  // instrument for side-effects checking
+  std::set<irep_idt> function_pointer_contracts;
+  instrument.instrument_function(function_id, function_pointer_contracts);
+  INVARIANT(
+    function_pointer_contracts.size() == 0,
+    "discovered function pointer contracts unexpectedly");
+  utils.set_hide(function_id, true);
+}
+
+void dfcc_spec_functionst::to_spec_assigns_instructions(
+  const exprt &write_set_to_fill,
+  goto_programt &program,
+  std::size_t &nof_targets)
+{
+  // counts the number of calls to built-ins to get an over approximation
+  // of the size of the set
+  std::size_t next_idx = 0;
+
+  // rewrite calls
+  Forall_goto_program_instructions(ins_it, program)
+  {
+    if(ins_it->is_function_call())
+    {
+      if(ins_it->call_function().id() != ID_symbol)
+      {
+        throw invalid_source_file_exceptiont(
+          "Function pointer call '" +
+            from_expr(ns, "", ins_it->call_function()) +
+            "' are supported in assigns clauses",
+          ins_it->source_location());
+      }
+
+      const irep_idt &callee_id =
+        to_symbol_expr(ins_it->call_function()).get_identifier();
+
+      // Only process built-in functions that specify assignable targets
+      // and error-out on any other function call
+
+      // Find the corresponding instrumentation hook
       INVARIANT(
         library.is_front_end_builtin(callee_id),
         "dfcc_spec_functionst::to_spec_assigns_function: function calls must "
@@ -276,7 +321,7 @@ void dfcc_spec_functionst::to_spec_assigns_function(
         ins_it->call_arguments().begin(), from_integer(next_idx, size_type()));
       // insert write set argument
       ins_it->call_arguments().insert(
-        ins_it->call_arguments().begin(), set_symbol.symbol_expr());
+        ins_it->call_arguments().begin(), write_set_to_fill);
 
       // remove the is_pointer_to_pointer argument which is not used in the
       // hook for insert assignable
@@ -286,8 +331,27 @@ void dfcc_spec_functionst::to_spec_assigns_function(
       ++next_idx;
     }
   }
-
   nof_targets = next_idx;
+}
+
+void dfcc_spec_functionst::to_spec_frees_function(
+  const irep_idt &function_id,
+  std::size_t &nof_targets)
+{
+  auto &goto_function = goto_model.goto_functions.function_map.at(function_id);
+
+  // add __dfcc_set parameter
+  const exprt &write_set_to_fill =
+    utils
+      .add_parameter(
+        function_id,
+        "__write_set_to_fill",
+        library.dfcc_type[dfcc_typet::WRITE_SET_PTR])
+      .symbol_expr();
+
+  to_spec_frees_instructions(
+    write_set_to_fill, goto_function.body, nof_targets);
+
   goto_model.goto_functions.update();
 
   // instrument for side-effects checking
@@ -296,24 +360,18 @@ void dfcc_spec_functionst::to_spec_assigns_function(
   INVARIANT(
     function_pointer_contracts.size() == 0,
     "discovered function pointer contracts unexpectedly");
+
   utils.set_hide(function_id, true);
 }
 
-void dfcc_spec_functionst::to_spec_frees_function(
-  const irep_idt &function_id,
+void dfcc_spec_functionst::to_spec_frees_instructions(
+  const exprt &write_set_to_fill,
+  goto_programt &program,
   std::size_t &nof_targets)
 {
   // counts the number of calls to the `freeable` builtin
   std::size_t next_idx = 0;
-  auto &goto_function = goto_model.goto_functions.function_map.at(function_id);
-
-  // add __dfcc_set parameter
-  auto &set_symbol = utils.add_parameter(
-    function_id,
-    "__write_set_to_fill",
-    library.dfcc_type[dfcc_typet::WRITE_SET_PTR]);
-
-  Forall_goto_program_instructions(ins_it, goto_function.body)
+  Forall_goto_program_instructions(ins_it, program)
   {
     if(ins_it->is_function_call())
     {
@@ -321,8 +379,8 @@ void dfcc_spec_functionst::to_spec_frees_function(
       {
         throw invalid_source_file_exceptiont(
           "Function pointer call '" +
-            from_expr(ns, function_id, ins_it->call_function()) +
-            "' in function '" + id2string(function_id) + "' is not supported",
+            from_expr(ns, "", ins_it->call_function()) +
+            "' are not supported in frees clauses",
           ins_it->source_location());
       }
 
@@ -340,20 +398,10 @@ void dfcc_spec_functionst::to_spec_frees_function(
         library.dfcc_fun_symbol[dfcc_funt::WRITE_SET_ADD_FREEABLE]
           .symbol_expr();
       ins_it->call_arguments().insert(
-        ins_it->call_arguments().begin(), set_symbol.symbol_expr());
+        ins_it->call_arguments().begin(), write_set_to_fill);
       ++next_idx;
     }
   }
 
   nof_targets = next_idx;
-  goto_model.goto_functions.update();
-
-  // instrument for side-effects checking
-  std::set<irep_idt> function_pointer_contracts;
-  instrument.instrument_function(function_id, function_pointer_contracts);
-  INVARIANT(
-    function_pointer_contracts.size() == 0,
-    "discovered function pointer contracts unexpectedly");
-
-  utils.set_hide(function_id, true);
 }

--- a/src/goto-instrument/contracts/dynamic-frames/dfcc_spec_functions.h
+++ b/src/goto-instrument/contracts/dynamic-frames/dfcc_spec_functions.h
@@ -152,11 +152,13 @@ public:
   /// `__CPROVER_object_from`, `__CPROVER_object_upto`.
   ///
   /// \param[in] write_set_to_fill write set to populate.
+  /// \param[in] language_mode used to format expressions.
   /// \param[inout] program function to transform in place
   /// \param[out] nof_targets receives the estimated size of the write set
   ///
   void to_spec_assigns_instructions(
     const exprt &write_set_to_fill,
+    const irep_idt &language_mode,
     goto_programt &program,
     std::size_t &nof_targets);
 
@@ -201,11 +203,13 @@ public:
   /// freeable targets: `__CPROVER_freeable`.
   ///
   /// \param[in] write_set_to_fill write set to populate.
+  /// \param[in] language_mode used to format expressions.
   /// \param[inout] program function to transform in place
   /// \param[out] nof_targets receives the estimated size of the write set
   ///
   void to_spec_frees_instructions(
     const exprt &write_set_to_fill,
+    const irep_idt &language_mode,
     goto_programt &program,
     std::size_t &nof_targets);
 

--- a/src/goto-instrument/contracts/dynamic-frames/dfcc_spec_functions.h
+++ b/src/goto-instrument/contracts/dynamic-frames/dfcc_spec_functions.h
@@ -78,6 +78,38 @@ public:
     const irep_idt &havoc_function_id,
     std::size_t &nof_targets);
 
+  /// Translates \p original_program that specifies assignable targets
+  /// into a program that havocs the targets.
+  ///
+  /// \pre The \p original_program must be already fully inlined, and the only
+  /// function calls allowed are to the built-ins that specify
+  /// assignable targets: `__CPROVER_assignable`, `__CPROVER_object_whole`,
+  /// `__CPROVER_object_from`, `__CPROVER_object_upto`.
+  ///
+  /// \details The \p original_program is assumed to encode an assigns clause
+  /// using the built-ins `__CPROVER_assignable`, `__CPROVER_object_whole`,
+  /// `__CPROVER_object_from`, `__CPROVER_object_upto`.
+  /// The method traverses \p original_program and emits a sequence of GOTO
+  /// instructions in \p havoc_program that encode the havocing of the target
+  /// write set \p write_set_to_havoc.
+  ///
+  /// \param[in] function_id function id to use for prefixing fresh variables
+  /// \param[in] mode function id to use for prefixing fresh variables
+  /// \param[in] module function id to use for prefixing fresh variables
+  /// \param[in] original_program program from which to derive the havoc program
+  /// \param[in] write_set_to_havoc write set symbol to havoc
+  /// \param[out] havoc_program destination program for havoc instructions
+  /// \param[out] nof_targets max number of havoc targets discovered
+  ///
+  void generate_havoc_instructions(
+    const irep_idt &function_id,
+    const irep_idt &mode,
+    const irep_idt &module,
+    const goto_programt &original_program,
+    const exprt &write_set_to_havoc,
+    goto_programt &havoc_program,
+    std::size_t &nof_targets);
+
   /// Transforms (in place) a function
   ///
   /// ```
@@ -103,6 +135,29 @@ public:
   ///
   void to_spec_assigns_function(
     const irep_idt &function_id,
+    std::size_t &nof_targets);
+
+  /// Rewrites in place \p program expressed in terms of built-ins specifying
+  /// assignable targets declaratively using `__CPROVER_assignable`,
+  /// `__CPROVER_object_whole`, `__CPROVER_object_from`,
+  /// `__CPROVER_object_upto` into a program populating \p write_set_to_fill.
+  ///
+  /// It is the responsibility of the caller of this method to instrument the
+  /// resulting program against another write set instance to check them for
+  /// unwanted side effects.
+  ///
+  /// \pre The \p program must be already fully inlined, and the only
+  /// function calls allowed are to the built-ins that specify
+  /// assignable targets: `__CPROVER_assignable`, `__CPROVER_object_whole`,
+  /// `__CPROVER_object_from`, `__CPROVER_object_upto`.
+  ///
+  /// \param[in] write_set_to_fill write set to populate.
+  /// \param[inout] program function to transform in place
+  /// \param[out] nof_targets receives the estimated size of the write set
+  ///
+  void to_spec_assigns_instructions(
+    const exprt &write_set_to_fill,
+    goto_programt &program,
     std::size_t &nof_targets);
 
   /// Transforms (in place) a function
@@ -132,6 +187,27 @@ public:
   ///
   void
   to_spec_frees_function(const irep_idt &function_id, std::size_t &nof_targets);
+
+  /// Rewrites in place \p program expressed in terms of built-ins specifying
+  /// freeable targets declaratively using `__CPROVER_freeable` into a program
+  /// populating \p write_set_to_fill.
+  ///
+  /// It is the responsibility of the caller of this method to instrument the
+  /// resulting program against another write set instance to check them for
+  /// unwanted side effects.
+  ///
+  /// \pre The \p program must be already fully inlined, and the only
+  /// function calls allowed are to the built-ins that specify
+  /// freeable targets: `__CPROVER_freeable`.
+  ///
+  /// \param[in] write_set_to_fill write set to populate.
+  /// \param[inout] program function to transform in place
+  /// \param[out] nof_targets receives the estimated size of the write set
+  ///
+  void to_spec_frees_instructions(
+    const exprt &write_set_to_fill,
+    goto_programt &program,
+    std::size_t &nof_targets);
 
 protected:
   goto_modelt &goto_model;

--- a/src/goto-instrument/contracts/dynamic-frames/dfcc_utils.h
+++ b/src/goto-instrument/contracts/dynamic-frames/dfcc_utils.h
@@ -20,6 +20,7 @@ Date: August 2022
 #include <set>
 
 class goto_modelt;
+class goto_programt;
 class message_handlert;
 class symbolt;
 
@@ -212,6 +213,22 @@ public:
 
   /// \returns True iff \p function_id is loop free.
   bool has_no_loops(const irep_idt &function_id);
+
+  /// \brief Inlines the given program, aborts on recursive calls during
+  /// inlining.
+  void inline_program(goto_programt &program);
+
+  /// \brief Inlines the given program, and returns function symbols that
+  /// caused warnings.
+  void inline_program(
+    goto_programt &goto_program,
+    std::set<irep_idt> &no_body,
+    std::set<irep_idt> &recursive_call,
+    std::set<irep_idt> &missing_function,
+    std::set<irep_idt> &not_enough_arguments);
+
+  /// \returns True iff \p goto_program is loop free.
+  bool has_no_loops(const goto_programt &goto_program);
 
   /// \brief Sets the given hide flag on all instructions of the function if it
   /// exists.

--- a/src/goto-instrument/contracts/dynamic-frames/dfcc_wrapper_program.cpp
+++ b/src/goto-instrument/contracts/dynamic-frames/dfcc_wrapper_program.cpp
@@ -30,6 +30,14 @@ Author: Remi Delmas, delmasrd@amazon.com
 #include "dfcc_lift_memory_predicates.h"
 #include "dfcc_utils.h"
 
+/// Lift a c++ bool to an exprt
+static exprt to_bool_expr(bool v)
+{
+  if(v)
+    return true_exprt();
+  return false_exprt();
+}
+
 /// Generate the contract write set
 const symbol_exprt create_contract_write_set(
   dfcc_utilst &utils,
@@ -299,45 +307,18 @@ void dfcc_wrapper_programt::encode_requires_write_set()
   preamble.add(goto_programt::make_assignment(
     address_of_write_set, address_of_exprt(write_set), wrapper_sl));
 
-  auto function_symbol =
-    library.dfcc_fun_symbol[dfcc_funt::WRITE_SET_CREATE].symbol_expr();
-  code_function_callt call(function_symbol);
-  auto &arguments = call.arguments();
-
-  // write set
-  arguments.emplace_back(address_of_write_set);
-
-  // max assigns clause size
-  arguments.emplace_back(from_integer(0, size_type()));
-
-  // max frees clause size
-  arguments.emplace_back(from_integer(0, size_type()));
-
-  // replacement mode
-  arguments.push_back(false_exprt());
-
-  if(contract_mode == dfcc_contract_modet::CHECK)
-  {
-    // assume_requires_ctx
-    arguments.push_back(true_exprt());
-
-    // assert_requires_ctx
-    arguments.push_back(false_exprt());
-  }
-  else
-  {
-    // assume_requires_ctx
-    arguments.push_back(false_exprt());
-
-    // assert_requires_ctx mode
-    arguments.push_back(true_exprt());
-  }
-
-  // assume_ensures_ctx mode
-  arguments.push_back(false_exprt());
-
-  // assert_ensures_ctx mode
-  arguments.push_back(false_exprt());
+  bool check_mode = contract_mode == dfcc_contract_modet::CHECK;
+  code_function_callt call = library.write_set_create_call(
+    address_of_write_set,
+    from_integer(0, size_type()),
+    from_integer(0, size_type()),
+    to_bool_expr(check_mode),
+    to_bool_expr(!check_mode),
+    false_exprt(),
+    false_exprt(),
+    true_exprt(),
+    true_exprt(),
+    wrapper_sl);
 
   preamble.add(goto_programt::make_function_call(call, wrapper_sl));
 
@@ -360,13 +341,8 @@ void dfcc_wrapper_programt::encode_requires_write_set()
   postamble.add(goto_programt::make_decl(check_var, wrapper_sl));
 
   postamble.add(goto_programt::make_function_call(
-    code_function_callt{
-      check_var,
-      library
-        .dfcc_fun_symbol
-          [dfcc_funt::WRITE_SET_CHECK_ALLOCATED_DEALLOCATED_IS_EMPTY]
-        .symbol_expr(),
-      {address_of_write_set}},
+    library.write_set_check_allocated_deallocated_is_empty_call(
+      check_var, address_of_write_set, wrapper_sl),
     wrapper_sl));
 
   source_locationt check_sl(wrapper_sl);
@@ -378,13 +354,10 @@ void dfcc_wrapper_programt::encode_requires_write_set()
   postamble.add(goto_programt::make_dead(check_var, wrapper_sl));
 
   // generate write set release and DEAD instructions
-  {
-    code_function_callt call(
-      library.dfcc_fun_symbol[dfcc_funt::WRITE_SET_RELEASE].symbol_expr(),
-      {address_of_write_set});
-    postamble.add(goto_programt::make_function_call(call, wrapper_sl));
-    postamble.add(goto_programt::make_dead(write_set, wrapper_sl));
-  }
+  postamble.add(goto_programt::make_function_call(
+    library.write_set_release_call(address_of_write_set, wrapper_sl),
+    wrapper_sl));
+  postamble.add(goto_programt::make_dead(write_set, wrapper_sl));
 }
 
 void dfcc_wrapper_programt::encode_ensures_write_set()
@@ -393,7 +366,6 @@ void dfcc_wrapper_programt::encode_ensures_write_set()
   //   ensures_write_set,
   //   assigns_size = 0,
   //   frees_size = 0,
-  //   replacement_mode = false,
   //   assume_requires_ctx = false,
   //   assert_requires_ctx = false,
   //   assume_ensures_ctx = contract_mode != check,
@@ -407,59 +379,29 @@ void dfcc_wrapper_programt::encode_ensures_write_set()
   preamble.add(goto_programt::make_assignment(
     address_of_write_set, address_of_exprt(write_set), wrapper_sl));
 
-  auto function_symbol =
-    library.dfcc_fun_symbol[dfcc_funt::WRITE_SET_CREATE].symbol_expr();
-  code_function_callt call(function_symbol);
-  auto &arguments = call.arguments();
+  bool check_mode = contract_mode == dfcc_contract_modet::CHECK;
 
-  // write set
-  arguments.emplace_back(address_of_write_set);
+  code_function_callt call = library.write_set_create_call(
+    address_of_write_set,
+    from_integer(0, size_type()),
+    from_integer(0, size_type()),
+    false_exprt(),
+    false_exprt(),
+    to_bool_expr(!check_mode),
+    to_bool_expr(check_mode),
+    true_exprt(),
+    true_exprt(),
+    wrapper_sl);
 
-  // max assigns clause size
-  arguments.emplace_back(from_integer(0, size_type()));
-
-  // max frees clause size
-  arguments.emplace_back(from_integer(0, size_type()));
-
-  // replacement mode
-  arguments.push_back(false_exprt());
-
-  // assume_requires_ctx
-  arguments.push_back(false_exprt());
-
-  // assume_requires_ctx
-  arguments.push_back(false_exprt());
-
-  if(contract_mode == dfcc_contract_modet::CHECK)
-  {
-    // assume_ensures_ctx
-    arguments.push_back(false_exprt());
-
-    // assert_ensures_ctx
-    arguments.push_back(true_exprt());
-  }
-  else
-  {
-    // assume_ensures_ctx
-    arguments.push_back(true_exprt());
-
-    // assert_ensures_ctx
-    arguments.push_back(false_exprt());
-  }
-
-  preamble.add(goto_programt::make_function_call(call));
+  preamble.add(goto_programt::make_function_call(call, wrapper_sl));
 
   // call link_allocated(pre_post, caller) if in REPLACE MODE
   if(contract_mode == dfcc_contract_modet::REPLACE)
   {
-    auto function_symbol =
-      library.dfcc_fun_symbol[dfcc_funt::LINK_ALLOCATED].symbol_expr();
-    code_function_callt call(function_symbol);
-    auto &arguments = call.arguments();
-    arguments.emplace_back(address_of_write_set);
-    arguments.emplace_back(caller_write_set);
-    link_allocated_caller.add(
-      goto_programt::make_function_call(call, wrapper_sl));
+    link_allocated_caller.add(goto_programt::make_function_call(
+      library.link_allocated_call(
+        address_of_write_set, caller_write_set, wrapper_sl),
+      wrapper_sl));
   }
 
   // check for absence of allocation/deallocation in contract clauses
@@ -481,13 +423,8 @@ void dfcc_wrapper_programt::encode_ensures_write_set()
   postamble.add(goto_programt::make_decl(check_var, wrapper_sl));
 
   postamble.add(goto_programt::make_function_call(
-    code_function_callt{
-      check_var,
-      library
-        .dfcc_fun_symbol
-          [dfcc_funt::WRITE_SET_CHECK_ALLOCATED_DEALLOCATED_IS_EMPTY]
-        .symbol_expr(),
-      {address_of_write_set}},
+    library.write_set_check_allocated_deallocated_is_empty_call(
+      check_var, address_of_write_set, wrapper_sl),
     wrapper_sl));
 
   source_locationt check_sl(wrapper_sl);
@@ -501,9 +438,7 @@ void dfcc_wrapper_programt::encode_ensures_write_set()
 
   // generate write set release
   postamble.add(goto_programt::make_function_call(
-    code_function_callt{
-      library.dfcc_fun_symbol[dfcc_funt::WRITE_SET_RELEASE].symbol_expr(),
-      {address_of_write_set}},
+    library.write_set_release_call(address_of_write_set, wrapper_sl),
     wrapper_sl));
 
   // declare write set DEAD
@@ -527,43 +462,18 @@ void dfcc_wrapper_programt::encode_contract_write_set()
 
   // call write_set_create
   {
-    auto function_symbol =
-      library.dfcc_fun_symbol[dfcc_funt::WRITE_SET_CREATE].symbol_expr();
-
-    code_function_callt call(function_symbol);
-    auto &arguments = call.arguments();
-
-    // write set
-    arguments.emplace_back(address_of_contract_write_set);
-
-    // max assigns clause size
-    arguments.emplace_back(
-      from_integer(contract_functions.get_nof_assigns_targets(), size_type()));
-
-    // max frees clause size
-    arguments.emplace_back(
-      from_integer(contract_functions.get_nof_frees_targets(), size_type()));
-
-    // activate replace mode
-    const bool replace = contract_mode == dfcc_contract_modet::REPLACE;
-    arguments.emplace_back(
-      (replace ? (exprt)true_exprt() : (exprt)false_exprt()));
-
-    // not analysing ensures or requires clauses, set all context flags to false
-
-    // assume_requires_ctx
-    arguments.push_back(false_exprt());
-
-    // assert_requires_ctx
-    arguments.push_back(false_exprt());
-
-    // assume_ensures_ctx
-    arguments.push_back(false_exprt());
-
-    // assert_ensures_ctx
-    arguments.push_back(false_exprt());
-
-    write_set_checks.add(goto_programt::make_function_call(call));
+    code_function_callt call = library.write_set_create_call(
+      address_of_contract_write_set,
+      from_integer(contract_functions.get_nof_assigns_targets(), size_type()),
+      from_integer(contract_functions.get_nof_frees_targets(), size_type()),
+      false_exprt(),
+      false_exprt(),
+      false_exprt(),
+      false_exprt(),
+      true_exprt(),
+      true_exprt(),
+      wrapper_sl);
+    write_set_checks.add(goto_programt::make_function_call(call, wrapper_sl));
   }
 
   // build arguments for assigns and frees clauses functions
@@ -615,13 +525,10 @@ void dfcc_wrapper_programt::encode_contract_write_set()
   }
 
   // generate write set release and DEAD instructions
-  {
-    code_function_callt call(
-      library.dfcc_fun_symbol[dfcc_funt::WRITE_SET_RELEASE].symbol_expr(),
-      {address_of_contract_write_set});
-    postamble.add(goto_programt::make_function_call(call, wrapper_sl));
-    postamble.add(goto_programt::make_dead(write_set, wrapper_sl));
-  }
+  postamble.add(goto_programt::make_function_call(
+    library.write_set_release_call(address_of_contract_write_set, wrapper_sl),
+    wrapper_sl));
+  postamble.add(goto_programt::make_dead(write_set, wrapper_sl));
 }
 
 void dfcc_wrapper_programt::encode_is_fresh_set()
@@ -636,31 +543,25 @@ void dfcc_wrapper_programt::encode_is_fresh_set()
 
   // CALL obj_set_create_indexed_by_object_id(is_fresh_set) in preamble
   preamble.add(goto_programt::make_function_call(
-    code_function_callt{
-      library.dfcc_fun_symbol[dfcc_funt::OBJ_SET_CREATE_INDEXED_BY_OBJECT_ID]
-        .symbol_expr(),
-      {address_of_object_set}},
+    library.obj_set_create_indexed_by_object_id_call(
+      address_of_object_set, wrapper_sl),
     wrapper_sl));
 
   // link to requires write set
   link_is_fresh.add(goto_programt::make_function_call(
-    code_function_callt(
-      library.dfcc_fun_symbol[dfcc_funt::LINK_IS_FRESH].symbol_expr(),
-      {addr_of_requires_write_set, address_of_object_set}),
+    library.link_is_fresh_call(
+      addr_of_requires_write_set, address_of_object_set, wrapper_sl),
     wrapper_sl));
 
   // link to ensures write set
   link_is_fresh.add(goto_programt::make_function_call(
-    code_function_callt(
-      library.dfcc_fun_symbol[dfcc_funt::LINK_IS_FRESH].symbol_expr(),
-      {addr_of_ensures_write_set, address_of_object_set}),
+    library.link_is_fresh_call(
+      addr_of_ensures_write_set, address_of_object_set, wrapper_sl),
     wrapper_sl));
 
   // release call in postamble
   postamble.add(goto_programt::make_function_call(
-    code_function_callt(
-      library.dfcc_fun_symbol[dfcc_funt::OBJ_SET_RELEASE].symbol_expr(),
-      {address_of_object_set}),
+    library.obj_set_release_call(address_of_object_set, wrapper_sl),
     wrapper_sl));
 
   // DEAD instructions in postamble
@@ -764,13 +665,10 @@ void dfcc_wrapper_programt::encode_ensures_clauses()
   // When checking an ensures clause we link the contract write set to the
   // ensures write set to know what was deallocated by the function so that
   // the was_freed predicate can perform its checks
-  code_function_callt call(
-    library.dfcc_fun_symbol[dfcc_funt::LINK_DEALLOCATED].symbol_expr());
-  auto &arguments = call.arguments();
-  arguments.emplace_back(address_of_ensures_write_set);
-  arguments.emplace_back(addr_of_contract_write_set);
-  link_deallocated_contract.add(
-    goto_programt::make_function_call(call, wrapper_sl));
+  link_deallocated_contract.add(goto_programt::make_function_call(
+    library.link_deallocated_call(
+      address_of_ensures_write_set, addr_of_contract_write_set, wrapper_sl),
+    wrapper_sl));
 
   // fix calls to user-defined user-defined memory predicates
   memory_predicates.fix_calls(ensures_program);
@@ -876,15 +774,11 @@ void dfcc_wrapper_programt::encode_havoced_function_call()
 
     write_set_checks.add(goto_programt::make_decl(check_var, wrapper_sl));
 
-    code_function_callt check_incl_call(
-      check_var,
-      library
-        .dfcc_fun_symbol[dfcc_funt::WRITE_SET_CHECK_ASSIGNS_CLAUSE_INCLUSION]
-        .symbol_expr(),
-      {caller_write_set, address_of_contract_write_set});
+    write_set_checks.add(goto_programt::make_function_call(
+      library.write_set_check_assigns_clause_inclusion_call(
+        check_var, caller_write_set, address_of_contract_write_set, wrapper_sl),
+      wrapper_sl));
 
-    write_set_checks.add(
-      goto_programt::make_function_call(check_incl_call, wrapper_sl));
     source_locationt check_sl(wrapper_sl);
     check_sl.set_function(wrapper_symbol.name);
     check_sl.set_property_class("assigns");
@@ -908,14 +802,10 @@ void dfcc_wrapper_programt::encode_havoced_function_call()
 
     write_set_checks.add(goto_programt::make_decl(check_var, wrapper_sl));
 
-    code_function_callt check_incl_call(
-      check_var,
-      library.dfcc_fun_symbol[dfcc_funt::WRITE_SET_CHECK_FREES_CLAUSE_INCLUSION]
-        .symbol_expr(),
-      {caller_write_set, address_of_contract_write_set});
-
-    write_set_checks.add(
-      goto_programt::make_function_call(check_incl_call, wrapper_sl));
+    write_set_checks.add(goto_programt::make_function_call(
+      library.write_set_check_frees_clause_inclusion_call(
+        check_var, caller_write_set, address_of_contract_write_set, wrapper_sl),
+      wrapper_sl));
 
     source_locationt check_sl(wrapper_sl);
     check_sl.set_function(wrapper_symbol.name);
@@ -960,10 +850,8 @@ void dfcc_wrapper_programt::encode_havoced_function_call()
 
   // nondet free the freeable set, record effects in both the contract write
   // set and the caller write set
-  code_function_callt deallocate_call(
-    library.dfcc_fun_symbol[dfcc_funt::WRITE_SET_DEALLOCATE_FREEABLE]
-      .symbol_expr(),
-    {address_of_contract_write_set, caller_write_set});
-  function_call.add(
-    goto_programt::make_function_call(deallocate_call, wrapper_sl));
+  function_call.add(goto_programt::make_function_call(
+    library.write_set_deallocate_freeable_call(
+      address_of_contract_write_set, caller_write_set, wrapper_sl),
+    wrapper_sl));
 }

--- a/src/goto-instrument/contracts/dynamic-frames/dfcc_wrapper_program.cpp
+++ b/src/goto-instrument/contracts/dynamic-frames/dfcc_wrapper_program.cpp
@@ -30,14 +30,6 @@ Author: Remi Delmas, delmasrd@amazon.com
 #include "dfcc_lift_memory_predicates.h"
 #include "dfcc_utils.h"
 
-/// Lift a c++ bool to an exprt
-static exprt to_bool_expr(bool v)
-{
-  if(v)
-    return true_exprt();
-  return false_exprt();
-}
-
 /// Generate the contract write set
 const symbol_exprt create_contract_write_set(
   dfcc_utilst &utils,
@@ -312,8 +304,8 @@ void dfcc_wrapper_programt::encode_requires_write_set()
     address_of_write_set,
     from_integer(0, size_type()),
     from_integer(0, size_type()),
-    to_bool_expr(check_mode),
-    to_bool_expr(!check_mode),
+    make_boolean_expr(check_mode),
+    make_boolean_expr(!check_mode),
     false_exprt(),
     false_exprt(),
     true_exprt(),
@@ -387,8 +379,8 @@ void dfcc_wrapper_programt::encode_ensures_write_set()
     from_integer(0, size_type()),
     false_exprt(),
     false_exprt(),
-    to_bool_expr(!check_mode),
-    to_bool_expr(check_mode),
+    make_boolean_expr(!check_mode),
+    make_boolean_expr(check_mode),
     true_exprt(),
     true_exprt(),
     wrapper_sl);


### PR DESCRIPTION
This PR refactors the DFCC code to make it possible to handle loop assigns clauses in https://github.com/diffblue/cbmc/pull/7541.

We now have a standalone class `dfcc_contract_clauses_codegent` which provides methods to generate GOTO programs that initialize a dynamic frame instance from an assigns clause specification or havoc the targets of an assigns clause.

Before, these code generation methods were encapsulated inside the class `dfcc_contract_functionst` which exclusively handles function contracts. This makes them available for loop contracts as well.

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

