### PR TITLE
Ignore empty loops during loop-contracts synthesis

### DIFF
--- a/regression/goto-synthesizer/empty_loop/main.c
+++ b/regression/goto-synthesizer/empty_loop/main.c
@@ -1,0 +1,10 @@
+void exit(int s)
+{
+_EXIT:
+  goto _EXIT;
+}
+
+int main()
+{
+  exit(1);
+}

--- a/regression/goto-synthesizer/empty_loop/test.desc
+++ b/regression/goto-synthesizer/empty_loop/test.desc
@@ -1,0 +1,9 @@
+CORE
+main.c
+--pointer-check
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+--
+Check if empty loops are correctly skipped.

--- a/src/goto-instrument/contracts/contracts.cpp
+++ b/src/goto-instrument/contracts/contracts.cpp
@@ -869,7 +869,8 @@ void code_contractst::apply_loop_contract(
   for(const auto &loop_head_and_content : natural_loops.loop_map)
   {
     const auto &loop_content = loop_head_and_content.second;
-    if(loop_content.empty())
+    // Skip empty loops and self-looped node.
+    if(loop_content.size() <= 1)
       continue;
 
     auto loop_head = loop_head_and_content.first;

--- a/src/goto-synthesizer/enumerative_loop_contracts_synthesizer.cpp
+++ b/src/goto-synthesizer/enumerative_loop_contracts_synthesizer.cpp
@@ -88,6 +88,10 @@ void enumerative_loop_contracts_synthesizert::init_candidates()
     // Initialize invariants for unannotated loops as true
     for(const auto &loop_head_and_content : natural_loops.loop_map)
     {
+      // Ignore empty loops and self-looped node.
+      if(loop_head_and_content.second.size() <= 1)
+        continue;
+
       goto_programt::const_targett loop_end =
         get_loop_end_from_loop_head_and_content(
           loop_head_and_content.first, loop_head_and_content.second);


### PR DESCRIPTION
<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

Fix the first issue in #7595. 
Skip empty loops (loops with size 0) and self-looped nodes (loops with size 1) when synthesizing or applying loop contracts.

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
