### PR TITLE
SMT2: support `onehot` and `onehot0`

### DIFF
--- a/src/solvers/flattening/boolbv.cpp
+++ b/src/solvers/flattening/boolbv.cpp
@@ -412,8 +412,10 @@ literalt boolbvt::convert_rest(const exprt &expr)
           expr.id()==ID_reduction_nor || expr.id()==ID_reduction_nand ||
           expr.id()==ID_reduction_xor || expr.id()==ID_reduction_xnor)
     return convert_reduction(to_unary_expr(expr));
-  else if(expr.id()==ID_onehot || expr.id()==ID_onehot0)
-    return convert_onehot(to_unary_expr(expr));
+  else if(expr.id() == ID_onehot)
+    return convert_onehot(to_onehot_expr(expr));
+  else if(expr.id() == ID_onehot0)
+    return convert_onehot(to_onehot0_expr(expr));
   else if(
     const auto binary_overflow =
       expr_try_dynamic_cast<binary_overflow_exprt>(expr))

--- a/src/solvers/smt2/smt2_conv.cpp
+++ b/src/solvers/smt2/smt2_conv.cpp
@@ -1831,6 +1831,14 @@ void smt2_convt::convert_expr(const exprt &expr)
       out << ")) #b1)"; // bvlshr, extract, =
     }
   }
+  else if(expr.id() == ID_onehot)
+  {
+    convert_expr(to_onehot_expr(expr).lower());
+  }
+  else if(expr.id() == ID_onehot0)
+  {
+    convert_expr(to_onehot0_expr(expr).lower());
+  }
   else if(expr.id()==ID_extractbits)
   {
     const extractbits_exprt &extractbits_expr = to_extractbits_expr(expr);

--- a/src/util/bitvector_expr.h
+++ b/src/util/bitvector_expr.h
@@ -1742,4 +1742,74 @@ inline zero_extend_exprt &to_zero_extend_expr(exprt &expr)
   return static_cast<zero_extend_exprt &>(expr);
 }
 
+/// \brief A Boolean expression returning true iff the given
+/// operand consists of exactly one '1' and '0' otherwise.
+class onehot_exprt : public unary_predicate_exprt
+{
+public:
+  explicit onehot_exprt(exprt _op)
+    : unary_predicate_exprt(ID_onehot, std::move(_op))
+  {
+  }
+
+  /// lowering to extractbit
+  exprt lower() const;
+};
+
+/// \brief Cast an exprt to a \ref onehot_exprt
+///
+/// \a expr must be known to be \ref onehot_exprt.
+///
+/// \param expr: Source expression
+/// \return Object of type \ref onehot_exprt
+inline const onehot_exprt &to_onehot_expr(const exprt &expr)
+{
+  PRECONDITION(expr.id() == ID_onehot);
+  onehot_exprt::check(expr);
+  return static_cast<const onehot_exprt &>(expr);
+}
+
+/// \copydoc to_onehot_expr(const exprt &)
+inline onehot_exprt &to_onehot_expr(exprt &expr)
+{
+  PRECONDITION(expr.id() == ID_onehot);
+  onehot_exprt::check(expr);
+  return static_cast<onehot_exprt &>(expr);
+}
+
+/// \brief A Boolean expression returning true iff the given
+/// operand consists of exactly one '0' and '1' otherwise.
+class onehot0_exprt : public unary_predicate_exprt
+{
+public:
+  explicit onehot0_exprt(exprt _op)
+    : unary_predicate_exprt(ID_onehot0, std::move(_op))
+  {
+  }
+
+  /// lowering to extractbit
+  exprt lower() const;
+};
+
+/// \brief Cast an exprt to a \ref onehot0_exprt
+///
+/// \a expr must be known to be \ref onehot0_exprt.
+///
+/// \param expr: Source expression
+/// \return Object of type \ref onehot0_exprt
+inline const onehot0_exprt &to_onehot0_expr(const exprt &expr)
+{
+  PRECONDITION(expr.id() == ID_onehot0);
+  onehot0_exprt::check(expr);
+  return static_cast<const onehot0_exprt &>(expr);
+}
+
+/// \copydoc to_onehot0_expr(const exprt &)
+inline onehot0_exprt &to_onehot0_expr(exprt &expr)
+{
+  PRECONDITION(expr.id() == ID_onehot0);
+  onehot0_exprt::check(expr);
+  return static_cast<onehot0_exprt &>(expr);
+}
+
 #endif // CPROVER_UTIL_BITVECTOR_EXPR_H

