### PR TITLE
Fix Python syntax error in doxygen markdown preprocessor

### DIFF
--- a/doc/doxygen-root/doxygen-markdown/doxygen-markdown-preprocessor.py
+++ b/doc/doxygen-root/doxygen-markdown/doxygen-markdown-preprocessor.py
@@ -53,15 +53,15 @@ def parse_arguments():
 
 
 def pandoc(path, pandoc_write, pandoc_wrap, pandoc_filter=None):
-    args = {
-        '--write': pandoc_write,
-        '--wrap': pandoc_wrap
-    }
+    args = [
+        '--write', pandoc_write,
+        '--wrap', pandoc_wrap
+        ]
     if pandoc_filter:
-        args['--filter'] = Path(pandoc_filter).resolve()
+        args.extend(['--filter', Path(pandoc_filter).resolve()])
 
 
-    lines = subprocess.run(['pandoc', **args, path],
+    lines = subprocess.run(['pandoc', *args, path],
                            check=True,
                            text=True,
                            capture_output=True).stdout.splitlines()


### PR DESCRIPTION
CodeQL was complaining that it couldn't scan our Python code for the invalid use of `**`. Python does not support repeat unpacking in that way, so use a list instead of a dict.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
