### PR TITLE
Document, test, and fix --race-check instrumentation

### DIFF
--- a/doc/cprover-manual/properties.md
+++ b/doc/cprover-manual/properties.md
@@ -130,6 +130,7 @@ The goto-instrument program supports these checks:
 | `--undefined-shift-check`    |  add range checks for shift distances                |
 | `--nan-check`                |  add floating-point NaN checks                       |
 | `--uninitialized-check`      |  add checks for uninitialized locals (experimental)  |
+| `--race-check`               |  add data race checks for concurrent programs        |
 | `--error-label label`        |  check that given label is unreachable               |
 
 As all of these checks apply across the entire input program, we may wish to

--- a/doc/man/goto-instrument.1
+++ b/doc/man/goto-instrument.1
@@ -249,7 +249,7 @@ add checks for uninitialized locals (experimental)
 add check that call stack size of non\-inlined functions never exceeds n
 .TP
 \fB\-\-race\-check\fR
-add floating\-point data race checks
+add data race checks for concurrent programs
 .SS "Semantic transformations:"
 .TP
 \fB\-\-nondet\-volatile\fR

--- a/regression/goto-instrument/race-check/assert-condition.c
+++ b/regression/goto-instrument/race-check/assert-condition.c
@@ -1,0 +1,17 @@
+int shared;
+
+void writer(void)
+{
+  shared = 42;
+}
+
+int main(void)
+{
+__CPROVER_ASYNC_0:
+  writer();
+  // Shared read inside an ASSERT condition (exercises the is_assert() path).
+  // The user assertion itself always holds (shared is 0 or 42); the race
+  // assertion inserted before it is what fails.
+  __CPROVER_assert(shared >= 0, "shared is non-negative");
+  return 0;
+}

--- a/regression/goto-instrument/race-check/assert-condition.desc
+++ b/regression/goto-instrument/race-check/assert-condition.desc
@@ -1,0 +1,9 @@
+CORE
+assert-condition.c
+--race-check
+^EXIT=10$
+^SIGNAL=0$
+R/W data race on shared
+^VERIFICATION FAILED$
+--
+^warning: ignoring

--- a/regression/goto-instrument/race-check/assume-condition.c
+++ b/regression/goto-instrument/race-check/assume-condition.c
@@ -1,0 +1,15 @@
+int shared;
+
+void writer(void)
+{
+  shared = 42;
+}
+
+int main(void)
+{
+__CPROVER_ASYNC_0:
+  writer();
+  // Shared read inside an ASSUME condition (exercises the is_assume() path).
+  __CPROVER_assume(shared != 0);
+  return 0;
+}

--- a/regression/goto-instrument/race-check/assume-condition.desc
+++ b/regression/goto-instrument/race-check/assume-condition.desc
@@ -1,0 +1,9 @@
+CORE
+assume-condition.c
+--race-check
+^EXIT=10$
+^SIGNAL=0$
+R/W data race on shared
+^VERIFICATION FAILED$
+--
+^warning: ignoring

--- a/regression/goto-instrument/race-check/conditional.c
+++ b/regression/goto-instrument/race-check/conditional.c
@@ -1,0 +1,17 @@
+int shared;
+_Bool flag;
+
+void thread(void)
+{
+  if(flag)
+    shared = 1;
+}
+
+int main(void)
+{
+  flag = 1;
+__CPROVER_ASYNC_0:
+  thread();
+  shared = 2;
+  return 0;
+}

--- a/regression/goto-instrument/race-check/conditional.desc
+++ b/regression/goto-instrument/race-check/conditional.desc
@@ -1,0 +1,9 @@
+CORE
+conditional.c
+--race-check
+^EXIT=10$
+^SIGNAL=0$
+W/W data race on shared
+^VERIFICATION FAILED$
+--
+^warning: ignoring

--- a/regression/goto-instrument/race-check/dirty-local-verification.desc
+++ b/regression/goto-instrument/race-check/dirty-local-verification.desc
@@ -1,0 +1,14 @@
+// This test verifies that --race-check detects a W/W data race on a
+// dirty local variable (a local whose address is passed to another thread).
+// It is marked KNOWNBUG because CBMC's symex aborts with "pointer handling
+// for concurrency is unsound" when a pointer to a local variable is shared
+// between threads, preventing verification from completing.
+KNOWNBUG
+dirty-local.c
+--race-check
+^EXIT=10$
+^SIGNAL=0$
+W/W data race on main::1::local
+^VERIFICATION FAILED$
+--
+^warning: ignoring

