### PR TITLE
Add incremental SMT support for struct with and member expressions

### DIFF
--- a/regression/cbmc-incr-smt2/structs/large_array_of_struct_nondet_index.c
+++ b/regression/cbmc-incr-smt2/structs/large_array_of_struct_nondet_index.c
@@ -1,0 +1,18 @@
+#include <assert.h>
+
+#define ARRAY_SIZE 10000
+
+int main()
+{
+  struct my_structt
+  {
+    int eggs;
+    int ham;
+  };
+  struct my_structt struct_array[ARRAY_SIZE];
+  int x;
+  __CPROVER_assume(x > 0 && x < ARRAY_SIZE);
+  struct_array[x].eggs = 3;
+  assert(struct_array[x].eggs + struct_array[x].ham != 10);
+  assert(struct_array[x].eggs + struct_array[x].ham != 11);
+}

--- a/regression/cbmc-incr-smt2/structs/large_array_of_struct_nondet_index.desc
+++ b/regression/cbmc-incr-smt2/structs/large_array_of_struct_nondet_index.desc
@@ -1,0 +1,18 @@
+CORE
+large_array_of_struct_nondet_index.c
+--trace
+Passing problem to incremental SMT2 solving
+^EXIT=10$
+^SIGNAL=0$
+line 16 assertion struct_array\[x\]\.eggs \+ struct_array\[x\]\.ham != 10\: FAILURE
+line 17 assertion struct_array\[x\]\.eggs \+ struct_array\[x\]\.ham != 11\: FAILURE
+\{\s*\.eggs=\d+,\s*\.ham=7\s*\}
+\{\s*\.eggs=\d+,\s*\.ham=8\s*\}
+x=\d{1,4}\s
+struct_array\[\(signed long int\)x\]\.eggs=3
+--
+--
+This test covers support for examples with large arrays of structs using nondet
+indexes including trace generation. This combination of features is chosen in
+order to avoid array cell sensitivity or struct field sensitivity simplifying
+away the relevant `member_exprt` and `with_exprt` expressions.

--- a/regression/cbmc-incr-smt2/structs/large_array_of_struct_nondet_index.desc
+++ b/regression/cbmc-incr-smt2/structs/large_array_of_struct_nondet_index.desc
@@ -9,7 +9,7 @@ line 17 assertion struct_array\[x\]\.eggs \+ struct_array\[x\]\.ham != 11\: FAIL
 \{\s*\.eggs=\d+,\s*\.ham=7\s*\}
 \{\s*\.eggs=\d+,\s*\.ham=8\s*\}
 x=\d{1,4}\s
-struct_array\[\(signed long int\)x\]\.eggs=3
+struct_array\[\(signed (long )+int\)x\]\.eggs=3
 --
 --
 This test covers support for examples with large arrays of structs using nondet

--- a/regression/cbmc/array-cell-sensitivity9/test.desc
+++ b/regression/cbmc/array-cell-sensitivity9/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 test.c
 --show-vcc
 main::1::array!0@1#2\[\[0\]\]..x =

--- a/regression/cbmc/array-cell-sensitivity9/test_execution.desc
+++ b/regression/cbmc/array-cell-sensitivity9/test_execution.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 test.c
 
 ^VERIFICATION SUCCESSFUL$

--- a/regression/cbmc/field-sensitivity-trace-wrong-counterexample-1/test.desc
+++ b/regression/cbmc/field-sensitivity-trace-wrong-counterexample-1/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 test.c
 --trace
 ^EXIT=10$

--- a/regression/cbmc/simplify_singleton_interval_7690/test_smt2.desc
+++ b/regression/cbmc/simplify_singleton_interval_7690/test_smt2.desc
@@ -1,4 +1,4 @@
-CORE smt-backend
+CORE smt-backend new-smt-backend
 singleton_interval_in_assume_7690.c
 --pointer-check
 ^\[stk_push\.pointer_dereference\.17] line \d+ dereference failure: pointer outside object bounds in stk-\>elems\[\(signed (long|long long) int\)stk-\>top\]: SUCCESS$

