### PR TITLE
Fix tests for unsigned-char architectures

### DIFF
--- a/regression/cbmc-incr-smt2/bitvector-bitwise-operators/shift_right.desc
+++ b/regression/cbmc-incr-smt2/bitvector-bitwise-operators/shift_right.desc
@@ -5,7 +5,7 @@ shift_right.c
 \[main\.assertion\.2\] line \d+ Right shifting a positive number has a lower bound of 0: SUCCESS
 \[main\.assertion\.3\] line \d+ Right shifting a negative number has a lower bound value of -1: SUCCESS
 second=128
-result_unsigned=64
+result_unsigned=(64|'@')
 ^EXIT=10$
 ^SIGNAL=0$
 --

--- a/regression/cbmc/integral-trace/test.desc
+++ b/regression/cbmc/integral-trace/test.desc
@@ -5,7 +5,7 @@ activate-multi-line-match
 ^EXIT=10$
 ^SIGNAL=0$
 VERIFICATION FAILED
-<full_lhs>u8</full_lhs>\s*<full_lhs_value binary="01100001">97</full_lhs_value>
+<full_lhs>u8</full_lhs>\s*<full_lhs_value binary="01100001">(97|'a')</full_lhs_value>
 <full_lhs>u16</full_lhs>\s*<full_lhs_value binary="0{12}1000">8</full_lhs_value>
 <full_lhs>u32</full_lhs>\s*<full_lhs_value binary="0{27}10000">16ul?</full_lhs_value>
 <full_lhs>u64</full_lhs>\s*<full_lhs_value binary="0{58}100000">32ull?</full_lhs_value>

--- a/regression/cbmc/pointer-offset-01/test.desc
+++ b/regression/cbmc/pointer-offset-01/test.desc
@@ -1,14 +1,14 @@
 CORE
 main.c
 --trace
-^\s*ub.*=\(char \*\)&dynamic_object \+ \d+
+^\s*ub.*=(\(char \*\)&)?dynamic_object \+ \d+
 ^\s*offset_ubp1=\d+ul* \(00000000 1[0 ]+1\)$
 ^VERIFICATION FAILED$
 ^EXIT=10$
 ^SIGNAL=0$
 --
 ^warning: ignoring
-^\s*ub.*=\(char \*\)&dynamic_object \+ -\d+
+^\s*ub.*=(\(char \*\)&)?dynamic_object \+ -\d+
 ^\s*offset_ubp1=\d+ul* \(11111111 1
 --
 Verifies that all offsets use unsigned arithmetic.

--- a/regression/goto-instrument-json/rol_signed/test-signed.desc
+++ b/regression/goto-instrument-json/rol_signed/test-signed.desc
@@ -3,7 +3,7 @@ test-signed.json
 --dump-c
 ^EXIT=0$
 ^SIGNAL=0$
-signed char rol8=\(unsigned char\)'8' << 3 % 8 \| \(unsigned char\)'8' >> 8 - 3 % 8;
+signed char rol8=\(unsigned char\)('8'|56) << 3 % 8 \| \(unsigned char\)('8'|56) >> 8 - 3 % 8;
 --
 irep
 --

--- a/regression/goto-instrument-json/rol_unsigned/test.desc
+++ b/regression/goto-instrument-json/rol_unsigned/test.desc
@@ -3,7 +3,7 @@ test.json
 --dump-c
 ^EXIT=0$
 ^SIGNAL=0$
-unsigned char rol8=56 << 3 % 8 \| 56 >> 8 - 3 % 8;
+unsigned char rol8=(56|'8') << 3 % 8 \| (56|'8') >> 8 - 3 % 8;
 --
 irep
 --

--- a/regression/goto-instrument-json/ror_signed/test-signed.desc
+++ b/regression/goto-instrument-json/ror_signed/test-signed.desc
@@ -3,7 +3,7 @@ test-signed.json
 --dump-c
 ^EXIT=0$
 ^SIGNAL=0$
-signed char ror8=\(unsigned char\)'8' >> 3 % 8 \| \(unsigned char\)'8' << 8 - 3 % 8;
+signed char ror8=\(unsigned char\)('8'|56) >> 3 % 8 \| \(unsigned char\)('8'|56) << 8 - 3 % 8;
 --
 irep
 --

--- a/regression/goto-instrument-json/ror_unsigned/test.desc
+++ b/regression/goto-instrument-json/ror_unsigned/test.desc
@@ -3,7 +3,7 @@ test.json
 --dump-c
 ^EXIT=0$
 ^SIGNAL=0$
-unsigned char ror8=56 >> 3 % 8 \| 56 << 8 - 3 % 8;
+unsigned char ror8=(56|'8') >> 3 % 8 \| (56|'8') << 8 - 3 % 8;
 --
 irep
 --


### PR DESCRIPTION
The `char` type may be (and actually: is) unsigned on some architectures. In such cases our pretty-printed output differs and we use ASCII characters instead.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
