### PR TITLE
Removed older/inactive CODEOWNERS and add minor redundancy

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,7 +2,7 @@
 # approval within two weeks.
 #
 # These owners will be the default owners for everything in the repo.
-*       @kroening @tautschnig @peterschrammel @chris-ryder
+*       @kroening @tautschnig @peterschrammel
 
 # Documentation can be reviewed by people with broad project responsibility
 
@@ -12,13 +12,13 @@
 # These files should rarely change
 
 /src/big-int/ @kroening
-/src/ansi-c/ @kroening @tautschnig @chris-ryder @peterschrammel @remi-delmas-3000
-/src/assembler/ @kroening @tautschnig @chris-ryder
-/src/goto-cc/ @kroening @tautschnig @chris-ryder
-/src/linking/ @kroening @tautschnig @chris-ryder
+/src/ansi-c/ @kroening @tautschnig @peterschrammel @remi-delmas-3000
+/src/assembler/ @kroening @tautschnig
+/src/goto-cc/ @kroening @tautschnig
+/src/linking/ @kroening @tautschnig
 /src/memory-models/ @kroening @tautschnig
 /src/goto-checker/ @kroening @tautschnig @peterschrammel
-/src/goto-symex/ @kroening @tautschnig @peterschrammel @romainbrenguier
+/src/goto-symex/ @kroening @tautschnig @peterschrammel
 /src/json/ @kroening @tautschnig @peterschrammel
 /src/json-symtab-language/ @martin-cs
 /src/langapi/ @kroening @tautschnig @peterschrammel
@@ -39,31 +39,31 @@
 /src/cbmc/ @kroening @tautschnig @peterschrammel @NlightNFotis @thomasspriggs
 /src/goto-programs/ @kroening @tautschnig @peterschrammel
 /src/util/ @kroening @tautschnig @peterschrammel
-/src/solvers/refinement @martin-cs @romainbrenguier @peterschrammel
-/src/solvers/strings @martin-cs @romainbrenguier @peterschrammel
-/jbmc/src/java_bytecode/ @romainbrenguier @peterschrammel
-/src/analyses/ @martin-cs @peterschrammel @chris-ryder
-/src/pointer-analysis/ @martin-cs @peterschrammel @chris-ryder
+/src/solvers/refinement @martin-cs @peterschrammel
+/src/solvers/strings @martin-cs @peterschrammel
+/jbmc/src/java_bytecode/ @peterschrammel @TGWDB
+/src/analyses/ @martin-cs @peterschrammel
+/src/pointer-analysis/ @martin-cs @peterschrammel
 /src/libcprover-cpp @NlightNFotis @thomasspriggs @esteffin @TGWDB @peterschrammel
 /src/libcprover-rust @NlightNFotis @thomasspriggs @TGWDB @peterschrammel
 
 # These files change frequently and changes are medium-risk
 
-/src/goto-analyzer/ @martin-cs @chris-ryder @peterschrammel
-/src/goto-harness/ @martin-cs @chris-ryder @peterschrammel
-/src/goto-instrument/ @martin-cs @chris-ryder @peterschrammel @tautschnig @kroening
+/src/goto-analyzer/ @martin-cs @peterschrammel
+/src/goto-harness/ @martin-cs @peterschrammel
+/src/goto-instrument/ @martin-cs @peterschrammel @tautschnig @kroening
 /src/goto-instrument/contracts/ @tautschnig @feliperodri @remi-delmas-3000
 /src/goto-synthesizer/ @qinheping @tautschnig @feliperodri @remi-delmas-3000
 /src/goto-diff/ @tautschnig @peterschrammel
 /src/jsil/ @kroening @tautschnig
-/src/memory-analyzer/ @tautschnig @chris-ryder @kroening
-/jbmc/src/jbmc/ @peterschrammel @romainbrenguier
-/jbmc/src/janalyzer/ @peterschrammel @romainbrenguier
+/src/memory-analyzer/ @tautschnig @kroening
+/jbmc/src/jbmc/ @peterschrammel @TGWDB
+/jbmc/src/janalyzer/ @peterschrammel @TGWDB
 /jbmc/src/jdiff/ @peterschrammel
 /src/cpp/ @kroening @tautschnig @peterschrammel
 /src/solvers/smt2 @kroening @martin-cs @peterschrammel @thomasspriggs @NlightNFotis @TGWDB
-/src/solvers/smt2_incremental @peterschrammel @thomasspriggs @NlightNFotis @TGWDB @chris-ryder
-/src/solvers/Makefile @kroening @tautschnig @peterschrammel @chris-ryder @thomasspriggs @NlightNFotis @TGWDB
+/src/solvers/smt2_incremental @peterschrammel @thomasspriggs @NlightNFotis @TGWDB
+/src/solvers/Makefile @kroening @tautschnig @peterschrammel @thomasspriggs @NlightNFotis @TGWDB
 /src/statement-list/ @kroening @tautschnig @peterschrammel
 
 /cmake/        @diffblue/diffblue-opensource


### PR DESCRIPTION
Removes @chris-ryder and @romainbrenguier as codeowners as they are no longer active. Adds TGWDB for a couple of Java areas.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
