### PR TITLE
Improvements to duplicate_per_byte to simplify the input value

### DIFF
--- a/src/util/expr_initializer.h
+++ b/src/util/expr_initializer.h
@@ -33,6 +33,9 @@ optionalt<exprt> expr_initializer(
   const namespacet &ns,
   const exprt &init_byte_expr);
 
-exprt duplicate_per_byte(const exprt &init_byte_expr, const typet &output_type);
+exprt duplicate_per_byte(
+  const exprt &init_byte_expr,
+  const typet &output_type,
+  const namespacet &ns);
 
 #endif // CPROVER_UTIL_EXPR_INITIALIZER_H


### PR DESCRIPTION
The function `duplicate_per_byte` contains an efficient implementation when `init_expr` is a constant.

However this feature is never used as the shadow memory module almost always wraps `init_expr` with a typecast to the type of the shadow memory.
    
This PR applies a simplification step in `duplicate_per_byte`, calling `simplify_expr`, so that the casts may be removed and the more efficient implementation will be used.

This PR also adds unit tests to make sure the simplification step is performed.

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [x] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
