### PR TITLE
CONTRACTS: make ptr_pred_ctx_reset_call call reset instead of init

### DIFF
--- a/regression/contracts-dfcc/test_is_fresh_enforce_requires_fail_separation/main.c
+++ b/regression/contracts-dfcc/test_is_fresh_enforce_requires_fail_separation/main.c
@@ -1,0 +1,14 @@
+// clang-format off
+int *foo(int *p)
+  __CPROVER_requires(__CPROVER_is_fresh(p, sizeof(int)))
+  __CPROVER_ensures(__CPROVER_is_fresh(__CPROVER_return_value, sizeof(int)))
+// clang-format on
+{
+  return p;
+}
+
+int main()
+{
+  int *p;
+  foo(p);
+}

--- a/regression/contracts-dfcc/test_is_fresh_enforce_requires_fail_separation/test.desc
+++ b/regression/contracts-dfcc/test_is_fresh_enforce_requires_fail_separation/test.desc
@@ -1,0 +1,11 @@
+CORE dfcc-only
+main.c
+--dfcc main --enforce-contract foo
+^\[foo.postcondition.\d+\].*Check ensures clause of contract contract::foo for function foo: FAILURE$
+^EXIT=10$
+^SIGNAL=0$
+^VERIFICATION FAILED$
+--
+--
+This test checks that __CPROVER_is_fresh separation checks fail when the
+return value aliases with a parameter that was required to be fresh.

--- a/src/goto-instrument/contracts/dynamic-frames/dfcc_library.cpp
+++ b/src/goto-instrument/contracts/dynamic-frames/dfcc_library.cpp
@@ -903,7 +903,7 @@ const code_function_callt dfcc_libraryt::ptr_pred_ctx_reset_call(
   const source_locationt &source_location)
 {
   code_function_callt call(
-    dfcc_fun_symbol[dfcc_funt::PTR_PRED_CTX_INIT].symbol_expr(),
+    dfcc_fun_symbol[dfcc_funt::PTR_PRED_CTX_RESET].symbol_expr(),
     {ptr_pred_ctx_ptr});
   call.add_source_location() = source_location;
   return call;


### PR DESCRIPTION
Fixes a copy and paste bug that results in a soundness bug.

The method `dfcc_libraryt::ptr_pred_ctx_reset_call` generated a call to the INIT function instead of the intended RESET function, which resulted in separation checks for the `__CPROVER_is_fresh` memory predicate failing to work  across function calls between requires and ensures clauses.

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

