### PR TITLE
fix for boolbvt::convert_extractbit

### DIFF
--- a/src/solvers/flattening/boolbv_extractbit.cpp
+++ b/src/solvers/flattening/boolbv_extractbit.cpp
@@ -53,8 +53,8 @@ literalt boolbvt::convert_extractbit(const extractbit_exprt &expr)
       std::max(address_bits(src_bv_width), index_bv_width);
     unsignedbv_typet index_type(index_width);
 
-    equal_exprt equality(
-      typecast_exprt::conditional_cast(index, index_type), exprt());
+    const auto index_casted =
+      typecast_exprt::conditional_cast(index, index_type);
 
     if(prop.has_set_to())
     {
@@ -64,7 +64,7 @@ literalt boolbvt::convert_extractbit(const extractbit_exprt &expr)
       // add implications
       for(std::size_t i = 0; i < src_bv.size(); i++)
       {
-        equality.rhs()=from_integer(i, index_type);
+        equal_exprt equality(index_casted, from_integer(i, index_type));
         literalt equal = prop.lequal(literal, src_bv[i]);
         prop.l_set_to_true(prop.limplies(convert(equality), equal));
       }
@@ -77,7 +77,7 @@ literalt boolbvt::convert_extractbit(const extractbit_exprt &expr)
 
       for(std::size_t i = 0; i < src_bv.size(); i++)
       {
-        equality.rhs()=from_integer(i, index_type);
+        equal_exprt equality(index_casted, from_integer(i, index_type));
         literal = prop.lselect(convert(equality), src_bv[i], literal);
       }
 


### PR DESCRIPTION
Since 4ab7663b407563676949bed5e2a16b0fe6a3c0a4 the constructor of `equal_exprt` enforces that the given expressions have the same type.  This fixes an instance in `boolbvt::convert_extractbit` where a temporary and type-inconsistent equality was constructed, which has then triggered the precondition of the `equal_exprt` constructor.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
