### PR TITLE
Fix --nondet-static-exclude to handle symbol names and report errors

### DIFF
--- a/regression/goto-instrument/nondet_static_exclude_symbol_name/main.c
+++ b/regression/goto-instrument/nondet_static_exclude_symbol_name/main.c
@@ -1,0 +1,14 @@
+int foo = 0;
+
+int f()
+{
+  static int bar = 0;
+  return bar;
+}
+
+int main()
+{
+  assert(foo == 0);
+  assert(f() == 0);
+  return 0;
+}

--- a/regression/goto-instrument/nondet_static_exclude_symbol_name/test.desc
+++ b/regression/goto-instrument/nondet_static_exclude_symbol_name/test.desc
@@ -1,0 +1,9 @@
+CORE
+main.c
+--nondet-static --nondet-static-exclude f::1::bar --nondet-static-exclude foo
+^VERIFICATION SUCCESSFUL$
+^EXIT=0$
+^SIGNAL=0$
+--
+--
+Test that --nondet-static-exclude works with symbol names like f::1::bar and with global variable names like foo

--- a/regression/goto-instrument/nondet_static_exclude_unknown/file-variable-typo.desc
+++ b/regression/goto-instrument/nondet_static_exclude_unknown/file-variable-typo.desc
@@ -1,0 +1,14 @@
+CORE
+main.c
+--nondet-static --nondet-static-exclude main.c:does_not_exist
+^Invalid User Input$
+^Option: --nondet-static-exclude$
+^Reason: 'main.c:does_not_exist' did not match any symbol$
+^EXIT=1$
+^SIGNAL=0$
+--
+^VERIFICATION
+//
+// Regression test for #8225: a file:variable exclusion that matches no symbol
+// (here a typo in the variable name) must also be reported as an error rather
+// than silently doing nothing.

--- a/regression/goto-instrument/nondet_static_exclude_unknown/main.c
+++ b/regression/goto-instrument/nondet_static_exclude_unknown/main.c
@@ -1,0 +1,14 @@
+int foo = 0;
+
+int f()
+{
+  static int bar = 0;
+  return bar;
+}
+
+int main()
+{
+  assert(foo == 0);
+  assert(f() == 0);
+  return 0;
+}

--- a/regression/goto-instrument/nondet_static_exclude_unknown/test.desc
+++ b/regression/goto-instrument/nondet_static_exclude_unknown/test.desc
@@ -1,0 +1,14 @@
+CORE
+main.c
+--nondet-static --nondet-static-exclude does_not_exist
+^Invalid User Input$
+^Option: --nondet-static-exclude$
+^Reason: 'does_not_exist' did not match any symbol$
+^EXIT=1$
+^SIGNAL=0$
+--
+^VERIFICATION
+//
+// Regression test for #8225: an unknown --nondet-static-exclude argument must
+// be reported as an error rather than silently ignored. chain.sh runs
+// goto-instrument under "set -e", so its non-zero exit propagates here.

--- a/src/goto-instrument/nondet_static.cpp
+++ b/src/goto-instrument/nondet_static.cpp
@@ -19,6 +19,7 @@ Date: November 2011
 
 #include "nondet_static.h"
 
+#include <util/exception_utils.h>
 #include <util/prefix.h>
 #include <util/std_code.h>
 
@@ -26,7 +27,17 @@ Date: November 2011
 
 #include <linking/static_lifetime_init.h>
 
+#include <map>
 #include <regex>
+#include <vector>
+
+/// \return the "file:variable" key used to identify \p symbol for the
+///   --nondet-static-exclude option.
+static std::string qualified_name(const symbolt &symbol)
+{
+  return id2string(symbol.location.get_file()) + ":" +
+         id2string(symbol.display_name());
+}
 
 /// See the return.
 /// \param symbol_expr: The symbol expression to analyze.
