### PR TITLE
Incremental SMT2 back-end: support _Bool casts

### DIFF
--- a/regression/cbmc/Bool/bool2.desc
+++ b/regression/cbmc/Bool/bool2.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 bool2.c
 
 ^EXIT=0$

--- a/regression/cbmc/Bool/bool3.desc
+++ b/regression/cbmc/Bool/bool3.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 bool3.c
 --json-ui
 ^EXIT=10$

--- a/regression/cbmc/c99_Bool/test.desc
+++ b/regression/cbmc/c99_Bool/test.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 main.c
 --function foo
 ^EXIT=0$

--- a/src/solvers/smt2_incremental/convert_expr_to_smt.cpp
+++ b/src/solvers/smt2_incremental/convert_expr_to_smt.cpp
@@ -182,6 +182,8 @@ extension_for_type(const typet &type)
     return smt_bit_vector_theoryt::zero_extend;
   if(can_cast_type<pointer_typet>(type))
     return smt_bit_vector_theoryt::zero_extend;
+  if(can_cast_type<c_bool_typet>(type))
+    return smt_bit_vector_theoryt::zero_extend;
   UNREACHABLE;
 }
 

--- a/unit/solvers/smt2_incremental/convert_expr_to_smt.cpp
+++ b/unit/solvers/smt2_incremental/convert_expr_to_smt.cpp
@@ -1423,6 +1423,7 @@ TEST_CASE("expr to smt conversion for type casts", "[core][smt2_incremental]")
       using make_typet = std::function<typet(std::size_t)>;
       const make_typet make_unsigned = constructor_oft<unsignedbv_typet>{};
       const make_typet make_signed = constructor_oft<signedbv_typet>{};
+      const make_typet make_c_bool = constructor_oft<c_bool_typet>{};
       using make_extensiont =
         std::function<std::function<smt_termt(smt_termt)>(std::size_t)>;
       const make_extensiont zero_extend = smt_bit_vector_theoryt::zero_extend;
@@ -1435,7 +1436,8 @@ TEST_CASE("expr to smt conversion for type casts", "[core][smt2_incremental]")
           types_rowt{make_unsigned, make_unsigned, zero_extend},
           types_rowt{make_signed, make_signed, sign_extend},
           types_rowt{make_signed, make_unsigned, sign_extend},
-          types_rowt{make_unsigned, make_signed, zero_extend});
+          types_rowt{make_unsigned, make_signed, zero_extend},
+          types_rowt{make_c_bool, make_unsigned, zero_extend});
       const typecast_exprt cast{
         from_integer(42, make_source_type(from_width)),
         make_destination_type(to_width)};


### PR DESCRIPTION
Added an extra case in `extension_for_type` to handle conversion between C boolean types and C integers by using zero extension.

Fixes: #8069

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
