### PR TITLE
Silence another spurious maybe-uninitialized warning

### DIFF
--- a/src/util/lower_byte_operators.cpp
+++ b/src/util/lower_byte_operators.cpp
@@ -1111,8 +1111,14 @@ static exprt lower_byte_extract_array_vector(
   if(num_elements.has_value())
   {
     exprt::operandst operands;
+    // Work around spurious GCC warning about num_elements being uninitialised.
+#pragma GCC diagnostic push
+#ifndef __clang__
+#  pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
     operands.reserve(*num_elements);
     for(std::size_t i = 0; i < *num_elements; ++i)
+#pragma GCC diagnostic pop
     {
       plus_exprt new_offset(
         unpacked.offset(),


### PR DESCRIPTION
Silence a spurious warning reported on CentOS 7 with GCC 6.4.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
