### PR TITLE
Code contracts: cleanup get_fresh_aux_symbol wrappers

### DIFF
--- a/src/goto-instrument/contracts/dynamic-frames/dfcc_cfg_info.cpp
+++ b/src/goto-instrument/contracts/dynamic-frames/dfcc_cfg_info.cpp
@@ -471,30 +471,22 @@ static dfcc_loop_infot gen_dfcc_loop_info(
 
   auto &loop = loop_nesting_graph[loop_id];
   const auto cbmc_loop_number = loop.latch->loop_number;
-  const auto &language_mode =
-    dfcc_utilst::get_function_symbol(symbol_table, function_id).mode;
 
   // Generate "write set" variable
-  const auto &write_set_var =
-    get_fresh_aux_symbol(
-      library.dfcc_type[dfcc_typet::WRITE_SET],
-      id2string(function_id),
-      "__write_set_loop_" + std::to_string(cbmc_loop_number),
-      loop.head->source_location(),
-      language_mode,
-      symbol_table)
-      .symbol_expr();
+  const auto write_set_var = dfcc_utilst::create_symbol(
+    symbol_table,
+    library.dfcc_type[dfcc_typet::WRITE_SET],
+    function_id,
+    "__write_set_loop_" + std::to_string(cbmc_loop_number),
+    loop.head->source_location());
 
   // Generate "address of write set" variable
-  const auto &addr_of_write_set_var =
-    get_fresh_aux_symbol(
-      library.dfcc_type[dfcc_typet::WRITE_SET_PTR],
-      id2string(function_id),
-      "__address_of_write_set_loop_" + std::to_string(cbmc_loop_number),
-      loop.head->source_location(),
-      language_mode,
-      symbol_table)
-      .symbol_expr();
+  const auto &addr_of_write_set_var = dfcc_utilst::create_symbol(
+    symbol_table,
+    library.dfcc_type[dfcc_typet::WRITE_SET_PTR],
+    function_id,
+    "__address_of_write_set_loop_" + std::to_string(cbmc_loop_number),
+    loop.head->source_location());
 
   return {
     loop_id,

--- a/src/goto-instrument/contracts/dynamic-frames/dfcc_instrument_loop.h
+++ b/src/goto-instrument/contracts/dynamic-frames/dfcc_instrument_loop.h
@@ -240,7 +240,6 @@ protected:
   /// \param[in] initial_invariant temporary variable `initial_invariant`.
   /// \param[in] in_base_case temporary variable `in_base_case`.
   /// \param[in] old_decreases_vars temporary vars of decreases clauses.
-  /// \param[in] symbol_mode Language mode of the function.
   /// \return The STEP jump target.
   goto_programt::instructiont::targett add_step_instructions(
     const std::size_t loop_id,
@@ -257,8 +256,7 @@ protected:
     const exprt &outer_write_set,
     const symbol_exprt &initial_invariant,
     const symbol_exprt &in_base_case,
-    const std::vector<symbol_exprt> &old_decreases_vars,
-    const irep_idt &symbol_mode);
+    const std::vector<symbol_exprt> &old_decreases_vars);
 
   /// \brief Adds instructions of the body block.
   ///

--- a/src/goto-instrument/contracts/dynamic-frames/dfcc_spec_functions.h
+++ b/src/goto-instrument/contracts/dynamic-frames/dfcc_spec_functions.h
@@ -87,8 +87,6 @@ public:
   /// write set \p write_set_to_havoc.
   ///
   /// \param[in] function_id function id to use for prefixing fresh variables
-  /// \param[in] mode function id to use for prefixing fresh variables
-  /// \param[in] module function id to use for prefixing fresh variables
   /// \param[in] original_program program from which to derive the havoc program
   /// \param[in] write_set_to_havoc write set symbol to havoc
   /// \param[out] havoc_program destination program for havoc instructions
@@ -96,8 +94,6 @@ public:
   ///
   void generate_havoc_instructions(
     const irep_idt &function_id,
-    const irep_idt &mode,
-    const irep_idt &module,
     const goto_programt &original_program,
     const exprt &write_set_to_havoc,
     goto_programt &havoc_program,

--- a/src/goto-instrument/contracts/dynamic-frames/dfcc_utils.h
+++ b/src/goto-instrument/contracts/dynamic-frames/dfcc_utils.h
@@ -37,19 +37,17 @@ struct dfcc_utilst
   static symbolt &
   get_function_symbol(symbol_table_baset &, const irep_idt &function_id);
 
-  /// Adds a new symbol named `prefix::base_name` of type `type`
-  /// with given attributes in the symbol table, and returns the created symbol.
+  /// Adds a new symbol named `function_id::base_name` of type `type`
+  /// with given attributes in the symbol table, and returns a symbol expression
+  /// for the created symbol.
   /// If a symbol of the same name already exists the name will be decorated
   /// with a unique suffix.
-  static const symbolt &create_symbol(
+  static symbol_exprt create_symbol(
     symbol_table_baset &,
     const typet &type,
-    const irep_idt &prefix,
-    const irep_idt &base_name,
-    const source_locationt &source_location,
-    const irep_idt &mode,
-    const irep_idt &module,
-    bool is_parameter);
+    const irep_idt &function_id,
+    const std::string &base_name,
+    const source_locationt &source_location);
 
   /// Adds a new static symbol named `prefix::base_name` of type `type` with
   /// value `initial_value` in the symbol table, returns the created symbol.
@@ -65,8 +63,8 @@ struct dfcc_utilst
   static const symbolt &create_static_symbol(
     symbol_table_baset &,
     const typet &type,
-    const irep_idt &prefix,
-    const irep_idt &base_name,
+    const std::string &prefix,
+    const std::string &base_name,
     const source_locationt &source_location,
     const irep_idt &mode,
     const irep_idt &module,
@@ -77,7 +75,7 @@ struct dfcc_utilst
   static const symbolt &create_new_parameter_symbol(
     symbol_table_baset &,
     const irep_idt &function_id,
-    const irep_idt &base_name,
+    const std::string &base_name,
     const typet &type);
 
   /// \brief Adds the given symbol as parameter to the function symbol's
@@ -93,7 +91,7 @@ struct dfcc_utilst
   static const symbolt &add_parameter(
     goto_modelt &,
     const irep_idt &function_id,
-    const irep_idt &base_name,
+    const std::string &base_name,
     const typet &type);
 
   /// \brief Creates a new function symbol and goto_function

--- a/src/goto-instrument/contracts/dynamic-frames/dfcc_wrapper_program.cpp
+++ b/src/goto-instrument/contracts/dynamic-frames/dfcc_wrapper_program.cpp
@@ -11,7 +11,6 @@ Author: Remi Delmas, delmasrd@amazon.com
 #include <util/c_types.h>
 #include <util/expr_util.h>
 #include <util/format_expr.h>
-#include <util/fresh_symbol.h>
 #include <util/invariant.h>
 #include <util/mathematical_expr.h>
 #include <util/namespace.h>
@@ -37,15 +36,11 @@ static symbol_exprt create_contract_write_set(
   const symbolt &wrapper_symbol)
 {
   return dfcc_utilst::create_symbol(
-           symbol_table,
-           library.dfcc_type[dfcc_typet::WRITE_SET],
-           id2string(wrapper_symbol.name),
-           "__contract_write_set",
-           wrapper_symbol.location,
-           wrapper_symbol.mode,
-           wrapper_symbol.module,
-           false)
-    .symbol_expr();
+    symbol_table,
+    library.dfcc_type[dfcc_typet::WRITE_SET],
+    wrapper_symbol.name,
+    "__contract_write_set",
+    wrapper_symbol.location);
 }
 
 /// Generate the contract write set pointer
@@ -55,15 +50,11 @@ static symbol_exprt create_addr_of_contract_write_set(
   const symbolt &wrapper_symbol)
 {
   return dfcc_utilst::create_symbol(
-           symbol_table,
-           library.dfcc_type[dfcc_typet::WRITE_SET_PTR],
-           id2string(wrapper_symbol.name),
-           "__address_of_contract_write_set",
-           wrapper_symbol.location,
-           wrapper_symbol.mode,
-           wrapper_symbol.module,
-           false)
-    .symbol_expr();
+    symbol_table,
+    library.dfcc_type[dfcc_typet::WRITE_SET_PTR],
+    wrapper_symbol.name,
+    "__address_of_contract_write_set",
+    wrapper_symbol.location);
 }
 
 // Generate the write set to check for side effects in requires clauses
@@ -73,15 +64,11 @@ static symbol_exprt create_requires_write_set(
   const symbolt &wrapper_symbol)
 {
   return dfcc_utilst::create_symbol(
-           symbol_table,
-           library.dfcc_type[dfcc_typet::WRITE_SET],
-           id2string(wrapper_symbol.name),
-           "__requires_write_set",
-           wrapper_symbol.location,
-           wrapper_symbol.mode,
-           wrapper_symbol.module,
-           false)
-    .symbol_expr();
+    symbol_table,
+    library.dfcc_type[dfcc_typet::WRITE_SET],
+    wrapper_symbol.name,
+    "__requires_write_set",
+    wrapper_symbol.location);
 }
 
 /// Generate the write set pointer to check side effects in requires clauses
