### PR TITLE
Add IEEE 754 TiesToAway rounding mode

### DIFF
--- a/src/solvers/floatbv/float_bv.cpp
+++ b/src/solvers/floatbv/float_bv.cpp
@@ -282,11 +282,14 @@ void float_bvt::rounding_mode_bitst::get(const exprt &rm)
   exprt round_to_minus_inf_const=
     from_integer(ieee_floatt::ROUND_TO_MINUS_INF, rm.type());
   exprt round_to_zero_const=from_integer(ieee_floatt::ROUND_TO_ZERO, rm.type());
+  exprt round_to_away_const =
+    from_integer(ieee_floatt::ROUND_TO_AWAY, rm.type());
 
   round_to_even=equal_exprt(rm, round_to_even_const);
   round_to_plus_inf=equal_exprt(rm, round_to_plus_inf_const);
   round_to_minus_inf=equal_exprt(rm, round_to_minus_inf_const);
   round_to_zero=equal_exprt(rm, round_to_zero_const);
+  round_to_away = equal_exprt(rm, round_to_away_const);
 }
 
 exprt float_bvt::sign_bit(const exprt &op)
@@ -1166,12 +1169,18 @@ exprt float_bvt::fraction_rounding_decision(
   // round to zero
   false_exprt round_to_zero;
 
+  // round to away
+  const auto round_to_away = or_exprt(rounding_bit, sticky_bit);
+
   // now select appropriate one
+  // clang-format off
   return if_exprt(rounding_mode_bits.round_to_even, round_to_even,
          if_exprt(rounding_mode_bits.round_to_plus_inf, round_to_plus_inf,
          if_exprt(rounding_mode_bits.round_to_minus_inf, round_to_minus_inf,
          if_exprt(rounding_mode_bits.round_to_zero, round_to_zero,
-           false_exprt())))); // otherwise zero
+         if_exprt(rounding_mode_bits.round_to_away, round_to_away,
+           false_exprt()))))); // otherwise zero
+  // clang-format off
 }
 
 void float_bvt::round_fraction(

--- a/src/solvers/floatbv/float_bv.h
+++ b/src/solvers/floatbv/float_bv.h
@@ -104,6 +104,7 @@ private:
     exprt round_to_zero;
     exprt round_to_plus_inf;
     exprt round_to_minus_inf;
+    exprt round_to_away;
 
     void get(const exprt &rm);
     explicit rounding_mode_bitst(const exprt &rm) { get(rm); }

--- a/src/solvers/floatbv/float_utils.h
+++ b/src/solvers/floatbv/float_utils.h
@@ -25,19 +25,21 @@ public:
     literalt round_to_zero;
     literalt round_to_plus_inf;
     literalt round_to_minus_inf;
+    literalt round_to_away;
 
-    rounding_mode_bitst():
-      round_to_even(const_literal(true)),
-      round_to_zero(const_literal(false)),
-      round_to_plus_inf(const_literal(false)),
-      round_to_minus_inf(const_literal(false))
+    rounding_mode_bitst()
+      : round_to_even(const_literal(true)),
+        round_to_zero(const_literal(false)),
+        round_to_plus_inf(const_literal(false)),
+        round_to_minus_inf(const_literal(false)),
+        round_to_away(const_literal(false))
     {
     }
 
     void set(const ieee_floatt::rounding_modet mode)
     {
-      round_to_even=round_to_zero=round_to_plus_inf=round_to_minus_inf=
-        const_literal(false);
+      round_to_even = round_to_zero = round_to_plus_inf = round_to_minus_inf =
+        round_to_away = const_literal(false);
 
       switch(mode)
       {
@@ -55,6 +57,10 @@ public:
 
       case ieee_floatt::ROUND_TO_ZERO:
         round_to_zero=const_literal(true);
+        break;
+
+      case ieee_floatt::ROUND_TO_AWAY:
+        round_to_away = const_literal(true);
         break;
 
       case ieee_floatt::NONDETERMINISTIC:

--- a/src/solvers/smt2/smt2_conv.cpp
+++ b/src/solvers/smt2/smt2_conv.cpp
@@ -3917,10 +3917,12 @@ void smt2_convt::convert_rounding_mode_FPA(const exprt &expr)
       out << "roundTowardPositive";
     else if(value==3)
       out << "roundTowardZero";
+    else if(value == 4)
+      out << "roundNearestTiesToAway";
     else
       INVARIANT_WITH_DIAGNOSTICS(
         false,
-        "Rounding mode should have value 0, 1, 2, or 3",
+        "Rounding mode should have value 0, 1, 2, 3, or 4",
         id2string(cexpr.get_value()));
   }
   else
@@ -3940,10 +3942,14 @@ void smt2_convt::convert_rounding_mode_FPA(const exprt &expr)
     convert_expr(expr);
     out << ") roundTowardPositive ";
 
-    // TODO: add some kind of error checking here
-    out << "roundTowardZero";
+    out << "(ite (= (_ bv3 " << width << ") ";
+    convert_expr(expr);
+    out << ") roundTowardZero ";
 
-    out << ")))";
+    // TODO: add some kind of error checking here
+    out << "roundNearestTiesToAway";
+
+    out << "))))";
   }
 }
 

