### PR TITLE
Enable typechecking of shadow memory primitives

### DIFF
--- a/regression/cbmc-shadow-memory/declarations1/test_bad1.desc
+++ b/regression/cbmc-shadow-memory/declarations1/test_bad1.desc
@@ -3,7 +3,8 @@ bad1.c
 --function bad_declaration1 --verbosity 10
 ^EXIT=6$
 ^SIGNAL=0$
-^A shadow memory field must not be larger than 8 bits.
+^file bad1\.c line 3 function bad_declaration1: __CPROVER_field_decl_local argument 2 must be a byte-sized integer, but \(\(signed int\)0\) has type `signed int`
+^CONVERSION ERROR
 --
 --
 Test that a shadow memory declaration of a too large type is rejected.

--- a/regression/cbmc-shadow-memory/declarations1/test_bad2.desc
+++ b/regression/cbmc-shadow-memory/declarations1/test_bad2.desc
@@ -3,7 +3,8 @@ bad2.c
 --function bad_declaration2 --verbosity 10
 ^EXIT=6$
 ^SIGNAL=0$
-^A shadow memory field must be of a bitvector type.
+^file bad2\.c line 7 function bad_declaration2: __CPROVER_field_decl_global argument 2 must be a byte-sized integer, but \(s\) has type `struct STRUCT`
+^CONVERSION ERROR
 --
 --
 Test that a shadow memory declaration of a non-bitvector type is rejected.

--- a/regression/cbmc-shadow-memory/intrinsics_warnings1/intrinsics_warn.c
+++ b/regression/cbmc-shadow-memory/intrinsics_warnings1/intrinsics_warn.c
@@ -1,0 +1,32 @@
+//
+// Created by Fotis Koutoulakis on 19/09/2023.
+//
+#include <assert.h>
+#include <stdio.h>
+
+struct S
+{
+  int i;
+  int j;
+};
+
+int main()
+{
+  __CPROVER_field_decl_local("uninitialized", (char)0);
+  __CPROVER_field_decl_global("uninitialized-global", (char)0);
+
+  struct S s;
+  char a;
+
+  __CPROVER_set_field(&a, "uninitialized", 1);
+
+  assert(__CPROVER_get_field(&a, "uninitialized") == 1);
+
+  __CPROVER_set_field(&s, "uninitialized", 1);
+
+  assert(__CPROVER_get_field(&s, "uninitialized") == 1);
+  assert(__CPROVER_get_field(&s.i, "uninitialized") == 1);
+  assert(__CPROVER_get_field(&s.j, "uninitialized") == 1);
+
+  return 0;
+}

--- a/regression/cbmc-shadow-memory/intrinsics_warnings1/test.desc
+++ b/regression/cbmc-shadow-memory/intrinsics_warnings1/test.desc
@@ -1,0 +1,16 @@
+CORE
+intrinsics_warn.c
+
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring
+WARNING: no body for function
+file intrinsics_warn.c line \d+ function main: function '__CPROVER_field_decl_global' is not declared
+file intrinsics_warn.c line \d+ function main: function '__CPROVER_field_decl_local' is not declared
+file intrinsics_warn.c line \d+ function main: function '__CPROVER_set_field' is not declared
+file intrinsics_warn.c line \d+ function main: function '__CPROVER_get_field' is not declared
+--
+This test is making sure that we don't get any of the log messages warning
+for the shadow memory intrinsics being undefined after the type check phase.

--- a/regression/cbmc-shadow-memory/intrinsics_warnings2/test.desc
+++ b/regression/cbmc-shadow-memory/intrinsics_warnings2/test.desc
@@ -1,0 +1,18 @@
+CORE
+typechecking_warning.c
+
+^EXIT=6$
+^SIGNAL=0$
+^CONVERSION ERROR$
+file typechecking_warning\.c line \d function main: __CPROVER_field_decl_local argument 2 must be a byte-sized integer, but \(10ul\) has type `unsigned long int`
+--
+^warning: ignoring
+WARNING: no body for function
+file intrinsics_warn.c line \d+ function main: function '__CPROVER_field_decl_global' is not declared
+file intrinsics_warn.c line \d+ function main: function '__CPROVER_field_decl_local' is not declared
+file intrinsics_warn.c line \d+ function main: function '__CPROVER_set_field' is not declared
+file intrinsics_warn.c line \d+ function main: function '__CPROVER_get_field' is not declared
+--
+This test is part of a suite of tests we have for ensuring that the typechecker
+comes up with proper error messages in the case of shadow memory intrinsics
+failing the typechecking phase.

--- a/regression/cbmc-shadow-memory/intrinsics_warnings2/typechecking_warning.c
+++ b/regression/cbmc-shadow-memory/intrinsics_warnings2/typechecking_warning.c
@@ -1,0 +1,9 @@
+//
+// Created by Fotis Koutoulakis on 19/09/2023.
+//
+int main()
+{
+  __CPROVER_field_decl_local("uninitialized", 10ul);
+
+  return 0;
+}

