### PR TITLE
Add the `readme.md` path to the Cargo.toml.

### DIFF
--- a/src/libcprover-rust/Cargo.toml
+++ b/src/libcprover-rust/Cargo.toml
@@ -7,6 +7,7 @@ repository = "https://github.com/diffblue/cbmc"
 documentation = "https://diffblue.github.io/cbmc/"
 license = "BSD-4-Clause"
 exclude = ["module_dependencies.txt", "Cargo.lock"]
+readme = "readme.md"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
According to the rust documentation at https://doc.rust-lang.org/cargo/reference/manifest.html#the-readme-field, the default readme file looked up when creating the package is a capitalised `README.md` (and some others).

Since ours isn't capitalised, we have to explicitly indicate the file name.

Fixes #7667.

