### PR TITLE
C++ front-end: fix parentheses matching for alignas parsing

### DIFF
--- a/regression/cpp/alignas1/main.cpp
+++ b/regression/cpp/alignas1/main.cpp
@@ -1,0 +1,9 @@
+struct alignas(0x1) t
+{
+  char c;
+};
+
+int main(int argc, char *argv[])
+{
+  struct t t;
+}

--- a/regression/cpp/alignas1/test.desc
+++ b/regression/cpp/alignas1/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.cpp
+-std=c++11
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+^CONVERSION ERROR$

--- a/src/cpp/parse.cpp
+++ b/src/cpp/parse.cpp
@@ -2122,9 +2122,8 @@ bool Parser::optAlignas(typet &cv)
 
   typet tname;
   cpp_tokent op, cp;
-
-  cpp_token_buffert::post pos=lex.Save();
   lex.get_token(op);
+  cpp_token_buffert::post pos = lex.Save();
 
   if(rTypeName(tname))
   {


### PR DESCRIPTION
We had parentheses consumed by rCommaExpression while still expecting to find one after this rule executed.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
