### PR TITLE
Remove dynamic_cast from hardness collection code paths

### DIFF
--- a/src/goto-checker/bmc_util.cpp
+++ b/src/goto-checker/bmc_util.cpp
@@ -145,15 +145,16 @@ void output_graphml(
   }
 }
 
-void convert_symex_target_equation(
+static void convert_symex_target_equation(
   symex_target_equationt &equation,
   decision_proceduret &decision_procedure,
+  solver_hardnesst *hardness_collector,
   message_handlert &message_handler)
 {
   messaget msg(message_handler);
   msg.status() << "converting SSA" << messaget::eom;
 
-  equation.convert(decision_procedure);
+  equation.convert(decision_procedure, hardness_collector);
 }
 
 std::unique_ptr<memory_model_baset>
@@ -350,7 +351,10 @@ std::chrono::duration<double> prepare_property_decider(
   try
   {
     convert_symex_target_equation(
-      equation, property_decider.get_decision_procedure(), ui_message_handler);
+      equation,
+      property_decider.get_decision_procedure(),
+      property_decider.get_hardness_collector(),
+      ui_message_handler);
     property_decider.update_properties_goals_from_symex_target_equation(
       properties);
     property_decider.convert_goals();

--- a/src/goto-checker/bmc_util.h
+++ b/src/goto-checker/bmc_util.h
@@ -26,18 +26,12 @@ class decision_proceduret;
 class goto_symex_property_decidert;
 class goto_tracet;
 class memory_model_baset;
-class message_handlert;
 class namespacet;
 class optionst;
 class symex_bmct;
 class symex_target_equationt;
 struct trace_optionst;
 class ui_message_handlert;
-
-void convert_symex_target_equation(
-  symex_target_equationt &equation,
-  decision_proceduret &decision_procedure,
-  message_handlert &message_handler);
 
 /// Returns a function that checks whether an SSA step is an assertion
 /// with \p property_id. Usually used for `build_goto_trace`.

--- a/src/goto-checker/goto_symex_property_decider.cpp
+++ b/src/goto-checker/goto_symex_property_decider.cpp
@@ -98,13 +98,14 @@ void goto_symex_property_decidert::add_constraint_from_goals(
   exprt goal_disjunction = disjunction(disjuncts);
   decision_procedure.set_to_true(goal_disjunction);
 
-  with_solver_hardness(decision_procedure, [](solver_hardnesst &hardness) {
+  if(auto hardness = solver->hardness_collector())
+  {
     // SSA expr and involved steps have already been collected
     // in symex_target_equationt::convert_assertions
     exprt ssa_expr_unused;
     std::vector<goto_programt::const_targett> involved_steps_unused;
-    hardness.register_assertion_ssas(ssa_expr_unused, involved_steps_unused);
-  });
+    hardness->register_assertion_ssas(ssa_expr_unused, involved_steps_unused);
+  }
 }
 
 decision_proceduret::resultt goto_symex_property_decidert::solve()
@@ -121,6 +122,11 @@ goto_symex_property_decidert::get_decision_procedure() const
 boolbvt &goto_symex_property_decidert::get_boolbv_decision_procedure() const
 {
   return solver->boolbv_decision_procedure();
+}
+
+solver_hardnesst *goto_symex_property_decidert::get_hardness_collector() const
+{
+  return solver->hardness_collector();
 }
 
 symex_target_equationt &goto_symex_property_decidert::get_equation() const

--- a/src/goto-checker/goto_symex_property_decider.h
+++ b/src/goto-checker/goto_symex_property_decider.h
@@ -50,6 +50,10 @@ public:
   /// Returns the solver instance
   boolbvt &get_boolbv_decision_procedure() const;
 
+  /// Returns a pointer to the hardness collector or `nullptr` when hardness
+  /// collection is not set up.
+  solver_hardnesst *get_hardness_collector() const;
+
   /// Return the equation associated with this instance
   symex_target_equationt &get_equation() const;
 

--- a/src/goto-checker/multi_path_symex_checker.cpp
+++ b/src/goto-checker/multi_path_symex_checker.cpp
@@ -169,8 +169,9 @@ void multi_path_symex_checkert::report()
 {
   if(options.is_set("write-solver-stats-to"))
   {
-    with_solver_hardness(
-      property_decider.get_decision_procedure(),
-      [](solver_hardnesst &hardness) { hardness.produce_report(); });
+    if(auto hardness = property_decider.get_hardness_collector())
+    {
+      hardness->produce_report();
+    }
   }
 }

--- a/src/goto-checker/single_loop_incremental_symex_checker.cpp
+++ b/src/goto-checker/single_loop_incremental_symex_checker.cpp
@@ -109,7 +109,8 @@ operator()(propertiest &properties)
 
         log.status() << "converting SSA" << messaget::eom;
         equation.convert_without_assertions(
-          property_decider.get_decision_procedure());
+          property_decider.get_decision_procedure(),
+          property_decider.get_hardness_collector());
 
         property_decider.update_properties_goals_from_symex_target_equation(
           properties);
@@ -117,7 +118,9 @@ operator()(propertiest &properties)
         // We convert the assertions in a new context.
         property_decider.get_decision_procedure().push();
         equation.convert_assertions(
-          property_decider.get_decision_procedure(), false);
+          property_decider.get_decision_procedure(),
+          property_decider.get_hardness_collector(),
+          false);
         property_decider.convert_goals();
 
         current_equation_converted = true;

