### PR TITLE
Refactor basic block detection into standalone utility module

### DIFF
--- a/src/analyses/basic_blocks.h
+++ b/src/analyses/basic_blocks.h
@@ -1,0 +1,194 @@
+/*******************************************************************\
+
+Module: Basic Block Detection for Goto Programs
+
+Author: Daniel Kroening, Peter Schrammel
+
+\*******************************************************************/
+
+/// \file
+/// Generic basic block detection for goto programs.
+///
+/// Extracted from goto-instrument/cover_basic_blocks.{cpp,h} so the analysis
+/// can be reused outside coverage instrumentation. Two detection strategies
+/// are provided as separate compile-time analyses, mirroring the template-only
+/// style of natural_loops_templatet (no runtime/virtual dispatch):
+///   - basic_blocks_templatet: control-flow based detection (C/C++);
+///   - java_basic_blocks_templatet: bytecode-index based detection (Java).
+
+#ifndef CPROVER_ANALYSES_BASIC_BLOCKS_H
+#define CPROVER_ANALYSES_BASIC_BLOCKS_H
+
+#include <util/invariant.h>
+#include <util/irep.h>
+#include <util/source_location.h>
+
+#include <goto-programs/goto_program.h>
+
+#include <map>
+#include <optional>
+#include <unordered_map>
+#include <vector>
+
+/// Options controlling basic block detection.
+struct basic_block_configt
+{
+  /// If true, an assume instruction terminates a basic block (subsequent
+  /// instructions may be unreachable). Consecutive assume instructions that
+  /// share a source line are kept in the same block, since a single program
+  /// location may carry several assumptions (e.g. emitted by an instrumentation
+  /// pass).
+  bool assume_delimit_blocks = true;
+
+  basic_block_configt() = default;
+  explicit basic_block_configt(bool _assume_delimit_blocks)
+    : assume_delimit_blocks(_assume_delimit_blocks)
+  {
+  }
+};
+
+/// Storage and accessors shared by the basic block analyses. The detection
+/// strategy (compute and block_of) is supplied by the derived analysis; the
+/// concrete analysis is selected at compile time, so there is no virtual
+/// dispatch.
+template <class T>
+class basic_blocks_baset
+{
+public:
+  /// Information about a single basic block.
+  struct block_infot
+  {
+    /// Instruction representative of this block (for instrumentation).
+    std::optional<T> representative_inst;
+    /// Source location representative of this block.
+    source_locationt source_location;
+  };
+
+  /// \return the representative instruction of block \p block_nr, if any.
+  std::optional<T> instruction_of(std::size_t block_nr) const
+  {
+    INVARIANT(block_nr < block_infos.size(), "block number out of range");
+    return block_infos[block_nr].representative_inst;
+  }
+
+  /// \return the representative source location of block \p block_nr.
+  const source_locationt &source_location_of(std::size_t block_nr) const
+  {
+    INVARIANT(block_nr < block_infos.size(), "block number out of range");
+    return block_infos[block_nr].source_location;
+  }
+
+  /// \return the number of detected blocks.
+  std::size_t size() const
+  {
+    return block_infos.size();
+  }
+
+protected:
+  ~basic_blocks_baset() = default;
+
+  /// Information about each block, indexed by block number.
+  std::vector<block_infot> block_infos;
+};
+
+/// Control-flow based basic block detection (C/C++).
+///
+/// \tparam P: program type (e.g. const goto_programt)
+/// \tparam T: instruction iterator type
+/// \tparam C: comparison functor ordering iterators
+template <class P, class T, typename C>
+class basic_blocks_templatet : public basic_blocks_baset<T>
+{
+public:
+  using typename basic_blocks_baset<T>::block_infot;
+  using block_mapt = std::map<T, std::size_t, C>;
+
+  /// Detect the basic blocks of \p program.
+  explicit basic_blocks_templatet(
+    const P &program,
+    const basic_block_configt &config = basic_block_configt())
+  {
+    compute(program, config);
+  }
+
+  /// \return the block number containing instruction \p t.
+  std::size_t block_of(T t) const
+  {
+    const auto it = block_map.find(t);
+    INVARIANT(it != block_map.end(), "instruction must be part of a block");
+    return it->second;
+  }
+
+  /// \return the instruction-to-block-number map, ordered by instruction.
+  const block_mapt &instruction_blocks() const
+  {
+    return block_map;
+  }
+
+protected:
+  /// Map each instruction to its block number.
+  block_mapt block_map;
+
+  void compute(const P &program, const basic_block_configt &config);
+
+  /// \return the block number this instruction continues, when it is reached
+  ///   only via a single unconditional forward goto.
+  static std::optional<std::size_t>
+  continuation_of_block(T instruction, block_mapt &block_map);
+
+  /// \return true iff \p a and \p b are on the same source line.
+  static bool
+  same_source_line(const source_locationt &a, const source_locationt &b)
+  {
+    return a.get_file() == b.get_file() && a.get_line() == b.get_line();
+  }
+};
+
+/// Bytecode-index based basic block detection (Java).
+///
+/// \tparam P: program type (e.g. const goto_programt)
+/// \tparam T: instruction iterator type
+template <class P, class T>
+class java_basic_blocks_templatet : public basic_blocks_baset<T>
+{
+public:
+  using typename basic_blocks_baset<T>::block_infot;
+
+  /// Detect the basic blocks of \p program.
+  explicit java_basic_blocks_templatet(const P &program)
+  {
+    compute(program);
+  }
+
+  /// \return the block number containing instruction \p t.
+  std::size_t block_of(T t) const
+  {
+    const auto &bytecode_index = t->source_location().get_java_bytecode_index();
+    const auto it = index_to_block.find(bytecode_index);
+    INVARIANT(
+      it != index_to_block.end(), "instruction must be part of a block");
+    return it->second;
+  }
+
+protected:
+  /// Map each Java bytecode index to its block number.
+  std::unordered_map<irep_idt, std::size_t> index_to_block;
+
+  void compute(const P &program);
+};
+
+/// Basic block detection on const goto programs (C/C++).
+using basic_blockst = basic_blocks_templatet<
+  const goto_programt,
+  goto_programt::const_targett,
+  goto_programt::target_less_than>;
+
+/// Basic block detection on const goto programs (Java).
+using java_basic_blockst = java_basic_blocks_templatet<
+  const goto_programt,
+  goto_programt::const_targett>;
+
+// Include template implementations
+#include "basic_blocks_impl.h"
+
+#endif // CPROVER_ANALYSES_BASIC_BLOCKS_H

