### PR TITLE
Interval expressions: cleanup type hierarchy

### DIFF
--- a/src/util/interval.h
+++ b/src/util/interval.h
@@ -11,30 +11,30 @@
 #include <util/std_expr.h>
 #include <util/threeval.h>
 
-#include <iostream>
+#include <iosfwd>
 
 /// +∞ upper bound for intervals
-class max_exprt : public exprt
+class max_exprt : public nullary_exprt
 {
 public:
-  explicit max_exprt(const typet &_type) : exprt(ID_max, _type)
+  explicit max_exprt(const typet &_type) : nullary_exprt(ID_max, _type)
   {
   }
 
-  explicit max_exprt(const exprt &_expr) : exprt(ID_max, _expr.type())
+  explicit max_exprt(const exprt &_expr) : nullary_exprt(ID_max, _expr.type())
   {
   }
 };
 
 /// -∞ upper bound for intervals
-class min_exprt : public exprt
+class min_exprt : public nullary_exprt
 {
 public:
-  explicit min_exprt(const typet &_type) : exprt(ID_min, _type)
+  explicit min_exprt(const typet &_type) : nullary_exprt(ID_min, _type)
   {
   }
 
-  explicit min_exprt(const exprt &_expr) : exprt(ID_min, _expr.type())
+  explicit min_exprt(const exprt &_expr) : nullary_exprt(ID_min, _expr.type())
   {
   }
 };
@@ -47,23 +47,14 @@ public:
 class constant_interval_exprt : public binary_exprt
 {
 public:
-  constant_interval_exprt(
-    const exprt &lower,
-    const exprt &upper,
-    const typet type)
-    : binary_exprt(lower, ID_constant_interval, upper, type)
+  constant_interval_exprt(exprt lower, exprt upper, typet type)
+    : binary_exprt(
+        std::move(lower),
+        ID_constant_interval,
+        std::move(upper),
+        std::move(type))
   {
     PRECONDITION(is_well_formed());
-  }
-
-  constant_interval_exprt(const constant_interval_exprt &x)
-    : constant_interval_exprt(x.get_lower(), x.get_upper(), x.type())
-  {
-  }
-
-  explicit constant_interval_exprt(const exprt &x)
-    : constant_interval_exprt(x, x, x.type())
-  {
   }
 
   explicit constant_interval_exprt(const typet &type)
@@ -74,6 +65,7 @@ public:
   constant_interval_exprt(const exprt &lower, const exprt &upper)
     : constant_interval_exprt(lower, upper, lower.type())
   {
+    PRECONDITION(is_well_formed());
   }
 
   bool is_well_formed() const
@@ -95,6 +87,11 @@ public:
     b &= !is_numeric() || is_bottom() || less_than_or_equal(lower, upper);
 
     return b;
+  }
+
+  static constant_interval_exprt singleton(const exprt &x)
+  {
+    return constant_interval_exprt{x, x, x.type()};
   }
 
   static bool is_valid_bound(const exprt &expr)

--- a/unit/util/interval/bitwise.cpp
+++ b/unit/util/interval/bitwise.cpp
@@ -15,9 +15,9 @@ SCENARIO("bitwise interval domain", "[core][analyses][interval][bitwise]")
   {
     const unsignedbv_typet &unsigned_int = unsignedbv_typet(32);
     constant_interval_exprt five =
-      constant_interval_exprt(from_integer(5, unsigned_int));
+      constant_interval_exprt::singleton(from_integer(5, unsigned_int));
     constant_interval_exprt nine =
-      constant_interval_exprt(from_integer(9, unsigned_int));
+      constant_interval_exprt::singleton(from_integer(9, unsigned_int));
 
     constant_interval_exprt five_to_nine(
       from_integer(5, unsigned_int), from_integer(9, unsigned_int));
@@ -26,7 +26,7 @@ SCENARIO("bitwise interval domain", "[core][analyses][interval][bitwise]")
     {
       REQUIRE(
         constant_interval_exprt::bitwise_or(five, nine) ==
-        constant_interval_exprt(from_integer(13, unsigned_int)));
+        constant_interval_exprt::singleton(from_integer(13, unsigned_int)));
 
       REQUIRE(constant_interval_exprt::bitwise_or(five_to_nine, nine).is_top());
     }
