### PR TITLE
Add remove_java_new pass to jdiff and janalyzer tools

### DIFF
--- a/jbmc/regression/janalyzer/nondet-object-new/pom.xml
+++ b/jbmc/regression/janalyzer/nondet-object-new/pom.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.cprover.regression</groupId>
+    <artifactId>regression.janalyzer.nondet-object-new</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <parent>
+        <groupId>org.cprover.regression</groupId>
+        <artifactId>regression.janalyzer</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.cprover.util</groupId>
+            <artifactId>cprover-api</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-jar</id>
+                        <phase>none</phase>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/jbmc/regression/janalyzer/nondet-object-new/src/main/java/Test.java
+++ b/jbmc/regression/janalyzer/nondet-object-new/src/main/java/Test.java
@@ -1,0 +1,24 @@
+class B
+{
+  void foo()
+  {
+  }
+}
+
+class A
+{
+  B b = new B();
+}
+
+public class Test
+{
+  // org.cprover.CProver.nondetWithoutNull(T) returns a nondeterministic
+  // non-null object of the argument's type. After replace_java_nondet turns
+  // it into a nondet side effect, convert_nondet's object factory materialises
+  // it -- introducing `new` for A and its field B -- which remove_java_new
+  // then lowers to an `allocate`.
+  public A f00(A x)
+  {
+    return org.cprover.CProver.nondetWithoutNull(x);
+  }
+}

--- a/jbmc/regression/janalyzer/nondet-object-new/test.desc
+++ b/jbmc/regression/janalyzer/nondet-object-new/test.desc
@@ -1,0 +1,9 @@
+CORE
+Test
+--show-goto-functions -cp target/classes
+activate-multi-line-match
+^EXIT=0$
+^SIGNAL=0$
+malloc_site := side_effect statement="allocate"
+--
+^warning: ignoring

--- a/jbmc/regression/janalyzer/pom.xml
+++ b/jbmc/regression/janalyzer/pom.xml
@@ -17,6 +17,7 @@
     <modules>
         <module>string-initializer</module>
         <module>too-many-args</module>
+        <module>nondet-object-new</module>
     </modules>
 
 </project>

--- a/jbmc/regression/jdiff/java-tmp-vars-new/show-goto-functions.desc
+++ b/jbmc/regression/jdiff/java-tmp-vars-new/show-goto-functions.desc
@@ -1,0 +1,15 @@
+CORE
+new.jar
+--show-goto-functions old.jar
+activate-multi-line-match
+^EXIT=0$
+^SIGNAL=0$
+malloc_site := side_effect statement="allocate"
+--
+^warning: ignoring
+//
+// The org.cprover.CProver.nondetWithoutNull() call in Test.f00 is turned into
+// a nondet side effect by replace_java_nondet and materialised into a `new`
+// (allocate) by convert_nondet; remove_java_new then lowers it. Before that
+// pipeline was added, f00 instead showed a CALL to CProver.nondetWithoutNull
+// with no allocation, so this output is what demonstrates the fix.

--- a/jbmc/src/janalyzer/janalyzer_parse_options.cpp
+++ b/jbmc/src/janalyzer/janalyzer_parse_options.cpp
@@ -17,6 +17,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/options.h>
 #include <util/version.h>
 
+#include <goto-programs/adjust_float_expressions.h>
 #include <goto-programs/goto_check.h>
 #include <goto-programs/remove_returns.h>
 #include <goto-programs/remove_skip.h>
@@ -35,10 +36,14 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <goto-analyzer/static_verifier.h>
 #include <goto-analyzer/taint_analysis.h>
 #include <goto-analyzer/unreachable_instructions.h>
+#include <java_bytecode/convert_java_nondet.h>
 #include <java_bytecode/java_bytecode_language.h>
+#include <java_bytecode/java_object_factory_parameters.h>
 #include <java_bytecode/lazy_goto_model.h>
 #include <java_bytecode/remove_exceptions.h>
 #include <java_bytecode/remove_instanceof.h>
