### PR TITLE
Investigate slow test root causes: OS vs solver

### DIFF
--- a/.github/workflows/bsd.yaml
+++ b/.github/workflows/bsd.yaml
@@ -3,7 +3,7 @@ on:
   push:
     branches: [ develop ]
   pull_request:
-    branches: [ develop ]
+    branches: [ disabled-for-investigation ]
 
 jobs:
   # This job takes approximately 6 to 26 minutes

--- a/.github/workflows/build-and-test-Xen.yaml
+++ b/.github/workflows/build-and-test-Xen.yaml
@@ -2,7 +2,7 @@ name: Build Xen with CPROVER tools
 
 on:
   pull_request:
-    branches: [ develop ]
+    branches: [ disabled-for-investigation ]
 
 jobs:
   # This job takes approximately 33 minutes

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ develop ]
   pull_request:
-    branches: [ develop ]
+    branches: [ disabled-for-investigation ]
 
 jobs:
   # This job takes approximately 82 minutes

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -3,7 +3,7 @@ on:
   push:
     branches: [ develop ]
   pull_request:
-    branches: [ develop ]
+    branches: [ disabled-for-investigation ]
 env:
   cvc5-version: "1.2.1"
   linux-vcpus: 4

--- a/.github/workflows/csmith.yaml
+++ b/.github/workflows/csmith.yaml
@@ -2,7 +2,7 @@ name: Run CSmith
 
 on:
   pull_request:
-    branches: [ develop ]
+    branches: [ disabled-for-investigation ]
 
 jobs:
   # This job takes approximately 18 minutes

--- a/.github/workflows/doxygen-check.yaml
+++ b/.github/workflows/doxygen-check.yaml
@@ -1,7 +1,7 @@
 name: Build Doxygen Documentation
 on:
   pull_request:
-    branches: [ develop ]
+    branches: [ disabled-for-investigation ]
 
 jobs:
   # This job takes approximately 2 minutes