--- a/src/goto-checker/solver_factory.cpp
+++ b/src/goto-checker/solver_factory.cpp
@@ -82,6 +82,16 @@ solver_factoryt::solvert::solvert(
 {
 }
 
+solver_factoryt::solvert::solvert(
+  std::unique_ptr<boolbvt> p1,
+  std::unique_ptr<propt> p2,
+  std::shared_ptr<solver_hardnesst> p3)
+  : hardness_ptr(std::move(p3)),
+    prop_ptr(std::move(p2)),
+    decision_procedure_is_boolbvt_ptr(std::move(p1))
+{
+}
+
 stack_decision_proceduret &solver_factoryt::solvert::decision_procedure() const
 {
   PRECONDITION(
@@ -97,6 +107,11 @@ boolbvt &solver_factoryt::solvert::boolbv_decision_procedure() const
 {
   PRECONDITION(decision_procedure_is_boolbvt_ptr != nullptr);
   return *decision_procedure_is_boolbvt_ptr;
+}
+
+solver_hardnesst *solver_factoryt::solvert::hardness_collector() const
+{
+  return hardness_ptr.get();
 }
 
 void solver_factoryt::set_decision_procedure_time_limit(
@@ -175,8 +190,9 @@ static void emit_solver_warning(
 template <typename SatcheckT>
 static typename std::enable_if<
   !std::is_base_of<hardness_collectort, SatcheckT>::value,
-  std::unique_ptr<SatcheckT>>::type
-make_satcheck_prop(message_handlert &message_handler, const optionst &options)
+  std::pair<std::unique_ptr<SatcheckT>, std::shared_ptr<solver_hardnesst>>>::
+  type
+  make_satcheck_prop(message_handlert &message_handler, const optionst &options)
 {
   auto satcheck = std::make_unique<SatcheckT>(message_handler);
   if(options.is_set("write-solver-stats-to"))
@@ -186,27 +202,29 @@ make_satcheck_prop(message_handlert &message_handler, const optionst &options)
       << "Configured solver does not support --write-solver-stats-to. "
       << "Solver stats will not be written." << messaget::eom;
   }
-  return satcheck;
+  return {std::move(satcheck), nullptr};
 }
 
 template <typename SatcheckT>
 static typename std::enable_if<
   std::is_base_of<hardness_collectort, SatcheckT>::value,
-  std::unique_ptr<SatcheckT>>::type
-make_satcheck_prop(message_handlert &message_handler, const optionst &options)
+  std::pair<std::unique_ptr<SatcheckT>, std::shared_ptr<solver_hardnesst>>>::
+  type
+  make_satcheck_prop(message_handlert &message_handler, const optionst &options)
 {
   auto satcheck = std::make_unique<SatcheckT>(message_handler);
-  if(options.is_set("write-solver-stats-to"))
-  {
-    std::unique_ptr<solver_hardnesst> solver_hardness =
-      std::make_unique<solver_hardnesst>();
-    solver_hardness->set_outfile(options.get_option("write-solver-stats-to"));
-    satcheck->solver_hardness = std::move(solver_hardness);
-  }
-  return satcheck;
+  if(!options.is_set("write-solver-stats-to"))
+    return {std::move(satcheck), nullptr};
+
+  std::shared_ptr<solver_hardnesst> solver_hardness =
+    std::make_shared<solver_hardnesst>();
+  solver_hardness->set_outfile(options.get_option("write-solver-stats-to"));
+  satcheck->solver_hardness = solver_hardness;
+
+  return {std::move(satcheck), std::move(solver_hardness)};
 }
 
-static std::unique_ptr<propt>
+static std::pair<std::unique_ptr<propt>, std::shared_ptr<solver_hardnesst>>
 get_sat_solver(message_handlert &message_handler, const optionst &options)
 {
   const bool no_simplifier = options.get_bool_option("beautify") ||
@@ -354,12 +372,15 @@ static std::unique_ptr<std::ofstream> open_outfile_and_check(
 
 std::unique_ptr<solver_factoryt::solvert> solver_factoryt::get_default()
 {
-  auto sat_solver = get_sat_solver(message_handler, options);
+  auto sat_solver_and_hardness_opt = get_sat_solver(message_handler, options);
 
   bool get_array_constraints =
     options.get_bool_option("show-array-constraints");
   auto bv_pointers = std::make_unique<bv_pointerst>(
-    ns, *sat_solver, message_handler, get_array_constraints);
+    ns,
+    *sat_solver_and_hardness_opt.first,
+    message_handler,
+    get_array_constraints);
 
   if(options.get_option("arrays-uf") == "never")
     bv_pointers->unbounded_array = bv_pointerst::unbounded_arrayt::U_NONE;
@@ -369,7 +390,10 @@ std::unique_ptr<solver_factoryt::solvert> solver_factoryt::get_default()
   set_decision_procedure_time_limit(*bv_pointers);
 
   std::unique_ptr<boolbvt> boolbv = std::move(bv_pointers);
-  return std::make_unique<solvert>(std::move(boolbv), std::move(sat_solver));
+  return std::make_unique<solvert>(
+    std::move(boolbv),
+    std::move(sat_solver_and_hardness_opt.first),
+    std::move(sat_solver_and_hardness_opt.second));
 }
 
 std::unique_ptr<solver_factoryt::solvert> solver_factoryt::get_dimacs()
@@ -415,11 +439,11 @@ std::unique_ptr<solver_factoryt::solvert> solver_factoryt::get_external_sat()
 
 std::unique_ptr<solver_factoryt::solvert> solver_factoryt::get_bv_refinement()
 {
-  std::unique_ptr<propt> prop = get_sat_solver(message_handler, options);
+  auto prop_and_hardness_opt = get_sat_solver(message_handler, options);
 
   bv_refinementt::infot info;
   info.ns = &ns;
-  info.prop = prop.get();
+  info.prop = prop_and_hardness_opt.first.get();
   info.output_xml = output_xml_in_refinement;
 
   // we allow setting some parameters
@@ -435,7 +459,9 @@ std::unique_ptr<solver_factoryt::solvert> solver_factoryt::get_bv_refinement()
     std::make_unique<bv_refinementt>(info);
   set_decision_procedure_time_limit(*decision_procedure);
   return std::make_unique<solvert>(
-    std::move(decision_procedure), std::move(prop));
+    std::move(decision_procedure),
+    std::move(prop_and_hardness_opt.first),
+    std::move(prop_and_hardness_opt.second));
 }
 
 /// the string refinement adds to the bit vector refinement specifications for
@@ -446,8 +472,8 @@ solver_factoryt::get_string_refinement()
 {
   string_refinementt::infot info;
   info.ns = &ns;
-  auto prop = get_sat_solver(message_handler, options);
-  info.prop = prop.get();
+  auto prop_and_hardness_opt = get_sat_solver(message_handler, options);
+  info.prop = prop_and_hardness_opt.first.get();
   info.refinement_bound = DEFAULT_MAX_NB_REFINEMENT;
   info.output_xml = output_xml_in_refinement;
   if(options.get_bool_option("max-node-refinement"))
@@ -461,7 +487,9 @@ solver_factoryt::get_string_refinement()
     std::make_unique<string_refinementt>(info);
   set_decision_procedure_time_limit(*decision_procedure);
   return std::make_unique<solvert>(
-    std::move(decision_procedure), std::move(prop));
+    std::move(decision_procedure),
+    std::move(prop_and_hardness_opt.first),
+    std::move(prop_and_hardness_opt.second));
 }
 
 std::unique_ptr<solver_factoryt::solvert>

--- a/src/goto-checker/solver_factory.h
+++ b/src/goto-checker/solver_factory.h
@@ -22,6 +22,7 @@ class cmdlinet;
 class message_handlert;
 class namespacet;
 class optionst;
+struct solver_hardnesst;
 class solver_resource_limitst;
 
 class solver_factoryt final
@@ -51,12 +52,21 @@ public:
       std::unique_ptr<boolbvt> p1,
       std::unique_ptr<propt> p2,
       std::unique_ptr<std::ofstream> p3);
+    solvert(
+      std::unique_ptr<boolbvt> p1,
+      std::unique_ptr<propt> p2,
+      std::shared_ptr<solver_hardnesst> p3);
 
     stack_decision_proceduret &decision_procedure() const;
     boolbvt &boolbv_decision_procedure() const;
+    solver_hardnesst *hardness_collector() const;
 
   private:
-    // the objects are deleted in the opposite order they appear below
+    // The objects are deleted in the opposite order in which they appear
+    // below. hardness_ptr is listed first so it is destroyed last: it is
+    // co-owned by the prop, which records into it, so it must outlive prop_ptr
+    // and the decision procedures.
+    std::shared_ptr<solver_hardnesst> hardness_ptr;
     std::unique_ptr<std::ofstream> ofstream_ptr;
     std::unique_ptr<propt> prop_ptr;
     std::unique_ptr<stack_decision_proceduret> decision_procedure_ptr;

--- a/src/goto-instrument/accelerate/scratch_program.cpp
+++ b/src/goto-instrument/accelerate/scratch_program.cpp
@@ -63,7 +63,7 @@ bool scratch_programt::check_sat(bool do_slice, guard_managert &guard_manager)
     return false;
   }
 
-  equation.convert(*checker);
+  equation.convert(*checker, nullptr);
 
 #ifdef DEBUG
   std::cout << "Finished symex, invoking decision procedure.\n";

--- a/src/goto-symex/solver_hardness.h
+++ b/src/goto-symex/solver_hardness.h
@@ -9,15 +9,14 @@ Author: Diffblue Ltd.
 #ifndef CPROVER_SOLVERS_SOLVER_HARDNESS_H
 #define CPROVER_SOLVERS_SOLVER_HARDNESS_H
 
+#include <goto-programs/goto_program.h>
+
 #include <solvers/hardness_collector.h>
-#include <solvers/prop/prop_conv_solver.h>
 
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
-
-#include <goto-programs/goto_program.h>
 
 /// A structure that facilitates collecting the complexity statistics from a
 /// decision procedure. The idea is to associate some solver complexity metric
@@ -157,27 +156,5 @@ struct hash<solver_hardnesst::hardness_ssa_keyt>
   }
 };
 } // namespace std
