### PR TITLE
C front-end: fix type2name for vectors

### DIFF
--- a/regression/ansi-c/gcc_vector2/main.c
+++ b/regression/ansi-c/gcc_vector2/main.c
@@ -1,0 +1,27 @@
+typedef int __v4 __attribute__((__vector_size__(16)));
+typedef int __v8 __attribute__((__vector_size__(32)));
+typedef int __v16 __attribute__((__vector_size__(64)));
+
+__v8 foo(__v16 __A)
+{
+  union
+  {
+    __v8 __a[2];
+    __v16 __v;
+  } __u = {.__v = __A};
+  return __u.__a[0];
+}
+
+__v4 bar(__v8 __A)
+{
+  union
+  {
+    __v4 __a[2];
+    __v8 __v;
+  } __u = {.__v = __A};
+  return __u.__a[0];
+}
+
+int main()
+{
+}

--- a/regression/ansi-c/gcc_vector2/test.desc
+++ b/regression/ansi-c/gcc_vector2/test.desc
@@ -1,0 +1,11 @@
+CORE gcc-only
+main.c
+
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+^CONVERSION ERROR$
+--
+We previously got a spurious type conflict for both unions got the same tag name
+(as type2name did not correctly name vectors of different size).

--- a/regression/goto-instrument/bitfield_naming/test.desc
+++ b/regression/goto-instrument/bitfield_naming/test.desc
@@ -3,10 +3,10 @@ main.c
 --show-goto-functions --json-ui
 ^EXIT=0$
 ^SIGNAL=0$
-BF1\{U8\}\$U8\$\'b11\'
-BF1\{U8\}\$U8\$\'b22\'
-BF2\{U8\}\$U8\$\'b34\'
-BF4\{U8\}\$U8\$\'b58\'
+BF1\{U8\}\'b11\'
+BF1\{U8\}\'b22\'
+BF2\{U8\}\'b34\'
+BF4\{U8\}\'b58\'
 --
 --
 

--- a/src/ansi-c/type2name.cpp
+++ b/src/ansi-c/type2name.cpp
@@ -245,7 +245,11 @@ static std::string type2name(
   else if(type.id()==ID_c_bit_field)
     result+="BF"+pointer_offset_bits_as_string(type, ns);
   else if(type.id()==ID_vector)
-    result+="VEC"+type.get_string(ID_size);
+  {
+    const constant_exprt &size = to_vector_type(type).size();
+    const auto size_int = numeric_cast_v<mp_integer>(size);
+    result += "VEC" + integer2string(size_int);
+  }
   else
     throw "unknown type '"+type.id_string()+"' encountered";
 
@@ -256,8 +260,7 @@ static std::string type2name(
       type2name(to_type_with_subtype(type).subtype(), ns, symbol_number);
     result+='}';
   }
-
-  if(type.has_subtypes())
+  else if(type.has_subtypes())
   {
     result+='$';
     for(const typet &subtype : to_type_with_subtypes(type).subtypes())


### PR DESCRIPTION
We generated VECconstant instead of VEC<size>, resulting in name clashes of distinct types.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
