### PR TITLE
Remove macos-12 CI job

### DIFF
--- a/.github/workflows/pull-request-checks.yaml
+++ b/.github/workflows/pull-request-checks.yaml
@@ -640,50 +640,6 @@ jobs:
         run: make -C jbmc/regression test-parallel JOBS=4
 
   # This job takes approximately 36 to 85 minutes
-  check-macos-12-cmake-clang:
-    runs-on: macos-12
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: recursive
-      - name: Fetch dependencies
-        run: brew install cmake ninja maven flex bison ccache z3
-      - name: Confirm z3 solver is available and log the version installed
-        run: z3 --version
-      - name: Download cvc5 binary and make sure it can be deployed
-        run: |
-          wget https://github.com/cvc5/cvc5/releases/download/cvc5-${{env.cvc5-version}}/cvc5-macOS-static.zip
-          unzip -j -d /usr/local/bin cvc5-macOS-static.zip cvc5-macOS-static/bin/cvc5
-          rm cvc5-macOS-static.zip
-          cvc5 --version
-      - name: Prepare ccache
-        uses: actions/cache@v4
-        with:
-          save-always: true
-          path: .ccache
-          key: ${{ runner.os }}-Release-Glucose-${{ github.ref }}-${{ github.sha }}-PR
-          restore-keys: |
-            ${{ runner.os }}-Release-Glucose-${{ github.ref }}
-            ${{ runner.os }}-Release-Glucose
-      - name: ccache environment
-        run: |
-          echo "CCACHE_BASEDIR=$PWD" >> $GITHUB_ENV
-          echo "CCACHE_DIR=$PWD/.ccache" >> $GITHUB_ENV
-      - name: Zero ccache stats and limit in size
-        run: ccache -z --max-size=500M
-      - name: Configure using CMake
-        run: |
-          mkdir build
-          cd build
-          cmake .. -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=$(brew --prefix llvm@15)/bin/clang -DCMAKE_CXX_COMPILER=$(brew --prefix llvm@15)/bin/clang++ -Dsat_impl=glucose
-      - name: Build with Ninja
-        run: cd build; ninja -j3
-      - name: Print ccache stats
-        run: ccache -s
-      - name: Run CTest
-        run: cd build; ctest -V -L CORE . -j3
-
-  # This job takes approximately 36 to 85 minutes
   check-macos-14-cmake-clang:
     runs-on: macos-14
     steps:


### PR DESCRIPTION
GitHub has deprecated the macos-12 image and will cease to support in in December '24. See https://github.com/actions/runner-images/issues/10721.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
