### PR TITLE
Add depth-bounding assertions

### DIFF
--- a/doc/cprover-manual/cbmc-tutorial.md
+++ b/doc/cprover-manual/cbmc-tutorial.md
@@ -283,15 +283,17 @@ performs. There are two ways to do so:
 Given the option `--unwinding-assertions`, CBMC checks whether the
 argument to `--unwind` is large enough to cover all program paths. If
 the argument is too small, CBMC will detect that not enough unwinding is
-done reports that an unwinding assertion has failed.
+done reports that an unwinding assertion has failed. Similarly, when
+using `--depth`, CBMC generates depth bounding assertions by default
+that will fail if any execution path reaches the depth limit.
 
 Reconsider the example. For a loop unwinding bound of one, no bug is
 found. But for a bound of two, CBMC detects a trace that
-violates an assertion. Without unwinding assertions, or when using the
-`--depth` command line switch, CBMC does not prove the program correct,
-but it can be helpful to find program bugs. The various command line
-options that CBMC offers for loop unwinding are described in the section
-on [understanding loop unwinding](../../cbmc/unwinding/).
+violates an assertion. Without unwinding assertions (or, when using
+`--depth`, without depth assertions), CBMC does not prove the program
+correct, but it can be helpful to find program bugs. The various command
+line options that CBMC offers for loop unwinding are described in the
+section on [understanding loop unwinding](../../cbmc/unwinding/).
 
 ## A Note About Compilers and the ANSI-C Library
 

--- a/doc/cprover-manual/cbmc-unwinding.md
+++ b/doc/cprover-manual/cbmc-unwinding.md
@@ -180,3 +180,10 @@ iterations. Note that CBMC uses the number of instructions in the
 control-flow graph as the criterion, not the number of instructions in
 the source code.
 
+When `--depth` is used, CBMC generates depth bounding assertions by
+default. These assertions will fail if any execution path actually
+reaches the depth limit, thus ensuring that the verification result is
+sound. Depth assertions can be disabled using `--no-depth-assertions`,
+but doing so may yield unsound verification results (analogous to using
+`--no-unwinding-assertions` with `--unwind`).
+

--- a/doc/cprover-manual/unsound_options.md
+++ b/doc/cprover-manual/unsound_options.md
@@ -31,7 +31,8 @@ The following options will produce a warning when used with CBMC or JBMC:
 
 * Use of `--unwind` or `--unwindset` without `--unwinding-assertions`, or the
   use of `--partial-loops`.
-* Depth or complexity-limited analysis (`--depth`, `--symex-complexity-limit`).
+* Depth-limited analysis using `--depth` with `--no-depth-assertions`, or
+  complexity-limited analysis (`--symex-complexity-limit`).
 
 See [Understanding Loop Unwinding](../cbmc/unwinding/) for an elaboration of
 these options.

--- a/doc/man/cbmc.1
+++ b/doc/man/cbmc.1
@@ -380,8 +380,19 @@ only show program expression
 \fB\-\-show\-byte\-ops\fR
 show all byte extracts and updates
 .TP
-\fB\-\-depth\fR nr
-limit search depth
+\fB\-\-depth\fR \fInr\fR
+limit search depth to \fInr\fR instructions on any single execution path.
+When the depth limit is reached, any remaining paths are cut short.
+Use \fB\-\-depth\-assertions\fR (enabled by default) to check whether the
+depth limit was actually reached.
+.TP
+\fB\-\-depth\-assertions\fR
+generate depth bounding assertions (enabled by default when using
+\fB\-\-depth\fR). These assertions will fail when the depth limit is
+reached on any execution path, ensuring that the analysis is sound.
+.TP
+\fB\-\-no\-depth\-assertions\fR
+do not generate depth bounding assertions
 .TP
 \fB\-\-max\-field\-sensitivity\-array\-size\fR M
 maximum size M of arrays for which field

--- a/doc/man/jbmc.1
+++ b/doc/man/jbmc.1
@@ -295,8 +295,19 @@ only show program expression
 \fB\-\-show\-byte\-ops\fR
 show all byte extracts and updates
 .TP
