### PR TITLE
SMT2: allow natural-typed shift distance

### DIFF
--- a/src/solvers/smt2/smt2_conv.cpp
+++ b/src/solvers/smt2/smt2_conv.cpp
@@ -1586,7 +1586,8 @@ void smt2_convt::convert_expr(const exprt &expr)
       // SMT2 requires the shift distance to have the same width as
       // the value that is shifted -- odd!
 
-      if(shift_expr.distance().type().id() == ID_integer)
+      const auto &distance_type = shift_expr.distance().type();
+      if(distance_type.id() == ID_integer || distance_type.id() == ID_natural)
       {
         const mp_integer i =
           numeric_cast_v<mp_integer>(to_constant_expr(shift_expr.distance()));
@@ -1597,13 +1598,12 @@ void smt2_convt::convert_expr(const exprt &expr)
         convert_expr(tmp);
       }
       else if(
-        shift_expr.distance().type().id() == ID_signedbv ||
-        shift_expr.distance().type().id() == ID_unsignedbv ||
-        shift_expr.distance().type().id() == ID_c_enum ||
-        shift_expr.distance().type().id() == ID_c_bool)
+        distance_type.id() == ID_signedbv ||
+        distance_type.id() == ID_unsignedbv ||
+        distance_type.id() == ID_c_enum || distance_type.id() == ID_c_bool)
       {
         std::size_t width_op0 = boolbv_width(shift_expr.op().type());
-        std::size_t width_op1 = boolbv_width(shift_expr.distance().type());
+        std::size_t width_op1 = boolbv_width(distance_type);
 
         if(width_op0==width_op1)
           convert_expr(shift_expr.distance());
@@ -1621,9 +1621,11 @@ void smt2_convt::convert_expr(const exprt &expr)
         }
       }
       else
+      {
         UNEXPECTEDCASE(
           "unsupported distance type for " + shift_expr.id_string() + ": " +
-          type.id_string());
+          distance_type.id_string());
+      }
 
       out << ")"; // bv*sh
     }


### PR DESCRIPTION
This adds conversion for shifts with natural-typed shift distance (in addition to integer-typed) to the SMT2 backend.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
