### PR TITLE
std::sort requires strict weak ordering

### DIFF
--- a/src/analyses/variable-sensitivity/value_set_abstract_object.cpp
+++ b/src/analyses/variable-sensitivity/value_set_abstract_object.cpp
@@ -493,6 +493,7 @@ static abstract_object_sett compact_values(const abstract_object_sett &values)
 static exprt eval_expr(const exprt &e);
 static bool is_eq(const exprt &lhs, const exprt &rhs);
 static bool is_le(const exprt &lhs, const exprt &rhs);
+static bool is_lt(const exprt &lhs, const exprt &rhs);
 static abstract_object_sett collapse_values_in_intervals(
   const abstract_object_sett &values,
   const std::vector<constant_interval_exprt> &intervals);
@@ -525,8 +526,8 @@ void collapse_overlapping_intervals(
     intervals.end(),
     [](constant_interval_exprt const &lhs, constant_interval_exprt const &rhs) {
       if(is_eq(lhs.get_lower(), rhs.get_lower()))
-        return is_le(lhs.get_upper(), rhs.get_upper());
-      return is_le(lhs.get_lower(), rhs.get_lower());
+        return is_lt(lhs.get_upper(), rhs.get_upper());
+      return is_lt(lhs.get_lower(), rhs.get_lower());
     });
 
   size_t index = 1;
@@ -644,6 +645,11 @@ static bool is_eq(const exprt &lhs, const exprt &rhs)
 static bool is_le(const exprt &lhs, const exprt &rhs)
 {
   return constant_interval_exprt::less_than_or_equal(lhs, rhs);
+}
+
+static bool is_lt(const exprt &lhs, const exprt &rhs)
+{
+  return constant_interval_exprt::less_than(lhs, rhs);
 }
 
 static abstract_object_sett widen_value_set(

--- a/src/cprover/generalization.cpp
+++ b/src/cprover/generalization.cpp
@@ -45,7 +45,7 @@ public:
       result.begin(),
       result.end(),
       [](counterst::const_iterator a, counterst::const_iterator b) -> bool {
-        return a->second >= b->second;
+        return a->second > b->second;
       });
     return result;
   }


### PR DESCRIPTION
Two of our uses of `std::sort` failed to satisfy the "strict" part of "strict weak ordering." This resulted in iterators running out of bounds with LLVM's libc++.

Fixes: #7949

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