@@ -91,15 +78,11 @@ static symbol_exprt create_addr_of_requires_write_set(
   const symbolt &wrapper_symbol)
 {
   return dfcc_utilst::create_symbol(
-           symbol_table,
-           library.dfcc_type[dfcc_typet::WRITE_SET_PTR],
-           id2string(wrapper_symbol.name),
-           "__address_of_requires_write_set",
-           wrapper_symbol.location,
-           wrapper_symbol.mode,
-           wrapper_symbol.module,
-           false)
-    .symbol_expr();
+    symbol_table,
+    library.dfcc_type[dfcc_typet::WRITE_SET_PTR],
+    wrapper_symbol.name,
+    "__address_of_requires_write_set",
+    wrapper_symbol.location);
 }
 
 /// Generate the write set to check side effects in ensures clauses
@@ -109,15 +92,11 @@ static symbol_exprt create_ensures_write_set(
   const symbolt &wrapper_symbol)
 {
   return dfcc_utilst::create_symbol(
-           symbol_table,
-           library.dfcc_type[dfcc_typet::WRITE_SET],
-           id2string(wrapper_symbol.name),
-           "__ensures_write_set",
-           wrapper_symbol.location,
-           wrapper_symbol.mode,
-           wrapper_symbol.module,
-           false)
-    .symbol_expr();
+    symbol_table,
+    library.dfcc_type[dfcc_typet::WRITE_SET],
+    wrapper_symbol.name,
+    "__ensures_write_set",
+    wrapper_symbol.location);
 }
 
 /// Generate the write set pointer to check side effects in ensures clauses