@@ -35,10 +35,10 @@ SCENARIO("bitwise interval domain", "[core][analyses][interval][bitwise]")
     {
       REQUIRE(
         constant_interval_exprt::bitwise_and(five, nine) ==
-        constant_interval_exprt(from_integer(1, unsigned_int)));
+        constant_interval_exprt::singleton(from_integer(1, unsigned_int)));
       REQUIRE(
         (five & nine) ==
-        constant_interval_exprt(from_integer(1, unsigned_int)));
+        constant_interval_exprt::singleton(from_integer(1, unsigned_int)));
 
       REQUIRE(
         constant_interval_exprt::bitwise_and(five_to_nine, nine).is_top());
@@ -48,7 +48,7 @@ SCENARIO("bitwise interval domain", "[core][analyses][interval][bitwise]")
     {
       REQUIRE(
         constant_interval_exprt::bitwise_xor(five, nine) ==
-        constant_interval_exprt(from_integer(12, unsigned_int)));
+        constant_interval_exprt::singleton(from_integer(12, unsigned_int)));
 
       REQUIRE(
         constant_interval_exprt::bitwise_xor(five_to_nine, nine).is_top());

--- a/unit/util/interval/comparisons.cpp
+++ b/unit/util/interval/comparisons.cpp
@@ -121,7 +121,8 @@ SCENARIO("comparison interval domain", "[core][analyses][interval][comparison]")
           constant_interval_exprt(CEV(10), CEV(20)) >
           constant_interval_exprt(CEV(30), CEV(40)));
         REQUIRE(
-          constant_interval_exprt(CEV(10)) < constant_interval_exprt(CEV(30)));
+          constant_interval_exprt::singleton(CEV(10)) <
+          constant_interval_exprt::singleton(CEV(30)));
       }
 
       THEN(
@@ -186,8 +187,8 @@ SCENARIO("comparison interval domain", "[core][analyses][interval][comparison]")
           constant_interval_exprt(CEV(10), CEV(31))
             .less_than_or_equal(constant_interval_exprt(CEV(30), CEV(40))) ==
           tvt::unknown());
-        CHECK(constant_interval_exprt(CEV(10))
-                .less_than_or_equal(constant_interval_exprt(CEV(30)))
+        CHECK(constant_interval_exprt::singleton(CEV(10))
+                .less_than_or_equal(constant_interval_exprt::singleton(CEV(30)))
                 .is_true());
       }
 
@@ -222,7 +223,8 @@ SCENARIO("comparison interval domain", "[core][analyses][interval][comparison]")
         REQUIRE(includes_zero_negative.is_definitely_true().is_unknown());
         REQUIRE(includes_zero_negative.is_definitely_false().is_unknown());
 
-        constant_interval_exprt zero(CEV(0));
+        constant_interval_exprt zero =
+          constant_interval_exprt::singleton(CEV(0));
         REQUIRE(zero.is_definitely_false().is_true());
         REQUIRE(zero.is_definitely_true().is_false());
 
