### PR TITLE
Simplify array size expressions

### DIFF
--- a/src/util/simplify_expr.cpp
+++ b/src/util/simplify_expr.cpp
@@ -2711,6 +2711,17 @@ bool simplify_exprt::simplify_node_preorder(exprt &expr)
     }
   }
 
+  if(as_const(expr).type().id() == ID_array)
+  {
+    const array_typet &array_type = to_array_type(as_const(expr).type());
+    resultt<> simp_size = simplify_rec(array_type.size());
+    if(simp_size.has_changed())
+    {
+      to_array_type(expr.type()).size() = simp_size.expr;
+      result = false;
+    }
+  }
+
   return result;
 }
 
@@ -3035,7 +3046,10 @@ simplify_exprt::resultt<> simplify_exprt::simplify_rec(const exprt &expr)
   else // change, new expression is 'tmp'
   {
     POSTCONDITION_WITH_DIAGNOSTICS(
-      as_const(tmp).type() == expr.type(), tmp.pretty(), expr.pretty());
+      (as_const(tmp).type().id() == ID_array && expr.type().id() == ID_array) ||
+        as_const(tmp).type() == expr.type(),
+      tmp.pretty(),
+      expr.pretty());
 
 #ifdef USE_CACHE
     // save in cache


### PR DESCRIPTION
Symbolic execution may be able to replace symbolic sizes by constants, but even the symbolic size might include a type cast (for examples, ones arising from uses of havoc_slice). Simplify those expressions to avoid appearance of almost-a-constant expressions.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
