### PR TITLE
Add edge case regression tests for --generate-function-body const handling

### DIFF
--- a/regression/goto-instrument/generate-function-body-array-of-pointers-to-const/main.c
+++ b/regression/goto-instrument/generate-function-body-array-of-pointers-to-const/main.c
@@ -1,0 +1,44 @@
+#include <assert.h>
+
+// Edge case: array of pointers where each pointer points to const data.
+// The parameter const int **arr has immediate pointee type `const int *` (a
+// non-const pointer), so the havoc generator reinitialises *arr, i.e. arr[0]
+// only. The remaining elements arr[1], arr[2] are left untouched.
+
+void havoc_array_of_pointers_to_const(const int **arr, int size);
+
+int main(void)
+{
+  int a = 10, b = 20, c = 30;
+  const int *arr[] = {&a, &b, &c};
+
+  assert(a == 10);       // 1
+  assert(b == 20);       // 2
+  assert(c == 30);       // 3
+  assert(*arr[0] == 10); // 4
+  assert(*arr[1] == 20); // 5
+  assert(*arr[2] == 30); // 6
+
+  havoc_array_of_pointers_to_const(arr, 3);
+
+  // The named locals a, b, c are never reached by the havoc, so they are
+  // preserved.
+  assert(a == 10); // 7: SUCCESS
+  assert(b == 20); // 8: SUCCESS
+  assert(c == 30); // 9: SUCCESS
+
+  // arr[0] (== *arr) was redirected to a fresh nondet object, so reading
+  // through it may observe a different value.
+  assert(*arr[0] == 10); // 10: FAILURE
+
+  // arr[1] and arr[2] are NOT havoc'd, so semantically these ought to remain
+  // provable SUCCESS. CBMC currently reports them as UNKNOWN: dereferencing the
+  // redirected (and nondet-nullable) arr[0] above introduces undecidable
+  // pointer-safety properties that leave the following dereferences undecided.
+  // That UNKNOWN is an incompleteness, not a guarantee, and shifts with
+  // solver/CBMC changes, so we deliberately do not pin assertions 11 and 12.
+  assert(*arr[1] == 20); // 11: UNKNOWN (not asserted; see above)
+  assert(*arr[2] == 30); // 12: UNKNOWN (not asserted; see above)
+
+  return 0;
+}

--- a/regression/goto-instrument/generate-function-body-array-of-pointers-to-const/test.desc
+++ b/regression/goto-instrument/generate-function-body-array-of-pointers-to-const/test.desc
@@ -1,0 +1,16 @@
+CORE
+main.c
+--generate-function-body havoc_array_of_pointers_to_const --generate-function-body-options havoc,params:.*
+^EXIT=10$
+^SIGNAL=0$
+^\[main.assertion.1\] .* assertion a == 10: SUCCESS$
+^\[main.assertion.2\] .* assertion b == 20: SUCCESS$
+^\[main.assertion.3\] .* assertion c == 30: SUCCESS$
+^\[main.assertion.4\] .* assertion \*arr\[0\] == 10: SUCCESS$
+^\[main.assertion.5\] .* assertion \*arr\[1\] == 20: SUCCESS$
+^\[main.assertion.6\] .* assertion \*arr\[2\] == 30: SUCCESS$
+^\[main.assertion.7\] .* assertion a == 10: SUCCESS$
+^\[main.assertion.8\] .* assertion b == 20: SUCCESS$
+^\[main.assertion.9\] .* assertion c == 30: SUCCESS$
+^\[main.assertion.10\] .* assertion \*arr\[0\] == 10: FAILURE$
+--

--- a/regression/goto-instrument/generate-function-body-const-array-parameter/main.c
+++ b/regression/goto-instrument/generate-function-body-const-array-parameter/main.c
@@ -1,0 +1,28 @@
+#include <assert.h>
+
+// Edge case: const array parameter
+// const int arr[] is equivalent to const int *arr
+void havoc_const_array(const int arr[], int size);
+
+int main(void)
+{
+  int data[] = {1, 2, 3, 4, 5};
+
+  assert(data[0] == 1);
+  assert(data[1] == 2);
+  assert(data[2] == 3);
+  assert(data[3] == 4);
+  assert(data[4] == 5);
+
+  // Array parameter with const should not allow modification of elements
+  havoc_const_array(data, 5);
+
+  // All should succeed due to const
+  assert(data[0] == 1);
+  assert(data[1] == 2);
+  assert(data[2] == 3);
+  assert(data[3] == 4);
+  assert(data[4] == 5);
+
+  return 0;
+}

