### PR TITLE
Remove unanchored "error" string from symtab2gb test specs

### DIFF
--- a/regression/symtab2gb/multiple_symtabs/test.desc
+++ b/regression/symtab2gb/multiple_symtabs/test.desc
@@ -7,4 +7,3 @@ user.json_symtab library.json_symtab
 ^\[2\] file library.adb line \d+ assertion: FAILURE$
 ^VERIFICATION FAILED$
 --
-error

--- a/regression/symtab2gb/single_symtab/test.desc
+++ b/regression/symtab2gb/single_symtab/test.desc
@@ -7,4 +7,3 @@ entry_point.json_symtab
 ^\[2\] file entry_point.adb line \d+ assertion: SUCCESS$
 ^VERIFICATION FAILED$
 --
-error


### PR DESCRIPTION
This string would (also) match the very legitimate output "Building error trace".

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
