### PR TITLE
[CONTRACTS] DFCC loop assigns infererence with functions inlined

### DIFF
--- a/regression/contracts-dfcc/invar_havoc_dynamic_array_const_idx/main.c
+++ b/regression/contracts-dfcc/invar_havoc_dynamic_array_const_idx/main.c
@@ -10,7 +10,7 @@ void main()
   data[4] = 0;
 
   for(unsigned i = 0; i < SIZE; i++)
-    __CPROVER_loop_invariant(i <= SIZE)
+    __CPROVER_assigns(data[1], i) __CPROVER_loop_invariant(i <= SIZE)
     {
       data[1] = i;
     }

--- a/regression/contracts-dfcc/loop_assigns_inference-01/test.desc
+++ b/regression/contracts-dfcc/loop_assigns_inference-01/test.desc
@@ -1,18 +1,18 @@
-KNOWNBUG
+CORE dfcc-only
 main.c
---dfcc main --apply-loop-contracts
+--dfcc main --apply-loop-contracts _ --no-standard-checks
 ^EXIT=0$
 ^SIGNAL=0$
 ^\[body_1.assigns.\d+\] .* Check that j is assignable: SUCCESS$
 ^\[body_2.assigns.\d+\] .* Check that \*i is assignable: SUCCESS$
 ^\[body_3.assigns.\d+\] .* Check that \*i is assignable: SUCCESS$
 ^\[incr.assigns.\d+\] .* Check that \*i is assignable: SUCCESS$
-^\[main.\d+\] .* Check loop invariant before entry: SUCCESS$
-^\[main.\d+\] .* Check that loop invariant is preserved: SUCCESS$
+^\[main.loop_invariant_base.\d+\] line \d+ Check invariant before entry for loop .*: SUCCESS$
+^\[main.loop_invariant_step.\d+\] line \d+ Check invariant after step for loop .*: SUCCESS$
+^\[main.loop_step_unwinding.\d+\] line \d+ Check step was unwound for loop .*: SUCCESS$
 ^\[main.assertion.\d+\] .* assertion j == 9: SUCCESS$
 ^VERIFICATION SUCCESSFUL$
 --
 --
 This test checks loop locals are correctly removed during assigns inference so
 that the assign clause is correctly inferred.
-This test failed when using dfcc for loop contracts.

--- a/regression/contracts-dfcc/loop_assigns_inference-04/main.c
+++ b/regression/contracts-dfcc/loop_assigns_inference-04/main.c
@@ -1,0 +1,22 @@
+struct hole
+{
+  int pos;
+};
+
+void set_len(struct hole *h, unsigned long int new_len)
+{
+  h->pos = new_len;
+}
+
+int main()
+{
+  int i = 0;
+  struct hole h;
+  h.pos = 0;
+  for(i = 0; i < 5; i++)
+    // __CPROVER_assigns(h.pos, i)
+    __CPROVER_loop_invariant(h.pos == i)
+    {
+      set_len(&h, h.pos + 1);
+    }
+}

--- a/regression/contracts-dfcc/loop_assigns_inference-04/test.desc
+++ b/regression/contracts-dfcc/loop_assigns_inference-04/test.desc
@@ -1,0 +1,14 @@
+CORE dfcc-only
+main.c
+--dfcc main --apply-loop-contracts
+^EXIT=0$
+^SIGNAL=0$
+^\[main.loop_invariant_base.\d+\] line \d+ Check invariant before entry for loop .*: SUCCESS$
+^\[main.loop_invariant_base.\d+\] line \d+ Check invariant before entry for loop .*: SUCCESS$
+^\[main.loop_invariant_step.\d+\] line \d+ Check invariant after step for loop .*: SUCCESS$
+^\[main.loop_step_unwinding.\d+\] line \d+ Check step was unwound for loop .*: SUCCESS$
+^\[set_len.assigns.\d+\] line \d+ Check that h\-\>pos is assignable: SUCCESS
+^VERIFICATION SUCCESSFUL$
+--
+--
+This test checks assigns h->pos is inferred correctly.

