### PR TITLE
xml_parsert: construct with message handler

### DIFF
--- a/src/xmllang/parser.y
+++ b/src/xmllang/parser.y
@@ -3,12 +3,12 @@
 
 #include "xml_parser.h"
 
-int yyxmllex();
-extern char *yyxmltext;
+int yyxmllex(void *);
+char *yyxmlget_text(void *);
 
-int yyxmlerror(const std::string &error)
+int yyxmlerror(xml_parsert &xml_parser, void *scanner, const std::string &error)
 {
-  xml_parser.parse_error(error, yyxmltext);
+  xml_parser.parse_error(error, yyxmlget_text(scanner));
   return 0;
 }
 
@@ -25,6 +25,10 @@ int yyxmlerror(const std::string &error)
 #pragma warning(disable:4702)
 #endif
 %}
+
+%parse-param {xml_parsert &xml_parser}
+%parse-param {void *scanner}
+%lex-param {void *scanner}
 
 %union {char *s;}
 

--- a/src/xmllang/scanner.l
+++ b/src/xmllang/scanner.l
@@ -3,6 +3,9 @@
 %option noinput
 %option nounistd
 %option never-interactive
+%option noyywrap
+%option reentrant
+%option extra-type="xml_parsert *"
 
 %{
 
@@ -19,7 +22,7 @@
 #include "xml_parser.h"
 #include "xml_y.tab.h"
 
-#define PARSER xml_parser
+#define PARSER (*yyextra)
 
 //static int keep;  /* To store start condition */
 
@@ -87,9 +90,5 @@ string     \"([^"&]|{esc})*\"|\'([^'&]|{esc})*\'
 <DTD>.            {/* skip */}
 <DTD>\]{close}    {BEGIN(INITIAL); /* skip */}
 
-.                 { yyxmlerror("unexpected character"); }
+.                 { yyxmlerror(*yyextra, yyscanner, "unexpected character"); }
 {nl}              {/* skip, must be an extra one at EOF */;}
-
-%%
-
-int yywrap() { return 1; }


### PR DESCRIPTION
This both avoids an object of static lifetime as well as it fixes the (transitive) use of the deprecated messaget() constructor.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
