### PR TITLE
Define coverage blocks so as to be terminated by all assumptions

### DIFF
--- a/regression/cbmc-cover/location-assume/end.c
+++ b/regression/cbmc-cover/location-assume/end.c
@@ -1,0 +1,9 @@
+#include <assert.h>
+
+void main()
+{
+  int i;
+  int *p = &i;
+  int j;
+  __CPROVER_assume(j == 1 / (*p));
+}

--- a/regression/cbmc-cover/location-assume/end.desc
+++ b/regression/cbmc-cover/location-assume/end.desc
@@ -1,0 +1,17 @@
+CORE
+end.c
+--pointer-check --div-by-zero-check --cover location
+^EXIT=0$
+^SIGNAL=0$
+^\[main.coverage.1\] file end.c line 5 function main block 1 \(lines end\.c:main:5-8\): SATISFIED$
+^\[main.coverage.2\] file end.c line 8 function main block 2 \(lines end\.c:main:8\): SATISFIED$
+^\[main.coverage.3\] file end.c line 8 function main block 3 \(lines end\.c:main:8\): SATISFIED$
+^\[main.coverage.4\] file end.c line 8 function main block 4 \(lines end\.c:main:8\): SATISFIED$
+^\[main.coverage.5\] file end.c line 9 function main block 5 \(lines end\.c:main:9\): SATISFIED$
+^\*\* 5 of 5 covered \(100.0%\)
+--
+^warning: ignoring
+--
+Test that in the case where multiple assertions are added on the same line of
+code due to the addition of instrumentation checks, these do not result in
+further splitting blocks.

--- a/regression/cbmc-cover/location-assume/middle.c
+++ b/regression/cbmc-cover/location-assume/middle.c
@@ -1,0 +1,11 @@
+#include <assert.h>
+
+int main()
+{
+  int i;
+  int j;
+  j = i;
+  __CPROVER_assume(0);
+  j = i + 2;
+  return 0;
+}

--- a/regression/cbmc-cover/location-assume/middle.desc
+++ b/regression/cbmc-cover/location-assume/middle.desc
@@ -1,0 +1,15 @@
+CORE
+middle.c
+--cover location
+^EXIT=0$
+^SIGNAL=0$
+^\[main.coverage.1\] file middle.c line 5 function main block 1 \(lines middle\.c:main:5-8\): SATISFIED$
+^\[main.coverage.2\] file middle.c line 9 function main block 2 \(lines middle\.c:main:9-11\): FAILED$
+^\*\* 1 of 2 covered \(50.0%\)
+--
+^warning: ignoring
+--
+This test confirms that assumptions in the middle of what would otherwise be a
+single blocks without control flow will cause the code to be split into 2
+coverage blocks. This is required as an unsatisfiable assumption can result in
+the following statements being unreachable.

--- a/regression/cbmc-cover/location12/test.desc
+++ b/regression/cbmc-cover/location12/test.desc
@@ -7,7 +7,8 @@ main.c
 ^\[main.coverage.2\] file main.c line 10 function main block 2.*: SATISFIED$
 ^\[foo.coverage.1\] file main.c line 3 function foo block 1.*: SATISFIED$
 ^\[foo.coverage.2\] file main.c line 4 function foo block 2.*: FAILED$
-^\[foo.coverage.3\] file main.c line 5 function foo block 3.*: SATISFIED$
-^\*\* 4 of 5 covered \(80.0%\)
+^\[foo.coverage.3\] file main.c line 5 function foo block 3.*: FAILED$
+^\[foo.coverage.4\] file main.c line 5 function foo block 4.*: SATISFIED$
+^\*\* 4 of 6 covered \(66.7%\)
 --
 ^warning: ignoring

--- a/regression/cbmc-cover/location15/test.desc
+++ b/regression/cbmc-cover/location15/test.desc
@@ -6,7 +6,8 @@ main.c
 ^\[main.coverage.1\] file main.c line 10 function main block 1.*: SATISFIED$
 ^\[main.coverage.2\] file main.c line 10 function main block 2.*: SATISFIED$
 ^\[main.coverage.3\] file main.c line 13 function main block 3.*: FAILED$
-^\[main.coverage.4\] file main.c line 16 function main block 4.*: SATISFIED$
+^\[main.coverage.4\] file main.c line 14 function main block 4.*: FAILED$
+^\[main.coverage.5\] file main.c line 16 function main block 5.*: SATISFIED$
 ^\[foo.coverage.1\] file main.c line 5 function foo block 1.*: FAILED$
 ^\*\* 3 of \d+ covered
 --