--- a/regression/cbmc-shadow-memory/intrinsics_warnings3/test.desc
+++ b/regression/cbmc-shadow-memory/intrinsics_warnings3/test.desc
@@ -1,0 +1,18 @@
+CORE
+typechecking_warning.c
+
+^EXIT=6$
+^SIGNAL=0$
+^CONVERSION ERROR$
+file typechecking_warning\.c line \d function main: __CPROVER_field_decl_local takes exactly 2 arguments, but 1 were provided
+--
+^warning: ignoring
+WARNING: no body for function
+file intrinsics_warn.c line \d+ function main: function '__CPROVER_field_decl_global' is not declared
+file intrinsics_warn.c line \d+ function main: function '__CPROVER_field_decl_local' is not declared
+file intrinsics_warn.c line \d+ function main: function '__CPROVER_set_field' is not declared
+file intrinsics_warn.c line \d+ function main: function '__CPROVER_get_field' is not declared
+--
+This test is part of a suite of tests we have for ensuring that the typechecker
+comes up with proper error messages in the case of shadow memory intrinsics
+failing the typechecking phase.

--- a/regression/cbmc-shadow-memory/intrinsics_warnings3/typechecking_warning.c
+++ b/regression/cbmc-shadow-memory/intrinsics_warnings3/typechecking_warning.c
@@ -1,0 +1,9 @@
+//
+// Created by Fotis Koutoulakis on 19/09/2023.
+//
+int main()
+{
+  __CPROVER_field_decl_local("uninitialized");
+
+  return 0;
+}

--- a/regression/cbmc-shadow-memory/void-ptr-param-get1/test.desc
+++ b/regression/cbmc-shadow-memory/void-ptr-param-get1/test.desc
@@ -3,6 +3,7 @@ main.c
 
 ^EXIT=6$
 ^SIGNAL=0$
-Shadow memory: cannot get shadow memory via type void\* for f_void_ptr::s
+^file main\.c line 12 function f_void_ptr: __CPROVER_get_field argument 1 must be a non-void pointer, but \(s\) has type `void \*`. Insert a cast to the type that you want to access\.
+CONVERSION ERROR
 --
 ^warning: ignoring

--- a/regression/cbmc-shadow-memory/void-ptr-param-set1/test.desc
+++ b/regression/cbmc-shadow-memory/void-ptr-param-set1/test.desc
@@ -3,6 +3,7 @@ main.c
 
 ^EXIT=6$
 ^SIGNAL=0$
-Shadow memory: cannot set shadow memory via type void\* for f_void_ptr::s
+^file main\.c line 12 function f_void_ptr: __CPROVER_set_field argument 1 must be a non-void pointer, but \(s\) has type `void \*`\. Insert a cast to the type that you want to access\.
+^CONVERSION ERROR
 --
 ^warning: ignoring

--- a/src/ansi-c/Makefile
+++ b/src/ansi-c/Makefile
@@ -23,6 +23,7 @@ SRC = anonymous_member.cpp \
       c_typecheck_code.cpp \
       c_typecheck_expr.cpp \
       c_typecheck_gcc_polymorphic_builtins.cpp \
+      c_typecheck_shadow_memory_builtin.cpp \
       c_typecheck_initializer.cpp \
       c_typecheck_type.cpp \
       c_typecheck_typecast.cpp \

--- a/src/ansi-c/c_typecheck_base.h
+++ b/src/ansi-c/c_typecheck_base.h
@@ -235,6 +235,8 @@ protected:
   virtual code_blockt instantiate_gcc_polymorphic_builtin(
     const irep_idt &identifier,
     const symbol_exprt &function_symbol);
