### PR TITLE
Fix filename completion in bash autocompletion

### DIFF
--- a/scripts/bash-autocomplete/cbmc.sh.template
+++ b/scripts/bash-autocomplete/cbmc.sh.template
@@ -54,6 +54,16 @@ _cbmc_autocomplete()
   fi
 
   #if none of the above applies, offer directories and files that we can analyze
-  COMPREPLY=( $(compgen -G '*.class|*.jar|*.cpp|*.cc|*.c\+\+|*.ii|*.cxx|*.c|*.i|*.gb' -- $cur) )
+  _filedir -d
+  COMPREPLY+=( $(compgen -G "$cur*.c") )
+  COMPREPLY+=( $(compgen -G "$cur*.c\+\+") )
+  COMPREPLY+=( $(compgen -G "$cur*.cc") )
+  COMPREPLY+=( $(compgen -G "$cur*.class") )
+  COMPREPLY+=( $(compgen -G "$cur*.cpp") )
+  COMPREPLY+=( $(compgen -G "$cur*.cxx") )
+  COMPREPLY+=( $(compgen -G "$cur*.gb") )
+  COMPREPLY+=( $(compgen -G "$cur*.i") )
+  COMPREPLY+=( $(compgen -G "$cur*.ii") )
+  COMPREPLY+=( $(compgen -G "$cur*.jar") )
 }
 complete -F _cbmc_autocomplete cbmc


### PR DESCRIPTION
Bash globbing does not support `|` for alternatives, which meant that the prior pattern would only match file names that contained a `|`.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