--- a/src/solvers/smt2_incremental/encoding/struct_encoding.cpp
+++ b/src/solvers/smt2_incremental/encoding/struct_encoding.cpp
@@ -50,6 +50,57 @@ typet struct_encodingt::encode(typet type) const
   return type;
 }
 
+/// \brief Extracts the component/field names and new values from a `with_exprt`
+///        which expresses a new struct value where one or more members of a
+///        struct have had their values substituted with new values.
+/// \note  This is implemented using direct access to the operands and other
+///        underlying irept interfaces, because the interface for `with_exprt`
+///        only supports a single `where` / `new_value` pair and does not
+///        support extracting the name from the `where` operand.
+static std::unordered_map<irep_idt, exprt>
+extricate_updates(const with_exprt &struct_expr)
+{
+  std::unordered_map<irep_idt, exprt> pairs;
+  auto current_operand = struct_expr.operands().begin();
+  // Skip the struct being updated in order to begin with the pairs.
+  current_operand++;
+  while(current_operand != struct_expr.operands().end())
+  {
+    INVARIANT(
+      current_operand->id() == ID_member_name,
+      "operand is expected to be the name of a member");
+    auto name = current_operand->find(ID_component_name).id();
+    ++current_operand;
+    INVARIANT(
+      current_operand != struct_expr.operands().end(),
+      "every name is expected to be followed by a paired value");
+    pairs[name] = *current_operand;
+    ++current_operand;
+  }
+  POSTCONDITION(!pairs.empty());
+  return pairs;
+}
+
+static exprt encode(const with_exprt &with, const namespacet &ns)
+{
+  const auto tag_type = type_checked_cast<struct_tag_typet>(with.type());
+  const auto struct_type =
+    type_checked_cast<struct_typet>(ns.follow(with.type()));
+  const auto updates = extricate_updates(with);
+  const auto components =
+    make_range(struct_type.components())
+      .map([&](const struct_union_typet::componentt &component) -> exprt {
+        const auto &update = updates.find(component.get_name());
+        if(update != updates.end())
+          return update->second;
+        else
+          return member_exprt{
+            with.old(), component.get_name(), component.type()};
+      })
+      .collect<exprt::operandst>();
+  return struct_exprt{components, tag_type};
+}
+
 static exprt encode(const struct_exprt &struct_expr)
 {
   INVARIANT(
@@ -111,6 +162,11 @@ exprt struct_encodingt::encode(exprt expr) const
   {
     exprt &current = *work_queue.front();
     work_queue.pop();
+    // Note that "with" expressions are handled before type encoding in order to
+    // facilitate checking that they are applied to structs rather than arrays.
+    if(const auto with_expr = expr_try_dynamic_cast<with_exprt>(current))
+      if(can_cast_type<struct_tag_typet>(current.type()))
+        current = ::encode(*with_expr, ns);
     current.type() = encode(current.type());
     if(const auto struct_expr = expr_try_dynamic_cast<struct_exprt>(current))
       current = ::encode(*struct_expr);

--- a/src/solvers/smt2_incremental/encoding/struct_encoding.cpp
+++ b/src/solvers/smt2_incremental/encoding/struct_encoding.cpp
@@ -5,18 +5,23 @@
 #include <util/bitvector_expr.h>
 #include <util/bitvector_types.h>
 #include <util/make_unique.h>
+#include <util/namespace.h>
+#include <util/range.h>
 
 #include <solvers/flattening/boolbv_width.h>
 
+#include <algorithm>
+#include <numeric>
 #include <queue>
 
 struct_encodingt::struct_encodingt(const namespacet &ns)
-  : boolbv_width{util_make_unique<boolbv_widtht>(ns)}
+  : boolbv_width{util_make_unique<boolbv_widtht>(ns)}, ns{ns}
 {
 }
 
 struct_encodingt::struct_encodingt(const struct_encodingt &other)
-  : boolbv_width{util_make_unique<boolbv_widtht>(*other.boolbv_width)}
+  : boolbv_width{util_make_unique<boolbv_widtht>(*other.boolbv_width)},
+    ns{other.ns}
 {
 }
 
@@ -55,6 +60,49 @@ static exprt encode(const struct_exprt &struct_expr)
   return concatenation_exprt{struct_expr.operands(), struct_expr.type()};
 }
 
+static std::size_t count_trailing_bit_width(
+  const struct_typet &type,
+  const irep_idt name,
+  const boolbv_widtht &boolbv_width)
+{
+  auto member_component_rit = std::find_if(
+    type.components().rbegin(),
+    type.components().rend(),
+    [&](const struct_union_typet::componentt &component) {
+      return component.get_name() == name;
+    });
+  INVARIANT(
+    member_component_rit != type.components().rend(),
+    "Definition of struct type should include named component.");
+  const auto trailing_widths =
+    make_range(type.components().rbegin(), member_component_rit)
+      .map([&](const struct_union_typet::componentt &component) -> std::size_t {
+        return boolbv_width(component.type());
+      });
+  return std::accumulate(
+    trailing_widths.begin(), trailing_widths.end(), std::size_t{0});
+}
+
+/// The member expression selects the value of a field from a struct. The
+/// struct is encoded as a single bitvector where the first field is stored
+/// in the highest bits. The second field is stored in the next highest set of
+/// bits and so on. As offsets are indexed from the lowest bit, any field can be
+/// selected by extracting the range of bits starting from an offset based on
+/// the combined width of the fields which follow the field being selected.
+exprt struct_encodingt::encode_member(const member_exprt &member_expr) const
+{
+  const auto &struct_type = type_checked_cast<struct_typet>(
+    ns.get().follow(member_expr.compound().type()));
+  const std::size_t offset_bits = count_trailing_bit_width(
+    struct_type, member_expr.get_component_name(), *boolbv_width);
+  const auto member_bits_width = (*boolbv_width)(member_expr.type());
+  return extractbits_exprt{
+    member_expr.compound(),
+    offset_bits + member_bits_width - 1,
+    offset_bits,
+    member_expr.type()};
+}
+
 exprt struct_encodingt::encode(exprt expr) const
 {
   std::queue<exprt *> work_queue;
@@ -66,6 +114,8 @@ exprt struct_encodingt::encode(exprt expr) const
     current.type() = encode(current.type());
     if(const auto struct_expr = expr_try_dynamic_cast<struct_exprt>(current))
       current = ::encode(*struct_expr);
+    if(const auto member_expr = expr_try_dynamic_cast<member_exprt>(current))
+      current = encode_member(*member_expr);
     for(auto &operand : current.operands())
       work_queue.push(&operand);
   }

--- a/src/solvers/smt2_incremental/encoding/struct_encoding.h
+++ b/src/solvers/smt2_incremental/encoding/struct_encoding.h
@@ -10,6 +10,7 @@
 
 class namespacet;
 class boolbv_widtht;
+class member_exprt;
 
 /// Encodes struct types/values into non-struct expressions/types.
 class struct_encodingt final
@@ -24,6 +25,9 @@ public:
 
 private:
   std::unique_ptr<boolbv_widtht> boolbv_width;
+  std::reference_wrapper<const namespacet> ns;
+
+  exprt encode_member(const member_exprt &member_expr) const;
 };
 
 #endif // CPROVER_SOLVERS_SMT2_INCREMENTAL_STRUCT_ENCODING_H

--- a/src/solvers/smt2_incremental/encoding/struct_encoding.h
+++ b/src/solvers/smt2_incremental/encoding/struct_encoding.h
@@ -11,6 +11,7 @@
 class namespacet;
 class boolbv_widtht;
 class member_exprt;
+class struct_tag_typet;
 
 /// Encodes struct types/values into non-struct expressions/types.
 class struct_encodingt final
@@ -22,6 +23,10 @@ public:
 
   typet encode(typet type) const;
   exprt encode(exprt expr) const;
+  /// Reconstructs a struct expression of the \p original_type using the data
+  /// from the bit vector \p encoded expression.
+  exprt
+  decode(const exprt &encoded, const struct_tag_typet &original_type) const;
 
 private:
   std::unique_ptr<boolbv_widtht> boolbv_width;

--- a/src/solvers/smt2_incremental/smt2_incremental_decision_procedure.cpp
+++ b/src/solvers/smt2_incremental/smt2_incremental_decision_procedure.cpp
@@ -343,13 +343,8 @@ exprt smt2_incremental_decision_proceduret::handle(const exprt &expr)
   return expr;
 }
 
