### PR TITLE
Remove renamedt from symex_targett interface

### DIFF
--- a/regression/cbmc/function_call_argument_simplification/main.c
+++ b/regression/cbmc/function_call_argument_simplification/main.c
@@ -1,0 +1,31 @@
+// Exercises value-set simplification of function-call arguments in
+// goto_symext::symex_function_call: each argument expression below is a pointer
+// dereference / pointer comparison that is L2-renamed and then value-set
+// simplified before being recorded as an SSA function_call step. The
+// assertions check that the argument values are preserved through that
+// simplification.
+
+void check_value(int x)
+{
+  __CPROVER_assert(x == 42, "dereferenced argument value preserved");
+}
+
+void check_flag(int b)
+{
+  __CPROVER_assert(b, "pointer-comparison argument preserved");
+}
+
+int main()
+{
+  int a = 42;
+  int *p = &a;
+  int **pp = &p;
+
+  // doubly-indirect dereference passed as an argument
+  check_value(**pp);
+
+  // pointer comparison passed as an argument
+  check_flag(p == &a);
+
+  return 0;
+}

--- a/regression/cbmc/function_call_argument_simplification/test.desc
+++ b/regression/cbmc/function_call_argument_simplification/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring

--- a/src/goto-symex/goto_symex.cpp
+++ b/src/goto-symex/goto_symex.cpp
@@ -37,6 +37,13 @@ void goto_symext::do_simplify(exprt &expr, const value_sett &value_set)
   }
 }
 
