### PR TITLE
util: Replace std::basic_string<unsigned> with std::basic_string<char32_t>

### DIFF
--- a/src/ansi-c/literals/convert_character_literal.cpp
+++ b/src/ansi-c/literals/convert_character_literal.cpp
@@ -32,8 +32,8 @@ exprt convert_character_literal(
     PRECONDITION(src[1] == '\'');
     PRECONDITION(src[src.size() - 1] == '\'');
 
-    std::basic_string<unsigned int> value=
-      unescape_wide_string(std::string(src, 2, src.size()-3));
+    std::basic_string<char32_t> value =
+      unescape_wide_string(std::string(src, 2, src.size() - 3));
     // the parser rejects empty character constants
     CHECK_RETURN(!value.empty());
 

--- a/src/ansi-c/literals/convert_string_literal.cpp
+++ b/src/ansi-c/literals/convert_string_literal.cpp
@@ -18,8 +18,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "unescape_string.h"
 
-std::basic_string<unsigned int> convert_one_string_literal(
-  const std::string &src)
+std::basic_string<char32_t> convert_one_string_literal(const std::string &src)
 {
   PRECONDITION(src.size() >= 2);
 
@@ -28,8 +27,8 @@ std::basic_string<unsigned int> convert_one_string_literal(
     PRECONDITION(src[src.size() - 1] == '"');
     PRECONDITION(src[2] == '"');
 
-    std::basic_string<unsigned int> value=
-      unescape_wide_string(std::string(src, 3, src.size()-4));
+    std::basic_string<char32_t> value =
+      unescape_wide_string(std::string(src, 3, src.size() - 4));
 
     // turn into utf-8
     const std::string utf8_value = utf32_native_endian_to_utf8(value);
@@ -57,7 +56,7 @@ std::basic_string<unsigned int> convert_one_string_literal(
       unescape_string(std::string(src, 1, src.size()-2));
 
     // pad into wide string
-    std::basic_string<unsigned int> value;
+    std::basic_string<char32_t> value;
     value.resize(char_value.size());
     for(std::size_t i=0; i<char_value.size(); i++)
       value[i]=char_value[i];
@@ -72,7 +71,7 @@ exprt convert_string_literal(const std::string &src)
   // e.g., something like "asd" "xyz".
   // GCC allows "asd" L"xyz"!
 
-  std::basic_string<unsigned int> value;
+  std::basic_string<char32_t> value;
 
   char wide=0;
 
@@ -101,8 +100,7 @@ exprt convert_string_literal(const std::string &src)
     INVARIANT(j < src.size(), "non-terminated string constant '" + src + "'");
 
     std::string tmp_src=std::string(src, i, j-i+1);
-    std::basic_string<unsigned int> tmp_value=
-      convert_one_string_literal(tmp_src);
+    std::basic_string<char32_t> tmp_value = convert_one_string_literal(tmp_src);
     value.append(tmp_value);
     i=j;
   }

--- a/src/ansi-c/literals/unescape_string.cpp
+++ b/src/ansi-c/literals/unescape_string.cpp
@@ -20,7 +20,7 @@ static void append_universal_char(
   unsigned int value,
   std::string &dest)
 {
-  std::basic_string<unsigned int> value_str(1, value);
+  std::basic_string<char32_t> value_str(1, value);
 
   // turn into utf-8
   const std::string utf8_value = utf32_native_endian_to_utf8(value_str);
@@ -28,9 +28,8 @@ static void append_universal_char(
   dest.append(utf8_value);
 }
 
-static void append_universal_char(
-  unsigned int value,
-  std::basic_string<unsigned int> &dest)
+static void
+append_universal_char(unsigned int value, std::basic_string<char32_t> &dest)
 {
   dest.push_back(value);
 }
@@ -153,10 +152,9 @@ std::string unescape_string(const std::string &src)
   return unescape_string_templ<char>(src);
 }
 
-std::basic_string<unsigned int> unescape_wide_string(
-  const std::string &src)
+std::basic_string<char32_t> unescape_wide_string(const std::string &src)
 {
-  return unescape_string_templ<unsigned int>(src);
+  return unescape_string_templ<char32_t>(src);
 }
 
 unsigned hex_to_unsigned(const char *hex, std::size_t digits)

--- a/src/ansi-c/literals/unescape_string.h
+++ b/src/ansi-c/literals/unescape_string.h
@@ -15,7 +15,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <string>
 
 std::string unescape_string(const std::string &);
-std::basic_string<unsigned int> unescape_wide_string(const std::string &);
+std::basic_string<char32_t> unescape_wide_string(const std::string &);
 
 unsigned hex_to_unsigned(const char *, std::size_t digits);
 unsigned octal_to_unsigned(const char *, std::size_t digits);

--- a/src/ansi-c/scanner.l
+++ b/src/ansi-c/scanner.l
@@ -89,7 +89,7 @@ int make_identifier()
       for(; *p!=0 && digits>0; digits--, p++);
       p--; // go back for p++ later
       
-      std::basic_string<unsigned> utf32;
+      std::basic_string<char32_t> utf32;
       utf32+=letter;
       
       // turn into utf-8

--- a/src/util/unicode.cpp
+++ b/src/util/unicode.cpp
@@ -133,8 +133,7 @@ static void utf8_append_code(unsigned int c, std::string &result)
 
 /// \param s: UTF-32 encoded wide string
 /// \return utf8-encoded string with the same unicode characters as the input.
-std::string
-utf32_native_endian_to_utf8(const std::basic_string<unsigned int> &s)
+std::string utf32_native_endian_to_utf8(const std::basic_string<char32_t> &s)
 {
   std::string result;
 

--- a/src/util/unicode.h
+++ b/src/util/unicode.h
@@ -28,8 +28,7 @@ std::wstring widen(const std::string &s);
 #  define widen_if_needed(s) (s)
 #endif
 
-std::string
-utf32_native_endian_to_utf8(const std::basic_string<unsigned int> &s);
+std::string utf32_native_endian_to_utf8(const std::basic_string<char32_t> &s);
 
 /// \param utf8_str: UTF-8 string
 /// \return UTF-32 encoding of the string


### PR DESCRIPTION
Fixes build with libc++19 that fails with the error:

> implicit instantiation of undefined template 'std::char_traits<unsigned int>'

Motivation for the change: std::basic_string<T> requires that
T implements std::char_traits and standard library provides specializations only
for the following types: char, char16_t, char32_t, wchar_t as per [1].

Note that this has been pointed out during a review previously [2], but made its
way back into the code in other places.

libc++19 has dropped implementations of std::char_traits for types not required
by the standard [3].

> The base template for std::char_traits has been removed in LLVM 19.
> If you are using std::char_traits with types other than char, wchar_t, char8_t, char16_t, char32_t
> or a custom character type for which you specialized std::char_traits, your code will stop working.

[1] N4713, 24.2.1 Character traits [char.traits] (C++17)
[2] https://www.github.com/diffblue/cbmc/pull/5277#discussion_r396609205
[3] https://libcxx.llvm.org/ReleaseNotes/19.html#deprecations-and-removals

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

---

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->

---

Discovered when building cbmc for darwin with clang-19 https://github.com/NixOS/nixpkgs/pull/371275#issuecomment-2571816860.

This change should be basically an NFC related to portability, so no tests and documentation updates seem to be necessary.
