### PR TITLE
Delete `string_constantt::get_value` and  `string_constantt::set_value` functions

### DIFF
--- a/src/util/string_constant.h
+++ b/src/util/string_constant.h
@@ -16,19 +16,7 @@ class string_constantt : public nullary_exprt
 public:
   explicit string_constantt(const irep_idt &);
 
-  DEPRECATED(SINCE(2023, 10, 31, "use value(...)"))
-  void set_value(const irep_idt &_value)
-  {
-    value(_value);
-  }
-
   void value(const irep_idt &);
-
-  DEPRECATED(SINCE(2023, 10, 31, "use value()"))
-  const irep_idt &get_value() const
-  {
-    return value();
-  }
 
   const irep_idt &value() const
   {


### PR DESCRIPTION
Marked `DEPRECATED` over the `value()` function.

Depends on #7999 

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
