### PR TITLE
Remove `namespace_baset::follow(typet)`

### DIFF
--- a/src/util/README.md
+++ b/src/util/README.md
@@ -195,7 +195,7 @@ table, looking up the target symbol name in each successive table until one is
 found. Note class \ref multi_namespacet can layer arbitrary numbers of symbol
 tables, while for historical reasons \ref namespacet can layer up to two.
 
-The namespace wrapper class also provides the \ref namespacet::follow
+The namespace wrapper class also provides the \ref namespacet::follow_tag
 operation, which dereferences a `tag_typet` to retrieve the type it refers
 to, including following a type tag which refers to another symbol which
 eventually refers to a 'real' type.

--- a/src/util/namespace.cpp
+++ b/src/util/namespace.cpp
@@ -43,20 +43,6 @@ const symbolt &namespace_baset::lookup(const tag_typet &type) const
   return lookup(type.get_identifier());
 }
 
-/// Resolve type symbol to the type it points to.
-/// \param src: The type we want to resolve in the symbol table.
-/// \return The resolved type.
-const typet &namespace_baset::follow(const typet &src) const
-{
-  if(src.id() == ID_union_tag)
-    return follow_tag(to_union_tag_type(src));
-
-  if(src.id() == ID_struct_tag)
-    return follow_tag(to_struct_tag_type(src));
-
-  return src;
-}
-
 /// Follow type tag of union type.
 /// \param src: The union tag type to dispatch on.
 /// \return The type of the union tag in the symbol table.

--- a/src/util/namespace.h
+++ b/src/util/namespace.h
@@ -10,7 +10,6 @@ Author: Daniel Kroening, kroening@kroening.com
 #ifndef CPROVER_UTIL_NAMESPACE_H
 #define CPROVER_UTIL_NAMESPACE_H
 
-#include "deprecate.h"
 #include "invariant.h"
 #include "irep.h"
 
@@ -61,8 +60,6 @@ public:
   virtual ~namespace_baset();
 
   void follow_macros(exprt &) const;
-  DEPRECATED(SINCE(2024, 2, 19, "use follow_tag(...) instead"))
-  const typet &follow(const typet &) const;
 
   const union_typet &follow_tag(const union_tag_typet &) const;
   const struct_typet &follow_tag(const struct_tag_typet &) const;


### PR DESCRIPTION
This method has been deprecated since 19th Feb 2024.  There are no uses.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- n/a Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
