### PR TITLE
change default verbosity to M_STATUS

### DIFF
--- a/regression/cbmc-concurrency/constant_prop1/test.desc
+++ b/regression/cbmc-concurrency/constant_prop1/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
-
+--verbosity 8
 ^EXIT=0$
 ^SIGNAL=0$
 ^VERIFICATION SUCCESSFUL$

--- a/regression/cbmc-incr-oneloop/alarm1/test.desc
+++ b/regression/cbmc-incr-oneloop/alarm1/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---no-standard-checks --incremental-loop main.0 --unwind-max 15
+--no-standard-checks --incremental-loop main.0 --unwind-max 15 --verbosity 8
 activate-multi-line-match
 ^EXIT=0$
 ^SIGNAL=0$

--- a/regression/cbmc-incr-oneloop/alarm2/test-json-output.desc
+++ b/regression/cbmc-incr-oneloop/alarm2/test-json-output.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---incremental-loop main.0 --unwind-min 5 --unwind-max 10 --json-ui
+--incremental-loop main.0 --unwind-min 5 --unwind-max 10 --json-ui --verbosity 8
 ^EXIT=10$
 ^SIGNAL=0$
 "messageText": "VERIFICATION FAILED"

--- a/regression/cbmc-incr-oneloop/alarm2/test-xml-output.desc
+++ b/regression/cbmc-incr-oneloop/alarm2/test-xml-output.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---incremental-loop main.0 --unwind-min 5 --unwind-max 10 --xml-ui
+--incremental-loop main.0 --unwind-min 5 --unwind-max 10 --xml-ui --verbosity 8
 ^EXIT=10$
 ^SIGNAL=0$
 <text>VERIFICATION FAILED</text>

--- a/regression/cbmc-incr-oneloop/alarm2/test.desc
+++ b/regression/cbmc-incr-oneloop/alarm2/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---incremental-loop main.0 --unwind-min 5 --unwind-max 10
+--incremental-loop main.0 --unwind-min 5 --unwind-max 10 --verbosity 8
 activate-multi-line-match
 Current unwinding: 1
 Incremental status: INCONCLUSIVE

--- a/regression/cbmc-incr-oneloop/minmaxunwind4/test.desc
+++ b/regression/cbmc-incr-oneloop/minmaxunwind4/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---no-standard-checks --unwind-min 6 --unwind-max 8 --incremental-loop main.0 --ignore-properties-before-unwind-min
+--no-standard-checks --unwind-min 6 --unwind-max 8 --incremental-loop main.0 --ignore-properties-before-unwind-min --verbosity 8
 ^EXIT=10$
 ^SIGNAL=0$
 ^VERIFICATION FAILED$

--- a/regression/cbmc-incr-oneloop/multiple-asserts/test-no-cp.desc
+++ b/regression/cbmc-incr-oneloop/multiple-asserts/test-no-cp.desc
@@ -1,6 +1,6 @@
 CORE
 test.c
---no-standard-checks --incremental-loop main.0 --no-propagation
+--no-standard-checks --incremental-loop main.0 --no-propagation --verbosity 8
 activate-multi-line-match
 Incremental status: INCONCLUSIVE\nCurrent unwinding: 2
 Incremental status: INCONCLUSIVE\nCurrent unwinding: 6

--- a/regression/cbmc-incr-oneloop/multiple-asserts/test.desc
+++ b/regression/cbmc-incr-oneloop/multiple-asserts/test.desc
@@ -1,6 +1,6 @@
 CORE
 test.c
---incremental-loop main.0
+--incremental-loop main.0 --verbosity 8
 activate-multi-line-match
 Incremental status: INCONCLUSIVE\nCurrent unwinding: 2
 Incremental status: INCONCLUSIVE\nCurrent unwinding: 6

