### PR TITLE
Remove deprecated messaget() constructor

### DIFF
--- a/src/goto-symex/complexity_limiter.h
+++ b/src/goto-symex/complexity_limiter.h
@@ -48,8 +48,6 @@ class optionst;
 class complexity_limitert
 {
 public:
-  complexity_limitert() = default;
-
   complexity_limitert(message_handlert &logger, const optionst &options);
 
   /// Is the complexity module active?

--- a/src/util/message.h
+++ b/src/util/message.h
@@ -10,14 +10,13 @@ Author: Daniel Kroening, kroening@kroening.com
 #ifndef CPROVER_UTIL_MESSAGE_H
 #define CPROVER_UTIL_MESSAGE_H
 
+#include "invariant.h"
+#include "source_location.h"
+
 #include <functional>
 #include <iosfwd>
 #include <sstream>
 #include <string>
-
-#include "deprecate.h"
-#include "invariant.h"
-#include "source_location.h"
 
 class json_objectt;
 class jsont;
@@ -190,13 +189,6 @@ public:
   }
 
   // constructors, destructor
-
-  DEPRECATED(SINCE(2019, 1, 7, "use messaget(message_handler) instead"))
-  messaget():
-    message_handler(nullptr),
-    mstream(M_DEBUG, *this)
-  {
-  }
 
   messaget(const messaget &other):
     message_handler(other.message_handler),

--- a/src/util/parser.h
+++ b/src/util/parser.h
@@ -12,7 +12,6 @@ Author: Daniel Kroening, kroening@kroening.com
 #ifndef CPROVER_UTIL_PARSER_H
 #define CPROVER_UTIL_PARSER_H
 
-#include "deprecate.h"
 #include "expr.h"
 #include "message.h"
 
@@ -29,11 +28,6 @@ public:
   std::string this_line, last_line;
 
   std::vector<exprt> stack;
-
-  DEPRECATED(SINCE(2023, 12, 20, "use parsert(message_handler) instead"))
-  parsert() : in(nullptr), line_no(0), previous_line_no(0), column(1)
-  {
-  }
 
   explicit parsert(message_handlert &message_handler)
     : in(nullptr),
@@ -135,11 +129,8 @@ public:
     column+=token_width;
   }
 
-  // should be protected or even just be a reference to a message handler, but
-  // for now enables a step-by-step transition
-  messaget log;
-
 protected:
+  messaget log;
   source_locationt source_location;
   unsigned line_no, previous_line_no;
   unsigned column;


### PR DESCRIPTION
It is now no longer possible to construct a messaget object that is not fully configured, i.e., lacks a message handler.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
