### PR TITLE
Deprecate `case_exprt`

### DIFF
--- a/src/util/std_expr.h
+++ b/src/util/std_expr.h
@@ -13,6 +13,7 @@ Author: Daniel Kroening, kroening@kroening.com
 /// \file util/std_expr.h
 /// API to expression classes
 
+#include "deprecate.h"
 #include "expr_cast.h"
 #include "invariant.h"
 #include "std_types.h"
@@ -3608,7 +3609,10 @@ inline cond_exprt &to_cond_expr(exprt &expr)
 /// matching case. The first operand is the value to compare against. Subsequent
 /// operands alternate between compare values and result values.  The syntax is:
 /// case(select_value, case1_value, result1, case2_value, result2, ...)
-class case_exprt : public multi_ary_exprt
+/// \deprecated This expression is SMV-specific and has no other use.
+// NOLINTNEXTLINE(readability/identifiers)
+class DEPRECATED(SINCE(2026, 1, 18, "SMV-specific, has no other use"))
+  case_exprt : public multi_ary_exprt
 {
 public:
   case_exprt(operandst _operands, typet _type)


### PR DESCRIPTION
- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- n/a Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

This expression is SMV-specific and has no other use.