### PR TITLE
Use extractbits to extract non-byte-fields from unions

### DIFF
--- a/regression/cbmc/Bitfields6/main.c
+++ b/regression/cbmc/Bitfields6/main.c
@@ -1,0 +1,10 @@
+union
+{
+  unsigned five : 5;
+  char *a;
+  unsigned one : 1;
+} b = {8};
+int main()
+{
+  __CPROVER_assert(0, "");
+}

--- a/regression/cbmc/Bitfields6/test.desc
+++ b/regression/cbmc/Bitfields6/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+
+^EXIT=10$
+^SIGNAL=0$
+^VERIFICATION FAILED$
+--
+^warning: ignoring

--- a/src/goto-programs/rewrite_union.cpp
+++ b/src/goto-programs/rewrite_union.cpp
@@ -12,8 +12,10 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "rewrite_union.h"
 
 #include <util/arith_tools.h>
+#include <util/bitvector_expr.h>
 #include <util/byte_operators.h>
 #include <util/c_types.h>
+#include <util/config.h>
 #include <util/pointer_expr.h>
 #include <util/pointer_offset_size.h>
 #include <util/std_code.h>
@@ -22,14 +24,14 @@ Author: Daniel Kroening, kroening@kroening.com
 
 static bool have_to_rewrite_union(const exprt &expr)
 {
-  if(expr.id()==ID_member)
+  if(expr.id() == ID_member)
   {
-    const exprt &op=to_member_expr(expr).struct_op();
+    const exprt &op = to_member_expr(expr).struct_op();
 
     if(op.type().id() == ID_union_tag || op.type().id() == ID_union)
       return true;
   }
-  else if(expr.id()==ID_union)
+  else if(expr.id() == ID_union)
     return true;
 
   for(const auto &op : expr.operands())
@@ -43,33 +45,35 @@ static bool have_to_rewrite_union(const exprt &expr)
 
 // inside an address of (&x), unions can simply
 // be type casts and don't have to be re-written!
-void rewrite_union_address_of(exprt &expr)
+static void rewrite_union(exprt &expr, const namespacet &ns);
+
+static void rewrite_union_address_of(exprt &expr, const namespacet &ns)
 {
   if(!have_to_rewrite_union(expr))
     return;
 
-  if(expr.id()==ID_index)
+  if(expr.id() == ID_index)
   {
-    rewrite_union_address_of(to_index_expr(expr).array());
-    rewrite_union(to_index_expr(expr).index());
+    rewrite_union_address_of(to_index_expr(expr).array(), ns);
+    rewrite_union(to_index_expr(expr).index(), ns);
   }
-  else if(expr.id()==ID_member)
-    rewrite_union_address_of(to_member_expr(expr).struct_op());
-  else if(expr.id()==ID_symbol)
+  else if(expr.id() == ID_member)
+    rewrite_union_address_of(to_member_expr(expr).struct_op(), ns);
+  else if(expr.id() == ID_symbol)
   {
     // done!
   }
-  else if(expr.id()==ID_dereference)
-    rewrite_union(to_dereference_expr(expr).pointer());
+  else if(expr.id() == ID_dereference)
+    rewrite_union(to_dereference_expr(expr).pointer(), ns);
 }
 
 /// We rewrite u.c for unions u into byte_extract(u, 0), and { .c = v } into
 /// byte_update(NIL, 0, v)
-void rewrite_union(exprt &expr)
+static void rewrite_union(exprt &expr, const namespacet &ns)
 {
-  if(expr.id()==ID_address_of)
+  if(expr.id() == ID_address_of)
   {
-    rewrite_union_address_of(to_address_of_expr(expr).object());
+    rewrite_union_address_of(to_address_of_expr(expr).object(), ns);
     return;
   }
 
@@ -77,35 +81,79 @@ void rewrite_union(exprt &expr)
     return;
 
   Forall_operands(it, expr)
-    rewrite_union(*it);
+    rewrite_union(*it, ns);
 
-  if(expr.id()==ID_member)
+  if(expr.id() == ID_member)
   {
-    const exprt &op=to_member_expr(expr).struct_op();
+    const exprt &op = to_member_expr(expr).struct_op();
 
     if(op.type().id() == ID_union_tag || op.type().id() == ID_union)
     {
-      exprt offset = from_integer(0, c_index_type());
-      expr = make_byte_extract(op, offset, expr.type());
+      if(
+        expr.type().id() != ID_c_bit_field ||
+        to_c_bit_field_type(expr.type()).get_width() %
+            config.ansi_c.char_width ==
+          0)
+      {
+        exprt offset = from_integer(0, c_index_type());
+        expr = make_byte_extract(op, offset, expr.type());
+      }
+      else
+      {
+        const auto &bf_type = to_c_bit_field_type(expr.type());
+        std::size_t bf_width = bf_type.get_width();
+
+        auto union_width = pointer_offset_bits(op.type(), ns);
+        CHECK_RETURN(union_width.has_value() && *union_width > 0);
+        std::size_t W = numeric_cast_v<std::size_t>(*union_width);
+
+        std::size_t bit_offset = 0;
+        if(
+          config.ansi_c.endianness ==
+          configt::ansi_ct::endiannesst::IS_BIG_ENDIAN)
+        {
+          bit_offset = W - bf_width;
+        }
+
+        // Cast the union to a flat bitvector so that extractbits
+        // (and, on the write side, update_bits) operate on a
+        // bitvector type as they require.
+        typecast_exprt bv_op{op, bv_typet{W}};
+        expr = extractbits_exprt{
+          std::move(bv_op),
+          from_integer(bit_offset, c_index_type()),
+          expr.type()};
+      }
     }
   }
-  else if(expr.id()==ID_union)
+  else if(expr.id() == ID_union)
   {
-    const union_exprt &union_expr=to_union_expr(expr);
+    const union_exprt &union_expr = to_union_expr(expr);
     exprt offset = from_integer(0, c_index_type());
     side_effect_expr_nondett nondet(expr.type(), expr.source_location());
     expr = make_byte_update(nondet, offset, union_expr.op());
   }
 }
 
+void rewrite_union(exprt &expr)
+{
+  // Legacy overload without namespace — cannot handle big-endian
+  // bit fields correctly. Use the namespacet overload when possible.
+  symbol_tablet empty_symbol_table;
+  const namespacet ns{empty_symbol_table};
+  rewrite_union(expr, ns);
+}
+
 void rewrite_union(goto_functionst::goto_functiont &goto_function)
 {
+  symbol_tablet empty_symbol_table;
+  const namespacet ns{empty_symbol_table};
   for(auto &instruction : goto_function.body.instructions)
   {
-    rewrite_union(instruction.code_nonconst());
+    rewrite_union(instruction.code_nonconst(), ns);
 
     if(instruction.has_condition())
-      rewrite_union(instruction.condition_nonconst());
+      rewrite_union(instruction.condition_nonconst(), ns);
   }
 }
 
@@ -117,7 +165,17 @@ void rewrite_union(goto_functionst &goto_functions)
 
 void rewrite_union(goto_modelt &goto_model)
 {
-  rewrite_union(goto_model.goto_functions);
+  const namespacet ns{goto_model.symbol_table};
+  for(auto &gf_entry : goto_model.goto_functions.function_map)
+  {
+    for(auto &instruction : gf_entry.second.body.instructions)
+    {
+      rewrite_union(instruction.code_nonconst(), ns);
+
+      if(instruction.has_condition())
+        rewrite_union(instruction.condition_nonconst(), ns);
+    }
+  }
 }
 
 /// Undo the union access -> byte_extract replacement that rewrite_union did for

--- a/src/goto-symex/build_goto_trace.cpp
+++ b/src/goto-symex/build_goto_trace.cpp
@@ -14,6 +14,7 @@ Author: Daniel Kroening
 #include "build_goto_trace.h"
 
 #include <util/arith_tools.h>
+#include <util/bitvector_expr.h>
 #include <util/byte_operators.h>
 #include <util/namespace.h>
 #include <util/simplify_expr.h>
@@ -109,6 +110,12 @@ static exprt build_full_lhs_rec(
       decision_procedure, ns, tmp.op(), to_byte_extract_expr(src_ssa).op());
 
     // re-write into big case-split
+  }
+  else if(id == ID_extractbits)
+  {
+    extractbits_exprt tmp = to_extractbits_expr(src_original);
+    tmp.src() = build_full_lhs_rec(
+      decision_procedure, ns, tmp.src(), to_extractbits_expr(src_ssa).src());
   }
 
   return src_original;

