### PR TITLE
add a fluent-style typet::with_source_location

### DIFF
--- a/src/ansi-c/c_typecheck_type.cpp
+++ b/src/ansi-c/c_typecheck_type.cpp
@@ -283,10 +283,8 @@ void c_typecheck_baset::typecheck_type(typet &type)
       else // give up, just use subtype
         result = to_type_with_subtype(type).subtype();
 
-      // save the location
-      result.add_source_location()=type.source_location();
-
-      type=result;
+      // preserve the location
+      type = result.with_source_location(type);
     }
     else if(underlying_type.id()==ID_complex)
     {
@@ -303,9 +301,7 @@ void c_typecheck_baset::typecheck_type(typet &type)
         result = to_type_with_subtype(type).subtype();
 
       // save the location
-      result.add_source_location()=type.source_location();
-
-      type=complex_typet(result);
+      type = complex_typet(result).with_source_location(type);
     }
     else
     {
@@ -726,9 +722,8 @@ void c_typecheck_baset::typecheck_vector_type(typet &type)
   // produce the type with ID_vector
   vector_typet new_type(
     c_index_type(), subtype, from_integer(s, signed_size_type()));
-  new_type.add_source_location() = source_location;
   new_type.size().add_source_location() = source_location;
-  type = new_type;
+  type = new_type.with_source_location(source_location);
 }
 
 void c_typecheck_baset::typecheck_compound_type(struct_union_typet &type)

--- a/src/util/type.h
+++ b/src/util/type.h
@@ -79,6 +79,39 @@ public:
     return static_cast<source_locationt &>(add(ID_C_source_location));
   }
 
+  /// This is a 'fluent style' method for creating a new type
+  /// with an added-on source location.
+  typet &&with_source_location(source_locationt location) &&
+  {
+    if(location.is_not_nil())
+      add_source_location() = std::move(location);
+    return std::move(*this);
+  }
+
+  /// This is a 'fluent style' method for adding a source location.
+  typet &with_source_location(source_locationt location) &
+  {
+    if(location.is_not_nil())
+      add_source_location() = std::move(location);
+    return *this;
+  }
+
+  /// This is a 'fluent style' method for creating a new type
+  /// with an added-on source location.
+  typet &&with_source_location(const typet &type) &&
+  {
+    return std::move(*this).with_source_location(type.source_location());
+  }
+
+  /// This is a 'fluent style' method for adding a source location.
+  typet &with_source_location(const typet &type) &
+  {
+    auto &location = type.source_location();
+    if(location.is_not_nil())
+      add_source_location() = location;
+    return *this;
+  }
+
   typet &add_type(const irep_idt &name)
   {
     return static_cast<typet &>(add(name));


### PR DESCRIPTION
This allows adding a source location to a type in functional style.  r-value variants are supplied.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- [X] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
