### PR TITLE
Cadical with preprocessor and local search

### DIFF
--- a/src/goto-checker/solver_factory.cpp
+++ b/src/goto-checker/solver_factory.cpp
@@ -297,7 +297,8 @@ get_sat_solver(message_handlert &message_handler, const optionst &options)
     else if(solver_option == "cadical")
     {
 #if defined SATCHECK_CADICAL
-      return make_satcheck_prop<satcheck_cadicalt>(message_handler, options);
+      return make_satcheck_prop<satcheck_cadical_no_preprocessingt>(
+        message_handler, options);
 #else
       emit_solver_warning(message_handler, "cadical");
 #endif

--- a/src/solvers/sat/satcheck.h
+++ b/src/solvers/sat/satcheck.h
@@ -137,8 +137,8 @@ typedef satcheck_glucose_no_simplifiert satcheck_no_simplifiert;
 
 #elif defined SATCHECK_CADICAL
 
-typedef satcheck_cadicalt satcheckt;
-typedef satcheck_cadicalt satcheck_no_simplifiert;
+typedef satcheck_cadical_no_preprocessingt satcheckt;
+typedef satcheck_cadical_no_preprocessingt satcheck_no_simplifiert;
 
 #endif
 

--- a/src/solvers/sat/satcheck_cadical.h
+++ b/src/solvers/sat/satcheck_cadical.h
@@ -19,11 +19,14 @@ namespace CaDiCaL // NOLINT(readability/namespace)
   class Solver; // NOLINT(readability/identifiers)
 }
 
-class satcheck_cadicalt : public cnf_solvert, public hardness_collectort
+class satcheck_cadical_baset : public cnf_solvert, public hardness_collectort
 {
 public:
-  explicit satcheck_cadicalt(message_handlert &message_handler);
-  virtual ~satcheck_cadicalt();
+  satcheck_cadical_baset(
+    int preprocessing_limit,
+    int localsearch_limit,
+    message_handlert &);
+  virtual ~satcheck_cadical_baset();
 
   std::string solver_text() const override;
   tvt l_get(literalt a) const override;
@@ -46,6 +49,25 @@ protected:
 
   // NOLINTNEXTLINE(readability/identifiers)
   CaDiCaL::Solver *solver;
+  int preprocessing_limit = 0, localsearch_limit = 0;
+};
+
+class satcheck_cadical_no_preprocessingt : public satcheck_cadical_baset
+{
+public:
+  explicit satcheck_cadical_no_preprocessingt(message_handlert &message_handler)
+    : satcheck_cadical_baset(0, 0, message_handler)
+  {
+  }
+};
+
+class satcheck_cadical_preprocessingt : public satcheck_cadical_baset
+{
+public:
+  explicit satcheck_cadical_preprocessingt(message_handlert &message_handler)
+    : satcheck_cadical_baset(1, 0, message_handler)
+  {
+  }
 };
 
 #endif // CPROVER_SOLVERS_SAT_SATCHECK_CADICAL_H

--- a/unit/solvers/sat/satcheck_cadical.cpp
+++ b/unit/solvers/sat/satcheck_cadical.cpp
@@ -23,7 +23,7 @@ SCENARIO("satcheck_cadical", "[core][solvers][sat][satcheck_cadical]")
 
   GIVEN("A satisfiable formula f")
   {
-    satcheck_cadicalt satcheck(message_handler);
+    satcheck_cadical_no_preprocessingt satcheck(message_handler);
     literalt f = satcheck.new_variable();
     satcheck.l_set_to_true(f);
 
@@ -42,7 +42,7 @@ SCENARIO("satcheck_cadical", "[core][solvers][sat][satcheck_cadical]")
 
   GIVEN("An unsatisfiable formula f && !f")
   {
-    satcheck_cadicalt satcheck(message_handler);
+    satcheck_cadical_no_preprocessingt satcheck(message_handler);
     literalt f = satcheck.new_variable();
     satcheck.l_set_to_true(satcheck.land(f, !f));
 
@@ -54,7 +54,7 @@ SCENARIO("satcheck_cadical", "[core][solvers][sat][satcheck_cadical]")
 
   GIVEN("An unsatisfiable formula false implied by a")
   {
-    satcheck_cadicalt satcheck(message_handler);
+    satcheck_cadical_no_preprocessingt satcheck(message_handler);
     literalt a = satcheck.new_variable();
     literalt a_implies_false = satcheck.lor(!a, const_literal(false));
     satcheck.l_set_to_true(a_implies_false);


### PR DESCRIPTION
This adds the option to enable Cadical's preprocessor and local search.  The default remains unchanged.

The choice of `preprocessor=1` and `localsearch=0` for `satcheck_cadical_preprocessingt` is motivated by the following data on the HWMCC 2008 benchmarks:

0, 0: ./hwmcc08.sh  114.78s
1, 0: ./hwmcc08.sh  107.44s
2, 0: ./hwmcc08.sh  117.63s
5, 0: ./hwmcc08.sh  129.10s
1, 1: ./hwmcc08.sh  113.50s
5, 5: ./hwmcc08.sh  154.71s

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [X] My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
