### PR TITLE
SMT back-end: report too-many-addressed-objects

### DIFF
--- a/regression/cbmc/address_space_size_limit1/test.desc
+++ b/regression/cbmc/address_space_size_limit1/test.desc
@@ -1,4 +1,4 @@
-CORE thorough-paths broken-smt-backend
+CORE thorough-paths
 test.c
 --no-simplify --unwind 300 --object-bits 8
 too many addressed objects

--- a/unit/solvers/smt2_incremental/convert_expr_to_smt.cpp
+++ b/unit/solvers/smt2_incremental/convert_expr_to_smt.cpp
@@ -1525,11 +1525,8 @@ TEST_CASE(
       const address_of_exprt address_of_foo{foo};
       track_expression_objects(address_of_foo, ns, test.object_map);
       test.object_map.at(foo).unique_id = 256;
-      REQUIRE_THROWS_MATCHES(
-        test.convert(address_of_exprt{foo}),
-        invariant_failedt,
-        invariant_failure_containing("There should be sufficient bits to "
-                                     "encode unique object identifier."));
+      REQUIRE_THROWS_AS(
+        test.convert(address_of_exprt{foo}), analysis_exceptiont);
     }
     SECTION("Pointer should be wide enough to encode offset")
     {
@@ -1537,11 +1534,8 @@ TEST_CASE(
       const address_of_exprt address_of_foo{foo};
       track_expression_objects(address_of_foo, ns, test.object_map);
       test.object_map.at(foo).unique_id = 256;
-      REQUIRE_THROWS_MATCHES(
-        test.convert(address_of_exprt{foo}),
-        invariant_failedt,
-        invariant_failure_containing("Pointer should be wider than object_bits "
-                                     "in order to allow for offset encoding."));
+      REQUIRE_THROWS_AS(
+        test.convert(address_of_exprt{foo}), analysis_exceptiont);
     }
   }
   SECTION("Comparison of address of operations.")


### PR DESCRIPTION
Fail generation of the SMT encoding with a meaningful error message rather than generating invalid SMT-LIB output. The behaviour now matches that of the SAT back-end.

Fixes: #7623

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
