### PR TITLE
Remove uses of `dynamic_cast` from qualifierst hierarchy

### DIFF
--- a/jbmc/src/java_bytecode/java_qualifiers.cpp
+++ b/jbmc/src/java_bytecode/java_qualifiers.cpp
@@ -51,36 +51,26 @@ void java_qualifierst::write(typet &src) const
   type_checked_cast<annotated_typet>(src).get_annotations() = annotations;
 }
 
-qualifierst &java_qualifierst::operator+=(const qualifierst &other)
+java_qualifierst &java_qualifierst::operator+=(const java_qualifierst &other)
 {
   c_qualifierst::operator+=(other);
-  auto jq = dynamic_cast<const java_qualifierst *>(&other);
-  if(jq != nullptr)
-  {
-    std::copy(
-      jq->annotations.begin(),
-      jq->annotations.end(),
-      std::back_inserter(annotations));
-  }
+  std::copy(
+    other.annotations.begin(),
+    other.annotations.end(),
+    std::back_inserter(annotations));
   return *this;
 }
 
-bool java_qualifierst::operator==(const qualifierst &other) const
+bool java_qualifierst::operator==(const java_qualifierst &other) const
 {
-  auto jq = dynamic_cast<const java_qualifierst *>(&other);
-  if(jq == nullptr)
-    return false;
-  return c_qualifierst::operator==(other) && annotations == jq->annotations;
+  return c_qualifierst::operator==(other) && annotations == other.annotations;
 }
 
-bool java_qualifierst::is_subset_of(const qualifierst &other) const
+bool java_qualifierst::is_subset_of(const java_qualifierst &other) const
 {
   if(!c_qualifierst::is_subset_of(other))
     return false;
-  auto jq = dynamic_cast<const java_qualifierst *>(&other);
-  if(jq == nullptr)
-    return annotations.empty();
-  auto &other_a = jq->annotations;
+  auto &other_a = other.annotations;
   for(const auto &annotation : annotations)
   {
     if(std::find(other_a.begin(), other_a.end(), annotation) == other_a.end())

--- a/jbmc/src/java_bytecode/java_qualifiers.h
+++ b/jbmc/src/java_bytecode/java_qualifiers.h
@@ -25,7 +25,7 @@ protected:
 public:
   virtual std::unique_ptr<qualifierst> clone() const override;
 
-  virtual qualifierst &operator+=(const qualifierst &other) override;
+  java_qualifierst &operator+=(const java_qualifierst &other);
 
   const std::vector<java_annotationt> &get_annotations() const
   {
@@ -38,8 +38,12 @@ public:
   virtual void read(const typet &src) override;
   virtual void write(typet &src) const override;
 
-  virtual bool is_subset_of(const qualifierst &other) const override;
-  virtual bool operator==(const qualifierst &other) const override;
+  bool is_subset_of(const java_qualifierst &other) const;
+  bool operator==(const java_qualifierst &other) const;
+  bool operator!=(const java_qualifierst &other) const
+  {
+    return !(*this == other);
+  }
 
   virtual std::string as_string() const override;
 };

--- a/src/ansi-c/c_qualifiers.h
+++ b/src/ansi-c/c_qualifiers.h
@@ -35,22 +35,12 @@ public:
 public:
   virtual std::unique_ptr<qualifierst> clone() const = 0;
 
-  virtual qualifierst &operator+=(const qualifierst &b) = 0;
-
   virtual std::size_t count() const = 0;
 
   virtual void clear() = 0;
 
   virtual void read(const typet &src) = 0;
   virtual void write(typet &src) const = 0;
-
-  // Comparisons
-  virtual bool is_subset_of(const qualifierst &q) const = 0;
-  virtual bool operator==(const qualifierst &other) const = 0;
-  bool operator!=(const qualifierst &other) const
-  {
-    return !(*this == other);
-  }
 
   // String conversion
   virtual std::string as_string() const = 0;
@@ -107,41 +97,47 @@ public:
 
   static void clear(typet &dest);
 
-  virtual bool is_subset_of(const qualifierst &other) const override
+  bool is_subset_of(const c_qualifierst &other) const
   {
-    const c_qualifierst *cq = dynamic_cast<const c_qualifierst *>(&other);
-    return (!is_constant || cq->is_constant) &&
-           (!is_volatile || cq->is_volatile) &&
-           (!is_restricted || cq->is_restricted) &&
-           (!is_atomic || cq->is_atomic) && (!is_ptr32 || cq->is_ptr32) &&
-           (!is_ptr64 || cq->is_ptr64) && (!is_nodiscard || cq->is_nodiscard) &&
-           (!is_noreturn || cq->is_noreturn);
+    return (!is_constant || other.is_constant) &&
+           (!is_volatile || other.is_volatile) &&
+           (!is_restricted || other.is_restricted) &&
+           (!is_atomic || other.is_atomic) && (!is_ptr32 || other.is_ptr32) &&
+           (!is_ptr64 || other.is_ptr64) &&
+           (!is_nodiscard || other.is_nodiscard) &&
+           (!is_noreturn || other.is_noreturn);
 
     // is_transparent_union isn't checked
   }
 
-  virtual bool operator==(const qualifierst &other) const override
+  bool operator==(const c_qualifierst &other) const
   {
-    const c_qualifierst *cq = dynamic_cast<const c_qualifierst *>(&other);
-    return is_constant == cq->is_constant && is_volatile == cq->is_volatile &&
-           is_restricted == cq->is_restricted && is_atomic == cq->is_atomic &&
-           is_ptr32 == cq->is_ptr32 && is_ptr64 == cq->is_ptr64 &&
-           is_transparent_union == cq->is_transparent_union &&
-           is_nodiscard == cq->is_nodiscard && is_noreturn == cq->is_noreturn;
+    return is_constant == other.is_constant &&
+           is_volatile == other.is_volatile &&
+           is_restricted == other.is_restricted &&
+           is_atomic == other.is_atomic && is_ptr32 == other.is_ptr32 &&
+           is_ptr64 == other.is_ptr64 &&
+           is_transparent_union == other.is_transparent_union &&
+           is_nodiscard == other.is_nodiscard &&
+           is_noreturn == other.is_noreturn;
   }
 
-  virtual qualifierst &operator+=(const qualifierst &other) override
+  bool operator!=(const c_qualifierst &other) const
   {
-    const c_qualifierst *cq = dynamic_cast<const c_qualifierst *>(&other);
-    is_constant |= cq->is_constant;
-    is_volatile |= cq->is_volatile;
-    is_restricted |= cq->is_restricted;
-    is_atomic |= cq->is_atomic;
-    is_ptr32 |= cq->is_ptr32;
-    is_ptr64 |= cq->is_ptr64;
-    is_transparent_union |= cq->is_transparent_union;
-    is_nodiscard |= cq->is_nodiscard;
-    is_noreturn |= cq->is_noreturn;
+    return !(*this == other);
+  }
+
+  c_qualifierst &operator+=(const c_qualifierst &other)
+  {
+    is_constant |= other.is_constant;
+    is_volatile |= other.is_volatile;
+    is_restricted |= other.is_restricted;
+    is_atomic |= other.is_atomic;
+    is_ptr32 |= other.is_ptr32;
+    is_ptr64 |= other.is_ptr64;
+    is_transparent_union |= other.is_transparent_union;
+    is_nodiscard |= other.is_nodiscard;
+    is_noreturn |= other.is_noreturn;
     return *this;
   }
 


### PR DESCRIPTION
There is no need to use virtual methods as we always know from context the exact type we are working with.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
