### PR TITLE
Fix line-number output in document-properties-*

### DIFF
--- a/regression/goto-instrument/document-properties-basic/html.desc
+++ b/regression/goto-instrument/document-properties-basic/html.desc
@@ -3,7 +3,7 @@ main.c
 --document-properties-html
 ^EXIT=0$
 ^SIGNAL=0$
-^<em>  assert\(1 == 1\);<\/em>$
+^\s*\d+&nbsp;&nbsp;<em>  assert\(1 == 1\);<\/em>$
 --
 ^warning: ignoring
 --

--- a/src/goto-instrument/document_properties.cpp
+++ b/src/goto-instrument/document_properties.cpp
@@ -225,6 +225,11 @@ document_propertiest::get_code(const source_locationt &source_location)
 
   // build dest
 
+  std::size_t max_line_number_width = 0;
+  if(!lines.empty())
+  {
+    max_line_number_width = std::to_string(lines.back().line_number).size();
+  }
   for(std::list<linet>::iterator it=lines.begin();
       it!=lines.end(); it++)
   {
@@ -235,10 +240,10 @@ document_propertiest::get_code(const source_locationt &source_location)
     switch(format)
     {
     case LATEX:
-      while(line_no.size()<4)
+      while(line_no.size() < max_line_number_width)
         line_no=" "+line_no;
 
-      line_no+"  ";
+      line_no += "  ";
 
       tmp+=escape_latex(it->text, true);
 
@@ -248,10 +253,10 @@ document_propertiest::get_code(const source_locationt &source_location)
       break;
 
     case HTML:
-      while(line_no.size()<4)
+      while(line_no.size() < max_line_number_width)
         line_no="&nbsp;"+line_no;
 
-      line_no+"&nbsp;&nbsp;";
+      line_no += "&nbsp;&nbsp;";
 
       tmp+=escape_html(it->text);
 
@@ -261,7 +266,7 @@ document_propertiest::get_code(const source_locationt &source_location)
       break;
     }
 
-    dest+=tmp+"\n";
+    dest += line_no + tmp + "\n";
   }
 
   return dest;


### PR DESCRIPTION
The `line_no` variable was never used in producing the output, even though it was written to (and in parts also used in an expression without having an effect, which tripped up the compiler with newer standards versions).

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
