### PR TITLE
[gcc 13] include cstdint for *int*_t

### DIFF
--- a/src/goto-programs/name_mangler.cpp
+++ b/src/goto-programs/name_mangler.cpp
@@ -10,6 +10,7 @@ Author: Kareem Khazem <karkhaz@karkhaz.com>, 2019
 
 #include <util/get_base_name.h>
 
+#include <cstdint>
 #include <iomanip>
 #include <sstream>
 

--- a/src/goto-programs/osx_fat_reader.h
+++ b/src/goto-programs/osx_fat_reader.h
@@ -14,6 +14,7 @@ Author:
 
 #include <util/message.h>
 
+#include <cstdint>
 #include <fstream>
 #include <map>
 #include <string>

--- a/src/solvers/prop/prop.h
+++ b/src/solvers/prop/prop.h
@@ -17,6 +17,8 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "literal.h"
 
+#include <cstdint>
+
 /*! \brief TO_BE_DOCUMENTED
 */
 class propt

--- a/src/solvers/smt2/smt2_conv.cpp
+++ b/src/solvers/smt2/smt2_conv.cpp
@@ -42,6 +42,8 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "smt2_tokenizer.h"
 
+#include <cstdint>
+
 // Mark different kinds of error conditions
 
 // Unexpected types and other combinations not implemented and not

--- a/src/util/ieee_float.cpp
+++ b/src/util/ieee_float.cpp
@@ -8,13 +8,14 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "ieee_float.h"
 
-#include <limits>
-
 #include "arith_tools.h"
 #include "bitvector_types.h"
 #include "floatbv_expr.h"
 #include "invariant.h"
 #include "std_expr.h"
+
+#include <cstdint>
+#include <limits>
 
 mp_integer ieee_float_spect::bias() const
 {

--- a/src/util/unicode.cpp
+++ b/src/util/unicode.cpp
@@ -8,12 +8,13 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "unicode.h"
 
+#include "invariant.h"
+
 #include <codecvt>
+#include <cstdint>
 #include <iomanip>
 #include <locale>
 #include <sstream>
-
-#include "invariant.h"
 
 #ifdef _WIN32
 #  include <util/pragma_push.def>


### PR DESCRIPTION
Otherwise we see errors like this with gcc13:
```
src/solvers/prop/prop.h:115:39: error: 'uint32_t' has not been declared
```
