### PR TITLE
Add goto-inspect regression tests to Makefile builds

### DIFF
--- a/regression/Makefile
+++ b/regression/Makefile
@@ -22,6 +22,7 @@ DIRS = cbmc-shadow-memory \
        goto-instrument-json \
        goto-instrument-wmm-core \
        goto-instrument-typedef \
+       goto-inspect \
        smt2_solver \
        smt2_strings \
        strings \

--- a/regression/goto-inspect/Makefile
+++ b/regression/goto-inspect/Makefile
@@ -1,0 +1,24 @@
+default: tests.log
+
+include ../../src/config.inc
+include ../../src/common
+
+ifeq ($(BUILD_ENV_),MSVC)
+	exe=../../../src/goto-cc/goto-cl
+	is_windows=true
+	excluded_tests = -X winbug
+else
+	exe=../../../src/goto-cc/goto-cc
+	is_windows=false
+endif
+
+test:
+	@../test.pl -e -p -c '../chain.sh $(exe) ../../../src/goto-inspect/goto-inspect $(is_windows)' $(excluded_tests)
+
+tests.log:
+	@../test.pl -e -p -c '../chain.sh $(exe) ../../../src/goto-inspect/goto-inspect $(is_windows)' $(excluded_tests)
+
+clean:
+	find . -name '*.out' -execdir $(RM) '{}' \;
+	find . -name '*.gb' -execdir $(RM) '{}' \;
+	$(RM) tests.log


### PR DESCRIPTION
These were added to the CMake configuration, but were missing an entry and configuration file for make-based builds.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
