### PR TITLE
Perform simplification of not_exprt as preorder step

### DIFF
--- a/src/util/simplify_expr.cpp
+++ b/src/util/simplify_expr.cpp
@@ -2985,6 +2985,10 @@ simplify_exprt::simplify_node_preorder(const exprt &expr)
   {
     result = simplify_unary_pointer_predicate_preorder(to_unary_expr(expr));
   }
+  else if(expr.id() == ID_not)
+  {
+    result = simplify_not_preorder(to_not_expr(expr));
+  }
   else if(expr.has_operands())
   {
     std::optional<exprt::operandst> new_operands;

--- a/src/util/simplify_expr_boolean.cpp
+++ b/src/util/simplify_expr_boolean.cpp
@@ -15,6 +15,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "namespace.h"
 #include "std_expr.h"
 
+#include <optional>
 #include <unordered_set>
 
 simplify_exprt::resultt<> simplify_exprt::simplify_boolean(const exprt &expr)
@@ -321,6 +322,56 @@ simplify_exprt::resultt<> simplify_exprt::simplify_boolean(const exprt &expr)
   return unchanged(expr);
 }
 
+/// Structural rewrites of `!op` that do not require op's operands to be
+/// simplified first: double negation, constant folding, De Morgan's laws,
+/// `!=`->`==`, and quantifier negation. Returns the rewritten (not yet
+/// simplified) expression, or an empty optional if no such rewrite applies.
+/// Shared by both \ref simplify_exprt::simplify_not (post-order) and
+/// \ref simplify_exprt::simplify_not_preorder so the rule set lives in a
+/// single place and cannot drift.
+static std::optional<exprt> simplify_not_rewrite(const not_exprt &expr)
+{
+  const exprt &op = expr.op();
+
+  if(op.id() == ID_not) // (not not a) == a
+    return to_not_expr(op).op();
+  else if(op.is_false())
+    return true_exprt{};
+  else if(op.is_true())
+    return false_exprt{};
+  else if(op.id() == ID_and || op.id() == ID_or) // De Morgan
+  {
+    exprt tmp = op;
+
+    for(auto &operand : tmp.operands())
+      operand = boolean_negate(operand);
+
+    tmp.id(tmp.id() == ID_and ? ID_or : ID_and);
+
+    return tmp;
+  }
+  else if(op.id() == ID_notequal) // !(a!=b) <-> a==b
+  {
+    exprt tmp = op;
+    tmp.id(ID_equal);
+    return tmp;
+  }
+  else if(op.id() == ID_exists) // !(exists: a) <-> forall: not a
+  {
+    auto const &op_as_exists = to_exists_expr(op);
+    return forall_exprt{
+      op_as_exists.variables(), not_exprt{op_as_exists.where()}};
+  }
+  else if(op.id() == ID_forall) // !(forall: a) <-> exists: not a
+  {
+    auto const &op_as_forall = to_forall_expr(op);
+    return exists_exprt{
+      op_as_forall.variables(), not_exprt{op_as_forall.where()}};
+  }
+
+  return {};
+}
+
 simplify_exprt::resultt<> simplify_exprt::simplify_not(const not_exprt &expr)
 {
   const exprt &op = expr.op();
@@ -330,52 +381,32 @@ simplify_exprt::resultt<> simplify_exprt::simplify_not(const not_exprt &expr)
     return unchanged(expr);
   }
 
-  if(op.id()==ID_not) // (not not a) == a
-  {
-    return to_not_expr(op).op();
-  }
-  else if(op == false)
-  {
-    return true_exprt();
-  }
-  else if(op == true)
-  {
-    return false_exprt();
-  }
-  else if(op.id()==ID_and ||
-          op.id()==ID_or)
-  {
-    exprt tmp = op;
-
-    Forall_operands(it, tmp)
-    {
-      *it = simplify_not(not_exprt(*it));
-    }
-
-    tmp.id(tmp.id() == ID_and ? ID_or : ID_and);
-
-    return std::move(tmp);
-  }
-  else if(op.id()==ID_notequal) // !(a!=b) <-> a==b
-  {
-    exprt tmp = op;
-    tmp.id(ID_equal);
-    return std::move(tmp);
-  }
-  else if(op.id()==ID_exists) // !(exists: a) <-> forall: not a
-  {
-    auto const &op_as_exists = to_exists_expr(op);
-    return forall_exprt{op_as_exists.variables(),
-                        simplify_not(not_exprt(op_as_exists.where()))};
-  }
-  else if(op.id() == ID_forall) // !(forall: a) <-> exists: not a
-  {
-    auto const &op_as_forall = to_forall_expr(op);
-    return exists_exprt{op_as_forall.variables(),
-                        simplify_not(not_exprt(op_as_forall.where()))};
-  }
+  if(auto rewritten = simplify_not_rewrite(expr))
+    return changed(simplify_rec(*rewritten));
 
   return unchanged(expr);
