### PR TITLE
Add Michael and Peter to Repository CI codeowners.

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -83,5 +83,5 @@ CHANGELOG      @diffblue/diffblue-opensource
 /scripts/ @diffblue/diffblue-opensource
 
 # CI pipeline is the responsibility of the Open Source maintenance team at Diffblue.
-/.github/ @diffblue/diffblue-opensource
-src/config.inc @diffblue/diffblue-opensource
+/.github/ @diffblue/diffblue-opensource @peterschrammel @tautschnig
+src/config.inc @diffblue/diffblue-opensource @peterschrammel @tautschnig


### PR DESCRIPTION
It would be good to have more codeowners so it's not bottlenecked by the Diffblue open source team.