### PR TITLE
add two helpers for bv_typet

### DIFF
--- a/src/util/bitvector_types.cpp
+++ b/src/util/bitvector_types.cpp
@@ -16,6 +16,18 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "std_expr.h"
 #include "string2int.h"
 
+constant_exprt bv_typet::all_zeros_expr() const
+{
+  return constant_exprt{
+    make_bvrep(get_width(), [](std::size_t) { return false; }), *this};
+}
+
+constant_exprt bv_typet::all_ones_expr() const
+{
+  return constant_exprt{
+    make_bvrep(get_width(), [](std::size_t) { return true; }), *this};
+}
+
 std::size_t fixedbv_typet::get_integer_bits() const
 {
   const irep_idt integer_bits = get(ID_integer_bits);

--- a/src/util/bitvector_types.h
+++ b/src/util/bitvector_types.h
@@ -60,6 +60,10 @@ public:
     DATA_CHECK(
       vm, !type.get(ID_width).empty(), "bitvector type must have width");
   }
+
+  // helpers to create common constants
+  constant_exprt all_zeros_expr() const;
+  constant_exprt all_ones_expr() const;
 };
 
 /// Check whether a reference to a typet is a \ref bv_typet.

--- a/src/util/lower_byte_operators.cpp
+++ b/src/util/lower_byte_operators.cpp
@@ -579,7 +579,7 @@ static exprt unpack_array_vector(
         numeric_cast_v<std::size_t>(std::min(
           *offset_bytes - (*offset_bytes % el_bytes),
           *num_elements * el_bytes)),
-        from_integer(0, bv_typet{bits_per_byte}));
+        bv_typet{bits_per_byte}.all_zeros_expr());
     }
   }
 
@@ -791,7 +791,7 @@ static array_exprt unpack_struct(
       byte_operands.resize(
         byte_operands.size() +
           numeric_cast_v<std::size_t>(*component_bits / bits_per_byte),
-        from_integer(0, bv_typet{bits_per_byte}));
+        bv_typet{bits_per_byte}.all_zeros_expr());
     }
     else
     {
@@ -2417,7 +2417,7 @@ static exprt lower_byte_update(
     if(bit_width > type_bits)
     {
       val_before = concatenation_exprt{
-        from_integer(0, bv_typet{bit_width - type_bits}),
+        bv_typet{bit_width - type_bits}.all_zeros_expr(),
         val_before,
         bv_typet{bit_width}};
 
@@ -2492,7 +2492,7 @@ static exprt lower_byte_update(
     if(bit_width > update_size_bits)
     {
       zero_extended = concatenation_exprt{
-        from_integer(0, bv_typet{bit_width - update_size_bits}),
+        bv_typet{bit_width - update_size_bits}.all_zeros_expr(),
         value,
         bv_typet{bit_width}};
 


### PR DESCRIPTION
`bv_typet` is meant for bit-vectors without numerical interpretation, e.g., when constructing bit-masks.  This adds two helper methods for creating a `bv`-typed constant with the frequently used bit patterns 0...0 and 1...1.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
