### PR TITLE
CONTRACTS: optimize is_fresh separation checks, add ptr predicate uniqueness checks

### DIFF
--- a/regression/contracts-dfcc/test_aliasing_ensure/main.c
+++ b/regression/contracts-dfcc/test_aliasing_ensure/main.c
@@ -1,35 +1,15 @@
-#include <assert.h>
-#include <stdbool.h>
-#include <stdlib.h>
-
-int z;
-
-// clang-format off
-int foo(int *x, int *y)
-  __CPROVER_assigns(z, *x)
-  __CPROVER_requires(
-    __CPROVER_is_fresh(x, sizeof(int)) &&
-    *x > 0 &&
-    *x < 4)
-  __CPROVER_ensures(
-    __CPROVER_is_fresh(y, sizeof(int)) &&
-    !__CPROVER_is_fresh(x, sizeof(int)) &&
-    x != NULL &&
-    x != y &&
-    __CPROVER_return_value == *x + 5)
+int *foo()
+  // clang-format off
+  __CPROVER_ensures(__CPROVER_is_fresh(__CPROVER_return_value, sizeof(int)))
 // clang-format on
 {
-  *x = *x + 4;
-  y = malloc(sizeof(*y));
-  *y = *x;
-  z = *y;
-  return (*x + 5);
+  int *ret = malloc(sizeof(int));
+  __CPROVER_assume(ret);
+  return ret;
 }
 
 int main()
 {
-  int n = 4;
-  n = foo(&n, &n);
-  assert(!(n < 4));
+  foo();
   return 0;
 }

--- a/regression/contracts-dfcc/test_aliasing_ensure/test.desc
+++ b/regression/contracts-dfcc/test_aliasing_ensure/test.desc
@@ -4,10 +4,6 @@ main.c
 ^EXIT=0$
 ^SIGNAL=0$
 \[foo.postcondition.\d+\].*Check ensures clause of contract contract::foo for function foo: SUCCESS$
-\[foo.assigns.\d+\].*Check that \*x is assignable: SUCCESS
-\[foo.assigns.\d+\].*Check that \*y is assignable: SUCCESS
-\[foo.assigns.\d+\].*Check that z is assignable: SUCCESS
-\[main.assertion.\d+\].*assertion \!\(n \< 4\): SUCCESS
 ^VERIFICATION SUCCESSFUL$
 --
 --

--- a/regression/contracts-dfcc/test_pointer_predicate_enforce_requires_equals_equals_fail/main.c
+++ b/regression/contracts-dfcc/test_pointer_predicate_enforce_requires_equals_equals_fail/main.c
@@ -1,0 +1,20 @@
+void foo(int *x, int *y)
+  // clang-format off
+__CPROVER_requires(__CPROVER_is_fresh(x, sizeof(int)))
+__CPROVER_requires(*x == 0)
+__CPROVER_requires(__CPROVER_pointer_equals(y, x) && __CPROVER_pointer_equals(y, x))
+__CPROVER_assigns(*y)
+__CPROVER_ensures(*y == 1)
+__CPROVER_ensures(*x == 1)
+// clang-format on
+{
+  *y = 1;
+}
+
+int main()
+{
+  int *x;
+  int *y;
+  foo(x, y);
+  return 0;
+}

--- a/regression/contracts-dfcc/test_pointer_predicate_enforce_requires_equals_equals_fail/test.desc
+++ b/regression/contracts-dfcc/test_pointer_predicate_enforce_requires_equals_equals_fail/test.desc
@@ -1,0 +1,11 @@
+CORE dfcc-only
+main.c
+--dfcc main --enforce-contract foo
+^\[__CPROVER_contracts_pointer_equals.assertion.\d+\] line \d+ __CPROVER_pointer_equals does not conflict with other pointer predicate: FAILURE$
+^EXIT=10$
+^SIGNAL=0$
+^VERIFICATION FAILED$
+--
+--
+Tests that assuming the more than one pointer predicate on the same target pointer
+at the same time triggers a failure.

--- a/regression/contracts-dfcc/test_pointer_predicate_enforce_requires_equals_equals_pass/main.c
+++ b/regression/contracts-dfcc/test_pointer_predicate_enforce_requires_equals_equals_pass/main.c
@@ -1,0 +1,20 @@
+void foo(int *x, int *y)
+  // clang-format off
+__CPROVER_requires(__CPROVER_is_fresh(x, sizeof(int)))
+__CPROVER_requires(*x == 0)
+__CPROVER_requires(__CPROVER_pointer_equals(y, x) || __CPROVER_pointer_equals(y, x))
+__CPROVER_assigns(*y)
+__CPROVER_ensures(*y == 1)
+__CPROVER_ensures(*x == 1 || *x == 0)
+// clang-format on
+{
+  *y = 1;
+}
+
+int main()
+{
+  int *x;
+  int *y;
+  foo(x, y);
+  return 0;
+}

--- a/regression/contracts-dfcc/test_pointer_predicate_enforce_requires_equals_equals_pass/test.desc
+++ b/regression/contracts-dfcc/test_pointer_predicate_enforce_requires_equals_equals_pass/test.desc
@@ -1,0 +1,10 @@
+CORE dfcc-only
+main.c
+--dfcc main --enforce-contract foo
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+--
+Tests that a same pointer can be the target of multiple pointer predicates as
+long as they do not apply at the same time.

--- a/regression/contracts-dfcc/test_pointer_predicate_enforce_requires_in_range_equals_fail/main.c
+++ b/regression/contracts-dfcc/test_pointer_predicate_enforce_requires_in_range_equals_fail/main.c
@@ -1,0 +1,22 @@
+void foo(int *x, int *y)
+  // clang-format off
+__CPROVER_requires(__CPROVER_is_fresh(x, sizeof(int)))
+__CPROVER_requires(*x == 0)
+__CPROVER_requires(
+  __CPROVER_pointer_in_range_dfcc(x, y, x) &&
+  __CPROVER_pointer_equals(y, x))
+__CPROVER_assigns(*y)
+__CPROVER_ensures(*y == 1)
+__CPROVER_ensures(*x == 1)
+// clang-format on
+{
+  *y = 1;
+}
+
+int main()
+{
+  int *x;
+  int *y;
+  foo(x, y);
+  return 0;
+}

--- a/regression/contracts-dfcc/test_pointer_predicate_enforce_requires_in_range_equals_fail/test.desc
+++ b/regression/contracts-dfcc/test_pointer_predicate_enforce_requires_in_range_equals_fail/test.desc
@@ -1,0 +1,11 @@
+CORE dfcc-only
+main.c
+--dfcc main --enforce-contract foo
+^\[__CPROVER_contracts_pointer_equals.assertion.\d+\] line \d+ __CPROVER_pointer_equals does not conflict with other pointer predicate: FAILURE$
+^EXIT=10$
+^SIGNAL=0$
+^VERIFICATION FAILED$
+--
+--
+Tests that assuming the more than one pointer predicate on the same target pointer
+at the same time triggers a failure.

