### PR TITLE
Add output_filet utility class from hw-cbmc

### DIFF
--- a/src/goto-symex/show_program.cpp
+++ b/src/goto-symex/show_program.cpp
@@ -13,12 +13,12 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include <util/byte_operators.h> // IWYU pragma: keep
 #include <util/json_irep.h>
+#include <util/output_file.h>
 #include <util/ui_message.h>
 
 #include <goto-symex/symex_target_equation.h>
 #include <langapi/language_util.h>
 
-#include <fstream> // IWYU pragma: keep
 #include <iostream>
 
 /// Output a single SSA step
@@ -257,12 +257,6 @@ std::string json_get_key_byte_op_stats()
     UNREACHABLE;
 }
 
-bool is_outfile_specified(const optionst &options)
-{
-  const std::string &filename = options.get_option("outfile");
-  return (!filename.empty() && filename != "-");
-}
-
 void show_byte_ops_plain(
   ui_message_handlert &ui_message_handler,
   std::ostream &out,
@@ -326,19 +320,11 @@ void show_byte_ops(
   const symex_target_equationt &equation)
 {
   const std::string &filename = options.get_option("outfile");
-  const bool outfile_given = is_outfile_specified(options);
 
-  std::ofstream of;
+  output_filet output_file{filename.empty() ? "-" : filename};
+  const bool outfile_given = output_file.is_file();
 
-  if(outfile_given)
-  {
-    of.open(filename, std::fstream::out);
-    if(!of)
-      throw invalid_command_line_argument_exceptiont(
-        "failed to open output file: " + filename, "--outfile");
-  }
-
-  std::ostream &out = outfile_given ? of : std::cout;
+  std::ostream &out = output_file.stream();
 
   switch(ui_message_handler.get_ui())
   {

--- a/src/goto-symex/show_vcc.cpp
+++ b/src/goto-symex/show_vcc.cpp
@@ -11,15 +11,12 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "show_vcc.h"
 
-#include <util/exception_utils.h>
 #include <util/format_expr.h>
 #include <util/json_irep.h>
+#include <util/output_file.h>
 #include <util/ui_message.h>
 
 #include "symex_target_equation.h"
-
-#include <fstream> // IWYU pragma: keep
-#include <iostream>
 
 /// Output equations from \p equation in plain text format to the given output
 /// stream \p out.
@@ -173,19 +170,11 @@ void show_vcc(
   messaget msg(ui_message_handler);
 
   const std::string &filename = options.get_option("outfile");
-  bool have_file = !filename.empty() && filename != "-";
 
-  std::ofstream of;
+  output_filet output_file{filename.empty() ? "-" : filename};
+  bool have_file = output_file.is_file();
 
-  if(have_file)
-  {
-    of.open(filename);
-    if(!of)
-      throw invalid_command_line_argument_exceptiont(
-        "failed to open output file: " + filename, "--outfile");
-  }
-
-  std::ostream &out = have_file ? of : std::cout;
+  std::ostream &out = output_file.stream();
 
   switch(ui_message_handler.get_ui())
   {
@@ -213,7 +202,4 @@ void show_vcc(
     }
     break;
   }
-
-  if(have_file)
-    of.close();
 }

--- a/src/util/Makefile
+++ b/src/util/Makefile
@@ -100,6 +100,7 @@ SRC = \
       symbol.cpp \
       symbol_table_base.cpp \
       symbol_table.cpp \
+      output_file.cpp \
       tempdir.cpp \
       tempfile.cpp \
       threeval.cpp \

--- a/src/util/output_file.cpp
+++ b/src/util/output_file.cpp
@@ -1,0 +1,36 @@
+/*******************************************************************\
+
+Module: Output File Container
+
+Author: Daniel Kroening, dkr@amazon.com
+
+\*******************************************************************/
+
+/// \file
+/// Output file container that handles stdout ("-") and regular files
+
+#include "output_file.h"
+
+#include "exception_utils.h"
+#include "unicode.h"
+
+#include <fstream>
+#include <iostream>
+
+output_filet::output_filet(std::string file_name) : _name(std::move(file_name))
+{
+  if(_name == "-")
+  {
+    _stream = &std::cout;
+    _name = "stdout";
+  }
+  else
+  {
+    _ofstream = std::make_unique<std::ofstream>(widen_if_needed(_name));
+    if(!*_ofstream)
+      throw system_exceptiont("failed to open " + _name);
+    _stream = _ofstream.get();
+  }
+}
+
+output_filet::~output_filet() = default;

--- a/src/util/output_file.h
+++ b/src/util/output_file.h
@@ -1,0 +1,52 @@
+/*******************************************************************\
+
+Module: Output File Container
+
+Author: Daniel Kroening, dkr@amazon.com
+
+\*******************************************************************/
+
+#ifndef CPROVER_UTIL_OUTPUT_FILE_H
+#define CPROVER_UTIL_OUTPUT_FILE_H
+
+/// \file
+/// Output file container that handles stdout ("-") and regular files
+
+#include <iosfwd>
+#include <memory>
+#include <string>
+
+/// RAII container for an output stream that is either stdout or a file.
+/// Pass "-" as the file name to write to stdout.
+class output_filet final
+{
+public:
+  /// Create a stream to the given file name, or stdout if "-".
+  /// Throws system_exceptiont if the file cannot be opened.
+  explicit output_filet(std::string file_name);
+  ~output_filet();
+
+  std::ostream &stream()
+  {
+    return *_stream;
+  }
+
+  /// The name of the file, or "stdout".
+  const std::string &name() const
+  {
+    return _name;
+  }
+
+  /// True if the output is a file (not stdout).
+  bool is_file() const
+  {
+    return _ofstream != nullptr;
+  }
+
+private:
+  std::string _name;
+  std::unique_ptr<std::ofstream> _ofstream;
+  std::ostream *_stream = nullptr;
+};
+
+#endif // CPROVER_UTIL_OUTPUT_FILE_H

--- a/unit/Makefile
+++ b/unit/Makefile
@@ -183,6 +183,7 @@ SRC += analyses/ai/ai.cpp \
        util/memory_info.cpp \
        util/message.cpp \
        util/optional_utils.cpp \
+       util/output_file.cpp \
        util/parse_options.cpp \
        util/piped_process.cpp \
        util/pointer_expr.cpp \

--- a/unit/util/output_file.cpp
+++ b/unit/util/output_file.cpp
@@ -1,0 +1,51 @@
+/*******************************************************************\
+
+Module: Output File Container
+
+Author: Daniel Kroening, dkr@amazon.com
+
+\*******************************************************************/
+
+/// \file
+/// output_filet unit tests
+
+#include <util/exception_utils.h>
+#include <util/output_file.h>
+#include <util/tempfile.h>
+
+#include <testing-utils/use_catch.h>
+
+#include <fstream>
+
+TEST_CASE("output_filet writes to file", "[core][util][output_file]")
+{
+  temporary_filet tmp("output_filet_test", ".txt");
+  const std::string filename = tmp();
+
+  {
+    output_filet out(filename);
+    REQUIRE(out.name() == filename);
+    REQUIRE(out.is_file());
+    out.stream() << "hello";
+  }
+
+  std::ifstream in(filename);
+  std::string content;
+  std::getline(in, content);
+  REQUIRE(content == "hello");
+}
+
+TEST_CASE("output_filet stdout for dash", "[core][util][output_file]")
+{
+  output_filet out("-");
+  REQUIRE(out.name() == "stdout");
+  REQUIRE_FALSE(out.is_file());
+}
+
+TEST_CASE("output_filet throws on invalid path", "[core][util][output_file]")
+{
+  temporary_filet tmp("output_filet_test", "");
+  // Use the temp file path as a "directory" — opening a file beneath it fails
+  const std::string bad_path = tmp() + "/file.txt";
+  REQUIRE_THROWS_AS(output_filet(bad_path), system_exceptiont);
+}


### PR DESCRIPTION
Promote output_filet from hw-cbmc's ebmc to src/util for reuse across CBMC. The class provides RAII management of output streams, mapping "-" to stdout and opening files otherwise.

Use output_filet in show_vcc.cpp and show_program.cpp to replace duplicated open-file-or-stdout boilerplate.

Add unit tests for file output, stdout mapping, and error handling.

Not yet refactored:
- solver_factory.cpp: open_outfile_and_check returns unique_ptr<ofstream>
  that gets moved into solver objects; converting would touch the solvert
  ownership model.
- cprover_parse_options.cpp: uses a different pattern (no "-" support, returns error code instead of throwing).

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