--- a/regression/cbmc-cover/location16/test.desc
+++ b/regression/cbmc-cover/location16/test.desc
@@ -9,7 +9,8 @@ main.c
 ^\[func.coverage.2\] file main.c line 6 function func block 2.*: FAILED$
 ^\[func.coverage.3\] file main.c line 8 function func block 3.*: FAILED$
 ^\[func.coverage.4\] file main.c line 12 function func block 4.*: FAILED$
-^\[func.coverage.5\] file main.c line 15 function func block 5.*: SATISFIED$
-^\*\* 4 of 7 covered \(57.1%\)
+^\[func.coverage.5\] file main.c line 14 function func block 5.*: FAILED$
+^\[func.coverage.6\] file main.c line 15 function func block 6.*: SATISFIED$
+^\*\* 4 of 8 covered \(50.0%\)
 --
 ^warning: ignoring

--- a/regression/cbmc-cover/location2/test.desc
+++ b/regression/cbmc-cover/location2/test.desc
@@ -4,8 +4,8 @@ main.c
 ^EXIT=0$
 ^SIGNAL=0$
 ^\[main.coverage.1\] file main.c line 9 function main block 1 \(lines main.c:main:9,10\): SATISFIED$
-^\[main.coverage.2\] file main.c line 11 function main block 2 \(lines main.c:main:11\): SATISFIED$
-^\*\* 2 of 2 covered \(100.0%\)
+^\[main.coverage.3\] file main.c line 11 function main block 3 \(lines main.c:main:11\): SATISFIED$
+^\*\* 3 of 3 covered \(100.0%\)
 --
 ^warning: ignoring
 main.c::5

--- a/regression/cbmc-cover/simple_assert/test.desc
+++ b/regression/cbmc-cover/simple_assert/test.desc
@@ -4,7 +4,7 @@ main.c
 ^EXIT=0$
 ^SIGNAL=0$
 ^\[main\.coverage\.1\] .* function main block 1.*: SATISFIED$
-(1 of 1|3 of 3) covered \(100\.0%\)$
+(1 of 1|2 of 2|3 of 3) covered \(100\.0%\)$
 --
 ^warning: ignoring
 ^CONVERSION ERROR$

--- a/regression/cbmc/cover-failed-assertions/test-no-failed-assertions.desc
+++ b/regression/cbmc/cover-failed-assertions/test-no-failed-assertions.desc
@@ -1,9 +1,15 @@
 CORE paths-lifo-expected-failure
 test.c
 --cover location --pointer-check --malloc-may-fail --malloc-fail-null
-\[main\.coverage\.4\] file test\.c line \d+ function main block 4 \(lines test\.c:main:17,18\): SATISFIED
-\[main\.coverage\.3\] file test\.c line \d+ function main block 3 \(lines test\.c:main:15\): FAILED
-\[main\.coverage\.2\] file test\.c line \d+ function main block 2 \(lines test\.c:main:5,6,12,14\): SATISFIED
+\[main\.coverage\.10\] file test\.c line \d+ function main block 10 \(lines test\.c:main:17,18\): SATISFIED
+\[main\.coverage\.9\] file test\.c line \d+ function main block 9 \(lines test\.c:main:15\): FAILED
+\[main\.coverage\.8\] file test\.c line \d+ function main block 8 \(lines test\.c:main:12,14\): SATISFIED
+\[main\.coverage\.7\] file test\.c line \d+ function main block 7 \(lines test\.c:main:12\): SATISFIED
+\[main\.coverage\.6\] file test\.c line \d+ function main block 6 \(lines test\.c:main:12\): SATISFIED
+\[main\.coverage\.5\] file test\.c line \d+ function main block 5 \(lines test\.c:main:12\): SATISFIED
+\[main\.coverage\.4\] file test\.c line \d+ function main block 4 \(lines test\.c:main:12\): SATISFIED
+\[main\.coverage\.3\] file test\.c line \d+ function main block 3 \(lines test\.c:main:12\): SATISFIED
+\[main\.coverage\.2\] file test\.c line \d+ function main block 2 \(lines test\.c:main:5,6,12\): SATISFIED
 \[main\.coverage\.1\] file test\.c line \d+ function main block 1 \(lines test\.c:main:5\): SATISFIED
 ^EXIT=0$
 ^SIGNAL=0$

--- a/src/goto-instrument/cover_basic_blocks.cpp
+++ b/src/goto-instrument/cover_basic_blocks.cpp
@@ -73,10 +73,11 @@ cover_basic_blockst::cover_basic_blockst(const goto_programt &goto_program)
     }
 
     next_is_target =
-#if 0
-      // Disabled for being too messy
+#if 1
+      // Previously disabled for being too messy.
       it->is_goto() || it->is_function_call() || it->is_assume();
 #else
+      // Disabled for being misleading.
       it->is_goto() || it->is_function_call();
 #endif
   }


