### PR TITLE
Do not error on undefined external linker symbols

### DIFF
--- a/src/goto-cc/linker_script_merge.cpp
+++ b/src/goto-cc/linker_script_merge.cpp
@@ -728,16 +728,19 @@ int linker_script_merget::get_linker_script_data(
 
 int linker_script_merget::goto_and_object_mismatch(
     const std::list<irep_idt> &linker_defined_symbols,
-    const linker_valuest &linker_values)
+    linker_valuest &linker_values)
 {
   int fail=0;
   for(const auto &sym : linker_defined_symbols)
     if(linker_values.find(sym)==linker_values.end())
     {
-      fail=1;
-      log.error() << "Variable '" << sym
+      log.warning() << "Variable '" << sym
                   << "' was declared extern but never given "
                   << "a value, even in a linker script" << messaget::eom;
+
+      null_pointer_exprt null_pointer(pointer_type(char_type()));
+      symbol_exprt null_sym(sym, pointer_type(char_type()));
+      linker_values.emplace(sym, std::make_pair(null_sym, null_pointer));
     }
 
   for(const auto &pair : linker_values)

--- a/src/goto-cc/linker_script_merge.cpp
+++ b/src/goto-cc/linker_script_merge.cpp
@@ -727,16 +727,16 @@ int linker_script_merget::get_linker_script_data(
 }
 
 int linker_script_merget::goto_and_object_mismatch(
-    const std::list<irep_idt> &linker_defined_symbols,
-    linker_valuest &linker_values)
+  const std::list<irep_idt> &linker_defined_symbols,
+  linker_valuest &linker_values)
 {
   int fail=0;
   for(const auto &sym : linker_defined_symbols)
     if(linker_values.find(sym)==linker_values.end())
     {
       log.warning() << "Variable '" << sym
-                  << "' was declared extern but never given "
-                  << "a value, even in a linker script" << messaget::eom;
+                    << "' was declared extern but never given a value, even in "
+                    << "a linker script" << messaget::eom;
 
       null_pointer_exprt null_pointer(pointer_type(char_type()));
       symbol_exprt null_sym(sym, pointer_type(char_type()));

--- a/src/goto-cc/linker_script_merge.h
+++ b/src/goto-cc/linker_script_merge.h
@@ -197,8 +197,8 @@ protected:
   /// \return `1` if there is some mismatch between the list and map, `0` if
   ///   everything is OK.
   int goto_and_object_mismatch(
-      const std::list<irep_idt> &linker_defined_symbols,
-      linker_valuest &linker_values);
+    const std::list<irep_idt> &linker_defined_symbols,
+    linker_valuest &linker_values);
 
   /// \brief Validate output of the `scripts/ls_parse.py` tool
   int linker_data_is_malformed(const jsont &data) const;

--- a/src/goto-cc/linker_script_merge.h
+++ b/src/goto-cc/linker_script_merge.h
@@ -198,7 +198,7 @@ protected:
   ///   everything is OK.
   int goto_and_object_mismatch(
       const std::list<irep_idt> &linker_defined_symbols,
-      const linker_valuest &linker_values);
+      linker_valuest &linker_values);
 
   /// \brief Validate output of the `scripts/ls_parse.py` tool
   int linker_data_is_malformed(const jsont &data) const;


### PR DESCRIPTION
goto-cc currently parses the linker script given by the -T flag to find addresses for variables that are extern-declared in C files but not given a definition. This is because some variables are defined in the linker script, not in C code, and reading these definitions from the linker script is necessary to verify the C program.

Prior to this commit, goto-cc would error out if some extern-defined variables remained undefined even after reading the linker script. There is actually a valid use case for having undefined symbols even after linking, see this (search for "Undefined symbol to cause link failure"):

    https://lore.kernel.org/all/5548CC6D.1040708@citrix.com/T/

This commit turns the error into a warning and synthesizes a null pointer for such symbols.

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
