### PR TITLE
Update COMPILING.md with .tar.gz build instructions

### DIFF
--- a/COMPILING.md
+++ b/COMPILING.md
@@ -67,6 +67,22 @@ files.
    ```
    git submodule update --init
    ```
+   **Note for .tar.gz source releases**: If you downloaded CBMC as a `.tar.gz`
+   archive from GitHub releases (rather than cloning the git repository), the
+   git submodules will not be included. This primarily affects JBMC compilation,
+   which requires the `java-models-library` submodule. You have two options:
+
+   - **Option 1: Download java-models-library** (required for JBMC):
+     ```
+     curl -L https://github.com/diffblue/java-models-library/archive/refs/heads/master.tar.gz | tar xz
+     mkdir -p jbmc/lib
+     mv java-models-library-master jbmc/lib/java-models-library
+     ```
+
+   - **Option 2: Disable JBMC compilation** (see step 4 below):
+     If you don't need JBMC, you can skip the submodule setup and disable JBMC
+     by passing `-DWITH_JBMC=OFF` to CMake in step 4.
+
 4. Generate build files with CMake:
    ```
    cmake -S . -Bbuild
@@ -173,6 +189,9 @@ We assume that you have a Debian/Ubuntu or Red Hat-like distribution.
    git clone https://github.com/diffblue/cbmc cbmc-git
    cd cbmc-git
    ```
+   **Note for .tar.gz source releases**: If you downloaded CBMC as a `.tar.gz`
+   archive from GitHub releases, extract it and `cd` into the extracted
+   directory instead of using the `git clone` command above.
 
 3. To compile, do
    ```
@@ -185,6 +204,16 @@ We assume that you have a Debian/Ubuntu or Red Hat-like distribution.
 4. To compile JBMC, do
    ```
    make -C jbmc/src setup-submodules
+   make -C jbmc/src
+   ```
+   **Note for .tar.gz source releases**: The `setup-submodules` target uses
+   `git submodule update --init`, which only works when building from a git
+   repository clone. If you downloaded a `.tar.gz` release, you must
+   download the java-models-library before compiling JBMC:
+   ```
+   curl -L https://github.com/diffblue/java-models-library/archive/refs/heads/master.tar.gz | tar xz
+   mkdir -p jbmc/lib
+   mv java-models-library-master jbmc/lib/java-models-library
    make -C jbmc/src
    ```
 
@@ -203,6 +232,10 @@ Follow these instructions:
    git clone https://github.com/diffblue/cbmc cbmc-git
    cd cbmc-git
    ```
+   **Note for .tar.gz source releases**: If you downloaded CBMC as a `.tar.gz`
+   archive from GitHub releases, extract it and `cd` into the extracted
+   directory instead of using the `git clone` command above.
+
 3. To compile CBMC, do
    ```
    make -C src minisat2-download
@@ -212,6 +245,16 @@ Follow these instructions:
    manually. Then do
    ```
    make -C jbmc/src setup-submodules
+   make -C jbmc/src
+   ```
+   **Note for .tar.gz source releases**: The `setup-submodules` target uses
+   `git submodule update --init`, which only works when building from a git
+   repository clone. If you downloaded a `.tar.gz` release, you must
+   download the java-models-library before compiling JBMC:
+   ```
+   curl -L https://github.com/diffblue/java-models-library/archive/refs/heads/master.tar.gz | tar xz
+   mkdir -p jbmc/lib
+   mv java-models-library-master jbmc/lib/java-models-library
    make -C jbmc/src
    ```
 
@@ -229,6 +272,10 @@ Maven 3 manually.
    git clone https://github.com/diffblue/cbmc cbmc-git
    cd cbmc-git
    ```
+   **Note for .tar.gz source releases**: If you downloaded CBMC as a `.tar.gz`
+   archive from GitHub releases, extract it and `cd` into the extracted
+   directory instead of using the `git clone` command above.
+
 3. To compile CBMC, type
    ```
    gmake -C src minisat2-download DOWNLOADER=wget TAR=gtar
@@ -237,6 +284,16 @@ Maven 3 manually.
 4. To compile JBMC, type
    ```
    gmake -C jbmc/src setup-submodules
+   gmake -C jbmc/src
+   ```
+   **Note for .tar.gz source releases**: The `setup-submodules` target uses
+   `git submodule update --init`, which only works when building from a git
+   repository clone. If you downloaded a `.tar.gz` release, you must
+   download the java-models-library before compiling JBMC:
+   ```
+   wget -O - https://github.com/diffblue/java-models-library/archive/refs/heads/master.tar.gz | gtar xz
+   mkdir -p jbmc/lib
+   mv java-models-library-master jbmc/lib/java-models-library
    gmake -C jbmc/src
    ```
 
@@ -255,6 +312,10 @@ Maven 3 manually.
    git clone https://github.com/diffblue/cbmc cbmc-git
    cd cbmc-git
    ```
+   **Note for .tar.gz source releases**: If you downloaded CBMC as a `.tar.gz`
+   archive from GitHub releases, extract it and `cd` into the extracted
+   directory instead of using the `git clone` command above.
+
 3. To compile CBMC, do
    ```
    gmake -C src minisat2-download
@@ -265,8 +326,18 @@ Maven 3 manually.
    gmake -C jbmc/src setup-submodules
    gmake -C jbmc/src
    ```
+   **Note for .tar.gz source releases**: The `setup-submodules` target uses
+   `git submodule update --init`, which only works when building from a git
+   repository clone. If you downloaded a `.tar.gz` release, you must
+   download the java-models-library before compiling JBMC:
+   ```
+   wget -O - https://github.com/diffblue/java-models-library/archive/refs/heads/master.tar.gz | tar xz
+   mkdir -p jbmc/lib
+   mv java-models-library-master jbmc/lib/java-models-library
+   gmake -C jbmc/src
+   ```
 
-#Working with IDEs and Docker
+# Working with IDEs and Docker
 
 ## Working with Visual Studio on Windows
 


### PR DESCRIPTION
Add documentation for building from .tar.gz releases:
- Instructions to manually clone java-models-library
- Clear distinction between git vs .tar.gz builds

Fixes: #7724

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [x] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- n/a Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
