### PR TITLE
array-bounds checks are now fatal

### DIFF
--- a/src/ansi-c/goto-conversion/goto_check_c.cpp
+++ b/src/ansi-c/goto-conversion/goto_check_c.cpp
@@ -1628,7 +1628,7 @@ void goto_check_ct::bounds_check_index(
           inequality,
           name + " lower bound",
           "array bounds",
-          false, // fatal
+          true, // fatal
           expr.find_source_location(),
           expr,
           guard);
@@ -1708,7 +1708,7 @@ void goto_check_ct::bounds_check_index(
       inequality,
       name + " upper bound",
       "array bounds",
-      false, // fatal
+      true, // fatal
       expr.find_source_location(),
       expr,
       guard);
@@ -1722,7 +1722,7 @@ void goto_check_ct::bounds_check_index(
       inequality,
       name + " upper bound",
       "array bounds",
-      false, // fatal
+      true, // fatal
       expr.find_source_location(),
       expr,
       guard);


### PR DESCRIPTION
Accessing an array out of bounds is undefined behavior, and hence, the assertions for this need to be fatal.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
