### PR TITLE
Limit MiniSat simplifier only when arrays-uf-always is used

### DIFF
--- a/regression/cbmc/Array_UF23/main.c
+++ b/regression/cbmc/Array_UF23/main.c
@@ -1,0 +1,26 @@
+/// \file
+/// Exercises incremental SAT solving with MiniSat's simplifier. Under
+/// --arrays-uf-always the variable-length array `a` uses the unbounded (U_ALL)
+/// array encoding, whose Ackermann-style array-constraint refinement issues
+/// many incremental SAT calls in the all-properties verification loop.
+/// Together with the default array-bounds checks on the VLA, this drives the
+/// repeated solves that, when MiniSat re-runs variable elimination before each
+/// of them, can blow up into a hang. That hang was observed in conjunction
+/// with the reduced Ackermann-constraint encoding for weak array equivalence
+/// and a 32-bit target; the accompanying fix limits the simplifier to the
+/// first solve. See test.desc for details.
+int main()
+{
+  unsigned long array_size;
+  int a[array_size];
+  int i0, i1, i2, i3, i4;
+
+  a[i0] = 0;
+  a[i1] = 1;
+  a[i2] = 2;
+  a[i3] = 3;
+  a[i4] = 4;
+
+  __CPROVER_assert(a[i0] >= 0, "a[i0] >= 0");
+  return 0;
+}

--- a/regression/cbmc/Array_UF23/test.desc
+++ b/regression/cbmc/Array_UF23/test.desc
@@ -1,0 +1,27 @@
+CORE
+main.c
+--arrays-uf-always --unwind 1 --32
+^\[main\.array_bounds\.1\] line 15 array 'a' lower bound in a\[i0\]: FAILURE$
+^EXIT=10$
+^SIGNAL=0$
+^VERIFICATION FAILED$
+--
+--
+This exercises the unbounded-array (U_ALL) Ackermann constraint refinement
+selected by --arrays-uf-always, which issues many incremental SAT calls,
+together with a simplifying SAT back-end and the default array-bounds checks on
+the variable-length array `a`. The verdict (array_bounds.1, lower bound of
+a[i0]) is produced regardless of how the simplifier is configured.
+
+The fix this accompanies addresses a solver hang rather than a wrong verdict:
+when MiniSat's simplifier re-runs variable elimination before every incremental
+solve, a later solve can blow up. That hang was observed in conjunction with
+the reduced Ackermann-constraint encoding for weak array equivalence and a
+32-bit verification target -- note it is the 32-bit *target* (--32) that
+matters, not a 32-bit build of cbmc: a 64-bit build with --32 reproduces it
+too. With the array encoding on its own this particular input still completes,
+so this test mainly pins the verdict and exercises the limited-simplification
+code path; the direct, self-contained guard for the fix is the unit test for
+set_limit_incremental_simplification(). test.pl applies no per-test timeout, so
+a reintroduced hang would surface as the (32-bit) CI job timing out rather than
+as a per-test failure.

--- a/src/goto-checker/solver_factory.cpp
+++ b/src/goto-checker/solver_factory.cpp
@@ -364,7 +364,18 @@ std::unique_ptr<solver_factoryt::solvert> solver_factoryt::get_default()
   if(options.get_option("arrays-uf") == "never")
     bv_pointers->unbounded_array = bv_pointerst::unbounded_arrayt::U_NONE;
   else if(options.get_option("arrays-uf") == "always")
+  {
     bv_pointers->unbounded_array = bv_pointerst::unbounded_arrayt::U_ALL;
+    // Ackermann-style (U_ALL) array handling refines lazily, issuing many
+    // incremental SAT calls. MiniSat's simplifying back-end re-runs variable
+    // elimination before every solve, and outside incremental symex the
+    // literals are not frozen, so it may eliminate and re-introduce variables
+    // on each call. On some array-heavy formulas this churn makes a later
+    // incremental solve blow up (observed as a hang in 32-bit configurations);
+    // ask the back-end to simplify only on the first solve. This is a no-op for
+    // back-ends that do not simplify incrementally.
+    sat_solver->set_limit_incremental_simplification();
+  }
 
   set_decision_procedure_time_limit(*bv_pointers);
 

