### PR TITLE
Maintain loop invariant annotation when converting do .. while

### DIFF
--- a/regression/contracts-dfcc/loop_contracts_do_while/assigns.c
+++ b/regression/contracts-dfcc/loop_contracts_do_while/assigns.c
@@ -1,0 +1,19 @@
+int global;
+
+int main()
+{
+  global = 0;
+  int argc = 1;
+  if(argc > 1)
+  {
+    do
+      __CPROVER_assigns(global)
+      {
+        global = 1;
+      }
+    while(0);
+  }
+  __CPROVER_assert(global == 0, "should be zero");
+
+  return 0;
+}

--- a/regression/contracts-dfcc/loop_contracts_do_while/assigns.desc
+++ b/regression/contracts-dfcc/loop_contracts_do_while/assigns.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE dfcc-only
 assigns.c
 --dfcc main --apply-loop-contracts
 ^EXIT=0$

--- a/regression/contracts-dfcc/loop_contracts_do_while/assigns.desc
+++ b/regression/contracts-dfcc/loop_contracts_do_while/assigns.desc
@@ -1,5 +1,5 @@
-CORE dfcc-only
-main.c
+KNOWNBUG
+assigns.c
 --dfcc main --apply-loop-contracts
 ^EXIT=0$
 ^SIGNAL=0$

--- a/regression/contracts-dfcc/loop_contracts_do_while/main.c
+++ b/regression/contracts-dfcc/loop_contracts_do_while/main.c
@@ -5,7 +5,7 @@ int main()
   int x = 0;
 
   do
-    __CPROVER_loop_invariant(0 <= x && x <= 10)
+    __CPROVER_loop_invariant(0 <= x && x < 10)
     {
       x++;
     }

--- a/regression/contracts-dfcc/loop_contracts_do_while/side_effect.c
+++ b/regression/contracts-dfcc/loop_contracts_do_while/side_effect.c
@@ -1,0 +1,24 @@
+int global;
+
+int foo()
+{
+  return 0;
+}
+
+int main()
+{
+  global = 0;
+  int argc = 1;
+  if(argc > 1)
+  {
+    do
+      __CPROVER_assigns(global)
+      {
+        global = 1;
+      }
+    while(foo());
+  }
+  __CPROVER_assert(global == 0, "should be zero");
+
+  return 0;
+}

--- a/regression/contracts-dfcc/loop_contracts_do_while/side_effect.desc
+++ b/regression/contracts-dfcc/loop_contracts_do_while/side_effect.desc
@@ -1,5 +1,5 @@
-CORE dfcc-only
-main.c
+KNOWNBUG
+side_effect.c
 --dfcc main --apply-loop-contracts
 ^EXIT=0$
 ^SIGNAL=0$

--- a/regression/contracts-dfcc/loop_contracts_do_while/side_effect.desc
+++ b/regression/contracts-dfcc/loop_contracts_do_while/side_effect.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE dfcc-only
 side_effect.c
 --dfcc main --apply-loop-contracts
 ^EXIT=0$

--- a/regression/contracts/loop_contracts_do_while/test.desc
+++ b/regression/contracts/loop_contracts_do_while/test.desc
@@ -1,4 +1,4 @@
-CORE
+KNOWNBUG
 main.c
 --apply-loop-contracts
 ^EXIT=0$
@@ -7,3 +7,4 @@ main.c
 --
 --
 This test checks that loop contracts work correctly on do/while loops.
+Fails because contracts are not yet supported on do while loops.

--- a/src/goto-instrument/contracts/utils.cpp
+++ b/src/goto-instrument/contracts/utils.cpp
@@ -250,7 +250,7 @@ void insert_before_and_update_jumps(
   const auto new_target = destination.insert_before(target, i);
   for(auto it : target->incoming_edges)
   {
-    if(it->is_goto())
+    if(it->is_goto() && it->get_target() == target)
       it->set_target(new_target);
   }
 }


### PR DESCRIPTION
With the changes in bbd9de4c9f6f7 we newly made do .. while converted instructions subject to `optimize_guarded_gotos`, which previously rewrote conditions without retaining annotations related to loop invariants.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
