### PR TITLE
CONTRACTS: ensure at most one predicate per pointer

### DIFF
--- a/regression/contracts-dfcc/test_pointer_pred_unique_enforce_fail/main.c
+++ b/regression/contracts-dfcc/test_pointer_pred_unique_enforce_fail/main.c
@@ -1,0 +1,66 @@
+int nondet_int();
+void foo(
+  int *in,
+  int *in1,
+  int *in2,
+  int *in3,
+  int *in4,
+  int *in5,
+  int *in6,
+  int **out1,
+  int **out2,
+  int **out3,
+  int **out4,
+  int **out5,
+  int **out6)
+  // clang-format off
+__CPROVER_requires(__CPROVER_is_fresh(in, sizeof(int)))
+__CPROVER_requires(__CPROVER_is_fresh(in1, sizeof(int)) && __CPROVER_pointer_in_range_dfcc(in, in1, in))
+__CPROVER_requires(__CPROVER_pointer_in_range_dfcc(in, in2, in) && __CPROVER_is_fresh(in2, sizeof(int)))
+__CPROVER_requires(__CPROVER_is_fresh(in3, sizeof(int)) && __CPROVER_pointer_equals(in3, in))
+__CPROVER_requires(__CPROVER_pointer_equals(in4, in) && __CPROVER_is_fresh(in4, sizeof(int)))
+__CPROVER_requires(__CPROVER_pointer_in_range_dfcc(in, in5, in) && __CPROVER_pointer_equals(in5, in))
+__CPROVER_requires(__CPROVER_pointer_equals(in6, in) && __CPROVER_pointer_in_range_dfcc(in, in6, in))
+__CPROVER_requires(__CPROVER_is_fresh(out1, sizeof(int *)))
+__CPROVER_requires(__CPROVER_is_fresh(out2, sizeof(int *)))
+__CPROVER_requires(__CPROVER_is_fresh(out3, sizeof(int *)))
+__CPROVER_requires(__CPROVER_is_fresh(out4, sizeof(int *)))
+__CPROVER_requires(__CPROVER_is_fresh(out5, sizeof(int *)))
+__CPROVER_requires(__CPROVER_is_fresh(out6, sizeof(int *)))
+__CPROVER_assigns(*out1, *out2, *out3, *out4, *out5, *out6)
+__CPROVER_ensures(__CPROVER_is_fresh(*out1, sizeof(int)) && __CPROVER_pointer_in_range_dfcc(in, *out1, in))
+__CPROVER_ensures(__CPROVER_pointer_in_range_dfcc(in, *out2, in) && __CPROVER_is_fresh(*out2, sizeof(int)))
+__CPROVER_ensures(__CPROVER_is_fresh(*out3, sizeof(int)) && __CPROVER_pointer_equals(*out3, in))
+__CPROVER_ensures(__CPROVER_pointer_equals(*out4, in) && __CPROVER_is_fresh(*out4, sizeof(int)))
+__CPROVER_ensures(__CPROVER_pointer_in_range_dfcc(in, *out5, in) && __CPROVER_pointer_equals(*out5, in))
+__CPROVER_ensures(__CPROVER_pointer_equals(*out6, in) && __CPROVER_pointer_in_range_dfcc(in, *out6, in))
+// clang-format on
+{
+  int *tmp1 = malloc(sizeof(int));
+  __CPROVER_assume(tmp1);
+  *out1 = nondet_int() ? tmp1 : in;
+
+  int *tmp2 = malloc(sizeof(int));
+  __CPROVER_assume(tmp2);
+  *out2 = nondet_int() ? tmp2 : in;
+
+  int *tmp3 = malloc(sizeof(int));
+  __CPROVER_assume(tmp3);
+  *out3 = nondet_int() ? tmp3 : in;
+
+  int *tmp4 = malloc(sizeof(int));
+  __CPROVER_assume(tmp4);
+  *out4 = nondet_int() ? tmp4 : in;
+
+  *out5 = in;
+
+  *out6 = in;
+}
+
+int main()
+{
+  int *in, *in1, *in2, *in3, *in4, *in5, *in6;
+  int **out1, **out2, **out3, **out4, **out5, **out6;
+  foo(in, in1, in2, in3, in4, in5, in6, out1, out2, out3, out4, out5, out6);
+  return 0;
+}

