### PR TITLE
Handle non-byte-sized array element types in bounds_check_index

### DIFF
--- a/regression/cbmc/bounds_check_integer_index1/fail.c
+++ b/regression/cbmc/bounds_check_integer_index1/fail.c
@@ -1,0 +1,10 @@
+int main()
+{
+  __CPROVER_integer arr[3];
+  __CPROVER_integer i;
+  // i is fully unconstrained: it may be negative (lower-bound violation) or
+  // >= 3 (upper-bound violation), so both generated checks must be able to
+  // fail.  This confirms the checks are meaningful, not vacuously true.
+  __CPROVER_integer x = arr[i];
+  __CPROVER_assert(1, "reachable");
+}

--- a/regression/cbmc/bounds_check_integer_index1/main.c
+++ b/regression/cbmc/bounds_check_integer_index1/main.c
@@ -1,0 +1,8 @@
+int main()
+{
+  __CPROVER_integer arr[3];
+  __CPROVER_integer i;
+  __CPROVER_assume(i >= 0 && i < 3);
+  __CPROVER_integer x = arr[i];
+  __CPROVER_assert(1, "reachable");
+}

--- a/regression/cbmc/bounds_check_integer_index1/smt.desc
+++ b/regression/cbmc/bounds_check_integer_index1/smt.desc
@@ -1,0 +1,10 @@
+CORE smt-backend broken-cprover-smt-backend no-new-smt
+main.c
+--bounds-check --smt2
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+--
+Verify that bounds checking arrays with mathematical integer element types
+succeeds when using an SMT backend.

--- a/regression/cbmc/bounds_check_integer_index1/test.desc
+++ b/regression/cbmc/bounds_check_integer_index1/test.desc
@@ -1,0 +1,14 @@
+CORE
+main.c
+--show-goto-functions
+^[[:space:]]*ASSERT.*lower bound in arr\[.*i\]$
+^[[:space:]]*ASSERT.*upper bound in arr\[.*i\]$
+^EXIT=0$
+^SIGNAL=0$
+--
+^warning: ignoring
+--
+Bounds checking arrays with mathematical integer element types must not crash.
+The element type has no byte size, so the byte-offset-based lower-bound check
+is replaced by a simple index-based check. Both lower and upper bound checks
+must be generated.

--- a/regression/cbmc/bounds_check_integer_index1/verify-fail.desc
+++ b/regression/cbmc/bounds_check_integer_index1/verify-fail.desc
@@ -1,0 +1,14 @@
+CORE broken-cprover-smt-backend no-new-smt
+fail.c
+--bounds-check
+^EXIT=10$
+^SIGNAL=0$
+^\[main\.array_bounds\.\d+\] line \d+ .*lower bound in arr\[.*i\]: FAILURE$
+^\[main\.array_bounds\.\d+\] line \d+ .*upper bound in arr\[.*i\]: FAILURE$
+^VERIFICATION FAILED$
+--
+--
+Negative case: an unconstrained mathematical-integer index into arr[3] must
+make both the generated lower- and upper-bound checks fail.  This confirms the
+non-byte-sized bounds checks are meaningful (catch out-of-bounds), not just
+that they are generated and pass when in-bounds.

--- a/regression/cbmc/bounds_check_integer_index1/verify.desc
+++ b/regression/cbmc/bounds_check_integer_index1/verify.desc
@@ -1,0 +1,10 @@
+CORE broken-cprover-smt-backend no-new-smt
+main.c
+--bounds-check
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+--
+Verify that bounds checking arrays with mathematical integer element types
+completes verification successfully.

