### PR TITLE
Move __CPROVER_uninterpreted_* conversion to C type checker

### DIFF
--- a/regression/ansi-c/undeclared_function/undeclared_uninterpreted.desc
+++ b/regression/ansi-c/undeclared_function/undeclared_uninterpreted.desc
@@ -2,7 +2,7 @@ CORE
 uninterpreted.c
 
 missing type information required to construct call to uninterpreted function
-^EXIT=70$
+^EXIT=(1|64)$
 ^SIGNAL=0$
 --
 ^warning: ignoring

--- a/regression/cbmc/uninterpreted_function_block_scope/main.c
+++ b/regression/cbmc/uninterpreted_function_block_scope/main.c
@@ -1,0 +1,13 @@
+// Test that block-scope declarations of __CPROVER_uninterpreted_*
+// functions are handled correctly (not emitted as DECL/DEAD).
+int main()
+{
+  int __CPROVER_uninterpreted_f(int);
+  int x;
+  __CPROVER_assume(x >= 0 && x <= 10);
+  int y = __CPROVER_uninterpreted_f(x);
+  __CPROVER_assert(
+    __CPROVER_uninterpreted_f(x) == y,
+    "uninterpreted function is deterministic");
+  return 0;
+}

--- a/regression/cbmc/uninterpreted_function_block_scope/test.desc
+++ b/regression/cbmc/uninterpreted_function_block_scope/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+
+^VERIFICATION SUCCESSFUL$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring

--- a/regression/contracts-dfcc/quantifiers-uninterpreted-function/main.c
+++ b/regression/contracts-dfcc/quantifiers-uninterpreted-function/main.c
@@ -1,0 +1,28 @@
+#include <ctype.h>
+
+int __CPROVER_uninterpreted_tolower(int);
+
+// clang-format off
+void tl1(char *dst, __CPROVER_size_t len)
+  __CPROVER_requires(__CPROVER_is_fresh(dst, len))
+  __CPROVER_assigns(__CPROVER_object_whole(dst))
+  __CPROVER_ensures(__CPROVER_forall {
+    int i;
+    (0 <= i && i < len) ==> dst[i % len] ==
+      __CPROVER_uninterpreted_tolower(__CPROVER_old(dst[i % len]))
+  });
+// clang-format on
+
+void tl1(char *dst, __CPROVER_size_t len)
+{
+  for(__CPROVER_size_t i = 0; i < len; i++)
+  {
+    dst[i] = tolower(dst[i]);
+  }
+}
+
+int main()
+{
+  char st[8] = "HELLOROD";
+  tl1(st, 8);
+}

--- a/regression/contracts-dfcc/quantifiers-uninterpreted-function/test.desc
+++ b/regression/contracts-dfcc/quantifiers-uninterpreted-function/test.desc
@@ -1,0 +1,13 @@
+CORE dfcc-only
+main.c
+--dfcc main --enforce-contract tl1
+^\[tl1.postcondition.1\] line \d+ Check ensures clause of contract contract::tl1 for function tl1: FAILURE$
+^\*\* 1 of \d+ failed
+^VERIFICATION FAILED$
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring
+--
+The purpose of this test is to ensure that we can use uninterpreted functions
+within quantifiers.

