### PR TITLE
Enable all `cbmc` regression tests that are passing to run with new SMT backend

### DIFF
--- a/regression/cbmc/Array_UF21/test.desc
+++ b/regression/cbmc/Array_UF21/test.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 main.c
 --arrays-uf-always --bounds-check
 ^VERIFICATION FAILED$

--- a/regression/cbmc/Float-equality2/test.desc
+++ b/regression/cbmc/Float-equality2/test.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 main.c
 
 (Starting CEGAR Loop|VCC\(s\), 0 remaining after simplification$)

--- a/regression/cbmc/Float-overflow1/test.desc
+++ b/regression/cbmc/Float-overflow1/test.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 main.c
 --floatbv --float-overflow-check
 ^EXIT=0$

--- a/regression/cbmc/Float-overflow2/test.desc
+++ b/regression/cbmc/Float-overflow2/test.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 main.c
 --floatbv --float-overflow-check
 ^EXIT=10$

--- a/regression/cbmc/Float-rounding/compile_time_rounding.desc
+++ b/regression/cbmc/Float-rounding/compile_time_rounding.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 compile_time_rounding.c
 
 ^EXIT=0$

--- a/regression/cbmc/Float1/test.desc
+++ b/regression/cbmc/Float1/test.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 main.c
 --floatbv
 ^EXIT=0$

--- a/regression/cbmc/Float11/test.desc
+++ b/regression/cbmc/Float11/test.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 main.c
 --floatbv
 ^EXIT=0$

--- a/regression/cbmc/Float13/test.desc
+++ b/regression/cbmc/Float13/test.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 main.c
 
 ^EXIT=0$

--- a/regression/cbmc/Float14/test.desc
+++ b/regression/cbmc/Float14/test.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 main.c
 
 ^EXIT=0$

--- a/regression/cbmc/Float2/test.desc
+++ b/regression/cbmc/Float2/test.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 main.c
 --floatbv
 ^EXIT=0$

--- a/regression/cbmc/Float22/test.desc
+++ b/regression/cbmc/Float22/test.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 main.c
 --floatbv
 ^EXIT=0$

--- a/regression/cbmc/Float7/test.desc
+++ b/regression/cbmc/Float7/test.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 main.c
 
 ^EXIT=0$

--- a/regression/cbmc/Function5/test.desc
+++ b/regression/cbmc/Function5/test.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 main.c
 --pointer-check --bounds-check
 ^SIGNAL=0$

--- a/regression/cbmc/Function_Pointer11/test.desc
+++ b/regression/cbmc/Function_Pointer11/test.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 main.c
 
 ^EXIT=0$

--- a/regression/cbmc/Function_Pointer15/test.desc
+++ b/regression/cbmc/Function_Pointer15/test.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 main.c
 
 ^EXIT=10$

--- a/regression/cbmc/Function_Pointer2/test.desc
+++ b/regression/cbmc/Function_Pointer2/test.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 main.c
 
 ^EXIT=0$

--- a/regression/cbmc/Function_Pointer3/test.desc
+++ b/regression/cbmc/Function_Pointer3/test.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 main.c
 
 ^EXIT=0$

--- a/regression/cbmc/Function_Pointer6/test.desc
+++ b/regression/cbmc/Function_Pointer6/test.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 main.c
 
 ^EXIT=0$

--- a/regression/cbmc/Function_Pointer9/test.desc
+++ b/regression/cbmc/Function_Pointer9/test.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 main.c
 
 ^EXIT=10$

--- a/regression/cbmc/Function_Pointer_Init_One_Candidate/test.desc
+++ b/regression/cbmc/Function_Pointer_Init_One_Candidate/test.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 main.c
 --function foo
 ^\[foo.assertion.\d+\] line \d+ assertion other_function\(4\) == 5: FAILURE$