--- a/regression/contracts-dfcc/test_pointer_predicate_enforce_requires_in_range_equals_pass/main.c
+++ b/regression/contracts-dfcc/test_pointer_predicate_enforce_requires_in_range_equals_pass/main.c
@@ -1,0 +1,22 @@
+void foo(int *x, int *y)
+  // clang-format off
+__CPROVER_requires(__CPROVER_is_fresh(x, sizeof(int)))
+__CPROVER_requires(*x == 0)
+__CPROVER_requires(
+  __CPROVER_pointer_in_range_dfcc(x, y, x) ||
+  __CPROVER_pointer_equals(y, x))
+__CPROVER_assigns(*y)
+__CPROVER_ensures(*y == 1)
+__CPROVER_ensures(*x == 1)
+// clang-format on
+{
+  *y = 1;
+}
+
+int main()
+{
+  int *x;
+  int *y;
+  foo(x, y);
+  return 0;
+}

--- a/regression/contracts-dfcc/test_pointer_predicate_enforce_requires_in_range_equals_pass/test.desc
+++ b/regression/contracts-dfcc/test_pointer_predicate_enforce_requires_in_range_equals_pass/test.desc
@@ -1,0 +1,10 @@
+CORE dfcc-only
+main.c
+--dfcc main --enforce-contract foo
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+--
+Tests that more than one predicate can be assumed on a same target as long at
+they don't hold at the same time.

--- a/regression/contracts-dfcc/test_pointer_predicate_enforce_requires_in_range_in_range_fail/main.c
+++ b/regression/contracts-dfcc/test_pointer_predicate_enforce_requires_in_range_in_range_fail/main.c
@@ -1,0 +1,22 @@
+void foo(int *x, int *y)
+  // clang-format off
+__CPROVER_requires(__CPROVER_is_fresh(x, sizeof(int)))
+__CPROVER_requires(*x == 0)
+__CPROVER_requires(
+  __CPROVER_pointer_in_range_dfcc(x, y, x) &&
+  __CPROVER_pointer_in_range_dfcc(x, y, x))
+__CPROVER_assigns(*y)
+__CPROVER_ensures(*y == 1)
+__CPROVER_ensures(*x == 1)
+// clang-format on
+{
+  *y = 1;
+}
+
+int main()
+{
+  int *x;
+  int *y;
+  foo(x, y);
+  return 0;
+}

--- a/regression/contracts-dfcc/test_pointer_predicate_enforce_requires_in_range_in_range_fail/test.desc
+++ b/regression/contracts-dfcc/test_pointer_predicate_enforce_requires_in_range_in_range_fail/test.desc
@@ -1,0 +1,10 @@
+CORE dfcc-only
+main.c
+--dfcc main --enforce-contract foo
+^\[__CPROVER_contracts_pointer_in_range_dfcc.assertion.6] line \d+ __CPROVER_pointer_in_range_dfcc does not conflict with other pointer predicate: FAILURE$
+^EXIT=10$
+^SIGNAL=0$
+^VERIFICATION FAILED$
+--
+--
+Tests that assuming more than one pointer predicate on the same target pointer triggers a failure.

--- a/regression/contracts-dfcc/test_pointer_predicate_enforce_requires_in_range_in_range_pass/main.c
+++ b/regression/contracts-dfcc/test_pointer_predicate_enforce_requires_in_range_in_range_pass/main.c
@@ -1,0 +1,22 @@
+void foo(int *x, int *y)
+  // clang-format off
+__CPROVER_requires(__CPROVER_is_fresh(x, sizeof(int)))
+__CPROVER_requires(*x == 0)
+__CPROVER_requires(
+  __CPROVER_pointer_in_range_dfcc(x, y, x) ||
+  __CPROVER_pointer_in_range_dfcc(x, y, x))
+__CPROVER_assigns(*y)
+__CPROVER_ensures(*y == 1)
+__CPROVER_ensures(*x == 1)
+// clang-format on
+{
+  *y = 1;
+}
+
+int main()
+{
+  int *x;
+  int *y;
+  foo(x, y);
+  return 0;
+}

--- a/regression/contracts-dfcc/test_pointer_predicate_enforce_requires_in_range_in_range_pass/test.desc
+++ b/regression/contracts-dfcc/test_pointer_predicate_enforce_requires_in_range_in_range_pass/test.desc
@@ -1,0 +1,10 @@
+CORE dfcc-only
+main.c
+--dfcc main --enforce-contract foo
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+--
+Tests that a same pointer can be the target of multiple pointer predicates as
+long as they do not apply at the same time.

--- a/regression/contracts-dfcc/test_pointer_predicate_enforce_requires_is_fresh_equals_fail/main.c
+++ b/regression/contracts-dfcc/test_pointer_predicate_enforce_requires_is_fresh_equals_fail/main.c
@@ -1,0 +1,20 @@
+void foo(int *x, int *y)
+  // clang-format off
+__CPROVER_requires(__CPROVER_is_fresh(x, sizeof(int)))
+__CPROVER_requires(*x == 0)
+__CPROVER_requires(__CPROVER_is_fresh(y, sizeof(int)) && __CPROVER_pointer_equals(y, x))
+__CPROVER_assigns(*y)
+__CPROVER_ensures(*y == 1)
+__CPROVER_ensures(*x == 1 || *x == 0)
+// clang-format on
+{
+  *y = 1;
+}
+
+int main()
+{
+  int *x;
+  int *y;
+  foo(x, y);
+  return 0;
+}

--- a/regression/contracts-dfcc/test_pointer_predicate_enforce_requires_is_fresh_equals_fail/test.desc
+++ b/regression/contracts-dfcc/test_pointer_predicate_enforce_requires_is_fresh_equals_fail/test.desc
@@ -1,0 +1,10 @@
+CORE dfcc-only
+main.c
+--dfcc main --enforce-contract foo
+^\[__CPROVER_contracts_pointer_equals.assertion.\d+\] line \d+ __CPROVER_pointer_equals does not conflict with other pointer predicate: FAILURE$
+^EXIT=10$
+^SIGNAL=0$
+^VERIFICATION FAILED$
+--
+--
+Tests that assuming more than one pointer predicate on the same target pointer triggers a failure.

--- a/regression/contracts-dfcc/test_pointer_predicate_enforce_requires_is_fresh_equals_pass/main.c
+++ b/regression/contracts-dfcc/test_pointer_predicate_enforce_requires_is_fresh_equals_pass/main.c
@@ -1,0 +1,20 @@
+void foo(int *x, int *y)
+  // clang-format off
+__CPROVER_requires(__CPROVER_is_fresh(x, sizeof(int)))
+__CPROVER_requires(*x == 0)
+__CPROVER_requires(__CPROVER_is_fresh(y, sizeof(int)) || __CPROVER_pointer_equals(y, x))
+__CPROVER_assigns(*y)
+__CPROVER_ensures(*y == 1)
+__CPROVER_ensures(*x == 1 || *x == 0)
+// clang-format on
+{
+  *y = 1;
+}
+
+int main()
+{
+  int *x;
+  int *y;
+  foo(x, y);
+  return 0;
+}

--- a/regression/contracts-dfcc/test_pointer_predicate_enforce_requires_is_fresh_equals_pass/test.desc
+++ b/regression/contracts-dfcc/test_pointer_predicate_enforce_requires_is_fresh_equals_pass/test.desc
@@ -1,0 +1,10 @@
+CORE dfcc-only
+main.c
+--dfcc main --enforce-contract foo
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+--
+Tests that a same pointer can be the target of multiple pointer predicates as
+long as they do not apply at the same time.

