### PR TITLE
Static initialisation: Replace uses of namespacet::follow

### DIFF
--- a/src/linking/static_lifetime_init.cpp
+++ b/src/linking/static_lifetime_init.cpp
@@ -47,24 +47,24 @@ static std::optional<codet> static_lifetime_init(
   if(identifier.starts_with(CPROVER_PREFIX "architecture_"))
     return {};
 
-  const typet &type = ns.follow(symbol.type);
-
   // check type
-  if(type.id() == ID_code || type.id() == ID_empty)
+  if(symbol.type.id() == ID_code || symbol.type.id() == ID_empty)
     return {};
 
-  if(type.id() == ID_array && to_array_type(type).size().is_nil())
+  if(symbol.type.id() == ID_array && to_array_type(symbol.type).size().is_nil())
   {
     // C standard 6.9.2, paragraph 5
     // adjust the type to an array of size 1
     symbolt &writable_symbol = symbol_table.get_writeable_ref(identifier);
-    writable_symbol.type = type;
+    writable_symbol.type = symbol.type;
     writable_symbol.type.set(ID_size, from_integer(1, size_type()));
   }
 
   if(
-    (type.id() == ID_struct || type.id() == ID_union) &&
-    to_struct_union_type(type).is_incomplete())
+    (symbol.type.id() == ID_struct_tag &&
+     ns.follow_tag(to_struct_tag_type(symbol.type)).is_incomplete()) ||
+    (symbol.type.id() == ID_union_tag &&
+     ns.follow_tag(to_union_tag_type(symbol.type)).is_incomplete()))
   {
     return {}; // do not initialize
   }


### PR DESCRIPTION
This is deprecated. Use suitable variants of `follow_tag` instead.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
