### PR TITLE
Fix display of code changes in clang-format CI action

### DIFF
--- a/.github/workflows/pull-request-check-clang-format.sh
+++ b/.github/workflows/pull-request-check-clang-format.sh
@@ -26,7 +26,7 @@ echo "Checking for formatting errors introduced since $MERGE_BASE"
 
 # Do the checking. "eval" is used so that quotes (as inserted into $EXCLUDES
 # above) are not interpreted as parts of file names.
-eval git-clang-format-15 --binary clang-format-15 $MERGE_BASE -- $EXCLUDES
+eval git-clang-format-15 --binary clang-format-15 $MERGE_BASE -- $EXCLUDES || true
 git diff > formatted.diff
 if [[ -s formatted.diff ]] ; then
   echo 'Formatting error! The following diff shows the required changes'


### PR DESCRIPTION
Versions of `git-clang-format` later than 11 issue exit code 1 when changes were made to the source code. Although our CI job ended with a non-zero exit code as expected, it terminated early than wanted so that the differences are not printed to the log.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