--- a/regression/contracts-dfcc/test_pointer_predicate_enforce_requires_is_fresh_in_range_fail/main.c
+++ b/regression/contracts-dfcc/test_pointer_predicate_enforce_requires_is_fresh_in_range_fail/main.c
@@ -1,0 +1,22 @@
+void foo(int *x, int *y)
+  // clang-format off
+__CPROVER_requires(__CPROVER_is_fresh(x, sizeof(int)))
+__CPROVER_requires(*x == 0)
+__CPROVER_requires(
+  __CPROVER_is_fresh(y, sizeof(int)) &&
+  __CPROVER_pointer_in_range_dfcc(x, y, x))
+__CPROVER_assigns(*y)
+__CPROVER_ensures(*y == 1)
+__CPROVER_ensures(*x == 1 || *x == 0)
+// clang-format on
+{
+  *y = 1;
+}
+
+int main()
+{
+  int *x;
+  int *y;
+  foo(x, y);
+  return 0;
+}

--- a/regression/contracts-dfcc/test_pointer_predicate_enforce_requires_is_fresh_in_range_fail/test.desc
+++ b/regression/contracts-dfcc/test_pointer_predicate_enforce_requires_is_fresh_in_range_fail/test.desc
@@ -1,0 +1,11 @@
+CORE dfcc-only
+main.c
+--dfcc main --enforce-contract foo
+^\[__CPROVER_contracts_pointer_in_range_dfcc.assertion.\d+\] line \d+ __CPROVER_pointer_in_range_dfcc does not conflict with other pointer predicate: FAILURE$
+^EXIT=10$
+^SIGNAL=0$
+^VERIFICATION FAILED$
+--
+--
+Tests that assuming the more than one pointer predicate on the same target pointer
+at the same time triggers a failure.

--- a/regression/contracts-dfcc/test_pointer_predicate_enforce_requires_is_fresh_in_range_pass/main.c
+++ b/regression/contracts-dfcc/test_pointer_predicate_enforce_requires_is_fresh_in_range_pass/main.c
@@ -1,0 +1,22 @@
+void foo(int *x, int *y)
+  // clang-format off
+__CPROVER_requires(__CPROVER_is_fresh(x, sizeof(int)))
+__CPROVER_requires(*x == 0)
+__CPROVER_requires(
+  __CPROVER_is_fresh(y, sizeof(int)) ||
+  __CPROVER_pointer_in_range_dfcc(x, y, x))
+__CPROVER_assigns(*y)
+__CPROVER_ensures(*y == 1)
+__CPROVER_ensures(*x == 1 || *x == 0)
+// clang-format on
+{
+  *y = 1;
+}
+
+int main()
+{
+  int *x;
+  int *y;
+  foo(x, y);
+  return 0;
+}

--- a/regression/contracts-dfcc/test_pointer_predicate_enforce_requires_is_fresh_in_range_pass/test.desc
+++ b/regression/contracts-dfcc/test_pointer_predicate_enforce_requires_is_fresh_in_range_pass/test.desc
@@ -1,0 +1,10 @@
+CORE dfcc-only
+main.c
+--dfcc main --enforce-contract foo
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+--
+Tests that a same pointer can be the target of multiple pointer predicates as
+long as they do not apply at the same time.

--- a/regression/contracts-dfcc/test_pointer_predicate_enforce_requires_is_fresh_is_fresh_fail/main.c
+++ b/regression/contracts-dfcc/test_pointer_predicate_enforce_requires_is_fresh_is_fresh_fail/main.c
@@ -1,0 +1,17 @@
+void foo(int *x)
+  // clang-format off
+__CPROVER_requires(
+  __CPROVER_is_fresh(x, sizeof(int)) && __CPROVER_is_fresh(x, sizeof(int)))
+__CPROVER_assigns(*x)
+__CPROVER_ensures(*x == 0)
+// clang-format on
+{
+  *x = 0;
+}
+
+int main()
+{
+  int *x;
+  foo(x);
+  return 0;
+}

--- a/regression/contracts-dfcc/test_pointer_predicate_enforce_requires_is_fresh_is_fresh_fail/test.desc
+++ b/regression/contracts-dfcc/test_pointer_predicate_enforce_requires_is_fresh_is_fresh_fail/test.desc
@@ -1,0 +1,11 @@
+CORE dfcc-only
+main.c
+--dfcc main --enforce-contract foo
+^\[__CPROVER_contracts_is_fresh.assertion.\d+\] line \d+ __CPROVER_is_fresh does not conflict with other pointer predicate: FAILURE$
+^EXIT=10$
+^SIGNAL=0$
+^VERIFICATION FAILED$
+--
+--
+Tests that assuming the more than one pointer predicate on the same target pointer
+at the same time triggers a failure.

--- a/regression/contracts-dfcc/test_pointer_predicate_enforce_requires_is_fresh_is_fresh_pass/main.c
+++ b/regression/contracts-dfcc/test_pointer_predicate_enforce_requires_is_fresh_is_fresh_pass/main.c
@@ -1,0 +1,17 @@
+void foo(int *x)
+  // clang-format off
+__CPROVER_requires(
+  __CPROVER_is_fresh(x, sizeof(int)) || __CPROVER_is_fresh(x, sizeof(int)))
+__CPROVER_assigns(*x)
+__CPROVER_ensures(*x == 0)
+// clang-format on
+{
+  *x = 0;
+}
+
+int main()
+{
+  int *x;
+  foo(x);
+  return 0;
+}

--- a/regression/contracts-dfcc/test_pointer_predicate_enforce_requires_is_fresh_is_fresh_pass/test.desc
+++ b/regression/contracts-dfcc/test_pointer_predicate_enforce_requires_is_fresh_is_fresh_pass/test.desc
@@ -1,0 +1,14 @@
+CORE dfcc-only
+main.c
+--dfcc main --enforce-contract foo
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+--
+Tests that a same pointer can be the target of multiple pointer predicates as
+long as they do not apply at the same time.
+- `x` is fresh and inialized to 0
+- `y` is equal to `x`if select is true, or fresh otherwise
+- foo assigns y to 1
+- x is equal to 1 if select is true, 0 otherwise

--- a/regression/contracts-dfcc/test_pointer_predicate_enforce_reset_before_requires_equals_equals_pass/main.c
+++ b/regression/contracts-dfcc/test_pointer_predicate_enforce_reset_before_requires_equals_equals_pass/main.c
@@ -1,0 +1,21 @@
+void foo(int *x, int *y, int **z)
+  // clang-format off
+__CPROVER_requires(__CPROVER_is_fresh(x, sizeof(int)))
+__CPROVER_requires(__CPROVER_is_fresh(y, sizeof(int)))
+__CPROVER_requires(__CPROVER_is_fresh(z, sizeof(int*)))
+__CPROVER_requires(__CPROVER_pointer_equals(*z, x))
+__CPROVER_assigns(*z)
+__CPROVER_ensures(__CPROVER_pointer_equals(*z, y))
+// clang-format on
+{
+  *z = y;
+}
+
+int main()
+{
+  int *x;
+  int *y;
+  int **z;
+  foo(x, y, z);
+  return 0;
+}

