### PR TITLE
Fix comment and error message typos

### DIFF
--- a/doc/man/goto-instrument.1
+++ b/doc/man/goto-instrument.1
@@ -346,7 +346,7 @@ void \fBtest_get_message\fP() {
 
 The harness verifies that \fIget_message\fR assigns non-decreasing time stamps
 to the returned messages. However, simply treating \fIclock\fR as
-non-deterministic would not allow to prove this property. Thus, we can supply a
+non-deterministic would not suffice to prove this property. Thus, we can supply a
 model for reads from \fIclock\fR:
 
 .EX

--- a/scripts/cpplint.py
+++ b/scripts/cpplint.py
@@ -2266,7 +2266,7 @@ def FindDoStart(clean_lines, linenum):
 
   Work our way up through the lines starting at linenum to find a do
   that hasn't been matched. This might not succeed as might just be an
-  emtpy while statement.
+  empty while statement.
 
   Args:
     clean_lines: A CleansedLines instance containing the file.

--- a/src/ansi-c/library/cprover_contracts.c
+++ b/src/ansi-c/library/cprover_contracts.c
@@ -780,7 +780,7 @@ __CPROVER_HIDE:;
   if(set->allocated.elems[__CPROVER_POINTER_OBJECT(ptr)] != 0)
     return 1;
 
-  // don't even drive symex into the rest of the function if the set is emtpy
+  // don't even drive symex into the rest of the function if the set is empty
   if(set->contract_assigns.max_elems == 0)
     return 0;
 

--- a/src/solvers/flattening/boolbv_concatenation.cpp
+++ b/src/solvers/flattening/boolbv_concatenation.cpp
@@ -18,7 +18,7 @@ bvt boolbvt::convert_concatenation(const concatenation_exprt &expr)
   const exprt::operandst &operands=expr.operands();
 
   DATA_INVARIANT(
-    !operands.empty(), "concatentation shall have at least one operand");
+    !operands.empty(), "concatenation shall have at least one operand");
 
   std::size_t offset=width;
   bvt bv;
@@ -30,7 +30,7 @@ bvt boolbvt::convert_concatenation(const concatenation_exprt &expr)
 
     INVARIANT(
       op.size() <= offset,
-      "concatentation operand must fit into the result bitvector");
+      "concatenation operand must fit into the result bitvector");
 
     offset-=op.size();
 
@@ -41,7 +41,7 @@ bvt boolbvt::convert_concatenation(const concatenation_exprt &expr)
   INVARIANT(
     offset == 0,
     "all bits in the result bitvector must have been filled up by the "
-    "concatentation operands");
+    "concatenation operands");
 
   return bv;
 }

--- a/src/solvers/sat/external_sat.cpp
+++ b/src/solvers/sat/external_sat.cpp
@@ -85,7 +85,7 @@ external_satt::resultt external_satt::parse_result(std::string solver_output)
       if(parts.size() < 2)
       {
         log.error() << "external SAT solver has provided an unexpected "
-                       "response in results.\nUnexpected reponse: "
+                       "response in results.\nUnexpected response: "
                     << line << messaget::eom;
         return resultt::P_ERROR;
       }


### PR DESCRIPTION
Debian's Lintian includes spell checking and reported typos in our source.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
