### PR TITLE
[CI] Perform apt update to sync repo sources before trying to install from them.

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -12,7 +12,9 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install doxygen
-        run: sudo apt install doxygen graphviz pandoc npm
+        run: |
+          sudo apt update
+          sudo apt install doxygen graphviz pandoc npm
 
       - name: Install python modules
         run: sudo python3 -m pip install gitpython pandocfilters


### PR DESCRIPTION
This PR should be fixing a recent CI issue where doxygen builds on the `Publish CBMC documentation` CI job fail.

My understanding from inspecting the logs of the failed job is that the apt sources are out of sync. From memory, when this happens it's usually a good idea to perform a sync of the `sources.list` with `apt update`.

Please refer to https://askubuntu.com/questions/1190717/when-to-run-sudo-apt-update-and-when-sudo-apt-update-sudo-apt-upgrade for a more elaborate explanation of the problem.