### PR TITLE
Add support for union values in traces for incremental smt2 decision procedure

### DIFF
--- a/regression/cbmc-incr-smt2/unions/padded.c
+++ b/regression/cbmc-incr-smt2/unions/padded.c
@@ -1,0 +1,14 @@
+#include <assert.h>
+#include <stdint.h>
+
+union my_uniont
+{
+  uint16_t a;
+  uint8_t b;
+};
+
+int main()
+{
+  union my_uniont my_union = {.b = 5};
+  assert(my_union.a == 5);
+}

--- a/regression/cbmc-incr-smt2/unions/padded.desc
+++ b/regression/cbmc-incr-smt2/unions/padded.desc
@@ -1,0 +1,12 @@
+CORE
+padded.c
+--trace
+Passing problem to incremental SMT2 solving
+\[main\.assertion\.1\] line 13 assertion my_union\.a \=\= 5\: FAILURE
+my_union\=\{ \.a\=\d+ \} \(\d{8} 00000101\)
+^EXIT=10$
+^SIGNAL=0$
+--
+--
+Test that we support union values and traces for a example where the trace
+should include non deterministic padding.

--- a/src/solvers/smt2_incremental/encoding/struct_encoding.cpp
+++ b/src/solvers/smt2_incremental/encoding/struct_encoding.cpp
@@ -277,3 +277,30 @@ exprt struct_encodingt::decode(
   }
   return simplify_expr(struct_exprt{encoded_fields, original_type}, ns);
 }
+
+exprt struct_encodingt::decode(
+  const exprt &encoded,
+  const union_tag_typet &original_type) const
+{
+  INVARIANT(
+    can_cast_type<bv_typet>(encoded.type()),
+    "Unions are expected to be encoded into bit vectors.");
+  const union_typet definition = ns.get().follow_tag(original_type);
+  const auto &components = definition.components();
+  if(components.empty())
+    return empty_union_exprt{original_type};
+  // A union expression is built here using the first component in the
+  // declaration of the union. There may be better alternatives but this matches
+  // the SAT backend. See the case for `type.id() == ID_union` in
+  // `boolbvt::bv_get_rec`.
+  const auto &component_for_definition = components[0];
+  return simplify_expr(
+    union_exprt{
+      component_for_definition.get_name(),
+      typecast_exprt{
+        encode(member_exprt{
+          typecast_exprt{encoded, original_type}, component_for_definition}),
+        component_for_definition.type()},
+      original_type},
+    ns);
+}

--- a/src/solvers/smt2_incremental/encoding/struct_encoding.h
+++ b/src/solvers/smt2_incremental/encoding/struct_encoding.h
@@ -12,6 +12,7 @@ class namespacet;
 class boolbv_widtht;
 class member_exprt;
 class struct_tag_typet;
+class union_tag_typet;
 
 /// Encodes struct types/values into non-struct expressions/types.
 class struct_encodingt final
@@ -27,6 +28,8 @@ public:
   /// from the bit vector \p encoded expression.
   exprt
   decode(const exprt &encoded, const struct_tag_typet &original_type) const;
+  exprt
+  decode(const exprt &encoded, const union_tag_typet &original_type) const;
 
 private:
   std::unique_ptr<boolbv_widtht> boolbv_width;

--- a/src/solvers/smt2_incremental/smt2_incremental_decision_procedure.cpp
+++ b/src/solvers/smt2_incremental/smt2_incremental_decision_procedure.cpp
@@ -4,6 +4,7 @@
 
 #include <util/arith_tools.h>
 #include <util/byte_operators.h>
+#include <util/c_types.h>
 #include <util/namespace.h>
 #include <util/nodiscard.h>
 #include <util/range.h>
