### PR TITLE
Support extractbits_exprt with non-constant index in SMT2 backend

### DIFF
--- a/regression/cbmc/Pointer28/test.desc
+++ b/regression/cbmc/Pointer28/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG no-new-smt
+KNOWNBUG
 main.c
 --little-endian
 ^EXIT=0$

--- a/regression/cbmc/array_constraints1/test.desc
+++ b/regression/cbmc/array_constraints1/test.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 main.c
 --unwind 2
 ^EXIT=10$

--- a/regression/cbmc/aws-byte-buf-regression/test.desc
+++ b/regression/cbmc/aws-byte-buf-regression/test.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 main.c
 
 VERIFICATION SUCCESSFUL

--- a/regression/cbmc/byte_update16/big-endian.desc
+++ b/regression/cbmc/byte_update16/big-endian.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 main.c
 --big-endian
 ^EXIT=0$

--- a/regression/cbmc/byte_update16/little-endian.desc
+++ b/regression/cbmc/byte_update16/little-endian.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 main.c
 --little-endian
 ^EXIT=0$

--- a/regression/cbmc/simplify-array-size/test.desc
+++ b/regression/cbmc/simplify-array-size/test.desc
@@ -1,4 +1,4 @@
-CORE no-new-smt
+CORE
 main.c
 --malloc-may-fail --malloc-fail-null
 ^VERIFICATION SUCCESSFUL$

--- a/src/solvers/flattening/boolbv_extractbits.cpp
+++ b/src/solvers/flattening/boolbv_extractbits.cpp
@@ -19,28 +19,49 @@ bvt boolbvt::convert_extractbits(const extractbits_exprt &expr)
 
   auto const maybe_index_as_int = numeric_cast<mp_integer>(expr.index());
 
-  // We only do constants for now.
-  // Should implement a shift here.
-  if(!maybe_index_as_int.has_value())
-    return conversion_failed(expr);
+  if(maybe_index_as_int.has_value())
+  {
+    auto index_as_int = maybe_index_as_int.value();
 
-  auto index_as_int = maybe_index_as_int.value();
+    DATA_INVARIANT_WITH_DIAGNOSTICS(
+      index_as_int >= 0 && index_as_int < src_bv.size(),
+      "index of extractbits must be within the bitvector",
+      expr.find_source_location(),
+      irep_pretty_diagnosticst{expr});
 
-  DATA_INVARIANT_WITH_DIAGNOSTICS(
-    index_as_int >= 0 && index_as_int < src_bv.size(),
-    "index of extractbits must be within the bitvector",
-    expr.find_source_location(),
-    irep_pretty_diagnosticst{expr});
+    DATA_INVARIANT_WITH_DIAGNOSTICS(
+      index_as_int + bv_width - 1 < src_bv.size(),
+      "index+width-1 of extractbits must be within the bitvector",
+      expr.find_source_location(),
+      irep_pretty_diagnosticst{expr});
 
-  DATA_INVARIANT_WITH_DIAGNOSTICS(
-    index_as_int + bv_width - 1 < src_bv.size(),
-    "index+width-1 of extractbits must be within the bitvector",
-    expr.find_source_location(),
-    irep_pretty_diagnosticst{expr});
+    const std::size_t offset = numeric_cast_v<std::size_t>(index_as_int);
 
-  const std::size_t offset = numeric_cast_v<std::size_t>(index_as_int);
+    bvt result_bv(src_bv.begin() + offset, src_bv.begin() + offset + bv_width);
 
-  bvt result_bv(src_bv.begin() + offset, src_bv.begin() + offset + bv_width);
+    return result_bv;
+  }
 
-  return result_bv;
+  // For non-constant indices, encode
+  //   extractbits(src, idx, T)
+  // as the low bv_width bits of (src >> idx'), where idx' has been
+  // zero-extended (or, if idx is wider than src, truncated) to
+  // src_bv.size(). Truncation is sound because well-formed extractbits
+  // indices satisfy idx + bv_width - 1 < src_bv.size() per the contract
+  // for extractbits_exprt, so the upper bits of idx are guaranteed to be
+  // zero. zero_extension (rather than sign-extension) is the correct
+  // choice because indices are non-negative; this stays correct even when
+  // idx has a signed type. Mirrors the encoding used by both SMT2
+  // backends in convert_expr_to_smt.cpp / smt2_conv.cpp.
+  bvt index_bv = convert_bv(expr.index());
+
+  if(index_bv.size() < src_bv.size())
+    index_bv = bv_utils.zero_extension(index_bv, src_bv.size());
+  else if(index_bv.size() > src_bv.size())
+    index_bv.resize(src_bv.size()); // truncate to low src_bv.size() bits
+
+  const bvt shifted =
+    bv_utils.shift(src_bv, bv_utilst::shiftt::SHIFT_LRIGHT, index_bv);
+
+  return bvt{shifted.begin(), shifted.begin() + bv_width};
 }

