### PR TITLE
remove typet::subtype()

### DIFF
--- a/src/cpp/cpp_template_type.h
+++ b/src/cpp/cpp_template_type.h
@@ -34,7 +34,17 @@ public:
     return (const template_parameterst &)find(ID_template_parameters).get_sub();
   }
 
-  using typet::subtype;
+  const typet &subtype() const
+  {
+    if(get_sub().empty())
+      return static_cast<const typet &>(get_nil_irep());
+    return static_cast<const typet &>(get_sub().front());
+  }
+
+  typet &subtype()
+  {
+    return add_subtype();
+  }
 };
 
 inline template_typet &to_template_type(typet &type)

--- a/src/util/c_types.h
+++ b/src/util/c_types.h
@@ -22,7 +22,7 @@ public:
   explicit c_bit_field_typet(typet _subtype, std::size_t width)
     : bitvector_typet(ID_c_bit_field, width)
   {
-    subtype().swap(_subtype);
+    add_subtype() = std::move(_subtype);
   }
 
   // These have a sub-type. The preferred way to access it
@@ -35,6 +35,28 @@ public:
   typet &underlying_type()
   {
     return subtype();
+  }
+
+  // Use .underlying_type() instead -- this method will be removed
+  const typet &subtype() const
+  {
+    // The existence of get_sub() front is enforced by check(...)
+    return static_cast<const typet &>(get_sub().front());
+  }
+
+  // Use .underlying_type() instead -- this method will be removed
+  typet &subtype()
+  {
+    // The existence of get_sub() front is enforced by check(...)
+    return static_cast<typet &>(get_sub().front());
+  }
+
+  static void check(
+    const typet &type,
+    const validation_modet vm = validation_modet::INVARIANT)
+  {
+    bitvector_typet::check(type, vm);
+    type_with_subtypet::check(type, vm);
   }
 };
 
@@ -58,7 +80,7 @@ inline bool can_cast_type<c_bit_field_typet>(const typet &type)
 inline const c_bit_field_typet &to_c_bit_field_type(const typet &type)
 {
   PRECONDITION(can_cast_type<c_bit_field_typet>(type));
-  type_with_subtypet::check(type);
+  c_bit_field_typet::check(type);
   return static_cast<const c_bit_field_typet &>(type);
 }
 

--- a/src/util/pointer_expr.h
+++ b/src/util/pointer_expr.h
@@ -26,7 +26,7 @@ public:
   pointer_typet(typet _base_type, std::size_t width)
     : bitvector_typet(ID_pointer, width)
   {
-    subtype().swap(_base_type);
+    add_subtype() = std::move(_base_type);
   }
 
   /// The type of the data what we point to.
@@ -45,6 +45,20 @@ public:
     return subtype();
   }
 
+  // Use .base_type() instead -- this method will be removed
+  const typet &subtype() const
+  {
+    // The existence of get_sub() front is enforced by check(...)
+    return static_cast<const typet &>(get_sub().front());
+  }
+
+  // Use .base_type() instead -- this method will be removed
+  typet &subtype()
+  {
+    // The existence of get_sub() front is enforced by check(...)
+    return static_cast<typet &>(get_sub().front());
+  }
+
   signedbv_typet difference_type() const
   {
     return signedbv_typet(get_width());
@@ -54,8 +68,8 @@ public:
     const typet &type,
     const validation_modet vm = validation_modet::INVARIANT)
   {
+    bitvector_typet::check(type, vm);
     type_with_subtypet::check(type);
-    DATA_CHECK(vm, !type.get(ID_width).empty(), "pointer must have width");
   }
 };
 

--- a/src/util/type.h
+++ b/src/util/type.h
@@ -41,28 +41,10 @@ public:
 #else
   typet(irep_idt _id, typet _subtype) : irept(std::move(_id))
   {
-    subtype() = std::move(_subtype);
+    add_subtype() = std::move(_subtype);
   }
 #endif
 
-  // Deliberately protected -- use type-specific accessor methods instead.
-protected:
-  const typet &subtype() const
-  {
-    if(get_sub().empty())
-      return static_cast<const typet &>(get_nil_irep());
-    return static_cast<const typet &>(get_sub().front());
-  }
-
-  typet &subtype()
-  {
-    subt &sub=get_sub();
-    if(sub.empty())
-      sub.resize(1);
-    return static_cast<typet &>(sub.front());
-  }
-
-public:
   // This method allows the construction of a type with a subtype by
   // starting from a type without subtype.  It avoids copying the contents
   // of the type.  The primary use-case are parsers, where a copy could be


### PR DESCRIPTION
This adds specialised variants of `typet::subtype()` to the three inheriting classes that use the method.  These cannot use `type_with_subtypet` since C++ doesn't have mixins.  The plan is to remove these methods in favor of the existing type-specific accessor methods.

After that, `typet::subtype()` can be removed.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
