### PR TITLE
Work around Z3 not producing models for some quantified expressions

### DIFF
--- a/regression/cbmc-primitives/exists_memory_checks/smt_missing_range_check.desc
+++ b/regression/cbmc-primitives/exists_memory_checks/smt_missing_range_check.desc
@@ -1,4 +1,4 @@
-KNOWNBUG smt-backend no-new-smt
+CORE smt-backend no-new-smt
 smt_missing_range_check.c
 --no-malloc-may-fail --pointer-check -z3
 ^EXIT=10$
@@ -13,6 +13,3 @@ quantifier, for out of bounds memory access, when using the smt backend and
 the range of the index is unbound. Note that this test is not expected to work
 with the SAT backend at the time of writing, as the SAT backend does not support
 quantifiers in this form.
-
-Neither Z3 nor CVC5 currently return complete models, and Bitwuzla does not
-complete in more than 5 minutes.

--- a/src/solvers/smt2/smt2_conv.cpp
+++ b/src/solvers/smt2/smt2_conv.cpp
@@ -976,17 +976,42 @@ literalt smt2_convt::convert(const exprt &expr)
   // Note that here we are always converting, so we do not need to consider
   // other literal kinds, only "|B###|"
 
-  // Z3 refuses get-value when a defined symbol contains a quantifier.
+  // Z3 refuses get-value when a defined symbol contains a quantifier, so we
+  // declare the symbol and constrain it separately rather than using
+  // define-fun.
   if(has_quantifier(prepared_expr))
   {
     out << "(declare-fun ";
     convert_literal(l);
     out << " () Bool)\n";
-    out << "(assert (= ";
-    convert_literal(l);
-    out << ' ';
-    convert_expr(prepared_expr);
-    out << "))\n";
+    if(solver == solvert::Z3)
+    {
+      // A single (assert (= B <expr>)) does not help on Z3: its solve_eqs
+      // preprocessor eliminates B by substituting the quantified <expr>, and
+      // then hands the eliminated form back through get-value (see
+      // Z3Prover/z3#7743). Asserting the equivalence as two implications
+      // instead prevents this. The underlying issue is fixed in Z3 >= 4.17
+      // (which also exposes (set-option :smt.solve_eqs.non_ground false)), but
+      // neither is widely available yet, so we keep the workaround for Z3.
+      out << "(assert (=> ";
+      convert_literal(l);
+      out << ' ';
+      convert_expr(prepared_expr);
+      out << "))\n";
+      out << "(assert (=> ";
+      convert_expr(prepared_expr);
+      out << ' ';
+      convert_literal(l);
+      out << "))\n";
+    }
+    else
+    {
+      out << "(assert (= ";
+      convert_literal(l);
+      out << ' ';
+      convert_expr(prepared_expr);
+      out << "))\n";
+    }
   }
   else
   {

--- a/src/solvers/smt2/smt2_conv.cpp
+++ b/src/solvers/smt2/smt2_conv.cpp
@@ -990,19 +990,18 @@ literalt smt2_convt::convert(const exprt &expr)
       // preprocessor eliminates B by substituting the quantified <expr>, and
       // then hands the eliminated form back through get-value (see
       // Z3Prover/z3#7743). Asserting the equivalence as two implications
-      // instead prevents this. The underlying issue is fixed in Z3 >= 4.17
-      // (which also exposes (set-option :smt.solve_eqs.non_ground false)), but
-      // neither is widely available yet, so we keep the workaround for Z3.
-      out << "(assert (=> ";
-      convert_literal(l);
-      out << ' ';
+      // instead prevents this; a let-binding shares the (possibly large)
+      // quantified expression so that it is emitted only once. The underlying
+      // issue is fixed in Z3 >= 4.17 (which also exposes
+      // (set-option :smt.solve_eqs.non_ground false)), but neither is widely
+      // available yet, so we keep the workaround for Z3.
+      out << "(assert (let ((?def ";
       convert_expr(prepared_expr);
-      out << "))\n";
-      out << "(assert (=> ";
-      convert_expr(prepared_expr);
-      out << ' ';
+      out << ")) (and (=> ";
       convert_literal(l);
-      out << "))\n";
+      out << " ?def) (=> ?def ";
+      convert_literal(l);
+      out << "))))\n";
     }
     else
     {

--- a/unit/solvers/smt2/smt2_conv.cpp
+++ b/unit/solvers/smt2/smt2_conv.cpp
@@ -227,24 +227,20 @@ TEST_CASE("smt2_convt quantifier definition encoding", "[core][solvers][smt2]")
     const std::string out = convert_handle(quantified, smt2_convt::solvert::Z3);
     INFO("SMT2 output:\n" << out);
 
-    THEN("it is declared and constrained by two implications, in order")
+    THEN("it is declared and constrained by a let-bound equivalence")
     {
       // A single `(assert (= B0 <quantifier>))` would be undone by Z3's
       // solve_eqs preprocessor (Z3Prover/z3#7743), so the equivalence is
-      // emitted as two implications, B0 => <q> followed by <q> => B0.
+      // emitted as two implications. A let-binding shares the quantified
+      // expression so that it is written only once.
       const std::string declare = "(declare-fun B0 () Bool)";
-      const std::string impl1 = "(assert (=> B0 " + quant + "))";
-      const std::string impl2 = "(assert (=> " + quant + " B0))";
+      const std::string assertion =
+        "(assert (let ((?def " + quant + ")) (and (=> B0 ?def) (=> ?def B0))))";
 
-      const auto p_declare = out.find(declare);
-      const auto p_impl1 = out.find(impl1);
-      const auto p_impl2 = out.find(impl2);
-
-      REQUIRE(p_declare != std::string::npos);
-      REQUIRE(p_impl1 != std::string::npos);
-      REQUIRE(p_impl2 != std::string::npos);
-      REQUIRE(p_declare < p_impl1);
-      REQUIRE(p_impl1 < p_impl2);
+      REQUIRE(out.find(declare) != std::string::npos);
+      REQUIRE(out.find(assertion) != std::string::npos);
+      // the quantified expression is emitted exactly once
+      REQUIRE(out.find(quant) == out.rfind(quant));
       // no plain equality definition
       REQUIRE(out.find("(assert (= B0 ") == std::string::npos);
     }

--- a/unit/solvers/smt2/smt2_conv.cpp
+++ b/unit/solvers/smt2/smt2_conv.cpp
@@ -8,6 +8,7 @@
 #include <util/bitvector_types.h>
 #include <util/c_types.h>
 #include <util/ieee_float.h>
+#include <util/mathematical_expr.h>
 #include <util/mathematical_types.h>
 #include <util/message.h>
 #include <util/namespace.h>
@@ -198,4 +199,73 @@ TEST_CASE(
   conv.set_to(equal_exprt{typecast_exprt{u_expr, u64}, expected}, true);
 
   REQUIRE(out.str().find("(_ bv4607182418800017408 64)") != std::string::npos);
+}
+
+/// Helper: full SMT2 emitted by converting (handling) a Boolean expression
+static std::string convert_handle(const exprt &expr, smt2_convt::solvert solver)
+{
+  symbol_tablet symbol_table;
+  namespacet ns(symbol_table);
+  std::ostringstream out;
+  smt2_convt conv(ns, "test", "", "QF_BV", solver, out);
+  conv.handle(expr);
+  return out.str();
+}
+
+TEST_CASE("smt2_convt quantifier definition encoding", "[core][solvers][smt2]")
+{
+  // A Boolean handle whose definition contains a quantifier cannot be emitted
+  // as a `define-fun` (Z3 rejects `get-value` on such a symbol), so it is
+  // declared and constrained separately.
+  const unsignedbv_typet bv8{8};
+  const symbol_exprt i{"i", bv8};
+  const exists_exprt quantified{i, equal_exprt{i, from_integer(0, bv8)}};
+  const std::string quant = "(exists ((i (_ BitVec 8))) (= i (_ bv0 8)))";
+
+  GIVEN("a quantified Boolean expression and the Z3 solver")
+  {
+    const std::string out = convert_handle(quantified, smt2_convt::solvert::Z3);
+    INFO("SMT2 output:\n" << out);
+
+    THEN("it is declared and constrained by two implications, in order")
+    {
+      // A single `(assert (= B0 <quantifier>))` would be undone by Z3's
+      // solve_eqs preprocessor (Z3Prover/z3#7743), so the equivalence is
+      // emitted as two implications, B0 => <q> followed by <q> => B0.
+      const std::string declare = "(declare-fun B0 () Bool)";
+      const std::string impl1 = "(assert (=> B0 " + quant + "))";
+      const std::string impl2 = "(assert (=> " + quant + " B0))";
+
+      const auto p_declare = out.find(declare);
+      const auto p_impl1 = out.find(impl1);
+      const auto p_impl2 = out.find(impl2);
+
+      REQUIRE(p_declare != std::string::npos);
+      REQUIRE(p_impl1 != std::string::npos);
+      REQUIRE(p_impl2 != std::string::npos);
+      REQUIRE(p_declare < p_impl1);
+      REQUIRE(p_impl1 < p_impl2);
+      // no plain equality definition
+      REQUIRE(out.find("(assert (= B0 ") == std::string::npos);
+    }
+  }
+
+  GIVEN("a quantified Boolean expression and a generic solver")
+  {
+    const std::string out =
+      convert_handle(quantified, smt2_convt::solvert::GENERIC);
+    INFO("SMT2 output:\n" << out);
+
+    THEN("it is declared and constrained by a single equality")
+    {
+      // The Z3-specific solve_eqs workaround is not applied to other solvers.
+      const std::string declare = "(declare-fun B0 () Bool)";
+      const std::string equality = "(assert (= B0 " + quant + "))";
+
+      REQUIRE(out.find(declare) != std::string::npos);
+      REQUIRE(out.find(equality) != std::string::npos);
+      // no implication-based workaround
+      REQUIRE(out.find("(assert (=> ") == std::string::npos);
+    }
+  }
 }


### PR DESCRIPTION
Until the Z3 bug-fix (see Z3Prover/z3#7743) is available widely work around the problem that Z3's preprocessing introduces by adding extra symbols. This may cause solving to take longer, to be determined empirically.

Fixes: #8679

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
