### PR TITLE
Function-pointer removal: fix interaction with slice-global-inits

### DIFF
--- a/regression/goto-instrument/slice-global-inits5/main.c
+++ b/regression/goto-instrument/slice-global-inits5/main.c
@@ -1,0 +1,15 @@
+int foo(void)
+{
+}
+
+const int (*const fptrs[])(void) = {&foo};
+
+void unused()
+{
+  const int (*const fp)(void) = fptrs[0];
+  (*fp)();
+}
+
+int main()
+{
+}

--- a/regression/goto-instrument/slice-global-inits5/test.desc
+++ b/regression/goto-instrument/slice-global-inits5/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+--remove-function-pointers --slice-global-inits
+^VERIFICATION SUCCESSFUL$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring

--- a/regression/goto-instrument/slice-global-inits6/main.c
+++ b/regression/goto-instrument/slice-global-inits6/main.c
@@ -1,0 +1,9 @@
+int foo()
+{
+}
+
+int main()
+{
+  int (*fp)() = &foo;
+  (*fp)();
+}

--- a/regression/goto-instrument/slice-global-inits6/test.desc
+++ b/regression/goto-instrument/slice-global-inits6/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+--slice-global-inits
+^VERIFICATION SUCCESSFUL$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring

--- a/src/goto-instrument/goto_instrument_parse_options.cpp
+++ b/src/goto-instrument/goto_instrument_parse_options.cpp
@@ -1481,6 +1481,8 @@ void goto_instrument_parse_optionst::instrument_goto_program()
 
   if(cmdline.isset("slice-global-inits"))
   {
+    do_indirect_call_and_rtti_removal();
+
     log.status() << "Slicing away initializations of unused global variables"
                  << messaget::eom;
     slice_global_inits(goto_model, ui_message_handler);

--- a/src/goto-programs/remove_const_function_pointers.cpp
+++ b/src/goto-programs/remove_const_function_pointers.cpp
@@ -74,7 +74,7 @@ exprt remove_const_function_pointerst::replace_const_symbols(
     {
       const symbolt &symbol =
         symbol_table.lookup_ref(to_symbol_expr(expression).get_identifier());
-      if(symbol.type.id()!=ID_code)
+      if(symbol.type.id() != ID_code && symbol.value.is_not_nil())
       {
         const exprt &symbol_value=symbol.value;
         return replace_const_symbols(symbol_value);


### PR DESCRIPTION
Running slice-global-inits will set some symbols' values to nil. Such nil values must not be used in (const-) function pointer removal for they would result in invalid expressions (for example, index-of-nil) being constructed.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
