### PR TITLE
Solver factory: set_decision_procedure_time_limit does not require dynamic_cast

### DIFF
--- a/src/goto-checker/solver_factory.cpp
+++ b/src/goto-checker/solver_factory.cpp
@@ -82,26 +82,13 @@ solver_factoryt::solvert::stack_decision_procedure() const
 }
 
 void solver_factoryt::set_decision_procedure_time_limit(
-  decision_proceduret &decision_procedure)
+  solver_resource_limitst &decision_procedure)
 {
   const int timeout_seconds =
     options.get_signed_int_option("solver-time-limit");
 
   if(timeout_seconds > 0)
-  {
-    solver_resource_limitst *solver =
-      dynamic_cast<solver_resource_limitst *>(&decision_procedure);
-    if(solver == nullptr)
-    {
-      messaget log(message_handler);
-      log.warning() << "cannot set solver time limit on "
-                    << decision_procedure.decision_procedure_text()
-                    << messaget::eom;
-      return;
-    }
-
-    solver->set_time_limit_seconds(timeout_seconds);
-  }
+    decision_procedure.set_time_limit_seconds(timeout_seconds);
 }
 
 void solver_factoryt::solvert::set_decision_procedure(
@@ -531,7 +518,6 @@ solver_factoryt::get_smt2(smt2_dect::solvert solver)
     if(options.get_bool_option("fpa"))
       smt2_dec->use_FPA_theory = true;
 
-    set_decision_procedure_time_limit(*smt2_dec);
     return std::make_unique<solvert>(std::move(smt2_dec));
   }
   else if(filename == "-")
@@ -547,7 +533,6 @@ solver_factoryt::get_smt2(smt2_dect::solvert solver)
     if(options.get_bool_option("fpa"))
       smt2_conv->use_FPA_theory = true;
 
-    set_decision_procedure_time_limit(*smt2_conv);
     return std::make_unique<solvert>(std::move(smt2_conv));
   }
   else
@@ -565,7 +550,6 @@ solver_factoryt::get_smt2(smt2_dect::solvert solver)
     if(options.get_bool_option("fpa"))
       smt2_conv->use_FPA_theory = true;
 
-    set_decision_procedure_time_limit(*smt2_conv);
     return std::make_unique<solvert>(std::move(smt2_conv), std::move(out));
   }
 }

--- a/src/goto-checker/solver_factory.h
+++ b/src/goto-checker/solver_factory.h
@@ -21,6 +21,7 @@ class cmdlinet;
 class message_handlert;
 class namespacet;
 class optionst;
+class solver_resource_limitst;
 class stack_decision_proceduret;
 
 class solver_factoryt final
@@ -81,8 +82,8 @@ protected:
   /// Sets the timeout of \p decision_procedure if the `solver-time-limit`
   /// option has a positive value (in seconds).
   /// \note Most solvers silently ignore the time limit at the moment.
-  void
-  set_decision_procedure_time_limit(decision_proceduret &decision_procedure);
+  void set_decision_procedure_time_limit(
+    solver_resource_limitst &decision_procedure);
 
   // consistency checks during solver creation
   void no_beautification();


### PR DESCRIPTION
At each call site we already know whether the decision procedure is a `solver_resource_limitst`, so we just don't invoke it when it is not.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
