### PR TITLE
Linking: only rename file-local symbols

### DIFF
--- a/regression/cbmc/Linking9/f1.c
+++ b/regression/cbmc/Linking9/f1.c
@@ -1,0 +1,8 @@
+static void f()
+{
+}
+void g()
+{
+  f();
+  int x = 42;
+}

--- a/regression/cbmc/Linking9/f2.c
+++ b/regression/cbmc/Linking9/f2.c
@@ -1,0 +1,4 @@
+void f()
+{
+  __CPROVER_assert(0, "unreachable");
+}

--- a/regression/cbmc/Linking9/f3.c
+++ b/regression/cbmc/Linking9/f3.c
@@ -1,0 +1,9 @@
+extern void f();
+extern void g();
+
+int main()
+{
+  g();
+  f();
+  return 0;
+}

--- a/regression/cbmc/Linking9/test.desc
+++ b/regression/cbmc/Linking9/test.desc
@@ -1,0 +1,8 @@
+CORE
+f3.c
+f1.c f2.c
+^VERIFICATION FAILED$
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring

--- a/src/linking/linking_class.h
+++ b/src/linking/linking_class.h
@@ -48,21 +48,24 @@ public:
   /// \return True, iff linking failed with unresolvable conflicts.
   bool link(const symbol_table_baset &src_symbol_table);
 
-  rename_symbolt rename_symbol;
+  rename_symbolt rename_main_symbol, rename_new_symbol;
   casting_replace_symbolt object_type_updates;
 
 protected:
-  bool needs_renaming_type(
-    const symbolt &old_symbol,
-    const symbolt &new_symbol);
+  enum renamingt
+  {
+    NO_RENAMING,
+    RENAME_OLD,
+    RENAME_NEW
+  };
 
-  bool needs_renaming_non_type(
-    const symbolt &old_symbol,
-    const symbolt &new_symbol);
+  renamingt
+  needs_renaming_type(const symbolt &old_symbol, const symbolt &new_symbol);
 
-  bool needs_renaming(
-    const symbolt &old_symbol,
-    const symbolt &new_symbol)
+  renamingt
+  needs_renaming_non_type(const symbolt &old_symbol, const symbolt &new_symbol);
+
+  renamingt needs_renaming(const symbolt &old_symbol, const symbolt &new_symbol)
   {
     if(new_symbol.is_type)
       return needs_renaming_type(old_symbol, new_symbol);


### PR DESCRIPTION
Rather than renaming whatever is to be added to an existing symbol table, always rename file-local symbols. This will make sure that we do not rename a symbol that a later translation unit wants to refer to.

Fixes: #7720

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
