### PR TITLE
CONTRACTS: fix fresh symbols for quantified vars

### DIFF
--- a/regression/contracts-dfcc/quantifiers-loops-fresh-bound-vars-smt/main.c
+++ b/regression/contracts-dfcc/quantifiers-loops-fresh-bound-vars-smt/main.c
@@ -1,0 +1,32 @@
+#include <stdlib.h>
+void foo(char *dst, const char *src, size_t n)
+  // clang-format off
+  __CPROVER_requires(__CPROVER_is_fresh(src, n))
+  __CPROVER_requires(__CPROVER_is_fresh(dst, n))
+  __CPROVER_assigns(__CPROVER_object_from(dst))
+  __CPROVER_ensures(__CPROVER_forall {
+    size_t j;
+    j < n ==> dst[j] == src[j]
+  })
+// clang-format on
+{
+  for(size_t i = 0; i < n; i++)
+    // clang-format off
+    __CPROVER_assigns(i, __CPROVER_object_from(dst))
+    __CPROVER_loop_invariant(i <= n)
+    __CPROVER_loop_invariant(
+      __CPROVER_forall { size_t j; j < i ==> dst[j] == src[j] })
+    // clang-format on
+    {
+      dst[i] = src[i];
+    }
+}
+
+int main()
+{
+  char *dst;
+  char *src;
+  size_t n;
+  foo(dst, src, n);
+  return 0;
+}

--- a/regression/contracts-dfcc/quantifiers-loops-fresh-bound-vars-smt/test.desc
+++ b/regression/contracts-dfcc/quantifiers-loops-fresh-bound-vars-smt/test.desc
@@ -1,0 +1,15 @@
+CORE dfcc-only smt-backend broken-cprover-smt-backend
+main.c
+--dfcc main --apply-loop-contracts --enforce-contract foo --malloc-may-fail --malloc-fail-null _ --z3 --slice-formula
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring
+--
+Tests support for quantifiers in loop contracts with the SMT backend.
+When quantified loop invariants are used, they are inserted three times
+in the transformed program (base case assertion, step case assumption,
+step case assertion), and each occurrence needs to be rewritten with fresh
+symbols for the quantified variables. The SMT solver would with an error
+whenever this renaming is not properly done.

--- a/src/goto-instrument/contracts/dynamic-frames/dfcc_instrument_loop.h
+++ b/src/goto-instrument/contracts/dynamic-frames/dfcc_instrument_loop.h
@@ -184,7 +184,7 @@ protected:
   /// \param[inout] loop_latch Latch node of the loop.
   /// \param[out] assigns_instrs `goto_programt` that contains instructions of
   ///                       populating assigns into the loop write set.
-  /// \param[out] invariant Loop invariants.
+  /// \param[in] invariant Loop invariants.
   /// \param[in] assigns Assigns targets of the loop.
   /// \param[in] loop_write_set Stack allocated loop write set variable.
   /// \param[in] addr_of_loop_write_set Loop write set pointer variable.
@@ -250,7 +250,7 @@ protected:
     goto_programt::targett loop_head,
     goto_programt::targett loop_latch,
     goto_programt &havoc_instrs,
-    const exprt &invariant,
+    exprt &invariant,
     const exprt::operandst &decreases_clauses,
     const symbol_exprt &loop_write_set,
     const exprt &outer_write_set,
@@ -296,7 +296,7 @@ protected:
     symbol_table_baset &symbol_table,
     goto_programt::targett loop_head,
     goto_programt::targett loop_latch,
-    const exprt &invariant,
+    exprt &invariant,
     const exprt::operandst &decreases_clauses,
     const symbol_exprt &entered_loop,
     const symbol_exprt &in_base_case,


### PR DESCRIPTION
Fixes https://github.com/diffblue/cbmc/issues/7785

When quantified formulas are used in loop invariants, each occurrence of the invariant (base case assert, step case assume, step case assert) needs to be rewritten to introduce a fresh symbol for the quantified variables.
 
- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.
