### PR TITLE
CMake: clean up setting CMAKE_VERSION

### DIFF
--- a/jbmc/src/CMakeLists.txt
+++ b/jbmc/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-project(JBMC)
+project(JBMC VERSION ${CBMC_VERSION})
 
 #   Set the public include locations for a target.
 macro(generic_includes name)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-project(CBMC)
+project(CBMC VERSION ${CBMC_VERSION})
 
 find_package(BISON REQUIRED)
 find_package(FLEX REQUIRED)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,12 +1,4 @@
-file(STRINGS
-        "${CMAKE_CURRENT_SOURCE_DIR}/config.inc"
-        cbmc_version_string
-        REGEX "CBMC_VERSION.*")
-
-string(REGEX REPLACE "CBMC_VERSION = (.*)" "\\1" CBMC_VERSION "${cbmc_version_string}")
-unset(cbmc_version_string)
-
-project(CBMC VERSION ${CBMC_VERSION})
+project(CBMC)
 
 find_package(BISON REQUIRED)
 find_package(FLEX REQUIRED)


### PR DESCRIPTION
CBMC_VERSION is already being set (using the very same code) in the top-level `CMakeLists.txt` file.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- n/a Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
