### PR TITLE
CMake builds: support system-installed CaDiCaL

### DIFF
--- a/src/solvers/CMakeLists.txt
+++ b/src/solvers/CMakeLists.txt
@@ -167,6 +167,19 @@ foreach(SOLVER ${sat_impl})
             ${cadical_SOURCE_DIR}/src
         )
         target_link_libraries(solvers cadical_ipasir)
+    elseif("${SOLVER}" STREQUAL "system-cadical")
+        include(CheckIncludeFileCXX)
+        # if/when we move to CMake 3.12 (or later) we could also check for the
+        # library via CMAKE_REQUIRED_LIBRARIES
+        find_path(cadical_header_found "cadical.hpp")
+        if(cadical_header_found)
+            message(STATUS "Building solvers with cadical (${cadical_header_found})")
+            target_compile_definitions(solvers PUBLIC SATCHECK_CADICAL HAVE_CADICAL)
+            target_include_directories(solvers PRIVATE ${cadical_header_found})
+            target_link_libraries(solvers cadical)
+        else()
+            message(FATAL_ERROR "Unable to find header file for preinstalled cadical")
+        endif()
     elseif("${SOLVER}" STREQUAL "ipasir-custom")
         message(STATUS "Building with IPASIR solver linking: custom solver provided")
 


### PR DESCRIPTION
Just like we support system-installed MiniSat2 we now support CaDiCaL when selecting "system-cadical" as solver.

Fixes: #8113

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
