### PR TITLE
Add function pointer support to incremental SMT decision procedure

### DIFF
--- a/regression/cbmc/Function_Pointer8/test.desc
+++ b/regression/cbmc/Function_Pointer8/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 
 ^EXIT=10$

--- a/unit/solvers/smt2_incremental/convert_expr_to_smt.cpp
+++ b/unit/solvers/smt2_incremental/convert_expr_to_smt.cpp
@@ -1477,28 +1477,31 @@ TEST_CASE(
   const symbol_exprt bar{"bar", unsignedbv_typet{32}};
   SECTION("Address of symbol")
   {
-    const address_of_exprt address_of_foo{foo};
-    track_expression_objects(address_of_foo, ns, test.object_map);
-    INFO("Expression " + address_of_foo.pretty(1, 0));
-    SECTION("8 object bits")
+    SECTION("bit vector symbol")
     {
-      config.bv_encoding.object_bits = 8;
-      const auto converted = test.convert(address_of_foo);
-      CHECK(test.object_map.at(foo).unique_id == 2);
-      CHECK(
-        converted == smt_bit_vector_theoryt::concat(
-                       smt_bit_vector_constant_termt{2, 8},
-                       smt_bit_vector_constant_termt{0, 56}));
-    }
-    SECTION("16 object bits")
-    {
-      config.bv_encoding.object_bits = 16;
-      const auto converted = test.convert(address_of_foo);
-      CHECK(test.object_map.at(foo).unique_id == 2);
-      CHECK(
-        converted == smt_bit_vector_theoryt::concat(
-                       smt_bit_vector_constant_termt{2, 16},
-                       smt_bit_vector_constant_termt{0, 48}));
+      const address_of_exprt address_of_foo{foo};
+      track_expression_objects(address_of_foo, ns, test.object_map);
+      INFO("Expression " + address_of_foo.pretty(1, 0));
+      SECTION("8 object bits")
+      {
+        config.bv_encoding.object_bits = 8;
+        const auto converted = test.convert(address_of_foo);
+        CHECK(test.object_map.at(foo).unique_id == 2);
+        CHECK(
+          converted == smt_bit_vector_theoryt::concat(
+                         smt_bit_vector_constant_termt{2, 8},
+                         smt_bit_vector_constant_termt{0, 56}));
+      }
+      SECTION("16 object bits")
+      {
+        config.bv_encoding.object_bits = 16;
+        const auto converted = test.convert(address_of_foo);
+        CHECK(test.object_map.at(foo).unique_id == 2);
+        CHECK(
+          converted == smt_bit_vector_theoryt::concat(
+                         smt_bit_vector_constant_termt{2, 16},
+                         smt_bit_vector_constant_termt{0, 48}));
+      }
     }
   }
   SECTION("Invariant checks")

--- a/unit/solvers/smt2_incremental/convert_expr_to_smt.cpp
+++ b/unit/solvers/smt2_incremental/convert_expr_to_smt.cpp
@@ -1503,6 +1503,20 @@ TEST_CASE(
                          smt_bit_vector_constant_termt{0, 48}));
       }
     }
+    SECTION("Code symbol")
+    {
+      config.bv_encoding.object_bits = 8;
+      const symbol_exprt function{"opaque", code_typet{{}, void_type()}};
+      const address_of_exprt function_pointer{function};
+      track_expression_objects(function_pointer, ns, test.object_map);
+      INFO("Expression " + function_pointer.pretty(1, 0));
+      const auto converted = test.convert(function_pointer);
+      CHECK(test.object_map.at(function).unique_id == 2);
+      CHECK(
+        converted == smt_bit_vector_theoryt::concat(
+                       smt_bit_vector_constant_termt{2, 8},
+                       smt_bit_vector_constant_termt{0, 56}));
+    }
   }
   SECTION("Invariant checks")
   {

--- a/unit/solvers/smt2_incremental/smt2_incremental_decision_procedure.cpp
+++ b/unit/solvers/smt2_incremental/smt2_incremental_decision_procedure.cpp
@@ -732,6 +732,30 @@ TEST_CASE(
 }
 
 TEST_CASE(
+  "smt2_incremental_decision_proceduret function pointer support.",
+  "[core][smt2_incremental]")
+{
+  auto test = decision_procedure_test_environmentt::make();
+  const code_typet function_type{{}, void_type()};
+  const symbolt function{"opaque", function_type, ID_C};
+  test.symbol_table.insert(function);
+  const address_of_exprt function_pointer{function.symbol_expr()};
+  const equal_exprt equals_null{
+    function_pointer, null_pointer_exprt{pointer_typet{function_type, 32}}};
+
+  test.sent_commands.clear();
+  test.procedure.set_to(equals_null, false);
+
+  const std::vector<smt_commandt> expected_commands{
+    smt_assert_commandt{smt_core_theoryt::make_not(smt_core_theoryt::equal(
+      smt_bit_vector_theoryt::concat(
+        smt_bit_vector_constant_termt{2, 8},
+        smt_bit_vector_constant_termt{0, 24}),
+      smt_bit_vector_constant_termt{0, 32}))}};
+  REQUIRE(test.sent_commands == expected_commands);
+}
+
+TEST_CASE(
   "smt2_incremental_decision_proceduret multi-ary with_exprt introduces "
   "correct number of indexes.",
   "[core][smt2_incremental]")


### PR DESCRIPTION
Previous to this PR, C examples containing function pointers
would cause INVARIANT violations due to an attempt to convert code
values inside address_of expressions into SMT terms. This commit avoids
performing the conversion. This is a valid approach as the decision
procedure only needs to handle code addresses, not the actual code
itself.


<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
