### PR TITLE
Fix book regression tests handling of smt test runs

### DIFF
--- a/regression/book-examples/CMakeLists.txt
+++ b/regression/book-examples/CMakeLists.txt
@@ -24,7 +24,7 @@ add_test_pl_profile(
 )
 
 add_test_pl_profile(
-    "cbmc-cprover-smt2"
+    "book-examples-cprover-smt2"
     "$<TARGET_FILE:cbmc> --cprover-smt2"
     "-C;-X;broken-smt-backend;-X;thorough-smt-backend;-X;broken-cprover-smt-backend;-X;thorough-cprover-smt-backend;${gcc_only_string}-s;cprover-smt2;${exclude_win_broken_tests_string}"
     "CORE"
@@ -32,7 +32,7 @@ add_test_pl_profile(
 
 # If `-I` (include flag) is passed, test.pl will run only the tests matching the label following it.
 add_test_pl_profile(
-  "cbmc-new-smt-backend"
+  "book-examples-new-smt-backend"
   "$<TARGET_FILE:cbmc> --incremental-smt2-solver 'z3 --smt2 -in'"
   "${gcc_only_string}-I;new-smt-backend;-s;new-smt-backend"
   "CORE"
@@ -41,7 +41,7 @@ add_test_pl_profile(
 # solver appears on the PATH in Windows already
 if(NOT "${CMAKE_SYSTEM_NAME}" STREQUAL "Windows")
   set_property(
-    TEST "cbmc-cprover-smt2-CORE"
+    TEST "book-examples-cprover-smt2-CORE"
     PROPERTY ENVIRONMENT
       "PATH=$ENV{PATH}:$<TARGET_FILE_DIR:smt2_solver>"
   )

--- a/regression/book-examples/abs/C1.desc
+++ b/regression/book-examples/abs/C1.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 abs.c
 --function abs
 ^EXIT=0$

--- a/regression/book-examples/abs/C13.desc
+++ b/regression/book-examples/abs/C13.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 abs.c
 --function abs --signed-overflow-check --show-goto-functions
 ^EXIT=0$

--- a/regression/book-examples/abs/C2.desc
+++ b/regression/book-examples/abs/C2.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 abs.c
 --function abs --signed-overflow-check
 ^EXIT=10$

--- a/regression/book-examples/abs/C3.desc
+++ b/regression/book-examples/abs/C3.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 abs.c
 --function abs --signed-overflow-check --trace
 ^EXIT=10$

--- a/regression/book-examples/binsearch/C4.desc
+++ b/regression/book-examples/binsearch/C4.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 binsearch.c
 --function binsearch --unwind 6 --bounds-check --unwinding-assertions
 ^EXIT=0$

--- a/regression/book-examples/lock/depth.desc
+++ b/regression/book-examples/lock/depth.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 lock.c
 --depth 10
 ^EXIT=0$

--- a/regression/book-examples/lock/unwind1.desc
+++ b/regression/book-examples/lock/unwind1.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 lock.c
 --unwind 1
 ^EXIT=0$

--- a/regression/book-examples/lock/unwind2.desc
+++ b/regression/book-examples/lock/unwind2.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 lock.c
 --unwind 2
 ^EXIT=10$

--- a/regression/book-examples/login/C5.desc
+++ b/regression/book-examples/login/C5.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 login.c
 --unwind 20 --bounds-check
 ^EXIT=10$

--- a/regression/book-examples/login/C6.desc
+++ b/regression/book-examples/login/C6.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 login.c
 --show-properties --bounds-check --pointer-check
 ^EXIT=0$

--- a/regression/book-examples/login/C7.desc
+++ b/regression/book-examples/login/C7.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 login.c
 --unwind 20 --show-vcc --bounds-check --pointer-check
 ^EXIT=0$

--- a/regression/book-examples/login/C8.desc
+++ b/regression/book-examples/login/C8.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 login.c
 --unwind 20 --bounds-check --pointer-check
 ^EXIT=10$

--- a/regression/book-examples/login/C9.desc
+++ b/regression/book-examples/login/C9.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 login.c
 --unwind 20 --bounds-check --pointer-check --trace
 ^EXIT=10$


### PR DESCRIPTION
The `CMakeLists.txt` for the `book-examples` directory appears to be
based on a copy of the one from the `regression/cbmc` directory.
Unfortunately the first parameter to `add_test_pl_profile` needs to be
unique and it has not been updated to a unique name for the new file.
This was resulting in the existing tests not being run.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
