### PR TITLE
fixup! fix exprt::opX accesses in linker_script_merge

### DIFF
--- a/src/goto-cc/linker_script_merge.cpp
+++ b/src/goto-cc/linker_script_merge.cpp
@@ -134,11 +134,13 @@ linker_script_merget::linker_script_merget(
     replacement_predicates(
       {replacement_predicatet(
          "address of array's first member",
-         [](const exprt &expr) -> const symbol_exprt & {
+         [](const exprt &expr) -> const symbol_exprt &
+         {
            return to_symbol_expr(
              to_index_expr(to_address_of_expr(expr).object()).array());
          },
-         [](const exprt &expr) {
+         [](const exprt &expr)
+         {
            return expr.id() == ID_address_of &&
                   expr.type().id() == ID_pointer &&
 
@@ -164,10 +166,10 @@ linker_script_merget::linker_script_merget(
          }),
        replacement_predicatet(
          "address of array",
-         [](const exprt &expr) -> const symbol_exprt & {
-           return to_symbol_expr(to_address_of_expr(expr).object());
-         },
-         [](const exprt &expr) {
+         [](const exprt &expr) -> const symbol_exprt &
+         { return to_symbol_expr(to_address_of_expr(expr).object()); },
+         [](const exprt &expr)
+         {
            return expr.id() == ID_address_of &&
                   expr.type().id() == ID_pointer &&
 
@@ -176,10 +178,10 @@ linker_script_merget::linker_script_merget(
          }),
        replacement_predicatet(
          "address of struct",
-         [](const exprt &expr) -> const symbol_exprt & {
-           return to_symbol_expr(to_address_of_expr(expr).object());
-         },
-         [](const exprt &expr) {
+         [](const exprt &expr) -> const symbol_exprt &
+         { return to_symbol_expr(to_address_of_expr(expr).object()); },
+         [](const exprt &expr)
+         {
            return expr.id() == ID_address_of &&
                   expr.type().id() == ID_pointer &&
 
@@ -190,20 +192,16 @@ linker_script_merget::linker_script_merget(
          }),
        replacement_predicatet(
          "array variable",
-         [](const exprt &expr) -> const symbol_exprt & {
-           return to_symbol_expr(expr);
-         },
-         [](const exprt &expr) {
-           return expr.id() == ID_symbol && expr.type().id() == ID_array;
-         }),
+         [](const exprt &expr) -> const symbol_exprt &
+         { return to_symbol_expr(expr); },
+         [](const exprt &expr)
+         { return expr.id() == ID_symbol && expr.type().id() == ID_array; }),
        replacement_predicatet(
          "pointer (does not need pointerizing)",
-         [](const exprt &expr) -> const symbol_exprt & {
-           return to_symbol_expr(expr);
-         },
-         [](const exprt &expr) {
-           return expr.id() == ID_symbol && expr.type().id() == ID_pointer;
-         })})
+         [](const exprt &expr) -> const symbol_exprt &
+         { return to_symbol_expr(expr); },
+         [](const exprt &expr)
+         { return expr.id() == ID_symbol && expr.type().id() == ID_pointer; })})
 {}
 
 int linker_script_merget::pointerize_linker_defined_symbols(

--- a/src/goto-cc/linker_script_merge.cpp
+++ b/src/goto-cc/linker_script_merge.cpp
@@ -136,7 +136,7 @@ linker_script_merget::linker_script_merget(
          "address of array's first member",
          [](const exprt &expr) -> const symbol_exprt & {
            return to_symbol_expr(
-             to_index_expr(to_address_of_expr(expr).object()).index());
+             to_index_expr(to_address_of_expr(expr).object()).array());
          },
          [](const exprt &expr) {
            return expr.id() == ID_address_of &&


### PR DESCRIPTION
In one case 7bf94f15794af48024b8cb0793711db5be6d5482 wrongly turned `index_exprt::op0` into `index_exprt::index()` when that should be `::array()`.

Running tests on aarch64 was thus broken (but we don't yet do that in CI).

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
