### PR TITLE
Add capability to export goto-program in symex-ready-goto form to CBMC.

### DIFF
--- a/doc/ADR/README.md
+++ b/doc/ADR/README.md
@@ -6,8 +6,8 @@ where taken at the time they were, so that future maintainers
 can more easily identify constraints that shaped the architecture
 of the system and the surrounding infrastructure.
 
-## Core goto form
-\subpage core-goto
+## Symex ready goto form
+\subpage symex-ready-goto
 
 ## Release & Packaging
 

--- a/doc/ADR/symex_ready_goto.md
+++ b/doc/ADR/symex_ready_goto.md
@@ -1,13 +1,13 @@
-\page core-goto Core goto definition
+\page symex-ready-goto Symex ready goto definition
 
 During the analysis of a program CBMC transforms the input program in an intermediate language
 called extended goto. Then the tool performs a series of simplifications on the obtained goto
 program until the program is given to the solver.
 
-We say that a program is in the **core goto form** when all the extended goto features have
+We say that a program is in the **symex ready goto form** when all the extended goto features have
 been simplified.
 
-More specifically, a program that is in **core goto form** is one that can be passed to **symex** by
+More specifically, a program that is in **symex ready goto form** is one that can be passed to **symex** by
 using any solver deriving from `goto_verifiert` without requiring any lowering step.
 
 At the time of writing, verifiers extending `goto_verifiert` are:

--- a/doc/architectural/goto-program-transformations.md
+++ b/doc/architectural/goto-program-transformations.md
@@ -5,7 +5,7 @@
 \section required-transforms Core Transformation Passes
 
 This section lists the transformation passes that must have been applied for the
-goto model to be in core goto format.
+goto model to be in symex ready goto format.
 
 Note that the passes are listed below in the order they are currently called in
 CBMC. While all dependencies on the ordering are not fully documented, the
@@ -184,11 +184,11 @@ nondet-transform if it is being used.</em>
 
 This transformation removes skip instructions. Note that this transformation is
 called in many places and may be called as part of other transformations. This
-instance here is part of the mandatory transformation to reach core goto format.
-If there is a use case where it is desirable to preserve a "no operation"
-instruction, a `LOCATION` type instruction may be used in place of a `SKIP`
-instruction. The `LOCATION` instruction has the same semantics as the `SKIP`
-instruction, but is not removed by the remove skip instructions pass.
+instance here is part of the mandatory transformation to reach symex ready goto
+format. If there is a use case where it is desirable to preserve a "no
+operation" instruction, a `LOCATION` type instruction may be used in place of a
+`SKIP` instruction. The `LOCATION` instruction has the same semantics as the
+`SKIP` instruction, but is not removed by the remove skip instructions pass.
 
 The implementation of this pass is called via \ref remove_skip(goto_modelt &)
 
@@ -215,7 +215,7 @@ coverage-transform if it is being used.</em>
 
 The sections lists the optional transformation passes that are optional and will
 modify a goto model. Note that these are documented here for consistency, but
-not required for core goto format.
+not required for symex ready goto format.
 
 Note for each optional pass there is a listed predeceesor pass. This is the pass
 currently called before the listed pass in CBMC. While the ordering may not be

--- a/doc/man/cbmc.1
+++ b/doc/man/cbmc.1
@@ -525,6 +525,9 @@ give a stack trace only
 \fB\-\-flush\fR
 flush every line of output
 .TP
+\fB\-\-export\-symex\-ready\-goto\fR filename
+export the symex ready version of the goto-model into the given filename
+.TP
 \fB\-\-verbosity\fR #
 verbosity level
 .TP

--- a/regression/cbmc/CMakeLists.txt
+++ b/regression/cbmc/CMakeLists.txt
@@ -1,26 +1,32 @@
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
   set(gcc_only -X gcc-only)
   set(gcc_only_string "-X;gcc-only;")
+  set(exclude_win_broken_tests -X winbug)
+  # We add the string at the end of the exclusion list, so it must not
+  # have the `;` at the end or it bugs out.
+  set(exclude_win_broken_tests_string "-X;winbug")
 else()
   set(gcc_only "")
   set(gcc_only_string "")
