### PR TITLE
remove duplicate SATCHECK_* defines

### DIFF
--- a/src/config.inc
+++ b/src/config.inc
@@ -42,38 +42,6 @@ ifeq ($(BOOLEFORCE)$(CHAFF)$(GLUCOSE)$(IPASIR)$(LINGELING)$(MINISAT)$(MINISAT2)$
   MINISAT2 = ../../minisat-2.2.1
 endif
 
-ifneq ($(PICOSAT),)
-  CP_CXXFLAGS += -DSATCHECK_PICOSAT
-endif
-
-ifneq ($(LINGELING),)
-  CP_CXXFLAGS += -DSATCHECK_LINGELING
-endif
-
-ifneq ($(CHAFF),)
-  CP_CXXFLAGS += -DSATCHECK_CHAFF
-endif
-
-ifneq ($(BOOLEFORCE),)
-  CP_CXXFLAGS += -DSATCHECK_BOOLEFORCE
-endif
-
-ifneq ($(MINISAT),)
-  CP_CXXFLAGS += -DSATCHECK_MINISAT
-endif
-
-ifneq ($(MINISAT2),)
-  CP_CXXFLAGS += -DSATCHECK_MINISAT2
-endif
-
-ifneq ($(GLUCOSE),)
-  CP_CXXFLAGS += -DSATCHECK_GLUCOSE
-endif
-
-ifneq ($(CADICAL),)
-  CP_CXXFLAGS += -DSATCHECK_CADICAL
-endif
-
 # Signing identity for MacOS Gatekeeper
 
 OSX_IDENTITY="Developer ID Application: Daniel Kroening"


### PR DESCRIPTION
The `SATCHECK_*` defines (e.g., `SATCHECK_MINISAT2`) are defined both in `src/solvers/satcheck.h`, and in `config.inc`.

This removes the instance in `config.inc`, in an effort to de-clutter the compiler command line.  Users of the macros can include the header file.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- n/a Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
