### PR TITLE
Cache the merged version of goto_statet.guard into goto_statet.merged…

### DIFF
--- a/src/analyses/guard_expr.h
+++ b/src/analyses/guard_expr.h
@@ -14,6 +14,8 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <util/expr.h>
 
+#include "merge_irep.h"
+
 /// This is unused by this implementation of guards, but can be used by other
 /// implementations of the same interface.
 struct guard_expr_managert
@@ -34,6 +36,10 @@ public:
   {
     expr = other.expr;
     return *this;
+  }
+
+  void merge_guard(merge_irept& merge_irep){
+    merge_irep(expr);
   }
 
   void add(const exprt &expr);

--- a/src/goto-symex/frame.h
+++ b/src/goto-symex/frame.h
@@ -29,7 +29,7 @@ struct framet
   std::map<goto_programt::const_targett, goto_state_listt> goto_state_map;
   symex_targett::sourcet calling_location;
   std::vector<irep_idt> parameter_names;
-  guardt guard_at_function_start;
+  guardt guard_at_function_start; // merged
   goto_programt::const_targett end_of_function;
   exprt call_lhs = nil_exprt();                // cleaned, but not renamed
   optionalt<symbol_exprt> return_value_symbol; // not renamed

--- a/src/goto-symex/goto_state.h
+++ b/src/goto-symex/goto_state.h
@@ -54,7 +54,7 @@ public:
   // to be executed. The easiest example is an if/else: each instruction along
   // the if branch will be guarded by the condition of the if (and if there
   // is an else branch then instructions on it will be guarded by the negation
-  // of the condition of the if).
+  // of the condition of the if). Invariant: guard is always merged.
   guardt guard;
 
   /// Is this code reachable? If not we can take shortcuts such as not entering

