### PR TITLE
Fix static lifetime pointer initialization dependency ordering

### DIFF
--- a/regression/cbmc/static_init_chain/main.c
+++ b/regression/cbmc/static_init_chain/main.c
@@ -1,0 +1,31 @@
+#include <assert.h>
+
+// Test case for chained static initialization dependencies
+// Tests: A -> B -> C dependency chain
+//
+// According to C standard (C99/C11):
+// - Section 6.7.9 paragraph 4: All expressions in an initializer for an
+//   object that has static storage duration shall be constant expressions.
+// - Section 6.6 paragraph 9: An address constant is a pointer to an lvalue
+//   designating an object of static storage duration.
+//
+// This means c_int must be initialized before b_ptr (which points to it),
+// and b_ptr must be initialized before a_ptr_ptr (which points to it).
+
+static int c_int = 42;
+static int *b_ptr = &c_int;
+static int **a_ptr_ptr = &b_ptr;
+
+int main()
+{
+  // Verify the entire chain is correctly initialized
+  assert(a_ptr_ptr != 0);
+  assert(*a_ptr_ptr != 0);
+  assert(**a_ptr_ptr == 42);
+
+  // Verify pointer values are correct
+  assert(*a_ptr_ptr == b_ptr);
+  assert(**a_ptr_ptr == c_int);
+
+  return 0;
+}

--- a/regression/cbmc/static_init_chain/test.desc
+++ b/regression/cbmc/static_init_chain/test.desc
@@ -1,0 +1,7 @@
+CORE
+main.c
+
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--

--- a/regression/cbmc/static_init_cycle/main.c
+++ b/regression/cbmc/static_init_cycle/main.c
@@ -1,0 +1,18 @@
+#include <assert.h>
+
+// Mutually-referential static address constants: a's initializer takes the
+// address of b and b's initializer takes the address of a. This is valid C
+// and forms a dependency cycle for static initialization. CBMC must break the
+// cycle (the chosen order is not semantically significant here) and initialize
+// both objects, rather than crashing or leaving a pointer uninitialized.
+
+extern int *b;
+int *a = (int *)&b;
+int *b = (int *)&a;
+
+int main()
+{
+  assert(a == (int *)&b);
+  assert(b == (int *)&a);
+  return 0;
+}

--- a/regression/cbmc/static_init_cycle/test.desc
+++ b/regression/cbmc/static_init_cycle/test.desc
@@ -1,0 +1,11 @@
+CORE
+main.c
+--pointer-check
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+Regression for mutually-referential static address constants, which form a
+dependency cycle in static initialization (see static_lifetime_init.cpp). The
+cycle is broken deterministically and both pointers are initialized; with
+--pointer-check this also confirms neither is left as an invalid pointer.

--- a/regression/cbmc/static_pointer_init_order/main.c
+++ b/regression/cbmc/static_pointer_init_order/main.c
@@ -1,0 +1,33 @@
+#include <assert.h>
+#include <stdint.h>
+#include <string.h>
+
+#define PACKETBUF_SIZE 128
+
+// Test case for GitHub issue #8593
+// When a pointer is initialized outside a function with a cast expression
+// pointing to another static storage duration object, CBMC should properly
+// handle the dependency and not mark the pointer as invalid.
+
+static uint32_t packetbuf_aligned[(PACKETBUF_SIZE + 3) / 4];
+// This pointer initialization depends on packetbuf_aligned being initialized first
+uint8_t *packetbuf = (uint8_t *)packetbuf_aligned;
+
+int main()
+{
+  uint16_t channelId = 0x1234;
+  uint8_t *data = packetbuf;
+
+  // This should not fail - data should point to valid memory
+  assert(data != 0);
+
+  // Write some data
+  memcpy(data, &channelId, 2);
+
+  // Verify the data was written correctly
+  uint16_t result;
+  memcpy(&result, data, 2);
+  assert(result == channelId);
+
+  return 0;
+}

--- a/regression/cbmc/static_pointer_init_order/test.desc
+++ b/regression/cbmc/static_pointer_init_order/test.desc
@@ -1,0 +1,10 @@
+CORE
+main.c
+--pointer-check
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+This reproduces GitHub issue #8593: a static pointer initialized from a cast of
+another static object's address used to surface as an invalid pointer.
+--pointer-check exercises that original failure mode directly.

--- a/src/linking/static_lifetime_init.cpp
+++ b/src/linking/static_lifetime_init.cpp
@@ -11,6 +11,8 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/arith_tools.h>
 #include <util/c_types.h>
 #include <util/expr_initializer.h>
+#include <util/find_symbols.h>
+#include <util/invariant.h>
 #include <util/namespace.h>
 #include <util/prefix.h>
 #include <util/std_code.h>
