### PR TITLE
document non-binary case for Boolean and bit-wise operators

### DIFF
--- a/src/util/bitvector_expr.h
+++ b/src/util/bitvector_expr.h
@@ -121,6 +121,8 @@ inline bitnot_exprt &to_bitnot_expr(exprt &expr)
 }
 
 /// \brief Bit-wise OR
+/// Any number of operands that is greater or equal one.
+/// The type of all operands must be the same.
 class bitor_exprt : public multi_ary_exprt
 {
 public:
@@ -162,6 +164,8 @@ inline bitor_exprt &to_bitor_expr(exprt &expr)
 
 /// \brief Bit-wise NOR
 ///
+/// Any number of operands that is greater or equal one.
+/// The type of all operands must be the same.
 /// When given one operand, this is equivalent to the bit-wise negation.
 /// When given three or more operands, this is equivalent to the bit-wise
 /// negation of the bitand expression with the same operands.
@@ -205,6 +209,8 @@ inline bitnor_exprt &to_bitnor_expr(exprt &expr)
 }
 
 /// \brief Bit-wise XOR
+/// Any number of operands that is greater or equal one.
+/// The type of all operands must be the same.
 class bitxor_exprt : public multi_ary_exprt
 {
 public:
@@ -246,6 +252,8 @@ inline bitxor_exprt &to_bitxor_expr(exprt &expr)
 
 /// \brief Bit-wise XNOR
 ///
+/// Any number of operands that is greater or equal one.
+/// The type of all operands must be the same.
 /// When given one operand, this is equivalent to the bit-wise negation.
 /// When given three or more operands, this is equivalent to the bit-wise
 /// negation of the bitxor expression with the same operands.
@@ -291,6 +299,8 @@ inline bitxnor_exprt &to_bitxnor_expr(exprt &expr)
 }
 
 /// \brief Bit-wise AND
+/// Any number of operands that is greater or equal one.
+/// The type of all operands must be the same.
 class bitand_exprt : public multi_ary_exprt
 {
 public:
@@ -332,6 +342,8 @@ inline bitand_exprt &to_bitand_expr(exprt &expr)
 
 /// \brief Bit-wise NAND
 ///
+/// Any number of operands that is greater or equal one.
+/// The type of all operands must be the same.
 /// When given one operand, this is equivalent to the bit-wise negation.
 /// When given three or more operands, this is equivalent to the bit-wise
 /// negation of the bitand expression with the same operands.

--- a/src/util/std_expr.h
+++ b/src/util/std_expr.h
@@ -2119,8 +2119,9 @@ inline typecast_exprt &to_typecast_expr(exprt &expr)
   return static_cast<typecast_exprt &>(expr);
 }
 
-
 /// \brief Boolean AND
+/// All operands must be boolean, and the result is always boolean.
+/// Any number of operands that is greater or equal one.
 class and_exprt:public multi_ary_exprt
 {
 public:
@@ -2189,6 +2190,8 @@ inline and_exprt &to_and_expr(exprt &expr)
 
 /// \brief Boolean NAND
 ///
+/// All operands must be boolean, and the result is always boolean.
+/// Any number of operands that is greater or equal one.
 /// When given one operand, this is equivalent to the negation.
 /// When given three or more operands, this is equivalent to the negation
 /// of the and expression with the same operands.
@@ -2269,8 +2272,9 @@ inline implies_exprt &to_implies_expr(exprt &expr)
   return ret;
 }
 
-
 /// \brief Boolean OR
+/// All operands must be boolean, and the result is always boolean.
+/// Any number of operands that is greater or equal one.
 class or_exprt:public multi_ary_exprt
 {
 public:
@@ -2334,6 +2338,8 @@ inline or_exprt &to_or_expr(exprt &expr)
 
 /// \brief Boolean NOR
 ///
+/// All operands must be boolean, and the result is always boolean.
+/// Any number of operands that is greater or equal one.
 /// When given one operand, this is equivalent to the negation.
 /// When given three or more operands, this is equivalent to the negation
 /// of the and expression with the same operands.
@@ -2371,6 +2377,8 @@ inline nor_exprt &to_nor_expr(exprt &expr)
 }
 
 /// \brief Boolean XOR
+/// All operands must be boolean, and the result is always boolean.
+/// Any number of operands that is greater or equal one.
 class xor_exprt:public multi_ary_exprt
 {
 public:


### PR DESCRIPTION
This documents the current behavior of the non-binary case of the Boolean operators and the bit-wise operators.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- n/a Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
