### PR TITLE
Remove dynamic_cast from counterexample beautification code path

### DIFF
--- a/src/goto-checker/goto_symex_property_decider.cpp
+++ b/src/goto-checker/goto_symex_property_decider.cpp
@@ -120,6 +120,11 @@ goto_symex_property_decidert::get_decision_procedure() const
   return solver->decision_procedure();
 }
 
+boolbvt &goto_symex_property_decidert::get_boolbv_decision_procedure() const
+{
+  return solver->boolbv_decision_procedure();
+}
+
 symex_target_equationt &goto_symex_property_decidert::get_equation() const
 {
   return equation;

--- a/src/goto-checker/goto_symex_property_decider.h
+++ b/src/goto-checker/goto_symex_property_decider.h
@@ -47,6 +47,9 @@ public:
   /// Returns the solver instance
   stack_decision_proceduret &get_decision_procedure() const;
 
+  /// Returns the solver instance
+  boolbvt &get_boolbv_decision_procedure() const;
+
   /// Return the equation associated with this instance
   symex_target_equationt &get_equation() const;
 

--- a/src/goto-checker/multi_path_symex_checker.cpp
+++ b/src/goto-checker/multi_path_symex_checker.cpp
@@ -113,8 +113,7 @@ goto_tracet multi_path_symex_checkert::build_shortest_trace() const
   {
     // NOLINTNEXTLINE(whitespace/braces)
     counterexample_beautificationt{ui_message_handler}(
-      dynamic_cast<boolbvt &>(property_decider.get_decision_procedure()),
-      equation);
+      property_decider.get_boolbv_decision_procedure(), equation);
   }
 
   goto_tracet goto_trace;

--- a/src/goto-checker/single_loop_incremental_symex_checker.cpp
+++ b/src/goto-checker/single_loop_incremental_symex_checker.cpp
@@ -207,8 +207,7 @@ goto_tracet single_loop_incremental_symex_checkert::build_shortest_trace() const
   {
     // NOLINTNEXTLINE(whitespace/braces)
     counterexample_beautificationt{ui_message_handler}(
-      dynamic_cast<boolbvt &>(property_decider.get_decision_procedure()),
-      equation);
+      property_decider.get_boolbv_decision_procedure(), equation);
   }
 
   goto_tracet goto_trace;

--- a/src/goto-checker/single_path_symex_checker.cpp
+++ b/src/goto-checker/single_path_symex_checker.cpp
@@ -144,7 +144,7 @@ goto_tracet single_path_symex_checkert::build_shortest_trace() const
   {
     // NOLINTNEXTLINE(whitespace/braces)
     counterexample_beautificationt{ui_message_handler}(
-      dynamic_cast<boolbvt &>(property_decider->get_decision_procedure()),
+      property_decider->get_boolbv_decision_procedure(),
       property_decider->get_equation());
   }
 

--- a/src/goto-checker/solver_factory.h
+++ b/src/goto-checker/solver_factory.h
@@ -12,7 +12,7 @@ Author: Daniel Kroening, Peter Schrammel
 #ifndef CPROVER_GOTO_CHECKER_SOLVER_FACTORY_H
 #define CPROVER_GOTO_CHECKER_SOLVER_FACTORY_H
 
-#include <solvers/prop/prop.h>
+#include <solvers/flattening/boolbv.h>
 #include <solvers/smt2/smt2_dec.h>
 
 #include <memory>
@@ -45,17 +45,17 @@ public:
     solvert(
       std::unique_ptr<stack_decision_proceduret> p1,
       std::unique_ptr<std::ofstream> p2);
+    solvert(std::unique_ptr<boolbvt> p1, std::unique_ptr<propt> p2);
 
     stack_decision_proceduret &decision_procedure() const;
+    boolbvt &boolbv_decision_procedure() const;
 
-    void set_decision_procedure(std::unique_ptr<stack_decision_proceduret> p);
-    void set_prop(std::unique_ptr<propt> p);
-    void set_ofstream(std::unique_ptr<std::ofstream> p);
-
+  private:
     // the objects are deleted in the opposite order they appear below
     std::unique_ptr<std::ofstream> ofstream_ptr;
     std::unique_ptr<propt> prop_ptr;
     std::unique_ptr<stack_decision_proceduret> decision_procedure_ptr;
+    std::unique_ptr<boolbvt> decision_procedure_is_boolbvt_ptr;
   };
 
   /// Returns a solvert object


### PR DESCRIPTION
We know at solver-construction time whether we have one deriving from boolbvt.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
