### PR TITLE
C library: model and test several __*_chk variants

### DIFF
--- a/regression/cbmc-library/fgets-01/__fgets_chk.desc
+++ b/regression/cbmc-library/fgets-01/__fgets_chk.desc
@@ -1,0 +1,14 @@
+KNOWNBUG
+main.c
+--pointer-check --bounds-check -D_FORTIFY_SOURCE=2 -D__OPTIMIZE__=2 --unwindset fgets:0
+^EXIT=10$
+^SIGNAL=0$
+^VERIFICATION FAILED$
+\[main.assertion.3\] line 16 assertion p\[1\] == 'b': FAILURE
+\*\* 1 of \d+ failed
+--
+^\*\*\*\* WARNING: no body for function __fgets_chk
+^warning: ignoring
+--
+Our asm renaming results in fgets and its alias being one and the same function
+to us, so we end up recursing in glibc's fgets wrapper.

--- a/regression/cbmc-library/fprintf-01/__fprintf_chk.desc
+++ b/regression/cbmc-library/fprintf-01/__fprintf_chk.desc
@@ -1,0 +1,9 @@
+CORE
+main.c
+--pointer-check --bounds-check -D_FORTIFY_SOURCE=2 -D__OPTIMIZE__=2
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^\*\*\*\* WARNING: no body for function __fprintf_chk
+^warning: ignoring

--- a/regression/cbmc-library/fread-01/__fread_chk.desc
+++ b/regression/cbmc-library/fread-01/__fread_chk.desc
@@ -1,0 +1,9 @@
+CORE
+main.c
+--pointer-check --bounds-check -D_FORTIFY_SOURCE=2 -D__OPTIMIZE__=2 --unwindset fread:0
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^\*\*\*\* WARNING: no body for function __fread_chk
+^warning: ignoring

--- a/regression/cbmc-library/fread-01/main.c
+++ b/regression/cbmc-library/fread-01/main.c
@@ -3,7 +3,15 @@
 
 int main()
 {
-  fread();
-  assert(0);
+  FILE *f = fdopen(0, "r");
+  if(!f)
+    return 1;
+
+  char buffer[3];
+  size_t result = fread(buffer, 3, 1, f);
+  assert(result <= 3);
+
+  fclose(f);
+
   return 0;
 }

--- a/regression/cbmc-library/fread-01/test.desc
+++ b/regression/cbmc-library/fread-01/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.c
 --pointer-check --bounds-check
 ^EXIT=0$

--- a/regression/cbmc-library/printf-01/__printf_chk.desc
+++ b/regression/cbmc-library/printf-01/__printf_chk.desc
@@ -1,0 +1,10 @@
+CORE
+main.c
+--pointer-check --bounds-check -D_FORTIFY_SOURCE=2 -D__OPTIMIZE__=2
+^EXIT=10$
+^SIGNAL=0$
+^\*\* 1 of \d+ failed
+^VERIFICATION FAILED$
+--
+^\*\*\*\* WARNING: no body for function __printf_chk
+^warning: ignoring

--- a/regression/cbmc-library/syslog-01/__syslog_chk.desc
+++ b/regression/cbmc-library/syslog-01/__syslog_chk.desc
@@ -1,0 +1,9 @@
+CORE
+main.c
+--pointer-check --bounds-check -D_FORTIFY_SOURCE=2 -D__OPTIMIZE__=2
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^\*\*\*\* WARNING: no body for function __syslog_chk
+^warning: ignoring

--- a/regression/cbmc-library/syslog-01/main.c
+++ b/regression/cbmc-library/syslog-01/main.c
@@ -1,9 +1,13 @@
 #include <assert.h>
-#include <syslog.h>
+#ifndef _WIN32
+#  include <syslog.h>
+#else
+void syslog(int priority, const char *format, ...);
+#endif
 
-int main()
+int main(int argc, char *argv[])
 {
-  syslog();
-  assert(0);
+  int some_priority;
+  syslog(some_priority, "%d\n", argc);
   return 0;
 }

--- a/regression/cbmc-library/syslog-01/test.desc
+++ b/regression/cbmc-library/syslog-01/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.c
 --pointer-check --bounds-check
 ^EXIT=0$

