### PR TITLE
jsil_parsert: construct with message handler

### DIFF
--- a/src/jsil/jsil_language.cpp
+++ b/src/jsil/jsil_language.cpp
@@ -62,12 +62,11 @@ bool jsil_languaget::parse(
   parse_path=path;
 
   // parsing
+  jsil_parsert jsil_parser{message_handler};
   jsil_parser.clear();
   jsil_parser.set_file(path);
   jsil_parser.in=&instream;
-  jsil_parser.log.set_message_handler(message_handler);
 
-  jsil_scanner_init();
   bool result=jsil_parser.parse();
 
   // save result
@@ -137,12 +136,10 @@ bool jsil_languaget::to_expr(
   std::istringstream instream(code);
 
   // parsing
-
+  jsil_parsert jsil_parser{message_handler};
   jsil_parser.clear();
   jsil_parser.set_file(irep_idt());
   jsil_parser.in=&instream;
-  jsil_parser.log.set_message_handler(message_handler);
-  jsil_scanner_init();
 
   bool result=jsil_parser.parse();
 

--- a/src/jsil/jsil_parser.cpp
+++ b/src/jsil/jsil_parser.cpp
@@ -10,13 +10,3 @@ Author: Michael Tautschnig, tautschn@amazon.com
 /// Jsil Language
 
 #include "jsil_parser.h"
-
-jsil_parsert jsil_parser;
-
-extern char *yyjsiltext;
-
-int yyjsilerror(const std::string &error)
-{
-  jsil_parser.parse_error(error, yyjsiltext);
-  return 0;
-}

--- a/src/jsil/jsil_parser.h
+++ b/src/jsil/jsil_parser.h
@@ -16,16 +16,24 @@ Author: Michael Tautschnig, tautschn@amazon.com
 
 #include "jsil_parse_tree.h"
 
-int yyjsilparse();
+class jsil_parsert;
+int yyjsilparse(jsil_parsert &);
+void jsil_scanner_init(jsil_parsert &);
 
 class jsil_parsert:public parsert
 {
 public:
+  explicit jsil_parsert(message_handlert &message_handler)
+    : parsert(message_handler)
+  {
+  }
+
   jsil_parse_treet parse_tree;
 
   virtual bool parse() override
   {
-    return yyjsilparse()!=0;
+    jsil_scanner_init(*this);
+    return yyjsilparse(*this) != 0;
   }
 
   virtual void clear() override
@@ -40,10 +48,5 @@ public:
   // internal state of the scanner
   std::string string_literal;
 };
-
-extern jsil_parsert jsil_parser;
-
-int yyjsilerror(const std::string &error);
-void jsil_scanner_init();
 
 #endif // CPROVER_JSIL_JSIL_PARSER_H

--- a/src/jsil/parser.y
+++ b/src/jsil/parser.y
@@ -1,12 +1,26 @@
 %{
 
 // #define YYDEBUG 1
-#define PARSER jsil_parser
+#define PARSER (*jsil_parser)
 
 #include "jsil_parser.h"
 
 int yyjsillex();
 extern char *yyjsiltext;
+
+static jsil_parsert *jsil_parser;
+int yyjsilparse(void);
+int yyjsilparse(jsil_parsert &_jsil_parser)
+{
+  jsil_parser = &_jsil_parser;
+  return yyjsilparse();
+}
+
+int yyjsilerror(const std::string &error)
+{
+  jsil_parser->parse_error(error, yyjsiltext);
+  return 0;
+}
 
 #define YYSTYPE unsigned
 #define YYSTYPE_IS_TRIVIAL 1

--- a/src/jsil/scanner.l
+++ b/src/jsil/scanner.l
@@ -17,12 +17,22 @@
 #include <ansi-c/literals/convert_float_literal.h>
 #include <ansi-c/literals/convert_string_literal.h>
 
-#define PARSER jsil_parser
+#define PARSER (*jsil_parser)
 #define YYSTYPE unsigned
 
 #include "jsil_parser.h"
 #include "jsil_y.tab.h"
 // extern int yyjsildebug;
+
+static jsil_parsert *jsil_parser;
+void jsil_scanner_init(jsil_parsert &_jsil_parser)
+{
+  jsil_parser = &_jsil_parser;
+  YY_FLUSH_BUFFER;
+  BEGIN(0);
+}
+
+int yyjsilerror(const std::string &error);
 
 #define loc() \
   { newstack(yyjsillval); PARSER.set_source_location(parser_stack(yyjsillval)); }
@@ -71,14 +81,6 @@ string_lit      ["]{s_char}*["]
 %x STRING_LITERAL_COMMENT
 %x STATEMENTS
 
-%{
-void jsil_scanner_init()
-{
-  // yyjsildebug=1;
-  YY_FLUSH_BUFFER;
-  BEGIN(0);
-}
-%}
  /* %option debug */
 
 %%

--- a/src/util/parser.h
+++ b/src/util/parser.h
@@ -12,6 +12,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #ifndef CPROVER_UTIL_PARSER_H
 #define CPROVER_UTIL_PARSER_H
 
+#include "deprecate.h"
 #include "expr.h"
 #include "message.h"
 
@@ -39,7 +40,13 @@ public:
     last_line.clear();
   }
 
+  DEPRECATED(SINCE(2023, 12, 20, "use parsert(message_handler) instead"))
   parsert():in(nullptr) { clear(); }
+  explicit parsert(message_handlert &message_handler)
+    : in(nullptr), log(message_handler)
+  {
+    clear();
+  }
   virtual ~parsert() { }
 
   // The following are for the benefit of the scanner


### PR DESCRIPTION
This both avoids an object of static lifetime as well as it fixes the (transitive) use of the deprecated messaget() constructor.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