+#include <java_bytecode/remove_java_new.h>
+#include <java_bytecode/replace_java_nondet.h>
 #include <langapi/language.h>
 #include <langapi/mode.h>
 #include <linking/static_lifetime_init.h>
@@ -76,6 +81,7 @@ void janalyzer_parse_optionst::get_command_line_options(optionst &options)
     options.set_option("function", cmdline.get_value("function"));
 
   parse_java_language_options(cmdline, options);
+  parse_java_object_factory_options(cmdline, options);
 
   // check assertions
   if(cmdline.isset("no-assertions"))
@@ -695,7 +701,28 @@ void janalyzer_parse_optionst::process_goto_function(
 
   remove_returns(function, function_is_stub);
 
-  transform_assertions_assumptions(options, function.get_goto_function().body);
+  // Java synthetic nondet calls (org.cprover.CProver.nondet*()) -> nondet
+  // side effects (may, in turn, introduce `new` statements below).
+  replace_java_nondet(function);
+
+  // convert Java nondet expressions
+  java_object_factory_parameterst object_factory_parameters;
+  object_factory_parameters.set(options);
+  convert_nondet(
+    function, ui_message_handler, object_factory_parameters, ID_java);
+
+  transform_assertions_assumptions(options, goto_function.body);
+
+  // remove Java new expressions (must be after convert_nondet, which may
+  // introduce them)
+  remove_java_new(
+    function.get_function_id(),
+    goto_function,
+    symbol_table,
+    ui_message_handler);
+
+  // checks don't know about adjusted float expressions
+  adjust_float_expressions(goto_function, ns);
 }
 
 bool janalyzer_parse_optionst::can_generate_function_body(const irep_idt &name)

--- a/jbmc/src/jdiff/jdiff_parse_options.cpp
+++ b/jbmc/src/jdiff/jdiff_parse_options.cpp
@@ -33,9 +33,13 @@ Author: Peter Schrammel
 #include <goto-diff/change_impact.h>
 #include <goto-diff/unified_diff.h>
 #include <goto-instrument/cover.h>
+#include <java_bytecode/convert_java_nondet.h>
 #include <java_bytecode/java_bytecode_language.h>
+#include <java_bytecode/java_object_factory_parameters.h>
 #include <java_bytecode/remove_exceptions.h>
 #include <java_bytecode/remove_instanceof.h>
+#include <java_bytecode/remove_java_new.h>
+#include <java_bytecode/replace_java_nondet.h>
 
 #include "java_syntactic_diff.h"
 
@@ -60,6 +64,7 @@ void jdiff_parse_optionst::get_command_line_options(optionst &options)
   }
 
   parse_java_language_options(cmdline, options);
+  parse_java_object_factory_options(cmdline, options);
 
   // check assertions
   if(cmdline.isset("no-assertions"))
@@ -198,7 +203,20 @@ bool jdiff_parse_optionst::process_goto_program(
   // remove returns
   remove_returns(goto_model);
 
+  // Java synthetic nondet calls (org.cprover.CProver.nondet*()) -> nondet
+  // side effects (may, in turn, introduce `new` statements below).
+  replace_java_nondet(goto_model);
+
+  // convert Java nondet expressions
+  java_object_factory_parameterst object_factory_parameters;
+  object_factory_parameters.set(options);
+  convert_nondet(goto_model, ui_message_handler, object_factory_parameters);
+
   transform_assertions_assumptions(options, goto_model);
+
+  // remove Java new expressions (must be after convert_nondet, which may
+  // introduce them)
+  remove_java_new(goto_model, ui_message_handler);
 
   // checks don't know about adjusted float expressions
   adjust_float_expressions(goto_model);


### PR DESCRIPTION
Add the `remove_java_new` pass after `convert_java_nondet` to both `jdiff` and `janalyzer`. This ensures that any new statements introduced by `convert_java_nondet` are properly processed.

Fixes: #3094

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
