### PR TITLE
CONTRACTS: track function parameters explicitly

### DIFF
--- a/regression/contracts-dfcc/loop_assigns_function_paramters/main.c
+++ b/regression/contracts-dfcc/loop_assigns_function_paramters/main.c
@@ -1,0 +1,19 @@
+#include <stdlib.h>
+
+void decr(size_t n)
+{
+  for(; n--;)
+    // clang-format off
+    __CPROVER_assigns(n)
+    __CPROVER_decreases(n)
+    // clang-format on
+    {
+    }
+}
+
+int main()
+{
+  size_t n;
+  decr(n);
+  return 0;
+}

--- a/regression/contracts-dfcc/loop_assigns_function_paramters/test.desc
+++ b/regression/contracts-dfcc/loop_assigns_function_paramters/test.desc
@@ -1,0 +1,11 @@
+CORE dfcc-only
+main.c
+--dfcc main --apply-loop-contracts --enforce-contract decr
+^\[decr.loop_assigns.\d+] line \d+ Check assigns clause inclusion for loop decr.0: SUCCESS$
+^VERIFICATION SUCCESSFUL$
+^EXIT=0$
+^SIGNAL=0$
+--
+--
+This test checks that function parameters are automatically added to the function
+write set when they are assigned from the body of a loop.

--- a/src/goto-instrument/contracts/dynamic-frames/dfcc_cfg_info.h
+++ b/src/goto-instrument/contracts/dynamic-frames/dfcc_cfg_info.h
@@ -291,6 +291,13 @@ public:
     return top_level_write_set;
   }
 
+  /// Returns the set of top level symbols that must be tracked explicitly in
+  /// the top level write set of the function.
+  const std::unordered_set<irep_idt> &get_top_level_tracked()
+  {
+    return top_level_tracked;
+  }
+
 private:
   const irep_idt &function_id;
   goto_functiont &goto_function;


### PR DESCRIPTION
Partly fixes #7760 

Function parameter are now tracked explicitly in the function write set if they are assigned from within some loop.

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

