### PR TITLE
C front-end: recognize __builtin_inff() as constant expression

### DIFF
--- a/regression/cbmc-library/__builtin_inf-01/main.c
+++ b/regression/cbmc-library/__builtin_inf-01/main.c
@@ -1,9 +1,0 @@
-#include <assert.h>
-#include <math.h>
-
-int main()
-{
-  __builtin_inf();
-  assert(0);
-  return 0;
-}

--- a/regression/cbmc-library/__builtin_inff-01/main.c
+++ b/regression/cbmc-library/__builtin_inff-01/main.c
@@ -1,9 +1,0 @@
-#include <assert.h>
-#include <math.h>
-
-int main()
-{
-  __builtin_inff();
-  assert(0);
-  return 0;
-}

--- a/regression/cbmc-library/__builtin_inff-01/test.desc
+++ b/regression/cbmc-library/__builtin_inff-01/test.desc
@@ -1,8 +1,0 @@
-KNOWNBUG
-main.c
---pointer-check --bounds-check
-^EXIT=0$
-^SIGNAL=0$
-^VERIFICATION SUCCESSFUL$
---
-^warning: ignoring

--- a/regression/cbmc-library/__builtin_infl-01/main.c
+++ b/regression/cbmc-library/__builtin_infl-01/main.c
@@ -1,9 +1,0 @@
-#include <assert.h>
-#include <math.h>
-
-int main()
-{
-  __builtin_infl();
-  assert(0);
-  return 0;
-}

--- a/regression/cbmc-library/__builtin_infl-01/test.desc
+++ b/regression/cbmc-library/__builtin_infl-01/test.desc
@@ -1,8 +1,0 @@
-KNOWNBUG
-main.c
---pointer-check --bounds-check
-^EXIT=0$
-^SIGNAL=0$
-^VERIFICATION SUCCESSFUL$
---
-^warning: ignoring

--- a/regression/cbmc/builtin_inf/static_init.c
+++ b/regression/cbmc/builtin_inf/static_init.c
@@ -1,0 +1,42 @@
+#include <assert.h>
+#include <math.h>
+
+float g = -INFINITY;
+
+void test_static_float_infinity()
+{
+  static float f = +INFINITY;
+  assert(isinf(f));
+}
+
+void test_static_double_infinity()
+{
+  static double d = INFINITY;
+  assert(isinf(d));
+}
+
+void test_static_long_double_infinity()
+{
+  static long double ld = INFINITY;
+  assert(isinf(ld));
+}
+
+void test_static_huge_val()
+{
+  static float f = HUGE_VALF;
+  static double d = HUGE_VAL;
+  static long double ld = HUGE_VALL;
+
+  assert(isinf(f));
+  assert(isinf(d));
+  assert(isinf(ld));
+}
+
+int main()
+{
+  test_static_float_infinity();
+  test_static_double_infinity();
+  test_static_long_double_infinity();
+  test_static_huge_val();
+  return 0;
+}

--- a/regression/cbmc/builtin_inf/test.desc
+++ b/regression/cbmc/builtin_inf/test.desc
@@ -1,6 +1,6 @@
-KNOWNBUG
-main.c
---pointer-check --bounds-check
+CORE
+static_init.c
+
 ^EXIT=0$
 ^SIGNAL=0$
 ^VERIFICATION SUCCESSFUL$

--- a/src/ansi-c/c_typecheck_expr.cpp
+++ b/src/ansi-c/c_typecheck_expr.cpp
@@ -3265,8 +3265,9 @@ exprt c_typecheck_baset::do_special_functions(
 
     return typecast_exprt::conditional_cast(isfinite_expr, expr.type());
   }
-  else if(identifier==CPROVER_PREFIX "inf" ||
-          identifier=="__builtin_inf")
+  else if(
+    identifier == CPROVER_PREFIX "inf" || identifier == "__builtin_inf" ||
+    identifier == "__builtin_huge_val")
   {
     constant_exprt inf_expr=
       ieee_floatt::plus_infinity(
@@ -3275,7 +3276,9 @@ exprt c_typecheck_baset::do_special_functions(
 
     return std::move(inf_expr);
   }
-  else if(identifier==CPROVER_PREFIX "inff")
+  else if(
+    identifier == CPROVER_PREFIX "inff" || identifier == "__builtin_inff" ||
+    identifier == "__builtin_huge_valf")
   {
     constant_exprt inff_expr=
       ieee_floatt::plus_infinity(
@@ -3284,7 +3287,9 @@ exprt c_typecheck_baset::do_special_functions(
 
     return std::move(inff_expr);
   }
-  else if(identifier==CPROVER_PREFIX "infl")
+  else if(
+    identifier == CPROVER_PREFIX "infl" || identifier == "__builtin_infl" ||
+    identifier == "__builtin_huge_vall")
   {
     floatbv_typet type=to_floatbv_type(long_double_type());
     constant_exprt infl_expr=

--- a/src/ansi-c/library/math.c
+++ b/src/ansi-c/library/math.c
@@ -216,39 +216,6 @@ int __isnormalf(float f)
   return __CPROVER_isnormalf(f);
 }
 
-/* FUNCTION: __builtin_inff */
-
-float __builtin_inff(void)
-{
-#pragma CPROVER check push
-#pragma CPROVER check disable "float-div-by-zero"
-#pragma CPROVER check disable "float-overflow"
-  return 1.0f / 0.0f;
-#pragma CPROVER check pop
-}
-
-/* FUNCTION: __builtin_inf */
-
-double __builtin_inf(void)
-{
-#pragma CPROVER check push
-#pragma CPROVER check disable "float-div-by-zero"
-#pragma CPROVER check disable "float-overflow"
-  return 1.0 / 0.0;
-#pragma CPROVER check pop
-}
-
-/* FUNCTION: __builtin_infl */
-
-long double __builtin_infl(void)
-{
-#pragma CPROVER check push
-#pragma CPROVER check disable "float-div-by-zero"
-#pragma CPROVER check disable "float-overflow"
-  return 1.0l / 0.0l;
-#pragma CPROVER check pop
-}
-
 /* FUNCTION: __builtin_isinf */
 
 int __builtin_isinf(double d)


### PR DESCRIPTION
This is accepted as a constant expression by GCC, so we need to mimic this to successfully type check code that relies on this.

Fixes: #8710

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