--- a/src/solvers/smt2/smt2_conv.cpp
+++ b/src/solvers/smt2/smt2_conv.cpp
@@ -2067,17 +2067,43 @@ void smt2_convt::convert_expr(const exprt &expr)
     }
     else
     {
-      #if 0
-      out << "(= ((_ extract 0 0) ";
-      // the arguments of the shift need to have the same width
-      out << "(bvlshr ";
-      convert_expr(expr.op0());
-      typecast_exprt tmp(expr.op0().type());
-      tmp.op0()=expr.op1();
-      convert_expr(tmp);
-      out << ")) bin1)"; // bvlshr, extract, =
-      #endif
-      SMT2_TODO("smt2: extractbits with non-constant index");
+      // For non-constant indices, encode
+      //   extractbits(src, idx, T)
+      // as
+      //   ((_ extract result_width-1 0) (bvlshr src idx'))
+      // where idx' has been zero-extended (or, if idx is wider than src,
+      // truncated) to the source width. Truncation is sound because
+      // well-formed extractbits indices satisfy
+      // idx + result_width - 1 < src_width per the contract for
+      // extractbits_exprt, so the upper bits of idx are guaranteed to be
+      // zero. We use zero_extend rather than sign_extend because indices
+      // are non-negative; this stays correct even when idx has a signed
+      // type. Mirrors the encoding used by the incremental SMT2 backend
+      // in convert_expr_to_smt.cpp and the flattening backend in
+      // boolbv_extractbits.cpp.
+      const auto src_width = boolbv_width(extractbits_expr.src().type());
+      const auto index_width = boolbv_width(extractbits_expr.index().type());
+
+      out << "((_ extract " << (width - 1) << " 0) (bvlshr ";
+      flatten2bv(extractbits_expr.src());
+      out << ' ';
+      if(index_width < src_width)
+      {
+        out << "((_ zero_extend " << (src_width - index_width) << ") ";
+        flatten2bv(extractbits_expr.index());
+        out << ")";
+      }
+      else if(index_width > src_width)
+      {
+        out << "((_ extract " << (src_width - 1) << " 0) ";
+        flatten2bv(extractbits_expr.index());
+        out << ")";
+      }
+      else
+      {
+        flatten2bv(extractbits_expr.index());
+      }
+      out << "))"; // bvlshr, extract
     }
   }
   else if(expr.id()==ID_replication)

