### PR TITLE
Implement incremental SMT2 support for `bswap_exprt`

### DIFF
--- a/regression/cbmc/gcc_bswap1/test.desc
+++ b/regression/cbmc/gcc_bswap1/test.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 main.c
 
 ^EXIT=10$

--- a/src/solvers/smt2_incremental/convert_expr_to_smt.cpp
+++ b/src/solvers/smt2_incremental/convert_expr_to_smt.cpp
@@ -1452,9 +1452,62 @@ static smt_termt convert_expr_to_smt(
   const bswap_exprt &byte_swap,
   const sub_expression_mapt &converted)
 {
-  UNIMPLEMENTED_FEATURE(
-    "Generation of SMT formula for byte swap expression: " +
-    byte_swap.pretty());
+  const auto operand_term = converted.at(byte_swap.op());
+  const auto &operand_type = byte_swap.op().type();
+
+  // bswap is only converted for bit-vector operands whose width is a multiple
+  // of the byte size. validate_expr(const bswap_exprt &) does not enforce
+  // this, so the guards below remain as explicit "unsupported" cases,
+  // mirroring conversion_failed in the bit-vector flattening backend
+  // (boolbv_bswap). The C front-end does not produce such bswap expressions,
+  // which is why these branches are not covered by tests.
+  if(!can_cast_type<bitvector_typet>(operand_type))
+  {
+    UNIMPLEMENTED_FEATURE(
+      "Generation of SMT formula for byte swap of non-bitvector type: " +
+      byte_swap.pretty());
+  }
+
+  const auto &bv_type = to_bitvector_type(operand_type);
+  const std::size_t width = bv_type.get_width();
+  const std::size_t byte_bits = byte_swap.get_bits_per_byte();
+
+  // Guard against a zero byte size before using it as a divisor below.
+  if(byte_bits == 0)
+  {
+    UNIMPLEMENTED_FEATURE(
+      "Generation of SMT formula for byte swap with zero-width bytes: " +
+      byte_swap.pretty());
+  }
+
+  // Unsupported (see above): width is expected to be a multiple of byte_bits.
+  if(width % byte_bits != 0)
+  {
+    UNIMPLEMENTED_FEATURE(
+      "Generation of SMT formula for byte swap with width not multiple of byte "
+      "size: " +
+      byte_swap.pretty());
+  }
+
+  const std::size_t num_bytes = width / byte_bits;
+
+  // If only one byte, no swapping needed
+  if(num_bytes == 1)
+    return operand_term;
+
+  // Reverse the byte order: extract each byte and concatenate, placing byte 0
+  // (originally least significant) in the most significant position.
+  // SMT concat(a, b) puts 'a' in the high bits.
+  const auto extract_byte = [&](std::size_t byte_idx)
+  {
+    return smt_bit_vector_theoryt::extract(
+      (byte_idx + 1) * byte_bits - 1, byte_idx * byte_bits)(operand_term);
+  };
+  smt_termt result = extract_byte(0);
+  for(std::size_t byte_idx = 1; byte_idx < num_bytes; ++byte_idx)
+    result = smt_bit_vector_theoryt::concat(result, extract_byte(byte_idx));
+
+  return result;
 }
 
 static smt_termt convert_expr_to_smt(

--- a/unit/solvers/smt2_incremental/convert_expr_to_smt.cpp
+++ b/unit/solvers/smt2_incremental/convert_expr_to_smt.cpp
@@ -1765,3 +1765,90 @@ TEST_CASE(
     CHECK(test.convert(assignment) == expected);
   }
 }
