### PR TITLE
Fix invalid assumptions and invariants in GraphML witness generation

### DIFF
--- a/src/goto-programs/graphml_witness.cpp
+++ b/src/goto-programs/graphml_witness.cpp
@@ -15,6 +15,7 @@ Author: Daniel Kroening
 #include <util/byte_operators.h>
 #include <util/c_types.h>
 #include <util/cprover_prefix.h>
+#include <util/find_symbols.h>
 #include <util/namespace.h>
 #include <util/pointer_predicates.h>
 #include <util/prefix.h>
@@ -274,6 +275,55 @@ static bool contains_symbol_prefix(const exprt &expr, const std::string &prefix)
   return false;
 }
 
+/// Check if a function is built-in (CPROVER library), has no body,
+/// or does not exist in the symbol table
+static bool is_function_built_in_or_extern(
+  const namespacet &ns,
+  const irep_idt &function_id)
+{
+  const symbolt *symbol_ptr = nullptr;
+  if(ns.lookup(function_id, symbol_ptr))
+    return true; // not found -- not a user function
+
+  if(symbol_ptr->type.id() != ID_code)
+    return true; // not a function
+
+  if(symbol_ptr->value.is_nil())
+    return true; // no body (truly extern)
+
+  if(symbol_ptr->location.is_built_in())
+    return true; // body from a built-in library source
+
+  return false;
+}
+
+/// Check if all symbols in an expression are in scope.
+/// Note: scope is determined by the prefix before the first "::". This is
+/// correct for CBMC's C front-end where locals are named "function::N::var"
+/// and function_id is "function". JBMC does not use graphml witnesses.
+static bool all_symbols_in_scope(const exprt &expr, const irep_idt &function_id)
+{
+  find_symbols_sett symbols;
+  find_symbols(expr, symbols);
+
+  for(const auto &symbol_id : symbols)
+  {
+    if(id2string(symbol_id).find(CPROVER_PREFIX) != std::string::npos)
+      continue;
+
+    std::string symbol_str = id2string(symbol_id);
+    auto scope_sep = symbol_str.find("::");
+
+    if(scope_sep != std::string::npos)
+    {
+      if(symbol_str.substr(0, scope_sep) != id2string(function_id))
+        return false;
+    }
+  }
+
+  return true;
+}
+
 /// counterexample witness
 void graphml_witnesst::operator()(const goto_tracet &goto_trace)
 {
@@ -460,30 +510,41 @@ void graphml_witnesst::operator()(const goto_tracet &goto_trace)
                to_multi_ary_expr(it->full_lhs_value).op0().get(ID_value)),
              "INVALID-")))
         {
-          xmlt &val = edge.new_element("data");
-          val.set_attribute("key", "assumption");
+          // Determine effective scope from lhs_id: the prefix before the
+          // first "::" matches function_id in CBMC's C naming convention
+          // (e.g., "main::1::x" -> "main").
+          irep_idt scope_function = it->function_id;
+          auto sep = lhs_id.find("::");
+          if(sep != std::string::npos)
+            scope_function = lhs_id.substr(0, sep);
 
+          // Skip assumptions from __CPROVER_initialize,
+          // built-in/extern functions, or with out-of-scope
+          // symbols in the RHS
           code_assignt assign{it->full_lhs, it->full_lhs_value};
-          val.data = convert_assign_rec(lhs_id, assign);
-
-          if(!it->function_id.empty())
+          if(
+            scope_function != CPROVER_PREFIX "initialize" &&
+            !is_function_built_in_or_extern(ns, scope_function) &&
+            all_symbols_in_scope(assign.rhs(), scope_function))
           {
-            xmlt &val_s = edge.new_element("data");
-            val_s.set_attribute("key", "assumption.scope");
-            irep_idt function_id = it->function_id;
-            const symbolt *symbol_ptr = nullptr;
-            if(!ns.lookup(lhs_id, symbol_ptr) && symbol_ptr->is_parameter)
+            xmlt &val = edge.new_element("data");
+            val.set_attribute("key", "assumption");
+
+            val.data = convert_assign_rec(lhs_id, assign);
+
+            if(!scope_function.empty())
             {
-              function_id = lhs_id.substr(0, lhs_id.find("::"));
+              xmlt &val_s = edge.new_element("data");
+              val_s.set_attribute("key", "assumption.scope");
+              val_s.data = id2string(scope_function);
             }
-            val_s.data = id2string(function_id);
-          }
 
-          if(has_prefix(val.data, "\\result ="))
-          {
-            xmlt &val_f = edge.new_element("data");
-            val_f.set_attribute("key", "assumption.resultfunction");
-            val_f.data = id2string(it->function_id);
+            if(has_prefix(val.data, "\\result ="))
+            {
+              xmlt &val_f = edge.new_element("data");
+              val_f.set_attribute("key", "assumption.resultfunction");
+              val_f.data = id2string(it->function_id);
+            }
           }
         }
       }
@@ -636,10 +697,30 @@ void graphml_witnesst::operator()(const symex_target_equationt &equation)
       {
         irep_idt identifier = it->ssa_lhs.get_object_name();
 
-        graphml[to].has_invariant = true;
+        // Determine effective scope from identifier: the prefix before the
+        // first "::" matches function_id in CBMC's C naming convention
+        // (e.g., "main::1::x" -> "main").
+        irep_idt scope_function = it->source.function_id;
+        std::string id_str = id2string(identifier);
+        auto sep = id_str.find("::");
+        if(sep != std::string::npos)
+          scope_function = id_str.substr(0, sep);
+
         code_assignt assign(it->ssa_lhs, it->ssa_rhs);
-        graphml[to].invariant = convert_assign_rec(identifier, assign);
-        graphml[to].invariant_scope = id2string(it->source.function_id);
+
+        if(
+          scope_function != CPROVER_PREFIX "initialize" &&
+          !is_function_built_in_or_extern(ns, scope_function) &&
+          all_symbols_in_scope(assign.rhs(), scope_function))
+        {
+          graphml[to].has_invariant = true;
+          graphml[to].invariant = convert_assign_rec(identifier, assign);
+
+          if(!scope_function.empty())
+          {
+            graphml[to].invariant_scope = id2string(scope_function);
+          }
+        }
       }
 
       graphml[to].in[from].xml_node = edge;

--- a/src/xmllang/graphml.cpp
+++ b/src/xmllang/graphml.cpp
@@ -531,9 +531,13 @@ bool write_graphml(const graphmlt &src, std::ostream &os)
       val.set_attribute("key", "invariant");
       val.data=n.invariant;
 
-      xmlt &val_s=node.new_element("data");
-      val_s.set_attribute("key", "invariant.scope");
-      val_s.data=n.invariant_scope;
+      // Only add invariant.scope if it's not empty
+      if(!n.invariant_scope.empty())
+      {
+        xmlt &val_s = node.new_element("data");
+        val_s.set_attribute("key", "invariant.scope");
+        val_s.data = n.invariant_scope;
+      }
     }
 
     for(graphmlt::edgest::const_iterator


### PR DESCRIPTION
- Remove assumptions with `__CPROVER_initialize` scope
- Filter out assumptions for internal variables of external functions
- Remove assumptions referencing out-of-scope local variables

Co-authored-by: Kiro autonomous agent

Fixes: #5264

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
