### PR TITLE
Make scripts/diff-filter.pl portable to macOS

### DIFF
--- a/src/goto-diff/scripts/diff-filter.pl
+++ b/src/goto-diff/scripts/diff-filter.pl
@@ -110,13 +110,30 @@ foreach my $f (keys(%edits))
 {
   my $f_edit="$dir/$f";
 
+  # collect line numbers to prefix
+  my %prefixes=();
   foreach my $l (keys(%{$edits{$f}}))
   {
     if($edits{$f}{$l} =~ /^[CDcd]$/)
     {
-      `sed -i '${l}s/^/$edits{$f}{$l}#/' $f_edit`;
+      $prefixes{$l}=$edits{$f}{$l};
     }
   }
+
+  next unless %prefixes;
+
+  open(my $fh, '<', $f_edit) or die "Cannot read $f_edit: $!\n";
+  my @lines=<$fh>;
+  close($fh);
+
+  foreach my $l (keys(%prefixes))
+  {
+    $lines[$l - 1]="$prefixes{$l}#$lines[$l - 1]" if $l <= scalar(@lines);
+  }
+
+  open($fh, '>', $f_edit) or die "Cannot write $f_edit: $!\n";
+  print $fh @lines;
+  close($fh);
 }
 
 my @diff_to_clean=split('\n', `cd $dir && diff -urN $old $new`);


### PR DESCRIPTION
This change impact analysis helper used `sed` in ways not portable to macOS.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
