### PR TITLE
Reduce Thomas and Fotis code ownership

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -35,7 +35,7 @@
 
 # These files change frequently and changes are high-risk
 
-/src/cbmc/ @kroening @tautschnig @peterschrammel @NlightNFotis
+/src/cbmc/ @kroening @tautschnig @peterschrammel
 /src/goto-programs/ @kroening @tautschnig @peterschrammel
 /src/util/ @kroening @tautschnig @peterschrammel
 /src/solvers/refinement @martin-cs @peterschrammel
@@ -43,13 +43,13 @@
 /jbmc/src/java_bytecode/ @peterschrammel @TGWDB
 /src/analyses/ @martin-cs @peterschrammel
 /src/pointer-analysis/ @martin-cs @peterschrammel
-/src/libcprover-cpp @NlightNFotis @esteffin @TGWDB @peterschrammel
-/src/libcprover-rust @NlightNFotis @TGWDB @peterschrammel @esteffin
+/src/libcprover-cpp @esteffin @TGWDB @peterschrammel
+/src/libcprover-rust @TGWDB @peterschrammel @esteffin
 
 # These files change frequently and changes are medium-risk
 
 /src/goto-analyzer/ @martin-cs @peterschrammel
-/src/goto-bmc/ @NlightNFotis @esteffin @TGWDB @peterschrammel
+/src/goto-bmc/ @esteffin @TGWDB @peterschrammel
 /src/goto-harness/ @martin-cs @peterschrammel
 /src/goto-instrument/ @martin-cs @peterschrammel @tautschnig @kroening
 /src/goto-instrument/contracts/ @tautschnig @feliperodri @remi-delmas-3000
@@ -61,9 +61,9 @@
 /jbmc/src/janalyzer/ @peterschrammel @TGWDB
 /jbmc/src/jdiff/ @peterschrammel
 /src/cpp/ @kroening @tautschnig @peterschrammel
-/src/solvers/smt2 @kroening @martin-cs @peterschrammel @NlightNFotis @TGWDB
-/src/solvers/smt2_incremental @peterschrammel @thomasspriggs @NlightNFotis @TGWDB @esteffin
-/src/solvers/Makefile @kroening @tautschnig @peterschrammel @NlightNFotis @TGWDB @esteffin
+/src/solvers/smt2 @kroening @martin-cs @peterschrammel @TGWDB
+/src/solvers/smt2_incremental @peterschrammel @thomasspriggs @TGWDB @esteffin
+/src/solvers/Makefile @kroening @tautschnig @peterschrammel @TGWDB @esteffin
 /src/statement-list/ @kroening @tautschnig @peterschrammel
 
 /cmake/        @diffblue/diffblue-opensource

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -35,7 +35,7 @@
 
 # These files change frequently and changes are high-risk
 
-/src/cbmc/ @kroening @tautschnig @peterschrammel @NlightNFotis @thomasspriggs
+/src/cbmc/ @kroening @tautschnig @peterschrammel @NlightNFotis
 /src/goto-programs/ @kroening @tautschnig @peterschrammel
 /src/util/ @kroening @tautschnig @peterschrammel
 /src/solvers/refinement @martin-cs @peterschrammel
@@ -43,13 +43,13 @@
 /jbmc/src/java_bytecode/ @peterschrammel @TGWDB
 /src/analyses/ @martin-cs @peterschrammel
 /src/pointer-analysis/ @martin-cs @peterschrammel
-/src/libcprover-cpp @NlightNFotis @thomasspriggs @esteffin @TGWDB @peterschrammel
-/src/libcprover-rust @NlightNFotis @thomasspriggs @TGWDB @peterschrammel @esteffin
+/src/libcprover-cpp @NlightNFotis @esteffin @TGWDB @peterschrammel
+/src/libcprover-rust @NlightNFotis @TGWDB @peterschrammel @esteffin
 
 # These files change frequently and changes are medium-risk
 
 /src/goto-analyzer/ @martin-cs @peterschrammel
-/src/goto-bmc/ @NlightNFotis @thomasspriggs @esteffin @TGWDB @peterschrammel
+/src/goto-bmc/ @NlightNFotis @esteffin @TGWDB @peterschrammel
 /src/goto-harness/ @martin-cs @peterschrammel
 /src/goto-instrument/ @martin-cs @peterschrammel @tautschnig @kroening
 /src/goto-instrument/contracts/ @tautschnig @feliperodri @remi-delmas-3000
@@ -61,9 +61,9 @@
 /jbmc/src/janalyzer/ @peterschrammel @TGWDB
 /jbmc/src/jdiff/ @peterschrammel
 /src/cpp/ @kroening @tautschnig @peterschrammel
-/src/solvers/smt2 @kroening @martin-cs @peterschrammel @thomasspriggs @NlightNFotis @TGWDB
+/src/solvers/smt2 @kroening @martin-cs @peterschrammel @NlightNFotis @TGWDB
 /src/solvers/smt2_incremental @peterschrammel @thomasspriggs @NlightNFotis @TGWDB @esteffin
-/src/solvers/Makefile @kroening @tautschnig @peterschrammel @thomasspriggs @NlightNFotis @TGWDB @esteffin
+/src/solvers/Makefile @kroening @tautschnig @peterschrammel @NlightNFotis @TGWDB @esteffin
 /src/statement-list/ @kroening @tautschnig @peterschrammel
 
 /cmake/        @diffblue/diffblue-opensource


### PR DESCRIPTION
This PR removes my code ownership except for that of the incremental SMT2 decision procedure. I am expecting the time I can make available for code reviews to be rather limited in the immediate future. As I do not wish to hold up anyone else's work waiting for my review, I am reducing the number of areas for which I am codeowner. I intend to retain code ownership of the incremental SMT2 decision procedure as I have particular expertise in this area.

Included in this PR is a similar change for Fotis.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