--- a/src/solvers/smt2/smt2_parser.cpp
+++ b/src/solvers/smt2/smt2_parser.cpp
@@ -1093,12 +1093,14 @@ void smt2_parsert::setup_expressions()
     return from_integer(ieee_floatt::ROUND_TO_EVEN, unsignedbv_typet(32));
   };
 
-  expressions["roundNearestTiesToAway"] = [this]() -> exprt {
-    throw error("unsupported rounding mode");
+  expressions["roundNearestTiesToAway"] = [] {
+    // we encode as 32-bit unsignedbv
+    return from_integer(ieee_floatt::ROUND_TO_AWAY, unsignedbv_typet(32));
   };
 
-  expressions["RNA"] = [this]() -> exprt {
-    throw error("unsupported rounding mode");
+  expressions["RNA"] = [] {
+    // we encode as 32-bit unsignedbv
+    return from_integer(ieee_floatt::ROUND_TO_AWAY, unsignedbv_typet(32));
   };
 
   expressions["roundTowardPositive"] = [] {

--- a/src/util/ieee_float.cpp
+++ b/src/util/ieee_float.cpp
@@ -894,6 +894,11 @@ void ieee_floatt::align()
       else
         make_fltmax(); // positive
       break;
+
+    case ROUND_TO_AWAY:
+      // round towards + or - infinity
+      infinity_flag = true;
+      break;
     }
 
     return; // done
@@ -967,6 +972,10 @@ void ieee_floatt::divide_and_round(
     case ROUND_TO_PLUS_INF:
       if(!sign_flag)
         ++dividend;
+      break;
+
+    case ROUND_TO_AWAY:
+      ++dividend;
       break;
 
     case NONDETERMINISTIC:

--- a/src/util/ieee_float.h
+++ b/src/util/ieee_float.h
@@ -331,14 +331,17 @@ class ieee_floatt : public ieee_float_valuet
 public:
   // ROUND_TO_EVEN is also known as "round to nearest, ties to even", and
   // is the IEEE default.
+  // ROUND_TO_AWAY is also known as "round to infinity".
   // The numbering below is what x86 uses in the control word and
-  // what is recommended in C11 5.2.4.2.2
+  // what is recommended in C11 5.2.4.2.2.
+  // The numbering of ROUND_TO_AWAY is not specified in C11 5.2.4.2.2.
   enum rounding_modet
   {
     ROUND_TO_EVEN = 0,
     ROUND_TO_MINUS_INF = 1,
     ROUND_TO_PLUS_INF = 2,
     ROUND_TO_ZERO = 3,
+    ROUND_TO_AWAY = 4,
     UNKNOWN,
     NONDETERMINISTIC
   };


### PR DESCRIPTION
This adds IEEE 754 TiesToAway rounding mode, which rounds away from zero in case of a tie.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [X] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
