### PR TITLE
test.pl now reports both directory and descriptor file name

### DIFF
--- a/regression/test.pl
+++ b/regression/test.pl
@@ -487,13 +487,13 @@ if($opt_p && $failures != 0) {
       if(0 == $printed_this_test) {
         $printed_this_test = 1;
         print "\n\n";
-        print "Failed test: $current_test\n";
+        print "Failed test: $current_test/$descriptor_file\n";
         open FH, "<$current_test/$output_file";
         while (my $f = <FH>) {
           print $f;
         }
         close FH;
-        print "\n\nFailed $descriptor_file lines:\n";
+        print "\n\nFailed $current_test/$descriptor_file lines:\n";
       }
 
       print "$line\n";


### PR DESCRIPTION
The `test.pl` script identifies tests by the directory and the name of the descriptor file name.  Historically, the directory was sufficient, since the descriptor file name used to be hardwired to `test.desc`.  This changes the output to include both the path and the name of the file, which removes the need to look for directory and file name in two different places.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
