### PR TITLE
Remove avoidable use of winbug test exclusion

### DIFF
--- a/regression/cbmc-cpp/Address_of_Method1/test.desc
+++ b/regression/cbmc-cpp/Address_of_Method1/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG winbug macos-assert-broken
+KNOWNBUG macos-assert-broken
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Anonymous_members1/test.desc
+++ b/regression/cbmc-cpp/Anonymous_members1/test.desc
@@ -1,4 +1,4 @@
-CORE winbug macos-assert-broken
+CORE macos-assert-broken
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Assignment1/test.desc
+++ b/regression/cbmc-cpp/Assignment1/test.desc
@@ -1,4 +1,4 @@
-CORE winbug macos-assert-broken
+CORE macos-assert-broken
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/CMakeLists.txt
+++ b/regression/cbmc-cpp/CMakeLists.txt
@@ -4,12 +4,6 @@ else()
   set(gcc_only "")
 endif()
 
-if("${CMAKE_SYSTEM_NAME}" STREQUAL "Windows")
-  set(exclude_win_broken_tests -X winbug)
-else()
-  set(exclude_win_broken_tests "")
-endif()
-
 if("${CMAKE_SYSTEM_NAME}" STREQUAL "Darwin")
   set(exclude_mac_broken_tests -X macos-assert-broken)
 else()
@@ -17,5 +11,5 @@ else()
 endif()
 
 add_test_pl_tests(
-    "$<TARGET_FILE:cbmc> --validate-goto-model --validate-ssa-equation" ${gcc_only} ${exclude_win_broken_tests} ${exclude_mac_broken_tests}
+    "$<TARGET_FILE:cbmc> --validate-goto-model --validate-ssa-equation" ${gcc_only} ${exclude_mac_broken_tests}
 )

