### PR TITLE
Enable logging of default flags on tool invocation

### DIFF
--- a/src/cbmc/cbmc_parse_options.cpp
+++ b/src/cbmc/cbmc_parse_options.cpp
@@ -108,7 +108,8 @@ void cbmc_parse_optionst::set_default_options(optionst &options)
 
 void cbmc_parse_optionst::set_default_analysis_flags(
   optionst &options,
-  const bool enabled)
+  const bool enabled,
+  const messaget &log)
 {
   // Checks enabled by default in v6.0+.
   options.set_option("bounds-check", enabled);
@@ -121,6 +122,29 @@ void cbmc_parse_optionst::set_default_analysis_flags(
   // Unwinding assertions required in certain cases for sound verification
   // results. See https://github.com/diffblue/cbmc/issues/6561 for elaboration.
   options.set_option("unwinding-assertions", enabled);
+
+  if(enabled)
+  {
+    log.status() << "Running with --standard-checks on: "
+                 << "bounds-check, pointer-check, pointer-primitive-check, "
+                    "div-by-zero-check, "
+                 << "signed-overflow-check, undefined-shift-check and "
+                    "unwinding-assertions are"
+                 << "**on** by default for this analysis run.\n"
+                 << messaget::eom;
+    ;
+  }
+  else
+  { // enabled == false
+    log.status() << "Running with --no-standard-checks on: "
+                 << "bounds-check, pointer-check, pointer-primitive-check, "
+                    "div-by-zero-check, "
+                 << "signed-overflow-check, undefined-shift-check and "
+                    "unwinding-assertions are "
+                 << "**off** by default for this analysis run.\n"
+                 << messaget::eom;
+    ;
+  }
 }
 
 void cbmc_parse_optionst::get_command_line_options(optionst &options)
@@ -335,7 +359,7 @@ void cbmc_parse_optionst::get_command_line_options(optionst &options)
   // Enable flags that in combination provide analysis with no surprises
   // (expected checks and no unsoundness by missing checks).
   cbmc_parse_optionst::set_default_analysis_flags(
-    options, !cmdline.isset("no-standard-checks"));
+    options, !cmdline.isset("no-standard-checks"), log);
 
   // all (other) checks supported by goto_check
   PARSE_OPTIONS_GOTO_CHECK(cmdline, options);

--- a/src/cbmc/cbmc_parse_options.h
+++ b/src/cbmc/cbmc_parse_options.h
@@ -96,7 +96,8 @@ public:
   ///
   /// This function sets up the default analysis checks as discussed
   /// in RFC https://github.com/diffblue/cbmc/issues/7975.
-  static void set_default_analysis_flags(optionst &, const bool enabled);
+  static void
+  set_default_analysis_flags(optionst &, const bool enabled, const messaget &);
   static bool process_goto_program(goto_modelt &, const optionst &, messaget &);
 
   static int get_goto_program(

--- a/src/goto-analyzer/goto_analyzer_parse_options.cpp
+++ b/src/goto-analyzer/goto_analyzer_parse_options.cpp
@@ -58,7 +58,8 @@ goto_analyzer_parse_optionst::goto_analyzer_parse_optionst(
 
 void goto_analyzer_parse_optionst::set_default_analysis_flags(
   optionst &options,
-  const bool enabled)
+  const bool enabled,
+  const messaget &log)
 {
   // Checks enabled by default in v6.0+.
   options.set_option("bounds-check", enabled);
@@ -71,6 +72,29 @@ void goto_analyzer_parse_optionst::set_default_analysis_flags(
   // This is in-line with the options we set for CBMC in cbmc_parse_optionst
   // with the exception of unwinding-assertions, which don't make sense in
   // the context of abstract interpretation.
+
+  if(enabled)
+  {
+    log.status()
+      << "Running with --standard-checks on: "
+      << "bounds-check, pointer-check, pointer-primitive-check, "
+         "div-by-zero-check, "
+      << "signed-overflow-check and undefined-shift-check are **on** by "
+      << "default for this analysis run.\n"
+      << messaget::eom;
+    ;
+  }
+  else
+  { // enabled == false
+    log.status()
+      << "Running with --no-standard-checks on: "
+      << "bounds-check, pointer-check, pointer-primitive-check, "
+         "div-by-zero-check, "
+      << "signed-overflow-check and undefined-shift-check are **off** by "
+      << "default for this analysis run.\n"
+      << messaget::eom;
+    ;
+  }
 }
 
 void goto_analyzer_parse_optionst::get_command_line_options(optionst &options)
@@ -85,7 +109,7 @@ void goto_analyzer_parse_optionst::get_command_line_options(optionst &options)
     options.set_option("function", cmdline.get_value("function"));
 
   goto_analyzer_parse_optionst::set_default_analysis_flags(
-    options, !cmdline.isset("no-standard-checks"));
+    options, !cmdline.isset("no-standard-checks"), log);
 
   // all (other) checks supported by goto_check
   PARSE_OPTIONS_GOTO_CHECK(cmdline, options);

--- a/src/goto-analyzer/goto_analyzer_parse_options.h
+++ b/src/goto-analyzer/goto_analyzer_parse_options.h
@@ -191,7 +191,8 @@ protected:
   virtual int perform_analysis(const optionst &options);
 
   // TODO: Add documentation
-  static void set_default_analysis_flags(optionst &options, const bool enabled);
+  static void
+  set_default_analysis_flags(optionst &options, const bool enabled, const messaget &);
 };
 
 #endif // CPROVER_GOTO_ANALYZER_GOTO_ANALYZER_PARSE_OPTIONS_H


### PR DESCRIPTION
This is addressing a review comment on #8093 and provides a message outlining the level of default checks applied at tool invocation.