### PR TITLE
Rename object files so that we don't have collisions between different

### DIFF
--- a/src/libcprover-cpp/add_dependencies.sh
+++ b/src/libcprover-cpp/add_dependencies.sh
@@ -15,11 +15,36 @@ DESTINATION=$1
 shift
 LIB_LIST=$@
 
+# We need to do the following renaming of object files because of translation
+# unit name collisions which affect linking against the final artefact. For more
+# details, please look at https://github.com/diffblue/cbmc/issues/7586 .
+
 # For each library to add:
 for lib in ${LIB_LIST}; do
+  # We will unpack and rename all .o of dependent libraries marking them with
+  # their library name to avoid clashes.
+  LIBNAME=$(basename ${lib} .a)
+
+  # Remove previous unpacked folders and create a new fresh one to work in.
+  rm -rf ${LIBNAME}
+  mkdir ${LIBNAME}
+  cd ${LIBNAME}  
+
   # Unpack the library
   ${AR_COMMAND} -x ${lib}
+
+  # Rename all object file in the library prepending "${LIBNAME}_" to avoid
+  # clashes.
+  for obj in *.o; do
+    mv ${obj} "${LIBNAME}_${obj}"
+  done
+
+  # Move back to the working directory.
+  cd ..
 done
 
 # Append all the unpacked files to the destination library
-${AR_COMMAND} -rcs ${DESTINATION} *.o
+${AR_COMMAND} -rcs ${DESTINATION} **/*.o
+
+# TODO: See if we need to do some cleanup in order to save cache space for
+# Github actions runners.

--- a/src/libcprover-cpp/add_dependencies.sh
+++ b/src/libcprover-cpp/add_dependencies.sh
@@ -19,6 +19,14 @@ LIB_LIST=$@
 # unit name collisions which affect linking against the final artefact. For more
 # details, please look at https://github.com/diffblue/cbmc/issues/7586 .
 
+# Create a temporary folder for this script to work in.
+rm -rf add_dependencies_tmp
+mkdir add_dependencies_tmp
+cd add_dependencies_tmp
+
+# The full path of the current "root" directory
+WORKING_DIR=$(pwd)
+
 # For each library to add:
 for lib in ${LIB_LIST}; do
   # We will unpack and rename all .o of dependent libraries marking them with
@@ -33,18 +41,18 @@ for lib in ${LIB_LIST}; do
   # Unpack the library
   ${AR_COMMAND} -x ${lib}
 
-  # Rename all object file in the library prepending "${LIBNAME}_" to avoid
-  # clashes.
+  # Rename all object files in the library prepending "${LIBNAME}_" to avoid
+  # clashes, and move to the "root" folder.
   for obj in *.o; do
-    mv ${obj} "${LIBNAME}_${obj}"
+    mv ${obj} "${WORKING_DIR}/${LIBNAME}_${obj}"
   done
 
   # Move back to the working directory.
-  cd ..
+  cd "${WORKING_DIR}"
 done
 
 # Append all the unpacked files to the destination library
-${AR_COMMAND} -rcs ${DESTINATION} **/*.o
+${AR_COMMAND} -rcs ${DESTINATION} *.o
 
 # TODO: See if we need to do some cleanup in order to save cache space for
 # Github actions runners.


### PR DESCRIPTION
Rename object files so that we don't have collisions between different object files coming from different projects.

Fixes #7586

Co-authored-by: Enrico Steffinlongo "enrico.steffinlongo@diffblue.com"
Co-authored-by: Fotis Koutoulakis "fotis.koutoulakis@diffblue.com"

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
