### PR TITLE
goto-symex: move level1 map to goto_statet

### DIFF
--- a/regression/cbmc/Local_out_of_scope5/main.c
+++ b/regression/cbmc/Local_out_of_scope5/main.c
@@ -1,0 +1,16 @@
+int main()
+{
+  int jumpguard;
+  jumpguard = jumpguard | 1;
+label_1:
+  while(1)
+  {
+    int canary = 1;
+    if(jumpguard == 0)
+    {
+      goto label_1;
+    }
+    __CPROVER_assert(canary, "should pass");
+    break;
+  }
+}

--- a/regression/cbmc/Local_out_of_scope5/test.desc
+++ b/regression/cbmc/Local_out_of_scope5/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring

--- a/regression/cbmc/Local_out_of_scope5/test.desc
+++ b/regression/cbmc/Local_out_of_scope5/test.desc
@@ -1,0 +1,16 @@
+CORE
+main.c
+--unwind 2 --unwinding-assertions
+^\[main\.assertion\.\d+\] line 13 should pass: SUCCESS$
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring
+--
+This is the exact invocation from #8437 (cbmc --unwind 2 --unwinding-assertions).
+A goto crossing the scope of `canary` confused the level1/level2 renaming, so
+the assertion referenced a stale version of `canary` and failed spuriously.
+Without the fix (level1 merged in goto_statet) this reports VERIFICATION FAILED.
+Note: the issue's program does not terminate symbolic execution without an
+unwinding bound, hence the explicit --unwind.

--- a/src/goto-symex/goto_state.h
+++ b/src/goto-symex/goto_state.h
@@ -38,6 +38,8 @@ protected:
   symex_level2t level2;
 
 public:
+  symex_level1t level1;
+
   /// This is used for eliminating repeated complicated dereferences.
   /// \see goto_symext::dereference_rec
   sharing_mapt<exprt, symbol_exprt, false, irep_hash> dereference_cache;

--- a/src/goto-symex/goto_state.h
+++ b/src/goto-symex/goto_state.h
@@ -38,6 +38,12 @@ protected:
   symex_level2t level2;
 
 public:
+  // Unlike level2, level1 is public: besides being applied for renaming it is
+  // mutated directly from outside this class (insert/insert_or_replace for new
+  // L1 objects, and restore_from on scope exit, function return and thread
+  // switch), so a const-only accessor like get_level2() would not suffice.
+  symex_level1t level1;
+
   /// This is used for eliminating repeated complicated dereferences.
   /// \see goto_symext::dereference_rec
   sharing_mapt<exprt, symbol_exprt, false, irep_hash> dereference_cache;

--- a/src/goto-symex/goto_symex_state.h
+++ b/src/goto-symex/goto_symex_state.h
@@ -70,8 +70,6 @@ public:
   guard_managert &guard_manager;
   symex_target_equationt *symex_target;
 
-  symex_level1t level1;
-
   /// Rewrites symbol expressions in \ref exprt, applying a suffix to each
   /// symbol reflecting its most recent version, which differs depending on
   /// which level you requested. Each level also updates its predecessors, so
@@ -188,6 +186,7 @@ public:
     irep_idt function_id;
     guardt guard;
     call_stackt call_stack;
+    symex_level1t level1;
     std::map<irep_idt, unsigned> function_frame;
     unsigned atomic_section_id = 0;
     explicit threadt(guard_managert &guard_manager)

--- a/src/goto-symex/goto_symex_state.h
+++ b/src/goto-symex/goto_symex_state.h
@@ -70,8 +70,6 @@ public:
   guard_managert &guard_manager;
   symex_target_equationt *symex_target = nullptr;
 
-  symex_level1t level1;
-
   /// Rewrites symbol expressions in \ref exprt, applying a suffix to each
   /// symbol reflecting its most recent version, which differs depending on
   /// which level you requested. Each level also updates its predecessors, so
@@ -188,6 +186,7 @@ public:
     irep_idt function_id;
     guardt guard;
     call_stackt call_stack;
+    symex_level1t level1;
     std::map<irep_idt, unsigned> function_frame;
     unsigned atomic_section_id = 0;
     explicit threadt(guard_managert &guard_manager)

--- a/src/goto-symex/symex_main.cpp
+++ b/src/goto-symex/symex_main.cpp
@@ -291,6 +291,8 @@ switch_to_thread(goto_symex_statet &state, const unsigned int thread_nb)
   state.source.pc = state.threads[thread_nb].pc;
   state.source.function_id = state.threads[thread_nb].function_id;
 
+  state.level1.restore_from(state.threads[thread_nb].level1);
+
   state.guard = state.threads[thread_nb].guard;
   // A thread's initial state is certainly reachable:
   state.reachable = true;

--- a/src/goto-symex/symex_main.cpp
+++ b/src/goto-symex/symex_main.cpp
@@ -291,6 +291,16 @@ switch_to_thread(goto_symex_statet &state, const unsigned int thread_nb)
   state.source.pc = state.threads[thread_nb].pc;
   state.source.function_id = state.threads[thread_nb].function_id;
 
+  // level1 now lives in goto_statet and can be overwritten by merge_goto, so
+  // on a thread switch we reinstate the target thread's start-of-thread
+  // snapshot. Unlike pc/atomic_section_id (saved back into the outgoing thread
+  // above), level1 -- like guard -- is only ever restored, never saved: under
+  // CBMC's run-to-completion thread model a thread is entered once (when the
+  // previous call stack is empty). restore_from (a union that never deletes)
+  // is safe because L1 keys carry the L0 thread tag and cannot alias across
+  // threads.
+  state.level1.restore_from(state.threads[thread_nb].level1);
+
   state.guard = state.threads[thread_nb].guard;
   // A thread's initial state is certainly reachable:
   state.reachable = true;

--- a/src/goto-symex/symex_start_thread.cpp
+++ b/src/goto-symex/symex_start_thread.cpp
@@ -117,6 +117,10 @@ void goto_symext::symex_start_thread(statet &state)
     }
   }
 
+  // retain the current set of objects so as to restore when symbolically
+  // executing the thread
+  new_thread.level1 = state.level1;
+
   // initialize all variables marked thread-local
   const symbol_tablet &symbol_table=ns.get_symbol_table();
 

--- a/src/goto-symex/symex_start_thread.cpp
+++ b/src/goto-symex/symex_start_thread.cpp
@@ -118,6 +118,10 @@ void goto_symext::symex_start_thread(statet &state)
     }
   }
 
+  // retain the current set of objects so as to restore when symbolically
+  // executing the thread
+  new_thread.level1 = state.level1;
+
   // initialize all variables marked thread-local
   const symbol_tablet &symbol_table=ns.get_symbol_table();
 


### PR DESCRIPTION
A local variable may have left the scope on a branch, but may still exist via another path. Upon merging paths we must not lose such objects.

Fixes: #8437

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
