### PR TITLE
Reading/writing goto binaries: consistently use return values

### DIFF
--- a/src/goto-analyzer/static_simplifier.cpp
+++ b/src/goto-analyzer/static_simplifier.cpp
@@ -190,7 +190,6 @@ bool static_simplifier(
   goto_model.goto_functions.update();
 
   m.status() << "Writing goto binary" << messaget::eom;
-  return write_goto_binary(out,
-                           ns.get_symbol_table(),
-                           goto_model.goto_functions);
+  return write_goto_binary(
+    out, ns.get_symbol_table(), goto_model.goto_functions, message_handler);
 }

--- a/src/goto-cc/compile.cpp
+++ b/src/goto-cc/compile.cpp
@@ -601,7 +601,7 @@ bool compilet::write_bin_object_file(
     return true;
   }
 
-  if(write_goto_binary(outfile, src_goto_model))
+  if(write_goto_binary(outfile, src_goto_model, message_handler))
     return true;
 
   const auto cnt = function_body_count(src_goto_model.goto_functions);

--- a/src/goto-harness/goto_harness_parse_options.cpp
+++ b/src/goto-harness/goto_harness_parse_options.cpp
@@ -163,8 +163,13 @@ int goto_harness_parse_optionst::doit()
   }
   else
   {
-    write_goto_binary(
-      got_harness_config.out_file, goto_model, log.get_message_handler());
+    if(write_goto_binary(
+         got_harness_config.out_file, goto_model, log.get_message_handler()))
+    {
+      throw system_exceptiont{
+        "failed to write goto program to file '" + got_harness_config.out_file +
+        "'"};
+    }
   }
 
   return CPROVER_EXIT_SUCCESS;

--- a/src/goto-programs/read_bin_goto_object.h
+++ b/src/goto-programs/read_bin_goto_object.h
@@ -21,7 +21,7 @@ class symbol_table_baset;
 class goto_functionst;
 class message_handlert;
 
