### PR TITLE
Avoid 64-bit platform support requirement for running tests

### DIFF
--- a/regression/cbmc/Pointer_byte_extract8/main.i
+++ b/regression/cbmc/Pointer_byte_extract8/main.i
@@ -1,10 +1,3 @@
-#include <assert.h>
-#include <stdlib.h>
-
-#ifdef _MSC_VER
-#  define _Static_assert(x, m) static_assert(x, m)
-#endif
-
 struct list;
 
 typedef struct list list_nodet;
@@ -22,11 +15,11 @@ int max_depth = 2;
 list_nodet *build_node(int depth)
 {
   if(max_depth < depth)
-    return ((list_nodet *)NULL);
+    return ((list_nodet *)0);
   else
   {
-    _Static_assert(sizeof(list_nodet) == 16, "");
-    list_nodet *result = malloc(16);
+    __CPROVER_assert(sizeof(list_nodet) == 16, "struct size is 16 bytes");
+    list_nodet *result = __CPROVER_allocate(16, 0);
 
     if(result)
     {
@@ -53,6 +46,6 @@ int main()
   {
     i = i + 1;
   }
-  assert(i == 3);
+  __CPROVER_assert(i == 3, "i should be 3");
   return 0;
 }

--- a/regression/cbmc/Pointer_byte_extract8/test.desc
+++ b/regression/cbmc/Pointer_byte_extract8/test.desc
@@ -1,5 +1,5 @@
 CORE
-main.c
+main.i
 --no-malloc-may-fail --64 --unwind 4 --unwinding-assertions
 ^EXIT=0$
 ^SIGNAL=0$


### PR DESCRIPTION
We can safely run 64-bit tests on 32-bit platforms as long as we do not need the preprocessor.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
