### PR TITLE
Remove unused {c,java}_qualifierst::count

### DIFF
--- a/jbmc/src/java_bytecode/java_qualifiers.cpp
+++ b/jbmc/src/java_bytecode/java_qualifiers.cpp
@@ -27,11 +27,6 @@ std::unique_ptr<c_qualifierst> java_qualifierst::clone() const
   return std::move(other);
 }
 
-std::size_t java_qualifierst::count() const
-{
-  return c_qualifierst::count() + annotations.size();
-}
-
 void java_qualifierst::clear()
 {
   c_qualifierst::clear();

--- a/jbmc/src/java_bytecode/java_qualifiers.h
+++ b/jbmc/src/java_bytecode/java_qualifiers.h
@@ -31,7 +31,6 @@ public:
   {
     return annotations;
   }
-  std::size_t count() const override;
 
   void clear() override;
 

--- a/src/ansi-c/c_qualifiers.h
+++ b/src/ansi-c/c_qualifiers.h
@@ -109,12 +109,6 @@ public:
     is_noreturn |= other.is_noreturn;
     return *this;
   }
-
-  virtual std::size_t count() const
-  {
-    return is_constant + is_volatile + is_restricted + is_atomic + is_ptr32 +
-           is_ptr64 + is_nodiscard + is_noreturn;
-  }
 };
 
 #endif // CPROVER_ANSI_C_C_QUALIFIERS_H


### PR DESCRIPTION
These are never used (and their implementation was awkwardly summing up Booleans, yielding conversion warnings).

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
