### PR TITLE
Formalize solver state machine in propt and decision_proceduret

### DIFF
--- a/src/solvers/decision_procedure.cpp
+++ b/src/solvers/decision_procedure.cpp
@@ -19,27 +19,50 @@ decision_proceduret::~decision_proceduret()
 
 decision_proceduret::resultt decision_proceduret::operator()()
 {
-  auto result = dec_solve(nil_exprt());
-  latest_result = result;
-  return result;
+  // dec_solve() may throw (e.g., on solver interruption). Ensure
+  // latest_result is set to D_ERROR in that case so that get_status() does
+  // not report a stale satisfiability result.
+  try
+  {
+    auto result = dec_solve(nil_exprt());
+    latest_result = result;
+    return result;
+  }
+  catch(...)
+  {
+    latest_result = resultt::D_ERROR;
+    throw;
+  }
 }
 
 decision_proceduret::resultt
 decision_proceduret::operator()(const exprt &assumption)
 {
-  auto result = dec_solve(assumption);
-  latest_result = result;
-  return result;
+  try
+  {
+    auto result = dec_solve(assumption);
+    latest_result = result;
+    return result;
+  }
+  catch(...)
+  {
+    latest_result = resultt::D_ERROR;
+    throw;
+  }
 }
 
 void decision_proceduret::set_to_true(const exprt &expr)
 {
-  latest_result = resultt::D_ERROR;
   set_to(expr, true);
 }
 
 void decision_proceduret::set_to_false(const exprt &expr)
 {
-  latest_result = resultt::D_ERROR;
   set_to(expr, false);
+}
+
+exprt decision_proceduret::handle(const exprt &expr)
+{
+  latest_result = resultt::D_ERROR;
+  return do_handle(expr);
 }

--- a/src/solvers/decision_procedure.cpp
+++ b/src/solvers/decision_procedure.cpp
@@ -19,21 +19,27 @@ decision_proceduret::~decision_proceduret()
 
 decision_proceduret::resultt decision_proceduret::operator()()
 {
-  return dec_solve(nil_exprt());
+  auto result = dec_solve(nil_exprt());
+  latest_result = result;
+  return result;
 }
 
 decision_proceduret::resultt
 decision_proceduret::operator()(const exprt &assumption)
 {
-  return dec_solve(assumption);
+  auto result = dec_solve(assumption);
+  latest_result = result;
+  return result;
 }
 
 void decision_proceduret::set_to_true(const exprt &expr)
 {
+  latest_result = resultt::D_ERROR;
   set_to(expr, true);
 }
 
 void decision_proceduret::set_to_false(const exprt &expr)
 {
+  latest_result = resultt::D_ERROR;
   set_to(expr, false);
 }

--- a/src/solvers/decision_procedure.h
+++ b/src/solvers/decision_procedure.h
@@ -33,12 +33,26 @@ class exprt;
 /// Reading the satisfying assignment via \ref get is only valid in the
 /// D_SATISFIABLE state. Adding new constraints (\ref set_to, \ref handle)
 /// resets the status to D_ERROR.
+///
+/// Note that D_ERROR is overloaded: it denotes both "no solve has been
+/// performed yet" (the initial/post-mutation state) and "the last solve
+/// reported a genuine error". Consequently the only fully actionable answer
+/// from \ref get_status() is D_SATISFIABLE. Distinguishing the two would
+/// require an explicit UNKNOWN value mirroring \ref propt::statust (or
+/// std::optional<resultt>); this is left as a follow-up.
 class decision_proceduret
 {
 public:
   /// For a Boolean expression \p expr, add the constraint 'expr' if \p value
-  /// is `true`, otherwise add 'not expr'
-  virtual void set_to(const exprt &, bool value) = 0;
+  /// is `true`, otherwise add 'not expr'.
+  /// This is a non-virtual entry point that resets the status to D_ERROR
+  /// before dispatching to \ref do_set_to, so that the state-machine
+  /// invariant holds for every caller, including direct callers of \ref set_to.
+  void set_to(const exprt &expr, bool value)
+  {
+    latest_result = resultt::D_ERROR;
+    do_set_to(expr, value);
+  }
 
   /// For a Boolean expression \p expr, add the constraint 'expr'
   void set_to_true(const exprt &);
@@ -53,7 +67,9 @@ public:
   /// \ref set_to.
   /// The returned expression may be the expression itself or a more compact
   /// but solver-specific representation.
-  virtual exprt handle(const exprt &) = 0;
+  /// This is a non-virtual entry point that resets the status to D_ERROR
+  /// before dispatching to \ref do_handle.
+  exprt handle(const exprt &expr);
 
   /// Result of running the decision procedure
   enum class resultt
@@ -97,9 +113,21 @@ public:
   }
 
 protected:
+  /// Implementation of \ref set_to. Subclasses add the constraint here; the
+  /// public \ref set_to wrapper has already reset the status to D_ERROR.
+  virtual void do_set_to(const exprt &expr, bool value) = 0;
+
+  /// Implementation of \ref handle. Subclasses create the handle here; the
+  /// public \ref handle wrapper has already reset the status to D_ERROR.
+  virtual exprt do_handle(const exprt &expr) = 0;
+
   /// Implementation of the decision procedure.
   virtual resultt dec_solve(const exprt &assumption) = 0;
 
+  /// The result of the most recent \ref operator()() call, or D_ERROR if no
+  /// solve has been performed yet or new constraints have since been added.
+  /// D_ERROR therefore conflates "unsolved" and "error"; see the note in the
+  /// class-level documentation.
   resultt latest_result = resultt::D_ERROR;
 };
 

--- a/src/solvers/decision_procedure.h
+++ b/src/solvers/decision_procedure.h
@@ -18,6 +18,21 @@ Author: Daniel Kroening, kroening@kroening.com
 class exprt;
 
 /// An interface for a decision procedure for satisfiability problems.
+///
+/// A decision procedure follows a state machine:
+///
+///   D_ERROR ──operator()──► D_SATISFIABLE ──set_to()──► D_ERROR
+///     ▲                        │
+///     │                        └──get() valid
+///     │
+///   D_ERROR ──operator()──► D_UNSATISFIABLE ──set_to()──► D_ERROR
+///
+/// After construction, the procedure's status (\ref latest_result) is
+/// initialised to D_ERROR, representing "not yet solved". Calling
+/// \ref operator()() transitions to D_SATISFIABLE, D_UNSATISFIABLE, or D_ERROR.
+/// Reading the satisfying assignment via \ref get is only valid in the
+/// D_SATISFIABLE state. Adding new constraints (\ref set_to, \ref handle)
+/// resets the status to D_ERROR.
 class decision_proceduret
 {
 public:
@@ -59,7 +74,8 @@ public:
 
   /// Return \p expr with variables replaced by values from satisfying
   /// assignment if available.
-  /// Return `nil` if not available
+  /// Return `nil` if not available.
+  /// \pre The last call to \ref operator()() returned D_SATISFIABLE.
   virtual exprt get(const exprt &) const = 0;
 
   /// Print satisfying assignment to \p out
@@ -73,9 +89,18 @@ public:
 
   virtual ~decision_proceduret();
 
+  /// Return the result of the last call to \ref operator()().
+  /// \return The most recent result, or D_ERROR if not yet called.
+  resultt get_status() const
+  {
+    return latest_result;
+  }
+
 protected:
   /// Implementation of the decision procedure.
   virtual resultt dec_solve(const exprt &assumption) = 0;
+
+  resultt latest_result = resultt::D_ERROR;
 };
 
 /// Add Boolean constraint \p src to decision procedure \p dest

--- a/src/solvers/flattening/boolbv.cpp
+++ b/src/solvers/flattening/boolbv.cpp
@@ -81,10 +81,10 @@ const bvt &boolbvt::convert_bv(
   return cache_entry;
 }
 
