### PR TITLE
Remove usages of the deprecated `std::iterator`

### DIFF
--- a/src/util/cmdline.h
+++ b/src/util/cmdline.h
@@ -111,8 +111,8 @@ public:
       using iterator_category = std::forward_iterator_tag;
       using value_type = std::string;
       using difference_type = std::ptrdiff_t;
-      using pointer = std::string *;
-      using reference = std::string &;
+      using pointer = const std::string *;
+      using reference = const std::string &;
 
       option_names_iteratort() = default;
       explicit option_names_iteratort(

--- a/src/util/cmdline.h
+++ b/src/util/cmdline.h
@@ -105,8 +105,15 @@ public:
   {
     explicit option_namest(const cmdlinet &command_line);
     struct option_names_iteratort
-      : public std::iterator<std::forward_iterator_tag, std::string>
     {
+      // These types are defined such that the class is compatible with being
+      // treated as an STL iterator. For this to work, they must not be renamed.
+      using iterator_category = std::forward_iterator_tag;
+      using value_type = std::string;
+      using difference_type = std::ptrdiff_t;
+      using pointer = std::string *;
+      using reference = std::string &;
+
       option_names_iteratort() = default;
       explicit option_names_iteratort(
         const cmdlinet *command_line,

--- a/src/util/dense_integer_map.h
+++ b/src/util/dense_integer_map.h
@@ -116,17 +116,21 @@ private:
   // operator++ that skips unset values.
   template <class UnderlyingIterator, class UnderlyingValue>
   class iterator_templatet
-    : public std::iterator<std::forward_iterator_tag, UnderlyingValue>
   {
-    // Type of the std::iterator support class we inherit
-    typedef std::iterator<std::forward_iterator_tag, UnderlyingValue>
-      base_typet;
     // Type of this template instantiation
     typedef iterator_templatet<UnderlyingIterator, UnderlyingValue> self_typet;
     // Type of our containing \ref dense_integer_mapt
     typedef dense_integer_mapt<K, V, KeyToDenseInteger> map_typet;
 
   public:
+    // These types are defined such that the class is compatible with being
+    // treated as an STL iterator. For this to work, they must not be renamed.
+    using iterator_category = std::forward_iterator_tag;
+    using value_type = UnderlyingValue;
+    using difference_type = std::ptrdiff_t;
+    using pointer = UnderlyingValue *;
+    using reference = UnderlyingValue &;
+
     iterator_templatet(UnderlyingIterator it, const map_typet &underlying_map)
       : underlying_iterator(it), underlying_map(underlying_map)
     {
@@ -153,11 +157,11 @@ private:
       underlying_iterator = advance(underlying_iterator);
       return *this;
     }
-    typename base_typet::reference operator*() const
+    reference operator*() const
     {
       return *underlying_iterator;
     }
-    typename base_typet::pointer operator->() const
+    pointer operator->() const
     {
       return &*underlying_iterator;
     }


### PR DESCRIPTION
`std::iterator` is deprecated in C++17, this PR removes our usages of it. This should result in fewer build warnings and support continuing to build cbmc if the class is removed in a future C++ standard.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
