### PR TITLE
CONTRACTS: force success for necessary pointer predicates

### DIFF
--- a/regression/contracts-dfcc/quantifiers-loops-fresh-bound-vars-smt/test.desc
+++ b/regression/contracts-dfcc/quantifiers-loops-fresh-bound-vars-smt/test.desc
@@ -1,4 +1,4 @@
-FUTURE dfcc-only smt-backend broken-cprover-smt-backend
+CORE dfcc-only smt-backend broken-cprover-smt-backend
 main.c
 --dfcc main --apply-loop-contracts --enforce-contract foo --malloc-may-fail --malloc-fail-null _ --z3 --slice-formula --no-standard-checks
 ^EXIT=0$
@@ -7,11 +7,6 @@ main.c
 --
 ^warning: ignoring
 --
-
-Marked as FUTURE because:
-- z3 >v4.12 and up can solve the problem with `--dfcc-simple-invalid-pointer-model`,
- but the CI uses older versions;
-- bitwuzla >v0.6 can solve the problem but we don't run bitwuzla in CI.
 
 Tests support for quantifiers in loop contracts with the SMT backend.
 When quantified loop invariants are used, they are inserted three times

--- a/src/ansi-c/library/cprover_contracts.c
+++ b/src/ansi-c/library/cprover_contracts.c
@@ -1166,6 +1166,7 @@ void __CPROVER_contracts_make_invalid_pointer(void **ptr)
 ///
 /// \param ptr1 First argument of the `pointer_equals` predicate
 /// \param ptr2 Second argument of the `pointer_equals` predicate
+/// \param may_fail Allow predicate to fail in assume mode
 /// \param write_set Write set which conveys the invocation context
 ///   (requires/ensures clause, assert/assume context);
 ///
