### PR TITLE
increase verbosity of warning about missing `__builtin_` declaration

### DIFF
--- a/src/ansi-c/c_typecheck_expr.cpp
+++ b/src/ansi-c/c_typecheck_expr.cpp
@@ -2471,8 +2471,18 @@ void c_typecheck_baset::typecheck_side_effect_function_call(
         symbolt *symbol_ptr;
         move_symbol(new_symbol, symbol_ptr);
 
-        warning().source_location=f_op.find_source_location();
-        warning() << "function '" << identifier << "' is not declared" << eom;
+        // We increase the verbosity level of the warning
+        // for gcc/clang __builtin_ functions, since there are too many.
+        if(identifier.starts_with("__builtin_"))
+        {
+          debug().source_location = f_op.find_source_location();
+          debug() << "builtin '" << identifier << "' is unknown" << eom;
+        }
+        else
+        {
+          warning().source_location = f_op.find_source_location();
+          warning() << "function '" << identifier << "' is not declared" << eom;
+        }
       }
     }
   }


### PR DESCRIPTION
The `__builtin_` declarations of gcc and clang are highly version-specific, and constantly changing.  User see a lot of warnings about missing declarations of `__builtin_` functions owing to compiler header files that use these builtins in inline wrappers.  This increases the verbosity level of these warnings to "debug".

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
