### PR TITLE
Union member fix

### DIFF
--- a/src/solvers/flattening/boolbv_member.cpp
+++ b/src/solvers/flattening/boolbv_member.cpp
@@ -18,8 +18,11 @@ static bvt convert_member_union(
   const namespacet &ns)
 {
   const exprt &union_op = expr.compound();
+
   const union_typet &union_op_type =
-    ns.follow_tag(to_union_tag_type(union_op.type()));
+    union_op.type().id() == ID_union_tag
+      ? ns.follow_tag(to_union_tag_type(union_op.type()))
+      : to_union_type(union_op.type());
 
   const irep_idt &component_name = expr.get_component_name();
   const union_typet::componentt &component =


### PR DESCRIPTION
`convert_member_union` now accepts a union-typed compound operand, as opposed
to requiring a union_tag type.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