--- a/src/analyses/basic_blocks_impl.h
+++ b/src/analyses/basic_blocks_impl.h
@@ -1,0 +1,138 @@
+/*******************************************************************\
+
+Module: Basic Block Detection - Template Implementations
+
+Author: Daniel Kroening, Peter Schrammel
+
+\*******************************************************************/
+
+/// \file
+/// Template implementations for basic block detection (see basic_blocks.h).
+/// Extracted from goto-instrument/cover_basic_blocks.cpp.
+
+#ifndef CPROVER_ANALYSES_BASIC_BLOCKS_IMPL_H
+#define CPROVER_ANALYSES_BASIC_BLOCKS_IMPL_H
+
+// ============================================================================
+// Control-flow based detection (C/C++)
+// ============================================================================
+
+template <class P, class T, typename C>
+std::optional<std::size_t>
+basic_blocks_templatet<P, T, C>::continuation_of_block(
+  T instruction,
+  block_mapt &block_map)
+{
+  if(instruction->incoming_edges.size() != 1)
+    return {};
+
+  const auto in_t = *instruction->incoming_edges.cbegin();
+  if(
+    in_t->is_goto() && !in_t->is_backwards_goto() &&
+    in_t->condition().is_true())
+  {
+    const auto it = block_map.find(in_t);
+    if(it != block_map.end())
+      return it->second;
+  }
+
+  return {};
+}
+
+template <class P, class T, typename C>
+void basic_blocks_templatet<P, T, C>::compute(
+  const P &program,
+  const basic_block_configt &config)
+{
+  block_map.clear();
+  this->block_infos.clear();
+
+  bool next_is_target = true;
+  const typename P::instructiont *preceding_assume = nullptr;
+  std::size_t current_block = 0;
+
+  forall_goto_program_instructions(it, program)
+  {
+    // When assume_delimit_blocks is set, an assume instruction terminates a
+    // block (subsequent instructions may be unreachable). Multiple consecutive
+    // assume instructions that share a source line are kept in the same block,
+    // since a single program location may carry several assumptions (e.g.
+    // emitted by an instrumentation pass).
+    bool end_of_assume_group = false;
+    if(config.assume_delimit_blocks)
+    {
+      end_of_assume_group =
+        preceding_assume &&
+        !(it->is_assume() &&
+          same_source_line(
+            preceding_assume->source_location(), it->source_location()));
+    }
+
+    // Is it a potential beginning of a block?
+    if(next_is_target || it->is_target() || end_of_assume_group)
+    {
+      if(auto block_number = continuation_of_block(it, block_map))
+      {
+        current_block = *block_number;
+      }
+      else
+      {
+        this->block_infos.emplace_back();
+        this->block_infos.back().representative_inst = it;
+        this->block_infos.back().source_location = source_locationt::nil();
+        current_block = this->block_infos.size() - 1;
+      }
+    }
+
+    INVARIANT(
+      current_block < this->block_infos.size(),
+      "current block number out of range");
+    block_infot &block_info = this->block_infos.at(current_block);
+
+    block_map[it] = current_block;
+
+    // Set representative program location to instrument
+    if(
+      !it->source_location().is_nil() &&
+      !it->source_location().get_file().empty() &&
+      !it->source_location().get_line().empty() &&
+      !it->source_location().is_built_in() &&
+      block_info.source_location.is_nil())
+    {
+      block_info.representative_inst = it; // update
+      block_info.source_location = it->source_location();
+    }
+
+    next_is_target = it->is_goto() || it->is_function_call();
+
+    if(config.assume_delimit_blocks)
+      preceding_assume = it->is_assume() ? &*it : nullptr;
+  }
+}
+
+// ============================================================================
+// Bytecode-index based detection (Java)
+// ============================================================================
+
+template <class P, class T>
+void java_basic_blocks_templatet<P, T>::compute(const P &program)
+{
+  this->block_infos.clear();
+  index_to_block.clear();
+
+  forall_goto_program_instructions(it, program)
+  {
+    const auto &location = it->source_location();
+    const auto &bytecode_index = location.get_java_bytecode_index();
+    auto entry =
+      index_to_block.emplace(bytecode_index, this->block_infos.size());
+    if(entry.second)
+    {
+      this->block_infos.emplace_back();
+      this->block_infos.back().representative_inst = it;
+      this->block_infos.back().source_location = location;
+    }
+  }
+}
+
+#endif // CPROVER_ANALYSES_BASIC_BLOCKS_IMPL_H