+
+TEST_CASE(
+  "expr to smt conversion for bswap_exprt expressions",
+  "[core][smt2_incremental]")
+{
+  auto test =
+    expr_to_smt_conversion_test_environmentt::make(test_archt::x86_64);
+
+  // Builds the expected byte-reversed term: extract each byte and concatenate
+  // so that byte 0 (originally least significant) becomes most significant,
+  // mirroring the conversion under test. Keeps the wide cases readable and
+  // easy to extend (e.g. to 128-bit).
+  const auto expected_bswap =
+    [](const smt_termt &op, std::size_t width, std::size_t byte_bits)
+  {
+    const std::size_t num_bytes = width / byte_bits;
+    const auto byte = [&](std::size_t i)
+    {
+      return smt_bit_vector_theoryt::extract(
+        (i + 1) * byte_bits - 1, i * byte_bits)(op);
+    };
+    smt_termt result = byte(0);
+    for(std::size_t i = 1; i < num_bytes; ++i)
+      result = smt_bit_vector_theoryt::concat(result, byte(i));
+    return result;
+  };
+
+  SECTION("16-bit byte swap")
+  {
+    const symbol_exprt operand{"my_value", unsignedbv_typet{16}};
+    const bswap_exprt byte_swap{operand, 8, unsignedbv_typet{16}};
+    INFO("Expression being converted: " + byte_swap.pretty(2, 0));
+    const smt_identifier_termt operand_smt{
+      "my_value", smt_bit_vector_sortt{16}};
+    // For 16-bit bswap, we extract [7:0] and [15:8], then concat in reverse
+    // order
+    // concat([7:0], [15:8]) puts [7:0] as most significant
+    const smt_termt expected = smt_bit_vector_theoryt::concat(
+      smt_bit_vector_theoryt::extract(7, 0)(operand_smt),
+      smt_bit_vector_theoryt::extract(15, 8)(operand_smt));
+    CHECK(test.convert(byte_swap) == expected);
+  }
+  SECTION("32-bit byte swap")
+  {
+    const symbol_exprt operand{"my_value", unsignedbv_typet{32}};
+    const bswap_exprt byte_swap{operand, 8, unsignedbv_typet{32}};
+    INFO("Expression being converted: " + byte_swap.pretty(2, 0));
+    const smt_identifier_termt operand_smt{
+      "my_value", smt_bit_vector_sortt{32}};
+    // For 32-bit bswap, we extract 4 bytes and concat in reverse order
+    CHECK(test.convert(byte_swap) == expected_bswap(operand_smt, 32, 8));
+  }
+  SECTION("64-bit byte swap")
+  {
+    const symbol_exprt operand{"my_value", unsignedbv_typet{64}};
+    const bswap_exprt byte_swap{operand, 8, unsignedbv_typet{64}};
+    INFO("Expression being converted: " + byte_swap.pretty(2, 0));
+    const smt_identifier_termt operand_smt{
+      "my_value", smt_bit_vector_sortt{64}};
+    // For 64-bit bswap, we extract 8 bytes and concat in reverse order
+    CHECK(test.convert(byte_swap) == expected_bswap(operand_smt, 64, 8));
+  }
+  SECTION("Single byte (no swap needed)")
+  {
+    const symbol_exprt operand{"my_value", unsignedbv_typet{8}};
+    const bswap_exprt byte_swap{operand, 8, unsignedbv_typet{8}};
+    INFO("Expression being converted: " + byte_swap.pretty(2, 0));
+    const smt_identifier_termt operand_smt{"my_value", smt_bit_vector_sortt{8}};
+    // Single byte should return operand unchanged
+    CHECK(test.convert(byte_swap) == operand_smt);
+  }
+  SECTION("Non-default byte width (two 16-bit halves)")
+  {
+    const symbol_exprt operand{"my_value", unsignedbv_typet{32}};
+    const bswap_exprt byte_swap{operand, 16, unsignedbv_typet{32}};
+    INFO("Expression being converted: " + byte_swap.pretty(2, 0));
+    const smt_identifier_termt operand_smt{
+      "my_value", smt_bit_vector_sortt{32}};
+    // With bits_per_byte == 16 the operand has two "bytes": extract [15:0] and
+    // [31:16] and concat in reverse so [15:0] becomes most significant. This
+    // exercises the byte_bits-parameterised extraction arithmetic.
+    const smt_termt expected = smt_bit_vector_theoryt::concat(
+      smt_bit_vector_theoryt::extract(15, 0)(operand_smt),
+      smt_bit_vector_theoryt::extract(31, 16)(operand_smt));
+    CHECK(test.convert(byte_swap) == expected);
+  }
+}


### PR DESCRIPTION
Implements byte swapping in the incremental SMT2 decision procedure and adds unit tests. Regression test `gcc_bswap1` now passes.

Fixes: #8064

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
