### PR TITLE
Use malloc fail null by default

### DIFF
--- a/doc/man/cbmc.1
+++ b/doc/man/cbmc.1
@@ -102,11 +102,8 @@ do not check that all pointers in pointer primitives are valid or null
 \fB\-\-no\-signed\-overflow\-check\fR
 disable signed arithmetic over\- and underflow checks
 .TP
-\fB\-\-no\-malloc\-may\-fail\fR
-do not allow malloc calls to fail by default
-.TP
-\fB\-\-no\-malloc\-fail\-null\fR
-do not set malloc failure mode to return null pointer
+\fB\-\-no\-malloc\-fail\fR
+Do not allow malloc calls to fail by default.
 .TP
 \fB\-\-no\-unwinding\-assertions\fR (\fBcbmc\fR\-only)
 do not generate unwinding assertions (cannot be

--- a/doc/man/cbmc.1
+++ b/doc/man/cbmc.1
@@ -102,8 +102,8 @@ do not check that all pointers in pointer primitives are valid or null
 \fB\-\-no\-signed\-overflow\-check\fR
 disable signed arithmetic over\- and underflow checks
 .TP
-\fB\-\-no\-malloc\-fail\fR
-Do not allow malloc calls to fail by default.
+\fB\-\-no\-malloc\-may\-fail\fR
+do not allow malloc calls to fail by default
 .TP
 \fB\-\-no\-unwinding\-assertions\fR (\fBcbmc\fR\-only)
 do not generate unwinding assertions (cannot be

--- a/doc/man/goto-analyzer.1
+++ b/doc/man/goto-analyzer.1
@@ -634,11 +634,8 @@ do not check that all pointers in pointer primitives are valid or null
 \fB\-\-no\-signed\-overflow\-check\fR
 disable signed arithmetic over\- and underflow checks
 .TP
-\fB\-\-no\-malloc\-may\-fail\fR
-do not allow malloc calls to fail by default
-.TP
-\fB\-\-no\-malloc\-fail\-null\fR
-do not set malloc failure mode to return null pointer
+\fB\-\-no\-malloc\-fail\fR
+Do not allow malloc calls to fail by default.
 .TP
 \fB\-\-no\-unwinding\-assertions\fR (\fBcbmc\fR\-only)
 do not generate unwinding assertions (cannot be

--- a/doc/man/goto-analyzer.1
+++ b/doc/man/goto-analyzer.1
@@ -634,8 +634,8 @@ do not check that all pointers in pointer primitives are valid or null
 \fB\-\-no\-signed\-overflow\-check\fR
 disable signed arithmetic over\- and underflow checks
 .TP
-\fB\-\-no\-malloc\-fail\fR
-Do not allow malloc calls to fail by default.
+\fB\-\-no\-malloc\-may\-fail\fR
+do not allow malloc calls to fail by default
 .TP
 \fB\-\-no\-unwinding\-assertions\fR (\fBcbmc\fR\-only)
 do not generate unwinding assertions (cannot be

--- a/doc/man/goto-instrument.1
+++ b/doc/man/goto-instrument.1
@@ -697,8 +697,8 @@ set malloc failure mode to assert\-then\-assume
 \fB\-\-malloc\-fail\-null\fR
 set malloc failure mode to return null
 .TP
-\fB\-\-no\-malloc\-fail\fR
-Do not allow malloc calls to fail by default.
+\fB\-\-no\-malloc\-may\-fail\fR
+do not allow malloc calls to fail by default
 .TP
 \fB\-\-string\-abstraction\fR
 track C string lengths and zero\-termination

--- a/doc/man/goto-instrument.1
+++ b/doc/man/goto-instrument.1
@@ -697,6 +697,9 @@ set malloc failure mode to assert\-then\-assume
 \fB\-\-malloc\-fail\-null\fR
 set malloc failure mode to return null
 .TP
+\fB\-\-no\-malloc\-fail\fR
+Do not allow malloc calls to fail by default.
+.TP
 \fB\-\-string\-abstraction\fR
 track C string lengths and zero\-termination
 .TP

--- a/regression/contracts-dfcc/chain.sh
+++ b/regression/contracts-dfcc/chain.sh
@@ -44,7 +44,7 @@ else
 fi
 
 if [[ "${args_inst}" != *"malloc"* ]]; then
-  args_inst="--no-malloc-fail $args_inst"
+  args_inst="--no-malloc-may-fail $args_inst"
 fi
 
 rm -f "${name}${dfcc_suffix}-mod.gb"

--- a/regression/contracts-dfcc/chain.sh
+++ b/regression/contracts-dfcc/chain.sh
@@ -43,6 +43,10 @@ else
   $goto_cc -o "${name}${dfcc_suffix}.gb" "${name}.c"
 fi
 
+if [[ "${args_inst}" != *"malloc"* ]]; then
+  args_inst="--no-malloc-fail $args_inst"
+fi
+
 rm -f "${name}${dfcc_suffix}-mod.gb"
 $goto_instrument ${args_inst} "${name}${dfcc_suffix}.gb" "${name}${dfcc_suffix}-mod.gb"
 if [ ! -e "${name}${dfcc_suffix}-mod.gb" ] ; then

--- a/regression/goto-instrument/chain.sh
+++ b/regression/goto-instrument/chain.sh
@@ -21,7 +21,7 @@ else
 fi
 
 rm -f "${target}-mod.gb"
-$goto_instrument ${args} "${target}.gb" "${target}-mod.gb"
+$goto_instrument --no-malloc-fail ${args} "${target}.gb" "${target}-mod.gb"
 if [ ! -e "${target}-mod.gb" ] ; then
   cp "${target}.gb" "${target}-mod.gb"
 elif echo $args | grep -q -- "--dump-c-type-header" ; then
@@ -39,5 +39,5 @@ elif echo $args | grep -q -- "--dump-c" ; then
 
   rm "${target}-mod.c"
 fi
-$goto_instrument --show-goto-functions "${target}-mod.gb"
+$goto_instrument --no-malloc-fail --show-goto-functions "${target}-mod.gb"
 $cbmc --no-standard-checks "${target}-mod.gb"

--- a/regression/goto-instrument/chain.sh
+++ b/regression/goto-instrument/chain.sh
@@ -21,7 +21,7 @@ else
 fi
 
 rm -f "${target}-mod.gb"
-$goto_instrument --no-malloc-fail ${args} "${target}.gb" "${target}-mod.gb"
+$goto_instrument --no-malloc-may-fail ${args} "${target}.gb" "${target}-mod.gb"
 if [ ! -e "${target}-mod.gb" ] ; then
   cp "${target}.gb" "${target}-mod.gb"
 elif echo $args | grep -q -- "--dump-c-type-header" ; then
@@ -39,5 +39,5 @@ elif echo $args | grep -q -- "--dump-c" ; then
 
   rm "${target}-mod.c"
 fi
-$goto_instrument --no-malloc-fail --show-goto-functions "${target}-mod.gb"
+$goto_instrument --no-malloc-may-fail --show-goto-functions "${target}-mod.gb"
 $cbmc --no-standard-checks "${target}-mod.gb"

--- a/regression/goto-synthesizer/chain.sh
+++ b/regression/goto-synthesizer/chain.sh
@@ -37,7 +37,7 @@ fi
 rm -f "${name}-mod.gb"
 rm -f "${name}-mod-2.gb"
 echo "Running goto-instrument: "
-$goto_instrument ${args_inst} "${name}.gb" "${name}-mod.gb"
+$goto_instrument --no-malloc-fail ${args_inst} "${name}.gb" "${name}-mod.gb"
 if [ ! -e "${name}-mod.gb" ] ; then
   cp "$name.gb" "${name}-mod.gb"
 elif echo $args_inst | grep -q -- "--dump-c" ; then
@@ -53,9 +53,9 @@ elif echo $args_inst | grep -q -- "--dump-c" ; then
 fi
 echo "Running goto-synthesizer: "
 if echo $args_synthesizer | grep -q -- "--dump-loop-contracts" ; then
-  $goto_synthesizer ${args_synthesizer} "${name}-mod.gb"
+  $goto_synthesizer ${args_synthesizer} --no-malloc-fail "${name}-mod.gb"
 else
-  $goto_synthesizer ${args_synthesizer} "${name}-mod.gb" "${name}-mod-2.gb"
+  $goto_synthesizer ${args_synthesizer} --no-malloc-fail "${name}-mod.gb" "${name}-mod-2.gb"
   echo "Running CBMC: "
   $cbmc --no-standard-checks ${args_cbmc} "${name}-mod-2.gb"
 fi

--- a/regression/goto-synthesizer/chain.sh
+++ b/regression/goto-synthesizer/chain.sh
@@ -37,7 +37,7 @@ fi
 rm -f "${name}-mod.gb"
 rm -f "${name}-mod-2.gb"
 echo "Running goto-instrument: "
-$goto_instrument --no-malloc-fail ${args_inst} "${name}.gb" "${name}-mod.gb"
+$goto_instrument --no-malloc-may-fail ${args_inst} "${name}.gb" "${name}-mod.gb"
 if [ ! -e "${name}-mod.gb" ] ; then
   cp "$name.gb" "${name}-mod.gb"
 elif echo $args_inst | grep -q -- "--dump-c" ; then
@@ -53,9 +53,9 @@ elif echo $args_inst | grep -q -- "--dump-c" ; then
 fi
 echo "Running goto-synthesizer: "
 if echo $args_synthesizer | grep -q -- "--dump-loop-contracts" ; then
-  $goto_synthesizer ${args_synthesizer} --no-malloc-fail "${name}-mod.gb"
+  $goto_synthesizer ${args_synthesizer} --no-malloc-may-fail "${name}-mod.gb"
 else
-  $goto_synthesizer ${args_synthesizer} --no-malloc-fail "${name}-mod.gb" "${name}-mod-2.gb"
+  $goto_synthesizer ${args_synthesizer} --no-malloc-may-fail "${name}-mod.gb" "${name}-mod-2.gb"
   echo "Running CBMC: "
   $cbmc --no-standard-checks ${args_cbmc} "${name}-mod-2.gb"
 fi

--- a/src/cbmc/cbmc_parse_options.cpp
+++ b/src/cbmc/cbmc_parse_options.cpp
@@ -126,10 +126,28 @@ void cbmc_parse_optionst::set_default_analysis_flags(
   {
     options.set_option("unwinding-assertions", enabled);
   }
+
+  if(enabled)
+  {
+    config.ansi_c.malloc_may_fail = true;
+    config.ansi_c.malloc_failure_mode =
+      configt::ansi_ct::malloc_failure_modet::malloc_failure_mode_return_null;
+  }
+  else
+  {
+    config.ansi_c.malloc_may_fail = false;
+    config.ansi_c.malloc_failure_mode =
+      configt::ansi_ct::malloc_failure_modet::malloc_failure_mode_none;
+  }
 }
 
 void cbmc_parse_optionst::get_command_line_options(optionst &options)
 {
+  // Enable flags that in combination provide analysis with no surprises
+  // (expected checks and no unsoundness by missing checks).
+  cbmc_parse_optionst::set_default_analysis_flags(
+    options, !cmdline.isset("no-standard-checks"));
+
   if(config.set(cmdline))
   {
     usage_error();
@@ -365,11 +383,6 @@ void cbmc_parse_optionst::get_command_line_options(optionst &options)
   options.set_option(
     "self-loops-to-assumptions",
     !cmdline.isset("no-self-loops-to-assumptions"));
-
-  // Enable flags that in combination provide analysis with no surprises
-  // (expected checks and no unsoundness by missing checks).
-  cbmc_parse_optionst::set_default_analysis_flags(
-    options, !cmdline.isset("no-standard-checks"));
 
   // all (other) checks supported by goto_check
   PARSE_OPTIONS_GOTO_CHECK(cmdline, options);

--- a/src/goto-analyzer/goto_analyzer_parse_options.cpp
+++ b/src/goto-analyzer/goto_analyzer_parse_options.cpp
@@ -68,6 +68,19 @@ void goto_analyzer_parse_optionst::set_default_analysis_flags(
   options.set_option("signed-overflow-check", enabled);
   options.set_option("undefined-shift-check", enabled);
 
+  if(enabled)
+  {
+    config.ansi_c.malloc_may_fail = true;
+    config.ansi_c.malloc_failure_mode =
+      configt::ansi_ct::malloc_failure_modet::malloc_failure_mode_return_null;
+  }
+  else
+  {
+    config.ansi_c.malloc_may_fail = false;
+    config.ansi_c.malloc_failure_mode =
+      configt::ansi_ct::malloc_failure_modet::malloc_failure_mode_none;
+  }
+
   // This is in-line with the options we set for CBMC in cbmc_parse_optionst
   // with the exception of unwinding-assertions, which don't make sense in
   // the context of abstract interpretation.
@@ -75,6 +88,9 @@ void goto_analyzer_parse_optionst::set_default_analysis_flags(
 
 void goto_analyzer_parse_optionst::get_command_line_options(optionst &options)
 {
+  goto_analyzer_parse_optionst::set_default_analysis_flags(
+    options, !cmdline.isset("no-standard-checks"));
+
   if(config.set(cmdline))
   {
     usage_error();
@@ -83,9 +99,6 @@ void goto_analyzer_parse_optionst::get_command_line_options(optionst &options)
 
   if(cmdline.isset("function"))
     options.set_option("function", cmdline.get_value("function"));
-
-  goto_analyzer_parse_optionst::set_default_analysis_flags(
-    options, !cmdline.isset("no-standard-checks"));
 
   // all (other) checks supported by goto_check
   PARSE_OPTIONS_GOTO_CHECK(cmdline, options);

--- a/src/goto-analyzer/goto_analyzer_parse_options.h
+++ b/src/goto-analyzer/goto_analyzer_parse_options.h
@@ -89,6 +89,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #ifndef CPROVER_GOTO_ANALYZER_GOTO_ANALYZER_PARSE_OPTIONS_H
 #define CPROVER_GOTO_ANALYZER_GOTO_ANALYZER_PARSE_OPTIONS_H
 
+#include <util/config.h>
 #include <util/parse_options.h>
 #include <util/timestamper.h>
 #include <util/ui_message.h>
@@ -152,6 +153,7 @@ class optionst;
   OPT_SHOW_GOTO_FUNCTIONS \
   OPT_SHOW_PROPERTIES \
   OPT_GOTO_CHECK \
+  OPT_CONFIG_LIBRARY \
   "(show-symbol-table)(show-parse-tree)" \
   "(property):" \
   "(verbosity):(version)" \

--- a/src/util/config.cpp
+++ b/src/util/config.cpp
@@ -1127,6 +1127,11 @@ bool configt::set(const cmdlinet &cmdline)
     ansi_c.malloc_failure_mode = ansi_c.malloc_failure_mode_assert_then_assume;
 
   ansi_c.malloc_may_fail = cmdline.isset("malloc-may-fail");
+  if(cmdline.isset("no-malloc-fail"))
+  {
+    ansi_c.malloc_may_fail = false;
+    ansi_c.malloc_failure_mode = ansi_ct::malloc_failure_mode_none;
+  }
 
   if(cmdline.isset("c89"))
     ansi_c.set_c89();

--- a/src/util/config.cpp
+++ b/src/util/config.cpp
@@ -1126,7 +1126,10 @@ bool configt::set(const cmdlinet &cmdline)
   if(cmdline.isset("malloc-fail-assert"))
     ansi_c.malloc_failure_mode = ansi_c.malloc_failure_mode_assert_then_assume;
 
-  ansi_c.malloc_may_fail = cmdline.isset("malloc-may-fail");
+  if(cmdline.isset("malloc-may-fail"))
+  {
+    ansi_c.malloc_may_fail = true;
+  }
   if(cmdline.isset("no-malloc-fail"))
   {
     ansi_c.malloc_may_fail = false;

--- a/src/util/config.cpp
+++ b/src/util/config.cpp
@@ -1130,7 +1130,7 @@ bool configt::set(const cmdlinet &cmdline)
   {
     ansi_c.malloc_may_fail = true;
   }
-  if(cmdline.isset("no-malloc-fail"))
+  if(cmdline.isset("no-malloc-may-fail"))
   {
     ansi_c.malloc_may_fail = false;
     ansi_c.malloc_failure_mode = ansi_ct::malloc_failure_mode_none;

--- a/src/util/config.h
+++ b/src/util/config.h
@@ -70,7 +70,7 @@ class symbol_table_baset;
     " {y--no-library} \t disable built-in abstract C library\n"
 
 #define OPT_CONFIG_LIBRARY                                                     \
-  "(malloc-fail-assert)(malloc-fail-null)(malloc-may-fail)"                    \
+  "(malloc-fail-assert)(malloc-fail-null)(malloc-may-fail)(no-malloc-fail)"    \
   "(string-abstraction)"
 
 #define HELP_CONFIG_LIBRARY                                                    \
@@ -78,6 +78,7 @@ class symbol_table_baset;
   " {y--malloc-fail-assert} \t "                                               \
   "set malloc failure mode to assert-then-assume\n"                            \
   " {y--malloc-fail-null} \t set malloc failure mode to return null\n"         \
+  " {y--no-malloc-fail} \t Disable potential malloc failure.\n"                \
   " {y--string-abstraction} \t track C string lengths and zero-termination\n"
 
 #define OPT_CONFIG_JAVA "(classpath)(cp)(main-class)"

--- a/src/util/config.h
+++ b/src/util/config.h
@@ -272,7 +272,7 @@ public:
     libt lib;
 
     bool string_abstraction;
-    bool malloc_may_fail = false;
+    bool malloc_may_fail = true;
 
     enum malloc_failure_modet
     {
@@ -281,7 +281,7 @@ public:
       malloc_failure_mode_assert_then_assume = 2
     };
 
-    malloc_failure_modet malloc_failure_mode = malloc_failure_mode_none;
+    malloc_failure_modet malloc_failure_mode = malloc_failure_mode_return_null;
 
     static const std::size_t default_object_bits = 8;
 

--- a/src/util/config.h
+++ b/src/util/config.h
@@ -70,15 +70,16 @@ class symbol_table_baset;
     " {y--no-library} \t disable built-in abstract C library\n"
 
 #define OPT_CONFIG_LIBRARY                                                     \
-  "(malloc-fail-assert)(malloc-fail-null)(malloc-may-fail)(no-malloc-fail)"    \
+  "(malloc-fail-assert)(malloc-fail-null)(malloc-may-fail)"                    \
+  "(no-malloc-may-fail)"                                                       \
   "(string-abstraction)"
 
 #define HELP_CONFIG_LIBRARY                                                    \
   " {y--malloc-may-fail} \t allow malloc calls to return a null pointer\n"     \
+  " {y--no-malloc-may-fail} \t disable potential malloc failure\n"             \
   " {y--malloc-fail-assert} \t "                                               \
   "set malloc failure mode to assert-then-assume\n"                            \
   " {y--malloc-fail-null} \t set malloc failure mode to return null\n"         \
-  " {y--no-malloc-fail} \t Disable potential malloc failure.\n"                \
   " {y--string-abstraction} \t track C string lengths and zero-termination\n"
 
 #define OPT_CONFIG_JAVA "(classpath)(cp)(main-class)"


### PR DESCRIPTION
This PR updates the defaults so that we use a model where malloc may fail with a null return value. This work is split from https://github.com/diffblue/cbmc/pull/8093  This change in the default avoids the possibility of memory allocations which overflow the size of the object bits.
<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
