### PR TITLE
Refactor entry point validation towards symex-callers

### DIFF
--- a/jbmc/src/java_bytecode/lazy_goto_functions_map.h
+++ b/jbmc/src/java_bytecode/lazy_goto_functions_map.h
@@ -119,12 +119,22 @@ public:
   /// Determines if this lazy GOTO functions map can produce a body for the
   /// given function
   /// \param name: function ID to query
-  /// \return true if we can produce a function body, or false if we would leave
-  ///   it a bodyless stub.
+  /// \return true if we can produce a function body (via lazy loading or
+  ///   function body generation), or if the symbol table already contains a
+  ///   function definition with a body; false if we would leave it a bodyless
+  ///   stub.
   bool can_produce_function(const key_type &name) const
   {
-    return language_files.can_convert_lazy_method(name) ||
-           driver_program_can_generate_function_body(name);
+    if(
+      language_files.can_convert_lazy_method(name) ||
+      driver_program_can_generate_function_body(name))
+    {
+      return true;
+    }
+
+    const symbolt *sym_ptr = symbol_table.lookup(name);
+    return sym_ptr && sym_ptr->type.id() == ID_code &&
+           sym_ptr->value.is_not_nil();
   }
 
   /// Remove the function named \p name from the function map, if it exists.

--- a/jbmc/unit/Makefile
+++ b/jbmc/unit/Makefile
@@ -60,6 +60,7 @@ SRC += java_bytecode/ci_lazy_methods/lazy_load_lambdas.cpp \
        java_bytecode/java_string_literals.cpp \
        java_bytecode/java_utils_test.cpp \
        java_bytecode/java_virtual_functions/virtual_functions.cpp \
+       java_bytecode/lazy_goto_functions_map.cpp \
        java_bytecode/load_method_by_regex.cpp \
        pointer-analysis/custom_value_set_analysis.cpp \
        solvers/strings/string_constraint_instantiation/instantiate_not_contains.cpp \

--- a/jbmc/unit/java_bytecode/lazy_goto_functions_map.cpp
+++ b/jbmc/unit/java_bytecode/lazy_goto_functions_map.cpp
@@ -1,0 +1,96 @@
+/*******************************************************************\
+
+Module: Unit tests for lazy_goto_functions_mapt
+
+Author: Diffblue Ltd.
+
+\*******************************************************************/
+
+#include <util/arith_tools.h>
+#include <util/bitvector_types.h>
+#include <util/message.h>
+#include <util/std_code.h>
+#include <util/std_types.h>
+#include <util/symbol_table.h>
+
+#include <goto-programs/goto_functions.h>
+
+#include <java_bytecode/lazy_goto_functions_map.h>
+#include <langapi/language_file.h>
+#include <testing-utils/use_catch.h>
+
+SCENARIO(
+  "lazy_goto_functions_mapt::can_produce_function",
+  "[core][java_bytecode][lazy_goto_functions_map]")
+{
+  // A map with no language files and a driver program that never generates a
+  // body, so that the lazy-conversion and driver branches both return false.
+  // can_produce_function can then only return true via the symbol-table
+  // branch under test.
+  std::map<irep_idt, goto_functiont> goto_functions;
+  language_filest language_files;
+  symbol_tablet symbol_table;
+  null_message_handlert message_handler;
+
+  lazy_goto_functions_mapt function_map{
+    goto_functions,
+    language_files,
+    symbol_table,
+    [](auto &&...) {},                      // post-process (unused here)
+    [](const irep_idt &) { return false; }, // driver cannot generate a body
+    [](auto &&...) { return false; },       // driver generate (unused here)
+    message_handler};
+
+  const code_typet code_type{{}, empty_typet{}};
+
+  GIVEN("an entry already materialised in the symbol table with a body")
+  {
+    symbolt with_body;
+    with_body.name = "with_body";
+    with_body.type = code_type;
+    with_body.value = code_blockt{}; // non-nil body
+    symbol_table.add(with_body);
+
+    THEN("can_produce_function returns true")
+    {
+      REQUIRE(function_map.can_produce_function("with_body"));
+    }
+  }
+
+  GIVEN("a bodyless stub in the symbol table (code-typed, nil value)")
+  {
+    symbolt stub;
+    stub.name = "stub";
+    stub.type = code_type; // value left nil
+
+    symbol_table.add(stub);
+
+    THEN("can_produce_function returns false")
+    {
+      REQUIRE_FALSE(function_map.can_produce_function("stub"));
+    }
+  }
+
+  GIVEN("a non-code symbol in the symbol table with a value")
+  {
+    symbolt data;
+    data.name = "data";
+    data.type = signedbv_typet{32};
+    data.value = from_integer(0, data.type);
+
+    symbol_table.add(data);
+
+    THEN("can_produce_function returns false")
+    {
+      REQUIRE_FALSE(function_map.can_produce_function("data"));
+    }
+  }
+
+  GIVEN("a function that is absent from the symbol table")
+  {
+    THEN("can_produce_function returns false")
+    {
+      REQUIRE_FALSE(function_map.can_produce_function("absent"));
+    }
+  }
+}

