### PR TITLE
C++ front-end: fix type checking of anonymous bit fields

### DIFF
--- a/regression/ansi-c/CMakeLists.txt
+++ b/regression/ansi-c/CMakeLists.txt
@@ -7,15 +7,10 @@ elseif("${CMAKE_SYSTEM_NAME}" STREQUAL "Darwin")
         "$<TARGET_FILE:goto-cc>"
     )
 
-    # In MacOS, a change in the assert.h header file
-    # is causing template errors when exercising the
-    # C++ front end (because of a transitive include
-    # of <type_traits>) for files that include the
-    # <assert.h> or <cassert> headers.
     add_test_pl_profile(
         "ansi-c-c++-front-end"
         "$<TARGET_FILE:goto-cc> -xc++ -D_Bool=bool"
-        "-C;-I;test-c++-front-end;-s;c++-front-end-X;macos-assert-broken"
+        "-C;-I;test-c++-front-end;-s;c++-front-end"
         "CORE"
     )
 else()

--- a/regression/ansi-c/Makefile
+++ b/regression/ansi-c/Makefile
@@ -11,15 +11,6 @@ endif
 
 ifeq ($(BUILD_ENV_),MSVC)
 	excluded_tests = -X gcc-only -X clang-only
-else
-ifeq ($(BUILD_ENV_),OSX)
-	# In MacOS, a change in the assert.h header file
-	# is causing template errors when exercising the
-	# C++ front end (because of a transitive include
-	# of <type_traits>) for files that include the
-	# <assert.h> or <cassert> headers.
-  excluded_tests = -X macos-assert-broken
-endif
 endif
 
 test:

--- a/regression/ansi-c/array_initialization2/test.desc
+++ b/regression/ansi-c/array_initialization2/test.desc
@@ -1,4 +1,4 @@
-CORE test-c++-front-end macos-assert-broken
+CORE test-c++-front-end
 main.c
 
 ^EXIT=0$

--- a/regression/ansi-c/float_constant2/test.desc
+++ b/regression/ansi-c/float_constant2/test.desc
@@ -1,4 +1,4 @@
-CORE test-c++-front-end macos-assert-broken
+CORE test-c++-front-end
 main.c
 
 ^EXIT=0$

--- a/regression/ansi-c/goto_convert_switch_range_case_valid/test.desc
+++ b/regression/ansi-c/goto_convert_switch_range_case_valid/test.desc
@@ -1,4 +1,4 @@
-CORE test-c++-front-end macos-assert-broken
+CORE test-c++-front-end
 main.c
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Address_of_Method1/test.desc
+++ b/regression/cbmc-cpp/Address_of_Method1/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG macos-assert-broken
+KNOWNBUG
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Anonymous_members1/test.desc
+++ b/regression/cbmc-cpp/Anonymous_members1/test.desc
@@ -1,4 +1,4 @@
-CORE macos-assert-broken
+CORE
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Assignment1/test.desc
+++ b/regression/cbmc-cpp/Assignment1/test.desc
@@ -1,4 +1,4 @@
-CORE macos-assert-broken
+CORE
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/CMakeLists.txt
+++ b/regression/cbmc-cpp/CMakeLists.txt
@@ -4,12 +4,6 @@ else()
   set(gcc_only "")
 endif()
 
-if("${CMAKE_SYSTEM_NAME}" STREQUAL "Darwin")
-  set(exclude_mac_broken_tests -X macos-assert-broken)
-else()
-  set(exclude_mac_broken_tests "")
-endif()
-
 add_test_pl_tests(
-    "$<TARGET_FILE:cbmc> --validate-goto-model --validate-ssa-equation" ${gcc_only} ${exclude_mac_broken_tests}
+    "$<TARGET_FILE:cbmc> --validate-goto-model --validate-ssa-equation" ${gcc_only}
 )

