### PR TITLE
argc/argv modelling: argument string must remain in scope

### DIFF
--- a/regression/goto-instrument/argc-argv1/main.c
+++ b/regression/goto-instrument/argc-argv1/main.c
@@ -3,7 +3,11 @@
 int main(int argc, char* argv[])
 {
   if(argc>=2)
+  {
     assert(argv[1]!=0);
+    // we can access at least one character (might be a string-terminating zero)
+    char first_char = *argv[1];
+  }
 
   return 0;
 }

--- a/src/goto-instrument/dump_c.cpp
+++ b/src/goto-instrument/dump_c.cpp
@@ -208,10 +208,14 @@ void dump_ct::operator()(std::ostream &os)
 
     // we don't want to dump in full all definitions; in particular
     // do not dump anonymous types that are defined in system headers
-    if((!tag_added || symbol.is_type) &&
-       system_symbols.is_symbol_internal_symbol(symbol, system_headers) &&
-       symbol.name!=goto_functions.entry_point())
+    if(
+      (!tag_added || symbol.is_type) &&
+      system_symbols.is_symbol_internal_symbol(symbol, system_headers) &&
+      symbol.name != goto_functions.entry_point() &&
+      symbol.name != CPROVER_PREFIX "arg_string") // model for argc/argv
+    {
       continue;
+    }
 
     bool inserted=symbols_sorted.insert(name_str).second;
     CHECK_RETURN(inserted);

--- a/src/goto-instrument/model_argc_argv.cpp
+++ b/src/goto-instrument/model_argc_argv.cpp
@@ -85,20 +85,22 @@ bool model_argc_argv(
   std::ostringstream oss;
   oss << "int ARGC;\n"
       << "char *ARGV[1];\n"
+      << "extern char " CPROVER_PREFIX "arg_string[4096];\n"
       << "void " << goto_model.goto_functions.entry_point() << "()\n"
       << "{\n"
       << "  unsigned next=0u;\n"
       << "  " CPROVER_PREFIX "assume(ARGC>=1);\n"
       << "  " CPROVER_PREFIX "assume(ARGC<=" << max_argc << ");\n"
-      << "  char arg_string[4096];\n"
-      << "  " CPROVER_PREFIX "input(\"arg_string\", &arg_string[0]);\n"
+      << "  " CPROVER_PREFIX "input(\"arg_string\", \n"
+      << "    &" CPROVER_PREFIX "arg_string[0]);\n"
       << "  for(int i=0; i<ARGC && i<" << max_argc << "; ++i)\n"
       << "  {\n"
       << "    unsigned len;\n"
       << "    " CPROVER_PREFIX "assume(len<4096);\n"
       << "    " CPROVER_PREFIX "assume(next+len<4096);\n"
-      << "    " CPROVER_PREFIX "assume(arg_string[next+len]==0);\n"
-      << "    ARGV[i]=&(arg_string[next]);\n"
+      << "    " CPROVER_PREFIX "assume(\n"
+      << "       " CPROVER_PREFIX "arg_string[next+len]==0);\n"
+      << "    ARGV[i]=&(" CPROVER_PREFIX "arg_string[next]);\n"
       << "    next+=len+1;\n"
       << "  }\n"
       << "}";
@@ -124,8 +126,11 @@ bool model_argc_argv(
     // add __CPROVER_assume if necessary (it might exist already)
     if(
       symbol_pair.first == CPROVER_PREFIX "assume" ||
-      symbol_pair.first == CPROVER_PREFIX "input")
+      symbol_pair.first == CPROVER_PREFIX "input" ||
+      symbol_pair.first == CPROVER_PREFIX "arg_string")
+    {
       goto_model.symbol_table.add(symbol_pair.second);
+    }
     else if(symbol_pair.first == goto_model.goto_functions.entry_point())
     {
       value = symbol_pair.second.value;


### PR DESCRIPTION
We previously produced an argument string that was marked DEAD before entering main, making accesses to argv[i] ones to a dead object.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
