### PR TITLE
Add saturating arithmetic support to SMT2 incremental solver

### DIFF
--- a/regression/cbmc/saturating_arithmetric/main.c
+++ b/regression/cbmc/saturating_arithmetric/main.c
@@ -1,7 +1,9 @@
 #include <limits.h>
+#include <stdint.h>
 
 int main()
 {
+  // Boundary saturation cases.
   __CPROVER_assert(
     __CPROVER_saturating_minus(INT_MIN, 1) == INT_MIN,
     "subtracting from INT_MIN");
@@ -14,4 +16,39 @@ int main()
     "adding to ULONG_MAX");
   __CPROVER_assert(
     __CPROVER_saturating_minus(10ul, ULONG_MAX) == 0, "subtracting ULONG_MAX");
+
+  // Signed plus with negative overflow saturates to INT_MIN.
+  __CPROVER_assert(
+    __CPROVER_saturating_plus(INT_MIN, -1) == INT_MIN,
+    "INT_MIN + (-1) saturates to INT_MIN");
+
+  // Non-saturating sanity cases: the result is in range and must be exact.
+  __CPROVER_assert(
+    __CPROVER_saturating_plus(2, 3) == 5, "signed plus, no saturation");
+  __CPROVER_assert(
+    __CPROVER_saturating_minus(5, 3) == 2, "signed minus, no saturation");
+  __CPROVER_assert(
+    __CPROVER_saturating_plus(2u, 3u) == 5u, "unsigned plus, no saturation");
+  __CPROVER_assert(
+    __CPROVER_saturating_minus(5u, 3u) == 2u, "unsigned minus, no saturation");
+
+  // 8-bit cases, exercising the width-1 / width bit extraction at a boundary
+  // other than 32/64.
+  __CPROVER_assert(
+    __CPROVER_saturating_plus((int8_t)10, (int8_t)20) == (int8_t)30,
+    "int8 plus, no saturation");
+  __CPROVER_assert(
+    __CPROVER_saturating_plus((int8_t)100, (int8_t)100) == (int8_t)127,
+    "int8 plus saturates to INT8_MAX");
+  __CPROVER_assert(
+    __CPROVER_saturating_minus((int8_t)-100, (int8_t)100) == (int8_t)-128,
+    "int8 minus saturates to INT8_MIN");
+  __CPROVER_assert(
+    __CPROVER_saturating_plus((uint8_t)200, (uint8_t)100) == (uint8_t)255,
+    "uint8 plus saturates to UINT8_MAX");
+  __CPROVER_assert(
+    __CPROVER_saturating_minus((uint8_t)10, (uint8_t)20) == (uint8_t)0,
+    "uint8 minus saturates to 0");
+
+  return 0;
 }

--- a/regression/cbmc/saturating_arithmetric/test.desc
+++ b/regression/cbmc/saturating_arithmetric/test.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 main.c
 
 ^EXIT=0$

--- a/src/solvers/smt2_incremental/convert_expr_to_smt.cpp
+++ b/src/solvers/smt2_incremental/convert_expr_to_smt.cpp
@@ -1325,6 +1325,111 @@ static smt_termt convert_expr_to_smt(
     mult_overflow.pretty());
 }
 
