### PR TITLE
Remove dfcc_utilst::make_map_start_address

### DIFF
--- a/src/goto-instrument/contracts/dynamic-frames/dfcc_utils.cpp
+++ b/src/goto-instrument/contracts/dynamic-frames/dfcc_utils.cpp
@@ -457,14 +457,6 @@ exprt dfcc_utilst::make_sizeof_expr(const exprt &expr)
   return size.value();
 }
 
-exprt dfcc_utilst::make_map_start_address(const exprt &expr)
-{
-  return typecast_exprt::conditional_cast(
-    address_of_exprt(index_exprt(
-      expr, from_integer(0, to_array_type(expr.type()).index_type()))),
-    pointer_type(bool_typet()));
-}
-
 void dfcc_utilst::inline_function(const irep_idt &function_id)
 {
   auto &goto_function = goto_model.goto_functions.function_map.at(function_id);

--- a/src/goto-instrument/contracts/dynamic-frames/dfcc_utils.h
+++ b/src/goto-instrument/contracts/dynamic-frames/dfcc_utils.h
@@ -195,9 +195,6 @@ public:
   /// \brief Returns the expression `sizeof(expr)`.
   exprt make_sizeof_expr(const exprt &expr);
 
-  /// \brief Returns the expression `&expr[0]`
-  exprt make_map_start_address(const exprt &expr);
-
   /// \brief Inlines the given function, aborts on recursive calls during
   /// inlining.
   void inline_function(const irep_idt &function_id);


### PR DESCRIPTION
This method is never used.

This PR is only one of several possible cleanups of `dfcc_utilst`. I will, however, hold off on any further attempts (including this one, leaving it as draft) until #7541 is merged.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