--- a/regression/contracts-dfcc/test_pointer_pred_unique_enforce_fail/test.desc
+++ b/regression/contracts-dfcc/test_pointer_pred_unique_enforce_fail/test.desc
@@ -1,0 +1,19 @@
+CORE dfcc-only
+main.c
+--dfcc main --enforce-contract foo _ --arrays-uf-always --slice-formula
+^\[__CPROVER_contracts_is_fresh.assertion.\d+] line \d+ __CPROVER_is_fresh does not conflict with other pointer predicate in assume context: FAILURE$
+^\[__CPROVER_contracts_is_fresh.assertion.\d+] line \d+ __CPROVER_is_fresh does not conflict with other pointer predicate in assert context: FAILURE$
+^\[__CPROVER_contracts_pointer_equals.assertion.\d+] line \d+ __CPROVER_pointer_equals does not conflict with other pointer predicate in assume context: FAILURE$
+^\[__CPROVER_contracts_pointer_equals.assertion.\d+] line \d+ __CPROVER_pointer_equals does not conflict with other pointer predicate in assert context: FAILURE$
+^\[__CPROVER_contracts_pointer_in_range_dfcc.assertion.\d+] line \d+ __CPROVER_pointer_in_range_dfcc does not conflict with other pointer predicate in assume context: FAILURE$
+^\[__CPROVER_contracts_pointer_in_range_dfcc.assertion.\d+] line \d+ __CPROVER_pointer_in_range_dfcc does not conflict with other predicate in assert context: FAILURE$
+^EXIT=10$
+^SIGNAL=0$
+^VERIFICATION FAILED$
+--
+--
+Tests that the analysis fails when a same pointer is the target of multiple
+pointer predicates at the same time.
+
+We test all 6 pairwise combinations of is_fresh, poitner_equals,
+pointer_in_range_dfcc in mode assume-requires/assert-ensures.

--- a/regression/contracts-dfcc/test_pointer_pred_unique_enforce_pass/main.c
+++ b/regression/contracts-dfcc/test_pointer_pred_unique_enforce_pass/main.c
@@ -1,0 +1,61 @@
+int nondet_int();
+void foo(
+  int *in,
+  int *in1,
+  int *in2,
+  int *in3,
+  int *in4,
+  int *in5,
+  int *in6,
+  int **out1,
+  int **out2,
+  int **out3,
+  int **out4,
+  int **out5,
+  int **out6)
+  // clang-format off
+__CPROVER_requires(__CPROVER_is_fresh(in, sizeof(int)))
+__CPROVER_requires(__CPROVER_is_fresh(in1, sizeof(int)) || __CPROVER_pointer_in_range_dfcc(in, in1, in))
+__CPROVER_requires(__CPROVER_pointer_in_range_dfcc(in, in2, in) || __CPROVER_is_fresh(in2, sizeof(int)))
+__CPROVER_requires(__CPROVER_is_fresh(in3, sizeof(int)) || __CPROVER_pointer_equals(in3, in))
+__CPROVER_requires(__CPROVER_pointer_equals(in4, in) || __CPROVER_is_fresh(in4, sizeof(int)))
+__CPROVER_requires(__CPROVER_pointer_in_range_dfcc(in, in5, in) || __CPROVER_pointer_equals(in5, in))
+__CPROVER_requires(__CPROVER_pointer_equals(in6, in) || __CPROVER_pointer_in_range_dfcc(in, in6, in))
+__CPROVER_requires(__CPROVER_is_fresh(out1, sizeof(int *)))
+__CPROVER_requires(__CPROVER_is_fresh(out2, sizeof(int *)))
+__CPROVER_requires(__CPROVER_is_fresh(out3, sizeof(int *)))
+__CPROVER_requires(__CPROVER_is_fresh(out4, sizeof(int *)))
+__CPROVER_requires(__CPROVER_is_fresh(out5, sizeof(int *)))
+__CPROVER_requires(__CPROVER_is_fresh(out6, sizeof(int *)))
+__CPROVER_assigns(*out1, *out2, *out3, *out4, *out5, *out6)
+__CPROVER_ensures(__CPROVER_is_fresh(*out1, sizeof(int)) || __CPROVER_pointer_in_range_dfcc(in, *out1, in))
+__CPROVER_ensures(__CPROVER_pointer_in_range_dfcc(in, *out2, in) || __CPROVER_is_fresh(*out2, sizeof(int)))
+__CPROVER_ensures(__CPROVER_is_fresh(*out3, sizeof(int)) || __CPROVER_pointer_equals(*out3, in))
+__CPROVER_ensures(__CPROVER_pointer_equals(*out4, in) || __CPROVER_is_fresh(*out4, sizeof(int)))
+__CPROVER_ensures(__CPROVER_pointer_in_range_dfcc(in, *out5, in) || __CPROVER_pointer_equals(*out5, in))
+__CPROVER_ensures(__CPROVER_pointer_equals(*out6, in) || __CPROVER_pointer_in_range_dfcc(in, *out6, in))
+// clang-format on
+{
+  int *tmp1 = malloc(sizeof(int));
+  __CPROVER_assume(tmp1);
+  *out1 = nondet_int() ? tmp1 : in;
+  int *tmp2 = malloc(sizeof(int));
+  __CPROVER_assume(tmp2);
+  *out2 = nondet_int() ? tmp2 : in;
+  int *tmp3 = malloc(sizeof(int));
+  __CPROVER_assume(tmp3);
+  *out3 = nondet_int() ? tmp3 : in;
+  int *tmp4 = malloc(sizeof(int));
+  __CPROVER_assume(tmp4);
+  *out4 = nondet_int() ? tmp4 : in;
+  *out5 = in;
+  *out6 = in;
+}
+
+int main()
+{
+  int *in, *in1, *in2, *in3, *in4, *in5, *in6;
+  int **out1, **out2, **out3, **out4, **out5, **out6;
+  foo(in, in1, in2, in3, in4, in5, in6, out1, out2, out3, out4, out5, out6);
+  return 0;
+}