+/// Shared implementation of saturating addition and subtraction.  The two
+/// operations differ only in (a) whether the extended operands are added or
+/// subtracted and (b), for unsigned types, whether overflow saturates to the
+/// maximum or to zero; everything else is identical.  \p subtract selects
+/// subtraction.  This mirrors the parameterised handling of ID_saturating_plus
+/// / ID_saturating_minus in the non-incremental back-end (smt2_conv.cpp).
+static smt_termt convert_saturating_add_or_subtract(
+  const binary_exprt &expr,
+  const sub_expression_mapt &converted,
+  const bool subtract)
+{
+  PRECONDITION(expr.lhs().type() == expr.rhs().type());
+  const typet &op_type = expr.type();
+  const smt_termt &left = converted.at(expr.lhs());
+  const smt_termt &right = converted.at(expr.rhs());
+
+  if(const auto signed_type = type_try_dynamic_cast<signedbv_typet>(op_type))
+  {
+    const std::size_t width = signed_type->get_width();
+
+    // Compute the result in width + 1 bits using sign extension, so a genuine
+    // signed overflow shows up as a disagreement between the two top bits.
+    const auto extend = smt_bit_vector_theoryt::sign_extend(1);
+    const auto extended_result =
+      subtract ? smt_bit_vector_theoryt::subtract(extend(left), extend(right))
+               : smt_bit_vector_theoryt::add(extend(left), extend(right));
+
+    // The extension bit (bit `width`) and the would-be sign bit (bit
+    // `width - 1`) agree exactly when the result fits in `width` bits, i.e.
+    // when no overflow occurred.
+    const auto extension_bit =
+      smt_bit_vector_theoryt::extract(width, width)(extended_result);
+    const auto sign_bit =
+      smt_bit_vector_theoryt::extract(width - 1, width - 1)(extended_result);
+    const auto no_overflow = smt_core_theoryt::equal(extension_bit, sign_bit);
+
+    const auto result =
+      smt_bit_vector_theoryt::extract(width - 1, 0)(extended_result);
+
+    // On overflow, an extension bit of 0 means the result was too large
+    // (positive overflow) and we clamp to MAX, otherwise to MIN.  For an
+    // N-bit signed type MAX is 2^(N-1) - 1 and MIN has the unsigned bit
+    // pattern 2^(N-1).
+    const auto positive_overflow = smt_core_theoryt::equal(
+      extension_bit, smt_bit_vector_constant_termt{0, 1});
+    const auto signed_max =
+      smt_bit_vector_constant_termt{power(2, width - 1) - 1, width};
+    const auto signed_min =
+      smt_bit_vector_constant_termt{power(2, width - 1), width};
+
+    return smt_core_theoryt::if_then_else(
+      no_overflow,
+      result,
+      smt_core_theoryt::if_then_else(
+        positive_overflow, signed_max, signed_min));
+  }
+  if(
+    const auto unsigned_type = type_try_dynamic_cast<unsignedbv_typet>(op_type))
+  {
+    const std::size_t width = unsigned_type->get_width();
+
+    // Compute the result in width + 1 bits using zero extension; the extra top
+    // bit then captures the carry (addition) or borrow (subtraction).
+    const auto extend = smt_bit_vector_theoryt::zero_extend(1);
+    const auto extended_result =
+      subtract ? smt_bit_vector_theoryt::subtract(extend(left), extend(right))
+               : smt_bit_vector_theoryt::add(extend(left), extend(right));
+
+    const auto overflow_bit =
+      smt_bit_vector_theoryt::extract(width, width)(extended_result);
+    const auto no_overflow = smt_core_theoryt::equal(
+      overflow_bit, smt_bit_vector_constant_termt{0, 1});
+
+    const auto result =
+      smt_bit_vector_theoryt::extract(width - 1, 0)(extended_result);
+
+    // Saturate to 0 on subtraction underflow, to the unsigned MAX (2^N - 1)
+    // on addition overflow.
+    const auto saturation =
+      subtract ? smt_bit_vector_constant_termt{0, width}
+               : smt_bit_vector_constant_termt{power(2, width) - 1, width};
+
+    return smt_core_theoryt::if_then_else(no_overflow, result, saturation);
+  }
+  UNIMPLEMENTED_FEATURE(
+    "Generation of SMT formula for saturating " +
+    std::string{subtract ? "minus" : "plus"} + " expression: " + expr.pretty());
+}
+
+static smt_termt convert_expr_to_smt(
+  const saturating_plus_exprt &saturating_plus,
+  const sub_expression_mapt &converted)
+{
+  return convert_saturating_add_or_subtract(
+    saturating_plus, converted, /*subtract=*/false);
+}
+
+static smt_termt convert_expr_to_smt(
+  const saturating_minus_exprt &saturating_minus,
+  const sub_expression_mapt &converted)
+{
+  return convert_saturating_add_or_subtract(
+    saturating_minus, converted, /*subtract=*/true);
+}
+
 static smt_termt convert_expr_to_smt(
   const pointer_object_exprt &pointer_object,
   const sub_expression_mapt &converted)