--- a/regression/goto-instrument/race-check/dirty-local.c
+++ b/regression/goto-instrument/race-check/dirty-local.c
@@ -1,0 +1,13 @@
+void writer(int *p)
+{
+  *p = 42;
+}
+
+int main(void)
+{
+  int local = 0;
+__CPROVER_ASYNC_0:
+  writer(&local);
+  local = 1;
+  return 0;
+}

--- a/regression/goto-instrument/race-check/dirty-local.desc
+++ b/regression/goto-instrument/race-check/dirty-local.desc
@@ -1,0 +1,9 @@
+CORE
+dirty-local.c
+--race-check
+ASSIGN main::1::local\$w_guard := true
+W/W data race on main::1::local
+^EXIT=6$
+^SIGNAL=0$
+--
+^warning: ignoring

--- a/regression/goto-instrument/race-check/function-call-arg.c
+++ b/regression/goto-instrument/race-check/function-call-arg.c
@@ -1,0 +1,19 @@
+int shared;
+
+void sink(int val)
+{
+  (void)val;
+}
+
+void writer(void)
+{
+  shared = 42;
+}
+
+int main(void)
+{
+__CPROVER_ASYNC_0:
+  writer();
+  sink(shared);
+  return 0;
+}

--- a/regression/goto-instrument/race-check/function-call-arg.desc
+++ b/regression/goto-instrument/race-check/function-call-arg.desc
@@ -1,0 +1,9 @@
+CORE
+function-call-arg.c
+--race-check
+^EXIT=10$
+^SIGNAL=0$
+R/W data race on shared
+^VERIFICATION FAILED$
+--
+^warning: ignoring

--- a/regression/goto-instrument/race-check/function-call-lhs.c
+++ b/regression/goto-instrument/race-check/function-call-lhs.c
@@ -1,0 +1,19 @@
+int shared;
+
+int source(void)
+{
+  return 42;
+}
+
+void writer(void)
+{
+  shared = 1;
+}
+
+int main(void)
+{
+__CPROVER_ASYNC_0:
+  writer();
+  shared = source();
+  return 0;
+}

--- a/regression/goto-instrument/race-check/function-call-lhs.desc
+++ b/regression/goto-instrument/race-check/function-call-lhs.desc
@@ -1,0 +1,9 @@
+CORE
+function-call-lhs.c
+--race-check
+^EXIT=10$
+^SIGNAL=0$
+W/W data race on shared
+^VERIFICATION FAILED$
+--
+^warning: ignoring

--- a/regression/goto-instrument/race-check/goto-guard.c
+++ b/regression/goto-instrument/race-check/goto-guard.c
@@ -1,0 +1,16 @@
+int shared;
+
+void writer(void)
+{
+  shared = 42;
+}
+
+int main(void)
+{
+__CPROVER_ASYNC_0:
+  writer();
+  if(shared)
+  {
+  }
+  return 0;
+}

--- a/regression/goto-instrument/race-check/goto-guard.desc
+++ b/regression/goto-instrument/race-check/goto-guard.desc
@@ -1,0 +1,9 @@
+CORE
+goto-guard.c
+--race-check
+^EXIT=10$
+^SIGNAL=0$
+^\[main\.race-check\.\d+\] line \d+ R/W data race on shared: FAILURE$
+^VERIFICATION FAILED$
+--
+^warning: ignoring

--- a/regression/goto-instrument/race-check/no-race-sequential.c
+++ b/regression/goto-instrument/race-check/no-race-sequential.c
@@ -1,0 +1,8 @@
+int shared;
+
+int main(void)
+{
+  shared = 1;
+  shared = 2;
+  return 0;
+}

--- a/regression/goto-instrument/race-check/no-race-sequential.desc
+++ b/regression/goto-instrument/race-check/no-race-sequential.desc
@@ -1,0 +1,9 @@
+CORE
+no-race-sequential.c
+--race-check
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring
+FAILED

