### PR TITLE
ansi_c_parsert: construct with message handler

### DIFF
--- a/regression/cbmc/fault_localization-all_properties2/test.desc
+++ b/regression/cbmc/fault_localization-all_properties2/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+FUTURE
 main.c
 --localize-faults
 ^EXIT=10$
@@ -8,4 +8,6 @@ line 9 function main$
 --
 --
 CBMC wrongly reports line 7 as the faulty statement when instead it should be
-line 9.
+line 9. The test is marked as "FUTURE" as it will sometimes pass, depending on
+what model the solver produces. It would, therefore, break our checking of
+"KNOWNBUG" tests.

--- a/src/ansi-c/ansi_c_parser.cpp
+++ b/src/ansi-c/ansi_c_parser.cpp
@@ -10,7 +10,22 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "c_storage_spec.h"
 
-ansi_c_parsert ansi_c_parser;
+int yyansi_clex_init_extra(ansi_c_parsert *, void **);
+int yyansi_clex_destroy(void *);
+int yyansi_cparse(ansi_c_parsert &, void *);
+void yyansi_cset_debug(int, void *);
+
+bool ansi_c_parsert::parse()
+{
+  void *scanner;
+  yyansi_clex_init_extra(this, &scanner);
+#ifdef ANSI_C_DEBUG
+  yyansi_cset_debug(1, scanner);
+#endif
+  bool parse_fail = yyansi_cparse(*this, scanner) != 0;
+  yyansi_clex_destroy(scanner);
+  return parse_fail;
+}
 
 ansi_c_id_classt ansi_c_parsert::lookup(
   const irep_idt &base_name,
@@ -71,14 +86,6 @@ void ansi_c_parsert::add_tag_with_body(irept &tag)
     identifier.prefixed_name=prefixed_name;
     tag.set(ID_identifier, prefixed_name);
   }