@@ -1782,6 +1887,18 @@ static smt_termt dispatch_expr_to_smt_conversion(
   if(const auto shl_overflow = expr_try_dynamic_cast<shl_overflow_exprt>(expr))
   {
     return convert_expr_to_smt(*shl_overflow, converted);
+  }
+  if(
+    const auto saturating_plus =
+      expr_try_dynamic_cast<saturating_plus_exprt>(expr))
+  {
+    return convert_expr_to_smt(*saturating_plus, converted);
+  }
+  if(
+    const auto saturating_minus =
+      expr_try_dynamic_cast<saturating_minus_exprt>(expr))
+  {
+    return convert_expr_to_smt(*saturating_minus, converted);
   }
   if(const auto array_construction = expr_try_dynamic_cast<array_exprt>(expr))
   {

--- a/unit/solvers/smt2_incremental/convert_expr_to_smt.cpp
+++ b/unit/solvers/smt2_incremental/convert_expr_to_smt.cpp
@@ -1776,3 +1776,89 @@ TEST_CASE(
     CHECK(test.convert(assignment) == expected);
   }
 }
+
+TEST_CASE(
+  "expr to smt conversion for \"saturating_plus\" operator",
+  "[core][smt2_incremental]")
+{
+  auto test = expr_to_smt_conversion_test_environmentt::make(test_archt::i386);
+  SECTION("signed")
+  {
+    const signedbv_typet type{8};
+    const symbol_exprt left{"a", type};
+    const symbol_exprt right{"b", type};
+    const auto extended = smt_bit_vector_theoryt::add(
+      smt_bit_vector_theoryt::sign_extend(1)(test.convert(left)),
+      smt_bit_vector_theoryt::sign_extend(1)(test.convert(right)));
+    const auto extension_bit = smt_bit_vector_theoryt::extract(8, 8)(extended);
+    const auto sign_bit = smt_bit_vector_theoryt::extract(7, 7)(extended);
+    const auto expected = smt_core_theoryt::if_then_else(
+      smt_core_theoryt::equal(extension_bit, sign_bit),
+      smt_bit_vector_theoryt::extract(7, 0)(extended),
+      smt_core_theoryt::if_then_else(
+        smt_core_theoryt::equal(
+          extension_bit, smt_bit_vector_constant_termt{0, 1}),
+        smt_bit_vector_constant_termt{127, 8},
+        smt_bit_vector_constant_termt{128, 8}));
+    CHECK(test.convert(saturating_plus_exprt{left, right}) == expected);
+  }
+  SECTION("unsigned")
+  {
+    const unsignedbv_typet type{8};
+    const symbol_exprt left{"a", type};
+    const symbol_exprt right{"b", type};
+    const auto extended = smt_bit_vector_theoryt::add(
+      smt_bit_vector_theoryt::zero_extend(1)(test.convert(left)),
+      smt_bit_vector_theoryt::zero_extend(1)(test.convert(right)));
+    const auto overflow_bit = smt_bit_vector_theoryt::extract(8, 8)(extended);
+    const auto expected = smt_core_theoryt::if_then_else(
+      smt_core_theoryt::equal(
+        overflow_bit, smt_bit_vector_constant_termt{0, 1}),
+      smt_bit_vector_theoryt::extract(7, 0)(extended),
+      smt_bit_vector_constant_termt{255, 8});
+    CHECK(test.convert(saturating_plus_exprt{left, right}) == expected);
+  }
+}
+
+TEST_CASE(
+  "expr to smt conversion for \"saturating_minus\" operator",
+  "[core][smt2_incremental]")
+{
+  auto test = expr_to_smt_conversion_test_environmentt::make(test_archt::i386);
+  SECTION("signed")
+  {
+    const signedbv_typet type{8};
+    const symbol_exprt left{"a", type};
+    const symbol_exprt right{"b", type};
+    const auto extended = smt_bit_vector_theoryt::subtract(
+      smt_bit_vector_theoryt::sign_extend(1)(test.convert(left)),
+      smt_bit_vector_theoryt::sign_extend(1)(test.convert(right)));
+    const auto extension_bit = smt_bit_vector_theoryt::extract(8, 8)(extended);
+    const auto sign_bit = smt_bit_vector_theoryt::extract(7, 7)(extended);
+    const auto expected = smt_core_theoryt::if_then_else(
+      smt_core_theoryt::equal(extension_bit, sign_bit),
+      smt_bit_vector_theoryt::extract(7, 0)(extended),
+      smt_core_theoryt::if_then_else(
+        smt_core_theoryt::equal(
+          extension_bit, smt_bit_vector_constant_termt{0, 1}),
+        smt_bit_vector_constant_termt{127, 8},
+        smt_bit_vector_constant_termt{128, 8}));
+    CHECK(test.convert(saturating_minus_exprt{left, right}) == expected);
+  }
+  SECTION("unsigned")
+  {
+    const unsignedbv_typet type{8};
+    const symbol_exprt left{"a", type};
+    const symbol_exprt right{"b", type};
+    const auto extended = smt_bit_vector_theoryt::subtract(
+      smt_bit_vector_theoryt::zero_extend(1)(test.convert(left)),
+      smt_bit_vector_theoryt::zero_extend(1)(test.convert(right)));
+    const auto underflow_bit = smt_bit_vector_theoryt::extract(8, 8)(extended);
+    const auto expected = smt_core_theoryt::if_then_else(
+      smt_core_theoryt::equal(
+        underflow_bit, smt_bit_vector_constant_termt{0, 1}),
+      smt_bit_vector_theoryt::extract(7, 0)(extended),
+      smt_bit_vector_constant_termt{0, 8});
+    CHECK(test.convert(saturating_minus_exprt{left, right}) == expected);
+  }
+}


### PR DESCRIPTION
Implements conversion of saturating_plus and saturating_minus expressions to SMT formulas for both signed and unsigned bit-vector types.

Fixes: #8070

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
