### PR TITLE
Mark constant_exprt::value_is_zero_string protected [depends-on: 8675]

### DIFF
--- a/src/goto-programs/json_expr.cpp
+++ b/src/goto-programs/json_expr.cpp
@@ -51,9 +51,7 @@ static exprt simplify_json_expr(const exprt &src)
       // simplify expressions of the form &member(object, @class_identifier)
       return simplify_json_expr(object);
     }
-    else if(
-      object.id() == ID_index && to_index_expr(object).index().is_constant() &&
-      to_constant_expr(to_index_expr(object).index()).value_is_zero_string())
+    else if(object.id() == ID_index && to_index_expr(object).index() == 0)
     {
       // simplify expressions of the form  &array[0]
       return simplify_json_expr(to_index_expr(object).array());

--- a/src/util/simplify_expr_int.cpp
+++ b/src/util/simplify_expr_int.cpp
@@ -782,7 +782,7 @@ simplify_exprt::simplify_bitwise(const multi_ary_exprt &expr)
       }
       else if(
         it->is_constant() && it->type().id() == ID_bv &&
-        to_constant_expr(*it).value_is_zero_string() &&
+        *it == to_bv_type(it->type()).all_zeros_expr() &&
         new_expr.operands().size() > 1)
       {
         it = new_expr.operands().erase(it);

--- a/src/util/std_expr.h
+++ b/src/util/std_expr.h
@@ -3133,8 +3133,6 @@ public:
     set(ID_value, value);
   }
 
-  bool value_is_zero_string() const;
-
   /// Returns true if \p expr has a pointer type and a value NULL; it also
   /// returns true when \p expr has value zero and NULL_is_zero is true; returns
   /// false in all other cases.
@@ -3166,6 +3164,9 @@ public:
   {
     check(expr, vm);
   }
+
+protected:
+  bool value_is_zero_string() const;
 };
 
 template <>

--- a/unit/goto-symex/goto_symex_state.cpp
+++ b/unit/goto-symex/goto_symex_state.cpp
@@ -173,8 +173,7 @@ SCENARIO(
           const symbol_exprt object_symbol =
             to_symbol_expr(object_descriptor->object());
           REQUIRE(object_symbol.get_identifier() == "int_value!0");
-          REQUIRE(to_constant_expr(object_descriptor->offset())
-                    .value_is_zero_string());
+          REQUIRE(object_descriptor->offset() == 0);
         }
         THEN("The target equations are unchanged")
         {


### PR DESCRIPTION
The value representation is an implementation detail. Callers should use methods at a higher level of abstraction.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
