### PR TITLE
C library: add __time64

### DIFF
--- a/src/ansi-c/library/time.c
+++ b/src/ansi-c/library/time.c
@@ -8,8 +8,23 @@
 #undef time
 
 time_t __VERIFIER_nondet_time_t(void);
+time_t __time64(time_t *);
 
 time_t time(time_t *tloc)
+{
+  return __time64(tloc);
+}
+
+/* FUNCTION: __time64 */
+
+#ifndef __CPROVER_TIME_H_INCLUDED
+#  include <time.h>
+#  define __CPROVER_TIME_H_INCLUDED
+#endif
+
+time_t __VERIFIER_nondet_time_t(void);
+
+time_t __time64(time_t *tloc)
 {
   time_t res=__VERIFIER_nondet_time_t();
   if(tloc)

--- a/src/ansi-c/library_check.sh
+++ b/src/ansi-c/library_check.sh
@@ -63,6 +63,7 @@ perl -p -i -e 's/^__fprintf_chk\n//' __functions # fprintf-01/__fprintf_chk.desc
 perl -p -i -e 's/^__fread_chk\n//' __functions # fread-01/__fread_chk.desc
 perl -p -i -e 's/^__printf_chk\n//' __functions # printf-01/__printf_chk.desc
 perl -p -i -e 's/^__syslog_chk\n//' __functions # syslog-01/__syslog_chk.desc
+perl -p -i -e 's/^__time64\n//' __functions # time
 perl -p -i -e 's/^__vfprintf_chk\n//' __functions # vfprintf-01/__vfprintf_chk.desc
 
 # Some functions are covered by tests in other folders:


### PR DESCRIPTION
This is used in glibc to facilitate a transition to 64-bit time_t.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
