### PR TITLE
goto-analyzer: support typecasts as left-hand sides

### DIFF
--- a/src/analyses/variable-sensitivity/abstract_environment.cpp
+++ b/src/analyses/variable-sensitivity/abstract_environment.cpp
@@ -77,9 +77,13 @@ bool is_ptr_comparison(const exprt &expr)
          (expr.operands()[1].type().id() == ID_pointer);
 }
 
-static bool is_access_expr(const irep_idt &id)
+static bool is_access_expr(const exprt &expr)
 {
-  return id == ID_member || id == ID_index || id == ID_dereference;
+  if(auto tc = expr_try_dynamic_cast<typecast_exprt>(expr))
+    return is_access_expr(tc->op());
+
+  return expr.id() == ID_member || expr.id() == ID_index ||
+         expr.id() == ID_dereference;
 }
 
 static bool is_object_creation(const irep_idt &id)
@@ -107,7 +111,7 @@ abstract_environmentt::eval(const exprt &expr, const namespacet &ns) const
     return resolve_symbol(simplified_expr, ns);
 
   if(
-    is_access_expr(simplified_id) || is_ptr_diff(simplified_expr) ||
+    is_access_expr(simplified_expr) || is_ptr_diff(simplified_expr) ||
     is_ptr_comparison(simplified_expr))
   {
     auto const operands = eval_operands(simplified_expr, *this, ns);
@@ -168,7 +172,9 @@ bool abstract_environmentt::assign(
   std::stack<exprt> stactions; // I'm not a continuation, honest guv'
   while(s.id() != ID_symbol)
   {
-    if(s.id() == ID_index || s.id() == ID_member || s.id() == ID_dereference)
+    if(
+      s.id() == ID_index || s.id() == ID_member || s.id() == ID_dereference ||
+      s.id() == ID_typecast)
     {
       stactions.push(s);
       s = s.operands()[0];
@@ -248,8 +254,8 @@ abstract_object_pointert abstract_environmentt::write(
   const irep_idt &stack_head_id = next_expr.id();
   INVARIANT(
     stack_head_id == ID_index || stack_head_id == ID_member ||
-      stack_head_id == ID_dereference,
-    "Write stack expressions must be index, member, or dereference");
+      stack_head_id == ID_dereference || stack_head_id == ID_typecast,
+    "Write stack expressions must be index, member, dereference, or typecast");
 
   return lhs->write(*this, ns, remaining_stack, next_expr, rhs, merge_write);
 }


### PR DESCRIPTION
This arises with aarch64 va_list structs (but possibly also in other cases).

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
