### PR TITLE
Add missing lowering of symbol values in new SMT backend

### DIFF
--- a/regression/cbmc-incr-smt2/structs/struct_static_init.c
+++ b/regression/cbmc-incr-smt2/structs/struct_static_init.c
@@ -1,0 +1,22 @@
+#include <assert.h>
+#include <stdint.h>
+
+struct F
+{
+  uint16_t w;
+  uint16_t x;
+};
+
+static struct F a = {0xdeadbeef};
+static struct F b = {0xbeefdead};
+
+int main()
+{
+  struct F *p;
+  if(nondet_int())
+    p = &a;
+  else
+    p = &b;
+
+  assert(p->w != 0xdead);
+}

--- a/regression/cbmc-incr-smt2/structs/struct_static_init.desc
+++ b/regression/cbmc-incr-smt2/structs/struct_static_init.desc
@@ -1,0 +1,11 @@
+CORE
+struct_static_init.c
+
+Passing problem to incremental SMT2 solving
+line \d+ assertion p->w != 0xdead: FAILURE
+^EXIT=10$
+^SIGNAL=0$
+--
+--
+Test that statically initialised variables of struct type (whose values are
+stored in the symbolt_table) are lowered correctly.

--- a/src/solvers/smt2_incremental/smt2_incremental_decision_procedure.cpp
+++ b/src/solvers/smt2_incremental/smt2_incremental_decision_procedure.cpp
@@ -223,10 +223,11 @@ void smt2_incremental_decision_proceduret::define_dependent_functions(
       }
       else
       {
-        if(push_dependencies_needed(symbol->value))
+        const exprt lowered = lower(symbol->value);
+        if(push_dependencies_needed(lowered))
           continue;
         const smt_define_function_commandt function{
-          symbol->name, {}, convert_expr_to_smt(symbol->value)};
+          symbol->name, {}, convert_expr_to_smt(lowered)};
         expression_identifiers.emplace(*symbol_expr, function.identifier());
         identifier_table.emplace(identifier, function.identifier());
         solver_process->send(function);


### PR DESCRIPTION
Fixes the missing lowering step to values of symbols in the `symbol_table` during the decision procedure of the new incremental SMT2 backend.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
