### PR TITLE
Non functional improvements to shadow memory utility functions

### DIFF
--- a/src/goto-symex/shadow_memory.cpp
+++ b/src/goto-symex/shadow_memory.cpp
@@ -116,7 +116,7 @@ void shadow_memoryt::symex_set_field(
 #endif
   std::vector<exprt> value_set = state.value_set.get_value_set(expr, ns);
   log_value_set(ns, log, value_set);
-  if(set_field_check_null(ns, log, value_set, expr))
+  if(check_value_set_contains_only_null_ptr(ns, log, value_set, expr))
   {
     log.warning() << "Shadow memory: cannot set shadow memory of NULL"
                   << messaget::eom;

--- a/src/goto-symex/shadow_memory.cpp
+++ b/src/goto-symex/shadow_memory.cpp
@@ -315,7 +315,8 @@ void shadow_memoryt::symex_get_field(
 #ifdef DEBUG_SHADOW_MEMORY
     log.debug() << "Shadow memory: RHS: " << format(rhs) << messaget::eom;
 #endif
-    // TODO: create the assignment of __CPROVER_shadow_memory_get_field
+
+    // create the assignment of __CPROVER_shadow_memory_get_field
     symex_assign(state, lhs, typecast_exprt::conditional_cast(rhs, lhs.type()));
   }
   else

--- a/src/goto-symex/shadow_memory.cpp
+++ b/src/goto-symex/shadow_memory.cpp
@@ -111,7 +111,7 @@ void shadow_memoryt::symex_set_field(
 
   // get value set
   replace_invalid_object_by_null(expr);
-#ifdef DEBUG_SM
+#ifdef DEBUG_SHADOW_MEMORY
   log_set_field(ns, log, field_name, expr, value);
 #endif
   std::vector<exprt> value_set = state.value_set.get_value_set(expr, ns);
@@ -143,7 +143,7 @@ void shadow_memoryt::symex_set_field(
                   << messaget::eom;
     }
     const exprt lhs = deref_expr(*maybe_lhs);
-#ifdef DEBUG_SM
+#ifdef DEBUG_SHADOW_MEMORY
     log.debug() << "Shadow memory: LHS: " << format(lhs) << messaget::eom;
 #endif
     if(lhs.type().id() == ID_empty)
@@ -168,7 +168,7 @@ void shadow_memoryt::symex_set_field(
       expr_initializer(lhs.type(), expr.source_location(), ns, casted_rhs);
     CHECK_RETURN(per_byte_rhs.has_value());
 
-#ifdef DEBUG_SM
+#ifdef DEBUG_SHADOW_MEMORY
     log.debug() << "Shadow memory: RHS: " << format(per_byte_rhs.value())
                 << messaget::eom;
 #endif
@@ -312,7 +312,7 @@ void shadow_memoryt::symex_get_field(
       log.debug() << "Shadow memory: mux size get_field: " << mux_size
                   << messaget::eom;
     }
-#ifdef DEBUG_SM
+#ifdef DEBUG_SHADOW_MEMORY
     log.debug() << "Shadow memory: RHS: " << format(rhs) << messaget::eom;
 #endif
     // TODO: create the assignment of __CPROVER_shadow_memory_get_field

--- a/src/goto-symex/shadow_memory.cpp
+++ b/src/goto-symex/shadow_memory.cpp
@@ -103,7 +103,7 @@ void shadow_memoryt::symex_set_field(
     irep_pretty_diagnosticst{expr_type});
 
   exprt value = arguments[2];
-  log_set_field(ns, log, field_name, expr, value);
+  shadow_memory_log_set_field(ns, log, field_name, expr, value);
   INVARIANT(
     state.shadow_memory.address_fields.count(field_name) == 1,
     id2string(field_name) + " should exist");
@@ -111,11 +111,11 @@ void shadow_memoryt::symex_set_field(
 
   // get value set
   replace_invalid_object_by_null(expr);
-#ifdef DEBUG_SHADOW_MEMORY
-  log_set_field(ns, log, field_name, expr, value);
-#endif
+
+  shadow_memory_log_set_field(ns, log, field_name, expr, value);
+
   std::vector<exprt> value_set = state.value_set.get_value_set(expr, ns);
-  log_value_set(ns, log, value_set);
+  shadow_memory_log_value_set(ns, log, value_set);
   if(check_value_set_contains_only_null_ptr(ns, log, value_set, expr))
   {
     log.warning() << "Shadow memory: cannot set shadow memory of NULL"
@@ -143,9 +143,9 @@ void shadow_memoryt::symex_set_field(
                   << messaget::eom;
     }
     const exprt lhs = deref_expr(*maybe_lhs);
-#ifdef DEBUG_SHADOW_MEMORY
-    log.debug() << "Shadow memory: LHS: " << format(lhs) << messaget::eom;
-#endif
+
+    shadow_memory_log_text_and_expr(ns, log, "LHS", lhs);
+
     if(lhs.type().id() == ID_empty)
     {
       std::stringstream s;
@@ -168,10 +168,7 @@ void shadow_memoryt::symex_set_field(
       expr_initializer(lhs.type(), expr.source_location(), ns, casted_rhs);
     CHECK_RETURN(per_byte_rhs.has_value());
 
-#ifdef DEBUG_SHADOW_MEMORY
-    log.debug() << "Shadow memory: RHS: " << format(per_byte_rhs.value())
-                << messaget::eom;
-#endif
+    shadow_memory_log_text_and_expr(ns, log, "RHS", per_byte_rhs.value());
     symex_assign(
       state,
       lhs,
@@ -206,7 +203,7 @@ void shadow_memoryt::symex_get_field(
   DATA_INVARIANT(
     expr_type.id() == ID_pointer,
     "shadow memory requires a pointer expression");
-  log_get_field(ns, log, field_name, expr);
+  shadow_memory_log_get_field(ns, log, field_name, expr);
 
   INVARIANT(
     state.shadow_memory.address_fields.count(field_name) == 1,
@@ -218,7 +215,7 @@ void shadow_memoryt::symex_get_field(
   replace_invalid_object_by_null(expr);
 
   std::vector<exprt> value_set = state.value_set.get_value_set(expr, ns);
-  log_value_set(ns, log, value_set);
+  shadow_memory_log_value_set(ns, log, value_set);
 
   std::vector<std::pair<exprt, exprt>> rhs_conds_values;
   const null_pointer_exprt null_pointer(to_pointer_type(expr.type()));
@@ -227,7 +224,7 @@ void shadow_memoryt::symex_get_field(
 
   if(contains_null_or_invalid(value_set, null_pointer))
   {
-    log_value_set_match(ns, log, null_pointer, expr);
+    shadow_memory_log_value_set_match(ns, log, null_pointer, expr);
     // If we have an invalid pointer, then return the default value of the
     // shadow memory as dereferencing it would fail
     rhs_conds_values.emplace_back(
@@ -312,9 +309,8 @@ void shadow_memoryt::symex_get_field(
       log.debug() << "Shadow memory: mux size get_field: " << mux_size
                   << messaget::eom;
     }
-#ifdef DEBUG_SHADOW_MEMORY
-    log.debug() << "Shadow memory: RHS: " << format(rhs) << messaget::eom;
-#endif
+
+    shadow_memory_log_text_and_expr(ns, log, "RHS", rhs);
 
     // create the assignment of __CPROVER_shadow_memory_get_field
     symex_assign(state, lhs, typecast_exprt::conditional_cast(rhs, lhs.type()));

--- a/src/goto-symex/shadow_memory_util.cpp
+++ b/src/goto-symex/shadow_memory_util.cpp
@@ -23,9 +23,8 @@ Author: Peter Schrammel
 #include <util/ssa_expr.h>
 #include <util/std_expr.h>
 
+#include <langapi/language_util.h>
 #include <solvers/flattening/boolbv_width.h>
-
-// TODO: change DEBUG_SM to DEBUG_SHADOW_MEMORY (it also appears in other files)
 
 irep_idt extract_field_name(const exprt &string_expr)
 {
@@ -125,7 +124,7 @@ void log_value_set(
   const messaget &log,
   const std::vector<exprt> &value_set)
 {
-#ifdef DEBUG_SM
+#ifdef DEBUG_SHADOW_MEMORY
   log.conditional_output(
     log.debug(), [ns, value_set](messaget::mstreamt &mstream) {
       for(const auto &e : value_set)
@@ -145,7 +144,7 @@ void log_value_set_match(
   const exprt &expr,
   const value_set_dereferencet::valuet &shadow_dereference)
 {
-#ifdef DEBUG_SM
+#ifdef DEBUG_SHADOW_MEMORY
   log.conditional_output(
     log.debug(),
     [ns,
@@ -174,7 +173,7 @@ void log_value_set_match(
   const exprt &expr)
 {
   // Leave guards rename to DEBUG_SHADOW_MEMORY
-#ifdef DEBUG_SM
+#ifdef DEBUG_SHADOW_MEMORY
   log.conditional_output(
     log.debug(), [ns, address, expr](messaget::mstreamt &mstream) {
       mstream << "Shadow memory: value_set_match: " << format(address)
@@ -188,7 +187,7 @@ void log_try_shadow_address(
   const messaget &log,
   const shadow_memory_statet::shadowed_addresst &shadowed_address)
 {
-#ifdef DEBUG_SM
+#ifdef DEBUG_SHADOW_MEMORY
   log.conditional_output(
     log.debug(), [ns, shadowed_address](messaget::mstreamt &mstream) {
       mstream << "Shadow memory: trying shadowed address: "
@@ -203,7 +202,7 @@ void log_cond(
   const char *cond_text,
   const exprt &cond)
 {
-#ifdef DEBUG_SM
+#ifdef DEBUG_SHADOW_MEMORY
   log.conditional_output(
     log.debug(), [ns, cond_text, cond](messaget::mstreamt &mstream) {
       mstream << "Shadow memory: " << cond_text << ": " << format(cond)
@@ -218,7 +217,7 @@ static void log_are_types_incompatible(
   const shadow_memory_statet::shadowed_addresst &shadowed_address,
   const messaget &log)
 {
-#ifdef DEBUG_SM
+#ifdef DEBUG_SHADOW_MEMORY
   log.debug() << "Shadow memory: incompatible types "
               << from_type(ns, "", expr.type()) << ", "
               << from_type(ns, "", shadowed_address.address.type())
@@ -718,7 +717,7 @@ static value_set_dereferencet::valuet get_shadow_dereference(
   shadowed_object.object() = shadow;
   value_set_dereferencet::valuet shadow_dereference =
     value_set_dereferencet::build_reference_to(shadowed_object, expr, ns);
-#ifdef DEBUG_SM
+#ifdef DEBUG_SHADOW_MEMORY
   log.debug() << "Shadow memory: shadow-deref: "
               << format(shadow_dereference.value) << messaget::eom;
 #endif
@@ -842,7 +841,7 @@ std::vector<std::pair<exprt, exprt>> get_shadow_dereference_candidates(
 
     if(base_cond.is_true() && expr_cond.is_true())
     {
-#ifdef DEBUG_SM
+#ifdef DEBUG_SHADOW_MEMORY
       log.debug() << "exact match" << messaget::eom;
 #endif
       exact_match = true;
@@ -855,7 +854,7 @@ std::vector<std::pair<exprt, exprt>> get_shadow_dereference_candidates(
     {
       // No point looking at further shadow addresses
       // as only one of them can match.
-#ifdef DEBUG_SM
+#ifdef DEBUG_SHADOW_MEMORY
       log.debug() << "base match" << messaget::eom;
 #endif
       result.clear();
@@ -864,7 +863,7 @@ std::vector<std::pair<exprt, exprt>> get_shadow_dereference_candidates(
     }
     else
     {
-#ifdef DEBUG_SM
+#ifdef DEBUG_SHADOW_MEMORY
       log.debug() << "conditional match" << messaget::eom;
 #endif
       result.emplace_back(and_exprt(base_cond, expr_cond), value);
@@ -932,7 +931,7 @@ bool check_value_set_contains_only_null_ptr(
   if(value_set.size() == 1 && contains_null_or_invalid(value_set, null_pointer))
   {
     // TODO: duplicated in log_value_set_match
-#ifdef DEBUG_SM
+#ifdef DEBUG_SHADOW_MEMORY
     log.conditional_output(
       log.debug(), [ns, null_pointer, expr](messaget::mstreamt &mstream) {
         mstream << "Shadow memory: value set match: " << format(null_pointer)
@@ -963,7 +962,7 @@ get_shadow_memory_for_matched_object(
 
     if(!are_types_compatible(expr.type(), shadowed_address.address.type()))
     {
-#ifdef DEBUG_SM
+#ifdef DEBUG_SHADOW_MEMORY
       log.debug() << "Shadow memory: incompatible types "
                   << from_type(ns, "", expr.type()) << ", "
                   << from_type(ns, "", shadowed_address.address.type())
@@ -1017,7 +1016,7 @@ get_shadow_memory_for_matched_object(
 
     if(base_cond.is_true() && expr_cond.is_true())
     {
-#ifdef DEBUG_SM
+#ifdef DEBUG_SHADOW_MEMORY
       log.debug() << "exact match" << messaget::eom;
 #endif
       exact_match = true;
@@ -1030,7 +1029,7 @@ get_shadow_memory_for_matched_object(
     {
       // No point looking at further shadow addresses
       // as only one of them can match.
-#ifdef DEBUG_SM
+#ifdef DEBUG_SHADOW_MEMORY
       log.debug() << "base match" << messaget::eom;
 #endif
       result.clear();
@@ -1039,7 +1038,7 @@ get_shadow_memory_for_matched_object(
     }
     else
     {
-#ifdef DEBUG_SM
+#ifdef DEBUG_SHADOW_MEMORY
       log.debug() << "conditional match" << messaget::eom;
 #endif
       result.emplace_back(

--- a/src/goto-symex/shadow_memory_util.cpp
+++ b/src/goto-symex/shadow_memory_util.cpp
@@ -138,6 +138,9 @@ void log_value_set(
 #endif
 }
 
+/// Log a match between an address and a value the value set. This version of
+/// the function reports more details, including the base address, the pointer
+/// and the shadow value.
 void log_value_set_match(
   const namespacet &ns,
   const messaget &log,
@@ -185,6 +188,9 @@ void log_value_set_match(
 #endif
 }
 
+/// Log trying out a match between an object and a (target) shadow address.
+/// @param shadowed_address The address for which we're currently attempting to
+///   match.
 void log_try_shadow_address(
   const namespacet &ns,
   const messaget &log,
@@ -199,6 +205,9 @@ void log_try_shadow_address(
 #endif
 }
 
+/// Generic logging function that will log depending on the configured
+/// verbosity. Will log a specific message given to it, along with an expression
+/// passed along to it.
 void log_cond(
   const namespacet &ns,
   const messaget &log,
@@ -294,7 +303,9 @@ bool contains_null_or_invalid(
   return false;
 }
 
-// TODO: doxygen?
+/// Casts a given (float) bitvector expression to an unsigned bitvector.
+/// \param value The expression that we are to conditionally cast.
+/// \return An unsigned bitvector expression if eligible - `id` otherwise.
 static exprt conditional_cast_floatbv_to_unsignedbv(const exprt &value)
 {
   if(value.type().id() != ID_floatbv)
@@ -307,7 +318,13 @@ static exprt conditional_cast_floatbv_to_unsignedbv(const exprt &value)
     unsignedbv_typet(to_bitvector_type(value.type()).get_width()));
 }
 
-// TODO: doxygen?
+/// Extract byte-sized elements from the input bitvector-typed expression value
+/// and places them into the array values.
+/// \param value the bitvector typed expression to extract the bytes from
+/// \param type the type of the expression expr (it must be bitvector)
+/// \param field_type the type of the shadow memory
+/// \param values the vector where all the extracted bytes of value will be
+///   placed.
 static void extract_bytes_of_bv(
   const exprt &value,
   const typet &type,
@@ -327,7 +344,16 @@ static void extract_bytes_of_bv(
   }
 }
 
-// TODO: doxygen?
+/// Extract the components from the input expression value and places them into
+/// the array values.
+/// \param element the expression to extract the bytes from
+/// \param field_type the type of the shadow memory
+/// \param ns the namespace within which we're going to perform symbol lookups
+/// \param log the message log to which we're going to print debugging messages,
+///   if debugging is set
+/// \param is_union true if the expression element is part of a union
+/// \param values the vector where all the extracted components of element will
+///   be placed.
 static void extract_bytes_of_expr(
   exprt element,
   const typet &field_type,
@@ -556,7 +582,6 @@ exprt compute_max_over_bytes(
   return max_expr;
 }
 
-// TODO: doxygen?
 exprt build_if_else_expr(
   const std::vector<std::pair<exprt, exprt>> &conds_values)
 {
@@ -577,7 +602,12 @@ exprt build_if_else_expr(
   return result;
 }
 
-// TODO: doxygen?
+/// @brief Checks given types (object type and shadow memory field type) for
+///   equality. We're inspecting only pointer types here - if the two types
+///   given are not pointer types, then we assume it to be vacuously true.
+/// @param expr_type The type of the real object.
+/// @param shadow_type The type of the shadow memory field's value.
+/// @return True if types equal, false otherwise.
 static bool
 are_types_compatible(const typet &expr_type, const typet &shadow_type)
 {
@@ -607,9 +637,9 @@ are_types_compatible(const typet &expr_type, const typet &shadow_type)
   return true;
 }
 
-// TODO: doxygen?
-/// We simplify &string_constant[0] to &string_constant to facilitate expression
+/// Simplify &string_constant[0] to &string_constant to facilitate expression
 /// equality for exact matching.
+/// \note expression expr will be changed.
 static void clean_string_constant(exprt &expr)
 {
   const auto *index_expr = expr_try_dynamic_cast<index_exprt>(expr);
@@ -621,7 +651,10 @@ static void clean_string_constant(exprt &expr)
   }
 }
 
-// TODO: doxygen?
+/// Flattens type of the form `pointer_type(array_type(element_type))` to
+/// `pointer_type(element_type)` and `pointer_type(string_constant_type)` to
+/// `pointer_type(char)`.
+/// \note type `type` will be changed.
 static void adjust_array_types(typet &type)
 {
   auto *pointer_type = type_try_dynamic_cast<pointer_typet>(type);
@@ -641,7 +674,12 @@ static void adjust_array_types(typet &type)
   }
 }
 
-// TODO: doxygen?
+/// Function that compares the two arguments shadowed_address and
+/// matched_base_address, simplifies the comparison expression and if the lhs
+/// and rhs are structurally identical returns true, otherwise returns the
+/// comparison.
+/// \return the comparison expression of shadowed_address and
+/// matched_base_address (or a true_exprt if identical modulo simplification).
 static exprt get_matched_base_cond(
   const exprt &shadowed_address,
   const exprt &matched_base_address,
@@ -676,7 +714,11 @@ static exprt get_matched_base_cond(
   return base_cond;
 }
 
-// TODO: doxygen?
+/// Function that compares the two arguments dereference_pointer and expr,
+/// simplifies the comparison expression and if the lhs and rhs are structurally
+/// identical returns true, otherwise returns the comparison.
+/// \return the comparison expression of dereference_pointer and expr (or a
+/// true_exprt if identical modulo simplification).
 static exprt get_matched_expr_cond(
   const exprt &dereference_pointer,
   const exprt &expr,
@@ -738,7 +780,6 @@ static value_set_dereferencet::valuet get_shadow_dereference(
   return shadow_dereference;
 }
 
-// TODO: doxygen?
 /* foreach shadowed_address in SM:
  *   if(incompatible(shadow.object, object)) continue; // Type incompatibility
  *   base_match = object == shadow_object; // Do the base obj match the SM obj
@@ -886,7 +927,6 @@ std::vector<std::pair<exprt, exprt>> get_shadow_dereference_candidates(
   return result;
 }
 
-// TODO: doxygen?
 // Unfortunately.
 static object_descriptor_exprt
 normalize(const object_descriptor_exprt &expr, const namespacet &ns)

--- a/src/goto-symex/shadow_memory_util.h
+++ b/src/goto-symex/shadow_memory_util.h
@@ -15,14 +15,53 @@ Author: Peter Schrammel
 #include <util/irep.h>
 #include <util/message.h> // IWYU pragma: keep
 
-#include <pointer-analysis/value_set_dereference.h>
-
 #include "goto_symex_state.h" // IWYU pragma: keep
 
 // To enable logging of Shadow Memory functions define DEBUG_SHADOW_MEMORY
 
 class exprt;
 class typet;
+
+/// Logs setting a value to a given shadow field. Mainly for use for
+/// debugging purposes.
+void shadow_memory_log_set_field(
+  const namespacet &ns,
+  const messaget &log,
+  const irep_idt &field_name,
+  const exprt &expr,
+  const exprt &value);
+
+/// Logs the retrieval of the value associated with a given shadow
+/// memory field. Mainly for use for debugging purposes. Dual to
+/// shadow_memory_log_get_field.
+void shadow_memory_log_value_set(
+  const namespacet &ns,
+  const messaget &log,
+  const std::vector<exprt> &value_set);
+
+/// Logs getting a value corresponding to a shadow memory field. Mainly used for
+/// debugging purposes.
+void shadow_memory_log_get_field(
+  const namespacet &ns,
+  const messaget &log,
+  const irep_idt &field_name,
+  const exprt &expr);
+
+/// Logs a successful match between an address and a value within the value set.
+void shadow_memory_log_value_set_match(
+  const namespacet &ns,
+  const messaget &log,
+  const exprt &address,
+  const exprt &expr);
+
+/// Generic logging function that will log depending on the configured
+/// verbosity. The log will be a specific message given to it, along with an
+/// expression passed along to it.
+void shadow_memory_log_text_and_expr(
+  const namespacet &ns,
+  const messaget &log,
+  const char *text,
+  const exprt &expr);
 
 /// Extracts the field name identifier from a string expression,
 /// e.g. as passed as argument to a __CPROVER_field_decl_local call.
@@ -42,66 +81,6 @@ void clean_pointer_expr(exprt &expr, const typet &type);
 /// Wraps a given expression into a `dereference_exprt` unless it is an
 /// `address_of_exprt` in which case it just unboxes it and returns its content.
 exprt deref_expr(const exprt &expr);
-
-/// Logs setting a value to a given shadow field. Mainly for use for
-/// debugging purposes.
-void log_set_field(
-  const namespacet &ns,
-  const messaget &log,
-  const irep_idt &field_name,
-  const exprt &expr,
-  const exprt &value);
-
-/// Logs getting a value corresponding to a shadow memory field. Mainly for
-/// use for debugging purposes.
-void log_get_field(
-  const namespacet &ns,
-  const messaget &log,
-  const irep_idt &field_name,
-  const exprt &expr);
-
-/// Logs the retrieval of the value associated with a given shadow
-/// memory field. Mainly for use for debugging purposes. Dual to log_get_field.
-void log_value_set(
-  const namespacet &ns,
-  const messaget &log,
-  const std::vector<exprt> &value_set);
-
-/// Log a match between an address and a value the value set. This version of
-/// the function reports more details, including the base address, the pointer
-/// and the shadow value.
-void log_value_set_match(
-  const namespacet &ns,
-  const messaget &log,
-  const shadow_memory_statet::shadowed_addresst &shadowed_address,
-  const exprt &matched_base_address,
-  const value_set_dereferencet::valuet &dereference,
-  const exprt &expr,
-  const value_set_dereferencet::valuet &shadow_dereference);
-
-/// Logs a successful match between an address and a value within the value set.
-void log_value_set_match(
-  const namespacet &ns,
-  const messaget &log,
-  const exprt &address,
-  const exprt &expr);
-
-/// Log trying out a match between an object and a (target) shadow address.
-/// @param shadowed_address The address for which we're currently attempting to
-///   match.
-void log_try_shadow_address(
-  const namespacet &ns,
-  const messaget &log,
-  const shadow_memory_statet::shadowed_addresst &shadowed_address);
-
-/// Generic logging function that will log depending on the configured
-/// verbosity. Will log a specific message given to it, along with an expression
-/// passed along to it.
-void log_cond(
-  const namespacet &ns,
-  const messaget &log,
-  const char *cond_text,
-  const exprt &cond);
 
 /// Replace an invalid object by a null pointer. Works recursively on the
 /// operands (child nodes) of the expression, as well.

--- a/src/goto-symex/shadow_memory_util.h
+++ b/src/goto-symex/shadow_memory_util.h
@@ -19,6 +19,8 @@ Author: Peter Schrammel
 
 #include "goto_symex_state.h" // IWYU pragma: keep
 
+// To enable logging of Shadow Memory functions define DEBUG_SHADOW_MEMORY
+
 class exprt;
 class typet;
 

--- a/src/goto-symex/shadow_memory_util.h
+++ b/src/goto-symex/shadow_memory_util.h
@@ -146,7 +146,7 @@ bool contains_null_or_invalid(
 
 /// Performs aggregation of the shadow memory field value over multiple cells
 /// for fields whose type is _Bool.
-exprt compute_or_over_cells(
+exprt compute_or_over_bytes(
   const exprt &expr,
   const typet &field_type,
   const namespacet &ns,
@@ -161,7 +161,7 @@ exprt compute_or_over_cells(
 /// \param ns the namespace to perform type-lookups into
 /// \return the aggregated max byte-sized value contained in expr
 /// Note that the expr type size must be known at compile time.
-exprt compute_max_over_cells(
+exprt compute_max_over_bytes(
   const exprt &expr,
   const typet &field_type,
   const namespacet &ns);
@@ -176,7 +176,7 @@ exprt build_if_else_expr(
 
 /// Checks if given expression is a null pointer.
 /// \returns true if expr is a a NULL pointer within value_set.
-bool set_field_check_null(
+bool check_value_set_contains_only_null_ptr(
   const namespacet &ns,
   const messaget &log,
   const std::vector<exprt> &value_set,

--- a/unit/Makefile
+++ b/unit/Makefile
@@ -85,6 +85,7 @@ SRC += analyses/ai/ai.cpp \
        goto-symex/goto_symex_state.cpp \
        goto-symex/ssa_equation.cpp \
        goto-symex/is_constant.cpp \
+       goto-symex/shadow_memory_util.cpp \
        goto-symex/symex_assign.cpp \
        goto-symex/symex_level0.cpp \
        goto-symex/symex_level1.cpp \

--- a/unit/goto-symex/shadow_memory_util.cpp
+++ b/unit/goto-symex/shadow_memory_util.cpp
@@ -1,0 +1,401 @@
+// Author: Diffblue Ltd.
+
+#include <util/arith_tools.h>
+#include <util/bitvector_expr.h>
+#include <util/bitvector_types.h>
+#include <util/c_types.h>
+#include <util/config.h>
+#include <util/pointer_expr.h>
+#include <util/string_constant.h>
+
+#include <goto-symex/shadow_memory_util.h>
+#include <testing-utils/invariant.h>
+
+#include <array>
+
+/// Helper struct to hold useful test components.
+struct shadow_memory_util_test_environmentt
+{
+  symbol_tablet symbol_table;
+  namespacet ns{symbol_table};
+  source_locationt loc{};
+  null_message_handlert null_message_handler{};
+  messaget log{null_message_handler};
+
+  static shadow_memory_util_test_environmentt make()
+  {
+    // These config lines are necessary before construction because char size
+    // depend on the global configuration.
+    config.ansi_c.mode = configt::ansi_ct::flavourt::GCC;
+    config.ansi_c.set_arch_spec_x86_64();
+    return {};
+  }
+
+private:
+  shadow_memory_util_test_environmentt() = default;
+};
+
+TEST_CASE("extract_field_name works", "[core][goto-symex][extract_field_name]")
+{
+  SECTION("with string_constantt")
+  {
+    const std::string name = "field_name";
+    const string_constantt string_constant{name};
+    irep_idt field_name = extract_field_name(string_constant);
+    REQUIRE(field_name == name);
+  }
+  SECTION("with typecast_exprt")
+  {
+    const std::string name = "field_name";
+    const string_constantt string_constant{name};
+    const typecast_exprt typecast_expr{string_constant, unsignedbv_typet{10}};
+    irep_idt field_name = extract_field_name(typecast_expr);
+    REQUIRE(field_name == name);
+  }
+  SECTION("with address_of_exprt")
+  {
+    const std::string name = "address_of_name";
+    const string_constantt string_constant{name};
+    const address_of_exprt address_of_expr{string_constant};
+    irep_idt field_name = extract_field_name(address_of_expr);
+    REQUIRE(field_name == name);
+  }
+  SECTION("with index_exprt")
+  {
+    const std::string name = "array_name";
+    const string_constantt string_constant{name};
+    const index_exprt index_expr{string_constant, false_exprt{}};
+    irep_idt field_name = extract_field_name(index_expr);
+    REQUIRE(field_name == name);
+  }
+}
+
+TEST_CASE(
+  "extract_field_name correctly fails",
+  "[core][goto-symex][extract_field_name]")
+{
+  const exprt unsignedbv_expr = from_integer(42, unsignedbv_typet{10});
+
+  const cbmc_invariants_should_throwt invariants_throw;
+
+  SECTION("with simple non string_constantt")
+  {
+    REQUIRE_THROWS_MATCHES(
+      extract_field_name(unsignedbv_expr),
+      invariant_failedt,
+      invariant_failure_containing(
+        "Failed to extract shadow memory field name."));
+  }
+  SECTION("with typecast_exprt")
+  {
+    const typecast_exprt typecast_expr{unsignedbv_expr, unsignedbv_typet{10}};
+    REQUIRE_THROWS_MATCHES(
+      extract_field_name(typecast_expr),
+      invariant_failedt,
+      invariant_failure_containing(
+        "Failed to extract shadow memory field name."));
+  }
+  SECTION("with address_of_exprt")
+  {
+    const address_of_exprt address_of_expr{unsignedbv_expr};
+
+    REQUIRE_THROWS_MATCHES(
+      extract_field_name(address_of_expr),
+      invariant_failedt,
+      invariant_failure_containing(
+        "Failed to extract shadow memory field name."));
+  }
+  SECTION("with index_exprt")
+  {
+    const array_exprt array_expr{
+      {unsignedbv_expr, unsignedbv_expr},
+      array_typet{
+        unsignedbv_expr.type(), from_integer(2, unsignedbv_typet{32})}};
+    const index_exprt index_expr{array_expr, false_exprt{}};
+
+    REQUIRE_THROWS_MATCHES(
+      extract_field_name(index_expr),
+      invariant_failedt,
+      invariant_failure_containing(
+        "Failed to extract shadow memory field name."));
+  }
+}
+
+TEST_CASE("deref_expr works correctly", "[core][goto-symex][deref_expr]")
+{
+  exprt expr = from_integer(0, pointer_typet{bool_typet{}, 64});
+  SECTION("with array_of_exprt")
+  {
+    const auto wrapped = address_of_exprt{expr};
+    const auto dereferenced = deref_expr(wrapped);
+
+    REQUIRE(dereferenced == expr);
+  }
+
+  SECTION("with generic exprt")
+  {
+    const auto dereference_expr = deref_expr(expr);
+    const auto expected = dereference_exprt{expr};
+
+    REQUIRE(dereference_expr == expected);
+  }
+}
+
+std::size_t max(const std::array<mp_integer, 7> &values)
+{
+  return std::max(
+    {values[0].to_long(),
+     values[1].to_long(),
+     values[2].to_long(),
+     values[3].to_long(),
+     values[4].to_long(),
+     values[5].to_long(),
+     values[6].to_long()});
+}
+
+TEST_CASE(
+  "compute_max_over_bytes works correctly",
+  "[core][goto-symex][compute_max_over_bytes]")
+{
+  auto test = shadow_memory_util_test_environmentt::make();
+  const auto sm_type = unsigned_char_type();
+
+  // Using mp_integer types otherwise on 32-bit machines n << 48 wraps around.
+  std::array<mp_integer, 7> values = GENERATE(
+    std::array<mp_integer, 7>{0, 0, 0, 0, 0, 0, 0},
+    std::array<mp_integer, 7>{1, 2, 3, 4, 5, 6, 7},
+    std::array<mp_integer, 7>{2, 3, 4, 5, 6, 7, 1},
+    std::array<mp_integer, 7>{3, 4, 5, 6, 7, 1, 2},
+    std::array<mp_integer, 7>{4, 5, 6, 7, 1, 2, 3},
+    std::array<mp_integer, 7>{5, 6, 7, 1, 2, 3, 4},
+    std::array<mp_integer, 7>{6, 7, 1, 2, 3, 4, 5},
+    std::array<mp_integer, 7>{7, 1, 2, 3, 4, 5, 6},
+    std::array<mp_integer, 7>{8, 8, 8, 8, 8, 8, 8});
+
+  SECTION("test set " + std::to_string(values[0].to_long()))
+  {
+    SECTION("on bitvector")
+    {
+      const exprt bitvector = from_integer(
+        values[0] + (values[1] << 8) + (values[2] << 16) + (values[3] << 24) +
+          (values[4] << 32) + (values[5] << 40) + (values[6] << 48),
+        unsignedbv_typet{56});
+
+      const exprt max_over_struct =
+        compute_max_over_bytes(bitvector, sm_type, test.ns);
+
+      const exprt simplified = simplify_expr(max_over_struct, test.ns);
+
+      REQUIRE(simplified == from_integer(max(values), sm_type));
+    }
+    SECTION("on array")
+    {
+      const array_typet array_type{
+        unsigned_char_type(), from_integer(7, unsigned_long_int_type())};
+      const array_exprt::operandst array_operands{
+        from_integer(values[0], unsigned_char_type()),
+        from_integer(values[1], unsigned_char_type()),
+        from_integer(values[2], unsigned_char_type()),
+        from_integer(values[3], unsigned_char_type()),
+        from_integer(values[4], unsigned_char_type()),
+        from_integer(values[5], unsigned_char_type()),
+        from_integer(values[6], unsigned_char_type())};
+      const array_exprt array_expr{array_operands, array_type};
+
+      const exprt max_over_struct =
+        compute_max_over_bytes(array_expr, sm_type, test.ns);
+
+      const exprt simplified = simplify_expr(max_over_struct, test.ns);
+
+      REQUIRE(simplified == from_integer(max(values), sm_type));
+    }
+    SECTION("on struct elements")
+    {
+      const struct_union_typet::componentst sub_struct_components{
+        {"foo", signedbv_typet{32}}, {"bar", unsignedbv_typet{16}}};
+      const struct_typet inner_struct_type{sub_struct_components};
+      const struct_union_typet::componentst struct_components{
+        {"fizz", char_type()}, {"bar", inner_struct_type}};
+      const struct_typet struct_type{struct_components};
+      const mp_integer foo =
+        values[0] + (values[1] << 8) + (values[2] << 16) + (values[3] << 24);
+      const mp_integer bar = values[4] + (values[5] << 8);
+      const mp_integer fizz = values[6];
+      const struct_exprt::operandst inner_operands{
+        from_integer(foo, signedbv_typet{32}),
+        from_integer(bar, unsignedbv_typet{16})};
+      const struct_exprt inner_struct_expr{inner_operands, inner_struct_type};
+      const struct_exprt::operandst struct_operands{
+        from_integer(fizz, char_type()), inner_struct_expr};
+      const struct_exprt struct_expr{struct_operands, struct_type};
+
+      const exprt max_over_struct =
+        compute_max_over_bytes(struct_expr, sm_type, test.ns);
+
+      const exprt simplified = simplify_expr(max_over_struct, test.ns);
+
+      REQUIRE(simplified == from_integer(max(values), sm_type));
+    }
+  }
+}
+
+bool compute_or(const std::array<mp_integer, 7> &values)
+{
+  return values[0].to_long() || values[1].to_long() || values[2].to_long() ||
+         values[3].to_long() || values[4].to_long() || values[5].to_long() ||
+         values[6].to_long();
+}
+
+// It seems that simplify_expr does not get rid of bitor_exprt, so we do it by
+// ourselves
+exprt simplify_bit_or_exprt(const exprt &expr)
+{
+  INVARIANT(
+    can_cast_type<bool_typet>(expr.type()),
+    "Or expression must be of bool type");
+  if(can_cast_expr<constant_exprt>(expr))
+  {
+    return expr;
+  }
+  if(const auto *or_expr = expr_try_dynamic_cast<bitor_exprt>(expr))
+  {
+    bool res = false;
+    for(const auto &operand : or_expr->operands())
+    {
+      const exprt reduced = simplify_bit_or_exprt(operand);
+      res |= reduced.is_true();
+    }
+    return from_integer(res, bool_typet{});
+  }
+  UNREACHABLE;
+}
+
+TEST_CASE(
+  "compute_or_over_bytes works correctly",
+  "[core][goto-symex][compute_max_over_bytes]")
+{
+  auto test = shadow_memory_util_test_environmentt::make();
+  const bool_typet sm_type;
+
+  // Using mp_integer types otherwise on 32-bit machines n << 48 wraps around.
+  std::array<mp_integer, 7> values = GENERATE(
+    std::array<mp_integer, 7>{0, 0, 0, 0, 0, 0, 0},
+    std::array<mp_integer, 7>{2, 0, 0, 0, 0, 0, 0},
+    std::array<mp_integer, 7>{0, 2, 0, 0, 0, 0, 0},
+    std::array<mp_integer, 7>{0, 0, 2, 0, 0, 0, 0},
+    std::array<mp_integer, 7>{0, 0, 0, 2, 0, 0, 0},
+    std::array<mp_integer, 7>{0, 0, 0, 0, 2, 0, 0},
+    std::array<mp_integer, 7>{0, 0, 0, 0, 0, 2, 0},
+    std::array<mp_integer, 7>{0, 0, 0, 0, 0, 0, 2},
+    std::array<mp_integer, 7>{8, 8, 8, 8, 8, 8, 8});
+
+  SECTION("test set " + std::to_string(values[0].to_long()))
+  {
+    SECTION("on bitvector")
+    {
+      const exprt bitvector = from_integer(
+        values[0] + (values[1] << 8) + (values[2] << 16) + (values[3] << 24) +
+          (values[4] << 32) + (values[5] << 40) + (values[6] << 48),
+        unsignedbv_typet{56});
+
+      const exprt max_over_struct =
+        compute_or_over_bytes(bitvector, sm_type, test.ns, test.log, false);
+
+      const exprt simplified =
+        simplify_bit_or_exprt(simplify_expr(max_over_struct, test.ns));
+
+      REQUIRE(simplified == from_integer(compute_or(values), sm_type));
+    }
+    SECTION("on array")
+    {
+      const array_typet array_type{
+        unsigned_char_type(), from_integer(7, unsigned_long_int_type())};
+      const array_exprt::operandst array_operands{
+        from_integer(values[0], unsigned_char_type()),
+        from_integer(values[1], unsigned_char_type()),
+        from_integer(values[2], unsigned_char_type()),
+        from_integer(values[3], unsigned_char_type()),
+        from_integer(values[4], unsigned_char_type()),
+        from_integer(values[5], unsigned_char_type()),
+        from_integer(values[6], unsigned_char_type())};
+      const array_exprt array_expr{array_operands, array_type};
+
+      const exprt max_over_struct =
+        compute_or_over_bytes(array_expr, sm_type, test.ns, test.log, false);
+
+      const exprt simplified =
+        simplify_bit_or_exprt(simplify_expr(max_over_struct, test.ns));
+
+      REQUIRE(simplified == from_integer(compute_or(values), sm_type));
+    }
+    SECTION("on struct elements")
+    {
+      const struct_union_typet::componentst sub_struct_components{
+        {"foo", signedbv_typet{32}}, {"bar", unsignedbv_typet{16}}};
+      const struct_typet inner_struct_type{sub_struct_components};
+      const struct_union_typet::componentst struct_components{
+        {"fizz", char_type()}, {"bar", inner_struct_type}};
+      const struct_typet struct_type{struct_components};
+      const mp_integer foo =
+        values[0] + (values[1] << 8) + (values[2] << 16) + (values[3] << 24);
+      const mp_integer bar = values[4] + (values[5] << 8);
+      const mp_integer fizz = values[6];
+      const struct_exprt::operandst inner_operands{
+        from_integer(foo, signedbv_typet{32}),
+        from_integer(bar, unsignedbv_typet{16})};
+      const struct_exprt inner_struct_expr{inner_operands, inner_struct_type};
+      const struct_exprt::operandst struct_operands{
+        from_integer(fizz, char_type()), inner_struct_expr};
+      const struct_exprt struct_expr{struct_operands, struct_type};
+
+      const exprt max_over_struct =
+        compute_or_over_bytes(struct_expr, sm_type, test.ns, test.log, false);
+
+      const exprt simplified =
+        simplify_bit_or_exprt(simplify_expr(max_over_struct, test.ns));
+
+      REQUIRE(simplified == from_integer(compute_or(values), sm_type));
+    }
+  }
+}
+
+TEST_CASE(
+  "build_if_else_expr works correctly",
+  "[core][goto-symex][build_if_else_expr]")
+{
+  const symbol_exprt symbol_a = {"condition_a", bool_typet{}};
+  const symbol_exprt symbol_b = {"condition_b", bool_typet{}};
+  const symbol_exprt symbol_c = {"condition_c", bool_typet{}};
+  const symbol_exprt symbol_d = {"condition_d", bool_typet{}};
+  const symbol_exprt symbol_e = {"condition_e", bool_typet{}};
+  const symbol_exprt symbol_f = {"condition_f", bool_typet{}};
+
+  const exprt value_a = from_integer(0, char_type());
+  const exprt value_b = from_integer(1, char_type());
+  const exprt value_c = from_integer(2, char_type());
+  const exprt value_d = from_integer(3, char_type());
+  const exprt value_e = from_integer(4, char_type());
+  const exprt value_f = from_integer(5, char_type());
+
+  std::vector<std::pair<exprt, exprt>> condition_and_value{
+    {symbol_a, value_a},
+    {symbol_b, value_b},
+    {symbol_c, value_c},
+    {symbol_d, value_d},
+    {symbol_e, value_e},
+    {symbol_f, value_f}};
+
+  const exprt joined = build_if_else_expr(condition_and_value);
+  const exprt expected = if_exprt(
+    symbol_f,
+    value_f,
+    if_exprt{
+      symbol_e,
+      value_e,
+      if_exprt{
+        symbol_d,
+        value_d,
+        if_exprt{symbol_c, value_c, if_exprt{symbol_b, value_b, value_a}}}});
+
+  REQUIRE(joined == expected);
+}


### PR DESCRIPTION
Several non functional improvements to shadow memory including:

 - renaming of 5 utility functions to better reflect their function
 - renaming of shadow memory log guard from `SM_DEBUG` to `SHADOW_MEMORY_DEBUG`
 - improvement of utility functions implementation by adding `INVARIANT`s with meaningful messages and changing `typet` and `exprt` conversion to more modern `try_cast` and `can_cast` instead of the old `expr.id()`
 - addition to doxygen to all shadow memory util functions
 - improvements on shadow memory log functions
 - addition of unit tests for some functions from `shado_memory_util.h`

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [x] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
