### PR TITLE
Make goto_{model,functions}t::unload return a value

### DIFF
--- a/jbmc/src/java_bytecode/lazy_goto_functions_map.h
+++ b/jbmc/src/java_bytecode/lazy_goto_functions_map.h
@@ -126,9 +126,12 @@ public:
            driver_program_can_generate_function_body(name);
   }
 
-  void unload(const key_type &name) const
+  /// Remove the function named \p name from the function map, if it exists.
+  /// \return Returns 0 when \p name was not present, and 1 when \p name was
+  ///   removed.
+  std::size_t unload(const key_type &name) const
   {
-    goto_functions.erase(name);
+    return goto_functions.erase(name);
   }
 
   void ensure_function_loaded(const key_type &name) const

--- a/jbmc/src/java_bytecode/lazy_goto_model.cpp
+++ b/jbmc/src/java_bytecode/lazy_goto_model.cpp
@@ -170,7 +170,7 @@ void lazy_goto_modelt::initialize(
   set_up_custom_entry_point(
     language_files,
     symbol_table,
-    [this](const irep_idt &id) { goto_functions.unload(id); },
+    [this](const irep_idt &id) { return goto_functions.unload(id); },
     options,
     false,
     message_handler);

--- a/src/goto-programs/goto_functions.h
+++ b/src/goto-programs/goto_functions.h
@@ -66,8 +66,13 @@ public:
     return *this;
   }
 
-  /// Remove function from the function map
-  void unload(const irep_idt &name) { function_map.erase(name); }
+  /// Remove the function named \p name from the function map, if it exists.
+  /// \return Returns 0 when \p name was not present, and 1 when \p name was
+  ///   removed.
+  std::size_t unload(const irep_idt &name)
+  {
+    return function_map.erase(name);
+  }
 
   void clear()
   {

--- a/src/goto-programs/goto_model.h
+++ b/src/goto-programs/goto_model.h
@@ -66,7 +66,13 @@ public:
     return *this;
   }
 
-  void unload(const irep_idt &name) { goto_functions.unload(name); }
+  /// Remove the function named \p name from the function map, if it exists.
+  /// \return Returns 0 when \p name was not present, and 1 when \p name was
+  ///   removed.
+  std::size_t unload(const irep_idt &name)
+  {
+    return goto_functions.unload(name);
+  }
 
   // Implement the abstract goto model interface:
 

--- a/src/goto-programs/initialize_goto_model.cpp
+++ b/src/goto-programs/initialize_goto_model.cpp
@@ -120,7 +120,7 @@ void initialize_from_source_files(
 void set_up_custom_entry_point(
   language_filest &language_files,
   symbol_tablet &symbol_table,
-  const std::function<void(const irep_idt &)> &unload,
+  const std::function<std::size_t(const irep_idt &)> &unload,
   const optionst &options,
   bool try_mode_lookup,
   message_handlert &message_handler)
@@ -213,7 +213,7 @@ goto_modelt initialize_goto_model(
   set_up_custom_entry_point(
     language_files,
     goto_model.symbol_table,
-    [&goto_model](const irep_idt &id) { goto_model.goto_functions.unload(id); },
+    [&goto_model](const irep_idt &id) { return goto_model.unload(id); },
     options,
     true,
     message_handler);

--- a/src/goto-programs/initialize_goto_model.h
+++ b/src/goto-programs/initialize_goto_model.h
@@ -51,7 +51,7 @@ void initialize_from_source_files(
 void set_up_custom_entry_point(
   language_filest &language_files,
   symbol_tablet &symbol_table,
-  const std::function<void(const irep_idt &)> &unload,
+  const std::function<std::size_t(const irep_idt &)> &unload,
   const optionst &options,
   bool try_mode_lookup,
   message_handlert &message_handler);


### PR DESCRIPTION
This will enable its use in place of .erase(...) when such a call required the number of functions that had been removed. The key user will be a refactored initialize-function re-creation code.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
