### PR TITLE
Field sensitivity: also rewrite byte extract to type casts

### DIFF
--- a/regression/contracts/assigns_enforce_conditional_unions/program-only.desc
+++ b/regression/contracts/assigns_enforce_conditional_unions/program-only.desc
@@ -1,0 +1,9 @@
+CORE
+main.c
+--enforce-contract update _ --program-only
+^EXIT=0$
+^SIGNAL=0$
+--
+^\(\d+\) guard#\d+ == .*byte_extract
+--
+Confirms that field sensitivity can resolve pointer byte extracts to type casts.

--- a/src/goto-symex/field_sensitivity.cpp
+++ b/src/goto-symex/field_sensitivity.cpp
@@ -123,6 +123,20 @@ exprt field_sensitivityt::apply(
           else
             return apply(ns, state, std::move(tmp), write);
         }
+        else if(
+          recursive_member.has_value() && recursive_member->id() == ID_typecast)
+        {
+          if(was_l2)
+          {
+            return apply(
+              ns,
+              state,
+              state.rename(std::move(*recursive_member), ns).get(),
+              write);
+          }
+          else
+            return apply(ns, state, std::move(*recursive_member), write);
+        }
       }
     }
   }


### PR DESCRIPTION
With https://github.com/model-checking/kani/pull/2456 we see examples where a pointer of a different type is byte-extracted from a union. This is caused by Rust's niche placement. `get_subexpression_at_offset` already catered for that, but we didn't use it in field expansion.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
