### PR TITLE
Move INITIALIZE_FUNCTION macro to goto-programs to reduce linking dependency

### DIFF
--- a/src/ansi-c/ansi_c_internal_additions.cpp
+++ b/src/ansi-c/ansi_c_internal_additions.cpp
@@ -12,8 +12,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/config.h>
 
 #include <goto-programs/adjust_float_expressions.h>
-
-#include <linking/static_lifetime_init.h>
+#include <goto-programs/initialize_function.h>
 
 #include "ansi_c_parser.h"
 

--- a/src/ansi-c/goto-conversion/goto_convert_functions.cpp
+++ b/src/ansi-c/goto-conversion/goto_convert_functions.cpp
@@ -14,8 +14,7 @@ Date: June 2003
 #include <util/symbol_table_builder.h>
 
 #include <goto-programs/goto_model.h>
-
-#include <linking/static_lifetime_init.h>
+#include <goto-programs/initialize_function.h>
 
 goto_convert_functionst::goto_convert_functionst(
   symbol_table_baset &_symbol_table,

--- a/src/cpp/cpp_internal_additions.cpp
+++ b/src/cpp/cpp_internal_additions.cpp
@@ -8,16 +8,15 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "cpp_internal_additions.h"
 
-#include <ostream>
-
 #include <util/c_types.h>
 #include <util/config.h>
 
+#include <goto-programs/adjust_float_expressions.h>
+#include <goto-programs/initialize_function.h>
+
 #include <ansi-c/ansi_c_internal_additions.h>
 
-#include <linking/static_lifetime_init.h>
-
-#include <goto-programs/adjust_float_expressions.h>
+#include <ostream>
 
 std::string c2cpp(const std::string &s)
 {

--- a/src/goto-cc/compile.cpp
+++ b/src/goto-cc/compile.cpp
@@ -23,6 +23,7 @@ Date: June 2006
 #include <util/unicode.h>
 #include <util/version.h>
 
+#include <goto-programs/initialize_function.h>
 #include <goto-programs/name_mangler.h>
 #include <goto-programs/read_goto_binary.h>
 #include <goto-programs/write_goto_binary.h>
@@ -34,7 +35,6 @@ Date: June 2006
 #include <langapi/language_file.h>
 #include <langapi/mode.h>
 #include <linking/linking.h>
-#include <linking/static_lifetime_init.h>
 
 #include <cstring>
 #include <filesystem>

--- a/src/goto-checker/module_dependencies.txt
+++ b/src/goto-checker/module_dependencies.txt
@@ -3,6 +3,5 @@ goto-checker
 goto-programs
 goto-symex
 langapi
-linking
 solvers
 util

--- a/src/goto-checker/symex_bmc.cpp
+++ b/src/goto-checker/symex_bmc.cpp
@@ -14,9 +14,8 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/simplify_expr.h>
 #include <util/source_location.h>
 
+#include <goto-programs/initialize_function.h>
 #include <goto-programs/unwindset.h>
-
-#include <linking/static_lifetime_init.h>
 
 #include <limits>
 

--- a/src/goto-checker/symex_coverage.cpp
+++ b/src/goto-checker/symex_coverage.cpp
@@ -19,9 +19,9 @@ Date: March 2016
 #include <util/xml.h>
 
 #include <goto-programs/goto_functions.h>
+#include <goto-programs/initialize_function.h>
 
 #include <langapi/language_util.h>
-#include <linking/static_lifetime_init.h>
 
 #include <chrono> // IWYU pragma: keep
 #include <ctime>  // IWYU pragma: keep - For std::time_t

--- a/src/goto-instrument/aggressive_slicer.cpp
+++ b/src/goto-instrument/aggressive_slicer.cpp
@@ -14,9 +14,8 @@ Author: Elizabeth Polgreen, elizabeth.polgreen@cs.ox.ac.uk
 #include <util/message.h>
 
 #include <goto-programs/goto_model.h>
+#include <goto-programs/initialize_function.h>
 #include <goto-programs/show_properties.h>
-
-#include <linking/static_lifetime_init.h>
 
 #include <analyses/call_graph_helpers.h>
 

--- a/src/goto-instrument/call_sequences.cpp
+++ b/src/goto-instrument/call_sequences.cpp
@@ -13,16 +13,15 @@ Date: April 2013
 
 #include "call_sequences.h"
 
-#include <stack>
-#include <iostream>
-
 #include <util/simplify_expr.h>
 
 #include <goto-programs/goto_model.h>
+#include <goto-programs/initialize_function.h>
 
 #include <langapi/language_util.h>
 
-#include <linking/static_lifetime_init.h>
+#include <iostream>
+#include <stack>
 
 void show_call_sequences(
   const irep_idt &caller,

--- a/src/goto-instrument/contracts/dynamic-frames/dfcc_library.cpp
+++ b/src/goto-instrument/contracts/dynamic-frames/dfcc_library.cpp
@@ -20,6 +20,7 @@ Author: Remi Delmas, delmarsd@amazon.com
 
 #include <goto-programs/goto_function.h>
 #include <goto-programs/goto_model.h>
+#include <goto-programs/initialize_function.h>
 #include <goto-programs/unwindset.h>
 
 #include <ansi-c/c_expr.h>
@@ -28,7 +29,6 @@ Author: Remi Delmas, delmarsd@amazon.com
 #include <ansi-c/goto-conversion/goto_convert_functions.h>
 #include <goto-instrument/generate_function_bodies.h>
 #include <goto-instrument/unwind.h>
-#include <linking/static_lifetime_init.h>
 
 #include "dfcc_utils.h"
 

--- a/src/goto-instrument/contracts/dynamic-frames/dfcc_utils.cpp
+++ b/src/goto-instrument/contracts/dynamic-frames/dfcc_utils.cpp
@@ -21,11 +21,11 @@ Date: August 2022
 
 #include <goto-programs/goto_inline.h>
 #include <goto-programs/goto_model.h>
+#include <goto-programs/initialize_function.h>
 
 #include <ansi-c/goto-conversion/goto_convert_functions.h>
 #include <goto-instrument/contracts/inlining_decorator.h>
 #include <goto-instrument/contracts/utils.h>
-#include <linking/static_lifetime_init.h>
 
 #include <set>
 

--- a/src/goto-instrument/count_eloc.cpp
+++ b/src/goto-instrument/count_eloc.cpp
@@ -19,8 +19,7 @@ Date: December 2012
 
 #include <goto-programs/cfg.h>
 #include <goto-programs/goto_model.h>
-
-#include <linking/static_lifetime_init.h>
+#include <goto-programs/initialize_function.h>
 
 #include <filesystem>
 #include <iostream>

--- a/src/goto-instrument/cover_filter.cpp
+++ b/src/goto-instrument/cover_filter.cpp
@@ -14,7 +14,7 @@ Author: Peter Schrammel
 #include <util/prefix.h>
 #include <util/symbol.h>
 
-#include <linking/static_lifetime_init.h>
+#include <goto-programs/initialize_function.h>
 
 /// Filter out functions that are not considered provided by the user
 /// \param function: the function under consideration

--- a/src/goto-instrument/dump_c.cpp
+++ b/src/goto-instrument/dump_c.cpp
@@ -24,11 +24,12 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/replace_symbol.h>
 #include <util/string_utils.h>
 
+#include <goto-programs/initialize_function.h>
+
 #include <ansi-c/expr2c.h>
 #include <ansi-c/type2name.h>
 #include <cpp/cpp_type2name.h>
 #include <cpp/expr2cpp.h>
-#include <linking/static_lifetime_init.h>
 
 #include "goto_program2code.h"
 

--- a/src/goto-instrument/interrupt.cpp
+++ b/src/goto-instrument/interrupt.cpp
@@ -16,7 +16,7 @@ Date: September 2011
 #include <util/range.h>
 #include <util/std_code.h>
 
-#include <linking/static_lifetime_init.h>
+#include <goto-programs/initialize_function.h>
 
 #ifdef LOCAL_MAY
 #include <analyses/local_may_alias.h>

--- a/src/goto-instrument/mmio.cpp
+++ b/src/goto-instrument/mmio.cpp
@@ -13,7 +13,7 @@ Date: September 2011
 
 #include "mmio.h"
 
-#include <linking/static_lifetime_init.h>
+#include <goto-programs/initialize_function.h>
 
 #include "rw_set.h"
 

--- a/src/goto-instrument/nondet_static.cpp
+++ b/src/goto-instrument/nondet_static.cpp
@@ -23,8 +23,7 @@ Date: November 2011
 #include <util/std_code.h>
 
 #include <goto-programs/goto_model.h>
-
-#include <linking/static_lifetime_init.h>
+#include <goto-programs/initialize_function.h>
 
 #include <regex>
 

--- a/src/goto-instrument/race_check.cpp
+++ b/src/goto-instrument/race_check.cpp
@@ -15,9 +15,8 @@ Date: February 2006
 
 #include <util/pointer_predicates.h>
 
+#include <goto-programs/initialize_function.h>
 #include <goto-programs/remove_skip.h>
-
-#include <linking/static_lifetime_init.h>
 
 #include "rw_set.h"
 

--- a/src/goto-instrument/wmm/goto2graph.cpp
+++ b/src/goto-instrument/wmm/goto2graph.cpp
@@ -13,18 +13,18 @@ Date: 2012
 
 #include "goto2graph.h"
 
-#include <vector>
-#include <string>
-#include <fstream>
-
 #include <util/options.h>
 #include <util/prefix.h>
 
-#include <linking/static_lifetime_init.h>
+#include <goto-programs/initialize_function.h>
 
 #include <goto-instrument/rw_set.h>
 
 #include "fence.h"
+
+#include <fstream>
+#include <string>
+#include <vector>
 
 // #define PRINT_UNSAFES
 

--- a/src/goto-instrument/wmm/module_dependencies.txt
+++ b/src/goto-instrument/wmm/module_dependencies.txt
@@ -1,5 +1,4 @@
 goto-instrument
 goto-instrument/wmm
 goto-programs
-linking
 util

--- a/src/goto-instrument/wmm/shared_buffers.cpp
+++ b/src/goto-instrument/wmm/shared_buffers.cpp
@@ -14,7 +14,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/pointer_expr.h>
 #include <util/std_code.h>
 
-#include <linking/static_lifetime_init.h>
+#include <goto-programs/initialize_function.h>
 
 #include <goto-instrument/rw_set.h>
 

--- a/src/goto-instrument/wmm/weak_memory.cpp
+++ b/src/goto-instrument/wmm/weak_memory.cpp
@@ -21,18 +21,17 @@ Date: September 2011
 
 #include "weak_memory.h"
 
-#include <set>
-
 #include <util/fresh_symbol.h>
 
+#include <goto-programs/initialize_function.h>
 #include <goto-programs/remove_skip.h>
-
-#include <linking/static_lifetime_init.h>
 
 #include <goto-instrument/rw_set.h>
 
-#include "shared_buffers.h"
 #include "goto2graph.h"
+#include "shared_buffers.h"
+
+#include <set>
 
 /// all access to shared variables is pushed into assignments
 void introduce_temporaries(

--- a/src/goto-programs/initialize_function.h
+++ b/src/goto-programs/initialize_function.h
@@ -1,0 +1,20 @@
+/*******************************************************************\
+
+Module: Initialize Goto Program
+
+Author: Daniel Kroening, kroening@kroening.com
+
+\*******************************************************************/
+
+/// \file
+/// Defines INITIALIZE_FUNCTION, the name of the function that initializes
+/// all non-function symbols with static lifetime.
+
+#ifndef CPROVER_GOTO_PROGRAMS_INITIALIZE_FUNCTION_H
+#define CPROVER_GOTO_PROGRAMS_INITIALIZE_FUNCTION_H
+
+#include <util/cprover_prefix.h>
+
+#define INITIALIZE_FUNCTION CPROVER_PREFIX "initialize"
+
+#endif // CPROVER_GOTO_PROGRAMS_INITIALIZE_FUNCTION_H

--- a/src/goto-symex/module_dependencies.txt
+++ b/src/goto-symex/module_dependencies.txt
@@ -2,7 +2,6 @@ analyses
 goto-programs
 goto-symex
 langapi # should go away
-linking
 pointer-analysis
 solvers
 util

--- a/src/goto-symex/shadow_memory.cpp
+++ b/src/goto-symex/shadow_memory.cpp
@@ -19,8 +19,9 @@ Author: Peter Schrammel
 #include <util/pointer_expr.h>
 #include <util/string_constant.h>
 
+#include <goto-programs/initialize_function.h>
+
 #include <langapi/language_util.h>
-#include <linking/static_lifetime_init.h>
 
 #include "goto_symex_state.h"
 #include "shadow_memory_util.h"

--- a/src/linking/static_lifetime_init.cpp
+++ b/src/linking/static_lifetime_init.cpp
@@ -16,6 +16,7 @@ Author: Daniel Kroening, kroening@kroening.com
 #include <util/std_code.h>
 #include <util/symbol_table_base.h>
 
+#include <goto-programs/initialize_function.h>
 #include <goto-programs/goto_model.h>
 
 #include <ansi-c/goto-conversion/goto_convert_functions.h>

--- a/src/linking/static_lifetime_init.h
+++ b/src/linking/static_lifetime_init.h
@@ -10,8 +10,6 @@ Author: Daniel Kroening, kroening@kroening.com
 #ifndef CPROVER_LINKING_STATIC_LIFETIME_INIT_H
 #define CPROVER_LINKING_STATIC_LIFETIME_INIT_H
 
-#include <util/cprover_prefix.h>
-
 class goto_modelt;
 class message_handlert;
 class source_locationt;
@@ -20,8 +18,6 @@ class symbol_table_baset;
 void static_lifetime_init(
   symbol_table_baset &symbol_table,
   const source_locationt &source_location);
-
-#define INITIALIZE_FUNCTION CPROVER_PREFIX "initialize"
 
 /// Regenerates the CPROVER_INITIALIZE function, which initializes all
 /// non-function symbols of the goto model that have static lifetime. It is an

--- a/src/statement-list/statement_list_entry_point.cpp
+++ b/src/statement-list/statement_list_entry_point.cpp
@@ -20,8 +20,7 @@ Author: Matthias Weiss, matthias.weiss@diffblue.com
 
 #include <goto-programs/adjust_float_expressions.h>
 #include <goto-programs/goto_functions.h>
-
-#include <linking/static_lifetime_init.h>
+#include <goto-programs/initialize_function.h>
 
 /// Postfix for the artificial data block that is created when calling a main
 /// symbol that is a function block.


### PR DESCRIPTION
The INITIALIZE_FUNCTION macro was defined in
linking/static_lifetime_init.h, causing 22 files across the codebase to include this header solely to access this string constant. This translated to an otherwise-unnecessary dependency on the linking module. Move the macro definition to a new header
goto-programs/initialize_function.h, which is a more fundamental module.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
