### PR TITLE
Cleanup USE_STD_STRING/USE_DSTRING configuration option

### DIFF
--- a/jbmc/src/java_bytecode/character_refine_preprocess.h
+++ b/jbmc/src/java_bytecode/character_refine_preprocess.h
@@ -23,6 +23,7 @@ Date:   March 2017
 #include <util/mp_arith.h>
 #include <util/std_code_base.h>
 
+#include <list>
 #include <unordered_map>
 
 class code_function_callt;

--- a/jbmc/src/java_bytecode/java_bytecode_parse_tree.h
+++ b/jbmc/src/java_bytecode/java_bytecode_parse_tree.h
@@ -10,13 +10,14 @@ Author: Daniel Kroening, kroening@kroening.com
 #ifndef CPROVER_JAVA_BYTECODE_JAVA_BYTECODE_PARSE_TREE_H
 #define CPROVER_JAVA_BYTECODE_JAVA_BYTECODE_PARSE_TREE_H
 
-#include <set>
-#include <map>
-
 #include <util/std_types.h>
 
 #include "bytecode_info.h"
 #include "java_types.h"
+
+#include <list>
+#include <map>
+#include <set>
 
 struct java_bytecode_parse_treet
 {

--- a/jbmc/src/java_bytecode/java_class_loader_base.h
+++ b/jbmc/src/java_bytecode/java_class_loader_base.h
@@ -13,6 +13,8 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "jar_pool.h"
 
+#include <list>
+
 class message_handlert;
 struct java_bytecode_parse_treet;
 

--- a/src/crangler/c_wrangler.cpp
+++ b/src/crangler/c_wrangler.cpp
@@ -23,6 +23,7 @@ Author: Daniel Kroening, dkr@amazon.com
 
 #include <fstream> // IWYU pragma: keep
 #include <iostream>
+#include <list>
 #include <map>
 #include <regex>
 #include <sstream>

--- a/src/goto-cc/compile.h
+++ b/src/goto-cc/compile.h
@@ -18,6 +18,7 @@ Date: June 2006
 #include <util/std_types.h>
 #include <util/symbol.h>
 
+#include <list>
 #include <map>
 
 class cmdlinet;

--- a/src/goto-cc/ld_mode.h
+++ b/src/goto-cc/ld_mode.h
@@ -17,6 +17,8 @@ Date: June 2006
 #include "gcc_message_handler.h"
 #include "goto_cc_mode.h"
 
+#include <list>
+
 class ld_modet : public goto_cc_modet
 {
 public:

--- a/src/goto-cc/linker_script_merge.h
+++ b/src/goto-cc/linker_script_merge.h
@@ -5,10 +5,11 @@
 #ifndef CPROVER_GOTO_CC_LINKER_SCRIPT_MERGE_H
 #define CPROVER_GOTO_CC_LINKER_SCRIPT_MERGE_H
 
-#include <functional>
-#include <map>
-
 #include <util/message.h>
+
+#include <functional>
+#include <list>
+#include <map>
 
 class cmdlinet;
 class exprt; // IWYU pragma: keep

--- a/src/goto-harness/recursive_initialization.h
+++ b/src/goto-harness/recursive_initialization.h
@@ -9,14 +9,15 @@ Author: Diffblue Ltd.
 #ifndef CPROVER_GOTO_HARNESS_RECURSIVE_INITIALIZATION_H
 #define CPROVER_GOTO_HARNESS_RECURSIVE_INITIALIZATION_H
 
-#include <map>
-#include <set>
-#include <unordered_set>
-
 #include <util/cprover_prefix.h>
 #include <util/prefix.h>
 #include <util/std_expr.h>
 #include <util/symbol.h>
+
+#include <list>
+#include <map>
+#include <set>
+#include <unordered_set>
 
 class code_blockt;
 class goto_modelt;

--- a/src/goto-programs/goto_program.h
+++ b/src/goto-programs/goto_program.h
@@ -12,15 +12,16 @@ Author: Daniel Kroening, kroening@kroening.com
 #ifndef CPROVER_GOTO_PROGRAMS_GOTO_PROGRAM_H
 #define CPROVER_GOTO_PROGRAMS_GOTO_PROGRAM_H
 
+#include <util/invariant.h>
+#include <util/source_location.h>
+
 #include "goto_instruction_code.h"
 
 #include <iosfwd>
-#include <set>
 #include <limits>
+#include <list>
+#include <set>
 #include <string>
-
-#include <util/invariant.h>
-#include <util/source_location.h>
 
 class code_gotot;
 class namespacet;

--- a/src/goto-programs/graphml_witness.cpp
+++ b/src/goto-programs/graphml_witness.cpp
@@ -20,6 +20,9 @@ Author: Daniel Kroening
 #include <util/prefix.h>
 #include <util/ssa_expr.h>
 #include <util/string_constant.h>
+#ifndef USE_DSTRING
+#  include <util/string_container.h>
+#endif
 #include <util/symbol.h>
 
 #include <ansi-c/expr2c.h>

--- a/src/goto-symex/symex_main.cpp
+++ b/src/goto-symex/symex_main.cpp
@@ -9,23 +9,23 @@ Author: Daniel Kroening, kroening@kroening.com
 /// \file
 /// Symbolic Execution
 
-#include "goto_symex.h"
-
-#include <memory>
-
-#include <pointer-analysis/value_set_dereference.h>
-
 #include <util/exception_utils.h>
 #include <util/expr_iterator.h>
 #include <util/expr_util.h>
 #include <util/format.h>
 #include <util/format_expr.h>
 #include <util/invariant.h>
+#include <util/magic.h>
 #include <util/mathematical_expr.h>
 #include <util/replace_symbol.h>
 #include <util/std_expr.h>
 
+#include <pointer-analysis/value_set_dereference.h>
+
+#include "goto_symex.h"
 #include "path_storage.h"
+
+#include <memory>
 
 symex_configt::symex_configt(const optionst &options)
   : max_depth(options.get_unsigned_int_option("depth")),

--- a/src/goto-synthesizer/expr_enumerator.h
+++ b/src/goto-synthesizer/expr_enumerator.h
@@ -11,6 +11,7 @@ Author: Qinheping Hu
 
 #include <util/expr.h>
 
+#include <list>
 #include <map>
 #include <set>
 

--- a/src/libcprover-cpp/verification_result.cpp
+++ b/src/libcprover-cpp/verification_result.cpp
@@ -114,7 +114,7 @@ std::vector<std::string> verification_resultt::get_property_ids() const
   std::vector<std::string> result;
   for(const auto &props : _impl->get_properties())
   {
-    result.push_back(as_string(props.first));
+    result.push_back(id2string(props.first));
   }
   return result;
 }

--- a/src/solvers/flattening/bv_utils.cpp
+++ b/src/solvers/flattening/bv_utils.cpp
@@ -8,6 +8,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "bv_utils.h"
 
+#include <list>
 #include <utility>
 
 bvt bv_utilst::build_constant(const mp_integer &n, std::size_t width)

--- a/src/solvers/smt2_incremental/response_or_error.h
+++ b/src/solvers/smt2_incremental/response_or_error.h
@@ -20,11 +20,6 @@ public:
   {
   }
 
-  explicit response_or_errort(std::string message)
-    : smt_or_messages{std::vector<std::string>{std::move(message)}}
-  {
-  }
-
   explicit response_or_errort(std::vector<std::string> messages)
     : smt_or_messages{std::move(messages)}
   {

--- a/src/solvers/smt2_incremental/smt_response_validation.cpp
+++ b/src/solvers/smt2_incremental/smt_response_validation.cpp
@@ -139,14 +139,14 @@ valid_smt_error_response(const irept &parse_tree)
   // unexpected in the parse tree is now considered to be an invalid response.
   if(parse_tree.get_sub().size() == 1)
   {
-    return {response_or_errort<smt_responset>{
-      "Error response is missing the error message."}};
+    return {response_or_errort<smt_responset>{std::vector<std::string>{
+      {"Error response is missing the error message."}}}};
   }
   if(parse_tree.get_sub().size() > 2)
   {
-    return {response_or_errort<smt_responset>{
-      "Error response has multiple error messages - \"" +
-      print_parse_tree(parse_tree) + "\"."}};
+    return {response_or_errort<smt_responset>{std::vector<std::string>{
+      {"Error response has multiple error messages - \"" +
+       print_parse_tree(parse_tree) + "\"."}}}};
   }
   return validation_propagating<smt_error_responset, smt_responset>(
     validate_string_literal(parse_tree.get_sub()[1]));
@@ -250,10 +250,10 @@ static std::optional<response_or_errort<smt_termt>> try_select_validation(
     return {};
   if(parse_tree.get_sub().size() != 3)
   {
-    return response_or_errort<smt_termt>{
-      "\"select\" is expected to have 2 arguments, but " +
-      std::to_string(parse_tree.get_sub().size()) +
-      " arguments were found - \"" + print_parse_tree(parse_tree) + "\"."};
+    return response_or_errort<smt_termt>{std::vector<std::string>{
+      {"\"select\" is expected to have 2 arguments, but " +
+       std::to_string(parse_tree.get_sub().size()) +
+       " arguments were found - \"" + print_parse_tree(parse_tree) + "\"."}}};
   }
   const auto array = validate_term(parse_tree.get_sub()[1], identifier_table);
   const auto index = validate_term(parse_tree.get_sub()[2], identifier_table);
@@ -281,8 +281,8 @@ static response_or_errort<smt_termt> validate_term(
   {
     return *select_validation;
   }
-  return response_or_errort<smt_termt>{"Unrecognised SMT term - \"" +
-                                       print_parse_tree(parse_tree) + "\"."};
+  return response_or_errort<smt_termt>{std::vector<std::string>{
+    {"Unrecognised SMT term - \"" + print_parse_tree(parse_tree) + "\"."}}};
 }
 
 static response_or_errort<smt_get_value_responset::valuation_pairt>
@@ -305,10 +305,10 @@ validate_valuation_pair(
   if(valid_descriptor.get_sort() != valid_value.get_sort())
   {
     return resultt{
-      "Mismatched descriptor and value sorts in - " +
-      print_parse_tree(pair_parse_tree) + "\nDescriptor has sort " +
-      smt_to_smt2_string(valid_descriptor.get_sort()) + "\nValue has sort " +
-      smt_to_smt2_string(valid_value.get_sort())};
+      {"Mismatched descriptor and value sorts in - " +
+       print_parse_tree(pair_parse_tree) + "\nDescriptor has sort " +
+       smt_to_smt2_string(valid_descriptor.get_sort()) + "\nValue has sort " +
+       smt_to_smt2_string(valid_value.get_sort())}};
   }
   // see https://github.com/diffblue/cbmc/issues/7464 for why we explicitly name
   // the valuation_pairt type here:
@@ -378,6 +378,6 @@ response_or_errort<smt_responset> validate_smt_response(
   {
     return *get_value_response;
   }
-  return response_or_errort<smt_responset>{"Invalid SMT response \"" +
-                                           id2string(parse_tree.id()) + "\""};
+  return response_or_errort<smt_responset>{std::vector<std::string>{
+    {"Invalid SMT response \"" + id2string(parse_tree.id()) + "\""}}};
 }

--- a/src/solvers/strings/string_constraint_instantiation.cpp
+++ b/src/solvers/strings/string_constraint_instantiation.cpp
@@ -10,14 +10,16 @@ Author: Jesse Sigal, jesse.sigal@diffblue.com
 /// Defines related function for string constraints.
 
 #include "string_constraint_instantiation.h"
-#include <algorithm>
-#include <unordered_set>
 
 #include <util/arith_tools.h>
 #include <util/expr_iterator.h>
 #include <util/format_expr.h>
 
 #include "string_constraint.h"
+
+#include <algorithm>
+#include <list>
+#include <unordered_set>
 
 /// Look for symbol \p qvar in the expression \p index and return true if found
 /// \return True, iff \p qvar appears in \p index.

--- a/src/statement-list/statement_list_parse_tree.h
+++ b/src/statement-list/statement_list_parse_tree.h
@@ -15,6 +15,8 @@ Author: Matthias Weiss, matthias.weiss@diffblue.com
 #include <util/std_code_base.h>
 #include <util/std_expr.h>
 
+#include <list>
+
 /// Intermediate representation of a parsed Statement List file before
 /// converting it into a goto program. Contains all data structures that are
 /// necessary for describing Statement List functions and function blocks.

--- a/src/util/irep_ids.cpp
+++ b/src/util/irep_ids.cpp
@@ -45,7 +45,7 @@ enum class idt:unsigned
 #else
 
 #define IREP_ID_ONE(the_id) const std::string ID_##the_id(#the_id);
-#define IREP_ID_TWO(the_id, str) const std::string ID_##the_id(#the_id);
+#  define IREP_ID_TWO(the_id, str) const std::string ID_##the_id(#  str);
 
 #endif
 

--- a/src/util/irep_serialization.cpp
+++ b/src/util/irep_serialization.cpp
@@ -13,10 +13,11 @@ Date: May 2007
 
 #include "irep_serialization.h"
 
+#include "exception_utils.h"
+#include "string_container.h"
+
 #include <climits>
 #include <iostream>
-
-#include "exception_utils.h"
 
 void irep_serializationt::write_irep(
   std::ostream &out,
@@ -211,7 +212,11 @@ void irep_serializationt::write_string_ref(
   std::ostream &out,
   const irep_idt &s)
 {
-  size_t id=irep_id_hash()(s);
+#ifdef USE_DSTRING
+  size_t id = s.get_no();
+#else
+  size_t id = get_string_container()[s];
+#endif
   if(id>=ireps_container.string_map.size())
     ireps_container.string_map.resize(id+1, false);
 

--- a/src/util/json.h
+++ b/src/util/json.h
@@ -274,7 +274,7 @@ public:
   {
   }
 
-#ifndef USE_STD_STRING
+#ifdef USE_DSTRING
   explicit json_stringt(const irep_idt &_value)
     : jsont(kindt::J_STRING, id2string(_value))
   {

--- a/src/util/symbol_table_base.h
+++ b/src/util/symbol_table_base.h
@@ -8,6 +8,7 @@
 
 #include "symbol.h" // IWYU pragma: keep
 
+#include <list>
 #include <map>
 #include <unordered_map>
 

--- a/unit/analyses/variable-sensitivity/abstract_environment/to_predicate.cpp
+++ b/unit/analyses/variable-sensitivity/abstract_environment/to_predicate.cpp
@@ -52,7 +52,7 @@ SCENARIO(
 
       auto type = signedbv_typet(32);
       auto val2 = make_constant(from_integer(2, type), env, ns);
-      auto x_name = symbol_exprt(dstringt("x"), type);
+      auto x_name = symbol_exprt("x", type);
 
       env.assign(x_name, val2, ns);
 
@@ -65,10 +65,10 @@ SCENARIO(
 
       auto type = signedbv_typet(32);
       auto val2 = make_constant(from_integer(2, type), env, ns);
-      auto x_name = symbol_exprt(dstringt("x"), type);
+      auto x_name = symbol_exprt("x", type);
 
       auto val3 = make_constant(from_integer(3, type), env, ns);
-      auto y_name = symbol_exprt(dstringt("y"), type);
+      auto y_name = symbol_exprt("y", type);
 
       env.assign(x_name, val2, ns);
       env.assign(y_name, val3, ns);

--- a/unit/analyses/variable-sensitivity/constant_abstract_value/to_predicate.cpp
+++ b/unit/analyses/variable-sensitivity/constant_abstract_value/to_predicate.cpp
@@ -25,7 +25,7 @@ SCENARIO(
   const typet type = signedbv_typet(32);
   const exprt val2 = from_integer(2, type);
 
-  const exprt x_name = symbol_exprt(dstringt("x"), type);
+  const exprt x_name = symbol_exprt("x", type);
 
   auto config = vsd_configt::constant_domain();
   config.context_tracking.data_dependency_context = false;

--- a/unit/analyses/variable-sensitivity/constant_pointer_abstract_object/to_predicate.cpp
+++ b/unit/analyses/variable-sensitivity/constant_pointer_abstract_object/to_predicate.cpp
@@ -24,9 +24,9 @@ SCENARIO(
 {
   const auto int_type = signedbv_typet(32);
   const auto ptr_type = pointer_typet(int_type, 32);
-  const auto val2_symbol = symbol_exprt(dstringt("val2"), int_type);
+  const auto val2_symbol = symbol_exprt("val2", int_type);
 
-  const auto x_name = symbol_exprt(dstringt("x"), int_type);
+  const auto x_name = symbol_exprt("x", int_type);
 
   auto config = vsd_configt::constant_domain();
   config.context_tracking.data_dependency_context = false;

--- a/unit/analyses/variable-sensitivity/interval_abstract_value/to_predicate.cpp
+++ b/unit/analyses/variable-sensitivity/interval_abstract_value/to_predicate.cpp
@@ -35,7 +35,7 @@ SCENARIO(
   const exprt val1 = from_integer(1, type);
   const exprt val2 = from_integer(2, type);
 
-  const exprt x_name = symbol_exprt(dstringt("x"), type);
+  const exprt x_name = symbol_exprt("x", type);
 
   auto config = vsd_configt::constant_domain();
   config.context_tracking.data_dependency_context = false;

--- a/unit/analyses/variable-sensitivity/value_expression_evaluation/assume.cpp
+++ b/unit/analyses/variable-sensitivity/value_expression_evaluation/assume.cpp
@@ -24,7 +24,7 @@
 #include <testing-utils/use_catch.h>
 
 exprt binary_expression(
-  dstringt const &exprId,
+  const irep_idt &exprId,
   const abstract_object_pointert &op1,
   const abstract_object_pointert &op2,
   abstract_environmentt &environment,
@@ -83,7 +83,7 @@ public:
   }
 
   void test_fn(
-    dstringt const &exprId,
+    const irep_idt &exprId,
     bool is_true,
     std::string const &test,
     std::string const &delimiter)

--- a/unit/analyses/variable-sensitivity/value_set_abstract_object/to_predicate.cpp
+++ b/unit/analyses/variable-sensitivity/value_set_abstract_object/to_predicate.cpp
@@ -37,7 +37,7 @@ SCENARIO(
   const exprt interval_0_2 = constant_interval_exprt(val1, val2);
   const exprt interval_2_3 = constant_interval_exprt(val2, val3);
 
-  const exprt x_name = symbol_exprt(dstringt("x"), type);
+  const exprt x_name = symbol_exprt("x", type);
 
   auto config = vsd_configt::constant_domain();
   config.context_tracking.data_dependency_context = false;

--- a/unit/analyses/variable-sensitivity/value_set_pointer_abstract_object/to_predicate.cpp
+++ b/unit/analyses/variable-sensitivity/value_set_pointer_abstract_object/to_predicate.cpp
@@ -32,10 +32,10 @@ SCENARIO(
 {
   const auto int_type = signedbv_typet(32);
   const auto ptr_type = pointer_typet(int_type, 32);
-  const auto val1_symbol = symbol_exprt(dstringt("val1"), int_type);
-  const auto val2_symbol = symbol_exprt(dstringt("val2"), int_type);
+  const auto val1_symbol = symbol_exprt("val1", int_type);
+  const auto val2_symbol = symbol_exprt("val2", int_type);
 
-  const auto x_name = symbol_exprt(dstringt("x"), int_type);
+  const auto x_name = symbol_exprt("x", int_type);
 
   auto config = vsd_configt::constant_domain();
   config.context_tracking.data_dependency_context = false;

--- a/unit/analyses/variable-sensitivity/variable_sensitivity_test_helpers.cpp
+++ b/unit/analyses/variable-sensitivity/variable_sensitivity_test_helpers.cpp
@@ -590,7 +590,7 @@ std::shared_ptr<const value_set_abstract_objectt> add_as_value_set(
 
 void THEN_PREDICATE(const abstract_object_pointert &obj, const std::string &out)
 {
-  const auto x_name = symbol_exprt(dstringt("x"), obj->type());
+  const auto x_name = symbol_exprt("x", obj->type());
   auto pred = obj->to_predicate(x_name);
   THEN("predicate is " + out)
   {

--- a/unit/compound_block_locations.h
+++ b/unit/compound_block_locations.h
@@ -7,6 +7,7 @@
 
 #include <util/irep.h>
 
+#include <list>
 #include <string>
 
 class exprt;

--- a/unit/goto-symex/apply_condition.cpp
+++ b/unit/goto-symex/apply_condition.cpp
@@ -6,12 +6,12 @@ Author: Owen Mansel-Chan, owen.mansel-chan@diffblue.com
 
 \*******************************************************************/
 
-#include <testing-utils/use_catch.h>
-
+#include <util/magic.h>
 #include <util/namespace.h>
 #include <util/symbol_table.h>
 
 #include <goto-symex/goto_symex_state.h>
+#include <testing-utils/use_catch.h>
 
 static void add_to_symbol_table(
   symbol_tablet &symbol_table,

--- a/unit/goto-symex/goto_symex_state.cpp
+++ b/unit/goto-symex/goto_symex_state.cpp
@@ -6,14 +6,15 @@ Author: Diffblue Ltd.
 
 \*******************************************************************/
 
-#include <testing-utils/use_catch.h>
+#include <util/arith_tools.h>
+#include <util/c_types.h>
+#include <util/magic.h>
+#include <util/namespace.h>
+#include <util/symbol_table.h>
 
 #include <analyses/dirty.h>
 #include <goto-symex/goto_symex_state.h>
-#include <util/arith_tools.h>
-#include <util/c_types.h>
-#include <util/namespace.h>
-#include <util/symbol_table.h>
+#include <testing-utils/use_catch.h>
 
 static void add_to_symbol_table(
   symbol_tablet &symbol_table,

--- a/unit/goto-symex/symex_assign.cpp
+++ b/unit/goto-symex/symex_assign.cpp
@@ -8,6 +8,7 @@ Author: Romain Brenguier, romain.brenguier@diffblue.com
 
 #include <util/arith_tools.h>
 #include <util/bitvector_types.h>
+#include <util/magic.h>
 #include <util/namespace.h>
 #include <util/options.h>
 #include <util/symbol_table.h>

--- a/unit/goto-symex/try_evaluate_pointer_comparisons.cpp
+++ b/unit/goto-symex/try_evaluate_pointer_comparisons.cpp
@@ -6,11 +6,11 @@ Author: Romain Brenguier, romain.brenguier@diffblue.com
 
 \*******************************************************************/
 
-#include <testing-utils/use_catch.h>
+#include <util/c_types.h>
+#include <util/magic.h>
 
 #include <goto-symex/goto_symex.h>
-
-#include <util/c_types.h>
+#include <testing-utils/use_catch.h>
 
 static void add_to_symbol_table(
   symbol_tablet &symbol_table,

--- a/unit/solvers/smt2_incremental/smt_response_validation.cpp
+++ b/unit/solvers/smt2_incremental/smt_response_validation.cpp
@@ -22,7 +22,8 @@ TEST_CASE("response_or_errort storage", "[core][smt2_incremental]")
   SECTION("Error response")
   {
     const std::string message{"Test error message"};
-    const response_or_errort<smt_responset> error{message};
+    const response_or_errort<smt_responset> error{
+      std::vector<std::string>{{message}}};
     CHECK_FALSE(error.get_if_valid());
     CHECK(*error.get_if_error() == std::vector<std::string>{message});
   }

--- a/unit/util/irep.cpp
+++ b/unit/util/irep.cpp
@@ -22,7 +22,7 @@ SCENARIO("irept_memory", "[core][utils][irept]")
       const std::size_t ref_count_size = 0;
 #endif
 
-#ifndef USE_STD_STRING
+#ifdef USE_DSTRING
       const std::size_t data_size = sizeof(dstringt);
       REQUIRE(sizeof(dstringt) == sizeof(unsigned));
 #else


### PR DESCRIPTION
The code is now back to a compilable state when `USE_STD_STRING` is set (i.e., `irep_idt` are `std::string` instead of `dstringt`). Not all tests pass as some string output is different, and performance is substantially worse. This might be enough of a reason to follow up with a PR that completely removes the possibility of using `std::string`, but I'd recommend we do so from a state where that would still have worked, i.e., only after merging this PR.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