--- a/regression/cbmc-cpp/Class_Members1/test.desc
+++ b/regression/cbmc-cpp/Class_Members1/test.desc
@@ -1,4 +1,4 @@
-CORE winbug macos-assert-broken
+CORE macos-assert-broken
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Comma_Operator1/test.desc
+++ b/regression/cbmc-cpp/Comma_Operator1/test.desc
@@ -1,4 +1,4 @@
-CORE winbug macos-assert-broken
+CORE macos-assert-broken
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/ConditionalExpression1/test.desc
+++ b/regression/cbmc-cpp/ConditionalExpression1/test.desc
@@ -1,4 +1,4 @@
-CORE winbug macos-assert-broken
+CORE macos-assert-broken
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/ConditionalExpression2/test.desc
+++ b/regression/cbmc-cpp/ConditionalExpression2/test.desc
@@ -1,4 +1,4 @@
-CORE winbug macos-assert-broken
+CORE macos-assert-broken
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Constructor1/test.desc
+++ b/regression/cbmc-cpp/Constructor1/test.desc
@@ -1,4 +1,4 @@
-CORE winbug macos-assert-broken
+CORE macos-assert-broken
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Constructor12/test.desc
+++ b/regression/cbmc-cpp/Constructor12/test.desc
@@ -1,4 +1,4 @@
-CORE winbug macos-assert-broken
+CORE macos-assert-broken
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Constructor13/test.desc
+++ b/regression/cbmc-cpp/Constructor13/test.desc
@@ -1,4 +1,4 @@
-CORE winbug macos-assert-broken
+CORE macos-assert-broken
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Constructor2/test.desc
+++ b/regression/cbmc-cpp/Constructor2/test.desc
@@ -1,4 +1,4 @@
-CORE winbug macos-assert-broken
+CORE macos-assert-broken
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Constructor3/test.desc
+++ b/regression/cbmc-cpp/Constructor3/test.desc
@@ -1,4 +1,4 @@
-CORE winbug macos-assert-broken
+CORE macos-assert-broken
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Constructor4/test.desc
+++ b/regression/cbmc-cpp/Constructor4/test.desc
@@ -1,4 +1,4 @@
-CORE winbug macos-assert-broken
+CORE macos-assert-broken
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Constructor5/test.desc
+++ b/regression/cbmc-cpp/Constructor5/test.desc
@@ -1,4 +1,4 @@
-CORE winbug macos-assert-broken
+CORE macos-assert-broken
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Constructor6/test.desc
+++ b/regression/cbmc-cpp/Constructor6/test.desc
@@ -1,4 +1,4 @@
-CORE winbug macos-assert-broken
+CORE macos-assert-broken
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Constructor9/test.desc
+++ b/regression/cbmc-cpp/Constructor9/test.desc
@@ -1,4 +1,4 @@
-CORE winbug macos-assert-broken
+CORE macos-assert-broken
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Conversion5/test.desc
+++ b/regression/cbmc-cpp/Conversion5/test.desc
@@ -1,4 +1,4 @@
-CORE winbug macos-assert-broken
+CORE macos-assert-broken
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Conversion6/test.desc
+++ b/regression/cbmc-cpp/Conversion6/test.desc
@@ -1,4 +1,4 @@
-CORE winbug macos-assert-broken
+CORE macos-assert-broken
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Conversion_Operator2/test.desc
+++ b/regression/cbmc-cpp/Conversion_Operator2/test.desc
@@ -1,4 +1,4 @@
-CORE winbug macos-assert-broken
+CORE macos-assert-broken
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Conversion_Operator3/test.desc
+++ b/regression/cbmc-cpp/Conversion_Operator3/test.desc
@@ -1,4 +1,4 @@
-CORE winbug macos-assert-broken
+CORE macos-assert-broken
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Conversion_Operator4/test.desc
+++ b/regression/cbmc-cpp/Conversion_Operator4/test.desc
@@ -1,4 +1,4 @@
-CORE winbug macos-assert-broken
+CORE macos-assert-broken
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Default_Arguments1/test.desc
+++ b/regression/cbmc-cpp/Default_Arguments1/test.desc
@@ -1,4 +1,4 @@
-CORE winbug macos-assert-broken
+CORE macos-assert-broken
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Default_Arguments2/test.desc
+++ b/regression/cbmc-cpp/Default_Arguments2/test.desc
@@ -1,4 +1,4 @@
-CORE winbug macos-assert-broken
+CORE macos-assert-broken
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Destructor_with_PtrMember/test.desc
+++ b/regression/cbmc-cpp/Destructor_with_PtrMember/test.desc
@@ -1,4 +1,4 @@
-CORE winbug macos-assert-broken
+CORE macos-assert-broken
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Float1/test.desc
+++ b/regression/cbmc-cpp/Float1/test.desc
@@ -1,4 +1,4 @@
-CORE winbug macos-assert-broken
+CORE macos-assert-broken
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Friend5/test.desc
+++ b/regression/cbmc-cpp/Friend5/test.desc
@@ -1,4 +1,4 @@
-CORE winbug macos-assert-broken
+CORE macos-assert-broken
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Function_Arguments2/test.desc
+++ b/regression/cbmc-cpp/Function_Arguments2/test.desc
@@ -1,4 +1,4 @@
-CORE winbug macos-assert-broken
+CORE macos-assert-broken
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Function_Arguments5/test.desc
+++ b/regression/cbmc-cpp/Function_Arguments5/test.desc
@@ -1,4 +1,4 @@
-CORE winbug macos-assert-broken
+CORE macos-assert-broken
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Function_Pointer1/test.desc
+++ b/regression/cbmc-cpp/Function_Pointer1/test.desc
@@ -1,4 +1,4 @@
-CORE winbug macos-assert-broken
+CORE macos-assert-broken
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Implicit_Conversion1/test.desc
+++ b/regression/cbmc-cpp/Implicit_Conversion1/test.desc
@@ -1,4 +1,4 @@
-CORE winbug macos-assert-broken
+CORE macos-assert-broken
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Implicit_Conversion4/test.desc
+++ b/regression/cbmc-cpp/Implicit_Conversion4/test.desc
@@ -1,4 +1,4 @@
-CORE winbug macos-assert-broken
+CORE macos-assert-broken
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Implicit_Conversion6/test.desc
+++ b/regression/cbmc-cpp/Implicit_Conversion6/test.desc
@@ -1,4 +1,4 @@
-CORE winbug macos-assert-broken
+CORE macos-assert-broken
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Implicit_Conversion7/test.desc
+++ b/regression/cbmc-cpp/Implicit_Conversion7/test.desc
@@ -1,4 +1,4 @@
-CORE winbug macos-assert-broken
+CORE macos-assert-broken
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Inheritance1/test.desc
+++ b/regression/cbmc-cpp/Inheritance1/test.desc
@@ -1,4 +1,4 @@
-CORE winbug macos-assert-broken
+CORE macos-assert-broken
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Inheritance3/test.desc
+++ b/regression/cbmc-cpp/Inheritance3/test.desc
@@ -1,4 +1,4 @@
-CORE winbug macos-assert-broken
+CORE macos-assert-broken
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Inheritance4/test.desc
+++ b/regression/cbmc-cpp/Inheritance4/test.desc
@@ -1,4 +1,4 @@
-CORE winbug macos-assert-broken
+CORE macos-assert-broken
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Initializer1/test.desc
+++ b/regression/cbmc-cpp/Initializer1/test.desc
@@ -1,4 +1,4 @@
-CORE winbug macos-assert-broken
+CORE macos-assert-broken
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Label0/test.desc
+++ b/regression/cbmc-cpp/Label0/test.desc
@@ -1,4 +1,4 @@
-CORE winbug macos-assert-broken
+CORE macos-assert-broken
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Linking1/test.desc
+++ b/regression/cbmc-cpp/Linking1/test.desc
@@ -1,4 +1,4 @@
-CORE winbug macos-assert-broken
+CORE macos-assert-broken
 main.cpp
 module.cpp
 ^EXIT=0$

