### PR TITLE
Simplify WITH expression over structs with a single component

### DIFF
--- a/regression/cbmc/havoc_slice/functional_slice_bytes.desc
+++ b/regression/cbmc/havoc_slice/functional_slice_bytes.desc
@@ -1,10 +1,12 @@
 CORE
 functional.c
 -DN=4 -DSLICE_BYTES --program-only
+WITH \[.*i!0@1#2:=\{ \.coeffs=byte_extract
 ^EXIT=0$
 ^SIGNAL=0$
 --
 byte_update
+WITH \[.*i!0@1#2:=\{ \{ \.coeffs=\{
 --
 We want these tests not to produce any byte_update expressions, but instead want
 updates at specific array indices.

--- a/src/util/simplify_expr.cpp
+++ b/src/util/simplify_expr.cpp
@@ -1470,14 +1470,14 @@ simplify_exprt::resultt<> simplify_exprt::simplify_with(const with_exprt &expr)
     expr.old().type().id() == ID_struct ||
     expr.old().type().id() == ID_struct_tag)
   {
+    const struct_typet &old_type_followed =
+      expr.old().type().id() == ID_struct_tag
+        ? ns.follow_tag(to_struct_tag_type(expr.old().type()))
+        : to_struct_type(expr.old().type());
+    const irep_idt &component_name = expr.where().get(ID_component_name);
+
     if(expr.old().id() == ID_struct || expr.old().is_constant())
     {
-      const irep_idt &component_name = expr.where().get(ID_component_name);
-
-      const struct_typet &old_type_followed =
-        expr.old().type().id() == ID_struct_tag
-          ? ns.follow_tag(to_struct_tag_type(expr.old().type()))
-          : to_struct_type(expr.old().type());
       if(!old_type_followed.has_component(component_name))
         return unchanged(expr);
 
@@ -1489,6 +1489,12 @@ simplify_exprt::resultt<> simplify_exprt::simplify_with(const with_exprt &expr)
       exprt result = expr.old();
       result.operands()[number] = expr.new_value();
       return result;
+    }
+    else if(
+      old_type_followed.components().size() == 1 &&
+      old_type_followed.has_component(component_name))
+    {
+      return struct_exprt{{expr.new_value()}, expr.type()};
     }
   }
   else if(


### PR DESCRIPTION
When updating the sole member of a struct we can just use the new value.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