+exprt goto_symext::rename_and_simplify(statet &state, exprt expr)
+{
+  expr = state.rename(std::move(expr), ns).get();
+  do_simplify(expr, state.value_set);
+  return expr;
+}
+
 void goto_symext::symex_assign(
   statet &state,
   const exprt &o_lhs,

--- a/src/goto-symex/goto_symex.h
+++ b/src/goto-symex/goto_symex.h
@@ -528,6 +528,14 @@ protected:
 
   virtual void do_simplify(exprt &expr, const value_sett &value_set);
 
+  /// L2-rename \p expr in \p state and then value-set simplify it. This is the
+  /// common preparation applied to expressions before they are recorded as SSA
+  /// steps via the \ref symex_targett interface.
+  /// \param state: Symbolic execution state for the current instruction
+  /// \param expr: Expression to be renamed and simplified
+  /// \return The L2-renamed and value-set-simplified expression
+  exprt rename_and_simplify(statet &state, exprt expr);
+
   /// Symbolically execute an ASSIGN instruction or simulate such an execution
   /// for a synthetic assignment
   /// \param state: Symbolic execution state for current instruction

--- a/src/goto-symex/symex_builtin_functions.cpp
+++ b/src/goto-symex/symex_builtin_functions.cpp
@@ -471,17 +471,13 @@ void goto_symext::symex_output(
   PRECONDITION(code.operands().size() >= 2);
   exprt id_arg = state.rename(code.op0(), ns).get();
 
-  std::list<renamedt<exprt, L2>> args;
+  std::list<exprt> args;
 
   for(std::size_t i=1; i<code.operands().size(); i++)
   {
     renamedt<exprt, L2> l2_arg = state.rename(code.operands()[i], ns);
-    if(symex_config.simplify_opt)
-    {
-      simplify_expr_with_value_sett simp{state.value_set, language_mode, ns};
-      l2_arg.simplify(simp);
-    }
-    args.emplace_back(l2_arg);
+    args.emplace_back(l2_arg.get());
+    do_simplify(args.back(), state.value_set);
   }
 
   const irep_idt output_id =

--- a/src/goto-symex/symex_builtin_functions.cpp
+++ b/src/goto-symex/symex_builtin_functions.cpp
@@ -425,10 +425,7 @@ void goto_symext::symex_printf(
       if(need_deref && parameter.id() == ID_address_of)
         parameter = to_address_of_expr(parameter).object();
       clean_expr(parameter, state, false);
-      parameter = state.rename(std::move(parameter), ns).get();
-      do_simplify(parameter, state.value_set);
-
-      args.push_back(std::move(parameter));
+      args.push_back(rename_and_simplify(state, std::move(parameter)));
     }
   }
 
@@ -453,9 +450,7 @@ void goto_symext::symex_input(
 
   for(std::size_t i=1; i<code.operands().size(); i++)
   {
-    exprt l2_arg = state.rename(code.operands()[i], ns).get();
-    do_simplify(l2_arg, state.value_set);
-    args.emplace_back(std::move(l2_arg));
+    args.emplace_back(rename_and_simplify(state, code.operands()[i]));
   }
 
   const irep_idt input_id =
@@ -475,9 +470,7 @@ void goto_symext::symex_output(
 
   for(std::size_t i=1; i<code.operands().size(); i++)
   {
-    renamedt<exprt, L2> l2_arg = state.rename(code.operands()[i], ns);
-    args.emplace_back(l2_arg.get());
-    do_simplify(args.back(), state.value_set);
+    args.emplace_back(rename_and_simplify(state, code.operands()[i]));
   }
 
   const irep_idt output_id =

--- a/src/goto-symex/symex_function_call.cpp
+++ b/src/goto-symex/symex_function_call.cpp
@@ -279,10 +279,9 @@ void goto_symext::symex_function_call_post_clean(
   }
 
   // read the arguments -- before the locality renaming
-  const std::vector<renamedt<exprt, L2>> renamed_arguments =
-    make_range(cleaned_arguments).map([&](const exprt &a) {
-      return state.rename(a, ns);
-    });
+  const std::vector<exprt> renamed_arguments =
+    make_range(cleaned_arguments)
+      .map([&](const exprt &a) { return state.rename(a, ns).get(); });
 
   // we hide the call if the caller and callee are both hidden
   const bool hidden =

--- a/src/goto-symex/symex_function_call.cpp
+++ b/src/goto-symex/symex_function_call.cpp
@@ -281,7 +281,13 @@ void goto_symext::symex_function_call_post_clean(
   // read the arguments -- before the locality renaming
   const std::vector<exprt> renamed_arguments =
     make_range(cleaned_arguments)
-      .map([&](const exprt &a) { return state.rename(a, ns).get(); });
+      .map(
+        [&](const exprt &a)
+        {
+          exprt arg = state.rename(a, ns).get();
+          do_simplify(arg, state.value_set);
+          return arg;
+        });
 
   // we hide the call if the caller and callee are both hidden
   const bool hidden =

--- a/src/goto-symex/symex_function_call.cpp
+++ b/src/goto-symex/symex_function_call.cpp
@@ -281,13 +281,7 @@ void goto_symext::symex_function_call_post_clean(
   // read the arguments -- before the locality renaming
   const std::vector<exprt> renamed_arguments =
     make_range(cleaned_arguments)
-      .map(
-        [&](const exprt &a)
-        {
-          exprt arg = state.rename(a, ns).get();
-          do_simplify(arg, state.value_set);
-          return arg;
-        });
+      .map([&](const exprt &a) { return rename_and_simplify(state, a); });
 
   // we hide the call if the caller and callee are both hidden
   const bool hidden =

--- a/src/goto-symex/symex_goto.cpp
+++ b/src/goto-symex/symex_goto.cpp
@@ -20,7 +20,6 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "goto_symex.h"
 #include "path_storage.h"
-#include "simplify_expr_with_value_set.h"
 
 #include <algorithm>
 #include <map>
@@ -74,12 +73,8 @@ void goto_symext::symex_goto(statet &state)
   exprt new_guard = clean_expr(instruction.condition(), state, false);
 
   renamedt<exprt, L2> renamed_guard = state.rename(std::move(new_guard), ns);
-  if(symex_config.simplify_opt)
-  {
-    simplify_expr_with_value_sett simp{state.value_set, language_mode, ns};
-    renamed_guard.simplify(simp);
-  }
   new_guard = renamed_guard.get();
+  do_simplify(new_guard, state.value_set);
 
   if(new_guard == false)
   {
@@ -90,7 +85,7 @@ void goto_symext::symex_goto(statet &state)
     return; // nothing to do
   }
 
-  target.goto_instruction(state.guard.as_expr(), renamed_guard, state.source);
+  target.goto_instruction(state.guard.as_expr(), new_guard, state.source);
 
   DATA_INVARIANT(
     !instruction.targets.empty(), "goto should have at least one target");

--- a/src/goto-symex/symex_goto.cpp
+++ b/src/goto-symex/symex_goto.cpp
@@ -72,9 +72,7 @@ void goto_symext::symex_goto(statet &state)
 
   exprt new_guard = clean_expr(instruction.condition(), state, false);
 
-  renamedt<exprt, L2> renamed_guard = state.rename(std::move(new_guard), ns);
-  new_guard = renamed_guard.get();
-  do_simplify(new_guard, state.value_set);
+  new_guard = rename_and_simplify(state, std::move(new_guard));
 
   if(new_guard == false)
   {

--- a/src/goto-symex/symex_target.h
+++ b/src/goto-symex/symex_target.h
@@ -14,13 +14,17 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <goto-programs/goto_program.h>
 
-#include "renamed.h"
-
 class ssa_exprt;
 
 /// The interface of the target _container_ for symbolic execution to record its
 /// symbolic steps into. Presently, \ref symex_target_equationt is the only
 /// implementation of this interface.
+///
+/// All expression parameters (`exprt`, `ssa_exprt`) passed to the methods below
+/// are expected to be L2-renamed unless the parameter's docstring says
+/// otherwise (notably, `assignment`'s `original_full_lhs`). "L2-renamed" means
+/// the expression has been processed by `goto_symex_statet::rename` (and
+/// possibly simplified) before being recorded.
 class symex_targett
 {
 public:
@@ -79,8 +83,8 @@ public:
   /// right--hand side of assignment): we effectively assign the value stored in
   /// \p ssa_object by another thread to \p ssa_object in the memory scope of
   /// this thread.
-  /// \param guard: Precondition for this read event
-  /// \param ssa_object: Variable to be read from
+  /// \param guard: Precondition for this read event (L2-renamed)
+  /// \param ssa_object: Variable to be read from (L2-renamed)
   /// \param atomic_section_id: ID of the atomic section in which this read
   ///  takes place (if any)
   /// \param source: Pointer to location in the input GOTO program of this read
@@ -92,8 +96,8 @@ public:
 
   /// Write to a shared variable \p ssa_object: we effectively assign a value
   /// from this thread to be visible by other threads.
-  /// \param guard: Precondition for this write event
-  /// \param ssa_object: Variable to be written to
+  /// \param guard: Precondition for this write event (L2-renamed)
+  /// \param ssa_object: Variable to be written to (L2-renamed)
   /// \param atomic_section_id: ID of the atomic section in which this write
   ///  takes place (if any)
   /// \param source: Pointer to location in the input GOTO program of this write
@@ -104,12 +108,14 @@ public:
     const sourcet &source) = 0;
 
   /// Write to a local variable. The `cond_expr` is _lhs==rhs_.
-  /// \param guard: Precondition for this read event
-  /// \param ssa_lhs: Variable to be written to, must be a symbol (and not nil)
-  /// \param ssa_full_lhs: Full left-hand side with symex level annotations
+  /// \param guard: Precondition for this assignment (L2-renamed)
+  /// \param ssa_lhs: L2-renamed variable to be written to, must be a
+  ///  symbol (and not nil)
+  /// \param ssa_full_lhs: L2-renamed full left-hand side with symex level
+  ///  annotations
   /// \param original_full_lhs: Full left-hand side without symex level
   ///  annotations
-  /// \param ssa_rhs: Right-hand side of the assignment
+  /// \param ssa_rhs: Right-hand side of the assignment (L2-renamed)
   /// \param source: Pointer to location in the input GOTO program of this
   ///  assignment
   /// \param assignment_type: To distinguish between different types of
@@ -124,9 +130,10 @@ public:
     assignment_typet assignment_type)=0;
 
   /// Declare a fresh variable. The `cond_expr` is _lhs==lhs_.
-  /// \param guard: Precondition for a declaration of this variable
-  /// \param ssa_lhs: Variable to be declared, must be symbol (and not nil)
-  /// \param initializer: Initial value
+  /// \param guard: Precondition for a declaration of this variable (L2-renamed)
+  /// \param ssa_lhs: L2-renamed variable to be declared, must be symbol
+  ///  (and not nil)
+  /// \param initializer: Initial value (L2-renamed)
   /// \param source: Pointer to location in the input GOTO program of this
   ///  declaration
   /// \param assignment_type: To distinguish between different types of
@@ -139,8 +146,8 @@ public:
     assignment_typet assignment_type) = 0;
 
   /// Remove a variable from the scope.
-  /// \param guard: Precondition for removal of this variable
-  /// \param ssa_lhs: Variable to be removed, must be symbol
+  /// \param guard: Precondition for removal of this variable (L2-renamed)
+  /// \param ssa_lhs: Variable to be removed, must be symbol (L2-renamed)
   /// \param source: Pointer to location in the input GOTO program of this
   ///  removal
   virtual void dead(
@@ -149,25 +156,26 @@ public:
     const sourcet &source)=0;
 
   /// Record a function call.
-  /// \param guard: Precondition for calling a function
+  /// \param guard: Precondition for calling a function (L2-renamed)
   /// \param function_id: Name of the function
   /// \param ssa_function_arguments: Vector of arguments in SSA form
-  /// \param source: To location in the input GOTO program of this
-  /// \param hidden: Should this step be recorded as hidden?
+  ///  (L2-renamed)
+  /// \param source: Pointer to location in the input GOTO program of this
   ///  function call
+  /// \param hidden: Should this step be recorded as hidden?
   virtual void function_call(
     const exprt &guard,
     const irep_idt &function_id,
-    const std::vector<renamedt<exprt, L2>> &ssa_function_arguments,
+    const std::vector<exprt> &ssa_function_arguments,
     const sourcet &source,
     bool hidden) = 0;
 
   /// Record return from a function.
-  /// \param guard: Precondition for returning from a function
+  /// \param guard: Precondition for returning from a function (L2-renamed)
   /// \param function_id: Name of the function from which we return
   /// \param source: Pointer to location in the input GOTO program of this
-  /// \param hidden: Should this step be recorded as hidden?
   ///  function return
+  /// \param hidden: Should this step be recorded as hidden?
   virtual void function_return(
     const exprt &guard,
     const irep_idt &function_id,
@@ -175,7 +183,7 @@ public:
     bool hidden) = 0;
 
   /// Record a location.
-  /// \param guard: Precondition for reaching this location
+  /// \param guard: Precondition for reaching this location (L2-renamed)
   /// \param source: Pointer to location in the input GOTO program to be
   ///  recorded
   virtual void location(
@@ -183,24 +191,24 @@ public:
     const sourcet &source)=0;
 
   /// Record an output.
-  /// \param guard: Precondition for writing to the output
+  /// \param guard: Precondition for writing to the output (L2-renamed)
   /// \param source: Pointer to location in the input GOTO program of this
   ///  output
   /// \param output_id: Name of the output
-  /// \param args: A list of IO arguments
+  /// \param args: A list of IO arguments (L2-renamed)
   virtual void output(
     const exprt &guard,
     const sourcet &source,
     const irep_idt &output_id,
-    const std::list<renamedt<exprt, L2>> &args) = 0;
+    const std::list<exprt> &args) = 0;
 
   /// Record formatted output.
-  /// \param guard: Precondition for writing to the output
+  /// \param guard: Precondition for writing to the output (L2-renamed)
   /// \param source: Pointer to location in the input GOTO program of this
   ///  output
   /// \param output_id: Name of the output
   /// \param fmt: Formatting string
-  /// \param args: A list of IO arguments
+  /// \param args: A list of IO arguments (L2-renamed)
   virtual void output_fmt(
     const exprt &guard,
     const sourcet &source,
@@ -209,11 +217,11 @@ public:
     const std::list<exprt> &args)=0;
 
   /// Record an input.
-  /// \param guard: Precondition for reading from the input
+  /// \param guard: Precondition for reading from the input (L2-renamed)
   /// \param source: Pointer to location in the input GOTO program of this
   ///  input
   /// \param input_id: Name of the input
-  /// \param args: A list of IO arguments
+  /// \param args: A list of IO arguments (L2-renamed)
   virtual void input(
     const exprt &guard,
     const sourcet &source,
@@ -221,8 +229,8 @@ public:
     const std::list<exprt> &args)=0;
 
   /// Record an assumption.
-  /// \param guard: Precondition for reaching this assumption
-  /// \param cond: Condition this assumption represents
+  /// \param guard: Precondition for reaching this assumption (L2-renamed)
+  /// \param cond: Condition this assumption represents (L2-renamed)
   /// \param source: Pointer to location in the input GOTO program of this
   ///  assumption
   virtual void assumption(
@@ -231,8 +239,8 @@ public:
     const sourcet &source)=0;
 
   /// Record an assertion.
-  /// \param guard: Precondition for reaching this assertion
-  /// \param cond: Condition this assertion represents
+  /// \param guard: Precondition for reaching this assertion (L2-renamed)
+  /// \param cond: Condition this assertion represents (L2-renamed)
   /// \param property_id: Unique property identifier of this assertion
   /// \param msg: The message associated with this assertion
   /// \param source: Pointer to location in the input GOTO program of this
@@ -245,17 +253,17 @@ public:
     const sourcet &source) = 0;
 
   /// Record a goto instruction.
-  /// \param guard: Precondition for reaching this goto instruction
-  /// \param cond: Condition under which this goto should be taken
+  /// \param guard: Precondition for reaching this goto instruction (L2-renamed)
+  /// \param cond: Condition under which this goto should be taken (L2-renamed)
   /// \param source: Pointer to location in the input GOTO program of this
   ///  goto instruction
   virtual void goto_instruction(
     const exprt &guard,
-    const renamedt<exprt, L2> &cond,
+    const exprt &cond,
     const sourcet &source) = 0;
 
   /// Record a _global_ constraint: there is no guard limiting its scope.
-  /// \param cond: Condition represented by this constraint
+  /// \param cond: Condition represented by this constraint (L2-renamed)
   /// \param msg: The message associated with this constraint
   /// \param source: Pointer to location in the input GOTO program of this
   ///  constraint
@@ -265,7 +273,7 @@ public:
     const sourcet &source)=0;
 
   /// Record spawning a new thread
-  /// \param guard: Precondition for reaching spawning a new thread
+  /// \param guard: Precondition for reaching spawning a new thread (L2-renamed)
   /// \param source: Pointer to location in the input GOTO program where a new
   ///  thread is to be spawned
   virtual void spawn(
@@ -273,7 +281,7 @@ public:
     const sourcet &source)=0;
 
   /// Record creating a memory barrier
-  /// \param guard: Precondition for reaching this barrier
+  /// \param guard: Precondition for reaching this barrier (L2-renamed)
   /// \param source: Pointer to location in the input GOTO program where a new
   ///  barrier is created
   virtual void memory_barrier(
@@ -281,7 +289,7 @@ public:
     const sourcet &source)=0;
 
   /// Record a beginning of an atomic section
-  /// \param guard: Precondition for reaching this atomic section
+  /// \param guard: Precondition for reaching this atomic section (L2-renamed)
   /// \param atomic_section_id: Identifier for this atomic section
   /// \param source: Pointer to location in the input GOTO program where an
   ///  atomic section begins
@@ -292,6 +300,7 @@ public:
 
   /// Record ending an atomic section
   /// \param guard: Precondition for reaching the end of this atomic section
+  ///  (L2-renamed)
   /// \param atomic_section_id: Identifier for this atomic section
   /// \param source: Pointer to location in the input GOTO program where an
   ///  atomic section ends

--- a/src/goto-symex/symex_target.h
+++ b/src/goto-symex/symex_target.h
@@ -159,7 +159,7 @@ public:
   /// \param guard: Precondition for calling a function (L2-renamed)
   /// \param function_id: Name of the function
   /// \param ssa_function_arguments: Vector of arguments in SSA form
-  ///  (L2-renamed)
+  ///  (L2-renamed and value-set-simplified)
   /// \param source: Pointer to location in the input GOTO program of this
   ///  function call
   /// \param hidden: Should this step be recorded as hidden?

--- a/src/goto-symex/symex_target_equation.cpp
+++ b/src/goto-symex/symex_target_equation.cpp
@@ -181,7 +181,7 @@ void symex_target_equationt::location(
 void symex_target_equationt::function_call(
   const exprt &guard,
   const irep_idt &function_id,
-  const std::vector<renamedt<exprt, L2>> &function_arguments,
+  const std::vector<exprt> &function_arguments,
   const sourcet &source,
   const bool hidden)
 {
@@ -190,8 +190,7 @@ void symex_target_equationt::function_call(
 
   SSA_step.guard = guard;
   SSA_step.called_function = function_id;
-  for(const auto &arg : function_arguments)
-    SSA_step.ssa_function_arguments.emplace_back(arg.get());
+  SSA_step.ssa_function_arguments = function_arguments;
   SSA_step.hidden = hidden;
 
   merge_ireps(SSA_step);
@@ -217,14 +216,13 @@ void symex_target_equationt::output(
   const exprt &guard,
   const sourcet &source,
   const irep_idt &output_id,
-  const std::list<renamedt<exprt, L2>> &args)
+  const std::list<exprt> &args)
 {
   SSA_steps.emplace_back(source, goto_trace_stept::typet::OUTPUT);
   SSA_stept &SSA_step=SSA_steps.back();
 
   SSA_step.guard=guard;
-  for(const auto &arg : args)
-    SSA_step.io_args.emplace_back(arg.get());
+  SSA_step.io_args = args;
   SSA_step.io_id=output_id;
 
   merge_ireps(SSA_step);
@@ -299,14 +297,14 @@ void symex_target_equationt::assertion(
 
 void symex_target_equationt::goto_instruction(
   const exprt &guard,
-  const renamedt<exprt, L2> &cond,
+  const exprt &cond,
   const sourcet &source)
 {
   SSA_steps.emplace_back(source, goto_trace_stept::typet::GOTO);
   SSA_stept &SSA_step=SSA_steps.back();
 
   SSA_step.guard=guard;
-  SSA_step.cond_expr = cond.get();
+  SSA_step.cond_expr = cond;
 
   merge_ireps(SSA_step);
 }

--- a/src/goto-symex/symex_target_equation.h
+++ b/src/goto-symex/symex_target_equation.h
@@ -82,7 +82,7 @@ public:
   virtual void function_call(
     const exprt &guard,
     const irep_idt &function_id,
-    const std::vector<renamedt<exprt, L2>> &ssa_function_arguments,
+    const std::vector<exprt> &ssa_function_arguments,
     const sourcet &source,
     bool hidden);
 
@@ -103,7 +103,7 @@ public:
     const exprt &guard,
     const sourcet &source,
     const irep_idt &output_id,
-    const std::list<renamedt<exprt, L2>> &args);
+    const std::list<exprt> &args);
 
   /// \copydoc symex_targett::output_fmt()
   virtual void output_fmt(
@@ -137,7 +137,7 @@ public:
   /// \copydoc symex_targett::goto_instruction()
   virtual void goto_instruction(
     const exprt &guard,
-    const renamedt<exprt, L2> &cond,
+    const exprt &cond,
     const sourcet &source);
 
   /// \copydoc symex_targett::constraint()


### PR DESCRIPTION
We did not consistently use it, and the three methods that did so can easily be adjusted to match the remaining ones in directly taking `exprt` instead.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