--- a/regression/cbmc-cpp/Makefile
+++ b/regression/cbmc-cpp/Makefile
@@ -4,7 +4,7 @@ include ../../src/config.inc
 include ../../src/common
 
 ifeq ($(BUILD_ENV_),MSVC)
-	excluded_tests = -X gcc-only -X winbug
+	excluded_tests = -X gcc-only
 else
 ifeq ($(BUILD_ENV_),OSX)
 	# In MacOS, a change in the assert.h header file

--- a/regression/cbmc-cpp/Member_Access_in_Class/test.desc
+++ b/regression/cbmc-cpp/Member_Access_in_Class/test.desc
@@ -1,4 +1,4 @@
-CORE winbug macos-assert-broken
+CORE macos-assert-broken
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Mutable1/test.desc
+++ b/regression/cbmc-cpp/Mutable1/test.desc
@@ -1,4 +1,4 @@
-CORE winbug macos-assert-broken
+CORE macos-assert-broken
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Overloading_Functions1/test.desc
+++ b/regression/cbmc-cpp/Overloading_Functions1/test.desc
@@ -1,4 +1,4 @@
-CORE winbug macos-assert-broken
+CORE macos-assert-broken
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Overloading_Functions3/test.desc
+++ b/regression/cbmc-cpp/Overloading_Functions3/test.desc
@@ -1,4 +1,4 @@
-CORE winbug macos-assert-broken
+CORE macos-assert-broken
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Overloading_Increment1/test.desc
+++ b/regression/cbmc-cpp/Overloading_Increment1/test.desc
@@ -1,4 +1,4 @@
-CORE winbug macos-assert-broken
+CORE macos-assert-broken
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Overloading_Members1/test.desc
+++ b/regression/cbmc-cpp/Overloading_Members1/test.desc
@@ -1,4 +1,4 @@
-CORE winbug macos-assert-broken
+CORE macos-assert-broken
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Overloading_Operators12/test.desc
+++ b/regression/cbmc-cpp/Overloading_Operators12/test.desc
@@ -1,4 +1,4 @@
-CORE winbug macos-assert-broken
+CORE macos-assert-broken
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Overloading_Operators13/test.desc
+++ b/regression/cbmc-cpp/Overloading_Operators13/test.desc
@@ -1,4 +1,4 @@
-CORE winbug macos-assert-broken
+CORE macos-assert-broken
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Overloading_Operators2/test.desc
+++ b/regression/cbmc-cpp/Overloading_Operators2/test.desc
@@ -1,4 +1,4 @@
-CORE winbug macos-assert-broken
+CORE macos-assert-broken
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Overloading_Operators7/test.desc
+++ b/regression/cbmc-cpp/Overloading_Operators7/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG winbug macos-assert-broken
+KNOWNBUG macos-assert-broken
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Overloading_Operators8/test.desc
+++ b/regression/cbmc-cpp/Overloading_Operators8/test.desc
@@ -1,4 +1,4 @@
-CORE winbug macos-assert-broken
+CORE macos-assert-broken
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Pointer_Conversion2/test.desc
+++ b/regression/cbmc-cpp/Pointer_Conversion2/test.desc
@@ -1,4 +1,4 @@
-CORE winbug macos-assert-broken
+CORE macos-assert-broken
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Protection2/test.desc
+++ b/regression/cbmc-cpp/Protection2/test.desc
@@ -1,4 +1,4 @@
-CORE winbug macos-assert-broken
+CORE macos-assert-broken
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Qualifier2/test.desc
+++ b/regression/cbmc-cpp/Qualifier2/test.desc
@@ -1,4 +1,4 @@
-CORE winbug macos-assert-broken
+CORE macos-assert-broken
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Reference2/test.desc
+++ b/regression/cbmc-cpp/Reference2/test.desc
@@ -1,4 +1,4 @@
-CORE winbug macos-assert-broken
+CORE macos-assert-broken
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Reference3/test.desc
+++ b/regression/cbmc-cpp/Reference3/test.desc
@@ -1,4 +1,4 @@
-CORE winbug macos-assert-broken
+CORE macos-assert-broken
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Reference6/test.desc
+++ b/regression/cbmc-cpp/Reference6/test.desc
@@ -1,4 +1,4 @@
-CORE winbug macos-assert-broken
+CORE macos-assert-broken
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Reference7/test.desc
+++ b/regression/cbmc-cpp/Reference7/test.desc
@@ -1,4 +1,4 @@
-CORE winbug macos-assert-broken
+CORE macos-assert-broken
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Resolver6/test.desc
+++ b/regression/cbmc-cpp/Resolver6/test.desc
@@ -1,4 +1,4 @@
-CORE winbug macos-assert-broken
+CORE macos-assert-broken
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Resolver7/test.desc
+++ b/regression/cbmc-cpp/Resolver7/test.desc
@@ -1,4 +1,4 @@
-CORE winbug macos-assert-broken
+CORE macos-assert-broken
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Resolver8/test.desc
+++ b/regression/cbmc-cpp/Resolver8/test.desc
@@ -1,4 +1,4 @@
-CORE winbug macos-assert-broken
+CORE macos-assert-broken
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Static_Method1/test.desc
+++ b/regression/cbmc-cpp/Static_Method1/test.desc
@@ -1,4 +1,4 @@
-CORE winbug macos-assert-broken
+CORE macos-assert-broken
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/String_Literal1/test.desc
+++ b/regression/cbmc-cpp/String_Literal1/test.desc
@@ -1,4 +1,4 @@
-CORE winbug macos-assert-broken
+CORE macos-assert-broken
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Templates10/test.desc
+++ b/regression/cbmc-cpp/Templates10/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG winbug macos-assert-broken
+KNOWNBUG macos-assert-broken
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Templates11/test.desc
+++ b/regression/cbmc-cpp/Templates11/test.desc
@@ -1,4 +1,4 @@
-CORE winbug macos-assert-broken
+CORE macos-assert-broken
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Templates12/test.desc
+++ b/regression/cbmc-cpp/Templates12/test.desc
@@ -1,4 +1,4 @@
-CORE winbug macos-assert-broken
+CORE macos-assert-broken
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Templates13/test.desc
+++ b/regression/cbmc-cpp/Templates13/test.desc
@@ -1,4 +1,4 @@
-CORE winbug macos-assert-broken
+CORE macos-assert-broken
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Templates14/test.desc
+++ b/regression/cbmc-cpp/Templates14/test.desc
@@ -1,4 +1,4 @@
-CORE winbug macos-assert-broken
+CORE macos-assert-broken
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Templates16/test.desc
+++ b/regression/cbmc-cpp/Templates16/test.desc
@@ -1,4 +1,4 @@
-CORE winbug macos-assert-broken
+CORE macos-assert-broken
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Templates19/test.desc
+++ b/regression/cbmc-cpp/Templates19/test.desc
@@ -1,4 +1,4 @@
-CORE winbug macos-assert-broken
+CORE macos-assert-broken
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Templates20/test.desc
+++ b/regression/cbmc-cpp/Templates20/test.desc
@@ -1,4 +1,4 @@
-CORE winbug macos-assert-broken
+CORE macos-assert-broken
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Templates21/test.desc
+++ b/regression/cbmc-cpp/Templates21/test.desc
@@ -1,4 +1,4 @@
-CORE winbug macos-assert-broken
+CORE macos-assert-broken
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Templates22/test.desc
+++ b/regression/cbmc-cpp/Templates22/test.desc
@@ -1,4 +1,4 @@
-CORE winbug macos-assert-broken
+CORE macos-assert-broken
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Templates23/test.desc
+++ b/regression/cbmc-cpp/Templates23/test.desc
@@ -1,4 +1,4 @@
-CORE winbug macos-assert-broken
+CORE macos-assert-broken
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Templates24/test.desc
+++ b/regression/cbmc-cpp/Templates24/test.desc
@@ -1,4 +1,4 @@
-CORE winbug macos-assert-broken
+CORE macos-assert-broken
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Templates25/test.desc
+++ b/regression/cbmc-cpp/Templates25/test.desc
@@ -1,4 +1,4 @@
-CORE winbug macos-assert-broken
+CORE macos-assert-broken
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Templates26/test.desc
+++ b/regression/cbmc-cpp/Templates26/test.desc
@@ -1,4 +1,4 @@
-CORE winbug macos-assert-broken
+CORE macos-assert-broken
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Templates27/test.desc
+++ b/regression/cbmc-cpp/Templates27/test.desc
@@ -1,4 +1,4 @@
-CORE winbug macos-assert-broken
+CORE macos-assert-broken
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Templates28/test.desc
+++ b/regression/cbmc-cpp/Templates28/test.desc
@@ -1,4 +1,4 @@
-CORE winbug macos-assert-broken
+CORE macos-assert-broken
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Templates3/test.desc
+++ b/regression/cbmc-cpp/Templates3/test.desc
@@ -1,4 +1,4 @@
-CORE winbug macos-assert-broken
+CORE macos-assert-broken
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Templates30/test.desc
+++ b/regression/cbmc-cpp/Templates30/test.desc
@@ -1,4 +1,4 @@
-CORE winbug macos-assert-broken
+CORE macos-assert-broken
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/Templates6/test.desc
+++ b/regression/cbmc-cpp/Templates6/test.desc
@@ -1,4 +1,4 @@
-CORE winbug macos-assert-broken
+CORE macos-assert-broken
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/argv1/test.desc
+++ b/regression/cbmc-cpp/argv1/test.desc
@@ -1,4 +1,4 @@
-CORE winbug macos-assert-broken
+CORE macos-assert-broken
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/const_cast1/test.desc
+++ b/regression/cbmc-cpp/const_cast1/test.desc
@@ -1,4 +1,4 @@
-CORE winbug macos-assert-broken
+CORE macos-assert-broken
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/cpp-new/test.desc
+++ b/regression/cbmc-cpp/cpp-new/test.desc
@@ -1,4 +1,4 @@
-CORE winbug macos-assert-broken
+CORE macos-assert-broken
 main.cpp
 --pointer-check
 ^EXIT=0$

