### PR TITLE
SMT2: concatenations with zero-width operands

### DIFF
--- a/src/solvers/smt2/smt2_conv.cpp
+++ b/src/solvers/smt2/smt2_conv.cpp
@@ -1301,9 +1301,36 @@ void smt2_convt::convert_expr(const exprt &expr)
   {
     convert_constant(to_constant_expr(expr));
   }
+  else if(expr.id() == ID_concatenation)
+  {
+    DATA_INVARIANT_WITH_DIAGNOSTICS(
+      !expr.operands().empty(),
+      "concatenation expression should have at least one operand",
+      expr.id_string());
+
+    if(expr.operands().size() == 1)
+    {
+      flatten2bv(expr.operands().front());
+    }
+    else // >= 2
+    {
+      out << "(concat";
+
+      for(const auto &op : expr.operands())
+      {
+        // drop zero-width operands, which are not allowed by SMT-LIB
+        if(!is_zero_width(op.type(), ns))
+        {
+          out << ' ';
+          flatten2bv(op);
+        }
+      }
+
+      out << ')';
+    }
+  }
   else if(
-    expr.id() == ID_concatenation || expr.id() == ID_bitand ||
-    expr.id() == ID_bitor || expr.id() == ID_bitxor)
+    expr.id() == ID_bitand || expr.id() == ID_bitor || expr.id() == ID_bitxor)
   {
     DATA_INVARIANT_WITH_DIAGNOSTICS(
       !expr.operands().empty(),
@@ -2078,6 +2105,10 @@ void smt2_convt::convert_expr(const exprt &expr)
     const replication_exprt &replication_expr = to_replication_expr(expr);
 
     mp_integer times = numeric_cast_v<mp_integer>(replication_expr.times());
+
+    // SMT-LIB requires that repeat is given a number of repetitions that is at
+    // least 1.
+    PRECONDITION(times >= 1);
 
     out << "((_ repeat " << times << ") ";
     flatten2bv(replication_expr.op());


### PR DESCRIPTION
This enables support for concatenation expressions that have some zero-width operands in the SMT2 backend.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [X] My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
