### PR TITLE
Remove dfcc_utilst::has_no_loops

### DIFF
--- a/src/goto-instrument/contracts/dynamic-frames/dfcc_contract_clauses_codegen.cpp
+++ b/src/goto-instrument/contracts/dynamic-frames/dfcc_contract_clauses_codegen.cpp
@@ -64,7 +64,7 @@ void dfcc_contract_clauses_codegent::gen_spec_assigns_instructions(
   // inline resulting program and check for loops
   inline_and_check_warnings(dest);
   PRECONDITION_WITH_DIAGNOSTICS(
-    utils.has_no_loops(dest),
+    is_loop_free(dest, ns, log),
     "loops in assigns clause specification functions must be unwound before "
     "contracts instrumentation");
 }
@@ -91,7 +91,7 @@ void dfcc_contract_clauses_codegent::gen_spec_frees_instructions(
   // inline resulting program and check for loops
   inline_and_check_warnings(dest);
   PRECONDITION_WITH_DIAGNOSTICS(
-    utils.has_no_loops(dest),
+    is_loop_free(dest, ns, log),
     "loops in assigns clause specification functions must be unwound before "
     "contracts instrumentation");
 }

--- a/src/goto-instrument/contracts/dynamic-frames/dfcc_utils.cpp
+++ b/src/goto-instrument/contracts/dynamic-frames/dfcc_utils.cpp
@@ -553,17 +553,6 @@ void dfcc_utilst::inline_program(
   goto_model.goto_functions.update();
 }
 
-bool dfcc_utilst::has_no_loops(const goto_programt &goto_program)
-{
-  return is_loop_free(goto_program, ns, log);
-}
-
-bool dfcc_utilst::has_no_loops(const irep_idt &function_id)
-{
-  return has_no_loops(
-    goto_model.goto_functions.function_map.at(function_id).body);
-}
-
 void dfcc_utilst::inhibit_unused_functions(const irep_idt &start)
 {
   PRECONDITION_WITH_DIAGNOSTICS(false, "not yet implemented");

--- a/src/goto-instrument/contracts/dynamic-frames/dfcc_utils.h
+++ b/src/goto-instrument/contracts/dynamic-frames/dfcc_utils.h
@@ -211,9 +211,6 @@ public:
     std::set<irep_idt> &missing_function,
     std::set<irep_idt> &not_enough_arguments);
 
-  /// \returns True iff \p function_id is loop free.
-  bool has_no_loops(const irep_idt &function_id);
-
   /// \brief Inlines the given program, aborts on recursive calls during
   /// inlining.
   void inline_program(goto_programt &program);
@@ -226,9 +223,6 @@ public:
     std::set<irep_idt> &recursive_call,
     std::set<irep_idt> &missing_function,
     std::set<irep_idt> &not_enough_arguments);
-
-  /// \returns True iff \p goto_program is loop free.
-  bool has_no_loops(const goto_programt &goto_program);
 
   /// \brief Traverses the call tree from the given entry point to identify
   /// functions symbols that are effectively called in the model,


### PR DESCRIPTION
This is just a thin wrapper around is_loop_free.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