-
-static inline void with_solver_hardness(
-  decision_proceduret &maybe_hardness_collector,
-  std::function<void(solver_hardnesst &hardness)> handler)
-{
-  // FIXME I am wondering if there is a way to do this that is a bit less
-  // dynamically typed.
-  if(
-    auto prop_conv_solver =
-      dynamic_cast<prop_conv_solvert *>(&maybe_hardness_collector))
-  {
-    if(auto hardness_collector = prop_conv_solver->get_hardness_collector())
-    {
-      if(hardness_collector->solver_hardness)
-      {
-        auto &solver_hardness = static_cast<solver_hardnesst &>(
-          *(hardness_collector->solver_hardness));
-        handler(solver_hardness);
-      }
-    }
-  }
-}
 
 #endif // CPROVER_SOLVERS_SOLVER_HARDNESS_H

--- a/src/goto-symex/symex_target_equation.cpp
+++ b/src/goto-symex/symex_target_equation.cpp
@@ -349,7 +349,7 @@ void symex_target_equationt::convert(decision_proceduret &decision_procedure)
   const auto convert_SSA_start = std::chrono::steady_clock::now();
 
   convert_without_assertions(decision_procedure);
-  convert_assertions(decision_procedure);
+  convert_assertions(decision_procedure, true);
 
   const auto convert_SSA_stop = std::chrono::steady_clock::now();
   std::chrono::duration<double> convert_SSA_runtime =

