### PR TITLE
Quantifier instantiation via simplistic E-matching

### DIFF
--- a/doc/cprover-manual/cbmc-assertions.md
+++ b/doc/cprover-manual/cbmc-assertions.md
@@ -82,12 +82,7 @@ int foo(int a, int b) {
 }
 ```
 
-A future release of CPROVER will support using these pre and
-postconditions to create a function contract, which can be used for
-modular verification.
-
-
-Future CPROVER releases will support explicit quantifiers with a syntax
+CPROVER supports explicit quantifiers with a syntax
 that resembles Spec\#:
 
 ```C

--- a/regression/CMakeLists.txt
+++ b/regression/CMakeLists.txt
@@ -8,6 +8,7 @@ macro(add_test_pl_profile name cmdline flag profile)
     )
     set_tests_properties("${name}-${profile}" PROPERTIES
         LABELS "${profile};CBMC"
+        TIMEOUT 1200
     )
 endmacro(add_test_pl_profile)
 

--- a/regression/cbmc/Quantifiers-fixpoint-instantiation/main.c
+++ b/regression/cbmc/Quantifiers-fixpoint-instantiation/main.c
@@ -1,0 +1,23 @@
+#include <assert.h>
+#include <stdlib.h>
+
+size_t nondet_size_t();
+
+int main()
+{
+  size_t n = nondet_size_t();
+  __CPROVER_assume(n >= 3 && n < 100);
+  int *arr = malloc(n * sizeof(int));
+  __CPROVER_assume(arr);
+
+  arr[0] = 1;
+
+  // forall j < n-1: arr[j] > 0 => arr[j+1] > 0
+  __CPROVER_assume(__CPROVER_forall {
+    size_t j;
+    !(j < n - 1) || !(arr[j] > 0) || (arr[j + 1] > 0)
+  });
+
+  // Requires chained instantiation: j=0 gives arr[1]>0, j=1 gives arr[2]>0
+  assert(arr[2] > 0);
+}

--- a/regression/cbmc/Quantifiers-fixpoint-instantiation/test.desc
+++ b/regression/cbmc/Quantifiers-fixpoint-instantiation/test.desc
@@ -1,0 +1,12 @@
+CORE broken-cprover-smt-backend no-new-smt
+main.c
+--no-standard-checks
+^VERIFICATION SUCCESSFUL$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--
+Tests the complete instantiation fixed-point computation. The property
+arr[2] > 0 requires chaining: instantiate j=0 to get arr[1]>0, then
+instantiate j=1 to get arr[2]>0.

--- a/regression/cbmc/Quantifiers-invalid-var-range/test.desc
+++ b/regression/cbmc/Quantifiers-invalid-var-range/test.desc
@@ -1,13 +1,11 @@
-KNOWNBUG broken-smt-backend
+CORE no-new-smt
 main.c
 
 ^\*\* Results:$
-^\*\* 0 of 1 failed
+^\*\* 0 of \d+ failed
 ^VERIFICATION SUCCESSFUL$
 ^EXIT=0$
 ^SIGNAL=0$
 --
 ^warning: ignoring
 --
-This produces the expected verification result, but actually ignores some
-quantifiers.

--- a/regression/cbmc/Quantifiers-offset-instantiation/main.c
+++ b/regression/cbmc/Quantifiers-offset-instantiation/main.c
@@ -1,0 +1,23 @@
+#include <assert.h>
+#include <stdlib.h>
+
+size_t nondet_size_t();
+
+int main()
+{
+  size_t n = nondet_size_t();
+  __CPROVER_assume(n > 2 && n < 100);
+  int *arr = malloc(n * sizeof(int));
+  __CPROVER_assume(arr);
+
+  arr[0] = 0;
+
+  // forall j: 0 <= j < n-1 => arr[j+1] == arr[j] + 1
+  __CPROVER_assume(__CPROVER_forall {
+    size_t j;
+    !(j < n - 1) || (arr[j + 1] == arr[j] + 1)
+  });
+
+  assert(arr[1] == 1);
+  assert(arr[2] == 2);
+}

--- a/regression/cbmc/Quantifiers-offset-instantiation/test.desc
+++ b/regression/cbmc/Quantifiers-offset-instantiation/test.desc
@@ -1,0 +1,12 @@
+CORE broken-cprover-smt-backend no-new-smt
+main.c
+--no-standard-checks
+^VERIFICATION SUCCESSFUL$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--
+Tests the complete instantiation approach for quantifiers with index offsets.
+The quantifier body uses arr[j+1] and arr[j], requiring the set constraint
+fixed-point computation to generate the right instantiation terms.

--- a/regression/cbmc/Quantifiers-two-dimension-array/no-upper-bound.c
+++ b/regression/cbmc/Quantifiers-two-dimension-array/no-upper-bound.c
@@ -1,0 +1,20 @@
+int main()
+{
+  int a[2][2];
+
+  __CPROVER_assume(__CPROVER_forall {
+    unsigned i;
+    __CPROVER_forall
+    {
+      unsigned j;
+      a[i % 2][j % 2] == (i % 2) + (j % 2)
+    }
+  });
+
+  assert(a[0][0] == 0);
+  assert(a[0][1] == 1);
+  assert(a[1][0] == 1);
+  assert(a[1][1] == 2);
+
+  return 0;
+}

--- a/regression/cbmc/Quantifiers-two-dimension-array/no-upper-bound.desc
+++ b/regression/cbmc/Quantifiers-two-dimension-array/no-upper-bound.desc
@@ -1,0 +1,11 @@
+CORE broken-cprover-smt-backend no-new-smt
+no-upper-bound.c
+--max-field-sensitivity-array-size 0
+^VERIFICATION SUCCESSFUL$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--
+E-matching does not yet handle array expressions (which field sensitivity
+produces for small fixed-size arrays), so we disable field sensitivity.

--- a/regression/cbmc/Quantifiers-type/test.desc
+++ b/regression/cbmc/Quantifiers-type/test.desc
@@ -1,14 +1,11 @@
-KNOWNBUG broken-smt-backend
+CORE broken-smt-backend no-new-smt
 main.c
 
 ^\*\* Results:$
-^\[main.assertion.1\] line 12 assertion tmp_if_expr(\$\d+)?: FAILURE$
-^\*\* 1 of 1 failed
+^\[main.assertion.1\] line 10 assertion a\[(\(signed (long )*int\))?0\] == 10 && a\[(\(signed (long )*int\))?1\] == 10: FAILURE$
+^\*\* 1 of \d+ failed
 ^VERIFICATION FAILED$
 ^EXIT=10$
 ^SIGNAL=0$
 --
 ^warning: ignoring
