### PR TITLE
Compile CaDiCaL with -DNDEBUG

### DIFF
--- a/scripts/cadical_CMakeLists.txt
+++ b/scripts/cadical_CMakeLists.txt
@@ -9,7 +9,7 @@ add_library(cadical ${sources})
 
 # Pass -DNBUILD to disable including the version information, which is not
 # needed since cbmc doesn't run the cadical binary
-target_compile_options(cadical PUBLIC -DNBUILD -DNFLEXIBLE)
+target_compile_options(cadical PRIVATE -DNBUILD -DNFLEXIBLE -DNDEBUG)
 
 set_target_properties(
     cadical

--- a/src/solvers/Makefile
+++ b/src/solvers/Makefile
@@ -281,7 +281,7 @@ solvers$(LIBEXT): $(OBJ) $(SOLVER_LIB)
 	$(LINKLIB)
 
 ../../cadical/build/libcadical$(LIBEXT):
-	$(MAKE) $(MAKEARGS) -C $(CADICAL)/build libcadical.a CXX="$(CXX)" CXXFLAGS="$(CP_CXXFLAGS) -DNFLEXIBLE"
+	$(MAKE) $(MAKEARGS) -C $(CADICAL)/build libcadical.a CXX="$(CXX)" CXXFLAGS="$(CP_CXXFLAGS) -DNFLEXIBLE -DNDEBUG"
 
 -include smt2/smt2_solver$(DEPEXT)
 


### PR DESCRIPTION
Using CaDiCaL with CBMC showed substantially decreased performance between versions 1.8.0 and 1.9.0. This has become apparent with Kani, but also our THOROUGH tests changed from 7 minutes to just under 2 hours in CI. The culprit is
https://github.com/arminbiere/cadical/commit/69e7cfb865868266dca396afe5aa66e78efd1c48, which introduces expensive checks in `NDEBUG` blocks.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [x] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
