### PR TITLE
SMT2 incremental back-end: don't use irep_full_hash

### DIFF
--- a/src/solvers/smt2_incremental/convert_expr_to_smt.cpp
+++ b/src/solvers/smt2_incremental/convert_expr_to_smt.cpp
@@ -34,8 +34,7 @@
 ///   * avoiding the deeply nested call stacks associated with recursion.
 ///   * supporting wider scope for the conversion of specific types of `exprt`,
 ///     without inflating the parameter list / scope for all conversions.
-using sub_expression_mapt =
-  std::unordered_map<exprt, smt_termt, irep_full_hash>;
+using sub_expression_mapt = std::unordered_map<exprt, smt_termt, irep_hash>;
 
 /// \brief Converts operator expressions with 2 or more operands to terms
 ///   expressed as binary operator application.

--- a/src/solvers/smt2_incremental/type_size_mapping.h
+++ b/src/solvers/smt2_incremental/type_size_mapping.h
@@ -15,7 +15,7 @@
 
 #include <unordered_map> // IWYU pragma: keep
 
-using type_size_mapt = std::unordered_map<typet, smt_termt, irep_full_hash>;
+using type_size_mapt = std::unordered_map<typet, smt_termt, irep_hash>;
 
 /// This function populates the (pointer) type -> size map.
 /// \param expression: the expression we're building the map for.


### PR DESCRIPTION
`irep_full_hash` would require also using `irep_full_eq`, but there is no need to consider comments in this context. This fixes the unexpected failures seen in runs like
https://github.com/diffblue/cbmc/actions/runs/5069698268/jobs/9103685508.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
