### PR TITLE
[CONTRACTS] Check side effect of loop contracts during instrumentation

### DIFF
--- a/doc/man/goto-instrument.1
+++ b/doc/man/goto-instrument.1
@@ -1015,7 +1015,13 @@ force aggressive slicer to preserve all direct paths
 .SS "Code contracts:"
 .TP
 \fB\-\-apply\-loop\-contracts\fR
-check and use loop contracts when provided
+.TP
+\fB\-disable\-loop\-contracts\-side\-effect\-check\fR
+UNSOUND OPTION. Disable checking the absence of side effects in loop
+contract clauses. In absence of such checking, loop contracts clauses will
+accept more expressions, such as pure functions and statement expressions.
+But user have to make sure the loop contracts are side-effect free by them self
+to get a sound result.
 .TP
 \fB\-loop\-contracts\-no\-unwind\fR
 do not unwind transformed loops

--- a/regression/contracts-dfcc/loop_contracts_statement_expression/main.c
+++ b/regression/contracts-dfcc/loop_contracts_statement_expression/main.c
@@ -1,0 +1,16 @@
+int main()
+{
+  unsigned i;
+
+  while(i > 1)
+    __CPROVER_loop_invariant(({
+      unsigned b = i >= 1;
+      goto label;
+      b = i < 1;
+    label:
+      b;
+    }))
+    {
+      i--;
+    }
+}

--- a/regression/contracts-dfcc/loop_contracts_statement_expression/test.desc
+++ b/regression/contracts-dfcc/loop_contracts_statement_expression/test.desc
@@ -1,0 +1,10 @@
+CORE
+main.c
+--dfcc main --apply-loop-contracts --disable-loop-contracts-side-effect-check
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+--
+This test demonstrates a case where the loop invariant
+is a side-effect free statement expression.

--- a/regression/contracts-dfcc/variant_function_call_fail/test.desc
+++ b/regression/contracts-dfcc/variant_function_call_fail/test.desc
@@ -1,8 +1,8 @@
 CORE
 main.c
 --dfcc main --apply-loop-contracts
-^Decreases clause is not side-effect free. \(at: file main.c line .* function main\)$
-^EXIT=70$
+^Decreases clause is not side-effect free.$
+^EXIT=6$
 ^SIGNAL=0$
 --
 --

--- a/regression/contracts-dfcc/variant_side_effects_fail/test.desc
+++ b/regression/contracts-dfcc/variant_side_effects_fail/test.desc
@@ -1,8 +1,8 @@
 CORE
 main.c
 --dfcc main --apply-loop-contracts
-^Decreases clause is not side-effect free. \(at: file main.c line .* function main\)$
-^EXIT=70$
+^Decreases clause is not side-effect free.$
+^EXIT=6$
 ^SIGNAL=0$
 --
 --

--- a/regression/contracts/loop_contracts_statement_expression/main.c
+++ b/regression/contracts/loop_contracts_statement_expression/main.c
@@ -1,0 +1,16 @@
+int main()
+{
+  unsigned i;
+
+  while(i > 1)
+    __CPROVER_loop_invariant(({
+      unsigned b = i >= 1;
+      goto label;
+      b = i < 1;
+    label:
+      b;
+    }))
+    {
+      i--;
+    }
+}

--- a/regression/contracts/loop_contracts_statement_expression/test.desc
+++ b/regression/contracts/loop_contracts_statement_expression/test.desc
@@ -1,0 +1,10 @@
+CORE
+main.c
+--apply-loop-contracts --disable-loop-contracts-side-effect-check
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+--
+This test demonstrates a case where the loop invariant
+is a side-effect free statement expression.

