### PR TITLE
Simplification towards singleton intervals requires single variable

### DIFF
--- a/regression/cbmc/simplify_singleton_interval_7953/main.c
+++ b/regression/cbmc/simplify_singleton_interval_7953/main.c
@@ -1,0 +1,11 @@
+#include <assert.h>
+extern void __VERIFIER_assume(int cond);
+extern int __VERIFIER_nondet_int(void);
+int main()
+{
+  int z = __VERIFIER_nondet_int();
+  int k = __VERIFIER_nondet_int();
+  __VERIFIER_assume(1 < z);
+  __VERIFIER_assume(1 <= z && k <= 1);
+  assert(0);
+}

--- a/regression/cbmc/simplify_singleton_interval_7953/test.desc
+++ b/regression/cbmc/simplify_singleton_interval_7953/test.desc
@@ -1,0 +1,10 @@
+CORE new-smt-backend
+main.c
+
+^VERIFICATION FAILED$
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring
+--
+Simplification must not spuriously turn the second assumption into an equality.

--- a/src/util/simplify_expr_boolean.cpp
+++ b/src/util/simplify_expr_boolean.cpp
@@ -151,6 +151,7 @@ simplify_exprt::resultt<> simplify_exprt::simplify_boolean(const exprt &expr)
       {
         mp_integer lower;
         mp_integer higher;
+        exprt non_const_value;
       };
       boundst bounds;
 
@@ -177,6 +178,7 @@ simplify_exprt::resultt<> simplify_exprt::simplify_boolean(const exprt &expr)
             auto int_opt =
               numeric_cast<mp_integer>(to_constant_expr(ge_expr->rhs())))
           {
+            bounds.non_const_value = ge_expr->lhs();
             bounds.lower = *int_opt;
             return true;
           }
@@ -198,6 +200,8 @@ simplify_exprt::resultt<> simplify_exprt::simplify_boolean(const exprt &expr)
             // If the rhs() is not constant, it has a different structure
             // (e.g. i >= j)
             if(!ge_expr->rhs().is_constant())
+              return false;
+            if(ge_expr->lhs() != bounds.non_const_value)
               return false;
             if(
               auto int_opt =


### PR DESCRIPTION
We must not blindly assume that that <exprA> and <exprB> in <exprA> >= C1 && !(<exprB> >= C2) are the same.

Fixes: #7953

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
