### PR TITLE
Fix dump-c bitfield truncation in compound assignments

### DIFF
--- a/regression/goto-instrument/dump-c-bitfield-truncation/main.c
+++ b/regression/goto-instrument/dump-c-bitfield-truncation/main.c
@@ -1,0 +1,19 @@
+#include <assert.h>
+
+struct S
+{
+  signed f : 3;
+};
+
+static struct S s = {-1};
+
+int main(void)
+{
+  // s.f = -1 (3-bit: 111), 8 = 0b1000
+  // s.f &= 8: sign-extend -1 to 0xFFFFFFFF, & 8 = 8, truncate to 3 bits = 0
+  // So (s.f &= 8) evaluates to 0 (the truncated value)
+  // 0 || 0 = 0
+  int x = (s.f &= 8) || 0;
+  assert(x == 0);
+  return 0;
+}

--- a/regression/goto-instrument/dump-c-bitfield-truncation/test.desc
+++ b/regression/goto-instrument/dump-c-bitfield-truncation/test.desc
@@ -1,0 +1,8 @@
+CORE
+main.c
+--dump-c
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring

--- a/src/goto-instrument/goto_program2code.cpp
+++ b/src/goto-instrument/goto_program2code.cpp
@@ -1938,7 +1938,42 @@ void goto_program2codet::cleanup_expr(exprt &expr, bool no_typecast)
   else if(expr.id()==ID_typecast)
   {
     if(expr.type().id() == ID_c_bit_field)
-      expr=to_typecast_expr(expr).op();
+    {
+      // A cast to c_bit_field truncates to the bitfield width. Simply
+      // dropping the cast loses the truncation semantics, which matters
+      // when the result is used in a boolean context (e.g., || or &&).
+      // Replace with explicit masking to the bitfield width.
+      const c_bit_field_typet &bf_type = to_c_bit_field_type(expr.type());
+      const std::size_t width = bf_type.get_width();
+      const bool is_signed = bf_type.underlying_type().id() == ID_signedbv;
+
+      exprt op = to_typecast_expr(expr).op();
+      const typet op_type = op.type();
+
+      if(width == 0)
+      {
+        expr = from_integer(0, op_type);
+      }
+      else if(is_signed)
+      {
+        // For signed: mask to width bits, then sign-extend by casting
+        // through an unsigned type and subtracting the sign bit weight.
+        // Equivalent to: ((unsigned)(op) & mask) as signed, with sign
+        // extension. Use: (op & mask) - ((op & sign_bit) ? (1<<width) : 0)
+        // Simpler: just mask and let the assignment to the bitfield handle
+        // sign extension. But we need the VALUE to be correct for boolean
+        // checks. The simplest correct approach: mask the lower N bits.
+        // If the result is used in a boolean context, only zero/non-zero
+        // matters, and masking preserves that correctly.
+        mp_integer mask = power(mp_integer(2), mp_integer(width)) - 1;
+        expr = bitand_exprt(op, from_integer(mask, op_type));
+      }
+      else
+      {
+        mp_integer mask = power(mp_integer(2), mp_integer(width)) - 1;
+        expr = bitand_exprt(op, from_integer(mask, op_type));
+      }
+    }
     else
     {
       add_local_types(expr.type());


### PR DESCRIPTION
When goto-instrument --dump-c converts a goto program back to C code, compound assignments to bitfields (e.g., s.f &= 8 where f is a 3-bit signed bitfield) were incorrectly handled. The goto program correctly inserts a cast to c_bit_field to truncate the intermediate result to the bitfield width, but goto_program2code.cpp was stripping this cast entirely, causing the pre-truncation 32-bit value to be used in subsequent boolean contexts.

Example: s.f = -1 (3-bit: 111), then (s.f &= 8) || 0
- Correct: -1 sign-extended & 8 = 8, truncated to 3 bits = 0, 0||0 = 0
- Bug: used pre-truncation value 8 (non-zero), so 8||0 = 1

The fix replaces the c_bit_field cast with an explicit bitwise AND mask that truncates to the bitfield width, preserving the zero/non-zero semantics needed for boolean contexts.

Minimal reproducer:
  struct S { signed f : 3; };
  static struct S s = {-1};
  int main(void) { int x = (s.f &= 8) || 0; assert(x == 0); }

This was found via CSmith test seed 1684847330 (issue #7729).

Fixes: #7729

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
