### PR TITLE
C front-end: tolerate type differences with asm renaming

### DIFF
--- a/regression/ansi-c/asm4/main.c
+++ b/regression/ansi-c/asm4/main.c
@@ -1,0 +1,26 @@
+// from Fedora's glibc
+struct dirent
+{
+  int dummy;
+};
+
+struct dirent64
+{
+  int dummy;
+};
+
+#ifdef __GNUC__
+extern struct dirent *readdir(void *__dirp) __asm__(
+  ""
+  "readdir64");
+extern struct dirent64 *readdir64(void *__dirp);
+#endif
+
+int main()
+{
+#ifdef __GNUC__
+  int x;
+  (void)readdir(&x);
+#endif
+  return 0;
+}

--- a/regression/ansi-c/asm4/test.desc
+++ b/regression/ansi-c/asm4/test.desc
@@ -1,0 +1,8 @@
+CORE test-c++-front-end
+main.c
+
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+^CONVERSION ERROR$

--- a/regression/cbmc-library/sscanf-01/main.c
+++ b/regression/cbmc-library/sscanf-01/main.c
@@ -3,7 +3,8 @@
 
 int main()
 {
-  sscanf();
-  assert(0);
+  char dest[10];
+  int result = sscanf("hello", "%s", dest);
+  assert(result == 1);
   return 0;
 }

--- a/regression/cbmc-library/sscanf-01/test.desc
+++ b/regression/cbmc-library/sscanf-01/test.desc
@@ -1,8 +1,10 @@
-KNOWNBUG
+CORE
 main.c
---pointer-check --bounds-check
-^EXIT=0$
+
+^\[main.assertion.1\] line 8 assertion result == 1: FAILURE$
+^\*\* 1 of \d+ failed
+^VERIFICATION FAILED$
+^EXIT=10$
 ^SIGNAL=0$
-^VERIFICATION SUCCESSFUL$
 --
 ^warning: ignoring

--- a/regression/cbmc-library/vfscanf-01/main.c
+++ b/regression/cbmc-library/vfscanf-01/main.c
@@ -1,9 +1,20 @@
 #include <assert.h>
+#include <stdarg.h>
 #include <stdio.h>
+
+int xscanf(const char *format, ...)
+{
+  va_list list;
+  va_start(list, format);
+  int result = vfscanf(stdin, format, list);
+  va_end(list);
+  return result;
+}
 
 int main()
 {
-  vfscanf();
-  assert(0);
+  char dest[10];
+  int result = xscanf("%s", dest);
+  assert(result == 1);
   return 0;
 }

--- a/regression/cbmc-library/vfscanf-01/test.desc
+++ b/regression/cbmc-library/vfscanf-01/test.desc
@@ -1,8 +1,10 @@
-KNOWNBUG
+CORE
 main.c
---pointer-check --bounds-check
-^EXIT=0$
+
+^\[main.assertion.1\] line 18 assertion result == 1: FAILURE$
+^\*\* 1 of \d+ failed
+^VERIFICATION FAILED$
+^EXIT=10$
 ^SIGNAL=0$
-^VERIFICATION SUCCESSFUL$
 --
 ^warning: ignoring

--- a/regression/cbmc-library/vscanf-01/main.c
+++ b/regression/cbmc-library/vscanf-01/main.c
@@ -1,9 +1,20 @@
 #include <assert.h>
+#include <stdarg.h>
 #include <stdio.h>
+
+int xscanf(const char *format, ...)
+{
+  va_list list;
+  va_start(list, format);
+  int result = vscanf(format, list);
+  va_end(list);
+  return result;
+}
 
 int main()
 {
-  vscanf();
-  assert(0);
+  char dest[10];
+  int result = xscanf("%s", dest);
+  assert(result == 1);
   return 0;
 }

--- a/regression/cbmc-library/vscanf-01/test.desc
+++ b/regression/cbmc-library/vscanf-01/test.desc
@@ -1,8 +1,10 @@
-KNOWNBUG
+CORE
 main.c
---pointer-check --bounds-check
-^EXIT=0$
+
+^\[main.assertion.1\] line 18 assertion result == 1: FAILURE$
+^\*\* 1 of \d+ failed
+^VERIFICATION FAILED$
+^EXIT=10$
 ^SIGNAL=0$
-^VERIFICATION SUCCESSFUL$
 --
 ^warning: ignoring

--- a/regression/cbmc-library/vsscanf-01/main.c
+++ b/regression/cbmc-library/vsscanf-01/main.c
@@ -1,9 +1,20 @@
 #include <assert.h>
+#include <stdarg.h>
 #include <stdio.h>
+
+int xscanf(const char *format, ...)
+{
+  va_list list;
+  va_start(list, format);
+  int result = vsscanf("hello", format, list);
+  va_end(list);
+  return result;
+}
 
 int main()
 {
-  vsscanf();
-  assert(0);
+  char dest[10];
+  int result = xscanf("%s", dest);
+  assert(result == 1);
   return 0;
 }

--- a/regression/cbmc-library/vsscanf-01/test.desc
+++ b/regression/cbmc-library/vsscanf-01/test.desc
@@ -1,8 +1,10 @@
-KNOWNBUG
+CORE
 main.c
---pointer-check --bounds-check
-^EXIT=0$
+
+^\[main.assertion.1\] line 18 assertion result == 1: FAILURE$
+^\*\* 1 of \d+ failed
+^VERIFICATION FAILED$
+^EXIT=10$
 ^SIGNAL=0$
-^VERIFICATION SUCCESSFUL$
 --
 ^warning: ignoring

--- a/src/ansi-c/c_typecheck_base.cpp
+++ b/src/ansi-c/c_typecheck_base.cpp
@@ -668,6 +668,10 @@ void c_typecheck_baset::apply_asm_label(
   {
     symbol.name=asm_label;
     symbol.base_name=asm_label;
+    // asm renaming may be combined with varied return types - make sure the
+    // actual definition sets the final type
+    if(symbol.type.id() == ID_code)
+      symbol.type.set(ID_C_incomplete, true);
   }
 
   if(symbol.name!=orig_name)


### PR DESCRIPTION
The example found in glibc shows how asm renaming may be combined with changes in return type names (even when there isn't actually a bit-level difference amongst the types). Weakening the asm-renamed declaration by marking it "incomplete" works around this problem.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