+  set(exclude_win_broken_tests "")
+  set(exclude_win_broken_tests_string "")
 endif()
 
 add_test_pl_tests(
-    "$<TARGET_FILE:cbmc> --validate-goto-model --validate-ssa-equation" -X smt-backend ${gcc_only}
+    "$<TARGET_FILE:cbmc> --validate-goto-model --validate-ssa-equation" -X smt-backend ${gcc_only} ${exclude_win_broken_tests}
 )
 
 add_test_pl_profile(
     "cbmc-paths-lifo"
     "$<TARGET_FILE:cbmc> --paths lifo"
-    "-C;-X;thorough-paths;-X;smt-backend;-X;paths-lifo-expected-failure;${gcc_only_string}-s;paths-lifo"
+    "-C;-X;thorough-paths;-X;smt-backend;-X;paths-lifo-expected-failure;${gcc_only_string}-s;paths-lifo;${exclude_win_broken_tests_string}"
     "CORE"
 )
 
 add_test_pl_profile(
     "cbmc-cprover-smt2"
     "$<TARGET_FILE:cbmc> --cprover-smt2"
-    "-C;-X;broken-smt-backend;-X;thorough-smt-backend;-X;broken-cprover-smt-backend;-X;thorough-cprover-smt-backend;${gcc_only_string}-s;cprover-smt2"
+    "-C;-X;broken-smt-backend;-X;thorough-smt-backend;-X;broken-cprover-smt-backend;-X;thorough-cprover-smt-backend;${gcc_only_string}-s;cprover-smt2;${exclude_win_broken_tests_string}"
     "CORE"
 )
 

--- a/regression/cbmc/export-symex-ready-goto/test-bad-usage.desc
+++ b/regression/cbmc/export-symex-ready-goto/test-bad-usage.desc
@@ -1,0 +1,15 @@
+CORE winbug
+test.c
+--export-symex-ready-goto ""
+^ERROR: Please provide a filename to write the goto-binary to.$
+^EXIT=6$
+^SIGNAL=0$
+--
+--
+Ensure that --export-symex-ready-goto exported.symex-ready.goto terminates
+with error when incorrectly used.
+
+The reason why we use `winbug` is that it fails on certain windows system
+probably due to different interpretation of "". Not a bug, but we're using
+that label to remain consistent with other parts of the codebase, and not
+to unnecessarily introduce new ones for simple use cases.

--- a/regression/cbmc/export-symex-ready-goto/test-correct.desc
+++ b/regression/cbmc/export-symex-ready-goto/test-correct.desc
@@ -1,0 +1,15 @@
+CORE
+test.c
+--export-symex-ready-goto exported.symex.ready.goto
+^Parsing test.c$
+^Converting$
+^Type-checking test$
+^Generating GOTO Program$
+^Removal of function pointers and virtual functions$
+^Generic Property Instrumentation$
+Exported goto-program in symex-ready-goto form at exported.symex.ready.goto
+^EXIT=0$
+^SIGNAL=0$
+--
+--
+Ensure that --export-symex-ready-goto exported.symex.ready.goto terminates successfully and logs this.

--- a/regression/cbmc/export-symex-ready-goto/test.c
+++ b/regression/cbmc/export-symex-ready-goto/test.c
@@ -1,0 +1,6 @@
+int main(int argc, char **argv)
+{
+  int arr[] = {0, 1, 2, 3, 4};
+  __CPROVER_assert(arr[0] == 1, "expected failure: 0 != 1");
+  return 0;
+}

--- a/src/cbmc/cbmc_parse_options.h
+++ b/src/cbmc/cbmc_parse_options.h
@@ -59,6 +59,7 @@ class optionst;
   "(verbosity):(no-library)" \
   "(nondet-static)" \
   "(version)" \
+  "(export-symex-ready-goto):" \
   OPT_COVER \
   "(symex-coverage-report):" \
   "(mm):" \


### PR DESCRIPTION
This allows CBMC to dump the goto-program when it is in symex-ready-goto form in a file on disk (when it is just before SYMEX, and all transformations have been applied).

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
