### PR TITLE
Add support for empty unions in incremental SMT decision procedure

### DIFF
--- a/regression/cbmc/Union_Initialization2/test.desc
+++ b/regression/cbmc/Union_Initialization2/test.desc
@@ -1,4 +1,4 @@
-CORE gcc-only
+CORE gcc-only new-smt-backend
 main.c
 
 ^EXIT=10$

--- a/unit/solvers/smt2_incremental/encoding/struct_encoding.cpp
+++ b/unit/solvers/smt2_incremental/encoding/struct_encoding.cpp
@@ -122,6 +122,17 @@ TEST_CASE("Encoding of union types", "[core][smt2_incremental]")
     {
       REQUIRE(test.struct_encoding.encode(union_tag) == bv_typet{8});
     }
+    SECTION("Value enoding")
+    {
+      const symbolt symbol{"my_empty_union", union_tag, ID_C};
+      test.symbol_table.insert(symbol);
+      const auto symbol_is_empty =
+        equal_exprt{symbol.symbol_expr(), empty_union_exprt{union_tag}};
+      const auto expected = equal_exprt{
+        symbol_exprt{"my_empty_union", bv_typet{8}},
+        from_integer(0, bv_typet{8})};
+      REQUIRE(test.struct_encoding.encode(symbol_is_empty) == expected);
+    }
   }
 }
 


### PR DESCRIPTION
This PR adds support for empty unions in the incremental SMT decision procedure.
<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
