### PR TITLE
`ieee_floatt`: add preconditions

### DIFF
--- a/src/util/ieee_float.cpp
+++ b/src/util/ieee_float.cpp
@@ -915,6 +915,8 @@ ieee_floatt &ieee_floatt::operator-=(const ieee_floatt &other)
 
 bool ieee_floatt::operator<(const ieee_floatt &other) const
 {
+  PRECONDITION(other.spec == spec);
+
   if(NaN_flag || other.NaN_flag)
     return false;
 
@@ -961,6 +963,8 @@ bool ieee_floatt::operator<(const ieee_floatt &other) const
 
 bool ieee_floatt::operator<=(const ieee_floatt &other) const
 {
+  PRECONDITION(other.spec == spec);
+
   if(NaN_flag || other.NaN_flag)
     return false;
 
@@ -994,6 +998,8 @@ bool ieee_floatt::operator>=(const ieee_floatt &other) const
 
 bool ieee_floatt::operator==(const ieee_floatt &other) const
 {
+  PRECONDITION(other.spec == spec);
+
   // packed equality!
   if(NaN_flag && other.NaN_flag)
     return true;
@@ -1016,6 +1022,8 @@ bool ieee_floatt::operator==(const ieee_floatt &other) const
 
 bool ieee_floatt::ieee_equal(const ieee_floatt &other) const
 {
+  PRECONDITION(other.spec == spec);
+
   if(NaN_flag || other.NaN_flag)
     return false;
   if(is_zero() && other.is_zero())
@@ -1038,6 +1046,8 @@ bool ieee_floatt::operator!=(const ieee_floatt &other) const
 
 bool ieee_floatt::ieee_not_equal(const ieee_floatt &other) const
 {
+  PRECONDITION(other.spec == spec);
+
   if(NaN_flag || other.NaN_flag)
     return true; // !!!
   if(is_zero() && other.is_zero())


### PR DESCRIPTION
This adds preconditons to further binary operators in `ieee_floatt` that the format must match.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