--- a/unit/util/bitvector_expr.cpp
+++ b/unit/util/bitvector_expr.cpp
@@ -1,8 +1,15 @@
 // Author: Diffblue Ltd.
 
+#include <util/arith_tools.h>
 #include <util/bitvector_expr.h>
 #include <util/bitvector_types.h>
+#include <util/cout_message.h>
+#include <util/namespace.h>
+#include <util/std_expr.h>
+#include <util/symbol_table.h>
 
+#include <solvers/flattening/boolbv.h>
+#include <solvers/sat/satcheck.h>
 #include <testing-utils/use_catch.h>
 
 TEST_CASE(
@@ -61,6 +68,77 @@ TEMPLATE_TEST_CASE(
     {
       REQUIRE(sub_class.lhs() == left);
       REQUIRE(sub_class.rhs() == right);
+    }
+  }
+}
+
+TEST_CASE("onehot expression lowering", "[core][util][expr]")
+{
+  console_message_handlert message_handler;
+  message_handler.set_verbosity(0);
+  satcheckt satcheck{message_handler};
+  symbol_tablet symbol_table;
+  namespacet ns{symbol_table};
+  boolbvt boolbv{ns, satcheck, message_handler};
+  unsignedbv_typet u8{8};
+
+  GIVEN("A bit-vector that is one-hot")
+  {
+    boolbv << onehot_exprt{from_integer(64, u8)}.lower();
+
+    THEN("the lowering of onehot is true")
+    {
+      REQUIRE(boolbv() == decision_proceduret::resultt::D_SATISFIABLE);
+    }
+  }
+
+  GIVEN("A bit-vector that is not one-hot")
+  {
+    boolbv << onehot_exprt{from_integer(5, u8)}.lower();
+
+    THEN("the lowering of onehot is false")
+    {
+      REQUIRE(boolbv() == decision_proceduret::resultt::D_UNSATISFIABLE);
+    }
+  }
+
+  GIVEN("A bit-vector that is not one-hot")
+  {
+    boolbv << onehot_exprt{from_integer(0, u8)}.lower();
+
+    THEN("the lowering of onehot is false")
+    {
+      REQUIRE(boolbv() == decision_proceduret::resultt::D_UNSATISFIABLE);
+    }
+  }
+
+  GIVEN("A bit-vector that is one-hot 0")
+  {
+    boolbv << onehot0_exprt{from_integer(0xfe, u8)}.lower();
+
+    THEN("the lowering of onehot0 is true")
+    {
+      REQUIRE(boolbv() == decision_proceduret::resultt::D_SATISFIABLE);
+    }
+  }
+
+  GIVEN("A bit-vector that is not one-hot 0")
+  {
+    boolbv << onehot0_exprt{from_integer(0x7e, u8)}.lower();
+
+    THEN("the lowering of onehot0 is false")
+    {
+      REQUIRE(boolbv() == decision_proceduret::resultt::D_UNSATISFIABLE);
+    }
+  }
+
+  GIVEN("A bit-vector that is not one-hot 0")
+  {
+    boolbv << onehot0_exprt{from_integer(0xff, u8)}.lower();
+
+    THEN("the lowering of onehot0 is false")
+    {
+      REQUIRE(boolbv() == decision_proceduret::resultt::D_UNSATISFIABLE);
     }
   }
 }

--- a/unit/util/module_dependencies.txt
+++ b/unit/util/module_dependencies.txt
@@ -1,2 +1,4 @@
 testing-utils
 util
+solvers/flattening
+solvers/sat


### PR DESCRIPTION
This adds support for the `onehot` and `onehot0` predicates to the SMT2 backend.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- [X] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
