### PR TITLE
Variadic args/va_arg: handle unexpected va_list types

### DIFF
--- a/regression/cbmc/va_list2/main.c
+++ b/regression/cbmc/va_list2/main.c
@@ -11,14 +11,16 @@ void my_f(int first, ...)
 
   int v;
   v=__builtin_va_arg(args, int);
-  assert(v==2);
+  assert(v == 1);
+  v = __builtin_va_arg(args, int);
+  assert(v == 0);
 
   __builtin_va_end(args);
 }
 
 int main()
 {
-  my_f(1, 2);
+  my_f(2, 1, 0);
 }
 
 #else

--- a/src/ansi-c/goto-conversion/builtin_functions.cpp
+++ b/src/ansi-c/goto-conversion/builtin_functions.cpp
@@ -20,6 +20,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/mathematical_expr.h>
 #include <util/mathematical_types.h>
 #include <util/pointer_expr.h>
+#include <util/pointer_offset_size.h>
 #include <util/rational.h>
 #include <util/rational_tools.h>
 #include <util/simplify_expr.h>
@@ -1306,12 +1307,24 @@ void goto_convertt::do_function_call_symbol(
         goto_programt::make_assignment(lhs, rhs, function.source_location()));
     }
 
-    code_assignt assign{
-      list_arg, plus_exprt{list_arg, from_integer(1, pointer_diff_type())}};
-    assign.rhs().set(
-      ID_C_va_arg_type, to_code_type(function.type()).return_type());
+    exprt rhs;
+    if(list_arg.type() == pointer_type(pointer_type(empty_typet{})))
+      rhs = plus_exprt{list_arg, from_integer(1, pointer_diff_type())};
+    else
+    {
+      // handle unexpected va_list types by just enforcing pointer increments by
+      // size-of-void*
+      rhs = typecast_exprt{
+        plus_exprt{
+          typecast_exprt{list_arg, pointer_type(char_type())},
+          from_integer(
+            *pointer_offset_size(pointer_type(empty_typet{}), ns),
+            pointer_diff_type())},
+        list_arg.type()};
+    }
+    rhs.set(ID_C_va_arg_type, to_code_type(function.type()).return_type());
     dest.add(goto_programt::make_assignment(
-      std::move(assign), function.source_location()));
+      list_arg, std::move(rhs), function.source_location()));
   }
   else if(identifier == "__builtin_va_copy")
   {


### PR DESCRIPTION
Our regression test has `void*` lists when we'd expected `void**`. This, however, went unnoticed as we only tried to access the first element. Attempts to access the second element would have been misaligned, and failed an invariant as of 35cc503 (we don't handle pointer arithmetic over void pointers in the back-end anymore).

We now make sure that we always increment by size-of-`void*`.

Fixes: #7706

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
