### PR TITLE
Set paths-symex-explore-all when unwinding-assertions defaults to true

### DIFF
--- a/regression/book-examples/CMakeLists.txt
+++ b/regression/book-examples/CMakeLists.txt
@@ -13,7 +13,7 @@ add_test_pl_tests(
 add_test_pl_profile(
     "book-examples-paths-lifo"
     "$<TARGET_FILE:cbmc> --paths lifo"
-    "-C;-X;thorough-paths;-X;smt-backend;-X;paths-lifo-expected-failure;${gcc_only_string}-s;paths-lifo"
+    "-C;-X;thorough-paths;-X;smt-backend;${gcc_only_string}-s;paths-lifo"
     "CORE"
 )
 

--- a/regression/book-examples/Makefile
+++ b/regression/book-examples/Makefile
@@ -26,7 +26,7 @@ test-z3:
 
 test-paths-lifo:
 	@../test.pl -e -p -c "../../../src/cbmc/cbmc --paths lifo" \
-					  -X thorough-paths -X smt-backend -X paths-lifo-expected-failure \
+					  -X thorough-paths -X smt-backend \
 					  -s paths-lifo $(GCC_ONLY)
 
 test-new-smt-backend:

--- a/regression/cbmc/Array_operations4/program-only.desc
+++ b/regression/cbmc/Array_operations4/program-only.desc
@@ -1,4 +1,4 @@
-CORE paths-lifo-expected-failure
+CORE
 main.c
 --program-only
 target!0@1#2 ==

--- a/regression/cbmc/array-cell-sensitivity15/test.desc
+++ b/regression/cbmc/array-cell-sensitivity15/test.desc
@@ -1,4 +1,4 @@
-CORE paths-lifo-expected-failure
+CORE
 access.c
 --program-only
 ^EXIT=0$

--- a/regression/cbmc/cover-failed-assertions/test-no-failed-assertions.desc
+++ b/regression/cbmc/cover-failed-assertions/test-no-failed-assertions.desc
@@ -13,3 +13,4 @@ test.c
 --
 This is checking that without the --cover-failed-assertions flag we still get the same result as we did before adding
 it in this example.
+--paths mode explores one path at a time, so individual paths may not cover all blocks.

--- a/regression/cbmc/cover-failed-assertions/test.desc
+++ b/regression/cbmc/cover-failed-assertions/test.desc
@@ -11,3 +11,4 @@ test.c
 ^warning: ignoring
 --
 This is checking that the if statement body can actually be covered with the new flag
+--paths mode explores one path at a time, so individual paths may not cover all blocks.

--- a/regression/cbmc/fault_localization-stop_on_fail1/test.desc
+++ b/regression/cbmc/fault_localization-stop_on_fail1/test.desc
@@ -7,3 +7,6 @@ main.c
 line . function main$
 ^VERIFICATION FAILED$
 --
+--
+--paths mode explores paths in a different order, finding a different failing
+assertion first, which changes the fault localization output.

--- a/regression/cbmc/outfile_no_dir/test.desc
+++ b/regression/cbmc/outfile_no_dir/test.desc
@@ -1,4 +1,4 @@
-CORE paths-lifo-expected-failure broken-z3-smt-backend broken-cprover-smt-backend no-new-smt
+CORE broken-z3-smt-backend broken-cprover-smt-backend no-new-smt
 main.c
 --dimacs --outfile /xyz/out.dimacs
 ^EXIT=1$

--- a/regression/cbmc/paths-lifo-no-body-callee/main.c
+++ b/regression/cbmc/paths-lifo-no-body-callee/main.c
@@ -1,0 +1,13 @@
+// Calling a function without a body produces a "no body for callee" assertion
+// that is generated during symbolic execution rather than collected from the
+// goto program up front. With no other (statically known) property present,
+// the single-path checker's has_finished_exploration would report completion
+// before exploring any path unless paths-symex-explore-all is set, so under
+// --paths lifo this property must still be reported as failing.
+void no_body(void);
+
+int main()
+{
+  no_body();
+  return 0;
+}

--- a/regression/cbmc/paths-lifo-no-body-callee/test.desc
+++ b/regression/cbmc/paths-lifo-no-body-callee/test.desc
@@ -1,0 +1,16 @@
+CORE
+main.c
+--paths lifo
+^\[main\.no-body\.no_body\] line 11 no body for callee no_body: FAILURE$
+^VERIFICATION FAILED$
+^EXIT=10$
+^SIGNAL=0$
+--
+^warning: ignoring
+//
+// Regression test for the soundness fix: the only failing property here is the
+// dynamically generated "no body for callee" assertion, which is absent from
+// the initial properties map. Before paths-symex-explore-all was defaulted in
+// lock-step with unwinding-assertions, --paths lifo reported VERIFICATION
+// SUCCESSFUL because has_finished_exploration terminated before exploring any
+// path. It must now report VERIFICATION FAILED.

--- a/regression/cbmc/sat-solver-error/test.desc
+++ b/regression/cbmc/sat-solver-error/test.desc
@@ -1,4 +1,4 @@
-CORE broken-z3-smt-backend broken-cprover-smt-backend paths-lifo-expected-failure no-new-smt
+CORE broken-z3-smt-backend broken-cprover-smt-backend no-new-smt
 test.c
 --sat-solver non-existing-solver
 ^EXIT=1$

--- a/regression/cbmc/unreachable-goto2/test-vccs.desc
+++ b/regression/cbmc/unreachable-goto2/test-vccs.desc
@@ -1,4 +1,4 @@
-CORE paths-lifo-expected-failure
+CORE
 test.c
 --show-vcc --verbosity 8
 ^Generated 1 VCC\(s\), 1 remaining after simplification$

--- a/src/cbmc/cbmc_parse_options.cpp
+++ b/src/cbmc/cbmc_parse_options.cpp
@@ -12,9 +12,11 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "cbmc_parse_options.h"
 
 #include <util/config.h>
+#include <util/exception_utils.h>
 #include <util/exit_codes.h>
 #include <util/help_formatter.h>
 #include <util/invariant.h>
+#include <util/output_file.h>
 #include <util/unicode.h>
 #include <util/version.h>
 
@@ -124,6 +126,16 @@ void cbmc_parse_optionst::set_default_analysis_flags(
   if(!options.is_set("unwinding-assertions"))
   {
     options.set_option("unwinding-assertions", enabled);
+    // Keep paths-symex-explore-all in lock-step with unwinding-assertions, as
+    // the explicit --[no-]unwinding-assertions handling does too. In --paths
+    // mode, has_finished_exploration may report completion before any path is
+    // explored when no property remains in the initial properties map. The
+    // only verification conditions generated during symex that are absent from
+    // that initial map -- loop and recursion unwinding assertions and the "no
+    // body for callee" assertion -- are all themselves gated on
+    // unwinding-assertions, so exploring all paths is required exactly when
+    // unwinding-assertions is enabled.
+    options.set_option("paths-symex-explore-all", enabled);
   }
 
   if(enabled)
@@ -682,6 +694,26 @@ int cbmc_parse_optionst::doit()
   if(
     options.get_bool_option("dimacs") || !options.get_option("outfile").empty())
   {
+    // Validate outfile path early so that errors are reported even when
+    // single-path symex simplifies away all VCCs (and thus never creates the
+    // solver, where solver_factoryt::open_outfile_and_check would otherwise
+    // report this same error). This intentionally opens (and truncates) the
+    // file purely for validation; it is opened again later for the actual
+    // write, so an empty file may be left behind if a later stage fails first.
+    const std::string outfile = options.get_option("outfile");
+    if(!outfile.empty() && outfile != "-")
+    {
+      try
+      {
+        output_filet{outfile};
+      }
+      catch(const system_exceptiont &)
+      {
+        throw invalid_command_line_argument_exceptiont(
+          "failed to open file: " + outfile, "--outfile");
+      }
+    }
+
     if(options.get_bool_option("paths"))
     {
       stop_on_fail_verifiert<single_path_symex_checkert> verifier(

--- a/src/goto-checker/solver_factory.cpp
+++ b/src/goto-checker/solver_factory.cpp
@@ -32,6 +32,7 @@ Author: Daniel Kroening, Peter Schrammel
 #include <solvers/strings/string_refinement.h>
 
 #include <iostream>
+#include <set>
 #include <vector>
 
 solver_factoryt::solver_factoryt(
@@ -161,6 +162,33 @@ smt2_dect::solvert solver_factoryt::get_smt2_solver_type() const
   return s;
 }
 
+/// The set of SAT solver names accepted on the command line. This is the
+/// single source of truth for known solver names: the dispatch chain in
+/// \ref get_sat_solver must handle exactly these names (enforced by an
+/// INVARIANT there), so keep the two in sync when adding or removing a solver.
+static const std::set<std::string> &known_sat_solver_names()
+{
+  static const std::set<std::string> names = {
+    "zchaff",
+    "booleforce",
+    "minisat1",
+    "minisat2",
+    "ipasir",
+    "picosat",
+    "lingeling",
+    "glucose",
+    "cadical"};
+  return names;
+}
+
+/// Check whether \p solver_name is a known SAT solver name. A solver may be
+/// known but not compiled in (in which case \ref get_sat_solver will fall back
+/// to the default solver with a warning).
+static bool is_known_sat_solver_name(const std::string &solver_name)
+{
+  return known_sat_solver_names().count(solver_name) != 0;
+}
+
 /// Emit a warning for non-existent solver \p solver via \p message_handler.
 static void emit_solver_warning(
   message_handlert &message_handler,
@@ -216,6 +244,8 @@ get_sat_solver(message_handlert &message_handler, const optionst &options)
   if(options.is_set("sat-solver"))
   {
     const std::string &solver_option = options.get_option("sat-solver");
+    // This dispatch must handle exactly the names in known_sat_solver_names();
+    // the INVARIANT in the trailing else-branch guards against drift.
     if(solver_option == "zchaff")
     {
 #if defined SATCHECK_ZCHAFF
@@ -311,6 +341,9 @@ get_sat_solver(message_handlert &message_handler, const optionst &options)
     }
     else
     {
+      INVARIANT(
+        !is_known_sat_solver_name(solver_option),
+        "known solver names should be handled above");
       messaget log(message_handler);
       log.error() << "unknown solver '" << solver_option << "'"
                   << messaget::eom;
@@ -622,7 +655,16 @@ static void parse_sat_options(const cmdlinet &cmdline, optionst &options)
     options.set_option("dimacs", true);
 
   if(cmdline.isset("sat-solver"))
-    options.set_option("sat-solver", cmdline.get_value("sat-solver"));
+  {
+    const std::string solver = cmdline.get_value("sat-solver");
+    options.set_option("sat-solver", solver);
+
+    if(!is_known_sat_solver_name(solver))
+    {
+      throw invalid_command_line_argument_exceptiont(
+        "unknown solver '" + solver + "'", "--sat-solver");
+    }
+  }
 }
 
 static void parse_smt2_options(const cmdlinet &cmdline, optionst &options)


### PR DESCRIPTION
When unwinding-assertions is enabled by default (via set_default_analysis_flags), paths-symex-explore-all must also be enabled. Otherwise, the single-path symex checker's has_finished_exploration check can return true before any path is explored, because dynamically generated properties (like 'no body for callee') don't exist in the initial properties map.

The explicit --unwinding-assertions flag already set paths-symex-explore-all, but the default enablement path did not, causing --paths lifo to miss no-body assertions. The coupling is sound: the only verification conditions generated during symex that are absent from the initial properties map -- loop and recursion unwinding assertions and the no-body-callee assertion -- are themselves gated on unwinding-assertions.

This also fixes two pre-existing bugs exposed by the exploration fix: an invalid --outfile path and an invalid --sat-solver name were both silently ignored in --paths mode (the solver, and thus the file, was never created when all VCCs were simplified away). Both are now validated early.

regression/cbmc/paths-lifo-no-body-callee is a direct regression test for the soundness fix: it reports VERIFICATION SUCCESSFUL before the fix and FAILED afterwards under --paths lifo. Five further tests previously tagged paths-lifo-expected-failure now pass with --paths lifo, so the tag is removed from those five .desc files. The exclusion in regression/cbmc is retained (other .desc files there still use the tag), while the now-unused exclusion in the book-examples test profiles (Makefile and CMakeLists.txt) is removed.

Co-authored-by: Kiro <kiro-agent@users.noreply.github.com>

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.
