### PR TITLE
Tests: Fix decision-procedure-runtime pattern

### DIFF
--- a/regression/cbmc/Failing_Assert1/dimacs.desc
+++ b/regression/cbmc/Failing_Assert1/dimacs.desc
@@ -1,7 +1,7 @@
 CORE
 main.c
 --dimacs
-^Runtime decision procedure: [0-9]+(\.[0-9]+(e-[0-9]+)?)?s$
+^Runtime decision procedure: [0-9]+(\.[0-9]+)?(e-[0-9]+)?s$
 ^c main::1::i!0@1#1
 ^c main::1::j!0@1#1
 ^EXIT=0$

--- a/regression/cbmc/Failing_Assert1/test.desc
+++ b/regression/cbmc/Failing_Assert1/test.desc
@@ -4,6 +4,6 @@ main.c
 ^EXIT=10$
 ^SIGNAL=0$
 ^VERIFICATION FAILED$
-^Runtime decision procedure: [0-9]+(\.[0-9]+(e-[0-9]+)?)?s$
+^Runtime decision procedure: [0-9]+(\.[0-9]+)?(e-[0-9]+)?s$
 --
 ^warning: ignoring


### PR DESCRIPTION
In
https://github.com/diffblue/cbmc/actions/runs/4398169028/jobs/7701816018 we saw a runtime of 9e-05s, i.e., no fractional part was printed for it was zero.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
