### PR TITLE
Remove parsert::clear and all of its overrides

### DIFF
--- a/src/ansi-c/ansi_c_parser.h
+++ b/src/ansi-c/ansi_c_parser.h
@@ -43,24 +43,6 @@ public:
 
   bool parse() override;
 
-  void clear() override
-  {
-    parsert::clear();
-    parse_tree.clear();
-
-    // scanner state
-    tag_following=false;
-    asm_block_following=false;
-    parenthesis_counter=0;
-    string_literal.clear();
-    pragma_pack.clear();
-    pragma_cprover_stack.clear();
-
-    // set up global scope
-    scopes.clear();
-    scopes.push_back(scopet());
-  }
-
   // internal state of the scanner
   bool tag_following;
   bool asm_block_following;

--- a/src/assembler/assembler_parser.h
+++ b/src/assembler/assembler_parser.h
@@ -42,12 +42,6 @@ public:
   }
 
   bool parse() override;
-
-  void clear() override
-  {
-    parsert::clear();
-    instructions.clear();
-  }
 };
 
 #endif // CPROVER_ASSEMBLER_ASSEMBLER_PARSER_H

--- a/src/cpp/cpp_language.cpp
+++ b/src/cpp/cpp_language.cpp
@@ -112,9 +112,6 @@ bool cpp_languaget::parse(
   // save result
   cpp_parse_tree.swap(cpp_parser.parse_tree);
 
-  // save some memory
-  cpp_parser.clear();
-
   return result;
 }
 
@@ -259,9 +256,6 @@ bool cpp_languaget::to_expr(
     // typecheck it
     result = cpp_typecheck(expr, message_handler, ns);
   }
-
-  // save some memory
-  cpp_parser.clear();
 
   return result;
 }

--- a/src/cpp/cpp_parser.h
+++ b/src/cpp/cpp_parser.h
@@ -28,14 +28,6 @@ public:
 
   virtual bool parse() override;
 
-  virtual void clear() override
-  {
-    parsert::clear();
-    parse_tree.clear();
-    token_buffer.clear();
-    asm_block_following=false;
-  }
-
   explicit cpp_parsert(message_handlert &message_handler)
     : parsert(message_handler),
       mode(configt::ansi_ct::flavourt::ANSI),

--- a/src/json/json_parser.cpp
+++ b/src/json/json_parser.cpp
@@ -41,9 +41,6 @@ bool parse_json(
   if(json_parser.stack.size()==1)
     dest.swap(json_parser.stack.top());
 
-  // save some memory
-  json_parser.clear();
-
   return result;
 }
 

--- a/src/json/json_parser.h
+++ b/src/json/json_parser.h
@@ -41,11 +41,6 @@ public:
     dest.swap(stack.top());
     stack.pop();
   }
-
-  virtual void clear() override
-  {
-    stack=stackt();
-  }
 };
 
 // 'do it all' functions

--- a/src/statement-list/statement_list_parser.cpp
+++ b/src/statement-list/statement_list_parser.cpp
@@ -352,12 +352,6 @@ bool statement_list_parsert::parse()
   return parse_fail;
 }
 
-void statement_list_parsert::clear()
-{
-  parsert::clear();
-  parse_tree.clear();
-}
-
 void statement_list_parsert::print_tree(std::ostream &out) const
 {
   output_parse_tree(out, parse_tree);

--- a/src/statement-list/statement_list_parser.h
+++ b/src/statement-list/statement_list_parser.h
@@ -74,10 +74,6 @@ public:
   /// \param other: Parse tree which should be used in the swap operation.
   void swap_tree(statement_list_parse_treet &other);
 
-  /// Removes all functions and function blocks from the parse tree and
-  /// clears the internal state of the parser.
-  void clear() override;
-
 private:
   /// Tree that is being filled by the parsing process.
   statement_list_parse_treet parse_tree;

--- a/src/util/parser.h
+++ b/src/util/parser.h
@@ -30,23 +30,20 @@ public:
 
   std::vector<exprt> stack;
 
-  virtual void clear()
+  DEPRECATED(SINCE(2023, 12, 20, "use parsert(message_handler) instead"))
+  parsert() : in(nullptr), line_no(0), previous_line_no(0), column(1)
   {
-    line_no=0;
-    previous_line_no=0;
-    column=1;
-    stack.clear();
-    source_location.clear();
-    last_line.clear();
   }
 
-  DEPRECATED(SINCE(2023, 12, 20, "use parsert(message_handler) instead"))
-  parsert():in(nullptr) { clear(); }
   explicit parsert(message_handlert &message_handler)
-    : in(nullptr), log(message_handler)
+    : in(nullptr),
+      log(message_handler),
+      line_no(0),
+      previous_line_no(0),
+      column(1)
   {
-    clear();
   }
+
   virtual ~parsert() { }
 
   // The following are for the benefit of the scanner

--- a/src/xmllang/xml_parser.h
+++ b/src/xmllang/xml_parser.h
@@ -50,17 +50,6 @@ public:
     stack.push_back(&current().elements.back());
   }
 
-  /// Clears the parser state. May be removed in future as there should not be a
-  /// need to re-use an existing parser object.
-  void clear() override
-  {
-    parse_tree.clear();
-    // set up stack
-    stack.clear();
-    stack.push_back(&parse_tree.element);
-    parsert::clear();
-  }
-
 protected:
   static int instance_count;
 };


### PR DESCRIPTION
Re-use of parsers should no longer be necessary now that they aren't objects of static lifetime anymore. Consequently, there is no need to "clear," and instead only a subset of the instructions is required in constructors.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
