### PR TITLE
Remove unused safety_checkert constructor

### DIFF
--- a/src/goto-programs/safety_checker.cpp
+++ b/src/goto-programs/safety_checker.cpp
@@ -11,11 +11,6 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "safety_checker.h"
 
-safety_checkert::safety_checkert(const namespacet &_ns):
-  ns(_ns)
-{
-}
-
 safety_checkert::safety_checkert(
   const namespacet &_ns,
   message_handlert &_message_handler):

--- a/src/goto-programs/safety_checker.h
+++ b/src/goto-programs/safety_checker.h
@@ -24,12 +24,7 @@ class goto_functionst;
 class safety_checkert:public messaget
 {
 public:
-  explicit safety_checkert(
-    const namespacet &_ns);
-
-  explicit safety_checkert(
-    const namespacet &_ns,
-    message_handlert &_message_handler);
+  safety_checkert(const namespacet &_ns, message_handlert &_message_handler);
 
   enum class resultt
   {


### PR DESCRIPTION
This avoids creating a messaget that isn't fully initialised.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
