### PR TITLE
Replace DFCC's set_hide by call to make_hidden

### DIFF
--- a/src/goto-instrument/contracts/dynamic-frames/dfcc_library.cpp
+++ b/src/goto-instrument/contracts/dynamic-frames/dfcc_library.cpp
@@ -360,7 +360,8 @@ void dfcc_libraryt::load(std::set<irep_idt> &to_instrument)
   inline_functions();
 
   // hide all instructions in counter example traces
-  set_hide(true);
+  for(auto it : dfcc_fun_symbol)
+    goto_model.goto_functions.function_map.at(it.second.name).make_hidden();
 }
 
 optionalt<dfcc_funt> dfcc_libraryt::get_dfcc_fun(const irep_idt &id) const
@@ -510,14 +511,6 @@ void dfcc_libraryt::inhibit_front_end_builtins()
         goto_function, goto_model.symbol_table, function_id);
     }
   }
-}
-
-/// Sets the given hide flag on all instructions of all library functions
-void dfcc_libraryt::set_hide(bool hide)
-{
-  PRECONDITION(dfcc_libraryt::loaded);
-  for(auto it : dfcc_fun_symbol)
-    utils.set_hide(it.second.name, hide);
 }
 
 const symbolt &dfcc_libraryt::get_instrumented_functions_map_symbol()

--- a/src/goto-instrument/contracts/dynamic-frames/dfcc_library.h
+++ b/src/goto-instrument/contracts/dynamic-frames/dfcc_library.h
@@ -250,9 +250,6 @@ public:
   /// implementation.
   void inhibit_front_end_builtins();
 
-  /// Sets the given hide flag on all instructions of all library functions
-  void set_hide(bool hide);
-
   /// Adds "checked" pragmas to instructions of all library functions
   /// instructions. By default checks are not disabled.
   void disable_checks();

--- a/src/goto-instrument/contracts/dynamic-frames/dfcc_spec_functions.cpp
+++ b/src/goto-instrument/contracts/dynamic-frames/dfcc_spec_functions.cpp
@@ -136,7 +136,7 @@ void dfcc_spec_functionst::generate_havoc_function(
     not_enough_arguments.empty(),
     "not enough arguments when inlining " + id2string(havoc_function_id));
 
-  utils.set_hide(havoc_function_id, true);
+  goto_model.goto_functions.function_map.at(havoc_function_id).make_hidden();
 
   goto_model.goto_functions.update();
 }
@@ -278,7 +278,7 @@ void dfcc_spec_functionst::to_spec_assigns_function(
   INVARIANT(
     function_pointer_contracts.empty(),
     "discovered function pointer contracts unexpectedly");
-  utils.set_hide(function_id, true);
+  goto_model.goto_functions.function_map.at(function_id).make_hidden();
 }
 
 void dfcc_spec_functionst::to_spec_assigns_instructions(
@@ -367,8 +367,7 @@ void dfcc_spec_functionst::to_spec_frees_function(
   INVARIANT(
     function_pointer_contracts.empty(),
     "discovered function pointer contracts unexpectedly");
-
-  utils.set_hide(function_id, true);
+  goto_model.goto_functions.function_map.at(function_id).make_hidden();
 }
 
 void dfcc_spec_functionst::to_spec_frees_instructions(

--- a/src/goto-instrument/contracts/dynamic-frames/dfcc_swap_and_wrap.cpp
+++ b/src/goto-instrument/contracts/dynamic-frames/dfcc_swap_and_wrap.cpp
@@ -267,7 +267,7 @@ void dfcc_swap_and_wrapt::check_contract(
   // extend the signature of the wrapper function with the write set parameter
   utils.add_parameter(write_set_symbol, function_id);
 
-  utils.set_hide(wrapper_id, true);
+  goto_model.goto_functions.function_map.at(wrapper_id).make_hidden();
 
   // instrument the wrapped function
   instrument.instrument_wrapped_function(
@@ -305,7 +305,7 @@ void dfcc_swap_and_wrapt::replace_with_contract(
   body.add(goto_programt::make_end_function(
     utils.get_function_symbol(wrapper_id).location));
 
-  utils.set_hide(wrapper_id, true);
+  goto_model.goto_functions.function_map.at(wrapper_id).make_hidden();
 
   // write the body to the GOTO function
   goto_model.goto_functions.function_map.at(function_id).body.swap(body);

--- a/src/goto-instrument/contracts/dynamic-frames/dfcc_utils.cpp
+++ b/src/goto-instrument/contracts/dynamic-frames/dfcc_utils.cpp
@@ -564,18 +564,6 @@ bool dfcc_utilst::has_no_loops(const irep_idt &function_id)
     goto_model.goto_functions.function_map.at(function_id).body);
 }
 
-void dfcc_utilst::set_hide(const irep_idt &function_id, bool hide)
-{
-  auto &goto_function = goto_model.goto_functions.function_map.at(function_id);
-  if(goto_function.body_available())
-  {
-    Forall_goto_program_instructions(inst, goto_function.body)
-    {
-      inst->source_location_nonconst().set(ID_hide, hide);
-    }
-  }
-}
-
 void dfcc_utilst::inhibit_unused_functions(const irep_idt &start)
 {
   PRECONDITION_WITH_DIAGNOSTICS(false, "not yet implemented");

--- a/src/goto-instrument/contracts/dynamic-frames/dfcc_utils.h
+++ b/src/goto-instrument/contracts/dynamic-frames/dfcc_utils.h
@@ -230,10 +230,6 @@ public:
   /// \returns True iff \p goto_program is loop free.
   bool has_no_loops(const goto_programt &goto_program);
 
-  /// \brief Sets the given hide flag on all instructions of the function if it
-  /// exists.
-  void set_hide(const irep_idt &function_id, bool hide);
-
   /// \brief Traverses the call tree from the given entry point to identify
   /// functions symbols that are effectively called in the model,
   /// Then goes over all functions of the model and turns the bodies of all


### PR DESCRIPTION
We don't need to mark each instruction as hidden for goto-symex will pick up the is-hidden marker from the goto_functiont containing the instruction(s).

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
