### PR TITLE
Fix heap-use-after-free in AI on empty goto programs

### DIFF
--- a/regression/goto-instrument/uninitialized-check-empty-body/main.c
+++ b/regression/goto-instrument/uninitialized-check-empty-body/main.c
@@ -1,0 +1,7 @@
+void external_function(void);
+
+int main(void)
+{
+  external_function();
+  return 0;
+}

--- a/regression/goto-instrument/uninitialized-check-empty-body/test.desc
+++ b/regression/goto-instrument/uninitialized-check-empty-body/test.desc
@@ -1,0 +1,10 @@
+CORE
+main.c
+--uninitialized-check
+^EXIT=10$
+^SIGNAL=0$
+--
+--
+Regression test for heap-use-after-free when running uninitialized variable
+analysis on a program with an external function that has no body (empty
+goto_programt).

--- a/src/analyses/ai.cpp
+++ b/src/analyses/ai.cpp
@@ -178,6 +178,9 @@ ai_baset::entry_state(const goto_functionst &goto_functions)
 
 ai_baset::trace_ptrt ai_baset::entry_state(const goto_programt &goto_program)
 {
+  if(goto_program.empty())
+    return nullptr;
+
   // The first instruction of 'goto_program' is the entry point
   trace_ptrt p = history_factory->epoch(goto_program.instructions.begin());
   get_state(p).make_entry();

--- a/src/analyses/ai.h
+++ b/src/analyses/ai.h
@@ -145,6 +145,8 @@ public:
     const goto_programt &goto_program,
     const namespacet &ns)
   {
+    if(goto_program.empty())
+      return;
     goto_functionst goto_functions;
     initialize(function_id, goto_program);
     trace_ptrt p = entry_state(goto_program);

--- a/src/analyses/ai.h
+++ b/src/analyses/ai.h
@@ -145,12 +145,11 @@ public:
     const goto_programt &goto_program,
     const namespacet &ns)
   {
-    if(goto_program.empty())
-      return;
     goto_functionst goto_functions;
     initialize(function_id, goto_program);
     trace_ptrt p = entry_state(goto_program);
-    fixedpoint(p, function_id, goto_program, goto_functions, ns);
+    if(p != nullptr)
+      fixedpoint(p, function_id, goto_program, goto_functions, ns);
     finalize();
   }
 
@@ -161,7 +160,8 @@ public:
   {
     initialize(goto_functions);
     trace_ptrt p = entry_state(goto_functions);
-    fixedpoint(p, goto_functions, ns);
+    if(p != nullptr)
+      fixedpoint(p, goto_functions, ns);
     finalize();
   }
 
@@ -171,7 +171,8 @@ public:
     const namespacet ns(goto_model.get_symbol_table());
     initialize(goto_model.get_goto_functions());
     trace_ptrt p = entry_state(goto_model.get_goto_functions());
-    fixedpoint(p, goto_model.get_goto_functions(), ns);
+    if(p != nullptr)
+      fixedpoint(p, goto_model.get_goto_functions(), ns);
     finalize();
   }
 
@@ -184,7 +185,8 @@ public:
     goto_functionst goto_functions;
     initialize(function_id, goto_function);
     trace_ptrt p = entry_state(goto_function.body);
-    fixedpoint(p, function_id, goto_function.body, goto_functions, ns);
+    if(p != nullptr)
+      fixedpoint(p, function_id, goto_function.body, goto_functions, ns);
     finalize();
   }
 


### PR DESCRIPTION
ai_baset::operator()(function_id, goto_program, ns) calls entry_state(goto_program) which creates a history object pointing to instructions.begin(). For an empty goto_programt, begin() == end(), so the history points to the list sentinel node. The subsequent fixedpoint iteration then dereferences this invalid iterator, reading freed memory (detected by AddressSanitizer).

This affects any analysis that iterates over all functions in a goto model, including uninitializedt::add_assertions, when the model contains functions with empty bodies (e.g., library functions like malloc that have declarations but no definitions in the goto binary).

The fix skips the analysis for empty programs.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
