### PR TITLE
Compact propositional encoding of OBJECT_SIZE(ptr)

### DIFF
--- a/src/solvers/flattening/bv_pointers.h
+++ b/src/solvers/flattening/bv_pointers.h
@@ -92,7 +92,16 @@ protected:
   typedef std::list<postponedt> postponed_listt;
   postponed_listt postponed_list;
 
-  void do_postponed(const postponedt &postponed);
+  /// Create Boolean functions describing all dynamic and all not-dynamic object
+  /// encodings over \p placeholders as input Boolean variables representing
+  /// object bits.
+  std::pair<exprt, exprt> prepare_postponed_is_dynamic_object(
+    std::vector<symbol_exprt> &placeholders) const;
+
+  /// Create Boolean functions describing all objects of each known object size
+  /// over \p placeholders as input Boolean variables representing object bits.
+  std::unordered_map<exprt, exprt, irep_hash>
+  prepare_postponed_object_size(std::vector<symbol_exprt> &placeholders) const;
 
   /// Given a pointer encoded in \p bv, extract the literals identifying the
   /// object that the pointer points to.


### PR DESCRIPTION
For each OBJECT_SIZE expression to be encoded by the propositional back-end we previously created a select statement over all objects, mapping a match to the object's size. This would yield a number of constraints linear in the number of objects times the number of OBJECT_SIZE expressions.

For a particular benchmark at hand these were 2047 OBJECT_SIZE expressions over 1669 objects. Post-processing exceeded 30GB of memory after several minutes of constructing constraints.

For programs that number of distinct object sizes will be small. In the above benchmark there are only 8 distinct object sizes (over those 1669 objects). The new encoding groups objects by size by forming a disjunction of the object identifiers. BDDs are used to compute compact representations of these disjunctions.

With this new approach, post-processing on the above benchmark completes in less than 10 seconds and memory never exceeds 3GB.

While at it, use the same trick for compacting the encoding of IS_DYNAMIC_OBJECT(ptr).

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [x] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
