### PR TITLE
Fix `alloca` related INVARIANT violation on Windows

### DIFF
--- a/regression/cbmc-library/alloca_declaration/missing_parameters.c
+++ b/regression/cbmc-library/alloca_declaration/missing_parameters.c
@@ -1,0 +1,13 @@
+#include <assert.h>
+#include <stddef.h>
+
+void *alloca();
+
+int main()
+{
+  int n;
+  __CPROVER_assume(5 <= n && n < 10);
+  int *c = alloca();
+  assert(c);
+  return 0;
+}

--- a/regression/cbmc-library/alloca_declaration/missing_parameters.desc
+++ b/regression/cbmc-library/alloca_declaration/missing_parameters.desc
@@ -1,0 +1,11 @@
+CORE
+missing_parameters.c
+
+file missing_parameters\.c line 10 function main: 'alloca' function called, but 'alloca' has not been declared with expected single 'size_t' parameter\.
+^EXIT=6$
+^SIGNAL=0$
+--
+^warning: ignoring
+--
+This is a test for C front end to confirm an appropriate error message is
+generated if `alloca` is called when it is declared without parameters.

--- a/regression/cbmc-library/alloca_declaration/too_many_parameters.c
+++ b/regression/cbmc-library/alloca_declaration/too_many_parameters.c
@@ -1,0 +1,13 @@
+#include <assert.h>
+#include <stddef.h>
+
+void *alloca(size_t a, size_t b);
+
+int main()
+{
+  int n;
+  __CPROVER_assume(5 <= n && n < 10);
+  int *c = alloca(n * sizeof(int), 42);
+  assert(c);
+  return 0;
+}

--- a/regression/cbmc-library/alloca_declaration/too_many_parameters.desc
+++ b/regression/cbmc-library/alloca_declaration/too_many_parameters.desc
@@ -1,0 +1,11 @@
+CORE
+too_many_parameters.c
+
+file too_many_parameters\.c line 10 function main: 'alloca' function called, but 'alloca' has not been declared with expected single 'size_t' parameter\.
+^EXIT=6$
+^SIGNAL=0$
+--
+^warning: ignoring
+--
+This is a test for C front end to confirm an appropriate error message is
+generated if `alloca` is called when it is declared with too many parameters.

--- a/regression/cbmc-library/alloca_declaration/undeclared.c
+++ b/regression/cbmc-library/alloca_declaration/undeclared.c
@@ -1,0 +1,11 @@
+#include <assert.h>
+#include <stddef.h>
+
+int main()
+{
+  int n;
+  __CPROVER_assume(5 <= n && n < 10);
+  int *c = alloca(n * sizeof(int));
+  assert(c);
+  return 0;
+}

--- a/regression/cbmc-library/alloca_declaration/undeclared.desc
+++ b/regression/cbmc-library/alloca_declaration/undeclared.desc
@@ -1,0 +1,11 @@
+CORE
+undeclared.c
+
+file undeclared\.c line 8 function main: 'alloca' function called, but 'alloca' has not been declared with expected 'void \*' return type\.
+^EXIT=6$
+^SIGNAL=0$
+--
+^warning: ignoring
+--
+This is a test for C front end to confirm an appropriate error message is
+generated if `alloca` is called when it is not declared.

--- a/regression/cbmc-library/alloca_declaration/valid_declaration.c
+++ b/regression/cbmc-library/alloca_declaration/valid_declaration.c
@@ -1,0 +1,13 @@
+#include <assert.h>
+#include <stddef.h>
+
+void *alloca(size_t alloca_size);
+
+int main()
+{
+  int n;
+  __CPROVER_assume(5 <= n && n < 10);
+  int *c = alloca(n * sizeof(int));
+  assert(c);
+  return 0;
+}

--- a/regression/cbmc-library/alloca_declaration/valid_declaration.desc
+++ b/regression/cbmc-library/alloca_declaration/valid_declaration.desc
@@ -1,0 +1,11 @@
+CORE
+valid_declaration.c
+
+^VERIFICATION SUCCESSFUL
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--
+This is a test for C front end to confirm that if `alloca` is declared as
+expected then no error is generated.