-\fB\-\-depth\fR nr
-limit search depth
+\fB\-\-depth\fR \fInr\fR
+limit search depth to \fInr\fR instructions on any single execution path.
+When the depth limit is reached, any remaining paths are cut short.
+Use \fB\-\-depth\-assertions\fR (enabled by default) to check whether the
+depth limit was actually reached.
+.TP
+\fB\-\-depth\-assertions\fR
+generate depth bounding assertions (enabled by default when using
+\fB\-\-depth\fR). These assertions will fail when the depth limit is
+reached on any execution path, ensuring that the analysis is sound.
+.TP
+\fB\-\-no\-depth\-assertions\fR
+do not generate depth bounding assertions
 .TP
 \fB\-\-max\-field\-sensitivity\-array\-size\fR M
 maximum size M of arrays for which field

--- a/jbmc/src/jbmc/jbmc_parse_options.cpp
+++ b/jbmc/src/jbmc/jbmc_parse_options.cpp
@@ -225,11 +225,18 @@ void jbmc_parse_optionst::get_command_line_options(optionst &options)
   if(cmdline.isset("depth"))
   {
     options.set_option("depth", cmdline.get_value("depth"));
-    log.warning()
-      << "**** WARNING: Depth-bounded analysis may yield unsound verification "
-         "results"
-      << messaget::eom;
+    if(
+      !cmdline.isset("no-depth-assertions") &&
+      !cmdline.isset("depth-assertions"))
+    {
+      options.set_option("depth-assertions", true);
+    }
   }
