### PR TITLE
CODING_STANDARD.md: fix references to clang-format

### DIFF
--- a/CODING_STANDARD.md
+++ b/CODING_STANDARD.md
@@ -12,8 +12,9 @@ Here a few minimalistic coding rules for the CPROVER source tree.
 
 # Whitespaces
 
-Formatting is enforced using clang-format. For more information about this, see
-`COMPILING.md`. A brief summary of the formatting rules is given below:
+Formatting is enforced using clang-format.  For more information about this,
+see the section "using clang-format" below.  A brief summary of the
+formatting rules is given below:
 
 - Use 2 spaces indent, no tabs.
 - No lines wider than 80 chars.
@@ -340,13 +341,13 @@ To avoid waiting until you've made a PR to find formatting issues, you can
 install clang-format locally and run it against your code as you are working.
 
 Different versions of clang-format have slightly different behaviors. CBMC uses
-clang-format-10 as it is available the repositories for Ubuntu 18.04 and
+clang-format-11 as it is available the repositories for Ubuntu 20.04 and
 Homebrew.
 To install on a Unix-like system, try installing using the system package
 manager:
 ```
-apt-get install clang-format-10  # Run this on Ubuntu, Debian etc.
-brew install clang-format@10     # Run this on a Mac with Homebrew installed
+apt-get install clang-format-11  # Run this on Ubuntu, Debian etc.
+brew install clang-format@11     # Run this on a Mac with Homebrew installed
 ```
 
 If your platform doesn't have a package for clang-format, you can download a
@@ -373,7 +374,7 @@ rebase your work onto the tip of the branch it's based on before running
 Note: By default, git-clang-format uses the git config variable
 `clangformat.binary`. If you have multiple versions of clang-format installed,
 you might need to update this, or explicitly specify the binary to use via
-`--binary clang-format-10`.
+`--binary clang-format-11`.
 
 ### RETROACTIVELY FORMATTING INDIVIDUAL COMMITS
 


### PR DESCRIPTION
This fixes the description of how to use clang-format in CODING_STANDARD.md.

* The CI uses clang-format-11 (as opposed to -10) since 557d941d339d6938d6946755cd58c78788a06553.

* The promise that this is available on Ubuntu 18.04 cannot be met.  The earliest version of Ubuntu that has clang-format-11 out of the box is 20.04.

* There is a reference to COMPILING.md, which does not say anything at all about clang-format.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- n/a Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
