### PR TITLE
Visual Studio: fix feraiseexcept test failure

### DIFF
--- a/regression/cbmc-library/feraiseexcept-01/main.c
+++ b/regression/cbmc-library/feraiseexcept-01/main.c
@@ -1,9 +1,18 @@
 #include <assert.h>
 #include <fenv.h>
 
+int nondet_int();
+
 int main()
 {
-  int exceptions;
+  int exceptions = nondet_int();
+#ifdef _MSC_VER
+  // Visual Studio's fenv.h includes an inlined implementation of
+  // feraiseexcept, which prevents us from using the one in
+  // our library.
+  __CPROVER_assert(0, "dummy assertion");
+#else
   feraiseexcept(exceptions);
+#endif
   return 0;
 }


### PR DESCRIPTION
We have a test that checks that our own implementation of `feraiseexcept`
triggers an assertion failure when a non-zero argument is given.  This test
now fails since Visual Studio has in implementation for `feraiseexcept` in the
fenv.h header file.

This commit disables the test when using Visual Studio.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [X] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
