### PR TITLE
Fix `onehot0` flattening

### DIFF
--- a/src/solvers/flattening/boolbv_onehot.cpp
+++ b/src/solvers/flattening/boolbv_onehot.cpp
@@ -15,6 +15,10 @@ literalt boolbvt::convert_onehot(const unary_exprt &expr)
 
   bvt op=convert_bv(expr.op());
 
+  // onehot0 is the same as onehot with the input bits flipped
+  if(expr.id() == ID_onehot0)
+    op = bv_utils.inverted(op);
+
   literalt one_seen=const_literal(false);
   literalt more_than_one_seen=const_literal(false);
 
@@ -25,14 +29,5 @@ literalt boolbvt::convert_onehot(const unary_exprt &expr)
     one_seen=prop.lor(*it, one_seen);
   }
 
-  if(expr.id()==ID_onehot)
-    return prop.land(one_seen, !more_than_one_seen);
-  else
-  {
-    INVARIANT(
-      expr.id() == ID_onehot0,
-      "should be a onehot0 expression as other onehot expression kind has been "
-      "handled in other branch");
-    return !more_than_one_seen;
-  }
+  return prop.land(one_seen, !more_than_one_seen);
 }

--- a/unit/Makefile
+++ b/unit/Makefile
@@ -96,6 +96,7 @@ SRC += analyses/ai/ai.cpp \
        pointer-analysis/value_set.cpp \
        solvers/bdd/miniBDD/miniBDD.cpp \
        solvers/flattening/boolbv.cpp \
+       solvers/flattening/boolbv_onehot.cpp \
        solvers/flattening/boolbv_update_bit.cpp \
        solvers/floatbv/float_utils.cpp \
        solvers/prop/bdd_expr.cpp \

--- a/unit/solvers/flattening/boolbv_onehot.cpp
+++ b/unit/solvers/flattening/boolbv_onehot.cpp
@@ -1,0 +1,92 @@
+/*******************************************************************\
+
+Module: Unit tests for solvers/flattening/boolbv_onehot
+
+Author: Daniel Kroening, dkr@amazon.com
+
+\*******************************************************************/
+
+/// \file
+
+#include <util/arith_tools.h>
+#include <util/bitvector_expr.h>
+#include <util/bitvector_types.h>
+#include <util/cout_message.h>
+#include <util/namespace.h>
+#include <util/std_expr.h>
+#include <util/symbol_table.h>
+
+#include <solvers/flattening/boolbv.h>
+#include <solvers/sat/satcheck.h>
+#include <testing-utils/use_catch.h>
+
+TEST_CASE("onehot flattening", "[core][solvers][flattening][boolbvt][onehot]")
+{
+  console_message_handlert message_handler;
+  message_handler.set_verbosity(0);
+  satcheckt satcheck{message_handler};
+  symbol_tablet symbol_table;
+  namespacet ns{symbol_table};
+  boolbvt boolbv{ns, satcheck, message_handler};
+  unsignedbv_typet u8{8};
+
+  GIVEN("A bit-vector that is one-hot")
+  {
+    boolbv << onehot_exprt{from_integer(64, u8)};
+
+    THEN("the lowering of onehot is true")
+    {
+      REQUIRE(boolbv() == decision_proceduret::resultt::D_SATISFIABLE);
+    }
+  }
+
+  GIVEN("A bit-vector that is not one-hot")
+  {
+    boolbv << onehot_exprt{from_integer(5, u8)};
+
+    THEN("the lowering of onehot is false")
+    {
+      REQUIRE(boolbv() == decision_proceduret::resultt::D_UNSATISFIABLE);
+    }
+  }
+
+  GIVEN("A bit-vector that is not one-hot")
+  {
+    boolbv << onehot_exprt{from_integer(0, u8)};
+
+    THEN("the lowering of onehot is false")
+    {
+      REQUIRE(boolbv() == decision_proceduret::resultt::D_UNSATISFIABLE);
+    }
+  }
+
+  GIVEN("A bit-vector that is one-hot 0")
+  {
+    boolbv << onehot0_exprt{from_integer(0xfe, u8)};
+
+    THEN("the lowering of onehot0 is true")
+    {
+      REQUIRE(boolbv() == decision_proceduret::resultt::D_SATISFIABLE);
+    }
+  }
+
+  GIVEN("A bit-vector that is not one-hot 0")
+  {
+    boolbv << onehot0_exprt{from_integer(0x7e, u8)};
+
+    THEN("the lowering of onehot0 is false")
+    {
+      REQUIRE(boolbv() == decision_proceduret::resultt::D_UNSATISFIABLE);
+    }
+  }
+
+  GIVEN("A bit-vector that is not one-hot 0")
+  {
+    boolbv << onehot0_exprt{from_integer(0xff, u8)};
+
+    THEN("the lowering of onehot0 is false")
+    {
+      REQUIRE(boolbv() == decision_proceduret::resultt::D_UNSATISFIABLE);
+    }
+  }
+}


### PR DESCRIPTION
This fixes the flattening of `onehot0` expressions.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [X] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
