### PR TITLE
Fix loop assign clause for Kani

### DIFF
--- a/src/ansi-c/goto-conversion/goto_convert.cpp
+++ b/src/ansi-c/goto-conversion/goto_convert.cpp
@@ -1078,7 +1078,7 @@ void goto_convertt::convert_loop_contracts(
   if(assigns.is_not_nil())
   {
     PRECONDITION(loop->is_goto() || loop->is_incomplete_goto());
-    loop->condition_nonconst().add(ID_C_spec_assigns).swap(assigns.op());
+    loop->condition_nonconst().add(ID_C_spec_assigns).swap(assigns);
   }
 
   auto invariant =


### PR DESCRIPTION
This PR fixes the bug that Kani only take the first target of the whole assign clause for loop.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