--- a/regression/cbmc-cpp/Class_Members1/test.desc
+++ b/regression/cbmc-cpp/Class_Members1/test.desc
@@ -1,4 +1,4 @@
-CORE macos-assert-broken
+CORE
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Comma_Operator1/test.desc
+++ b/regression/cbmc-cpp/Comma_Operator1/test.desc
@@ -1,4 +1,4 @@
-CORE macos-assert-broken
+CORE
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/ConditionalExpression1/test.desc
+++ b/regression/cbmc-cpp/ConditionalExpression1/test.desc
@@ -1,4 +1,4 @@
-CORE macos-assert-broken
+CORE
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/ConditionalExpression2/test.desc
+++ b/regression/cbmc-cpp/ConditionalExpression2/test.desc
@@ -1,4 +1,4 @@
-CORE macos-assert-broken
+CORE
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Constructor1/test.desc
+++ b/regression/cbmc-cpp/Constructor1/test.desc
@@ -1,4 +1,4 @@
-CORE macos-assert-broken
+CORE
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Constructor12/test.desc
+++ b/regression/cbmc-cpp/Constructor12/test.desc
@@ -1,4 +1,4 @@
-CORE macos-assert-broken
+CORE
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Constructor13/test.desc
+++ b/regression/cbmc-cpp/Constructor13/test.desc
@@ -1,4 +1,4 @@
-CORE macos-assert-broken
+CORE
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Constructor2/test.desc
+++ b/regression/cbmc-cpp/Constructor2/test.desc
@@ -1,4 +1,4 @@
-CORE macos-assert-broken
+CORE
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Constructor3/test.desc
+++ b/regression/cbmc-cpp/Constructor3/test.desc
@@ -1,4 +1,4 @@
-CORE macos-assert-broken
+CORE
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Constructor4/test.desc
+++ b/regression/cbmc-cpp/Constructor4/test.desc
@@ -1,4 +1,4 @@
-CORE macos-assert-broken
+CORE
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Constructor5/test.desc
+++ b/regression/cbmc-cpp/Constructor5/test.desc
@@ -1,4 +1,4 @@
-CORE macos-assert-broken
+CORE
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Constructor6/test.desc
+++ b/regression/cbmc-cpp/Constructor6/test.desc
@@ -1,4 +1,4 @@
-CORE macos-assert-broken
+CORE
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Constructor9/test.desc
+++ b/regression/cbmc-cpp/Constructor9/test.desc
@@ -1,4 +1,4 @@
-CORE macos-assert-broken
+CORE
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Conversion5/test.desc
+++ b/regression/cbmc-cpp/Conversion5/test.desc
@@ -1,4 +1,4 @@
-CORE macos-assert-broken
+CORE
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Conversion6/test.desc
+++ b/regression/cbmc-cpp/Conversion6/test.desc
@@ -1,4 +1,4 @@
-CORE macos-assert-broken
+CORE
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Conversion_Operator2/test.desc
+++ b/regression/cbmc-cpp/Conversion_Operator2/test.desc
@@ -1,4 +1,4 @@
-CORE macos-assert-broken
+CORE
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Conversion_Operator3/test.desc
+++ b/regression/cbmc-cpp/Conversion_Operator3/test.desc
@@ -1,4 +1,4 @@
-CORE macos-assert-broken
+CORE
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Conversion_Operator4/test.desc
+++ b/regression/cbmc-cpp/Conversion_Operator4/test.desc
@@ -1,4 +1,4 @@
-CORE macos-assert-broken
+CORE
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Default_Arguments1/test.desc
+++ b/regression/cbmc-cpp/Default_Arguments1/test.desc
@@ -1,4 +1,4 @@
-CORE macos-assert-broken
+CORE
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Default_Arguments2/test.desc
+++ b/regression/cbmc-cpp/Default_Arguments2/test.desc
@@ -1,4 +1,4 @@
-CORE macos-assert-broken
+CORE
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Destructor_with_PtrMember/test.desc
+++ b/regression/cbmc-cpp/Destructor_with_PtrMember/test.desc
@@ -1,4 +1,4 @@
-CORE macos-assert-broken
+CORE
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Float1/test.desc
+++ b/regression/cbmc-cpp/Float1/test.desc
@@ -1,4 +1,4 @@
-CORE macos-assert-broken
+CORE
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Friend5/test.desc
+++ b/regression/cbmc-cpp/Friend5/test.desc
@@ -1,4 +1,4 @@
-CORE macos-assert-broken
+CORE
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/FunctionParam1/test.desc
+++ b/regression/cbmc-cpp/FunctionParam1/test.desc
@@ -1,4 +1,4 @@
-CORE macos-assert-broken
+CORE
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Function_Arguments2/test.desc
+++ b/regression/cbmc-cpp/Function_Arguments2/test.desc
@@ -1,4 +1,4 @@
-CORE macos-assert-broken
+CORE
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Function_Arguments5/test.desc
+++ b/regression/cbmc-cpp/Function_Arguments5/test.desc
@@ -1,4 +1,4 @@
-CORE macos-assert-broken
+CORE
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Function_Pointer1/test.desc
+++ b/regression/cbmc-cpp/Function_Pointer1/test.desc
@@ -1,4 +1,4 @@
-CORE macos-assert-broken
+CORE
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Implicit_Conversion1/test.desc
+++ b/regression/cbmc-cpp/Implicit_Conversion1/test.desc
@@ -1,4 +1,4 @@
-CORE macos-assert-broken
+CORE
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Implicit_Conversion4/test.desc
+++ b/regression/cbmc-cpp/Implicit_Conversion4/test.desc
@@ -1,4 +1,4 @@
-CORE macos-assert-broken
+CORE
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Implicit_Conversion6/test.desc
+++ b/regression/cbmc-cpp/Implicit_Conversion6/test.desc
@@ -1,4 +1,4 @@
-CORE macos-assert-broken
+CORE
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Implicit_Conversion7/test.desc
+++ b/regression/cbmc-cpp/Implicit_Conversion7/test.desc
@@ -1,4 +1,4 @@
-CORE macos-assert-broken
+CORE
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Inheritance1/test.desc
+++ b/regression/cbmc-cpp/Inheritance1/test.desc
@@ -1,4 +1,4 @@
-CORE macos-assert-broken
+CORE
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Inheritance3/test.desc
+++ b/regression/cbmc-cpp/Inheritance3/test.desc
@@ -1,4 +1,4 @@
-CORE macos-assert-broken
+CORE
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Inheritance4/test.desc
+++ b/regression/cbmc-cpp/Inheritance4/test.desc
@@ -1,4 +1,4 @@
-CORE macos-assert-broken
+CORE
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Initializer1/test.desc
+++ b/regression/cbmc-cpp/Initializer1/test.desc
@@ -1,4 +1,4 @@
-CORE macos-assert-broken
+CORE
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Label0/test.desc
+++ b/regression/cbmc-cpp/Label0/test.desc
@@ -1,4 +1,4 @@
-CORE macos-assert-broken
+CORE
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Linking1/test.desc
+++ b/regression/cbmc-cpp/Linking1/test.desc
@@ -1,4 +1,4 @@
-CORE macos-assert-broken
+CORE
 main.cpp
 module.cpp
 ^EXIT=0$