--- a/regression/contracts-dfcc/loop_assigns_inference-05/main.c
+++ b/regression/contracts-dfcc/loop_assigns_inference-05/main.c
@@ -1,0 +1,17 @@
+#include <stdlib.h>
+
+#define SIZE 8
+
+int main()
+{
+  int i = 0;
+  int *j = malloc(SIZE * sizeof(int));
+  for(i = 0; i < SIZE; i++)
+    // __CPROVER_assigns(h.pos, i)
+    __CPROVER_loop_invariant(0 <= i && i <= SIZE)
+    {
+      int *k;
+      k = j + i;
+      *k = 1;
+    }
+}

--- a/regression/contracts-dfcc/loop_assigns_inference-05/test.desc
+++ b/regression/contracts-dfcc/loop_assigns_inference-05/test.desc
@@ -1,0 +1,15 @@
+CORE dfcc-only
+main.c
+--no-malloc-may-fail --dfcc main --apply-loop-contracts
+^EXIT=0$
+^SIGNAL=0$
+^\[main.loop_invariant_base.\d+\] line \d+ Check invariant before entry for loop .*: SUCCESS$
+^\[main.loop_invariant_base.\d+\] line \d+ Check invariant before entry for loop .*: SUCCESS$
+^\[main.loop_invariant_step.\d+\] line \d+ Check invariant after step for loop .*: SUCCESS$
+^\[main.loop_step_unwinding.\d+\] line \d+ Check step was unwound for loop .*: SUCCESS$
+^\[main.assigns.\d+\] line \d+ Check that \*k is assignable: SUCCESS
+^VERIFICATION SUCCESSFUL$
+--
+--
+This test checks assigns __CPROVER_object_whole(k) is inferred correctly,
+which requires widening *k to the whole object.

--- a/src/goto-instrument/contracts/dynamic-frames/dfcc_cfg_info.h
+++ b/src/goto-instrument/contracts/dynamic-frames/dfcc_cfg_info.h
@@ -21,6 +21,7 @@ Date: March 2023
 #include <util/std_expr.h>
 #include <util/symbol_table.h>
 
+#include <goto-programs/goto_model.h>
 #include <goto-programs/goto_program.h>
 
 #include <goto-instrument/contracts/loop_contract_config.h>