-static optionalt<smt_termt> get_identifier(
-  const exprt &expr,
-  const std::unordered_map<exprt, smt_identifier_termt, irep_hash>
-    &expression_handle_identifiers,
-  const std::unordered_map<exprt, smt_identifier_termt, irep_hash>
-    &expression_identifiers,
-  const namespacet &ns)
+optionalt<smt_termt>
+smt2_incremental_decision_proceduret::get_identifier(const exprt &expr) const
 {
   // Lookup the non-lowered form first.
   const auto handle_find_result = expression_handle_identifiers.find(expr);
@@ -457,23 +452,13 @@ exprt smt2_incremental_decision_proceduret::get(const exprt &expr) const
   auto descriptor = [&]() -> optionalt<smt_termt> {
     if(const auto index_expr = expr_try_dynamic_cast<index_exprt>(expr))
     {
-      const auto array = get_identifier(
-        index_expr->array(),
-        expression_handle_identifiers,
-        expression_identifiers,
-        ns);
-      const auto index = get_identifier(
-        index_expr->index(),
-        expression_handle_identifiers,
-        expression_identifiers,
-        ns);
+      const auto array = get_identifier(index_expr->array());
+      const auto index = get_identifier(index_expr->index());
       if(!array || !index)
         return {};
       return smt_array_theoryt::select(*array, *index);
     }
-    if(
-      auto identifier_descriptor = get_identifier(
-        expr, expression_handle_identifiers, expression_identifiers, ns))
+    if(auto identifier_descriptor = get_identifier(expr))
     {
       return identifier_descriptor;
     }

--- a/src/solvers/smt2_incremental/smt2_incremental_decision_procedure.cpp
+++ b/src/solvers/smt2_incremental/smt2_incremental_decision_procedure.cpp
@@ -355,7 +355,7 @@ smt2_incremental_decision_proceduret::get_identifier(const exprt &expr) const
     return expr_find_result->second;
 
   // If that didn't yield any results, then try the lowered form.
-  const exprt lowered_expr = lower_enum(expr, ns);
+  const exprt lowered_expr = lower(expr);
   const auto lowered_handle_find_result =
     expression_handle_identifiers.find(lowered_expr);
   if(lowered_handle_find_result != expression_handle_identifiers.cend())
@@ -589,7 +589,7 @@ void smt2_incremental_decision_proceduret::define_object_properties()
   }
 }
 
