### PR TITLE
prophecy_r_or_w_ok_exprt lowering: adjust for dynamic/static objects

### DIFF
--- a/src/util/pointer_expr.cpp
+++ b/src/util/pointer_expr.cpp
@@ -12,9 +12,11 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "byte_operators.h"
 #include "c_types.h"
 #include "expr_util.h"
+#include "namespace.h"
 #include "pointer_offset_size.h"
 #include "pointer_predicates.h"
 #include "simplify_expr.h"
+#include "symbol.h"
 
 void dynamic_object_exprt::set_instance(unsigned int instance)
 {
@@ -247,6 +249,41 @@ exprt pointer_in_range_exprt::lower() const
 
 exprt prophecy_r_or_w_ok_exprt::lower(const namespacet &ns) const
 {
+  exprt base_ptr = skip_typecast(pointer());
+  if(auto plus_expr = expr_try_dynamic_cast<plus_exprt>(base_ptr))
+  {
+    if(plus_expr->op0().id() == ID_address_of)
+      base_ptr = plus_expr->op0();
+  }
+  if(auto address_of = expr_try_dynamic_cast<address_of_exprt>(base_ptr))
+  {
+    const exprt &root_object =
+      object_descriptor_exprt::root_object(address_of->object());
+    if(auto symbol_expr = expr_try_dynamic_cast<symbol_exprt>(root_object))
+    {
+      const symbolt *s_ptr = nullptr;
+      if(
+        !ns.lookup(symbol_expr->get_identifier(), s_ptr) &&
+        s_ptr->is_static_lifetime)
+      {
+        return and_exprt{
+          {not_exprt{null_object(pointer())},
+           not_exprt{is_invalid_pointer_exprt{pointer()}},
+           not_exprt{object_lower_bound(pointer(), nil_exprt())},
+           not_exprt{object_upper_bound(pointer(), size())}}};
+      }
+      else if(symbol_expr->get_identifier().starts_with(SYMEX_DYNAMIC_PREFIX
+                                                        "::"))
+      {
+        return and_exprt{
+          {not_exprt{null_object(pointer())},
+           not_exprt{is_invalid_pointer_exprt{pointer()}},
+           not_exprt{same_object(pointer(), deallocated_ptr())},
+           not_exprt{object_lower_bound(pointer(), nil_exprt())},
+           not_exprt{object_upper_bound(pointer(), size())}}};
+      }
+    }
+  }
   return and_exprt{
     {not_exprt{null_object(pointer())},
      not_exprt{is_invalid_pointer_exprt{pointer()}},


### PR DESCRIPTION
We do not need to create comparisons to dead and/or deallocated when handling a dynamic object (which will never be marked "dead") or a static object (which will neither be marked "dead" nor "deallocated"). This avoids unnecessary branches when the prophecy_r_or_w_ok_exprt can now be simplified to a constant.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
