### PR TITLE
C++ front-end: permit GCC attributes in using declarations

### DIFF
--- a/regression/cpp/using1/main.cpp
+++ b/regression/cpp/using1/main.cpp
@@ -1,0 +1,13 @@
+#ifdef __GNUC__
+using type __attribute__((__nodebug__)) = int;
+
+typedef int my_int_t;
+namespace N
+{
+using ::my_int_t __attribute__((__using_if_exists__));
+}
+#endif
+
+int main(int argc, char *argv[])
+{
+}

--- a/regression/cpp/using1/test.desc
+++ b/regression/cpp/using1/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.cpp
+-std=c++11
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+^CONVERSION ERROR$


### PR DESCRIPTION
LLVM's standard library uses these in type_traits.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
