### PR TITLE
[CONTRACTS] Support for Kani Loop Contracts

### DIFF
--- a/src/goto-instrument/contracts/contracts.h
+++ b/src/goto-instrument/contracts/contracts.h
@@ -33,6 +33,10 @@ Date: February 2016
 #define HELP_LOOP_CONTRACTS                                                    \
   " {y--apply-loop-contracts} \t check and use loop contracts when provided\n"
 
+#define FLAG_KANI_LOOP_CONTRACTS "apply-kani-loop-contracts"
+#define HELP_KANI_LOOP_CONTRACTS                                               \
+  " {y--apply-kani-loop-contracts} \t check loop contracts from kani\n"
+
 #define FLAG_LOOP_CONTRACTS_NO_UNWIND "loop-contracts-no-unwind"
 #define HELP_LOOP_CONTRACTS_NO_UNWIND                                          \
   " {y--loop-contracts-no-unwind} \t do not unwind transformed loops\n"
@@ -122,6 +126,7 @@ public:
     goto_programt::targett loop_head,
     goto_programt::targett loop_end,
     const loopt &loop,
+    const goto_programt::instructionst &eval_ins,
     exprt assigns_clause,
     exprt invariant,
     exprt decreases_clause,
@@ -143,6 +148,9 @@ public:
 
   // Unwind transformed loops after applying loop contracts or not.
   bool unwind_transformed_loops = true;
+
+  // Unwind transformed loops after applying loop contracts or not.
+  bool apply_kani_loop_contracts = false;
 
 protected:
   goto_modelt &goto_model;

