### PR TITLE
Add `union_exprt` encoding support in incremental smt2 decision procedure

### DIFF
--- a/src/solvers/Makefile
+++ b/src/solvers/Makefile
@@ -211,6 +211,7 @@ SRC = $(BOOLEFORCE_SRC) \
       smt2_incremental/smt2_incremental_decision_procedure.cpp \
       smt2_incremental/encoding/struct_encoding.cpp \
       smt2_incremental/encoding/enum_encoding.cpp \
+      smt2_incremental/encoding/nondet_padding.cpp \
       smt2_incremental/theories/smt_array_theory.cpp \
       smt2_incremental/theories/smt_bit_vector_theory.cpp \
       smt2_incremental/theories/smt_core_theory.cpp \

--- a/src/solvers/smt2_incremental/encoding/module_dependencies.txt
+++ b/src/solvers/smt2_incremental/encoding/module_dependencies.txt
@@ -1,1 +1,2 @@
+solvers/smt2_incremental/encoding
 util

--- a/src/solvers/smt2_incremental/encoding/nondet_padding.cpp
+++ b/src/solvers/smt2_incremental/encoding/nondet_padding.cpp
@@ -1,0 +1,5 @@
+// Author: Diffblue Ltd.
+
+#include "nondet_padding.h"
+
+const irep_idt nondet_padding_exprt::ID_nondet_padding = "nondet_padding";

--- a/src/solvers/smt2_incremental/encoding/nondet_padding.h
+++ b/src/solvers/smt2_incremental/encoding/nondet_padding.h
@@ -13,11 +13,11 @@
 class nondet_padding_exprt;
 void validate_expr(const nondet_padding_exprt &padding);
 
