### PR TITLE
Fix Alpine's assert-statement conversion special case

### DIFF
--- a/regression/ansi-c/goto_convert_assert/main.c
+++ b/regression/ansi-c/goto_convert_assert/main.c
@@ -1,0 +1,22 @@
+void __assert_fail(char *, char *, unsigned, char *);
+
+int main()
+{
+  (void)((1 < 2) || (__CPROVER_assert(0, ""), 0));
+
+  int jumpguard;
+  jumpguard = (jumpguard | 1);
+label_1:;
+  {
+    while(1)
+    {
+      if(jumpguard == 0)
+      {
+        __assert_fail("0", "lc2.c", 8U, "func");
+        goto label_1;
+      }
+      goto label_2;
+    }
+  label_2:;
+  }
+}

--- a/regression/ansi-c/goto_convert_assert/test.desc
+++ b/regression/ansi-c/goto_convert_assert/test.desc
@@ -1,0 +1,7 @@
+CORE test-c++-front-end
+main.c
+
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring

--- a/src/ansi-c/goto-conversion/goto_convert.cpp
+++ b/src/ansi-c/goto-conversion/goto_convert.cpp
@@ -1812,8 +1812,11 @@ void goto_convertt::generate_ifthenelse(
   if(
     is_empty(false_case) && true_case.instructions.size() == 2 &&
     true_case.instructions.front().is_assert() &&
-    true_case.instructions.front().condition().is_false() &&
+    simplify_expr(true_case.instructions.front().condition(), ns).is_false() &&
     true_case.instructions.front().labels.empty() &&
+    true_case.instructions.back().is_other() &&
+    true_case.instructions.back().get_other().get_statement() ==
+      ID_expression &&
     true_case.instructions.back().labels.empty())
   {
     true_case.instructions.front().condition_nonconst() = boolean_negate(guard);


### PR DESCRIPTION
In d44bfd3a1545b we added a special case to catch Alpine Linux' assert structure. The match, however, was not sufficiently specific as it just accepted any statement that follows the actual assertion.

Fixes: #8436

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
