### PR TITLE
Turns off using lambdas for array comprehension

### DIFF
--- a/src/solvers/smt2/smt2_conv.cpp
+++ b/src/solvers/smt2/smt2_conv.cpp
@@ -132,7 +132,6 @@ smt2_convt::smt2_convt(
     use_array_of_bool = true;
     use_as_const = true;
     use_check_sat_assuming = true;
-    use_lambda_for_array = true;
     emit_set_logic = false;
     use_datatypes = true;
     break;


### PR DESCRIPTION
Using lambdas for array comprehension can cause errors in get-value operations later.

Fixes #7767

- [X] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.
