### PR TITLE
simplify prop_conv_solvert::push

### DIFF
--- a/src/goto-checker/goto_symex_fault_localizer.cpp
+++ b/src/goto-checker/goto_symex_fault_localizer.cpp
@@ -95,7 +95,7 @@ bool goto_symex_fault_localizert::check(
   }
 
   // lock the failed assertion
-  assumptions.push_back(solver.handle(not_exprt(failed_step.cond_handle)));
+  assumptions.push_back(not_exprt(failed_step.cond_handle));
 
   solver.push(assumptions);
 

--- a/src/solvers/prop/prop_conv_solver.cpp
+++ b/src/solvers/prop/prop_conv_solver.cpp
@@ -463,7 +463,7 @@ prop_conv_solvert::dec_solve(const exprt &assumption)
   if(assumption.is_nil())
     push();
   else
-    push({literal_exprt(convert(assumption))});
+    push({assumption});
 
   auto prop_result = prop.prop_solve(assumption_stack);
 
@@ -539,7 +539,12 @@ void prop_conv_solvert::push(const std::vector<exprt> &assumptions)
   // We push the given assumptions as a single context onto the stack.
   assumption_stack.reserve(assumption_stack.size() + assumptions.size());
   for(const auto &assumption : assumptions)
-    assumption_stack.push_back(to_literal_expr(assumption).get_literal());
+  {
+    auto literal = convert(assumption);
+    if(!literal.is_constant())
+      set_frozen(literal);
+    assumption_stack.push_back(literal);
+  }
   context_size_stack.push_back(assumptions.size());
 }
 


### PR DESCRIPTION
This change relieves the user of `prop_conv_solvert::push` from the restriction that the expressions pushed as assumptions must be `literal_exprt` and frozen.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
