### PR TITLE
goto-symex: assumed pointer equalities must update value set

### DIFF
--- a/regression/cbmc/Pointer_Assume2/main.c
+++ b/regression/cbmc/Pointer_Assume2/main.c
@@ -1,0 +1,27 @@
+int main()
+{
+  int *r;
+  int *a;
+#if 1
+  _Bool tmp_if_expr;
+  if(r == 0)
+  {
+    tmp_if_expr = 0;
+  }
+  else
+  {
+    r = __CPROVER_allocate(sizeof(int), 0);
+    tmp_if_expr = 1;
+  }
+
+  __CPROVER_assume(tmp_if_expr);
+#else
+  // this works, because we constant-propagate r as an address-of expression
+  __CPROVER_assume(r != 0);
+  r = __CPROVER_allocate(sizeof(int), 0);
+#endif
+  __CPROVER_assume(r != 0);
+  __CPROVER_assume(r == a);
+  __CPROVER_assert(r == a, " r == a before");
+  __CPROVER_assert(*r == *a, "*r == *a before");
+}

--- a/regression/cbmc/Pointer_Assume2/test.desc
+++ b/regression/cbmc/Pointer_Assume2/test.desc
@@ -1,0 +1,7 @@
+CORE
+main.c
+
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--

--- a/src/goto-symex/goto_state.cpp
+++ b/src/goto-symex/goto_state.cpp
@@ -92,19 +92,20 @@ void goto_statet::apply_condition(
     if(is_ssa_expr(rhs))
       std::swap(lhs, rhs);
 
-    if(is_ssa_expr(lhs) && goto_symex_can_forward_propagatet(ns)(rhs))
+    if(is_ssa_expr(lhs))
     {
       const ssa_exprt &ssa_lhs = to_ssa_expr(lhs);
       INVARIANT(
         !ssa_lhs.get_level_2().empty(),
         "apply_condition operand should be L2 renamed");
+      const ssa_exprt l1_lhs = remove_level_2(ssa_lhs);
 
       if(
-        previous_state.threads.size() == 1 ||
-        previous_state.write_is_shared(ssa_lhs, ns) !=
-          goto_symex_statet::write_is_shared_resultt::SHARED)
+        goto_symex_can_forward_propagatet(ns)(rhs) &&
+        (previous_state.threads.size() == 1 ||
+         previous_state.write_is_shared(ssa_lhs, ns) !=
+           goto_symex_statet::write_is_shared_resultt::SHARED))
       {
-        const ssa_exprt l1_lhs = remove_level_2(ssa_lhs);
         const irep_idt &l1_identifier = l1_lhs.get_identifier();
 
         level2.increase_generation(
@@ -117,6 +118,20 @@ void goto_statet::apply_condition(
           propagation.replace(l1_identifier, rhs);
 
         value_set.assign(l1_lhs, rhs, ns, true, false);
+      }
+      else if(is_ssa_expr(rhs))
+      {
+        const ssa_exprt &ssa_rhs = to_ssa_expr(rhs);
+        INVARIANT(
+          !ssa_rhs.get_level_2().empty(),
+          "apply_condition operand should be L2 renamed");
+        const ssa_exprt l1_rhs = remove_level_2(ssa_rhs);
+
+        // We have a condition a == b. Make both a's and b's value sets the
+        // union of their previous value sets (the last "true" argument makes
+        // sure we add rather than replace value sets).
+        value_set.assign(l1_lhs, l1_rhs, ns, true, true);
+        value_set.assign(l1_rhs, l1_lhs, ns, true, true);
       }
     }
   }


### PR DESCRIPTION
Value sets and constant propagation are our only sources of points-to information when resolving dereferences in goto-symex. Therefore, assuming or branching on equalities of pointer-typed variables must have us consider both of their value sets to be equal. Else we may end up with spurious counterexamples as seen with the enclosed regression test (where we previously did not have any known value for `a`).

Fixes: #8492

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
