### PR TITLE
goto-gcc/goto-ld: reproduce original help output

### DIFF
--- a/src/goto-cc/gcc_mode.cpp
+++ b/src/goto-cc/gcc_mode.cpp
@@ -308,13 +308,6 @@ bool gcc_modet::needs_preprocessing(const std::string &file)
 /// does it.
 int gcc_modet::doit()
 {
-  if(cmdline.isset('?') ||
-     cmdline.isset("help"))
-  {
-    help();
-    return EX_OK;
-  }
-
   native_tool_name=
     compiler_name(cmdline, base_name);
 
@@ -373,6 +366,20 @@ int gcc_modet::doit()
       std::cout << "gcc: " << gcc_version << '\n';
 
     return EX_OK; // Exit!
+  }
+
+  // In hybrid mode, when --help is requested, just reproduce the output of the
+  // original compiler. This is so as not to confuse configure scripts that
+  // depend on particular information (such as the list of supported targets).
+  if(cmdline.isset("help") && produce_hybrid_binary)
+  {
+    help();
+    return run_gcc(compiler);
+  }
+  else if(cmdline.isset('?') || cmdline.isset("help"))
+  {
+    help();
+    return EX_OK;
   }
 
   if(

--- a/src/goto-cc/ld_mode.cpp
+++ b/src/goto-cc/ld_mode.cpp
@@ -62,16 +62,18 @@ ld_modet::ld_modet(goto_cc_cmdlinet &_cmdline, const std::string &_base_name)
 /// does it.
 int ld_modet::doit()
 {
-  if(cmdline.isset("help"))
-  {
-    help();
-    return EX_OK;
-  }
-
   native_tool_name = linker_name(cmdline, base_name);
 
-  if(cmdline.isset("version") || cmdline.isset("print-sysroot"))
+  // When --help is requested, just reproduce the output of the original
+  // compiler. This is so as not to confuse configure scripts that depend on
+  // particular information (such as the list of supported targets).
+  if(
+    cmdline.isset("help") || cmdline.isset("version") ||
+    cmdline.isset("print-sysroot"))
+  {
+    help();
     return run_ld();
+  }
 
   messaget::eval_verbosity(
     cmdline.get_value("verbosity"), messaget::M_ERROR, gcc_message_handler);


### PR DESCRIPTION
There are configure scripts that parse the --help output to obtain the set of supported targets. Without the original output those build systems are then led to believe that we don't support shared libraries (which in turn breaks some builds).

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
