### PR TITLE
Enable higher verbosity for benchmarking

### DIFF
--- a/.github/performance/benchcomp-config.yaml
+++ b/.github/performance/benchcomp-config.yaml
@@ -14,12 +14,14 @@ variants:
       directory: /home/runner/work/cbmc/cbmc/aws-c-common.git
       env:
         PATH: /home/runner/work/cbmc/cbmc/old/build/bin:${PATH}
+        CBMC_VERBOSITY: --verbosity 9
   aws-c-common@new:
     config:
       command_line: cd verification/cbmc/proofs && ./run-cbmc-proofs.py
       directory: /home/runner/work/cbmc/cbmc/aws-c-common.git
       env:
         PATH: /home/runner/work/cbmc/cbmc/new/build/bin:${PATH}
+        CBMC_VERBOSITY: --verbosity 9
 
 run:
   suites:


### PR DESCRIPTION
Performance evaluation needs access to timing statistics.

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
