### PR TITLE
C front-end: ensure array type updates are consistent

### DIFF
--- a/regression/cbmc/extern6/main.c
+++ b/regression/cbmc/extern6/main.c
@@ -1,0 +1,12 @@
+extern int stuff[];
+
+extern int a[];
+int a[] = {1, 2, 3};
+
+int main()
+{
+  unsigned char idx;
+  long val = *(long *)(stuff + idx);
+  __CPROVER_assert(val == 13, "compare");
+  return 0;
+}

--- a/regression/cbmc/extern6/test.desc
+++ b/regression/cbmc/extern6/test.desc
@@ -1,0 +1,9 @@
+CORE broken-smt-backend no-new-smt
+main.c
+
+^EXIT=10$
+^SIGNAL=0$
+^VERIFICATION FAILED$
+--
+^warning: ignoring
+^Invariant check failed

--- a/regression/cbmc/incomplete-array-cross-tu/def.c
+++ b/regression/cbmc/incomplete-array-cross-tu/def.c
@@ -1,0 +1,10 @@
+// Tentative definition of an incomplete array (C standard 6.9.2, paragraph 5).
+// The C front-end adjusts this to an array of size 1 during typecheck, i.e.
+// before linking. This must still link cleanly against the extern declaration
+// of the same array in another translation unit (ref.c).
+int arr[];
+
+int get(int i)
+{
+  return arr[i];
+}

--- a/regression/cbmc/incomplete-array-cross-tu/ref.c
+++ b/regression/cbmc/incomplete-array-cross-tu/ref.c
@@ -1,0 +1,10 @@
+// Declaration referencing the array defined (tentatively) in def.c.
+extern int arr[];
+int get(int);
+
+int main()
+{
+  // arr is adjusted to size 1 and zero-initialised; reading element 0 yields 0.
+  __CPROVER_assert(get(0) == 0, "tentative array element is zero-initialised");
+  return 0;
+}

--- a/regression/cbmc/incomplete-array-cross-tu/test.desc
+++ b/regression/cbmc/incomplete-array-cross-tu/test.desc
@@ -1,0 +1,10 @@
+CORE
+def.c
+ref.c
+^EXIT=0$
+^SIGNAL=0$
+^\[main\.assertion\.1\] line \d+ tentative array element is zero-initialised: SUCCESS$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring
+conflicting array sizes

--- a/regression/goto-analyzer/variable-sensitivity-dependence-graph16/test.desc
+++ b/regression/goto-analyzer/variable-sensitivity-dependence-graph16/test.desc
@@ -6,5 +6,8 @@ activate-multi-line-match
 ^SIGNAL=0$
 // Assignment from the result of a function call to a function with no body
 // should have a data dependency on the function
-^Data dependencies: 18 \[f2\]\n(.*\n).*\/\/ 19 file .*main.c line 15 function main\n.*t2 := .*nondet.*
+// The concrete node/line numbers are matched as \d+ because static_lifetime_init
+// no longer inserts the incomplete-array size patch (done in the front end
+// now), which shifts instruction numbering.
+^Data dependencies: \d+ \[f2\]\n(.*\n).*\/\/ \d+ file .*main.c line 15 function main\n.*t2 := .*nondet.*
 --

--- a/src/ansi-c/ansi_c_language.cpp
+++ b/src/ansi-c/ansi_c_language.cpp
@@ -8,8 +8,11 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "ansi_c_language.h"
 
+#include <util/arith_tools.h>
+#include <util/c_types.h>
 #include <util/config.h>
 #include <util/get_base_name.h>
+#include <util/replace_symbol.h>
 #include <util/symbol_table.h>
 
 #include <linking/linking.h>
@@ -106,6 +109,44 @@ bool ansi_c_languaget::parse(
   return result;
 }
 
