### PR TITLE
[CONTRACTS] Detect loop locals with goto_rw in DFCC

### DIFF
--- a/regression/contracts-dfcc/dont_skip_cprover_prefixed_vars_fail/main.c
+++ b/regression/contracts-dfcc/dont_skip_cprover_prefixed_vars_fail/main.c
@@ -1,8 +1,11 @@
 void foo()
 {
-  int nondet_var;
-  int __VERIFIER_var;
-  int __CPROVER_var;
+  // Initialize them with `nondet_int` to avoid them being ignored by DFCC.
+  // DFCC ignores variables that are not read/written to outside the loop
+  // or in the loop contracts.
+  int nondet_var = nondet_int();
+  int __VERIFIER_var = nondet_int();
+  int __CPROVER_var = nondet_int();
   for(int i = 10; i > 0; i--)
     // clang-format off
   __CPROVER_assigns(i)

--- a/regression/contracts-dfcc/dont_skip_cprover_prefixed_vars_pass/main.c
+++ b/regression/contracts-dfcc/dont_skip_cprover_prefixed_vars_pass/main.c
@@ -1,8 +1,11 @@
 void foo()
 {
-  int nondet_var;
-  int __VERIFIER_var;
-  int __CPROVER_var;
+  // Initialize them with `nondet_int` to avoid them being ignored by DFCC.
+  // DFCC ignores variables that are not read/written to outside the loop
+  // or in the loop contracts.
+  int nondet_var = nondet_int();
+  int __VERIFIER_var = nondet_int();
+  int __CPROVER_var = nondet_int();
   for(int i = 10; i > 0; i--)
     // clang-format off
   __CPROVER_assigns(i,nondet_var, __VERIFIER_var, __CPROVER_var)

--- a/regression/contracts-dfcc/invar_loop-entry_check/main.c
+++ b/regression/contracts-dfcc/invar_loop-entry_check/main.c
@@ -12,7 +12,7 @@ void main()
   x1 = &z1;
 
   while(y1 > 0)
-    __CPROVER_loop_invariant(*x1 == __CPROVER_loop_entry(*x1))
+    __CPROVER_loop_invariant(y1 >= 0 && *x1 == __CPROVER_loop_entry(*x1))
     {
       --y1;
       *x1 = *x1 + 1;
@@ -24,7 +24,7 @@ void main()
   x2 = z2;
 
   while(y2 > 0)
-    __CPROVER_loop_invariant(x2 == __CPROVER_loop_entry(x2))
+    __CPROVER_loop_invariant(y2 >= 0 && x2 == __CPROVER_loop_entry(x2))
     {
       --y2;
       x2 = x2 + 1;
@@ -34,11 +34,12 @@ void main()
 
   int y3;
   s s0, s1, *s2 = &s0;
+  s0.n = malloc(sizeof(int));
   s2->n = malloc(sizeof(int));
   s1.n = s2->n;
 
   while(y3 > 0)
-    __CPROVER_loop_invariant(s2->n == __CPROVER_loop_entry(s2->n))
+    __CPROVER_loop_invariant(y3 >= 0 && s2->n == __CPROVER_loop_entry(s2->n))
     {
       --y3;
       s0.n = s0.n + 1;

--- a/regression/contracts-dfcc/invar_loop-entry_check/test.desc
+++ b/regression/contracts-dfcc/invar_loop-entry_check/test.desc
@@ -11,10 +11,10 @@ main.c
 ^\[main.loop_invariant_base.\d+] line 26 Check invariant before entry for loop .*: SUCCESS$
 ^\[main.loop_invariant_step.\d+] line 26 Check invariant after step for loop .*: SUCCESS$
 ^\[main.loop_step_unwinding.\d+] line 26 Check step was unwound for loop .*: SUCCESS$
-^\[main.loop_assigns.\d+] line 40 Check assigns clause inclusion for loop .*: SUCCESS$
-^\[main.loop_invariant_base.\d+] line 40 Check invariant before entry for loop .*: SUCCESS$
-^\[main.loop_invariant_step.\d+] line 40 Check invariant after step for loop .*: SUCCESS$
-^\[main.loop_step_unwinding.\d+] line 40 Check step was unwound for loop .*: SUCCESS$
+^\[main.loop_assigns.\d+] line 41 Check assigns clause inclusion for loop .*: SUCCESS$
+^\[main.loop_invariant_base.\d+] line 41 Check invariant before entry for loop .*: SUCCESS$
+^\[main.loop_invariant_step.\d+] line 41 Check invariant after step for loop .*: SUCCESS$
+^\[main.loop_step_unwinding.\d+] line 41 Check step was unwound for loop .*: SUCCESS$
 ^\[main\.assertion\.\d+\] .* assertion \*x1 == z1: SUCCESS$
 ^\[main\.assertion\.\d+\] .* assertion x2 == z2: SUCCESS$
 ^\[main.assigns.\d+\] .* Check that y1 is assignable: SUCCESS$

--- a/regression/contracts-dfcc/invar_loop-entry_fail/main.c
+++ b/regression/contracts-dfcc/invar_loop-entry_fail/main.c
@@ -6,7 +6,7 @@ void main()
   x = z;
 
   while(y > 0)
-    __CPROVER_loop_invariant(x == __CPROVER_loop_entry(x))
+    __CPROVER_loop_invariant(y >= 0 && x == __CPROVER_loop_entry(x))
     {
       --y;
       x = x + 1;

--- a/regression/contracts-dfcc/loop_assigns_inference-03/main.c
+++ b/regression/contracts-dfcc/loop_assigns_inference-03/main.c
@@ -7,7 +7,7 @@ void main()
   int b[SIZE];
   for(unsigned i = 0; i < SIZE; i++)
     // clang-format off
-    __CPROVER_loop_invariant(i <= SIZE)
+    __CPROVER_loop_invariant((i == 0 || b[0] == 1) && i <= SIZE)
     // clang-format on
     {
       b[i] = 1;

--- a/src/goto-instrument/contracts/dynamic-frames/dfcc_infer_loop_assigns.h
+++ b/src/goto-instrument/contracts/dynamic-frames/dfcc_infer_loop_assigns.h
@@ -14,16 +14,29 @@ Author: Remi Delmas, delmasrd@amazon.com
 
 #include <analyses/local_may_alias.h>
 #include <goto-instrument/loop_utils.h>
+
+#include "dfcc_loop_nesting_graph.h"
+
 class source_locationt;
 class messaget;
 class namespacet;
+class message_handlert;
 
 // \brief Infer assigns clause targets for a loop from its instructions and a
 // may alias analysis at the function level.
 assignst dfcc_infer_loop_assigns(
   const local_may_aliast &local_may_alias,
-  const loopt &loop_instructions,
-  const source_locationt &loop_head_location,
+  goto_functiont &goto_function,
+  const dfcc_loop_nesting_graph_nodet &loop_instructions,
+  message_handlert &message_handler,
+  const namespacet &ns);
+
+/// Collect identifiers that are local to `loop`.
+std::unordered_set<irep_idt> gen_loop_locals_set(
+  const irep_idt &function_id,
+  goto_functiont &goto_function,
+  const dfcc_loop_nesting_graph_nodet &loop,
+  message_handlert &message_handler,
   const namespacet &ns);
 
 #endif


### PR DESCRIPTION
This PR improve the loop locals detection in DFCC by also detecting variables that are not written or read outside the loop.


- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.
