### PR TITLE
bump clang-format to clang-15

### DIFF
--- a/.github/workflows/pull-request-check-clang-format.sh
+++ b/.github/workflows/pull-request-check-clang-format.sh
@@ -7,7 +7,7 @@ set -e
 echo "Pull request's base branch is: ${BASE_BRANCH}"
 echo "Pull request's merge branch is: ${MERGE_BRANCH}"
 echo "Pull request's source branch is: ${GITHUB_HEAD_REF}"
-clang-format-11 --version
+clang-format-15 --version
 
 # The checkout action leaves us in detatched head state. The following line
 # names the checked out commit, for simpler reference later.
@@ -26,7 +26,7 @@ echo "Checking for formatting errors introduced since $MERGE_BASE"
 
 # Do the checking. "eval" is used so that quotes (as inserted into $EXCLUDES
 # above) are not interpreted as parts of file names.
-eval git-clang-format-11 --binary clang-format-11 $MERGE_BASE -- $EXCLUDES
+eval git-clang-format-15 --binary clang-format-15 $MERGE_BASE -- $EXCLUDES
 git diff > formatted.diff
 if [[ -s formatted.diff ]] ; then
   echo 'Formatting error! The following diff shows the required changes'

--- a/.github/workflows/syntax-checks.yaml
+++ b/.github/workflows/syntax-checks.yaml
@@ -6,7 +6,7 @@ on:
 jobs:
   # This job takes approximately 1 minute
   check-clang-format:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
         with:
@@ -19,8 +19,8 @@ jobs:
           DEBIAN_FRONTEND: noninteractive
         run: |
           sudo apt-get update
-          sudo apt-get install --no-install-recommends -yq clang-format-11
-      - name: Check updated lines of code match clang-format-11 style
+          sudo apt-get install --no-install-recommends -yq clang-format-15
+      - name: Check updated lines of code match clang-format-15 style
         env:
           BASE_BRANCH: ${{ github.base_ref }}
           MERGE_BRANCH: ${{ github.ref }}

--- a/CODING_STANDARD.md
+++ b/CODING_STANDARD.md
@@ -340,14 +340,13 @@ Now, you can commit and push the formatting fixes.
 To avoid waiting until you've made a PR to find formatting issues, you can
 install clang-format locally and run it against your code as you are working.
 
-Different versions of clang-format have slightly different behaviors. CBMC uses
-clang-format-11 as it is available the repositories for Ubuntu 20.04 and
-Homebrew.
-To install on a Unix-like system, try installing using the system package
-manager:
+Different versions of clang-format have slightly different behaviors.  CBMC
+uses clang-format-15, or later, available in the standard Ubuntu 24.04 and
+Homebrew repositories.  To install on a Unix-like system, try installing
+using the system package manager:
 ```
-apt-get install clang-format-11  # Run this on Ubuntu, Debian etc.
-brew install clang-format@11     # Run this on a Mac with Homebrew installed
+apt-get install clang-format     # Run this on Ubuntu, Debian etc.
+brew install clang-format        # Run this on a Mac with Homebrew installed
 ```
 
 If your platform doesn't have a package for clang-format, you can download a


### PR DESCRIPTION
clang 11 was released in 2007, and the last variant of Ubuntu with the clang-format-11 package is 22.04.

This bumps the clang-format used for the formatting check to clang 15, available with 24.04.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- n/a Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
