### PR TITLE
DFCC instrumentation: ensure programs are well-formed

### DIFF
--- a/.github/workflows/pull-request-checks.yaml
+++ b/.github/workflows/pull-request-checks.yaml
@@ -432,7 +432,7 @@ jobs:
           echo "CCACHE_BASEDIR=$PWD" >> $GITHUB_ENV
           echo "CCACHE_DIR=$PWD/.ccache" >> $GITHUB_ENV
       - name: Configure using CMake
-        run: cmake -S . -Bbuild -G Ninja -DCMAKE_BUILD_TYPE=Release
+        run: cmake -S . -Bbuild -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS=-Wp,-D_GLIBCXX_ASSERTIONS
       - name: Zero ccache stats and limit in size
         run: ccache -z --max-size=500M
       - name: Build with Ninja

--- a/src/goto-instrument/contracts/dynamic-frames/dfcc_wrapper_program.cpp
+++ b/src/goto-instrument/contracts/dynamic-frames/dfcc_wrapper_program.cpp
@@ -578,11 +578,15 @@ void dfcc_wrapper_programt::encode_requires_clauses()
   memory_predicates.fix_calls(requires_program);
 
   // instrument for side effects
+  // make the program well-formed
+  requires_program.add(goto_programt::make_end_function());
   instrument.instrument_goto_program(
     wrapper_id,
     requires_program,
     addr_of_requires_write_set,
     function_pointer_contracts);
+  // turn it back into a sequence of statements
+  requires_program.instructions.back().turn_into_skip();
 
   // append resulting program to preconditions section
   preconditions.destructive_append(requires_program);
@@ -637,11 +641,15 @@ void dfcc_wrapper_programt::encode_ensures_clauses()
   memory_predicates.fix_calls(ensures_program);
 
   // instrument for side effects
+  // make the program well-formed
+  ensures_program.add(goto_programt::make_end_function());
   instrument.instrument_goto_program(
     wrapper_id,
     ensures_program,
     addr_of_ensures_write_set,
     function_pointer_contracts);
+  // turn it back into a sequence of statements
+  ensures_program.instructions.back().turn_into_skip();
 
   // add the ensures program to the postconditions section
   postconditions.destructive_append(ensures_program);


### PR DESCRIPTION
We must not pass to analyses goto programs that aren't terminated by END_FUNCTION (i.e., really just sequences of statements). On this occasion, local_may_aliast was the one relying on well-formedness. We now make sure that sequences of instructions are terminated by END_FUNCTION when we pass them around as goto programs.

Fixes: #7866

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
