### PR TITLE
use `power_exprt` in `boolbvt`

### DIFF
--- a/src/solvers/flattening/boolbv.cpp
+++ b/src/solvers/flattening/boolbv.cpp
@@ -15,6 +15,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/config.h>
 #include <util/floatbv_expr.h>
 #include <util/magic.h>
+#include <util/mathematical_expr.h>
 #include <util/mp_arith.h>
 #include <util/simplify_expr.h>
 #include <util/std_expr.h>
@@ -233,7 +234,7 @@ bvt boolbvt::convert_bitvector(const exprt &expr)
   else if(expr.id()==ID_not)
     return convert_not(to_not_expr(expr));
   else if(expr.id()==ID_power)
-     return convert_power(to_binary_expr(expr));
+    return convert_power(to_power_expr(expr));
   else if(expr.id() == ID_popcount)
      return convert_popcount(to_popcount_expr(expr));
   else if(expr.id() == ID_count_leading_zeros)

--- a/src/solvers/flattening/boolbv.h
+++ b/src/solvers/flattening/boolbv.h
@@ -38,6 +38,7 @@ class floatbv_typecast_exprt;
 class ieee_float_op_exprt;
 class overflow_result_exprt;
 class popcount_exprt;
+class power_exprt;
 class replication_exprt;
 class unary_overflow_exprt;
 class union_typet;
@@ -198,7 +199,7 @@ protected:
   virtual bvt convert_symbol(const exprt &expr);
   virtual bvt convert_bv_reduction(const unary_exprt &expr);
   virtual bvt convert_not(const not_exprt &expr);
-  virtual bvt convert_power(const binary_exprt &expr);
+  virtual bvt convert_power(const power_exprt &expr);
   virtual bvt convert_function_application(
     const function_application_exprt &expr);
   virtual bvt convert_bitreverse(const bitreverse_exprt &expr);

--- a/src/solvers/flattening/boolbv_power.cpp
+++ b/src/solvers/flattening/boolbv_power.cpp
@@ -6,10 +6,11 @@ Author: Daniel Kroening, kroening@kroening.com
 
 \*******************************************************************/
 
+#include <util/mathematical_expr.h>
 
 #include "boolbv.h"
 
-bvt boolbvt::convert_power(const binary_exprt &expr)
+bvt boolbvt::convert_power(const power_exprt &expr)
 {
   const typet &type = expr.type();
 
@@ -19,14 +20,14 @@ bvt boolbvt::convert_power(const binary_exprt &expr)
      type.id()==ID_signedbv)
   {
     // Let's do the special case 2**x
-    bvt op0=convert_bv(expr.op0());
-    bvt op1=convert_bv(expr.op1());
+    bvt base = convert_bv(expr.base());
+    bvt exponent = convert_bv(expr.exponent());
 
-    literalt eq_2=
-      bv_utils.equal(op0, bv_utils.build_constant(2, op0.size()));
+    literalt eq_2 =
+      bv_utils.equal(base, bv_utils.build_constant(2, base.size()));
 
     bvt one=bv_utils.build_constant(1, width);
-    bvt shift=bv_utils.shift(one, bv_utilst::shiftt::SHIFT_LEFT, op1);
+    bvt shift = bv_utils.shift(one, bv_utilst::shiftt::SHIFT_LEFT, exponent);
 
     bvt nondet=prop.new_variables(width);
 


### PR DESCRIPTION
This replaces the use of `binary_exprt` in `boolbvt` by the more specific `power_exprt`.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [X] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [X] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
