### PR TITLE
Format bit-vectors with `[` ... `]` vector notation

### DIFF
--- a/src/util/format_expr.cpp
+++ b/src/util/format_expr.cpp
@@ -190,13 +190,16 @@ static std::ostream &format_rec(std::ostream &os, const constant_exprt &src)
   {
     // These do not have a numerical interpretation.
     // We'll print the 0/1 bit pattern, starting with the bit
-    // that has the highest index.
+    // that has the highest index. We use vector notation
+    // [...] to avoid confusion with decimal numbers.
     auto width = to_bv_type(src.type()).get_width();
     std::string result;
-    result.reserve(width);
+    result.reserve(width + 2);
     auto &value = src.get_value();
+    result += '[';
     for(std::size_t i = 0; i < width; i++)
       result += get_bvrep_bit(value, width, width - i - 1) ? '1' : '0';
+    result += ']';
     return os << result;
   }
   else if(type == ID_integer || type == ID_natural || type == ID_range)

--- a/unit/util/format_expr.cpp
+++ b/unit/util/format_expr.cpp
@@ -30,5 +30,5 @@ TEST_CASE("Format a bv-typed constant", "[core][util][format_expr]")
 {
   auto value = make_bvrep(4, [](std::size_t index) { return index != 2; });
   auto expr = constant_exprt{value, bv_typet{4}};
-  REQUIRE(format_to_string(expr) == "1011");
+  REQUIRE(format_to_string(expr) == "[1011]");
 }


### PR DESCRIPTION
To avoid confusion between bit-vectors and decimal numbers, format bv-typed bit-vectors using `[` ...  `]` vector notation.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [X] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
