### PR TITLE
Cleanup type conversions in java_bytecode_parsert::read

### DIFF
--- a/jbmc/src/java_bytecode/java_bytecode_parser.cpp
+++ b/jbmc/src/java_bytecode/java_bytecode_parser.cpp
@@ -705,15 +705,15 @@ void java_bytecode_parsert::rconstant_pool()
       break;
 
     case CONSTANT_Utf8:
-      {
-        const u2 bytes = read<u2>();
-        std::string s;
-        s.resize(bytes);
-        for(auto &ch : s)
-          ch = read<std::string::value_type>();
-        it->s = s; // Add to string table
-      }
+    {
+      const u2 bytes = read<u2>();
+      std::string s;
+      s.resize(bytes);
+      for(auto &ch : s)
+        ch = read<std::string::value_type>();
+      it->s = s; // Add to string table
       break;
+    }
 
     case CONSTANT_MethodHandle:
       it->ref1 = read<u1>();
@@ -951,34 +951,34 @@ void java_bytecode_parsert::rbytecode(std::vector<instructiont> &instructions)
       break;
 
     case 'b': // a signed byte
-      {
-        const s1 c = read<s1>();
-        instruction.args.push_back(from_integer(c, signedbv_typet(8)));
-      }
+    {
+      const s1 c = read<s1>();
+      instruction.args.push_back(from_integer(c, signedbv_typet(8)));
       address+=1;
       break;
+    }
 
     case 'o': // two byte branch offset, signed
-      {
-        const s2 offset = read<s2>();
-        // By converting the signed offset into an absolute address (by adding
-        // the current address) the number represented becomes unsigned.
-        instruction.args.push_back(
-          from_integer(address+offset, unsignedbv_typet(16)));
-      }
+    {
+      const s2 offset = read<s2>();
+      // By converting the signed offset into an absolute address (by adding
+      // the current address) the number represented becomes unsigned.
+      instruction.args.push_back(
+        from_integer(address + offset, unsignedbv_typet(16)));
       address+=2;
       break;
+    }
 
     case 'O': // four byte branch offset, signed
-      {
-        const s4 offset = read<s4>();
-        // By converting the signed offset into an absolute address (by adding
-        // the current address) the number represented becomes unsigned.
-        instruction.args.push_back(
-          from_integer(address+offset, unsignedbv_typet(32)));
-      }
+    {
+      const s4 offset = read<s4>();
+      // By converting the signed offset into an absolute address (by adding
+      // the current address) the number represented becomes unsigned.
+      instruction.args.push_back(
+        from_integer(address + offset, unsignedbv_typet(32)));
       address+=4;
       break;
+    }
 
     case 'v': // local variable index (one byte)
       {
@@ -1140,8 +1140,8 @@ void java_bytecode_parsert::rbytecode(std::vector<instructiont> &instructions)
 
     case 's': // a signed short
       {
-        const s2 s = read<s2>();
-        instruction.args.push_back(from_integer(s, signedbv_typet(16)));
+      const s2 s = read<s2>();
+      instruction.args.push_back(from_integer(s, signedbv_typet(16)));
       }
       address+=2;
       break;

--- a/jbmc/src/java_bytecode/java_bytecode_parser.cpp
+++ b/jbmc/src/java_bytecode/java_bytecode_parser.cpp
@@ -132,9 +132,19 @@ private:
   T read()
   {
     static_assert(
-      std::is_unsigned<T>::value, "T should be an unsigned integer");
+      std::is_unsigned<T>::value || std::is_signed<T>::value,
+      "T should be a signed or unsigned integer");
     const constexpr size_t bytes = sizeof(T);
-    u8 result = 0;
+    if(bytes == 1)
+    {
+      if(!*in)
+      {
+        log.error() << "unexpected end of bytecode file" << messaget::eom;
+        throw 0;
+      }
+      return static_cast<T>(in->get());
+    }
+    T result = 0;
     for(size_t i = 0; i < bytes; i++)
     {
       if(!*in)
@@ -145,7 +155,7 @@ private:
       result <<= 8u;
       result |= static_cast<u1>(in->get());
     }
-    return narrow_cast<T>(result);
+    return result;
   }
 
   void store_unknown_method_handle(size_t bootstrap_method_index);
@@ -700,7 +710,7 @@ void java_bytecode_parsert::rconstant_pool()
         std::string s;
         s.resize(bytes);
         for(auto &ch : s)
