### PR TITLE
introduce widen_if_needed

### DIFF
--- a/src/ansi-c/c_preprocess.cpp
+++ b/src/ansi-c/c_preprocess.cpp
@@ -15,10 +15,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/run.h>
 #include <util/suffix.h>
 #include <util/tempfile.h>
-
-#ifdef _MSC_VER
-#  include <util/unicode.h>
-#endif
+#include <util/unicode.h>
 
 #include <fstream>
 
@@ -720,11 +717,7 @@ bool c_preprocess_none(
   std::ostream &outstream,
   message_handlert &message_handler)
 {
-  #ifdef _MSC_VER
-  std::ifstream infile(widen(file));
-  #else
-  std::ifstream infile(file);
-  #endif
+  std::ifstream infile(widen_if_needed(file));
 
   if(!infile)
   {

--- a/src/cbmc/cbmc_parse_options.cpp
+++ b/src/cbmc/cbmc_parse_options.cpp
@@ -16,16 +16,8 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/help_formatter.h>
 #include <util/invariant.h>
 #include <util/make_unique.h>
+#include <util/unicode.h>
 #include <util/version.h>
-
-#include <cstdlib> // exit()
-#include <fstream> // IWYU pragma: keep
-#include <iostream>
-#include <memory>
-
-#ifdef _MSC_VER
-#  include <util/unicode.h>
-#endif
 
 #include <goto-programs/initialize_goto_model.h>
 #include <goto-programs/link_to_library.h>
@@ -68,6 +60,11 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <pointer-analysis/add_failed_symbols.h>
 
 #include "c_test_input_generator.h"
+
+#include <cstdlib> // exit()
+#include <fstream> // IWYU pragma: keep
+#include <iostream>
+#include <memory>
 
 cbmc_parse_optionst::cbmc_parse_optionst(int argc, const char **argv)
   : parse_options_baset(
@@ -507,11 +504,7 @@ int cbmc_parse_optionst::doit()
 
     std::string filename=cmdline.args[0];
 
-    #ifdef _MSC_VER
-    std::ifstream infile(widen(filename));
-    #else
-    std::ifstream infile(filename);
-    #endif
+    std::ifstream infile(widen_if_needed(filename));
 
     if(!infile)
     {

--- a/src/cprover/cprover_parse_options.cpp
+++ b/src/cprover/cprover_parse_options.cpp
@@ -19,11 +19,8 @@ Author: Daniel Kroening, dkr@amazon.com
 #include <util/parse_options.h>
 #include <util/signal_catcher.h>
 #include <util/ui_message.h>
+#include <util/unicode.h>
 #include <util/version.h>
-
-#ifdef _WIN32
-#  include <util/unicode.h>
-#endif
 
 #include <goto-programs/adjust_float_expressions.h>
 #include <goto-programs/goto_inline.h>
@@ -236,11 +233,8 @@ int cprover_parse_optionst::main()
       if(cmdline.isset("outfile"))
       {
         auto file_name = cmdline.get_value("outfile");
-#ifdef _WIN32
-        std::ofstream out(widen(file_name));
-#else
-        std::ofstream out(file_name);
-#endif
+        std::ofstream out(widen_if_needed(file_name));
+
         if(!out)
         {
           std::cerr << "failed to open " << file_name << '\n';

--- a/src/goto-analyzer/show_on_source.cpp
+++ b/src/goto-analyzer/show_on_source.cpp
@@ -9,10 +9,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "show_on_source.h"
 
 #include <util/message.h>
-
-#ifdef _MSC_VER
-#  include <util/unicode.h>
-#endif
+#include <util/unicode.h>
 
 #include <analyses/ai.h>
 
@@ -74,11 +71,7 @@ void show_on_source(
   const ai_baset &ai,
   message_handlert &message_handler)
 {
-#ifdef _MSC_VER
-  std::ifstream in(widen(source_file));
-#else
-  std::ifstream in(source_file);
-#endif
+  std::ifstream in(widen_if_needed(source_file));
 
   messaget message(message_handler);
 

--- a/src/goto-cc/cl_message_handler.cpp
+++ b/src/goto-cc/cl_message_handler.cpp
@@ -8,9 +8,7 @@ Author: Michael Tautschnig
 
 #include "cl_message_handler.h"
 
-#ifdef _MSC_VER
-#  include <util/unicode.h>
-#endif
+#include <util/unicode.h>
 
 #include <fstream>
 
@@ -42,11 +40,8 @@ void cl_message_handlert::print(
 
   if(full_path.has_value() && !line.empty())
   {
-#ifdef _MSC_VER
-    std::ifstream in(widen(full_path.value()));
-#else
-    std::ifstream in(full_path.value());
-#endif
+    std::ifstream in(widen_if_needed(full_path.value()));
+
     if(in)
     {
       const auto line_number = std::stoull(line);

--- a/src/goto-cc/compile.cpp
+++ b/src/goto-cc/compile.cpp
@@ -13,10 +13,6 @@ Date: June 2006
 
 #include "compile.h"
 
-#include <cstring>
-#include <fstream>
-#include <iostream>
-
 #include <util/cmdline.h>
 #include <util/config.h>
 #include <util/file_util.h>
@@ -26,26 +22,25 @@ Date: June 2006
 #include <util/symbol_table_builder.h>
 #include <util/tempdir.h>
 #include <util/tempfile.h>
+#include <util/unicode.h>
 #include <util/version.h>
-
-#ifdef _MSC_VER
-#  include <util/unicode.h>
-#endif
-
-#include <ansi-c/ansi_c_entry_point.h>
-#include <ansi-c/c_object_factory_parameters.h>
 
 #include <goto-programs/goto_convert_functions.h>
 #include <goto-programs/name_mangler.h>
 #include <goto-programs/read_goto_binary.h>
 #include <goto-programs/write_goto_binary.h>
 
+#include <ansi-c/ansi_c_entry_point.h>
+#include <ansi-c/c_object_factory_parameters.h>
 #include <langapi/language.h>
 #include <langapi/language_file.h>
 #include <langapi/mode.h>
-
 #include <linking/linking.h>
 #include <linking/static_lifetime_init.h>
+
+#include <cstring>
+#include <fstream>
+#include <iostream>
 
 #define DOTGRAPHSETTINGS  "color=black;" \
                           "orientation=portrait;" \
@@ -479,11 +474,7 @@ bool compilet::parse(
   if(file_name == "-")
     return parse_stdin(*languagep);
 
-#ifdef _MSC_VER
-  std::ifstream infile(widen(file_name));
-#else
-  std::ifstream infile(file_name);
-#endif
+  std::ifstream infile(widen_if_needed(file_name));
 
   if(!infile)
   {

--- a/src/goto-cc/gcc_message_handler.cpp
+++ b/src/goto-cc/gcc_message_handler.cpp
@@ -8,9 +8,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "gcc_message_handler.h"
 
-#ifdef _MSC_VER
-#  include <util/unicode.h>
-#endif
+#include <util/unicode.h>
 
 #include <fstream> // IWYU pragma: keep
 #include <iostream>
@@ -68,11 +66,8 @@ void gcc_message_handlert::print(
     const auto file_name = location.full_path();
     if(file_name.has_value() && !line.empty())
     {
-#ifdef _MSC_VER
-      std::ifstream in(widen(file_name.value()));
-#else
-      std::ifstream in(file_name.value());
-#endif
+      std::ifstream in(widen_if_needed(file_name.value()));
+
       if(in)
       {
         const auto line_number = std::stoull(id2string(line));

--- a/src/goto-checker/solver_factory.cpp
+++ b/src/goto-checker/solver_factory.cpp
@@ -17,16 +17,10 @@ Author: Daniel Kroening, Peter Schrammel
 #include <util/make_unique.h>
 #include <util/message.h>
 #include <util/options.h>
+#include <util/unicode.h>
 #include <util/version.h>
 
-#include <iostream>
-
-#ifdef _MSC_VER
-#include <util/unicode.h>
-#endif
-
-#include <solvers/stack_decision_procedure.h>
-
+#include <goto-symex/solver_hardness.h>
 #include <solvers/flattening/bv_dimacs.h>
 #include <solvers/prop/prop.h>
 #include <solvers/prop/solver_resource_limits.h>
@@ -36,9 +30,10 @@ Author: Daniel Kroening, Peter Schrammel
 #include <solvers/sat/satcheck.h>
 #include <solvers/smt2_incremental/smt2_incremental_decision_procedure.h>
 #include <solvers/smt2_incremental/smt_solver_process.h>
+#include <solvers/stack_decision_procedure.h>
 #include <solvers/strings/string_refinement.h>
 
-#include <goto-symex/solver_hardness.h>
+#include <iostream>
 
 solver_factoryt::solver_factoryt(
   const optionst &_options,
@@ -450,11 +445,7 @@ std::unique_ptr<std::ofstream> open_outfile_and_check(
   if(filename.empty())
     return nullptr;
 
-#ifdef _MSC_VER
-  auto out = util_make_unique<std::ofstream>(widen(filename));
-#else
-  auto out = util_make_unique<std::ofstream>(filename);
-#endif
+  auto out = util_make_unique<std::ofstream>(widen_if_needed(filename));
 
   if(!*out)
   {

--- a/src/goto-instrument/goto_instrument_parse_options.cpp
+++ b/src/goto-instrument/goto_instrument_parse_options.cpp
@@ -18,15 +18,8 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/options.h>
 #include <util/string2int.h>
 #include <util/string_utils.h>
+#include <util/unicode.h>
 #include <util/version.h>
-
-#include <fstream> // IWYU pragma: keep
-#include <iostream>
-#include <memory>
-
-#ifdef _MSC_VER
-#  include <util/unicode.h>
-#endif
 
 #include <goto-programs/class_hierarchy.h>
 #include <goto-programs/ensure_one_backedge_per_target.h>
@@ -108,6 +101,10 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "undefined_functions.h"
 #include "unwind.h"
 #include "value_set_fi_fp_removal.h"
+
+#include <fstream> // IWYU pragma: keep
+#include <iostream>
+#include <memory>
 
 #include "accelerate/accelerate.h"
 
@@ -248,11 +245,8 @@ int goto_instrument_parse_optionst::doit()
 
           if(have_file)
           {
-#ifdef _MSC_VER
-            std::ofstream of(widen(filename));
-#else
-            std::ofstream of(filename);
-#endif
+            std::ofstream of(widen_if_needed(filename));
+
             if(!of)
               throw "failed to open file "+filename;
 
@@ -745,11 +739,8 @@ int goto_instrument_parse_optionst::doit()
 
       if(cmdline.args.size()==2)
       {
-        #ifdef _MSC_VER
-        std::ofstream out(widen(cmdline.args[1]));
-        #else
-        std::ofstream out(cmdline.args[1]);
-        #endif
+        std::ofstream out(widen_if_needed(cmdline.args[1]));
+
         if(!out)
         {
           log.error() << "failed to write to '" << cmdline.args[1] << "'";
@@ -844,11 +835,8 @@ int goto_instrument_parse_optionst::doit()
 
       if(cmdline.args.size()==2)
       {
-        #ifdef _MSC_VER
-        std::ofstream out(widen(cmdline.args[1]));
-        #else
-        std::ofstream out(cmdline.args[1]);
-        #endif
+        std::ofstream out(widen_if_needed(cmdline.args[1]));
+
         if(!out)
         {
           log.error() << "failed to write to " << cmdline.args[1] << "'";
@@ -891,11 +879,7 @@ int goto_instrument_parse_optionst::doit()
 
       if(cmdline.args.size()==2)
       {
-        #ifdef _MSC_VER
-        std::ofstream out(widen(cmdline.args[1]));
-        #else
-        std::ofstream out(cmdline.args[1]);
-        #endif
+        std::ofstream out(widen_if_needed(cmdline.args[1]));
 
         if(!out)
         {
@@ -1338,11 +1322,8 @@ void goto_instrument_parse_optionst::instrument_goto_program()
 
       if(have_file)
       {
-#ifdef _MSC_VER
-        std::ofstream of(widen(filename));
-#else
-        std::ofstream of(filename);
-#endif
+        std::ofstream of(widen_if_needed(filename));
+
         if(!of)
           throw "failed to open file "+filename;
 

--- a/src/goto-instrument/unwindset.cpp
+++ b/src/goto-instrument/unwindset.cpp
@@ -13,10 +13,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/string2int.h>
 #include <util/string_utils.h>
 #include <util/symbol_table.h>
-
-#ifdef _MSC_VER
-#  include <util/unicode.h>
-#endif
+#include <util/unicode.h>
 
 #include <goto-programs/abstract_goto_model.h>
 
@@ -234,11 +231,7 @@ void unwindsett::parse_unwindset_file(
   const std::string &file_name,
   message_handlert &message_handler)
 {
-  #ifdef _MSC_VER
-  std::ifstream file(widen(file_name));
-  #else
-  std::ifstream file(file_name);
-  #endif
+  std::ifstream file(widen_if_needed(file_name));
 
   if(!file)
     throw "cannot open file "+file_name;

--- a/src/goto-programs/read_goto_binary.cpp
+++ b/src/goto-programs/read_goto_binary.cpp
@@ -11,22 +11,19 @@ Author:
 
 #include "read_goto_binary.h"
 
-#include <fstream>
-
 #include <util/config.h>
 #include <util/message.h>
 #include <util/replace_symbol.h>
 #include <util/tempfile.h>
+#include <util/unicode.h>
 
-#ifdef _MSC_VER
-#  include <util/unicode.h>
-#endif
-
+#include "elf_reader.h"
 #include "goto_model.h"
 #include "link_goto_model.h"
-#include "read_bin_goto_object.h"
-#include "elf_reader.h"
 #include "osx_fat_reader.h"
+#include "read_bin_goto_object.h"
+
+#include <fstream>
 
 static bool read_goto_binary(
   const std::string &filename,
@@ -64,11 +61,7 @@ static bool read_goto_binary(
   goto_functionst &goto_functions,
   message_handlert &message_handler)
 {
-  #ifdef _MSC_VER
-  std::ifstream in(widen(filename), std::ios::binary);
-  #else
-  std::ifstream in(filename, std::ios::binary);
-  #endif
+  std::ifstream in(widen_if_needed(filename), std::ios::binary);
 
   messaget message(message_handler);
 
@@ -193,11 +186,7 @@ bool is_goto_binary(
   const std::string &filename,
   message_handlert &message_handler)
 {
-  #ifdef _MSC_VER
-  std::ifstream in(widen(filename), std::ios::binary);
-  #else
-  std::ifstream in(filename, std::ios::binary);
-  #endif
+  std::ifstream in(widen_if_needed(filename), std::ios::binary);
 
   if(!in)
     return false;

--- a/src/goto-synthesizer/goto_synthesizer_parse_options.cpp
+++ b/src/goto-synthesizer/goto_synthesizer_parse_options.cpp
@@ -10,6 +10,7 @@ Author: Qinheping Hu
 
 #include <util/exit_codes.h>
 #include <util/help_formatter.h>
+#include <util/unicode.h>
 #include <util/version.h>
 
 #include <goto-programs/read_goto_binary.h>
@@ -24,10 +25,6 @@ Author: Qinheping Hu
 
 #include <fstream>
 #include <iostream>
-
-#ifdef _MSC_VER
-#  include <util/unicode.h>
-#endif
 
 /// invoke main modules
 int goto_synthesizer_parse_optionst::doit()
@@ -84,11 +81,8 @@ int goto_synthesizer_parse_optionst::doit()
     // Output file specified
     if(cmdline.args.size() == 2)
     {
-#ifdef _MSC_VER
-      std::ofstream out(widen(cmdline.args[1]));
-#else
-      std::ofstream out(cmdline.args[1]);
-#endif
+      std::ofstream out(widen_if_needed(cmdline.args[1]));
+
       if(!out)
       {
         log.error() << "failed to write to '" << cmdline.args[1] << "'";

--- a/src/util/unicode.h
+++ b/src/util/unicode.h
@@ -21,6 +21,13 @@ std::wstring widen(const char *s);
 std::string narrow(const std::wstring &s);
 std::wstring widen(const std::string &s);
 
+// This removes the need to have a #ifdef whenever using std::fstream.
+#ifdef _WIN32
+#  define widen_if_needed(s) widen(s)
+#else
+#  define widen_if_needed(s) (s)
+#endif
+
 std::string
 utf32_native_endian_to_utf8(const std::basic_string<unsigned int> &s);
 


### PR DESCRIPTION
This introduces a macro `widen_if_needed(s)` to replace the common pattern

```
 #ifdef _MSC_VER
  std::ifstream infile(widen(file));
 #else
  std::ifstream infile(file);
 #endif
```

by the shorter and less redundant

  `std::ifstream infile(widen_if_needed(file));`

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
