### PR TITLE
Add default codeowners to `/src/symtab2gb/` and `/src/json-symtab-language/`

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -20,7 +20,7 @@
 /src/goto-checker/ @kroening @tautschnig @peterschrammel
 /src/goto-symex/ @kroening @tautschnig @peterschrammel
 /src/json/ @kroening @tautschnig @peterschrammel
-/src/json-symtab-language/ @martin-cs
+/src/json-symtab-language/ @martin-cs @kroening @tautschnig @peterschrammel
 /src/langapi/ @kroening @tautschnig @peterschrammel
 /src/xmllang/ @kroening @tautschnig @peterschrammel
 /src/nonstd/ @peterschrammel
@@ -29,7 +29,7 @@
 /src/solvers/miniBDD @tautschnig @kroening
 /src/solvers/prop @martin-cs @kroening @tautschnig @peterschrammel
 /src/solvers/sat @martin-cs @kroening @tautschnig @peterschrammel
-/src/symtab2gb/ @martin-cs
+/src/symtab2gb/ @martin-cs @kroening @tautschnig @peterschrammel
 /jbmc/src/miniz/ @peterschrammel
 /src/crangler/ @kroening @tautschnig @qinheping
 


### PR DESCRIPTION
The existing lines in the `CODEOWNERS` file overrides the default code owners, leaving Martin as the sole code owner. Adding the default code owners to the list should make it more straight forward to maintain these areas.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
