### PR TITLE
fix nondeterministic hex_trace test

### DIFF
--- a/regression/cbmc/hex_trace/test.desc
+++ b/regression/cbmc/hex_trace/test.desc
@@ -4,7 +4,6 @@ main.c
 ^EXIT=10$
 ^SIGNAL=0$
 a=0 \s*\(0x0\)
-b=0ul? \s*\(0x0\)
 a=-100 \s*\(0xFFFFFF9C\)
 a=2147483647 \s*\(0x7FFFFFFF\)
 b=4294967294ul? \s*\(0xFFFFFFFE\)


### PR DESCRIPTION
The `cbmc/hex_trace` test pattern relies on a particular value (0) for an uninitialized local variable.  This removes the pattern.

See
https://github.com/diffblue/cbmc/actions/runs/6672135313/job/18269948126?pr=7979 as an exemplar where this was triggered.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [X] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
