### PR TITLE
CSmith test script: avoid a need for argv modelling

### DIFF
--- a/scripts/csmith.sh
+++ b/scripts/csmith.sh
@@ -60,6 +60,9 @@ csmith_test() {
   # Prepare the test CBMC by injecting the checksum as an assertion.
   gcc -E -I/usr/include/csmith -D__FRAMAC \
     -D'Frama_C_dump_assert_each()'="assert($check==(crc))" $f -o $bn.i
+  # We don't model argv here, so make sure we don't end up with a spurious
+  # null-pointer use.
+  sed -i 's/strcmp(argv\[1\], "1")/0/' $bn.i
   # Run the test using CBMC for up to 90 seconds, unwinding loops up to 257
   # times.
   ec=0


### PR DESCRIPTION
With additional checks turned on as of #8093, we failed CSmith tests with (legitimate) pointer property failures in `strcmp`. These are caused by trying to compare `argv[1]` to a string. As we do not model `argv` in these tests, `argv[1]` was not a valid pointer. This fix just removes the string comparison, which is only used for turning on/off debug output in test execution.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
