### PR TITLE
Automatically create release tags via GitHub actions

### DIFF
--- a/.github/workflows/release-create-tag.yaml
+++ b/.github/workflows/release-create-tag.yaml
@@ -1,0 +1,28 @@
+name: Create release tag
+on:
+  push:
+    branches: [ develop ]
+    paths:
+      - 'src/config.inc'
+
+jobs:
+  create-tag:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: '0'
+    - name: Get version
+      run: |
+        v=$(grep ^CBMC_VERSION src/config.inc | perl -p -e 's/^CBMC_VERSION\s*=\s*//')
+        echo "CBMC_VERSION=$v" >> $GITHUB_ENV
+    - name: Set new tag
+      uses: anothrNick/github-tag-action@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        RELEASE_BRANCHES: develop
+        CUSTOM_TAG: cbmc-${{ env.CBMC_VERSION }}
+        VERBOSE: false
+        DRY_RUN: true

--- a/doc/ADR/release_process.md
+++ b/doc/ADR/release_process.md
@@ -10,23 +10,18 @@
 The current process we follow through to make a new release is the following:
 
 1. At the point in time we want to make the release, we make a change to
-   two files: `src/config.inc`, wherein we update the configuration variable
-   `CBMC_VERSION`, and `src/libcprover-rust/Cargo.toml`, wherein we update
+   three files: `src/config.inc`, wherein we update the configuration variable
+   `CBMC_VERSION`, src/libcprover-rust/Cargo.toml`, wherein we update
    the `version` variable to be the same as `CBMC_VERSION` (e.g. set both
-   to `5.80.0`).
+   to `5.80.0`), and CHANGELOG.
 
-   This is important as it informs the various tools of the current version
-   of CBMC.
+   This is important as it informs the various tools of the current version of
+   CBMC. These changes need to be pushed as a PR. Once that PR is merged into
+   `develop`, a Git tag of the form `cbmc-<version>` (where `<version>` is the
+   value of `CBMC_VERSION`) is automatically created. This tag then triggers
+   further automatic steps, see below.
 
-   (This needs to be pushed as a PR, and after it gets merged we move on to:)
-
-2. Then we make a `git tag` out of that commit, and push it to github. The
-   tag needs to be of the form `cbmc-<version>` with version being a version
-   number of the form of `x.y.z`, with `x` denoting the major version, `y`
-   denoting the minor version, and `z` identifying the patch version (useful
-   for a hotfix or patch.)
-
-3. Pushing the Rust crate, which is documented [here](https://doc.rust-lang.org/cargo/commands/cargo-publish.html)
+2. Pushing the Rust crate, which is documented [here](https://doc.rust-lang.org/cargo/commands/cargo-publish.html)
    but effectively entails logging in with an API token generated from
    https://crates.io with `cargo login`, and then issuing `cargo publish`.
 


### PR DESCRIPTION
Release tags are now created automatically when including an indicator (see updated documentation) in the commit message.

For now: keep automated release tagging in dry-run mode (we should first make sure this actually works on this repository before enabling it in production).

This is a second attempt, see some prior discussion in #5649. This new attempt just reads the version to use for tagging off of `config.inc` rather than computing it from commit messages or the likes.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [x] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
