### PR TITLE
Byte-operator lowering: handle c_bool (and pointer) in adjust_width

### DIFF
--- a/src/util/byte_operators.h
+++ b/src/util/byte_operators.h
@@ -20,6 +20,8 @@ Author: Daniel Kroening, kroening@kroening.com
 #include "invariant.h"
 #include "std_expr.h"
 
+class bitvector_typet;
+
 /// Expression of type \c type extracted from some object \c op starting at
 /// position \c offset (given in number of bytes).
 /// The object can either be interpreted in big endian or little endian, which

--- a/src/util/lower_byte_operators.cpp
+++ b/src/util/lower_byte_operators.cpp
@@ -55,22 +55,36 @@ static boundst map_bounds(
   return result;
 }
 
-/// changes the width of the given bitvector type
+/// Returns a bitvector type of width \p new_width that mirrors the shape of
+/// \p src. Accepted source type ids are ID_unsignedbv, ID_signedbv, ID_bv,
+/// ID_c_enum and ID_c_bit_field (resolved via their underlying type), and
+/// ID_pointer and ID_c_bool (both mapped to ID_bv, matching the treatment of
+/// these types in unpack_rec). Floating-point types (ID_floatbv, ID_fixedbv)
+/// are intentionally unsupported: reinterpreting them at a different width as a
+/// raw bitvector would be meaningless, so callers must not pass them.
+/// Not marked `static` to make unit-testing possible (regression for #8475).
+/// \param src: source type whose id selects the kind of the result
+/// \param new_width: width of the returned bitvector type
+/// \return a bitvector type of width \p new_width
 bitvector_typet adjust_width(const typet &src, std::size_t new_width)
 {
   if(src.id() == ID_unsignedbv)
     return unsignedbv_typet(new_width);
-  else if(src.id() == ID_signedbv)
+  if(src.id() == ID_signedbv)
     return signedbv_typet(new_width);
-  else if(src.id() == ID_bv)
+  if(src.id() == ID_bv)
     return bv_typet(new_width);
-  else if(src.id() == ID_c_enum) // we use the underlying type
+  if(src.id() == ID_c_enum) // we use the underlying type
     return adjust_width(to_c_enum_type(src).underlying_type(), new_width);
-  else if(src.id() == ID_c_bit_field)
+  if(src.id() == ID_c_bit_field)
     return c_bit_field_typet(
       to_c_bit_field_type(src).underlying_type(), new_width);
-  else
-    PRECONDITION(false);
+  // Pointers and C Booleans are stored as plain bitvectors; reinterpret their
+  // raw bits at the requested width, as unpack_rec does for these types.
+  if(src.id() == ID_pointer || src.id() == ID_c_bool)
+    return bv_typet(new_width);
+
+  PRECONDITION(false);
 }
 
 /// Convert a bitvector-typed expression \p bitvector_expr to a struct-typed

--- a/unit/util/lower_byte_operators.cpp
+++ b/unit/util/lower_byte_operators.cpp
@@ -13,6 +13,7 @@
 #include <util/config.h>
 #include <util/expr_util.h>
 #include <util/namespace.h>
+#include <util/pointer_expr.h>
 #include <util/pointer_offset_size.h>
 #include <util/simplify_expr.h>
 #include <util/simplify_utils.h>
@@ -512,6 +513,204 @@ SCENARIO("byte_update_lowering", "[core][util][lowering][byte_update]")
             REQUIRE(lower_bu_s == *r);
           }
         }
