### PR TITLE
Reword documentation of __CPROVER_{r,w,rw}_ok

### DIFF
--- a/doc/cprover-manual/memory-primitives.md
+++ b/doc/cprover-manual/memory-primitives.md
@@ -233,11 +233,11 @@ number of bytes:
 - `_Bool __CPROVER_w_ok(const void *p, size_t size)`
 
 At present, both primitives are equivalent as all memory in CBMC is considered
-both readable and writeable. If `p` is the null pointer, the primitives return
-false. If `p` is valid, the primitives return true if the memory segment
-starting at the pointer has at least the given size, and false otherwise. If `p`
-is neither null nor valid, the semantics is unspecified. It is valid to apply
-the primitive to pointers that point to within a memory object. For example:
+both readable and writeable. The primitives return true if `p` points to a live
+object and the object that `p` points into extends to at least `size` more
+bytes. Else, an assertion encompassing the primitive will be reported to fail.
+Do not use these primitives in assumptions when `p` can be not valid as such use
+can yield spurious verification results.
 
 ```C
 char *p = malloc(10);


### PR DESCRIPTION
It is safe to use these primitives for asserting validity of pointers.

Fixes: #8217, #8199

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [x] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- n/a Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
