### PR TITLE
C library: Apple does not adhere to aarch64 ABI

### DIFF
--- a/src/ansi-c/library/stdio.c
+++ b/src/ansi-c/library/stdio.c
@@ -1134,7 +1134,7 @@ int vfscanf(FILE *restrict stream, const char *restrict format, va_list arg)
   }
 
   (void)*format;
-#  if defined(__aarch64__) || defined(_M_ARM64)
+#  if(defined(__aarch64__) || defined(_M_ARM64)) && !defined(__APPLE__)
   while((__CPROVER_size_t)__CPROVER_POINTER_OFFSET(arg.__stack) <
         __CPROVER_OBJECT_SIZE(arg.__stack))
   {
@@ -1192,7 +1192,7 @@ __CPROVER_HIDE:;
   }
 
   (void)*format;
-#if defined(__aarch64__) || defined(_M_ARM64)
+#if(defined(__aarch64__) || defined(_M_ARM64)) && !defined(__APPLE__)
   while((__CPROVER_size_t)__CPROVER_POINTER_OFFSET(arg.__stack) <
         __CPROVER_OBJECT_SIZE(arg.__stack))
   {
@@ -1250,7 +1250,7 @@ int __stdio_common_vfscanf(
   }
 
   (void)*format;
-#  if defined(__aarch64__) || defined(_M_ARM64)
+#  if(defined(__aarch64__) || defined(_M_ARM64)) && !defined(__APPLE__)
   while((__CPROVER_size_t)__CPROVER_POINTER_OFFSET(args.__stack) <
         __CPROVER_OBJECT_SIZE(args.__stack))
   {
@@ -1338,7 +1338,7 @@ __CPROVER_HIDE:;
   int result = __VERIFIER_nondet_int();
   (void)*s;
   (void)*format;
-#  if defined(__aarch64__) || defined(_M_ARM64)
+#  if(defined(__aarch64__) || defined(_M_ARM64)) && !defined(__APPLE__)
   while((__CPROVER_size_t)__CPROVER_POINTER_OFFSET(arg.__stack) <
         __CPROVER_OBJECT_SIZE(arg.__stack))
   {
@@ -1382,7 +1382,7 @@ __CPROVER_HIDE:;
   int result = __VERIFIER_nondet_int();
   (void)*s;
   (void)*format;
-#if defined(__aarch64__) || defined(_M_ARM64)
+#if(defined(__aarch64__) || defined(_M_ARM64)) && !defined(__APPLE__)
   while((__CPROVER_size_t)__CPROVER_POINTER_OFFSET(arg.__stack) <
         __CPROVER_OBJECT_SIZE(arg.__stack))
   {
@@ -1432,7 +1432,7 @@ int __stdio_common_vsscanf(
 
   (void)*s;
   (void)*format;
-#  if defined(__aarch64__) || defined(_M_ARM64)
+#  if(defined(__aarch64__) || defined(_M_ARM64)) && !defined(__APPLE__)
   while((__CPROVER_size_t)__CPROVER_POINTER_OFFSET(args.__stack) <
         __CPROVER_OBJECT_SIZE(args.__stack))
   {
@@ -1827,7 +1827,7 @@ int vsnprintf(char *str, size_t size, const char *fmt, va_list ap)
 {
   (void)*fmt;
 
-#if defined(__aarch64__) || defined(_M_ARM64)
+#if(defined(__aarch64__) || defined(_M_ARM64)) && !defined(__APPLE__)
   while((__CPROVER_size_t)__CPROVER_POINTER_OFFSET(ap.__stack) <
         __CPROVER_OBJECT_SIZE(ap.__stack))
 
@@ -1887,7 +1887,7 @@ int __builtin___vsnprintf_chk(
   (void)bufsize;
   (void)*fmt;
 
-#if defined(__aarch64__) || defined(_M_ARM64)
+#if(defined(__aarch64__) || defined(_M_ARM64)) && !defined(__APPLE__)
   while((__CPROVER_size_t)__CPROVER_POINTER_OFFSET(ap.__stack) <
         __CPROVER_OBJECT_SIZE(ap.__stack))
 


### PR DESCRIPTION
The fix from #8366 must not be used on macOS as that platform still uses `__builtin_va_list` instead of the ARM-mandated struct.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
