### PR TITLE
json_parsert: construct with message handler

### DIFF
--- a/src/json/json_parser.cpp
+++ b/src/json/json_parser.cpp
@@ -10,7 +10,18 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <fstream>
 
-json_parsert json_parser;
+int yyjsonlex_init_extra(json_parsert *, void **);
+int yyjsonlex_destroy(void *);
+int yyjsonparse(json_parsert &, void *);
+
+bool json_parsert::parse()
+{
+  void *scanner;
+  yyjsonlex_init_extra(this, &scanner);
+  bool parse_fail = yyjsonparse(*this, scanner) != 0;
+  yyjsonlex_destroy(scanner);
+  return parse_fail;
+}
 
 // 'do it all' function
 bool parse_json(
@@ -19,10 +30,10 @@ bool parse_json(
   message_handlert &message_handler,
   jsont &dest)
 {
-  json_parser.clear();
+  json_parsert json_parser{message_handler};
+
   json_parser.set_file(filename);
   json_parser.in=&in;
-  json_parser.log.set_message_handler(message_handler);
 
   bool result=json_parser.parse();
 

--- a/src/json/json_parser.h
+++ b/src/json/json_parser.h
@@ -15,21 +15,20 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/parser.h>
 #include <util/json.h>
 
-int yyjsonparse();
-void yyjsonrestart(FILE *input_file);
-
 class json_parsert:public parsert
 {
 public:
+  explicit json_parsert(message_handlert &message_handler)
+    : parsert(message_handler)
+  {
+  }
+
   typedef std::stack<jsont, std::vector<jsont> > stackt;
   stackt stack;
 
   jsont &top() { return stack.top(); }
 
-  virtual bool parse() override
-  {
-    return yyjsonparse()!=0;
-  }
+  bool parse() override;
 
   void push(const jsont &x)
   {
@@ -46,13 +45,8 @@ public:
   virtual void clear() override
   {
     stack=stackt();
-    yyjsonrestart(nullptr);
   }
 };
-
-extern json_parsert json_parser;
-
-int yyjsonerror(const std::string &error);
 
 // 'do it all' functions
 bool parse_json(

--- a/src/json/scanner.l
+++ b/src/json/scanner.l
@@ -11,8 +11,9 @@
 %option noinput
 %option nounistd
 %option never-interactive
-
 %option noyywrap
+%option reentrant
+%option extra-type="json_parsert *"
 
 %{
 
@@ -24,7 +25,7 @@
 #pragma warning(disable:4005)
 #endif
 
-#define PARSER json_parser
+#define PARSER (*yyextra)
 
 #include "json_parser.h"
 #include "json_y.tab.h"


### PR DESCRIPTION
This both avoids an object of static lifetime as well as it fixes the (transitive) use of the deprecated messaget() constructor.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
