### PR TITLE
Initialise all POD members of goto_symex_statet

### DIFF
--- a/src/goto-symex/goto_symex_state.h
+++ b/src/goto-symex/goto_symex_state.h
@@ -68,7 +68,7 @@ public:
 
   // Manager is required to be able to resize the thread vector
   guard_managert &guard_manager;
-  symex_target_equationt *symex_target;
+  symex_target_equationt *symex_target = nullptr;
 
   symex_level1t level1;
 
@@ -217,14 +217,14 @@ public:
   goto_programt::const_targett saved_target;
 
   /// \brief This state is saved, with the PC pointing to the target of a GOTO
-  bool has_saved_jump_target;
+  bool has_saved_jump_target = false;
 
   /// \brief This state is saved, with the PC pointing to the next instruction
   /// of a GOTO
-  bool has_saved_next_instruction;
+  bool has_saved_next_instruction = false;
 
   /// \brief Should the additional validation checks be run?
-  bool run_validation_checks;
+  bool run_validation_checks = false;
 
   unsigned total_vccs = 0;
   unsigned remaining_vccs = 0;


### PR DESCRIPTION
The constructor did not take care of them and our unit tests exposed that, at least within unit tests, we were accessing uninitialised members.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