--- a/.github/workflows/investigate-slow-tests.yaml
+++ b/.github/workflows/investigate-slow-tests.yaml
@@ -1,0 +1,216 @@
+# Temporary workflow to investigate why 4 tests are extremely slow on
+# certain platforms. Tests OS vs solver to determine root cause.
+#
+# Round 1 (completed): normal pass — {Linux, macOS} × {minisat2, cadical}
+#   Result: No OS difference. CaDiCaL ~5x slower for pid/C11. All times <20s.
+#   The extreme slowness (1950s StringSubstring, 1069s pid/C11) was NOT in
+#   the normal pass.
+#
+# Round 2: investigate the actual slow configurations:
+#   - StringSubstring & pid/C11 with --symex-driven-lazy-loading
+#   - assigns-local-composite with --cprover-smt2 backend
+#   - pid/C11 with --cprover-smt2 backend
+#   All across {Linux, macOS} × {minisat2, cadical}
+#
+# Round 1 also confirmed: large_array_of_struct_nondet_index is a Windows
+# platform issue (473s vs 3s), not solver-related. No further investigation.
+
+name: Investigate slow tests
+on:
+  pull_request:
+    branches: [ develop ]
+
+env:
+  cvc5-version: "1.2.1"
+
+jobs:
+  linux-minisat2:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: recursive
+      - name: Fetch dependencies
+        env:
+          DEBIAN_FRONTEND: noninteractive
+        run: |
+          sudo apt-get update
+          sudo apt-get install --no-install-recommends -yq cmake ninja-build gcc g++ flex bison maven ccache
+      - name: Build with minisat2
+        run: |
+          cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release -Dsat_impl=minisat2
+          cmake --build build -j$(nproc)
+      - name: Test StringSubstring
+        run: cd jbmc/regression/jbmc-strings && time ../../../regression/test.pl -e -p -c "../../../../build/bin/jbmc --validate-goto-model --validate-ssa-equation" -C StringSubstring
+      - name: Test pid/C11
+        run: cd regression/book-examples && time ../test.pl -e -p -c "../../../build/bin/cbmc --validate-goto-model --validate-ssa-equation" -C pid
+      - name: Test assigns-local-composite
+        run: cd regression/contracts-dfcc && time ../test.pl -e -p -c '../chain.sh ../../../build/bin/goto-cc ../../../build/bin/goto-instrument ../../../build/bin/cbmc false true' -C assigns-local-composite
+      - name: Test StringSubstring (symex-driven-lazy-loading)
+        run: cd jbmc/regression/jbmc-strings && time ../../../regression/test.pl -e -p -c "../../../../build/bin/jbmc --validate-goto-model --validate-ssa-equation --symex-driven-lazy-loading" -C StringSubstring
+      - name: Test pid/C11 (cprover-smt2)
+        run: |
+          export PATH=$PATH:$PWD/build/bin
+          cd regression/book-examples && time ../test.pl -e -p -c "../../../build/bin/cbmc --cprover-smt2" -C pid
+      - name: Test assigns-local-composite (cprover-smt2)
+        run: |
+          export PATH=$PATH:$PWD/build/bin
+          cd regression/contracts-dfcc && time ../test.pl -e -p -c '../chain.sh ../../../build/bin/goto-cc ../../../build/bin/goto-instrument "../../../build/bin/cbmc --cprover-smt2" false true' -C assigns-local-composite
+
+  linux-cadical:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: recursive
+      - name: Fetch dependencies
+        env:
+          DEBIAN_FRONTEND: noninteractive
+        run: |
+          sudo apt-get update
+          sudo apt-get install --no-install-recommends -yq cmake ninja-build gcc g++ flex bison maven ccache
+      - name: Build with cadical
+        run: |
+          cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release -Dsat_impl=cadical
+          cmake --build build -j$(nproc)
+      - name: Test StringSubstring
+        run: cd jbmc/regression/jbmc-strings && time ../../../regression/test.pl -e -p -c "../../../../build/bin/jbmc --validate-goto-model --validate-ssa-equation" -C StringSubstring
+      - name: Test pid/C11
+        run: cd regression/book-examples && time ../test.pl -e -p -c "../../../build/bin/cbmc --validate-goto-model --validate-ssa-equation" -C pid
+      - name: Test assigns-local-composite
+        run: cd regression/contracts-dfcc && time ../test.pl -e -p -c '../chain.sh ../../../build/bin/goto-cc ../../../build/bin/goto-instrument ../../../build/bin/cbmc false true' -C assigns-local-composite
+      - name: Test StringSubstring (symex-driven-lazy-loading)
+        run: cd jbmc/regression/jbmc-strings && time ../../../regression/test.pl -e -p -c "../../../../build/bin/jbmc --validate-goto-model --validate-ssa-equation --symex-driven-lazy-loading" -C StringSubstring
+      - name: Test pid/C11 (cprover-smt2)
+        run: |
+          export PATH=$PATH:$PWD/build/bin
+          cd regression/book-examples && time ../test.pl -e -p -c "../../../build/bin/cbmc --cprover-smt2" -C pid
+      - name: Test assigns-local-composite (cprover-smt2)
+        run: |
+          export PATH=$PATH:$PWD/build/bin
+          cd regression/contracts-dfcc && time ../test.pl -e -p -c '../chain.sh ../../../build/bin/goto-cc ../../../build/bin/goto-instrument "../../../build/bin/cbmc --cprover-smt2" false true' -C assigns-local-composite
+
+  macos-minisat2:
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: recursive
+      - name: Fetch dependencies
+        run: brew install ninja maven flex bison ccache
+      - name: Build with minisat2
+        run: |
+          cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_C_COMPILER=/usr/bin/clang \
+            -DCMAKE_CXX_COMPILER=/usr/bin/clang++ \
+            -Dsat_impl=minisat2
+          cmake --build build -j3
+      - name: Test StringSubstring
+        run: cd jbmc/regression/jbmc-strings && time ../../../regression/test.pl -e -p -c "../../../../build/bin/jbmc --validate-goto-model --validate-ssa-equation" -C StringSubstring
+      - name: Test pid/C11
+        run: cd regression/book-examples && time ../test.pl -e -p -c "../../../build/bin/cbmc --validate-goto-model --validate-ssa-equation" -C pid
+      - name: Test assigns-local-composite
+        run: cd regression/contracts-dfcc && time ../test.pl -e -p -c '../chain.sh ../../../build/bin/goto-cc ../../../build/bin/goto-instrument ../../../build/bin/cbmc false true' -C assigns-local-composite
+      - name: Test StringSubstring (symex-driven-lazy-loading)
+        run: cd jbmc/regression/jbmc-strings && time ../../../regression/test.pl -e -p -c "../../../../build/bin/jbmc --validate-goto-model --validate-ssa-equation --symex-driven-lazy-loading" -C StringSubstring
+      - name: Test pid/C11 (cprover-smt2)
+        run: |
+          export PATH=$PATH:$PWD/build/bin
+          cd regression/book-examples && time ../test.pl -e -p -c "../../../build/bin/cbmc --cprover-smt2" -C pid
+      - name: Test assigns-local-composite (cprover-smt2)
+        run: |
+          export PATH=$PATH:$PWD/build/bin
+          cd regression/contracts-dfcc && time ../test.pl -e -p -c '../chain.sh ../../../build/bin/goto-cc ../../../build/bin/goto-instrument "../../../build/bin/cbmc --cprover-smt2" false true' -C assigns-local-composite
+
+  macos-cadical:
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: recursive
+      - name: Fetch dependencies
+        run: brew install ninja maven flex bison ccache
+      - name: Build with cadical
+        run: |
+          cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_C_COMPILER=/usr/bin/clang \
+            -DCMAKE_CXX_COMPILER=/usr/bin/clang++ \
+            -Dsat_impl=cadical
+          cmake --build build -j3
+      - name: Test StringSubstring
+        run: cd jbmc/regression/jbmc-strings && time ../../../regression/test.pl -e -p -c "../../../../build/bin/jbmc --validate-goto-model --validate-ssa-equation" -C StringSubstring
+      - name: Test pid/C11
+        run: cd regression/book-examples && time ../test.pl -e -p -c "../../../build/bin/cbmc --validate-goto-model --validate-ssa-equation" -C pid
+      - name: Test assigns-local-composite
+        run: cd regression/contracts-dfcc && time ../test.pl -e -p -c '../chain.sh ../../../build/bin/goto-cc ../../../build/bin/goto-instrument ../../../build/bin/cbmc false true' -C assigns-local-composite
+      - name: Test StringSubstring (symex-driven-lazy-loading)
+        run: cd jbmc/regression/jbmc-strings && time ../../../regression/test.pl -e -p -c "../../../../build/bin/jbmc --validate-goto-model --validate-ssa-equation --symex-driven-lazy-loading" -C StringSubstring
+      - name: Test pid/C11 (cprover-smt2)
+        run: |
+          export PATH=$PATH:$PWD/build/bin
+          cd regression/book-examples && time ../test.pl -e -p -c "../../../build/bin/cbmc --cprover-smt2" -C pid
+      - name: Test assigns-local-composite (cprover-smt2)
+        run: |
+          export PATH=$PATH:$PWD/build/bin
+          cd regression/contracts-dfcc && time ../test.pl -e -p -c '../chain.sh ../../../build/bin/goto-cc ../../../build/bin/goto-instrument "../../../build/bin/cbmc --cprover-smt2" false true' -C assigns-local-composite
+
+  linux-incr-smt2:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: recursive
+      - name: Fetch dependencies
+        env:
+          DEBIAN_FRONTEND: noninteractive
+        run: |
+          sudo apt-get update
+          sudo apt-get install --no-install-recommends -yq cmake ninja-build gcc g++ flex bison ccache z3
+          wget -q https://github.com/cvc5/cvc5/releases/download/cvc5-${{env.cvc5-version}}/cvc5-Linux-x86_64-static.zip
+          unzip -j -d /usr/local/bin cvc5-Linux-x86_64-static.zip cvc5-Linux-x86_64-static/bin/cvc5
+          rm cvc5-Linux-x86_64-static.zip
+      - name: Build
+        run: |
+          cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release -Dsat_impl="minisat2;cadical"
+          cmake --build build -j$(nproc)
+      - name: Test large_array_of_struct_nondet_index
+        run: cd regression/cbmc-incr-smt2 && time ../test.pl -e -p -c "../../../build/bin/cbmc --incremental-smt2-solver 'z3 --smt2 -in'" -C structs
+      - name: Test large_array_of_struct_nondet_index (cvc5)
+        run: cd regression/cbmc-incr-smt2 && time ../test.pl -e -p -c "../../../build/bin/cbmc --incremental-smt2-solver 'cvc5 --lang smt2 --incremental'" -C structs
+
+  windows-incr-smt2:
+    runs-on: windows-2022
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: recursive
+      - uses: microsoft/setup-msbuild@v2
+      - uses: ilammy/msvc-dev-cmd@v1
+      - name: Fetch dependencies
+        run: |
+          choco install winflexbison3 strawberryperl -y
+          nuget install clcache -OutputDirectory "c:\tools" -ExcludeVersion -Version 4.1.0
+          echo "c:\tools\clcache\clcache-4.1.0" >> $env:GITHUB_PATH
+          Invoke-WebRequest -Uri https://github.com/Z3Prover/z3/releases/download/z3-4.8.10/z3-4.8.10-x64-win.zip -OutFile .\z3.zip
+          Expand-Archive -LiteralPath '.\z3.Zip' -DestinationPath C:\tools
+          echo "c:\tools\z3-4.8.10-x64-win\bin;" >> $env:GITHUB_PATH
+          New-Item -ItemType directory "C:\tools\cvc5"
+          Invoke-WebRequest -Uri https://github.com/cvc5/cvc5/releases/download/cvc5-${{env.cvc5-version}}/cvc5-Win64-x86_64-static.zip -OutFile .\cvc5.zip
+          Expand-Archive -LiteralPath '.\cvc5.zip'
+          Move-Item -Path .\cvc5\cvc5-Win64-x86_64-static\bin\cvc5.exe c:\tools\cvc5\cvc5.exe
+          echo "c:\tools\cvc5;" >> $env:GITHUB_PATH
+          echo "c:\Strawberry\" >> $env:GITHUB_PATH
+      - name: Configure and build
+        run: |
+          cmake -S . -B build
+          cmake --build build --config Release
+      - name: Test large_array_of_struct_nondet_index (z3)
+        shell: bash
+        run: |
+          cd regression/cbmc-incr-smt2
+          time perl ../test.pl -e -p -c "../../../build/bin/Release/cbmc --incremental-smt2-solver 'z3 --smt2 -in'" -C structs
+      - name: Test large_array_of_struct_nondet_index (cvc5)
+        shell: bash
+        run: |
+          cd regression/cbmc-incr-smt2
+          time perl ../test.pl -e -p -c "../../../build/bin/Release/cbmc --incremental-smt2-solver 'cvc5 --lang smt2 --incremental'" -C structs