--- a/src/goto-instrument/cover_basic_blocks.cpp
+++ b/src/goto-instrument/cover_basic_blocks.cpp
@@ -8,111 +8,51 @@ Author: Peter Schrammel
 
 /// \file
 /// Basic blocks detection for Coverage Instrumentation
+/// This file adapts the generic basic block detection utility from
+/// src/analyses/basic_blocks.h for use in coverage instrumentation.
 
 #include "cover_basic_blocks.h"
 
 #include <util/message.h>
 
-std::optional<std::size_t> cover_basic_blockst::continuation_of_block(
-  const goto_programt::const_targett &instruction,
-  cover_basic_blockst::block_mapt &block_map)
+#include <analyses/basic_blocks.h>
+
+// ============================================================================
+// cover_basic_blockst implementation (default C/C++ behavior)
+// ============================================================================
+
+cover_basic_blockst::cover_basic_blockst(
+  const goto_programt &goto_program,
+  const basic_block_configt &config)
+  : blocks(goto_program, config)
 {
-  if(instruction->incoming_edges.size() != 1)
-    return {};
+  // Initialize extended information for each block (source lines)
+  block_infos.resize(blocks.size());
 
-  const goto_programt::targett in_t = *instruction->incoming_edges.cbegin();
-  if(in_t->is_goto() && !in_t->is_backwards_goto() && in_t->condition() == true)
-    return block_map[in_t];
-
-  return {};
-}
-
-static bool
-same_source_line(const source_locationt &a, const source_locationt &b)
-{
-  return a.get_file() == b.get_file() && a.get_line() == b.get_line();
-}
-
-cover_basic_blockst::cover_basic_blockst(const goto_programt &goto_program)
-{
-  bool next_is_target = true;
-  const goto_programt::instructiont *preceding_assume = nullptr;
-  std::size_t current_block = 0;
-
+  // Collect source lines for each instruction
   forall_goto_program_instructions(it, goto_program)
   {
-    // For the purposes of coverage blocks, multiple consecutive assume
-    // instructions with the same source location are considered to be part of
-    // the same block. Assumptions should terminate a block, as subsequent
-    // instructions may be unreachable. However check instrumentation passes
-    // may insert multiple assertions in the same program location. Therefore
-    // these are combined for reasons of readability of the coverage output.
-    bool end_of_assume_group =
-      preceding_assume &&
-      !(it->is_assume() &&
-        same_source_line(
-          preceding_assume->source_location(), it->source_location()));
-
-    // Is it a potential beginning of a block?
-    if(next_is_target || it->is_target() || end_of_assume_group)
-    {
-      if(auto block_number = continuation_of_block(it, block_map))
-      {
-        current_block = *block_number;
-      }
-      else
-      {
-        block_infos.emplace_back();
-        block_infos.back().representative_inst = it;
-        block_infos.back().source_location = source_locationt::nil();
-        current_block = block_infos.size() - 1;
-      }
-    }
-
-    INVARIANT(
-      current_block < block_infos.size(), "current block number out of range");
-    block_infot &block_info = block_infos.at(current_block);
-
-    block_map[it] = current_block;
-
-    add_block_lines(block_info, *it);
-
-    // set representative program location to instrument
-    if(
-      !it->source_location().is_nil() &&
-      !it->source_location().get_file().empty() &&
-      !it->source_location().get_line().empty() &&
-      !it->source_location().is_built_in() &&
-      block_info.source_location.is_nil())
-    {
-      block_info.representative_inst = it; // update
-      block_info.source_location = it->source_location();
-    }
-
-    next_is_target = it->is_goto() || it->is_function_call();
-    preceding_assume = it->is_assume() ? &*it : nullptr;
+    const std::size_t block_nr = blocks.block_of(it);
+    INVARIANT(block_nr < block_infos.size(), "block number out of range");
+    add_block_lines(block_infos[block_nr], *it);
   }
 }
 
 std::size_t cover_basic_blockst::block_of(goto_programt::const_targett t) const
 {
-  const auto it = block_map.find(t);
-  INVARIANT(it != block_map.end(), "instruction must be part of a block");
-  return it->second;
+  return blocks.block_of(t);
 }
 
 std::optional<goto_programt::const_targett>
 cover_basic_blockst::instruction_of(const std::size_t block_nr) const
 {
-  INVARIANT(block_nr < block_infos.size(), "block number out of range");
-  return block_infos[block_nr].representative_inst;
+  return blocks.instruction_of(block_nr);
 }
 
 const source_locationt &
 cover_basic_blockst::source_location_of(const std::size_t block_nr) const
 {
-  INVARIANT(block_nr < block_infos.size(), "block number out of range");
-  return block_infos[block_nr].source_location;
+  return blocks.source_location_of(block_nr);
 }
 
 const source_linest &