--- a/regression/contracts-dfcc/test_pointer_pred_unique_enforce_pass/test.desc
+++ b/regression/contracts-dfcc/test_pointer_pred_unique_enforce_pass/test.desc
@@ -1,0 +1,19 @@
+CORE dfcc-only
+main.c
+--dfcc main --enforce-contract foo _ --arrays-uf-always --slice-formula
+^\[__CPROVER_contracts_is_fresh.assertion.\d+\] line \d+ __CPROVER_is_fresh does not conflict with other pointer predicate in assume context: SUCCESS$
+^\[__CPROVER_contracts_is_fresh.assertion.\d+\] line \d+ __CPROVER_is_fresh does not conflict with other pointer predicate in assert context: SUCCESS$
+^\[__CPROVER_contracts_pointer_equals.assertion.\d+\] line \d+ __CPROVER_pointer_equals does not conflict with other pointer predicate in assume context: SUCCESS$
+^\[__CPROVER_contracts_pointer_equals.assertion.\d+\] line \d+ __CPROVER_pointer_equals does not conflict with other pointer predicate in assert context: SUCCESS$
+^\[__CPROVER_contracts_pointer_in_range_dfcc.assertion.\d+\] line \d+ __CPROVER_pointer_in_range_dfcc does not conflict with other pointer predicate in assume context: SUCCESS$
+^\[__CPROVER_contracts_pointer_in_range_dfcc.assertion.\d+\] line \d+ __CPROVER_pointer_in_range_dfcc does not conflict with other predicate in assert context: SUCCESS$
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+--
+Tests that a same pointer can be the target of multiple pointer predicates as
+long as they do not apply at the same time.
+
+We test all 6 pairwise combinations of is_fresh, poitner_equals,
+pointer_in_range_dfcc in mode assume-requires/assert-ensures.

