### PR TITLE
Make `going_to` variable cprover-prefixed

### DIFF
--- a/regression/cbmc/destructors/enter_lexical_block.desc
+++ b/regression/cbmc/destructors/enter_lexical_block.desc
@@ -2,7 +2,7 @@ CORE
 main.c
 --unwind 10 --show-goto-functions
 activate-multi-line-match
-(?P<comment_block>\/\/ [0-9]+ file main\.c line [0-9]+ function main)[\s]*6: .*newAlloc4 : struct tag-test[\s]*(?P>comment_block)[\s]*.*newAlloc4 := \{ 4 \}[\s]*(?P>comment_block)[\s]*.*newAlloc6 : struct tag-test[\s]*(?P>comment_block)[\s]*.*newAlloc6 := \{ 6 \}[\s]*(?P>comment_block)[\s]*.*newAlloc7 : struct tag-test[\s]*(?P>comment_block)[\s]*.*newAlloc7 := \{ 7 \}[\s]*(?P>comment_block)[\s]*.*DEAD main::1::2::2::newAlloc7[\s]*(?P>comment_block)[\s]*.*DEAD main::1::2::2::newAlloc6[\s]*(?P>comment_block)[\s]*.*DEAD main::1::2::2::newAlloc4[\s]*(?P>comment_block)[\s]*.*ASSIGN going_to::nested_if := true[\s]*(?P>comment_block)[\s]*.*GOTO 3
+(?P<comment_block>\/\/ [0-9]+ file main\.c line [0-9]+ function main)[\s]*6: .*newAlloc4 : struct tag-test[\s]*(?P>comment_block)[\s]*.*newAlloc4 := \{ 4 \}[\s]*(?P>comment_block)[\s]*.*newAlloc6 : struct tag-test[\s]*(?P>comment_block)[\s]*.*newAlloc6 := \{ 6 \}[\s]*(?P>comment_block)[\s]*.*newAlloc7 : struct tag-test[\s]*(?P>comment_block)[\s]*.*newAlloc7 := \{ 7 \}[\s]*(?P>comment_block)[\s]*.*DEAD main::1::2::2::newAlloc7[\s]*(?P>comment_block)[\s]*.*DEAD main::1::2::2::newAlloc6[\s]*(?P>comment_block)[\s]*.*DEAD main::1::2::2::newAlloc4[\s]*(?P>comment_block)[\s]*.*ASSIGN __CPROVER_going_to::nested_if := true[\s]*(?P>comment_block)[\s]*.*GOTO 3
 ^EXIT=0$
 ^SIGNAL=0$
 --
@@ -28,7 +28,7 @@ Checks for:
        // 49 file main.c line 39 function main
        DEAD main::1::2::2::newAlloc4
        // 50 file main.c line 39 function main
-       ASSIGN going_to::nested_if := true
+       ASSIGN __CPROVER_going_to::nested_if := true
        // 51 file main.c line 39 function main
        GOTO 3
 

--- a/src/ansi-c/goto-conversion/goto_convert.cpp
+++ b/src/ansi-c/goto-conversion/goto_convert.cpp
@@ -127,27 +127,27 @@ void goto_convertt::build_declaration_hops(
   //   }
   // to code which looks like -
   //   {
-  //     __CPROVER_bool going_to::user_label;
-  //     going_to::user_label = false;
+  //     __CPROVER_bool __CPROVER_going_to::user_label;
+  //     __CPROVER_going_to::user_label = false;
   //     statement_block_a();
   //     if(...)
   //     {
-  //       going_to::user_label = true;
+  //       __CPROVER_going_to::user_label = true;
   //       goto scope_x_label;
   //     }
   //     statement_block_b();
   //   scope_x_label:
   //     int x;
-  //     if going_to::user_label goto scope_y_label:
+  //     if __CPROVER_going_to::user_label goto scope_y_label:
   //     x = 0;
   //     statement_block_c();
   //   scope_y_label:
   //     int y;
-  //     if going_to::user_label goto user_label:
+  //     if __CPROVER_going_to::user_label goto user_label:
   //     y = 0;
   //     statement_block_d();
   //   user_label:
-  //     going_to::user_label = false;
+  //     __CPROVER_going_to::user_label = false;
   //     statement_block_e();
   //   }
 
@@ -162,7 +162,7 @@ void goto_convertt::build_declaration_hops(
     label_location.set_hide();
     const symbolt &new_flag = get_fresh_aux_symbol(
       bool_typet{},
-      "going_to",
+      CPROVER_PREFIX "going_to",
       id2string(inputs.label),
       label_location,
       inputs.mode,


### PR DESCRIPTION
<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

The `goint_go` variables are cprover variables and hence should be cprover-prefixed.

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