--- a/regression/cbmc-cpp/cpp1/test.desc
+++ b/regression/cbmc-cpp/cpp1/test.desc
@@ -1,4 +1,4 @@
-CORE winbug macos-assert-broken
+CORE macos-assert-broken
 main.cpp
 --unwind 1 --unwinding-assertions
 ^EXIT=0$

--- a/regression/cbmc-cpp/for1/test.desc
+++ b/regression/cbmc-cpp/for1/test.desc
@@ -1,4 +1,4 @@
-CORE winbug macos-assert-broken
+CORE macos-assert-broken
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/initialization3/test.desc
+++ b/regression/cbmc-cpp/initialization3/test.desc
@@ -1,4 +1,4 @@
-CORE winbug macos-assert-broken
+CORE macos-assert-broken
 main.cpp
 
 ^EXIT=10$

--- a/regression/cbmc-cpp/initialization5/test.desc
+++ b/regression/cbmc-cpp/initialization5/test.desc
@@ -1,4 +1,4 @@
-CORE winbug macos-assert-broken
+CORE macos-assert-broken
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/lvalue1/test.desc
+++ b/regression/cbmc-cpp/lvalue1/test.desc
@@ -1,4 +1,4 @@
-CORE winbug macos-assert-broken
+CORE macos-assert-broken
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/namespace1/test.desc
+++ b/regression/cbmc-cpp/namespace1/test.desc
@@ -1,4 +1,4 @@
-CORE winbug macos-assert-broken
+CORE macos-assert-broken
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/namespace2/test.desc
+++ b/regression/cbmc-cpp/namespace2/test.desc
@@ -1,4 +1,4 @@
-CORE winbug macos-assert-broken
+CORE macos-assert-broken
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/namespace3/test.desc
+++ b/regression/cbmc-cpp/namespace3/test.desc
@@ -1,4 +1,4 @@
-CORE winbug macos-assert-broken
+CORE macos-assert-broken
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/new1/test.desc
+++ b/regression/cbmc-cpp/new1/test.desc
@@ -1,4 +1,4 @@
-CORE winbug macos-assert-broken
+CORE macos-assert-broken
 main.cpp
 --pointer-check
 ^EXIT=0$

