### PR TITLE
Mark CBMC version 5.80.0

### DIFF
--- a/regression/libcprover-cpp/call_bmc.cpp
+++ b/regression/libcprover-cpp/call_bmc.cpp
@@ -23,6 +23,7 @@ int main(int argc, char *argv[])
   try
   {
     std::cout << "Hello from API stub" << std::endl;
+    std::cout << "Working from C++ API version ";
 
     // Convert argv to vector of strings for initialize_goto_model
     std::vector<std::string> arguments(argv + 1, argv + argc);
@@ -35,6 +36,7 @@ int main(int argc, char *argv[])
 
     // Initialise API dependencies and global configuration in one step.
     api_sessiont api(api_options);
+    std::cout << *api.get_api_version() << std::endl;
 
     // Demonstrate the loading of a goto-model from the command line arguments
     api.set_message_callback(print_messages_to_stdout, nullptr);

--- a/src/config.inc
+++ b/src/config.inc
@@ -76,7 +76,7 @@ endif
 OSX_IDENTITY="Developer ID Application: Daniel Kroening"
 
 # Detailed version information
-CBMC_VERSION = 5.79.0
+CBMC_VERSION = 5.80.0
 
 # Use the CUDD library for BDDs, can be installed using `make -C src cudd-download`
 # CUDD = ../../cudd-3.0.0

--- a/src/libcprover-cpp/api.cpp
+++ b/src/libcprover-cpp/api.cpp
@@ -8,6 +8,7 @@
 #include <util/message.h>
 #include <util/options.h>
 #include <util/ui_message.h>
+#include <util/version.h>
 
 #include <goto-programs/goto_model.h>
 #include <goto-programs/initialize_goto_model.h>
@@ -34,7 +35,7 @@ extern configt config;
 
 std::unique_ptr<std::string> api_sessiont::get_api_version() const
 {
-  return util_make_unique<std::string>(std::string{"0.1"});
+  return util_make_unique<std::string>(std::string{CBMC_VERSION});
 }
 
 struct api_session_implementationt

--- a/src/libcprover-rust/Cargo.lock
+++ b/src/libcprover-rust/Cargo.lock
@@ -64,7 +64,7 @@ dependencies = [
 
 [[package]]
 name = "libcprover_rust"
-version = "0.1.0"
+version = "5.80.0"
 dependencies = [
  "cxx",
  "cxx-build",

--- a/src/libcprover-rust/Cargo.toml
+++ b/src/libcprover-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libcprover_rust"
-version = "0.1.0"
+version = "5.80.0"
 edition = "2021"
 description = "Rust API for CBMC and assorted CProver tools"
 repository = "https://github.com/diffblue/cbmc"

--- a/src/libcprover-rust/src/lib.rs
+++ b/src/libcprover-rust/src/lib.rs
@@ -89,8 +89,8 @@ mod tests {
         let client = cprover_api::new_api_session();
         let result = client.get_api_version();
 
-        let_cxx_string!(expected_version = "0.1");
-        assert_eq!(*result, *expected_version);
+        let_cxx_string!(expected_version = "5.79.0");
+        assert!(*result > *expected_version);
     }
 
     #[test]


### PR DESCRIPTION
This PR brings the C++ API version reported up to speed with the general CBMC version, and then updates the CBMC version to 5.80.0

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
