### PR TITLE
Symex: Simplify left-hand side

### DIFF
--- a/regression/cbmc/simplify-array-size/main.c
+++ b/regression/cbmc/simplify-array-size/main.c
@@ -1,0 +1,36 @@
+#include <stdlib.h>
+#include <string.h>
+
+struct state
+{
+  size_t size;
+  int slots[];
+};
+
+struct hash_table
+{
+  struct state *p_impl;
+};
+
+void main(void)
+{
+  struct hash_table map;
+  size_t num_entries;
+  __CPROVER_assume(num_entries <= 8ul);
+  size_t required_bytes = num_entries * sizeof(int) + sizeof(struct state);
+  struct state *impl = malloc(required_bytes);
+  if(impl != NULL)
+  {
+    impl->size = num_entries;
+    map.p_impl = impl;
+  }
+  else
+    map.p_impl = NULL;
+
+  if(impl != NULL)
+  {
+    // keep this line even though it is never read
+    struct state *state = impl;
+    memset(impl->slots, 0, sizeof(int) * map.p_impl->size);
+  }
+}

--- a/regression/cbmc/simplify-array-size/test.desc
+++ b/regression/cbmc/simplify-array-size/test.desc
@@ -1,0 +1,12 @@
+CORE broken-smt-backend
+main.c
+--malloc-may-fail --malloc-fail-null
+^VERIFICATION SUCCESSFUL$
+^EXIT=0$
+^SIGNAL=0$
+--
+^Invariant check failed
+^warning: ignoring
+--
+Simplification of array sizes must be applied consistently and must not result
+in value-set assignment invariant failures.

--- a/src/goto-symex/goto_symex_state.cpp
+++ b/src/goto-symex/goto_symex_state.cpp
@@ -84,6 +84,8 @@ renamedt<ssa_exprt, L2> goto_symex_statet::assignment(
 
   // the type might need renaming
   rename<L2>(lhs.type(), l1_identifier, ns);
+  if(rhs_is_simplified)
+    simplify(lhs, ns);
   lhs.update_type();
   if(run_validation_checks)
   {


### PR DESCRIPTION
With #7622 we may have syntactically changed the type on the right-hand side via simplification. To maintain syntactic type equality we need to apply simplifications on the left-hand side as well. See https://github.com/awslabs/aws-c-common/actions/runs/4822448417 for an example where this failed after #7622.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