--- a/src/goto-instrument/contracts/utils_kani.cpp
+++ b/src/goto-instrument/contracts/utils_kani.cpp
@@ -1,0 +1,156 @@
+/*******************************************************************\
+
+Module: Utility functions for Kani code contracts.
+
+Author: Qinheping Hu, qinhh@amazon.com
+
+\*******************************************************************/
+
+#include "utils_kani.h"
+
+#include <analyses/natural_loops.h>
+
+bool is_kani_loop_invariant(const goto_programt::instructiont instr)
+{
+  if(!instr.is_function_call())
+    return false;
+
+  auto s = id2string(to_symbol_expr(instr.call_function()).get_identifier());
+  return (s.find("kani_loop_invariant") != std::string::npos) &&
+         (s.find("kani_loop_invariant_") == std::string::npos);
+}
+
+bool is_kani_loop_invariant_begin(const goto_programt::instructiont instr)
+{
+  if(!instr.is_function_call())
+    return false;
+
+  auto s = id2string(to_symbol_expr(instr.call_function()).get_identifier());
+  return s.find("kani_loop_invariant_begin") != std::string::npos;
+}
+
+bool is_kani_loop_invariant_end(const goto_programt::instructiont instr)
+{
+  if(!instr.is_function_call())
+    return false;
+
+  auto s = id2string(to_symbol_expr(instr.call_function()).get_identifier());
+  return s.find("kani_loop_invariant_end") != std::string::npos;
+}
+
+void annotate_kani_loop_invariants(goto_programt &body, messaget &log)
+{
+  // The place holder function call
+  //   kani_loop_invariant(cond)
+  // indicate its successor loop latch contains loop invariants.
+  // So for each such function call, we find the loop end for it and
+  // annotate loop contracts to the loop end.
+  // Note that here we only annotate 'true' to indicate it contains
+  // loop contracts. And will later get the loop contracts with another pass.
+
+  natural_loops_mutablet natural_loops(body);
+  std::set<goto_programt::targett, goto_programt::target_less_than>
+    loop_latches;
+
+  // Collect all latches
+  for(const auto &loop_head_and_content : natural_loops.loop_map)
+  {
+    const auto &loop_content = loop_head_and_content.second;
+    // Skip empty loops and self-looped node.
+    if(loop_content.size() <= 1)
+      continue;
+
+    auto loop_head = loop_head_and_content.first;
+    auto loop_end = loop_head;
+
+    // Find the last back edge to `loop_head`
+    for(const auto &t : loop_content)
+    {
+      if(
+        t->is_goto() && t->get_target() == loop_head &&
+        t->location_number > loop_end->location_number)
+        loop_end = t;
+    }
+
+    if(loop_end == loop_head)
+    {
+      log.error() << "Could not find end of the loop starting at: "
+                  << loop_head->source_location() << messaget::eom;
+      throw 0;
+    }
+    loop_latches.insert(loop_end);
+  }
+
+  // Go through all instructions in the body to find the placeholder
+  //    kani_loop_invariant()
+  for(auto it = body.instructions.begin(); it != body.instructions.end(); it++)
+  {
+    if(is_kani_loop_invariant(*it))
+    {
+      auto temp_it = it;
+      while(!loop_latches.count(temp_it))
+      {
+        temp_it = body.get_successors(temp_it).front();
+      }
+
+      auto op = and_exprt(true_exprt(), true_exprt());
+
+      temp_it->condition_nonconst().add(ID_C_spec_loop_invariant).swap(op);
+    }
+  }
+}
+
+void get_kani_invariants(
+  const goto_functiont &goto_function,
+  const goto_programt::const_targett &loop_head,
+  exprt::operandst &invariant_clauses,
+  goto_programt::instructionst &eval_instructions)
+{
+  // The loop invariants in kani goto are passed as the instructions
+  // right before the loop head, and between two placeholder function
+  // calls kani_loop_invariant_begin() and kani_loop_invariant_end().
+  auto &body = goto_function.body;
+
+  for(auto it = body.instructions.begin(); it != body.instructions.end(); it++)
+  {
+    // first find the loop head
+    if(it == loop_head)
+    {
+      // skip irrelevant instructions until we see the placeholder
+      while(!is_kani_loop_invariant_end(*it))
+      {
+        it--;
+      }
+      // skip the placeholder
+      it--;
+
+      // copy and store all instructions between the two placeholders
+      while(!is_kani_loop_invariant_begin(*it))
+      {
+        // except for goto and dead
+        // because here the goto is not a real goto, but just goto the next
+        // instruction.
+        // Dead instructions are for those temporary variables and can be
+        // safely ignored here.
+        if(!it->is_goto() && !it->is_dead())
+        {
+          auto new_instruction = goto_programt::instructiont(*it);
+          new_instruction.target_number =
+            goto_programt::instructiont::nil_target;
+          eval_instructions.push_front(new_instruction);
+        }
+
+        // The only function call assign the evaluated result to a boolean
+        // variable. We will use the result variable as loop invariants.
+        if(it->is_function_call())
+        {
+          invariant_clauses.push_back(
+            typecast_exprt(it->call_lhs(), bool_typet()));
+        }
+        it--;
+      }
+      return;
+    }
+  }
+  UNREACHABLE;
+}

--- a/src/goto-instrument/contracts/utils_kani.h
+++ b/src/goto-instrument/contracts/utils_kani.h
@@ -1,0 +1,51 @@
+/*******************************************************************\
+
+Module: Utility functions for Kani code contracts.
+
+Author: Qinheping Hu, qinhh@amazon.com
+
+\*******************************************************************/
+
+#ifndef CPROVER_GOTO_INSTRUMENT_CONTRACTS_UTILS_KANI_H
+#define CPROVER_GOTO_INSTRUMENT_CONTRACTS_UTILS_KANI_H
+
+#include <util/message.h>
+#include <util/namespace.h>
+#include <util/std_expr.h>
+#include <util/symbol_table.h>
+
+#include <goto-programs/goto_function.h>
+#include <goto-programs/goto_program.h>
+
+#include <goto-instrument/contracts/dynamic-frames/dfcc_loop_contract_mode.h>
+
+#include <map>
+#include <set>
+#include <unordered_set>
+
+/// Decide if an instruction is call to the kani placeholder
+///     kani_loop_invariant(cond);
+bool is_kani_loop_invariant(const goto_programt::instructiont instr);
+
+/// Decide if an instruction is call to the kani placeholder
+///     kani_loop_invariant_begin();
+bool is_kani_loop_invariant_begin(const goto_programt::instructiont instr);
+
+/// Decide if an instruction is call to the kani placeholder
+///     kani_loop_invariant_end();
+bool is_kani_loop_invariant_end(const goto_programt::instructiont instr);
+
+/// Find loops end with the call to placeholder
+///     kani_loop_invariant(cond);
+/// and set the spec_loop_invariants sub of the latch node to true
+void annotate_kani_loop_invariants(goto_programt &body, messaget &log);
+
+/// Get the instructions `eval_instructions` to evaluate the kani loop
+/// invariants. The evaluation result will be `invariant_clause`
+void get_kani_invariants(
+  const goto_functiont &goto_function,
+  const goto_programt::const_targett &loop_head,
+  exprt::operandst &invariant_clauses,
+  goto_programt::instructionst &eval_instructions);
+
+#endif // CPROVER_GOTO_INSTRUMENT_CONTRACTS_UTILS_KANI_H

