### PR TITLE
Fix problem on array size L2 renaming

### DIFF
--- a/regression/cbmc-shadow-memory/getenv1/test.desc
+++ b/regression/cbmc-shadow-memory/getenv1/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.c
 
 ^EXIT=0$

--- a/src/goto-symex/goto_symex_state.cpp
+++ b/src/goto-symex/goto_symex_state.cpp
@@ -280,14 +280,23 @@ goto_symex_statet::rename(exprt expr, const namespacet &ns)
       expr.type() = to_with_expr(expr).old().type();
     }
     INVARIANT_WITH_DIAGNOSTICS(
-      (expr.id() != ID_with ||
-       c_expr.type() == to_with_expr(c_expr).old().type()) &&
-        (expr.id() != ID_if ||
-         (c_expr.type() == to_if_expr(c_expr).true_case().type() &&
-          c_expr.type() == to_if_expr(c_expr).false_case().type())),
-      "Type of renamed expr should be the same as operands for with_exprt and "
-      "if_exprt",
-      irep_pretty_diagnosticst{expr});
+      expr.id() != ID_with ||
+        c_expr.type() == to_with_expr(c_expr).old().type(),
+      "Type of renamed expr should be the same as operands for with_exprt",
+      c_expr.type().pretty(),
+      to_with_expr(c_expr).old().type().pretty());
+    INVARIANT_WITH_DIAGNOSTICS(
+      expr.id() != ID_if ||
+        c_expr.type() == to_if_expr(c_expr).true_case().type(),
+      "Type of renamed expr should be the same as operands for if_exprt",
+      c_expr.type().pretty(),
+      to_if_expr(c_expr).true_case().type().pretty());
+    INVARIANT_WITH_DIAGNOSTICS(
+      expr.id() != ID_if ||
+        c_expr.type() == to_if_expr(c_expr).false_case().type(),
+      "Type of renamed expr should be the same as operands for if_exprt",
+      c_expr.type().pretty(),
+      to_if_expr(c_expr).false_case().type().pretty());
 
     if(level == L2)
       expr = field_sensitivity.apply(ns, *this, std::move(expr), false);

--- a/src/goto-symex/goto_symex_state.cpp
+++ b/src/goto-symex/goto_symex_state.cpp
@@ -263,6 +263,22 @@ goto_symex_statet::rename(exprt expr, const namespacet &ns)
       *it = rename<level>(std::move(*it), ns).get();
 
     const exprt &c_expr = as_const(expr);
+
+    // It may happen that the `old` subexpression of a `with_exprt` expression
+    // is propagated with a value that has an array type with a size that is a
+    // symbol with an L2 index that is different. In this case the type of the
+    // `with_exprt` will not match with the type of the `old` subexpression
+    // anymore.
+    // To address this issue we re-canonicalize the `with_exprt` by propagating
+    // the type of the `old` subexpression to the type of the `with_exprt`.
+    const auto *c_with_expr = expr_try_dynamic_cast<with_exprt>(c_expr);
+    if(
+      c_with_expr && can_cast_type<array_typet>(c_with_expr->type()) &&
+      can_cast_type<array_typet>(c_with_expr->old().type()) &&
+      c_with_expr->type() != c_with_expr->old().type())
+    {
+      expr.type() = to_with_expr(expr).old().type();
+    }
     INVARIANT_WITH_DIAGNOSTICS(
       (expr.id() != ID_with ||
        c_expr.type() == to_with_expr(c_expr).old().type()) &&


### PR DESCRIPTION
Pull request adding the hack to fix array size L2 problem.

It also re-enable the failing regression test that is now passing.

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
