### PR TITLE
`cmdlinet`: add `value_opt` methods

### DIFF
--- a/src/goto-cc/armcc_mode.cpp
+++ b/src/goto-cc/armcc_mode.cpp
@@ -105,11 +105,8 @@ int armcc_modet::doit()
   }
 
   // armcc's default is .o
-  if(cmdline.isset("default_extension="))
-    compiler.object_file_extension=
-      cmdline.get_value("default_extension=");
-  else
-    compiler.object_file_extension="o";
+  compiler.object_file_extension =
+    cmdline.value_opt("default_extension=").value_or("o");
 
   // note that ARM's default is "unsigned_chars",
   // in contrast to gcc's default!

--- a/src/goto-cc/gcc_mode.cpp
+++ b/src/goto-cc/gcc_mode.cpp
@@ -982,10 +982,7 @@ int gcc_modet::gcc_hybrid_binary(compilet &compiler)
   else
   {
     // -c is not given
-    if(cmdline.isset('o'))
-      output_files.push_back(cmdline.get_value('o'));
-    else
-      output_files.push_back("a.out");
+    output_files.push_back(cmdline.value_opt('o').value_or("a.out"));
   }
 
   if(output_files.empty() ||

--- a/src/goto-instrument/goto_instrument_parse_options.cpp
+++ b/src/goto-instrument/goto_instrument_parse_options.cpp
@@ -241,8 +241,8 @@ int goto_instrument_parse_optionst::doit()
 
         if(cmdline.isset("log"))
         {
-          std::string filename=cmdline.get_value("log");
-          bool have_file=!filename.empty() && filename!="-";
+          std::string filename = cmdline.value_opt("log").value_or("-");
+          bool have_file = filename != "-";
 
           jsont result=goto_unwind.output_log_json();
 
@@ -1319,8 +1319,8 @@ void goto_instrument_parse_optionst::instrument_goto_program()
     }
     else
     {
-      std::string filename=cmdline.get_value("log");
-      bool have_file=!filename.empty() && filename!="-";
+      std::string filename = cmdline.value_opt("log").value_or("-");
+      bool have_file = filename != "-";
 
       jsont result = goto_function_inline_and_log(
         goto_model, function, ui_message_handler, true, caching);

--- a/src/util/cmdline.cpp
+++ b/src/util/cmdline.cpp
@@ -47,12 +47,17 @@ bool cmdlinet::isset(const char *option) const
 
 std::string cmdlinet::get_value(char option) const
 {
+  return value_opt(option).value_or("");
+}
+
+std::optional<std::string> cmdlinet::value_opt(char option) const
+{
   auto i=getoptnr(option);
 
   if(i.has_value() && !options[*i].values.empty())
     return options[*i].values.front();
   else
-    return "";
+    return {};
 }
 
 void cmdlinet::set(const std::string &option, bool value)
@@ -98,12 +103,17 @@ const std::list<std::string> &cmdlinet::get_values(char option) const
 
 std::string cmdlinet::get_value(const char *option) const
 {
+  return value_opt(option).value_or("");
+}
+
+std::optional<std::string> cmdlinet::value_opt(const char *option) const
+{
   auto i=getoptnr(option);
 
   if(i.has_value() && !options[*i].values.empty())
     return options[*i].values.front();
   else
-    return "";
+    return {};
 }
 
 const std::list<std::string> &cmdlinet::get_values(

--- a/src/util/cmdline.h
+++ b/src/util/cmdline.h
@@ -76,6 +76,9 @@ public:
   std::string get_value(char option) const;
   std::string get_value(const char *option) const;
 
+  std::optional<std::string> value_opt(char option) const;
+  std::optional<std::string> value_opt(const char *option) const;
+
   const std::list<std::string> &get_values(const std::string &option) const;
   const std::list<std::string> &get_values(char option) const;
 


### PR DESCRIPTION
This adds an alternative to `cmdlinet::get_value`, which returns std::optional, as opposed to defaulting to an empty string when the option isn't set.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
