### PR TITLE
Fix solver option conflict detection in CBMC

### DIFF
--- a/regression/cbmc/Failing_Assert1/dimacs.desc
+++ b/regression/cbmc/Failing_Assert1/dimacs.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE no-new-smt broken-z3-smt-backend broken-cprover-smt-backend
 main.c
 --dimacs --verbosity 8
 ^Runtime decision procedure: [0-9]+(\.[0-9]+)?(e-[0-9]+)?s$

--- a/regression/cbmc/Failing_Assert1/external-z3.desc
+++ b/regression/cbmc/Failing_Assert1/external-z3.desc
@@ -1,4 +1,4 @@
-CORE gcc-only no-new-smt
+CORE gcc-only no-new-smt broken-z3-smt-backend broken-cprover-smt-backend
 main.c
 --external-sat-solver ./z3-wrapper.sh --trace
 ^VERIFICATION FAILED$

--- a/regression/cbmc/conflicting_solver_options/main.c
+++ b/regression/cbmc/conflicting_solver_options/main.c
@@ -1,0 +1,6 @@
+int main()
+{
+  int x;
+  __CPROVER_assert(x == 0, "");
+  return 0;
+}

--- a/regression/cbmc/conflicting_solver_options/test.desc
+++ b/regression/cbmc/conflicting_solver_options/test.desc
@@ -1,0 +1,7 @@
+CORE broken-z3-smt-backend broken-cprover-smt-backend no-new-smt
+main.c
+--smt2 --external-sat-solver kissat
+^EXIT=1$
+^SIGNAL=0$
+conflicting solver options: --external-sat-solver and --smt2 must not be given together
+--

--- a/regression/cbmc/conflicting_solver_options/test2.desc
+++ b/regression/cbmc/conflicting_solver_options/test2.desc
@@ -1,0 +1,7 @@
+CORE broken-z3-smt-backend broken-cprover-smt-backend no-new-smt
+main.c
+--dimacs --external-sat-solver kissat
+^EXIT=1$
+^SIGNAL=0$
+conflicting solver options: --dimacs and --external-sat-solver must not be given together
+--

--- a/regression/cbmc/conflicting_solver_options/test3.desc
+++ b/regression/cbmc/conflicting_solver_options/test3.desc
@@ -1,0 +1,7 @@
+CORE broken-z3-smt-backend broken-cprover-smt-backend no-new-smt
+main.c
+--z3 --external-sat-solver kissat
+^EXIT=1$
+^SIGNAL=0$
+conflicting solver options: --external-sat-solver and --z3 must not be given together
+--

--- a/regression/cbmc/conflicting_solver_options/test4.desc
+++ b/regression/cbmc/conflicting_solver_options/test4.desc
@@ -1,0 +1,7 @@
+CORE broken-z3-smt-backend broken-cprover-smt-backend no-new-smt
+main.c
+--dimacs --smt2
+^EXIT=1$
+^SIGNAL=0$
+conflicting solver options: --dimacs and --smt2 must not be given together
+--

--- a/regression/cbmc/conflicting_solver_options/test5.desc
+++ b/regression/cbmc/conflicting_solver_options/test5.desc
@@ -1,0 +1,7 @@
+CORE broken-z3-smt-backend broken-cprover-smt-backend no-new-smt
+main.c
+--smt2 --incremental-smt2-solver z3
+^EXIT=1$
+^SIGNAL=0$
+conflicting solver options: --smt2 and --incremental-smt2-solver must not be given together
+--

--- a/regression/cbmc/conflicting_solver_options/test6.desc
+++ b/regression/cbmc/conflicting_solver_options/test6.desc
@@ -1,0 +1,7 @@
+CORE broken-z3-smt-backend broken-cprover-smt-backend no-new-smt
+main.c
+--external-smt2-solver z3 --external-sat-solver kissat
+^EXIT=1$
+^SIGNAL=0$
+conflicting solver options: --external-sat-solver and --external-smt2-solver must not be given together
+--

--- a/regression/cbmc/conflicting_solver_options/test7.desc
+++ b/regression/cbmc/conflicting_solver_options/test7.desc
@@ -1,0 +1,7 @@
+CORE broken-z3-smt-backend broken-cprover-smt-backend no-new-smt
+main.c
+--fpa --incremental-smt2-solver z3
+^EXIT=1$
+^SIGNAL=0$
+--fpa is not supported with --incremental-smt2-solver
+--

--- a/regression/cbmc/deterministic-smt-output/test.desc
+++ b/regression/cbmc/deterministic-smt-output/test.desc
@@ -1,4 +1,4 @@
-CORE
+CORE no-new-smt
 main.c
 --smt2 --outfile -
 activate-multi-line-match

