### PR TITLE
Conversion check: fix off-by-one error for float-to-unsigned

### DIFF
--- a/regression/cbmc/overflow/float_conversion.c
+++ b/regression/cbmc/overflow/float_conversion.c
@@ -1,0 +1,20 @@
+#include <stdint.h>
+
+int main()
+{
+  uint32_t u = 0xffffffffu;
+
+  // since the double type seems to be implemented with a IEEE 754 binary64
+  // format in CBMC, which has 53 bits of mantissa, double has enough bits to
+  // represent the exact value of u, use, e.g., http://weitz.de/ieee/ to check;
+  // therefore, C17, section 6.3.1.4, paragraph 2 says that this is
+  // defined behavior and d should store the exact value that u stores
+  double d = u;
+
+  // defined behavior behavior as well, by C17 section 6.3.1.4, paragraph 1,
+  // because the 'unsigned' type can represent the value; however,
+  // cbmc --conversion-check used to complain
+  u = (uint32_t)d;
+
+  return 0;
+}

--- a/regression/cbmc/overflow/float_conversion.desc
+++ b/regression/cbmc/overflow/float_conversion.desc
@@ -1,0 +1,8 @@
+CORE
+float_conversion.c
+
+^VERIFICATION SUCCESSFUL$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring

--- a/src/ansi-c/goto_check_c.cpp
+++ b/src/ansi-c/goto_check_c.cpp
@@ -796,7 +796,7 @@ void goto_check_ct::conversion_check(const exprt &expr, const guardt &guard)
       {
         // Note that the fractional part is truncated!
         ieee_floatt upper(to_floatbv_type(old_type));
-        upper.from_integer(power(2, new_width) - 1);
+        upper.from_integer(power(2, new_width));
         const binary_relation_exprt no_overflow_upper(
           op, ID_lt, upper.to_expr());
 


### PR DESCRIPTION
We use less-than in the comparison, so make the bound one larger than the largest representable value (as we do in the other cases of float-to-signed/unsigned conversion checks).

Fixes: #8131

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
