### PR TITLE
add range_type to `from_integer`/`to_integer`

### DIFF
--- a/src/util/arith_tools.cpp
+++ b/src/util/arith_tools.cpp
@@ -31,8 +31,7 @@ bool to_integer(const constant_exprt &expr, mp_integer &int_value)
       return false;
     }
   }
-  else if(type_id==ID_integer ||
-          type_id==ID_natural)
+  else if(type_id == ID_integer || type_id == ID_natural || type_id == ID_range)
   {
     int_value=string2integer(id2string(value));
     return false;
@@ -111,6 +110,13 @@ constant_exprt from_integer(
   {
     PRECONDITION(int_value >= 0);
     return constant_exprt(integer2string(int_value), type);
+  }
+  else if(type_id == ID_range)
+  {
+    auto &range_type = to_range_type(type);
+    PRECONDITION(int_value >= range_type.get_from());
+    PRECONDITION(int_value <= range_type.get_to());
+    return constant_exprt{integer2string(int_value), type};
   }
   else if(type_id==ID_unsignedbv)
   {


### PR DESCRIPTION
This adds support for `range_typet` to both `from_integer` and `to_integer`.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