--- a/regression/cbmc-incr-oneloop/unwind-more-loops1/test.desc
+++ b/regression/cbmc-incr-oneloop/unwind-more-loops1/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---no-standard-checks --incremental-loop main.1 --unwind 2
+--no-standard-checks --incremental-loop main.1 --unwind 2 --verbosity 8
 ^EXIT=10$
 ^SIGNAL=0$
 ^VERIFICATION FAILED$

--- a/regression/cbmc-incr-oneloop/unwindset-more-loops1/test.desc
+++ b/regression/cbmc-incr-oneloop/unwindset-more-loops1/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---no-standard-checks --incremental-loop main.3 --unwindset main.1:2,main.2:8
+--no-standard-checks --incremental-loop main.3 --unwindset main.1:2,main.2:8 --verbosity 8
 ^EXIT=10$
 ^SIGNAL=0$
 ^VERIFICATION FAILED$

--- a/regression/cbmc-incr-oneloop/valid-asserts/test.desc
+++ b/regression/cbmc-incr-oneloop/valid-asserts/test.desc
@@ -1,6 +1,6 @@
 CORE
 test.c
---incremental-loop main.0
+--incremental-loop main.0 --verbosity 8
 activate-multi-line-match
 Incremental status: INCONCLUSIVE\nCurrent unwinding: 2
 Incremental status: INCONCLUSIVE\nCurrent unwinding: 10

--- a/regression/cbmc-library/memcpy-01/constant-propagation.desc
+++ b/regression/cbmc-library/memcpy-01/constant-propagation.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---no-standard-checks
+--no-standard-checks --verbosity 8
 ^Generated 1\d* VCC\(s\), 0 remaining after simplification$
 ^EXIT=0$
 ^SIGNAL=0$

--- a/regression/cbmc-library/memmove-01/constant.desc
+++ b/regression/cbmc-library/memmove-01/constant.desc
@@ -1,6 +1,6 @@
 CORE
 constant.c
---no-standard-checks --unwind 17
+--no-standard-checks --unwind 17 --verbosity 8
 ^EXIT=0$
 ^SIGNAL=0$
 ^VERIFICATION SUCCESSFUL$

--- a/regression/cbmc-shadow-memory/constchar-param1/test.desc
+++ b/regression/cbmc-shadow-memory/constchar-param1/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---unwind 11
+--unwind 11 --verbosity 8
 ^EXIT=0$
 ^SIGNAL=0$
 ^VERIFICATION SUCCESSFUL$

--- a/regression/cbmc-with-incr/Fixedbv4/test.desc
+++ b/regression/cbmc-with-incr/Fixedbv4/test.desc
@@ -1,6 +1,6 @@
 FUTURE
 main.c
---fixedbv
+--fixedbv --verbosity 8
 ^EXIT=0$
 ^SIGNAL=0$
 ^VERIFICATION SUCCESSFUL$

--- a/regression/cbmc/Array_Propagation1/test.desc
+++ b/regression/cbmc/Array_Propagation1/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
-
+--verbosity 8
 ^EXIT=0$
 ^SIGNAL=0$
 ^VERIFICATION SUCCESSFUL$

--- a/regression/cbmc/BV_Arithmetic3/test.desc
+++ b/regression/cbmc/BV_Arithmetic3/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
-
+--verbosity 8
 ^EXIT=0$
 ^SIGNAL=0$
 (Starting CEGAR Loop|^Generated 68 VCC\(s\), 0 remaining after simplification$)

--- a/regression/cbmc/Bool/bool5-full-slice.desc
+++ b/regression/cbmc/Bool/bool5-full-slice.desc
@@ -1,6 +1,6 @@
 CORE
 bool5.c
---full-slice
+--full-slice --verbosity 8
 Generated 10 VCC\(s\), 0 remaining after simplification
 ^VERIFICATION SUCCESSFUL$
 ^EXIT=0$

--- a/regression/cbmc/Bool/bool5.desc
+++ b/regression/cbmc/Bool/bool5.desc
@@ -1,6 +1,6 @@
 CORE
 bool5.c
