### PR TITLE
Visual Studio has added _Static_assert

### DIFF
--- a/regression/ansi-c/_Static_assert1/main.c
+++ b/regression/ansi-c/_Static_assert1/main.c
@@ -1,17 +1,9 @@
-
-// Not yet available in Visual Studio
-
-#ifdef _MSC_VER
-
-int main()
-{
-}
-
-#else
-
 struct S
 {
+  // Visual Studio does not support _Static_assert in compound bodies.
+#ifndef _MSC_VER
   _Static_assert(1, "in struct");
+#endif
   int x;
 } asd;
 
@@ -21,5 +13,3 @@ int main()
 {
   _Static_assert(1, "in function");
 }
-
-#endif

--- a/regression/ansi-c/_Static_assert2/global.desc
+++ b/regression/ansi-c/_Static_assert2/global.desc
@@ -1,4 +1,4 @@
-CORE gcc-only
+CORE
 global.c
 
 static assertion failed: must fail

--- a/regression/ansi-c/_Static_assert2/local.desc
+++ b/regression/ansi-c/_Static_assert2/local.desc
@@ -1,4 +1,4 @@
-CORE gcc-only
+CORE
 local.c
 
 static assertion failed: must fail

--- a/regression/ansi-c/_Static_assert2/not_constant.desc
+++ b/regression/ansi-c/_Static_assert2/not_constant.desc
@@ -1,4 +1,4 @@
-CORE gcc-only
+CORE
 not_constant.c
 
 expected constant expression

--- a/regression/ansi-c/anonymous_member1/main.c
+++ b/regression/ansi-c/anonymous_member1/main.c
@@ -1,8 +1,3 @@
-#ifdef _MSC_VER
-// No _Static_assert in Visual Studio
-#  define _Static_assert(condition, message) static_assert(condition, message)
-#endif
-
 struct S
 {
   struct

--- a/regression/ansi-c/simplify-overflow/main.c
+++ b/regression/ansi-c/simplify-overflow/main.c
@@ -1,7 +1,3 @@
-#ifdef _MSC_VER
-#  define _Static_assert static_assert
-#endif
-
 int main()
 {
   _Static_assert(!__CPROVER_overflow_plus(1, 2), "");

--- a/regression/ansi-c/sizeof2/main.c
+++ b/regression/ansi-c/sizeof2/main.c
@@ -1,11 +1,3 @@
-#ifdef _MSC_VER
-
-// No _Static_assert in Visual Studio
-#define _Static_assert(condition, message) \
-  int some_array##__LINE__[(condition) ? 1 : -1];
-
-#endif
-
 // sizeof is unsigned
 _Static_assert( 1 - sizeof(int) >=0, "sizeof is unsigned" );
 

--- a/regression/cbmc/Bitfields5/main.c
+++ b/regression/cbmc/Bitfields5/main.c
@@ -7,10 +7,6 @@ struct S0
   int x;
 };
 
-#ifdef _MSC_VER
-#  define _Static_assert static_assert
-#endif
-
 int main()
 {
   struct S0 g = {0};

--- a/regression/cbmc/inequality-with-constant-normalisation1/main.c
+++ b/regression/cbmc/inequality-with-constant-normalisation1/main.c
@@ -1,9 +1,5 @@
 #include <assert.h>
 
-#ifdef _MSC_VER
-#  define _Static_assert(x, m) static_assert(x, m)
-#endif
-
 int main()
 {
   _Bool b1, b2;

--- a/regression/cbmc/member_bounds3/main.c
+++ b/regression/cbmc/member_bounds3/main.c
@@ -8,10 +8,6 @@ struct S
 };
 #pragma pack(pop)
 
-#ifdef _MSC_VER
-#  define _Static_assert(x, m) static_assert(x, m)
-#endif
-
 int main()
 {
   int A[3];

--- a/src/ansi-c/scanner.l
+++ b/src/ansi-c/scanner.l
@@ -876,8 +876,9 @@ or_eq               { return cpp98_keyword(TOK_ORASSIGN); }
 private             { return cpp98_keyword(TOK_PRIVATE); }
 protected           { return cpp98_keyword(TOK_PROTECTED); }
 public              { return cpp98_keyword(TOK_PUBLIC); }
-static_assert       { // C++11, but Visual Studio supports it in all modes (and
-                      // doesn't support _Static_assert)
+static_assert       { // C++11, but Visual Studio supports it in all modes
+                      // as a keyword, even though the documentation claims
+                      // it's a macro.
                       if(PARSER.mode == configt::ansi_ct::flavourt::VISUAL_STUDIO)
                       {
                         loc(); return TOK_STATIC_ASSERT;
@@ -1490,10 +1491,7 @@ __decltype          { if(PARSER.cpp98 &&
 
   /* This is a C11 keyword */
 
-"_Static_assert" { if(!PARSER.cpp98 &&
-                      (PARSER.mode==configt::ansi_ct::flavourt::GCC ||
-                      PARSER.mode==configt::ansi_ct::flavourt::CLANG ||
-                       PARSER.mode==configt::ansi_ct::flavourt::ARM))
+"_Static_assert" { if(!PARSER.cpp98)
                     { loc(); return TOK_STATIC_ASSERT; }
                   else
                     return make_identifier();


### PR DESCRIPTION
Visual Studio now supports C11's `_Static_assert`.

However, in constrast to what is claimed at

https://learn.microsoft.com/en-us/cpp/c-language/static-assert-c?view=msvc-170

the identifier `static_assert` is recognised as a keyword, and is not implemented as a macro.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [X] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
