### PR TITLE
Fix ENABLE_ARRAY_FIELD_SENSITIVITY

### DIFF
--- a/src/goto-symex/field_sensitivity.cpp
+++ b/src/goto-symex/field_sensitivity.cpp
@@ -17,8 +17,6 @@ Author: Michael Tautschnig
 #include "goto_symex_state.h"
 #include "symex_target.h"
 
-#define ENABLE_ARRAY_FIELD_SENSITIVITY
-
 exprt field_sensitivityt::apply(
   const namespacet &ns,
   goto_symex_statet &state,

--- a/src/goto-symex/field_sensitivity.h
+++ b/src/goto-symex/field_sensitivity.h
@@ -12,6 +12,8 @@ Author: Michael Tautschnig
 #include <util/nodiscard.h>
 #include <util/ssa_expr.h>
 
+#define ENABLE_ARRAY_FIELD_SENSITIVITY
+
 class namespacet;
 class goto_symex_statet;
 class symex_targett;
@@ -121,7 +123,10 @@ public:
   ///   applied to array cells
   /// \param should_simplify: simplify expressions
   field_sensitivityt(std::size_t max_array_size, bool should_simplify)
-    : max_field_sensitivity_array_size(max_array_size),
+    :
+#ifdef ENABLE_ARRAY_FIELD_SENSITIVITY
+      max_field_sensitivity_array_size(max_array_size),
+#endif
       should_simplify(should_simplify)
   {
   }
@@ -202,7 +207,9 @@ public:
   bool is_divisible(const ssa_exprt &expr, bool disjoined_fields_only) const;
 
 private:
+#ifdef ENABLE_ARRAY_FIELD_SENSITIVITY
   const std::size_t max_field_sensitivity_array_size;
+#endif
 
   const bool should_simplify;
 


### PR DESCRIPTION
Turning off that switch would lead to compilation errors, which are now fixed.

- [X] Each commit message has a non-empty body, explaining why the change was made.
- [n/a] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [n/a] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [n/a] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [n/a] My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- [n/a] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