--- a/regression/cbmc-cpp/Makefile
+++ b/regression/cbmc-cpp/Makefile
@@ -5,15 +5,6 @@ include ../../src/common
 
 ifeq ($(BUILD_ENV_),MSVC)
 	excluded_tests = -X gcc-only
-else
-ifeq ($(BUILD_ENV_),OSX)
-	# In MacOS, a change in the assert.h header file
-	# is causing template errors when exercising the
-	# C++ front end (because of a transitive include
-	# of <type_traits>) for files that include the
-	# <assert.h> or <cassert> headers.
-  excluded_tests = -X macos-assert-broken
-endif
 endif
 
 test:

--- a/regression/cbmc-cpp/Member_Access_in_Class/test.desc
+++ b/regression/cbmc-cpp/Member_Access_in_Class/test.desc
@@ -1,4 +1,4 @@
-CORE macos-assert-broken
+CORE
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/MethodParam1/test.desc
+++ b/regression/cbmc-cpp/MethodParam1/test.desc
@@ -1,4 +1,4 @@
-CORE macos-assert-broken
+CORE
 main.cpp
 
 instance is SATISFIABLE$

--- a/regression/cbmc-cpp/Mutable1/test.desc
+++ b/regression/cbmc-cpp/Mutable1/test.desc
@@ -1,4 +1,4 @@
-CORE macos-assert-broken
+CORE
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Overloading_Functions1/test.desc
+++ b/regression/cbmc-cpp/Overloading_Functions1/test.desc
@@ -1,4 +1,4 @@
-CORE macos-assert-broken
+CORE
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Overloading_Functions3/test.desc
+++ b/regression/cbmc-cpp/Overloading_Functions3/test.desc
@@ -1,4 +1,4 @@
-CORE macos-assert-broken
+CORE
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Overloading_Increment1/test.desc
+++ b/regression/cbmc-cpp/Overloading_Increment1/test.desc
@@ -1,4 +1,4 @@
-CORE macos-assert-broken
+CORE
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Overloading_Members1/test.desc
+++ b/regression/cbmc-cpp/Overloading_Members1/test.desc
@@ -1,4 +1,4 @@
-CORE macos-assert-broken
+CORE
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Overloading_Operators12/test.desc
+++ b/regression/cbmc-cpp/Overloading_Operators12/test.desc
@@ -1,4 +1,4 @@
-CORE macos-assert-broken
+CORE
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Overloading_Operators13/test.desc
+++ b/regression/cbmc-cpp/Overloading_Operators13/test.desc
@@ -1,4 +1,4 @@
-CORE macos-assert-broken
+CORE
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Overloading_Operators2/test.desc
+++ b/regression/cbmc-cpp/Overloading_Operators2/test.desc
@@ -1,4 +1,4 @@
-CORE macos-assert-broken
+CORE
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Overloading_Operators7/test.desc
+++ b/regression/cbmc-cpp/Overloading_Operators7/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG macos-assert-broken
+KNOWNBUG
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Overloading_Operators8/test.desc
+++ b/regression/cbmc-cpp/Overloading_Operators8/test.desc
@@ -1,4 +1,4 @@
-CORE macos-assert-broken
+CORE
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Pointer_Conversion2/test.desc
+++ b/regression/cbmc-cpp/Pointer_Conversion2/test.desc
@@ -1,4 +1,4 @@
-CORE macos-assert-broken
+CORE
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Protection2/test.desc
+++ b/regression/cbmc-cpp/Protection2/test.desc
@@ -1,4 +1,4 @@
-CORE macos-assert-broken
+CORE
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Qualifier2/test.desc
+++ b/regression/cbmc-cpp/Qualifier2/test.desc
@@ -1,4 +1,4 @@
-CORE macos-assert-broken
+CORE
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Reference2/test.desc
+++ b/regression/cbmc-cpp/Reference2/test.desc
@@ -1,4 +1,4 @@
-CORE macos-assert-broken
+CORE
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Reference3/test.desc
+++ b/regression/cbmc-cpp/Reference3/test.desc
@@ -1,4 +1,4 @@
-CORE macos-assert-broken
+CORE
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Reference6/test.desc
+++ b/regression/cbmc-cpp/Reference6/test.desc
@@ -1,4 +1,4 @@
-CORE macos-assert-broken
+CORE
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Reference7/test.desc
+++ b/regression/cbmc-cpp/Reference7/test.desc
@@ -1,4 +1,4 @@
-CORE macos-assert-broken
+CORE
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Resolver6/test.desc
+++ b/regression/cbmc-cpp/Resolver6/test.desc
@@ -1,4 +1,4 @@
-CORE macos-assert-broken
+CORE
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Resolver7/test.desc
+++ b/regression/cbmc-cpp/Resolver7/test.desc
@@ -1,4 +1,4 @@
-CORE macos-assert-broken
+CORE
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Resolver8/test.desc
+++ b/regression/cbmc-cpp/Resolver8/test.desc
@@ -1,4 +1,4 @@
-CORE macos-assert-broken
+CORE
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Static_Method1/test.desc
+++ b/regression/cbmc-cpp/Static_Method1/test.desc
@@ -1,4 +1,4 @@
-CORE macos-assert-broken
+CORE
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/String_Literal1/test.desc
+++ b/regression/cbmc-cpp/String_Literal1/test.desc
@@ -1,4 +1,4 @@
-CORE macos-assert-broken
+CORE
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Templates10/test.desc
+++ b/regression/cbmc-cpp/Templates10/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG macos-assert-broken
+KNOWNBUG
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Templates11/test.desc
+++ b/regression/cbmc-cpp/Templates11/test.desc
@@ -1,4 +1,4 @@
-CORE macos-assert-broken
+CORE
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Templates12/test.desc
+++ b/regression/cbmc-cpp/Templates12/test.desc
@@ -1,4 +1,4 @@
-CORE macos-assert-broken
+CORE
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Templates13/test.desc
+++ b/regression/cbmc-cpp/Templates13/test.desc
@@ -1,4 +1,4 @@
-CORE macos-assert-broken
+CORE
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Templates14/test.desc
+++ b/regression/cbmc-cpp/Templates14/test.desc
@@ -1,4 +1,4 @@
-CORE macos-assert-broken
+CORE
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Templates16/test.desc
+++ b/regression/cbmc-cpp/Templates16/test.desc
@@ -1,4 +1,4 @@
-CORE macos-assert-broken
+CORE
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Templates19/test.desc
+++ b/regression/cbmc-cpp/Templates19/test.desc
@@ -1,4 +1,4 @@
-CORE macos-assert-broken
+CORE
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Templates20/test.desc
+++ b/regression/cbmc-cpp/Templates20/test.desc
@@ -1,4 +1,4 @@
-CORE macos-assert-broken
+CORE
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Templates21/test.desc
+++ b/regression/cbmc-cpp/Templates21/test.desc
@@ -1,4 +1,4 @@
-CORE macos-assert-broken
+CORE
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Templates22/test.desc
+++ b/regression/cbmc-cpp/Templates22/test.desc
@@ -1,4 +1,4 @@
-CORE macos-assert-broken
+CORE
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Templates23/test.desc
+++ b/regression/cbmc-cpp/Templates23/test.desc
@@ -1,4 +1,4 @@
-CORE macos-assert-broken
+CORE
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Templates24/test.desc
+++ b/regression/cbmc-cpp/Templates24/test.desc
@@ -1,4 +1,4 @@
-CORE macos-assert-broken
+CORE
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Templates25/test.desc
+++ b/regression/cbmc-cpp/Templates25/test.desc
@@ -1,4 +1,4 @@
-CORE macos-assert-broken
+CORE
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Templates26/test.desc
+++ b/regression/cbmc-cpp/Templates26/test.desc
@@ -1,4 +1,4 @@
-CORE macos-assert-broken
+CORE
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Templates27/test.desc
+++ b/regression/cbmc-cpp/Templates27/test.desc
@@ -1,4 +1,4 @@
-CORE macos-assert-broken
+CORE
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Templates28/test.desc
+++ b/regression/cbmc-cpp/Templates28/test.desc
@@ -1,4 +1,4 @@
-CORE macos-assert-broken
+CORE
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Templates3/test.desc
+++ b/regression/cbmc-cpp/Templates3/test.desc
@@ -1,4 +1,4 @@
-CORE macos-assert-broken
+CORE
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Templates30/test.desc
+++ b/regression/cbmc-cpp/Templates30/test.desc
@@ -1,4 +1,4 @@
-CORE macos-assert-broken
+CORE
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Templates6/test.desc
+++ b/regression/cbmc-cpp/Templates6/test.desc
@@ -1,4 +1,4 @@
-CORE macos-assert-broken
+CORE
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/argv1/test.desc
+++ b/regression/cbmc-cpp/argv1/test.desc
@@ -1,4 +1,4 @@
-CORE macos-assert-broken
+CORE
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/const_cast1/test.desc
+++ b/regression/cbmc-cpp/const_cast1/test.desc
@@ -1,4 +1,4 @@
-CORE macos-assert-broken
+CORE
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/cpp-new/test.desc
+++ b/regression/cbmc-cpp/cpp-new/test.desc
@@ -1,4 +1,4 @@
-CORE macos-assert-broken
+CORE
 main.cpp
 --pointer-check
 ^EXIT=0$

