### PR TITLE
Fix SMT encoding of structs which contain a single struct field

### DIFF
--- a/regression/cbmc/Struct_Initialization5/test.desc
+++ b/regression/cbmc/Struct_Initialization5/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 
 ^EXIT=0$

--- a/unit/solvers/smt2_incremental/encoding/struct_encoding.cpp
+++ b/unit/solvers/smt2_incremental/encoding/struct_encoding.cpp
@@ -169,6 +169,18 @@ TEST_CASE("struct encoding of expressions", "[core][smt2_incremental]")
     const concatenation_exprt expected_result{
       {green_ham.symbol_expr(), forty_two, minus_one}, bv_typet{72}};
     REQUIRE(test.struct_encoding.encode(struct_expr) == expected_result);
+    SECTION("struct containing a single struct")
+    {
+      const struct_typet struct_struct_type{
+        struct_union_typet::componentst{{"inner", struct_tag}}};
+      const type_symbolt struct_struct_type_symbol{
+        "struct_structt", struct_type, ID_C};
+      test.symbol_table.insert(type_symbol);
+      const struct_tag_typet struct_struct_tag{type_symbol.name};
+      const struct_exprt struct_struct{
+        exprt::operandst{struct_expr}, struct_struct_tag};
+      REQUIRE(test.struct_encoding.encode(struct_struct) == expected_result);
+    }
   }
   SECTION("member expression selecting a data member of a struct")
   {


### PR DESCRIPTION
This PR fixes SMT encoding of structs which contain a single struct field.
<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
