### PR TITLE
Support Minisat source variants where l_False/l_True are not macros

### DIFF
--- a/src/solvers/sat/satcheck_minisat2.cpp
+++ b/src/solvers/sat/satcheck_minisat2.cpp
@@ -21,6 +21,11 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <minisat/core/Solver.h>
 #include <minisat/simp/SimpSolver.h>
 
+#ifndef l_False
+#  define l_False Minisat::l_False
+#  define l_True Minisat::l_True
+#endif
+
 #ifndef HAVE_MINISAT2
 #error "Expected HAVE_MINISAT2"
 #endif


### PR DESCRIPTION
There isn't really a single authoritative Minisat source anymore, and therefore system-provided Minisat installations may use slightly different source layouts. Cater for this by supporting at least the variants with/without macros for l_False/l_True.

Fixes: #8052

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
