### PR TITLE
Fix pointer validity instrumentation for incomplete array types

### DIFF
--- a/regression/cbmc/pointer-check-incomplete-array/main.c
+++ b/regression/cbmc/pointer-check-incomplete-array/main.c
@@ -1,0 +1,31 @@
+// This test checks that dereferencing a pointer to an incomplete array type
+// does not trigger an invariant violation.
+// Related to issues #5293 and #4930
+
+int (*a)[];
+
+void b()
+{
+  *a; // This should not cause an invariant violation
+}
+
+void c()
+{
+  int(*p)[];
+  *p; // Another case with a local variable
+}
+
+void test_pointer_arithmetic()
+{
+  int(*p)[] = a;
+  int(*q)[] = p + 1; // Pointer arithmetic on incomplete array type
+  int(*r)[] = q - 1; // Subtraction
+}
+
+int main()
+{
+  b();
+  c();
+  test_pointer_arithmetic();
+  return 0;
+}

--- a/regression/cbmc/pointer-check-incomplete-array/test.desc
+++ b/regression/cbmc/pointer-check-incomplete-array/test.desc
@@ -1,0 +1,15 @@
+CORE no-new-smt
+main.c
+--pointer-overflow-check
+^\[b.pointer_dereference.1\] line 9 dereference failure: pointer NULL in \*a: FAILURE$
+^\[c.pointer_dereference.1\] line 15 dereference failure: pointer NULL in \*p: FAILURE$
+^VERIFICATION FAILED$
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring
+^CONVERSION ERROR$
+^Invariant check failed
+--
+Test that dereferencing pointers to incomplete array types does not cause
+invariant violations.

--- a/regression/contracts/ensures-old-incomplete-array-deref/main.c
+++ b/regression/contracts/ensures-old-incomplete-array-deref/main.c
@@ -1,0 +1,21 @@
+// `p` points to an incomplete array type. The ensures clause captures the
+// pre-state value via __CPROVER_old((*p)[i]); building that history variable
+// runs all_dereferences_are_valid (goto-instrument/contracts/utils.cpp) over
+// the dereference *p. size_of_expr() has no value for the incomplete array
+// element, so this exercises the minimal-size fall-back rather than crashing.
+int (*p)[];
+
+int foo(int i)
+  // clang-format off
+  __CPROVER_ensures(__CPROVER_return_value == __CPROVER_old((*p)[i]))
+// clang-format on
+{
+  return (*p)[i];
+}
+
+int main()
+{
+  int i;
+  foo(i);
+  return 0;
+}

--- a/regression/contracts/ensures-old-incomplete-array-deref/test.desc
+++ b/regression/contracts/ensures-old-incomplete-array-deref/test.desc
@@ -1,0 +1,18 @@
+CORE
+main.c
+--enforce-contract foo
+R_OK\(p, 1ul?l?\)
+^EXIT=10$
+^SIGNAL=0$
+--
+^Invariant check failed
+^CONVERSION ERROR$
+--
+Exercises all_dereferences_are_valid (goto-instrument/contracts/utils.cpp) on a
+dereference of an incomplete-array pointer.  Building the history variable for
+__CPROVER_old((*p)[i]) checks validity of the dereference *p; the element size
+of the incomplete array is unknown, so the minimal-size fall-back is used,
+emitting R_OK(p, 1).  Before the fall-back goto-instrument aborted on the
+unset size; the R_OK(p, 1) check (and absence of an invariant/conversion
+error) confirms the path is handled.  Verification then fails only because the
+global pointer p is unconstrained, which is incidental to this test.

--- a/src/ansi-c/goto-conversion/goto_check_c.cpp
+++ b/src/ansi-c/goto-conversion/goto_check_c.cpp
@@ -1406,7 +1406,16 @@ void goto_check_ct::pointer_overflow_check(
   if(object_type.id() != ID_empty)
   {
     auto size_of_expr_opt = size_of_expr(object_type, ns);
-    CHECK_RETURN(size_of_expr_opt.has_value());
+
+    // For incomplete array types (e.g. pointer arithmetic on int (*p)[]) the
+    // element size is unknown: we can neither check the offset multiplication
+    // for overflow nor compute object bounds, and the bit-vector encoding
+    // cannot represent arithmetic over such pointers. Skip the whole
+    // pointer-arithmetic check (as done for pointers of otherwise-unknown
+    // pointee size).
+    if(!size_of_expr_opt.has_value())
+      return;
+
     exprt object_size = size_of_expr_opt.value();
 
     const binary_exprt &binary_expr = to_binary_expr(expr);
@@ -1465,9 +1474,10 @@ void goto_check_ct::pointer_validity_check(
   }
   else
   {
-    auto size_of_expr_opt = size_of_expr(expr.type(), ns);
-    CHECK_RETURN(size_of_expr_opt.has_value());
-    size = size_of_expr_opt.value();
+    // For incomplete array types (e.g. dereferencing int (*p)[]) size_of_expr()
+    // returns an empty optional since the size is unknown; fall back to a
+    // minimal size of 1, as is done for void pointers above.
+    size = size_of_expr(expr.type(), ns).value_or(from_integer(1, size_type()));
   }
 
   auto conditions = get_pointer_dereferenceable_conditions(pointer, size);

--- a/src/goto-instrument/contracts/utils.cpp
+++ b/src/goto-instrument/contracts/utils.cpp
@@ -10,6 +10,7 @@ Date: September 2021
 
 #include "utils.h"
 
+#include <util/arith_tools.h>
 #include <util/c_types.h>
 #include <util/fresh_symbol.h>
 #include <util/graph.h>
@@ -178,10 +179,13 @@ exprt all_dereferences_are_valid(const exprt &expr, const namespacet &ns)
 
   if(auto deref = expr_try_dynamic_cast<dereference_exprt>(expr))
   {
+    // For incomplete types (e.g. incomplete arrays) size_of_expr() returns an
+    // empty optional; fall back to a minimal size of 1, as is done for void
+    // pointers.
     const auto size_of_expr_opt = size_of_expr(expr.type(), ns);
-    CHECK_RETURN(size_of_expr_opt.has_value());
-
-    validity_checks.push_back(r_ok_exprt{deref->pointer(), *size_of_expr_opt});
+    validity_checks.push_back(r_ok_exprt{
+      deref->pointer(),
+      size_of_expr_opt.value_or(from_integer(1, size_type()))});
   }
 
   for(const auto &op : expr.operands())


### PR DESCRIPTION
Use the same fall-back as is done for void pointers.

Fixes: #8700

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
