### PR TITLE
C front-end: address-of-label is a compile-time constant

### DIFF
--- a/regression/cbmc/Computed-Goto1/main.c
+++ b/regression/cbmc/Computed-Goto1/main.c
@@ -1,6 +1,6 @@
 int main()
 {
-  void *table[]={ &&l0, &&l1, &&l2 };
+  static void *table[] = {&&l0, &&l1, &&l2};
   int in, out;
 
   if(in>=0 && in<=2)

--- a/src/ansi-c/c_typecheck_expr.cpp
+++ b/src/ansi-c/c_typecheck_expr.cpp
@@ -4520,6 +4520,8 @@ protected:
     }
     else if(e.id() == ID_array && e.get_bool(ID_C_string_constant))
       return true;
+    else if(e.id() == ID_label)
+      return true;
     else
       return is_constantt::is_constant_address_of(e);
   }


### PR DESCRIPTION
When using computed gotos, the addresses of labels are taken. These are compile-time constants that are safe to use in initializers of objects with static lifetime.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