--- a/src/goto-instrument/goto_instrument_parse_options.cpp
+++ b/src/goto-instrument/goto_instrument_parse_options.cpp
@@ -1236,9 +1236,12 @@ void goto_instrument_parse_optionst::instrument_goto_program()
       to_exclude_from_nondet_static,
       log.get_message_handler());
   }
-  else if((cmdline.isset(FLAG_LOOP_CONTRACTS) ||
-           cmdline.isset(FLAG_REPLACE_CALL) ||
-           cmdline.isset(FLAG_ENFORCE_CONTRACT)))
+
+  if(
+    !use_dfcc &&
+    (cmdline.isset(FLAG_LOOP_CONTRACTS) || cmdline.isset(FLAG_REPLACE_CALL) ||
+     cmdline.isset(FLAG_ENFORCE_CONTRACT) ||
+     cmdline.isset(FLAG_KANI_LOOP_CONTRACTS)))
   {
     do_indirect_call_and_rtti_removal();
     log.status() << "Trying to force one backedge per target" << messaget::eom;
@@ -1264,7 +1267,9 @@ void goto_instrument_parse_optionst::instrument_goto_program()
     contracts.replace_calls(to_replace);
     contracts.enforce_contracts(to_enforce, to_exclude_from_nondet_static);
 
-    if(cmdline.isset(FLAG_LOOP_CONTRACTS))
+    if(
+      cmdline.isset(FLAG_LOOP_CONTRACTS) ||
+      cmdline.isset(FLAG_KANI_LOOP_CONTRACTS))
     {
       if(cmdline.isset(FLAG_LOOP_CONTRACTS_NO_UNWIND))
       {
@@ -1280,6 +1285,10 @@ void goto_instrument_parse_optionst::instrument_goto_program()
                       << "them at least twice to pass unwinding-assertions."
                       << messaget::eom;
       }
+
+      if(cmdline.isset(FLAG_KANI_LOOP_CONTRACTS))
+        contracts.apply_kani_loop_contracts = true;
+
       contracts.apply_loop_contracts(to_exclude_from_nondet_static);
     }
   }

--- a/src/goto-instrument/goto_instrument_parse_options.h
+++ b/src/goto-instrument/goto_instrument_parse_options.h
@@ -101,6 +101,7 @@ Author: Daniel Kroening, kroening@kroening.com
   "(horn)(skip-loops):(model-argc-argv):" \
   OPT_DFCC \
   "(" FLAG_LOOP_CONTRACTS ")" \
+  "(" FLAG_KANI_LOOP_CONTRACTS ")" \
   "(" FLAG_LOOP_CONTRACTS_NO_UNWIND ")" \
   "(" FLAG_LOOP_CONTRACTS_FILE "):" \
   "(" FLAG_REPLACE_CALL "):" \


### PR DESCRIPTION
<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

This PR add support for Kani loop contracts introduced in https://github.com/model-checking/kani/pull/3151. It adds
1. a new flag to goto-instrument to enable kani loop contracts.
2. new instrumentation rules for loop contracts annotated by Kani.
3. and helper functions to extract loop contracts from goto model generated by Kani.

As this feature is specified to GOTO generated by Kani, it is not clear to me how to test it along without Kani.



- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
