### PR TITLE
Visual Studio recognises `__nullptr` in C++ mode

### DIFF
--- a/src/ansi-c/scanner.l
+++ b/src/ansi-c/scanner.l
@@ -1012,11 +1012,12 @@ enable_or_disable ("enable"|"disable")
                      TOK_CHAR16_T);
                  }
 
-"__nullptr"     { // GNU extension
+"__nullptr"     { // GNU, clang, VS extension
                    return conditional_keyword(
                      PARSER.cpp98 &&
                      (PARSER.mode==configt::ansi_ct::flavourt::GCC ||
-                      PARSER.mode==configt::ansi_ct::flavourt::CLANG),
+                      PARSER.mode==configt::ansi_ct::flavourt::CLANG ||
+                      PARSER.mode==configt::ansi_ct::flavourt::VISUAL_STUDIO),
                      TOK_NULLPTR);
                  }
 


### PR DESCRIPTION
Visual Studio C++ recognises `__nullptr`.

https://learn.microsoft.com/en-us/cpp/extensions/nullptr-cpp-component-extensions?view=msvc-170

Fixes #8308

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
