### PR TITLE
Use array comprehension for large byte_extract lowering

### DIFF
--- a/src/util/lower_byte_operators.cpp
+++ b/src/util/lower_byte_operators.cpp
@@ -12,6 +12,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "c_types.h"
 #include "endianness_map.h"
 #include "expr_util.h"
+#include "magic.h"
 #include "namespace.h"
 #include "narrow.h"
 #include "pointer_offset_size.h"
@@ -1112,7 +1113,13 @@ static exprt lower_byte_extract_array_vector(
   else
     num_elements = numeric_cast<std::size_t>(to_vector_type(src.type()).size());
 
-  if(num_elements.has_value())
+  // For large arrays, element-by-element expansion creates N expressions
+  // that are each recursively lowered and simplified, resulting in O(N^2)
+  // behaviour. Use array_comprehension_exprt (below) instead, which
+  // represents the same semantics with a single symbolic expression.
+  if(
+    num_elements.has_value() &&
+    (src.type().id() != ID_array || *num_elements <= MAX_FLATTENED_ARRAY_SIZE))
   {
     exprt::operandst operands;
     operands.reserve(*num_elements);
@@ -1797,8 +1804,8 @@ static exprt lower_byte_update_array_vector_non_const(
 
   // compute the number of bytes (from the update value) that are going to be
   // consumed for updating the first element
-  const exprt update_size =
-    from_integer(value_as_byte_array.operands().size(), subtype_size.type());
+  const exprt update_size = typecast_exprt::conditional_cast(
+    to_array_type(value_as_byte_array.type()).size(), subtype_size.type());
   exprt initial_bytes = minus_exprt{subtype_size, update_offset};
   exprt update_bound;
   if(non_const_update_bound.has_value())
@@ -1808,9 +1815,6 @@ static exprt lower_byte_update_array_vector_non_const(
   }
   else
   {
-    DATA_INVARIANT(
-      value_as_byte_array.id() == ID_array,
-      "value should be an array expression if the update bound is constant");
     update_bound = update_size;
   }
   initial_bytes = if_exprt{
@@ -1833,12 +1837,16 @@ static exprt lower_byte_update_array_vector_non_const(
 
   if(value_as_byte_array.id() != ID_array)
   {
+    exprt update_bound =
+      non_const_update_bound.has_value()
+        ? *non_const_update_bound
+        : to_array_type(value_as_byte_array.type()).size();
     return lower_byte_update_array_vector_unbounded(
       src,
       subtype,
       subtype_size,
       value_as_byte_array,
-      *non_const_update_bound,
+      update_bound,
       initial_bytes,
       first_index,
       first_update_value,
@@ -2333,11 +2341,12 @@ static exprt lower_byte_update(
     {
       if(value_as_byte_array.id() != ID_array)
       {
-        DATA_INVARIANT(
-          non_const_update_bound.has_value(),
-          "constant update bound should yield an array expression");
+        exprt update_bound =
+          non_const_update_bound.has_value()
+            ? *non_const_update_bound
+            : to_array_type(value_as_byte_array.type()).size();
         return lower_byte_update_byte_array_vector_non_const(
-          src, *subtype, value_as_byte_array, *non_const_update_bound, ns);
+          src, *subtype, value_as_byte_array, update_bound, ns);
       }
 
       return lower_byte_update_byte_array_vector(

--- a/unit/util/lower_byte_operators.cpp
+++ b/unit/util/lower_byte_operators.cpp
@@ -20,7 +20,53 @@
 #include <util/string_constant.h>
 #include <util/symbol_table.h>
 
+#include <util/magic.h>
+
 #include <testing-utils/use_catch.h>
+
+TEST_CASE(
+  "byte update with large array value",
+  "[core][util][lowering][byte_update]")
+{
+  // this test does require a proper architecture to be set so that byte update
+  // uses adequate endianness
+  cmdlinet cmdline;
+  config.set(cmdline);
+
+  const symbol_tablet symbol_table;
+  const namespacet ns(symbol_table);
+
+  // Target: a char array larger than the update value
+  const std::size_t update_size = MAX_FLATTENED_ARRAY_SIZE + 1;
+  const std::size_t target_size = 2 * update_size;
+  const array_typet target_type{
+    unsignedbv_typet{config.ansi_c.char_width},
+    from_integer(target_size, size_type())};
+  const symbol_exprt target{"target", target_type};
+
+  // Update value: a char array with more than MAX_FLATTENED_ARRAY_SIZE elements
+  // so that lower_byte_extract produces an array_comprehension_exprt
+  const array_typet update_type{
+    unsignedbv_typet{config.ansi_c.char_width},
+    from_integer(update_size, size_type())};
+  const symbol_exprt update_value{"update_value", update_type};
+
+  // Constant offset
+  const byte_update_exprt bu{
+    ID_byte_update_little_endian,
+    target,
+    from_integer(0, c_index_type()),
+    update_value,
+    config.ansi_c.char_width};
+
+  // This must not crash (previously triggered an invariant violation because
+  // lower_byte_extract produces an array_comprehension_exprt for large arrays,
+  // which was not handled by lower_byte_update).
+  const exprt result = lower_byte_update(bu, ns);
+  REQUIRE(result.type() == target_type);
+  REQUIRE(!has_subexpr(result, ID_byte_update_little_endian));
+  REQUIRE(!has_subexpr(result, ID_byte_update_big_endian));
+}
 
 TEST_CASE("byte extract and bits", "[core][util][lowering][byte_extract]")
 {


### PR DESCRIPTION
lower_byte_extract_array_vector expands byte_extract of an array type into an element-by-element array_exprt. For large arrays (e.g., char[100000] in a union), this creates N sub-expressions that are each recursively lowered and simplified, resulting in O(N^2) behavior.

When the array size exceeds MAX_FLATTENED_ARRAY_SIZE (1000), use array_comprehension_exprt instead. This path already exists for arrays with non-constant size; now it is also used for large constant-size arrays. This reduces the lowering from O(N) expressions to O(1).

Performance on union_large_array (char[100000] in a union):
  Before: >120s with --arrays-uf-always
  After:  2.3s with --arrays-uf-always

Co-authored-by: Kiro

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [x] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
