### PR TITLE
goto-instrument/unwinding: enable unwinding assertions by default

### DIFF
--- a/doc/man/cbmc.1
+++ b/doc/man/cbmc.1
@@ -79,7 +79,7 @@ allow malloc calls to return a null pointer
 \fB\-\-malloc\-fail\-null\fR
 set malloc failure mode to return null
 .TP
-\fB\-\-unwinding\-assertions\fR (\fBcbmc\fR\-only)
+\fB\-\-unwinding\-assertions\fR
 generate unwinding assertions (cannot be
 used with \fB\-\-cover\fR)
 .PP
@@ -108,9 +108,8 @@ disable signed arithmetic over\- and underflow checks
 \fB\-\-no\-malloc\-may\-fail\fR
 do not allow malloc calls to fail by default
 .TP
-\fB\-\-no\-unwinding\-assertions\fR (\fBcbmc\fR\-only)
-do not generate unwinding assertions (cannot be
-used with \fB\-\-cover\fR)
+\fB\-\-no\-unwinding\-assertions\fR
+do not generate unwinding assertions
 .PP
 If an already set flag is re-set, like calling \fB\-\-pointer\-check\fR
 when default checks are already on, the flag is simply ignored.

--- a/doc/man/goto-instrument.1
+++ b/doc/man/goto-instrument.1
@@ -862,8 +862,12 @@ read unwindset from file
 \fB\-\-partial\-loops\fR
 permit paths with partial loops
 .TP
+\fB\-\-no\-unwinding\-assertions\fR
+do not generate unwinding assertions
+.TP
 \fB\-\-unwinding\-assertions\fR
-generate unwinding assertions
+generate unwinding assertions (enabled by default; overrides
+\fB\-\-no\-unwinding\-assertions\fR when both of these are given)
 .TP
 \fB\-\-continue\-as\-loops\fR
 add loop for remaining iterations after unwound part

--- a/regression/goto-instrument/slice01/test.desc
+++ b/regression/goto-instrument/slice01/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---no-malloc-may-fail --unwind 2 --full-slice --add-library _ --no-standard-checks
+--no-malloc-may-fail --unwind 2 --no-unwinding-assertions --full-slice --add-library _ --no-standard-checks
 ^EXIT=0$
 ^SIGNAL=0$
 ^VERIFICATION SUCCESSFUL$

--- a/regression/goto-instrument/slice08/test.desc
+++ b/regression/goto-instrument/slice08/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---full-slice --unwind 1
+--full-slice --unwind 1 --no-unwinding-assertions
 ^EXIT=0$
 ^SIGNAL=0$
 ^VERIFICATION SUCCESSFUL$

--- a/regression/goto-instrument/slice16/test.desc
+++ b/regression/goto-instrument/slice16/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---full-slice --unwind 2
+--full-slice --unwind 2 --no-unwinding-assertions
 ^EXIT=0$
 ^SIGNAL=0$
 ^VERIFICATION SUCCESSFUL$

--- a/regression/goto-instrument/unwind-assume2/test.desc
+++ b/regression/goto-instrument/unwind-assume2/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---unwind 9
+--unwind 9 --no-unwinding-assertions
 ^EXIT=0$
 ^SIGNAL=0$
 ^VERIFICATION SUCCESSFUL$

--- a/src/goto-instrument/goto_instrument_parse_options.cpp
+++ b/src/goto-instrument/goto_instrument_parse_options.cpp
@@ -201,9 +201,11 @@ int goto_instrument_parse_optionst::doit()
             ui_message_handler);
         }
 
-        bool unwinding_assertions=cmdline.isset("unwinding-assertions");
-        bool partial_loops=cmdline.isset("partial-loops");
         bool continue_as_loops=cmdline.isset("continue-as-loops");
+        bool partial_loops = cmdline.isset("partial-loops");
+        bool unwinding_assertions = cmdline.isset("unwinding-assertions") ||
+                                    (!continue_as_loops && !partial_loops &&
+                                     !cmdline.isset("no-unwinding-assertions"));
         if(continue_as_loops)
         {
           if(unwinding_assertions)
@@ -1996,7 +1998,9 @@ void goto_instrument_parse_optionst::help()
     HELP_UNWINDSET
     " {y--unwindset-file_<file>} \t read unwindset from file\n"
     " {y--partial-loops} \t permit paths with partial loops\n"
-    " {y--unwinding-assertions} \t generate unwinding assertions\n"
+    " {y--unwinding-assertions} \t generate unwinding assertions"
+    " (enabled by default)\n"
+    " {y--no-unwinding-assertions} \t do not generate unwinding assertions\n"
     " {y--continue-as-loops} \t add loop for remaining iterations after"
     " unwound part\n"
     " {y--k-induction} {uk} \t check loops with k-induction\n"

--- a/src/goto-instrument/goto_instrument_parse_options.h
+++ b/src/goto-instrument/goto_instrument_parse_options.h
@@ -60,6 +60,7 @@ Author: Daniel Kroening, kroening@kroening.com
   OPT_UNWINDSET \
   "(unwindset-file):" \
   "(unwinding-assertions)(partial-loops)(continue-as-loops)" \
+  "(no-unwinding-assertions)" \
   "(log):" \
   "(call-graph)(reachable-call-graph)" \
   OPT_INSERT_FINAL_ASSERT_FALSE \


### PR DESCRIPTION
This will make behaviour consistent (and sound-by-default) across CBMC and goto-instrument.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