+      }
+    }
+  }
+}
+
+bitvector_typet adjust_width(const typet &src, std::size_t new_width);
+
+TEST_CASE(
+  "adjust_width handles c_bool and pointer types",
+  "[core][util][lowering][byte_extract]")
+{
+  // Regression test for issue #8475: adjust_width must map ID_c_bool (and
+  // ID_pointer) to a plain bitvector type rather than hitting its
+  // PRECONDITION(false). ID_c_bool is the type that the heap_iterator.c
+  // reproducer of #8475 actually reaches (a `bool` array is byte-extracted at a
+  // wider width); ID_pointer is handled for the same reason. This is the most
+  // direct check of the fix; the lower_byte_extract SCENARIOs below exercise it
+  // through the surrounding lowering.
+  cmdlinet cmdline;
+  config.set(cmdline);
+
+  const c_bool_typet bool_type{config.ansi_c.char_width};
+  const bitvector_typet from_c_bool = adjust_width(bool_type, 64);
+  REQUIRE(from_c_bool.id() == ID_bv);
+  REQUIRE(from_c_bool.get_width() == 64);
+
+  const pointer_typet ptr_type{signedbv_typet{32}, config.ansi_c.pointer_width};
+  const bitvector_typet from_pointer = adjust_width(ptr_type, 64);
+  REQUIRE(from_pointer.id() == ID_bv);
+  REQUIRE(from_pointer.get_width() == 64);
+}
+
+TEST_CASE(
+  "byte extract from c_bool array",
+  "[core][util][lowering][byte_extract]")
+{
+  // End-to-end-style check at the lowering level for issue #8475: extracting a
+  // value wider than one byte from an array of C Booleans drives
+  // lower_byte_extract down the concatenation path, which calls
+  // adjust_width(*subtype) with subtype == c_bool (C Booleans are byte sized,
+  // so unpacking leaves them in place). Before the fix this aborted at the
+  // adjust_width PRECONDITION; afterwards lowering succeeds.
+  cmdlinet cmdline;
+  config.set(cmdline);
+
+  const namespacet &ns = empty_namespace;
+
+  const c_bool_typet bool_type{config.ansi_c.char_width};
+  const array_typet arr_type{bool_type, from_integer(8, size_type())};
+  const symbol_exprt src{"b", arr_type};
+
+  THEN("lowering a multi-byte read does not crash")
+  {
+    for(const auto &endianness :
+        {ID_byte_extract_little_endian, ID_byte_extract_big_endian})
+    {
+      // a 16-bit read spans two c_bool elements -> width_bytes == 2
+      const byte_extract_exprt be(
+        endianness,
+        src,
+        from_integer(0, c_index_type()),
+        config.ansi_c.char_width,
+        unsignedbv_typet{16});
+
+      const exprt lower_be = lower_byte_extract(be, ns);
+      REQUIRE(!has_subexpr(lower_be, ID_byte_extract_little_endian));
+      REQUIRE(!has_subexpr(lower_be, ID_byte_extract_big_endian));
+      REQUIRE(lower_be.type() == be.type());
+    }
+  }
+}
+
+TEST_CASE("byte extract pointer type", "[core][util][lowering][byte_extract]")
+{
+  cmdlinet cmdline;
+  config.set(cmdline);
+
+  const namespacet &ns = empty_namespace;
+
+  const pointer_typet ptr_type{signedbv_typet{32}, config.ansi_c.pointer_width};
+
+  GIVEN("A byte_extract of pointer type from a bitvector")
+  {
+    const unsignedbv_typet u64{64};
+    const exprt src = from_integer(0, u64);
+
+    THEN("lowering does not crash")
+    {
+      for(const auto &endianness :
+          {ID_byte_extract_little_endian, ID_byte_extract_big_endian})
+      {
+        const byte_extract_exprt be(
+          endianness,
+          src,
+          from_integer(0, c_index_type()),
+          config.ansi_c.char_width,
+          ptr_type);
+
+        const exprt lower_be = lower_byte_extract(be, ns);
+        REQUIRE(!has_subexpr(lower_be, ID_byte_extract_little_endian));
+        REQUIRE(!has_subexpr(lower_be, ID_byte_extract_big_endian));
+        REQUIRE(lower_be.type() == be.type());
+      }
+    }
+  }
+
+  GIVEN("A byte_extract of an array of pointers")
+  {
+    const array_typet arr_type{ptr_type, from_integer(2, size_type())};
+    const auto arr_bits = pointer_offset_bits(arr_type, ns);
+    REQUIRE(arr_bits.has_value());
+    const unsignedbv_typet src_type{
+      numeric_cast_v<std::size_t>(*arr_bits) + 16};
+    const exprt src = from_integer(0, src_type);
+
+    THEN("lowering does not crash")
+    {
+      for(const auto &endianness :
+          {ID_byte_extract_little_endian, ID_byte_extract_big_endian})
+      {
+        const byte_extract_exprt be(
+          endianness,
+          src,
+          from_integer(2, c_index_type()),
+          config.ansi_c.char_width,
+          arr_type);
+
+        const exprt lower_be = lower_byte_extract(be, ns);
+        REQUIRE(!has_subexpr(lower_be, ID_byte_extract_little_endian));
+        REQUIRE(!has_subexpr(lower_be, ID_byte_extract_big_endian));
+        REQUIRE(lower_be.type() == be.type());
+      }
+    }
+  }
+}
+
+TEST_CASE("byte update pointer type", "[core][util][lowering][byte_update]")
+{
+  // Companion to "byte extract pointer type": lowering a byte_update whose
+  // object has pointer (or array-of-pointer) type reconstructs the result via
+  // the same bv_to_expr path that feeds adjust_width with a pointer type.
+  cmdlinet cmdline;
+  config.set(cmdline);
+
+  const namespacet &ns = empty_namespace;
+
+  const pointer_typet ptr_type{signedbv_typet{32}, config.ansi_c.pointer_width};
+  const unsignedbv_typet u8{config.ansi_c.char_width};
+
+  GIVEN("A byte_update overwriting a byte of a pointer")
+  {
+    const symbol_exprt p{"p", ptr_type};
+
+    THEN("lowering does not crash")
+    {
+      for(const auto &endianness :
+          {ID_byte_update_little_endian, ID_byte_update_big_endian})
+      {
+        const byte_update_exprt bu(
+          endianness,
+          p,
+          from_integer(0, c_index_type()),
+          from_integer(0, u8),
+          config.ansi_c.char_width);
+
+        const exprt lower_bu = lower_byte_operators(bu, ns);
+        REQUIRE(!has_subexpr(lower_bu, ID_byte_update_little_endian));
+        REQUIRE(!has_subexpr(lower_bu, ID_byte_update_big_endian));
+        REQUIRE(!has_subexpr(lower_bu, ID_byte_extract_little_endian));
+        REQUIRE(!has_subexpr(lower_bu, ID_byte_extract_big_endian));
+        REQUIRE(lower_bu.type() == bu.type());
+      }
+    }
+  }
+
+  GIVEN("A byte_update overwriting a byte of an array of pointers")
+  {
+    const array_typet arr_type{ptr_type, from_integer(2, size_type())};
+    const symbol_exprt a{"a", arr_type};
+
+    THEN("lowering does not crash")
+    {
+      for(const auto &endianness :
+          {ID_byte_update_little_endian, ID_byte_update_big_endian})
+      {
+        const byte_update_exprt bu(
+          endianness,
+          a,
+          from_integer(2, c_index_type()),
+          from_integer(0, u8),
+          config.ansi_c.char_width);
+
+        const exprt lower_bu = lower_byte_operators(bu, ns);
+        REQUIRE(!has_subexpr(lower_bu, ID_byte_update_little_endian));
+        REQUIRE(!has_subexpr(lower_bu, ID_byte_update_big_endian));
+        REQUIRE(!has_subexpr(lower_bu, ID_byte_extract_little_endian));
+        REQUIRE(!has_subexpr(lower_bu, ID_byte_extract_big_endian));
+        REQUIRE(lower_bu.type() == bu.type());
       }
     }
   }


### PR DESCRIPTION
`adjust_width()` in `lower_byte_operators.cpp` handled only a fixed set of
bitvector type ids and hit `PRECONDITION(false)` for anything else.

When `lower_byte_extract` reconstructs a value wider than one byte from an array
whose element type is byte sized, it calls `adjust_width` on that element type.
For an array of C Booleans (`bool[]`) the element type is `ID_c_bool`, which was
not handled, so CBMC aborted with

```
Invariant check failed
File: .../src/util/lower_byte_operators.cpp function: adjust_width
Reason: Precondition
```

while converting the SSA. This is the failure reported in #8475, whose
reproducer is a heap data structure that byte-accesses a `bool` array.

### Fix

Handle `ID_c_bool` by returning a plain bitvector type of the requested width,
mirroring the way `unpack_rec` treats such values as raw bits. The same
reasoning applies to `ID_pointer`, so it is handled alongside.

Note on the original diagnosis: the issue was initially attributed to
`ID_pointer`, but on the #8475 reproducer the type that actually reaches
`adjust_width` is `ID_c_bool`. 64-bit pointers are unpacked into individual
byte-sized elements before reaching `adjust_width`, whereas C Booleans are
already byte sized, so a `bool[]` array keeps `ID_c_bool` as its element type
and is the type that triggers the abort. `ID_pointer` is kept for robustness and
to keep its direct unit test meaningful.

### Testing

Added unit tests in `unit/util/lower_byte_operators.cpp`:
- `adjust_width handles c_bool and pointer types` — directly checks that both ids
  map to a bitvector type of the requested width.
- `byte extract from c_bool array` — drives `lower_byte_extract` to read a
  multi-byte value from an array of C Booleans, exercising the exact code path
  from #8475.

Both tests abort at the `adjust_width` precondition before this change and pass
after it (verified against a pre-fix build).

No end-to-end `regression/cbmc` test is included: on the original reproducer the
abort only triggers with `--unwind 5`, at which point solving the (fixed) proof
needs roughly 1.5 minutes and ~30 GB of RAM — too heavy for CI — and every
minimal hand-crafted C variant is simplified by symbolic execution before the
byte-extract reaches the SAT backend. The unit tests reproduce the failure
deterministically at the lowering level where it occurs.

Fixes: #8475

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/ (N/A: internal lowering fix, no user-visible behaviour change beyond no longer aborting).
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed). (N/A: no performance claim.)
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own. (N/A: none.)
