### PR TITLE
java_bytecode_parsert: construct with message handler

### DIFF
--- a/jbmc/src/java_bytecode/java_bytecode_parser.cpp
+++ b/jbmc/src/java_bytecode/java_bytecode_parser.cpp
@@ -27,8 +27,10 @@ Author: Daniel Kroening, kroening@kroening.com
 class java_bytecode_parsert final : public parsert
 {
 public:
-  explicit java_bytecode_parsert(bool skip_instructions)
-    : skip_instructions(skip_instructions)
+  java_bytecode_parsert(
+    bool skip_instructions,
+    message_handlert &message_handler)
+    : parsert(message_handler), skip_instructions(skip_instructions)
   {
   }
 
@@ -1809,9 +1811,9 @@ std::optional<java_bytecode_parse_treet> java_bytecode_parse(
   message_handlert &message_handler,
   bool skip_instructions)
 {
-  java_bytecode_parsert java_bytecode_parser(skip_instructions);
+  java_bytecode_parsert java_bytecode_parser(
+    skip_instructions, message_handler);
   java_bytecode_parser.in=&istream;
-  java_bytecode_parser.log.set_message_handler(message_handler);
 
   bool parser_result=java_bytecode_parser.parse();
 


### PR DESCRIPTION
This both avoids an object of static lifetime as well as it fixes the (transitive) use of the deprecated messaget() constructor.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
