### PR TITLE
Remove set but not used variables

### DIFF
--- a/src/solvers/flattening/boolbv_overflow.cpp
+++ b/src/solvers/flattening/boolbv_overflow.cpp
@@ -125,15 +125,14 @@ literalt boolbvt::convert_binary_overflow(const binary_overflow_exprt &expr)
       ? bv_utilst::representationt::SIGNED
       : bv_utilst::representationt::UNSIGNED;
 
-  if(
-    const auto plus_overflow = expr_try_dynamic_cast<plus_overflow_exprt>(expr))
+  if(expr_try_dynamic_cast<plus_overflow_exprt>(expr))
   {
     if(bv0.size() != bv1.size())
       return SUB::convert_rest(expr);
 
     return bv_utils.overflow_add(bv0, bv1, rep);
   }
-  if(const auto minus = expr_try_dynamic_cast<minus_overflow_exprt>(expr))
+  if(expr_try_dynamic_cast<minus_overflow_exprt>(expr))
   {
     if(bv0.size() != bv1.size())
       return SUB::convert_rest(expr);
@@ -158,8 +157,7 @@ literalt boolbvt::convert_binary_overflow(const binary_overflow_exprt &expr)
 
     return mult_overflow_result(prop, bv0, bv1, rep).back();
   }
-  else if(
-    const auto shl_overflow = expr_try_dynamic_cast<shl_overflow_exprt>(expr))
+  else if(expr_try_dynamic_cast<shl_overflow_exprt>(expr))
   {
     DATA_INVARIANT(!bv0.empty(), "zero-sized operand");
 

--- a/src/solvers/smt2_incremental/convert_expr_to_smt.cpp
+++ b/src/solvers/smt2_incremental/convert_expr_to_smt.cpp
@@ -175,14 +175,14 @@ static smt_termt make_bitvector_resize_cast(
   const bitvector_typet &from_type,
   const bitvector_typet &to_type)
 {
-  if(const auto to_fixedbv_type = type_try_dynamic_cast<fixedbv_typet>(to_type))
+  if(type_try_dynamic_cast<fixedbv_typet>(to_type))
   {
     UNIMPLEMENTED_FEATURE(
       "Generation of SMT formula for type cast to fixed-point bitvector "
       "type: " +
       to_type.pretty());
   }
-  if(const auto to_floatbv_type = type_try_dynamic_cast<floatbv_typet>(to_type))
+  if(type_try_dynamic_cast<floatbv_typet>(to_type))
   {
     UNIMPLEMENTED_FEATURE(
       "Generation of SMT formula for type cast to floating-point bitvector "
@@ -258,7 +258,7 @@ static smt_termt convert_expr_to_smt(
   const auto &from_term = converted.at(cast.op());
   const typet &from_type = cast.op().type();
   const typet &to_type = cast.type();
-  if(const auto bool_type = type_try_dynamic_cast<bool_typet>(to_type))
+  if(type_try_dynamic_cast<bool_typet>(to_type))
     return make_not_zero(from_term, cast.op().type());
   if(const auto c_bool_type = type_try_dynamic_cast<c_bool_typet>(to_type))
     return convert_c_bool_cast(from_term, from_type, *c_bool_type);
@@ -893,9 +893,7 @@ static smt_termt convert_expr_to_smt(
     "Pointer should be wider than object_bits in order to allow for offset "
     "encoding.");
   const size_t offset_bits = type->get_width() - object_bits;
-  if(
-    const auto symbol =
-      expr_try_dynamic_cast<symbol_exprt>(address_of.object()))
+  if(expr_try_dynamic_cast<symbol_exprt>(address_of.object()))
   {
     const smt_bit_vector_constant_termt offset{0, offset_bits};
     return smt_bit_vector_theoryt::concat(object_bit_vector, offset);


### PR DESCRIPTION
clang 19.1.17 warns about `set but not used` variables and stops compilation because of `-Werror`

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- [X] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
