### PR TITLE
Add tracking of goto-function transformation history

### DIFF
--- a/doc/architectural/central-data-structures.md
+++ b/doc/architectural/central-data-structures.md
@@ -36,6 +36,7 @@ erDiagram
   goto_functiont {
     goto_programt body
     ordered_collection_of parameter_identifiers
+    ordered_collection_of completed_transformations
   }
   goto_functiont ||--|| goto_programt : ""
   goto_programt {
@@ -87,13 +88,15 @@ and documented in [`src/util/symbol.h`](../../src/util/symbol.h) and the
 
 ## goto_functiont
 
-A `goto_functiont` is also defined as a pair. It's designed to represent a function
-at the goto level, and effectively it's the following data type (in pseudocode):
+A `goto_functiont` is also a collection of data fields. It's designed to
+represent a function at the goto level, and effectively it's the following data
+type (in pseudocode):
 
 ```js
 type goto_functiont {
     goto_programt body
     list<identifiers> parameters
+    list<transform> history
 }
 ```
 
@@ -104,6 +107,13 @@ are included in the serialised goto binaries.
 
 The `parameters` subcomponent is a list of identifiers that are to be looked-up
 in the symbol-table for their definitions.
+
+A historical record is kept of each of the transformation passes which have been
+applied to each individual function. This record is kept at the function level
+in order to potentially record different transformations being applied to
+different goto binaries before they are linked together. Although for
+simplicity it may be preferable to require that all goto binaries being linked
+have compatible (or identical) histories.
 
 ## goto_programt
 

--- a/jbmc/src/janalyzer/janalyzer_parse_options.cpp
+++ b/jbmc/src/janalyzer/janalyzer_parse_options.cpp
@@ -694,7 +694,7 @@ void janalyzer_parse_optionst::process_goto_function(
 
   remove_returns(function, function_is_stub);
 
-  transform_assertions_assumptions(options, function.get_goto_function().body);
+  transform_assertions_assumptions(options, function);
 }
 
 bool janalyzer_parse_optionst::can_generate_function_body(const irep_idt &name)

--- a/jbmc/src/jbmc/jbmc_parse_options.cpp
+++ b/jbmc/src/jbmc/jbmc_parse_options.cpp
@@ -718,7 +718,7 @@ void jbmc_parse_optionst::process_goto_function(
       ui_message_handler);
   }
 
