### PR TITLE
Remove unused goto_convertt::has_function_call

### DIFF
--- a/src/goto-programs/goto_convert_class.h
+++ b/src/goto-programs/goto_convert_class.h
@@ -107,8 +107,6 @@ protected:
 
   void rewrite_boolean(exprt &dest);
 
-  static bool has_function_call(const exprt &expr);
-
   void remove_side_effect(
     side_effect_exprt &expr,
     goto_programt &dest,

--- a/src/goto-programs/goto_convert_side_effect.cpp
+++ b/src/goto-programs/goto_convert_side_effect.cpp
@@ -22,21 +22,6 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <ansi-c/c_expr.h>
 
-bool goto_convertt::has_function_call(const exprt &expr)
-{
-  for(const auto &op : expr.operands())
-  {
-    if(has_function_call(op))
-      return true;
-  }
-
-  if(expr.id()==ID_side_effect &&
-     expr.get(ID_statement)==ID_function_call)
-    return true;
-
-  return false;
-}
-
 void goto_convertt::remove_assignment(
   side_effect_exprt &expr,
   goto_programt &dest,


### PR DESCRIPTION
Its use (if ever) predates Git history. Removing to reduce the amount of dead code.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- n/a Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