--- a/src/goto-symex/field_sensitivity.cpp
+++ b/src/goto-symex/field_sensitivity.cpp
@@ -9,8 +9,10 @@ Author: Michael Tautschnig
 #include "field_sensitivity.h"
 
 #include <util/arith_tools.h>
+#include <util/bitvector_expr.h>
 #include <util/byte_operators.h>
 #include <util/c_types.h>
+#include <util/config.h>
 #include <util/pointer_offset_size.h>
 
 #include "goto_symex_state.h"
@@ -512,15 +514,42 @@ void field_sensitivityt::field_assignments_rec(
     exprt::operandst::const_iterator fs_it = lhs_fs.operands().begin();
     for(const auto &comp : components)
     {
-      const exprt member_rhs = apply(
-        ns,
-        state,
-        simplify_opt(
-          make_byte_extract(
-            ssa_rhs, from_integer(0, c_index_type()), comp.type()),
-          state.value_set,
-          ns),
-        false);
+      exprt extract;
+      if(
+        comp.type().id() != ID_c_bit_field ||
+        to_c_bit_field_type(comp.type()).get_width() %
+            config.ansi_c.char_width ==
+          0)
+      {
+        extract = make_byte_extract(
+          ssa_rhs, from_integer(0, c_index_type()), comp.type());
+      }
+      else
+      {
+        const auto &bf_type = to_c_bit_field_type(comp.type());
+        std::size_t bf_width = bf_type.get_width();
+
+        auto rhs_width = pointer_offset_bits(ssa_rhs.type(), ns);
+        CHECK_RETURN(rhs_width.has_value() && *rhs_width > 0);
+        std::size_t W = numeric_cast_v<std::size_t>(*rhs_width);
+
+        std::size_t bit_offset = 0;
+        if(
+          config.ansi_c.endianness ==
+          configt::ansi_ct::endiannesst::IS_BIG_ENDIAN)
+        {
+          bit_offset = W - bf_width;
+        }
+
+        typecast_exprt bv_rhs{ssa_rhs, bv_typet{W}};
+        extract = extractbits_exprt{
+          std::move(bv_rhs),
+          from_integer(bit_offset, c_index_type()),
+          comp.type()};
+      }
+
+      const exprt member_rhs =
+        apply(ns, state, simplify_opt(extract, state.value_set, ns), false);
 
       const exprt &member_lhs = *fs_it;
       if(

--- a/src/goto-symex/goto_symex_state.cpp
+++ b/src/goto-symex/goto_symex_state.cpp
@@ -13,6 +13,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <util/as_const.h>
 #include <util/base_exceptions.h> // IWYU pragma: keep
+#include <util/bitvector_expr.h>
 #include <util/byte_operators.h>
 #include <util/c_types.h>
 #include <util/exception_utils.h>
@@ -339,6 +340,13 @@ exprt goto_symex_statet::l2_rename_rvalues(exprt lvalue, const namespacet &ns)
     auto &byte_extract_lvalue = to_byte_extract_expr(lvalue);
     byte_extract_lvalue.op() = l2_rename_rvalues(byte_extract_lvalue.op(), ns);
     byte_extract_lvalue.offset() = rename(byte_extract_lvalue.offset(), ns);
+  }
+  else if(lvalue.id() == ID_extractbits)
+  {
+    // The index is an rvalue:
+    auto &extractbits_lvalue = to_extractbits_expr(lvalue);
+    extractbits_lvalue.src() = l2_rename_rvalues(extractbits_lvalue.src(), ns);
+    extractbits_lvalue.index() = rename(extractbits_lvalue.index(), ns).get();
   }
   else if(lvalue.id() == ID_if)
   {

--- a/src/goto-symex/symex_assign.cpp
+++ b/src/goto-symex/symex_assign.cpp
@@ -11,6 +11,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "symex_assign.h"
 
+#include <util/bitvector_expr.h>
 #include <util/byte_operators.h>
 #include <util/pointer_expr.h>
 #include <util/range.h>
@@ -113,6 +114,22 @@ void symex_assignt::assign_rec(
           lhs.id()==ID_byte_extract_big_endian)
   {
     assign_byte_extract(to_byte_extract_expr(lhs), full_lhs, rhs, guard);
+  }
+  else if(lhs.id() == ID_extractbits)
+  {
+    // extractbits(typecast(obj, bv), idx, type) = value
+    // becomes typecast(obj, bv) = update_bits(typecast(obj, bv), idx, value)
+    const auto &extractbits_lhs = to_extractbits_expr(lhs);
+    // Ensure the value has the exact bit width that update_bits
+    // needs to know how many bits to replace. Use a bitvector type
+    // that the simplifier won't strip away.
+    const auto bf_width = to_bitvector_type(lhs.type()).get_width();
+    exprt typed_rhs = typecast_exprt{rhs, bv_typet{bf_width}};
+    const update_bits_exprt new_rhs{
+      extractbits_lhs.src(), extractbits_lhs.index(), typed_rhs};
+    const expr_skeletont new_skeleton =
+      full_lhs.compose(expr_skeletont::remove_op0(lhs));
+    assign_rec(extractbits_lhs.src(), new_skeleton, new_rhs, guard);
   }
   else if(lhs.id() == ID_complex_real)
   {

--- a/src/goto-symex/symex_other.cpp
+++ b/src/goto-symex/symex_other.cpp
@@ -9,13 +9,14 @@ Author: Daniel Kroening, kroening@kroening.com
 /// \file
 /// Symbolic Execution
 
-#include "goto_symex.h"
-
 #include <util/arith_tools.h>
+#include <util/bitvector_expr.h>
 #include <util/byte_operators.h>
 #include <util/c_types.h>
 #include <util/pointer_offset_size.h>
 #include <util/std_code.h>
+
+#include "goto_symex.h"
 
 void goto_symext::havoc_rec(
   statet &state,
@@ -41,6 +42,10 @@ void goto_symext::havoc_rec(
           dest.id()==ID_byte_extract_big_endian)
   {
     havoc_rec(state, guard, to_byte_extract_expr(dest).op());
+  }
+  else if(dest.id() == ID_extractbits)
+  {
+    havoc_rec(state, guard, to_extractbits_expr(dest).src());
   }
   else if(dest.id()==ID_if)
   {

--- a/src/solvers/flattening/boolbv.cpp
+++ b/src/solvers/flattening/boolbv.cpp
@@ -123,6 +123,8 @@ bvt boolbvt::convert_bitvector(const exprt &expr)
     return convert_update(to_update_expr(expr));
   else if(expr.id() == ID_update_bit)
     return convert_update_bit(to_update_bit_expr(expr));
+  else if(expr.id() == ID_update_bits)
+    return convert_update_bits(to_update_bits_expr(expr));
   else if(expr.id()==ID_case)
     return convert_case(to_case_expr(expr));
   else if(expr.id()==ID_cond)

--- a/src/solvers/flattening/boolbv_typecast.cpp
+++ b/src/solvers/flattening/boolbv_typecast.cpp
@@ -543,6 +543,15 @@ bool boolbvt::type_conversion(
         return false;
       }
     }
+    else if(
+      src_width == dest_width &&
+      (src_type.id() == ID_union || src_type.id() == ID_union_tag ||
+       dest_type.id() == ID_union || dest_type.id() == ID_union_tag ||
+       dest_type.id() == ID_bv || src_type.id() == ID_bv))
+    {
+      dest = src;
+      return false;
+    }
     else if(dest_type.id() == ID_struct || dest_type.id() == ID_struct_tag)
     {
       const struct_typet &dest_struct =

--- a/src/solvers/smt2/smt2_conv.cpp
+++ b/src/solvers/smt2/smt2_conv.cpp
@@ -3363,6 +3363,17 @@ void smt2_convt::convert_typecast(const typecast_exprt &expr)
       UNEXPECTEDCASE(
         "Unknown typecast " + src_type.id_string() + " -> rational");
   }
+  else if(dest_type.id() == ID_union || dest_type.id() == ID_union_tag)
+  {
+    // A union is represented as a bit-vector of its (maximum member) width,
+    // just like the source bit-vector. Reinterpreting the bits as the union
+    // is therefore the identity at this level; this is the inverse of the
+    // union-to-bit-vector flattening handled above.
+    INVARIANT(
+      boolbv_width(src_type) == boolbv_width(dest_type),
+      "bit vector width of source and destination type shall be equal");
+    convert_expr(src); // nothing else to do!
+  }
   else
     UNEXPECTEDCASE(
       "TODO typecast8 "+src_type.id_string()+" -> "+dest_type.id_string());

--- a/src/solvers/smt2_incremental/convert_expr_to_smt.cpp
+++ b/src/solvers/smt2_incremental/convert_expr_to_smt.cpp
@@ -177,6 +177,12 @@ extension_for_type(const typet &type)
     return smt_bit_vector_theoryt::zero_extend;
   if(can_cast_type<pointer_typet>(type))
     return smt_bit_vector_theoryt::zero_extend;
+  if(const auto bit_field = type_try_dynamic_cast<c_bit_field_typet>(type))
+  {
+    // A C bit-field extends like its underlying integer type (i.e. sign-extend
+    // for a signed underlying type, zero-extend otherwise).
+    return extension_for_type(bit_field->underlying_type());
+  }
   UNREACHABLE;
 }
 
@@ -360,6 +366,42 @@ static smt_termt convert_expr_to_smt(const constant_exprt &constant_literal)
   return *converter.result;
 }
 
+/// Convert a single operand of a \ref concatenation_exprt to a bit-vector term.
+/// Bit-vector operands are passed through unchanged. An operand that is an
+/// array of bit-vectors (as produced, for example, by the byte-/bit-level
+/// encoding of unions) is flattened into a bit-vector by concatenating its
+/// elements, with the lowest-indexed element occupying the least-significant
+/// bits. This matches the flattening performed by \ref boolbvt.
+static smt_termt concatenation_operand_to_bit_vector(
+  const exprt &operand,
+  const sub_expression_mapt &converted)
+{
+  const smt_termt &operand_term = converted.at(operand);
+  if(can_cast_type<bitvector_typet>(operand.type()))
+    return operand_term;
+  const auto &array_type = to_array_type(operand.type());
+  const auto size = numeric_cast<std::size_t>(array_type.size());
+  INVARIANT(
+    size && *size != 0,
+    "concatenation over an array requires a constant, non-zero size");
+  const auto array_sort = operand_term.get_sort().cast<smt_array_sortt>();
+  INVARIANT(array_sort, "array-typed operand must have an array sort");
+  const auto index_sort = array_sort->index_sort().cast<smt_bit_vector_sortt>();
+  INVARIANT(index_sort, "array index sort must be a bit-vector sort");
+  const std::size_t index_width = index_sort->bit_width();
+  const auto select_element = [&](const std::size_t index)
+  {
+    return smt_array_theoryt::select(
+      operand_term, smt_bit_vector_constant_termt{index, index_width});
+  };
+  // Concatenate elements most-significant (highest index) first, so that
+  // element 0 ends up in the least-significant bits.
+  smt_termt result = select_element(*size - 1);
+  for(std::size_t index = *size - 1; index != 0; --index)
+    result = smt_bit_vector_theoryt::concat(result, select_element(index - 1));
+  return result;
+}
+
 static smt_termt convert_expr_to_smt(
   const concatenation_exprt &concatenation,
   const sub_expression_mapt &converted)
@@ -368,6 +410,32 @@ static smt_termt convert_expr_to_smt(
   {
     return convert_multiary_operator_to_terms(
       concatenation, converted, smt_bit_vector_theoryt::concat);
+  }
+  // The byte-/bit-level encoding of unions can concatenate bit-vector operands
+  // with arrays of bit-vectors; flatten any such array operands.
+  const auto is_bit_vector_or_array_thereof = [](const exprt &operand)
+  {
+    if(can_cast_type<bitvector_typet>(operand.type()))
+      return true;
+    const auto array_type = type_try_dynamic_cast<array_typet>(operand.type());
+    return array_type &&
+           can_cast_type<bitvector_typet>(array_type->element_type());
+  };
+  if(std::all_of(
+       concatenation.operands().begin(),
+       concatenation.operands().end(),
+       is_bit_vector_or_array_thereof))
+  {
+    PRECONDITION(!concatenation.operands().empty());
+    std::optional<smt_termt> result;
+    for(const auto &operand : concatenation.operands())
+    {
+      smt_termt operand_term =
+        concatenation_operand_to_bit_vector(operand, converted);
+      result = result ? smt_bit_vector_theoryt::concat(*result, operand_term)
+                      : std::move(operand_term);
+    }
+    return *result;
   }
   UNIMPLEMENTED_FEATURE(
     "Generation of SMT formula for concatenation expression: " +
@@ -1130,6 +1198,40 @@ static smt_termt convert_expr_to_smt(
 }
 
 static smt_termt convert_expr_to_smt(
+  const update_bits_exprt &update_bits,
+  const sub_expression_mapt &converted)
+{
+  // Replace the bits of `src` starting at the (least-significant) bit offset
+  // `index` with `new_value`, leaving the surrounding bits intact. The result
+  // is rebuilt by concatenating, from most- to least-significant: the unchanged
+  // high bits, the new value, and the unchanged low bits.
+  const smt_termt &src = converted.at(update_bits.src());
+  const smt_termt &new_value = converted.at(update_bits.new_value());
+  const auto src_sort = src.get_sort().cast<smt_bit_vector_sortt>();
+  const auto value_sort = new_value.get_sort().cast<smt_bit_vector_sortt>();
+  INVARIANT(
+    src_sort && value_sort,
+    "update_bits is expected to operate on bit-vector terms.");
+  const std::size_t src_width = src_sort->bit_width();
+  const std::size_t value_width = value_sort->bit_width();
+  const auto index = numeric_cast<std::size_t>(update_bits.index());
+  INVARIANT(index, "update_bits is expected to have a constant bit index.");
+  INVARIANT(
+    *index + value_width <= src_width,
+    "update_bits range must lie within the source bit-vector.");
+  std::optional<smt_termt> result;
+  if(*index + value_width < src_width)
+    result =
+      smt_bit_vector_theoryt::extract(src_width - 1, *index + value_width)(src);
+  result =
+    result ? smt_bit_vector_theoryt::concat(*result, new_value) : new_value;
+  if(*index != 0)
+    result = smt_bit_vector_theoryt::concat(
+      *result, smt_bit_vector_theoryt::extract(*index - 1, 0)(src));
+  return *result;
+}
+
+static smt_termt convert_expr_to_smt(
   const replication_exprt &replication,
   const sub_expression_mapt &converted)
 {
@@ -1728,6 +1830,10 @@ static smt_termt dispatch_expr_to_smt_conversion(
   if(const auto extract_bits = expr_try_dynamic_cast<extractbits_exprt>(expr))
   {
     return convert_expr_to_smt(*extract_bits, converted);
+  }
+  if(const auto update_bits = expr_try_dynamic_cast<update_bits_exprt>(expr))
+  {
+    return convert_expr_to_smt(*update_bits, converted);
   }
   if(const auto replication = expr_try_dynamic_cast<replication_exprt>(expr))
   {

--- a/src/util/format_type.cpp
+++ b/src/util/format_type.cpp
@@ -123,6 +123,8 @@ std::ostream &format_rec(std::ostream &os, const typet &type)
     os << u8" \u2192 "; // → -- we don't use ⟶  since that doesn't render well
     return os << format(mathematical_function.codomain());
   }
+  else if(id == ID_c_bit_field)
+    return os << "c_bit_field[" << to_c_bit_field_type(type).get_width() << ']';
   else
     return os << id;
 }


### PR DESCRIPTION
Do not use byte_extract to extract members that aren't multiples of bytes. Instead, use extractbits in that case.

Issue was found by CSmith (test generated with random seed 1692379469), regression test generated via C-Reduce.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
