### PR TITLE
Mark slowest CI test outliers as THOROUGH

### DIFF
--- a/jbmc/regression/jbmc-strings/StringSubstring/test.desc
+++ b/jbmc/regression/jbmc-strings/StringSubstring/test.desc
@@ -1,4 +1,4 @@
-CORE
+THOROUGH
 Test
 --unwind 10 --max-nondet-string-length 6  --function Test.testSuccess --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar ../../../lib/java-models-library/target/cprover-api.jar`
 ^EXIT=0$

--- a/regression/book-examples/pid/C11.desc
+++ b/regression/book-examples/pid/C11.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+THOROUGH no-new-smt
 pid.c
 --cover mcdc --unwind 6
 ^EXIT=0$

--- a/regression/cbmc-incr-smt2/structs/large_array_of_struct_nondet_index.desc
+++ b/regression/cbmc-incr-smt2/structs/large_array_of_struct_nondet_index.desc
@@ -1,4 +1,4 @@
-CORE
+THOROUGH
 large_array_of_struct_nondet_index.c
 --trace
 Passing problem to incremental SMT2 solving

--- a/regression/contracts-dfcc/assigns-local-composite/test.desc
+++ b/regression/contracts-dfcc/assigns-local-composite/test.desc
@@ -1,4 +1,4 @@
-CORE
+THOROUGH
 main.c
 --no-malloc-may-fail --dfcc main --enforce-contract foo _ --no-standard-checks
 ^EXIT=0$


### PR DESCRIPTION
Move four extreme outlier tests from CORE to THOROUGH to reduce CI wall-clock time. These tests were identified by analysing 5 recent 'Build and Test CBMC' workflow runs across macOS-14, Windows (VS 2022 and VS 2025), and Linux.

Tests moved to THOROUGH:

1. jbmc-strings/StringSubstring/test.desc
   - macOS-14 ARM: 1950s (32.5 min), Linux: 3s — 650x slower
   - Single biggest contributor to the jbmc-strings-symex-driven-lazy- loading-CORE suite (avg 1h26m on macOS-14), which is the primary bottleneck in the entire CI pipeline
   - Also affects jbmc-strings-CORE (29s on macOS-14 vs 3s on Linux)

2. book-examples/pid/C11.desc
   - macOS-14 ARM: 1069s (17.8 min), Linux: 28s — 38x slower
   - Dominates the book-examples-cprover-smt2-CORE suite entirely (18 min avg on macOS-14, all from this one test)
   - Also slow in book-examples-CORE (3m14s avg on macOS-14)

3. contracts-dfcc/assigns-local-composite/test.desc
   - macOS-14: 90s, VS 2025: 114s, VS 2022: 78s, Linux: 8s
   - 10-14x slower on macOS and Windows than Linux
   - Top individual test in contracts-dfcc-CORE on all platforms

4. cbmc-incr-smt2/structs/large_array_of_struct_nondet_index.desc
   - VS 2022: 472s (7.9 min) per solver, VS 2025: 103s, Linux: fast
   - Windows-specific bottleneck; runs twice (z3 + cvc5)
   - Single biggest contributor to cbmc-incr-smt2 suite on Windows

Expected impact on the critical path (check-macos-14-cmake-clang):
- jbmc-strings-symex-driven-lazy-loading-CORE: ~1h26m -> ~54m (est.)
- book-examples-cprover-smt2-CORE: ~18m -> ~1m (est.)
- contracts-dfcc-CORE: ~13m -> ~12m (est.)
- Overall job: ~2h25m -> ~1h30m (est.)

These tests will continue to run in the THOROUGH CI job (check-ubuntu-24_04-cmake-gcc-THOROUGH).

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [x] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
