### PR TITLE
C library: add __to{lower,upper} as alternative names for {tolower,toupper}

### DIFF
--- a/regression/cbmc-library/tolower-01/main.c
+++ b/regression/cbmc-library/tolower-01/main.c
@@ -3,7 +3,8 @@
 
 int main()
 {
-  tolower();
-  assert(0);
+  int x;
+  int r = tolower(x);
+  assert(r >= x);
   return 0;
 }

--- a/regression/cbmc-library/tolower-01/test.desc
+++ b/regression/cbmc-library/tolower-01/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.c
 --pointer-check --bounds-check
 ^EXIT=0$

--- a/regression/cbmc-library/toupper-01/main.c
+++ b/regression/cbmc-library/toupper-01/main.c
@@ -3,7 +3,8 @@
 
 int main()
 {
-  toupper();
-  assert(0);
+  int x;
+  int r = toupper(x);
+  assert(r <= x);
   return 0;
 }

--- a/regression/cbmc-library/toupper-01/test.desc
+++ b/regression/cbmc-library/toupper-01/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.c
 --pointer-check --bounds-check
 ^EXIT=0$

--- a/src/ansi-c/library/ctype.c
+++ b/src/ansi-c/library/ctype.c
@@ -95,12 +95,52 @@ int isupper(int c)
 int isxdigit(int c)
 { return (c>='A' && c<='F') || (c>='a' && c<='f') || (c>='0' && c<='9'); }
 
+/* FUNCTION: __CPROVER_tolower */
+
+int __CPROVER_tolower(int c)
+{
+  return (c >= 'A' && c <= 'Z') ? c + ('a' - 'A') : c;
+}
+
 /* FUNCTION: tolower */
 
+int __CPROVER_tolower(int c);
+
 int tolower(int c)
-{ return (c>='A' && c<='Z')?c+('a'-'A'):c; }
+{
+  return __CPROVER_tolower(c);
+}
+
+/* FUNCTION: __tolower */
+
+int __CPROVER_tolower(int c);
+
+int __tolower(int c)
+{
+  return __CPROVER_tolower(c);
+}
+
+/* FUNCTION: __CPROVER_toupper */
+
+int __CPROVER_toupper(int c)
+{
+  return (c >= 'a' && c <= 'z') ? c - ('a' - 'A') : c;
+}
 
 /* FUNCTION: toupper */
 
+int __CPROVER_toupper(int c);
+
 int toupper(int c)
-{ return (c>='a' && c<='z')?c-('a'-'A'):c; }
+{
+  return __CPROVER_toupper(c);
+}
+
+/* FUNCTION: __toupper */
+
+int __CPROVER_toupper(int c);
+
+int __toupper(int c)
+{
+  return __CPROVER_toupper(c);
+}

--- a/src/ansi-c/library_check.sh
+++ b/src/ansi-c/library_check.sh
@@ -54,9 +54,12 @@ perl -p -i -e 's/^__stdio_common_vsprintf\n//' __functions # snprintf, Windows
 perl -p -i -e 's/^__stdio_common_vsscanf\n//' __functions # sscanf, Windows
 perl -p -i -e 's/^__srget\n//' __functions # gets, FreeBSD
 perl -p -i -e 's/^__swbuf\n//' __functions # putc, FreeBSD
+perl -p -i -e 's/^__tolower\n//' __functions # tolower, macOS
+perl -p -i -e 's/^__toupper\n//' __functions # toupper, macOS
 
 # Some functions are covered by existing tests:
 perl -p -i -e 's/^__CPROVER_(creat|fcntl|open|openat)\n//' __functions # creat, fcntl, open, openat
+perl -p -i -e 's/^__CPROVER_(tolower|toupper)\n//' __functions # tolower, toupper
 perl -p -i -e 's/^(creat|fcntl|open|openat)64\n//' __functions # same as creat, fcntl, open, openat
 perl -p -i -e 's/^__CPROVER_deallocate\n//' __functions # free-01
 perl -p -i -e 's/^__builtin_alloca\n//' __functions # alloca-01


### PR DESCRIPTION
macOS eventually calls a function called `__tolower` (`__toupper`). Rename our previous implementation to `__CPROVER_tolower` (`__CPROVER_toupper`) and make both `tolower` (`toupper`) and `__tolower` (`__toupper`)  use this. Also enable their regression tests.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