-bool read_bin_goto_object(
+[[nodiscard]] bool read_bin_goto_object(
   std::istream &in,
   const std::string &filename,
   symbol_table_baset &symbol_table,

--- a/src/goto-programs/read_goto_binary.h
+++ b/src/goto-programs/read_goto_binary.h
@@ -29,7 +29,7 @@ bool is_goto_binary(const std::string &filename, message_handlert &);
 /// \param [out] dest: GOTO model to update.
 /// \param message_handler: for diagnostics
 /// \return True on error, false otherwise
-bool read_objects_and_link(
+[[nodiscard]] bool read_objects_and_link(
   const std::list<std::string> &file_names,
   goto_modelt &dest,
   message_handlert &message_handler);

--- a/src/goto-programs/write_goto_binary.cpp
+++ b/src/goto-programs/write_goto_binary.cpp
@@ -11,13 +11,12 @@ Author: CM Wintersteiger
 
 #include "write_goto_binary.h"
 
-#include <fstream>
-
-#include <util/exception_utils.h>
 #include <util/irep_serialization.h>
 #include <util/message.h>
 
 #include <goto-programs/goto_model.h>
+
+#include <fstream>
 
 /// Writes the symbol table to file.
 static void write_symbol_table_binary(
@@ -144,12 +143,14 @@ static void write_goto_binary(
 bool write_goto_binary(
   std::ostream &out,
   const goto_modelt &goto_model,
+  message_handlert &message_handler,
   int version)
 {
   return write_goto_binary(
     out,
     goto_model.symbol_table,
     goto_model.goto_functions,
+    message_handler,
     version);
 }
 
@@ -158,19 +159,24 @@ bool write_goto_binary(
   std::ostream &out,
   const symbol_table_baset &symbol_table,
   const goto_functionst &goto_functions,
+  message_handlert &message_handler,
   int version)
 {
+  messaget message{message_handler};
+
   if(version < GOTO_BINARY_VERSION)
   {
-    throw invalid_command_line_argument_exceptiont(
-      "version " + std::to_string(version) + " no longer supported",
-      "supported version = " + std::to_string(GOTO_BINARY_VERSION));
+    message.error() << "version " << version << " no longer supported; "
+                    << "supported version = " << GOTO_BINARY_VERSION
+                    << messaget::eom;
+    return true;
   }
   if(version > GOTO_BINARY_VERSION)
   {
-    throw invalid_command_line_argument_exceptiont(
-      "unknown goto binary version " + std::to_string(version),
-      "supported version = " + std::to_string(GOTO_BINARY_VERSION));
+    message.error() << "unknown goto binary version " << version << "; "
+                    << "supported version = " << GOTO_BINARY_VERSION
+                    << messaget::eom;
+    return true;
   }
 
   // header
@@ -195,9 +201,9 @@ bool write_goto_binary(
   if(!out)
   {
     messaget message(message_handler);
-    message.error() << "Failed to open '" << filename << "'";
+    message.error() << "Failed to open '" << filename << "'" << messaget::eom;
     return true;
   }
 
-  return write_goto_binary(out, goto_model);
+  return write_goto_binary(out, goto_model, message_handler);
 }

--- a/src/goto-programs/write_goto_binary.cpp
+++ b/src/goto-programs/write_goto_binary.cpp
@@ -160,13 +160,6 @@ bool write_goto_binary(
   const goto_functionst &goto_functions,
   int version)
 {
-  // header
-  out << char(0x7f) << "GBF";
-  write_gb_word(out, version);
-
-  irep_serializationt::ireps_containert irepc;
-  irep_serializationt irepconverter(irepc);
-
   if(version < GOTO_BINARY_VERSION)
   {
     throw invalid_command_line_argument_exceptiont(
@@ -179,6 +172,14 @@ bool write_goto_binary(
       "unknown goto binary version " + std::to_string(version),
       "supported version = " + std::to_string(GOTO_BINARY_VERSION));
   }
+
+  // header
+  out << char(0x7f) << "GBF";
+  write_gb_word(out, version);
+
+  irep_serializationt::ireps_containert irepc;
+  irep_serializationt irepconverter(irepc);
+
   write_goto_binary(out, symbol_table, goto_functions, irepconverter);
   return false;
 }

--- a/src/goto-programs/write_goto_binary.h
+++ b/src/goto-programs/write_goto_binary.h
@@ -22,18 +22,20 @@ class goto_modelt;
 class message_handlert;
 class symbol_table_baset;
 
-bool write_goto_binary(
+[[nodiscard]] bool write_goto_binary(
   std::ostream &out,
   const goto_modelt &,
-  int version=GOTO_BINARY_VERSION);
+  message_handlert &,
+  int version = GOTO_BINARY_VERSION);
 
-bool write_goto_binary(
+[[nodiscard]] bool write_goto_binary(
   std::ostream &out,
   const symbol_table_baset &,
   const goto_functionst &,
+  message_handlert &,
   int version = GOTO_BINARY_VERSION);
 
-bool write_goto_binary(
+[[nodiscard]] bool write_goto_binary(
   const std::string &filename,
   const goto_modelt &,
   message_handlert &);

--- a/src/symtab2gb/symtab2gb_parse_options.cpp
+++ b/src/symtab2gb/symtab2gb_parse_options.cpp
@@ -142,7 +142,7 @@ static void run_symtab2gb(
   // Convert symbols to goto functions
   goto_convert(linked_goto_model, message_handler);
 
-  if(failed(write_goto_binary(out_file, linked_goto_model)))
+  if(failed(write_goto_binary(out_file, linked_goto_model, message_handler)))
   {
     throw system_exceptiont{"failed to write goto binary to " + gb_filename};
   }

--- a/unit/Makefile
+++ b/unit/Makefile
@@ -78,6 +78,7 @@ SRC += analyses/ai/ai.cpp \
        goto-programs/restrict_function_pointers.cpp \
        goto-programs/structured_trace_util.cpp \
        goto-programs/remove_returns.cpp \
+       goto-programs/write_goto_binary.cpp \
        goto-programs/xml_expr.cpp \
        goto-symex/apply_condition.cpp \
        goto-symex/complexity_limiter.cpp \

--- a/unit/goto-programs/write_goto_binary.cpp
+++ b/unit/goto-programs/write_goto_binary.cpp
@@ -1,0 +1,49 @@
+/*******************************************************************\
+
+Module: Unit tests for write_goto_binary
+
+Author: Diffblue Ltd.
+
+\*******************************************************************/
+
+#include <util/message.h>
+
+#include <goto-programs/goto_model.h>
+#include <goto-programs/write_goto_binary.h>
+
+#include <testing-utils/use_catch.h>
+
+#include <sstream>
+
+TEST_CASE(
+  "write_goto_binary validates the version before writing",
+  "[core][goto-programs][write_goto_binary]")
+{
+  const goto_modelt goto_model;
+  null_message_handlert message_handler;
+
+  SECTION("a version below the supported one is rejected, nothing written")
+  {
+    std::ostringstream out;
+    REQUIRE(write_goto_binary(
+      out, goto_model, message_handler, GOTO_BINARY_VERSION - 1));
+    // the version is validated before the header is written, so the stream is
+    // left untouched
+    REQUIRE(out.str().empty());
+  }
+
+  SECTION("a version above the supported one is rejected, nothing written")
+  {
+    std::ostringstream out;
+    REQUIRE(write_goto_binary(
+      out, goto_model, message_handler, GOTO_BINARY_VERSION + 1));
+    REQUIRE(out.str().empty());
+  }
+
+  SECTION("the supported version is written successfully")
+  {
+    std::ostringstream out;
+    REQUIRE_FALSE(write_goto_binary(out, goto_model, message_handler));
+    REQUIRE_FALSE(out.str().empty());
+  }
+}


### PR DESCRIPTION
Always use the return value to communicate errors, not a mix of return values and exceptions.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
