### PR TITLE
simplify `extractbits_exprt` representation

### DIFF
--- a/src/ansi-c/expr2c.cpp
+++ b/src/ansi-c/expr2c.cpp
@@ -3494,9 +3494,18 @@ expr2ct::convert_extractbits(const extractbits_exprt &src, unsigned precedence)
 {
   std::string dest = convert_with_precedence(src.src(), precedence);
   dest+='[';
-  dest += convert_with_precedence(src.upper(), precedence);
+  auto expr_width_opt = pointer_offset_bits(src.type(), ns);
+  if(expr_width_opt.has_value())
+  {
+    auto upper = plus_exprt{
+      src.index(),
+      from_integer(expr_width_opt.value() - 1, src.index().type())};
+    dest += convert_with_precedence(upper, precedence);
+  }
+  else
+    dest += "?";
   dest+=", ";
-  dest += convert_with_precedence(src.lower(), precedence);
+  dest += convert_with_precedence(src.index(), precedence);
   dest+=']';
 
   return dest;

--- a/src/ansi-c/goto_check_c.cpp
+++ b/src/ansi-c/goto_check_c.cpp
@@ -973,7 +973,6 @@ void goto_check_ct::integer_overflow_check(
 
       const exprt top_bits = extractbits_exprt(
         op_ext_shifted,
-        new_type.get_width() - 1,
         new_type.get_width() - number_of_top_bits,
         unsignedbv_typet(number_of_top_bits));
 

--- a/src/cpp/expr2cpp.cpp
+++ b/src/cpp/expr2cpp.cpp
@@ -33,7 +33,6 @@ protected:
   std::string convert_cpp_this();
   std::string convert_cpp_new(const exprt &src);
   std::string convert_extractbit(const exprt &src);
-  std::string convert_extractbits(const exprt &src);
   std::string convert_code_cpp_delete(const exprt &src, unsigned indent);
   std::string convert_code_cpp_new(const exprt &src, unsigned indent);
   std::string convert_struct(const exprt &src, unsigned &precedence) override;
@@ -433,11 +432,6 @@ std::string expr2cppt::convert_with_precedence(
     precedence = 15;
     return convert_extractbit(src);
   }
-  else if(src.id()==ID_extractbits)
-  {
-    precedence = 15;
-    return convert_extractbits(src);
-  }
   else if(src.id()==ID_side_effect &&
           (src.get(ID_statement)==ID_cpp_new ||
            src.get(ID_statement)==ID_cpp_new_array))
@@ -487,14 +481,6 @@ std::string expr2cppt::convert_extractbit(const exprt &src)
   const auto &extractbit_expr = to_extractbit_expr(src);
   return convert(extractbit_expr.op0()) + "[" + convert(extractbit_expr.op1()) +
          "]";
-}
-
-std::string expr2cppt::convert_extractbits(const exprt &src)
-{
-  const auto &extractbits_expr = to_extractbits_expr(src);
-  return convert(extractbits_expr.src()) + ".range(" +
-         convert(extractbits_expr.upper()) + "," +
-         convert(extractbits_expr.lower()) + ")";
 }
 
 std::string expr2cpp(const exprt &expr, const namespacet &ns)

--- a/src/solvers/smt2/smt2_conv.cpp
+++ b/src/solvers/smt2/smt2_conv.cpp
@@ -1831,22 +1831,14 @@ void smt2_convt::convert_expr(const exprt &expr)
   else if(expr.id()==ID_extractbits)
   {
     const extractbits_exprt &extractbits_expr = to_extractbits_expr(expr);
+    auto width = boolbv_width(expr.type());
 
-    if(
-      extractbits_expr.upper().is_constant() &&
-      extractbits_expr.lower().is_constant())
+    if(extractbits_expr.index().is_constant())
     {
-      mp_integer op1_i =
-        numeric_cast_v<mp_integer>(to_constant_expr(extractbits_expr.upper()));
-      mp_integer op2_i =
-        numeric_cast_v<mp_integer>(to_constant_expr(extractbits_expr.lower()));
+      mp_integer index_i =
+        numeric_cast_v<mp_integer>(to_constant_expr(extractbits_expr.index()));
 
-      if(op2_i>op1_i)
-        std::swap(op1_i, op2_i);
-
-      // now op1_i>=op2_i
-
-      out << "((_ extract " << op1_i << " " << op2_i << ") ";
+      out << "((_ extract " << (width + index_i - 1) << " " << index_i << ") ";
       flatten2bv(extractbits_expr.src());
       out << ")";
     }

--- a/src/solvers/smt2/smt2_parser.cpp
+++ b/src/solvers/smt2/smt2_parser.cpp
@@ -638,15 +638,14 @@ exprt smt2_parsert::function_application()
           if(op.size()!=1)
             throw error("extract takes one operand");
 
-          auto upper_e=from_integer(upper, integer_typet());
-          auto lower_e=from_integer(lower, integer_typet());
-
           if(upper<lower)
             throw error("extract got bad indices");
 
+          auto lower_e = from_integer(lower, integer_typet());
+
           unsignedbv_typet t(upper-lower+1);
 
-          return extractbits_exprt(op[0], upper_e, lower_e, t);
+          return extractbits_exprt(op[0], lower_e, t);
         }
         else if(id=="rotate_left" ||
                 id=="rotate_right" ||

--- a/src/solvers/smt2_incremental/convert_expr_to_smt.cpp
+++ b/src/solvers/smt2_incremental/convert_expr_to_smt.cpp
@@ -1111,10 +1111,14 @@ static smt_termt convert_expr_to_smt(
   const sub_expression_mapt &converted)
 {
   const smt_termt &from = converted.at(extract_bits.src());
-  const auto upper_value = numeric_cast<std::size_t>(extract_bits.upper());
-  const auto lower_value = numeric_cast<std::size_t>(extract_bits.lower());
-  if(upper_value && lower_value)
-    return smt_bit_vector_theoryt::extract(*upper_value, *lower_value)(from);
+  const auto bit_vector_sort =
+    convert_type_to_smt_sort(extract_bits.type()).cast<smt_bit_vector_sortt>();
+  INVARIANT(
+    bit_vector_sort, "Extract can only be applied to bit vector terms.");
+  const auto index_value = numeric_cast<std::size_t>(extract_bits.index());
+  if(index_value)
+    return smt_bit_vector_theoryt::extract(
+      *index_value + bit_vector_sort->bit_width() - 1, *index_value)(from);
   UNIMPLEMENTED_FEATURE(
     "Generation of SMT formula for extract bits expression: " +
     extract_bits.pretty());

--- a/src/solvers/smt2_incremental/encoding/struct_encoding.cpp
+++ b/src/solvers/smt2_incremental/encoding/struct_encoding.cpp
@@ -195,7 +195,6 @@ static std::size_t count_trailing_bit_width(
 exprt struct_encodingt::encode_member(const member_exprt &member_expr) const
 {
   const auto &type = ns.get().follow(member_expr.compound().type());
-  const auto member_bits_width = (*boolbv_width)(member_expr.type());
   const auto offset_bits = [&]() -> std::size_t {
     if(can_cast_type<union_typet>(type))
       return 0;
@@ -204,10 +203,7 @@ exprt struct_encodingt::encode_member(const member_exprt &member_expr) const
       struct_type, member_expr.get_component_name(), *boolbv_width);
   }();
   return extractbits_exprt{
-    member_expr.compound(),
-    offset_bits + member_bits_width - 1,
-    offset_bits,
-    member_expr.type()};
+    member_expr.compound(), offset_bits, member_expr.type()};
 }
 
 exprt struct_encodingt::encode(exprt expr) const

--- a/src/solvers/strings/string_constraint_generator_float.cpp
+++ b/src/solvers/strings/string_constraint_generator_float.cpp
@@ -28,8 +28,7 @@ Author: Romain Brenguier, romain.brenguier@diffblue.com
 ///   in octuple precision.
 exprt get_exponent(const exprt &src, const ieee_float_spect &spec)
 {
-  const extractbits_exprt exp_bits(
-    src, spec.f + spec.e - 1, spec.f, unsignedbv_typet(spec.e));
+  const extractbits_exprt exp_bits(src, spec.f, unsignedbv_typet(spec.e));
 
   // Exponent is in biased form (numbers from -128 to 127 are encoded with
   // integer from 0 to 255) we have to remove the bias.
@@ -44,7 +43,7 @@ exprt get_exponent(const exprt &src, const ieee_float_spect &spec)
 /// \return An unsigned value representing the fractional part.
 exprt get_fraction(const exprt &src, const ieee_float_spect &spec)
 {
-  return extractbits_exprt(src, spec.f - 1, 0, unsignedbv_typet(spec.f));
+  return extractbits_exprt(src, 0, unsignedbv_typet(spec.f));
 }
 
 /// Gets the significand as a java integer, looking for the hidden bit.

--- a/src/util/bitvector_expr.cpp
+++ b/src/util/bitvector_expr.cpp
@@ -30,16 +30,11 @@ extractbit_exprt::extractbit_exprt(exprt _src, const std::size_t _index)
 
 extractbits_exprt::extractbits_exprt(
   exprt _src,
-  const std::size_t _upper,
-  const std::size_t _lower,
+  const std::size_t _index,
   typet _type)
   : expr_protectedt(ID_extractbits, std::move(_type))
 {
-  PRECONDITION(_upper >= _lower);
-  add_to_operands(
-    std::move(_src),
-    from_integer(_upper, integer_typet()),
-    from_integer(_lower, integer_typet()));
+  add_to_operands(std::move(_src), from_integer(_index, integer_typet()));
 }
 
 exprt update_bit_exprt::lower() const

--- a/src/util/bitvector_expr.h
+++ b/src/util/bitvector_expr.h
@@ -447,38 +447,29 @@ inline extractbit_exprt &to_extractbit_expr(exprt &expr)
 class extractbits_exprt : public expr_protectedt
 {
 public:
-  /// Extract the bits [\p _lower .. \p _upper] from \p _src to produce a result
-  /// of type \p _type. Note that this specifies a closed interval, i.e., both
-  /// bits \p _lower and \p _upper are included. Indices count from the
-  /// least-significant bit, and are not affected by endianness.
-  /// The ordering upper-lower matches what SMT-LIB uses.
-  extractbits_exprt(exprt _src, exprt _upper, exprt _lower, typet _type)
+  /// Extract the bits [\p _index .. \p _index + width - 1] from \p _src
+  /// to produce a result of type \p _type where width is the number of bits
+  /// of \p _type. Note that this specifies a closed interval, i.e., both
+  /// bits \p _lower and \p _index + width - 1 are included. Indices count
+  /// from the least-significant bit, and are not affected by endianness.
+  extractbits_exprt(exprt _src, exprt _index, typet _type)
     : expr_protectedt(
         ID_extractbits,
         std::move(_type),
-        {std::move(_src), std::move(_upper), std::move(_lower)})
+        {std::move(_src), std::move(_index)})
   {
   }
 
-  extractbits_exprt(
-    exprt _src,
-    const std::size_t _upper,
-    const std::size_t _lower,
-    typet _type);
+  extractbits_exprt(exprt _src, const std::size_t _index, typet _type);
 
   exprt &src()
   {
     return op0();
   }
 
-  exprt &upper()
+  exprt &index()
   {
     return op1();
-  }
-
-  exprt &lower()
-  {
-    return op2();
   }
 
   const exprt &src() const
@@ -486,14 +477,9 @@ public:
     return op0();
   }
 
-  const exprt &upper() const
+  const exprt &index() const
   {
     return op1();
-  }
-
-  const exprt &lower() const
-  {
-    return op2();
   }
 };
 
@@ -505,7 +491,7 @@ inline bool can_cast_expr<extractbits_exprt>(const exprt &base)
 
 inline void validate_expr(const extractbits_exprt &value)
 {
-  validate_operands(value, 3, "Extract bits must have three operands");
+  validate_operands(value, 2, "Extractbits must have two operands");
 }
 
 /// \brief Cast an exprt to an \ref extractbits_exprt

--- a/src/util/lower_byte_operators.cpp
+++ b/src/util/lower_byte_operators.cpp
@@ -110,7 +110,7 @@ static struct_exprt bv_to_struct_expr(
     bitvector_typet type = adjust_width(bitvector_expr.type(), component_bits);
     PRECONDITION(pointer_offset_bits(bitvector_expr.type(), ns).has_value());
     operands.push_back(bv_to_expr(
-      extractbits_exprt{bitvector_expr, bounds.ub, bounds.lb, std::move(type)},
+      extractbits_exprt{bitvector_expr, bounds.lb, std::move(type)},
       comp.type(),
       endianness_map,
       ns));
@@ -163,7 +163,7 @@ static exprt bv_to_union_expr(
   return union_exprt{
     component_name,
     bv_to_expr(
-      extractbits_exprt{bitvector_expr, bounds.ub, bounds.lb, std::move(type)},
+      extractbits_exprt{bitvector_expr, bounds.lb, std::move(type)},
       component_type,
       endianness_map,
       ns),
@@ -209,8 +209,7 @@ static array_exprt bv_to_array_expr(
         adjust_width(bitvector_expr.type(), subtype_bits_int);
       PRECONDITION(pointer_offset_bits(bitvector_expr.type(), ns).has_value());
       operands.push_back(bv_to_expr(
-        extractbits_exprt{
-          bitvector_expr, bounds.ub, bounds.lb, std::move(type)},
+        extractbits_exprt{bitvector_expr, bounds.lb, std::move(type)},
         array_type.element_type(),
         endianness_map,
         ns));
@@ -256,8 +255,7 @@ static vector_exprt bv_to_vector_expr(
         adjust_width(bitvector_expr.type(), subtype_bits_int);
       PRECONDITION(pointer_offset_bits(bitvector_expr.type(), ns).has_value());
       operands.push_back(bv_to_expr(
-        extractbits_exprt{
-          bitvector_expr, bounds.ub, bounds.lb, std::move(type)},
+        extractbits_exprt{bitvector_expr, bounds.lb, std::move(type)},
         vector_type.element_type(),
         endianness_map,
         ns));
@@ -304,12 +302,12 @@ static complex_exprt bv_to_complex_expr(
   PRECONDITION(pointer_offset_bits(bitvector_expr.type(), ns).has_value());
   return complex_exprt{
     bv_to_expr(
-      extractbits_exprt{bitvector_expr, bounds_real.ub, bounds_real.lb, type},
+      extractbits_exprt{bitvector_expr, bounds_real.lb, type},
       complex_type.subtype(),
       endianness_map,
       ns),
     bv_to_expr(
-      extractbits_exprt{bitvector_expr, bounds_imag.ub, bounds_imag.lb, type},
+      extractbits_exprt{bitvector_expr, bounds_imag.lb, type},
       complex_type.subtype(),
       endianness_map,
       ns),
@@ -1063,7 +1061,6 @@ static exprt unpack_rec(
         pointer_offset_bits(src_as_bitvector.type(), ns).has_value());
       extractbits_exprt extractbits(
         src_as_bitvector,
-        from_integer(bit_offset + bits_per_byte - 1, array_type.index_type()),
         from_integer(bit_offset, array_type.index_type()),
         byte_type);
 
@@ -2006,7 +2003,6 @@ static exprt lower_byte_update_single_element(
 
       extractbits_exprt bits_to_keep{
         element_to_update,
-        subtype_bits_int - 1,
         subtype_bits_int - offset_bits_int,
         bv_typet{offset_bits_int}};
       new_value = concatenation_exprt{
@@ -2014,7 +2010,6 @@ static exprt lower_byte_update_single_element(
         extractbits_exprt{
           concatenation_exprt{
             update_values, bv_typet{update_size * src.get_bits_per_byte()}},
-          update_size * src.get_bits_per_byte() - 1,
           offset_bits_int,
           bv_typet{update_size * src.get_bits_per_byte() - offset_bits_int}},
         bv_typet{update_size * src.get_bits_per_byte()}};
@@ -2521,8 +2516,7 @@ static exprt lower_byte_update(
       PRECONDITION(pointer_offset_bits(bitor_expr.type(), ns).has_value());
       return simplify_expr(
         typecast_exprt::conditional_cast(
-          extractbits_exprt{
-            bitor_expr, bounds.ub, bounds.lb, bv_typet{type_bits}},
+          extractbits_exprt{bitor_expr, bounds.lb, bv_typet{type_bits}},
           src.type()),
         ns);
     }
@@ -2601,8 +2595,7 @@ exprt lower_byte_update(const byte_update_exprt &src, const namespacet &ns)
         lower_byte_extract(overlapping_byte_extract, ns);
 
       size_t n_extra_bits = bits_per_byte - update_bits_int % bits_per_byte;
-      extractbits_exprt extra_bits{
-        overlapping_byte, n_extra_bits - 1, 0, bv_typet{n_extra_bits}};
+      extractbits_exprt extra_bits{overlapping_byte, 0, bv_typet{n_extra_bits}};
 
       update_value = concatenation_exprt{
         typecast_exprt::conditional_cast(

--- a/unit/solvers/smt2_incremental/convert_expr_to_smt.cpp
+++ b/unit/solvers/smt2_incremental/convert_expr_to_smt.cpp
@@ -1329,13 +1329,12 @@ TEST_CASE(
       "Bit vector typed bounds",
       extractbits_exprt{
         symbol_exprt{"foo", operand_type},
-        from_integer(4, operand_type),
         from_integer(2, operand_type),
         unsignedbv_typet{3}}},
     rowt{
       "Constant integer bounds",
       extractbits_exprt{
-        symbol_exprt{"foo", operand_type}, 4, 2, unsignedbv_typet{3}}});
+        symbol_exprt{"foo", operand_type}, 2, unsignedbv_typet{3}}});
   const smt_termt expected_result = smt_bit_vector_theoryt::extract(4, 2)(
     smt_identifier_termt{"foo", smt_bit_vector_sortt{8}});
   SECTION(description)
@@ -1345,7 +1344,6 @@ TEST_CASE(
     const cbmc_invariants_should_throwt invariants_throw;
     CHECK_THROWS(test.convert(extractbits_exprt{
       symbol_exprt{"foo", operand_type},
-      symbol_exprt{"bar", operand_type},
       symbol_exprt{"bar", operand_type},
       unsignedbv_typet{3}}));
   }

--- a/unit/solvers/smt2_incremental/encoding/struct_encoding.cpp
+++ b/unit/solvers/smt2_incremental/encoding/struct_encoding.cpp
@@ -206,7 +206,7 @@ TEST_CASE("struct encoding of expressions", "[core][smt2_incremental]")
       const exprt expected = equal_exprt{
         zero,
         extractbits_exprt{
-          symbol_exprt{"breakfast", bv_typet{72}}, 71, 40, field_type}};
+          symbol_exprt{"breakfast", bv_typet{72}}, 40, field_type}};
       REQUIRE(test.struct_encoding.encode(input) == expected);
     }
     SECTION("Second member")
@@ -218,7 +218,7 @@ TEST_CASE("struct encoding of expressions", "[core][smt2_incremental]")
       const exprt expected = equal_exprt{
         dozen,
         extractbits_exprt{
-          symbol_exprt{"breakfast", bv_typet{72}}, 39, 24, field_type}};
+          symbol_exprt{"breakfast", bv_typet{72}}, 24, field_type}};
       REQUIRE(test.struct_encoding.encode(input) == expected);
     }
     SECTION("Third member")
@@ -230,7 +230,7 @@ TEST_CASE("struct encoding of expressions", "[core][smt2_incremental]")
       const exprt expected = equal_exprt{
         two,
         extractbits_exprt{
-          symbol_exprt{"breakfast", bv_typet{72}}, 23, 0, field_type}};
+          symbol_exprt{"breakfast", bv_typet{72}}, 0, field_type}};
       REQUIRE(test.struct_encoding.encode(input) == expected);
     }
   }
