### PR TITLE
Add missing include of `<ctime>`

### DIFF
--- a/src/goto-checker/symex_coverage.cpp
+++ b/src/goto-checker/symex_coverage.cpp
@@ -24,6 +24,7 @@ Date: March 2016
 #include <linking/static_lifetime_init.h>
 
 #include <chrono> // IWYU pragma: keep
+#include <ctime>  // IWYU pragma: keep - For std::time_t
 #include <fstream> // IWYU pragma: keep
 #include <iostream>
 


### PR DESCRIPTION
The type `std::time_t` is used in [src/goto-checker/symex_coverage.cpp](https://github.com/diffblue/cbmc/compare/develop...thomasspriggs:tas/ctime_fix?expand=1#diff-efabcf1309f2f6a49635f9dcf98aa997a87e44cd712179d451b4558f44131bbc). `std::time_t` is defined in `<ctime>`, but was not previously included. This caused build failures locally, when building with Visual Studio Community 2019 Version 16.7.4.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
