### PR TITLE
SMT2: bvnor, bvnand are binary only; add bvxnor

### DIFF
--- a/src/util/bitvector_expr.h
+++ b/src/util/bitvector_expr.h
@@ -253,7 +253,7 @@ class bitxnor_exprt : public multi_ary_exprt
 {
 public:
   bitxnor_exprt(exprt _op0, exprt _op1)
-    : multi_ary_exprt(std::move(_op0), ID_bitxnor, std::move(_op1))
+    : multi_ary_exprt(_op0, ID_bitxnor, _op1, _op0.type())
   {
   }
 
@@ -278,6 +278,7 @@ inline bool can_cast_expr<bitxnor_exprt>(const exprt &base)
 inline const bitxnor_exprt &to_bitxnor_expr(const exprt &expr)
 {
   PRECONDITION(expr.id() == ID_bitxnor);
+  bitxnor_exprt::check(expr, validation_modet::INVARIANT);
   return static_cast<const bitxnor_exprt &>(expr);
 }
 
@@ -285,6 +286,7 @@ inline const bitxnor_exprt &to_bitxnor_expr(const exprt &expr)
 inline bitxnor_exprt &to_bitxnor_expr(exprt &expr)
 {
   PRECONDITION(expr.id() == ID_bitxnor);
+  bitxnor_exprt::check(expr, validation_modet::INVARIANT);
   return static_cast<bitxnor_exprt &>(expr);
 }
 


### PR DESCRIPTION
The SMT-LIB2 expressions `bvnor` and `bvnand` are not multi-ary.

Furthermore, this adds the (binary) `bvxnor` expression.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