--- a/regression/goto-instrument/race-check/no-race-sequential.desc
+++ b/regression/goto-instrument/race-check/no-race-sequential.desc
@@ -6,4 +6,3 @@ no-race-sequential.c
 ^VERIFICATION SUCCESSFUL$
 --
 ^warning: ignoring
-FAILED

--- a/regression/goto-instrument/race-check/no-race.c
+++ b/regression/goto-instrument/race-check/no-race.c
@@ -1,0 +1,14 @@
+__CPROVER_thread_local int thread_local_var;
+
+void thread(void)
+{
+  thread_local_var = 1;
+}
+
+int main(void)
+{
+__CPROVER_ASYNC_0:
+  thread();
+  thread_local_var = 2;
+  return 0;
+}

--- a/regression/goto-instrument/race-check/no-race.desc
+++ b/regression/goto-instrument/race-check/no-race.desc
@@ -6,4 +6,3 @@ no-race.c
 ^VERIFICATION SUCCESSFUL$
 --
 ^warning: ignoring
-FAILED

--- a/regression/goto-instrument/race-check/no-race.desc
+++ b/regression/goto-instrument/race-check/no-race.desc
@@ -1,0 +1,9 @@
+CORE
+no-race.c
+--race-check
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring
+FAILED

--- a/regression/goto-instrument/race-check/pointer.c
+++ b/regression/goto-instrument/race-check/pointer.c
@@ -1,0 +1,14 @@
+int x;
+
+void thread(int *p)
+{
+  *p = 1;
+}
+
+int main(void)
+{
+__CPROVER_ASYNC_0:
+  thread(&x);
+  x = 2;
+  return 0;
+}

--- a/regression/goto-instrument/race-check/pointer.desc
+++ b/regression/goto-instrument/race-check/pointer.desc
@@ -1,0 +1,9 @@
+CORE
+pointer.c
+--race-check
+^EXIT=10$
+^SIGNAL=0$
+data race on x
+^VERIFICATION FAILED$
+--
+^warning: ignoring

--- a/regression/goto-instrument/race-check/read-write.c
+++ b/regression/goto-instrument/race-check/read-write.c
@@ -1,0 +1,15 @@
+int shared;
+
+void thread(void)
+{
+  shared = 1;
+}
+
+int main(void)
+{
+  int local;
+__CPROVER_ASYNC_0:
+  thread();
+  local = shared;
+  return 0;
+}

--- a/regression/goto-instrument/race-check/read-write.desc
+++ b/regression/goto-instrument/race-check/read-write.desc
@@ -1,0 +1,9 @@
+CORE
+read-write.c
+--race-check
+^EXIT=10$
+^SIGNAL=0$
+R/W data race on shared
+^VERIFICATION FAILED$
+--
+^warning: ignoring

--- a/regression/goto-instrument/race-check/return-value.c
+++ b/regression/goto-instrument/race-check/return-value.c
@@ -1,0 +1,20 @@
+int shared;
+
+int get_shared(void)
+{
+  return shared;
+}
+
+void writer(void)
+{
+  shared = 42;
+}
+
+int main(void)
+{
+  int local;
+__CPROVER_ASYNC_0:
+  writer();
+  local = get_shared();
+  return 0;
+}

--- a/regression/goto-instrument/race-check/return-value.desc
+++ b/regression/goto-instrument/race-check/return-value.desc
@@ -1,0 +1,9 @@
+CORE
+return-value.c
+--race-check
+^EXIT=10$
+^SIGNAL=0$
+R/W data race on shared
+^VERIFICATION FAILED$
+--
+^warning: ignoring

--- a/regression/goto-instrument/race-check/write-write.c
+++ b/regression/goto-instrument/race-check/write-write.c
@@ -1,0 +1,14 @@
+int shared;
+
+void thread(void)
+{
+  shared = 1;
+}
+
+int main(void)
+{
+__CPROVER_ASYNC_0:
+  thread();
+  shared = 2;
+  return 0;
+}

--- a/regression/goto-instrument/race-check/write-write.desc
+++ b/regression/goto-instrument/race-check/write-write.desc
@@ -1,0 +1,9 @@
+CORE
+write-write.c
+--race-check
+^EXIT=10$
+^SIGNAL=0$
+W/W data race on shared
+^VERIFICATION FAILED$
+--
+^warning: ignoring

