### PR TITLE
Support reordered pointer operands in local_bitvector_analysis

### DIFF
--- a/src/analyses/local_bitvector_analysis.cpp
+++ b/src/analyses/local_bitvector_analysis.cpp
@@ -170,31 +170,16 @@ local_bitvector_analysist::flagst local_bitvector_analysist::get_rec(
   {
     const auto &plus_expr = to_plus_expr(rhs);
 
-    if(plus_expr.operands().size() >= 3)
+    // A pointer-typed sum has exactly one pointer-typed operand (adding two
+    // pointers is not valid); front-ends typically place it at op0, but
+    // simplification may reorder operands, so search all of them.
+    for(const auto &op : plus_expr.operands())
     {
-      DATA_INVARIANT(
-        plus_expr.op0().type().id() == ID_pointer,
-        "pointer in pointer-typed sum must be op0");
-      return get_rec(plus_expr.op0(), loc_info_src) | flagst::mk_uses_offset();
+      if(op.type().id() == ID_pointer)
+        return get_rec(op, loc_info_src) | flagst::mk_uses_offset();
     }
-    else if(plus_expr.operands().size() == 2)
-    {
-      // one must be pointer, one an integer
-      if(plus_expr.op0().type().id() == ID_pointer)
-      {
-        return get_rec(plus_expr.op0(), loc_info_src) |
-               flagst::mk_uses_offset();
-      }
-      else if(plus_expr.op1().type().id() == ID_pointer)
-      {
-        return get_rec(plus_expr.op1(), loc_info_src) |
-               flagst::mk_uses_offset();
-      }
-      else
-        return flagst::mk_unknown();
-    }
-    else
-      return flagst::mk_unknown();
+
+    return flagst::mk_unknown();
   }
   else if(rhs.id()==ID_minus)
   {

--- a/unit/Makefile
+++ b/unit/Makefile
@@ -14,6 +14,7 @@ SRC += analyses/ai/ai.cpp \
        analyses/does_remove_const/does_expr_lose_const.cpp \
        analyses/does_remove_const/does_type_preserve_const_correctness.cpp \
        analyses/does_remove_const/is_type_at_least_as_const_as.cpp \
+       analyses/local_bitvector_analysis.cpp \
        analyses/variable-sensitivity/abstract_environment/to_predicate.cpp \
        analyses/variable-sensitivity/abstract_object/merge.cpp \
        analyses/variable-sensitivity/abstract_object/index_range.cpp \

--- a/unit/analyses/local_bitvector_analysis.cpp
+++ b/unit/analyses/local_bitvector_analysis.cpp
@@ -1,0 +1,165 @@
+/*******************************************************************\
+
+Module: Unit tests for local_bitvector_analysist
+
+Author: Michael Tautschnig
+
+\*******************************************************************/
+
+/// \file
+/// Unit tests for local_bitvector_analysist
+
+#include <util/arith_tools.h>
+#include <util/c_types.h>
+#include <util/pointer_expr.h>
+#include <util/std_code.h>
+#include <util/std_expr.h>
+#include <util/symbol.h>
+
+#include <goto-programs/goto_model.h>
+
+#include <analyses/local_bitvector_analysis.h>
+#include <ansi-c/goto-conversion/goto_convert_functions.h>
+#include <testing-utils/message.h>
+#include <testing-utils/use_catch.h>
+
+SCENARIO(
+  "local_bitvector_analysis pointer-typed plus with 3+ operands",
+  "[core][analyses][local_bitvector_analysis]")
+{
+  const pointer_typet ptr_type = pointer_type(signed_int_type());
+
+  GIVEN("A 3-operand plus with pointer at op0")
+  {
+    goto_modelt goto_model;
+
+    symbolt local_p{"main::p", ptr_type, ID_C};
+    local_p.is_lvalue = true;
+    symbolt local_q{"main::q", ptr_type, ID_C};
+    local_q.is_lvalue = true;
+
+    // q = p + 1 + 2  (pointer is op0)
+    exprt::operandst ops;
+    ops.push_back(local_p.symbol_expr());
+    ops.push_back(from_integer(1, signed_int_type()));
+    ops.push_back(from_integer(2, signed_int_type()));
+    plus_exprt plus_op0_ptr(std::move(ops), ptr_type);
+
+    code_blockt code(
+      {code_declt(local_p.symbol_expr()),
+       code_declt(local_q.symbol_expr()),
+       code_assignt(local_q.symbol_expr(), plus_op0_ptr)});
+
+    symbolt main_sym{"main", code_typet({}, empty_typet()), ID_C};
+    main_sym.value = code;
+
+    goto_model.symbol_table.add(local_p);
+    goto_model.symbol_table.add(local_q);
+    goto_model.symbol_table.add(main_sym);
+    goto_convert(goto_model, null_message_handler);
+
+    const auto &main_fn = goto_model.get_goto_function("main");
+    const namespacet ns(goto_model.symbol_table);
+    local_bitvector_analysist analysis(main_fn, ns);
+
+    // Find the assignment to q
+    auto it = main_fn.body.instructions.begin();
+    while(it != main_fn.body.instructions.end() && !it->is_assign())
+      ++it;
+    REQUIRE(it != main_fn.body.instructions.end());
+
+    THEN("The result includes uses_offset")
+    {
+      auto flags = analysis.get(it, plus_op0_ptr);
+      REQUIRE(flags.is_uses_offset());
+      REQUIRE_FALSE(flags.is_unknown());
+    }
+  }
+
+  GIVEN("A 3-operand plus with pointer NOT at op0")
+  {
+    goto_modelt goto_model;
+
+    symbolt local_p{"main::p", ptr_type, ID_C};
+    local_p.is_lvalue = true;
+    symbolt local_q{"main::q", ptr_type, ID_C};
+    local_q.is_lvalue = true;
+
+    // q = 1 + 2 + p  (pointer is op2, not op0)
+    exprt::operandst ops;
+    ops.push_back(from_integer(1, signed_int_type()));
+    ops.push_back(from_integer(2, signed_int_type()));
+    ops.push_back(local_p.symbol_expr());
+    plus_exprt plus_ptr_last(std::move(ops), ptr_type);
+
+    code_blockt code(
+      {code_declt(local_p.symbol_expr()),
+       code_declt(local_q.symbol_expr()),
+       code_assignt(local_q.symbol_expr(), plus_ptr_last)});
+
+    symbolt main_sym{"main", code_typet({}, empty_typet()), ID_C};
+    main_sym.value = code;
+
+    goto_model.symbol_table.add(local_p);
+    goto_model.symbol_table.add(local_q);
+    goto_model.symbol_table.add(main_sym);
+    goto_convert(goto_model, null_message_handler);
+
+    const auto &main_fn = goto_model.get_goto_function("main");
+    const namespacet ns(goto_model.symbol_table);
+    local_bitvector_analysist analysis(main_fn, ns);
+
+    auto it = main_fn.body.instructions.begin();
+    while(it != main_fn.body.instructions.end() && !it->is_assign())
+      ++it;
+    REQUIRE(it != main_fn.body.instructions.end());
+
+    THEN("The result includes uses_offset even when pointer is not op0")
+    {
+      auto flags = analysis.get(it, plus_ptr_last);
+      REQUIRE(flags.is_uses_offset());
+      REQUIRE_FALSE(flags.is_unknown());
+    }
+  }
+
+  GIVEN("A 3-operand plus with NO pointer operand")
+  {
+    goto_modelt goto_model;
+
+    symbolt local_p{"main::p", ptr_type, ID_C};
+    local_p.is_lvalue = true;
+
+    // p = (int*)(1 + 2 + 3)  (no pointer operand in the plus)
+    exprt::operandst ops;
+    ops.push_back(from_integer(1, signed_int_type()));
+    ops.push_back(from_integer(2, signed_int_type()));
+    ops.push_back(from_integer(3, signed_int_type()));
+    plus_exprt plus_no_ptr(std::move(ops), ptr_type);
+
+    code_blockt code(
+      {code_declt(local_p.symbol_expr()),
+       code_assignt(local_p.symbol_expr(), plus_no_ptr)});
+
+    symbolt main_sym{"main", code_typet({}, empty_typet()), ID_C};
+    main_sym.value = code;
+
+    goto_model.symbol_table.add(local_p);
+    goto_model.symbol_table.add(main_sym);
+    goto_convert(goto_model, null_message_handler);
+
+    const auto &main_fn = goto_model.get_goto_function("main");
+    const namespacet ns(goto_model.symbol_table);
+    local_bitvector_analysist analysis(main_fn, ns);
+
+    auto it = main_fn.body.instructions.begin();
+    while(it != main_fn.body.instructions.end() && !it->is_assign())
+      ++it;
+    REQUIRE(it != main_fn.body.instructions.end());
+
+    THEN("The result is unknown when no pointer operand exists")
+    {
+      auto flags = analysis.get(it, plus_no_ptr);
+      REQUIRE(flags.is_unknown());
+    }
+  }
+}


### PR DESCRIPTION
`local_bitvector_analysist` previously assumed that pointer arithmetic expressions with 3+ operands always have the pointer operand at position `op0()`. We do not, however, have such a requirement anywhere, and even if front-ends construct expressions this way then simplification may re-order the operands.

Fixes: #2689

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