-exprt boolbvt::handle(const exprt &expr)
+exprt boolbvt::do_handle(const exprt &expr)
 {
   if(expr.type().id() == ID_bool)
-    return prop_conv_solvert::handle(expr);
+    return prop_conv_solvert::do_handle(expr);
   auto bv = convert_bv(expr);
   set_frozen(bv); // for incremental usage
   return literal_vector_exprt{bv, expr.type()};
@@ -529,14 +529,14 @@ bool boolbvt::boolbv_set_equality_to_true(const equal_exprt &expr)
   return true;
 }
 
-void boolbvt::set_to(const exprt &expr, bool value)
+void boolbvt::do_set_to(const exprt &expr, bool value)
 {
   PRECONDITION(expr.is_boolean());
 
   const auto equal_expr = expr_try_dynamic_cast<equal_exprt>(expr);
   if(value && equal_expr && !boolbv_set_equality_to_true(*equal_expr))
     return;
-  SUB::set_to(expr, value);
+  SUB::do_set_to(expr, value);
 }
 
 bool boolbvt::is_unbounded_array(const typet &type) const

--- a/src/solvers/flattening/boolbv.h
+++ b/src/solvers/flattening/boolbv.h
@@ -71,9 +71,9 @@ public:
 
   // overloading
   exprt get(const exprt &expr) const override;
-  void set_to(const exprt &expr, bool value) override;
+  void do_set_to(const exprt &expr, bool value) override;
   void print_assignment(std::ostream &out) const override;
-  exprt handle(const exprt &) override;
+  exprt do_handle(const exprt &) override;
 
   void clear_cache() override
   {

--- a/src/solvers/prop/prop.cpp
+++ b/src/solvers/prop/prop.cpp
@@ -36,17 +36,54 @@ bvt propt::new_variables(std::size_t width)
   return result;
 }
 
+static propt::statust status_from_result(propt::resultt result)
+{
+  switch(result)
+  {
+  case propt::resultt::P_SATISFIABLE:
+    return propt::statust::SAT;
+  case propt::resultt::P_UNSATISFIABLE:
+    return propt::statust::UNSAT;
+  case propt::resultt::P_ERROR:
+    return propt::statust::ERROR;
+  }
+  UNREACHABLE;
+}
+
 propt::resultt propt::prop_solve()
 {
   static const bvt empty_assumptions;
   ++number_of_solver_calls;
-  return do_prop_solve(empty_assumptions);
+  // Some do_prop_solve() implementations may throw (e.g., on solver
+  // interruption). Ensure solver_state is set to ERROR in that case so that
+  // l_get()/is_in_conflict() preconditions will fail.
+  try
+  {
+    auto result = do_prop_solve(empty_assumptions);
+    solver_state = status_from_result(result);
+    return result;
+  }
+  catch(...)
+  {
+    solver_state = statust::ERROR;
+    throw;
+  }
 }
 
 propt::resultt propt::prop_solve(const bvt &assumptions)
 {
   ++number_of_solver_calls;
-  return do_prop_solve(assumptions);
+  try
+  {
+    auto result = do_prop_solve(assumptions);
+    solver_state = status_from_result(result);
+    return result;
+  }
+  catch(...)
+  {
+    solver_state = statust::ERROR;
+    throw;
+  }
 }
 
 std::size_t propt::get_number_of_solver_calls() const

--- a/src/solvers/prop/prop.h
+++ b/src/solvers/prop/prop.h
@@ -19,7 +19,22 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <cstdint>
 
-/// \brief TO_BE_DOCUMENTED
+/// \brief Abstract interface for propositional logic solvers.
+///
+/// Provides the common API for constructing propositional formulas and solving
+/// them. Formulas are built from \ref literalt variables obtained via
+/// \ref new_variable, combined using Boolean operators (\ref land, \ref lor,
+/// etc.), and constrained via clauses (\ref lcnf) or unit constraints
+/// (\ref l_set_to). Calling \ref prop_solve checks satisfiability; the
+/// satisfying assignment can then be read via \ref l_get, or, in the
+/// unsatisfiable case, the conflict queried via \ref is_in_conflict.
+///
+/// Concrete implementations include SAT solvers (MiniSat, CaDiCaL, etc.)
+/// and structural representations (DIMACS file output, AIG).
+///
+/// The solver supports incremental use: after solving, new constraints or
+/// variables may be added and the solver invoked again. The state machine
+/// below describes which operations are valid in each state.
 ///
 /// A propositional solver follows a state machine:
 ///

--- a/src/solvers/prop/prop.h
+++ b/src/solvers/prop/prop.h
@@ -19,8 +19,24 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <cstdint>
 
