### PR TITLE
Fix `missing braces around initializer` GCC warning

### DIFF
--- a/unit/goto-symex/shadow_memory_util.cpp
+++ b/unit/goto-symex/shadow_memory_util.cpp
@@ -162,15 +162,15 @@ TEST_CASE(
 
   // Using mp_integer types otherwise on 32-bit machines n << 48 wraps around.
   std::array<mp_integer, 7> values = GENERATE(
-    std::array<mp_integer, 7>{0, 0, 0, 0, 0, 0, 0},
-    std::array<mp_integer, 7>{1, 2, 3, 4, 5, 6, 7},
-    std::array<mp_integer, 7>{2, 3, 4, 5, 6, 7, 1},
-    std::array<mp_integer, 7>{3, 4, 5, 6, 7, 1, 2},
-    std::array<mp_integer, 7>{4, 5, 6, 7, 1, 2, 3},
-    std::array<mp_integer, 7>{5, 6, 7, 1, 2, 3, 4},
-    std::array<mp_integer, 7>{6, 7, 1, 2, 3, 4, 5},
-    std::array<mp_integer, 7>{7, 1, 2, 3, 4, 5, 6},
-    std::array<mp_integer, 7>{8, 8, 8, 8, 8, 8, 8});
+    std::array<mp_integer, 7>{{0, 0, 0, 0, 0, 0, 0}},
+    std::array<mp_integer, 7>{{1, 2, 3, 4, 5, 6, 7}},
+    std::array<mp_integer, 7>{{2, 3, 4, 5, 6, 7, 1}},
+    std::array<mp_integer, 7>{{3, 4, 5, 6, 7, 1, 2}},
+    std::array<mp_integer, 7>{{4, 5, 6, 7, 1, 2, 3}},
+    std::array<mp_integer, 7>{{5, 6, 7, 1, 2, 3, 4}},
+    std::array<mp_integer, 7>{{6, 7, 1, 2, 3, 4, 5}},
+    std::array<mp_integer, 7>{{7, 1, 2, 3, 4, 5, 6}},
+    std::array<mp_integer, 7>{{8, 8, 8, 8, 8, 8, 8}});
 
   SECTION("test set " + std::to_string(values[0].to_long()))
   {
@@ -279,15 +279,15 @@ TEST_CASE(
 
   // Using mp_integer types otherwise on 32-bit machines n << 48 wraps around.
   std::array<mp_integer, 7> values = GENERATE(
-    std::array<mp_integer, 7>{0, 0, 0, 0, 0, 0, 0},
-    std::array<mp_integer, 7>{2, 0, 0, 0, 0, 0, 0},
-    std::array<mp_integer, 7>{0, 2, 0, 0, 0, 0, 0},
-    std::array<mp_integer, 7>{0, 0, 2, 0, 0, 0, 0},
-    std::array<mp_integer, 7>{0, 0, 0, 2, 0, 0, 0},
-    std::array<mp_integer, 7>{0, 0, 0, 0, 2, 0, 0},
-    std::array<mp_integer, 7>{0, 0, 0, 0, 0, 2, 0},
-    std::array<mp_integer, 7>{0, 0, 0, 0, 0, 0, 2},
-    std::array<mp_integer, 7>{8, 8, 8, 8, 8, 8, 8});
+    std::array<mp_integer, 7>{{0, 0, 0, 0, 0, 0, 0}},
+    std::array<mp_integer, 7>{{2, 0, 0, 0, 0, 0, 0}},
+    std::array<mp_integer, 7>{{0, 2, 0, 0, 0, 0, 0}},
+    std::array<mp_integer, 7>{{0, 0, 2, 0, 0, 0, 0}},
+    std::array<mp_integer, 7>{{0, 0, 0, 2, 0, 0, 0}},
+    std::array<mp_integer, 7>{{0, 0, 0, 0, 2, 0, 0}},
+    std::array<mp_integer, 7>{{0, 0, 0, 0, 0, 2, 0}},
+    std::array<mp_integer, 7>{{0, 0, 0, 0, 0, 0, 2}},
+    std::array<mp_integer, 7>{{8, 8, 8, 8, 8, 8, 8}});
 
   SECTION("test set " + std::to_string(values[0].to_long()))
   {


### PR DESCRIPTION
Fixes build failures with older GCC versions on AL2.

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.