--- a/regression/contracts-dfcc/test_pointer_predicate_enforce_reset_before_requires_equals_equals_pass/test.desc
+++ b/regression/contracts-dfcc/test_pointer_predicate_enforce_reset_before_requires_equals_equals_pass/test.desc
@@ -1,0 +1,10 @@
+CORE dfcc-only
+main.c
+--dfcc main --enforce-contract foo
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+--
+Tests that assuming different predicates on a same pointer is possible across pre and post conditions.
+Initially *z equals x, after the call *z equals y.

--- a/regression/contracts-dfcc/test_pointer_predicate_replace_reset_before_requires_equals_equals_pass/main.c
+++ b/regression/contracts-dfcc/test_pointer_predicate_replace_reset_before_requires_equals_equals_pass/main.c
@@ -1,0 +1,32 @@
+void foo(int *x, int *y, int **z)
+  // clang-format off
+__CPROVER_requires(__CPROVER_is_fresh(x, sizeof(int)))
+__CPROVER_requires(__CPROVER_is_fresh(y, sizeof(int)))
+__CPROVER_requires(__CPROVER_is_fresh(z, sizeof(int*)))
+__CPROVER_requires(__CPROVER_pointer_equals(*z, x))
+__CPROVER_assigns(*z)
+__CPROVER_ensures(__CPROVER_pointer_equals(*z, y))
+// clang-format on
+{
+  *z = y;
+}
+
+void bar()
+  // clang-format off
+__CPROVER_requires(1)
+__CPROVER_assigns()
+__CPROVER_ensures(1)
+// clang-format on
+{
+  int x;
+  int y;
+  int *z = &x;
+  foo(&x, &y, &z);
+  assert(z == &y);
+}
+
+int main()
+{
+  bar();
+  return 0;
+}

--- a/regression/contracts-dfcc/test_pointer_predicate_replace_reset_before_requires_equals_equals_pass/test.desc
+++ b/regression/contracts-dfcc/test_pointer_predicate_replace_reset_before_requires_equals_equals_pass/test.desc
@@ -1,0 +1,10 @@
+CORE dfcc-only
+main.c
+--dfcc main --enforce-contract bar --replace-call-with-contract foo
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+--
+Tests that assuming different predicates on a same pointer is possible across pre and post conditions.
+Initially *z equals x, after the call *z equals y.

--- a/regression/contracts-dfcc/test_pointer_predicate_requires_in_range_in_range_fail/main.c
+++ b/regression/contracts-dfcc/test_pointer_predicate_requires_in_range_in_range_fail/main.c
@@ -1,0 +1,22 @@
+void foo(int *x, int *y)
+  // clang-format off
+__CPROVER_requires(__CPROVER_is_fresh(x, sizeof(int)))
+__CPROVER_requires(*x == 0)
+__CPROVER_requires(
+  __CPROVER_pointer_in_range_dfcc(x, y, x) &&
+  __CPROVER_pointer_in_range_dfcc(x, y, x))
+__CPROVER_assigns(*y)
+__CPROVER_ensures(*y == 1)
+__CPROVER_ensures(*x == 1)
+// clang-format on
+{
+  *y = 1;
+}
+
+int main()
+{
+  int *x;
+  int *y;
+  foo(x, y);
+  return 0;
+}

--- a/regression/contracts-dfcc/test_pointer_predicate_requires_in_range_in_range_fail/test.desc
+++ b/regression/contracts-dfcc/test_pointer_predicate_requires_in_range_in_range_fail/test.desc
@@ -1,0 +1,11 @@
+CORE dfcc-only
+main.c
+--dfcc main --enforce-contract foo
+^\[__CPROVER_contracts_pointer_in_range_dfcc.assertion.\d+\] line \d+ __CPROVER_pointer_in_range_dfcc does not conflict with other pointer predicate: FAILURE$
+^EXIT=10$
+^SIGNAL=0$
+^VERIFICATION FAILED$
+--
+--
+Tests that assuming the more than one pointer predicate on the same target pointer
+at the same time triggers a failure.

--- a/regression/contracts-dfcc/test_scalar_memory_enforce/main.c
+++ b/regression/contracts-dfcc/test_scalar_memory_enforce/main.c
@@ -21,7 +21,6 @@ int foo(int *x)
     ptr_ok(x))
   __CPROVER_ensures(
     !ptr_ok(x) &&
-    !__CPROVER_is_fresh(x, sizeof(int)) &&
     return_ok(__CPROVER_return_value, x))
 // clang-format on
 {

--- a/src/ansi-c/library/cprover_contracts.c
+++ b/src/ansi-c/library/cprover_contracts.c
@@ -64,8 +64,27 @@ typedef struct
   void **elems;
 } __CPROVER_contracts_obj_set_t;
 
-/// \brief Type of pointers to \ref __CPROVER_contracts_car_set_t.
+/// \brief Type of pointers to \ref __CPROVER_contracts_obj_set_t.
 typedef __CPROVER_contracts_obj_set_t *__CPROVER_contracts_obj_set_ptr_t;
+
+/// \brief Stores context information supporting the evaluation of pointer
+/// predicates in both assume and assert contexts for all predicates:
+/// pointer equals, pointer_in_range_dfcc, pointer_is_fresh, obeys_contract.
+typedef struct
+{
+  /// \brief Nondet variable ranging over the set of objects allocated
+  /// by __CPROVER_contracts_is_fresh. Used to check separation constraints
+  /// in __CPROVER_contracts_is_fresh.
+  void *fresh_ptr;
+  /// \brief Nondet variable ranging over the set of locations storing
+  /// pointers on which predicates were assumed/asserted. Used to ensure
+  /// that at most one predicate is assumed per pointer.
+  void **ptr_pred;
+} __CPROVER_contracts_ptr_pred_ctx_t;
+
+/// \brief Type of pointers to \ref __CPROVER_contracts_ptr_pred_ctx_t.
+typedef __CPROVER_contracts_ptr_pred_ctx_t
+  *__CPROVER_contracts_ptr_pred_ctx_ptr_t;
 
 /// \brief Runtime representation of a write set.
 typedef struct
@@ -84,7 +103,7 @@ typedef struct
   __CPROVER_contracts_obj_set_t deallocated;
   /// \brief Pointer to object set supporting the is_fresh predicate checks
   /// (indexed mode)
-  __CPROVER_contracts_obj_set_ptr_t linked_is_fresh;
+  __CPROVER_contracts_ptr_pred_ctx_ptr_t linked_ptr_pred_ctx;
   /// \brief Object set recording the is_fresh allocations in post conditions
   __CPROVER_contracts_obj_set_ptr_t linked_allocated;
   /// \brief Object set recording the deallocations (used by was_freed)
@@ -393,6 +412,27 @@ __CPROVER_HIDE:;
   return set->elems[object_id] == ptr;
 }
 
+/// \brief Resets the nondet tracker for pointer predicates in \p set.
+/// Invoked between requires and ensures clauses evaluation to allow ensures
+/// clauses to establish different pointer predicates on the same pointers.
+void __CPROVER_contracts_ptr_pred_ctx_init(
+  __CPROVER_contracts_ptr_pred_ctx_ptr_t set)
+{
+__CPROVER_HIDE:;
+  set->fresh_ptr = (void *)0;
+  set->ptr_pred = (void **)0;
+}
+
+/// \brief Resets the nondet tracker for pointer predicates in \p set.
+/// Invoked right between requires and ensures clauses to allow ensures clauses
+/// to establish a different pointer predicates on the same pointers.
+void __CPROVER_contracts_ptr_pred_ctx_reset(
+  __CPROVER_contracts_ptr_pred_ctx_ptr_t set)
+{
+__CPROVER_HIDE:;
+  set->ptr_pred = (void **)0;
+}
+
 /// \brief Initialises a \ref __CPROVER_contracts_write_set_t object.
 /// \param[inout] set Pointer to the object to initialise
 /// \param[in] contract_assigns_size Max size of the assigns clause