-  transform_assertions_assumptions(options, function.get_goto_function().body);
+  transform_assertions_assumptions(options, function);
 
   // Replace Java new side effects
   remove_java_new(

--- a/jbmc/src/jbmc/jbmc_parse_options.cpp
+++ b/jbmc/src/jbmc/jbmc_parse_options.cpp
@@ -747,7 +747,7 @@ void jbmc_parse_optionst::process_goto_function(
   if(using_symex_driven_loading)
   {
     // label the assertions
-    label_properties(function.get_function_id(), goto_function.body);
+    label_properties(function);
 
     goto_function.body.update();
     function.compute_location_numbers();

--- a/src/goto-programs/Makefile
+++ b/src/goto-programs/Makefile
@@ -24,6 +24,7 @@ SRC = allocate_objects.cpp \
       goto_instruction_code.cpp \
       goto_program.cpp \
       goto_trace.cpp \
+      goto_transform_history.cpp \
       graphml_witness.cpp \
       initialize_goto_model.cpp \
       instrument_preconditions.cpp \

--- a/src/goto-programs/adjust_float_expressions.cpp
+++ b/src/goto-programs/adjust_float_expressions.cpp
@@ -216,6 +216,8 @@ void adjust_float_expressions(
       else
         return {};
     });
+  add_history_transform(
+    goto_transform_kindt::adjust_float_expressions, goto_function);
 }
 
 void adjust_float_expressions(

--- a/src/goto-programs/goto_check.cpp
+++ b/src/goto-programs/goto_check.cpp
@@ -17,12 +17,13 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "remove_skip.h"
 
 static void transform_assertions_assumptions(
-  goto_programt &goto_program,
+  goto_functiont &goto_function,
   bool enable_assertions,
   bool enable_built_in_assertions,
   bool enable_assumptions)
 {
   bool did_something = false;
+  auto &goto_program = goto_function.body;
 
   for(auto &instruction : goto_program.instructions)
   {
@@ -52,6 +53,9 @@ static void transform_assertions_assumptions(
 
   if(did_something)
     remove_skip(goto_program);
+
+  add_history_transform(
+    goto_transform_kindt::transform_assertions_assumptions, goto_function);
 }
 
 void transform_assertions_assumptions(
@@ -70,12 +74,10 @@ void transform_assertions_assumptions(
   for(auto &entry : goto_model.goto_functions.function_map)
   {
     transform_assertions_assumptions(
-      entry.second.body,
+      entry.second,
       enable_assertions,
       enable_built_in_assertions,
       enable_assumptions);
-    add_history_transform(
-      goto_transform_kindt::transform_assertions_assumptions, entry.second);
   }
 }
 
@@ -94,10 +96,8 @@ void transform_assertions_assumptions(
 
   auto &goto_function = function.get_goto_function();
   transform_assertions_assumptions(
-    goto_function.body,
+    goto_function,
     enable_assertions,
     enable_built_in_assertions,
     enable_assumptions);
-  add_history_transform(
-    goto_transform_kindt::transform_assertions_assumptions, goto_function);
 }

--- a/src/goto-programs/goto_check.cpp
+++ b/src/goto-programs/goto_check.cpp
@@ -79,7 +79,7 @@ void transform_assertions_assumptions(
 
 void transform_assertions_assumptions(
   const optionst &options,
-  goto_programt &goto_program)
+  goto_model_functiont &function)
 {
   const bool enable_assertions = options.get_bool_option("assertions");
   const bool enable_built_in_assertions =
@@ -90,8 +90,9 @@ void transform_assertions_assumptions(
   if(enable_assertions && enable_built_in_assertions && enable_assumptions)
     return;
 
+  auto &goto_function = function.get_goto_function();
   transform_assertions_assumptions(
-    goto_program,
+    goto_function.body,
     enable_assertions,
     enable_built_in_assertions,
     enable_assumptions);

--- a/src/goto-programs/goto_check.cpp
+++ b/src/goto-programs/goto_check.cpp
@@ -74,6 +74,8 @@ void transform_assertions_assumptions(
       enable_assertions,
       enable_built_in_assertions,
       enable_assumptions);
+    add_history_transform(
+      goto_transform_kindt::transform_assertions_assumptions, entry.second);
   }
 }
 
@@ -96,4 +98,6 @@ void transform_assertions_assumptions(
     enable_assertions,
     enable_built_in_assertions,
     enable_assumptions);
+  add_history_transform(
+    goto_transform_kindt::transform_assertions_assumptions, goto_function);
 }

--- a/src/goto-programs/goto_check.h
+++ b/src/goto-programs/goto_check.h
@@ -12,8 +12,8 @@ Author: Daniel Kroening, kroening@kroening.com
 #ifndef CPROVER_GOTO_PROGRAMS_GOTO_CHECK_H
 #define CPROVER_GOTO_PROGRAMS_GOTO_CHECK_H
 
+class goto_model_functiont;
 class goto_modelt;
-class goto_programt;
 class optionst;
 
 /// Handle the options "assertions", "built-in-assertions", "assumptions" to
@@ -24,10 +24,10 @@ void transform_assertions_assumptions(
   goto_modelt &goto_model);
 
 /// Handle the options "assertions", "built-in-assertions", "assumptions" to
-/// remove assertions and assumptions in \p goto_program when these are set to
+/// remove assertions and assumptions in \p function when these are set to
 /// false in \p options.
 void transform_assertions_assumptions(
   const optionst &options,
-  goto_programt &goto_program);
+  goto_model_functiont &function);
 
 #endif // CPROVER_GOTO_PROGRAMS_GOTO_CHECK_H

--- a/src/goto-programs/goto_function.h
+++ b/src/goto-programs/goto_function.h
@@ -17,6 +17,7 @@ Date: May 2018
 #include <util/std_types.h>
 
 #include "goto_program.h"
+#include "goto_transform_history.h"
 
 /// A goto function, consisting of function body (see #body) and parameter
 /// identifiers (see #parameter_identifiers).
@@ -31,6 +32,10 @@ public:
   /// Note: This is now the preferred way of getting the identifiers of the
   /// parameters. The identifiers in the type will go away.
   parameter_identifierst parameter_identifiers;
+
+  /// The ordered collection of transformations which have been applied to this
+  /// function.
+  goto_transform_historyt history;
 
   bool body_available() const
   {
@@ -64,6 +69,7 @@ public:
     body.clear();
     parameter_identifiers.clear();
     function_is_hidden = false;
+    history = {};
   }
 
   void swap(goto_functiont &other)
@@ -71,6 +77,7 @@ public:
     body.swap(other.body);
     parameter_identifiers.swap(other.parameter_identifiers);
     std::swap(function_is_hidden, other.function_is_hidden);
+    std::swap(history, other.history);
   }
 
   void copy_from(const goto_functiont &other)
@@ -78,6 +85,7 @@ public:
     body.copy_from(other.body);
     parameter_identifiers = other.parameter_identifiers;
     function_is_hidden = other.function_is_hidden;
+    history = other.history;
   }
 
   goto_functiont(const goto_functiont &) = delete;
@@ -86,6 +94,7 @@ public:
   goto_functiont(goto_functiont &&other)
     : body(std::move(other.body)),
       parameter_identifiers(std::move(other.parameter_identifiers)),
+      history(std::move(other.history)),
       function_is_hidden(other.function_is_hidden)
   {
   }
@@ -95,6 +104,7 @@ public:
     body = std::move(other.body);
     parameter_identifiers = std::move(other.parameter_identifiers);
     function_is_hidden = other.function_is_hidden;
+    history = other.history;
     return *this;
   }
 

