### PR TITLE
add `emscripten` architecture

### DIFF
--- a/src/util/config.cpp
+++ b/src/util/config.cpp
@@ -701,6 +701,35 @@ void configt::ansi_ct::set_arch_spec_loongarch64()
   }
 }
 
+void configt::ansi_ct::set_arch_spec_emscripten()
+{
+  set_ILP32();
+  endianness = endiannesst::IS_LITTLE_ENDIAN;
+  long_double_width = 16 * 8;
+  char_is_unsigned = false;
+  NULL_is_zero = true;
+
+  switch(mode)
+  {
+  case flavourt::CLANG:
+    defines.push_back("__EMSCRIPTEN__");
+    break;
+
+  case flavourt::VISUAL_STUDIO:
+    UNREACHABLE; // not supported by Visual Studio
+    break;
+
+  case flavourt::GCC:
+  case flavourt::CODEWARRIOR:
+  case flavourt::ARM:
+  case flavourt::ANSI:
+    break;
+
+  case flavourt::NONE:
+    UNREACHABLE;
+  }
+}
+
 configt::ansi_ct::c_standardt configt::ansi_ct::default_c_standard()
 {
 #if defined(__APPLE__)
@@ -787,6 +816,8 @@ void configt::set_arch(const irep_idt &arch)
     ansi_c.set_arch_spec_i386();
   else if(arch == "loongarch64")
     ansi_c.set_arch_spec_loongarch64();
+  else if(arch == "emscripten")
+    ansi_c.set_arch_spec_emscripten();
   else
   {
     // We run on something new and unknown.
@@ -1482,6 +1513,8 @@ irep_idt configt::this_architecture()
     this_arch = "sh4";
   #elif defined(__loongarch__)
     this_arch = "loongarch64";
+  #elif defined(__EMSCRIPTEN__)
+    this_arch = "emscripten";
   #else
     // something new and unknown!
     this_arch = "unknown";
@@ -1527,6 +1560,8 @@ irep_idt configt::this_operating_system()
   this_os="solaris";
 #elif __gnu_hurd__
   this_os = "hurd";
+#elif __EMSCRIPTEN__
+  this_os = "emscripten";
 #else
   this_os="unknown";
 #endif

--- a/src/util/config.h
+++ b/src/util/config.h
@@ -241,6 +241,7 @@ public:
     void set_arch_spec_hppa();
     void set_arch_spec_sh4();
     void set_arch_spec_loongarch64();
+    void set_arch_spec_emscripten();
 
     enum class flavourt
     {


### PR DESCRIPTION
This adds support for the architecture created by the `emcc` (emscripten) compiler, which largely resembles 32-bit Unix.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