@@ -434,7 +474,7 @@ __CPROVER_HIDE:;
     &(set->contract_frees_append), contract_frees_size);
   __CPROVER_contracts_obj_set_create_indexed_by_object_id(&(set->allocated));
   __CPROVER_contracts_obj_set_create_indexed_by_object_id(&(set->deallocated));
-  set->linked_is_fresh = 0;
+  set->linked_ptr_pred_ctx = 0;
   set->linked_allocated = 0;
   set->linked_deallocated = 0;
   set->assume_requires_ctx = assume_requires_ctx;
@@ -473,8 +513,8 @@ __CPROVER_HIDE:;
   __CPROVER_deallocate(set->contract_frees_append.elems);
   __CPROVER_deallocate(set->allocated.elems);
   __CPROVER_deallocate(set->deallocated.elems);
-  // do not free set->linked_is_fresh->elems or set->deallocated_linked->elems
-  // since they are owned by someone else.
+  // do not free set->linked_ptr_pred_ctx->elems or
+  // set->deallocated_linked->elems since they are owned by someone else.
 }
 
 /// \brief Inserts a snapshot of the range starting at \p ptr of size \p size
@@ -542,9 +582,6 @@ void __CPROVER_contracts_write_set_insert_object_from(
 /// \brief Inserts a snapshot of the range of bytes starting at \p ptr of
 /// \p size bytes in \p set->contact_assigns at index \p idx.
 ///
-/// - The start address is `ptr`
-/// - The size in bytes is `size`
-///
 /// \param[inout] set The set to update
 /// \param[in] idx Insertion index
 /// \param[in] ptr Pointer to the start of the range
@@ -567,10 +604,8 @@ void __CPROVER_contracts_write_set_add_freeable(
   void *ptr)
 {
 __CPROVER_HIDE:;
-  // we don't check yet that the pointer satisfies
-  // the __CPROVER_contracts_is_freeable as precondition.
-  // preconditions will be checked if there is an actual attempt
-  // to free the pointer.
+  // Preconditions will be checked if there is an actual attempt
+  // to free the pointer, don't check preemptively.
 
   // store pointer
   __CPROVER_size_t object_id = __CPROVER_POINTER_OBJECT(ptr);
@@ -1060,23 +1095,23 @@ SET_DEALLOCATE_FREEABLE_LOOP:
 }
 
 /// \brief Links \p is_fresh_set to
-/// \p write_set->linked_is_fresh so that the is_fresh predicates
-/// can be evaluated in requires and ensures clauses.
-void __CPROVER_contracts_link_is_fresh(
+/// \p write_set->linked_ptr_pred_ctx to share evaluation context between
+/// requires and ensures clauses for separation checks.
+void __CPROVER_contracts_link_ptr_pred_ctx(
   __CPROVER_contracts_write_set_ptr_t write_set,
-  __CPROVER_contracts_obj_set_ptr_t is_fresh_set)
+  __CPROVER_contracts_ptr_pred_ctx_ptr_t ptr_pred_ctx)
 {
 __CPROVER_HIDE:;
 #ifdef __CPROVER_DFCC_DEBUG_LIB
   __CPROVER_assert(write_set != 0, "write_set not NULL");
 #endif
-  if((is_fresh_set != 0))
+  if((ptr_pred_ctx != 0))
   {
-    write_set->linked_is_fresh = is_fresh_set;
+    write_set->linked_ptr_pred_ctx = ptr_pred_ctx;
   }
   else
   {
-    write_set->linked_is_fresh = 0;
+    write_set->linked_ptr_pred_ctx = 0;
   }
 }
 
@@ -1205,7 +1240,15 @@ __CPROVER_HIDE:;
     }
     __CPROVER_assert(
       (ptr2 == 0) || __CPROVER_r_ok(ptr2, 0),
-      "pointer_equals is only called with valid pointers");
+      "__CPROVER_pointer_equals is only called with valid pointers");
+    __CPROVER_assert(
+      write_set->linked_ptr_pred_ctx->ptr_pred != ptr1,
+      "__CPROVER_pointer_equals does not conflict with other pointer "
+      "predicate");
+    write_set->linked_ptr_pred_ctx->ptr_pred =
+      __VERIFIER_nondet___CPROVER_bool()
+        ? ptr1
+        : write_set->linked_ptr_pred_ctx->ptr_pred;
     *ptr1 = ptr2;
     return 1;
   }
@@ -1214,35 +1257,41 @@ __CPROVER_HIDE:;
     void *derefd = *ptr1;
     __CPROVER_assert(
       (derefd == 0) || __CPROVER_r_ok(derefd, 0),
-      "pointer_equals is only called with valid pointers");
+      "__CPROVER_pointer_equals is only called with valid pointers");
     __CPROVER_assert(
       (ptr2 == 0) || __CPROVER_r_ok(ptr2, 0),
-      "pointer_equals is only called with valid pointers");
-    return derefd == ptr2;
+      "__CPROVER_pointer_equals is only called with valid pointers");
+    if(derefd != ptr2)
+    {
+      return 0;
+    }
+    __CPROVER_assert(
+      write_set->linked_ptr_pred_ctx->ptr_pred != ptr1,
+      "__CPROVER_pointer_equals does not conflict with other pointer "
+      "predicate");
+    write_set->linked_ptr_pred_ctx->ptr_pred =
+      __VERIFIER_nondet___CPROVER_bool()
+        ? ptr1
+        : write_set->linked_ptr_pred_ctx->ptr_pred;
+    return 1;
   }
 }
 
 /// \brief Implementation of the `is_fresh` front-end predicate.
 ///
-/// The behaviour depends on the boolean flags carried by \p write_set
-/// which reflect the invocation context: checking vs. replacing a contract,
-/// in a requires or an ensures clause context.
 /// \param elem Pointer to the target pointer of the check
-/// \param size Size to check for
+/// \param size Size to check
 /// \param may_fail Allow predicate to fail in assume mode
-/// \param write_set Write set in which seen/allocated objects are recorded;
+/// \param write_set Write set (carries assert/assume requires/ensures context
+///   flags, sets to allocated/seen objects for separation checks)
 ///
 /// \details The behaviour is as follows:
