### PR TITLE
Support C17, C23 standards with goto-cc

### DIFF
--- a/regression/ansi-c/c23_attributes1/main.c
+++ b/regression/ansi-c/c23_attributes1/main.c
@@ -1,0 +1,8 @@
+enum [[nodiscard]] error_t
+{
+  A,
+};
+
+int main()
+{
+}

--- a/regression/ansi-c/c23_attributes1/test.desc
+++ b/regression/ansi-c/c23_attributes1/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+-std=c2x
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+^CONVERSION ERROR$

--- a/src/ansi-c/scanner.l
+++ b/src/ansi-c/scanner.l
@@ -899,8 +899,18 @@ enable_or_disable ("enable"|"disable")
 "__if_not_exists"   { return MSC_cpp_keyword(TOK_MSC_IF_NOT_EXISTS); }
 "__underlying_type" { return conditional_keyword(PARSER.cpp98, TOK_UNDERLYING_TYPE); }
 
-"[["                { if(PARSER.c23)
+"[["                { // C23 attributes (also C++11 and later, but for C++ we
+                      // handle them directly in the parser); GCC >= 11, Clang
+                      // >= 17, and Visual Studio >= 2022 support these
+                      // irrespective of the language standard selected on the
+                      // command-line.
+                      if(PARSER.c23 ||
+                         PARSER.mode==configt::ansi_ct::flavourt::GCC ||
+                         PARSER.mode==configt::ansi_ct::flavourt::CLANG ||
+                         PARSER.mode==configt::ansi_ct::flavourt::VISUAL_STUDIO)
+                      {
                         BEGIN(STD_ANNOTATION);
+                      }
                       else
                       {
                         yyless(1); // puts one [ back into stream

--- a/src/goto-cc/gcc_mode.cpp
+++ b/src/goto-cc/gcc_mode.cpp
@@ -648,6 +648,20 @@ int gcc_modet::doit()
        std_string=="gnu1x" || std_string=="c1x")
       config.ansi_c.set_c11();
 
+    if(
+      std_string == "gnu17" || std_string == "c17" || std_string == "gnu18" ||
+      std_string == "c18")
+    {
+      config.ansi_c.set_c17();
+    }
+
+    if(
+      std_string == "gnu2x" || std_string == "c2x" || std_string == "gnu23" ||
+      std_string == "c23")
+    {
+      config.ansi_c.set_c23();
+    }
+
     if(std_string=="c++11" || std_string=="c++1x" ||
        std_string=="gnu++11" || std_string=="gnu++1x" ||
        std_string=="c++1y" ||


### PR DESCRIPTION
We previously added the necessary language features in the C front end, but failed to permit selection of these standards in goto-cc.

Also, GCC >= 11 and Clang >= 17 support C23-style attributes irrespective of the configured language standard. So let's accept these in our C front end whenever operating in GCC/Clang mode.

Fixes: #8671

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
