### PR TITLE
Use same CMake minimum version in DownloadProject configuration

### DIFF
--- a/.github/workflows/pull-request-checks.yaml
+++ b/.github/workflows/pull-request-checks.yaml
@@ -51,7 +51,7 @@ jobs:
       - name: Build with make
         run: |
           git clone https://github.com/conp-solutions/riss riss.git
-          cmake -Hriss.git -Briss.git/release -DCMAKE_BUILD_TYPE=Release
+          cmake -Hriss.git -Briss.git/release -DCMAKE_BUILD_TYPE=Release -DCMAKE_POLICY_VERSION_MINIMUM=3.5
           make -C riss.git/release riss-coprocessor-lib-static -j${{env.linux-vcpus}}
           make -C src -j${{env.linux-vcpus}} CXX="ccache g++" LIBS="$PWD/riss.git/release/lib/libriss-coprocessor.a -lpthread" IPASIR=$PWD/riss.git/riss
           make -C jbmc/src -j${{env.linux-vcpus}} CXX="ccache g++" LIBS="$PWD/riss.git/release/lib/libriss-coprocessor.a -lpthread" IPASIR=$PWD/riss.git/riss

--- a/cmake/DownloadProject.CMakeLists.cmake.in
+++ b/cmake/DownloadProject.CMakeLists.cmake.in
@@ -1,7 +1,7 @@
 # Distributed under the OSI-approved MIT License.  See accompanying
 # file LICENSE or https://github.com/Crascit/DownloadProject for details.
 
-cmake_minimum_required(VERSION 2.8.2)
+cmake_minimum_required(VERSION 3.8)
 
 project(${DL_ARGS_PROJ}-download NONE)
 


### PR DESCRIPTION
We already have a top-level minimum requirement for CMake >= 3.8, so don't need to specify a lower requirement in a file included from the top level.

Having a requirement as low as 2.8.2 broke building on newer version of CMake, which error with "Compatibility with CMake < 3.5 has been removed from CMake." (seen in GitHub runners with Ubuntu 24.04).

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
