### PR TITLE
Enable parallel regression test execution for Windows VS 2022

### DIFF
--- a/.github/workflows/pull-request-checks.yaml
+++ b/.github/workflows/pull-request-checks.yaml
@@ -921,7 +921,7 @@ jobs:
           make CXX=clcache BUILD_ENV=MSVC -C unit test TAGS="[z3]"
           make CXX=clcache BUILD_ENV=MSVC -C jbmc/unit test
       - name: Run CBMC regression tests
-        run: make CXX=clcache BUILD_ENV=MSVC -C regression test
+        run: make CXX=clcache BUILD_ENV=MSVC -j${{env.windows-vcpus}} -C regression test-parallel-jobs
 
   # This job takes approximately 7 to 32 minutes
   windows-msi-package:

--- a/jbmc/regression/Makefile
+++ b/jbmc/regression/Makefile
@@ -42,6 +42,19 @@ test-parallel:
 		$(MAKE) "{}" \
 		::: $(DIRS)
 
+# Run all test directories in parallel when invoked with make -j<N>
+# (no GNU Parallel needed).
+# Example: make -j8 test-parallel-jobs
+# Without -j, the directories will run sequentially.
+PARALLEL_DIRS = $(addprefix parallel__,$(DIRS))
+.PHONY: mvn-package test-parallel-jobs $(PARALLEL_DIRS)
+mvn-package:
+	mvn --quiet clean package -T1C
+test-parallel-jobs: $(PARALLEL_DIRS)
+$(PARALLEL_DIRS): parallel__%: mvn-package
+	@echo "Running $*..."
+	$(MAKE) -C "$*" test
+
 
 .PHONY: clean
 clean:

--- a/regression/Makefile
+++ b/regression/Makefile
@@ -112,6 +112,17 @@ test-parallel:
 		$(MAKE) "{}" \
 		::: $(DIRS)
 
+# Run all test directories in parallel when invoked with make -j<N>
+# (no GNU Parallel needed).
+# Example: make -j8 test-parallel-jobs
+# Without -j, the directories will run sequentially.
+PARALLEL_DIRS = $(addprefix parallel__,$(DIRS))
+.PHONY: test-parallel-jobs $(PARALLEL_DIRS)
+test-parallel-jobs: $(PARALLEL_DIRS)
+$(PARALLEL_DIRS): parallel__%:
+	@echo "Running $*..."
+	$(MAKE) -C "$*" test
+
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
Add a 'test-parallel-jobs' Makefile target to both regression/Makefile and jbmc/regression/Makefile that uses make -j for parallelism instead of GNU Parallel (which is unavailable on Windows runners).

The target creates a phony rule per test directory using the `$(addprefix parallel__,$(DIRS))` pattern, allowing make's built-in job server to schedule directories in parallel.

The VS 2022 CI job is updated to use this target with -j$windows-vcpus, replacing the sequential 'make test' invocation. This reduces test wall-clock time from 40 minutes down to 15 minutes.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [x] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