--- a/.github/workflows/performance.yaml
+++ b/.github/workflows/performance.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ develop ]
   pull_request:
-    branches: [ develop ]
+    branches: [ disabled-for-investigation ]
 
 jobs:
   perf-benchcomp:

--- a/.github/workflows/pull-request-check-rust-api.yaml
+++ b/.github/workflows/pull-request-check-rust-api.yaml
@@ -3,7 +3,7 @@ on:
   push:
     branches: [ develop ]
   pull_request:
-    branches: [ develop ]
+    branches: [ disabled-for-investigation ]
 env:
   default_build_dir: "build/"
   default_solver: "minisat2"

--- a/.github/workflows/pull-request-checks.yaml
+++ b/.github/workflows/pull-request-checks.yaml
@@ -3,7 +3,7 @@ on:
   push:
     branches: [ develop ]
   pull_request:
-    branches: [ develop ]
+    branches: [ disabled-for-investigation ]
 env:
   cvc5-version: "1.2.1"
   linux-vcpus: 4

--- a/.github/workflows/syntax-checks.yaml
+++ b/.github/workflows/syntax-checks.yaml
@@ -1,7 +1,7 @@
 name: Syntactic checks
 on:
   pull_request:
-    branches: [ develop ]
+    branches: [ disabled-for-investigation ]
 
 jobs:
   # This job takes approximately 1 minute

