### PR TITLE
Make -Wno-maybe-uninitialized the default with GCC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,15 +71,22 @@ set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
-if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" OR
-   "${CMAKE_CXX_COMPILER_ID}" STREQUAL "AppleClang" OR
-   "${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU"
-)
+if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
     #   Ensure NDEBUG is not set for release builds
     set(CMAKE_CXX_FLAGS_RELEASE "-O2")
     set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O2 -g")
     #   Enable lots of warnings
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wpedantic -Werror -Wno-deprecated-declarations -Wswitch-enum")
+    set(CMAKE_CXX_FLAGS
+        "${CMAKE_CXX_FLAGS} -Wall -Wpedantic -Werror -Wswitch-enum \
+         -Wno-deprecated-declarations -Wno-maybe-uninitialized")
+elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" OR
+       "${CMAKE_CXX_COMPILER_ID}" STREQUAL "AppleClang")
+    #   Ensure NDEBUG is not set for release builds
+    set(CMAKE_CXX_FLAGS_RELEASE "-O2")
+    set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O2 -g")
+    #   Enable lots of warnings
+    set(CMAKE_CXX_FLAGS
+        "${CMAKE_CXX_FLAGS} -Wall -Wpedantic -Werror -Wswitch-enum -Wno-deprecated-declarations")
 elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
     # This would be the place to enable warnings for Windows builds, although
     # config.inc doesn't seem to do that currently

--- a/src/config.inc
+++ b/src/config.inc
@@ -5,7 +5,10 @@ BUILD_ENV = AUTO
 ifeq ($(BUILD_ENV),MSVC)
   #CXXFLAGS += /Wall /WX
 else
-  CXXFLAGS += -Wall -pedantic -Werror -Wno-deprecated-declarations -Wswitch-enum
+  CXXFLAGS += -Wall -pedantic -Werror -Wswitch-enum
+  CXXFLAGS += -Wno-deprecated-declarations
+  # GCC only, silence clang warning
+  CXXFLAGS += -Wno-maybe-uninitialized -Wno-unknown-warning-option
 endif
 
 ifeq ($(CPROVER_WITH_PROFILING),1)

--- a/src/goto-instrument/unwindset.cpp
+++ b/src/goto-instrument/unwindset.cpp
@@ -33,13 +33,7 @@ void unwindsett::parse_unwindset_one_loop(
   if(val.empty())
     return;
 
-// Work around spurious GCC 12 warning about thread_nr being uninitialised.
-#pragma GCC diagnostic push
-#ifndef __clang__
-#  pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
   optionalt<unsigned> thread_nr;
-#pragma GCC diagnostic pop
   if(isdigit(val[0]))
   {
     auto c_pos = val.find(':');
@@ -160,13 +154,7 @@ void unwindsett::parse_unwindset_one_loop(
           return;
         }
         else
-// Work around spurious GCC 12 warning about thread_nr being uninitialised.
-#pragma GCC diagnostic push
-#ifndef __clang__
-#  pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
           id = function_id + "." + std::to_string(*nr);
-#pragma GCC diagnostic pop
       }
     }
 
@@ -182,13 +170,7 @@ void unwindsett::parse_unwindset_one_loop(
 
     if(thread_nr.has_value())
     {
-// Work around spurious GCC 12 warning about thread_nr being uninitialised.
-#pragma GCC diagnostic push
-#ifndef __clang__
-#  pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
       thread_loop_map[std::pair<irep_idt, unsigned>(id, *thread_nr)] = uw;
-#pragma GCC diagnostic pop
     }
     else
     {

--- a/src/util/cmdline.cpp
+++ b/src/util/cmdline.cpp
@@ -296,13 +296,7 @@ bool cmdlinet::parse_arguments(int argc, const char **argv)
         return true;
       }
 
-      // Work around spurious GCC 12 warning about optnr being uninitialised.
-#pragma GCC diagnostic push
-#ifndef __clang__
-#  pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
       options[*optnr].isset = true;
-#pragma GCC diagnostic pop
 
       if(options[*optnr].hasval)
       {

--- a/src/util/lower_byte_operators.cpp
+++ b/src/util/lower_byte_operators.cpp
@@ -1111,14 +1111,8 @@ static exprt lower_byte_extract_array_vector(
   if(num_elements.has_value())
   {
     exprt::operandst operands;
-    // Work around spurious GCC warning about num_elements being uninitialised.
-#pragma GCC diagnostic push
-#ifndef __clang__
-#  pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
     operands.reserve(*num_elements);
     for(std::size_t i = 0; i < *num_elements; ++i)
-#pragma GCC diagnostic pop
     {
       plus_exprt new_offset(
         unpacked.offset(),

--- a/src/util/simplify_expr_int.cpp
+++ b/src/util/simplify_expr_int.cpp
@@ -159,12 +159,6 @@ static bool mul_expr(
   return true;
 }
 
-// Work around spurious GCC 12 warning about c_sizeof_type being
-// uninitialised in its destructor (!).
-#pragma GCC diagnostic push
-#ifndef __clang__
-#  pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
 simplify_exprt::resultt<> simplify_exprt::simplify_mult(const mult_exprt &expr)
 {
   // check to see if it is a number type
@@ -276,7 +270,6 @@ simplify_exprt::resultt<> simplify_exprt::simplify_mult(const mult_exprt &expr)
     return std::move(tmp);
   }
 }
-#pragma GCC diagnostic pop
 
 simplify_exprt::resultt<> simplify_exprt::simplify_div(const div_exprt &expr)
 {


### PR DESCRIPTION
With our use of optionalt/std::optional, these warnings pop up in an unpredictable manner. See
https://gcc.gnu.org/bugzilla/buglist.cgi?quicksearch=std%3A%3Aoptional for a number of bug reports against GCC about this.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
