### PR TITLE
C library: fix build on FreeBSD

### DIFF
--- a/src/ansi-c/library/stdio.c
+++ b/src/ansi-c/library/stdio.c
@@ -6,8 +6,8 @@
 #define __CPROVER_STDIO_H_INCLUDED
 #endif
 
-/* undefine macros in OpenBSD's stdio.h that are problematic to the checker. */
-#if defined(__OpenBSD__)
+/* undefine macros in certain OS' stdio.h that are problematic to the checker. */
+#if defined(__OpenBSD__) || defined(__FreeBSD__)
 #undef getchar
 #undef putchar
 #undef getc


### PR DESCRIPTION
FreeBSD #defines several stdio macros the same way OpenBSD does. Extend the scope of the existing special case to FreeBSD as well, and generalize the comment (in anticipation of it needing to be extended).

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.