--- a/regression/cbmc-cpp/cpp1/test.desc
+++ b/regression/cbmc-cpp/cpp1/test.desc
@@ -1,4 +1,4 @@
-CORE macos-assert-broken
+CORE
 main.cpp
 --unwind 1 --unwinding-assertions
 ^EXIT=0$

--- a/regression/cbmc-cpp/for1/test.desc
+++ b/regression/cbmc-cpp/for1/test.desc
@@ -1,4 +1,4 @@
-CORE macos-assert-broken
+CORE
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/initialization3/test.desc
+++ b/regression/cbmc-cpp/initialization3/test.desc
@@ -1,4 +1,4 @@
-CORE macos-assert-broken
+CORE
 main.cpp
 
 ^EXIT=10$

--- a/regression/cbmc-cpp/initialization5/test.desc
+++ b/regression/cbmc-cpp/initialization5/test.desc
@@ -1,4 +1,4 @@
-CORE macos-assert-broken
+CORE
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/lvalue1/test.desc
+++ b/regression/cbmc-cpp/lvalue1/test.desc
@@ -1,4 +1,4 @@
-CORE macos-assert-broken
+CORE
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/namespace1/test.desc
+++ b/regression/cbmc-cpp/namespace1/test.desc
@@ -1,4 +1,4 @@
-CORE macos-assert-broken
+CORE
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/namespace2/test.desc
+++ b/regression/cbmc-cpp/namespace2/test.desc
@@ -1,4 +1,4 @@
-CORE macos-assert-broken
+CORE
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/namespace3/test.desc
+++ b/regression/cbmc-cpp/namespace3/test.desc
@@ -1,4 +1,4 @@
-CORE macos-assert-broken
+CORE
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/new1/test.desc
+++ b/regression/cbmc-cpp/new1/test.desc
@@ -1,4 +1,4 @@
-CORE macos-assert-broken
+CORE
 main.cpp
 --pointer-check
 ^EXIT=0$

