### PR TITLE
reduce verbosity of runtime messages

### DIFF
--- a/regression/cbmc/Failing_Assert1/dimacs.desc
+++ b/regression/cbmc/Failing_Assert1/dimacs.desc
@@ -1,6 +1,6 @@
 CORE no-new-smt
 main.c
---dimacs
+--dimacs --verbosity 8
 ^Runtime decision procedure: [0-9]+(\.[0-9]+)?(e-[0-9]+)?s$
 ^c main::1::i!0@1#1
 ^c main::1::j!0@1#1

--- a/src/goto-checker/bmc_util.cpp
+++ b/src/goto-checker/bmc_util.cpp
@@ -407,16 +407,16 @@ void run_property_decider(
   auto const sat_solver_stop = std::chrono::steady_clock::now();
   std::chrono::duration<double> sat_solver_runtime =
     std::chrono::duration<double>(sat_solver_stop - sat_solver_start);
-  log.status() << "Runtime Solver: " << sat_solver_runtime.count() << "s"
-               << messaget::eom;
+  log.statistics() << "Runtime Solver: " << sat_solver_runtime.count() << "s"
+                   << messaget::eom;
 
   property_decider.update_properties_status_from_goals(
     properties, result.updated_properties, dec_result, set_pass);
 
   auto solver_stop = std::chrono::steady_clock::now();
   solver_runtime += std::chrono::duration<double>(solver_stop - solver_start);
-  log.status() << "Runtime decision procedure: " << solver_runtime.count()
-               << "s" << messaget::eom;
+  log.statistics() << "Runtime decision procedure: " << solver_runtime.count()
+                   << "s" << messaget::eom;
 
   if(dec_result == decision_proceduret::resultt::D_SATISFIABLE)
   {

--- a/src/goto-symex/symex_target_equation.cpp
+++ b/src/goto-symex/symex_target_equation.cpp
@@ -354,8 +354,8 @@ void symex_target_equationt::convert(decision_proceduret &decision_procedure)
   const auto convert_SSA_stop = std::chrono::steady_clock::now();
   std::chrono::duration<double> convert_SSA_runtime =
     std::chrono::duration<double>(convert_SSA_stop - convert_SSA_start);
-  log.status() << "Runtime Convert SSA: " << convert_SSA_runtime.count() << "s"
-               << messaget::eom;
+  log.statistics() << "Runtime Convert SSA: " << convert_SSA_runtime.count()
+                   << "s" << messaget::eom;
 }
 
 void symex_target_equationt::convert_assignments(


### PR DESCRIPTION
The time taken for particular steps is statistics, not status.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