--- a/src/ansi-c/c_typecheck_base.cpp
+++ b/src/ansi-c/c_typecheck_base.cpp
@@ -142,7 +142,8 @@ void c_typecheck_baset::typecheck_symbol(symbolt &symbol)
     {
       if(
         (!old_it->second.is_static_lifetime || !symbol.is_static_lifetime) &&
-        symbol.type.id() != ID_code)
+        (symbol.type.id() != ID_code &&
+         symbol.type.id() != ID_mathematical_function))
       {
         error().source_location = symbol.location;
         error() << "redeclaration of '" << symbol.display_name()
@@ -346,8 +347,12 @@ void c_typecheck_baset::typecheck_redefinition_non_type(
   }
 
   // do initializer, this may change the type
-  if(new_symbol.type.id() != ID_code && !new_symbol.is_macro)
+  if(
+    new_symbol.type.id() != ID_code &&
+    new_symbol.type.id() != ID_mathematical_function && !new_symbol.is_macro)
+  {
     do_initializer(new_symbol);
+  }
 
   const typet &final_new = new_symbol.type;
 
@@ -874,6 +879,18 @@ void c_typecheck_baset::typecheck_declaration(
 
       irep_idt identifier=symbol.name;
       declarator.set_name(identifier);
+
+      if(
+        symbol.type.id() == ID_code &&
+        identifier.starts_with(CPROVER_PREFIX "uninterpreted_"))
+      {
+        const code_typet &function_call_type = to_code_type(symbol.type);
+        mathematical_function_typet::domaint domain;
+        for(const auto &parameter : function_call_type.parameters())
+          domain.push_back(parameter.type());
+        symbol.type =
+          mathematical_function_typet{domain, function_call_type.return_type()};
+      }
 
       typecheck_symbol(symbol);
 

--- a/src/ansi-c/c_typecheck_code.cpp
+++ b/src/ansi-c/c_typecheck_code.cpp
@@ -314,7 +314,9 @@ void c_typecheck_baset::typecheck_decl(codet &code)
     // see if it's a typedef
     // or a function
     // or static
-    if(symbol.is_type || symbol.type.id() == ID_code)
+    if(
+      symbol.is_type || symbol.type.id() == ID_code ||
+      symbol.type.id() == ID_mathematical_function)
     {
       // we ignore
     }

--- a/src/ansi-c/c_typecheck_expr.cpp
+++ b/src/ansi-c/c_typecheck_expr.cpp
@@ -2500,6 +2500,16 @@ void c_typecheck_baset::typecheck_side_effect_function_call(
       }
       else
       {
+        if(identifier.starts_with(CPROVER_PREFIX "uninterpreted_"))
+        {
+          throw invalid_source_file_exceptiont{
+            "'" + id2string(identifier) +
+              "' is not declared, "
+              "missing type information required to construct call to "
+              "uninterpreted function",
+            expr.source_location()};
+        }
+
         // This is an undeclared function that's not a builtin.
         // Let's just add it.
         // We do a bit of return-type guessing, but just a bit.
@@ -2566,13 +2576,14 @@ void c_typecheck_baset::typecheck_side_effect_function_call(
     for(auto &p :
         make_range(expr.arguments()).zip(mathematical_function_type.domain()))
     {
-      if(p.first.type() != p.second)
-      {
-        error().source_location = p.first.source_location();
-        error() << "expected argument of type " << to_string(p.second)
-                << " but got " << to_string(p.first.type()) << eom;
-        throw 0;
-      }
+      implicit_typecast(p.first, p.second);
+    }
+
+    if(f_op.id() != ID_lambda && f_op.id() != ID_symbol)
+    {
+      throw invalid_source_file_exceptiont{
+        "expected function symbol or lambda, but got " + id2string(f_op.id()),
+        f_op.source_location()};
     }
 
     function_application_exprt function_application(f_op, expr.arguments());

--- a/src/ansi-c/goto-conversion/builtin_functions.cpp
+++ b/src/ansi-c/goto-conversion/builtin_functions.cpp
@@ -17,8 +17,6 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/expr_initializer.h>
 #include <util/expr_util.h>
 #include <util/fresh_symbol.h>
-#include <util/mathematical_expr.h>
-#include <util/mathematical_types.h>
 #include <util/pointer_expr.h>
 #include <util/rational.h>
 #include <util/rational_tools.h>
@@ -1107,34 +1105,6 @@ void goto_convertt::do_function_call_symbol(
       rhs = side_effect_expr_nondett(lhs.type(), function.source_location());
       rhs.set(ID_C_identifier, identifier);
     }
-
-    code_assignt assignment(lhs, rhs);
-    assignment.add_source_location() = function.source_location();
-    copy(assignment, ASSIGN, dest);
-  }
-  else if(identifier.starts_with(CPROVER_PREFIX "uninterpreted_"))
-  {
-    // make it a side effect if there is an LHS
-    if(lhs.is_nil())
-      return;
-
-    if(function.type().get_bool(ID_C_incomplete))
-    {
-      error().source_location = function.find_source_location();
-      error() << "'" << identifier << "' is not declared, "
-              << "missing type information required to construct call to "
-              << "uninterpreted function" << eom;
-      throw 0;
-    }
-
-    const code_typet &function_call_type = to_code_type(function.type());
-    mathematical_function_typet::domaint domain;
-    for(const auto &parameter : function_call_type.parameters())
-      domain.push_back(parameter.type());
-    mathematical_function_typet function_type{
-      domain, function_call_type.return_type()};
-    const function_application_exprt rhs(
-      symbol_exprt{function.get_identifier(), function_type}, arguments);
 
     code_assignt assignment(lhs, rhs);
     assignment.add_source_location() = function.source_location();


### PR DESCRIPTION
Previously, `__CPROVER_uninterpreted_*` functions were converted to mathematical_function_typet during GOTO conversion. This meant they did not work inside quantifier bodies (`__CPROVER_forall`/`__CPROVER_exists`), because quantifier bodies are kept as expressions and are not processed by GOTO conversion.

Move this conversion to the C type checker, where we already handle mathematical_function types for lambda expressions. This ensures uninterpreted functions get the correct type regardless of where they appear, fixing their use inside quantifiers.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