@@ -131,21 +71,20 @@ void cover_basic_blockst::report_block_anomalies(
   std::set<std::size_t> blocks_seen;
   forall_goto_program_instructions(it, goto_program)
   {
-    const std::size_t block_nr = block_of(it);
-    const block_infot &block_info = block_infos.at(block_nr);
+    const std::size_t block_nr = blocks.block_of(it);
+    const auto representative_inst = blocks.instruction_of(block_nr);
+    const auto &source_location = blocks.source_location_of(block_nr);
 
     if(
       blocks_seen.insert(block_nr).second &&
-      block_info.representative_inst == goto_program.instructions.end())
+      representative_inst == goto_program.instructions.end())
     {
       msg.warning() << "Ignoring block " << (block_nr + 1) << " location "
                     << it->location_number << " " << it->source_location()
                     << " (bytecode-index already instrumented)"
                     << messaget::eom;
     }
-    else if(
-      block_info.representative_inst == it &&
-      block_info.source_location.is_nil())
+    else if(representative_inst == it && source_location.is_nil())
     {
       msg.warning() << "Ignoring block " << (block_nr + 1) << " location "
                     << it->location_number << " " << function_id
@@ -158,7 +97,8 @@ void cover_basic_blockst::report_block_anomalies(
 
 void cover_basic_blockst::output(std::ostream &out) const
 {
-  for(const auto &block_pair : block_map)
+  // One line per instruction: its source location -> containing block number.
+  for(const auto &block_pair : blocks.instruction_blocks())
     out << block_pair.first->source_location() << " -> " << block_pair.second
         << '\n';
 }
@@ -182,59 +122,55 @@ void cover_basic_blockst::add_block_lines(
   });
 }
 
+// ============================================================================
+// cover_basic_blocks_javat implementation (Java-specific behavior)
+// ============================================================================
+
 cover_basic_blocks_javat::cover_basic_blocks_javat(
-  const goto_programt &_goto_program)
+  const goto_programt &goto_program)
+  : blocks(goto_program)
 {
-  forall_goto_program_instructions(it, _goto_program)
+  // Initialize source lines for each block
+  block_source_lines.resize(blocks.size());
+
+  // Collect source lines for each instruction
+  forall_goto_program_instructions(it, goto_program)
   {
+    const std::size_t block_nr = blocks.block_of(it);
+    INVARIANT(
+      block_nr < block_source_lines.size(), "block number out of range");
     const auto &location = it->source_location();
-    const auto &bytecode_index = location.get_java_bytecode_index();
-    auto entry = index_to_block.emplace(bytecode_index, block_infos.size());
-    if(entry.second)
-    {
-      block_infos.push_back(it);
-      block_locations.push_back(location);
-      block_source_lines.emplace_back(location);
-    }
-    else
-    {
-      block_source_lines[entry.first->second].insert(location);
-    }
+    block_source_lines[block_nr].insert(location);
   }
 }
 
 std::size_t
 cover_basic_blocks_javat::block_of(goto_programt::const_targett t) const
 {
-  const auto &bytecode_index = t->source_location().get_java_bytecode_index();
-  const auto it = index_to_block.find(bytecode_index);
-  INVARIANT(it != index_to_block.end(), "instruction must be part of a block");
-  return it->second;
+  return blocks.block_of(t);
 }
 
 std::optional<goto_programt::const_targett>
 cover_basic_blocks_javat::instruction_of(const std::size_t block_nr) const
 {
-  PRECONDITION(block_nr < block_infos.size());
-  return block_infos[block_nr];
+  return blocks.instruction_of(block_nr);
 }
 
 const source_locationt &
 cover_basic_blocks_javat::source_location_of(const std::size_t block_nr) const
 {
-  PRECONDITION(block_nr < block_locations.size());
-  return block_locations[block_nr];
+  return blocks.source_location_of(block_nr);
 }
 
 const source_linest &
 cover_basic_blocks_javat::source_lines_of(const std::size_t block_nr) const
 {
-  PRECONDITION(block_nr < block_locations.size());
+  PRECONDITION(block_nr < block_source_lines.size());
   return block_source_lines[block_nr];
 }
 
 void cover_basic_blocks_javat::output(std::ostream &out) const
 {
-  for(std::size_t i = 0; i < block_locations.size(); ++i)
-    out << block_locations[i] << " -> " << i << '\n';
+  for(std::size_t i = 0; i < blocks.size(); ++i)
+    out << blocks.source_location_of(i) << " -> " << i << '\n';
 }

