### PR TITLE
Fix _Generic selection for pointer-to-array types

### DIFF
--- a/regression/ansi-c/_Generic_array_typedef/main.c
+++ b/regression/ansi-c/_Generic_array_typedef/main.c
@@ -1,0 +1,38 @@
+// Test case for _Generic with array typedef
+// This should reproduce the issue from GitHub issue #8243
+
+typedef struct m_string_s
+{
+  int s, a;
+  char *ptr;
+} m_string_t[1];
+
+#define TEST_GENERIC(x)                                                        \
+  _Generic((x), struct m_string_s * : 42, int : 1, float : 2, default : 99)
+
+int main(void)
+{
+  m_string_t s; // Array type that should decay to pointer
+  int i = 5;
+  float f = 3.14f;
+  char c = 'x';
+
+  // Compile-time checks: regression/ansi-c runs under goto-cc, which only
+  // compiles, so a wrong _Generic selection must be turned into a translation
+  // error via _Static_assert rather than a run-time assert that is never
+  // evaluated.
+
+  // The array typedef must decay to a pointer and match `struct m_string_s *`.
+  _Static_assert(TEST_GENERIC(s) == 42, "array typedef decays to pointer");
+
+  // Other types match as expected.
+  _Static_assert(TEST_GENERIC(i) == 1, "int");
+  _Static_assert(TEST_GENERIC(f) == 2, "float");
+  _Static_assert(TEST_GENERIC(c) == 99, "char falls to default");
+
+  (void)s;
+  (void)i;
+  (void)f;
+  (void)c;
+  return 0;
+}