--- a/regression/cbmc/issue_5952_soundness_bug_smt_encoding/test_original.desc
+++ b/regression/cbmc/issue_5952_soundness_bug_smt_encoding/test_original.desc
@@ -1,4 +1,4 @@
-CORE smt-backend
+CORE smt-backend no-new-smt
 original_repro.c
 --smt2
 ^EXIT=0$

--- a/regression/cbmc/issue_5952_soundness_bug_smt_encoding/test_short.desc
+++ b/regression/cbmc/issue_5952_soundness_bug_smt_encoding/test_short.desc
@@ -1,4 +1,4 @@
-CORE smt-backend
+CORE smt-backend no-new-smt
 short.c
 --smt2 --no-malloc-may-fail
 ^EXIT=0$

--- a/regression/cbmc/outfile_no_dir/test.desc
+++ b/regression/cbmc/outfile_no_dir/test.desc
@@ -1,4 +1,4 @@
-CORE paths-lifo-expected-failure
+CORE paths-lifo-expected-failure broken-z3-smt-backend broken-cprover-smt-backend no-new-smt
 main.c
 --dimacs --outfile /xyz/out.dimacs
 ^EXIT=1$

--- a/regression/cbmc/struct15/test.desc
+++ b/regression/cbmc/struct15/test.desc
@@ -1,4 +1,4 @@
-CORE smt-backend
+CORE smt-backend no-new-smt
 main.c
 --trace --z3
 ^EXIT=0$

--- a/regression/cbmc/z3/invalid.desc
+++ b/regression/cbmc/z3/invalid.desc
@@ -1,4 +1,4 @@
-CORE smt-backend
+CORE smt-backend no-new-smt
 invalid.c
 --trace --smt2 --z3
 ^EXIT=10$

--- a/regression/cbmc/z3/valid.desc
+++ b/regression/cbmc/z3/valid.desc
@@ -1,4 +1,4 @@
-CORE smt-backend
+CORE smt-backend no-new-smt
 valid.c
 --trace --smt2 --z3
 ^EXIT=0$

--- a/src/goto-checker/solver_factory.cpp
+++ b/src/goto-checker/solver_factory.cpp
@@ -32,6 +32,7 @@ Author: Daniel Kroening, Peter Schrammel
 #include <solvers/strings/string_refinement.h>
 
 #include <iostream>
+#include <vector>
 
 solver_factoryt::solver_factoryt(
   const optionst &_options,
@@ -720,6 +721,59 @@ void parse_solver_options(const cmdlinet &cmdline, optionst &options)
 {
   parse_sat_options(cmdline, options);
   parse_smt2_options(cmdline, options);
+
+  // Detect conflicting solver backend selections. The solver categories
+  // are mutually exclusive: DIMACS output, an external SAT solver, an
+  // SMT2 solver (including --smt2, solver-specific flags like --z3, and
+  // --external-smt2-solver), and the incremental SMT2 solver.
+  std::vector<std::string> solver_flags;
+
+  if(cmdline.isset("dimacs"))
+    solver_flags.push_back("--dimacs");
+
+  if(cmdline.isset("external-sat-solver"))
+    solver_flags.push_back("--external-sat-solver");
+
+  // All SMT2-related flags are in the same category (at most one
+  // reported in the conflict message).
+  for(const char *smt2_flag :
+      {"smt2",
+       "bitwuzla",
+       "boolector",
+       "cprover-smt2",
+       "mathsat",
+       "cvc3",
+       "cvc4",
+       "cvc5",
+       "yices",
+       "z3",
+       "external-smt2-solver"})
+  {
+    if(cmdline.isset(smt2_flag))
+    {
+      solver_flags.push_back(std::string("--") + smt2_flag);
+      break;
+    }
+  }
+
+  if(cmdline.isset("incremental-smt2-solver"))
+    solver_flags.push_back("--incremental-smt2-solver");
+
+  if(solver_flags.size() > 1)
+  {
+    throw invalid_command_line_argument_exceptiont(
+      "conflicting solver options: " + solver_flags[0] + " and " +
+        solver_flags[1] + " must not be given together",
+      solver_flags[0] + " " + solver_flags[1]);
+  }
+
+  // --fpa is not supported with the incremental SMT2 solver
+  if(cmdline.isset("incremental-smt2-solver") && cmdline.isset("fpa"))
+  {
+    throw invalid_command_line_argument_exceptiont(
+      "--fpa is not supported with --incremental-smt2-solver",
+      "--fpa --incremental-smt2-solver");
+  }
 
   if(cmdline.isset("outfile"))
     options.set_option("outfile", cmdline.get_value("outfile"));


### PR DESCRIPTION
- Add validation logic to detect conflicting solver options
- Fail with error when mutually exclusive options are used together
- Add comprehensive test cases for various conflict scenarios
- Fixes issue where --smt2 and --external-sat-solver could be used simultaneously

Fixes: #8401

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
