### PR TITLE
C front-end: GCC >= 12 support __builtin_shufflevector

### DIFF
--- a/regression/cbmc/gcc_vector3/main.c
+++ b/regression/cbmc/gcc_vector3/main.c
@@ -9,7 +9,7 @@ typedef union {
 } vector_u;
 #endif
 
-int main()
+void test_shuffle()
 {
 #if defined(__GNUC__) && !defined(__clang__)
   // https://gcc.gnu.org/onlinedocs/gcc/Vector-Extensions.html
@@ -31,7 +31,12 @@ int main()
   assert(res.members[1] == 5);
   assert(res.members[2] == 3);
   assert(res.members[3] == 6);
-#elif defined(__clang__)
+#endif
+}
+
+void test_shufflevector(void)
+{
+#if defined(__clang__) || (defined(__GNUC__) && __GNUC__ >= 12)
   v4si a = {1, 2, 3, 4};
   v4si b = {5, 6, 7, 8};
 
@@ -49,4 +54,10 @@ int main()
   assert(res.members[2] == 3);
   assert(res.members[3] == 6);
 #endif
+}
+
+int main()
+{
+  test_shuffle();
+  test_shufflevector();
 }

--- a/src/ansi-c/c_typecheck_expr.cpp
+++ b/src/ansi-c/c_typecheck_expr.cpp
@@ -2133,9 +2133,7 @@ void c_typecheck_baset::typecheck_side_effect_function_call(
 
         return;
       }
-      else if(
-        identifier == "__builtin_shufflevector" &&
-        config.ansi_c.mode == configt::ansi_ct::flavourt::CLANG)
+      else if(identifier == "__builtin_shufflevector")
       {
         exprt result = typecheck_shuffle_vector(expr);
         expr.swap(result);


### PR DESCRIPTION
This used to be Clang-only, but is now also supported by GCC.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
