### PR TITLE
Value set: remove array-of-array special case

### DIFF
--- a/src/pointer-analysis/value_set.cpp
+++ b/src/pointer-analysis/value_set.cpp
@@ -1352,14 +1352,7 @@ void value_sett::get_reference_set_rec(
     exprt l1_expr =
       is_ssa_expr(expr) ? remove_level_2(to_ssa_expr(expr)) : expr;
 
-    if(
-      expr.type().id() == ID_array &&
-      to_array_type(expr.type()).element_type().id() == ID_array)
-    {
-      insert(dest, l1_expr);
-    }
-    else
-      insert(dest, l1_expr, from_integer(0, c_index_type()));
+    insert(dest, l1_expr, from_integer(0, c_index_type()));
 
     return;
   }


### PR DESCRIPTION
There should not be a need for `get_reference_set` to consider array-of-array typed expressions to have an unknown offset when others firmly have offset zero.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
