### PR TITLE
Enable SMT tests fixed by rudimentary struct support

### DIFF
--- a/regression/cbmc/Endianness7/test.desc
+++ b/regression/cbmc/Endianness7/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 --big-endian --no-simplify
 ^EXIT=0$

--- a/regression/cbmc/Malloc13/test.desc
+++ b/regression/cbmc/Malloc13/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 --string-abstraction
 ^EXIT=0$

--- a/regression/cbmc/Malloc23/test.desc
+++ b/regression/cbmc/Malloc23/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 --pointer-check
 ^EXIT=10$

--- a/regression/cbmc/String_Abstraction24/test.desc
+++ b/regression/cbmc/String_Abstraction24/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 --string-abstraction
 ^VERIFICATION FAILED$

--- a/regression/cbmc/equality_through_array_of_struct1/test.desc
+++ b/regression/cbmc/equality_through_array_of_struct1/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 
 ^EXIT=0$

--- a/regression/cbmc/equality_through_array_of_struct2/test.desc
+++ b/regression/cbmc/equality_through_array_of_struct2/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 
 ^EXIT=0$

--- a/regression/cbmc/equality_through_array_of_struct3/test.desc
+++ b/regression/cbmc/equality_through_array_of_struct3/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 
 ^EXIT=0$

--- a/regression/cbmc/equality_through_array_of_struct4/test.desc
+++ b/regression/cbmc/equality_through_array_of_struct4/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 
 ^EXIT=0$

--- a/regression/cbmc/offsetof1/test.desc
+++ b/regression/cbmc/offsetof1/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 
 ^EXIT=0$


### PR DESCRIPTION
This PR enables SMT tests fixed by rudimentary struct support.
These tests now pass due to the functionality added in PR7740.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