--- a/src/solvers/prop/prop.h
+++ b/src/solvers/prop/prop.h
@@ -116,6 +116,13 @@ public:
   // an incremental solver may remove any variables that aren't frozen
   virtual void set_frozen(literalt) { }
 
+  // An incremental simplifying solver may limit simplification to the first
+  // solve call: re-running variable elimination before every incremental solve
+  // can otherwise make a later solve blow up. No-op unless overridden.
+  virtual void set_limit_incremental_simplification()
+  {
+  }
+
   // Resource limits:
   virtual void set_time_limit_seconds(uint32_t)
   {

--- a/src/solvers/sat/satcheck_minisat2.cpp
+++ b/src/solvers/sat/satcheck_minisat2.cpp
@@ -13,13 +13,14 @@ Author: Daniel Kroening, kroening@kroening.com
 #  include <unistd.h>
 #endif
 
-#include <limits>
-
 #include <util/invariant.h>
 #include <util/threeval.h>
 
 #include <minisat/core/Solver.h>
 #include <minisat/simp/SimpSolver.h>
+
+#include <limits>
+#include <type_traits>
 
 #ifndef l_False
 #  define l_False Minisat::l_False
@@ -240,6 +241,15 @@ propt::resultt satcheck_minisat2_baset<T>::do_prop_solve(const bvt &assumptions)
 
     using Minisat::lbool;
 
+    // For the simplifying solver, decide whether to run the simplifier on this
+    // solve. When simplification is limited, it runs only on the first solve:
+    // MiniSat's variable elimination, re-run before every incremental call,
+    // can otherwise make a later solve blow up for the CDCL search (it hurts
+    // both SAT and UNSAT search; in practice it was observed as a hang).
+    [[maybe_unused]] bool do_simp = true;
+    if constexpr(std::is_same_v<T, Minisat::SimpSolver>)
+      do_simp = simplify_on_next_solve();
+
 #ifndef _WIN32
 
     void (*old_handler)(int) = SIG_ERR;
@@ -254,7 +264,15 @@ propt::resultt satcheck_minisat2_baset<T>::do_prop_solve(const bvt &assumptions)
         alarm(time_limit_seconds);
     }
 
-    lbool solver_result = solver->solveLimited(solver_assumptions);
+    lbool solver_result;
+    if constexpr(std::is_same_v<T, Minisat::SimpSolver>)
+    {
+      solver_result = solver->solveLimited(solver_assumptions, do_simp, false);
+    }
+    else
+    {
+      solver_result = solver->solveLimited(solver_assumptions);
+    }
 
     if(old_handler != SIG_ERR)
     {
@@ -271,7 +289,16 @@ propt::resultt satcheck_minisat2_baset<T>::do_prop_solve(const bvt &assumptions)
                     << messaget::eom;
     }
 
-    lbool solver_result = solver->solve(solver_assumptions) ? l_True : l_False;
+    lbool solver_result;
+    if constexpr(std::is_same_v<T, Minisat::SimpSolver>)
+    {
+      solver_result =
+        solver->solve(solver_assumptions, do_simp) ? l_True : l_False;
+    }
+    else
+    {
+      solver_result = solver->solve(solver_assumptions) ? l_True : l_False;
+    }
 
 #endif
 

--- a/src/solvers/sat/satcheck_minisat2.h
+++ b/src/solvers/sat/satcheck_minisat2.h
@@ -70,6 +70,16 @@ public:
 protected:
   resultt do_prop_solve(const bvt &) override;
 
