### PR TITLE
SMT2 back-end: report error when invoking solver fails

### DIFF
--- a/regression/cbmc/smt2-solver-invocation-error/main.c
+++ b/regression/cbmc/smt2-solver-invocation-error/main.c
@@ -1,0 +1,6 @@
+int main()
+{
+  int x;
+  __CPROVER_assert(x == 0, "x is zero");
+  return 0;
+}

--- a/regression/cbmc/smt2-solver-invocation-error/test.desc
+++ b/regression/cbmc/smt2-solver-invocation-error/test.desc
@@ -1,0 +1,16 @@
+CORE
+main.c
+--cprover-smt2 --external-smt2-solver nonexistent_smt2_solver_8362
+^SMT2 solver returned exit code [0-9]+
+^VERIFICATION ERROR$
+^EXIT=6$
+^SIGNAL=0$
+--
+//
+// Regression test for #8362: when invoking the SMT2 solver fails -- here by
+// pointing at a non-existent external solver binary -- the failure must be
+// reported rather than silently ignored. The previous `if(res < 0)` check was
+// dead code (run() never returns a negative value), so no message was produced
+// and the only symptom was an unexplained inconclusive result. We do not match
+// the platform-specific stderr text (e.g. "execvp ... failed") to keep the
+// test portable.

--- a/src/solvers/smt2/smt2_dec.cpp
+++ b/src/solvers/smt2/smt2_dec.cpp
@@ -16,6 +16,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "smt2irep.h"
 
 #include <fstream>
+#include <iterator>
 
 std::string smt2_dect::decision_procedure_text() const
 {
@@ -31,6 +32,47 @@ std::string smt2_dect::decision_procedure_text() const
      solver==solvert::Z3?"Z3":
      "(unknown)");
   // clang-format on
+}
+
+bool smt2_solver_exit_code_expected(smt2_convt::solvert solver, int exit_code)
+{
+  // A zero exit code always indicates a successful invocation.
+  if(exit_code == 0)
+    return true;
+
+  // Some solvers use a non-zero exit code to report that they emitted an
+  // (error ...) response while otherwise running successfully. Such errors are
+  // written to stdout and read back via read_result, so they do not indicate a
+  // failed invocation and must not be reported as one.
+  switch(solver)
+  {
+  case smt2_convt::solvert::CPROVER_SMT2:
+    // smt2_solver.cpp returns 20 when it emitted an (error ...) response.
+    return exit_code == 20;
+
+  case smt2_convt::solvert::Z3:
+    // z3 -smt2 returns 1 when it encountered at least one error while
+    // processing the commands: read_smtlib2_commands returns
+    // `parse_smt2_commands(...) ? 0 : 1`, and those errors are printed as
+    // (error ...) on stdout, analogous to CPROVER_SMT2's exit code 20.
+    // Genuine failures use distinct codes (e.g. 101 memout, 102 timeout, 110
+    // internal fatal). A missing z3 binary also yields exit code 1 via run()'s
+    // execvp failure, but that case is distinguished by its non-empty stderr.
+    return exit_code == 1;
+
+  case smt2_convt::solvert::BITWUZLA:
+  case smt2_convt::solvert::BOOLECTOR:
+  case smt2_convt::solvert::CVC3:
+  case smt2_convt::solvert::CVC4:
+  case smt2_convt::solvert::CVC5:
+  case smt2_convt::solvert::MATHSAT:
+  case smt2_convt::solvert::YICES:
+  case smt2_convt::solvert::GENERIC:
+    // No known benign non-zero exit code for these solvers.
+    return false;
+  }
+
+  UNREACHABLE;
 }
 
 decision_proceduret::resultt smt2_dect::dec_solve(const exprt &assumption)
@@ -135,11 +177,33 @@ decision_proceduret::resultt smt2_dect::dec_solve(const exprt &assumption)
   int res =
     run(argv[0], argv, stdin_filename, temp_file_stdout(), temp_file_stderr());
 
-  if(res<0)
+  // We report a problem when the exit code is unexpected for this solver, or
+  // when the solver produced any stderr output. The first catches a solver
+  // that failed while running; the second catches a solver that could not be
+  // invoked at all (e.g. a missing binary, which run() reports via a non-empty
+  // stderr -- see #8362). Benign solver-reported errors (e.g. get-value after
+  // an unsat result) instead appear as (error ...) on stdout and are handled
+  // by read_result, so they must not trigger a report here.
+  const bool solver_exit_expected = smt2_solver_exit_code_expected(solver, res);
+
+  std::ifstream stderr_stream(temp_file_stderr());
+  const std::string stderr_contents{
+    std::istreambuf_iterator<char>{stderr_stream},
+    std::istreambuf_iterator<char>{}};
+
+  if(!solver_exit_expected || !stderr_contents.empty())
   {
     messaget log{message_handler};
-    log.error() << "error running SMT2 solver" << messaget::eom;
-    return decision_proceduret::resultt::D_ERROR;
+    // An unexpected exit code means the solver could not be invoked or failed
+    // while running, which is reported as an error. An expected exit code with
+    // stderr output means the solver ran but emitted diagnostics, reported as
+    // a warning.
+    messaget::mstreamt &message =
+      solver_exit_expected ? log.warning() : log.error();
+    message << "SMT2 solver returned exit code " << res;
+    if(!stderr_contents.empty())
+      message << ": " << stderr_contents;
+    message << messaget::eom;
   }
 
   std::ifstream in(temp_file_stdout());

--- a/src/solvers/smt2/smt2_dec.h
+++ b/src/solvers/smt2/smt2_dec.h
@@ -53,4 +53,11 @@ protected:
   resultt read_result(std::istream &in);
 };
 