--- a/src/goto-programs/goto_inline_class.cpp
+++ b/src/goto-programs/goto_inline_class.cpp
@@ -486,6 +486,8 @@ void goto_inlinet::goto_inline(
     goto_function,
     inline_map,
     force_full);
+  add_history_transform(
+    goto_transform_kindt::goto_partial_inline, goto_function);
 }
 
 void goto_inlinet::goto_inline(

--- a/src/goto-programs/goto_transform_history.cpp
+++ b/src/goto-programs/goto_transform_history.cpp
@@ -2,8 +2,13 @@
 
 #include "goto_transform_history.h"
 
+#include <util/invariant.h>
+
 void goto_transform_historyt::add(goto_transform_kindt transform)
 {
+  INVARIANT(
+    is_valid_transform_kind(transform),
+    "History should be built using valid transformations.");
   _transforms.push_back(transform);
 }
 
@@ -11,4 +16,32 @@ const goto_transform_historyt::transformst &
 goto_transform_historyt::transforms() const
 {
   return _transforms;
+}
+
+bool is_valid_transform_kind(const goto_transform_kindt transform)
+{
+  switch(transform)
+  {
+  case goto_transform_kindt::link_to_library:
+  case goto_transform_kindt::string_instrumentation:
+  case goto_transform_kindt::remove_function_pointers:
+  case goto_transform_kindt::mm_io:
+  case goto_transform_kindt::instrument_preconditions:
+  case goto_transform_kindt::goto_partial_inline:
+  case goto_transform_kindt::remove_returns:
+  case goto_transform_kindt::remove_vector:
+  case goto_transform_kindt::remove_complex:
+  case goto_transform_kindt::rewrite_union:
+  case goto_transform_kindt::transform_assertions_assumptions:
+  case goto_transform_kindt::adjust_float_expressions:
+  case goto_transform_kindt::string_abstraction:
+  case goto_transform_kindt::remove_unused_functions:
+  case goto_transform_kindt::remove_skip:
+  case goto_transform_kindt::label_properties:
+    return true;
+    // Note: There is deliberately no `default:` case here in order to ensure
+    // that there is a compilation error if the enum is updated without
+    // updating the validation.
+  }
+  return false;
 }

--- a/src/goto-programs/goto_transform_history.cpp
+++ b/src/goto-programs/goto_transform_history.cpp
@@ -1,0 +1,14 @@
+// Author: Diffblue Ltd.
+
+#include "goto_transform_history.h"
+
+void goto_transform_historyt::add(goto_transform_kindt transform)
+{
+  _transforms.push_back(transform);
+}
+
+const goto_transform_historyt::transformst &
+goto_transform_historyt::transforms() const
+{
+  return _transforms;
+}

--- a/src/goto-programs/goto_transform_history.cpp
+++ b/src/goto-programs/goto_transform_history.cpp
@@ -4,6 +4,9 @@
 
 #include <util/invariant.h>
 
+#include "goto_function.h"
+#include "goto_functions.h"
+
 void goto_transform_historyt::add(goto_transform_kindt transform)
 {
   INVARIANT(
@@ -44,4 +47,21 @@ bool is_valid_transform_kind(const goto_transform_kindt transform)
     // updating the validation.
   }
   return false;
+}
+
+void add_history_transform(
+  goto_transform_kindt transform_kind,
+  goto_functiont &function)
+{
+  function.history.add(transform_kind);
+}
+
+void add_history_transform(
+  goto_transform_kindt transform_kind,
+  goto_functionst &functions)
+{
+  for(auto &function_pair : functions.function_map)
+  {
+    add_history_transform(transform_kind, function_pair.second);
+  }
 }

--- a/src/goto-programs/goto_transform_history.h
+++ b/src/goto-programs/goto_transform_history.h
@@ -66,4 +66,8 @@ enum class goto_transform_kindt
   label_properties = 16
 };
 
+/// Returns true if \param transform is one of the values in the definition of
+/// the enumeration above.
+bool is_valid_transform_kind(goto_transform_kindt transform);
+
 #endif // CPROVER_GOTO_PROGRAMS_GOTO_TRANSFORM_HISTORY_H