+  /// Whether to run the solver's simplifier on the next solve call.
+  /// Non-simplifying solvers always "simplify" (a no-op for them); the
+  /// simplifying subclass overrides this to honour
+  /// set_limit_incremental_simplification(). Has the side effect of recording
+  /// that a solve has happened.
+  virtual bool simplify_on_next_solve()
+  {
+    return true;
+  }
+
   std::unique_ptr<T> solver;
   uint32_t time_limit_seconds;
 
@@ -92,6 +102,30 @@ public:
   std::string solver_text() const override final;
   void set_frozen(literalt a) override final;
   bool is_eliminated(literalt a) const;
+
+  /// When set, the MiniSat simplifier only runs on the first solve call. This
+  /// prevents variable elimination between incremental calls from degrading
+  /// CDCL performance on certain array-heavy problems.
+  void set_limit_incremental_simplification() override final
+  {
+    limit_incremental_simplification = true;
+  }
+
+protected:
+  bool simplify_on_next_solve() override final
+  {
+    // Simplify (run variable elimination) only until the first solve has
+    // happened: once we are solving incrementally, re-running elimination
+    // before each solve is what degrades performance (see the class comment
+    // and set_limit_incremental_simplification()).
+    const bool do_simp =
+      !limit_incremental_simplification || !solver_was_called;
+    solver_was_called = true;
+    return do_simp;
+  }
+
+  bool solver_was_called = false;
+  bool limit_incremental_simplification = false;
 };
 
 #endif // CPROVER_SOLVERS_SAT_SATCHECK_MINISAT2_H

--- a/unit/solvers/sat/satcheck_minisat2.cpp
+++ b/unit/solvers/sat/satcheck_minisat2.cpp
@@ -82,6 +82,45 @@ SCENARIO("satcheck_minisat2", "[core][solvers][sat][satcheck_minisat2]")
         satcheck.prop_solve(assumptions) == propt::resultt::P_SATISFIABLE);
     }
   }
+
+  GIVEN("A simplifying solver with incremental simplification limited")
+  {
+    satcheck_minisat_simplifiert satcheck(message_handler);
+    satcheck.set_limit_incremental_simplification();
+
+    literalt a = satcheck.new_variable();
+    // freeze so the simplifier does not eliminate the variable we assume on
+    satcheck.set_frozen(a);
+    satcheck.l_set_to_true(a);
+
+    THEN("incremental solves remain correct after the first (simplifying) call")
+    {
+      // first solve runs the simplifier; subsequent solves run with the
+      // simplifier disabled (do_simp == false)
+      REQUIRE(satcheck.prop_solve() == propt::resultt::P_SATISFIABLE);
+      bvt assumptions;
+      assumptions.push_back(!a);
+      REQUIRE(
+        satcheck.prop_solve(assumptions) == propt::resultt::P_UNSATISFIABLE);
+      REQUIRE(satcheck.prop_solve() == propt::resultt::P_SATISFIABLE);
+    }
+  }
+
+  GIVEN("A non-simplifying solver")
+  {
+    satcheck_minisat_no_simplifiert satcheck(message_handler);
+
+    THEN("set_limit_incremental_simplification is a no-op and solving works")
+    {
+      // the propt default is a no-op for non-simplifying back-ends
+      propt &prop = satcheck;
+      prop.set_limit_incremental_simplification();
+
+      literalt f = satcheck.new_variable();
+      satcheck.l_set_to_true(f);
+      REQUIRE(satcheck.prop_solve() == propt::resultt::P_SATISFIABLE);
+    }
+  }
 }
 
 #endif


### PR DESCRIPTION
MiniSat's SimpSolver runs variable elimination (eliminate()) before every solveLimited/solve call by default. When used incrementally in the all-properties verification loop, this repeated elimination can degrade the solver's ability to prove UNSAT, causing the CDCL search to hang indefinitely.

Fix by passing do_simp=false on all calls after the first. The first call still benefits from the full simplification pass, but subsequent incremental calls skip it, preventing the problematic variable elimination between iterations.

This fixes a hang when running:
  cbmc --arrays-uf-always --unwind 1 --32 Array_UF23/main.c

See the individual commit messages for more details.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
