### PR TITLE
Floating-point normalization must not overflow

### DIFF
--- a/regression/cbmc/Float-rounding2/main.c
+++ b/regression/cbmc/Float-rounding2/main.c
@@ -1,0 +1,27 @@
+#include <assert.h>
+
+int main()
+{
+#if 0
+  // examples of constants that previously exhibited wrong behaviour
+  union U
+  {
+    double d;
+    uint64_t b;
+  };
+  union U u = {
+    .b = 0b0000000000000011111111111111111111111110000001000000000000000000};
+  union U u2 = {
+    .b = 0b0000000000000000000000000000001111111111111111111111111000000000};
+  double d = u.d;
+#else
+  double d;
+#endif
+  float f;
+  if(d > 0.0 && d < 1.0)
+  {
+    f = d;
+    assert(f <= 1.0f);
+  }
+  return 0;
+}

--- a/regression/cbmc/Float-rounding2/test.desc
+++ b/regression/cbmc/Float-rounding2/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring

--- a/src/solvers/floatbv/float_bv.cpp
+++ b/src/solvers/floatbv/float_bv.cpp
@@ -458,7 +458,14 @@ exprt float_bvt::conversion(
     // if the number was denormal and is normal in the new format,
     // normalise it!
     if(dest_spec.e > src_spec.e)
+    {
       normalization_shift(result.fraction, result.exponent);
+      // normalization_shift unconditionally extends the exponent size to avoid
+      // arithmetic overflow, but this cannot have happened here as the exponent
+      // had already been extended to dest_spec's size
+      result.exponent =
+        typecast_exprt(result.exponent, signedbv_typet(dest_spec.e));
+    }
 
     // the flags get copied
     result.sign=unpacked_src.sign;
@@ -954,8 +961,8 @@ void float_bvt::normalization_shift(
 
   std::size_t depth = address_bits(fraction_bits - 1);
 
-  if(exponent_bits<depth)
-    exponent=typecast_exprt(exponent, signedbv_typet(depth));
+  exponent = typecast_exprt(
+    exponent, signedbv_typet(std::max(depth, exponent_bits + 1)));
 
   exprt exponent_delta=from_integer(0, exponent.type());
 

--- a/src/solvers/floatbv/float_utils.cpp
+++ b/src/solvers/floatbv/float_utils.cpp
@@ -195,6 +195,10 @@ bvt float_utilst::conversion(
     if(dest_spec.e > spec.e)
     {
       normalization_shift(result.fraction, result.exponent);
+      // normalization_shift unconditionally extends the exponent size to avoid
+      // arithmetic overflow, but this cannot have happened here as the exponent
+      // had already been extended to dest_spec's size
+      result.exponent.resize(dest_spec.e);
     }
 
     // the flags get copied
@@ -792,8 +796,9 @@ void float_utilst::normalization_shift(bvt &fraction, bvt &exponent)
   PRECONDITION(!fraction.empty());
   std::size_t depth = address_bits(fraction.size() - 1);
 
-  if(exponent.size()<depth)
-    exponent=bv_utils.sign_extension(exponent, depth);
+  // sign-extend to ensure the arithmetic below cannot result in overflow/underflow
+  exponent =
+    bv_utils.sign_extension(exponent, std::max(depth, exponent.size() + 1));
 
   bvt exponent_delta=bv_utils.zeros(exponent.size());
 


### PR DESCRIPTION
We need to extend the exponent to compute a new exponent without
overflow; subsequent denormalization and rounding will ensure the
exponent fits into the target format.

Fixes: #7616

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
