### PR TITLE
goto-synthesizer: correctly configure the C front-end

### DIFF
--- a/src/goto-synthesizer/goto_synthesizer_parse_options.cpp
+++ b/src/goto-synthesizer/goto_synthesizer_parse_options.cpp
@@ -16,6 +16,7 @@ Author: Qinheping Hu
 #include <goto-programs/set_properties.h>
 #include <goto-programs/write_goto_binary.h>
 
+#include <ansi-c/gcc_version.h>
 #include <goto-instrument/contracts/contracts.h>
 #include <goto-instrument/nondet_volatile.h>
 
@@ -51,6 +52,14 @@ int goto_synthesizer_parse_optionst::doit()
   const auto result_get_goto_program = get_goto_program();
   if(result_get_goto_program != CPROVER_EXIT_SUCCESS)
     return result_get_goto_program;
+
+  // configure gcc, if required -- get_goto_program will have set the config
+  if(config.ansi_c.preprocessor == configt::ansi_ct::preprocessort::GCC)
+  {
+    gcc_versiont gcc_version;
+    gcc_version.get("gcc");
+    configure_gcc(gcc_version);
+  }
 
   // Synthesize loop invariants and annotate them into `goto_model`
   enumerative_loop_contracts_synthesizert synthesizer(goto_model, log);


### PR DESCRIPTION
goto-synthesizer will eventually invoke code that parses C code (for example, the model library), which in turn requires correct configuration to support _Float16. (For other tools this was previously done in b2b27340f21.)

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
