### PR TITLE
Goto crossing scopes: fix scope tree entry of conditions

### DIFF
--- a/regression/cbmc/declaration-goto/no-duplicate-decl.c
+++ b/regression/cbmc/declaration-goto/no-duplicate-decl.c
@@ -1,0 +1,16 @@
+int foo()
+{
+  return 1;
+}
+
+int main()
+{
+  if(foo())
+    goto out;
+
+  return 1;
+
+out:
+  __CPROVER_assert(0, "false");
+  return 0;
+}

--- a/regression/cbmc/declaration-goto/no-duplicate-decl.desc
+++ b/regression/cbmc/declaration-goto/no-duplicate-decl.desc
@@ -1,0 +1,11 @@
+CORE
+no-duplicate-decl.c
+--show-goto-functions
+^[[:space:]]*DECL main::\$tmp::return_value_foo
+^EXIT=0$
+^SIGNAL=0$
+--
+^[[:space:]]*DECL going_to::out
+^[[:space:]]*\d+: DECL main::\$tmp::return_value_foo
+--
+Test that no loop back to the declaration is generated.

--- a/regression/validate-trace-xml-schema/check.py
+++ b/regression/validate-trace-xml-schema/check.py
@@ -23,6 +23,7 @@ ExcludedTests = list(map(lambda s: os.path.join(test_base_dir, s[0], s[1]), [
     ['xml-interface1', 'test_wrong_flag.desc'],
     # these want --show-goto-functions instead of producing a trace
     ['integer-assignments1', 'integer-typecheck.desc'],
+    ['declaration-goto', 'no-duplicate-decl.desc'],
     ['destructors', 'compound_literal.desc'],
     ['destructors', 'enter_lexical_block.desc'],
     ['enum_is_in_range', 'enum_test3-simplified.desc'],

--- a/src/ansi-c/goto-conversion/goto_convert.cpp
+++ b/src/ansi-c/goto-conversion/goto_convert.cpp
@@ -1597,6 +1597,9 @@ void goto_convertt::convert_ifthenelse(
     return convert_ifthenelse(new_if0, dest, mode);
   }
 
+  exprt tmp_guard = code.cond();
+  clean_expr(tmp_guard, dest, mode);
+
   // convert 'then'-branch
   goto_programt tmp_then;
   convert(code.then_case(), tmp_then, mode);
@@ -1615,9 +1618,6 @@ void goto_convertt::convert_ifthenelse(
                           ? to_code_block(code.else_case()).end_location()
                           : code.else_case().source_location();
   }
-
-  exprt tmp_guard = code.cond();
-  clean_expr(tmp_guard, dest, mode);
 
   generate_ifthenelse(
     tmp_guard,


### PR DESCRIPTION
We must convert the condition of an if/then/else first to make sure any declarations produced by converting the condition have a suitable scope-tree node. Previously, gotos in either branch of the if-then-else were led to believe that declarations resulting from condition were not yet in scope. The feature from #8091 would, thus, result in a spurious loop back to the declaration to put it in scope before following the goto edge.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
