### PR TITLE
Work around further spurious GCC12 maybe-uninitialized warnings

### DIFF
--- a/src/goto-instrument/unwindset.cpp
+++ b/src/goto-instrument/unwindset.cpp
@@ -36,7 +36,13 @@ void unwindsett::parse_unwindset_one_loop(
   if(val.empty())
     return;
 
+// Work around spurious GCC 12 warning about thread_nr being uninitialised.
+#pragma GCC diagnostic push
+#ifndef __clang__
+#  pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
   optionalt<unsigned> thread_nr;
+#pragma GCC diagnostic pop
   if(isdigit(val[0]))
   {
     auto c_pos = val.find(':');
@@ -157,7 +163,13 @@ void unwindsett::parse_unwindset_one_loop(
           return;
         }
         else
+// Work around spurious GCC 12 warning about thread_nr being uninitialised.
+#pragma GCC diagnostic push
+#ifndef __clang__
+#  pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
           id = function_id + "." + std::to_string(*nr);
+#pragma GCC diagnostic pop
       }
     }
 

--- a/src/util/cmdline.cpp
+++ b/src/util/cmdline.cpp
@@ -296,7 +296,13 @@ bool cmdlinet::parse_arguments(int argc, const char **argv)
         return true;
       }
 
+      // Work around spurious GCC 12 warning about optnr being uninitialised.
+#pragma GCC diagnostic push
+#ifndef __clang__
+#  pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
       options[*optnr].isset = true;
+#pragma GCC diagnostic pop
 
       if(options[*optnr].hasval)
       {

--- a/src/util/simplify_expr_int.cpp
+++ b/src/util/simplify_expr_int.cpp
@@ -159,6 +159,12 @@ static bool mul_expr(
   return true;
 }
 
+// Work around spurious GCC 12 warning about c_sizeof_type being
+// uninitialised in its destructor (!).
+#pragma GCC diagnostic push
+#ifndef __clang__
+#  pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
 simplify_exprt::resultt<> simplify_exprt::simplify_mult(const mult_exprt &expr)
 {
   // check to see if it is a number type
@@ -270,6 +276,7 @@ simplify_exprt::resultt<> simplify_exprt::simplify_mult(const mult_exprt &expr)
     return std::move(tmp);
   }
 }
+#pragma GCC diagnostic pop
 
 simplify_exprt::resultt<> simplify_exprt::simplify_div(const div_exprt &expr)
 {


### PR DESCRIPTION
It seems that each GCC version introduces a new spurious case.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
