### PR TITLE
GOTO conversion: create temporaries with minimal scope

### DIFF
--- a/regression/cbmc-cover/location14/test.desc
+++ b/regression/cbmc-cover/location14/test.desc
@@ -6,8 +6,9 @@ main.c
 ^\[main.coverage.1\] file main.c line 8 function main block 1.*: SATISFIED$
 ^\[main.coverage.2\] file main.c line 12 function main block 2.*: FAILED$
 ^\[main.coverage.3\] file main.c line 12 function main block 3.*: FAILED$
-^\[main.coverage.4\] file main.c line 13 function main block 4.*: SATISFIED$
+^\[main.coverage.4\] file main.c line 12 function main block 4.*: FAILED$
+^\[main.coverage.5\] file main.c line 13 function main block 5.*: SATISFIED$
 ^\[foo.coverage.1\] file main.c line 3 function foo block 1.*: FAILED$
-^\*\* 2 of 5 covered \(40.0%\)
+^\*\* 2 of 6 covered \(33.3%\)
 --
 ^warning: ignoring

--- a/regression/contracts/loop_contracts_do_while/test.desc
+++ b/regression/contracts/loop_contracts_do_while/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.c
 --apply-loop-contracts
 ^EXIT=0$
@@ -7,4 +7,3 @@ main.c
 --
 --
 This test checks that loop contracts work correctly on do/while loops.
-Fails because contracts are not yet supported on do while loops.

--- a/regression/cprover/safety/use_after_free1.desc
+++ b/regression/cprover/safety/use_after_free1.desc
@@ -4,5 +4,5 @@ use_after_free1.c
 ^EXIT=0$
 ^SIGNAL=0$
 ^\(\d+\) ∀ ς : state . S11\(ς\) ⇒ S12\(ς\[❝main::\$tmp::return_value_malloc❞:=allocate\(ς, 4\)\]\)$
-^\(\d+\) ∀ ς : state . S15\(ς\) ⇒ S16\(deallocate_state\(ς, cast\(ς\(❝main::1::p❞\), empty\*\)\)\)$
+^\(\d+\) ∀ ς : state . S16\(ς\) ⇒ S17\(deallocate_state\(ς, cast\(ς\(❝main::1::p❞\), empty\*\)\)\)$
 --

--- a/regression/goto-analyzer/branching-ge/test-always-constants.desc
+++ b/regression/goto-analyzer/branching-ge/test-always-constants.desc
@@ -3,6 +3,6 @@ main-always.c
 --no-standard-checks --variable-sensitivity --vsd-values constants --show
 ^EXIT=0$
 ^SIGNAL=0$
-^main::1::i .* TOP @ \[17, 19\]
-^main::1::p .* TOP @ \[3, 8, 14\]
+^main::1::i .* TOP @ \[23, 25\]
+^main::1::p .* TOP @ \[3, 9, 18\]
 --

--- a/regression/goto-analyzer/branching-ge/test-always-intervals.desc
+++ b/regression/goto-analyzer/branching-ge/test-always-intervals.desc
@@ -3,6 +3,6 @@ main-always.c
 --no-standard-checks --variable-sensitivity --vsd-values intervals --show
 ^EXIT=0$
 ^SIGNAL=0$
-^main::1::i .* \[5, 5\] @ \[17\]
-^main::1::p .* \[0, A\] @ \[3, 8, 14\]
+^main::1::i .* \[5, 5\] @ \[23\]
+^main::1::p .* \[0, A\] @ \[3, 9, 18\]
 --

--- a/regression/goto-analyzer/branching-ge/test-always-value-set.desc
+++ b/regression/goto-analyzer/branching-ge/test-always-value-set.desc
@@ -3,6 +3,6 @@ main-always.c
 --no-standard-checks --variable-sensitivity --vsd-values set-of-constants --show
 ^EXIT=0$
 ^SIGNAL=0$
-^main::1::i .* value-set-begin: 5 :value-set-end @ \[17\]
-^main::1::p .* value-set-begin: 0, 5, 10 :value-set-end @ \[3, 8, 14\]
+^main::1::i .* value-set-begin: 5 :value-set-end @ \[23\]
+^main::1::p .* value-set-begin: 0, 5, 10 :value-set-end @ \[3, 9, 18\]
 --

--- a/regression/goto-analyzer/branching-ge/test-indeterminate-constants.desc
+++ b/regression/goto-analyzer/branching-ge/test-indeterminate-constants.desc
@@ -3,6 +3,6 @@ main-indeterminate.c
 --no-standard-checks --variable-sensitivity --vsd-values constants --show
 ^EXIT=0$
 ^SIGNAL=0$
-^main::1::i .* TOP @ \[17, 19\]
-^main::1::p .* TOP @ \[3, 8, 14\]
+^main::1::i .* TOP @ \[23, 25\]
+^main::1::p .* TOP @ \[3, 9, 18\]
 --

--- a/regression/goto-analyzer/branching-ge/test-indeterminate-intervals.desc
+++ b/regression/goto-analyzer/branching-ge/test-indeterminate-intervals.desc
@@ -3,6 +3,6 @@ main-indeterminate.c
 --no-standard-checks --variable-sensitivity --vsd-values intervals --show
 ^EXIT=0$
 ^SIGNAL=0$
-^main::1::i .* \[FFFFFFFB, 5\] @ \[17, 19\]
-^main::1::p .* \[0, A\] @ \[3, 8, 14\]
+^main::1::i .* \[FFFFFFFB, 5\] @ \[23, 25\]
+^main::1::p .* \[0, A\] @ \[3, 9, 18\]
 --

--- a/regression/goto-analyzer/branching-ge/test-indeterminate-value-set.desc
+++ b/regression/goto-analyzer/branching-ge/test-indeterminate-value-set.desc
@@ -3,6 +3,6 @@ main-indeterminate.c
 --no-standard-checks --variable-sensitivity --vsd-values set-of-constants --show
 ^EXIT=0$
 ^SIGNAL=0$
-^main::1::i .* value-set-begin: 5, -5 :value-set-end @ \[17, 19\]
-^main::1::p .* value-set-begin: 0, 5, 10 :value-set-end @ \[3, 8, 14\]
+^main::1::i .* value-set-begin: 5, -5 :value-set-end @ \[23, 25\]
+^main::1::p .* value-set-begin: 0, 5, 10 :value-set-end @ \[3, 9, 18\]
 --

--- a/regression/goto-analyzer/branching-ge/test-never-constants.desc
+++ b/regression/goto-analyzer/branching-ge/test-never-constants.desc
@@ -3,6 +3,6 @@ main-never.c
 --no-standard-checks --variable-sensitivity --vsd-values constants --show
 ^EXIT=0$
 ^SIGNAL=0$
-^main::1::i .* TOP @ \[17, 19\]
-^main::1::p .* TOP @ \[3, 8, 14\]
+^main::1::i .* TOP @ \[23, 25\]
+^main::1::p .* TOP @ \[3, 9, 18\]
 --

--- a/regression/goto-analyzer/branching-ge/test-never-intervals.desc
+++ b/regression/goto-analyzer/branching-ge/test-never-intervals.desc
@@ -3,6 +3,6 @@ main-never.c
 --no-standard-checks --variable-sensitivity --vsd-values intervals --show
 ^EXIT=0$
 ^SIGNAL=0$
-^main::1::i .* \[FFFFFFFB, FFFFFFFB\] @ \[19\]
-^main::1::p .* \[0, A\] @ \[3, 8, 14\]
+^main::1::i .* \[FFFFFFFB, FFFFFFFB\] @ \[25\]
+^main::1::p .* \[0, A\] @ \[3, 9, 18\]
 --

--- a/regression/goto-analyzer/branching-ge/test-never-value-set.desc
+++ b/regression/goto-analyzer/branching-ge/test-never-value-set.desc
@@ -3,6 +3,6 @@ main-never.c
 --no-standard-checks --variable-sensitivity --vsd-values set-of-constants --show
 ^EXIT=0$
 ^SIGNAL=0$
-^main::1::i .* value-set-begin: -5 :value-set-end @ \[19\]
-^main::1::p .* value-set-begin: 0, 5, 10 :value-set-end @ \[3, 8, 14\]
+^main::1::i .* value-set-begin: -5 :value-set-end @ \[25\]
+^main::1::p .* value-set-begin: 0, 5, 10 :value-set-end @ \[3, 9, 18\]
 --

