### PR TITLE
Fix undefined shift on non-64-bit architectures

### DIFF
--- a/unit/solvers/smt2_incremental/convert_expr_to_smt.cpp
+++ b/unit/solvers/smt2_incremental/convert_expr_to_smt.cpp
@@ -246,8 +246,11 @@ TEST_CASE(
     expr_to_smt_conversion_test_environmentt::make(test_archt::x86_64);
   const pointer_typet pointer_type = ::pointer_type(void_type());
   const std::size_t pointer_width = pointer_type.get_width();
+  static_assert(
+    sizeof(unsigned long long) >= 8,
+    "unsigned long long  must be 64bits or wider");
   const constant_exprt invalid_ptr{
-    integer2bvrep(1ul << (pointer_width - object_bits), pointer_width),
+    integer2bvrep(1ull << (pointer_width - object_bits), pointer_width),
     pointer_type};
   const is_invalid_pointer_exprt is_invalid_ptr{invalid_ptr};
   const smt_termt expected_smt_term = smt_core_theoryt::equal(


### PR DESCRIPTION
Unsigned long need not be 64 bits wide when the test emulates a 64-bit architecture.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
