### PR TITLE
Add initial struct support for incremental SMT2 decision procedure

### DIFF
--- a/regression/cbmc-incr-smt2/structs/simple.c
+++ b/regression/cbmc-incr-smt2/structs/simple.c
@@ -1,0 +1,21 @@
+#include <assert.h>
+#include <stdint.h>
+
+struct my_struct_type
+{
+  int16_t a;
+  int16_t b;
+};
+
+int main()
+{
+  int16_t nondet;
+  struct my_struct_type my_struct;
+  if(nondet == 3)
+    my_struct.a = 10;
+  else
+    my_struct.a = 12;
+  struct my_struct_type struct_copy;
+  struct_copy = my_struct;
+  assert(my_struct.b != 30 || struct_copy.a != 10);
+}

--- a/regression/cbmc-incr-smt2/structs/simple.desc
+++ b/regression/cbmc-incr-smt2/structs/simple.desc
@@ -1,0 +1,17 @@
+CORE
+simple.c
+--trace
+Passing problem to incremental SMT2 solving
+line 20 assertion my_struct.b != 30 || struct_copy.a != 10: FAILURE
+nondet=3
+struct_copy.a=10
+struct_copy.b=30
+^EXIT=10$
+^SIGNAL=0$
+--
+--
+Test that we support struct values and traces for a trivial example. At the
+time of adding the regression test, this exercised the conversion code specific
+to struct_tag_typet and struct_exprt. Field sensitivity is expected to eliminate
+many of the struct specific expressions before they can reach the decision
+procedure with this simple example.

--- a/src/solvers/Makefile
+++ b/src/solvers/Makefile
@@ -210,6 +210,7 @@ SRC = $(BOOLEFORCE_SRC) \
       smt2_incremental/smt_solver_process.cpp \
       smt2_incremental/smt_to_smt2_string.cpp \
       smt2_incremental/smt2_incremental_decision_procedure.cpp \
+      smt2_incremental/struct_encoding.cpp \
       smt2_incremental/theories/smt_array_theory.cpp \
       smt2_incremental/theories/smt_bit_vector_theory.cpp \
       smt2_incremental/theories/smt_core_theory.cpp \

