### PR TITLE
Stop using GNU parallel on windows-2022 runner

### DIFF
--- a/.github/workflows/pull-request-checks.yaml
+++ b/.github/workflows/pull-request-checks.yaml
@@ -799,7 +799,7 @@ jobs:
           Set-Location build
           ctest -V -L CORE -C Release . -j${{env.windows-vcpus}}
 
-  # This job takes approximately 18 to 84 minutes
+  # This job takes approximately 65 to 84 minutes
   check-vs-2022-make-build-and-test:
     runs-on: windows-2022
     env:
@@ -829,9 +829,6 @@ jobs:
           Expand-Archive -LiteralPath '.\cvc5-Win64-x86_64-static.Zip'
           Move-Item -Path .\cvc5-Win64-x86_64-static\cvc5-Win64-x86_64-static\bin\cvc5.exe c:\tools\cvc5\cvc5.exe
           echo "c:\tools\cvc5;" >> $env:GITHUB_PATH
-          New-Item -ItemType directory "C:\tools\parallel"
-          wget.exe -O c:\tools\parallel\parallel https://raw.githubusercontent.com/martinda/gnu-parallel/refs/heads/master/src/parallel
-          echo "c:\tools\parallel" >> $env:GITHUB_PATH
       - name: Confirm z3 solver is available and log the version installed
         run: z3 --version
       - name: Confirm cvc5 solver is available and log the version installed
@@ -875,7 +872,7 @@ jobs:
           make CXX=clcache BUILD_ENV=MSVC -C unit test TAGS="[z3]"
           make CXX=clcache BUILD_ENV=MSVC -C jbmc/unit test
       - name: Run CBMC regression tests
-        run: make CXX=clcache BUILD_ENV=MSVC -C regression test-parallel JOBS=${{env.windows-vcpus}}
+        run: make CXX=clcache BUILD_ENV=MSVC -C regression test
 
   # This job takes approximately 7 to 32 minutes
   windows-msi-package:


### PR DESCRIPTION
This reverts commit 7b4da6cd92938f4451407bf22ea4f58cb2e56079: it seems
that with some change that occurred between 2025-06-25 and 2025-06-26
for the windows-2022 runner the use of GNU parallel is no longer
possible: even with `--jobs 1` it blocks as soon as `parellel ...` is
called.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