--- a/regression/cbmc/Function_Pointer_Init_Two_Candidates/test.desc
+++ b/regression/cbmc/Function_Pointer_Init_Two_Candidates/test.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 main.c
 --function foo
 ^\[foo.assertion.\d+\] line \d+ assertion other_function\(4\) == 5: FAILURE$

--- a/regression/cbmc/Initialization5/test.desc
+++ b/regression/cbmc/Initialization5/test.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 main.c
 
 ^EXIT=10$

--- a/regression/cbmc/Linking7/member-name-mismatch.desc
+++ b/regression/cbmc/Linking7/member-name-mismatch.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 main.c
 module2.c
 ^EXIT=10$

--- a/regression/cbmc/Linking7/test.desc
+++ b/regression/cbmc/Linking7/test.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 main.c
 module.c
 ^EXIT=10$

--- a/regression/cbmc/Malloc19/test.desc
+++ b/regression/cbmc/Malloc19/test.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 main.c
 
 ^EXIT=0$

--- a/regression/cbmc/Malloc8/test.desc
+++ b/regression/cbmc/Malloc8/test.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 main.c
 --pointer-check
 ^EXIT=10$

--- a/regression/cbmc/Memory_leak1/test.desc
+++ b/regression/cbmc/Memory_leak1/test.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 main.c
 --memory-leak-check
 ^EXIT=10$

--- a/regression/cbmc/Memory_leak2/test.desc
+++ b/regression/cbmc/Memory_leak2/test.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 main.c
 --memory-leak-check
 ^EXIT=0$

--- a/regression/cbmc/Pointer14/test.desc
+++ b/regression/cbmc/Pointer14/test.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 main.c
 --pointer-check
 ^VERIFICATION FAILED$

--- a/regression/cbmc/Pointer2/test.desc
+++ b/regression/cbmc/Pointer2/test.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 main.c
 
 ^VERIFICATION SUCCESSFUL$

--- a/regression/cbmc/Pointer27/test.desc
+++ b/regression/cbmc/Pointer27/test.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 main.c
 
 ^SIGNAL=0$

--- a/regression/cbmc/Pointer_comparison4/test.desc
+++ b/regression/cbmc/Pointer_comparison4/test.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 main.c
 --unwind 10 --unwinding-assertions
 ^VERIFICATION SUCCESSFUL$

--- a/regression/cbmc/Pointer_comparison5/test.desc
+++ b/regression/cbmc/Pointer_comparison5/test.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 main.c
 
 ^Generated \d+ VCC\(s\), 1 remaining after simplification$

--- a/regression/cbmc/String2/test.desc
+++ b/regression/cbmc/String2/test.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 main.c
 --pointer-check --bounds-check
 ^EXIT=10$

--- a/regression/cbmc/String8/test.desc
+++ b/regression/cbmc/String8/test.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 main.c
 --pointer-check --bounds-check
 ^EXIT=0$

--- a/regression/cbmc/String_Abstraction13/test.desc
+++ b/regression/cbmc/String_Abstraction13/test.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 constant.c
 --string-abstraction
 ^EXIT=0$

--- a/regression/cbmc/String_Abstraction16/test.desc
+++ b/regression/cbmc/String_Abstraction16/test.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 ptr-arith.c
 --string-abstraction
 ^EXIT=0$

--- a/regression/cbmc/String_Abstraction17/test.desc
+++ b/regression/cbmc/String_Abstraction17/test.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 strcpy-no-decl.c
 --string-abstraction --validate-goto-model
 ^EXIT=10$

--- a/regression/cbmc/String_Abstraction18/test.desc
+++ b/regression/cbmc/String_Abstraction18/test.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 strcpy.c
 --string-abstraction
 ^EXIT=0$

--- a/regression/cbmc/String_Abstraction21/test.desc
+++ b/regression/cbmc/String_Abstraction21/test.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 strcpy2.c
 --string-abstraction
 ^EXIT=0$

--- a/regression/cbmc/String_Abstraction4/test.desc
+++ b/regression/cbmc/String_Abstraction4/test.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 main.c
 --string-abstraction --pointer-check --bounds-check
 ^EXIT=10$

