### PR TITLE
SYNTHESIZER: Conver do{ }while(0) to non-loop block

### DIFF
--- a/regression/goto-synthesizer/do_while_loop_0/main.c
+++ b/regression/goto-synthesizer/do_while_loop_0/main.c
@@ -1,0 +1,8 @@
+int main()
+{
+  int result = 0;
+  do
+  {
+    result += 1;
+  } while(0 == 1);
+}

--- a/regression/goto-synthesizer/do_while_loop_0/test.desc
+++ b/regression/goto-synthesizer/do_while_loop_0/test.desc
@@ -1,0 +1,10 @@
+CORE
+main.c
+--pointer-check
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring
+--
+Check if synthesizer works for do {} while (0).


### PR DESCRIPTION
<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->
The following construct is common in C. It also appears in Kani compiled GOTO. 
```c
do {
  // loop body
} while (0)
```

However, the old contracts (non dfcc) doesn't support do/while loops. This PR as an ad hoc fix until we migrate the synthesizer to dfcc.



- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