-}
-
-extern char *yyansi_ctext;
-
-int yyansi_cerror(const std::string &error)
-{
-  ansi_c_parser.parse_error(error, yyansi_ctext);
-  return 0;
 }
 
 void ansi_c_parsert::add_declarator(

--- a/src/ansi-c/ansi_c_parser.h
+++ b/src/ansi-c/ansi_c_parser.h
@@ -18,15 +18,14 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "ansi_c_parse_tree.h"
 #include "ansi_c_scope.h"
 
-int yyansi_cparse();
-
 class ansi_c_parsert:public parsert
 {
 public:
   ansi_c_parse_treet parse_tree;
 
-  ansi_c_parsert()
-    : tag_following(false),
+  explicit ansi_c_parsert(message_handlert &message_handler)
+    : parsert(message_handler),
+      tag_following(false),
       asm_block_following(false),
       parenthesis_counter(0),
       mode(modet::NONE),
@@ -37,14 +36,14 @@ public:
       float16_type(false),
       bf16_type(false)
   {
+    // set up global scope
+    scopes.clear();
+    scopes.push_back(scopet());
   }
 
-  virtual bool parse() override
-  {
-    return yyansi_cparse()!=0;
-  }
+  bool parse() override;
 
-  virtual void clear() override
+  void clear() override
   {
     parsert::clear();
     parse_tree.clear();
@@ -169,10 +168,5 @@ public:
 private:
   std::list<std::map<const irep_idt, bool>> pragma_cprover_stack;
 };
-
-extern ansi_c_parsert ansi_c_parser;
-
-int yyansi_cerror(const std::string &error);
-void ansi_c_scanner_init();
 
 #endif // CPROVER_ANSI_C_ANSI_C_PARSER_H

--- a/src/ansi-c/builtin_factory.cpp
+++ b/src/ansi-c/builtin_factory.cpp
@@ -47,16 +47,16 @@ static bool convert(
 {
   std::istringstream in(s.str());
 
-  ansi_c_parser.clear();
+  ansi_c_parsert ansi_c_parser{message_handler};
   ansi_c_parser.set_file(ID_built_in);
   ansi_c_parser.in=&in;
-  ansi_c_parser.log.set_message_handler(message_handler);
   ansi_c_parser.for_has_scope=config.ansi_c.for_has_scope;
+  ansi_c_parser.ts_18661_3_Floatn_types = config.ansi_c.ts_18661_3_Floatn_types;
+  ansi_c_parser.float16_type = config.ansi_c.float16_type;
+  ansi_c_parser.bf16_type = config.ansi_c.bf16_type;
   ansi_c_parser.cpp98=false; // it's not C++
   ansi_c_parser.cpp11=false; // it's not C++
   ansi_c_parser.mode=config.ansi_c.mode;
-
-  ansi_c_scanner_init();
 
   if(ansi_c_parser.parse())
     return true;

--- a/src/ansi-c/parser.y
+++ b/src/ansi-c/parser.y
@@ -17,8 +17,17 @@
 
 #include "ansi_c_parser.h"
 
-int yyansi_clex();
-extern char *yyansi_ctext;
+int yyansi_clex(void *);
+char *yyansi_cget_text(void *);
+
+int yyansi_cerror(
+  ansi_c_parsert &ansi_c_parser,
+  void *scanner,
+  const std::string &error)
+{
+  ansi_c_parser.parse_error(error, yyansi_cget_text(scanner));
+  return 0;
+}
 
 #include "parser_static.inc"
 
@@ -44,9 +53,13 @@ extern char *yyansi_ctext;
 // statements have right recursion, deep nesting of statements thus
 // requires more stack space
 #define YYMAXDEPTH 25600
+%}
+
+%parse-param {ansi_c_parsert &ansi_c_parser}
+%parse-param {void *scanner}
+%lex-param {void *scanner}
 
 /*** token declaration **************************************************/
-%}
 
 /*** ANSI-C keywords ***/
 
@@ -358,7 +371,7 @@ generic_selection:
           TOK_GENERIC '(' assignment_expression ',' generic_assoc_list ')'
         {
           $$=$1;
-          set($$, ID_generic_selection);
+          set(PARSER, $$, ID_generic_selection);
           mto($$, $3);
           parser_stack($$).add(ID_generic_associations).get_sub().swap((irept::subt&)parser_stack($5).operands());
         }
@@ -367,7 +380,7 @@ generic_selection:
 generic_assoc_list:
           generic_association
         {
-          init($$); mto($$, $1);
+          init(PARSER, $$); mto($$, $1);
         }
         | generic_assoc_list ',' generic_association
         {
@@ -445,7 +458,7 @@ offsetof:
 offsetof_member_designator:
           member_name
         {
-          init($$);
+          init(PARSER, $$);
           exprt op{ID_member};
           op.add_source_location()=parser_stack($1).source_location();
           op.set(ID_component_name, parser_stack($1).get(ID_C_base_name));
@@ -454,24 +467,24 @@ offsetof_member_designator:
         | offsetof_member_designator '.' member_name
         {
           $$=$1;
-          set($2, ID_member);
+          set(PARSER, $2, ID_member);
           parser_stack($2).set(ID_component_name, parser_stack($3).get(ID_C_base_name));
           mto($$, $2);
         }
         | offsetof_member_designator '[' comma_expression ']'
         {
           $$=$1;
-          set($2, ID_index);
+          set(PARSER, $2, ID_index);
           mto($2, $3);
           mto($$, $2);
         }
         | offsetof_member_designator TOK_ARROW member_name
         {
           $$=$1;
-          set($2, ID_index);
+          set(PARSER, $2, ID_index);
           parser_stack($2).add_to_operands(convert_integer_literal("0"));
           mto($$, $2);
-          set($2, ID_member);
+          set(PARSER, $2, ID_member);
           parser_stack($2).set(ID_component_name, parser_stack($3).get(ID_C_base_name));
           mto($$, $2);
         }
@@ -481,7 +494,7 @@ quantifier_expression:
           TOK_FORALL compound_scope '{' declaration comma_expression '}'
         {
           $$=$1;
-          set($$, ID_forall);
+          set(PARSER, $$, ID_forall);
           parser_stack($$).add_to_operands(tuple_exprt( { std::move(parser_stack($4)) } ));
           mto($$, $5);
           PARSER.pop_scope();
@@ -489,7 +502,7 @@ quantifier_expression:
         | TOK_EXISTS compound_scope '{' declaration comma_expression '}'
         {
           $$=$1;
-          set($$, ID_exists);
+          set(PARSER, $$, ID_exists);
           parser_stack($$).add_to_operands(tuple_exprt( { std::move(parser_stack($4)) } ));
           mto($$, $5);
           PARSER.pop_scope();
@@ -503,27 +516,27 @@ cprover_contract_loop_invariant:
 
 cprover_contract_loop_invariant_list:
           cprover_contract_loop_invariant
-        { init($$); mto($$, $1); }
+        { init(PARSER, $$); mto($$, $1); }
         | cprover_contract_loop_invariant_list cprover_contract_loop_invariant
         { $$=$1; mto($$, $2); }
         ;
 
 cprover_contract_loop_invariant_list_opt:
         /* nothing */
-        { init($$); parser_stack($$).make_nil(); }
+        { init(PARSER, $$); parser_stack($$).make_nil(); }
         | cprover_contract_loop_invariant_list
         ;
 
 ACSL_binding_expression_list:
           ACSL_binding_expression
-        { init($$); mto($$, $1); }
+        { init(PARSER, $$); mto($$, $1); }
         | ACSL_binding_expression_list ',' ACSL_binding_expression
         { $$=$1; mto($$, $3); }
         ;
 
 cprover_contract_decreases_opt:
         /* nothing */
-        { init($$); parser_stack($$).make_nil(); }
+        { init(PARSER, $$); parser_stack($$).make_nil(); }
         | TOK_CPROVER_DECREASES '(' ACSL_binding_expression_list ')'
         { $$=$3; }
         ;
@@ -531,7 +544,7 @@ cprover_contract_decreases_opt:
 statement_expression: '(' compound_statement ')'
         { 
           $$=$1;
-          set($$, ID_side_effect);
+          set(PARSER, $$, ID_side_effect);
           parser_stack($$).set(ID_statement, ID_statement_expression);
           mto($$, $2);
         }
@@ -543,7 +556,7 @@ postfix_expression:
         { binary($$, $1, $2, ID_index, $3); }
         | postfix_expression '(' ')'
         { $$=$2;
-          set($$, ID_side_effect);
+          set(PARSER, $$, ID_side_effect);
           auto &side_effect = to_side_effect_expr(parser_stack($$));
           side_effect.set_statement(ID_function_call);
           side_effect.operands().resize(2);
@@ -553,7 +566,7 @@ postfix_expression:
         }
         | postfix_expression '(' argument_expression_list ')'
         { $$=$2;
-          set($$, ID_side_effect);
+          set(PARSER, $$, ID_side_effect);
           auto &side_effect = to_side_effect_expr(parser_stack($$));
           side_effect.set_statement(ID_function_call);
           side_effect.operands().resize(2);
@@ -563,25 +576,25 @@ postfix_expression:
         }
         | postfix_expression '.' member_name
         { $$=$2;
-          set($$, ID_member);
+          set(PARSER, $$, ID_member);
           mto($$, $1);
           parser_stack($$).set(ID_component_name, parser_stack($3).get(ID_C_base_name));
         }
         | postfix_expression TOK_ARROW member_name
         { $$=$2;
-          set($$, ID_ptrmember);
+          set(PARSER, $$, ID_ptrmember);
           mto($$, $1);
           parser_stack($$).set(ID_component_name, parser_stack($3).get(ID_C_base_name));
         }
         | postfix_expression TOK_INCR
         { $$=$2;
-          set($$, ID_side_effect);
+          set(PARSER, $$, ID_side_effect);
           parser_stack($$).set(ID_statement, ID_postincrement);
           mto($$, $1);
         }
         | postfix_expression TOK_DECR
         { $$=$2;
-          set($$, ID_side_effect);
+          set(PARSER, $$, ID_side_effect);
           parser_stack($$).set(ID_statement, ID_postdecrement);
           mto($$, $1);
         }
@@ -592,7 +605,7 @@ postfix_expression:
           tmp.add_source_location()=parser_stack($4).source_location();
           tmp.operands().swap(parser_stack($5).operands());
           $$=$1;
-          set($$, ID_typecast);
+          set(PARSER, $$, ID_typecast);
           parser_stack($$).add_to_operands(std::move(tmp));
           parser_stack($$).type().swap(parser_stack($2));
         }
@@ -603,7 +616,7 @@ postfix_expression:
           tmp.add_source_location()=parser_stack($4).source_location();
           tmp.operands().swap(parser_stack($5).operands());
           $$=$1;
-          set($$, ID_typecast);
+          set(PARSER, $$, ID_typecast);
           parser_stack($$).add_to_operands(std::move(tmp));
           parser_stack($$).type().swap(parser_stack($2));
         }
@@ -617,7 +630,7 @@ member_name:
 argument_expression_list:
           assignment_expression
         {
-          init($$, ID_expression_list);
+          init(PARSER, $$, ID_expression_list);
           mto($$, $1);
         }
         | argument_expression_list ',' assignment_expression
@@ -631,26 +644,26 @@ unary_expression:
           postfix_expression
         | TOK_INCR unary_expression
         { $$=$1;
-          set($$, ID_side_effect);
+          set(PARSER, $$, ID_side_effect);
           parser_stack($$).set(ID_statement, ID_preincrement);
           mto($$, $2);
         }
         | TOK_DECR unary_expression
         { $$=$1;
-          set($$, ID_side_effect);
+          set(PARSER, $$, ID_side_effect);
           parser_stack($$).set(ID_statement, ID_predecrement);
           mto($$, $2);
         }
         | '&' cast_expression
         { $$=$1;
-          set($$, ID_address_of);
+          set(PARSER, $$, ID_address_of);
           mto($$, $2);
         }
         | TOK_ANDAND gcc_local_label
         { // this takes the address of a label (a gcc extension)
           $$=$1;
           irep_idt identifier=PARSER.lookup_label(parser_stack($2).get(ID_C_base_name));
-          set($$, ID_address_of);
+          set(PARSER, $$, ID_address_of);
           parser_stack($$).operands().resize(1);
           auto &op = to_unary_expr(parser_stack($$)).op();
           op=parser_stack($2);
@@ -659,43 +672,43 @@ unary_expression:
         }
         | '*' cast_expression
         { $$=$1;
-          set($$, ID_dereference);
+          set(PARSER, $$, ID_dereference);
           mto($$, $2);
         }
         | '+' cast_expression
         { $$=$1;
-          set($$, ID_unary_plus);
+          set(PARSER, $$, ID_unary_plus);
           mto($$, $2);
         }
         | '-' cast_expression
         { $$=$1;
-          set($$, ID_unary_minus);
+          set(PARSER, $$, ID_unary_minus);
           mto($$, $2);
         }
         | '~' cast_expression
         { $$=$1;
-          set($$, ID_bitnot);
+          set(PARSER, $$, ID_bitnot);
           mto($$, $2);
         }
         | '!' cast_expression
         { $$=$1;
-          set($$, ID_not);
+          set(PARSER, $$, ID_not);
           mto($$, $2);
         }
         | TOK_SIZEOF unary_expression
         { $$=$1;
-          set($$, ID_sizeof);
+          set(PARSER, $$, ID_sizeof);
           mto($$, $2);
         }
         | TOK_SIZEOF '(' type_name ')'
         { $$=$1;
-          set($$, ID_sizeof);
+          set(PARSER, $$, ID_sizeof);
           parser_stack($$).add(ID_type_arg).swap(parser_stack($3));
         }
         | TOK_ALIGNOF unary_expression
         { // note no parentheses for expressions, just like sizeof
           $$=$1;
-          set($$, ID_alignof);
+          set(PARSER, $$, ID_alignof);
           mto($$, $2);
         }
         | TOK_ALIGNOF '(' type_name ')'
@@ -711,18 +724,18 @@ cast_expression:
         | '(' type_name ')' cast_expression
         {
           $$=$1;
-          set($$, ID_typecast);
+          set(PARSER, $$, ID_typecast);
           mto($$, $4);
           parser_stack($$).type().swap(parser_stack($2));
         }
         | TOK_REAL cast_expression
         { $$=$1;
-          set($$, ID_complex_real);
+          set(PARSER, $$, ID_complex_real);
           mto($$, $2);
         }
         | TOK_IMAG cast_expression
         { $$=$1;
-          set($$, ID_complex_imag);
+          set(PARSER, $$, ID_complex_imag);
           mto($$, $2);
         }
         ;
@@ -833,7 +846,7 @@ ACSL_binding_expression:
         | TOK_ACSL_FORALL compound_scope declaration ACSL_binding_expression
         {
           $$=$1;
-          set($$, ID_forall);
+          set(PARSER, $$, ID_forall);
           parser_stack($$).add_to_operands(tuple_exprt( { std::move(parser_stack($3)) } ));
           mto($$, $4);
           PARSER.pop_scope();
@@ -841,7 +854,7 @@ ACSL_binding_expression:
         | TOK_ACSL_EXISTS compound_scope declaration ACSL_binding_expression
         {
           $$=$1;
-          set($$, ID_exists);
+          set(PARSER, $$, ID_exists);
           parser_stack($$).add_to_operands(tuple_exprt( { std::move(parser_stack($3)) } ));
           mto($$, $4);
           PARSER.pop_scope();
@@ -849,7 +862,7 @@ ACSL_binding_expression:
         | TOK_ACSL_LAMBDA compound_scope declaration ACSL_binding_expression
         {
           $$=$1;
-          set($$, ID_lambda);
+          set(PARSER, $$, ID_lambda);
           parser_stack($$).add_to_operands(tuple_exprt( { std::move(parser_stack($3)) } ));
           mto($$, $4);
           PARSER.pop_scope();
@@ -912,7 +925,7 @@ constant_expression:
 
 comma_expression_opt:
         /* nothing */
-        { init($$); parser_stack($$).make_nil(); }
+        { init(PARSER, $$); parser_stack($$).make_nil(); }
         | comma_expression
         ;
 
@@ -922,13 +935,13 @@ declaration:
           declaration_specifier ';'
         {
           // type only, no declarator!
-          init($$, ID_declaration);
+          init(PARSER, $$, ID_declaration);
           parser_stack($$).type().swap(parser_stack($1));
         }
         | type_specifier ';'
         {
           // type only, no identifier!
-          init($$, ID_declaration);
+          init(PARSER, $$, ID_declaration);
           parser_stack($$).type().swap(parser_stack($1));
         }
         | static_assert_declaration ';'
@@ -940,7 +953,7 @@ static_assert_declaration:
           TOK_STATIC_ASSERT '(' assignment_expression ',' assignment_expression ')'
         {
           $$=$1;
-          set($$, ID_declaration);
+          set(PARSER, $$, ID_declaration);
           to_ansi_c_declaration(parser_stack($$)).set_is_static_assert(true);
           mto($$, $3);
           mto($$, $5);
@@ -950,7 +963,7 @@ static_assert_declaration:
 default_declaring_list:
           declaration_qualifier_list identifier_declarator
           {
-            init($$, ID_declaration);
+            init(PARSER, $$, ID_declaration);
             parser_stack($$).type().swap(parser_stack($1));
             PARSER.add_declarator(parser_stack($$), parser_stack($2));
           }
@@ -962,7 +975,7 @@ default_declaring_list:
         }
         | type_qualifier_list identifier_declarator
           {
-            init($$, ID_declaration);
+            init(PARSER, $$, ID_declaration);
             parser_stack($$).type().swap(parser_stack($1));
             PARSER.add_declarator(parser_stack($$), parser_stack($2));
           }
@@ -1001,7 +1014,7 @@ post_declarator_attribute:
 post_declarator_attributes:
           post_declarator_attributes post_declarator_attribute
         {
-          $$=merge($1, $2);
+          $$=merge(PARSER, $1, $2);
         }
         | post_declarator_attribute
         ;
@@ -1009,7 +1022,7 @@ post_declarator_attributes:
 post_declarator_attributes_opt:
           /* nothing */
         {
-          init($$);
+          init(PARSER, $$);
         }
         | post_declarator_attributes
         ;
@@ -1018,10 +1031,10 @@ declaring_list:
           declaration_specifier declarator
           post_declarator_attributes_opt
           {
-            $2=merge($3, $2); // type attribute
+            $2=merge(PARSER, $3, $2); // type attribute
             
             // the symbol has to be visible during initialization
-            init($$, ID_declaration);
+            init(PARSER, $$, ID_declaration);
             parser_stack($$).type().swap(parser_stack($1));
             PARSER.add_declarator(parser_stack($$), parser_stack($2));
           }
@@ -1034,10 +1047,10 @@ declaring_list:
         | type_specifier declarator
           post_declarator_attributes_opt
           {
-            $2=merge($3, $2);
+            $2=merge(PARSER, $3, $2);
             
             // the symbol has to be visible during initialization
-            init($$, ID_declaration);
+            init(PARSER, $$, ID_declaration);
             parser_stack($$).type().swap(parser_stack($1));
             PARSER.add_declarator(parser_stack($$), parser_stack($2));
           }
@@ -1054,10 +1067,10 @@ declaring_list:
           parser_stack($1).id(ID_typeof);
           parser_stack($1).copy_to_operands(parser_stack($5));
 
-          $2=merge($3, $2);
+          $2=merge(PARSER, $3, $2);
 
           // the symbol has to be visible during initialization
-          init($$, ID_declaration);
+          init(PARSER, $$, ID_declaration);
           parser_stack($$).type().swap(parser_stack($1));
           PARSER.add_declarator(parser_stack($$), parser_stack($2));
           // add the initializer
@@ -1067,8 +1080,8 @@ declaring_list:
           post_declarator_attributes_opt
           {
             // type attribute goes into declarator
-            $5=merge($5, $3);
-            $4=merge($5, $4);
+            $5=merge(PARSER, $5, $3);
+            $4=merge(PARSER, $5, $4);
             PARSER.add_declarator(parser_stack($1), parser_stack($4));
           }
           initializer_opt
@@ -1099,16 +1112,16 @@ declaration_qualifier_list:
           storage_class
         | type_qualifier_list storage_class
         {
-          $$=merge($1, $2);
+          $$=merge(PARSER, $1, $2);
         }
         | gcc_attribute_specifier
         | declaration_qualifier_list gcc_attribute_specifier
         {
-          $$=merge($1, $2);
+          $$=merge(PARSER, $1, $2);
         }
         | declaration_qualifier_list declaration_qualifier
         {
-          $$=merge($1, $2);
+          $$=merge(PARSER, $1, $2);
         }
         ;
 
@@ -1116,14 +1129,14 @@ type_qualifier_list:
           type_qualifier
         | type_qualifier_list type_qualifier
         {
-          $$=merge($1, $2);
+          $$=merge(PARSER, $1, $2);
         }
         /* The following is to allow mixing of type attributes with
            type qualifiers, but the list has to start with a
            proper type qualifier. */
         | type_qualifier_list gcc_attribute_specifier
         {
-          $$=merge($1, $2);
+          $$=merge(PARSER, $1, $2);
         }
         ;
 
@@ -1131,7 +1144,7 @@ attribute_type_qualifier_list:
           attribute_or_type_qualifier
         | attribute_type_qualifier_list attribute_or_type_qualifier
         {
-          $$=merge($1, $2);
+          $$=merge(PARSER, $1, $2);
         }
         ;
 
@@ -1141,14 +1154,14 @@ declaration_qualifier:
         ;
 
 type_qualifier:
-          TOK_ATOMIC_TYPE_QUALIFIER { $$=$1; set($$, ID_atomic); }
-        | TOK_CONST                 { $$=$1; set($$, ID_const); }
-        | TOK_RESTRICT              { $$=$1; set($$, ID_restrict); }
-        | TOK_VOLATILE              { $$=$1; set($$, ID_volatile); }
-        | TOK_CPROVER_ATOMIC        { $$=$1; set($$, ID_cprover_atomic); }
-        | TOK_PTR32                 { $$=$1; set($$, ID_ptr32); }
-        | TOK_PTR64                 { $$=$1; set($$, ID_ptr64); }
-        | TOK_MSC_BASED '(' comma_expression ')' { $$=$1; set($$, ID_msc_based); mto($$, $3); }
+          TOK_ATOMIC_TYPE_QUALIFIER { $$=$1; set(PARSER, $$, ID_atomic); }
+        | TOK_CONST                 { $$=$1; set(PARSER, $$, ID_const); }
+        | TOK_RESTRICT              { $$=$1; set(PARSER, $$, ID_restrict); }
+        | TOK_VOLATILE              { $$=$1; set(PARSER, $$, ID_volatile); }
+        | TOK_CPROVER_ATOMIC        { $$=$1; set(PARSER, $$, ID_cprover_atomic); }
+        | TOK_PTR32                 { $$=$1; set(PARSER, $$, ID_ptr32); }
+        | TOK_PTR64                 { $$=$1; set(PARSER, $$, ID_ptr64); }
+        | TOK_MSC_BASED '(' comma_expression ')' { $$=$1; set(PARSER, $$, ID_msc_based); mto($$, $3); }
         | alignas_specifier
         ;
 
@@ -1180,60 +1193,60 @@ attribute_type_qualifier_storage_class_list:
           attribute_or_type_qualifier_or_storage_class
         | attribute_type_qualifier_storage_class_list attribute_or_type_qualifier_or_storage_class
         {
-          $$=merge($1, $2);
+          $$=merge(PARSER, $1, $2);
         }
         ;
 
 basic_declaration_specifier:
           declaration_qualifier_list basic_type_name gcc_type_attribute_opt
         {
-          $$=merge($1, merge($2, $3));
+          $$=merge(PARSER, $1, merge(PARSER, $2, $3));
         }
         | basic_type_specifier storage_class gcc_type_attribute_opt
         {
-          $$=merge($1, merge($2, $3));
+          $$=merge(PARSER, $1, merge(PARSER, $2, $3));
         }
         | basic_declaration_specifier declaration_qualifier gcc_type_attribute_opt
         {
-          $$=merge($1, merge($2, $3));
+          $$=merge(PARSER, $1, merge(PARSER, $2, $3));
         }
         | basic_declaration_specifier basic_type_name gcc_type_attribute_opt
         {
-          $$=merge($1, merge($2, $3));
+          $$=merge(PARSER, $1, merge(PARSER, $2, $3));
         }
         ;
 
 basic_type_specifier:
           basic_type_name gcc_type_attribute_opt
         {
-          $$=merge($1, $2); // type attribute
+          $$=merge(PARSER, $1, $2); // type attribute
         }
         | type_qualifier_list basic_type_name gcc_type_attribute_opt
         {
-          $$=merge($1, merge($2, $3));
+          $$=merge(PARSER, $1, merge(PARSER, $2, $3));
         }
         | basic_type_specifier type_qualifier
         {
-          $$=merge($1, $2);
+          $$=merge(PARSER, $1, $2);
         }
         | basic_type_specifier basic_type_name gcc_type_attribute_opt
         {
-          $$=merge($1, merge($2, $3));
+          $$=merge(PARSER, $1, merge(PARSER, $2, $3));
         }
         ;
 
 sue_declaration_specifier:
           declaration_qualifier_list elaborated_type_name
         {
-          $$=merge($1, $2);
+          $$=merge(PARSER, $1, $2);
         }
         | sue_type_specifier storage_class gcc_type_attribute_opt
         {
-          $$=merge($1, merge($2, $3));
+          $$=merge(PARSER, $1, merge(PARSER, $2, $3));
         }
         | sue_declaration_specifier declaration_qualifier gcc_type_attribute_opt
         {
-          $$=merge($1, merge($2, $3));
+          $$=merge(PARSER, $1, merge(PARSER, $2, $3));
         }
         ;
 
@@ -1241,71 +1254,71 @@ sue_type_specifier:
           elaborated_type_name
         | type_qualifier_list elaborated_type_name
         {
-          $$=merge($1, $2);
+          $$=merge(PARSER, $1, $2);
         }
         | sue_type_specifier type_qualifier gcc_type_attribute_opt
         {
-          $$=merge($1, merge($2, $3));
+          $$=merge(PARSER, $1, merge(PARSER, $2, $3));
         }
         ;
 
 typedef_declaration_specifier:
           typedef_type_specifier storage_class gcc_type_attribute_opt
         {
-          $$=merge($1, merge($2, $3));
+          $$=merge(PARSER, $1, merge(PARSER, $2, $3));
         }
         | declaration_qualifier_list typedef_name gcc_type_attribute_opt
         {
-          $$=merge($1, merge($2, $3));
+          $$=merge(PARSER, $1, merge(PARSER, $2, $3));
         }
         | typedef_declaration_specifier declaration_qualifier gcc_type_attribute_opt
         {
-          $$=merge($1, merge($2, $3));
+          $$=merge(PARSER, $1, merge(PARSER, $2, $3));
         }
         ;
 
 typeof_declaration_specifier:
           typeof_type_specifier storage_class gcc_type_attribute_opt
         {
-          $$=merge($1, merge($2, $3));
+          $$=merge(PARSER, $1, merge(PARSER, $2, $3));
         }
         | declaration_qualifier_list typeof_specifier gcc_type_attribute_opt
         {
-          $$=merge($1, merge($2, $3));
+          $$=merge(PARSER, $1, merge(PARSER, $2, $3));
         }
         | typeof_declaration_specifier declaration_qualifier gcc_type_attribute_opt
         {
-          $$=merge($1, merge($2, $3));
+          $$=merge(PARSER, $1, merge(PARSER, $2, $3));
         }
         ;
 
 atomic_declaration_specifier:
           atomic_type_specifier storage_class gcc_type_attribute_opt
         {
-          $$=merge($1, merge($2, $3));
+          $$=merge(PARSER, $1, merge(PARSER, $2, $3));
         }
         | declaration_qualifier_list atomic_specifier gcc_type_attribute_opt
         {
-          $$=merge($1, merge($2, $3));
+          $$=merge(PARSER, $1, merge(PARSER, $2, $3));
         }
         | atomic_declaration_specifier declaration_qualifier gcc_type_attribute_opt
         {
-          $$=merge($1, merge($2, $3));
+          $$=merge(PARSER, $1, merge(PARSER, $2, $3));
         }
         ;
 
 typedef_type_specifier:
           typedef_name gcc_type_attribute_opt
         {
-          $$=merge($1, $2);
+          $$=merge(PARSER, $1, $2);
         }
         | type_qualifier_list typedef_name gcc_type_attribute_opt
         {
-          $$=merge($1, merge($2, $3));
+          $$=merge(PARSER, $1, merge(PARSER, $2, $3));
         }
         | typedef_type_specifier type_qualifier gcc_type_attribute_opt
         {
-          $$=merge($1, merge($2, $3));
+          $$=merge(PARSER, $1, merge(PARSER, $2, $3));
         }
         ;
 
@@ -1326,15 +1339,15 @@ typeof_type_specifier:
           typeof_specifier
         | type_qualifier_list typeof_specifier
         {
-          $$=merge($1, $2);
+          $$=merge(PARSER, $1, $2);
         }
         | type_qualifier_list typeof_specifier type_qualifier_list
         {
-          $$=merge($1, merge($2, $3));
+          $$=merge(PARSER, $1, merge(PARSER, $2, $3));
         }
         | typeof_specifier type_qualifier_list
         {
-          $$=merge($1, $2);
+          $$=merge(PARSER, $1, $2);
         }
         ;
 
@@ -1351,15 +1364,15 @@ atomic_type_specifier:
           atomic_specifier
         | type_qualifier_list atomic_specifier
         {
-          $$=merge($1, $2);
+          $$=merge(PARSER, $1, $2);
         }
         | type_qualifier_list atomic_specifier type_qualifier_list
         {
-          $$=merge($1, merge($2, $3));
+          $$=merge(PARSER, $1, merge(PARSER, $2, $3));
         }
         | atomic_specifier type_qualifier_list
         {
-          $$=merge($1, $2);
+          $$=merge(PARSER, $1, $2);
         }
         ;
 
@@ -1396,13 +1409,13 @@ msc_decl_modifier:
         {
           $$=$1; mto($$, $3); mto($$, $5); mto($$, $7); mto($$, $9);
         }
-        | ',' { init($$, ID_nil); }
+        | ',' { init(PARSER, $$, ID_nil); }
         ;
 
 msc_declspec_seq:
           msc_decl_modifier
         {
-          init($$); mto($$, $1);
+          init(PARSER, $$); mto($$, $1);
         }
         | msc_declspec_seq msc_decl_modifier
         {
@@ -1413,19 +1426,19 @@ msc_declspec_seq:
 msc_declspec:
           TOK_MSC_DECLSPEC '(' msc_declspec_seq ')'
         {
-          $$=$1; set($$, ID_msc_declspec);
+          $$=$1; set(PARSER, $$, ID_msc_declspec);
           parser_stack($$).operands().swap(parser_stack($3).operands());
         }
         | TOK_MSC_DECLSPEC '(' ')'
         {
-          $$=$1; set($$, ID_msc_declspec);
+          $$=$1; set(PARSER, $$, ID_msc_declspec);
         }
         ;
 
 msc_declspec_opt:
           /* blank */
         {
-          init($$, ID_nil);
+          init(PARSER, $$, ID_nil);
         }
         | msc_declspec_opt msc_declspec
         {
@@ -1444,85 +1457,85 @@ msc_declspec_opt:
         ;
 
 storage_class:
-          TOK_TYPEDEF      { $$=$1; set($$, ID_typedef); }
-        | TOK_EXTERN       { $$=$1; set($$, ID_extern); }
-        | TOK_STATIC       { $$=$1; set($$, ID_static); }
-        | TOK_AUTO         { $$=$1; set($$, ID_auto); }
-        | TOK_REGISTER     { $$=$1; set($$, ID_register); }
-        | TOK_INLINE       { $$=$1; set($$, ID_inline); }
-        | TOK_THREAD_LOCAL { $$=$1; set($$, ID_thread_local); }
-        | TOK_GCC_ASM      { $$=$1; set($$, ID_asm); }
+          TOK_TYPEDEF      { $$=$1; set(PARSER, $$, ID_typedef); }
+        | TOK_EXTERN       { $$=$1; set(PARSER, $$, ID_extern); }
+        | TOK_STATIC       { $$=$1; set(PARSER, $$, ID_static); }
+        | TOK_AUTO         { $$=$1; set(PARSER, $$, ID_auto); }
+        | TOK_REGISTER     { $$=$1; set(PARSER, $$, ID_register); }
+        | TOK_INLINE       { $$=$1; set(PARSER, $$, ID_inline); }
+        | TOK_THREAD_LOCAL { $$=$1; set(PARSER, $$, ID_thread_local); }
+        | TOK_GCC_ASM      { $$=$1; set(PARSER, $$, ID_asm); }
         | msc_declspec     { $$=$1; }
         | TOK_MSC_FORCEINLINE
         {
           // equivalent to always_inline, and seemingly also has the semantics
           // of extern inline in that multiple definitions can be provided in
           // the same translation unit
-          init($$);
-          set($$, ID_static);
-          set($1, ID_inline);
+          init(PARSER, $$);
+          set(PARSER, $$, ID_static);
+          set(PARSER, $1, ID_inline);
           #if 0
           // enable once always_inline support is reinstantiated
           $1=merge($1, $$);
 
-          init($$);
-          set($$, ID_always_inline);
-          $$=merge($1, $$);
+          init(PARSER, $$);
+          set(PARSER, $$, ID_always_inline);
+          $$=merge(PARSER, $1, $$);
           #else
-          $$=merge($1, $$);
+          $$=merge(PARSER, $1, $$);
           #endif
         }
         ;
 
 basic_type_name:
-          TOK_INT      { $$=$1; set($$, ID_int); }
-        | TOK_INT8     { $$=$1; set($$, ID_int8); }
-        | TOK_INT16    { $$=$1; set($$, ID_int16); }
-        | TOK_INT32    { $$=$1; set($$, ID_int32); }
-        | TOK_INT64    { $$=$1; set($$, ID_int64); }
-        | TOK_CHAR     { $$=$1; set($$, ID_char); }
-        | TOK_SHORT    { $$=$1; set($$, ID_short); }
-        | TOK_LONG     { $$=$1; set($$, ID_long); }
-        | TOK_FLOAT    { $$=$1; set($$, ID_float); }
-        | TOK_GCC_FLOAT16   { $$=$1; set($$, ID_gcc_float16); }
-        | TOK_GCC_FLOAT32   { $$=$1; set($$, ID_gcc_float32); }
-        | TOK_GCC_FLOAT32X  { $$=$1; set($$, ID_gcc_float32x); }
-        | TOK_GCC_FLOAT64   { $$=$1; set($$, ID_gcc_float64); }
-        | TOK_GCC_FLOAT64X  { $$=$1; set($$, ID_gcc_float64x); }
-        | TOK_GCC_FLOAT80   { $$=$1; set($$, ID_gcc_float80); }
-        | TOK_GCC_FLOAT128  { $$=$1; set($$, ID_gcc_float128); }
-        | TOK_GCC_FLOAT128X { $$=$1; set($$, ID_gcc_float128x); }
-        | TOK_GCC_INT128    { $$=$1; set($$, ID_gcc_int128); }
-        | TOK_GCC_DECIMAL32 { $$=$1; set($$, ID_gcc_decimal32); }
-        | TOK_GCC_DECIMAL64 { $$=$1; set($$, ID_gcc_decimal64); }
-        | TOK_GCC_DECIMAL128 { $$=$1; set($$, ID_gcc_decimal128); }
-        | TOK_DOUBLE   { $$=$1; set($$, ID_double); }
-        | TOK_SIGNED   { $$=$1; set($$, ID_signed); }
-        | TOK_UNSIGNED { $$=$1; set($$, ID_unsigned); }
-        | TOK_VOID     { $$=$1; set($$, ID_void); }
-        | TOK_BOOL     { $$=$1; set($$, ID_c_bool); }
-        | TOK_COMPLEX  { $$=$1; set($$, ID_complex); }
+          TOK_INT      { $$=$1; set(PARSER, $$, ID_int); }
+        | TOK_INT8     { $$=$1; set(PARSER, $$, ID_int8); }
+        | TOK_INT16    { $$=$1; set(PARSER, $$, ID_int16); }
+        | TOK_INT32    { $$=$1; set(PARSER, $$, ID_int32); }
+        | TOK_INT64    { $$=$1; set(PARSER, $$, ID_int64); }
+        | TOK_CHAR     { $$=$1; set(PARSER, $$, ID_char); }
+        | TOK_SHORT    { $$=$1; set(PARSER, $$, ID_short); }
+        | TOK_LONG     { $$=$1; set(PARSER, $$, ID_long); }
+        | TOK_FLOAT    { $$=$1; set(PARSER, $$, ID_float); }
+        | TOK_GCC_FLOAT16   { $$=$1; set(PARSER, $$, ID_gcc_float16); }
+        | TOK_GCC_FLOAT32   { $$=$1; set(PARSER, $$, ID_gcc_float32); }
+        | TOK_GCC_FLOAT32X  { $$=$1; set(PARSER, $$, ID_gcc_float32x); }
+        | TOK_GCC_FLOAT64   { $$=$1; set(PARSER, $$, ID_gcc_float64); }
+        | TOK_GCC_FLOAT64X  { $$=$1; set(PARSER, $$, ID_gcc_float64x); }
+        | TOK_GCC_FLOAT80   { $$=$1; set(PARSER, $$, ID_gcc_float80); }
+        | TOK_GCC_FLOAT128  { $$=$1; set(PARSER, $$, ID_gcc_float128); }
+        | TOK_GCC_FLOAT128X { $$=$1; set(PARSER, $$, ID_gcc_float128x); }
+        | TOK_GCC_INT128    { $$=$1; set(PARSER, $$, ID_gcc_int128); }
+        | TOK_GCC_DECIMAL32 { $$=$1; set(PARSER, $$, ID_gcc_decimal32); }
+        | TOK_GCC_DECIMAL64 { $$=$1; set(PARSER, $$, ID_gcc_decimal64); }
+        | TOK_GCC_DECIMAL128 { $$=$1; set(PARSER, $$, ID_gcc_decimal128); }
+        | TOK_DOUBLE   { $$=$1; set(PARSER, $$, ID_double); }
+        | TOK_SIGNED   { $$=$1; set(PARSER, $$, ID_signed); }
+        | TOK_UNSIGNED { $$=$1; set(PARSER, $$, ID_unsigned); }
+        | TOK_VOID     { $$=$1; set(PARSER, $$, ID_void); }
+        | TOK_BOOL     { $$=$1; set(PARSER, $$, ID_c_bool); }
+        | TOK_COMPLEX  { $$=$1; set(PARSER, $$, ID_complex); }
         | TOK_CPROVER_BITVECTOR '[' comma_expression ']'
         {
           $$=$1;
-          set($$, ID_custom_bv);
+          set(PARSER, $$, ID_custom_bv);
           parser_stack($$).add(ID_size).swap(parser_stack($3));
         }
         | TOK_CPROVER_FLOATBV '[' comma_expression ']' '[' comma_expression ']'
         {
           $$=$1;
-          set($$, ID_custom_floatbv);
+          set(PARSER, $$, ID_custom_floatbv);
           parser_stack($$).add(ID_size).swap(parser_stack($3));
           parser_stack($$).add(ID_f).swap(parser_stack($6));
         }
         | TOK_CPROVER_FIXEDBV '[' comma_expression ']' '[' comma_expression ']'
         {
           $$=$1;
-          set($$, ID_custom_fixedbv);
+          set(PARSER, $$, ID_custom_fixedbv);
           parser_stack($$).add(ID_size).swap(parser_stack($3));
           parser_stack($$).add(ID_f).swap(parser_stack($6));
         }
-        | TOK_CPROVER_BOOL { $$=$1; set($$, ID_proper_bool); }
+        | TOK_CPROVER_BOOL { $$=$1; set(PARSER, $$, ID_proper_bool); }
         ;
 
 elaborated_type_name:
@@ -1538,10 +1551,10 @@ array_of_construct:
 
 pragma_packed:
         {
-          init($$);
+          init(PARSER, $$);
           if(!PARSER.pragma_pack.empty() &&
              PARSER.pragma_pack.back().is_one())
-            set($$, ID_packed);
+            set(PARSER, $$, ID_packed);
         }
         ;
 
@@ -1561,7 +1574,7 @@ aggregate_name:
             (irept::subt &)parser_stack($6).operands());
 
           // throw in the gcc attributes
-          $$=merge($1, merge($2, merge($8, $9)));
+          $$=merge(PARSER, $1, merge(PARSER, $2, merge(PARSER, $8, $9)));
         }
         | aggregate_key
           gcc_type_attribute_opt
@@ -1581,7 +1594,7 @@ aggregate_name:
             (irept::subt &)parser_stack($7).operands());
 
           // throw in the gcc attributes
-          $$=merge($1, merge($2, merge($9, $10)));
+          $$=merge(PARSER, $1, merge(PARSER, $2, merge(PARSER, $9, $10)));
         }
         | aggregate_key
           gcc_type_attribute_opt
@@ -1595,57 +1608,57 @@ aggregate_name:
         {
           parser_stack($1).set(ID_components, ID_nil);
           // type attributes
-          $$=merge($1, merge($2, $6));
+          $$=merge(PARSER, $1, merge(PARSER, $2, $6));
         }
         ;
 
 aggregate_key:
           TOK_STRUCT
-        { $$=$1; set($$, ID_struct); }
+        { $$=$1; set(PARSER, $$, ID_struct); }
         | TOK_UNION
-        { $$=$1; set($$, ID_union); }
+        { $$=$1; set(PARSER, $$, ID_union); }
         ;
 
 gcc_type_attribute:
           TOK_GCC_ATTRIBUTE_PACKED
-        { $$=$1; set($$, ID_packed); }
+        { $$=$1; set(PARSER, $$, ID_packed); }
         | TOK_GCC_ATTRIBUTE_TRANSPARENT_UNION
-        { $$=$1; set($$, ID_transparent_union); }
+        { $$=$1; set(PARSER, $$, ID_transparent_union); }
         | TOK_GCC_ATTRIBUTE_VECTOR_SIZE '(' comma_expression ')'
-        { $$=$1; set($$, ID_frontend_vector); parser_stack($$).add(ID_size)=parser_stack($3); }
+        { $$=$1; set(PARSER, $$, ID_frontend_vector); parser_stack($$).add(ID_size)=parser_stack($3); }
         | TOK_GCC_ATTRIBUTE_ALIGNED
-        { $$=$1; set($$, ID_aligned); }
+        { $$=$1; set(PARSER, $$, ID_aligned); }
         | TOK_GCC_ATTRIBUTE_ALIGNED '(' comma_expression ')'
-        { $$=$1; set($$, ID_aligned); parser_stack($$).set(ID_size, parser_stack($3)); }
+        { $$=$1; set(PARSER, $$, ID_aligned); parser_stack($$).set(ID_size, parser_stack($3)); }
         | TOK_GCC_ATTRIBUTE_MODE '(' identifier ')'
-        { $$=$1; set($$, ID_gcc_attribute_mode); parser_stack($$).set(ID_size, parser_stack($3).get(ID_identifier)); }
+        { $$=$1; set(PARSER, $$, ID_gcc_attribute_mode); parser_stack($$).set(ID_size, parser_stack($3).get(ID_identifier)); }
         | TOK_GCC_ATTRIBUTE_GNU_INLINE
-        { $$=$1; set($$, ID_static); } /* GCC extern inline - cleanup in ansi_c_declarationt::to_symbol */
+        { $$=$1; set(PARSER, $$, ID_static); } /* GCC extern inline - cleanup in ansi_c_declarationt::to_symbol */
         | TOK_GCC_ATTRIBUTE_WEAK
-        { $$=$1; set($$, ID_weak); }
+        { $$=$1; set(PARSER, $$, ID_weak); }
         | TOK_GCC_ATTRIBUTE_ALIAS '(' TOK_STRING ')'
-        { $$=$1; set($$, ID_alias); mto($$, $3); }
+        { $$=$1; set(PARSER, $$, ID_alias); mto($$, $3); }
         | TOK_GCC_ATTRIBUTE_SECTION '(' TOK_STRING ')'
-        { $$=$1; set($$, ID_section); mto($$, $3); }
+        { $$=$1; set(PARSER, $$, ID_section); mto($$, $3); }
         | TOK_GCC_ATTRIBUTE_NORETURN
-        { $$=$1; set($$, ID_noreturn); }
+        { $$=$1; set(PARSER, $$, ID_noreturn); }
         | TOK_GCC_ATTRIBUTE_CONSTRUCTOR
-        { $$=$1; set($$, ID_constructor); }
+        { $$=$1; set(PARSER, $$, ID_constructor); }
         | TOK_GCC_ATTRIBUTE_DESTRUCTOR
-        { $$=$1; set($$, ID_destructor); }
+        { $$=$1; set(PARSER, $$, ID_destructor); }
         | TOK_GCC_ATTRIBUTE_USED
-        { $$=$1; set($$, ID_used); }
+        { $$=$1; set(PARSER, $$, ID_used); }
         ;
 
 gcc_attribute:
           /* empty */
         {
-          init($$);
+          init(PARSER, $$);
         }
         | TOK_GCC_ATTRIBUTE_FALLTHROUGH
         {
           // attribute ignored
-          init($$);
+          init(PARSER, $$);
         }
         | gcc_type_attribute
         ;
@@ -1654,7 +1667,7 @@ gcc_attribute_list:
           gcc_attribute
         | gcc_attribute_list ',' gcc_attribute
         {
-          $$=merge($1, $3);
+          $$=merge(PARSER, $1, $3);
         }
         ;          
 
@@ -1662,13 +1675,13 @@ gcc_attribute_specifier:
           TOK_GCC_ATTRIBUTE '(' '(' gcc_attribute_list ')' ')'
         { $$=$4; }
         | TOK_NORETURN
-        { $$=$1; set($$, ID_noreturn); }
+        { $$=$1; set(PARSER, $$, ID_noreturn); }
         ;
 
 gcc_type_attribute_opt:
           /* empty */
         {
-          init($$);
+          init(PARSER, $$);
         }
         | gcc_type_attribute_list
         ;
@@ -1677,14 +1690,14 @@ gcc_type_attribute_list:
           gcc_attribute_specifier
         | gcc_type_attribute_list gcc_attribute_specifier
         {
-          $$=merge($1, $2);
+          $$=merge(PARSER, $1, $2);
         }
         ;
 
 member_declaration_list_opt:
                   /* Nothing */
         {
-          init($$, ID_declaration_list);
+          init(PARSER, $$, ID_declaration_list);
         }
         | member_declaration_list
         ;
@@ -1692,7 +1705,7 @@ member_declaration_list_opt:
 member_declaration_list:
           member_declaration
         {
-          init($$, ID_declaration_list);
+          init(PARSER, $$, ID_declaration_list);
           mto($$, $1);
         }
         | member_declaration_list member_declaration
@@ -1721,9 +1734,9 @@ member_default_declaring_list:
           type_qualifier_list
           member_identifier_declarator
         {
-          $2=merge($2, $1);
+          $2=merge(PARSER, $2, $1);
 
-          init($$, ID_declaration);
+          init(PARSER, $$, ID_declaration);
           to_ansi_c_declaration(parser_stack($$)).set_is_member(true);
           parser_stack($$).add_source_location()=parser_stack($2).source_location();
           parser_stack($$).type().swap(parser_stack($2));
@@ -1749,19 +1762,19 @@ member_declaring_list:
             // communicate #pragma pack(n) alignment constraints by
             // by both setting packing AND alignment for individual struct/union
             // members; see padding.cpp for more details
-            init($$);
-            set($$, ID_packed);
-            $2=merge($2, $$);
+            init(PARSER, $$);
+            set(PARSER, $$, ID_packed);
+            $2=merge(PARSER, $2, $$);
 
-            init($$);
-            set($$, ID_aligned);
+            init(PARSER, $$);
+            set(PARSER, $$, ID_aligned);
             parser_stack($$).set(ID_size, PARSER.pragma_pack.back());
-            $2=merge($2, $$);
+            $2=merge(PARSER, $2, $$);
           }
 
-          $2=merge($2, $1);
+          $2=merge(PARSER, $2, $1);
 
-          init($$, ID_declaration);
+          init(PARSER, $$, ID_declaration);
           to_ansi_c_declaration(parser_stack($$)).set_is_member(true);
           parser_stack($$).add_source_location()=parser_stack($2).source_location();
           parser_stack($$).type().swap(parser_stack($2));
@@ -1780,14 +1793,14 @@ member_declarator:
           $$=$1;
 
           if(parser_stack($2).is_not_nil())
-            make_subtype($$, $2);
+            make_subtype(PARSER, $$, $2);
 
           if(parser_stack($3).is_not_nil()) // type attribute
-            $$=merge($3, $$);
+            $$=merge(PARSER, $3, $$);
         }
         | /* empty */
         {
-          init($$, ID_abstract);
+          init(PARSER, $$, ID_abstract);
         }
         | bit_field_size gcc_type_attribute_opt
         {
@@ -1795,7 +1808,7 @@ member_declarator:
           stack_type($$).add_subtype()=typet(ID_abstract);
 
           if(parser_stack($2).is_not_nil()) // type attribute
-            $$=merge($2, $$);
+            $$=merge(PARSER, $2, $$);
         }
         ;
 
@@ -1804,10 +1817,10 @@ member_identifier_declarator:
         {
           $$=$1;
           if(parser_stack($2).is_not_nil())
-            make_subtype($$, $2);
+            make_subtype(PARSER, $$, $2);
           
           if(parser_stack($3).is_not_nil()) // type attribute
-            $$=merge($3, $$);
+            $$=merge(PARSER, $3, $$);
         }
         | bit_field_size gcc_type_attribute_opt
         {
@@ -1815,14 +1828,14 @@ member_identifier_declarator:
           stack_type($$).add_subtype()=typet(ID_abstract);
 
           if(parser_stack($2).is_not_nil()) // type attribute
-            $$=merge($2, $$);
+            $$=merge(PARSER, $2, $$);
         }
         ;
 
 bit_field_size_opt:
         /* nothing */
         {
-          init($$, ID_nil);
+          init(PARSER, $$, ID_nil);
         }
         | bit_field_size
         ;
@@ -1831,7 +1844,7 @@ bit_field_size:
         ':' constant_expression
         {
           $$=$1;
-          set($$, ID_c_bit_field);
+          set(PARSER, $$, ID_c_bit_field);
           stack_type($$).set(ID_size, parser_stack($2));
           stack_type($$).add_subtype().id(ID_abstract);
         }
@@ -1852,7 +1865,7 @@ enum_name:
           gcc_type_attribute_opt
         {
           parser_stack($1).operands().swap(parser_stack($6).operands());
-          $$=merge($1, merge($2, $8)); // throw in the gcc attributes
+          $$=merge(PARSER, $1, merge(PARSER, $2, $8)); // throw in the gcc attributes
         }
         | enum_key
           gcc_type_attribute_opt
@@ -1879,7 +1892,7 @@ enum_name:
             parser_stack($1).id(ID_c_enum_tag);
           }
 
-          $$=merge($1, merge($2, $7)); // throw in the gcc attributes
+          $$=merge(PARSER, $1, merge(PARSER, $2, $7)); // throw in the gcc attributes
         }
         ;
 
@@ -1887,7 +1900,7 @@ basic_type_name_list:
     basic_type_name
   | basic_type_name_list basic_type_name
   {
-    $$ = merge($1, $2);
+    $$ = merge(PARSER, $1, $2);
   }
 
 enum_underlying_type:
@@ -1897,7 +1910,7 @@ enum_underlying_type:
 enum_underlying_type_opt:
         /* empty */
         {
-          init($$);
+          init(PARSER, $$);
           parser_stack($$).make_nil();
         }
         | ':' enum_underlying_type
@@ -1908,7 +1921,7 @@ enum_underlying_type_opt:
 braced_enumerator_list_opt:
         /* empty */
         {
-          init($$);
+          init(PARSER, $$);
           parser_stack($$).make_nil();
         }
         | '{' enumerator_list_opt '}'
@@ -1919,14 +1932,14 @@ braced_enumerator_list_opt:
 enum_key: TOK_ENUM
         {
           $$=$1;
-          set($$, ID_c_enum);
+          set(PARSER, $$, ID_c_enum);
         }
         ;
 
 enumerator_list_opt:
           /* nothing */
         {
-          init($$, ID_declaration_list);
+          init(PARSER, $$, ID_declaration_list);
         }
         | enumerator_list
         ;
@@ -1934,7 +1947,7 @@ enumerator_list_opt:
 enumerator_list:
           enumerator_declaration
         {
-          init($$, ID_declaration_list);
+          init(PARSER, $$, ID_declaration_list);
           mto($$, $1);
         }
         | enumerator_list ',' enumerator_declaration
@@ -1951,7 +1964,7 @@ enumerator_list:
 enumerator_declaration:
           identifier_or_typedef_name gcc_type_attribute_opt enumerator_value_opt
         {
-          init($$, ID_declaration);
+          init(PARSER, $$, ID_declaration);
           to_ansi_c_declaration(parser_stack($$)).set_is_enum_constant(true);
           PARSER.add_declarator(parser_stack($$), parser_stack($1));
           to_ansi_c_declaration(parser_stack($$)).add_initializer(parser_stack($3));
@@ -1961,7 +1974,7 @@ enumerator_declaration:
 enumerator_value_opt:
         /* nothing */
         {
-          init($$);
+          init(PARSER, $$);
           parser_stack($$).make_nil();
         }
         | '=' constant_expression
@@ -1983,7 +1996,7 @@ parameter_type_list:
 KnR_parameter_list:
           KnR_parameter
         {
-          init($$, ID_parameters);
+          init(PARSER, $$, ID_parameters);
           mts($$, $1);
         }
         | KnR_parameter_list ',' KnR_parameter
@@ -1995,7 +2008,7 @@ KnR_parameter_list:
 
 KnR_parameter: identifier
         {
-          init($$, ID_declaration);
+          init(PARSER, $$, ID_declaration);
           parser_stack($$).type()=typet(ID_KnR);
           PARSER.add_declarator(parser_stack($$), parser_stack($1));
         }
@@ -2004,7 +2017,7 @@ KnR_parameter: identifier
 parameter_list:
           parameter_declaration
         {
-          init($$, ID_parameters);
+          init(PARSER, $$, ID_parameters);
           mts($$, $1);
         }
         | parameter_list ',' parameter_declaration
@@ -2017,7 +2030,7 @@ parameter_list:
 parameter_declaration:
           declaration_specifier
         {
-          init($$, ID_declaration);
+          init(PARSER, $$, ID_declaration);
           to_ansi_c_declaration(parser_stack($$)).set_is_parameter(true);
           to_ansi_c_declaration(parser_stack($$)).type().swap(parser_stack($1));
           exprt declarator=exprt(ID_abstract);
@@ -2025,15 +2038,15 @@ parameter_declaration:
         }
         | declaration_specifier parameter_abstract_declarator
         {
-          init($$, ID_declaration);
+          init(PARSER, $$, ID_declaration);
           to_ansi_c_declaration(parser_stack($$)).set_is_parameter(true);
           to_ansi_c_declaration(parser_stack($$)).type().swap(parser_stack($1));
           PARSER.add_declarator(parser_stack($$), parser_stack($2));
         }
         | declaration_specifier identifier_declarator gcc_type_attribute_opt
         {
-          $2=merge($3, $2); // type attribute to go into declarator
-          init($$, ID_declaration);
+          $2=merge(PARSER, $3, $2); // type attribute to go into declarator
+          init(PARSER, $$, ID_declaration);
           to_ansi_c_declaration(parser_stack($$)).set_is_parameter(true);
           to_ansi_c_declaration(parser_stack($$)).type().swap(parser_stack($1));
           PARSER.add_declarator(parser_stack($$), parser_stack($2));
@@ -2042,14 +2055,14 @@ parameter_declaration:
         {
           // the second tree is really the declarator -- not part
           // of the type!
-          init($$, ID_declaration);
+          init(PARSER, $$, ID_declaration);
           to_ansi_c_declaration(parser_stack($$)).set_is_parameter(true);
           to_ansi_c_declaration(parser_stack($$)).type().swap(parser_stack($1));
           PARSER.add_declarator(parser_stack($$), parser_stack($2));
         }
         | declaration_qualifier_list
         {
-          init($$, ID_declaration);
+          init(PARSER, $$, ID_declaration);
           to_ansi_c_declaration(parser_stack($$)).set_is_parameter(true);
           to_ansi_c_declaration(parser_stack($$)).type().swap(parser_stack($1));
           exprt declarator=exprt(ID_abstract);
@@ -2057,22 +2070,22 @@ parameter_declaration:
         }
         | declaration_qualifier_list parameter_abstract_declarator
         {
-          init($$, ID_declaration);
+          init(PARSER, $$, ID_declaration);
           to_ansi_c_declaration(parser_stack($$)).set_is_parameter(true);
           to_ansi_c_declaration(parser_stack($$)).type().swap(parser_stack($1));
           PARSER.add_declarator(parser_stack($$), parser_stack($2));
         }
         | declaration_qualifier_list identifier_declarator gcc_type_attribute_opt
         {
-          $2=merge($3, $2); // type attribute to go into declarator
-          init($$, ID_declaration);
+          $2=merge(PARSER, $3, $2); // type attribute to go into declarator
+          init(PARSER, $$, ID_declaration);
           to_ansi_c_declaration(parser_stack($$)).set_is_parameter(true);
           to_ansi_c_declaration(parser_stack($$)).type().swap(parser_stack($1));
           PARSER.add_declarator(parser_stack($$), parser_stack($2));
         }
         | type_specifier
         {
-          init($$, ID_declaration);
+          init(PARSER, $$, ID_declaration);
           to_ansi_c_declaration(parser_stack($$)).set_is_parameter(true);
           to_ansi_c_declaration(parser_stack($$)).type().swap(parser_stack($1));
           exprt declarator=exprt(ID_abstract);
@@ -2080,15 +2093,15 @@ parameter_declaration:
         }
         | type_specifier parameter_abstract_declarator
         {
-          init($$, ID_declaration);
+          init(PARSER, $$, ID_declaration);
           to_ansi_c_declaration(parser_stack($$)).set_is_parameter(true);
           to_ansi_c_declaration(parser_stack($$)).type().swap(parser_stack($1));
           PARSER.add_declarator(parser_stack($$), parser_stack($2));
         }
         | type_specifier identifier_declarator gcc_type_attribute_opt
         {
-          $2=merge($3, $2); // type attribute to go into declarator
-          init($$, ID_declaration);
+          $2=merge(PARSER, $3, $2); // type attribute to go into declarator
+          init(PARSER, $$, ID_declaration);
           to_ansi_c_declaration(parser_stack($$)).set_is_parameter(true);
           to_ansi_c_declaration(parser_stack($$)).type().swap(parser_stack($1));
           PARSER.add_declarator(parser_stack($$), parser_stack($2));
@@ -2096,14 +2109,14 @@ parameter_declaration:
         | type_specifier parameter_typedef_declarator
         {
           // the second tree is really the declarator -- not part of the type!
-          init($$, ID_declaration);
+          init(PARSER, $$, ID_declaration);
           to_ansi_c_declaration(parser_stack($$)).set_is_parameter(true);
           to_ansi_c_declaration(parser_stack($$)).type().swap(parser_stack($1));
           PARSER.add_declarator(parser_stack($$), parser_stack($2));
         }
         | type_qualifier_list
         {
-          init($$, ID_declaration);
+          init(PARSER, $$, ID_declaration);
           to_ansi_c_declaration(parser_stack($$)).set_is_parameter(true);
           to_ansi_c_declaration(parser_stack($$)).type().swap(parser_stack($1));
           exprt declarator=exprt(ID_abstract);
@@ -2111,15 +2124,15 @@ parameter_declaration:
         }
         | type_qualifier_list parameter_abstract_declarator
         {
-          init($$, ID_declaration);
+          init(PARSER, $$, ID_declaration);
           to_ansi_c_declaration(parser_stack($$)).set_is_parameter(true);
           to_ansi_c_declaration(parser_stack($$)).type().swap(parser_stack($1));
           PARSER.add_declarator(parser_stack($$), parser_stack($2));
         }
         | type_qualifier_list identifier_declarator gcc_type_attribute_opt
         {
-          $2=merge($3, $2); // type attribute to go into declarator
-          init($$, ID_declaration);
+          $2=merge(PARSER, $3, $2); // type attribute to go into declarator
+          init(PARSER, $$, ID_declaration);
           to_ansi_c_declaration(parser_stack($$)).set_is_parameter(true);
           to_ansi_c_declaration(parser_stack($$)).type().swap(parser_stack($1));
           PARSER.add_declarator(parser_stack($$), parser_stack($2));
@@ -2134,28 +2147,28 @@ identifier_or_typedef_name:
 type_name:
           gcc_type_attribute_opt type_specifier
         {
-          $$=merge($2, $1);
+          $$=merge(PARSER, $2, $1);
         }
         | gcc_type_attribute_opt type_specifier abstract_declarator
         {
-          $$=merge($2, $1);
-          make_subtype($$, $3);
+          $$=merge(PARSER, $2, $1);
+          make_subtype(PARSER, $$, $3);
         }
         | gcc_type_attribute_opt type_qualifier_list
         {
-          $$=merge($2, $1);
+          $$=merge(PARSER, $2, $1);
         }
         | gcc_type_attribute_opt type_qualifier_list abstract_declarator
         {
-          $$=merge($2, $1);
-          make_subtype($$, $3);
+          $$=merge(PARSER, $2, $1);
+          make_subtype(PARSER, $$, $3);
         }
         ;
 
 initializer_opt:
         /* nothing */
         {
-          init($$);
+          init(PARSER, $$);
           parser_stack($$).make_nil();
         }
         | '=' initializer
@@ -2172,13 +2185,13 @@ initializer:
         | '{' initializer_list_opt '}'
         {
           $$=$1;
-          set($$, ID_initializer_list);
+          set(PARSER, $$, ID_initializer_list);
           parser_stack($$).operands().swap(parser_stack($2).operands());
         }
         | '{' initializer_list ',' '}'
         {
           $$=$1;
-          set($$, ID_initializer_list);
+          set(PARSER, $$, ID_initializer_list);
           parser_stack($$).operands().swap(parser_stack($2).operands());
         }
         ;
@@ -2203,8 +2216,8 @@ initializer_list_opt:
           initializer_list
         | /* nothing */
         {
-          init($$);
-          set($$, ID_initializer_list);
+          init(PARSER, $$);
+          set(PARSER, $$, ID_initializer_list);
           parser_stack($$).operands().clear();
         }
         ;
@@ -2221,7 +2234,7 @@ designated_initializer:
         /* the following two are obsolete GCC extensions */
         | designator initializer
         {
-          init($$, ID_designated_initializer);
+          init(PARSER, $$, ID_designated_initializer);
           parser_stack($$).add(ID_designator).swap(parser_stack($1));
           mto($$, $2);
         }
@@ -2242,14 +2255,14 @@ designated_initializer:
 designator:
           '.' member_name
         {
-          init($$);
+          init(PARSER, $$);
           parser_stack($1).id(ID_member);
           parser_stack($1).set(ID_component_name, parser_stack($2).get(ID_C_base_name));
           mto($$, $1);
         }
         | '[' comma_expression ']'
         {
-          init($$);
+          init(PARSER, $$);
           parser_stack($1).id(ID_index);
           mto($1, $2);
           mto($$, $1);
@@ -2257,7 +2270,7 @@ designator:
         | '[' comma_expression TOK_ELLIPSIS comma_expression ']'
         {
           // TODO
-          init($$);
+          init(PARSER, $$);
           parser_stack($1).id(ID_index);
           mto($1, $2);
           mto($$, $1);
@@ -2311,8 +2324,8 @@ stmt_not_decl_or_attr:
 declaration_statement:
           declaration
         {
-          init($$);
-          statement($$, ID_decl);
+          init(PARSER, $$);
+          statement(PARSER, $$, ID_decl);
           mto($$, $1);
         }
         ;
@@ -2320,7 +2333,7 @@ declaration_statement:
 gcc_attribute_specifier_opt:
           /* empty */
         {
-          init($$);
+          init(PARSER, $$);
         }
         | gcc_attribute_specifier
         ;
@@ -2335,7 +2348,7 @@ labeled_statement:
         {
           // we ignore the GCC attribute
           $$=$2;
-          statement($$, ID_label);
+          statement(PARSER, $$, ID_label);
           irep_idt identifier=PARSER.lookup_label(parser_stack($1).get(ID_C_base_name));
           parser_stack($$).set(ID_label, identifier);
           mto($$, $4);
@@ -2343,7 +2356,7 @@ labeled_statement:
         | msc_label_identifier ':' statement
         {
           $$=$2;
-          statement($$, ID_label);
+          statement(PARSER, $$, ID_label);
           irep_idt identifier=PARSER.lookup_label(parser_stack($1).get(ID_C_base_name));
           parser_stack($$).set(ID_label, identifier);
           mto($$, $3);
@@ -2351,7 +2364,7 @@ labeled_statement:
         | TOK_CASE constant_expression ':' statement
         {
           $$=$1;
-          statement($$, ID_switch_case);
+          statement(PARSER, $$, ID_switch_case);
           mto($$, $2);
           mto($$, $4);
         }
@@ -2359,7 +2372,7 @@ labeled_statement:
         {
           // this is a GCC extension
           $$=$1;
-          statement($$, ID_gcc_switch_case_range);
+          statement(PARSER, $$, ID_gcc_switch_case_range);
           mto($$, $2);
           mto($$, $4);
           mto($$, $6);
@@ -2367,7 +2380,7 @@ labeled_statement:
         | TOK_DEFAULT ':' statement
         {
           $$=$1;
-          statement($$, ID_switch_case);
+          statement(PARSER, $$, ID_switch_case);
           parser_stack($$).operands().push_back(nil_exprt());
           mto($$, $3);
           parser_stack($$).set(ID_default, true);
@@ -2382,7 +2395,7 @@ statement_attribute:
           // https://gcc.gnu.org/onlinedocs/gcc/Label-Attributes.html
           // We ignore all such attributes.
           $$=$1;
-          statement($$, ID_skip);
+          statement(PARSER, $$, ID_skip);
         }
         ;
 
@@ -2390,14 +2403,14 @@ compound_statement:
           compound_scope '{' '}'
         {
           $$=$2;
-          statement($$, ID_block);
+          statement(PARSER, $$, ID_block);
           parser_stack($$).set(ID_C_end_location, parser_stack($3).source_location());
           PARSER.pop_scope();
         }
         | compound_scope '{' statement_list '}'
         {
           $$=$2;
-          statement($$, ID_block);
+          statement(PARSER, $$, ID_block);
           parser_stack($$).set(ID_C_end_location, parser_stack($4).source_location());
           parser_stack($$).operands().swap(parser_stack($3).operands());
           PARSER.pop_scope();
@@ -2405,7 +2418,7 @@ compound_statement:
         | compound_scope '{' TOK_ASM_STRING '}'
         {
           $$=$2;
-          statement($$, ID_asm);
+          statement(PARSER, $$, ID_asm);
           parser_stack($$).set(ID_C_end_location, parser_stack($4).source_location());
           mto($$, $3);
           PARSER.pop_scope();
@@ -2423,7 +2436,7 @@ compound_scope:
 statement_list:
           statement
         {
-          init($$);
+          init(PARSER, $$);
           mto($$, $1);
         }
         | statement_list statement
@@ -2438,10 +2451,10 @@ expression_statement:
           $$=$2;
 
           if(parser_stack($1).is_nil())
-            statement($$, ID_skip);
+            statement(PARSER, $$, ID_skip);
           else
           {
-            statement($$, ID_expression);
+            statement(PARSER, $$, ID_expression);
             mto($$, $1);
           }
         }
@@ -2451,21 +2464,21 @@ selection_statement:
           TOK_IF '(' comma_expression ')' statement
         {
           $$=$1;
-          statement($$, ID_ifthenelse);
+          statement(PARSER, $$, ID_ifthenelse);
           parser_stack($$).add_to_operands(
             std::move(parser_stack($3)), std::move(parser_stack($5)), nil_exprt());
         }
         | TOK_IF '(' comma_expression ')' statement TOK_ELSE statement
         {
           $$=$1;
-          statement($$, ID_ifthenelse);
+          statement(PARSER, $$, ID_ifthenelse);
           parser_stack($$).add_to_operands(
             std::move(parser_stack($3)), std::move(parser_stack($5)), std::move(parser_stack($7)));
         }
         | TOK_SWITCH '(' comma_expression ')' statement
         {
           $$=$1;
-          statement($$, ID_switch);
+          statement(PARSER, $$, ID_switch);
           parser_stack($$).add_to_operands(std::move(parser_stack($3)), std::move(parser_stack($5)));
         }
         ;
@@ -2483,7 +2496,7 @@ iteration_statement:
           statement
         {
           $$=$1;
-          statement($$, ID_while);
+          statement(PARSER, $$, ID_while);
           parser_stack($$).add_to_operands(std::move(parser_stack($3)), std::move(parser_stack($8)));
 
           if(!parser_stack($5).operands().empty())
@@ -2503,7 +2516,7 @@ iteration_statement:
           TOK_WHILE '(' comma_expression ')' ';'
         {
           $$=$1;
-          statement($$, ID_dowhile);
+          statement(PARSER, $$, ID_dowhile);
           parser_stack($$).add_to_operands(std::move(parser_stack($8)), std::move(parser_stack($5)));
 
           if(!parser_stack($2).operands().empty())
@@ -2533,7 +2546,7 @@ iteration_statement:
           statement
         {
           $$=$1;
-          statement($$, ID_for);
+          statement(PARSER, $$, ID_for);
           parser_stack($$).operands().reserve(4);
           mto($$, $4);
           mto($$, $5);
@@ -2560,7 +2573,7 @@ jump_statement:
           $$=$1;
           if(parser_stack($2).id()==ID_symbol)
           {
-            statement($$, ID_goto);
+            statement(PARSER, $$, ID_goto);
             irep_idt identifier=PARSER.lookup_label(parser_stack($2).get(ID_C_base_name));
             parser_stack($$).set(ID_destination, identifier);
           }
@@ -2568,36 +2581,36 @@ jump_statement:
           {
             // this is a gcc extension.
             // the original grammar uses identifier_or_typedef_name
-            statement($$, ID_gcc_computed_goto);
+            statement(PARSER, $$, ID_gcc_computed_goto);
             mto($$, $2);
           }
         }
         | TOK_GOTO typedef_name ';'
         {
           $$=$1;
-          statement($$, ID_goto);
+          statement(PARSER, $$, ID_goto);
           irep_idt identifier=PARSER.lookup_label(parser_stack($2).get(ID_C_base_name));
           parser_stack($$).set(ID_destination, identifier);
         }
         | TOK_CONTINUE ';'
-        { $$=$1; statement($$, ID_continue); }
+        { $$=$1; statement(PARSER, $$, ID_continue); }
         | TOK_BREAK ';'
-        { $$=$1; statement($$, ID_break); }
+        { $$=$1; statement(PARSER, $$, ID_break); }
         | TOK_RETURN ';'
         {
           $$=$1;
-          statement($$, ID_return);
+          statement(PARSER, $$, ID_return);
           parser_stack($$).operands().push_back(nil_exprt());
         }
         | TOK_RETURN comma_expression ';'
-        { $$=$1; statement($$, ID_return); mto($$, $2); }
+        { $$=$1; statement(PARSER, $$, ID_return); mto($$, $2); }
         ;
 
 gcc_local_label_statement:
           TOK_GCC_LABEL gcc_local_label_list ';'
         { 
           $$=$1;
-          statement($$, ID_gcc_local_label);
+          statement(PARSER, $$, ID_gcc_local_label);
           
           // put these into the scope
           for(const auto &op : as_const(parser_stack($2)).operands())
@@ -2618,7 +2631,7 @@ gcc_local_label_statement:
 gcc_local_label_list:
           gcc_local_label
         {
-          init($$);
+          init(PARSER, $$);
           mto($$, $1);
         }
         | gcc_local_label_list ',' gcc_local_label
@@ -2634,14 +2647,14 @@ gcc_local_label: identifier_or_typedef_name
 gcc_asm_statement:
           TOK_GCC_ASM_PAREN volatile_or_goto_opt '(' gcc_asm_commands ')' ';'
         { $$=$1;
-          statement($$, ID_asm);
+          statement(PARSER, $$, ID_asm);
           parser_stack($$).set(ID_flavor, ID_gcc);
           parser_stack($$).operands().swap(parser_stack($4).operands());
         }
         | TOK_GCC_ASM_PAREN volatile_or_goto_opt '{' TOK_ASM_STRING '}'
         {
           $$=$1;
-          statement($$, ID_asm);
+          statement(PARSER, $$, ID_asm);
           parser_stack($$).set(ID_flavor, ID_gcc);
           parser_stack($$).operands().resize(5);
           to_multi_ary_expr(parser_stack($$)).op0()=parser_stack($4);
@@ -2651,13 +2664,13 @@ gcc_asm_statement:
 msc_asm_statement:
           TOK_MSC_ASM '{' TOK_ASM_STRING '}'
         { $$=$1;
-          statement($$, ID_asm);
+          statement(PARSER, $$, ID_asm);
           parser_stack($$).set(ID_flavor, ID_msc);
           mto($$, $3);
         }
         | TOK_MSC_ASM TOK_ASM_STRING
         { $$=$1;
-          statement($$, ID_asm);
+          statement(PARSER, $$, ID_asm);
           parser_stack($$).set(ID_flavor, ID_msc);
           mto($$, $2);
         }
@@ -2668,7 +2681,7 @@ msc_seh_statement:
           TOK_MSC_EXCEPT '(' comma_expression ')' compound_statement
         {
           $$=$1;
-          statement($$, ID_msc_try_except);
+          statement(PARSER, $$, ID_msc_try_except);
           mto($$, $2);
           mto($$, $5);
           mto($$, $7);
@@ -2677,14 +2690,14 @@ msc_seh_statement:
           TOK_MSC_FINALLY compound_statement
         {
           $$=$1;
-          statement($$, ID_msc_try_finally);
+          statement(PARSER, $$, ID_msc_try_finally);
           mto($$, $2);
           mto($$, $4);
         }
         | TOK_MSC_LEAVE
         {
           $$=$1;
-          statement($$, ID_msc_leave);
+          statement(PARSER, $$, ID_msc_leave);
         }
         ;
 
@@ -2692,13 +2705,13 @@ cprover_exception_statement:
           TOK_CPROVER_THROW ';'
         {
           $$=$1;
-          statement($$, ID_CPROVER_throw);
+          statement(PARSER, $$, ID_CPROVER_throw);
         }
         | TOK_CPROVER_TRY compound_statement
           TOK_CPROVER_CATCH compound_statement
         {
           $$=$1;
-          statement($$, ID_CPROVER_try_catch);
+          statement(PARSER, $$, ID_CPROVER_try_catch);
           mto($$, $2);
           mto($$, $4);
         }
@@ -2706,7 +2719,7 @@ cprover_exception_statement:
           TOK_CPROVER_FINALLY compound_statement
         {
           $$=$1;
-          statement($$, ID_CPROVER_try_finally);
+          statement(PARSER, $$, ID_CPROVER_try_finally);
           mto($$, $2);
           mto($$, $4);
         }
@@ -2730,20 +2743,20 @@ volatile_or_goto_opt:
 gcc_asm_commands:
           gcc_asm_assembler_template
         {
-          init($$);
+          init(PARSER, $$);
           parser_stack($$).operands().resize(5);
           parser_stack($$).operands()[0]=parser_stack($1);
         }
         | gcc_asm_assembler_template gcc_asm_outputs
         {
-          init($$);
+          init(PARSER, $$);
           parser_stack($$).operands().resize(5);
           parser_stack($$).operands()[0]=parser_stack($1);
           parser_stack($$).operands()[1]=parser_stack($2);
         }
         | gcc_asm_assembler_template gcc_asm_outputs gcc_asm_inputs
         {
-          init($$);
+          init(PARSER, $$);
           parser_stack($$).operands().resize(5);
           parser_stack($$).operands()[0]=parser_stack($1);
           parser_stack($$).operands()[1]=parser_stack($2);
@@ -2751,7 +2764,7 @@ gcc_asm_commands:
         }
         | gcc_asm_assembler_template gcc_asm_outputs gcc_asm_inputs gcc_asm_clobbered_registers
         {
-          init($$);
+          init(PARSER, $$);
           parser_stack($$).operands().resize(5);
           parser_stack($$).operands()[0]=parser_stack($1);
           parser_stack($$).operands()[1]=parser_stack($2);
@@ -2760,7 +2773,7 @@ gcc_asm_commands:
         }
         | gcc_asm_assembler_template gcc_asm_outputs gcc_asm_inputs gcc_asm_clobbered_registers gcc_asm_labels
         {
-          init($$);
+          init(PARSER, $$);
           parser_stack($$).operands().resize(5);
           parser_stack($$).operands()[0]=parser_stack($1);
           parser_stack($$).operands()[1]=parser_stack($2);
@@ -2800,7 +2813,7 @@ gcc_asm_output:
 gcc_asm_output_list:
           gcc_asm_output
         {
-          init($$, irep_idt());
+          init(PARSER, $$, irep_idt());
           mto($$, $1);
         }
         | gcc_asm_output_list ',' gcc_asm_output
@@ -2837,7 +2850,7 @@ gcc_asm_input:
 gcc_asm_input_list:
           gcc_asm_input
         {
-          init($$, irep_idt());
+          init(PARSER, $$, irep_idt());
           mto($$, $1);
         }
         | gcc_asm_input_list ',' gcc_asm_input
@@ -2858,7 +2871,7 @@ gcc_asm_clobbered_registers:
 gcc_asm_clobbered_register:
           string
         {
-          init($$, ID_gcc_asm_clobbered_register);
+          init(PARSER, $$, ID_gcc_asm_clobbered_register);
           mto($$, $1);
         }
         ;
@@ -2866,7 +2879,7 @@ gcc_asm_clobbered_register:
 gcc_asm_clobbered_registers_list:
           gcc_asm_clobbered_register
         {
-          init($$, irep_idt());
+          init(PARSER, $$, irep_idt());
           mto($$, $1);
         }
         | gcc_asm_clobbered_registers_list ',' gcc_asm_clobbered_register
@@ -2887,7 +2900,7 @@ gcc_asm_labels:
 gcc_asm_labels_list:
           gcc_asm_label
         {
-          init($$);
+          init(PARSER, $$);
           mto($$, $1);
         }
         | gcc_asm_labels_list ',' gcc_asm_label
@@ -2971,7 +2984,7 @@ function_body:
 KnR_parameter_header_opt:
           /* empty */
         {
-          init($$);
+          init(PARSER, $$);
         }
         | KnR_parameter_header
         ;
@@ -2979,7 +2992,7 @@ KnR_parameter_header_opt:
 KnR_parameter_header:
           KnR_parameter_declaration
         {
-          init($$, ID_decl_block);
+          init(PARSER, $$, ID_decl_block);
           mto($$, $1);
         }
         | KnR_parameter_header KnR_parameter_declaration
@@ -2998,30 +3011,30 @@ KnR_declaration_qualifier_list:
           storage_class
         | type_qualifier storage_class
         {
-          $$=merge($2, $1);
+          $$=merge(PARSER, $2, $1);
         }
         | KnR_declaration_qualifier_list declaration_qualifier
         {
-          $$=merge($2, $1);
+          $$=merge(PARSER, $2, $1);
         }
         ;
 
 KnR_basic_declaration_specifier:
           KnR_declaration_qualifier_list basic_type_name gcc_type_attribute_opt
         {
-          $$=merge($1, merge($2, $3));
+          $$=merge(PARSER, $1, merge(PARSER, $2, $3));
         }
         | basic_type_specifier storage_class gcc_type_attribute_opt
         {
-          $$=merge($1, merge($2, $3));
+          $$=merge(PARSER, $1, merge(PARSER, $2, $3));
         }
         | KnR_basic_declaration_specifier declaration_qualifier gcc_type_attribute_opt
         {
-          $$=merge($1, merge($2, $3));
+          $$=merge(PARSER, $1, merge(PARSER, $2, $3));
         }
         | KnR_basic_declaration_specifier basic_type_name gcc_type_attribute_opt
         {
-          $$=merge($1, merge($2, $3));
+          $$=merge(PARSER, $1, merge(PARSER, $2, $3));
         }
         ;
 
@@ -3029,15 +3042,15 @@ KnR_basic_declaration_specifier:
 KnR_typedef_declaration_specifier:
           typedef_type_specifier storage_class gcc_type_attribute_opt
         {
-          $$=merge($1, merge($2, $3));
+          $$=merge(PARSER, $1, merge(PARSER, $2, $3));
         }
         | KnR_declaration_qualifier_list typedef_name gcc_type_attribute_opt
         {
-          $$=merge($1, merge($2, $3));
+          $$=merge(PARSER, $1, merge(PARSER, $2, $3));
         }
         | KnR_typedef_declaration_specifier declaration_qualifier gcc_type_attribute_opt
         {
-          $$=merge($1, merge($2, $3));
+          $$=merge(PARSER, $1, merge(PARSER, $2, $3));
         }
         ;
 
@@ -3046,13 +3059,13 @@ KnR_sue_declaration_specifier:
         KnR_declaration_qualifier_list aggregate_key identifier_or_typedef_name gcc_type_attribute_opt
         {
           parser_stack($2).set(ID_tag, parser_stack($3));
-          $$=merge($1, merge($2, $4));
+          $$=merge(PARSER, $1, merge(PARSER, $2, $4));
         }
         | KnR_declaration_qualifier_list enum_key identifier_or_typedef_name gcc_type_attribute_opt
         {
           parser_stack($2).id(ID_c_enum_tag);
           parser_stack($2).set(ID_tag, parser_stack($3));
-          $$=merge($1, merge($2, $4));
+          $$=merge(PARSER, $1, merge(PARSER, $2, $4));
         }
         ;
 
@@ -3066,13 +3079,13 @@ KnR_declaration_specifier:
 KnR_parameter_declaring_list:
           KnR_declaration_specifier declarator
         {
-          init($$, ID_declaration);
+          init(PARSER, $$, ID_declaration);
           parser_stack($$).type().swap(parser_stack($1));
           PARSER.add_declarator(parser_stack($$), parser_stack($2));
         }
         | type_specifier declarator
         {
-          init($$, ID_declaration);
+          init(PARSER, $$, ID_declaration);
           parser_stack($$).type().swap(parser_stack($1));
           PARSER.add_declarator(parser_stack($$), parser_stack($2));
         }
@@ -3086,41 +3099,41 @@ KnR_parameter_declaring_list:
 function_head:
           identifier_declarator /* no return type given */
         {
-          init($$, ID_declaration);
+          init(PARSER, $$, ID_declaration);
           irept return_type(ID_int);
           parser_stack($$).type().swap(return_type);
           PARSER.add_declarator(parser_stack($$), parser_stack($1));
-          create_function_scope($$);
+          create_function_scope(PARSER, $$);
         }
         | declaration_specifier declarator post_declarator_attributes_opt
         {
-          init($$, ID_declaration);
+          init(PARSER, $$, ID_declaration);
           parser_stack($$).type().swap(parser_stack($1));
-          $2=merge($3, $2);
+          $2=merge(PARSER, $3, $2);
           PARSER.add_declarator(parser_stack($$), parser_stack($2));
-          create_function_scope($$);
+          create_function_scope(PARSER, $$);
         }
         | type_specifier declarator post_declarator_attributes_opt
         {
-          init($$, ID_declaration);
+          init(PARSER, $$, ID_declaration);
           parser_stack($$).type().swap(parser_stack($1));
-          $2=merge($3, $2);
+          $2=merge(PARSER, $3, $2);
           PARSER.add_declarator(parser_stack($$), parser_stack($2));
-          create_function_scope($$);
+          create_function_scope(PARSER, $$);
         }
         | declaration_qualifier_list identifier_declarator
         {
-          init($$, ID_declaration);
+          init(PARSER, $$, ID_declaration);
           parser_stack($$).type().swap(parser_stack($1));
           PARSER.add_declarator(parser_stack($$), parser_stack($2));
-          create_function_scope($$);
+          create_function_scope(PARSER, $$);
         }
         | type_qualifier_list identifier_declarator
         {
-          init($$, ID_declaration);
+          init(PARSER, $$, ID_declaration);
           parser_stack($$).type().swap(parser_stack($1));
           PARSER.add_declarator(parser_stack($$), parser_stack($2));
-          create_function_scope($$);
+          create_function_scope(PARSER, $$);
         }
         ;
 
@@ -3134,24 +3147,24 @@ paren_attribute_declarator:
           '(' gcc_type_attribute_list identifier_declarator ')'
         {
           stack_type($1)=typet(ID_abstract);
-          $2=merge($2, $1); // dest=$2
-          make_subtype($3, $2); // dest=$3
+          $2=merge(PARSER, $2, $1); // dest=$2
+          make_subtype(PARSER, $3, $2); // dest=$3
           $$=$3;
         }
         | '(' gcc_type_attribute_list identifier_declarator ')' postfixing_abstract_declarator
         {
           stack_type($1)=typet(ID_abstract);
-          $2=merge($2, $1); // dest=$2
-          make_subtype($3, $2); // dest=$3
+          $2=merge(PARSER, $2, $1); // dest=$2
+          make_subtype(PARSER, $3, $2); // dest=$3
           /* note: this is (a pointer to) a function ($5) */
           /* or an array ($5) with name ($3) */
           $$=$3;
-          make_subtype($$, $5);
+          make_subtype(PARSER, $$, $5);
         }
         | '*' paren_attribute_declarator
         {
           $$=$2;
-          do_pointer($1, $2);
+          do_pointer(PARSER, $1, $2);
         }
         ;
 
@@ -3165,7 +3178,7 @@ parameter_typedef_declarator:
         | typedef_name postfixing_abstract_declarator
         {
           $$=$1;
-          make_subtype($$, $2);
+          make_subtype(PARSER, $$, $2);
         }
         | clean_typedef_declarator
         ;
@@ -3175,12 +3188,12 @@ clean_typedef_declarator:
         | '*' parameter_typedef_declarator
         {
           $$=$2;
-          do_pointer($1, $2);
+          do_pointer(PARSER, $1, $2);
         }
         | '*' attribute_type_qualifier_list parameter_typedef_declarator
         {
-          $$=merge($2, $3);
-          do_pointer($1, $2);
+          $$=merge(PARSER, $2, $3);
+          do_pointer(PARSER, $1, $2);
         }
         ;
 
@@ -3192,7 +3205,7 @@ clean_postfix_typedef_declarator:
           /* note: this is a pointer ($2) to a function ($4) */
           /* or an array ($4)! */
           $$=$2;
-          make_subtype($$, $4);
+          make_subtype(PARSER, $$, $4);
         }
         ;
 
@@ -3201,23 +3214,23 @@ paren_typedef_declarator:
         | '*' '(' simple_paren_typedef_declarator ')'
         {
           $$=$3;
-          do_pointer($1, $3);
+          do_pointer(PARSER, $1, $3);
         }
         | '*' attribute_type_qualifier_list '(' simple_paren_typedef_declarator ')'
         {
           // not sure where the type qualifiers belong
-          $$=merge($2, $4);
-          do_pointer($1, $2);
+          $$=merge(PARSER, $2, $4);
+          do_pointer(PARSER, $1, $2);
         }
         | '*' paren_typedef_declarator
         {
           $$=$2;
-          do_pointer($1, $2);
+          do_pointer(PARSER, $1, $2);
         }
         | '*' attribute_type_qualifier_list paren_typedef_declarator
         {
-          $$=merge($2, $3);
-          do_pointer($1, $2);
+          $$=merge(PARSER, $2, $3);
+          do_pointer(PARSER, $1, $2);
         }
         ;
 
@@ -3227,14 +3240,14 @@ paren_postfix_typedef_declarator:
         | '(' simple_paren_typedef_declarator postfixing_abstract_declarator ')'
         {        /* note: this is a function ($3) with a typedef name ($2) */
           $$=$2;
-          make_subtype($$, $3);
+          make_subtype(PARSER, $$, $3);
         }
         | '(' paren_typedef_declarator ')' postfixing_abstract_declarator
         {
           /* note: this is a pointer ($2) to a function ($4) */
           /* or an array ($4)! */
           $$=$2;
-          make_subtype($$, $4);
+          make_subtype(PARSER, $$, $4);
         }
         ;
 
@@ -3254,14 +3267,14 @@ unary_identifier_declarator:
         | '*' identifier_declarator
         {
           $$=$2;
-          do_pointer($1, $2);
+          do_pointer(PARSER, $1, $2);
         }
         | '^' identifier_declarator
         {
           // This is an Apple extension to C/C++/Objective C.
           // http://en.wikipedia.org/wiki/Blocks_(C_language_extension)
           $$=$2;
-          do_pointer($1, $2);
+          do_pointer(PARSER, $1, $2);
         }
         | '*' attribute_type_qualifier_list identifier_declarator
         {
@@ -3271,8 +3284,8 @@ unary_identifier_declarator:
           // the width is added during conversion.
           stack_type($1).id(ID_frontend_pointer);
           stack_type($1).add_subtype()=typet(ID_abstract);
-          $2=merge($2, $1); // dest=$2
-          make_subtype($3, $2); // dest=$3
+          $2=merge(PARSER, $2, $1); // dest=$2
+          make_subtype(PARSER, $3, $2); // dest=$3
           $$=$3;
         }
         ;
@@ -3282,7 +3295,7 @@ postfix_identifier_declarator:
         {
           /* note: this is a function or array ($2) with name ($1) */
           $$=$1;
-          make_subtype($$, $2);
+          make_subtype(PARSER, $$, $2);
         }
         | '(' unary_identifier_declarator ')'
         { $$ = $2; }
@@ -3291,7 +3304,7 @@ postfix_identifier_declarator:
           /* note: this is a pointer ($2) to a function ($4) */
           /* or an array ($4)! */
           $$=$2;
-          make_subtype($$, $4);
+          make_subtype(PARSER, $$, $4);
         }
         ;
 
@@ -3322,13 +3335,13 @@ cprover_function_contract:
           TOK_CPROVER_ENSURES '(' ACSL_binding_expression ')'
         {
           $$=$1;
-          set($$, ID_C_spec_ensures);
+          set(PARSER, $$, ID_C_spec_ensures);
           mto($$, $3);
         }
         | TOK_CPROVER_REQUIRES '(' ACSL_binding_expression ')'
         {
           $$=$1;
-          set($$, ID_C_spec_requires);
+          set(PARSER, $$, ID_C_spec_requires);
           mto($$, $3);
         }
         | cprover_contract_assigns
@@ -3338,7 +3351,7 @@ cprover_function_contract:
 unary_expression_list:
           unary_expression
         {
-          init($$, ID_expression_list);
+          init(PARSER, $$, ID_expression_list);
           parser_stack($$).add_source_location()=parser_stack($1).source_location();
           mto($$, $1);
         }
@@ -3352,7 +3365,7 @@ unary_expression_list:
 conditional_target_group:
           unary_expression_list
         {
-          init($$, ID_conditional_target_group);
+          init(PARSER, $$, ID_conditional_target_group);
           parser_stack($$).add_source_location()=parser_stack($1).source_location();
           parser_stack($$).add_to_operands(true_exprt{});
           mto($$, $1);
@@ -3360,7 +3373,7 @@ conditional_target_group:
         | logical_equivalence_expression ':' unary_expression_list
         { 
           $$=$2;
-          set($$, ID_conditional_target_group);
+          set(PARSER, $$, ID_conditional_target_group);
           mto($$, $1);
           mto($$, $3);
         }
@@ -3369,7 +3382,7 @@ conditional_target_group:
 conditional_target_list:
           conditional_target_group
         {
-          init($$, ID_target_list);
+          init(PARSER, $$, ID_target_list);
           mto($$, $1);
         }
         | conditional_target_list ';' conditional_target_group
@@ -3393,20 +3406,20 @@ cprover_contract_assigns:
          TOK_CPROVER_ASSIGNS '(' conditional_target_list_opt_semicol ')'
         {
           $$=$1;
-          set($$, ID_C_spec_assigns);
+          set(PARSER, $$, ID_C_spec_assigns);
           mto($$, $3);
         }
         | TOK_CPROVER_ASSIGNS '(' ')'
         {
           $$=$1;
-          set($$, ID_C_spec_assigns);
+          set(PARSER, $$, ID_C_spec_assigns);
           parser_stack($$).add_to_operands(exprt(ID_target_list));
         }
         ;
 
 cprover_contract_assigns_opt:
         /* nothing */
-        { init($$); parser_stack($$).make_nil(); }
+        { init(PARSER, $$); parser_stack($$).make_nil(); }
         | cprover_contract_assigns
         ;
 
@@ -3414,13 +3427,13 @@ cprover_contract_frees:
          TOK_CPROVER_FREES '(' conditional_target_list_opt_semicol ')'
         {
           $$=$1;
-          set($$, ID_C_spec_frees);
+          set(PARSER, $$, ID_C_spec_frees);
           mto($$, $3);
         }
         | TOK_CPROVER_FREES '(' ')'
         {
           $$=$1;
-          set($$, ID_C_spec_frees);
+          set(PARSER, $$, ID_C_spec_frees);
           parser_stack($$).add_to_operands(exprt(ID_target_list));
         }
         ;
@@ -3430,13 +3443,13 @@ cprover_function_contract_sequence:
         | cprover_function_contract_sequence cprover_function_contract
         {
           $$=$1;
-          merge($$, $2);
+          merge(PARSER, $$, $2);
         }
         ;
 
 cprover_function_contract_sequence_opt:
           /* nothing */
-          { init($$); }
+          { init(PARSER, $$); }
         | cprover_function_contract_sequence
         {
           // Function contracts should either be attached to a
@@ -3447,7 +3460,10 @@ cprover_function_contract_sequence_opt:
           int contract_in_top_level_function_scope = (PARSER.scopes.size() == 2);
           if(!contract_in_global_scope && !contract_in_top_level_function_scope)
           {
-            yyansi_cerror("Function contracts allowed only at top-level declarations.");
+            yyansi_cerror(
+              PARSER,
+              scanner,
+              "Function contracts allowed only at top-level declarations.");
             YYABORT;
           }
         }
@@ -3461,7 +3477,7 @@ postfixing_abstract_declarator:
           KnR_parameter_header
         {
           $$=$1;
-          set($$, ID_code);
+          set(PARSER, $$, ID_code);
           stack_type($$).add_subtype()=typet(ID_abstract);
           stack_type($$).add(ID_parameters);
           stack_type($$).set(ID_C_KnR, true);
@@ -3478,7 +3494,7 @@ postfixing_abstract_declarator:
           KnR_parameter_header_opt
         {
           $$=$1;
-          set($$, ID_code);
+          set(PARSER, $$, ID_code);
           stack_type($$).add_subtype()=typet(ID_abstract);
           stack_type($$).add(ID_parameters).get_sub().
             swap((irept::subt &)(to_type_with_subtypes(stack_type($3)).subtypes()));
@@ -3505,7 +3521,7 @@ parameter_postfixing_abstract_declarator:
           }
           cprover_function_contract_sequence_opt
         {
-          set($1, ID_code);
+          set(PARSER, $1, ID_code);
           stack_type($1).add(ID_parameters);
           stack_type($1).add_subtype()=typet(ID_abstract);
           PARSER.pop_scope();
@@ -3516,7 +3532,7 @@ parameter_postfixing_abstract_declarator:
             PARSER.set_function(irep_idt());
           }
 
-          $$ = merge($4, $1);
+          $$ = merge(PARSER, $4, $1);
         }
         | '('
           {
@@ -3536,7 +3552,7 @@ parameter_postfixing_abstract_declarator:
           KnR_parameter_header_opt
           cprover_function_contract_sequence_opt
         {
-          set($1, ID_code);
+          set(PARSER, $1, ID_code);
           stack_type($1).add_subtype()=typet(ID_abstract);
           stack_type($1).add(ID_parameters).get_sub().
             swap((irept::subt &)(to_type_with_subtypes(stack_type($3)).subtypes()));
@@ -3554,7 +3570,7 @@ parameter_postfixing_abstract_declarator:
             parser_stack($$).set(ID_C_KnR, true);
           }
 
-          $$ = merge($6, $1);
+          $$ = merge(PARSER, $6, $1);
         }
         ;
 
@@ -3562,7 +3578,7 @@ array_abstract_declarator:
           '[' ']'
         {
           $$=$1;
-          set($$, ID_array);
+          set(PARSER, $$, ID_array);
           stack_type($$).add_subtype()=typet(ID_abstract);
           stack_type($$).add(ID_size).make_nil();
         }
@@ -3571,23 +3587,23 @@ array_abstract_declarator:
           // this is C99: e.g., restrict, const, etc
           // The type qualifier belongs to the array, not the
           // contents of the array, nor the size.
-          set($1, ID_array);
+          set(PARSER, $1, ID_array);
           stack_type($1).add_subtype()=typet(ID_abstract);
           stack_type($1).add(ID_size).make_nil();
-          $$=merge($2, $1);
+          $$=merge(PARSER, $2, $1);
         }
         | '[' '*' ']'
         {
           // these should be allowed in prototypes only
           $$=$1;
-          set($$, ID_array);
+          set(PARSER, $$, ID_array);
           stack_type($$).add_subtype()=typet(ID_abstract);
           stack_type($$).add(ID_size).make_nil();
         }
         | '[' constant_expression ']'
         {
           $$=$1;
-          set($$, ID_array);
+          set(PARSER, $$, ID_array);
           stack_type($$).add(ID_size).swap(parser_stack($2));
           stack_type($$).add_subtype()=typet(ID_abstract);
         }
@@ -3595,29 +3611,29 @@ array_abstract_declarator:
         {
           // The type qualifier belongs to the array, not the
           // contents of the array, nor the size.
-          set($1, ID_array);
+          set(PARSER, $1, ID_array);
           stack_type($1).add(ID_size).swap(parser_stack($3));
           stack_type($1).add_subtype()=typet(ID_abstract);
-          $$=merge($2, $1); // dest=$2
+          $$=merge(PARSER, $2, $1); // dest=$2
         }
         | array_abstract_declarator '[' constant_expression ']'
         {
           // we need to push this down
           $$=$1;
-          set($2, ID_array);
+          set(PARSER, $2, ID_array);
           stack_type($2).add(ID_size).swap(parser_stack($3));
           stack_type($2).add_subtype()=typet(ID_abstract);
-          make_subtype($1, $2);
+          make_subtype(PARSER, $1, $2);
         }
         | array_abstract_declarator '[' '*' ']'
         {
           // these should be allowed in prototypes only
           // we need to push this down
           $$=$1;
-          set($2, ID_array);
+          set(PARSER, $2, ID_array);
           stack_type($2).add(ID_size).make_nil();
           stack_type($2).add_subtype()=typet(ID_abstract);
-          make_subtype($1, $2);
+          make_subtype(PARSER, $1, $2);
         }
         ;
 
@@ -3638,12 +3654,12 @@ unary_abstract_declarator:
           // the width is added during conversion.
           stack_type($1).id(ID_frontend_pointer);
           stack_type($1).add_subtype()=typet(ID_abstract);
-          $$=merge($2, $1);
+          $$=merge(PARSER, $2, $1);
         }
         | '*' abstract_declarator
         {
           $$=$2;
-          do_pointer($1, $2);
+          do_pointer(PARSER, $1, $2);
         }
         | '*' attribute_type_qualifier_list abstract_declarator
         {
@@ -3653,8 +3669,8 @@ unary_abstract_declarator:
           // the width is added during conversion.
           stack_type($1).id(ID_frontend_pointer);
           stack_type($1).add_subtype()=typet(ID_abstract);
-          $2=merge($2, $1); // dest=$2
-          make_subtype($3, $2); // dest=$3
+          $2=merge(PARSER, $2, $1); // dest=$2
+          make_subtype(PARSER, $3, $2); // dest=$3
           $$=$3;
         }
         | '^'
@@ -3662,7 +3678,7 @@ unary_abstract_declarator:
           // This is an Apple extension to C/C++/Objective C.
           // http://en.wikipedia.org/wiki/Blocks_(C_language_extension)
           $$=$1;
-          set($$, ID_block_pointer);
+          set(PARSER, $$, ID_block_pointer);
           stack_type($$).add_subtype()=typet(ID_abstract);
         }
         ;
@@ -3684,12 +3700,12 @@ parameter_unary_abstract_declarator:
           // the width is added during conversion.
           stack_type($1).id(ID_frontend_pointer);
           stack_type($1).add_subtype()=typet(ID_abstract);
-          $$=merge($2, $1);
+          $$=merge(PARSER, $2, $1);
         }
         | '*' parameter_abstract_declarator
         {
           $$=$2;
-          do_pointer($1, $2);
+          do_pointer(PARSER, $1, $2);
         }
         | '*' attribute_type_qualifier_list parameter_abstract_declarator
         {
@@ -3699,8 +3715,8 @@ parameter_unary_abstract_declarator:
           // the width is added during conversion.
           stack_type($1).id(ID_frontend_pointer);
           stack_type($1).add_subtype()=typet(ID_abstract);
-          $2=merge($2, $1); // dest=$2
-          make_subtype($3, $2); // dest=$3
+          $2=merge(PARSER, $2, $1); // dest=$2
+          make_subtype(PARSER, $3, $2); // dest=$3
           $$=$3;
         }
         | '^'
@@ -3708,7 +3724,7 @@ parameter_unary_abstract_declarator:
           // This is an Apple extension to C/C++/Objective C.
           // http://en.wikipedia.org/wiki/Blocks_(C_language_extension)
           $$=$1;
-          set($$, ID_block_pointer);
+          set(PARSER, $$, ID_block_pointer);
           stack_type($$).add_subtype()=typet(ID_abstract);
         }
         ;
@@ -3724,13 +3740,13 @@ postfix_abstract_declarator:
         {
           /* note: this is a pointer ($2) to a function or array ($4) */
           $$=$2;
-          make_subtype($$, $4);
+          make_subtype(PARSER, $$, $4);
         }
         | '(' unary_abstract_declarator ')' postfixing_abstract_declarator
         {
           /* note: this is a pointer ($2) to a function or array ($4) */
           $$=$2;
-          make_subtype($$, $4);
+          make_subtype(PARSER, $$, $4);
         }
         ;
 
@@ -3744,8 +3760,6 @@ parameter_postfix_abstract_declarator:
         {
           /* note: this is a pointer ($2) to a function ($4) */
           $$=$2;
-          make_subtype($$, $4);
+          make_subtype(PARSER, $$, $4);
         }
         ;
-
-%%

--- a/src/ansi-c/parser_static.inc
+++ b/src/ansi-c/parser_static.inc
@@ -9,7 +9,7 @@
 
 #define mto(x, y) parser_stack(x).add_to_operands(std::move(parser_stack(y)))
 #define mts(x, y) (to_type_with_subtypes(stack_type(x)).move_to_subtypes(stack_type(y)))
-#define binary(x, y, l, id, z) { init(x, id); \
+#define binary(x, y, l, id, z) { init(PARSER, x, id); \
   parser_stack(x).add_source_location()=parser_stack(l).source_location(); \
   parser_stack(x).add_to_operands(std::move(parser_stack(y)), std::move(parser_stack(z))); }
 
@@ -25,7 +25,7 @@ Function: init
 
 \*******************************************************************/
 
-static void init(YYSTYPE &expr)
+static void init(ansi_c_parsert &ansi_c_parser, YYSTYPE &expr)
 {
   newstack(expr);
 }
@@ -42,7 +42,10 @@ Function: init
 
 \*******************************************************************/
 
-inline static void init(YYSTYPE &expr, const irep_idt &id)
+inline static void init(
+  ansi_c_parsert &ansi_c_parser,
+  YYSTYPE &expr,
+  const irep_idt &id)
 {
   newstack(expr);
   parser_stack(expr).id(id);
@@ -60,7 +63,10 @@ Function: set
 
 \*******************************************************************/
 
-inline static void set(YYSTYPE expr, const irep_idt &id)
+inline static void set(
+  ansi_c_parsert &ansi_c_parser,
+  YYSTYPE expr,
+  const irep_idt &id)
 {
   parser_stack(expr).id(id);
 }
@@ -77,9 +83,12 @@ Function: statement
 
 \*******************************************************************/
 
-static void statement(YYSTYPE &expr, const irep_idt &id)
+static void statement(
+  ansi_c_parsert &ansi_c_parser,
+  YYSTYPE &expr,
+  const irep_idt &id)
 {
-  set(expr, ID_code);
+  set(ansi_c_parser, expr, ID_code);
   parser_stack(expr).set(ID_statement, id);
 }
 
@@ -136,7 +145,10 @@ Function: merge_types
 \*******************************************************************/
 
 #if 0
-static void merge_types(const YYSTYPE dest, const YYSTYPE src)
+static void merge_types(
+  ansi_c_parsert &ansi_c_parser,
+  const YYSTYPE dest,
+  const YYSTYPE src)
 {
   merge_types(parser_stack(dest), parser_stack(src));
 }
@@ -154,7 +166,10 @@ Function: merge
 
 \*******************************************************************/
 
-static YYSTYPE merge(const YYSTYPE src1, const YYSTYPE src2)
+static YYSTYPE merge(
+  ansi_c_parsert &ansi_c_parser,
+  const YYSTYPE src1,
+  const YYSTYPE src2)
 {
   merge_types(parser_stack(src1), parser_stack(src2));
   return src1;
@@ -270,7 +285,10 @@ Function: make_subtype
 
 \*******************************************************************/
 
-static void make_subtype(YYSTYPE dest, YYSTYPE src)
+static void make_subtype(
+  ansi_c_parsert &ansi_c_parser,
+  YYSTYPE dest,
+  YYSTYPE src)
 {
   make_subtype(stack_type(dest), stack_type(src));
 }
@@ -287,7 +305,7 @@ Function: make_pointer
 
 \*******************************************************************/
 
-static void make_pointer(const YYSTYPE dest)
+static void make_pointer(ansi_c_parsert &ansi_c_parser, const YYSTYPE dest)
 {
   // The below deliberately avoids pointer_type().
   // The width is set during conversion.
@@ -307,10 +325,13 @@ Function: do_pointer
 
 \*******************************************************************/
 
-static void do_pointer(const YYSTYPE ptr, const YYSTYPE dest)
+static void do_pointer(
+  ansi_c_parsert &ansi_c_parser,
+  const YYSTYPE ptr,
+  const YYSTYPE dest)
 {
-  make_pointer(ptr);
-  make_subtype(dest, ptr);
+  make_pointer(ansi_c_parser, ptr);
+  make_subtype(ansi_c_parser, dest, ptr);
 }
 
 /*******************************************************************\
@@ -325,7 +346,9 @@ Function: create_function_scope
 
 \*******************************************************************/
 
-static void create_function_scope(const YYSTYPE d)
+static void create_function_scope(
+  ansi_c_parsert &ansi_c_parser,
+  const YYSTYPE d)
 {
   ansi_c_declarationt &declaration=to_ansi_c_declaration(parser_stack(d));
   ansi_c_declaratort &declarator=declaration.declarator();

--- a/src/ansi-c/scanner.l
+++ b/src/ansi-c/scanner.l
@@ -1,6 +1,9 @@
 %option nounput
 %option noinput
 %option stack
+%option noyywrap
+%option reentrant
+%option extra-type="ansi_c_parsert *"
 
 %{
 
@@ -38,29 +41,36 @@ static int isatty(int) { return 0; }
 #include "literals/convert_string_literal.h"
 #include "literals/unescape_string.h"
 
-#define PARSER ansi_c_parser
+#define PARSER (*yyansi_cget_extra(yyscanner))
 #define YYSTYPE unsigned
 #undef  ECHO
 #define ECHO
 
 #include "ansi_c_parser.h"
 #include "ansi_c_y.tab.h"
-#ifdef ANSI_C_DEBUG
-extern int yyansi_cdebug;
-#endif
+
+int yyansi_cerror(ansi_c_parsert &, void *, const std::string &);
 
 #define loc() \
   { newstack(yyansi_clval); PARSER.set_source_location(parser_stack(yyansi_clval)); }
 
-int make_identifier()
+ansi_c_parsert *yyansi_cget_extra(void *);
+#if defined(__APPLE__) || defined(__OpenBSD__) || defined(__NetBSD__)
+size_t yyansi_cget_leng(void *);
+#else
+int yyansi_cget_leng(void *);
+#endif
+char *yyansi_cget_text(void *);
+
+int make_identifier(void *yyscanner)
 {
   loc();
   
   // deal with universal charater names
   std::string final_base_name;
-  final_base_name.reserve(yyleng);
+  final_base_name.reserve(yyansi_cget_leng(yyscanner));
   
-  for(const char *p=yytext; *p!=0; p++)
+  for(const char *p=yyansi_cget_text(yyscanner); *p!=0; p++)
   {
     if(p[0]=='\\' && (p[1]=='u' || p[1]=='U'))
     {
@@ -119,7 +129,7 @@ int make_identifier()
   }
 }
 
-int MSC_Keyword(int token)
+int MSC_Keyword(int token, void *yyscanner)
 {
   if(PARSER.mode==configt::ansi_ct::flavourt::VISUAL_STUDIO)
   {
@@ -128,10 +138,10 @@ int MSC_Keyword(int token)
     return token;
   }
   else
-    return make_identifier();
+    return make_identifier(yyscanner);
 }
 
-int cpp98_keyword(int token)
+int cpp98_keyword(int token, void *yyscanner)
 {
   if(PARSER.cpp98)
   {
@@ -139,10 +149,10 @@ int cpp98_keyword(int token)
     return token;
   }
   else
-    return make_identifier();
+    return make_identifier(yyscanner);
 }
 
-int cpp11_keyword(int token)
+int cpp11_keyword(int token, void *yyscanner)
 {
   if(PARSER.cpp11)
   {
@@ -150,10 +160,10 @@ int cpp11_keyword(int token)
     return token;
   }
   else
-    return make_identifier();
+    return make_identifier(yyscanner);
 }
 
-int MSC_cpp_keyword(int token)
+int MSC_cpp_keyword(int token, void *yyscanner)
 {
   if(PARSER.cpp98 && PARSER.mode==configt::ansi_ct::flavourt::VISUAL_STUDIO)
   {
@@ -161,10 +171,10 @@ int MSC_cpp_keyword(int token)
     return token;
   }
   else
-    return make_identifier();
+    return make_identifier(yyscanner);
 }
 
-int cpp_operator(int token)
+int cpp_operator(int token, void *yyscanner)
 {
   if(PARSER.cpp98)
   {
@@ -173,7 +183,7 @@ int cpp_operator(int token)
   }
   else
   {
-    yyansi_cerror("C++ operator not allowed in C mode");
+    yyansi_cerror(PARSER, yyscanner, "C++ operator not allowed in C mode");
     return TOK_SCANNER_ERROR;
   }
 }
@@ -267,17 +277,6 @@ enable_or_disable ("enable"|"disable")
 %x CPROVER_PRAGMA
 %x OTHER_PRAGMA
 
-%{
-void ansi_c_scanner_init()
-{
-#ifdef ANSI_C_DEBUG
-  yyansi_cdebug=1;
-#endif
-  YY_FLUSH_BUFFER;
-  BEGIN(0);
-}
-%}
-
 %%
 
 <INITIAL>.|\n   { BEGIN(GRAMMAR);
@@ -288,17 +287,17 @@ void ansi_c_scanner_init()
 
 <COMMENT1>{
    "*/"         { BEGIN(GRAMMAR); } /* end comment state, back to GRAMMAR */
-   "/*"         { yyansi_cerror("Probably nested comments"); }
-   <<EOF>>      { yyansi_cerror("Unterminated comment"); return TOK_SCANNER_ERROR; }
+   "/*"         { yyansi_cerror(PARSER, yyscanner, "Probably nested comments"); }
+   <<EOF>>      { yyansi_cerror(PARSER, yyscanner, "Unterminated comment"); return TOK_SCANNER_ERROR; }
    [^*/\n]*     { /* ignore every char except '*' and NL (performance!) */ }
    .            { } /* all single characters within comments are ignored */
    \n           { }
 }
 
 <STRING_LITERAL_COMMENT>{
-   "*/"         { yy_pop_state(); } /* end comment state, back to STRING_LITERAL */
-   "/*"         { yyansi_cerror("Probably nested comments"); }
-   <<EOF>>      { yyansi_cerror("Unterminated comment"); return TOK_SCANNER_ERROR; }
+   "*/"         { yy_pop_state(yyscanner); } /* end comment state, back to STRING_LITERAL */
+   "/*"         { yyansi_cerror(PARSER, yyscanner, "Probably nested comments"); }
+   <<EOF>>      { yyansi_cerror(PARSER, yyscanner, "Unterminated comment"); return TOK_SCANNER_ERROR; }
    [^*/\n]*     { /* ignore every char except '*' and NL (performance!) */ }
    .            { } /* all single characters within comments are ignored */
    \n           { }
@@ -324,9 +323,9 @@ void ansi_c_scanner_init()
                   loc();
                   // String literals can be continued in
                   // the next line
-                  yy_push_state(STRING_LITERAL);
+                  yy_push_state(STRING_LITERAL, yyscanner);
                   // use yy_top_state() to keep the compiler happy
-                  (void)yy_top_state();
+                  (void)yy_top_state(yyscanner);
                 }
 
 <STRING_LITERAL>{string_lit} { PARSER.string_literal.append(yytext); }
@@ -337,13 +336,13 @@ void ansi_c_scanner_init()
                   PARSER.set_line_no(PARSER.get_line_no()-1);
                 }
 <STRING_LITERAL>{cppstart}.* { /* ignore */ }
-<STRING_LITERAL>"/*" { yy_push_state(STRING_LITERAL_COMMENT); /* C comment, ignore */ }
+<STRING_LITERAL>"/*" { yy_push_state(STRING_LITERAL_COMMENT, yyscanner); /* C comment, ignore */ }
 <STRING_LITERAL>"//".*\n { /* C++ comment, ignore */ }
 <STRING_LITERAL>. { // anything else: back to normal
                   source_locationt l=parser_stack(yyansi_clval).source_location();
                   parser_stack(yyansi_clval)=convert_string_literal(PARSER.string_literal);
                   parser_stack(yyansi_clval).add_source_location().swap(l);
-                  yy_pop_state(); // back to normal
+                  yy_pop_state(yyscanner); // back to normal
                   yyless(0); // put back
                   return TOK_STRING;
                 }
@@ -428,6 +427,8 @@ void ansi_c_scanner_init()
                   if(clash)
                   {
                     yyansi_cerror(
+                      PARSER,
+                      yyscanner,
                       "Found enable and disable pragmas for " +
                       id2string(check_name));
                     return TOK_SCANNER_ERROR;
@@ -437,7 +438,7 @@ void ansi_c_scanner_init()
                 }
 
 <CPROVER_PRAGMA>. {
-                  yyansi_cerror("Unsupported #pragma CPROVER");
+                  yyansi_cerror(PARSER, yyscanner, "Unsupported #pragma CPROVER");
                   return TOK_SCANNER_ERROR;
                 }
 
@@ -460,7 +461,7 @@ void ansi_c_scanner_init()
                     return '{';
                   }
                   else
-                    return make_identifier();
+                    return make_identifier(yyscanner);
                 }
 
 <GRAMMAR>{cppstart}"endasm" {
@@ -469,7 +470,7 @@ void ansi_c_scanner_init()
                 }
 
 <GRAMMAR>{cppdirective} {
-                  yyansi_cerror("Preprocessor directive found");
+                  yyansi_cerror(PARSER, yyscanner, "Preprocessor directive found");
                   return TOK_SCANNER_ERROR;
                 }
 
@@ -480,7 +481,7 @@ void ansi_c_scanner_init()
 <GRAMMAR,GCC_ATTRIBUTE3>{
 "auto"          { loc(); return TOK_AUTO; }
 "_Bool"         { if(PARSER.cpp98)
-                    return make_identifier();
+                    return make_identifier(yyscanner);
                   else
                   { loc(); return TOK_BOOL; }
                 }
@@ -524,43 +525,43 @@ void ansi_c_scanner_init()
                      && !PARSER.cpp98)
                   { loc(); return TOK_GCC_AUTO_TYPE; }
                   else
-                    return make_identifier();
+                    return make_identifier(yyscanner);
                 }
 
 "_Float16"      { if(PARSER.float16_type)
                   { loc(); return TOK_GCC_FLOAT16; }
                   else
-                    return make_identifier();
+                    return make_identifier(yyscanner);
                 }
 
 "__bf16"        { if(PARSER.bf16_type)
                   { loc(); return TOK_GCC_FLOAT16; }
                   else
-                    return make_identifier();
+                    return make_identifier(yyscanner);
                 }
 
 "_Float32"      { if(PARSER.ts_18661_3_Floatn_types)
                   { loc(); return TOK_GCC_FLOAT32; }
                   else
-                    return make_identifier();
+                    return make_identifier(yyscanner);
                 }
 
 "_Float32x"     { if(PARSER.ts_18661_3_Floatn_types)
                   { loc(); return TOK_GCC_FLOAT32X; }
                   else
-                    return make_identifier();
+                    return make_identifier(yyscanner);
                 }
 
 "_Float64"      { if(PARSER.ts_18661_3_Floatn_types)
                   { loc(); return TOK_GCC_FLOAT64; }
                   else
-                    return make_identifier();
+                    return make_identifier(yyscanner);
                 }
 
 "_Float64x"     { if(PARSER.ts_18661_3_Floatn_types)
                   { loc(); return TOK_GCC_FLOAT64X; }
                   else
-                    return make_identifier();
+                    return make_identifier(yyscanner);
                 }
 
 {CPROVER_PREFIX}"Float64x" {
@@ -576,13 +577,13 @@ void ansi_c_scanner_init()
                   if(PARSER.mode==configt::ansi_ct::flavourt::CLANG)
                   { loc(); return TOK_GCC_FLOAT128; }
                   else
-                    return make_identifier();
+                    return make_identifier(yyscanner);
                 }
 
 "_Float128"     { if(PARSER.ts_18661_3_Floatn_types)
                   { loc(); return TOK_GCC_FLOAT128; }
                   else
-                    return make_identifier();
+                    return make_identifier(yyscanner);
                 }
 
 {CPROVER_PREFIX}"Float128" {
@@ -592,61 +593,61 @@ void ansi_c_scanner_init()
 "_Float128x"    { if(PARSER.ts_18661_3_Floatn_types)
                   { loc(); return TOK_GCC_FLOAT128X; }
                   else
-                    return make_identifier();
+                    return make_identifier(yyscanner);
                 }
 
 "__int128"      { if(PARSER.mode==configt::ansi_ct::flavourt::GCC ||
                      PARSER.mode==configt::ansi_ct::flavourt::CLANG)
                   { loc(); return TOK_GCC_INT128; }
                   else
-                    return make_identifier();
+                    return make_identifier(yyscanner);
                 }
 
 "_Decimal32"    { // clang doesn't have it
                   if(PARSER.mode==configt::ansi_ct::flavourt::GCC)
                     { loc(); return TOK_GCC_DECIMAL32; }
                   else
-                    return make_identifier();
+                    return make_identifier(yyscanner);
                 }
 
 "_Decimal64"    { // clang doesn't have it
                   if(PARSER.mode==configt::ansi_ct::flavourt::GCC)
                     { loc(); return TOK_GCC_DECIMAL64; }
                   else
-                    return make_identifier();
+                    return make_identifier(yyscanner);
                 }
 
 "_Decimal128"   { // clang doesn't have it
                   if(PARSER.mode==configt::ansi_ct::flavourt::GCC)
                     { loc(); return TOK_GCC_DECIMAL128; }
                   else
-                    return make_identifier();
+                    return make_identifier(yyscanner);
                 }
 
-"__int8"        { return MSC_Keyword(TOK_INT8); }
-"__int16"       { return MSC_Keyword(TOK_INT16); }
-"__int32"       { return MSC_Keyword(TOK_INT32); }
+"__int8"        { return MSC_Keyword(TOK_INT8, yyscanner); }
+"__int16"       { return MSC_Keyword(TOK_INT16, yyscanner); }
+"__int32"       { return MSC_Keyword(TOK_INT32, yyscanner); }
 
 "__int64"       { if(PARSER.mode==configt::ansi_ct::flavourt::VISUAL_STUDIO ||
                      PARSER.mode==configt::ansi_ct::flavourt::ARM ||
                      PARSER.mode==configt::ansi_ct::flavourt::CODEWARRIOR)
                     { loc(); return TOK_INT64; }
                   else
-                    return make_identifier();
+                    return make_identifier(yyscanner);
                 }
 "_int64"        { if(PARSER.mode==configt::ansi_ct::flavourt::VISUAL_STUDIO)
                     { loc(); return TOK_INT64; }
                   else
-                    return make_identifier();
+                    return make_identifier(yyscanner);
                 }
-"__ptr32"       { return MSC_Keyword(TOK_PTR32); }
-"__ptr64"       { return MSC_Keyword(TOK_PTR64); }
+"__ptr32"       { return MSC_Keyword(TOK_PTR32, yyscanner); }
+"__ptr64"       { return MSC_Keyword(TOK_PTR64, yyscanner); }
 
 %{
 /*
-"__stdcall"     { return MSC_Keyword(TOK_STDCALL); }
-"__fastcall"    { return MSC_Keyword(TOK_FASTCALL); }
-"__clrcall"     { return MSC_Keyword(TOK_CLRCALL); }
+"__stdcall"     { return MSC_Keyword(TOK_STDCALL, yyscanner); }
+"__fastcall"    { return MSC_Keyword(TOK_FASTCALL, yyscanner); }
+"__clrcall"     { return MSC_Keyword(TOK_CLRCALL, yyscanner); }
 */
 %}
 
@@ -656,7 +657,7 @@ void ansi_c_scanner_init()
                      PARSER.mode==configt::ansi_ct::flavourt::ARM)
                     { loc(); return TOK_COMPLEX; }
                   else
-                    return make_identifier();
+                    return make_identifier(yyscanner);
                 }
 
 "__real__" |
@@ -665,7 +666,7 @@ void ansi_c_scanner_init()
                      PARSER.mode==configt::ansi_ct::flavourt::ARM)
                     { loc(); return TOK_REAL; }
                   else
-                    return make_identifier();
+                    return make_identifier(yyscanner);
                 }
 
 "__imag__" |
@@ -674,7 +675,7 @@ void ansi_c_scanner_init()
                      PARSER.mode==configt::ansi_ct::flavourt::ARM)
                     { loc(); return TOK_IMAG; }
                   else
-                    return make_identifier();
+                    return make_identifier(yyscanner);
                 }
 
 %{
@@ -685,7 +686,7 @@ void ansi_c_scanner_init()
 "_var_arg_typeof" { if(PARSER.mode==configt::ansi_ct::flavourt::CODEWARRIOR)
                     { loc(); return TOK_CW_VAR_ARG_TYPEOF; }
                   else
-                    return make_identifier();
+                    return make_identifier(yyscanner);
                 }
 
 "__builtin_va_arg" { if(PARSER.mode==configt::ansi_ct::flavourt::GCC ||
@@ -693,7 +694,7 @@ void ansi_c_scanner_init()
                         PARSER.mode==configt::ansi_ct::flavourt::ARM)
                     { loc(); return TOK_BUILTIN_VA_ARG; }
                   else
-                    return make_identifier();
+                    return make_identifier(yyscanner);
                 }
 
 "__builtin_offsetof" |
@@ -703,7 +704,7 @@ void ansi_c_scanner_init()
                      PARSER.mode==configt::ansi_ct::flavourt::ARM)
                     { loc(); return TOK_OFFSETOF; }
                   else
-                    return make_identifier();
+                    return make_identifier(yyscanner);
                 }
 
 "__builtin_types_compatible_p" {
@@ -712,7 +713,7 @@ void ansi_c_scanner_init()
                      PARSER.mode==configt::ansi_ct::flavourt::ARM)
                     { loc(); return TOK_GCC_BUILTIN_TYPES_COMPATIBLE_P; }
                   else
-                    return make_identifier();
+                    return make_identifier(yyscanner);
                 }
 
 "__builtin_convertvector" {
@@ -720,7 +721,7 @@ void ansi_c_scanner_init()
                      PARSER.mode==configt::ansi_ct::flavourt::CLANG)
                     { loc(); return TOK_CLANG_BUILTIN_CONVERTVECTOR; }
                   else
-                    return make_identifier();
+                    return make_identifier(yyscanner);
                 }
 
 "__alignof__"   { if(PARSER.mode==configt::ansi_ct::flavourt::GCC ||
@@ -728,7 +729,7 @@ void ansi_c_scanner_init()
                      PARSER.mode==configt::ansi_ct::flavourt::ARM)
                     { loc(); return TOK_ALIGNOF; }
                   else
-                    return make_identifier();
+                    return make_identifier(yyscanner);
                 }
 
 "__alignof"     { // MS supports __alignof:
@@ -739,13 +740,13 @@ void ansi_c_scanner_init()
                      PARSER.mode==configt::ansi_ct::flavourt::ARM)
                     { loc(); return TOK_ALIGNOF; }
                   else
-                    return make_identifier();
+                    return make_identifier(yyscanner);
                 }
 
 "__ALIGNOF__"   { if(PARSER.mode==configt::ansi_ct::flavourt::ARM)
                     { loc(); return TOK_ALIGNOF; }
                   else
-                    return make_identifier();
+                    return make_identifier(yyscanner);
                 }
 
 "__builtin_alignof" {
@@ -755,7 +756,7 @@ void ansi_c_scanner_init()
                      PARSER.mode==configt::ansi_ct::flavourt::ARM)
                     { loc(); return TOK_ALIGNOF; }
                   else
-                    return make_identifier();
+                    return make_identifier(yyscanner);
                 }
 
 "__asm"         { if(PARSER.mode==configt::ansi_ct::flavourt::VISUAL_STUDIO)
@@ -786,7 +787,7 @@ void ansi_c_scanner_init()
                       BEGIN(GCC_ASM);
                   }
                   else
-                    return make_identifier();
+                    return make_identifier(yyscanner);
                 }
 
 "__asm__"       { if(PARSER.mode==configt::ansi_ct::flavourt::GCC ||
@@ -803,71 +804,71 @@ void ansi_c_scanner_init()
                       BEGIN(GCC_ASM);
                   }
                   else
-                    return make_identifier();
+                    return make_identifier(yyscanner);
                 }
 
 "__based"       { if(PARSER.mode==configt::ansi_ct::flavourt::VISUAL_STUDIO)
                     { loc(); return TOK_MSC_BASED; }
                   else
-                    return make_identifier();
+                    return make_identifier(yyscanner);
                 }
 
 "__unaligned"   { if(PARSER.mode==configt::ansi_ct::flavourt::VISUAL_STUDIO)
                     { /* ignore for now */ }
                   else
-                    return make_identifier();
+                    return make_identifier(yyscanner);
                 }
 
 "__wchar_t"     { if(PARSER.mode==configt::ansi_ct::flavourt::VISUAL_STUDIO)
                     { loc(); return TOK_WCHAR_T; }
                   else
-                    return make_identifier();
+                    return make_identifier(yyscanner);
                 }
 
 %{
 /* C++ Keywords and Operators */
 %}
 
-alignas             { return cpp11_keyword(TOK_ALIGNAS); } // C++11
-alignof             { return cpp11_keyword(TOK_ALIGNOF); } // C++11
-and                 { return cpp98_keyword(TOK_ANDAND); }
-and_eq              { return cpp98_keyword(TOK_ANDASSIGN); }
-bool                { return cpp98_keyword(TOK_BOOL); }
-catch               { return cpp98_keyword(TOK_CATCH); }
+alignas             { return cpp11_keyword(TOK_ALIGNAS, yyscanner); } // C++11
+alignof             { return cpp11_keyword(TOK_ALIGNOF, yyscanner); } // C++11
+and                 { return cpp98_keyword(TOK_ANDAND, yyscanner); }
+and_eq              { return cpp98_keyword(TOK_ANDASSIGN, yyscanner); }
+bool                { return cpp98_keyword(TOK_BOOL, yyscanner); }
+catch               { return cpp98_keyword(TOK_CATCH, yyscanner); }
 char16_t            { // C++11, but Visual Studio uses typedefs
                       if(PARSER.mode == configt::ansi_ct::flavourt::VISUAL_STUDIO)
-                        return make_identifier();
+                        return make_identifier(yyscanner);
                       else
-                        return cpp11_keyword(TOK_CHAR16_T);
+                        return cpp11_keyword(TOK_CHAR16_T, yyscanner);
                     }
 char32_t            { // C++11, but Visual Studio uses typedefs
                       if(PARSER.mode == configt::ansi_ct::flavourt::VISUAL_STUDIO)
-                        return make_identifier();
+                        return make_identifier(yyscanner);
                       else
-                        return cpp11_keyword(TOK_CHAR32_T);
+                        return cpp11_keyword(TOK_CHAR32_T, yyscanner);
                     }
-class               { return cpp98_keyword(TOK_CLASS); }
-compl               { return cpp98_keyword('~'); }
-constexpr           { return cpp11_keyword(TOK_CONSTEXPR); } // C++11
-delete              { return cpp98_keyword(TOK_DELETE); }
-decltype            { return cpp11_keyword(TOK_DECLTYPE); } // C++11
-explicit            { return cpp98_keyword(TOK_EXPLICIT); }
-false               { return cpp98_keyword(TOK_FALSE); }
-friend              { return cpp98_keyword(TOK_FRIEND); }
-mutable             { return cpp98_keyword(TOK_MUTABLE); }
-namespace           { return cpp98_keyword(TOK_NAMESPACE); }
-new                 { return cpp98_keyword(TOK_NEW); }
-noexcept            { return cpp11_keyword(TOK_NOEXCEPT); } // C++11
-noreturn            { return cpp11_keyword(TOK_NORETURN); } // C++11
-not                 { return cpp98_keyword('!'); }
-not_eq              { return cpp98_keyword(TOK_NE); }
-nullptr             { return cpp11_keyword(TOK_NULLPTR); } // C++11
-operator            { return cpp98_keyword(TOK_OPERATOR); }
-or                  { return cpp98_keyword(TOK_OROR); }
-or_eq               { return cpp98_keyword(TOK_ORASSIGN); }
-private             { return cpp98_keyword(TOK_PRIVATE); }
-protected           { return cpp98_keyword(TOK_PROTECTED); }
-public              { return cpp98_keyword(TOK_PUBLIC); }
+class               { return cpp98_keyword(TOK_CLASS, yyscanner); }
+compl               { return cpp98_keyword('~', yyscanner); }
+constexpr           { return cpp11_keyword(TOK_CONSTEXPR, yyscanner); } // C++11
+delete              { return cpp98_keyword(TOK_DELETE, yyscanner); }
+decltype            { return cpp11_keyword(TOK_DECLTYPE, yyscanner); } // C++11
+explicit            { return cpp98_keyword(TOK_EXPLICIT, yyscanner); }
+false               { return cpp98_keyword(TOK_FALSE, yyscanner); }
+friend              { return cpp98_keyword(TOK_FRIEND, yyscanner); }
+mutable             { return cpp98_keyword(TOK_MUTABLE, yyscanner); }
+namespace           { return cpp98_keyword(TOK_NAMESPACE, yyscanner); }
+new                 { return cpp98_keyword(TOK_NEW, yyscanner); }
+noexcept            { return cpp11_keyword(TOK_NOEXCEPT, yyscanner); } // C++11
+noreturn            { return cpp11_keyword(TOK_NORETURN, yyscanner); } // C++11
+not                 { return cpp98_keyword('!', yyscanner); }
+not_eq              { return cpp98_keyword(TOK_NE, yyscanner); }
+nullptr             { return cpp11_keyword(TOK_NULLPTR, yyscanner); } // C++11
+operator            { return cpp98_keyword(TOK_OPERATOR, yyscanner); }
+or                  { return cpp98_keyword(TOK_OROR, yyscanner); }
+or_eq               { return cpp98_keyword(TOK_ORASSIGN, yyscanner); }
+private             { return cpp98_keyword(TOK_PRIVATE, yyscanner); }
+protected           { return cpp98_keyword(TOK_PROTECTED, yyscanner); }
+public              { return cpp98_keyword(TOK_PUBLIC, yyscanner); }
 static_assert       { // C++11, but Visual Studio supports it in all modes (and
                       // doesn't support _Static_assert)
                       if(PARSER.mode == configt::ansi_ct::flavourt::VISUAL_STUDIO)
@@ -875,30 +876,30 @@ static_assert       { // C++11, but Visual Studio supports it in all modes (and
                         loc(); return TOK_STATIC_ASSERT;
                       }
                       else
-                        return cpp11_keyword(TOK_STATIC_ASSERT);
+                        return cpp11_keyword(TOK_STATIC_ASSERT, yyscanner);
                     }
-template            { return cpp98_keyword(TOK_TEMPLATE); }
-this                { return cpp98_keyword(TOK_THIS); }
-thread_local        { return cpp11_keyword(TOK_THREAD_LOCAL); } // C++11
-throw               { return cpp98_keyword(TOK_THROW); }
-true                { return cpp98_keyword(TOK_TRUE); }
-typeid              { return cpp98_keyword(TOK_TYPEID); }
-typename            { return cpp98_keyword(TOK_TYPENAME); }
-using               { return cpp98_keyword(TOK_USING); }
-virtual             { return cpp98_keyword(TOK_VIRTUAL); }
+template            { return cpp98_keyword(TOK_TEMPLATE, yyscanner); }
+this                { return cpp98_keyword(TOK_THIS, yyscanner); }
+thread_local        { return cpp11_keyword(TOK_THREAD_LOCAL, yyscanner); } // C++11
+throw               { return cpp98_keyword(TOK_THROW, yyscanner); }
+true                { return cpp98_keyword(TOK_TRUE, yyscanner); }
+typeid              { return cpp98_keyword(TOK_TYPEID, yyscanner); }
+typename            { return cpp98_keyword(TOK_TYPENAME, yyscanner); }
+using               { return cpp98_keyword(TOK_USING, yyscanner); }
+virtual             { return cpp98_keyword(TOK_VIRTUAL, yyscanner); }
 wchar_t             { // CodeWarrior doesn't have wchar_t built in,
                       // and MSC has a command-line option to turn it off
                       if(PARSER.mode==configt::ansi_ct::flavourt::CODEWARRIOR)
-                        return make_identifier();
+                        return make_identifier(yyscanner);
                       else
-                        return cpp98_keyword(TOK_WCHAR_T);
+                        return cpp98_keyword(TOK_WCHAR_T, yyscanner);
                     }
-xor                 { return cpp98_keyword('^'); }
-xor_eq              { return cpp98_keyword(TOK_XORASSIGN); }
-".*"                { return cpp_operator(TOK_DOTPM); }
-"->*"               { return cpp_operator(TOK_ARROWPM); }
+xor                 { return cpp98_keyword('^', yyscanner); }
+xor_eq              { return cpp98_keyword(TOK_XORASSIGN, yyscanner); }
+".*"                { return cpp_operator(TOK_DOTPM, yyscanner); }
+"->*"               { return cpp_operator(TOK_ARROWPM, yyscanner); }
 "::"                { if(PARSER.cpp98)
-                        return cpp_operator(TOK_SCOPE);
+                        return cpp_operator(TOK_SCOPE, yyscanner);
                       else
                       {
                         yyless(1); // puts all but one : back into stream
@@ -911,9 +912,9 @@ xor_eq              { return cpp98_keyword(TOK_XORASSIGN); }
 __decltype          { if(PARSER.cpp98 &&
                          (PARSER.mode==configt::ansi_ct::flavourt::GCC ||
                           PARSER.mode==configt::ansi_ct::flavourt::CLANG))
-                        return cpp98_keyword(TOK_DECLTYPE);
+                        return cpp98_keyword(TOK_DECLTYPE, yyscanner);
                       else
-                        return make_identifier();
+                        return make_identifier(yyscanner);
                     }
 
 %{
@@ -923,38 +924,38 @@ __decltype          { if(PARSER.cpp98 &&
    http://clang.llvm.org/docs/LanguageExtensions.html#checks-for-type-trait-primitives */
 %}
 
-"__has_assign"      { loc(); return MSC_cpp_keyword(TOK_UNARY_TYPE_PREDICATE); }
-"__has_copy"        { loc(); return MSC_cpp_keyword(TOK_UNARY_TYPE_PREDICATE); }
-"__has_finalizer"   { loc(); return MSC_cpp_keyword(TOK_UNARY_TYPE_PREDICATE); }
-"__has_nothrow_assign" { loc(); return cpp98_keyword(TOK_UNARY_TYPE_PREDICATE); }
-"__has_nothrow_constructor" { loc(); return cpp98_keyword(TOK_UNARY_TYPE_PREDICATE); }
-"__has_nothrow_copy" { loc(); return cpp98_keyword(TOK_UNARY_TYPE_PREDICATE); }
-"__has_trivial_assign" { loc(); return cpp98_keyword(TOK_UNARY_TYPE_PREDICATE); }
-"__has_trivial_constructor" { loc(); return cpp98_keyword(TOK_UNARY_TYPE_PREDICATE); }
-"__has_trivial_copy" { loc(); return cpp98_keyword(TOK_UNARY_TYPE_PREDICATE); }
-"__has_trivial_destructor" { loc(); return cpp98_keyword(TOK_UNARY_TYPE_PREDICATE); }
-"__has_user_destructor" { loc(); return MSC_cpp_keyword(TOK_UNARY_TYPE_PREDICATE); }
-"__has_virtual_destructor" { loc(); return cpp98_keyword(TOK_UNARY_TYPE_PREDICATE); }
-"__is_abstract"     { loc(); return cpp98_keyword(TOK_UNARY_TYPE_PREDICATE); }
-"__is_base_of"      { loc(); return cpp98_keyword(TOK_BINARY_TYPE_PREDICATE); }
-"__is_class"        { loc(); return cpp98_keyword(TOK_UNARY_TYPE_PREDICATE); }
-"__is_convertible_to" { loc(); return cpp98_keyword(TOK_BINARY_TYPE_PREDICATE); }
-"__is_delegate"     { loc(); return MSC_cpp_keyword(TOK_UNARY_TYPE_PREDICATE); }
-"__is_empty"        { loc(); return cpp98_keyword(TOK_UNARY_TYPE_PREDICATE); }
-"__is_enum"         { loc(); return cpp98_keyword(TOK_UNARY_TYPE_PREDICATE); }
-"__is_interface_class" { loc(); return cpp98_keyword(TOK_UNARY_TYPE_PREDICATE); }
-"__is_pod"          { loc(); return cpp98_keyword(TOK_UNARY_TYPE_PREDICATE); }
-"__is_polymorphic"  { loc(); return cpp98_keyword(TOK_UNARY_TYPE_PREDICATE); }
-"__is_ref_array"    { loc(); return MSC_cpp_keyword(TOK_UNARY_TYPE_PREDICATE); }
-"__is_ref_class"    { loc(); return MSC_cpp_keyword(TOK_UNARY_TYPE_PREDICATE); }
-"__is_sealed"       { loc(); return MSC_cpp_keyword(TOK_UNARY_TYPE_PREDICATE); }
-"__is_simple_value_class" { loc(); return MSC_cpp_keyword(TOK_UNARY_TYPE_PREDICATE); }
-"__is_union"        { loc(); return cpp98_keyword(TOK_UNARY_TYPE_PREDICATE); }
-"__is_value_class"  { loc(); return MSC_cpp_keyword(TOK_UNARY_TYPE_PREDICATE); }
+"__has_assign"      { loc(); return MSC_cpp_keyword(TOK_UNARY_TYPE_PREDICATE, yyscanner); }
+"__has_copy"        { loc(); return MSC_cpp_keyword(TOK_UNARY_TYPE_PREDICATE, yyscanner); }
+"__has_finalizer"   { loc(); return MSC_cpp_keyword(TOK_UNARY_TYPE_PREDICATE, yyscanner); }
+"__has_nothrow_assign" { loc(); return cpp98_keyword(TOK_UNARY_TYPE_PREDICATE, yyscanner); }
+"__has_nothrow_constructor" { loc(); return cpp98_keyword(TOK_UNARY_TYPE_PREDICATE, yyscanner); }
+"__has_nothrow_copy" { loc(); return cpp98_keyword(TOK_UNARY_TYPE_PREDICATE, yyscanner); }
+"__has_trivial_assign" { loc(); return cpp98_keyword(TOK_UNARY_TYPE_PREDICATE, yyscanner); }
+"__has_trivial_constructor" { loc(); return cpp98_keyword(TOK_UNARY_TYPE_PREDICATE, yyscanner); }
+"__has_trivial_copy" { loc(); return cpp98_keyword(TOK_UNARY_TYPE_PREDICATE, yyscanner); }
+"__has_trivial_destructor" { loc(); return cpp98_keyword(TOK_UNARY_TYPE_PREDICATE, yyscanner); }
+"__has_user_destructor" { loc(); return MSC_cpp_keyword(TOK_UNARY_TYPE_PREDICATE, yyscanner); }
+"__has_virtual_destructor" { loc(); return cpp98_keyword(TOK_UNARY_TYPE_PREDICATE, yyscanner); }
+"__is_abstract"     { loc(); return cpp98_keyword(TOK_UNARY_TYPE_PREDICATE, yyscanner); }
+"__is_base_of"      { loc(); return cpp98_keyword(TOK_BINARY_TYPE_PREDICATE, yyscanner); }
+"__is_class"        { loc(); return cpp98_keyword(TOK_UNARY_TYPE_PREDICATE, yyscanner); }
+"__is_convertible_to" { loc(); return cpp98_keyword(TOK_BINARY_TYPE_PREDICATE, yyscanner); }
+"__is_delegate"     { loc(); return MSC_cpp_keyword(TOK_UNARY_TYPE_PREDICATE, yyscanner); }
+"__is_empty"        { loc(); return cpp98_keyword(TOK_UNARY_TYPE_PREDICATE, yyscanner); }
+"__is_enum"         { loc(); return cpp98_keyword(TOK_UNARY_TYPE_PREDICATE, yyscanner); }
+"__is_interface_class" { loc(); return cpp98_keyword(TOK_UNARY_TYPE_PREDICATE, yyscanner); }
+"__is_pod"          { loc(); return cpp98_keyword(TOK_UNARY_TYPE_PREDICATE, yyscanner); }
+"__is_polymorphic"  { loc(); return cpp98_keyword(TOK_UNARY_TYPE_PREDICATE, yyscanner); }
+"__is_ref_array"    { loc(); return MSC_cpp_keyword(TOK_UNARY_TYPE_PREDICATE, yyscanner); }
+"__is_ref_class"    { loc(); return MSC_cpp_keyword(TOK_UNARY_TYPE_PREDICATE, yyscanner); }
+"__is_sealed"       { loc(); return MSC_cpp_keyword(TOK_UNARY_TYPE_PREDICATE, yyscanner); }
+"__is_simple_value_class" { loc(); return MSC_cpp_keyword(TOK_UNARY_TYPE_PREDICATE, yyscanner); }
+"__is_union"        { loc(); return cpp98_keyword(TOK_UNARY_TYPE_PREDICATE, yyscanner); }
+"__is_value_class"  { loc(); return MSC_cpp_keyword(TOK_UNARY_TYPE_PREDICATE, yyscanner); }
 
-"__if_exists"       { loc(); return MSC_cpp_keyword(TOK_MSC_IF_EXISTS); }
-"__if_not_exists"   { loc(); return MSC_cpp_keyword(TOK_MSC_IF_NOT_EXISTS); }
-"__underlying_type" { loc(); return cpp98_keyword(TOK_UNDERLYING_TYPE); }
+"__if_exists"       { loc(); return MSC_cpp_keyword(TOK_MSC_IF_EXISTS, yyscanner); }
+"__if_not_exists"   { loc(); return MSC_cpp_keyword(TOK_MSC_IF_NOT_EXISTS, yyscanner); }
+"__underlying_type" { loc(); return cpp98_keyword(TOK_UNDERLYING_TYPE, yyscanner); }
 
 "["{ws}"repeatable" |
 "["{ws}"source_annotation_attribute" |
@@ -979,30 +980,30 @@ __decltype          { if(PARSER.cpp98 &&
 
 "__char16_t"     { if(PARSER.mode==configt::ansi_ct::flavourt::GCC ||
                       PARSER.mode==configt::ansi_ct::flavourt::CLANG)
-                     return cpp98_keyword(TOK_CHAR16_T); // GNU extension
+                     return cpp98_keyword(TOK_CHAR16_T, yyscanner); // GNU extension
                    else
-                     return make_identifier();
+                     return make_identifier(yyscanner);
                  }
 
 "__nullptr"     { if(PARSER.mode==configt::ansi_ct::flavourt::GCC ||
                       PARSER.mode==configt::ansi_ct::flavourt::CLANG)
-                     return cpp98_keyword(TOK_NULLPTR); // GNU extension
+                     return cpp98_keyword(TOK_NULLPTR, yyscanner); // GNU extension
                    else
-                     return make_identifier();
+                     return make_identifier(yyscanner);
                  }
 
 "__null"         { if(PARSER.mode==configt::ansi_ct::flavourt::GCC ||
                       PARSER.mode==configt::ansi_ct::flavourt::CLANG)
-                     return cpp98_keyword(TOK_NULLPTR); // GNU extension
+                     return cpp98_keyword(TOK_NULLPTR, yyscanner); // GNU extension
                    else
-                     return make_identifier();
+                     return make_identifier(yyscanner);
                  }
 
 "__char32_t"     { if(PARSER.mode==configt::ansi_ct::flavourt::GCC ||
                       PARSER.mode==configt::ansi_ct::flavourt::CLANG)
-                     return cpp98_keyword(TOK_CHAR32_T); // GNU extension
+                     return cpp98_keyword(TOK_CHAR32_T, yyscanner); // GNU extension
                    else
-                     return make_identifier();
+                     return make_identifier(yyscanner);
                  }
 
 "__declspec" |
@@ -1023,7 +1024,7 @@ __decltype          { if(PARSER.cpp98 &&
                     loc(); return TOK_MSC_DECLSPEC;
                   }
                   else
-                    return make_identifier();
+                    return make_identifier(yyscanner);
                 }
 
 "__pragma"      { if(PARSER.mode==configt::ansi_ct::flavourt::VISUAL_STUDIO)
@@ -1032,7 +1033,7 @@ __decltype          { if(PARSER.cpp98 &&
                     PARSER.parenthesis_counter=0;
                   }
                   else
-                    return make_identifier();
+                    return make_identifier(yyscanner);
                 }
 
 "__attribute__" |
@@ -1046,7 +1047,7 @@ __decltype          { if(PARSER.cpp98 &&
                     return TOK_GCC_ATTRIBUTE;
                   }
                   else
-                    return make_identifier();
+                    return make_identifier(yyscanner);
                 }
 
 "__aligned"     { /* ignore */ }
@@ -1084,7 +1085,7 @@ __decltype          { if(PARSER.cpp98 &&
                     // ignore
                   }
                   else
-                    return make_identifier();
+                    return make_identifier(yyscanner);
                 }
 
 "__align"       { /* an ARM extension */
@@ -1094,7 +1095,7 @@ __decltype          { if(PARSER.cpp98 &&
                     PARSER.parenthesis_counter=0;
                   }
                   else
-                    return make_identifier();
+                    return make_identifier(yyscanner);
                 }
 
 "__smc"         { /* an ARM extension */
@@ -1104,7 +1105,7 @@ __decltype          { if(PARSER.cpp98 &&
                     PARSER.parenthesis_counter=0;
                   }
                   else
-                    return make_identifier();
+                    return make_identifier(yyscanner);
                 }
 
 "__INTADDR__"   { /* an ARM extension */
@@ -1113,7 +1114,7 @@ __decltype          { if(PARSER.cpp98 &&
                     // ignore
                   }
                   else
-                    return make_identifier();
+                    return make_identifier(yyscanner);
                 }
 
 "__irq"         { /* an ARM extension */
@@ -1122,7 +1123,7 @@ __decltype          { if(PARSER.cpp98 &&
                     // ignore
                   }
                   else
-                    return make_identifier();
+                    return make_identifier(yyscanner);
                 }
 
 "__packed"      { /* an ARM extension */
@@ -1131,7 +1132,7 @@ __decltype          { if(PARSER.cpp98 &&
                     // ignore
                   }
                   else
-                    return make_identifier();
+                    return make_identifier(yyscanner);
                 }
 
 "__value_in_regs" { /* an ARM extension */
@@ -1140,7 +1141,7 @@ __decltype          { if(PARSER.cpp98 &&
                     // ignore
                   }
                   else
-                    return make_identifier();
+                    return make_identifier(yyscanner);
                 }
 
 "__weak"        { /* an ARM extension */
@@ -1149,7 +1150,7 @@ __decltype          { if(PARSER.cpp98 &&
                     // ignore
                   }
                   else
-                    return make_identifier();
+                    return make_identifier(yyscanner);
                 }
 
 "__writeonly"   { /* an ARM extension */
@@ -1158,7 +1159,7 @@ __decltype          { if(PARSER.cpp98 &&
                     // ignore
                   }
                   else
-                    return make_identifier();
+                    return make_identifier(yyscanner);
                 }
 
 "__global_reg"  { /* an ARM extension */
@@ -1168,7 +1169,7 @@ __decltype          { if(PARSER.cpp98 &&
                     PARSER.parenthesis_counter=0;
                   }
                   else
-                    return make_identifier();
+                    return make_identifier(yyscanner);
                 }
 
 "__svc"         { /* an ARM extension */
@@ -1178,7 +1179,7 @@ __decltype          { if(PARSER.cpp98 &&
                     PARSER.parenthesis_counter=0;
                   }
                   else
-                    return make_identifier();
+                    return make_identifier(yyscanner);
                 }
 
 "__svc_indirect" { /* an ARM extension */
@@ -1188,7 +1189,7 @@ __decltype          { if(PARSER.cpp98 &&
                     PARSER.parenthesis_counter=0;
                   }
                   else
-                    return make_identifier();
+                    return make_identifier(yyscanner);
                 }
 
 "__svc_indirect_r7" { /* an ARM extension */
@@ -1198,7 +1199,7 @@ __decltype          { if(PARSER.cpp98 &&
                     PARSER.parenthesis_counter=0;
                   }
                   else
-                    return make_identifier();
+                    return make_identifier(yyscanner);
                 }
 
 "__softfp"      { /* an ARM extension */
@@ -1207,7 +1208,7 @@ __decltype          { if(PARSER.cpp98 &&
                     // ignore
                   }
                   else
-                    return make_identifier();
+                    return make_identifier(yyscanner);
                 }
 
 "typeof"        { if(PARSER.cpp98 ||
@@ -1217,14 +1218,14 @@ __decltype          { if(PARSER.cpp98 &&
                      PARSER.mode==configt::ansi_ct::flavourt::ARM)
                     { loc(); return TOK_TYPEOF; }
                   else
-                    return make_identifier();
+                    return make_identifier(yyscanner);
                 }
 "__typeof"      { if(PARSER.mode==configt::ansi_ct::flavourt::GCC ||
                      PARSER.mode==configt::ansi_ct::flavourt::CLANG ||
                      PARSER.mode==configt::ansi_ct::flavourt::ARM)
                     { loc(); return TOK_TYPEOF; }
                   else
-                    return make_identifier();
+                    return make_identifier(yyscanner);
                 }
 
 "__typeof__"    { loc(); return TOK_TYPEOF; }
@@ -1233,14 +1234,14 @@ __decltype          { if(PARSER.cpp98 &&
                      PARSER.mode==configt::ansi_ct::flavourt::ARM)
                     { loc(); return TOK_MSC_FORCEINLINE; }
                   else
-                    return make_identifier();
+                    return make_identifier(yyscanner);
                 }
 
 "_inline"       { // http://msdn.microsoft.com/en-us/library/z8y1yy88.aspx
                   if(PARSER.mode==configt::ansi_ct::flavourt::VISUAL_STUDIO)
                     { loc(); return TOK_INLINE; }
                   else
-                    return make_identifier();
+                    return make_identifier(yyscanner);
                 }
 
 "__inline"      { loc(); return TOK_INLINE; }
@@ -1251,37 +1252,37 @@ __decltype          { if(PARSER.cpp98 &&
                      PARSER.mode==configt::ansi_ct::flavourt::ARM)
                     { loc(); return TOK_GCC_LABEL; }
                   else
-                    return make_identifier();
+                    return make_identifier(yyscanner);
                 }
 
 "__try"         { if(PARSER.mode==configt::ansi_ct::flavourt::VISUAL_STUDIO)
                     { loc(); return TOK_MSC_TRY; }
                   else
-                    return make_identifier();
+                    return make_identifier(yyscanner);
                 }
 
 "try"           { if(PARSER.cpp98) // C++?
                     { loc(); return TOK_TRY; }
                   else
-                    return make_identifier();
+                    return make_identifier(yyscanner);
                 }
 
 "__finally"     { if(PARSER.mode==configt::ansi_ct::flavourt::VISUAL_STUDIO)
                     { loc(); return TOK_MSC_FINALLY; }
                   else
-                    return make_identifier();
+                    return make_identifier(yyscanner);
                 }
 
 "__except"      { if(PARSER.mode==configt::ansi_ct::flavourt::VISUAL_STUDIO)
                     { loc(); return TOK_MSC_EXCEPT; }
                   else
-                    return make_identifier();
+                    return make_identifier(yyscanner);
                 }
 
 "__leave"       { if(PARSER.mode==configt::ansi_ct::flavourt::VISUAL_STUDIO)
                     { loc(); return TOK_MSC_LEAVE; }
                   else
-                    return make_identifier();
+                    return make_identifier(yyscanner);
                 }
 
 {CPROVER_PREFIX}"atomic"       { loc(); return TOK_CPROVER_ATOMIC; }
@@ -1383,7 +1384,7 @@ __decltype          { if(PARSER.cpp98 &&
                      PARSER.mode==configt::ansi_ct::flavourt::ARM)
                     { loc(); return TOK_THREAD_LOCAL; }
                   else
-                    return make_identifier();
+                    return make_identifier(yyscanner);
                 }
 
   /* This is a C11 keyword */
@@ -1394,7 +1395,7 @@ __decltype          { if(PARSER.cpp98 &&
                       PARSER.mode==configt::ansi_ct::flavourt::ARM))
                     { loc(); return TOK_ALIGNAS; }
                   else
-                    return make_identifier();
+                    return make_identifier(yyscanner);
                 }
 
   /* This is a C11 keyword */
@@ -1406,7 +1407,7 @@ __decltype          { if(PARSER.cpp98 &&
                       PARSER.mode==configt::ansi_ct::flavourt::VISUAL_STUDIO))
                     { loc(); return TOK_ALIGNOF; }
                   else
-                    return make_identifier();
+                    return make_identifier(yyscanner);
                 }
 
   /* This is a C11 keyword. It can be used as a type qualifier
@@ -1427,7 +1428,7 @@ __decltype          { if(PARSER.cpp98 &&
                        PARSER.mode==configt::ansi_ct::flavourt::ARM))
                     { loc(); return TOK_ATOMIC_TYPE_SPECIFIER; }
                   else
-                    return make_identifier();
+                    return make_identifier(yyscanner);
                 }
 
 "_Atomic"       { if(!PARSER.cpp98 &&
@@ -1436,7 +1437,7 @@ __decltype          { if(PARSER.cpp98 &&
                       PARSER.mode==configt::ansi_ct::flavourt::ARM))
                     { loc(); return TOK_ATOMIC_TYPE_QUALIFIER; }
                   else
-                    return make_identifier();
+                    return make_identifier(yyscanner);
                 }
 
   /* This is a C11 keyword */
@@ -1447,7 +1448,7 @@ __decltype          { if(PARSER.cpp98 &&
                       PARSER.mode==configt::ansi_ct::flavourt::ARM))
                     { loc(); return TOK_GENERIC; }
                   else
-                    return make_identifier();
+                    return make_identifier(yyscanner);
                 }
 
   /* This is a C11 keyword */
@@ -1458,7 +1459,7 @@ __decltype          { if(PARSER.cpp98 &&
                       PARSER.mode==configt::ansi_ct::flavourt::ARM))
                     { loc(); return TOK_IMAGINARY; }
                   else
-                    return make_identifier();
+                    return make_identifier(yyscanner);
                 }
 
   /* This is a C11 keyword */
@@ -1469,7 +1470,7 @@ __decltype          { if(PARSER.cpp98 &&
                       PARSER.mode==configt::ansi_ct::flavourt::ARM))
                     { loc(); return TOK_NORETURN; }
                   else
-                    return make_identifier();
+                    return make_identifier(yyscanner);
                 }
 
   /* This is a C11 keyword */
@@ -1480,7 +1481,7 @@ __decltype          { if(PARSER.cpp98 &&
                        PARSER.mode==configt::ansi_ct::flavourt::ARM))
                     { loc(); return TOK_STATIC_ASSERT; }
                   else
-                    return make_identifier();
+                    return make_identifier(yyscanner);
                 }
 
   /* This is a C11 keyword */
@@ -1491,7 +1492,7 @@ __decltype          { if(PARSER.cpp98 &&
                       PARSER.mode==configt::ansi_ct::flavourt::ARM))
                     { loc(); return TOK_THREAD_LOCAL; }
                   else
-                    return make_identifier();
+                    return make_identifier(yyscanner);
                 }
 
   /* This is a clang extension */
@@ -1499,7 +1500,7 @@ __decltype          { if(PARSER.cpp98 &&
 "_Nullable" { if(PARSER.mode==configt::ansi_ct::flavourt::CLANG)
                 { /* ignore */ }
               else
-                return make_identifier();
+                return make_identifier(yyscanner);
             }
 
   /* This is a clang extension */
@@ -1507,7 +1508,7 @@ __decltype          { if(PARSER.cpp98 &&
 "_Nonnull" { if(PARSER.mode==configt::ansi_ct::flavourt::CLANG)
                 { /* ignore */ }
               else
-                return make_identifier();
+                return make_identifier(yyscanner);
             }
 
   /* This is a clang extension */
@@ -1515,7 +1516,7 @@ __decltype          { if(PARSER.cpp98 &&
 "_Null_unspecified" { if(PARSER.mode==configt::ansi_ct::flavourt::CLANG)
                 { /* ignore */ }
               else
-                return make_identifier();
+                return make_identifier(yyscanner);
             }
 
 }
@@ -1556,7 +1557,7 @@ __decltype          { if(PARSER.cpp98 &&
 
 <GRAMMAR>{
 
-{identifier}    { return make_identifier(); }
+{identifier}    { return make_identifier(yyscanner); }
 
 {integer_s}     { newstack(yyansi_clval);
                   parser_stack(yyansi_clval)=convert_integer_literal(yytext);
@@ -1567,7 +1568,10 @@ __decltype          { if(PARSER.cpp98 &&
 {clang_ext_float_s} { if(PARSER.mode!=configt::ansi_ct::flavourt::GCC &&
                          PARSER.mode != configt::ansi_ct::flavourt::CLANG)
                       {
-                        yyansi_cerror("Floating-point constant with unsupported extension");
+                        yyansi_cerror(
+                          PARSER,
+                          yyscanner,
+                          "Floating-point constant with unsupported extension");
                         return TOK_SCANNER_ERROR;
                       }
                       newstack(yyansi_clval);
@@ -1578,7 +1582,10 @@ __decltype          { if(PARSER.cpp98 &&
 
 {gcc_ext_float_s} { if(PARSER.mode!=configt::ansi_ct::flavourt::GCC)
                     {
-                      yyansi_cerror("Floating-point constant with unsupported extension");
+                      yyansi_cerror(
+                        PARSER,
+                        yyscanner,
+                        "Floating-point constant with unsupported extension");
                       return TOK_SCANNER_ERROR;
                     }
                     newstack(yyansi_clval);
@@ -1789,7 +1796,7 @@ __decltype          { if(PARSER.cpp98 &&
                 }
 {ws}            { /* ignore */ }
 {newline}       { /* ignore */ }
-{identifier}    { return make_identifier(); }
+{identifier}    { return make_identifier(yyscanner); }
 .               { loc(); return yytext[0]; }
 }
 
@@ -1826,7 +1833,3 @@ __decltype          { if(PARSER.cpp98 &&
 }
 
 <<EOF>>         { yyterminate(); /* done! */ }
-
-%%
-
-int yywrap() { return 1; }

--- a/src/cpp/cpp_language.cpp
+++ b/src/cpp/cpp_language.cpp
@@ -102,11 +102,9 @@ bool cpp_languaget::parse(
   std::istringstream i_preprocessed(o_preprocessed.str());
 
   // parsing
-
-  cpp_parser.clear();
+  cpp_parsert cpp_parser{message_handler};
   cpp_parser.set_file(path);
   cpp_parser.in=&i_preprocessed;
-  cpp_parser.log.set_message_handler(message_handler);
   cpp_parser.mode=config.ansi_c.mode;
 
   bool result=cpp_parser.parse();
@@ -245,11 +243,9 @@ bool cpp_languaget::to_expr(
   std::istringstream i_preprocessed(code);
 
   // parsing
-
-  cpp_parser.clear();
+  cpp_parsert cpp_parser{message_handler};
   cpp_parser.set_file(irep_idt());
   cpp_parser.in=&i_preprocessed;
-  cpp_parser.log.set_message_handler(message_handler);
 
   bool result=cpp_parser.parse();
 

--- a/src/cpp/cpp_parser.cpp
+++ b/src/cpp/cpp_parser.cpp
@@ -15,9 +15,7 @@ Author: Daniel Kroening, kroening@cs.cmu.edu
 
 #include <ansi-c/gcc_version.h>
 
-cpp_parsert cpp_parser;
-
-bool cpp_parse();
+bool cpp_parse(cpp_parsert &, message_handlert &);
 
 bool cpp_parsert::parse()
 {
@@ -35,18 +33,18 @@ bool cpp_parsert::parse()
   }
 
   // We use the ANSI-C scanner
-  ansi_c_parser.cpp98=true;
-  ansi_c_parser.cpp11 =
+  token_buffer.ansi_c_parser.cpp98 = true;
+  token_buffer.ansi_c_parser.cpp11 =
     config.cpp.cpp_standard == configt::cppt::cpp_standardt::CPP11 ||
     config.cpp.cpp_standard == configt::cppt::cpp_standardt::CPP14 ||
     config.cpp.cpp_standard == configt::cppt::cpp_standardt::CPP17;
-  ansi_c_parser.ts_18661_3_Floatn_types = false; // these are still typedefs
-  ansi_c_parser.float16_type = *support_float16;
-  ansi_c_parser.bf16_type = *support_float16;
-  ansi_c_parser.in=in;
-  ansi_c_parser.mode=mode;
-  ansi_c_parser.set_file(get_file());
-  ansi_c_parser.log.set_message_handler(log.get_message_handler());
+  token_buffer.ansi_c_parser.ts_18661_3_Floatn_types =
+    false; // these are still typedefs
+  token_buffer.ansi_c_parser.float16_type = *support_float16;
+  token_buffer.ansi_c_parser.bf16_type = *support_float16;
+  token_buffer.ansi_c_parser.in = in;
+  token_buffer.ansi_c_parser.mode = mode;
+  token_buffer.ansi_c_parser.set_file(get_file());
 
-  return cpp_parse();
+  return cpp_parse(*this, log.get_message_handler());
 }

--- a/src/cpp/cpp_parser.h
+++ b/src/cpp/cpp_parser.h
@@ -36,9 +36,11 @@ public:
     asm_block_following=false;
   }
 
-  cpp_parsert()
-    : mode(configt::ansi_ct::flavourt::ANSI),
+  explicit cpp_parsert(message_handlert &message_handler)
+    : parsert(message_handler),
+      mode(configt::ansi_ct::flavourt::ANSI),
       recognize_wchar_t(true),
+      token_buffer(message_handler),
       asm_block_following(false),
       support_float16(std::nullopt)
   {
@@ -72,7 +74,5 @@ public:
 protected:
   std::optional<bool> support_float16;
 };
-
-extern cpp_parsert cpp_parser;
 
 #endif // CPROVER_CPP_CPP_PARSER_H

--- a/src/cpp/cpp_token_buffer.cpp
+++ b/src/cpp/cpp_token_buffer.cpp
@@ -11,8 +11,6 @@ Author: Daniel Kroening, kroening@cs.cmu.edu
 
 #include "cpp_token_buffer.h"
 
-#include <ansi-c/ansi_c_parser.h>
-
 int cpp_token_buffert::LookAhead(unsigned offset)
 {
   PRECONDITION(current_pos <= token_vector.size());
@@ -67,8 +65,8 @@ int cpp_token_buffert::LookAhead(unsigned offset, cpp_tokent &token)
   return token.kind;
 }
 
-int yyansi_clex();
-extern char *yyansi_ctext;
+int yyansi_clex(void *);
+char *yyansi_cget_text(void *);
 
 void cpp_token_buffert::read_token()
 {
@@ -78,8 +76,8 @@ void cpp_token_buffert::read_token()
   int kind;
 
   ansi_c_parser.stack.clear();
-  kind=yyansi_clex();
-  tokens.back().text=yyansi_ctext;
+  kind = yyansi_clex(ansi_c_scanner_state);
+  tokens.back().text = yyansi_cget_text(ansi_c_scanner_state);
   if(ansi_c_parser.stack.size()==1)
   {
     tokens.back().data=ansi_c_parser.stack.front();

--- a/src/cpp/cpp_token_buffer.h
+++ b/src/cpp/cpp_token_buffer.h
@@ -12,17 +12,40 @@ Author: Daniel Kroening, kroening@cs.cmu.edu
 #ifndef CPROVER_CPP_CPP_TOKEN_BUFFER_H
 #define CPROVER_CPP_CPP_TOKEN_BUFFER_H
 
+#include <util/config.h>
+#include <util/invariant.h>
+
+#include <ansi-c/ansi_c_parser.h>
+
 #include "cpp_token.h"
 
 #include <list>
 
-#include <util/invariant.h>
+int yyansi_clex_init_extra(ansi_c_parsert *, void **);
+int yyansi_clex_destroy(void *);
+int yyansi_cparse(ansi_c_parsert &, void *);
 
 class cpp_token_buffert
 {
 public:
-  cpp_token_buffert():current_pos(0)
+  explicit cpp_token_buffert(message_handlert &message_handler)
+    : ansi_c_parser(message_handler), current_pos(0)
   {
+    // We use the ANSI-C scanner
+    ansi_c_parser.cpp98 = true;
+    ansi_c_parser.cpp11 =
+      config.cpp.cpp_standard == configt::cppt::cpp_standardt::CPP11 ||
+      config.cpp.cpp_standard == configt::cppt::cpp_standardt::CPP14 ||
+      config.cpp.cpp_standard == configt::cppt::cpp_standardt::CPP17;
+    ansi_c_parser.ts_18661_3_Floatn_types = false;
+    ansi_c_parser.mode = config.ansi_c.mode;
+
+    yyansi_clex_init_extra(&ansi_c_parser, &ansi_c_scanner_state);
+  }
+
+  ~cpp_token_buffert()
+  {
+    yyansi_clex_destroy(ansi_c_scanner_state);
   }
 
   typedef unsigned int post;
@@ -51,6 +74,8 @@ public:
     return tokens.back();
   }
 
+  ansi_c_parsert ansi_c_parser;
+
 protected:
   typedef std::list<cpp_tokent> tokenst;
   tokenst tokens;
@@ -58,6 +83,8 @@ protected:
   std::vector<tokenst::iterator> token_vector;
 
   post current_pos;
+
+  void *ansi_c_scanner_state;
 
   // get another token from lexer
   void read_token();

--- a/src/goto-instrument/contracts/contracts_wrangler.cpp
+++ b/src/goto-instrument/contracts/contracts_wrangler.cpp
@@ -139,11 +139,17 @@ void contracts_wranglert::mangle(
 
   // Parse the fake function.
   std::istringstream is(pr.str());
-  ansi_c_parser.clear();
+  ansi_c_parsert ansi_c_parser{message_handler};
   ansi_c_parser.set_line_no(0);
   ansi_c_parser.set_file("<predicate>");
   ansi_c_parser.in = &is;
-  ansi_c_scanner_init();
+  ansi_c_parser.for_has_scope = config.ansi_c.for_has_scope;
+  ansi_c_parser.ts_18661_3_Floatn_types = config.ansi_c.ts_18661_3_Floatn_types;
+  ansi_c_parser.float16_type = config.ansi_c.float16_type;
+  ansi_c_parser.bf16_type = config.ansi_c.bf16_type;
+  ansi_c_parser.cpp98 = false; // it's not C++
+  ansi_c_parser.cpp11 = false; // it's not C++
+  ansi_c_parser.mode = config.ansi_c.mode;
   ansi_c_parser.parse();
 
   // Extract the invariants from prase_tree.

--- a/unit/cpp_scanner.cpp
+++ b/unit/cpp_scanner.cpp
@@ -1,3 +1,11 @@
+/*******************************************************************\
+
+Module: CPP lexer test
+
+Author: Daniel Kroening, 2015
+
+\*******************************************************************/
+
 #include <fstream>
 #include <iostream>
 
@@ -32,6 +40,9 @@ int main(int argc, const char *argv[])
   ansi_c_parser.mode=ansi_c_parsert::GCC;
   ansi_c_parser.cpp98=true;
   ansi_c_parser.cpp11=false;
+  ansi_c_parser.ts_18661_3_Floatn_types = false;
+  ansi_c_parser.float16_type = false;
+  ansi_c_parser.bf16_type = false;
   ansi_c_parser.in=&in;
   cpp_parser.in=&in;
 


### PR DESCRIPTION
This both avoids an object of static lifetime as well as it fixes the (transitive) use of the deprecated messaget() constructor.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
