### PR TITLE
remove three deprecated goto_instructiont methods

### DIFF
--- a/src/cprover/cprover_parse_options.cpp
+++ b/src/cprover/cprover_parse_options.cpp
@@ -62,7 +62,7 @@ static void show_goto_functions(const goto_modelt &goto_model)
       std::cout << "^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n\n";
 
       std::cout << symbol.display_name() << " /* " << symbol.name << " */\n";
-      fun->second.body.output(ns, symbol.name, std::cout);
+      fun->second.body.output(std::cout);
     }
   }
 }

--- a/src/goto-instrument/cover_basic_blocks.cpp
+++ b/src/goto-instrument/cover_basic_blocks.cpp
@@ -163,7 +163,7 @@ void cover_basic_blockst::add_block_lines(
     }
   };
   add_location(instruction.source_location());
-  instruction.get_code().visit_pre([&](const exprt &expr) {
+  instruction.code().visit_pre([&](const exprt &expr) {
     const auto &location = expr.source_location();
     if(!location.get_function().empty())
       add_location(location);

--- a/src/goto-instrument/full_slicer.cpp
+++ b/src/goto-instrument/full_slicer.cpp
@@ -235,7 +235,7 @@ static bool implicit(goto_programt::const_targett target)
 {
   // some variables are used during symbolic execution only
 
-  const irep_idt &statement = target->get_code().get_statement();
+  const irep_idt &statement = target->code().get_statement();
   if(statement==ID_array_copy)
     return true;
 

--- a/src/goto-instrument/goto_program2code.cpp
+++ b/src/goto-instrument/goto_program2code.cpp
@@ -1964,8 +1964,8 @@ void goto_program2codet::copy_source_location(
   goto_programt::const_targett src,
   codet &dst)
 {
-  if(src->get_code().source_location().is_not_nil())
-    dst.add_source_location() = src->get_code().source_location();
+  if(src->code().source_location().is_not_nil())
+    dst.add_source_location() = src->code().source_location();
   else if(src->source_location().is_not_nil())
     dst.add_source_location() = src->source_location();
 }

--- a/src/goto-programs/goto_program.h
+++ b/src/goto-programs/goto_program.h
@@ -19,7 +19,6 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <limits>
 #include <string>
 
-#include <util/deprecate.h>
 #include <util/invariant.h>
 #include <util/source_location.h>
 
@@ -184,13 +183,6 @@ public:
     goto_instruction_codet _code;
 
   public:
-    /// Get the code represented by this instruction
-    DEPRECATED(SINCE(2021, 10, 12, "Use code() instead"))
-    const goto_instruction_codet &get_code() const
-    {
-      return _code;
-    }
-
     /// Get the code represented by this instruction
     const goto_instruction_codet &code() const
     {
@@ -734,29 +726,8 @@ public:
     return add(instructiont(type));
   }
 
-  /// Output goto program to given stream
-  DEPRECATED(SINCE(2022, 5, 29, "Use output(out) instead"))
-  std::ostream &output(
-    const namespacet &ns,
-    const irep_idt &identifier,
-    std::ostream &out) const
-  {
-    return output(out);
-  }
-
   /// Output goto-program to given stream
   std::ostream &output(std::ostream &out) const;
-
-  /// Output a single instruction
-  DEPRECATED(SINCE(2022, 5, 29, "Use instruction.output(out) instead"))
-  std::ostream &output_instruction(
-    const namespacet &ns,
-    const irep_idt &identifier,
-    std::ostream &out,
-    const instructionst::value_type &instruction) const
-  {
-    return instruction.output(out);
-  }
 
   /// Compute the target numbers
   void compute_target_numbers();


### PR DESCRIPTION
This removes three deprecated methods from `goto_programt::instructiont` and `goto_programt`.  Their replacement is straight-forward.  The remaining users are replaced accordingly.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
