### PR TITLE
CI: use Visual Studio 2025 runners instead of 2019

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -32,7 +32,7 @@ We are currently building and testing CBMC under the following configurations:
 * `cmake` * `gcc` * `linux` (ubuntu 22.04 32-bit)
 * `make` * `clang` * `macos` (13)
 * `cmake` * `clang` * `macos` (14)
-* `cmake` * `vs` * `windows` (vs2019)
+* `cmake` * `vs` * `windows` (vs2025)
 * `make` * `vs` * `windows` (vs2022)
 
 Aside from the main platform builds for testing, we are also performing

--- a/.github/workflows/pull-request-checks.yaml
+++ b/.github/workflows/pull-request-checks.yaml
@@ -684,8 +684,8 @@ jobs:
         run: cd build; ctest -V -L CORE . -j3
 
   # This job takes approximately 49 to 70 minutes
-  check-vs-2019-cmake-build-and-test:
-    runs-on: windows-2019
+  check-vs-2025-cmake-build-and-test:
+    runs-on: windows-2025
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
@@ -825,7 +825,7 @@ jobs:
 
   # This job takes approximately 7 to 32 minutes
   windows-msi-package:
-    runs-on: windows-2019
+    runs-on: windows-2025
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:

--- a/.github/workflows/regular-release.yaml
+++ b/.github/workflows/regular-release.yaml
@@ -76,9 +76,9 @@ jobs:
             PATH="C:\Program Files\cbmc\bin";%PATH%
             ```
 
-            Note that we depend on the Visual C++ redistributables. You likely already have these, if not please download and run vcredist.x64.exe from Microsoft to install them prior to running cbmc, or make sure you have Visual Studio 2019 installed.
+            Note that we depend on the Visual C++ redistributables. You likely already have these, if not please download and run vcredist.x64.exe from Microsoft to install them prior to running cbmc, or make sure you have Visual Studio 2025 installed.
 
-            You can download either [Visual Studio 2019 Community Edition](https://visualstudio.microsoft.com/vs/community/) or the [Visual C++ Redistributables](https://support.microsoft.com/en-gb/help/2977003/the-latest-supported-visual-c-downloads) from Microsoft for free.
+            You can download either [Visual Studio 2025 Community Edition](https://visualstudio.microsoft.com/vs/community/) or the [Visual C++ Redistributables](https://support.microsoft.com/en-gb/help/2977003/the-latest-supported-visual-c-downloads) from Microsoft for free.
 
             ## Docker
 

--- a/.github/workflows/release-packages.yaml
+++ b/.github/workflows/release-packages.yaml
@@ -181,7 +181,7 @@ jobs:
           go run scripts/slack_notification_action.go
 
   windows-msi-package:
-    runs-on: windows-2019
+    runs-on: windows-2025
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:


### PR DESCRIPTION
Visual Studio 2019 runners are deprecated and will cease to be provided by 2025-06-30.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [x] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