--- a/investigate-slow-tests.md
+++ b/investigate-slow-tests.md
@@ -1,0 +1,90 @@
+# Investigation: Why Are 4 CI Tests Extremely Slow on Certain Platforms?
+
+Tracking PR: https://github.com/diffblue/cbmc/pull/8868
+
+These tests were moved from CORE to THOROUGH in commit 6e616e96 to reduce
+CI wall-clock time. This investigation determines the root cause of the
+slowness: is it the operating system, the SAT/SMT solver, or a specific
+CBMC mode?
+
+## Tests Under Investigation
+
+| # | Test | Reported slowness |
+|---|------|-------------------|
+| 1 | `jbmc-strings/StringSubstring/test.desc` | macOS-14: 1950s, Linux: 3s (650×) |
+| 2 | `book-examples/pid/C11.desc` | macOS-14: 1069s, Linux: 28s (38×) |
+| 3 | `contracts-dfcc/assigns-local-composite/test.desc` | macOS-14: 90s, Win: 78–114s, Linux: 8s |
+| 4 | `cbmc-incr-smt2/structs/large_array_of_struct_nondet_index.desc` | Win VS2022: 472s, Linux: fast |
+
+## Round 1: Normal Pass — {Linux, macOS} × {minisat2, cadical}
+
+Tests 1–3 with the default SAT backend (no `--symex-driven-lazy-loading`,
+no `--cprover-smt2`). Test 4 with incremental SMT2 on {Linux, Windows}.
+
+### Results
+
+| Test | Linux minisat2 | Linux cadical | macOS minisat2 | macOS cadical |
+|------|---------------|--------------|----------------|---------------|
+| StringSubstring | 2s | 4s | 2s | 3s |
+| pid/C11 | 3s | 19s | 5s | 15s |
+| assigns-local-composite | 4s | 5s | 7s | 5s |
+
+| Test | Linux z3 | Linux cvc5 | Windows z3 | Windows cvc5 |
+|------|---------|-----------|-----------|-------------|
+| large_array_of_struct | 3s | 3s | **473s** | **472s** |
+
+### Round 1 Conclusions
+
+1. **No OS difference for tests 1–3.** macOS-14 ARM and Linux x86_64
+   produce identical times for the same solver. The OS is not the cause.
+
+2. **CaDiCaL is moderately slower** for pid/C11 (~5× vs minisat2) and
+   StringSubstring (~2×), but all times are under 20 seconds. This does
+   not explain the reported 1950s / 1069s.
+
+3. **assigns-local-composite** shows no difference (4–7s everywhere) in
+   the normal SAT pass.
+
+4. **Test 4 is a Windows platform issue.** 473s on Windows vs 3s on
+   Linux, identical across z3 and cvc5. The solver is irrelevant. This
+   is likely due to Windows pipe/IPC overhead in the incremental SMT2
+   pipeline. **Root cause identified — inherent to Windows.**
+
+5. **The extreme slowness is NOT in the normal pass.** The reported times
+   (1950s, 1069s, 90s) must come from other test configurations:
+   `--symex-driven-lazy-loading` or `--cprover-smt2`.
+
+## Round 2: Specific Slow Configurations (pending)
+
+Based on Round 1, the extreme times come from specific CBMC modes, not
+the default SAT pass. Round 2 tests:
+
+- **StringSubstring with `--symex-driven-lazy-loading`** across
+  {Linux, macOS} × {minisat2, cadical} — the 1950s was reported in the
+  `jbmc-strings-symex-driven-lazy-loading-CORE` suite.
+
+- **pid/C11 with `--cprover-smt2`** across {Linux, macOS} × {minisat2,
+  cadical} — the 1069s was reported in `book-examples-cprover-smt2-CORE`.
+
+- **assigns-local-composite with `--cprover-smt2`** across {Linux, macOS}
+  × {minisat2, cadical} — the 90s macOS / 78–114s Windows times may come
+  from the cprover-smt2 pass.
+
+### Expected Outcomes
+
+If the slowness is solver-dependent (e.g., cadical + lazy-loading is
+pathological), we can fix it by changing the default solver on macOS or
+adding solver-specific exclusion tags.
+
+If the slowness is inherent to the mode (e.g., `--symex-driven-lazy-loading`
+is slow regardless of solver), the THOROUGH classification is correct and
+no further action is needed beyond the existing CI configuration.
+
+## CI Configuration Notes
+
+- macOS-14 CI uses `-Dsat_impl=cadical` (CaDiCaL only)
+- Linux make builds use minisat2 (default)
+- Linux cmake builds use `-Dsat_impl="minisat2;cadical"` (both, minisat2 default)
+- The `--cprover-smt2` backend uses the `smt2_solver` binary via pipes
+- The `--symex-driven-lazy-loading` mode uses a different class-loading
+  strategy for Java bytecode (JBMC only)