--- a/src/ansi-c/goto-conversion/goto_convert.cpp
+++ b/src/ansi-c/goto-conversion/goto_convert.cpp
@@ -1036,12 +1036,6 @@ void goto_convertt::convert_loop_contracts(
     static_cast<const exprt &>(code.find(ID_C_spec_loop_invariant));
   if(!invariant.is_nil())
   {
-    if(has_subexpr(invariant, ID_side_effect))
-    {
-      throw incorrect_goto_program_exceptiont(
-        "Loop invariant is not side-effect free.", code.find_source_location());
-    }
-
     PRECONDITION(loop->is_goto() || loop->is_incomplete_goto());
     loop->condition_nonconst().add(ID_C_spec_loop_invariant).swap(invariant);
   }
@@ -1050,13 +1044,6 @@ void goto_convertt::convert_loop_contracts(
     static_cast<const exprt &>(code.find(ID_C_spec_decreases));
   if(!decreases_clause.is_nil())
   {
-    if(has_subexpr(decreases_clause, ID_side_effect))
-    {
-      throw incorrect_goto_program_exceptiont(
-        "Decreases clause is not side-effect free.",
-        code.find_source_location());
-    }
-
     PRECONDITION(loop->is_goto() || loop->is_incomplete_goto());
     loop->condition_nonconst().add(ID_C_spec_decreases).swap(decreases_clause);
   }

--- a/src/cprover/instrument_given_invariants.cpp
+++ b/src/cprover/instrument_given_invariants.cpp
@@ -11,6 +11,8 @@ Author: Daniel Kroening, dkr@amazon.com
 
 #include "instrument_given_invariants.h"
 
+#include <util/expr_util.h>
+
 #include <goto-programs/goto_model.h>
 
 void instrument_given_invariants(goto_functionst::function_mapt::value_type &f)
@@ -25,6 +27,15 @@ void instrument_given_invariants(goto_functionst::function_mapt::value_type &f)
     {
       const auto &invariants = static_cast<const exprt &>(
         it->condition().find(ID_C_spec_loop_invariant));
+      if(!invariants.is_nil())
+      {
+        if(has_subexpr(invariants, ID_side_effect))
+        {
+          throw incorrect_goto_program_exceptiont(
+            "Loop invariant is not side-effect free.",
+            it->condition().find_source_location());
+        }
+      }
 
       for(const auto &invariant : invariants.operands())
       {

--- a/src/goto-instrument/contracts/contracts.cpp
+++ b/src/goto-instrument/contracts/contracts.cpp
@@ -983,12 +983,11 @@ void code_contractst::apply_loop_contract(
       goto_function.body, loop_head, goto_programt::make_skip());
     loop_end->set_target(loop_head);
 
-    exprt assigns_clause =
-      static_cast<const exprt &>(loop_end->condition().find(ID_C_spec_assigns));
-    exprt invariant = static_cast<const exprt &>(
-      loop_end->condition().find(ID_C_spec_loop_invariant));
-    exprt decreases_clause = static_cast<const exprt &>(
-      loop_end->condition().find(ID_C_spec_decreases));
+    exprt assigns_clause = get_loop_assigns(loop_end);
+    exprt invariant =
+      get_loop_invariants(loop_end, loop_contract_config.check_side_effect);
+    exprt decreases_clause =
+      get_loop_decreases(loop_end, loop_contract_config.check_side_effect);
 
     if(invariant.is_nil())
     {

--- a/src/goto-instrument/contracts/contracts.h
+++ b/src/goto-instrument/contracts/contracts.h
@@ -33,6 +33,11 @@ Date: February 2016
 #define HELP_LOOP_CONTRACTS                                                    \
   " {y--apply-loop-contracts} \t check and use loop contracts when provided\n"
 
+#define FLAG_DISABLE_SIDE_EFFECT_CHECK                                         \
+  "disable-loop-contracts-side-effect-check"
+#define HELP_DISABLE_SIDE_EFFECT_CHECK                                         \
+  " {y--disable-loop-contracts-side-effect-check} \t UNSOUND OPTION.\t "       \
+  " disable the check of side-effect of loop contracts\n"
 #define FLAG_LOOP_CONTRACTS_NO_UNWIND "loop-contracts-no-unwind"
 #define HELP_LOOP_CONTRACTS_NO_UNWIND                                          \
   " {y--loop-contracts-no-unwind} \t do not unwind transformed loops\n"

--- a/src/goto-instrument/contracts/utils.h
+++ b/src/goto-instrument/contracts/utils.h
@@ -313,6 +313,23 @@ get_loop_end(const unsigned int loop_number, goto_functiont &function);
 goto_programt::targett
 get_loop_head(const unsigned int loop_number, goto_functiont &function);
 
+/// Extract loop invariants from annotated loop end.
+/// Will check if the loop invariant is side-effect free if
+/// \p check_side_effect` is set.
+exprt get_loop_invariants(
+  const goto_programt::const_targett &loop_end,
+  const bool check_side_effect = true);
+
+/// Extract loop assigns from annotated loop end.
+exprt get_loop_assigns(const goto_programt::const_targett &loop_end);
+
+/// Extract loop decreases from annotated loop end.
+/// Will check if the loop decreases is side-effect free if
+/// \p check_side_effect` is set.
+exprt get_loop_decreases(
+  const goto_programt::const_targett &loop_end,
+  const bool check_side_effect = true);
+
 /// Annotate the invariants in `invariant_map` to their corresponding
 /// loops. Corresponding loops are specified by keys of `invariant_map`
 void annotate_invariants(

--- a/src/goto-instrument/goto_instrument_parse_options.cpp
+++ b/src/goto-instrument/goto_instrument_parse_options.cpp
@@ -1169,7 +1169,8 @@ void goto_instrument_parse_optionst::instrument_goto_program()
   // Initialize loop contract config from cmdline.
   loop_contract_configt loop_contract_config = {
     cmdline.isset(FLAG_LOOP_CONTRACTS),
-    !cmdline.isset(FLAG_LOOP_CONTRACTS_NO_UNWIND)};
+    !cmdline.isset(FLAG_LOOP_CONTRACTS_NO_UNWIND),
+    !cmdline.isset(FLAG_DISABLE_SIDE_EFFECT_CHECK)};
 
   if(
     cmdline.isset(FLAG_LOOP_CONTRACTS) &&
@@ -2029,6 +2030,7 @@ void goto_instrument_parse_optionst::help()
     "Code contracts:\n"
     HELP_DFCC
     HELP_LOOP_CONTRACTS
+    HELP_DISABLE_SIDE_EFFECT_CHECK
     HELP_LOOP_CONTRACTS_NO_UNWIND
     HELP_LOOP_CONTRACTS_FILE
     HELP_REPLACE_CALL

--- a/src/goto-instrument/goto_instrument_parse_options.h
+++ b/src/goto-instrument/goto_instrument_parse_options.h
@@ -102,6 +102,7 @@ Author: Daniel Kroening, kroening@kroening.com
   "(horn)(skip-loops):(model-argc-argv):" \
   OPT_DFCC \
   "(" FLAG_LOOP_CONTRACTS ")" \
+  "(" FLAG_DISABLE_SIDE_EFFECT_CHECK ")" \
   "(" FLAG_LOOP_CONTRACTS_NO_UNWIND ")" \
   "(" FLAG_LOOP_CONTRACTS_FILE "):" \
   "(" FLAG_REPLACE_CALL "):" \


### PR DESCRIPTION
<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

Now, CBMC check side effect of loop contracts in `goto_convertt` by rejecting all `side_effect_exprt`. However, we might want to accept side-effect loop contracts and remove the side effect during instrumentation, or accept `side_effect_exprt` which is actually side-effect free (see the added regression test of this PR as an example).

This PR postpone the check of side effect of loop contracts from code converting to the actual instrumentation time. It also provide a new options to disable the side-effect check.

This PR include the commit from #8359. The regression test added in this PR also test #8359 (introducing new symbols) and #8282 (containing a GOTO jump in the loop invariant). 

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