--- a/regression/cbmc-cpp/operators/test.desc
+++ b/regression/cbmc-cpp/operators/test.desc
@@ -1,4 +1,4 @@
-CORE winbug macos-assert-broken
+CORE macos-assert-broken
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/reinterpret_cast1/test.desc
+++ b/regression/cbmc-cpp/reinterpret_cast1/test.desc
@@ -1,4 +1,4 @@
-CORE winbug macos-assert-broken
+CORE macos-assert-broken
 main.cpp
 --little-endian
 ^EXIT=0$

--- a/regression/cbmc-cpp/static_cast1/test.desc
+++ b/regression/cbmc-cpp/static_cast1/test.desc
@@ -1,4 +1,4 @@
-CORE winbug macos-assert-broken
+CORE macos-assert-broken
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/static_cast3/test.desc
+++ b/regression/cbmc-cpp/static_cast3/test.desc
@@ -1,4 +1,4 @@
-CORE winbug macos-assert-broken
+CORE macos-assert-broken
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/static_cast5/test.desc
+++ b/regression/cbmc-cpp/static_cast5/test.desc
@@ -1,4 +1,4 @@
-CORE winbug macos-assert-broken
+CORE macos-assert-broken
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/typecast_ambiguity3/test.desc
+++ b/regression/cbmc-cpp/typecast_ambiguity3/test.desc
@@ -1,4 +1,4 @@
-CORE winbug macos-assert-broken
+CORE macos-assert-broken
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/typedef4/test.desc
+++ b/regression/cbmc-cpp/typedef4/test.desc
@@ -1,4 +1,4 @@
-CORE winbug macos-assert-broken
+CORE macos-assert-broken
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/virtual10/test.desc
+++ b/regression/cbmc-cpp/virtual10/test.desc
@@ -1,4 +1,4 @@
-CORE winbug macos-assert-broken
+CORE macos-assert-broken
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/virtual2/test.desc
+++ b/regression/cbmc-cpp/virtual2/test.desc
@@ -1,4 +1,4 @@
-CORE winbug macos-assert-broken
+CORE macos-assert-broken
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-cpp/virtual9/test.desc
+++ b/regression/cbmc-cpp/virtual9/test.desc
@@ -1,4 +1,4 @@
-CORE winbug macos-assert-broken
+CORE macos-assert-broken
 main.cpp
 
 ^EXIT=0$

