### PR TITLE
Fix segfault in k-induction step case with nested loops

### DIFF
--- a/regression/k-induction/loop-exit-condition-fail/main.c
+++ b/regression/k-induction/loop-exit-condition-fail/main.c
@@ -1,0 +1,11 @@
+// Polarity guard (failing variant). After the loop i is 2, so i < 2 is false
+// and must be reported as a violation. This is exactly the case an inverted
+// loop-exit assume would mask: assuming the *continue* condition (i < 2)
+// prunes the true exit state (i == 2), spuriously "verifying" the property.
+int main()
+{
+  unsigned i = 0;
+  while(i < 2)
+    i++;
+  __CPROVER_assert(i < 2, "i < 2 must fail at loop exit");
+}

--- a/regression/k-induction/loop-exit-condition-fail/test.desc
+++ b/regression/k-induction/loop-exit-condition-fail/test.desc
@@ -1,0 +1,11 @@
+CORE
+main.c
+2
+^EXIT=0$
+^SIGNAL=0$
+^Instrumenting k-induction for k=2, base case$
+^Instrumenting k-induction for k=2, step case$
+^## Base case fails$
+^## Step case fails$
+--
+^warning: ignoring

--- a/regression/k-induction/loop-exit-condition-pass/main.c
+++ b/regression/k-induction/loop-exit-condition-pass/main.c
@@ -1,0 +1,12 @@
+// Polarity guard for the loop-exit assumption inserted by k-induction.
+// The assertion is *after* the loop, so it is only reachable through the
+// loop-exit assume(loop has exited). With the correct exit condition
+// (i >= 2), this true property is verified; an inverted assume would prune
+// the real exit state.
+int main()
+{
+  unsigned i = 0;
+  while(i < 2)
+    i++;
+  __CPROVER_assert(i >= 2, "i >= 2 holds at loop exit");
+}

--- a/regression/k-induction/loop-exit-condition-pass/test.desc
+++ b/regression/k-induction/loop-exit-condition-pass/test.desc
@@ -1,0 +1,11 @@
+CORE
+main.c
+2
+^EXIT=0$
+^SIGNAL=0$
+^Instrumenting k-induction for k=2, base case$
+^Instrumenting k-induction for k=2, step case$
+^## Base case passes$
+^## Step case passes$
+--
+^warning: ignoring

--- a/regression/k-induction/nested-loops/main.c
+++ b/regression/k-induction/nested-loops/main.c
@@ -1,0 +1,19 @@
+// Test case for nested loops in k-induction instrumentation.
+// This used to cause segmentation faults because the code incorrectly assumed
+// loop heads always have conditions and didn't handle nested loop iterator
+// invalidation.
+int main()
+{
+  unsigned i = 0;
+  unsigned j;
+  while(i < 2)
+  {
+    j = 0;
+    while(j < 2)
+    {
+      j++;
+    }
+    __CPROVER_assert(j == 2, "inner loop terminates at 2");
+    i++;
+  }
+}

--- a/regression/k-induction/nested-loops/test.desc
+++ b/regression/k-induction/nested-loops/test.desc
@@ -1,0 +1,11 @@
+CORE
+main.c
+2
+^EXIT=0$
+^SIGNAL=0$
+^Instrumenting k-induction for k=2, base case$
+^Instrumenting k-induction for k=2, step case$
+^## Base case passes$
+^## Step case passes$
+--
+^warning: ignoring

--- a/regression/k-induction/sibling-nested-loops/main.c
+++ b/regression/k-induction/sibling-nested-loops/main.c
@@ -1,0 +1,26 @@
+// Iterator-invalidation guard: two sibling outer loops, each containing a
+// nested inner loop. Processing the first outer loop mutates the goto program;
+// if that erased list nodes it would invalidate the natural-loops iterators
+// used to process the second outer loop, causing a segfault.
+int main()
+{
+  unsigned i = 0, j;
+  while(i < 2)
+  {
+    j = 0;
+    while(j < 2)
+      j++;
+    __CPROVER_assert(j == 2, "inner loop A terminates at 2");
+    i++;
+  }
+
+  unsigned m = 0, n;
+  while(m < 2)
+  {
+    n = 0;
+    while(n < 2)
+      n++;
+    __CPROVER_assert(n == 2, "inner loop B terminates at 2");
+    m++;
+  }
+}

--- a/regression/k-induction/sibling-nested-loops/test.desc
+++ b/regression/k-induction/sibling-nested-loops/test.desc
@@ -1,0 +1,11 @@
+CORE
+main.c
+2
+^EXIT=0$
+^SIGNAL=0$
+^Instrumenting k-induction for k=2, base case$
+^Instrumenting k-induction for k=2, step case$
+^## Base case passes$
+^## Step case passes$
+--
+^warning: ignoring

--- a/src/goto-instrument/k_induction.cpp
+++ b/src/goto-instrument/k_induction.cpp
@@ -11,10 +11,13 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "k_induction.h"
 
