### PR TITLE
DRAFT: Control Flow Retrace feature

### DIFF
--- a/doc/man/cbmc.1
+++ b/doc/man/cbmc.1
@@ -366,6 +366,9 @@ explore paths one at a time
 \fB\-\-show\-symex\-strategies\fR
 list strategies for use with \fB\-\-paths\fR
 .TP
+\fB\-\-retrace\fR [trace]
+follow a single control flow path, given by a trace string of 0s and 1s
+.TP
 \fB\-\-show\-goto\-symex\-steps\fR
 show which steps symex travels, includes
 diagnostic information

--- a/doc/man/jbmc.1
+++ b/doc/man/jbmc.1
@@ -281,6 +281,9 @@ explore paths one at a time
 \fB\-\-show\-symex\-strategies\fR
 list strategies for use with \fB\-\-paths\fR
 .TP
+\fB\-\-retrace\fR [trace]
+follow a single control flow path, given by a trace string of 0s and 1s
+.TP
 \fB\-\-show\-goto\-symex\-steps\fR
 show which steps symex travels, includes
 diagnostic information

--- a/regression/book-examples/simple-goto/C00.desc
+++ b/regression/book-examples/simple-goto/C00.desc
@@ -1,0 +1,6 @@
+CORE
+simple_goto.c
+--function foo --retrace 00
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$

--- a/regression/book-examples/simple-goto/C01.desc
+++ b/regression/book-examples/simple-goto/C01.desc
@@ -1,0 +1,6 @@
+CORE
+simple_goto.c
+--function foo --retrace 01
+^EXIT=10$
+^SIGNAL=0$
+^VERIFICATION FAILED$

--- a/regression/book-examples/simple-goto/C10.desc
+++ b/regression/book-examples/simple-goto/C10.desc
@@ -1,0 +1,6 @@
+CORE
+simple_goto.c
+--function foo --retrace 10
+^EXIT=10$
+^SIGNAL=0$
+^VERIFICATION FAILED$

--- a/regression/book-examples/simple-goto/simple_goto.c
+++ b/regression/book-examples/simple-goto/simple_goto.c
@@ -1,0 +1,18 @@
+#include <assert.h>
+#include <stdbool.h>
+
+void foo(bool arg1, bool arg2)
+{
+  bool v1 = false;
+  bool v2 = false;
+  if(arg1)
+    goto l1;
+  v1 = true;
+l1:
+  if(arg2)
+    goto l2;
+  v2 = true;
+l2:
+  assert(v1);
+  assert(v2);
+}

--- a/src/cbmc/cbmc_parse_options.cpp
+++ b/src/cbmc/cbmc_parse_options.cpp
@@ -168,6 +168,21 @@ void cbmc_parse_optionst::get_command_line_options(optionst &options)
     exit(CPROVER_EXIT_USAGE_ERROR);
   }
 