--- a/src/goto-programs/goto_transform_history.h
+++ b/src/goto-programs/goto_transform_history.h
@@ -5,6 +5,9 @@
 
 #include <vector>
 
+class goto_functiont;
+class goto_functionst;
+
 enum class goto_transform_kindt;
 
 /// An ordered collection of transformations which have been applied. This
@@ -69,5 +72,13 @@ enum class goto_transform_kindt
 /// Returns true if \param transform is one of the values in the definition of
 /// the enumeration above.
 bool is_valid_transform_kind(goto_transform_kindt transform);
+
+void add_history_transform(
+  goto_transform_kindt transform_kind,
+  goto_functiont &function);
+
+void add_history_transform(
+  goto_transform_kindt transform_kind,
+  goto_functionst &functions);
 
 #endif // CPROVER_GOTO_PROGRAMS_GOTO_TRANSFORM_HISTORY_H

--- a/src/goto-programs/goto_transform_history.h
+++ b/src/goto-programs/goto_transform_history.h
@@ -1,0 +1,69 @@
+// Author: Diffblue Ltd.
+
+#ifndef CPROVER_GOTO_PROGRAMS_GOTO_TRANSFORM_HISTORY_H
+#define CPROVER_GOTO_PROGRAMS_GOTO_TRANSFORM_HISTORY_H
+
+#include <vector>
+
+enum class goto_transform_kindt;
+
+/// An ordered collection of transformations which have been applied. This
+/// collection is encapsulated in a class in order to support -
+///  * Writing newly applied transforms to the correct end of the history.
+///  * Querying the existing history.
+///  * Restricting mutating existing history.
+class goto_transform_historyt
+{
+public:
+  using transformst = std::vector<goto_transform_kindt>;
+
+  void add(goto_transform_kindt transform);
+  const transformst &transforms() const;
+
+private:
+  std::vector<goto_transform_kindt> _transforms;
+};
+
+/// Each of the kinds of transformation below are associated with the
+/// implementation of a transformation. These associations are as follows -
+///  * link_to_library \ref goto-programs/link_to_library.h
+///  * string_instrumentation \ref goto-programs/string_instrumentation.h
+///  * remove_function_pointers \ref goto-programs/remove_function_pointers.h
+///  * mm_io \ref goto-programs/mm_io.h
+///  * instrument_preconditions \ref goto-programs/instrument_preconditions.h
+///  * goto_partial_inline \ref goto-programs/goto_inline_class.h
+///  * remove_returns \ref goto-programs/remove_returns.h
+///  * remove_vector \ref goto-programs/remove_vector.h
+///  * remove_complex \ref goto-programs/remove_complex.h
+///  * rewrite_union \ref goto-programs/rewrite_union.h
+///  * transform_assertions_assumptions \ref goto-programs/goto_check.h
+///  * adjust_float_expressions \ref goto-programs/adjust_float_expressions.h
+///  * string_abstraction \ref goto-programs/string_abstraction.h
+///  * remove_unused_functions \ref goto-programs/remove_unused_functions.h
+///  * remove_skip \ref goto-programs/remove_skip.h
+///  * label_properties \ref goto-programs/set_properties.h
+enum class goto_transform_kindt
+{
+  // Warning! The numeric values in this enumeration are used for serialisation
+  // and deserialization. The entries should not be renumbered or removed and
+  // reused. The ordering here is not intended to be used for any relational
+  // operation. So new identifiers can be allocated sequentially.
+  link_to_library = 1,
+  string_instrumentation = 2,
+  remove_function_pointers = 3,
+  mm_io = 4,
+  instrument_preconditions = 5,
+  goto_partial_inline = 6,
+  remove_returns = 7,
+  remove_vector = 8,
+  remove_complex = 9,
+  rewrite_union = 10,
+  transform_assertions_assumptions = 11,
+  adjust_float_expressions = 12,
+  string_abstraction = 13,
+  remove_unused_functions = 14,
+  remove_skip = 15,
+  label_properties = 16
+};
+
+#endif // CPROVER_GOTO_PROGRAMS_GOTO_TRANSFORM_HISTORY_H

--- a/src/goto-programs/instrument_preconditions.cpp
+++ b/src/goto-programs/instrument_preconditions.cpp
@@ -157,6 +157,8 @@ void instrument_preconditions(goto_modelt &goto_model)
   // Note that only the first loop is the one known to leave locations
   // uninitialized.
   goto_model.goto_functions.update();
+  add_history_transform(
+    goto_transform_kindt::instrument_preconditions, goto_model.goto_functions);
 }
 
 void remove_preconditions(goto_functiont &goto_function)

