### PR TITLE
`bitvector_typet`: set width from mp_integer

### DIFF
--- a/src/ansi-c/c_typecheck_type.cpp
+++ b/src/ansi-c/c_typecheck_type.cpp
@@ -1496,7 +1496,7 @@ void c_typecheck_baset::typecheck_c_bit_field_type(c_bit_field_typet &type)
         << "bit field width is negative";
     }
 
-    type.set_width(numeric_cast_v<std::size_t>(i));
+    type.width(i);
     type.remove(ID_size);
   }
 

--- a/src/util/std_types.cpp
+++ b/src/util/std_types.cpp
@@ -12,6 +12,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "std_types.h"
 
+#include "arith_tools.h"
 #include "c_types.h"
 #include "namespace.h"
 #include "std_expr.h"
@@ -152,6 +153,16 @@ bool is_rvalue_reference(const typet &type)
 {
   return type.id()==ID_pointer &&
          type.get_bool(ID_C_rvalue_reference);
+}
+
+std::size_t bitvector_typet::width() const
+{
+  return get_size_t(ID_width);
+}
+
+void bitvector_typet::width(const mp_integer &width)
+{
+  set_width(numeric_cast_v<std::size_t>(width));
 }
 
 void range_typet::set_from(const mp_integer &from)

--- a/src/util/std_types.h
+++ b/src/util/std_types.h
@@ -917,15 +917,24 @@ public:
     set_width(width);
   }
 
+  bitvector_typet(const irep_idt &_id, mp_integer _width) : typet(_id)
+  {
+    width(_width);
+  }
+
   std::size_t get_width() const
   {
     return get_size_t(ID_width);
   }
 
+  std::size_t width() const;
+
   void set_width(std::size_t width)
   {
     set_size_t(ID_width, width);
   }
+
+  void width(const mp_integer &);
 
   static void check(
     const typet &type,


### PR DESCRIPTION
This adds C-style getter/setter methods to `bitvector_typet` for the width of the vector.

The setter takes an `mp_integer`, which checks that the width fits within `std::size_t`.  This removes the burden of performing this check from the caller, and allows callers to avoid potential arithmetic overflows by using `mp_integer`.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [X] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