--- a/jbmc/regression/jbmc-strings/StringSubstring/test.desc
+++ b/jbmc/regression/jbmc-strings/StringSubstring/test.desc
@@ -1,4 +1,4 @@
-THOROUGH
+CORE
 Test
 --unwind 10 --max-nondet-string-length 6  --function Test.testSuccess --cp `../../../../scripts/format_classpath.sh . ../../../lib/java-models-library/target/core-models.jar ../../../lib/java-models-library/target/cprover-api.jar`
 ^EXIT=0$

--- a/regression/book-examples/pid/C11.desc
+++ b/regression/book-examples/pid/C11.desc
@@ -1,4 +1,4 @@
-THOROUGH no-new-smt
+CORE no-new-smt
 pid.c
 --cover mcdc --unwind 6
 ^EXIT=0$

--- a/regression/cbmc-incr-smt2/structs/large_array_of_struct_nondet_index.desc
+++ b/regression/cbmc-incr-smt2/structs/large_array_of_struct_nondet_index.desc
@@ -1,4 +1,4 @@
-THOROUGH
+CORE
 large_array_of_struct_nondet_index.c
 --trace
 Passing problem to incremental SMT2 solving

--- a/regression/contracts-dfcc/assigns-local-composite/test.desc
+++ b/regression/contracts-dfcc/assigns-local-composite/test.desc
@@ -1,4 +1,4 @@
-THOROUGH
+CORE
 main.c
 --no-malloc-may-fail --dfcc main --enforce-contract foo _ --no-standard-checks
 ^EXIT=0$


### PR DESCRIPTION
Add a focused CI workflow that runs the 4 tests marked THOROUGH in 6e616e96 across different OS × solver combinations to determine whether the slowness is inherent to the operating system or caused by the choice of SAT/SMT solver.

Test matrix:
- Tests 1-3 (StringSubstring, pid/C11, assigns-local-composite): {Linux, macOS-14} × {minisat2, cadical}
- Test 4 (large_array_of_struct_nondet_index): {Linux, Windows} × incremental SMT2

The 4 tests are temporarily changed back to CORE so CTest picks them up. All other PR-triggered workflows are disabled to minimize CI load.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
