### PR TITLE
Fix SIGABRT crash in field_sensitivityt::get_fields for c_enum_tag types

### DIFF
--- a/src/goto-symex/field_sensitivity.cpp
+++ b/src/goto-symex/field_sensitivity.cpp
@@ -19,6 +19,31 @@ Author: Michael Tautschnig
 
 #define ENABLE_ARRAY_FIELD_SENSITIVITY
 
+/// Helper function to safely convert a constant expression to mp_integer.
+/// Handles c_enum_tag types by following the tag to get the underlying enum type.
+/// \param expr: constant expression to convert
+/// \param ns: namespace for resolving tags
+/// \return mp_integer value
+static mp_integer safe_numeric_cast(
+  const constant_exprt &expr,
+  const namespacet &ns)
+{
+  // If the type is c_enum_tag, we need to follow the tag to get the actual
+  // c_enum type before conversion
+  if(expr.type().id() == ID_c_enum_tag)
+  {
+    // Create a new constant expression with the followed type
+    const c_enum_typet &followed_enum =
+      ns.follow_tag(to_c_enum_tag_type(expr.type()));
+    constant_exprt tmp(expr.get_value(), followed_enum);
+    return numeric_cast_v<mp_integer>(tmp);
+  }
+  else
+  {
+    return numeric_cast_v<mp_integer>(expr);
+  }
+}
+
 exprt field_sensitivityt::apply(
   const namespacet &ns,
   goto_symex_statet &state,
@@ -80,8 +105,8 @@ exprt field_sensitivityt::apply_byte_extract(
 #ifdef ENABLE_ARRAY_FIELD_SENSITIVITY
         if(
           !to_array_type(parent->type()).size().is_constant() ||
-          numeric_cast_v<mp_integer>(
-            to_constant_expr(to_array_type(parent->type()).size())) >
+          safe_numeric_cast(
+            to_constant_expr(to_array_type(parent->type()).size()), ns) >
             max_field_sensitivity_array_size)
         {
           for_ssa = parent;
@@ -227,7 +252,7 @@ exprt field_sensitivityt::apply(
 
       if(
         l2_size.is_constant() &&
-        numeric_cast_v<mp_integer>(to_constant_expr(l2_size)) <=
+        safe_numeric_cast(to_constant_expr(l2_size), ns) <=
           max_field_sensitivity_array_size)
       {
         if(l2_index.is_constant())
@@ -315,8 +340,8 @@ exprt field_sensitivityt::get_fields(
     ssa_expr.type().id() == ID_array &&
     to_array_type(ssa_expr.type()).size().is_constant())
   {
-    const mp_integer mp_array_size = numeric_cast_v<mp_integer>(
-      to_constant_expr(to_array_type(ssa_expr.type()).size()));
+    const mp_integer mp_array_size = safe_numeric_cast(
+      to_constant_expr(to_array_type(ssa_expr.type()).size()), ns);
     if(mp_array_size < 0 || mp_array_size > max_field_sensitivity_array_size)
       return ssa_expr;
 
@@ -371,7 +396,7 @@ void field_sensitivityt::field_assignments(
     // Erase the composite symbol from our working state. Note that we need to
     // have it in the propagation table and the value set while doing the field
     // assignments, thus we cannot skip putting it in there above.
-    if(is_divisible(lhs, true))
+    if(is_divisible(ns, lhs, true))
     {
       state.propagation.erase_if_exists(lhs.get_identifier());
       state.value_set.erase_symbol(lhs, ns);
@@ -417,7 +442,7 @@ void field_sensitivityt::field_assignments_rec(
     // Erase the composite symbol from our working state. Note that we need to
     // have it in the propagation table and the value set while doing the field
     // assignments, thus we cannot skip putting it in there above.
-    if(is_divisible(l1_lhs, true))
+    if(is_divisible(ns, l1_lhs, true))
     {
       state.propagation.erase_if_exists(l1_lhs.get_identifier());
       state.value_set.erase_symbol(l1_lhs, ns);
@@ -515,8 +540,8 @@ void field_sensitivityt::field_assignments_rec(
 #ifdef ENABLE_ARRAY_FIELD_SENSITIVITY
   else if(const auto &type = type_try_dynamic_cast<array_typet>(ssa_rhs.type()))
   {
-    const std::size_t array_size =
-      numeric_cast_v<std::size_t>(to_constant_expr(type->size()));
+    const std::size_t array_size = numeric_cast_v<std::size_t>(
+      safe_numeric_cast(to_constant_expr(type->size()), ns));
     PRECONDITION(lhs_fs.operands().size() == array_size);
 
     if(array_size > max_field_sensitivity_array_size)
@@ -586,6 +611,7 @@ void field_sensitivityt::field_assignments_rec(
 }
 
 bool field_sensitivityt::is_divisible(
+  const namespacet &ns,
   const ssa_exprt &expr,
   bool disjoined_fields_only) const
 {
@@ -596,8 +622,8 @@ bool field_sensitivityt::is_divisible(
   if(
     expr.type().id() == ID_array &&
     to_array_type(expr.type()).size().is_constant() &&
-    numeric_cast_v<mp_integer>(to_constant_expr(
-      to_array_type(expr.type()).size())) <= max_field_sensitivity_array_size)
+    safe_numeric_cast(to_constant_expr(
+      to_array_type(expr.type()).size()), ns) <= max_field_sensitivity_array_size)
   {
     return true;
   }

--- a/src/goto-symex/field_sensitivity.h
+++ b/src/goto-symex/field_sensitivity.h
@@ -196,13 +196,16 @@ public:
   /// (returns false) or a composite object made of several SSA expressions as
   /// components (such as a struct with each member becoming an individual SSA
   /// expression, return true in this case).
+  /// \param ns: a namespace to resolve type symbols/tag types
   /// \param expr: the expression to evaluate
   /// \param disjoined_fields_only: whether to expand unions (`false`) or not
   ///   (`true`)
   /// \return False, if and only if, \p expr would be a single field-sensitive
   /// SSA expression.
-  [[nodiscard]] bool
-  is_divisible(const ssa_exprt &expr, bool disjoined_fields_only) const;
+  [[nodiscard]] bool is_divisible(
+    const namespacet &ns,
+    const ssa_exprt &expr,
+    bool disjoined_fields_only) const;
 
 private:
   const std::size_t max_field_sensitivity_array_size;

--- a/src/goto-symex/goto_symex.cpp
+++ b/src/goto-symex/goto_symex.cpp
@@ -132,7 +132,7 @@ void goto_symext::symex_assign(
     const bool maybe_divisible =
       lhs.id() == ID_index ||
       (is_ssa_expr(lhs) &&
-       state.field_sensitivity.is_divisible(to_ssa_expr(lhs), false));
+       state.field_sensitivity.is_divisible(ns, to_ssa_expr(lhs), false));
     const bool need_atomic_section = maybe_divisible &&
                                      state.threads.size() > 1 &&
                                      state.atomic_section_id == 0;

--- a/src/goto-symex/goto_symex_state.cpp
+++ b/src/goto-symex/goto_symex_state.cpp
@@ -392,7 +392,7 @@ bool goto_symex_statet::l2_thread_read_encoding(
   }
 
   // only continue if an indivisible object is being accessed
-  if(field_sensitivity.is_divisible(expr, true))
+  if(field_sensitivity.is_divisible(ns, expr, true))
     return false;
 
   const ssa_exprt ssa_l1 = remove_level_2(expr);
@@ -528,7 +528,7 @@ goto_symex_statet::write_is_shared_resultt goto_symex_statet::write_is_shared(
   }
 
   // only continue if an indivisible object is being accessed
-  if(field_sensitivity.is_divisible(expr, true))
+  if(field_sensitivity.is_divisible(ns, expr, true))
     return write_is_shared_resultt::NOT_SHARED;
 
   if(atomic_section_id != 0)

--- a/src/goto-symex/symex_assign.cpp
+++ b/src/goto-symex/symex_assign.cpp
@@ -250,7 +250,7 @@ void symex_assignt::assign_non_struct_symbol(
     current_assignment_type);
 
   const ssa_exprt &l1_lhs = assignment.lhs;
-  if(state.field_sensitivity.is_divisible(l1_lhs, false))
+  if(state.field_sensitivity.is_divisible(ns, l1_lhs, false))
   {
     // Split composite symbol lhs into its components
     state.field_sensitivity.field_assignments(

--- a/src/goto-symex/symex_goto.cpp
+++ b/src/goto-symex/symex_goto.cpp
@@ -603,7 +603,7 @@ static void merge_names(
   }
 
   // field sensitivity: only merge on individual fields
-  if(dest_state.field_sensitivity.is_divisible(ssa, true))
+  if(dest_state.field_sensitivity.is_divisible(ns, ssa, true))
     return;
 
   // shared variables are renamed on every access anyway, we don't need to


### PR DESCRIPTION
Fixes: #8479

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