-
+--verbosity 8
 Generated 10 VCC\(s\), 0 remaining after simplification
 ^VERIFICATION SUCCESSFUL$
 ^EXIT=0$

--- a/regression/cbmc/Fixedbv4/test.desc
+++ b/regression/cbmc/Fixedbv4/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
-
+--unwind 8 --verbosity 8
 ^EXIT=0$
 ^SIGNAL=0$
 ^VERIFICATION SUCCESSFUL$

--- a/regression/cbmc/Float-equality2/test.desc
+++ b/regression/cbmc/Float-equality2/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
-
+--verbosity 8
 (Starting CEGAR Loop|VCC\(s\), 0 remaining after simplification$)
 ^VERIFICATION SUCCESSFUL$
 ^EXIT=0$

--- a/regression/cbmc/Pointer_comparison5/test.desc
+++ b/regression/cbmc/Pointer_comparison5/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
-
+--verbosity 8
 ^Generated \d+ VCC\(s\), 1 remaining after simplification$
 ^VERIFICATION SUCCESSFUL$
 ^EXIT=0$

--- a/regression/cbmc/Struct_Propagation1/test.desc
+++ b/regression/cbmc/Struct_Propagation1/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---unwind 5
+--unwind 5 --verbosity 8
 ^EXIT=0$
 ^SIGNAL=0$
 ^VERIFICATION SUCCESSFUL$

--- a/regression/cbmc/bounds_check2/test.desc
+++ b/regression/cbmc/bounds_check2/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---retain-trivial-checks
+--retain-trivial-checks --verbosity 8
 ^Generated \d+ VCC\(s\), 0 remaining after simplification$
 ^\[main.array_bounds.1\] line 4 array 'A' (lower|upper) bound in A\[(\(signed (long (long )?)?int\))?1\]: SUCCESS$
 ^VERIFICATION SUCCESSFUL$

--- a/regression/cbmc/condition-propagation-1/test.desc
+++ b/regression/cbmc/condition-propagation-1/test.desc
@@ -1,6 +1,6 @@
 CORE
 test.c
-
+--verbosity 8
 ^EXIT=0$
 ^SIGNAL=0$
 ^VERIFICATION SUCCESSFUL$

--- a/regression/cbmc/condition-propagation-2/test.desc
+++ b/regression/cbmc/condition-propagation-2/test.desc
@@ -1,6 +1,6 @@
 CORE
 test.c
-
+--verbosity 8
 ^EXIT=0$
 ^SIGNAL=0$
 ^VERIFICATION SUCCESSFUL$

--- a/regression/cbmc/condition-propagation-3/test.desc
+++ b/regression/cbmc/condition-propagation-3/test.desc
@@ -1,6 +1,6 @@
 CORE
 test.c
-
+--verbosity 8
 ^EXIT=0$
 ^SIGNAL=0$
 ^VERIFICATION SUCCESSFUL$

--- a/regression/cbmc/condition-propagation-4/test.desc
+++ b/regression/cbmc/condition-propagation-4/test.desc
@@ -1,6 +1,6 @@
 CORE
 test.c
-
+--verbosity 8
 ^EXIT=0$
 ^SIGNAL=0$
 ^VERIFICATION SUCCESSFUL$

--- a/regression/cbmc/constant_folding3/test.desc
+++ b/regression/cbmc/constant_folding3/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
-
+--verbosity 8
 ^Generated 1 VCC\(s\), 0 remaining after simplification$
 ^VERIFICATION SUCCESSFUL$
 ^EXIT=0$

--- a/regression/cbmc/field-sensitivity14/test.desc
+++ b/regression/cbmc/field-sensitivity14/test.desc
@@ -1,6 +1,6 @@
 CORE no-new-smt
 main.c
