### PR TITLE
Fix the doxygen for the `remove_asm.h` file

### DIFF
--- a/src/assembler/remove_asm.h
+++ b/src/assembler/remove_asm.h
@@ -11,8 +11,8 @@ Date:   December 2014
 
 /// \file
 /// Remove 'asm' statements by compiling them into suitable standard goto
-/// program instructions
-
+/// program instructions.
+///
 /// Inline assembly statements in the source program (in either gcc- or
 /// msc-style) are represented by instructions of kind `OTHER` with a `code`
 /// member of type `code_asmt` in the goto program.

--- a/src/assembler/remove_asm.h
+++ b/src/assembler/remove_asm.h
@@ -12,7 +12,7 @@ Date:   December 2014
 /// \file
 /// Remove 'asm' statements by compiling them into suitable standard goto
 /// program instructions.
-///
+/// \details
 /// Inline assembly statements in the source program (in either gcc- or
 /// msc-style) are represented by instructions of kind `OTHER` with a `code`
 /// member of type `code_asmt` in the goto program.


### PR DESCRIPTION
This PR fixs the doxygen for the `remove_asm.h` file because it does not currently render correctly. The current doxygen output missing half the documentation in the file and it is rendered here - https://diffblue.github.io/cbmc/remove__asm_8h.html
<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