--- a/regression/goto-analyzer/branching-gt/test-always-constants.desc
+++ b/regression/goto-analyzer/branching-gt/test-always-constants.desc
@@ -3,6 +3,6 @@ main-always.c
 --no-standard-checks --variable-sensitivity --vsd-values constants --show
 ^EXIT=0$
 ^SIGNAL=0$
-^main::1::i .* TOP @ \[17, 19\]
-^main::1::p .* TOP @ \[3, 8, 14\]
+^main::1::i .* TOP @ \[23, 25\]
+^main::1::p .* TOP @ \[3, 9, 18\]
 --

--- a/regression/goto-analyzer/branching-gt/test-always-intervals.desc
+++ b/regression/goto-analyzer/branching-gt/test-always-intervals.desc
@@ -3,6 +3,6 @@ main-always.c
 --no-standard-checks --variable-sensitivity --vsd-values intervals --show
 ^EXIT=0$
 ^SIGNAL=0$
-^main::1::i .* \[5, 5\] @ \[17\]
-^main::1::p .* \[0, A\] @ \[3, 8, 14\]
+^main::1::i .* \[5, 5\] @ \[23\]
+^main::1::p .* \[0, A\] @ \[3, 9, 18\]
 --

--- a/regression/goto-analyzer/branching-gt/test-always-value-set.desc
+++ b/regression/goto-analyzer/branching-gt/test-always-value-set.desc
@@ -3,6 +3,6 @@ main-always.c
 --no-standard-checks --variable-sensitivity --vsd-values set-of-constants --show
 ^EXIT=0$
 ^SIGNAL=0$
-^main::1::i .* value-set-begin: 5 :value-set-end @ \[17\]
-^main::1::p .* value-set-begin: 0, 5, 10 :value-set-end @ \[3, 8, 14\]
+^main::1::i .* value-set-begin: 5 :value-set-end @ \[23\]
+^main::1::p .* value-set-begin: 0, 5, 10 :value-set-end @ \[3, 9, 18\]
 --

--- a/regression/goto-analyzer/branching-gt/test-indeterminate-constants.desc
+++ b/regression/goto-analyzer/branching-gt/test-indeterminate-constants.desc
@@ -3,6 +3,6 @@ main-indeterminate.c
 --no-standard-checks --variable-sensitivity --vsd-values constants --show
 ^EXIT=0$
 ^SIGNAL=0$
-^main::1::i .* TOP @ \[17, 19\]
-^main::1::p .* TOP @ \[3, 8, 14\]
+^main::1::i .* TOP @ \[23, 25\]
+^main::1::p .* TOP @ \[3, 9, 18\]
 --

--- a/regression/goto-analyzer/branching-gt/test-indeterminate-intervals.desc
+++ b/regression/goto-analyzer/branching-gt/test-indeterminate-intervals.desc
@@ -3,6 +3,6 @@ main-indeterminate.c
 --no-standard-checks --variable-sensitivity --vsd-values intervals --show
 ^EXIT=0$
 ^SIGNAL=0$
-^main::1::i .* \[FFFFFFFB, 5\] @ \[17, 19\]
-^main::1::p .* \[0, A\] @ \[3, 8, 14\]
+^main::1::i .* \[FFFFFFFB, 5\] @ \[23, 25\]
+^main::1::p .* \[0, A\] @ \[3, 9, 18\]
 --

--- a/regression/goto-analyzer/branching-gt/test-indeterminate-value-set.desc
+++ b/regression/goto-analyzer/branching-gt/test-indeterminate-value-set.desc
@@ -3,6 +3,6 @@ main-indeterminate.c
 --no-standard-checks --variable-sensitivity --vsd-values set-of-constants --show
 ^EXIT=0$
 ^SIGNAL=0$
-^main::1::i .* value-set-begin: 5, -5 :value-set-end @ \[17, 19\]
-^main::1::p .* value-set-begin: 0, 5, 10 :value-set-end @ \[3, 8, 14\]
+^main::1::i .* value-set-begin: 5, -5 :value-set-end @ \[23, 25\]
+^main::1::p .* value-set-begin: 0, 5, 10 :value-set-end @ \[3, 9, 18\]
 --

--- a/regression/goto-analyzer/branching-gt/test-never-constants.desc
+++ b/regression/goto-analyzer/branching-gt/test-never-constants.desc
@@ -3,6 +3,6 @@ main-never.c
 --no-standard-checks --variable-sensitivity --vsd-values constants --show
 ^EXIT=0$
 ^SIGNAL=0$
-^main::1::i .* TOP @ \[17, 19\]
-^main::1::p .* TOP @ \[3, 8, 14\]
+^main::1::i .* TOP @ \[23, 25\]
+^main::1::p .* TOP @ \[3, 9, 18\]
 --

--- a/regression/goto-analyzer/branching-gt/test-never-intervals.desc
+++ b/regression/goto-analyzer/branching-gt/test-never-intervals.desc
@@ -3,6 +3,6 @@ main-never.c
 --no-standard-checks --variable-sensitivity --vsd-values intervals --show
 ^EXIT=0$
 ^SIGNAL=0$
-^main::1::i .* \[FFFFFFFB, FFFFFFFB\] @ \[19\]
-^main::1::p .* \[0, A\] @ \[3, 8, 14\]
+^main::1::i .* \[FFFFFFFB, FFFFFFFB\] @ \[25\]
+^main::1::p .* \[0, A\] @ \[3, 9, 18\]
 --

--- a/regression/goto-analyzer/branching-gt/test-never-value-set.desc
+++ b/regression/goto-analyzer/branching-gt/test-never-value-set.desc
@@ -3,6 +3,6 @@ main-never.c
 --no-standard-checks --variable-sensitivity --vsd-values set-of-constants --show
 ^EXIT=0$
 ^SIGNAL=0$
-^main::1::i .* value-set-begin: -5 :value-set-end @ \[19\]
-^main::1::p .* value-set-begin: 0, 5, 10 :value-set-end @ \[3, 8, 14\]
+^main::1::i .* value-set-begin: -5 :value-set-end @ \[25\]
+^main::1::p .* value-set-begin: 0, 5, 10 :value-set-end @ \[3, 9, 18\]
 --

--- a/regression/goto-analyzer/branching-le/test-always-constants.desc
+++ b/regression/goto-analyzer/branching-le/test-always-constants.desc
@@ -3,6 +3,6 @@ main-always.c
 --no-standard-checks --variable-sensitivity --vsd-values constants --show
 ^EXIT=0$
 ^SIGNAL=0$
-^main::1::i .* TOP @ \[17, 19\]
-^main::1::p .* TOP @ \[3, 8, 14\]
+^main::1::i .* TOP @ \[23, 25\]
+^main::1::p .* TOP @ \[3, 9, 18\]
 --

--- a/regression/goto-analyzer/branching-le/test-always-intervals.desc
+++ b/regression/goto-analyzer/branching-le/test-always-intervals.desc
@@ -3,6 +3,6 @@ main-always.c
 --no-standard-checks --variable-sensitivity --vsd-values intervals --show
 ^EXIT=0$
 ^SIGNAL=0$
-^main::1::i .* \[5, 5\] @ \[17\]
-^main::1::p .* \[0, A\] @ \[3, 8, 14\]
+^main::1::i .* \[5, 5\] @ \[23\]
+^main::1::p .* \[0, A\] @ \[3, 9, 18\]
 --

--- a/regression/goto-analyzer/branching-le/test-always-value-set.desc
+++ b/regression/goto-analyzer/branching-le/test-always-value-set.desc
@@ -3,6 +3,6 @@ main-always.c
 --no-standard-checks --variable-sensitivity --vsd-values set-of-constants --show
 ^EXIT=0$
 ^SIGNAL=0$
-^main::1::i .* value-set-begin: 5 :value-set-end @ \[17\]
-^main::1::p .* value-set-begin: 0, 5, 10 :value-set-end @ \[3, 8, 14\]
+^main::1::i .* value-set-begin: 5 :value-set-end @ \[23\]
+^main::1::p .* value-set-begin: 0, 5, 10 :value-set-end @ \[3, 9, 18\]
 --

