### PR TITLE
Add `python` to the install list of chocolatey.

### DIFF
--- a/.github/workflows/pull-request-checks.yaml
+++ b/.github/workflows/pull-request-checks.yaml
@@ -739,6 +739,7 @@ jobs:
       - name: Fetch dependencies
         run: |
           choco install -y winflexbison3 strawberryperl wget
+          choco install python311
           if($LastExitCode -ne 0)
           {
             Write-Output "::error ::Dependency installation via Chocolatey failed."


### PR DESCRIPTION
We are facing a CI issue where the builds for `vs2022` are failing because of a bad Python binary failing to instantiate itself (it fails to link against DLLs that are present).

The bad binary appears to be already present in the system, either as a result of being installed as a transitive dependency of something else, or it comes pre-installed with chocolatey (we're not sure which one is the case).

Either way, this PR adds Python to the list of software that `chocolatey` installs, in order to force an override of the version we're currently using with a more recent one (chocolatey appears to be controlling the default version by using shims for the versioned binary).


