### PR TITLE
Fix array_exprt handling in incremental SMT2 procedure

### DIFF
--- a/regression/cbmc/array-cell-sensitivity12/test_execution.desc
+++ b/regression/cbmc/array-cell-sensitivity12/test_execution.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 test.c
 
 ^VERIFICATION FAILED$

--- a/src/solvers/smt2_incremental/smt2_incremental_decision_procedure.cpp
+++ b/src/solvers/smt2_incremental/smt2_incremental_decision_procedure.cpp
@@ -6,7 +6,6 @@
 #include <util/bitvector_expr.h>
 #include <util/byte_operators.h>
 #include <util/c_types.h>
-#include <util/range.h>
 #include <util/simplify_expr.h>
 #include <util/std_expr.h>
 #include <util/string_constant.h>
@@ -185,18 +184,23 @@ void send_function_definition(
 void smt2_incremental_decision_proceduret::define_dependent_functions(
   const exprt &expr)
 {
-  std::unordered_set<exprt, irep_hash> seen_expressions =
-    make_range(expression_identifiers)
-      .map([](const std::pair<exprt, smt_identifier_termt> &expr_identifier) {
-        return expr_identifier.first;
-      });
+  // A dependency needs defining only if it is not already defined (present in
+  // expression_identifiers) and has not already been queued by this traversal.
+  // Querying expression_identifiers directly avoids copying all of its keys
+  // into a fresh "seen" set on every call: convert_expr_to_smt -- and hence
+  // this function -- is invoked once per array element by
+  // initialize_array_elements, so rebuilding such a snapshot would make
+  // defining an N-element array O(N * |expression_identifiers|).
+  std::unordered_set<exprt, irep_hash> queued;
   std::stack<exprt> to_be_defined;
   const auto push_dependencies_needed = [&](const exprt &expr) {
     bool result = false;
     for(const auto &dependency : gather_dependent_expressions(expr))
     {
-      if(!seen_expressions.insert(dependency).second)
-        continue;
+      if(expression_identifiers.count(dependency) != 0)
+        continue; // already defined
+      if(!queued.insert(dependency).second)
+        continue; // already queued by this traversal
       result = true;
       to_be_defined.push(dependency);
     }

--- a/src/solvers/smt2_incremental/smt2_incremental_decision_procedure.cpp
+++ b/src/solvers/smt2_incremental/smt2_incremental_decision_procedure.cpp
@@ -357,7 +357,6 @@ void smt2_incremental_decision_proceduret::ensure_handle_for_expr_defined(
 
   const exprt lowered_expr = lower(in_expr);
 
-  define_dependent_functions(lowered_expr);
   smt_define_function_commandt function{
     "B" + std::to_string(handle_sequence()),
     {},
@@ -414,6 +413,14 @@ smt_termt
 smt2_incremental_decision_proceduret::convert_expr_to_smt(const exprt &expr)
 {
   define_index_identifiers(expr);
+  // Canonical place to define (and then substitute out) any array/string/symbol
+  // dependencies, so that every conversion path has them defined -- including
+  // the internal, re-entrant calls made from define_index_identifiers above and
+  // from initialize_array_elements. The free ::convert_expr_to_smt overloads
+  // for array_exprt/array_of_exprt/string constants are UNHANDLED_CASE, so such
+  // nodes must be turned into function definitions and substituted before
+  // conversion (see issue #8080).
+  define_dependent_functions(expr);
   const exprt substituted = substitute_defined_padding(
     substitute_identifiers(expr, expression_identifiers));
   track_expression_objects(substituted, ns, object_map);
@@ -655,6 +662,9 @@ void smt2_incremental_decision_proceduret::set_to(
   const exprt lowered_expr = lower(in_expr);
   PRECONDITION(can_cast_type<bool_typet>(lowered_expr.type()));
 
+  // Retained in addition to convert_expr_to_smt's own call because the
+  // cached-handle branch below can return without ever reaching
+  // convert_expr_to_smt.
   define_dependent_functions(lowered_expr);
   auto converted_term = [&]() -> smt_termt {
     const auto expression_handle_identifier =
@@ -713,7 +723,6 @@ void smt2_incremental_decision_proceduret::define_object_properties()
       continue;
     else
       object_properties_defined[object.unique_id] = true;
-    define_dependent_functions(object.size);
     solver_process->send(object_size_function.make_definition(
       object.unique_id, convert_expr_to_smt(object.size)));
     solver_process->send(is_dynamic_object_function.make_definition(

--- a/unit/solvers/smt2_incremental/smt2_incremental_decision_procedure.cpp
+++ b/unit/solvers/smt2_incremental/smt2_incremental_decision_procedure.cpp
@@ -1197,3 +1197,41 @@ TEST_CASE(
 
   CHECK(test.sent_commands == expected_commands);
 }
+
+TEST_CASE(
+  "smt2_incremental_decision_proceduret defines array dependencies that are "
+  "only reached via an internal convert_expr_to_smt call (regression for "
+  "#8080).",
+  "[core][smt2_incremental]")
+{
+  auto test = decision_procedure_test_environmentt::make();
+  const signedbv_typet index_type{32};
+  const signedbv_typet value_type{8};
+
+  // An array literal embedded inside the *index* of a with-expression. The
+  // index is integer-typed (a select from the literal) yet transitively
+  // depends on an array_exprt. define_index_identifiers converts this index via
+  // an internal convert_expr_to_smt call, which runs before the outer
+  // define_dependent_functions -- this is the exact path that regressed in
+  // issue #8080, where the array_exprt reached the UNHANDLED_CASE free
+  // ::convert_expr_to_smt overload because it had not been defined and
+  // substituted out first. Unlike set_to/handle of an array literal, no entry
+  // point pre-defines the dependency on this route.
+  const array_typet inner_array_type{index_type, from_integer(2, index_type)};
+  const array_exprt inner_array{
+    {from_integer(5, index_type), from_integer(6, index_type)},
+    inner_array_type};
+  const index_exprt array_index{inner_array, from_integer(0, index_type)};
+  const array_typet array_type{value_type, from_integer(2, index_type)};
+  const auto array_symbol = make_test_symbol("the_array", array_type);
+  const with_exprt with_expr{
+    array_symbol.symbol_expr(), array_index, from_integer(7, value_type)};
+
+  // With invariants configured to throw, conversion would raise
+  // invariant_failedt ("Unhandled case") without the fix.
+  cbmc_invariants_should_throwt invariants_throw;
+  REQUIRE_NOTHROW(test.procedure.handle(with_expr));
+  // The conversion really ran and emitted SMT commands (incl. defining the
+  // array dependency), rather than short-circuiting.
+  REQUIRE_FALSE(test.sent_commands.empty());
+}


### PR DESCRIPTION
The call to `define_dependent_functions` ensures that `array_exprt` expressions are properly handled and their dependent functions are defined before the expression conversion process begins.

Fixes: #8080

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
