### PR TITLE
Flattening backend: further cases for casts to range types

### DIFF
--- a/src/solvers/flattening/boolbv_typecast.cpp
+++ b/src/solvers/flattening/boolbv_typecast.cpp
@@ -124,40 +124,47 @@ bool boolbvt::type_conversion(
   {
   case bvtypet::IS_RANGE:
     if(
-      src_bvtype == bvtypet::IS_UNSIGNED || src_bvtype == bvtypet::IS_SIGNED ||
-      src_bvtype == bvtypet::IS_C_BOOL)
+      src_bvtype == bvtypet::IS_UNSIGNED ||
+      src_bvtype == bvtypet::IS_C_BOOL) // unsigned to range
     {
-      mp_integer dest_from = to_range_type(dest_type).get_from();
+      // need to do arithmetic: add -dest_from
+      mp_integer offset = -to_range_type(dest_type).get_from();
+      dest = bv_utils.add(
+        bv_utils.zero_extension(src, dest_width),
+        bv_utils.build_constant(offset, dest_width));
 
-      if(dest_from == 0)
-      {
-        // do zero extension
-        dest.resize(dest_width);
-        for(std::size_t i = 0; i < dest.size(); i++)
-          dest[i] = (i < src.size() ? src[i] : const_literal(false));
+      return false;
+    }
+    else if(src_bvtype == bvtypet::IS_SIGNED) // signed to range
+    {
+      // need to do arithmetic: add -dest_from
+      mp_integer offset = -to_range_type(dest_type).get_from();
+      dest = bv_utils.add(
+        bv_utils.sign_extension(src, dest_width),
+        bv_utils.build_constant(offset, dest_width));
 
-        return false;
-      }
+      return false;
     }
     else if(src_bvtype == bvtypet::IS_RANGE) // range to range
     {
       mp_integer src_from = to_range_type(src_type).get_from();
       mp_integer dest_from = to_range_type(dest_type).get_from();
 
-      if(dest_from == src_from)
-      {
-        // do zero extension, if needed
-        dest = bv_utils.zero_extension(src, dest_width);
-        return false;
-      }
-      else
-      {
-        // need to do arithmetic: add src_from-dest_from
-        mp_integer offset = src_from - dest_from;
-        dest = bv_utils.add(
-          bv_utils.zero_extension(src, dest_width),
-          bv_utils.build_constant(offset, dest_width));
-      }
+      // need to do arithmetic: add src_from-dest_from
+      mp_integer offset = src_from - dest_from;
+      dest = bv_utils.add(
+        bv_utils.zero_extension(src, dest_width),
+        bv_utils.build_constant(offset, dest_width));
+
+      return false;
+    }
+    else if(src_type.id() == ID_bool) // bool to range
+    {
+      // need to do arithmetic: add -dest_from
+      mp_integer offset = -to_range_type(dest_type).get_from();
+      dest = bv_utils.add(
+        bv_utils.zero_extension(src, dest_width),
+        bv_utils.build_constant(offset, dest_width));
 
       return false;
     }


### PR DESCRIPTION
This adds further cases for casts to range types to the flattening backend (casts from bool, casts from signed bit vectors, casts to ranges that do not start at zero).

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
