### PR TITLE
relax bitvector constant check for Verilog bitvectors

### DIFF
--- a/src/util/std_expr.cpp
+++ b/src/util/std_expr.cpp
@@ -36,13 +36,17 @@ void constant_exprt::check(const exprt &expr, const validation_modet vm)
     vm,
     !can_cast_type<bitvector_typet>(expr.type()) ||
       can_cast_type<pointer_typet>(expr.type()) ||
+      expr.type().id() == ID_verilog_unsignedbv ||
+      expr.type().id() == ID_verilog_signedbv ||
       id2string(value).find_first_not_of("0123456789ABCDEF") ==
         std::string::npos,
     "negative bitvector constant must use two's complement");
 
   DATA_CHECK(
     vm,
-    !can_cast_type<bitvector_typet>(expr.type()) || value == ID_0 ||
+    !can_cast_type<bitvector_typet>(expr.type()) ||
+      expr.type().id() == ID_verilog_unsignedbv ||
+      expr.type().id() == ID_verilog_signedbv || value == ID_0 ||
       id2string(value)[0] != '0',
     "bitvector constant must not have leading zeros");
 }


### PR DESCRIPTION
Verilog bitvectors use a four-valued logic, and hence do not meet the requirements of their binary counterparts.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
