### PR TITLE
Shadow Memory: Refactoring, enabling tests and minor doxygen improvements.

### DIFF
--- a/regression/cbmc-shadow-memory/char1/test.desc
+++ b/regression/cbmc-shadow-memory/char1/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.c
 
 ^EXIT=0$

--- a/regression/cbmc-shadow-memory/constchar-pointers1/test.desc
+++ b/regression/cbmc-shadow-memory/constchar-pointers1/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.c
 --unwind 11
 ^EXIT=0$

--- a/regression/cbmc-shadow-memory/linked-list1/test.desc
+++ b/regression/cbmc-shadow-memory/linked-list1/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.c
 
 ^EXIT=0$

--- a/regression/cbmc-shadow-memory/linked-list2/test.desc
+++ b/regression/cbmc-shadow-memory/linked-list2/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.c
 
 ^EXIT=0$

--- a/regression/cbmc-shadow-memory/maybe-null1/test.desc
+++ b/regression/cbmc-shadow-memory/maybe-null1/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.c
 
 ^EXIT=0$

--- a/regression/cbmc-shadow-memory/nondet-size-arrays1/main.c
+++ b/regression/cbmc-shadow-memory/nondet-size-arrays1/main.c
@@ -1,6 +1,10 @@
 #include <assert.h>
 #include <stdlib.h>
 
+#ifdef _WIN32
+void *alloca(size_t alloca_size);
+#endif
+
 int main()
 {
   __CPROVER_field_decl_local("field1", (char)0);

--- a/regression/cbmc-shadow-memory/nondet-size-arrays1/test.desc
+++ b/regression/cbmc-shadow-memory/nondet-size-arrays1/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.c
 
 ^EXIT=0$

--- a/regression/cbmc-shadow-memory/struct-set1/test.desc
+++ b/regression/cbmc-shadow-memory/struct-set1/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.c
 
 ^EXIT=0$

--- a/regression/cbmc-shadow-memory/taint-example1/test.desc
+++ b/regression/cbmc-shadow-memory/taint-example1/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.c
 --unwind 15
 ^EXIT=0$

--- a/regression/cbmc-shadow-memory/union-get-max1/test.desc
+++ b/regression/cbmc-shadow-memory/union-get-max1/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.c
 
 ^EXIT=0$

--- a/regression/cbmc-shadow-memory/union-get-or1/test.desc
+++ b/regression/cbmc-shadow-memory/union-get-or1/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.c
 
 ^EXIT=0$

--- a/regression/cbmc-shadow-memory/union-set1/test.desc
+++ b/regression/cbmc-shadow-memory/union-set1/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.c
 
 ^EXIT=0$

--- a/src/goto-symex/shadow_memory_util.h
+++ b/src/goto-symex/shadow_memory_util.h
@@ -37,10 +37,11 @@ irep_idt extract_field_name(const exprt &string_expr);
 /// \param type The followed type of expr.
 void clean_pointer_expr(exprt &expr, const typet &type);
 
-// TODO: Daxygen
+/// Converts a given expression into a dereference_exprt.
 exprt deref_expr(const exprt &expr);
 
-// TODO: DOxYGEN
+/// Logs setting a value to a given shadow field. Mainly for use for
+/// debugging purposes.
 void log_set_field(
   const namespacet &ns,
   const messaget &log,
@@ -48,20 +49,22 @@ void log_set_field(
   const exprt &expr,
   const exprt &value);
 
-// TODO: doxygen
+/// Logs setting a value to a given shadow field. Mainly for use for
+/// debugging purposes.
 void log_get_field(
   const namespacet &ns,
   const messaget &log,
   const irep_idt &field_name,
   const exprt &expr);
 
-// TODO: doxygen
+/// Logs the retrieval of the value associated with a given shadow
+/// memory field. Mainly for use for debugging purposes. Dual to log_get_field.
 void log_value_set(
   const namespacet &ns,
   const messaget &log,
   const std::vector<exprt> &value_set);
 
-// TODO: doxygen
+/// Log a match between a value in the value set of a given expression, and
 void log_value_set_match(
   const namespacet &ns,
   const messaget &log,

--- a/src/pointer-analysis/value_set_dereference.cpp
+++ b/src/pointer-analysis/value_set_dereference.cpp
@@ -17,6 +17,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <util/arith_tools.h>
 #include <util/byte_operators.h>
+#include <util/c_types.h>
 #include <util/config.h>
 #include <util/cprover_prefix.h>
 #include <util/expr_iterator.h>
@@ -661,8 +662,21 @@ value_set_dereferencet::valuet value_set_dereferencet::build_reference_to(
     result.pointer = typecast_exprt::conditional_cast(
       address_of_exprt{skip_typecast(o.root_object())}, pointer_type);
 
-    if(!memory_model(result.value, dereference_type, offset, ns))
+    if(memory_model(result.value, dereference_type, offset, ns))
+    {
+      // set pointer correctly
+      result.pointer = typecast_exprt::conditional_cast(
+        plus_exprt(
+          typecast_exprt(
+            result.pointer,
+            pointer_typet(char_type(), pointer_type.get_width())),
+          offset),
+        pointer_type);
+    }
+    else
+    {
       return {}; // give up, no way that this is ok
+    }
 
     return result;
   }


### PR DESCRIPTION
The second part of our work on the `set_field`, this is enabling some tests that are now passing after our bug fixes, refactoring code to use a more modern style at places, and adding some doxygen documentation for some of the functions.

This is really just a checkin of our current work in progress before we move forward with more tests && refactors.

Work done with @esteffin 