-#include <analyses/natural_loops.h>
-#include <analyses/local_may_alias.h>
+#include <util/expr_util.h>
+#include <util/std_expr.h>
 
 #include <goto-programs/remove_skip.h>
+
+#include <analyses/local_may_alias.h>
+#include <analyses/natural_loops.h>
 
 #include "havoc_utils.h"
 #include "loop_utils.h"
@@ -55,10 +58,61 @@ protected:
 
   void k_induction();
 
+  static exprt find_loop_guard(
+    goto_programt::targett loop_head,
+    goto_programt::targett loop_exit,
+    const loopt &loop);
+
   void process_loop(
     const goto_programt::targett loop_head,
     const loopt &);
 };
+
+/// Find the loop *exit* condition, i.e. the condition under which control
+/// leaves the loop. This is what process_loop assumes (via make_assumption)
+/// right before the loop exit, modelling "the loop condition has become
+/// false". For a continue condition `c` this returns `¬c`. The guard can be
+/// expressed in one of two ways:
+/// 1. as a conditional backwards goto at the end of the loop (the backedge),
+///    whose condition is the *continue* condition `c`, so we negate it;
+/// 2. as a forward goto at the loop head that targets the loop exit, whose
+///    condition is already the *exit* condition `¬c`.
+/// If neither is found (e.g. an unconditional/infinite loop with no
+/// identifiable guard), we fall back to `true`: as an exit assumption this is
+/// permissive (it prunes no states) and hence sound.
+exprt k_inductiont::find_loop_guard(
+  const goto_programt::targett loop_head,
+  const goto_programt::targett loop_exit,
+  const loopt &loop)
+{
+  // Find the backwards goto (backedge) for this loop
+  goto_programt::targett backedge;
+  bool found_backedge = false;
+  for(const auto &t : loop)
+  {
+    if(t->is_backwards_goto() && t->get_target() == loop_head)
+    {
+      backedge = t;
+      found_backedge = true;
+      break;
+    }
+  }
+
+  // The backedge condition is the loop *continue* condition; the exit
+  // condition is its negation.
+  if(found_backedge && !backedge->condition().is_true())
+    return boolean_negate(backedge->condition());
+
+  // A forward goto at the loop head that jumps to the loop exit already holds
+  // the exit condition.
+  if(loop_head->is_goto())
+  {
+    if(loop_head->get_target() == loop_exit)
+      return loop_head->condition();
+  }
+
+  return true_exprt();
+}
 
 void k_inductiont::process_loop(
   const goto_programt::targett loop_head,
@@ -66,12 +120,11 @@ void k_inductiont::process_loop(
 {
   PRECONDITION(!loop.empty());
 
-  // save the loop guard
-  const exprt loop_guard = loop_head->condition();
-
   // compute the loop exit
   goto_programt::targett loop_exit=
     get_loop_exit(loop);
+
+  const exprt loop_guard = find_loop_guard(loop_head, loop_exit, loop);
 
   if(base_case)
   {
@@ -149,20 +202,41 @@ void k_inductiont::process_loop(
     // preserve jumps to loop head.
     goto_function.body.insert_before_swap(loop_head, havoc_code);
   }
-
-  // remove skips
-  remove_skip(goto_function.body);
 }
 
 void k_inductiont::k_induction()
 {
-  // iterate over the (natural) loops in the function
+  // Iterate over the (natural) loops in the function and process the outermost
+  // loops only; inner loops are handled as part of the outer loop body during
+  // unwinding.
+  //
+  // Processing a loop inserts instructions (which does not invalidate
+  // std::list iterators) but must not erase any, or it would invalidate the
+  // goto_programt::targett iterators held as keys/values in
+  // natural_loops.loop_map that we keep iterating here. At k >= 1 the unwinder
+  // only inserts; the sole erasing step is remove_skip, which we therefore
+  // defer to a single call once the whole map has been processed (see below).
 
-  for(natural_loops_mutablet::loop_mapt::const_iterator
-      l_it=natural_loops.loop_map.begin();
-      l_it!=natural_loops.loop_map.end();
-      l_it++)
-    process_loop(l_it->first, l_it->second);
+  for(const auto &[loop_head, loop] : natural_loops.loop_map)
+  {
+    bool is_nested = false;
+
+    for(const auto &[other_head, other_loop] : natural_loops.loop_map)
+    {
+      if(other_head != loop_head && other_loop.contains(loop_head))
+      {
+        is_nested = true;
+        break;
+      }
+    }
+
+    if(!is_nested)
+      process_loop(loop_head, loop);
+  }
+
+  // Now that we no longer iterate loop_map, it is safe to erase the skip
+  // instructions introduced during processing.
+  remove_skip(goto_function.body);
 }
 
 void k_induction(


### PR DESCRIPTION
The original code assumed `loop_head->condition()` always contained the loop guard, but in nested loop scenarios, the loop structure can vary. The backedge might contain the condition instead, or the loop might be unconditional.

Also, when processing nested loops, modifying the outer loop's goto-program could invalidate iterators pointing to the inner loop, causing memory access violations.

Co-authored-by: Kiro autonomous agent

Fixes: #5357

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