--- a/src/goto-programs/link_to_library.cpp
+++ b/src/goto-programs/link_to_library.cpp
@@ -175,4 +175,7 @@ void link_to_library(
 
   if(!object_type_updates.empty())
     finalize_linking(goto_model, object_type_updates);
+
+  add_history_transform(
+    goto_transform_kindt::link_to_library, goto_model.goto_functions);
 }

--- a/src/goto-programs/mm_io.cpp
+++ b/src/goto-programs/mm_io.cpp
@@ -134,7 +134,10 @@ void mm_io(symbol_tablet &symbol_table, goto_functionst &goto_functions)
     mm_io_w = mm_io_w_symbol->symbol_expr();
 
   for(auto & f : goto_functions.function_map)
+  {
     mm_io(mm_io_r, mm_io_r_value, mm_io_w, f.second, ns);
+    add_history_transform(goto_transform_kindt::mm_io, f.second);
+  }
 }
 
 void mm_io(goto_modelt &model)

--- a/src/goto-programs/read_bin_goto_object.cpp
+++ b/src/goto-programs/read_bin_goto_object.cpp
@@ -15,6 +15,7 @@ Date: June 2006
 
 #include <util/irep_serialization.h>
 #include <util/message.h>
+#include <util/nodiscard.h>
 #include <util/symbol_table_base.h>
 
 #include "goto_functions.h"
@@ -93,6 +94,19 @@ static void copy_parameter_identifiers(
       functions.function_map.emplace(symbol.name, goto_functiont());
     emplaced.first->second.set_parameter_identifiers(*code_type);
   }
+}
+
+NODISCARD static goto_transform_historyt
+read_bin_transform_history_object(std::istream &in)
+{
+  goto_transform_historyt read;
+  auto transform_count = irep_serializationt::read_gb_word(in);
+  while(transform_count--)
+  {
+    const auto transform = irep_serializationt::read_gb_word(in);
+    read.add(static_cast<goto_transform_kindt>(transform));
+  }
+  return read;
 }
 
 static void read_bin_functions_object(
@@ -184,6 +198,8 @@ static void read_bin_functions_object(
 
     if(hidden)
       f.make_hidden();
+
+    f.history = read_bin_transform_history_object(in);
   }
 
   functions.compute_location_numbers();

--- a/src/goto-programs/remove_complex.cpp
+++ b/src/goto-programs/remove_complex.cpp
@@ -311,6 +311,7 @@ void remove_complex(
 {
   remove_complex(symbol_table);
   remove_complex(goto_functions);
+  add_history_transform(goto_transform_kindt::remove_complex, goto_functions);
 }
 
 /// removes complex data type

--- a/src/goto-programs/remove_function_pointers.cpp
+++ b/src/goto-programs/remove_function_pointers.cpp
@@ -533,4 +533,6 @@ void remove_function_pointers(
     goto_model.goto_functions);
 
   rfp(goto_model.goto_functions);
+  add_history_transform(
+    goto_transform_kindt::remove_function_pointers, goto_model.goto_functions);
 }

--- a/src/goto-programs/remove_returns.cpp
+++ b/src/goto-programs/remove_returns.cpp
@@ -231,6 +231,8 @@ void remove_returnst::operator()(goto_functionst &goto_functions)
     replace_returns(gf_entry.first, gf_entry.second);
     if(do_function_calls(function_is_stub, gf_entry.second.body))
       goto_functions.compute_location_numbers(gf_entry.second.body);
+    add_history_transform(
+      goto_transform_kindt::remove_returns, gf_entry.second);
   }
 }
 

--- a/src/goto-programs/remove_skip.cpp
+++ b/src/goto-programs/remove_skip.cpp
@@ -201,6 +201,7 @@ void remove_skip(goto_functionst &goto_functions)
       gf_entry.second.body,
       gf_entry.second.body.instructions.begin(),
       gf_entry.second.body.instructions.end());
+    add_history_transform(goto_transform_kindt::remove_skip, gf_entry.second);
   }
 
   // we may remove targets

--- a/src/goto-programs/remove_unused_functions.cpp
+++ b/src/goto-programs/remove_unused_functions.cpp
@@ -52,6 +52,8 @@ void remove_unused_functions(
 
   for(const auto &f : unused_functions)
     functions.function_map.erase(f);
+  add_history_transform(
+    goto_transform_kindt::remove_unused_functions, functions);
 }
 
 void find_used_functions(

--- a/src/goto-programs/remove_vector.cpp
+++ b/src/goto-programs/remove_vector.cpp
@@ -379,6 +379,7 @@ void remove_vector(
 {
   remove_vector(symbol_table);
   remove_vector(goto_functions);
+  add_history_transform(goto_transform_kindt::remove_vector, goto_functions);
 }
 
 /// removes vector data type

--- a/src/goto-programs/rewrite_union.cpp
+++ b/src/goto-programs/rewrite_union.cpp
@@ -107,6 +107,7 @@ void rewrite_union(goto_functionst::goto_functiont &goto_function)
     if(instruction.has_condition())
       rewrite_union(instruction.condition_nonconst());
   }
+  add_history_transform(goto_transform_kindt::rewrite_union, goto_function);
 }
 
 void rewrite_union(goto_functionst &goto_functions)