--- a/regression/goto-analyzer/branching-le/test-indeterminate-constants.desc
+++ b/regression/goto-analyzer/branching-le/test-indeterminate-constants.desc
@@ -3,6 +3,6 @@ main-indeterminate.c
 --no-standard-checks --variable-sensitivity --vsd-values constants --show
 ^EXIT=0$
 ^SIGNAL=0$
-^main::1::i .* TOP @ \[17, 19\]
-^main::1::p .* TOP @ \[3, 8, 14\]
+^main::1::i .* TOP @ \[23, 25\]
+^main::1::p .* TOP @ \[3, 9, 18\]
 --

--- a/regression/goto-analyzer/branching-le/test-indeterminate-intervals.desc
+++ b/regression/goto-analyzer/branching-le/test-indeterminate-intervals.desc
@@ -3,6 +3,6 @@ main-indeterminate.c
 --no-standard-checks --variable-sensitivity --vsd-values intervals --show
 ^EXIT=0$
 ^SIGNAL=0$
-^main::1::i .* \[FFFFFFFB, 5\] @ \[17, 19\]
-^main::1::p .* \[0, A\] @ \[3, 8, 14\]
+^main::1::i .* \[FFFFFFFB, 5\] @ \[23, 25\]
+^main::1::p .* \[0, A\] @ \[3, 9, 18\]
 --

--- a/regression/goto-analyzer/branching-le/test-indeterminate-value-set.desc
+++ b/regression/goto-analyzer/branching-le/test-indeterminate-value-set.desc
@@ -3,6 +3,6 @@ main-indeterminate.c
 --no-standard-checks --variable-sensitivity --vsd-values set-of-constants --show
 ^EXIT=0$
 ^SIGNAL=0$
-^main::1::i .* value-set-begin: 5, -5 :value-set-end @ \[17, 19\]
-^main::1::p .* value-set-begin: 0, 5, 10 :value-set-end @ \[3, 8, 14\]
+^main::1::i .* value-set-begin: 5, -5 :value-set-end @ \[23, 25\]
+^main::1::p .* value-set-begin: 0, 5, 10 :value-set-end @ \[3, 9, 18\]
 --

--- a/regression/goto-analyzer/branching-le/test-never-constants.desc
+++ b/regression/goto-analyzer/branching-le/test-never-constants.desc
@@ -3,6 +3,6 @@ main-never.c
 --no-standard-checks --variable-sensitivity --vsd-values constants --show
 ^EXIT=0$
 ^SIGNAL=0$
-^main::1::i .* TOP @ \[17, 19\]
-^main::1::p .* TOP @ \[3, 8, 14\]
+^main::1::i .* TOP @ \[23, 25\]
+^main::1::p .* TOP @ \[3, 9, 18\]
 --

--- a/regression/goto-analyzer/branching-le/test-never-intervals.desc
+++ b/regression/goto-analyzer/branching-le/test-never-intervals.desc
@@ -3,6 +3,6 @@ main-never.c
 --no-standard-checks --variable-sensitivity --vsd-values intervals --show
 ^EXIT=0$
 ^SIGNAL=0$
-^main::1::i .* \[FFFFFFFB, FFFFFFFB\] @ \[19\]
-^main::1::p .* \[0, A\] @ \[3, 8, 14\]
+^main::1::i .* \[FFFFFFFB, FFFFFFFB\] @ \[25\]
+^main::1::p .* \[0, A\] @ \[3, 9, 18\]
 --

--- a/regression/goto-analyzer/branching-le/test-never-value-set.desc
+++ b/regression/goto-analyzer/branching-le/test-never-value-set.desc
@@ -3,6 +3,6 @@ main-never.c
 --no-standard-checks --variable-sensitivity --vsd-values set-of-constants --show
 ^EXIT=0$
 ^SIGNAL=0$
-^main::1::i .* value-set-begin: -5 :value-set-end @ \[19\]
-^main::1::p .* value-set-begin: 0, 5, 10 :value-set-end @ \[3, 8, 14\]
+^main::1::i .* value-set-begin: -5 :value-set-end @ \[25\]
+^main::1::p .* value-set-begin: 0, 5, 10 :value-set-end @ \[3, 9, 18\]
 --

--- a/regression/goto-analyzer/branching-lt/test-always-constants.desc
+++ b/regression/goto-analyzer/branching-lt/test-always-constants.desc
@@ -3,6 +3,6 @@ main-always.c
 --no-standard-checks --variable-sensitivity --vsd-values constants --show
 ^EXIT=0$
 ^SIGNAL=0$
-^main::1::i .* TOP @ \[17, 19\]
-^main::1::p .* TOP @ \[3, 8, 14\]
+^main::1::i .* TOP @ \[23, 25\]
+^main::1::p .* TOP @ \[3, 9, 18\]
 --

--- a/regression/goto-analyzer/branching-lt/test-always-intervals.desc
+++ b/regression/goto-analyzer/branching-lt/test-always-intervals.desc
@@ -3,6 +3,6 @@ main-always.c
 --no-standard-checks --variable-sensitivity --vsd-values intervals --show
 ^EXIT=0$
 ^SIGNAL=0$
-^main::1::i .* \[5, 5\] @ \[17\]
-^main::1::p .* \[0, A\] @ \[3, 8, 14\]
+^main::1::i .* \[5, 5\] @ \[23\]
+^main::1::p .* \[0, A\] @ \[3, 9, 18\]
 --

--- a/regression/goto-analyzer/branching-lt/test-always-value-set.desc
+++ b/regression/goto-analyzer/branching-lt/test-always-value-set.desc
@@ -3,6 +3,6 @@ main-always.c
 --no-standard-checks --variable-sensitivity --vsd-values set-of-constants --show
 ^EXIT=0$
 ^SIGNAL=0$
-^main::1::i .* value-set-begin: 5 :value-set-end @ \[17\]
-^main::1::p .* value-set-begin: 0, 5, 10 :value-set-end @ \[3, 8, 14\]
+^main::1::i .* value-set-begin: 5 :value-set-end @ \[23\]
+^main::1::p .* value-set-begin: 0, 5, 10 :value-set-end @ \[3, 9, 18\]
 --

--- a/regression/goto-analyzer/branching-lt/test-indeterminate-constants.desc
+++ b/regression/goto-analyzer/branching-lt/test-indeterminate-constants.desc
@@ -3,6 +3,6 @@ main-indeterminate.c
 --no-standard-checks --variable-sensitivity --vsd-values constants --show
 ^EXIT=0$
 ^SIGNAL=0$
-^main::1::i .* TOP @ \[17, 19\]
-^main::1::p .* TOP @ \[3, 8, 14\]
+^main::1::i .* TOP @ \[23, 25\]
+^main::1::p .* TOP @ \[3, 9, 18\]
 --

--- a/regression/goto-analyzer/branching-lt/test-indeterminate-intervals.desc
+++ b/regression/goto-analyzer/branching-lt/test-indeterminate-intervals.desc
@@ -3,6 +3,6 @@ main-indeterminate.c
 --no-standard-checks --variable-sensitivity --vsd-values intervals --show
 ^EXIT=0$
 ^SIGNAL=0$
-^main::1::i .* \[FFFFFFFB, 5\] @ \[17, 19\]
-^main::1::p .* \[0, A\] @ \[3, 8, 14\]
+^main::1::i .* \[FFFFFFFB, 5\] @ \[23, 25\]
+^main::1::p .* \[0, A\] @ \[3, 9, 18\]
 --

--- a/regression/goto-analyzer/branching-lt/test-indeterminate-value-set.desc
+++ b/regression/goto-analyzer/branching-lt/test-indeterminate-value-set.desc
@@ -3,6 +3,6 @@ main-indeterminate.c
 --no-standard-checks --variable-sensitivity --vsd-values set-of-constants --show
 ^EXIT=0$
 ^SIGNAL=0$
-^main::1::i .* value-set-begin: 5, -5 :value-set-end @ \[17, 19\]
-^main::1::p .* value-set-begin: 0, 5, 10 :value-set-end @ \[3, 8, 14\]
+^main::1::i .* value-set-begin: 5, -5 :value-set-end @ \[23, 25\]
+^main::1::p .* value-set-begin: 0, 5, 10 :value-set-end @ \[3, 9, 18\]
 --

