### PR TITLE
Simplify inequality over pointers

### DIFF
--- a/regression/cbmc-incr-smt2/pointers-relational-operators/pointers_stack_lessthan.c
+++ b/regression/cbmc-incr-smt2/pointers-relational-operators/pointers_stack_lessthan.c
@@ -2,8 +2,8 @@
 
 int main()
 {
-  int i = 12;
-  int *x = &i;
+  int i[2] = {12, 13};
+  int *x = &i[0] + 1;
   int *y = x + 1;
   int *z = x - 1;
 

--- a/regression/cbmc/Pointer_comparison4/main.c
+++ b/regression/cbmc/Pointer_comparison4/main.c
@@ -1,0 +1,6 @@
+int main()
+{
+  int A[5] = {0, 1, 2, 3, 4};
+  for(int *iter = &A[0]; iter < &A[5]; ++iter)
+    __CPROVER_assert(*iter == iter - &A[0], "values match");
+}

--- a/regression/cbmc/Pointer_comparison4/test.desc
+++ b/regression/cbmc/Pointer_comparison4/test.desc
@@ -1,0 +1,12 @@
+CORE
+main.c
+--unwind 10 --unwinding-assertions
+^VERIFICATION SUCCESSFUL$
+^EXIT=0$
+^SIGNAL=0$
+--
+Unwinding loop .* iteration 6
+^warning: ignoring
+--
+Simplification and constant propagation should ensure that unwinding the loop
+stops when reaching the array bound.


### PR DESCRIPTION
When using pointers as iterators we may see less-than (or less-or-equal) comparison of pointers with some offsets. When the base pointers point to the same root object we can safely simplify this.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
