### PR TITLE
Catch out-of-memory exceptions during propositional reduction

### DIFF
--- a/src/goto-checker/bmc_util.cpp
+++ b/src/goto-checker/bmc_util.cpp
@@ -347,11 +347,23 @@ std::chrono::duration<double> prepare_property_decider(
     << property_decider.get_decision_procedure().decision_procedure_text()
     << messaget::eom;
 
-  convert_symex_target_equation(
-    equation, property_decider.get_decision_procedure(), ui_message_handler);
-  property_decider.update_properties_goals_from_symex_target_equation(
-    properties);
-  property_decider.convert_goals();
+  try
+  {
+    convert_symex_target_equation(
+      equation, property_decider.get_decision_procedure(), ui_message_handler);
+    property_decider.update_properties_goals_from_symex_target_equation(
+      properties);
+    property_decider.convert_goals();
+  }
+  catch(const std::bad_alloc &)
+  {
+    log.error() << "Solver ran out of memory during propositional reduction."
+                << messaget::eom;
+    log.error()
+      << "Try reducing the problem size or increasing available memory."
+      << messaget::eom;
+    throw;
+  }
 
   auto solver_stop = std::chrono::steady_clock::now();
   return std::chrono::duration<double>(solver_stop - solver_start);

--- a/src/solvers/prop/prop_conv_solver.cpp
+++ b/src/solvers/prop/prop_conv_solver.cpp
@@ -443,44 +443,56 @@ void prop_conv_solvert::finish_eager_conversion()
 decision_proceduret::resultt
 prop_conv_solvert::dec_solve(const exprt &assumption)
 {
-  // post-processing isn't incremental yet
-  if(!post_processing_done)
+  try
   {
-    const auto post_process_start = std::chrono::steady_clock::now();
+    // post-processing isn't incremental yet
+    if(!post_processing_done)
+    {
+      const auto post_process_start = std::chrono::steady_clock::now();
 
-    log.progress() << "Post-processing" << messaget::eom;
-    finish_eager_conversion();
-    post_processing_done = true;
+      log.progress() << "Post-processing" << messaget::eom;
+      finish_eager_conversion();
+      post_processing_done = true;
 
-    const auto post_process_stop = std::chrono::steady_clock::now();
-    std::chrono::duration<double> post_process_runtime =
-      std::chrono::duration<double>(post_process_stop - post_process_start);
-    log.statistics() << "Runtime Post-process: " << post_process_runtime.count()
-                     << "s" << messaget::eom;
+      const auto post_process_stop = std::chrono::steady_clock::now();
+      std::chrono::duration<double> post_process_runtime =
+        std::chrono::duration<double>(post_process_stop - post_process_start);
+      log.statistics() << "Runtime Post-process: "
+                       << post_process_runtime.count() << "s" << messaget::eom;
+    }
+
+    log.progress() << "Solving with " << prop.solver_text() << messaget::eom;
+
+    if(assumption.is_nil())
+      push();
+    else
+      push({assumption});
+
+    auto prop_result = prop.prop_solve(assumption_stack);
+
+    pop();
+
+    switch(prop_result)
+    {
+    case propt::resultt::P_SATISFIABLE:
+      return resultt::D_SATISFIABLE;
+    case propt::resultt::P_UNSATISFIABLE:
+      return resultt::D_UNSATISFIABLE;
+    case propt::resultt::P_ERROR:
+      return resultt::D_ERROR;
+    }
+
+    UNREACHABLE;
   }
-
-  log.progress() << "Solving with " << prop.solver_text() << messaget::eom;
-
-  if(assumption.is_nil())
-    push();
-  else
-    push({assumption});
-
-  auto prop_result = prop.prop_solve(assumption_stack);
-
-  pop();
-
-  switch(prop_result)
+  catch(const std::bad_alloc &)
   {
-  case propt::resultt::P_SATISFIABLE:
-    return resultt::D_SATISFIABLE;
-  case propt::resultt::P_UNSATISFIABLE:
-    return resultt::D_UNSATISFIABLE;
-  case propt::resultt::P_ERROR:
+    log.error() << "Solver ran out of memory during propositional reduction."
+                << messaget::eom;
+    log.error()
+      << "Try reducing the problem size or increasing available memory."
+      << messaget::eom;
     return resultt::D_ERROR;
   }
-
-  UNREACHABLE;
 }
 
 exprt prop_conv_solvert::get(const exprt &expr) const


### PR DESCRIPTION
We already caught out-of-memory exceptions in some places in the solver back-ends, but not at the more global level of various propositional reduction steps.

Fixes: #727

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
