### PR TITLE
Make regression tests work when cvc5 is not available

### DIFF
--- a/.github/workflows/pull-request-checks.yaml
+++ b/.github/workflows/pull-request-checks.yaml
@@ -361,15 +361,7 @@ jobs:
           DEBIAN_FRONTEND: noninteractive
         run: |
           sudo apt-get update
-          sudo apt-get install --no-install-recommends -yq cmake ninja-build gcc gdb g++ maven flex bison libxml2-utils dpkg-dev ccache doxygen graphviz z3
-      - name: Confirm z3 solver is available and log the version installed
-        run: z3 --version
-      - name: Download cvc-5 from the releases page and make sure it can be deployed
-        run: |
-          wget https://github.com/cvc5/cvc5/releases/download/cvc5-${{env.cvc5-version}}/cvc5-Linux-x86_64-static.zip
-          unzip -j -d /usr/local/bin cvc5-Linux-x86_64-static.zip cvc5-Linux-x86_64-static/bin/cvc5
-          rm cvc5-Linux-x86_64-static.zip
-          cvc5 --version
+          sudo apt-get install --no-install-recommends -yq cmake ninja-build gcc gdb g++ maven flex bison libxml2-utils dpkg-dev ccache doxygen graphviz
       - name: Prepare ccache
         uses: actions/cache@v5
         with:
@@ -570,6 +562,8 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install --no-install-recommends -yq cmake ninja-build gcc g++ maven flex bison libxml2-utils ccache z3
+      - name: Confirm z3 solver is available and log the version installed
+        run: z3 --version
       - name: Prepare ccache
         uses: actions/cache@v5
         with:
@@ -617,6 +611,8 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install --no-install-recommends -yq cmake ninja-build gcc g++ maven flex bison libxml2-utils ccache z3
+      - name: Confirm z3 solver is available and log the version installed
+        run: z3 --version
       - name: Prepare ccache
         uses: actions/cache@v5
         with:

--- a/regression/README.md
+++ b/regression/README.md
@@ -17,6 +17,10 @@ This folder contains the CProver regression test-suite.
 
 ### Solver
 
+- `z3`:
+  These tests _require_ z3 to be available on the PATH.
+- `cvc5`:
+  These tests _require_ cvc5 to be available on the PATH.
 - `broken-cprover-smt-backend`:
   These tests are known to not work with CPROVER SMT2.
 - `thorough-cprover-smt-backend`:

--- a/regression/book-examples/CMakeLists.txt
+++ b/regression/book-examples/CMakeLists.txt
@@ -25,12 +25,15 @@ add_test_pl_profile(
 )
 
 # If `-X` (exclude flag) is passed, test.pl will exclude the tests matching the label following it.
-add_test_pl_profile(
-  "book-examples-new-smt-backend"
-  "$<TARGET_FILE:cbmc> --incremental-smt2-solver 'z3 --smt2 -in'"
-  "${gcc_only_string}-X;no-new-smt;-s;new-smt-backend"
-  "CORE"
-)
+find_program(Z3_SOLVER z3)
+if(Z3_SOLVER)
+  add_test_pl_profile(
+    "book-examples-new-smt-backend"
+    "$<TARGET_FILE:cbmc> --incremental-smt2-solver 'z3 --smt2 -in'"
+    "${gcc_only_string}-X;no-new-smt;-s;new-smt-backend"
+    "CORE"
+  )
+endif()
 
 # solver appears on the PATH in Windows already
 if(NOT "${CMAKE_SYSTEM_NAME}" STREQUAL "Windows")

--- a/regression/cbmc-incr-smt2/CMakeLists.txt
+++ b/regression/cbmc-incr-smt2/CMakeLists.txt
@@ -1,13 +1,20 @@
-add_test_pl_profile(
-    "cbmc-incr-smt2-z3"
-    "$<TARGET_FILE:cbmc> --incremental-smt2-solver 'z3 --smt2 -in' --validate-goto-model --validate-ssa-equation"
-    "-C;-s;new-smt-z3"
-    "CORE"
-)
+find_program(Z3_SOLVER z3)
+find_program(CVC5_SOLVER cvc5)
 
-add_test_pl_profile(
-    "cbmc-incr-smt2-cvc5"
-    "$<TARGET_FILE:cbmc> --incremental-smt2-solver 'cvc5 --lang=smtlib2.6 --incremental' --validate-goto-model --validate-ssa-equation"
-    "-C;-s;new-smt-cvc5"
-    "CORE"
-)
+if(Z3_SOLVER)
+  add_test_pl_profile(
+      "cbmc-incr-smt2-z3"
+      "$<TARGET_FILE:cbmc> --incremental-smt2-solver 'z3 --smt2 -in' --validate-goto-model --validate-ssa-equation"
+      "-C;-s;new-smt-z3"
+      "CORE"
+  )
+endif()
+
+if(CVC5_SOLVER)
+  add_test_pl_profile(
+      "cbmc-incr-smt2-cvc5"
+      "$<TARGET_FILE:cbmc> --incremental-smt2-solver 'cvc5 --lang=smtlib2.6 --incremental' --validate-goto-model --validate-ssa-equation"
+      "-C;-s;new-smt-cvc5"
+      "CORE"
+  )
+endif()

