### PR TITLE
reduce default verbosity of cprover binary

### DIFF
--- a/src/cprover/cprover_parse_options.cpp
+++ b/src/cprover/cprover_parse_options.cpp
@@ -135,6 +135,11 @@ int cprover_parse_optionst::main()
     console_message_handlert message_handler;
     null_message_handlert null_message_handler;
 
+    if(cmdline.isset("verbose"))
+      message_handler.set_verbosity(messaget::M_PROGRESS);
+    else
+      message_handler.set_verbosity(messaget::M_STATUS);
+
     optionst options;
     auto goto_model =
       initialize_goto_model(cmdline.args, message_handler, options);


### PR DESCRIPTION
This sets a new default for the verbosity of the `cprover` binary, to match the level of the `cbmc` binary.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