@@ -244,8 +244,8 @@ TEST_CASE("struct encoding of expressions", "[core][smt2_incremental]")
         from_integer(0, signedbv_typet{32})};
       const concatenation_exprt expected{
         {from_integer(0, signedbv_typet{32}),
-         extractbits_exprt{symbol_expr_as_bv, 39, 24, unsignedbv_typet{16}},
-         extractbits_exprt{symbol_expr_as_bv, 23, 0, signedbv_typet{24}}},
+         extractbits_exprt{symbol_expr_as_bv, 24, unsignedbv_typet{16}},
+         extractbits_exprt{symbol_expr_as_bv, 0, signedbv_typet{24}}},
         bv_typet{72}};
       REQUIRE(test.struct_encoding.encode(with) == expected);
     }
@@ -256,9 +256,9 @@ TEST_CASE("struct encoding of expressions", "[core][smt2_incremental]")
         make_member_name_expression("eggs"),
         from_integer(0, unsignedbv_typet{16})};
       const concatenation_exprt expected{
-        {extractbits_exprt{symbol_expr_as_bv, 71, 40, signedbv_typet{32}},
+        {extractbits_exprt{symbol_expr_as_bv, 40, signedbv_typet{32}},
          from_integer(0, unsignedbv_typet{16}),
-         extractbits_exprt{symbol_expr_as_bv, 23, 0, signedbv_typet{24}}},
+         extractbits_exprt{symbol_expr_as_bv, 0, signedbv_typet{24}}},
         bv_typet{72}};
       REQUIRE(test.struct_encoding.encode(with) == expected);
     }
