### PR TITLE
DFCC: do not surface confusing warning

### DIFF
--- a/src/goto-instrument/contracts/dynamic-frames/dfcc.cpp
+++ b/src/goto-instrument/contracts/dynamic-frames/dfcc.cpp
@@ -497,7 +497,8 @@ void dfcct::transform_goto_model()
     std::regex("(?!" CPROVER_PREFIX ").*"),
     *generate_implementation,
     goto_model,
-    message_handler);
+    message_handler,
+    true);
   goto_model.goto_functions.update();
 
   reinitialize_model();

--- a/src/goto-instrument/generate_function_bodies.cpp
+++ b/src/goto-instrument/generate_function_bodies.cpp
@@ -498,11 +498,14 @@ std::unique_ptr<generate_function_bodiest> generate_function_bodies_factory(
 /// \param generate_function_body: Specifies what kind of body to generate
 /// \param model: The goto-model in which to generate the function bodies
 /// \param message_handler: Destination for status/warning messages
+/// \param ignore_no_match: Do not warn in case no function matched
+///   \p functions_regex
 void generate_function_bodies(
   const std::regex &functions_regex,
   const generate_function_bodiest &generate_function_body,
   goto_modelt &model,
-  message_handlert &message_handler)
+  message_handlert &message_handler,
+  bool ignore_no_match)
 {
   messaget messages(message_handler);
   const std::regex cprover_prefix = std::regex("__CPROVER.*");
@@ -526,7 +529,7 @@ void generate_function_bodies(
         function.second, model.symbol_table, function.first);
     }
   }
-  if(!did_generate_body)
+  if(!did_generate_body && !ignore_no_match)
   {
     messages.warning()
       << "generate function bodies: No function name matched regex"

--- a/src/goto-instrument/generate_function_bodies.h
+++ b/src/goto-instrument/generate_function_bodies.h
@@ -68,7 +68,8 @@ void generate_function_bodies(
   const std::regex &functions_regex,
   const generate_function_bodiest &generate_function_body,
   goto_modelt &model,
-  message_handlert &message_handler);
+  message_handlert &message_handler,
+  bool ignore_no_match);
 
 /// Generate a clone of \p function_name (labelled with \p call_site_id) and
 ///   instantiate its body with selective havocing of its parameters.

--- a/src/goto-instrument/goto_instrument_parse_options.cpp
+++ b/src/goto-instrument/goto_instrument_parse_options.cpp
@@ -1400,7 +1400,8 @@ void goto_instrument_parse_optionst::instrument_goto_program()
       std::regex(cmdline.get_value("generate-function-body")),
       *generate_implementation,
       goto_model,
-      ui_message_handler);
+      ui_message_handler,
+      false);
   }
 
   if(cmdline.isset("generate-havocing-body"))
@@ -1427,7 +1428,8 @@ void goto_instrument_parse_optionst::instrument_goto_program()
         std::regex(options_split[0]),
         *generate_implementation,
         goto_model,
-        ui_message_handler);
+        ui_message_handler,
+        false);
     }
     else
     {


### PR DESCRIPTION
Users do not know that DFCC uses generate-function-bodies to ensure sound operation, and indeed the user had everything set up just right when _no_ function needed to be generated.

Resolves: #8638

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
