### PR TITLE
implement `xnor` in prop_conv_solvert

### DIFF
--- a/src/solvers/prop/prop_conv_solver.cpp
+++ b/src/solvers/prop/prop_conv_solver.cpp
@@ -257,7 +257,7 @@ literalt prop_conv_solvert::convert_bool(const exprt &expr)
   }
   else if(
     expr.id() == ID_or || expr.id() == ID_and || expr.id() == ID_xor ||
-    expr.id() == ID_nor || expr.id() == ID_nand)
+    expr.id() == ID_nor || expr.id() == ID_nand || expr.id() == ID_xnor)
   {
     INVARIANT(
       !op.empty(),
@@ -268,19 +268,20 @@ literalt prop_conv_solvert::convert_bool(const exprt &expr)
     for(const auto &operand : op)
       bv.push_back(convert(operand));
 
-    if(!bv.empty())
-    {
-      if(expr.id() == ID_or)
-        return prop.lor(bv);
-      else if(expr.id() == ID_nor)
-        return !prop.lor(bv);
-      else if(expr.id() == ID_and)
-        return prop.land(bv);
-      else if(expr.id() == ID_nand)
-        return !prop.land(bv);
-      else if(expr.id() == ID_xor)
-        return prop.lxor(bv);
-    }
+    CHECK_RETURN(!bv.empty());
+
+    if(expr.id() == ID_or)
+      return prop.lor(bv);
+    else if(expr.id() == ID_nor)
+      return !prop.lor(bv);
+    else if(expr.id() == ID_and)
+      return prop.land(bv);
+    else if(expr.id() == ID_nand)
+      return !prop.land(bv);
+    else if(expr.id() == ID_xor)
+      return prop.lxor(bv);
+    else if(expr.id() == ID_xnor)
+      return !prop.lxor(bv);
   }
   else if(expr.id() == ID_not)
   {


### PR DESCRIPTION
This adds `xnor` to `prop_conv_solvert`, mirroring the implementation for `nor`/`nand`.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
