### PR TITLE
Replace conditions in quantified statement expressions

### DIFF
--- a/regression/cbmc/Quantifiers-statement-expression/main.c
+++ b/regression/cbmc/Quantifiers-statement-expression/main.c
@@ -4,7 +4,7 @@ int main()
   // no side effects!
   int j = 0;
   int a[5] = {0 , 0, 0, 0, 0};
-  assert(__CPROVER_forall { int i;  ({ int j = i; i=i; if(i < 0 || i >4) i = 1;  ( a[i] < 5); }) });
+  assert(__CPROVER_forall { int i;  ({ int j = i; int cond = i < 0 || i >4; if(cond) i = 1;  ( a[i] < 5); }) });
   // clang-format on
 
   return 0;

--- a/src/ansi-c/goto-conversion/goto_clean_expr.cpp
+++ b/src/ansi-c/goto-conversion/goto_clean_expr.cpp
@@ -211,19 +211,16 @@ static exprt convert_statement_expression(
     // path_condition && cond.
     case goto_program_instruction_typet::GOTO:
     {
-      if(!current_it->condition().is_true())
+      exprt condition = current_it->condition();
+      replace_expr(value_map, condition);
+      if(!condition.is_true())
       {
         auto next_it = current_it->targets.front();
         exprt copy_path_condition = path_condition;
-        replace_mapt copy_symbol_map = value_map;
-        auto copy_condition = current_it->condition();
-        path_condition =
-          and_exprt(path_condition, not_exprt(current_it->condition()));
+        path_condition = and_exprt(path_condition, not_exprt(condition));
         current_it++;
         paths.push_back(
-          next_it,
-          and_exprt(copy_path_condition, copy_condition),
-          copy_symbol_map);
+          next_it, and_exprt(copy_path_condition, condition), value_map);
       }
       else
       {


### PR DESCRIPTION
When doing symbolic execution during converting quantified statement expressions, conditions of `GOTO` instructions should also be replaced with the valuation map. The PR fixes the bug.

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
