### PR TITLE
Re-enable array theory as default for array size above threshold

### DIFF
--- a/regression/cbmc/array-bug-6230/main.c
+++ b/regression/cbmc/array-bug-6230/main.c
@@ -3,7 +3,9 @@
 
 struct inner
 {
-  uint32_t exts[32]; // 32 is the minimum to crash
+  // 32 is the minimum to crash as it will produce an array wider than 1000 bits
+  // (the default value of MAX_FLATTENED_ARRAY_SIZE)
+  uint32_t exts[32];
 };
 
 struct outer

--- a/regression/cbmc/bounds_check1/test.desc
+++ b/regression/cbmc/bounds_check1/test.desc
@@ -1,6 +1,6 @@
 CORE thorough-smt-backend no-new-smt
 main.c
---no-malloc-may-fail
+--no-malloc-may-fail --arrays-uf-never
 ^EXIT=10$
 ^SIGNAL=0$
 \[\(.*\)i2\]: FAILURE

--- a/regression/cbmc/union/union_large_array.desc
+++ b/regression/cbmc/union/union_large_array.desc
@@ -1,6 +1,6 @@
 CORE thorough-smt-backend no-new-smt
 union_large_array.c
-
+--arrays-uf-never
 ^EXIT=10$
 ^SIGNAL=0$
 ^\[main\.assertion\.1\] line \d+ should fail: FAILURE$

--- a/src/solvers/flattening/arrays.cpp
+++ b/src/solvers/flattening/arrays.cpp
@@ -196,12 +196,24 @@ void arrayst::collect_arrays(const exprt &a)
   }
   else if(a.id()==ID_member)
   {
-    const auto &struct_op = to_member_expr(a).struct_op();
+    const exprt *struct_op_ptr = &to_member_expr(a).struct_op();
+    while(struct_op_ptr->id() == ID_member)
+      struct_op_ptr = &to_member_expr(*struct_op_ptr).struct_op();
 
-    DATA_INVARIANT(
-      struct_op.id() == ID_symbol || struct_op.id() == ID_nondet_symbol,
-      "unexpected array expression: member with '" + struct_op.id_string() +
-        "'");
+    if(struct_op_ptr->id() == ID_index)
+    {
+      const auto &array_op = to_index_expr(*struct_op_ptr).array();
+      arrays.make_union(a, array_op);
+      collect_arrays(array_op);
+    }
+    else
+    {
+      DATA_INVARIANT(
+        struct_op_ptr->id() == ID_struct || struct_op_ptr->id() == ID_symbol ||
+          struct_op_ptr->id() == ID_nondet_symbol,
+        "unexpected array expression: member with '" +
+          struct_op_ptr->id_string() + "'");
+    }
   }
   else if(a.is_constant() || a.id() == ID_array || a.id() == ID_string_constant)
   {
@@ -497,10 +509,7 @@ void arrayst::add_array_constraints(
     expr.id() == ID_string_constant)
   {
   }
-  else if(
-    expr.id() == ID_member &&
-    (to_member_expr(expr).struct_op().id() == ID_symbol ||
-     to_member_expr(expr).struct_op().id() == ID_nondet_symbol))
+  else if(expr.id() == ID_member)
   {
   }
   else if(expr.id()==ID_byte_update_little_endian ||

--- a/src/solvers/flattening/boolbv.h
+++ b/src/solvers/flattening/boolbv.h
@@ -51,7 +51,7 @@ public:
     message_handlert &message_handler,
     bool get_array_constraints = false)
     : arrayst(_ns, _prop, message_handler, get_array_constraints),
-      unbounded_array(unbounded_arrayt::U_NONE),
+      unbounded_array(unbounded_arrayt::U_AUTO),
       bv_width(_ns),
       bv_utils(_prop),
       functions(*this),


### PR DESCRIPTION
Previously, the command line permitted setting uninterpreted functions to "never" or "always", where "never" actually was the default. The "automatic" mode could not be enabled in any way.

We previously attempted to do this in in #6194 (inspired by #2108, but not picking up all its changes), but then reverted the gist of the change in #6232 as `array-bug-6230/main.c` demonstrated lingering issues. This PR now addresses the flaw in the array theory back-end.

We may still run into performance regressions as the threshold of 1000 bits of total size of the array object is possibly lower than where the cost of bit-blasting exceeds the cost of constraints produced by our current array theory implementation. Two of our existing regression tests already demonstrate this problem, hence those now use `--arrays-uf-never`.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
