### PR TITLE
Mark CBMC cbmc-5.94.1.

### DIFF
--- a/src/config.inc
+++ b/src/config.inc
@@ -76,7 +76,7 @@ endif
 OSX_IDENTITY="Developer ID Application: Daniel Kroening"
 
 # Detailed version information
-CBMC_VERSION = 5.94.0
+CBMC_VERSION = 5.94.1
 
 # Use the CUDD library for BDDs, can be installed using `make -C src cudd-download`
 # CUDD = ../../cudd-3.0.0

--- a/src/libcprover-rust/Cargo.toml
+++ b/src/libcprover-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libcprover_rust"
-version = "5.94.0"
+version = "5.94.1"
 edition = "2021"
 description = "Rust API for CBMC and assorted CProver tools"
 repository = "https://github.com/diffblue/cbmc"


### PR DESCRIPTION
Extraordinary release for inclusion of build-breaking bug fix https://github.com/diffblue/cbmc/pull/7958 ahead of v6 release.