### PR TITLE
Fix `va_list` types for `__CPROVER_OBJECT_SIZE` in ARM64 Linux

### DIFF
--- a/src/ansi-c/library/stdio.c
+++ b/src/ansi-c/library/stdio.c
@@ -1047,7 +1047,7 @@ __CPROVER_HIDE:;
 
   (void)*format;
   while((__CPROVER_size_t)__CPROVER_POINTER_OFFSET(*(void **)&arg) <
-        __CPROVER_OBJECT_SIZE(arg))
+        __CPROVER_OBJECT_SIZE(*(void **)&arg))
   {
     void *a = va_arg(arg, void *);
     __CPROVER_havoc_object(a);
@@ -1210,7 +1210,7 @@ __CPROVER_HIDE:;
   (void)*s;
   (void)*format;
   while((__CPROVER_size_t)__CPROVER_POINTER_OFFSET(*(void **)&arg) <
-        __CPROVER_OBJECT_SIZE(arg))
+        __CPROVER_OBJECT_SIZE(*(void **)&arg))
   {
     void *a = va_arg(arg, void *);
     __CPROVER_havoc_object(a);


### PR DESCRIPTION
<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

--->
In a nutshell, this is like #7521 but for `__CPROVER_OBJECT_SIZE`.
#7862 shows the compilation error I'm getting unless I apply the changes in this PR.

Fixes #7862

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