--- a/regression/ansi-c/_Generic_array_typedef/test.desc
+++ b/regression/ansi-c/_Generic_array_typedef/test.desc
@@ -1,0 +1,12 @@
+CORE gcc-only
+main.c
+
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+^CONVERSION ERROR$
+--
+_Generic with array typedef should match pointer type due to array decay
+(issue #8243). The selection is verified at compile time via _Static_assert,
+since regression/ansi-c runs under goto-cc and never executes main.

--- a/regression/ansi-c/_Generic_enum/main.c
+++ b/regression/ansi-c/_Generic_enum/main.c
@@ -1,0 +1,33 @@
+// _Generic matching is by C11 compatibility. GCC and Clang do not treat an
+// enumerated type as compatible with a plain `int` controlling expression (or
+// vice versa) for the purpose of generic selection: such a controlling
+// expression falls through to `default`. This pins that CBMC behaves the same,
+// since matching now goes through gcc_types_compatible_p (which otherwise
+// relates an enum to its underlying integer type).
+//
+// Note: CBMC's _Generic parser does not accept an inline `enum E :`
+// association, so the enumerated type is referred to via a typedef.
+
+enum E
+{
+  A
+};
+typedef enum E enumE;
+
+int main(void)
+{
+  int i = 0;
+  // int controlling expression does not match the enum arm -> default.
+  _Static_assert(_Generic(i, enumE : 1, default : 2) == 2, "int -> default");
+
+  enumE e = A;
+  // enum controlling expression does not match the int arm -> default.
+  _Static_assert(_Generic(e, int : 1, default : 2) == 2, "enum -> default");
+
+  // an enum controlling expression matches its own enum arm.
+  _Static_assert(_Generic(e, enumE : 3, default : 2) == 3, "enum -> enum");
+
+  (void)i;
+  (void)e;
+  return 0;
+}

--- a/regression/ansi-c/_Generic_enum/test.desc
+++ b/regression/ansi-c/_Generic_enum/test.desc
@@ -1,0 +1,13 @@
+CORE gcc-only
+main.c
+
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+^CONVERSION ERROR$
+--
+_Generic does not treat an enum as compatible with a plain int controlling
+expression (and vice versa), matching GCC and Clang; such controlling
+expressions fall through to default. The _Static_assert checks make a wrong
+selection a compile-time error under goto-cc.

--- a/regression/ansi-c/_Generic_multiple_match/main.c
+++ b/regression/ansi-c/_Generic_multiple_match/main.c
@@ -1,0 +1,9 @@
+int main(void)
+{
+  // C11 6.5.1.1p2: no two generic associations shall specify compatible types.
+  // int(*)[5] is compatible with both int(*)[] and int(*)[5], so this generic
+  // selection is a constraint violation. GCC and Clang both reject it; CBMC
+  // must too rather than silently picking one association.
+  int arr[5];
+  return _Generic(&arr, int(*)[] : 1, int(*)[5] : 2);
+}

--- a/regression/ansi-c/_Generic_multiple_match/test.desc
+++ b/regression/ansi-c/_Generic_multiple_match/test.desc
@@ -1,0 +1,13 @@
+CORE gcc-only
+main.c
+
+^CONVERSION ERROR$
+^EXIT=(1|64)$
+^SIGNAL=0$
+--
+^VERIFICATION
+--
+C11 6.5.1.1p2: a generic selection whose controlling type is compatible with
+more than one association is a constraint violation (here int(*)[5] matches
+both int(*)[] and int(*)[5]). GCC and Clang reject this; CBMC must diagnose it
+rather than silently selecting one association.

--- a/regression/ansi-c/_Generic_pointer_to_array/main.c
+++ b/regression/ansi-c/_Generic_pointer_to_array/main.c
@@ -1,0 +1,37 @@
+#include <stdbool.h>
+
+int main(void)
+{
+  // Test case from issue #8690
+  // A generic selection on a value of type int(*)[5] should match an arm for
+  // int(*)[]. regression/ansi-c runs under goto-cc (compile only), so we use
+  // _Static_assert / no-default arms: a wrong selection becomes a translation
+  // error rather than a never-evaluated run-time assert.
+
+  // No-default arms: a non-match is a CONVERSION ERROR at compile time.
+  int arr[5];
+  (void)_Generic(&arr, int(*)[] : true);
+
+  // Different array sizes - should all match int(*)[].
+  int arr2[10];
+  (void)_Generic(&arr2, int(*)[] : true);
+
+  int arr3[1];
+  (void)_Generic(&arr3, int(*)[] : true);
+
+  // Character arrays: verify the selected value via a compile-time check so
+  // the default-fallback arm is actually exercised.
+  char carr[20];
+  _Static_assert(_Generic(&carr, char(*)[] : 1, default : 0) == 1, "char(*)[]");
+
+  // Default case as fallback: an int* must not match int(*)[], so the result
+  // is the default value 2.
+  int *ptr;
+  _Static_assert(_Generic(ptr, int(*)[] : 1, default : 2) == 2, "default");
+
+  // Pointer to array of specific size should also match int(*)[].
+  int(*ptr_to_arr)[5] = &arr;
+  (void)_Generic(ptr_to_arr, int(*)[] : true);
+
+  return 0;
+}

--- a/regression/ansi-c/_Generic_pointer_to_array/test.desc
+++ b/regression/ansi-c/_Generic_pointer_to_array/test.desc
@@ -1,0 +1,11 @@
+CORE gcc-only
+main.c
+
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+^CONVERSION ERROR$
+--
+Test _Generic selection with pointer-to-array types (issue #8690).
+Pointer to array with specified size should match pointer to array with unspecified size.

--- a/regression/ansi-c/gcc_types_compatible_p1/main.c
+++ b/regression/ansi-c/gcc_types_compatible_p1/main.c
@@ -94,6 +94,8 @@ STATIC_ASSERT(!__builtin_types_compatible_p(char, int));
 STATIC_ASSERT(!__builtin_types_compatible_p(char *, char **));
 STATIC_ASSERT(!__builtin_types_compatible_p(typeof (hot), unsigned int));
 STATIC_ASSERT(!__builtin_types_compatible_p(int[], int *));
+// arrays with different, present sizes are incompatible (C11 6.2.7)
+STATIC_ASSERT(!__builtin_types_compatible_p(int[5], int[10]));
 STATIC_ASSERT(!__builtin_types_compatible_p(long int, int));
 STATIC_ASSERT(!__builtin_types_compatible_p(long long int, long int));
 STATIC_ASSERT(!__builtin_types_compatible_p(unsigned, signed));

--- a/regression/cbmc/_Generic_pointer_qualifiers/main.c
+++ b/regression/cbmc/_Generic_pointer_qualifiers/main.c
@@ -1,0 +1,53 @@
+// _Generic must distinguish pointer-to-const from pointer-to-non-const
+// (C11 6.5.1.1: matching is by compatible type after lvalue conversion;
+// top-level qualifiers are dropped, but pointee qualifiers are not).
+// Plain irept == ignored the qualifier "comments", so `int *` wrongly
+// matched `const int *`.  This is the basis of the Linux kernel's
+// container_of_const()/inet_sk() macro.
+#include <stddef.h>
+
+#define container_of(p, type, member)                                          \
+  ((type *)((char *)(p)-offsetof(type, member)))
+#define container_of_const(p, type, member)                                    \
+  _Generic(p, \
+    const __typeof__(*(p)) *: ((const type *)container_of(p, type, member)), \
+    default: ((type *)container_of(p, type, member)))
+
+struct sock
+{
+  int x;
+};
+struct inet_sock
+{
+  struct sock sk;
+  int csum;
+};
+
+int main(void)
+{
+  struct sock *p = 0;
+  int r = _Generic(p, const struct sock * : 1, default : 2);
+  __CPROVER_assert(r == 2, "non-const ptr -> default");
+
+  const struct sock *cp = 0;
+  int r2 = _Generic(cp, const struct sock * : 1, default : 2);
+  __CPROVER_assert(r2 == 1, "const ptr -> const branch");
+
+  // exact non-const branch must win over a const branch
+  int r3 = _Generic(p, struct sock * : 3, const struct sock * : 1, default : 2);
+  __CPROVER_assert(r3 == 3, "exact non-const branch");
+
+  // container_of_const on a non-const pointer yields a *modifiable* lvalue
+  struct inet_sock is;
+  is.csum = 0;
+  container_of_const(&is.sk, struct inet_sock, sk)->csum++; // must compile
+  __CPROVER_assert(is.csum == 1, "container_of_const writable");
+
+  // C11 lvalue conversion: an array controlling expression decays to a
+  // pointer (kernel ATTRIBUTE_GROUPS: _Generic(attrs[], struct X **: ...)).
+  static struct sock *arr[2] = {0, 0};
+  int r4 = _Generic(arr, struct sock * * : 5, default : 6);
+  __CPROVER_assert(r4 == 5, "array decays to pointer");
+
+  return 0;
+}

--- a/regression/cbmc/_Generic_pointer_qualifiers/test.desc
+++ b/regression/cbmc/_Generic_pointer_qualifiers/test.desc
@@ -1,0 +1,12 @@
+CORE gcc-only
+main.c
+
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring
+^CONVERSION ERROR$
+--
+_Generic distinguishes pointee const-qualification (int* vs const int*),
+as required by C11 and by the kernel's container_of_const()/inet_sk().

--- a/src/ansi-c/c_typecheck_expr.cpp
+++ b/src/ansi-c/c_typecheck_expr.cpp
@@ -130,9 +130,26 @@ bool c_typecheck_baset::gcc_types_compatible_p(
   else if(type1.id()==ID_array &&
           type2.id()==ID_array)
   {
-    return gcc_types_compatible_p(
-      to_array_type(type1).element_type(),
-      to_array_type(type2).element_type()); // ignore size
+    // For C11 6.2.7: array types are compatible if element types are
+    // compatible and both size specifiers are present and equal, OR
+    // one or both size specifiers are absent.
+    if(!gcc_types_compatible_p(
+         to_array_type(type1).element_type(),
+         to_array_type(type2).element_type()))
+      return false;
+
+    const array_typet &a_type1 = to_array_type(type1);
+    const array_typet &a_type2 = to_array_type(type2);
+
+    // If either size is absent (incomplete), arrays are compatible
+    if(!a_type1.is_complete() || !a_type2.is_complete())
+      return true;
+
+    // Both sizes are present - they must be equal. This is a syntactic
+    // comparison of the size ireps, so equal-but-not-identical constant size
+    // expressions (e.g. `[5]` vs `[2+3]`) are conservatively treated as
+    // incompatible.
+    return a_type1.size() == a_type2.size();
   }
   else if(type1.id()==ID_code &&
           type2.id()==ID_code)
@@ -473,13 +490,43 @@ void c_typecheck_baset::typecheck_expr_main(exprt &expr)
 
     const typet &op_type = op.type();
 
+    // C11 6.5.1.1p2: The controlling expression undergoes lvalue
+    // conversions (in type domain only): array-to-pointer decay,
+    // function-to-pointer conversion, and qualifier removal.
+    typet adjusted_op_type = op_type;
+    if(adjusted_op_type.id() == ID_array)
+      adjusted_op_type =
+        pointer_type(to_array_type(adjusted_op_type).element_type());
+    else if(adjusted_op_type.id() == ID_code)
+      adjusted_op_type = pointer_type(adjusted_op_type);
+    adjusted_op_type.remove(ID_C_constant);
+    adjusted_op_type.remove(ID_C_volatile);
+    adjusted_op_type.remove(ID_C_restricted);
+
     for(const auto &irep : generic_associations)
     {
       if(irep.get(ID_type_arg) == ID_default)
         default_match = static_cast<const exprt &>(irep.find(ID_value));
-      else if(op_type == static_cast<const typet &>(irep.find(ID_type_arg)))
+      else
       {
-        assoc_match = static_cast<const exprt &>(irep.find(ID_value));
+        const typet &assoc_type =
+          static_cast<const typet &>(irep.find(ID_type_arg));
+        // C11 6.5.1.1p3: Use type compatibility matching instead of
+        // exact equality, as required by the standard.
+        if(gcc_types_compatible_p(adjusted_op_type, assoc_type))
+        {
+          // C11 6.5.1.1p2: no two generic associations shall specify
+          // compatible types, so the controlling expression must match at
+          // most one association.
+          if(assoc_match.is_not_nil())
+          {
+            error().source_location = expr.source_location();
+            error() << "generic selection matches more than one association"
+                    << eom;
+            throw 0;
+          }
+          assoc_match = static_cast<const exprt &>(irep.find(ID_value));
+        }
       }
     }
 
@@ -490,8 +537,8 @@ void c_typecheck_baset::typecheck_expr_main(exprt &expr)
       else
       {
         error().source_location = expr.source_location();
-        error() << "unmatched generic selection: " << to_string(op.type())
-                << eom;
+        error() << "unmatched generic selection: "
+                << to_string(adjusted_op_type) << eom;
         throw 0;
       }
     }


### PR DESCRIPTION
Use type compatibility matching instead of exact equality in _Generic. Also fix array type compatibility check to follow C11 6.2.7 standard: Arrays with unspecified size are compatible with specified sizes.

Fixes: #8690

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
