### PR TITLE
The emscripten compiler has alloca.h

### DIFF
--- a/src/big-int/allocainc.h
+++ b/src/big-int/allocainc.h
@@ -5,15 +5,17 @@
 #ifndef CPROVER_BIG_INT_ALLOCAINC_H
 #define CPROVER_BIG_INT_ALLOCAINC_H
 
-
+// clang-format off
 #if defined linux || defined __linux__		\
  || defined __sun				\
  || defined UWIN				\
  || defined osf1                                \
  || defined __MACH__                            \
- || defined __CYGWIN__
+ || defined __CYGWIN__                          \
+ || defined __EMSCRIPTEN__
+// clang-format on
 
-#include <alloca.h>
+#  include <alloca.h>
 
 #elif defined _MSC_VER    \
    || defined __BORLANDC__ \

--- a/src/big-int/allocainc.h
+++ b/src/big-int/allocainc.h
@@ -1,4 +1,10 @@
-// $Id: allocainc.h,v 1.7 2005-12-25 14:44:24 kroening Exp $
+/*******************************************************************\
+
+Module: Big Integers
+
+Author: Daniel Kroening, dkr@amazon.com
+
+\*******************************************************************/
 
 // Whatever is necessary to use alloca().
 

--- a/src/big-int/allocainc.h
+++ b/src/big-int/allocainc.h
@@ -12,13 +12,13 @@ Author: Daniel Kroening, dkr@amazon.com
 #define CPROVER_BIG_INT_ALLOCAINC_H
 
 // clang-format off
-#if defined linux || defined __linux__		\
- || defined __sun				\
- || defined UWIN				\
- || defined osf1                                \
- || defined __MACH__                            \
- || defined __CYGWIN__                          \
- || defined __EMSCRIPTEN__
+#if defined linux || defined __linux__ \
+  || defined __sun                     \
+  || defined UWIN                      \
+  || defined osf1                      \
+  || defined __MACH__                  \
+  || defined __CYGWIN__                \
+  || defined __EMSCRIPTEN__
 // clang-format on
 
 #  include <alloca.h>


### PR DESCRIPTION
Emscripten is a compiler that targets WASM.  To enable cross-compilation with emscripten, allocainc.h now uses alloca.h for this compiler.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- n/a Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