+/// Determine whether \p exit_code is an expected exit code for \p solver, i.e.
+/// one that does not by itself indicate a failed solver invocation. A zero exit
+/// code is always expected; some solvers additionally use a specific non-zero
+/// exit code to signal that they emitted an (error ...) response on stdout
+/// (which is read back via read_result) while otherwise running successfully.
+bool smt2_solver_exit_code_expected(smt2_convt::solvert solver, int exit_code);
+
 #endif // CPROVER_SOLVERS_SMT2_SMT2_DEC_H

--- a/unit/Makefile
+++ b/unit/Makefile
@@ -112,6 +112,7 @@ SRC += analyses/ai/ai.cpp \
        solvers/sat/satcheck_cadical.cpp \
        solvers/sat/satcheck_minisat2.cpp \
        solvers/smt2/smt2_conv.cpp \
+       solvers/smt2/smt2_dec.cpp \
        solvers/smt2/smt2irep.cpp \
        solvers/smt2/smt2_tokenizer.cpp \
        solvers/smt2_incremental/ast/smt_commands.cpp \

--- a/unit/solvers/smt2/smt2_dec.cpp
+++ b/unit/solvers/smt2/smt2_dec.cpp
@@ -1,0 +1,67 @@
+// Author: Daniel Kroening, kroening@kroening.com
+
+/// \file
+/// Unit tests for smt2_solver_exit_code_expected
+
+#include <testing-utils/use_catch.h>
+
+#include <solvers/smt2/smt2_dec.h>
+
+TEST_CASE(
+  "smt2_solver_exit_code_expected classification",
+  "[core][solvers][smt2]")
+{
+  using solvert = smt2_convt::solvert;
+
+  const solvert all_solvers[] = {
+    solvert::GENERIC,
+    solvert::BITWUZLA,
+    solvert::BOOLECTOR,
+    solvert::CPROVER_SMT2,
+    solvert::CVC3,
+    solvert::CVC4,
+    solvert::CVC5,
+    solvert::MATHSAT,
+    solvert::YICES,
+    solvert::Z3};
+
+  SECTION("a zero exit code is expected for every solver")
+  {
+    for(const auto solver : all_solvers)
+      CHECK(smt2_solver_exit_code_expected(solver, 0));
+  }
+
+  SECTION("CPROVER_SMT2 expects exit code 20 for (error ...) responses")
+  {
+    CHECK(smt2_solver_exit_code_expected(solvert::CPROVER_SMT2, 20));
+    CHECK_FALSE(smt2_solver_exit_code_expected(solvert::CPROVER_SMT2, 1));
+    CHECK_FALSE(smt2_solver_exit_code_expected(solvert::CPROVER_SMT2, 10));
+  }
+
+  SECTION("Z3 expects exit code 1 when it emitted an (error ...) response")
+  {
+    CHECK(smt2_solver_exit_code_expected(solvert::Z3, 1));
+    CHECK_FALSE(smt2_solver_exit_code_expected(solvert::Z3, 20));
+    // Genuine z3 failures use distinct codes that must still be reported.
+    CHECK_FALSE(smt2_solver_exit_code_expected(solvert::Z3, 101)); // memout
+    CHECK_FALSE(smt2_solver_exit_code_expected(solvert::Z3, 102)); // timeout
+    CHECK_FALSE(smt2_solver_exit_code_expected(solvert::Z3, 110)); // internal
+  }
+
+  SECTION("other solvers have no known benign non-zero exit code")
+  {
+    for(const auto solver :
+        {solvert::GENERIC,
+         solvert::BITWUZLA,
+         solvert::BOOLECTOR,
+         solvert::CVC3,
+         solvert::CVC4,
+         solvert::CVC5,
+         solvert::MATHSAT,
+         solvert::YICES})
+    {
+      CHECK_FALSE(smt2_solver_exit_code_expected(solver, 1));
+      CHECK_FALSE(smt2_solver_exit_code_expected(solver, 20));
+    }
+  }
+}


### PR DESCRIPTION
Our previous attempt at reporting errors was dead code: `run` never returns a negative value, so the `if(res < 0)` check never fired and a failed solver invocation (e.g. a missing binary) was silently ignored.

A solver invocation is now treated as failed when **either** the exit code is not one that is expected for the given solver, **or** the solver wrote anything to stderr. The stderr clause is what catches the missing-binary case from #8362: `run()` reports the `execvp` failure on stderr while exiting with code 1.

The set of expected exit codes is per-solver, because some solvers use a non-zero exit code to signal that they emitted an `(error ...)` response on stdout (which is read back via `read_result`) rather than failing to run:
- `CPROVER_SMT2` returns 20 when it produced an `(error ...)` response (see `smt2_solver.cpp`).
- `z3 -smt2` returns 1 when it encountered at least one error while processing the commands — `read_smtlib2_commands` returns `parse_smt2_commands(...) ? 0 : 1`, and those errors are printed as `(error ...)` on stdout, analogous to `CPROVER_SMT2`'s exit code 20. Genuine z3 failures use distinct codes (e.g. 101 memout, 102 timeout, 110 internal).

The classification is extracted into a free function `smt2_solver_exit_code_expected` so it is self-documenting and unit-testable. An unexpected exit code is reported via `error()`, an expected exit code with stderr output via `warning()`; both fall through to `read_result`, which yields `D_ERROR` on the resulting empty stdout.

Tests:
- `unit/solvers/smt2/smt2_dec.cpp` checks the `(solver, exit_code)` classification table directly.
- `regression/cbmc/smt2-solver-invocation-error` points a solver at a non-existent binary and asserts the failure is now reported (it fails on develop, where the message is absent).

Fixes: #8362

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.