--- a/src/goto-symex/symex_target_equation.cpp
+++ b/src/goto-symex/symex_target_equation.cpp
@@ -14,10 +14,21 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <util/std_expr.h>
 
+#include <solvers/decision_procedure.h>
+
 #include "solver_hardness.h"
 #include "ssa_step.h"
 
 #include <chrono> // IWYU pragma: keep
+#include <functional>
+
+static void with_solver_hardness(
+  solver_hardnesst *maybe_hardness_collector,
+  const std::function<void(solver_hardnesst &hardness)> &handler)
+{
+  if(maybe_hardness_collector)
+    handler(*maybe_hardness_collector);
+}
 
 static std::function<void(solver_hardnesst &)>
 hardness_register_ssa(std::size_t step_index, const SSA_stept &step)
@@ -328,28 +339,32 @@ void symex_target_equationt::constraint(
 }
 
 void symex_target_equationt::convert_without_assertions(
-  decision_proceduret &decision_procedure)
+  decision_proceduret &decision_procedure,
+  solver_hardnesst *hardness_collector)
 {
-  with_solver_hardness(decision_procedure, [&](solver_hardnesst &hardness) {
-    hardness.register_ssa_size(SSA_steps.size());
-  });
+  with_solver_hardness(
+    hardness_collector,
+    [&](solver_hardnesst &hardness)
+    { hardness.register_ssa_size(SSA_steps.size()); });
 
-  convert_guards(decision_procedure);
-  convert_assignments(decision_procedure);
-  convert_decls(decision_procedure);
-  convert_assumptions(decision_procedure);
-  convert_goto_instructions(decision_procedure);
-  convert_function_calls(decision_procedure);
-  convert_io(decision_procedure);
-  convert_constraints(decision_procedure);
+  convert_guards(decision_procedure, hardness_collector);
+  convert_assignments(decision_procedure, hardness_collector);
+  convert_decls(decision_procedure, hardness_collector);
+  convert_assumptions(decision_procedure, hardness_collector);
+  convert_goto_instructions(decision_procedure, hardness_collector);
+  convert_function_calls(decision_procedure, hardness_collector);
+  convert_io(decision_procedure, hardness_collector);
+  convert_constraints(decision_procedure, hardness_collector);
 }
 
