### PR TITLE
Lower-byte-operators: bv_to_expr should support bool target type

### DIFF
--- a/src/util/lower_byte_operators.cpp
+++ b/src/util/lower_byte_operators.cpp
@@ -346,13 +346,14 @@ static exprt bv_to_expr(
   else if(
     can_cast_type<bitvector_typet>(target_type) ||
     target_type.id() == ID_c_enum || target_type.id() == ID_c_enum_tag ||
-    target_type.id() == ID_string)
+    target_type.id() == ID_string ||
+    (target_type.id() == ID_bool &&
+     to_bitvector_type(bitvector_expr.type()).get_width() == 1))
   {
     return simplify_expr(
       typecast_exprt::conditional_cast(bitvector_expr, target_type), ns);
   }
-
-  if(target_type.id() == ID_struct)
+  else if(target_type.id() == ID_struct)
   {
     return bv_to_struct_expr(
       bitvector_expr, to_struct_type(target_type), endianness_map, ns);


### PR DESCRIPTION
When byte updating or byte extracting structs that contain single-bit `__CPROVER_bool` members (as is used in `__CPROVER_contracts_car_t`) we may need to turn a `bv` typed single-bit `extractbits` expression into one that has `bool` (`__CPROVER_bool`) type.

Fixes: #8303

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
