### PR TITLE
use `zero_extend_exprt` in SMT2 front-end

### DIFF
--- a/src/solvers/smt2/smt2_parser.cpp
+++ b/src/solvers/smt2/smt2_parser.cpp
@@ -656,7 +656,7 @@ exprt smt2_parsert::function_application()
           if(next_token() != smt2_tokenizert::NUMERAL)
             throw error() << "expected numeral after " << id;
 
-          auto index = std::stoll(smt2_tokenizer.get_buffer());
+          auto index = string2integer(smt2_tokenizer.get_buffer());
 
           if(next_token() != smt2_tokenizert::CLOSE)
             throw error() << "expected ')' after " << id << " index";
@@ -681,21 +681,21 @@ exprt smt2_parsert::function_application()
             // we first convert to a signed type of the original width,
             // then extend to the new width, and then go to unsigned
             const auto width = to_unsignedbv_type(op[0].type()).get_width();
-            const signedbv_typet small_signed_type(width);
-            const signedbv_typet large_signed_type(width + index);
-            const unsignedbv_typet unsigned_type(width + index);
+            const signedbv_typet small_signed_type{width};
+            const signedbv_typet large_signed_type{width + index};
+            const unsignedbv_typet unsigned_type{width + index};
 
             return typecast_exprt(
               typecast_exprt(
                 typecast_exprt(op[0], small_signed_type), large_signed_type),
               unsigned_type);
           }
-          else if(id=="zero_extend")
+          else if(id == ID_zero_extend)
           {
             auto width=to_unsignedbv_type(op[0].type()).get_width();
-            unsignedbv_typet unsigned_type(width+index);
+            unsignedbv_typet unsigned_type{width + index};
 
-            return typecast_exprt(op[0], unsigned_type);
+            return zero_extend_exprt{op[0], unsigned_type};
           }
           else if(id == ID_repeat)
           {

--- a/src/util/bitvector_types.h
+++ b/src/util/bitvector_types.h
@@ -107,6 +107,11 @@ public:
   {
   }
 
+  integer_bitvector_typet(const irep_idt &id, const mp_integer &width)
+    : bitvector_typet(id, width)
+  {
+  }
+
   /// Return the smallest value that can be represented using this type.
   mp_integer smallest() const;
   /// Return the largest value that can be represented using this type.
@@ -167,6 +172,11 @@ public:
   {
   }
 
+  explicit unsignedbv_typet(const mp_integer &width)
+    : integer_bitvector_typet(ID_unsignedbv, width)
+  {
+  }
+
   static void check(
     const typet &type,
     const validation_modet vm = validation_modet::INVARIANT)
@@ -212,6 +222,11 @@ class signedbv_typet : public integer_bitvector_typet
 {
 public:
   explicit signedbv_typet(std::size_t width)
+    : integer_bitvector_typet(ID_signedbv, width)
+  {
+  }
+
+  explicit signedbv_typet(const mp_integer &width)
     : integer_bitvector_typet(ID_signedbv, width)
   {
   }


### PR DESCRIPTION
This replaces the use of a typecast expression by `zero_extend_exprt` when parsing an SMT-LIB2 `zero_extend` expression.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