--- a/regression/validate-trace-xml-schema/check.py
+++ b/regression/validate-trace-xml-schema/check.py
@@ -72,6 +72,7 @@ ExcludedTests = list(map(lambda s: os.path.join(test_base_dir, s[0], s[1]), [
     ['Bool', 'bool3.desc'],
     ['Empty_struct3', 'test.desc'],
     # uses show-goto-functions
+    ['bounds_check_integer_index1', 'test.desc'],
     ['reachability-slice', 'test.desc'],
     ['reachability-slice', 'test2.desc'],
     ['reachability-slice', 'test3.desc'],

--- a/src/ansi-c/goto-conversion/goto_check_c.cpp
+++ b/src/ansi-c/goto-conversion/goto_check_c.cpp
@@ -1596,63 +1596,141 @@ void goto_check_ct::bounds_check_index(
   std::string name = array_name(expr.array());
 
   const exprt &index = expr.index();
-  object_descriptor_exprt ode;
-  ode.build(expr, ns);
 
-  if(index.type().id() != ID_unsignedbv)
+  // When the array element type has no byte size (e.g., __CPROVER_integer or
+  // arrays of unbounded arrays used in heap models),
+  // object_descriptor_exprt::build cannot compute byte offsets and produces an
+  // ID_unknown offset. Fall back to a simple index-based lower-bound check. We
+  // strip typecasts from integer/natural types to bitvector types so that the
+  // resulting assertions stay in the integer domain and can be handled by SMT
+  // solvers.
+  std::optional<object_descriptor_exprt> ode;
+  // effective_index is only used in the non-byte-sized path; it strips
+  // bitvector casts from integer/natural types to keep assertions in the
+  // integer domain.
+  exprt effective_index = index;
+  if(!size_of_expr(expr.type(), ns).has_value())
   {
-    // we undo typecasts to signedbv
-    if(
-      index.id() == ID_typecast &&
-      to_typecast_expr(index).op().type().id() == ID_unsignedbv)
+    // Arrays with non-byte-sized element types arise from internal modeling
+    // constructs and should not be accessed via pointer dereference. Walk
+    // through member/index/typecast to find the root object.
+    const exprt *root = &expr.array();
+    while(root->id() == ID_member || root->id() == ID_index ||
+          root->id() == ID_typecast)
     {
-      // ok
+      if(root->id() == ID_member)
+        root = &to_member_expr(*root).compound();
+      else if(root->id() == ID_index)
+        root = &to_index_expr(*root).array();
+      else
+        root = &to_typecast_expr(*root).op();
     }
-    else
+    DATA_INVARIANT(
+      root->id() != ID_dereference,
+      "arrays with non-byte-sized element types should not be accessed via "
+      "pointer dereference");
+    if(
+      effective_index.id() == ID_typecast &&
+      (to_typecast_expr(effective_index).op().type().id() == ID_integer ||
+       to_typecast_expr(effective_index).op().type().id() == ID_natural))
     {
-      const auto i = numeric_cast<mp_integer>(index);
+      effective_index = to_typecast_expr(effective_index).op();
+    }
 
-      if(!i.has_value() || *i < 0)
+    if(
+      effective_index.type().id() != ID_unsignedbv &&
+      effective_index.type().id() != ID_natural)
+    {
+      // we undo typecasts to signedbv
+      if(
+        effective_index.id() == ID_typecast &&
+        to_typecast_expr(effective_index).op().type().id() == ID_unsignedbv)
       {
-        exprt effective_offset = ode.offset();
+        // ok
+      }
+      else
+      {
+        const auto i = numeric_cast<mp_integer>(effective_index);
 
-        if(ode.root_object().id() == ID_dereference)
+        if(!i.has_value() || *i < 0)
         {
-          exprt p_offset =
-            pointer_offset(to_dereference_expr(ode.root_object()).pointer());
+          exprt zero = from_integer(0, effective_index.type());
 
-          effective_offset = plus_exprt{
-            p_offset,
-            typecast_exprt::conditional_cast(
-              effective_offset, p_offset.type())};
+          binary_relation_exprt inequality(
+            effective_index, ID_ge, std::move(zero));
+
+          add_guarded_property(
+            inequality,
+            name + " lower bound",
+            "array bounds",
+            true, // fatal
+            expr.find_source_location(),
+            expr,
+            guard);
         }
+      }
+    }
+  }
+  else
+  {
+    ode.emplace();
+    ode->build(expr, ns);
 
-        exprt zero = from_integer(0, effective_offset.type());
+    if(index.type().id() != ID_unsignedbv)
+    {
+      // we undo typecasts to signedbv
+      if(
+        index.id() == ID_typecast &&
+        to_typecast_expr(index).op().type().id() == ID_unsignedbv)
+      {
+        // ok
+      }
+      else
+      {
+        const auto i = numeric_cast<mp_integer>(index);
 
-        // the final offset must not be negative
-        binary_relation_exprt inequality(
-          effective_offset, ID_ge, std::move(zero));
+        if(!i.has_value() || *i < 0)
+        {
+          exprt effective_offset = ode->offset();
 
-        add_guarded_property(
-          inequality,
-          name + " lower bound",
-          "array bounds",
-          true, // fatal
-          expr.find_source_location(),
-          expr,
-          guard);
+          if(ode->root_object().id() == ID_dereference)
+          {
+            exprt p_offset =
+              pointer_offset(to_dereference_expr(ode->root_object()).pointer());
+
+            effective_offset = plus_exprt{
+              p_offset,
+              typecast_exprt::conditional_cast(
+                effective_offset, p_offset.type())};
+          }
+
+          exprt zero = from_integer(0, effective_offset.type());
+
+          // the final offset must not be negative
+          binary_relation_exprt inequality(
+            effective_offset, ID_ge, std::move(zero));
+
+          add_guarded_property(
+            inequality,
+            name + " lower bound",
+            "array bounds",
+            true, // fatal
+            expr.find_source_location(),
+            expr,
+            guard);
+        }
       }
     }
   }
 
-  if(ode.root_object().id() == ID_dereference)
+  if(ode && ode->root_object().id() == ID_dereference)
   {
-    const exprt &pointer = to_dereference_expr(ode.root_object()).pointer();
+    const exprt &pointer = to_dereference_expr(ode->root_object()).pointer();
 
     const plus_exprt effective_offset{
-      ode.offset(),
+      ode->offset(),
       typecast_exprt::conditional_cast(
-        pointer_offset(pointer), ode.offset().type())};
+        pointer_offset(pointer), ode->offset().type())};
 
     binary_relation_exprt inequality{
       effective_offset,
@@ -1663,7 +1741,7 @@ void goto_check_ct::bounds_check_index(
     exprt in_bounds_of_some_explicit_allocation =
       is_in_bounds_of_some_explicit_allocation(
         pointer,
-        plus_exprt{ode.offset(), from_integer(1, ode.offset().type())});
+        plus_exprt{ode->offset(), from_integer(1, ode->offset().type())});
 
     or_exprt precond(
       std::move(in_bounds_of_some_explicit_allocation), inequality);
@@ -1693,7 +1771,7 @@ void goto_check_ct::bounds_check_index(
   {
   }
   else if(
-    expr.array().id() == ID_member &&
+    ode && expr.array().id() == ID_member &&
     (size == 0 || array_type.get_bool(ID_C_flexible_array_member)))
   {
     // a variable sized struct member
@@ -1705,13 +1783,32 @@ void goto_check_ct::bounds_check_index(
     // array (with the same element type) that would not make the structure
     // larger than the object being accessed; [...]
     const auto type_size_opt =
-      pointer_offset_size(ode.root_object().type(), ns);
+      pointer_offset_size(ode->root_object().type(), ns);
     CHECK_RETURN(type_size_opt.has_value());
 
     binary_relation_exprt inequality(
-      ode.offset(),
+      ode->offset(),
       ID_lt,
-      from_integer(type_size_opt.value(), ode.offset().type()));
+      from_integer(type_size_opt.value(), ode->offset().type()));
+
+    add_guarded_property(
+      inequality,
+      name + " upper bound",
+      "array bounds",
+      true, // fatal
+      expr.find_source_location(),
+      expr,
+      guard);
+  }
+  else if(!ode.has_value())
+  {
+    // non-byte-sized element type: use effective_index (which has bitvector
+    // casts stripped) and cast the size to match
+    PRECONDITION(size.is_not_nil());
+    binary_relation_exprt inequality{
+      effective_index,
+      ID_lt,
+      typecast_exprt::conditional_cast(size, effective_index.type())};
 
     add_guarded_property(
       inequality,

--- a/src/ansi-c/goto-conversion/goto_check_c.cpp
+++ b/src/ansi-c/goto-conversion/goto_check_c.cpp
@@ -180,6 +180,13 @@ protected:
 
   void bounds_check(const exprt &, const guardt &);
   void bounds_check_index(const index_exprt &, const guardt &);
+  /// Adds a `<name> lower bound` array-bounds property asserting that
+  /// \p offset_or_index is non-negative.
+  void add_array_lower_bound_check(
+    const exprt &offset_or_index,
+    const index_exprt &expr,
+    const std::string &name,
+    const guardt &guard);
   void bounds_check_bit_count(const unary_exprt &, const guardt &);
   void div_by_zero_check(const div_exprt &, const guardt &);
   void float_div_by_zero_check(const div_exprt &, const guardt &);
@@ -1581,6 +1588,42 @@ void goto_check_ct::bounds_check(const exprt &expr, const guardt &guard)
   }
 }
 
+/// \return true if an array index needs an explicit lower-bound (>= 0) check,
+/// i.e. it is not of an unsigned or natural type, not a cast from an unsigned
+/// type, and not a statically non-negative constant.  A natural index is
+/// non-negative by construction; it never arises for byte-sized arrays, so
+/// excluding it here is also correct for that path.
+static bool array_index_needs_lower_bound_check(const exprt &index)
+{
+  if(index.type().id() == ID_unsignedbv || index.type().id() == ID_natural)
+    return false;
+  if(
+    index.id() == ID_typecast &&
+    to_typecast_expr(index).op().type().id() == ID_unsignedbv)
+  {
+    return false;
+  }
+  const auto i = numeric_cast<mp_integer>(index);
+  return !i.has_value() || *i < 0;
+}
+
+void goto_check_ct::add_array_lower_bound_check(
+  const exprt &offset_or_index,
+  const index_exprt &expr,
+  const std::string &name,
+  const guardt &guard)
+{
+  exprt zero = from_integer(0, offset_or_index.type());
+  add_guarded_property(
+    binary_relation_exprt{offset_or_index, ID_ge, std::move(zero)},
+    name + " lower bound",
+    "array bounds",
+    true, // fatal
+    expr.find_source_location(),
+    expr,
+    guard);
+}
+
 void goto_check_ct::bounds_check_index(
   const index_exprt &expr,
   const guardt &guard)
@@ -1605,10 +1648,10 @@ void goto_check_ct::bounds_check_index(
   // resulting assertions stay in the integer domain and can be handled by SMT
   // solvers.
   std::optional<object_descriptor_exprt> ode;
-  // effective_index is only used in the non-byte-sized path; it strips
-  // bitvector casts from integer/natural types to keep assertions in the
-  // integer domain.
-  exprt effective_index = index;
+  // effective_index is only set (and used) in the non-byte-sized path; it
+  // strips bitvector casts from integer/natural types to keep the assertions
+  // in the integer domain.
+  std::optional<exprt> effective_index;
   if(!size_of_expr(expr.type(), ns).has_value())
   {
     // Arrays with non-byte-sized element types arise from internal modeling
@@ -1629,97 +1672,43 @@ void goto_check_ct::bounds_check_index(
       root->id() != ID_dereference,
       "arrays with non-byte-sized element types should not be accessed via "
       "pointer dereference");
+
+    // strip a bitvector cast from an integer/natural type so the assertion
+    // stays in the integer domain
+    exprt stripped = index;
     if(
-      effective_index.id() == ID_typecast &&
-      (to_typecast_expr(effective_index).op().type().id() == ID_integer ||
-       to_typecast_expr(effective_index).op().type().id() == ID_natural))
+      stripped.id() == ID_typecast &&
+      (to_typecast_expr(stripped).op().type().id() == ID_integer ||
+       to_typecast_expr(stripped).op().type().id() == ID_natural))
     {
-      effective_index = to_typecast_expr(effective_index).op();
+      stripped = to_typecast_expr(stripped).op();
     }
+    effective_index = std::move(stripped);
 
-    if(
-      effective_index.type().id() != ID_unsignedbv &&
-      effective_index.type().id() != ID_natural)
-    {
-      // we undo typecasts to signedbv
-      if(
-        effective_index.id() == ID_typecast &&
-        to_typecast_expr(effective_index).op().type().id() == ID_unsignedbv)
-      {
-        // ok
-      }
-      else
-      {
-        const auto i = numeric_cast<mp_integer>(effective_index);
-
-        if(!i.has_value() || *i < 0)
-        {
-          exprt zero = from_integer(0, effective_index.type());
-
-          binary_relation_exprt inequality(
-            effective_index, ID_ge, std::move(zero));
-
-          add_guarded_property(
-            inequality,
-            name + " lower bound",
-            "array bounds",
-            true, // fatal
-            expr.find_source_location(),
-            expr,
-            guard);
-        }
-      }
-    }
+    if(array_index_needs_lower_bound_check(*effective_index))
+      add_array_lower_bound_check(*effective_index, expr, name, guard);
   }
   else
   {
     ode.emplace();
     ode->build(expr, ns);
 
-    if(index.type().id() != ID_unsignedbv)
+    if(array_index_needs_lower_bound_check(index))
     {
-      // we undo typecasts to signedbv
-      if(
-        index.id() == ID_typecast &&
-        to_typecast_expr(index).op().type().id() == ID_unsignedbv)
+      exprt effective_offset = ode->offset();
+
+      if(ode->root_object().id() == ID_dereference)
       {
-        // ok
+        exprt p_offset =
+          pointer_offset(to_dereference_expr(ode->root_object()).pointer());
+
+        effective_offset = plus_exprt{
+          p_offset,
+          typecast_exprt::conditional_cast(effective_offset, p_offset.type())};
       }
-      else
-      {
-        const auto i = numeric_cast<mp_integer>(index);
 
-        if(!i.has_value() || *i < 0)
-        {
-          exprt effective_offset = ode->offset();
-
-          if(ode->root_object().id() == ID_dereference)
-          {
-            exprt p_offset =
-              pointer_offset(to_dereference_expr(ode->root_object()).pointer());
-
-            effective_offset = plus_exprt{
-              p_offset,
-              typecast_exprt::conditional_cast(
-                effective_offset, p_offset.type())};
-          }
-
-          exprt zero = from_integer(0, effective_offset.type());
-
-          // the final offset must not be negative
-          binary_relation_exprt inequality(
-            effective_offset, ID_ge, std::move(zero));
-
-          add_guarded_property(
-            inequality,
-            name + " lower bound",
-            "array bounds",
-            true, // fatal
-            expr.find_source_location(),
-            expr,
-            guard);
-        }
-      }
+      // the final offset must not be negative
+      add_array_lower_bound_check(effective_offset, expr, name, guard);
     }
   }
 
@@ -1806,9 +1795,9 @@ void goto_check_ct::bounds_check_index(
     // casts stripped) and cast the size to match
     PRECONDITION(size.is_not_nil());
     binary_relation_exprt inequality{
-      effective_index,
+      *effective_index,
       ID_lt,
-      typecast_exprt::conditional_cast(size, effective_index.type())};
+      typecast_exprt::conditional_cast(size, effective_index->type())};
 
     add_guarded_property(
       inequality,

--- a/src/solvers/flattening/boolbv_get.cpp
+++ b/src/solvers/flattening/boolbv_get.cpp
@@ -232,9 +232,6 @@ exprt boolbvt::bv_get_rec(const exprt &expr, const bvt &bv, std::size_t offset)
   switch(bvtype)
   {
   case bvtypet::IS_UNKNOWN:
-    PRECONDITION(
-      type.id() == ID_string || type.id() == ID_empty ||
-      type.id() == ID_enumeration);
     if(type.id()==ID_string)
     {
       mp_integer int_value=binary2integer(value, false);
@@ -259,6 +256,18 @@ exprt boolbvt::bv_get_rec(const exprt &expr, const bvt &bv, std::size_t offset)
       else
         return constant_exprt{
           elements[numeric_cast_v<std::size_t>(int_value)].id(), type};
+    }
+    else
+    {
+      // Types without a genuine bit-vector representation reach this point,
+      // e.g. mathematical integers (ID_integer), rationals, reals and
+      // naturals, to which boolbv_widtht assigns only a dummy width. The
+      // flattening back-end cannot reconstruct a concrete value for such a
+      // type, so emit a graceful "unknown" placeholder (rendered as '*' by
+      // expr2c and '?' as a trace value) rather than aborting -- matching
+      // the exprt(ID_unknown) placeholder used elsewhere in this file for
+      // values we cannot determine.
+      return exprt{ID_unknown, type};
     }
     break;
 


### PR DESCRIPTION
﻿When the array element type has no byte size (e.g., arrays of __CPROVER_integer), object_descriptor_exprt::build cannot compute byte offsets. Fall back to a simple index-based lower-bound check instead of crashing. The upper bound check uses the array size directly and does not require byte offsets.

A DATA_INVARIANT ensures that arrays with non-byte-sized element types are not accessed via pointer dereference, making explicit the assumption that these arise only from internal modeling constructs.

Co-authored-by: Kiro <kiro-agent@users.noreply.github.com>

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