--- a/regression/goto-instrument/generate-function-body-const-array-parameter/test.desc
+++ b/regression/goto-instrument/generate-function-body-const-array-parameter/test.desc
@@ -1,0 +1,17 @@
+CORE
+main.c
+--generate-function-body havoc_const_array --generate-function-body-options havoc,params:.*
+^EXIT=0$
+^SIGNAL=0$
+^\[main.assertion.1\] .* assertion data\[0\] == 1: SUCCESS$
+^\[main.assertion.2\] .* assertion data\[1\] == 2: SUCCESS$
+^\[main.assertion.3\] .* assertion data\[2\] == 3: SUCCESS$
+^\[main.assertion.4\] .* assertion data\[3\] == 4: SUCCESS$
+^\[main.assertion.5\] .* assertion data\[4\] == 5: SUCCESS$
+^\[main.assertion.6\] .* assertion data\[0\] == 1: SUCCESS$
+^\[main.assertion.7\] .* assertion data\[1\] == 2: SUCCESS$
+^\[main.assertion.8\] .* assertion data\[2\] == 3: SUCCESS$
+^\[main.assertion.9\] .* assertion data\[3\] == 4: SUCCESS$
+^\[main.assertion.10\] .* assertion data\[4\] == 5: SUCCESS$
+^VERIFICATION SUCCESSFUL$
+--

--- a/regression/goto-instrument/generate-function-body-const-pointer-to-const/main.c
+++ b/regression/goto-instrument/generate-function-body-const-pointer-to-const/main.c
@@ -1,0 +1,23 @@
+#include <assert.h>
+
+// Edge case: both pointer and pointed-to data are const
+// const int * const means neither the pointer nor the data can be modified
+void havoc_const_pointer_to_const(const int *const param);
+
+int main(void)
+{
+  int x = 55;
+  const int *const ptr = &x;
+
+  assert(x == 55);
+  assert(*ptr == 55);
+
+  // With both const qualifiers, havoc should not modify anything
+  havoc_const_pointer_to_const(ptr);
+
+  // Both should succeed since everything is const
+  assert(x == 55);
+  assert(*ptr == 55);
+
+  return 0;
+}

--- a/regression/goto-instrument/generate-function-body-const-pointer-to-const/test.desc
+++ b/regression/goto-instrument/generate-function-body-const-pointer-to-const/test.desc
@@ -1,0 +1,11 @@
+CORE
+main.c
+--generate-function-body havoc_const_pointer_to_const --generate-function-body-options havoc,params:.*
+^EXIT=0$
+^SIGNAL=0$
+^\[main.assertion.1\] .* assertion x == 55: SUCCESS$
+^\[main.assertion.2\] .* assertion \*ptr == 55: SUCCESS$
+^\[main.assertion.3\] .* assertion x == 55: SUCCESS$
+^\[main.assertion.4\] .* assertion \*ptr == 55: SUCCESS$
+^VERIFICATION SUCCESSFUL$
+--

--- a/regression/goto-instrument/generate-function-body-function-pointer-const/main.c
+++ b/regression/goto-instrument/generate-function-body-function-pointer-const/main.c
@@ -1,0 +1,30 @@
+#include <assert.h>
+
+// Edge case: a const pointer to a function pointer.
+// The parameter type func_ptr_t *const makes the POINTER TO the function
+// pointer const; the function-pointer value it points to is itself freely
+// modifiable.
+typedef int (*func_ptr_t)(void);
+
+int test_function(void)
+{
+  return 42;
+}
+
+void havoc_const_function_pointer(func_ptr_t *const func_ptr);
+
+int main(void)
+{
+  func_ptr_t fp = test_function;
+  func_ptr_t *const const_fp_ptr = &fp;
+
+  havoc_const_function_pointer(const_fp_ptr);
+
+  // Top-level const on the parameter does not protect the pointee: the
+  // immediate pointee type (func_ptr_t) is non-const, so the havoc generator
+  // reinitialises *func_ptr, i.e. fp. The function-pointer value may therefore
+  // change, which is why this assertion fails.
+  assert(fp == test_function);
+
+  return 0;
+}

