### PR TITLE
Make all methods of dfcc_utilst static

### DIFF
--- a/src/goto-instrument/contracts/dynamic-frames/dfcc.cpp
+++ b/src/goto-instrument/contracts/dynamic-frames/dfcc.cpp
@@ -188,23 +188,20 @@ dfcct::dfcct(
     to_exclude_from_nondet_static(to_exclude_from_nondet_static),
     message_handler(message_handler),
     log(message_handler),
-    utils(goto_model, message_handler),
-    library(goto_model, utils, message_handler),
+    library(goto_model, message_handler),
     ns(goto_model.symbol_table),
-    spec_functions(goto_model, message_handler, utils, library),
-    contract_clauses_codegen(goto_model, message_handler, utils, library),
+    spec_functions(goto_model, message_handler, library),
+    contract_clauses_codegen(goto_model, message_handler, library),
     instrument(
       goto_model,
       message_handler,
-      utils,
       library,
       spec_functions,
       contract_clauses_codegen),
-    memory_predicates(goto_model, utils, library, instrument, message_handler),
+    memory_predicates(goto_model, library, instrument, message_handler),
     contract_handler(
       goto_model,
       message_handler,
-      utils,
       library,
       instrument,
       memory_predicates,
@@ -213,7 +210,6 @@ dfcct::dfcct(
     swap_and_wrap(
       goto_model,
       message_handler,
-      utils,
       library,
       instrument,
       spec_functions,
@@ -227,7 +223,7 @@ void dfcct::check_transform_goto_model_preconditions()
 {
   // check that harness function exists
   PRECONDITION_WITH_DIAGNOSTICS(
-    utils.function_symbol_with_body_exists(harness_id),
+    dfcc_utilst::function_symbol_with_body_exists(goto_model, harness_id),
     "Harness function '" + id2string(harness_id) +
       "' either not found or has no body");
 
@@ -235,7 +231,7 @@ void dfcct::check_transform_goto_model_preconditions()
   {
     auto pair = to_check.value();
     PRECONDITION_WITH_DIAGNOSTICS(
-      utils.function_symbol_with_body_exists(pair.first),
+      dfcc_utilst::function_symbol_with_body_exists(goto_model, pair.first),
       "Function to check '" + id2string(pair.first) +
         "' either not found or has no body");
 
@@ -268,7 +264,7 @@ void dfcct::check_transform_goto_model_preconditions()
     // for functions to replace with contracts we don't require the replaced
     // function to have a body because only the contract is actually used
     PRECONDITION_WITH_DIAGNOSTICS(
-      utils.function_symbol_exists(pair.first),
+      dfcc_utilst::function_symbol_exists(goto_model, pair.first),
       "Function to replace '" + id2string(pair.first) + "' not found");
 
     // triggers signature compatibility checking
@@ -454,7 +450,7 @@ void dfcct::wrap_discovered_function_pointer_contracts()
       {
         // we need to swap it with itself
         PRECONDITION_WITH_DIAGNOSTICS(
-          utils.function_symbol_exists(str),
+          dfcc_utilst::function_symbol_exists(goto_model, str),
           "Function pointer contract '" + str + "' not found.");
 
         // triggers signature compatibility checking
@@ -581,7 +577,7 @@ void dfcct::reinitialize_model()
     goto_model.symbol_table.symbols.find(goto_functionst::entry_point()));
   // regenerate the CPROVER start function
   generate_ansi_c_start_function(
-    utils.get_function_symbol(harness_id),
+    dfcc_utilst::get_function_symbol(goto_model.symbol_table, harness_id),
     goto_model.symbol_table,
     message_handler,
     c_object_factory_parameterst(options));

--- a/src/goto-instrument/contracts/dynamic-frames/dfcc.h
+++ b/src/goto-instrument/contracts/dynamic-frames/dfcc.h
@@ -41,7 +41,6 @@ Author: Remi Delmas, delmasrd@amazon.com
 #include "dfcc_loop_contract_mode.h"
 #include "dfcc_spec_functions.h"
 #include "dfcc_swap_and_wrap.h"
-#include "dfcc_utils.h"
 
 #include <map>
 #include <set>
@@ -217,7 +216,6 @@ protected:
 
   // Singletons that hold the global state of the program transformation
   // (caches etc.)
-  dfcc_utilst utils;
   dfcc_libraryt library;
   namespacet ns;
   dfcc_spec_functionst spec_functions;

--- a/src/goto-instrument/contracts/dynamic-frames/dfcc_cfg_info.cpp
+++ b/src/goto-instrument/contracts/dynamic-frames/dfcc_cfg_info.cpp
@@ -436,9 +436,8 @@ static dfcc_loop_infot gen_dfcc_loop_info(
   dirtyt &dirty,
   local_may_aliast &local_may_alias,
   message_handlert &message_handler,
-  dfcc_utilst &utils,
   dfcc_libraryt &library,
-  symbol_tablet &symbol_table)
+  symbol_table_baset &symbol_table)
 {
   std::unordered_set<irep_idt> loop_locals =
     gen_loop_locals_set(loop_nesting_graph, loop_id);
@@ -472,7 +471,8 @@ static dfcc_loop_infot gen_dfcc_loop_info(
 
   auto &loop = loop_nesting_graph[loop_id];
   const auto cbmc_loop_number = loop.latch->loop_number;
-  const auto &language_mode = utils.get_function_symbol(function_id).mode;
+  const auto &language_mode =
+    dfcc_utilst::get_function_symbol(symbol_table, function_id).mode;
 
   // Generate "write set" variable
   const auto &write_set_var =
@@ -515,9 +515,8 @@ dfcc_cfg_infot::dfcc_cfg_infot(
   goto_functiont &goto_function,
   const exprt &top_level_write_set,
   const dfcc_loop_contract_modet loop_contract_mode,
-  symbol_tablet &symbol_table,
+  symbol_table_baset &symbol_table,
   message_handlert &message_handler,
-  dfcc_utilst &utils,
   dfcc_libraryt &library)
   : function_id(function_id),
     goto_function(goto_function),
@@ -581,7 +580,6 @@ dfcc_cfg_infot::dfcc_cfg_infot(
          dirty,
          local_may_alias,
          message_handler,
-         utils,
          library,
          symbol_table)});
 

--- a/src/goto-instrument/contracts/dynamic-frames/dfcc_cfg_info.h
+++ b/src/goto-instrument/contracts/dynamic-frames/dfcc_cfg_info.h
@@ -29,7 +29,6 @@ Date: March 2023
 #include <set>
 #include <unordered_set>
 
-class dfcc_utilst;
 class dfcc_libraryt;
 class goto_functiont;
 class message_handlert;
@@ -240,9 +239,8 @@ public:
     goto_functiont &goto_function,
     const exprt &top_level_write_set,
     const dfcc_loop_contract_modet loop_contract_mode,
-    symbol_tablet &symbol_table,
+    symbol_table_baset &symbol_table,
     message_handlert &message_handler,
-    dfcc_utilst &utils,
     dfcc_libraryt &library);
 
   void output(std::ostream &out) const;

--- a/src/goto-instrument/contracts/dynamic-frames/dfcc_contract_clauses_codegen.cpp
+++ b/src/goto-instrument/contracts/dynamic-frames/dfcc_contract_clauses_codegen.cpp
@@ -30,12 +30,10 @@ Date: February 2023
 dfcc_contract_clauses_codegent::dfcc_contract_clauses_codegent(
   goto_modelt &goto_model,
   message_handlert &message_handler,
-  dfcc_utilst &utils,
   dfcc_libraryt &library)
   : goto_model(goto_model),
     message_handler(message_handler),
     log(message_handler),
-    utils(utils),
     library(library),
     ns(goto_model.symbol_table)
 {
@@ -233,7 +231,9 @@ void dfcc_contract_clauses_codegent::encode_freeable_target(
   {
     // A plain `target` becomes `CALL __CPROVER_freeable(target);`
     code_function_callt code_function_call(
-      utils.get_function_symbol(CPROVER_PREFIX "freeable").symbol_expr());
+      dfcc_utilst::get_function_symbol(
+        goto_model.symbol_table, CPROVER_PREFIX "freeable")
+        .symbol_expr());
     auto &arguments = code_function_call.arguments();
     arguments.emplace_back(target);
 
@@ -258,12 +258,14 @@ void dfcc_contract_clauses_codegent::inline_and_check_warnings(
   std::set<irep_idt> recursive_call;
   std::set<irep_idt> not_enough_arguments;
 
-  utils.inline_program(
+  dfcc_utilst::inline_program(
+    goto_model,
     goto_program,
     no_body,
     recursive_call,
     missing_function,
-    not_enough_arguments);
+    not_enough_arguments,
+    message_handler);
 
   // check that the only no body / missing functions are the cprover builtins
   for(const auto &id : no_body)

--- a/src/goto-instrument/contracts/dynamic-frames/dfcc_contract_clauses_codegen.h
+++ b/src/goto-instrument/contracts/dynamic-frames/dfcc_contract_clauses_codegen.h
@@ -28,7 +28,6 @@ Date: February 2023
 class goto_modelt;
 class message_handlert;
 class dfcc_libraryt;
-class dfcc_utilst;
 class code_with_contract_typet;
 class conditional_target_group_exprt;
 
@@ -39,12 +38,10 @@ class dfcc_contract_clauses_codegent
 public:
   /// \param goto_model GOTO model being transformed
   /// \param message_handler Used debug/warning/error messages
-  /// \param utils Utility class for dynamic frames
   /// \param library The contracts instrumentation library
   dfcc_contract_clauses_codegent(
     goto_modelt &goto_model,
     message_handlert &message_handler,
-    dfcc_utilst &utils,
     dfcc_libraryt &library);
 
   /// \brief Generates instructions encoding the \p assigns_clause targets and
@@ -81,7 +78,6 @@ protected:
   goto_modelt &goto_model;
   message_handlert &message_handler;
   messaget log;
-  dfcc_utilst &utils;
   dfcc_libraryt &library;
   namespacet ns;
 

--- a/src/goto-instrument/contracts/dynamic-frames/dfcc_contract_functions.cpp
+++ b/src/goto-instrument/contracts/dynamic-frames/dfcc_contract_functions.cpp
@@ -26,13 +26,11 @@ Date: August 2022
 #include "dfcc_instrument.h"
 #include "dfcc_library.h"
 #include "dfcc_spec_functions.h"
-#include "dfcc_utils.h"
 
 dfcc_contract_functionst::dfcc_contract_functionst(
   const symbolt &pure_contract_symbol,
   goto_modelt &goto_model,
   message_handlert &message_handler,
-  dfcc_utilst &utils,
   dfcc_libraryt &library,
   dfcc_spec_functionst &spec_functions,
   dfcc_contract_clauses_codegent &contract_clauses_codegen,
@@ -48,7 +46,6 @@ dfcc_contract_functionst::dfcc_contract_functionst(
     goto_model(goto_model),
     message_handler(message_handler),
     log(message_handler),
-    utils(utils),
     library(library),
     spec_functions(spec_functions),
     contract_clauses_codegen(contract_clauses_codegen),
@@ -122,8 +119,11 @@ const std::size_t dfcc_contract_functionst::get_nof_frees_targets() const
 
 void dfcc_contract_functionst::gen_spec_assigns_function()
 {
-  const auto &spec_function_symbol = utils.clone_and_rename_function(
-    pure_contract_symbol.name, spec_assigns_function_id, empty_typet());
+  const auto &spec_function_symbol = dfcc_utilst::clone_and_rename_function(
+    goto_model,
+    pure_contract_symbol.name,
+    spec_assigns_function_id,
+    empty_typet());
 
   const auto &spec_function_id = spec_function_symbol.name;
 
@@ -171,8 +171,11 @@ void dfcc_contract_functionst::gen_spec_frees_function()
   const auto &code_with_contract =
     to_code_with_contract_type(pure_contract_symbol.type);
 
-  auto &spec_function_symbol = utils.clone_and_rename_function(
-    pure_contract_symbol.name, spec_frees_function_id, empty_typet());
+  auto &spec_function_symbol = dfcc_utilst::clone_and_rename_function(
+    goto_model,
+    pure_contract_symbol.name,
+    spec_frees_function_id,
+    empty_typet());
 
   const auto &spec_function_id = spec_function_symbol.name;
 

--- a/src/goto-instrument/contracts/dynamic-frames/dfcc_contract_functions.h
+++ b/src/goto-instrument/contracts/dynamic-frames/dfcc_contract_functions.h
@@ -28,7 +28,6 @@ Date: August 2022
 class goto_modelt;
 class message_handlert;
 class dfcc_libraryt;
-class dfcc_utilst;
 class dfcc_instrumentt;
 class dfcc_spec_functionst;
 class dfcc_contract_clauses_codegent;
@@ -68,7 +67,6 @@ public:
   /// \param pure_contract_symbol the contract to generate code from
   /// \param goto_model goto model being transformed
   /// \param message_handler used debug/warning/error messages
-  /// \param utils utility class for dynamic frames
   /// \param library the contracts instrumentation library
   /// \param spec_functions provides translation methods for assignable set
   /// \param contract_clauses_codegen provides GOTO code generation methods
@@ -78,7 +76,6 @@ public:
     const symbolt &pure_contract_symbol,
     goto_modelt &goto_model,
     message_handlert &message_handler,
-    dfcc_utilst &utils,
     dfcc_libraryt &library,
     dfcc_spec_functionst &spec_functions,
     dfcc_contract_clauses_codegent &contract_clauses_codegen,
@@ -126,7 +123,6 @@ protected:
   goto_modelt &goto_model;
   message_handlert &message_handler;
   messaget log;
-  dfcc_utilst &utils;
   dfcc_libraryt &library;
   dfcc_spec_functionst &spec_functions;
   dfcc_contract_clauses_codegent &contract_clauses_codegen;

--- a/src/goto-instrument/contracts/dynamic-frames/dfcc_contract_handler.cpp
+++ b/src/goto-instrument/contracts/dynamic-frames/dfcc_contract_handler.cpp
@@ -30,7 +30,6 @@ Date: August 2022
 #include "dfcc_instrument.h"
 #include "dfcc_library.h"
 #include "dfcc_spec_functions.h"
-#include "dfcc_utils.h"
 #include "dfcc_wrapper_program.h"
 
 std::map<irep_idt, dfcc_contract_functionst>
@@ -39,7 +38,6 @@ std::map<irep_idt, dfcc_contract_functionst>
 dfcc_contract_handlert::dfcc_contract_handlert(
   goto_modelt &goto_model,
   message_handlert &message_handler,
-  dfcc_utilst &utils,
   dfcc_libraryt &library,
   dfcc_instrumentt &instrument,
   dfcc_lift_memory_predicatest &memory_predicates,
@@ -48,7 +46,6 @@ dfcc_contract_handlert::dfcc_contract_handlert(
   : goto_model(goto_model),
     message_handler(message_handler),
     log(message_handler),
-    utils(utils),
     library(library),
     instrument(instrument),
     memory_predicates(memory_predicates),
@@ -75,7 +72,6 @@ dfcc_contract_handlert::get_contract_functions(const irep_idt &contract_id)
          get_pure_contract_symbol(contract_id),
          goto_model,
          message_handler,
-         utils,
          library,
          spec_functions,
          contract_clauses_codegen,
@@ -100,13 +96,12 @@ void dfcc_contract_handlert::add_contract_instructions(
 {
   dfcc_wrapper_programt(
     contract_mode,
-    utils.get_function_symbol(wrapper_id),
-    utils.get_function_symbol(wrapped_id),
+    dfcc_utilst::get_function_symbol(goto_model.symbol_table, wrapper_id),
+    dfcc_utilst::get_function_symbol(goto_model.symbol_table, wrapped_id),
     get_contract_functions(contract_id),
     wrapper_write_set_symbol,
     goto_model,
     message_handler,
-    utils,
     library,
     instrument,
     memory_predicates)
@@ -124,7 +119,8 @@ const symbolt &dfcc_contract_handlert::get_pure_contract_symbol(
     if(function_id_opt.has_value())
     {
       auto function_id = function_id_opt.value();
-      const auto &function_symbol = utils.get_function_symbol(function_id);
+      const auto &function_symbol =
+        dfcc_utilst::get_function_symbol(goto_model.symbol_table, function_id);
       check_signature_compat(
         function_id,
         to_code_type(function_symbol.type),
@@ -145,7 +141,8 @@ const symbolt &dfcc_contract_handlert::get_pure_contract_symbol(
         "to derive a default contract");
 
     auto function_id = function_id_opt.value();
-    const auto &function_symbol = utils.get_function_symbol(function_id);
+    const auto &function_symbol =
+      dfcc_utilst::get_function_symbol(goto_model.symbol_table, function_id);
 
     log.warning() << "Contract '" << contract_id
                   << "' not found, deriving empty pure contract '"

--- a/src/goto-instrument/contracts/dynamic-frames/dfcc_contract_handler.h
+++ b/src/goto-instrument/contracts/dynamic-frames/dfcc_contract_handler.h
@@ -27,7 +27,6 @@ Date: August 2022
 class goto_modelt;
 class message_handlert;
 class dfcc_libraryt;
-class dfcc_utilst;
 class dfcc_instrumentt;
 class dfcc_lift_memory_predicatest;
 class dfcc_spec_functionst;
@@ -69,7 +68,6 @@ public:
   dfcc_contract_handlert(
     goto_modelt &goto_model,
     message_handlert &message_handler,
-    dfcc_utilst &utils,
     dfcc_libraryt &library,
     dfcc_instrumentt &instrument,
     dfcc_lift_memory_predicatest &memory_predicates,
@@ -119,7 +117,6 @@ protected:
   goto_modelt &goto_model;
   message_handlert &message_handler;
   messaget log;
-  dfcc_utilst &utils;
   dfcc_libraryt &library;
   dfcc_instrumentt &instrument;
   dfcc_lift_memory_predicatest &memory_predicates;

--- a/src/goto-instrument/contracts/dynamic-frames/dfcc_instrument.h
+++ b/src/goto-instrument/contracts/dynamic-frames/dfcc_instrument.h
@@ -35,9 +35,6 @@ class conditional_target_group_exprt;
 class dfcc_libraryt;
 class dfcc_spec_functionst;
 class dfcc_contract_clauses_codegent;
-class dfcc_utilst;
-class dfcc_loop_utilst;
-class dirtyt;
 class dfcc_cfg_infot;
 
 /// This class instruments GOTO functions or instruction sequences
@@ -48,7 +45,6 @@ public:
   dfcc_instrumentt(
     goto_modelt &goto_model,
     message_handlert &message_handler,
-    dfcc_utilst &utils,
     dfcc_libraryt &library,
     dfcc_spec_functionst &spec_functions,
     dfcc_contract_clauses_codegent &contract_clauses_codegen);
@@ -169,7 +165,6 @@ protected:
   goto_modelt &goto_model;
   message_handlert &message_handler;
   messaget log;
-  dfcc_utilst &utils;
   dfcc_libraryt &library;
   dfcc_spec_functionst &spec_functions;
   dfcc_contract_clauses_codegent &contract_clauses_codegen;

--- a/src/goto-instrument/contracts/dynamic-frames/dfcc_instrument_loop.h
+++ b/src/goto-instrument/contracts/dynamic-frames/dfcc_instrument_loop.h
@@ -24,7 +24,6 @@ Date: April 2023
 #include <analyses/local_may_alias.h>
 
 class dfcc_spec_functionst;
-class dfcc_utilst;
 class dfcc_libraryt;
 class dfcc_instrumentt;
 class dfcc_spec_functionst;
@@ -39,7 +38,6 @@ public:
   /// \brief Constructor for the loop contract instrumentation class.
   /// \param[inout] goto_model GOTO model being instrumented
   /// \param[inout] message_handler For status/debug output
-  /// \param[inout] utils DFCC utility methods
   /// \param[inout] library DFCC instrumentation library functions
   /// \param[inout] spec_functions Class used to translate assigns clauses
   /// to GOTO instructions.
@@ -48,7 +46,6 @@ public:
   dfcc_instrument_loopt(
     goto_modelt &goto_model,
     message_handlert &message_handler,
-    dfcc_utilst &utils,
     dfcc_libraryt &library,
     dfcc_spec_functionst &spec_functions,
     dfcc_contract_clauses_codegent &contract_clauses_codegen);
@@ -151,7 +148,6 @@ protected:
   std::size_t max_assigns_clause_size = 0;
   goto_modelt &goto_model;
   messaget log;
-  dfcc_utilst &utils;
   dfcc_libraryt &library;
   dfcc_spec_functionst &spec_functions;
   dfcc_contract_clauses_codegent &contract_clauses_codegen;
@@ -200,7 +196,7 @@ protected:
   std::unordered_map<exprt, symbol_exprt, irep_hash> add_prehead_instructions(
     const std::size_t loop_id,
     goto_functionst::goto_functiont &goto_function,
-    symbol_tablet &symbol_table,
+    symbol_table_baset &symbol_table,
     goto_programt::targett loop_head,
     goto_programt::targett loop_latch,
     goto_programt &assigns_instrs,
@@ -251,7 +247,7 @@ protected:
     const std::size_t cbmc_loop_id,
     const irep_idt &function_id,
     goto_functionst::goto_functiont &goto_function,
-    symbol_tablet &symbol_table,
+    symbol_table_baset &symbol_table,
     goto_programt::targett loop_head,
     goto_programt::targett loop_latch,
     goto_programt &havoc_instrs,
@@ -299,7 +295,7 @@ protected:
     const std::size_t loop_id,
     const std::size_t cbmc_loop_id,
     goto_functionst::goto_functiont &goto_function,
-    symbol_tablet &symbol_table,
+    symbol_table_baset &symbol_table,
     goto_programt::targett loop_head,
     goto_programt::targett loop_latch,
     const exprt &invariant,

--- a/src/goto-instrument/contracts/dynamic-frames/dfcc_library.cpp
+++ b/src/goto-instrument/contracts/dynamic-frames/dfcc_library.cpp
@@ -173,10 +173,8 @@ const std::set<irep_idt> create_assignable_builtin_names()
 /// Class constructor
 dfcc_libraryt::dfcc_libraryt(
   goto_modelt &goto_model,
-  dfcc_utilst &utils,
   message_handlert &message_handler)
   : goto_model(goto_model),
-    utils(utils),
     message_handler(message_handler),
     log(message_handler),
     dfcc_type_to_name(create_dfcc_type_to_name()),
@@ -411,7 +409,8 @@ void dfcc_libraryt::inline_functions()
   inlined = true;
   for(const auto &function_id : to_inline)
   {
-    utils.inline_function(dfcc_fun_to_name.at(function_id));
+    dfcc_utilst::inline_function(
+      goto_model, dfcc_fun_to_name.at(function_id), message_handler);
   }
 }
 
@@ -523,7 +522,8 @@ const symbolt &dfcc_libraryt::get_instrumented_functions_map_symbol()
   auto map_type =
     array_typet(unsigned_char_type(), infinity_exprt(size_type()));
 
-  return utils.create_static_symbol(
+  return dfcc_utilst::create_static_symbol(
+    goto_model.symbol_table,
     map_type,
     "",
     "__dfcc_instrumented_functions",
@@ -544,8 +544,9 @@ void dfcc_libraryt::add_instrumented_functions_map_init_instructions(
 
   for(auto &function_id : instrumented_functions)
   {
-    auto object_id = pointer_object(
-      address_of_exprt(utils.get_function_symbol(function_id).symbol_expr()));
+    auto object_id = pointer_object(address_of_exprt(
+      dfcc_utilst::get_function_symbol(goto_model.symbol_table, function_id)
+        .symbol_expr()));
     auto index_expr = index_exprt(instrumented_functions_map, object_id);
     dest.add(goto_programt::make_assignment(
       index_expr, from_integer(1, unsigned_char_type()), source_location));

--- a/src/goto-instrument/contracts/dynamic-frames/dfcc_library.h
+++ b/src/goto-instrument/contracts/dynamic-frames/dfcc_library.h
@@ -148,7 +148,6 @@ class message_handlert;
 class symbolt;
 class symbol_exprt;
 class typet;
-class dfcc_utilst;
 
 /// Class interface to library types and functions defined in
 /// `cprover_contracts.c`.
@@ -157,7 +156,6 @@ class dfcc_libraryt
 public:
   dfcc_libraryt(
     goto_modelt &goto_model,
-    dfcc_utilst &utils,
     message_handlert &lmessage_handler);
 
 protected:
@@ -175,7 +173,6 @@ protected:
   static bool malloc_free_fixed;
 
   goto_modelt &goto_model;
-  dfcc_utilst &utils;
   message_handlert &message_handler;
   messaget log;
 

--- a/src/goto-instrument/contracts/dynamic-frames/dfcc_lift_memory_predicates.cpp
+++ b/src/goto-instrument/contracts/dynamic-frames/dfcc_lift_memory_predicates.cpp
@@ -24,12 +24,10 @@ Date: August 2022
 
 dfcc_lift_memory_predicatest::dfcc_lift_memory_predicatest(
   goto_modelt &goto_model,
-  dfcc_utilst &utils,
   dfcc_libraryt &library,
   dfcc_instrumentt &instrument,
   message_handlert &message_handler)
   : goto_model(goto_model),
-    utils(utils),
     library(library),
     instrument(instrument),
     log(message_handler)
@@ -214,7 +212,8 @@ static optionalt<std::size_t> is_param_expr(
 void dfcc_lift_memory_predicatest::collect_parameters_to_lift(
   const irep_idt &function_id)
 {
-  const symbolt &function_symbol = utils.get_function_symbol(function_id);
+  const symbolt &function_symbol =
+    dfcc_utilst::get_function_symbol(goto_model.symbol_table, function_id);
   // map of parameter name to its rank in the signature
   std::map<irep_idt, std::size_t> parameter_rank;
   const auto &parameters = to_code_type(function_symbol.type).parameters();
@@ -279,7 +278,8 @@ void dfcc_lift_memory_predicatest::add_pointer_type(
   const std::size_t parameter_rank,
   replace_symbolt &replace_lifted_param)
 {
-  symbolt &function_symbol = utils.get_function_symbol(function_id);
+  symbolt &function_symbol =
+    dfcc_utilst::get_function_symbol(goto_model.symbol_table, function_id);
   code_typet &code_type = to_code_type(function_symbol.type);
   auto &parameters = code_type.parameters();
   auto &parameter_id = parameters[parameter_rank].get_identifier();

--- a/src/goto-instrument/contracts/dynamic-frames/dfcc_lift_memory_predicates.h
+++ b/src/goto-instrument/contracts/dynamic-frames/dfcc_lift_memory_predicates.h
@@ -26,7 +26,6 @@ Date: November 2022
 #include <map>
 #include <set>
 
-class dfcc_utilst;
 class dfcc_libraryt;
 class dfcc_instrumentt;
 class message_handlert;
@@ -38,13 +37,11 @@ class dfcc_lift_memory_predicatest
 {
 public:
   /// \param goto_model The goto model to process
-  /// \param utils Utility methods
   /// \param library The contracts instrumentation library
   /// \param instrument The DFCC instrumenter object
   /// \param message_handler Used for messages
   dfcc_lift_memory_predicatest(
     goto_modelt &goto_model,
-    dfcc_utilst &utils,
     dfcc_libraryt &library,
     dfcc_instrumentt &instrument,
     message_handlert &message_handler);
@@ -70,7 +67,6 @@ public:
 
 protected:
   goto_modelt &goto_model;
-  dfcc_utilst &utils;
   dfcc_libraryt &library;
   dfcc_instrumentt &instrument;
   messaget log;

--- a/src/goto-instrument/contracts/dynamic-frames/dfcc_spec_functions.h
+++ b/src/goto-instrument/contracts/dynamic-frames/dfcc_spec_functions.h
@@ -46,7 +46,6 @@ public:
   dfcc_spec_functionst(
     goto_modelt &goto_model,
     message_handlert &message_handler,
-    dfcc_utilst &utils,
     dfcc_libraryt &library);
 
   /// From a function:
@@ -207,7 +206,6 @@ protected:
   goto_modelt &goto_model;
   message_handlert &message_handler;
   messaget log;
-  dfcc_utilst &utils;
   dfcc_libraryt &library;
   namespacet ns;
 

--- a/src/goto-instrument/contracts/dynamic-frames/dfcc_swap_and_wrap.h
+++ b/src/goto-instrument/contracts/dynamic-frames/dfcc_swap_and_wrap.h
@@ -28,7 +28,6 @@ Author: Remi Delmas, delmasrd@amazon.com
 #include "dfcc_instrument.h"
 #include "dfcc_library.h"
 #include "dfcc_spec_functions.h"
-#include "dfcc_utils.h"
 
 #include <map>
 #include <set>
@@ -45,7 +44,6 @@ public:
   dfcc_swap_and_wrapt(
     goto_modelt &goto_model,
     message_handlert &message_handler,
-    dfcc_utilst &utils,
     dfcc_libraryt &library,
     dfcc_instrumentt &instrument,
     dfcc_spec_functionst &spec_functions,
@@ -88,7 +86,6 @@ protected:
   goto_modelt &goto_model;
   message_handlert &message_handler;
   messaget log;
-  dfcc_utilst &utils;
   dfcc_libraryt &library;
   dfcc_instrumentt &instrument;
   dfcc_spec_functionst &spec_functions;

--- a/src/goto-instrument/contracts/dynamic-frames/dfcc_utils.h
+++ b/src/goto-instrument/contracts/dynamic-frames/dfcc_utils.h
@@ -24,35 +24,25 @@ class goto_programt;
 class message_handlert;
 class symbolt;
 
-class dfcc_utilst
+struct dfcc_utilst
 {
-public:
-  dfcc_utilst(goto_modelt &goto_model, message_handlert &message_handler);
-
-protected:
-  goto_modelt &goto_model;
-  message_handlert &message_handler;
-  messaget log;
-  namespacet ns;
-
-public:
   /// Returns true iff the given symbol exists and satisfies requirements.
-  const bool symbol_exists(
-    const irep_idt &function_id,
-    const bool require_has_code_type = false,
-    const bool require_body_available = false);
-
-  const bool function_symbol_exists(const irep_idt &function_id);
-  const bool function_symbol_with_body_exists(const irep_idt &function_id);
+  static bool
+  function_symbol_exists(const goto_modelt &, const irep_idt &function_id);
+  static bool function_symbol_with_body_exists(
+    const goto_modelt &,
+    const irep_idt &function_id);
 
   /// Returns the `symbolt` for `function_id`.
-  symbolt &get_function_symbol(const irep_idt &function_id);
+  static symbolt &
+  get_function_symbol(symbol_table_baset &, const irep_idt &function_id);
 
   /// Adds a new symbol named `prefix::base_name` of type `type`
   /// with given attributes in the symbol table, and returns the created symbol.
   /// If a symbol of the same name already exists the name will be decorated
   /// with a unique suffix.
-  const symbolt &create_symbol(
+  static const symbolt &create_symbol(
+    symbol_table_baset &,
     const typet &type,
     const irep_idt &prefix,
     const irep_idt &base_name,
@@ -72,7 +62,8 @@ public:
   /// keep their initial values for the instrumentation to work as intended.
   /// To allow nondet-initialisation of the symbol,
   /// just set  \p no_nondet_initialization to `false` when calling the method.
-  const symbolt &create_static_symbol(
+  static const symbolt &create_static_symbol(
+    symbol_table_baset &,
     const typet &type,
     const irep_idt &prefix,
     const irep_idt &base_name,
@@ -83,7 +74,8 @@ public:
     const bool no_nondet_initialization = true);
 
   /// Creates a new parameter symbol for the given function_id
-  const symbolt &create_new_parameter_symbol(
+  static const symbolt &create_new_parameter_symbol(
+    symbol_table_baset &,
     const irep_idt &function_id,
     const irep_idt &base_name,
     const typet &type);
@@ -91,64 +83,27 @@ public:
   /// \brief Adds the given symbol as parameter to the function symbol's
   /// code_type. Also adds the corresponding parameter to its goto_function if
   /// it exists in the function map of the goto model.
-  void add_parameter(const symbolt &symbol, const irep_idt &function_id);
-
-  /// \brief Adds the given symbol as parameter to the given code_typet.
-  void add_parameter(const symbolt &symbol, code_typet &code_type);
+  static void add_parameter(
+    goto_modelt &,
+    const symbolt &symbol,
+    const irep_idt &function_id);
 
   /// \brief Adds a parameter with given `base_name` and `type` to the given
   /// `function_id`. Both the symbol and the goto_function are updated.
-  const symbolt &add_parameter(
+  static const symbolt &add_parameter(
+    goto_modelt &,
     const irep_idt &function_id,
     const irep_idt &base_name,
     const typet &type);
 
-  /// \brief Creates a new symbol in the `symbol_table` by cloning
-  /// the given `function_id` function and transforming the existing's
-  /// function's name, parameter names, return type and source location
-  /// using the given `trans_fun`, `trans_param` and `trans_ret_type` and
-  /// `trans_loc` functions.
-  ///
-  /// Also creates a new `goto_function` under the transformed name in
-  /// the `function_map` with new parameters and an empty body.
-  /// Returns the new symbol.
-  ///
-  /// \param function_id function to clone
-  /// \param trans_fun transformation function for the function name
-  /// \param trans_param transformation function for the parameter names
-  /// \param trans_ret_type transformation function for the return type
-  /// \param trans_loc transformation function for the source location
-  /// \return the new function symbol
-  const symbolt &clone_and_rename_function(
-    const irep_idt &function_id,
-    std::function<const irep_idt(const irep_idt &)> &trans_fun,
-    std::function<const irep_idt(const irep_idt &)> &trans_param,
-    std::function<const typet(const typet &)> &trans_ret_type,
-    std::function<const source_locationt(const source_locationt &)> &trans_loc);
-
-  /// \brief Clones the old_params into the new_params list, applying the
-  /// trans_param function to generate the names of the cloned params.
-  void clone_parameters(
-    const code_typet::parameterst &old_params,
-    const irep_idt &mode,
-    const irep_idt &module,
-    const source_locationt &location,
-    std::function<const irep_idt(const irep_idt &)> &trans_param,
-    const irep_idt &new_function_id,
-    code_typet::parameterst &new_params);
-
-  /// \brief Creates names for anonymous parameters and declares them
-  /// in the symbol table if needed (using goto_convert requires all function
-  /// parameters to have names).
-  void fix_parameters_symbols(const irep_idt &function_id);
-
-  /// \brief Creates a new function symbol and and goto_function
+  /// \brief Creates a new function symbol and goto_function
   /// entry in the `goto_functions_map` by cloning the given `function_id`.
   ///
   /// The cloned function symbol has `new_function_id` as name
   /// The cloned parameters symbols have `new_function_id::name` as name
   /// Returns the new function symbol
-  const symbolt &clone_and_rename_function(
+  static const symbolt &clone_and_rename_function(
+    goto_modelt &goto_model,
     const irep_idt &function_id,
     const irep_idt &new_function_id,
     optionalt<typet> new_return_type);
@@ -181,41 +136,45 @@ public:
   ///
   /// By generating a new body for `foo`, one can implement contract
   /// checking logic, contract replacement logic, etc.
-  void wrap_function(
+  static void wrap_function(
+    goto_modelt &goto_model,
     const irep_idt &function_id,
     const irep_idt &wrapped_function_id);
 
   /// \brief Returns the expression `expr == NULL`.
-  const exprt make_null_check_expr(const exprt &ptr);
+  static const exprt make_null_check_expr(const exprt &ptr);
 
   /// \brief Returns the expression `sizeof(expr)`.
-  exprt make_sizeof_expr(const exprt &expr);
+  static exprt make_sizeof_expr(const exprt &expr, const namespacet &);
 
   /// \brief Inlines the given function, aborts on recursive calls during
   /// inlining.
-  void inline_function(const irep_idt &function_id);
+  static void inline_function(
+    goto_modelt &goto_model,
+    const irep_idt &function_id,
+    message_handlert &message_handler);
 
   /// \brief Inlines the given function, and returns function symbols that
   /// caused warnings.
-  void inline_function(
+  static void inline_function(
+    goto_modelt &goto_model,
     const irep_idt &function_id,
     std::set<irep_idt> &no_body,
     std::set<irep_idt> &recursive_call,
     std::set<irep_idt> &missing_function,
-    std::set<irep_idt> &not_enough_arguments);
-
-  /// \brief Inlines the given program, aborts on recursive calls during
-  /// inlining.
-  void inline_program(goto_programt &program);
+    std::set<irep_idt> &not_enough_arguments,
+    message_handlert &message_handler);
 
   /// \brief Inlines the given program, and returns function symbols that
   /// caused warnings.
-  void inline_program(
+  static void inline_program(
+    goto_modelt &goto_model,
     goto_programt &goto_program,
     std::set<irep_idt> &no_body,
     std::set<irep_idt> &recursive_call,
     std::set<irep_idt> &missing_function,
-    std::set<irep_idt> &not_enough_arguments);
+    std::set<irep_idt> &not_enough_arguments,
+    message_handlert &message_handler);
 };
 
 #endif

--- a/src/goto-instrument/contracts/dynamic-frames/dfcc_wrapper_program.cpp
+++ b/src/goto-instrument/contracts/dynamic-frames/dfcc_wrapper_program.cpp
@@ -31,146 +31,146 @@ Author: Remi Delmas, delmasrd@amazon.com
 #include "dfcc_utils.h"
 
 /// Generate the contract write set
-const symbol_exprt create_contract_write_set(
-  dfcc_utilst &utils,
+static symbol_exprt create_contract_write_set(
+  symbol_table_baset &symbol_table,
   dfcc_libraryt &library,
   const symbolt &wrapper_symbol)
 {
-  return utils
-    .create_symbol(
-      library.dfcc_type[dfcc_typet::WRITE_SET],
-      id2string(wrapper_symbol.name),
-      "__contract_write_set",
-      wrapper_symbol.location,
-      wrapper_symbol.mode,
-      wrapper_symbol.module,
-      false)
+  return dfcc_utilst::create_symbol(
+           symbol_table,
+           library.dfcc_type[dfcc_typet::WRITE_SET],
+           id2string(wrapper_symbol.name),
+           "__contract_write_set",
+           wrapper_symbol.location,
+           wrapper_symbol.mode,
+           wrapper_symbol.module,
+           false)
     .symbol_expr();
 }
 
 /// Generate the contract write set pointer
-const symbol_exprt create_addr_of_contract_write_set(
-  dfcc_utilst &utils,
+static symbol_exprt create_addr_of_contract_write_set(
+  symbol_table_baset &symbol_table,
   dfcc_libraryt &library,
   const symbolt &wrapper_symbol)
 {
-  return utils
-    .create_symbol(
-      library.dfcc_type[dfcc_typet::WRITE_SET_PTR],
-      id2string(wrapper_symbol.name),
-      "__address_of_contract_write_set",
-      wrapper_symbol.location,
-      wrapper_symbol.mode,
-      wrapper_symbol.module,
-      false)
+  return dfcc_utilst::create_symbol(
+           symbol_table,
+           library.dfcc_type[dfcc_typet::WRITE_SET_PTR],
+           id2string(wrapper_symbol.name),
+           "__address_of_contract_write_set",
+           wrapper_symbol.location,
+           wrapper_symbol.mode,
+           wrapper_symbol.module,
+           false)
     .symbol_expr();
 }
 
 // Generate the write set to check for side effects in requires clauses
-const symbol_exprt create_requires_write_set(
-  dfcc_utilst &utils,
+static symbol_exprt create_requires_write_set(
+  symbol_table_baset &symbol_table,
   dfcc_libraryt &library,
   const symbolt &wrapper_symbol)
 {
-  return utils
-    .create_symbol(
-      library.dfcc_type[dfcc_typet::WRITE_SET],
-      id2string(wrapper_symbol.name),
-      "__requires_write_set",
-      wrapper_symbol.location,
-      wrapper_symbol.mode,
-      wrapper_symbol.module,
-      false)
+  return dfcc_utilst::create_symbol(
+           symbol_table,
+           library.dfcc_type[dfcc_typet::WRITE_SET],
+           id2string(wrapper_symbol.name),
+           "__requires_write_set",
+           wrapper_symbol.location,
+           wrapper_symbol.mode,
+           wrapper_symbol.module,
+           false)
     .symbol_expr();
 }
 
 /// Generate the write set pointer to check side effects in requires clauses
-const symbol_exprt create_addr_of_requires_write_set(
-  dfcc_utilst &utils,
+static symbol_exprt create_addr_of_requires_write_set(
+  symbol_table_baset &symbol_table,
   dfcc_libraryt &library,
   const symbolt &wrapper_symbol)
 {
-  return utils
-    .create_symbol(
-      library.dfcc_type[dfcc_typet::WRITE_SET_PTR],
-      id2string(wrapper_symbol.name),
-      "__address_of_requires_write_set",
-      wrapper_symbol.location,
-      wrapper_symbol.mode,
-      wrapper_symbol.module,
-      false)
+  return dfcc_utilst::create_symbol(
+           symbol_table,
+           library.dfcc_type[dfcc_typet::WRITE_SET_PTR],
+           id2string(wrapper_symbol.name),
+           "__address_of_requires_write_set",
+           wrapper_symbol.location,
+           wrapper_symbol.mode,
+           wrapper_symbol.module,
+           false)
     .symbol_expr();
 }
 
 /// Generate the write set to check side effects in ensures clauses
-const symbol_exprt create_ensures_write_set(
-  dfcc_utilst &utils,
+static symbol_exprt create_ensures_write_set(
+  symbol_table_baset &symbol_table,
   dfcc_libraryt &library,
   const symbolt &wrapper_symbol)
 {
-  return utils
-    .create_symbol(
-      library.dfcc_type[dfcc_typet::WRITE_SET],
-      id2string(wrapper_symbol.name),
-      "__ensures_write_set",
-      wrapper_symbol.location,
-      wrapper_symbol.mode,
-      wrapper_symbol.module,
-      false)
+  return dfcc_utilst::create_symbol(
+           symbol_table,
+           library.dfcc_type[dfcc_typet::WRITE_SET],
+           id2string(wrapper_symbol.name),
+           "__ensures_write_set",
+           wrapper_symbol.location,
+           wrapper_symbol.mode,
+           wrapper_symbol.module,
+           false)
     .symbol_expr();
 }
 
 /// Generate the write set pointer to check side effects in ensures clauses
-const symbol_exprt create_addr_of_ensures_write_set(
-  dfcc_utilst &utils,
+static symbol_exprt create_addr_of_ensures_write_set(
+  symbol_table_baset &symbol_table,
   dfcc_libraryt &library,
   const symbolt &wrapper_symbol)
 {
-  return utils
-    .create_symbol(
-      library.dfcc_type[dfcc_typet::WRITE_SET_PTR],
-      id2string(wrapper_symbol.name),
-      "__address_of_ensures_write_set",
-      wrapper_symbol.location,
-      wrapper_symbol.mode,
-      wrapper_symbol.module,
-      false)
+  return dfcc_utilst::create_symbol(
+           symbol_table,
+           library.dfcc_type[dfcc_typet::WRITE_SET_PTR],
+           id2string(wrapper_symbol.name),
+           "__address_of_ensures_write_set",
+           wrapper_symbol.location,
+           wrapper_symbol.mode,
+           wrapper_symbol.module,
+           false)
     .symbol_expr();
 }
 
 /// Generate object set used to support is_fresh predicates
-const symbol_exprt create_is_fresh_set(
-  dfcc_utilst &utils,
+static symbol_exprt create_is_fresh_set(
+  symbol_table_baset &symbol_table,
   dfcc_libraryt &library,
   const symbolt &wrapper_symbol)
 {
-  return utils
-    .create_symbol(
-      library.dfcc_type[dfcc_typet::OBJ_SET],
-      id2string(wrapper_symbol.name),
-      "__is_fresh_set",
-      wrapper_symbol.location,
-      wrapper_symbol.mode,
-      wrapper_symbol.module,
-      false)
+  return dfcc_utilst::create_symbol(
+           symbol_table,
+           library.dfcc_type[dfcc_typet::OBJ_SET],
+           id2string(wrapper_symbol.name),
+           "__is_fresh_set",
+           wrapper_symbol.location,
+           wrapper_symbol.mode,
+           wrapper_symbol.module,
+           false)
     .symbol_expr();
 }
 
 /// Generate object set pointer used to support is_fresh predicates
-const symbol_exprt create_addr_of_is_fresh_set(
-  dfcc_utilst &utils,
+static symbol_exprt create_addr_of_is_fresh_set(
+  symbol_table_baset &symbol_table,
   dfcc_libraryt &library,
   const symbolt &wrapper_symbol)
 {
-  return utils
-    .create_symbol(
-      library.dfcc_type[dfcc_typet::OBJ_SET_PTR],
-      id2string(wrapper_symbol.name),
-      "__address_of_is_fresh_set",
-      wrapper_symbol.location,
-      wrapper_symbol.mode,
-      wrapper_symbol.module,
-      false)
+  return dfcc_utilst::create_symbol(
+           symbol_table,
+           library.dfcc_type[dfcc_typet::OBJ_SET_PTR],
+           id2string(wrapper_symbol.name),
+           "__address_of_is_fresh_set",
+           wrapper_symbol.location,
+           wrapper_symbol.mode,
+           wrapper_symbol.module,
+           false)
     .symbol_expr();
 }
 
@@ -182,7 +182,6 @@ dfcc_wrapper_programt::dfcc_wrapper_programt(
   const symbolt &caller_write_set_symbol,
   goto_modelt &goto_model,
   message_handlert &message_handler,
-  dfcc_utilst &utils,
   dfcc_libraryt &library,
   dfcc_instrumentt &instrument,
   dfcc_lift_memory_predicatest &memory_predicates)
@@ -195,25 +194,40 @@ dfcc_wrapper_programt::dfcc_wrapper_programt(
     caller_write_set(caller_write_set_symbol.symbol_expr()),
     wrapper_sl(wrapper_symbol.location),
     return_value_opt(),
-    contract_write_set(
-      create_contract_write_set(utils, library, wrapper_symbol)),
-    addr_of_contract_write_set(
-      create_addr_of_contract_write_set(utils, library, wrapper_symbol)),
-    requires_write_set(
-      create_requires_write_set(utils, library, wrapper_symbol)),
-    addr_of_requires_write_set(
-      create_addr_of_requires_write_set(utils, library, wrapper_symbol)),
-    ensures_write_set(create_ensures_write_set(utils, library, wrapper_symbol)),
-    addr_of_ensures_write_set(
-      create_addr_of_ensures_write_set(utils, library, wrapper_symbol)),
-    is_fresh_set(create_is_fresh_set(utils, library, wrapper_symbol)),
-    addr_of_is_fresh_set(
-      create_addr_of_is_fresh_set(utils, library, wrapper_symbol)),
+    contract_write_set(create_contract_write_set(
+      goto_model.symbol_table,
+      library,
+      wrapper_symbol)),
+    addr_of_contract_write_set(create_addr_of_contract_write_set(
+      goto_model.symbol_table,
+      library,
+      wrapper_symbol)),
+    requires_write_set(create_requires_write_set(
+      goto_model.symbol_table,
+      library,
+      wrapper_symbol)),
+    addr_of_requires_write_set(create_addr_of_requires_write_set(
+      goto_model.symbol_table,
+      library,
+      wrapper_symbol)),
+    ensures_write_set(create_ensures_write_set(
+      goto_model.symbol_table,
+      library,
+      wrapper_symbol)),
+    addr_of_ensures_write_set(create_addr_of_ensures_write_set(
+      goto_model.symbol_table,
+      library,
+      wrapper_symbol)),
+    is_fresh_set(
+      create_is_fresh_set(goto_model.symbol_table, library, wrapper_symbol)),
+    addr_of_is_fresh_set(create_addr_of_is_fresh_set(
+      goto_model.symbol_table,
+      library,
+      wrapper_symbol)),
     function_pointer_contracts(),
     goto_model(goto_model),
     message_handler(message_handler),
     log(message_handler),
-    utils(utils),
     library(library),
     instrument(instrument),
     memory_predicates(memory_predicates),
@@ -223,15 +237,15 @@ dfcc_wrapper_programt::dfcc_wrapper_programt(
   // generate a return value symbol (needed to instantiate all contract lambdas)
   if(contract_code_type.return_type().id() != ID_empty)
   {
-    return_value_opt = utils
-                         .create_symbol(
-                           contract_code_type.return_type(),
-                           id2string(wrapper_symbol.name),
-                           "__contract_return_value",
-                           wrapper_symbol.location,
-                           wrapper_symbol.mode,
-                           wrapper_symbol.module,
-                           false)
+    return_value_opt = dfcc_utilst::create_symbol(
+                         goto_model.symbol_table,
+                         contract_code_type.return_type(),
+                         id2string(wrapper_symbol.name),
+                         "__contract_return_value",
+                         wrapper_symbol.location,
+                         wrapper_symbol.mode,
+                         wrapper_symbol.module,
+                         false)
                          .symbol_expr();
 
     // build contract_lambda_parameters
@@ -566,7 +580,8 @@ void dfcc_wrapper_programt::encode_requires_clauses()
   // we use this empty requires write set to check for the absence of side
   // effects in the requires clauses
   const auto &wrapper_id = wrapper_symbol.name;
-  const auto &language_mode = utils.get_function_symbol(wrapper_id).mode;
+  const auto &language_mode =
+    dfcc_utilst::get_function_symbol(goto_model.symbol_table, wrapper_id).mode;
 
   // if in replacement mode, check that assertions hold in the current context,
   // otherwise assume
@@ -739,7 +754,7 @@ void dfcc_wrapper_programt::encode_havoced_function_call()
 
   auto goto_instruction =
     write_set_checks.add(goto_programt::make_incomplete_goto(
-      utils.make_null_check_expr(caller_write_set), wrapper_sl));
+      dfcc_utilst::make_null_check_expr(caller_write_set), wrapper_sl));
 
   {
     // assigns clause inclusion

--- a/src/goto-instrument/contracts/dynamic-frames/dfcc_wrapper_program.h
+++ b/src/goto-instrument/contracts/dynamic-frames/dfcc_wrapper_program.h
@@ -31,7 +31,6 @@ class message_handlert;
 class dfcc_instrumentt;
 class dfcc_libraryt;
 class dfcc_lift_memory_predicatest;
-class dfcc_utilst;
 class code_with_contract_typet;
 class conditional_target_group_exprt;
 
@@ -106,7 +105,6 @@ public:
   /// to the wrapper function by its caller.
   /// \param goto_model the goto model being transformed
   /// \param message_handler used for debug/warning/error messages
-  /// \param utils utility functions for contracts transformation
   /// \param library the contracts instrumentation library
   /// \param instrument the instrumenter class for goto functions/goto programs
   /// \param memory_predicates handler for user-defed memory predicates, used to
@@ -120,7 +118,6 @@ public:
     const symbolt &caller_write_set_symbol,
     goto_modelt &goto_model,
     message_handlert &message_handler,
-    dfcc_utilst &utils,
     dfcc_libraryt &library,
     dfcc_instrumentt &instrument,
     dfcc_lift_memory_predicatest &memory_predicates);
@@ -175,7 +172,6 @@ protected:
   goto_modelt &goto_model;
   message_handlert &message_handler;
   messaget log;
-  dfcc_utilst &utils;
   dfcc_libraryt &library;
   dfcc_instrumentt &instrument;
   dfcc_lift_memory_predicatest &memory_predicates;


### PR DESCRIPTION
This class has no state, there is no need to instantiate it.

Depends on #7680, among others.

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