-
+--verbosity 8
 ^Generated \d+ VCC\(s\), \d remaining after simplification$
 ^VERIFICATION SUCCESSFUL$
 ^EXIT=0$

--- a/regression/cbmc/gcc_builtin_sub_overflow/simplify.desc
+++ b/regression/cbmc/gcc_builtin_sub_overflow/simplify.desc
@@ -1,6 +1,6 @@
 CORE
 simplify.c
-
+--verbosity 8
 ^Generated 2 VCC\(s\), 0 remaining after simplification$
 ^VERIFICATION SUCCESSFUL$
 ^EXIT=0$

--- a/regression/cbmc/json-interface1/test.desc
+++ b/regression/cbmc/json-interface1/test.desc
@@ -1,6 +1,6 @@
 CORE
 --json-interface
-< test.json
+--verbosity 8 < test.json
 activate-multi-line-match
 ^EXIT=10$
 ^SIGNAL=0$

--- a/regression/cbmc/no-propagation/test.desc
+++ b/regression/cbmc/no-propagation/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---no-propagation
+--no-propagation --verbosity 8
 Generated 1 VCC\(s\), 1 remaining after simplification
 ^VERIFICATION SUCCESSFUL$
 ^EXIT=0$

--- a/regression/cbmc/null8/test.desc
+++ b/regression/cbmc/null8/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
-
+--verbosity 8
 Generated 1 VCC\(s\), 0 remaining after simplification
 ^EXIT=0$
 ^SIGNAL=0$

--- a/regression/cbmc/runtime-profiling/test.desc
+++ b/regression/cbmc/runtime-profiling/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---no-standard-checks
+--no-standard-checks --verbosity 8
 ^EXIT=0$
 ^SIGNAL=0$
 ^Runtime Symex:.*$

--- a/regression/cbmc/self_loops_to_assumptions1/default.desc
+++ b/regression/cbmc/self_loops_to_assumptions1/default.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---unwind 1 --unwinding-assertions
+--unwind 1 --unwinding-assertions --verbosity 8
 ^replacing self-loop at file main.c line 3 function main by assume\(FALSE\)$
 ^no unwinding assertion will be generated for self-loop at file main.c line 3 function main$
 ^EXIT=0$

--- a/regression/cbmc/simplify-union/test.desc
+++ b/regression/cbmc/simplify-union/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---no-malloc-may-fail
+--no-malloc-may-fail --verbosity 8
 ^Generated 13 VCC\(s\), 0 remaining after simplification$
 ^VERIFICATION SUCCESSFUL$
 ^EXIT=0$

--- a/regression/cbmc/union13/no-arch.desc
+++ b/regression/cbmc/union13/no-arch.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---arch none --little-endian
+--arch none --little-endian --verbosity 8
 (Starting CEGAR Loop|^Generated 1 VCC\(s\), 1 remaining after simplification$)
 ^EXIT=0$
 ^SIGNAL=0$

--- a/regression/cbmc/union18/test.desc
+++ b/regression/cbmc/union18/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
-
+--verbosity 8
 ^Generated 1 VCC\(s\), 0 remaining after simplification$
 ^VERIFICATION SUCCESSFUL$
 ^EXIT=0$

--- a/regression/cbmc/unreachable-goto1/test-vccs.desc
+++ b/regression/cbmc/unreachable-goto1/test-vccs.desc
@@ -1,6 +1,6 @@
 CORE paths-lifo-expected-failure
 test.c
---show-vcc
+--show-vcc --verbosity 8
 ^Generated 1 VCC\(s\), 1 remaining after simplification$
 ^\{1\} false$
 ^EXIT=0$

--- a/regression/cbmc/unreachable-goto2/test-vccs.desc
+++ b/regression/cbmc/unreachable-goto2/test-vccs.desc
@@ -1,6 +1,6 @@
 CORE paths-lifo-expected-failure
 test.c
