### PR TITLE
Rename follow_struct_or_union_tag to follow_tag

### DIFF
--- a/src/util/namespace.cpp
+++ b/src/util/namespace.cpp
@@ -92,8 +92,9 @@ namespace_baset::follow_tag(const c_enum_tag_typet &src) const
   return to_c_enum_type(symbol.type);
 }
 
-const struct_union_typet &namespace_baset::follow_struct_or_union_tag(
-  const struct_or_union_tag_typet &src) const
+/// Resolve a `struct_tag_typet` or `union_tag_typet` to the complete version.
+const struct_union_typet &
+namespace_baset::follow_tag(const struct_or_union_tag_typet &src) const
 {
   const symbolt &symbol = lookup(src.get_identifier());
   CHECK_RETURN(symbol.is_type);

--- a/src/util/namespace.h
+++ b/src/util/namespace.h
@@ -64,15 +64,10 @@ public:
   DEPRECATED(SINCE(2024, 2, 19, "use follow_tag(...) instead"))
   const typet &follow(const typet &) const;
 
-  // These produce union_typet, struct_typet, c_enum_typet or
-  // the incomplete version.
   const union_typet &follow_tag(const union_tag_typet &) const;
   const struct_typet &follow_tag(const struct_tag_typet &) const;
   const c_enum_typet &follow_tag(const c_enum_tag_typet &) const;
-
-  /// Resolve a `struct_tag_typet` or `union_tag_typet` to the complete version.
-  const struct_union_typet &
-  follow_struct_or_union_tag(const struct_or_union_tag_typet &) const;
+  const struct_union_typet &follow_tag(const struct_or_union_tag_typet &) const;
 
   /// Returns the minimal integer n such that there is no symbol (in any of the
   /// symbol tables) whose name is of the form "An" where A is \p prefix.


### PR DESCRIPTION
With the new `struct_or_union_tag_typet` the API is entirely consistent with the other `follow_tag` variants. Invoking
`follow_struct_or_union_tag(to_struct_or_union_tag_type(t))` just made for awkwardly looking code.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
