### PR TITLE
Fix builtin function return hidden flag inconsistency

### DIFF
--- a/regression/cbmc/builtin-function-hidden-flag/test.c
+++ b/regression/cbmc/builtin-function-hidden-flag/test.c
@@ -1,0 +1,19 @@
+#include <assert.h>
+
+// Regression test for #5207: a function hidden via __CPROVER_HIDE must keep its
+// body hidden in traces, while its function-call and matching function-return
+// events carry a consistent (here: visible) hidden flag, so a trace consumer
+// can ignore internal steps yet still pair calls with returns.
+int hidden_helper(int *p)
+{
+__CPROVER_HIDE:;
+  *p = 1; // internal step: must remain hidden
+  return *p;
+}
+
+int main()
+{
+  int x = 0;
+  int r = hidden_helper(&x);
+  assert(r == 0); // fails, producing a trace through hidden_helper
+}

--- a/regression/cbmc/builtin-function-hidden-flag/test.desc
+++ b/regression/cbmc/builtin-function-hidden-flag/test.desc
@@ -1,0 +1,11 @@
+CORE
+test.c
+--json-ui
+activate-multi-line-match
+^EXIT=10$
+^SIGNAL=0$
+"function": \{[^}]*"displayName": "hidden_helper",[^}]*"sourceLocation": \{[^}]*\}[^}]*\}[^}]*"hidden": false[^}]*"sourceLocation": \{[^}]*\}[^}]*"stepType": "function-call"
+"function": \{[^}]*"displayName": "hidden_helper",[^}]*"sourceLocation": \{[^}]*\}[^}]*\}[^}]*"hidden": false[^}]*"sourceLocation": \{[^}]*\}[^}]*"stepType": "function-return"
+"hidden": true,[^}]*"sourceLocation": \{[^}]*"function": "hidden_helper"[^}]*\}[^}]*"stepType": "assignment"
+--
+^warning: ignoring

--- a/regression/cbmc/builtin-function-hidden-flag/test_xml.desc
+++ b/regression/cbmc/builtin-function-hidden-flag/test_xml.desc
@@ -1,0 +1,11 @@
+CORE
+test.c
+--xml-ui
+activate-multi-line-match
+^EXIT=10$
+^SIGNAL=0$
+<function_call hidden="false" step_nr="\d+" thread="0">\n\s*<function display_name="hidden_helper" identifier="hidden_helper"
+<function_return hidden="false" step_nr="\d+" thread="0">\n\s*<function display_name="hidden_helper" identifier="hidden_helper"
+<assignment[^>]*hidden="true"[^>]*>\n\s*<location file="test.c" function="hidden_helper"
+--
+^warning: ignoring

--- a/src/goto-symex/frame.h
+++ b/src/goto-symex/frame.h
@@ -37,7 +37,15 @@ struct framet
   goto_programt::const_targett end_of_function;
   exprt call_lhs = nil_exprt();                // cleaned, but not renamed
   std::optional<symbol_exprt> return_value_symbol; // not renamed
+  // Whether the steps executed inside this function body are hidden in traces.
+  // Driven by goto_functiont::is_hidden() (i.e. a CPROVER_HIDE label), it hides
+  // declarations and assignments within the function.
   bool hidden_function = false;
+  // Whether the function-call and matching function-return events for this
+  // frame are hidden in traces. Kept separate from hidden_function so that a
+  // hidden function's body stays hidden while its call/return boundary carries
+  // the (consistent) visibility of the call site.
+  bool hidden_function_call = false;
 
   symex_level1t old_level1;
 

--- a/src/goto-symex/symex_function_call.cpp
+++ b/src/goto-symex/symex_function_call.cpp
@@ -344,7 +344,15 @@ void goto_symext::symex_function_call_post_clean(
   frame.call_lhs = cleaned_lhs;
   frame.end_of_function = --goto_function.body.instructions.end();
   frame.function_identifier=identifier;
+  // The function body's internal steps are hidden iff the function itself is
+  // hidden (a CPROVER_HIDE label); this keeps a hidden function's body hidden
+  // regardless of the caller. The function-call/return *events*, however, are
+  // recorded with the combined caller/callee flag above, so we store it
+  // separately and reuse it for the matching function-return event emitted in
+  // symex_end_of_function. This keeps call and return consistent without
+  // un-hiding the body of a hidden function called from a visible caller.
   frame.hidden_function = goto_function.is_hidden();
+  frame.hidden_function_call = hidden;
 
   // set up the 'return value symbol' when needed
   if(frame.call_lhs.is_not_nil())
@@ -438,7 +446,10 @@ void goto_symext::symex_end_of_function(statet &state)
 {
   PRECONDITION(!state.call_stack().empty());
 
-  const bool hidden = state.call_stack().top().hidden_function;
+  // The function-return event mirrors the function-call event's hidden flag
+  // (see symex_function_call_post_clean), not the body's hidden_function, so
+  // that call and return stay consistent while the body remains hidden.
+  const bool hidden = state.call_stack().top().hidden_function_call;
 
   // first record the return
   target.function_return(


### PR DESCRIPTION
Function returns for built-in functions now correctly match their function call hidden flag. This is done by symex storing the combined hidden flag in call frame.

Co-authored-by: Kiro autonomous agent

Fixes: #5207

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