--- a/regression/goto-analyzer/branching-lt/test-never-constants.desc
+++ b/regression/goto-analyzer/branching-lt/test-never-constants.desc
@@ -3,6 +3,6 @@ main-never.c
 --no-standard-checks --variable-sensitivity --vsd-values constants --show
 ^EXIT=0$
 ^SIGNAL=0$
-^main::1::i .* TOP @ \[17, 19\]
-^main::1::p .* TOP @ \[3, 8, 14\]
+^main::1::i .* TOP @ \[23, 25\]
+^main::1::p .* TOP @ \[3, 9, 18\]
 --

--- a/regression/goto-analyzer/branching-lt/test-never-intervals.desc
+++ b/regression/goto-analyzer/branching-lt/test-never-intervals.desc
@@ -3,6 +3,6 @@ main-never.c
 --no-standard-checks --variable-sensitivity --vsd-values intervals --show
 ^EXIT=0$
 ^SIGNAL=0$
-^main::1::i .* \[FFFFFFFB, FFFFFFFB\] @ \[19\]
-^main::1::p .* \[0, A\] @ \[3, 8, 14\]
+^main::1::i .* \[FFFFFFFB, FFFFFFFB\] @ \[25\]
+^main::1::p .* \[0, A\] @ \[3, 9, 18\]
 --

--- a/regression/goto-analyzer/branching-lt/test-never-value-set.desc
+++ b/regression/goto-analyzer/branching-lt/test-never-value-set.desc
@@ -3,6 +3,6 @@ main-never.c
 --no-standard-checks --variable-sensitivity --vsd-values set-of-constants --show
 ^EXIT=0$
 ^SIGNAL=0$
-^main::1::i .* value-set-begin: -5 :value-set-end @ \[19\]
-^main::1::p .* value-set-begin: 0, 5, 10 :value-set-end @ \[3, 8, 14\]
+^main::1::i .* value-set-begin: -5 :value-set-end @ \[25\]
+^main::1::p .* value-set-begin: 0, 5, 10 :value-set-end @ \[3, 9, 18\]
 --

--- a/regression/goto-instrument/ensure-one-backedge-per-target-not-lexical/with-transform.desc
+++ b/regression/goto-instrument/ensure-one-backedge-per-target-not-lexical/with-transform.desc
@@ -2,6 +2,6 @@ CORE
 main.c
 --ensure-one-backedge-per-target --show-lexical-loops
 ^3 is head of \{ 3, 4, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26 \(backedge\) \}$
-^16 is head of \{ 16, 17, 22, 23, 24, 25 \(backedge\) \}$
+^17 is head of \{ 17, 18, 22, 23, 24, 25 \(backedge\) \}$
 ^EXIT=0$
 ^SIGNAL=0$

--- a/regression/goto-instrument/ensure-one-backedge-per-target-not-lexical/without-transform.desc
+++ b/regression/goto-instrument/ensure-one-backedge-per-target-not-lexical/without-transform.desc
@@ -1,7 +1,7 @@
 CORE
 main.c
 --show-lexical-loops
-^16 is head of \{ 16, 17, 22, 23, 24, 25 \(backedge\) \}$
+^17 is head of \{ 17, 18, 22, 23, 24, 25 \(backedge\) \}$
 Note not all loops were in lexical loop form
 ^EXIT=0$
 ^SIGNAL=0$

--- a/regression/goto-instrument/region-analysis-14/test.desc
+++ b/regression/goto-instrument/region-analysis-14/test.desc
@@ -3,6 +3,6 @@ test.c
 --show-sese-regions
 ^Function contains 2 single-entry, single-exit regions:$
 ^Region starting at \(2, [0-9]+\) .*::x := 0 ends at \(5, [0-9]+\) SKIP$
-^Region starting at \(0, [0-9]+\) IF .*5.* THEN GOTO 2 ends at \(9, [0-9]+\) 3: SKIP$
+^Region starting at \(0, [0-9]+\) IF .*5.* THEN GOTO 2 ends at \(10, [0-9]+\) 3: SKIP$
 ^EXIT=0$
 ^SIGNAL=0$

--- a/regression/goto-instrument/region-analysis-15/test.desc
+++ b/regression/goto-instrument/region-analysis-15/test.desc
@@ -2,7 +2,7 @@ CORE
 test.c
 --show-sese-regions
 ^Function contains 2 single-entry, single-exit regions:$
-^Region starting at \(2, [0-9]+\) .*::x := 0 ends at \(8, [0-9]+\) 2: SKIP$
-^Region starting at \(0, [0-9]+\) IF .*5.* THEN GOTO 3 ends at \(12, [0-9]+\) 4: SKIP$
+^Region starting at \(2, [0-9]+\) .*::x := 0 ends at \(9, [0-9]+\) 2: SKIP$
+^Region starting at \(0, [0-9]+\) IF .*5.* THEN GOTO 3 ends at \(13, [0-9]+\) 4: SKIP$
 ^EXIT=0$
 ^SIGNAL=0$

--- a/regression/goto-instrument/region-analysis-16/test.desc
+++ b/regression/goto-instrument/region-analysis-16/test.desc
@@ -3,7 +3,7 @@ test.c
 --show-sese-regions
 ^Function contains 3 single-entry, single-exit regions:$
 ^Region starting at \(3, [0-9]+\) 1: IF .*7.* THEN GOTO 2 ends at \(8, [0-9]+\) 3: IF .*::x < 10 THEN GOTO 1$
-^Region starting at \(0, [0-9]+\) IF .*5.* THEN GOTO 4 ends at \(13, [0-9]+\) 5: SKIP$
+^Region starting at \(0, [0-9]+\) IF .*5.* THEN GOTO 4 ends at \(14, [0-9]+\) 5: SKIP$
 ^Region starting at \(2, [0-9]+\) .*::x := 0 ends at \(9, [0-9]+\) SKIP$
 ^EXIT=0$
 ^SIGNAL=0$

--- a/src/analyses/variable-sensitivity/abstract_value_object.cpp
+++ b/src/analyses/variable-sensitivity/abstract_value_object.cpp
@@ -438,7 +438,7 @@ private:
     }
 
     INVARIANT(
-      result.type() == expression.type(),
+      result.is_top() || result.type() == expression.type(),
       "Type of result interval should match expression type");
     return make_interval(result);
   }

--- a/src/ansi-c/goto-conversion/builtin_functions.cpp
+++ b/src/ansi-c/goto-conversion/builtin_functions.cpp
@@ -401,7 +401,7 @@ void goto_convertt::do_cpp_new(
   bool new_array = rhs.get(ID_statement) == ID_cpp_new_array;
 
   exprt count;
-  needs_destructiont new_vars;
+  clean_expr_resultt side_effects;
 
   if(new_array)
   {
@@ -409,7 +409,8 @@ void goto_convertt::do_cpp_new(
       static_cast<const exprt &>(rhs.find(ID_size)), object_size.type());
 
     // might have side-effect
-    new_vars.add(clean_expr(count, dest, ID_cpp));
+    side_effects.add(clean_expr(count, ID_cpp));
+    dest.destructive_append(side_effects.side_effects);
   }
 
   exprt tmp_symbol_expr;
@@ -495,9 +496,8 @@ void goto_convertt::do_cpp_new(
     typecast_exprt(tmp_symbol_expr, lhs.type()),
     rhs.find_source_location()));
 
-  new_vars.minimal_scope.push_front(
-    to_symbol_expr(tmp_symbol_expr).get_identifier());
-  destruct_locals(new_vars.minimal_scope, dest, ns);
+  side_effects.add_temporary(to_symbol_expr(tmp_symbol_expr).get_identifier());
+  destruct_locals(side_effects.temporaries, dest, ns);
 
   // grab initializer
   goto_programt tmp_initializer;

--- a/src/ansi-c/goto-conversion/destructor.h
+++ b/src/ansi-c/goto-conversion/destructor.h
@@ -12,10 +12,20 @@ Author: Daniel Kroening, kroening@kroening.com
 #ifndef CPROVER_GOTO_PROGRAMS_DESTRUCTOR_H
 #define CPROVER_GOTO_PROGRAMS_DESTRUCTOR_H
 