@@ -21,6 +23,153 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <ansi-c/goto-conversion/goto_convert_functions.h>
 
 #include <set>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+using dependency_mapt =
+  std::unordered_map<irep_idt, std::unordered_set<irep_idt>>;
+
+/// Build a dependency graph for static lifetime objects.
+/// Returns a map from symbol identifier to the set of identifiers it depends
+/// on.  According to C standard (C99/C11 Section 6.7.9 and 6.6 paragraph 9):
+/// - Objects with static storage duration can be initialized with constant
+///   expressions or string literals
+/// - An address constant is a pointer to an lvalue designating an object of
+///   static storage duration
+/// - When a static object's initializer references another static object,
+///   that referenced object must be initialized first to maintain proper
+///   initialization order
+static dependency_mapt build_static_initialization_dependencies(
+  const std::set<std::string> &symbols,
+  const namespacet &ns)
+{
+  dependency_mapt dependencies;
+
+  for(const std::string &id : symbols)
+  {
+    const symbolt &symbol = ns.lookup(id);
+
+    // Only track dependencies for objects with static lifetime that have
+    // initializers
+    if(
+      !symbol.is_static_lifetime || symbol.is_type || symbol.is_macro ||
+      symbol.type.id() == ID_code || symbol.type.id() == ID_empty)
+    {
+      continue;
+    }
+
+    // Skip if no initializer or nondet initializer (either as a direct
+    // ID_nondet or as a side_effect nondet expression)
+    if(
+      symbol.value.is_nil() || symbol.value.id() == ID_nondet ||
+      (symbol.value.id() == ID_side_effect &&
+       to_side_effect_expr(symbol.value).get_statement() == ID_nondet))
+    {
+      continue;
+    }
+
+    // Find all symbols referenced in the initializer.  Note that
+    // find_symbol_identifiers also reports identifiers referenced from types
+    // nested in the initializer (e.g. a size symbol in an array type), not
+    // just value sub-expressions.  This only ever over-approximates the
+    // dependency set, which is safe (harmless) for initialization ordering.
+    find_symbols_sett referenced_symbols =
+      find_symbol_identifiers(symbol.value);
+
+    // Add dependencies on other static lifetime objects
+    for(const irep_idt &ref_id : referenced_symbols)
+    {
+      // Skip self-references
+      if(ref_id == symbol.name)
+        continue;
+
+      // Check if the referenced symbol is in our set of symbols to initialize
+      if(symbols.find(id2string(ref_id)) == symbols.end())
+        continue;
+
+      // Verify it's a static lifetime object
+      if(ns.lookup(ref_id).is_static_lifetime)
+        dependencies[symbol.name].insert(ref_id);
+    }
+  }
+
+  return dependencies;
+}
+
+/// Depth-first post-order visit of \p id and the static objects its
+/// initializer depends on, appending each symbol to \p result only after all
+/// of its dependencies.  Dependencies are visited in alphabetical order for
+/// reproducibility.  Cycles -- which can occur with mutually-referential
+/// address constants (e.g. two globals taking each other's addresses), valid
+/// C -- are broken by ignoring the back-edge: a node already \p in_progress is
+/// skipped, so the original visit for that node completes and emits it exactly
+/// once.
+/// \param id: symbol to visit
+/// \param symbols: the set of symbols being ordered (dependencies outside this
+///   set are ignored)
+/// \param dependencies: initialization dependency graph
+/// \param [in,out] visited: symbols already emitted to \p result
+/// \param [in,out] in_progress: symbols on the current DFS path (cycle
+///   detection)
+/// \param [in,out] result: initialization order being built
+static void topological_sort_visit(
+  const irep_idt &id,
+  const std::set<std::string> &symbols,
+  const dependency_mapt &dependencies,
+  std::unordered_set<irep_idt> &visited,
+  std::unordered_set<irep_idt> &in_progress,
+  std::vector<irep_idt> &result)
+{
+  // If already visited, nothing to do
+  if(visited.find(id) != visited.end())
+    return;
+
+  // Break cycles by ignoring the back-edge (see function documentation).
+  if(!in_progress.insert(id).second)
+    return;
+
+  // Visit all dependencies first
+  auto dep_it = dependencies.find(id);
+  if(dep_it != dependencies.end())
+  {
+    // Sort dependencies alphabetically for reproducibility
+    std::set<std::string> sorted_deps;
+    for(const irep_idt &dep : dep_it->second)
+      sorted_deps.insert(id2string(dep));
+
+    for(const std::string &dep : sorted_deps)
+    {
+      // Only visit if it's in our symbol set
+      if(symbols.find(dep) != symbols.end())
+        topological_sort_visit(
+          dep, symbols, dependencies, visited, in_progress, result);
+    }
+  }
+
+  in_progress.erase(id);
+  visited.insert(id);
+  result.push_back(id);
+}
+
+/// Perform a topological sort on symbols considering their initialization
+/// dependencies. Returns a vector of symbol identifiers in initialization
+/// order. Uses alphabetical ordering as a tiebreaker for reproducibility.
+static std::vector<irep_idt> topological_sort_with_dependencies(
+  const std::set<std::string> &symbols,
+  const dependency_mapt &dependencies)
+{
+  std::vector<irep_idt> result;
+  std::unordered_set<irep_idt> visited;
+  std::unordered_set<irep_idt> in_progress; // For cycle detection
+
+  // Process all symbols in alphabetical order for reproducibility
+  for(const std::string &id : symbols)
+    topological_sort_visit(
+      id, symbols, dependencies, visited, in_progress, result);
+
+  return result;
+}
 
 static std::optional<codet> static_lifetime_init(
   const irep_idt &identifier,
@@ -121,7 +270,22 @@ void static_lifetime_init(
 
   // do assignments based on "value"
 
-  // sort alphabetically for reproducible results
+  // Build dependency graph for static lifetime initialization.
+  // According to the C standard (C99/C11):
+  // - Section 6.7.9 paragraph 4: All expressions in an initializer for an
+  //   object that has static storage duration shall be constant expressions
+  //   or string literals.
+  // - Section 6.6 paragraph 9: An address constant is a null pointer, a pointer
+  //   to an lvalue designating an object of static storage duration, or a
+  //   pointer to a function designator.
+  // - Section 6.2.4: Objects with static storage duration are initialized
+  //   before program startup.
+  //
+  // When one static object's initializer takes the address of another static
+  // object, the referenced object must be initialized first to ensure the
+  // address constant is properly available.
+
+  // First, collect all symbols and sort alphabetically for reproducible results
   std::set<std::string> symbols;
 
   for(const auto &symbol_pair : symbol_table.symbols)
@@ -129,23 +293,58 @@ void static_lifetime_init(
     symbols.insert(id2string(symbol_pair.first));
   }
 
-  // first do framework variables
-  for(const std::string &id : symbols)
-    if(has_prefix(id, CPROVER_PREFIX))
-    {
-      auto code = static_lifetime_init(id, symbol_table);
-      if(code.has_value())
-        dest.add(std::move(*code));
-    }
+  // Build dependency graph
+  auto dependencies = build_static_initialization_dependencies(symbols, ns);
 
-  // now all other variables
+  // Separate CPROVER framework variables from user variables.
+  // Sorting each group independently is safe: CPROVER symbols are always
+  // initialized first, and cross-group dependencies (user -> CPROVER) are
+  // satisfied by that ordering.  Dependencies in the other direction
+  // (CPROVER -> user) do not occur; this is asserted below so that a future
+  // violation fails loudly rather than silently producing a wrong order.
+  std::set<std::string> cprover_symbols;
+  std::set<std::string> user_symbols;
+
   for(const std::string &id : symbols)
-    if(!has_prefix(id, CPROVER_PREFIX))
+  {
+    if(has_prefix(id, CPROVER_PREFIX))
+      cprover_symbols.insert(id);
+    else
+      user_symbols.insert(id);
+  }
+
+  // A CPROVER symbol must not depend on a user symbol: each group is sorted in
+  // isolation, so such a cross-group edge would be dropped and mis-order the
+  // initialization.
+  for(const std::string &id : cprover_symbols)
+  {
+    auto dep_it = dependencies.find(id);
+    if(dep_it != dependencies.end())
+    {
+      for(const irep_idt &dep : dep_it->second)
+      {
+        DATA_INVARIANT(
+          cprover_symbols.find(id2string(dep)) != cprover_symbols.end(),
+          "CPROVER static initializer must not depend on a user symbol");
+      }
+    }
+  }
+
+  // Initialize framework variables first, then all other variables; within
+  // each group, order by initialization dependencies.
+  const auto emit_in_dependency_order = [&](const std::set<std::string> &group)
+  {
+    for(const irep_idt &id :
+        topological_sort_with_dependencies(group, dependencies))
     {
       auto code = static_lifetime_init(id, symbol_table);
       if(code.has_value())
         dest.add(std::move(*code));
     }
+  };
+
+  emit_in_dependency_order(cprover_symbols);
+  emit_in_dependency_order(user_symbols);
 
   // now call designated "initialization" functions
 


### PR DESCRIPTION
Add dependency tracking between static objects per C standard (C99/C11 6.7.9, 6.6) and use this for static-lifetime object initialisation order.

Fixes: #8593

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
