### PR TITLE
CONTRACTS: ignore `__CPROVER_dead_object` assignments

### DIFF
--- a/src/goto-instrument/contracts/dynamic-frames/dfcc_instrument.h
+++ b/src/goto-instrument/contracts/dynamic-frames/dfcc_instrument.h
@@ -283,13 +283,6 @@ protected:
     goto_programt &goto_program,
     dfcc_cfg_infot &cfg_info);
 
-  /// Checks if \p lhs is the `dead_object`, and if \p rhs
-  /// is an `if_exprt(nondet, ptr, dead_object)` expression.
-  /// Returns a pointer to the `ptr` expression if the pattern was matched,
-  /// returns `nullptr` otherwise.
-  std::optional<exprt>
-  is_dead_object_update(const exprt &lhs, const exprt &rhs);
-
   /// Instrument the \p lhs of an `ASSIGN lhs := rhs` instruction by
   /// adding an inclusion check of \p lhs in \p write_set.
   /// If \ref is_dead_object_update returns a successful match, the matched

--- a/src/goto-instrument/contracts/dynamic-frames/dfcc_instrument.h
+++ b/src/goto-instrument/contracts/dynamic-frames/dfcc_instrument.h
@@ -285,8 +285,6 @@ protected:
 
   /// Instrument the \p lhs of an `ASSIGN lhs := rhs` instruction by
   /// adding an inclusion check of \p lhs in \p write_set.
-  /// If \ref is_dead_object_update returns a successful match, the matched
-  /// pointer expression is removed from \p write_set.
   /// If \p rhs is a `side_effect_expr(ID_allocate)`, the allocated pointer gets
   /// added to the \p write_set.
   /// \pre \p target points to an `ASSIGN` instruction.


### PR DESCRIPTION
Fixes https://github.com/model-checking/kani/issues/3796.

This change fixes spurious violations on GOTO models generated from MIR programs by Kani. MIR programs declare all stack-allocated place variables at the top of the function regardless of the original scope of the variable, and uses `storageLive` and `storageDead` events to delimit their dynamic lifetime. Kani uses a DECL to introduce place variables and uses dynamic assignments to `__CPROVER_dead_object` to encode `storageLive` and `storageDead`. DFCC instrumentation would only pick up `storageDead` events, not `storageLive`, resulting in spurious proof failures.

With this change we go back to relying only on DECL/DEAD for object liftetime tracking in DFCC and completely ignoring dynamic assignments to `__CPROVER_dead_object`. This means that contract instrumentation won't be able to detect bad accesses to objects for which the lifetime is managed via `__CPROVER_dead_object` anymore, for instance: dynamic stack-allocated objects created using `alloca`, or MIR place variables (that have their address taken) as encoded by Kani. As a consequence, `--pointer-checks` have to be enabled when analysing contracts-instrumented code.

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.