--- a/regression/cbmc-incr-smt2/Makefile
+++ b/regression/cbmc-incr-smt2/Makefile
@@ -6,10 +6,14 @@ include ../../src/common
 test: test.z3 test.cvc5
 
 test.z3:
-	@../test.pl -e -p -c "../../../src/cbmc/cbmc --incremental-smt2-solver 'z3 --smt2 -in' --validate-goto-model --validate-ssa-equation"
+	@if command -v z3 > /dev/null 2>&1 ; then \
+	  ../test.pl -e -p -c "../../../src/cbmc/cbmc --incremental-smt2-solver 'z3 --smt2 -in' --validate-goto-model --validate-ssa-equation" ; \
+	fi
 
 test.cvc5:
-	@../test.pl -e -p -c "../../../src/cbmc/cbmc --incremental-smt2-solver 'cvc5 --lang=smtlib2.6 --incremental' --validate-goto-model --validate-ssa-equation"
+	@if command -v cvc5 > /dev/null 2>&1 ; then \
+	  ../test.pl -e -p -c "../../../src/cbmc/cbmc --incremental-smt2-solver 'cvc5 --lang=smtlib2.6 --incremental' --validate-goto-model --validate-ssa-equation" ; \
+	fi
 
 tests.log: ../test.pl test
 

--- a/regression/cbmc-output-file/CMakeLists.txt
+++ b/regression/cbmc-output-file/CMakeLists.txt
@@ -1,3 +1,15 @@
+find_program(Z3_SOLVER z3)
+find_program(CVC5_SOLVER cvc5)
+
+set(CBMC_OUTPUT_FILE_EXTRA_ARGS "-f")
+if(NOT CVC5_SOLVER)
+  list(APPEND CBMC_OUTPUT_FILE_EXTRA_ARGS "-X" "cvc5")
+endif()
+if(NOT Z3_SOLVER)
+  list(APPEND CBMC_OUTPUT_FILE_EXTRA_ARGS "-X" "z3")
+endif()
+
 add_test_pl_tests(
-    "${CMAKE_CURRENT_SOURCE_DIR}/chain.py $<TARGET_FILE:cbmc>" "-f"
+    "${CMAKE_CURRENT_SOURCE_DIR}/chain.py $<TARGET_FILE:cbmc>"
+    ${CBMC_OUTPUT_FILE_EXTRA_ARGS}
 )

--- a/regression/cbmc-output-file/Makefile
+++ b/regression/cbmc-output-file/Makefile
@@ -3,11 +3,19 @@ default: tests.log
 include ../../src/config.inc
 include ../../src/common
 
+EXCLUDED_TAGS =
+ifeq ($(shell command -v cvc5 > /dev/null 2>&1 && echo found),)
+  EXCLUDED_TAGS += -X cvc5
+endif
+ifeq ($(shell command -v z3 > /dev/null 2>&1 && echo found),)
+  EXCLUDED_TAGS += -X z3
+endif
+
 test:
-	@../test.pl -f -e -p -c '../chain.py ../../../src/cbmc/cbmc'
+	@../test.pl -f -e -p -c '../chain.py ../../../src/cbmc/cbmc' $(EXCLUDED_TAGS)
 
 tests.log:
-	@../test.pl -f -e -p -c '../chain.py ../../../src/cbmc/cbmc'
+	@../test.pl -f -e -p -c '../chain.py ../../../src/cbmc/cbmc' $(EXCLUDED_TAGS)
 
 clean:
 	$(RM) tests.log

--- a/regression/cbmc-output-file/dump-smt-formula/cvc5-match.desc
+++ b/regression/cbmc-output-file/dump-smt-formula/cvc5-match.desc
@@ -1,4 +1,4 @@
-CORE
+CORE cvc5
 test.c
 --incremental-smt2-solver 'cvc5 --lang=smtlib2.6 --incremental' --dump-smt-formula %out-file-name%
 Passing problem to incremental SMT2 solving via "cvc5 --lang=smtlib2.6 --incremental"

--- a/regression/cbmc-output-file/dump-smt-formula/cvc5-no-match.desc
+++ b/regression/cbmc-output-file/dump-smt-formula/cvc5-no-match.desc
@@ -1,4 +1,4 @@
-CORE
+CORE cvc5
 test.c
 --incremental-smt2-solver 'cvc5 --lang=smtlib2.6 --incremental' --dump-smt-formula %out-file-name%
 Passing problem to incremental SMT2 solving via "cvc5 --lang=smtlib2.6 --incremental"

