### PR TITLE
Fix fp.isZero to handle -0 correctly

### DIFF
--- a/regression/smt2_solver/fp-issues/z3-isSubnormal-neg-zero.desc
+++ b/regression/smt2_solver/fp-issues/z3-isSubnormal-neg-zero.desc
@@ -1,0 +1,10 @@
+CORE
+z3-isSubnormal-neg-zero.smt2
+
+^EXIT=0$
+^SIGNAL=0$
+^unsat$
+--
+fp.isSubnormal(-0) must be false: -0 equals +0, so the "non-zero" conjunct
+(a float -> bool cast) is false. The assertion is therefore unsatisfiable.
+This shares the float -> bool cast fix with the fp.isZero case.

--- a/regression/smt2_solver/fp-issues/z3-isSubnormal-neg-zero.smt2
+++ b/regression/smt2_solver/fp-issues/z3-isSubnormal-neg-zero.smt2
@@ -1,0 +1,4 @@
+; Regression: fp.isSubnormal(-0) should be false (-0 is zero, not subnormal)
+(set-logic QF_FP)
+(assert (fp.isSubnormal (fp #b1 #b00000000 #b00000000000000000000000)))
+(check-sat)

--- a/regression/smt2_solver/fp-issues/z3-isZero-neg-zero.desc
+++ b/regression/smt2_solver/fp-issues/z3-isZero-neg-zero.desc
@@ -1,0 +1,10 @@
+CORE
+z3-isZero-neg-zero.smt2
+
+^EXIT=0$
+^SIGNAL=0$
+^unsat$
+--
+fp.isZero(-0) must be true: -0 equals +0 per IEEE 754, so the assertion
+not(fp.isZero(-0)) is unsatisfiable. This exercises the float -> bool cast,
+which must mask the sign bit rather than OR all bits together.

--- a/regression/smt2_solver/fp-issues/z3-isZero-neg-zero.smt2
+++ b/regression/smt2_solver/fp-issues/z3-isZero-neg-zero.smt2
@@ -1,0 +1,4 @@
+; Regression: fp.isZero(-0) should be true
+(set-logic QF_FP)
+(assert (not (fp.isZero (fp #b1 #b00000000 #b00000000000000000000000))))
+(check-sat)

--- a/src/solvers/flattening/boolbv_typecast.cpp
+++ b/src/solvers/flattening/boolbv_typecast.cpp
@@ -637,7 +637,21 @@ literalt boolbvt::convert_typecast(const typecast_exprt &expr)
   const bvt &bv = convert_bv(expr.op());
 
   if(!bv.empty())
+  {
+    // For a floating-point source, casting to bool yields "value is non-zero",
+    // and -0 must count as zero even though its sign bit is set. Mask the sign
+    // via float_utilst::is_zero rather than OR-ing all bits together. This
+    // mirrors the IS_C_BOOL (_Bool) destination case in type_conversion.
+    if(expr.op().type().id() == ID_floatbv)
+    {
+      float_utilst float_utils(prop, to_floatbv_type(expr.op().type()));
+      return !float_utils.is_zero(bv);
+    }
+
+    // Other bitvector sources (fixedbv, integers, ...) intentionally fall
+    // through: they have no -0, so OR-ing all bits is a correct non-zero test.
     return prop.lor(bv);
+  }
 
   return SUB::convert_rest(expr);
 }


### PR DESCRIPTION
The previous implementation used not(typecast_to_bool) which checks if the bitvector is all-zeros, but -0 has sign bit 1 so it was incorrectly reported as non-zero.

Fix: use ieee_float_equal with +0, which correctly treats -0 == +0 per IEEE 754 semantics.

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
