### PR TITLE
Update natural_loops.h lowerbound runtime.

### DIFF
--- a/src/analyses/natural_loops.h
+++ b/src/analyses/natural_loops.h
@@ -107,11 +107,7 @@ inline void show_natural_loops(const goto_modelt &goto_model, std::ostream &out)
 template <class P, class T, typename C>
 void natural_loops_templatet<P, T, C>::compute(P &program)
 {
-  cfg_dominators(program);
-
-#ifdef DEBUG
-  cfg_dominators.output(std::cout);
-#endif
+  bool no_cycle_currently = true;
 
   // find back-edges m->n
   for(T m_it=program.instructions.begin();
@@ -124,6 +120,17 @@ void natural_loops_templatet<P, T, C>::compute(P &program)
 
       if(target->location_number<=m_it->location_number)
       {
+        if(no_cycle_currently)
+        {
+          cfg_dominators(program);
+          
+          no_cycle_currently = false;
+          
+        #ifdef DEBUG
+          cfg_dominators.output(std::cout);
+        #endif
+        }
+
         #ifdef DEBUG
         std::cout << "Computing loop for "
                   << m_it->location_number << " -> "


### PR DESCRIPTION
<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->
This pull request reduces the lower bound run time of natural_loops.h by only computing the dominators for the program if a loop is detected. Programs that do not contain back edges do not have their dominators computed.

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- n/a Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->