### PR TITLE
util: Replace uses of namespacet::follow

### DIFF
--- a/src/util/lower_byte_operators.cpp
+++ b/src/util/lower_byte_operators.cpp
@@ -696,7 +696,10 @@ static array_exprt unpack_struct(
   const std::size_t bits_per_byte,
   const namespacet &ns)
 {
-  const struct_typet &struct_type = to_struct_type(ns.follow(src.type()));
+  const struct_typet &struct_type =
+    src.type().id() == ID_struct_tag
+      ? ns.follow_tag(to_struct_tag_type(src.type()))
+      : to_struct_type(src.type());
   const struct_typet::componentst &components = struct_type.components();
 
   std::optional<mp_integer> offset_in_member;
@@ -963,7 +966,10 @@ static exprt unpack_rec(
   }
   else if(src.type().id() == ID_union || src.type().id() == ID_union_tag)
   {
-    const union_typet &union_type = to_union_type(ns.follow(src.type()));
+    const union_typet &union_type =
+      src.type().id() == ID_union_tag
+        ? ns.follow_tag(to_union_tag_type(src.type()))
+        : to_union_type(src.type());
 
     const auto widest_member = union_type.find_widest_union_component(ns);
 
@@ -1316,7 +1322,10 @@ exprt lower_byte_extract(const byte_extract_exprt &src, const namespacet &ns)
   }
   else if(src.type().id() == ID_struct || src.type().id() == ID_struct_tag)
   {
-    const struct_typet &struct_type = to_struct_type(ns.follow(src.type()));
+    const struct_typet &struct_type =
+      src.type().id() == ID_struct_tag
+        ? ns.follow_tag(to_struct_tag_type(src.type()))
+        : to_struct_type(src.type());
     const struct_typet::componentst &components = struct_type.components();
 
     bool failed = false;
@@ -1361,7 +1370,10 @@ exprt lower_byte_extract(const byte_extract_exprt &src, const namespacet &ns)
   }
   else if(src.type().id() == ID_union || src.type().id() == ID_union_tag)
   {
-    const union_typet &union_type = to_union_type(ns.follow(src.type()));
+    const union_typet &union_type =
+      src.type().id() == ID_union_tag
+        ? ns.follow_tag(to_union_tag_type(src.type()))
+        : to_union_type(src.type());
 
     const auto widest_member = union_type.find_widest_union_component(ns);
 
@@ -2355,23 +2367,23 @@ static exprt lower_byte_update(
   }
   else if(src.type().id() == ID_struct || src.type().id() == ID_struct_tag)
   {
+    const struct_typet &struct_type =
+      src.type().id() == ID_struct_tag
+        ? ns.follow_tag(to_struct_tag_type(src.type()))
+        : to_struct_type(src.type());
     exprt result = lower_byte_update_struct(
-      src,
-      to_struct_type(ns.follow(src.type())),
-      value_as_byte_array,
-      non_const_update_bound,
-      ns);
+      src, struct_type, value_as_byte_array, non_const_update_bound, ns);
     result.type() = src.type();
     return result;
   }
   else if(src.type().id() == ID_union || src.type().id() == ID_union_tag)
   {
+    const union_typet &union_type =
+      src.type().id() == ID_union_tag
+        ? ns.follow_tag(to_union_tag_type(src.type()))
+        : to_union_type(src.type());
     exprt result = lower_byte_update_union(
-      src,
-      to_union_type(ns.follow(src.type())),
-      value_as_byte_array,
-      non_const_update_bound,
-      ns);
+      src, union_type, value_as_byte_array, non_const_update_bound, ns);
     result.type() = src.type();
     return result;
   }

--- a/src/util/simplify_expr_pointer.cpp
+++ b/src/util/simplify_expr_pointer.cpp
@@ -149,9 +149,9 @@ simplify_exprt::simplify_address_of_arg(const exprt &expr)
       no_change = false;
     }
 
-    const typet &op_type = ns.follow(new_member_expr.struct_op().type());
+    const typet &op_type = new_member_expr.struct_op().type();
 
-    if(op_type.id() == ID_struct)
+    if(op_type.id() == ID_struct || op_type.id() == ID_struct_tag)
     {
       // rewrite NULL -> member by
       // pushing the member inside
@@ -159,8 +159,12 @@ simplify_exprt::simplify_address_of_arg(const exprt &expr)
       mp_integer address;
       if(is_dereference_integer_object(new_member_expr.struct_op(), address))
       {
+        const struct_typet &struct_type =
+          op_type.id() == ID_struct_tag
+            ? ns.follow_tag(to_struct_tag_type(op_type))
+            : to_struct_type(op_type);
         const irep_idt &member = to_member_expr(expr).get_component_name();
-        auto offset = member_offset(to_struct_type(op_type), member, ns);
+        auto offset = member_offset(struct_type, member, ns);
         if(offset.has_value())
         {
           pointer_typet pointer_type = to_pointer_type(

--- a/src/util/std_types.cpp
+++ b/src/util/std_types.cpp
@@ -225,9 +225,14 @@ bool is_constant_or_has_constant_components(
   // we have to use the namespace to resolve to its definition:
   // struct t { const int a; };
   // struct t t1;
-  if(type.id() == ID_struct_tag || type.id() == ID_union_tag)
+  if(type.id() == ID_struct_tag)
   {
-    const auto &resolved_type = ns.follow(type);
+    const auto &resolved_type = ns.follow_tag(to_struct_tag_type(type));
+    return has_constant_components(resolved_type);
+  }
+  else if(type.id() == ID_union_tag)
+  {
+    const auto &resolved_type = ns.follow_tag(to_union_tag_type(type));
     return has_constant_components(resolved_type);
   }
 


### PR DESCRIPTION
This is deprecated. Use suitable variants of `follow_tag` instead.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