--- a/regression/goto-instrument/generate-function-body-function-pointer-const/test.desc
+++ b/regression/goto-instrument/generate-function-body-function-pointer-const/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+--generate-function-body havoc_const_function_pointer --generate-function-body-options havoc,params:.*
+^EXIT=10$
+^SIGNAL=0$
+^\[main.assertion.1\] .* assertion fp == test_function: FAILURE$
+^VERIFICATION FAILED$
+--

--- a/regression/goto-instrument/generate-function-body-nested-struct-const-pointers/main.c
+++ b/regression/goto-instrument/generate-function-body-nested-struct-const-pointers/main.c
@@ -1,0 +1,50 @@
+#include <assert.h>
+
+// Edge case: nested struct with mixed const pointer qualifiers
+struct inner
+{
+  const int *const_ptr; // pointer to const
+  int *normal_ptr;      // normal pointer
+};
+
+struct outer
+{
+  struct inner *const const_inner_ptr;  // const pointer to struct
+  struct inner *normal_inner_ptr;       // normal pointer to struct
+  const struct inner *const_struct_ptr; // pointer to const struct
+};
+
+void havoc_nested_struct_const_pointers(struct outer *s);
+
+int main(void)
+{
+  int x = 100, y = 200, z = 300, w = 400;
+
+  struct inner inner1 = {&x, &y};
+  struct inner inner2 = {&z, &w};
+  struct outer outer_struct = {&inner1, &inner2, &inner1};
+
+  // Initial state
+  assert(x == 100);
+  assert(y == 200);
+  assert(z == 300);
+  assert(w == 400);
+  assert(*outer_struct.const_inner_ptr->const_ptr == 100);
+  assert(*outer_struct.const_inner_ptr->normal_ptr == 200);
+
+  havoc_nested_struct_const_pointers(&outer_struct);
+
+  // Values pointed to by const pointers should be preserved
+  assert(x == 100); // pointed to by const_ptr
+  assert(z == 300); // pointed to by const_ptr in inner2
+
+  // Characterization note (#1948): y and w are reachable through NON-const
+  // pointers (inner.normal_ptr), so a real callee could legally write them.
+  // They survive only because the havoc generator does not follow pointers
+  // through nested structs -- over-restrictive behaviour that we pin here.
+  // Update the expectation if the generator gains deeper struct traversal.
+  assert(y == 200); // preserved - havoc doesn't reach through nested struct
+  assert(w == 400); // preserved - havoc doesn't reach through nested struct
+
+  return 0;
+}

--- a/regression/goto-instrument/generate-function-body-nested-struct-const-pointers/test.desc
+++ b/regression/goto-instrument/generate-function-body-nested-struct-const-pointers/test.desc
@@ -1,0 +1,17 @@
+CORE
+main.c
+--generate-function-body havoc_nested_struct_const_pointers --generate-function-body-options havoc,params:.*
+^EXIT=0$
+^SIGNAL=0$
+^\[main.assertion.1\] .* assertion x == 100: SUCCESS$
+^\[main.assertion.2\] .* assertion y == 200: SUCCESS$
+^\[main.assertion.3\] .* assertion z == 300: SUCCESS$
+^\[main.assertion.4\] .* assertion w == 400: SUCCESS$
+^\[main.assertion.5\] .* assertion \*outer_struct.const_inner_ptr->const_ptr == 100: SUCCESS$
+^\[main.assertion.6\] .* assertion \*outer_struct.const_inner_ptr->normal_ptr == 200: SUCCESS$
+^\[main.assertion.7\] .* assertion x == 100: SUCCESS$
+^\[main.assertion.8\] .* assertion z == 300: SUCCESS$
+^\[main.assertion.9\] .* assertion y == 200: SUCCESS$
+^\[main.assertion.10\] .* assertion w == 400: SUCCESS$
+^VERIFICATION SUCCESSFUL$
+--

