### PR TITLE
Fix C++ ternary operator type checking for bitfield operands

### DIFF
--- a/regression/cbmc-cpp/Bitfields_Ternary1/main.cpp
+++ b/regression/cbmc-cpp/Bitfields_Ternary1/main.cpp
@@ -1,0 +1,72 @@
+#include <cassert>
+#include <stdint.h>
+
+// Regression test for issue where CBMC incorrectly failed with an
+// "equality without matching types" error when using ternary expressions
+// with bitfield types. The issue occurred when the third argument of a
+// ternary operator was a bitfield type (uint8_t : 1) that needed to be
+// implicitly converted to bool. GCC and Clang accept this code without
+// warnings, and CBMC should handle the implicit conversion as well.
+
+typedef struct
+{
+  uint32_t value_31_0 : 32;
+} signal32_t;
+
+typedef struct
+{
+  uint8_t value_0_0 : 1;
+} signal1_t;
+
+static inline bool yosys_simplec_get_bit_25_of_32(const signal32_t *sig)
+{
+  return (sig->value_31_0 >> 25) & 1;
+}
+
+typedef struct rvfi_insn_srai_state_t
+{
+  signal32_t rvfi_insn;
+  signal32_t rvfi_rs1_rdata;
+  signal1_t _abc_1398_n364;
+  signal1_t _abc_1398_n363;
+} rvfi_insn_srai_state_t;
+
+int main()
+{
+  rvfi_insn_srai_state_t state;
+
+  // Test case 1: op1 is bool (function-call result), op2 is a 1-bit
+  // bit-field. Without the fix, typecheck_expr_trinary leaves op1 and
+  // op2 with mismatched types after implicit conversion.
+  state.rvfi_insn.value_31_0 = 0;
+  state.rvfi_rs1_rdata.value_31_0 = 0;
+  state._abc_1398_n363.value_0_0 = 1;
+
+  // This ternary should work: condition ? bool : uint8_t:1
+  // The third operand is a bitfield that should be implicitly converted to bool
+  state._abc_1398_n364.value_0_0 =
+    yosys_simplec_get_bit_25_of_32(&state.rvfi_insn)
+      ? yosys_simplec_get_bit_25_of_32(&state.rvfi_rs1_rdata)
+      : state._abc_1398_n363.value_0_0;
+
+  // Since bit 25 of rvfi_insn is 0, the condition is false,
+  // so the result should be _abc_1398_n363.value_0_0, which is 1
+  assert(state._abc_1398_n364.value_0_0 == 1);
+
+  // Test case 2: same operand shapes as test case 1 (op1 is bool from a
+  // function call, op2 is the bit-field access state._abc_1398_n363.
+  // value_0_0); only the condition is now true.
+  state.rvfi_insn.value_31_0 = (1u << 25); // Set bit 25
+  state.rvfi_rs1_rdata.value_31_0 = 0;
+
+  state._abc_1398_n364.value_0_0 =
+    yosys_simplec_get_bit_25_of_32(&state.rvfi_insn)
+      ? yosys_simplec_get_bit_25_of_32(&state.rvfi_rs1_rdata)
+      : state._abc_1398_n363.value_0_0;
+
+  // Since bit 25 of rvfi_insn is 1, the condition is true,
+  // so the result should be the bit 25 of rvfi_rs1_rdata, which is 0
+  assert(state._abc_1398_n364.value_0_0 == 0);
+
+  return 0;
+}

--- a/regression/cbmc-cpp/Bitfields_Ternary1/test.desc
+++ b/regression/cbmc-cpp/Bitfields_Ternary1/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.cpp
+
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring

