### PR TITLE
Move is_{true,false,zero,one} from `exprt` to `constant_exprt`

### DIFF
--- a/jbmc/src/java_bytecode/java_object_factory.cpp
+++ b/jbmc/src/java_bytecode/java_object_factory.cpp
@@ -1087,8 +1087,12 @@ void java_object_factoryt::gen_nondet_init(
       else
       {
         exprt within_bounds = interval.make_contains_expr(expr);
-        if(!within_bounds.is_true())
+        if(
+          !within_bounds.is_constant() ||
+          !to_constant_expr(within_bounds).is_true())
+        {
           assignments.add(code_assumet(std::move(within_bounds)));
+        }
       }
 
       if(

--- a/src/analyses/constant_propagator.cpp
+++ b/src/analyses/constant_propagator.cpp
@@ -183,8 +183,8 @@ void constant_propagator_domaint::transform(
     else
       g = not_exprt(from->condition());
     partial_evaluate(values, g, ns);
-    if(g.is_false())
-     values.set_to_bottom();
+    if(g.is_constant() && to_constant_expr(g).is_false())
+      values.set_to_bottom();
     else
       two_way_propagate_rec(g, ns, cp);
   }
@@ -376,7 +376,7 @@ bool constant_propagator_domaint::two_way_propagate_rec(
 
     // x != FALSE ==> x == TRUE
 
-    if(rhs.is_zero() || rhs.is_false())
+    if(to_constant_expr(rhs).is_zero() || to_constant_expr(rhs).is_false())
       rhs = from_integer(1, rhs.type());
     else
       rhs = from_integer(0, rhs.type());

--- a/src/analyses/custom_bitvector_analysis.cpp
+++ b/src/analyses/custom_bitvector_analysis.cpp
@@ -530,7 +530,7 @@ void custom_bitvector_domaint::transform(
 
       const exprt result2 = simplify_expr(eval(guard, cba), ns);
 
-      if(result2.is_false())
+      if(result2.is_constant() && to_constant_expr(result2).is_false())
         make_bottom();
     }
     break;
@@ -814,12 +814,12 @@ void custom_bitvector_analysist::check(
       if(use_xml)
       {
         out << "<result status=\"";
-        if(result.is_true())
-          out << "SUCCESS";
-        else if(result.is_false())
-          out << "FAILURE";
-        else
+        if(!result.is_constant())
           out << "UNKNOWN";
+        else if(to_constant_expr(result).is_true())
+          out << "SUCCESS";
+        else
+          out << "FAILURE";
         out << "\">\n";
         out << xml(i_it->source_location());
         out << "<description>"
@@ -838,12 +838,12 @@ void custom_bitvector_analysist::check(
         out << '\n';
       }
 
-      if(result.is_true())
-        pass++;
-      else if(result.is_false())
-        fail++;
-      else
+      if(!result.is_constant())
         unknown++;
+      else if(to_constant_expr(result).is_true())
+        pass++;
+      else
+        fail++;
     }
 
     if(!use_xml)

--- a/src/analyses/goto_rw.cpp
+++ b/src/analyses/goto_rw.cpp
@@ -116,17 +116,17 @@ void rw_range_sett::get_objects_if(
   const range_spect &range_start,
   const range_spect &size)
 {
-  if(if_expr.cond().is_false())
-    get_objects_rec(mode, if_expr.false_case(), range_start, size);
-  else if(if_expr.cond().is_true())
-    get_objects_rec(mode, if_expr.true_case(), range_start, size);
-  else
+  if(!if_expr.cond().is_constant())
   {
     get_objects_rec(get_modet::READ, if_expr.cond());
 
     get_objects_rec(mode, if_expr.false_case(), range_start, size);
     get_objects_rec(mode, if_expr.true_case(), range_start, size);
   }
+  else if(to_constant_expr(if_expr.cond()).is_false())
+    get_objects_rec(mode, if_expr.false_case(), range_start, size);
+  else
+    get_objects_rec(mode, if_expr.true_case(), range_start, size);
 }
 
 void rw_range_sett::get_objects_dereference(
@@ -735,11 +735,7 @@ void rw_guarded_range_set_value_sett::get_objects_if(
   const range_spect &range_start,
   const range_spect &size)
 {
-  if(if_expr.cond().is_false())
-    get_objects_rec(mode, if_expr.false_case(), range_start, size);
-  else if(if_expr.cond().is_true())
-    get_objects_rec(mode, if_expr.true_case(), range_start, size);
-  else
+  if(!if_expr.cond().is_constant())
   {
     get_objects_rec(get_modet::READ, if_expr.cond());
 
@@ -753,6 +749,10 @@ void rw_guarded_range_set_value_sett::get_objects_if(
     get_objects_rec(mode, if_expr.true_case(), range_start, size);
     guard = std::move(copy);
   }
+  else if(to_constant_expr(if_expr.cond()).is_false())
+    get_objects_rec(mode, if_expr.false_case(), range_start, size);
+  else
+    get_objects_rec(mode, if_expr.true_case(), range_start, size);
 }
 
 void rw_guarded_range_set_value_sett::add(

--- a/src/analyses/guard_bdd.cpp
+++ b/src/analyses/guard_bdd.cpp
@@ -44,7 +44,7 @@ exprt guard_bddt::guard_expr(exprt expr) const
   }
   else
   {
-    if(expr.is_false())
+    if(expr.is_constant() && to_constant_expr(expr).is_false())
     {
       return boolean_negate(as_expr());
     }

--- a/src/analyses/guard_expr.cpp
+++ b/src/analyses/guard_expr.cpp
@@ -24,7 +24,7 @@ exprt guard_exprt::guard_expr(exprt expr) const
   }
   else
   {
-    if(expr.is_false())
+    if(expr.is_constant() && to_constant_expr(expr).is_false())
     {
       return boolean_negate(as_expr());
     }
@@ -39,9 +39,10 @@ void guard_exprt::add(const exprt &expr)
 {
   PRECONDITION(expr.is_boolean());
 
-  if(is_false() || expr.is_true())
+  if(is_false() || (expr.is_constant() && to_constant_expr(expr).is_true()))
     return;
-  else if(is_true() || expr.is_false())
+  else if(
+    is_true() || (expr.is_constant() && to_constant_expr(expr).is_false()))
   {
     this->expr = expr;
 
@@ -198,7 +199,9 @@ guard_exprt &operator|=(guard_exprt &g1, const guard_exprt &g2)
 
   if(tmp != and_expr1)
   {
-    if(and_expr1.is_true() || and_expr2.is_true())
+    if(
+      (and_expr1.is_constant() && to_constant_expr(and_expr1).is_true()) ||
+      (and_expr2.is_constant() && to_constant_expr(and_expr2).is_true()))
     {
     }
     else

--- a/src/analyses/guard_expr.h
+++ b/src/analyses/guard_expr.h
@@ -12,7 +12,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #ifndef CPROVER_ANALYSES_GUARD_EXPR_H
 #define CPROVER_ANALYSES_GUARD_EXPR_H
 
-#include <util/expr.h>
+#include <util/std_expr.h>
 
 /// This is unused by this implementation of guards, but can be used by other
 /// implementations of the same interface.
@@ -59,12 +59,12 @@ public:
 
   bool is_true() const
   {
-    return expr.is_true();
+    return expr.is_constant() && to_constant_expr(expr).is_true();
   }
 
   bool is_false() const
   {
-    return expr.is_false();
+    return expr.is_constant() && to_constant_expr(expr).is_false();
   }
 
   friend guard_exprt &operator-=(guard_exprt &g1, const guard_exprt &g2);

--- a/src/analyses/interval_analysis.cpp
+++ b/src/analyses/interval_analysis.cpp
@@ -46,7 +46,10 @@ void instrument_intervals(
     {
       goto_programt::const_targett previous = std::prev(i_it);
 
-      if(previous->is_goto() && !previous->condition().is_true())
+      if(
+        previous->is_goto() &&
+        (!previous->condition().is_constant() ||
+         !to_constant_expr(previous->condition()).is_true()))
       {
         // we follow a branch, instrument
       }
@@ -69,7 +72,7 @@ void instrument_intervals(
     for(const auto &symbol_expr : symbols)
     {
       exprt tmp=d.make_expression(symbol_expr);
-      if(!tmp.is_true())
+      if(!tmp.is_constant() || !to_constant_expr(tmp).is_true())
         assertion.push_back(tmp);
     }
 

--- a/src/analyses/interval_domain.cpp
+++ b/src/analyses/interval_domain.cpp
@@ -501,7 +501,8 @@ bool interval_domaint::ai_simplify(
                                           //  of when condition is true
     if(!a.join(d))                        // If d (this) is included in a...
     {                                     // Then the condition is always true
-      unchanged=condition.is_true();
+      unchanged =
+        condition.is_constant() && to_constant_expr(condition).is_true();
       condition = true_exprt();
     }
   }
@@ -514,7 +515,8 @@ bool interval_domaint::ai_simplify(
     d.assume(not_exprt(condition), ns);   // Restrict to when condition is false
     if(d.is_bottom())                     // If there there are none...
     {                                     // Then the condition is always true
-      unchanged=condition.is_true();
+      unchanged =
+        condition.is_constant() && to_constant_expr(condition).is_true();
       condition = true_exprt();
     }
   }

--- a/src/analyses/invariant_set.cpp
+++ b/src/analyses/invariant_set.cpp
@@ -394,14 +394,17 @@ void invariant_sett::strengthen_rec(const exprt &expr)
     return;
   }
 
-  if(expr.is_true())
+  if(expr.is_constant())
   {
-    // do nothing, it's useless
-  }
-  else if(expr.is_false())
-  {
-    // wow, that's strong
-    make_false();
+    if(to_constant_expr(expr).is_true())
+    {
+      // do nothing, it's useless
+    }
+    else
+    {
+      // wow, that's strong
+      make_false();
+    }
   }
   else if(expr.id()==ID_not)
   {
@@ -596,7 +599,7 @@ tvt invariant_sett::implies_rec(const exprt &expr) const
   if(is_false) // can't get any stronger
     return tvt(true);
 
-  if(expr.is_true())
+  if(expr.is_constant() && to_constant_expr(expr).is_true())
     return tvt(true);
   else if(expr.id()==ID_not)
   {
@@ -701,15 +704,18 @@ void invariant_sett::nnf(exprt &expr, bool negate)
   if(!expr.is_boolean())
     throw "nnf: non-Boolean expression";
 
-  if(expr.is_true())
+  if(expr.is_constant())
   {
-    if(negate)
-      expr=false_exprt();
-  }
-  else if(expr.is_false())
-  {
-    if(negate)
-      expr=true_exprt();
+    if(to_constant_expr(expr).is_true())
+    {
+      if(negate)
+        expr = false_exprt();
+    }
+    else
+    {
+      if(negate)
+        expr = true_exprt();
+    }
   }
   else if(expr.id()==ID_not)
   {

--- a/src/analyses/local_bitvector_analysis.cpp
+++ b/src/analyses/local_bitvector_analysis.cpp
@@ -115,7 +115,7 @@ local_bitvector_analysist::flagst local_bitvector_analysist::get_rec(
 {
   if(rhs.is_constant())
   {
-    if(rhs.is_zero())
+    if(to_constant_expr(rhs).is_zero())
       return flagst::mk_null();
     else
       return flagst::mk_integer_address();

--- a/src/analyses/local_cfg.cpp
+++ b/src/analyses/local_cfg.cpp
@@ -35,8 +35,12 @@ void local_cfgt::build(const goto_programt &goto_program)
     switch(instruction.type())
     {
     case GOTO:
-      if(!instruction.condition().is_true())
+      if(
+        !instruction.condition().is_constant() ||
+        !to_constant_expr(instruction.condition()).is_true())
+      {
         node.successors.push_back(loc_nr+1);
+      }
 
       for(const auto &target : instruction.targets)
       {

--- a/src/analyses/local_may_alias.cpp
+++ b/src/analyses/local_may_alias.cpp
@@ -171,7 +171,7 @@ void local_may_aliast::get_rec(
 {
   if(rhs.is_constant())
   {
-    if(rhs.is_zero())
+    if(to_constant_expr(rhs).is_zero())
       dest.insert(objects.number(exprt(ID_null_object)));
     else
       dest.insert(objects.number(exprt(ID_integer_address_object)));

--- a/src/analyses/variable-sensitivity/abstract_environment.cpp
+++ b/src/analyses/variable-sensitivity/abstract_environment.cpp
@@ -275,7 +275,7 @@ bool abstract_environmentt::assume(const exprt &expr, const namespacet &ns)
     // Should be of the right type
     INVARIANT(assumption.is_boolean(), "simplification preserves type");
 
-    if(assumption.is_false())
+    if(assumption.is_constant() && to_constant_expr(assumption).is_false())
     {
       bool currently_bottom = is_bottom();
       make_bottom();
@@ -579,10 +579,10 @@ static auto inverse_operations =
 
 static exprt invert_result(const exprt &result)
 {
-  if(!result.is_boolean())
+  if(!result.is_boolean() || !result.is_constant())
     return result;
 
-  if(result.is_true())
+  if(to_constant_expr(result).is_true())
     return false_exprt();
   return true_exprt();
 }
@@ -640,7 +640,7 @@ exprt assume_and(
   for(auto const &operand : and_expr.operands())
   {
     auto result = env.do_assume(operand, ns);
-    if(result.is_false())
+    if(result.is_constant() && to_constant_expr(result).is_false())
       return result;
     nil |= result.is_nil();
   }
@@ -833,7 +833,7 @@ exprt assume_less_than(
   auto reduced_le_expr =
     binary_relation_exprt(left_lower, expr.id(), right_upper);
   auto result = env.eval(reduced_le_expr, ns)->to_constant();
-  if(result.is_true())
+  if(result.is_constant() && to_constant_expr(result).is_true())
   {
     if(is_assignable(operands.lhs))
     {

--- a/src/analyses/variable-sensitivity/abstract_value_object.cpp
+++ b/src/analyses/variable-sensitivity/abstract_value_object.cpp
@@ -664,8 +664,10 @@ private:
     for(const auto &v : condition)
     {
       auto expr = v->to_constant();
-      all_true = all_true && expr.is_true();
-      all_false = all_false && expr.is_false();
+      all_true =
+        all_true && expr.is_constant() && to_constant_expr(expr).is_true();
+      all_false =
+        all_false && expr.is_constant() && to_constant_expr(expr).is_false();
     }
     auto indeterminate = !all_true && !all_false;
 

--- a/src/analyses/variable-sensitivity/full_array_abstract_object.cpp
+++ b/src/analyses/variable-sensitivity/full_array_abstract_object.cpp
@@ -426,7 +426,7 @@ exprt full_array_abstract_objectt::to_predicate_internal(
     auto index = index_exprt(name, ii);
     auto field_expr = field.second->to_predicate(index);
 
-    if(!field_expr.is_true())
+    if(!field_expr.is_constant() || !to_constant_expr(field_expr).is_true())
       all_predicates.push_back(field_expr);
   }
 

--- a/src/analyses/variable-sensitivity/full_struct_abstract_object.cpp
+++ b/src/analyses/variable-sensitivity/full_struct_abstract_object.cpp
@@ -312,7 +312,7 @@ exprt full_struct_abstract_objectt::to_predicate_internal(
       member_exprt(name, compound_type.get_component(field.first));
     auto field_expr = field.second->to_predicate(field_name);
 
-    if(!field_expr.is_true())
+    if(!field_expr.is_constant() || !to_constant_expr(field_expr).is_true())
       all_predicates.push_back(field_expr);
   }
 

--- a/src/analyses/variable-sensitivity/interval_abstract_value.cpp
+++ b/src/analyses/variable-sensitivity/interval_abstract_value.cpp
@@ -45,8 +45,9 @@ public:
   {
     index = next;
     next = next_element(next, ns);
-    return simplify_expr(binary_predicate_exprt(index, ID_le, upper), ns)
-      .is_true();
+    auto simp_expr =
+      simplify_expr(binary_predicate_exprt(index, ID_le, upper), ns);
+    return simp_expr.is_constant() && to_constant_expr(simp_expr).is_true();
   }
 
   index_range_implementation_ptrt reset() const override
@@ -239,11 +240,15 @@ bool new_interval_is_top(const constant_interval_exprt &e)
   if(e.is_top())
     return true;
 
-  if(e.get_lower().is_false() && e.get_upper().is_true())
+  if(!e.get_lower().is_constant() || !e.get_upper().is_constant())
+    return false;
+
+  const constant_exprt &lower = to_constant_expr(e.get_lower());
+  const constant_exprt &upper = to_constant_expr(e.get_upper());
+
+  if(lower.is_false() && upper.is_true())
     return true;
-  if(
-    e.type().id() == ID_c_bool && e.get_lower().is_zero() &&
-    e.get_upper().is_one())
+  if(e.type().id() == ID_c_bool && lower.is_zero() && upper.is_one())
     return true;
 
   return false;

--- a/src/analyses/variable-sensitivity/value_set_abstract_object.cpp
+++ b/src/analyses/variable-sensitivity/value_set_abstract_object.cpp
@@ -441,11 +441,13 @@ static bool is_set_extreme(const typet &type, const abstract_object_sett &set)
       set,
       [](const abstract_value_objectt &value) {
         auto c = value.to_constant();
-        return c.is_false() || (c.id() == ID_min_value);
+        return (c.is_constant() && to_constant_expr(c).is_false()) ||
+               (c.id() == ID_min_value);
       },
       [](const abstract_value_objectt &value) {
         auto c = value.to_constant();
-        return c.is_true() || (c.id() == ID_max_value);
+        return (c.is_constant() && to_constant_expr(c).is_true()) ||
+               (c.id() == ID_max_value);
       });
   }
 
@@ -455,11 +457,13 @@ static bool is_set_extreme(const typet &type, const abstract_object_sett &set)
       set,
       [](const abstract_value_objectt &value) {
         auto c = value.to_constant();
-        return c.is_zero() || (c.id() == ID_min_value);
+        return (c.is_constant() && to_constant_expr(c).is_zero()) ||
+               (c.id() == ID_min_value);
       },
       [](const abstract_value_objectt &value) {
         auto c = value.to_constant();
-        return c.is_one() || (c.id() == ID_max_value);
+        return (c.is_constant() && to_constant_expr(c).is_one()) ||
+               (c.id() == ID_max_value);
       });
   }
 

--- a/src/ansi-c/c_typecast.cpp
+++ b/src/ansi-c/c_typecast.cpp
@@ -565,11 +565,11 @@ void c_typecastt::implicit_typecast_followed(
   {
     // special case: 0 == NULL
 
-    if(simplify_expr(expr, ns).is_zero() && (
-       src_type.id()==ID_unsignedbv ||
-       src_type.id()==ID_signedbv ||
-       src_type.id()==ID_natural ||
-       src_type.id()==ID_integer))
+    auto simp_expr = simplify_expr(expr, ns);
+    if(
+      simp_expr.is_constant() && to_constant_expr(simp_expr).is_zero() &&
+      (src_type.id() == ID_unsignedbv || src_type.id() == ID_signedbv ||
+       src_type.id() == ID_natural || src_type.id() == ID_integer))
     {
       expr = null_pointer_exprt{to_pointer_type(orig_dest_type)};
       return; // ok

--- a/src/ansi-c/c_typecheck_base.cpp
+++ b/src/ansi-c/c_typecheck_base.cpp
@@ -312,7 +312,9 @@ static bool is_instantiation_of_flexible_array(
   return old_array_type.element_type() == new_array_type.element_type() &&
          old_array_type.get_bool(ID_C_flexible_array_member) &&
          new_array_type.get_bool(ID_C_flexible_array_member) &&
-         (old_array_type.size().is_nil() || old_array_type.size().is_zero());
+         (old_array_type.size().is_nil() ||
+          (old_array_type.size().is_constant() &&
+           to_constant_expr(old_array_type.size()).is_zero()));
 }
 
 void c_typecheck_baset::typecheck_redefinition_non_type(

--- a/src/ansi-c/c_typecheck_code.cpp
+++ b/src/ansi-c/c_typecheck_code.cpp
@@ -116,7 +116,7 @@ void c_typecheck_baset::typecheck_code(codet &code)
     implicit_typecast_bool(code.op0());
     make_constant(code.op0());
 
-    if(code.op0().is_false())
+    if(code.op0().is_constant() && to_constant_expr(code.op0()).is_false())
     {
       // failed
       error().source_location = code.find_source_location();
@@ -951,7 +951,7 @@ void c_typecheck_baset::typecheck_conditional_targets(
     auto &condition = conditional_target_group.condition();
     typecheck_spec_condition(condition);
 
-    if(condition.is_true())
+    if(condition.is_constant() && to_constant_expr(condition).is_true())
     {
       // if the condition is trivially true,
       // simplify expr and expose the bare expressions

--- a/src/ansi-c/c_typecheck_expr.cpp
+++ b/src/ansi-c/c_typecheck_expr.cpp
@@ -1441,18 +1441,24 @@ void c_typecheck_baset::typecheck_expr_rel(
   else
   {
     // pointer and zero
-    if(type0.id()==ID_pointer &&
-       simplify_expr(op1, *this).is_zero())
+    if(type0.id() == ID_pointer)
     {
-      op1 = null_pointer_exprt{to_pointer_type(type0)};
-      return;
+      auto simp_op1 = simplify_expr(op1, *this);
+      if(simp_op1.is_constant() && to_constant_expr(simp_op1).is_zero())
+      {
+        op1 = null_pointer_exprt{to_pointer_type(type0)};
+        return;
+      }
     }
 
-    if(type1.id()==ID_pointer &&
-       simplify_expr(op0, *this).is_zero())
+    if(type1.id() == ID_pointer)
     {
-      op0 = null_pointer_exprt{to_pointer_type(type1)};
-      return;
+      auto simp_op0 = simplify_expr(op0, *this);
+      if(simp_op0.is_constant() && to_constant_expr(simp_op0).is_zero())
+      {
+        op0 = null_pointer_exprt{to_pointer_type(type1)};
+        return;
+      }
     }
 
     // pointer and integer
@@ -3619,9 +3625,9 @@ exprt c_typecheck_baset::do_special_functions(
 
     mp_integer arg1;
 
-    if(expr.arguments()[1].is_true())
+    if(to_constant_expr(expr.arguments()[1]).is_true())
       arg1=1;
-    else if(expr.arguments()[1].is_false())
+    else if(to_constant_expr(expr.arguments()[1]).is_false())
       arg1=0;
     else if(to_integer(to_constant_expr(expr.arguments()[1]), arg1))
     {
@@ -3663,7 +3669,7 @@ exprt c_typecheck_baset::do_special_functions(
       typecast_exprt::conditional_cast(expr.arguments()[0], bool_typet());
     make_constant(arg0);
 
-    if(arg0.is_true())
+    if(to_constant_expr(arg0).is_true())
       return expr.arguments()[1];
     else
       return expr.arguments()[2];

--- a/src/ansi-c/c_typecheck_initializer.cpp
+++ b/src/ansi-c/c_typecheck_initializer.cpp
@@ -405,8 +405,10 @@ exprt::operandst::const_iterator c_typecheck_baset::do_designated_initializer(
       if(index>=dest->operands().size())
       {
         if(
-          type.id() == ID_array && (to_array_type(type).size().is_zero() ||
-                                    to_array_type(type).size().is_nil()))
+          type.id() == ID_array &&
+          ((to_array_type(type).size().is_constant() &&
+            to_constant_expr(to_array_type(type).size()).is_zero()) ||
+           to_array_type(type).size().is_nil()))
         {
           const typet &element_type = to_array_type(type).element_type();
 
@@ -673,10 +675,11 @@ exprt::operandst::const_iterator c_typecheck_baset::do_designated_initializer(
 
       // in case of a variable-length array consume all remaining
       // initializer elements
-      if(vla_permitted &&
-         dest_type.id()==ID_array &&
-         (to_array_type(dest_type).size().is_zero() ||
-          to_array_type(dest_type).size().is_nil()))
+      if(
+        vla_permitted && dest_type.id() == ID_array &&
+        ((to_array_type(dest_type).size().is_constant() &&
+          to_constant_expr(to_array_type(dest_type).size()).is_zero()) ||
+         to_array_type(dest_type).size().is_nil()))
       {
         value.id(ID_initializer_list);
         value.operands().clear();

--- a/src/ansi-c/c_typecheck_type.cpp
+++ b/src/ansi-c/c_typecheck_type.cpp
@@ -1129,12 +1129,12 @@ void c_typecheck_baset::typecheck_compound_body(
       assertion = typecast_exprt(assertion, bool_typet());
       make_constant(assertion);
 
-      if(assertion.is_false())
+      if(to_constant_expr(assertion).is_false())
       {
         throw errort().with_location(it->source_location())
           << "failed _Static_assert";
       }
-      else if(!assertion.is_true())
+      else if(!to_constant_expr(assertion).is_true())
       {
         // should warn/complain
       }
@@ -1303,9 +1303,9 @@ void c_typecheck_baset::typecheck_c_enum_type(typet &type)
       typecheck_expr(tmp_v);
       add_rounding_mode(tmp_v);
       simplify(tmp_v, *this);
-      if(tmp_v.is_true())
+      if(tmp_v.is_constant() && to_constant_expr(tmp_v).is_true())
         value=1;
-      else if(tmp_v.is_false())
+      else if(tmp_v.is_constant() && to_constant_expr(tmp_v).is_false())
         value=0;
       else if(
         tmp_v.is_constant() && !to_integer(to_constant_expr(tmp_v), value))

--- a/src/ansi-c/expr2c.cpp
+++ b/src/ansi-c/expr2c.cpp
@@ -1280,7 +1280,8 @@ std::string expr2ct::convert_complex(
   unsigned precedence)
 {
   if(
-    src.operands().size() == 2 && to_binary_expr(src).op0().is_zero() &&
+    src.operands().size() == 2 && to_binary_expr(src).op0().is_constant() &&
+    to_constant_expr(to_binary_expr(src).op0()).is_zero() &&
     to_binary_expr(src).op1().is_constant())
   {
     // This is believed to be gcc only; check if this is sensible
@@ -3559,7 +3560,7 @@ std::string expr2ct::convert_conditional_target_group(const exprt &src)
   std::string dest;
   unsigned p;
   const auto &cond = src.operands().front();
-  if(!cond.is_true())
+  if(!cond.is_constant() || !to_constant_expr(cond).is_true())
   {
     dest += convert_with_precedence(cond, p);
     dest += ": ";
@@ -3779,8 +3780,12 @@ std::string expr2ct::convert_with_precedence(
 
     if(object.id() == ID_label)
       return "&&" + object.get_string(ID_identifier);
-    else if(object.id() == ID_index && to_index_expr(object).index().is_zero())
+    else if(
+      object.id() == ID_index && to_index_expr(object).index().is_constant() &&
+      to_constant_expr(to_index_expr(object).index()).is_zero())
+    {
       return convert(to_index_expr(object).array());
+    }
     else if(to_pointer_type(src.type()).base_type().id() == ID_code)
       return convert_unary(to_unary_expr(src), "", precedence = 15);
     else

--- a/src/ansi-c/goto-conversion/builtin_functions.cpp
+++ b/src/ansi-c/goto-conversion/builtin_functions.cpp
@@ -606,7 +606,8 @@ exprt make_va_list(const exprt &expr)
   }
 
   while(result.type().id() == ID_array &&
-        to_array_type(result.type()).size().is_one())
+        to_array_type(result.type()).size().is_constant() &&
+        to_constant_expr(to_array_type(result.type()).size()).is_one())
   {
     result = index_exprt{result, from_integer(0, c_index_type())};
   }

--- a/src/ansi-c/goto-conversion/goto_check_c.cpp
+++ b/src/ansi-c/goto-conversion/goto_check_c.cpp
@@ -1695,7 +1695,8 @@ void goto_check_ct::bounds_check_index(
   }
   else if(
     expr.array().id() == ID_member &&
-    (size.is_zero() || array_type.get_bool(ID_C_flexible_array_member)))
+    ((size.is_constant() && to_constant_expr(size).is_zero()) ||
+     array_type.get_bool(ID_C_flexible_array_member)))
   {
     // a variable sized struct member
     //
@@ -1776,8 +1777,12 @@ void goto_check_ct::add_guarded_property(
     enable_simplify ? simplify_expr(asserted_expr, ns) : asserted_expr;
 
   // throw away trivial properties?
-  if(!retain_trivial && simplified_expr.is_true())
+  if(
+    !retain_trivial && simplified_expr.is_constant() &&
+    to_constant_expr(simplified_expr).is_true())
+  {
     return;
+  }
 
   // add the guard
   exprt guarded_expr = guard(simplified_expr);
@@ -2245,7 +2250,8 @@ void goto_check_ct::goto_check(
       // These are further 'exit points' of the program
       const exprt simplified_guard = simplify_expr(i.condition(), ns);
       if(
-        enable_memory_cleanup_check && simplified_guard.is_false() &&
+        enable_memory_cleanup_check && simplified_guard.is_constant() &&
+        to_constant_expr(simplified_guard).is_false() &&
         (function_identifier == "abort" || function_identifier == "exit" ||
          function_identifier == "_Exit" ||
          (i.labels.size() == 1 && i.labels.front() == "__VERIFIER_abort")))

--- a/src/ansi-c/goto-conversion/goto_clean_expr.cpp
+++ b/src/ansi-c/goto-conversion/goto_clean_expr.cpp
@@ -489,13 +489,13 @@ goto_convertt::clean_expr_resultt goto_convertt::clean_expr(
     {
       exprt tmp_cond=if_expr.cond();
       simplify(tmp_cond, ns);
-      if(tmp_cond.is_true())
+      if(tmp_cond.is_constant() && to_constant_expr(tmp_cond).is_true())
       {
         clean_expr(if_expr.true_case(), dest, result_is_used);
         expr=if_expr.true_case();
         return;
       }
-      else if(tmp_cond.is_false())
+      else if(tmp_cond.is_constant() && to_constant_expr(tmp_cond).is_false())
       {
         clean_expr(if_expr.false_case(), dest, result_is_used);
         expr=if_expr.false_case();

--- a/src/ansi-c/goto-conversion/goto_convert.cpp
+++ b/src/ansi-c/goto-conversion/goto_convert.cpp
@@ -419,7 +419,9 @@ void goto_convertt::optimize_guarded_gotos(goto_programt &dest)
 
     if(
       it_goto_y == dest.instructions.end() || !it_goto_y->is_goto() ||
-      !it_goto_y->condition().is_true() || it_goto_y->is_target())
+      !it_goto_y->condition().is_constant() ||
+      !to_constant_expr(it_goto_y->condition()).is_true() ||
+      it_goto_y->is_target())
     {
       continue;
     }
@@ -702,7 +704,7 @@ void goto_convertt::convert(
       typecast_exprt::conditional_cast(code.op0(), bool_typet());
     simplify(assertion, ns);
     INVARIANT_WITH_DIAGNOSTICS(
-      !assertion.is_false(),
+      !assertion.is_constant() || !to_constant_expr(assertion).is_false(),
       "static assertion is false",
       code.op0().find_source_location());
   }
@@ -745,7 +747,8 @@ void goto_convertt::convert_block(
   // in a prior break/continue/return already, don't create dead code
   if(
     !dest.empty() && dest.instructions.back().is_goto() &&
-    dest.instructions.back().condition().is_true())
+    dest.instructions.back().condition().is_constant() &&
+    to_constant_expr(dest.instructions.back().condition()).is_true())
   {
     // don't do destructors when we are unreachable
   }
@@ -1776,7 +1779,8 @@ void goto_convertt::generate_ifthenelse(
   // do guarded assertions directly
   if(
     is_size_one(true_case) && true_case.instructions.back().is_assert() &&
-    true_case.instructions.back().condition().is_false() &&
+    true_case.instructions.back().condition().is_constant() &&
+    to_constant_expr(true_case.instructions.back().condition()).is_false() &&
     true_case.instructions.back().labels.empty())
   {
     // The above conjunction deliberately excludes the instance
@@ -1794,7 +1798,8 @@ void goto_convertt::generate_ifthenelse(
   // similarly, do guarded assertions directly
   if(
     is_size_one(false_case) && false_case.instructions.back().is_assert() &&
-    false_case.instructions.back().condition().is_false() &&
+    false_case.instructions.back().condition().is_constant() &&
+    to_constant_expr(false_case.instructions.back().condition()).is_false() &&
     false_case.instructions.back().labels.empty())
   {
     // The above conjunction deliberately excludes the instance
@@ -1814,7 +1819,11 @@ void goto_convertt::generate_ifthenelse(
   if(
     is_empty(false_case) && true_case.instructions.size() == 2 &&
     true_case.instructions.front().is_assert() &&
-    simplify_expr(true_case.instructions.front().condition(), ns).is_false() &&
+    simplify_expr(true_case.instructions.front().condition(), ns)
+      .is_constant() &&
+    to_constant_expr(
+      simplify_expr(true_case.instructions.front().condition(), ns))
+      .is_false() &&
     true_case.instructions.front().labels.empty() &&
     true_case.instructions.back().is_other() &&
     true_case.instructions.back().get_other().get_statement() ==

--- a/src/ansi-c/goto-conversion/goto_convert_functions.cpp
+++ b/src/ansi-c/goto-conversion/goto_convert_functions.cpp
@@ -96,8 +96,11 @@ void goto_convert_functionst::add_return(
   // see if we have an unconditional goto at the end
   if(!f.body.instructions.empty() &&
      f.body.instructions.back().is_goto() &&
-     f.body.instructions.back().guard.is_true())
+     f.body.instructions.back().guard.is_constant() &&
+     to_constant_expr(f.body.instructions.back().guard).is_true())
+  {
     return;
+  }
 #else
 
   if(!f.body.instructions.empty())
@@ -108,7 +111,10 @@ void goto_convert_functionst::add_return(
     while(true)
     {
       // unconditional goto, say from while(1)?
-      if(last_instruction->is_goto() && last_instruction->condition().is_true())
+      if(
+        last_instruction->is_goto() &&
+        last_instruction->condition().is_constant() &&
+        to_constant_expr(last_instruction->condition()).is_true())
       {
         return;
       }

--- a/src/ansi-c/parser.y
+++ b/src/ansi-c/parser.y
@@ -1606,7 +1606,8 @@ pragma_packed:
         {
           init($$);
           if(!PARSER.pragma_pack.empty() &&
-             PARSER.pragma_pack.back().is_one())
+             PARSER.pragma_pack.back().is_constant() &&
+             to_constant_expr(PARSER.pragma_pack.back()).is_one())
             set($$, ID_packed);
         }
         ;
@@ -1810,7 +1811,8 @@ member_declaring_list:
           if(parser_stack($2).id() != ID_struct &&
              parser_stack($2).id() != ID_union &&
              !PARSER.pragma_pack.empty() &&
-             !PARSER.pragma_pack.back().is_zero())
+             (!PARSER.pragma_pack.back().is_constant() ||
+             !to_constant_expr(PARSER.pragma_pack.back()).is_zero()))
           {
             // communicate #pragma pack(n) alignment constraints by
             // by both setting packing AND alignment for individual struct/union

--- a/src/ansi-c/printf_formatter.cpp
+++ b/src/ansi-c/printf_formatter.cpp
@@ -215,7 +215,8 @@ void printf_formattert::process_format(std::ostream &out)
             expr_try_dynamic_cast<index_exprt>(address_of->object()))
         {
           if(
-            index_expr->index().is_zero() &&
+            index_expr->index().is_constant() &&
+            to_constant_expr(index_expr->index()).is_zero() &&
             index_expr->array().id() == ID_string_constant)
           {
             out << format_constant(index_expr->array());

--- a/src/cpp/cpp_instantiate_template.cpp
+++ b/src/cpp/cpp_instantiate_template.cpp
@@ -67,9 +67,9 @@ std::string cpp_typecheckt::template_suffix(
       // this must be a constant, which includes true/false
       mp_integer i;
 
-      if(e.is_true())
+      if(to_constant_expr(e).is_true())
         i=1;
-      else if(e.is_false())
+      else if(to_constant_expr(e).is_false())
         i=0;
       else if(to_integer(to_constant_expr(e), i))
       {

--- a/src/cpp/cpp_typecheck_conversions.cpp
+++ b/src/cpp/cpp_typecheck_conversions.cpp
@@ -465,8 +465,10 @@ bool cpp_typecheckt::standard_conversion_pointer(
     return false;
 
   // integer 0 to NULL pointer conversion?
-  if(simplify_expr(expr, *this).is_zero() &&
-     expr.type().id()!=ID_pointer)
+  auto simp_expr = simplify_expr(expr, *this);
+  if(
+    simp_expr.is_constant() && to_constant_expr(simp_expr).is_zero() &&
+    expr.type().id() != ID_pointer)
   {
     new_expr=expr;
     new_expr.set(ID_value, ID_NULL);
@@ -1857,7 +1859,8 @@ bool cpp_typecheckt::reinterpret_typecast(
     type.id() == ID_pointer && !is_reference(type))
   {
     // integer to pointer
-    if(simplify_expr(e, *this).is_zero())
+    auto simp_e = simplify_expr(e, *this);
+    if(simp_e.is_constant() && to_constant_expr(simp_e).is_zero())
     {
       // NULL
       new_expr=e;

--- a/src/cpp/cpp_typecheck_method_bodies.cpp
+++ b/src/cpp/cpp_typecheck_method_bodies.cpp
@@ -39,10 +39,16 @@ void cpp_typecheckt::typecheck_method_bodies()
 #ifdef DEBUG
     std::cout << "convert_method_body: " << method_symbol.name << '\n';
     std::cout << "  is_not_nil: " << body.is_not_nil() << '\n';
-    std::cout << "  !is_zero: " << (!body.is_zero()) << '\n';
+    std::cout << "  !is_zero: "
+              << (!body.is_constant() || !to_constant_expr(body).is_zero())
+              << '\n';
 #endif
-    if(body.is_not_nil() && !body.is_zero())
+    if(
+      body.is_not_nil() &&
+      (!body.is_constant() || !to_constant_expr(body).is_zero()))
+    {
       convert_function(method_symbol);
+    }
   }
 
   old_instantiation_stack.swap(instantiation_stack);

--- a/src/cpp/cpp_typecheck_static_assert.cpp
+++ b/src/cpp/cpp_typecheck_static_assert.cpp
@@ -21,7 +21,7 @@ void cpp_typecheckt::convert(cpp_static_assertt &cpp_static_assert)
   implicit_typecast_bool(cpp_static_assert.op0());
   make_constant(cpp_static_assert.op0());
 
-  if(cpp_static_assert.op0().is_false())
+  if(to_constant_expr(cpp_static_assert.op0()).is_false())
   {
     // failed
     error().source_location=cpp_static_assert.source_location();

--- a/src/cprover/inductiveness.cpp
+++ b/src/cprover/inductiveness.cpp
@@ -36,7 +36,7 @@ bool is_subsumed(
   bool verbose,
   const namespacet &ns)
 {
-  if(b.is_true())
+  if(b.is_constant() && to_constant_expr(b).is_true())
     return true; // anything subsumes 'true'
 
   if(a1.find(false_exprt()) != a1.end())
@@ -161,7 +161,7 @@ inductiveness_resultt inductiveness_check(
                   << frame_ref.index << consolet::reset << ' ';
 
       // trivially true?
-      if(invariant.is_true())
+      if(invariant.is_constant() && to_constant_expr(invariant).is_true())
       {
         if(solver_options.verbose)
           std::cout << "trivial\n";

--- a/src/cprover/instrument_contracts.cpp
+++ b/src/cprover/instrument_contracts.cpp
@@ -110,12 +110,14 @@ exprt assigns_match(const exprt &assigns, const exprt &lhs)
 
   if(lhs.id() == ID_member)
   {
-    if(assigns_match(assigns, to_member_expr(lhs).struct_op()).is_true())
+    exprt struct_op = assigns_match(assigns, to_member_expr(lhs).struct_op());
+    if(struct_op.is_constant() && to_constant_expr(struct_op).is_true())
       return true_exprt();
   }
   else if(lhs.id() == ID_index)
   {
-    if(assigns_match(assigns, to_index_expr(lhs).array()).is_true())
+    exprt array = assigns_match(assigns, to_index_expr(lhs).array());
+    if(array.is_constant() && to_constant_expr(array).is_true())
       return true_exprt();
   }
 
@@ -169,7 +171,7 @@ static exprt make_assigns_assertion(
       auto match = assigns_match(a, lhs);
 
       // trivial?
-      if(match.is_true())
+      if(match.is_constant() && to_constant_expr(match).is_true())
         return true_exprt();
 
       disjuncts.push_back(std::move(match));

--- a/src/cprover/may_alias.cpp
+++ b/src/cprover/may_alias.cpp
@@ -179,8 +179,12 @@ same_address(const exprt &a, const exprt &b, const namespacet &ns)
 
       CHECK_RETURN(base_same_address.has_value());
 
-      if(base_same_address->is_false())
+      if(
+        base_same_address->is_constant() &&
+        to_constant_expr(*base_same_address).is_false())
+      {
         return false_expr;
+      }
       else
       {
         return and_exprt(

--- a/src/cprover/simplify_state_expr.cpp
+++ b/src/cprover/simplify_state_expr.cpp
@@ -73,7 +73,7 @@ exprt simplify_evaluate_update(
   if(may_alias.has_value())
   {
     // 'simple' case
-    if(may_alias->is_true())
+    if(may_alias->is_constant() && to_constant_expr(*may_alias).is_true())
     {
       // The object is known to be the same.
       // (ς[A:=V])(A) --> V
@@ -83,7 +83,7 @@ exprt simplify_evaluate_update(
         address_taken,
         ns);
     }
-    else if(may_alias->is_false())
+    else if(may_alias->is_constant() && to_constant_expr(*may_alias).is_false())
     {
       // The object is known to be different.
       // (ς[❝x❞:=V])(❝y❞) --> ς(❝y❞)
@@ -680,7 +680,9 @@ exprt simplify_is_cstring_expr(
     auto may_alias =
       ::may_alias(pointer, update_state_expr.address(), address_taken, ns);
 
-    if(may_alias.has_value() && may_alias->is_false())
+    if(
+      may_alias.has_value() && may_alias->is_constant() &&
+      to_constant_expr(*may_alias).is_false())
     {
       // different objects
       // cstring(s[x:=v], p) --> cstring(s, p)
@@ -690,7 +692,9 @@ exprt simplify_is_cstring_expr(
     // maybe the same
 
     // Are we writing zero?
-    if(update_state_expr.new_value().is_zero())
+    if(
+      update_state_expr.new_value().is_constant() &&
+      to_constant_expr(update_state_expr.new_value()).is_zero())
     {
       // cstring(s[p:=0], q) --> if p alias q then true else cstring(s, q)
       auto same_object = ::same_object(pointer, update_state_expr.address());
@@ -776,7 +780,9 @@ exprt simplify_cstrlen_expr(
     auto may_be_same_object = ::may_be_same_object(
       pointer, update_state_expr.address(), address_taken, ns);
 
-    if(may_be_same_object.is_false())
+    if(
+      may_be_same_object.is_constant() &&
+      to_constant_expr(may_be_same_object).is_false())
     {
       // different objects
       // cstrlen(s[x:=v], p) --> cstrlen(s, p)

--- a/src/cprover/state_encoding.cpp
+++ b/src/cprover/state_encoding.cpp
@@ -134,7 +134,9 @@ std::vector<symbol_exprt> state_encodingt::incoming_symbols(loct loc) const
 
     // conditional jump from loc_in to loc?
     if(
-      loc_in->is_goto() && !loc_in->condition().is_true() &&
+      loc_in->is_goto() &&
+      (!loc_in->condition().is_constant() ||
+       !to_constant_expr(loc_in->condition()).is_true()) &&
       loc != std::next(loc_in))
     {
       suffix = "T";
@@ -617,7 +619,9 @@ void state_encodingt::setup_incoming(const goto_functiont &goto_function)
   forall_goto_program_instructions(it, goto_function.body)
   {
     auto next = std::next(it);
-    if(it->is_goto() && it->condition().is_true())
+    if(
+      it->is_goto() && it->condition().is_constant() &&
+      to_constant_expr(it->condition()).is_true())
     {
     }
     else if(next != goto_function.body.instructions.end())
@@ -1013,7 +1017,7 @@ void state_encodingt::encode(
       // We produce ∅ when the 'other' branch is taken. Get the condition.
       const auto &condition = loc->condition();
 
-      if(condition.is_true())
+      if(condition.is_constant() && to_constant_expr(condition).is_true())
       {
         dest << equal_exprt(out_state_expr(loc), in_state_expr(loc));
       }

--- a/src/goto-analyzer/static_verifier.cpp
+++ b/src/goto-analyzer/static_verifier.cpp
@@ -92,11 +92,11 @@ check_assertion(const ai_domain_baset &domain, exprt e, const namespacet &ns)
   }
 
   domain.ai_simplify(e, ns);
-  if(e.is_true())
+  if(e.is_constant() && to_constant_expr(e).is_true())
   {
     return ai_verifier_statust::TRUE;
   }
-  else if(e.is_false())
+  else if(e.is_constant() && to_constant_expr(e).is_false())
   {
     return ai_verifier_statust::FALSE_IF_REACHABLE;
   }

--- a/src/goto-analyzer/taint_analysis.cpp
+++ b/src/goto-analyzer/taint_analysis.cpp
@@ -343,7 +343,8 @@ bool taint_analysist::operator()(
           continue;
 
         exprt result = custom_bitvector_analysis.eval(i_it->condition(), i_it);
-        if(simplify_expr(std::move(result), ns).is_true())
+        exprt simp_result = simplify_expr(std::move(result), ns);
+        if(simp_result.is_constant() && to_constant_expr(simp_result).is_true())
           continue;
 
         if(first)

--- a/src/goto-checker/bmc_util.cpp
+++ b/src/goto-checker/bmc_util.cpp
@@ -55,9 +55,12 @@ ssa_step_matches_failing_property(const irep_idt &property_id)
 {
   return [property_id](
            symex_target_equationt::SSA_stepst::const_iterator step,
-           const decision_proceduret &decision_procedure) {
+           const decision_proceduret &decision_procedure)
+  {
     return step->is_assert() && step->property_id == property_id &&
-           decision_procedure.get(step->cond_handle).is_false();
+           decision_procedure.get(step->cond_handle).is_constant() &&
+           to_constant_expr(decision_procedure.get(step->cond_handle))
+             .is_false();
   };
 }
 
@@ -250,8 +253,10 @@ void update_properties_status_from_symex_target_equation(
 
     // Don't update status of properties that are constant 'false';
     // we wouldn't have traces for them.
-    const auto status = step.cond_expr.is_true() ? property_statust::PASS
-                                                 : property_statust::UNKNOWN;
+    const auto status = (step.cond_expr.is_constant() &&
+                         to_constant_expr(step.cond_expr).is_true())
+                          ? property_statust::PASS
+                          : property_statust::UNKNOWN;
     auto emplace_result = properties.emplace(
       property_id, property_infot{step.source.pc, step.comment, status});
 

--- a/src/goto-checker/counterexample_beautification.cpp
+++ b/src/goto-checker/counterexample_beautification.cpp
@@ -37,7 +37,8 @@ void counterexample_beautificationt::get_minimization_list(
       it->is_assignment() &&
       it->assignment_type == symex_targett::assignment_typet::STATE)
     {
-      if(!prop_conv.get(it->guard_handle).is_false())
+      exprt v = prop_conv.get(it->guard_handle);
+      if(!v.is_constant() || !to_constant_expr(v).is_false())
       {
         const typet &type = it->ssa_lhs.type();
 
@@ -75,9 +76,14 @@ counterexample_beautificationt::get_failed_property(
       it != equation.SSA_steps.end();
       it++)
   {
+    if(!it->is_assert())
+      continue;
+
+    exprt g = prop_conv.get(it->guard_handle);
+    exprt c = prop_conv.get(it->cond_handle);
     if(
-      it->is_assert() && prop_conv.get(it->guard_handle).is_true() &&
-      prop_conv.get(it->cond_handle).is_false())
+      g.is_constant() && to_constant_expr(g).is_true() && c.is_constant() &&
+      to_constant_expr(c).is_false())
     {
       return it;
     }

--- a/src/goto-checker/goto_symex_fault_localizer.cpp
+++ b/src/goto-checker/goto_symex_fault_localizer.cpp
@@ -108,11 +108,12 @@ void goto_symex_fault_localizert::update_scores(
   for(auto &l : localization_points)
   {
     auto &score = l.second->second;
-    if(solver.get(l.first).is_true())
+    exprt v = solver.get(l.first);
+    if(v.is_constant() && to_constant_expr(v).is_true())
     {
       score++;
     }
-    else if(solver.get(l.first).is_false() && score > 0)
+    else if(v.is_constant() && to_constant_expr(v).is_false() && score > 0)
     {
       score--;
     }

--- a/src/goto-checker/goto_symex_property_decider.cpp
+++ b/src/goto-checker/goto_symex_property_decider.cpp
@@ -90,7 +90,8 @@ void goto_symex_property_decidert::add_constraint_from_goals(
   {
     if(
       select_property(goal_pair.first) &&
-      !goal_pair.second.condition.is_false())
+      (!goal_pair.second.condition.is_constant() ||
+       !to_constant_expr(goal_pair.second.condition).is_false()))
     {
       disjuncts.push_back(goal_pair.second.condition);
     }
@@ -142,10 +143,9 @@ void goto_symex_property_decidert::update_properties_status_from_goals(
     for(auto &goal_pair : goal_map)
     {
       auto &status = properties.at(goal_pair.first).status;
+      exprt v = solver->decision_procedure().get(goal_pair.second.condition);
       if(
-        solver->decision_procedure()
-          .get(goal_pair.second.condition)
-          .is_true() &&
+        v.is_constant() && to_constant_expr(v).is_true() &&
         status != property_statust::FAIL)
       {
         status |= property_statust::FAIL;

--- a/src/goto-checker/symex_bmc.cpp
+++ b/src/goto-checker/symex_bmc.cpp
@@ -57,19 +57,21 @@ void symex_bmct::symex_step(
   const goto_programt::const_targett cur_pc = state.source.pc;
   const guardt cur_guard = state.guard;
 
-  if(
-    !state.guard.is_false() && state.source.pc->is_assume() &&
-    simplify_expr(state.source.pc->condition(), ns).is_false())
+  if(!state.guard.is_false() && state.source.pc->is_assume())
   {
-    log.statistics() << "aborting path on assume(false) at "
-                     << state.source.pc->source_location() << " thread "
-                     << state.source.thread_nr;
+    exprt simp_cond = simplify_expr(state.source.pc->condition(), ns);
+    if(simp_cond.is_constant() && to_constant_expr(simp_cond).is_false())
+    {
+      log.statistics() << "aborting path on assume(false) at "
+                       << state.source.pc->source_location() << " thread "
+                       << state.source.thread_nr;
 
-    const irep_idt &c = state.source.pc->source_location().get_comment();
-    if(!c.empty())
-      log.statistics() << ": " << c;
+      const irep_idt &c = state.source.pc->source_location().get_comment();
+      if(!c.empty())
+        log.statistics() << ": " << c;
 
-    log.statistics() << log.eom;
+      log.statistics() << log.eom;
+    }
   }
 
   goto_symext::symex_step(get_goto_function, state);
@@ -88,7 +90,8 @@ void symex_bmct::symex_step(
     // sure the goto is considered covered
     if(
       cur_pc->is_goto() && cur_pc->get_target() != state.source.pc &&
-      cur_pc->condition().is_true())
+      cur_pc->condition().is_constant() &&
+      to_constant_expr(cur_pc->condition()).is_true())
       symex_coverage.covered(cur_pc, cur_pc->get_target());
     else if(!state.guard.is_false())
       symex_coverage.covered(cur_pc, state.source.pc);
@@ -111,8 +114,11 @@ void symex_bmct::merge_goto(
     // could the branch possibly be taken?
     !prev_guard.is_false() && !state.guard.is_false() &&
     // branches only, no single-successor goto
-    !prev_pc->condition().is_true())
+    (!prev_pc->condition().is_constant() ||
+     !to_constant_expr(prev_pc->condition()).is_true()))
+  {
     symex_coverage.covered(prev_pc, state.source.pc);
+  }
 }
 
 bool symex_bmct::should_stop_unwind(

--- a/src/goto-instrument/accelerate/accelerate.cpp
+++ b/src/goto-instrument/accelerate/accelerate.cpp
@@ -44,7 +44,8 @@ goto_programt::targett acceleratet::find_back_jump(
   for(const auto &t : loop)
   {
     if(
-      t->is_goto() && t->condition().is_true() && t->targets.size() == 1 &&
+      t->is_goto() && t->condition().is_constant() &&
+      to_constant_expr(t->condition()).is_true() && t->targets.size() == 1 &&
       t->targets.front() == loop_header &&
       t->location_number > back_jump->location_number)
     {

--- a/src/goto-instrument/accelerate/acceleration_utils.cpp
+++ b/src/goto-instrument/accelerate/acceleration_utils.cpp
@@ -256,7 +256,10 @@ exprt acceleration_utilst::precondition(patht &path)
       // Ignore.
     }
 
-    if(!r_it->guard.is_true() && !r_it->guard.is_nil())
+    if(
+      (!r_it->guard.is_constant() ||
+       !to_constant_expr(r_it->guard).is_true()) &&
+      !r_it->guard.is_nil())
     {
       // The guard isn't constant true, so we need to accumulate that too.
       ret=implies_exprt(r_it->guard, ret);

--- a/src/goto-instrument/accelerate/cone_of_influence.cpp
+++ b/src/goto-instrument/accelerate/cone_of_influence.cpp
@@ -89,7 +89,9 @@ void cone_of_influencet::get_succs(
 
   if(rit->is_goto())
   {
-    if(!rit->condition().is_false())
+    if(
+      !rit->condition().is_constant() ||
+      !to_constant_expr(rit->condition()).is_false())
     {
       // Branch can be taken.
       for(goto_programt::targetst::const_iterator t=rit->targets.begin();
@@ -102,14 +104,18 @@ void cone_of_influencet::get_succs(
       }
     }
 
-    if(rit->condition().is_true())
+    if(
+      rit->condition().is_constant() &&
+      to_constant_expr(rit->condition()).is_true())
     {
       return;
     }
   }
   else if(rit->is_assume() || rit->is_assert())
   {
-    if(rit->condition().is_false())
+    if(
+      rit->condition().is_constant() &&
+      to_constant_expr(rit->condition()).is_false())
     {
       return;
     }

--- a/src/goto-instrument/accelerate/disjunctive_polynomial_acceleration.cpp
+++ b/src/goto-instrument/accelerate/disjunctive_polynomial_acceleration.cpp
@@ -789,7 +789,9 @@ void disjunctive_polynomial_accelerationt::build_path(
     for(const auto &succ : succs)
     {
       exprt &distinguisher=distinguishing_points[succ];
-      bool taken=scratch_program.eval(distinguisher).is_true();
+      exprt distinguisher_eval = scratch_program.eval(distinguisher);
+      bool taken = distinguisher_eval.is_constant() &&
+                   to_constant_expr(distinguisher_eval).is_true();
 
       if(taken)
       {
@@ -992,7 +994,8 @@ void disjunctive_polynomial_accelerationt::record_path(
       it != distinguishers.end();
       ++it)
   {
-    path_val[*it]=program.eval(*it).is_true();
+    exprt eval = program.eval(*it);
+    path_val[*it] = eval.is_constant() && to_constant_expr(eval).is_true();
   }
 
   accelerated_paths.push_back(path_val);

--- a/src/goto-instrument/accelerate/polynomial_accelerator.cpp
+++ b/src/goto-instrument/accelerate/polynomial_accelerator.cpp
@@ -785,7 +785,10 @@ exprt polynomial_acceleratort::precondition(patht &path)
       // Ignore.
     }
 
-    if(!r_it->guard.is_true() && !r_it->guard.is_nil())
+    if(
+      (!r_it->guard.is_constant() ||
+       !to_constant_expr(r_it->guard).is_true()) &&
+      !r_it->guard.is_nil())
     {
       // The guard isn't constant true, so we need to accumulate that too.
       ret=implies_exprt(r_it->guard, ret);

--- a/src/goto-instrument/accelerate/sat_path_enumerator.cpp
+++ b/src/goto-instrument/accelerate/sat_path_enumerator.cpp
@@ -136,7 +136,9 @@ void sat_path_enumeratort::build_path(
     for(const auto &succ : succs)
     {
       exprt &distinguisher=distinguishing_points[succ];
-      bool taken=scratch_program.eval(distinguisher).is_true();
+      exprt distinguisher_eval = scratch_program.eval(distinguisher);
+      bool taken = distinguisher_eval.is_constant() &&
+                   to_constant_expr(distinguisher_eval).is_true();
 
       if(taken)
       {
@@ -335,7 +337,10 @@ void sat_path_enumeratort::record_path(scratch_programt &program)
   distinguish_valuest path_val;
 
   for(const auto &expr : distinguishers)
-    path_val[expr]=program.eval(expr).is_true();
+  {
+    exprt eval = program.eval(expr);
+    path_val[expr] = eval.is_constant() && to_constant_expr(eval).is_true();
+  }
 
   accelerated_paths.push_back(path_val);
 }

--- a/src/goto-instrument/call_sequences.cpp
+++ b/src/goto-instrument/call_sequences.cpp
@@ -231,8 +231,12 @@ void check_call_sequencet::operator()()
     {
       goto_programt::const_targett t=e.pc->get_target();
 
-      if(e.pc->condition().is_true())
+      if(
+        e.pc->condition().is_constant() &&
+        to_constant_expr(e.pc->condition()).is_true())
+      {
         e.pc=t;
+      }
       else
       {
         e.pc++;

--- a/src/goto-instrument/contracts/contracts.cpp
+++ b/src/goto-instrument/contracts/contracts.cpp
@@ -375,7 +375,9 @@ void code_contractst::check_apply_loop_contracts(
   }
 
   // TODO: Fix loop contract handling for do/while loops.
-  if(loop_end->is_goto() && !loop_end->condition().is_true())
+  if(
+    loop_end->is_goto() && (!loop_end->condition().is_constant() ||
+                            !to_constant_expr(loop_end->condition()).is_true()))
   {
     log.error() << "Loop contracts are unsupported on do/while loops: "
                 << loop_head_location << messaget::eom;
@@ -782,7 +784,7 @@ void code_contractst::apply_function_contract(
   // Generate: assume(ensures)
   for(auto &clause : instantiated_ensures_clauses)
   {
-    if(clause.is_false())
+    if(clause.is_constant() && to_constant_expr(clause).is_false())
     {
       throw invalid_input_exceptiont(
         std::string("Attempt to assume false at ")
@@ -1353,7 +1355,9 @@ void code_contractst::add_contract_check(
   {
     auto instantiated_clause =
       to_lambda_expr(clause).application(instantiation_values);
-    if(instantiated_clause.is_false())
+    if(
+      instantiated_clause.is_constant() &&
+      to_constant_expr(instantiated_clause).is_false())
     {
       throw invalid_input_exceptiont(
         std::string("Attempt to assume false at ")

--- a/src/goto-instrument/contracts/dynamic-frames/dfcc_check_loop_normal_form.cpp
+++ b/src/goto-instrument/contracts/dynamic-frames/dfcc_check_loop_normal_form.cpp
@@ -156,7 +156,10 @@ void dfcc_check_loop_normal_form(goto_programt &goto_program, messaget &log)
     //       IF TRUE GOTO HEAD
     // EXIT: SKIP
     // ```
-    if(latch->has_condition() && !latch->condition().is_true())
+    if(
+      latch->has_condition() &&
+      (!latch->condition().is_constant() ||
+       !to_constant_expr(latch->condition()).is_true()))
     {
       const source_locationt &loc = latch->source_location();
       const auto &exit =

--- a/src/goto-instrument/contracts/instrument_spec_assigns.cpp
+++ b/src/goto-instrument/contracts/instrument_spec_assigns.cpp
@@ -585,8 +585,10 @@ car_exprt instrument_spec_assignst::create_car_expr(
           valid_var,
           lower_bound_var,
           upper_bound_var,
-          is_ptr_to_ptr.is_true() ? car_havoc_methodt::NONDET_ASSIGN
-                                  : car_havoc_methodt::HAVOC_SLICE};
+          (is_ptr_to_ptr.is_constant() &&
+           to_constant_expr(is_ptr_to_ptr).is_true())
+            ? car_havoc_methodt::NONDET_ASSIGN
+            : car_havoc_methodt::HAVOC_SLICE};
       }
     }
   }
@@ -685,7 +687,9 @@ void instrument_spec_assignst::target_validity_assertion(
   std::string comment = "Check that ";
   comment += from_expr(ns, "", car.target());
   comment += " is valid";
-  if(!car.condition().is_true())
+  if(
+    !car.condition().is_constant() ||
+    !to_constant_expr(car.condition()).is_true())
   {
     comment += " when ";
     comment += from_expr(ns, "", car.condition());
@@ -719,8 +723,12 @@ void instrument_spec_assignst::inclusion_check_assertion(
   std::string comment = "Check that ";
   if(!is_assigns_clause_replacement_tracking_comment(orig_comment))
   {
-    if(!car.condition().is_true())
+    if(
+      !car.condition().is_constant() ||
+      !to_constant_expr(car.condition()).is_true())
+    {
       comment += from_expr(ns, "", car.condition()) + ": ";
+    }
     comment += from_expr(ns, "", car.target());
   }
   else

--- a/src/goto-instrument/contracts/utils.cpp
+++ b/src/goto-instrument/contracts/utils.cpp
@@ -151,7 +151,9 @@ void havoc_assigns_targetst::append_havoc_code_for_expr(
     {
       const auto &ptr = funcall.arguments().at(0);
       const auto &size = funcall.arguments().at(1);
-      if(funcall.arguments().at(2).is_true())
+      if(
+        funcall.arguments().at(2).is_constant() &&
+        to_constant_expr(funcall.arguments().at(2)).is_true())
       {
         append_havoc_pointer_code(expr.source_location(), ptr, dest);
       }
@@ -261,10 +263,14 @@ void simplify_gotos(goto_programt &goto_program, const namespacet &ns)
 {
   for(auto &instruction : goto_program.instructions)
   {
-    if(
-      instruction.is_goto() &&
-      simplify_expr(instruction.condition(), ns).is_false())
+    if(!instruction.is_goto())
+      continue;
+
+    exprt simp_cond = simplify_expr(instruction.condition(), ns);
+    if(simp_cond.is_constant() && to_constant_expr(simp_cond).is_false())
+    {
       instruction.turn_into_skip();
+    }
   }
 }
 

--- a/src/goto-instrument/cover_basic_blocks.cpp
+++ b/src/goto-instrument/cover_basic_blocks.cpp
@@ -23,8 +23,11 @@ std::optional<std::size_t> cover_basic_blockst::continuation_of_block(
   const goto_programt::targett in_t = *instruction->incoming_edges.cbegin();
   if(
     in_t->is_goto() && !in_t->is_backwards_goto() &&
-    in_t->condition().is_true())
+    in_t->condition().is_constant() &&
+    to_constant_expr(in_t->condition()).is_true())
+  {
     return block_map[in_t];
+  }
 
   return {};
 }

--- a/src/goto-instrument/cover_instrument_branch.cpp
+++ b/src/goto-instrument/cover_instrument_branch.cpp
@@ -26,7 +26,8 @@ void cover_branch_instrumentert::instrument(
   const bool is_function_entry_point =
     i_it == goto_program.instructions.begin();
   const bool is_conditional_goto =
-    i_it->is_goto() && !i_it->condition().is_true();
+    i_it->is_goto() && (!i_it->condition().is_constant() ||
+                        !to_constant_expr(i_it->condition()).is_true());
   if(!is_function_entry_point && !is_conditional_goto)
     return;
 

--- a/src/goto-instrument/dot.cpp
+++ b/src/goto-instrument/dot.cpp
@@ -108,8 +108,12 @@ void dott::write_dot_subgraph(
       std::stringstream tmp;
       if(it->is_goto())
       {
-        if(it->condition().is_true())
+        if(
+          it->condition().is_constant() &&
+          to_constant_expr(it->condition()).is_true())
+        {
           tmp.str("Goto");
+        }
         else
         {
           std::string t = from_expr(ns, function_id, it->condition());
@@ -320,14 +324,20 @@ void dott::find_next(
   std::set<goto_programt::const_targett, goto_programt::target_less_than> &tres,
   std::set<goto_programt::const_targett, goto_programt::target_less_than> &fres)
 {
-  if(it->is_goto() && !it->condition().is_false())
+  if(
+    it->is_goto() && (!it->condition().is_constant() ||
+                      !to_constant_expr(it->condition()).is_false()))
   {
     for(const auto &target : it->targets)
       tres.insert(target);
   }
 
-  if(it->is_goto() && it->condition().is_true())
+  if(
+    it->is_goto() && it->condition().is_constant() &&
+    to_constant_expr(it->condition()).is_true())
+  {
     return;
+  }
 
   goto_programt::const_targett next = it; next++;
   if(next!=instructions.end())

--- a/src/goto-instrument/dump_c.cpp
+++ b/src/goto-instrument/dump_c.cpp
@@ -1499,7 +1499,9 @@ void dump_ct::cleanup_expr(exprt &expr)
   {
     const byte_update_exprt &bu = to_byte_update_expr(expr);
 
-    if(bu.op().id() == ID_union && bu.offset().is_zero())
+    if(
+      bu.op().id() == ID_union && bu.offset().is_constant() &&
+      to_constant_expr(bu.offset()).is_zero())
     {
       const union_exprt &union_expr = to_union_expr(bu.op());
       const union_typet &union_type =
@@ -1537,7 +1539,7 @@ void dump_ct::cleanup_expr(exprt &expr)
       to_side_effect_expr(bu.op()).get_statement() == ID_nondet &&
       (bu.op().type().id() == ID_union ||
        bu.op().type().id() == ID_union_tag) &&
-      bu.offset().is_zero())
+      bu.offset().is_constant() && to_constant_expr(bu.offset()).is_zero())
     {
       const union_typet &union_type =
         bu.op().type().id() == ID_union_tag

--- a/src/goto-instrument/full_slicer.cpp
+++ b/src/goto-instrument/full_slicer.cpp
@@ -281,9 +281,12 @@ void full_slicert::operator()(
     else if(implicit(instruction))
       add_to_queue(queue, instruction_node_index, instruction);
     else if(
-      (instruction->is_goto() && instruction->condition().is_true()) ||
+      (instruction->is_goto() && instruction->condition().is_constant() &&
+       to_constant_expr(instruction->condition()).is_true()) ||
       instruction->is_throw())
+    {
       jumps.push_back(instruction_node_index);
+    }
     else if(instruction->is_decl())
     {
       const auto &s = instruction->decl_symbol();

--- a/src/goto-instrument/horn_encoding.cpp
+++ b/src/goto-instrument/horn_encoding.cpp
@@ -428,7 +428,9 @@ std::vector<symbol_exprt> state_encodingt::incoming_symbols(loct loc) const
 
     // conditional jump from loc_in to loc?
     if(
-      loc_in->is_goto() && !loc_in->condition().is_true() &&
+      loc_in->is_goto() &&
+      (!loc_in->condition().is_constant() ||
+       !to_constant_expr(loc_in->condition()).is_true()) &&
       loc != std::next(loc_in))
     {
       suffix = "T";
@@ -688,7 +690,9 @@ void state_encodingt::setup_incoming(const goto_functiont &goto_function)
   forall_goto_program_instructions(it, goto_function.body)
   {
     auto next = std::next(it);
-    if(it->is_goto() && it->condition().is_true())
+    if(
+      it->is_goto() && it->condition().is_constant() &&
+      to_constant_expr(it->condition()).is_true())
     {
     }
     else if(next != goto_function.body.instructions.end())
@@ -921,7 +925,7 @@ void state_encodingt::encode(
       // We produce ∅ when the 'other' branch is taken. Get the condition.
       const auto &condition = loc->condition();
 
-      if(condition.is_true())
+      if(condition.is_constant() && to_constant_expr(condition).is_true())
       {
         dest << equal_exprt(out_state_expr(loc), in_state_expr(loc));
       }

--- a/src/goto-instrument/unwind.cpp
+++ b/src/goto-instrument/unwind.cpp
@@ -140,7 +140,9 @@ void goto_unwindt::unwind(
 
     exprt exit_cond = false_exprt(); // default is false
 
-    if(!t->condition().is_true()) // cond in backedge
+    if(
+      !t->condition().is_constant() ||
+      !to_constant_expr(t->condition()).is_true()) // cond in backedge
     {
       exit_cond = boolean_negate(t->condition());
     }
@@ -190,7 +192,9 @@ void goto_unwindt::unwind(
     goto_programt::const_targett t_before=loop_exit;
     t_before--;
 
-    if(!t_before->is_goto() || !t_before->condition().is_true())
+    if(
+      !t_before->is_goto() || !t_before->condition().is_constant() ||
+      !to_constant_expr(t_before->condition()).is_true())
     {
       goto_programt::targett t_goto = goto_program.insert_before(
         loop_exit,

--- a/src/goto-programs/cfg.h
+++ b/src/goto-programs/cfg.h
@@ -320,7 +320,8 @@ void cfg_baset<T, P, I>::compute_edges_goto(
 {
   if(
     next_PC != goto_program.instructions.end() &&
-    !instruction.condition().is_true())
+    (!instruction.condition().is_constant() ||
+     !to_constant_expr(instruction.condition()).is_true()))
   {
     this->add_edge(entry, entry_map[next_PC]);
   }
@@ -501,8 +502,12 @@ void cfg_baset<T, P, I>::compute_edges(
 
   case ASSUME:
     // false guard -> no successor
-    if(instruction.condition().is_false())
+    if(
+      instruction.condition().is_constant() &&
+      to_constant_expr(instruction.condition()).is_false())
+    {
       break;
+    }
 
   case ASSIGN:
   case ASSERT:

--- a/src/goto-programs/ensure_one_backedge_per_target.cpp
+++ b/src/goto-programs/ensure_one_backedge_per_target.cpp
@@ -57,7 +57,9 @@ bool ensure_one_backedge_per_target(
 
   // If the last backedge is a conditional jump, add an extra unconditional
   // backedge after it:
-  if(!last_backedge->condition().is_true())
+  if(
+    !last_backedge->condition().is_constant() ||
+    !to_constant_expr(last_backedge->condition()).is_true())
   {
     auto new_goto =
       goto_program.insert_after(last_backedge, goto_programt::make_goto(it));

--- a/src/goto-programs/goto_program.cpp
+++ b/src/goto-programs/goto_program.cpp
@@ -79,7 +79,7 @@ std::ostream &goto_programt::instructiont::output(std::ostream &out) const
 
   case GOTO:
   case INCOMPLETE_GOTO:
-    if(!condition().is_true())
+    if(!condition().is_constant() || !to_constant_expr(condition()).is_true())
     {
       out << "IF " << format(condition()) << " THEN ";
     }
@@ -525,7 +525,9 @@ std::string as_string(
     return "(NO INSTRUCTION TYPE)";
 
   case GOTO:
-    if(!i.condition().is_true())
+    if(
+      !i.condition().is_constant() ||
+      !to_constant_expr(i.condition()).is_true())
     {
       result += "IF " + from_expr(ns, function, i.condition()) + " THEN ";
     }
@@ -742,8 +744,14 @@ void goto_programt::copy_from(const goto_programt &src)
 bool goto_programt::has_assertion() const
 {
   for(const auto &i : instructions)
-    if(i.is_assert() && !i.condition().is_true())
+  {
+    if(
+      i.is_assert() && (!i.condition().is_constant() ||
+                        !to_constant_expr(i.condition()).is_true()))
+    {
       return true;
+    }
+  }
 
   return false;
 }

--- a/src/goto-programs/goto_program.h
+++ b/src/goto-programs/goto_program.h
@@ -1136,8 +1136,13 @@ std::list<Target> goto_programt::get_successors(
   {
     std::list<Target> successors(i.targets.begin(), i.targets.end());
 
-    if(!i.condition().is_true() && next != instructions.end())
+    if(
+      (!i.condition().is_constant() ||
+       !to_constant_expr(i.condition()).is_true()) &&
+      next != instructions.end())
+    {
       successors.push_back(next);
+    }
 
     return successors;
   }
@@ -1166,7 +1171,9 @@ std::list<Target> goto_programt::get_successors(
 
   if(i.is_assume())
   {
-    return !i.condition().is_false() && next != instructions.end()
+    return (!i.condition().is_constant() ||
+            !to_constant_expr(i.condition()).is_false()) &&
+               next != instructions.end()
              ? std::list<Target>{next}
              : std::list<Target>();
   }

--- a/src/goto-programs/goto_trace.cpp
+++ b/src/goto-programs/goto_trace.cpp
@@ -227,7 +227,7 @@ std::string trace_numeric_value(
     }
     else if(type.id()==ID_bool)
     {
-      return expr.is_true()?"1":"0";
+      return to_constant_expr(expr).is_true() ? "1" : "0";
     }
     else if(type.id()==ID_integer)
     {

--- a/src/goto-programs/graphml_witness.cpp
+++ b/src/goto-programs/graphml_witness.cpp
@@ -238,8 +238,12 @@ static bool filter_out(
     prev_it->pc->source_location() == it->pc->source_location())
     return true;
 
-  if(it->is_goto() && it->pc->condition().is_true())
+  if(
+    it->is_goto() && it->pc->condition().is_constant() &&
+    to_constant_expr(it->pc->condition()).is_true())
+  {
     return true;
+  }
 
   const source_locationt &source_location = it->pc->source_location();
 
@@ -546,7 +550,8 @@ void graphml_witnesst::operator()(const symex_target_equationt &equation)
     if(
       it->hidden ||
       (!it->is_assignment() && !it->is_goto() && !it->is_assert()) ||
-      (it->is_goto() && it->source.pc->condition().is_true()) ||
+      (it->is_goto() && it->source.pc->condition().is_constant() &&
+       to_constant_expr(it->source.pc->condition()).is_true()) ||
       source_location.is_nil() || source_location.is_built_in() ||
       source_location.get_line().empty())
     {

--- a/src/goto-programs/interpreter_evaluate.cpp
+++ b/src/goto-programs/interpreter_evaluate.cpp
@@ -382,7 +382,7 @@ interpretert::mp_vectort interpretert::evaluate(const exprt &expr)
     }
     else if(expr.is_boolean())
     {
-      return {expr.is_true()};
+      return {to_constant_expr(expr).is_true()};
     }
     else if(expr.type().id()==ID_string)
     {

--- a/src/goto-programs/json_expr.cpp
+++ b/src/goto-programs/json_expr.cpp
@@ -288,8 +288,9 @@ json_objectt json(const exprt &expr, const namespacet &ns, const irep_idt &mode)
     else if(type.id() == ID_bool)
     {
       result["name"] = json_stringt("boolean");
-      result["binary"] = json_stringt(expr.is_true() ? "1" : "0");
-      result["data"] = jsont::json_boolean(expr.is_true());
+      result["binary"] =
+        json_stringt(to_constant_expr(expr).is_true() ? "1" : "0");
+      result["data"] = jsont::json_boolean(to_constant_expr(expr).is_true());
     }
     else if(type.id() == ID_string)
     {

--- a/src/goto-programs/pointer_arithmetic.cpp
+++ b/src/goto-programs/pointer_arithmetic.cpp
@@ -46,7 +46,9 @@ void pointer_arithmetict::read(const exprt &src)
     {
       const index_exprt &index_expr = to_index_expr(address_of_src.op());
 
-      if(index_expr.index().is_zero())
+      if(
+        index_expr.index().is_constant() &&
+        to_constant_expr(index_expr.index()).is_zero())
         make_pointer(address_of_src);
       else
       {

--- a/src/goto-programs/remove_const_function_pointers.cpp
+++ b/src/goto-programs/remove_const_function_pointers.cpp
@@ -170,7 +170,7 @@ bool remove_const_function_pointerst::try_resolve_function_call(
   }
   else if(simplified_expr.is_constant())
   {
-    if(simplified_expr.is_zero())
+    if(to_constant_expr(simplified_expr).is_zero())
     {
       // We have the null pointer - no need to throw everything away
       // but we don't add any functions either

--- a/src/goto-programs/remove_skip.cpp
+++ b/src/goto-programs/remove_skip.cpp
@@ -37,8 +37,12 @@ bool is_skip(
 
   if(it->is_goto())
   {
-    if(it->condition().is_false())
+    if(
+      it->condition().is_constant() &&
+      to_constant_expr(it->condition()).is_false())
+    {
       return true;
+    }
 
     goto_programt::const_targett next_it = it;
     next_it++;
@@ -48,7 +52,9 @@ bool is_skip(
 
     // A branch to the next instruction is a skip
     // We also require the guard to be 'true'
-    return it->condition().is_true() && it->get_target() == next_it;
+    return it->condition().is_constant() &&
+           to_constant_expr(it->condition()).is_true() &&
+           it->get_target() == next_it;
   }
 
   if(it->is_other())

--- a/src/goto-programs/rewrite_union.cpp
+++ b/src/goto-programs/rewrite_union.cpp
@@ -146,7 +146,9 @@ static bool restore_union_rec(exprt &expr, const namespacet &ns)
 
       for(const auto &comp : union_type.components())
       {
-        if(be.offset().is_zero() && be.type() == comp.type())
+        if(
+          be.offset().is_constant() &&
+          to_constant_expr(be.offset()).is_zero() && be.type() == comp.type())
         {
           expr = member_exprt{be.op(), comp.get_name(), be.type()};
           return false;

--- a/src/goto-programs/string_abstraction.cpp
+++ b/src/goto-programs/string_abstraction.cpp
@@ -910,7 +910,7 @@ bool string_abstractiont::build_array(const array_exprt &object,
 
   exprt::operandst::const_iterator it=object.operands().begin();
   for(mp_integer i = 0; i < *size; ++i, ++it)
-    if(it->is_zero())
+    if(it->is_constant() && to_constant_expr(*it).is_zero())
       return build_symbol_constant(i, *size, dest);
 
   return true;
@@ -1194,7 +1194,7 @@ goto_programt::targett string_abstractiont::abstract_char_assign(
     rhsp = &(to_typecast_expr(*rhsp).op());
 
   // we only care if the constant zero is assigned
-  if(!rhsp->is_zero())
+  if(!rhsp->is_constant() || !to_constant_expr(*rhsp).is_zero())
     return target;
 
   // index into a character array

--- a/src/goto-programs/vcd_goto_trace.cpp
+++ b/src/goto-programs/vcd_goto_trace.cpp
@@ -131,15 +131,25 @@ void output_vcd(
         // booleans are special in VCD
         if(type.id() == ID_bool)
         {
-          if(step.full_lhs_value.is_true())
+          if(
+            step.full_lhs_value.is_constant() &&
+            to_constant_expr(step.full_lhs_value).is_true())
+          {
             out << "1"
                 << "V" << number << "\n";
-          else if(step.full_lhs_value.is_false())
+          }
+          else if(
+            step.full_lhs_value.is_constant() &&
+            to_constant_expr(step.full_lhs_value).is_false())
+          {
             out << "0"
                 << "V" << number << "\n";
+          }
           else
+          {
             out << "x"
                 << "V" << number << "\n";
+          }
         }
         else
         {

--- a/src/goto-symex/goto_symex_state.cpp
+++ b/src/goto-symex/goto_symex_state.cpp
@@ -344,10 +344,18 @@ exprt goto_symex_statet::l2_rename_rvalues(exprt lvalue, const namespacet &ns)
     // The condition is an rvalue:
     auto &if_lvalue = to_if_expr(lvalue);
     if_lvalue.cond() = rename(if_lvalue.cond(), ns);
-    if(!if_lvalue.cond().is_false())
+    if(
+      !if_lvalue.cond().is_constant() ||
+      !to_constant_expr(if_lvalue.cond()).is_false())
+    {
       if_lvalue.true_case() = l2_rename_rvalues(if_lvalue.true_case(), ns);
-    if(!if_lvalue.cond().is_true())
+    }
+    if(
+      !if_lvalue.cond().is_constant() ||
+      !to_constant_expr(if_lvalue.cond()).is_true())
+    {
       if_lvalue.false_case() = l2_rename_rvalues(if_lvalue.false_case(), ns);
+    }
   }
   else if(lvalue.id() == ID_complex_real)
   {
@@ -441,8 +449,12 @@ bool goto_symex_statet::l2_thread_read_encoding(
     }
 
     guardt cond = read_guard;
-    if(!no_write.op().is_false())
+    if(
+      !no_write.op().is_constant() ||
+      !to_constant_expr(no_write.op()).is_false())
+    {
       cond |= guardt{no_write.op(), guard_manager};
+    }
 
     // It is safe to perform constant propagation in case we have read or
     // written this object within the atomic section. We must actually do this,
@@ -485,8 +497,12 @@ bool goto_symex_statet::l2_thread_read_encoding(
     expr = std::move(ssa_l2);
 
     a_s_read.second.push_back(guard);
-    if(!no_write.op().is_false())
+    if(
+      !no_write.op().is_constant() ||
+      !to_constant_expr(no_write.op()).is_false())
+    {
       a_s_read.second.back().add(no_write);
+    }
 
     return true;
   }

--- a/src/goto-symex/memory_model_sc.cpp
+++ b/src/goto-symex/memory_model_sc.cpp
@@ -302,7 +302,9 @@ void memory_model_sct::from_read(symex_target_equationt &equation)
           exprt cond;
           cond.make_nil();
 
-          if(c_it->first.second==*w_prime && !ws1.is_false())
+          if(
+            c_it->first.second == *w_prime &&
+            (!ws1.is_constant() || !to_constant_expr(ws1).is_false()))
           {
             exprt fr=before(r, *w);
 
@@ -314,7 +316,9 @@ void memory_model_sct::from_read(symex_target_equationt &equation)
                 and_exprt(r->guard, (*w)->guard, ws1, rf),
                 fr);
           }
-          else if(c_it->first.second==*w && !ws2.is_false())
+          else if(
+            c_it->first.second == *w &&
+            (!ws2.is_constant() || !to_constant_expr(ws2).is_false()))
           {
             exprt fr=before(r, *w_prime);
 

--- a/src/goto-symex/memory_model_tso.cpp
+++ b/src/goto-symex/memory_model_tso.cpp
@@ -148,7 +148,7 @@ void memory_model_tsot::program_order(
           simplify(cond, ns);
         }
 
-        if(!cond.is_false())
+        if(!cond.is_constant() || !to_constant_expr(cond).is_false())
         {
           if(ordering.is_nil())
             ordering=partial_order_concurrencyt::before(

--- a/src/goto-symex/partial_order_concurrency.cpp
+++ b/src/goto-symex/partial_order_concurrency.cpp
@@ -51,9 +51,9 @@ void partial_order_concurrencyt::add_init_writes(
     if(init_done.find(a)!=init_done.end())
       continue;
 
-    if(spawn_seen ||
-       e_it->is_shared_read() ||
-       !e_it->guard.is_true())
+    if(
+      spawn_seen || e_it->is_shared_read() || !e_it->guard.is_constant() ||
+      !to_constant_expr(e_it->guard).is_true())
     {
       init_steps.emplace_back(
         e_it->source, goto_trace_stept::typet::SHARED_WRITE);

--- a/src/goto-symex/postcondition.cpp
+++ b/src/goto-symex/postcondition.cpp
@@ -62,7 +62,7 @@ void postcondition(
   {
     postconditiont postcondition(ns, value_set, *it, s);
     postcondition.compute(dest);
-    if(dest.is_false())
+    if(dest.is_constant() && to_constant_expr(dest).is_false())
       return;
   }
 }
@@ -137,7 +137,7 @@ void postconditiont::strengthen(exprt &dest)
     exprt equality =
       get_original_name(equal_exprt{SSA_step.ssa_lhs, SSA_step.ssa_rhs});
 
-    if(dest.is_true())
+    if(dest.is_constant() && to_constant_expr(dest).is_true())
       dest.swap(equality);
     else
       dest=and_exprt(dest, equality);

--- a/src/goto-symex/precondition.cpp
+++ b/src/goto-symex/precondition.cpp
@@ -70,7 +70,7 @@ void precondition(
   {
     preconditiont precondition(ns, value_sets, target, *it, s, message_handler);
     precondition.compute(dest);
-    if(dest.is_false())
+    if(dest.is_constant() && to_constant_expr(dest).is_false())
       return;
   }
 }

--- a/src/goto-symex/shadow_memory.cpp
+++ b/src/goto-symex/shadow_memory.cpp
@@ -39,7 +39,8 @@ void shadow_memoryt::initialize_shadow_memory(
 
     if(
       field_pair.second.id() == ID_typecast &&
-      to_typecast_expr(field_pair.second).op().is_zero())
+      to_typecast_expr(field_pair.second).op().is_constant() &&
+      to_constant_expr(to_typecast_expr(field_pair.second).op()).is_zero())
     {
       const auto zero_value =
         zero_initializer(type, expr.source_location(), ns);

--- a/src/goto-symex/shadow_memory_util.cpp
+++ b/src/goto-symex/shadow_memory_util.cpp
@@ -691,7 +691,8 @@ static void clean_string_constant(exprt &expr)
 {
   const auto *index_expr = expr_try_dynamic_cast<index_exprt>(expr);
   if(
-    index_expr && index_expr->index().is_zero() &&
+    index_expr && index_expr->index().is_constant() &&
+    to_constant_expr(index_expr->index()).is_zero() &&
     can_cast_expr<string_constantt>(index_expr->array()))
   {
     expr = index_expr->array();
@@ -929,19 +930,21 @@ std::vector<std::pair<exprt, exprt>> get_shadow_dereference_candidates(
     const exprt base_cond = get_matched_base_cond(
       shadowed_address.address, matched_base_address, ns, log);
     shadow_memory_log_text_and_expr(ns, log, "base_cond", base_cond);
-    if(base_cond.is_false())
+    if(base_cond.is_constant() && to_constant_expr(base_cond).is_false())
     {
       continue;
     }
 
     const exprt expr_cond =
       get_matched_expr_cond(dereference.pointer, expr, ns, log);
-    if(expr_cond.is_false())
+    if(expr_cond.is_constant() && to_constant_expr(expr_cond).is_false())
     {
       continue;
     }
 
-    if(base_cond.is_true() && expr_cond.is_true())
+    if(
+      base_cond.is_constant() && to_constant_expr(base_cond).is_true() &&
+      expr_cond.is_constant() && to_constant_expr(expr_cond).is_true())
     {
 #ifdef DEBUG_SHADOW_MEMORY
       log.debug() << "exact match" << messaget::eom;
@@ -952,7 +955,7 @@ std::vector<std::pair<exprt, exprt>> get_shadow_dereference_candidates(
       break;
     }
 
-    if(base_cond.is_true())
+    if(base_cond.is_constant() && to_constant_expr(base_cond).is_true())
     {
       // No point looking at further shadow addresses
       // as only one of them can match.
@@ -1096,19 +1099,21 @@ get_shadow_memory_for_matched_object(
     const exprt base_cond = get_matched_base_cond(
       shadowed_address.address, matched_base_address, ns, log);
     shadow_memory_log_text_and_expr(ns, log, "base_cond", base_cond);
-    if(base_cond.is_false())
+    if(base_cond.is_constant() && to_constant_expr(base_cond).is_false())
     {
       continue;
     }
 
     const exprt expr_cond =
       get_matched_expr_cond(dereference.pointer, expr, ns, log);
-    if(expr_cond.is_false())
+    if(expr_cond.is_constant() && to_constant_expr(expr_cond).is_false())
     {
       continue;
     }
 
-    if(base_cond.is_true() && expr_cond.is_true())
+    if(
+      base_cond.is_constant() && to_constant_expr(base_cond).is_true() &&
+      expr_cond.is_constant() && to_constant_expr(expr_cond).is_true())
     {
       log_shadow_memory_message(log, "exact match");
 
@@ -1118,7 +1123,7 @@ get_shadow_memory_for_matched_object(
       break;
     }
 
-    if(base_cond.is_true())
+    if(base_cond.is_constant() && to_constant_expr(base_cond).is_true())
     {
       // No point looking at further shadow addresses
       // as only one of them can match.

--- a/src/goto-symex/show_program.cpp
+++ b/src/goto-symex/show_program.cpp
@@ -47,7 +47,7 @@ static void show_step(
     std::cout << annotation << '(' << string_value << ')';
   std::cout << '\n';
 
-  if(!step.guard.is_true())
+  if(!step.guard.is_constant() || !to_constant_expr(step.guard).is_true())
   {
     const std::string guard_string = from_expr(ns, function_id, step.guard);
     std::cout << std::string(std::to_string(count).size() + 3, ' ');
@@ -76,7 +76,8 @@ void show_program(const namespacet &ns, const symex_target_equationt &equation)
       show_step(ns, step, "ASSUME", count);
     else if(step.is_constraint())
     {
-      PRECONDITION(step.guard.is_true());
+      PRECONDITION(
+        step.guard.is_constant() && to_constant_expr(step.guard).is_true());
       show_step(ns, step, "CONSTRAINT", count);
     }
     else if(step.is_shared_read())

--- a/src/goto-symex/solver_hardness.cpp
+++ b/src/goto-symex/solver_hardness.cpp
@@ -246,7 +246,9 @@ solver_hardnesst::goto_instruction2string(goto_programt::const_targett pc)
 
   case GOTO:
   case INCOMPLETE_GOTO:
-    if(!instruction.condition().is_true())
+    if(
+      !instruction.condition().is_constant() ||
+      !to_constant_expr(instruction.condition()).is_true())
     {
       out << "IF " << format(instruction.condition()) << " THEN ";
     }

--- a/src/goto-symex/symex_assign.cpp
+++ b/src/goto-symex/symex_assign.cpp
@@ -47,7 +47,10 @@ static bool is_string_constant_initialization(const exprt &rhs)
       const auto &index =
         expr_try_dynamic_cast<index_exprt>(address_of->object()))
     {
-      if(index->array().id() == ID_string_constant && index->index().is_zero())
+      if(
+        index->array().id() == ID_string_constant &&
+        index->index().is_constant() &&
+        to_constant_expr(index->index()).is_zero())
       {
         return true;
       }

--- a/src/goto-symex/symex_builtin_functions.cpp
+++ b/src/goto-symex/symex_builtin_functions.cpp
@@ -173,7 +173,9 @@ void goto_symext::symex_allocate(
   INVARIANT(
     zero_init.is_constant(), "allocate expects constant as second argument");
 
-  if(!zero_init.is_zero() && !zero_init.is_false())
+  if(
+    !to_constant_expr(zero_init).is_zero() &&
+    !to_constant_expr(zero_init).is_false())
   {
     const auto zero_value =
       zero_initializer(*object_type, code.source_location(), ns);
@@ -318,7 +320,8 @@ static irep_idt get_string_argument_rec(const exprt &src)
 
       if(
         index_expr.array().id() == ID_string_constant &&
-        index_expr.index().is_zero())
+        index_expr.index().is_constant() &&
+        to_constant_expr(index_expr.index()).is_zero())
       {
         const exprt &fmt_str = index_expr.array();
         return to_string_constant(fmt_str).value();
@@ -363,8 +366,12 @@ static std::optional<exprt> get_va_args(const exprt::operandst &operands)
     return {};
 
   const index_exprt &index_expr = to_index_expr(object);
-  if(!index_expr.index().is_zero())
+  if(
+    !index_expr.index().is_constant() ||
+    !to_constant_expr(index_expr.index()).is_zero())
+  {
     return {};
+  }
   else
     return index_expr.array();
 }

--- a/src/goto-symex/symex_clean_expr.cpp
+++ b/src/goto-symex/symex_clean_expr.cpp
@@ -79,7 +79,7 @@ static void process_array_expr(exprt &expr, const namespacet &ns)
     if(expr.type().id() == ID_empty)
       return;
 
-    if(!ode.offset().is_zero())
+    if(!ode.offset().is_constant() || !to_constant_expr(ode.offset()).is_zero())
     {
       if(expr.type().id() != ID_array)
       {

--- a/src/goto-symex/symex_dereference.cpp
+++ b/src/goto-symex/symex_dereference.cpp
@@ -363,7 +363,9 @@ void goto_symext::dereference_rec(
   }
   else if(
     expr.id() == ID_index && to_index_expr(expr).array().id() == ID_member &&
-    to_array_type(to_index_expr(expr).array().type()).size().is_zero())
+    to_array_type(to_index_expr(expr).array().type()).size().is_constant() &&
+    to_constant_expr(to_array_type(to_index_expr(expr).array().type()).size())
+      .is_zero())
   {
     // This is an expression of the form x.a[i],
     // where a is a zero-sized array. This gets

--- a/src/goto-symex/symex_goto.cpp
+++ b/src/goto-symex/symex_goto.cpp
@@ -80,7 +80,7 @@ void goto_symext::symex_goto(statet &state)
   }
   new_guard = renamed_guard.get();
 
-  if(new_guard.is_false())
+  if(new_guard.is_constant() && to_constant_expr(new_guard).is_false())
   {
     target.location(state.guard.as_expr(), state.source);
 
@@ -113,7 +113,8 @@ void goto_symext::symex_goto(statet &state)
        // while(cond);
        (instruction.incoming_edges.size() == 1 &&
         *instruction.incoming_edges.begin() == goto_target &&
-        goto_target->is_goto() && new_guard.is_true())))
+        goto_target->is_goto() && new_guard.is_constant() &&
+        to_constant_expr(new_guard).is_true())))
     {
       // generate assume(false) or a suitable negation if this
       // instruction is a conditional goto
@@ -152,7 +153,7 @@ void goto_symext::symex_goto(statet &state)
       return;
     }
 
-    if(new_guard.is_true())
+    if(new_guard.is_constant() && to_constant_expr(new_guard).is_true())
     {
       // we continue executing the loop
       if(check_break(loop_id, unwind))
@@ -166,7 +167,8 @@ void goto_symext::symex_goto(statet &state)
 
   // No point executing both branches of an unconditional goto.
   if(
-    new_guard.is_true() && // We have an unconditional goto, AND
+    new_guard.is_constant() && to_constant_expr(new_guard).is_true() &&
+    // We have an unconditional goto, AND
     // either there are no reachable blocks between us and the target in the
     // surrounding scope (because state.guard == true implies there is no path
     // around this GOTO instruction)
@@ -193,7 +195,7 @@ void goto_symext::symex_goto(statet &state)
     state_pc++;
 
     // skip dead instructions
-    if(new_guard.is_true())
+    if(new_guard.is_constant() && to_constant_expr(new_guard).is_true())
       while(state_pc!=goto_target && !state_pc->is_target())
         ++state_pc;
 
@@ -280,7 +282,7 @@ void goto_symext::symex_goto(statet &state)
   // On an unconditional GOTO we don't need our state, as it will be overwritten
   // by merge_goto. Therefore we move it onto goto_state_list instead of copying
   // as usual.
-  if(new_guard.is_true())
+  if(new_guard.is_constant() && to_constant_expr(new_guard).is_true())
   {
     // The move here only moves goto_statet, the base class of goto_symex_statet
     // and not the entire thing.
@@ -410,7 +412,9 @@ void goto_symext::symex_unreachable_goto(statet &state)
     goto_state_list.emplace_back(state.source, std::move(new_state));
   };
 
-  if(instruction.condition().is_true())
+  if(
+    instruction.condition().is_constant() &&
+    to_constant_expr(instruction.condition()).is_true())
   {
     if(instruction.is_backwards_goto())
     {

--- a/src/goto-symex/symex_main.cpp
+++ b/src/goto-symex/symex_main.cpp
@@ -186,7 +186,7 @@ void goto_symext::vcc(
   state.total_vccs++;
   path_segment_vccs++;
 
-  if(condition.is_true())
+  if(condition.is_constant() && to_constant_expr(condition).is_true())
     return;
 
   const exprt guarded_condition = state.guard.guard_expr(condition);
@@ -218,10 +218,10 @@ void goto_symext::symex_assume(statet &state, const exprt &cond)
 
 void goto_symext::symex_assume_l2(statet &state, const exprt &cond)
 {
-  if(cond.is_true())
+  if(cond.is_constant() && to_constant_expr(cond).is_true())
     return;
 
-  if(cond.is_false())
+  if(cond.is_constant() && to_constant_expr(cond).is_false())
     state.reachable = false;
 
   // we are willing to re-write some quantified expressions
@@ -856,11 +856,15 @@ void goto_symext::try_filter_value_sets(
 
     do_simplify(modified_condition, state.value_set);
 
-    if(jump_taken_value_set && modified_condition.is_false())
+    if(
+      jump_taken_value_set && modified_condition.is_constant() &&
+      to_constant_expr(modified_condition).is_false())
     {
       erase_from_jump_taken_value_set.insert(value_set_element);
     }
-    else if(jump_not_taken_value_set && modified_condition.is_true())
+    else if(
+      jump_not_taken_value_set && modified_condition.is_constant() &&
+      to_constant_expr(modified_condition).is_true())
     {
       erase_from_jump_not_taken_value_set.insert(value_set_element);
     }

--- a/src/pointer-analysis/value_set.cpp
+++ b/src/pointer-analysis/value_set.cpp
@@ -673,7 +673,7 @@ void value_sett::get_value_set_rec(
     {
       // integer-to-something
 
-      if(op.is_zero())
+      if(op.is_constant() && to_constant_expr(op).is_zero())
       {
         insert(
           dest,

--- a/src/pointer-analysis/value_set_dereference.cpp
+++ b/src/pointer-analysis/value_set_dereference.cpp
@@ -487,7 +487,7 @@ value_set_dereferencet::valuet value_set_dereferencet::build_reference_to(
 
   if(root_object.id() == ID_null_object)
   {
-    if(!o.offset().is_zero())
+    if(!o.offset().is_constant() || !to_constant_expr(o.offset()).is_zero())
       return {};
 
     valuet result;
@@ -573,7 +573,7 @@ value_set_dereferencet::valuet value_set_dereferencet::build_reference_to(
     // something generic -- really has to be a symbol
     address_of_exprt object_pointer(object);
 
-    if(o.offset().is_zero())
+    if(o.offset().is_constant() && to_constant_expr(o.offset()).is_zero())
     {
       result.pointer_guard = equal_exprt(
         typecast_exprt::conditional_cast(pointer_expr, object_pointer.type()),
@@ -589,7 +589,7 @@ value_set_dereferencet::valuet value_set_dereferencet::build_reference_to(
 
     if(
       dereference_type_compare(object_type, dereference_type, ns) &&
-      o.offset().is_zero())
+      o.offset().is_constant() && to_constant_expr(o.offset()).is_zero())
     {
       // The simplest case: types match, and offset is zero!
       // This is great, we are almost done.

--- a/src/pointer-analysis/value_set_fi.cpp
+++ b/src/pointer-analysis/value_set_fi.cpp
@@ -923,7 +923,7 @@ void value_set_fit::get_reference_set_sharing_rec(
         offsett o = object_entry.second;
         const auto i = numeric_cast<mp_integer>(offset);
 
-        if(offset.is_zero())
+        if(i.has_value() && i == 0)
         {
         }
         else if(i.has_value() && offset_is_zero(o))

--- a/src/solvers/flattening/boolbv_quantifier.cpp
+++ b/src/solvers/flattening/boolbv_quantifier.cpp
@@ -176,7 +176,9 @@ static std::optional<exprt> eager_quantifier_instantiation(
   const exprt where_simplified = simplify_expr(expr.where(), ns);
 
   if(
-    (where_simplified.is_true() || where_simplified.is_false()) &&
+    where_simplified.is_constant() &&
+    (to_constant_expr(where_simplified).is_true() ||
+     to_constant_expr(where_simplified).is_false()) &&
     (var_expr.type().id() == ID_integer ||
      var_expr.type().id() == ID_rational || var_expr.type().id() == ID_real ||
      var_expr.type().id() == ID_bool ||

--- a/src/solvers/flattening/pointer_logic.cpp
+++ b/src/solvers/flattening/pointer_logic.cpp
@@ -129,7 +129,7 @@ exprt pointer_logict::pointer_expr(
 
   const byte_extract_exprt &be = to_byte_extract_expr(deep_object);
   const address_of_exprt base(be.op());
-  if(be.offset().is_zero())
+  if(be.offset().is_constant() && to_constant_expr(be.offset()).is_zero())
     return typecast_exprt::conditional_cast(base, type);
 
   const auto object_size = pointer_offset_size(be.op().type(), ns);

--- a/src/solvers/prop/bdd_expr.cpp
+++ b/src/solvers/prop/bdd_expr.cpp
@@ -21,7 +21,10 @@ bddt bdd_exprt::from_expr_rec(const exprt &expr)
   PRECONDITION(expr.is_boolean());
 
   if(expr.is_constant())
-    return expr.is_false() ? bdd_mgr.bdd_false() : bdd_mgr.bdd_true();
+  {
+    return to_constant_expr(expr).is_false() ? bdd_mgr.bdd_false()
+                                             : bdd_mgr.bdd_true();
+  }
   else if(expr.id()==ID_not)
     return from_expr_rec(to_not_expr(expr).op()).bdd_not();
   else if(expr.id()==ID_and ||

--- a/src/solvers/prop/cover_goals.cpp
+++ b/src/solvers/prop/cover_goals.cpp
@@ -26,9 +26,12 @@ void cover_goalst::mark()
     o->satisfying_assignment();
 
   for(auto &g : goals)
-    if(
-      g.status == goalt::statust::UNKNOWN &&
-      decision_procedure.get(g.condition).is_true())
+  {
+    if(g.status != goalt::statust::UNKNOWN)
+      continue;
+
+    exprt v = decision_procedure.get(g.condition);
+    if(v.is_constant() && to_constant_expr(v).is_true())
     {
       g.status=goalt::statust::COVERED;
       _number_covered++;
@@ -37,6 +40,7 @@ void cover_goalst::mark()
       for(const auto &o : observers)
         o->goal_covered(g);
     }
+  }
 }
 
 /// Build clause
@@ -47,8 +51,14 @@ void cover_goalst::constraint()
   // cover at least one unknown goal
 
   for(const auto &g : goals)
-    if(g.status == goalt::statust::UNKNOWN && !g.condition.is_false())
+  {
+    if(
+      g.status == goalt::statust::UNKNOWN &&
+      (!g.condition.is_constant() || !to_constant_expr(g.condition).is_false()))
+    {
       disjuncts.push_back(g.condition);
+    }
+  }
 
   // this is 'false' if there are no disjuncts
   decision_procedure.set_to_true(disjunction(disjuncts));

--- a/src/solvers/prop/prop_conv_solver.cpp
+++ b/src/solvers/prop/prop_conv_solver.cpp
@@ -78,11 +78,11 @@ std::optional<bool> prop_conv_solvert::get_bool(const exprt &expr) const
 {
   // trivial cases
 
-  if(expr.is_true())
+  if(expr.is_constant() && to_constant_expr(expr).is_true())
   {
     return true;
   }
-  else if(expr.is_false())
+  else if(expr.is_constant() && to_constant_expr(expr).is_false())
   {
     return false;
   }
@@ -195,12 +195,12 @@ literalt prop_conv_solvert::convert_bool(const exprt &expr)
 
   if(expr.is_constant())
   {
-    if(expr.is_true())
+    if(to_constant_expr(expr).is_true())
       return const_literal(true);
     else
     {
       INVARIANT(
-        expr.is_false(),
+        to_constant_expr(expr).is_false(),
         "constant expression of type bool should be either true or false");
       return const_literal(false);
     }

--- a/src/solvers/smt2/smt2_conv.cpp
+++ b/src/solvers/smt2/smt2_conv.cpp
@@ -273,7 +273,7 @@ static bool is_zero_width(const typet &type, const namespacet &ns)
   }
   else if(auto array_type = type_try_dynamic_cast<array_typet>(type))
   {
-    // we ignore array_type->size().is_zero() for now as there may be
+    // we ignore array_type->size() being zero for now as there may be
     // out-of-bounds accesses that we need to model
     return is_zero_width(array_type->element_type(), ns);
   }
@@ -364,9 +364,9 @@ exprt smt2_convt::get(const exprt &expr) const
   else if(expr.id() == ID_not)
   {
     auto op = get(to_not_expr(expr).op());
-    if(op.is_true())
+    if(op.is_constant() && to_constant_expr(op).is_true())
       return false_exprt();
-    else if(op.is_false())
+    else if(op.is_constant() && to_constant_expr(op).is_false())
       return true_exprt();
   }
   else if(
@@ -816,7 +816,7 @@ void smt2_convt::convert_address_of_rec(
     const exprt &array = index_expr.array();
     const exprt &index = index_expr.index();
 
-    if(index.is_zero())
+    if(index.is_constant() && to_constant_expr(index).is_zero())
     {
       if(array.type().id()==ID_pointer)
         convert_expr(array);
@@ -904,9 +904,9 @@ literalt smt2_convt::convert(const exprt &expr)
 
   // Three cases where no new handle is needed.
 
-  if(expr.is_true())
+  if(expr.is_constant() && to_constant_expr(expr).is_true())
     return const_literal(true);
-  else if(expr.is_false())
+  else if(expr.is_constant() && to_constant_expr(expr).is_false())
     return const_literal(false);
   else if(expr.id()==ID_literal)
     return to_literal_expr(expr).get_literal();

--- a/src/solvers/smt2/smt2_format.cpp
+++ b/src/solvers/smt2/smt2_format.cpp
@@ -60,9 +60,9 @@ std::ostream &smt2_format_rec(std::ostream &out, const exprt &expr)
     }
     else if(expr_type.id() == ID_bool)
     {
-      if(expr.is_true())
+      if(to_constant_expr(expr).is_true())
         out << "true";
-      else if(expr.is_false())
+      else if(to_constant_expr(expr).is_false())
         out << "false";
       else
         DATA_INVARIANT(false, "unknown Boolean constant");

--- a/src/solvers/strings/string_builtin_function.cpp
+++ b/src/solvers/strings/string_builtin_function.cpp
@@ -31,7 +31,7 @@ std::optional<std::vector<mp_integer>> eval_string(
     const exprt cond = get_value(ite.cond());
     if(!cond.is_constant())
       return {};
-    return cond.is_true()
+    return to_constant_expr(cond).is_true()
              ? eval_string(to_array_string_expr(ite.true_case()), get_value)
              : eval_string(to_array_string_expr(ite.false_case()), get_value);
   }

--- a/src/solvers/strings/string_format_builtin_function.cpp
+++ b/src/solvers/strings/string_format_builtin_function.cpp
@@ -596,8 +596,9 @@ string_constraintst string_format_builtin_functiont::constraints(
 
   auto result_constraint_pair = add_axioms_for_format(
     generator, result, format_string.value(), inputs, message_handler);
+  auto simp_expr = simplify_expr(result_constraint_pair.first, generator.ns);
   INVARIANT(
-    simplify_expr(result_constraint_pair.first, generator.ns).is_zero(),
+    simp_expr.is_constant() && to_constant_expr(simp_expr).is_zero(),
     "add_axioms_for_format should return 0, meaning that formatting was"
     "successful");
   result_constraint_pair.second.existential.push_back(

--- a/src/solvers/strings/string_refinement.cpp
+++ b/src/solvers/strings/string_refinement.cpp
@@ -920,7 +920,7 @@ void string_refinementt::add_lemma(
     simplify(simple_lemma, ns);
   }
 
-  if(simple_lemma.is_true())
+  if(simple_lemma.is_constant() && to_constant_expr(simple_lemma).is_true())
   {
 #if 0
     log.debug() << "string_refinementt::add_lemma : tautology" << messaget::eom;
@@ -1843,9 +1843,9 @@ exprt string_refinementt::get(const exprt &expr) const
     {
       const auto &if_expr = expr_dynamic_cast<if_exprt>(current.get());
       const exprt cond = get(if_expr.cond());
-      if(cond.is_true())
+      if(cond.is_constant() && to_constant_expr(cond).is_true())
         current = std::cref(if_expr.true_case());
-      else if(cond.is_false())
+      else if(cond.is_constant() && to_constant_expr(cond).is_false())
         current = std::cref(if_expr.false_case());
       else
         UNREACHABLE;
@@ -2021,7 +2021,7 @@ static bool is_valid_string_constraint(
       const exprt i = pair.second[j];
       const equal_exprt equals(rep, i);
       const exprt result = simplify_expr(equals, ns);
-      if(result.is_false())
+      if(result.is_constant() && to_constant_expr(result).is_false())
       {
         stream << "Indices not equal: " << to_string(constraint)
                << ", str: " << format(pair.first) << messaget::eom;

--- a/src/util/expr.cpp
+++ b/src/util/expr.cpp
@@ -26,14 +26,14 @@ Author: Daniel Kroening, kroening@kroening.com
 /// \return True if is a Boolean constant representing `true`, false otherwise.
 bool exprt::is_true() const
 {
-  return is_constant() && is_boolean() && get(ID_value) != ID_false;
+  return is_constant() && to_constant_expr(*this).is_true();
 }
 
 /// Return whether the expression is a constant representing `false`.
 /// \return True if is a Boolean constant representing `false`, false otherwise.
 bool exprt::is_false() const
 {
-  return is_constant() && is_boolean() && get(ID_value) == ID_false;
+  return is_constant() && to_constant_expr(*this).is_false();
 }
 
 /// Return whether the expression is a constant representing 0.
@@ -47,44 +47,9 @@ bool exprt::is_false() const
 bool exprt::is_zero() const
 {
   if(is_constant())
-  {
-    const constant_exprt &constant=to_constant_expr(*this);
-    const irep_idt &type_id=type().id_string();
-
-    if(type_id==ID_integer || type_id==ID_natural)
-    {
-      return constant.value_is_zero_string();
-    }
-    else if(type_id==ID_rational)
-    {
-      rationalt rat_value;
-      if(to_rational(*this, rat_value))
-        CHECK_RETURN(false);
-      return rat_value.is_zero();
-    }
-    else if(
-      type_id == ID_unsignedbv || type_id == ID_signedbv ||
-      type_id == ID_c_bool || type_id == ID_c_bit_field)
-    {
-      return constant.value_is_zero_string();
-    }
-    else if(type_id==ID_fixedbv)
-    {
-      if(fixedbvt(constant)==0)
-        return true;
-    }
-    else if(type_id==ID_floatbv)
-    {
-      if(ieee_float_valuet(constant) == 0)
-        return true;
-    }
-    else if(type_id==ID_pointer)
-    {
-      return is_null_pointer(constant);
-    }
-  }
-
-  return false;
+    return to_constant_expr(*this).is_zero();
+  else
+    return false;
 }
 
 /// Return whether the expression is a constant representing 1.
@@ -96,47 +61,9 @@ bool exprt::is_zero() const
 bool exprt::is_one() const
 {
   if(is_constant())
-  {
-    const auto &constant_expr = to_constant_expr(*this);
-    const irep_idt &type_id = type().id();
-
-    if(type_id==ID_integer || type_id==ID_natural)
-    {
-      mp_integer int_value =
-        string2integer(id2string(constant_expr.get_value()));
-      if(int_value==1)
-        return true;
-    }
-    else if(type_id==ID_rational)
-    {
-      rationalt rat_value;
-      if(to_rational(*this, rat_value))
-        CHECK_RETURN(false);
-      return rat_value.is_one();
-    }
-    else if(
-      type_id == ID_unsignedbv || type_id == ID_signedbv ||
-      type_id == ID_c_bool || type_id == ID_c_bit_field)
-    {
-      const auto width = to_bitvector_type(type()).get_width();
-      mp_integer int_value =
-        bvrep2integer(id2string(constant_expr.get_value()), width, false);
-      if(int_value==1)
-        return true;
-    }
-    else if(type_id==ID_fixedbv)
-    {
-      if(fixedbvt(constant_expr) == 1)
-        return true;
-    }
-    else if(type_id==ID_floatbv)
-    {
-      if(ieee_float_valuet(constant_expr) == 1)
-        return true;
-    }
-  }
-
-  return false;
+    return to_constant_expr(*this).is_one();
+  else
+    return false;
 }
 
 /// Get a \ref source_locationt from the expression or from its operands

--- a/src/util/expr.h
+++ b/src/util/expr.h
@@ -10,6 +10,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #define CPROVER_UTIL_EXPR_H
 
 #include "as_const.h"
+#include "deprecate.h"
 #include "type.h"
 #include "validate_expressions.h"
 #include "validate_types.h"
@@ -214,9 +215,13 @@ public:
     return id() == ID_constant;
   }
 
+  DEPRECATED(SINCE(2025, 6, 25, "use constant_exprt::is_true() instead"))
   bool is_true() const;
+  DEPRECATED(SINCE(2025, 6, 25, "use constant_exprt::is_false() instead"))
   bool is_false() const;
+  DEPRECATED(SINCE(2025, 6, 25, "use constant_exprt::is_zero() instead"))
   bool is_zero() const;
+  DEPRECATED(SINCE(2025, 6, 25, "use constant_exprt::is_one() instead"))
   bool is_one() const;
 
   /// Return whether the expression represents a Boolean.

--- a/src/util/expr_initializer.cpp
+++ b/src/util/expr_initializer.cpp
@@ -66,7 +66,7 @@ std::optional<exprt> expr_initializert::expr_initializer_rec(
     exprt result;
     if(init_expr.id() == ID_nondet)
       result = side_effect_expr_nondett(type, source_location);
-    else if(init_expr.is_zero())
+    else if(init_expr.is_constant() && to_constant_expr(init_expr).is_zero())
       result = from_integer(0, type);
     else
       result = duplicate_per_byte(init_expr, type, ns);
@@ -80,7 +80,7 @@ std::optional<exprt> expr_initializert::expr_initializer_rec(
     exprt result;
     if(init_expr.id() == ID_nondet)
       result = side_effect_expr_nondett(type, source_location);
-    else if(init_expr.is_zero())
+    else if(init_expr.is_constant() && to_constant_expr(init_expr).is_zero())
       result = constant_exprt(ID_0, type);
     else
       result = duplicate_per_byte(init_expr, type, ns);
@@ -94,7 +94,7 @@ std::optional<exprt> expr_initializert::expr_initializer_rec(
     exprt result;
     if(init_expr.id() == ID_nondet)
       result = side_effect_expr_nondett(type, source_location);
-    else if(init_expr.is_zero())
+    else if(init_expr.is_constant() && to_constant_expr(init_expr).is_zero())
     {
       const std::size_t width = to_bitvector_type(type).get_width();
       std::string value(width, '0');
@@ -112,7 +112,7 @@ std::optional<exprt> expr_initializert::expr_initializer_rec(
     exprt result;
     if(init_expr.id() == ID_nondet)
       result = side_effect_expr_nondett(type, source_location);
-    else if(init_expr.is_zero())
+    else if(init_expr.is_constant() && to_constant_expr(init_expr).is_zero())
     {
       auto sub_zero = expr_initializer_rec(
         to_complex_type(type).subtype(), source_location, init_expr);
@@ -287,7 +287,7 @@ std::optional<exprt> expr_initializert::expr_initializer_rec(
     exprt result;
     if(init_expr.id() == ID_nondet)
       result = side_effect_expr_nondett(type, source_location);
-    else if(init_expr.is_zero())
+    else if(init_expr.is_constant() && to_constant_expr(init_expr).is_zero())
       result = constant_exprt(irep_idt(), type);
     else
       result = duplicate_per_byte(init_expr, type, ns);

--- a/src/util/expr_util.cpp
+++ b/src/util/expr_util.cpp
@@ -102,12 +102,17 @@ exprt is_not_zero(
 
 exprt boolean_negate(const exprt &src)
 {
+  PRECONDITION(src.is_boolean());
+
   if(src.id() == ID_not)
     return to_not_expr(src).op();
-  else if(src.is_true())
-    return false_exprt();
-  else if(src.is_false())
-    return true_exprt();
+  else if(auto constant_expr = expr_try_dynamic_cast<constant_exprt>(src))
+  {
+    if(constant_expr->is_true())
+      return false_exprt{};
+    else
+      return true_exprt{};
+  }
   else
     return not_exprt(src);
 }

--- a/src/util/pointer_offset_sum.cpp
+++ b/src/util/pointer_offset_sum.cpp
@@ -19,9 +19,9 @@ exprt pointer_offset_sum(const exprt &a, const exprt &b)
     return a;
   else if(b.id() == ID_unknown)
     return b;
-  else if(a.is_zero())
+  else if(a.is_constant() && to_constant_expr(a).is_zero())
     return b;
-  else if(b.is_zero())
+  else if(b.is_constant() && to_constant_expr(b).is_zero())
     return a;
 
   return plus_exprt(a, typecast_exprt::conditional_cast(b, a.type()));

--- a/src/util/simplify_expr.cpp
+++ b/src/util/simplify_expr.cpp
@@ -858,7 +858,7 @@ simplify_exprt::simplify_typecast(const typecast_exprt &expr)
   if(
     expr_type.id() == ID_pointer && expr.op().is_constant() &&
     (to_constant_expr(expr.op()).get_value() == ID_NULL ||
-     (expr.op().is_zero() && config.ansi_c.NULL_is_zero)))
+     (to_constant_expr(expr.op()).is_zero() && config.ansi_c.NULL_is_zero)))
   {
     exprt tmp = expr.op();
     tmp.type()=expr.type();
@@ -904,7 +904,8 @@ simplify_exprt::simplify_typecast(const typecast_exprt &expr)
 
     if(
       (op_plus_expr.op0().id() == ID_typecast &&
-       to_typecast_expr(op_plus_expr.op0()).op().is_zero()) ||
+       to_typecast_expr(op_plus_expr.op0()).op().is_constant() &&
+       to_constant_expr(to_typecast_expr(op_plus_expr.op0()).op()).is_zero()) ||
       (op_plus_expr.op0().is_constant() &&
        to_constant_expr(op_plus_expr.op0()).is_null_pointer()))
     {
@@ -1072,11 +1073,11 @@ simplify_exprt::simplify_typecast(const typecast_exprt &expr)
          expr_type_id==ID_c_enum ||
          expr_type_id==ID_c_bit_field)
       {
-        if(operand.is_true())
+        if(to_constant_expr(operand).is_true())
         {
           return from_integer(1, expr_type);
         }
-        else if(operand.is_false())
+        else if(to_constant_expr(operand).is_false())
         {
           return from_integer(0, expr_type);
         }
@@ -1086,15 +1087,15 @@ simplify_exprt::simplify_typecast(const typecast_exprt &expr)
         const auto &c_enum_type = ns.follow_tag(to_c_enum_tag_type(expr_type));
         if(!c_enum_type.is_incomplete()) // possibly incomplete
         {
-          unsigned int_value = operand.is_true() ? 1u : 0u;
+          unsigned int_value = to_constant_expr(operand).is_true() ? 1u : 0u;
           exprt tmp=from_integer(int_value, c_enum_type);
           tmp.type()=expr_type; // we maintain the tag type
           return std::move(tmp);
         }
       }
-      else if(expr_type_id==ID_pointer &&
-              operand.is_false() &&
-              config.ansi_c.NULL_is_zero)
+      else if(
+        expr_type_id == ID_pointer && to_constant_expr(operand).is_false() &&
+        config.ansi_c.NULL_is_zero)
       {
         return null_pointer_exprt(to_pointer_type(expr_type));
       }
@@ -2098,8 +2099,9 @@ simplify_exprt::simplify_byte_update(const byte_update_exprt &expr)
 
   // byte update of full object is byte_extract(new value)
   if(
-    offset.is_zero() && val_size.has_value() && *val_size > 0 &&
-    root_size.has_value() && *root_size > 0 && *val_size >= *root_size)
+    offset.is_constant() && to_constant_expr(offset).is_zero() &&
+    val_size.has_value() && *val_size > 0 && root_size.has_value() &&
+    *root_size > 0 && *val_size >= *root_size)
   {
     byte_extract_exprt be(
       matching_byte_extract_id,
@@ -2423,8 +2425,9 @@ simplify_exprt::simplify_overflow_binary(const binary_overflow_exprt &expr)
   // When one operand is zero, an overflow can only occur for a subtraction from
   // zero.
   if(
-    expr.op1().is_zero() ||
-    (expr.op0().is_zero() && !can_cast_expr<minus_overflow_exprt>(expr)))
+    (expr.op1().is_constant() && to_constant_expr(expr.op1()).is_zero()) ||
+    (expr.op0().is_constant() && to_constant_expr(expr.op0()).is_zero() &&
+     !can_cast_expr<minus_overflow_exprt>(expr)))
   {
     return false_exprt{};
   }
@@ -2432,7 +2435,8 @@ simplify_exprt::simplify_overflow_binary(const binary_overflow_exprt &expr)
   // One is neutral element for multiplication
   if(
     can_cast_expr<mult_overflow_exprt>(expr) &&
-    (expr.op0().is_one() || expr.op1().is_one()))
+    ((expr.op0().is_constant() && to_constant_expr(expr.op0()).is_one()) ||
+     (expr.op1().is_constant() && to_constant_expr(expr.op1()).is_one())))
   {
     return false_exprt{};
   }
@@ -2493,7 +2497,7 @@ simplify_exprt::resultt<>
 simplify_exprt::simplify_overflow_unary(const unary_overflow_exprt &expr)
 {
   // zero is a neutral element for all operations supported here
-  if(expr.op().is_zero())
+  if(expr.op().is_constant() && to_constant_expr(expr.op()).is_zero())
     return false_exprt{};
 
   // catch some cases over mathematical types
@@ -2543,7 +2547,7 @@ simplify_exprt::simplify_overflow_result(const overflow_result_exprt &expr)
   if(expr.id() == ID_overflow_result_unary_minus)
   {
     // zero is a neutral element
-    if(expr.op0().is_zero())
+    if(expr.op0().is_constant() && to_constant_expr(expr.op0()).is_zero())
       return struct_exprt{{expr.op0(), false_exprt{}}, expr.type()};
 
     // catch some cases over mathematical types
@@ -2594,7 +2598,7 @@ simplify_exprt::simplify_overflow_result(const overflow_result_exprt &expr)
   {
     // When one operand is zero, an overflow can only occur for a subtraction
     // from zero.
-    if(expr.op0().is_zero())
+    if(expr.op0().is_constant() && to_constant_expr(expr.op0()).is_zero())
     {
       if(
         expr.id() == ID_overflow_result_plus ||
@@ -2608,7 +2612,7 @@ simplify_exprt::simplify_overflow_result(const overflow_result_exprt &expr)
           {from_integer(0, expr.op0().type()), false_exprt{}}, expr.type()};
       }
     }
-    else if(expr.op1().is_zero())
+    else if(expr.op1().is_constant() && to_constant_expr(expr.op1()).is_zero())
     {
       if(
         expr.id() == ID_overflow_result_plus ||
@@ -2627,10 +2631,14 @@ simplify_exprt::simplify_overflow_result(const overflow_result_exprt &expr)
     // One is neutral element for multiplication
     if(
       expr.id() == ID_overflow_result_mult &&
-      (expr.op0().is_one() || expr.op1().is_one()))
+      ((expr.op0().is_constant() && to_constant_expr(expr.op0()).is_one()) ||
+       (expr.op1().is_constant() && to_constant_expr(expr.op1()).is_one())))
     {
       return struct_exprt{
-        {expr.op0().is_one() ? expr.op1() : expr.op0(), false_exprt{}},
+        {(expr.op0().is_constant() && to_constant_expr(expr.op0()).is_one())
+           ? expr.op1()
+           : expr.op0(),
+         false_exprt{}},
         expr.type()};
     }
 

--- a/src/util/simplify_expr_array.cpp
+++ b/src/util/simplify_expr_array.cpp
@@ -93,11 +93,15 @@ simplify_exprt::simplify_index(const index_exprt &expr)
       exprt new_index_expr = simplify_index(
         index_exprt(with_expr.old(), index, new_expr.type())); // recursive call
 
-      if(equality_expr.is_true())
+      if(
+        equality_expr.is_constant() &&
+        to_constant_expr(equality_expr).is_true())
       {
         return with_expr.new_value();
       }
-      else if(equality_expr.is_false())
+      else if(
+        equality_expr.is_constant() &&
+        to_constant_expr(equality_expr).is_false())
       {
         return new_index_expr;
       }

--- a/src/util/simplify_expr_boolean.cpp
+++ b/src/util/simplify_expr_boolean.cpp
@@ -56,13 +56,13 @@ simplify_exprt::resultt<> simplify_exprt::simplify_boolean(const exprt &expr)
 
       bool erase;
 
-      if(it->is_true())
+      if(it->is_constant() && to_constant_expr(*it).is_true())
       {
         erase=true;
         negate=!negate;
       }
       else
-        erase=it->is_false();
+        erase = it->is_constant() && to_constant_expr(*it).is_false();
 
       if(erase)
       {
@@ -110,8 +110,8 @@ simplify_exprt::resultt<> simplify_exprt::simplify_boolean(const exprt &expr)
       if(!it->is_boolean())
         return unchanged(expr);
 
-      bool is_true=it->is_true();
-      bool is_false=it->is_false();
+      bool is_true = it->is_constant() && to_constant_expr(*it).is_true();
+      bool is_false = it->is_constant() && to_constant_expr(*it).is_false();
 
       if(expr.id()==ID_and && is_false)
       {
@@ -334,11 +334,11 @@ simplify_exprt::resultt<> simplify_exprt::simplify_not(const not_exprt &expr)
   {
     return to_not_expr(op).op();
   }
-  else if(op.is_false())
+  else if(op.is_constant() && to_constant_expr(op).is_false())
   {
     return true_exprt();
   }
-  else if(op.is_true())
+  else if(op.is_constant() && to_constant_expr(op).is_true())
   {
     return false_exprt();
   }

--- a/src/util/simplify_expr_floatbv.cpp
+++ b/src/util/simplify_expr_floatbv.cpp
@@ -347,8 +347,9 @@ simplify_exprt::simplify_floatbv_op(const ieee_float_op_exprt &expr)
   }
 
   // division by one? Exact for all rounding modes.
-  if(expr.id()==ID_floatbv_div &&
-     op1.is_constant() && op1.is_one())
+  if(
+    expr.id() == ID_floatbv_div && op1.is_constant() &&
+    to_constant_expr(op1).is_one())
   {
     return op0;
   }

--- a/src/util/simplify_expr_int.cpp
+++ b/src/util/simplify_expr_int.cpp
@@ -192,8 +192,9 @@ simplify_exprt::resultt<> simplify_exprt::simplify_mult(const mult_exprt &expr)
 
     // if one of the operands is zero the result is zero
     // note: not true on IEEE floating point arithmetic
-    if(it->is_zero() &&
-       it->type().id()!=ID_floatbv)
+    if(
+      it->is_constant() && to_constant_expr(*it).is_zero() &&
+      it->type().id() != ID_floatbv)
     {
       return from_integer(0, expr.type());
     }
@@ -253,7 +254,7 @@ simplify_exprt::resultt<> simplify_exprt::simplify_mult(const mult_exprt &expr)
   else
   {
     // if the constant is a one and there are other factors
-    if(constant_found && constant->is_one())
+    if(constant_found && to_constant_expr(*constant).is_one())
     {
       // just delete it
       new_operands.erase(constant);
@@ -346,8 +347,7 @@ simplify_exprt::resultt<> simplify_exprt::simplify_div(const div_exprt &expr)
   else if(expr_type.id()==ID_fixedbv)
   {
     // division by one?
-    if(expr.op1().is_constant() &&
-       expr.op1().is_one())
+    if(expr.op1().is_constant() && to_constant_expr(expr.op1()).is_one())
     {
       return expr.op0();
     }
@@ -541,7 +541,9 @@ simplify_exprt::resultt<> simplify_exprt::simplify_plus(const plus_exprt &expr)
         it != new_operands.end();
         /* no it++ */)
     {
-      if(is_number(it->type()) && it->is_zero())
+      if(
+        is_number(it->type()) && it->is_constant() &&
+        to_constant_expr(*it).is_zero())
       {
         it = new_operands.erase(it);
         no_change = false;
@@ -622,7 +624,8 @@ simplify_exprt::simplify_minus(const minus_exprt &expr)
       if(
         offset_op0.is_constant() && offset_op1.is_constant() &&
         object_size.has_value() && element_size.has_value() &&
-        element_size->is_constant() && !element_size->is_zero() &&
+        element_size->is_constant() &&
+        !to_constant_expr(*element_size).is_zero() &&
         numeric_cast_v<mp_integer>(to_constant_expr(offset_op0)) <=
           *object_size &&
         numeric_cast_v<mp_integer>(to_constant_expr(offset_op1)) <=
@@ -650,7 +653,7 @@ simplify_exprt::simplify_minus(const minus_exprt &expr)
 
       if(
         element_size.has_value() && element_size->is_constant() &&
-        !element_size->is_zero())
+        !to_constant_expr(*element_size).is_zero())
       {
         return changed(simplify_rec(div_exprt{
           minus_exprt{offset_op0, offset_op1},
@@ -678,7 +681,9 @@ simplify_exprt::simplify_bitwise(const multi_ary_exprt &expr)
       if(op.id() == ID_typecast && to_typecast_expr(op).op().is_boolean())
       {
       }
-      else if(op.is_zero() || op.is_one())
+      else if(
+        op.is_constant() &&
+        (to_constant_expr(op).is_zero() || to_constant_expr(op).is_one()))
       {
       }
       else
@@ -705,9 +710,9 @@ simplify_exprt::simplify_bitwise(const multi_ary_exprt &expr)
       {
         if(it->id()==ID_typecast)
           *it = to_typecast_expr(*it).op();
-        else if(it->is_zero())
+        else if(it->is_constant() && to_constant_expr(*it).is_zero())
           *it=false_exprt();
-        else if(it->is_one())
+        else if(it->is_constant() && to_constant_expr(*it).is_one())
           *it=true_exprt();
       }
 
@@ -777,7 +782,9 @@ simplify_exprt::simplify_bitwise(const multi_ary_exprt &expr)
     for(exprt::operandst::iterator it = new_expr.operands().begin();
         it != new_expr.operands().end();) // no it++
     {
-      if(it->is_zero() && new_expr.operands().size() > 1)
+      if(
+        it->is_constant() && to_constant_expr(*it).is_zero() &&
+        new_expr.operands().size() > 1)
       {
         it = new_expr.operands().erase(it);
         no_change = false;
@@ -882,9 +889,11 @@ simplify_exprt::simplify_concatenation(const concatenation_exprt &expr)
     Forall_operands(it, new_expr)
     {
       exprt &op=*it;
-      if(op.is_true() || op.is_false())
+      if(
+        op.is_constant() &&
+        (to_constant_expr(op).is_true() || to_constant_expr(op).is_false()))
       {
-        const bool value = op.is_true();
+        const bool value = to_constant_expr(op).is_true();
         op = from_integer(value, unsignedbv_typet(1));
         no_change = false;
       }
@@ -1562,7 +1571,8 @@ static bool eliminate_common_addends(exprt &op0, exprt &op1)
 {
   // we can't eliminate zeros
   if(
-    op0.is_zero() || op1.is_zero() ||
+    (op0.is_constant() && to_constant_expr(op0).is_zero()) ||
+    (op1.is_constant() && to_constant_expr(op1).is_zero()) ||
     (op0.is_constant() && to_constant_expr(op0).is_null_pointer()) ||
     (op1.is_constant() && to_constant_expr(op1).is_null_pointer()))
   {
@@ -1591,8 +1601,9 @@ static bool eliminate_common_addends(exprt &op0, exprt &op1)
   }
   else if(op0==op1)
   {
-    if(!op0.is_zero() &&
-       op0.type().id()!=ID_complex)
+    if(
+      (!op0.is_constant() || !to_constant_expr(op0).is_zero()) &&
+      op0.type().id() != ID_complex)
     {
       // elimination!
       op0=from_integer(0, op0.type());
@@ -1650,7 +1661,7 @@ simplify_exprt::resultt<> simplify_exprt::simplify_inequality_no_constant(
                            std::move(offset), ID_lt, std::move(*object_size)})
               .expr;
           if(in_object_bounds.is_constant())
-            return tvt{in_object_bounds.is_true()};
+            return tvt{to_constant_expr(in_object_bounds).is_true()};
         }
 
         return tvt::unknown();
@@ -1825,7 +1836,7 @@ simplify_exprt::resultt<> simplify_exprt::simplify_inequality_rhs_is_constant(
         exprt ptr = simplify_object(expr.op0()).expr;
         // NULL + N == NULL is N == 0
         if(ptr.is_constant() && to_constant_expr(ptr).is_null_pointer())
-          return make_boolean_expr(offset.is_zero());
+          return make_boolean_expr(to_constant_expr(offset).is_zero());
         // &x + N == NULL is false when the offset is in bounds
         else if(auto address_of = expr_try_dynamic_cast<address_of_exprt>(ptr))
         {
@@ -1913,7 +1924,7 @@ simplify_exprt::resultt<> simplify_exprt::simplify_inequality_rhs_is_constant(
 
   // is the constant zero?
 
-  if(expr.op1().is_zero())
+  if(expr.op1().is_constant() && to_constant_expr(expr.op1()).is_zero())
   {
     if(expr.id()==ID_ge &&
        expr.op0().type().id()==ID_unsignedbv)
@@ -2002,13 +2013,17 @@ simplify_exprt::resultt<> simplify_exprt::simplify_inequality_rhs_is_constant(
     const auto &lhs_typecast_op = to_typecast_expr(expr.op0()).op();
 
     // we re-write (TYPE)boolean == 0 -> !boolean
-    if(expr.op1().is_zero() && expr.id()==ID_equal)
+    if(
+      expr.op1().is_constant() && to_constant_expr(expr.op1()).is_zero() &&
+      expr.id() == ID_equal)
     {
       return changed(simplify_not(not_exprt(lhs_typecast_op)));
     }
 
     // we re-write (TYPE)boolean != 0 -> boolean
-    if(expr.op1().is_zero() && expr.id()==ID_notequal)
+    if(
+      expr.op1().is_constant() && to_constant_expr(expr.op1()).is_zero() &&
+      expr.id() == ID_notequal)
     {
       return lhs_typecast_op;
     }

--- a/src/util/simplify_expr_struct.cpp
+++ b/src/util/simplify_expr_struct.cpp
@@ -172,7 +172,9 @@ simplify_exprt::simplify_member(const member_exprt &expr)
     {
       // rewrite byte_extract(X, 0).member to X
       // if the type of X is that of the member
-      if(byte_extract_expr.offset().is_zero())
+      if(
+        byte_extract_expr.offset().is_constant() &&
+        to_constant_expr(byte_extract_expr.offset()).is_zero())
       {
         const union_typet &union_type =
           op.type().id() == ID_union_tag

--- a/src/util/std_expr.cpp
+++ b/src/util/std_expr.cpp
@@ -8,10 +8,17 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "std_expr.h"
 
+#include "arith_tools.h"
 #include "config.h"
+#include "expr_util.h"
+#include "fixedbv.h"
+#include "ieee_float.h"
+#include "mathematical_types.h"
 #include "namespace.h"
 #include "pointer_expr.h"
 #include "range.h"
+#include "rational.h"
+#include "rational_tools.h"
 #include "substitute_symbols.h"
 
 #include <map>
@@ -20,6 +27,107 @@ bool constant_exprt::value_is_zero_string() const
 {
   const std::string val=id2string(get_value());
   return val.find_first_not_of('0')==std::string::npos;
+}
+
+bool constant_exprt::is_true() const
+{
+  return is_boolean() && get_value() != ID_false;
+}
+
+bool constant_exprt::is_false() const
+{
+  return is_boolean() && get_value() == ID_false;
+}
+
+bool constant_exprt::is_zero() const
+{
+  const irep_idt &type_id = type().id();
+
+  if(type_id == ID_integer)
+  {
+    return integer_typet{}.zero_expr() == *this;
+  }
+  else if(type_id == ID_natural)
+  {
+    return natural_typet{}.zero_expr() == *this;
+  }
+  else if(type_id == ID_real)
+  {
+    return real_typet{}.zero_expr() == *this;
+  }
+  else if(type_id == ID_rational)
+  {
+    rationalt rat_value;
+    if(to_rational(*this, rat_value))
+      CHECK_RETURN(false);
+    return rat_value.is_zero();
+  }
+  else if(
+    type_id == ID_unsignedbv || type_id == ID_signedbv ||
+    type_id == ID_c_bool || type_id == ID_c_bit_field)
+  {
+    return value_is_zero_string();
+  }
+  else if(type_id == ID_fixedbv)
+  {
+    return fixedbvt(*this).is_zero();
+  }
+  else if(type_id == ID_floatbv)
+  {
+    return ieee_float_valuet(*this).is_zero();
+  }
+  else if(type_id == ID_pointer)
+  {
+    return is_null_pointer();
+  }
+  else
+    return false;
+}
+
+bool constant_exprt::is_one() const
+{
+  const irep_idt &type_id = type().id();
+
+  if(type_id == ID_integer)
+  {
+    return integer_typet{}.one_expr() == *this;
+  }
+  else if(type_id == ID_natural)
+  {
+    return natural_typet{}.one_expr() == *this;
+  }
+  else if(type_id == ID_real)
+  {
+    return real_typet{}.one_expr() == *this;
+  }
+  else if(type_id == ID_rational)
+  {
+    rationalt rat_value;
+    if(to_rational(*this, rat_value))
+      CHECK_RETURN(false);
+    return rat_value.is_one();
+  }
+  else if(
+    type_id == ID_unsignedbv || type_id == ID_signedbv ||
+    type_id == ID_c_bool || type_id == ID_c_bit_field)
+  {
+    const auto width = to_bitvector_type(type()).get_width();
+    mp_integer int_value = bvrep2integer(id2string(get_value()), width, false);
+    return int_value == 1;
+  }
+  else if(type_id == ID_fixedbv)
+  {
+    fixedbv_spect spec{to_fixedbv_type(type())};
+    fixedbvt one{spec};
+    one.from_integer(1);
+    return one == fixedbvt{*this};
+  }
+  else if(type_id == ID_floatbv)
+  {
+    return ieee_float_valuet(*this) == 1;
+  }
+  else
+    return false;
 }
 
 bool constant_exprt::is_null_pointer() const

--- a/src/util/std_expr.h
+++ b/src/util/std_expr.h
@@ -3133,6 +3133,33 @@ public:
   }
 
   bool value_is_zero_string() const;
+  /// Return whether the expression is a constant representing `true`.
+  /// \return True if it is of Boolean type and has value representing `true`,
+  ///   false otherwise.
+  bool is_true() const;
+
+  /// Return whether the expression is a constant representing `false`.
+  /// \return True if it is of Boolean type and has value representing `false`,
+  ///   and returns false otherwise.
+  bool is_false() const;
+
+  /// Return whether the expression is a constant representing 0.
+  /// Will consider the following types: ID_integer, ID_natural, ID_rational,
+  /// ID_unsignedbv, ID_signedbv, ID_c_bool, ID_c_bit_field, ID_fixedbv,
+  /// ID_floatbv, ID_pointer.<br>
+  /// For ID_pointer, returns true iff the value is a zero string or a null
+  /// pointer.
+  /// For everything not in the above list, return false.
+  /// \return True if has value 0, false otherwise.
+  bool is_zero() const;
+
+  /// Return whether the expression is a constant representing 1.
+  /// Will consider the following types: ID_integer, ID_natural, ID_rational,
+  /// ID_unsignedbv, ID_signedbv, ID_c_bool, ID_c_bit_field, ID_fixedbv,
+  /// ID_floatbv.<br>
+  /// For all other types, return false.
+  /// \return True if has value 1, false otherwise.
+  bool is_one() const;
 
   /// Returns true if \p expr has a pointer type and a value NULL; it also
   /// returns true when \p expr has value zero and NULL_is_zero is true; returns

--- a/unit/analyses/variable-sensitivity/value_expression_evaluation/assume.cpp
+++ b/unit/analyses/variable-sensitivity/value_expression_evaluation/assume.cpp
@@ -803,7 +803,8 @@ void ASSUME_TRUE(
     auto assumption = env.do_assume(expr, ns);
     REQUIRE(assumption.id() != ID_nil);
     REQUIRE(assumption.is_boolean());
-    REQUIRE(assumption.is_true());
+    REQUIRE(assumption.is_constant());
+    REQUIRE(to_constant_expr(assumption).is_true());
   }
 }
 
@@ -817,7 +818,8 @@ void ASSUME_FALSE(
     auto assumption = env.do_assume(expr, ns);
     REQUIRE(assumption.id() != ID_nil);
     REQUIRE(assumption.is_boolean());
-    REQUIRE(assumption.is_false());
+    REQUIRE(assumption.is_constant());
+    REQUIRE(to_constant_expr(assumption).is_false());
   }
 }
 

--- a/unit/analyses/variable-sensitivity/value_expression_evaluation/assume_prune.cpp
+++ b/unit/analyses/variable-sensitivity/value_expression_evaluation/assume_prune.cpp
@@ -34,7 +34,8 @@ static void ASSUME_TRUE(
 
   REQUIRE(assumption.id() != ID_nil);
   REQUIRE(assumption.is_boolean());
-  REQUIRE(assumption.is_true());
+  REQUIRE(assumption.is_constant());
+  REQUIRE(to_constant_expr(assumption).is_true());
 }
 
 static void EXPECT_RESULT(

--- a/unit/goto-symex/shadow_memory_util.cpp
+++ b/unit/goto-symex/shadow_memory_util.cpp
@@ -264,7 +264,7 @@ exprt simplify_bit_or_exprt(const exprt &expr)
     for(const auto &operand : or_expr->operands())
     {
       const exprt reduced = simplify_bit_or_exprt(operand);
-      res |= reduced.is_true();
+      res |= reduced.is_constant() && to_constant_expr(reduced).is_true();
     }
     return from_integer(res, bool_typet{});
   }

--- a/unit/util/expr.cpp
+++ b/unit/util/expr.cpp
@@ -20,7 +20,7 @@ SCENARIO("bitfield-expr-is-zero", "[core][util][expr]")
 
     THEN("is_zero() should be false")
     {
-      REQUIRE_FALSE(bitfield3.is_zero());
+      REQUIRE_FALSE(to_constant_expr(bitfield3).is_zero());
     }
   }
   GIVEN("An exprt representing a bitfield constant of 0")
@@ -30,7 +30,7 @@ SCENARIO("bitfield-expr-is-zero", "[core][util][expr]")
 
     THEN("is_zero() should be true")
     {
-      REQUIRE(bitfield0.is_zero());
+      REQUIRE(to_constant_expr(bitfield0).is_zero());
     }
   }
 }

--- a/unit/util/interval/get_extreme.cpp
+++ b/unit/util/interval/get_extreme.cpp
@@ -41,7 +41,8 @@ SCENARIO("get extreme exprt value", "[core][analyses][interval][get_extreme]")
 
       THEN("Require it is TRUE")
       {
-        REQUIRE(op1.is_true());
+        REQUIRE(op1.is_constant());
+        REQUIRE(to_constant_expr(op1).is_true());
         REQUIRE(interval_eval);
       }
     }
@@ -55,7 +56,8 @@ SCENARIO("get extreme exprt value", "[core][analyses][interval][get_extreme]")
 
       THEN("Require it is FALSE")
       {
-        REQUIRE(op1.is_false());
+        REQUIRE(op1.is_constant());
+        REQUIRE(to_constant_expr(op1).is_false());
         REQUIRE_FALSE(interval_eval);
       }
     }
@@ -70,7 +72,8 @@ SCENARIO("get extreme exprt value", "[core][analyses][interval][get_extreme]")
 
       THEN("Require it is TRUE")
       {
-        REQUIRE(op1.is_true());
+        REQUIRE(op1.is_constant());
+        REQUIRE(to_constant_expr(op1).is_true());
         REQUIRE(interval_eval);
         REQUIRE(constant_interval_exprt::equal(CEV(1), CEV(1)));
       }

--- a/unit/util/simplify_expr.cpp
+++ b/unit/util/simplify_expr.cpp
@@ -247,7 +247,8 @@ TEST_CASE("Simplify pointer_object equality", "[core][util]")
 
   exprt simp = simplify_expr(equal_exprt{p_o_void, p_o_int}, ns);
 
-  REQUIRE(simp.is_true());
+  REQUIRE(simp.is_constant());
+  REQUIRE(to_constant_expr(simp).is_true());
 }
 
 TEST_CASE("Simplify cast from bool", "[core][util]")


### PR DESCRIPTION
true/false/zero/one are constants, so only for a `constant_exprt` those methods can ever evaluate to true.

This commit both deprecates the `exprt` methods and removes all their uses from the code base.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
