### PR TITLE
Fix variable initialization order in snapshot-harness aliasing pointers

### DIFF
--- a/regression/snapshot-harness/dynamic-array-int-ordering/test.desc
+++ b/regression/snapshot-harness/dynamic-array-int-ordering/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.c
 a,a1,iterator1,a2,a3,iterator2,a4,a5,iterator3,a6,a7,array2,a8 --harness-type initialize-with-memory-snapshot --initial-goto-location main:4
 ^EXIT=10$
@@ -9,10 +9,8 @@ a,a1,iterator1,a2,a3,iterator2,a4,a5,iterator3,a6,a7,array2,a8 --harness-type in
 \[main.assertion.4\] line [0-9]+ assertion iterator2 == \&array2\[1\]: SUCCESS
 \[main.assertion.5\] line [0-9]+ assertion \*iterator3 == array2\[1\]: SUCCESS
 \[main.assertion.6\] line [0-9]+ assertion \*iterator3 == 2: SUCCESS
-\[main.pointer_dereference.27\] line [0-9]+ dereference failure: pointer outside object bounds in \*iterator3: FAILURE
+\[main.pointer_dereference.\d+\] line [0-9]+ dereference failure: pointer outside object bounds in \*iterator3: FAILURE
 \[main.assertion.7\] line [0-9]+ assertion \*iterator3 == 0: FAILURE
 VERIFICATION FAILED
 --
 unwinding assertion loop \d+: FAILURE
---
-For more information take a look at github#5351

--- a/regression/snapshot-harness/dynamic-array-int/test.desc
+++ b/regression/snapshot-harness/dynamic-array-int/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.c
 array,iterator1,iterator2,iterator3 --harness-type initialize-with-memory-snapshot --initial-goto-location main:4
 ^EXIT=10$
@@ -9,11 +9,8 @@ array,iterator1,iterator2,iterator3 --harness-type initialize-with-memory-snapsh
 \[main.assertion.4\] line [0-9]+ assertion iterator2 == \&array\[1\]: SUCCESS
 \[main.assertion.5\] line [0-9]+ assertion \*iterator3 == array\[1\]: SUCCESS
 \[main.assertion.6\] line [0-9]+ assertion \*iterator3 == 2: SUCCESS
-\[main.pointer_dereference.27\] line [0-9]+ dereference failure: pointer outside object bounds in \*iterator3: FAILURE
+\[main.pointer_dereference.\d+\] line [0-9]+ dereference failure: pointer outside object bounds in \*iterator3: FAILURE
 \[main.assertion.7\] line [0-9]+ assertion \*iterator3 == 0: FAILURE
 VERIFICATION FAILED
 --
 unwinding assertion loop \d+: FAILURE
---
-Broken by https://github.com/diffblue/cbmc/issues/4978
-For more information take a look at github#5351

--- a/src/goto-harness/memory_snapshot_harness_generator.h
+++ b/src/goto-harness/memory_snapshot_harness_generator.h
@@ -324,6 +324,9 @@ protected:
       auto push_to_output = [&output](const valuet &value) {
         output.push_back(value);
       };
+      // Clear the sets before starting the sort to ensure a fresh traversal
+      seen.clear();
+      inserted.clear();
       for(const auto &item : input)
       {
         dfs(item, associate_key_with_t, push_to_output);
@@ -339,10 +342,7 @@ protected:
     template <typename Value, typename Map, typename Handler>
     void dfs(Value &&node, Map &&key_to_t, Handler &&handle)
     {
-      PRECONDITION(seen.empty() && inserted.empty());
       dfs_inner(node, key_to_t, handle);
-      seen.clear();
-      inserted.clear();
     }
 
     template <typename Value, typename Map, typename Handler>


### PR DESCRIPTION
The root cause was in the topological sort implementation. The `dfs()` method enforced that seen and inserted sets must be empty on entry (via `PRECONDITION`) and would clear them on exit. However, `topological_sort()` calls `dfs()` multiple times in a loop for each item in the input collection. This meant only the first item was sorted correctly; subsequent items would fail the precondition or produce incorrect results.

The fix moves the set clearing logic to the beginning of `topological_sort()`, ensuring a fresh DFS traversal for the entire collection while allowing the DFS to maintain state across recursive calls within a single item's dependency graph.

Co-authored-by: Kiro autonomous agent

Fixes: #4978

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