--- a/src/goto-instrument/goto_instrument_parse_options.cpp
+++ b/src/goto-instrument/goto_instrument_parse_options.cpp
@@ -1940,7 +1940,7 @@ void goto_instrument_parse_optionst::help()
     HELP_UNINITIALIZED_CHECK
     " {y--stack-depth} {un} \t add check that call stack size of non-inlined"
     " functions never exceeds {un}\n"
-    " {y--race-check} \t add floating-point data race checks\n"
+    " {y--race-check} \t add data race checks for concurrent programs\n"
     "\n"
     "Semantic transformations:\n"
     HELP_NONDET_VOLATILE

--- a/src/goto-instrument/race_check.cpp
+++ b/src/goto-instrument/race_check.cpp
@@ -133,6 +133,33 @@ static std::string comment(const rw_set_baset::entryt &entry, bool write)
   return result;
 }
 
+/// Emit a race-check assertion for a single read/write-set \p entry,
+/// inserted immediately before \p i_it in \p goto_program. Centralises the
+/// comment text and the `race-check` property class so that every emission
+/// site stays consistent.
+/// \param goto_program: program to instrument
+/// \param i_it: instruction before which to insert the assertion
+/// \param w_guards: write-guard bookkeeping providing the assertion expression
+/// \param entry: the read/write-set entry being checked
+/// \param is_write: true for a W/W check, false for an R/W check
+/// \param source_location: source location to annotate the assertion with
+static void add_race_assertion(
+  goto_programt &goto_program,
+  goto_programt::targett i_it,
+  w_guardst &w_guards,
+  const rw_set_baset::entryt &entry,
+  bool is_write,
+  const source_locationt &source_location)
+{
+  source_locationt annotated_location = source_location;
+  annotated_location.set_comment(comment(entry, is_write));
+  annotated_location.set_property_class("race-check");
+  goto_program.insert_before(
+    i_it,
+    goto_programt::make_assertion(
+      w_guards.get_assertion(entry), annotated_location));
+}
+
 /// Check whether a symbol refers to a shared (non-thread-local) variable,
 /// excluding internal CPROVER symbols that should not be race-checked.
 static bool is_shared(const namespacet &ns, const symbol_exprt &symbol_expr)
@@ -149,7 +176,7 @@ static bool is_shared(const namespacet &ns, const symbol_exprt &symbol_expr)
     return false; // no race check
 
   const symbolt &symbol=ns.lookup(identifier);
-  return symbol.is_shared();
+  return !symbol.is_function() && symbol.is_shared();
 }
 
 /// Check whether any entry in the read/write set refers to a shared variable.