-void symex_target_equationt::convert(decision_proceduret &decision_procedure)
+void symex_target_equationt::convert(
+  decision_proceduret &decision_procedure,
+  solver_hardnesst *hardness_collector)
 {
   const auto convert_SSA_start = std::chrono::steady_clock::now();
 
-  convert_without_assertions(decision_procedure);
-  convert_assertions(decision_procedure, true);
+  convert_without_assertions(decision_procedure, hardness_collector);
+  convert_assertions(decision_procedure, hardness_collector, true);
 
   const auto convert_SSA_stop = std::chrono::steady_clock::now();
   std::chrono::duration<double> convert_SSA_runtime =
@@ -359,7 +374,8 @@ void symex_target_equationt::convert(decision_proceduret &decision_procedure)
 }
 
 void symex_target_equationt::convert_assignments(
-  decision_proceduret &decision_procedure)
+  decision_proceduret &decision_procedure,
+  solver_hardnesst *hardness_collector)
 {
   std::size_t step_index = 0;
   for(auto &step : SSA_steps)
@@ -374,14 +390,15 @@ void symex_target_equationt::convert_assignments(
       decision_procedure.set_to_true(step.cond_expr);
       step.converted = true;
       with_solver_hardness(
-        decision_procedure, hardness_register_ssa(step_index, step));
+        hardness_collector, hardness_register_ssa(step_index, step));
     }
     ++step_index;
   }
 }
 
 void symex_target_equationt::convert_decls(
-  decision_proceduret &decision_procedure)
+  decision_proceduret &decision_procedure,
+  solver_hardnesst *hardness_collector)
 {
   std::size_t step_index = 0;
   for(auto &step : SSA_steps)
@@ -395,14 +412,15 @@ void symex_target_equationt::convert_decls(
         equal_exprt{step.ssa_full_lhs, step.ssa_full_lhs});
       step.converted = true;
       with_solver_hardness(
-        decision_procedure, hardness_register_ssa(step_index, step));
+        hardness_collector, hardness_register_ssa(step_index, step));
     }
     ++step_index;
   }
 }
 
 void symex_target_equationt::convert_guards(
-  decision_proceduret &decision_procedure)
+  decision_proceduret &decision_procedure,
+  solver_hardnesst *hardness_collector)
 {
   std::size_t step_index = 0;
   for(auto &step : SSA_steps)
@@ -418,16 +436,17 @@ void symex_target_equationt::convert_guards(
 
       step.guard_handle = decision_procedure.handle(step.guard);
       with_solver_hardness(
-        decision_procedure, [step_index, &step](solver_hardnesst &hardness) {
-          hardness.register_ssa(step_index, step.guard, step.source.pc);
-        });
+        hardness_collector,
+        [step_index, &step](solver_hardnesst &hardness)
+        { hardness.register_ssa(step_index, step.guard, step.source.pc); });
     }
     ++step_index;
   }
 }
 
 void symex_target_equationt::convert_assumptions(
-  decision_proceduret &decision_procedure)
+  decision_proceduret &decision_procedure,
+  solver_hardnesst *hardness_collector)
 {
   std::size_t step_index = 0;
   for(auto &step : SSA_steps)
@@ -447,7 +466,7 @@ void symex_target_equationt::convert_assumptions(
         step.cond_handle = decision_procedure.handle(step.cond_expr);
 
         with_solver_hardness(
-          decision_procedure, hardness_register_ssa(step_index, step));
+          hardness_collector, hardness_register_ssa(step_index, step));
       }
     }
     ++step_index;