--- a/regression/cbmc-incr-smt2/CMakeLists.txt
+++ b/regression/cbmc-incr-smt2/CMakeLists.txt
@@ -1,20 +1,13 @@
-
-if("${CMAKE_SYSTEM_NAME}" STREQUAL "Windows")
-    set(exclude_win_broken_tests "-X;winbug")
-else()
-    set(exclude_win_broken_tests "")
-endif()
-
 add_test_pl_profile(
     "cbmc-incr-smt2-z3"
     "$<TARGET_FILE:cbmc> --incremental-smt2-solver 'z3 --smt2 -in' --validate-goto-model --validate-ssa-equation"
-    "-C;${exclude_win_broken_tests};-s;new-smt-z3"
+    "-C;-s;new-smt-z3"
     "CORE"
 )
 
 add_test_pl_profile(
     "cbmc-incr-smt2-cvc5"
     "$<TARGET_FILE:cbmc> --incremental-smt2-solver 'cvc5 --lang=smtlib2.6 --incremental' --validate-goto-model --validate-ssa-equation"
-    "-C;${exclude_win_broken_tests};-s;new-smt-cvc5"
+    "-C;-s;new-smt-cvc5"
     "CORE"
 )

--- a/regression/cbmc-incr-smt2/Makefile
+++ b/regression/cbmc-incr-smt2/Makefile
@@ -3,19 +3,13 @@ default: test
 include ../../src/config.inc
 include ../../src/common
 
-ifeq ($(BUILD_ENV_),MSVC)
-	exclude_broken_windows_tests=-X winbug
-else
-	exclude_broken_windows_tests=
-endif
-
 test: test.z3 test.cvc5
 
 test.z3:
-	@../test.pl -e -p -c "../../../src/cbmc/cbmc --incremental-smt2-solver 'z3 --smt2 -in' --validate-goto-model --validate-ssa-equation" $(exclude_broken_windows_tests)
+	@../test.pl -e -p -c "../../../src/cbmc/cbmc --incremental-smt2-solver 'z3 --smt2 -in' --validate-goto-model --validate-ssa-equation"
 
 test.cvc5:
-	@../test.pl -e -p -c "../../../src/cbmc/cbmc --incremental-smt2-solver 'cvc5 --lang=smtlib2.6 --incremental' --validate-goto-model --validate-ssa-equation" $(exclude_broken_windows_tests)
+	@../test.pl -e -p -c "../../../src/cbmc/cbmc --incremental-smt2-solver 'cvc5 --lang=smtlib2.6 --incremental' --validate-goto-model --validate-ssa-equation"
 
 tests.log: ../test.pl test
 

--- a/regression/cbmc/export-symex-ready-goto/test-bad-usage.desc
+++ b/regression/cbmc/export-symex-ready-goto/test-bad-usage.desc
@@ -1,6 +1,6 @@
-CORE winbug
+CORE
 test.c
---export-symex-ready-goto ""
+--export-symex-ready-goto ''
 ^ERROR: Please provide a filename to write the goto-binary to.$
 ^EXIT=6$
 ^SIGNAL=0$

--- a/regression/cpp/CMakeLists.txt
+++ b/regression/cpp/CMakeLists.txt
@@ -4,12 +4,6 @@ else()
   set(gcc_only "")
 endif()
 
-if("${CMAKE_SYSTEM_NAME}" STREQUAL "Windows")
-  set(exclude_win_broken_tests -X winbug)
-else()
-  set(exclude_win_broken_tests "")
-endif()
-
 if("${CMAKE_SYSTEM_NAME}" STREQUAL "Darwin")
   set(exclude_mac_broken_tests -X macos-assert-broken)
 else()
@@ -17,5 +11,5 @@ else()
 endif()
 
 add_test_pl_tests(
-    "$<TARGET_FILE:goto-cc>" ${gcc_only} ${exclude_win_broken_tests} ${exclude_mac_broken_tests}
+    "$<TARGET_FILE:goto-cc>" ${gcc_only} ${exclude_mac_broken_tests}
 )

--- a/regression/cpp/Function_Overloading3/test.desc
+++ b/regression/cpp/Function_Overloading3/test.desc
@@ -1,4 +1,4 @@
-CORE winbug
+CORE
 main.cpp
 
 ^EXIT=0$

--- a/regression/cpp/Makefile
+++ b/regression/cpp/Makefile
@@ -10,7 +10,7 @@ else
 endif
 
 ifeq ($(BUILD_ENV_),MSVC)
-	excluded_tests = -X gcc-only -X winbug
+	excluded_tests = -X gcc-only
 else
 ifeq ($(BUILD_ENV_),OSX)
 	# In MacOS, a change in the assert.h header file

--- a/regression/cpp/Method_qualifier1/test.desc
+++ b/regression/cpp/Method_qualifier1/test.desc
@@ -1,4 +1,4 @@
-CORE winbug macos-assert-broken
+CORE macos-assert-broken
 main.cpp
 
 ^EXIT=0$

--- a/regression/cpp/Unary_Function_Overload1/test.desc
+++ b/regression/cpp/Unary_Function_Overload1/test.desc
@@ -1,4 +1,4 @@
-CORE winbug
+CORE
 main.cpp
 
 ^EXIT=0$

