### PR TITLE
format_expr: format constants with natural number type

### DIFF
--- a/src/util/format_expr.cpp
+++ b/src/util/format_expr.cpp
@@ -187,7 +187,7 @@ static std::ostream &format_rec(std::ostream &os, const constant_exprt &src)
     type == ID_unsignedbv || type == ID_signedbv || type == ID_c_bool ||
     type == ID_c_bit_field)
     return os << *numeric_cast<mp_integer>(src);
-  else if(type == ID_integer)
+  else if(type == ID_integer || type == ID_natural)
     return os << src.get_value();
   else if(type == ID_string)
     return os << '"' << escape(id2string(src.get_value())) << '"';


### PR DESCRIPTION
This adds the case of `constant_exprt` expressions that have type `natural_typet`.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
