### PR TITLE
dfcc_wrapper_programt::encode_ensures_clauses: remove unnecessary local

### DIFF
--- a/src/goto-instrument/contracts/dynamic-frames/dfcc_wrapper_program.cpp
+++ b/src/goto-instrument/contracts/dynamic-frames/dfcc_wrapper_program.cpp
@@ -617,9 +617,6 @@ void dfcc_wrapper_programt::encode_ensures_clauses()
   const auto &statement_type =
     (contract_mode == dfcc_contract_modet::CHECK) ? ID_assert : ID_assume;
 
-  // goto program where all history variable snapshots are added
-  goto_programt history_snapshot_program;
-
   // goto program where all requires are added
   goto_programt ensures_program;
 
@@ -634,10 +631,7 @@ void dfcc_wrapper_programt::encode_ensures_clauses()
 
     // this also rewrites ID_old expressions to fresh variables
     generate_history_variables_initialization(
-      goto_model.symbol_table,
-      ensures,
-      language_mode,
-      history_snapshot_program);
+      goto_model.symbol_table, ensures, language_mode, history);
 
     source_locationt sl(e.source_location());
     if(statement_type == ID_assert)
@@ -671,9 +665,6 @@ void dfcc_wrapper_programt::encode_ensures_clauses()
     ensures_program,
     address_of_ensures_write_set,
     function_pointer_contracts);
-
-  // add the snapshot program in the history section
-  history.destructive_append(history_snapshot_program);
 
   // add the ensures program to the postconditions section
   postconditions.destructive_append(ensures_program);


### PR DESCRIPTION
We can directly append to the history program rather than crafting a local program and then appending that in turn.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
