### PR TITLE
CONTRACTS: separation checks using nondet demonic variable

### DIFF
--- a/regression/contracts-dfcc/test_aliasing_ensure/main.c
+++ b/regression/contracts-dfcc/test_aliasing_ensure/main.c
@@ -1,35 +1,15 @@
-#include <assert.h>
-#include <stdbool.h>
-#include <stdlib.h>
-
-int z;
-
-// clang-format off
-int foo(int *x, int *y)
-  __CPROVER_assigns(z, *x)
-  __CPROVER_requires(
-    __CPROVER_is_fresh(x, sizeof(int)) &&
-    *x > 0 &&
-    *x < 4)
-  __CPROVER_ensures(
-    __CPROVER_is_fresh(y, sizeof(int)) &&
-    !__CPROVER_is_fresh(x, sizeof(int)) &&
-    x != NULL &&
-    x != y &&
-    __CPROVER_return_value == *x + 5)
+int *foo()
+  // clang-format off
+  __CPROVER_ensures(__CPROVER_is_fresh(__CPROVER_return_value, sizeof(int)))
 // clang-format on
 {
-  *x = *x + 4;
-  y = malloc(sizeof(*y));
-  *y = *x;
-  z = *y;
-  return (*x + 5);
+  int *ret = malloc(sizeof(int));
+  __CPROVER_assume(ret);
+  return ret;
 }
 
 int main()
 {
-  int n = 4;
-  n = foo(&n, &n);
-  assert(!(n < 4));
+  foo();
   return 0;
 }

--- a/regression/contracts-dfcc/test_aliasing_ensure/test.desc
+++ b/regression/contracts-dfcc/test_aliasing_ensure/test.desc
@@ -4,10 +4,6 @@ main.c
 ^EXIT=0$
 ^SIGNAL=0$
 \[foo.postcondition.\d+\].*Check ensures clause of contract contract::foo for function foo: SUCCESS$
-\[foo.assigns.\d+\].*Check that \*x is assignable: SUCCESS
-\[foo.assigns.\d+\].*Check that \*y is assignable: SUCCESS
-\[foo.assigns.\d+\].*Check that z is assignable: SUCCESS
-\[main.assertion.\d+\].*assertion \!\(n \< 4\): SUCCESS
 ^VERIFICATION SUCCESSFUL$
 --
 --

--- a/regression/contracts-dfcc/test_scalar_memory_enforce/main.c
+++ b/regression/contracts-dfcc/test_scalar_memory_enforce/main.c
@@ -21,7 +21,6 @@ int foo(int *x)
     ptr_ok(x))
   __CPROVER_ensures(
     !ptr_ok(x) &&
-    !__CPROVER_is_fresh(x, sizeof(int)) &&
     return_ok(__CPROVER_return_value, x))
 // clang-format on
 {

--- a/src/goto-instrument/contracts/doc/developer/contracts-dev-spec-dfcc-runtime.md
+++ b/src/goto-instrument/contracts/doc/developer/contracts-dev-spec-dfcc-runtime.md
@@ -112,8 +112,8 @@ typedef struct __CPROVER_contracts_write_set_t
   // Set of objects deallocated by the function under analysis (indexed mode)
   __CPROVER_contracts_obj_set_t deallocated;
 
-  // Object set supporting the is_fresh predicate checks (indexed mode)
-  __CPROVER_contracts_obj_set_ptr_t linked_is_fresh;
+  // Object set supporting the pointer predicate checks
+  __CPROVER_contracts_ptr_pred_ctx_ptr_t linked_ptr_pred_ctx;
 
   // Object set recording the is_fresh allocations in post conditions
   // (replacement mode only)

--- a/src/goto-instrument/contracts/dynamic-frames/dfcc_is_cprover_symbol.cpp
+++ b/src/goto-instrument/contracts/dynamic-frames/dfcc_is_cprover_symbol.cpp
@@ -30,6 +30,8 @@ init_function_symbols(std::unordered_set<irep_idt> &function_symbols)
     function_symbols.insert(CPROVER_PREFIX "assert");
     function_symbols.insert(CPROVER_PREFIX "assignable");
     function_symbols.insert(CPROVER_PREFIX "assume");
+    function_symbols.insert(CPROVER_PREFIX "contracts_ptr_pred_ctx_init");
+    function_symbols.insert(CPROVER_PREFIX "contracts_ptr_pred_ctx_reset");
     function_symbols.insert(CPROVER_PREFIX "contracts_car_create");
     function_symbols.insert(CPROVER_PREFIX "contracts_car_set_contains");
     function_symbols.insert(CPROVER_PREFIX "contracts_car_set_create");
@@ -42,7 +44,7 @@ init_function_symbols(std::unordered_set<irep_idt> &function_symbols)
     function_symbols.insert(CPROVER_PREFIX "contracts_is_fresh");
     function_symbols.insert(CPROVER_PREFIX "contracts_link_allocated");
     function_symbols.insert(CPROVER_PREFIX "contracts_link_deallocated");
-    function_symbols.insert(CPROVER_PREFIX "contracts_link_is_fresh");
+    function_symbols.insert(CPROVER_PREFIX "contracts_link_ptr_pred_ctx");
     function_symbols.insert(CPROVER_PREFIX "contracts_obeys_contract");
     function_symbols.insert(CPROVER_PREFIX "contracts_obj_set_add");
     function_symbols.insert(CPROVER_PREFIX "contracts_obj_set_append");

--- a/src/goto-instrument/contracts/dynamic-frames/dfcc_library.cpp
+++ b/src/goto-instrument/contracts/dynamic-frames/dfcc_library.cpp
@@ -52,6 +52,8 @@ const std::map<dfcc_typet, irep_idt> create_dfcc_type_to_name()
     {dfcc_typet::CAR, CONTRACTS_PREFIX "car_t"},
     {dfcc_typet::CAR_SET, CONTRACTS_PREFIX "car_set_t"},
     {dfcc_typet::CAR_SET_PTR, CONTRACTS_PREFIX "car_set_ptr_t"},
+    {dfcc_typet::PTR_PRED_CTX, CONTRACTS_PREFIX "ptr_pred_ctx_t"},
+    {dfcc_typet::PTR_PRED_CTX_PTR, CONTRACTS_PREFIX "ptr_pred_ctx_ptr_t"},
     {dfcc_typet::OBJ_SET, CONTRACTS_PREFIX "obj_set_t"},
     {dfcc_typet::OBJ_SET_PTR, CONTRACTS_PREFIX "obj_set_ptr_t"},
     {dfcc_typet::WRITE_SET, CONTRACTS_PREFIX "write_set_t"},
@@ -122,9 +124,11 @@ const std::map<dfcc_funt, irep_idt> create_dfcc_fun_to_name()
      CONTRACTS_PREFIX "write_set_havoc_object_whole"},
     {dfcc_funt::WRITE_SET_HAVOC_SLICE,
      CONTRACTS_PREFIX "write_set_havoc_slice"},
