### PR TITLE
Add lookup for unlowered form in `get_identifier`.

### DIFF
--- a/regression/cbmc/enum_is_in_range/enum_test5.desc
+++ b/regression/cbmc/enum_is_in_range/enum_test5.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 enum_test5.c
 --enum-range-check
 ^EXIT=10$

--- a/src/solvers/smt2_incremental/smt2_incremental_decision_procedure.cpp
+++ b/src/solvers/smt2_incremental/smt2_incremental_decision_procedure.cpp
@@ -351,14 +351,24 @@ static optionalt<smt_termt> get_identifier(
     &expression_identifiers,
   const namespacet &ns)
 {
-  const exprt lowered_expr = lower_enum(expr, ns);
-  const auto handle_find_result =
-    expression_handle_identifiers.find(lowered_expr);
+  // Lookup the non-lowered form first.
+  const auto handle_find_result = expression_handle_identifiers.find(expr);
   if(handle_find_result != expression_handle_identifiers.cend())
     return handle_find_result->second;
-  const auto expr_find_result = expression_identifiers.find(lowered_expr);
+  const auto expr_find_result = expression_identifiers.find(expr);
   if(expr_find_result != expression_identifiers.cend())
     return expr_find_result->second;
+
+  // If that didn't yield any results, then try the lowered form.
+  const exprt lowered_expr = lower_enum(expr, ns);
+  const auto lowered_handle_find_result =
+    expression_handle_identifiers.find(lowered_expr);
+  if(lowered_handle_find_result != expression_handle_identifiers.cend())
+    return lowered_handle_find_result->second;
+  const auto lowered_expr_find_result =
+    expression_identifiers.find(lowered_expr);
+  if(lowered_expr_find_result != expression_identifiers.cend())
+    return lowered_expr_find_result->second;
   return {};
 }
 

--- a/unit/solvers/smt2_incremental/encoding/enum_encoding.cpp
+++ b/unit/solvers/smt2_incremental/encoding/enum_encoding.cpp
@@ -29,7 +29,7 @@ static c_enum_typet make_c_enum_type(
   return enum_type;
 }
 
-constant_exprt create_enum_tag_typed_constant(
+static constant_exprt create_enum_tag_typed_constant(
   const mp_integer &value,
   const c_enum_typet &enum_type,
   const c_enum_tag_typet &enum_tag_type)


### PR DESCRIPTION
This fixes a problem with looking up the value of an implication expression not being `True`, which resulted in the properties not being properly updated after the property decider had run.

This also activates a regression test for `enum_is_in_range` while we're at it as well, and adds unit tests for the fix.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