-/// - When \p set->assume_requires_ctx is `true`, the predicate allocates a new
-/// object, records the object in \p set->linked_is_fresh, updates \p *elem to
-/// point to the fresh object and returns `true`;
-/// - When \p set->assume_ensures_ctx is `true`, the predicate allocates a new
-/// object, records the object in \p set->linked_allocated, updates \p *elem
-/// to point to the fresh object and returns `true`;
-/// - When \p set->assert_requires_ctx or \p set->assert_ensures_ctx is `true`,
-/// the predicate first computes wether \p *elem is in \p set->linked_is_fresh
-/// and returns false if it is. Otherwise it records the object in
-/// \p set->linked_is_fresh and returns the value of r_ok(*elem, size).
+/// - In assume contexts, returns false if another pointer predicate is already
+///  assumed, otherwise, allocates a fresh object, mark *elem and elem as seen
+///  in the write set.
+/// - In assert contexts, returns false if another pointer predicate is already
+///  succesfully asserted, otherwise checks separation and size, mark *elem and
+/// elem as seen in the write set.
 __CPROVER_bool __CPROVER_contracts_is_fresh(
   void **elem,
   __CPROVER_size_t size,
@@ -1250,19 +1299,7 @@ __CPROVER_bool __CPROVER_contracts_is_fresh(
   __CPROVER_contracts_write_set_ptr_t write_set)
 {
 __CPROVER_HIDE:;
-  __CPROVER_assert(
-    (write_set != 0) & ((write_set->assume_requires_ctx == 1) |
-                        (write_set->assert_requires_ctx == 1) |
-                        (write_set->assume_ensures_ctx == 1) |
-                        (write_set->assert_ensures_ctx == 1)),
-    "__CPROVER_is_fresh is used only in requires or ensures clauses");
-#ifdef __CPROVER_DFCC_DEBUG_LIB
-  __CPROVER_assert(
-    __CPROVER_rw_ok(write_set, sizeof(__CPROVER_contracts_write_set_t)),
-    "set readable");
-  __CPROVER_assert(
-    write_set->linked_is_fresh, "set->linked_is_fresh is not NULL");
-#endif
+
   if(write_set->assume_requires_ctx)
   {
 #ifdef __CPROVER_DFCC_DEBUG_LIB
@@ -1299,32 +1336,28 @@ __CPROVER_HIDE:;
       __CPROVER_contracts_make_invalid_pointer(elem);
       return 0;
     }
-
     void *ptr = __CPROVER_allocate(size, 0);
     *elem = ptr;
+    __CPROVER_assert(
+      write_set->linked_ptr_pred_ctx->ptr_pred != elem,
+      "__CPROVER_is_fresh does not conflict with other pointer predicate");
+    write_set->linked_ptr_pred_ctx->ptr_pred =
+      __VERIFIER_nondet___CPROVER_bool()
+        ? elem
+        : write_set->linked_ptr_pred_ctx->ptr_pred;
+    write_set->linked_ptr_pred_ctx->fresh_ptr =
+      __VERIFIER_nondet___CPROVER_bool()
+        ? ptr
+        : write_set->linked_ptr_pred_ctx->fresh_ptr;
 
     // record the object size for non-determistic bounds checking
     __CPROVER_bool record_malloc = __VERIFIER_nondet___CPROVER_bool();
     __CPROVER_malloc_is_new_array =
       record_malloc ? 0 : __CPROVER_malloc_is_new_array;
-
     // do not detect memory leaks when assuming a precondition of a contract
     // for contract checking
     // __CPROVER_bool record_may_leak = __VERIFIER_nondet___CPROVER_bool();
     // __CPROVER_memory_leak = record_may_leak ? ptr : __CPROVER_memory_leak;
-
-#ifdef __CPROVER_DFCC_DEBUG_LIB
-    // manually inlined below
-    __CPROVER_contracts_obj_set_add(write_set->linked_is_fresh, ptr);
-#else
-    __CPROVER_size_t object_id = __CPROVER_POINTER_OBJECT(ptr);
-    write_set->linked_is_fresh->nof_elems =
-      (write_set->linked_is_fresh->elems[object_id] != 0)
-        ? write_set->linked_is_fresh->nof_elems
-        : write_set->linked_is_fresh->nof_elems + 1;
-    write_set->linked_is_fresh->elems[object_id] = ptr;
-    write_set->linked_is_fresh->is_empty = 0;
-#endif
     return 1;
   }
   else if(write_set->assume_ensures_ctx)
@@ -1362,6 +1395,17 @@ __CPROVER_HIDE:;
 
     void *ptr = __CPROVER_allocate(size, 0);
     *elem = ptr;
+    __CPROVER_assert(
+      write_set->linked_ptr_pred_ctx->ptr_pred != elem,
+      "__CPROVER_is_fresh does not conflict with other pointer predicate");
+    write_set->linked_ptr_pred_ctx->ptr_pred =
+      __VERIFIER_nondet___CPROVER_bool()
+        ? elem
+        : write_set->linked_ptr_pred_ctx->ptr_pred;
+    write_set->linked_ptr_pred_ctx->fresh_ptr =
+      __VERIFIER_nondet___CPROVER_bool()
+        ? ptr
+        : write_set->linked_ptr_pred_ctx->fresh_ptr;
 
     // record the object size for non-determistic bounds checking
     __CPROVER_bool record_malloc = __VERIFIER_nondet___CPROVER_bool();
@@ -1395,34 +1439,26 @@ __CPROVER_HIDE:;
         (write_set->assume_ensures_ctx == 0),
       "only one context flag at a time");
 #endif
-    __CPROVER_contracts_obj_set_ptr_t seen = write_set->linked_is_fresh;
     void *ptr = *elem;
-    // null pointers or already seen pointers are not fresh
-#ifdef __CPROVER_DFCC_DEBUG_LIB
-    // manually inlined below
-    if((ptr == 0) || (__CPROVER_contracts_obj_set_contains(seen, ptr)))
-      return 0;
-#else
-    if(ptr == 0)
-      return 0;
-
-    __CPROVER_size_t object_id = __CPROVER_POINTER_OBJECT(ptr);
-
-    if(seen->elems[object_id] != 0)
-      return 0;
-#endif
-
-#ifdef __CPROVER_DFCC_DEBUG_LIB
-    // manually inlined below
-    __CPROVER_contracts_obj_set_add(seen, ptr);
-#else
-    seen->nof_elems =
-      (seen->elems[object_id] != 0) ? seen->nof_elems : seen->nof_elems + 1;
-    seen->elems[object_id] = ptr;
-    seen->is_empty = 0;
-#endif
-    // check size
-    return __CPROVER_r_ok(ptr, size);
+    if(
+      ptr != (void *)0 &&
+      !__CPROVER_same_object(write_set->linked_ptr_pred_ctx->fresh_ptr, ptr) &&
+      __CPROVER_r_ok(ptr, size))
+    {
+      __CPROVER_assert(
+        write_set->linked_ptr_pred_ctx->ptr_pred != elem,
+        "__CPROVER_is_fresh does not conflict with other pointer predicate");
+      write_set->linked_ptr_pred_ctx->ptr_pred =
+        __VERIFIER_nondet___CPROVER_bool()
+          ? elem
+          : write_set->linked_ptr_pred_ctx->ptr_pred;
+      write_set->linked_ptr_pred_ctx->fresh_ptr =
+        __VERIFIER_nondet___CPROVER_bool()
+          ? ptr
+          : write_set->linked_ptr_pred_ctx->fresh_ptr;
+      return 1;
+    }
+    return 0;
   }
   else
   {
@@ -1491,13 +1527,37 @@ __CPROVER_HIDE:;
     __CPROVER_size_t max_offset = ub_offset - lb_offset;
     __CPROVER_assume(offset <= max_offset);
     *ptr = (char *)lb + offset;
+    __CPROVER_assert(
+      write_set->linked_ptr_pred_ctx->ptr_pred != ptr,
+      "__CPROVER_pointer_in_range_dfcc does not conflict with other pointer "
+      "predicate");
+    write_set->linked_ptr_pred_ctx->ptr_pred =
+      __VERIFIER_nondet___CPROVER_bool()
+        ? ptr
+        : write_set->linked_ptr_pred_ctx->ptr_pred;
     return 1;
   }
   else /* write_set->assert_requires_ctx | write_set->assert_ensures_ctx */
   {
     __CPROVER_size_t offset = __CPROVER_POINTER_OFFSET(*ptr);
-    return __CPROVER_same_object(lb, *ptr) && lb_offset <= offset &&
-           offset <= ub_offset;
+    if(
+      __CPROVER_same_object(lb, *ptr) && lb_offset <= offset &&
+      offset <= ub_offset)
+    {
+      __CPROVER_assert(
+        write_set->linked_ptr_pred_ctx->ptr_pred != ptr,
+        "__CPROVER_pointer_in_range_dfcc does not conflict with other "
+        "predicate");
+      write_set->linked_ptr_pred_ctx->ptr_pred =
+        __VERIFIER_nondet___CPROVER_bool()
+          ? ptr
+          : write_set->linked_ptr_pred_ctx->ptr_pred;
+      return 1;
+    }
+    else
+    {
+      return 0;
+    }
   }
 }
 
