### PR TITLE
Remove line that adds `chocolatey/bin` folder to `GITHUB_PATH` from CI.

### DIFF
--- a/.github/workflows/pull-request-checks.yaml
+++ b/.github/workflows/pull-request-checks.yaml
@@ -746,7 +746,6 @@ jobs:
           }
           nuget install clcache -OutputDirectory "c:\tools" -ExcludeVersion -Version 4.1.0
           echo "c:\tools\clcache\clcache-4.1.0" >> $env:GITHUB_PATH
-          echo "c:\ProgramData\chocolatey\bin" >> $env:GITHUB_PATH
           echo "c:\Strawberry\" >> $env:GITHUB_PATH
           Invoke-WebRequest -Uri https://github.com/Z3Prover/z3/releases/download/z3-4.8.10/z3-4.8.10-x64-win.zip -OutFile .\z3.zip
           Expand-Archive -LiteralPath '.\z3.Zip' -DestinationPath C:\tools


### PR DESCRIPTION
We have an issue with our CI in that the job for `vs2022` is failing to execute some tests that depend on a python script, because the python interpreter fails to be instantiated (that is, it fails during binary initialisation by failing to link against a DLL).

This version of Python appears to be preinstalled in some fashion (either it comes with `chocolatey`, or is installed as a transitive dependency of other dependencies of our build), but the end result is that we fail at running some of the tests.

This change appears in our experiments to fix the situation with the bad binary that is installed for Python with `chocolatey`, by removing the folder from the path, we don't trigger execution with the bad binary.