--- a/regression/cbmc-library/vfprintf-01/__vfprintf_chk.desc
+++ b/regression/cbmc-library/vfprintf-01/__vfprintf_chk.desc
@@ -1,0 +1,9 @@
+CORE
+main.c
+--pointer-check --bounds-check -D_FORTIFY_SOURCE=2 -D__OPTIMIZE__=2
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^\*\*\*\* WARNING: no body for function __vfprintf_chk
+^warning: ignoring

--- a/regression/cbmc-library/vfprintf-01/main.c
+++ b/regression/cbmc-library/vfprintf-01/main.c
@@ -1,9 +1,17 @@
-#include <assert.h>
+#include <stdarg.h>
 #include <stdio.h>
+
+int xprintf(const char *format, ...)
+{
+  va_list list;
+  va_start(list, format);
+  int result = vfprintf(stdout, format, list);
+  va_end(list);
+  return result;
+}
 
 int main()
 {
-  vfprintf();
-  assert(0);
+  xprintf("%d\n", 42);
   return 0;
 }

--- a/regression/cbmc-library/vfprintf-01/test.desc
+++ b/regression/cbmc-library/vfprintf-01/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.c
 --pointer-check --bounds-check
 ^EXIT=0$

--- a/src/ansi-c/library/stdio.c
+++ b/src/ansi-c/library/stdio.c
@@ -280,7 +280,7 @@ int __VERIFIER_nondet_int(void);
 
 char *fgets(char *str, int size, FILE *stream)
 {
-  __CPROVER_HIDE:;
+__CPROVER_HIDE:;
   __CPROVER_bool error=__VERIFIER_nondet___CPROVER_bool();
 
   (void)size;
@@ -323,6 +323,63 @@ char *fgets(char *str, int size, FILE *stream)
   return error?0:str;
 }
 
+/* FUNCTION: __fgets_chk */
+
+#ifndef __CPROVER_STDIO_H_INCLUDED
+#  include <stdio.h>
+#  define __CPROVER_STDIO_H_INCLUDED
+#endif
+
+__CPROVER_bool __VERIFIER_nondet___CPROVER_bool(void);
+int __VERIFIER_nondet_int(void);
+
+char *__fgets_chk(char *str, __CPROVER_size_t bufsize, int size, FILE *stream)
+{
+__CPROVER_HIDE:;
+  (void)bufsize;
+  __CPROVER_bool error = __VERIFIER_nondet___CPROVER_bool();
+
+  (void)size;
+  if(stream != stdin)
+  {
+#if !defined(__linux__) || defined(__GLIBC__)
+    (void)*stream;
+#else
+    (void)*(char *)stream;
+#endif
+  }
+
+#ifdef __CPROVER_CUSTOM_BITVECTOR_ANALYSIS
+  __CPROVER_assert(
+    __CPROVER_get_must(stream, "open"), "fgets file must be open");
+#endif
+
+#ifdef __CPROVER_STRING_ABSTRACTION
+  int resulting_size;
+  __CPROVER_assert(
+    __CPROVER_buffer_size(str) >= size, "buffer-overflow in fgets");
+  if(size > 0)
+  {
+    __CPROVER_assume(resulting_size < size);
+    __CPROVER_is_zero_string(str) = !error;
+    __CPROVER_zero_string_length(str) = resulting_size;
+  }
+#else
+  if(size > 0)
+  {
+    int str_length = __VERIFIER_nondet_int();
+    __CPROVER_assume(str_length >= 0 && str_length < size);
+    __CPROVER_precondition(__CPROVER_w_ok(str, size), "fgets buffer writable");
+    char contents_nondet[str_length];
+    __CPROVER_array_replace(str, contents_nondet);
+    if(!error)
+      str[str_length] = '\0';
+  }
+#endif
+
+  return error ? 0 : str;
+}
+
 /* FUNCTION: fread */
 
 #ifndef __CPROVER_STDIO_H_INCLUDED
