### PR TITLE
CONTRACTS: allow pointer predicates to fail in `assume` contexts

### DIFF
--- a/doc/man/cbmc.1
+++ b/doc/man/cbmc.1
@@ -334,6 +334,9 @@ set malloc failure mode to return null
 \fB\-\-string\-abstraction\fR
 track C string lengths and zero\-termination
 .TP
+\fB\-\-dfcc\-debug\-lib\fR
+enable debug assertions in the cprover contracts library
+.TP
 \fB\-\-reachability\-slice\fR
 remove instructions that cannot appear on a trace
 from entry point to a property

--- a/doc/man/cbmc.1
+++ b/doc/man/cbmc.1
@@ -337,6 +337,10 @@ track C string lengths and zero\-termination
 \fB\-\-dfcc\-debug\-lib\fR
 enable debug assertions in the cprover contracts library
 .TP
+\fB\-\-dfcc\-simple\-invalid\-pointer\-model\fR
+use simplified invalid pointer model in the cprover contracts library
+(faster, unsound)
+.TP
 \fB\-\-reachability\-slice\fR
 remove instructions that cannot appear on a trace
 from entry point to a property

--- a/doc/man/goto-analyzer.1
+++ b/doc/man/goto-analyzer.1
@@ -588,6 +588,10 @@ track C string lengths and zero\-termination
 .TP
 \fB\-\-dfcc\-debug\-lib\fR
 enable debug assertions in the cprover contracts library
+.TP
+\fB\-\-dfcc\-simple\-invalid\-pointer\-model\fR
+use simplified invalid pointer model in the cprover contracts library
+(faster, unsound)
 .SS "Standard Checks"
 From version \fB6.0\fR onwards, \fBcbmc\fR, \fBgoto-analyzer\fR and some other tools
 apply some checks to the program by default (called the "standard checks"), with the

--- a/doc/man/goto-analyzer.1
+++ b/doc/man/goto-analyzer.1
@@ -585,6 +585,9 @@ set malloc failure mode to return null
 .TP
 \fB\-\-string\-abstraction\fR
 track C string lengths and zero\-termination
+.TP
+\fB\-\-dfcc\-debug\-lib\fR
+enable debug assertions in the cprover contracts library
 .SS "Standard Checks"
 From version \fB6.0\fR onwards, \fBcbmc\fR, \fBgoto-analyzer\fR and some other tools
 apply some checks to the program by default (called the "standard checks"), with the

--- a/doc/man/goto-instrument.1
+++ b/doc/man/goto-instrument.1
@@ -706,6 +706,9 @@ do not allow malloc calls to fail by default
 \fB\-\-string\-abstraction\fR
 track C string lengths and zero\-termination
 .TP
+\fB\-\-dfcc\-debug\-lib\fR
+enable debug assertions in the cprover contracts library
+.TP
 \fB\-\-model\-argc\-argv\fR \fIn\fR
 Create up to \fIn\fR non-deterministic C strings as entries to \fIargv\fR and
 set \fIargc\fR accordingly. In absence of such modelling, \fIargv\fR is left

--- a/doc/man/goto-instrument.1
+++ b/doc/man/goto-instrument.1
@@ -709,6 +709,10 @@ track C string lengths and zero\-termination
 \fB\-\-dfcc\-debug\-lib\fR
 enable debug assertions in the cprover contracts library
 .TP
+\fB\-\-dfcc\-simple\-invalid\-pointer\-model\fR
+use simplified invalid pointer model in the cprover contracts library
+(faster, unsound)
+.TP
 \fB\-\-model\-argc\-argv\fR \fIn\fR
 Create up to \fIn\fR non-deterministic C strings as entries to \fIargv\fR and
 set \fIargc\fR accordingly. In absence of such modelling, \fIargv\fR is left

--- a/regression/contracts-dfcc/quantifiers-loops-fresh-bound-vars-smt/test.desc
+++ b/regression/contracts-dfcc/quantifiers-loops-fresh-bound-vars-smt/test.desc
@@ -1,4 +1,4 @@
-CORE dfcc-only smt-backend broken-cprover-smt-backend
+FUTURE dfcc-only smt-backend broken-cprover-smt-backend
 main.c
 --dfcc main --apply-loop-contracts --enforce-contract foo --malloc-may-fail --malloc-fail-null _ --z3 --slice-formula --no-standard-checks
 ^EXIT=0$
@@ -7,6 +7,12 @@ main.c
 --
 ^warning: ignoring
 --