+  if(cmdline.isset("retrace"))
+  {
+    auto retrace_input = cmdline.get_value("retrace");
+    options.set_option("retrace", retrace_input);
+
+    // check retrace input
+    for(auto &c : retrace_input)
+      if(c != '0' && c != '1')
+      {
+        log.error() << "--retrace input string must only contain 0s and 1s"
+                    << messaget::eom;
+        exit(CPROVER_EXIT_USAGE_ERROR);
+      }
+  }
+
   // We want to warn the user that if we are using standard checks (that enables
   // unwinding-assertions) and we did not disable them manually.
   if(

--- a/src/goto-checker/bmc_util.cpp
+++ b/src/goto-checker/bmc_util.cpp
@@ -186,7 +186,14 @@ void setup_symex(
   if(!ns.lookup(INITIALIZE_FUNCTION, init_symbol))
     symex.language_mode = init_symbol->mode;
 
-  msg.status() << "Starting Bounded Model Checking" << messaget::eom;
+  if(options.is_set("retrace"))
+  {
+    msg.status() << "Starting Retrace Model Checking" << messaget::eom;
+  }
+  else
+  {
+    msg.status() << "Starting Bounded Model Checking" << messaget::eom;
+  }
 
   symex.last_source_location.make_nil();
 

--- a/src/goto-checker/bmc_util.h
+++ b/src/goto-checker/bmc_util.h
@@ -182,6 +182,7 @@ void run_property_decider(
   "(partial-loops)"                                                            \
   "(paths):"                                                                   \
   "(show-symex-strategies)"                                                    \
+  "(retrace):"                                                                 \
   "(depth):"                                                                   \
   "(max-field-sensitivity-array-size):"                                        \
   "(no-array-field-sensitivity)"                                               \
@@ -197,6 +198,8 @@ void run_property_decider(
 #define HELP_BMC                                                               \
   " {y--paths} [strategy] \t explore paths one at a time\n"                    \
   " {y--show-symex-strategies} \t list strategies for use with {y--paths}\n"   \
+  " {y--retrace} [trace] \t follow a single control flow path, given by a "    \
+  "trace string of 0s and 1s\n"                                                \
   " {y--show-goto-symex-steps} \t show which steps symex travels, includes "   \
   "diagnostic information\n"                                                   \
   " {y--show-points-to-sets} \t show points-to sets for pointer dereference. " \

--- a/src/goto-symex/goto_symex.h
+++ b/src/goto-symex/goto_symex.h
@@ -318,6 +318,9 @@ protected:
   /// Symbolically execute a GOTO instruction in the context of unreachable code
   /// \param state: Symbolic execution state for current instruction
   void symex_unreachable_goto(statet &state);
+  /// Symbolically execute a GOTO along a control flow retrace input path
+  /// \param state: Symbolic execution state for current instruction
+  void symex_goto_retrace(statet &state);
   /// Symbolically execute a SET_RETURN_VALUE instruction
   /// \param state: Symbolic execution state for current instruction
   /// \param return_value: The value to be returned

--- a/src/goto-symex/symex_config.h
+++ b/src/goto-symex/symex_config.h
@@ -24,6 +24,9 @@ struct symex_configt final
 
   bool doing_path_exploration;
 
+  bool retracing;
+  std::string retrace_input;
+
   bool allow_pointer_unsoundness;
 
   bool constant_propagation;

--- a/src/goto-symex/symex_goto.cpp
+++ b/src/goto-symex/symex_goto.cpp
@@ -260,8 +260,7 @@ void goto_symext::symex_goto(statet &state)
   DATA_INVARIANT(
     instruction.targets.size() == 1, "no support for non-deterministic gotos");
 
-  goto_programt::const_targett goto_target=
-    instruction.get_target();
+  goto_programt::const_targett goto_target = instruction.get_target();
 
   const bool backward = instruction.is_backwards_goto();
 
@@ -612,6 +611,194 @@ void goto_symext::symex_unreachable_goto(statet &state)
   }
 
   symex_transition(state);
+}
+
+void goto_symext::symex_goto_retrace(statet &state)
+{
+  // get guard, targets as in symex_goto()
+  const goto_programt::instructiont &instruction = *state.source.pc;
+
+  exprt new_guard = clean_expr(instruction.condition(), state, false);
+
+  renamedt<exprt, L2> renamed_guard = state.rename(std::move(new_guard), ns);
+  renamed_guard = try_evaluate_pointer_comparisons(
+    std::move(renamed_guard), state.value_set, language_mode, ns);
+  if(symex_config.simplify_opt)
+    renamed_guard.simplify(ns);
+  new_guard = renamed_guard.get();
+
+  target.goto_instruction(state.guard.as_expr(), renamed_guard, state.source);
+
+  DATA_INVARIANT(
+    !instruction.targets.empty(), "goto should have at least one target");
+
+  // we only do deterministic gotos for now
+  DATA_INVARIANT(
+    instruction.targets.size() == 1, "no support for non-deterministic gotos");
+
+  goto_programt::const_targett goto_target = instruction.get_target();
+
+  const bool backward = instruction.is_backwards_goto();
+
+  goto_programt::const_targett next_instruction = state.source.pc;
+  next_instruction++;
+
+  // goto or next depends on input trace from user
+  bool choose_goto;
+  static size_t retrace_index = 0;
+  if(retrace_index < symex_config.retrace_input.size())
+  {
+    choose_goto = symex_config.retrace_input[retrace_index] == '1';
+  }
+  else
+  {
+    choose_goto = false;
+  }
+  retrace_index++;
+
+  // print goto choice
+  log.conditional_output(
+    log.status(),
+    [this, &state, &goto_target, &next_instruction, choose_goto](
+      messaget::mstreamt &mstream)
+    {
+      source_locationt cur = state.source.pc->source_location();
+      source_locationt goto_dest = goto_target->source_location();
+      source_locationt next_dest = next_instruction->source_location();
+      source_locationt t_dest = choose_goto ? goto_dest : next_dest;
+      source_locationt nt_dest = choose_goto ? next_dest : goto_dest;
+
+      auto cur_file = cur.get_file();
+      if(cur_file.empty())
+        cur_file = "<unknown>";
+      auto t_file = t_dest.get_file();
+      if(t_file.empty())
+        t_file = "<unknown>";
+      auto nt_file = nt_dest.get_file();
+      if(nt_file.empty())
+        nt_file = "<unknown>";
+
+      // print nothing when files are the same
+      if(cur_file == t_file)
+        t_file = "";
+      if(cur_file == nt_file)
+        nt_file = "";
+
+      auto cur_line = cur.get_line();
+      if(cur_line.empty())
+        cur_line = "?";
+      auto t_line = t_dest.get_line();
+      if(t_line.empty())
+        t_line = "?";
+      auto nt_line = nt_dest.get_line();
+      if(nt_line.empty())
+        nt_line = "?";
+
+      std::string head = symex_config.retrace_input;
+      // add 0s in case input trace was shorter
+      head.resize(retrace_index - 1, '0');
+      std::string decision = choose_goto ? "1" : "0";
+
+      std::string step = choose_goto ? " goto " : " next ";
+
+      std::string padding_1 =
+        cur_line.size() < 3 ? std::string(3 - cur_line.size(), ' ') : "";
+      std::string padding_2 =
+        t_line.size() < 3 ? std::string(3 - t_line.size(), ' ') : "";
+
+      mstream << "Retrace " << head << messaget::bold << decision
+              << messaget::reset << " at " << cur_file << ":" << cur_line
+              << padding_1 << step << t_file << ":" << t_line << padding_2
+              << " (not " << nt_file << ":" << nt_line << ")" << messaget::eom;
+    });
+
+  // warn when not following unconditional goto
+  if(new_guard.is_true() && !choose_goto)
+  {
+    log.result() << "Retrace input " << messaget::red << "inconsistent"
+                 << messaget::reset << ": 0/next although guard is true!"
+                 << log.eom;
+    should_pause_symex = true;
+  }
+  else if(new_guard.is_false() && choose_goto)
+  {
+    log.result() << "Retrace input " << messaget::red << "inconsistent"
+                 << messaget::reset << ": 1/goto although guard is false!"
+                 << log.eom;
+    should_pause_symex = true;
+  }
+
+  symex_targett::sourcet original_source = state.source;
+  goto_programt::const_targett new_state_pc;
+
+  if(choose_goto)
+  {
+    // Jump to the jump target if the input is '1'
+    new_state_pc = goto_target;
+    symex_transition(state, new_state_pc, backward);
+  }
+  else
+  {
+    // Jump to the next instruction
+    new_state_pc = state.source.pc;
+    new_state_pc++;
+    symex_transition(state);
+  }
+
+  // produce new guard symbol
+  exprt guard_expr;
+
+  if(
+    new_guard.id() == ID_symbol ||
+    (new_guard.id() == ID_not && to_not_expr(new_guard).op().id() == ID_symbol))
+  {
+    guard_expr = new_guard;
+  }
+  else
+  {
+    symbol_exprt guard_symbol_expr =
+      symbol_exprt(statet::guard_identifier(), bool_typet());
+    exprt new_rhs = boolean_negate(new_guard);
+
+    ssa_exprt new_lhs =
+      state.rename_ssa<L1>(ssa_exprt{guard_symbol_expr}, ns).get();
+    new_lhs =
+      state.assignment(std::move(new_lhs), new_rhs, ns, true, false).get();
+
+    guardt guard{true_exprt{}, guard_manager};
+
+    log.conditional_output(
+      log.debug(),
+      [this, &new_lhs](messaget::mstreamt &mstream)
+      {
+        mstream << "Assignment to " << new_lhs.get_identifier() << " ["
+                << pointer_offset_bits(new_lhs.type(), ns).value_or(0)
+                << " bits]" << messaget::eom;
+      });
+
+    target.assignment(
+      guard.as_expr(),
+      new_lhs,
+      new_lhs,
+      guard_symbol_expr,
+      new_rhs,
+      original_source,
+      symex_targett::assignment_typet::GUARD);
+
+    guard_expr = state.rename(boolean_negate(guard_symbol_expr), ns).get();
+  }
+
+  if(choose_goto)
+  {
+    symex_assume_l2(state, guard_expr);
+    state.guard.add(guard_expr);
+  }
+  else
+  {
+    symex_assume_l2(state, boolean_negate(guard_expr));
+    state.guard.add(boolean_negate(guard_expr));
+  }
+  return;
 }
 
 bool goto_symext::check_break(const irep_idt &loop_id, unsigned unwind)

--- a/src/goto-symex/symex_main.cpp
+++ b/src/goto-symex/symex_main.cpp
@@ -30,6 +30,8 @@ Author: Daniel Kroening, kroening@kroening.com
 symex_configt::symex_configt(const optionst &options)
   : max_depth(options.get_unsigned_int_option("depth")),
     doing_path_exploration(options.is_set("paths")),
+    retracing(options.is_set("retrace")),
+    retrace_input(options.get_option("retrace")),
     allow_pointer_unsoundness(
       options.get_bool_option("allow-pointer-unsoundness")),
     constant_propagation(options.get_bool_option("propagation")),
@@ -641,7 +643,9 @@ void goto_symext::execute_next_instruction(
     break;
 
   case GOTO:
-    if(state.reachable)
+    if(symex_config.retracing)
+      symex_goto_retrace(state);
+    else if(state.reachable)
       symex_goto(state);
     else
       symex_unreachable_goto(state);

--- a/src/goto-symex/symex_main.cpp
+++ b/src/goto-symex/symex_main.cpp
@@ -44,12 +44,10 @@ symex_configt::symex_configt(const optionst &options)
     show_symex_steps(options.get_bool_option("show-goto-symex-steps")),
     show_points_to_sets(options.get_bool_option("show-points-to-sets")),
     max_field_sensitivity_array_size(
-      options.is_set("no-array-field-sensitivity")
-        ? 0
-        : options.is_set("max-field-sensitivity-array-size")
-            ? options.get_unsigned_int_option(
-                "max-field-sensitivity-array-size")
-            : DEFAULT_MAX_FIELD_SENSITIVITY_ARRAY_SIZE),
+      options.is_set("no-array-field-sensitivity") ? 0
+      : options.is_set("max-field-sensitivity-array-size")
+        ? options.get_unsigned_int_option("max-field-sensitivity-array-size")
+        : DEFAULT_MAX_FIELD_SENSITIVITY_ARRAY_SIZE),
     complexity_limits_active(
       options.get_signed_int_option("symex-complexity-limit") > 0),
     cache_dereferences{options.get_bool_option("symex-cache-dereferences")}


### PR DESCRIPTION
<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

### Description

Adds a feature to retrace and verify a single control flow path. The path can be given using `--retrace` as a string of 0s and 1s. From a very brief evaluation test, it seems to be faster than bounded loop unwinding. Only that it might be challenging to find a path to retrace. The 0s and 1s in the input retrace string follow the goto decisions in cbmc's internal goto program representation. During symbolic execution, files and line numbers for each decision are logged to the console, so the interactive use should be intuitive.

Some examples and evaluations are here: [examples_and_evaluation.zip](https://github.com/user-attachments/files/20099368/examples_and_evaluation.zip)

### Use Cases

- Trying out different traces for interactive debugging with cbmc. The restriction to a single control flow path can make interactive debugging more worthwhile because there is no state splitting/merging. When there is a failed assertion (or similar), we know exactly the path on which the assertion is violated.
- Symbolic testing using a control flow path as generalization to normal testing using concrete inputs.
- Debugging when bugreports contain control flow traces. The approach is to record control flow paths (outside of cbmc) and retrace it using cbmc. This can be useful when we observe a crash of the recorded program and retrace it on a different computer (I found two papers describing related approaches, ["Better bug reporting with better privacy"](https://doi.org/10.1145/1346281.1346322) and [REPT](https://www.usenix.org/conference/osdi18/presentation/weidong)). The recording could have a minimal overhead, using for example the [src-tracer](https://github.com/lks9/src-tracer) we are developing.

### Open problems/questions

- Documentation and regression or unit tests are still missing, we are also a bit unsure on the way and extent to do that. 
- We are currently working on how to record a trace externally and then retrace it in cbmc.
- Retracing line numbers instead of 0s and 1s: We think this would not be very predictable and only doable by using a complicated heuristics. So we did not try to implement this.
- Recording a control flow path in cbmc: Modify cbmc, so that a control flow trace is recorded for a normal call with `--unwind` and `--paths`. We tried to implement this also in cbmc, but we faced several problems, like where to store the intermediate tracing decisions, as multiple branches are explored and states are sometimes copied, sometimes reused. Furthermore, the method `symex_goto()` is very complicated so that it is not trivial, when and which tracing decisions were taken.
- How stable is the goto program translation in cbmc? If there is some kind of optimization in the goto-program translation that would make retracing more unpredictable? What about internal function calls like sqrt() in cbmc? Are the respective goto functions stable?
- What about threads? They are supported by cbmc but we have not yet looked into them.
- What about mixing BMC and retracing? For example, internal functions could be done by BMC and only selected parts by retracing.

### Technical remarks

The implementation is mainly in the new method `goto_retrace()` in `symex_goto.cpp`.

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
