### PR TITLE
C library: remove explicit zero initialisers

### DIFF
--- a/src/ansi-c/library/cprover_contracts.c
+++ b/src/ansi-c/library/cprover_contracts.c
@@ -7,11 +7,11 @@
 #define __CPROVER_contracts_library_defined
 
 // external dependencies
-const void *__CPROVER_alloca_object = 0;
+const void *__CPROVER_alloca_object;
 extern const void *__CPROVER_deallocated;
-const void *__CPROVER_new_object = 0;
+const void *__CPROVER_new_object;
 extern const void *__CPROVER_memory_leak;
-__CPROVER_bool __CPROVER_malloc_is_new_array = 0;
+__CPROVER_bool __CPROVER_malloc_is_new_array;
 #if defined(_WIN32) && defined(_M_X64)
 int __builtin_clzll(unsigned long long);
 #else

--- a/src/ansi-c/library/getopt.c
+++ b/src/ansi-c/library/getopt.c
@@ -5,7 +5,7 @@
 #define __CPROVER_STRING_H_INCLUDED
 #endif
 
-char *optarg = NULL;
+char *optarg;
 int optind = 1;
 
 __CPROVER_bool __VERIFIER_nondet___CPROVER_bool(void);

--- a/src/ansi-c/library/pthread_lib.c
+++ b/src/ansi-c/library/pthread_lib.c
@@ -341,7 +341,7 @@ __CPROVER_bool __CPROVER_threads_exited[__CPROVER_constant_infinity_uint];
 #ifndef LIBRARY_CHECK
 __CPROVER_thread_local unsigned long __CPROVER_thread_id = 0;
 #endif
-unsigned long __CPROVER_next_thread_id = 0;
+unsigned long __CPROVER_next_thread_id;
 
 int pthread_join(pthread_t thread, void **value_ptr)
 {
@@ -379,7 +379,7 @@ __CPROVER_HIDE:;
 __CPROVER_bool __CPROVER_threads_exited[__CPROVER_constant_infinity_uint];
 #  ifndef LIBRARY_CHECK
 __CPROVER_thread_local unsigned long __CPROVER_thread_id = 0;
-unsigned long __CPROVER_next_thread_id = 0;
+unsigned long __CPROVER_next_thread_id;
 #  endif
 
 int _pthread_join(pthread_t thread, void **value_ptr)
@@ -615,7 +615,7 @@ __CPROVER_HIDE:;
 #endif
 
 #ifndef LIBRARY_CHECK
-unsigned long __CPROVER_next_thread_id = 0;
+unsigned long __CPROVER_next_thread_id;
 #  if 0
 __CPROVER_thread_local void (
   *__CPROVER_thread_key_dtors[__CPROVER_constant_infinity_uint])(void *);

--- a/src/ansi-c/library/stdlib.c
+++ b/src/ansi-c/library/stdlib.c
@@ -141,7 +141,7 @@ __CPROVER_bool __VERIFIER_nondet___CPROVER_bool(void);
 #ifndef __GNUC__
 _Bool __builtin_mul_overflow();
 #endif
-__CPROVER_bool __CPROVER_malloc_is_new_array = 0;
+__CPROVER_bool __CPROVER_malloc_is_new_array;
 
 void *calloc(__CPROVER_size_t nmemb, __CPROVER_size_t size)
 {
@@ -204,7 +204,7 @@ __CPROVER_HIDE:;
 
 __CPROVER_bool __VERIFIER_nondet___CPROVER_bool(void);
 #ifndef LIBRARY_CHECK
-__CPROVER_bool __CPROVER_malloc_is_new_array = 0;
+__CPROVER_bool __CPROVER_malloc_is_new_array;
 #endif
 
 // malloc is marked "inline" for the benefit of goto-analyzer. Really,
@@ -262,9 +262,9 @@ __CPROVER_HIDE:;
 /* FUNCTION: __builtin_alloca */
 
 __CPROVER_bool __VERIFIER_nondet___CPROVER_bool(void);
-const void *__CPROVER_alloca_object = 0;
+const void *__CPROVER_alloca_object;
 #ifndef LIBRARY_CHECK
-__CPROVER_bool __CPROVER_malloc_is_new_array = 0;
+__CPROVER_bool __CPROVER_malloc_is_new_array;
 #endif
 
 void *__builtin_alloca(__CPROVER_size_t alloca_size)
@@ -307,11 +307,11 @@ __CPROVER_HIDE:;
 void __CPROVER_deallocate(void *);
 __CPROVER_bool __VERIFIER_nondet___CPROVER_bool(void);
 #ifndef LIBRARY_CHECK
-const void *__CPROVER_alloca_object = 0;
+const void *__CPROVER_alloca_object;
 #endif
-const void *__CPROVER_new_object = 0;
+const void *__CPROVER_new_object;
 #ifndef LIBRARY_CHECK
-__CPROVER_bool __CPROVER_malloc_is_new_array = 0;
+__CPROVER_bool __CPROVER_malloc_is_new_array;
 #endif
 
 void free(void *ptr)

--- a/src/ansi-c/library/unistd.c
+++ b/src/ansi-c/library/unistd.c
@@ -83,7 +83,7 @@ int unlink(const char *s)
 extern struct __CPROVER_pipet __CPROVER_pipes[__CPROVER_constant_infinity_uint];
 // offset to make sure we don't collide with other fds
 extern const int __CPROVER_pipe_offset;
-unsigned __CPROVER_pipe_count = 0;
+unsigned __CPROVER_pipe_count;
 
 __CPROVER_bool __VERIFIER_nondet___CPROVER_bool(void);
 


### PR DESCRIPTION
We initialise (with the default zero) value global variables in multiple model functions, which can result in spurious warnings about those variables already having an initial value.

Towards: #8638

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