+  virtual optionalt<symbol_exprt>
+  typecheck_shadow_memory_builtin(const side_effect_expr_function_callt &expr);
   virtual exprt
   typecheck_shuffle_vector(const side_effect_expr_function_callt &expr);
   void disallow_subexpr_by_id(

--- a/src/ansi-c/c_typecheck_shadow_memory_builtin.cpp
+++ b/src/ansi-c/c_typecheck_shadow_memory_builtin.cpp
@@ -1,0 +1,251 @@
+//
+// Author: Enrico Steffinlongo for Diffblue Ltd
+//
+
+#include <util/c_types.h>
+#include <util/config.h>
+#include <util/cprover_prefix.h>
+#include <util/expr.h>
+#include <util/string_constant.h>
+
+#include "c_typecheck_base.h"
+#include "expr2c.h"
+
+/// Function to typecheck a shadow memory field_declaration function.
+/// \return a symbol of the shadow memory function
+/// \throws invalid_source_file_exceptiont if the typecheck fails.
+static symbol_exprt typecheck_field_decl(
+  const side_effect_expr_function_callt &expr,
+  const irep_idt &identifier,
+  const namespacet &ns)
+{
+  // Check correct number of arguments
+  if(expr.arguments().size() != 2)
+  {
+    std::ostringstream error_message;
+    error_message << identifier << " takes exactly 2 arguments, but "
+                  << expr.arguments().size() << " were provided";
+    throw invalid_source_file_exceptiont{
+      error_message.str(), expr.source_location()};
+  }
+
+  const auto &arg1 = expr.arguments()[0];
+  if(!can_cast_expr<string_constantt>(arg1))
+  {
+    // Can't declare a shadow memory field that has a name that is not a
+    // constant string
+    std::ostringstream error_message;
+    error_message << identifier
+                  << " argument 1 must be string constant (literal), but ("
+                  << expr2c(arg1, ns) << ") has type `"
+                  << type2c(arg1.type(), ns) << '`';
+    throw invalid_source_file_exceptiont{
+      error_message.str(), expr.source_location()};
+  }
+
+  // The second argument type must be either a boolean or a bitvector of size
+  // less or equal to the size of a char.
+  const auto &arg2 = expr.arguments()[1];
+  const auto &arg2_type = arg2.type();
+  const auto arg2_type_as_bv =
+    type_try_dynamic_cast<bitvector_typet>(arg2_type);
+  if(
+    (!arg2_type_as_bv ||
+     arg2_type_as_bv->get_width() > config.ansi_c.char_width) &&
+    !can_cast_type<bool_typet>(arg2_type))
+  {
+    // Can't declare a shadow memory field with a non-boolean and non bitvector
+    // type or with a bitvector type greater than 8 bit.
+    std::ostringstream error_message;
+    error_message << identifier
+                  << " argument 2 must be a byte-sized integer, but ("
+                  << expr2c(arg2, ns) << ") has type `" << type2c(arg2_type, ns)
+                  << '`';
+    throw invalid_source_file_exceptiont{
+      error_message.str(), expr.source_location()};
+  }
+
+  // The function type is just an ellipsis, otherwise the non-ellipsis arguments
+  // will be typechecked and implicitly casted.
+  code_typet t({}, void_type());
+  t.make_ellipsis();
+
+  // Create the symbol with the right type.
+  symbol_exprt result(identifier, std::move(t));
+  result.add_source_location() = expr.source_location();
+  return result;
+}
+
+/// Function to typecheck a shadow memory get_field function.
+/// \return a symbol of the shadow memory function.
+/// \throws invalid_source_file_exceptiont if the typecheck fails.
+static symbol_exprt typecheck_get_field(
+  const side_effect_expr_function_callt &expr,
+  const irep_idt &identifier,
+  const namespacet &ns)
+{
+  // Check correct number of arguments
+  if(expr.arguments().size() != 2)
+  {
+    std::ostringstream error_message;
+    error_message << identifier << " takes exactly 2 arguments, but "
+                  << expr.arguments().size() << " were provided";
+    throw invalid_source_file_exceptiont{
+      error_message.str(), expr.source_location()};
+  }
+
+  const auto &arg1 = expr.arguments()[0];
+  const auto arg1_type_as_ptr =
+    type_try_dynamic_cast<pointer_typet>(arg1.type());
+  if(
+    !arg1_type_as_ptr || !arg1_type_as_ptr->has_subtype() ||
+    to_type_with_subtype(*arg1_type_as_ptr).subtype() == empty_typet{})
+  {
+    // Can't get the shadow memory value of anything other than a non-void
+    // pointer
+    std::ostringstream error_message;
+    error_message << identifier
+                  << " argument 1 must be a non-void pointer, but ("
+                  << expr2c(arg1, ns) << ") has type `"
+                  << type2c(arg1.type(), ns)
+                  << "`. Insert a cast to the type that you want to access.";
+    throw invalid_source_file_exceptiont{
+      error_message.str(), expr.source_location()};
+  }
+
+  const auto &arg2 = expr.arguments()[1];
+  if(!can_cast_expr<string_constantt>(arg2))
+  {
+    // Can't get value from a shadow memory field that has a name that is
+    // not a constant string
+    std::ostringstream error_message;
+    error_message << identifier
+                  << " argument 2 must be string constant (literal), but ("
+                  << expr2c(arg2, ns) << ") has type `"
+                  << type2c(arg2.type(), ns) << '`';
+    throw invalid_source_file_exceptiont{
+      error_message.str(), expr.source_location()};
+  }
+
+  // The function type is just an ellipsis, otherwise the non-ellipsis arguments
+  // will be typechecked and implicitly casted.
+  // Setting the return type to `signed_int_type` otherwise it was creating
+  // problem with signed-unsigned char comparison. Having `signed_int_type`
+  // seems to fix the issue as it contains more bits for the conversion.
+  code_typet t({}, signed_int_type());
+  t.make_ellipsis();
+
+  // Create the symbol with the right type.
+  symbol_exprt result(identifier, std::move(t));
+  result.add_source_location() = expr.source_location();
+  return result;
+}
+
+/// Function to typecheck a shadow memory set_field function.
+/// \return a symbol of the shadow memory function.
+/// \throws invalid_source_file_exceptiont if the typecheck fails.
+static symbol_exprt typecheck_set_field(
+  const side_effect_expr_function_callt &expr,
+  const irep_idt &identifier,
+  const namespacet &ns)
+{
+  // Check correct number of arguments
+  if(expr.arguments().size() != 3)
+  {
+    std::ostringstream error_message;
+    error_message << identifier << " takes exactly 3 arguments, but "
+                  << expr.arguments().size() << " were provided";
+    throw invalid_source_file_exceptiont{
+      error_message.str(), expr.source_location()};
+  }
+
+  const auto &arg1 = expr.arguments()[0];
+  const auto arg1_type_as_ptr =
+    type_try_dynamic_cast<pointer_typet>(arg1.type());
+  if(
+    !arg1_type_as_ptr || !arg1_type_as_ptr->has_subtype() ||
+    to_type_with_subtype(*arg1_type_as_ptr).subtype() == empty_typet{})
+  {
+    // Can't set the shadow memory value of anything other than a non-void
+    // pointer
+    std::ostringstream error_message;
+    error_message << identifier
+                  << " argument 1 must be a non-void pointer, but ("
+                  << expr2c(arg1, ns) << ") has type `"
+                  << type2c(arg1.type(), ns)
+                  << "`. Insert a cast to the type that you want to access.";
+    throw invalid_source_file_exceptiont{
+      error_message.str(), expr.source_location()};
+  }
+
+  const auto &arg2 = expr.arguments()[1];
+  if(!can_cast_expr<string_constantt>(arg2))
+  {
+    // Can't set value from a shadow memory field that has a name that is
+    // not a constant string
+    std::ostringstream error_message;
+    error_message << identifier
+                  << " argument 2 must be string constant (literal), but ("
+                  << expr2c(arg2, ns) << ") has type `"
+                  << type2c(arg2.type(), ns) << '`';
+    throw invalid_source_file_exceptiont{
+      error_message.str(), expr.source_location()};
+  }
+
+  // The third argument type must be either a boolean or a bitvector.
+  const auto &arg3 = expr.arguments()[2];
+  const auto &arg3_type = arg3.type();
+  if(
+    !can_cast_type<bitvector_typet>(arg3_type) &&
+    !can_cast_type<bool_typet>(arg3_type))
+  {
+    // Can't set the shadow memory value with a non-boolean and non-bitvector
+    // value.
+    std::ostringstream error_message;
+    error_message << identifier
+                  << " argument 3 must be a boolean or of integer value, but ("
+                  << expr2c(arg3, ns) << ") has type `" << type2c(arg3_type, ns)
+                  << '`';
+    throw invalid_source_file_exceptiont{
+      error_message.str(), expr.source_location()};
+  }
+
+  // The function type is just an ellipsis, otherwise the non-ellipsis arguments
+  // will be typechecked and implicitly casted.
+  code_typet t({}, void_type());
+  t.make_ellipsis();
+
+  // Create the symbol with the right type.
+  symbol_exprt result(identifier, std::move(t));
+  result.add_source_location() = expr.source_location();
+  return result;
+}
+
+/// Typecheck the function if it is a shadow_memory builtin and return a symbol
+/// for it. Otherwise return empty.
+optionalt<symbol_exprt> c_typecheck_baset::typecheck_shadow_memory_builtin(
+  const side_effect_expr_function_callt &expr)
+{
+  const exprt &f_op = expr.function();
+  INVARIANT(
+    can_cast_expr<symbol_exprt>(f_op),
+    "expr.function() has to be a symbol_expr");
+  const irep_idt &identifier = to_symbol_expr(f_op).get_identifier();
+
+  if(
+    identifier == CPROVER_PREFIX "field_decl_global" ||
+    identifier == CPROVER_PREFIX "field_decl_local")
+  {
+    return typecheck_field_decl(expr, identifier, *this);
+  }
+  else if(identifier == CPROVER_PREFIX "get_field")
+  {
+    return typecheck_get_field(expr, identifier, *this);
+  }
+  else if(identifier == CPROVER_PREFIX "set_field")
+  {
+    return typecheck_set_field(expr, identifier, *this);
+  }
+  // The function is not a shadow memory builtin, so we return <empty>.
+  return {};
+}

--- a/unit/Makefile
+++ b/unit/Makefile
@@ -51,6 +51,7 @@ SRC += analyses/ai/ai.cpp \
        ansi-c/expr2c.cpp \
        ansi-c/max_malloc_size.cpp \
        ansi-c/type2name.cpp \
+       ansi-c/c_typecheck_base.cpp \
        big-int/big-int.cpp \
        compound_block_locations.cpp \
        get_goto_model_from_c_test.cpp \

--- a/unit/ansi-c/c_typecheck_base.cpp
+++ b/unit/ansi-c/c_typecheck_base.cpp
@@ -1,0 +1,474 @@
+//
+// Author: Enrico Steffinlongo for Diffblue Ltd
+//
+
+#include <util/arith_tools.h>
+#include <util/c_types.h>
+#include <util/config.h>
+#include <util/cprover_prefix.h>
+#include <util/string_constant.h>
+#include <util/symbol_table.h>
+
+#include <ansi-c/c_typecheck_base.h>
+#include <ansi-c/expr2c.h>
+#include <testing-utils/use_catch.h>
+
+class c_typecheck_testt : public c_typecheck_baset
+{
+public:
+  c_typecheck_testt(
+    symbol_table_baset &_symbol_table,
+    const std::string &_module,
+    message_handlert &_message_handler)
+    : c_typecheck_baset(_symbol_table, _module, _message_handler)
+  {
+  }
+
+  void typecheck() override
+  {
+  }
+
+  optionalt<symbol_exprt> test_typecheck_shadow_memory_builtin(
+    const side_effect_expr_function_callt &expr)
+  {
+    return typecheck_shadow_memory_builtin(expr);
+  }
+
+  void test_typecheck_side_effect_function_call(
+    side_effect_expr_function_callt &expr)
+  {
+    typecheck_side_effect_function_call(expr);
+  }
+};
+
+/// Helper struct to hold useful test components.
+struct c_typecheck_test_environmentt
+{
+  symbol_tablet symbol_table;
+  source_locationt loc{};
+  null_message_handlert message_handler{};
+  c_typecheck_testt c_typecheck_test{symbol_table, "test", message_handler};
+
+  static c_typecheck_test_environmentt make()
+  {
+    // These config lines are necessary before construction because char size
+    // depend on the global configuration.
+    config.ansi_c.mode = configt::ansi_ct::flavourt::GCC;
+    config.ansi_c.set_arch_spec_x86_64();
+    c_typecheck_test_environmentt result;
+    result.loc.set_file("a_file");
+    result.loc.set_line(0);
+    result.loc.set_column(0);
+    return result;
+  }
+
+private:
+  c_typecheck_test_environmentt() = default;
+};
+
+TEST_CASE(
+  "typecheck shadow memory declaration functions",
+  "[core][ansi-c][typecheck_shadow_memory_builtin]")
+{
+  auto test = c_typecheck_test_environmentt::make();
+
+  const std::string function_call_name = GENERATE(
+    CPROVER_PREFIX "field_decl_local", CPROVER_PREFIX "field_decl_global");
+
+  SECTION("works on " + function_call_name)
+  {
+    exprt init_value = GENERATE(
+      static_cast<exprt>(from_integer(0, unsigned_char_type())),
+      static_cast<exprt>(from_integer(0, char_type())),
+      static_cast<exprt>(from_integer(0, bool_typet{})),
+      static_cast<exprt>(from_integer(0, unsignedbv_typet{5})),
+      static_cast<exprt>(from_integer(0, signedbv_typet{5})),
+      typecast_exprt::conditional_cast(
+        from_integer(0, unsignedbv_typet{32}), char_type()),
+      typecast_exprt::conditional_cast(
+        from_integer(0, unsignedbv_typet{32}), bool_typet{}));
+    SECTION(
+      "with init_value " + type2c(init_value.type(), test.c_typecheck_test) +
+      expr2c(init_value, test.c_typecheck_test))
+    {
+      symbol_exprt symbol_expr{function_call_name, empty_typet{}};
+      symbol_expr.add_source_location() = test.loc;
+      const side_effect_expr_function_callt expr{
+        symbol_expr,
+        {string_constantt{"field"}, init_value},
+        void_type(),
+        test.loc};
+      const auto builtin_result =
+        test.c_typecheck_test.test_typecheck_shadow_memory_builtin(expr);
+
+      code_typet expected_code_type{{}, void_type()};
+      expected_code_type.make_ellipsis();
+      symbol_exprt expected_symbol_expr{function_call_name, expected_code_type};
+      expected_symbol_expr.add_source_location() = test.loc;
+
+      REQUIRE(builtin_result);
+      REQUIRE(builtin_result.value() == expected_symbol_expr);
+      REQUIRE(test.symbol_table.symbols.empty());
+
+      side_effect_expr_function_callt expr_to_typecheck = expr;
+
+      symbolt expected_symbol{function_call_name, builtin_result->type(), ID_C};
+      expected_symbol.base_name = function_call_name;
+      expected_symbol.location = expr.source_location();
+      expected_symbol.value = code_blockt{};
+
+      test.c_typecheck_test.test_typecheck_side_effect_function_call(
+        expr_to_typecheck);
+
+      // We changed the `function()` field of `expr` as expected
+      REQUIRE(expr_to_typecheck.function() == builtin_result.value());
+      REQUIRE(test.symbol_table.has_symbol(function_call_name));
+      REQUIRE(*test.symbol_table.lookup(function_call_name) == expected_symbol);
+    }
+  }
+}
+
+TEST_CASE(
+  "typecheck shadow memory declaration functions fail correctly",
+  "[core][ansi-c][typecheck_shadow_memory_builtin]")
+{
+  auto test = c_typecheck_test_environmentt::make();
+
+  const std::string function_call_name = GENERATE(
+    CPROVER_PREFIX "field_decl_local", CPROVER_PREFIX "field_decl_global");
+
+  SECTION(" when wrong argument number is provided")
+  {
+    symbol_exprt symbol_expr{function_call_name, empty_typet{}};
+    symbol_expr.add_source_location() = test.loc;
+    const side_effect_expr_function_callt expr{
+      symbol_expr, {string_constantt{"field"}}, void_type(), test.loc};
+
+    const cbmc_invariants_should_throwt invariants_throw;
+
+    REQUIRE_THROWS_AS(
+      test.c_typecheck_test.test_typecheck_shadow_memory_builtin(expr),
+      invalid_source_file_exceptiont);
+  }
+
+  SECTION("when field_name is not a constant_string")
+  {
+    symbol_exprt symbol_expr{function_call_name, empty_typet{}};
+    symbol_expr.add_source_location() = test.loc;
+    const side_effect_expr_function_callt expr{
+      symbol_expr, {true_exprt(), true_exprt()}, void_type(), test.loc};
+
+    const cbmc_invariants_should_throwt invariants_throw;
+
+    REQUIRE_THROWS_AS(
+      test.c_typecheck_test.test_typecheck_shadow_memory_builtin(expr),
+      invalid_source_file_exceptiont);
+  }
+
+  SECTION("when field type is wrong")
+  {
+    exprt init_value = GENERATE(
+      static_cast<exprt>(from_integer(0, unsignedbv_typet{10})),
+      from_integer(0, float_type()),
+      from_integer(0, pointer_typet{char_type(), 32}),
+      string_constantt{"a_value"});
+
+    SECTION(
+      "init_value is " + type2c(init_value.type(), test.c_typecheck_test) +
+      " " + expr2c(init_value, test.c_typecheck_test))
+    {
+      symbol_exprt symbol_expr{function_call_name, empty_typet{}};
+      symbol_expr.add_source_location() = test.loc;
+      const side_effect_expr_function_callt expr{
+        symbol_expr,
+        {string_constantt{"field"}, init_value},
+        void_type(),
+        test.loc};
+
+      const cbmc_invariants_should_throwt invariants_throw;
+
+      REQUIRE_THROWS_AS(
+        test.c_typecheck_test.test_typecheck_shadow_memory_builtin(expr),
+        invalid_source_file_exceptiont);
+    }
+  }
+}
+
+TEST_CASE(
+  "typecheck shadow memory get_field works",
+  "[core][ansi-c][typecheck_shadow_memory_builtin]")
+{
+  auto test = c_typecheck_test_environmentt::make();
+
+  const std::string function_call_name = CPROVER_PREFIX "get_field";
+
+  const pointer_typet pointer_type{char_type(), 32};
+  // We don't care that the pointer is null. At typecheck we just care that the
+  // type of the argument is pointer.
+  const null_pointer_exprt pointer{pointer_type};
+
+  symbol_exprt symbol_expr{function_call_name, empty_typet{}};
+  symbol_expr.add_source_location() = test.loc;
+  const side_effect_expr_function_callt expr{
+    symbol_expr, {pointer, string_constantt{"field"}}, void_type(), test.loc};
+  const auto builtin_result =
+    test.c_typecheck_test.test_typecheck_shadow_memory_builtin(expr);
+
+  code_typet expected_code_type{{}, signed_int_type()};
+  expected_code_type.make_ellipsis();
+  symbol_exprt expected_symbol_expr{function_call_name, expected_code_type};
+  expected_symbol_expr.add_source_location() = test.loc;
+
+  REQUIRE(builtin_result);
+  REQUIRE(builtin_result.value() == expected_symbol_expr);
+  REQUIRE(test.symbol_table.symbols.empty());
+
+  side_effect_expr_function_callt expr_to_typecheck = expr;
+
+  symbolt expected_symbol{function_call_name, builtin_result->type(), ID_C};
+  expected_symbol.base_name = function_call_name;
+  expected_symbol.location = expr.source_location();
+  expected_symbol.value = code_blockt{};
+
+  test.c_typecheck_test.test_typecheck_side_effect_function_call(
+    expr_to_typecheck);
+
+  // We changed the `function()` field of `expr` as expected
+  REQUIRE(expr_to_typecheck.function() == builtin_result.value());
+  REQUIRE(test.symbol_table.has_symbol(function_call_name));
+  REQUIRE(*test.symbol_table.lookup(function_call_name) == expected_symbol);
+}
+
+TEST_CASE(
+  "typecheck shadow memory get_field fails correctly",
+  "[core][ansi-c][typecheck_shadow_memory_builtin]")
+{
+  auto test = c_typecheck_test_environmentt::make();
+
+  const std::string function_call_name = CPROVER_PREFIX "get_field";
+
+  SECTION(" when wrong argument number is provided")
+  {
+    symbol_exprt symbol_expr{function_call_name, empty_typet{}};
+    symbol_expr.add_source_location() = test.loc;
+    const side_effect_expr_function_callt expr{
+      symbol_expr, {string_constantt{"field"}}, void_type(), test.loc};
+
+    const cbmc_invariants_should_throwt invariants_throw;
+
+    REQUIRE_THROWS_AS(
+      test.c_typecheck_test.test_typecheck_shadow_memory_builtin(expr),
+      invalid_source_file_exceptiont);
+  }
+
+  SECTION("when pointer type is wrong")
+  {
+    exprt pointer_value = GENERATE(
+      from_integer(0, unsignedbv_typet{32}),
+      from_integer(0, pointer_typet{void_type(), 32}));
+
+    SECTION(
+      "pointer_value is " +
+      type2c(pointer_value.type(), test.c_typecheck_test) + " " +
+      expr2c(pointer_value, test.c_typecheck_test))
+    {
+      symbol_exprt symbol_expr{function_call_name, empty_typet{}};
+      symbol_expr.add_source_location() = test.loc;
+      const side_effect_expr_function_callt expr{
+        symbol_expr,
+        {pointer_value, string_constantt{"field"}},
+        void_type(),
+        test.loc};
+
+      const cbmc_invariants_should_throwt invariants_throw;
+
+      REQUIRE_THROWS_AS(
+        test.c_typecheck_test.test_typecheck_shadow_memory_builtin(expr),
+        invalid_source_file_exceptiont);
+    }
+  }
+
+  SECTION("when field_name is not a constant_string")
+  {
+    symbol_exprt symbol_expr{function_call_name, empty_typet{}};
+    symbol_expr.add_source_location() = test.loc;
+    const side_effect_expr_function_callt expr{
+      symbol_expr,
+      {from_integer(0, pointer_typet{char_type(), 32}), true_exprt()},
+      void_type(),
+      test.loc};
+
+    const cbmc_invariants_should_throwt invariants_throw;
+
+    REQUIRE_THROWS_AS(
+      test.c_typecheck_test.test_typecheck_shadow_memory_builtin(expr),
+      invalid_source_file_exceptiont);
+  }
+}
+
+TEST_CASE(
+  "typecheck shadow memory set_field works",
+  "[core][ansi-c][typecheck_shadow_memory_builtin]")
+{
+  auto test = c_typecheck_test_environmentt::make();
+
+  const std::string function_call_name = CPROVER_PREFIX "set_field";
+
+  const pointer_typet pointer_type{char_type(), 32};
+  // We don't care that the pointer is null. At typecheck we just care that the
+  // type of the argument is pointer.
+  const null_pointer_exprt pointer{pointer_type};
+
+  exprt set_value = GENERATE(
+    from_integer(0, unsigned_char_type()),
+    from_integer(0, char_type()),
+    from_integer(0, bool_typet{}),
+    from_integer(0, unsignedbv_typet{5}),
+    from_integer(0, signedbv_typet{5}),
+    from_integer(0, signedbv_typet{32}),
+    from_integer(0, unsignedbv_typet{32}));
+
+  SECTION(
+    "with init_value: " + type2c(set_value.type(), test.c_typecheck_test) +
+    " " + expr2c(set_value, test.c_typecheck_test))
+  {
+    symbol_exprt symbol_expr{function_call_name, empty_typet{}};
+    symbol_expr.add_source_location() = test.loc;
+    const side_effect_expr_function_callt expr{
+      symbol_expr,
+      {pointer, string_constantt{"field"}, set_value},
+      void_type(),
+      test.loc};
+    const auto builtin_result =
+      test.c_typecheck_test.test_typecheck_shadow_memory_builtin(expr);
+
+    code_typet expected_code_type{{}, void_type()};
+    expected_code_type.make_ellipsis();
+    symbol_exprt expected_symbol_expr{function_call_name, expected_code_type};
+    expected_symbol_expr.add_source_location() = test.loc;
+
+    REQUIRE(builtin_result);
+    REQUIRE(builtin_result.value() == expected_symbol_expr);
+    REQUIRE(test.symbol_table.symbols.empty());
+
+    side_effect_expr_function_callt expr_to_typecheck = expr;
+
+    symbolt expected_symbol{function_call_name, builtin_result->type(), ID_C};
+    expected_symbol.base_name = function_call_name;
+    expected_symbol.location = expr.source_location();
+    expected_symbol.value = code_blockt{};
+
+    test.c_typecheck_test.test_typecheck_side_effect_function_call(
+      expr_to_typecheck);
+
+    // We changed the `function()` field of `expr` as expected
+    REQUIRE(expr_to_typecheck.function() == builtin_result.value());
+    REQUIRE(test.symbol_table.has_symbol(function_call_name));
+    REQUIRE(*test.symbol_table.lookup(function_call_name) == expected_symbol);
+  }
+}
+
+TEST_CASE(
+  "typecheck shadow memory set_field fails correctly",
+  "[core][ansi-c][typecheck_shadow_memory_builtin]")
+{
+  auto test = c_typecheck_test_environmentt::make();
+
+  const std::string function_call_name = CPROVER_PREFIX "set_field";
+
+  SECTION("when wrong argument number is provided")
+  {
+    symbol_exprt symbol_expr{function_call_name, empty_typet{}};
+    symbol_expr.add_source_location() = test.loc;
+    const side_effect_expr_function_callt expr{
+      symbol_expr, {string_constantt{"field"}}, void_type(), test.loc};
+
+    const cbmc_invariants_should_throwt invariants_throw;
+
+    REQUIRE_THROWS_AS(
+      test.c_typecheck_test.test_typecheck_shadow_memory_builtin(expr),
+      invalid_source_file_exceptiont);
+  }
+
+  SECTION("when pointer type is wrong")
+  {
+    exprt pointer_value = GENERATE(
+      from_integer(0, unsignedbv_typet{32}),
+      from_integer(0, pointer_typet{void_type(), 32}));
+
+    SECTION(
+      "pointer_value is " +
+      type2c(pointer_value.type(), test.c_typecheck_test) + " " +
+      expr2c(pointer_value, test.c_typecheck_test))
+    {
+      symbol_exprt symbol_expr{function_call_name, empty_typet{}};
+      symbol_expr.add_source_location() = test.loc;
+      const side_effect_expr_function_callt expr{
+        symbol_expr,
+        {pointer_value, string_constantt{"field"}, true_exprt{}},
+        void_type(),
+        test.loc};
+
+      const cbmc_invariants_should_throwt invariants_throw;
+
+      REQUIRE_THROWS_AS(
+        test.c_typecheck_test.test_typecheck_shadow_memory_builtin(expr),
+        invalid_source_file_exceptiont);
+    }
+  }
+
+  SECTION("when field_name is not a constant_string")
+  {
+    symbol_exprt symbol_expr{function_call_name, empty_typet{}};
+    symbol_expr.add_source_location() = test.loc;
+    const side_effect_expr_function_callt expr{
+      symbol_expr,
+      {from_integer(0, pointer_typet{char_type(), 32}),
+       true_exprt(),
+       true_exprt{}},
+      void_type(),
+      test.loc};
+
+    const cbmc_invariants_should_throwt invariants_throw;
+
+    REQUIRE_THROWS_AS(
+      test.c_typecheck_test.test_typecheck_shadow_memory_builtin(expr),
+      invalid_source_file_exceptiont);
+  }
+
+  SECTION("when set_value is not valid")
+  {
+    symbol_exprt symbol_expr{function_call_name, empty_typet{}};
+    symbol_expr.add_source_location() = test.loc;
+    const side_effect_expr_function_callt expr{
+      symbol_expr,
+      {from_integer(0, pointer_typet{char_type(), 32}),
+       string_constantt{"field"},
+       string_constantt{"a_value"}},
+      void_type(),
+      test.loc};
+
+    const cbmc_invariants_should_throwt invariants_throw;
+
+    REQUIRE_THROWS_AS(
+      test.c_typecheck_test.test_typecheck_shadow_memory_builtin(expr),
+      invalid_source_file_exceptiont);
+  }
+}
+
+TEST_CASE(
+  "typecheck_shadow_memory_builtin returns nothing if not shadow memory",
+  "[core][ansi-c][typecheck_shadow_memory_builtin]")
+{
+  auto test = c_typecheck_test_environmentt::make();
+
+  const std::string function_call_name = "foo";
+
+  symbol_exprt symbol_expr{function_call_name, empty_typet{}};
+  const side_effect_expr_function_callt expr{
+    symbol_expr, {string_constantt{"field"}}, void_type(), test.loc};
+  const auto builtin_result =
+    test.c_typecheck_test.test_typecheck_shadow_memory_builtin(expr);
+
+  REQUIRE_FALSE(builtin_result.has_value());
+}


### PR DESCRIPTION
This PR enables typechecking of shadow memory primitives.

The primitives are checked for correct number of arguments, correct types and also enforce other invariants such as having a constant string for name, a bit-vector type of size `< 8` and non-`void` pointers for accessing it.

It also adds regressions and unit tests for it.

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
