### PR TITLE
implement flattening for +/- for the range type

### DIFF
--- a/src/solvers/flattening/boolbv_add_sub.cpp
+++ b/src/solvers/flattening/boolbv_add_sub.cpp
@@ -124,6 +124,15 @@ bvt boolbvt::convert_add_sub(const exprt &expr)
         }
       }
     }
+    else if(type.id() == ID_range)
+    {
+      // add: lhs + from + rhs + from - from = lhs + rhs + from
+      // sub: lhs + from - (rhs + from) - from = lhs - rhs - from
+      mp_integer from = to_range_type(type).get_from();
+      bv = bv_utils.add_sub(bv, op, subtract);
+      bv = bv_utils.add_sub(
+        bv, bv_utils.build_constant(from, op.size()), subtract);
+    }
     else if(type.id()==ID_floatbv)
     {
       // needs to change due to rounding mode


### PR DESCRIPTION
The flattening solver backend lowers the integer range type to bitvectors. This adds support for addition and subtraction for the range type via lowering to bitvector addition/subtraction.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
