### PR TITLE
array_set: do not fail upon an invalid (void) pointer

### DIFF
--- a/regression/cbmc/Array_operations3/main.c
+++ b/regression/cbmc/Array_operations3/main.c
@@ -1,0 +1,7 @@
+int main()
+{
+  void *p;
+  __CPROVER_array_set(p, 0);
+  __CPROVER_assert(
+    *(char *)p == 0, "should fail: array_set had no effect on invalid object");
+}

--- a/regression/cbmc/Array_operations3/test.desc
+++ b/regression/cbmc/Array_operations3/test.desc
@@ -1,0 +1,11 @@
+CORE
+main.c
+
+^\[main.assertion.1\] line 5 should fail: array_set had no effect on invalid object: FAILURE$
+^VERIFICATION FAILED$
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring
+--
+An array_set on an invalid pointer must not result in an invariant failure.

--- a/src/goto-symex/symex_other.cpp
+++ b/src/goto-symex/symex_other.cpp
@@ -183,6 +183,11 @@ void goto_symext::symex_other(
     // obtain the actual array(s)
     process_array_expr(state, array_expr);
 
+    // if we dereferenced a void pointer, we may get a zero-sized (failed)
+    // object -- nothing to be assigned
+    if(array_expr.type().id() == ID_empty)
+      return;
+
     // prepare to build the array_of
     exprt value = clean_expr(code.op1(), state, false);
 


### PR DESCRIPTION
Even when the pointer cannot be successfully dereferenced, symex must not yield an invariant failure.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
