### PR TITLE
SYNTHESIZER: Use only symbols from the original goto as terminals

### DIFF
--- a/src/goto-synthesizer/enumerative_loop_contracts_synthesizer.cpp
+++ b/src/goto-synthesizer/enumerative_loop_contracts_synthesizer.cpp
@@ -49,6 +49,12 @@ void replace_tmp_post(
 
 std::vector<exprt> construct_terminals(const std::set<symbol_exprt> &symbols)
 {
+  // Construct a vector of terminal expressions.
+  // Terminals include:
+  //   1: scalar type variables and their loop_entry version.
+  //   2: offsets of pointers and loop_entry of pointers.
+  //   3: constants 0 and 1.
+
   std::vector<exprt> result;
   for(const auto &e : symbols)
   {
@@ -243,6 +249,18 @@ enumerative_loop_contracts_synthesizert::compute_dependent_symbols(
   std::set<symbol_exprt> result;
   for(const auto &e : live_vars)
     find_symbols(e, result);
+
+  // Erase all variables added during loop transformations---they are not in
+  // the original symbol table.
+  for(auto it = result.begin(); it != result.end();)
+  {
+    if(original_symbol_table.lookup(it->get_identifier()) == nullptr)
+    {
+      it = result.erase(it);
+    }
+    else
+      it++;
+  }
 
   return result;
 }

--- a/src/goto-synthesizer/enumerative_loop_contracts_synthesizer.h
+++ b/src/goto-synthesizer/enumerative_loop_contracts_synthesizer.h
@@ -36,7 +36,8 @@ public:
     messaget &log)
     : loop_contracts_synthesizer_baset(goto_model, log),
       options(options),
-      ns(goto_model.symbol_table)
+      ns(goto_model.symbol_table),
+      original_symbol_table(goto_model.symbol_table)
   {
   }
 
@@ -97,6 +98,9 @@ private:
 
   /// Map from tmp_post variables to their original variables.
   std::unordered_map<exprt, exprt, irep_hash> tmp_post_map;
+
+  /// Symbol table of the input goto model
+  const symbol_tablet original_symbol_table;
 };
 
 // NOLINTNEXTLINE(whitespace/line_length)


### PR DESCRIPTION
Collecting variables from trace will also collect those variables added during loop transformation, such as the car variables. Those variables should not appear in the loop contracts. This commit erases them from the terminals of the enumerating grammar used by the synthesizer.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
