### PR TITLE
Refactor `smt_function_application_termt::indices` using C++17 feature

### DIFF
--- a/src/solvers/smt2_incremental/ast/smt_terms.h
+++ b/src/solvers/smt2_incremental/ast/smt_terms.h
@@ -153,28 +153,15 @@ private:
   {
   };
 
-  /// Overload for when \p functiont does not have indices.
-  template <class functiont>
-  static std::vector<smt_indext>
-  indices(const functiont &function, const std::false_type &has_indices)
-  {
-    return {};
-  }
-
-  /// Overload for when \p functiont has indices member function.
-  template <class functiont>
-  static std::vector<smt_indext>
-  indices(const functiont &function, const std::true_type &has_indices)
-  {
-    return function.indices();
-  }
-
-  /// Returns `function.indices` if `functiont` has an `indices` member function
-  /// or returns an empty collection otherwise.
+  /// Returns `function.indices()` if `functiont` has an `indices` member
+  /// function or returns an empty collection otherwise.
   template <class functiont>
   static std::vector<smt_indext> indices(const functiont &function)
   {
-    return indices(function, has_indicest<functiont>{});
+    if constexpr(has_indicest<functiont>::value)
+      return function.indices();
+    else
+      return {};
   }
 
 public:


### PR DESCRIPTION
With C++17's `if constexpr` feature we can now remove two alternate function templates and just put the alternate implementations in line. This puts the specialisation into the outer function, so that it is specialised with the correct implementation for the given `functiont`, rather than dispatching based on the `std::true_type` / `std::false_type` overloads.
<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