--- a/src/solvers/smt2_incremental/smt2_incremental_decision_procedure.cpp
+++ b/src/solvers/smt2_incremental/smt2_incremental_decision_procedure.cpp
@@ -515,12 +515,12 @@ void smt2_incremental_decision_proceduret::set_to(
   const exprt &in_expr,
   bool value)
 {
-  const exprt lowered_expr = lower(in_expr);
-  PRECONDITION(can_cast_type<bool_typet>(lowered_expr.type()));
   log.conditional_output(log.debug(), [&](messaget::mstreamt &debug) {
     debug << "`set_to` (" << std::string{value ? "true" : "false"} << ") -\n  "
-          << lowered_expr.pretty(2, 0) << messaget::eom;
+          << in_expr.pretty(2, 0) << messaget::eom;
   });
+  const exprt lowered_expr = lower(in_expr);
+  PRECONDITION(can_cast_type<bool_typet>(lowered_expr.type()));
 
   define_dependent_functions(lowered_expr);
   auto converted_term = [&]() -> smt_termt {
@@ -590,7 +590,13 @@ void smt2_incremental_decision_proceduret::define_object_properties()
 
 exprt smt2_incremental_decision_proceduret::lower(exprt expression)
 {
-  return struct_encoding.encode(lower_byte_operators(expression, ns));
+  const exprt lowered =
+    struct_encoding.encode(lower_byte_operators(expression, ns));
+  log.conditional_output(log.debug(), [&](messaget::mstreamt &debug) {
+    if(lowered != expression)
+      debug << "lowered to -\n  " << lowered.pretty(2, 0) << messaget::eom;
+  });
+  return lowered;
 }
 
 decision_proceduret::resultt smt2_incremental_decision_proceduret::dec_solve()

--- a/src/solvers/smt2_incremental/smt2_incremental_decision_procedure.cpp
+++ b/src/solvers/smt2_incremental/smt2_incremental_decision_procedure.cpp
@@ -268,7 +268,7 @@ void smt2_incremental_decision_proceduret::ensure_handle_for_expr_defined(
     return;
   }
 
-  const exprt lowered_expr = lower_byte_operators(in_expr, ns);
+  const exprt lowered_expr = lower(in_expr);
 
   define_dependent_functions(lowered_expr);
   smt_define_function_commandt function{
@@ -514,7 +514,7 @@ void smt2_incremental_decision_proceduret::set_to(
   const exprt &in_expr,
   bool value)
 {
-  const exprt lowered_expr = lower_byte_operators(in_expr, ns);
+  const exprt lowered_expr = lower(in_expr);
   PRECONDITION(can_cast_type<bool_typet>(lowered_expr.type()));
   log.conditional_output(log.debug(), [&](messaget::mstreamt &debug) {
     debug << "`set_to` (" << std::string{value ? "true" : "false"} << ") -\n  "
@@ -585,6 +585,11 @@ void smt2_incremental_decision_proceduret::define_object_properties()
     solver_process->send(is_dynamic_object_function.make_definition(
       object.unique_id, object.is_dynamic));
   }
+}
+
+exprt smt2_incremental_decision_proceduret::lower(exprt expression)
+{
+  return lower_byte_operators(expression, ns);
 }
 
 decision_proceduret::resultt smt2_incremental_decision_proceduret::dec_solve()

--- a/src/solvers/smt2_incremental/smt2_incremental_decision_procedure.cpp
+++ b/src/solvers/smt2_incremental/smt2_incremental_decision_procedure.cpp
@@ -249,7 +249,8 @@ smt2_incremental_decision_proceduret::smt2_incremental_decision_proceduret(
     number_of_solver_calls{0},
     solver_process(std::move(_solver_process)),
     log{message_handler},
-    object_map{initial_smt_object_map()}
+    object_map{initial_smt_object_map()},
+    struct_encoding{_ns}
 {
   solver_process->send(
     smt_set_option_commandt{smt_option_produce_modelst{true}});
@@ -589,7 +590,7 @@ void smt2_incremental_decision_proceduret::define_object_properties()
 
 exprt smt2_incremental_decision_proceduret::lower(exprt expression)
 {
-  return lower_byte_operators(expression, ns);
+  return struct_encoding.encode(lower_byte_operators(expression, ns));
 }
 
 decision_proceduret::resultt smt2_incremental_decision_proceduret::dec_solve()

--- a/src/solvers/smt2_incremental/smt2_incremental_decision_procedure.h
+++ b/src/solvers/smt2_incremental/smt2_incremental_decision_procedure.h
@@ -93,6 +93,10 @@ protected:
   /// Sends the solver the definitions of the object sizes and dynamic memory
   /// statuses.
   void define_object_properties();
+  /// Performs a combination of transformations which reduces the set of
+  /// possible expression forms by expressing these in terms of the remaining
+  /// language features.
+  exprt lower(exprt expression);
 
   /// Namespace for looking up the expressions which symbol_exprts relate to.
   /// This includes the symbols defined outside of the decision procedure but

--- a/src/solvers/smt2_incremental/smt2_incremental_decision_procedure.h
+++ b/src/solvers/smt2_incremental/smt2_incremental_decision_procedure.h
@@ -13,6 +13,7 @@
 #include <solvers/smt2_incremental/object_tracking.h>
 #include <solvers/smt2_incremental/smt_is_dynamic_object.h>
 #include <solvers/smt2_incremental/smt_object_size.h>
+#include <solvers/smt2_incremental/struct_encoding.h>
 #include <solvers/smt2_incremental/type_size_mapping.h>
 #include <solvers/stack_decision_procedure.h>
 
@@ -169,6 +170,7 @@ protected:
   smt_is_dynamic_objectt is_dynamic_object_function;
   /// Precalculated type sizes used for pointer arithmetic.
   type_size_mapt pointer_sizes_map;
+  struct_encodingt struct_encoding;
 };
 
 #endif // CPROVER_SOLVERS_SMT2_INCREMENTAL_SMT2_INCREMENTAL_DECISION_PROCEDURE_H

--- a/src/solvers/smt2_incremental/struct_encoding.cpp
+++ b/src/solvers/smt2_incremental/struct_encoding.cpp
@@ -40,3 +40,18 @@ typet struct_encodingt::encode(typet type) const
   }
   return type;
 }
+
+exprt struct_encodingt::encode(exprt expr) const
+{
+  std::queue<exprt *> work_queue;
+  work_queue.push(&expr);
+  while(!work_queue.empty())
+  {
+    exprt &current = *work_queue.front();
+    work_queue.pop();
+    current.type() = encode(current.type());
+    for(auto &operand : current.operands())
+      work_queue.push(&operand);
+  }
+  return expr;
+}

--- a/src/solvers/smt2_incremental/struct_encoding.cpp
+++ b/src/solvers/smt2_incremental/struct_encoding.cpp
@@ -2,6 +2,7 @@
 
 #include "struct_encoding.h"
 
+#include <util/bitvector_expr.h>
 #include <util/bitvector_types.h>
 #include <util/make_unique.h>
 
@@ -41,6 +42,11 @@ typet struct_encodingt::encode(typet type) const
   return type;
 }
 
+static exprt encode(const struct_exprt &struct_expr)
+{
+  return concatenation_exprt{struct_expr.operands(), struct_expr.type()};
+}
+
 exprt struct_encodingt::encode(exprt expr) const
 {
   std::queue<exprt *> work_queue;
@@ -50,6 +56,8 @@ exprt struct_encodingt::encode(exprt expr) const
     exprt &current = *work_queue.front();
     work_queue.pop();
     current.type() = encode(current.type());
+    if(const auto struct_expr = expr_try_dynamic_cast<struct_exprt>(current))
+      current = ::encode(*struct_expr);
     for(auto &operand : current.operands())
       work_queue.push(&operand);
   }

--- a/src/solvers/smt2_incremental/struct_encoding.cpp
+++ b/src/solvers/smt2_incremental/struct_encoding.cpp
@@ -1,0 +1,42 @@
+// Author: Diffblue Ltd.
+
+#include "struct_encoding.h"
+
+#include <util/bitvector_types.h>
+#include <util/make_unique.h>
+
+#include <solvers/flattening/boolbv_width.h>
+
+#include <queue>
+
+struct_encodingt::struct_encodingt(const namespacet &ns)
+  : boolbv_width{util_make_unique<boolbv_widtht>(ns)}
+{
+}
+
+struct_encodingt::struct_encodingt(const struct_encodingt &other)
+  : boolbv_width{util_make_unique<boolbv_widtht>(*other.boolbv_width)}
+{
+}
+
+struct_encodingt::~struct_encodingt() = default;
+
+typet struct_encodingt::encode(typet type) const
+{
+  std::queue<typet *> work_queue;
+  work_queue.push(&type);
+  while(!work_queue.empty())
+  {
+    typet &current = *work_queue.front();
+    work_queue.pop();
+    if(const auto struct_tag = type_try_dynamic_cast<struct_tag_typet>(current))
+    {
+      current = bv_typet{(*boolbv_width)(*struct_tag)};
+    }
+    if(const auto array = type_try_dynamic_cast<array_typet>(current))
+    {
+      work_queue.push(&array->element_type());
+    }
+  }
+  return type;
+}

--- a/src/solvers/smt2_incremental/struct_encoding.h
+++ b/src/solvers/smt2_incremental/struct_encoding.h
@@ -3,6 +3,7 @@
 #ifndef CPROVER_SOLVERS_SMT2_INCREMENTAL_STRUCT_ENCODING_H
 #define CPROVER_SOLVERS_SMT2_INCREMENTAL_STRUCT_ENCODING_H
 
+#include <util/expr.h> // For passing exprt by value. // IWYU pragma: keep
 #include <util/type.h> // For passing `typet` by value. // IWYU pragma: keep
 
 #include <memory>
@@ -19,6 +20,7 @@ public:
   ~struct_encodingt();
 
   typet encode(typet type) const;
+  exprt encode(exprt expr) const;
 
 private:
   std::unique_ptr<boolbv_widtht> boolbv_width;

--- a/src/solvers/smt2_incremental/struct_encoding.h
+++ b/src/solvers/smt2_incremental/struct_encoding.h
@@ -1,0 +1,27 @@
+// Author: Diffblue Ltd.
+
+#ifndef CPROVER_SOLVERS_SMT2_INCREMENTAL_STRUCT_ENCODING_H
+#define CPROVER_SOLVERS_SMT2_INCREMENTAL_STRUCT_ENCODING_H
+
+#include <util/type.h> // For passing `typet` by value. // IWYU pragma: keep
+
+#include <memory>
+
+class namespacet;
+class boolbv_widtht;
+
+/// Encodes struct types/values into non-struct expressions/types.
+class struct_encodingt final
+{
+public:
+  explicit struct_encodingt(const namespacet &ns);
+  struct_encodingt(const struct_encodingt &other);
+  ~struct_encodingt();
+
+  typet encode(typet type) const;
+
+private:
+  std::unique_ptr<boolbv_widtht> boolbv_width;
+};
+
+#endif // CPROVER_SOLVERS_SMT2_INCREMENTAL_STRUCT_ENCODING_H

--- a/unit/Makefile
+++ b/unit/Makefile
@@ -114,6 +114,7 @@ SRC += analyses/ai/ai.cpp \
        solvers/smt2_incremental/smt_object_size.cpp \
        solvers/smt2_incremental/smt_response_validation.cpp \
        solvers/smt2_incremental/smt_to_smt2_string.cpp \
+       solvers/smt2_incremental/struct_encoding.cpp \
        solvers/smt2_incremental/theories/smt_array_theory.cpp \
        solvers/smt2_incremental/theories/smt_bit_vector_theory.cpp \
        solvers/smt2_incremental/theories/smt_core_theory.cpp \

--- a/unit/solvers/smt2_incremental/struct_encoding.cpp
+++ b/unit/solvers/smt2_incremental/struct_encoding.cpp
@@ -68,3 +68,28 @@ TEST_CASE("struct encoding of types", "[core][smt2_incremental]")
       expected_encoded_array);
   }
 }
