### PR TITLE
Fix extractbits invariant for non-byte-aligned bitfields

### DIFF
--- a/regression/cbmc/byte_extract1/extractbits-bitfield.c
+++ b/regression/cbmc/byte_extract1/extractbits-bitfield.c
@@ -1,0 +1,14 @@
+// Regression test for issue #8581
+// When unpacking a non-byte-aligned bitfield into bytes, extractbits
+// operations were created that exceeded the source bitvector width.
+typedef a;
+union
+{
+  signed : 28;
+  signed : 25;
+  a *b;
+} c = {10};
+main()
+{
+  d();
+}

--- a/regression/cbmc/byte_extract1/extractbits-bitfield.desc
+++ b/regression/cbmc/byte_extract1/extractbits-bitfield.desc
@@ -1,0 +1,11 @@
+CORE paths-lifo-expected-failure
+extractbits-bitfield.c
+
+^EXIT=10$
+^SIGNAL=0$
+--
+Invariant check failed
+--
+This example previously failed the DATA_INVARIANT "index+width-1 of extractbits
+must be within the bitvector" when unpacking a non-byte-aligned bitfield into
+bytes (see issue #8581).

--- a/src/util/lower_byte_operators.cpp
+++ b/src/util/lower_byte_operators.cpp
@@ -1068,8 +1068,22 @@ static exprt unpack_rec(
       }
     }
 
-    auto const src_as_bitvector = typecast_exprt::conditional_cast(
+    // When the source width is not a multiple of the byte size, round up
+    // to the next byte boundary and zero-extend the source so that all
+    // byte-sized extractbits operations remain within bounds. The padding
+    // bits (the high bits of the final partial byte) are unspecified and are
+    // filled with zero.
+    const mp_integer padded_bits =
+      total_bits % bits_per_byte == 0
+        ? total_bits
+        : total_bits + bits_per_byte - total_bits % bits_per_byte;
+    exprt src_as_bitvector = typecast_exprt::conditional_cast(
       src, bv_typet{numeric_cast_v<std::size_t>(total_bits)});
+    if(padded_bits > total_bits)
+    {
+      src_as_bitvector = zero_extend_exprt{
+        src_as_bitvector, bv_typet{numeric_cast_v<std::size_t>(padded_bits)}};
+    }
     auto const byte_type = bv_typet{bits_per_byte};
     exprt::operandst byte_operands;
     array_typet array_type{


### PR DESCRIPTION
When unpacking a non-byte-aligned bitfield (e.g., 28 bits) into bytes, the unpack_rec function in lower_byte_operators.cpp created byte-sized extractbits operations that could exceed the source bitvector width. For a 28-bit source, the last byte extraction at offset 24 would try to read bits 24-31, but only bits 0-27 exist. The simplifier then merged these adjacent extractbits into a single extractbits(src, 0, bv[32]) from a 28-bit source, violating the DATA_INVARIANT in convert_extractbits.

Fix by zero-extending the source to the next byte boundary before creating byte-sized extractbits, so all extractions stay within bounds. Restore the original DATA_INVARIANT that correctly detects malformed extractbits expressions.

The regression test was minimised from CSmith seed 1736798452 using creduce.

Fixes: #8581

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