---show-vcc
+--show-vcc --verbosity 8
 ^Generated 1 VCC\(s\), 1 remaining after simplification$
 ^\{1\} goto_symex::\\guard#1$
 ^EXIT=0$

--- a/regression/cbmc/unreachable-goto3/test-vccs.desc
+++ b/regression/cbmc/unreachable-goto3/test-vccs.desc
@@ -1,6 +1,6 @@
 CORE paths-lifo-expected-failure
 test.c
---show-vcc
+--show-vcc --verbosity 8
 ^Generated 1 VCC\(s\), 1 remaining after simplification$
 ^\{1\} false$
 ^EXIT=0$

--- a/regression/cbmc/unreachable-goto4/test-vccs.desc
+++ b/regression/cbmc/unreachable-goto4/test-vccs.desc
@@ -1,6 +1,6 @@
 CORE paths-lifo-expected-failure
 test.c
---show-vcc
+--show-vcc --verbosity 8
 ^Generated 1 VCC\(s\), 1 remaining after simplification$
 ^\{1\} false$
 ^EXIT=0$

--- a/regression/cbmc/unreachable-goto5/test-vccs.desc
+++ b/regression/cbmc/unreachable-goto5/test-vccs.desc
@@ -1,6 +1,6 @@
 CORE paths-lifo-expected-failure
 test.c
---show-vcc
+--show-vcc --verbosity 8
 ^Generated 1 VCC\(s\), 1 remaining after simplification$
 ^\{1\} false$
 ^EXIT=0$

--- a/regression/cbmc/unreachable-goto6/test-vccs.desc
+++ b/regression/cbmc/unreachable-goto6/test-vccs.desc
@@ -1,6 +1,6 @@
 CORE paths-lifo-expected-failure
 test.c
---show-vcc
+--show-vcc --verbosity 8
 ^Generated 1 VCC\(s\), 1 remaining after simplification$
 ^\{1\} false$
 ^EXIT=0$

--- a/regression/cbmc/xml-interface1/test.desc
+++ b/regression/cbmc/xml-interface1/test.desc
@@ -1,6 +1,6 @@
 CORE
 --xml-interface
-< test.xml
+--verbosity 8 < test.xml
 ^EXIT=10$
 ^SIGNAL=0$
 Not unwinding loop foo\.0 iteration 3 file main\.c line 5 function foo thread 0

--- a/regression/goto-analyzer/approx-const-fp-array-variable-const-fp-with-null/test.desc
+++ b/regression/goto-analyzer/approx-const-fp-array-variable-const-fp-with-null/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---show-goto-functions --pointer-check
+--show-goto-functions --pointer-check --verbosity 8
 ^Removal of function pointers and virtual functions$
 ^\s*IF .*::fp = address_of\(f2\) THEN GOTO [0-9]$
 ^\s*IF .*::fp = address_of\(f3\) THEN GOTO [0-9]$

--- a/regression/goto-analyzer/no-match-array-literal-const-fp-null/test.desc
+++ b/regression/goto-analyzer/no-match-array-literal-const-fp-null/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---show-goto-functions --pointer-check
+--show-goto-functions --pointer-check --verbosity 8
 ^Removal of function pointers and virtual functions$
 ^\s*ASSERT false // no candidates for dereferenced function pointer
 ^EXIT=0$

--- a/regression/goto-analyzer/no-match-const-fp-const-fp-null/test.desc
+++ b/regression/goto-analyzer/no-match-const-fp-const-fp-null/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---show-goto-functions --pointer-check
+--show-goto-functions --pointer-check --verbosity 8
 ^Removal of function pointers and virtual functions$
 ^\s*ASSERT false // no candidates for dereferenced function pointer
 ^EXIT=0$

