### PR TITLE
C front-end: fix the interaction between packing and alignment

### DIFF
--- a/regression/ansi-c/gcc_attributes15/main.c
+++ b/regression/ansi-c/gcc_attributes15/main.c
@@ -1,0 +1,45 @@
+#define PADDING_SIZE (64 - sizeof(char) - sizeof(int))
+
+typedef struct __attribute__((packed, aligned(64)))
+{
+  char uchar;
+  int uint;
+  char padding[PADDING_SIZE];
+} a_t;
+
+typedef struct __attribute__((packed, aligned(64)))
+{
+  int uint;
+  char uchar;
+  char padding[PADDING_SIZE];
+} b_t;
+
+typedef struct __attribute__((packed))
+{
+  int uint;
+  char uchar;
+  struct
+  {
+    char a;
+    int b;
+  } not_packed __attribute__((aligned(8)));
+} c_t;
+
+typedef struct __attribute__((packed, aligned(1)))
+{
+  int uint;
+  char uchar;
+  struct
+  {
+    char a;
+    int b;
+  } not_packed __attribute__((aligned(8)));
+} d_t;
+
+int main()
+{
+  _Static_assert(sizeof(a_t) == sizeof(b_t), "");
+  _Static_assert(sizeof(c_t) == 8 + 2 * sizeof(int), "");
+  _Static_assert(sizeof(d_t) == 8 + 2 * sizeof(int), "");
+  return 0;
+}

--- a/regression/ansi-c/gcc_attributes15/test.desc
+++ b/regression/ansi-c/gcc_attributes15/test.desc
@@ -1,0 +1,8 @@
+CORE gcc-only
+main.c
+
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+^CONVERSION ERROR$

--- a/regression/ansi-c/pragma_pack4/main.c
+++ b/regression/ansi-c/pragma_pack4/main.c
@@ -1,0 +1,27 @@
+struct S1
+{
+  char a;
+  struct
+  {
+    short b;
+  } c;
+};
+
+#pragma pack(4)
+// note that the above is different from __attribute__((packed, aligned(4))) in
+// that it sets the _maximum_ alignment of members - it does not affect the
+// overall alignment of the struct
+
+struct S2
+{
+  char a;
+  struct
+  {
+    short b;
+  } c;
+};
+
+int main()
+{
+  _Static_assert(sizeof(struct S1) == sizeof(struct S2), "");
+}

--- a/regression/ansi-c/pragma_pack4/test.desc
+++ b/regression/ansi-c/pragma_pack4/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+^CONVERSION ERROR$

--- a/src/ansi-c/parser.y
+++ b/src/ansi-c/parser.y
@@ -1741,12 +1741,14 @@ member_declaring_list:
           type_specifier
           member_declarator
         {
-          if(!PARSER.pragma_pack.empty() &&
+          if(parser_stack($2).id() != ID_struct &&
+             parser_stack($2).id() != ID_union &&
+             !PARSER.pragma_pack.empty() &&
              !PARSER.pragma_pack.back().is_zero())
           {
             // communicate #pragma pack(n) alignment constraints by
-            // by both setting packing AND alignment; see padding.cpp
-            // for more details
+            // by both setting packing AND alignment for individual struct/union
+            // members; see padding.cpp for more details
             init($$);
             set($$, ID_packed);
             $2=merge($2, $$);


### PR DESCRIPTION
Alignment computation must consider packing set for the surrounding compound type.

Fixes: #7596

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
