### PR TITLE
C++ front-end: support constexpr

### DIFF
--- a/regression/cpp/constexpr1/main.cpp
+++ b/regression/cpp/constexpr1/main.cpp
@@ -14,6 +14,18 @@ constexpr int some_other_value =
 
 static_assert(some_other_value == 2, "some_other_value == 2");
 
+constexpr int some_function2(int a)
+{
+  int b;
+  a = a + 1;
+  b = a;
+  return b + 1;
+}
+
+constexpr int some_other_value2 = some_function2(1);
+
+static_assert(some_other_value2 == 3, "some_other_value == 2");
+
 int main()
 {
 }

--- a/regression/cpp/constexpr1/test.desc
+++ b/regression/cpp/constexpr1/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.cpp
 -std=c++11
 ^EXIT=0$

--- a/src/cpp/cpp_convert_type.cpp
+++ b/src/cpp/cpp_convert_type.cpp
@@ -63,8 +63,6 @@ void cpp_convert_typet::read_rec(const typet &type)
     ++char16_t_count;
   else if(type.id()==ID_char32_t)
     ++char32_t_count;
-  else if(type.id()==ID_constexpr)
-    c_qualifiers.is_constant = true;
   else if(type.id()==ID_function_type)
   {
     read_function_type(type);

--- a/src/cpp/cpp_storage_spec.cpp
+++ b/src/cpp/cpp_storage_spec.cpp
@@ -33,4 +33,6 @@ void cpp_storage_spect::read(const typet &type)
     set_asm();
   else if(type.id() == ID_weak)
     set_weak();
+  else if(type.id() == ID_constexpr)
+    set_constexpr();
 }

--- a/src/cpp/cpp_storage_spec.h
+++ b/src/cpp/cpp_storage_spec.h
@@ -47,6 +47,10 @@ public:
   {
     return get_bool(ID_weak);
   }
+  bool is_constexpr() const
+  {
+    return get_bool(ID_constexpr);
+  }
 
   void set_static()       { set(ID_static, true); }
   void set_extern()       { set(ID_extern, true); }
@@ -59,11 +63,16 @@ public:
   {
     set(ID_weak, true);
   }
+  void set_constexpr()
+  {
+    set(ID_constexpr, true);
+  }
 
   bool is_empty() const
   {
     return !is_static() && !is_extern() && !is_auto() && !is_register() &&
-           !is_mutable() && !is_thread_local() && !is_asm() && !is_weak();
+           !is_mutable() && !is_thread_local() && !is_asm() && !is_weak() &&
+           !is_constexpr();
   }
 
   cpp_storage_spect &operator|=(const cpp_storage_spect &other)
@@ -84,6 +93,8 @@ public:
       set_asm();
     if(other.is_weak())
       set_weak();
+    if(other.is_constexpr())
+      set_constexpr();
 
     return *this;
   }

--- a/src/cpp/cpp_typecheck_resolve.cpp
+++ b/src/cpp/cpp_typecheck_resolve.cpp
@@ -359,8 +359,16 @@ exprt cpp_typecheck_resolvet::convert_identifier(
     }
     else if(symbol.is_macro)
     {
-      e=symbol.value;
-      PRECONDITION(e.is_not_nil());
+      if(symbol.type.id() == ID_code)
+      {
+        // constexpr function
+        e = cpp_symbol_expr(symbol);
+      }
+      else
+      {
+        e = symbol.value;
+        PRECONDITION(e.is_not_nil());
+      }
     }
     else
     {


### PR DESCRIPTION
Mark `constexpr` symbols as macros and use direct replacement (non-function symbols) or in-place evaluation (uses of `constexpr` function symbols).

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
