### PR TITLE
Stop building memory-analyzer on Mac and Windows

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -122,6 +122,6 @@ add_subdirectory(symtab2gb)
 add_subdirectory(libcprover-cpp)
 add_subdirectory(goto-bmc)
 
-if(UNIX OR WITH_MEMORY_ANALYZER)
+if((NOT WIN32 AND NOT APPLE) OR WITH_MEMORY_ANALYZER)
 add_subdirectory(memory-analyzer)
 endif()

--- a/src/Makefile
+++ b/src/Makefile
@@ -52,9 +52,9 @@ else
   detected_OS := $(shell sh -c 'uname 2>/dev/null || echo Unknown')
 endif
 
-ifeq ($(detected_OS),Linux)
+ifeq ($(WITH_MEMORY_ANALYZER),1)
   all: memory-analyzer.dir
-else ifeq ($(WITH_MEMORY_ANALYZER),1)
+else ifneq ($(filter-out Windows Darwin,$(detected_OS)),)
   all: memory-analyzer.dir
 endif
 


### PR DESCRIPTION
This PR fixes an issue when trying to build `memory-analyzer` on Apple Silicon machines by excluding it on Windows and Apple systems.

This also was the expected behaviour for it.

Fixes Issue https://github.com/diffblue/cbmc/issues/7922

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