+
+TEST_CASE("struct encoding of expressions", "[core][smt2_incremental]")
+{
+  const struct_union_typet::componentst components{
+    {"green", signedbv_typet{32}}, {"eggs", unsignedbv_typet{16}}};
+  const struct_typet struct_type{components};
+  const type_symbolt type_symbol{"my_structt", struct_type, ID_C};
+  auto test = struct_encoding_test_environmentt::make();
+  test.symbol_table.insert(type_symbol);
+  const struct_tag_typet struct_tag{type_symbol.name};
+  const symbolt struct_value_symbol{"my_struct", struct_tag, ID_C};
+  test.symbol_table.insert(struct_value_symbol);
+  const auto symbol_expr = struct_value_symbol.symbol_expr();
+  const auto symbol_expr_as_bv = symbol_exprt{"my_struct", bv_typet{48}};
+  SECTION("struct typed symbol expression")
+  {
+    REQUIRE(test.struct_encoding.encode(symbol_expr) == symbol_expr_as_bv);
+  }
+  SECTION("struct equality expression")
+  {
+    const auto struct_equal = equal_exprt{symbol_expr, symbol_expr};
+    const auto bv_equal = equal_exprt{symbol_expr_as_bv, symbol_expr_as_bv};
+    REQUIRE(test.struct_encoding.encode(struct_equal) == bv_equal);
+  }
+}

