### PR TITLE
[CONTRACTS] Add loop-contract symbols into symbol table during typecheck

### DIFF
--- a/src/linking/remove_internal_symbols.cpp
+++ b/src/linking/remove_internal_symbols.cpp
@@ -43,8 +43,12 @@ static void get_symbols(
 
     find_symbols_sett new_symbols;
 
-    find_type_and_expr_symbols(symbol.type, new_symbols);
-    find_type_and_expr_symbols(symbol.value, new_symbols);
+    // ID of named subs of loop contracts
+    std::vector<irep_idt> loop_contracts_subs{
+      ID_C_spec_loop_invariant, ID_C_spec_decreases};
+
+    find_type_and_expr_symbols(symbol.type, new_symbols, loop_contracts_subs);
+    find_type_and_expr_symbols(symbol.value, new_symbols, loop_contracts_subs);
 
     for(const auto &s : new_symbols)
       working_set.push_back(&ns.lookup(s));

--- a/src/util/find_symbols.h
+++ b/src/util/find_symbols.h
@@ -79,16 +79,20 @@ void find_non_pointer_type_symbols(
   const exprt &src,
   find_symbols_sett &dest);
 
-/// Find identifiers of the sub expressions with id ID_symbol, considering both
-/// free and bound variables, as well as any type tags.
+/// Find identifiers with id ID_symbol of the sub expressions and the subs with
+/// ID in \p subs_to_find
+/// considering both free and bound variables, as well as any type tags.
 void find_type_and_expr_symbols(
   const typet &src,
-  find_symbols_sett &dest);
+  find_symbols_sett &dest,
+  const std::vector<irep_idt> &subs_to_find = {});
 
-/// Find identifiers of the sub expressions with id ID_symbol, considering both
-/// free and bound variables, as well as any type tags.
+/// Find identifiers with id ID_symbol of the sub expressions and the subs with
+/// ID in \p subs_to_find
+/// considering both free and bound variables, as well as any type tags.
 void find_type_and_expr_symbols(
   const exprt &src,
-  find_symbols_sett &dest);
+  find_symbols_sett &dest,
+  const std::vector<irep_idt> &subs_to_find = {});
 
 #endif // CPROVER_UTIL_FIND_SYMBOLS_H


### PR DESCRIPTION
<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

Currently, when type-checking functions with contracts, we only keep function contracts symbols (see https://github.com/diffblue/cbmc/blob/develop/src/linking/remove_internal_symbols.cpp#L69). It was OK as there couldn't be any new symbol declared in loop contracts. However, if we want to support statement expressions or pure functions in loop contracts, we shouldn't remove loop contract symbols during type checking.

This PR will keep symbols in loop contracts---not removing them in `remove_internal_symbols`. In detail, we not only find symbols in sub-expressions (`find_symbols`) but also find symbols in given named subs (`find_symbols_in_expr_and_subs`) when finding symbols to keep.

The test of #8360 covers the change of this PR.

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