--- a/src/goto-instrument/cover_basic_blocks.h
+++ b/src/goto-instrument/cover_basic_blocks.h
@@ -8,11 +8,18 @@ Author: Daniel Kroening
 
 /// \file
 /// Basic blocks detection for Coverage Instrumentation
+///
+/// This module provides an adapter layer between the generic basic block
+/// detection utility in src/analyses/basic_blocks.h and the coverage
+/// instrumentation system. It extends the basic block detection with
+/// source line tracking needed for coverage reporting.
 
 #ifndef CPROVER_GOTO_INSTRUMENT_COVER_BASIC_BLOCKS_H
 #define CPROVER_GOTO_INSTRUMENT_COVER_BASIC_BLOCKS_H
 
 #include <goto-programs/goto_program.h>
+
+#include <analyses/basic_blocks.h>
 
 #include "source_lines.h"
 
@@ -62,10 +69,18 @@ public:
   }
 };
 
+/// Default basic block detection for C/C++ with source line tracking
+/// This adapter extends the generic basic_blockst with source line
+/// information needed for coverage reporting.
 class cover_basic_blockst final : public cover_blocks_baset
 {
 public:
-  explicit cover_basic_blockst(const goto_programt &goto_program);
+  /// Create basic block detector for the given program
+  /// \param goto_program: The program to analyze
+  /// \param config: Configuration for block detection (optional)
+  explicit cover_basic_blockst(
+    const goto_programt &goto_program,
+    const basic_block_configt &config = basic_block_configt());
 
   /// \param t: a goto instruction
   /// \return the block number of the block
@@ -101,57 +116,32 @@ public:
   void output(std::ostream &out) const override;
 
 private:
-  typedef std::map<
-    goto_programt::const_targett,
-    std::size_t,
-    goto_programt::target_less_than>
-    block_mapt;
+  /// The underlying basic block detector
+  basic_blockst blocks;
 
+  /// Extended block information with source lines
   struct block_infot
   {
-    /// the program location to instrument for this block
-    std::optional<goto_programt::const_targett> representative_inst;
-
-    /// the source location representative for this block
-    /// (we need a separate copy of source locations because we attach
-    ///  the line number ranges to them)
-    source_locationt source_location;
-
     /// the set of source code lines belonging to this block
     source_linest source_lines;
   };
 
-  /// map program locations to block numbers
-  block_mapt block_map;
-  /// map block numbers to block information
+  /// Extended information for each block
   std::vector<block_infot> block_infos;
 
   /// Adds the lines which \p instruction spans to \p block.
   static void add_block_lines(
-    cover_basic_blockst::block_infot &block,
+    block_infot &block,
     const goto_programt::instructiont &instruction);
-
-  /// If this block is a continuation of a previous block through unconditional
-  /// forward gotos, return this blocks number.
-  static std::optional<std::size_t> continuation_of_block(
-    const goto_programt::const_targett &instruction,
-    block_mapt &block_map);
 };
 