--- a/unit/solvers/smt2_incremental/struct_encoding.cpp
+++ b/unit/solvers/smt2_incremental/struct_encoding.cpp
@@ -1,0 +1,85 @@
+// Author: Diffblue Ltd.
+
+#include <util/arith_tools.h>
+#include <util/bitvector_types.h>
+#include <util/namespace.h>
+#include <util/symbol_table.h>
+
+#include <solvers/smt2_incremental/struct_encoding.h>
+#include <testing-utils/use_catch.h>
+
+struct struct_encoding_test_environmentt
+{
+  symbol_tablet symbol_table;
+  namespacet ns{symbol_table};
+  struct_encodingt struct_encoding{ns};
+
+  static struct_encoding_test_environmentt make()
+  {
+    return {};
+  }
+
+private:
+  struct_encoding_test_environmentt() = default;
+};
+
+TEST_CASE(
+  "struct encoding of non-stuct type is a no-op",
+  "[core][smt2_incremental]")
+{
+  auto test = struct_encoding_test_environmentt::make();
+  typet input = signedbv_typet{8};
+  REQUIRE(test.struct_encoding.encode(input) == input);
+}
+
+TEST_CASE("struct encoding of struct_tag_type", "[core][smt2_incremental]")
+{
+  const struct_union_typet::componentst components{
+    {"foo", unsignedbv_typet{8}}, {"bar", signedbv_typet{16}}};
+  struct_typet struct_type{components};
+  type_symbolt type_symbol{"my_structt", struct_type, ID_C};
+  auto test = struct_encoding_test_environmentt::make();
+  test.symbol_table.insert(type_symbol);
+  struct_tag_typet struct_tag{type_symbol.name};
+  REQUIRE(test.struct_encoding.encode(struct_tag) == bv_typet{24});
+}
+
+TEST_CASE("struct encoding of array of structs", "[core][smt2_incremental]")
+{
+  const struct_union_typet::componentst components{
+    {"foo", unsignedbv_typet{8}}, {"bar", signedbv_typet{16}}};
+  struct_typet struct_type{components};
+  type_symbolt type_symbol{"my_structt", struct_type, ID_C};
+  auto test = struct_encoding_test_environmentt::make();
+  test.symbol_table.insert(type_symbol);
+  struct_tag_typet struct_tag{type_symbol.name};
+  const auto index_type = signedbv_typet{32};
+  const auto array_size = from_integer(5, index_type);
+  array_typet array_of_struct{struct_tag, array_size};
+  array_typet expected_encoded_array{bv_typet{24}, array_size};
+  REQUIRE(
+    test.struct_encoding.encode(array_of_struct) == expected_encoded_array);
+}
+
+TEST_CASE(
+  "struct encoding of array of array of structs",
+  "[core][smt2_incremental]")
+{
+  const struct_union_typet::componentst components{
+    {"foo", unsignedbv_typet{8}}, {"bar", signedbv_typet{16}}};
+  struct_typet struct_type{components};
+  type_symbolt type_symbol{"my_structt", struct_type, ID_C};
+  auto test = struct_encoding_test_environmentt::make();
+  test.symbol_table.insert(type_symbol);
+  struct_tag_typet struct_tag{type_symbol.name};
+  const auto index_type = signedbv_typet{32};
+  const auto array_size_inner = from_integer(4, index_type);
+  const auto array_size_outer = from_integer(2, index_type);
+  array_typet array_of_struct{struct_tag, array_size_inner};
+  array_typet array_of_array_of_struct{array_of_struct, array_size_outer};
+  array_typet expected_encoded_array{
+    array_typet{bv_typet{24}, array_size_inner}, array_size_outer};
+  REQUIRE(
+    test.struct_encoding.encode(array_of_array_of_struct) ==
+    expected_encoded_array);
+}