@@ -335,10 +392,10 @@ size_t __VERIFIER_nondet_size_t(void);
 
 size_t fread(void *ptr, size_t size, size_t nitems, FILE *stream)
 {
-  __CPROVER_HIDE:;
-  size_t nread=__VERIFIER_nondet_size_t();
-  size_t bytes=nread*size;
-  __CPROVER_assume(nread<=nitems);
+__CPROVER_HIDE:;
+  size_t bytes_read = __VERIFIER_nondet_size_t();
+  size_t upper_bound = nitems * size;
+  __CPROVER_assume(bytes_read <= upper_bound);
 
   if(stream != stdin)
   {
@@ -354,12 +411,52 @@ size_t fread(void *ptr, size_t size, size_t nitems, FILE *stream)
                    "fread file must be open");
 #endif
 
-  for(size_t i=0; i<bytes; i++)
+  for(size_t i = 0; i < bytes_read && i < upper_bound; i++)
   {
     ((char *)ptr)[i] = __VERIFIER_nondet_char();
   }
 
-  return nread;
+  return bytes_read / size;
+}
+
+/* FUNCTION: __fread_chk */
+
+#ifndef __CPROVER_STDIO_H_INCLUDED
+#  include <stdio.h>
+#  define __CPROVER_STDIO_H_INCLUDED
+#endif
+
+char __VERIFIER_nondet_char(void);
+size_t __VERIFIER_nondet_size_t(void);
+
+size_t
+__fread_chk(void *ptr, size_t ptrlen, size_t size, size_t nitems, FILE *stream)
+{
+__CPROVER_HIDE:;
+  size_t bytes_read = __VERIFIER_nondet_size_t();
+  size_t upper_bound = nitems * size;
+  __CPROVER_assume(bytes_read <= upper_bound);
+
+  if(stream != stdin)
+  {
+#if !defined(__linux__) || defined(__GLIBC__)
+    (void)*stream;
+#else
+    (void)*(char *)stream;
+#endif
+  }
+
+#ifdef __CPROVER_CUSTOM_BITVECTOR_ANALYSIS
+  __CPROVER_assert(
+    __CPROVER_get_must(stream, "open"), "fread file must be open");
+#endif
+
+  for(size_t i = 0; i < bytes_read && i < upper_bound && i < ptrlen; i++)
+  {
+    ((char *)ptr)[i] = __VERIFIER_nondet_char();
+  }
+
+  return bytes_read / size;
 }
 
 /* FUNCTION: feof */
@@ -1287,6 +1384,32 @@ __CPROVER_HIDE:;
   return result;
 }
 
+/* FUNCTION: __printf_chk */
+
+#ifndef __CPROVER_STDIO_H_INCLUDED
+#  include <stdio.h>
+#  define __CPROVER_STDIO_H_INCLUDED
+#endif
+
+#ifndef __CPROVER_STDARG_H_INCLUDED
+#  include <stdarg.h>
+#  define __CPROVER_STDARG_H_INCLUDED
+#endif
+
+int __VERIFIER_nondet_int(void);
+
+int __printf_chk(int flag, const char *format, ...)
+{
+__CPROVER_HIDE:;
+  (void)flag;
+  int result = __VERIFIER_nondet_int();
+  va_list list;
+  va_start(list, format);
+  __CPROVER_printf(format, list);
+  va_end(list);
+  return result;
+}
+
 /* FUNCTION: fprintf */
 
 #ifndef __CPROVER_STDIO_H_INCLUDED
@@ -1305,6 +1428,29 @@ int fprintf(FILE *stream, const char *restrict format, ...)
   va_list list;
   va_start(list, format);
   int result=vfprintf(stream, format, list);
+  va_end(list);
+  return result;
+}
+
+/* FUNCTION: __fprintf_chk */
+
+#ifndef __CPROVER_STDIO_H_INCLUDED
+#  include <stdio.h>
+#  define __CPROVER_STDIO_H_INCLUDED
+#endif
+
+#ifndef __CPROVER_STDARG_H_INCLUDED
+#  include <stdarg.h>
+#  define __CPROVER_STDARG_H_INCLUDED
+#endif
+
+int __fprintf_chk(FILE *stream, int flag, const char *restrict format, ...)
+{
+__CPROVER_HIDE:;
+  (void)flag;
+  va_list list;
+  va_start(list, format);
+  int result = vfprintf(stream, format, list);
   va_end(list);
   return result;
 }
@@ -1344,6 +1490,51 @@ int vfprintf(FILE *stream, const char *restrict format, va_list arg)
 #ifdef __CPROVER_CUSTOM_BITVECTOR_ANALYSIS
   __CPROVER_assert(__CPROVER_get_must(stream, "open"),
                    "vfprintf file must be open");
