### PR TITLE
protect array_typet::subtype and vector_typet::subtype

### DIFF
--- a/src/solvers/flattening/boolbv_get.cpp
+++ b/src/solvers/flattening/boolbv_get.cpp
@@ -339,7 +339,7 @@ exprt boolbvt::bv_get_unbounded_array(const exprt &expr) const
         {
           if(value.is_nil())
             values[*index_mpint] =
-              exprt(ID_unknown, to_array_type(type).subtype());
+              exprt(ID_unknown, to_array_type(type).element_type());
           else
             values[*index_mpint] = value;
         }

--- a/src/solvers/strings/string_refinement.cpp
+++ b/src/solvers/strings/string_refinement.cpp
@@ -927,7 +927,7 @@ void string_refinementt::add_lemma(
     {
       it.mutate() = array_of_exprt(
         from_integer(
-          CHARACTER_FOR_UNKNOWN, to_array_type(it->type()).subtype()),
+          CHARACTER_FOR_UNKNOWN, to_array_type(it->type()).element_type()),
         to_array_type(it->type()));
       it.next_sibling_or_parent();
     }
@@ -1032,7 +1032,7 @@ static optionalt<exprt> get_array(
   }
 
   const exprt arr_val = simplify_expr(super_get(arr), ns);
-  const typet char_type = to_array_type(arr.type()).subtype();
+  const typet char_type = to_array_type(arr.type()).element_type();
   const typet &index_type = size.value().type();
 
   if(

--- a/src/util/std_types.h
+++ b/src/util/std_types.h
@@ -780,16 +780,12 @@ public:
   }
 
   /// The type of the elements of the array.
-  /// This method is preferred over .subtype(),
-  /// which will eventually be deprecated.
   const typet &element_type() const
   {
     return subtype();
   }
 
   /// The type of the elements of the array.
-  /// This method is preferred over .subtype(),
-  /// which will eventually be deprecated.
   typet &element_type()
   {
     return subtype();
@@ -822,6 +818,10 @@ public:
   static void check(
     const typet &type,
     const validation_modet vm = validation_modet::INVARIANT);
+
+protected:
+  // Use element_type() instead
+  using type_with_subtypet::subtype;
 };
 
 /// Check whether a reference to a typet is a \ref array_typet.
@@ -1021,16 +1021,12 @@ public:
   }
 
   /// The type of the elements of the vector.
-  /// This method is preferred over .subtype(),
-  /// which will eventually be deprecated.
   const typet &element_type() const
   {
     return subtype();
   }
 
   /// The type of the elements of the vector.
-  /// This method is preferred over .subtype(),
-  /// which will eventually be deprecated.
   typet &element_type()
   {
     return subtype();
@@ -1038,6 +1034,10 @@ public:
 
   const constant_exprt &size() const;
   constant_exprt &size();
+
+protected:
+  // Use element_type() instead
+  using type_with_subtypet::subtype;
 };
 
 /// Check whether a reference to a typet is a \ref vector_typet.


### PR DESCRIPTION
This protects the deprecated methods `array_typet::subtype()` and `vector_typet::subtype()` and replaces the remaining three users by `.element_type()`.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- n/a Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
