### PR TITLE
Fix groff syntax errors in man pages

### DIFF
--- a/doc/man/cbmc.1
+++ b/doc/man/cbmc.1
@@ -537,7 +537,7 @@ monotonically.  \fBwall\fR: ISO\-8601 wall clock timestamps.
 .SH ENVIRONMENT
 All tools honor the TMPDIR environment variable when generating temporary
 files and directories. Furthermore note that
-the preprocessor used by \fBcbmc\R will use environment variables to locate
+the preprocessor used by \fBcbmc\fR will use environment variables to locate
 header files.
 .SH BUGS
 If you encounter a problem please create an issue at

--- a/doc/man/goto-analyzer.1
+++ b/doc/man/goto-analyzer.1
@@ -307,7 +307,7 @@ on a read.  More precise than this is \fBsmash\fR which stores one abstract
 element for all of the values.  This is relatively cheap but a lot more precise,
 particularly if used with \fBintervals\fR or \fBset-of-constants\fR.
 \fBup-to-n-elements\fR generalizes \fBsmash\fR by storing abstract objects for
-the first \fIn\fR elements of each array (\fIn\R defaults to \fB10\fR and can be
+the first \fIn\fR elements of each array (\fIn\fR defaults to \fB10\fR and can be
 controlled by \fB\-\-vsd\-array\-max\-elements\fR) and then condensing all other
 elements down to a single abstract object.  This allows reasonably fine-grained
 control over the amount of memory used and can give much more precise results
@@ -389,7 +389,7 @@ Output results in plain text to given file.
 Writes the output as a JSON object to \fIfile_name\fR.
 .TP
 \fB\-\-xml\fR \fIfile_name\fR
-Output results in XML format to \fIfile_name\R.
+Output results in XML format to \fIfile_name\fR.
 .TP
 \fB\-\-dot\fR \fIfile_name\fR
 Writes the output in \fBdot\fR(1) format to \fIfile_name\fR.  This is

--- a/doc/man/goto-harness.1
+++ b/doc/man/goto-harness.1
@@ -106,8 +106,8 @@ Initialize memory from JSON memory snapshot stored in \fIfile\fR.
 \fB\-\-initial\-goto\-location\fR \fIfunc\fR[:\fIn\fR]
 Use function \fIfunc\fR and GOTO binary location number \fIn\fR as entry point.
 .TP
-\fB\-\-initial\-source\-location\fR \fIfile\R:\fIn\fR
-Use given file name \fIfile\fR and line number \fIn\R in that file as entry
+\fB\-\-initial\-source\-location\fR \fIfile\fR:\fIn\fR
+Use given file name \fIfile\fR and line number \fIn\fR in that file as entry
 point.
 .TP
 \fB\-\-havoc\-variables\fR \fIvars\fR

--- a/doc/man/janalyzer.1
+++ b/doc/man/janalyzer.1
@@ -142,7 +142,7 @@ Output results in plain text to given file.
 Writes the output as a JSON object to \fIfile_name\fR.
 .TP
 \fB\-\-xml\fR \fIfile_name\fR
-Output results in XML format to \fIfile_name\R.
+Output results in XML format to \fIfile_name\fR.
 .TP
 \fB\-\-dot\fR \fIfile_name\fR
 Writes the output in \fBdot\fR(1) format to \fIfile_name\fR.  This is


### PR DESCRIPTION
Fixes formatting syntax errors reported by Debian's Lintian.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