--- a/regression/contracts-dfcc/test_pointer_pred_unique_replace_fail/main.c
+++ b/regression/contracts-dfcc/test_pointer_pred_unique_replace_fail/main.c
@@ -1,0 +1,89 @@
+int nondet_int();
+void foo(
+  int *in,
+  int *in1,
+  int *in2,
+  int *in3,
+  int *in4,
+  int *in5,
+  int *in6,
+  int **out1,
+  int **out2,
+  int **out3,
+  int **out4,
+  int **out5,
+  int **out6)
+  // clang-format off
+__CPROVER_requires(__CPROVER_is_fresh(in, sizeof(int)))
+__CPROVER_requires(__CPROVER_is_fresh(in1, sizeof(int)) && __CPROVER_pointer_in_range_dfcc(in, in1, in))
+__CPROVER_requires(__CPROVER_pointer_in_range_dfcc(in, in2, in) && __CPROVER_is_fresh(in2, sizeof(int)))
+__CPROVER_requires(__CPROVER_is_fresh(in3, sizeof(int)) && __CPROVER_pointer_equals(in3, in))
+__CPROVER_requires(__CPROVER_pointer_equals(in4, in) && __CPROVER_is_fresh(in4, sizeof(int)))
+__CPROVER_requires(__CPROVER_pointer_in_range_dfcc(in, in5, in) && __CPROVER_pointer_equals(in5, in))
+__CPROVER_requires(__CPROVER_pointer_equals(in6, in) && __CPROVER_pointer_in_range_dfcc(in, in6, in))
+__CPROVER_requires(__CPROVER_is_fresh(out1, sizeof(int *)))
+__CPROVER_requires(__CPROVER_is_fresh(out2, sizeof(int *)))
+__CPROVER_requires(__CPROVER_is_fresh(out3, sizeof(int *)))
+__CPROVER_requires(__CPROVER_is_fresh(out4, sizeof(int *)))
+__CPROVER_requires(__CPROVER_is_fresh(out5, sizeof(int *)))
+__CPROVER_requires(__CPROVER_is_fresh(out6, sizeof(int *)))
+__CPROVER_assigns(*out1, *out2, *out3, *out4, *out5, *out6)
+__CPROVER_ensures(__CPROVER_is_fresh(*out1, sizeof(int)) && __CPROVER_pointer_in_range_dfcc(in, *out1, in))
+__CPROVER_ensures(__CPROVER_pointer_in_range_dfcc(in, *out2, in) && __CPROVER_is_fresh(*out2, sizeof(int)))
+__CPROVER_ensures(__CPROVER_is_fresh(*out3, sizeof(int)) && __CPROVER_pointer_equals(*out3, in))
+__CPROVER_ensures(__CPROVER_pointer_equals(*out4, in) && __CPROVER_is_fresh(*out4, sizeof(int)))
+__CPROVER_ensures(__CPROVER_pointer_in_range_dfcc(in, *out5, in) && __CPROVER_pointer_equals(*out5, in))
+__CPROVER_ensures(__CPROVER_pointer_equals(*out6, in) && __CPROVER_pointer_in_range_dfcc(in, *out6, in))
+// clang-format on
+{
+  int *tmp1 = malloc(sizeof(int));
+  __CPROVER_assume(tmp1);
+  *out1 = nondet_int() ? tmp1 : in;
+
+  int *tmp2 = malloc(sizeof(int));
+  __CPROVER_assume(tmp2);
+  *out2 = nondet_int() ? tmp2 : in;
+
+  int *tmp3 = malloc(sizeof(int));
+  __CPROVER_assume(tmp3);
+  *out3 = nondet_int() ? tmp3 : in;
+
+  int *tmp4 = malloc(sizeof(int));
+  __CPROVER_assume(tmp4);
+  *out4 = nondet_int() ? tmp4 : in;
+
+  *out5 = in;
+
+  *out6 = in;
+}
+
+void bar()
+  // clang-format off
+__CPROVER_requires(1)
+__CPROVER_assigns()
+__CPROVER_ensures(1)
+// clang-format on
+{
+  int in, in1, in2, in3, in4, in5, in6;
+  int *out1, *out2, *out3, *out4, *out5, *out6;
+  foo(
+    &in,
+    nondet_bool() ? &in : &in1,
+    nondet_bool() ? &in : &in2,
+    nondet_bool() ? &in : &in3,
+    nondet_bool() ? &in : &in4,
+    &in,
+    &in,
+    &out1,
+    &out2,
+    &out3,
+    &out4,
+    &out5,
+    &out6);
+}
+
+int main()
+{
+  bar();
+  return 0;
+}