+/// Adjust non-extern file-scope incomplete array definitions (tentative
+/// definitions without a size) to an array of size 1, per C standard 6.9.2(5),
+/// and rewrite the type carried on any symbol expressions referring to them so
+/// that the symbol's type and its uses in code stay consistent.
+static void adjust_tentative_array_definitions(symbol_table_baset &symbol_table)
+{
+  unchecked_replace_symbolt array_type_updates;
+  for(auto it = symbol_table.begin(); it != symbol_table.end(); ++it)
+  {
+    const symbolt &symbol = it->second;
+    if(
+      symbol.is_static_lifetime && !symbol.is_extern && !symbol.is_type &&
+      !symbol.is_macro && symbol.type.id() == ID_array &&
+      to_array_type(symbol.type).size().is_nil())
+    {
+      symbolt &writeable_symbol = it.get_writeable_symbol();
+      symbol_exprt previous_expr = writeable_symbol.symbol_expr();
+      to_array_type(writeable_symbol.type).size() =
+        from_integer(1, size_type());
+      array_type_updates.insert(previous_expr, writeable_symbol.symbol_expr());
+    }
+  }
+
+  if(array_type_updates.empty())
+    return;
+
+  // Apply the type updates to the values (initializers) of all symbols.
+  for(auto it = symbol_table.begin(); it != symbol_table.end(); ++it)
+  {
+    if(
+      !it->second.is_type && !it->second.is_macro &&
+      it->second.value.is_not_nil())
+    {
+      array_type_updates(it.get_writeable_symbol().value);
+    }
+  }
+}
+
 bool ansi_c_languaget::typecheck(
   symbol_table_baset &symbol_table,
   const std::string &module,
@@ -128,6 +169,12 @@ bool ansi_c_languaget::typecheck(
   {
     return true;
   }
+
+  // C standard 6.9.2(5): non-extern file-scope incomplete array definitions
+  // are adjusted to an array of size 1. Done here (in the front end, before
+  // linking) so the symbol's type and the types carried on symbol expressions
+  // in code stay consistent.
+  adjust_tentative_array_definitions(new_symbol_table);
 
   remove_internal_symbols(
     new_symbol_table, message_handler, keep_file_local, keep);

--- a/src/linking/static_lifetime_init.cpp
+++ b/src/linking/static_lifetime_init.cpp
@@ -54,11 +54,16 @@ static std::optional<codet> static_lifetime_init(
 
   if(symbol.type.id() == ID_array && to_array_type(symbol.type).size().is_nil())
   {
-    // C standard 6.9.2, paragraph 5
-    // adjust the type to an array of size 1
-    symbolt &writable_symbol = symbol_table.get_writeable_ref(identifier);
-    writable_symbol.type = symbol.type;
-    writable_symbol.type.set(ID_size, from_integer(1, size_type()));
+    if(symbol.is_extern)
+      return {};
+    // The C front-end adjusts non-extern tentative array definitions to size 1
+    // during typecheck (C standard 6.9.2, paragraph 5), keeping the symbol's
+    // type and its uses in code consistent. As a safety net for symbols
+    // produced by other means (other front-ends, instrumentation, or
+    // pre-existing goto binaries) that did not undergo that adjustment, patch
+    // the size in place here rather than aborting.
+    symbol_table.get_writeable_ref(identifier)
+      .type.set(ID_size, from_integer(1, size_type()));
   }
 
   if(

--- a/src/util/lower_byte_operators.cpp
+++ b/src/util/lower_byte_operators.cpp
@@ -510,6 +510,19 @@ static exprt unpack_array_vector_no_known_bounds(
                                     ? to_vector_type(src.type()).size()
                                     : to_array_type(src.type()).size();
 
+  if(array_vector_size.is_nil())
+  {
+    // The source array/vector has no statically known size (an incomplete
+    // type whose extent is genuinely unknown here, e.g. an extern array
+    // declared without a bound). Represent it as a zero-length comprehension;
+    // any byte access into it is then out of bounds and becomes nondet/fails,
+    // which is the behaviour the extern6 regression exercises.
+    return array_comprehension_exprt{
+      std::move(array_comprehension_index),
+      std::move(body),
+      array_typet{bv_typet{bits_per_byte}, from_integer(0, size_type())}};
+  }
+
   return array_comprehension_exprt{
     std::move(array_comprehension_index),
     std::move(body),


### PR DESCRIPTION
We must not end up in a situation where the symbol's array type is different from the type applied to symbol expressions in code. With the previous approach, support-function generation would alter the type after typechecking of code had already been completed.

Fixes: #7608

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
