### PR TITLE
C front-end: support vector expressions as compile-time constants

### DIFF
--- a/regression/ansi-c/MMX2/main.c
+++ b/regression/ansi-c/MMX2/main.c
@@ -7,6 +7,7 @@ int main()
   int  nonsense1;
 #ifdef __MMX__
   __m128i qq = {0};
+  __m128 f = {1.0f, 1.0f, 1.0f, 1.0f};
 #endif
   return (0);
 }

--- a/src/ansi-c/c_typecheck_expr.cpp
+++ b/src/ansi-c/c_typecheck_expr.cpp
@@ -4568,7 +4568,7 @@ protected:
       e.id() == ID_le || e.id() == ID_gt || e.id() == ID_ge ||
       e.id() == ID_if || e.id() == ID_not || e.id() == ID_and ||
       e.id() == ID_or || e.id() == ID_bitnot || e.id() == ID_bitand ||
-      e.id() == ID_bitor || e.id() == ID_bitxor)
+      e.id() == ID_bitor || e.id() == ID_bitxor || e.id() == ID_vector)
     {
       return std::all_of(
         e.operands().begin(), e.operands().end(), [this](const exprt &op) {


### PR DESCRIPTION
Just like arrays (of constants) are compile-time constants, vectors (of constants) are compile-time constants.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
