### PR TITLE
KNOWNBUG test for enum-range check inside LHS of an assignment

### DIFF
--- a/regression/cbmc/enum_is_in_range/enum_lhs.c
+++ b/regression/cbmc/enum_is_in_range/enum_lhs.c
@@ -1,0 +1,17 @@
+typedef enum my_enum
+{
+  A = 1,
+  B = 2
+};
+int my_array[10];
+
+int main()
+{
+  // should fail
+  (enum my_enumt)3;
+
+  // should fail
+  my_array[(enum my_enumt)4] = 10;
+
+  return 0;
+}

--- a/regression/cbmc/enum_is_in_range/enum_lhs.desc
+++ b/regression/cbmc/enum_is_in_range/enum_lhs.desc
@@ -1,0 +1,11 @@
+KNOWNBUG
+enum_lhs.c
+--enum-range-check
+^\[main\.enum-range-check\.2\] line 14 enum range check in \(my_enumt\)4: FAILURE$
+^EXIT=10$
+^SIGNAL=0$
+--
+--
+The conversion to enum on the LHS should fail the enum-range check, but
+doesn't.
+


### PR DESCRIPTION
This adds a test that should fail an enum-range check inside the LHS of an assignment.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [X] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- n/a My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
