### PR TITLE
Name `-paths-lifo` test profiles uniquely

### DIFF
--- a/regression/book-examples/CMakeLists.txt
+++ b/regression/book-examples/CMakeLists.txt
@@ -17,7 +17,7 @@ add_test_pl_tests(
 )
 
 add_test_pl_profile(
-    "cbmc-paths-lifo"
+    "book-examples-paths-lifo"
     "$<TARGET_FILE:cbmc> --paths lifo"
     "-C;-X;thorough-paths;-X;smt-backend;-X;paths-lifo-expected-failure;${gcc_only_string}-s;paths-lifo;${exclude_win_broken_tests_string}"
     "CORE"


### PR DESCRIPTION
The test profile name `cbmc-paths-lifo` in `book-examples` had already been used in the `regression/cbmc`. This commit gives the profile a unique name so that the test suite functions correctly.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