--- a/regression/goto-instrument/generate-function-body-pointer-to-const-struct/main.c
+++ b/regression/goto-instrument/generate-function-body-pointer-to-const-struct/main.c
@@ -1,0 +1,40 @@
+#include <assert.h>
+
+// Edge case: pointer to const struct (entire struct is const)
+struct test_struct
+{
+  int a;
+  int b;
+  int *ptr;
+};
+
+void havoc_pointer_to_const_struct(const struct test_struct *s);
+
+int main(void)
+{
+  int x = 500;
+  struct test_struct s = {10, 20, &x};
+
+  assert(s.a == 10);
+  assert(s.b == 20);
+  assert(x == 500);
+  assert(*s.ptr == 500);
+
+  // Characterization note (#1948): this pins current, over-restrictive (and
+  // arguably unsound) tool behaviour. `const struct test_struct *` only makes
+  // the struct's own members non-assignable; *s.ptr (an int) is still legally
+  // writable by a real callee. The havoc generator nevertheless skips the
+  // whole parameter because its immediate pointee type is const-qualified.
+  // Update the expectation if the generator learns to follow non-const
+  // pointees of const structs.
+  havoc_pointer_to_const_struct(&s);
+
+  // All struct members, and the int reached via s.ptr, are preserved (this is
+  // the pinned tool behaviour, not a C-language guarantee).
+  assert(s.a == 10);
+  assert(s.b == 20);
+  assert(x == 500);
+  assert(*s.ptr == 500);
+
+  return 0;
+}

--- a/regression/goto-instrument/generate-function-body-pointer-to-const-struct/test.desc
+++ b/regression/goto-instrument/generate-function-body-pointer-to-const-struct/test.desc
@@ -1,0 +1,15 @@
+CORE
+main.c
+--generate-function-body havoc_pointer_to_const_struct --generate-function-body-options havoc,params:.*
+^EXIT=0$
+^SIGNAL=0$
+^\[main.assertion.1\] .* assertion s.a == 10: SUCCESS$
+^\[main.assertion.2\] .* assertion s.b == 20: SUCCESS$
+^\[main.assertion.3\] .* assertion x == 500: SUCCESS$
+^\[main.assertion.4\] .* assertion \*s.ptr == 500: SUCCESS$
+^\[main.assertion.5\] .* assertion s.a == 10: SUCCESS$
+^\[main.assertion.6\] .* assertion s.b == 20: SUCCESS$
+^\[main.assertion.7\] .* assertion x == 500: SUCCESS$
+^\[main.assertion.8\] .* assertion \*s.ptr == 500: SUCCESS$
+^VERIFICATION SUCCESSFUL$
+--

--- a/regression/goto-instrument/generate-function-body-pointer-variations-const/s1_pp_const_int.c
+++ b/regression/goto-instrument/generate-function-body-pointer-variations-const/s1_pp_const_int.c
@@ -1,0 +1,25 @@
+#include <assert.h>
+
+// Multi-level pointer const variation: const int ** (pointer to pointer to
+// const int). The immediate pointee type is `const int *` -- a NON-const
+// pointer -- so the havoc generator reinitialises *pp to a fresh nondet
+// object. The deep `const int` is therefore not protected: reading through the
+// (now redirected) pointer chain may observe a different value.
+void havoc_pp_const_int(const int **pp);
+
+int main(void)
+{
+  int a = 1;
+  const int *cpa = &a;
+  const int **pp = &cpa;
+
+  assert(a == 1);    // baseline
+  assert(**pp == 1); // baseline
+
+  havoc_pp_const_int(pp);
+
+  assert(a == 1);    // the named local 'a' is never reached by havoc: SUCCESS
+  assert(**pp == 1); // *pp was redirected to a nondet object: FAILURE
+
+  return 0;
+}

--- a/regression/goto-instrument/generate-function-body-pointer-variations-const/s1_pp_const_int.desc
+++ b/regression/goto-instrument/generate-function-body-pointer-variations-const/s1_pp_const_int.desc
@@ -1,0 +1,10 @@
+CORE
+s1_pp_const_int.c
+--generate-function-body havoc_pp_const_int --generate-function-body-options havoc,params:.*
+^EXIT=10$
+^SIGNAL=0$
+^\[main.assertion.1\] .* assertion a == 1: SUCCESS$
+^\[main.assertion.2\] .* assertion \*\*pp == 1: SUCCESS$
+^\[main.assertion.3\] .* assertion a == 1: SUCCESS$
+^\[main.assertion.4\] .* assertion \*\*pp == 1: FAILURE$
+--