--- a/regression/cpp/Unary_Function_Overload2/test.desc
+++ b/regression/cpp/Unary_Function_Overload2/test.desc
@@ -1,4 +1,4 @@
-CORE winbug
+CORE
 main.cpp
 
 ^EXIT=0$

--- a/regression/cpp/Unary_Function_Overload3/test.desc
+++ b/regression/cpp/Unary_Function_Overload3/test.desc
@@ -1,4 +1,4 @@
-CORE winbug
+CORE
 main.cpp
 
 ^EXIT=0$

--- a/regression/cpp/auto1/test.desc
+++ b/regression/cpp/auto1/test.desc
@@ -1,4 +1,4 @@
-CORE winbug macos-assert-broken
+CORE macos-assert-broken
 main.cpp
 -std=c++11
 ^EXIT=0$

--- a/regression/cpp/enum5/test.desc
+++ b/regression/cpp/enum5/test.desc
@@ -1,4 +1,4 @@
-CORE winbug macos-assert-broken
+CORE macos-assert-broken
 main.cpp
 
 ^EXIT=0$

--- a/regression/cpp/switch1/test.desc
+++ b/regression/cpp/switch1/test.desc
@@ -1,4 +1,4 @@
-CORE winbug macos-assert-broken
+CORE macos-assert-broken
 main.cpp
 
 ^EXIT=0$

--- a/regression/goto-inspect/CMakeLists.txt
+++ b/regression/goto-inspect/CMakeLists.txt
@@ -1,11 +1,9 @@
 if("${CMAKE_SYSTEM_NAME}" STREQUAL "Windows")
   set(is_windows true)
-  set(exclude_win_broken_tests -X winbug)
 else()
   set(is_windows false)
-  set(exclude_win_broken_tests "")
 endif()
 
 add_test_pl_tests(
-  "${CMAKE_CURRENT_SOURCE_DIR}/chain.sh $<TARGET_FILE:goto-cc> $<TARGET_FILE:goto-inspect> ${is_windows}" ${exclude_win_broken_tests}
+  "${CMAKE_CURRENT_SOURCE_DIR}/chain.sh $<TARGET_FILE:goto-cc> $<TARGET_FILE:goto-inspect> ${is_windows}"
 )

--- a/regression/goto-inspect/Makefile
+++ b/regression/goto-inspect/Makefile
@@ -6,17 +6,16 @@ include ../../src/common
 ifeq ($(BUILD_ENV_),MSVC)
 	exe=../../../src/goto-cc/goto-cl
 	is_windows=true
-	excluded_tests = -X winbug
 else
 	exe=../../../src/goto-cc/goto-cc
 	is_windows=false
 endif
 
 test:
-	@../test.pl -e -p -c '../chain.sh $(exe) ../../../src/goto-inspect/goto-inspect $(is_windows)' $(excluded_tests)
+	@../test.pl -e -p -c '../chain.sh $(exe) ../../../src/goto-inspect/goto-inspect $(is_windows)'
 
 tests.log:
-	@../test.pl -e -p -c '../chain.sh $(exe) ../../../src/goto-inspect/goto-inspect $(is_windows)' $(excluded_tests)
+	@../test.pl -e -p -c '../chain.sh $(exe) ../../../src/goto-inspect/goto-inspect $(is_windows)'
 
 clean:
 	find . -name '*.out' -execdir $(RM) '{}' \;

--- a/regression/goto-inspect/show-goto-functions/negative.desc
+++ b/regression/goto-inspect/show-goto-functions/negative.desc
@@ -1,6 +1,6 @@
-CORE winbug
+CORE
 main.c
-" "
+' '
 ^EXIT=6$
 ^SIGNAL=0$
 --
@@ -13,10 +13,3 @@ END_FUNCTION
 --
 This is testing the behaviour of the goto-inspect binary in case a binary
 is present, but no inspection option is present.
-
-This is labelled `winbug` to avoid running on windows because of issues with
-the empty string in line 3 (simulating the lack of an option) not working as
-it should (it is contrary to the behaviour of unix systems). The behaviour
-has been verified manually on a machine as working as expected, but getting
-the test to run automatically is a lot more involved, so we're opting to
-skipping this on that platform for now.

--- a/regression/systemc/Array2/test.desc
+++ b/regression/systemc/Array2/test.desc
@@ -1,4 +1,4 @@
-CORE winbug macos-assert-broken
+CORE macos-assert-broken
 main.cpp
 -DNO_IO -DNO_STRING
 ^EXIT=0$

--- a/regression/systemc/Array3/test.desc
+++ b/regression/systemc/Array3/test.desc
@@ -1,4 +1,4 @@
-CORE winbug macos-assert-broken
+CORE macos-assert-broken
 main.cpp
 -DNO_IO -DNO_STRING
 ^EXIT=0$

--- a/regression/systemc/Array4/test.desc
+++ b/regression/systemc/Array4/test.desc
@@ -1,4 +1,4 @@
-CORE winbug macos-assert-broken
+CORE macos-assert-broken
 main.cpp
 -DNO_IO -DNO_STRING
 ^EXIT=0$