--- a/src/goto-programs/set_properties.cpp
+++ b/src/goto-programs/set_properties.cpp
@@ -103,6 +103,7 @@ void label_properties(goto_model_functiont &function)
   auto &goto_function = function.get_goto_function();
   label_properties(
     function.get_function_id(), goto_function.body, property_counters);
+  add_history_transform(goto_transform_kindt::label_properties, goto_function);
 }
 
 void set_properties(
@@ -137,5 +138,8 @@ void label_properties(goto_functionst &goto_functions)
       it=goto_functions.function_map.begin();
       it!=goto_functions.function_map.end();
       it++)
+  {
     label_properties(it->first, it->second.body, property_counters);
+    add_history_transform(goto_transform_kindt::label_properties, it->second);
+  }
 }

--- a/src/goto-programs/set_properties.cpp
+++ b/src/goto-programs/set_properties.cpp
@@ -49,9 +49,10 @@ void label_properties(goto_modelt &goto_model)
 
 static void label_properties(
   const irep_idt function_identifier,
-  goto_programt &goto_program,
+  goto_functiont &goto_function,
   std::map<irep_idt, std::size_t> &property_counters)
 {
+  goto_programt &goto_program = goto_function.body;
   for(goto_programt::instructionst::iterator
       it=goto_program.instructions.begin();
       it!=goto_program.instructions.end();
@@ -95,6 +96,7 @@ static void label_properties(
 
     it->source_location_nonconst().set_property_id(property_id);
   }
+  add_history_transform(goto_transform_kindt::label_properties, goto_function);
 }
 
 void label_properties(goto_model_functiont &function)
@@ -102,8 +104,7 @@ void label_properties(goto_model_functiont &function)
   std::map<irep_idt, std::size_t> property_counters;
   auto &goto_function = function.get_goto_function();
   label_properties(
-    function.get_function_id(), goto_function.body, property_counters);
-  add_history_transform(goto_transform_kindt::label_properties, goto_function);
+    function.get_function_id(), goto_function, property_counters);
 }
 
 void set_properties(
@@ -139,7 +140,6 @@ void label_properties(goto_functionst &goto_functions)
       it!=goto_functions.function_map.end();
       it++)
   {
-    label_properties(it->first, it->second.body, property_counters);
-    add_history_transform(goto_transform_kindt::label_properties, it->second);
+    label_properties(it->first, it->second, property_counters);
   }
 }

--- a/src/goto-programs/set_properties.cpp
+++ b/src/goto-programs/set_properties.cpp
@@ -97,10 +97,12 @@ void label_properties(
   }
 }
 
-void label_properties(irep_idt function_identifier, goto_programt &goto_program)
+void label_properties(goto_model_functiont &function)
 {
   std::map<irep_idt, std::size_t> property_counters;
-  label_properties(function_identifier, goto_program, property_counters);
+  auto &goto_function = function.get_goto_function();
+  label_properties(
+    function.get_function_id(), goto_function.body, property_counters);
 }
 
 void set_properties(

--- a/src/goto-programs/set_properties.cpp
+++ b/src/goto-programs/set_properties.cpp
@@ -47,7 +47,7 @@ void label_properties(goto_modelt &goto_model)
   label_properties(goto_model.goto_functions);
 }
 
-void label_properties(
+static void label_properties(
   const irep_idt function_identifier,
   goto_programt &goto_program,
   std::map<irep_idt, std::size_t> &property_counters)

--- a/src/goto-programs/set_properties.h
+++ b/src/goto-programs/set_properties.h
@@ -12,13 +12,12 @@ Author: Daniel Kroening, kroening@kroening.com
 #ifndef CPROVER_GOTO_PROGRAMS_SET_PROPERTIES_H
 #define CPROVER_GOTO_PROGRAMS_SET_PROPERTIES_H
 
-#include <util/irep.h>
-
 #include <list>
+#include <string>
 
 class goto_functionst;
+class goto_model_functiont;
 class goto_modelt;
-class goto_programt;
 
 void set_properties(
   goto_functionst &goto_functions,
@@ -29,7 +28,7 @@ void set_properties(
   const std::list<std::string> &properties);
 
 void label_properties(goto_functionst &);
-void label_properties(irep_idt function_identifier, goto_programt &);
+void label_properties(goto_model_functiont &);
 void label_properties(goto_modelt &);
 
 #endif // CPROVER_GOTO_PROGRAMS_SET_PROPERTIES_H

--- a/src/goto-programs/string_abstraction.cpp
+++ b/src/goto-programs/string_abstraction.cpp
@@ -178,6 +178,7 @@ void string_abstractiont::apply()
     main.swap(initialization);
     initialization.clear();
   }
+  add_history_transform(goto_transform_kindt::string_abstraction, dest);
 }
 
 void string_abstractiont::apply(goto_programt &dest)

