### PR TITLE
Promote set_all_frozen to decision_proceduret to remove a dynamic_cast

### DIFF
--- a/src/goto-checker/single_loop_incremental_symex_checker.cpp
+++ b/src/goto-checker/single_loop_incremental_symex_checker.cpp
@@ -43,11 +43,9 @@ single_loop_incremental_symex_checkert::single_loop_incremental_symex_checkert(
   unwindset.parse_unwindset(
     options.get_list_option("unwindset"), goto_model, ui_message_handler);
 
-  // Freeze all symbols if we are using a prop_conv_solvert
-  prop_conv_solvert *prop_conv_solver = dynamic_cast<prop_conv_solvert *>(
-    &property_decider.get_decision_procedure());
-  if(prop_conv_solver != nullptr)
-    prop_conv_solver->set_all_frozen();
+  // Freeze all solver variables for SAT-based incremental solving (a no-op for
+  // non-SAT-flattening decision procedures).
+  property_decider.get_decision_procedure().set_all_frozen();
 }
 
 void output_incremental_status(

--- a/src/solvers/prop/prop_conv_solver.h
+++ b/src/solvers/prop/prop_conv_solver.h
@@ -54,7 +54,7 @@ public:
 
   void set_frozen(literalt);
   void set_frozen(const bvt &);
-  void set_all_frozen();
+  void set_all_frozen() override;
 
   literalt convert(const exprt &expr) override;
   bool is_in_conflict(const exprt &expr) const override;

--- a/src/solvers/stack_decision_procedure.h
+++ b/src/solvers/stack_decision_procedure.h
@@ -75,6 +75,16 @@ public:
   /// Popping from the empty stack results in an invariant violation.
   virtual void pop() = 0;
 
+  /// Freeze all solver variables that the decision procedure introduces, so
+  /// that an incremental SAT backend's simplifier does not eliminate them
+  /// between successive `operator()` calls. This is needed by SAT-based
+  /// flattening backends (see `prop_conv_solvert::set_all_frozen`); SMT-based
+  /// stack decision procedures rely on push/pop for incrementality and so do
+  /// not need freezing, which is why the default implementation is a no-op.
+  virtual void set_all_frozen()
+  {
+  }
+
   virtual ~stack_decision_proceduret() = default;
 };
 


### PR DESCRIPTION
We can safely implement this as a no-op.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
