### PR TITLE
Add TweetNaCl constant-time verification regression test

### DIFF
--- a/regression/goto-analyzer/tweetnacl-constant-time/test.desc
+++ b/regression/goto-analyzer/tweetnacl-constant-time/test.desc
@@ -1,0 +1,28 @@
+CORE
+tweetnacl.c
+--dependence-graph --show --text -
+activate-multi-line-match
+^EXIT=0$
+^SIGNAL=0$
+\*\*\*\* (\d+) .*function crypto_verify_16\n\n.*\n.*ASSIGN crypto_verify_16::1::i := 0\n\n\*\*\*\* (\d+) .*function crypto_verify_16\nControl dependencies: \2\nData dependencies: \1,(\d+)\n\n.*\n.*IF.*crypto_verify_16::1::i < 16.*\n(.*\n)*?.*\*\*\*\* \3 .*function crypto_verify_16\n(.*\n)*?.*ASSIGN crypto_verify_16::1::i := crypto_verify_16::1::i \+ 1
+\*\*\*\* (\d+) .*function cswap\n\n.*\n.*ASSIGN cswap::1::i := 0\n\n\*\*\*\* (\d+) .*function cswap\nControl dependencies: \2\nData dependencies: \1,(\d+)\n\n.*\n.*IF.*cswap::1::i < 32.*\n(.*\n)*?.*\*\*\*\* \3 .*function cswap\n(.*\n)*?.*ASSIGN cswap::1::i := cswap::1::i \+ 1
+--
+^warning: ignoring
+Function: sel25519\n((?!.*END_FUNCTION).*\n)*.*\bIF\b
+--
+Verifies TweetNaCl's constant-time property claims (issue #366):
+
+1. sel25519 is branchless: no IF instruction appears between the function
+   header and END_FUNCTION (negative match).
+
+2. crypto_verify_16 loop bound is constant: the IF instruction's data
+   dependencies (captured via backreferences) trace back only to the loop
+   counter initialization (i := 0) and increment (i := i + 1), not to any
+   secret input data.
+
+3. cswap loop bound is constant: same as crypto_verify_16 -- the loop
+   condition depends only on the loop counter, not on the secret swap bit.
+
+This confirms that secret inputs create data dependencies (values flow
+through computations) but NOT control dependencies (secret values don't
+determine which branches are taken or loop iteration counts).

--- a/regression/goto-analyzer/tweetnacl-constant-time/tweetnacl.c
+++ b/regression/goto-analyzer/tweetnacl-constant-time/tweetnacl.c
@@ -1,0 +1,66 @@
+/*
+ * Simplified subset of TweetNaCl cryptographic library
+ * For testing constant-time properties with CBMC's dependence graph analysis
+ *
+ * TweetNaCl claims to have no data-dependent branches or array indices.
+ * This test verifies these claims using goto-analyzer --dependence-graph
+ *
+ * Reference: https://github.com/diffblue/cbmc/issues/366
+ * Based on TweetNaCl: https://tweetnacl.cr.yp.to/
+ * Public domain code
+ */
+
+typedef unsigned char u8;
+typedef unsigned int u32;
+typedef unsigned long long u64;
+
+// Constant-time selection (sel25519 from TweetNaCl)
+// Uses bitwise mask instead of if-statement: no branches at all
+u64 sel25519(u64 a, u64 b, u64 c)
+{
+  u64 mask = ~(c - 1);
+  return a ^ ((a ^ b) & mask);
+}
+
+// Constant-time byte comparison (crypto_verify_16 from TweetNaCl)
+// Loop bound is constant 16, not dependent on secret data
+int crypto_verify_16(const u8 *x, const u8 *y)
+{
+  u32 d = 0;
+  int i;
+  for(i = 0; i < 16; i++)
+    d |= x[i] ^ y[i];
+  return (1 & ((d - 1) >> 8)) - 1;
+}
+
+// Constant-time conditional swap (from Curve25519)
+// Loop bound is constant 32, not dependent on secret swap bit b
+void cswap(u64 p[32], u64 q[32], u8 b)
+{
+  int i;
+  u64 mask = ~((u64)b - 1);
+  for(i = 0; i < 32; i++)
+  {
+    u64 t = (p[i] ^ q[i]) & mask;
+    p[i] ^= t;
+    q[i] ^= t;
+  }
+}
+
+int main(void)
+{
+  u8 secret_key[32];
+  u8 msg1[16], msg2[16];
+  u64 x[32], z[32];
+
+  // Test constant-time selection
+  u64 sel_result = sel25519(42, 99, secret_key[0] & 1);
+
+  // Test constant-time comparison
+  int verify_result = crypto_verify_16(msg1, msg2);
+
+  // Test constant-time swap
+  cswap(x, z, secret_key[1] & 1);
+
+  return (sel_result + verify_result + x[0]) & 1;
+}


### PR DESCRIPTION
Implements a regression test for dependence graph analysis using a compacted version of TweetNaCl cryptographic library. The verification goal is to verify constant-time property claims.

Fixes: #366

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
