### PR TITLE
Piped process: fix off-by-one error

### DIFF
--- a/src/util/piped_process.cpp
+++ b/src/util/piped_process.cpp
@@ -277,10 +277,10 @@ piped_processt::piped_processt(
     dup2(pipe_output[1], STDOUT_FILENO);
     dup2(pipe_output[1], STDERR_FILENO);
 
-    // Create a char** for the arguments (all the contents of commandvec
-    // except the first element, i.e. the command itself).
-    char **args =
-      reinterpret_cast<char **>(malloc((commandvec.size()) * sizeof(char *)));
+    // Create a char** for the arguments plus a NULL terminator (by convention,
+    // the first "argument" is the command itself)
+    char **args = reinterpret_cast<char **>(
+      malloc((commandvec.size() + 1) * sizeof(char *)));
     // Add all the arguments to the args array of char *.
     unsigned long i = 0;
     while(i < commandvec.size())


### PR DESCRIPTION
The NULL terminator previously was an out-of-bounds write. This fixes the test failure seen in
https://github.com/diffblue/cbmc/actions/runs/5112785459/jobs/9191230589?pr=7395, which was locally reproducible. Out-of-bounds write found by `valgrind` via
```
regression/cbmc/dynamic_sizeof1$ valgrind \
  ../../../build-coverage/bin/cbmc main.c \
  --incremental-smt2-solver 'z3 --smt2 -in'
```

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