@@ -455,7 +474,8 @@ void symex_target_equationt::convert_assumptions(
 }
 
 void symex_target_equationt::convert_goto_instructions(
-  decision_proceduret &decision_procedure)
+  decision_proceduret &decision_procedure,
+  solver_hardnesst *hardness_collector)
 {
   std::size_t step_index = 0;
   for(auto &step : SSA_steps)
@@ -474,7 +494,7 @@ void symex_target_equationt::convert_goto_instructions(
 
         step.cond_handle = decision_procedure.handle(step.cond_expr);
         with_solver_hardness(
-          decision_procedure, hardness_register_ssa(step_index, step));
+          hardness_collector, hardness_register_ssa(step_index, step));
       }
     }
     ++step_index;
@@ -482,7 +502,8 @@ void symex_target_equationt::convert_goto_instructions(
 }
 
 void symex_target_equationt::convert_constraints(
-  decision_proceduret &decision_procedure)
+  decision_proceduret &decision_procedure,
+  solver_hardnesst *hardness_collector)
 {
   std::size_t step_index = 0;
   for(auto &step : SSA_steps)
@@ -498,7 +519,7 @@ void symex_target_equationt::convert_constraints(
       step.converted = true;
 
       with_solver_hardness(
-        decision_procedure, hardness_register_ssa(step_index, step));
+        hardness_collector, hardness_register_ssa(step_index, step));
     }
     ++step_index;
   }
@@ -506,6 +527,7 @@ void symex_target_equationt::convert_constraints(
 
 void symex_target_equationt::convert_assertions(
   decision_proceduret &decision_procedure,
+  solver_hardnesst *hardness_collector,
   bool optimized_for_single_assertions)
 {
   // we find out if there is only _one_ assertion,
@@ -532,7 +554,7 @@ void symex_target_equationt::convert_assertions(
         step.cond_handle = false_exprt();
 
         with_solver_hardness(
-          decision_procedure, hardness_register_ssa(step_index, step));
+          hardness_collector, hardness_register_ssa(step_index, step));
         return; // prevent further assumptions!
       }
       else if(step.is_assume())
@@ -540,7 +562,7 @@ void symex_target_equationt::convert_assertions(
         decision_procedure.set_to_true(step.cond_expr);
 
         with_solver_hardness(
-          decision_procedure, hardness_register_ssa(step_index, step));
+          hardness_collector, hardness_register_ssa(step_index, step));
       }
       ++step_index;
     }
@@ -580,10 +602,9 @@ void symex_target_equationt::convert_assertions(
       step.cond_handle = decision_procedure.handle(implication);
 
       with_solver_hardness(
-        decision_procedure,
-        [&involved_steps, &step](solver_hardnesst &hardness) {
-          involved_steps.push_back(step.source.pc);
-        });
+        hardness_collector,
+        [&involved_steps, &step](solver_hardnesst &hardness)
+        { involved_steps.push_back(step.source.pc); });
 
       // store disjunct
       disjuncts.push_back(not_exprt(step.cond_handle));
@@ -598,10 +619,9 @@ void symex_target_equationt::convert_assertions(
         assumption = and_exprt(assumption, step.cond_handle);
 
       with_solver_hardness(
-        decision_procedure,
-        [&involved_steps, &step](solver_hardnesst &hardness) {
-          involved_steps.push_back(step.source.pc);
-        });
+        hardness_collector,
+        [&involved_steps, &step](solver_hardnesst &hardness)
+        { involved_steps.push_back(step.source.pc); });
     }
   }
 