@@ -127,15 +106,11 @@ static symbol_exprt create_addr_of_ensures_write_set(
   const symbolt &wrapper_symbol)
 {
   return dfcc_utilst::create_symbol(
-           symbol_table,
-           library.dfcc_type[dfcc_typet::WRITE_SET_PTR],
-           id2string(wrapper_symbol.name),
-           "__address_of_ensures_write_set",
-           wrapper_symbol.location,
-           wrapper_symbol.mode,
-           wrapper_symbol.module,
-           false)
-    .symbol_expr();
+    symbol_table,
+    library.dfcc_type[dfcc_typet::WRITE_SET_PTR],
+    wrapper_symbol.name,
+    "__address_of_ensures_write_set",
+    wrapper_symbol.location);
 }
 
 /// Generate object set used to support is_fresh predicates
@@ -145,15 +120,11 @@ static symbol_exprt create_is_fresh_set(
   const symbolt &wrapper_symbol)
 {
   return dfcc_utilst::create_symbol(
-           symbol_table,
-           library.dfcc_type[dfcc_typet::OBJ_SET],
-           id2string(wrapper_symbol.name),
-           "__is_fresh_set",
-           wrapper_symbol.location,
-           wrapper_symbol.mode,
-           wrapper_symbol.module,
-           false)
-    .symbol_expr();
+    symbol_table,
+    library.dfcc_type[dfcc_typet::OBJ_SET],
+    wrapper_symbol.name,
+    "__is_fresh_set",
+    wrapper_symbol.location);
 }
 
 /// Generate object set pointer used to support is_fresh predicates
