### PR TITLE
Fix in readme and CMake build system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,8 @@ string(REGEX REPLACE "CBMC_VERSION = (.*)" "\\1" CBMC_VERSION ${CBMC_VERSION})
 
 project(CBMC VERSION ${CBMC_VERSION})
 
+set(CBMC_ROOT_DIR ${CMAKE_CURRENT_SOURCE_DIR})
+
 # when config.inc changes we’ll need to reconfigure to check if the version changed
 set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/src/config.inc")
 

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Contributing to the code base
 6. Create a Pull Request targeting the `develop` branch
 
 New contributors can look through the [mini
-projects](https://github.com/diffblue/cbmc/blob/develop/MINI-PROJECTS.md)
+projects](https://github.com/diffblue/cbmc/blob/develop/FEATURE_IDEAS.md)
 page for small, focussed feature ideas.
 
 License

--- a/src/cbmc/CMakeLists.txt
+++ b/src/cbmc/CMakeLists.txt
@@ -58,15 +58,15 @@ endif()
 
 # bash completion
 if(NOT WIN32)
-  add_custom_command(OUTPUT "${CMAKE_SOURCE_DIR}/scripts/bash-autocomplete/cbmc.sh"
-    COMMAND "${CMAKE_SOURCE_DIR}/scripts/bash-autocomplete/extract_switches.sh"
+  add_custom_command(OUTPUT "${CBMC_ROOT_DIR}/scripts/bash-autocomplete/cbmc.sh"
+    COMMAND "${CBMC_ROOT_DIR}/scripts/bash-autocomplete/extract_switches.sh"
     DEPENDS $<TARGET_FILE:cbmc>
   )
   add_custom_target(cbmc.sh ALL
-    DEPENDS "${CMAKE_SOURCE_DIR}/scripts/bash-autocomplete/cbmc.sh"
+    DEPENDS "${CBMC_ROOT_DIR}/scripts/bash-autocomplete/cbmc.sh"
   )
   install(
-    FILES ${CMAKE_SOURCE_DIR}/scripts/bash-autocomplete/cbmc.sh
+    FILES ${CBMC_ROOT_DIR}/scripts/bash-autocomplete/cbmc.sh
     DESTINATION etc/bash_completion.d
     RENAME cbmc
   )


### PR DESCRIPTION
Fixes #7649 for Cmake builds using `add_subdirectory` as well as `fetch_content`.
Now the bash scripts are generated/called relative to the directory where `/src/cbmc/CMakeFiles.txt` is located. This means that when the original `CMakeFiles.txt` is outside of cbmc's root directory (for example in an external project) then the correct path is used when running the bash scripts.

Edit( This has been removed and a separate issue has been created): I also added the "-Wno-return-type" flag as that threw compilation errors in cases where `UNREACHABLE` was used but no return was used in dead code.

I also fixed a link in the readme.md that used to point to "MINI-PROJECTS". It now points to "FEATURE_IDEAS.md".