### PR TITLE
Add namespacet::follow_struct_union_tag to simplify follow_tag uses

### DIFF
--- a/src/util/c_types.h
+++ b/src/util/c_types.h
@@ -195,11 +195,11 @@ inline union_typet &to_union_type(typet &type)
 }
 
 /// A union tag type, i.e., \ref union_typet with an identifier
-class union_tag_typet : public tag_typet
+class union_tag_typet : public struct_or_union_tag_typet
 {
 public:
   explicit union_tag_typet(const irep_idt &identifier)
-    : tag_typet(ID_union_tag, identifier)
+    : struct_or_union_tag_typet(ID_union_tag, identifier)
   {
   }
 };

--- a/src/util/namespace.cpp
+++ b/src/util/namespace.cpp
@@ -92,6 +92,15 @@ namespace_baset::follow_tag(const c_enum_tag_typet &src) const
   return to_c_enum_type(symbol.type);
 }
 
+const struct_union_typet &namespace_baset::follow_struct_or_union_tag(
+  const struct_or_union_tag_typet &src) const
+{
+  const symbolt &symbol = lookup(src.get_identifier());
+  CHECK_RETURN(symbol.is_type);
+  CHECK_RETURN(symbol.type.id() == ID_struct || symbol.type.id() == ID_union);
+  return to_struct_union_type(symbol.type);
+}
+
 /// Follow macros to their values in a given expression.
 /// \param expr: The expression to follow macros in.
 void namespace_baset::follow_macros(exprt &expr) const

--- a/src/util/namespace.h
+++ b/src/util/namespace.h
@@ -21,9 +21,11 @@ class symbol_exprt;
 class tag_typet;
 class union_typet;
 class struct_typet;
+class struct_union_typet;
 class c_enum_typet;
 class union_tag_typet;
 class struct_tag_typet;
+class struct_or_union_tag_typet;
 class c_enum_tag_typet;
 class symbol_table_baset;
 
@@ -67,6 +69,10 @@ public:
   const union_typet &follow_tag(const union_tag_typet &) const;
   const struct_typet &follow_tag(const struct_tag_typet &) const;
   const c_enum_typet &follow_tag(const c_enum_tag_typet &) const;
+
+  /// Resolve a `struct_tag_typet` or `union_tag_typet` to the complete version.
+  const struct_union_typet &
+  follow_struct_or_union_tag(const struct_or_union_tag_typet &) const;
 
   /// Returns the minimal integer n such that there is no symbol (in any of the
   /// symbol tables) whose name is of the form "An" where A is \p prefix.

--- a/src/util/std_types.h
+++ b/src/util/std_types.h
@@ -444,12 +444,56 @@ inline tag_typet &to_tag_type(typet &type)
   return static_cast<tag_typet &>(type);
 }
 
+/// A struct or union tag type. This is only to be used to create type-safe /
+/// APIs, no instances of this one can be created directly, use \ref
+/// struct_tag_typet or \ref union_tag_typet when creating objects.
+class struct_or_union_tag_typet : public tag_typet
+{
+protected:
+  struct_or_union_tag_typet(const irep_idt &id, const irep_idt &identifier)
+    : tag_typet(id, identifier)
+  {
+    PRECONDITION(id == ID_struct_tag || id == ID_union_tag);
+  }
+};
+
+/// Check whether a reference to a typet is a \ref struct_or_union_tag_typet.
+/// \param type: Source type.
+/// \return True if \p type is a \ref struct_or_union_tag_typet.
+template <>
+inline bool can_cast_type<struct_or_union_tag_typet>(const typet &type)
+{
+  return type.id() == ID_struct_tag || type.id() == ID_union_tag;
+}
+
+/// \brief Cast a typet to a \ref struct_or_union_tag_typet
+///
+/// This is an unchecked conversion. \a type must be known to be \ref
+/// struct_or_union_tag_typet. Will fail with a precondition violation if type
+/// doesn't match.
+///
+/// \param type: Source type.
+/// \return Object of type \ref struct_or_union_tag_typet
+inline const struct_or_union_tag_typet &
+to_struct_or_union_tag_type(const typet &type)
+{
+  PRECONDITION(can_cast_type<struct_or_union_tag_typet>(type));
+  return static_cast<const struct_or_union_tag_typet &>(type);
+}
+
+/// \copydoc to_struct_or_union_tag_type(const typet &)
+inline struct_or_union_tag_typet &to_struct_or_union_tag_type(typet &type)
+{
+  PRECONDITION(can_cast_type<struct_or_union_tag_typet>(type));
+  return static_cast<struct_or_union_tag_typet &>(type);
+}
+
 /// A struct tag type, i.e., \ref struct_typet with an identifier
-class struct_tag_typet:public tag_typet
+class struct_tag_typet : public struct_or_union_tag_typet
 {
 public:
-  explicit struct_tag_typet(const irep_idt &identifier):
-    tag_typet(ID_struct_tag, identifier)
+  explicit struct_tag_typet(const irep_idt &identifier)
+    : struct_or_union_tag_typet(ID_struct_tag, identifier)
   {
   }
 };


### PR DESCRIPTION
Replacing namespacet::follow by namespacet::follow_tag produced several instances that require expanding composite data types, without a need to distinguish structs vs unions.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