--- a/regression/contracts-dfcc/test_pointer_pred_unique_replace_fail/test.desc
+++ b/regression/contracts-dfcc/test_pointer_pred_unique_replace_fail/test.desc
@@ -1,0 +1,19 @@
+CORE dfcc-only
+main.c
+--dfcc main --replace-call-with-contract foo _ --arrays-uf-always --slice-formula
+^\[__CPROVER_contracts_is_fresh.assertion.\d+] line \d+ __CPROVER_is_fresh does not conflict with other pointer predicate in assume context: FAILURE$
+^\[__CPROVER_contracts_is_fresh.assertion.\d+] line \d+ __CPROVER_is_fresh does not conflict with other pointer predicate in assert context: FAILURE$
+^\[__CPROVER_contracts_pointer_equals.assertion.\d+] line \d+ __CPROVER_pointer_equals does not conflict with other pointer predicate in assume context: FAILURE$
+^\[__CPROVER_contracts_pointer_equals.assertion.\d+] line \d+ __CPROVER_pointer_equals does not conflict with other pointer predicate in assert context: FAILURE$
+^\[__CPROVER_contracts_pointer_in_range_dfcc.assertion.\d+] line \d+ __CPROVER_pointer_in_range_dfcc does not conflict with other pointer predicate in assume context: FAILURE$
+^\[__CPROVER_contracts_pointer_in_range_dfcc.assertion.\d+] line \d+ __CPROVER_pointer_in_range_dfcc does not conflict with other predicate in assert context: FAILURE$
+^EXIT=10$
+^SIGNAL=0$
+^VERIFICATION FAILED$
+--
+--
+Tests that the analysis fails when a same pointer is the target of multiple
+pointer predicates at the same time.
+
+We test all 6 pairwise combinations of is_fresh, poitner_equals,
+pointer_in_range_dfcc in mode assume-requires/assert-ensures.

--- a/regression/contracts-dfcc/test_pointer_pred_unique_replace_pass/main.c
+++ b/regression/contracts-dfcc/test_pointer_pred_unique_replace_pass/main.c
@@ -1,0 +1,84 @@
+int nondet_int();
+void foo(
+  int *in,
+  int *in1,
+  int *in2,
+  int *in3,
+  int *in4,
+  int *in5,
+  int *in6,
+  int **out1,
+  int **out2,
+  int **out3,
+  int **out4,
+  int **out5,
+  int **out6)
+  // clang-format off
+__CPROVER_requires(__CPROVER_is_fresh(in, sizeof(int)))
+__CPROVER_requires(__CPROVER_is_fresh(in1, sizeof(int)) || __CPROVER_pointer_in_range_dfcc(in, in1, in))
+__CPROVER_requires(__CPROVER_pointer_in_range_dfcc(in, in2, in) || __CPROVER_is_fresh(in2, sizeof(int)))
+__CPROVER_requires(__CPROVER_is_fresh(in3, sizeof(int)) || __CPROVER_pointer_equals(in3, in))
+__CPROVER_requires(__CPROVER_pointer_equals(in4, in) || __CPROVER_is_fresh(in4, sizeof(int)))
+__CPROVER_requires(__CPROVER_pointer_in_range_dfcc(in, in5, in) || __CPROVER_pointer_equals(in5, in))
+__CPROVER_requires(__CPROVER_pointer_equals(in6, in) || __CPROVER_pointer_in_range_dfcc(in, in6, in))
+__CPROVER_requires(__CPROVER_is_fresh(out1, sizeof(int *)))
+__CPROVER_requires(__CPROVER_is_fresh(out2, sizeof(int *)))
+__CPROVER_requires(__CPROVER_is_fresh(out3, sizeof(int *)))
+__CPROVER_requires(__CPROVER_is_fresh(out4, sizeof(int *)))
+__CPROVER_requires(__CPROVER_is_fresh(out5, sizeof(int *)))
+__CPROVER_requires(__CPROVER_is_fresh(out6, sizeof(int *)))
+__CPROVER_assigns(*out1, *out2, *out3, *out4, *out5, *out6)
+__CPROVER_ensures(__CPROVER_is_fresh(*out1, sizeof(int)) || __CPROVER_pointer_in_range_dfcc(in, *out1, in))
+__CPROVER_ensures(__CPROVER_pointer_in_range_dfcc(in, *out2, in) || __CPROVER_is_fresh(*out2, sizeof(int)))
+__CPROVER_ensures(__CPROVER_is_fresh(*out3, sizeof(int)) || __CPROVER_pointer_equals(*out3, in))
+__CPROVER_ensures(__CPROVER_pointer_equals(*out4, in) || __CPROVER_is_fresh(*out4, sizeof(int)))
+__CPROVER_ensures(__CPROVER_pointer_in_range_dfcc(in, *out5, in) || __CPROVER_pointer_equals(*out5, in))
+__CPROVER_ensures(__CPROVER_pointer_equals(*out6, in) || __CPROVER_pointer_in_range_dfcc(in, *out6, in))
+// clang-format on
+{
+  int *tmp1 = malloc(sizeof(int));
+  __CPROVER_assume(tmp1);
+  *out1 = nondet_int() ? tmp1 : in;
+  int *tmp2 = malloc(sizeof(int));
+  __CPROVER_assume(tmp2);
+  *out2 = nondet_int() ? tmp2 : in;
+  int *tmp3 = malloc(sizeof(int));
+  __CPROVER_assume(tmp3);
+  *out3 = nondet_int() ? tmp3 : in;
+  int *tmp4 = malloc(sizeof(int));
+  __CPROVER_assume(tmp4);
+  *out4 = nondet_int() ? tmp4 : in;
+  *out5 = in;
+  *out6 = in;
+}
+
+void bar()
+  // clang-format off
+__CPROVER_requires(1)
+__CPROVER_assigns()
+__CPROVER_ensures(1)
+// clang-format on
+{
+  int in, in1, in2, in3, in4, in5, in6;
+  int *out1, *out2, *out3, *out4, *out5, *out6;
+  foo(
+    &in,
+    nondet_bool() ? &in : &in1,
+    nondet_bool() ? &in : &in2,
+    nondet_bool() ? &in : &in3,
+    nondet_bool() ? &in : &in4,
+    &in,
+    &in,
+    &out1,
+    &out2,
+    &out3,
+    &out4,
+    &out5,
+    &out6);
+}
+
+int main()
+{
+  bar();
+  return 0;
+}