--- a/regression/cbmc-cpp/operators/test.desc
+++ b/regression/cbmc-cpp/operators/test.desc
@@ -1,4 +1,4 @@
-CORE macos-assert-broken
+CORE
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/reinterpret_cast1/test.desc
+++ b/regression/cbmc-cpp/reinterpret_cast1/test.desc
@@ -1,4 +1,4 @@
-CORE macos-assert-broken
+CORE
 main.cpp
 --little-endian
 ^EXIT=0$

--- a/regression/cbmc-cpp/static_cast1/test.desc
+++ b/regression/cbmc-cpp/static_cast1/test.desc
@@ -1,4 +1,4 @@
-CORE macos-assert-broken
+CORE
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/static_cast3/test.desc
+++ b/regression/cbmc-cpp/static_cast3/test.desc
@@ -1,4 +1,4 @@
-CORE macos-assert-broken
+CORE
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/static_cast5/test.desc
+++ b/regression/cbmc-cpp/static_cast5/test.desc
@@ -1,4 +1,4 @@
-CORE macos-assert-broken
+CORE
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/typecast_ambiguity3/test.desc
+++ b/regression/cbmc-cpp/typecast_ambiguity3/test.desc
@@ -1,4 +1,4 @@
-CORE macos-assert-broken
+CORE
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/typedef4/test.desc
+++ b/regression/cbmc-cpp/typedef4/test.desc
@@ -1,4 +1,4 @@
-CORE macos-assert-broken
+CORE
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/union2/test.desc
+++ b/regression/cbmc-cpp/union2/test.desc
@@ -1,4 +1,4 @@
-CORE macos-assert-broken
+CORE
 main.cpp
 --little-endian
 ^EXIT=0$

