### PR TITLE
Remove dfcc_utilst::inhibit_unused_functions

### DIFF
--- a/src/goto-instrument/contracts/dynamic-frames/dfcc.cpp
+++ b/src/goto-instrument/contracts/dynamic-frames/dfcc.cpp
@@ -513,7 +513,21 @@ void dfcct::transform_goto_model()
   instrument_other_functions();
   library.inhibit_front_end_builtins();
 
-  // TODO implement and use utils.inhibit_unreachable_functions(harness);
+  // TODO implement a means to inhibit unreachable functions (possibly via the
+  // code that implements drop-unused-functions followed by
+  // generate-function-bodies):
+  // Traverse the call tree from the given entry point to identify
+  // functions symbols that are effectively called in the model,
+  // Then goes over all functions of the model and turns the bodies of all
+  // functions that are not in the used function set into:
+  //  ```c
+  //  assert(false, "function identified as unreachable");
+  //  assume(false);
+  //  ```
+  // That way, if the analysis mistakenly pruned some functions, assertions
+  // will be violated and the analysis will fail.
+  // TODO: add a command line flag to tell the instrumentation to not prune
+  // a function.
   goto_model.goto_functions.update();
 
   remove_skip(goto_model);

--- a/src/goto-instrument/contracts/dynamic-frames/dfcc_utils.cpp
+++ b/src/goto-instrument/contracts/dynamic-frames/dfcc_utils.cpp
@@ -552,8 +552,3 @@ void dfcc_utilst::inline_program(
     decorated.get_not_enough_arguments_set().end());
   goto_model.goto_functions.update();
 }
-
-void dfcc_utilst::inhibit_unused_functions(const irep_idt &start)
-{
-  PRECONDITION_WITH_DIAGNOSTICS(false, "not yet implemented");
-}

--- a/src/goto-instrument/contracts/dynamic-frames/dfcc_utils.h
+++ b/src/goto-instrument/contracts/dynamic-frames/dfcc_utils.h
@@ -223,21 +223,6 @@ public:
     std::set<irep_idt> &recursive_call,
     std::set<irep_idt> &missing_function,
     std::set<irep_idt> &not_enough_arguments);
-
-  /// \brief Traverses the call tree from the given entry point to identify
-  /// functions symbols that are effectively called in the model,
-  /// Then goes over all functions of the model and turns the bodies of all
-  /// functions that are not in the used function set into:
-  ///  ```c
-  ///  assert(false, "function identified as unreachable");
-  ///  assume(false);
-  ///  ```
-  /// That way, if the analysis mistakenly pruned some functions, assertions
-  /// will be violated and the analysis will fail.
-  /// TODO: add a command line flag to tell the instrumentation to not prune
-  /// a function.
-  /// \param start name of the entry point
-  void inhibit_unused_functions(const irep_idt &start);
 };
 
 #endif


### PR DESCRIPTION
This has neither been implemented nor used so far. If a future use is necessary, then this commit should just be reverted.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
