### PR TITLE
Fix a pair of issues where `const` was (unintentionally) cast away

### DIFF
--- a/src/cpp/cpp_using.h
+++ b/src/cpp/cpp_using.h
@@ -28,7 +28,7 @@ public:
 
   const cpp_namet &name() const
   {
-    return (cpp_namet &)find(ID_name);
+    return (const cpp_namet &)find(ID_name);
   }
 
   bool get_namespace() const

--- a/src/util/std_code.h
+++ b/src/util/std_code.h
@@ -1858,7 +1858,7 @@ public:
   }
 
   exception_listt &exception_list() {
-    return (exception_listt &)find(ID_exception_list).get_sub();
+    return (exception_listt &)add(ID_exception_list).get_sub();
   }
 
   const exception_listt &exception_list() const {


### PR DESCRIPTION
This PR fixes a pair of issues where `const` was (unintentionally) cast away. These don't appear to have caused any major issues but they present a potential problem for any future changes to `irept`.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
