### PR TITLE
Replace deprecated upload-release-asset with action-gh-release

### DIFF
--- a/.github/workflows/release-packages.yaml
+++ b/.github/workflows/release-packages.yaml
@@ -57,16 +57,12 @@ jobs:
           deb_package_name="$(ls *.deb)"
           echo "deb_package=./build/$deb_package_name" >> $GITHUB_OUTPUT
           echo "deb_package_name=ubuntu-24.04-$deb_package_name" >> $GITHUB_OUTPUT
-      - name: Get release info
-        id: get_release_info
-        uses: bruceadams/get-release@v1.3.2
+      - name: Rename package for release
+        run: cp ${{ steps.create_packages.outputs.deb_package }} ${{ steps.create_packages.outputs.deb_package_name }}
       - name: Upload binary packages
-        uses: actions/upload-release-asset@v1
+        uses: softprops/action-gh-release@v2
         with:
-          upload_url: ${{ steps.get_release_info.outputs.upload_url }}
-          asset_path: ${{ steps.create_packages.outputs.deb_package }}
-          asset_name: ${{ steps.create_packages.outputs.deb_package_name }}
-          asset_content_type: application/x-deb
+          files: ${{ steps.create_packages.outputs.deb_package_name }}
       - name: Slack notification of CI status
         uses: rtCamp/action-slack-notify@v2
         if: success() || failure()
@@ -128,16 +124,12 @@ jobs:
           deb_package_name="$(ls *.deb)"
           echo "deb_package=./build/$deb_package_name" >> $GITHUB_OUTPUT
           echo "deb_package_name=ubuntu-24.04-arm64-$deb_package_name" >> $GITHUB_OUTPUT
-      - name: Get release info
-        id: get_release_info
-        uses: bruceadams/get-release@v1.3.2
+      - name: Rename package for release
+        run: cp ${{ steps.create_packages.outputs.deb_package }} ${{ steps.create_packages.outputs.deb_package_name }}
       - name: Upload binary packages
-        uses: actions/upload-release-asset@v1
+        uses: softprops/action-gh-release@v2
         with:
-          upload_url: ${{ steps.get_release_info.outputs.upload_url }}
-          asset_path: ${{ steps.create_packages.outputs.deb_package }}
-          asset_name: ${{ steps.create_packages.outputs.deb_package_name }}
-          asset_content_type: application/x-deb
+          files: ${{ steps.create_packages.outputs.deb_package_name }}
       - name: Slack notification of CI status
         uses: rtCamp/action-slack-notify@v2
         if: success() || failure()
@@ -199,16 +191,12 @@ jobs:
           deb_package_name="$(ls *.deb)"
           echo "deb_package=./build/$deb_package_name" >> $GITHUB_OUTPUT
           echo "deb_package_name=ubuntu-22.04-$deb_package_name" >> $GITHUB_OUTPUT
-      - name: Get release info
-        id: get_release_info
-        uses: bruceadams/get-release@v1.3.2
+      - name: Rename package for release
+        run: cp ${{ steps.create_packages.outputs.deb_package }} ${{ steps.create_packages.outputs.deb_package_name }}
       - name: Upload binary packages
-        uses: actions/upload-release-asset@v1
+        uses: softprops/action-gh-release@v2
         with:
-          upload_url: ${{ steps.get_release_info.outputs.upload_url }}
-          asset_path: ${{ steps.create_packages.outputs.deb_package }}
-          asset_name: ${{ steps.create_packages.outputs.deb_package_name }}
-          asset_content_type: application/x-deb
+          files: ${{ steps.create_packages.outputs.deb_package_name }}
       - name: Slack notification of CI status
         uses: rtCamp/action-slack-notify@v2
         if: success() || failure()
@@ -351,16 +339,10 @@ jobs:
         id: verify_codesign
         run: |
           & signtool.exe verify /pa ${{ steps.create_packages.outputs.msi_installer }}
-      - name: Get release info
-        id: get_release_info
-        uses: bruceadams/get-release@v1.3.2
       - name: Upload binary packages
-        uses: actions/upload-release-asset@v1
+        uses: softprops/action-gh-release@v2
         with:
-          upload_url: ${{ steps.get_release_info.outputs.upload_url }}
-          asset_path: ${{ steps.create_packages.outputs.msi_installer }}
-          asset_name: ${{ steps.create_packages.outputs.msi_name }}
-          asset_content_type: application/x-msi
+          files: ${{ steps.create_packages.outputs.msi_installer }}
       - name: Slack notification of CI status
         if: success() || failure()
         env:


### PR DESCRIPTION
This is the recommended replacement and is also what we are already using successfully in, e.g., cbmc-viewer.

Fixes: #7280

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