--- a/regression/goto-instrument/generate-function-body-pointer-variations-const/s2_p_const_p_int.c
+++ b/regression/goto-instrument/generate-function-body-pointer-variations-const/s2_p_const_p_int.c
@@ -1,0 +1,28 @@
+#include <assert.h>
+
+// Multi-level pointer const variation: int * const * (pointer to a const
+// pointer to int). The immediate pointee type `int * const` is const, so the
+// havoc generator skips the whole parameter (empty body): nothing changes.
+//
+// Characterization note (#1948): this pins current, over-restrictive
+// behaviour. A real callee could legally write **pp (the underlying int is not
+// const); the generator nevertheless does nothing. Update the expectation if
+// the generator learns to havoc non-const data behind a const pointer.
+void havoc_p_const_p_int(int *const *pp);
+
+int main(void)
+{
+  int b = 2;
+  int *pb = &b;
+  int *const *pp = &pb;
+
+  assert(b == 2);    // baseline
+  assert(**pp == 2); // baseline
+
+  havoc_p_const_p_int(pp);
+
+  assert(b == 2);    // empty body: SUCCESS
+  assert(**pp == 2); // empty body: SUCCESS
+
+  return 0;
+}

--- a/regression/goto-instrument/generate-function-body-pointer-variations-const/s2_p_const_p_int.desc
+++ b/regression/goto-instrument/generate-function-body-pointer-variations-const/s2_p_const_p_int.desc
@@ -1,0 +1,10 @@
+CORE
+s2_p_const_p_int.c
+--generate-function-body havoc_p_const_p_int --generate-function-body-options havoc,params:.*
+^EXIT=0$
+^SIGNAL=0$
+^\[main.assertion.1\] .* assertion b == 2: SUCCESS$
+^\[main.assertion.2\] .* assertion \*\*pp == 2: SUCCESS$
+^\[main.assertion.3\] .* assertion b == 2: SUCCESS$
+^\[main.assertion.4\] .* assertion \*\*pp == 2: SUCCESS$
+--

--- a/regression/goto-instrument/generate-function-body-pointer-variations-const/s3_const_pp_int.c
+++ b/regression/goto-instrument/generate-function-body-pointer-variations-const/s3_const_pp_int.c
@@ -1,0 +1,24 @@
+#include <assert.h>
+
+// Multi-level pointer const variation: int ** const (a const, by-value pointer
+// to a non-const pointer to int). Top-level const on a by-value parameter is
+// irrelevant to the callee, and the immediate pointee `int *` is non-const, so
+// the generator redirects *pp to a fresh nondet object.
+void havoc_const_pp_int(int **const pp);
+
+int main(void)
+{
+  int c = 3;
+  int *pc = &c;
+  int **const pp = &pc;
+
+  assert(c == 3);    // baseline
+  assert(**pp == 3); // baseline
+
+  havoc_const_pp_int(pp);
+
+  assert(c == 3);    // the named local 'c' is untouched: SUCCESS
+  assert(**pp == 3); // *pp was redirected to a nondet object: FAILURE
+
+  return 0;
+}

--- a/regression/goto-instrument/generate-function-body-pointer-variations-const/s3_const_pp_int.desc
+++ b/regression/goto-instrument/generate-function-body-pointer-variations-const/s3_const_pp_int.desc
@@ -1,0 +1,10 @@
+CORE
+s3_const_pp_int.c
+--generate-function-body havoc_const_pp_int --generate-function-body-options havoc,params:.*
+^EXIT=10$
+^SIGNAL=0$
+^\[main.assertion.1\] .* assertion c == 3: SUCCESS$
+^\[main.assertion.2\] .* assertion \*\*pp == 3: SUCCESS$
+^\[main.assertion.3\] .* assertion c == 3: SUCCESS$
+^\[main.assertion.4\] .* assertion \*\*pp == 3: FAILURE$
+--

