### PR TITLE
Dynamic frames: do not add trivial properties

### DIFF
--- a/regression/contracts-dfcc/assigns_enforce_malloc_02/test.desc
+++ b/regression/contracts-dfcc/assigns_enforce_malloc_02/test.desc
@@ -2,9 +2,7 @@ CORE dfcc-only
 main.c
 --no-malloc-may-fail --dfcc main --enforce-contract f
 main.c function f
-^\[f.assigns.\d+\] line 7 Check that ptr is assignable: SUCCESS$
 ^\[f.assigns.\d+\] line 12 Check that \*ptr is assignable: SUCCESS$
-^\[f.assigns.\d+\] line 13 Check that n is assignable: SUCCESS$
 ^EXIT=0$
 ^SIGNAL=0$
 ^VERIFICATION SUCCESSFUL$

--- a/regression/contracts-dfcc/assigns_enforce_statics/test.desc
+++ b/regression/contracts-dfcc/assigns_enforce_statics/test.desc
@@ -1,7 +1,6 @@
 CORE dfcc-only
 main.c
 --dfcc main --enforce-contract foo _ --pointer-primitive-check
-^\[foo.assigns.\d+\] line \d+ Check that y is assignable: SUCCESS$
 ^\[foo.assigns.\d+\] line \d+ Check that foo\$\$1\$\$x is assignable: SUCCESS$
 ^\[foo.assigns.\d+\] line \d+ Check that \*y is assignable: FAILURE$
 ^VERIFICATION FAILED$

--- a/regression/contracts-dfcc/loop-freeness-check/test.desc
+++ b/regression/contracts-dfcc/loop-freeness-check/test.desc
@@ -1,7 +1,6 @@
 CORE dfcc-only
 main.c
 --dfcc main --enforce-contract foo
-^\[foo.assigns.\d+\].*Check that i is assignable: SUCCESS$
 ^\[foo.assigns.\d+\].*Check that arr\[(\(.*\))?i\] is assignable: SUCCESS$
 ^VERIFICATION SUCCESSFUL$
 ^EXIT=0$

--- a/regression/contracts-dfcc/loop_body_with_hole/test.desc
+++ b/regression/contracts-dfcc/loop_body_with_hole/test.desc
@@ -1,14 +1,11 @@
 CORE dfcc-only
 main.c
 --dfcc main --apply-loop-contracts
-^\[main.assigns.\d+\] line 6 Check that sum_to_k is assignable: SUCCESS$
-^\[main.assigns.\d+\] line 7 Check that flag is assignable: SUCCESS$
 ^\[main.assigns.\d+\] line 9 Check that i is assignable: SUCCESS$
 ^\[main.loop_assigns.\d+\] line 9 Check assigns clause inclusion for loop .*: SUCCESS$
 ^\[main.loop_invariant_base.\d+\] line 9 Check invariant before entry for loop .*: SUCCESS$
 ^\[main.loop_invariant_step.\d+\] line 9 Check invariant after step for loop .*: SUCCESS$
 ^\[main.loop_step_unwinding.\d+\] line 9 Check step was unwound for loop .*: SUCCESS$
-^\[main.assigns.\d+\] line 17 Check that flag is assignable: SUCCESS$
 ^\[main.assigns.\d+\] line 20 Check that sum_to_k is assignable: SUCCESS$
 ^VERIFICATION SUCCESSFUL$
 ^EXIT=0$


### PR DESCRIPTION
There is no need to add `ASSERT true` to the collection of properties.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
