### PR TITLE
Fix array refinement: use actual SAT model values in get()

### DIFF
--- a/regression/cbmc/Array_UF4/test.desc
+++ b/regression/cbmc/Array_UF4/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.c
 --arrays-uf-always --no-propagation --refine-arrays --unwind 2
 ^EXIT=0$

--- a/regression/cbmc/Array_UF8/test.desc
+++ b/regression/cbmc/Array_UF8/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.c
 --arrays-uf-always --no-propagation --refine-arrays --unwind 6
 ^EXIT=0$

--- a/src/solvers/flattening/boolbv.h
+++ b/src/solvers/flattening/boolbv.h
@@ -258,6 +258,12 @@ protected:
   exprt bv_get(const bvt &bv, const typet &type) const;
   exprt bv_get_cache(const exprt &expr) const;
 
+  /// Return the model value for \p expr. Unlike get(), this checks the
+  /// bitvector cache first so that expressions that were converted to SAT
+  /// variables are read from the SAT model rather than symbolically
+  /// evaluated. Intended for use by the refinement loop.
+  exprt get_value(const exprt &expr) const;
+
   // unbounded arrays
   bool is_unbounded_array(const typet &type) const override;
 

--- a/src/solvers/flattening/boolbv_get.cpp
+++ b/src/solvers/flattening/boolbv_get.cpp
@@ -46,11 +46,13 @@ exprt boolbvt::get(const exprt &expr) const
     }
   }
 
-  // If the expression was converted to bitvectors, return the actual
-  // model value rather than symbolically evaluating sub-expressions.
-  // This is important for array index expressions during refinement,
-  // where symbolic evaluation of with-expressions can mask
-  // inconsistencies in the SAT model.
+  return SUB::get(expr);
+}
+
+exprt boolbvt::get_value(const exprt &expr) const
+{
+  // For non-boolean expressions that were converted to SAT variables,
+  // read the value directly from the SAT model.
   if(!expr.is_boolean())
   {
     auto cache_it = bv_cache.find(expr);
@@ -58,7 +60,26 @@ exprt boolbvt::get(const exprt &expr) const
       return bv_get(cache_it->second, expr.type());
   }
 
-  return SUB::get(expr);
+  // For symbols, get() already reads from the SAT model.
+  if(expr.id() == ID_symbol || expr.id() == ID_nondet_symbol)
+    return get(expr);
+
+  // For booleans, read the propositional value.
+  if(expr.is_boolean())
+  {
+    auto value = get_bool(expr);
+    if(value.has_value())
+      return *value ? static_cast<exprt>(true_exprt()) : false_exprt();
+  }
+
+  // Recursively evaluate operands.
+  exprt tmp = expr;
+  for(auto &op : tmp.operands())
+  {
+    exprt tmp_op = get_value(op);
+    op.swap(tmp_op);
+  }
+  return tmp;
 }
 
 exprt boolbvt::bv_get_rec(const exprt &expr, const bvt &bv, std::size_t offset)

--- a/src/solvers/flattening/boolbv_get.cpp
+++ b/src/solvers/flattening/boolbv_get.cpp
@@ -46,6 +46,18 @@ exprt boolbvt::get(const exprt &expr) const
     }
   }
 
+  // If the expression was converted to bitvectors, return the actual
+  // model value rather than symbolically evaluating sub-expressions.
+  // This is important for array index expressions during refinement,
+  // where symbolic evaluation of with-expressions can mask
+  // inconsistencies in the SAT model.
+  if(!expr.is_boolean())
+  {
+    auto cache_it = bv_cache.find(expr);
+    if(cache_it != bv_cache.end())
+      return bv_get(cache_it->second, expr.type());
+  }
+
   return SUB::get(expr);
 }
 

--- a/src/solvers/refinement/refine_arrays.cpp
+++ b/src/solvers/refinement/refine_arrays.cpp
@@ -111,6 +111,7 @@ void bv_refinementt::freeze_lazy_constraints()
 
   for(const auto &constraint : lazy_array_constraints)
   {
+    // Freeze all symbols in the constraint
     for(const auto &symbol : find_symbols(constraint.lazy))
     {
       if(!bv_width.get_width_opt(symbol.type()).has_value())
@@ -120,5 +121,12 @@ void bv_refinementt::freeze_lazy_constraints()
         if(!literal.is_constant())
           prop.set_frozen(literal);
     }
+
+    // Also freeze the full constraint literal and its sub-expressions
+    // so that convert() during refinement does not hit eliminated
+    // variables.
+    literalt constraint_lit = convert(constraint.lazy);
+    if(!constraint_lit.is_constant())
+      prop.set_frozen(constraint_lit);
   }
 }

--- a/src/solvers/refinement/refine_arrays.cpp
+++ b/src/solvers/refinement/refine_arrays.cpp
@@ -54,7 +54,7 @@ void bv_refinementt::arrays_overapproximated()
     if(current.id()==ID_implies)
     {
       implies_exprt imp=to_implies_expr(current);
-      exprt implies_simplified=get(imp.op0());
+      exprt implies_simplified = get_value(imp.op0());
       if(implies_simplified==false_exprt())
       {
         ++it;
@@ -67,8 +67,8 @@ void bv_refinementt::arrays_overapproximated()
       or_exprt orexp=to_or_expr(current);
       INVARIANT(
         orexp.operands().size() == 2, "only treats the case of a binary or");
-      exprt o1=get(orexp.op0());
-      exprt o2=get(orexp.op1());
+      exprt o1 = get_value(orexp.op0());
+      exprt o2 = get_value(orexp.op1());
       if(o1==true_exprt() || o2 == true_exprt())
       {
         ++it;
@@ -76,7 +76,7 @@ void bv_refinementt::arrays_overapproximated()
       }
     }
 
-    exprt simplified=get(current);
+    exprt simplified = get_value(current);
     solver << simplified;
 
     switch(static_cast<decision_proceduret::resultt>(sat_check.prop_solve()))


### PR DESCRIPTION
Two bugs prevented the array refinement loop from detecting spurious counterexamples:

1. boolbvt::get() for non-symbol expressions (e.g., array index expressions like a[i]) fell through to prop_conv_solvert::get() which symbolically evaluated sub-expressions. For with-expressions, this symbolic evaluation produced the 'correct' value, masking inconsistencies in the actual SAT model. Fix: when an expression is in the bitvector cache (i.e., it was converted to SAT variables), return the actual model value via bv_get().

2. freeze_lazy_constraints() only froze the symbols appearing in lazy constraints, but not the intermediate variables created by convert(). When the refinement loop later called convert() on a violated constraint, MiniSat crashed because some variables had been eliminated. Fix: pre-convert and freeze the full constraint literal during freeze_lazy_constraints().

These fixes resolve Array_UF4 and Array_UF8 which were marked as KNOWNBUG.

Co-authored-by: Kiro

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
