### PR TITLE
Remove typecheckt interface from linkingt

### DIFF
--- a/regression/cbmc/incomplete-structs/test.desc
+++ b/regression/cbmc/incomplete-structs/test.desc
@@ -1,9 +1,6 @@
 CORE new-smt-backend
 typesmain.c
 types1.c types2.c types3.c
-reason for conflict at \*#this.u: number of members is different \(3/0\)
-reason for conflict at \*#this.u: number of members is different \(0/3\)
-struct U   \(incomplete\)
 warning: pointer parameter types differ between declaration and definition "bar"
 warning: pointer parameter types differ between declaration and definition "foo"
 ^VERIFICATION SUCCESSFUL$

--- a/src/goto-programs/link_goto_model.cpp
+++ b/src/goto-programs/link_goto_model.cpp
@@ -10,15 +10,15 @@ Author: Michael Tautschnig, Daniel Kroening
 /// Link Goto Programs
 
 #include "link_goto_model.h"
-
-#include <unordered_set>
-
-#include <util/symbol.h>
-#include <util/rename_symbol.h>
-
 #include <linking/linking_class.h>
 
+#include <util/message.h>
+#include <util/rename_symbol.h>
+#include <util/symbol.h>
+
 #include "goto_model.h"
+
+#include <unordered_set>
 
 static void rename_symbols_in_function(
   goto_functionst::goto_functiont &function,
@@ -119,9 +119,9 @@ optionalt<replace_symbolt::expr_mapt> link_goto_model(
       weak_symbols.insert(symbol_pair.first);
   }
 
-  linkingt linking(dest.symbol_table, src.symbol_table, message_handler);
+  linkingt linking(dest.symbol_table, message_handler);
 
-  if(linking.typecheck_main())
+  if(linking.link(src.symbol_table))
   {
     messaget log{message_handler};
     log.error() << "typechecking main failed" << messaget::eom;


### PR DESCRIPTION
There is no particular benefit in this inheritance. Also prepare for maintaining state across multiple calls to the linker by making the source symbol table an argument specific to each linking call.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