--- a/jbmc/unit/java_bytecode/module_dependencies.txt
+++ b/jbmc/unit/java_bytecode/module_dependencies.txt
@@ -1,5 +1,7 @@
 ansi-c
+goto-programs
 java_bytecode
+langapi # should go away
 linking
 testing-utils
 util

--- a/src/goto-checker/multi_path_symex_only_checker.cpp
+++ b/src/goto-checker/multi_path_symex_only_checker.cpp
@@ -74,6 +74,10 @@ operator()(propertiest &properties)
 
 void multi_path_symex_only_checkert::generate_equation()
 {
+  // Validate that the entry point exists before doing any work, so that we
+  // fail fast without performing unnecessary work.
+  goto_symext::validate_entry_point(goto_model);
+
   // Gather fields for shadow memory instrumentation
   const auto fields =
     shadow_memoryt::gather_field_declarations(goto_model, ui_message_handler);

--- a/src/goto-checker/single_loop_incremental_symex_checker.cpp
+++ b/src/goto-checker/single_loop_incremental_symex_checker.cpp
@@ -77,6 +77,9 @@ operator()(propertiest &properties)
   // we haven't got an equation yet
   if(!initial_equation_generated)
   {
+    // Validate that the entry point exists before calling symex
+    goto_symext::validate_entry_point(goto_model);
+
     full_equation_generated = !symex.from_entry_point_of(
       goto_symext::get_goto_function(goto_model), symex_symbol_table);
 

--- a/src/goto-checker/single_path_symex_only_checker.cpp
+++ b/src/goto-checker/single_path_symex_only_checker.cpp
@@ -64,6 +64,10 @@ operator()(propertiest &properties)
 
 void single_path_symex_only_checkert::initialize_worklist()
 {
+  // Validate that the entry point exists before doing any work, so that we
+  // fail fast without performing unnecessary work.
+  goto_symext::validate_entry_point(goto_model);
+
   // Put initial state into the work list
   symex_target_equationt equation(ui_message_handler);
   symex_bmct symex(

--- a/src/goto-symex/goto_symex.h
+++ b/src/goto-symex/goto_symex.h
@@ -102,6 +102,11 @@ public:
   ///   goto_functionst
   static get_goto_functiont get_goto_function(abstract_goto_modelt &goto_model);
 
+  /// Validate that the entry point function exists in the given model.
+  /// \param goto_model: The goto model to check
+  /// \throw invalid_input_exceptiont if the entry point cannot be produced
+  static void validate_entry_point(const abstract_goto_modelt &goto_model);
+
   /// \brief Symbolically execute the entire program starting from entry point
   /// \remarks
   /// The state that goto_symext maintains uses a lot of memory.
@@ -189,6 +194,9 @@ protected:
   /// the beginning of the entry point function.
   /// \param get_goto_function: producer for GOTO functions
   /// \return Initialized symex state.
+  /// \pre The entry point function must exist in the model provided by
+  ///   get_goto_function. Callers should validate this before calling this
+  ///   method to ensure proper error reporting.
   std::unique_ptr<statet>
   initialize_entry_point_state(const get_goto_functiont &get_goto_function);
 

--- a/src/goto-symex/symex_main.cpp
+++ b/src/goto-symex/symex_main.cpp
@@ -399,15 +399,23 @@ std::unique_ptr<goto_symext::statet> goto_symext::initialize_entry_point_state(
 {
   const irep_idt entry_point_id = goto_functionst::entry_point();
 
-  const goto_functionst::goto_functiont *start_function;
+  // Entry point existence is a precondition: callers must validate it via
+  // validate_entry_point() before calling this function. We enforce it here so
+  // that a missed call surfaces as an actionable invariant violation rather
+  // than an unhandled std::out_of_range from get_goto_function.
+  const goto_functionst::goto_functiont *start_function_ptr = nullptr;
   try
   {
-    start_function = &get_goto_function(entry_point_id);
+    start_function_ptr = &get_goto_function(entry_point_id);
   }
   catch(const std::out_of_range &)
   {
-    throw unsupported_operation_exceptiont("the program has no entry point");
+    INVARIANT(
+      false,
+      "the entry point must exist in the model; callers must validate it via "
+      "validate_entry_point() before initialize_entry_point_state()");
   }
+  const goto_functionst::goto_functiont &start_function = *start_function_ptr;
 
   // Get our path_storage pointer because this state will live beyond
   // this instance of goto_symext, so we can't take the reference directly.
@@ -415,7 +423,7 @@ std::unique_ptr<goto_symext::statet> goto_symext::initialize_entry_point_state(
 
   // create and prepare the state
   auto state = std::make_unique<statet>(
-    symex_targett::sourcet(entry_point_id, start_function->body),
+    symex_targett::sourcet(entry_point_id, start_function.body),
     symex_config.max_field_sensitivity_array_size,
     symex_config.simplify_opt,
     language_mode,
@@ -426,11 +434,11 @@ std::unique_ptr<goto_symext::statet> goto_symext::initialize_entry_point_state(
   CHECK_RETURN(!state->call_stack().empty());
 
   goto_programt::const_targett limit =
-    std::prev(start_function->body.instructions.end());
+    std::prev(start_function.body.instructions.end());
   state->call_stack().top().end_of_function = limit;
   state->call_stack().top().calling_location.pc =
     state->call_stack().top().end_of_function;
-  state->call_stack().top().hidden_function = start_function->is_hidden();
+  state->call_stack().top().hidden_function = start_function.is_hidden();
 
   state->symex_target = &target;
 
@@ -440,17 +448,17 @@ std::unique_ptr<goto_symext::statet> goto_symext::initialize_entry_point_state(
   auto emplace_safe_pointers_result =
     path_storage.safe_pointers.emplace(entry_point_id, local_safe_pointerst{});
   if(emplace_safe_pointers_result.second)
-    emplace_safe_pointers_result.first->second(start_function->body);
+    emplace_safe_pointers_result.first->second(start_function.body);
 
   path_storage.dirty.populate_dirty_for_function(
-    entry_point_id, *start_function);
+    entry_point_id, start_function);
   state->dirty = &path_storage.dirty;
 
   // Only enable loop analysis when complexity is enabled.
   if(symex_config.complexity_limits_active)
   {
     // Set initial loop analysis.
-    path_storage.add_function_loops(entry_point_id, start_function->body);
+    path_storage.add_function_loops(entry_point_id, start_function.body);
     state->call_stack().top().loops_info =
       path_storage.get_loop_analysis(entry_point_id);
   }
@@ -496,6 +504,13 @@ goto_symext::get_goto_function(abstract_goto_modelt &goto_model)
            const irep_idt &id) -> const goto_functionst::goto_functiont & {
     return goto_model.get_goto_function(id);
   };
+}
+
+void goto_symext::validate_entry_point(const abstract_goto_modelt &goto_model)
+{
+  const irep_idt entry_point_id = goto_functionst::entry_point();
+  if(!goto_model.can_produce_function(entry_point_id))
+    throw invalid_input_exceptiont("the program has no entry point");
 }
 
 messaget::mstreamt &


### PR DESCRIPTION
We can detect the absence of an entry point much earlier and do not need to perform unnecessary work before inevitably failing.

Fixes: #1847

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
