### PR TITLE
C++ front-end: fix global constructor and member initialization

### DIFF
--- a/regression/cbmc-cpp/gh-issue-537/main.cpp
+++ b/regression/cbmc-cpp/gh-issue-537/main.cpp
@@ -1,0 +1,32 @@
+#include <assert.h>
+
+class C
+{
+public:
+  int x;
+
+  C() : x(7)
+  {
+  }
+};
+
+C c1;
+
+class D
+{
+public:
+  int x = 7;
+};
+
+int main()
+{
+  assert(c1.x == 7); // regression: global object initialization
+
+  C c2;
+  assert(c2.x == 7); // regression: local object initialization via constructor
+
+  D d;
+  assert(d.x == 7); // regression: C++11 default member initialization
+
+  return 0;
+}

--- a/regression/cbmc-cpp/gh-issue-537/test.desc
+++ b/regression/cbmc-cpp/gh-issue-537/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.cpp
+--cpp11
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring

--- a/src/cpp/cpp_typecheck_compound_type.cpp
+++ b/src/cpp/cpp_typecheck_compound_type.cpp
@@ -754,6 +754,13 @@ void cpp_typecheckt::typecheck_compound_declarator(
     }
   }
 
+  // Handle C++11 default member initializers for non-static members
+  if(!is_static && !is_method && value.is_not_nil())
+  {
+    // Store the default initializer value in the component
+    component.add(ID_C_default_value) = value;
+  }
+
   // array members must have fixed size
   check_fixed_size_array(component.type());
 
@@ -1097,7 +1104,25 @@ void cpp_typecheckt::typecheck_compound_body(symbolt &symbol)
   if(symbol.type.id()==ID_struct)
     do_virtual_table(symbol);
 
-  if(!found_ctor && !cpp_is_pod(symbol.type))
+  // Check if any component has a C++11 default member initializer
+  bool has_default_member_initializer = false;
+  for(const auto &component : type.components())
+  {
+    if(
+      !component.get_bool(ID_from_base) && component.type().id() != ID_code &&
+      !component.get_bool(ID_is_type) && !component.get_bool(ID_is_static) &&
+      component.find(ID_C_default_value).is_not_nil())
+    {
+      has_default_member_initializer = true;
+      break;
+    }
+  }
+
+  // Generate a default constructor if:
+  // - No constructor was found, AND
+  // - Either the type is not POD OR it has C++11 default member initializers
+  if(
+    !found_ctor && (!cpp_is_pod(symbol.type) || has_default_member_initializer))
   {
     // it's public!
     exprt cpp_public("cpp-public");

--- a/src/cpp/cpp_typecheck_constructor.cpp
+++ b/src/cpp/cpp_typecheck_constructor.cpp
@@ -752,6 +752,18 @@ void cpp_typecheckt::full_member_initialization(
       mem_init.set(ID_member, cppname);
       final_initializers.move_to_sub(mem_init);
     }
+    // Handle C++11 default member initializers for POD types
+    else if(
+      !found && cpp_is_pod(c.type()) && c.find(ID_C_default_value).is_not_nil())
+    {
+      cpp_namet cppname(mem_name);
+
+      codet mem_init(ID_member_initializer);
+      mem_init.set(ID_member, cppname);
+      mem_init.copy_to_operands(
+        static_cast<const exprt &>(c.find(ID_C_default_value)));
+      final_initializers.move_to_sub(mem_init);
+    }
   }
 
   initializers.swap(final_initializers);


### PR DESCRIPTION
1. Store default values: Modified compound type declarator handling to preserve C++11 default member initializers in the AST using `ID_C_default_value`.

2. Generate constructors when needed: Modified compound body type checking to generate default constructors for classes with default member initializers, ensuring static initialization occurs.

3. Apply default values: Modified constructor member initialization to check for stored default values and create appropriate member initializers.

Fixes: #537

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
