### PR TITLE
SMT2: implement nand, nor, xnor

### DIFF
--- a/src/solvers/smt2/smt2_conv.cpp
+++ b/src/solvers/smt2/smt2_conv.cpp
@@ -1362,6 +1362,38 @@ void smt2_convt::convert_expr(const exprt &expr)
     }
     out << ")";
   }
+  else if(expr.id() == ID_nand || expr.id() == ID_nor || expr.id() == ID_xnor)
+  {
+    DATA_INVARIANT(
+      expr.is_boolean(),
+      "logical nand, nor, xnor expressions should have Boolean type");
+    DATA_INVARIANT(
+      expr.operands().size() >= 1,
+      "logical nand, nor, xnor expressions should have at least one operand");
+
+    // SMT-LIB doesn't have nand, nor, xnor
+    out << "(not ";
+    if(expr.operands().size() == 1)
+      convert_expr(to_multi_ary_expr(expr).op0());
+    else
+    {
+      if(expr.id() == ID_nand)
+        out << "(and";
+      else if(expr.id() == ID_nor)
+        out << "(and";
+      else if(expr.id() == ID_xnor)
+        out << "(xor";
+      else
+        DATA_INVARIANT(false, "unexpected expression");
+      for(const auto &op : expr.operands())
+      {
+        out << ' ';
+        convert_expr(op);
+      }
+      out << ')'; // or, and, xor
+    }
+    out << ')'; // not
+  }
   else if(expr.id()==ID_implies)
   {
     const implies_exprt &implies_expr = to_implies_expr(expr);


### PR DESCRIPTION
This adds the multi-ary Boolean operators `nand` and `nor` to the SMT2 backend.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
