### PR TITLE
Release CBMC 6.4.1

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,23 @@
+# CBMC 6.4.1
+
+This patch release addresses a hard-coding of C semantics in the back-end for pointer subtraction (via #8497).
+
+## Bug Fixes
+* fix `update_bit` lowering by @kroening in https://github.com/diffblue/cbmc/pull/8496
+* Pointer subtraction in back-end: no need for bounds checking by @tautschnig in https://github.com/diffblue/cbmc/pull/8497
+* remove duplicate SATCHECK_* defines by @kroening in https://github.com/diffblue/cbmc/pull/8501
+* simplify bitxnor by @kroening in https://github.com/diffblue/cbmc/pull/8506
+* Reword documentation of __CPROVER_{r,w,rw}_ok by @tautschnig in https://github.com/diffblue/cbmc/pull/8472
+* simplify x^0 and x^1 by @kroening in https://github.com/diffblue/cbmc/pull/8509
+* add multi-ary constructor for `mult_exprt` by @kroening in https://github.com/diffblue/cbmc/pull/8510
+* Format bit-vectors with `[` ... `]` vector notation by @kroening in https://github.com/diffblue/cbmc/pull/8514
+* add range_type to `from_integer`/`to_integer` by @kroening in https://github.com/diffblue/cbmc/pull/8520
+* Bump codecov/codecov-action from 4 to 5 by @dependabot in https://github.com/diffblue/cbmc/pull/8507
+* CONTRACTS: add doc for loop assigns inference by @qinheping in https://github.com/diffblue/cbmc/pull/8516
+* Cadical with preprocessor and local search by @kroening in https://github.com/diffblue/cbmc/pull/8502
+
+**Full Changelog**: https://github.com/diffblue/cbmc/compare/cbmc-6.4.0...cbmc-6.4.1
+
 # CBMC 6.4.0
 
 This release improves upon automated assigns-clause inference for loop invariants, which should make manually adding assigns clauses to loops less frequent.

--- a/src/config.inc
+++ b/src/config.inc
@@ -47,7 +47,7 @@ endif
 OSX_IDENTITY="Developer ID Application: Daniel Kroening"
 
 # Detailed version information
-CBMC_VERSION = 6.4.0
+CBMC_VERSION = 6.4.1
 
 # Use the CUDD library for BDDs, can be installed using `make -C src cudd-download`
 # CUDD = ../../cudd-3.0.0

--- a/src/libcprover-rust/Cargo.toml
+++ b/src/libcprover-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libcprover_rust"
-version = "6.4.0"
+version = "6.4.1"
 edition = "2021"
 description = "Rust API for CBMC and assorted CProver tools"
 repository = "https://github.com/diffblue/cbmc"


### PR DESCRIPTION
This patch release addresses a hard-coding of C semantics in the back-end for pointer subtraction (via #8497).

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