+}
+
+simplify_exprt::resultt<>
+simplify_exprt::simplify_not_preorder(const not_exprt &expr)
+{
+  const exprt &op = expr.op();
+
+  if(!expr.is_boolean() || !op.is_boolean())
+  {
+    return unchanged(expr);
+  }
+
+  if(auto rewritten = simplify_not_rewrite(expr))
+    return changed(simplify_rec(*rewritten));
+
+  auto op_result = simplify_rec(op);
+  if(!op_result.has_changed())
+    return unchanged(expr);
+
+  not_exprt tmp = expr;
+  tmp.op() = std::move(op_result.expr);
+  return std::move(tmp);
 }
 
 simplify_exprt::resultt<>

--- a/src/util/simplify_expr_class.h
+++ b/src/util/simplify_expr_class.h
@@ -174,6 +174,7 @@ public:
   [[nodiscard]] resultt<> simplify_if(const if_exprt &);
   [[nodiscard]] resultt<> simplify_bitnot(const bitnot_exprt &);
   [[nodiscard]] resultt<> simplify_not(const not_exprt &);
+  [[nodiscard]] resultt<> simplify_not_preorder(const not_exprt &);
   [[nodiscard]] resultt<> simplify_boolean(const exprt &);
   [[nodiscard]] virtual resultt<>
   simplify_inequality(const binary_relation_exprt &);

--- a/unit/util/simplify_expr.cpp
+++ b/unit/util/simplify_expr.cpp
@@ -353,6 +353,31 @@ TEST_CASE("simplify_expr boolean expressions", "[core][util]")
   {
     REQUIRE(simplify_expr(not_exprt{true_exprt()}, ns) == false_exprt());
     REQUIRE(simplify_expr(not_exprt{false_exprt()}, ns) == true_exprt());
+
+    const symbol_exprt a{"a", bool_typet{}};
+    const symbol_exprt b{"b", bool_typet{}};
+
+    // double negation: !!a == a. Note the inner negation is held as an exprt
+    // so that the outer not_exprt nests it (rather than copy-constructing).
+    const exprt not_a = not_exprt{a};
+    REQUIRE(simplify_expr(not_exprt{not_a}, ns) == a);
+
+    // De Morgan: !(a && b) == !a || !b
+    REQUIRE(
+      simplify_expr(not_exprt{and_exprt{a, b}}, ns) ==
+      simplify_expr(or_exprt{not_exprt{a}, not_exprt{b}}, ns));
+
+    // De Morgan: !(a || b) == !a && !b
+    REQUIRE(
+      simplify_expr(not_exprt{or_exprt{a, b}}, ns) ==
+      simplify_expr(and_exprt{not_exprt{a}, not_exprt{b}}, ns));
+
+    // !(x != y) == x == y
+    const symbol_exprt x{"x", integer_typet{}};
+    const symbol_exprt y{"y", integer_typet{}};
+    REQUIRE(
+      simplify_expr(not_exprt{notequal_exprt{x, y}}, ns) ==
+      simplify_expr(equal_exprt{x, y}, ns));
   }
   SECTION("Nested boolean expressions")
   {
@@ -619,6 +644,32 @@ TEST_CASE("Simplify quantifier", "[core][util]")
     REQUIRE(simplify_expr(forall_exprt{a, false_exprt{}}, ns) == false_exprt{});
 
     REQUIRE(simplify_expr(forall_exprt{a, true_exprt{}}, ns) == true_exprt{});
+  }
+
+  SECTION("Negation of quantifiers")
+  {
+    const symbol_exprt x{"x", integer_typet{}};
+    const symbol_exprt y{"y", integer_typet{}};
+    const exprt body = equal_exprt{x, y};
+
+    // single variable: !(exists x. x==y) <-> forall x. !(x==y)
+    REQUIRE(
+      simplify_expr(not_exprt{exists_exprt{x, body}}, ns) ==
+      simplify_expr(forall_exprt{x, not_exprt{body}}, ns));
+    REQUIRE(
+      simplify_expr(not_exprt{forall_exprt{x, body}}, ns) ==
+      simplify_expr(exists_exprt{x, not_exprt{body}}, ns));
+
+    // multiple variables: regression for the symbol()/variables() narrowing --
+    // a multi-variable quantifier must be rewritten, not trip the single
+    // variable PRECONDITION of quantifier_exprt::symbol().
+    const binding_exprt::variablest vars{x, y};
+    REQUIRE(
+      simplify_expr(not_exprt{forall_exprt{vars, body}}, ns) ==
+      simplify_expr(exists_exprt{vars, not_exprt{body}}, ns));
+    REQUIRE(
+      simplify_expr(not_exprt{exists_exprt{vars, body}}, ns) ==
+      simplify_expr(forall_exprt{vars, not_exprt{body}}, ns));
   }
 }
 


### PR DESCRIPTION
Each of the possible simplifications has an impact on its operands, which in turn mostly needs to be simplified. Instead of doing this again (as the operand has already been simplified), do most of the work as a preorder step so that only the modified operand is subject to simplification.

We may wish to merge #6118 first to then use `resultt` as return types and pass `const` arguments.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
