### PR TITLE
Remove deprecated make_with_expr

### DIFF
--- a/src/util/expr_util.cpp
+++ b/src/util/expr_util.cpp
@@ -66,11 +66,6 @@ exprt make_binary(const exprt &expr)
   return previous;
 }
 
-with_exprt make_with_expr(const update_exprt &src)
-{
-  return src.make_with_expr();
-}
-
 exprt is_not_zero(
   const exprt &src,
   const namespacet &ns)

--- a/src/util/expr_util.h
+++ b/src/util/expr_util.h
@@ -40,10 +40,6 @@ bool is_assignable(const exprt &);
 /// splits an expression with >=3 operands into nested binary expressions
 exprt make_binary(const exprt &);
 
-/// converts an update expr into a (possibly nested) with expression
-DEPRECATED(SINCE(2024, 9, 10, "use update_exprt::make_with_expr() instead"))
-with_exprt make_with_expr(const update_exprt &);
-
 /// converts a scalar/float expression to C/C++ Booleans
 exprt is_not_zero(const exprt &, const namespacet &ns);
 


### PR DESCRIPTION
This was deprecated over 6 months ago.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
