### PR TITLE
Remove deprecated is_null_pointer

### DIFF
--- a/src/util/expr.cpp
+++ b/src/util/expr.cpp
@@ -80,7 +80,7 @@ bool exprt::is_zero() const
     }
     else if(type_id==ID_pointer)
     {
-      return is_null_pointer(constant);
+      return constant.is_null_pointer();
     }
   }
 

--- a/src/util/expr_util.cpp
+++ b/src/util/expr_util.cpp
@@ -340,8 +340,3 @@ exprt make_and(exprt a, exprt b)
   }
   return and_exprt{std::move(a), std::move(b)};
 }
-
-bool is_null_pointer(const constant_exprt &expr)
-{
-  return expr.is_null_pointer();
-}

--- a/src/util/expr_util.h
+++ b/src/util/expr_util.h
@@ -115,10 +115,4 @@ constant_exprt make_boolean_expr(bool);
 /// return the other expression. If one is `false` returns `false`.
 exprt make_and(exprt a, exprt b);
 
-/// Returns true if \p expr has a pointer type and a value NULL; it also returns
-/// true when \p expr has value zero and NULL_is_zero is true; returns false in
-/// all other cases.
-DEPRECATED(SINCE(2024, 9, 10, "use constant_exprt::is_null_pointer() instead"))
-bool is_null_pointer(const constant_exprt &expr);
-
 #endif // CPROVER_UTIL_EXPR_UTIL_H


### PR DESCRIPTION
This was deprecated over 6 months ago.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
