### PR TITLE
Add support for GNU Hurd

### DIFF
--- a/doc/man/cbmc.1
+++ b/doc/man/cbmc.1
@@ -202,7 +202,7 @@ Set analysis architecture, which defaults to the host architecture. Use one of:
 \fB\-\-os\fR \fIos\fR
 Set analysis operating system, which defaults to the host operating system. Use
 one of: \fBfreebsd\fR, \fBlinux\fR, \fBmacos\fR, \fBnetbsd\fR, \fBopenbsd\fR,
-\fBsolaris\fR, or \fBwindows\fR.
+\fBsolaris\fR, \fBhurd\fR, or \fBwindows\fR.
 .TP
 \fB\-\-i386\-linux\fR, \fB\-\-i386\-win32\fR, \fB\-\-i386\-macos\fR, \fB\-\-ppc\-macos\fR, \fB\-\-win32\fR, \fB\-\-winx64\fR
 Set analysis architecture and operating system.

--- a/doc/man/goto-analyzer.1
+++ b/doc/man/goto-analyzer.1
@@ -461,7 +461,7 @@ Set analysis architecture, which defaults to the host architecture. Use one of:
 \fB\-\-os\fR \fIos\fR
 Set analysis operating system, which defaults to the host operating system. Use
 one of: \fBfreebsd\fR, \fBlinux\fR, \fBmacos\fR, \fBnetbsd\fR, \fBopenbsd\fR,
-\fBsolaris\fR, or \fBwindows\fR.
+\fBsolaris\fR, \fBhurd\fR, or \fBwindows\fR.
 .TP
 \fB\-\-i386\-linux\fR, \fB\-\-i386\-win32\fR, \fB\-\-i386\-macos\fR, \fB\-\-ppc\-macos\fR, \fB\-\-win32\fR, \fB\-\-winx64\fR
 Set analysis architecture and operating system.

--- a/doc/man/janalyzer.1
+++ b/doc/man/janalyzer.1
@@ -279,7 +279,7 @@ Set analysis architecture, which defaults to the host architecture. Use one of:
 \fB\-\-os\fR \fIos\fR
 Set analysis operating system, which defaults to the host operating system. Use
 one of: \fBfreebsd\fR, \fBlinux\fR, \fBmacos\fR, \fBnetbsd\fR, \fBopenbsd\fR,
-\fBsolaris\fR, or \fBwindows\fR.
+\fBsolaris\fR, \fBhurd\fR, or \fBwindows\fR.
 .TP
 \fB\-\-i386\-linux\fR, \fB\-\-i386\-win32\fR, \fB\-\-i386\-macos\fR, \fB\-\-ppc\-macos\fR, \fB\-\-win32\fR, \fB\-\-winx64\fR
 Set analysis architecture and operating system.

--- a/doc/man/jbmc.1
+++ b/doc/man/jbmc.1
@@ -83,7 +83,7 @@ Set analysis architecture, which defaults to the host architecture. Use one of:
 \fB\-\-os\fR \fIos\fR
 Set analysis operating system, which defaults to the host operating system. Use
 one of: \fBfreebsd\fR, \fBlinux\fR, \fBmacos\fR, \fBnetbsd\fR, \fBopenbsd\fR,
-\fBsolaris\fR, or \fBwindows\fR.
+\fBsolaris\fR, \fBhurd\fR, or \fBwindows\fR.
 .TP
 \fB\-\-i386\-linux\fR, \fB\-\-i386\-win32\fR, \fB\-\-i386\-macos\fR, \fB\-\-ppc\-macos\fR, \fB\-\-win32\fR, \fB\-\-winx64\fR
 Set analysis architecture and operating system.

--- a/src/goto-cc/hybrid_binary.cpp
+++ b/src/goto-cc/hybrid_binary.cpp
@@ -49,7 +49,8 @@ int hybrid_binary(
   int result = 0;
 
 #if defined(__linux__) || defined(__FreeBSD_kernel__) ||                       \
-  defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__)
+  defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__) ||       \
+  defined(__gnu_hurd__)
   // we can use objcopy for both object files and executables
   (void)building_executable;
 

--- a/src/util/config.cpp
+++ b/src/util/config.cpp
@@ -985,7 +985,7 @@ bool configt::set(const cmdlinet &cmdline)
     ansi_c.mode = ansi_ct::flavourt::CLANG;
     ansi_c.preprocessor=ansi_ct::preprocessort::CLANG;
   }
-  else if(os == "linux" || os == "solaris" || os == "netbsd")
+  else if(os == "linux" || os == "solaris" || os == "netbsd" || os == "hurd")
   {
     ansi_c.lib=configt::ansi_ct::libt::LIB_FULL;
     ansi_c.os=configt::ansi_ct::ost::OS_LINUX;
@@ -1509,6 +1509,8 @@ irep_idt configt::this_operating_system()
   this_os="linux";
 #elif __SVR4
   this_os="solaris";
+#elif __gnu_hurd__
+  this_os = "hurd";
 #else
   this_os="unknown";
 #endif

--- a/src/util/config.h
+++ b/src/util/config.h
@@ -107,7 +107,7 @@ class symbol_table_baset;
     "set operating system (default: " +                                        \
     id2string(configt::this_operating_system()) +                              \
     ") to one of: {yfreebsd}, {ylinux}, {ymacos}, {ynetbsd}, {yopenbsd}, "     \
-    "{ysolaris}, or {ywindows}\n"                                              \
+    "{ysolaris}, {yhurd}, or {ywindows}\n"                                     \
     " {y--i386-linux}, {y--i386-win32}, {y--i386-macos}, {y--ppc-macos}, "     \
     "{y--win32}, {y--winx64} \t "                                              \
     "set architecture and operating system\n"                                  \


### PR DESCRIPTION
Builds with tests passing on hurd-i386 per https://buildd.debian.org/status/fetch.php?pkg=cbmc&arch=hurd-i386&ver=5.95.1-6&stamp=1714528231&raw=0.


<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
