### PR TITLE
Fix pointer_offset expressions in dump-c generated code

### DIFF
--- a/regression/goto-instrument/dump-c-pointer-offset/main.c
+++ b/regression/goto-instrument/dump-c-pointer-offset/main.c
@@ -1,0 +1,9 @@
+int l[10][10];
+int g;
+
+int main(void)
+{
+  if(&l[g + 2][g] == &l[3][3])
+    return 1;
+  return 0;
+}

--- a/regression/goto-instrument/dump-c-pointer-offset/test.desc
+++ b/regression/goto-instrument/dump-c-pointer-offset/test.desc
@@ -1,0 +1,7 @@
+CORE
+main.c
+--dump-c
+^EXIT=0$
+^SIGNAL=0$
+--
+__CPROVER_POINTER_OFFSET

--- a/src/goto-instrument/dump_c.cpp
+++ b/src/goto-instrument/dump_c.cpp
@@ -20,6 +20,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/find_symbols.h>
 #include <util/get_base_name.h>
 #include <util/invariant.h>
+#include <util/pointer_expr.h>
 #include <util/prefix.h>
 #include <util/replace_symbol.h>
 #include <util/string_utils.h>
@@ -1595,6 +1596,39 @@ void dump_ct::cleanup_expr(exprt &expr)
     member_exprt &member_expr = to_member_expr(expr);
     member_expr.set_component_name(
       clean_identifier(member_expr.get_component_name()));
+  }
+  else if(expr.id() == ID_pointer_offset)
+  {
+    // Convert pointer_offset(p) to ((char*)(p) - (char*)&root_object)
+    // so that dump-c produces valid C code instead of
+    // __CPROVER_POINTER_OFFSET.
+    const exprt &ptr = to_pointer_offset_expr(expr).pointer();
+
+    // Find the root object by unwrapping address_of, index, member,
+    // and typecast operations
+    const exprt *obj = &ptr;
+    if(obj->id() == ID_address_of)
+      obj = &to_address_of_expr(*obj).object();
+    const exprt *root = obj;
+    while(root->id() == ID_index || root->id() == ID_typecast ||
+          root->id() == ID_member)
+    {
+      if(root->id() == ID_index)
+        root = &to_index_expr(*root).array();
+      else if(root->id() == ID_member)
+        root = &to_member_expr(*root).compound();
+      else
+        root = &to_typecast_expr(*root).op();
+    }
+
+    const typet char_ptr = pointer_type(char_type());
+    const typet result_type = expr.type();
+
+    exprt cast_ptr = typecast_exprt(ptr, char_ptr);
+    exprt cast_base = typecast_exprt(address_of_exprt(*root), char_ptr);
+    exprt diff = minus_exprt(cast_ptr, cast_base);
+    expr = typecast_exprt(diff, result_type);
+    cleanup_expr(expr);
   }
 }
 


### PR DESCRIPTION
When goto-instrument --dump-c converts a goto program back to C, pointer comparisons like &arr[i][j] == &arr[x][y] get simplified by the expression simplifier into pointer_offset arithmetic. The pointer_offset_exprt is then rendered as __CPROVER_POINTER_OFFSET by expr2c, which is not valid C and cannot be compiled by GCC.

The fix adds handling for pointer_offset expressions in dump_ct's cleanup_expr. It converts pointer_offset(p) to the equivalent C expression ((char*)(p) - (char*)&root_object), where root_object is found by unwrapping address_of, index, member, and typecast operations from the pointer operand.

Minimal reproducer:
  int l[10][10]; int g;
  int main(void) { if(&l[g+2][g] == &l[3][3]) return 1; return 0; }

This was found via CSmith test seed 1750841832.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