--- a/regression/cbmc-cpp/virtual10/test.desc
+++ b/regression/cbmc-cpp/virtual10/test.desc
@@ -1,4 +1,4 @@
-CORE macos-assert-broken
+CORE
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/virtual2/test.desc
+++ b/regression/cbmc-cpp/virtual2/test.desc
@@ -1,4 +1,4 @@
-CORE macos-assert-broken
+CORE
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/virtual9/test.desc
+++ b/regression/cbmc-cpp/virtual9/test.desc
@@ -1,4 +1,4 @@
-CORE macos-assert-broken
+CORE
 main.cpp
 
 ^EXIT=0$

--- a/regression/cpp/Bit_fields1/main.cpp
+++ b/regression/cpp/Bit_fields1/main.cpp
@@ -9,6 +9,7 @@ struct some_struct {
 
   // an anonymous bitfield
   signed int :2;
+  signed int d : 2, : 6;
 
   // with typedef
   INT x:1;

--- a/regression/cpp/CMakeLists.txt
+++ b/regression/cpp/CMakeLists.txt
@@ -4,12 +4,6 @@ else()
   set(gcc_only "")
 endif()
 
-if("${CMAKE_SYSTEM_NAME}" STREQUAL "Darwin")
-  set(exclude_mac_broken_tests -X macos-assert-broken)
-else()
-  set(exclude_mac_broken_tests "")
-endif()
-
 add_test_pl_tests(
-    "$<TARGET_FILE:goto-cc>" ${gcc_only} ${exclude_mac_broken_tests}
+    "$<TARGET_FILE:goto-cc>" ${gcc_only}
 )

--- a/regression/cpp/Makefile
+++ b/regression/cpp/Makefile
@@ -11,15 +11,6 @@ endif
 
 ifeq ($(BUILD_ENV_),MSVC)
 	excluded_tests = -X gcc-only
-else
-ifeq ($(BUILD_ENV_),OSX)
-	# In MacOS, a change in the assert.h header file
-	# is causing template errors when exercising the
-	# C++ front end (because of a transitive include
-	# of <type_traits>) for files that include the
-	# <assert.h> or <cassert> headers.
-  excluded_tests = -X macos-assert-broken
-endif
 endif
 
 test:

--- a/regression/cpp/Method_qualifier1/test.desc
+++ b/regression/cpp/Method_qualifier1/test.desc
@@ -1,4 +1,4 @@
-CORE macos-assert-broken
+CORE
 main.cpp
 
 ^EXIT=0$

--- a/regression/cpp/auto1/test.desc
+++ b/regression/cpp/auto1/test.desc
@@ -1,4 +1,4 @@
-CORE macos-assert-broken
+CORE
 main.cpp
 -std=c++11
 ^EXIT=0$

--- a/regression/cpp/enum5/test.desc
+++ b/regression/cpp/enum5/test.desc
@@ -1,4 +1,4 @@
-CORE macos-assert-broken
+CORE
 main.cpp
 
 ^EXIT=0$

--- a/regression/cpp/switch1/test.desc
+++ b/regression/cpp/switch1/test.desc
@@ -1,4 +1,4 @@
-CORE macos-assert-broken
+CORE
 main.cpp
 
 ^EXIT=0$

--- a/regression/cpp/virtual1/test.desc
+++ b/regression/cpp/virtual1/test.desc
@@ -1,4 +1,4 @@
-CORE macos-assert-broken
+CORE
 main.cpp
 
 ^EXIT=0$

--- a/regression/systemc/Array2/test.desc
+++ b/regression/systemc/Array2/test.desc
@@ -1,4 +1,4 @@
-CORE macos-assert-broken
+CORE
 main.cpp
 -DNO_IO -DNO_STRING
 ^EXIT=0$

--- a/regression/systemc/Array3/test.desc
+++ b/regression/systemc/Array3/test.desc
@@ -1,4 +1,4 @@
-CORE macos-assert-broken
+CORE
 main.cpp
 -DNO_IO -DNO_STRING
 ^EXIT=0$

--- a/regression/systemc/Array4/test.desc
+++ b/regression/systemc/Array4/test.desc
@@ -1,4 +1,4 @@
-CORE macos-assert-broken
+CORE
 main.cpp
 -DNO_IO -DNO_STRING
 ^EXIT=0$

--- a/regression/systemc/BitvectorCpp1/test.desc
+++ b/regression/systemc/BitvectorCpp1/test.desc
@@ -1,4 +1,4 @@
-CORE macos-assert-broken
+CORE
 main.cpp
 
 ^EXIT=0$

--- a/regression/systemc/BitvectorCpp2/test.desc
+++ b/regression/systemc/BitvectorCpp2/test.desc
@@ -1,4 +1,4 @@
-CORE macos-assert-broken
+CORE
 main.cpp
 
 ^EXIT=0$

--- a/regression/systemc/BitvectorSc3/test.desc
+++ b/regression/systemc/BitvectorSc3/test.desc
@@ -1,4 +1,4 @@
-CORE macos-assert-broken
+CORE
 main.cpp
 
 ^EXIT=0$

--- a/regression/systemc/CMakeLists.txt
+++ b/regression/systemc/CMakeLists.txt
@@ -1,9 +1,3 @@
-if("${CMAKE_SYSTEM_NAME}" STREQUAL "Darwin")
-  set(exclude_mac_broken_tests -X macos-assert-broken)
-else()
-  set(exclude_mac_broken_tests "")
-endif()
-
 add_test_pl_tests(
-    "$<TARGET_FILE:cbmc> --validate-goto-model --validate-ssa-equation" ${exclude_mac_broken_tests}
+    "$<TARGET_FILE:cbmc> --validate-goto-model --validate-ssa-equation"
 )

--- a/regression/systemc/ForwardDecl1/test.desc
+++ b/regression/systemc/ForwardDecl1/test.desc
@@ -1,4 +1,4 @@
-CORE macos-assert-broken
+CORE
 main.cpp
 
 ^EXIT=0$

--- a/regression/systemc/Makefile
+++ b/regression/systemc/Makefile
@@ -11,15 +11,6 @@ endif
 
 ifeq ($(BUILD_ENV_),MSVC)
 	excluded_tests = -X gcc-only
-else
-ifeq ($(BUILD_ENV_),OSX)
-	# In MacOS, a change in the assert.h header file
-	# is causing template errors when exercising the
-	# C++ front end (because of a transitive include
-	# of <type_traits>) for files that include the
-	# <assert.h> or <cassert> headers.
-  excluded_tests = -X macos-assert-broken
-endif
 endif
 
 default: tests.log

--- a/regression/systemc/Masc1/test.desc
+++ b/regression/systemc/Masc1/test.desc
@@ -1,4 +1,4 @@
-CORE macos-assert-broken
+CORE
 main.cpp
 
 ^EXIT=0$

--- a/regression/systemc/MascInst1/test.desc
+++ b/regression/systemc/MascInst1/test.desc
@@ -1,4 +1,4 @@
-CORE macos-assert-broken
+CORE
 main.cpp
 
 ^EXIT=0$

--- a/regression/systemc/Reference1/test.desc
+++ b/regression/systemc/Reference1/test.desc
@@ -1,4 +1,4 @@
-CORE macos-assert-broken
+CORE
 main.cpp
 
 ^EXIT=0$

--- a/regression/systemc/This1/test.desc
+++ b/regression/systemc/This1/test.desc
@@ -1,4 +1,4 @@
-CORE macos-assert-broken
+CORE
 main.cpp
 
 ^EXIT=0$

--- a/regression/systemc/Tuple1/test.desc
+++ b/regression/systemc/Tuple1/test.desc
@@ -1,4 +1,4 @@
-CORE macos-assert-broken
+CORE
 main.cpp
 -DNO_IO -DNO_STRING
 ^EXIT=0$

--- a/regression/systemc/Tuple2/test.desc
+++ b/regression/systemc/Tuple2/test.desc
@@ -1,4 +1,4 @@
-CORE macos-assert-broken
+CORE
 main.cpp
 -DNO_IO -DNO_STRING
 ^EXIT=0$

--- a/src/cpp/parse.cpp
+++ b/src/cpp/parse.cpp
@@ -2880,7 +2880,7 @@ bool Parser::rDeclaratorWithInit(
     bit_field_type.add_subtype().make_nil();
     set_location(bit_field_type, tk);
 
-    merge_types(bit_field_type, dw.type());
+    dw.type() = std::move(bit_field_type);
 
     return true;
   }


### PR DESCRIPTION
For `unsigned : 2;` we tried to merge a necessarily empty (not nil!) irept via `merge_types`. MacOS has such anonymous bit fields in some system headers.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
