### PR TITLE
Mark CBMC cbmc-5.95.1.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,11 +1,23 @@
-# CBMC 5.95.0
+# CBMC 5.95.1
 
 ## What's Changed
+
+* Multiplication encoding: cleanup, Dadda, data by @tautschnig in https://github.com/diffblue/cbmc/pull/7984
+
+## Bug Fixes
+
+* Remove extraneous y parameter from calls to exp and logl by @NlightNFotis in https://github.com/diffblue/cbmc/pull/7985
+
+**Full Changelog**: https://github.com/diffblue/cbmc/compare/cbmc-5.95.0...cbmc-5.95.1
+
+## CBMC 5.95.0
+
+### What's Changed
 
 * Add C front-end support for vector expressions as compile-time constants by @tautschnig in https://github.com/diffblue/cbmc/pull/7947
 * C library: add exp, log, pow models by @tautschnig in https://github.com/diffblue/cbmc/pull/7906
 
-## Bug Fixes
+### Bug Fixes
 
 * Fix bug with std::sort requires strict weak ordering by @tautschnig in https://github.com/diffblue/cbmc/pull/7956
 * SYNTHESIZER: Use only symbols from the original goto as terminals by @qinheping in https://github.com/diffblue/cbmc/pull/7970

--- a/src/config.inc
+++ b/src/config.inc
@@ -76,7 +76,7 @@ endif
 OSX_IDENTITY="Developer ID Application: Daniel Kroening"
 
 # Detailed version information
-CBMC_VERSION = 5.95.0
+CBMC_VERSION = 5.95.1
 
 # Use the CUDD library for BDDs, can be installed using `make -C src cudd-download`
 # CUDD = ../../cudd-3.0.0

--- a/src/libcprover-rust/Cargo.toml
+++ b/src/libcprover-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libcprover_rust"
-version = "5.95.0"
+version = "5.95.1"
 edition = "2021"
 description = "Rust API for CBMC and assorted CProver tools"
 repository = "https://github.com/diffblue/cbmc"


### PR DESCRIPTION
Point release to include build-breaking issue fix at #7985.