--- a/regression/cbmc/String_Abstraction5/test.desc
+++ b/regression/cbmc/String_Abstraction5/test.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 main.c
 --string-abstraction --pointer-check --bounds-check
 ^EXIT=0$

--- a/regression/cbmc/String_Literal1/test.desc
+++ b/regression/cbmc/String_Literal1/test.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 main.c
 --trace
 ^State \d+ file main.c function main line 20 thread 0$

--- a/regression/cbmc/array-cell-sensitivity1/test.desc
+++ b/regression/cbmc/array-cell-sensitivity1/test.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 test.c
 --show-vcc
 main::1::array!0@1#2\[\[1\]\] =

--- a/regression/cbmc/array-cell-sensitivity10/test.desc
+++ b/regression/cbmc/array-cell-sensitivity10/test.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 test.c
 --show-vcc
 main::1::array!0@1#2\[\[0\]\]..x =

--- a/regression/cbmc/array-cell-sensitivity10/test_execution.desc
+++ b/regression/cbmc/array-cell-sensitivity10/test_execution.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 test.c
 
 ^VERIFICATION FAILED$

--- a/regression/cbmc/array-cell-sensitivity11/test_execution.desc
+++ b/regression/cbmc/array-cell-sensitivity11/test_execution.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 test.c
 
 ^VERIFICATION FAILED$

--- a/regression/cbmc/array-cell-sensitivity3/test.desc
+++ b/regression/cbmc/array-cell-sensitivity3/test.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 test.c
 --show-vcc
 main::1::array!0@1#2\[\[0\]\] =

--- a/regression/cbmc/array-cell-sensitivity3/test_execution.desc
+++ b/regression/cbmc/array-cell-sensitivity3/test_execution.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 test.c
 
 ^VERIFICATION FAILED$

--- a/regression/cbmc/array-cell-sensitivity4/test.desc
+++ b/regression/cbmc/array-cell-sensitivity4/test.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 test.c
 --show-vcc
 main::1::array!0@1#2\[\[1\]\] =

--- a/regression/cbmc/array-cell-sensitivity5/test.desc
+++ b/regression/cbmc/array-cell-sensitivity5/test.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 test.c
 --show-vcc
 symex_dynamic::dynamic_object#2\[\[1\]\] =

--- a/regression/cbmc/array-cell-sensitivity6/test.desc
+++ b/regression/cbmc/array-cell-sensitivity6/test.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 test.c
 --show-vcc
 symex_dynamic::dynamic_object#2\[\[1\]\] =

--- a/regression/cbmc/array-cell-sensitivity7/test.desc
+++ b/regression/cbmc/array-cell-sensitivity7/test.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 test.c
 --show-vcc
 main::1::array!0@1#2\[\[1\]\] =

--- a/regression/cbmc/array-cell-sensitivity7/test_execution.desc
+++ b/regression/cbmc/array-cell-sensitivity7/test_execution.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 test.c
 
 ^VERIFICATION FAILED$

--- a/regression/cbmc/array-cell-sensitivity8/test.desc
+++ b/regression/cbmc/array-cell-sensitivity8/test.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 test.c
 --show-vcc
 main::1::array!0@1#2\[\[1\]\] =

--- a/regression/cbmc/array-cell-sensitivity8/test_execution.desc
+++ b/regression/cbmc/array-cell-sensitivity8/test_execution.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 test.c
 
 ^VERIFICATION FAILED$

--- a/regression/cbmc/atomic_section_seq1/test.desc
+++ b/regression/cbmc/atomic_section_seq1/test.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 main.c
 
 ^EXIT=10$

--- a/regression/cbmc/byte_update11/test.desc
+++ b/regression/cbmc/byte_update11/test.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 main.c
 --little-endian
 ^EXIT=0$

