### PR TITLE
Bugfix: flattening for non-binary `bitnor`, `bitnand`, `bitxnor`

### DIFF
--- a/src/solvers/flattening/boolbv_bitwise.cpp
+++ b/src/solvers/flattening/boolbv_bitwise.cpp
@@ -25,6 +25,17 @@ bvt boolbvt::convert_bitwise(const exprt &expr)
           expr.id()==ID_bitnand || expr.id()==ID_bitnor ||
           expr.id()==ID_bitxnor)
   {
+    std::function<literalt(literalt, literalt)> f;
+
+    if(expr.id() == ID_bitand || expr.id() == ID_bitnand)
+      f = [this](literalt a, literalt b) { return prop.land(a, b); };
+    else if(expr.id() == ID_bitor || expr.id() == ID_bitnor)
+      f = [this](literalt a, literalt b) { return prop.lor(a, b); };
+    else if(expr.id() == ID_bitxor || expr.id() == ID_bitxnor)
+      f = [this](literalt a, literalt b) { return prop.lxor(a, b); };
+    else
+      UNIMPLEMENTED;
+
     bvt bv;
     bv.resize(width);
 
@@ -38,25 +49,19 @@ bvt boolbvt::convert_bitwise(const exprt &expr)
       {
         for(std::size_t i=0; i<width; i++)
         {
-          if(expr.id()==ID_bitand)
-            bv[i]=prop.land(bv[i], op[i]);
-          else if(expr.id()==ID_bitor)
-            bv[i]=prop.lor(bv[i], op[i]);
-          else if(expr.id()==ID_bitxor)
-            bv[i]=prop.lxor(bv[i], op[i]);
-          else if(expr.id()==ID_bitnand)
-            bv[i]=prop.lnand(bv[i], op[i]);
-          else if(expr.id()==ID_bitnor)
-            bv[i]=prop.lnor(bv[i], op[i]);
-          else if(expr.id()==ID_bitxnor)
-            bv[i]=prop.lequal(bv[i], op[i]);
-          else
-            UNIMPLEMENTED;
+          bv[i] = f(bv[i], op[i]);
         }
       }
     }
 
-    return bv;
+    if(
+      expr.id() == ID_bitnand || expr.id() == ID_bitnor ||
+      expr.id() == ID_bitxnor)
+    {
+      return bv_utils.inverted(bv);
+    }
+    else
+      return bv;
   }
 
   UNIMPLEMENTED;


### PR DESCRIPTION
This fixes the flattening for `bitnor`, `bitnand`, `bitxnor` for the case that the expression has one operand or more than two operands.

For one operand, the result is now the bit-wise negation.

For three or more operands, the result is now the bit-wise negation of the `bitor`, `bitand`, `bitxor` with the same operands.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