-const irep_idt ID_nondet_padding = "nondet_padding";
-
 class nondet_padding_exprt : public expr_protectedt
 {
 public:
+  static const irep_idt ID_nondet_padding;
+
   explicit nondet_padding_exprt(typet type)
     : expr_protectedt{ID_nondet_padding, std::move(type)}
   {
@@ -28,7 +28,7 @@ public:
 template <>
 inline bool can_cast_expr<nondet_padding_exprt>(const exprt &base)
 {
-  return base.id() == ID_nondet_padding;
+  return base.id() == nondet_padding_exprt::ID_nondet_padding;
 }
 
 inline void validate_expr(const nondet_padding_exprt &padding)

--- a/src/solvers/smt2_incremental/encoding/nondet_padding.h
+++ b/src/solvers/smt2_incremental/encoding/nondet_padding.h
@@ -13,6 +13,10 @@
 class nondet_padding_exprt;
 void validate_expr(const nondet_padding_exprt &padding);
 
+/// This expression serves as a placeholder for the bits which have non
+/// deterministic value in a larger bit vector. It is inserted in contexts where
+/// a subset of the bits are assigned to an expression and the remainder are
+/// left unspecified.
 class nondet_padding_exprt : public expr_protectedt
 {
 public:

--- a/src/solvers/smt2_incremental/encoding/nondet_padding.h
+++ b/src/solvers/smt2_incremental/encoding/nondet_padding.h
@@ -1,0 +1,41 @@
+// Author: Diffblue Ltd.
+
+/// \file
+/// Expressions for use in incremental SMT2 decision procedure
+
+#ifndef CPROVER_SOLVERS_SMT2_INCREMENTAL_ENCODING_NONDET_PADDING_H
+#define CPROVER_SOLVERS_SMT2_INCREMENTAL_ENCODING_NONDET_PADDING_H
+
+#include <util/bitvector_types.h>
+#include <util/expr.h>
+#include <util/invariant.h>
+
+class nondet_padding_exprt;
+void validate_expr(const nondet_padding_exprt &padding);
+
+const irep_idt ID_nondet_padding = "nondet_padding";
+
+class nondet_padding_exprt : public expr_protectedt
+{
+public:
+  explicit nondet_padding_exprt(typet type)
+    : expr_protectedt{ID_nondet_padding, std::move(type)}
+  {
+    validate_expr(*this);
+  }
+};
+
+template <>
+inline bool can_cast_expr<nondet_padding_exprt>(const exprt &base)
+{
+  return base.id() == ID_nondet_padding;
+}
+
+inline void validate_expr(const nondet_padding_exprt &padding)
+{
+  INVARIANT(
+    can_cast_type<bv_typet>(padding.type()),
+    "Nondet padding is expected to pad a bit vector type.");
+}
+
+#endif // CPROVER_SOLVERS_SMT2_INCREMENTAL_ENCODING_NONDET_PADDING_H

--- a/src/solvers/smt2_incremental/smt2_incremental_decision_procedure.h
+++ b/src/solvers/smt2_incremental/smt2_incremental_decision_procedure.h
@@ -102,6 +102,11 @@ protected:
   /// \note This function is non-const because it mutates the object_map.
   smt_termt convert_expr_to_smt(const exprt &expr);
   void define_index_identifiers(const exprt &expr);
+  /// In the case where lowering passes insert instances of the anonymous
+  /// `nondet_padding_exprt`, these need functions declaring for each instance.
+  /// These instances are then substituted for the function identifier in order
+  /// to free the solver to choose a non-det value.
+  exprt substitute_defined_padding(exprt expr);
   /// Sends the solver the definitions of the object sizes and dynamic memory
   /// statuses.
   void define_object_properties();
@@ -135,7 +140,7 @@ protected:
     {
       return next_id++;
     }
-  } handle_sequence, array_sequence, index_sequence;
+  } handle_sequence, array_sequence, index_sequence, padding_sequence;
   /// When the `handle(exprt)` member function is called, the decision procedure
   /// commands the SMT solver to define a new function corresponding to the
   /// given expression. The mapping of the expressions to the function

--- a/unit/Makefile
+++ b/unit/Makefile
@@ -117,6 +117,7 @@ SRC += analyses/ai/ai.cpp \
        solvers/smt2_incremental/smt_to_smt2_string.cpp \
        solvers/smt2_incremental/encoding/struct_encoding.cpp \
        solvers/smt2_incremental/encoding/enum_encoding.cpp \
+       solvers/smt2_incremental/encoding/nondet_padding.cpp \
        solvers/smt2_incremental/theories/smt_array_theory.cpp \
        solvers/smt2_incremental/theories/smt_bit_vector_theory.cpp \
        solvers/smt2_incremental/theories/smt_core_theory.cpp \

--- a/unit/solvers/smt2_incremental/encoding/nondet_padding.cpp
+++ b/unit/solvers/smt2_incremental/encoding/nondet_padding.cpp
@@ -1,0 +1,43 @@
+// Author: Diffblue Ltd.
+
+#include <util/expr_cast.h>
+#include <util/std_expr.h>
+
+#include <solvers/smt2_incremental/encoding/nondet_padding.h>
+#include <testing-utils/invariant.h>
+#include <testing-utils/use_catch.h>
+
+TEST_CASE("Nondet padding expression", "[core][smt2_incremental]")
+{
+  const bv_typet type{8};
+  const exprt padding = nondet_padding_exprt{type};
+  SECTION("Valid usage")
+  {
+    REQUIRE(padding.type() == type);
+    REQUIRE(nullptr != expr_try_dynamic_cast<nondet_padding_exprt>(padding));
+  }
+  const auto type_error = invariant_failure_containing(
+    "Nondet padding is expected to pad a bit vector type.");
+  SECTION("Failed downcasts")
+  {
+    const exprt not_padding = symbol_exprt{"foo", empty_typet{}};
+    REQUIRE(
+      nullptr == expr_try_dynamic_cast<nondet_padding_exprt>(not_padding));
+    const exprt wrong_type = [&]() {
+      exprt padding = nondet_padding_exprt{type};
+      padding.type() = empty_typet{};
+      return padding;
+    }();
+    cbmc_invariants_should_throwt invariants_throw;
+    CHECK_THROWS_MATCHES(
+      expr_checked_cast<nondet_padding_exprt>(wrong_type),
+      invariant_failedt,
+      type_error);
+  }
+  SECTION("Construction with incorrect type")
+  {
+    cbmc_invariants_should_throwt invariants_throw;
+    CHECK_THROWS_MATCHES(
+      nondet_padding_exprt{empty_typet{}}, invariant_failedt, type_error);
+  }
+}


### PR DESCRIPTION
This PR is a follow-up to https://github.com/diffblue/cbmc/pull/7914 Like the previous PR, I am attempting to keep this relatively small for ease of review. This PR adds support for `union_exprt` and only tests this support via catch tests.

I am planning to add support for `member_exprt` applied to unions in a follow-up PR. At which point it should be possible to make more complete union regression tests pass.
<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
