### PR TITLE
Fix statement-expression expansion for Kani-provided quantifiers

### DIFF
--- a/regression/cbmc/Quantifiers-statement-expression1/main.c
+++ b/regression/cbmc/Quantifiers-statement-expression1/main.c
@@ -1,0 +1,21 @@
+int main()
+{
+  __CPROVER_assert(
+    __CPROVER_forall {
+      int i;
+      ({
+        goto out;
+        i == i;
+      })
+    },
+    "");
+  __CPROVER_assert(
+    __CPROVER_forall {
+      int i;
+      ({ i == i; })
+    },
+    "");
+out:
+
+  return 0;
+}

--- a/regression/cbmc/Quantifiers-statement-expression1/test.desc
+++ b/regression/cbmc/Quantifiers-statement-expression1/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+
+goto label 'out' not found
+^EXIT=6$
+^SIGNAL=0$
+--
+^warning: ignoring

--- a/src/ansi-c/goto-conversion/goto_clean_expr.cpp
+++ b/src/ansi-c/goto-conversion/goto_clean_expr.cpp
@@ -61,9 +61,11 @@ static exprt convert_statement_expression(
   const quantifier_exprt &qex,
   const code_expressiont &code,
   const irep_idt &mode,
-  goto_convertt &converter)
+  symbol_table_baset &symbol_table,
+  message_handlert &message_handler)
 {
   goto_programt where;
+  goto_convertt converter{symbol_table, message_handler};
   converter.goto_convert(code, where, mode);
   where.compute_location_numbers();
 
@@ -716,7 +718,8 @@ goto_convertt::clean_expr_resultt goto_convertt::clean_expr(
       code.operands()[0].get_named_sub()[ID_statement].id() ==
         ID_statement_expression)
     {
-      auto res = convert_statement_expression(qex, code, mode, *this);
+      auto res = convert_statement_expression(
+        qex, code, mode, symbol_table, get_message_handler());
       qex.where() = res;
       return clean_expr(res, mode, result_is_used);
     }


### PR DESCRIPTION
CBMC side of https://github.com/model-checking/kani/issues/4020: re-using the same converter instance would confuse finish-gotos (when really we don't want gotos inside the statement expression to be considered at all by the main goto-converter instances).

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
