### PR TITLE
[CONTRACTS] Ignore cprover symbols in loop assigns inference

### DIFF
--- a/regression/contracts-dfcc/invar_loop_with_goto/main.c
+++ b/regression/contracts-dfcc/invar_loop_with_goto/main.c
@@ -1,0 +1,38 @@
+#include <assert.h>
+typedef struct test
+{
+  int id;
+} test;
+
+int main()
+{
+  int r, s = 1;
+  __CPROVER_assume(r >= 0);
+  while(r > 0)
+    // clang-format off
+    __CPROVER_loop_invariant(r >= 0 && s == 1)
+    __CPROVER_decreases(r)
+    // clang-format on
+    {
+      s = 1;
+      goto label_1;
+
+      if(1 == 1)
+        goto label_0;
+
+      test newAlloc0 = {0};
+
+      if(1 == 1)
+        goto label_1;
+
+    label_0:
+      r--;
+
+    label_1:
+      r--;
+    }
+  assert(r == 0);
+  assert(s == 1);
+
+  return 0;
+}

--- a/regression/contracts-dfcc/invar_loop_with_goto/test.desc
+++ b/regression/contracts-dfcc/invar_loop_with_goto/test.desc
@@ -1,0 +1,9 @@
+CORE
+main.c
+--dfcc main --apply-loop-contracts
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+This test checks the assigns inference correctly
+ignore __CPROVER_going_to variables.

--- a/regression/contracts/invar_loop_with_goto/main.c
+++ b/regression/contracts/invar_loop_with_goto/main.c
@@ -1,0 +1,38 @@
+#include <assert.h>
+typedef struct test
+{
+  int id;
+} test;
+
+int main()
+{
+  int r, s = 1;
+  __CPROVER_assume(r >= 0);
+  while(r > 0)
+    // clang-format off
+    __CPROVER_loop_invariant(r >= 0 && s == 1)
+    __CPROVER_decreases(r)
+    // clang-format on
+    {
+      s = 1;
+      goto label_1;
+
+      if(1 == 1)
+        goto label_0;
+
+      test newAlloc0 = {0};
+
+      if(1 == 1)
+        goto label_1;
+
+    label_0:
+      r--;
+
+    label_1:
+      r--;
+    }
+  assert(r == 0);
+  assert(s == 1);
+
+  return 0;
+}

--- a/regression/contracts/invar_loop_with_goto/test.desc
+++ b/regression/contracts/invar_loop_with_goto/test.desc
@@ -1,0 +1,9 @@
+CORE
+main.c
+--apply-loop-contracts
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+This test checks the assigns inference correctly
+ignore __CPROVER_going_to variables.