-/*! \brief TO_BE_DOCUMENTED
-*/
+/// \brief TO_BE_DOCUMENTED
+///
+/// A propositional solver follows a state machine:
+///
+///   UNKNOWN ──prop_solve()──► SAT ──lcnf()/new_variable()──► UNKNOWN
+///      ▲                      │
+///      │                      └──l_get() valid
+///      │
+///   UNKNOWN ──prop_solve()──► UNSAT ──lcnf()/new_variable()──► UNKNOWN
+///                              │
+///                              └──is_in_conflict() valid
+///
+/// After construction, the solver is in the UNKNOWN state. Calling
+/// \ref prop_solve transitions to SAT, UNSAT, or ERROR. Reading the
+/// satisfying assignment via \ref l_get is only valid in the SAT state.
+/// Querying \ref is_in_conflict is only valid in the UNSAT state.
+/// Adding new constraints (\ref lcnf, \ref l_set_to) or variables
+/// (\ref new_variable) transitions back to UNKNOWN.
 class propt
 {
 public:
@@ -46,6 +62,7 @@ public:
 
   virtual void l_set_to(literalt a, bool value)
   {
+    clear_status();
     set_equal(a, const_literal(value));
   }
 
@@ -56,10 +73,17 @@ public:
 
   // constraints
   void lcnf(literalt l0, literalt l1)
-  { lcnf_bv.resize(2); lcnf_bv[0]=l0; lcnf_bv[1]=l1; lcnf(lcnf_bv); }
+  {
+    clear_status();
+    lcnf_bv.resize(2);
+    lcnf_bv[0] = l0;
+    lcnf_bv[1] = l1;
+    lcnf(lcnf_bv);
+  }
 
   void lcnf(literalt l0, literalt l1, literalt l2)
   {
+    clear_status();
     lcnf_bv.resize(3);
     lcnf_bv[0]=l0;
     lcnf_bv[1]=l1;
@@ -69,6 +93,7 @@ public:
 
   void lcnf(literalt l0, literalt l1, literalt l2, literalt l3)
   {
+    clear_status();
     lcnf_bv.resize(4);
     lcnf_bv[0]=l0;
     lcnf_bv[1]=l1;
@@ -102,6 +127,21 @@ public:
   resultt prop_solve();
   resultt prop_solve(const bvt &assumptions);
 
+  /// Solver state: tracks whether the model or conflict can be queried.
+  enum class statust
+  {
+    UNKNOWN,
+    SAT,
+    UNSAT,
+    ERROR
+  };
+
+  /// Return the current solver state.
+  statust get_status() const
+  {
+    return solver_state;
+  }
+
   // satisfying assignment
   virtual tvt l_get(literalt a) const=0;
   virtual void set_assignment(literalt a, bool value) = 0;
@@ -128,11 +168,21 @@ protected:
   // solve under the given assumption
   virtual resultt do_prop_solve(const bvt &assumptions) = 0;
 
+  /// Transition to UNKNOWN state when the solver is mutated.
+  /// The ERROR state is intentionally sticky: once the solver has encountered
+  /// an error, adding new constraints does not clear it.
+  void clear_status()
+  {
+    if(solver_state == statust::SAT || solver_state == statust::UNSAT)
+      solver_state = statust::UNKNOWN;
+  }
+
   // to avoid a temporary for lcnf(...)
   bvt lcnf_bv;
 
   messaget log;
   std::size_t number_of_solver_calls = 0;
+  statust solver_state = statust::UNKNOWN;
 };
 
 #endif // CPROVER_SOLVERS_PROP_PROP_H

--- a/src/solvers/prop/prop.h
+++ b/src/solvers/prop/prop.h
@@ -43,15 +43,19 @@ Author: Daniel Kroening, kroening@kroening.com
 ///      │                      └──l_get() valid
 ///      │
 ///   UNKNOWN ──prop_solve()──► UNSAT ──lcnf()/new_variable()──► UNKNOWN
-///                              │
-///                              └──is_in_conflict() valid
+///      │                       │
+///      │                       └──is_in_conflict() valid
+///      │
+///   UNKNOWN ──prop_solve()──► ERROR (sticky)
 ///
 /// After construction, the solver is in the UNKNOWN state. Calling
 /// \ref prop_solve transitions to SAT, UNSAT, or ERROR. Reading the
 /// satisfying assignment via \ref l_get is only valid in the SAT state.
 /// Querying \ref is_in_conflict is only valid in the UNSAT state.
 /// Adding new constraints (\ref lcnf, \ref l_set_to) or variables
-/// (\ref new_variable) transitions back to UNKNOWN.
+/// (\ref new_variable) transitions SAT/UNSAT back to UNKNOWN. The ERROR state
+/// is sticky: once \ref prop_solve has reported an error (or thrown), adding
+/// constraints or variables does not clear it (see \ref clear_status()).
 class propt
 {
 public:
@@ -89,7 +93,6 @@ public:
   // constraints
   void lcnf(literalt l0, literalt l1)
   {
-    clear_status();
     lcnf_bv.resize(2);
     lcnf_bv[0] = l0;
     lcnf_bv[1] = l1;
@@ -98,7 +101,6 @@ public:
 
   void lcnf(literalt l0, literalt l1, literalt l2)
   {
-    clear_status();
     lcnf_bv.resize(3);
     lcnf_bv[0]=l0;
     lcnf_bv[1]=l1;
@@ -108,7 +110,6 @@ public:
 
   void lcnf(literalt l0, literalt l1, literalt l2, literalt l3)
   {
-    clear_status();
     lcnf_bv.resize(4);
     lcnf_bv[0]=l0;
     lcnf_bv[1]=l1;
@@ -117,7 +118,16 @@ public:
     lcnf(lcnf_bv);
   }
 
-  virtual void lcnf(const bvt &bv)=0;
+  /// Add the clause \p bv to the formula.
+  /// This is a non-virtual entry point that calls \ref clear_status() once
+  /// and dispatches to the backend-specific \ref do_lcnf, ensuring the
+  /// state-machine invariant is enforced for every backend without per-backend
+  /// boilerplate.
+  void lcnf(const bvt &bv)
+  {
+    clear_status();
+    do_lcnf(bv);
+  }
   virtual bool has_set_to() const { return true; }
 
   // Some solvers (notably aig) prefer encodings that avoid raw CNF
@@ -143,6 +153,12 @@ public:
   resultt prop_solve(const bvt &assumptions);
 
   /// Solver state: tracks whether the model or conflict can be queried.
+  // TODO: resultt (P_SATISFIABLE/P_UNSATISFIABLE/P_ERROR) and statust
+  // (UNKNOWN/SAT/UNSAT/ERROR) overlap heavily; statust additionally
+  // distinguishes the "not yet solved" UNKNOWN state. These should be unified
+  // as a follow-up (e.g. by using statust everywhere, or std::optional<resultt>
+  // for the state), which would also remove the status_from_result() helper in
+  // prop.cpp.
   enum class statust
   {
     UNKNOWN,
@@ -182,6 +198,11 @@ public:
 protected:
   // solve under the given assumption
   virtual resultt do_prop_solve(const bvt &assumptions) = 0;
+
+  /// Backend-specific clause addition. Called by the non-virtual \ref lcnf
+  /// entry point, which has already invalidated any cached solver state via
+  /// \ref clear_status().
+  virtual void do_lcnf(const bvt &bv) = 0;
 
   /// Transition to UNKNOWN state when the solver is mutated.
   /// The ERROR state is intentionally sticky: once the solver has encountered

--- a/src/solvers/prop/prop_conv_solver.cpp
+++ b/src/solvers/prop/prop_conv_solver.cpp
@@ -35,7 +35,7 @@ void prop_conv_solvert::set_all_frozen()
   freeze_all = true;
 }
 
-exprt prop_conv_solvert::handle(const exprt &expr)
+exprt prop_conv_solvert::do_handle(const exprt &expr)
 {
   // We can only improve Booleans.
   if(!expr.is_boolean())
@@ -532,7 +532,7 @@ std::size_t prop_conv_solvert::get_number_of_solver_calls() const
 
 const char *prop_conv_solvert::context_prefix = "prop_conv::context$";
 
-void prop_conv_solvert::set_to(const exprt &expr, bool value)
+void prop_conv_solvert::do_set_to(const exprt &expr, bool value)
 {
   if(assumption_stack.empty())
   {

--- a/src/solvers/prop/prop_conv_solver.h
+++ b/src/solvers/prop/prop_conv_solver.h
@@ -50,7 +50,7 @@ public:
     return prop.l_get(a);
   }
 
-  exprt handle(const exprt &expr) override;
+  exprt do_handle(const exprt &expr) override;
 
   void set_frozen(literalt);
   void set_frozen(const bvt &);
@@ -62,7 +62,7 @@ public:
   /// For a Boolean expression \p expr, add the constraint
   /// 'current_context => expr' if \p value is `true`,
   /// otherwise add 'current_context => not expr'
-  void set_to(const exprt &expr, bool value) override;
+  void do_set_to(const exprt &expr, bool value) override;
 
   void push() override;
 

--- a/src/solvers/qbf/qbf_bdd_core.cpp
+++ b/src/solvers/qbf/qbf_bdd_core.cpp
@@ -171,7 +171,7 @@ literalt qbf_bdd_coret::new_variable()
   return res;
 }
 
-void qbf_bdd_coret::lcnf(const bvt &bv)
+void qbf_bdd_coret::do_lcnf(const bvt &bv)
 {
   bvt new_bv;
 

--- a/src/solvers/qbf/qbf_bdd_core.h
+++ b/src/solvers/qbf/qbf_bdd_core.h
@@ -54,7 +54,7 @@ public:
 
   literalt new_variable() override;
 
-  void lcnf(const bvt &bv) override;
+  void do_lcnf(const bvt &bv) override;
   literalt lor(literalt a, literalt b) override;
   literalt lor(const bvt &bv) override;
 

--- a/src/solvers/qbf/qbf_squolem.cpp
+++ b/src/solvers/qbf/qbf_squolem.cpp
@@ -68,7 +68,7 @@ propt::resultt qbf_squolemt::prop_solve()
   return P_ERROR;
 }
 
-void qbf_squolemt::lcnf(const bvt &bv)
+void qbf_squolemt::do_lcnf(const bvt &bv)
 {
   if(early_decision)
     return; // we don't need no more...

--- a/src/solvers/qbf/qbf_squolem.h
+++ b/src/solvers/qbf/qbf_squolem.h
@@ -30,7 +30,7 @@ public:
   resultt prop_solve() override;
   tvt l_get(literalt a) const override;
 
-  void lcnf(const bvt &bv) override;
+  void do_lcnf(const bvt &bv) override;
   void add_quantifier(const quantifiert &quantifier) override;
   void set_quantifier(const quantifiert::typet type, const literalt l) override;
   void set_no_variables(size_t no) override;

--- a/src/solvers/qbf/qbf_squolem_core.cpp
+++ b/src/solvers/qbf/qbf_squolem_core.cpp
@@ -123,7 +123,7 @@ qbf_squolem_coret::modeltypet qbf_squolem_coret::m_get(literalt a) const
     return M_DONTCARE;
 }
 
-void qbf_squolem_coret::lcnf(const bvt &bv)
+void qbf_squolem_coret::do_lcnf(const bvt &bv)
 {
   if(early_decision)
     return; // we don't need no more...

--- a/src/solvers/qbf/qbf_squolem_core.h
+++ b/src/solvers/qbf/qbf_squolem_core.h
@@ -34,7 +34,7 @@ public:
 
   void set_debug_filename(const std::string &str);
 
-  void lcnf(const bvt &bv) override;
+  void do_lcnf(const bvt &bv) override;
   void add_quantifier(const quantifiert &quantifier) override;
   void set_quantifier(const quantifiert::typet type, const literalt l) override;
   void set_no_variables(size_t no) override;

--- a/src/solvers/sat/cnf.cpp
+++ b/src/solvers/sat/cnf.cpp
@@ -384,6 +384,7 @@ literalt cnft::lselect(literalt a, literalt b, literalt c)
 /// \return New variable as literal
 literalt cnft::new_variable()
 {
+  clear_status();
   literalt l(_no_variables, false);
 
   set_no_variables(_no_variables+1);
@@ -395,6 +396,7 @@ literalt cnft::new_variable()
 /// \return Vector of new variables.
 bvt cnft::new_variables(std::size_t width)
 {
+  clear_status();
   bvt result;
   result.reserve(width);
 

--- a/src/solvers/sat/cnf.h
+++ b/src/solvers/sat/cnf.h
@@ -85,6 +85,8 @@ public:
 protected:
   // Legacy status tracking in do_prop_solve implementations.
   // The canonical state is now propt::solver_state, updated by prop_solve().
+  // TODO: unify this enum with propt::statust and remove it; it is retained
+  // only because the do_prop_solve implementations still set it.
   enum class statust { INIT, SAT, UNSAT, ERROR };
   statust status;
   size_t clause_counter;

--- a/src/solvers/sat/cnf.h
+++ b/src/solvers/sat/cnf.h
@@ -83,6 +83,8 @@ public:
   }
 
 protected:
+  // Legacy status tracking in do_prop_solve implementations.
+  // The canonical state is now propt::solver_state, updated by prop_solve().
   enum class statust { INIT, SAT, UNSAT, ERROR };
   statust status;
   size_t clause_counter;

--- a/src/solvers/sat/cnf_clause_list.cpp
+++ b/src/solvers/sat/cnf_clause_list.cpp
@@ -13,9 +13,8 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <ostream>
 
-void cnf_clause_listt::lcnf(const bvt &bv)
+void cnf_clause_listt::do_lcnf(const bvt &bv)
 {
-  clear_status();
   bvt new_bv;
 
   if(process_clause(bv, new_bv))

--- a/src/solvers/sat/cnf_clause_list.cpp
+++ b/src/solvers/sat/cnf_clause_list.cpp
@@ -15,6 +15,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 void cnf_clause_listt::lcnf(const bvt &bv)
 {
+  clear_status();
   bvt new_bv;
 
   if(process_clause(bv, new_bv))

--- a/src/solvers/sat/cnf_clause_list.h
+++ b/src/solvers/sat/cnf_clause_list.h
@@ -29,7 +29,7 @@ public:
   }
   virtual ~cnf_clause_listt() { }
 
-  void lcnf(const bvt &bv) override;
+  void do_lcnf(const bvt &bv) override;
 
   std::string solver_text() const override
   { return "CNF clause list"; }

--- a/src/solvers/sat/dimacs_cnf.cpp
+++ b/src/solvers/sat/dimacs_cnf.cpp
@@ -97,5 +97,6 @@ void dimacs_cnft::write_clauses(std::ostream &out) const
 
 void dimacs_cnf_dumpt::lcnf(const bvt &bv)
 {
+  clear_status();
   dimacs_cnft::write_dimacs_clause(bv, out, true);
 }

--- a/src/solvers/sat/dimacs_cnf.cpp
+++ b/src/solvers/sat/dimacs_cnf.cpp
@@ -95,8 +95,7 @@ void dimacs_cnft::write_clauses(std::ostream &out) const
   out << output_block.str();
 }
 
-void dimacs_cnf_dumpt::lcnf(const bvt &bv)
+void dimacs_cnf_dumpt::do_lcnf(const bvt &bv)
 {
-  clear_status();
   dimacs_cnft::write_dimacs_clause(bv, out, true);
 }

--- a/src/solvers/sat/dimacs_cnf.h
+++ b/src/solvers/sat/dimacs_cnf.h
@@ -53,7 +53,7 @@ public:
     return "DIMACS CNF Dumper";
   }
 
-  void lcnf(const bvt &bv) override;
+  void do_lcnf(const bvt &bv) override;
 
   tvt l_get(literalt) const override
   {

--- a/src/solvers/sat/satcheck_booleforce.cpp
+++ b/src/solvers/sat/satcheck_booleforce.cpp
@@ -63,9 +63,8 @@ std::string satcheck_booleforce_baset::solver_text() const
   return std::string("Booleforce version ")+booleforce_version();
 }
 
-void satcheck_booleforce_baset::lcnf(const bvt &bv)
+void satcheck_booleforce_baset::do_lcnf(const bvt &bv)
 {
-  clear_status();
   bvt tmp;
 
   if(process_clause(bv, tmp))

--- a/src/solvers/sat/satcheck_booleforce.cpp
+++ b/src/solvers/sat/satcheck_booleforce.cpp
@@ -65,6 +65,7 @@ std::string satcheck_booleforce_baset::solver_text() const
 
 void satcheck_booleforce_baset::lcnf(const bvt &bv)
 {
+  clear_status();
   bvt tmp;
 
   if(process_clause(bv, tmp))

--- a/src/solvers/sat/satcheck_booleforce.h
+++ b/src/solvers/sat/satcheck_booleforce.h
@@ -23,7 +23,7 @@ public:
   std::string solver_text() const override;
   tvt l_get(literalt a) const override;
 
-  void lcnf(const bvt &bv) override;
+  void do_lcnf(const bvt &bv) override;
 
 protected:
   resultt do_prop_solve(const bvt &assumptions) override;

--- a/src/solvers/sat/satcheck_cadical.cpp
+++ b/src/solvers/sat/satcheck_cadical.cpp
@@ -19,9 +19,12 @@ Author: Michael Tautschnig
 
 tvt satcheck_cadical_baset::l_get(literalt a) const
 {
-  PRECONDITION(solver_state == propt::statust::SAT);
+  // Constant literals have a state-independent value; answer them before
+  // checking the solver state so that constant-folding callers are not
+  // subject to the SAT-state precondition.
   if(a.is_constant())
     return tvt(a.sign());
+  PRECONDITION(solver_state == propt::statust::SAT);
 
   tvt result;
 
@@ -44,10 +47,8 @@ std::string satcheck_cadical_baset::solver_text() const
   return std::string("CaDiCaL ") + solver->version();
 }
 
-void satcheck_cadical_baset::lcnf(const bvt &bv)
+void satcheck_cadical_baset::do_lcnf(const bvt &bv)
 {
-  clear_status();
-
   for(const auto &lit : bv)
   {
     if(lit.is_true())

--- a/src/solvers/sat/satcheck_cadical.cpp
+++ b/src/solvers/sat/satcheck_cadical.cpp
@@ -19,6 +19,7 @@ Author: Michael Tautschnig
 
 tvt satcheck_cadical_baset::l_get(literalt a) const
 {
+  PRECONDITION(solver_state == propt::statust::SAT);
   if(a.is_constant())
     return tvt(a.sign());
 
@@ -195,6 +196,8 @@ satcheck_cadical_baset::~satcheck_cadical_baset()
 
 bool satcheck_cadical_baset::is_in_conflict(literalt a) const
 {
+  PRECONDITION(solver_state == propt::statust::UNSAT);
+  PRECONDITION(!a.is_constant());
   return solver->failed(a.dimacs());
 }
 

--- a/src/solvers/sat/satcheck_cadical.cpp
+++ b/src/solvers/sat/satcheck_cadical.cpp
@@ -45,6 +45,8 @@ std::string satcheck_cadical_baset::solver_text() const
 
 void satcheck_cadical_baset::lcnf(const bvt &bv)
 {
+  clear_status();
+
   for(const auto &lit : bv)
   {
     if(lit.is_true())

--- a/src/solvers/sat/satcheck_cadical.h
+++ b/src/solvers/sat/satcheck_cadical.h
@@ -31,7 +31,7 @@ public:
   std::string solver_text() const override;
   tvt l_get(literalt a) const override;
 
-  void lcnf(const bvt &bv) override;
+  void do_lcnf(const bvt &bv) override;
   void set_assignment(literalt a, bool value) override;
 
   bool has_assumptions() const override

--- a/src/solvers/sat/satcheck_glucose.cpp
+++ b/src/solvers/sat/satcheck_glucose.cpp
@@ -105,10 +105,9 @@ void satcheck_glucose_baset<T>::add_variables()
     solver->newVar();
 }
 
-template<typename T>
-void satcheck_glucose_baset<T>::lcnf(const bvt &bv)
+template <typename T>
+void satcheck_glucose_baset<T>::do_lcnf(const bvt &bv)
 {
-  clear_status();
   try
   {
     add_variables();

--- a/src/solvers/sat/satcheck_glucose.cpp
+++ b/src/solvers/sat/satcheck_glucose.cpp
@@ -108,6 +108,7 @@ void satcheck_glucose_baset<T>::add_variables()
 template<typename T>
 void satcheck_glucose_baset<T>::lcnf(const bvt &bv)
 {
+  clear_status();
   try
   {
     add_variables();

--- a/src/solvers/sat/satcheck_glucose.h
+++ b/src/solvers/sat/satcheck_glucose.h
@@ -38,7 +38,7 @@ public:
 
   tvt l_get(literalt a) const override;
 
-  void lcnf(const bvt &bv) override;
+  void do_lcnf(const bvt &bv) override;
   void set_assignment(literalt a, bool value) override;
 
   // extra MiniSat feature: default branching decision

--- a/src/solvers/sat/satcheck_ipasir.cpp
+++ b/src/solvers/sat/satcheck_ipasir.cpp
@@ -64,9 +64,8 @@ std::string satcheck_ipasirt::solver_text() const
   return std::string(ipasir_signature());
 }
 
-void satcheck_ipasirt::lcnf(const bvt &bv)
+void satcheck_ipasirt::do_lcnf(const bvt &bv)
 {
-  clear_status();
   for(const auto &literal : bv)
   {
     if(literal.is_true())

--- a/src/solvers/sat/satcheck_ipasir.cpp
+++ b/src/solvers/sat/satcheck_ipasir.cpp
@@ -66,6 +66,7 @@ std::string satcheck_ipasirt::solver_text() const
 
 void satcheck_ipasirt::lcnf(const bvt &bv)
 {
+  clear_status();
   for(const auto &literal : bv)
   {
     if(literal.is_true())

--- a/src/solvers/sat/satcheck_ipasir.h
+++ b/src/solvers/sat/satcheck_ipasir.h
@@ -29,7 +29,7 @@ public:
   /// This method returns the truth value for a literal of the current SAT model
   tvt l_get(literalt a) const override final;
 
-  void lcnf(const bvt &bv) override final;
+  void do_lcnf(const bvt &bv) override final;
 
   /* This method is not supported, and currently not called anywhere in CBMC */
   void set_assignment(literalt a, bool value) override;

--- a/src/solvers/sat/satcheck_lingeling.cpp
+++ b/src/solvers/sat/satcheck_lingeling.cpp
@@ -48,9 +48,8 @@ std::string satcheck_lingelingt::solver_text() const
   return "Lingeling";
 }
 
-void satcheck_lingelingt::lcnf(const bvt &bv)
+void satcheck_lingelingt::do_lcnf(const bvt &bv)
 {
-  clear_status();
   bvt new_bv;
 
   if(process_clause(bv, new_bv))

--- a/src/solvers/sat/satcheck_lingeling.cpp
+++ b/src/solvers/sat/satcheck_lingeling.cpp
@@ -50,6 +50,7 @@ std::string satcheck_lingelingt::solver_text() const
 
 void satcheck_lingelingt::lcnf(const bvt &bv)
 {
+  clear_status();
   bvt new_bv;
 
   if(process_clause(bv, new_bv))

--- a/src/solvers/sat/satcheck_lingeling.h
+++ b/src/solvers/sat/satcheck_lingeling.h
@@ -24,7 +24,7 @@ public:
   std::string solver_text() const override;
   tvt l_get(literalt a) const override;
 
-  void lcnf(const bvt &bv) override;
+  void do_lcnf(const bvt &bv) override;
   void set_assignment(literalt a, bool value) override;
 
   bool has_assumptions() const override

--- a/src/solvers/sat/satcheck_minisat.cpp
+++ b/src/solvers/sat/satcheck_minisat.cpp
@@ -121,6 +121,7 @@ void satcheck_minisat1_baset::add_variables()
 
 void satcheck_minisat1_baset::lcnf(const bvt &bv)
 {
+  clear_status();
   bvt new_bv;
 
   if(process_clause(bv, new_bv))

--- a/src/solvers/sat/satcheck_minisat.cpp
+++ b/src/solvers/sat/satcheck_minisat.cpp
@@ -119,9 +119,8 @@ void satcheck_minisat1_baset::add_variables()
     solver->newVar();
 }
 
-void satcheck_minisat1_baset::lcnf(const bvt &bv)
+void satcheck_minisat1_baset::do_lcnf(const bvt &bv)
 {
-  clear_status();
   bvt new_bv;
 
   if(process_clause(bv, new_bv))

--- a/src/solvers/sat/satcheck_minisat.h
+++ b/src/solvers/sat/satcheck_minisat.h
@@ -27,7 +27,7 @@ public:
   std::string solver_text() const override;
   tvt l_get(literalt a) const override;
 
-  void lcnf(const bvt &bv) final;
+  void do_lcnf(const bvt &bv) final;
 
   void set_assignment(literalt a, bool value) override;
 

--- a/src/solvers/sat/satcheck_minisat2.cpp
+++ b/src/solvers/sat/satcheck_minisat2.cpp
@@ -134,10 +134,9 @@ void satcheck_minisat2_baset<T>::add_variables()
     solver->newVar();
 }
 
-template<typename T>
-void satcheck_minisat2_baset<T>::lcnf(const bvt &bv)
+template <typename T>
+void satcheck_minisat2_baset<T>::do_lcnf(const bvt &bv)
 {
-  clear_status();
   try
   {
     add_variables();

--- a/src/solvers/sat/satcheck_minisat2.cpp
+++ b/src/solvers/sat/satcheck_minisat2.cpp
@@ -137,6 +137,7 @@ void satcheck_minisat2_baset<T>::add_variables()
 template<typename T>
 void satcheck_minisat2_baset<T>::lcnf(const bvt &bv)
 {
+  clear_status();
   try
   {
     add_variables();

--- a/src/solvers/sat/satcheck_minisat2.h
+++ b/src/solvers/sat/satcheck_minisat2.h
@@ -40,7 +40,7 @@ public:
 
   tvt l_get(literalt a) const override final;
 
-  void lcnf(const bvt &bv) override final;
+  void do_lcnf(const bvt &bv) override final;
   void set_assignment(literalt a, bool value) override;
 
   // extra MiniSat feature: default branching decision

--- a/src/solvers/sat/satcheck_picosat.cpp
+++ b/src/solvers/sat/satcheck_picosat.cpp
@@ -48,9 +48,8 @@ std::string satcheck_picosatt::solver_text() const
   return "PicoSAT";
 }
 
-void satcheck_picosatt::lcnf(const bvt &bv)
+void satcheck_picosatt::do_lcnf(const bvt &bv)
 {
-  clear_status();
   bvt new_bv;
 
   if(process_clause(bv, new_bv))

--- a/src/solvers/sat/satcheck_picosat.cpp
+++ b/src/solvers/sat/satcheck_picosat.cpp
@@ -50,6 +50,7 @@ std::string satcheck_picosatt::solver_text() const
 
 void satcheck_picosatt::lcnf(const bvt &bv)
 {
+  clear_status();
   bvt new_bv;
 
   if(process_clause(bv, new_bv))

--- a/src/solvers/sat/satcheck_picosat.h
+++ b/src/solvers/sat/satcheck_picosat.h
@@ -24,7 +24,7 @@ public:
   std::string solver_text() const override;
   tvt l_get(literalt a) const override;
 
-  void lcnf(const bvt &bv) override;
+  void do_lcnf(const bvt &bv) override;
   void set_assignment(literalt a, bool value) override;
 
   bool is_in_conflict(literalt a) const override;

--- a/src/solvers/smt2/smt2_conv.cpp
+++ b/src/solvers/smt2/smt2_conv.cpp
@@ -1034,7 +1034,7 @@ literalt smt2_convt::convert(const exprt &expr)
   return l;
 }
 
-exprt smt2_convt::handle(const exprt &expr)
+exprt smt2_convt::do_handle(const exprt &expr)
 {
   // We can only improve Booleans.
   if(!expr.is_boolean())
@@ -5159,27 +5159,27 @@ void smt2_convt::unflatten(
   }
 }
 
-void smt2_convt::set_to(const exprt &expr, bool value)
+void smt2_convt::do_set_to(const exprt &expr, bool value)
 {
   PRECONDITION(expr.is_boolean());
 
   if(expr.id()==ID_and && value)
   {
     for(const auto &op : expr.operands())
-      set_to(op, true);
+      do_set_to(op, true);
     return;
   }
 
   if(expr.id()==ID_or && !value)
   {
     for(const auto &op : expr.operands())
-      set_to(op, false);
+      do_set_to(op, false);
     return;
   }
 
   if(expr.id()==ID_not)
   {
-    return set_to(to_not_expr(expr).op(), !value);
+    return do_set_to(to_not_expr(expr).op(), !value);
   }
 
   out << "\n";

--- a/src/solvers/smt2/smt2_conv.h
+++ b/src/solvers/smt2/smt2_conv.h
@@ -71,8 +71,8 @@ public:
   bool use_lambda_for_array = false;
   bool emit_set_logic = true;
 
-  exprt handle(const exprt &expr) override;
-  void set_to(const exprt &expr, bool value) override;
+  exprt do_handle(const exprt &expr) override;
+  void do_set_to(const exprt &expr, bool value) override;
   exprt get(const exprt &expr) const override;
   std::string decision_procedure_text() const override;
   void print_assignment(std::ostream &out) const override;

--- a/src/solvers/smt2_incremental/smt2_incremental_decision_procedure.cpp
+++ b/src/solvers/smt2_incremental/smt2_incremental_decision_procedure.cpp
@@ -432,7 +432,7 @@ smt2_incremental_decision_proceduret::convert_expr_to_smt(const exprt &expr)
     is_dynamic_object_function.make_application);
 }
 
-exprt smt2_incremental_decision_proceduret::handle(const exprt &expr)
+exprt smt2_incremental_decision_proceduret::do_handle(const exprt &expr)
 {
   log.conditional_output(log.debug(), [&](messaget::mstreamt &debug) {
     debug << "`handle`  -\n  " << expr.pretty(2, 0) << messaget::eom;
@@ -644,7 +644,7 @@ smt2_incremental_decision_proceduret::get_number_of_solver_calls() const
   return number_of_solver_calls;
 }
 
-void smt2_incremental_decision_proceduret::set_to(
+void smt2_incremental_decision_proceduret::do_set_to(
   const exprt &in_expr,
   bool value)
 {

--- a/src/solvers/smt2_incremental/smt2_incremental_decision_procedure.h
+++ b/src/solvers/smt2_incremental/smt2_incremental_decision_procedure.h
@@ -41,12 +41,12 @@ public:
     message_handlert &message_handler);
 
   // Implementation of public decision_proceduret member functions.
-  exprt handle(const exprt &expr) override;
+  exprt do_handle(const exprt &expr) override;
   exprt get(const exprt &expr) const override;
   void print_assignment(std::ostream &out) const override;
   std::string decision_procedure_text() const override;
   std::size_t get_number_of_solver_calls() const override;
-  void set_to(const exprt &expr, bool value) override;
+  void do_set_to(const exprt &expr, bool value) override;
 
   // Implementation of public stack_decision_proceduret member functions.
   void push(const std::vector<exprt> &assumptions) override;

--- a/src/solvers/strings/string_refinement.cpp
+++ b/src/solvers/strings/string_refinement.cpp
@@ -280,7 +280,7 @@ replace_expr_copy(const union_find_replacet &symbol_resolve, exprt expr)
 /// the boolean is true and false otherwise.
 /// \param expr: an expression of type `bool`
 /// \param value: the boolean value to set it to
-void string_refinementt::set_to(const exprt &expr, bool value)
+void string_refinementt::do_set_to(const exprt &expr, bool value)
 {
   PRECONDITION(expr.is_boolean());
   PRECONDITION(equality_propagation);
@@ -735,7 +735,7 @@ string_refinementt::dec_solve(const exprt &assumption)
 #ifdef DEBUG
     log.debug() << "dec_solve: set_to " << format(eq) << messaget::eom;
 #endif
-    supert::set_to(eq, true);
+    supert::do_set_to(eq, true);
   }
 
   std::transform(

--- a/src/solvers/strings/string_refinement.h
+++ b/src/solvers/strings/string_refinement.h
@@ -83,7 +83,7 @@ public:
   }
 
   exprt get(const exprt &expr) const override;
-  void set_to(const exprt &expr, bool value) override;
+  void do_set_to(const exprt &expr, bool value) override;
 
 protected:
   decision_proceduret::resultt dec_solve(const exprt &) override;

--- a/unit/Makefile
+++ b/unit/Makefile
@@ -111,6 +111,7 @@ SRC += analyses/ai/ai.cpp \
        solvers/sat/external_sat.cpp \
        solvers/sat/satcheck_cadical.cpp \
        solvers/sat/satcheck_minisat2.cpp \
+       solvers/sat/solver_state_machine.cpp \
        solvers/smt2/smt2_conv.cpp \
        solvers/smt2/smt2irep.cpp \
        solvers/smt2/smt2_tokenizer.cpp \

--- a/unit/solvers/bdd/miniBDD/miniBDD.cpp
+++ b/unit/solvers/bdd/miniBDD/miniBDD.cpp
@@ -130,7 +130,7 @@ public:
     return to_literal((to_bdd(!c) | to_bdd(t)) & (to_bdd(c) | to_bdd(f)));
   }
 
-  void lcnf(const bvt &) override
+  void do_lcnf(const bvt &) override
   {
     UNREACHABLE;
   }

--- a/unit/solvers/sat/module_dependencies.txt
+++ b/unit/solvers/sat/module_dependencies.txt
@@ -1,3 +1,4 @@
+solvers
 solvers/prop
 solvers/sat
 testing-utils

--- a/unit/solvers/sat/satcheck_cadical.cpp
+++ b/unit/solvers/sat/satcheck_cadical.cpp
@@ -11,11 +11,13 @@ Author: Peter Schrammel, Michael Tautschnig
 
 #ifdef HAVE_CADICAL
 
-#  include <testing-utils/use_catch.h>
+#  include <util/cout_message.h>
+#  include <util/invariant.h>
 
 #  include <solvers/prop/literal.h>
 #  include <solvers/sat/satcheck_cadical.h>
-#  include <util/cout_message.h>
+#  include <testing-utils/invariant.h>
+#  include <testing-utils/use_catch.h>
 
 SCENARIO("satcheck_cadical", "[core][solvers][sat][satcheck_cadical]")
 {
@@ -169,6 +171,58 @@ SCENARIO(
       // Adding a new variable transitions state back to UNKNOWN
       satcheck.new_variable();
       REQUIRE(satcheck.get_status() == propt::statust::UNKNOWN);
+    }
+  }
+}
+
+SCENARIO(
+  "propt state machine preconditions",
+  "[core][solvers][sat][satcheck_cadical][prop_state]")
+{
+  console_message_handlert message_handler;
+  const cbmc_invariants_should_throwt invariants_throw;
+
+  GIVEN("A solver with a variable but no solve performed (UNKNOWN state)")
+  {
+    satcheck_cadical_no_preprocessingt satcheck(message_handler);
+    const literalt v = satcheck.new_variable();
+    REQUIRE(satcheck.get_status() == propt::statust::UNKNOWN);
+
+    THEN("l_get() outside the SAT state fires its precondition")
+    {
+      REQUIRE_THROWS_AS(satcheck.l_get(v), invariant_failedt);
+    }
+    THEN("is_in_conflict() outside the UNSAT state fires its precondition")
+    {
+      REQUIRE_THROWS_AS(satcheck.is_in_conflict(v), invariant_failedt);
+    }
+  }
+
+  GIVEN("A solver that has produced a SAT result")
+  {
+    satcheck_cadical_no_preprocessingt satcheck(message_handler);
+    const literalt v = satcheck.new_variable();
+    satcheck.set_frozen(v);
+    satcheck.l_set_to_true(v);
+    REQUIRE(satcheck.prop_solve() == propt::resultt::P_SATISFIABLE);
+
+    THEN("is_in_conflict() (only valid in UNSAT) fires its precondition")
+    {
+      REQUIRE_THROWS_AS(satcheck.is_in_conflict(v), invariant_failedt);
+    }
+  }
+
+  GIVEN("A solver that has produced an UNSAT result")
+  {
+    satcheck_cadical_no_preprocessingt satcheck(message_handler);
+    const literalt v = satcheck.new_variable();
+    satcheck.set_frozen(v);
+    satcheck.l_set_to_true(satcheck.land(v, !v));
+    REQUIRE(satcheck.prop_solve() == propt::resultt::P_UNSATISFIABLE);
+
+    THEN("l_get() (only valid in SAT) fires its precondition")
+    {
+      REQUIRE_THROWS_AS(satcheck.l_get(v), invariant_failedt);
     }
   }
 }

--- a/unit/solvers/sat/satcheck_cadical.cpp
+++ b/unit/solvers/sat/satcheck_cadical.cpp
@@ -83,4 +83,94 @@ SCENARIO("satcheck_cadical", "[core][solvers][sat][satcheck_cadical]")
   }
 }
 
+SCENARIO(
+  "propt state machine",
+  "[core][solvers][sat][satcheck_cadical][prop_state]")
+{
+  console_message_handlert message_handler;
+
+  GIVEN("A fresh solver")
+  {
+    satcheck_cadical_no_preprocessingt satcheck(message_handler);
+
+    THEN("initial state is UNKNOWN")
+    {
+      REQUIRE(satcheck.get_status() == propt::statust::UNKNOWN);
+    }
+  }
+
+  GIVEN("A satisfiable formula")
+  {
+    satcheck_cadical_no_preprocessingt satcheck(message_handler);
+    literalt f = satcheck.new_variable();
+    satcheck.l_set_to_true(f);
+
+    WHEN("solved")
+    {
+      auto result = satcheck.prop_solve();
+      THEN("state is SAT")
+      {
+        REQUIRE(result == propt::resultt::P_SATISFIABLE);
+        REQUIRE(satcheck.get_status() == propt::statust::SAT);
+      }
+      THEN("l_get returns a definite value")
+      {
+        REQUIRE(satcheck.l_get(f).is_true());
+      }
+    }
+  }
+
+  GIVEN("An unsatisfiable formula")
+  {
+    satcheck_cadical_no_preprocessingt satcheck(message_handler);
+    literalt f = satcheck.new_variable();
+    satcheck.l_set_to_true(satcheck.land(f, !f));
+
+    WHEN("solved")
+    {
+      auto result = satcheck.prop_solve();
+      THEN("state is UNSAT")
+      {
+        REQUIRE(result == propt::resultt::P_UNSATISFIABLE);
+        REQUIRE(satcheck.get_status() == propt::statust::UNSAT);
+      }
+    }
+  }
+
+  GIVEN("A satisfiable formula that becomes unsatisfiable incrementally")
+  {
+    satcheck_cadical_no_preprocessingt satcheck(message_handler);
+    literalt a = satcheck.new_variable();
+    satcheck.set_frozen(a);
+    satcheck.l_set_to_true(a);
+
+    WHEN("first solve is SAT, then add contradicting clause")
+    {
+      REQUIRE(satcheck.prop_solve() == propt::resultt::P_SATISFIABLE);
+      REQUIRE(satcheck.get_status() == propt::statust::SAT);
+      REQUIRE(satcheck.l_get(a).is_true());
+
+      // Adding a new clause transitions state back to UNKNOWN
+      satcheck.l_set_to_false(a);
+      REQUIRE(satcheck.get_status() == propt::statust::UNKNOWN);
+
+      THEN("re-solving yields UNSAT")
+      {
+        REQUIRE(satcheck.prop_solve() == propt::resultt::P_UNSATISFIABLE);
+        REQUIRE(satcheck.get_status() == propt::statust::UNSAT);
+      }
+    }
+
+    WHEN("first solve is SAT, then add a new variable")
+    {
+      REQUIRE(satcheck.prop_solve() == propt::resultt::P_SATISFIABLE);
+      REQUIRE(satcheck.get_status() == propt::statust::SAT);
+
+      // Adding a new variable transitions state back to UNKNOWN
+      satcheck.new_variable();
+      REQUIRE(satcheck.get_status() == propt::statust::UNKNOWN);
+    }
+  }
+}
+
 #endif

--- a/unit/solvers/sat/solver_state_machine.cpp
+++ b/unit/solvers/sat/solver_state_machine.cpp
@@ -1,0 +1,277 @@
+/*******************************************************************\
+
+Module: Unit tests for the propt and decision_proceduret state machines
+
+Author: Diffblue Ltd.
+
+\*******************************************************************/
+
+/// \file
+/// Backend-independent unit tests for the solver state machine formalised in
+/// propt and decision_proceduret. These use small mock back ends so that the
+/// safety guarantees (status invalidation, exception handling, sticky ERROR
+/// state) can be exercised in isolation, independently of which SAT solver is
+/// configured.
+
+#include <util/message.h>
+#include <util/std_expr.h>
+
+#include <solvers/decision_procedure.h>
+#include <solvers/sat/cnf.h>
+#include <testing-utils/use_catch.h>
+
+#include <stdexcept>
+
+/// Minimal concrete decision_proceduret that records how often the mutation
+/// hooks are called and lets the test drive the result of dec_solve().
+class mock_decision_proceduret : public decision_proceduret
+{
+public:
+  bool throw_on_solve = false;
+  resultt next_result = resultt::D_SATISFIABLE;
+  std::size_t do_set_to_calls = 0;
+  std::size_t do_handle_calls = 0;
+
+  exprt get(const exprt &) const override
+  {
+    return nil_exprt{};
+  }
+  void print_assignment(std::ostream &) const override
+  {
+  }
+  std::string decision_procedure_text() const override
+  {
+    return "mock decision procedure";
+  }
+  std::size_t get_number_of_solver_calls() const override
+  {
+    return 0;
+  }
+
+protected:
+  void do_set_to(const exprt &, bool) override
+  {
+    ++do_set_to_calls;
+  }
+  exprt do_handle(const exprt &expr) override
+  {
+    ++do_handle_calls;
+    return expr;
+  }
+  resultt dec_solve(const exprt &) override
+  {
+    if(throw_on_solve)
+      throw std::runtime_error("mock decision procedure failure");
+    return next_result;
+  }
+};
+
+SCENARIO(
+  "decision_proceduret state machine",
+  "[core][solvers][decision_procedure][dp_state]")
+{
+  mock_decision_proceduret dp;
+  const true_exprt constraint;
+
+  GIVEN("a freshly constructed decision procedure")
+  {
+    THEN("the initial status is D_ERROR (not yet solved)")
+    {
+      REQUIRE(dp.get_status() == decision_proceduret::resultt::D_ERROR);
+    }
+  }
+
+  GIVEN("a decision procedure that reports D_SATISFIABLE")
+  {
+    dp.next_result = decision_proceduret::resultt::D_SATISFIABLE;
+
+    WHEN("operator() is invoked")
+    {
+      const auto result = dp();
+      THEN("it returns and records the satisfiable result")
+      {
+        REQUIRE(result == decision_proceduret::resultt::D_SATISFIABLE);
+        REQUIRE(dp.get_status() == decision_proceduret::resultt::D_SATISFIABLE);
+      }
+      THEN("a direct call to set_to() resets the status to D_ERROR")
+      {
+        dp.set_to(constraint, true);
+        REQUIRE(dp.get_status() == decision_proceduret::resultt::D_ERROR);
+        REQUIRE(dp.do_set_to_calls == 1);
+      }
+      THEN("set_to_true()/set_to_false() also reset the status")
+      {
+        dp.set_to_true(constraint);
+        REQUIRE(dp.get_status() == decision_proceduret::resultt::D_ERROR);
+        dp.next_result = decision_proceduret::resultt::D_SATISFIABLE;
+        REQUIRE(dp() == decision_proceduret::resultt::D_SATISFIABLE);
+        dp.set_to_false(constraint);
+        REQUIRE(dp.get_status() == decision_proceduret::resultt::D_ERROR);
+        REQUIRE(dp.do_set_to_calls == 2);
+      }
+      THEN("a direct call to handle() resets the status to D_ERROR")
+      {
+        dp.handle(constraint);
+        REQUIRE(dp.get_status() == decision_proceduret::resultt::D_ERROR);
+        REQUIRE(dp.do_handle_calls == 1);
+      }
+    }
+  }
+
+  GIVEN("a decision procedure that has reported D_SATISFIABLE")
+  {
+    dp.next_result = decision_proceduret::resultt::D_SATISFIABLE;
+    REQUIRE(dp() == decision_proceduret::resultt::D_SATISFIABLE);
+
+    WHEN("a subsequent solve throws")
+    {
+      dp.throw_on_solve = true;
+      THEN("the exception propagates and the status is reset to D_ERROR")
+      {
+        REQUIRE_THROWS_AS(dp(), std::runtime_error);
+        REQUIRE(dp.get_status() == decision_proceduret::resultt::D_ERROR);
+      }
+      THEN("the assumption-taking overload behaves the same way")
+      {
+        REQUIRE_THROWS_AS(dp(constraint), std::runtime_error);
+        REQUIRE(dp.get_status() == decision_proceduret::resultt::D_ERROR);
+      }
+    }
+  }
+}
+
+/// Minimal concrete propt (via cnft, which provides the Boolean operators)
+/// that lets the test drive the result of do_prop_solve() and count clauses.
+class mock_propt : public cnft
+{
+public:
+  explicit mock_propt(message_handlert &message_handler) : cnft(message_handler)
+  {
+  }
+
+  bool throw_on_solve = false;
+  resultt next_result = resultt::P_SATISFIABLE;
+  std::size_t clauses = 0;
+
+  std::string solver_text() const override
+  {
+    return "mock propositional solver";
+  }
+  size_t no_clauses() const override
+  {
+    return clauses;
+  }
+  tvt l_get(literalt) const override
+  {
+    return tvt{true};
+  }
+  void set_assignment(literalt, bool) override
+  {
+  }
+  bool is_in_conflict(literalt) const override
+  {
+    return false;
+  }
+
+protected:
+  void do_lcnf(const bvt &) override
+  {
+    ++clauses;
+  }
+  resultt do_prop_solve(const bvt &) override
+  {
+    if(throw_on_solve)
+      throw std::runtime_error("mock solver failure");
+    return next_result;
+  }
+};
+
+SCENARIO(
+  "propt state machine (mock backend)",
+  "[core][solvers][prop][prop_state]")
+{
+  null_message_handlert message_handler;
+  mock_propt solver{message_handler};
+
+  GIVEN("a freshly constructed solver")
+  {
+    THEN("the initial state is UNKNOWN")
+    {
+      REQUIRE(solver.get_status() == propt::statust::UNKNOWN);
+    }
+  }
+
+  GIVEN("a solver that reports SAT")
+  {
+    solver.next_result = propt::resultt::P_SATISFIABLE;
+    const literalt l = solver.new_variable();
+    REQUIRE(solver.prop_solve() == propt::resultt::P_SATISFIABLE);
+    REQUIRE(solver.get_status() == propt::statust::SAT);
+
+    WHEN("a clause is added via lcnf()")
+    {
+      solver.lcnf(bvt{l});
+      THEN("the state is invalidated to UNKNOWN")
+      {
+        REQUIRE(solver.get_status() == propt::statust::UNKNOWN);
+      }
+    }
+    WHEN("a unit constraint is added via l_set_to()")
+    {
+      solver.l_set_to(l, true);
+      THEN("the state is invalidated to UNKNOWN")
+      {
+        REQUIRE(solver.get_status() == propt::statust::UNKNOWN);
+      }
+    }
+    WHEN("a new variable is allocated")
+    {
+      solver.new_variable();
+      THEN("the state is invalidated to UNKNOWN")
+      {
+        REQUIRE(solver.get_status() == propt::statust::UNKNOWN);
+      }
+    }
+  }
+
+  GIVEN("a solver whose do_prop_solve() throws")
+  {
+    solver.throw_on_solve = true;
+
+    WHEN("prop_solve() is called")
+    {
+      THEN("the exception propagates and the state becomes ERROR")
+      {
+        REQUIRE_THROWS_AS(solver.prop_solve(), std::runtime_error);
+        REQUIRE(solver.get_status() == propt::statust::ERROR);
+      }
+    }
+  }
+
+  GIVEN("a solver in the ERROR state")
+  {
+    solver.throw_on_solve = true;
+    REQUIRE_THROWS_AS(solver.prop_solve(), std::runtime_error);
+    REQUIRE(solver.get_status() == propt::statust::ERROR);
+    const literalt l = solver.new_variable();
+
+    WHEN("constraints or variables are added")
+    {
+      THEN("the ERROR state is sticky: it is not cleared by lcnf()")
+      {
+        solver.lcnf(bvt{l});
+        REQUIRE(solver.get_status() == propt::statust::ERROR);
+      }
+      THEN("the ERROR state is not cleared by l_set_to()")
+      {
+        solver.l_set_to(l, true);
+        REQUIRE(solver.get_status() == propt::statust::ERROR);
+      }
+      THEN("the ERROR state is not cleared by new_variable()")
+      {
+        solver.new_variable();
+        REQUIRE(solver.get_status() == propt::statust::ERROR);
+      }
+    }
+  }
+}


### PR DESCRIPTION
As suggested by @kroening in #8849, this formalizes the solver state machine in `propt` and `decision_proceduret`.

**Commit 1: Document and track solver state machine**
- Adds `propt::statust` enum (`UNKNOWN`, `SAT`, `UNSAT`, `ERROR`) and tracks state transitions:
  - `prop_solve()` sets state based on result
  - `l_set_to()` and `lcnf()` overloads call `clear_status()` to transition SAT/UNSAT → UNKNOWN
- Adds `decision_proceduret::get_status()` tracking `latest_result`
- Documents the state machine contract as class-level comments
- Adds unit tests verifying state transitions in CaDiCaL

**Commit 2: Call `clear_status()` in all solver backends**
- All SAT solver `lcnf()` implementations now call `clear_status()` at entry, ensuring the state machine is consistently enforced across all backends.

**Commit 3: Enforce state preconditions**
- `l_get()` requires `SAT` state, `is_in_conflict()` requires `UNSAT` state (via `PRECONDITION`)
- All existing regression and unit tests pass — the codebase already respects the state machine; this commit makes violations fail-fast.

Note: `cnf_solvert::statust` is retained for now (marked as legacy/superseded) since it is used by all `do_prop_solve` implementations. Unifying the two can be done as a follow-up.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
