### PR TITLE
C library: __fcntl_time64 for Debian/ARM

### DIFF
--- a/src/ansi-c/library/fcntl.c
+++ b/src/ansi-c/library/fcntl.c
@@ -54,6 +54,15 @@ int fcntl64(int fd, int cmd, ...)
   return __CPROVER_fcntl(fd, cmd);
 }
 
+/* FUNCTION: __fcntl_time64 */
+
+int __CPROVER_fcntl(int, int);
+
+int __fcntl_time64(int fd, int cmd, ...)
+{
+  return __CPROVER_fcntl(fd, cmd);
+}
+
 /* FUNCTION: __CPROVER_open */
 
 #ifndef __CPROVER_FCNTL_H_INCLUDED

--- a/src/ansi-c/library_check.sh
+++ b/src/ansi-c/library_check.sh
@@ -45,6 +45,7 @@ perl -p -i -e 's/^_setjmp\n//' __functions # pipe, macOS
 perl -p -i -e 's/^_time(32|64)\n//' __functions # time, Windows
 perl -p -i -e 's/^__builtin___snprintf_chk\n//' __functions # snprintf, macOS
 perl -p -i -e 's/^__builtin___vsnprintf_chk\n//' __functions # vsnprintf, macOS
+perl -p -i -e 's/^__fcntl_time64\n//' __functions # fcntl, Linux
 perl -p -i -e 's/^__inet_(addr|aton|ntoa|network)\n//' __functions # inet_*, FreeBSD
 perl -p -i -e 's/^__isoc99_v?fscanf\n//' __functions # fscanf, Linux
 perl -p -i -e 's/^__isoc99_v?scanf\n//' __functions # scanf, Linux


### PR DESCRIPTION
`fcntl` is renamed to `__fcntl_time64` for `time64` support. Seen on ARM platforms in Debian builds.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