@@ -479,6 +480,17 @@ optionalt<exprt> smt2_incremental_decision_proceduret::get_expr(
 }
 
 optionalt<exprt> smt2_incremental_decision_proceduret::get_expr(
+  const smt_termt &union_term,
+  const union_tag_typet &type) const
+{
+  const auto encoded_result =
+    get_expr(union_term, struct_encoding.encode(type));
+  if(!encoded_result)
+    return {};
+  return {struct_encoding.decode(*encoded_result, type)};
+}
+
+optionalt<exprt> smt2_incremental_decision_proceduret::get_expr(
   const smt_termt &descriptor,
   const typet &type) const
 {
@@ -491,6 +503,10 @@ optionalt<exprt> smt2_incremental_decision_proceduret::get_expr(
   if(const auto struct_type = type_try_dynamic_cast<struct_tag_typet>(type))
   {
     return get_expr(descriptor, *struct_type);
+  }
+  if(const auto union_type = type_try_dynamic_cast<union_tag_typet>(type))
+  {
+    return get_expr(descriptor, *union_type);
   }
   const smt_get_value_commandt get_value_command{descriptor};
   const smt_responset response = get_response_to_command(

--- a/src/solvers/smt2_incremental/smt2_incremental_decision_procedure.h
+++ b/src/solvers/smt2_incremental/smt2_incremental_decision_procedure.h
@@ -23,6 +23,7 @@
 class namespacet;
 class smt_base_solver_processt; // IWYU pragma: keep
 class string_constantt;
+class union_tag_typet;
 
 class smt2_incremental_decision_proceduret final
   : public stack_decision_proceduret
@@ -59,6 +60,8 @@ public:
   get_expr(const smt_termt &descriptor, const typet &type) const;
   optionalt<exprt>
   get_expr(const smt_termt &struct_term, const struct_tag_typet &type) const;
+  optionalt<exprt>
+  get_expr(const smt_termt &union_term, const union_tag_typet &type) const;
   optionalt<exprt>
   get_expr(const smt_termt &array, const array_typet &type) const;
 

--- a/unit/solvers/smt2_incremental/encoding/struct_encoding.cpp
+++ b/unit/solvers/smt2_incremental/encoding/struct_encoding.cpp
@@ -418,6 +418,50 @@ TEST_CASE("decoding into struct expressions.", "[core][smt2_incremental]")
   REQUIRE(test.struct_encoding.decode(encoded, struct_tag) == expected);
 }
 
+TEST_CASE("decoding into union expressions.", "[core][smt2_incremental]")
+{
+  auto test = struct_encoding_test_environmentt::make();
+  SECTION("Single union component")
+  {
+    const struct_union_typet::componentst type_components{
+      {"eggs", unsignedbv_typet{16}}};
+    const union_typet union_type{type_components};
+    const type_symbolt type_symbol{"my_uniont", union_type, ID_C};
+    test.symbol_table.insert(type_symbol);
+    const union_tag_typet union_tag{type_symbol.name};
+    const union_exprt expected{
+      "eggs", from_integer(12, unsignedbv_typet{16}), union_tag};
+    const exprt encoded = from_integer(12, bv_typet{16});
+    REQUIRE(test.struct_encoding.decode(encoded, union_tag) == expected);
+  }
+  SECTION("Multiple union components")
+  {
+    const struct_union_typet::componentst type_components{
+      {"green", signedbv_typet{32}},
+      {"eggs", unsignedbv_typet{16}},
+      {"ham", signedbv_typet{24}}};
+    const union_typet union_type{type_components};
+    const type_symbolt type_symbol{"my_uniont", union_type, ID_C};
+    test.symbol_table.insert(type_symbol);
+    const union_tag_typet union_tag{type_symbol.name};
+    const union_exprt expected{
+      "green", from_integer(-42, signedbv_typet{32}), union_tag};
+    const exprt encoded = from_integer((~uint32_t{42} + 1), bv_typet{32});
+    REQUIRE(test.struct_encoding.decode(encoded, union_tag) == expected);
+  }
+  SECTION("Empty union")
+  {
+    const struct_union_typet::componentst type_components{};
+    const union_typet union_type{type_components};
+    const type_symbolt type_symbol{"my_empty_uniont", union_type, ID_C};
+    test.symbol_table.insert(type_symbol);
+    const union_tag_typet union_tag{type_symbol.name};
+    const empty_union_exprt expected{union_tag};
+    const exprt encoded = from_integer(0, bv_typet{8});
+    REQUIRE(test.struct_encoding.decode(encoded, union_tag) == expected);
+  }
+}
+
 TEST_CASE("encoding of struct with no members", "[core][smt2_incremental]")
 {
   auto test = struct_encoding_test_environmentt::make();


### PR DESCRIPTION
This PR adds support for union values in traces for incremental smt2 decision procedure.
<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
