### PR TITLE
Fix crash in shadow memory operations with zero-sized types

### DIFF
--- a/regression/cbmc-shadow-memory/zero-sized-types/main.c
+++ b/regression/cbmc-shadow-memory/zero-sized-types/main.c
@@ -1,0 +1,82 @@
+// Regression test for zero-sized types (ZSTs) in shadow memory operations
+// This test verifies that CBMC doesn't crash when shadow memory operations
+// are used with structures containing ZST fields.
+
+struct ZeroSized
+{
+};
+
+struct WithZST
+{
+  int i;
+  struct ZeroSized zst;
+};
+
+struct TopStruct
+{
+  int f1;
+  struct WithZST f2;
+};
+
+// Test with nested ZST
+struct NestedZST
+{
+  struct ZeroSized zst1;
+  struct ZeroSized zst2;
+  int value;
+};
+
+// Test with only ZST members
+struct OnlyZST
+{
+  struct ZeroSized zst;
+};
+
+void main()
+{
+  __CPROVER_field_decl_local("shadow", (_Bool)0);
+
+  // Test 1: Basic struct with ZST field
+  struct TopStruct top;
+  __CPROVER_set_field(&top.f1, "shadow", 1);
+  __CPROVER_assert(
+    __CPROVER_get_field(&top.f1, "shadow") == 1,
+    "expected success: set field to value 1");
+
+  // Test 2: Get field on struct containing ZST
+  // This used to crash with invariant violation in boolbv.cpp
+  __CPROVER_assert(
+    __CPROVER_get_field(&top.f2, "shadow") == 0,
+    "expected success: default value is 0");
+
+  // Test 3: Set and get field on struct containing ZST
+  __CPROVER_set_field(&top.f2, "shadow", 1);
+  __CPROVER_assert(
+    __CPROVER_get_field(&top.f2, "shadow") == 1,
+    "expected success: set/get field on struct with ZST");
+
+  // Test 4: Test with member access on struct with ZST
+  __CPROVER_set_field(&top.f2.i, "shadow", 1);
+  __CPROVER_assert(
+    __CPROVER_get_field(&top.f2.i, "shadow") == 1,
+    "expected success: set/get on int member of struct with ZST");
+
+  // Test 5: Nested ZST fields
+  struct NestedZST nested;
+  __CPROVER_set_field(&nested.value, "shadow", 1);
+  __CPROVER_assert(
+    __CPROVER_get_field(&nested.value, "shadow") == 1,
+    "expected success: nested ZST fields");
+
+  __CPROVER_assert(
+    __CPROVER_get_field(&nested, "shadow") == 1,
+    "expected success: get field on entire struct with multiple ZSTs");
+
+  // Test 6: Struct with only ZST members
+  struct OnlyZST only_zst;
+  // Getting/setting shadow memory on a struct with only ZST members
+  // should work and return the default value
+  __CPROVER_assert(
+    __CPROVER_get_field(&only_zst, "shadow") == 0,
+    "expected success: struct with only ZST members has default value");
+}

--- a/regression/cbmc-shadow-memory/zero-sized-types/test.desc
+++ b/regression/cbmc-shadow-memory/zero-sized-types/test.desc
@@ -1,0 +1,8 @@
+CORE gcc-only
+main.c
+--no-standard-checks
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+^warning: ignoring

--- a/src/goto-symex/shadow_memory_util.cpp
+++ b/src/goto-symex/shadow_memory_util.cpp
@@ -430,6 +430,11 @@ static void extract_bytes_of_expr(
 /// \return A newly constructed or_exprt over the possible values given.
 static exprt or_values(const exprt::operandst &values, const typet &field_type)
 {
+  if(values.empty())
+  {
+    // Return false (zero) for empty values (e.g., when all fields are ZSTs)
+    return from_integer(0, field_type);
+  }
   if(values.size() == 1)
   {
     return values[0];
@@ -461,6 +466,13 @@ exprt compute_or_over_bytes(
     for(const auto &component : components)
     {
       if(component.get_is_padding())
+      {
+        continue;
+      }
+      // Skip zero-sized types (ZSTs) to avoid creating expressions with
+      // zero-width bitvectors that violate solver invariants
+      auto component_bits = pointer_offset_bits(component.type(), ns);
+      if(component_bits.has_value() && *component_bits == 0)
       {
         continue;
       }
@@ -608,6 +620,12 @@ exprt compute_max_over_bytes(
 
   // Compute how many bytes are in `expr`
   std::size_t byte_count = size / config.ansi_c.char_width;
+
+  // Handle zero-sized types (ZSTs) - return the default value (zero)
+  if(byte_count == 0)
+  {
+    return from_integer(0, field_type);
+  }
 
   // Extract each byte of `expr` by using byte_extract.
   std::vector<exprt> extracted_bytes;


### PR DESCRIPTION
- Add ZST width checks in compute_or_over_bytes and compute_max_over_bytes
- Skip zero-sized components to prevent bitvector invariant violations
- Return default value (zero) for empty values and zero-byte types
- Add comprehensive regression test for ZST handling in shadow memory

Fixes: #8284

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
