### PR TITLE
Avoid invalid shift caused by excessive object bits

### DIFF
--- a/regression/cbmc-incr-smt2/object-bits-too-many/test.c
+++ b/regression/cbmc-incr-smt2/object-bits-too-many/test.c
@@ -1,0 +1,16 @@
+#include <assert.h>
+#include <stdlib.h>
+
+// Regression test for the object-bits bound check in the incremental SMT2
+// backend (convert_expr_to_smt). Allocating more objects than 2^object_bits
+// must raise a graceful "too many addressed objects" diagnostic rather than an
+// invalid shift of std::size_t(1) by object_bits.
+int main()
+{
+  for(int i = 0; i < 20; ++i)
+  {
+    char *p = malloc(1);
+    assert(p != 0);
+  }
+  return 0;
+}

--- a/regression/cbmc-incr-smt2/object-bits-too-many/test.desc
+++ b/regression/cbmc-incr-smt2/object-bits-too-many/test.desc
@@ -1,0 +1,7 @@
+CORE
+test.c
+--object-bits 2 --unwind 25
+too many addressed objects: maximum number of objects is set to 2\^n=4 \(with n=2\)
+^EXIT=6$
+^SIGNAL=0$
+--

--- a/src/cprover/bv_pointers_wide.cpp
+++ b/src/cprover/bv_pointers_wide.cpp
@@ -11,6 +11,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/arith_tools.h>
 #include <util/byte_operators.h>
 #include <util/c_types.h>
+#include <util/config.h>
 #include <util/exception_utils.h>
 #include <util/expr_util.h>
 #include <util/namespace.h>
@@ -850,14 +851,7 @@ bvt bv_pointers_widet::add_addr(const exprt &expr)
 
   const pointer_typet type = pointer_type(expr.type());
   const std::size_t object_bits = get_object_width(type);
-  const std::size_t max_objects = std::size_t(1) << object_bits;
-
-  if(a == max_objects)
-    throw analysis_exceptiont(
-      "too many addressed objects: maximum number of objects is set to 2^n=" +
-      std::to_string(max_objects) + " (with n=" + std::to_string(object_bits) +
-      "); " +
-      "use the `--object-bits n` option to increase the maximum number");
+  check_object_bits_bound(a, object_bits);
 
   return encode(a, type);
 }

--- a/src/solvers/flattening/bv_pointers.cpp
+++ b/src/solvers/flattening/bv_pointers.cpp
@@ -12,7 +12,6 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/byte_operators.h>
 #include <util/c_types.h>
 #include <util/config.h>
-#include <util/exception_utils.h>
 #include <util/namespace.h>
 #include <util/pointer_expr.h>
 #include <util/pointer_offset_size.h>
@@ -882,14 +881,7 @@ bvt bv_pointerst::add_addr(const exprt &expr)
 
   const pointer_typet type = pointer_type(expr.type());
   const std::size_t object_bits = get_object_width(type);
-  const std::size_t max_objects=std::size_t(1)<<object_bits;
-
-  if(a==max_objects)
-    throw analysis_exceptiont(
-      "too many addressed objects: maximum number of objects is set to 2^n=" +
-      std::to_string(max_objects) + " (with n=" + std::to_string(object_bits) +
-      "); " +
-      "use the `--object-bits n` option to increase the maximum number");
+  check_object_bits_bound(a, object_bits);
 
   return encode(a, type);
 }

--- a/src/solvers/smt2/smt2_conv.cpp
+++ b/src/solvers/smt2/smt2_conv.cpp
@@ -842,17 +842,8 @@ void smt2_convt::convert_address_of_rec(
     expr.id() == ID_string_constant || expr.id() == ID_label)
   {
     const std::size_t object_bits = config.bv_encoding.object_bits;
-    const std::size_t max_objects = std::size_t(1) << object_bits;
     const mp_integer object_id = pointer_logic.add_object(expr);
-
-    if(object_id >= max_objects)
-    {
-      throw analysis_exceptiont{
-        "too many addressed objects: maximum number of objects is set to 2^n=" +
-        std::to_string(max_objects) +
-        " (with n=" + std::to_string(object_bits) + "); " +
-        "use the `--object-bits n` option to increase the maximum number"};
-    }
+    check_object_bits_bound(object_id, object_bits);
 
     out << "(concat (_ bv" << object_id << " " << object_bits << ")"
         << " (_ bv0 " << boolbv_width(result_type) - object_bits << "))";

--- a/src/solvers/smt2_incremental/convert_expr_to_smt.cpp
+++ b/src/solvers/smt2_incremental/convert_expr_to_smt.cpp
@@ -888,21 +888,16 @@ static smt_termt convert_expr_to_smt(
     "Objects should be tracked before converting their address to SMT terms");
   const std::size_t object_id = object->second.unique_id;
   const std::size_t object_bits = config.bv_encoding.object_bits;
-  const std::size_t max_objects = std::size_t(1) << object_bits;
-  if(object_id >= max_objects)
-  {
-    throw analysis_exceptiont{
-      "too many addressed objects: maximum number of objects is set to 2^n=" +
-      std::to_string(max_objects) + " (with n=" + std::to_string(object_bits) +
-      "); " +
-      "use the `--object-bits n` option to increase the maximum number"};
-  }
+  check_object_bits_bound(object_id, object_bits);
   const smt_termt object_bit_vector =
     smt_bit_vector_constant_termt{object_id, object_bits};
-  INVARIANT(
-    type->get_width() > object_bits,
-    "Pointer should be wider than object_bits in order to allow for offset "
-    "encoding.");
+  if(type->get_width() <= object_bits)
+  {
+    throw analysis_exceptiont{
+      "pointer width " + std::to_string(type->get_width()) +
+      " must be greater than object_bits (" + std::to_string(object_bits) +
+      ") to allow for offset encoding"};
+  }
   const size_t offset_bits = type->get_width() - object_bits;
   if(expr_try_dynamic_cast<symbol_exprt>(address_of.object()))
   {

--- a/src/util/config.cpp
+++ b/src/util/config.cpp
@@ -860,6 +860,20 @@ configt::bv_encodingt parse_object_bits_encoding(
   return bv_encoding;
 }
 
+void check_object_bits_bound(
+  const mp_integer &object_id,
+  std::size_t object_bits)
+{
+  const mp_integer max_objects = power(2, object_bits);
+  if(object_id >= max_objects)
+  {
+    throw analysis_exceptiont{
+      "too many addressed objects: maximum number of objects is set to 2^n=" +
+      integer2string(max_objects) + " (with n=" + std::to_string(object_bits) +
+      "); use the `--object-bits n` option to increase the maximum number"};
+  }
+}
+
 bool configt::set(const cmdlinet &cmdline)
 {
   // defaults -- we match the architecture we have ourselves

--- a/src/util/config.h
+++ b/src/util/config.h
@@ -409,4 +409,14 @@ private:
 
 extern configt config;
 
+/// Throw an analysis_exceptiont when more objects have been addressed than can
+/// be represented in \p object_bits bits, i.e. when
+/// \p object_id `>= 2^object_bits`. The number of object bits is governed by
+/// the analysis *target* and may exceed the analysis-execution platform's
+/// integer width, so the bound is computed using mp_integer to avoid an
+/// invalid shift.
+void check_object_bits_bound(
+  const mp_integer &object_id,
+  std::size_t object_bits);
+
 #endif // CPROVER_UTIL_CONFIG_H


### PR DESCRIPTION
Use mp_integer to compute the number of permitted objects as the number of object bits is related to the analysis target platform and need not be within the analysis-execution platform's limits.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
