### PR TITLE
Avoid deadlock in the `ls_parse.py` script

### DIFF
--- a/scripts/ls_parse.py
+++ b/scripts/ls_parse.py
@@ -379,9 +379,9 @@ def symbols_from(object_file):
     cmd = ["objdump", "--syms", object_file]
     proc = subprocess.Popen(cmd, universal_newlines=True,
             stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
-    if proc.wait():
-        logging.error("`%s` failed. Output:\n%s", " ".join(cmd),
-                      proc.stdout.read())
+    proc_output, _ = proc.communicate()
+    if proc.returncode:
+        logging.error("`%s` failed. Output:\n%s", " ".join(cmd), proc_output)
         exit(1)
     pat = re.compile(r"(?P<addr>[^\s]+)\s+"
                      r"(?P<flags>[lgu! ][w ][C ][W ][Ii ][Dd ][FfO ])\s+"
@@ -391,7 +391,7 @@ def symbols_from(object_file):
                     )
     matching = False
     ret = {}
-    for line in proc.stdout.read().splitlines():
+    for line in proc_output.splitlines():
         if not line:
             continue
         if not matching and re.match("SYMBOL TABLE:", line):


### PR DESCRIPTION
Python `subprocess.Popen.wait` deadlocks when using `stdout=subprocess.PIPE`, and the child process generates enough output to a pipe such that it blocks waiting for the OS pipe buffer to accept more data. See https://docs.python.org/3/library/subprocess.html#subprocess.Popen.wait.

Spotted while trying to compile Xen `4.11`.

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.
