### PR TITLE
fix conversions between long and long long

### DIFF
--- a/src/solvers/sat/external_sat.cpp
+++ b/src/solvers/sat/external_sat.cpp
@@ -119,8 +119,8 @@ external_satt::resultt external_satt::parse_result(std::string solver_output)
       {
         try
         {
-          signed long long as_long = std::stol(assignment_string);
-          size_t index = std::labs(as_long);
+          signed long long as_long = std::stoll(assignment_string);
+          size_t index = std::llabs(as_long);
 
           if(index >= number_of_variables)
           {


### PR DESCRIPTION
`as_long` in external_sat.cpp was declared as `long long`, computed as `long`, and subsequently passed to `labs`, which expects a `long`.  This yields an error on any platform where `long` is not `long long`.

This changes the calculation to use long long consistently.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- n/a Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
