### PR TITLE
C++ front-end: Replace uses of namespacet::follow

### DIFF
--- a/src/cpp/cpp_constructor.cpp
+++ b/src/cpp/cpp_constructor.cpp
@@ -30,10 +30,9 @@ std::optional<codet> cpp_typecheckt::cpp_constructor(
 
   elaborate_class_template(object_tc.type());
 
-  typet tmp_type(follow(object_tc.type()));
-  CHECK_RETURN(!is_reference(tmp_type));
+  CHECK_RETURN(!is_reference(object_tc.type()));
 
-  if(tmp_type.id()==ID_array)
+  if(object_tc.type().id() == ID_array)
   {
     // We allow only one operand and it must be tagged with '#array_ini'.
     // Note that the operand is an array that is used for copy-initialization.
@@ -53,11 +52,10 @@ std::optional<codet> cpp_typecheckt::cpp_constructor(
       operands.empty() || operands.size() == 1,
       "array constructor must have at most one operand");
 
-    if(operands.empty() && cpp_is_pod(tmp_type))
+    if(operands.empty() && cpp_is_pod(object_tc.type()))
       return {};
 
-    const exprt &size_expr=
-      to_array_type(tmp_type).size();
+    const exprt &size_expr = to_array_type(object_tc.type()).size();
 
     if(size_expr.id() == ID_infinity)
       return {}; // don't initialize
@@ -74,7 +72,7 @@ std::optional<codet> cpp_typecheckt::cpp_constructor(
       throw 0;
     }
 
-    /*if(cpp_is_pod(tmp_type))
+    /*if(cpp_is_pod(object_tc.type()))
     {
       code_expressiont new_code;
       exprt op_tc=operands.front();
@@ -119,7 +117,7 @@ std::optional<codet> cpp_typecheckt::cpp_constructor(
       return std::move(new_code);
     }
   }
-  else if(cpp_is_pod(tmp_type))
+  else if(cpp_is_pod(object_tc.type()))
   {
     exprt::operandst operands_tc=operands;
 
@@ -152,11 +150,11 @@ std::optional<codet> cpp_typecheckt::cpp_constructor(
       throw 0;
     }
   }
-  else if(tmp_type.id()==ID_union)
+  else if(object_tc.type().id() == ID_union_tag)
   {
     UNREACHABLE; // Todo: union
   }
-  else if(tmp_type.id()==ID_struct)
+  else if(object_tc.type().id() == ID_struct_tag)
   {
     exprt::operandst operands_tc=operands;
 
@@ -166,8 +164,8 @@ std::optional<codet> cpp_typecheckt::cpp_constructor(
       add_implicit_dereference(op);
     }
 
-    const struct_typet &struct_type=
-      to_struct_type(tmp_type);
+    const struct_typet &struct_type =
+      follow_tag(to_struct_tag_type(object_tc.type()));
 
     // set most-derived bits
     code_blockt block;

--- a/src/cpp/cpp_destructor.cpp
+++ b/src/cpp/cpp_destructor.cpp
@@ -22,17 +22,15 @@ std::optional<codet> cpp_typecheckt::cpp_destructor(
 {
   elaborate_class_template(object.type());
 
-  typet tmp_type(follow(object.type()));
-  CHECK_RETURN(!is_reference(tmp_type));
+  CHECK_RETURN(!is_reference(object.type()));
 
   // PODs don't need a destructor
-  if(cpp_is_pod(tmp_type))
+  if(cpp_is_pod(object.type()))
     return {};
 
-  if(tmp_type.id()==ID_array)
+  if(object.type().id() == ID_array)
   {
-    const exprt &size_expr=
-      to_array_type(tmp_type).size();
+    const exprt &size_expr = to_array_type(object.type()).size();
 
     if(size_expr.id() == ID_infinity)
       return {}; // don't initialize
@@ -70,8 +68,8 @@ std::optional<codet> cpp_typecheckt::cpp_destructor(
   }
   else
   {
-    const struct_typet &struct_type=
-      to_struct_type(tmp_type);
+    const struct_typet &struct_type =
+      follow_tag(to_struct_tag_type(object.type()));
 
     // enter struct scope
     cpp_save_scopet save_scope(cpp_scopes);

--- a/src/cpp/cpp_typecheck.cpp
+++ b/src/cpp/cpp_typecheck.cpp
@@ -67,9 +67,9 @@ const struct_typet &cpp_typecheckt::this_struct_type()
   CHECK_RETURN(this_expr.is_not_nil());
   CHECK_RETURN(this_expr.type().id() == ID_pointer);
 
-  const typet &t = follow(to_pointer_type(this_expr.type()).base_type());
-  CHECK_RETURN(t.id() == ID_struct);
-  return to_struct_type(t);
+  const typet &t = to_pointer_type(this_expr.type()).base_type();
+  CHECK_RETURN(t.id() == ID_struct_tag);
+  return follow_tag(to_struct_tag_type(t));
 }
 
 std::string cpp_typecheckt::to_string(const exprt &expr)

--- a/src/cpp/cpp_typecheck.h
+++ b/src/cpp/cpp_typecheck.h
@@ -25,6 +25,9 @@ Author: Daniel Kroening, kroening@cs.cmu.edu
 #include <set>
 #include <unordered_set>
 
+class pointer_typet;
+class reference_typet;
+
 bool cpp_typecheck(
   cpp_parse_treet &cpp_parse_tree,
   symbol_table_baset &symbol_table,
@@ -524,14 +527,18 @@ public:
   bool user_defined_conversion_sequence(
     const exprt &expr, const typet &type, exprt &new_expr, unsigned &rank);
 
-  bool reference_related(
-    const exprt &expr, const typet &type) const;
+  bool reference_related(const exprt &expr, const reference_typet &type) const;
 
   bool reference_compatible(
-    const exprt &expr, const typet &type, unsigned &rank) const;
+    const exprt &expr,
+    const reference_typet &type,
+    unsigned &rank) const;
 
   bool reference_binding(
-    exprt expr, const typet &type, exprt &new_expr, unsigned &rank);
+    exprt expr,
+    const reference_typet &type,
+    exprt &new_expr,
+    unsigned &rank);
 
   bool implicit_conversion_sequence(
     const exprt &expr, const typet &type, exprt &new_expr, unsigned &rank);
@@ -542,7 +549,7 @@ public:
   bool implicit_conversion_sequence(
     const exprt &expr, const typet &type, exprt &new_expr);
 
-  void reference_initializer(exprt &expr, const typet &type);
+  void reference_initializer(exprt &expr, const reference_typet &type);
 
   void implicit_typecast(exprt &expr, const typet &type) override;
 
@@ -556,9 +563,7 @@ public:
     const struct_typet &from,
     const struct_typet &to) const;
 
-  void make_ptr_typecast(
-    exprt &expr,
-    const typet &dest_type);
+  void make_ptr_typecast(exprt &expr, const pointer_typet &dest_type);
 
   // the C++ typecasts
 

--- a/src/cpp/cpp_typecheck_code.cpp
+++ b/src/cpp/cpp_typecheck_code.cpp
@@ -258,8 +258,7 @@ void cpp_typecheckt::typecheck_member_initializer(codet &code)
     PRECONDITION(this_expr.is_not_nil());
 
     make_ptr_typecast(
-      this_expr,
-      code_type.parameters().front().type());
+      this_expr, to_pointer_type(code_type.parameters().front().type()));
 
     function_call.arguments().push_back(this_expr);
 
@@ -354,7 +353,8 @@ void cpp_typecheckt::typecheck_member_initializer(codet &code)
           throw 0;
         }
 
-        reference_initializer(code.op0(), symbol_expr.type());
+        reference_initializer(
+          code.op0(), to_reference_type(symbol_expr.type()));
 
         // assign the pointers
         symbol_expr.type().remove(ID_C_reference);

--- a/src/cpp/cpp_typecheck_compound_type.cpp
+++ b/src/cpp/cpp_typecheck_compound_type.cpp
@@ -1680,18 +1680,17 @@ bool cpp_typecheckt::subtype_typecast(
 
 void cpp_typecheckt::make_ptr_typecast(
   exprt &expr,
-  const typet &dest_type)
+  const pointer_typet &dest_type)
 {
   typet src_type=expr.type();
 
   PRECONDITION(src_type.id() == ID_pointer);
-  PRECONDITION(dest_type.id() == ID_pointer);
 
   const struct_typet &src_struct = to_struct_type(
     static_cast<const typet &>(follow(to_pointer_type(src_type).base_type())));
 
-  const struct_typet &dest_struct = to_struct_type(
-    static_cast<const typet &>(follow(to_pointer_type(dest_type).base_type())));
+  const struct_typet &dest_struct =
+    to_struct_type(static_cast<const typet &>(follow(dest_type.base_type())));
 
   PRECONDITION(
     subtype_typecast(src_struct, dest_struct) ||

--- a/src/cpp/cpp_typecheck_compound_type.cpp
+++ b/src/cpp/cpp_typecheck_compound_type.cpp
@@ -1019,15 +1019,21 @@ void cpp_typecheckt::typecheck_compound_body(symbolt &symbol)
         throw 0;
       }
 
-      typet final_type=follow(declaration.type());
-
       // anonymous member?
-      if(declaration.declarators().empty() &&
-         final_type.get_bool(ID_C_is_anonymous))
+      if(
+        declaration.declarators().empty() &&
+        ((declaration.type().id() == ID_struct_tag &&
+          follow_tag(to_struct_tag_type(declaration.type()))
+            .get_bool(ID_C_is_anonymous)) ||
+         (declaration.type().id() == ID_union_tag &&
+          follow_tag(to_union_tag_type(declaration.type()))
+            .get_bool(ID_C_is_anonymous)) ||
+         declaration.type().get_bool(ID_C_is_anonymous)))
       {
         // we only allow this on struct/union types
-        if(final_type.id()!=ID_union &&
-           final_type.id()!=ID_struct)
+        if(
+          declaration.type().id() != ID_union_tag &&
+          declaration.type().id() != ID_struct_tag)
         {
           error().source_location=declaration.type().source_location();
           error() << "member declaration does not declare anything"
@@ -1423,8 +1429,14 @@ void cpp_typecheckt::convert_anon_struct_union_member(
   const irep_idt &access,
   struct_typet::componentst &components)
 {
+  const struct_union_typet &final_type =
+    declaration.type().id() == ID_struct_tag
+      ? static_cast<const struct_union_typet &>(
+          follow_tag(to_struct_tag_type(declaration.type())))
+      : static_cast<const struct_union_typet &>(
+          follow_tag(to_union_tag_type(declaration.type())));
   symbolt &struct_union_symbol =
-    symbol_table.get_writeable_ref(follow(declaration.type()).get(ID_name));
+    symbol_table.get_writeable_ref(final_type.get(ID_name));
 
   if(declaration.storage_spec().is_static() ||
      declaration.storage_spec().is_mutable())
@@ -1477,13 +1489,15 @@ bool cpp_typecheckt::get_component(
   const irep_idt &component_name,
   exprt &member)
 {
-  const typet &followed_type=follow(object.type());
-
   PRECONDITION(
-    followed_type.id() == ID_struct || followed_type.id() == ID_union);
+    object.type().id() == ID_struct_tag || object.type().id() == ID_union_tag);
 
-  struct_union_typet final_type=
-    to_struct_union_type(followed_type);
+  struct_union_typet final_type =
+    object.type().id() == ID_struct_tag
+      ? static_cast<const struct_union_typet &>(
+          follow_tag(to_struct_tag_type(object.type())))
+      : static_cast<const struct_union_typet &>(
+          follow_tag(to_union_tag_type(object.type())));
 
   const struct_union_typet::componentst &components=
     final_type.components();
@@ -1529,14 +1543,22 @@ bool cpp_typecheckt::get_component(
 
       return true; // component found
     }
-    else if(follow(component.type()).find(ID_C_unnamed_object).is_not_nil())
+    else if(
+      (component.type().id() == ID_struct_tag &&
+       follow_tag(to_struct_tag_type(component.type()))
+         .find(ID_C_unnamed_object)
+         .is_not_nil()) ||
+      (component.type().id() == ID_union_tag &&
+       follow_tag(to_union_tag_type(component.type()))
+         .find(ID_C_unnamed_object)
+         .is_not_nil()) ||
+      component.type().find(ID_C_unnamed_object).is_not_nil())
     {
       // could be anonymous union or struct
 
-      const typet &component_type=follow(component.type());
-
-      if(component_type.id()==ID_union ||
-         component_type.id()==ID_struct)
+      if(
+        component.type().id() == ID_union_tag ||
+        component.type().id() == ID_struct_tag)
       {
         // recursive call!
         if(get_component(source_location, tmp, component_name, member))
@@ -1686,11 +1708,11 @@ void cpp_typecheckt::make_ptr_typecast(
 
   PRECONDITION(src_type.id() == ID_pointer);
 
-  const struct_typet &src_struct = to_struct_type(
-    static_cast<const typet &>(follow(to_pointer_type(src_type).base_type())));
+  const struct_typet &src_struct =
+    follow_tag(to_struct_tag_type(to_pointer_type(src_type).base_type()));
 
   const struct_typet &dest_struct =
-    to_struct_type(static_cast<const typet &>(follow(dest_type.base_type())));
+    follow_tag(to_struct_tag_type(dest_type.base_type()));
 
   PRECONDITION(
     subtype_typecast(src_struct, dest_struct) ||

--- a/src/cpp/cpp_typecheck_destructor.cpp
+++ b/src/cpp/cpp_typecheck_destructor.cpp
@@ -134,9 +134,8 @@ codet cpp_typecheckt::dtor(const symbolt &symbol, const symbol_exprt &this_expr)
       bit++)
   {
     DATA_INVARIANT(bit->id() == ID_base, "base class expression expected");
-    const symbolt &psymb = lookup(bit->type());
 
-    dereference_exprt object{this_expr, psymb.type};
+    dereference_exprt object{this_expr, bit->type()};
     object.add_source_location() = source_location;
 
     const bool disabled_access_control = disable_access_control;

--- a/src/cpp/cpp_typecheck_initializer.cpp
+++ b/src/cpp/cpp_typecheck_initializer.cpp
@@ -199,11 +199,9 @@ void cpp_typecheckt::zero_initializer(
   const source_locationt &source_location,
   exprt::operandst &ops)
 {
-  const typet &final_type=follow(type);
-
-  if(final_type.id()==ID_struct)
+  if(type.id() == ID_struct_tag)
   {
-    const auto &struct_type = to_struct_type(final_type);
+    const auto &struct_type = follow_tag(to_struct_tag_type(type));
 
     if(struct_type.is_incomplete())
     {
@@ -230,8 +228,7 @@ void cpp_typecheckt::zero_initializer(
     }
   }
   else if(
-    final_type.id() == ID_array &&
-    !cpp_is_pod(to_array_type(final_type).element_type()))
+    type.id() == ID_array && !cpp_is_pod(to_array_type(type).element_type()))
   {
     const array_typet &array_type=to_array_type(type);
     const exprt &size_expr=array_type.size();
@@ -251,9 +248,9 @@ void cpp_typecheckt::zero_initializer(
       zero_initializer(index, array_type.element_type(), source_location, ops);
     }
   }
-  else if(final_type.id()==ID_union)
+  else if(type.id() == ID_union_tag)
   {
-    const auto &union_type = to_union_type(final_type);
+    const auto &union_type = follow_tag(to_union_tag_type(type));
 
     if(union_type.is_incomplete())
     {
@@ -298,10 +295,10 @@ void cpp_typecheckt::zero_initializer(
       zero_initializer(member, comp.type(), source_location, ops);
     }
   }
-  else if(final_type.id()==ID_c_enum)
+  else if(type.id() == ID_c_enum_tag)
   {
     const unsignedbv_typet enum_type(
-      to_bitvector_type(to_c_enum_type(final_type).underlying_type())
+      to_bitvector_type(follow_tag(to_c_enum_tag_type(type)).underlying_type())
         .get_width());
 
     exprt zero =
@@ -322,12 +319,11 @@ void cpp_typecheckt::zero_initializer(
   }
   else
   {
-    const auto value = ::zero_initializer(final_type, source_location, *this);
+    const auto value = ::zero_initializer(type, source_location, *this);
     if(!value.has_value())
     {
       error().source_location = source_location;
-      error() << "cannot zero-initialize '" << to_string(final_type) << "'"
-              << eom;
+      error() << "cannot zero-initialize '" << to_string(type) << "'" << eom;
       throw 0;
     }
 

--- a/src/cpp/cpp_typecheck_initializer.cpp
+++ b/src/cpp/cpp_typecheck_initializer.cpp
@@ -72,7 +72,7 @@ void cpp_typecheckt::convert_initializer(symbolt &symbol)
       implicit_typecast(symbol.value, symbol.type);
     }
 
-    reference_initializer(symbol.value, symbol.type);
+    reference_initializer(symbol.value, to_reference_type(symbol.type));
   }
   else if(cpp_is_pod(symbol.type))
   {

--- a/src/cpp/expr2cpp.cpp
+++ b/src/cpp/expr2cpp.cpp
@@ -51,12 +51,13 @@ std::string expr2cppt::convert_struct(
   const exprt &src,
   unsigned &precedence)
 {
-  const typet &full_type=ns.follow(src.type());
-
-  if(full_type.id()!=ID_struct)
+  if(src.type().id() != ID_struct && src.type().id() != ID_struct_tag)
     return convert_norep(src, precedence);
 
-  const struct_typet &struct_type=to_struct_type(full_type);
+  const struct_typet &struct_type =
+    src.type().id() == ID_struct_tag
+      ? ns.follow_tag(to_struct_tag_type(src.type()))
+      : to_struct_type(src.type());
 
   std::string dest="{ ";
 


### PR DESCRIPTION
This is deprecated. Use suitable variants of `follow_tag` instead.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