--- a/regression/goto-analyzer/no-match-const-fp-const-pointer-const-struct-const-fp-null/test.desc
+++ b/regression/goto-analyzer/no-match-const-fp-const-pointer-const-struct-const-fp-null/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---show-goto-functions --pointer-check
+--show-goto-functions --pointer-check --verbosity 8
 ^Removal of function pointers and virtual functions$
 ^\s*ASSERT false // dereferenced function pointer must be one of \[(f[1-9], ){8}f[1-9]\]$
 replacing function pointer by 9 possible targets

--- a/regression/goto-analyzer/no-match-const-fp-dereference-const-pointer-null/test.desc
+++ b/regression/goto-analyzer/no-match-const-fp-dereference-const-pointer-null/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---show-goto-functions --pointer-check
+--show-goto-functions --pointer-check --verbosity 8
 ^Removal of function pointers and virtual functions$
 ^\s*ASSERT false // dereferenced function pointer must be one of \[(f[1-9], ){8}f[1-9]\]$
 replacing function pointer by 9 possible targets

--- a/regression/goto-analyzer/no-match-const-fp-null/test.desc
+++ b/regression/goto-analyzer/no-match-const-fp-null/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---show-goto-functions --pointer-check
+--show-goto-functions --pointer-check --verbosity 8
 ^Removal of function pointers and virtual functions$
 ^\s*ASSERT false // no candidates for dereferenced function pointer
 function func: replacing function pointer by 0 possible targets

--- a/regression/goto-analyzer/no-match-const-struct-non-const-fp-null/test.desc
+++ b/regression/goto-analyzer/no-match-const-struct-non-const-fp-null/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---show-goto-functions --pointer-check
+--show-goto-functions --pointer-check --verbosity 8
 ^Removal of function pointers and virtual functions$
 ^\s*ASSERT false // no candidates for dereferenced function pointer
 ^EXIT=0$

--- a/regression/goto-analyzer/value-set-function-pointers-arrays/test.desc
+++ b/regression/goto-analyzer/value-set-function-pointers-arrays/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---variable-sensitivity --vsd-structs every-field --vsd-arrays every-element --vsd-pointers value-set --vsd-values set-of-constants --show --pointer-check --three-way-merge
+--variable-sensitivity --vsd-structs every-field --vsd-arrays every-element --vsd-pointers value-set --vsd-values set-of-constants --show --pointer-check --three-way-merge --verbosity 8
 ^file main.c line 29 function main: replacing function pointer by 2 possible targets$
 ^file main.c line 40 function main: replacing function pointer by 2 possible targets$
 ^main::1::fun1 \(\) -> value-set-begin: ptr ->\(f\), ptr ->\(g\) :value-set-end

--- a/regression/goto-analyzer/value-set-function-pointers-incremented-01/test.desc
+++ b/regression/goto-analyzer/value-set-function-pointers-incremented-01/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---variable-sensitivity --vsd-values set-of-constants --vsd-structs every-field --vsd-arrays every-element --vsd-pointers value-set --show --pointer-check
+--variable-sensitivity --vsd-values set-of-constants --vsd-structs every-field --vsd-arrays every-element --vsd-pointers value-set --show --pointer-check --verbosity 8
 ^file main.c line 28 function main: replacing function pointer by 2 possible targets$
 ^main::1::fun_incremented_show \(\) -> value-set-begin: TOP :value-set-end
 ^EXIT=0$

--- a/regression/goto-analyzer/value-set-function-pointers-incremented-02/test.desc
+++ b/regression/goto-analyzer/value-set-function-pointers-incremented-02/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---variable-sensitivity --vsd-values set-of-constants --vsd-structs every-field --vsd-arrays every-element --vsd-pointers value-set --show --pointer-check
+--variable-sensitivity --vsd-values set-of-constants --vsd-structs every-field --vsd-arrays every-element --vsd-pointers value-set --show --pointer-check --verbosity 8
 ^file main.c line 32 function main: replacing function pointer by 3 possible targets$
 ^main::1::fun_incremented_show \(\) -> value-set-begin: TOP, ptr ->\(h\) :value-set-end
 ^EXIT=0$

