### PR TITLE
Minor formatting fix to contracts help

### DIFF
--- a/src/goto-instrument/contracts/dynamic-frames/dfcc.h
+++ b/src/goto-instrument/contracts/dynamic-frames/dfcc.h
@@ -58,8 +58,9 @@ class optionst;
 
 // clang-format off
 #define HELP_DFCC                                                              \
-  " --dfcc <harness>   activate dynamic frame condition checking for function\n"\
-  "                    contracts using the given harness as entry point\n"
+  " --dfcc <harness>             activate dynamic frame condition checking\n"\
+  "                              for function contracts using the given\n"\
+  "                              harness as entry point\n"
 
 #define FLAG_ENFORCE_CONTRACT_REC "enforce-contract-rec"
 #define OPT_ENFORCE_CONTRACT_REC "(" FLAG_ENFORCE_CONTRACT_REC "):"

--- a/src/goto-instrument/contracts/dynamic-frames/dfcc.h
+++ b/src/goto-instrument/contracts/dynamic-frames/dfcc.h
@@ -58,8 +58,8 @@ class optionst;
 
 // clang-format off
 #define HELP_DFCC                                                              \
-  "--dfcc <harness>   activate dynamic frame condition checking for function\n"\
-  "                   contracts using the given harness as entry point"
+  " --dfcc <harness>   activate dynamic frame condition checking for function\n"\
+  "                    contracts using the given harness as entry point\n"
 
 #define FLAG_ENFORCE_CONTRACT_REC "enforce-contract-rec"
 #define OPT_ENFORCE_CONTRACT_REC "(" FLAG_ENFORCE_CONTRACT_REC "):"
@@ -67,7 +67,7 @@ class optionst;
   " --enforce-contract-rec <function>[/<contract>]"                            \
   "                               wrap fun with an assertion of the contract\n"\
   "                               and assume recursive calls to fun satisfy \n"\
-  "                               the contract"
+  "                               the contract\n"
 // clang-format on
 
 /// Exception thrown for bad function/contract specification pairs passed on

--- a/src/goto-instrument/goto_instrument_parse_options.cpp
+++ b/src/goto-instrument/goto_instrument_parse_options.cpp
@@ -1980,11 +1980,11 @@ void goto_instrument_parse_optionst::help()
     "                              used with aggressive-slice, preserves all functions within <n> function calls\n" // NOLINT(*)
     "                              of the functions on the shortest path\n"
     " --aggressive-slice-preserve-function <f>\n"
-    "                             force the aggressive slicer to preserve function <f>\n" // NOLINT(*)
+    "                              force the aggressive slicer to preserve function <f>\n" // NOLINT(*)
     " --aggressive-slice-preserve-functions-containing <f>\n"
     "                              force the aggressive slicer to preserve all functions with names containing <f>\n" // NOLINT(*)
     " --aggressive-slice-preserve-all-direct-paths \n"
-    "                             force aggressive slicer to preserve all direct paths\n" // NOLINT(*)
+    "                              force aggressive slicer to preserve all direct paths\n" // NOLINT(*)
     "\n"
     "Code contracts:\n"
     HELP_DFCC


### PR DESCRIPTION
<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

Minor formatting fixes to the contracts section of `goto-instrument --help`. Primarily added missing newlines without which the `--apply-loop-contracts` option was appearing with the previous option. This is the output diff:
```diff
242c242
<                              force the aggressive slicer to preserve function <f>
---
>                               force the aggressive slicer to preserve function <f>
246c246
<                              force aggressive slicer to preserve all direct paths
---
>                               force aggressive slicer to preserve all direct paths
249,250c249,252
< --dfcc <harness>   activate dynamic frame condition checking for function
<                    contracts using the given harness as entry point --apply-loop-contracts
---
>  --dfcc <harness>             activate dynamic frame condition checking
>                               for function contracts using the given
>                               harness as entry point
>  --apply-loop-contracts
```

- [X] Each commit message has a non-empty body, explaining why the change was made.
- [X] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [X] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [X] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [X] My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- [X] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