--- a/src/solvers/smt2_incremental/convert_expr_to_smt.cpp
+++ b/src/solvers/smt2_incremental/convert_expr_to_smt.cpp
@@ -1120,13 +1120,40 @@ static smt_termt convert_expr_to_smt(
     convert_type_to_smt_sort(extract_bits.type()).cast<smt_bit_vector_sortt>();
   INVARIANT(
     bit_vector_sort, "Extract can only be applied to bit vector terms.");
+  const std::size_t result_width = bit_vector_sort->bit_width();
   const auto index_value = numeric_cast<std::size_t>(extract_bits.index());
-  if(index_value)
+  if(index_value.has_value())
     return smt_bit_vector_theoryt::extract(
-      *index_value + bit_vector_sort->bit_width() - 1, *index_value)(from);
-  UNIMPLEMENTED_FEATURE(
-    "Generation of SMT formula for extract bits expression: " +
-    extract_bits.pretty());
+      *index_value + result_width - 1, *index_value)(from);
+  // For non-constant indices, encode
+  //   extractbits(src, idx, T)
+  // as
+  //   ((_ extract result_width-1 0) (bvlshr src idx'))
+  // where idx' has been zero-extended (or, if idx is wider than src,
+  // truncated) to from_width. Truncation is sound because well-formed
+  // extractbits indices satisfy idx + result_width - 1 < from_width
+  // (per bitvector_expr.h's contract for extractbits_exprt), so
+  // idx < from_width and the upper bits of idx are guaranteed to be
+  // zero. We use zero_extend rather than sign_extend because indices
+  // are non-negative; this is correct even when idx has a signed type
+  // because the same width-bound applies.
+  const smt_termt &index_term = converted.at(extract_bits.index());
+  const auto from_sort = from.get_sort().cast<smt_bit_vector_sortt>();
+  const auto index_sort = index_term.get_sort().cast<smt_bit_vector_sortt>();
+  INVARIANT(
+    from_sort && index_sort,
+    "Extract bits operands are expected to have bit vector sorts.");
+  const std::size_t from_width = from_sort->bit_width();
+  const std::size_t index_width = index_sort->bit_width();
+  const smt_termt adjusted_index =
+    index_width < from_width ? smt_bit_vector_theoryt::zero_extend(
+                                 from_width - index_width)(index_term)
+    : index_width > from_width
+      ? smt_bit_vector_theoryt::extract(from_width - 1, 0)(index_term)
+      : index_term;
+  const smt_termt shifted =
+    smt_bit_vector_theoryt::logical_shift_right(from, adjusted_index);
+  return smt_bit_vector_theoryt::extract(result_width - 1, 0)(shifted);
 }
 
 static smt_termt convert_expr_to_smt(

--- a/unit/solvers/flattening/boolbv.cpp
+++ b/unit/solvers/flattening/boolbv.cpp
@@ -10,6 +10,7 @@ Author: Daniel Kroening
 /// Unit tests for boolbvt
 
 #include <util/arith_tools.h>
+#include <util/bitvector_expr.h>
 #include <util/bitvector_types.h>
 #include <util/byte_operators.h>
 #include <util/c_types.h>
@@ -93,6 +94,88 @@ SCENARIO(
     {
       boolbv << let;
       REQUIRE(boolbv() == decision_proceduret::resultt::D_SATISFIABLE);
+    }
+  }
+}
+
+SCENARIO(
+  "boolbvt::convert_extractbits with non-constant index",
+  "[core][solvers][flattening][boolbvt]")
+{
+  // End-to-end SAT-based check that the non-constant-index lowering in
+  // boolbvt::convert_extractbits is correct: pin the index to a known
+  // value via an assumption and assert that the extracted bits equal
+  // the expected slice. Without the lowering, convert_extractbits used
+  // to call conversion_failed which returns fresh unconstrained
+  // variables, so the pinned-value check below would not be entailed
+  // and the corresponding UNSATISFIABLE assumption would be SAT instead.
+  console_message_handlert message_handler;
+  message_handler.set_verbosity(0);
+
+  GIVEN("A 16-bit source and an 8-bit non-constant index")
+  {
+    satcheckt satcheck(message_handler);
+    symbol_tablet symbol_table;
+    namespacet ns(symbol_table);
+    boolbvt boolbv(ns, satcheck, message_handler);
+
+    const unsignedbv_typet u8{8};
+    const unsignedbv_typet u16{16};
+    const unsignedbv_typet u4{4};
+    const symbol_exprt src{"src", u16};
+    const symbol_exprt idx{"idx", u8};
+
+    // src = 0xABCD = 1010101111001101, idx = 4
+    // extractbits(src, idx, u4) selects bits [idx+3 .. idx], i.e. for
+    // idx=4 the nibble at bits 7..4 of 0xABCD == 0xC.
+    boolbv << equal_exprt{src, from_integer(0xABCD, u16)};
+    boolbv << equal_exprt{idx, from_integer(4, u8)};
+
+    const extractbits_exprt extract{src, idx, u4};
+    const equal_exprt good{extract, from_integer(0xC, u4)};
+    const equal_exprt bad{extract, from_integer(0xA, u4)};
+
+    THEN("the encoding selects the nibble at bits idx..idx+3")
+    {
+      // good is entailed -> ~good is unsat
+      REQUIRE(
+        boolbv(not_exprt{good}) ==
+        decision_proceduret::resultt::D_UNSATISFIABLE);
+    }
+
+    THEN("the encoding does NOT pick a different nibble")
+    {
+      // bad is unsat under the same model
+      REQUIRE(boolbv(bad) == decision_proceduret::resultt::D_UNSATISFIABLE);
+    }
+  }
+
+  GIVEN("Index wider than source (truncation case)")
+  {
+    satcheckt satcheck(message_handler);
+    symbol_tablet symbol_table;
+    namespacet ns(symbol_table);
+    boolbvt boolbv(ns, satcheck, message_handler);
+
+    const unsignedbv_typet u16{16};
+    const unsignedbv_typet u32{32};
+    const unsignedbv_typet u4{4};
+    const symbol_exprt src{"src", u16};
+    const symbol_exprt idx{"idx", u32};
+
+    boolbv << equal_exprt{src, from_integer(0x1234, u16)};
+    boolbv << equal_exprt{idx, from_integer(8, u32)};
+
+    // For idx=8, extractbits(src, idx, u4) selects bits 11..8 of 0x1234,
+    // which is the nibble 0x2.
+    const extractbits_exprt extract{src, idx, u4};
+    const equal_exprt good{extract, from_integer(0x2, u4)};
+
+    THEN("the truncated index still selects the right nibble")
+    {
+      REQUIRE(
+        boolbv(not_exprt{good}) ==
+        decision_proceduret::resultt::D_UNSATISFIABLE);
     }
   }
 }