+/// Java-specific basic block detection with source line tracking
 class cover_basic_blocks_javat final : public cover_blocks_baset
 {
-private:
-  // map block number to first instruction of the block
-  std::vector<goto_programt::const_targett> block_infos;
-  // map block number to its location
-  std::vector<source_locationt> block_locations;
-  // map java indexes to block indexes
-  std::unordered_map<irep_idt, std::size_t> index_to_block;
-  // map block number to its source lines
-  std::vector<source_linest> block_source_lines;
-
 public:
-  explicit cover_basic_blocks_javat(const goto_programt &_goto_program);
+  /// Create basic block detector for Java programs
+  /// \param goto_program: The program to analyze
+  explicit cover_basic_blocks_javat(const goto_programt &goto_program);
 
   /// \param t: a goto instruction
   /// \return block number the given goto instruction is part of
@@ -173,6 +163,13 @@ public:
 
   /// Outputs the list of blocks
   void output(std::ostream &out) const override;
+
+private:
+  /// The underlying Java basic block detector
+  java_basic_blockst blocks;
+
+  /// Source lines for each block
+  std::vector<source_linest> block_source_lines;
 };
 
 #endif // CPROVER_GOTO_INSTRUMENT_COVER_BASIC_BLOCKS_H

--- a/unit/Makefile
+++ b/unit/Makefile
@@ -7,6 +7,7 @@ SRC = unit_tests.cpp \
 # Test source files
 SRC += analyses/ai/ai.cpp \
        analyses/ai/ai_simplify_lhs.cpp \
