### PR TITLE
Update CaDiCaL from 1.4.1 to 1.5.3

### DIFF
--- a/scripts/cadical-1.5.3-patch
+++ b/scripts/cadical-1.5.3-patch
@@ -32,3 +32,14 @@ index 9e8a16b..3d5721a 100644
      cubes.cubes.push_back(std::vector<int>());
      return cubes;
    }
+diff -urN cadical-rel-1.5.3/src/solver.cpp cadical-rel-1.5.3.patched/src/solver.cpp
+--- cadical-rel-1.5.3/src/solver.cpp	2023-02-13 09:11:26.000000000 +0000
++++ cadical-rel-1.5.3.patched/src/solver.cpp	2023-05-29 09:42:55.871965742 +0000
+@@ -258,7 +258,6 @@
+
+ #define TRACE(...) \
+ do { \
+-  if ((this == 0)) break; \
+   if ((internal == 0)) break; \
+   LOG_API_CALL_BEGIN (__VA_ARGS__); \
+   if (!trace_api_file) break; \

--- a/src/Makefile
+++ b/src/Makefile
@@ -174,17 +174,17 @@ glucose-download:
 	@(cd ../glucose-syrup; patch -p1 < ../scripts/glucose-syrup-patch)
 	@$(RM) $(glucose_rev).tar.gz
 
-cadical_release = rel-1.4.1
+cadical_release = rel-1.5.3
 cadical-download:
 	@echo "Downloading CaDiCaL $(cadical_release)"
 	@$(DOWNLOADER) https://github.com/arminbiere/cadical/archive/$(cadical_release).tar.gz
 	@$(TAR) xfz $(cadical_release).tar.gz
 	@rm -Rf ../cadical
 	@mv cadical-$(cadical_release) ../cadical
-	@(cd ../cadical; patch -p1 < ../scripts/cadical-1.4.1-patch)
+	@(cd ../cadical; patch -p1 < ../scripts/cadical-1.5.3-patch)
 	@(cd ../cadical && ./configure)
-  # Need to rename VERSION so that it isn't picked up by `#include<version>` on
-  # macOS which is case insensitive
+	# Need to rename VERSION so that it isn't picked up by `#include<version>` on
+	# macOS which is case insensitive
 	@(cd ../cadical && mv VERSION VERSION.txt)
 	@$(RM) $(cadical_release).tar.gz
 

--- a/src/solvers/CMakeLists.txt
+++ b/src/solvers/CMakeLists.txt
@@ -110,11 +110,11 @@ foreach(SOLVER ${sat_impl})
         message(STATUS "Building solvers with cadical")
 
         download_project(PROJ cadical
-            URL https://github.com/arminbiere/cadical/archive/rel-1.4.1.tar.gz
-            PATCH_COMMAND patch -p1 -i ${CBMC_SOURCE_DIR}/../scripts/cadical-1.4.1-patch
+            URL https://github.com/arminbiere/cadical/archive/rel-1.5.3.tar.gz
+            PATCH_COMMAND patch -p1 -i ${CBMC_SOURCE_DIR}/../scripts/cadical-1.5.3-patch
             COMMAND cmake -E copy ${CBMC_SOURCE_DIR}/../scripts/cadical_CMakeLists.txt CMakeLists.txt
             COMMAND ./configure
-            URL_MD5 b44874501a175106424f4bd5de29aa59
+            URL_MD5 265b1a715000ed3c5b6de36ddd1278a0
         )
 
         add_subdirectory(${cadical_SOURCE_DIR} ${cadical_BINARY_DIR})
@@ -133,10 +133,10 @@ foreach(SOLVER ${sat_impl})
         message(STATUS "Building with IPASIR solver linking against: CaDiCaL")
 
         download_project(PROJ cadical
-            URL https://github.com/arminbiere/cadical/archive/rel-1.4.1.tar.gz
-            PATCH_COMMAND true
-            COMMAND CXX=${CMAKE_CXX_COMPILER} ./configure -O3 -s CXXFLAGS=-std=c++14
-            URL_MD5 b44874501a175106424f4bd5de29aa59
+            URL https://github.com/arminbiere/cadical/archive/rel-1.5.3.tar.gz
+            PATCH_COMMAND patch -p1 -i ${CBMC_SOURCE_DIR}/../scripts/cadical-1.5.3-patch
+            COMMAND ./configure
+            URL_MD5 265b1a715000ed3c5b6de36ddd1278a0
         )
 
         message(STATUS "Building CaDiCaL")


### PR DESCRIPTION
Maintenance update to the latest release, no notable performance differences expected or observed.

Also patch out the comparison of `this` against `NULL`, which we reported upstream as https://github.com/arminbiere/cadical/issues/54.

Fixes: #7725

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [x] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
