### PR TITLE
Fix byte update of struct/array elements

### DIFF
--- a/regression/cbmc/byte_update18/main.c
+++ b/regression/cbmc/byte_update18/main.c
@@ -1,0 +1,22 @@
+struct S
+{
+  unsigned char A[1];
+  char len; // keep this to reproduce
+};
+
+struct O
+{
+  struct S A[2];
+  char len; // this is key to reproduce
+};
+
+int main()
+{
+  struct O t = {{{{0}, 2}, {{42}, 2}}, 2};
+  unsigned n;
+  __CPROVER_assume(n < 2);
+  __CPROVER_assume(n > 0);
+  char src_n[n];
+  __CPROVER_array_replace((char *)t.A[0].A, src_n);
+  __CPROVER_assert(t.A[1].A[0] == 42, "");
+}

--- a/regression/cbmc/byte_update18/test.desc
+++ b/regression/cbmc/byte_update18/test.desc
@@ -1,0 +1,11 @@
+CORE broken-cprover-smt-backend
+main.c
+
+^VERIFICATION SUCCESSFUL$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--
+Some bug in our in-tree SMT2 solver makes it report SAT, when Z3 states that the
+same SMT2 formula is (as expected) UNSAT.


### PR DESCRIPTION
A key part of this is factoring out code that was almost-the-same from lower_byte_update_array_vector and lower_byte_update_struct, but actually had subtle bugs as documented in regression test included in this commit.

For consistency, do all offset calculations in bits rather than flipping back and forth between bits and bytes.

This will fix the spurious failure reported in https://github.com/model-checking/kani/issues/2650.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