@@ -242,8 +244,8 @@ TEST_CASE("interval::equality", "[core][analyses][interval]")
 {
   SECTION("Single element intervals")
   {
-    constant_interval_exprt two(CEV(2));
-    constant_interval_exprt four(CEV(4));
+    constant_interval_exprt two = constant_interval_exprt::singleton(CEV(2));
+    constant_interval_exprt four = constant_interval_exprt::singleton(CEV(4));
 
     REQUIRE_FALSE(two.equal(four).is_true());
     REQUIRE(two.equal(two).is_true());

--- a/unit/util/interval/divide.cpp
+++ b/unit/util/interval/divide.cpp
@@ -38,11 +38,16 @@ TEST_CASE("interval::divide", "[core][util][interval][divide]")
 
   SECTION("Single element intervals")
   {
-    const constant_interval_exprt zero_interval(zero);
-    const constant_interval_exprt one_interval(one);
-    const constant_interval_exprt four_interval(four);
-    const constant_interval_exprt eight_interval(eight);
-    const constant_interval_exprt negative_twelve_interval(negative_twelve);
+    const constant_interval_exprt zero_interval =
+      constant_interval_exprt::singleton(zero);
+    const constant_interval_exprt one_interval =
+      constant_interval_exprt::singleton(one);
+    const constant_interval_exprt four_interval =
+      constant_interval_exprt::singleton(four);
+    const constant_interval_exprt eight_interval =
+      constant_interval_exprt::singleton(eight);
+    const constant_interval_exprt negative_twelve_interval =
+      constant_interval_exprt::singleton(negative_twelve);
 
     REQUIRE(value_of(zero_interval.divide(four_interval)) == 0);
     REQUIRE(value_of(four_interval.divide(four_interval)) == 1);
@@ -61,8 +66,10 @@ TEST_CASE("interval::divide", "[core][util][interval][divide]")
 
     SECTION("Max & Min")
     {
-      const constant_interval_exprt min_interval{min_exprt{signed_int_type}};
-      const constant_interval_exprt max_interval{max_exprt{signed_int_type}};
+      const constant_interval_exprt min_interval =
+        constant_interval_exprt::singleton(min_exprt{signed_int_type});
+      const constant_interval_exprt max_interval =
+        constant_interval_exprt::singleton(max_exprt{signed_int_type});
       // TODO: division of single max or min don't work as expected
       // CHECK(max_interval.divide(max_interval).is_top());
       // CHECK(max_interval.divide(min_interval).is_top());
@@ -82,7 +89,8 @@ TEST_CASE("interval::divide", "[core][util][interval][divide]")
     const constant_interval_exprt negative_range(
       negative_sixteen, negative_twelve);
     const constant_interval_exprt range_containing_zero(negative_twelve, four);
-    const constant_interval_exprt zero_interval(zero);
+    const constant_interval_exprt zero_interval =
+      constant_interval_exprt::singleton(zero);
 
     const constant_exprt &two = from_integer(2, signed_int_type);
     REQUIRE(matching_range(

--- a/unit/util/interval/eval.cpp
+++ b/unit/util/interval/eval.cpp
@@ -14,9 +14,9 @@ SCENARIO("Unary eval on intervals", "[core][analyses][interval][eval]")
   WHEN("Negating a boolean interval")
   {
     constant_interval_exprt true_interval =
-      constant_interval_exprt(true_exprt());
+      constant_interval_exprt::singleton(true_exprt());
     constant_interval_exprt false_interval =
-      constant_interval_exprt(false_exprt());
+      constant_interval_exprt::singleton(false_exprt());
     constant_interval_exprt bool_top_interval =
       constant_interval_exprt(bool_typet());
 
@@ -37,11 +37,11 @@ SCENARIO("Unary eval on intervals", "[core][analyses][interval][eval]")
   WHEN("Unary operations to an single element interval")
   {
     constant_interval_exprt five =
-      constant_interval_exprt(from_integer(5, signedbv_typet(32)));
+      constant_interval_exprt::singleton(from_integer(5, signedbv_typet(32)));
     const constant_interval_exprt &max_interval =
-      constant_interval_exprt(max_exprt{signedbv_typet(32)});
+      constant_interval_exprt::singleton(max_exprt{signedbv_typet(32)});
     const constant_interval_exprt &min_interval =
-      constant_interval_exprt(min_exprt{signedbv_typet(32)});
+      constant_interval_exprt::singleton(min_exprt{signedbv_typet(32)});
 
     THEN("When we apply unary addition to it, nothing should happen")
     {
@@ -102,7 +102,8 @@ SCENARIO("Unary eval on intervals", "[core][analyses][interval][eval]")
 TEST_CASE("binary eval switch", "[core][analyses][interval]")
 {
   const auto interval_of = [](const int value) {
-    return constant_interval_exprt(from_integer(value, signedbv_typet(32)));
+    return constant_interval_exprt::singleton(
+      from_integer(value, signedbv_typet(32)));
   };
 
   const auto interval_from_to = [](const int lower, const int upper) {

--- a/unit/util/interval/modulo.cpp
+++ b/unit/util/interval/modulo.cpp
@@ -19,9 +19,9 @@ SCENARIO("modulo interval domain", "[core][analyses][interval][modulo]")
 {
   GIVEN("Two single element internvals")
   {
-    constant_interval_exprt a(CEV(5));
-    constant_interval_exprt b(CEV(10));
-    constant_interval_exprt zero(CEV(0));
+    constant_interval_exprt a = constant_interval_exprt::singleton(CEV(5));
+    constant_interval_exprt b = constant_interval_exprt::singleton(CEV(10));
+    constant_interval_exprt zero = constant_interval_exprt::singleton(CEV(0));
     const auto a_mod_b = a.modulo(b);
     REQUIRE(V(a_mod_b.get_upper()) == 5);
 
@@ -30,7 +30,7 @@ SCENARIO("modulo interval domain", "[core][analyses][interval][modulo]")
     REQUIRE(V(b_mod_a.get_upper()) == 4);
 
     const auto zero_mod_a = zero.modulo(a);
-    REQUIRE(zero_mod_a == constant_interval_exprt(CEV(0)));
+    REQUIRE(zero_mod_a == constant_interval_exprt::singleton(CEV(0)));
 
     // TODO: this causes an invariant as it is unable to simplify the
     // TODO: simplify(a % 0) == a % 0
@@ -95,7 +95,7 @@ SCENARIO("modulo interval domain", "[core][analyses][interval][modulo]")
           constant_interval_exprt::modulo(
             constant_interval_exprt(CEV(-20), CEV(-10)),
             constant_interval_exprt(CEV(1), CEV(1))) ==
-          constant_interval_exprt(CEV(0)));
+          constant_interval_exprt::singleton(CEV(0)));
 
         REQUIRE(
           constant_interval_exprt::modulo(

--- a/unit/util/interval/multiply.cpp
+++ b/unit/util/interval/multiply.cpp
@@ -24,8 +24,8 @@ SCENARIO("multiply interval domain", "[core][analyses][interval][multiply]")
 
     WHEN("Single element multiplication")
     {
-      constant_interval_exprt a(CEV(5));
-      constant_interval_exprt b(CEV(10));
+      constant_interval_exprt a = constant_interval_exprt::singleton(CEV(5));
+      constant_interval_exprt b = constant_interval_exprt::singleton(CEV(10));
       const auto a_times_b = a.multiply(b);
       REQUIRE(a_times_b == constant_interval_exprt(CEV(50), CEV(50)));
     }

--- a/unit/util/interval/shift.cpp
+++ b/unit/util/interval/shift.cpp
@@ -19,16 +19,19 @@ TEST_CASE("shift interval domain", "[core][analyses][interval][shift]")
   {
     REQUIRE(
       constant_interval_exprt::left_shift(
-        constant_interval_exprt(CEV(5)), constant_interval_exprt(CEV(1))) ==
-      constant_interval_exprt(CEV(10)));
+        constant_interval_exprt::singleton(CEV(5)),
+        constant_interval_exprt::singleton(CEV(1))) ==
+      constant_interval_exprt::singleton(CEV(10)));
 
     const constant_interval_exprt four_to_eight(CEV(4), CEV(8));
-    const constant_interval_exprt one(CEV(1));
+    const constant_interval_exprt one =
+      constant_interval_exprt::singleton(CEV(1));
     REQUIRE(
       constant_interval_exprt::left_shift(four_to_eight, one) ==
       constant_interval_exprt(CEV(8), CEV(16)));
 
-    const constant_interval_exprt negative_one(CEV(-1));
+    const constant_interval_exprt negative_one =
+      constant_interval_exprt::singleton(CEV(-1));
     REQUIRE(constant_interval_exprt::left_shift(four_to_eight, negative_one)
               .is_top());
   }
@@ -36,16 +39,19 @@ TEST_CASE("shift interval domain", "[core][analyses][interval][shift]")
   {
     REQUIRE(
       constant_interval_exprt::right_shift(
-        constant_interval_exprt(CEV(5)), constant_interval_exprt(CEV(1))) ==
-      constant_interval_exprt(CEV(2)));
+        constant_interval_exprt::singleton(CEV(5)),
+        constant_interval_exprt::singleton(CEV(1))) ==
+      constant_interval_exprt::singleton(CEV(2)));
 
     const constant_interval_exprt four_to_eight(CEV(4), CEV(8));
-    const constant_interval_exprt one(CEV(1));
+    const constant_interval_exprt one =
+      constant_interval_exprt::singleton(CEV(1));
     REQUIRE(
       constant_interval_exprt::right_shift(four_to_eight, one) ==
       constant_interval_exprt(CEV(2), CEV(4)));
 
-    const constant_interval_exprt negative_one(CEV(-1));
+    const constant_interval_exprt negative_one =
+      constant_interval_exprt::singleton(CEV(-1));
     REQUIRE(constant_interval_exprt::right_shift(four_to_eight, negative_one)
               .is_top());
   }

--- a/unit/util/interval/subtract.cpp
+++ b/unit/util/interval/subtract.cpp
@@ -105,8 +105,8 @@ SCENARIO(
 
   WHEN("Subtracting two constant intervals")
   {
-    auto lhs = constant_interval_exprt(get_value(10));
-    auto rhs = constant_interval_exprt(get_value(3));
+    auto lhs = constant_interval_exprt::singleton(get_value(10));
+    auto rhs = constant_interval_exprt::singleton(get_value(3));
     THEN("it should work")
     {
       auto result = constant_interval_exprt::minus(lhs, rhs);
@@ -119,8 +119,8 @@ SCENARIO(
 
   WHEN("Subtracting zero from something")
   {
-    auto lhs = constant_interval_exprt(get_value(10));
-    auto rhs = constant_interval_exprt(get_value(0));
+    auto lhs = constant_interval_exprt::singleton(get_value(10));
+    auto rhs = constant_interval_exprt::singleton(get_value(0));
 
     THEN("it should not give a completely crazy result")
     {
@@ -134,7 +134,7 @@ SCENARIO(
 
   WHEN("Subtracting an non-constant interval containing zero")
   {
-    auto lhs = constant_interval_exprt(get_value(10));
+    auto lhs = constant_interval_exprt::singleton(get_value(10));
     auto rhs = constant_interval_exprt(get_value(0), get_value(1));
     THEN("it should not give a completely crazy result")
     {

--- a/unit/util/interval/to_string.cpp
+++ b/unit/util/interval/to_string.cpp
@@ -20,7 +20,8 @@ TEST_CASE("interval::to_string", "[core][analyses][interval]")
     return from_integer(value, unsigned_int_type);
   };
 
-  REQUIRE(constant_interval_exprt(signed_expr(1)).to_string() == "[1,1]");
+  REQUIRE(
+    constant_interval_exprt::singleton(signed_expr(1)).to_string() == "[1,1]");
   REQUIRE(
     constant_interval_exprt(signed_expr(1), signed_expr(2)).to_string() ==
     "[1,2]");


### PR DESCRIPTION
Mark nullary expressions as such, and avoid ambiguity in single-argument constructors.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
