### PR TITLE
Simplify byte extract: support signed and unsigned offsets

### DIFF
--- a/src/util/simplify_expr.cpp
+++ b/src/util/simplify_expr.cpp
@@ -1660,8 +1660,10 @@ simplify_exprt::simplify_byte_extract(const byte_extract_exprt &expr)
   {
     auto tmp = expr;
 
-    tmp.offset() = simplify_plus(
-      plus_exprt(to_byte_extract_expr(expr.op()).offset(), expr.offset()));
+    tmp.offset() = simplify_rec(plus_exprt(
+      typecast_exprt::conditional_cast(
+        to_byte_extract_expr(expr.op()).offset(), expr.offset().type()),
+      expr.offset()));
     tmp.op() = to_byte_extract_expr(expr.op()).op();
 
     return changed(simplify_byte_extract(tmp)); // recursive call


### PR DESCRIPTION
The minimized example from #7357 resulted in an invariant failure in `solvers/flattening/boolbv_add_sub.cpp`, reporting "add/sub with mixed types." This was caused by simplifying nested byte-extract operations where one used unsigned offsets and the other one signed. Since we do not required a particular type for byte-extract offsets we must cope with different offset types when folding nested byte-extract operations into a single one.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
