### PR TITLE
Use get_writeable_symbol() to avoid redundant search

### DIFF
--- a/jbmc/src/java_bytecode/java_bytecode_concurrency_instrumentation.cpp
+++ b/jbmc/src/java_bytecode/java_bytecode_concurrency_instrumentation.cpp
@@ -605,9 +605,9 @@ void convert_synchronized_methods(
   message_handlert &message_handler)
 {
   namespacet ns(symbol_table);
-  for(const auto &entry : symbol_table)
+  for(auto s_it = symbol_table.begin(); s_it != symbol_table.end(); ++s_it)
   {
-    const symbolt &symbol = entry.second;
+    const symbolt &symbol = s_it->second;
 
     if(symbol.type.id() != ID_code)
       continue;
@@ -619,11 +619,10 @@ void convert_synchronized_methods(
     if(symbol.type.get_bool(ID_is_static))
     {
       messaget message(message_handler);
-      message.warning() << "Java method '" << entry.first
+      message.warning() << "Java method '" << s_it->first
                         << "' is static and synchronized."
                         << " This is unsupported, the synchronized keyword"
-                        << " will be ignored."
-                        << messaget::eom;
+                        << " will be ignored." << messaget::eom;
       continue;
     }
 
@@ -638,7 +637,7 @@ void convert_synchronized_methods(
       continue;
 
     // get writeable reference and instrument the method
-    symbolt &w_symbol = symbol_table.get_writeable_ref(entry.first);
+    symbolt &w_symbol = s_it.get_writeable_symbol();
     instrument_synchronized_code(
       symbol_table, w_symbol, it->second.symbol_expr());
   }

--- a/src/ansi-c/c_typecheck_type.cpp
+++ b/src/ansi-c/c_typecheck_type.cpp
@@ -1422,13 +1422,12 @@ void c_typecheck_baset::typecheck_c_enum_type(typet &type)
   enum_tag_symbol.type.add_subtype() = underlying_type;
 
   // is it in the symbol table already?
-  symbol_table_baset::symbolst::const_iterator s_it =
-    symbol_table.symbols.find(identifier);
+  symbolt *existing_symbol = symbol_table.get_writeable(identifier);
 
-  if(s_it!=symbol_table.symbols.end())
+  if(existing_symbol)
   {
     // Yes.
-    const symbolt &symbol=s_it->second;
+    const symbolt &symbol = *existing_symbol;
 
     if(symbol.type.id() != ID_c_enum)
     {
@@ -1441,7 +1440,7 @@ void c_typecheck_baset::typecheck_c_enum_type(typet &type)
     {
       // Ok, overwrite the type in the symbol table.
       // This gives us the members and the subtype.
-      symbol_table.get_writeable_ref(symbol.name).type=enum_tag_symbol.type;
+      existing_symbol->type = enum_tag_symbol.type;
     }
     else
     {

--- a/src/cpp/cpp_typecheck.cpp
+++ b/src/cpp/cpp_typecheck.cpp
@@ -158,7 +158,7 @@ void cpp_typecheckt::static_and_dynamic_initialization()
 
   for(const irep_idt &d_it : dynamic_initializations)
   {
-    const symbolt &symbol = symbol_table.lookup_ref(d_it);
+    symbolt &symbol = symbol_table.get_writeable_ref(d_it);
 
     if(symbol.is_extern)
       continue;
@@ -182,7 +182,7 @@ void cpp_typecheckt::static_and_dynamic_initialization()
 
       // Make it nil to get zero initialization by
       // __CPROVER_initialize
-      symbol_table.get_writeable_ref(d_it).value.make_nil();
+      symbol.value.make_nil();
     }
     else
     {
@@ -220,9 +220,9 @@ void cpp_typecheckt::do_not_typechecked()
   {
     cont = false;
 
-    for(const auto &named_symbol : symbol_table.symbols)
+    for(auto it = symbol_table.begin(); it != symbol_table.end(); ++it)
     {
-      const symbolt &symbol=named_symbol.second;
+      const symbolt &symbol = it->second;
 
       if(
         symbol.value.id() == ID_cpp_not_typechecked &&
@@ -248,8 +248,7 @@ void cpp_typecheckt::do_not_typechecked()
         else
           UNREACHABLE; // Don't know what to do!
 
-        symbolt &writable_symbol =
-          symbol_table.get_writeable_ref(named_symbol.first);
+        symbolt &writable_symbol = it.get_writeable_symbol();
         writable_symbol.value.swap(value);
         convert_function(writable_symbol);
       }
@@ -257,21 +256,20 @@ void cpp_typecheckt::do_not_typechecked()
   }
   while(cont);
 
-  for(const auto &named_symbol : symbol_table.symbols)
+  for(auto it = symbol_table.begin(); it != symbol_table.end(); ++it)
   {
-    if(named_symbol.second.value.id() == ID_cpp_not_typechecked)
-      symbol_table.get_writeable_ref(named_symbol.first).value.make_nil();
+    if(it->second.value.id() == ID_cpp_not_typechecked)
+      it.get_writeable_symbol().value.make_nil();
   }
 }
 
 void cpp_typecheckt::clean_up()
 {
-  symbol_table_baset::symbolst::const_iterator it =
-    symbol_table.symbols.begin();
+  auto it = symbol_table.begin();
 
-  while(it!=symbol_table.symbols.end())
+  while(it != symbol_table.end())
   {
-    symbol_table_baset::symbolst::const_iterator cur_it = it;
+    auto cur_it = it;
     it++;
 
     const symbolt &symbol=cur_it->second;
@@ -288,8 +286,8 @@ void cpp_typecheckt::clean_up()
             symbol.type.id()==ID_union)
     {
       // remove methods from 'components'
-      struct_union_typet &struct_union_type=to_struct_union_type(
-        symbol_table.get_writeable_ref(cur_it->first).type);
+      struct_union_typet &struct_union_type =
+        to_struct_union_type(cur_it.get_writeable_symbol().type);
 
       const struct_union_typet::componentst &components=
         struct_union_type.components();

--- a/src/cpp/cpp_typecheck_declaration.cpp
+++ b/src/cpp/cpp_typecheck_declaration.cpp
@@ -60,7 +60,7 @@ codet cpp_typecheckt::convert_anonymous_union(cpp_declarationt &declaration)
   new_code.add_to_operands(code_frontend_declt(cpp_symbol_expr(symbol)));
 
   // do scoping
-  symbolt union_symbol =
+  symbolt &union_symbol =
     symbol_table.get_writeable_ref(follow(symbol.type).get(ID_name));
 
   for(const auto &c : to_union_type(union_symbol.type).components())
@@ -89,8 +89,7 @@ codet cpp_typecheckt::convert_anonymous_union(cpp_declarationt &declaration)
     id.is_member=true;
   }
 
-  symbol_table.get_writeable_ref(union_symbol.name)
-    .type.set(ID_C_unnamed_object, symbol.base_name);
+  union_symbol.type.set(ID_C_unnamed_object, symbol.base_name);
 
   return new_code;
 }

--- a/src/cpp/cpp_typecheck_template.cpp
+++ b/src/cpp/cpp_typecheck_template.cpp
@@ -240,14 +240,14 @@ void cpp_typecheckt::typecheck_function_template(
 
   // check if we have it already
 
-  symbol_table_baset::symbolst::const_iterator previous_symbol =
-    symbol_table.symbols.find(symbol_name);
+  symbolt *previous_symbol = symbol_table.get_writeable(symbol_name);
 
-  if(previous_symbol!=symbol_table.symbols.end())
+  if(previous_symbol)
   {
-    bool previous_has_value =
-     to_cpp_declaration(previous_symbol->second.type).
-       declarators()[0].find(ID_value).is_not_nil();
+    bool previous_has_value = to_cpp_declaration(previous_symbol->type)
+                                .declarators()[0]
+                                .find(ID_value)
+                                .is_not_nil();
 
     if(has_value && previous_has_value)
     {
@@ -255,13 +255,13 @@ void cpp_typecheckt::typecheck_function_template(
       error() << "function template symbol '" << base_name
               << "' declared previously\n"
               << "location of previous definition: "
-              << previous_symbol->second.location << eom;
+              << previous_symbol->location << eom;
       throw 0;
     }
 
     if(has_value)
     {
-      symbol_table.get_writeable_ref(symbol_name).type.swap(declaration);
+      previous_symbol->type.swap(declaration);
       cpp_scopes.id_map[symbol_name]=&template_scope;
     }
 

--- a/src/goto-cc/linker_script_merge.cpp
+++ b/src/goto-cc/linker_script_merge.cpp
@@ -225,26 +225,26 @@ int linker_script_merget::pointerize_linker_defined_symbols(
 
   // Next, find all occurrences of linker-defined symbols that are _values_
   // of some symbol in the symbol table, and pointerize them too
-  for(const auto &pair : goto_model.symbol_table.symbols)
+  for(auto it = goto_model.symbol_table.begin();
+      it != goto_model.symbol_table.end();
+      ++it)
   {
     std::list<symbol_exprt> to_pointerize;
-    symbols_to_pointerize(linker_values, pair.second.value, to_pointerize);
+    symbols_to_pointerize(linker_values, it->second.value, to_pointerize);
 
     if(to_pointerize.empty())
       continue;
-    log.debug() << "Pointerizing the symbol-table value of symbol "
-                << pair.first << messaget::eom;
+    log.debug() << "Pointerizing the symbol-table value of symbol " << it->first
+                << messaget::eom;
     int fail = pointerize_subexprs_of(
-      goto_model.symbol_table.get_writeable_ref(pair.first).value,
-      to_pointerize,
-      linker_values);
+      it.get_writeable_symbol().value, to_pointerize, linker_values);
     if(to_pointerize.empty() && fail==0)
       continue;
     ret=1;
     for(const auto &sym : to_pointerize)
     {
       log.error() << " Could not pointerize '" << sym.get_identifier()
-                  << "' in symbol table entry " << pair.first << ". Pretty:\n"
+                  << "' in symbol table entry " << it->first << ". Pretty:\n"
                   << sym.pretty() << "\n";
     }
     log.error() << messaget::eom;

--- a/src/goto-instrument/dump_c.cpp
+++ b/src/goto-instrument/dump_c.cpp
@@ -83,9 +83,10 @@ void dump_ct::operator()(std::ostream &os)
   // add copies of struct types when ID_C_transparent_union is only
   // annotated to parameter
   symbol_tablet additional_symbols;
-  for(const auto &named_symbol : copied_symbol_table.symbols)
+  for(auto it = copied_symbol_table.begin(); it != copied_symbol_table.end();
+      ++it)
   {
-    const symbolt &symbol=named_symbol.second;
+    const symbolt &symbol = it->second;
 
     if(
       (symbol.type.id() == ID_union || symbol.type.id() == ID_struct) &&
@@ -99,8 +100,7 @@ void dump_ct::operator()(std::ostream &os)
       else
         UNREACHABLE;
       type_symbolt ts{tag_name, symbol.type, symbol.mode};
-      typet &type =
-        copied_symbol_table.get_writeable_ref(named_symbol.first).type;
+      typet &type = it.get_writeable_symbol().type;
       if(ts.type.id() == ID_union)
         type = union_tag_typet{ts.name};
       else
@@ -111,8 +111,7 @@ void dump_ct::operator()(std::ostream &os)
     if(symbol.type.id()!=ID_code)
       continue;
 
-    code_typet &code_type=to_code_type(
-      copied_symbol_table.get_writeable_ref(named_symbol.first).type);
+    code_typet &code_type = to_code_type(it.get_writeable_symbol().type);
     code_typet::parameterst &parameters=code_type.parameters();
 
     for(code_typet::parameterst::iterator
@@ -149,9 +148,10 @@ void dump_ct::operator()(std::ostream &os)
   // add tags to anonymous union/struct/enum,
   // and prepare lexicographic order
   std::set<std::string> symbols_sorted;
-  for(const auto &named_symbol : copied_symbol_table.symbols)
+  for(auto it = copied_symbol_table.begin(); it != copied_symbol_table.end();
+      ++it)
   {
-    symbolt &symbol = copied_symbol_table.get_writeable_ref(named_symbol.first);
+    symbolt &symbol = it.get_writeable_symbol();
     bool tag_added=false;
 
     // TODO we could get rid of some of the ID_anonymous by looking up
@@ -172,7 +172,7 @@ void dump_ct::operator()(std::ostream &os)
       tag_added=true;
     }
 
-    const std::string name_str=id2string(named_symbol.first);
+    const std::string name_str = id2string(it->first);
     if(symbol.is_type &&
        (symbol.type.id()==ID_union ||
         symbol.type.id()==ID_struct ||

--- a/src/goto-programs/name_mangler.h
+++ b/src/goto-programs/name_mangler.h
@@ -88,16 +88,17 @@ public:
     for(const auto &sym : old_syms)
       model.symbol_table.erase(sym);
 
-    for(const auto &sym_pair : model.symbol_table)
+    for(auto it = model.symbol_table.begin(); it != model.symbol_table.end();
+        ++it)
     {
-      const symbolt &sym = sym_pair.second;
+      const symbolt &sym = it->second;
 
       exprt e = sym.value;
       typet t = sym.type;
       if(rename(e) && rename(t))
         continue;
 
-      symbolt &new_sym = model.symbol_table.get_writeable_ref(sym.name);
+      symbolt &new_sym = it.get_writeable_symbol();
       new_sym.value = e;
       new_sym.type = t;
     }

--- a/src/goto-programs/remove_complex.cpp
+++ b/src/goto-programs/remove_complex.cpp
@@ -275,10 +275,10 @@ static void remove_complex(symbolt &symbol)
 }
 
 /// removes complex data type
-void remove_complex(symbol_tablet &symbol_table)
+static void remove_complex(symbol_table_baset &symbol_table)
 {
-  for(const auto &named_symbol : symbol_table.symbols)
-    remove_complex(symbol_table.get_writeable_ref(named_symbol.first));
+  for(auto it = symbol_table.begin(); it != symbol_table.end(); ++it)
+    remove_complex(it.get_writeable_symbol());
 }
 
 /// removes complex data type
@@ -306,7 +306,7 @@ static void remove_complex(goto_functionst &goto_functions)
 
 /// removes complex data type
 void remove_complex(
-  symbol_tablet &symbol_table,
+  symbol_table_baset &symbol_table,
   goto_functionst &goto_functions)
 {
   remove_complex(symbol_table);

--- a/src/goto-programs/remove_complex.h
+++ b/src/goto-programs/remove_complex.h
@@ -16,9 +16,9 @@ Date:   September 2014
 
 class goto_functionst;
 class goto_modelt;
-class symbol_tablet;
+class symbol_table_baset;
 
-void remove_complex(symbol_tablet &, goto_functionst &);
+void remove_complex(symbol_table_baset &, goto_functionst &);
 
 void remove_complex(goto_modelt &);
 

--- a/src/goto-programs/remove_vector.cpp
+++ b/src/goto-programs/remove_vector.cpp
@@ -344,10 +344,10 @@ static void remove_vector(symbolt &symbol)
 }
 
 /// removes vector data type
-static void remove_vector(symbol_tablet &symbol_table)
+static void remove_vector(symbol_table_baset &symbol_table)
 {
-  for(const auto &named_symbol : symbol_table.symbols)
-    remove_vector(symbol_table.get_writeable_ref(named_symbol.first));
+  for(auto it = symbol_table.begin(); it != symbol_table.end(); ++it)
+    remove_vector(it.get_writeable_symbol());
 }
 
 /// removes vector data type
@@ -374,7 +374,7 @@ static void remove_vector(goto_functionst &goto_functions)
 
 /// removes vector data type
 void remove_vector(
-  symbol_tablet &symbol_table,
+  symbol_table_baset &symbol_table,
   goto_functionst &goto_functions)
 {
   remove_vector(symbol_table);

--- a/src/goto-programs/remove_vector.h
+++ b/src/goto-programs/remove_vector.h
@@ -16,9 +16,9 @@ Date:   September 2014
 
 class goto_functionst;
 class goto_modelt;
-class symbol_tablet;
+class symbol_table_baset;
 
-void remove_vector(symbol_tablet &, goto_functionst &);
+void remove_vector(symbol_table_baset &, goto_functionst &);
 
 void remove_vector(goto_modelt &);
 

--- a/src/goto-programs/slice_global_inits.cpp
+++ b/src/goto-programs/slice_global_inits.cpp
@@ -116,15 +116,17 @@ void slice_global_inits(
 
   // now remove unnecessary initializations
   bool changed = false;
-  for(auto &entry : goto_model.symbol_table)
+  for(auto it = goto_model.symbol_table.begin();
+      it != goto_model.symbol_table.end();
+      ++it)
   {
     if(
-      entry.second.is_static_lifetime && !entry.second.is_type &&
-      !entry.second.is_macro && entry.second.type.id() != ID_code &&
-      !has_prefix(id2string(entry.first), CPROVER_PREFIX) &&
-      symbols_to_keep.find(entry.first) == symbols_to_keep.end())
+      it->second.is_static_lifetime && !it->second.is_type &&
+      !it->second.is_macro && it->second.type.id() != ID_code &&
+      !has_prefix(id2string(it->first), CPROVER_PREFIX) &&
+      symbols_to_keep.find(it->first) == symbols_to_keep.end())
     {
-      symbolt &symbol = goto_model.symbol_table.get_writeable_ref(entry.first);
+      symbolt &symbol = it.get_writeable_symbol();
       symbol.is_extern = true;
       symbol.value.make_nil();
       symbol.value.set(ID_C_no_nondet_initialization, 1);

--- a/src/goto-programs/string_abstraction.cpp
+++ b/src/goto-programs/string_abstraction.cpp
@@ -136,7 +136,8 @@ void string_abstractiont::apply()
   // the symbol table and can thus invalidate iterators
   for(auto &sym_name : symbol_table.sorted_symbol_names())
   {
-    const typet &type = symbol_table.lookup_ref(sym_name).type;
+    symbolt &symbol = symbol_table.get_writeable_ref(sym_name);
+    const typet &type = symbol.type;
 
     if(type.id() != ID_code)
       continue;
@@ -147,15 +148,13 @@ void string_abstractiont::apply()
       dest.function_map.find(sym_name);
     if(fct_entry != dest.function_map.end())
     {
-      add_str_parameters(
-        symbol_table.get_writeable_ref(sym_name),
-        fct_entry->second.parameter_identifiers);
+      add_str_parameters(symbol, fct_entry->second.parameter_identifiers);
     }
     else
     {
       goto_functiont::parameter_identifierst dummy(
         to_code_type(type).parameters().size(), irep_idt{});
-      add_str_parameters(symbol_table.get_writeable_ref(sym_name), dummy);
+      add_str_parameters(symbol, dummy);
     }
   }
 

--- a/src/linking/linking.cpp
+++ b/src/linking/linking.cpp
@@ -1495,14 +1495,13 @@ void linkingt::copy_symbols(
   }
 
   // Apply type updates to initializers
-  for(const auto &named_symbol : main_symbol_table.symbols)
+  for(auto it = main_symbol_table.begin(); it != main_symbol_table.end(); ++it)
   {
-    if(!named_symbol.second.is_type &&
-       !named_symbol.second.is_macro &&
-       named_symbol.second.value.is_not_nil())
+    if(
+      !it->second.is_type && !it->second.is_macro &&
+      it->second.value.is_not_nil())
     {
-      object_type_updates(
-        main_symbol_table.get_writeable_ref(named_symbol.first).value);
+      object_type_updates(it.get_writeable_symbol().value);
     }
   }
 }

--- a/src/util/symbol_table_base.h
+++ b/src/util/symbol_table_base.h
@@ -196,6 +196,11 @@ public:
     {
     }
 
+    operator symbolst::const_iterator() const
+    {
+      return symbolst::const_iterator{it};
+    }
+
     // The following typedefs are NOLINT as they are needed by the STL
     typedef symbolst::iterator::difference_type difference_type;     // NOLINT
     typedef symbolst::const_iterator::value_type value_type;         // NOLINT


### PR DESCRIPTION
Don't iterate over a symbol table and then search the symbol we hold an iterator to from scratch. Just use our custom iterators instead of ranged for loops to directly access a writeable version of the symbol.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