@@ -1179,6 +1180,7 @@ void __CPROVER_contracts_make_invalid_pointer(void **ptr)
 __CPROVER_bool __CPROVER_contracts_pointer_equals(
   void **ptr1,
   void *ptr2,
+  __CPROVER_bool may_fail,
   __CPROVER_contracts_write_set_ptr_t write_set)
 {
 __CPROVER_HIDE:;
@@ -1195,7 +1197,8 @@ __CPROVER_HIDE:;
 #endif
   if(write_set->assume_requires_ctx | write_set->assume_ensures_ctx)
   {
-    if(__VERIFIER_nondet___CPROVER_bool())
+    // SOUNDNESS: allow predicate to fail
+    if(may_fail && __VERIFIER_nondet___CPROVER_bool())
     {
       __CPROVER_contracts_make_invalid_pointer(ptr1);
       return 0;
@@ -1224,8 +1227,9 @@ __CPROVER_HIDE:;
 /// The behaviour depends on the boolean flags carried by \p write_set
 /// which reflect the invocation context: checking vs. replacing a contract,
 /// in a requires or an ensures clause context.
-/// \param elem First argument of the `is_fresh` predicate
-/// \param size Second argument of the `is_fresh` predicate
+/// \param elem Pointer to the target pointer of the check
+/// \param size Size to check for
+/// \param may_fail Allow predicate to fail in assume mode
 /// \param write_set Write set in which seen/allocated objects are recorded;
 ///
 /// \details The behaviour is as follows:
@@ -1242,6 +1246,7 @@ __CPROVER_HIDE:;
 __CPROVER_bool __CPROVER_contracts_is_fresh(
   void **elem,
   __CPROVER_size_t size,
+  __CPROVER_bool may_fail,
   __CPROVER_contracts_write_set_ptr_t write_set)
 {
 __CPROVER_HIDE:;
@@ -1289,7 +1294,7 @@ __CPROVER_HIDE:;
     }
 
     // SOUNDNESS: allow predicate to fail
-    if(__VERIFIER_nondet___CPROVER_bool())
+    if(may_fail && __VERIFIER_nondet___CPROVER_bool())
     {
       __CPROVER_contracts_make_invalid_pointer(elem);
       return 0;
@@ -1349,7 +1354,7 @@ __CPROVER_HIDE:;
     }
 
     // SOUNDNESS: allow predicate to fail
-    if(__VERIFIER_nondet___CPROVER_bool())
+    if(may_fail && __VERIFIER_nondet___CPROVER_bool())
     {
       __CPROVER_contracts_make_invalid_pointer(elem);
       return 0;
@@ -1436,6 +1441,7 @@ __CPROVER_HIDE:;
 /// \param lb Lower bound pointer
 /// \param ptr Target pointer of the predicate
 /// \param ub Upper bound pointer
+/// \param may_fail Allow predicate to fail in assume mode
 /// \param write_set Write set in which seen/allocated objects are recorded;
 ///
 /// \details The behaviour is as follows:
@@ -1449,6 +1455,7 @@ __CPROVER_bool __CPROVER_contracts_pointer_in_range_dfcc(
   void *lb,
   void **ptr,
   void *ub,
+  __CPROVER_bool may_fail,
   __CPROVER_contracts_write_set_ptr_t write_set)
 {
 __CPROVER_HIDE:;
@@ -1470,9 +1477,9 @@ __CPROVER_HIDE:;
     lb_offset <= ub_offset, "lb and ub pointers must be ordered");
   if(write_set->assume_requires_ctx | write_set->assume_ensures_ctx)
   {
-    if(__VERIFIER_nondet___CPROVER_bool())
+    // SOUNDNESS: allow predicate to fail
+    if(may_fail && __VERIFIER_nondet___CPROVER_bool())
     {
-      // SOUNDNESS: allow predicate to fail
       __CPROVER_contracts_make_invalid_pointer(ptr);
       return 0;
     }
@@ -1647,6 +1654,7 @@ __CPROVER_HIDE:;
 __CPROVER_bool __CPROVER_contracts_obeys_contract(
   void (**function_pointer)(void),
   void (*contract)(void),
+  __CPROVER_bool may_fail,
   __CPROVER_contracts_write_set_ptr_t set)
 {
 __CPROVER_HIDE:;
@@ -1657,8 +1665,8 @@ __CPROVER_HIDE:;
     "__CPROVER_obeys_contract is used only in requires or ensures clauses");
   if((set->assume_requires_ctx == 1) | (set->assume_ensures_ctx == 1))
   {
-    // decide if predicate must hold
-    if(__VERIFIER_nondet___CPROVER_bool())
+    // SOUDNESS: allow predicate to fail
+    if(may_fail && __VERIFIER_nondet___CPROVER_bool())
       return 0;
 
     // must hold, assign the function pointer to the contract function

--- a/src/goto-instrument/contracts/dynamic-frames/dfcc_is_cprover_symbol.cpp
+++ b/src/goto-instrument/contracts/dynamic-frames/dfcc_is_cprover_symbol.cpp
@@ -156,3 +156,11 @@ bool dfcc_is_cprover_static_symbol(const irep_idt &id)
          // going_to variables converted from goto statements
          has_prefix(id2string(id), CPROVER_PREFIX "going_to");
 }
+
+bool dfcc_is_cprover_pointer_predicate(const irep_idt &id)
+{
+  return id == CPROVER_PREFIX "pointer_equals" ||
+         id == CPROVER_PREFIX "is_fresh" ||
+         id == CPROVER_PREFIX "pointer_in_range_dfcc" ||
+         id == CPROVER_PREFIX "obeys_contract";
+}

--- a/src/goto-instrument/contracts/dynamic-frames/dfcc_is_cprover_symbol.h
+++ b/src/goto-instrument/contracts/dynamic-frames/dfcc_is_cprover_symbol.h
@@ -24,4 +24,7 @@ bool dfcc_is_cprover_function_symbol(const irep_idt &id);
 /// auto-generated object following a pointer dereference.
 bool dfcc_is_cprover_static_symbol(const irep_idt &id);
 
+/// Returns `true` iff the symbol is one of the CPROVER pointer predicates
+bool dfcc_is_cprover_pointer_predicate(const irep_idt &id);
+
 #endif

--- a/src/goto-instrument/contracts/dynamic-frames/dfcc_is_fresh.cpp
+++ b/src/goto-instrument/contracts/dynamic-frames/dfcc_is_fresh.cpp
@@ -11,6 +11,8 @@ Date: August 2022
 
 #include <util/cprover_prefix.h>
 #include <util/pointer_expr.h>
+#include <util/prefix.h>
+#include <util/suffix.h>
 #include <util/symbol.h>
 
 #include "dfcc_cfg_info.h"
@@ -50,8 +52,7 @@ void dfcc_is_fresht::rewrite_calls(
       if(function.id() == ID_symbol)
       {
         const irep_idt &fun_name = to_symbol_expr(function).get_identifier();
-
-        if(fun_name == CPROVER_PREFIX "is_fresh")
+        if(has_prefix(id2string(fun_name), CPROVER_PREFIX "is_fresh"))
         {
           // add address on first operand
           target->call_arguments()[0] =
@@ -60,6 +61,12 @@ void dfcc_is_fresht::rewrite_calls(
           // fix the function name.
           to_symbol_expr(target->call_function())
             .set_identifier(library.dfcc_fun_symbol[dfcc_funt::IS_FRESH].name);
+
+          // pass the may_fail flag
+          if(function.source_location().get_bool("no_fail"))
+            target->call_arguments().push_back(false_exprt());
+          else
+            target->call_arguments().push_back(true_exprt());
 
           // pass the write_set
           target->call_arguments().push_back(cfg_info.get_write_set(target));

--- a/src/goto-instrument/contracts/dynamic-frames/dfcc_obeys_contract.cpp
+++ b/src/goto-instrument/contracts/dynamic-frames/dfcc_obeys_contract.cpp
@@ -12,6 +12,7 @@ Date: August 2022
 #include <util/cprover_prefix.h>
 #include <util/pointer_expr.h>
 #include <util/prefix.h>
+#include <util/suffix.h>
 #include <util/symbol.h>
 
 #include <langapi/language_util.h>
@@ -86,6 +87,12 @@ void dfcc_obeys_contractt::rewrite_calls(
           to_symbol_expr(target->call_function())
             .set_identifier(
               library.dfcc_fun_symbol[dfcc_funt::OBEYS_CONTRACT].name);
+
+          // pass the may_fail flag
+          if(function.source_location().get_bool("no_fail"))
+            target->call_arguments().push_back(false_exprt());
+          else
+            target->call_arguments().push_back(true_exprt());
 
           // pass the write_set
           target->call_arguments().push_back(cfg_info.get_write_set(target));

--- a/src/goto-instrument/contracts/dynamic-frames/dfcc_pointer_equals.cpp
+++ b/src/goto-instrument/contracts/dynamic-frames/dfcc_pointer_equals.cpp
@@ -13,9 +13,11 @@ Date: Jan 2025
 #include <util/cprover_prefix.h>
 #include <util/expr_iterator.h>
 #include <util/pointer_expr.h>
+#include <util/prefix.h>
 #include <util/replace_expr.h>
 #include <util/std_code.h>
 #include <util/std_expr.h>
+#include <util/suffix.h>
 #include <util/symbol.h>
 
 #include "dfcc_cfg_info.h"
@@ -56,7 +58,7 @@ void dfcc_pointer_equalst::rewrite_calls(
       {
         const irep_idt &fun_name = to_symbol_expr(function).get_identifier();
 
-        if(fun_name == CPROVER_PREFIX "pointer_equals")
+        if(has_prefix(id2string(fun_name), CPROVER_PREFIX "pointer_equals"))
         {
           // add address on first operand
           target->call_arguments()[0] =
@@ -66,6 +68,12 @@ void dfcc_pointer_equalst::rewrite_calls(
           to_symbol_expr(target->call_function())
             .set_identifier(
               library.dfcc_fun_symbol[dfcc_funt::POINTER_EQUALS].name);
+
+          // pass the may_fail flag
+          if(function.source_location().get_bool("no_fail"))
+            target->call_arguments().push_back(false_exprt());
+          else
+            target->call_arguments().push_back(true_exprt());
 
           // pass the write_set
           target->call_arguments().push_back(cfg_info.get_write_set(target));
@@ -106,7 +114,8 @@ public:
        code_typet::parametert(pointer_type(void_type()))},
       bool_typet());
 
-    symbol_exprt pointer_equals("ID_pointer_equals", pointer_equals_type);
+    symbol_exprt pointer_equals(
+      CPROVER_PREFIX "pointer_equals", pointer_equals_type);
 
     for(exprt *expr_ptr : equality_exprs_to_transform)
     {

--- a/src/goto-instrument/contracts/dynamic-frames/dfcc_pointer_in_range.cpp
+++ b/src/goto-instrument/contracts/dynamic-frames/dfcc_pointer_in_range.cpp
@@ -11,8 +11,10 @@ Date: August 2022
 
 #include <util/cprover_prefix.h>
 #include <util/pointer_expr.h>
+#include <util/prefix.h>
 #include <util/replace_expr.h>
 #include <util/std_code.h>
+#include <util/suffix.h>
 #include <util/symbol.h>
 
 #include "dfcc_cfg_info.h"
@@ -53,7 +55,8 @@ void dfcc_pointer_in_ranget::rewrite_calls(
       {
         const irep_idt &fun_name = to_symbol_expr(function).get_identifier();
 
-        if(fun_name == CPROVER_PREFIX "pointer_in_range_dfcc")
+        if(has_prefix(
+             id2string(fun_name), CPROVER_PREFIX "pointer_in_range_dfcc"))
         {
           // add address on second operand
           target->call_arguments()[1] =
@@ -63,6 +66,13 @@ void dfcc_pointer_in_ranget::rewrite_calls(
           to_symbol_expr(target->call_function())
             .set_identifier(
               library.dfcc_fun_symbol[dfcc_funt::POINTER_IN_RANGE_DFCC].name);
+
+          // pass the may_fail flag
+          // pass the may_fail flag
+          if(function.source_location().get_bool("no_fail"))
+            target->call_arguments().push_back(false_exprt());
+          else
+            target->call_arguments().push_back(true_exprt());
 
           // pass the write_set
           target->call_arguments().push_back(cfg_info.get_write_set(target));


### PR DESCRIPTION
Force success for pointer predicates that must necessarily hold if they ever get invoked in an assumption context. This ensures that the value sets of pointers as as small as possible after assuming a requires or an ensures clause and solves a performance issue with z3. All predicates in the `cprover_contracts.c` library now have an extra input `may_fail` controlling the failure behaviour, DFCC instrumentation sets the `may_fail` parameter to true or false using a recursive downwards propagation algorithm that takes into account the shortcutting behaviour of `==>`, `&&` and `||`. This applies to all predicates (pointer_equals, is_fresh, pointer_in_range and obeys_contract for function pointers).

The test that regressed due to #8562 now passes again.

## Example

```C
void foo(int len_a, int* a, int len_b, int *b)
__CPROVER_requires(len_a > 0 ==> is_fresh(a, len_a) && len_b > 0 ==> is_fresh(b, len_b));
```
Is tagged  as follows :

```  
                         AND[F]
                ___________|_____________
               /                         \
              /                           \
         IMPLIES[F]                    IMPLIES[F]
          /      \                     /         \
        /         \                   /           \
 len_a>0[T]   is_fresh(a,len)[F]  len_b>0[T] is_fresh(b,len_b)[F]
```
In order for the the requires clause to hold when assumed, the `is_fresh` predicates in the RHS of implications 
must not fail if they ever get invoked, those left of disjunctions may fail

## Example

```C
void foo(int len, int* a, int *b, int *c, int *d)
__CPROVER_ensures(
   is_fresh(a, len) && 
   is_fresh(b, len)  && 
   is_fresh(c, len) && 
   (pointer_equals(d, a) || pointer_equals(d, b) || pointer_equals(d, c))
)
```

Will be tagged 
```
                                     AND[F]
                 ____________________|___________________________
                /                /                   |           \
               /                /                    |            \
              /                /                     |             \
    is_fresh(a,len)[F]  is_fresh(b,len)[F]  is_fresh(c,len)[F]    OR [F]
                                                                ______|_________
                                                               /      |         \
                                                              /       |          \
                                                             /        |           \
                                                 ptr_eq(d,a)[T]  ptr_eq(d,b)[T]  ptr_eq(d,c)[F]
```
The top conjuncts may not fail for the whole expression to hold, and the last element of the disjunction may not fail if it ever gets invoked after all other leftmost disjuncts may have failed.

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.
