### PR TITLE
CONTRACTS: is_cprover_symbol utility function

### DIFF
--- a/src/goto-instrument/Makefile
+++ b/src/goto-instrument/Makefile
@@ -19,6 +19,7 @@ SRC = accelerate/accelerate.cpp \
       contracts/contracts.cpp \
       contracts/dynamic-frames/dfcc_utils.cpp \
       contracts/dynamic-frames/dfcc_library.cpp \
+      contracts/dynamic-frames/dfcc_is_cprover_symbol.cpp \
       contracts/dynamic-frames/dfcc_is_fresh.cpp \
       contracts/dynamic-frames/dfcc_pointer_in_range.cpp \
       contracts/dynamic-frames/dfcc_is_freeable.cpp \

--- a/src/goto-instrument/contracts/dynamic-frames/dfcc_is_cprover_symbol.cpp
+++ b/src/goto-instrument/contracts/dynamic-frames/dfcc_is_cprover_symbol.cpp
@@ -1,0 +1,22 @@
+/*******************************************************************\
+
+Module: Dynamic frame condition checking
+
+Author: Remi Delmas, delmasrd@amazon.com
+
+Date: March 2023
+
+\*******************************************************************/
+
+#include "dfcc_is_cprover_symbol.h"
+
+#include <util/cprover_prefix.h>
+#include <util/prefix.h>
+#include <util/suffix.h>
+
+bool dfcc_is_cprover_symbol(const irep_idt &id)
+{
+  std::string str = id2string(id);
+  return has_prefix(str, CPROVER_PREFIX) || has_prefix(str, "__VERIFIER") ||
+         has_prefix(str, "nondet") || has_suffix(str, "$object");
+}

--- a/src/goto-instrument/contracts/dynamic-frames/dfcc_is_cprover_symbol.h
+++ b/src/goto-instrument/contracts/dynamic-frames/dfcc_is_cprover_symbol.h
@@ -1,0 +1,22 @@
+/*******************************************************************\
+
+Module: Dynamic frame condition checking
+
+Author: Remi Delmas, delmasrd@amazon.com
+
+Date: March 2023
+
+\*******************************************************************/
+
+/// \file
+
+#ifndef CPROVER_GOTO_INSTRUMENT_CONTRACTS_DYNAMIC_FRAMES_DFCC_IS_CPROVER_SYMBOL_H
+#define CPROVER_GOTO_INSTRUMENT_CONTRACTS_DYNAMIC_FRAMES_DFCC_IS_CPROVER_SYMBOL_H
+
+#include <util/irep.h>
+
+/// \return True iff the id starts with CPROVER_PREFIX, `__VERIFIER`, `nondet`
+/// or ends with `$object`.
+bool dfcc_is_cprover_symbol(const irep_idt &id);
+
+#endif


### PR DESCRIPTION
Used by contract instrumentation to skip instrumenting CPROVER symbols with special meaning.

Extracted from https://github.com/diffblue/cbmc/pull/7541, can only be tested once all features are in place.


- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.