@@ -242,6 +243,7 @@ class dfcc_cfg_infot
 {
 public:
   dfcc_cfg_infot(
+    goto_modelt &goto_model,
     const irep_idt &function_id,
     goto_functiont &goto_function,
     const exprt &top_level_write_set,

--- a/src/goto-instrument/contracts/dynamic-frames/dfcc_infer_loop_assigns.cpp
+++ b/src/goto-instrument/contracts/dynamic-frames/dfcc_infer_loop_assigns.cpp
@@ -262,7 +262,9 @@ static assignst dfcc_infer_loop_assigns_for_loop(
     {
       address_of_exprt address_of_expr(expr);
       address_of_expr.add_source_location() = expr.source_location();
-      if(!is_constant(address_of_expr))
+      // Widen assigns targets to object_whole if `expr` is a dereference or
+      // with constant address.
+      if(expr.id() == ID_dereference || !is_constant(address_of_expr))
       {
         // Target address is not constant, widening to the whole object
         result.emplace(make_object_whole_call_expr(address_of_expr, ns));

--- a/src/goto-instrument/contracts/dynamic-frames/dfcc_infer_loop_assigns.cpp
+++ b/src/goto-instrument/contracts/dynamic-frames/dfcc_infer_loop_assigns.cpp
@@ -13,10 +13,13 @@ Author: Remi Delmas, delmasrd@amazon.com
 #include <util/pointer_expr.h>
 #include <util/std_code.h>
 
+#include <goto-programs/goto_inline.h>
+
 #include <analyses/goto_rw.h>
 #include <goto-instrument/contracts/utils.h>
 #include <goto-instrument/havoc_utils.h>
 
+#include "dfcc_loop_nesting_graph.h"
 #include "dfcc_root_object.h"
 
 /// Builds a call expression `object_whole(expr)`
@@ -154,10 +157,67 @@ std::unordered_set<irep_idt> gen_loop_locals_set(
   return loop_locals;
 }
 
-assignst dfcc_infer_loop_assigns(
+/// Find all identifiers in `src`.
+static std::unordered_set<irep_idt>
+find_symbol_identifiers(const goto_programt &src)
+{
+  std::unordered_set<irep_idt> identifiers;
+  for(const auto &instruction : src.instructions)
+  {
+    // compute forward edges first
+    switch(instruction.type())
+    {
+    case ASSERT:
+    case ASSUME:
+    case GOTO:
+      find_symbols(instruction.condition(), identifiers);
+      break;
+
+    case FUNCTION_CALL:
+      find_symbols(instruction.call_lhs(), identifiers);
+      for(const auto &e : instruction.call_arguments())
+        find_symbols(e, identifiers);
+      break;
+    case ASSIGN:
+    case OTHER:
+
+    case SET_RETURN_VALUE:
+    case DECL:
+    case DEAD:
+      for(const auto &e : instruction.code().operands())
+      {
+        find_symbols(e, identifiers);
+      }
+      break;
+
+    case END_THREAD:
+    case END_FUNCTION:
+    case ATOMIC_BEGIN:
+    case ATOMIC_END:
+    case SKIP:
+    case LOCATION:
+    case CATCH:
+    case THROW:
+    case START_THREAD:
+      break;
+    case NO_INSTRUCTION_TYPE:
+    case INCOMPLETE_GOTO:
+      UNREACHABLE;
+      break;
+    }
+  }
+  return identifiers;
+}
+
+/// Infer loop assigns in the given `loop`. Loop assigns should depend
+/// on some identifiers in `candidate_targets`. `function_assigns_map`
+/// contains the function contracts used to infer loop assigns of
+/// function_call instructions.
+static assignst dfcc_infer_loop_assigns_for_loop(
   const local_may_aliast &local_may_alias,
   goto_functiont &goto_function,
   const dfcc_loop_nesting_graph_nodet &loop,
+  const std::unordered_set<irep_idt> &candidate_targets,
   message_handlert &message_handler,
   const namespacet &ns)
 {
@@ -176,6 +236,12 @@ assignst dfcc_infer_loop_assigns(
   assignst result;
   for(const auto &expr : assigns)
   {
+    // Skip targets that only depend on non-visible identifiers.
+    if(!depends_on(expr, candidate_targets))
+    {
+      continue;
+    }
+
     if(depends_on(expr, loop_locals))
     {
       // Target depends on loop locals, attempt widening to the root object
@@ -209,4 +275,104 @@ assignst dfcc_infer_loop_assigns(
   }
 
   return result;
+}
+
+/// Remove assignments to `__CPROVER_dead_object` to avoid aliasing all targets
+/// that are assigned to `__CPROVER_dead_object`.
+static void remove_dead_object_assignment(goto_functiont &goto_function)
+{
+  Forall_goto_program_instructions(i_it, goto_function.body)
+  {
+    if(i_it->is_assign())
+    {
+      auto &lhs = i_it->assign_lhs();
+
+      if(
+        lhs.id() == ID_symbol &&
+        to_symbol_expr(lhs).get_identifier() == CPROVER_PREFIX "dead_object")
+      {
+        i_it->turn_into_skip();
+      }
+    }
+  }
+}
+
+void dfcc_infer_loop_assigns_for_function(
+  std::map<std::size_t, assignst> &inferred_loop_assigns_map,
+  goto_functionst &goto_functions,
+  const goto_functiont &goto_function,
+  message_handlert &message_handler,
+  const namespacet &ns)
+{
+  messaget log(message_handler);
+
+  // Collect all candidate targets---identifiers visible in `goto_function`.
+  const auto candidate_targets = find_symbol_identifiers(goto_function.body);
+
+  // We infer loop assigns based on the copy of `goto_function`.
+  goto_functiont goto_function_copy;
+  goto_function_copy.copy_from(goto_function);
+
+  // Build the loop id map before inlining attempt. So that we can later
+  // distinguish loops in the original body and loops added by inlining.
+  const auto loop_nesting_graph =
+    build_loop_nesting_graph(goto_function_copy.body);
+  auto topsorted = loop_nesting_graph.topsort();
+  // skip function without loop.
+  if(topsorted.empty())
+    return;
+
+  // Map from targett in `goto_function_copy` to loop number.
+  std::
+    unordered_map<goto_programt::const_targett, std::size_t, const_target_hash>
+      loop_number_map;
+
+  for(const auto id : topsorted)
+  {
+    loop_number_map.emplace(
+      loop_nesting_graph[id].head, loop_nesting_graph[id].latch->loop_number);
+  }
+
+  // We avoid inlining `malloc` and `free` whose variables are not assigns.
+  auto malloc_body = goto_functions.function_map.extract(irep_idt("malloc"));
+  auto free_body = goto_functions.function_map.extract(irep_idt("free"));
+
+  // Inline all function calls in goto_function_copy.
+  goto_program_inline(
+    goto_functions, goto_function_copy.body, ns, log.get_message_handler());
+  // Update the body to make sure all goto correctly jump to valid targets.
+  goto_function_copy.body.update();
+  // Build the loop graph after inlining.
+  const auto inlined_loop_nesting_graph =
+    build_loop_nesting_graph(goto_function_copy.body);
+
+  // Alias analysis.
+  remove_dead_object_assignment(goto_function_copy);
+  local_may_aliast local_may_alias(goto_function_copy);
+
+  auto inlined_topsorted = inlined_loop_nesting_graph.topsort();
+
+  for(const auto inlined_id : inlined_topsorted)
+  {
+    // We only infer loop assigns for loops in the original function.
+    if(
+      loop_number_map.find(inlined_loop_nesting_graph[inlined_id].head) !=
+      loop_number_map.end())
+    {
+      const auto loop_number =
+        loop_number_map[inlined_loop_nesting_graph[inlined_id].head];
+      const auto inlined_loop = inlined_loop_nesting_graph[inlined_id];
+
+      inferred_loop_assigns_map[loop_number] = dfcc_infer_loop_assigns_for_loop(
+        local_may_alias,
+        goto_function_copy,
+        inlined_loop,
+        candidate_targets,
+        message_handler,
+        ns);
+    }
+  }
+  // Restore the function boyd of `malloc` and `free`.
+  goto_functions.function_map.insert(std::move(malloc_body));
+  goto_functions.function_map.insert(std::move(free_body));
 }

--- a/src/goto-instrument/contracts/dynamic-frames/dfcc_infer_loop_assigns.h
+++ b/src/goto-instrument/contracts/dynamic-frames/dfcc_infer_loop_assigns.h
@@ -22,20 +22,22 @@ class messaget;
 class namespacet;
 class message_handlert;
 
-// \brief Infer assigns clause targets for a loop from its instructions and a
-// may alias analysis at the function level.
-assignst dfcc_infer_loop_assigns(
-  const local_may_aliast &local_may_alias,
-  goto_functiont &goto_function,
-  const dfcc_loop_nesting_graph_nodet &loop_instructions,
-  message_handlert &message_handler,
-  const namespacet &ns);
-
 /// Collect identifiers that are local to `loop`.
 std::unordered_set<irep_idt> gen_loop_locals_set(
   const irep_idt &function_id,
   goto_functiont &goto_function,
   const dfcc_loop_nesting_graph_nodet &loop,
+  message_handlert &message_handler,
+  const namespacet &ns);
+
+/// \brief Infer assigns clause targets for loops in `goto_function` from their
+/// instructions and an alias analysis at the function level (with inlining),
+/// and store the result in `inferred_loop_assigns_map`, a map from loop
+/// numbers to the set of inferred assigns targets.
+void dfcc_infer_loop_assigns_for_function(
+  std::map<std::size_t, assignst> &inferred_loop_assigns_map,
+  goto_functionst &goto_functions,
+  const goto_functiont &goto_function,
   message_handlert &message_handler,
   const namespacet &ns);
 

--- a/src/goto-instrument/contracts/dynamic-frames/dfcc_instrument.cpp
+++ b/src/goto-instrument/contracts/dynamic-frames/dfcc_instrument.cpp
@@ -399,6 +399,7 @@ void dfcc_instrumentt::instrument_goto_program(
 
   // build control flow graph information
   dfcc_cfg_infot cfg_info(
+    goto_model,
     function_id,
     goto_function,
     write_set,
@@ -448,6 +449,7 @@ void dfcc_instrumentt::instrument_goto_function(
 
   // build control flow graph information
   dfcc_cfg_infot cfg_info(
+    goto_model,
     function_id,
     goto_function,
     write_set,


### PR DESCRIPTION
Current loop assigns inference of DFCC can only infer targets considering only instructions in the same function. However, variables may be written to in the call of another function from function call inside the loop. So in this PR, we infer loop assigns based on a copy of the function and inlining all calls in the copy.

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
