### PR TITLE
Conditionally simplify use of if-then-else conditions

### DIFF
--- a/regression/cbmc/Pointer32/main.c
+++ b/regression/cbmc/Pointer32/main.c
@@ -1,0 +1,16 @@
+struct S
+{
+  int len;
+};
+
+__CPROVER_bool nondet_bool();
+
+int main()
+{
+  struct S *s_p = 0;
+  struct S s;
+  if(nondet_bool())
+    s_p = &s;
+  s_p->len = s_p->len + 1;
+  __CPROVER_assert(0, "");
+}

--- a/regression/cbmc/Pointer32/test.desc
+++ b/regression/cbmc/Pointer32/test.desc
@@ -1,0 +1,12 @@
+CORE paths-lifo-expected-failure
+main.c
+--show-vcc
+main::1::s!0@1#2..len = .+ \? .+ : .+
+^SIGNAL=0$
+^EXIT=0$
+--
+main::1::s!0@1#2..len = .+ \? .+ \?
+--
+We should not find nested if-then-else expressions in the right-hand side
+evaluating `len` when simplification works as intended. (With --paths lifo we do
+not have any branching, so it is marked paths-lifo-expected-failure.)

--- a/src/goto-symex/symex_assign.cpp
+++ b/src/goto-symex/symex_assign.cpp
@@ -10,6 +10,7 @@ Author: Daniel Kroening, kroening@kroening.com
 /// Symbolic Execution
 
 #include "symex_assign.h"
+#include <util/simplify_expr_class.h>
 
 #include <util/byte_operators.h>
 #include <util/expr_util.h>
@@ -203,7 +204,10 @@ void symex_assignt::assign_non_struct_symbol(
   assignmentt assignment{lhs, full_lhs, l2_rhs};
 
   if(symex_config.simplify_opt)
-    assignment.rhs = simplify_expr(std::move(assignment.rhs), ns);
+  {
+    simplify_exprt simp{ns, true};
+    simp.simplify(assignment.rhs);
+  }
 
   const ssa_exprt l2_lhs = state
                              .assignment(

--- a/src/util/simplify_expr.cpp
+++ b/src/util/simplify_expr.cpp
@@ -3169,22 +3169,21 @@ simplify_exprt::resultt<> simplify_exprt::simplify_rec(const exprt &expr)
       simplify_node_preorder_result.expr_changed;
   }
 
-#ifdef USE_LOCAL_REPLACE_MAP
-  exprt tmp = simplify_node_result.expr;
-#  if 1
-  replace_mapt::const_iterator it =
-    local_replace_map.find(simplify_node_result.expr);
-  if(it!=local_replace_map.end())
-    simplify_node_result = changed(it->second);
+  if(!local_replace_map.empty())
+  {
+#if 1
+    replace_mapt::const_iterator it =
+      local_replace_map.find(simplify_node_result.expr);
+    if(it != local_replace_map.end())
+      simplify_node_result = changed(it->second);
 #  else
   if(
-    !local_replace_map.empty() &&
     !replace_expr(local_replace_map, simplify_node_result.expr))
   {
     simplify_node_result = changed(simplify_rec(simplify_node_result.expr));
   }
-#  endif
 #endif
+  }
 
   if(!simplify_node_result.has_changed())
   {

--- a/src/util/simplify_expr_class.h
+++ b/src/util/simplify_expr_class.h
@@ -20,10 +20,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "expr.h"
 #include "mp_arith.h"
 #include "type.h"
-// #define USE_LOCAL_REPLACE_MAP
-#ifdef USE_LOCAL_REPLACE_MAP
 #include "replace_expr.h"
-#endif
 
 class abs_exprt;
 class address_of_exprt;
@@ -80,17 +77,22 @@ class with_exprt;
 class simplify_exprt
 {
 public:
-  explicit simplify_exprt(const namespacet &_ns):
-    do_simplify_if(true),
-    ns(_ns)
+  simplify_exprt(const namespacet &_ns, bool propagate_if_cond)
+    : do_simplify_if(propagate_if_cond),
+      ns(_ns)
 #ifdef DEBUG_ON_DEMAND
-    , debug_on(false)
+      ,
+      debug_on(false)
 #endif
   {
 #ifdef DEBUG_ON_DEMAND
     struct stat f;
     debug_on=stat("SIMP_DEBUG", &f)==0;
 #endif
+  }
+
+  explicit simplify_exprt(const namespacet &_ns) : simplify_exprt(_ns, false)
+  {
   }
 
   virtual ~simplify_exprt()
@@ -287,10 +289,7 @@ protected:
 #ifdef DEBUG_ON_DEMAND
   bool debug_on;
 #endif
-#ifdef USE_LOCAL_REPLACE_MAP
   replace_mapt local_replace_map;
-#endif
-
 };
 
 #endif // CPROVER_UTIL_SIMPLIFY_EXPR_CLASS_H


### PR DESCRIPTION
When symbolically executing (and dereferencing) statements like `*p = *p + 1;` where `p` may point to more than a single object we ended up with nested if-then-else expressions on the right-hand side that would use the very same conditions. In this particular case, we should propagate the conditions into nested if-then-else expressions. This simplification may be expensive, so we don't enable it in general.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
