### PR TITLE
Document why slow CI tests are marked THOROUGH

### DIFF
--- a/jbmc/regression/jbmc-strings/StringSubstring/test.desc
+++ b/jbmc/regression/jbmc-strings/StringSubstring/test.desc
@@ -4,3 +4,8 @@ Test
 ^EXIT=0$
 ^SIGNAL=0$
 assertion at file Test.java line 21.*: SUCCESS
+// Marked THOROUGH because CaDiCaL is extremely slow on this test when
+// combined with --symex-driven-lazy-loading: 223s on macOS ARM (cadical)
+// vs 2s (minisat2). The macOS CI uses CaDiCaL exclusively. On Linux with
+// cadical the test takes 81s. With minisat2 it completes in 2s on all
+// platforms. See PR #8868 for the full investigation.

--- a/regression/book-examples/pid/C11.desc
+++ b/regression/book-examples/pid/C11.desc
@@ -4,3 +4,7 @@ pid.c
 ^EXIT=0$
 ^SIGNAL=0$
 coverage results
+// Marked THOROUGH because CaDiCaL is slow on this test when combined with
+// the --cprover-smt2 backend: ~118s (cadical) vs 17-22s (minisat2). The
+// macOS CI uses CaDiCaL exclusively. No OS difference -- the slowness is
+// purely solver-dependent. See PR #8868 for the full investigation.

--- a/regression/cbmc-incr-smt2/structs/large_array_of_struct_nondet_index.desc
+++ b/regression/cbmc-incr-smt2/structs/large_array_of_struct_nondet_index.desc
@@ -16,3 +16,9 @@ This test covers support for examples with large arrays of structs using nondet
 indexes including trace generation. This combination of features is chosen in
 order to avoid array cell sensitivity or struct field sensitivity simplifying
 away the relevant `member_exprt` and `with_exprt` expressions.
+
+Marked THOROUGH because of Windows platform IPC overhead: the incremental
+SMT2 pipeline communicates with the solver via pipes, which takes 473s on
+Windows vs 3s on Linux. Both z3 and cvc5 show identical times, confirming
+this is a platform issue, not solver-dependent. See PR #8868 for the full
+investigation.

--- a/regression/contracts-dfcc/assigns-local-composite/test.desc
+++ b/regression/contracts-dfcc/assigns-local-composite/test.desc
@@ -4,6 +4,11 @@ main.c
 ^EXIT=0$
 ^SIGNAL=0$
 ^VERIFICATION SUCCESSFUL$
+// Marked THOROUGH because this test is slow on macOS and Windows. Per-PR CI
+// (PR #8869) measured 64-72s on macOS-14 (ARM) and up to 22s on macOS-15
+// (Intel), and 85s (VS-2022) / 136s (VS-2026) on Windows, versus 4-8s on
+// Linux. An earlier estimate of 4-7s held only on Linux. See PR #8868 for the
+// full investigation.
 --
 --
 Checks that assigns clause checking explicitly checks assignments to locally


### PR DESCRIPTION
Add investigation findings to each test descriptor explaining the root cause of the slowness (see PR #8868 for the full investigation):

- StringSubstring: CaDiCaL is 112x slower than minisat2 when combined with --symex-driven-lazy-loading (223s vs 2s on macOS ARM).
- pid/C11: CaDiCaL is 5-7x slower than minisat2 when combined with the --cprover-smt2 backend (~118s vs 17-22s).
- large_array_of_struct_nondet_index: Windows pipe/IPC overhead causes a 157x slowdown (473s vs 3s on Linux), solver-independent.
- assigns-local-composite: slow on macOS and Windows. Per-PR CI measured 64-72s on macOS-14 (ARM), up to 22s on macOS-15 (Intel), and 85s (VS-2022) / 136s (VS-2026) on Windows, versus 4-8s on Linux. An earlier estimate of 4-7s held only on Linux, so it stays THOROUGH.

All four tests remain THOROUGH; this PR only documents *why*. No test tags are changed.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- n/a Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [x] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
