### PR TITLE
Fix array refinement crash with CaDiCaL SAT solver

### DIFF
--- a/src/solvers/refinement/refine_arrays.cpp
+++ b/src/solvers/refinement/refine_arrays.cpp
@@ -40,14 +40,25 @@ void bv_refinementt::arrays_overapproximated()
 
   unsigned nb_active=0;
 
-  std::list<lazy_constraintt>::iterator it=lazy_array_constraints.begin();
-  while(it!=lazy_array_constraints.end())
+  // Evaluate all lazy constraints while the solver is still in SAT state.
+  // We must not interleave get_value() calls with modifications to the
+  // main solver (prop) because some SAT solvers (e.g., CaDiCaL) only
+  // permit reading model values while in the satisfied state, and adding
+  // clauses invalidates that state.
+  struct evaluated_constraintt
   {
-    satcheck_no_simplifiert sat_check{log.get_message_handler()};
-    bv_pointerst solver{ns, sat_check, log.get_message_handler()};
-    solver.unbounded_array=bv_pointerst::unbounded_arrayt::U_ALL;
+    exprt constraint;
+    exprt simplified;
+    std::list<lazy_constraintt>::iterator list_it;
+  };
+  std::vector<evaluated_constraintt> to_check;
+  to_check.reserve(lazy_array_constraints.size());
 
-    exprt current=(*it).lazy;
+  for(auto it = lazy_array_constraints.begin();
+      it != lazy_array_constraints.end();
+      ++it)
+  {
+    const exprt &current = it->lazy;
 
     // some minor simplifications
     // check if they are worth having
@@ -57,7 +68,6 @@ void bv_refinementt::arrays_overapproximated()
       exprt implies_simplified = get_value(imp.op0());
       if(implies_simplified==false_exprt())
       {
-        ++it;
         continue;
       }
     }
@@ -71,23 +81,31 @@ void bv_refinementt::arrays_overapproximated()
       exprt o2 = get_value(orexp.op1());
       if(o1==true_exprt() || o2 == true_exprt())
       {
-        ++it;
         continue;
       }
     }
 
-    exprt simplified = get_value(current);
-    solver << simplified;
+    to_check.push_back({current, get_value(current), it});
+  }
+
+  // Now check each evaluated constraint using a local solver and activate
+  // violated ones. This phase may modify the main solver (prop).
+  for(auto &entry : to_check)
+  {
+    satcheck_no_simplifiert sat_check{log.get_message_handler()};
+    bv_pointerst solver{ns, sat_check, log.get_message_handler()};
+    solver.unbounded_array = bv_pointerst::unbounded_arrayt::U_ALL;
+
+    solver << entry.simplified;
 
     switch(static_cast<decision_proceduret::resultt>(sat_check.prop_solve()))
     {
     case decision_proceduret::resultt::D_SATISFIABLE:
-      ++it;
       break;
     case decision_proceduret::resultt::D_UNSATISFIABLE:
-      prop.l_set_to_true(convert(current));
+      prop.l_set_to_true(convert(entry.constraint));
       nb_active++;
-      lazy_array_constraints.erase(it++);
+      lazy_array_constraints.erase(entry.list_it);
       break;
     case decision_proceduret::resultt::D_ERROR:
       INVARIANT(false, "error in array over approximation check");


### PR DESCRIPTION
Commit 6ff2ce40b8 ("Use get_value() instead of get() in array refinement loop", PR #8842) introduced get_value() calls in arrays_overapproximated() that read actual values from the SAT model (via CaDiCaL's val()). The loop interleaved these calls with modifications to the main solver (adding clauses via prop.l_set_to_true(convert(...))). CaDiCaL 3.0.0 strictly enforces that val() can only be called in the satisfied state, and adding clauses invalidates that state, causing a fatal error:
  'can only get value in satisfied state'

This was observed on the macOS-14 CI job (which uses CaDiCaL) for Array_UF3, Array_UF4, Array_UF5, Array_UF7, Array_UF8, Array_UF9, and Array_UF16 tests, all of which use --refine-arrays.

Fix: split the loop into two phases. First, evaluate all lazy constraints using get_value() while the solver is still in SAT state. Then, check each evaluated constraint with a local solver and activate violated ones by adding clauses to the main solver.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
