### PR TITLE
Add floatbv_mod_exprt and floatbv_rem_exprt classes

### DIFF
--- a/src/util/floatbv_expr.h
+++ b/src/util/floatbv_expr.h
@@ -438,6 +438,72 @@ inline ieee_float_op_exprt &to_ieee_float_op_expr(exprt &expr)
   return ret;
 }
 
+/// \brief IEEE floating-point mod
+///
+/// Note that this expression does not have a rounding mode.
+class floatbv_mod_exprt : public binary_exprt
+{
+public:
+  floatbv_mod_exprt(exprt _lhs, exprt _rhs)
+    : binary_exprt(_lhs, ID_floatbv_mod, _rhs, _lhs.type())
+  {
+  }
+};
+
+/// \brief Cast an exprt to a \ref floatbv_mod_exprt
+///
+/// \a expr must be known to be \ref floatbv_mod_exprt.
+///
+/// \param expr: Source expression
+/// \return Object of type \ref floatbv_mod_exprt
+inline const floatbv_mod_exprt &to_floatbv_mod_expr(const exprt &expr)
+{
+  PRECONDITION(expr.id() == ID_floatbv_mod);
+  floatbv_mod_exprt::check(expr);
+  return static_cast<const floatbv_mod_exprt &>(expr);
+}
+
+/// \copydoc to_floatbv_mod_expr(const exprt &)
+inline floatbv_mod_exprt &to_floatbv_mod_expr(exprt &expr)
+{
+  PRECONDITION(expr.id() == ID_floatbv_mod);
+  floatbv_mod_exprt::check(expr);
+  return static_cast<floatbv_mod_exprt &>(expr);
+}
+
+/// \brief IEEE floating-point rem
+///
+/// Note that this expression does not have a rounding mode.
+class floatbv_rem_exprt : public binary_exprt
+{
+public:
+  floatbv_rem_exprt(exprt _lhs, exprt _rhs)
+    : binary_exprt(_lhs, ID_floatbv_rem, _rhs, _lhs.type())
+  {
+  }
+};
+
+/// \brief Cast an exprt to a \ref floatbv_rem_exprt
+///
+/// \a expr must be known to be \ref floatbv_rem_exprt.
+///
+/// \param expr: Source expression
+/// \return Object of type \ref floatbv_rem_exprt
+inline const floatbv_rem_exprt &to_floatbv_rem_expr(const exprt &expr)
+{
+  PRECONDITION(expr.id() == ID_floatbv_rem);
+  floatbv_rem_exprt::check(expr);
+  return static_cast<const floatbv_rem_exprt &>(expr);
+}
+
+/// \copydoc to_floatbv_rem_expr(const exprt &)
+inline floatbv_rem_exprt &to_floatbv_rem_expr(exprt &expr)
+{
+  PRECONDITION(expr.id() == ID_floatbv_rem);
+  floatbv_rem_exprt::check(expr);
+  return static_cast<floatbv_rem_exprt &>(expr);
+}
+
 /// \brief returns the a rounding mode expression for a given
 /// IEEE rounding mode, encoded using the recommendation in
 /// C11 5.2.4.2.2

--- a/src/util/format_expr.cpp
+++ b/src/util/format_expr.cpp
@@ -354,7 +354,8 @@ void format_expr_configt::setup()
   expr_map[ID_floatbv_minus] = ternary_expr;
   expr_map[ID_floatbv_mult] = ternary_expr;
   expr_map[ID_floatbv_div] = ternary_expr;
-  expr_map[ID_floatbv_mod] = ternary_expr;
+  expr_map[ID_floatbv_mod] = binary_infix_expr;
+  expr_map[ID_floatbv_rem] = binary_infix_expr;
 
   expr_map[ID_constant] =
     [](std::ostream &os, const exprt &expr) -> std::ostream & {


### PR DESCRIPTION
This documents the existing use of the `floatbv_mod` and `floatbv_rem` expressions.

Fixes #8276.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- [X] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
