### PR TITLE
line number for files with no newline

### DIFF
--- a/regression/ansi-c/errors/file_with_no_newline.desc
+++ b/regression/ansi-c/errors/file_with_no_newline.desc
@@ -1,0 +1,7 @@
+CORE
+file_with_no_newline.i
+
+^file_with_no_newline\.i((:[01]:1)|(\(1\))): error: .*$
+^EXIT=(1|64)$
+^SIGNAL=0$
+--

--- a/regression/ansi-c/errors/file_with_no_newline.i
+++ b/regression/ansi-c/errors/file_with_no_newline.i
@@ -1,0 +1,1 @@
+syntax error, no newline here ->

--- a/src/ansi-c/ansi_c_parser.cpp
+++ b/src/ansi-c/ansi_c_parser.cpp
@@ -208,13 +208,13 @@ void ansi_c_parsert::set_pragma_cprover()
     for(const auto &pragma : pragma_set)
       flattened[pragma.first] = pragma.second;
 
-  source_location.remove(ID_pragma);
+  _source_location.remove(ID_pragma);
 
   for(const auto &pragma : flattened)
   {
     std::string check_name = id2string(pragma.first);
     std::string full_name =
       (pragma.second ? "enable:" : "disable:") + check_name;
-    source_location.add_pragma(full_name);
+    _source_location.add_pragma(full_name);
   }
 }

--- a/src/cpp/cpp_parser.h
+++ b/src/cpp/cpp_parser.h
@@ -56,7 +56,7 @@ public:
   void add_location()
   {
     token_buffer.current_token().line_no=get_line_no()-1;
-    token_buffer.current_token().filename=source_location.get_file();
+    token_buffer.current_token().filename = source_location().get_file();
   }
 
   // scanner

--- a/src/util/parser.cpp
+++ b/src/util/parser.cpp
@@ -40,7 +40,7 @@ void parsert::parse_error(
   tmp_source_location.set_column(column-before.size());
   print(1, tmp, -1, tmp_source_location);
 #else
-  log.error().source_location = source_location;
+  log.error().source_location = source_location();
   log.error() << tmp << messaget::eom;
 #endif
 }


### PR DESCRIPTION
The parser sets the line number used for error messages once reaching a newline.  This fixes the logic for the case that the input file does not have a newline.

This is only visible on `.i` files, as the preprocessor adds a newline when there isn't one on `.c` files.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [X] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
