### PR TITLE
Assignments to bit-fields yield results of bit-field type

### DIFF
--- a/regression/cbmc/Bitfields1/main.c
+++ b/regression/cbmc/Bitfields1/main.c
@@ -51,9 +51,13 @@ int main() {
   bf.d=2;
   assert(bf.d==1);
 
-  // assignments have the underlying type
+  // assignments have the underlying type, except for GCC
   assert(sizeof(bf.d=1)==sizeof(_Bool));
+#if defined(__GNUC__) && !defined(__INTEL_COMPILER) && !defined(__clang__)
+  assert(sizeof(bf.a += 1) == 1);
+#else
   assert(sizeof(bf.a += 1) == sizeof(unsigned long));
+#endif
 
   bf.Type=IntelCacheTrace;
 

--- a/regression/cbmc/Bitfields5/main.c
+++ b/regression/cbmc/Bitfields5/main.c
@@ -1,0 +1,36 @@
+#include <assert.h>
+#include <limits.h>
+
+struct S0
+{
+  unsigned f2 : CHAR_BIT + 1;
+  int x;
+};
+
+#ifdef _MSC_VER
+#  define _Static_assert static_assert
+#endif
+
+int main()
+{
+  struct S0 g = {0};
+  // All compilers in compiler explorer appear to agree that comma and
+  // assignment expressions over bit-fields permit the use of sizeof. With GCC,
+  // the result is the declared width (rounded to bytes), all others use the
+  // size of the underlying type.
+  // https://www.open-std.org/jtc1/sc22/wg14/www/docs/n2958.htm
+  // for a discussion that this isn't actually specified (while being a
+  // sizeof/typeof peculiarity)
+#if defined(__GNUC__) && !defined(__INTEL_COMPILER) && !defined(__clang__)
+#  define WIDTH 2
+#else
+#  define WIDTH sizeof(unsigned)
+#endif
+  _Static_assert(sizeof(++g.f2) == WIDTH, "");
+  _Static_assert(sizeof(0, g.f2) == WIDTH, "");
+  _Static_assert(sizeof(g.f2 = g.f2) == WIDTH, "");
+  if(g.f2 <= -1)
+    assert(0);
+  if((g.f2 = g.f2) <= -1)
+    assert(0);
+}

--- a/regression/cbmc/Bitfields5/test.desc
+++ b/regression/cbmc/Bitfields5/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring


### PR DESCRIPTION
Do not pre-emptively cast side effects over bit-fields to the underlying type. sizeof just has a very peculiar semantics, which is discussed in https://www.open-std.org/jtc1/sc22/wg14/www/docs/n2958.htm.

Issue was found by CSmith (test generated with random seed 1700653858).

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
