### PR TITLE
Fix shadow memory trace generation

### DIFF
--- a/regression/cbmc-shadow-memory/trace1/test.desc
+++ b/regression/cbmc-shadow-memory/trace1/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.c
 --stop-on-fail --unwind 5
 ^EXIT=10$

--- a/src/goto-programs/remove_returns.cpp
+++ b/src/goto-programs/remove_returns.cpp
@@ -17,8 +17,9 @@ Date:   September 2009
 #include <util/std_expr.h>
 #include <util/suffix.h>
 
-#include "goto_model.h"
+#include <goto-symex/shadow_memory.h>
 
+#include "goto_model.h"
 #include "remove_skip.h"
 
 #define RETURN_VALUE_SUFFIX "#return_value"
@@ -225,7 +226,10 @@ void remove_returnst::operator()(goto_functionst &goto_functions)
         findit != goto_functions.function_map.end(),
         "called function `" + id2string(function_id) +
           "' should have an entry in the function map");
-      return !findit->second.body_available();
+      return !findit->second.body_available() &&
+             function_id != CPROVER_PREFIX SHADOW_MEMORY_FIELD_DECL &&
+             function_id != CPROVER_PREFIX SHADOW_MEMORY_GET_FIELD &&
+             function_id != CPROVER_PREFIX SHADOW_MEMORY_SET_FIELD;
     };
 
     replace_returns(gf_entry.first, gf_entry.second);

--- a/src/goto-symex/shadow_memory.h
+++ b/src/goto-symex/shadow_memory.h
@@ -23,6 +23,7 @@ Author: Peter Schrammel
 #define SHADOW_MEMORY_LOCAL_SCOPE "_local"
 #define SHADOW_MEMORY_GET_FIELD "get_field"
 #define SHADOW_MEMORY_SET_FIELD "set_field"
+#define SHADOW_MEMORY_SYMBOL_PREFIX "__SM"
 
 class code_function_callt;
 class abstract_goto_modelt;

--- a/src/goto-symex/symex_assign.cpp
+++ b/src/goto-symex/symex_assign.cpp
@@ -228,7 +228,9 @@ void symex_assignt::assign_non_struct_symbol(
   state.record_events.pop();
 
   auto current_assignment_type =
-    ns.lookup(l2_lhs.get_object_name()).is_auxiliary
+    ns.lookup(l2_lhs.get_object_name()).is_auxiliary &&
+        id2string(l2_lhs.get_object_name()).find(SHADOW_MEMORY_SYMBOL_PREFIX) !=
+          std::string::npos
       ? symex_targett::assignment_typet::HIDDEN
       : assignment_type;
 


### PR DESCRIPTION
This PR fixes shadow memory trace generation and re-enables its corresponding regression test.

It also port an improvement in `remove_returns` to better detect shadow memory functions.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