--- a/regression/goto-instrument/generate-function-body-pointer-variations-const/s4_p_const_p_const_int.c
+++ b/regression/goto-instrument/generate-function-body-pointer-variations-const/s4_p_const_p_const_int.c
@@ -1,0 +1,23 @@
+#include <assert.h>
+
+// Multi-level pointer const variation: const int * const * (pointer to a const
+// pointer to const int). The immediate pointee `const int * const` is const,
+// so the havoc generator skips the parameter (empty body): nothing changes.
+void havoc_p_const_p_const_int(const int *const *pp);
+
+int main(void)
+{
+  int d = 4;
+  const int *cpd = &d;
+  const int *const *pp = &cpd;
+
+  assert(d == 4);    // baseline
+  assert(**pp == 4); // baseline
+
+  havoc_p_const_p_const_int(pp);
+
+  assert(d == 4);    // empty body: SUCCESS
+  assert(**pp == 4); // empty body: SUCCESS
+
+  return 0;
+}

--- a/regression/goto-instrument/generate-function-body-pointer-variations-const/s4_p_const_p_const_int.desc
+++ b/regression/goto-instrument/generate-function-body-pointer-variations-const/s4_p_const_p_const_int.desc
@@ -1,0 +1,10 @@
+CORE
+s4_p_const_p_const_int.c
+--generate-function-body havoc_p_const_p_const_int --generate-function-body-options havoc,params:.*
+^EXIT=0$
+^SIGNAL=0$
+^\[main.assertion.1\] .* assertion d == 4: SUCCESS$
+^\[main.assertion.2\] .* assertion \*\*pp == 4: SUCCESS$
+^\[main.assertion.3\] .* assertion d == 4: SUCCESS$
+^\[main.assertion.4\] .* assertion \*\*pp == 4: SUCCESS$
+--

--- a/regression/goto-instrument/generate-function-body-pointer-variations-const/s5_const_pp_const_int.c
+++ b/regression/goto-instrument/generate-function-body-pointer-variations-const/s5_const_pp_const_int.c
@@ -1,0 +1,24 @@
+#include <assert.h>
+
+// Multi-level pointer const variation: const int ** const (a const, by-value
+// pointer to a NON-const pointer to const int). Top-level const is irrelevant
+// to the callee and the immediate pointee `const int *` is a non-const
+// pointer, so the generator redirects *pp to a fresh nondet object.
+void havoc_const_pp_const_int(const int **const pp);
+
+int main(void)
+{
+  int e = 5;
+  const int *cpe = &e;
+  const int **const pp = &cpe;
+
+  assert(e == 5);    // baseline
+  assert(**pp == 5); // baseline
+
+  havoc_const_pp_const_int(pp);
+
+  assert(e == 5);    // the named local 'e' is untouched: SUCCESS
+  assert(**pp == 5); // *pp was redirected to a nondet object: FAILURE
+
+  return 0;
+}

--- a/regression/goto-instrument/generate-function-body-pointer-variations-const/s5_const_pp_const_int.desc
+++ b/regression/goto-instrument/generate-function-body-pointer-variations-const/s5_const_pp_const_int.desc
@@ -1,0 +1,10 @@
+CORE
+s5_const_pp_const_int.c
+--generate-function-body havoc_const_pp_const_int --generate-function-body-options havoc,params:.*
+^EXIT=10$
+^SIGNAL=0$
+^\[main.assertion.1\] .* assertion e == 5: SUCCESS$
+^\[main.assertion.2\] .* assertion \*\*pp == 5: SUCCESS$
+^\[main.assertion.3\] .* assertion e == 5: SUCCESS$
+^\[main.assertion.4\] .* assertion \*\*pp == 5: FAILURE$
+--