--- a/regression/cbmc-cpp/Bitfields_Ternary2/main.cpp
+++ b/regression/cbmc-cpp/Bitfields_Ternary2/main.cpp
@@ -1,0 +1,103 @@
+#include <cassert>
+#include <stdint.h>
+
+// Regression test that exercises the symmetric branch of
+// cpp_typecheckt::typecheck_expr_trinary, where
+//   implicit_conversion_sequence(op1, op2.type())
+// fails but
+//   implicit_conversion_sequence(op2, op1.type())
+// succeeds. To trigger this we need an asymmetric conversion: the
+// class types below have user-defined conversion operators, but the
+// reverse direction is not available, so the first
+// implicit_conversion_sequence call fails and the second one fires.
+//
+// Bitfields_Ternary1 covers the first branch; this test covers the
+// second. The second test case below additionally pairs the
+// user-defined conversion with a bit-field operand, which forces the
+// new typecast fix-up inside the symmetric branch to fire (the
+// implicit_conversion_sequence call strips the c_bit_field wrapper
+// from the requested type, so the operand types still need to be
+// re-aligned to the result type).
+
+typedef struct
+{
+  uint8_t value_0_0 : 1;
+} signal1_t;
+
+// One-way conversion: class -> bool. There is no bool -> class_to_bool
+// constructor, so implicit_conversion_sequence(bool, class) fails.
+class class_to_bool
+{
+public:
+  signal1_t s;
+  operator bool() const
+  {
+    return s.value_0_0 != 0;
+  }
+};
+
+// One-way conversion: class -> uint8_t. Used to pair against a
+// bit-field operand on op1; the second-branch fix-up has to typecast
+// op1 from c_bit_field<uint8_t,1> to uint8_t.
+class class_to_uint8
+{
+public:
+  uint8_t v;
+  operator uint8_t() const
+  {
+    return v;
+  }
+};
+
+int main()
+{
+  // Case 1: outer symmetric branch fires; types already align so the
+  // inner if is skipped.
+  {
+    bool cond;
+    class_to_bool holder;
+    holder.s.value_0_0 = 1;
+
+    // op1 is a bool literal, op2 is class_to_bool. First branch's
+    // implicit_conversion_sequence(bool -> class_to_bool) fails (no
+    // matching conversion); the symmetric branch then tries
+    // implicit_conversion_sequence(class_to_bool -> bool), which
+    // succeeds via operator bool(). The result type is bool.
+    bool result = cond ? false : holder;
+
+    // When cond is false we take op2 (class_to_bool -> bool == true
+    // since value_0_0 == 1).
+    if(!cond)
+      assert(result == true);
+
+    // When cond is true we take op1 (false).
+    if(cond)
+      assert(result == false);
+  }
+
+  // Case 2: outer symmetric branch fires AND the inner typecast
+  // fix-up fires. op1 is a bit-field, op2 is class_to_uint8. The
+  // first branch's implicit_conversion_sequence(bit-field ->
+  // class_to_uint8) fails. The symmetric branch then converts op2 to
+  // op1's bit-field type via operator uint8_t() + bit-field
+  // promotion. The result type after the strip is plain uint8_t, but
+  // op1 still wears the c_bit_field<uint8_t,1> label, so the new
+  // fix-up must align it.
+  {
+    bool cond;
+    signal1_t bf;
+    bf.value_0_0 = 1;
+    class_to_uint8 holder;
+    holder.v = 7;
+
+    uint8_t result = cond ? bf.value_0_0 : holder;
+
+    if(!cond)
+      assert(result == 7);
+
+    if(cond)
+      assert(result == 1);
+  }
+
+  return 0;
+}

--- a/regression/cbmc-cpp/Bitfields_Ternary2/test.desc
+++ b/regression/cbmc-cpp/Bitfields_Ternary2/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.cpp
+
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring

--- a/regression/cbmc-cpp/Ternary_Throw1/main.cpp
+++ b/regression/cbmc-cpp/Ternary_Throw1/main.cpp
@@ -1,0 +1,43 @@
+#include <cassert>
+
+// Regression test for a typo in cpp_typecheckt::typecheck_expr_trinary
+// where the void-operand handling block was guarded by
+//
+//   if(expr.op1().type().id()==ID_empty ||
+//      expr.op1().type().id()==ID_empty)
+//
+// (both disjuncts reference op1). The intent was to enter the block
+// whenever EITHER operand is void; in particular, a ternary whose
+// third operand is a throw expression (which has type void) should
+// take the type of the second operand. Under the typo, that case
+// fell through to the regular type-matching paths and produced a
+// "types are incompatible" error: "I got 'signed int' and 'void'".
+//
+// The result of the ternary is discarded via static_cast<void>;
+// goto_convert handles the discarded form by simply emitting the
+// non-throw branch as an expression statement and the throw branch
+// as a throw, so no goto-program assignment with mismatched lhs/rhs
+// types is generated. This keeps the test compatible with the
+// regression suite's --validate-goto-model profile, which does not
+// currently support a ternary with a throw operand whose value is
+// assigned to a variable (a separate, pre-existing issue).
+//
+// Both gcc and clang accept the construct below; cbmc should as
+// well.
+
+int main()
+{
+  int x = 5;
+  bool cond = true;
+  // op1 = int (non-void), op2 = throw 1 (void). Without the fix the
+  // void-handling block is skipped (because both disjuncts referenced
+  // op1), and typechecking ultimately fails with the
+  // "types are incompatible" error. With the fix, the block is
+  // entered, the throw-side handling sets the result type to op1's
+  // type (int), and the expression typechecks. cond is fixed to true
+  // so the throw branch is never executed at runtime.
+  static_cast<void>(cond ? x : throw 1);
+  assert(x == 5);
+
+  return 0;
+}

