### PR TITLE
C library: ASM functions take void* pointers

### DIFF
--- a/.github/workflows/build-and-test-Xen.yaml
+++ b/.github/workflows/build-and-test-Xen.yaml
@@ -62,3 +62,9 @@ jobs:
         
       - name: Check for goto-cc section in xen-syms binary
         run: objdump -h xen_4_13/xen/xen-syms | grep "goto-cc"
+
+      - name: Show goto-cc properties
+        run:  $(pwd)/src/cbmc/cbmc --show-properties xen_4_13/xen/xen-syms
+
+      - name: Show some goto-cc functions
+        run:  $(pwd)/src/cbmc/cbmc --list-goto-functions xen_4_13/xen/xen-syms | grep "arch"

--- a/src/ansi-c/library/x86_assembler.c
+++ b/src/ansi-c/library/x86_assembler.c
@@ -3,30 +3,30 @@
 
 extern int __CPROVER_rounding_mode;
 
-void __asm_fnstcw(unsigned short *dest)
+void __asm_fnstcw(void *dest)
 {
   // the rounding mode is bits 10 and 11 in the control word
-  *dest=__CPROVER_rounding_mode<<10;
+  *(unsigned short *)dest = __CPROVER_rounding_mode << 10;
 }
 
 /* FUNCTION: __asm_fstcw */
 
 extern int __CPROVER_rounding_mode;
 
-void __asm_fstcw(unsigned short *dest)
+void __asm_fstcw(void *dest)
 {
   // the rounding mode is bits 10 and 11 in the control word
-  *dest=__CPROVER_rounding_mode<<10;
+  *(unsigned short *)dest = __CPROVER_rounding_mode << 10;
 }
 
 /* FUNCTION: __asm_fldcw */
 
 extern int __CPROVER_rounding_mode;
 
-void __asm_fldcw(const unsigned short *src)
+void __asm_fldcw(void *src)
 {
   // the rounding mode is bits 10 and 11 in the control word
-  __CPROVER_rounding_mode=((*src)>>10)&3;
+  __CPROVER_rounding_mode = ((*(const unsigned short *)src) >> 10) & 3;
 }
 
 /* FUNCTION: __asm_mfence */


### PR DESCRIPTION
This is the type of the function symbol created by `remove_asmt::gcc_asm_function_call`.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