@@ -1669,6 +1729,14 @@ __CPROVER_HIDE:;
     if(may_fail && __VERIFIER_nondet___CPROVER_bool())
       return 0;
 
+    __CPROVER_assert(
+      set->linked_ptr_pred_ctx->ptr_pred != (void **)function_pointer,
+      "__CPROVER_obeys_contract does not conflict with other pointer "
+      "predicate");
+    set->linked_ptr_pred_ctx->ptr_pred = __VERIFIER_nondet___CPROVER_bool()
+                                           ? (void **)function_pointer
+                                           : set->linked_ptr_pred_ctx->ptr_pred;
+
     // must hold, assign the function pointer to the contract function
     *function_pointer = contract;
     return 1;
@@ -1676,7 +1744,18 @@ __CPROVER_HIDE:;
   else
   {
     // in assumption contexts, the pointer gets checked for equality
-    return *function_pointer == contract;
+    if(*function_pointer == contract)
+    {
+      __CPROVER_assert(
+        set->linked_ptr_pred_ctx->ptr_pred != (void **)function_pointer,
+        "__CPROVER_obeys_contract does not conflict with other pointer "
+        "predicate");
+      set->linked_ptr_pred_ctx->ptr_pred =
+        __VERIFIER_nondet___CPROVER_bool() ? (void **)function_pointer
+                                           : set->linked_ptr_pred_ctx->ptr_pred;
+      return 1;
+    }
+    return 0;
   }
 }
 #endif // __CPROVER_contracts_library_defined

--- a/src/goto-instrument/contracts/doc/developer/contracts-dev-spec-dfcc-runtime.md
+++ b/src/goto-instrument/contracts/doc/developer/contracts-dev-spec-dfcc-runtime.md
@@ -112,8 +112,8 @@ typedef struct __CPROVER_contracts_write_set_t
   // Set of objects deallocated by the function under analysis (indexed mode)
   __CPROVER_contracts_obj_set_t deallocated;
 
-  // Object set supporting the is_fresh predicate checks (indexed mode)
-  __CPROVER_contracts_obj_set_ptr_t linked_is_fresh;
+  // Object set supporting the pointer predicate checks
+  __CPROVER_contracts_ptr_pred_ctx_ptr_t linked_ptr_pred_ctx;
 
   // Object set recording the is_fresh allocations in post conditions
   // (replacement mode only)

--- a/src/goto-instrument/contracts/dynamic-frames/dfcc_is_cprover_symbol.cpp
+++ b/src/goto-instrument/contracts/dynamic-frames/dfcc_is_cprover_symbol.cpp
@@ -30,6 +30,8 @@ init_function_symbols(std::unordered_set<irep_idt> &function_symbols)
     function_symbols.insert(CPROVER_PREFIX "assert");
     function_symbols.insert(CPROVER_PREFIX "assignable");
     function_symbols.insert(CPROVER_PREFIX "assume");
+    function_symbols.insert(CPROVER_PREFIX "contracts_ptr_pred_ctx_init");
+    function_symbols.insert(CPROVER_PREFIX "contracts_ptr_pred_ctx_reset");
     function_symbols.insert(CPROVER_PREFIX "contracts_car_create");
     function_symbols.insert(CPROVER_PREFIX "contracts_car_set_contains");
     function_symbols.insert(CPROVER_PREFIX "contracts_car_set_create");
@@ -42,7 +44,7 @@ init_function_symbols(std::unordered_set<irep_idt> &function_symbols)
     function_symbols.insert(CPROVER_PREFIX "contracts_is_fresh");
     function_symbols.insert(CPROVER_PREFIX "contracts_link_allocated");
     function_symbols.insert(CPROVER_PREFIX "contracts_link_deallocated");
-    function_symbols.insert(CPROVER_PREFIX "contracts_link_is_fresh");
+    function_symbols.insert(CPROVER_PREFIX "contracts_link_ptr_pred_ctx");
     function_symbols.insert(CPROVER_PREFIX "contracts_obeys_contract");
     function_symbols.insert(CPROVER_PREFIX "contracts_obj_set_add");
     function_symbols.insert(CPROVER_PREFIX "contracts_obj_set_append");

--- a/src/goto-instrument/contracts/dynamic-frames/dfcc_library.cpp
+++ b/src/goto-instrument/contracts/dynamic-frames/dfcc_library.cpp
@@ -52,6 +52,8 @@ const std::map<dfcc_typet, irep_idt> create_dfcc_type_to_name()
     {dfcc_typet::CAR, CONTRACTS_PREFIX "car_t"},
     {dfcc_typet::CAR_SET, CONTRACTS_PREFIX "car_set_t"},
     {dfcc_typet::CAR_SET_PTR, CONTRACTS_PREFIX "car_set_ptr_t"},
+    {dfcc_typet::PTR_PRED_CTX, CONTRACTS_PREFIX "ptr_pred_ctx_t"},
+    {dfcc_typet::PTR_PRED_CTX_PTR, CONTRACTS_PREFIX "ptr_pred_ctx_ptr_t"},
     {dfcc_typet::OBJ_SET, CONTRACTS_PREFIX "obj_set_t"},
     {dfcc_typet::OBJ_SET_PTR, CONTRACTS_PREFIX "obj_set_ptr_t"},
     {dfcc_typet::WRITE_SET, CONTRACTS_PREFIX "write_set_t"},
@@ -122,9 +124,11 @@ const std::map<dfcc_funt, irep_idt> create_dfcc_fun_to_name()
      CONTRACTS_PREFIX "write_set_havoc_object_whole"},
     {dfcc_funt::WRITE_SET_HAVOC_SLICE,
      CONTRACTS_PREFIX "write_set_havoc_slice"},
-    {dfcc_funt::LINK_IS_FRESH, CONTRACTS_PREFIX "link_is_fresh"},
+    {dfcc_funt::LINK_PTR_PRED_CTX, CONTRACTS_PREFIX "link_ptr_pred_ctx"},
     {dfcc_funt::LINK_ALLOCATED, CONTRACTS_PREFIX "link_allocated"},
     {dfcc_funt::LINK_DEALLOCATED, CONTRACTS_PREFIX "link_deallocated"},