+#include <util/irep.h>
+
+#include <list>
+
+class goto_programt;
 class namespacet;
 class typet;
 
 class code_function_callt
 get_destructor(const namespacet &ns, const typet &type);
+
+void destruct_locals(
+  const std::list<irep_idt> &vars,
+  goto_programt &dest,
+  const namespacet &ns);
 
 #endif // CPROVER_GOTO_PROGRAMS_DESTRUCTOR_H

--- a/src/ansi-c/goto-conversion/goto_clean_expr.cpp
+++ b/src/ansi-c/goto-conversion/goto_clean_expr.cpp
@@ -166,9 +166,8 @@ void goto_convertt::rewrite_boolean(exprt &expr)
   expr.swap(tmp);
 }
 
-goto_convertt::needs_destructiont goto_convertt::clean_expr(
+goto_convertt::clean_expr_resultt goto_convertt::clean_expr(
   exprt &expr,
-  goto_programt &dest,
   const irep_idt &mode,
   bool result_is_used)
 {
@@ -189,20 +188,20 @@ goto_convertt::needs_destructiont goto_convertt::clean_expr(
     rewrite_boolean(expr);
 
     // recursive call
-    return clean_expr(expr, dest, mode, result_is_used);
+    return clean_expr(expr, mode, result_is_used);
   }
   else if(expr.id() == ID_if)
   {
     // first clean condition
-    needs_destructiont new_vars =
-      clean_expr(to_if_expr(expr).cond(), dest, mode, true);
+    clean_expr_resultt side_effects =
+      clean_expr(to_if_expr(expr).cond(), mode, true);
 
     // possibly done now
     if(
       !needs_cleaning(to_if_expr(expr).true_case()) &&
       !needs_cleaning(to_if_expr(expr).false_case()))
     {
-      return new_vars;
+      return side_effects;
     }
 
     // copy expression
@@ -236,30 +235,32 @@ goto_convertt::needs_destructiont goto_convertt::clean_expr(
     }
 #endif
 
-    goto_programt tmp_true;
-    new_vars.add(
-      clean_expr(if_expr.true_case(), tmp_true, mode, result_is_used));
+    clean_expr_resultt tmp_true(
+      clean_expr(if_expr.true_case(), mode, result_is_used));
 
-    goto_programt tmp_false;
-    new_vars.add(
-      clean_expr(if_expr.false_case(), tmp_false, mode, result_is_used));
+    clean_expr_resultt tmp_false(
+      clean_expr(if_expr.false_case(), mode, result_is_used));
 
     if(result_is_used)
     {
-      symbolt &new_symbol =
-        new_tmp_symbol(expr.type(), "if_expr", dest, source_location, mode);
+      symbolt &new_symbol = new_tmp_symbol(
+        expr.type(),
+        "if_expr",
+        side_effects.side_effects,
+        source_location,
+        mode);
 
       code_assignt assignment_true;
       assignment_true.lhs() = new_symbol.symbol_expr();
       assignment_true.rhs() = if_expr.true_case();
       assignment_true.add_source_location() = source_location;
-      convert(assignment_true, tmp_true, mode);
+      convert(assignment_true, tmp_true.side_effects, mode);
 
       code_assignt assignment_false;
       assignment_false.lhs() = new_symbol.symbol_expr();
       assignment_false.rhs() = if_expr.false_case();
       assignment_false.add_source_location() = source_location;
-      convert(assignment_false, tmp_false, mode);
+      convert(assignment_false, tmp_false.side_effects, mode);
 
       // overwrites expr
       expr = new_symbol.symbol_expr();
@@ -273,7 +274,7 @@ goto_convertt::needs_destructiont goto_convertt::clean_expr(
         // expression is just a constant
         code_expressiont code_expression(
           typecast_exprt(if_expr.true_case(), empty_typet()));
-        convert(code_expression, tmp_true, mode);
+        convert(code_expression, tmp_true.side_effects, mode);
       }
 
       if(if_expr.false_case().is_not_nil())
@@ -282,7 +283,7 @@ goto_convertt::needs_destructiont goto_convertt::clean_expr(
         // expression is just a constant
         code_expressiont code_expression(
           typecast_exprt(if_expr.false_case(), empty_typet()));
-        convert(code_expression, tmp_false, mode);
+        convert(code_expression, tmp_false.side_effects, mode);
       }
 
       expr = nil_exprt();
@@ -292,24 +293,26 @@ goto_convertt::needs_destructiont goto_convertt::clean_expr(
     generate_ifthenelse(
       if_expr.cond(),
       source_location,
-      tmp_true,
+      tmp_true.side_effects,
       if_expr.true_case().source_location(),
-      tmp_false,
+      tmp_false.side_effects,
       if_expr.false_case().source_location(),
-      dest,
+      side_effects.side_effects,
       mode);
 
-    destruct_locals(new_vars.minimal_scope, dest, ns);
-    new_vars.minimal_scope.clear();
+    destruct_locals(tmp_false.temporaries, side_effects.side_effects, ns);
+    destruct_locals(tmp_true.temporaries, side_effects.side_effects, ns);
+    destruct_locals(side_effects.temporaries, side_effects.side_effects, ns);
+    side_effects.temporaries.clear();
 
     if(expr.is_not_nil())
-      new_vars.minimal_scope.push_front(to_symbol_expr(expr).get_identifier());
+      side_effects.add_temporary(to_symbol_expr(expr).get_identifier());
 
-    return new_vars;
+    return side_effects;
   }
   else if(expr.id() == ID_comma)
   {
-    needs_destructiont new_vars;
+    clean_expr_resultt side_effects;
 
     if(result_is_used)
     {
@@ -323,15 +326,15 @@ goto_convertt::needs_destructiont goto_convertt::clean_expr(
         if(last)
         {
           result.swap(*it);
-          new_vars.add(clean_expr(result, dest, mode, true));
+          side_effects.add(clean_expr(result, mode, true));
         }
         else
         {
-          new_vars.add(clean_expr(*it, dest, mode, false));
+          side_effects.add(clean_expr(*it, mode, false));
 
           // remember these for later checks
           if(it->is_not_nil())
-            convert(code_expressiont(*it), dest, mode);
+            convert(code_expressiont(*it), side_effects.side_effects, mode);
         }
       }
 
@@ -341,30 +344,30 @@ goto_convertt::needs_destructiont goto_convertt::clean_expr(
     {
       Forall_operands(it, expr)
       {
-        new_vars.add(clean_expr(*it, dest, mode, false));
+        side_effects.add(clean_expr(*it, mode, false));
 
         // remember as expression statement for later checks
         if(it->is_not_nil())
-          convert(code_expressiont(*it), dest, mode);
+          convert(code_expressiont(*it), side_effects.side_effects, mode);
       }
 
       expr = nil_exprt();
     }
 
-    return new_vars;
+    return side_effects;
   }
   else if(expr.id() == ID_typecast)
   {
     typecast_exprt &typecast = to_typecast_expr(expr);
 
     // preserve 'result_is_used'
-    needs_destructiont new_vars =
-      clean_expr(typecast.op(), dest, mode, result_is_used);
+    clean_expr_resultt side_effects =
+      clean_expr(typecast.op(), mode, result_is_used);
 
     if(typecast.op().is_nil())
       expr.make_nil();
 
-    return new_vars;
+    return side_effects;
   }
   else if(expr.id() == ID_side_effect)
   {
@@ -374,14 +377,14 @@ goto_convertt::needs_destructiont goto_convertt::clean_expr(
     if(statement == ID_gcc_conditional_expression)
     {
       // need to do separately
-      return remove_gcc_conditional_expression(expr, dest, mode);
+      return remove_gcc_conditional_expression(expr, mode);
     }
     else if(statement == ID_statement_expression)
     {
       // need to do separately to prevent that
       // the operands of expr get 'cleaned'
       return remove_statement_expression(
-        to_side_effect_expr(expr), dest, mode, result_is_used);
+        to_side_effect_expr(expr), mode, result_is_used);
     }
     else if(statement == ID_assign)
     {
@@ -397,16 +400,15 @@ goto_convertt::needs_destructiont goto_convertt::clean_expr(
         to_side_effect_expr(side_effect_assign.rhs()).get_statement() ==
           ID_function_call)
       {
-        needs_destructiont new_vars =
-          clean_expr(side_effect_assign.lhs(), dest, mode);
+        clean_expr_resultt side_effects =
+          clean_expr(side_effect_assign.lhs(), mode);
         exprt lhs = side_effect_assign.lhs();
 
         const bool must_use_rhs = assignment_lhs_needs_temporary(lhs);
         if(must_use_rhs)
         {
-          new_vars.add(remove_function_call(
+          side_effects.add(remove_function_call(
             to_side_effect_expr_function_call(side_effect_assign.rhs()),
-            dest,
             mode,
             true));
         }
@@ -417,14 +419,14 @@ goto_convertt::needs_destructiont goto_convertt::clean_expr(
           side_effect_assign.rhs(), new_lhs.type());
         code_assignt assignment(std::move(new_lhs), new_rhs);
         assignment.add_source_location() = expr.source_location();
-        convert_assign(assignment, dest, mode);
+        convert_assign(assignment, side_effects.side_effects, mode);
 
         if(result_is_used)
           expr = must_use_rhs ? new_rhs : lhs;
         else
           expr.make_nil();
 
-        return new_vars;
+        return side_effects;
       }
     }
   }
@@ -437,20 +439,20 @@ goto_convertt::needs_destructiont goto_convertt::clean_expr(
   else if(expr.id() == ID_address_of)
   {
     address_of_exprt &addr = to_address_of_expr(expr);
-    return clean_expr_address_of(addr.object(), dest, mode);
+    return clean_expr_address_of(addr.object(), mode);
   }
 
-  needs_destructiont new_vars;
+  clean_expr_resultt side_effects;
 
   // TODO: evaluation order
 
   Forall_operands(it, expr)
-    new_vars.add(clean_expr(*it, dest, mode));
+    side_effects.add(clean_expr(*it, mode));
 
   if(expr.id() == ID_side_effect)
   {
-    new_vars.add(remove_side_effect(
-      to_side_effect_expr(expr), dest, mode, result_is_used, false));
+    side_effects.add(remove_side_effect(
+      to_side_effect_expr(expr), mode, result_is_used, false));
   }
   else if(expr.id() == ID_compound_literal)
   {
@@ -460,15 +462,13 @@ goto_convertt::needs_destructiont goto_convertt::clean_expr(
     expr = to_unary_expr(expr).op();
   }
 
-  return new_vars;
+  return side_effects;
 }
 
-goto_convertt::needs_destructiont goto_convertt::clean_expr_address_of(
-  exprt &expr,
-  goto_programt &dest,
-  const irep_idt &mode)
+goto_convertt::clean_expr_resultt
+goto_convertt::clean_expr_address_of(exprt &expr, const irep_idt &mode)
 {
-  needs_destructiont new_vars;
+  clean_expr_resultt side_effects;
 
   // The address of object constructors can be taken,
   // which is re-written into the address of a variable.
@@ -477,8 +477,9 @@ goto_convertt::needs_destructiont goto_convertt::clean_expr_address_of(
   {
     DATA_INVARIANT(
       expr.operands().size() == 1, "ID_compound_literal has a single operand");
-    new_vars.add(clean_expr(to_unary_expr(expr).op(), dest, mode));
-    expr = make_compound_literal(to_unary_expr(expr).op(), dest, mode);
+    side_effects.add(clean_expr(to_unary_expr(expr).op(), mode));
+    expr = make_compound_literal(
+      to_unary_expr(expr).op(), side_effects.side_effects, mode);
   }
   else if(expr.id() == ID_string_constant)
   {
@@ -488,13 +489,13 @@ goto_convertt::needs_destructiont goto_convertt::clean_expr_address_of(
   else if(expr.id() == ID_index)
   {
     index_exprt &index_expr = to_index_expr(expr);
-    new_vars.add(clean_expr_address_of(index_expr.array(), dest, mode));
-    new_vars.add(clean_expr(index_expr.index(), dest, mode));
+    side_effects.add(clean_expr_address_of(index_expr.array(), mode));
+    side_effects.add(clean_expr(index_expr.index(), mode));
   }
   else if(expr.id() == ID_dereference)
   {
     dereference_exprt &deref_expr = to_dereference_expr(expr);
-    new_vars.add(clean_expr(deref_expr.pointer(), dest, mode));
+    side_effects.add(clean_expr(deref_expr.pointer(), mode));
   }
   else if(expr.id() == ID_comma)
   {
@@ -512,44 +513,43 @@ goto_convertt::needs_destructiont goto_convertt::clean_expr_address_of(
         result.swap(*it);
       else
       {
-        new_vars.add(clean_expr(*it, dest, mode, false));
+        side_effects.add(clean_expr(*it, mode, false));
 
         // get any side-effects
         if(it->is_not_nil())
-          convert(code_expressiont(*it), dest, mode);
+          convert(code_expressiont(*it), side_effects.side_effects, mode);
       }
     }
 
     expr.swap(result);
 
     // do again
-    new_vars.add(clean_expr_address_of(expr, dest, mode));
+    side_effects.add(clean_expr_address_of(expr, mode));
   }
   else if(expr.id() == ID_side_effect)
   {
-    new_vars.add(
-      remove_side_effect(to_side_effect_expr(expr), dest, mode, true, true));
+    side_effects.add(
+      remove_side_effect(to_side_effect_expr(expr), mode, true, true));
   }
   else
     Forall_operands(it, expr)
-      new_vars.add(clean_expr_address_of(*it, dest, mode));
+      side_effects.add(clean_expr_address_of(*it, mode));
 
-  return new_vars;
+  return side_effects;
 }
 
-goto_convertt::needs_destructiont
+goto_convertt::clean_expr_resultt
 goto_convertt::remove_gcc_conditional_expression(
   exprt &expr,
-  goto_programt &dest,
   const irep_idt &mode)
 {
-  needs_destructiont new_vars;
+  clean_expr_resultt side_effects;
 
   {
     auto &binary_expr = to_binary_expr(expr);
 
     // first remove side-effects from condition
-    new_vars = clean_expr(to_binary_expr(expr).op0(), dest, mode);
+    side_effects = clean_expr(to_binary_expr(expr).op0(), mode);
 
     // now we can copy op0 safely
     if_exprt if_expr(
@@ -563,7 +563,7 @@ goto_convertt::remove_gcc_conditional_expression(
   }
 
   // there might still be junk in expr.op2()
-  new_vars.add(clean_expr(expr, dest, mode));
+  side_effects.add(clean_expr(expr, mode));
 
-  return new_vars;
+  return side_effects;
 }

--- a/src/ansi-c/goto-conversion/goto_convert_class.h
+++ b/src/ansi-c/goto-conversion/goto_convert_class.h
@@ -56,19 +56,29 @@ protected:
   std::string tmp_symbol_prefix;
   lifetimet lifetime = lifetimet::STATIC_GLOBAL;
 
-  struct needs_destructiont
+  struct clean_expr_resultt
   {
-    std::list<irep_idt> minimal_scope;
+    /// Identifiers of temporaries introduced while cleaning an expression. The
+    /// caller needs to add destructors for these (via `destruct_locals`) on all
+    /// control-flow paths as soon as the temporaries are no longer needed.
+    std::list<irep_idt> temporaries;
+    /// Statements implementing side effects of the expression that was subject
+    /// to cleaning. The caller needs to merge (typically via
+    /// `destructive_append`) these statements into the destination GOTO
+    /// program.
+    goto_programt side_effects;
 
-    needs_destructiont() = default;
+    clean_expr_resultt() = default;
 
-    explicit needs_destructiont(irep_idt id) : minimal_scope({id})
+    void add(clean_expr_resultt &&other)
     {
+      temporaries.splice(temporaries.begin(), other.temporaries);
+      side_effects.destructive_append(other.side_effects);
     }
 
-    void add(needs_destructiont &&other)
+    void add_temporary(const irep_idt &id)
     {
-      minimal_scope.splice(minimal_scope.begin(), other.minimal_scope);
+      temporaries.push_front(id);
     }
   };
 
@@ -97,14 +107,11 @@ protected:
   // into the program logic
   //
 
-  [[nodiscard]] needs_destructiont clean_expr(
-    exprt &expr,
-    goto_programt &dest,
-    const irep_idt &mode,
-    bool result_is_used = true);
+  [[nodiscard]] clean_expr_resultt
+  clean_expr(exprt &expr, const irep_idt &mode, bool result_is_used = true);
 
-  [[nodiscard]] needs_destructiont
-  clean_expr_address_of(exprt &expr, goto_programt &dest, const irep_idt &mode);
+  [[nodiscard]] clean_expr_resultt
+  clean_expr_address_of(exprt &expr, const irep_idt &mode);
 
   static bool needs_cleaning(const exprt &expr);
 
@@ -125,58 +132,46 @@ protected:
 
   void rewrite_boolean(exprt &dest);
 
-  [[nodiscard]] needs_destructiont remove_side_effect(
+  [[nodiscard]] clean_expr_resultt remove_side_effect(
     side_effect_exprt &expr,
-    goto_programt &dest,
     const irep_idt &mode,
     bool result_is_used,
     bool address_taken);
-  [[nodiscard]] needs_destructiont remove_assignment(
+  [[nodiscard]] clean_expr_resultt remove_assignment(
     side_effect_exprt &expr,
-    goto_programt &dest,
     bool result_is_used,
     bool address_taken,
     const irep_idt &mode);
-  [[nodiscard]] needs_destructiont remove_pre(
+  [[nodiscard]] clean_expr_resultt remove_pre(
     side_effect_exprt &expr,
-    goto_programt &dest,
     bool result_is_used,
     bool address_taken,
     const irep_idt &mode);
-  [[nodiscard]] needs_destructiont remove_post(
+  [[nodiscard]] clean_expr_resultt remove_post(
     side_effect_exprt &expr,
-    goto_programt &dest,
     const irep_idt &mode,
     bool result_is_used);
-  [[nodiscard]] needs_destructiont remove_function_call(
+  [[nodiscard]] clean_expr_resultt remove_function_call(
     side_effect_expr_function_callt &expr,
-    goto_programt &dest,
     const irep_idt &mode,
     bool result_is_used);
-  [[nodiscard]] needs_destructiont remove_cpp_new(
+  [[nodiscard]] clean_expr_resultt
+  remove_cpp_new(side_effect_exprt &expr, bool result_is_used);
+  [[nodiscard]] clean_expr_resultt remove_cpp_delete(side_effect_exprt &expr);
+  [[nodiscard]] clean_expr_resultt remove_malloc(
     side_effect_exprt &expr,
-    goto_programt &dest,
-    bool result_is_used);
-  void remove_cpp_delete(side_effect_exprt &expr, goto_programt &dest);
-  [[nodiscard]] needs_destructiont remove_malloc(
-    side_effect_exprt &expr,
-    goto_programt &dest,
     const irep_idt &mode,
     bool result_is_used);
-  [[nodiscard]] needs_destructiont
-  remove_temporary_object(side_effect_exprt &expr, goto_programt &dest);
-  [[nodiscard]] needs_destructiont remove_statement_expression(
+  [[nodiscard]] clean_expr_resultt
+  remove_temporary_object(side_effect_exprt &expr);
+  [[nodiscard]] clean_expr_resultt remove_statement_expression(
     side_effect_exprt &expr,
-    goto_programt &dest,
     const irep_idt &mode,
     bool result_is_used);
-  [[nodiscard]] needs_destructiont remove_gcc_conditional_expression(
-    exprt &expr,
-    goto_programt &dest,
-    const irep_idt &mode);
-  [[nodiscard]] needs_destructiont remove_overflow(
+  [[nodiscard]] clean_expr_resultt
+  remove_gcc_conditional_expression(exprt &expr, const irep_idt &mode);
+  [[nodiscard]] clean_expr_resultt remove_overflow(
     side_effect_expr_overflowt &expr,
-    goto_programt &dest,
     bool result_is_used,
     const irep_idt &mode);
 

--- a/src/ansi-c/goto-conversion/goto_convert_class.h
+++ b/src/ansi-c/goto-conversion/goto_convert_class.h
@@ -56,6 +56,22 @@ protected:
   std::string tmp_symbol_prefix;
   lifetimet lifetime = lifetimet::STATIC_GLOBAL;
 
+  struct needs_destructiont
+  {
+    std::list<irep_idt> minimal_scope;
+
+    needs_destructiont() = default;
+
+    explicit needs_destructiont(irep_idt id) : minimal_scope({id})
+    {
+    }
+
+    void add(needs_destructiont &&other)
+    {
+      minimal_scope.splice(minimal_scope.begin(), other.minimal_scope);
+    }
+  };
+
   void goto_convert_rec(
     const codet &code,
     goto_programt &dest,
@@ -64,7 +80,7 @@ protected:
   //
   // tools for symbols
   //
-  symbolt &new_tmp_symbol(
+  [[nodiscard]] symbolt &new_tmp_symbol(
     const typet &type,
     const std::string &suffix,
     goto_programt &dest,
@@ -81,13 +97,13 @@ protected:
   // into the program logic
   //
 
-  void clean_expr(
+  [[nodiscard]] needs_destructiont clean_expr(
     exprt &expr,
     goto_programt &dest,
     const irep_idt &mode,
     bool result_is_used = true);
 
-  void
+  [[nodiscard]] needs_destructiont
   clean_expr_address_of(exprt &expr, goto_programt &dest, const irep_idt &mode);
 
   static bool needs_cleaning(const exprt &expr);
@@ -101,7 +117,7 @@ protected:
     return lhs.id() != ID_symbol;
   }
 
-  void make_temp_symbol(
+  [[nodiscard]] irep_idt make_temp_symbol(
     exprt &expr,
     const std::string &suffix,
     goto_programt &,
@@ -109,55 +125,56 @@ protected:
 
   void rewrite_boolean(exprt &dest);
 
-  void remove_side_effect(
+  [[nodiscard]] needs_destructiont remove_side_effect(
     side_effect_exprt &expr,
     goto_programt &dest,
     const irep_idt &mode,
     bool result_is_used,
     bool address_taken);
-  void remove_assignment(
+  [[nodiscard]] needs_destructiont remove_assignment(
     side_effect_exprt &expr,
     goto_programt &dest,
     bool result_is_used,
     bool address_taken,
     const irep_idt &mode);
-  void remove_pre(
+  [[nodiscard]] needs_destructiont remove_pre(
     side_effect_exprt &expr,
     goto_programt &dest,
     bool result_is_used,
     bool address_taken,
     const irep_idt &mode);
-  void remove_post(
+  [[nodiscard]] needs_destructiont remove_post(
     side_effect_exprt &expr,
     goto_programt &dest,
     const irep_idt &mode,
     bool result_is_used);
-  void remove_function_call(
+  [[nodiscard]] needs_destructiont remove_function_call(
     side_effect_expr_function_callt &expr,
     goto_programt &dest,
     const irep_idt &mode,
     bool result_is_used);
-  void remove_cpp_new(
+  [[nodiscard]] needs_destructiont remove_cpp_new(
     side_effect_exprt &expr,
     goto_programt &dest,
     bool result_is_used);
   void remove_cpp_delete(side_effect_exprt &expr, goto_programt &dest);
-  void remove_malloc(
+  [[nodiscard]] needs_destructiont remove_malloc(
     side_effect_exprt &expr,
     goto_programt &dest,
     const irep_idt &mode,
     bool result_is_used);
-  void remove_temporary_object(side_effect_exprt &expr, goto_programt &dest);
-  void remove_statement_expression(
+  [[nodiscard]] needs_destructiont
+  remove_temporary_object(side_effect_exprt &expr, goto_programt &dest);
+  [[nodiscard]] needs_destructiont remove_statement_expression(
     side_effect_exprt &expr,
     goto_programt &dest,
     const irep_idt &mode,
     bool result_is_used);
-  void remove_gcc_conditional_expression(
+  [[nodiscard]] needs_destructiont remove_gcc_conditional_expression(
     exprt &expr,
     goto_programt &dest,
     const irep_idt &mode);
-  void remove_overflow(
+  [[nodiscard]] needs_destructiont remove_overflow(
     side_effect_expr_overflowt &expr,
     goto_programt &dest,
     bool result_is_used,

--- a/src/ansi-c/goto-conversion/goto_convert_function_call.cpp
+++ b/src/ansi-c/goto-conversion/goto_convert_function_call.cpp
@@ -43,15 +43,17 @@ void goto_convertt::do_function_call(
 
   exprt::operandst new_arguments = arguments;
 
-  needs_destructiont new_vars;
+  clean_expr_resultt side_effects;
 
   if(!new_lhs.is_nil())
-    new_vars.add(clean_expr(new_lhs, dest, mode));
+    side_effects.add(clean_expr(new_lhs, mode));
 
-  new_vars.add(clean_expr(new_function, dest, mode));
+  side_effects.add(clean_expr(new_function, mode));
 
   for(auto &new_argument : new_arguments)
-    new_vars.add(clean_expr(new_argument, dest, mode));
+    side_effects.add(clean_expr(new_argument, mode));
+
+  dest.destructive_append(side_effects.side_effects);
 
   // split on the function
 
@@ -83,7 +85,7 @@ void goto_convertt::do_function_call(
       function.find_source_location());
   }
 
-  destruct_locals(new_vars.minimal_scope, dest, ns);
+  destruct_locals(side_effects.temporaries, dest, ns);
 }
 
 void goto_convertt::do_function_call_if(

--- a/src/cprover/simplify_state_expr.cpp
+++ b/src/cprover/simplify_state_expr.cpp
@@ -517,6 +517,10 @@ exprt simplify_object_size_expr(
   {
     return src.with_state(to_update_state_expr(src.state()).state());
   }
+  else if(src.state().id() == ID_exit_scope_state)
+  {
+    return src.with_state(to_exit_scope_state_expr(src.state()).state());
+  }
 
   return std::move(src);
 }

--- a/src/goto-instrument/contracts/contracts.cpp
+++ b/src/goto-instrument/contracts/contracts.cpp
@@ -581,13 +581,16 @@ static void generate_contract_constraints(
   goto_programt constraint;
   if(location.get_property_class() == ID_assume)
   {
-    converter.goto_convert(code_assumet(instantiated_clause), constraint, mode);
+    code_assumet assumption(instantiated_clause);
+    assumption.add_source_location() = location;
+    converter.goto_convert(assumption, constraint, mode);
   }
   else
   {
-    converter.goto_convert(code_assertt(instantiated_clause), constraint, mode);
+    code_assertt assertion(instantiated_clause);
+    assertion.add_source_location() = location;
+    converter.goto_convert(assertion, constraint, mode);
   }
-  constraint.instructions.back().source_location_nonconst() = location;
   is_fresh_update(constraint);
   throw_on_unsupported(constraint);
   program.destructive_append(constraint);

--- a/src/goto-instrument/contracts/dynamic-frames/dfcc_contract_clauses_codegen.cpp
+++ b/src/goto-instrument/contracts/dynamic-frames/dfcc_contract_clauses_codegen.cpp
@@ -21,6 +21,7 @@ Date: February 2023
 #include <goto-programs/goto_model.h>
 
 #include <ansi-c/c_expr.h>
+#include <ansi-c/goto-conversion/destructor.h>
 #include <goto-instrument/contracts/utils.h>
 #include <langapi/language_util.h>
 
@@ -104,8 +105,9 @@ void dfcc_contract_clauses_codegent::encode_assignable_target_group(
   // clean up side effects from the condition expression if needed
   cleanert cleaner(goto_model.symbol_table, log.get_message_handler());
   exprt condition(group.condition());
+  std::list<irep_idt> new_vars;
   if(has_subexpr(condition, ID_side_effect))
-    cleaner.clean(condition, dest, language_mode);
+    new_vars = cleaner.clean(condition, dest, language_mode);
 
   // Jump target if condition is false
   auto goto_instruction = dest.add(
@@ -116,6 +118,8 @@ void dfcc_contract_clauses_codegent::encode_assignable_target_group(
 
   auto label_instruction = dest.add(goto_programt::make_skip(source_location));
   goto_instruction->complete_goto(label_instruction);
+
+  destruct_locals(new_vars, dest, ns);
 }
 
 void dfcc_contract_clauses_codegent::encode_assignable_target(
@@ -190,8 +194,9 @@ void dfcc_contract_clauses_codegent::encode_freeable_target_group(
   // clean up side effects from the condition expression if needed
   cleanert cleaner(goto_model.symbol_table, log.get_message_handler());
   exprt condition(group.condition());
+  std::list<irep_idt> new_vars;
   if(has_subexpr(condition, ID_side_effect))
-    cleaner.clean(condition, dest, language_mode);
+    new_vars = cleaner.clean(condition, dest, language_mode);
 
   // Jump target if condition is false
   auto goto_instruction = dest.add(
@@ -202,6 +207,8 @@ void dfcc_contract_clauses_codegent::encode_freeable_target_group(
 
   auto label_instruction = dest.add(goto_programt::make_skip(source_location));
   goto_instruction->complete_goto(label_instruction);
+
+  destruct_locals(new_vars, dest, ns);
 }
 
 void dfcc_contract_clauses_codegent::encode_freeable_target(

--- a/src/goto-instrument/contracts/instrument_spec_assigns.cpp
+++ b/src/goto-instrument/contracts/instrument_spec_assigns.cpp
@@ -23,6 +23,7 @@ Date: January 2022
 #include <util/simplify_expr.h>
 
 #include <ansi-c/c_expr.h>
+#include <ansi-c/goto-conversion/destructor.h>
 #include <langapi/language_util.h>
 
 #include "cfg_info.h"
@@ -419,8 +420,9 @@ void instrument_spec_assignst::track_spec_target_group(
   // clean up side effects from the guard expression if needed
   cleanert cleaner(st, log.get_message_handler());
   exprt condition(group.condition());
+  std::list<irep_idt> new_vars;
   if(has_subexpr(condition, ID_side_effect))
-    cleaner.clean(condition, dest, mode);
+    new_vars = cleaner.clean(condition, dest, mode);
 
   // create conditional address ranges by distributing the condition
   for(const auto &target : group.targets())
@@ -434,6 +436,8 @@ void instrument_spec_assignst::track_spec_target_group(
     // generate snapshot instructions for this target.
     create_snapshot(car, dest);
   }
+
+  destruct_locals(new_vars, dest, ns);
 }
 
 void instrument_spec_assignst::track_plain_spec_target(

--- a/src/goto-instrument/contracts/utils.h
+++ b/src/goto-instrument/contracts/utils.h
@@ -43,9 +43,10 @@ public:
   {
   }
 
-  void clean(exprt &guard, goto_programt &dest, const irep_idt &mode)
+  [[nodiscard]] std::list<irep_idt>
+  clean(exprt &guard, goto_programt &dest, const irep_idt &mode)
   {
-    goto_convertt::clean_expr(guard, dest, mode, true);
+    return goto_convertt::clean_expr(guard, dest, mode, true).minimal_scope;
   }
 
   void do_havoc_slice(

--- a/src/goto-instrument/contracts/utils.h
+++ b/src/goto-instrument/contracts/utils.h
@@ -46,7 +46,9 @@ public:
   [[nodiscard]] std::list<irep_idt>
   clean(exprt &guard, goto_programt &dest, const irep_idt &mode)
   {
-    return goto_convertt::clean_expr(guard, dest, mode, true).minimal_scope;
+    auto clean_result = goto_convertt::clean_expr(guard, mode, true);
+    dest.destructive_append(clean_result.side_effects);
+    return clean_result.temporaries;
   }
 
   void do_havoc_slice(


### PR DESCRIPTION
GOTO conversion introduces temporaries when cleaning expression, e.g., removing side effects. We previously considered them to have block scope as they only were marked dead when the block containing them was left. This, however, can be a much larger range of instructions than for what instructions they actually need to be live for. As a consequence, GOTO conversion frequently deemed it necessary to introduce declaration hops for we had goto instructions that would jump over the declaration of the temporary, but still within the block that contained that temporary (and well after the last actual use of that temporary).

This PR now largely (with the exception of compound literals, which yield temporaries that must have block scope) removes the side effect that creating temporaries had on scope tracking. Instead, methods explicitly return the list of temporaries in need of cleanup.

This avoids performance penalties seen when trying to upgrade Kani to CBMC version 6. Kani makes extensive use of statement expressions, which are one case of instructions that yield a temporary that needs to be cleaned up as soon as possible.

The second commit is code cleanup that touches almost the same lines as the first commit, so this PR is best reviewed all-commits-at-once.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [x] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
