### PR TITLE
Limit string length to avoid spurious regression test failure

### DIFF
--- a/jbmc/regression/jbmc/assume-inputs-non-null/class_assume.desc
+++ b/jbmc/regression/jbmc/assume-inputs-non-null/class_assume.desc
@@ -1,6 +1,6 @@
 CORE
 My
---function My.classArg --java-assume-inputs-non-null
+--function My.classArg --java-assume-inputs-non-null --max-nondet-string-length 1000
 ^EXIT=10$
 ^SIGNAL=0$
 ^VERIFICATION FAILED$


### PR DESCRIPTION
As seen in
https://github.com/diffblue/cbmc/actions/runs/4979949266/jobs/8933402303?pr=7413 we may end up with a counterexample too large to store on GitHub's runner. Limit the string length as the length is immaterial to the test.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
