### PR TITLE
added forwarding of arguments (in string form) to call of smt2 solvers. ...

### DIFF
--- a/src/solvers/smt2/smt2_dec.cpp
+++ b/src/solvers/smt2/smt2_dec.cpp
@@ -126,6 +126,8 @@ decision_proceduret::resultt smt2_dect::dec_solve()
     UNREACHABLE;
   }
 
+  argv.insert(argv.end(), solver_args.begin(), solver_args.end());
+
   int res =
     run(argv[0], argv, stdin_filename, temp_file_stdout(), temp_file_stderr());
 

--- a/src/solvers/smt2/smt2_dec.h
+++ b/src/solvers/smt2/smt2_dec.h
@@ -33,9 +33,12 @@ public:
     const std::string &_notes,
     const std::string &_logic,
     solvert _solver,
-    message_handlert &_message_handler)
+    message_handlert &_message_handler,
+    const std::vector<std::string>& smt_solv_args = {})
     : smt2_convt(_ns, _benchmark, _notes, _logic, _solver, stringstream),
-      message_handler(_message_handler)
+      message_handler(_message_handler),
+      solver_args(smt_solv_args)
+
   {
   }
 
@@ -48,6 +51,10 @@ protected:
   /// Everything except the footer is cached, so that output files can be
   /// rewritten with varying footers.
   std::stringstream cached_output;
+
+  // CMD line arguments forwarded to the solver. Note that the arguments
+  // are solver specific and can differ from solver to solver (no checking is done).
+  std::vector<std::string> solver_args;
 
   resultt read_result(std::istream &in);
 };

--- a/unit/solvers/smt2/smt2_dec.cpp
+++ b/unit/solvers/smt2/smt2_dec.cpp
@@ -1,0 +1,48 @@
+//
+// Author: Julian Parsert
+//
+
+#include <testing-utils/use_catch.h>
+#include <namespace.h>
+#include <symbol_table.h>
+#include <message.h>
+#include <solvers/smt2/smt2_dec.h>
+#include <util/tempfile.h>
+
+TEST_CASE(
+  "smt2_dect::smt2_dect decision_procedure_text.",
+  "[core][solvers][smt2]")
+{
+  symbol_tablet symbol_table;
+  namespacet ns(symbol_table);
+
+  null_message_handlert message_h;
+
+  smt2_dect solver(
+    ns, "test_solver", "generated to test the solver.", "BV", smt2_dect::solvert::Z3, message_h, {"-T:5"});
+
+  CHECK(solver.decision_procedure_text() == "SMT2 BV using Z3");
+
+}
+
+TEST_CASE(
+  "smt2_dect::smt2_dect sygus commandline argument for cvc5.",
+  "[core][solvers][smt2]")
+{
+  symbol_tablet symbol_table;
+  namespacet ns(symbol_table);
+
+  std::stringstream ss;
+  stream_message_handlert message_h(ss);
+  message_h.set_verbosity(10);
+
+  smt2_dect solver(
+    ns, "solver_version", "generated to test the solver version output.", "BV", smt2_dect::solvert::Z3, message_h, {"--version"});
+
+  decision_proceduret::resultt res = solver();
+
+  // CHECK(get message == "VERSION")
+  // output should start with "This is cvc5 version"
+
+  CHECK(res == decision_proceduret::resultt::D_ERROR);
+}


### PR DESCRIPTION
... The arguments are solver specific and their correctness is not checked

I added the ability to "give" arguments to smt2 solvers. These arguments are taken and forwarded in string form as is and no checking if the arguments are correct etc. is done. Hence, these are solver specific. For example, z3 has "-T:10" for a timeout of 10 seconds and cvc5 has {"-tlimit" "10"}. The arguments are given in form of a string vector to the constructor of smt2_dect with the empty vector {} as a default and then appended to the end of the argv vector bevore the call to run.

I think this only affects code owned by @kroening @martin-cs @peterschrammel @thomasspriggs @NlightNFotis @TGWDB
