### PR TITLE
Disable self-loops-to-assumptions when unwinding assertions are on

### DIFF
--- a/jbmc/src/jbmc/jbmc_parse_options.cpp
+++ b/jbmc/src/jbmc/jbmc_parse_options.cpp
@@ -250,7 +250,8 @@ void jbmc_parse_optionst::get_command_line_options(optionst &options)
   // transform self loops to assumptions
   options.set_option(
     "self-loops-to-assumptions",
-    !cmdline.isset("no-self-loops-to-assumptions"));
+    !options.get_bool_option("unwinding-assertions") &&
+      !cmdline.isset("no-self-loops-to-assumptions"));
 
   // unwind loops in java enum static initialization
   if(cmdline.isset("java-unwind-enum-static"))

--- a/src/cbmc/cbmc_parse_options.cpp
+++ b/src/cbmc/cbmc_parse_options.cpp
@@ -379,7 +379,8 @@ void cbmc_parse_optionst::get_command_line_options(optionst &options)
   // transform self loops to assumptions
   options.set_option(
     "self-loops-to-assumptions",
-    !cmdline.isset("no-self-loops-to-assumptions"));
+    !options.get_bool_option("unwinding-assertions") &&
+      !cmdline.isset("no-self-loops-to-assumptions"));
 
   // all (other) checks supported by goto_check
   PARSE_OPTIONS_GOTO_CHECK(cmdline, options);

--- a/src/goto-checker/bmc_util.h
+++ b/src/goto-checker/bmc_util.h
@@ -228,7 +228,7 @@ void run_property_decider(
   "used with {y--cover})\n"                                                    \
   " {y--partial-loops} \t permit paths with partial loops\n"                   \
   " {y--no-self-loops-to-assumptions} \t do not simplify while(1){ {}} to "    \
-  "assume(0)\n"                                                                \
+  "assume(0), only effective with {y--no-unwinding-assertions}\n"              \
   " {y--symex-complexity-limit} {uN} \t "                                      \
   "how complex ({uN}) a path can become before symex abandons it. Currently "  \
   "uses guard size to calculate complexity.\n"                                 \


### PR DESCRIPTION
We would fail to detect loop-unwinding failures despite having unwinding assertions enabled.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [x] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
