### PR TITLE
simplify: rewrite `bitxnor` on booleans to equal

### DIFF
--- a/src/util/simplify_expr_int.cpp
+++ b/src/util/simplify_expr_int.cpp
@@ -696,6 +696,8 @@ simplify_exprt::simplify_bitwise(const multi_ary_exprt &expr)
         new_expr.id(ID_or);
       else if(expr.id()==ID_bitxor)
         new_expr.id(ID_xor);
+      else if(expr.id() == ID_bitxnor)
+        new_expr.id(ID_equal);
       else
         UNREACHABLE;
 
@@ -709,8 +711,8 @@ simplify_exprt::simplify_bitwise(const multi_ary_exprt &expr)
           *it=true_exprt();
       }
 
-      new_expr.type()=bool_typet();
-      new_expr = simplify_boolean(new_expr);
+      new_expr.type() = bool_typet{};
+      new_expr = simplify_node(new_expr);
 
       return changed(simplify_typecast(typecast_exprt(new_expr, expr.type())));
     }


### PR DESCRIPTION
This adds the rewrite `a xnor b` --> `a = b` for booleans `a`, `b` to the simplifier.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
