### PR TITLE
Fix crash in --show-intervals by adding missing do_remove_returns()

### DIFF
--- a/regression/goto-instrument/show-intervals1/main.c
+++ b/regression/goto-instrument/show-intervals1/main.c
@@ -1,0 +1,7 @@
+int main()
+{
+  int x = 0;
+  if(x < 10)
+    x = x + 1;
+  return x;
+}

--- a/regression/goto-instrument/show-intervals1/test.desc
+++ b/regression/goto-instrument/show-intervals1/test.desc
@@ -1,0 +1,9 @@
+CORE
+main.c
+--show-intervals
+^EXIT=0$
+^SIGNAL=0$
+^Interval Analysis$
+^0 <= main::1::x <= 0$
+--
+^warning: ignoring

--- a/src/goto-instrument/goto_instrument_parse_options.cpp
+++ b/src/goto-instrument/goto_instrument_parse_options.cpp
@@ -502,6 +502,8 @@ int goto_instrument_parse_optionst::doit()
     if(cmdline.isset("show-intervals"))
     {
       do_indirect_call_and_rtti_removal();
+      do_remove_returns();
+      parameter_assignments(goto_model);
 
       // recalculate numbers, etc.
       goto_model.goto_functions.update();


### PR DESCRIPTION
interval_domaint::transform() requires SET_RETURN_VALUE instructions to be removed before analysis, but --show-intervals did not call do_remove_returns(). This caused a DATA_INVARIANT crash on any program.

Add the missing do_remove_returns() call, consistent with how --show-global-may-alias handles this.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
