### PR TITLE
fix SMT-LIB2 `nor`

### DIFF
--- a/src/solvers/smt2/smt2_conv.cpp
+++ b/src/solvers/smt2/smt2_conv.cpp
@@ -1578,7 +1578,7 @@ void smt2_convt::convert_expr(const exprt &expr)
       if(expr.id() == ID_nand)
         out << "(and";
       else if(expr.id() == ID_nor)
-        out << "(and";
+        out << "(or";
       else if(expr.id() == ID_xnor)
         out << "(xor";
       else

--- a/src/util/std_expr.h
+++ b/src/util/std_expr.h
@@ -2103,7 +2103,7 @@ inline and_exprt &to_and_expr(exprt &expr)
 /// Any number of operands that is greater or equal one.
 /// When given one operand, this is equivalent to the negation.
 /// When given three or more operands, this is equivalent to the negation
-/// of the and expression with the same operands.
+/// of the 'and' expression with the same operands.
 class nand_exprt : public multi_ary_exprt
 {
 public:
@@ -2248,7 +2248,7 @@ inline or_exprt &to_or_expr(exprt &expr)
 /// Any number of operands that is greater or equal one.
 /// When given one operand, this is equivalent to the negation.
 /// When given three or more operands, this is equivalent to the negation
-/// of the and expression with the same operands.
+/// of the 'or' expression with the same operands.
 class nor_exprt : public multi_ary_exprt
 {
 public:
@@ -2331,7 +2331,7 @@ inline xor_exprt &to_xor_expr(exprt &expr)
 ///
 /// When given one operand, this is equivalent to the negation.
 /// When given three or more operands, this is equivalent to the negation
-/// of the xor expression with the same operands.
+/// of the 'xor' expression with the same operands.
 class xnor_exprt : public multi_ary_exprt
 {
 public:


### PR DESCRIPTION
This fixes the implementation of `nor` in the SMT-LIB2 backend, and the comment that describes the semantics of `nor_exprt`.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X ] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