---
-This produces the expected verification result, but actually ignores some
-quantifiers.

--- a/regression/cbmc/Quantifiers-unbounded-array-overflow/main.c
+++ b/regression/cbmc/Quantifiers-unbounded-array-overflow/main.c
@@ -1,0 +1,102 @@
+#include <assert.h>
+#include <limits.h>
+#include <stdlib.h>
+#include <string.h>
+
+size_t nondet_size_t();
+
+#if UINT_MAX < SIZE_MAX
+#  define SMALLER_TYPE int
+#else
+#  define SMALLER_TYPE short
+#endif
+
+// The model has an overflow, falsified instantly with SAT,
+// takes forever with z3 because of the quantifiers
+int main()
+{
+  size_t size = nondet_size_t();
+  __CPROVER_assume(0 < size);
+  __CPROVER_assume(size <= __CPROVER_max_malloc_size / sizeof(SMALLER_TYPE));
+  // we remove this assumption, which in turn allows to cause an integer
+  // overflow in the loop body when computing i*2, because we would end up
+  // comparing i*2, which does not overflow on size_t, to the overflowed
+  // (wrap-around) value when i*2 was assigned to the int-typed array element
+  // __CPROVER_assume(size < INT_MAX / 2);
+  size_t nof_bytes = size * sizeof(SMALLER_TYPE);
+  SMALLER_TYPE *arr = malloc(nof_bytes);
+  __CPROVER_assume(arr);
+  __CPROVER_array_set(arr, 0);
+
+  // None of this should overflow because initially arr[j] == 0 for all j
+
+  // the original loop
+  // size_t i = 0;
+  // while (i < size)
+  // __CPROVER_loop_invariant(i <= size)
+  // __CPROVER_loop_invariant(__CPROVER_forall {size_t j; !(j < i) || (arr[j] == j * 2) })
+  // __CPROVER_loop_invariant(__CPROVER_forall {size_t j; !(i <= j && j < size) || (arr[j] == 0) })
+  // {
+  //     arr[i] = arr[i] + 2 * i;
+  //     i += 1;
+  // }
+
+  size_t i = 0;
+
+  // check base case
+  assert(i <= size);
+  assert(__CPROVER_forall {
+    size_t j;
+    !(j < i) || (arr[j] == j * 2)
+  });
+  assert(__CPROVER_forall {
+    size_t j;
+    !(i <= j && j < size) || (arr[j] == 0)
+  });
+
+  // jump to a nondet state
+  i = nondet_size_t();
+  __CPROVER_havoc_object(arr);
+
+  // assume loop invariant
+  __CPROVER_assume(i <= size);
+  __CPROVER_assume(i <= size);
+  __CPROVER_assume(__CPROVER_forall {
+    size_t j;
+    !(j < i) || (arr[j] == j * 2)
+  });
+  __CPROVER_assume(__CPROVER_forall {
+    size_t j;
+    !(i <= j && j < size) || (arr[j] == 0)
+  });
+
+  size_t old_i = i;
+  if(i < size)
+  {
+    arr[i] = arr[i] + i * 2;
+    i += 1;
+
+    // check loop invariant post loop step
+    assert(i <= size);
+    assert(__CPROVER_forall {
+      size_t j;
+      !(j < i) || (arr[j] == j * 2)
+    });
+    assert(__CPROVER_forall {
+      size_t j;
+      !(i <= j && j < size) || (arr[j] == 0)
+    });
+    __CPROVER_assume(0); // stop progress
+  }
+
+  // check that the loop invariant holds post loop
+  assert(__CPROVER_forall {
+    size_t j;
+    !(j < i) || (arr[j] == j * 2)
+  });
+
+  assert(__CPROVER_forall {
+    size_t j;
+    !(i <= j && j < size) || (arr[j] == 0)
+  });
+}

--- a/regression/cbmc/Quantifiers-unbounded-array-overflow/test.desc
+++ b/regression/cbmc/Quantifiers-unbounded-array-overflow/test.desc
@@ -1,0 +1,14 @@
+CORE thorough-z3-smt-backend broken-cprover-smt-backend no-new-smt
+main.c
+--no-standard-checks
+^\[main.assertion.5\] line 81 assertion __CPROVER_forall \{ size_t j; !\(j < i\) \|\| \(arr\[j\] == j \* 2\) \}: FAILURE$
+^\*\* 1 of \d+ failed
+^VERIFICATION FAILED$
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring
+--
+Uses --no-standard-checks to contain verification time with MiniSat; with
+CaDiCaL this completes in under 5 seconds either way. Takes an unknown amount of
+time (has never been run to completion) when using Z3.

--- a/regression/cbmc/Quantifiers-unbounded-array/main.c
+++ b/regression/cbmc/Quantifiers-unbounded-array/main.c
@@ -1,0 +1,41 @@
+#include <assert.h>
+#include <limits.h>
+#include <stdlib.h>
+
+size_t nondet_size_t();
+
+int main()
+{
+  size_t size = nondet_size_t();
+  __CPROVER_assume(0 < size);
+
+  // avoids overflows in the loop body on i * 2
+  __CPROVER_assume(size < INT_MAX / 2);
+  size_t nof_bytes = size * sizeof(int);
+  int *arr = malloc(nof_bytes);
+  __CPROVER_assume(arr);
+  __CPROVER_array_set(arr, 0);
+
+  // jump to a nondet state
+  size_t i = nondet_size_t();
+  __CPROVER_assume(i < size);
+  __CPROVER_havoc_object(arr);
+
+  // assume loop invariant
+  __CPROVER_assume(__CPROVER_forall {
+    size_t j;
+    !(j < i) || (arr[j] == j * 2)
+  });
+  __CPROVER_assume(__CPROVER_forall {
+    size_t j;
+    !(i <= j && j < size) || (arr[j] == 0)
+  });
+
+  arr[i] = arr[i] + i * 2;
+  i += 1;
+
+  assert(__CPROVER_forall {
+    size_t j;
+    !(i <= j && j < size) || (arr[j] == 0)
+  });
+}

--- a/regression/cbmc/Quantifiers-unbounded-array/test.desc
+++ b/regression/cbmc/Quantifiers-unbounded-array/test.desc
@@ -1,0 +1,8 @@
+CORE broken-cprover-smt-backend no-new-smt
+main.c
+
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring

--- a/regression/libcprover-cpp/CMakeLists.txt
+++ b/regression/libcprover-cpp/CMakeLists.txt
@@ -20,6 +20,7 @@ macro(add_test_pl_profile name cmdline flag profile)
     )
     set_tests_properties("${name}-${profile}" PROPERTIES
         LABELS "${profile};CBMC"
+        TIMEOUT 1200
     )
 endmacro(add_test_pl_profile)
 

--- a/regression/test.pl
+++ b/regression/test.pl
@@ -31,8 +31,8 @@ sub with_color {
   }
 }
 
-sub run($$$$$) {
-  my ($name, $input, $cmd, $options, $output) = @_;
+sub run($$$$$$) {
+  my ($name, $input, $cmd, $options, $output, $timeout) = @_;
   my $cmdline;
   if(length($input)) {
     $cmdline = "$cmd $options '$input' >'$output' 2>&1";
@@ -41,12 +41,55 @@ sub run($$$$$) {
   }
 
   print LOG "Running $cmdline\n";
-  # see https://github.com/git-for-windows/msys2-runtime/pull/11/files
-  system("bash", "-c", "cd '$name' ; MSYS_NO_PATHCONV=1 $cmdline");
-  my $exit_value = $? >> 8;
-  my $signal_num = $? & 127;
-  my $dumped_core = $? & 128;
+  my $exit_value;
+  my $signal_num;
+  my $dumped_core;
+  my $timed_out = 0;
+
+  # Fork so we can enforce a timeout via kill on the child process group.
+  my $pid = fork();
+  die "fork failed: $!" unless defined $pid;
+
+  if($pid == 0) {
+    # Child: start a new process group so we can kill the whole group on
+    # timeout, then exec the test command.
+    setpgrp(0, 0);
+    # see https://github.com/git-for-windows/msys2-runtime/pull/11/files
+    exec("bash", "-c", "cd '$name' ; MSYS_NO_PATHCONV=1 $cmdline");
+    die "exec failed: $!";
+  }
+
+  # Parent: wait for the child, with an optional timeout.
+  if($timeout) {
+    eval {
+      local $SIG{ALRM} = sub { die "alarm\n" };
+      alarm($timeout);
+      waitpid($pid, 0);
+      alarm(0);
+    };
+    if($@ && $@ eq "alarm\n") {
+      $timed_out = 1;
+      # Kill the entire process group of the child.
+      kill(-9, $pid);
+      waitpid($pid, 0);
+    }
+  } else {
+    waitpid($pid, 0);
+  }
+
+  $exit_value = $? >> 8;
+  $signal_num = $? & 127;
+  $dumped_core = $? & 128;
   my $failed = 0;
+
+  if($timed_out) {
+    print LOG "  Timed out after $timeout seconds\n";
+    print " [TIMEOUT]";
+    $failed = 1;
+    # Write output so that pattern matching does not crash on missing file.
+    system("bash", "-c", "cd '$name' ; echo '\nTIMEOUT=1\nEXIT=137\nSIGNAL=9\n' >> '$output'");
+    return $failed;
+  }
 
   print LOG "  Exit: $exit_value\n";
   print LOG "  Signal: $signal_num\n";
@@ -84,8 +127,8 @@ sub load($$) {
   return @data;
 }
 
-sub test($$$$$$$$$$$) {
-  my ($name, $test, $t_level, $cmd, $ign, $dry_run, $defines, $include_tags, $exclude_tags, $output_suffix, $exit_signal_checks) = @_;
+sub test($$$$$$$$$$$$) {
+  my ($name, $test, $t_level, $cmd, $ign, $dry_run, $defines, $include_tags, $exclude_tags, $output_suffix, $exit_signal_checks, $timeout) = @_;
   my ($level_and_tags, $input, $options, $grep_options, @results) = load("$test", $exit_signal_checks);
   my @keys = keys %{$defines};
   foreach my $key (@keys) {
@@ -179,7 +222,7 @@ sub test($$$$$$$$$$$) {
       return 0;
     }
 
-    $failed = run($name, $input, $cmd, $options, $output);
+    $failed = run($name, $input, $cmd, $options, $output, $timeout);
 
     if(!$failed) {
       print LOG "Execution [OK]\n";
@@ -302,6 +345,8 @@ Usage: test.pl -c CMD [OPTIONS] [DIRECTORIES ...]
              as runs with different suffixes will operate independently and keep
              independent logs.
   -f         forward the test name to CMD
+  -t <secs>  timeout per test in seconds (kills test if exceeded)
+             if present, the environment variable TESTPL_TIMEOUT is used as the default
 
   --[no]color enable/disable color output; enabled by default unless
               TESTPL_COLOR_OUTPUT is set to 0, in which case it is
@@ -341,7 +386,7 @@ use Getopt::Std;
 use Getopt::Long qw(:config pass_through bundling);
 $main::VERSION = 0.1;
 $Getopt::Std::STANDARD_HELP_VERSION = 1;
-our ($opt_c, $opt_e, $opt_f, $opt_i, $opt_j, $opt_n, $opt_p, $opt_h, $opt_C, $opt_T, $opt_F, $opt_K, $opt_s, $opt_S, %defines, @include_tags, @exclude_tags); # the variables for getopt
+our ($opt_c, $opt_e, $opt_f, $opt_i, $opt_j, $opt_n, $opt_p, $opt_h, $opt_C, $opt_T, $opt_F, $opt_K, $opt_s, $opt_S, $opt_t, %defines, @include_tags, @exclude_tags); # the variables for getopt
 
 # this needs to come before GetOptions to ensure the
 # default -> environment -> flag override priority
@@ -351,7 +396,7 @@ if (exists $ENV{'TESTPL_COLOR_OUTPUT'}) {
 }
 
 GetOptions("D=s" => \%defines, "X=s" => \@exclude_tags, "I=s" => \@include_tags, 'color!' => \$color_output_enabled);
-getopts('c:efi:j:nphCTFKs:S:') or &main::HELP_MESSAGE(\*STDOUT, "", $main::VERSION, "");
+getopts('c:efi:j:nphCTFKs:S:t:') or &main::HELP_MESSAGE(\*STDOUT, "", $main::VERSION, "");
 $opt_c or &main::HELP_MESSAGE(\*STDOUT, "", $main::VERSION, "");
 $opt_j = $opt_j || $ENV{'TESTPL_JOBS'} || 0;
 if($opt_j && $opt_j != 1 && !$has_thread_pool) {
@@ -369,6 +414,7 @@ $t_level += 1 if($opt_C || 0 == $t_level);
 my $dry_run = $opt_n;
 my $log_suffix = $opt_s;
 my $exit_signal_checks = defined($opt_e);
+my $timeout = $opt_t || $ENV{'TESTPL_TIMEOUT'} || 0;
 
 my $logfile_name = "tests";
 if($log_suffix) {
@@ -403,7 +449,7 @@ sub do_test($)
     defined($pool) or print "  Running $files[$_]";
     my $start_time = time();
     $failed_skipped = test(
-      $test, $files[$_], $t_level, $opt_c, $opt_i, $dry_run, \%defines, \@include_tags, \@exclude_tags, $log_suffix, $exit_signal_checks);
+      $test, $files[$_], $t_level, $opt_c, $opt_i, $dry_run, \%defines, \@include_tags, \@exclude_tags, $log_suffix, $exit_signal_checks, $timeout);
     my $runtime = time() - $start_time;
 
     lock($skips);

--- a/src/solvers/flattening/boolbv_quantifier.cpp
+++ b/src/solvers/flattening/boolbv_quantifier.cpp
@@ -217,9 +217,6 @@ static std::optional<exprt> eager_quantifier_instantiation(
   mp_integer lb = numeric_cast_v<mp_integer>(min_i.value());
   mp_integer ub = numeric_cast_v<mp_integer>(max_i.value());
 
-  if(lb > ub)
-    return {};
-
   auto expr_simplified =
     quantifier_exprt(expr.id(), expr.variables(), where_simplified);
 

--- a/src/solvers/flattening/boolbv_quantifier.cpp
+++ b/src/solvers/flattening/boolbv_quantifier.cpp
@@ -288,12 +288,523 @@ literalt boolbvt::convert_quantifier(const quantifier_exprt &src)
   return quantifier_list.back().l;
 }
 
-/// Eliminate the quantifier in \p q_expr via E-matching in \p context_map.
-/// \return Quantifier-free expression, if quantifier elimination was
-///   successful, else nullopt.
+/// \file
+/// Complete instantiation for quantified formulas.
+///
+/// This file implements quantifier elimination for CBMC's bitvector
+/// solver. Two strategies are used:
+///
+/// 1. **Eager instantiation** (bounded ranges): When the quantifier body
+///    contains explicit bounds on the variable (e.g., `!(j >= lb) || body`),
+///    the quantifier is expanded into a conjunction/disjunction over all
+///    values in [lb, ub]. This is handled by `eager_quantifier_instantiation`.
+///
+/// 2. **Complete instantiation** (unbounded/symbolic ranges): When no
+///    explicit bounds are available, we use an approach based on:
+///
+///      Yeting Ge and Leonardo de Moura, "Complete instantiation for
+///      quantified formulas in Satisfiability Modulo Theories", CAV 2009.
+///
+///    The key idea is that for *essentially uninterpreted* formulas (where
+///    quantified variables only appear as arguments of uninterpreted
+///    functions), the quantifier can be eliminated by instantiating with
+///    a finite set of ground terms. In CBMC's context, "uninterpreted
+///    functions" correspond to array accesses (index_exprt).
+///
+///    The paper defines a system of set constraints ΔF that captures which
+///    ground terms are relevant for each function argument position. The
+///    least fixed point of ΔF gives the complete set of instantiation
+///    terms. For the *almost uninterpreted* fragment (Section 4 of the
+///    paper), variables may also appear with arithmetic offsets, e.g.,
+///    `arr[j + 1]`. The offset extension adds constraints:
+///      S_{k,i} + r ⊆ A_{f,j}  and  A_{f,j} + (-r) ⊆ S_{k,i}
+///    ensuring that the fixed point accounts for shifted indices.
+///
+///    The formula F is in the *finite essentially uninterpreted* (FEU)
+///    fragment when ΔF is stratified (i.e., the fixed point is finite).
+///    For non-stratified cases (e.g., offsets that create infinite chains),
+///    we bound the computation to ensure termination.
+///
+///    This is implemented by `instantiate_one_quantifier` and its helpers,
+///    called from `finish_eager_conversion_quantifiers` as a post-processing
+///    step after the main bitvector conversion.
+
+/// Represents how a bound variable is used as an array index, possibly with
+/// an arithmetic offset. In the paper's terminology, this captures one
+/// occurrence of an uninterpreted function application f(... x_i + r ...)
+/// where f is an array access, x_i is the bound variable, and r is the
+/// offset.
+///
+/// For `arr[j + r]`: \p array is `arr`, \p offset is `r`.
+/// For `arr[j]`: \p array is `arr`, \p offset is zero.
+/// For `arr[j - r]`: \p array is `arr`, \p offset is `-r`.
+struct index_contextt
+{
+  exprt array;
+  exprt offset;
+};
+
+/// Check whether two array expressions refer to the same underlying
+/// Check whether \p pattern and \p candidate refer to the same
+/// array, accounting for SSA renaming. After symbolic execution, the
+/// same source-level array may appear with different SSA version
+/// numbers (e.g., `arr#1` vs `arr#2`). We compare L1 object
+/// identifiers to match across versions. For nested array accesses
+/// (e.g., `a[0]` as a sub-array), we recursively match the base
+/// array and compare the simplified indices.
+static bool
+arrays_match(const exprt &pattern, const exprt &candidate, const namespacet &ns)
+{
+  if(auto ssa_pattern = expr_try_dynamic_cast<ssa_exprt>(pattern))
+  {
+    if(auto ssa_candidate = expr_try_dynamic_cast<ssa_exprt>(candidate))
+    {
+      return ssa_pattern->get_l1_object_identifier() ==
+             ssa_candidate->get_l1_object_identifier();
+    }
+    return false;
+  }
+  // For nested array accesses like a[0][j], the "array" operand
+  // is itself an index_exprt (a[0]). Match recursively on the
+  // base array and compare simplified indices (the pattern may
+  // contain unsimplified arithmetic like cast(0 % 2) that equals
+  // a constant in the candidate).
+  if(auto idx_pattern = expr_try_dynamic_cast<index_exprt>(pattern))
+  {
+    if(auto idx_candidate = expr_try_dynamic_cast<index_exprt>(candidate))
+    {
+      return arrays_match(idx_pattern->array(), idx_candidate->array(), ns) &&
+             simplify_expr(idx_pattern->index(), ns) ==
+               simplify_expr(idx_candidate->index(), ns);
+    }
+    return false;
+  }
+  return pattern == candidate;
+}
+
+/// Find all index_exprt nodes in \p expr whose index sub-expression
+/// contains the symbol \p bound_var_id. For each such node, decompose
+/// the index into `bound_var + offset` (where offset may be zero).
+///
+/// This corresponds to identifying the uninterpreted function
+/// applications in the paper's terminology. In CBMC, array accesses
+/// (`index_exprt`) play the role of uninterpreted functions: the
+/// array is the function symbol, and the index is the argument.
+///
+/// The offset decomposition implements the extension from Section 4
+/// of the paper ("Offsets"): for terms of the form `f(x_i + r)`,
+/// we extract the offset `r` to generate the additional set
+/// constraints `S_{k,i} + r ⊆ A_{f,j}` and
+/// `A_{f,j} + (-r) ⊆ S_{k,i}`.
+///
+/// Recognised patterns:
+///   - `var` or `cast(var)` → offset = 0
+///   - `var + r` or `r + var` → offset = r
+///   - `var - r` → offset = -r
+///   - complex expressions containing var → offset = 0 (fallback)
+static std::vector<index_contextt>
+find_index_contexts(const exprt &expr, const irep_idt &bound_var_id)
+{
+  std::vector<index_contextt> contexts;
+  expr.visit_pre(
+    [&bound_var_id, &contexts](const exprt &e)
+    {
+      auto index_expr = expr_try_dynamic_cast<index_exprt>(e);
+      if(!index_expr)
+        return;
+
+      // Check whether the index sub-expression mentions the bound variable.
+      bool has_bound_var = false;
+      index_expr->index().visit_pre(
+        [&bound_var_id, &has_bound_var](const exprt &sub)
+        {
+          if(auto sym = expr_try_dynamic_cast<symbol_exprt>(sub))
+            has_bound_var |= sym->get_identifier() == bound_var_id;
+        });
+      if(!has_bound_var)
+        return;
+
+      // Decompose index into bound_var + offset.
+      // We recognise: var, var + const, const + var, var - const.
+      const exprt &idx = index_expr->index();
+      auto zero = from_integer(0, idx.type());
+
+      if(auto sym = expr_try_dynamic_cast<symbol_exprt>(idx))
+      {
+        if(sym->get_identifier() == bound_var_id)
+        {
+          contexts.push_back({index_expr->array(), std::move(zero)});
+          return;
+        }
+      }
+
+      if(auto tc = expr_try_dynamic_cast<typecast_exprt>(idx))
+      {
+        if(auto sym = expr_try_dynamic_cast<symbol_exprt>(tc->op()))
+        {
+          if(sym->get_identifier() == bound_var_id)
+          {
+            contexts.push_back(
+              {index_expr->array(), from_integer(0, idx.type())});
+            return;
+          }
+        }
+      }
+
+      if(idx.id() == ID_plus && idx.operands().size() == 2)
+      {
+        const auto &lhs = idx.operands()[0];
+        const auto &rhs = idx.operands()[1];
+
+        auto is_bound_var = [&bound_var_id](const exprt &e) -> bool
+        {
+          if(auto sym = expr_try_dynamic_cast<symbol_exprt>(e))
+            return sym->get_identifier() == bound_var_id;
+          if(auto tc = expr_try_dynamic_cast<typecast_exprt>(e))
+          {
+            if(auto sym = expr_try_dynamic_cast<symbol_exprt>(tc->op()))
+              return sym->get_identifier() == bound_var_id;
+          }
+          return false;
+        };
+
+        // Check for patterns: bound_var + offset, offset + bound_var
+        if(is_bound_var(lhs))
+        {
+          contexts.push_back({index_expr->array(), rhs});
+          return;
+        }
+        if(is_bound_var(rhs))
+        {
+          contexts.push_back({index_expr->array(), lhs});
+          return;
+        }
+      }
+
+      if(idx.id() == ID_minus && idx.operands().size() == 2)
+      {
+        const auto &lhs = idx.operands()[0];
+        const auto &rhs = idx.operands()[1];
+
+        auto is_bound_var = [&bound_var_id](const exprt &e) -> bool
+        {
+          if(auto sym = expr_try_dynamic_cast<symbol_exprt>(e))
+            return sym->get_identifier() == bound_var_id;
+          if(auto tc = expr_try_dynamic_cast<typecast_exprt>(e))
+          {
+            if(auto sym = expr_try_dynamic_cast<symbol_exprt>(tc->op()))
+              return sym->get_identifier() == bound_var_id;
+          }
+          return false;
+        };
+
+        // bound_var - offset => offset is negated
+        if(is_bound_var(lhs))
+        {
+          contexts.push_back({index_expr->array(), unary_minus_exprt(rhs)});
+          return;
+        }
+      }
+
+      // Fallback: treat the whole index as a context with zero offset
+      // (the variable is buried in a complex expression we don't decompose)
+      contexts.push_back({index_expr->array(), std::move(zero)});
+    });
+  return contexts;
+}
+
+/// Collect all ground index terms from \p context_map for arrays
+/// that match any of the given \p contexts.
+///
+/// In the paper's terminology, this builds the initial content of
+/// the sets A_{f,j}: the ground terms that appear as the j-th
+/// argument of uninterpreted function f in the ground clauses of F.
+/// We scan the bitvector cache for:
+///   - index_exprt (array reads): the index is a ground term
+///   - with_exprt (array writes): the update index is a ground term
+static std::unordered_set<exprt, irep_hash> collect_ground_indices(
+  const std::vector<index_contextt> &contexts,
+  const std::unordered_map<const exprt, bvt, irep_hash> &context_map,
+  const namespacet &ns)
+{
+  std::unordered_set<exprt, irep_hash> ground_indices;
+  for(const auto &cache_entry : context_map)
+  {
+    // Match array reads: index_exprt(array, index)
+    if(auto index_expr = expr_try_dynamic_cast<index_exprt>(cache_entry.first))
+    {
+      for(const auto &ctx : contexts)
+      {
+        if(arrays_match(ctx.array, index_expr->array(), ns))
+        {
+          ground_indices.insert(index_expr->index());
+          break;
+        }
+      }
+    }
+    // Match array writes: with_exprt(array, index, value)
+    else if(
+      auto with_expr = expr_try_dynamic_cast<with_exprt>(cache_entry.first))
+    {
+      for(const auto &ctx : contexts)
+      {
+        if(arrays_match(ctx.array, with_expr->old(), ns))
+        {
+          ground_indices.insert(with_expr->where());
+          break;
+        }
+      }
+    }
+  }
+  return ground_indices;
+}
+
+/// Compute the complete set of instantiation terms for a bound
+/// variable, implementing the set constraint fixed-point from
+/// Section 3 and the offset extension from Section 4 of:
+///
+///   Ge & de Moura, "Complete instantiation for quantified formulas
+///   in Satisfiability Modulo Theories", CAV 2009.
+///
+/// The paper defines a system of set constraints ΔF induced by the
+/// formula F. For each clause C_k containing a variable x_i that
+/// appears as the j-th argument of uninterpreted function f:
+///
+///   - If x_i appears directly: S_{k,i} = A_{f,j}
+///   - If a ground term t appears: t ∈ A_{f,j}
+///   - If x_i + r appears (offset): S_{k,i} + r ⊆ A_{f,j}
+///     and A_{f,j} + (-r) ⊆ S_{k,i}
+///
+/// The least fixed point of ΔF gives the sets S_{k,i} of ground
+/// terms to use for instantiating x_i. The formula F* obtained by
+/// instantiating each clause C_k[x] with terms from S_{k,i} is
+/// equisatisfiable with F (Theorem 1 and Theorem 2 in the paper).
+///
+/// When ΔF is stratified (the FEU fragment), the fixed point is
+/// finite. For non-stratified cases (e.g., offsets that create
+/// infinite chains as in Example 4 of the paper), we bound the
+/// computation with max_iterations and max_terms.
+///
+/// Two computation paths are provided:
+///   1. **Numeric path**: When all offsets and ground indices are
+///      constants, we use integer arithmetic for efficiency.
+///   2. **Symbolic path**: For non-constant terms, we build
+///      expressions and use simplify_expr to normalize them.
+///
+/// \param contexts: the index contexts (array, offset) pairs
+/// \param initial_ground_indices: ground terms from the bv_cache
+/// \param var_type: the type of the bound variable
+/// \param ns: namespace for expression simplification
+/// \return the set of terms to substitute for the bound variable
+static std::unordered_set<exprt, irep_hash> compute_instantiation_set(
+  const std::vector<index_contextt> &contexts,
+  const std::unordered_set<exprt, irep_hash> &initial_ground_indices,
+  const typet &var_type,
+  const namespacet &ns)
+{
+  std::unordered_set<exprt, irep_hash> all_ground = initial_ground_indices;
+  std::unordered_set<exprt, irep_hash> var_terms;
+
+  // Collect all distinct offsets
+  std::vector<exprt> offsets;
+  for(const auto &ctx : contexts)
+    offsets.push_back(ctx.offset);
+
+  // Check if all offsets are zero (no offset case) - skip fixed-point
+  bool has_nonzero_offset = false;
+  for(const auto &r : offsets)
+  {
+    if(!r.is_zero())
+    {
+      has_nonzero_offset = true;
+      break;
+    }
+  }
+
+  if(!has_nonzero_offset)
+  {
+    for(const auto &g : all_ground)
+      var_terms.insert(typecast_exprt::conditional_cast(g, var_type));
+    return var_terms;
+  }
+
+  // Try to extract numeric offset values for efficient fixed-point computation
+  std::vector<std::optional<mp_integer>> numeric_offsets;
+  bool all_numeric_offsets = true;
+  for(const auto &r : offsets)
+  {
+    if(r.is_zero())
+    {
+      numeric_offsets.push_back(mp_integer(0));
+    }
+    else
+    {
+      auto val = numeric_cast<mp_integer>(r);
+      numeric_offsets.push_back(val);
+      if(!val.has_value())
+        all_numeric_offsets = false;
+    }
+  }
+
+  // Try to extract numeric ground indices
+  std::set<mp_integer> numeric_ground;
+  bool all_numeric_ground = true;
+  for(const auto &g : all_ground)
+  {
+    auto val = numeric_cast<mp_integer>(g);
+    if(val.has_value())
+      numeric_ground.insert(*val);
+    else
+      all_numeric_ground = false;
+  }
+
+  // If we have numeric offsets and ground indices, compute the fixed point
+  // using integer arithmetic (much more efficient)
+  if(all_numeric_offsets && all_numeric_ground && !numeric_ground.empty())
+  {
+    std::set<mp_integer> var_values;
+    bool changed = true;
+    const std::size_t max_iterations = 5;
+    const std::size_t max_terms = 50;
+    std::size_t iteration = 0;
+    while(changed && iteration < max_iterations)
+    {
+      changed = false;
+      ++iteration;
+
+      std::set<mp_integer> new_var_values;
+      for(const auto &g : numeric_ground)
+      {
+        for(const auto &r : numeric_offsets)
+        {
+          mp_integer v = g - *r;
+          if(var_values.find(v) == var_values.end())
+            new_var_values.insert(v);
+        }
+      }
+      for(const auto &v : new_var_values)
+      {
+        if(var_values.insert(v).second)
+          changed = true;
+      }
+      if(var_values.size() > max_terms)
+        break;
+
+      std::set<mp_integer> new_ground;
+      for(const auto &v : var_values)
+      {
+        for(const auto &r : numeric_offsets)
+        {
+          mp_integer g = v + *r;
+          if(numeric_ground.find(g) == numeric_ground.end())
+            new_ground.insert(g);
+        }
+      }
+      for(const auto &g : new_ground)
+      {
+        if(numeric_ground.insert(g).second)
+          changed = true;
+      }
+      if(numeric_ground.size() > max_terms)
+        break;
+    }
+
+    for(const auto &v : var_values)
+      var_terms.insert(from_integer(v, var_type));
+    return var_terms;
+  }
+
+  // Fallback: symbolic fixed-point with simplification
+  bool changed = true;
+  const std::size_t max_iterations = 3;
+  const std::size_t max_terms = 30;
+  std::size_t iteration = 0;
+  while(changed && iteration < max_iterations)
+  {
+    changed = false;
+    ++iteration;
+
+    std::unordered_set<exprt, irep_hash> new_var_terms;
+    for(const auto &g : all_ground)
+    {
+      for(const auto &r : offsets)
+      {
+        exprt var_term;
+        if(r.is_zero())
+          var_term = typecast_exprt::conditional_cast(g, var_type);
+        else
+        {
+          var_term = simplify_expr(
+            typecast_exprt::conditional_cast(minus_exprt(g, r), var_type), ns);
+        }
+        if(var_terms.find(var_term) == var_terms.end())
+          new_var_terms.insert(var_term);
+      }
+    }
+    for(auto &v : new_var_terms)
+    {
+      if(var_terms.insert(std::move(v)).second)
+        changed = true;
+    }
+    if(var_terms.size() > max_terms)
+      break;
+
+    std::unordered_set<exprt, irep_hash> new_ground;
+    for(const auto &v : var_terms)
+    {
+      for(const auto &r : offsets)
+      {
+        exprt ground_term;
+        if(r.is_zero())
+          ground_term = typecast_exprt::conditional_cast(v, r.type());
+        else
+        {
+          ground_term = simplify_expr(
+            plus_exprt(typecast_exprt::conditional_cast(v, r.type()), r), ns);
+        }
+        if(all_ground.find(ground_term) == all_ground.end())
+          new_ground.insert(ground_term);
+      }
+    }
+    for(auto &g : new_ground)
+    {
+      if(all_ground.insert(std::move(g)).second)
+        changed = true;
+    }
+    if(all_ground.size() > max_terms)
+      break;
+  }
+
+  return var_terms;
+}
+
+/// Eliminate the quantifier in \p q_expr via complete instantiation
+/// using ground terms from \p context_map.
+///
+/// Implements the approach from Ge & de Moura, "Complete
+/// instantiation for quantified formulas in SMT" (CAV 2009).
+/// The procedure:
+///   1. Identifies how the bound variable is used as an array index
+///      (find_index_contexts), corresponding to the paper's
+///      identification of uninterpreted function applications.
+///   2. Collects ground index terms from the bitvector cache
+///      (collect_ground_indices), seeding the sets A_{f,j}.
+///   3. Computes the fixed point of the set constraint system ΔF
+///      (compute_instantiation_set), yielding the instantiation
+///      terms S_{k,i}.
+///   4. Instantiates the quantifier body with each term and
+///      combines: conjunction for forall, disjunction for exists.
+///
+/// \param q_expr: the quantifier expression to eliminate
+/// \param context_map: the bitvector cache (bv_cache) mapping
+///   expressions to their bitvector encodings
+/// \param ns: namespace for expression simplification
+/// \return quantifier-free expression, or nullopt if instantiation
+///   was not possible (e.g., no array index contexts found)
 static std::optional<exprt> instantiate_one_quantifier(
   const quantifier_exprt &q_expr,
-  const std::unordered_map<const exprt, bvt, irep_hash> &context_map)
+  const std::unordered_map<const exprt, bvt, irep_hash> &context_map,
+  const namespacet &ns)
 {
   if(q_expr.variables().size() > 1)
   {
@@ -305,75 +816,46 @@ static std::optional<exprt> instantiate_one_quantifier(
       q_expr.id(),
       q_expr.variables().back(),
       quantifier_exprt{q_expr.id(), new_variables, q_expr.where()}};
-    return instantiate_one_quantifier(new_expression, context_map);
+    return instantiate_one_quantifier(new_expression, context_map, ns);
   }
 
-  // find the contexts in which the bound variable is used
   const irep_idt &bound_variable_id = q_expr.symbol().get_identifier();
-  bool required_context = false;
-  std::unordered_set<index_exprt, irep_hash> index_contexts;
-  auto context_finder =
-    [&bound_variable_id, &required_context, &index_contexts](const exprt &e)
-  {
-    if(auto symbol_expr = expr_try_dynamic_cast<symbol_exprt>(e))
-    {
-      required_context |= bound_variable_id == symbol_expr->get_identifier();
-    }
-    else if(required_context)
-    {
-      if(auto index_expr = expr_try_dynamic_cast<index_exprt>(e))
-      {
-        index_contexts.insert(*index_expr);
-        required_context = false;
-      }
-    }
-  };
-  q_expr.where().visit_post(context_finder);
-  // make sure we found some context for instantiation
-  if(index_contexts.empty())
+
+  // Find all array index contexts where the bound variable appears
+  auto contexts = find_index_contexts(q_expr.where(), bound_variable_id);
+  if(contexts.empty())
     return {};
 
-  // match the contexts against expressions that we have cached
-  std::unordered_set<exprt, irep_hash> instantiation_candidates;
-  for(const auto &cache_entry : context_map)
-  {
-    // consider re-organizing the cache to use expression ids at the top level
-    if(auto index_expr = expr_try_dynamic_cast<index_exprt>(cache_entry.first))
-    {
-      for(const auto &index_context : index_contexts)
-      {
-        if(
-          auto ssa_context =
-            expr_try_dynamic_cast<ssa_exprt>(index_context.array()))
-        {
-          if(
-            auto ssa_array =
-              expr_try_dynamic_cast<ssa_exprt>(index_expr->array()))
-          {
-            if(
-              ssa_context->get_l1_object_identifier() ==
-              ssa_array->get_l1_object_identifier())
-            {
-              instantiation_candidates.insert(index_expr->index());
-              break;
-            }
-          }
-        }
-        else if(index_expr->array() == index_context.array())
-        {
-          instantiation_candidates.insert(index_expr->index());
-          break;
-        }
-      }
-    }
-  }
-
-  if(instantiation_candidates.empty())
+  // Collect ground index terms from the cache
+  auto ground_indices = collect_ground_indices(contexts, context_map, ns);
+  if(ground_indices.empty())
     return {};
+
+  // Compute the complete instantiation set using the paper's set constraint
+  // fixed-point approach
+  auto instantiation_terms = compute_instantiation_set(
+    contexts, ground_indices, q_expr.symbol().type(), ns);
+
+  if(instantiation_terms.empty())
+    return {};
+
+  // Sort instantiation terms for deterministic clause ordering
+  // in the SAT solver. Without sorting, the unordered_set iteration
+  // order depends on expression hashes, which incorporate source
+  // locations (including file paths). This causes MiniSat to see
+  // different clause orderings for the same formula depending on
+  // how the input file is specified, with performance varying from
+  // sub-second to minutes on the same UNSAT instance.
+  std::vector<exprt> sorted_terms(
+    instantiation_terms.begin(), instantiation_terms.end());
+  std::sort(
+    sorted_terms.begin(),
+    sorted_terms.end(),
+    [](const exprt &a, const exprt &b) { return a < b; });
 
   exprt::operandst instantiations;
-  instantiations.reserve(instantiation_candidates.size());
-  for(const auto &e : instantiation_candidates)
+  instantiations.reserve(sorted_terms.size());
+  for(const auto &e : sorted_terms)
   {
     exprt::operandst values{
       {typecast_exprt::conditional_cast(e, q_expr.symbol().type())}};
@@ -402,7 +884,7 @@ void boolbvt::finish_eager_conversion_quantifiers()
     for(const auto &q : remaining_quantifiers)
     {
       instantiations.push_back(
-        instantiate_one_quantifier(to_quantifier_expr(q.expr), bv_cache));
+        instantiate_one_quantifier(to_quantifier_expr(q.expr), bv_cache, ns));
     }
 
     auto instantiations_it = instantiations.begin();

--- a/src/solvers/flattening/boolbv_quantifier.cpp
+++ b/src/solvers/flattening/boolbv_quantifier.cpp
@@ -11,6 +11,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/expr_util.h>
 #include <util/invariant.h>
 #include <util/simplify_expr.h>
+#include <util/ssa_expr.h>
 
 #include "boolbv.h"
 
@@ -287,12 +288,136 @@ literalt boolbvt::convert_quantifier(const quantifier_exprt &src)
   return quantifier_list.back().l;
 }
 
+/// Eliminate the quantifier in \p q_expr via E-matching in \p context_map.
+/// \return Quantifier-free expression, if quantifier elimination was
+///   successful, else nullopt.
+static std::optional<exprt> instantiate_one_quantifier(
+  const quantifier_exprt &q_expr,
+  const std::unordered_map<const exprt, bvt, irep_hash> &context_map)
+{
+  if(q_expr.variables().size() > 1)
+  {
+    // Rewrite Qx,y.P(x,y) as Qy.Qx.P(x,y), just like
+    // eager_quantifier_instantiation does.
+    auto new_variables = q_expr.variables();
+    new_variables.pop_back();
+    quantifier_exprt new_expression{
+      q_expr.id(),
+      q_expr.variables().back(),
+      quantifier_exprt{q_expr.id(), new_variables, q_expr.where()}};
+    return instantiate_one_quantifier(new_expression, context_map);
+  }
+
+  // find the contexts in which the bound variable is used
+  const irep_idt &bound_variable_id = q_expr.symbol().get_identifier();
+  bool required_context = false;
+  std::unordered_set<index_exprt, irep_hash> index_contexts;
+  auto context_finder =
+    [&bound_variable_id, &required_context, &index_contexts](const exprt &e)
+  {
+    if(auto symbol_expr = expr_try_dynamic_cast<symbol_exprt>(e))
+    {
+      required_context |= bound_variable_id == symbol_expr->get_identifier();
+    }
+    else if(required_context)
+    {
+      if(auto index_expr = expr_try_dynamic_cast<index_exprt>(e))
+      {
+        index_contexts.insert(*index_expr);
+        required_context = false;
+      }
+    }
+  };
+  q_expr.where().visit_post(context_finder);
+  // make sure we found some context for instantiation
+  if(index_contexts.empty())
+    return {};
+
+  // match the contexts against expressions that we have cached
+  std::unordered_set<exprt, irep_hash> instantiation_candidates;
+  for(const auto &cache_entry : context_map)
+  {
+    // consider re-organizing the cache to use expression ids at the top level
+    if(auto index_expr = expr_try_dynamic_cast<index_exprt>(cache_entry.first))
+    {
+      for(const auto &index_context : index_contexts)
+      {
+        if(
+          auto ssa_context =
+            expr_try_dynamic_cast<ssa_exprt>(index_context.array()))
+        {
+          if(
+            auto ssa_array =
+              expr_try_dynamic_cast<ssa_exprt>(index_expr->array()))
+          {
+            if(
+              ssa_context->get_l1_object_identifier() ==
+              ssa_array->get_l1_object_identifier())
+            {
+              instantiation_candidates.insert(index_expr->index());
+              break;
+            }
+          }
+        }
+        else if(index_expr->array() == index_context.array())
+        {
+          instantiation_candidates.insert(index_expr->index());
+          break;
+        }
+      }
+    }
+  }
+
+  if(instantiation_candidates.empty())
+    return {};
+
+  exprt::operandst instantiations;
+  instantiations.reserve(instantiation_candidates.size());
+  for(const auto &e : instantiation_candidates)
+  {
+    exprt::operandst values{
+      {typecast_exprt::conditional_cast(e, q_expr.symbol().type())}};
+    instantiations.push_back(q_expr.instantiate(values));
+  }
+
+  if(q_expr.id() == ID_exists)
+    return disjunction(instantiations);
+  else
+  {
+    PRECONDITION(q_expr.id() == ID_forall);
+    return conjunction(instantiations);
+  }
+}
+
 void boolbvt::finish_eager_conversion_quantifiers()
 {
-  if(quantifier_list.empty())
-    return;
+  // Nested quantifiers may yield additional entries in quantifier_list via
+  // convert.
+  while(!quantifier_list.empty())
+  {
+    std::list<quantifiert> remaining_quantifiers;
+    std::swap(quantifier_list, remaining_quantifiers);
+    std::list<std::optional<exprt>> instantiations;
 
-  // we do not yet have any elaborate post-processing
-  for(const auto &q : quantifier_list)
-    conversion_failed(q.expr);
+    for(const auto &q : remaining_quantifiers)
+    {
+      instantiations.push_back(
+        instantiate_one_quantifier(to_quantifier_expr(q.expr), bv_cache));
+    }
+
+    auto instantiations_it = instantiations.begin();
+    for(const auto &q : remaining_quantifiers)
+    {
+      if(!instantiations_it->has_value())
+      {
+        conversion_failed(q.expr);
+        ++instantiations_it;
+        continue;
+      }
+
+      literalt result_lit = convert(**instantiations_it);
+      prop.l_set_to_true(prop.lequal(q.l, result_lit));
+      ++instantiations_it;
+    }
+  }
 }


### PR DESCRIPTION
Depends-on: [tautschnig/array-theory-improvements](https://github.com/tautschnig/cbmc/tree/array-theory-improvements)

Use E-matching on index expressions to instantiate quantifiers when eager instantiation (aka enumerative instantiation) cannot be applied.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [x] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
