### PR TITLE
Remove useless steps from Rust CI pipeline

### DIFF
--- a/.github/workflows/pull-request-check-rust-api.yaml
+++ b/.github/workflows/pull-request-check-rust-api.yaml
@@ -29,7 +29,7 @@ jobs:
           DEBIAN_FRONTEND: noninteractive
         run: |
           sudo apt-get update
-          sudo apt-get install --no-install-recommends -yq clang-13 clang++-13 maven flex bison libxml2-utils ccache
+          sudo apt-get install --no-install-recommends -yq clang-13 clang++-13 flex bison libxml2-utils ccache
       - name: Log cargo/rust version
         run: cargo --version
       - name: Prepare ccache
@@ -53,9 +53,9 @@ jobs:
       # local experiments on the same platform, but it seems to be doing no harm to the build overall
       # and allows us to test the Rust API on Linux without issues.
       - name: Configure using CMake
-        run: cmake -S. -B${{env.default_build_dir}} -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DCMAKE_C_COMPILER=/usr/bin/clang-13 -DCMAKE_CXX_COMPILER=/usr/bin/clang++-13
+        run: cmake -S. -B${{env.default_build_dir}} -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DCMAKE_C_COMPILER=/usr/bin/clang-13 -DCMAKE_CXX_COMPILER=/usr/bin/clang++-13 -DWITH_JBMC=OFF
       - name: Build with CMake
-        run: cmake --build ${{env.default_build_dir}} -j2
+        run: cmake --build ${{env.default_build_dir}} -j2 --target cprover-api-cpp
       - name: Print ccache stats
         run: ccache -s
       # We won't be running any of the regular regression tests, as these are covered
@@ -75,7 +75,7 @@ jobs:
         with:
           submodules: recursive
       - name: Fetch dependencies
-        run: brew install cmake ninja maven flex bison ccache
+        run: brew install cmake ninja flex bison ccache
       - name: Log cargo/rust version
         run: cargo --version
       - name: Prepare ccache
@@ -93,9 +93,9 @@ jobs:
       - name: Zero ccache stats and limit in size
         run: ccache -z --max-size=500M
       - name: Configure using CMake
-        run: cmake -S. -B${{env.default_build_dir}} -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=/usr/bin/clang -DCMAKE_CXX_COMPILER=/usr/bin/clang++
+        run: cmake -S. -B${{env.default_build_dir}} -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=/usr/bin/clang -DCMAKE_CXX_COMPILER=/usr/bin/clang++ -DWITH_JBMC=OFF
       - name: Build with Ninja
-        run: cd ${{env.default_build_dir}}; ninja -j3
+        run: cd ${{env.default_build_dir}}; ninja -j3 cprover-api-cpp
       - name: Print ccache stats
         run: ccache -s
       # We won't be running any of the regular regression tests, as these are covered


### PR DESCRIPTION
Removed 3 useless steps from the CBMC Rust:

1. now we build only the required `cprover-api-cpp` target and its transitive dependencies excluding all binaries not needed, unit tests and JBMC.
2. we add `-DWITH_JBMC=OFF` to the cmake arguments removing the configuration steps for it.
3. we removed the installation of `maven` used only when building JBMC that is now not happening.


- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