--- a/regression/cbmc-library/alloca_declaration/wrong_parameter_type.c
+++ b/regression/cbmc-library/alloca_declaration/wrong_parameter_type.c
@@ -1,0 +1,13 @@
+#include <assert.h>
+#include <stddef.h>
+
+void *alloca(char);
+
+int main()
+{
+  int n;
+  __CPROVER_assume(5 <= n && n < 10);
+  int *c = alloca(n * sizeof(int));
+  assert(c);
+  return 0;
+}

--- a/regression/cbmc-library/alloca_declaration/wrong_parameter_type.desc
+++ b/regression/cbmc-library/alloca_declaration/wrong_parameter_type.desc
@@ -1,0 +1,11 @@
+CORE
+wrong_parameter_type.c
+
+file wrong_parameter_type\.c line 10 function main: 'alloca' function called, but 'alloca' has not been declared with expected single 'size_t' parameter\.
+^EXIT=6$
+^SIGNAL=0$
+--
+^warning: ignoring
+--
+This is a test for C front end to confirm an appropriate error message is
+generated if `alloca` is called when it is declared with too many parameters.

--- a/regression/cbmc-library/alloca_declaration/wrong_return_type.c
+++ b/regression/cbmc-library/alloca_declaration/wrong_return_type.c
@@ -1,0 +1,13 @@
+#include <assert.h>
+#include <stddef.h>
+
+char alloca(size_t alloca_size);
+
+int main()
+{
+  int n;
+  __CPROVER_assume(5 <= n && n < 10);
+  int *c = alloca(n * sizeof(int));
+  assert(c);
+  return 0;
+}

--- a/regression/cbmc-library/alloca_declaration/wrong_return_type.desc
+++ b/regression/cbmc-library/alloca_declaration/wrong_return_type.desc
@@ -1,0 +1,12 @@
+CORE
+wrong_return_type.c
+
+file wrong_return_type\.c line 10 function main: 'alloca' function called, but 'alloca' has not been declared with expected 'void \*' return type\.
+^EXIT=6$
+^SIGNAL=0$
+--
+^warning: ignoring
+--
+This is a test for C front end to confirm an appropriate error message is
+generated if `alloca` is called when it is declared with a different return
+type from the type expected.

--- a/src/goto-programs/builtin_functions.cpp
+++ b/src/goto-programs/builtin_functions.cpp
@@ -704,19 +704,18 @@ void goto_convertt::do_alloca(
   const irep_idt &mode)
 {
   const source_locationt &source_location = function.source_location();
+  const auto alloca_type = to_code_type(function.type());
+
   exprt new_lhs = lhs;
 
   // make sure we have a left-hand side to track the allocation even when the
   // original program did not
   if(lhs.is_nil())
   {
-    new_lhs = new_tmp_symbol(
-                to_code_type(function.type()).return_type(),
-                "alloca",
-                dest,
-                source_location,
-                mode)
-                .symbol_expr();
+    new_lhs =
+      new_tmp_symbol(
+        alloca_type.return_type(), "alloca", dest, source_location, mode)
+        .symbol_expr();
   }
 
   // do the actual function call
@@ -740,7 +739,7 @@ void goto_convertt::do_alloca(
   // NULL
   symbol_exprt this_alloca_ptr =
     get_fresh_aux_symbol(
-      to_code_type(function.type()).return_type(),
+      alloca_type.return_type(),
       id2string(function.source_location().get_function()),
       "tmp_alloca",
       source_location,

--- a/src/goto-programs/builtin_functions.cpp
+++ b/src/goto-programs/builtin_functions.cpp
@@ -706,6 +706,23 @@ void goto_convertt::do_alloca(
   const source_locationt &source_location = function.source_location();
   const auto alloca_type = to_code_type(function.type());
 
+  if(alloca_type.return_type() != pointer_type(void_type()))
+  {
+    error().source_location = source_location;
+    error() << "'alloca' function called, but 'alloca' has not been declared "
+            << "with expected 'void *' return type." << eom;
+    throw 0;
+  }
+  if(
+    alloca_type.parameters().size() != 1 ||
+    alloca_type.parameters()[0].type() != size_type())
+  {
+    error().source_location = source_location;
+    error() << "'alloca' function called, but 'alloca' has not been declared "
+            << "with expected single 'size_t' parameter." << eom;
+    throw 0;
+  }
+
   exprt new_lhs = lhs;
 
   // make sure we have a left-hand side to track the allocation even when the


### PR DESCRIPTION
This PR fixes issue https://github.com/diffblue/cbmc/issues/7869 with `alloca` on Windows.
<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
