### PR TITLE
Remove Java's unnecessary languaget::parse peculiarity

### DIFF
--- a/jbmc/src/janalyzer/janalyzer_parse_options.cpp
+++ b/jbmc/src/janalyzer/janalyzer_parse_options.cpp
@@ -380,8 +380,8 @@ int janalyzer_parse_optionst::doit()
 
     log.status() << "Parsing ..." << messaget::eom;
 
-    if(static_cast<java_bytecode_languaget *>(language.get())
-         ->parse(ui_message_handler))
+    std::istringstream unused;
+    if(language.get()->parse(unused, "", ui_message_handler))
     {
       log.error() << "PARSING ERROR" << messaget::eom;
       return CPROVER_EXIT_PARSE_ERROR;

--- a/jbmc/src/java_bytecode/java_bytecode_language.cpp
+++ b/jbmc/src/java_bytecode/java_bytecode_language.cpp
@@ -363,17 +363,6 @@ void java_bytecode_languaget::parse_from_main_class(
 }
 
 /// We set the main class (i.e.\ class to start the class loading analysis,
-/// see \ref java_class_loadert) when we have have been given a main class.
-bool java_bytecode_languaget::parse(message_handlert &message_handler)
-{
-  PRECONDITION(language_options.has_value());
-  initialize_class_loader(message_handler);
-  main_class = config.java.main_class;
-  parse_from_main_class(message_handler);
-  return false;
-}
-
-/// We set the main class (i.e.\ class to start the class loading analysis,
 /// see \ref java_class_loadert)
 /// when we have a JAR file given via the -jar option:
 ///    a) the argument of the --main-class command-line option,

--- a/jbmc/src/java_bytecode/java_bytecode_language.h
+++ b/jbmc/src/java_bytecode/java_bytecode_language.h
@@ -267,12 +267,6 @@ public:
     std::ostream &outstream,
     message_handlert &message_handler) override;
 
-  // This is an extension to languaget
-  // required because parsing of Java programs can be initiated without
-  // opening a file first or providing a path to a file
-  // as dictated by \ref languaget.
-  virtual bool parse(message_handlert &);
-
   bool parse(
     std::istream &instream,
     const std::string &path,

--- a/jbmc/src/java_bytecode/lazy_goto_model.cpp
+++ b/jbmc/src/java_bytecode/lazy_goto_model.cpp
@@ -145,7 +145,8 @@ void lazy_goto_modelt::initialize(
 
     msg.status() << "Parsing ..." << messaget::eom;
 
-    if(dynamic_cast<java_bytecode_languaget &>(language).parse(message_handler))
+    std::istringstream unused;
+    if(language.parse(unused, "", message_handler))
     {
       throw invalid_input_exceptiont("PARSING ERROR");
     }

--- a/jbmc/src/jbmc/jbmc_parse_options.cpp
+++ b/jbmc/src/jbmc/jbmc_parse_options.cpp
@@ -458,8 +458,8 @@ int jbmc_parse_optionst::doit()
 
     log.status() << "Parsing ..." << messaget::eom;
 
-    if(static_cast<java_bytecode_languaget *>(language.get())
-         ->parse(ui_message_handler))
+    std::istringstream unused;
+    if(language.get()->parse(unused, "", ui_message_handler))
     {
       log.error() << "PARSING ERROR" << messaget::eom;
       return CPROVER_EXIT_PARSE_ERROR;


### PR DESCRIPTION
We can safely use the three-argument version and thereby avoid a need for casting.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