@@ -269,8 +269,8 @@ TEST_CASE("struct encoding of expressions", "[core][smt2_incremental]")
         make_member_name_expression("ham"),
         from_integer(0, signedbv_typet{24})};
       const concatenation_exprt expected{
-        {extractbits_exprt{symbol_expr_as_bv, 71, 40, signedbv_typet{32}},
-         extractbits_exprt{symbol_expr_as_bv, 39, 24, unsignedbv_typet{16}},
+        {extractbits_exprt{symbol_expr_as_bv, 40, signedbv_typet{32}},
+         extractbits_exprt{symbol_expr_as_bv, 24, unsignedbv_typet{16}},
          from_integer(0, signedbv_typet{24})},
         bv_typet{72}};
       REQUIRE(test.struct_encoding.encode(with) == expected);
@@ -280,7 +280,7 @@ TEST_CASE("struct encoding of expressions", "[core][smt2_incremental]")
       const concatenation_exprt expected{
         {from_integer(0, signedbv_typet{32}),
          from_integer(1, unsignedbv_typet{16}),
-         extractbits_exprt{symbol_expr_as_bv, 23, 0, signedbv_typet{24}}},
+         extractbits_exprt{symbol_expr_as_bv, 0, signedbv_typet{24}}},
         bv_typet{72}};
       SECTION("Operands in field order")
       {
@@ -309,7 +309,7 @@ TEST_CASE("struct encoding of expressions", "[core][smt2_incremental]")
     {
       const concatenation_exprt expected{
         {from_integer(0, signedbv_typet{32}),
-         extractbits_exprt{symbol_expr_as_bv, 39, 24, unsignedbv_typet{16}},
+         extractbits_exprt{symbol_expr_as_bv, 24, unsignedbv_typet{16}},
          from_integer(1, signedbv_typet{24})},
         bv_typet{72}};
       SECTION("Operands in field order")
@@ -337,7 +337,7 @@ TEST_CASE("struct encoding of expressions", "[core][smt2_incremental]")
     SECTION("Second and third members")
     {
       const concatenation_exprt expected{
-        {extractbits_exprt{symbol_expr_as_bv, 71, 40, signedbv_typet{32}},
+        {extractbits_exprt{symbol_expr_as_bv, 40, signedbv_typet{32}},
          from_integer(0, unsignedbv_typet{16}),
          from_integer(1, signedbv_typet{24})},
         bv_typet{72}};
@@ -564,8 +564,8 @@ TEST_CASE("encoding of union expressions", "[core][smt2_incremental]")
       const exprt zero = from_integer(0, field_type);
       const exprt input =
         equal_exprt{zero, member_exprt{symbol_expr, "ham", field_type}};
-      const exprt expected = equal_exprt{
-        zero, extractbits_exprt{symbol_expr_as_bv, 31, 0, field_type}};
+      const exprt expected =
+        equal_exprt{zero, extractbits_exprt{symbol_expr_as_bv, 0, field_type}};
       REQUIRE(test.struct_encoding.encode(input) == expected);
     }
     SECTION("Member which is smaller than the union as a whole")
@@ -573,8 +573,8 @@ TEST_CASE("encoding of union expressions", "[core][smt2_incremental]")
       const typet field_type = unsignedbv_typet{8};
       const exprt input =
         equal_exprt{dozen, member_exprt{symbol_expr, "eggs", field_type}};
-      const exprt expected = equal_exprt{
-        dozen, extractbits_exprt{symbol_expr_as_bv, 7, 0, field_type}};
+      const exprt expected =
+        equal_exprt{dozen, extractbits_exprt{symbol_expr_as_bv, 0, field_type}};
       REQUIRE(test.struct_encoding.encode(input) == expected);
     }
   }

--- a/unit/util/simplify_expr.cpp
+++ b/unit/util/simplify_expr.cpp
@@ -176,7 +176,7 @@ TEST_CASE("Simplify extractbits", "[core][util]")
 
   const exprt deadbeef = from_integer(0xdeadbeef, unsignedbv_typet(32));
 
-  exprt eb = extractbits_exprt(deadbeef, 15, 8, unsignedbv_typet(8));
+  exprt eb = extractbits_exprt(deadbeef, 8, unsignedbv_typet(8));
   bool unmodified = simplify(eb, ns);
 
   REQUIRE(!unmodified);


### PR DESCRIPTION
The current representation of `extractbits_exprt` stores both the upper and lower indices of the range that is to be extracted, and their difference plus one in form of the width of the type of the expression.
    
This removes the upper index, as it can be deduced from the lower index and the width of the result.  The key benefit is reducing burden on the user of the class, who a) doesn't have to remember which index comes first, and b) doesn't have to do the calculation of the upper index.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- [X] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
