### PR TITLE
Fix documentation links

### DIFF
--- a/doc/architectural/symex-instructions.md
+++ b/doc/architectural/symex-instructions.md
@@ -23,12 +23,12 @@ Symex is, at its core, a GOTO-program interpreter that uses symbolic values inst
 This produces a formula which describes all possible outputs rather than a single output value.
 While Symex is interpreting the program, it also builds a list of Static Single Assignment (SSA)
 steps that form part of the equation that is to be sent to the solver. For more information see
-[src/goto-symex](../../src/goto-symex/README.md).
+\ref symbolic-execution.
 
 You can see the main instruction dispatcher (what corresponds to the main interpreter
 loop) at `goto_symext::execute_next_instruction`.
 
-Symex's source code is available under [src/goto-symex](../../src/goto-symex/).
+Symex's source code is available under \ref goto-symex.
 
 ## Instruction Types
 
@@ -115,7 +115,7 @@ case ASSUME:
   break;
 ```
 
-The way the [`symex` subfolder](../../src/goto-symex/) is structured, the different
+The way the \ref goto-symex subfolder is structured, the different
 dispatching functions are usually in their own file, designated by the instruction's
 name. As an example, you can find the code for the function goto_symext::symex_goto
 in [symex_goto.cpp](../../src/goto-symex/symex_goto.cpp)

--- a/doc/doxygen-root/doxyfile
+++ b/doc/doxygen-root/doxyfile
@@ -853,6 +853,7 @@ INPUT_ENCODING         = UTF-8
 FILE_PATTERNS          = *.cpp
 FILE_PATTERNS         += *.h
 FILE_PATTERNS         += *.md
+FILE_PATTERNS         += *.c
 
 # The RECURSIVE tag can be used to specify whether or not subdirectories should
 # be searched for input files as well.


### PR DESCRIPTION
1) Make sure .c source files are considered by Doxygen. (Notably, cprover_contracts.c contains relevant documentation.)
2) Reference other files in ways understood by Doxygen.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [x] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- n/a Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
