### PR TITLE
constructors for multi-ary expressions with operand type

### DIFF
--- a/src/util/bitvector_expr.h
+++ b/src/util/bitvector_expr.h
@@ -131,6 +131,11 @@ public:
   {
   }
 
+  explicit bitor_exprt(exprt::operandst _operands)
+    : multi_ary_exprt(ID_bitor, std::move(_operands))
+  {
+  }
+
   bitor_exprt(exprt::operandst _operands, typet _type)
     : multi_ary_exprt(ID_bitor, std::move(_operands), std::move(_type))
   {
@@ -177,6 +182,11 @@ public:
   {
   }
 
+  explicit bitnor_exprt(exprt::operandst _operands)
+    : multi_ary_exprt(ID_bitnor, std::move(_operands))
+  {
+  }
+
   bitnor_exprt(exprt::operandst _operands, typet _type)
     : multi_ary_exprt(ID_bitnor, std::move(_operands), std::move(_type))
   {
@@ -216,6 +226,11 @@ class bitxor_exprt : public multi_ary_exprt
 public:
   bitxor_exprt(exprt _op0, exprt _op1)
     : multi_ary_exprt(std::move(_op0), ID_bitxor, std::move(_op1))
+  {
+  }
+
+  explicit bitxor_exprt(exprt::operandst _operands)
+    : multi_ary_exprt(ID_bitxor, std::move(_operands))
   {
   }
 
@@ -265,6 +280,11 @@ public:
   {
   }
 
+  explicit bitxnor_exprt(exprt::operandst _operands)
+    : multi_ary_exprt(ID_bitxnor, std::move(_operands))
+  {
+  }
+
   bitxnor_exprt(exprt::operandst _operands, typet _type)
     : multi_ary_exprt(ID_bitxnor, std::move(_operands), std::move(_type))
   {
@@ -306,6 +326,11 @@ class bitand_exprt : public multi_ary_exprt
 public:
   bitand_exprt(const exprt &_op0, exprt _op1)
     : multi_ary_exprt(_op0, ID_bitand, std::move(_op1), _op0.type())
+  {
+  }
+
+  explicit bitand_exprt(exprt::operandst _operands)
+    : multi_ary_exprt(ID_bitand, std::move(_operands))
   {
   }
 
@@ -352,6 +377,11 @@ class bitnand_exprt : public multi_ary_exprt
 public:
   bitnand_exprt(exprt _op0, exprt _op1)
     : multi_ary_exprt(std::move(_op0), ID_bitnand, std::move(_op1))
+  {
+  }
+
+  explicit bitnand_exprt(exprt::operandst _operands)
+    : multi_ary_exprt(ID_bitnand, std::move(_operands))
   {
   }
 

--- a/src/util/std_expr.h
+++ b/src/util/std_expr.h
@@ -917,6 +917,14 @@ public:
     operands() = std::move(_operands);
   }
 
+  multi_ary_exprt(const irep_idt &_id, operandst _operands)
+    : expr_protectedt(_id, typet{})
+  {
+    PRECONDITION(!_operands.empty());
+    type() = _operands.front().type();
+    operands() = std::move(_operands);
+  }
+
   multi_ary_exprt(const exprt &_lhs, const irep_idt &_id, exprt _rhs)
     : expr_protectedt(_id, _lhs.type(), {_lhs, std::move(_rhs)})
   {
@@ -1015,6 +1023,11 @@ public:
   {
   }
 
+  explicit plus_exprt(operandst _operands)
+    : multi_ary_exprt(ID_plus, std::move(_operands))
+  {
+  }
+
   plus_exprt(operandst _operands, typet _type)
     : multi_ary_exprt(ID_plus, std::move(_operands), std::move(_type))
   {
@@ -1108,6 +1121,11 @@ class mult_exprt:public multi_ary_exprt
 public:
   mult_exprt(exprt _lhs, exprt _rhs)
     : multi_ary_exprt(std::move(_lhs), ID_mult, std::move(_rhs))
+  {
+  }
+
+  explicit mult_exprt(exprt::operandst factors)
+    : multi_ary_exprt(ID_mult, std::move(factors))
   {
   }
 


### PR DESCRIPTION
This adds a new constructor to the base class `multi_ary_exprt` and classes derived from that.  The new constructor takes a non-empty sequence of operands, and takes the type of the expression from the type of the first operand.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
