### PR TITLE
C front-end: place requires and ensures in designated scope

### DIFF
--- a/regression/ansi-c/contracts_scope1/main.c
+++ b/regression/ansi-c/contracts_scope1/main.c
@@ -1,0 +1,28 @@
+#define C 8
+
+typedef unsigned st[C];
+
+// clang-format off
+void init_st(st dst)
+  __CPROVER_requires(__CPROVER_is_fresh(dst, sizeof(st)))
+  __CPROVER_assigns(__CPROVER_object_whole(dst))
+  __CPROVER_ensures(__CPROVER_forall {
+    unsigned i; (0 <= i && i < C) ==> dst[i] == 0
+  });
+// clang-format on
+
+void init_st(st dst)
+{
+  __CPROVER_size_t i;
+  for(i = 0; i < C; i++)
+  {
+    dst[i] = 0;
+  }
+}
+
+int main()
+{
+  st dest;
+
+  init_st(dest);
+}

--- a/regression/ansi-c/contracts_scope1/test.desc
+++ b/regression/ansi-c/contracts_scope1/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+^CONVERSION ERROR$

--- a/src/ansi-c/parser.y
+++ b/src/ansi-c/parser.y
@@ -3337,17 +3337,27 @@ parameter_abstract_declarator:
         ;
 
 cprover_function_contract:
-          TOK_CPROVER_ENSURES '(' ACSL_binding_expression ')'
+          TOK_CPROVER_ENSURES
+        {
+          PARSER.new_scope("ensures::");
+        }
+          '(' ACSL_binding_expression ')'
         {
           $$=$1;
           set($$, ID_C_spec_ensures);
-          mto($$, $3);
+          mto($$, $4);
+          PARSER.pop_scope();
         }
-        | TOK_CPROVER_REQUIRES '(' ACSL_binding_expression ')'
+        | TOK_CPROVER_REQUIRES
+        {
+          PARSER.new_scope("requires::");
+        }
+          '(' ACSL_binding_expression ')'
         {
           $$=$1;
           set($$, ID_C_spec_requires);
-          mto($$, $3);
+          mto($$, $4);
+          PARSER.pop_scope();
         }
         | cprover_contract_assigns
         | cprover_contract_frees


### PR DESCRIPTION
These contract clauses may introduce new symbols, which must not conflict with ones declared in the body of the function.

Fixes: #8337

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
