### PR TITLE
`run(..., std::ostream &, ...)` with pipe

### DIFF
--- a/src/ansi-c/c_preprocess.cpp
+++ b/src/ansi-c/c_preprocess.cpp
@@ -305,8 +305,6 @@ bool c_preprocess_visual_studio(
     command_file << shell_quote(file) << "\n";
   }
 
-  // _popen isn't very reliable on WIN32
-  // that's why we use run()
   int result =
     run("cl", {"cl", "@" + command_file_name()}, "", outstream, stderr_file());
 

--- a/src/util/run.cpp
+++ b/src/util/run.cpp
@@ -541,40 +541,119 @@ int run(
 
   return result;
   #else
-  std::string command;
-
-  bool first = true;
-
-  // note we use 'what' instead of 'argv[0]' as the name of the executable
-  for(const auto &arg : argv)
-  {
-    if(first) // this is argv[0]
-    {
-      command += shell_quote(what);
-      first = false;
-    }
-    else
-      command += " " + shell_quote(arg);
-  }
-
-  if(!std_input.empty())
-    command += " < " + shell_quote(std_input);
-
-  if(!std_error.empty())
-    command += " 2> " + shell_quote(std_error);
-
-  FILE *stream=popen(command.c_str(), "r");
-
-  if(stream!=nullptr)
-  {
-    int ch;
-    while((ch=fgetc(stream))!=EOF)
-      std_output << (unsigned char)ch;
-
-    int result = pclose(stream);
-    return WEXITSTATUS(result);
-  }
-  else
+  int pipefd[2];
+  if(pipe(pipefd) == -1)
     return -1;
-  #endif
+
+  int stdin_fd = stdio_redirection(STDIN_FILENO, std_input);
+  int stdout_fd = pipefd[1];
+  int stderr_fd = stdio_redirection(STDERR_FILENO, std_error);
+
+  if(stdin_fd == -1 || stdout_fd == -1 || stderr_fd == -1)
+    return 1;
+
+  // temporarily suspend all signals
+  sigset_t new_mask, old_mask;
+  sigemptyset(&new_mask);
+  sigprocmask(SIG_SETMASK, &new_mask, &old_mask);
+
+  /* now create new process */
+  pid_t childpid = fork();
+
+  if(childpid >= 0) /* fork succeeded */
+  {
+    if(childpid == 0) /* fork() returns 0 to the child process */
+    {
+      // resume signals
+      remove_signal_catcher();
+      sigprocmask(SIG_SETMASK, &old_mask, nullptr);
+
+      close(pipefd[0]); // unused in child
+
+      std::vector<char *> _argv(argv.size() + 1);
+      for(std::size_t i = 0; i < argv.size(); i++)
+        _argv[i] = strdup(argv[i].c_str());
+
+      _argv[argv.size()] = nullptr;
+
+      if(stdin_fd != STDIN_FILENO)
+        dup2(stdin_fd, STDIN_FILENO);
+      if(stdout_fd != STDOUT_FILENO)
+        dup2(stdout_fd, STDOUT_FILENO);
+      if(stderr_fd != STDERR_FILENO)
+        dup2(stderr_fd, STDERR_FILENO);
+
+      errno = 0;
+      execvp(what.c_str(), _argv.data());
+
+      /* usually no return */
+      perror(std::string("execvp " + what + " failed").c_str());
+      exit(1);
+    }
+    else /* fork() returns new pid to the parent process */
+    {
+      // must do before resuming signals to avoid race
+      register_child(childpid);
+
+      // resume signals
+      sigprocmask(SIG_SETMASK, &old_mask, nullptr);
+
+      close(pipefd[1]); // unused in the parent
+
+      const int buffer_size = 1024;
+      std::vector<char> buffer(buffer_size);
+      ssize_t bytes_read;
+
+      while((bytes_read = read(pipefd[0], buffer.data(), buffer_size)) > 0)
+        std_output.write(buffer.data(), bytes_read);
+
+      int status; /* parent process: child's exit status */
+
+      /* wait for child to exit, and store its status */
+      while(waitpid(childpid, &status, 0) == -1)
+      {
+        if(errno == EINTR)
+          continue; // try again
+        else
+        {
+          unregister_child();
+
+          perror("Waiting for child process failed");
+          if(stdin_fd != STDIN_FILENO)
+            close(stdin_fd);
+          if(stdout_fd != STDOUT_FILENO)
+            close(stdout_fd);
+          if(stderr_fd != STDERR_FILENO)
+            close(stderr_fd);
+          return 1;
+        }
+      }
+
+      unregister_child();
+
+      if(stdin_fd != STDIN_FILENO)
+        close(stdin_fd);
+      if(stdout_fd != STDOUT_FILENO)
+        close(stdout_fd);
+      if(stderr_fd != STDERR_FILENO)
+        close(stderr_fd);
+
+      return WEXITSTATUS(status);
+    }
+  }
+  else /* fork returns -1 on failure */
+  {
+    // resume signals
+    sigprocmask(SIG_SETMASK, &old_mask, nullptr);
+
+    if(stdin_fd != STDIN_FILENO)
+      close(stdin_fd);
+    if(stdout_fd != STDOUT_FILENO)
+      close(stdout_fd);
+    if(stderr_fd != STDERR_FILENO)
+      close(stderr_fd);
+
+    return 1;
+  }
+#endif
 }


### PR DESCRIPTION
`run(...)` has a variant that that accepts an `std::ostream` for the stdout redirection.  This replaces the use of `popen(...)` in this variant by a standard combination of `pipe`/`fork`/`exec`.

The benefit is this change is that the use of a shell is avoided, which is difficult to secure owing to the parsing of the command by the shell.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