--- a/src/goto-symex/symex_assign.cpp
+++ b/src/goto-symex/symex_assign.cpp
@@ -232,8 +232,10 @@ void symex_assignt::assign_non_struct_symbol(
       ? symex_targett::assignment_typet::HIDDEN
       : assignment_type;
 
+  exprt assignment_guard = make_and(state.guard.as_expr(), conjunction(guard));
+  target.merge_irep(assignment_guard);
   target.assignment(
-    make_and(state.guard.as_expr(), conjunction(guard)),
+    assignment_guard,
     l2_lhs,
     l2_full_lhs,
     get_original_name(l2_full_lhs),

--- a/src/goto-symex/symex_atomic_section.cpp
+++ b/src/goto-symex/symex_atomic_section.cpp
@@ -59,6 +59,7 @@ void goto_symext::symex_atomic_end(statet &state)
       read_guard|=*it;
     exprt read_guard_expr=read_guard.as_expr();
     do_simplify(read_guard_expr);
+    target.merge_irep(read_guard_expr);
 
     target.shared_read(
       read_guard_expr,
@@ -82,6 +83,7 @@ void goto_symext::symex_atomic_end(statet &state)
     exprt write_guard_expr=write_guard.as_expr();
     do_simplify(write_guard_expr);
 
+    target.merge_irep(write_guard_expr);
     target.shared_write(
       write_guard_expr,
       w,

--- a/src/goto-symex/symex_main.cpp
+++ b/src/goto-symex/symex_main.cpp
@@ -244,7 +244,10 @@ void goto_symext::symex_assume_l2(statet &state, const exprt &cond)
   // x=0;                   assume(x==1);
   // assert(x!=42);         x=42;
   else
+  {
     state.guard.add(rewritten_cond);
+    state.guard.merge_guard(target.merge_irep);
+  }
 
   if(state.atomic_section_id!=0 &&
      state.guard.is_false())

--- a/src/goto-symex/symex_other.cpp
+++ b/src/goto-symex/symex_other.cpp
@@ -48,10 +48,12 @@ void goto_symext::havoc_rec(
 
     guardt guard_t=state.guard;
     guard_t.add(if_expr.cond());
+    guard_t.merge_guard(target.merge_irep);
     havoc_rec(state, guard_t, if_expr.true_case());
 
     guardt guard_f=state.guard;
     guard_f.add(not_exprt(if_expr.cond()));
+    guard_f.merge_guard(target.merge_irep);
     havoc_rec(state, guard_f, if_expr.false_case());
   }
   else if(dest.id()==ID_typecast)

--- a/src/goto-symex/symex_target.h
+++ b/src/goto-symex/symex_target.h
@@ -12,6 +12,8 @@ Author: Daniel Kroening, kroening@kroening.com
 #ifndef CPROVER_GOTO_SYMEX_SYMEX_TARGET_H
 #define CPROVER_GOTO_SYMEX_SYMEX_TARGET_H
 
+#include <util/merge_irep.h>
+
 #include <goto-programs/goto_program.h>
 
 #include "renamed.h"
@@ -75,11 +77,14 @@ public:
     GUARD,
   };
 
+  merge_irept merge_irep;
+
   /// Read from a shared variable \p ssa_object (which is both the left- and the
   /// right--hand side of assignment): we effectively assign the value stored in
   /// \p ssa_object by another thread to \p ssa_object in the memory scope of
   /// this thread.
   /// \param guard: Precondition for this read event
+  /// \pre guard is merged
   /// \param ssa_object: Variable to be read from
   /// \param atomic_section_id: ID of the atomic section in which this read
   ///  takes place (if any)
@@ -93,6 +98,7 @@ public:
   /// Write to a shared variable \p ssa_object: we effectively assign a value
   /// from this thread to be visible by other threads.
   /// \param guard: Precondition for this write event
+  /// \pre guard is merged
   /// \param ssa_object: Variable to be written to
   /// \param atomic_section_id: ID of the atomic section in which this write
   ///  takes place (if any)
@@ -105,6 +111,7 @@ public:
 
   /// Write to a local variable. The `cond_expr` is _lhs==rhs_.
   /// \param guard: Precondition for this read event
+  /// \pre guard is merged
   /// \param ssa_lhs: Variable to be written to, must be a symbol (and not nil)
   /// \param ssa_full_lhs: Full left-hand side with symex level annotations
   /// \param original_full_lhs: Full left-hand side without symex level
@@ -125,6 +132,7 @@ public:
 
   /// Declare a fresh variable. The `cond_expr` is _lhs==lhs_.
   /// \param guard: Precondition for a declaration of this variable
+  /// \pre guard is merged
   /// \param ssa_lhs: Variable to be declared, must be symbol (and not nil)
   /// \param initializer: Initial value
   /// \param source: Pointer to location in the input GOTO program of this
@@ -150,6 +158,7 @@ public:
 
   /// Record a function call.
   /// \param guard: Precondition for calling a function
+  /// \pre guard is merged
   /// \param function_id: Name of the function
   /// \param ssa_function_arguments: Vector of arguments in SSA form
   /// \param source: To location in the input GOTO program of this
@@ -164,6 +173,7 @@ public:
 
   /// Record return from a function.
   /// \param guard: Precondition for returning from a function
+  /// \pre guard is merged
   /// \param function_id: Name of the function from which we return
   /// \param source: Pointer to location in the input GOTO program of this
   /// \param hidden: Should this step be recorded as hidden?
@@ -176,6 +186,7 @@ public:
 
   /// Record a location.
   /// \param guard: Precondition for reaching this location
+  /// \pre guard is merged
   /// \param source: Pointer to location in the input GOTO program to be
   ///  recorded
   virtual void location(
@@ -184,6 +195,7 @@ public:
 
   /// Record an output.
   /// \param guard: Precondition for writing to the output
+  /// \pre guard is merged
   /// \param source: Pointer to location in the input GOTO program of this
   ///  output
   /// \param output_id: Name of the output
@@ -196,6 +208,7 @@ public:
 
   /// Record formatted output.
   /// \param guard: Precondition for writing to the output
+  /// \pre guard is merged
   /// \param source: Pointer to location in the input GOTO program of this
   ///  output
   /// \param output_id: Name of the output
@@ -210,6 +223,7 @@ public:
 
   /// Record an input.
   /// \param guard: Precondition for reading from the input
+  /// \pre guard is merged
   /// \param source: Pointer to location in the input GOTO program of this
   ///  input
   /// \param input_id: Name of the input
@@ -222,6 +236,7 @@ public:
 
   /// Record an assumption.
   /// \param guard: Precondition for reaching this assumption
+  /// \pre guard is merged
   /// \param cond: Condition this assumption represents
   /// \param source: Pointer to location in the input GOTO program of this
   ///  assumption
@@ -232,6 +247,7 @@ public:
 
   /// Record an assertion.
   /// \param guard: Precondition for reaching this assertion
+  /// \pre guard is merged
   /// \param cond: Condition this assertion represents
   /// \param property_id: Unique property identifier of this assertion
   /// \param msg: The message associated with this assertion
@@ -246,6 +262,7 @@ public:
 
   /// Record a goto instruction.
   /// \param guard: Precondition for reaching this goto instruction
+  /// \pre guard is merged
   /// \param cond: Condition under which this goto should be taken
   /// \param source: Pointer to location in the input GOTO program of this
   ///  goto instruction
@@ -266,6 +283,7 @@ public:
 
   /// Record spawning a new thread
   /// \param guard: Precondition for reaching spawning a new thread
+  /// \pre guard is merged
   /// \param source: Pointer to location in the input GOTO program where a new
   ///  thread is to be spawned
   virtual void spawn(
@@ -274,6 +292,7 @@ public:
 
   /// Record creating a memory barrier
   /// \param guard: Precondition for reaching this barrier
+  /// \pre guard is merged
   /// \param source: Pointer to location in the input GOTO program where a new
   ///  barrier is created
   virtual void memory_barrier(
@@ -282,6 +301,7 @@ public:
 
   /// Record a beginning of an atomic section
   /// \param guard: Precondition for reaching this atomic section
+  /// \pre guard is merged
   /// \param atomic_section_id: Identifier for this atomic section
   /// \param source: Pointer to location in the input GOTO program where an
   ///  atomic section begins
@@ -292,6 +312,7 @@ public:
 
   /// Record ending an atomic section
   /// \param guard: Precondition for reaching the end of this atomic section
+  /// \pre guard is merged
   /// \param atomic_section_id: Identifier for this atomic section
   /// \param source: Pointer to location in the input GOTO program where an
   ///  atomic section ends

--- a/src/goto-symex/symex_target_equation.h
+++ b/src/goto-symex/symex_target_equation.h
@@ -17,7 +17,6 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <list>
 
 #include <util/invariant.h>
-#include <util/merge_irep.h>
 #include <util/message.h>
 #include <util/narrow.h>
 
@@ -286,7 +285,6 @@ protected:
   messaget log;
 
   // for enforcing sharing in the expressions stored
-  merge_irept merge_irep;
   void merge_ireps(SSA_stept &SSA_step);
 
   // for unique I/O identifiers


### PR DESCRIPTION
<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- [X] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [X] My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- [X] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->

goto_statet::merged_guard contains the merged version of goto_statet::guard (i.e, the result of merge_irept::operator()). The merged version is cached until the guard changes. This optimization is useful when a long sequence of statements does not change the guard (e.g., assignment) and the guard is very big. In some cases, this significantly reduces the Symex time: in the sequentialized version of safestack produced by lazycseq, Symex time goes from 3368.18s to 1871.72s.