### PR TITLE
SMT2: implement cond

### DIFF
--- a/src/solvers/smt2/smt2_conv.cpp
+++ b/src/solvers/smt2/smt2_conv.cpp
@@ -2490,6 +2490,11 @@ void smt2_convt::convert_expr(const exprt &expr)
       out << ')';
     }
   }
+  else if(expr.id() == ID_cond)
+  {
+    // use the lowering
+    convert_expr(to_cond_expr(expr).lower());
+  }
   else
     INVARIANT_WITH_DIAGNOSTICS(
       false,

--- a/src/util/std_expr.cpp
+++ b/src/util/std_expr.cpp
@@ -260,3 +260,32 @@ exprt binding_exprt::instantiate(const variablest &new_variables) const
     values.push_back(new_variable);
   return instantiate(values);
 }
+
+exprt cond_exprt::lower() const
+{
+  INVARIANT(
+    operands().size() % 2 == 0, "cond must have even number of operands");
+
+  exprt result = nil_exprt();
+
+  auto &operands = this->operands();
+
+  // functional version -- go backwards
+  for(std::size_t i = operands.size(); i != 0; i -= 2)
+  {
+    INVARIANT(
+      i >= 2,
+      "since the number of operands is even if i is nonzero it must be "
+      "greater than two");
+
+    const exprt &cond = operands[i - 2];
+    const exprt &value = operands[i - 1];
+
+    if(result.is_nil())
+      result = value;
+    else
+      result = if_exprt{cond, value, std::move(result)};
+  }
+
+  return result;
+}

--- a/src/util/std_expr.h
+++ b/src/util/std_expr.h
@@ -3491,6 +3491,9 @@ public:
     operands().push_back(condition);
     operands().push_back(value);
   }
+
+  // a lowering to nested if_exprt
+  exprt lower() const;
 };
 
 template <>


### PR DESCRIPTION
This adds support for `cond_exprt`, via a lowering to nested `?:`, to the SMT backend.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