-exprt smt2_incremental_decision_proceduret::lower(exprt expression)
+exprt smt2_incremental_decision_proceduret::lower(exprt expression) const
 {
   const exprt lowered = struct_encoding.encode(
     lower_enum(lower_byte_operators(expression, ns), ns));

--- a/src/solvers/smt2_incremental/smt2_incremental_decision_procedure.cpp
+++ b/src/solvers/smt2_incremental/smt2_incremental_decision_procedure.cpp
@@ -4,7 +4,6 @@
 
 #include <util/arith_tools.h>
 #include <util/byte_operators.h>
-#include <util/expr.h>
 #include <util/namespace.h>
 #include <util/nodiscard.h>
 #include <util/range.h>

--- a/src/solvers/smt2_incremental/smt2_incremental_decision_procedure.cpp
+++ b/src/solvers/smt2_incremental/smt2_incremental_decision_procedure.cpp
@@ -398,6 +398,17 @@ optionalt<exprt> smt2_incremental_decision_proceduret::get_expr(
 }
 
 optionalt<exprt> smt2_incremental_decision_proceduret::get_expr(
+  const smt_termt &struct_term,
+  const struct_tag_typet &type) const
+{
+  const auto encoded_result =
+    get_expr(struct_term, struct_encoding.encode(type));
+  if(!encoded_result)
+    return {};
+  return {struct_encoding.decode(*encoded_result, type)};
+}
+
+optionalt<exprt> smt2_incremental_decision_proceduret::get_expr(
   const smt_termt &descriptor,
   const typet &type) const
 {
@@ -406,6 +417,10 @@ optionalt<exprt> smt2_incremental_decision_proceduret::get_expr(
     if(array_type->is_incomplete())
       return {};
     return get_expr(descriptor, *array_type);
+  }
+  if(const auto struct_type = type_try_dynamic_cast<struct_tag_typet>(type))
+  {
+    return get_expr(descriptor, *struct_type);
   }
   const smt_get_value_commandt get_value_command{descriptor};
   const smt_responset response = get_response_to_command(

--- a/src/solvers/smt2_incremental/smt2_incremental_decision_procedure.cpp
+++ b/src/solvers/smt2_incremental/smt2_incremental_decision_procedure.cpp
@@ -382,16 +382,14 @@ array_exprt smt2_incremental_decision_proceduret::get_expr(
   elements.reserve(*size);
   for(std::size_t index = 0; index < size; ++index)
   {
+    const auto index_term = ::convert_expr_to_smt(
+      from_integer(index, index_type),
+      object_map,
+      pointer_sizes_map,
+      object_size_function.make_application,
+      is_dynamic_object_function.make_application);
     elements.push_back(get_expr(
-      smt_array_theoryt::select(
-        array,
-        ::convert_expr_to_smt(
-          from_integer(index, index_type),
-          object_map,
-          pointer_sizes_map,
-          object_size_function.make_application,
-          is_dynamic_object_function.make_application)),
-      type.element_type()));
+      smt_array_theoryt::select(array, index_term), type.element_type()));
   }
   return array_exprt{elements, type};
 }

--- a/src/solvers/smt2_incremental/smt2_incremental_decision_procedure.h
+++ b/src/solvers/smt2_incremental/smt2_incremental_decision_procedure.h
@@ -97,7 +97,7 @@ protected:
   /// Performs a combination of transformations which reduces the set of
   /// possible expression forms by expressing these in terms of the remaining
   /// language features.
-  exprt lower(exprt expression);
+  exprt lower(exprt expression) const;
   optionalt<smt_termt> get_identifier(const exprt &expr) const;
 
   /// Namespace for looking up the expressions which symbol_exprts relate to.

--- a/src/solvers/smt2_incremental/smt2_incremental_decision_procedure.h
+++ b/src/solvers/smt2_incremental/smt2_incremental_decision_procedure.h
@@ -54,8 +54,10 @@ public:
   /// Gets the value of \p descriptor from the solver and returns the solver
   /// response expressed as an exprt of type \p type. This is an implementation
   /// detail of the `get(exprt)` member function.
-  exprt get_expr(const smt_termt &descriptor, const typet &type) const;
-  array_exprt get_expr(const smt_termt &array, const array_typet &type) const;
+  optionalt<exprt>
+  get_expr(const smt_termt &descriptor, const typet &type) const;
+  optionalt<exprt>
+  get_expr(const smt_termt &array, const array_typet &type) const;
 
 protected:
   // Implementation of protected decision_proceduret member function.

--- a/src/solvers/smt2_incremental/smt2_incremental_decision_procedure.h
+++ b/src/solvers/smt2_incremental/smt2_incremental_decision_procedure.h
@@ -6,8 +6,8 @@
 #ifndef CPROVER_SOLVERS_SMT2_INCREMENTAL_SMT2_INCREMENTAL_DECISION_PROCEDURE_H
 #define CPROVER_SOLVERS_SMT2_INCREMENTAL_SMT2_INCREMENTAL_DECISION_PROCEDURE_H
 
+#include <util/expr.h> // Needed for `exprt` values. IWYU pragma: keep
 #include <util/message.h>
-#include <util/std_expr.h>
 
 #include <solvers/smt2_incremental/ast/smt_terms.h>
 #include <solvers/smt2_incremental/encoding/struct_encoding.h>

--- a/src/solvers/smt2_incremental/smt2_incremental_decision_procedure.h
+++ b/src/solvers/smt2_incremental/smt2_incremental_decision_procedure.h
@@ -57,6 +57,8 @@ public:
   optionalt<exprt>
   get_expr(const smt_termt &descriptor, const typet &type) const;
   optionalt<exprt>
+  get_expr(const smt_termt &struct_term, const struct_tag_typet &type) const;
+  optionalt<exprt>
   get_expr(const smt_termt &array, const array_typet &type) const;
 
 protected:

--- a/src/solvers/smt2_incremental/smt2_incremental_decision_procedure.h
+++ b/src/solvers/smt2_incremental/smt2_incremental_decision_procedure.h
@@ -98,6 +98,7 @@ protected:
   /// possible expression forms by expressing these in terms of the remaining
   /// language features.
   exprt lower(exprt expression);
+  optionalt<smt_termt> get_identifier(const exprt &expr) const;
 
   /// Namespace for looking up the expressions which symbol_exprts relate to.
   /// This includes the symbols defined outside of the decision procedure but

--- a/unit/solvers/smt2_incremental/encoding/struct_encoding.cpp
+++ b/unit/solvers/smt2_incremental/encoding/struct_encoding.cpp
@@ -3,6 +3,7 @@
 #include <util/arith_tools.h>
 #include <util/bitvector_expr.h>
 #include <util/bitvector_types.h>
+#include <util/mathematical_types.h>
 #include <util/namespace.h>
 #include <util/symbol_table.h>
 
@@ -107,6 +108,47 @@ TEST_CASE("struct encoding of expressions", "[core][smt2_incremental]")
     const concatenation_exprt expected_result{
       {green_ham.symbol_expr(), forty_two, minus_one}, bv_typet{72}};
     REQUIRE(test.struct_encoding.encode(struct_expr) == expected_result);
+  }
+  SECTION("member expression selecting a data member of a struct")
+  {
+    const symbolt breakfast{"breakfast", struct_tag, ID_C};
+    test.symbol_table.insert(breakfast);
+    SECTION("First member")
+    {
+      const typet field_type = signedbv_typet{32};
+      const exprt zero = from_integer(0, field_type);
+      const exprt input = equal_exprt{
+        zero, member_exprt{breakfast.symbol_expr(), "green", field_type}};
+      const exprt expected = equal_exprt{
+        zero,
+        extractbits_exprt{
+          symbol_exprt{"breakfast", bv_typet{72}}, 71, 40, field_type}};
+      REQUIRE(test.struct_encoding.encode(input) == expected);
+    }
+    SECTION("Second member")
+    {
+      const typet field_type = unsignedbv_typet{16};
+      const exprt dozen = from_integer(12, field_type);
+      const exprt input = equal_exprt{
+        dozen, member_exprt{breakfast.symbol_expr(), "eggs", field_type}};
+      const exprt expected = equal_exprt{
+        dozen,
+        extractbits_exprt{
+          symbol_exprt{"breakfast", bv_typet{72}}, 39, 24, field_type}};
+      REQUIRE(test.struct_encoding.encode(input) == expected);
+    }
+    SECTION("Third member")
+    {
+      const typet field_type = signedbv_typet{24};
+      const exprt two = from_integer(2, field_type);
+      const exprt input = equal_exprt{
+        two, member_exprt{breakfast.symbol_expr(), "ham", field_type}};
+      const exprt expected = equal_exprt{
+        two,
+        extractbits_exprt{
+          symbol_exprt{"breakfast", bv_typet{72}}, 23, 0, field_type}};
+      REQUIRE(test.struct_encoding.encode(input) == expected);
+    }
   }
 }
 

