### PR TITLE
Constructor/destructor attributes also work with forward declarations

### DIFF
--- a/regression/cbmc/constructor1/main.c
+++ b/regression/cbmc/constructor1/main.c
@@ -1,11 +1,12 @@
 #include <assert.h>
 
 #ifdef __GNUC__
-int x, y;
+int x, y, z;
 
 // forward declaration with and without attribute is ok
 static __attribute__((constructor)) void format_init(void);
 static void other_init(void);
+static __attribute__((constructor)) void more_init(void);
 
 static __attribute__((constructor))
 void format_init(void)
@@ -18,6 +19,11 @@ static __attribute__((constructor)) void other_init(void)
 {
   y = 42;
 }
+
+static void more_init(void)
+{
+  z = 42;
+}
 #endif
 
 int main()
@@ -25,6 +31,7 @@ int main()
 #ifdef __GNUC__
   assert(x==42);
   assert(y == 42);
+  assert(z == 42);
 #endif
   return 0;
 }

--- a/src/ansi-c/c_typecheck_base.cpp
+++ b/src/ansi-c/c_typecheck_base.cpp
@@ -379,12 +379,21 @@ void c_typecheck_baset::typecheck_redefinition_non_type(
       new_ct.return_type().id() != ID_constructor &&
       new_ct.return_type().id() != ID_destructor)
     {
-      throw invalid_source_file_exceptiont{
-        "function symbol '" + id2string(new_symbol.display_name()) +
-          "' redefined with a different type:\n" +
-          "Original: " + to_string(old_symbol.type) + "\n" +
-          "     New: " + to_string(new_symbol.type),
-        new_symbol.location};
+      if(
+        old_ct.return_type().id() == ID_constructor ||
+        old_ct.return_type().id() == ID_destructor)
+      {
+        new_ct = old_ct;
+      }
+      else
+      {
+        throw invalid_source_file_exceptiont{
+          "function symbol '" + id2string(new_symbol.display_name()) +
+            "' redefined with a different type:\n" +
+            "Original: " + to_string(old_symbol.type) + "\n" +
+            "     New: " + to_string(new_symbol.type),
+          new_symbol.location};
+      }
     }
     const bool inlined = old_ct.get_inlined() || new_ct.get_inlined();
 


### PR DESCRIPTION
GCC and Clang accept and apply these attributes when they are part of the forward declaration, the definition, or both.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
