### PR TITLE
Skip get_literals call for unbounded arrays with zero-width elements

### DIFF
--- a/regression/cbmc/zero_width_unbounded_array_index/main.c
+++ b/regression/cbmc/zero_width_unbounded_array_index/main.c
@@ -1,0 +1,11 @@
+struct empty
+{
+};
+
+int main()
+{
+  struct empty arr[10];
+  struct empty *p = arr;
+  struct empty e = p[1];
+  return 0;
+}

--- a/regression/cbmc/zero_width_unbounded_array_index/test.desc
+++ b/regression/cbmc/zero_width_unbounded_array_index/test.desc
@@ -1,0 +1,12 @@
+CORE gcc-only
+main.c
+--pointer-check
+^EXIT=0$
+^SIGNAL=0$
+^VERIFICATION SUCCESSFUL$
+--
+Invariant check failed
+--
+Regression test for GitHub issue #8480: get_literals called with width=0
+for unbounded arrays of zero-width elements should not trigger an invariant
+violation.

--- a/src/solvers/flattening/boolbv_index.cpp
+++ b/src/solvers/flattening/boolbv_index.cpp
@@ -51,10 +51,11 @@ bvt boolbvt::convert_index(const index_exprt &expr)
           final_array.id() == ID_symbol || final_array.id() == ID_nondet_symbol)
         {
           const auto &array_width_opt = bv_width.get_width_opt(array_type);
-          (void)map.get_literals(
-            final_array.get(ID_identifier),
-            array_type,
-            array_width_opt.value_or(0));
+          if(array_width_opt.has_value())
+          {
+            (void)map.get_literals(
+              final_array.get(ID_identifier), array_type, *array_width_opt);
+          }
         }
 
         // make sure we have the index in the cache
@@ -71,8 +72,11 @@ bvt boolbvt::convert_index(const index_exprt &expr)
         if(array.id() == ID_symbol || array.id() == ID_nondet_symbol)
         {
           const auto &array_width_opt = bv_width.get_width_opt(array_type);
-          (void)map.get_literals(
-            array.get(ID_identifier), array_type, array_width_opt.value_or(0));
+          if(array_width_opt.has_value())
+          {
+            (void)map.get_literals(
+              array.get(ID_identifier), array_type, *array_width_opt);
+          }
         }
 
         // make sure we have the index in the cache


### PR DESCRIPTION
In convert_index, bv_width.get_width_opt(array_type) returns nullopt for unbounded arrays of zero-width elements (e.g., empty structs). The previous code used value_or(0), which passed width=0 to map.get_literals. If the identifier already existed in the boolbv_map with a non-zero literal_map size, the invariant map_entry.literal_map.size() == width would fail.

Fix: guard both get_literals calls so they are only made when the array width is known. Add regression test for this scenario.

Fixes: #8480

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.

If your PR fixes a bug, include the regression test(s) in the same commit as the bug fix. Else, keep commits small and orthogonal, possibly placing tests in commits of their own.
--->

- [ ] Each commit message has a non-empty body, explaining why the change was made.
- [ ] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [ ] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [ ] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [ ] My commit message includes data points confirming performance improvements (if claimed).
- [ ] My PR is restricted to a single feature or bugfix.
- [ ] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->