-          ch = read<u1>();
+          ch = read<std::string::value_type>();
         it->s = s; // Add to string table
       }
       break;
@@ -942,7 +952,7 @@ void java_bytecode_parsert::rbytecode(std::vector<instructiont> &instructions)
 
     case 'b': // a signed byte
       {
-        const s1 c = read<u1>();
+        const s1 c = read<s1>();
         instruction.args.push_back(from_integer(c, signedbv_typet(8)));
       }
       address+=1;
@@ -950,7 +960,7 @@ void java_bytecode_parsert::rbytecode(std::vector<instructiont> &instructions)
 
     case 'o': // two byte branch offset, signed
       {
-        const s2 offset = read<u2>();
+        const s2 offset = read<s2>();
         // By converting the signed offset into an absolute address (by adding
         // the current address) the number represented becomes unsigned.
         instruction.args.push_back(
@@ -961,7 +971,7 @@ void java_bytecode_parsert::rbytecode(std::vector<instructiont> &instructions)
 
     case 'O': // four byte branch offset, signed
       {
-        const s4 offset = read<u4>();
+        const s4 offset = read<s4>();
         // By converting the signed offset into an absolute address (by adding
         // the current address) the number represented becomes unsigned.
         instruction.args.push_back(
@@ -994,7 +1004,7 @@ void java_bytecode_parsert::rbytecode(std::vector<instructiont> &instructions)
       {
         const u2 v = read<u2>();
         instruction.args.push_back(from_integer(v, unsignedbv_typet(16)));
-        const s2 c = read<u2>();
+        const s2 c = read<s2>();
         instruction.args.push_back(from_integer(c, signedbv_typet(16)));
         address+=4;
       }
@@ -1002,7 +1012,7 @@ void java_bytecode_parsert::rbytecode(std::vector<instructiont> &instructions)
       {
         const u1 v = read<u1>();
         instruction.args.push_back(from_integer(v, unsignedbv_typet(8)));
-        const s1 c = read<u1>();
+        const s1 c = read<s1>();
         instruction.args.push_back(from_integer(c, signedbv_typet(8)));
         address+=2;
       }
@@ -1032,7 +1042,7 @@ void java_bytecode_parsert::rbytecode(std::vector<instructiont> &instructions)
         }
 
         // now default value
-        const s4 default_value = read<u4>();
+        const s4 default_value = read<s4>();
         // By converting the signed offset into an absolute address (by adding
         // the current address) the number represented becomes unsigned.
         instruction.args.push_back(
@@ -1045,8 +1055,8 @@ void java_bytecode_parsert::rbytecode(std::vector<instructiont> &instructions)
 
         for(std::size_t i=0; i<npairs; i++)
         {
-          const s4 match = read<u4>();
-          const s4 offset = read<u4>();
+          const s4 match = read<s4>();
+          const s4 offset = read<s4>();
           instruction.args.push_back(
             from_integer(match, signedbv_typet(32)));
           // By converting the signed offset into an absolute address (by adding
@@ -1070,23 +1080,23 @@ void java_bytecode_parsert::rbytecode(std::vector<instructiont> &instructions)
         }
 
         // now default value
-        const s4 default_value = read<u4>();
+        const s4 default_value = read<s4>();
         instruction.args.push_back(
           from_integer(base_offset+default_value, signedbv_typet(32)));
         address+=4;
 
         // now low value
-        const s4 low_value = read<u4>();
+        const s4 low_value = read<s4>();
         address+=4;
 
         // now high value
-        const s4 high_value = read<u4>();
+        const s4 high_value = read<s4>();
         address+=4;
 
         // there are high-low+1 offsets, and they are signed
         for(s4 i=low_value; i<=high_value; i++)
         {
-          s4 offset = read<u4>();
+          s4 offset = read<s4>();
           instruction.args.push_back(from_integer(i, signedbv_typet(32)));
           // By converting the signed offset into an absolute address (by adding
           // the current address) the number represented becomes unsigned.
@@ -1130,7 +1140,7 @@ void java_bytecode_parsert::rbytecode(std::vector<instructiont> &instructions)
 
     case 's': // a signed short
       {
-        const s2 s = read<u2>();
+        const s2 s = read<s2>();
         instruction.args.push_back(from_integer(s, signedbv_typet(16)));
       }
       address+=2;


### PR DESCRIPTION
We can safely read signed values and don't need to defer the type conversion to the call site.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