--- a/regression/contracts-dfcc/test_pointer_pred_unique_replace_pass/test.desc
+++ b/regression/contracts-dfcc/test_pointer_pred_unique_replace_pass/test.desc
@@ -1,0 +1,19 @@
+CORE dfcc-only
+main.c
+--dfcc main --replace-call-with-contract foo _ --arrays-uf-always --slice-formula
+^\[__CPROVER_contracts_is_fresh.assertion.\d+\] line \d+ __CPROVER_is_fresh does not conflict with other pointer predicate in assume context: SUCCESS$
+^\[__CPROVER_contracts_is_fresh.assertion.\d+\] line \d+ __CPROVER_is_fresh does not conflict with other pointer predicate in assert context: SUCCESS$
+^\[__CPROVER_contracts_pointer_equals.assertion.\d+\] line \d+ __CPROVER_pointer_equals does not conflict with other pointer predicate in assume context: SUCCESS$
+^\[__CPROVER_contracts_pointer_equals.assertion.\d+\] line \d+ __CPROVER_pointer_equals does not conflict with other pointer predicate in assert context: SUCCESS$
+^\[__CPROVER_contracts_pointer_in_range_dfcc.assertion.\d+\] line \d+ __CPROVER_pointer_in_range_dfcc does not conflict with other pointer predicate in assume context: SUCCESS$
+^\[__CPROVER_contracts_pointer_in_range_dfcc.assertion.\d+\] line \d+ __CPROVER_pointer_in_range_dfcc does not conflict with other predicate in assert context: SUCCESS$
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+--
+Tests that a same pointer can be the target of multiple pointer predicates as
+long as they do not apply at the same time.
+
+Tests all 6 pairwise combinations of is_fresh, pointer_equals,
+pointer_in_range_dfcc in mode assert-requires/assume-ensures.


### PR DESCRIPTION
Please ignore the first commit, it is from https://github.com/diffblue/cbmc/pull/8576 and will disappear when rebasing.


Fixes a discrepancy between assert and assume behaviour for pointer predicates, by ensuring
that at most one predicate occurrence can be established at all times, in both assume and assert
contexts.

Before, `is_fresh(p, n) && is_fresh(p, n)` would fail in assert contexts but pass in assume contexts
by allocating twice.


- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [x] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [ x White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
