### PR TITLE
Remove dynamic_cast from bv_dimacst

### DIFF
--- a/src/solvers/flattening/bv_dimacs.cpp
+++ b/src/solvers/flattening/bv_dimacs.cpp
@@ -16,6 +16,17 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <fstream> // IWYU pragma: keep
 #include <iostream>
 
+bv_dimacst::bv_dimacst(
+  const namespacet &_ns,
+  dimacs_cnft &_prop,
+  message_handlert &message_handler,
+  const std::string &_filename)
+  : bv_pointerst(_ns, _prop, message_handler),
+    filename(_filename),
+    dimacs_cnf_prop(_prop)
+{
+}
+
 bool bv_dimacst::write_dimacs()
 {
   if(filename.empty() || filename == "-")
@@ -34,7 +45,7 @@ bool bv_dimacst::write_dimacs()
 
 bool bv_dimacst::write_dimacs(std::ostream &out)
 {
-  dynamic_cast<dimacs_cnft &>(prop).write_dimacs_cnf(out);
+  dimacs_cnf_prop.write_dimacs_cnf(out);
 
   // we dump the mapping variable<->literals
   for(const auto &s : get_symbols())

--- a/src/solvers/flattening/bv_dimacs.h
+++ b/src/solvers/flattening/bv_dimacs.h
@@ -14,17 +14,16 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "bv_pointers.h"
 
+class dimacs_cnft;
+
 class bv_dimacst : public bv_pointerst
 {
 public:
   bv_dimacst(
     const namespacet &_ns,
-    propt &_prop,
+    dimacs_cnft &_prop,
     message_handlert &message_handler,
-    const std::string &_filename)
-    : bv_pointerst(_ns, _prop, message_handler), filename(_filename)
-  {
-  }
+    const std::string &_filename);
 
   virtual ~bv_dimacst()
   {
@@ -33,6 +32,8 @@ public:
 
 protected:
   const std::string filename;
+  const dimacs_cnft &dimacs_cnf_prop;
+
   bool write_dimacs();
   bool write_dimacs(std::ostream &);
 };

--- a/src/solvers/sat/dimacs_cnf.cpp
+++ b/src/solvers/sat/dimacs_cnf.cpp
@@ -37,13 +37,13 @@ dimacs_cnf_dumpt::dimacs_cnf_dumpt(
 {
 }
 
-void dimacs_cnft::write_dimacs_cnf(std::ostream &out)
+void dimacs_cnft::write_dimacs_cnf(std::ostream &out) const
 {
   write_problem_line(out);
   write_clauses(out);
 }
 
-void dimacs_cnft::write_problem_line(std::ostream &out)
+void dimacs_cnft::write_problem_line(std::ostream &out) const
 {
   // We start counting at 1, thus there is one variable fewer.
   out << "p cnf " << (no_variables()-1) << " "
@@ -76,7 +76,7 @@ void dimacs_cnft::write_dimacs_clause(
   out << "0" << "\n";
 }
 
-void dimacs_cnft::write_clauses(std::ostream &out)
+void dimacs_cnft::write_clauses(std::ostream &out) const
 {
   std::size_t count = 0;
   std::stringstream output_block;

--- a/src/solvers/sat/dimacs_cnf.h
+++ b/src/solvers/sat/dimacs_cnf.h
@@ -20,7 +20,7 @@ public:
   explicit dimacs_cnft(message_handlert &);
   virtual ~dimacs_cnft() { }
 
-  virtual void write_dimacs_cnf(std::ostream &out);
+  virtual void write_dimacs_cnf(std::ostream &out) const;
 
   // dummy functions
 
@@ -36,8 +36,8 @@ public:
   write_dimacs_clause(const bvt &, std::ostream &, bool break_lines);
 
 protected:
-  void write_problem_line(std::ostream &out);
-  void write_clauses(std::ostream &out);
+  void write_problem_line(std::ostream &out) const;
+  void write_clauses(std::ostream &out) const;
 
   bool break_lines;
 };


### PR DESCRIPTION
We can just hold on to the dimacs_cnft typed instance of propt that is used for constructing the object.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
