### PR TITLE
Add regression test to ascertain struct hack support

### DIFF
--- a/regression/cbmc/gh_issue_8617_structhack/main.c
+++ b/regression/cbmc/gh_issue_8617_structhack/main.c
@@ -1,0 +1,28 @@
+#include <assert.h>
+#include <stdlib.h>
+
+// Reproduction case for struct hack bug reported for CBMC 5.12
+// Bug: When a struct with a flexible array member is allocated with extra
+// space, CBMC incorrectly fails assertions when accessing elements beyond
+// the declared size.
+
+struct Foo
+{
+  int i;
+  char data[1];
+};
+
+int main()
+{
+  struct Foo *foo = malloc(sizeof(struct Foo) + sizeof(char) * 2);
+  assert(foo);
+  foo->data[0] = 'a';
+  assert(foo->data[0] == 'a'); // always succeeds
+  foo->data[1] = 'b';          // set data[1]
+  assert(foo->data[1] == 'b'); // check data[1] -- should succeed
+  foo->data[2] = 'c';          // set data[2]
+  assert(
+    foo->data[1] == 'b'); // check data[1] again - this used to fail in 5.12
+
+  return 0;
+}

--- a/regression/cbmc/gh_issue_8617_structhack/test.desc
+++ b/regression/cbmc/gh_issue_8617_structhack/test.desc
@@ -1,0 +1,30 @@
+CORE
+main.c
+--no-malloc-may-fail
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring
+--
+Regression test for GitHub issue #8617.
+Exact reproduction of the struct hack bug reported for CBMC 5.12.
+
+In the original bug report, when a struct with a flexible array member
+(char data[1]) was allocated with extra space via
+malloc(sizeof(struct Foo) + sizeof(char)*2), CBMC would incorrectly fail
+the assertion assert(foo->data[1]=='b') after setting foo->data[2]='c'.
+
+This was caused by incorrect handling of byte_extract operations for
+flexible array members. Array operations may fall back to byte_extract
+expressions, and without proper simplification, accesses to dynamically
+allocated extra memory beyond the declared struct size would fail.
+
+Fixed in CBMC 6.7.0 by commit 78839a978c which improved simplification
+of byte_extract operations to handle multiple-of-element size accesses
+to arrays correctly, converting them to index expressions when the offset
+is known to be a multiple of the array-element size.
+
+Note: C90 did not have flexible arrays, and using arrays of size 1 was
+common practice (the "struct hack"). While this is technically undefined
+behavior in C99+, CBMC now handles this pattern correctly.


### PR DESCRIPTION
When a struct with a C90-style flexible array member (e.g., `char data[1]`, aka "struct hack") was allocated with extra space using `malloc(sizeof(struct Foo) + sizeof(char)*2)`, CBMC before 78839a9 incorrectly failed assertions when accessing elements beyond the declared array size.

Co-authored-by: Kiro autonomous agent

Fixes: #5213

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
