### PR TITLE
Simplify equality over address-of with offset

### DIFF
--- a/regression/cbmc/Pointer_comparison5/main.c
+++ b/regression/cbmc/Pointer_comparison5/main.c
@@ -1,0 +1,16 @@
+int main()
+{
+  int A[2];
+  int b;
+
+  int *ptr = &A[1];
+
+  if(ptr == &b)
+  {
+    __CPROVER_assert(0, "unreachable");
+  }
+  else if((unsigned long long)ptr == (unsigned long long)&b)
+  {
+    __CPROVER_assert(0, "unreachable");
+  }
+}

--- a/regression/cbmc/Pointer_comparison5/test.desc
+++ b/regression/cbmc/Pointer_comparison5/test.desc
@@ -1,0 +1,14 @@
+CORE
+main.c
+
+^Generated \d+ VCC\(s\), 1 remaining after simplification$
+^VERIFICATION SUCCESSFUL$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--
+Simplification and constant propagation make the comparison over (unrelated)
+pointers trivially false; the corresponding comparison over pointers cast to
+integers is not simplified as the simplifier need not know how pointers convert
+to integers (except for NULL).


### PR DESCRIPTION
When testing equality of two pointers to different objects where each of them is strictly within the respective object bounds the result is necessarily false.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
