### PR TITLE
Add clock_gettime model

### DIFF
--- a/regression/cbmc-library/clock_gettime-01/main.c
+++ b/regression/cbmc-library/clock_gettime-01/main.c
@@ -1,0 +1,67 @@
+#include <assert.h>
+#include <errno.h>
+#include <stdint.h>
+#include <time.h>
+
+// MSVC doesn't have CLOCK_* macros
+#ifdef _WIN32
+#  define CLOCK_MONOTONIC 1
+#  define CLOCK_REALTIME 1
+int clock_gettime(int clockid, struct timespec *tp);
+#endif
+
+// Test function from the issue description
+uint32_t my_time(void)
+{
+  struct timespec t;
+  int ret = clock_gettime(CLOCK_MONOTONIC, &t);
+
+  // If clock_gettime fails, return a safe value
+  if(ret != 0)
+  {
+    return 0;
+  }
+
+  return (t.tv_nsec / 1000000) + ((t.tv_sec % 86400) * 1000);
+}
+
+int main()
+{
+  // Test null pointer behavior
+  int result_null = clock_gettime(CLOCK_REALTIME, 0);
+  if(result_null == -1)
+  {
+    // errno should be set to EFAULT for null pointer
+    assert(errno == EFAULT);
+  }
+
+  struct timespec ts;
+
+  // Test basic functionality with different clock types
+  int result1 = clock_gettime(CLOCK_REALTIME, &ts);
+  assert(result1 == 0 || result1 == -1);
+
+  if(result1 == 0)
+  {
+    // If successful, tv_nsec should be in valid range
+    assert(ts.tv_nsec >= 0 && ts.tv_nsec <= 999999999L);
+  }
+
+  // Test with CLOCK_MONOTONIC
+  int result2 = clock_gettime(CLOCK_MONOTONIC, &ts);
+  assert(result2 == 0 || result2 == -1);
+
+  if(result2 == 0)
+  {
+    // If successful, tv_nsec should be in valid range
+    assert(ts.tv_nsec >= 0 && ts.tv_nsec <= 999999999L);
+  }
+
+  // Test the my_time function from the issue
+  // Note: my_time() handles the failure case internally
+  uint32_t time_result = my_time();
+  // Should return either 0 (on failure) or valid millisecond value within a day
+  assert(time_result < 86400000 || time_result == 0);
+
+  return 0;
+}

--- a/regression/cbmc-library/clock_gettime-01/test.desc
+++ b/regression/cbmc-library/clock_gettime-01/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+--pointer-check --bounds-check
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring

--- a/src/ansi-c/library/time.c
+++ b/src/ansi-c/library/time.c
@@ -280,3 +280,72 @@ __CPROVER_size_t _strftime(
   s[length] = '\0';
   return length;
 }
+
+/* FUNCTION: clock_gettime */
+
+#ifndef __CPROVER_TIME_H_INCLUDED
+#  include <time.h>
+#  define __CPROVER_TIME_H_INCLUDED
+#endif
+
+#ifndef __CPROVER_ERRNO_H_INCLUDED
+#  include <errno.h>
+#  define __CPROVER_ERRNO_H_INCLUDED
+#endif
+
+int __VERIFIER_nondet_int(void);
+time_t __VERIFIER_nondet_time_t(void);
+long __VERIFIER_nondet_long(void);
+
+#ifdef _WIN32
+typedef int clockid_t;
+#endif
+
+int clock_gettime(clockid_t clockid, struct timespec *tp)
+{
+__CPROVER_HIDE:;
+
+  // Use the clockid parameter (all clock types are modeled the same way)
+  (void)clockid;
+
+  // Check for null pointer - should set errno to EFAULT
+  // Some systems have C headers where `tp` is annotated to be nonnull
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wnonnull-compare"
+  if(!tp)
+  {
+    errno = EFAULT;
+    return -1;
+  }
+#pragma GCC diagnostic pop
+
+  // Non-deterministically choose success or failure
+  int result = __VERIFIER_nondet_int();
+
+  if(result == 0)
+  {
+    // Success case: fill in the timespec structure with non-deterministic but valid values
+    time_t sec = __VERIFIER_nondet_time_t();
+    // Assume reasonable time values (non-negative for typical use cases)
+    __CPROVER_assume(sec >= 0);
+    tp->tv_sec = sec;
+
+    // Nanoseconds should be between 0 and 999,999,999
+    long nanosec = __VERIFIER_nondet_long();
+    __CPROVER_assume(nanosec >= 0 && nanosec <= 999999999L);
+    tp->tv_nsec = nanosec;
+
+    return 0;
+  }
+  else
+  {
+    // Failure case: set errno and return -1
+    int error_code = __VERIFIER_nondet_int();
+    // Most common error codes for clock_gettime
+    __CPROVER_assume(
+      error_code == EINVAL || error_code == EACCES || error_code == ENODEV ||
+      error_code == ENOTSUP || error_code == EOVERFLOW || error_code == EPERM);
+    errno = error_code;
+    return -1;
+  }
+}


### PR DESCRIPTION
Add a library model for `clock_gettime`:
- Model follows POSIX specification with proper error handling
- Non-deterministic behavior covers both success and failure paths
- Validates timespec structure with appropriate constraints
- Sets errno correctly (EFAULT for null pointer, EINVAL on failure)

Fixes: #7639

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
