### PR TITLE
ITE and binary relations are constant when all operands are constants

### DIFF
--- a/regression/cbmc/constant_folding3/main.c
+++ b/regression/cbmc/constant_folding3/main.c
@@ -1,0 +1,8 @@
+int main(void)
+{
+  int x;
+  int plus_one_is_null = &x + 1 == (int *)0 ? 1 : 0;
+  __CPROVER_assert(plus_one_is_null != 2, "cannot be 2");
+
+  return 0;
+}

--- a/regression/cbmc/constant_folding3/test.desc
+++ b/regression/cbmc/constant_folding3/test.desc
@@ -1,0 +1,9 @@
+CORE new-smt-backend
+main.c
+
+^Generated 1 VCC\(s\), 0 remaining after simplification$
+^VERIFICATION SUCCESSFUL$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring

--- a/src/util/expr_util.cpp
+++ b/src/util/expr_util.cpp
@@ -239,8 +239,12 @@ bool is_constantt::is_constant(const exprt &expr) const
     expr.id() == ID_typecast || expr.id() == ID_array_of ||
     expr.id() == ID_plus || expr.id() == ID_mult || expr.id() == ID_array ||
     expr.id() == ID_with || expr.id() == ID_struct || expr.id() == ID_union ||
-    expr.id() == ID_empty_union ||
-    expr.id() == ID_byte_update_big_endian ||
+    expr.id() == ID_empty_union || expr.id() == ID_equal ||
+    expr.id() == ID_notequal || expr.id() == ID_lt || expr.id() == ID_le ||
+    expr.id() == ID_gt || expr.id() == ID_ge || expr.id() == ID_if ||
+    expr.id() == ID_not || expr.id() == ID_and || expr.id() == ID_or ||
+    expr.id() == ID_bitnot || expr.id() == ID_bitand || expr.id() == ID_bitor ||
+    expr.id() == ID_bitxor || expr.id() == ID_byte_update_big_endian ||
     expr.id() == ID_byte_update_little_endian)
   {
     return std::all_of(


### PR DESCRIPTION
This expands the definition of is_constantt to cover if-then-else as well as binary relations. In many, but not, cases the simplifier will have turned these into simpler constants. The included regression test is derived from Rust code, where the intermediate representation (together with constant propagation) will yield such comparisons.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
