### PR TITLE
nondet-volatile: fix handling of enum types

### DIFF
--- a/regression/goto-instrument/nondet-volatile-01/test.c
+++ b/regression/goto-instrument/nondet-volatile-01/test.c
@@ -1,5 +1,11 @@
 #include <assert.h>
 
+enum E
+{
+  A,
+  B
+};
+
 void main()
 {
   int a[2] = {0};
@@ -8,4 +14,8 @@ void main()
   a[i] = 1;
 
   assert(a[1] == 0); // should fail
+
+  // make sure the use of enum (tags) does not cause infinite recursion
+  enum A e = A;
+  e = e;
 }

--- a/src/goto-instrument/nondet_volatile.cpp
+++ b/src/goto-instrument/nondet_volatile.cpp
@@ -13,6 +13,7 @@ Date: September 2011
 
 #include "nondet_volatile.h"
 
+#include <util/c_types.h>
 #include <util/cmdline.h>
 #include <util/fresh_symbol.h>
 #include <util/options.h>
@@ -94,14 +95,14 @@ bool nondet_volatilet::is_volatile(const namespacet &ns, const typet &src)
   if(src.get_bool(ID_C_volatile))
     return true;
 
-  if(
-    src.id() == ID_struct_tag || src.id() == ID_union_tag ||
-    src.id() == ID_c_enum_tag)
-  {
-    return is_volatile(ns, ns.follow(src));
-  }
-
-  return false;
+  if(auto struct_tag = type_try_dynamic_cast<struct_tag_typet>(src))
+    return is_volatile(ns, ns.follow_tag(*struct_tag));
+  else if(auto union_tag = type_try_dynamic_cast<union_tag_typet>(src))
+    return is_volatile(ns, ns.follow_tag(*union_tag));
+  else if(auto enum_tag = type_try_dynamic_cast<c_enum_tag_typet>(src))
+    return is_volatile(ns, ns.follow_tag(*enum_tag));
+  else
+    return false;
 }
 
 void nondet_volatilet::handle_volatile_expression(


### PR DESCRIPTION
`namespacet::follow` does not follow enum tags. Use `follow_tag` instead
to avoid unbounded recursion when using nondet-volatile on programs that
use enums.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