+
+Marked as FUTURE because:
+- z3 >v4.12 and up can solve the problem with `--dfcc-simple-invalid-pointer-model`,
+ but the CI uses older versions;
+- bitwuzla >v0.6 can solve the problem but we don't run bitwuzla in CI.
+
 Tests support for quantifiers in loop contracts with the SMT backend.
 When quantified loop invariants are used, they are inserted three times
 in the transformed program (base case assertion, step case assumption,

--- a/regression/contracts-dfcc/test_is_fresh_enforce_requires_disjunction_fail/main.c
+++ b/regression/contracts-dfcc/test_is_fresh_enforce_requires_disjunction_fail/main.c
@@ -1,0 +1,14 @@
+void foo(int *x)
+  // clang-format off
+  __CPROVER_requires(__CPROVER_is_fresh(x, sizeof(int)) || 1)
+  __CPROVER_assigns(*x)
+// clang-format on
+{
+  *x = 0;
+}
+
+void main()
+{
+  int *x;
+  foo(x);
+}

--- a/regression/contracts-dfcc/test_is_fresh_enforce_requires_disjunction_fail/test.desc
+++ b/regression/contracts-dfcc/test_is_fresh_enforce_requires_disjunction_fail/test.desc
@@ -1,0 +1,20 @@
+CORE dfcc-only
+main.c
+--dfcc main --enforce-contract foo
+^\[__CPROVER_contracts_car_set_insert.assertion.\d+\] line \d+ ptr NULL or writable up to size: (FAILURE|UNKNOWN)$
+^\[__CPROVER_contracts_write_set_check_assignment.assertion.\d+\] line \d+ ptr NULL or writable up to size: (FAILURE|UNKNOWN)$
+^\[foo.assigns.\d+\] line \d+ Check that \*x is assignable: (FAILURE|UNKNOWN)$
+^\[foo.pointer_dereference.\d+\] line \d+ dereference failure: pointer NULL in \*x: (FAILURE|UNKNOWN)
+^\[foo.pointer_dereference.\d+\] line \d+ dereference failure: pointer invalid in \*x: (FAILURE|UNKNOWN)$
+^\[foo.pointer_dereference.\d+\] line \d+ dereference failure: deallocated dynamic object in \*x: (FAILURE|UNKNOWN)
+^\[foo.pointer_dereference.\d+\] line \d+ dereference failure: dead object in \*x: (FAILURE|UNKNOWN)
+^\[foo.pointer_dereference.\d+\] line \d+ dereference failure: pointer outside object bounds in \*x: (FAILURE|UNKNOWN)
+^\[foo.pointer_dereference.\d+\] line \d+ dereference failure: invalid integer address in \*x: (FAILURE|UNKNOWN)$
+^EXIT=10$
+^SIGNAL=0$
+^VERIFICATION FAILED$
+--
+--
+This test checks that when `__CPROVER_is_fresh` is used in disjunctions,
+the program accepts models where `__CPROVER_is_fresh` evaluates to false
+and no object gets allocated, and pointers remain invalid.

--- a/regression/contracts-dfcc/test_is_fresh_enforce_requires_disjunction_pass/main.c
+++ b/regression/contracts-dfcc/test_is_fresh_enforce_requires_disjunction_pass/main.c
@@ -1,0 +1,30 @@
+#include <stdlib.h>
+void foo(int *x, int *y)
+  // clang-format off
+  __CPROVER_requires(
+    (__CPROVER_is_fresh(x, sizeof(*x)) && y == NULL) ||
+    (x == NULL && __CPROVER_is_fresh(y, sizeof(*y)))
+  )
+  __CPROVER_assigns(y == NULL: *x)
+  __CPROVER_assigns(x == NULL: *y)
+// clang-format on
+{
+  if(y == NULL)
+  {
+    assert(0);
+    *x = 0;
+  }
+  else
+  {
+    assert(0);
+    assert(x == NULL);
+    *y = 0;
+  }
+}
+
+void main()
+{
+  int *x;
+  int *y;
+  foo(x, y);
+}

--- a/regression/contracts-dfcc/test_is_fresh_enforce_requires_disjunction_pass/test.desc
+++ b/regression/contracts-dfcc/test_is_fresh_enforce_requires_disjunction_pass/test.desc
@@ -1,0 +1,30 @@
+CORE dfcc-only
+main.c
+--dfcc main --enforce-contract foo
+^\[foo.assertion.\d+\] line 14 assertion 0: FAILURE$
+^\[foo.assigns.\d+\] line 15 Check that \*x is assignable: SUCCESS$
+^\[foo.pointer_dereference.\d+\] line 15 dereference failure: pointer NULL in \*x: SUCCESS$
+^\[foo.pointer_dereference.\d+\] line 15 dereference failure: pointer invalid in \*x: SUCCESS$
+^\[foo.pointer_dereference.\d+\] line 15 dereference failure: deallocated dynamic object in \*x: SUCCESS$
+^\[foo.pointer_dereference.\d+\] line 15 dereference failure: dead object in \*x: SUCCESS$
+^\[foo.pointer_dereference.\d+\] line 15 dereference failure: pointer outside object bounds in \*x: SUCCESS$
+^\[foo.pointer_dereference.\d+\] line 15 dereference failure: invalid integer address in \*x: SUCCESS$
+^\[foo.assertion.\d+\] line 19 assertion 0: FAILURE$
+^\[foo.assertion.\d+\] line 20 assertion x == \(\(.*\)NULL\): SUCCESS$
+^\[foo.assigns.\d+\] line 21 Check that \*y is assignable: SUCCESS$
+^\[foo.pointer_dereference.\d+\] line 21 dereference failure: pointer NULL in \*y: SUCCESS$
+^\[foo.pointer_dereference.\d+\] line 21 dereference failure: pointer invalid in \*y: SUCCESS$
+^\[foo.pointer_dereference.\d+\] line 21 dereference failure: deallocated dynamic object in \*y: SUCCESS$
+^\[foo.pointer_dereference.\d+\] line 21 dereference failure: dead object in \*y: SUCCESS$
+^\[foo.pointer_dereference.\d+\] line 21 dereference failure: pointer outside object bounds in \*y: SUCCESS$
+^\[foo.pointer_dereference.\d+\] line 21 dereference failure: invalid integer address in \*y: SUCCESS$
+^EXIT=10$
+^SIGNAL=0$
+^VERIFICATION FAILED$
+--
+--
+Illustrates the behaviour of `__CPROVER_is_fresh` under disjunctions in assume contexts.
+The precondition of `foo` describes a disjunction of cases, either `x` is fresh and `y` is null,
+or `x` is null and `y` is fresh. The function `foo` branches on `y == NULL`.
+The test suceeds if the two `assert(0)` in `foo` are falsifiable, which which shows
+that both cases of the disjunction expressed in the requires clause are reachable.

--- a/regression/contracts-dfcc/test_is_fresh_replace_ensures_disjunction_fail/main.c
+++ b/regression/contracts-dfcc/test_is_fresh_replace_ensures_disjunction_fail/main.c
@@ -1,0 +1,15 @@
+int *foo()
+  // clang-format off
+  __CPROVER_ensures(
+    __CPROVER_is_fresh(__CPROVER_return_value, sizeof(int)) || 1);
+// clang-format on
+
+void bar()
+{
+  int *x = foo();
+  *x = 0; //expected to fail
+}
+void main()
+{
+  bar();
+}

--- a/regression/contracts-dfcc/test_is_fresh_replace_ensures_disjunction_fail/test.desc
+++ b/regression/contracts-dfcc/test_is_fresh_replace_ensures_disjunction_fail/test.desc
@@ -1,0 +1,17 @@
+CORE dfcc-only
+main.c
+--dfcc main --replace-call-with-contract foo
+^\[bar.pointer_dereference.\d+\] line 10 dereference failure: pointer NULL in \*x: (UNKNOWN|FAILURE)$
+^\[bar.pointer_dereference.\d+\] line 10 dereference failure: pointer invalid in \*x: (UNKNOWN|FAILURE)$
+^\[bar.pointer_dereference.\d+\] line 10 dereference failure: deallocated dynamic object in \*x: (UNKNOWN|FAILURE)$
+^\[bar.pointer_dereference.\d+\] line 10 dereference failure: dead object in \*x: (UNKNOWN|FAILURE)$
+^\[bar.pointer_dereference.\d+\] line 10 dereference failure: pointer outside object bounds in \*x: (UNKNOWN|FAILURE)$
+^\[bar.pointer_dereference.\d+\] line 10 dereference failure: invalid integer address in \*x: (UNKNOWN|FAILURE)$
+^EXIT=10$
+^SIGNAL=0$
+^VERIFICATION FAILED$
+--
+--
+This test checks that when `__CPROVER_is_fresh` is used in disjunctions,
+the program accepts models where `__CPROVER_is_fresh` evaluates to false
+and no object gets allocated, and pointers remain invalid.

--- a/regression/contracts-dfcc/test_is_fresh_replace_ensures_disjunction_pass/main.c
+++ b/regression/contracts-dfcc/test_is_fresh_replace_ensures_disjunction_pass/main.c
@@ -1,0 +1,41 @@
+#include <stdlib.h>
+typedef struct
+{
+  int *x;
+  int *y;
+} ret_t;
+
+ret_t foo()
+  // clang-format off
+  __CPROVER_ensures((
+      __CPROVER_is_fresh(__CPROVER_return_value.x, sizeof(int)) &&
+      __CPROVER_return_value.y == NULL
+    ) || (
+      __CPROVER_return_value.x == NULL &&
+      __CPROVER_is_fresh(__CPROVER_return_value.y, sizeof(int))
+    ))
+  // clang-format on
+  ;
+
+void bar()
+{
+  ret_t ret = foo();
+  int *x = ret.x;
+  int *y = ret.y;
+  if(y == NULL)
+  {
+    assert(0);
+    *x = 0;
+  }
+  else
+  {
+    assert(0);
+    assert(x == NULL);
+    *y = 0;
+  }
+}
+
+void main()
+{
+  bar();
+}

--- a/regression/contracts-dfcc/test_is_fresh_replace_ensures_disjunction_pass/test.desc
+++ b/regression/contracts-dfcc/test_is_fresh_replace_ensures_disjunction_pass/test.desc
@@ -1,0 +1,30 @@
+CORE dfcc-only
+main.c
+--dfcc main --replace-call-with-contract foo
+^\[bar.assertion.\d+\] line 27 assertion 0: FAILURE$
+^\[bar.assigns.\d+\] line 28 Check that \*x is assignable: SUCCESS$
+^\[bar.pointer_dereference.\d+\] line 28 dereference failure: pointer NULL in \*x: SUCCESS$
+^\[bar.pointer_dereference.\d+\] line 28 dereference failure: pointer invalid in \*x: SUCCESS$
+^\[bar.pointer_dereference.\d+\] line 28 dereference failure: deallocated dynamic object in \*x: SUCCESS$
+^\[bar.pointer_dereference.\d+\] line 28 dereference failure: dead object in \*x: SUCCESS$
+^\[bar.pointer_dereference.\d+\] line 28 dereference failure: pointer outside object bounds in \*x: SUCCESS$
+^\[bar.pointer_dereference.\d+\] line 28 dereference failure: invalid integer address in \*x: SUCCESS$
+^\[bar.assertion.\d+\] line 32 assertion 0: FAILURE$
+^\[bar.assertion.\d+\] line 33 assertion x == \(\(.*\)NULL\): SUCCESS$
+^\[bar.assigns.\d+\] line 34 Check that \*y is assignable: SUCCESS$
+^\[bar.pointer_dereference.\d+\] line 34 dereference failure: pointer NULL in \*y: SUCCESS$
+^\[bar.pointer_dereference.\d+\] line 34 dereference failure: pointer invalid in \*y: SUCCESS$
+^\[bar.pointer_dereference.\d+\] line 34 dereference failure: deallocated dynamic object in \*y: SUCCESS$
+^\[bar.pointer_dereference.\d+\] line 34 dereference failure: dead object in \*y: SUCCESS$
+^\[bar.pointer_dereference.\d+\] line 34 dereference failure: pointer outside object bounds in \*y: SUCCESS$
+^\[bar.pointer_dereference.\d+\] line 34 dereference failure: invalid integer address in \*y: SUCCESS$
+^EXIT=10$
+^SIGNAL=0$
+^VERIFICATION FAILED$
+--
+--
+Illustrates the behaviour of `__CPROVER_is_fresh` under disjunctions in assume contexts.
+The postcondition of `foo` describes a disjunction of cases: either `x` is fresh and `y` is null,
+or `x` is null and `y` is fresh. The function `bar` branches on `y == NULL`.
+The test succeeds if the two `assert(0)` are falsifiable, which which shows that
+both cases of the disjunction expressed in the ensures clause of `foo` are reachable.

--- a/regression/contracts-dfcc/test_pointer_equals_enforce_requires_disjunction_fail/main.c
+++ b/regression/contracts-dfcc/test_pointer_equals_enforce_requires_disjunction_fail/main.c
@@ -1,0 +1,16 @@
+void foo(int *x, int *y)
+  // clang-format off
+  __CPROVER_requires(__CPROVER_is_fresh(x, sizeof(int)))
+  __CPROVER_requires(__CPROVER_pointer_equals(y, x) || 1)
+  __CPROVER_assigns(*y)
+// clang-format on
+{
+  *y = 0;
+}
+
+void main()
+{
+  int *x;
+  int *y;
+  foo(x, y);
+}

--- a/regression/contracts-dfcc/test_pointer_equals_enforce_requires_disjunction_fail/test.desc
+++ b/regression/contracts-dfcc/test_pointer_equals_enforce_requires_disjunction_fail/test.desc
@@ -1,0 +1,20 @@
+CORE dfcc-only
+main.c
+--dfcc main --enforce-contract foo
+^\[__CPROVER_contracts_car_set_insert.assertion.\d+\] line \d+ ptr NULL or writable up to size: (UNKNOWN|FAILURE)$
+^\[__CPROVER_contracts_write_set_check_assignment.assertion.\d+\] line \d+ ptr NULL or writable up to size: (UNKNOWN|FAILURE)$
+^\[foo.assigns.\d+\] line \d+ Check that \*y is assignable: (UNKNOWN|FAILURE)$
+^\[foo.pointer_dereference.\d+\] line \d+ dereference failure: pointer NULL in \*y: (UNKNOWN|FAILURE)$
+^\[foo.pointer_dereference.\d+\] line \d+ dereference failure: pointer invalid in \*y: (UNKNOWN|FAILURE)$
+^\[foo.pointer_dereference.\d+\] line \d+ dereference failure: deallocated dynamic object in \*y: (UNKNOWN|FAILURE)$
+^\[foo.pointer_dereference.\d+\] line \d+ dereference failure: dead object in \*y: (UNKNOWN|FAILURE)$
+^\[foo.pointer_dereference.\d+\] line \d+ dereference failure: pointer outside object bounds in \*y: (UNKNOWN|FAILURE)$
+^\[foo.pointer_dereference.\d+\] line \d+ dereference failure: invalid integer address in \*y: (UNKNOWN|FAILURE)$
+^EXIT=10$
+^SIGNAL=0$
+^VERIFICATION FAILED$
+--
+--
+This test checks that when `__CPROVER_pointer_equals` is used in disjunctions,
+the program accepts models where `__CPROVER_pointer_equals` evaluates to
+false and the target pointer remains invalid.

--- a/regression/contracts-dfcc/test_pointer_equals_enforce_requires_disjunction_pass/main.c
+++ b/regression/contracts-dfcc/test_pointer_equals_enforce_requires_disjunction_pass/main.c
@@ -1,0 +1,34 @@
+#include <stdlib.h>
+void foo(int *a, int *x, int *y)
+  // clang-format off
+  __CPROVER_requires(__CPROVER_is_fresh(a, sizeof(int)))
+  __CPROVER_requires(
+    (__CPROVER_pointer_equals(x,a) && y == NULL) ||
+    (x == NULL && __CPROVER_pointer_equals(y,a))
+  )
+  __CPROVER_assigns(y == NULL: *x)
+  __CPROVER_assigns(x == NULL: *y)
+// clang-format on
+{
+  if(y == NULL)
+  {
+    assert(0);
+    assert(__CPROVER_same_object(a, x));
+    *x = 0;
+  }
+  else
+  {
+    assert(0);
+    assert(x == NULL);
+    assert(__CPROVER_same_object(a, y));
+    *y = 0;
+  }
+}
+
+void main()
+{
+  int *a;
+  int *x;
+  int *y;
+  foo(a, x, y);
+}

--- a/regression/contracts-dfcc/test_pointer_equals_enforce_requires_disjunction_pass/test.desc
+++ b/regression/contracts-dfcc/test_pointer_equals_enforce_requires_disjunction_pass/test.desc
@@ -1,0 +1,32 @@
+CORE dfcc-only
+main.c
+--dfcc main --enforce-contract foo
+^\[foo.assertion.\d+\] line 15 assertion 0: FAILURE$
+^\[foo.assertion.\d+\] line \d+ assertion __CPROVER_POINTER_OBJECT\(\(.*\)a\) == __CPROVER_POINTER_OBJECT\(\(.*\)x\): SUCCESS$
+^\[foo.assigns.\d+\] line \d+ Check that \*x is assignable: SUCCESS$
+^\[foo.pointer_dereference.\d+\] line \d+ dereference failure: pointer NULL in \*x: SUCCESS$
+^\[foo.pointer_dereference.\d+\] line \d+ dereference failure: pointer invalid in \*x: SUCCESS$
+^\[foo.pointer_dereference.\d+\] line \d+ dereference failure: deallocated dynamic object in \*x: SUCCESS$
+^\[foo.pointer_dereference.\d+\] line \d+ dereference failure: dead object in \*x: SUCCESS$
+^\[foo.pointer_dereference.\d+\] line \d+ dereference failure: pointer outside object bounds in \*x: SUCCESS$
+^\[foo.pointer_dereference.\d+\] line \d+ dereference failure: invalid integer address in \*x: SUCCESS$
+^\[foo.assertion.\d+\] line 21 assertion 0: FAILURE$
+^\[foo.assertion.\d+\] line \d+ assertion x == \(\(.*\)NULL\): SUCCESS$
+^\[foo.assertion.\d+\] line \d+ assertion __CPROVER_POINTER_OBJECT\(\(.*\)a\) == __CPROVER_POINTER_OBJECT\(\(.*\)y\): SUCCESS$
+^\[foo.assigns.\d+\] line \d+ Check that \*y is assignable: SUCCESS$
+^\[foo.pointer_dereference.\d+\] line \d+ dereference failure: pointer NULL in \*y: SUCCESS$
+^\[foo.pointer_dereference.\d+\] line \d+ dereference failure: pointer invalid in \*y: SUCCESS$
+^\[foo.pointer_dereference.\d+\] line \d+ dereference failure: deallocated dynamic object in \*y: SUCCESS$
+^\[foo.pointer_dereference.\d+\] line \d+ dereference failure: dead object in \*y: SUCCESS$
+^\[foo.pointer_dereference.\d+\] line \d+ dereference failure: pointer outside object bounds in \*y: SUCCESS$
+^\[foo.pointer_dereference.\d+\] line \d+ dereference failure: invalid integer address in \*y: SUCCESS$
+^EXIT=10$
+^SIGNAL=0$
+^VERIFICATION FAILED$
+--
+--
+Illustrates the behaviour of `__CPROVER_pointer_equals` under disjunctions in assume contexts.
+The precondition of `foo` describes a disjunction of cases, either `x` equals `a` and `y` is null,
+or `x` is null and `y` equals `a`. The function `foo` branches on `y == NULL`.
+The test suceeds if the two `assert(0)` in `foo` are falsifiable, which which shows
+that both cases of the disjunction expressed in the requires clause are reachable.

--- a/regression/contracts-dfcc/test_pointer_equals_replace_ensures_disjunction_fail/main.c
+++ b/regression/contracts-dfcc/test_pointer_equals_replace_ensures_disjunction_fail/main.c
@@ -1,0 +1,28 @@
+
+typedef struct
+{
+  int *a;
+  int *x;
+} ret_t;
+
+ret_t foo()
+  // clang-format off
+  __CPROVER_ensures(__CPROVER_is_fresh(__CPROVER_return_value.a, sizeof(int)))
+  __CPROVER_ensures(
+    __CPROVER_pointer_equals(
+      __CPROVER_return_value.x,
+      __CPROVER_return_value.a) || 1)
+  // clang-format on
+  ;
+
+void bar()
+{
+  ret_t ret = foo();
+  int *x = ret.x;
+  *x = 0; //expected to fail
+}
+
+void main()
+{
+  bar();
+}

--- a/regression/contracts-dfcc/test_pointer_equals_replace_ensures_disjunction_fail/test.desc
+++ b/regression/contracts-dfcc/test_pointer_equals_replace_ensures_disjunction_fail/test.desc
@@ -1,0 +1,17 @@
+CORE dfcc-only
+main.c
+--dfcc main --replace-call-with-contract foo
+^\[bar.pointer_dereference.\d+\] line \d+ dereference failure: pointer NULL in \*x: (UNKNOWN|FAILURE)$
+^\[bar.pointer_dereference.\d+\] line \d+ dereference failure: pointer invalid in \*x: (UNKNOWN|FAILURE)$
+^\[bar.pointer_dereference.\d+\] line \d+ dereference failure: deallocated dynamic object in \*x: (UNKNOWN|FAILURE)$
+^\[bar.pointer_dereference.\d+\] line \d+ dereference failure: dead object in \*x: (UNKNOWN|FAILURE)$
+^\[bar.pointer_dereference.\d+\] line \d+ dereference failure: pointer outside object bounds in \*x: (UNKNOWN|FAILURE)$
+^\[bar.pointer_dereference.\d+\] line \d+ dereference failure: invalid integer address in \*x: (UNKNOWN|FAILURE)$
+^EXIT=10$
+^SIGNAL=0$
+^VERIFICATION FAILED$
+--
+--
+This test checks that when `__CPROVER_pointer_equals` is used in disjunctions,
+the program accepts models where `__CPROVER_pointer_equals` evaluates to
+false and the target pointer remains invalid.

--- a/regression/contracts-dfcc/test_pointer_equals_replace_ensures_disjunction_pass/main.c
+++ b/regression/contracts-dfcc/test_pointer_equals_replace_ensures_disjunction_pass/main.c
@@ -1,0 +1,49 @@
+#include <stdlib.h>
+typedef struct
+{
+  int *a;
+  int *x;
+  int *y;
+} ret_t;
+
+ret_t foo()
+  // clang-format off
+  __CPROVER_ensures(__CPROVER_is_fresh(__CPROVER_return_value.a, sizeof(int)))
+  __CPROVER_ensures((
+      __CPROVER_pointer_equals(
+        __CPROVER_return_value.x,
+        __CPROVER_return_value.a) &&
+      __CPROVER_return_value.y == NULL
+    ) || (
+      __CPROVER_return_value.x == NULL &&
+      __CPROVER_pointer_equals(
+        __CPROVER_return_value.y,
+        __CPROVER_return_value.a)))
+  // clang-format on
+  ;
+
+void bar()
+{
+  ret_t ret = foo();
+  int *a = ret.a;
+  int *x = ret.x;
+  int *y = ret.y;
+  if(y == NULL)
+  {
+    assert(0);
+    assert(__CPROVER_same_object(x, a));
+    *x = 0;
+  }
+  else
+  {
+    assert(0);
+    assert(x == NULL);
+    assert(__CPROVER_same_object(y, a));
+    *y = 0;
+  }
+}
+
+void main()
+{
+  bar();
+}

--- a/regression/contracts-dfcc/test_pointer_equals_replace_ensures_disjunction_pass/test.desc
+++ b/regression/contracts-dfcc/test_pointer_equals_replace_ensures_disjunction_pass/test.desc
@@ -1,0 +1,32 @@
+CORE dfcc-only
+main.c
+--dfcc main --replace-call-with-contract foo
+^\[bar.assertion.\d+\] line 33 assertion 0: FAILURE$
+^\[bar.assertion.\d+\] line \d+ assertion __CPROVER_POINTER_OBJECT\(\(.*\)x\) == __CPROVER_POINTER_OBJECT\(\(.*\)a\): SUCCESS$
+^\[bar.assigns.\d+\] line \d+ Check that \*x is assignable: SUCCESS$
+^\[bar.pointer_dereference.\d+\] line \d+ dereference failure: pointer NULL in \*x: SUCCESS$
+^\[bar.pointer_dereference.\d+\] line \d+ dereference failure: pointer invalid in \*x: SUCCESS$
+^\[bar.pointer_dereference.\d+\] line \d+ dereference failure: deallocated dynamic object in \*x: SUCCESS$
+^\[bar.pointer_dereference.\d+\] line \d+ dereference failure: dead object in \*x: SUCCESS$
+^\[bar.pointer_dereference.\d+\] line \d+ dereference failure: pointer outside object bounds in \*x: SUCCESS$
+^\[bar.pointer_dereference.\d+\] line \d+ dereference failure: invalid integer address in \*x: SUCCESS$
+^\[bar.assertion.\d+\] line 39 assertion 0: FAILURE$
+^\[bar.assertion.\d+\] line \d+ assertion x == \(\(.*\)NULL\): SUCCESS$
+^\[bar.assertion.\d+\] line \d+ assertion __CPROVER_POINTER_OBJECT\(\(.*\)y\) == __CPROVER_POINTER_OBJECT\(\(.*\)a\): SUCCESS$
+^\[bar.assigns.\d+\] line \d+ Check that \*y is assignable: SUCCESS$
+^\[bar.pointer_dereference.\d+\] line \d+ dereference failure: pointer NULL in \*y: SUCCESS$
+^\[bar.pointer_dereference.\d+\] line \d+ dereference failure: pointer invalid in \*y: SUCCESS$
+^\[bar.pointer_dereference.\d+\] line \d+ dereference failure: deallocated dynamic object in \*y: SUCCESS$
+^\[bar.pointer_dereference.\d+\] line \d+ dereference failure: dead object in \*y: SUCCESS$
+^\[bar.pointer_dereference.\d+\] line \d+ dereference failure: pointer outside object bounds in \*y: SUCCESS$
+^\[bar.pointer_dereference.\d+\] line \d+ dereference failure: invalid integer address in \*y: SUCCESS$
+^EXIT=10$
+^SIGNAL=0$
+^VERIFICATION FAILED$
+--
+--
+Illustrates the behaviour of `__CPROVER_pointer_equals` under disjunctions in assume contexts.
+The postcondition of `foo` describes a disjunction of cases: either `x` equals `a` and `y` is null,
+or `x` is null and `y` equals `a`. The function `bar` branches on `y == NULL`.
+The test succeeds if the two `assert(0)` are falsifiable, which which shows that
+both cases of the disjunction expressed in the ensures clause of `foo` are reachable.

--- a/regression/contracts-dfcc/test_pointer_in_range_enforce_requires_disjunction_fail/main.c
+++ b/regression/contracts-dfcc/test_pointer_in_range_enforce_requires_disjunction_fail/main.c
@@ -1,0 +1,16 @@
+void foo(int *x, int *y)
+  // clang-format off
+  __CPROVER_requires(__CPROVER_is_fresh(x, 8*sizeof(int)))
+  __CPROVER_requires(__CPROVER_pointer_in_range_dfcc(x, y, x+7) || 1)
+  __CPROVER_assigns(*y)
+// clang-format on
+{
+  *y = 0;
+}
+
+void main()
+{
+  int *x;
+  int *y;
+  foo(x, y);
+}

--- a/regression/contracts-dfcc/test_pointer_in_range_enforce_requires_disjunction_fail/test.desc
+++ b/regression/contracts-dfcc/test_pointer_in_range_enforce_requires_disjunction_fail/test.desc
@@ -1,0 +1,20 @@
+CORE dfcc-only
+main.c
+--dfcc main --enforce-contract foo
+^\[__CPROVER_contracts_car_set_insert.assertion.\d+\] line \d+ ptr NULL or writable up to size: (UNKNOWN|FAILURE)$
+^\[__CPROVER_contracts_write_set_check_assignment.assertion.\d+\] line \d+ ptr NULL or writable up to size: (UNKNOWN|FAILURE)$
+^\[foo.assigns.\d+\] line \d+ Check that \*y is assignable: (UNKNOWN|FAILURE)$
+^\[foo.pointer_dereference.\d+\] line \d+ dereference failure: pointer NULL in \*y: (UNKNOWN|FAILURE)$
+^\[foo.pointer_dereference.\d+\] line \d+ dereference failure: pointer invalid in \*y: (UNKNOWN|FAILURE)$
+^\[foo.pointer_dereference.\d+\] line \d+ dereference failure: deallocated dynamic object in \*y: (UNKNOWN|FAILURE)$
+^\[foo.pointer_dereference.\d+\] line \d+ dereference failure: dead object in \*y: (UNKNOWN|FAILURE)$
+^\[foo.pointer_dereference.\d+\] line \d+ dereference failure: pointer outside object bounds in \*y: (UNKNOWN|FAILURE)$
+^\[foo.pointer_dereference.\d+\] line \d+ dereference failure: invalid integer address in \*y: (UNKNOWN|FAILURE)$
+^EXIT=10$
+^SIGNAL=0$
+^VERIFICATION FAILED$
+--
+--
+This test checks that when `__CPROVER_pointer_equals` is used in disjunctions,
+the program accepts models where `__CPROVER_pointer_equals` evaluates to
+false and the target pointer remains invalid.

--- a/regression/contracts-dfcc/test_pointer_in_range_enforce_requires_disjunction_pass/main.c
+++ b/regression/contracts-dfcc/test_pointer_in_range_enforce_requires_disjunction_pass/main.c
@@ -1,0 +1,34 @@
+#include <stdlib.h>
+void foo(int *a, int *x, int *y)
+  // clang-format off
+  __CPROVER_requires(__CPROVER_is_fresh(a, 8*sizeof(int)))
+  __CPROVER_requires(
+    (__CPROVER_pointer_in_range_dfcc(a, x, a+7) && y == NULL) ||
+    (x == NULL && __CPROVER_pointer_in_range_dfcc(a, y, a+7))
+  )
+  __CPROVER_assigns(y == NULL: *x)
+  __CPROVER_assigns(x == NULL: *y)
+// clang-format on
+{
+  if(y == NULL)
+  {
+    assert(0);
+    assert(__CPROVER_same_object(a, x));
+    *x = 0;
+  }
+  else
+  {
+    assert(0);
+    assert(x == NULL);
+    assert(__CPROVER_same_object(a, y));
+    *y = 0;
+  }
+}
+
+void main()
+{
+  int *a;
+  int *x;
+  int *y;
+  foo(a, x, y);
+}

--- a/regression/contracts-dfcc/test_pointer_in_range_enforce_requires_disjunction_pass/test.desc
+++ b/regression/contracts-dfcc/test_pointer_in_range_enforce_requires_disjunction_pass/test.desc
@@ -1,0 +1,32 @@
+CORE dfcc-only
+main.c
+--dfcc main --enforce-contract foo
+^\[foo.assertion.\d+\] line 15 assertion 0: FAILURE$
+^\[foo.assertion.\d+\] line 16 assertion __CPROVER_POINTER_OBJECT\(\(.*\)a\) == __CPROVER_POINTER_OBJECT\(\(.*\)x\): SUCCESS$
+^\[foo.assigns.\d+\] line 17 Check that \*x is assignable: SUCCESS$
+^\[foo.pointer_dereference.\d+\] line 17 dereference failure: pointer NULL in \*x: SUCCESS$
+^\[foo.pointer_dereference.\d+\] line 17 dereference failure: pointer invalid in \*x: SUCCESS$
+^\[foo.pointer_dereference.\d+\] line 17 dereference failure: deallocated dynamic object in \*x: SUCCESS$
+^\[foo.pointer_dereference.\d+\] line 17 dereference failure: dead object in \*x: SUCCESS$
+^\[foo.pointer_dereference.\d+\] line 17 dereference failure: pointer outside object bounds in \*x: SUCCESS$
+^\[foo.pointer_dereference.\d+\] line 17 dereference failure: invalid integer address in \*x: SUCCESS$
+^\[foo.assertion.\d+\] line 21 assertion 0: FAILURE$
+^\[foo.assertion.\d+\] line 22 assertion x == \(\(.*\)NULL\): SUCCESS$
+^\[foo.assertion.\d+\] line 23 assertion __CPROVER_POINTER_OBJECT\(\(.*\)a\) == __CPROVER_POINTER_OBJECT\(\(.*\)y\): SUCCESS$
+^\[foo.assigns.\d+\] line 24 Check that \*y is assignable: SUCCESS$
+^\[foo.pointer_dereference.\d+\] line 24 dereference failure: pointer NULL in \*y: SUCCESS$
+^\[foo.pointer_dereference.\d+\] line 24 dereference failure: pointer invalid in \*y: SUCCESS$
+^\[foo.pointer_dereference.\d+\] line 24 dereference failure: deallocated dynamic object in \*y: SUCCESS$
+^\[foo.pointer_dereference.\d+\] line 24 dereference failure: dead object in \*y: SUCCESS$
+^\[foo.pointer_dereference.\d+\] line 24 dereference failure: pointer outside object bounds in \*y: SUCCESS$
+^\[foo.pointer_dereference.\d+\] line 24 dereference failure: invalid integer address in \*y: SUCCESS$
+^EXIT=10$
+^SIGNAL=0$
+^VERIFICATION FAILED$
+--
+--
+Illustrates the behaviour of `__CPROVER_pointer_in_range_dfcc` under disjunctions in assume contexts.
+The precondition of `foo` describes a disjunction of cases, either `x` is in range of `a` and `y` is null,
+or `x` is null and `y` is in range of `a`. The function `foo` branches on `y == NULL`.
+The test suceeds if the two `assert(0)` in `foo` are falsifiable, which which shows
+that both cases of the disjunction expressed in the requires clause are reachable.

--- a/regression/contracts-dfcc/test_pointer_in_range_replace_ensures_disjunction_fail/main.c
+++ b/regression/contracts-dfcc/test_pointer_in_range_replace_ensures_disjunction_fail/main.c
@@ -1,0 +1,30 @@
+
+typedef struct
+{
+  int *a;
+  int *x;
+} ret_t;
+
+ret_t foo()
+  // clang-format off
+  __CPROVER_ensures(__CPROVER_is_fresh(__CPROVER_return_value.a, 8*sizeof(int)))
+  __CPROVER_ensures(
+    __CPROVER_pointer_in_range_dfcc(
+      __CPROVER_return_value.a,
+      __CPROVER_return_value.x,
+      __CPROVER_return_value.a + 7
+    ) || 1)
+  // clang-format on
+  ;
+
+void bar()
+{
+  ret_t ret = foo();
+  int *x = ret.x;
+  *x = 0; //expected to fail
+}
+
+void main()
+{
+  bar();
+}

--- a/regression/contracts-dfcc/test_pointer_in_range_replace_ensures_disjunction_fail/test.desc
+++ b/regression/contracts-dfcc/test_pointer_in_range_replace_ensures_disjunction_fail/test.desc
@@ -1,0 +1,17 @@
+CORE dfcc-only
+main.c
+--dfcc main --replace-call-with-contract foo
+^\[bar.pointer_dereference.\d+\] line \d+ dereference failure: pointer NULL in \*x: (UNKNOWN|FAILURE)$
+^\[bar.pointer_dereference.\d+\] line \d+ dereference failure: pointer invalid in \*x: (UNKNOWN|FAILURE)$
+^\[bar.pointer_dereference.\d+\] line \d+ dereference failure: deallocated dynamic object in \*x: (UNKNOWN|FAILURE)$
+^\[bar.pointer_dereference.\d+\] line \d+ dereference failure: dead object in \*x: (UNKNOWN|FAILURE)$
+^\[bar.pointer_dereference.\d+\] line \d+ dereference failure: pointer outside object bounds in \*x: (UNKNOWN|FAILURE)$
+^\[bar.pointer_dereference.\d+\] line \d+ dereference failure: invalid integer address in \*x: (UNKNOWN|FAILURE)$
+^EXIT=10$
+^SIGNAL=0$
+^VERIFICATION FAILED$
+--
+--
+This test checks that when `__CPROVER_pointer_in_range_dfcc` is used in disjunctions,
+the program accepts models where `__CPROVER_pointer_in_range_dfcc` evaluates to
+false and the target pointer remains invalid.

--- a/regression/contracts-dfcc/test_pointer_in_range_replace_ensures_disjunction_pass/main.c
+++ b/regression/contracts-dfcc/test_pointer_in_range_replace_ensures_disjunction_pass/main.c
@@ -1,0 +1,51 @@
+#include <stdlib.h>
+typedef struct
+{
+  int *a;
+  int *x;
+  int *y;
+} ret_t;
+
+ret_t foo()
+  // clang-format off
+  __CPROVER_ensures(__CPROVER_is_fresh(__CPROVER_return_value.a, 8*sizeof(int)))
+  __CPROVER_ensures((
+      __CPROVER_pointer_in_range_dfcc(
+        __CPROVER_return_value.a,
+        __CPROVER_return_value.x,
+        __CPROVER_return_value.a + 7) &&
+      __CPROVER_return_value.y == NULL
+    ) || (
+      __CPROVER_return_value.x == NULL &&
+      __CPROVER_pointer_in_range_dfcc(
+        __CPROVER_return_value.a,
+        __CPROVER_return_value.y,
+        __CPROVER_return_value.a + 7)))
+  // clang-format on
+  ;
+
+void bar()
+{
+  ret_t ret = foo();
+  int *a = ret.a;
+  int *x = ret.x;
+  int *y = ret.y;
+  if(y == NULL)
+  {
+    assert(0);
+    assert(__CPROVER_same_object(x, a));
+    *x = 0;
+  }
+  else
+  {
+    assert(0);
+    assert(x == NULL);
+    assert(__CPROVER_same_object(y, a));
+    *y = 0;
+  }
+}
+
+void main()
+{
+  bar();
+}

--- a/regression/contracts-dfcc/test_pointer_in_range_replace_ensures_disjunction_pass/test.desc
+++ b/regression/contracts-dfcc/test_pointer_in_range_replace_ensures_disjunction_pass/test.desc
@@ -1,0 +1,32 @@
+CORE dfcc-only
+main.c
+--dfcc main --replace-call-with-contract foo
+^\[bar.assertion.\d+\] line 35 assertion 0: FAILURE$
+^\[bar.assertion.\d+\] line 36 assertion __CPROVER_POINTER_OBJECT\(\(.*\)x\) == __CPROVER_POINTER_OBJECT\(\(.*\)a\): SUCCESS$
+^\[bar.assigns.\d+\] line 37 Check that \*x is assignable: SUCCESS$
+^\[bar.pointer_dereference.\d+\] line 37 dereference failure: pointer NULL in \*x: SUCCESS$
+^\[bar.pointer_dereference.\d+\] line 37 dereference failure: pointer invalid in \*x: SUCCESS$
+^\[bar.pointer_dereference.\d+\] line 37 dereference failure: deallocated dynamic object in \*x: SUCCESS$
+^\[bar.pointer_dereference.\d+\] line 37 dereference failure: dead object in \*x: SUCCESS$
+^\[bar.pointer_dereference.\d+\] line 37 dereference failure: pointer outside object bounds in \*x: SUCCESS$
+^\[bar.pointer_dereference.\d+\] line 37 dereference failure: invalid integer address in \*x: SUCCESS$
+^\[bar.assertion.\d+\] line 41 assertion 0: FAILURE$
+^\[bar.assertion.\d+\] line 42 assertion x == \(\(.*\)NULL\): SUCCESS$
+^\[bar.assertion.\d+\] line 43 assertion __CPROVER_POINTER_OBJECT\(\(.*\)y\) == __CPROVER_POINTER_OBJECT\(\(.*\)a\): SUCCESS$
+^\[bar.assigns.\d+\] line 44 Check that \*y is assignable: SUCCESS$
+^\[bar.pointer_dereference.\d+\] line 44 dereference failure: pointer NULL in \*y: SUCCESS$
+^\[bar.pointer_dereference.\d+\] line 44 dereference failure: pointer invalid in \*y: SUCCESS$
+^\[bar.pointer_dereference.\d+\] line 44 dereference failure: deallocated dynamic object in \*y: SUCCESS$
+^\[bar.pointer_dereference.\d+\] line 44 dereference failure: dead object in \*y: SUCCESS$
+^\[bar.pointer_dereference.\d+\] line 44 dereference failure: pointer outside object bounds in \*y: SUCCESS$
+^\[bar.pointer_dereference.\d+\] line 44 dereference failure: invalid integer address in \*y: SUCCESS$
+^EXIT=10$
+^SIGNAL=0$
+^VERIFICATION FAILED$
+--
+--
+Illustrates the behaviour of `__CPROVER_pointer_in_range` under disjunctions in assume contexts.
+The postcondition of `foo` describes a disjunction of cases: either `x` is in range of `a` and `y` is null,
+or `x` is null and `y` is in range of `a`. The function `bar` branches on `y == NULL`.
+The test succeeds if the two `assert(0)` are falsifiable, which which shows that
+both cases of the disjunction expressed in the ensures clause of `foo` are reachable.

--- a/src/ansi-c/c_typecheck_expr.cpp
+++ b/src/ansi-c/c_typecheck_expr.cpp
@@ -2591,7 +2591,19 @@ exprt c_typecheck_baset::do_special_functions(
 
   const irep_idt &identifier=to_symbol_expr(f_op).get_identifier();
 
-  if(identifier == CPROVER_PREFIX "is_fresh")
+  if(identifier == CPROVER_PREFIX "pointer_equals")
+  {
+    if(expr.arguments().size() != 2)
+    {
+      error().source_location = f_op.source_location();
+      error() << CPROVER_PREFIX "pointer_equals expects two operands; "
+              << expr.arguments().size() << "provided." << eom;
+      throw 0;
+    }
+    typecheck_function_call_arguments(expr);
+    return nil_exprt();
+  }
+  else if(identifier == CPROVER_PREFIX "is_fresh")
   {
     if(expr.arguments().size() != 2)
     {

--- a/src/ansi-c/cprover_builtin_headers.h
+++ b/src/ansi-c/cprover_builtin_headers.h
@@ -44,6 +44,7 @@ void __CPROVER_fence(const char *kind, ...);
 // contract-related functions
 __CPROVER_bool __CPROVER_is_freeable(const void *mem);
 __CPROVER_bool __CPROVER_was_freed(const void *mem);
+__CPROVER_bool __CPROVER_pointer_equals(void *p, void *q);
 __CPROVER_bool __CPROVER_is_fresh(const void *mem, __CPROVER_size_t size);
 __CPROVER_bool __CPROVER_obeys_contract(void (*)(void), void (*)(void));
 // same as pointer_in_range with experimental support in contracts

--- a/src/ansi-c/cprover_library.cpp
+++ b/src/ansi-c/cprover_library.cpp
@@ -48,6 +48,10 @@ static std::string get_cprover_library_text(
   if(config.ansi_c.dfcc_debug_lib)
     library_text << "#define " CPROVER_PREFIX "DFCC_DEBUG_LIB\n";
 
+  if(config.ansi_c.simple_invalid_pointer_model)
+    library_text << "#define " CPROVER_PREFIX
+                    "DFCC_SIMPLE_INVALID_POINTER_MODEL\n";
+
   // cprover_library.inc may not have been generated when running Doxygen, thus
   // make Doxygen skip this part
   /// \cond

--- a/src/ansi-c/cprover_library.cpp
+++ b/src/ansi-c/cprover_library.cpp
@@ -45,6 +45,9 @@ static std::string get_cprover_library_text(
   if(config.ansi_c.string_abstraction)
     library_text << "#define " CPROVER_PREFIX "STRING_ABSTRACTION\n";
 
+  if(config.ansi_c.dfcc_debug_lib)
+    library_text << "#define " CPROVER_PREFIX "DFCC_DEBUG_LIB\n";
+
   // cprover_library.inc may not have been generated when running Doxygen, thus
   // make Doxygen skip this part
   /// \cond

--- a/src/ansi-c/library/cprover_contracts.c
+++ b/src/ansi-c/library/cprover_contracts.c
@@ -136,7 +136,7 @@ void __CPROVER_contracts_car_set_create(
   __CPROVER_size_t max_elems)
 {
 __CPROVER_HIDE:;
-#ifdef DFCC_DEBUG
+#ifdef __CPROVER_DFCC_DEBUG_LIB
   __CPROVER_assert(
     __CPROVER_rw_ok(set, sizeof(__CPROVER_contracts_car_set_t)),
     "set writable");
@@ -159,7 +159,7 @@ void __CPROVER_contracts_car_set_insert(
   __CPROVER_size_t size)
 {
 __CPROVER_HIDE:;
-#ifdef DFCC_DEBUG
+#ifdef __CPROVER_DFCC_DEBUG_LIB
   __CPROVER_assert((set != 0) & (idx < set->max_elems), "no OOB access");
 #endif
   __CPROVER_assert(
@@ -239,7 +239,7 @@ void __CPROVER_contracts_obj_set_create_indexed_by_object_id(
   __CPROVER_contracts_obj_set_ptr_t set)
 {
 __CPROVER_HIDE:;
-#ifdef DFCC_DEBUG
+#ifdef __CPROVER_DFCC_DEBUG_LIB
   __CPROVER_assert(
     __CPROVER_rw_ok(set, sizeof(__CPROVER_contracts_obj_set_t)),
     "set writable");
@@ -274,7 +274,7 @@ void __CPROVER_contracts_obj_set_create_append(
   __CPROVER_size_t max_elems)
 {
 __CPROVER_HIDE:;
-#ifdef DFCC_DEBUG
+#ifdef __CPROVER_DFCC_DEBUG_LIB
   __CPROVER_assert(
     __CPROVER_rw_ok(set, sizeof(__CPROVER_contracts_obj_set_t)),
     "set writable");
@@ -292,7 +292,7 @@ __CPROVER_HIDE:;
 void __CPROVER_contracts_obj_set_release(__CPROVER_contracts_obj_set_ptr_t set)
 {
 __CPROVER_HIDE:;
-#ifdef DFCC_DEBUG
+#ifdef __CPROVER_DFCC_DEBUG_LIB
   __CPROVER_assert(
     __CPROVER_rw_ok(set, sizeof(__CPROVER_contracts_obj_set_t)),
     "set readable");
@@ -311,7 +311,7 @@ void __CPROVER_contracts_obj_set_add(
 {
 __CPROVER_HIDE:;
   __CPROVER_size_t object_id = __CPROVER_POINTER_OBJECT(ptr);
-#ifdef DFCC_DEBUG
+#ifdef __CPROVER_DFCC_DEBUG_LIB
   __CPROVER_assert(set->indexed_by_object_id, "indexed by object id");
   __CPROVER_assert(object_id < set->max_elems, "no OOB access");
 #endif
@@ -329,7 +329,7 @@ void __CPROVER_contracts_obj_set_append(
   void *ptr)
 {
 __CPROVER_HIDE:;
-#ifdef DFCC_DEBUG
+#ifdef __CPROVER_DFCC_DEBUG_LIB
   __CPROVER_assert(!(set->indexed_by_object_id), "not indexed by object id");
   __CPROVER_assert(set->watermark < set->max_elems, "no OOB access");
 #endif
@@ -349,7 +349,7 @@ void __CPROVER_contracts_obj_set_remove(
 {
 __CPROVER_HIDE:;
   __CPROVER_size_t object_id = __CPROVER_POINTER_OBJECT(ptr);
-#ifdef DFCC_DEBUG
+#ifdef __CPROVER_DFCC_DEBUG_LIB
   __CPROVER_assert(set->indexed_by_object_id, "indexed by object id");
   __CPROVER_assert(object_id < set->max_elems, "no OOB access");
 #endif
@@ -369,7 +369,7 @@ __CPROVER_bool __CPROVER_contracts_obj_set_contains(
 {
 __CPROVER_HIDE:;
   __CPROVER_size_t object_id = __CPROVER_POINTER_OBJECT(ptr);
-#ifdef DFCC_DEBUG
+#ifdef __CPROVER_DFCC_DEBUG_LIB
   __CPROVER_assert(set->indexed_by_object_id, "indexed by object id");
   __CPROVER_assert(object_id < set->max_elems, "no OOB access");
 #endif
@@ -386,7 +386,7 @@ __CPROVER_bool __CPROVER_contracts_obj_set_contains_exact(
 {
 __CPROVER_HIDE:;
   __CPROVER_size_t object_id = __CPROVER_POINTER_OBJECT(ptr);
-#ifdef DFCC_DEBUG
+#ifdef __CPROVER_DFCC_DEBUG_LIB
   __CPROVER_assert(set->indexed_by_object_id, "indexed by object id");
   __CPROVER_assert(object_id < set->max_elems, "no OOB access");
 #endif
@@ -421,7 +421,7 @@ void __CPROVER_contracts_write_set_create(
   __CPROVER_bool allow_deallocate)
 {
 __CPROVER_HIDE:;
-#ifdef DFCC_DEBUG
+#ifdef __CPROVER_DFCC_DEBUG_LIB
   __CPROVER_assert(
     __CPROVER_w_ok(set, sizeof(__CPROVER_contracts_write_set_t)),
     "set writable");
@@ -450,7 +450,7 @@ void __CPROVER_contracts_write_set_release(
   __CPROVER_contracts_write_set_ptr_t set)
 {
 __CPROVER_HIDE:;
-#ifdef DFCC_DEBUG
+#ifdef __CPROVER_DFCC_DEBUG_LIB
   __CPROVER_assert(
     __CPROVER_rw_ok(set, sizeof(__CPROVER_contracts_write_set_t)),
     "set readable");
@@ -574,7 +574,7 @@ __CPROVER_HIDE:;
 
   // store pointer
   __CPROVER_size_t object_id = __CPROVER_POINTER_OBJECT(ptr);
-#ifdef DFCC_DEBUG
+#ifdef __CPROVER_DFCC_DEBUG_LIB
   // manually inlined below
   __CPROVER_contracts_obj_set_add(&(set->contract_frees), ptr);
   __CPROVER_assert(object_id < set->contract_frees.max_elems, "no OOB access");
@@ -587,7 +587,7 @@ __CPROVER_HIDE:;
 #endif
 
   // append pointer if available
-#ifdef DFCC_DEBUG
+#ifdef __CPROVER_DFCC_DEBUG_LIB
   __CPROVER_contracts_obj_set_append(&(set->contract_frees_append), ptr);
 #else
   set->contract_frees_append.nof_elems = set->contract_frees_append.watermark;
@@ -606,7 +606,7 @@ void __CPROVER_contracts_write_set_add_allocated(
 {
 __CPROVER_HIDE:;
   __CPROVER_assert(set->allow_allocate, "dynamic allocation is allowed");
-#if DFCC_DEBUG
+#if __CPROVER_DFCC_DEBUG_LIB
   // call inlined below
   __CPROVER_contracts_obj_set_add(&(set->allocated), ptr);
 #else
@@ -627,7 +627,7 @@ void __CPROVER_contracts_write_set_add_decl(
   void *ptr)
 {
 __CPROVER_HIDE:;
-#if DFCC_DEBUG
+#if __CPROVER_DFCC_DEBUG_LIB
   // call inlined below
   __CPROVER_contracts_obj_set_add(&(set->allocated), ptr);
 #else
@@ -652,7 +652,7 @@ void __CPROVER_contracts_write_set_record_dead(
   void *ptr)
 {
 __CPROVER_HIDE:;
-#ifdef DFCC_DEBUG
+#ifdef __CPROVER_DFCC_DEBUG_LIB
   // manually inlined below
   __CPROVER_contracts_obj_set_remove(&(set->allocated), ptr);
 #else
@@ -677,7 +677,7 @@ void __CPROVER_contracts_write_set_record_deallocated(
   void *ptr)
 {
 __CPROVER_HIDE:;
-#if DFCC_DEBUG
+#if __CPROVER_DFCC_DEBUG_LIB
   // we record the deallocation to be able to evaluate was_freed post conditions
   __CPROVER_contracts_obj_set_add(&(set->deallocated), ptr);
   __CPROVER_contracts_obj_set_remove(&(set->allocated), ptr);
@@ -745,7 +745,7 @@ __CPROVER_bool __CPROVER_contracts_write_set_check_assignment(
   __CPROVER_contracts_write_set_ptr_t set,
   void *ptr,
   __CPROVER_size_t size)
-#if DFCC_DEBUG
+#if __CPROVER_DFCC_DEBUG_LIB
 // manually inlined below
 {
 __CPROVER_HIDE:;
@@ -926,7 +926,7 @@ __CPROVER_bool __CPROVER_contracts_write_set_check_deallocate(
 __CPROVER_HIDE:;
   __CPROVER_size_t object_id = __CPROVER_POINTER_OBJECT(ptr);
 
-#ifdef DFCC_DEBUG
+#ifdef __CPROVER_DFCC_DEBUG_LIB
   __CPROVER_assert(
     set->contract_frees.indexed_by_object_id,
     "set->contract_frees is indexed by object id");
@@ -984,7 +984,7 @@ __CPROVER_bool __CPROVER_contracts_write_set_check_frees_clause_inclusion(
   __CPROVER_contracts_write_set_ptr_t candidate)
 {
 __CPROVER_HIDE:;
-#ifdef DFCC_DEBUG
+#ifdef __CPROVER_DFCC_DEBUG_LIB
   __CPROVER_assert(
     reference->contract_frees.indexed_by_object_id,
     "reference->contract_frees is indexed by object id");
@@ -1067,7 +1067,7 @@ void __CPROVER_contracts_link_is_fresh(
   __CPROVER_contracts_obj_set_ptr_t is_fresh_set)
 {
 __CPROVER_HIDE:;
-#ifdef DFCC_DEBUG
+#ifdef __CPROVER_DFCC_DEBUG_LIB
   __CPROVER_assert(write_set != 0, "write_set not NULL");
 #endif
   if((is_fresh_set != 0))
@@ -1089,7 +1089,7 @@ void __CPROVER_contracts_link_allocated(
   __CPROVER_contracts_write_set_ptr_t write_set_to_link)
 {
 __CPROVER_HIDE:;
-#ifdef DFCC_DEBUG
+#ifdef __CPROVER_DFCC_DEBUG_LIB
   __CPROVER_assert(
     write_set_postconditions != 0, "write_set_postconditions not NULL");
 #endif
@@ -1114,7 +1114,7 @@ void __CPROVER_contracts_link_deallocated(
   __CPROVER_contracts_write_set_ptr_t write_set_to_link)
 {
 __CPROVER_HIDE:;
-#ifdef DFCC_DEBUG
+#ifdef __CPROVER_DFCC_DEBUG_LIB
   __CPROVER_assert(
     write_set_postconditions != 0, "write_set_postconditions not NULL");
 #endif
@@ -1168,7 +1168,7 @@ __CPROVER_HIDE:;
                         (write_set->assume_ensures_ctx == 1) |
                         (write_set->assert_ensures_ctx == 1)),
     "__CPROVER_is_fresh is used only in requires or ensures clauses");
-#ifdef DFCC_DEBUG
+#ifdef __CPROVER_DFCC_DEBUG_LIB
   __CPROVER_assert(
     __CPROVER_rw_ok(write_set, sizeof(__CPROVER_contracts_write_set_t)),
     "set readable");
@@ -1177,7 +1177,7 @@ __CPROVER_HIDE:;
 #endif
   if(write_set->assume_requires_ctx)
   {
-#ifdef DFCC_DEBUG
+#ifdef __CPROVER_DFCC_DEBUG_LIB
     __CPROVER_assert(
       (write_set->assert_requires_ctx == 0) &
         (write_set->assume_ensures_ctx == 0) &
@@ -1219,7 +1219,7 @@ __CPROVER_HIDE:;
     // __CPROVER_memory_leak = record_may_leak ? ptr : __CPROVER_memory_leak;
 
     // record fresh object in the object set
-#ifdef DFCC_DEBUG
+#ifdef __CPROVER_DFCC_DEBUG_LIB
     // manually inlined below
     __CPROVER_contracts_obj_set_add(write_set->linked_is_fresh, ptr);
 #else
@@ -1235,7 +1235,7 @@ __CPROVER_HIDE:;
   }
   else if(write_set->assume_ensures_ctx)
   {
-#ifdef DFCC_DEBUG
+#ifdef __CPROVER_DFCC_DEBUG_LIB
     __CPROVER_assert(
       (write_set->assume_requires_ctx == 0) &
         (write_set->assert_requires_ctx == 0) &
@@ -1274,7 +1274,7 @@ __CPROVER_HIDE:;
     __CPROVER_memory_leak = record_may_leak ? ptr : __CPROVER_memory_leak;
 
     // record fresh object in the caller's write set
-#ifdef DFCC_DEBUG
+#ifdef __CPROVER_DFCC_DEBUG_LIB
     __CPROVER_contracts_obj_set_add(write_set->linked_allocated, ptr);
 #else
     __CPROVER_size_t object_id = __CPROVER_POINTER_OBJECT(ptr);
@@ -1289,7 +1289,7 @@ __CPROVER_HIDE:;
   }
   else if(write_set->assert_requires_ctx | write_set->assert_ensures_ctx)
   {
-#ifdef DFCC_DEBUG
+#ifdef __CPROVER_DFCC_DEBUG_LIB
     __CPROVER_assert(
       (write_set->assume_requires_ctx == 0) &
         (write_set->assume_ensures_ctx == 0),
@@ -1298,7 +1298,7 @@ __CPROVER_HIDE:;
     __CPROVER_contracts_obj_set_ptr_t seen = write_set->linked_is_fresh;
     void *ptr = *elem;
     // null pointers or already seen pointers are not fresh
-#ifdef DFCC_DEBUG
+#ifdef __CPROVER_DFCC_DEBUG_LIB
     // manually inlined below
     if((ptr == 0) || (__CPROVER_contracts_obj_set_contains(seen, ptr)))
       return 0;
@@ -1312,7 +1312,7 @@ __CPROVER_HIDE:;
       return 0;
 #endif
       // record fresh object in the object set
-#ifdef DFCC_DEBUG
+#ifdef __CPROVER_DFCC_DEBUG_LIB
     // manually inlined below
     __CPROVER_contracts_obj_set_add(seen, ptr);
 #else
@@ -1385,7 +1385,7 @@ void *__CPROVER_contracts_write_set_havoc_get_assignable_target(
   __CPROVER_size_t idx)
 {
 __CPROVER_HIDE:;
-#ifdef DFCC_DEBUG
+#ifdef __CPROVER_DFCC_DEBUG_LIB
   __CPROVER_assert(write_set != 0, "write_set not NULL");
 #endif
 
@@ -1417,7 +1417,7 @@ void __CPROVER_contracts_write_set_havoc_slice(
   __CPROVER_size_t idx)
 {
 __CPROVER_HIDE:;
-#ifdef DFCC_DEBUG
+#ifdef __CPROVER_DFCC_DEBUG_LIB
   __CPROVER_assert(idx < set->contract_assigns.max_elems, "no OOB access");
 #endif
   __CPROVER_contracts_car_t car = set->contract_assigns.elems[idx];
@@ -1478,7 +1478,7 @@ __CPROVER_HIDE:;
     "__CPROVER_was_freed is used only in ensures clauses");
   __CPROVER_assert(
     (set->linked_deallocated != 0), "linked_deallocated is not null");
-#ifdef DFCC_DEBUG
+#ifdef __CPROVER_DFCC_DEBUG_LIB
   // manually inlined below
   return __CPROVER_contracts_obj_set_contains_exact(
     set->linked_deallocated, ptr);
@@ -1504,7 +1504,7 @@ __CPROVER_HIDE:;
 
   if(set->assume_ensures_ctx)
   {
-#ifdef DFCC_DEBUG
+#ifdef __CPROVER_DFCC_DEBUG_LIB
     // manually inlined below
     __CPROVER_assert(
       __CPROVER_contracts_obj_set_contains_exact(&(set->contract_frees), ptr),

--- a/src/goto-instrument/Makefile
+++ b/src/goto-instrument/Makefile
@@ -29,6 +29,7 @@ SRC = accelerate/accelerate.cpp \
       contracts/dynamic-frames/dfcc_instrument_loop.cpp \
       contracts/dynamic-frames/dfcc_library.cpp \
       contracts/dynamic-frames/dfcc_is_cprover_symbol.cpp \
+      contracts/dynamic-frames/dfcc_pointer_equals.cpp \
       contracts/dynamic-frames/dfcc_is_fresh.cpp \
       contracts/dynamic-frames/dfcc_pointer_in_range.cpp \
       contracts/dynamic-frames/dfcc_is_freeable.cpp \

--- a/src/goto-instrument/contracts/doc/developer/contracts-dev-arch.md
+++ b/src/goto-instrument/contracts/doc/developer/contracts-dev-arch.md
@@ -29,6 +29,7 @@ Each of these translation passes is implemented in a specific class:
  @ref dfcc_instrumentt           | Implements @ref contracts-dev-spec-dfcc for @ref goto_functiont, @ref goto_programt, or subsequences of instructions of @ref goto_programt
  @ref dfcc_is_fresht             | Implements @ref contracts-dev-spec-is-fresh
  @ref dfcc_pointer_in_ranget     | Implements @ref contracts-dev-spec-pointer-in-range
+ @ref dfcc_pointer_equalst       | Implements @ref contracts-dev-spec-pointer-equals
  @ref dfcc_lift_memory_predicatest | Implements @ref contracts-dev-spec-memory-predicates-rewriting
  @ref dfcc_is_freeablet          | Implements @ref contracts-dev-spec-is-freeable
  @ref dfcc_obeys_contractt       | Implements @ref contracts-dev-spec-obeys-contract

--- a/src/goto-instrument/contracts/doc/developer/contracts-dev-spec-dfcc-instrument.md
+++ b/src/goto-instrument/contracts/doc/developer/contracts-dev-spec-dfcc-instrument.md
@@ -174,6 +174,9 @@ Calls to `__CPROVER_obeys_contract` are rewritten as described in
 Calls to `__CPROVER_pointer_in_range_dfcc` are rewritten as described in
 @subpage contracts-dev-spec-pointer-in-range
 
+Calls to `__CPROVER_pointer_equals` are rewritten as described in
+@subpage contracts-dev-spec-pointer-equals
+
 For all other function or function pointer calls, we proceed as follows.
 
 If the function call has an LHS (i.e. its result is assigned to a return value

--- a/src/goto-instrument/contracts/doc/developer/contracts-dev-spec-memory-predicates-rewriting.md
+++ b/src/goto-instrument/contracts/doc/developer/contracts-dev-spec-memory-predicates-rewriting.md
@@ -8,6 +8,9 @@ The C extensions for contract specification provide three pointer-related memory
 predicates:
 
 ```c
+// Holds iff ptr1 and ptr2 are both either null or valid and are equal.
+__CPROVER_bool __CPROVER_pointer_equals(void *ptr1, void* ptr2);
+
 // Holds iff ptr is pointing to an object distinct to all objects pointed to by
 // other __CPROVER_is_fresh occurrences in the contract's pre and post conditions
 __CPROVER_bool __CPROVER_is_fresh(void *ptr, size_t size);

--- a/src/goto-instrument/contracts/doc/developer/contracts-dev-spec-pointer-equals.md
+++ b/src/goto-instrument/contracts/doc/developer/contracts-dev-spec-pointer-equals.md
@@ -1,4 +1,4 @@
-# Rewriting Calls to the __CPROVER_pointer_in_range_dfcc Predicate {#contracts-dev-spec-pointer-in-range}
+# Rewriting Calls to the __CPROVER_pointer_equals Predicate {#contracts-dev-spec-pointer-equals}
 
 Back to top @ref contracts-dev-spec
 
@@ -6,21 +6,20 @@ Back to top @ref contracts-dev-spec
 
 In goto programs encoding pre or post conditions (generated from the contract
 clauses) and in all user-defined functions, we simply replace calls to
-`__CPROVER_pointer_in_range_dfcc` with calls to the library implementation.
+`__CPROVER_pointer_equals` with calls to the library implementation.
 
 ```c
-__CPROVER_pointer_in_range_dfcc(
-    void *lb,
-    void **ptr,
-    void *ub,
+__CPROVER_contracts_pointer_equals(
+    void **ptr1,
+    void *ptr2,
     __CPROVER_contracts_write_set_ptr_t write_set);
 ```
 
-This function implements the `__CPROVER_pointer_in_range_dfcc` behaviour in all
+This function implements the `__CPROVER_pointer_equals` behaviour in all
 possible contexts (contract checking vs replacement, requires vs ensures clause
 context, as described by the flags carried by the write set parameter).
 
 ---
  Prev | Next
 :-----|:------
- @ref contracts-dev | @ref contracts-dev-spec-pointer-equals
+ @ref contracts-dev | @ref contracts-dev-spec-reminder

--- a/src/goto-instrument/contracts/doc/user/contracts-memory-predicates.md
+++ b/src/goto-instrument/contracts/doc/user/contracts-memory-predicates.md
@@ -9,6 +9,49 @@ let users describe the shape of the memory accessed through pointers in
 _requires clauses_ and _ensures clauses_. Attempting to call these predicates
 outside of a requires or ensures clause context will result in a verification
 error.
+
+## The __CPROVER_pointer_equals predicate
+### Syntax
+
+```c
+bool __CPROVER_pointer_equals(void *p, void *q);
+```
+This predicate can only be used in ensures and requires clauses and checks for
+pointer validity and equality.
+
+#### Parameters
+
+`__CPROVER_pointer_equals` takes two pointers as arguments.
+
+#### Return Value
+
+It returns a `bool` value:
+- `true` iff pointers are both null or valid and are equal,
+- `false` otherwise.
+
+### Semantics
+
+#### Enforcement
+
+When checking a contract using `--enforce-contract foo`:
+- used in a _requires_ clause, the predicate will check that `ptr2` is always
+  either null or valid, and it will make `ptr1` equal to `ptr2`.
+  This results in a state resulting in a state where both pointers are either
+  null or valid and equal;
+- used in an _ensures_ clause it will check that memory both pointers are always
+  either null or valid and equal.
+
+#### Replacement
+
+When checking a contract using `--replace-call-with-contract foo`, we get the
+dual behaviour:
+- used in a _requires_ clause it will check that memory both pointers are always
+  either null or valid and equal,
+- used in an _ensures_ clause, the predicate will check that `ptr2` is always
+  either null or valid, and it will make `ptr1` equal to `ptr2`.
+  This results in a state resulting in a state where both pointers are either
+  null or valid and equal.
+
 ## The __CPROVER_is_fresh predicate
 ### Syntax
 

--- a/src/goto-instrument/contracts/dynamic-frames/dfcc_instrument.cpp
+++ b/src/goto-instrument/contracts/dynamic-frames/dfcc_instrument.cpp
@@ -37,6 +37,7 @@ Author: Remi Delmas, delmarsd@amazon.com
 #include "dfcc_is_fresh.h"
 #include "dfcc_library.h"
 #include "dfcc_obeys_contract.h"
+#include "dfcc_pointer_equals.h"
 #include "dfcc_pointer_in_range.h"
 #include "dfcc_spec_functions.h"
 #include "dfcc_utils.h"
@@ -525,6 +526,11 @@ void dfcc_instrumentt::instrument_instructions(
   dfcc_cfg_infot &cfg_info,
   std::set<irep_idt> &function_pointer_contracts)
 {
+  // rewrite pointer_equals calls
+  dfcc_pointer_equalst pointer_equals(library, message_handler);
+  pointer_equals.rewrite_calls(
+    goto_program, first_instruction, last_instruction, cfg_info);
+
   // rewrite pointer_in_range calls
   dfcc_pointer_in_ranget pointer_in_range(library, message_handler);
   pointer_in_range.rewrite_calls(

--- a/src/goto-instrument/contracts/dynamic-frames/dfcc_instrument_loop.cpp
+++ b/src/goto-instrument/contracts/dynamic-frames/dfcc_instrument_loop.cpp
@@ -121,6 +121,7 @@ void dfcc_instrument_loopt::operator()(
     function_id,
     write_set_populate_instrs,
     loop.addr_of_write_set_var,
+    dfcc_ptr_havoc_modet::NONDET,
     havoc_instrs,
     nof_targets);
   spec_functions.to_spec_assigns_instructions(

--- a/src/goto-instrument/contracts/dynamic-frames/dfcc_is_cprover_symbol.cpp
+++ b/src/goto-instrument/contracts/dynamic-frames/dfcc_is_cprover_symbol.cpp
@@ -53,6 +53,7 @@ init_function_symbols(std::unordered_set<irep_idt> &function_symbols)
                             "contracts_obj_set_create_indexed_by_object_id");
     function_symbols.insert(CPROVER_PREFIX "contracts_obj_set_release");
     function_symbols.insert(CPROVER_PREFIX "contracts_obj_set_remove");
+    function_symbols.insert(CPROVER_PREFIX "contracts_pointer_equals");
     function_symbols.insert(CPROVER_PREFIX "contracts_pointer_in_range_dfcc");
     function_symbols.insert(CPROVER_PREFIX "contracts_was_freed");
     function_symbols.insert(CPROVER_PREFIX "contracts_write_set_add_allocated");

--- a/src/goto-instrument/contracts/dynamic-frames/dfcc_library.cpp
+++ b/src/goto-instrument/contracts/dynamic-frames/dfcc_library.cpp
@@ -125,6 +125,7 @@ const std::map<dfcc_funt, irep_idt> create_dfcc_fun_to_name()
     {dfcc_funt::LINK_IS_FRESH, CONTRACTS_PREFIX "link_is_fresh"},
     {dfcc_funt::LINK_ALLOCATED, CONTRACTS_PREFIX "link_allocated"},
     {dfcc_funt::LINK_DEALLOCATED, CONTRACTS_PREFIX "link_deallocated"},
+    {dfcc_funt::POINTER_EQUALS, CONTRACTS_PREFIX "pointer_equals"},
     {dfcc_funt::IS_FRESH, CONTRACTS_PREFIX "is_fresh"},
     {dfcc_funt::POINTER_IN_RANGE_DFCC,
      CONTRACTS_PREFIX "pointer_in_range_dfcc"},

--- a/src/goto-instrument/contracts/dynamic-frames/dfcc_library.h
+++ b/src/goto-instrument/contracts/dynamic-frames/dfcc_library.h
@@ -126,6 +126,8 @@ enum class dfcc_funt
   LINK_ALLOCATED,
   /// \see __CPROVER_contracts_link_deallocated
   LINK_DEALLOCATED,
+  /// \see __CPROVER_contracts_pointer_equals
+  POINTER_EQUALS,
   /// \see __CPROVER_contracts_is_fresh
   IS_FRESH,
   /// \see __CPROVER_contracts_pointer_in_range_dfcc

--- a/src/goto-instrument/contracts/dynamic-frames/dfcc_lift_memory_predicates.cpp
+++ b/src/goto-instrument/contracts/dynamic-frames/dfcc_lift_memory_predicates.cpp
@@ -7,6 +7,10 @@ Date: August 2022
 
 \*******************************************************************/
 
+// TODO when scanning the goto functions to detect pointer predicates,
+// replace pointer equality p == q with __CPROVER_pointer_equals(p,q)
+// in all user-defined memory predicates.
+
 #include "dfcc_lift_memory_predicates.h"
 
 #include <util/cprover_prefix.h>
@@ -44,7 +48,8 @@ bool dfcc_lift_memory_predicatest::is_lifted_function(
 /// True iff function_id is a core memory predicate
 static bool is_core_memory_predicate(const irep_idt &function_id)
 {
-  return (function_id == CPROVER_PREFIX "is_fresh") ||
+  return (function_id == CPROVER_PREFIX "pointer_equals") ||
+         (function_id == CPROVER_PREFIX "is_fresh") ||
          (function_id == CPROVER_PREFIX "pointer_in_range_dfcc") ||
          (function_id == CPROVER_PREFIX "obeys_contract");
 }
@@ -231,7 +236,15 @@ void dfcc_lift_memory_predicatest::collect_parameters_to_lift(
     {
       const irep_idt &callee_id =
         to_symbol_expr(it.call_function()).get_identifier();
-      if(callee_id == CPROVER_PREFIX "is_fresh")
+      if(callee_id == CPROVER_PREFIX "pointer_equals")
+      {
+        auto opt_rank = is_param_expr(it.call_arguments()[0], parameter_rank);
+        if(opt_rank.has_value())
+        {
+          lifted_parameters[function_id].insert(opt_rank.value());
+        }
+      }
+      else if(callee_id == CPROVER_PREFIX "is_fresh")
       {
         auto opt_rank = is_param_expr(it.call_arguments()[0], parameter_rank);
         if(opt_rank.has_value())

--- a/src/goto-instrument/contracts/dynamic-frames/dfcc_pointer_equals.cpp
+++ b/src/goto-instrument/contracts/dynamic-frames/dfcc_pointer_equals.cpp
@@ -1,0 +1,145 @@
+/*******************************************************************\
+
+Module: Dynamic frame condition checking for function contracts
+
+Author: Remi Delmas, delmasrd@amazon.com
+Date: Jan 2025
+
+\*******************************************************************/
+
+#include "dfcc_pointer_equals.h"
+
+#include <util/c_types.h>
+#include <util/cprover_prefix.h>
+#include <util/expr_iterator.h>
+#include <util/pointer_expr.h>
+#include <util/replace_expr.h>
+#include <util/std_code.h>
+#include <util/std_expr.h>
+#include <util/symbol.h>
+
+#include "dfcc_cfg_info.h"
+#include "dfcc_library.h"
+
+dfcc_pointer_equalst::dfcc_pointer_equalst(
+  dfcc_libraryt &library,
+  message_handlert &message_handler)
+  : library(library), message_handler(message_handler), log(message_handler)
+{
+}
+
+void dfcc_pointer_equalst::rewrite_calls(
+  goto_programt &program,
+  dfcc_cfg_infot cfg_info)
+{
+  rewrite_calls(
+    program,
+    program.instructions.begin(),
+    program.instructions.end(),
+    cfg_info);
+}
+
+void dfcc_pointer_equalst::rewrite_calls(
+  goto_programt &program,
+  goto_programt::targett first_instruction,
+  const goto_programt::targett &last_instruction,
+  dfcc_cfg_infot cfg_info)
+{
+  auto &target = first_instruction;
+  while(target != last_instruction)
+  {
+    if(target->is_function_call())
+    {
+      const auto &function = target->call_function();
+
+      if(function.id() == ID_symbol)
+      {
+        const irep_idt &fun_name = to_symbol_expr(function).get_identifier();
+
+        if(fun_name == CPROVER_PREFIX "pointer_equals")
+        {
+          // add address on first operand
+          target->call_arguments()[0] =
+            address_of_exprt(target->call_arguments()[0]);
+
+          // fix the function name.
+          to_symbol_expr(target->call_function())
+            .set_identifier(
+              library.dfcc_fun_symbol[dfcc_funt::POINTER_EQUALS].name);
+
+          // pass the write_set
+          target->call_arguments().push_back(cfg_info.get_write_set(target));
+        }
+      }
+    }
+    target++;
+  }
+}
+
+class pointer_equality_visitort : public expr_visitort
+{
+private:
+  std::vector<exprt *> equality_exprs_to_transform;
+
+public:
+  void visit_expr(exprt &expr)
+  {
+    if(expr.id() == ID_equal)
+    {
+      const equal_exprt &equal_expr = to_equal_expr(expr);
+
+      // Check if both operands are pointers
+      if(
+        equal_expr.lhs().type().id() == ID_pointer &&
+        equal_expr.rhs().type().id() == ID_pointer)
+      {
+        equality_exprs_to_transform.push_back(&expr);
+      }
+    }
+  }
+
+  // Apply the transformations after visiting
+  void transform()
+  {
+    const code_typet pointer_equals_type(
+      {code_typet::parametert(pointer_type(void_type())),
+       code_typet::parametert(pointer_type(void_type()))},
+      bool_typet());
+
+    symbol_exprt pointer_equals("ID_pointer_equals", pointer_equals_type);
+
+    for(exprt *expr_ptr : equality_exprs_to_transform)
+    {
+      const equal_exprt &equal_expr = to_equal_expr(*expr_ptr);
+
+      // Create the function call to __CPROVER_pointer_equals
+      // Add the original equality operands as arguments
+      side_effect_expr_function_callt result(
+        pointer_equals,
+        {equal_expr.lhs(), equal_expr.rhs()},
+        bool_typet(),
+        equal_expr.source_location());
+
+      result.arguments().push_back(equal_expr.lhs());
+      result.arguments().push_back(equal_expr.rhs());
+
+      // Set the type of the function call
+      result.type() = bool_typet();
+
+      // Replace the original expression
+      *expr_ptr = result;
+    }
+  }
+};
+
+// Usage function
+void rewrite_equal_exprt_to_pointer_equals(exprt &expr)
+{
+  pointer_equality_visitort visitor;
+
+  // First collect all equality expressions
+  expr.visit(visitor);
+
+  // Then transform them
+  visitor.transform();
+}

--- a/src/goto-instrument/contracts/dynamic-frames/dfcc_pointer_equals.h
+++ b/src/goto-instrument/contracts/dynamic-frames/dfcc_pointer_equals.h
@@ -1,0 +1,65 @@
+/*******************************************************************\
+
+Module: Dynamic frame condition checking for function contracts
+
+Author: Remi Delmas, delmasrd@amazon.com
+Date: Jan 2025
+
+\*******************************************************************/
+
+/// \file
+/// Instruments occurrences of pointer_equals predicates in programs
+/// encoding requires and ensures clauses of contracts.
+
+#ifndef CPROVER_GOTO_INSTRUMENT_CONTRACTS_DYNAMIC_FRAMES_DFCC_POINTER_EQUALS_H
+#define CPROVER_GOTO_INSTRUMENT_CONTRACTS_DYNAMIC_FRAMES_DFCC_POINTER_EQUALS_H
+
+#include <util/message.h>
+
+#include <goto-programs/goto_program.h>
+
+class goto_modelt;
+class message_handlert;
+class dfcc_libraryt;
+class dfcc_cfg_infot;
+class exprt;
+
+/// Rewrites `equal_exprt` over pointers into calls
+/// to the front-end function `__CPROVER_pointer_equals`,
+/// at the expression level. Meant to be Applied before GOTO conversion
+/// of function contract clauses, followed by `rewrite_calls`.
+void rewrite_equal_exprt_to_pointer_equals(exprt &expr);
+
+/// Rewrites calls to pointer_equals predicates into calls
+/// to the library implementation.
+class dfcc_pointer_equalst
+{
+public:
+  /// \param library The contracts instrumentation library
+  /// \param message_handler Used for messages
+  dfcc_pointer_equalst(
+    dfcc_libraryt &library,
+    message_handlert &message_handler);
+
+  /// Rewrites calls to pointer_equals predicates into calls
+  /// to the library implementation in the given program, passing the
+  /// given write_set expression as parameter to the library function.
+  void rewrite_calls(goto_programt &program, dfcc_cfg_infot cfg_info);
+
+  /// Rewrites calls to pointer_equals predicates into calls
+  /// to the library implementation in the given program between
+  /// first_instruction (included) and last_instruction (excluded), passing the
+  /// given write_set expression as parameter to the library function.
+  void rewrite_calls(
+    goto_programt &program,
+    goto_programt::targett first_instruction,
+    const goto_programt::targett &last_instruction,
+    dfcc_cfg_infot cfg_info);
+
+protected:
+  dfcc_libraryt &library;
+  message_handlert &message_handler;
+  messaget log;
+};
+
+#endif

--- a/src/goto-instrument/contracts/dynamic-frames/dfcc_spec_functions.h
+++ b/src/goto-instrument/contracts/dynamic-frames/dfcc_spec_functions.h
@@ -32,6 +32,19 @@ class message_handlert;
 class symbolt;
 class conditional_target_group_exprt;
 
+/// \brief Represents the different ways to havoc pointers.
+///
+/// Remark:
+/// - Function contracts use invalid
+/// - Loop contracts use nondet
+enum class dfcc_ptr_havoc_modet
+{
+  /// havocs the pointer to an invalid pointer
+  INVALID,
+  /// havocs the pointer to an nondet pointer
+  NONDET
+};
+
 /// This class rewrites GOTO functions that use the built-ins:
 /// - `__CPROVER_assignable`,
 /// - `__CPROVER_object_whole`,
@@ -48,6 +61,9 @@ public:
     message_handlert &message_handler,
     dfcc_libraryt &library);
 
+  /// Generates the havoc function for a function contract.
+  /// Pointer-typed targets are turned into invalid pointers by the havoc.
+  ///
   /// From a function:
   ///
   /// ```
@@ -62,10 +78,9 @@ public:
   ///
   /// Which havocs the targets specified by `function_id`, passed
   ///
-  /// \param function_id function to generate instructions from
-  /// \param havoc_function_id write set variable to havoc
-  /// \param nof_targets maximum number of targets to havoc
-  ///
+  /// \param[in] function_id function to generate instructions from
+  /// \param[in] havoc_function_id write set variable to havoc
+  /// \param[out] nof_targets maximum number of targets to havoc
   void generate_havoc_function(
     const irep_idt &function_id,
     const irep_idt &havoc_function_id,
@@ -89,13 +104,14 @@ public:
   /// \param[in] function_id function id to use for prefixing fresh variables
   /// \param[in] original_program program from which to derive the havoc program
   /// \param[in] write_set_to_havoc write set symbol to havoc
+  /// \param[in] ptr_havoc_mode havocing mode for pointers
   /// \param[out] havoc_program destination program for havoc instructions
   /// \param[out] nof_targets max number of havoc targets discovered
-  ///
   void generate_havoc_instructions(
     const irep_idt &function_id,
     const goto_programt &original_program,
     const exprt &write_set_to_havoc,
+    dfcc_ptr_havoc_modet ptr_havoc_mode,
     goto_programt &havoc_program,
     std::size_t &nof_targets);
 

--- a/src/goto-instrument/contracts/dynamic-frames/dfcc_wrapper_program.cpp
+++ b/src/goto-instrument/contracts/dynamic-frames/dfcc_wrapper_program.cpp
@@ -27,6 +27,7 @@ Author: Remi Delmas, delmasrd@amazon.com
 #include "dfcc_instrument.h"
 #include "dfcc_library.h"
 #include "dfcc_lift_memory_predicates.h"
+#include "dfcc_pointer_equals.h"
 #include "dfcc_utils.h"
 
 /// Generate the contract write set
@@ -563,6 +564,8 @@ void dfcc_wrapper_programt::encode_requires_clauses()
         "Check requires clause of contract " + id2string(contract_symbol.name) +
         " for function " + id2string(wrapper_id));
     }
+    // // rewrite pointer equalities before goto conversion
+    // TODO rewrite_equal_exprt_to_pointer_equals(requires_lmbd);
     codet requires_statement(statement_type, {std::move(requires_lmbd)}, sl);
     converter.goto_convert(requires_statement, requires_program, language_mode);
   }
@@ -614,7 +617,8 @@ void dfcc_wrapper_programt::encode_ensures_clauses()
         "Check ensures clause of contract " + id2string(contract_symbol.name) +
         " for function " + id2string(wrapper_id));
     }
-
+    // // rewrite pointer equalities before goto conversion
+    // TODO rewrite_equal_exprt_to_pointer_equals(ensures);
     codet ensures_statement(statement_type, {std::move(ensures)}, sl);
     converter.goto_convert(ensures_statement, ensures_program, language_mode);
   }

--- a/src/util/config.cpp
+++ b/src/util/config.cpp
@@ -1169,6 +1169,11 @@ bool configt::set(const cmdlinet &cmdline)
   else
     ansi_c.dfcc_debug_lib = false;
 
+  if(cmdline.isset("dfcc-simple-invalid-pointer-model"))
+    ansi_c.simple_invalid_pointer_model = true;
+  else
+    ansi_c.simple_invalid_pointer_model = false;
+
   if(cmdline.isset("no-library"))
     ansi_c.lib=configt::ansi_ct::libt::LIB_NONE;
 

--- a/src/util/config.cpp
+++ b/src/util/config.cpp
@@ -1164,6 +1164,11 @@ bool configt::set(const cmdlinet &cmdline)
   else
     ansi_c.string_abstraction=false;
 
+  if(cmdline.isset("dfcc-debug-lib"))
+    ansi_c.dfcc_debug_lib = true;
+  else
+    ansi_c.dfcc_debug_lib = false;
+
   if(cmdline.isset("no-library"))
     ansi_c.lib=configt::ansi_ct::libt::LIB_NONE;
 

--- a/src/util/config.h
+++ b/src/util/config.h
@@ -72,7 +72,8 @@ class symbol_table_baset;
 #define OPT_CONFIG_LIBRARY                                                     \
   "(malloc-fail-assert)(malloc-fail-null)(malloc-may-fail)"                    \
   "(no-malloc-may-fail)"                                                       \
-  "(string-abstraction)"
+  "(string-abstraction)"                                                       \
+  "(dfcc-debug-lib)"
 
 #define HELP_CONFIG_LIBRARY                                                    \
   " {y--malloc-may-fail} \t allow malloc calls to return a null pointer\n"     \
@@ -80,7 +81,9 @@ class symbol_table_baset;
   " {y--malloc-fail-assert} \t "                                               \
   "set malloc failure mode to assert-then-assume\n"                            \
   " {y--malloc-fail-null} \t set malloc failure mode to return null\n"         \
-  " {y--string-abstraction} \t track C string lengths and zero-termination\n"
+  " {y--string-abstraction} \t track C string lengths and zero-termination\n"  \
+  " {y--dfcc-debug-lib} \t enable debug assertions in the cprover contracts "  \
+  "library\n"
 
 #define OPT_CONFIG_JAVA "(classpath)(cp)(main-class)"
 
@@ -281,6 +284,10 @@ public:
 
     bool string_abstraction;
     bool malloc_may_fail = true;
+
+    /// enable debug code in cprover_contracts library
+    bool dfcc_debug_lib = false;
+
 
     enum malloc_failure_modet
     {

--- a/src/util/config.h
+++ b/src/util/config.h
@@ -73,7 +73,8 @@ class symbol_table_baset;
   "(malloc-fail-assert)(malloc-fail-null)(malloc-may-fail)"                    \
   "(no-malloc-may-fail)"                                                       \
   "(string-abstraction)"                                                       \
-  "(dfcc-debug-lib)"
+  "(dfcc-debug-lib)"                                                           \
+  "(dfcc-simple-invalid-pointer-model)"
 
 #define HELP_CONFIG_LIBRARY                                                    \
   " {y--malloc-may-fail} \t allow malloc calls to return a null pointer\n"     \
@@ -83,7 +84,9 @@ class symbol_table_baset;
   " {y--malloc-fail-null} \t set malloc failure mode to return null\n"         \
   " {y--string-abstraction} \t track C string lengths and zero-termination\n"  \
   " {y--dfcc-debug-lib} \t enable debug assertions in the cprover contracts "  \
-  "library\n"
+  "library\n"                                                                  \
+  " {y--dfcc-simple-invalid-pointer-model} \t use simplified invalid pointer " \
+  "model in the cprover contracts library (faster, unsound)\n"
 
 #define OPT_CONFIG_JAVA "(classpath)(cp)(main-class)"
 
@@ -288,6 +291,8 @@ public:
     /// enable debug code in cprover_contracts library
     bool dfcc_debug_lib = false;
 
+    /// use simplified invalid pointer model in cprover_contracts library
+    bool simple_invalid_pointer_model = false;
 
     enum malloc_failure_modet
     {


### PR DESCRIPTION
# The problem

The soundness problem was reported in issue https://github.com/diffblue/cbmc/issues/8560.

When used in an assumption context (i.e. requires clause in contract checking mode, or ensures clause in contract replacement mode), the predicate always succeeds and allocates a fresh object, which can mask other cases of a disjunction. 

This function takes a pointer that can be either valid, or invalid:
```C
void foo(char *p)
requires(__is_fresh(p, size) || true)
assigns(p!=null: __object_from(p))
{
   if (!p) {
     assert(false); // unreachable
   }
}
```
The precondition uses a disjunction to specify both cases:
- The predicate `is_fresh(p,size)` always succeeds in the left disjunct and short-circuits the right disjunct.
- The `assert(false)` in the body of foo is unreachable, whereas it would be reachable in a real execution where the left disjunct does not hold.
- This is a soundness issue because the set of states described by the precondition was (unintentionally) under-approximated. 

# Summary of the fixes

The fix restores soundness by ensuring that both true and false outcomes are always possible for all basic memory predicates and their combinations under short cutting operators ==>, && , ||. 

We also introduce a new predicate `__CPROVER_pointer_equals(p, q)` as a replacement for `p == q` for pointer equality.
It serves as a hook to let us override the behaviour of pointer equality in assume contexts to make it constructive (ie. assign right hand side to left hand side).

With each basic predicate, the `false` outcome yields an invalid pointer with an empty value set and a nondeterministic bit pattern. This ensures that:
- In outcomes where some pointer predicates are positively assumed, the target pointers are by construction either null or valid pointers.
- when no pointer predicate is positively enforced via an requires clause under --enforce-contract (or via an ensures clause under --replace-call-with-contract, downstream GOTO instructions cannot use the pointer (checking an assertion, dereferencing, performing offset arithmetic) without triggering a verification error. 

Last, when replacing a function call by its contract abstraction, instead of making pointers fully nondeterministic like we used to do, we now make them invalid. We rely on the ensures clause evaluated in "assume" mode, to construct a null or valid pointer satisfying the post condition. 

This helps solving a major performance degradation due to an explosion of the value set with the built-in pointer havoc of CBMC (see next section).

# Performance impact of the fix

Reintroducing nondeterminism impacts performance negatively in some cases (specially with quantifiers).

The invalid pointers introduced by `false` exit path for pointer predicates enter the value set of the pointers, and remain there even if the `true` exit path  is forced via an assume (the assumption enters the path condition but does not prune the pointers value sets, which is what CBMC uses to resolve dereference operations).

This results in pointer dereference operations being distributed over both valid and invalid objects, even if the invalid objects are not reachable under the local path condition. This yields very large case split expressions. In addition, since pointer offsets for invalid pointers are non-deterministic, the expressions may also contain a large number (from dozens to hundreds) of sdiv/smod/srem/byte_extract/byte_concat operators to handle misalinged accesses that overlap different array cells, struct members, padding bytes, etc. 

As a result `z3` is not able to solve these problems, specially when quantifiers are involved.

To mitigate the performance regression with z3, I added a switch `--dfcc-simple-invalid-pointer-model` that eliminates offset non-determinism for invalid pointers generated in failure paths of pointer predicates.
When the switch is activated, an invalid pointer is nondeterministically NULL or pointing to a unique dummy object of size 0 that is declared dead/deallocated. This mode is tagged as "unsound" in the CLI documentation and MAN pages due to the reduced non-determinism. Still, I think there is enough non-determinism to ensure that any attempt to use such a pointer by the user-program would result in an analysis failure.

The good news is, with this switch activated, z3  > v4.12 seems to be able to solve problems involving quantifiers more easily, and `bitwuzla`  >v0.6.0 appears able to solve these problems without using `--dfcc-simple-invalid-pointer-model`.

Since our CI runs with old versions of `z3` (as old as v4.8.7 from 2019), and does not run `bitwuzla` yet, I turned 1 `CORE`  test `contracts-dfcc/quantifiers-loops-fresh-bound-vars-smt/test.desc`  into `FUTURE`, while waiting for better performance fixes (see last commit of the PR).

# Why did this go unnoticed ?

- In the initial implementation of is_fresh both true and false cases were reachable in assume contexts (when malloc failure modes were active); 
- Our contracts-dfcc regression test suite did not contain tests for disjunctions or the “return false”  case.
- We did not notice our test suite was missing this behaviour, because:
    - The predicate is implemented in the CPROVER library, as C code
    - The CPROVER library is only symbolically executed during proofs
    - We don’t collect symbolic reachability/coverage metrics for the CPROVER library
    - hence, we could not detect that parts of the predicate implementation (the path that returns false) were not exercised at all by the contracts-dfcc regression suite.
- Up to this point, the predicate behaviour was still sound, but we had an incomplete contracts-dfcc test suite
- Later, the predicate implementation was modified to encode “allocation size too large" failure modes
    - https://github.com/diffblue/cbmc/commit/3a1a5ac4874ed84fe485da27e586b06d8140f780"
    - This commit inadvertently removed the code path that returns false in assume contexts
    - The bug was not caught by regression suite (for reasons mentioned above).
 
 # Process improvements

Besides design and code reviews, I think the problem could have be found if we had looked at the path coverage achieved by our test suite on the instrumentation code found in `cprover_contracts.c`. This code is only symbolically executed when analyzing a model, and at the moment we don't collect reachability/coverage metrics for that type of code under regression testing. If we had instrumented branch condition coverage we could have realized early on that no tests covered the false branch in our __CPROVER_is_fresh predicate implementation.

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [x] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.
