### PR TITLE
Add regression test for goto-diff --unified

### DIFF
--- a/regression/goto-diff/unified-diff1/a.c
+++ b/regression/goto-diff/unified-diff1/a.c
@@ -1,0 +1,10 @@
+int main()
+{
+  int x;
+  return 0;
+}
+
+void foo()
+{
+  int y;
+}

--- a/regression/goto-diff/unified-diff1/b.c
+++ b/regression/goto-diff/unified-diff1/b.c
@@ -1,0 +1,10 @@
+int main()
+{
+  int x = 42;
+  return 0;
+}
+
+void bar()
+{
+  int z;
+}

--- a/regression/goto-diff/unified-diff1/test.desc
+++ b/regression/goto-diff/unified-diff1/test.desc
@@ -1,0 +1,21 @@
+CORE
+b.c
+a.c --unified
+^EXIT=0$
+^SIGNAL=0$
+\*\* main \*\*
+^\+.*function main
+ASSIGN main::1::x := 42
+\*\* foo \*\*
+^-.*function foo
+\*\* bar \*\*
+^\+.*function bar
+--
+^warning: ignoring
+//
+// goto-diff a.c (old) --unified b.c (new) -- old=a.c keeps the same old/new
+// convention as the sibling syntactic-diff1 test. Beyond the function headers
+// and the changed assignment, assert the unified-diff markers that
+// output_diff() emits on the leading "// <loc>" line of each instruction, so
+// the test pins all three classifications: main modified (+), foo deleted (-),
+// bar added (+).


### PR DESCRIPTION
Exercises unified_diff.cpp which previously had 0% coverage.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
