### PR TITLE
GOTO conversion: Declaration hops must not invalidate incomplete gotos

### DIFF
--- a/src/ansi-c/goto-conversion/goto_convert_class.h
+++ b/src/ansi-c/goto-conversion/goto_convert_class.h
@@ -354,7 +354,10 @@ protected:
     std::optional<node_indext> destructor_end_point = {},
     std::optional<node_indext> destructor_start_point = {});
 
-  void build_declaration_hops(
+  typedef std::list<
+    std::pair<goto_programt::targett, goto_programt::instructiont>>
+    declaration_hop_instrumentationt;
+  [[nodiscard]] declaration_hop_instrumentationt build_declaration_hops(
     goto_programt &dest,
     std::unordered_map<irep_idt, symbolt, irep_id_hash> &label_flags,
     const build_declaration_hops_inputst &inputs);


### PR DESCRIPTION
Declaration hops are built as part of finish_gotos, and must not invalidate goto-instructions that are yet to be finished. To accomplish this, collect all instructions that are to be inserted and do the insertion after having finished all gotos.

Bug was observed when invoking CBMC from Kani.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
