### PR TITLE
Replace usage of `std::result_of` with `std::invoke_result`

### DIFF
--- a/src/util/range.h
+++ b/src/util/range.h
@@ -418,9 +418,7 @@ public:
   /// a value through `f`. `f` may take a move-only typed parameter by const
   /// reference. 'f' may also construct and return a move-only typed value.
   template <typename functiont>
-  auto map(functiont &&f) -> ranget<map_iteratort<
-    iteratort,
-    typename std::result_of<functiont(value_type)>::type>>
+  auto map(functiont &&f)
   {
     using outputt = typename std::result_of<functiont(value_type)>::type;
     auto shared_f = std::make_shared<

--- a/src/util/range.h
+++ b/src/util/range.h
@@ -420,7 +420,7 @@ public:
   template <typename functiont>
   auto map(functiont &&f)
   {
-    using outputt = typename std::result_of<functiont(value_type)>::type;
+    using outputt = typename std::invoke_result<functiont, value_type>::type;
     auto shared_f = std::make_shared<
       std::function<outputt(const typename iteratort::value_type &)>>(
       std::forward<functiont>(f));


### PR DESCRIPTION
C++17 deprecates `std::result_of` in favour of `std::invoke_result`. Updating our code to use the replacement avoids the use of the deprecated version.
<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
