### PR TITLE
add mulit-ary constructor for xor_exprt, bitxor_exprt, bitand_exprt, …

### DIFF
--- a/src/util/bitvector_expr.h
+++ b/src/util/bitvector_expr.h
@@ -128,6 +128,11 @@ public:
     : multi_ary_exprt(_op0, ID_bitor, std::move(_op1), _op0.type())
   {
   }
+
+  bitor_exprt(exprt::operandst _operands, typet _type)
+    : multi_ary_exprt(ID_bitor, std::move(_operands), std::move(_type))
+  {
+  }
 };
 
 template <>
@@ -161,6 +166,11 @@ class bitxor_exprt : public multi_ary_exprt
 public:
   bitxor_exprt(exprt _op0, exprt _op1)
     : multi_ary_exprt(std::move(_op0), ID_bitxor, std::move(_op1))
+  {
+  }
+
+  bitxor_exprt(exprt::operandst _operands, typet _type)
+    : multi_ary_exprt(ID_bitxor, std::move(_operands), std::move(_type))
   {
   }
 };
@@ -231,6 +241,11 @@ class bitand_exprt : public multi_ary_exprt
 public:
   bitand_exprt(const exprt &_op0, exprt _op1)
     : multi_ary_exprt(_op0, ID_bitand, std::move(_op1), _op0.type())
+  {
+  }
+
+  bitand_exprt(exprt::operandst _operands, typet _type)
+    : multi_ary_exprt(ID_bitand, std::move(_operands), std::move(_type))
   {
   }
 };

--- a/src/util/std_expr.h
+++ b/src/util/std_expr.h
@@ -2299,6 +2299,11 @@ public:
     : multi_ary_exprt(std::move(_op0), ID_xor, std::move(_op1), bool_typet())
   {
   }
+
+  explicit xor_exprt(exprt::operandst _operands)
+    : multi_ary_exprt(ID_xor, std::move(_operands), bool_typet())
+  {
+  }
 };
 
 template <>


### PR DESCRIPTION
This adds a constructor that takes an `exprt::operandst` argument, for constructing `xor_exprt`, `bitxor_exprt`, `bitand_exprt`, `bitor_exprt` with more than two operands.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
