### PR TITLE
Run additional regressions with new SMT solver

### DIFF
--- a/regression/cbmc/dynamic_size1/stack_object.desc
+++ b/regression/cbmc/dynamic_size1/stack_object.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 stack_object.c
 --pointer-check
 ^EXIT=0$

--- a/regression/cbmc/ptr_arithmetic_on_null/type_conflict.desc
+++ b/regression/cbmc/ptr_arithmetic_on_null/type_conflict.desc
@@ -1,4 +1,4 @@
-CORE gcc-only no-new-smt
+CORE gcc-only
 main.c
 -DMISSING_CAST
 pointer subtraction over different types


### PR DESCRIPTION
Adding other 2 regression tests now passing to be run with new SMT solver.

Specifically:
 - `dynamic_size1/stack_object.desc`
 - `ptr_arithmetic_on_null/type_conflict.desc`

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
