### PR TITLE
Ensure hardening flags apply to all built binaries

### DIFF
--- a/regression/ansi-c/Makefile
+++ b/regression/ansi-c/Makefile
@@ -23,10 +23,10 @@ endif
 endif
 
 test:
-	if which clang ; then \
+	@if which clang ; then \
 	  ../test.pl -e -p -c "$(exe) --native-compiler clang" $(excluded_tests) ; \
 	fi
-	if which gcc ; then \
+	@if which gcc ; then \
 	  ../test.pl -e -p -c "$(exe) --native-compiler gcc" $(excluded_tests) \
 		  -X fake-gcc-version -X clang-only && \
 	  ../test.pl -e -p -c $(exe) $(excluded_tests) -I fake-gcc-version ; \

--- a/src/common
+++ b/src/common
@@ -54,7 +54,7 @@ ifeq ($(filter-out OSX OSX_Universal,$(BUILD_ENV_)),)
   endif
   LINKLIB = /usr/bin/libtool -static -o $@ $^
   LINKBIN = $(CXX) $(LINKFLAGS) -o $@ $^ $(LIBS)
-  LINKNATIVE = $(HOSTCXX) -o $@ $^
+  LINKNATIVE = $(HOSTCXX) $(HOSTLINKFLAGS) -o $@ $^
   ifeq ($(origin CC),default)
     CC     = clang
   endif
@@ -66,7 +66,7 @@ else ifeq ($(filter-out FreeBSD,$(BUILD_ENV_)),)
   CP_CXXFLAGS +=
   LINKLIB = ar rcT $@ $^
   LINKBIN = $(CXX) $(LINKFLAGS) -o $@ -Wl,--start-group $^ -Wl,--end-group $(LIBS)
-  LINKNATIVE = $(HOSTCXX) -o $@ $^
+  LINKNATIVE = $(HOSTCXX) $(HOSTLINKFLAGS) -o $@ $^
   ifeq ($(origin CC),default)
     CC     = clang
   endif
@@ -77,7 +77,7 @@ else ifeq ($(filter-out FreeBSD,$(BUILD_ENV_)),)
 else
   LINKLIB = ar rcT $@ $^
   LINKBIN = $(CXX) $(LINKFLAGS) -o $@ -Wl,--start-group $^ -Wl,--end-group $(LIBS)
-  LINKNATIVE = $(HOSTCXX) -o $@ $^
+  LINKNATIVE = $(HOSTCXX) $(HOSTLINKFLAGS) -o $@ $^
   ifeq ($(origin CC),default)
     CC     = gcc
     #CC     = icc
@@ -111,7 +111,7 @@ else ifeq ($(BUILD_ENV_),Cygwin)
   LINKFLAGS = -static -std=c++11
   LINKLIB = ar rcT $@ $^
   LINKBIN = $(CXX) $(LINKFLAGS) -o $@ -Wl,--start-group $^ -Wl,--end-group $(LIBS)
-  LINKNATIVE = $(HOSTCXX) -std=c++11 -o $@ $^ -static
+  LINKNATIVE = $(HOSTCXX) $(HOSTLINKFLAGS) -std=c++11 -o $@ $^ -static
 ifeq ($(origin CC),default)
   #CC = gcc
   CC = x86_64-w64-mingw32-gcc
@@ -141,7 +141,7 @@ else ifeq ($(BUILD_ENV_),MSVC)
   CP_CXXFLAGS +=
   LINKLIB = lib /NOLOGO /OUT:$@ $^
   LINKBIN = $(CXX) $(LINKFLAGS) /Fe$@ /Z7 /nologo $^ DbgHelp.lib $(LIBS)
-  LINKNATIVE = $(HOSTCXX) /Fe$@ /nologo /EHsc $^
+  LINKNATIVE = $(HOSTCXX) $(HOSTLINKFLAGS) /Fe$@ /nologo /EHsc $^
 ifeq ($(origin CC),default)
   CC = cl
 endif
@@ -212,6 +212,7 @@ endif
 first_target: all
 
 HOSTCXX ?= $(CXX)
+HOSTLINKFLAGS ?= $(LINKFLAGS)
 
 CP_CFLAGS += $(CFLAGS) $(CP_EXTRA_CFLAGS) $(INCLUDES)
 CP_CXXFLAGS += $(CXXFLAGS) $(CP_EXTRA_CXXFLAGS) $(INCLUDES)


### PR DESCRIPTION
Debian builds check for hardening (format-string warnings, fortified functions) of all built binaries by inspecting build logs. These changes make sure we do forward compiler flags where needed.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
