### PR TITLE
Simplify tests of is-null that use integer types

### DIFF
--- a/regression/cbmc/null8/main.c
+++ b/regression/cbmc/null8/main.c
@@ -1,0 +1,12 @@
+union U
+{
+  void *ptr;
+  __CPROVER_size_t n;
+};
+
+int main()
+{
+  int *p = __CPROVER_allocate(sizeof(int), 0);
+  union U u = {.ptr = p};
+  __CPROVER_assert(u.n != 0, "is not null");
+}

--- a/regression/cbmc/null8/test.desc
+++ b/regression/cbmc/null8/test.desc
@@ -1,0 +1,9 @@
+CORE new-smt-backend
+main.c
+
+Generated 1 VCC\(s\), 0 remaining after simplification
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring


### PR DESCRIPTION
Injecting casts to integer types should not hamper our ability to simplify tests for null-ness. Such expressions emerge from Rust code, see https://github.com/model-checking/kani/issues/2191.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
