### PR TITLE
introduce `zero_expr()` and `one_expr()` for number types

### DIFF
--- a/src/util/mathematical_types.cpp
+++ b/src/util/mathematical_types.cpp
@@ -12,6 +12,8 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "mathematical_types.h"
 
+#include "std_expr.h"
+
 /// Returns true if the type is a rational, real, integer, natural, complex,
 /// unsignedbv, signedbv, floatbv or fixedbv.
 bool is_number(const typet &type)
@@ -20,4 +22,44 @@ bool is_number(const typet &type)
   return id == ID_rational || id == ID_real || id == ID_integer ||
          id == ID_natural || id == ID_complex || id == ID_unsignedbv ||
          id == ID_signedbv || id == ID_floatbv || id == ID_fixedbv;
+}
+
+constant_exprt integer_typet::zero_expr() const
+{
+  return constant_exprt{ID_0, *this};
+}
+
+constant_exprt integer_typet::one_expr() const
+{
+  return constant_exprt{ID_1, *this};
+}
+
+constant_exprt natural_typet::zero_expr() const
+{
+  return constant_exprt{ID_0, *this};
+}
+
+constant_exprt natural_typet::one_expr() const
+{
+  return constant_exprt{ID_1, *this};
+}
+
+constant_exprt rational_typet::zero_expr() const
+{
+  return constant_exprt{ID_0, *this};
+}
+
+constant_exprt rational_typet::one_expr() const
+{
+  return constant_exprt{ID_1, *this};
+}
+
+constant_exprt real_typet::zero_expr() const
+{
+  return constant_exprt{ID_0, *this};
+}
+
+constant_exprt real_typet::one_expr() const
+{
+  return constant_exprt{ID_1, *this};
 }

--- a/src/util/mathematical_types.h
+++ b/src/util/mathematical_types.h
@@ -17,6 +17,8 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "invariant.h"
 #include "type.h"
 
+class constant_exprt;
+
 /// Unbounded, signed integers (mathematical integers, not bitvectors)
 class integer_typet : public typet
 {
@@ -24,6 +26,9 @@ public:
   integer_typet() : typet(ID_integer)
   {
   }
+
+  constant_exprt zero_expr() const;
+  constant_exprt one_expr() const;
 };
 
 /// Natural numbers including zero (mathematical integers, not bitvectors)
@@ -33,6 +38,9 @@ public:
   natural_typet() : typet(ID_natural)
   {
   }
+
+  constant_exprt zero_expr() const;
+  constant_exprt one_expr() const;
 };
 
 /// Unbounded, signed rational numbers
@@ -42,6 +50,9 @@ public:
   rational_typet() : typet(ID_rational)
   {
   }
+
+  constant_exprt zero_expr() const;
+  constant_exprt one_expr() const;
 };
 
 /// Unbounded, signed real numbers
@@ -51,6 +62,9 @@ public:
   real_typet() : typet(ID_real)
   {
   }
+
+  constant_exprt zero_expr() const;
+  constant_exprt one_expr() const;
 };
 
 /// A type for mathematical functions (do not confuse with functions/methods


### PR DESCRIPTION
This adds `.zero_expr()` and `.one_expr()` for integers, natural numbers, rationals and reals.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