--- a/src/goto-programs/string_instrumentation.cpp
+++ b/src/goto-programs/string_instrumentation.cpp
@@ -172,6 +172,7 @@ void string_instrumentation(
 {
   string_instrumentationt string_instrumentation{symbol_table};
   string_instrumentation(dest);
+  add_history_transform(goto_transform_kindt::string_instrumentation, dest);
 }
 
 void string_instrumentation(goto_modelt &goto_model)

--- a/src/goto-programs/string_instrumentation.h
+++ b/src/goto-programs/string_instrumentation.h
@@ -15,10 +15,7 @@ Author: Daniel Kroening, kroening@kroening.com
 class exprt;
 class goto_functionst;
 class goto_modelt;
-class goto_programt;
 class symbol_table_baset;
-
-void string_instrumentation(symbol_table_baset &, goto_programt &);
 
 void string_instrumentation(symbol_table_baset &, goto_functionst &);
 

--- a/src/goto-programs/write_goto_binary.cpp
+++ b/src/goto-programs/write_goto_binary.cpp
@@ -100,6 +100,18 @@ static void write_instructions_binary(
   }
 }
 
+static void write_transform_history_binary(
+  std::ostream &out,
+  const goto_transform_historyt &history)
+{
+  const auto &transforms = history.transforms();
+  write_gb_word(out, transforms.size());
+  for(const auto &transform : history.transforms())
+  {
+    write_gb_word(out, static_cast<std::size_t>(transform));
+  }
+}
+
 /// Writes the functions to file, but only those with non-empty body.
 static void write_goto_functions_binary(
   std::ostream &out,
@@ -126,6 +138,7 @@ static void write_goto_functions_binary(
     const auto function_name = id2string(fct.first);
     write_gb_string(out, function_name);
     write_instructions_binary(out, irepconverter, fct);
+    write_transform_history_binary(out, fct.second.history);
   }
 }
 

--- a/src/goto-programs/write_goto_binary.h
+++ b/src/goto-programs/write_goto_binary.h
@@ -12,7 +12,7 @@ Author: CM Wintersteiger
 #ifndef CPROVER_GOTO_PROGRAMS_WRITE_GOTO_BINARY_H
 #define CPROVER_GOTO_PROGRAMS_WRITE_GOTO_BINARY_H
 
-#define GOTO_BINARY_VERSION 5
+#define GOTO_BINARY_VERSION 6
 
 #include <iosfwd>
 #include <string>

--- a/unit/Makefile
+++ b/unit/Makefile
@@ -71,6 +71,7 @@ SRC += analyses/ai/ai.cpp \
        goto-programs/goto_program_table_consistency.cpp \
        goto-programs/goto_program_validate.cpp \
        goto-programs/goto_trace_output.cpp \
+       goto-programs/goto_transform_history.cpp \
        goto-programs/is_goto_binary.cpp \
        goto-programs/label_function_pointer_call_sites.cpp \
        goto-programs/osx_fat_reader.cpp \

--- a/unit/Makefile
+++ b/unit/Makefile
@@ -61,6 +61,7 @@ SRC += analyses/ai/ai.cpp \
        goto-instrument/cover/cover_only.cpp \
        goto-synthesizer/expr_enumerator/expr_enumerator.cpp \
        goto-programs/allocate_objects.cpp \
+       goto-programs/goto_binary_serialization.cpp \
        goto-programs/goto_program_assume.cpp \
        goto-programs/goto_program_dead.cpp \
        goto-programs/goto_program_declaration.cpp \

