### PR TITLE
goto-analyzer: fix reachable-functions analysis for inline functions

### DIFF
--- a/regression/goto-analyzer/reachable-functions-inline/test.c
+++ b/regression/goto-analyzer/reachable-functions-inline/test.c
@@ -1,0 +1,16 @@
+#include <stdio.h>
+
+// A plain (non-static) inline definition survives into the goto model on all
+// platforms but is never called and never has its address taken, so it is not
+// reachable from the entry point. Before the fix, inline functions were
+// treated as reachable regardless, which is the bug being guarded against
+// (see #5173).
+inline int uncalled_inline(void)
+{
+  return getchar();
+}
+
+int main()
+{
+  return 0;
+}

--- a/regression/goto-analyzer/reachable-functions-inline/test.desc
+++ b/regression/goto-analyzer/reachable-functions-inline/test.desc
@@ -1,0 +1,14 @@
+CORE
+test.c
+--reachable-functions
+test\.c main [0-9]+ [0-9]+$
+^EXIT=0$
+^SIGNAL=0$
+--
+uncalled_inline
+--
+Portable regression for #5173: an uncalled `inline` function must NOT be
+reported as reachable. uncalled_inline is never called and its address is
+never taken, so it must be absent from --reachable-functions. Before the fix
+(which dropped the "inline implies reachable" special case) this test fails,
+as inline functions were reported reachable regardless of being called.

--- a/regression/goto-analyzer/unreachable-functions-inline/test.c
+++ b/regression/goto-analyzer/unreachable-functions-inline/test.c
@@ -1,0 +1,16 @@
+#include <stdio.h>
+
+// A plain (non-static) inline definition survives into the goto model on all
+// platforms but is never called and never has its address taken, so it is not
+// reachable from the entry point. Before the fix, inline functions were
+// treated as reachable regardless, which is the bug being guarded against
+// (see #5173).
+inline int uncalled_inline(void)
+{
+  return getchar();
+}
+
+int main()
+{
+  return 0;
+}

--- a/regression/goto-analyzer/unreachable-functions-inline/test.desc
+++ b/regression/goto-analyzer/unreachable-functions-inline/test.desc
@@ -1,0 +1,12 @@
+CORE
+test.c
+--unreachable-functions
+test\.c uncalled_inline [0-9]+ [0-9]+$
+^EXIT=0$
+^SIGNAL=0$
+--
+--
+Companion to reachable-functions-inline (#5173): an uncalled `inline` function
+must be reported as unreachable. Before the fix, inline functions were treated
+as reachable regardless of being called, so uncalled_inline was absent from
+--unreachable-functions and this test fails.

--- a/src/goto-analyzer/unreachable_instructions.cpp
+++ b/src/goto-analyzer/unreachable_instructions.cpp
@@ -160,6 +160,17 @@ static void add_to_json(
   dest.push_back(std::move(entry));
 }
 
+/// \return true if the function \p id is reachable from the entry point.
+/// \param called: the set computed by \ref compute_called_functions, i.e. the
+///   functions transitively reachable from the entry point. This includes
+///   functions whose address is taken (and which may therefore be called
+///   indirectly), so this is reachability rather than strictly "called".
+static bool
+is_reachable(const std::unordered_set<irep_idt> &called, const irep_idt &id)
+{
+  return called.find(id) != called.end();
+}
+
 void unreachable_instructions(
   const goto_modelt &goto_model,
   const bool json,
@@ -179,11 +190,11 @@ void unreachable_instructions(
     const goto_programt &goto_program = gf_entry.second.body;
     dead_mapt dead_map;
 
-    const symbolt &decl = ns.lookup(gf_entry.first);
-
-    if(
-      called.find(decl.name) != called.end() ||
-      to_code_type(decl.type).get_inlined())
+    // A function that is not reachable from the entry point has all of its
+    // instructions reported as unreachable (rather than relying on a
+    // per-instruction analysis, which would e.g. treat uncalled inline
+    // functions as reachable).
+    if(is_reachable(called, gf_entry.first))
     {
       unreachable_instructions(goto_program, dead_map);
     }
@@ -314,9 +325,8 @@ static void list_functions(
   {
     const symbolt &decl = ns.lookup(gf_entry.first);
 
-    if(
-      unreachable == (called.find(decl.name) != called.end() ||
-                      to_code_type(decl.type).get_inlined()))
+    // Skip functions whose reachability does not match what we are listing.
+    if(unreachable == is_reachable(called, decl.name))
     {
       continue;
     }


### PR DESCRIPTION
We now only consider functions reachable when they are actually called, and don't automatically consider `inline` functions reachable.

Fixes: #5173

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