--- a/regression/goto-analyzer/value-set-function-pointers-simple/test.desc
+++ b/regression/goto-analyzer/value-set-function-pointers-simple/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---variable-sensitivity --vsd-structs every-field --vsd-arrays every-element --vsd-pointers value-set --vsd-values set-of-constants --show --pointer-check --three-way-merge
+--variable-sensitivity --vsd-structs every-field --vsd-arrays every-element --vsd-pointers value-set --vsd-values set-of-constants --show --pointer-check --three-way-merge --verbosity 8
 ^file main.c line 25 function main: replacing function pointer by 2 possible targets$
 ^file main.c line 28 function main: replacing function pointer by 2 possible targets$
 ^file main.c line 33 function main: replacing function pointer by 2 possible targets$

--- a/regression/goto-analyzer/value-set-function-pointers-structs/test.desc
+++ b/regression/goto-analyzer/value-set-function-pointers-structs/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---variable-sensitivity --vsd-structs every-field --vsd-arrays every-element --vsd-pointers value-set --vsd-values set-of-constants --show --pointer-check
+--variable-sensitivity --vsd-structs every-field --vsd-arrays every-element --vsd-pointers value-set --vsd-values set-of-constants --show --pointer-check --verbosity 8
 ^file main.c line 38 function main: replacing function pointer by 2 possible targets$
 ^file main.c line 46 function main: replacing function pointer by 2 possible targets$
 ^file main.c line 54 function main: replacing function pointer by 2 possible targets$

--- a/regression/goto-instrument/unwind-continue-as-loops1/test.desc
+++ b/regression/goto-instrument/unwind-continue-as-loops1/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---unwind 5 --continue-as-loops
+--verbosity 10 --unwind 5 --continue-as-loops _ --verbosity 8
 ^Unwinding loop.*iteration 5
 ^EXIT=0$
 ^SIGNAL=0$

--- a/regression/goto-instrument/unwind-unwindset2/test.desc
+++ b/regression/goto-instrument/unwind-unwindset2/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---unwindset main.0:10 --unwinding-assertions
+--unwindset main.0:10 --unwinding-assertions _ --verbosity 8
 ^Unwinding loop
 ^EXIT=0$
 ^SIGNAL=0$

--- a/regression/goto-instrument/unwind-unwindset3/test.desc
+++ b/regression/goto-instrument/unwind-unwindset3/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---unwind 10 --unwindset main.0:
+--unwind 10 --unwindset main.0: _ --verbosity 8
 ^Unwinding loop
 ^EXIT=0$
 ^SIGNAL=0$

--- a/regression/goto-instrument/unwind-zero-unwind2/test.desc
+++ b/regression/goto-instrument/unwind-zero-unwind2/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---unwind 0 --continue-as-loops
+--unwind 0 --continue-as-loops _ --verbosity 8
 ^Unwinding loop.*iteration 10
 ^EXIT=0$
 ^SIGNAL=0$

--- a/regression/goto-instrument/value-set-fi-fp-removal4/test.desc
+++ b/regression/goto-instrument/value-set-fi-fp-removal4/test.desc
@@ -1,6 +1,6 @@
 CORE
 test.c
---value-set-fi-fp-removal _ --no-standard-checks
+--value-set-fi-fp-removal --verbosity 8 _ --no-standard-checks
 ^EXIT=10$
 ^SIGNAL=0$
 ^file test.c line 20 function main: replacing function pointer by 2 possible targets$

--- a/regression/goto-instrument/value-set-fi-fp-removal5/test.desc
+++ b/regression/goto-instrument/value-set-fi-fp-removal5/test.desc
@@ -1,6 +1,6 @@
 CORE
 test.c
---value-set-fi-fp-removal _ --no-standard-checks
+--value-set-fi-fp-removal --verbosity 8 _ --no-standard-checks
 ^EXIT=10$
 ^SIGNAL=0$
 ^file test.c line 19 function main: replacing function pointer by 0 possible targets$

