### PR TITLE
Fix Xen CI job by moving to GitHub mirror

### DIFF
--- a/.github/workflows/build-and-test-Xen.yaml
+++ b/.github/workflows/build-and-test-Xen.yaml
@@ -49,7 +49,7 @@ jobs:
         run: git clone -b path-addition https://github.com/awslabs/one-line-scan.git
 
       - name: Get Xen 4.13
-        run: git clone git://xenbits.xen.org/xen.git xen_4_13 && cd xen_4_13 && git reset --hard RELEASE-4.13.0 && pwd
+        run: git clone --branch RELEASE-4.13.0 --depth=1 https://github.com/xen-project/xen xen_4_13
 
       - name: Prepare compile Xen with CBMC via one-line-scan
         run: |


### PR DESCRIPTION
git://xenbits.xen.org/xen.git appears to be working fine from my local host, but maybe the (plaintext) git protocol is being blocked somewhere. Use GitHub's mirror of the Xen project instead.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
