### PR TITLE
Free up additional disk space on GitHub runner

### DIFF
--- a/.github/workflows/pull-request-checks.yaml
+++ b/.github/workflows/pull-request-checks.yaml
@@ -910,6 +910,12 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: recursive
+      - name: Remove unnecessary software to free up disk space
+        run: |
+          # inspired by https://github.com/easimon/maximize-build-space/blob/master/action.yml
+          df -h
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/* /opt/*
+          df -h
       - name: Download testing and coverage dependencies
         env:
           # This is needed in addition to -yq to prevent apt-get from asking for


### PR DESCRIPTION
Building with coverage support creates large binaries as well as
coverage records, all of which consume considerable disk space.
2cee3b182fd appears to have pushed this over the top for it creates a
library archive consuming another 2.2 GB of disk space.

This additional build step cleans out binaries that we do not need, such
as Haskell, .NET, or Android SDKs. This frees up 28 GB of memory (out of
a total of 84 GB).

The merge of #6479 into develop was the last successful Codecov CI job run. Ever since all Codecov job runs got cancelled at some point.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [x] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
