### PR TITLE
SMT2: allow unary bitand, bitor, bitxor

### DIFF
--- a/src/solvers/smt2/smt2_conv.cpp
+++ b/src/solvers/smt2/smt2_conv.cpp
@@ -1301,46 +1301,40 @@ void smt2_convt::convert_expr(const exprt &expr)
   {
     convert_constant(to_constant_expr(expr));
   }
-  else if(expr.id() == ID_concatenation && expr.operands().size() == 1)
-  {
-    DATA_INVARIANT_WITH_DIAGNOSTICS(
-      expr.type() == expr.operands().front().type(),
-      "concatenation over a single operand should have matching types",
-      expr.pretty());
-
-    convert_expr(expr.operands().front());
-  }
   else if(
     expr.id() == ID_concatenation || expr.id() == ID_bitand ||
     expr.id() == ID_bitor || expr.id() == ID_bitxor)
   {
     DATA_INVARIANT_WITH_DIAGNOSTICS(
-      expr.operands().size() >= 2,
-      "given expression should have at least two operands",
+      !expr.operands().empty(),
+      "given expression should have at least one operand",
       expr.id_string());
 
-    out << "(";
-
-    if(expr.id()==ID_concatenation)
-      out << "concat";
-    else if(expr.id()==ID_bitand)
-      out << "bvand";
-    else if(expr.id()==ID_bitor)
-      out << "bvor";
-    else if(expr.id()==ID_bitxor)
-      out << "bvxor";
-    else if(expr.id()==ID_bitnand)
-      out << "bvnand";
-    else if(expr.id()==ID_bitnor)
-      out << "bvnor";
-
-    for(const auto &op : expr.operands())
+    if(expr.operands().size() == 1)
     {
-      out << " ";
-      flatten2bv(op);
+      flatten2bv(expr.operands().front());
     }
+    else // >= 2
+    {
+      out << '(';
 
-    out << ")";
+      if(expr.id() == ID_concatenation)
+        out << "concat";
+      else if(expr.id() == ID_bitand)
+        out << "bvand";
+      else if(expr.id() == ID_bitor)
+        out << "bvor";
+      else if(expr.id() == ID_bitxor)
+        out << "bvxor";
+
+      for(const auto &op : expr.operands())
+      {
+        out << ' ';
+        flatten2bv(op);
+      }
+
+      out << ')';
+    }
   }
   else if(
     expr.id() == ID_bitxnor || expr.id() == ID_bitnand ||


### PR DESCRIPTION
This converts unary `bitand`, `bitor`, `bitxor` bit-vector expressions as the identity in the SMT2 backend.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
