### PR TITLE
C front-end: typecheck conditional operator over string literal and 0

### DIFF
--- a/regression/ansi-c/null_pointer_constant1/main.c
+++ b/regression/ansi-c/null_pointer_constant1/main.c
@@ -1,0 +1,6 @@
+int main(int argc, char *argv[])
+{
+  // Literal 0 is a valid null-pointer constant, which makes this conditional
+  // operator well-formed.
+  char *maybe_str = argc > 1 ? "args" : 0;
+}

--- a/regression/ansi-c/null_pointer_constant1/test.desc
+++ b/regression/ansi-c/null_pointer_constant1/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+^CONVERSION ERROR$

--- a/src/ansi-c/c_typecheck_expr.cpp
+++ b/src/ansi-c/c_typecheck_expr.cpp
@@ -1642,6 +1642,18 @@ void c_typecheck_baset::typecheck_expr_trinary(if_exprt &expr)
     return;
   }
 
+  if(
+    auto string_constant = expr_try_dynamic_cast<string_constantt>(operands[1]))
+  {
+    implicit_typecast(operands[1], pointer_type(string_constant->char_type()));
+  }
+
+  if(
+    auto string_constant = expr_try_dynamic_cast<string_constantt>(operands[2]))
+  {
+    implicit_typecast(operands[2], pointer_type(string_constant->char_type()));
+  }
+
   if(operands[1].type().id()==ID_pointer &&
      operands[2].type().id()!=ID_pointer)
     implicit_typecast(operands[2], operands[1].type());


### PR DESCRIPTION
0 is a valid null-pointer constant, even in the absence of an explicit type cast.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
