### PR TITLE
C++ front-end: fix parsing of >> as closing template args

### DIFF
--- a/regression/cpp/Templates4/main.cpp
+++ b/regression/cpp/Templates4/main.cpp
@@ -1,0 +1,29 @@
+template <typename _Tp>
+struct __remove_cvref_t
+{
+};
+
+template <typename _Tp, typename _Up = __remove_cvref_t<_Tp>>
+struct __inv_unwrap
+{
+};
+
+template <typename...>
+struct __or_;
+
+template <bool _Cond, typename _Iftrue, typename _Iffalse>
+struct conditional
+{
+  typedef _Iftrue type;
+};
+
+template <typename _B1, typename _B2, typename _B3, typename... _Bn>
+struct __or_<_B1, _B2, _B3, _Bn...>
+  : public conditional<_B1::value, _B1, __or_<_B2, _B3, _Bn...>>::type
+{
+};
+
+int main(int argc, char *argv[])
+{
+  int x = 10 >> 1;
+}

--- a/regression/cpp/Templates4/test.desc
+++ b/regression/cpp/Templates4/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.cpp
+
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+^CONVERSION ERROR$

--- a/src/cpp/parse.cpp
+++ b/src/cpp/parse.cpp
@@ -4017,8 +4017,8 @@ bool Parser::rTemplateArgs(irept &template_args)
       tk2.text='>';
       lex.Replace(tk2);
       lex.Insert(tk2);
+      lex.get_token();
       DATA_INVARIANT(lex.LookAhead(0) == '>', "should be >");
-      DATA_INVARIANT(lex.LookAhead(1) == '>', "should be >");
       return true;
 
     default:


### PR DESCRIPTION
We also need to pop one token, not just replace the existing ones.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
