### PR TITLE
C++ front-end: not all declarators are code-typed

### DIFF
--- a/regression/cpp/Templates3/main.cpp
+++ b/regression/cpp/Templates3/main.cpp
@@ -1,0 +1,14 @@
+template <class _Tp, _Tp __v>
+struct integral_constant
+{
+  static const _Tp value = __v;
+};
+
+template <class _Tp, _Tp __v>
+const _Tp integral_constant<_Tp, __v>::value;
+
+typedef integral_constant<bool, true> true_type;
+
+int main(int argc, char *argv[])
+{
+}

--- a/regression/cpp/Templates3/test.desc
+++ b/regression/cpp/Templates3/test.desc
@@ -3,6 +3,6 @@ main.cpp
 
 ^EXIT=0$
 ^SIGNAL=0$
-^VERIFICATION SUCCESSFUL$
 --
 ^warning: ignoring
+^CONVERSION ERROR$

--- a/src/cpp/cpp_declarator_converter.cpp
+++ b/src/cpp/cpp_declarator_converter.cpp
@@ -163,7 +163,9 @@ symbolt &cpp_declarator_convertert::convert(
 
     // If it is a constructor, we take care of the
     // object initialization
-    if(to_code_type(final_type).return_type().id() == ID_constructor)
+    if(
+      final_type.id() == ID_code &&
+      to_code_type(final_type).return_type().id() == ID_constructor)
     {
       const cpp_namet &name=declarator.name();
 


### PR DESCRIPTION
The example included as regression test has a bool instead.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
