### PR TITLE
Add support for union member expressions in incremental smt2 decision procedure

### DIFF
--- a/regression/cbmc/Union_Initialization1/test.desc
+++ b/regression/cbmc/Union_Initialization1/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 
 ^EXIT=0$

--- a/regression/cbmc/Union_Initialization5/test.desc
+++ b/regression/cbmc/Union_Initialization5/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 
 ^EXIT=0$

--- a/regression/cbmc/union1/test.desc
+++ b/regression/cbmc/union1/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 
 ^EXIT=0$

--- a/regression/cbmc/union10/union_list2.desc
+++ b/regression/cbmc/union10/union_list2.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 union_list2.c
 
 ^EXIT=0$

--- a/regression/cbmc/union11/union_list.desc
+++ b/regression/cbmc/union11/union_list.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 union_list.c
 
 ^EXIT=0$

--- a/regression/cbmc/union13/no-arch.desc
+++ b/regression/cbmc/union13/no-arch.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 --arch none --little-endian
 (Starting CEGAR Loop|^Generated 1 VCC\(s\), 1 remaining after simplification$)

--- a/regression/cbmc/union13/test.desc
+++ b/regression/cbmc/union13/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 
 ^EXIT=0$

--- a/regression/cbmc/union14/test.desc
+++ b/regression/cbmc/union14/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 
 ^EXIT=0$

--- a/regression/cbmc/union15/test.desc
+++ b/regression/cbmc/union15/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 
 ^EXIT=0$

--- a/regression/cbmc/union16/test.desc
+++ b/regression/cbmc/union16/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 
 ^EXIT=0$

--- a/regression/cbmc/union18/test.desc
+++ b/regression/cbmc/union18/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 
 ^Generated 1 VCC\(s\), 0 remaining after simplification$

--- a/regression/cbmc/union2/test.desc
+++ b/regression/cbmc/union2/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 
 ^EXIT=0$

--- a/regression/cbmc/union3/test.desc
+++ b/regression/cbmc/union3/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 
 ^EXIT=0$

--- a/regression/cbmc/union4/test.desc
+++ b/regression/cbmc/union4/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 
 ^EXIT=0$

--- a/regression/cbmc/union5/test.desc
+++ b/regression/cbmc/union5/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 
 ^EXIT=10$

--- a/regression/cbmc/union6/test.desc
+++ b/regression/cbmc/union6/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 --little-endian
 ^EXIT=0$

--- a/regression/cbmc/union7/test.desc
+++ b/regression/cbmc/union7/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 --big-endian
 ^EXIT=0$

--- a/regression/cbmc/union8/test.desc
+++ b/regression/cbmc/union8/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 
 ^EXIT=0$

--- a/regression/cbmc/union9/test.desc
+++ b/regression/cbmc/union9/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE new-smt-backend
 main.c
 
 ^EXIT=0$

--- a/unit/solvers/smt2_incremental/encoding/struct_encoding.cpp
+++ b/unit/solvers/smt2_incremental/encoding/struct_encoding.cpp
@@ -501,4 +501,26 @@ TEST_CASE("encoding of union expressions", "[core][smt2_incremental]")
     const auto bv_equal = equal_exprt{symbol_expr_as_bv, partial_union_as_bv};
     REQUIRE(test.struct_encoding.encode(union_equal) == bv_equal);
   }
+  SECTION("member expression selecting a data member of a union")
+  {
+    SECTION("Member which fits the size of the whole union")
+    {
+      const typet field_type = signedbv_typet{32};
+      const exprt zero = from_integer(0, field_type);
+      const exprt input =
+        equal_exprt{zero, member_exprt{symbol_expr, "ham", field_type}};
+      const exprt expected = equal_exprt{
+        zero, extractbits_exprt{symbol_expr_as_bv, 31, 0, field_type}};
+      REQUIRE(test.struct_encoding.encode(input) == expected);
+    }
+    SECTION("Member which is smaller than the union as a whole")
+    {
+      const typet field_type = unsignedbv_typet{8};
+      const exprt input =
+        equal_exprt{dozen, member_exprt{symbol_expr, "eggs", field_type}};
+      const exprt expected = equal_exprt{
+        dozen, extractbits_exprt{symbol_expr_as_bv, 7, 0, field_type}};
+      REQUIRE(test.struct_encoding.encode(input) == expected);
+    }
+  }
 }


### PR DESCRIPTION
This PR adds support for union member expressions in incremental smt2 decision procedure. This support is sufficient for some of the existing union regression tests to pass.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
