### PR TITLE
Value-set supported simplifier: add object_size, is_invalid_pointer

### DIFF
--- a/src/goto-symex/simplify_expr_with_value_set.cpp
+++ b/src/goto-symex/simplify_expr_with_value_set.cpp
@@ -10,6 +10,7 @@ Author: Michael Tautschnig
 
 #include <util/expr_util.h>
 #include <util/pointer_expr.h>
+#include <util/pointer_offset_size.h>
 #include <util/simplify_expr.h>
 #include <util/ssa_expr.h>
 
@@ -188,10 +189,22 @@ simplify_expr_with_value_sett::simplify_inequality_pointer_object(
           objects.clear();
           break;
         }
-
-        objects.insert(
-          to_object_descriptor_expr(value_set_element).root_object());
+        else if(value_set_element.id() == ID_null_object)
+        {
+          // make sure all NULL objects being considered look the same
+          objects.insert(exprt{ID_null_object, empty_typet{}});
+        }
+        else
+        {
+          objects.insert(
+            to_object_descriptor_expr(value_set_element).root_object());
+        }
       }
+    }
+    else if(
+      pointer.is_constant() && to_constant_expr(pointer).is_null_pointer())
+    {
+      objects.insert(exprt{ID_null_object, empty_typet{}});
     }
     return objects;
   };
@@ -280,4 +293,100 @@ simplify_expr_with_value_sett::simplify_pointer_offset(
 
   return changed(
     simplify_rec(typecast_exprt::conditional_cast(*offset, expr.type())));
+}
+
+simplify_exprt::resultt<> simplify_expr_with_value_sett::simplify_object_size(
+  const object_size_exprt &expr)
+{
+  const exprt &ptr = expr.pointer();
+
+  if(ptr.type().id() != ID_pointer)
+    return unchanged(expr);
+
+  const ssa_exprt *ssa_symbol_expr = expr_try_dynamic_cast<ssa_exprt>(ptr);
+
+  if(!ssa_symbol_expr)
+    return simplify_exprt::simplify_object_size(expr);
+
+  ssa_exprt l1_expr{*ssa_symbol_expr};
+  l1_expr.remove_level_2();
+  const std::vector<exprt> value_set_elements =
+    value_set.get_value_set(l1_expr, ns);
+
+  std::optional<exprt> object_size;
+
+  for(const auto &value_set_element : value_set_elements)
+  {
+    if(
+      value_set_element.id() == ID_unknown ||
+      value_set_element.id() == ID_invalid ||
+      is_failed_symbol(
+        to_object_descriptor_expr(value_set_element).root_object()) ||
+      to_object_descriptor_expr(value_set_element).offset().id() == ID_unknown)
+    {
+      object_size.reset();
+      break;
+    }
+
+    auto this_object_size_opt = size_of_expr(
+      to_object_descriptor_expr(value_set_element).root_object().type(), ns);
+    if(
+      !this_object_size_opt.has_value() ||
+      (object_size.has_value() && *this_object_size_opt != *object_size))
+    {
+      object_size.reset();
+      break;
+    }
+    else if(!object_size.has_value())
+    {
+      object_size = this_object_size_opt;
+    }
+  }
+
+  if(!object_size.has_value())
+    return simplify_exprt::simplify_object_size(expr);
+
+  return changed(
+    simplify_rec(typecast_exprt::conditional_cast(*object_size, expr.type())));
+}
+
+simplify_exprt::resultt<>
+simplify_expr_with_value_sett::simplify_is_invalid_pointer(
+  const unary_exprt &expr)
+{
+  const exprt &ptr = expr.op();
+
+  if(ptr.type().id() != ID_pointer)
+    return unchanged(expr);
+
+  const ssa_exprt *ssa_symbol_expr = expr_try_dynamic_cast<ssa_exprt>(ptr);
+
+  if(!ssa_symbol_expr)
+    return simplify_exprt::simplify_is_invalid_pointer(expr);
+
+  ssa_exprt l1_expr{*ssa_symbol_expr};
+  l1_expr.remove_level_2();
+  const std::vector<exprt> value_set_elements =
+    value_set.get_value_set(l1_expr, ns);
+
+  bool all_valid = !value_set_elements.empty();
+
+  for(const auto &value_set_element : value_set_elements)
+  {
+    if(
+      value_set_element.id() == ID_unknown ||
+      value_set_element.id() == ID_invalid ||
+      is_failed_symbol(
+        to_object_descriptor_expr(value_set_element).root_object()) ||
+      to_object_descriptor_expr(value_set_element).offset().id() == ID_unknown)
+    {
+      all_valid = false;
+      break;
+    }
+  }
+
+  if(all_valid)
+    return changed(static_cast<exprt>(false_exprt{}));
+  else
+    return simplify_exprt::simplify_is_invalid_pointer(expr);
 }

--- a/src/goto-symex/simplify_expr_with_value_set.h
+++ b/src/goto-symex/simplify_expr_with_value_set.h
@@ -31,6 +31,10 @@ public:
   [[nodiscard]] resultt<>
   simplify_inequality_pointer_object(const binary_relation_exprt &) override;
   [[nodiscard]] resultt<>
+  simplify_is_invalid_pointer(const unary_exprt &) override;
+  [[nodiscard]] resultt<>
+  simplify_object_size(const object_size_exprt &) override;
+  [[nodiscard]] resultt<>
   simplify_pointer_offset(const pointer_offset_exprt &) override;
 
 protected:

--- a/src/util/simplify_expr_class.h
+++ b/src/util/simplify_expr_class.h
@@ -193,9 +193,11 @@ public:
   [[nodiscard]] resultt<> simplify_pointer_object(const pointer_object_exprt &);
   [[nodiscard]] resultt<>
   simplify_unary_pointer_predicate_preorder(const unary_exprt &);
-  [[nodiscard]] resultt<> simplify_object_size(const object_size_exprt &);
+  [[nodiscard]] virtual resultt<>
+  simplify_object_size(const object_size_exprt &);
   [[nodiscard]] resultt<> simplify_is_dynamic_object(const unary_exprt &);
-  [[nodiscard]] resultt<> simplify_is_invalid_pointer(const unary_exprt &);
+  [[nodiscard]] virtual resultt<>
+  simplify_is_invalid_pointer(const unary_exprt &);
   [[nodiscard]] resultt<> simplify_object(const exprt &);
   [[nodiscard]] resultt<> simplify_unary_minus(const unary_minus_exprt &);
   [[nodiscard]] resultt<> simplify_unary_plus(const unary_plus_exprt &);


### PR DESCRIPTION
We can also use the value set to simplify `object_size` and `is_invalid_pointer` expressions.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