--- a/regression/cbmc-output-file/dump-smt-formula/z3-match.desc
+++ b/regression/cbmc-output-file/dump-smt-formula/z3-match.desc
@@ -1,4 +1,4 @@
-CORE
+CORE z3
 test.c
 --incremental-smt2-solver 'z3 --smt2 -in' --dump-smt-formula %out-file-name%
 Passing problem to incremental SMT2 solving via "z3 --smt2 -in"

--- a/regression/cbmc-output-file/dump-smt-formula/z3-no-match.desc
+++ b/regression/cbmc-output-file/dump-smt-formula/z3-no-match.desc
@@ -1,4 +1,4 @@
-CORE
+CORE z3
 test.c
 --incremental-smt2-solver 'z3 --smt2 -in' --dump-smt-formula %out-file-name%
 Passing problem to incremental SMT2 solving via "z3 --smt2 -in"

--- a/regression/cbmc-output-file/outfile/cvc5-match.desc
+++ b/regression/cbmc-output-file/outfile/cvc5-match.desc
@@ -1,4 +1,4 @@
-CORE
+CORE cvc5
 test.c
 --incremental-smt2-solver 'cvc5 --lang=smtlib2.6 --incremental' --outfile %out-file-name%
 Passing problem to incremental SMT2 solving via SMT2 incremental dry-run

--- a/regression/cbmc-output-file/outfile/cvc5-no-match.desc
+++ b/regression/cbmc-output-file/outfile/cvc5-no-match.desc
@@ -1,4 +1,4 @@
-CORE
+CORE cvc5
 test.c
 --incremental-smt2-solver 'cvc5 --lang=smtlib2.6 --incremental' --outfile %out-file-name%
 Passing problem to incremental SMT2 solving via SMT2 incremental dry-run

--- a/regression/cbmc-output-file/outfile/z3-match.desc
+++ b/regression/cbmc-output-file/outfile/z3-match.desc
@@ -1,4 +1,4 @@
-CORE
+CORE z3
 test.c
 --incremental-smt2-solver 'z3 --smt2 -in' --outfile %out-file-name%
 Passing problem to incremental SMT2 solving via SMT2 incremental dry-run

--- a/regression/cbmc-output-file/outfile/z3-no-match.desc
+++ b/regression/cbmc-output-file/outfile/z3-no-match.desc
@@ -1,4 +1,4 @@
-CORE
+CORE z3
 test.c
 --incremental-smt2-solver 'z3 --smt2 -in' --outfile %out-file-name%
 Passing problem to incremental SMT2 solving via SMT2 incremental dry-run

--- a/regression/cbmc-primitives/CMakeLists.txt
+++ b/regression/cbmc-primitives/CMakeLists.txt
@@ -1,6 +1,6 @@
 find_program(Z3_EXISTS "z3")
-message(${Z3_EXISTS})
 if(Z3_EXISTS)
+    message(STATUS "z3 found: ${Z3_EXISTS}")
     add_test_pl_tests(
         "$<TARGET_FILE:cbmc>"
     )
@@ -13,6 +13,7 @@ if(Z3_EXISTS)
             "CORE"
     )
 else()
+    message(STATUS "z3 not found, skipping smt-backend tests in cbmc-primitives")
     add_test_pl_tests(
         "$<TARGET_FILE:cbmc>" -X smt-backend
     )

--- a/regression/cbmc/CMakeLists.txt
+++ b/regression/cbmc/CMakeLists.txt
@@ -25,12 +25,15 @@ add_test_pl_profile(
 )
 
 # If `-X` (exclude flag) is passed, test.pl will exclude the tests matching the label following it.
-add_test_pl_profile(
-  "cbmc-new-smt-backend"
-  "$<TARGET_FILE:cbmc> --incremental-smt2-solver 'z3 --smt2 -in'"
-  "${gcc_only_string}-X;no-new-smt;-s;new-smt-backend"
-  "CORE"
-)
+find_program(Z3_SOLVER z3)
+if(Z3_SOLVER)
+  add_test_pl_profile(
+    "cbmc-new-smt-backend"
+    "$<TARGET_FILE:cbmc> --incremental-smt2-solver 'z3 --smt2 -in'"
+    "${gcc_only_string}-X;no-new-smt;-s;new-smt-backend"
+    "CORE"
+  )
+endif()
 
 # solver appears on the PATH in Windows already
 if(NOT "${CMAKE_SYSTEM_NAME}" STREQUAL "Windows")


### PR DESCRIPTION
We should not have cvc5 as firm build (and test) dependency as CBMC works just fine when cvc5 is not available.

Please review commit-by-commit.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
