### PR TITLE
Fix race in regression tests

### DIFF
--- a/regression/contracts-dfcc/chain.sh
+++ b/regression/contracts-dfcc/chain.sh
@@ -21,6 +21,7 @@ else
   args_cbmc="${args#*" _ "}"
 fi
 
+dfcc_suffix=""
 if [[ "${use_dfcc}" == "false" ]]; then
   set -- $args_inst
   args_inst=""
@@ -32,28 +33,30 @@ if [[ "${use_dfcc}" == "false" ]]; then
       shift
     fi
   done
+else
+  dfcc_suffix="dfcc"
 fi
 
 if [[ "${is_windows}" == "true" ]]; then
-  $goto_cc "${name}.c" "/Fe${name}.gb"
+  $goto_cc "${name}.c" "/Fe${name}${dfcc_suffix}.gb"
 else
-  $goto_cc -o "${name}.gb" "${name}.c"
+  $goto_cc -o "${name}${dfcc_suffix}.gb" "${name}.c"
 fi
 
-rm -f "${name}-mod.gb"
-$goto_instrument ${args_inst} "${name}.gb" "${name}-mod.gb"
-if [ ! -e "${name}-mod.gb" ] ; then
-  cp "$name.gb" "${name}-mod.gb"
+rm -f "${name}${dfcc_suffix}-mod.gb"
+$goto_instrument ${args_inst} "${name}${dfcc_suffix}.gb" "${name}${dfcc_suffix}-mod.gb"
+if [ ! -e "${name}${dfcc_suffix}-mod.gb" ] ; then
+  cp "${name}${dfcc_suffix}.gb" "${name}${dfcc_suffix}-mod.gb"
 elif echo $args_inst | grep -q -- "--dump-c" ; then
-  mv "${name}-mod.gb" "${name}-mod.c"
+  mv "${name}${dfcc_suffix}-mod.gb" "${name}${dfcc_suffix}-mod.c"
 
   if [[ "${is_windows}" == "true" ]]; then
-    $goto_cc "${name}-mod.c" "/Fe${name}-mod.gb"
+    $goto_cc "${name}${dfcc_suffix}-mod.c" "/Fe${name}${dfcc_suffix}-mod.gb"
   else
-    $goto_cc -o "${name}-mod.gb" "${name}-mod.c"
+    $goto_cc -o "${name}${dfcc_suffix}-mod.gb" "${name}${dfcc_suffix}-mod.c"
   fi
 
-  rm "${name}-mod.c"
+  rm "${name}${dfcc_suffix}-mod.c"
 fi
-$goto_instrument --show-goto-functions "${name}-mod.gb"
-$cbmc "${name}-mod.gb" ${args_cbmc}
+$goto_instrument --show-goto-functions "${name}${dfcc_suffix}-mod.gb"
+$cbmc "${name}${dfcc_suffix}-mod.gb" ${args_cbmc}


### PR DESCRIPTION
The tagged test configuration in #7581 introduced a race for multiple test runs would read/write via the same file names, and may be doing so concurrently. See
https://github.com/diffblue/cbmc/actions/runs/4480043988/jobs/7874814034 for one such example.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