--- a/unit/solvers/smt2_incremental/encoding/struct_encoding.cpp
+++ b/unit/solvers/smt2_incremental/encoding/struct_encoding.cpp
@@ -321,6 +321,26 @@ TEST_CASE("struct encoding of expressions", "[core][smt2_incremental]")
   }
 }
 
+TEST_CASE("decoding into struct expressions.", "[core][smt2_incremental]")
+{
+  const struct_union_typet::componentst component_types{
+    {"green", signedbv_typet{32}},
+    {"eggs", unsignedbv_typet{16}},
+    {"ham", signedbv_typet{24}}};
+  const struct_typet struct_type{component_types};
+  const type_symbolt type_symbol{"my_structt", struct_type, ID_C};
+  auto test = struct_encoding_test_environmentt::make();
+  test.symbol_table.insert(type_symbol);
+  const struct_tag_typet struct_tag{type_symbol.name};
+  const struct_exprt expected{
+    {from_integer(3, signedbv_typet{32}),
+     from_integer(2, unsignedbv_typet{16}),
+     from_integer(1, signedbv_typet{24})},
+    struct_tag};
+  const exprt encoded = constant_exprt{"000000030002000001", bv_typet{72}};
+  REQUIRE(test.struct_encoding.decode(encoded, struct_tag) == expected);
+}
+
 TEST_CASE(
   "encoding of single member struct expressions",
   "[core][smt2_incremental]")

