### PR TITLE
Simplify typecast of zero-extension to just a typecast

### DIFF
--- a/regression/cbmc/Quantifiers-type2/unsigned-char.c
+++ b/regression/cbmc/Quantifiers-type2/unsigned-char.c
@@ -5,7 +5,7 @@ int main()
 
   // clang-format off
   // clang-format would rewrite the "==>" as "== >"
-  __CPROVER_assume( __CPROVER_forall { signed char i; (i>=0 && i<2) ==> b[i]>=10 && b[i]<=10 } );
+  __CPROVER_assume( __CPROVER_forall { unsigned char i; (i>=0 && i<2) ==> b[i]>=10 && b[i]<=10 } );
   __CPROVER_assume( __CPROVER_forall { unsigned i; (i>=0 && i<2) ==> c[i]>=10 && c[i]<=10 } );
   // clang-format on
 

--- a/regression/cbmc/Quantifiers-type2/unsigned-char.desc
+++ b/regression/cbmc/Quantifiers-type2/unsigned-char.desc
@@ -1,0 +1,11 @@
+CORE no-new-smt
+unsigned-char.c
+
+^\*\* Results:$
+^\[main.assertion.1\] line 12 assertion b\[.*0\] == 10 && b\[.*1\] == 10: SUCCESS$
+^\[main.assertion.2\] line 13 assertion c\[.*0\] == 10 && c\[.*1\] == 10: SUCCESS$
+^VERIFICATION SUCCESSFUL$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring

--- a/src/util/simplify_expr.cpp
+++ b/src/util/simplify_expr.cpp
@@ -975,6 +975,52 @@ simplify_exprt::simplify_typecast(const typecast_exprt &expr)
       else if(op_id==ID_ashr || op_id==ID_lshr || op_id==ID_shl)
       {
       }
+      else if(op_id == ID_zero_extend)
+      {
+        const exprt &zero_extended_op = to_zero_extend_expr(expr.op());
+        if(
+          auto bv_type =
+            type_try_dynamic_cast<bitvector_typet>(zero_extended_op.type()))
+        {
+          auto new_expr = expr;
+          if(
+            bv_type->id() == ID_signedbv &&
+            bv_type->get_width() < to_bitvector_type(expr_type).get_width())
+          {
+            new_expr.op() =
+              simplify_typecast(
+                typecast_exprt{
+                  zero_extended_op, unsignedbv_typet{bv_type->get_width()}})
+                .expr;
+          }
+          else
+            new_expr.op() = zero_extended_op;
+          return changed(simplify_typecast(new_expr)); // rec. call
+        }
+      }
+      else if(op_id == ID_concatenation)
+      {
+        const auto &operands = expr.op().operands();
+        if(
+          operands.size() == 2 && operands.front().is_constant() &&
+          to_constant_expr(operands.front()).value_is_zero_string())
+        {
+          auto new_expr = expr;
+          const bitvector_typet &bv_type =
+            to_bitvector_type(operands.back().type());
+          if(bv_type.id() == ID_signedbv)
+          {
+            new_expr.op() =
+              simplify_typecast(
+                typecast_exprt{
+                  operands.back(), unsignedbv_typet{bv_type.get_width()}})
+                .expr;
+          }
+          else
+            new_expr.op() = operands.back();
+          return changed(simplify_typecast(new_expr)); // rec. call
+        }
+      }
     }
   }
 


### PR DESCRIPTION
The intervening zero-extension does not alter the semantics and hinders the application of `skip_typecast`.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