-    {dfcc_funt::LINK_IS_FRESH, CONTRACTS_PREFIX "link_is_fresh"},
+    {dfcc_funt::LINK_PTR_PRED_CTX, CONTRACTS_PREFIX "link_ptr_pred_ctx"},
     {dfcc_funt::LINK_ALLOCATED, CONTRACTS_PREFIX "link_allocated"},
     {dfcc_funt::LINK_DEALLOCATED, CONTRACTS_PREFIX "link_deallocated"},
+    {dfcc_funt::PTR_PRED_CTX_INIT, CONTRACTS_PREFIX "ptr_pred_ctx_init"},
+    {dfcc_funt::PTR_PRED_CTX_RESET, CONTRACTS_PREFIX "ptr_pred_ctx_reset"},
     {dfcc_funt::POINTER_EQUALS, CONTRACTS_PREFIX "pointer_equals"},
     {dfcc_funt::IS_FRESH, CONTRACTS_PREFIX "is_fresh"},
     {dfcc_funt::POINTER_IN_RANGE_DFCC,
@@ -810,14 +814,14 @@ const code_function_callt dfcc_libraryt::write_set_deallocate_freeable_call(
   return call;
 }
 
-const code_function_callt dfcc_libraryt::link_is_fresh_call(
+const code_function_callt dfcc_libraryt::link_ptr_pred_ctx_call(
   const exprt &write_set_ptr,
-  const exprt &is_fresh_obj_set_ptr,
+  const exprt &ptr_pred_ctx_ptr,
   const source_locationt &source_location)
 {
   code_function_callt call(
-    dfcc_fun_symbol[dfcc_funt::LINK_IS_FRESH].symbol_expr(),
-    {write_set_ptr, is_fresh_obj_set_ptr});
+    dfcc_fun_symbol[dfcc_funt::LINK_PTR_PRED_CTX].symbol_expr(),
+    {write_set_ptr, ptr_pred_ctx_ptr});
   call.add_source_location() = source_location;
   return call;
 }
@@ -879,6 +883,28 @@ const code_function_callt dfcc_libraryt::obj_set_release_call(
 {
   code_function_callt call(
     dfcc_fun_symbol[dfcc_funt::OBJ_SET_RELEASE].symbol_expr(), {obj_set_ptr});
+  call.add_source_location() = source_location;
+  return call;
+}
+
+const code_function_callt dfcc_libraryt::ptr_pred_ctx_init_call(
+  const exprt &ptr_pred_ctx_ptr,
+  const source_locationt &source_location)
+{
+  code_function_callt call(
+    dfcc_fun_symbol[dfcc_funt::PTR_PRED_CTX_INIT].symbol_expr(),
+    {ptr_pred_ctx_ptr});
+  call.add_source_location() = source_location;
+  return call;
+}
+
+const code_function_callt dfcc_libraryt::ptr_pred_ctx_reset_call(
+  const exprt &ptr_pred_ctx_ptr,
+  const source_locationt &source_location)
+{
+  code_function_callt call(
+    dfcc_fun_symbol[dfcc_funt::PTR_PRED_CTX_INIT].symbol_expr(),
+    {ptr_pred_ctx_ptr});
   call.add_source_location() = source_location;
   return call;
 }

--- a/src/goto-instrument/contracts/dynamic-frames/dfcc_library.h
+++ b/src/goto-instrument/contracts/dynamic-frames/dfcc_library.h
@@ -31,6 +31,10 @@ enum class dfcc_typet
   CAR_SET,
   /// type of pointers to sets of CAR
   CAR_SET_PTR,
+  /// type of context info for pointer predicates evaluation
+  PTR_PRED_CTX,
+  /// type of pointers to context info for pointer predicates evaluation
+  PTR_PRED_CTX_PTR,
   /// type of sets of object identifiers
   OBJ_SET,
   /// type of pointers to sets of object identifiers
@@ -62,6 +66,10 @@ enum class dfcc_funt
   OBJ_SET_CREATE_APPEND,
   /// \see __CPROVER_contracts_obj_set_release
   OBJ_SET_RELEASE,
+  /// \see __CPROVER_contracts_ptr_pred_ctx_init
+  PTR_PRED_CTX_INIT,
+  /// \see __CPROVER_contracts_ptr_pred_ctx_reset
+  PTR_PRED_CTX_RESET,
   /// \see __CPROVER_contracts_obj_set_add
   OBJ_SET_ADD,
   /// \see __CPROVER_contracts_obj_set_append
@@ -120,8 +128,8 @@ enum class dfcc_funt
   WRITE_SET_HAVOC_OBJECT_WHOLE,
   /// \see __CPROVER_contracts_write_set_havoc_slice
   WRITE_SET_HAVOC_SLICE,
-  /// \see __CPROVER_contracts_link_is_fresh
-  LINK_IS_FRESH,
+  /// \see __CPROVER_contracts_link_ptr_pred_ctx
+  LINK_PTR_PRED_CTX,
   /// \see __CPROVER_contracts_link_allocated
   LINK_ALLOCATED,
   /// \see __CPROVER_contracts_link_deallocated
@@ -155,9 +163,7 @@ class typet;
 class dfcc_libraryt
 {
 public:
-  dfcc_libraryt(
-    goto_modelt &goto_model,
-    message_handlert &lmessage_handler);
+  dfcc_libraryt(goto_modelt &goto_model, message_handlert &lmessage_handler);
 
 protected:
   /// True iff the contracts library symbols are loaded
@@ -413,10 +419,10 @@ public:
     const source_locationt &source_location);
 
   /// \brief Builds call to
-  /// \ref __CPROVER_contracts_link_is_fresh
-  const code_function_callt link_is_fresh_call(
+  /// \ref __CPROVER_contracts_link_ptr_pred_ctx
+  const code_function_callt link_ptr_pred_ctx_call(
     const exprt &write_set_ptr,
-    const exprt &is_fresh_obj_set_ptr,
+    const exprt &ptr_pred_ctx_ptr,
     const source_locationt &source_location);
 
   /// \brief Builds call to
@@ -450,6 +456,18 @@ public:
   /// \ref __CPROVER_contracts_obj_set_release
   const code_function_callt obj_set_release_call(
     const exprt &obj_set_ptr,
+    const source_locationt &source_location);
+
+  /// \brief Builds call to
+  /// \ref __CPROVER_contracts_ptr_pred_ctx_init
+  const code_function_callt ptr_pred_ctx_init_call(
+    const exprt &ptr_pred_ctx_ptr,
+    const source_locationt &source_location);
+
+  /// \brief Builds call to
+  /// \ref __CPROVER_contracts_ptr_pred_ctx_init
+  const code_function_callt ptr_pred_ctx_reset_call(
+    const exprt &ptr_pred_ctx_ptr,
     const source_locationt &source_location);
 };
 


### PR DESCRIPTION
replace bool array indexed by object ID with nondet demonic tracker for `__CPROVER_is_fresh` separation checks

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