--- a/unit/solvers/smt2_incremental/encoding/struct_encoding.cpp
+++ b/unit/solvers/smt2_incremental/encoding/struct_encoding.cpp
@@ -73,7 +73,9 @@ TEST_CASE("struct encoding of types", "[core][smt2_incremental]")
 TEST_CASE("struct encoding of expressions", "[core][smt2_incremental]")
 {
   const struct_union_typet::componentst component_types{
-    {"green", signedbv_typet{32}}, {"eggs", unsignedbv_typet{16}}};
+    {"green", signedbv_typet{32}},
+    {"eggs", unsignedbv_typet{16}},
+    {"ham", signedbv_typet{24}}};
   const struct_typet struct_type{component_types};
   const type_symbolt type_symbol{"my_structt", struct_type, ID_C};
   auto test = struct_encoding_test_environmentt::make();
@@ -82,7 +84,7 @@ TEST_CASE("struct encoding of expressions", "[core][smt2_incremental]")
   const symbolt struct_value_symbol{"my_struct", struct_tag, ID_C};
   test.symbol_table.insert(struct_value_symbol);
   const auto symbol_expr = struct_value_symbol.symbol_expr();
-  const auto symbol_expr_as_bv = symbol_exprt{"my_struct", bv_typet{48}};
+  const auto symbol_expr_as_bv = symbol_exprt{"my_struct", bv_typet{72}};
   SECTION("struct typed symbol expression")
   {
     REQUIRE(test.struct_encoding.encode(symbol_expr) == symbol_expr_as_bv);
@@ -98,10 +100,12 @@ TEST_CASE("struct encoding of expressions", "[core][smt2_incremental]")
     const symbolt green_ham{"ham", signedbv_typet{32}, ID_C};
     test.symbol_table.insert(green_ham);
     const auto forty_two = from_integer(42, unsignedbv_typet{16});
-    const exprt::operandst components{green_ham.symbol_expr(), forty_two};
+    const auto minus_one = from_integer(-1, signedbv_typet{24});
+    const exprt::operandst components{
+      green_ham.symbol_expr(), forty_two, minus_one};
     const struct_exprt struct_expr{components, struct_tag};
     const concatenation_exprt expected_result{
-      {green_ham.symbol_expr(), forty_two}, bv_typet{48}};
+      {green_ham.symbol_expr(), forty_two, minus_one}, bv_typet{72}};
     REQUIRE(test.struct_encoding.encode(struct_expr) == expected_result);
   }
 }


### PR DESCRIPTION
This PR adds incremental SMT support for struct with and member expressions.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
