### PR TITLE
Value sets: make pointers nondet only once

### DIFF
--- a/jbmc/unit/pointer-analysis/custom_value_set_analysis.cpp
+++ b/jbmc/unit/pointer-analysis/custom_value_set_analysis.cpp
@@ -78,6 +78,7 @@ public:
   void get_value_set_rec(
     const exprt &expr,
     object_mapt &dest,
+    bool &includes_nondet_pointer,
     const std::string &suffix,
     const typet &original_type,
     const namespacet &ns) const override
@@ -91,7 +92,7 @@ public:
     else
     {
       value_sett::get_value_set_rec(
-        expr, dest, suffix, original_type, ns);
+        expr, dest, includes_nondet_pointer, suffix, original_type, ns);
     }
   }
 

--- a/src/pointer-analysis/value_set.h
+++ b/src/pointer-analysis/value_set.h
@@ -470,13 +470,21 @@ protected:
     const std::string &erase_prefix,
     const namespacet &ns);
 
+protected:
   // Subclass customisation points:
 
-protected:
-  /// Subclass customisation point for recursion over RHS expression:
+  /// Subclass customisation point for recursion over RHS expression.
+  /// \param expr: RHS expression to get value set for.
+  /// \param [out] dest: value set for \p expr.
+  /// \param [out] includes_nondet_pointer: \p expr includes a non-deterministic
+  ///   value, and the caller may want to expand \p dest to reflect this.
+  /// \param suffix: context to enable field sensitivity.
+  /// \param original_type: type of \p expr when starting the recursion.
+  /// \param ns: namespace.
   virtual void get_value_set_rec(
     const exprt &expr,
     object_mapt &dest,
+    bool &includes_nondet_pointer,
     const std::string &suffix,
     const typet &original_type,
     const namespacet &ns) const;
@@ -493,8 +501,6 @@ protected:
   virtual void apply_code_rec(
     const codet &code,
     const namespacet &ns);
-
-  mutable bool nondet_pointer = false;
 
 private:
   /// Subclass customisation point to filter or otherwise alter the value-set

--- a/src/pointer-analysis/value_set.h
+++ b/src/pointer-analysis/value_set.h
@@ -494,7 +494,9 @@ protected:
     const codet &code,
     const namespacet &ns);
 
- private:
+  mutable bool nondet_pointer = false;
+
+private:
   /// Subclass customisation point to filter or otherwise alter the value-set
   /// returned from get_value_set before it is passed into assign. For example,
   /// this is used in one subclass to tag and thus differentiate values that

--- a/src/pointer-analysis/value_set_fi.h
+++ b/src/pointer-analysis/value_set_fi.h
@@ -302,11 +302,11 @@ protected:
   void get_value_set_rec(
     const exprt &expr,
     object_mapt &dest,
+    bool &includes_nondet_pointer,
     const std::string &suffix,
     const typet &original_type,
     const namespacet &ns,
     gvs_recursion_sett &recursion_set) const;
-
 
   void get_value_set(
     const exprt &expr,


### PR DESCRIPTION
When `get_value_set_rec` discovers a nondet symbol it will consider the pointer pointing to any of the known objects (as of 37896707577). It suffices to do this once for each run of `get_value_set`, even when multiple nondet symbols are encountered while traversing an expression.

This reduces the symex time on the test of #7357 from 930 seconds to 404 seconds.

~~RFC: The initial implementation is done so as to be keep the change as small as possible. We will want to explore variants that avoid the use of `mutable`.~~

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [x] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
