### PR TITLE
[CI] Minor fixes to CI accompanying C++17 version change

### DIFF
--- a/.github/workflows/pull-request-check-rust-api.yaml
+++ b/.github/workflows/pull-request-check-rust-api.yaml
@@ -62,7 +62,7 @@ jobs:
       # by the other jobs already present in `pull-request-checks.yaml`.
       - name: Run Rust API tests
         run: |
-          VERSION=$(cat src/config.inc | python3 -c "import sys,re;line = [line for line in sys.stdin if re.search('CBMC_VERSION = (\d+\.\d+\.\d+)', line)];sys.stdout.write(re.search('CBMC_VERSION = (\d+\.\d+\.\d+)', line[0]).group(1))")
+          VERSION=$(cat src/config.inc | python3 -c "import sys,re;line = [line for line in sys.stdin if re.search(r'CBMC_VERSION = (\d+\.\d+\.\d+)', line)];sys.stdout.write(re.search(r'CBMC_VERSION = (\d+\.\d+\.\d+)', line[0]).group(1))")
           cd src/libcprover-rust;\
           cargo clean;\
           CBMC_INCLUDE_DIR=../../${{env.default_include_dir}} CBMC_LIB_DIR=../../${{env.default_build_dir}}/lib CBMC_VERSION=$VERSION cargo test -- --test-threads=1
@@ -102,7 +102,7 @@ jobs:
       # by the other jobs already present in `pull-request-checks.yaml`.
       - name: Run Rust API tests
         run: |
-          VERSION=$(cat src/config.inc | python3 -c "import sys,re;line = [line for line in sys.stdin if re.search('CBMC_VERSION = (\d+\.\d+\.\d+)', line)];sys.stdout.write(re.search('CBMC_VERSION = (\d+\.\d+\.\d+)', line[0]).group(1))")
+          VERSION=$(cat src/config.inc | python3 -c "import sys,re;line = [line for line in sys.stdin if re.search(r'CBMC_VERSION = (\d+\.\d+\.\d+)', line)];sys.stdout.write(re.search(r'CBMC_VERSION = (\d+\.\d+\.\d+)', line[0]).group(1))")
           cd src/libcprover-rust;\
           cargo clean;\
           CBMC_INCLUDE_DIR=../../${{env.default_include_dir}} CBMC_LIB_DIR=../../${{env.default_build_dir}}/lib CBMC_VERSION=$VERSION cargo test -- --test-threads=1

--- a/.github/workflows/pull-request-check-rust-api.yaml
+++ b/.github/workflows/pull-request-check-rust-api.yaml
@@ -68,8 +68,8 @@ jobs:
           CBMC_INCLUDE_DIR=../../${{env.default_include_dir}} CBMC_LIB_DIR=../../${{env.default_build_dir}}/lib CBMC_VERSION=$VERSION cargo test -- --test-threads=1
 
 
-  check-macos-12-cmake-clang-rust:
-    runs-on: macos-12
+  check-macos-13-cmake-clang-rust:
+    runs-on: macos-13
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/pull-request-check-rust-api.yaml
+++ b/.github/workflows/pull-request-check-rust-api.yaml
@@ -102,6 +102,7 @@ jobs:
       # by the other jobs already present in `pull-request-checks.yaml`.
       - name: Run Rust API tests
         run: |
+          export MACOSX_DEPLOYMENT_TARGET=10.15
           VERSION=$(cat src/config.inc | python3 -c "import sys,re;line = [line for line in sys.stdin if re.search(r'CBMC_VERSION = (\d+\.\d+\.\d+)', line)];sys.stdout.write(re.search(r'CBMC_VERSION = (\d+\.\d+\.\d+)', line[0]).group(1))")
           cd src/libcprover-rust;\
           cargo clean;\

--- a/.github/workflows/pull-request-check-rust-api.yaml
+++ b/.github/workflows/pull-request-check-rust-api.yaml
@@ -82,10 +82,10 @@ jobs:
         uses: actions/cache@v3
         with:
           path: .ccache
-          key: ${{ runner.os }}-Release-${{ github.ref }}-${{ github.sha }}-PR-Rust-API
+          key: ${{ runner.os }}-Release-Minisat-${{ github.ref }}-${{ github.sha }}-PR-Rust-API
           restore-keys: |
-            ${{ runner.os }}-Release-${{ github.ref }}
-            ${{ runner.os }}-Release
+            ${{ runner.os }}-Release-Minisat-${{ github.ref }}
+            ${{ runner.os }}-Release-Minisat
       - name: ccache environment
         run: |
           echo "CCACHE_BASEDIR=$PWD" >> $GITHUB_ENV

--- a/src/libcprover-rust/Cargo.toml
+++ b/src/libcprover-rust/Cargo.toml
@@ -12,7 +12,7 @@ readme = "readme.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-cxx = "1.0"
+cxx = { version = "1.0", default-features = false, features = ["std", "c++17"] }
 
 [build-dependencies]
 cxx-build = "1.0"

--- a/src/libcprover-rust/build.rs
+++ b/src/libcprover-rust/build.rs
@@ -72,7 +72,7 @@ fn main() {
         .include(cpp_api_include_path)
         .include(get_current_working_dir().unwrap())
         .file("src/c_api.cc")
-        .flag_if_supported("-std=c++11")
+        .flag_if_supported("-std=c++17")
         .compile("cprover-rust-api");
 
     println!("cargo:rerun-if-changed=src/c_api.cc");

--- a/src/libcprover-rust/src/lib.rs
+++ b/src/libcprover-rust/src/lib.rs
@@ -517,7 +517,7 @@ mod tests {
         if let Ok(el) = results {
             let_cxx_string!(non_existing_property = "main.the.jabberwocky");
             let prop_status = cprover_api::get_property_status(&el, &non_existing_property);
-            if let Err(status) = prop_status {
+            if let Err(_status) = prop_status {
                 Ok(())
             } else {
                 let error_msg = format!(


### PR DESCRIPTION
Currently the Rust API build for macOS when running on `develop` is failing, with the toolchain saying that it cannot find the file for `<algorithm>`. This points to a stale or otherwise compromised build configuration, so this is an experimental PR to change the environment (macOS) to a newer version (12 -> 13) in an attempt to ameliorate the situation.