### PR TITLE
Temporarily revert #6876

### DIFF
--- a/regression/cbmc/memory_allocation1/test.desc
+++ b/regression/cbmc/memory_allocation1/test.desc
@@ -3,7 +3,6 @@ main.c
 --pointer-check
 ^EXIT=10$
 ^SIGNAL=0$
-^\*\*\*\* WARNING: `__CPROVER_allocated_memory' in file main\.c line \d+ function main$
 ^\[main\.pointer_dereference\.2\] .* dereference failure: invalid integer address in \*p: SUCCESS$
 ^\[main\.assertion\.1\] .* assertion \*p==42: SUCCESS$
 ^\[main\.pointer_dereference\.[0-9]+\] .* dereference failure: invalid integer address in p\[.*1\]: FAILURE$

--- a/src/ansi-c/goto_check_c.cpp
+++ b/src/ansi-c/goto_check_c.cpp
@@ -441,17 +441,6 @@ void goto_check_ct::collect_allocations(const goto_functionst &goto_functions)
           "allocated_memory")
         continue;
 
-      const auto function_line = function.source_location().as_string();
-      log.warning() << "**** WARNING: `" CPROVER_PREFIX "allocated_memory' in "
-                    << function_line << messaget::eom;
-      log.warning() << "**** WARNING: `" CPROVER_PREFIX
-                       "allocated_memory' is "
-                       "deprecated and scheduled for deletion "
-                    << "in version 6 and upwards." << messaget::eom;
-      log.warning() << "Please avoid using this intrinsic. For more "
-                       "information, please check issue "
-                    << "cbmc#6872 in Github" << messaget::eom;
-
       const code_function_callt::argumentst &args =
         instruction.call_arguments();
       if(


### PR DESCRIPTION
As much as we would like to get rid of `__CPROVER_allocated_memory`, we don't currently have a replacement available. This PR removes the deprecation warning to reduce the noise for users who intentionally use this intrinsic. This is a clean revert of the two commit of #6876, and these two commits should be added back once we have a replacement.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