--- a/regression/cbmc/byte_update14/test.desc
+++ b/regression/cbmc/byte_update14/test.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 test.c
 
 ^VERIFICATION FAILED$

--- a/regression/cbmc/compact-trace/test.desc
+++ b/regression/cbmc/compact-trace/test.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 main.c
 --compact-trace
 activate-multi-line-match

--- a/regression/cbmc/complex1/test.desc
+++ b/regression/cbmc/complex1/test.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 main.c
 
 ^EXIT=0$

--- a/regression/cbmc/constructor2/test.desc
+++ b/regression/cbmc/constructor2/test.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 main.c
 
 ^EXIT=0$

--- a/regression/cbmc/coverage_report2/test.desc
+++ b/regression/cbmc/coverage_report2/test.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 main.c
 --symex-coverage-report - --unwind 1
 <line branch="true" condition-coverage="50% \(1/2\)" hits="2" number="3">

--- a/regression/cbmc/double_deref/double_deref_with_pointer_arithmetic_single_alias.desc
+++ b/regression/cbmc/double_deref/double_deref_with_pointer_arithmetic_single_alias.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 double_deref_with_pointer_arithmetic_single_alias.c
 --show-vcc
 \{1\} \(derefd_pointer::derefd_pointer!0#1 = address_of\(symex_dynamic::dynamic_object\$0\) \? main::argc!0@1#1 = 1 : symex::invalid_object!0#0 = main::argc!0@1#1\)

--- a/regression/cbmc/empty_compound_type4/test.desc
+++ b/regression/cbmc/empty_compound_type4/test.desc
@@ -1,4 +1,4 @@
-CORE gcc-only no-new-smt
+CORE gcc-only
 main.c
 --trace
 ^VERIFICATION FAILED$

--- a/regression/cbmc/enum5/test.desc
+++ b/regression/cbmc/enum5/test.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 main.c
 
 ^EXIT=10$

--- a/regression/cbmc/equality_through_struct1/test.desc
+++ b/regression/cbmc/equality_through_struct1/test.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 main.c
 
 ^EXIT=0$

--- a/regression/cbmc/equality_through_struct2/test.desc
+++ b/regression/cbmc/equality_through_struct2/test.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 main.c
 
 ^EXIT=0$

--- a/regression/cbmc/equality_through_struct3/test.desc
+++ b/regression/cbmc/equality_through_struct3/test.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 main.c
 
 ^EXIT=0$

--- a/regression/cbmc/equality_through_struct4/test.desc
+++ b/regression/cbmc/equality_through_struct4/test.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 main.c
 
 ^EXIT=0$

--- a/regression/cbmc/equality_through_struct_containing_arrays1/test.desc
+++ b/regression/cbmc/equality_through_struct_containing_arrays1/test.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 main.c
 
 ^EXIT=0$

--- a/regression/cbmc/equality_through_union1/test.desc
+++ b/regression/cbmc/equality_through_union1/test.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 main.c
 
 ^EXIT=0$

--- a/regression/cbmc/equality_through_union2/test.desc
+++ b/regression/cbmc/equality_through_union2/test.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 main.c
 
 ^EXIT=0$

--- a/regression/cbmc/equality_through_union3/test.desc
+++ b/regression/cbmc/equality_through_union3/test.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 main.c
 
 ^EXIT=0$

--- a/regression/cbmc/export-symex-ready-goto/test-bad-usage.desc
+++ b/regression/cbmc/export-symex-ready-goto/test-bad-usage.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 test.c
 --export-symex-ready-goto ''
 ^ERROR: Please provide a filename to write the goto-binary to.$

--- a/regression/cbmc/export-symex-ready-goto/test-correct.desc
+++ b/regression/cbmc/export-symex-ready-goto/test-correct.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 test.c
 --export-symex-ready-goto exported.symex.ready.goto
 ^Parsing test.c$

--- a/regression/cbmc/field-sensitivity1/test.desc
+++ b/regression/cbmc/field-sensitivity1/test.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 test.c
 --show-vcc
 main::1::a!0@1#2\.\.x = main::argc!0@1#1

--- a/regression/cbmc/field-sensitivity11/test.desc
+++ b/regression/cbmc/field-sensitivity11/test.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 test.c
 --show-vcc
 main::1::a1!0@1#2\.\.x = main::argc!0@1#1

--- a/regression/cbmc/field-sensitivity12/test.desc
+++ b/regression/cbmc/field-sensitivity12/test.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 test.c
 --show-vcc
 main::1::a1!0@1#2\.\.x = main::argc!0@1#1

--- a/regression/cbmc/field-sensitivity13/test.desc
+++ b/regression/cbmc/field-sensitivity13/test.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 test.c
 --show-vcc
 main::1::b1!0@1#2\.\.a\.\.x = main::argc!0@1#1

--- a/regression/cbmc/field-sensitivity15/test.desc
+++ b/regression/cbmc/field-sensitivity15/test.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 main.c
 
 ^VERIFICATION SUCCESSFUL$

--- a/regression/cbmc/field-sensitivity16/test.desc
+++ b/regression/cbmc/field-sensitivity16/test.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 main.c
 
 ^VERIFICATION SUCCESSFUL$

--- a/regression/cbmc/field-sensitivity2/test.desc
+++ b/regression/cbmc/field-sensitivity2/test.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 test.c
 --show-vcc
 main::1::a1!0@1#2\.\.x =

--- a/regression/cbmc/field-sensitivity3/test.desc
+++ b/regression/cbmc/field-sensitivity3/test.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 test.c
 --show-vcc
 main::1::a1!0@1#2\.\.x =

--- a/regression/cbmc/field-sensitivity5/test.desc
+++ b/regression/cbmc/field-sensitivity5/test.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 test.c
 --show-vcc
 main::1::node1!0@1#2\.\.head =

--- a/regression/cbmc/field-sensitivity9/test.desc
+++ b/regression/cbmc/field-sensitivity9/test.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 test.c
 --show-vcc
 main::1::a1!0@1#2 =

--- a/regression/cbmc/full_slice1/test.desc
+++ b/regression/cbmc/full_slice1/test.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 main.c
 --full-slice --property main.assertion.1 --unwind 1
 ^EXIT=10$

--- a/regression/cbmc/full_slice2/test.desc
+++ b/regression/cbmc/full_slice2/test.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 main.c
 --full-slice --property main.assertion.2 --unwind 1
 ^EXIT=10$

--- a/regression/cbmc/gcc_builtin_sub_overflow/simplify.desc
+++ b/regression/cbmc/gcc_builtin_sub_overflow/simplify.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 simplify.c
 
 ^Generated 1 VCC\(s\), 0 remaining after simplification$

--- a/regression/cbmc/graphml_witness1/test.desc
+++ b/regression/cbmc/graphml_witness1/test.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 main.c
 --graphml-witness -
 ^EXIT=10$

--- a/regression/cbmc/graphml_witness2/test.desc
+++ b/regression/cbmc/graphml_witness2/test.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 main.c
 --graphml-witness - --unwindset main.0:1 --unwinding-assertions --stack-trace
 ^EXIT=10$

--- a/regression/cbmc/havoc_object1/full-slice.desc
+++ b/regression/cbmc/havoc_object1/full-slice.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 main.c
 --full-slice
 ^EXIT=10$

--- a/regression/cbmc/havoc_object1/test.desc
+++ b/regression/cbmc/havoc_object1/test.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 main.c
 
 ^EXIT=10$

--- a/regression/cbmc/havoc_slice/test_nondet_conditional.desc
+++ b/regression/cbmc/havoc_slice/test_nondet_conditional.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 test_nondet_conditional.c
 
 ^EXIT=10$

--- a/regression/cbmc/integral-trace/test.desc
+++ b/regression/cbmc/integral-trace/test.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 test.c
 --trace --xml-ui
 activate-multi-line-match

--- a/regression/cbmc/lhs-pointer-aliases-constant/test.desc
+++ b/regression/cbmc/lhs-pointer-aliases-constant/test.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 test.c
 
 ^VERIFICATION SUCCESSFUL$

--- a/regression/cbmc/multiple-goto-traces/test.desc
+++ b/regression/cbmc/multiple-goto-traces/test.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 main.c
 --trace
 activate-multi-line-match

--- a/regression/cbmc/no_nondet_static/test.desc
+++ b/regression/cbmc/no_nondet_static/test.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 main.c
 --nondet-static
 ^VERIFICATION FAILED$

--- a/regression/cbmc/pointer-function-parameters-struct-non-recursive/test.desc
+++ b/regression/cbmc/pointer-function-parameters-struct-non-recursive/test.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 main.c
 --function func --min-null-tree-depth 10
 ^EXIT=10$

--- a/regression/cbmc/pointer-to-struct-with-flexible-array-member-as-parameter-to-entry-point/test.desc
+++ b/regression/cbmc/pointer-to-struct-with-flexible-array-member-as-parameter-to-entry-point/test.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 main.c
 --function testFunc
 ^EXIT=0$

--- a/regression/cbmc/points-to-sets/test.desc
+++ b/regression/cbmc/points-to-sets/test.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 main.c
 --show-points-to-sets
 ^EXIT=1$

--- a/regression/cbmc/ptr_arithmetic_on_null/test.desc
+++ b/regression/cbmc/ptr_arithmetic_on_null/test.desc
@@ -1,4 +1,4 @@
-CORE gcc-only no-new-smt
+CORE gcc-only
 main.c
 
 ^\[main.assertion.1\] line .* assertion \(\(char \*\)NULL\) != \(char \*\)\(void \*\)0 \+ (\(.*\))?1: SUCCESS$

--- a/regression/cbmc/show-vcc/main_prec.desc
+++ b/regression/cbmc/show-vcc/main_prec.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 main_prec.c
 --show-vcc
 ^EXIT=0$

--- a/regression/cbmc/simplify_singleton_interval_7690/negative_test.desc
+++ b/regression/cbmc/simplify_singleton_interval_7690/negative_test.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 --trace
 singleton_interval_simp_neg.c
 ^VERIFICATION FAILED$

--- a/regression/cbmc/simplify_singleton_interval_7690/positive_test.desc
+++ b/regression/cbmc/simplify_singleton_interval_7690/positive_test.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 --trace
 singleton_interval_simp.c
 ^VERIFICATION FAILED$

--- a/regression/cbmc/symex_should_evaluate_simple_pointer_conditions/test.desc
+++ b/regression/cbmc/symex_should_evaluate_simple_pointer_conditions/test.desc
@@ -1,4 +1,4 @@
-CORE paths-lifo-expected-failure no-new-smt
+CORE paths-lifo-expected-failure
 test.c
 --function test --show-vcc
 ^EXIT=0$

--- a/regression/cbmc/symex_should_exclude_null_pointers/nondet.desc
+++ b/regression/cbmc/symex_should_exclude_null_pointers/nondet.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 nondet.c
 
 ^VERIFICATION SUCCESSFUL$

--- a/regression/cbmc/symex_should_exclude_null_pointers/test.desc
+++ b/regression/cbmc/symex_should_exclude_null_pointers/test.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 main.c
 --show-vcc
 ^EXIT=0$

--- a/regression/cbmc/symex_should_filter_value_sets/test.desc
+++ b/regression/cbmc/symex_should_filter_value_sets/test.desc
@@ -1,4 +1,4 @@
-CORE paths-lifo-expected-failure no-new-smt
+CORE paths-lifo-expected-failure
 main.c
 --show-vcc
 ^EXIT=0$

--- a/regression/cbmc/trace_show_code/test.desc
+++ b/regression/cbmc/trace_show_code/test.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 main.c
 --trace --trace-show-code
 ^EXIT=10$

--- a/regression/cbmc/typedef-return-anon-struct1/test.desc
+++ b/regression/cbmc/typedef-return-anon-struct1/test.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 main.c
 --show-symbol-table --function fun
 // Enable multi-line checking

--- a/regression/cbmc/typedef-return-anon-union1/test.desc
+++ b/regression/cbmc/typedef-return-anon-union1/test.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 main.c
 --show-symbol-table --function fun
 // Enable multi-line checking

--- a/regression/cbmc/typedef-return-struct1/test.desc
+++ b/regression/cbmc/typedef-return-struct1/test.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 main.c
 --show-symbol-table --function fun
 // Enable multi-line checking

--- a/regression/cbmc/typedef-return-type1/test.desc
+++ b/regression/cbmc/typedef-return-type1/test.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 main.c
 --show-symbol-table --function fun
 // Enable multi-line checking

--- a/regression/cbmc/typedef-return-type2/test.desc
+++ b/regression/cbmc/typedef-return-type2/test.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 main.c
 --show-symbol-table --function fun
 // Enable multi-line checking

--- a/regression/cbmc/typedef-return-type3/test.desc
+++ b/regression/cbmc/typedef-return-type3/test.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 main.c
 --show-symbol-table --function fun
 // Enable multi-line checking

--- a/regression/cbmc/typedef-return-union1/test.desc
+++ b/regression/cbmc/typedef-return-union1/test.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 main.c
 --show-symbol-table --function fun
 // Enable multi-line checking

--- a/regression/cbmc/union-unequal-element-size1/test.desc
+++ b/regression/cbmc/union-unequal-element-size1/test.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 main.c
 --verbosity 10
 ^EXIT=0$

--- a/regression/cbmc/union/union_member.desc
+++ b/regression/cbmc/union/union_member.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 union_member.c
 
 ^EXIT=10$

--- a/regression/cbmc/union12/test.desc
+++ b/regression/cbmc/union12/test.desc
@@ -1,4 +1,4 @@
-CORE broken-smt-backend no-new-smt
+CORE broken-smt-backend
 main.c
 --pointer-check
 ^EXIT=10$

--- a/regression/cbmc/void_pointer1/test.desc
+++ b/regression/cbmc/void_pointer1/test.desc
@@ -1,4 +1,4 @@
-CORE gcc-only no-new-smt
+CORE gcc-only
 main.c
 --pointer-check
 ^EXIT=0$

--- a/regression/cbmc/void_pointer2/test.desc
+++ b/regression/cbmc/void_pointer2/test.desc
@@ -1,4 +1,4 @@
-CORE gcc-only no-new-smt
+CORE gcc-only
 main.c
 --pointer-check --no-simplify --unwind 3
 ^EXIT=0$

--- a/regression/cbmc/void_pointer3/test.desc
+++ b/regression/cbmc/void_pointer3/test.desc
@@ -1,4 +1,4 @@
-CORE gcc-only no-new-smt
+CORE gcc-only
 main.c
 
 ^EXIT=0$

--- a/regression/cbmc/void_pointer6/test.desc
+++ b/regression/cbmc/void_pointer6/test.desc
@@ -1,4 +1,4 @@
-CORE gcc-only no-new-smt
+CORE gcc-only
 main.c
 --pointer-check
 ^EXIT=10$

--- a/regression/cbmc/void_pointer7/test.desc
+++ b/regression/cbmc/void_pointer7/test.desc
@@ -1,4 +1,4 @@
-CORE gcc-only no-new-smt
+CORE gcc-only
 main.c
 --pointer-check
 ^EXIT=0$


### PR DESCRIPTION
This PR adds 130 tests from `regression/cbmc` to the list of tests that is run with the new incremental SMT2 solver.
This is done by removing the `no-new-smt` exclusion flag from the tests as the current policy is to run the tests with the incremental SMT2 solver by default.

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.
