### PR TITLE
Flow-insensitive value set: don't create index expressions over non-array objects

### DIFF
--- a/src/pointer-analysis/value_set_fi.cpp
+++ b/src/pointer-analysis/value_set_fi.cpp
@@ -905,8 +905,12 @@ void value_set_fit::get_reference_set_sharing_rec(
     {
       const exprt &object = object_numbering[object_entry.first];
 
-      if(object.id()==ID_unknown)
+      if(
+        object.id() == ID_unknown ||
+        (object.type().id() != ID_array && object.type().id() != ID_vector))
+      {
         insert(dest, exprt(ID_unknown, expr.type()));
+      }
       else
       {
         index_exprt index_expr(


### PR DESCRIPTION
When evaluating an index expression, the value set must ignore pointed-to objects that are neither arrays nor vectors. Any appearance of such objects should produce `unknown` instead. (Trying to create an `index_exprt` with neither an array nor a vector as root object will fail an invariant.)

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