### PR DESCRIPTION
This PR is a variation on https://github.com/diffblue/cbmc/pull/7810 which is raised in response to this comment here - https://github.com/diffblue/cbmc/pull/7810#issuecomment-1741176404

I have kept these changes as a separate PR/branch for the moment as they are functionally different from the ones which have been previously been approved and I would like confirmation from @remi-delmas-3000 before we continue with the approach in this PR.

The key difference between this PR and the original PR is that the original PR will produce a single block for the case where there are multiple consecutive assumptions which map to the same source line. Kind of like a transformation from `assume(a); assume(b);` to `assume(a && b);`. This PR will create a coverage block for each of the assumptions. This tends to be the case where we add assertions during instrumentation passes, which become assumptions for the purposes of coverage checks.

The drawback with the presence of multiple coverage blocks on the same line of code is that the coverage reporting only reports at a granularity of source lines rather than goto instructions. This can make the output appear somewhat odd. Only source lines are included in the output regardless of whether we are using the default plain text UI or `--xml-ui` or `--json-ui`. To illustrate this issue I have taken one of the examples from our test suite and run it against develop, my first PR and this PR.

<details>
  <summary>C source</summary>

```C
#include <stdlib.h>

int main()
{
  int *ptr = malloc(sizeof(*ptr));
  int a;

  // pointer check would detect the dereference of a null pointer here
  // default --cover lines behaviour is to treat non-cover assertions as
  // assumptions instead, so in the ptr == NULL case we don't get past this line
  // leading to failed coverage for the body of the if statement down below
  a = *ptr;

  if(ptr == NULL)
    a = 1;

  return 0;
}
```
</details>

For this example we run `cbmc test.c --cover location --pointer-check --malloc-may-fail --malloc-fail-null`

<details>
  <summary>Coverage reporting on develop.</summary>

```
** coverage results:
[main.coverage.1] file test.c line 5 function main block 1 (lines test.c:main:5): SATISFIED
[main.coverage.2] file test.c line 5 function main block 2 (lines test.c:main:5,6,12,14): SATISFIED
[main.coverage.3] file test.c line 15 function main block 3 (lines test.c:main:15): FAILED
[main.coverage.4] file test.c line 17 function main block 4 (lines test.c:main:17,18): SATISFIED

** 3 of 4 covered (75.0%)
** Used 2 iterations
```
</details>

The above results combine lines 12 and 14 in the same block, even though line 14 would be unreachable if the instrumentation assertions could not be satisfied. This demonstrates the problem from original issue.

<details>
  <summary>Coverage reporting from https://github.com/diffblue/cbmc/pull/7810</summary>

```
** coverage results:
[main.coverage.1] file test.c line 5 function main block 1 (lines test.c:main:5): SATISFIED
[main.coverage.2] file test.c line 5 function main block 2 (lines test.c:main:5,6,12): SATISFIED
[main.coverage.3] file test.c line 12 function main block 3 (lines test.c:main:12,14): SATISFIED
[main.coverage.4] file test.c line 15 function main block 4 (lines test.c:main:15): FAILED
[main.coverage.5] file test.c line 17 function main block 5 (lines test.c:main:17,18): SATISFIED
```
</details>

The above coverage output includes an additional block for line 14. This is correctly shown as SATISFIED / reachable as the conditions added by the instrumentation can be satisfied in this case.

<details>
  <summary>Coverage reporting from this PR</summary>

```
** coverage results:
[main.coverage.1] file test.c line 5 function main block 1 (lines test.c:main:5): SATISFIED
[main.coverage.2] file test.c line 5 function main block 2 (lines test.c:main:5,6,12): SATISFIED
[main.coverage.3] file test.c line 12 function main block 3 (lines test.c:main:12): SATISFIED
[main.coverage.4] file test.c line 12 function main block 4 (lines test.c:main:12): SATISFIED
[main.coverage.5] file test.c line 12 function main block 5 (lines test.c:main:12): SATISFIED
[main.coverage.6] file test.c line 12 function main block 6 (lines test.c:main:12): SATISFIED
[main.coverage.7] file test.c line 12 function main block 7 (lines test.c:main:12): SATISFIED
[main.coverage.8] file test.c line 12 function main block 8 (lines test.c:main:12,14): SATISFIED
[main.coverage.9] file test.c line 15 function main block 9 (lines test.c:main:15): FAILED
[main.coverage.10] file test.c line 17 function main block 10 (lines test.c:main:17,18): SATISFIED
```
</details>

The coverage output now shows 5 blocks which each cover line 12 alone. In this example they aren't too difficult to consolidate. However it is conceivable that some of them could report as SATISFIED with others for the same line showing as FAILED. This could occur in the case where the first check is satisifyable but one of the following checks is not.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
