### PR TITLE
Deprecate namespacet::follow

### DIFF
--- a/src/util/namespace.h
+++ b/src/util/namespace.h
@@ -10,6 +10,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #ifndef CPROVER_UTIL_NAMESPACE_H
 #define CPROVER_UTIL_NAMESPACE_H
 
+#include "deprecate.h"
 #include "invariant.h"
 #include "irep.h"
 
@@ -58,6 +59,7 @@ public:
   virtual ~namespace_baset();
 
   void follow_macros(exprt &) const;
+  DEPRECATED(SINCE(2024, 2, 19, "use follow_tag(...) instead"))
   const typet &follow(const typet &) const;
 
   // These produce union_typet, struct_typet, c_enum_typet or


### PR DESCRIPTION
Follows struct and union tags, but does not follow enum tags. This is not obvious from its documentation, and led to surprising behaviour as seen (and fixed) in https://github.com/diffblue/cbmc/pull/8203. Using suitable variants of `follow_tag` is safer.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