--- a/regression/systemc/BitvectorCpp1/test.desc
+++ b/regression/systemc/BitvectorCpp1/test.desc
@@ -1,4 +1,4 @@
-CORE winbug macos-assert-broken
+CORE macos-assert-broken
 main.cpp
 
 ^EXIT=0$

--- a/regression/systemc/BitvectorCpp2/test.desc
+++ b/regression/systemc/BitvectorCpp2/test.desc
@@ -1,4 +1,4 @@
-CORE winbug macos-assert-broken
+CORE macos-assert-broken
 main.cpp
 
 ^EXIT=0$

--- a/regression/systemc/BitvectorSc3/test.desc
+++ b/regression/systemc/BitvectorSc3/test.desc
@@ -1,4 +1,4 @@
-CORE winbug macos-assert-broken
+CORE macos-assert-broken
 main.cpp
 
 ^EXIT=0$

--- a/regression/systemc/CMakeLists.txt
+++ b/regression/systemc/CMakeLists.txt
@@ -1,9 +1,3 @@
-if("${CMAKE_SYSTEM_NAME}" STREQUAL "Windows")
-  set(exclude_win_broken_tests -X winbug)
-else()
-  set(exclude_win_broken_tests "")
-endif()
-
 if("${CMAKE_SYSTEM_NAME}" STREQUAL "Darwin")
   set(exclude_mac_broken_tests -X macos-assert-broken)
 else()
@@ -11,5 +5,5 @@ else()
 endif()
 
 add_test_pl_tests(
-    "$<TARGET_FILE:cbmc> --validate-goto-model --validate-ssa-equation" ${exclude_win_broken_tests} ${exclude_mac_broken_tests}
+    "$<TARGET_FILE:cbmc> --validate-goto-model --validate-ssa-equation" ${exclude_mac_broken_tests}
 )

--- a/regression/systemc/EqualOp3/test.desc
+++ b/regression/systemc/EqualOp3/test.desc
@@ -1,4 +1,4 @@
-CORE winbug
+CORE
 main.cpp
 
 ^EXIT=10$

--- a/regression/systemc/ForwardDecl1/test.desc
+++ b/regression/systemc/ForwardDecl1/test.desc
@@ -1,4 +1,4 @@
-CORE winbug macos-assert-broken
+CORE macos-assert-broken
 main.cpp
 
 ^EXIT=0$

--- a/regression/systemc/FunTempl1/test.desc
+++ b/regression/systemc/FunTempl1/test.desc
@@ -1,4 +1,4 @@
-CORE winbug
+CORE
 main.cpp
 
 ^EXIT=0$

--- a/regression/systemc/Makefile
+++ b/regression/systemc/Makefile
@@ -10,7 +10,7 @@ else
 endif
 
 ifeq ($(BUILD_ENV_),MSVC)
-	excluded_tests = -X gcc-only -X winbug
+	excluded_tests = -X gcc-only
 else
 ifeq ($(BUILD_ENV_),OSX)
 	# In MacOS, a change in the assert.h header file

--- a/regression/systemc/Masc1/test.desc
+++ b/regression/systemc/Masc1/test.desc
@@ -1,4 +1,4 @@
-CORE winbug macos-assert-broken
+CORE macos-assert-broken
 main.cpp
 
 ^EXIT=0$

--- a/regression/systemc/MascInst1/test.desc
+++ b/regression/systemc/MascInst1/test.desc
@@ -1,4 +1,4 @@
-CORE winbug macos-assert-broken
+CORE macos-assert-broken
 main.cpp
 
 ^EXIT=0$

--- a/regression/systemc/Reference1/test.desc
+++ b/regression/systemc/Reference1/test.desc
@@ -1,4 +1,4 @@
-CORE winbug macos-assert-broken
+CORE macos-assert-broken
 main.cpp
 
 ^EXIT=0$

--- a/regression/systemc/This1/test.desc
+++ b/regression/systemc/This1/test.desc
@@ -1,4 +1,4 @@
-CORE winbug macos-assert-broken
+CORE macos-assert-broken
 main.cpp
 
 ^EXIT=0$

--- a/regression/systemc/Tuple1/test.desc
+++ b/regression/systemc/Tuple1/test.desc
@@ -1,4 +1,4 @@
-CORE winbug macos-assert-broken
+CORE macos-assert-broken
 main.cpp
 -DNO_IO -DNO_STRING
 ^EXIT=0$

--- a/regression/systemc/Tuple2/test.desc
+++ b/regression/systemc/Tuple2/test.desc
@@ -1,4 +1,4 @@
-CORE winbug macos-assert-broken
+CORE macos-assert-broken
 main.cpp
 -DNO_IO -DNO_STRING
 ^EXIT=0$


### PR DESCRIPTION
Please review commit-by-commit: these tests actually pass on Windows, or making them pass just requires fixing the test pattern file.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
