### PR TITLE
C front-end: do not warn when re-initialising a variable with the same value

### DIFF
--- a/src/ansi-c/c_typecheck_base.cpp
+++ b/src/ansi-c/c_typecheck_base.cpp
@@ -573,10 +573,7 @@ void c_typecheck_baset::typecheck_redefinition_non_type(
     // see if we already have one
     if(old_symbol.value.is_not_nil())
     {
-      if(
-        new_symbol.is_macro && final_new.id() == ID_c_enum &&
-        old_symbol.value.is_constant() && new_symbol.value.is_constant() &&
-        old_symbol.value.get(ID_value) == new_symbol.value.get(ID_value))
+      if(old_symbol.value == new_symbol.value)
       {
         // ignore
       }
@@ -584,7 +581,7 @@ void c_typecheck_baset::typecheck_redefinition_non_type(
       {
         warning().source_location = new_symbol.value.find_source_location();
         warning() << "symbol '" << new_symbol.display_name()
-                  << "' already has an initial value" << eom;
+                  << "' already has a different initial value" << eom;
       }
     }
     else


### PR DESCRIPTION
There is no surprising behaviour when all initialisers are the same.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