+#endif
+
+  return result;
+}
+
+/* FUNCTION: __vfprintf_chk */
+
+#ifndef __CPROVER_STDIO_H_INCLUDED
+#  include <stdio.h>
+#  define __CPROVER_STDIO_H_INCLUDED
+#endif
+
+#ifndef __CPROVER_STDARG_H_INCLUDED
+#  include <stdarg.h>
+#  define __CPROVER_STDARG_H_INCLUDED
+#endif
+
+int __VERIFIER_nondet_int(void);
+
+int __vfprintf_chk(
+  FILE *stream,
+  int flag,
+  const char *restrict format,
+  va_list arg)
+{
+__CPROVER_HIDE:;
+  (void)flag;
+
+  int result = __VERIFIER_nondet_int();
+
+  if(stream != stdout && stream != stderr)
+  {
+#if !defined(__linux__) || defined(__GLIBC__)
+    (void)*stream;
+#else
+    (void)*(char *)stream;
+#endif
+  }
+
+  (void)*format;
+  (void)arg;
+
+#ifdef __CPROVER_CUSTOM_BITVECTOR_ANALYSIS
+  __CPROVER_assert(
+    __CPROVER_get_must(stream, "open"), "vfprintf file must be open");
 #endif
 
   return result;

--- a/src/ansi-c/library/syslog.c
+++ b/src/ansi-c/library/syslog.c
@@ -1,10 +1,5 @@
 /* FUNCTION: openlog */
 
-#ifndef __CPROVER_SYSLOG_H_INCLUDED
-#include <syslog.h>
-#define __CPROVER_SYSLOG_H_INCLUDED
-#endif
-
 void openlog(const char *ident, int option, int facility)
 {
   (void)*ident;
@@ -14,24 +9,23 @@ void openlog(const char *ident, int option, int facility)
 
 /* FUNCTION: closelog */
 
-#ifndef __CPROVER_SYSLOG_H_INCLUDED
-#include <syslog.h>
-#define __CPROVER_SYSLOG_H_INCLUDED
-#endif
-
 void closelog(void)
 {
 }
 
 /* FUNCTION: syslog */
 
-#ifndef __CPROVER_SYSLOG_H_INCLUDED
-#include <syslog.h>
-#define __CPROVER_SYSLOG_H_INCLUDED
-#endif
-
 void syslog(int priority, const char *format, ...)
 {
   (void)priority;
+  (void)*format;
+}
+
+/* FUNCTION: __syslog_chk */
+
+void __syslog_chk(int priority, int flag, const char *format, ...)
+{
+  (void)priority;
+  (void)flag;
   (void)*format;
 }

--- a/src/ansi-c/library_check.sh
+++ b/src/ansi-c/library_check.sh
@@ -49,6 +49,12 @@ perl -p -i -e 's/^__CPROVER_deallocate\n//' __functions # free-01
 perl -p -i -e 's/^__builtin_alloca\n//' __functions # alloca-01
 perl -p -i -e 's/^fclose_cleanup\n//' __functions # fopen
 perl -p -i -e 's/^munmap\n//' __functions # mmap-01
+perl -p -i -e 's/^__fgets_chk\n//' __functions # fgets-01/__fgets_chk.desc
+perl -p -i -e 's/^__fprintf_chk\n//' __functions # fprintf-01/__fprintf_chk.desc
+perl -p -i -e 's/^__fread_chk\n//' __functions # fread-01/__fread_chk.desc
+perl -p -i -e 's/^__printf_chk\n//' __functions # printf-01/__printf_chk.desc
+perl -p -i -e 's/^__syslog_chk\n//' __functions # syslog-01/__syslog_chk.desc
+perl -p -i -e 's/^__vfprintf_chk\n//' __functions # vfprintf-01/__vfprintf_chk.desc
 
 # Some functions are covered by tests in other folders:
 perl -p -i -e 's/^__spawned_thread\n//' __functions # any pthread_create tests


### PR DESCRIPTION
These are the runtime bounds-checked versions of
{fgets,fprintf,fread,printf,syslog,vfprintf} provided by glibc. While at it, also enable the regression tests of {fread,syslog,vfprintf}.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