--- a/regression/goto-instrument/generate-function-body-pointer-variations-const/s6_triple_const_middle.c
+++ b/regression/goto-instrument/generate-function-body-pointer-variations-const/s6_triple_const_middle.c
@@ -1,0 +1,35 @@
+#include <assert.h>
+
+// Multi-level pointer const variation: int * const ** (the MIDDLE pointer is
+// const). The immediate pointee of the parameter is `int * const *`, a
+// non-const pointer, so the generator redirects the outer level; recursion
+// then stops at the const middle pointer, leaving x and y untouched.
+//
+// Characterization note (#1948): this pins current, over-restrictive
+// behaviour. ***triple_ptr is a non-const int and is legal C to write, so x/y
+// are NOT protected by the C language -- they survive only because the havoc
+// generator stops at the const middle pointer. Update the expectation if the
+// generator learns to follow non-const data through const pointers.
+void havoc_triple_pointer_const_middle(int *const **triple_ptr);
+
+int main(void)
+{
+  int x = 42;
+  int y = 100;
+  int *ptr_to_x = &x;
+  int *const *ptr_to_const_ptr = &ptr_to_x;
+  int *const **triple_ptr = &ptr_to_const_ptr;
+
+  assert(x == 42);             // baseline
+  assert(y == 100);            // baseline
+  assert(***triple_ptr == 42); // baseline
+
+  havoc_triple_pointer_const_middle(triple_ptr);
+
+  // The const middle pointer stops havoc traversal, so the named locals x and
+  // y are preserved.
+  assert(x == 42);  // SUCCESS
+  assert(y == 100); // SUCCESS
+
+  return 0;
+}

--- a/regression/goto-instrument/generate-function-body-pointer-variations-const/s6_triple_const_middle.desc
+++ b/regression/goto-instrument/generate-function-body-pointer-variations-const/s6_triple_const_middle.desc
@@ -1,0 +1,11 @@
+CORE
+s6_triple_const_middle.c
+--generate-function-body havoc_triple_pointer_const_middle --generate-function-body-options havoc,params:.*
+^EXIT=0$
+^SIGNAL=0$
+^\[main.assertion.1\] .* assertion x == 42: SUCCESS$
+^\[main.assertion.2\] .* assertion y == 100: SUCCESS$
+^\[main.assertion.3\] .* assertion \*\*\*triple_ptr == 42: SUCCESS$
+^\[main.assertion.4\] .* assertion x == 42: SUCCESS$
+^\[main.assertion.5\] .* assertion y == 100: SUCCESS$
+--

--- a/regression/goto-instrument/generate-function-body-volatile-const-pointers/main.c
+++ b/regression/goto-instrument/generate-function-body-volatile-const-pointers/main.c
@@ -1,0 +1,24 @@
+#include <assert.h>
+
+// Edge case: volatile and const qualifiers together
+// volatile const int * means pointer to volatile const data
+void havoc_volatile_const_pointer(volatile const int *ptr);
+
+int main(void)
+{
+  volatile int x = 77;
+  volatile const int *ptr = &x;
+
+  assert(x == 77);
+  assert(*ptr == 77);
+
+  // With const qualifier, the pointed-to value should not be modified
+  // even though it's volatile
+  havoc_volatile_const_pointer(ptr);
+
+  // Should succeed due to const
+  assert(x == 77);
+  assert(*ptr == 77);
+
+  return 0;
+}

--- a/regression/goto-instrument/generate-function-body-volatile-const-pointers/test.desc
+++ b/regression/goto-instrument/generate-function-body-volatile-const-pointers/test.desc
@@ -1,0 +1,11 @@
+CORE
+main.c
+--generate-function-body havoc_volatile_const_pointer --generate-function-body-options havoc,params:.*
+^EXIT=0$
+^SIGNAL=0$
+^\[main.assertion.1\] .* assertion x == 77: SUCCESS$
+^\[main.assertion.2\] .* assertion \*ptr == 77: SUCCESS$
+^\[main.assertion.3\] .* assertion x == 77: SUCCESS$
+^\[main.assertion.4\] .* assertion \*ptr == 77: SUCCESS$
+^VERIFICATION SUCCESSFUL$
+--


### PR DESCRIPTION
The existing tests provided basic const handling coverage, but several complex scenarios were not comprehensively tested. This PR addresses the following edge cases:

1. **Triple pointer const handling** - `int * const **` (const at middle level)
2. **Double const qualification** - `const int * const` (both pointer and data const)
3. **Array of pointers to const** - `const int **` / `const int *arr[]`
4. **Const function pointers** - `func_ptr_t * const`
5. **Nested struct const pointers** - Mixed const/non-const in nested structures
6. **Combined qualifiers** - `volatile const int *` (volatile + const interaction)
7. **Const array parameters** - `const int[]` (array parameter const protection)
8. **Pointer to const struct** - `const struct test_struct *` (struct-level const)
9. **Systematic const variations** - Comprehensive test of const at each pointer level

Co-authored-by: Kiro autonomous agent

Fixes: #1948

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
