### PR TITLE
`format_expr` now prints `bv`-typed constants

### DIFF
--- a/src/util/format_expr.cpp
+++ b/src/util/format_expr.cpp
@@ -186,6 +186,19 @@ static std::ostream &format_rec(std::ostream &os, const constant_exprt &src)
     type == ID_unsignedbv || type == ID_signedbv || type == ID_c_bool ||
     type == ID_c_bit_field)
     return os << *numeric_cast<mp_integer>(src);
+  else if(type == ID_bv)
+  {
+    // These do not have a numerical interpretation.
+    // We'll print the 0/1 bit pattern, starting with the bit
+    // that has the highest index.
+    auto width = to_bv_type(src.type()).get_width();
+    std::string result;
+    result.reserve(width);
+    auto &value = src.get_value();
+    for(std::size_t i = 0; i < width; i++)
+      result += get_bvrep_bit(value, width, width - i - 1) ? '1' : '0';
+    return os << result;
+  }
   else if(type == ID_integer || type == ID_natural || type == ID_range)
     return os << src.get_value();
   else if(type == ID_string)

--- a/unit/util/format_expr.cpp
+++ b/unit/util/format_expr.cpp
@@ -6,8 +6,10 @@
 
 \*******************************************************************/
 
-#include <util/expr.h>
+#include <util/arith_tools.h>
+#include <util/bitvector_types.h>
 #include <util/format_expr.h>
+#include <util/std_expr.h>
 
 #include <testing-utils/use_catch.h>
 
@@ -22,4 +24,11 @@ TEST_CASE(
       return out;
     });
   REQUIRE(format_to_string(exprt{custom_id}) == "output");
+}
+
+TEST_CASE("Format a bv-typed constant", "[core][util][format_expr]")
+{
+  auto value = make_bvrep(4, [](std::size_t index) { return index != 2; });
+  auto expr = constant_exprt{value, bv_typet{4}};
+  REQUIRE(format_to_string(expr) == "1011");
 }


### PR DESCRIPTION
This adds formatting for `bv`-type constants to `format_expr`.  As the `bv` type does not have a numerical representation, the 0/1 bit pattern is printed, starting with the bit with the highest index.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