--- a/unit/solvers/smt2_incremental/struct_encoding.cpp
+++ b/unit/solvers/smt2_incremental/struct_encoding.cpp
@@ -32,7 +32,7 @@ TEST_CASE(
   REQUIRE(test.struct_encoding.encode(input) == input);
 }
 
-TEST_CASE("struct encoding of struct_tag_type", "[core][smt2_incremental]")
+TEST_CASE("struct encoding of types", "[core][smt2_incremental]")
 {
   const struct_union_typet::componentst components{
     {"foo", unsignedbv_typet{8}}, {"bar", signedbv_typet{16}}};
@@ -41,45 +41,30 @@ TEST_CASE("struct encoding of struct_tag_type", "[core][smt2_incremental]")
   auto test = struct_encoding_test_environmentt::make();
   test.symbol_table.insert(type_symbol);
   struct_tag_typet struct_tag{type_symbol.name};
-  REQUIRE(test.struct_encoding.encode(struct_tag) == bv_typet{24});
-}
-
-TEST_CASE("struct encoding of array of structs", "[core][smt2_incremental]")
-{
-  const struct_union_typet::componentst components{
-    {"foo", unsignedbv_typet{8}}, {"bar", signedbv_typet{16}}};
-  struct_typet struct_type{components};
-  type_symbolt type_symbol{"my_structt", struct_type, ID_C};
-  auto test = struct_encoding_test_environmentt::make();
-  test.symbol_table.insert(type_symbol);
-  struct_tag_typet struct_tag{type_symbol.name};
-  const auto index_type = signedbv_typet{32};
-  const auto array_size = from_integer(5, index_type);
-  array_typet array_of_struct{struct_tag, array_size};
-  array_typet expected_encoded_array{bv_typet{24}, array_size};
-  REQUIRE(
-    test.struct_encoding.encode(array_of_struct) == expected_encoded_array);
-}
-
-TEST_CASE(
-  "struct encoding of array of array of structs",
-  "[core][smt2_incremental]")
-{
-  const struct_union_typet::componentst components{
-    {"foo", unsignedbv_typet{8}}, {"bar", signedbv_typet{16}}};
-  struct_typet struct_type{components};
-  type_symbolt type_symbol{"my_structt", struct_type, ID_C};
-  auto test = struct_encoding_test_environmentt::make();
-  test.symbol_table.insert(type_symbol);
-  struct_tag_typet struct_tag{type_symbol.name};
-  const auto index_type = signedbv_typet{32};
-  const auto array_size_inner = from_integer(4, index_type);
-  const auto array_size_outer = from_integer(2, index_type);
-  array_typet array_of_struct{struct_tag, array_size_inner};
-  array_typet array_of_array_of_struct{array_of_struct, array_size_outer};
-  array_typet expected_encoded_array{
-    array_typet{bv_typet{24}, array_size_inner}, array_size_outer};
-  REQUIRE(
-    test.struct_encoding.encode(array_of_array_of_struct) ==
-    expected_encoded_array);
+  SECTION("direct struct_tag_type encoding")
+  {
+    REQUIRE(test.struct_encoding.encode(struct_tag) == bv_typet{24});
+  }
+  SECTION("array of structs encoding")
+  {
+    const auto index_type = signedbv_typet{32};
+    const auto array_size = from_integer(5, index_type);
+    array_typet array_of_struct{struct_tag, array_size};
+    array_typet expected_encoded_array{bv_typet{24}, array_size};
+    REQUIRE(
+      test.struct_encoding.encode(array_of_struct) == expected_encoded_array);
+  }
+  SECTION("array of array of structs encoding")
+  {
+    const auto index_type = signedbv_typet{32};
+    const auto array_size_inner = from_integer(4, index_type);
+    const auto array_size_outer = from_integer(2, index_type);
+    array_typet array_of_struct{struct_tag, array_size_inner};
+    array_typet array_of_array_of_struct{array_of_struct, array_size_outer};
+    array_typet expected_encoded_array{
+      array_typet{bv_typet{24}, array_size_inner}, array_size_outer};
+    REQUIRE(
+      test.struct_encoding.encode(array_of_array_of_struct) ==
+      expected_encoded_array);
+  }
 }


### PR DESCRIPTION
This PR adds initial `struct` support for the incremental SMT2 decision procedure. Further refinements of this and support for other kinds of expression will be handled in follow-up PRs.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