+       analyses/basic_blocks.cpp \
        analyses/call_graph.cpp \
        analyses/constant_propagator.cpp \
        analyses/dependence_graph.cpp \

--- a/unit/analyses/basic_blocks.cpp
+++ b/unit/analyses/basic_blocks.cpp
@@ -1,0 +1,107 @@
+/*******************************************************************\
+
+Module: Unit tests for basic block detection
+
+Author: Diffblue Ltd.
+
+\*******************************************************************/
+
+#include <util/std_expr.h>
+
+#include <goto-programs/goto_program.h>
+
+#include <analyses/basic_blocks.h>
+#include <testing-utils/use_catch.h>
+
+static source_locationt make_location(const char *file, const char *line)
+{
+  source_locationt location;
+  location.set_file(file);
+  location.set_line(line);
+  return location;
+}
+
+SCENARIO(
+  "basic block detection for C/C++ goto programs",
+  "[core][analyses][basic_blocks]")
+{
+  GIVEN("a straight-line program with an assume in the middle")
+  {
+    // SKIP; ASSUME(true); SKIP; END_FUNCTION
+    goto_programt program;
+    const auto skip_before =
+      program.add(goto_programt::make_skip(make_location("test.c", "1")));
+    const auto assume = program.add(goto_programt::make_assumption(
+      true_exprt{}, make_location("test.c", "2")));
+    const auto skip_after =
+      program.add(goto_programt::make_skip(make_location("test.c", "3")));
+    program.add(goto_programt::make_end_function(make_location("test.c", "3")));
+    program.update();
+
+    const goto_programt::const_targett before = skip_before;
+    const goto_programt::const_targett the_assume = assume;
+    const goto_programt::const_targett after = skip_after;
+
+    WHEN("assume statements delimit blocks (the default)")
+    {
+      const basic_blockst blocks{program};
+
+      THEN("the assume terminates its block")
+      {
+        REQUIRE(blocks.size() == 2);
+        REQUIRE(blocks.block_of(before) == blocks.block_of(the_assume));
+        REQUIRE(blocks.block_of(after) != blocks.block_of(before));
+      }
+    }
+
+    WHEN("assume statements do not delimit blocks")
+    {
+      const basic_blockst blocks{program, basic_block_configt{false}};
+
+      THEN("the whole straight-line program is a single block")
+      {
+        REQUIRE(blocks.size() == 1);
+        REQUIRE(blocks.block_of(before) == blocks.block_of(after));
+      }
+    }
+  }
+}
+
+SCENARIO(
+  "basic block detection for Java goto programs",
+  "[core][analyses][basic_blocks]")
+{
+  GIVEN("a program whose instructions carry Java bytecode indices")
+  {
+    const auto with_index = [](const char *index)
+    {
+      source_locationt location;
+      location.set_java_bytecode_index(index);
+      return location;
+    };
+
+    goto_programt program;
+    // Two instructions at bytecode index 0, then one at index 1.
+    const auto first = program.add(goto_programt::make_skip(with_index("0")));
+    const auto second = program.add(goto_programt::make_skip(with_index("0")));
+    const auto third = program.add(goto_programt::make_skip(with_index("1")));
+    program.add(goto_programt::make_end_function(with_index("1")));
+    program.update();
+
+    WHEN("blocks are detected by bytecode index")
+    {
+      const java_basic_blockst blocks{program};
+
+      THEN("instructions are grouped per bytecode index")
+      {
+        REQUIRE(blocks.size() == 2);
+        REQUIRE(
+          blocks.block_of(goto_programt::const_targett{first}) ==
+          blocks.block_of(goto_programt::const_targett{second}));
+        REQUIRE(
+          blocks.block_of(goto_programt::const_targett{third}) !=
+          blocks.block_of(goto_programt::const_targett{first}));
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR refactors the basic block detection functionality from the coverage goal instrumenter into a standalone utility module in the `src/analyses/` directory. The new utility provides a generic, reusable interface for basic block detection across different parts of the codebase, similar to how `natural_loops_templatet` handles loop detection.

Fixes: #1686

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
