### PR TITLE
Makefile builds: do not inherit SRC from environment in big-int

### DIFF
--- a/src/big-int/makefile
+++ b/src/big-int/makefile
@@ -1,7 +1,8 @@
+SRC = bigint-func.cc bigint.cc
+
 include ../config.inc
 include ../common
 
-SRC = bigint-func.cc bigint.cc
 CLEANFILES = big-int$(LIBEXT)
 
 all: big-int$(LIBEXT)

--- a/src/common
+++ b/src/common
@@ -270,6 +270,7 @@ sources: Makefile
 # endif
 
 D_FILES1 = $(SRC:.c=$(DEPEXT))
-D_FILES = $(D_FILES1:.cpp=$(DEPEXT))
+D_FILES2 = $(D_FILES1:.cc=$(DEPEXT))
+D_FILES = $(D_FILES2:.cpp=$(DEPEXT))
 
 -include $(D_FILES)


### PR DESCRIPTION
In just `src/big-int` we were including `common` before defining `SRC`,
which meant a possible environment-defined value of `SRC` was being used
to construct some rules. The possible reason for having the `include`
earlier in just that file was that we were lacking a rule for `.cc`
files, the absence of which caused `make` to fail when sourcing `common`
after setting `SRC`.

Both fixes together now ensure that even an environment with `SRC` set
won't cause builds to fail in strange ways.

Fixes: #4834

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
