### PR TITLE
Move make_with_expr to update_exprt

### DIFF
--- a/src/util/expr_util.cpp
+++ b/src/util/expr_util.cpp
@@ -68,33 +68,7 @@ exprt make_binary(const exprt &expr)
 
 with_exprt make_with_expr(const update_exprt &src)
 {
-  const exprt::operandst &designator=src.designator();
-  PRECONDITION(!designator.empty());
-
-  with_exprt result{exprt{}, exprt{}, exprt{}};
-  exprt *dest=&result;
-
-  for(const auto &expr : designator)
-  {
-    with_exprt tmp{exprt{}, exprt{}, exprt{}};
-
-    if(expr.id() == ID_index_designator)
-    {
-      tmp.where() = to_index_designator(expr).index();
-    }
-    else if(expr.id() == ID_member_designator)
-    {
-      // irep_idt component_name=
-      //  to_member_designator(*it).get_component_name();
-    }
-    else
-      UNREACHABLE;
-
-    *dest=tmp;
-    dest=&to_with_expr(*dest).new_value();
-  }
-
-  return result;
+  return src.make_with_expr();
 }
 
 exprt is_not_zero(

--- a/src/util/expr_util.h
+++ b/src/util/expr_util.h
@@ -41,6 +41,7 @@ bool is_assignable(const exprt &);
 exprt make_binary(const exprt &);
 
 /// converts an update expr into a (possibly nested) with expression
+DEPRECATED(SINCE(2024, 9, 10, "use update_exprt::make_with_expr() instead"))
 with_exprt make_with_expr(const update_exprt &);
 
 /// converts a scalar/float expression to C/C++ Booleans

--- a/src/util/std_expr.cpp
+++ b/src/util/std_expr.cpp
@@ -191,6 +191,37 @@ void let_exprt::validate(const exprt &expr, const validation_modet vm)
   }
 }
 
+with_exprt update_exprt::make_with_expr() const
+{
+  const exprt::operandst &designators = designator();
+  PRECONDITION(!designators.empty());
+
+  with_exprt result{exprt{}, exprt{}, exprt{}};
+  exprt *dest = &result;
+
+  for(const auto &expr : designators)
+  {
+    with_exprt tmp{exprt{}, exprt{}, exprt{}};
+
+    if(expr.id() == ID_index_designator)
+    {
+      tmp.where() = to_index_designator(expr).index();
+    }
+    else if(expr.id() == ID_member_designator)
+    {
+      // irep_idt component_name=
+      //  to_member_designator(*it).get_component_name();
+    }
+    else
+      UNREACHABLE;
+
+    *dest = tmp;
+    dest = &to_with_expr(*dest).new_value();
+  }
+
+  return result;
+}
+
 exprt binding_exprt::instantiate(const operandst &values) const
 {
   // number of values must match the number of bound variables

--- a/src/util/std_expr.h
+++ b/src/util/std_expr.h
@@ -2698,6 +2698,9 @@ public:
     return op2();
   }
 
+  /// converts an update expr into a (possibly nested) with expression
+  with_exprt make_with_expr() const;
+
   static void check(
     const exprt &expr,
     const validation_modet vm = validation_modet::INVARIANT)


### PR DESCRIPTION
This will eventually remove one of the functions from the expr_util translation unit, which is supposed to be deprecated.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
