### PR TITLE
GitHub actions: No need for setup-nuget

### DIFF
--- a/.github/workflows/pull-request-checks.yaml
+++ b/.github/workflows/pull-request-checks.yaml
@@ -675,9 +675,8 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: recursive
-      - uses: nuget/setup-nuget@v1
-        with:
-          nuget-version: '5.8.x'
+      - name: Setup Visual Studio environment
+        uses: microsoft/setup-msbuild@v1
       - name: Fetch dependencies
         run: |
           choco install winflexbison3
@@ -698,8 +697,6 @@ jobs:
         run: z3 --version
       - name: Confirm cvc5 solver is available and log the version installed
         run: cvc5 --version
-      - name: Setup Visual Studio environment
-        uses: microsoft/setup-msbuild@v1
       - name: Prepare ccache
         uses: actions/cache@v3
         with:
@@ -733,9 +730,8 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: recursive
-      - uses: nuget/setup-nuget@v1
-        with:
-          nuget-version: '5.8.x'
+      - name: Setup MSBuild
+        uses: microsoft/setup-msbuild@v1
       - name: Fetch dependencies
         run: |
           choco install -y winflexbison3 strawberryperl wget
@@ -757,8 +753,6 @@ jobs:
         run: z3 --version
       - name: Confirm cvc5 solver is available and log the version installed
         run: cvc5 --version
-      - name: Setup MSBuild
-        uses: microsoft/setup-msbuild@v1
       - name: Initialise Developer Command Line
         uses: ilammy/msvc-dev-cmd@v1
       - name: Prepare ccache
@@ -804,9 +798,8 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: recursive
-      - uses: nuget/setup-nuget@v1
-        with:
-          nuget-version: '5.8.x'
+      - name: Setup Visual Studio environment
+        uses: microsoft/setup-msbuild@v1
       - name: Fetch dependencies
         run: |
           choco install winflexbison3
@@ -817,8 +810,6 @@ jobs:
           }
           nuget install clcache -OutputDirectory "c:\tools" -ExcludeVersion -Version 4.1.0
           echo "c:\tools\clcache\clcache-4.1.0" >> $env:GITHUB_PATH
-      - name: Setup Visual Studio environment
-        uses: microsoft/setup-msbuild@v1
       - name: Prepare ccache
         uses: actions/cache@v3
         with:

--- a/.github/workflows/release-packages.yaml
+++ b/.github/workflows/release-packages.yaml
@@ -187,16 +187,13 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: recursive
-      - uses: nuget/setup-nuget@v1
-        with:
-          nuget-version: '5.8.x'
+      - name: Setup Visual Studio environment
+        uses: microsoft/setup-msbuild@v1
       - name: Fetch dependencies
         run: |
           choco install winflexbison3
           nuget install clcache -OutputDirectory "c:\tools" -ExcludeVersion -Version 4.1.0
           echo "c:\tools\clcache\clcache-4.1.0" >> $env:GITHUB_PATH
-      - name: Setup Visual Studio environment
-        uses: microsoft/setup-msbuild@v1
       - name: Setup code sign environment
         run: |
           echo "$(Split-Path -Path $(Get-ChildItem -Path "${env:ProgramFiles(x86)}\Windows Kits\10\App Certification Kit\signtool.exe"))" >> $env:GITHUB_PATH


### PR DESCRIPTION
As per setup-nuget's documentation, setup-msbuild also takes care of making `nuget` available. Since we need the latter anyway, just move it earlier in the sequence of steps and remove a dependency (on setup-nuget).

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
