### PR TITLE
Support comparing arrays of non-constant size with array_equal

### DIFF
--- a/regression/cbmc/Array_operations4/main.c
+++ b/regression/cbmc/Array_operations4/main.c
@@ -1,0 +1,16 @@
+#include <stdlib.h>
+
+size_t nondet_size_t();
+int main()
+{
+  size_t size = nondet_size_t();
+  if(0 < size && size <= __CPROVER_max_malloc_size)
+  {
+    char *a = malloc(size);
+    char *b = malloc(size);
+    __CPROVER_array_copy(a, b);
+    __CPROVER_assert(__CPROVER_array_equal(a, b), "should pass");
+    a[0] = 0;
+    __CPROVER_assert(__CPROVER_array_equal(a, b), "may fail");
+  }
+}

--- a/regression/cbmc/Array_operations4/test.desc
+++ b/regression/cbmc/Array_operations4/test.desc
@@ -1,0 +1,13 @@
+CORE
+main.c
+
+^\[main.assertion.1\] line 12 should pass: SUCCESS
+^\[main.assertion.2\] line 14 may fail: FAILURE
+^\*\* 1 of \d+ failed
+^VERIFICATION FAILED$
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring
+--
+Verify that array_equal works for arrays of non-constant size.


### PR DESCRIPTION
Using simple type equality is too strict for arrays of non-constant size: we introduce a fresh symbol for the size of each dynamically allocated object of non-constant size. Consequently, two dynamically allocated arrays of non-constant size will never pass type equality checking, even when their underlying sizes are the same.

We now explicitly compare the sizes of the two arrays passed to array_equal when types are not trivially equal.

Fixes: #8176

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