@@ -145,49 +156,72 @@ void nondet_static(
   const std::set<std::string> &except_values)
 {
   const namespacet ns(goto_model.symbol_table);
-  std::set<std::string> to_exclude;
+  symbol_tablet &symbol_table = goto_model.symbol_table;
 
-  for(auto const &except : except_values)
+  // Build the set of "file:variable" keys to exclude. Each requested exclusion
+  // is first looked up as a symbol identifier (e.g. "f::1::bar" or a global
+  // "foo"); if that fails it is treated as a "file:variable" name. Either way
+  // the exclusion has to match some symbol below -- silently ignoring an
+  // unknown exclusion is exactly the bug reported in #8225, so we track which
+  // requested exclusions are actually used and report any that are not.
+  const std::vector<std::string> except_list(
+    except_values.begin(), except_values.end());
+  std::vector<bool> matched(except_list.size(), false);
+  // maps a candidate "file:variable" key to the index of the requesting
+  // exclusion in except_list
+  std::multimap<std::string, std::size_t> to_exclude;
+
+  for(std::size_t i = 0; i < except_list.size(); ++i)
   {
-    const bool file_prefix_found = except.find(":") != std::string::npos;
+    const std::string &except = except_list[i];
+    const symbolt *symbol_ptr = symbol_table.lookup(except);
 
-    if(file_prefix_found)
+    if(symbol_ptr != nullptr)
     {
-      to_exclude.insert(except);
-      if(has_prefix(except, "./"))
-      {
-        to_exclude.insert(except.substr(2, except.length() - 2));
-      }
-      else
-      {
-        to_exclude.insert("./" + except);
-      }
+      // resolved as a symbol identifier
+      to_exclude.emplace(qualified_name(*symbol_ptr), i);
     }
     else
     {
-      irep_idt symbol_name(except);
-      symbolt lookup_results = ns.lookup(symbol_name);
-      to_exclude.insert(
-        id2string(lookup_results.location.get_file()) + ":" + except);
+      // treat as a "file:variable" name (validated via matched[] below)
+      to_exclude.emplace(except, i);
+      if(has_prefix(except, "./"))
+        to_exclude.emplace(except.substr(2, except.length() - 2), i);
+      else
+        to_exclude.emplace("./" + except, i);
     }
   }
-
-  symbol_tablet &symbol_table = goto_model.symbol_table;
 
   for(symbol_tablet::iteratort symbol_it = symbol_table.begin();
       symbol_it != symbol_table.end();
       symbol_it++)
   {
     symbolt &symbol = symbol_it.get_writeable_symbol();
-    std::string qualified_name = id2string(symbol.location.get_file()) + ":" +
-                                 id2string(symbol.display_name());
-    if(to_exclude.find(qualified_name) != to_exclude.end())
+    const std::string name = qualified_name(symbol);
+    const auto range = to_exclude.equal_range(name);
+    if(range.first != range.second)
     {
       symbol.value.set(ID_C_no_nondet_initialization, 1);
+      for(auto it = range.first; it != range.second; ++it)
+        matched[it->second] = true;
     }
     else if(is_nondet_initializable_static(symbol.symbol_expr(), ns))
     {
       symbol.value = side_effect_expr_nondett(symbol.type, symbol.location);
+    }
+  }
+
+  // Report any requested exclusion that did not match a symbol, so that typos
+  // in either the symbol-identifier or the "file:variable" form are surfaced
+  // rather than silently ignored (#8225).
+  for(std::size_t i = 0; i < except_list.size(); ++i)
+  {
+    if(!matched[i])
+    {
+      throw invalid_command_line_argument_exceptiont(
+        "'" + except_list[i] + "' did not match any symbol",
+        "--nondet-static-exclude",
+        "a symbol identifier (e.g. f::1::bar) or a file:variable name");
     }
   }
 
@@ -210,9 +244,8 @@ void nondet_static_matching(goto_modelt &goto_model, const std::string &regex)
       symbol_it++)
   {
     symbolt &symbol = symbol_it.get_writeable_symbol();
-    std::string qualified_name = id2string(symbol.location.get_file()) + ":" +
-                                 id2string(symbol.display_name());
-    if(!std::regex_match(qualified_name, regex_matcher))
+    const std::string name = qualified_name(symbol);
+    if(!std::regex_match(name, regex_matcher))
     {
       symbol.value.set(ID_C_no_nondet_initialization, 1);
     }


### PR DESCRIPTION
`--nondet-static-exclude` previously silently failed or crashed when using certain variable name formats.

Fixes: #8225

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
