### PR TITLE
Make constant_propagation_08 test platform agnostic

### DIFF
--- a/regression/goto-analyzer/constant_propagation_08/main.c
+++ b/regression/goto-analyzer/constant_propagation_08/main.c
@@ -5,10 +5,17 @@ int main()
   int i;
   i = 0;
 
+#ifndef _WIN64
   if (i==0)
-    a[0]=1;
+    a[0l] = 1;
   else
-    a[1]=2;
+    a[1l] = 2;
+#else
+  if(i == 0)
+    a[0ll] = 1;
+  else
+    a[1ll] = 2;
+#endif
 
   __CPROVER_assert(a[0] == 1 || a[1] == 2, "a[0]==1 || a[1]==2");
 

--- a/regression/goto-analyzer/constant_propagation_08/test-vsd.desc
+++ b/regression/goto-analyzer/constant_propagation_08/test-vsd.desc
@@ -3,7 +3,7 @@ main.c
 --variable-sensitivity --vsd-arrays every-element --simplify out.gb
 ^EXIT=0$
 ^SIGNAL=0$
-^Simplified:  assert: 1, assume: 0, goto: 1, assigns: [12], function calls: 0$
-^Unmodified:  assert: 0, assume: 0, goto: 2, assigns: [89], function calls: 2$
+^Simplified:  assert: 1, assume: 0, goto: 1, assigns: 1, function calls: 0$
+^Unmodified:  assert: 0, assume: 0, goto: 2, assigns: 9, function calls: 2$
 --
 ^warning: ignoring


### PR DESCRIPTION
We had a varying number of simplifications as platforms with sizeof(int) != sizeof(long) would yield 2 simplifications, and those with matching bit widths only a single one. The extra simplification referred to the cast in the index operand (on platforms with sizeof(int) != sizeof(long)), which we can avoid by making the index a long-type constant in the first place.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
