### PR TITLE
Fix crash in --show-global-may-alias on OTHER instructions

### DIFF
--- a/regression/goto-instrument/show-global-may-alias1/main.c
+++ b/regression/goto-instrument/show-global-may-alias1/main.c
@@ -1,0 +1,10 @@
+// Returning a value makes the front-end emit an OUTPUT (an OTHER instruction)
+// in __CPROVER__start, which used to crash --show-global-may-alias.
+int g;
+int *p;
+int main()
+{
+  p = &g;
+  g = 1;
+  return *p;
+}

--- a/regression/goto-instrument/show-global-may-alias1/test.desc
+++ b/regression/goto-instrument/show-global-may-alias1/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--show-global-may-alias
+^EXIT=0$
+^SIGNAL=0$

--- a/src/analyses/global_may_alias.cpp
+++ b/src/analyses/global_may_alias.cpp
@@ -146,7 +146,8 @@ void global_may_alias_domaint::transform(
   case END_FUNCTION: // No action required
     break;
   case OTHER:
-    DATA_INVARIANT(false, "Unclear what is a safe over-approximation of OTHER");
+    // Treated as a no-op (best-effort, as for FUNCTION_CALL above): the
+    // OTHER forms reaching this analysis, e.g. OUTPUT, do not create aliases.
     break;
   case INCOMPLETE_GOTO:
   case NO_INSTRUCTION_TYPE:


### PR DESCRIPTION
global_may_alias_domaint::transform() had a DATA_INVARIANT(false) for OTHER instructions, causing a crash on any program with OUTPUT or similar OTHER-type instructions. Ignoring OTHER is a valid over-approximation, consistent with how ASSUME and SKIP are handled.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
