### PR TITLE
`format_type` can now format `range_typet`

### DIFF
--- a/src/util/format_type.cpp
+++ b/src/util/format_type.cpp
@@ -98,6 +98,12 @@ std::ostream &format_rec(std::ostream &os, const typet &type)
     return os << "\xe2\x84\xa4"; // u+2124, 'Z'
   else if(id == ID_natural)
     return os << "\xe2\x84\x95"; // u+2115, 'N'
+  else if(id == ID_range)
+  {
+    auto &range_type = to_range_type(type);
+    return os << "{ " << range_type.get_from() << ", ..., "
+              << range_type.get_to() << " }";
+  }
   else if(id == ID_rational)
     return os << "\xe2\x84\x9a"; // u+211A, 'Q'
   else if(id == ID_mathematical_function)

--- a/unit/Makefile
+++ b/unit/Makefile
@@ -144,6 +144,7 @@ SRC += analyses/ai/ai.cpp \
        util/format.cpp \
        util/format_expr.cpp \
        util/format_number_range.cpp \
+       util/format_type.cpp \
        util/get_base_name.cpp \
        util/graph.cpp \
        util/help_formatter.cpp \

--- a/unit/util/format_type.cpp
+++ b/unit/util/format_type.cpp
@@ -1,0 +1,19 @@
+/*******************************************************************\
+
+ Module: Unit tests for `format` function on types
+
+ Author: Daniel Kroening, dkr@amazon.com
+
+\*******************************************************************/
+
+#include <util/format.h>
+#include <util/format_type.h>
+#include <util/std_expr.h>
+
+#include <testing-utils/use_catch.h>
+
+TEST_CASE("Format a range type", "[core][util][format_type]")
+{
+  auto type = range_typet(1, 10);
+  REQUIRE(format_to_string(type) == "{ 1, ..., 10 }");
+}


### PR DESCRIPTION
This adds formatting for `range_typet` as `{ from, ..., to }`.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [X] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