+    {dfcc_funt::PTR_PRED_CTX_INIT, CONTRACTS_PREFIX "ptr_pred_ctx_init"},
+    {dfcc_funt::PTR_PRED_CTX_RESET, CONTRACTS_PREFIX "ptr_pred_ctx_reset"},
     {dfcc_funt::POINTER_EQUALS, CONTRACTS_PREFIX "pointer_equals"},
     {dfcc_funt::IS_FRESH, CONTRACTS_PREFIX "is_fresh"},
     {dfcc_funt::POINTER_IN_RANGE_DFCC,
@@ -810,14 +814,14 @@ const code_function_callt dfcc_libraryt::write_set_deallocate_freeable_call(
   return call;
 }
 
-const code_function_callt dfcc_libraryt::link_is_fresh_call(
+const code_function_callt dfcc_libraryt::link_ptr_pred_ctx_call(
   const exprt &write_set_ptr,
-  const exprt &is_fresh_obj_set_ptr,
+  const exprt &ptr_pred_ctx_ptr,
   const source_locationt &source_location)
 {
   code_function_callt call(
-    dfcc_fun_symbol[dfcc_funt::LINK_IS_FRESH].symbol_expr(),
-    {write_set_ptr, is_fresh_obj_set_ptr});
+    dfcc_fun_symbol[dfcc_funt::LINK_PTR_PRED_CTX].symbol_expr(),
+    {write_set_ptr, ptr_pred_ctx_ptr});
   call.add_source_location() = source_location;
   return call;
 }
@@ -879,6 +883,28 @@ const code_function_callt dfcc_libraryt::obj_set_release_call(
 {
   code_function_callt call(
     dfcc_fun_symbol[dfcc_funt::OBJ_SET_RELEASE].symbol_expr(), {obj_set_ptr});
+  call.add_source_location() = source_location;
+  return call;
+}
+
+const code_function_callt dfcc_libraryt::ptr_pred_ctx_init_call(
+  const exprt &ptr_pred_ctx_ptr,
+  const source_locationt &source_location)
+{
+  code_function_callt call(
+    dfcc_fun_symbol[dfcc_funt::PTR_PRED_CTX_INIT].symbol_expr(),
+    {ptr_pred_ctx_ptr});
+  call.add_source_location() = source_location;
+  return call;
+}
+
+const code_function_callt dfcc_libraryt::ptr_pred_ctx_reset_call(
+  const exprt &ptr_pred_ctx_ptr,
+  const source_locationt &source_location)
+{
+  code_function_callt call(
+    dfcc_fun_symbol[dfcc_funt::PTR_PRED_CTX_INIT].symbol_expr(),
+    {ptr_pred_ctx_ptr});
   call.add_source_location() = source_location;
   return call;
 }

--- a/src/goto-instrument/contracts/dynamic-frames/dfcc_library.h
+++ b/src/goto-instrument/contracts/dynamic-frames/dfcc_library.h
@@ -31,6 +31,10 @@ enum class dfcc_typet
   CAR_SET,
   /// type of pointers to sets of CAR
   CAR_SET_PTR,
+  /// type of context info for pointer predicates evaluation
+  PTR_PRED_CTX,
+  /// type of pointers to context info for pointer predicates evaluation
+  PTR_PRED_CTX_PTR,
   /// type of sets of object identifiers
   OBJ_SET,
   /// type of pointers to sets of object identifiers
@@ -62,6 +66,10 @@ enum class dfcc_funt
   OBJ_SET_CREATE_APPEND,
   /// \see __CPROVER_contracts_obj_set_release
   OBJ_SET_RELEASE,
+  /// \see __CPROVER_contracts_ptr_pred_ctx_init
+  PTR_PRED_CTX_INIT,
+  /// \see __CPROVER_contracts_ptr_pred_ctx_reset
+  PTR_PRED_CTX_RESET,
   /// \see __CPROVER_contracts_obj_set_add
   OBJ_SET_ADD,
   /// \see __CPROVER_contracts_obj_set_append
@@ -120,8 +128,8 @@ enum class dfcc_funt
   WRITE_SET_HAVOC_OBJECT_WHOLE,
   /// \see __CPROVER_contracts_write_set_havoc_slice
   WRITE_SET_HAVOC_SLICE,
-  /// \see __CPROVER_contracts_link_is_fresh
-  LINK_IS_FRESH,
+  /// \see __CPROVER_contracts_link_ptr_pred_ctx
+  LINK_PTR_PRED_CTX,
   /// \see __CPROVER_contracts_link_allocated
   LINK_ALLOCATED,
   /// \see __CPROVER_contracts_link_deallocated
@@ -155,9 +163,7 @@ class typet;
 class dfcc_libraryt
 {
 public:
-  dfcc_libraryt(
-    goto_modelt &goto_model,
-    message_handlert &lmessage_handler);
+  dfcc_libraryt(goto_modelt &goto_model, message_handlert &lmessage_handler);
 
 protected:
   /// True iff the contracts library symbols are loaded
@@ -413,10 +419,10 @@ public:
     const source_locationt &source_location);
 
   /// \brief Builds call to
-  /// \ref __CPROVER_contracts_link_is_fresh
-  const code_function_callt link_is_fresh_call(
+  /// \ref __CPROVER_contracts_link_ptr_pred_ctx
+  const code_function_callt link_ptr_pred_ctx_call(
     const exprt &write_set_ptr,
-    const exprt &is_fresh_obj_set_ptr,
+    const exprt &ptr_pred_ctx_ptr,
     const source_locationt &source_location);
 
   /// \brief Builds call to
@@ -450,6 +456,18 @@ public:
   /// \ref __CPROVER_contracts_obj_set_release
   const code_function_callt obj_set_release_call(
     const exprt &obj_set_ptr,
+    const source_locationt &source_location);
+
+  /// \brief Builds call to
+  /// \ref __CPROVER_contracts_ptr_pred_ctx_init
+  const code_function_callt ptr_pred_ctx_init_call(
+    const exprt &ptr_pred_ctx_ptr,
+    const source_locationt &source_location);
+
+  /// \brief Builds call to
+  /// \ref __CPROVER_contracts_ptr_pred_ctx_init
+  const code_function_callt ptr_pred_ctx_reset_call(
+    const exprt &ptr_pred_ctx_ptr,
     const source_locationt &source_location);
 };
 


### PR DESCRIPTION
- Replaces a bool array indexed by object ID by a nondet demonic variable to
track the set of fresh objects and implement separation checks.
- Ensures requires or ensures clause assume/assert at most one predicate
per pointer by tracking locations where these pointers are stored and adding
separation checks on them as well. This is necessary to catch and reject occurences like
`__CPROVER_is_fresh(p, size) && __CPROVER_is_fresh(p, size)` that would pass in assume
contexts by allocating twice but fail in assert contexts.
- Adds a new type `__CPROVER_contracts_ptr_pred_ctx_t` in `cprover_contracts.c`
to store all contextual information needed to evaluate all pointer predicates.
- Propagate changes to `dfcc_libraryt` and `dfcc_wrapper_programt`.
- Add new tests for pointer assumption uniqueness checks.
- Fix failing tests that used is_fresh under negation in ensures.
- Update dev doc


<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [x] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