+
+  if(cmdline.isset("depth-assertions"))
+    options.set_option("depth-assertions", true);
+  else if(cmdline.isset("no-depth-assertions"))
+    options.set_option("depth-assertions", false);
 
   if(cmdline.isset("unwindset"))
   {

--- a/regression/cbmc/depth-assertion1/main.c
+++ b/regression/cbmc/depth-assertion1/main.c
@@ -1,0 +1,6 @@
+int main()
+{
+  int i;
+  while(i)
+    i--;
+}

--- a/regression/cbmc/depth-assertion1/test.desc
+++ b/regression/cbmc/depth-assertion1/test.desc
@@ -1,0 +1,8 @@
+CORE paths-lifo-expected-failure
+main.c
+--depth 5 --no-standard-checks --no-unwinding-assertions
+^EXIT=10$
+^SIGNAL=0$
+depth assertion: FAILURE
+--
+^warning: ignoring

--- a/regression/cbmc/depth-assertion2/main.c
+++ b/regression/cbmc/depth-assertion2/main.c
@@ -1,0 +1,6 @@
+int main()
+{
+  int i;
+  while(i)
+    i--;
+}

--- a/regression/cbmc/depth-assertion2/test.desc
+++ b/regression/cbmc/depth-assertion2/test.desc
@@ -1,0 +1,9 @@
+CORE
+main.c
+--depth 5 --no-standard-checks --no-unwinding-assertions --no-depth-assertions
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring
+depth assertion

--- a/regression/cbmc/guard1/test.desc
+++ b/regression/cbmc/guard1/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---depth 19 --no-standard-checks
+--depth 19 --no-standard-checks --no-depth-assertions
 ^EXIT=0$
 ^SIGNAL=0$
 ^VERIFICATION SUCCESSFUL$

--- a/src/cbmc/cbmc_parse_options.cpp
+++ b/src/cbmc/cbmc_parse_options.cpp
@@ -346,11 +346,18 @@ void cbmc_parse_optionst::get_command_line_options(optionst &options)
   if(cmdline.isset("depth"))
   {
     options.set_option("depth", cmdline.get_value("depth"));
-    log.warning()
-      << "**** WARNING: Depth-bounded analysis may yield unsound verification "
-         "results"
-      << messaget::eom;
+    if(
+      !cmdline.isset("no-depth-assertions") &&
+      !cmdline.isset("depth-assertions"))
+    {
+      options.set_option("depth-assertions", true);
+    }
   }
+
+  if(cmdline.isset("depth-assertions"))
+    options.set_option("depth-assertions", true);
+  else if(cmdline.isset("no-depth-assertions"))
+    options.set_option("depth-assertions", false);
 
   if(cmdline.isset("slice-by-trace"))
   {

--- a/src/goto-checker/bmc_util.h
+++ b/src/goto-checker/bmc_util.h
@@ -178,6 +178,8 @@ void run_property_decider(
   "(paths):"                                                                   \
   "(show-symex-strategies)"                                                    \
   "(depth):"                                                                   \
+  "(depth-assertions)"                                                         \
+  "(no-depth-assertions)"                                                      \
   "(max-field-sensitivity-array-size):"                                        \
   "(no-array-field-sensitivity)"                                               \
   "(graphml-witness):"                                                         \
@@ -199,6 +201,9 @@ void run_property_decider(
   " {y--program-only} \t only show program expression\n"                       \
   " {y--show-byte-ops} \t show all byte extracts and updates\n"                \
   " {y--depth} {unr} \t limit search depth\n"                                  \
+  " {y--depth-assertions} \t generate depth bounding assertions (enabled "     \
+  "by default when using {y--depth})\n"                                        \
+  " {y--no-depth-assertions} \t disable depth bounding assertions\n"           \
   " {y--max-field-sensitivity-array-size} {uM} \t "                            \
   "maximum size {uM} of arrays for which field sensitivity will be "           \
   "applied to array, the default is 64\n"                                      \

--- a/src/goto-symex/symex_config.h
+++ b/src/goto-symex/symex_config.h
@@ -34,6 +34,8 @@ struct symex_configt final
 
   bool unwinding_assertions;
 
+  bool depth_assertions;
+
   bool partial_loops;
 
   /// \brief Should the additional validation checks be run?

--- a/src/goto-symex/symex_main.cpp
+++ b/src/goto-symex/symex_main.cpp
@@ -37,17 +37,16 @@ symex_configt::symex_configt(const optionst &options)
       options.get_bool_option("self-loops-to-assumptions")),
     simplify_opt(options.get_bool_option("simplify")),
     unwinding_assertions(options.get_bool_option("unwinding-assertions")),
+    depth_assertions(options.get_bool_option("depth-assertions")),
     partial_loops(options.get_bool_option("partial-loops")),
     run_validation_checks(options.get_bool_option("validate-ssa-equation")),
     show_symex_steps(options.get_bool_option("show-goto-symex-steps")),
     show_points_to_sets(options.get_bool_option("show-points-to-sets")),
     max_field_sensitivity_array_size(
-      options.is_set("no-array-field-sensitivity")
-        ? 0
-        : options.is_set("max-field-sensitivity-array-size")
-            ? options.get_unsigned_int_option(
-                "max-field-sensitivity-array-size")
-            : DEFAULT_MAX_FIELD_SENSITIVITY_ARRAY_SIZE),
+      options.is_set("no-array-field-sensitivity") ? 0
+      : options.is_set("max-field-sensitivity-array-size")
+        ? options.get_unsigned_int_option("max-field-sensitivity-array-size")
+        : DEFAULT_MAX_FIELD_SENSITIVITY_ARRAY_SIZE),
     complexity_limits_active(
       options.get_signed_int_option("symex-complexity-limit") > 0),
     cache_dereferences{options.get_bool_option("symex-cache-dereferences")}
@@ -614,6 +613,13 @@ void goto_symext::execute_next_instruction(
   // depth exceeded?
   if(state.depth > symex_config.max_depth)
   {
+    if(symex_config.depth_assertions)
+    {
+      const std::string property_id =
+        id2string(state.source.function_id) + ".depth";
+      vcc(false_exprt(), property_id, "depth assertion", state);
+    }
+
     // Rule out this path:
     symex_assume_l2(state, false_exprt());
   }


### PR DESCRIPTION
Introduce depth assertions that are generated when --depth is used, analogous to unwinding assertions. When the execution depth limit is reached, a verification condition is generated that will fail if any path actually reaches the depth bound, making the analysis sound.

Depth assertions are enabled by default when --depth is specified. They can be disabled with --no-depth-assertions, or explicitly enabled with --depth-assertions.

Improve the --depth man page entries in cbmc.1 and jbmc.1 to describe the option's behavior in more detail, consistent with how --unwinding-assertions is documented.

Update the CProver manual:
- cbmc-tutorial.md: mention depth assertions alongside unwinding assertions
- cbmc-unwinding.md: add paragraph about depth assertions to the depth-based unwinding section
- unsound_options.md: --depth is now sound by default (with depth assertions); only --depth with --no-depth-assertions is unsound

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [x] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