--- a/src/cbmc/cbmc_parse_options.cpp
+++ b/src/cbmc/cbmc_parse_options.cpp
@@ -500,7 +500,7 @@ int cbmc_parse_optionst::doit()
   get_command_line_options(options);
 
   messaget::eval_verbosity(
-    cmdline.get_value("verbosity"), messaget::M_STATISTICS, ui_message_handler);
+    cmdline.get_value("verbosity"), messaget::M_STATUS, ui_message_handler);
 
   log_version_and_architecture("CBMC");
 
@@ -1081,7 +1081,7 @@ void cbmc_parse_optionst::help()
     HELP_JSON_INTERFACE
     HELP_GOTO_TRACE
     HELP_FLUSH
-    " {y--verbosity} {u#} \t verbosity level\n"
+    " {y--verbosity} {u#} \t verbosity level (default 6)\n"
     HELP_TIMESTAMP
     "\n");
   // clang-format on

--- a/src/goto-analyzer/goto_analyzer_parse_options.cpp
+++ b/src/goto-analyzer/goto_analyzer_parse_options.cpp
@@ -408,7 +408,7 @@ int goto_analyzer_parse_optionst::doit()
   optionst options;
   get_command_line_options(options);
   messaget::eval_verbosity(
-    cmdline.get_value("verbosity"), messaget::M_STATISTICS, ui_message_handler);
+    cmdline.get_value("verbosity"), messaget::M_STATUS, ui_message_handler);
 
   log_version_and_architecture("GOTO-ANALYZER");
 

--- a/src/goto-diff/goto_diff_parse_options.cpp
+++ b/src/goto-diff/goto_diff_parse_options.cpp
@@ -85,7 +85,7 @@ int goto_diff_parse_optionst::doit()
   optionst options;
   get_command_line_options(options);
   messaget::eval_verbosity(
-    cmdline.get_value("verbosity"), messaget::M_STATISTICS, ui_message_handler);
+    cmdline.get_value("verbosity"), messaget::M_STATUS, ui_message_handler);
 
   log_version_and_architecture("GOTO-DIFF");
 

--- a/src/goto-instrument/goto_instrument_parse_options.cpp
+++ b/src/goto-instrument/goto_instrument_parse_options.cpp
@@ -125,7 +125,7 @@ int goto_instrument_parse_optionst::doit()
   }
 
   messaget::eval_verbosity(
-    cmdline.get_value("verbosity"), messaget::M_STATISTICS, ui_message_handler);
+    cmdline.get_value("verbosity"), messaget::M_STATUS, ui_message_handler);
 
   {
     register_languages();

--- a/src/goto-synthesizer/goto_synthesizer_parse_options.cpp
+++ b/src/goto-synthesizer/goto_synthesizer_parse_options.cpp
@@ -58,7 +58,7 @@ int goto_synthesizer_parse_optionst::doit()
   }
 
   messaget::eval_verbosity(
-    cmdline.get_value("verbosity"), messaget::M_STATISTICS, ui_message_handler);
+    cmdline.get_value("verbosity"), messaget::M_STATUS, ui_message_handler);
 
   register_languages();
 

--- a/src/symtab2gb/symtab2gb_parse_options.cpp
+++ b/src/symtab2gb/symtab2gb_parse_options.cpp
@@ -66,7 +66,7 @@ static void run_symtab2gb(
 
   stream_message_handlert message_handler{std::cerr};
   messaget::eval_verbosity(
-    cmdline_verbosity, messaget::M_STATISTICS, message_handler);
+    cmdline_verbosity, messaget::M_STATUS, message_handler);
 
   auto const symtab_language = new_json_symtab_language();
 


### PR DESCRIPTION
This changes the default verbosity from `M_STATISTICS` to `M_STATUS`, in an effort to reduce the amount of console output.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
