### PR TITLE
Constructor attribute is not required with forward declaration

### DIFF
--- a/regression/cbmc/constructor1/main.c
+++ b/regression/cbmc/constructor1/main.c
@@ -1,9 +1,11 @@
 #include <assert.h>
 
 #ifdef __GNUC__
-int x;
+int x, y;
 
+// forward declaration with and without attribute is ok
 static __attribute__((constructor)) void format_init(void);
+static void other_init(void);
 
 static __attribute__((constructor))
 void format_init(void)
@@ -11,12 +13,18 @@ void format_init(void)
   x=42;
   return;
 }
+
+static __attribute__((constructor)) void other_init(void)
+{
+  y = 42;
+}
 #endif
 
 int main()
 {
 #ifdef __GNUC__
   assert(x==42);
+  assert(y == 42);
 #endif
   return 0;
 }

--- a/src/ansi-c/c_typecheck_base.cpp
+++ b/src/ansi-c/c_typecheck_base.cpp
@@ -375,7 +375,9 @@ void c_typecheck_baset::typecheck_redefinition_non_type(
 
     if(
       old_ct.return_type() != new_ct.return_type() &&
-      !old_ct.get_bool(ID_C_incomplete))
+      !old_ct.get_bool(ID_C_incomplete) &&
+      new_ct.return_type().id() != ID_constructor &&
+      new_ct.return_type().id() != ID_destructor)
     {
       throw invalid_source_file_exceptiont{
         "function symbol '" + id2string(new_symbol.display_name()) +


### PR DESCRIPTION
GCC happily accepts constructor (and destructor) definitions when an earlier forward declaration did not have any such attribute.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
