### PR TITLE
Add --pointer-check for shadow memory address

### DIFF
--- a/regression/cbmc-shadow-memory/pointer-checks1/main.c
+++ b/regression/cbmc-shadow-memory/pointer-checks1/main.c
@@ -1,0 +1,18 @@
+#include <assert.h>
+
+extern _Bool nondet();
+
+int main()
+{
+  __CPROVER_field_decl_local("field1", (_Bool)0);
+
+  char *buffer[10];
+
+  __CPROVER_set_field(&buffer[9], "field1", 1);
+  assert(__CPROVER_get_field(&buffer[9], "field1") == 1);
+  __CPROVER_set_field(&buffer[10], "field1", 1);
+  if(nondet())
+  {
+    assert(__CPROVER_get_field(&buffer[10], "field1") == 1);
+  }
+}

--- a/regression/cbmc-shadow-memory/pointer-checks1/test.desc
+++ b/regression/cbmc-shadow-memory/pointer-checks1/test.desc
@@ -1,0 +1,12 @@
+CORE
+main.c
+--verbosity 10 --pointer-check
+^EXIT=10$
+^SIGNAL=0$
+^VERIFICATION FAILED$
+line 13 dereference failure: pointer outside object bounds.*: FAILURE
+line 16 dereference failure: pointer outside object bounds.*: FAILURE
+--
+^warning: ignoring
+line 11 dereference failure: pointer outside object bounds.*: FAILURE
+line 12 dereference failure: pointer outside object bounds.*: FAILURE

--- a/regression/cbmc-shadow-memory/pointer-checks2/main.c
+++ b/regression/cbmc-shadow-memory/pointer-checks2/main.c
@@ -1,0 +1,15 @@
+#include <assert.h>
+
+int main()
+{
+  __CPROVER_field_decl_local("uninitialized", (char)0);
+
+  char a;
+  int *i = &a;
+
+  __CPROVER_set_field(i, "uninitialized", 1); // should this fail?
+
+  assert(__CPROVER_get_field(&a, "uninitialized") == 1);
+  assert(__CPROVER_get_field(&a + 1, "uninitialized") == 1);
+  assert(__CPROVER_get_field(i, "uninitialized") == 1);
+}

--- a/regression/cbmc-shadow-memory/pointer-checks2/test.desc
+++ b/regression/cbmc-shadow-memory/pointer-checks2/test.desc
@@ -1,0 +1,10 @@
+CORE
+main.c
+--verbosity 10 --pointer-check
+^EXIT=10$
+^SIGNAL=0$
+^VERIFICATION FAILED$
+line 10 dereference failure: pointer outside object bounds in \*i.*: FAILURE
+line 13 dereference failure: pointer outside object bounds in \(&a\).*: FAILURE
+line 14 dereference failure: pointer outside object bounds in \*i.*: FAILURE
+--


### PR DESCRIPTION
Add --pointer-check for shadow memory address.

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