@@ -195,8 +222,16 @@ static void race_check(
   {
     goto_programt::instructiont &instruction=*i_it;
 
-    if(instruction.is_assign())
+    if(instruction.is_assign() || instruction.is_function_call())
     {
+      // For a FUNCTION_CALL we reuse the ASSIGN set/reset sequence: the write
+      // guard for the call's lhs is set before the call and reset only after
+      // it returns, so the modelled write window spans the whole callee
+      // execution rather than just the return-value assignment. This is an
+      // intentional over-approximation -- it is sound for race finding (it
+      // cannot miss a race) but may over-report a W/W race if the callee
+      // itself sequentially touches the lhs. It is consistent with how ASSIGN
+      // is modelled.
       rw_set_loct rw_set(
         ns,
         value_sets,
@@ -254,14 +289,13 @@ static void race_check(
         if(!is_shared(ns, r_entry.second.symbol_expr))
           continue;
 
-        source_locationt annotated_location =
-          original_instruction.source_location();
-        annotated_location.set_comment(comment(r_entry.second, false));
-        annotated_location.set_property_class("race-check");
-        goto_program.insert_before(
+        add_race_assertion(
+          goto_program,
           i_it,
-          goto_programt::make_assertion(
-            w_guards.get_assertion(r_entry.second), annotated_location));
+          w_guards,
+          r_entry.second,
+          false,
+          original_instruction.source_location());
       }
 
       for(const auto &w_entry : rw_set.w_entries)
@@ -269,17 +303,45 @@ static void race_check(
         if(!is_shared(ns, w_entry.second.symbol_expr))
           continue;
 
-        source_locationt annotated_location =
-          original_instruction.source_location();
-        annotated_location.set_comment(comment(w_entry.second, true));
-        annotated_location.set_property_class("race-check");
-        goto_program.insert_before(
+        add_race_assertion(
+          goto_program,
           i_it,
-          goto_programt::make_assertion(
-            w_guards.get_assertion(w_entry.second), annotated_location));
+          w_guards,
+          w_entry.second,
+          true,
+          original_instruction.source_location());
       }
 
       i_it--; // the for loop already counts us up
+    }
+    else if(
+      instruction.is_goto() || instruction.is_assume() ||
+      instruction.is_assert() || instruction.is_set_return_value())
+    {
+      rw_set_loct rw_set(
+        ns,
+        value_sets,
+        function_id,
+        i_it L_M_LAST_ARG(local_may),
+        message_handler);
+
+      if(!has_shared_entries(ns, rw_set))
+        continue;
+
+      // add R/W assertions for shared reads before the instruction
+      for(const auto &r_entry : rw_set.r_entries)
+      {
+        if(!is_shared(ns, r_entry.second.symbol_expr))
+          continue;
+
+        add_race_assertion(
+          goto_program,
+          i_it,
+          w_guards,
+          r_entry.second,
+          false,
+          instruction.source_location());
+      }
     }
   }
 

--- a/src/goto-instrument/race_check.cpp
+++ b/src/goto-instrument/race_check.cpp
@@ -257,6 +257,7 @@ static void race_check(
         source_locationt annotated_location =
           original_instruction.source_location();
         annotated_location.set_comment(comment(r_entry.second, false));
+        annotated_location.set_property_class("race-check");
         goto_program.insert_before(
           i_it,
           goto_programt::make_assertion(
@@ -271,6 +272,7 @@ static void race_check(
         source_locationt annotated_location =
           original_instruction.source_location();
         annotated_location.set_comment(comment(w_entry.second, true));
+        annotated_location.set_property_class("race-check");
         goto_program.insert_before(
           i_it,
           goto_programt::make_assertion(

--- a/src/goto-instrument/race_check.cpp
+++ b/src/goto-instrument/race_check.cpp
@@ -19,6 +19,7 @@ Date: February 2006
 
 #include <goto-programs/remove_skip.h>
 
+#include <analyses/dirty.h>
 #include <linking/static_lifetime_init.h>
 
 #include "rw_set.h"
@@ -162,7 +163,13 @@ static void add_race_assertion(
 
 /// Check whether a symbol refers to a shared (non-thread-local) variable,
 /// excluding internal CPROVER symbols that should not be race-checked.
-static bool is_shared(const namespacet &ns, const symbol_exprt &symbol_expr)
+/// A variable is considered shared if it is globally shared or if it is a
+/// "dirty" local (its address has been taken, so it may be accessible from
+/// other threads).
+static bool is_shared(
+  const namespacet &ns,
+  const symbol_exprt &symbol_expr,
+  const dirtyt &dirty)
 {
   const irep_idt &identifier = symbol_expr.identifier();
 
@@ -176,24 +183,27 @@ static bool is_shared(const namespacet &ns, const symbol_exprt &symbol_expr)
     return false; // no race check
 
   const symbolt &symbol=ns.lookup(identifier);
-  return !symbol.is_function() && symbol.is_shared();
+  return !symbol.is_function() && (symbol.is_shared() || dirty(identifier));
 }
 
 /// Check whether any entry in the read/write set refers to a shared variable.
-static bool has_shared_entries(const namespacet &ns, const rw_set_baset &rw_set)
+static bool has_shared_entries(
+  const namespacet &ns,
+  const rw_set_baset &rw_set,
+  const dirtyt &dirty)
 {
   for(rw_set_baset::entriest::const_iterator
       it=rw_set.r_entries.begin();
       it!=rw_set.r_entries.end();
       it++)
-    if(is_shared(ns, it->second.symbol_expr))
+    if(is_shared(ns, it->second.symbol_expr, dirty))
       return true;
 
   for(rw_set_baset::entriest::const_iterator
       it=rw_set.w_entries.begin();
       it!=rw_set.w_entries.end();
       it++)
-    if(is_shared(ns, it->second.symbol_expr))
+    if(is_shared(ns, it->second.symbol_expr, dirty))
       return true;
 
   return false;
@@ -209,6 +219,7 @@ static void race_check(
   L_M_ARG(const goto_functionst::goto_functiont &goto_function)
   goto_programt &goto_program,
   w_guardst &w_guards,
+  const dirtyt &dirty,
   message_handlert &message_handler)
 // clang-format on
 {
@@ -239,7 +250,7 @@ static void race_check(
         i_it L_M_LAST_ARG(local_may),
         message_handler);
 
-      if(!has_shared_entries(ns, rw_set))
+      if(!has_shared_entries(ns, rw_set, dirty))
         continue;
 
       goto_programt::instructiont original_instruction;
@@ -252,7 +263,7 @@ static void race_check(
       // now add assignments for what is written -- set
       for(const auto &w_entry : rw_set.w_entries)
       {
-        if(!is_shared(ns, w_entry.second.symbol_expr))
+        if(!is_shared(ns, w_entry.second.symbol_expr, dirty))
           continue;
 
         goto_program.insert_before(
@@ -272,7 +283,7 @@ static void race_check(
       // now add assignments for what is written -- reset
       for(const auto &w_entry : rw_set.w_entries)
       {
-        if(!is_shared(ns, w_entry.second.symbol_expr))
+        if(!is_shared(ns, w_entry.second.symbol_expr, dirty))
           continue;
 
         goto_program.insert_before(
@@ -286,7 +297,7 @@ static void race_check(
       // now add assertions for what is read and written
       for(const auto &r_entry : rw_set.r_entries)
       {
-        if(!is_shared(ns, r_entry.second.symbol_expr))
+        if(!is_shared(ns, r_entry.second.symbol_expr, dirty))
           continue;
 
         add_race_assertion(
@@ -300,7 +311,7 @@ static void race_check(
 
       for(const auto &w_entry : rw_set.w_entries)
       {
-        if(!is_shared(ns, w_entry.second.symbol_expr))
+        if(!is_shared(ns, w_entry.second.symbol_expr, dirty))
           continue;
 
         add_race_assertion(
@@ -325,13 +336,13 @@ static void race_check(
         i_it L_M_LAST_ARG(local_may),
         message_handler);
 
-      if(!has_shared_entries(ns, rw_set))
+      if(!has_shared_entries(ns, rw_set, dirty))
         continue;
 
       // add R/W assertions for shared reads before the instruction
       for(const auto &r_entry : rw_set.r_entries)
       {
-        if(!is_shared(ns, r_entry.second.symbol_expr))
+        if(!is_shared(ns, r_entry.second.symbol_expr, dirty))
           continue;
 
         add_race_assertion(
@@ -359,6 +370,10 @@ void race_check(
   message_handlert &message_handler)
 {
   w_guardst w_guards(symbol_table);
+  // When called for a single function we don't have the full goto_functions
+  // to build a complete dirtyt, so we use an empty one. The goto_modelt
+  // overload below computes a proper whole-program dirty analysis.
+  dirtyt dirty{goto_functionst{}};
 
   race_check(
     value_sets,
@@ -366,6 +381,7 @@ void race_check(
     function_id,
     L_M_ARG(goto_function) goto_program,
     w_guards,
+    dirty,
     message_handler);
 
   w_guards.add_initialization(goto_program);
@@ -378,6 +394,7 @@ void race_check(
   message_handlert &message_handler)
 {
   w_guardst w_guards(goto_model.symbol_table);
+  dirtyt dirty(goto_model.goto_functions);
 
   for(auto &gf_entry : goto_model.goto_functions.function_map)
   {
@@ -391,6 +408,7 @@ void race_check(
         gf_entry.first,
         L_M_ARG(gf_entry.second) gf_entry.second.body,
         w_guards,
+        dirty,
         message_handler);
     }
   }

--- a/src/goto-instrument/race_check.cpp
+++ b/src/goto-instrument/race_check.cpp
@@ -10,6 +10,8 @@ Date: February 2006
 
 /// \file
 /// Race Detection for Threaded Goto Programs
+///
+/// \see race_check.h for an overview of the instrumentation scheme.
 
 #include "race_check.h"
 
@@ -30,6 +32,10 @@ Date: February 2006
 #define L_M_LAST_ARG(x)
 #endif
 
+/// Manages boolean "write guard" variables used to detect concurrent writes.
+/// For each shared variable `x`, a boolean symbol `x$w_guard` is created.
+/// These guards are set to true around write accesses and checked by
+/// assertions in other threads.
 class w_guardst
 {
 public:
@@ -63,6 +69,9 @@ protected:
   symbol_table_baset &symbol_table;
 };
 
+/// Get or create the boolean guard symbol for a shared variable.
+/// \param object: the identifier of the shared variable
+/// \return the guard symbol `<object>$w_guard`
 const symbolt &w_guardst::get_guard_symbol(const irep_idt &object)
 {
   const irep_idt identifier=id2string(object)+"$w_guard";
@@ -86,6 +95,8 @@ const symbolt &w_guardst::get_guard_symbol(const irep_idt &object)
   return *symbol_ptr;
 }
 
+/// Insert assignments to initialize all write guard variables to false
+/// at the beginning of the given program.
 void w_guardst::add_initialization(goto_programt &goto_program) const
 {
   goto_programt::targett t=goto_program.instructions.begin();
@@ -105,6 +116,10 @@ void w_guardst::add_initialization(goto_programt &goto_program) const
   }
 }
 
+/// Build a human-readable comment for a race-check assertion.
+/// \param entry: the read/write set entry describing the access
+/// \param write: true if this is a W/W race check, false for R/W
+/// \return a string like "R/W data race on x" or "W/W data race on x"
 static std::string comment(const rw_set_baset::entryt &entry, bool write)
 {
   std::string result;
@@ -118,6 +133,8 @@ static std::string comment(const rw_set_baset::entryt &entry, bool write)
   return result;
 }
 
+/// Check whether a symbol refers to a shared (non-thread-local) variable,
+/// excluding internal CPROVER symbols that should not be race-checked.
 static bool is_shared(const namespacet &ns, const symbol_exprt &symbol_expr)
 {
   const irep_idt &identifier = symbol_expr.identifier();
@@ -135,6 +152,7 @@ static bool is_shared(const namespacet &ns, const symbol_exprt &symbol_expr)
   return symbol.is_shared();
 }
 
+/// Check whether any entry in the read/write set refers to a shared variable.
 static bool has_shared_entries(const namespacet &ns, const rw_set_baset &rw_set)
 {
   for(rw_set_baset::entriest::const_iterator

--- a/src/goto-instrument/race_check.h
+++ b/src/goto-instrument/race_check.h
@@ -10,6 +10,41 @@ Date: February 2006
 
 /// \file
 /// Race Detection for Threaded Goto Programs
+///
+/// This implements a data-race detector for concurrent programs, inspired by
+/// the Eraser algorithm (Savage et al., "Eraser: A Dynamic Data Race Detector
+/// for Multithreaded Programs", ACM TOCS 1997). While Eraser uses lockset
+/// tracking at runtime, this implementation adapts the core idea for static
+/// verification via bounded model checking: it instruments the program with
+/// boolean "write guard" flags and assertions so that CBMC's exploration of
+/// thread interleavings can reveal conflicting concurrent accesses.
+///
+/// A data race occurs when two threads access the same shared memory location
+/// concurrently and at least one access is a write. This instrumentation
+/// detects two kinds of races:
+/// - R/W races: one thread reads a variable while another writes it.
+/// - W/W races: two threads write the same variable concurrently.
+///
+/// For each assignment that accesses shared variables, the instrumentation
+/// replaces the original instruction with the following sequence:
+///
+/// 1. For each shared variable `x` written: set `x$w_guard` to the guard
+///    condition under which the write occurs.
+/// 2. Execute the original assignment.
+/// 3. For each shared variable `x` written: reset `x$w_guard` to false.
+/// 4. For each shared variable `y` read: assert `!y$w_guard` (R/W check).
+/// 5. For each shared variable `x` written: assert `!x$w_guard` (W/W check).
+///
+/// During symbolic execution of concurrent programs, CBMC explores thread
+/// interleavings. If another thread's write guard is set (step 1) when the
+/// current thread checks it (steps 4/5), the assertion fails, indicating a
+/// data race.
+///
+/// Pointer dereferences are resolved using value-set analysis (or, when
+/// LOCAL_MAY is defined, local may-alias analysis) so that races through
+/// aliased pointer accesses are detected. For example, if thread A writes
+/// `*p` and thread B writes `x`, and `p` points to `x`, the instrumentation
+/// will detect the W/W race on `x`.
 
 #ifndef CPROVER_GOTO_INSTRUMENT_RACE_CHECK_H
 #define CPROVER_GOTO_INSTRUMENT_RACE_CHECK_H
@@ -25,6 +60,12 @@ class goto_programt;
 class message_handlert;
 class value_setst;
 
+/// Instrument a single function with data-race detection assertions.
+/// \param value_sets: value-set analysis results for pointer resolution
+/// \param symbol_table: the symbol table (modified to add guard symbols)
+/// \param function_id: identifier of the function being instrumented
+/// \param goto_program: the function body to instrument
+/// \param message_handler: handler for status and diagnostic messages
 void race_check(
   value_setst &,
   class symbol_table_baset &,
@@ -35,6 +76,11 @@ void race_check(
   goto_programt &goto_program,
   message_handlert &);
 
+/// Instrument all functions in a goto model with data-race detection
+/// assertions. Skips the entry point and the initialization function.
+/// \param value_sets: value-set analysis results for pointer resolution
+/// \param goto_model: the goto model to instrument
+/// \param message_handler: handler for status and diagnostic messages
 void race_check(value_setst &, goto_modelt &, message_handlert &);
 
 #endif // CPROVER_GOTO_INSTRUMENT_RACE_CHECK_H

--- a/src/goto-instrument/race_check.h
+++ b/src/goto-instrument/race_check.h
@@ -25,15 +25,20 @@ Date: February 2006
 /// - R/W races: one thread reads a variable while another writes it.
 /// - W/W races: two threads write the same variable concurrently.
 ///
-/// For each assignment that accesses shared variables, the instrumentation
-/// replaces the original instruction with the following sequence:
+/// For each assignment or function call that accesses shared variables, the
+/// instrumentation replaces the original instruction with the following
+/// sequence:
 ///
 /// 1. For each shared variable `x` written: set `x$w_guard` to the guard
 ///    condition under which the write occurs.
-/// 2. Execute the original assignment.
+/// 2. Execute the original instruction.
 /// 3. For each shared variable `x` written: reset `x$w_guard` to false.
 /// 4. For each shared variable `y` read: assert `!y$w_guard` (R/W check).
 /// 5. For each shared variable `x` written: assert `!x$w_guard` (W/W check).
+///
+/// For instructions that only read shared variables (GOTO/ASSUME/ASSERT
+/// guards, SET_RETURN_VALUE), only R/W assertions (step 4) are added before
+/// the instruction.
 ///
 /// During symbolic execution of concurrent programs, CBMC explores thread
 /// interleavings. If another thread's write guard is set (step 1) when the

--- a/src/goto-instrument/rw_set.cpp
+++ b/src/goto-instrument/rw_set.cpp
@@ -68,6 +68,10 @@ void _rw_set_loct::compute()
     if(target->call_lhs().is_not_nil())
       write(target->call_lhs());
   }
+  else if(target->is_set_return_value())
+  {
+    read(target->return_value());
+  }
 }
 
 void _rw_set_loct::assign(const exprt &lhs, const exprt &rhs)


### PR DESCRIPTION
Please review commit-by-commit. Overall summary:

## Improve `--race-check`: docs, bug fixes, dirty-locals support

Document the Eraser-inspired write-guard instrumentation scheme. Fix the incorrect "floating-point" help text and add `--race-check` to the cprover manual.

Fix missed races: instrument GOTO guards, function call arguments, and return statements (not just ASSIGN). Exclude function symbols from race checking. Set `property_class` to `"race-check"` on generated assertions.

Use `dirtyt` analysis to treat address-taken locals as shared, matching `goto-symex` behavior.

Add 11 regression tests in `regression/goto-instrument/race-check/`.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [x] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
