### PR TITLE
Decouple is_fresh from code_contractst

### DIFF
--- a/src/goto-instrument/contracts/contracts.cpp
+++ b/src/goto-instrument/contracts/contracts.cpp
@@ -668,7 +668,8 @@ void code_contractst::apply_function_contract(
   // new program where all contract-derived instructions are added
   goto_programt new_program;
 
-  is_fresh_replacet is_fresh(*this, log, target_function);
+  is_fresh_replacet is_fresh(
+    goto_model, log.get_message_handler(), target_function);
   is_fresh.create_declarations();
   is_fresh.add_memory_map_decl(new_program);
 
@@ -1072,16 +1073,6 @@ void code_contractst::apply_loop_contract(
   }
 }
 
-symbol_tablet &code_contractst::get_symbol_table()
-{
-  return symbol_table;
-}
-
-goto_functionst &code_contractst::get_goto_functions()
-{
-  return goto_functions;
-}
-
 void code_contractst::check_frame_conditions_function(const irep_idt &function)
 {
   // Get the function object before instrumentation.
@@ -1302,7 +1293,8 @@ void code_contractst::add_contract_check(
     instantiation_values.push_back(p);
   }
 
-  is_fresh_enforcet visitor(*this, log, wrapper_function);
+  is_fresh_enforcet visitor(
+    goto_model, log.get_message_handler(), wrapper_function);
   visitor.create_declarations();
   visitor.add_memory_map_decl(check);
 

--- a/src/goto-instrument/contracts/contracts.h
+++ b/src/goto-instrument/contracts/contracts.h
@@ -126,10 +126,6 @@ public:
     exprt decreases_clause,
     const irep_idt &mode);
 
-  // for "helper" classes to update symbol table.
-  symbol_tablet &get_symbol_table();
-  goto_functionst &get_goto_functions();
-
   std::unordered_map<goto_programt::const_targett, unsigned, const_target_hash>
   get_original_loop_number_map() const
   {

--- a/src/goto-instrument/contracts/memory_predicates.h
+++ b/src/goto-instrument/contracts/memory_predicates.h
@@ -14,22 +14,22 @@ Date: July 2021
 #ifndef CPROVER_GOTO_INSTRUMENT_CONTRACTS_MEMORY_PREDICATES_H
 #define CPROVER_GOTO_INSTRUMENT_CONTRACTS_MEMORY_PREDICATES_H
 
-#include <util/message.h>
 #include <util/symbol.h>
 
 #include <goto-programs/goto_program.h>
 
-class code_contractst;
 class goto_functionst;
+class goto_modelt;
+class message_handlert;
 
 class is_fresh_baset
 {
 public:
   is_fresh_baset(
-    code_contractst &_parent,
-    messaget _log,
-    const irep_idt _fun_id)
-    : parent(_parent), log(_log), fun_id(_fun_id)
+    goto_modelt &goto_model,
+    message_handlert &message_handler,
+    const irep_idt &_fun_id)
+    : goto_model(goto_model), message_handler(message_handler), fun_id(_fun_id)
   {
   }
 
@@ -51,9 +51,9 @@ protected:
   virtual void create_requires_fn_call(goto_programt::targett &target) = 0;
   virtual void create_ensures_fn_call(goto_programt::targett &target) = 0;
 
-  code_contractst &parent;
-  messaget log;
-  irep_idt fun_id;
+  goto_modelt &goto_model;
+  message_handlert &message_handler;
+  const irep_idt &fun_id;
 
   // written by the child classes.
   std::string memmap_name;
@@ -68,9 +68,9 @@ class is_fresh_enforcet : public is_fresh_baset
 {
 public:
   is_fresh_enforcet(
-    code_contractst &_parent,
-    messaget _log,
-    const irep_idt _fun_id);
+    goto_modelt &goto_model,
+    message_handlert &message_handler,
+    const irep_idt &_fun_id);
 
   virtual void create_declarations();
 
@@ -83,9 +83,9 @@ class is_fresh_replacet : public is_fresh_baset
 {
 public:
   is_fresh_replacet(
-    code_contractst &_parent,
-    messaget _log,
-    const irep_idt _fun_id);
+    goto_modelt &goto_model,
+    message_handlert &message_handler,
+    const irep_idt &_fun_id);
 
   virtual void create_declarations();
 
@@ -121,8 +121,8 @@ class functions_in_scope_visitort
 public:
   functions_in_scope_visitort(
     const goto_functionst &goto_functions,
-    messaget &log)
-    : goto_functions(goto_functions), log(log)
+    message_handlert &message_handler)
+    : goto_functions(goto_functions), message_handler(message_handler)
   {
   }
 
@@ -133,7 +133,7 @@ public:
 
 protected:
   const goto_functionst &goto_functions;
-  messaget &log;
+  message_handlert &message_handler;
   std::set<irep_idt> function_set;
 };
 


### PR DESCRIPTION
It really just needs a goto model, and otherwise has no dependency on code contracts. Also consistently use message handlers, not messaget.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