@@ -610,14 +630,15 @@ void symex_target_equationt::convert_assertions(
   decision_procedure.set_to_true(assertion_disjunction);
 
   with_solver_hardness(
-    decision_procedure,
+    hardness_collector,
     [&assertion_disjunction, &involved_steps](solver_hardnesst &hardness) {
       hardness.register_assertion_ssas(assertion_disjunction, involved_steps);
     });
 }
 
 void symex_target_equationt::convert_function_calls(
-  decision_proceduret &decision_procedure)
+  decision_proceduret &decision_procedure,
+  solver_hardnesst *hardness_collector)
 {
   std::size_t step_index = 0;
   for(auto &step : SSA_steps)
@@ -646,7 +667,7 @@ void symex_target_equationt::convert_function_calls(
         }
       }
       with_solver_hardness(
-        decision_procedure,
+        hardness_collector,
         [step_index, &conjuncts, &step](solver_hardnesst &hardness) {
           hardness.register_ssa(
             step_index, conjunction(conjuncts), step.source.pc);
@@ -656,7 +677,9 @@ void symex_target_equationt::convert_function_calls(
   }
 }
 
-void symex_target_equationt::convert_io(decision_proceduret &decision_procedure)
+void symex_target_equationt::convert_io(
+  decision_proceduret &decision_procedure,
+  solver_hardnesst *hardness_collector)
 {
   std::size_t step_index = 0;
   for(auto &step : SSA_steps)
@@ -684,7 +707,7 @@ void symex_target_equationt::convert_io(decision_proceduret &decision_procedure)
         }
       }
       with_solver_hardness(
-        decision_procedure,
+        hardness_collector,
         [step_index, &conjuncts, &step](solver_hardnesst &hardness) {
           hardness.register_ssa(
             step_index, conjunction(conjuncts), step.source.pc);

--- a/src/goto-symex/symex_target_equation.h
+++ b/src/goto-symex/symex_target_equation.h
@@ -25,6 +25,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 class decision_proceduret;
 class namespacet;
+struct solver_hardnesst;
 
 /// Inheriting the interface of symex_targett this class represents the SSA
 /// form of the input program as a list of \ref SSA_stept. It further extends
@@ -171,7 +172,11 @@ public:
   /// format. The method iterates over the equation, i.e. over the SSA steps and
   /// converts each type of step separately.
   /// \param decision_procedure: A handle to a decision procedure interface
-  void convert(decision_proceduret &decision_procedure);
+  /// \param hardness_collector: If non-null, a collector for hardness
+  ///   statistics
+  void convert(
+    decision_proceduret &decision_procedure,
+    solver_hardnesst *hardness_collector);
 
   /// Interface method to initiate the conversion into a decision procedure
   /// format. The method iterates over the equation, i.e. over the SSA steps and
@@ -180,14 +185,21 @@ public:
   /// e.g. for incremental solving.
   /// \param decision_procedure: A handle to a particular decision procedure
   ///   interface
-  void convert_without_assertions(decision_proceduret &decision_procedure);
+  /// \param hardness_collector: If non-null, a collector for hardness
+  ///   statistics
+  void convert_without_assertions(
+    decision_proceduret &decision_procedure,
+    solver_hardnesst *hardness_collector);
 
   /// Converts assertions: build a disjunction of negated assertions.
   /// \param decision_procedure: A handle to a decision procedure interface
+  /// \param hardness_collector: If non-null, a collector for hardness
+  ///   statistics
   /// \param optimized_for_single_assertions: Use an optimized encoding for
   ///   single assertions (unsound for incremental conversions)
   void convert_assertions(
     decision_proceduret &decision_procedure,
+    solver_hardnesst *hardness_collector,
     bool optimized_for_single_assertions);
 
   typedef std::list<SSA_stept> SSA_stepst;
@@ -229,40 +241,72 @@ protected:
   /// Converts assignments: set the equality _lhs==rhs_ to _True_.
   /// \param decision_procedure: A handle to a decision procedure
   ///  interface
-  void convert_assignments(decision_proceduret &decision_procedure);
+  /// \param hardness_collector: If non-null, a collector for hardness
+  ///   statistics
+  void convert_assignments(
+    decision_proceduret &decision_procedure,
+    solver_hardnesst *hardness_collector);
 
   /// Converts declarations: these are effectively ignored by the decision
   /// procedure.
   /// \param decision_procedure: A handle to a decision procedure
   ///  interface
-  void convert_decls(decision_proceduret &decision_procedure);
+  /// \param hardness_collector: If non-null, a collector for hardness
+  ///   statistics
+  void convert_decls(
+    decision_proceduret &decision_procedure,
+    solver_hardnesst *hardness_collector);
 
   /// Converts assumptions: convert the expression the assumption represents.
   /// \param decision_procedure: A handle to a decision procedure interface
-  void convert_assumptions(decision_proceduret &decision_procedure);
+  /// \param hardness_collector: If non-null, a collector for hardness
+  ///   statistics
+  void convert_assumptions(
+    decision_proceduret &decision_procedure,
+    solver_hardnesst *hardness_collector);
 
   /// Converts constraints: set the represented condition to _True_.
   /// \param decision_procedure: A handle to a decision procedure interface
-  void convert_constraints(decision_proceduret &decision_procedure);
+  /// \param hardness_collector: If non-null, a collector for hardness
+  ///   statistics
+  void convert_constraints(
+    decision_proceduret &decision_procedure,
+    solver_hardnesst *hardness_collector);
 
   /// Converts goto instructions: convert the expression representing the
   /// condition of this goto.
   /// \param decision_procedure: A handle to a decision procedure interface
-  void convert_goto_instructions(decision_proceduret &decision_procedure);
+  /// \param hardness_collector: If non-null, a collector for hardness
+  ///   statistics
+  void convert_goto_instructions(
+    decision_proceduret &decision_procedure,
+    solver_hardnesst *hardness_collector);
 
   /// Converts guards: convert the expression the guard represents.
   /// \param decision_procedure: A handle to a decision procedure interface
-  void convert_guards(decision_proceduret &decision_procedure);
+  /// \param hardness_collector: If non-null, a collector for hardness
+  ///   statistics
+  void convert_guards(
+    decision_proceduret &decision_procedure,
+    solver_hardnesst *hardness_collector);
 
   /// Converts function calls: for each argument build an equality between its
   /// symbol and the argument itself.
   /// \param decision_procedure: A handle to a decision procedure interface
-  void convert_function_calls(decision_proceduret &decision_procedure);
+  /// \param hardness_collector: If non-null, a collector for hardness
+  ///   statistics
+  void convert_function_calls(
+    decision_proceduret &decision_procedure,
+    solver_hardnesst *hardness_collector);
 
   /// Converts I/O: for each argument build an equality between its
   /// symbol and the argument itself.
   /// \param decision_procedure: A handle to a decision procedure interface
-  void convert_io(decision_proceduret &decision_procedure);
+  /// \param hardness_collector: If non-null, a collector for hardness
+  ///   statistics
+  void convert_io(
+    decision_proceduret &decision_procedure,
+    solver_hardnesst *hardness_collector);
 
   messaget log;
 

--- a/src/solvers/hardness_collector.h
+++ b/src/solvers/hardness_collector.h
@@ -44,7 +44,7 @@ public:
 class hardness_collectort
 {
 public:
-  std::unique_ptr<clause_hardness_collectort> solver_hardness;
+  std::shared_ptr<clause_hardness_collectort> solver_hardness;
 };
 
 #endif // CPROVER_SOLVERS_HARDNESS_COLLECTOR_H

--- a/src/solvers/prop/prop_conv_solver.h
+++ b/src/solvers/prop/prop_conv_solver.h
@@ -9,18 +9,17 @@ Author: Daniel Kroening, kroening@kroening.com
 #ifndef CPROVER_SOLVERS_PROP_PROP_CONV_SOLVER_H
 #define CPROVER_SOLVERS_PROP_PROP_CONV_SOLVER_H
 
-#include <map>
-#include <string>
-
 #include <util/expr.h>
 #include <util/message.h>
 
 #include <solvers/conflict_provider.h>
-#include <solvers/hardness_collector.h>
 
 #include "prop.h"
 #include "prop_conv.h"
 #include "solver_resource_limits.h"
+
+#include <map>
+#include <string>
 
 class equal_exprt;
 
@@ -98,11 +97,6 @@ public:
   }
 
   std::size_t get_number_of_solver_calls() const override;
-
-  hardness_collectort *get_hardness_collector()
-  {
-    return dynamic_cast<hardness_collectort *>(&prop);
-  }
 
 protected:
   bool post_processing_done = false;


### PR DESCRIPTION
Use a `shared_ptr` to retain co-ownership of the hardness collector in `solver_factoryt::solvert` and adjust the `symex_target_equationt` API to `consume a solver_hardnesst`.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
