### PR TITLE
Fixup GCC 12 errors

### DIFF
--- a/regression/invariants/driver.cpp
+++ b/regression/invariants/driver.cpp
@@ -112,6 +112,8 @@ int main(int argc, char** argv)
     UNREACHABLE_STRUCTURED(structured_error_testt, 1, "Structured error"); // NOLINT
   else if(arg=="unreachable-string")
     UNREACHABLE;
+  else if(arg == "unreachable-because")
+    UNREACHABLE_BECAUSE("Unreachable with explanation text");
   else if(arg=="data-invariant-structured")
     DATA_INVARIANT_STRUCTURED(false, structured_error_testt, 1, "Structured error"); // NOLINT
   else if(arg=="data-invariant-string")

--- a/regression/invariants/invariant-failure21/test.desc
+++ b/regression/invariants/invariant-failure21/test.desc
@@ -1,0 +1,12 @@
+CORE
+dummy_parameter.c
+unreachable-because
+^EXIT=(0|127|134|137)$
+^SIGNAL=0$
+--- begin invariant violation report ---
+Unreachable with explanation text
+Invariant check failed
+^(Backtrace)|(Backtraces not supported)$
+--
+^warning: ignoring
+^VERIFICATION SUCCESSFUL$

--- a/src/solvers/smt2/smt2_conv.cpp
+++ b/src/solvers/smt2/smt2_conv.cpp
@@ -516,10 +516,9 @@ constant_exprt smt2_convt::parse_literal(
     return from_integer(value, type);
   }
   else
-    INVARIANT(
-      false,
+    UNREACHABLE_BECAUSE(
       "smt2_convt::parse_literal should not be of unsupported type " +
-        type.id_string());
+      type.id_string());
 }
 
 exprt smt2_convt::parse_array(

--- a/src/solvers/strings/string_format_builtin_function.cpp
+++ b/src/solvers/strings/string_format_builtin_function.cpp
@@ -232,7 +232,8 @@ add_axioms_for_format_specifier(
   }
   }
 
-  INVARIANT(false, "format specifier must belong to [bBhHsScCdoxXeEfgGaAtT%n]");
+  UNREACHABLE_BECAUSE(
+    "format specifier must belong to [bBhHsScCdoxXeEfgGaAtT%n]");
 }
 
 /// Deserialize an argument for format from \p string.

--- a/src/util/invariant.h
+++ b/src/util/invariant.h
@@ -509,6 +509,12 @@ CBMC_NORETURN void report_invariant_failure(
       INVARIANT(false, "Unreachable");                                         \
       __builtin_unreachable();                                                 \
     } while(false)
+#  define UNREACHABLE_BECAUSE(REASON)                                          \
+    do                                                                         \
+    {                                                                          \
+      INVARIANT(false, REASON);                                                \
+      __builtin_unreachable();                                                 \
+    } while(false)
 #  define UNREACHABLE_STRUCTURED(TYPENAME, ...)                                \
     do                                                                         \
     {                                                                          \
@@ -517,6 +523,7 @@ CBMC_NORETURN void report_invariant_failure(
     } while(false)
 #else
 #  define UNREACHABLE INVARIANT(false, "Unreachable")
+#  define UNREACHABLE_BECAUSE(REASON) INVARIANT(false, REASON)
 #  define UNREACHABLE_STRUCTURED(TYPENAME, ...)                                \
     EXPAND_MACRO(INVARIANT_STRUCTURED(false, TYPENAME, __VA_ARGS__))
 #endif

--- a/src/util/invariant.h
+++ b/src/util/invariant.h
@@ -531,8 +531,17 @@ CBMC_NORETURN void report_invariant_failure(
 #define DATA_INVARIANT_STRUCTURED(CONDITION, TYPENAME, ...)                    \
   EXPAND_MACRO(INVARIANT_STRUCTURED(CONDITION, TYPENAME, __VA_ARGS__))
 
-#define UNIMPLEMENTED_FEATURE(FEATURE)                                         \
-  INVARIANT(false, std::string{"Reached unimplemented "} + (FEATURE))
+#if __GNUC__
+#  define UNIMPLEMENTED_FEATURE(FEATURE)                                       \
+    do                                                                         \
+    {                                                                          \
+      INVARIANT(false, std::string{"Reached unimplemented "} + (FEATURE));     \
+      __builtin_unreachable();                                                 \
+    } while(false)
+#else
+#  define UNIMPLEMENTED_FEATURE(FEATURE)                                       \
+    INVARIANT(false, std::string{"Reached unimplemented "} + (FEATURE))
+#endif
 
 // Legacy annotations
 


### PR DESCRIPTION
GCC 12 when using `-O0` fails because of a missing-return-statement warning caused by the implementation of `INVARIANT(false)`.

This is because the condition `if (true)` is not considered exahustive.

The solution involves marking the unreachable path as `__builtin_unreachable()`.

This PR also replaces some `INVARIANT(false, REASON)` statement used to have `UNREACHABLE`, but with a reason.

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
