### PR TITLE
Byte-operator lowering: do not unconditionally insert bv cast

### DIFF
--- a/src/util/lower_byte_operators.cpp
+++ b/src/util/lower_byte_operators.cpp
@@ -337,16 +337,21 @@ static exprt bv_to_expr(
 {
   PRECONDITION(can_cast_type<bitvector_typet>(bitvector_expr.type()));
 
-  if(
-    can_cast_type<bitvector_typet>(target_type) ||
-    target_type.id() == ID_c_enum || target_type.id() == ID_c_enum_tag ||
-    target_type.id() == ID_string)
+  if(target_type.id() == ID_floatbv)
   {
     std::size_t width = to_bitvector_type(bitvector_expr.type()).get_width();
     exprt bv_expr =
       typecast_exprt::conditional_cast(bitvector_expr, bv_typet{width});
     return simplify_expr(
       typecast_exprt::conditional_cast(bv_expr, target_type), ns);
+  }
+  else if(
+    can_cast_type<bitvector_typet>(target_type) ||
+    target_type.id() == ID_c_enum || target_type.id() == ID_c_enum_tag ||
+    target_type.id() == ID_string)
+  {
+    return simplify_expr(
+      typecast_exprt::conditional_cast(bitvector_expr, target_type), ns);
   }
 
   if(target_type.id() == ID_struct)


### PR DESCRIPTION
In 848e633b6770d a cast to bv was inserted to block interpreting floatbv type casts from taking place. It was unnecessarily inserted for all bitvector types. While this does not result in wrong semantics, it may block simplification for happening when we end up (via other simplifier rules) creating a bv (and not (un)signed bv) typed constant. All of these transformations are correct, but we may end up with an equality over pointer-typed constants where the underlying constant is a(n) (un)signed bv on one side, and a bv on the other side. The bit patterns match, so the back-end will correctly solve this, but the simplifier cannot.

Observed when studying
https://github.com/model-checking/kani/issues/1978.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
