### PR TITLE
SMT2 back-end: CVC5 does not support lambda expressions

### DIFF
--- a/src/solvers/smt2/smt2_conv.cpp
+++ b/src/solvers/smt2/smt2_conv.cpp
@@ -119,7 +119,6 @@ smt2_convt::smt2_convt(
     use_array_of_bool = true;
     use_as_const = true;
     use_check_sat_assuming = true;
-    use_lambda_for_array = true;
     use_datatypes = true;
     break;
 


### PR DESCRIPTION
I wrongly asserted (in 8fdb8bb8bd8) that CVC5 supports lambda. It seemingly does not, as can also be confirmed using Z3's test https://github.com/Z3Prover/z3test/blob/master/regressions/smt2/memset.smt2.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
