### PR TITLE
Fix out-of-bounds read in MC/DC coverage eval_expr

### DIFF
--- a/src/goto-instrument/cover_instrument_mcdc.cpp
+++ b/src/goto-instrument/cover_instrument_mcdc.cpp
@@ -425,11 +425,12 @@ bool eval_expr(const std::map<exprt, signed> &atomic_exprs, const exprt &src)
   }
   else // if(is_condition(src))
   {
+    auto it = atomic_exprs.find(src);
     // ''src'' should be guaranteed to be consistent
     // with ''atomic_exprs''
-    if(atomic_exprs.find(src)->second == +1)
+    if(it != atomic_exprs.end() && it->second == +1)
       return true;
-    else // if(atomic_exprs.find(src)->second==-1)
+    else // if not found or second==-1
       return false;
   }
 }


### PR DESCRIPTION
The eval_expr function in cover_instrument_mcdc.cpp dereferences the result of std::map::find() without checking for end(). This happens when values_of_atomic_exprs skips inconsistent expressions (where signs.size() != 1), leaving them absent from the map. When eval_expr later encounters such an expression, find() returns end() and the dereference is undefined behavior (stack-buffer-overflow detected by AddressSanitizer).

Fix by checking the iterator before dereferencing.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