--- a/unit/goto-programs/goto_binary_serialization.cpp
+++ b/unit/goto-programs/goto_binary_serialization.cpp
@@ -1,0 +1,49 @@
+/*******************************************************************\
+
+Module: Unit tests for read_goto_binary and write_goto_binary
+
+Author: Diffblue Ltd.
+
+\*******************************************************************/
+
+#include <util/tempfile.h>
+
+#include <goto-programs/goto_model.h>
+#include <goto-programs/read_goto_binary.h>
+#include <goto-programs/write_goto_binary.h>
+
+#include <testing-utils/message.h>
+#include <testing-utils/use_catch.h>
+
+goto_functiont &add_goto_function(const irep_idt &name, goto_modelt &model)
+{
+  goto_functiont function{};
+  function.body.add(goto_programt::make_location(source_locationt{}));
+  auto result =
+    model.goto_functions.function_map.emplace(name, std::move(function));
+  return result.first->second;
+}
+
+TEST_CASE(
+  "Test goto_modelt can be saved and restored",
+  "[core][goto-programs][goto-binary]")
+{
+  temporary_filet tmp_file{"serialization", ".gb"};
+
+  goto_modelt model{};
+
+  irep_idt function_name{"foo"};
+  add_goto_function(function_name, model);
+
+  write_goto_binary(tmp_file(), model, null_message_handler);
+
+  auto deserialized_model = read_goto_binary(tmp_file(), null_message_handler);
+
+  REQUIRE(deserialized_model.has_value());
+  const auto &deserialized_function_map =
+    deserialized_model->goto_functions.function_map;
+  REQUIRE(deserialized_function_map.size() == 1);
+  REQUIRE(
+    deserialized_function_map.find(function_name) !=
+    deserialized_function_map.end());
+}

--- a/unit/goto-programs/goto_binary_serialization.cpp
+++ b/unit/goto-programs/goto_binary_serialization.cpp
@@ -47,3 +47,55 @@ TEST_CASE(
     deserialized_function_map.find(function_name) !=
     deserialized_function_map.end());
 }
+
+TEST_CASE(
+  "Test goto_historyt is saved and restored",
+  "[core][goto-programs][goto-binary]")
+{
+  temporary_filet tmp_file{"serialization", ".gb"};
+
+  goto_modelt model{};
+
+  irep_idt foo_name{"foo"};
+  auto &foo_function = add_goto_function(foo_name, model);
+  foo_function.history.add(goto_transform_kindt::adjust_float_expressions);
+  const auto &foo_transforms = foo_function.history.transforms();
+
+  irep_idt bar_name{"bar"};
+  auto &bar_function = add_goto_function(bar_name, model);
+  bar_function.history.add(goto_transform_kindt::mm_io);
+  const auto &bar_transforms = bar_function.history.transforms();
+
+  irep_idt buz_name{"buz"};
+  auto &buz_function = add_goto_function(buz_name, model);
+  buz_function.history.add(goto_transform_kindt::adjust_float_expressions);
+  buz_function.history.add(goto_transform_kindt::mm_io);
+  const auto &buz_transforms = buz_function.history.transforms();
+
+  write_goto_binary(tmp_file(), model, null_message_handler);
+
+  auto deserialized_model = read_goto_binary(tmp_file(), null_message_handler);
+
+  REQUIRE(deserialized_model.has_value());
+  const auto &deserialized_function_map =
+    deserialized_model->goto_functions.function_map;
+  REQUIRE(deserialized_function_map.size() == 3);
+
+  const auto deserialized_foo_function =
+    deserialized_function_map.find(foo_name);
+  REQUIRE(deserialized_foo_function != deserialized_function_map.end());
+  REQUIRE(
+    deserialized_foo_function->second.history.transforms() == foo_transforms);
+
+  const auto deserialized_bar_function =
+    deserialized_function_map.find(bar_name);
+  REQUIRE(deserialized_bar_function != deserialized_function_map.end());
+  REQUIRE(
+    deserialized_bar_function->second.history.transforms() == bar_transforms);
+
+  const auto deserialized_buz_function =
+    deserialized_function_map.find(buz_name);
+  REQUIRE(deserialized_buz_function != deserialized_function_map.end());
+  REQUIRE(
+    deserialized_buz_function->second.history.transforms() == buz_transforms);
+}

--- a/unit/goto-programs/goto_transform_history.cpp
+++ b/unit/goto-programs/goto_transform_history.cpp
@@ -1,0 +1,22 @@
+// Author: Diffblue Ltd.
+
+#include <goto-programs/goto_transform_history.h>
+
+#include <testing-utils/use_catch.h>
+
+TEST_CASE("Goto transform history data structure", "[core][goto-programs]")
+{
+  goto_transform_historyt history;
+  REQUIRE(history.transforms().empty());
+  history.add(goto_transform_kindt::mm_io);
+  REQUIRE_THAT(
+    history.transforms(),
+    Catch::Matchers::Equals(
+      goto_transform_historyt::transformst{goto_transform_kindt::mm_io}));
+  history.add(goto_transform_kindt::adjust_float_expressions);
+  REQUIRE_THAT(
+    history.transforms(),
+    Catch::Matchers::Equals(goto_transform_historyt::transformst{
+      goto_transform_kindt::mm_io,
+      goto_transform_kindt::adjust_float_expressions}));
+}


### PR DESCRIPTION
This PR adds tracking of goto-function transformation history. This will enable adding checks relating to transform inter-dependencies and checks that appropriate transforms have been performed before reaching symex.
<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
