### PR TITLE
Byte-extract lowering: do not blindly use offsets

### DIFF
--- a/regression/cbmc/byte_extract2/main.c
+++ b/regression/cbmc/byte_extract2/main.c
@@ -1,0 +1,22 @@
+#include <assert.h>
+
+#define SIZE 1
+
+struct s
+{
+  char a1[1];
+  unsigned int a2_len;
+  char a2[SIZE];
+};
+
+void main()
+{
+  struct s s1;
+  char buf[SIZE];
+
+  __CPROVER_assume(s1.a2_len <= SIZE);
+  __CPROVER_assume(s1.a2_len >= SIZE);
+  char src_n[s1.a2_len];
+  __CPROVER_array_copy(src_n, s1.a2);
+  assert(src_n[0] == s1.a2[0]);
+}

--- a/regression/cbmc/byte_extract2/test.desc
+++ b/regression/cbmc/byte_extract2/test.desc
@@ -1,0 +1,11 @@
+CORE broken-cprover-smt-backend
+main.c
+
+^VERIFICATION SUCCESSFUL$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--
+The CPROVER SMT2 back-end does not support quantifiers, which are brought into
+this example via an array comprehension.

--- a/src/solvers/smt2/smt2_parser.cpp
+++ b/src/solvers/smt2/smt2_parser.cpp
@@ -1207,7 +1207,7 @@ void smt2_parsert::setup_expressions()
 
     // add the widths
     auto op_width = make_range(op).map(
-      [](const exprt &o) { return to_unsignedbv_type(o.type()).get_width(); });
+      [](const exprt &o) { return to_bitvector_type(o.type()).get_width(); });
 
     const std::size_t total_width =
       std::accumulate(op_width.begin(), op_width.end(), 0);


### PR DESCRIPTION
When unpacking an array we must not create 0 bytes up until an offset when the source array can never be as large. Doing so when within a struct would spuriously produce a larger member.

Fixes: #7654

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
