### PR TITLE
Fix incorrect linkage of global variables with section attributes

### DIFF
--- a/regression/cbmc/section_attribute_linkage/main.c
+++ b/regression/cbmc/section_attribute_linkage/main.c
@@ -1,0 +1,18 @@
+#include "other.h"
+
+#include <assert.h>
+
+int main()
+{
+  p.x = 123;
+
+  // valid assertion, gets proof
+  assert(p.x == 123);
+
+  int i = get();
+
+  // valid assertion, but gets cex
+  assert(i == 123);
+
+  return 0;
+}

--- a/regression/cbmc/section_attribute_linkage/other.c
+++ b/regression/cbmc/section_attribute_linkage/other.c
@@ -1,0 +1,8 @@
+#include "other.h"
+
+struct point p __attribute__((section("foo")));
+
+int get()
+{
+  return p.x;
+}

--- a/regression/cbmc/section_attribute_linkage/other.h
+++ b/regression/cbmc/section_attribute_linkage/other.h
@@ -1,0 +1,14 @@
+#ifndef OTHER_H
+#define OTHER_H
+
+struct point
+{
+  int x;
+  int y;
+};
+
+extern struct point p;
+
+int get();
+
+#endif

--- a/regression/cbmc/section_attribute_linkage/test.desc
+++ b/regression/cbmc/section_attribute_linkage/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+other.c
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring

--- a/src/linking/linking.cpp
+++ b/src/linking/linking.cpp
@@ -1061,6 +1061,31 @@ bool linkingt::link(const symbol_table_baset &src_symbol_table)
 
   std::unordered_set<irep_idt> needs_to_be_renamed;
 
+  // Handle section-attributed symbols: when a symbol has been renamed due to
+  // __attribute__((section("name"))) (resulting in a "name$$base" identifier),
+  // ensure that any matching extern declaration using just the base name is
+  // renamed to the section-prefixed name.
+  for(const auto &src_sym_pair : src_symbol_table.symbols)
+  {
+    const std::string &name_str = id2string(src_sym_pair.first);
+    std::size_t pos = name_str.find("$$");
+    if(pos == std::string::npos)
+      continue;
+
+    // Only handle non-type symbols with static lifetime (global variables)
+    if(src_sym_pair.second.is_type || !src_sym_pair.second.is_static_lifetime)
+      continue;
+
+    irep_idt base_name(name_str.substr(pos + 2));
+    auto m_it = main_symbol_table.symbols.find(base_name);
+    if(
+      m_it != main_symbol_table.symbols.end() && !m_it->second.is_type &&
+      m_it->second.is_extern)
+    {
+      rename_main_symbol.insert_expr(base_name, src_sym_pair.first);
+    }
+  }
+
   for(const auto &symbol_pair : src_symbol_table.symbols)
   {
     symbol_table_baset::symbolst::const_iterator m_it =


### PR DESCRIPTION
When a global variable is defined with __attribute__((section("name"))),
CBMC renames it to "name$$base_name" during type-checking. However,
extern declarations of the same variable in other translation units
retain the original name. The linker did not recognize these as the same
symbol, leading to incorrect verification results.

The fix adds a pre-pass in the linker that detects section-attributed
symbols (those with "$$" in their name) from the source symbol table
and renames matching extern declarations in the main symbol table to
use the section-prefixed name, ensuring proper unification.

Fixes: #8127

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
