### PR TITLE
C library: model strftime

### DIFF
--- a/regression/cbmc-library/_strftime-01/main.c
+++ b/regression/cbmc-library/_strftime-01/main.c
@@ -1,0 +1,15 @@
+#include <assert.h>
+#include <time.h>
+
+#ifndef __DARWIN_ALIAS
+size_t _strftime(char *s, size_t max, const char *format, const struct tm *tm);
+#endif
+
+int main()
+{
+  char dest[3];
+  struct tm input;
+  size_t result = _strftime(dest, 3, "%y", &input);
+  assert(result < 3);
+  return 0;
+}

--- a/regression/cbmc-library/_strftime-01/test.desc
+++ b/regression/cbmc-library/_strftime-01/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+--pointer-check --bounds-check
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring

--- a/regression/cbmc-library/strftime-01/main.c
+++ b/regression/cbmc-library/strftime-01/main.c
@@ -1,0 +1,11 @@
+#include <assert.h>
+#include <time.h>
+
+int main()
+{
+  char dest[3];
+  struct tm input;
+  size_t result = strftime(dest, 3, "%y", &input);
+  assert(result < 3);
+  return 0;
+}

--- a/regression/cbmc-library/strftime-01/test.desc
+++ b/regression/cbmc-library/strftime-01/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+--pointer-check --bounds-check
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring

--- a/src/ansi-c/library/time.c
+++ b/src/ansi-c/library/time.c
@@ -218,3 +218,50 @@ char *ctime(const time_t *clock)
   return ctime_result;
   #endif
 }
+
+/* FUNCTION: strftime */
+
+#ifndef __CPROVER_TIME_H_INCLUDED
+#  include <time.h>
+#  define __CPROVER_TIME_H_INCLUDED
+#endif
+
+__CPROVER_size_t __VERIFIER_nondet_size_t(void);
+
+__CPROVER_size_t
+strftime(char *s, __CPROVER_size_t max, const char *format, const struct tm *tm)
+{
+  (void)*format;
+  (void)*tm;
+  __CPROVER_havoc_slice(s, max);
+  __CPROVER_size_t length = __VERIFIER_nondet_size_t();
+  if(length >= max)
+    return 0;
+  s[length] = '\0';
+  return length;
+}
+
+/* FUNCTION: _strftime */
+
+#ifndef __CPROVER_TIME_H_INCLUDED
+#  include <time.h>
+#  define __CPROVER_TIME_H_INCLUDED
+#endif
+
+__CPROVER_size_t __VERIFIER_nondet_size_t(void);
+
+__CPROVER_size_t _strftime(
+  char *s,
+  __CPROVER_size_t max,
+  const char *format,
+  const struct tm *tm)
+{
+  (void)*format;
+  (void)*tm;
+  __CPROVER_havoc_slice(s, max);
+  __CPROVER_size_t length = __VERIFIER_nondet_size_t();
+  if(length >= max)
+    return 0;
+  s[length] = '\0';
+  return length;
+}


### PR DESCRIPTION
We set the target character array to non-deterministic values and return values according to the specification: 0 is returned when the formatted output (including a terminating 0 byte) would require more than the available space.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
