### PR TITLE
Fix CMake configuration for IMPORTED ipasir-custom library

### DIFF
--- a/.github/workflows/pull-request-checks.yaml
+++ b/.github/workflows/pull-request-checks.yaml
@@ -301,6 +301,28 @@ jobs:
         with:
           path: .ccache
           key: ${{ steps.restore-ccache.outputs.cache-primary-key }}
+
+  # Builds the libcprover-cpp API with an IPASIR solver (CaDiCaL, which is
+  # self-contained and downloaded by CMake) to exercise the static-archive
+  # aggregation over an IMPORTED solver target. This guards against
+  # regressions like #8249, which no minisat2/cadical job would catch.
+  check-ubuntu-24_04-cmake-gcc-ipasir-cadical:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: recursive
+      - name: Fetch dependencies
+        env:
+          DEBIAN_FRONTEND: noninteractive
+        run: |
+          sudo apt-get update
+          sudo apt-get install --no-install-recommends -yq cmake ninja-build gcc g++ flex bison patch
+      - name: Configure using CMake with ipasir-cadical
+        run: cmake -S . -Bbuild-ipasir -G Ninja -DCMAKE_BUILD_TYPE=Release -Dsat_impl=ipasir-cadical
+      - name: Build cprover-api-cpp (aggregates the IMPORTED CaDiCaL archive)
+        run: cmake --build build-ipasir --target cprover-api-cpp -j${{env.linux-vcpus}}
+
   # This job takes approximately 20 to 38 minutes
   check-ubuntu-22_04-make-clang:
     runs-on: ubuntu-22.04

--- a/src/libcprover-cpp/CMakeLists.txt
+++ b/src/libcprover-cpp/CMakeLists.txt
@@ -64,6 +64,13 @@ foreach(dep ${LIBRARY_DEPENDENCIES})
         list(APPEND DEPENDENCY_TARGETS "$<TARGET_FILE:${dep}>")
     else()
         find_library(dep_path ${dep})
+        if(NOT dep_path)
+          message(FATAL_ERROR
+            "libcprover-cpp cannot be linked: dependency '${dep}' is neither a "
+            "visible CMake target nor a discoverable library. If '${dep}' is an "
+            "IMPORTED target, it must be declared with IMPORTED ... GLOBAL to be "
+            "visible in this (sibling) directory. See issue #8249.")
+        endif()
         string(REGEX REPLACE "[.]so$" ".a" dep_static_path ${dep_path})
         if (NOT EXISTS "${dep_static_path}")
           message(FATAL_ERROR "libcprover-cpp cannot be linked as dependency ${dep_path} does not have a static correspondent file (${dep_static_path})")

--- a/src/solvers/CMakeLists.txt
+++ b/src/solvers/CMakeLists.txt
@@ -61,6 +61,18 @@ add_library(solvers ${sources})
 
 include("${CBMC_SOURCE_DIR}/cmake/DownloadProject.cmake")
 
+# Declare an IMPORTED static library for an IPASIR solver at the given location.
+#
+# GLOBAL is essential here: by default IMPORTED targets are scoped to the
+# directory that declares them, so without it the sibling directory
+# src/libcprover-cpp/ cannot see the target via if(TARGET ...) when it iterates
+# over solvers' LINK_LIBRARIES to aggregate the static archives. It would then
+# fall through to find_library() and fail with a "-NOTFOUND" error. See #8249.
+function(add_imported_ipasir_solver name location)
+    add_library(${name} STATIC IMPORTED GLOBAL)
+    set_property(TARGET ${name} PROPERTY IMPORTED_LOCATION ${location})
+endfunction()
+
 foreach(SOLVER ${sat_impl})
     if("${SOLVER}" STREQUAL "minisat2")
         message(STATUS "Building solvers with minisat2")
@@ -157,10 +169,8 @@ foreach(SOLVER ${sat_impl})
             SATCHECK_IPASIR HAVE_IPASIR IPASIR=${cadical_SOURCE_DIR}/src
         )
 
-        add_library(cadical_ipasir STATIC IMPORTED)
-        set_property(TARGET cadical_ipasir
-            PROPERTY IMPORTED_LOCATION ${cadical_SOURCE_DIR}/build/libcadical.a
-        )
+        add_imported_ipasir_solver(cadical_ipasir
+            ${cadical_SOURCE_DIR}/build/libcadical.a)
 
         target_include_directories(solvers
             PUBLIC
@@ -202,10 +212,7 @@ foreach(SOLVER ${sat_impl})
             SATCHECK_IPASIR HAVE_IPASIR IPASIR=${IPASIR}
         )
 
-        add_library(ipasir_custom STATIC IMPORTED)
-        set_property(TARGET ipasir_custom
-            PROPERTY IMPORTED_LOCATION ${IPASIR_LIB}
-        )
+        add_imported_ipasir_solver(ipasir_custom ${IPASIR_LIB})
 
         target_include_directories(solvers
             PUBLIC

--- a/src/solvers/CMakeLists.txt
+++ b/src/solvers/CMakeLists.txt
@@ -158,6 +158,11 @@ foreach(SOLVER ${sat_impl})
         download_project(PROJ cadical
             URL https://github.com/arminbiere/cadical/archive/rel-3.0.0.tar.gz
             PATCH_COMMAND patch -p1 -i ${CBMC_SOURCE_DIR}/scripts/cadical-3.0.0-patch
+            # The patch makes CaDiCaL's make-build-header.sh read the version
+            # from VERSION.txt (rather than VERSION); provide that file so the
+            # native build below can generate build.hpp. The CMake-driven
+            # cadical build above avoids this via -DNBUILD instead.
+            COMMAND cmake -E copy_if_different VERSION VERSION.txt
             COMMAND ./configure
             URL_HASH SHA256=282b1c9422fde8631cb721b86450ae94df4e8de0545c17a69a301aaa4bf92fcf
         )


### PR DESCRIPTION
`IMPORTED` targets in CMake have directory scope by default, so they are not visible to sibling directories. In `src/libcprover-cpp/CMakeLists.txt`, the loop that aggregates the static archives of `cprover-api-cpp`'s dependencies checks `if(TARGET ${dep})`; for the `IMPORTED` targets `cadical_ipasir` / `ipasir_custom` (declared in `src/solvers/CMakeLists.txt`) this returns `FALSE`, so the code falls through to `find_library(${dep})`, which returns `-NOTFOUND`, and configuration fails.

The fix declares those `IMPORTED` libraries with `GLOBAL` (via a small `add_imported_ipasir_solver()` helper that documents why `GLOBAL` is required), making them visible project-wide so the existing `$<TARGET_FILE:...>` generator expression resolves correctly. A separate commit adds a CI job that builds the `libcprover-cpp` API with `-Dsat_impl=ipasir-cadical` to guard against this class of regression, and the consumer-side fallback now emits a clearer error hinting at a missing `IMPORTED ... GLOBAL`.

Fixes: #8249

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message). A CI job (`check-ubuntu-24_04-cmake-gcc-ipasir-cadical`) builds the API with an IPASIR solver and exercises the IMPORTED-target aggregation.
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
