### PR TITLE
copy constructors for exception classes

### DIFF
--- a/src/solvers/smt2/smt2_tokenizer.h
+++ b/src/solvers/smt2/smt2_tokenizer.h
@@ -24,6 +24,15 @@ public:
   class smt2_errort
   {
   public:
+    smt2_errort(smt2_errort &&) = default;
+
+    smt2_errort(const smt2_errort &other)
+    {
+      // ostringstream does not have a copy constructor
+      message << other.message.str();
+      line_no = other.line_no;
+    }
+
     smt2_errort(const std::string &_message, unsigned _line_no)
       : line_no(_line_no)
     {

--- a/src/util/typecheck.h
+++ b/src/util/typecheck.h
@@ -25,6 +25,15 @@ public:
   class errort final
   {
   public:
+    errort() = default;
+    errort(errort &&) = default;
+    errort(const errort &other)
+    {
+      // ostringstream does not have a copy constructor
+      message << other.message.str();
+      __location = other.__location;
+    }
+
     std::string what() const
     {
       return message.str();


### PR DESCRIPTION
C++11 15.1 §5 requires that objects that are thrown have an accessible copy/move constructor and a destructor.

This adds an explicit copy constructor to a few classes where the compiler cannot build the default copy constructor.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
