### PR TITLE
Fail CI immediately when Chocolatey dependency installation fails

### DIFF
--- a/.github/workflows/pull-request-checks.yaml
+++ b/.github/workflows/pull-request-checks.yaml
@@ -753,6 +753,18 @@ jobs:
           submodules: recursive
       - name: Setup Visual Studio environment
         uses: microsoft/setup-msbuild@v2
+      - name: Get current month for cache key
+        id: cache-key
+        run: echo "month=$(Get-Date -Format 'yyyy-MM')" >> $env:GITHUB_OUTPUT
+      - name: Cache Chocolatey packages
+        uses: actions/cache@v5
+        with:
+          path: |
+            C:\ProgramData\chocolatey\lib
+            C:\ProgramData\chocolatey\bin
+          key: ${{ runner.os }}-choco-${{ steps.cache-key.outputs.month }}-winflexbison3
+          restore-keys: |
+            ${{ runner.os }}-choco-${{ steps.cache-key.outputs.month }}
       - name: Fetch dependencies
         run: |
           function Require-Tool($Name) {
@@ -823,6 +835,18 @@ jobs:
           submodules: recursive
       - name: Setup MSBuild
         uses: microsoft/setup-msbuild@v2
+      - name: Get current month for cache key
+        id: cache-key
+        run: echo "month=$(Get-Date -Format 'yyyy-MM')" >> $env:GITHUB_OUTPUT
+      - name: Cache Chocolatey packages
+        uses: actions/cache@v5
+        with:
+          path: |
+            C:\ProgramData\chocolatey\lib
+            C:\ProgramData\chocolatey\bin
+          key: ${{ runner.os }}-choco-${{ steps.cache-key.outputs.month }}-winflexbison3-strawberryperl-wget
+          restore-keys: |
+            ${{ runner.os }}-choco-${{ steps.cache-key.outputs.month }}
       - name: Fetch dependencies
         run: |
           function Require-Tool($Name) {
@@ -910,6 +934,18 @@ jobs:
           submodules: recursive
       - name: Setup Visual Studio environment
         uses: microsoft/setup-msbuild@v2
+      - name: Get current month for cache key
+        id: cache-key
+        run: echo "month=$(Get-Date -Format 'yyyy-MM')" >> $env:GITHUB_OUTPUT
+      - name: Cache Chocolatey packages
+        uses: actions/cache@v5
+        with:
+          path: |
+            C:\ProgramData\chocolatey\lib
+            C:\ProgramData\chocolatey\bin
+          key: ${{ runner.os }}-choco-${{ steps.cache-key.outputs.month }}-winflexbison3
+          restore-keys: |
+            ${{ runner.os }}-choco-${{ steps.cache-key.outputs.month }}
       - name: Fetch dependencies
         run: |
           function Require-Tool($Name) {

--- a/.github/workflows/pull-request-checks.yaml
+++ b/.github/workflows/pull-request-checks.yaml
@@ -755,12 +755,20 @@ jobs:
         uses: microsoft/setup-msbuild@v2
       - name: Fetch dependencies
         run: |
+          function Require-Tool($Name) {
+            if (-not (Get-Command $Name -ErrorAction SilentlyContinue)) {
+              Write-Output "::error ::Required tool '$Name' not found in PATH after Chocolatey installation."
+              exit 1
+            }
+          }
           choco install winflexbison3
           if($LastExitCode -ne 0)
           {
             Write-Output "::error ::Dependency installation via Chocolatey failed."
             exit $LastExitCode
           }
+          Require-Tool win_flex
+          Require-Tool win_bison
           nuget install clcache -OutputDirectory "c:\tools" -ExcludeVersion -Version 4.1.0
           echo "c:\tools\clcache\clcache-4.1.0" >> $env:GITHUB_PATH
           Invoke-WebRequest -Uri https://github.com/Z3Prover/z3/releases/download/z3-4.8.10/z3-4.8.10-x64-win.zip -OutFile .\z3.zip
@@ -817,12 +825,22 @@ jobs:
         uses: microsoft/setup-msbuild@v2
       - name: Fetch dependencies
         run: |
+          function Require-Tool($Name) {
+            if (-not (Get-Command $Name -ErrorAction SilentlyContinue)) {
+              Write-Output "::error ::Required tool '$Name' not found in PATH after Chocolatey installation."
+              exit 1
+            }
+          }
           choco install -y winflexbison3 strawberryperl wget
           if($LastExitCode -ne 0)
           {
             Write-Output "::error ::Dependency installation via Chocolatey failed."
             exit $LastExitCode
           }
+          Require-Tool win_flex
+          Require-Tool win_bison
+          Require-Tool perl
+          Require-Tool wget.exe
           nuget install clcache -OutputDirectory "c:\tools" -ExcludeVersion -Version 4.1.0
           echo "c:\tools\clcache\clcache-4.1.0" >> $env:GITHUB_PATH
           echo "c:\Strawberry\" >> $env:GITHUB_PATH
@@ -894,12 +912,20 @@ jobs:
         uses: microsoft/setup-msbuild@v2
       - name: Fetch dependencies
         run: |
+          function Require-Tool($Name) {
+            if (-not (Get-Command $Name -ErrorAction SilentlyContinue)) {
+              Write-Output "::error ::Required tool '$Name' not found in PATH after Chocolatey installation."
+              exit 1
+            }
+          }
           choco install winflexbison3
           if($LastExitCode -ne 0)
           {
             Write-Output "::error ::Dependency installation via Chocolatey failed."
             exit $LastExitCode
           }
+          Require-Tool win_flex
+          Require-Tool win_bison
           nuget install clcache -OutputDirectory "c:\tools" -ExcludeVersion -Version 4.1.0
           echo "c:\tools\clcache\clcache-4.1.0" >> $env:GITHUB_PATH
       - name: Prepare ccache

--- a/.github/workflows/release-packages.yaml
+++ b/.github/workflows/release-packages.yaml
@@ -263,7 +263,20 @@ jobs:
         uses: microsoft/setup-msbuild@v2
       - name: Fetch dependencies
         run: |
+          function Require-Tool($Name) {
+            if (-not (Get-Command $Name -ErrorAction SilentlyContinue)) {
+              Write-Output "::error ::Required tool '$Name' not found in PATH after Chocolatey installation."
+              exit 1
+            }
+          }
           choco install winflexbison3
+          if($LastExitCode -ne 0)
+          {
+            Write-Output "::error ::Dependency installation via Chocolatey failed."
+            exit $LastExitCode
+          }
+          Require-Tool win_flex
+          Require-Tool win_bison
           nuget install clcache -OutputDirectory "c:\tools" -ExcludeVersion -Version 4.1.0
           echo "c:\tools\clcache\clcache-4.1.0" >> $env:GITHUB_PATH
       - name: Setup code sign environment

--- a/.github/workflows/release-packages.yaml
+++ b/.github/workflows/release-packages.yaml
@@ -261,6 +261,18 @@ jobs:
           submodules: recursive
       - name: Setup Visual Studio environment
         uses: microsoft/setup-msbuild@v2
+      - name: Get current month for cache key
+        id: cache-key
+        run: echo "month=$(Get-Date -Format 'yyyy-MM')" >> $env:GITHUB_OUTPUT
+      - name: Cache Chocolatey packages
+        uses: actions/cache@v5
+        with:
+          path: |
+            C:\ProgramData\chocolatey\lib
+            C:\ProgramData\chocolatey\bin
+          key: ${{ runner.os }}-choco-${{ steps.cache-key.outputs.month }}-winflexbison3
+          restore-keys: |
+            ${{ runner.os }}-choco-${{ steps.cache-key.outputs.month }}
       - name: Fetch dependencies
         run: |
           function Require-Tool($Name) {


### PR DESCRIPTION
Chocolatey may return exit code 0 even when a package fails to install (e.g., due to a 504 from the server). The existing $LastExitCode check does not catch this, causing the build to proceed and fail much later with a confusing error (e.g., missing flex-generated scanner).

Add Get-Command checks for win_flex, win_bison (and perl, wget where applicable) right after the choco install step. These use -ErrorAction Stop to immediately terminate the step if any tool is not available.

Also add the missing error check in release-packages.yaml which had no $LastExitCode check at all.

See https://github.com/diffblue/cbmc/actions/runs/22671621294/job/65716959293?pr=8846 for an example of a run that should have aborted much earlier.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