--- a/unit/solvers/smt2/smt2_conv.cpp
+++ b/unit/solvers/smt2/smt2_conv.cpp
@@ -48,6 +48,48 @@ static std::string get_assert(const exprt &red_expr)
   return result.substr(pos, end - pos + 1);
 }
 
+TEST_CASE(
+  "smt2_convt::convert_expr extractbits with non-constant index",
+  "[core][solvers][smt2]")
+{
+  // Pin the SMT2 emission for an extractbits with a non-constant index.
+  // Encoding: ((_ extract result_width-1 0) (bvlshr src idx'))
+  // where idx' is zero-extended (narrower) or truncated (wider) to the
+  // source width. Without the fix, this branch used to throw
+  // SMT2_TODO("smt2: extractbits with non-constant index").
+  const unsignedbv_typet u4{4};
+  const unsignedbv_typet u8{8};
+  const unsignedbv_typet u16{16};
+  const unsignedbv_typet u32{32};
+  const symbol_exprt src{"src", u16};
+
+  SECTION("Same-width index")
+  {
+    const extractbits_exprt extract{src, symbol_exprt{"i16", u16}, u4};
+    REQUIRE(
+      get_assert(equal_exprt{extract, from_integer(0, u4)}) ==
+      "(assert (= ((_ extract 3 0) (bvlshr src i16)) (_ bv0 4)))");
+  }
+
+  SECTION("Narrower index requires zero_extend")
+  {
+    const extractbits_exprt extract{src, symbol_exprt{"idx", u8}, u4};
+    REQUIRE(
+      get_assert(equal_exprt{extract, from_integer(0, u4)}) ==
+      "(assert (= ((_ extract 3 0) "
+      "(bvlshr src ((_ zero_extend 8) idx))) (_ bv0 4)))");
+  }
+
+  SECTION("Wider index requires truncation")
+  {
+    const extractbits_exprt extract{src, symbol_exprt{"big", u32}, u4};
+    REQUIRE(
+      get_assert(equal_exprt{extract, from_integer(0, u4)}) ==
+      "(assert (= ((_ extract 3 0) "
+      "(bvlshr src ((_ extract 15 0) big))) (_ bv0 4)))");
+  }
+}
+
 TEST_CASE("smt2_convt reduction operators", "[core][solvers][smt2]")
 {
   unsignedbv_typet u2(2);

--- a/unit/solvers/smt2_incremental/convert_expr_to_smt.cpp
+++ b/unit/solvers/smt2_incremental/convert_expr_to_smt.cpp
@@ -1337,11 +1337,91 @@ TEST_CASE(
   {
     INFO("Input expression - " + input.pretty(1, 0));
     CHECK(test.convert(input) == expected_result);
-    const cbmc_invariants_should_throwt invariants_throw;
-    CHECK_THROWS(test.convert(extractbits_exprt{
+  }
+  SECTION("Non-constant index, same width")
+  {
+    const auto non_const_input = extractbits_exprt{
       symbol_exprt{"foo", operand_type},
       symbol_exprt{"bar", operand_type},
-      unsignedbv_typet{3}}));
+      unsignedbv_typet{3}};
+    const smt_termt foo_term =
+      smt_identifier_termt{"foo", smt_bit_vector_sortt{8}};
+    const smt_termt bar_term =
+      smt_identifier_termt{"bar", smt_bit_vector_sortt{8}};
+    const smt_termt expected = smt_bit_vector_theoryt::extract(2, 0)(
+      smt_bit_vector_theoryt::logical_shift_right(foo_term, bar_term));
+    CHECK(test.convert(non_const_input) == expected);
+  }
+  SECTION("Non-constant index, different width requires zero extension")
+  {
+    const typet wide_type = unsignedbv_typet{16};
+    const typet narrow_type = unsignedbv_typet{8};
+    const auto non_const_input = extractbits_exprt{
+      symbol_exprt{"foo", wide_type},
+      symbol_exprt{"bar", narrow_type},
+      unsignedbv_typet{4}};
+    const smt_termt foo_term =
+      smt_identifier_termt{"foo", smt_bit_vector_sortt{16}};
+    const smt_termt bar_term =
+      smt_identifier_termt{"bar", smt_bit_vector_sortt{8}};
+    const smt_termt expected = smt_bit_vector_theoryt::extract(3, 0)(
+      smt_bit_vector_theoryt::logical_shift_right(
+        foo_term, smt_bit_vector_theoryt::zero_extend(8)(bar_term)));
+    CHECK(test.convert(non_const_input) == expected);
+  }
+  SECTION("Non-constant index, wider index requires truncation")
+  {
+    const typet narrow_type = unsignedbv_typet{16};
+    const typet wide_type = unsignedbv_typet{32};
+    const auto non_const_input = extractbits_exprt{
+      symbol_exprt{"foo", narrow_type},
+      symbol_exprt{"bar", wide_type},
+      unsignedbv_typet{4}};
+    const smt_termt foo_term =
+      smt_identifier_termt{"foo", smt_bit_vector_sortt{16}};
+    const smt_termt bar_term =
+      smt_identifier_termt{"bar", smt_bit_vector_sortt{32}};
+    const smt_termt expected = smt_bit_vector_theoryt::extract(3, 0)(
+      smt_bit_vector_theoryt::logical_shift_right(
+        foo_term, smt_bit_vector_theoryt::extract(15, 0)(bar_term)));
+    CHECK(test.convert(non_const_input) == expected);
+  }
+  SECTION("Non-constant signed index uses zero_extend, not sign_extend")
+  {
+    // Indices are non-negative by extractbits' contract, so the sign bit
+    // is always 0. The encoding deliberately uses zero_extend; this
+    // SECTION locks that choice in even when the index has a signed type.
+    const typet wide_type = unsignedbv_typet{16};
+    const typet signed_narrow_type = signedbv_typet{8};
+    const auto non_const_input = extractbits_exprt{
+      symbol_exprt{"foo", wide_type},
+      symbol_exprt{"bar", signed_narrow_type},
+      unsignedbv_typet{4}};
+    const smt_termt foo_term =
+      smt_identifier_termt{"foo", smt_bit_vector_sortt{16}};
+    const smt_termt bar_term =
+      smt_identifier_termt{"bar", smt_bit_vector_sortt{8}};
+    const smt_termt expected = smt_bit_vector_theoryt::extract(3, 0)(
+      smt_bit_vector_theoryt::logical_shift_right(
+        foo_term, smt_bit_vector_theoryt::zero_extend(8)(bar_term)));
+    CHECK(test.convert(non_const_input) == expected);
+  }
+  SECTION("Constant zero index hits the constant branch, not the shift path")
+  {
+    // numeric_cast<std::size_t>(...).has_value() is the predicate guarding
+    // the constant branch, and an optional<std::size_t> with value 0 is
+    // truthy. This SECTION pins that index 0 still folds to a plain
+    // (_ extract result_width-1 0) on the source rather than to the
+    // bvlshr-shaped path; an accidental switch to "if(*index_value)" or
+    // "if(index_value && *index_value)" would change the result.
+    const auto const_zero_input = extractbits_exprt{
+      symbol_exprt{"foo", operand_type},
+      from_integer(0, operand_type),
+      unsignedbv_typet{3}};
+    const smt_termt foo_term =
+      smt_identifier_termt{"foo", smt_bit_vector_sortt{8}};
+    const smt_termt expected = smt_bit_vector_theoryt::extract(2, 0)(foo_term);
+    CHECK(test.convert(const_zero_input) == expected);
   }
 }
 


### PR DESCRIPTION
When the index of extractbits_exprt is not a compile-time constant, shift the source right by the index using bvlshr, then extract from bit 0 to result_width-1. Zero-extend or truncate the index to match the source width as required by the SMT shift operator.

Keep Pointer28 as KNOWNBUG (it fails with all backends, not just incremental SMT2). Remove no-new-smt from array_constraints1, aws-byte-buf-regression, byte_update16, and simplify-array-size.

Fixes: #8065

Co-authored-by: Kiro (autonomous agent) <kiro-agent@users.noreply.github.com>

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- n/a Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- n/a The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- n/a My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- n/a White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
