### PR TITLE
Support __builtin_dynamic_object_size

### DIFF
--- a/src/ansi-c/c_typecheck_expr.cpp
+++ b/src/ansi-c/c_typecheck_expr.cpp
@@ -3512,11 +3512,15 @@ exprt c_typecheck_baset::do_special_functions(
 
     return typecast_exprt(expr.arguments()[0], expr.type());
   }
-  else if(identifier=="__builtin_object_size")
+  else if(
+    identifier == "__builtin_object_size" ||
+    identifier == "__builtin_dynamic_object_size")
   {
-    // this is a gcc extension to provide information about
+    // These are gcc extensions to provide information about
     // object sizes at compile time
     // http://gcc.gnu.org/onlinedocs/gcc/Object-Size-Checking.html
+    // Our behavior is as if it was never possible to determine the object that
+    // the pointer pointed to.
 
     if(expr.arguments().size()!=2)
     {

--- a/src/ansi-c/compiler_headers/gcc_builtin_headers_mem_string.h
+++ b/src/ansi-c/compiler_headers/gcc_builtin_headers_mem_string.h
@@ -119,6 +119,7 @@ void* __builtin_memmove(void*, const void*, __CPROVER_size_t);
 void* __builtin_mempcpy(void*, const void*, __CPROVER_size_t);
 void* __builtin_memset(void*, int, __CPROVER_size_t);
 __CPROVER_size_t __builtin_object_size(const void*, int);
+__CPROVER_size_t __builtin_dynamic_object_size(const void*, int);
 int __builtin_popcount(unsigned);
 int __builtin_popcountimax(uintmax_t);
 int __builtin_popcountll(unsigned long long int x);


### PR DESCRIPTION
Use the same approximation of the behaviour as we already did for `__builtin_object_size`.

Fixes: #8116

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
