### PR TITLE
Simplify overflow-result-minus over (X + n), X

### DIFF
--- a/regression/cbmc/gcc_builtin_sub_overflow/simplify.c
+++ b/regression/cbmc/gcc_builtin_sub_overflow/simplify.c
@@ -1,0 +1,13 @@
+#ifndef __GNUC__
+_Bool __builtin_sub_overflow();
+#endif
+
+int main(void)
+{
+  __CPROVER_size_t result;
+  int x;
+  __CPROVER_assert(
+    !__builtin_sub_overflow(
+      (__CPROVER_size_t)((char *)&x + 1), (__CPROVER_size_t)&x, &result),
+    "cannot overflow");
+}

--- a/regression/cbmc/gcc_builtin_sub_overflow/simplify.desc
+++ b/regression/cbmc/gcc_builtin_sub_overflow/simplify.desc
@@ -1,0 +1,9 @@
+CORE
+simplify.c
+
+^Generated 1 VCC\(s\), 0 remaining after simplification$
+^VERIFICATION SUCCESSFUL$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring


### PR DESCRIPTION
This evaluates to (possible element-size multiple of) n and n-is-not-representable.

This kind of expression is generated after constant propagation from code like
https://github.com/rust-lang/rust/blob/0b35f448f8e9f39ed6fc1c494eeb331afba513bc/library/core/src/slice/iter/macros.rs#L25..L29, where `X` will be some address-of expression.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
