### PR TITLE
Contracts: document use of __CPROVER_loop_entry with arrays

### DIFF
--- a/src/goto-instrument/contracts/doc/user/contracts-history-variables.md
+++ b/src/goto-instrument/contracts/doc/user/contracts-history-variables.md
@@ -53,6 +53,13 @@ __CPROVER_loop_entry(*identifier*)
 
 ### Semantics
 `__CPROVER_loop_entry` takes a snapshot of the variable value right before the **first iteration** of the loop.
+Caveat: to create a snapshot of an array, cast the array variable (which is a
+pointer per C's type system) to a pointer-to-array, and then dereference.
+```c
+typedef int array_type[2];
+array_type var;
+__CPROVER_loop_invariant(__CPROVER_loop_entry(*(array_type*)var)[0] <= 42)
+```
 
 ### Example
 In this example the loop invariant asserts that `x <= 200` is upheld before and after every iteration of the `while` loop:


### PR DESCRIPTION
Snapshotting of array-typed variables requires care as users may unintentionally copy the pointer rather than the contents.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [x] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
