### PR TITLE
SMT2 back-end: handle unflatten for arrays when use_as_const is false

### DIFF
--- a/regression/cbmc/smt2-outfile-array-nested/main.c
+++ b/regression/cbmc/smt2-outfile-array-nested/main.c
@@ -1,0 +1,27 @@
+// Wider-coverage companion to ../smt2-outfile-array: exercises the
+// non-as-const unflatten path on a multi-dimensional array, where the
+// outer array's element type is itself an array. The
+// find_symbols_rec recursion must declare an unflatten_base_* for both
+// the inner and outer array types, and unflatten must then nest its
+// store-chain through both levels without forward-referencing the
+// auxiliary names.
+
+struct S
+{
+  int data[2][2];
+  int x;
+};
+
+struct S nondet_S(void);
+
+int main()
+{
+  struct S s = nondet_S();
+  int arr[2][2];
+  arr[0][0] = s.data[0][0];
+  arr[0][1] = s.data[0][1];
+  arr[1][0] = s.data[1][0];
+  arr[1][1] = s.data[1][1];
+  __CPROVER_assert(arr[0][0] == arr[1][1], "check");
+  return 0;
+}

--- a/regression/cbmc/smt2-outfile-array-nested/test.desc
+++ b/regression/cbmc/smt2-outfile-array-nested/test.desc
@@ -1,0 +1,21 @@
+CORE no-new-smt broken-cprover-smt-backend broken-z3-smt-backend
+main.c
+--smt2 --outfile -
+activate-multi-line-match
+\(declare-fun unflatten_base_\d+ \(\) \(Array \(_ BitVec \d+\) \(_ BitVec \d+\)\)\)(?s:.)*\(declare-fun unflatten_base_\d+ \(\) \(Array \(_ BitVec \d+\) \(Array \(_ BitVec \d+\) \(_ BitVec \d+\)\)\)\)(?s:.)*\(store unflatten_base_\d+
+^EXIT=0$
+^SIGNAL=0$
+--
+^Invariant check failed
+^warning: ignoring
+--
+Wider-coverage companion to ../smt2-outfile-array: exercises the
+non-as-const unflatten path on a multi-dimensional array. The C input
+has a `int data[2][2]` field, which forces find_symbols_rec to declare
+auxiliaries for both the inner array (Array bv64 bv32) and the outer
+array (Array bv64 (Array bv64 bv32)). The regex pins the presence of
+both top-level declarations and that at least one is used as a store
+base, ensuring that nested unflatten correctly threads the helper
+identifiers through both levels rather than relying on (as const).
+The `no-new-smt`, `broken-cprover-smt-backend` and `broken-z3-smt-backend`
+tags are set for the same reason as in ../smt2-outfile-array/test.desc.

--- a/regression/cbmc/smt2-outfile-array/main.c
+++ b/regression/cbmc/smt2-outfile-array/main.c
@@ -1,0 +1,17 @@
+struct S
+{
+  int data[4];
+  int x;
+};
+
+struct S nondet_S(void);
+
+int main()
+{
+  struct S s = nondet_S();
+  int arr[4];
+  arr[0] = s.data[0];
+  arr[1] = s.data[1];
+  __CPROVER_assert(arr[0] == arr[1], "check");
+  return 0;
+}

--- a/regression/cbmc/smt2-outfile-array/test.desc
+++ b/regression/cbmc/smt2-outfile-array/test.desc
@@ -1,0 +1,31 @@
+CORE no-new-smt broken-cprover-smt-backend broken-z3-smt-backend
+main.c
+--smt2 --outfile -
+activate-multi-line-match
+\(declare-fun unflatten_base_\d+ \(\) \(Array \(_ BitVec \d+\) \(_ BitVec \d+\)\)\)(?s:.)*\(store unflatten_base_\d+
+^EXIT=0$
+^SIGNAL=0$
+--
+^Invariant check failed
+^warning: ignoring
+--
+Reproducer for #8637: --smt2 --outfile (without an explicit solver) used
+to abort with PRECONDITION(use_as_const) in unflatten when an array LHS
+appeared at a define-fun site with use_as_const == false.
+
+This descriptor pins both the absence of that abort and the structure of
+the new encoding: an `unflatten_base_<n>` array is declared at the top
+level (during find_symbols_rec on the array type), and it is later used
+as the base of a nested `(store ...)` chain that initialises every
+in-range index. The multi-line regex enforces that the declaration
+precedes the first store onto the auxiliary, which would otherwise be a
+forward-reference. `--outfile -` writes to stdout to avoid leaving an
+`outfile.smt2` artifact in the test directory.
+
+The `no-new-smt` tag excludes this test from the incremental SMT2
+back-end (`--incremental-smt2-solver`), which uses a separate code
+path and is incompatible with `--smt2 --outfile`. The
+`broken-cprover-smt-backend` and `broken-z3-smt-backend` tags exclude the
+cprover-smt2 and z3 profiles, which prepend `--cprover-smt2` / `--z3` to the
+test command and switch the back-end to use_as_const = true, in which case
+`unflatten_base_*` declarations are not emitted.

--- a/regression/validate-trace-xml-schema/check.py
+++ b/regression/validate-trace-xml-schema/check.py
@@ -16,6 +16,8 @@ ExcludedTests = list(map(lambda s: os.path.join(test_base_dir, s[0], s[1]), [
     ['array_of_bool_as_bitvec', 'test-smt2-outfile.desc'],
     ['deterministic-smt-output', 'test.desc'],
     ['z3-lambda-unflatten', 'test.desc'],
+    ['smt2-outfile-array', 'test.desc'],
+    ['smt2-outfile-array-nested', 'test.desc'],
     # these tests expect input from stdin
     ['json-interface1', 'test_wrong_option.desc'],
     ['json-interface1', 'test.desc'],

--- a/src/solvers/smt2/smt2_conv.cpp
+++ b/src/solvers/smt2/smt2_conv.cpp
@@ -5022,6 +5022,34 @@ void smt2_convt::flatten2bv(const exprt &expr)
     convert_expr(expr);
 }
 
+std::string smt2_convt::declare_unflatten_base(const array_typet &array_type)
+{
+  auto it = unflatten_cache.find(array_type);
+  if(it != unflatten_cache.end())
+    return it->second;
+  std::string name = "unflatten_base_" + std::to_string(unflatten_counter++);
+  out << "(declare-fun " << name << " () ";
+  convert_type(array_type);
+  out << ")\n";
+  unflatten_cache[array_type] = name;
+  return name;
+}
+
+void smt2_convt::unflatten_store_pair(
+  const array_typet &array_type,
+  const mp_integer &i,
+  std::size_t offset,
+  std::size_t subtype_width,
+  unsigned nesting)
+{
+  convert_expr(from_integer(i, array_type.index_type()));
+  out << ' ';
+  unflatten(wheret::BEGIN, array_type.element_type(), nesting + 1);
+  out << "((_ extract " << offset + subtype_width - 1 << " " << offset
+      << ") ?ufop" << nesting << ")";
+  unflatten(wheret::END, array_type.element_type(), nesting + 1);
+}
+
 void smt2_convt::unflatten(
   wheret where,
   const typet &type,
@@ -5036,8 +5064,6 @@ void smt2_convt::unflatten(
   }
   else if(type.id() == ID_array)
   {
-    PRECONDITION(use_as_const || use_lambda_for_array);
-
     if(where == wheret::BEGIN)
       out << "(let ((?ufop" << nesting << " ";
     else
@@ -5054,49 +5080,76 @@ void smt2_convt::unflatten(
       mp_integer size =
         numeric_cast_v<mp_integer>(to_constant_expr(array_type.size()));
 
-      for(mp_integer i = 1; i < size; ++i)
-        out << "(store ";
-
-      // Build a constant array filled with element 0 as the base, then
-      // overwrite indices 1..N-1 via (store ...).
-      if(use_as_const)
+      if(use_as_const || use_lambda_for_array)
       {
-        out << "((as const ";
-        convert_type(array_type);
+        // A constant-array base supplies element 0 as the default value;
+        // overwrite indices 1..N-1 via (store ...).
+        for(mp_integer i = 1; i < size; ++i)
+          out << "(store ";
+
+        if(use_as_const)
+        {
+          out << "((as const ";
+          convert_type(array_type);
+          out << ") ";
+        }
+        else
+        {
+          // Note: lambda is a Z3/Bitwuzla extension; not part of the
+          // SMT-LIB 2.6 standard. It is used in preference to `(as const
+          // ...)` for back-ends (e.g. Z3) where the latter is unavailable or
+          // unsound. The bound variable `?ufidx<n>` is intentionally unused
+          // -- the body returns the element-0 value regardless of its
+          // argument, making this semantically equivalent to `(as const ...)`.
+          out << "(lambda ((?ufidx" << nesting << " ";
+          convert_type(array_type.index_type());
+          out << ")) ";
+        }
+        // use element at index 0 as default value
+        unflatten(wheret::BEGIN, array_type.element_type(), nesting + 1);
+        out << "((_ extract " << subtype_width - 1 << " "
+            << "0) ?ufop" << nesting << ")";
+        unflatten(wheret::END, array_type.element_type(), nesting + 1);
         out << ") ";
+
+        std::size_t offset = subtype_width;
+        for(mp_integer i = 1; i < size; ++i, offset += subtype_width)
+        {
+          unflatten_store_pair(array_type, i, offset, subtype_width, nesting);
+          out << ")"; // store
+        }
       }
       else
       {
+        // Neither `(as const ...)` nor `(lambda ...)` is available; build the
+        // array by storing all in-range elements onto a pre-declared
+        // auxiliary base array (standard SMT-LIB, no extensions).
+        //
+        // NOTE: Unlike the arms above, indices outside [0, size) here are
+        // left unconstrained rather than equal to element 0. This is
+        // acceptable for CBMC's existing call sites because bounds checks
+        // guarantee no out-of-range select can be reached, but the two
+        // encodings are NOT semantically equivalent.
+        auto cache_it = unflatten_cache.find(array_type);
         INVARIANT(
-          use_lambda_for_array,
-          "unflatten relies on `(lambda ...)` for constant arrays "
-          "when `(as const ...)` is unavailable");
-        // Note: lambda is a Z3/Bitwuzla extension; not part of the
-        // SMT-LIB 2.6 standard.  The bound variable `?ufidx<n>` is
-        // intentionally unused -- the body returns the element-0 value
-        // regardless of its argument, making this semantically
-        // equivalent to `(as const ...)`.
-        out << "(lambda ((?ufidx" << nesting << " ";
-        convert_type(array_type.index_type());
-        out << ")) ";
-      }
-      // use element at index 0 as default value
-      unflatten(wheret::BEGIN, array_type.element_type(), nesting + 1);
-      out << "((_ extract " << subtype_width - 1 << " "
-          << "0) ?ufop" << nesting << ")";
-      unflatten(wheret::END, array_type.element_type(), nesting + 1);
-      out << ") ";
+          cache_it != unflatten_cache.end(),
+          "unflatten auxiliary must have been pre-declared by "
+          "find_symbols_rec; this site assumes find_symbols (directly or "
+          "via prepare_for_convert_expr) was invoked on the array type "
+          "before reaching unflatten");
 
-      std::size_t offset = subtype_width;
-      for(mp_integer i = 1; i < size; ++i, offset += subtype_width)
-      {
-        convert_expr(from_integer(i, array_type.index_type()));
-        out << ' ';
-        unflatten(wheret::BEGIN, array_type.element_type(), nesting + 1);
-        out << "((_ extract " << offset + subtype_width - 1 << " " << offset
-            << ") ?ufop" << nesting << ")";
-        unflatten(wheret::END, array_type.element_type(), nesting + 1);
-        out << ")"; // store
+        for(mp_integer i = 0; i < size; ++i)
+          out << "(store ";
+
+        out << cache_it->second;
+
+        std::size_t offset = 0;
+        for(mp_integer i = 0; i < size; ++i, offset += subtype_width)
+        {
+          out << ' ';
+          unflatten_store_pair(array_type, i, offset, subtype_width, nesting);
+          out << ")"; // store
+        }
       }
 
       out << ")"; // let
@@ -6198,6 +6251,14 @@ void smt2_convt::find_symbols_rec(
     const array_typet &array_type=to_array_type(type);
     find_symbols(array_type.size());
     find_symbols_rec(array_type.element_type(), recstack);
+
+    // Pre-declare auxiliary base arrays for unflatten when neither
+    // `(as const ...)` nor `(lambda ...)` is available. Any inconsistency
+    // about which array types are eligible (e.g. non-constant size) surfaces
+    // at the DATA_INVARIANT in unflatten with its targeted message, rather
+    // than silently skipping here.
+    if(!use_as_const && !use_lambda_for_array)
+      declare_unflatten_base(array_type);
   }
   else if(type.id()==ID_complex)
   {

--- a/src/solvers/smt2/smt2_conv.h
+++ b/src/solvers/smt2/smt2_conv.h
@@ -236,6 +236,35 @@ protected:
   void flatten2bv(const exprt &);
   void unflatten(wheret, const typet &, unsigned nesting=0);
 
+  /// Cache of pre-declared auxiliary base arrays used by \ref unflatten when
+  /// `use_as_const` is false. Maps array types to SMT2 identifier names.
+  std::map<typet, std::string> unflatten_cache;
+  std::size_t unflatten_counter = 0;
+
+  /// Declare an auxiliary SMT2 array variable for use as the base in
+  /// \ref unflatten when `use_as_const` is false. The declaration is
+  /// emitted to \ref out and cached in \ref unflatten_cache so that
+  /// repeated calls for the same array type reuse the same variable.
+  /// \param array_type: the array type to declare a base variable for
+  /// \return the SMT2 identifier name of the declared variable
+  std::string declare_unflatten_base(const array_typet &array_type);
+
+  /// Emit a single `<idx> <unflattened-element>` pair for index \p i of
+  /// \p array_type, taking the bits at `[offset, offset + subtype_width)`
+  /// from `?ufop<nesting>`. The caller is responsible for emitting the
+  /// surrounding `(store ...)` and any whitespace.
+  /// \param array_type: the array type whose element is being emitted
+  /// \param i: the array index
+  /// \param offset: the bit offset within the flattened bit-vector
+  /// \param subtype_width: the width of the element in bits
+  /// \param nesting: the current `?ufop` let-binding nesting level
+  void unflatten_store_pair(
+    const array_typet &array_type,
+    const mp_integer &i,
+    std::size_t offset,
+    std::size_t subtype_width,
+    unsigned nesting);
+
   // pointers
   pointer_logict pointer_logic;
   void convert_address_of_rec(


### PR DESCRIPTION
When using --smt2 --outfile without an explicit solver, CBMC defaults to the GENERIC solver which has use_as_const=false. The unflatten function for array types had PRECONDITION(use_as_const) which caused a crash in this configuration.

The fix provides an alternative code path when use_as_const is false: instead of using the non-standard ((as const ArrayType) value) syntax, it uses a pre-declared auxiliary base array variable with nested store operations for all array elements.

The auxiliary arrays are pre-declared at the top level during find_symbols_rec (for type discovery) and in set_to (before define-fun emission), ensuring they are available before any expression context that might need them.

Exclude smt2-outfile-array test from incremental SMT backend as the test uses --smt2 --outfile which is incompatible with the incremental SMT2 solver backend (--incremental-smt2-solver).  Add no-new-smt tag to exclude it from that test suite.

Fixes: #8637

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