--- a/regression/cbmc-cpp/Ternary_Throw1/test.desc
+++ b/regression/cbmc-cpp/Ternary_Throw1/test.desc
@@ -1,0 +1,10 @@
+CORE
+main.cpp
+
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring
+^CONVERSION ERROR$
+^.*types are incompatible.*$

--- a/src/cpp/cpp_typecheck_expr.cpp
+++ b/src/cpp/cpp_typecheck_expr.cpp
@@ -136,8 +136,7 @@ void cpp_typecheckt::typecheck_expr_trinary(if_exprt &expr)
 
   implicit_typecast(expr.op0(), bool_typet());
 
-  if(expr.op1().type().id()==ID_empty ||
-     expr.op1().type().id()==ID_empty)
+  if(expr.op1().type().id() == ID_empty || expr.op2().type().id() == ID_empty)
   {
     if(expr.op1().get_bool(ID_C_lvalue))
     {

--- a/src/cpp/cpp_typecheck_expr.cpp
+++ b/src/cpp/cpp_typecheck_expr.cpp
@@ -243,11 +243,24 @@ void cpp_typecheckt::typecheck_expr_trinary(if_exprt &expr)
     {
       expr.type()=e1.type();
       expr.op1().swap(e1);
+      // implicit_conversion_sequence may have stripped a c_bit_field
+      // wrapper from op2's type when computing the common type, so
+      // re-align op2 explicitly. The outer if has already proved the
+      // conversion is legal, so a typecast is sufficient (and safer
+      // than a second implicit_conversion_sequence call whose
+      // failure mode would silently corrupt the expression tree).
+      if(expr.type() != expr.op2().type())
+        expr.op2() = typecast_exprt{expr.op2(), expr.type()};
     }
     else if(implicit_conversion_sequence(expr.op2(), expr.op1().type(), e2))
     {
       expr.type()=e2.type();
       expr.op2().swap(e2);
+      // Mirror of the above for the symmetric case where op2 -> op1's
+      // type succeeded; align op1 to the (possibly bit-field-stripped)
+      // common type.
+      if(expr.type() != expr.op1().type())
+        expr.op1() = typecast_exprt{expr.op1(), expr.type()};
     }
     else if(
       expr.op1().type().id() == ID_array &&
@@ -277,6 +290,17 @@ void cpp_typecheckt::typecheck_expr_trinary(if_exprt &expr)
               << type2cpp(expr.op2().type(), *this) << "'." << eom;
       throw 0;
     }
+
+    // Post-condition: by the time we fall through this else block,
+    // expr.type() and the two operand types must agree. The branches
+    // above either align them explicitly (via swap or typecast),
+    // return early (the array-to-pointer case), or throw. A future
+    // branch that forgets to align the operands trips this invariant
+    // at typecheck time rather than producing a malformed expression
+    // tree that surfaces much later.
+    INVARIANT(
+      expr.type() == expr.op1().type() && expr.type() == expr.op2().type(),
+      "ternary operands' types must match the result type");
   }
 
   if(expr.op1().get_bool(ID_C_lvalue) &&


### PR DESCRIPTION
`implicit_conversion_sequence` does not guarantee to produce the exact type requested as bitfields promote to the underlying type. Therefore, add typecasts as needed to ensure type consistency.

Fixes: #933

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
