### PR TITLE
CONTRACTS: use alias analysis to infer loop assigns in synthesizer

### DIFF
--- a/regression/contracts/loop_assigns-fail/test.desc
+++ b/regression/contracts/loop_assigns-fail/test.desc
@@ -1,10 +1,11 @@
 CORE
 main.c
 --apply-loop-contracts
-activate-multi-line-match
-Failed to infer variables being modified by the loop at file main.c line \d+ function main\.\nPlease specify an assigns clause\.\nReason:\nAlias analysis returned UNKNOWN!
-^EXIT=6$
+^EXIT=10$
 ^SIGNAL=0$
+^\[main.assigns.\d+\] .* Check that i is assignable: SUCCESS$
+^\[main.assigns.\d+\] .* Check that b->data\[(.*)i\] is assignable: FAILURE$
+^VERIFICATION FAILED$
 --
 --
 This test (taken from #6021) shows the need for assigns clauses on loops.

--- a/src/goto-instrument/loop_utils.cpp
+++ b/src/goto-instrument/loop_utils.cpp
@@ -52,7 +52,7 @@ void get_assigns_lhs(
       const typecast_exprt typed_mod{mod, ptr.pointer.type()};
       if(mod.id() == ID_unknown)
       {
-        throw analysis_exceptiont("Alias analysis returned UNKNOWN!");
+        continue;
       }
       if(ptr.offset.is_nil())
         assigns.insert(dereference_exprt{typed_mod});

--- a/src/goto-synthesizer/enumerative_loop_contracts_synthesizer.h
+++ b/src/goto-synthesizer/enumerative_loop_contracts_synthesizer.h
@@ -31,7 +31,8 @@ public:
   enumerative_loop_contracts_synthesizert(
     goto_modelt &goto_model,
     messaget &log)
-    : loop_contracts_synthesizer_baset(goto_model, log)
+    : loop_contracts_synthesizer_baset(goto_model, log),
+      ns(goto_model.symbol_table)
   {
   }
 
@@ -44,6 +45,8 @@ public:
   {
     return assigns_map;
   }
+
+  namespacet ns;
 
 private:
   /// Initialize invariants as true for all unannotated loops.


### PR DESCRIPTION
<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

This PR contains two changes.

First, we will no longer error out when the alias analysis fails when we infer loop assigns. When the local alias analysis fails on some pointers, it still probably success on other pointers. So it is worth to return whatever assigns targets inferred. 

Second, we will use local alias analysis to infer initial loop assigns during loop-contracts synthesis. The synthesizer currently uses traces reported by CBMC to construct assigns targets from counterexamples. It can construct at more one assigns target for one call to CBMC. One run of local alias analysis is faster than one run of CBMC, and can infer more than one assigns targets. Therefore, using local alias analysis can improve the performance of the synthesizer.


- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