@@ -163,15 +134,11 @@ static symbol_exprt create_addr_of_is_fresh_set(
   const symbolt &wrapper_symbol)
 {
   return dfcc_utilst::create_symbol(
-           symbol_table,
-           library.dfcc_type[dfcc_typet::OBJ_SET_PTR],
-           id2string(wrapper_symbol.name),
-           "__address_of_is_fresh_set",
-           wrapper_symbol.location,
-           wrapper_symbol.mode,
-           wrapper_symbol.module,
-           false)
-    .symbol_expr();
+    symbol_table,
+    library.dfcc_type[dfcc_typet::OBJ_SET_PTR],
+    wrapper_symbol.name,
+    "__address_of_is_fresh_set",
+    wrapper_symbol.location);
 }
 
 dfcc_wrapper_programt::dfcc_wrapper_programt(
@@ -238,15 +205,11 @@ dfcc_wrapper_programt::dfcc_wrapper_programt(
   if(contract_code_type.return_type().id() != ID_empty)
   {
     return_value_opt = dfcc_utilst::create_symbol(
-                         goto_model.symbol_table,
-                         contract_code_type.return_type(),
-                         id2string(wrapper_symbol.name),
-                         "__contract_return_value",
-                         wrapper_symbol.location,
-                         wrapper_symbol.mode,
-                         wrapper_symbol.module,
-                         false)
-                         .symbol_expr();
+      goto_model.symbol_table,
+      contract_code_type.return_type(),
+      wrapper_symbol.name,
+      "__contract_return_value",
+      wrapper_symbol.location);
 
     // build contract_lambda_parameters
     contract_lambda_parameters.push_back(return_value_opt.value());
@@ -336,14 +299,12 @@ void dfcc_wrapper_programt::encode_requires_write_set()
   // ASSERT __check_no_alloc;
   // DEAD __check_no_alloc: bool;
   // ```
-  auto check_var = get_fresh_aux_symbol(
-                     bool_typet(),
-                     id2string(wrapper_symbol.name),
-                     "__no_alloc_dealloc_in_requires",
-                     wrapper_sl,
-                     wrapper_symbol.mode,
-                     goto_model.symbol_table)
-                     .symbol_expr();
+  const auto check_var = dfcc_utilst::create_symbol(
+    goto_model.symbol_table,
+    bool_typet(),
+    wrapper_symbol.name,
+    "__no_alloc_dealloc_in_requires",
+    wrapper_sl);
 
   postamble.add(goto_programt::make_decl(check_var, wrapper_sl));
 
@@ -418,14 +379,12 @@ void dfcc_wrapper_programt::encode_ensures_write_set()
   // ASSERT __check_no_alloc;
   // DEAD __check_no_alloc: bool;
   // ```
-  auto check_var = get_fresh_aux_symbol(
-                     bool_typet(),
-                     id2string(wrapper_symbol.name),
-                     "__no_alloc_dealloc_in_ensures_clauses",
-                     wrapper_sl,
-                     wrapper_symbol.mode,
-                     goto_model.symbol_table)
-                     .symbol_expr();
+  const auto check_var = dfcc_utilst::create_symbol(
+    goto_model.symbol_table,
+    bool_typet(),
+    wrapper_symbol.name,
+    "__no_alloc_dealloc_in_ensures_clauses",
+    wrapper_sl);
 
   postamble.add(goto_programt::make_decl(check_var, wrapper_sl));
 
@@ -758,14 +717,12 @@ void dfcc_wrapper_programt::encode_havoced_function_call()
 
   {
     // assigns clause inclusion
-    auto check_var = get_fresh_aux_symbol(
-                       bool_typet(),
-                       id2string(wrapper_symbol.name),
-                       "__check_assigns_clause_incl",
-                       wrapper_sl,
-                       wrapper_symbol.mode,
-                       goto_model.symbol_table)
-                       .symbol_expr();
+    const auto check_var = dfcc_utilst::create_symbol(
+      goto_model.symbol_table,
+      bool_typet(),
+      wrapper_symbol.name,
+      "__check_assigns_clause_incl",
+      wrapper_sl);
 
     write_set_checks.add(goto_programt::make_decl(check_var, wrapper_sl));
 
@@ -786,14 +743,12 @@ void dfcc_wrapper_programt::encode_havoced_function_call()
 
   {
     // frees clause inclusion
-    auto check_var = get_fresh_aux_symbol(
-                       bool_typet(),
-                       id2string(wrapper_symbol.name),
-                       "__check_frees_clause_incl",
-                       wrapper_sl,
-                       wrapper_symbol.mode,
-                       goto_model.symbol_table)
-                       .symbol_expr();
+    const auto check_var = dfcc_utilst::create_symbol(
+      goto_model.symbol_table,
+      bool_typet(),
+      wrapper_symbol.name,
+      "__check_frees_clause_incl",
+      wrapper_sl);
 
     write_set_checks.add(goto_programt::make_decl(check_var, wrapper_sl));
 

--- a/src/goto-instrument/contracts/instrument_spec_assigns.h
+++ b/src/goto-instrument/contracts/instrument_spec_assigns.h
@@ -501,13 +501,6 @@ protected:
   /// checking assertions for a conditional target group from an assigns clause
   void track_plain_spec_target(const exprt &expr, goto_programt &dest);
 
-  /// Creates a fresh symbolt with given suffix,
-  /// scoped to \ref function_id.
-  const symbolt create_fresh_symbol(
-    const std::string &suffix,
-    const typet &type,
-    const source_locationt &location) const;
-
   /// Returns snapshot instructions for a car_exprt
   void create_snapshot(const car_exprt &car, goto_programt &dest) const;
 

--- a/src/goto-instrument/contracts/memory_predicates.cpp
+++ b/src/goto-instrument/contracts/memory_predicates.cpp
@@ -16,6 +16,7 @@ Date: July 2021
 #include <util/arith_tools.h>
 #include <util/c_types.h>
 #include <util/config.h>
+#include <util/fresh_symbol.h>
 #include <util/prefix.h>
 
 #include <goto-programs/goto_convert_functions.h>
@@ -255,13 +256,13 @@ is_fresh_enforcet::is_fresh_enforcet(
   this->memmap_name = ssmemmap.str();
 
   const auto &mode = goto_model.symbol_table.lookup_ref(_fun_id).mode;
-  this->memmap_symbol = new_tmp_symbol(
+  this->memmap_symbol = get_fresh_aux_symbol(
     get_memmap_type(),
+    "",
+    this->memmap_name,
     source_locationt(),
     mode,
-    goto_model.symbol_table,
-    this->memmap_name,
-    true);
+    goto_model.symbol_table);
 }
 
 void is_fresh_enforcet::create_declarations()
@@ -334,13 +335,13 @@ is_fresh_replacet::is_fresh_replacet(
   this->memmap_name = ssmemmap.str();
 
   const auto &mode = goto_model.symbol_table.lookup_ref(_fun_id).mode;
-  this->memmap_symbol = new_tmp_symbol(
+  this->memmap_symbol = get_fresh_aux_symbol(
     get_memmap_type(),
+    "",
+    this->memmap_name,
     source_locationt(),
     mode,
-    goto_model.symbol_table,
-    this->memmap_name,
-    true);
+    goto_model.symbol_table);
 }
 
 void is_fresh_replacet::create_declarations()

--- a/src/goto-instrument/contracts/utils.cpp
+++ b/src/goto-instrument/contracts/utils.cpp
@@ -253,20 +253,6 @@ void insert_before_and_update_jumps(
   }
 }
 
-const symbolt &new_tmp_symbol(
-  const typet &type,
-  const source_locationt &location,
-  const irep_idt &mode,
-  symbol_table_baset &symtab,
-  std::string suffix,
-  bool is_auxiliary)
-{
-  symbolt &new_symbol = get_fresh_aux_symbol(
-    type, id2string(location.get_function()), suffix, location, mode, symtab);
-  new_symbol.is_auxiliary = is_auxiliary;
-  return new_symbol;
-}
-
 void simplify_gotos(goto_programt &goto_program, namespacet &ns)
 {
   for(auto &instruction : goto_program.instructions)
@@ -427,8 +413,10 @@ void add_quantified_variable(
     for(const auto &quantified_variable : quantifier_expression.variables())
     {
       // 1. create fresh symbol
-      symbolt new_symbol = new_tmp_symbol(
+      symbolt new_symbol = get_fresh_aux_symbol(
         quantified_variable.type(),
+        id2string(quantified_variable.source_location().get_function()),
+        "tmp_cc",
         quantified_variable.source_location(),
         mode,
         symbol_table);
@@ -486,9 +474,14 @@ static void replace_history_parameter_rec(
   {
     // 1. Create a temporary symbol expression that represents the
     // history variable
-    entry.first->second =
-      new_tmp_symbol(parameter.type(), location, mode, symbol_table)
-        .symbol_expr();
+    entry.first->second = get_fresh_aux_symbol(
+                            parameter.type(),
+                            id2string(location.get_function()),
+                            "tmp_cc",
+                            location,
+                            mode,
+                            symbol_table)
+                            .symbol_expr();
 
     // 2. Add the required instructions to the instructions list
     // 2.1. Declare the newly created temporary variable

--- a/src/goto-instrument/contracts/utils.h
+++ b/src/goto-instrument/contracts/utils.h
@@ -187,23 +187,6 @@ void insert_before_and_update_jumps(
   goto_programt::targett &target,
   const goto_programt::instructiont &i);
 
-/// \brief Adds a fresh and uniquely named symbol to the symbol table.
-///
-/// \param type: The type of the new symbol.
-/// \param location: The source location for the new symbol.
-/// \param mode: The mode for the new symbol, e.g. ID_C, ID_java.
-/// \param symtab: The symbol table to which the new symbol is to be added.
-/// \param suffix: Suffix to use to generate the unique name
-/// \param is_auxiliary: Do not print symbol in traces if true (default = true)
-/// \return The new symbolt object.
-const symbolt &new_tmp_symbol(
-  const typet &type,
-  const source_locationt &location,
-  const irep_idt &mode,
-  symbol_table_baset &symtab,
-  std::string suffix = "tmp_cc",
-  bool is_auxiliary = true);
-
 /// Turns goto instructions `IF cond GOTO label` where the condition
 /// statically simplifies to `false` into SKIP instructions.
 void simplify_gotos(goto_programt &goto_program, namespacet &ns);


### PR DESCRIPTION
1. Consistently either use the wrappers or get_fresh_aux_symbol
directly.
2. Remove wrappers that did not yield significant simplification.
3. Make remaining wrappers do all work that was previously done by each
caller.

~~Depends on #7683 (which is the first commit).~~

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
