### PR TITLE
Fix __float128 portability

### DIFF
--- a/regression/ansi-c/gcc_version1/gcc-5.c
+++ b/regression/ansi-c/gcc_version1/gcc-5.c
@@ -9,5 +9,9 @@ typedef long double _Float128;
 typedef long double _Float128x;
 
 // But this type should:
+// https://gcc.gnu.org/onlinedocs/gcc/Floating-Types.html
+#  if defined(__i386__) || defined(__x86_64__) || defined(__ia64__) ||         \
+    defined(__hppa__) || defined(__powerpc__)
 __float128 f128;
+#endif
 #endif

--- a/regression/ansi-c/gcc_version1/gcc-7.c
+++ b/regression/ansi-c/gcc_version1/gcc-7.c
@@ -8,5 +8,9 @@ _Float64x f64x;
 _Float128 f128;
 _Float128x f128x;
 
+// https://gcc.gnu.org/onlinedocs/gcc/Floating-Types.html
+#  if defined(__i386__) || defined(__x86_64__) || defined(__ia64__) ||         \
+    defined(__hppa__) || defined(__powerpc__)
 __float128 gcc_f128;
+#endif
 #endif

--- a/regression/cbmc/ts18661_typedefs/main.c
+++ b/regression/cbmc/ts18661_typedefs/main.c
@@ -19,7 +19,11 @@
 #    endif
 
 #    if __GNUC_PREREQ(4, FLOAT128_MINOR_VERSION)
-#      define HAS_FLOAT128
+// https://gcc.gnu.org/onlinedocs/gcc/Floating-Types.html
+#      if defined(__i386__) || defined(__x86_64__) || defined(__ia64__) ||     \
+        defined(__hppa__) || defined(__powerpc__)
+#        define HAS_FLOAT128
+#      endif
 #    endif
 
 #  endif

--- a/src/cpp/cpp_internal_additions.cpp
+++ b/src/cpp/cpp_internal_additions.cpp
@@ -111,9 +111,8 @@ void cpp_internal_additions(std::ostream &out)
 
     if(
       config.ansi_c.arch == "i386" || config.ansi_c.arch == "x86_64" ||
-      config.ansi_c.arch == "x32" || config.ansi_c.arch == "powerpc" ||
-      config.ansi_c.arch == "ppc64" || config.ansi_c.arch == "ppc64le" ||
-      config.ansi_c.arch == "ia64")
+      config.ansi_c.arch == "x32" || config.ansi_c.arch == "ia64" ||
+      config.ansi_c.arch == "powerpc" || config.ansi_c.arch == "ppc64")
     {
       // https://gcc.gnu.org/onlinedocs/gcc/Floating-Types.html
       // For clang, __float128 is a keyword.
@@ -130,6 +129,12 @@ void cpp_internal_additions(std::ostream &out)
       // C++ doesn't have _Float128.
       if(config.ansi_c.mode != configt::ansi_ct::flavourt::CLANG)
         out << "typedef long double __float128;" << '\n';
+    }
+    else if(config.ansi_c.arch == "ppc64le")
+    {
+      // https://patchwork.ozlabs.org/patch/792295/
+      if(config.ansi_c.mode != configt::ansi_ct::flavourt::CLANG)
+        out << "typedef " CPROVER_PREFIX "Float128 __ieee128;\n";
     }
 
     if(


### PR DESCRIPTION
GCC does not provide this type on all architectures.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