--- a/src/goto-instrument/contracts/contracts.cpp
+++ b/src/goto-instrument/contracts/contracts.cpp
@@ -218,7 +218,7 @@ void code_contractst::check_apply_loop_contracts(
     // and the inferred aliasing relation.
     try
     {
-      get_assigns(local_may_alias, loop, to_havoc);
+      infer_loop_assigns(local_may_alias, loop, to_havoc);
 
       // remove loop-local symbols from the inferred set
       cfg_info.erase_locals(to_havoc);

--- a/src/goto-instrument/contracts/dynamic-frames/dfcc_infer_loop_assigns.cpp
+++ b/src/goto-instrument/contracts/dynamic-frames/dfcc_infer_loop_assigns.cpp
@@ -13,6 +13,7 @@ Author: Remi Delmas, delmasrd@amazon.com
 #include <util/pointer_expr.h>
 #include <util/std_code.h>
 
+#include <goto-instrument/contracts/utils.h>
 #include <goto-instrument/havoc_utils.h>
 
 #include "dfcc_root_object.h"
@@ -53,7 +54,7 @@ assignst dfcc_infer_loop_assigns(
 {
   // infer
   assignst assigns;
-  get_assigns(local_may_alias, loop_instructions, assigns);
+  infer_loop_assigns(local_may_alias, loop_instructions, assigns);
 
   // compute locals
   std::unordered_set<irep_idt> loop_locals;

--- a/src/goto-instrument/contracts/dynamic-frames/dfcc_is_cprover_symbol.cpp
+++ b/src/goto-instrument/contracts/dynamic-frames/dfcc_is_cprover_symbol.cpp
@@ -151,5 +151,7 @@ bool dfcc_is_cprover_static_symbol(const irep_idt &id)
   init_static_symbols(static_symbols);
   return static_symbols.find(id) != static_symbols.end() ||
          // auto objects from pointer derefs
-         has_suffix(id2string(id), "$object");
+         has_suffix(id2string(id), "$object") ||
+         // going_to variables converted from goto statements
+         has_prefix(id2string(id), CPROVER_PREFIX "going_to");
 }

--- a/src/goto-instrument/contracts/instrument_spec_assigns.cpp
+++ b/src/goto-instrument/contracts/instrument_spec_assigns.cpp
@@ -19,6 +19,7 @@ Date: January 2022
 #include <util/fresh_symbol.h>
 #include <util/pointer_offset_size.h>
 #include <util/pointer_predicates.h>
+#include <util/prefix.h>
 #include <util/simplify_expr.h>
 
 #include <ansi-c/c_expr.h>
@@ -147,6 +148,13 @@ void instrument_spec_assignst::check_inclusion_assignment(
   const exprt &lhs,
   goto_programt &dest) const
 {
+  // Don't check assignable for CPROVER symbol
+  if(
+    lhs.id() == ID_symbol &&
+    has_prefix(id2string(to_symbol_expr(lhs).get_identifier()), CPROVER_PREFIX))
+  {
+    return;
+  }
   // create temporary car but do not track
   const auto car = create_car_expr(true_exprt{}, lhs);
   create_snapshot(car, dest);

--- a/src/goto-instrument/contracts/utils.h
+++ b/src/goto-instrument/contracts/utils.h
@@ -16,7 +16,9 @@ Date: September 2021
 #include <goto-programs/goto_model.h>
 #include <goto-programs/loop_ids.h>
 
+#include <analyses/local_may_alias.h>
 #include <goto-instrument/havoc_utils.h>
+#include <goto-instrument/loop_utils.h>
 
 #include <vector>
 
@@ -213,6 +215,12 @@ irep_idt make_assigns_clause_replacement_tracking_comment(
 /// Returns true if the given comment matches the type of comments created by
 /// \ref make_assigns_clause_replacement_tracking_comment.
 bool is_assigns_clause_replacement_tracking_comment(const irep_idt &comment);
+
+/// Infer loop assigns using alias analysis result `local_may_alias`.
+void infer_loop_assigns(
+  const local_may_aliast &local_may_alias,
+  const loopt &loop,
+  assignst &assigns);
 
 /// Widen expressions in \p assigns with the following strategy.
 /// If an expression is an array index or object dereference expression,

--- a/src/goto-instrument/loop_utils.h
+++ b/src/goto-instrument/loop_utils.h
@@ -24,11 +24,26 @@ void get_assigns(
   const loopt &loop,
   assignst &assigns);
 
+/// get all assign targets that satisfy `predicate` within the loops.
+void get_assigns(
+  const local_may_aliast &local_may_alias,
+  const loopt &loop,
+  assignst &assigns,
+  std::function<bool(const exprt &)> predicate);
+
 void get_assigns_lhs(
   const local_may_aliast &local_may_alias,
   goto_programt::const_targett t,
   const exprt &lhs,
   assignst &assigns);
+
+/// get all assign targets that satisfy `predicate` from `lhs`.
+void get_assigns_lhs(
+  const local_may_aliast &local_may_alias,
+  goto_programt::const_targett t,
+  const exprt &lhs,
+  assignst &assigns,
+  std::function<bool(const exprt &)> predicate);
 
 goto_programt::targett get_loop_exit(const loopt &);
 


### PR DESCRIPTION
CPROVER symbols are created by CBMC, and some of them (for example, `CPROVER_PREFIX going_to`) are supposed to be written to. Hence they should not be checked if assignable or inferred as loop assigns.


- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
